### PR TITLE
ci: APP-5393 update secret for releases (#216)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,9 +77,12 @@ jobs:
           poetry lock
 
       - name: Commit version bump and changelog
+        env:
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
         run: |
           git config --global user.name 'atlan-ci'
           git config --global user.email 'it@atlan.com'
+          git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/$GITHUB_REPOSITORY
 
           git add pyproject.toml poetry.lock
           git commit -m "chore(release): bump version"
@@ -87,6 +90,6 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
         run: |
           gh release create "v$(poetry version -s)" --generate-notes


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow for releases, specifically in the file `.github/workflows/release.yaml`. The main change is the update of the environment variable used for authentication.

Changes to GitHub Actions workflow:

* Updated the `GH_TOKEN` environment variable to use `secrets.ORG_PAT_GITHUB` instead of `secrets.GITHUB_TOKEN` for both the "Commit version bump and changelog" and "Create GitHub Release" steps. This ensures that the correct token is used for authentication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the release process authentication to ensure consistent and reliable deployment automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->