### PR TITLE
fix: Update APP_HOST env variable default value

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -36,7 +36,7 @@ APPLICATION_NAME = os.getenv("ATLAN_APPLICATION_NAME", "default")
 #: Name of the deployment, used to distinguish between different deployments of the same application
 DEPLOYMENT_NAME = os.getenv("ATLAN_DEPLOYMENT_NAME", LOCAL_ENVIRONMENT)
 #: Host address for the application's HTTP server
-APP_HOST = str(os.getenv("ATLAN_APP_HTTP_HOST", "localhost"))
+APP_HOST = str(os.getenv("ATLAN_APP_HTTP_HOST", "0.0.0.0"))
 #: Port number for the application's HTTP server
 APP_PORT = int(os.getenv("ATLAN_APP_HTTP_PORT", "8000"))
 #: Tenant ID for multi-tenant applications


### PR DESCRIPTION
### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- Update APP_HOST env variable default value
- default value of `localhost` was not working with some tenants due to ipv6 restrictions. Server startup was failing with below error
```
[Errno 99] error while attempting to bind on address ('::1', 8000, 0, 0): cannot assign requested address
```

- Updated it to point to `0.0.0.0` which now works fine

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->