### PR TITLE
feat: add support for stop workflow endpoint

### DIFF
--- a/application_sdk/application/fastapi/__init__.py
+++ b/application_sdk/application/fastapi/__init__.py
@@ -164,6 +164,12 @@ class FastAPIApplication(AtlanApplicationInterface):
             methods=["GET"],
         )
 
+        self.workflow_router.add_api_route(
+            "/stop/{workflow_id}/{run_id:path}",
+            self.stop_workflow,
+            methods=["POST"],
+        )
+
         self.dapr_router.add_api_route(
             "/subscribe",
             self.get_dapr_subscriptions,
@@ -277,6 +283,13 @@ class FastAPIApplication(AtlanApplicationInterface):
             message="Workflow configuration updated successfully",
             data=config,
         )
+
+    async def stop_workflow(self, workflow_id: str, run_id: str) -> JSONResponse:
+        if not self.temporal_client:
+            raise Exception("Temporal client not initialized")
+
+        await self.temporal_client.stop_workflow(workflow_id, run_id)
+        return JSONResponse(status_code=status.HTTP_200_OK, content={"success": True})
 
     async def start(self, host: str = "0.0.0.0", port: int = 8000):
         server = Server(

--- a/application_sdk/clients/temporal.py
+++ b/application_sdk/clients/temporal.py
@@ -303,6 +303,22 @@ class TemporalClient(ClientInterface):
             logger.error(f"Workflow failure: {e}")
             raise e
 
+    async def stop_workflow(self, workflow_id: str, run_id: str) -> None:
+        """Stop a workflow execution.
+
+        Args:
+            workflow_id (str): The ID of the workflow.
+            run_id (str): The run ID of the workflow.
+        """
+        try:
+            workflow_handle = self.client.get_workflow_handle(
+                workflow_id, run_id=run_id
+            )
+            await workflow_handle.terminate()
+        except Exception as e:
+            logger.error(f"Error terminating workflow {workflow_id} {run_id}: {e}")
+            raise e
+
     def create_worker(
         self,
         activities: Sequence[CallableType],


### PR DESCRIPTION
- Adds support to stop running workflow
- this will allow the sidecar to stop the existing stale workflow before submitting a new one in case of pod eviction/deletion
- [Context](https://atlanhq.slack.com/archives/C07A8R56R2A/p1738912360451799)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- Added a new API endpoint that lets you stop ongoing workflows.
	- Enhanced workflow management by ensuring robust termination and improved error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->