### PR TITLE
APP-5247: Auto reload functionality not working

### DIFF
--- a/application_sdk/application/fastapi/__init__.py
+++ b/application_sdk/application/fastapi/__init__.py
@@ -279,12 +279,13 @@ class FastAPIApplication(AtlanApplicationInterface):
             data=config,
         )
 
-    async def start(self, host: str = "0.0.0.0", port: int = 8000):
+    async def start(self, host: str = "0.0.0.0", port: int = 8000, reload: bool = True):
         server = Server(
             Config(
                 app=self.app,
                 host=host,
                 port=port,
+                reload=reload,
             )
         )
         await server.serve()


### PR DESCRIPTION
- added a optional reload param in the run method for the FastApi app.
- the functionality was not working as we were not setting reload=True in the server Config while programatically starting the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable option for automatic reloading during server startup, offering enhanced control over the service's behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->