### PR TITLE
Update metadata keys to use hyphens instead of underscores

### DIFF
--- a/application_sdk/application/fastapi/models.py
+++ b/application_sdk/application/fastapi/models.py
@@ -55,9 +55,9 @@ class PreflightCheckRequest(BaseModel):
                     "database": "databasename",
                 },
                 "metadata": {
-                    "include_filter": '{"^dbengine$":["^public$","^airflow$"]}',
-                    "exclude_filter": "{}",
-                    "temp_table_regex": "",
+                    "include-filter": '{"^dbengine$":["^public$","^airflow$"]}',
+                    "exclude-filter": "{}",
+                    "temp-table-regex": "",
                 },
             }
         }
@@ -100,10 +100,9 @@ class WorkflowRequest(RootModel[Dict[str, Any]]):
                 },
                 "connection": {"connection": "dev"},
                 "metadata": {
-                    "include_filter": '{"^dbengine$":["^public$","^airflow$"]}',
-                    "exclude_filter": "{}",
-                    "temp_table_regex": "",
-                    "advanced_config_strategy": "default",
+                    "include-filter": '{"^dbengine$":["^public$","^airflow$"]}',
+                    "exclude-filter": "{}",
+                    "temp-table-regex": "",
                 },
             }
         }
@@ -168,10 +167,9 @@ class WorkflowConfigResponse(BaseModel):
                     "credential_guid": "credential_test-uuid",
                     "connection": {"connection": "dev"},
                     "metadata": {
-                        "include_filter": '{"^dbengine$":["^public$","^airflow$"]}',
-                        "exclude_filter": "{}",
-                        "temp_table_regex": "",
-                        "advanced_config_strategy": "default",
+                        "include-filter": '{"^dbengine$":["^public$","^airflow$"]}',
+                        "exclude-filter": "{}",
+                        "temp-table-regex": "",
                     },
                 },
             }

--- a/application_sdk/common/utils.py
+++ b/application_sdk/common/utils.py
@@ -28,9 +28,9 @@ def prepare_query(
         workflow_args (Dict[str, Any]): A dictionary containing metadata and
             workflow-related arguments. Expected keys include:
             - "metadata": A dictionary with the following keys:
-                - "include_filter" (str): Regex pattern to include tables/data.
-                - "exclude_filter" (str): Regex pattern to exclude tables/data.
-                - "temp_table_regex" (str): Regex for temporary tables.
+                - "include-filter" (str): Regex pattern to include tables/data.
+                - "exclude-filter" (str): Regex pattern to exclude tables/data.
+                - "temp-table-regex" (str): Regex for temporary tables.
                 - "exclude_empty_tables" (bool): Whether to exclude empty tables.
                 - "exclude_views" (bool): Whether to exclude views.
         temp_table_regex_sql (str, optional): SQL snippet for excluding temporary
@@ -47,11 +47,11 @@ def prepare_query(
         metadata = workflow_args.get("metadata", {})
 
         # using "or" instead of default correct defaults are set in case of empty string
-        include_filter = metadata.get("include_filter") or "{}"
-        exclude_filter = metadata.get("exclude_filter") or "{}"
-        if metadata.get("temp_table_regex"):
+        include_filter = metadata.get("include-filter") or "{}"
+        exclude_filter = metadata.get("exclude-filter") or "{}"
+        if metadata.get("temp-table-regex"):
             temp_table_regex_sql = temp_table_regex_sql.format(
-                exclude_table_regex=metadata.get("temp_table_regex")
+                exclude_table_regex=metadata.get("temp-table-regex")
             )
         else:
             temp_table_regex_sql = ""

--- a/application_sdk/handlers/sql.py
+++ b/application_sdk/handlers/sql.py
@@ -210,7 +210,7 @@ class SQLHandler(HandlerInterface):
             schemas_results: List[Dict[str, str]] = await self.prepare_metadata()
 
             include_filter = json.loads(
-                payload.get("metadata", {}).get("include_filter", "{}")
+                payload.get("metadata", {}).get("include-filter", "{}")
             )
             allowed_databases, allowed_schemas = self.extract_allowed_schemas(
                 schemas_results

--- a/examples/application_sql.py
+++ b/examples/application_sql.py
@@ -152,10 +152,9 @@ async def application_sql(daemon: bool = True) -> Dict[str, Any]:
             "connection_qualified_name": "default/postgres/1728518400",
         },
         "metadata": {
-            "exclude_filter": "{}",
-            "include_filter": "{}",
-            "temp_table_regex": "",
-            "advanced_config_strategy": "default",
+            "exclude-filter": "{}",
+            "include-filter": "{}",
+            "temp-table-regex": "",
             "extraction-method": "direct",
             "exclude_views": "true",
             "exclude_empty_tables": "false",

--- a/examples/application_sql_miner.py
+++ b/examples/application_sql_miner.py
@@ -184,10 +184,9 @@ async def application_sql_miner(daemon: bool = True) -> Dict[str, Any]:
             "connection_qualified_name": "default/postgres/1728518400",
         },
         "metadata": {
-            "exclude_filter": "{}",
-            "include_filter": '{"^E2E_TEST_DB$":["^HIERARCHY_OFFER75$"]}',
-            "temp_table_regex": "",
-            "advanced_config_strategy": "default",
+            "exclude-filter": "{}",
+            "include-filter": '{"^E2E_TEST_DB$":["^HIERARCHY_OFFER75$"]}',
+            "temp-table-regex": "",
             "extraction-method": "direct",
         },
     }

--- a/examples/application_sql_with_custom_transformer.py
+++ b/examples/application_sql_with_custom_transformer.py
@@ -182,10 +182,9 @@ async def application_sql_with_custom_transformer(
             "connection_qualified_name": "default/postgres/1728518400",
         },
         "metadata": {
-            "exclude_filter": "{}",
-            "include_filter": "{}",
-            "temp_table_regex": "",
-            "advanced_config_strategy": "default",
+            "exclude-filter": "{}",
+            "include-filter": "{}",
+            "temp-table-regex": "",
             "extraction-method": "direct",
             "exclude_views": "true",
             "exclude_empty_tables": "false",

--- a/tests/integration/api/test_configuration_api.py
+++ b/tests/integration/api/test_configuration_api.py
@@ -21,10 +21,9 @@ class TestConfigurationAPI:
                 "credential_guid": "credential_test-abcd",
                 "connection": {"connection": "production"},
                 "metadata": {
-                    "exclude_filter": "{}",
-                    "include_filter": "{}",
-                    "temp_table_regex": "^temp_",
-                    "advanced_config_strategy": "default",
+                    "exclude-filter": "{}",
+                    "include-filter": "{}",
+                    "temp-table-regex": "^temp_",
                 },
             }
             mock_store_creds.return_value = "credential_test-uuid"
@@ -34,10 +33,9 @@ class TestConfigurationAPI:
                 "credential_guid": "credential_test-uuid",
                 "connection": {"connection": "dev"},
                 "metadata": {
-                    "exclude_filter": "{}",
-                    "include_filter": "{}",
-                    "temp_table_regex": "",
-                    "advanced_config_strategy": "default",
+                    "exclude-filter": "{}",
+                    "include-filter": "{}",
+                    "temp-table-regex": "",
                 },
             }
             expected_config = payload.copy()
@@ -62,9 +60,9 @@ class TestConfigurationAPI:
         existing_config = {
             "connection": {"connection": "dev"},
             "metadata": {
-                "exclude_filter": "{}",
-                "include_filter": "{}",
-                "temp_table_regex": "",
+                "exclude-filter": "{}",
+                "include-filter": "{}",
+                "temp-table-regex": "",
             },
             "credential_guid": "old-credential-uuid",
         }
@@ -105,9 +103,9 @@ class TestConfigurationAPI:
         test_config = {
             "connection": {"connection": "dev"},
             "metadata": {
-                "exclude_filter": "{}",
-                "include_filter": "{}",
-                "temp_table_regex": "",
+                "exclude-filter": "{}",
+                "include-filter": "{}",
+                "temp-table-regex": "",
             },
             "credential_guid": "credential_test-uuid",
         }
@@ -148,9 +146,9 @@ class TestConfigurationAPI:
         payload = {
             "connection": {"connection": "dev"},
             "metadata": {
-                "exclude_filter": "{}",
-                "include_filter": "{}",
-                "temp_table_regex": "",
+                "exclude-filter": "{}",
+                "include-filter": "{}",
+                "temp-table-regex": "",
             },
         }
 

--- a/tests/integration/api/test_preflight_check.py
+++ b/tests/integration/api/test_preflight_check.py
@@ -38,9 +38,9 @@ class TestSQLPreflightCheck:
                 "warehouse": "COMPUTE_WH",
             },
             "metadata": {
-                "include_filter": json.dumps({"^TESTDB$": ["^PUBLIC$"]}),
-                "exclude_filter": "{}",
-                "temp_table_regex": "",
+                "include-filter": json.dumps({"^TESTDB$": ["^PUBLIC$"]}),
+                "exclude-filter": "{}",
+                "temp-table-regex": "",
             },
         }
 
@@ -98,9 +98,9 @@ class TestSQLPreflightCheck:
                 "warehouse": "COMPUTE_WH",
             },
             "metadata": {
-                "include_filter": json.dumps({"^TESTDB$": ["^PUBLIC$"]}),
-                "exclude_filter": "{}",
-                "temp_table_regex": "^TEMP_TABLE$",
+                "include-filter": json.dumps({"^TESTDB$": ["^PUBLIC$"]}),
+                "exclude-filter": "{}",
+                "temp-table-regex": "^TEMP_TABLE$",
             },
         }
 
@@ -157,9 +157,9 @@ class TestSQLPreflightCheck:
                 "warehouse": "COMPUTE_WH",
             },
             "metadata": {
-                "include_filter": "{}",
-                "exclude_filter": "{}",
-                "temp_table_regex": "",
+                "include-filter": "{}",
+                "exclude-filter": "{}",
+                "temp-table-regex": "",
             },
         }
 
@@ -207,9 +207,9 @@ class TestSQLPreflightCheck:
                 "warehouse": "COMPUTE_WH",
             },
             "metadata": {
-                "include_filter": json.dumps({"^TESTDB$": ["^PUBLIC$"]}),
-                "exclude_filter": json.dumps({"^TESTDB$": ["^PRIVATE$"]}),
-                "temp_table_regex": "",
+                "include-filter": json.dumps({"^TESTDB$": ["^PUBLIC$"]}),
+                "exclude-filter": json.dumps({"^TESTDB$": ["^PRIVATE$"]}),
+                "temp-table-regex": "",
             },
         }
 

--- a/tests/unit/application/fastapi/test__init__.py
+++ b/tests/unit/application/fastapi/test__init__.py
@@ -45,9 +45,9 @@ class TestFastAPIApplication:
                 "warehouse": "COMPUTE_WH",
             },
             "metadata": {
-                "include_filter": json.dumps({"^TESTDB$": ["^PUBLIC$"]}),
-                "exclude_filter": "{}",
-                "temp_table_regex": "",
+                "include-filter": json.dumps({"^TESTDB$": ["^PUBLIC$"]}),
+                "exclude-filter": "{}",
+                "temp-table-regex": "",
             },
         }
 

--- a/tests/unit/handlers/sql/test_preflight_check.py
+++ b/tests/unit/handlers/sql/test_preflight_check.py
@@ -44,7 +44,7 @@ async def test_fetch_metadata_no_resource():
 
 
 async def test_check_schemas_and_databases_success(handler: SQLHandler):
-    payload = {"metadata": {"include_filter": json.dumps({"db1": ["schema1"]})}}
+    payload = {"metadata": {"include-filter": json.dumps({"db1": ["schema1"]})}}
 
     result = await handler.check_schemas_and_databases(payload)
 
@@ -55,7 +55,7 @@ async def test_check_schemas_and_databases_success(handler: SQLHandler):
 
 async def test_check_schemas_and_databases_failure(handler: SQLHandler):
     payload = {
-        "metadata": {"include_filter": json.dumps({"invalid_db": ["invalid_schema"]})}
+        "metadata": {"include-filter": json.dumps({"invalid_db": ["invalid_schema"]})}
     }
 
     result = await handler.check_schemas_and_databases(payload)
@@ -68,7 +68,7 @@ async def test_check_schemas_and_databases_with_wildcard_success(
     handler: SQLHandler,
 ):
     # Test with wildcard for all schemas in db1
-    payload = {"metadata": {"include_filter": json.dumps({"^db1$": "*"})}}
+    payload = {"metadata": {"include-filter": json.dumps({"^db1$": "*"})}}
 
     result = await handler.check_schemas_and_databases(payload)
 
@@ -81,7 +81,7 @@ async def test_check_schemas_and_databases_with_wildcard_invalid_db(
     handler: SQLHandler,
 ):
     # Test with wildcard but invalid database
-    payload = {"metadata": {"include_filter": json.dumps({"^invalid_db$": "*"})}}
+    payload = {"metadata": {"include-filter": json.dumps({"^invalid_db$": "*"})}}
 
     result = await handler.check_schemas_and_databases(payload)
 
@@ -93,7 +93,7 @@ async def test_check_schemas_and_databases_mixed_format(handler: SQLHandler):
     # Test with mix of wildcard and specific schema selections
     payload = {
         "metadata": {
-            "include_filter": json.dumps(
+            "include-filter": json.dumps(
                 {
                     "^db1$": "*",  # All schemas in db1
                     "^db2$": ["schema1"],  # Specific schema in db2
@@ -110,7 +110,7 @@ async def test_check_schemas_and_databases_mixed_format(handler: SQLHandler):
 
 
 async def test_preflight_check_success(handler: SQLHandler):
-    payload = {"metadata": {"include_filter": json.dumps({"db1": ["schema1"]})}}
+    payload = {"metadata": {"include-filter": json.dumps({"db1": ["schema1"]})}}
 
     with patch.object(handler, "tables_check") as mock_tables_check:
         mock_tables_check.return_value = {
@@ -127,7 +127,7 @@ async def test_preflight_check_success(handler: SQLHandler):
 
 
 async def test_preflight_check_with_wildcard_success(handler: SQLHandler):
-    payload = {"metadata": {"include_filter": json.dumps({"^db1$": "*"})}}
+    payload = {"metadata": {"include-filter": json.dumps({"^db1$": "*"})}}
 
     with patch.object(handler, "tables_check") as mock_tables_check:
         mock_tables_check.return_value = {
@@ -144,7 +144,7 @@ async def test_preflight_check_with_wildcard_success(handler: SQLHandler):
 
 
 async def test_preflight_check_failure(handler: SQLHandler):
-    payload = {"metadata": {"include_filter": json.dumps({"invalid_db": ["schema1"]})}}
+    payload = {"metadata": {"include-filter": json.dumps({"invalid_db": ["schema1"]})}}
 
     result = await handler.preflight_check(payload)
 

--- a/tests/unit/workflows/sql/test_workflow.py
+++ b/tests/unit/workflows/sql/test_workflow.py
@@ -47,7 +47,7 @@ async def test_prepare_query():
                         and concat(CATALOG_NAME, concat('.', SCHEMA_NAME)) NOT REGEXP '{normalized_exclude_regex}'
                         and concat(CATALOG_NAME, concat('.', SCHEMA_NAME)) REGEXP '{normalized_include_regex}';""",
             "workflow_args": {
-                "metadata": {"include_filter": "{}", "exclude_filter": "{}"}
+                "metadata": {"include-filter": "{}", "exclude-filter": "{}"}
             },
             "expected": """SELECT
                             S.COMMENT AS REMARKS, S.*, IFNULL(T.TABLE_COUNT, 0) AS TABLE_COUNT, IFNULL(V.VIEW_COUNT, 0) AS VIEW_COUNT


### PR DESCRIPTION
Change metadata keys from underscores to hyphens for consistency across the codebase. This improves readability and aligns with naming conventions.