### PR TITLE
ci: APP-5393 correct commit command 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,7 +86,7 @@ jobs:
 
           git add pyproject.toml poetry.lock
           git commit -m "chore(release): bump version"
-          git push origin ${{ github.ref_name }}
+          git push origin ${{ github.ref_name }} --force
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yaml` file. The change modifies the `git push` command to use the `--force` flag for pushing to the origin.

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL89-R89): Added the `--force` flag to the `git push` command to ensure that the push operation is forced.