### PR TITLE
fixed the e2e test for on push

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -52,7 +52,7 @@ jobs:
         with:
           github-token: ${{ secrets.ORG_PAT_GITHUB }}
           repo-name: ${{ matrix.repo_name }}
-          target-branch: ${{ env.base_branch }}
+          target-branch: ${{ github.ref_name }}
 
   # Documentation
   docs:


### PR DESCRIPTION
This pull request introduces updates to GitHub Actions workflows and configuration files, along with a version downgrade in the `pyproject.toml` file. The most notable changes include adding support for specifying a target branch in workflows and increasing timeout and retry durations for e2e tests.

### GitHub Actions Workflow Updates:

* [`.github/actions/e2e-apps/action.yaml`](diffhunk://#diff-cac4408eb675925b43aeae631f5789798b898eec27785ce3885345f500577028R23-R25): Added a new `target-branch` input to specify the branch to test. Updated the `ref` parameter to use this input and increased `workflow_timeout_seconds` from 120 to 300 and `workflow_job_steps_retry_seconds` from 10 to 20. [[1]](diffhunk://#diff-cac4408eb675925b43aeae631f5789798b898eec27785ce3885345f500577028R23-R25) [[2]](diffhunk://#diff-cac4408eb675925b43aeae631f5789798b898eec27785ce3885345f500577028L51-R59)
* [`.github/workflows/pull_request.yaml`](diffhunk://#diff-7b2a967de7060a238e49a57908f83e860b8cb53a0b0991c3d0d275857c1014d4R200): Passed the `target-branch` input dynamically using `matrix.target_branch` for pull request workflows.
* [`.github/workflows/push.yaml`](diffhunk://#diff-1790f2f8b7123d50d46235053b54f1cc5996bc7388b803aad4233fd5582e0badR55): Passed the `target-branch` input using `github.ref_name` for push workflows.

### Configuration Change:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Downgraded the `application-sdk` version from `0.2.1` to `0.0.9`.### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- _to be added_

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


<!-- for any questions, reachout to #pod-app-framework or apps@atlan.com -->