### PR TITLE
Fix: Changed application -> server, custom servers in constructor should work

### DIFF
--- a/application_sdk/application/__init__.py
+++ b/application_sdk/application/__init__.py
@@ -29,13 +29,11 @@ class BaseApplication:
             server (ServerInterface): The server class for the application.
         """
         self.application_name = name
-        self.server = server
 
         # setup application server. serves the UI, and handles the various triggers
-        self.application = None
+        self.server = server
 
         self.worker = None
-        self.application = None  # For server, if needed
 
         self.workflow_client = get_workflow_client(application_name=name)
 
@@ -99,14 +97,14 @@ class BaseApplication:
         if self.workflow_client is None:
             await self.workflow_client.load()
 
-        # setup application server. serves the UI, and handles the various triggers
-        self.application = APIServer(
+        # Overrides the application server. serves the UI, and handles the various triggers
+        self.server = APIServer(
             workflow_client=self.workflow_client,
         )
 
         # register the workflow on the application server
         # the workflow is by default triggered by an HTTP POST request to the /start endpoint
-        self.application.register_workflow(
+        self.server.register_workflow(
             workflow_class=workflow_class,
             triggers=[HttpWorkflowTrigger()],
         )
@@ -118,7 +116,7 @@ class BaseApplication:
         Raises:
             ValueError: If the application server is not initialized.
         """
-        if self.application is None:
+        if self.server is None:
             raise ValueError("Application server not initialized")
 
-        await self.application.start()
+        await self.server.start()

--- a/application_sdk/application/metadata_extraction/sql.py
+++ b/application_sdk/application/metadata_extraction/sql.py
@@ -39,6 +39,7 @@ class BaseSQLMetadataExtractionApplication(BaseApplication):
         client_class: Optional[Type[BaseSQLClient]] = None,
         handler_class: Optional[Type[BaseSQLHandler]] = None,
         transformer_class: Optional[Type[QueryBasedTransformer]] = None,
+        server: Optional[APIServer] = None,
     ):
         """
         Initialize the SQL metadata extraction application.
@@ -48,6 +49,7 @@ class BaseSQLMetadataExtractionApplication(BaseApplication):
             client_class (Type[BaseSQLClient]): SQL client class for source connectivity.
             handler_class (Optional[Type[HandlerInterface]]): Handler class for preflight checks and metadata logic. Defaults to BaseSQLHandler.
             transformer_class (Optional[Type[TransformerInterface]]): Transformer class for mapping to Atlas entities. Defaults to QueryBasedTransformer.
+            server (Optional[APIServer]): Server for the application. Defaults to None.
         """
         self.application_name = name
         self.transformer_class = transformer_class or QueryBasedTransformer
@@ -55,7 +57,7 @@ class BaseSQLMetadataExtractionApplication(BaseApplication):
         self.handler_class = handler_class or BaseSQLHandler
 
         # setup application server. serves the UI, and handles the various triggers
-        self.server = None
+        self.server = server
 
         self.worker = None
 

--- a/application_sdk/application/metadata_extraction/sql.py
+++ b/application_sdk/application/metadata_extraction/sql.py
@@ -55,7 +55,7 @@ class BaseSQLMetadataExtractionApplication(BaseApplication):
         self.handler_class = handler_class or BaseSQLHandler
 
         # setup application server. serves the UI, and handles the various triggers
-        self.application = None
+        self.server = None
 
         self.worker = None
 
@@ -169,14 +169,14 @@ class BaseSQLMetadataExtractionApplication(BaseApplication):
             await self.workflow_client.load()
 
         # setup application server. serves the UI, and handles the various triggers
-        self.application = APIServer(
+        self.server = APIServer(
             handler=self.handler_class(sql_client=self.client_class()),
             workflow_client=self.workflow_client,
         )
 
         # register the workflow on the application server
         # the workflow is by default triggered by an HTTP POST request to the /start endpoint
-        self.application.register_workflow(
+        self.server.register_workflow(
             workflow_class=workflow_class,
             triggers=[HttpWorkflowTrigger()],
         )


### PR DESCRIPTION
### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- Updated application server naming, `application` -> `server`
- Due to two different application servers being created before (`application`, and `server`), the `server` passed in the constructor was not being used. 

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->