### PR TITLE
fix: db name regex pattern

### DIFF
--- a/application_sdk/common/utils.py
+++ b/application_sdk/common/utils.py
@@ -73,7 +73,7 @@ def extract_database_names_from_regex(normalized_regex: str) -> str:
                     db_name = parts[0].strip()
                     if db_name and db_name not in (".*", "^$"):
                         # Validate database name format
-                        if re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", db_name):
+                        if re.match(r"^[a-zA-Z_][a-zA-Z0-9_-]*$", db_name):
                             database_names.add(db_name)
                         else:
                             logger.warning(f"Invalid database name format: {db_name}")

--- a/application_sdk/common/utils.py
+++ b/application_sdk/common/utils.py
@@ -72,8 +72,8 @@ def extract_database_names_from_regex(normalized_regex: str) -> str:
                 if parts:
                     db_name = parts[0].strip()
                     if db_name and db_name not in (".*", "^$"):
-                        # Validate database name format
-                        if re.match(r"^[a-zA-Z_][a-zA-Z0-9_-]*$", db_name):
+                        # Validate database name format (Redshift naming rules)
+                        if re.match(r"^[a-zA-Z_][a-zA-Z0-9_$-]*$", db_name):
                             database_names.add(db_name)
                         else:
                             logger.warning(f"Invalid database name format: {db_name}")

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -246,11 +246,13 @@ class TestExtractDatabaseNamesFromRegex:
 
     def test_extract_database_names_from_regex_with_special_characters(self) -> None:
         """Test extracting database names from regex with special characters"""
-        normalized_regex = "db@test\\.schema1|db#test\\.schema2|db_test\\.schema3"
+        normalized_regex = (
+            "db@test\\.schema1|db#test\\.schema2|db_test\\.schema3|db$test\\.schema4"
+        )
         result = extract_database_names_from_regex(normalized_regex)
 
         # Only db_test should be included (valid format)
-        assert result == "'^(db_test)$'"
+        assert result == "'^(db$test|db_test)$'"
 
     def test_extract_database_names_from_regex_with_dot_patterns(self) -> None:
         """Test extracting database names from regex with dot patterns"""

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -178,6 +178,16 @@ class TestExtractDatabaseNamesFromRegex:
         # Should return sorted database names in regex format
         assert result == "'^(dev|wide_world_importers)$'"
 
+    def test_extract_database_names_from_regex_with_multiple_databases_with_special_characters(
+        self,
+    ) -> None:
+        """Test extracting database names from regex with multiple databases with special characters in database names"""
+        normalized_regex = "dev\\.external_schema$|wide_world_importers\\.bronze_sales$|test-db\\.schema_name$"
+        result = extract_database_names_from_regex(normalized_regex)
+
+        # Should return sorted database names in regex format
+        assert result == "'^(dev|test-db|wide_world_importers)$'"
+
     def test_extract_database_names_from_regex_with_wildcard_schemas(self) -> None:
         """Test extracting database names from regex with wildcard schemas"""
         normalized_regex = "dev\\.*|wide_world_importers\\.*"
@@ -232,7 +242,7 @@ class TestExtractDatabaseNamesFromRegex:
         result = extract_database_names_from_regex(normalized_regex)
 
         # Only valid_db should be included (starts with letter/underscore, alphanumeric + underscore)
-        assert result == "'^(valid_db)$'"
+        assert result == "'^(db-2|valid_db)$'"
 
     def test_extract_database_names_from_regex_with_special_characters(self) -> None:
         """Test extracting database names from regex with special characters"""
@@ -317,12 +327,12 @@ class TestExtractDatabaseNamesFromRegex:
         """Test that extract_database_names_from_regex logs warnings for processing errors"""
         # This test would require mocking the split operation to raise an exception
         # For now, we'll test with a pattern that should trigger a warning
-        normalized_regex = "db1\\.schema1|invalid-pattern|db2\\.schema2"
+        normalized_regex = "db1\\.schema1|invalid^pattern|db2\\.schema2"
         result = extract_database_names_from_regex(normalized_regex)
 
         # Should log warning for invalid database name format
         mock_logger.warning.assert_called_with(
-            "Invalid database name format: invalid-pattern"
+            "Invalid database name format: invalid^pattern"
         )
         assert result == "'^(db1|db2)$'"
 


### PR DESCRIPTION
### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
Regex pattern used to extract the database name from the pattern was considering the db names with hyphen (-) e.g (test-db) as invalid. The PR will fix the same and not flag them as invalid

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->

### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [x] Additional tests added
- [x] All CI checks passed
- [x] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->