### PR TITLE
PLT-3015 : Refactor JSON output handling in JsonOutput class

### DIFF
--- a/application_sdk/outputs/json.py
+++ b/application_sdk/outputs/json.py
@@ -90,8 +90,10 @@ class JsonOutput(Output):
             self.chunk_count += 1
             self.total_record_count += len(combined_df)
             output_file_name = f"{self.output_path}/{self.path_gen(self.chunk_start, self.chunk_count)}"
-            combined_df.to_json(output_file_name, orient="records", lines=True)
-
+            json_content = combined_df.to_json(orient="records", lines=True, force_ascii=False).replace('\\/', '/')
+            with open(output_file_name, 'w') as f:
+                f.write(json_content)
+            
             # Push the file to the object store
             await ObjectStore.push_file_to_object_store(
                 self.upload_file_prefix, output_file_name


### PR DESCRIPTION
This pull request refactors the JSON output handling in the JsonOutput class. The method for writing JSON output has been updated to use explicit file handling instead of the built-in to_json method. This change ensures proper encoding by replacing escaped slashes in the JSON content. The refactoring improves the readability and maintainability of the output generation process.