### PR TITLE
Fix scalability and async issues

### DIFF
--- a/application_sdk/common/utils.py
+++ b/application_sdk/common/utils.py
@@ -2,7 +2,6 @@ import asyncio
 import glob
 import json
 import os
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
 from application_sdk.common.error_codes import CommonError
@@ -318,18 +317,17 @@ def parse_credentials_extra(credentials: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def run_sync(func):
-    """Run a function in a thread pool executor.
+    """Run a synchronous function without blocking the event loop.
 
     Args:
-        func: The function to run in thread pool.
+        func: The function to run in a thread from the default executor.
 
     Returns:
-        An async wrapper function that runs the input function in a thread pool.
+        An async wrapper function that runs the input function in the event loop's default executor.
     """
 
     async def wrapper(*args, **kwargs):
         loop = asyncio.get_running_loop()
-        with ThreadPoolExecutor() as pool:
-            return await loop.run_in_executor(pool, func, *args, **kwargs)
+        return await loop.run_in_executor(None, func, *args, **kwargs)
 
     return wrapper

--- a/docs/docs/concepts/common.md
+++ b/docs/docs/concepts/common.md
@@ -456,7 +456,7 @@ Contains miscellaneous helper functions used throughout the SDK.
 *   **`get_actual_cpu_count()`**: Attempts to determine the number of CPUs available to the current process, considering potential container limits (via `os.sched_getaffinity`), falling back to `os.cpu_count()`.
 *   **`get_safe_num_threads()`**: Calculates a reasonable number of threads for parallel processing, typically `get_actual_cpu_count() + 4`.
 *   **`parse_credentials_extra(credentials)`**: Safely parses the `extra` field within a `credentials` dictionary (assuming it's a JSON string) and merges its contents back into the main dictionary.
-*   **`run_sync(func)`**: A decorator (intended for internal use, e.g., in `AsyncBaseSQLClient`) to run a synchronous function (`func`) in a `ThreadPoolExecutor` to avoid blocking an asyncio event loop.
+*   **`run_sync(func)`**: A decorator (intended for internal use, e.g., in `AsyncBaseSQLClient`) to run a synchronous function (`func`) in the event loop's default executor so the asyncio loop isn't blocked.
 
 ### Usage Examples
 

--- a/docs/docs/concepts/worker.md
+++ b/docs/docs/concepts/worker.md
@@ -56,8 +56,8 @@ await worker.start(daemon=True)
 **Parameters:**
 
 *   **`daemon` (bool):**
-    *   `True` (Default): Starts the worker in a separate background daemon thread. The `await worker.start()` call returns immediately, allowing your main application (like a FastAPI server) to continue running. This is the typical mode when running alongside a web application.
-    *   `False`: Starts the worker in the current thread. The `await worker.start()` call will block indefinitely until the worker is interrupted (e.g., by Ctrl+C). This is useful for standalone worker processes or debugging.
+    *   `True` (Default): Schedules the worker as a background asyncio task. The `await worker.start()` call returns immediately, allowing your main application (like a FastAPI server) to continue running. This is the typical mode when running alongside a web application.
+    *   `False`: Runs the worker in the current task. The `await worker.start()` call will block indefinitely until the worker is interrupted (e.g., by Ctrl+C). This is useful for standalone worker processes or debugging.
 
 ## Configuration and Extensibility
 


### PR DESCRIPTION
## Summary
- write observability records to new parquet files instead of rewriting existing ones
- use loop's default executor for sync wrappers and SQL queries
- start workers as asyncio tasks when daemon mode is enabled
- clarify docs for `run_sync` and worker daemon behavior

## Testing
- `pip install .[tests]` *(partial output omitted for brevity)*
- `pytest -q` *(fails: 35 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_685a4021f0008322a70ebbda78191a0a