### PR TITLE
chore: APP-5393 create different action for conventional commits

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -35,6 +35,3 @@ jobs:
         poetry config virtualenvs.in-project true
         poetry install --no-root --without dev,test --extras "workflows"
     - uses: pre-commit/action@v3.0.1
-    - uses: webiny/action-conventional-commits@v1.3.0
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/commits.yaml
+++ b/.github/workflows/commits.yaml
@@ -1,0 +1,33 @@
+# Ensures all the commits in the PR follow the conventional commits standard
+
+# Examples for conventional commits (read more at https://www.conventionalcommits.org):
+# feat: add new user authentication feature
+# fix: resolve login page crash
+# docs: update API documentation
+# style: format user profile component
+# refactor: restructure database queries
+# test: add unit tests for auth service
+# chore: update dependencies
+# perf: optimize image loading
+# ci: update GitHub Actions workflow
+# build: modify webpack configuration
+# revert: revert last commit
+
+name: Conventional Commits Check
+
+on:
+  workflow_call:
+  pull_request:
+    types: [ opened, synchronize, labeled, reopened ]
+    branches: [ main, master, develop ]
+
+jobs:
+  conventional-commits:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: webiny/action-conventional-commits@v1.3.0
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -1,3 +1,13 @@
+# Validate Pull Request Title
+#
+# This action validates pull request titles in two ways:
+# Ensures a Jira issue key (e.g., ABC-123) is present anywhere in the PR title, and if the
+# PR title match the Conventional Commits spec.
+#
+# Examples:
+#   - "feat: APP-3214 Add user authentication"
+#   - "fix: APP-1234 Resolve memory leak issue"
+
 name: Validate PR Title
 run-name: ${{ github.actor }} is ensuring Jira ID is present in PR title
 on:


### PR DESCRIPTION
This pull request includes changes to the GitHub workflows to ensure that all commits follow the conventional commits standard. The most important changes include the removal of the conventional commits action from the `checks.yaml` workflow and the addition of a new workflow specifically for conventional commits checks.

Changes to GitHub workflows:

* [`.github/workflows/checks.yaml`](diffhunk://#diff-4af11422a4987e947e5a47adead7a30d32cdb2db82e2d3fe36f8e6cbe84d5ac5L38-L40): Removed the `webiny/action-conventional-commits@v1.3.0` action from the workflow.
* [`.github/workflows/commits.yaml`](diffhunk://#diff-454bb1dd8d666f3456af56aa4374f88bd982812a27a7f7a386e75a77a8813d8bR1-R20): Added a new workflow to enforce conventional commits on pull requests targeting the `main`, `master`, and `develop` branches. This workflow runs the `webiny/action-conventional-commits@v1.3.0` action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Streamlined our automated checks by introducing new workflows to validate pull request titles and enforce standardized commit messaging for pull requests.
  - Enhanced the existing validation workflow with detailed descriptions and examples for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->