### PR TITLE
feat: add retain_local_copy option to upload methods in ObjectStore

### DIFF
--- a/application_sdk/clients/temporal.py
+++ b/application_sdk/clients/temporal.py
@@ -26,6 +26,10 @@ from application_sdk.constants import (
     WORKFLOW_PORT,
     WORKFLOW_TLS_ENABLED_KEY,
 )
+from application_sdk.interceptors.cleanup import (
+    CleanupInterceptor,
+    cleanup_app_artifacts,
+)
 from application_sdk.interceptors.events import EventInterceptor, publish_event
 from application_sdk.interceptors.lock import RedisLockInterceptor
 from application_sdk.observability.logger_adaptor import get_logger
@@ -359,7 +363,7 @@ class TemporalWorkflowClient(WorkflowClient):
             )
 
         # Start with provided activities and add system activities
-        final_activities = list(activities) + [publish_event]
+        final_activities = list(activities) + [publish_event, cleanup_app_artifacts]
 
         # Add lock management activities if needed
         if not IS_LOCKING_DISABLED:
@@ -395,6 +399,7 @@ class TemporalWorkflowClient(WorkflowClient):
             activity_executor=activity_executor,
             interceptors=[
                 EventInterceptor(),
+                CleanupInterceptor(),
                 RedisLockInterceptor(activities_dict),
             ],
         )

--- a/application_sdk/clients/temporal.py
+++ b/application_sdk/clients/temporal.py
@@ -26,10 +26,7 @@ from application_sdk.constants import (
     WORKFLOW_PORT,
     WORKFLOW_TLS_ENABLED_KEY,
 )
-from application_sdk.interceptors.cleanup import (
-    CleanupInterceptor,
-    cleanup_app_artifacts,
-)
+from application_sdk.interceptors.cleanup import CleanupInterceptor, cleanup
 from application_sdk.interceptors.events import EventInterceptor, publish_event
 from application_sdk.interceptors.lock import RedisLockInterceptor
 from application_sdk.observability.logger_adaptor import get_logger
@@ -363,7 +360,7 @@ class TemporalWorkflowClient(WorkflowClient):
             )
 
         # Start with provided activities and add system activities
-        final_activities = list(activities) + [publish_event, cleanup_app_artifacts]
+        final_activities = list(activities) + [publish_event, cleanup]
 
         # Add lock management activities if needed
         if not IS_LOCKING_DISABLED:

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -59,6 +59,11 @@ WORKFLOW_OUTPUT_PATH_TEMPLATE = (
 # Temporary Path (used to store intermediate files)
 TEMPORARY_PATH = os.getenv("ATLAN_TEMPORARY_PATH", "./local/tmp/")
 
+# Cleanup Path (custom path for cleanup operations, defaults to TEMPORARY_PATH/artifacts/apps)
+CLEANUP_BASE_PATH = os.getenv(
+    "ATLAN_CLEANUP_BASE_PATH", f"{TEMPORARY_PATH}artifacts/apps"
+)
+
 # State Store Constants
 #: Path template for state store files (example: objectstore://bucket/persistent-artifacts/apps/{application_name}/{state_type}/{id}/config.json)
 STATE_STORE_PATH_TEMPLATE = (

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -60,11 +60,10 @@ WORKFLOW_OUTPUT_PATH_TEMPLATE = (
 TEMPORARY_PATH = os.getenv("ATLAN_TEMPORARY_PATH", "./local/tmp/")
 
 # Cleanup Paths (custom paths for cleanup operations, supports multiple paths separated by comma)
+# If empty, cleanup activities will default to workflow-specific paths at runtime
 CLEANUP_BASE_PATHS = [
     path.strip()
-    for path in os.getenv(
-        "ATLAN_CLEANUP_BASE_PATHS", f"{TEMPORARY_PATH}artifacts/apps"
-    ).split(",")
+    for path in os.getenv("ATLAN_CLEANUP_BASE_PATHS", "").split(",")
     if path.strip()
 ]
 

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -59,10 +59,14 @@ WORKFLOW_OUTPUT_PATH_TEMPLATE = (
 # Temporary Path (used to store intermediate files)
 TEMPORARY_PATH = os.getenv("ATLAN_TEMPORARY_PATH", "./local/tmp/")
 
-# Cleanup Path (custom path for cleanup operations, defaults to TEMPORARY_PATH/artifacts/apps)
-CLEANUP_BASE_PATH = os.getenv(
-    "ATLAN_CLEANUP_BASE_PATH", f"{TEMPORARY_PATH}artifacts/apps"
-)
+# Cleanup Paths (custom paths for cleanup operations, supports multiple paths separated by comma)
+CLEANUP_BASE_PATHS = [
+    path.strip()
+    for path in os.getenv(
+        "ATLAN_CLEANUP_BASE_PATHS", f"{TEMPORARY_PATH}artifacts/apps"
+    ).split(",")
+    if path.strip()
+]
 
 # State Store Constants
 #: Path template for state store files (example: objectstore://bucket/persistent-artifacts/apps/{application_name}/{state_type}/{id}/config.json)

--- a/application_sdk/interceptors/cleanup.py
+++ b/application_sdk/interceptors/cleanup.py
@@ -14,7 +14,7 @@ from temporalio.worker import (
 
 from application_sdk.activities import ActivitiesInterface
 from application_sdk.activities.common.utils import build_output_path
-from application_sdk.constants import CLEANUP_BASE_PATHS
+from application_sdk.constants import CLEANUP_BASE_PATHS, TEMPORARY_PATH
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -36,7 +36,7 @@ async def cleanup() -> Dict[str, bool]:
             Keys include base paths and "activities_state".
     """
     cleanup_results: Dict[str, bool] = {}
-    base_paths: List[str] = [build_output_path()]
+    base_paths: List[str] = [f"{TEMPORARY_PATH}{build_output_path()}"]
 
     # Use configured paths or default to workflow-specific artifacts directory
     if CLEANUP_BASE_PATHS:

--- a/application_sdk/interceptors/cleanup.py
+++ b/application_sdk/interceptors/cleanup.py
@@ -96,13 +96,9 @@ async def cleanup_app_artifacts() -> Dict[str, bool]:
 
             if os.path.exists(cleanup_path):
                 if os.path.isdir(cleanup_path):
-                    # Remove all contents inside the base path, but keep the directory itself
-                    for item in os.listdir(cleanup_path):
-                        item_path = os.path.join(cleanup_path, item)
-                        if os.path.isdir(item_path):
-                            shutil.rmtree(item_path)
-                        else:
-                            os.remove(item_path)
+                    # Remove entire directory and recreate it empty
+                    shutil.rmtree(cleanup_path)
+                    os.makedirs(cleanup_path, exist_ok=True)
                     activity.logger.info(
                         f"Cleaned up all contents from: {cleanup_path}"
                     )

--- a/application_sdk/interceptors/cleanup.py
+++ b/application_sdk/interceptors/cleanup.py
@@ -1,0 +1,214 @@
+import shutil
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, Dict, Optional, Type
+
+from temporalio import activity, workflow
+from temporalio.common import RetryPolicy
+from temporalio.worker import (
+    ExecuteWorkflowInput,
+    Interceptor,
+    WorkflowInboundInterceptor,
+    WorkflowInterceptorClassInput,
+)
+
+from application_sdk.constants import APPLICATION_NAME, CLEANUP_BASE_PATH
+from application_sdk.observability.logger_adaptor import get_logger
+
+logger = get_logger(__name__)
+
+
+@activity.defn
+async def cleanup_app_artifacts(
+    app_name: str,
+    workflow_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    base_path: str = CLEANUP_BASE_PATH,
+) -> Dict[str, bool]:
+    """Activity to cleanup application artifacts outside the workflow sandbox.
+
+    Cleans up artifacts following the pattern: local/tmp/artifacts/apps/appname/workflow_id/run_id
+    Can cleanup at different levels based on provided parameters.
+
+    Args:
+        app_name (str): Name of the application
+        workflow_id (Optional[str]): Workflow ID to cleanup. If None, cleans entire app directory
+        run_id (Optional[str]): Run ID to cleanup. If None, cleans entire workflow directory
+        base_path (str): Base path for artifacts (configurable via ATLAN_CLEANUP_BASE_PATH env var)
+
+    Returns:
+        Dict[str, bool]: Dictionary with cleanup results
+
+    Example cleanup scenarios:
+
+    Scenario 1 - Cleanup specific run:
+    Input: app_name="my_app", workflow_id="wf_123", run_id="run_456"
+    Path: {CLEANUP_BASE_PATH}/my_app/wf_123/run_456/
+
+    Scenario 2 - Cleanup entire workflow:
+    Input: app_name="my_app", workflow_id="wf_123", run_id=None
+    Path: {CLEANUP_BASE_PATH}/my_app/wf_123/
+
+    Scenario 3 - Cleanup entire app:
+    Input: app_name="my_app", workflow_id=None, run_id=None
+    Path: {CLEANUP_BASE_PATH}/my_app/
+
+    Directory Structure Before Cleanup:
+    +----+----+----+
+    | apps/ | my_app/ | wf_123/ | run_456/ | data.parquet |
+    |       |         |         | run_789/ | temp.csv     |
+    |       |         | wf_124/ | run_001/ | output.json  |
+    +----+----+----+
+
+    Directory Structure After Cleanup (workflow level):
+    +----+----+----+
+    | apps/ | my_app/ | wf_124/ | run_001/ | output.json |
+    +----+----+----+
+
+    Transformations:
+    - Removes all files and subdirectories at target level
+    - Preserves parent directory structure
+    - Logs cleanup success/failure for each operation
+    """
+    cleanup_results = {}
+
+    try:
+        # Build the cleanup path based on provided parameters
+        cleanup_path = Path(base_path) / app_name
+
+        if workflow_id:
+            cleanup_path = cleanup_path / workflow_id
+
+        if run_id:
+            cleanup_path = cleanup_path / run_id
+
+        cleanup_path_str = str(cleanup_path)
+
+        if cleanup_path.exists():
+            if cleanup_path.is_dir():
+                # Remove the entire directory and its contents
+                shutil.rmtree(cleanup_path_str)
+                activity.logger.info(f"Cleaned up directory: {cleanup_path_str}")
+                cleanup_results[cleanup_path_str] = True
+            else:
+                activity.logger.warning(f"Path is not a directory: {cleanup_path_str}")
+                cleanup_results[cleanup_path_str] = False
+        else:
+            activity.logger.debug(
+                f"Directory already removed or doesn't exist: {cleanup_path_str}"
+            )
+            cleanup_results[cleanup_path_str] = True
+
+    except PermissionError as e:
+        activity.logger.error(f"Permission denied cleaning up {cleanup_path_str}: {e}")
+        cleanup_results[cleanup_path_str] = False
+    except OSError as e:
+        activity.logger.error(f"OS error cleaning up {cleanup_path_str}: {e}")
+        cleanup_results[cleanup_path_str] = False
+    except Exception as e:
+        activity.logger.error(f"Unexpected error cleaning up {cleanup_path_str}: {e}")
+        cleanup_results[cleanup_path_str] = False
+
+    return cleanup_results
+
+
+class CleanupWorkflowInboundInterceptor(WorkflowInboundInterceptor):
+    """Interceptor for workflow-level app artifacts cleanup.
+
+    This interceptor cleans up the entire app directory structure when the workflow
+    completes or fails, following the pattern: {CLEANUP_BASE_PATH}/appname/workflow_id/run_id
+    """
+
+    async def execute_workflow(self, input: ExecuteWorkflowInput) -> Any:
+        """Execute a workflow with app artifacts cleanup.
+
+        Args:
+            input (ExecuteWorkflowInput): The workflow execution input
+
+        Returns:
+            Any: The result of the workflow execution
+
+        Raises:
+            Exception: Re-raises any exceptions from workflow execution
+        """
+        workflow_id = input.info.workflow_id
+        workflow_type = input.info.workflow_type
+        run_id = input.info.run_id
+
+        workflow.logger.info(
+            f"Starting workflow with cleanup tracking: {workflow_type}"
+        )
+
+        output = None
+        try:
+            output = await super().execute_workflow(input)
+            workflow.logger.info(f"Workflow {workflow_type} completed successfully")
+
+        except Exception as e:
+            workflow.logger.error(f"Workflow {workflow_type} failed: {e}")
+            raise
+
+        finally:
+            # Always attempt cleanup regardless of workflow success/failure
+            try:
+                workflow.logger.info(
+                    f"Cleaning up artifacts for workflow: {workflow_id}, run: {run_id}"
+                )
+
+                await workflow.execute_activity(
+                    cleanup_app_artifacts,
+                    args=[APPLICATION_NAME, workflow_id, run_id, CLEANUP_BASE_PATH],
+                    schedule_to_close_timeout=timedelta(minutes=5),
+                    retry_policy=RetryPolicy(
+                        maximum_attempts=3,
+                        initial_interval=timedelta(seconds=1),
+                        maximum_interval=timedelta(seconds=10),
+                    ),
+                )
+
+                workflow.logger.info("Cleanup completed successfully")
+
+            except Exception as e:
+                workflow.logger.warning(f"Failed to cleanup artifacts: {e}")
+                # Don't re-raise - cleanup failures shouldn't fail the workflow
+
+        return output
+
+
+class CleanupInterceptor(Interceptor):
+    """Temporal interceptor for automatic app artifacts cleanup.
+
+    This interceptor provides cleanup capabilities for application artifacts
+    following the directory pattern: {CLEANUP_BASE_PATH}/appname/workflow_id/run_id
+
+    Features:
+    - Automatic cleanup of app-specific artifact directories
+    - Cleanup on workflow completion or failure
+    - Uses APPLICATION_NAME from constants
+    - Configurable cleanup path via ATLAN_CLEANUP_BASE_PATH env var
+    - Simple activity-based cleanup logic
+    - Comprehensive error handling and logging
+
+    Example:
+        >>> # Register the interceptor with Temporal worker
+        >>> worker = Worker(
+        ...     client,
+        ...     task_queue="my-task-queue",
+        ...     workflows=[MyWorkflow],
+        ...     activities=[my_activity, cleanup_app_artifacts],
+        ...     interceptors=[CleanupInterceptor()]
+        ... )
+    """
+
+    def workflow_interceptor_class(
+        self, input: WorkflowInterceptorClassInput
+    ) -> Optional[Type[WorkflowInboundInterceptor]]:
+        """Get the workflow interceptor class for cleanup.
+
+        Args:
+            input (WorkflowInterceptorClassInput): The interceptor input
+
+        Returns:
+            Optional[Type[WorkflowInboundInterceptor]]: The workflow interceptor class
+        """
+        return CleanupWorkflowInboundInterceptor

--- a/application_sdk/interceptors/cleanup.py
+++ b/application_sdk/interceptors/cleanup.py
@@ -119,9 +119,8 @@ class CleanupWorkflowInboundInterceptor(WorkflowInboundInterceptor):
                     schedule_to_close_timeout=timedelta(minutes=5),
                     retry_policy=RetryPolicy(
                         maximum_attempts=3,
-                        initial_interval=timedelta(seconds=1),
-                        maximum_interval=timedelta(seconds=10),
                     ),
+                    summary="This activity is used to cleanup the local artifacts and the activity state after the workflow is completed.",
                 )
 
                 workflow.logger.info("Cleanup completed successfully")

--- a/application_sdk/interceptors/cleanup.py
+++ b/application_sdk/interceptors/cleanup.py
@@ -36,7 +36,7 @@ async def cleanup() -> Dict[str, bool]:
             Keys include base paths and "activities_state".
     """
     cleanup_results: Dict[str, bool] = {}
-    base_paths: List[str] = [f"{TEMPORARY_PATH}{build_output_path()}"]
+    base_paths: List[str] = [os.path.join(TEMPORARY_PATH, build_output_path())]
 
     # Use configured paths or default to workflow-specific artifacts directory
     if CLEANUP_BASE_PATHS:

--- a/application_sdk/interceptors/cleanup.py
+++ b/application_sdk/interceptors/cleanup.py
@@ -97,7 +97,12 @@ async def cleanup_app_artifacts() -> Dict[str, bool]:
             if os.path.exists(cleanup_path):
                 if os.path.isdir(cleanup_path):
                     # Remove all contents inside the base path, but keep the directory itself
-                    shutil.rmtree(cleanup_path)
+                    for item in os.listdir(cleanup_path):
+                        item_path = os.path.join(cleanup_path, item)
+                        if os.path.isdir(item_path):
+                            shutil.rmtree(item_path)
+                        else:
+                            os.remove(item_path)
                     activity.logger.info(
                         f"Cleaned up all contents from: {cleanup_path}"
                     )

--- a/application_sdk/interceptors/cleanup.py
+++ b/application_sdk/interceptors/cleanup.py
@@ -13,7 +13,6 @@ from temporalio.worker import (
     WorkflowInterceptorClassInput,
 )
 
-from application_sdk.activities import ActivitiesInterface
 from application_sdk.activities.common.utils import build_output_path
 from application_sdk.constants import CLEANUP_BASE_PATHS, TEMPORARY_PATH
 from application_sdk.observability.logger_adaptor import get_logger
@@ -28,13 +27,9 @@ class CleanupResult(BaseModel):
 
     Attributes:
         path_results (Dict[str, bool]): Cleanup results for each path (True=success, False=failure)
-        activities_state (bool): Result of activities state cleanup
-        total_paths_cleaned (int): Number of paths successfully cleaned
-        total_paths_failed (int): Number of paths that failed to clean
     """
 
     path_results: Dict[str, bool]
-    activities_state: bool
 
 
 @activity.defn
@@ -79,19 +74,8 @@ async def cleanup() -> CleanupResult:
             logger.error(f"Unexpected error cleaning up {base_path}: {e}")
             path_results[base_path] = False
 
-    activities_state_result = True
-    try:
-        activities_state = ActivitiesInterface()
-        await activities_state._clean_state()
-        logger.info("Activities state cleaned up successfully")
-
-    except Exception as e:
-        logger.error(f"Unexpected error cleaning up activities state: {e}")
-        activities_state_result = False
-
     return CleanupResult(
         path_results=path_results,
-        activities_state=activities_state_result,
     )
 
 

--- a/application_sdk/interceptors/cleanup.py
+++ b/application_sdk/interceptors/cleanup.py
@@ -41,9 +41,7 @@ async def cleanup() -> Dict[str, bool]:
     # Use configured paths or default to workflow-specific artifacts directory
     if CLEANUP_BASE_PATHS:
         base_paths = CLEANUP_BASE_PATHS
-        activity.logger.info(
-            f"No CLEANUP_BASE_PATHS configured, using default workflow path: {base_paths}"
-        )
+        activity.logger.info(f"Using CLEANUP_BASE_PATHS: {base_paths} for cleanup")
 
     activity.logger.info(f"Cleaning up all contents from base paths: {base_paths}")
 
@@ -62,12 +60,6 @@ async def cleanup() -> Dict[str, bool]:
                 activity.logger.debug(f"Directory doesn't exist: {base_path}")
                 cleanup_results[base_path] = True
 
-        except PermissionError as e:
-            activity.logger.error(f"Permission denied cleaning up {base_path}: {e}")
-            cleanup_results[base_path] = False
-        except OSError as e:
-            activity.logger.error(f"OS error cleaning up {base_path}: {e}")
-            cleanup_results[base_path] = False
         except Exception as e:
             activity.logger.error(f"Unexpected error cleaning up {base_path}: {e}")
             cleanup_results[base_path] = False

--- a/application_sdk/interceptors/cleanup.py
+++ b/application_sdk/interceptors/cleanup.py
@@ -97,11 +97,7 @@ async def cleanup_app_artifacts() -> Dict[str, bool]:
             if os.path.exists(cleanup_path):
                 if os.path.isdir(cleanup_path):
                     # Remove all contents inside the base path, but keep the directory itself
-                    for item in os.listdir(cleanup_path):
-                        if os.path.isdir(item):
-                            shutil.rmtree(item)
-                        else:
-                            os.remove(item)
+                    shutil.rmtree(cleanup_path)
                     activity.logger.info(
                         f"Cleaned up all contents from: {cleanup_path}"
                     )

--- a/application_sdk/outputs/iceberg.py
+++ b/application_sdk/outputs/iceberg.py
@@ -29,6 +29,7 @@ class IcebergOutput(Output):
         mode: str = "append",
         total_record_count: int = 0,
         chunk_count: int = 0,
+        retain_local_copy: bool = False,
     ):
         """Initialize the Iceberg output class.
 
@@ -39,6 +40,8 @@ class IcebergOutput(Output):
             mode (str, optional): Write mode for the iceberg table. Defaults to "append".
             total_record_count (int, optional): Total record count written to the iceberg table. Defaults to 0.
             chunk_count (int, optional): Number of chunks written to the iceberg table. Defaults to 0.
+            retain_local_copy (bool, optional): Whether to retain the local copy of the files.
+                Defaults to False.
         """
         self.total_record_count = total_record_count
         self.chunk_count = chunk_count
@@ -47,6 +50,7 @@ class IcebergOutput(Output):
         self.iceberg_table = iceberg_table
         self.mode = mode
         self.metrics = get_metrics()
+        self.retain_local_copy = retain_local_copy
 
     async def write_dataframe(self, dataframe: "pd.DataFrame"):
         """

--- a/application_sdk/outputs/json.py
+++ b/application_sdk/outputs/json.py
@@ -93,6 +93,7 @@ class JsonOutput(Output):
         path_gen: Callable[[int | None, int], str] = path_gen,
         start_marker: Optional[str] = None,
         end_marker: Optional[str] = None,
+        retain_local_copy: bool = False,
         **kwargs: Dict[str, Any],
     ):
         """Initialize the JSON output handler.
@@ -113,6 +114,8 @@ class JsonOutput(Output):
                 Defaults to 0.
             path_gen (Callable, optional): Function to generate file paths.
                 Defaults to path_gen function.
+            retain_local_copy (bool, optional): Whether to retain the local copy of the files.
+                Defaults to False.
         """
         self.output_path = output_path
         self.output_suffix = output_suffix
@@ -133,6 +136,7 @@ class JsonOutput(Output):
         self.start_marker = start_marker
         self.end_marker = end_marker
         self.metrics = get_metrics()
+        self.retain_local_copy = retain_local_copy
 
         if not self.output_path:
             raise ValueError("output_path is required")
@@ -282,6 +286,7 @@ class JsonOutput(Output):
             await ObjectStore.upload_prefix(
                 source=self.output_path,
                 destination=get_object_store_prefix(self.output_path),
+                retain_local_copy=self.retain_local_copy,
             )
 
         except Exception as e:
@@ -367,6 +372,7 @@ class JsonOutput(Output):
                 await ObjectStore.upload_file(
                     source=output_file_name,
                     destination=get_object_store_prefix(output_file_name),
+                    retain_local_copy=self.retain_local_copy,
                 )
 
             self.buffer.clear()

--- a/application_sdk/outputs/parquet.py
+++ b/application_sdk/outputs/parquet.py
@@ -299,9 +299,14 @@ class ParquetOutput(Output):
             #  Upload the entire directory (contains multiple parquet files created by Daft)
             if write_mode == WriteMode.OVERWRITE:
                 # Delete the directory from object store
-                await ObjectStore.delete_prefix(
-                    prefix=get_object_store_prefix(self.output_path)
-                )
+                try:
+                    await ObjectStore.delete_prefix(
+                        prefix=get_object_store_prefix(self.output_path)
+                    )
+                except FileNotFoundError as e:
+                    logger.info(
+                        f"No files found under prefix {get_object_store_prefix(self.output_path)}: {str(e)}"
+                    )
 
             await ObjectStore.upload_prefix(
                 source=self.output_path,

--- a/application_sdk/outputs/parquet.py
+++ b/application_sdk/outputs/parquet.py
@@ -60,6 +60,7 @@ class ParquetOutput(Output):
         chunk_start: Optional[int] = None,
         start_marker: Optional[str] = None,
         end_marker: Optional[str] = None,
+        retain_local_copy: bool = False,
     ):
         """Initialize the Parquet output handler.
 
@@ -79,6 +80,8 @@ class ParquetOutput(Output):
                 Defaults to None.
             end_marker (Optional[str], optional): End marker for query extraction.
                 Defaults to None.
+            retain_local_copy (bool, optional): Whether to retain the local copy of the files.
+                Defaults to False.
         """
         self.output_path = output_path
         self.output_suffix = output_suffix
@@ -99,6 +102,7 @@ class ParquetOutput(Output):
         self.end_marker = end_marker
         self.statistics = []
         self.metrics = get_metrics()
+        self.retain_local_copy = retain_local_copy
 
         # Create output directory
         self.output_path = os.path.join(self.output_path, self.output_suffix)
@@ -302,6 +306,7 @@ class ParquetOutput(Output):
             await ObjectStore.upload_prefix(
                 source=self.output_path,
                 destination=get_object_store_prefix(self.output_path),
+                retain_local_copy=self.retain_local_copy,
             )
 
         except Exception as e:

--- a/application_sdk/services/objectstore.py
+++ b/application_sdk/services/objectstore.py
@@ -236,6 +236,7 @@ class ObjectStore:
         source: str,
         destination: str,
         store_name: str = DEPLOYMENT_OBJECT_STORE_NAME,
+        retain_local_copy: bool = False,
     ) -> None:
         """Upload a single file to the object store.
 
@@ -277,7 +278,8 @@ class ObjectStore:
             raise e
 
         # Clean up local file after successful upload
-        cls._cleanup_local_path(source)
+        if not retain_local_copy:
+            cls._cleanup_local_path(source)
 
     @classmethod
     async def upload_prefix(
@@ -286,6 +288,7 @@ class ObjectStore:
         destination: str,
         store_name: str = DEPLOYMENT_OBJECT_STORE_NAME,
         recursive: bool = True,
+        retain_local_copy: bool = False,
     ) -> None:
         """Upload all files from a directory to the object store.
 
@@ -333,7 +336,9 @@ class ObjectStore:
                     store_key = os.path.join(destination, relative_path).replace(
                         os.sep, "/"
                     )
-                    await cls.upload_file(file_path, store_key, store_name)
+                    await cls.upload_file(
+                        file_path, store_key, store_name, retain_local_copy
+                    )
 
             logger.info(f"Completed uploading directory {source} to object store")
         except Exception as e:

--- a/application_sdk/services/objectstore.py
+++ b/application_sdk/services/objectstore.py
@@ -208,7 +208,13 @@ class ObjectStore:
         """
         try:
             # First, list all files under the prefix
-            files_to_delete = await cls.list_files(prefix=prefix, store_name=store_name)
+            try:
+                files_to_delete = await cls.list_files(
+                    prefix=prefix, store_name=store_name
+                )
+            except Exception as e:
+                logger.info(f"Error listing files under prefix {prefix}: {str(e)}")
+                raise FileNotFoundError(f"No files found under prefix: {prefix}")
 
             if not files_to_delete:
                 logger.info(f"No files found under prefix: {prefix}")

--- a/application_sdk/services/objectstore.py
+++ b/application_sdk/services/objectstore.py
@@ -213,7 +213,9 @@ class ObjectStore:
                     prefix=prefix, store_name=store_name
                 )
             except Exception as e:
-                logger.info(f"Error listing files under prefix {prefix}: {str(e)}")
+                # If we can't list files for any reason, we can't delete them either
+                # Raise FileNotFoundError to give developers clear feedback
+                logger.info(f"Cannot list files under prefix {prefix}: {str(e)}")
                 raise FileNotFoundError(f"No files found under prefix: {prefix}")
 
             if not files_to_delete:

--- a/tests/unit/clients/test_temporal_client.py
+++ b/tests/unit/clients/test_temporal_client.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 import pytest
 
 from application_sdk.clients.temporal import TemporalWorkflowClient
+from application_sdk.interceptors.cleanup import cleanup
 from application_sdk.interceptors.events import publish_event
 from application_sdk.workflows import WorkflowInterface
 
@@ -269,11 +270,7 @@ async def test_create_worker(
         activities, workflow_classes, passthrough_modules
     )
 
-    # Verify Worker was instantiated with the expected parameters
-    # Note: activities now includes publish_event and cleanup_app_artifacts
-    from application_sdk.interceptors.cleanup import cleanup_app_artifacts
-
-    expected_activities = list(activities) + [publish_event, cleanup_app_artifacts]
+    expected_activities = list(activities) + [publish_event, cleanup]
     mock_worker_class.assert_called_once_with(
         temporal_client.client,
         task_queue=temporal_client.worker_task_queue,

--- a/tests/unit/clients/test_temporal_client.py
+++ b/tests/unit/clients/test_temporal_client.py
@@ -270,8 +270,10 @@ async def test_create_worker(
     )
 
     # Verify Worker was instantiated with the expected parameters
-    # Note: activities now includes publish_event
-    expected_activities = list(activities) + [publish_event]
+    # Note: activities now includes publish_event and cleanup_app_artifacts
+    from application_sdk.interceptors.cleanup import cleanup_app_artifacts
+
+    expected_activities = list(activities) + [publish_event, cleanup_app_artifacts]
     mock_worker_class.assert_called_once_with(
         temporal_client.client,
         task_queue=temporal_client.worker_task_queue,

--- a/tests/unit/services/test_objectstore.py
+++ b/tests/unit/services/test_objectstore.py
@@ -185,7 +185,9 @@ class TestObjectStore:
         """Test delete prefix failure when listing files fails."""
         mock_list_files.side_effect = Exception("Failed to list files")
 
-        with pytest.raises(Exception, match="Failed to list files"):
+        with pytest.raises(
+            FileNotFoundError, match="No files found under prefix: prefix/"
+        ):
             await ObjectStore.delete_prefix(prefix="prefix/")
 
     # @patch("application_sdk.services.objectstore.ObjectStore.list_files", new_callable=AsyncMock)

--- a/tests/unit/services/test_objectstore.py
+++ b/tests/unit/services/test_objectstore.py
@@ -182,9 +182,10 @@ class TestObjectStore:
         new_callable=AsyncMock,
     )
     async def test_delete_prefix_list_failure(self, mock_list_files: AsyncMock) -> None:
-        """Test delete prefix failure when listing files fails."""
+        """Test delete prefix when listing files fails - should raise FileNotFoundError."""
         mock_list_files.side_effect = Exception("Failed to list files")
 
+        # Should raise FileNotFoundError to give developers clear feedback
         with pytest.raises(
             FileNotFoundError, match="No files found under prefix: prefix/"
         ):


### PR DESCRIPTION
- Introduced  parameter to  and  methods, allowing users to choose whether to keep the local file after upload.
- Updated cleanup logic to conditionally remove local files based on the new parameter, enhancing flexibility in file management.

### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- _to be added_

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->