### PR TITLE
Fix miner output path

### DIFF
--- a/application_sdk/activities/query_extraction/sql.py
+++ b/application_sdk/activities/query_extraction/sql.py
@@ -201,8 +201,9 @@ class SQLQueryExtractionActivities(ActivitiesInterface):
             sql_input = SQLQueryInput(
                 engine=state.sql_client.engine,
                 query=self.get_formatted_query(self.fetch_queries_sql, workflow_args),
+                chunk_size=None,
             )
-            sql_input = await sql_input.get_daft_dataframe()
+            sql_input = await sql_input.get_dataframe()
 
             raw_output = ParquetOutput(
                 output_prefix=workflow_args["output_prefix"],
@@ -212,7 +213,7 @@ class SQLQueryExtractionActivities(ActivitiesInterface):
                 start_marker=workflow_args["start_marker"],
                 end_marker=workflow_args["end_marker"],
             )
-            await raw_output.write_daft_dataframe(sql_input)
+            await raw_output.write_dataframe(sql_input)
 
             logger.info(
                 f"Query fetch completed, {raw_output.total_record_count} records processed",


### PR DESCRIPTION
### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
Fix miner output path by switching from daft to pandas

The daft parquet writer does not allow us to define specific file names while writing the parquet files.
However we require to define specific file paths while writing the query output files. Since pandas allows us to do so we are switching to pandas

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->