### PR TITLE
ci: APP-5393 correct release commit user

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,6 +77,8 @@ jobs:
           poetry lock
 
       - name: Commit version bump and changelog
+        env:
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yaml` file to update the GitHub Actions bot configuration. The change updates the global Git user name and email to use the GitHub Actions bot credentials.

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL83-R84): Updated Git user name to 'github-actions[bot]' and email to 'github-actions[bot]@users.noreply.github.com'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the automated release process to use a dedicated bot identity for commit attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->