### PR TITLE
fix: cleanup local path post upload to object store

### DIFF
--- a/application_sdk/outputs/atlan_storage.py
+++ b/application_sdk/outputs/atlan_storage.py
@@ -82,7 +82,6 @@ class AtlanStorageOutput:
 
             logger.debug(f"Successfully migrated: {file_path}")
             return file_path, True, ""
-
         except Exception as e:
             error_msg = str(e)
             logger.error(f"Failed to migrate file {file_path}: {error_msg}")


### PR DESCRIPTION
### Changelog
- added a method to perform local path cleanup post upload

TODO:
- [ ] cleanup observability data post upload (cc: @abhishekagrawal-atlan)

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [x] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->