### PR TITLE
fix: Update security advisory link to application-sdk

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Vulnerability Disclosure
 
 If you think you have found a potential security vulnerability,
-please open a [draft Security Advisory](https://github.com/atlanhq/agent-toolkit/security/advisories/new) via GitHub. We will coordinate verification and next steps through that secure medium.
+please open a [draft Security Advisory](https://github.com/atlanhq/application-sdk/security/advisories/new) via GitHub. We will coordinate verification and next steps through that secure medium.
 
 If English is not your first language, please try to describe the
 problem and its impact to the best of your ability. For greater detail,


### PR DESCRIPTION
Correct the link for opening a draft Security Advisory to point to the application-sdk repository.