### PR TITLE
Fix object store download path

### DIFF
--- a/application_sdk/inputs/json.py
+++ b/application_sdk/inputs/json.py
@@ -50,8 +50,11 @@ class JsonInput(Input):
                 if self.download_file_prefix is not None and not os.path.exists(
                     os.path.join(self.path, file_name)
                 ):
+                    # Only pass the prefix without the filename so that
+                    # download_file_from_object_store can correctly compute
+                    # the relative path for the object store lookup.
                     ObjectStoreInput.download_file_from_object_store(
-                        os.path.join(self.download_file_prefix, file_name),
+                        self.download_file_prefix,
                         os.path.join(self.path, file_name),
                     )
             except IOError as e:

--- a/application_sdk/inputs/objectstore.py
+++ b/application_sdk/inputs/objectstore.py
@@ -27,8 +27,9 @@ class ObjectStoreInput:
         Downloads all files from the object store for a given prefix.
 
         Args:
-            download_file_prefix (str): The base path in the object store to download files from.
-            local_directory (str): The local directory where the files should be downloaded.
+            download_file_prefix (str): The base path in the object store to
+                download files from.
+            file_path (str): Local directory where the files will be saved.
 
         Raises:
             Exception: If there's an error downloading any file from the object store.
@@ -40,8 +41,9 @@ class ObjectStoreInput:
 
             # List all files in the object store path
             with DaprClient() as client:
-                relative_path = os.path.relpath(file_path, download_file_prefix)
-                metadata = {"fileName": relative_path}
+                # Use the prefix directly when listing files from the object store
+                # as it represents the remote path from which files should be retrieved.
+                metadata = {"fileName": download_file_prefix}
                 try:
                     # Assuming the object store binding supports a "list" operation
                     response = client.invoke_binding(


### PR DESCRIPTION
## Summary
- fix JsonInput to pass prefix without filename for object store download
- use download prefix directly when listing object-store files

## Testing
- `pytest tests/unit/inputs/test_json_input.py -k test_not_download_file_that_exists -vv` *(fails: ModuleNotFoundError: No module named 'dapr')*

------
https://chatgpt.com/codex/tasks/task_b_685a3ec820d483228ec54ad3826f62b0