### PR TITLE
fix: Update boto3 and validators to latest versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -292,17 +292,17 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.38.5"
+version = "1.38.6"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "boto3-1.38.5-py3-none-any.whl", hash = "sha256:78601ef259865a954ae0385f278fbe5d9b632cf6c5fe6500e1ceb94d35acf07f"},
-    {file = "boto3-1.38.5.tar.gz", hash = "sha256:4cd581f77e67dbc28579134e1ee7b522797cfde30e0c735e7537ec4a3fb6af45"},
+    {file = "boto3-1.38.6-py3-none-any.whl", hash = "sha256:fe5bbd349310ef560b247e61453983ee6078ad4c2672620ca66bc0d29d64e728"},
+    {file = "boto3-1.38.6.tar.gz", hash = "sha256:9d764c402cadd112020812b9621a567058aa29d41a491d2d04b070be19ad5173"},
 ]
 
 [package.dependencies]
-botocore = ">=1.38.5,<1.39.0"
+botocore = ">=1.38.6,<1.39.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.12.0,<0.13.0"
 
@@ -311,13 +311,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "boto3-stubs"
-version = "1.38.5"
-description = "Type annotations for boto3 1.38.5 generated with mypy-boto3-builder 8.10.1"
+version = "1.38.6"
+description = "Type annotations for boto3 1.38.6 generated with mypy-boto3-builder 8.10.1"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "boto3_stubs-1.38.5-py3-none-any.whl", hash = "sha256:bce709424c2d56493457c1e4687d93e6dff28d197123fabec2cb11d06b0e5198"},
-    {file = "boto3_stubs-1.38.5.tar.gz", hash = "sha256:b02c6347f8f4dc69a9990b8a49de347a31d1de9db3f87dbcc3e5e94e93515520"},
+    {file = "boto3_stubs-1.38.6-py3-none-any.whl", hash = "sha256:501117865f52445654c9192885abd5995cfd31fec46aac02c7f5ea0b78492252"},
+    {file = "boto3_stubs-1.38.6.tar.gz", hash = "sha256:3459d1203da5ca3400a1606b5dac53b10c31877ac11bbf95a82b85784ff32771"},
 ]
 
 [package.dependencies]
@@ -373,7 +373,7 @@ bedrock-data-automation-runtime = ["mypy-boto3-bedrock-data-automation-runtime (
 bedrock-runtime = ["mypy-boto3-bedrock-runtime (>=1.38.0,<1.39.0)"]
 billing = ["mypy-boto3-billing (>=1.38.0,<1.39.0)"]
 billingconductor = ["mypy-boto3-billingconductor (>=1.38.0,<1.39.0)"]
-boto3 = ["boto3 (==1.38.5)"]
+boto3 = ["boto3 (==1.38.6)"]
 braket = ["mypy-boto3-braket (>=1.38.0,<1.39.0)"]
 budgets = ["mypy-boto3-budgets (>=1.38.0,<1.39.0)"]
 ce = ["mypy-boto3-ce (>=1.38.0,<1.39.0)"]
@@ -738,13 +738,13 @@ xray = ["mypy-boto3-xray (>=1.38.0,<1.39.0)"]
 
 [[package]]
 name = "botocore"
-version = "1.38.5"
+version = "1.38.6"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "botocore-1.38.5-py3-none-any.whl", hash = "sha256:df1dc1dfe3607e3f802ddeb1f25a9f0abc8909ea674032480f71362e96c3c548"},
-    {file = "botocore-1.38.5.tar.gz", hash = "sha256:506e8274f7ddb84ca4ec85f7f9229de59fb43702e2e0b1400bea07f7f4a7ba82"},
+    {file = "botocore-1.38.6-py3-none-any.whl", hash = "sha256:ccac197e444b7fcdc2ddbdafddddf9f82454a7e1f9d2a55ef9dcc0258b3b27e3"},
+    {file = "botocore-1.38.6.tar.gz", hash = "sha256:07e0721f6b1758183ed425f481a7af79e4897a3c02c2c486e101c576aee7377c"},
 ]
 
 [package.dependencies]
@@ -757,13 +757,13 @@ crt = ["awscrt (==0.23.8)"]
 
 [[package]]
 name = "botocore-stubs"
-version = "1.38.5"
+version = "1.38.6"
 description = "Type annotations and code completion for botocore"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "botocore_stubs-1.38.5-py3-none-any.whl", hash = "sha256:e5c3f6a7d1377b5f183848eab985bea71926df43b00e02ca36fb8a22e827af48"},
-    {file = "botocore_stubs-1.38.5.tar.gz", hash = "sha256:560e193e39f2b153b0d64bc420a7e02f8a188f3f1c667b79a94bbf2ab56addc7"},
+    {file = "botocore_stubs-1.38.6-py3-none-any.whl", hash = "sha256:9a17a5cc2d36120f3683ebe78c40a96281497592e07175a8bf6ee6cd01910a50"},
+    {file = "botocore_stubs-1.38.6.tar.gz", hash = "sha256:56ed87b3e0870d21a968a8346129b578e1f6b70ee902d00bbb6b162c291222f4"},
 ]
 
 [package.dependencies]
@@ -5157,13 +5157,13 @@ test = ["aiohttp (>=3.10.5)", "flake8 (>=5.0,<6.0)", "mypy (>=0.800)", "psutil",
 
 [[package]]
 name = "validators"
-version = "0.34.0"
+version = "0.35.0"
 description = "Python Data Validation for Humans™"
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "validators-0.34.0-py3-none-any.whl", hash = "sha256:c804b476e3e6d3786fa07a30073a4ef694e617805eb1946ceee3fe5a9b8b1321"},
-    {file = "validators-0.34.0.tar.gz", hash = "sha256:647fe407b45af9a74d245b943b18e6a816acf4926974278f6dd617778e1e781f"},
+    {file = "validators-0.35.0-py3-none-any.whl", hash = "sha256:e8c947097eae7892cb3d26868d637f79f47b4a0554bc6b80065dfe5aac3705dd"},
+    {file = "validators-0.35.0.tar.gz", hash = "sha256:992d6c48a4e77c81f1b4daba10d16c3a9bb0dbb79b3a19ea847ff0928e70497a"},
 ]
 
 [package.extras]
@@ -5711,4 +5711,4 @@ workflows = ["dapr", "orjson", "temporalio"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "e39d5cf48a0dcf012aa70cc29719c643ab5e4d05a03363d1f59adf292b1e24a4"
+content-hash = "4b147211aba6bb58e0747fefcc78799fe8317199da490bf08311f5225335da65"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ duckdb-engine = {version = "^0.17.0", optional = true}
 temporalio = {version = "^1.7.1", optional = true}
 getdaft = {extras = ["sql"], version = "^0.4.12", optional = true}
 pyiceberg = {version = "^0.8.1", optional = true} # For iceberg input and output support
-boto3 = {version = "^1.38.4", optional = true} # For iam auth support
+boto3 = {version = "^1.38.6", optional = true} # For iam auth support
 pydantic = "^2.10.6"
 loguru = "^0.7.3"
 uvloop = "^0.21.0" # in worker module for managing Temporal workers.
@@ -77,7 +77,7 @@ scale_data_generator = [
 pre-commit = "^4.2.0"
 isort = "^5.13.2"
 pylint = "^3.3.3"
-boto3-stubs = {version = "^1.38.5", optional = true} # For boto related type checking
+boto3-stubs = {version = "^1.38.6", optional = true} # For boto related type checking
 mkdocs = "^1.6.1"
 mkdocs-material = "^9.6.4"
 pydoctor = "^24.11.2"


### PR DESCRIPTION
Upgrade boto3 and related packages to version 1.38.6 and validators to version 0.35.0 for improved functionality and compatibility.