### PR TITLE
fix: Update compiled_url logic

### DIFF
--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -274,10 +274,12 @@ class BaseSQLClient(ClientInterface):
             ValueError: If required connection parameters are missing.
         """
         extra = parse_credentials_extra(self.resolved_credentials)
+
+        # TODO: Uncomment this when the native deployment is ready
         # If the compiled_url is present, use it directly
-        sqlalchemy_url = extra.get("compiled_url")
-        if sqlalchemy_url:
-            return self.get_supported_sqlalchemy_url(sqlalchemy_url)
+        # sqlalchemy_url = extra.get("compiled_url")
+        # if sqlalchemy_url:
+        #     return self.get_supported_sqlalchemy_url(sqlalchemy_url)
 
         auth_token = self.get_auth_token()
 

--- a/tests/unit/clients/test_sql_client.py
+++ b/tests/unit/clients/test_sql_client.py
@@ -632,6 +632,7 @@ def test_get_sqlalchemy_connection_string_iam_role_missing_role_arn(
         sql_client_with_db_config.get_sqlalchemy_connection_string()
 
 
+@pytest.mark.skip(reason="Skipping this test until the native deployment is ready")
 def test_get_sqlalchemy_connection_string_with_compiled_url(sql_client_with_db_config):
     """Test connection string generation with compiled url"""
     credentials = {
@@ -646,6 +647,7 @@ def test_get_sqlalchemy_connection_string_with_compiled_url(sql_client_with_db_c
     assert conn_str == expected
 
 
+@pytest.mark.skip(reason="Skipping this test until the native deployment is ready")
 def test_get_sqlalchemy_connection_string_with_compiled_url_with_invalid_dialect(
     sql_client_with_db_config,
 ):


### PR DESCRIPTION
### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
Atlan frontend is sending the compiled_url even if explicitly the url option is not selected in the frontend
This causes an issue since it sends a JDBC url and we have added a check which validates if compiled_url is present or not if yes use it to create the SQLAlchemy engine

For this PR commenting the compiled_url logic in the sdk till we have a plan on native deployment. Will add it back once we finalise the details

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->