### PR TITLE
fix: multi-database fetch based on include / exclude filter

### DIFF
--- a/application_sdk/common/utils.py
+++ b/application_sdk/common/utils.py
@@ -152,6 +152,10 @@ def prepare_query(
         include_databases = extract_database_names_from_regex(normalized_include_regex)
         exclude_databases = extract_database_names_from_regex(normalized_exclude_regex)
 
+        if include_databases == "'^$'" and exclude_databases == "'^$'":
+            include_databases = "'.*'"
+            exclude_databases = "'^$'"
+
         # Use sets directly for SQL query formatting
         exclude_empty_tables = workflow_args.get("metadata", {}).get(
             "exclude_empty_tables", False

--- a/application_sdk/common/utils.py
+++ b/application_sdk/common/utils.py
@@ -93,7 +93,7 @@ def extract_database_names_from_regex(normalized_regex: str) -> str:
             f"Error extracting database names from regex '{normalized_regex}': {str(e)}"
         )
         # Return a safe default that excludes everything
-        return
+        return "'^$'"
 
 
 def prepare_query(

--- a/application_sdk/handlers/sql.py
+++ b/application_sdk/handlers/sql.py
@@ -152,7 +152,7 @@ class BaseSQLHandler(HandlerInterface):
             raise ValueError("fetch_databases_sql is not defined")
 
         databases = []
-        async for batch in self.sql_client.run_query(self.fetch_databases_sql):
+        async for batch in self.sql_client.run_query(self.fetch_metadata):
             for row in batch:
                 databases.append(
                     {self.database_result_key: row[self.database_result_key]}

--- a/application_sdk/handlers/sql.py
+++ b/application_sdk/handlers/sql.py
@@ -152,7 +152,7 @@ class BaseSQLHandler(HandlerInterface):
             raise ValueError("fetch_databases_sql is not defined")
 
         databases = []
-        async for batch in self.sql_client.run_query(self.fetch_metadata):
+        async for batch in self.sql_client.run_query(self.metadata_sql):
             for row in batch:
                 databases.append(
                     {self.database_result_key: row[self.database_result_key]}

--- a/application_sdk/handlers/sql.py
+++ b/application_sdk/handlers/sql.py
@@ -145,11 +145,11 @@ class BaseSQLHandler(HandlerInterface):
             raise
 
     async def fetch_databases(self) -> List[Dict[str, str]]:
-        """Fetch only database information."""
+        """Fetch only database information using metadata_sql."""
         if not self.sql_client:
             raise ValueError("SQL Client not defined")
-        if self.fetch_databases_sql is None:
-            raise ValueError("fetch_databases_sql is not defined")
+        if self.metadata_sql is None:
+            raise ValueError("metadata_sql is not defined")
 
         databases = []
         async for batch in self.sql_client.run_query(self.metadata_sql):

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, mock_open, patch
 
 from application_sdk.common.error_codes import CommonError
 from application_sdk.common.utils import (
+    extract_database_names_from_regex,
     get_workflow_config,
     normalize_filters,
     prepare_filters,
@@ -168,6 +169,178 @@ class TestNormalizeFilters:
 
         # The implementation strips ^ from schema names but keeps $
         assert result == ["db1\\.schema1$"]
+
+
+class TestExtractDatabaseNamesFromRegex:
+    def test_extract_database_names_from_regex_with_multiple_databases(self) -> None:
+        """Test extracting database names from regex with multiple databases"""
+        normalized_regex = "dev\\.external_schema$|wide_world_importers\\.bronze_sales$"
+        result = extract_database_names_from_regex(normalized_regex)
+
+        # Should return sorted database names in regex format
+        assert result == "'^(dev|wide_world_importers)$'"
+
+    def test_extract_database_names_from_regex_with_wildcard_schemas(self) -> None:
+        """Test extracting database names from regex with wildcard schemas"""
+        normalized_regex = "dev\\.*|wide_world_importers\\.*"
+        result = extract_database_names_from_regex(normalized_regex)
+
+        assert result == "'^(dev|wide_world_importers)$'"
+
+    def test_extract_database_names_from_regex_with_single_database(self) -> None:
+        """Test extracting database names from regex with single database"""
+        normalized_regex = "test_db\\.schema_name$"
+        result = extract_database_names_from_regex(normalized_regex)
+
+        assert result == "'^(test_db)$'"
+
+    def test_extract_database_names_from_regex_with_empty_input(self) -> None:
+        """Test extracting database names from regex with empty input"""
+        result = extract_database_names_from_regex("")
+
+        assert result == "'^$'"
+
+    def test_extract_database_names_from_regex_with_none_input(self) -> None:
+        """Test extracting database names from regex with None input"""
+        result = extract_database_names_from_regex(None)  # type: ignore
+
+        assert result == "'^$'"
+
+    def test_extract_database_names_from_regex_with_non_string_input(self) -> None:
+        """Test extracting database names from regex with non-string input"""
+        result = extract_database_names_from_regex(123)  # type: ignore
+
+        assert result == "'^$'"
+
+    def test_extract_database_names_from_regex_with_empty_patterns(self) -> None:
+        """Test extracting database names from regex with empty patterns"""
+        normalized_regex = "|||"
+        result = extract_database_names_from_regex(normalized_regex)
+
+        assert result == "'^$'"
+
+    def test_extract_database_names_from_regex_with_whitespace_patterns(self) -> None:
+        """Test extracting database names from regex with whitespace patterns"""
+        normalized_regex = "   |  db1\\.schema1  |  "
+        result = extract_database_names_from_regex(normalized_regex)
+
+        assert result == "'^(db1)$'"
+
+    def test_extract_database_names_from_regex_with_invalid_database_names(
+        self,
+    ) -> None:
+        """Test extracting database names from regex with invalid database names"""
+        normalized_regex = "123db\\.schema1|db-2\\.schema2|valid_db\\.schema3"
+        result = extract_database_names_from_regex(normalized_regex)
+
+        # Only valid_db should be included (starts with letter/underscore, alphanumeric + underscore)
+        assert result == "'^(valid_db)$'"
+
+    def test_extract_database_names_from_regex_with_special_characters(self) -> None:
+        """Test extracting database names from regex with special characters"""
+        normalized_regex = "db@test\\.schema1|db#test\\.schema2|db_test\\.schema3"
+        result = extract_database_names_from_regex(normalized_regex)
+
+        # Only db_test should be included (valid format)
+        assert result == "'^(db_test)$'"
+
+    def test_extract_database_names_from_regex_with_dot_patterns(self) -> None:
+        """Test extracting database names from regex with dot patterns"""
+        normalized_regex = ".*\\.schema1|^$\\.schema2|db1\\.schema3"
+        result = extract_database_names_from_regex(normalized_regex)
+
+        # Only db1 should be included (.* and ^$ are excluded)
+        assert result == "'^(db1)$'"
+
+    def test_extract_database_names_from_regex_with_underscore_names(self) -> None:
+        """Test extracting database names from regex with underscore names"""
+        normalized_regex = "_test_db\\.schema1|test_db_\\.schema2|_test_db_\\.schema3"
+        result = extract_database_names_from_regex(normalized_regex)
+
+        # All should be included as they start with underscore or letter
+        assert result == "'^(_test_db|_test_db_|test_db_)$'"
+
+    def test_extract_database_names_from_regex_with_mixed_case(self) -> None:
+        """Test extracting database names from regex with mixed case"""
+        normalized_regex = "TestDB\\.schema1|test_db\\.schema2|TEST_DB\\.schema3"
+        result = extract_database_names_from_regex(normalized_regex)
+
+        # All should be included as they follow valid naming convention
+        assert result == "'^(TEST_DB|TestDB|test_db)$'"
+
+    def test_extract_database_names_from_regex_with_numbers_in_names(self) -> None:
+        """Test extracting database names from regex with numbers in names"""
+        normalized_regex = "db1\\.schema1|db_2\\.schema2|db3_test\\.schema3"
+        result = extract_database_names_from_regex(normalized_regex)
+
+        # All should be included as they follow valid naming convention
+        assert result == "'^(db1|db3_test|db_2)$'"
+
+    def test_extract_database_names_from_regex_with_complex_patterns(self) -> None:
+        """Test extracting database names from regex with complex patterns"""
+        normalized_regex = "dev\\.external_schema$|wide_world_importers\\.bronze_sales$|test_db\\.*|prod\\.schema1$"
+        result = extract_database_names_from_regex(normalized_regex)
+
+        # Should return all valid database names sorted
+        assert result == "'^(dev|prod|test_db|wide_world_importers)$'"
+
+    def test_extract_database_names_from_regex_with_duplicate_names(self) -> None:
+        """Test extracting database names from regex with duplicate names"""
+        normalized_regex = "db1\\.schema1|db1\\.schema2|db2\\.schema3|db1\\.schema4"
+        result = extract_database_names_from_regex(normalized_regex)
+
+        # Should deduplicate and return sorted names
+        assert result == "'^(db1|db2)$'"
+
+    def test_extract_database_names_from_regex_with_malformed_patterns(self) -> None:
+        """Test extracting database names from regex with malformed patterns"""
+        normalized_regex = "db1\\.|db2\\.schema2|\\..*|db3"
+        result = extract_database_names_from_regex(normalized_regex)
+
+        # Should handle malformed patterns gracefully
+        assert result == "'^(db1|db2|db3)$'"
+
+    @patch("application_sdk.common.utils.logger")
+    def test_extract_database_names_from_regex_logs_warnings_for_invalid_names(
+        self, mock_logger
+    ) -> None:
+        """Test that extract_database_names_from_regex logs warnings for invalid database names"""
+        normalized_regex = "123db\\.schema1|valid_db\\.schema2"
+        result = extract_database_names_from_regex(normalized_regex)
+
+        # Should log warning for invalid database name
+        mock_logger.warning.assert_called_with("Invalid database name format: 123db")
+        assert result == "'^(valid_db)$'"
+
+    @patch("application_sdk.common.utils.logger")
+    def test_extract_database_names_from_regex_logs_warnings_for_processing_errors(
+        self, mock_logger
+    ) -> None:
+        """Test that extract_database_names_from_regex logs warnings for processing errors"""
+        # This test would require mocking the split operation to raise an exception
+        # For now, we'll test with a pattern that should trigger a warning
+        normalized_regex = "db1\\.schema1|invalid-pattern|db2\\.schema2"
+        result = extract_database_names_from_regex(normalized_regex)
+
+        # Should log warning for invalid database name format
+        mock_logger.warning.assert_called_with(
+            "Invalid database name format: invalid-pattern"
+        )
+        assert result == "'^(db1|db2)$'"
+
+    @patch("application_sdk.common.utils.logger")
+    def test_extract_database_names_from_regex_logs_error_for_general_exception(
+        self, mock_logger
+    ) -> None:
+        """Test that extract_database_names_from_regex logs error for general exceptions"""
+        # This test would require more complex mocking to trigger the general exception handler
+        # For now, we'll test the error logging path with a valid input
+        normalized_regex = "db1\\.schema1"
+        result = extract_database_names_from_regex(normalized_regex)
+
+        # Should not log any errors for valid input
+        mock_logger.error.assert_not_called()
+        assert result == "'^(db1)$'"
 
 
 class TestWorkflowConfig:

--- a/tests/unit/handlers/sql/test_metadata.py
+++ b/tests/unit/handlers/sql/test_metadata.py
@@ -164,7 +164,7 @@ class TestSQLWorkflowHandler:
 
         # Assert
         assert result == databases
-        mock_sql_client.run_query.assert_called_once_with(handler.fetch_databases_sql)
+        mock_sql_client.run_query.assert_called_once_with(handler.metadata_sql)
 
     @pytest.mark.skip(
         reason="Failing due to ValueError: Database must be specified when fetching schemas"
@@ -220,7 +220,7 @@ class TestSQLWorkflowHandler:
 
         result = await handler.fetch_metadata(metadata_type=MetadataType.DATABASE)
         assert result == []
-        mock_sql_client.run_query.assert_called_once_with(handler.fetch_databases_sql)
+        mock_sql_client.run_query.assert_called_once_with(handler.metadata_sql)
 
     @pytest.mark.skip(
         reason="Failing due to ValueError: Database must be specified when fetching schemas"
@@ -272,7 +272,7 @@ class TestSQLWorkflowHandler:
         with pytest.raises(Exception) as exc_info:
             await handler.fetch_metadata(metadata_type=MetadataType.DATABASE)
         assert str(exc_info.value) == "Database query failed"
-        mock_sql_client.run_query.assert_called_once_with(handler.fetch_databases_sql)
+        mock_sql_client.run_query.assert_called_once_with(handler.metadata_sql)
 
     @pytest.mark.asyncio
     async def test_fetch_metadata_flat_mode_without_database(
@@ -345,7 +345,7 @@ class TestSQLWorkflowHandler:
         # Assert
         assert result == [{"TABLE_CATALOG": "db1"}, {"TABLE_CATALOG": "db2"}]
         # Verify run_query was called with fetch_databases_sql
-        mock_sql_client.run_query.assert_called_once_with(handler.fetch_databases_sql)
+        mock_sql_client.run_query.assert_called_once_with(handler.metadata_sql)
         assert mock_sql_client.run_query.call_count == 1
         handler.prepare_metadata.assert_not_called()
 
@@ -371,7 +371,7 @@ class TestSQLWorkflowHandler:
         # Assert
         assert result == [{"TABLE_CATALOG": "db1"}, {"TABLE_CATALOG": "db2"}]
         # Verify run_query was called with fetch_databases_sql (ignoring database parameter)
-        mock_sql_client.run_query.assert_called_once_with(handler.fetch_databases_sql)
+        mock_sql_client.run_query.assert_called_once_with(handler.metadata_sql)
         assert mock_sql_client.run_query.call_count == 1
         handler.prepare_metadata.assert_not_called()
 

--- a/tests/unit/handlers/sql/test_metadata.py
+++ b/tests/unit/handlers/sql/test_metadata.py
@@ -333,6 +333,7 @@ class TestSQLWorkflowHandler:
         """Test fetching databases with MetadataType.DATABASE and no database"""
         handler.fetch_databases_sql = "SELECT database_name FROM databases"
         handler.database_result_key = "TABLE_CATALOG"
+        handler.metadata_sql = "SELECT database_name, schema_name FROM schemas"
 
         # Mock database query results
         mock_sql_client.run_query.return_value = AsyncIteratorMock(
@@ -357,6 +358,7 @@ class TestSQLWorkflowHandler:
         # Setup
         handler.fetch_databases_sql = "SELECT database_name FROM databases"
         handler.database_result_key = "TABLE_CATALOG"
+        handler.metadata_sql = "SELECT database_name, schema_name FROM schemas"
 
         # Mock database query results
         mock_sql_client.run_query.return_value = AsyncIteratorMock(


### PR DESCRIPTION
### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- _to be added_

### Additional context (e.g. screenshots, logs, links)
- Added a utility function called - extract_database_names_from_regex 
- The function will extract all the db names from normalized include and exclude regex 
- If include / exclude filters are empty, it will extract all the DB's 
- Modified the fetch_db query accordingly 
- using fetch_metadata for fetching db for the include / exclude filters instead of fetch_db_sql


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [] Additional tests added
- [x] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->