### PR TITLE
feat(release): APP-5849 handle edge case for squashed commits to main

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -125,13 +125,14 @@ def calculate_version_bump(
             logging.info(f"Feature detected - bumping minor version to {new_version}")
         elif is_fix:
             # Patch was already bumped in the develop branch
-            version.prerelease = None
-            new_version = version
+            new_version = version.next_version(part="patch")
             logging.info(f"Fix detected - bumping version to {new_version}")
         else:
             # No changes were detected in the commits, remove the prerelease, as patch was already bumped in the develop branch
-            version.prerelease = None
-            new_version = version
+            new_version = version.next_version(part="patch")
+            logging.info(
+                f"No changes detected - bumping patch version to {new_version}"
+            )
 
         return str(new_version)
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "application-sdk"
-version = "0.3.0"
+version = "0.2.1-rc.8"
 description = "Python Application SDK is a Python library for developing applications on the Atlan Platform"
 authors = ["Atlan App Team <apps@atlan.com>"]
 readme = "README.md"


### PR DESCRIPTION
This pull request includes changes to the release script and workflow to improve version bumping and commit retrieval processes. The most important changes include updating the `get_commits_since_last_tag` function to include commit descriptions, modifying the version bump logic to use a more consistent method, and updating the workflow file to reflect the new script location.

Improvements to commit retrieval:

* [`.github/scripts/release.py`](diffhunk://#diff-ec6cb62649e81d13fd26e64977e877bc55b47052d1e443f25fe31b50e27e96faL23-R27): Updated `get_commits_since_last_tag` to include both subject and description of commits and to filter out empty lines.

Enhancements to version bump logic:

* [`.github/scripts/release.py`](diffhunk://#diff-ec6cb62649e81d13fd26e64977e877bc55b47052d1e443f25fe31b50e27e96faL126-R135): Modified `calculate_version_bump` to use `version.next_version(part="patch")` for more consistent version bumping.

Workflow updates:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL76-R76): Updated the path to the release script to reflect its new location in the `.github/scripts` directory.