### PR TITLE
feat: Add SQLAlchemy url support

### DIFF
--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -236,7 +236,7 @@ class BaseSQLClient(ClientInterface):
 
         return connection_string
 
-    def update_dialect_in_url(self, sqlalchemy_url: str) -> str:
+    def get_supported_sqlalchemy_url(self, sqlalchemy_url: str) -> str:
         """Update the dialect in the URL if it is different from the installed dialect.
 
         Args:
@@ -269,8 +269,7 @@ class BaseSQLClient(ClientInterface):
         # If the compiled_url is present, use it directly
         sqlalchemy_url = extra.get("compiled_url")
         if sqlalchemy_url:
-            sqlalchemy_url = self.update_dialect_in_url(sqlalchemy_url)
-            return sqlalchemy_url
+            return self.get_supported_sqlalchemy_url(sqlalchemy_url)
 
         auth_token = self.get_auth_token()
 

--- a/tests/unit/clients/test_sql_client.py
+++ b/tests/unit/clients/test_sql_client.py
@@ -630,3 +630,33 @@ def test_get_sqlalchemy_connection_string_iam_role_missing_role_arn(
         CommonError, match="aws_role_arn is required for IAM role authentication"
     ):
         sql_client_with_db_config.get_sqlalchemy_connection_string()
+
+
+def test_get_sqlalchemy_connection_string_with_compiled_url(sql_client_with_db_config):
+    """Test connection string generation with compiled url"""
+    credentials = {
+        "extra": {
+            "compiled_url": "postgresql+psycopg://test_user:test_pass@localhost:5432/test_db?connect_timeout=5&ssl_mode=require"
+        }
+    }
+    sql_client_with_db_config.credentials = credentials
+
+    conn_str = sql_client_with_db_config.get_sqlalchemy_connection_string()
+    expected = "postgresql+psycopg://test_user:test_pass@localhost:5432/test_db?connect_timeout=5&ssl_mode=require"
+    assert conn_str == expected
+
+
+def test_get_sqlalchemy_connection_string_with_compiled_url_with_invalid_dialect(
+    sql_client_with_db_config,
+):
+    """Test connection string generation with compiled url with invalid dialect"""
+    credentials = {
+        "extra": {
+            "compiled_url": "postgresql+psycopg2://test_user:test_pass@localhost:5432/test_db?connect_timeout=5&ssl_mode=require"
+        }
+    }
+    sql_client_with_db_config.credentials = credentials
+
+    conn_str = sql_client_with_db_config.get_sqlalchemy_connection_string()
+    expected = "postgresql+psycopg://test_user:test_pass@localhost:5432/test_db?connect_timeout=5&ssl_mode=require"
+    assert conn_str == expected


### PR DESCRIPTION
### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->

- Added support to create sqlalchemy engine from a directly passed sqlalchemy supported url
- This was done to enable support for users to add any extra connection arguments that might be required to be added in order to connect to the source
- In this also in conjuction with the JDBC url support added in 2.0 framework

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- https://atlanhq.atlassian.net/browse/APP-6616


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [x] Additional tests added
- [x] All CI checks passed
- [x] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->