### PR TITLE
fix: handle str and dict types in preflight checks

### DIFF
--- a/application_sdk/handlers/sql.py
+++ b/application_sdk/handlers/sql.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import re
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple
@@ -7,7 +6,11 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from packaging import version
 
 from application_sdk.clients.sql import BaseSQLClient
-from application_sdk.common.utils import prepare_query, read_sql_files
+from application_sdk.common.utils import (
+    parse_filter_input,
+    prepare_query,
+    read_sql_files,
+)
 from application_sdk.constants import SQL_QUERIES_PATH, SQL_SERVER_MIN_VERSION
 from application_sdk.handlers import HandlerInterface
 from application_sdk.inputs.sql_query import SQLQueryInput
@@ -220,10 +223,10 @@ class BaseSQLHandler(HandlerInterface):
         """
         try:
             schemas_results: List[Dict[str, str]] = await self.prepare_metadata()
-
-            include_filter = json.loads(
-                payload.get("metadata", {}).get("include-filter", "{}")
+            include_filter = parse_filter_input(
+                payload.get("metadata", {}).get("include-filter", {})
             )
+
             allowed_databases, allowed_schemas = self.extract_allowed_schemas(
                 schemas_results
             )


### PR DESCRIPTION
### Changelog

- fix: preflight check handler when the frontend sends both str and dict input types


### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [x] Additional tests added
- [x] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->