### PR TITLE
ci: APP-5393 update secret for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,9 +84,11 @@ jobs:
           git add pyproject.toml poetry.lock
           git commit -m "chore(release): bump version"
           git push origin ${{ github.ref_name }}
+        env:
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
         run: |
           gh release create "v$(poetry version -s)" --generate-notes


### PR DESCRIPTION
This pull request includes a small but significant change to the GitHub Actions workflow for releases. The change updates the environment variable for the GitHub token to use a more specific secret.

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR87-R92): Updated the `GH_TOKEN` environment variable to use `secrets.ORG_PAT_GITHUB` instead of `secrets.GITHUB_TOKEN` for both the git push and GitHub release steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the authentication configuration for release operations, ensuring improved environment variable handling for version bump and release creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->