### PR TITLE
feat: Add handler route registration to APIServer

### DIFF
--- a/application_sdk/application/__init__.py
+++ b/application_sdk/application/__init__.py
@@ -26,6 +26,7 @@ class BaseApplication:
         self,
         name: str,
         server: Optional[ServerInterface] = None,
+        handler: Optional[HandlerInterface] = None,
         application_manifest: Optional[dict] = None,
     ):
         """
@@ -34,8 +35,11 @@ class BaseApplication:
         Args:
             name (str): The name of the application.
             server (ServerInterface): The server class for the application.
+            handler (HandlerInterface): The handler instance for processing server-specific operations.
+            application_manifest (dict): The application manifest.
         """
         self.application_name = name
+        self.handler = handler
 
         # setup application server. serves the UI, and handles the various triggers
         self.server = server
@@ -147,7 +151,6 @@ class BaseApplication:
     async def setup_server(
         self,
         workflow_class,
-        handler: Optional[HandlerInterface] = None,
         ui_enabled: bool = True,
     ):
         """
@@ -157,9 +160,6 @@ class BaseApplication:
 
         Args:
             workflow_class: The workflow class to register with the server.
-            handler (Optional[HandlerInterface]): Optional handler instance for processing
-                server-specific operations. If provided, this handler will be used for any
-                registered handler routes. Defaults to None.
             ui_enabled (bool): Whether to enable the UI. Defaults to True.
 
         Raises:
@@ -172,7 +172,7 @@ class BaseApplication:
         if self.server is None:
             self.server = APIServer(
                 workflow_client=self.workflow_client,
-                handler=handler,
+                handler=self.handler,
                 ui_enabled=ui_enabled,
             )
 

--- a/application_sdk/server/fastapi/__init__.py
+++ b/application_sdk/server/fastapi/__init__.py
@@ -740,3 +740,32 @@ class APIServer(ServerInterface):
             )
         )
         await server.serve()
+
+    def add_handler_route(
+        self,
+        path: str,
+        handler_method: Callable,
+        methods: List[str],
+        response_model: Optional[Type] = None,
+    ) -> None:
+        """
+        Add a route that uses a handler method.
+
+        Args:
+            path: API path
+            handler_method: The handler method to use
+            methods: List of HTTP methods
+            response_model: Optional response model for FastAPI
+
+        Raises:
+            ValueError: If handler is not initialized
+        """
+        if not self.handler:
+            raise ValueError("Handler not initialized")
+
+        self.workflow_router.add_api_route(
+            path=path,
+            endpoint=handler_method,
+            methods=methods,
+            response_model=response_model,
+        )

--- a/application_sdk/server/fastapi/__init__.py
+++ b/application_sdk/server/fastapi/__init__.py
@@ -769,3 +769,4 @@ class APIServer(ServerInterface):
             methods=methods,
             response_model=response_model,
         )
+        self.app.include_router(self.workflow_router, prefix="/workflows/v1")

--- a/application_sdk/server/fastapi/models.py
+++ b/application_sdk/server/fastapi/models.py
@@ -1,7 +1,7 @@
 # Request/Response DTOs for workflows
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Callable, Dict, List, Optional, Type
 
 from pydantic import BaseModel, Field, RootModel
 
@@ -221,3 +221,20 @@ class EventWorkflowTrigger(WorkflowTrigger):
 
     def should_trigger_workflow(self, event: Event) -> bool:
         return True
+
+
+class HandlerRoute(BaseModel):
+    """Model for defining a handler route."""
+
+    path: str = Field(..., description="API path for the route")
+    handler_method: Callable = Field(..., description="The handler method to be called")
+    methods: List[str] = Field(
+        ..., description="List of HTTP methods (GET, POST, etc.)"
+    )
+    response_model: Optional[Type] = Field(
+        None, description="Optional response model for FastAPI"
+    )
+
+    model_config = {
+        "arbitrary_types_allowed": True  # Needed for Callable and Type fields
+    }


### PR DESCRIPTION
Introduce a mechanism for registering handler routes in the APIServer, enhancing the server setup process to accommodate optional handler instances for processing server-specific operations.