### PR TITLE
Fix: JsonOutput type checking while writing dataframe

### DIFF
--- a/application_sdk/outputs/json.py
+++ b/application_sdk/outputs/json.py
@@ -256,9 +256,9 @@ class JsonOutput(Output):
         if not self.buffer or not self.current_buffer_size:
             return
 
-        if not isinstance(self.buffer, List["pd.DataFrame"]):
+        if not all(isinstance(df, pd.DataFrame) for df in self.buffer):
             raise TypeError(
-                "_flush_buffer encountered non-list buffer. This should not happen."
+                "_flush_buffer encountered non-DataFrame elements in buffer. This should not happen."
             )
 
         # Now it's safe to cast for pd.concat


### PR DESCRIPTION
### Changelog


The existing code is checking if `self.buffer` itself is a `List["pd.DataFrame"]` type, which won't work as expected because:

1. `isinstance()` can't check against parametrized generic types like `List["pd.DataFrame"]`
2. It's checking the container type, not the content of the container

The proposed code works because it checks the actual content - verifying that each element in `self.buffer` is a pandas DataFrame, which is what's needed before calling `pd.concat(pd_buffer)`.


### Additional context (e.g. screenshots, logs, links)

- You can reproduce this issue, by writing list of dataframes using the JsonOutputs' `write_dataframe`


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [x] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to #pod-app-framework or connect@atlan.com -->