### PR TITLE
fix: issues with inferring workflow_run_id

### DIFF
--- a/application_sdk/activities/__init__.py
+++ b/application_sdk/activities/__init__.py
@@ -24,6 +24,7 @@ from application_sdk.activities.common.utils import (
     auto_heartbeater,
     build_output_path,
     get_workflow_id,
+    get_workflow_run_id,
 )
 from application_sdk.common.error_codes import OrchestratorError
 from application_sdk.constants import TEMPORARY_PATH
@@ -183,7 +184,7 @@ class ActivitiesInterface(ABC, Generic[ActivitiesStateType]):
         Raises:
             IOError: If configuration cannot be retrieved from state store
         """
-        workflow_id = workflow_config.get("workflow_id")
+        workflow_id = workflow_config.get("workflow_id", get_workflow_id())
         if not workflow_id:
             raise ValueError("workflow_id is required in workflow_config")
 
@@ -196,6 +197,8 @@ class ActivitiesInterface(ABC, Generic[ActivitiesStateType]):
             workflow_args["output_path"] = os.path.join(
                 workflow_args["output_prefix"], build_output_path()
             )
+            workflow_args["workflow_id"] = workflow_id
+            workflow_args["workflow_run_id"] = get_workflow_run_id()
             return workflow_args
 
         except Exception as e:

--- a/application_sdk/workflows/__init__.py
+++ b/application_sdk/workflows/__init__.py
@@ -85,9 +85,6 @@ class WorkflowInterface(ABC, Generic[ActivitiesInterfaceType]):
         logger.info("Starting workflow execution")
 
         try:
-            workflow_run_id = workflow.info().run_id
-            workflow_args["workflow_run_id"] = workflow_run_id
-
             retry_policy = RetryPolicy(maximum_attempts=2, backoff_coefficient=2)
 
             await workflow.execute_activity_method(

--- a/application_sdk/workflows/metadata_extraction/sql.py
+++ b/application_sdk/workflows/metadata_extraction/sql.py
@@ -201,9 +201,6 @@ class BaseSQLMetadataExtractionWorkflow(MetadataExtractionWorkflow):
                 heartbeat_timeout=self.default_heartbeat_timeout,
             )
 
-            workflow_run_id = workflow.info().run_id
-            workflow_args["workflow_run_id"] = workflow_run_id
-
             logger.info(f"Starting extraction workflow for {workflow_id}")
             retry_policy = RetryPolicy(
                 maximum_attempts=6,

--- a/docs/docs/concepts/workflows.md
+++ b/docs/docs/concepts/workflows.md
@@ -129,7 +129,6 @@ While most customization typically happens in `Activities`, `Handlers`, or `Clie
         @workflow.run
         async def run(self, workflow_config: Dict[str, Any]) -> str: # Return type example
             # 1. Load full arguments (Essential step)
-            workflow_id = workflow_config["workflow_id"]
             workflow_args: Dict[str, Any] = await workflow.execute_activity_method(
                 self.activities_cls.get_workflow_args,
                 workflow_config,  # Pass the whole config containing workflow_id
@@ -137,8 +136,6 @@ While most customization typically happens in `Activities`, `Handlers`, or `Clie
                 start_to_close_timeout=self.default_start_to_close_timeout,
                 heartbeat_timeout=self.default_heartbeat_timeout,
             )
-            workflow.logger.info(f"Starting custom run logic for {workflow_id}")
-            workflow_args["workflow_run_id"] = workflow.info().run_id # Add run ID
 
             # Define a standard retry policy for activities
             retry_policy = RetryPolicy(maximum_attempts=3)


### PR DESCRIPTION
### Changelog
- issues with inferring workflow_run_id, earlier there were issues with activities using `get_workflow_args` to infer the workflow_run_id as it wasn't passed along, this change infers the workflow_run_id via activity info.

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [x] Additional tests added
- [x] All CI checks passed
- [x] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->