### PR TITLE
Increase timeout for E2E (Apps)

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -326,7 +326,7 @@ jobs:
 
           status="in_progress"
           start_time=$(date +%s)
-          timeout=180
+          timeout=240
           while [[ "$status" == "in_progress" || "$status" == "queued" ]]; do
             sleep 10
             response=$(curl -s -H "Authorization: Bearer ${{ secrets.ORG_PAT_GITHUB }}" \

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -180,7 +180,7 @@ jobs:
 
           status="in_progress"
           start_time=$(date +%s)
-          timeout=180
+          timeout=240
           while [[ "$status" == "in_progress" || "$status" == "queued" ]]; do
             sleep 10
             response=$(curl -s -H "Authorization: Bearer ${{ secrets.ORG_PAT_GITHUB }}" \


### PR DESCRIPTION
Increased timeout for E2E (Apps) test from 180 seconds to 240 seconds as there were multiple instances observed where the test even though, it was getting succeeded in the backend was getting timed-out.

## Pull Request Template

### Changelog
- Increased the timeout for E2E Integration tests to 240 seconds from earlier 180 seconds

### Additional context, dependencies & links
- The E2E integration tests seemed to be failing even though the workflow was passing eventually. 
- The workflow has a timeout of 300 seconds while check workflow status had a timeout of 180 seconds which was causing the issue. 

### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [x] Additional tests added
- [x] All CI checks passed


<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


<!-- for any questions, reachout to #pod-app-framework or apps@atlan.com -->