### PR TITLE
fix: file not found exception across cloud providers, suppress logs in case of upsert

### DIFF
--- a/application_sdk/services/objectstore.py
+++ b/application_sdk/services/objectstore.py
@@ -114,14 +114,17 @@ class ObjectStore:
 
     @classmethod
     async def get_content(
-        cls, key: str, store_name: str = DEPLOYMENT_OBJECT_STORE_NAME
-    ) -> bytes:
+        cls,
+        key: str,
+        store_name: str = DEPLOYMENT_OBJECT_STORE_NAME,
+        suppress_error: bool = False,
+    ) -> bytes | None:
         """Get raw file content from the object store.
 
         Args:
             key: The path of the file in the object store.
             store_name: Name of the Dapr object store binding to use.
-
+            suppress_error: Whether to suppress the error and return None if the file does not exist.
         Returns:
             The raw file content as bytes.
 
@@ -138,14 +141,18 @@ class ObjectStore:
                 store_name=store_name,
             )
             if not response_data:
+                if suppress_error:
+                    return None
                 raise Exception(f"No data received for file: {key}")
 
             logger.debug(f"Successfully retrieved file content: {key}")
             return response_data
 
         except Exception as e:
+            if suppress_error:
+                return None
             logger.error(f"Error getting file content for {key}: {str(e)}")
-            raise e
+            raise
 
     @classmethod
     async def exists(
@@ -450,8 +457,7 @@ class ObjectStore:
                     binding_metadata=metadata,
                 )
                 return response.data
-        except Exception as e:
-            logger.error(f"Error in Dapr binding operation '{operation}': {str(e)}")
+        except Exception:
             raise
 
     @classmethod

--- a/tests/unit/services/test_objectstore.py
+++ b/tests/unit/services/test_objectstore.py
@@ -188,6 +188,116 @@ class TestObjectStore:
         with pytest.raises(Exception, match="Failed to list files"):
             await ObjectStore.delete_prefix(prefix="prefix/")
 
+    @patch("application_sdk.services.objectstore.DaprClient")
+    async def test_get_content_success(self, mock_dapr_client: MagicMock) -> None:
+        """Test successful file content retrieval."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = b"test file content"
+        mock_client.invoke_binding.return_value = mock_response
+        mock_dapr_client.return_value.__enter__.return_value = mock_client
+
+        result = await ObjectStore.get_content(key="test/file.txt")
+
+        assert result == b"test file content"
+        mock_client.invoke_binding.assert_called_once_with(
+            binding_name="objectstore",
+            operation="get",
+            data=b'{"key": "test/file.txt"}',
+            binding_metadata={
+                "key": "test/file.txt",
+                "fileName": "test/file.txt",
+                "blobName": "test/file.txt",
+            },
+        )
+
+    @patch("application_sdk.services.objectstore.DaprClient")
+    async def test_get_content_file_not_found_with_suppress_error_false(
+        self, mock_dapr_client: MagicMock
+    ) -> None:
+        """Test get_content raises exception when file not found and suppress_error=False."""
+        mock_client = MagicMock()
+        mock_client.invoke_binding.side_effect = Exception("File not found")
+        mock_dapr_client.return_value.__enter__.return_value = mock_client
+
+        with pytest.raises(Exception, match="File not found"):
+            await ObjectStore.get_content(
+                key="nonexistent/file.txt", suppress_error=False
+            )
+
+    @patch("application_sdk.services.objectstore.DaprClient")
+    async def test_get_content_file_not_found_with_suppress_error_true(
+        self, mock_dapr_client: MagicMock
+    ) -> None:
+        """Test get_content returns None when file not found and suppress_error=True."""
+        mock_client = MagicMock()
+        mock_client.invoke_binding.side_effect = Exception("File not found")
+        mock_dapr_client.return_value.__enter__.return_value = mock_client
+
+        result = await ObjectStore.get_content(
+            key="nonexistent/file.txt", suppress_error=True
+        )
+
+        assert result is None
+
+    @patch("application_sdk.services.objectstore.DaprClient")
+    async def test_get_content_no_data_with_suppress_error_false(
+        self, mock_dapr_client: MagicMock
+    ) -> None:
+        """Test get_content raises exception when no data returned and suppress_error=False."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = None
+        mock_client.invoke_binding.return_value = mock_response
+        mock_dapr_client.return_value.__enter__.return_value = mock_client
+
+        with pytest.raises(Exception, match="No data received for file: test/file.txt"):
+            await ObjectStore.get_content(key="test/file.txt", suppress_error=False)
+
+    @patch("application_sdk.services.objectstore.DaprClient")
+    async def test_get_content_no_data_with_suppress_error_true(
+        self, mock_dapr_client: MagicMock
+    ) -> None:
+        """Test get_content returns None when no data returned and suppress_error=True."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = None
+        mock_client.invoke_binding.return_value = mock_response
+        mock_dapr_client.return_value.__enter__.return_value = mock_client
+
+        result = await ObjectStore.get_content(key="test/file.txt", suppress_error=True)
+
+        assert result is None
+
+    @patch("application_sdk.services.objectstore.DaprClient")
+    async def test_get_content_empty_data_with_suppress_error_false(
+        self, mock_dapr_client: MagicMock
+    ) -> None:
+        """Test get_content raises exception when empty data returned and suppress_error=False."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = b""
+        mock_client.invoke_binding.return_value = mock_response
+        mock_dapr_client.return_value.__enter__.return_value = mock_client
+
+        with pytest.raises(Exception, match="No data received for file: test/file.txt"):
+            await ObjectStore.get_content(key="test/file.txt", suppress_error=False)
+
+    @patch("application_sdk.services.objectstore.DaprClient")
+    async def test_get_content_empty_data_with_suppress_error_true(
+        self, mock_dapr_client: MagicMock
+    ) -> None:
+        """Test get_content returns None when empty data returned and suppress_error=True."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = b""
+        mock_client.invoke_binding.return_value = mock_response
+        mock_dapr_client.return_value.__enter__.return_value = mock_client
+
+        result = await ObjectStore.get_content(key="test/file.txt", suppress_error=True)
+
+        assert result is None
+
     # @patch("application_sdk.services.objectstore.ObjectStore.list_files", new_callable=AsyncMock)
     # @patch("application_sdk.services.objectstore.ObjectStore._download_file", new_callable=AsyncMock)
     # async def test_download_directory_success(

--- a/tests/unit/services/test_statestore.py
+++ b/tests/unit/services/test_statestore.py
@@ -1,87 +1,229 @@
+"""Unit tests for StateStore services."""
+
 import json
-from typing import Any, Dict, Generator
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import pytest
-from hypothesis import HealthCheck, given, settings
 
-from application_sdk.constants import STATE_STORE_NAME
-from application_sdk.services.secretstore import SecretStore
-from application_sdk.services.statestore import StateStore, StateType
-from application_sdk.test_utils.hypothesis.strategies.outputs.statestore import (
-    configuration_strategy,
-    credentials_strategy,
-    uuid_strategy,
+from application_sdk.services.statestore import (
+    StateStore,
+    StateType,
+    build_state_store_path,
 )
 
-# Configure Hypothesis settings at the module level
-settings.register_profile(
-    "statestore_tests", suppress_health_check=[HealthCheck.function_scoped_fixture]
-)
-settings.load_profile("statestore_tests")
 
+class TestStateStore:
+    """Test suite for StateStore class."""
 
-@pytest.fixture
-def mock_dapr_output_client() -> Generator[MagicMock, None, None]:
-    with patch(
-        "application_sdk.services.statestore.DaprClient"
-    ) as mock_statestore_client, patch(
-        "application_sdk.services.secretstore.DaprClient"
-    ) as mock_secretstore_client:
-        mock_instance = MagicMock()
-        mock_statestore_client.return_value = mock_instance
-        mock_secretstore_client.return_value = mock_instance
-        mock_instance.__enter__.return_value = mock_instance
-        mock_instance.__exit__.return_value = None
-        yield mock_instance
-
-
-def test_state_store_name() -> None:
-    assert STATE_STORE_NAME == "statestore"
-
-
-@pytest.mark.skip(
-    reason="Failing due to hypothesis error: Cannot create a collection of min_size=213 unique elements with values drawn from only 17 distinct elements"
-)
-@given(config=configuration_strategy(), uuid=uuid_strategy)  # type: ignore
-def test_store_configuration_success(
-    mock_dapr_output_client: MagicMock, config: Dict[str, Any], uuid: str
-) -> None:
-    mock_dapr_output_client.reset_mock()  # Reset mock between examples
-    result = StateStore.save_state_object(uuid, config, StateType.CONFIGURATION)
-
-    assert result == uuid
-    mock_dapr_output_client.save_state.assert_called_once_with(
-        store_name="statestore", key=f"config_{uuid}", value=json.dumps(config)
+    @pytest.mark.asyncio
+    @patch(
+        "application_sdk.services.statestore.ObjectStore.get_content",
+        new_callable=AsyncMock,
     )
+    async def test_get_state_success(self, mock_get_content: AsyncMock) -> None:
+        """Test successful state retrieval from object store."""
+        test_state = {"status": "running", "progress": 50}
+        mock_get_content.return_value = json.dumps(test_state).encode("utf-8")
 
+        result = await StateStore.get_state("test-id", StateType.WORKFLOWS)
 
-@pytest.mark.skip(
-    reason="Failing due to hypothesis error: Cannot create a collection of min_size=11383 unique elements with values drawn from only 17 distinct elements"
-)
-@given(config=credentials_strategy())  # type: ignore
-async def test_store_credentials_success(
-    mock_dapr_output_client: MagicMock, config: Dict[str, Any]
-) -> None:
-    mock_dapr_output_client.reset_mock()  # Reset mock between examples
-    with patch("uuid.uuid4", return_value="test-uuid"):
-        result = await SecretStore.save_secret(config)
+        assert result == test_state
+        mock_get_content.assert_called_once()
+        # Verify suppress_error=True is passed
+        call_args = mock_get_content.call_args
+        assert call_args.kwargs.get("suppress_error") is True
 
-    assert result == "test-uuid"
-    mock_dapr_output_client.save_state.assert_called_once_with(
-        store_name="statestore", key="credential_test-uuid", value=json.dumps(config)
+    @pytest.mark.asyncio
+    @patch(
+        "application_sdk.services.statestore.ObjectStore.get_content",
+        new_callable=AsyncMock,
     )
+    async def test_get_state_not_found_returns_empty_dict(
+        self, mock_get_content: AsyncMock
+    ) -> None:
+        """Test get_state returns empty dict when file not found."""
+        # Simulate file not found by returning None (suppress_error=True behavior)
+        mock_get_content.return_value = None
 
+        result = await StateStore.get_state("nonexistent-id", StateType.WORKFLOWS)
 
-@pytest.mark.skip(
-    reason="Failing due to hypothesis error: Cannot create a collection of min_size=1019 unique elements with values drawn from only 17 distinct elements"
-)
-@given(config=credentials_strategy())  # type: ignore
-async def test_store_credentials_failure(
-    mock_dapr_output_client: MagicMock, config: Dict[str, Any]
-) -> None:
-    mock_dapr_output_client.reset_mock()  # Reset mock between examples
-    mock_dapr_output_client.save_state.side_effect = Exception("Dapr error")
+        assert result == {}
+        mock_get_content.assert_called_once()
+        # Verify suppress_error=True is passed
+        call_args = mock_get_content.call_args
+        assert call_args.kwargs.get("suppress_error") is True
 
-    with pytest.raises(Exception):
-        await SecretStore.save_secret(config)
+    @pytest.mark.asyncio
+    @patch(
+        "application_sdk.services.statestore.ObjectStore.get_content",
+        new_callable=AsyncMock,
+    )
+    async def test_get_state_json_decode_error(
+        self, mock_get_content: AsyncMock
+    ) -> None:
+        """Test get_state raises exception on JSON decode error."""
+        # Return invalid JSON
+        mock_get_content.return_value = b"invalid json content"
+
+        with pytest.raises(json.JSONDecodeError):
+            await StateStore.get_state("test-id", StateType.WORKFLOWS)
+
+    @pytest.mark.asyncio
+    @patch(
+        "application_sdk.services.statestore.ObjectStore.get_content",
+        new_callable=AsyncMock,
+    )
+    async def test_get_state_object_store_error(
+        self, mock_get_content: AsyncMock
+    ) -> None:
+        """Test get_state propagates object store errors."""
+        mock_get_content.side_effect = Exception("Object store connection failed")
+
+        with pytest.raises(Exception, match="Object store connection failed"):
+            await StateStore.get_state("test-id", StateType.WORKFLOWS)
+
+    @pytest.mark.asyncio
+    @patch(
+        "application_sdk.services.statestore.ObjectStore.upload_file",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "application_sdk.services.statestore.StateStore.get_state",
+        new_callable=AsyncMock,
+    )
+    @patch("os.makedirs")
+    async def test_save_state_success(
+        self,
+        mock_makedirs: MagicMock,
+        mock_get_state: AsyncMock,
+        mock_upload_file: AsyncMock,
+    ) -> None:
+        """Test successful state saving."""
+        # Setup existing state
+        existing_state = {"status": "running", "step": 1}
+        mock_get_state.return_value = existing_state
+
+        with patch("builtins.open", mock_open()) as mock_file:
+            await StateStore.save_state("progress", 75, "test-id", StateType.WORKFLOWS)
+
+        # Verify state was merged
+        mock_get_state.assert_called_once_with("test-id", StateType.WORKFLOWS)
+
+        # Verify file operations
+        mock_makedirs.assert_called_once()
+        mock_file.assert_called_once()
+
+        # Verify upload was called
+        mock_upload_file.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch(
+        "application_sdk.services.statestore.ObjectStore.upload_file",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "application_sdk.services.statestore.StateStore.get_state",
+        new_callable=AsyncMock,
+    )
+    @patch("os.makedirs")
+    async def test_save_state_object_success(
+        self,
+        mock_makedirs: MagicMock,
+        mock_get_state: AsyncMock,
+        mock_upload_file: AsyncMock,
+    ) -> None:
+        """Test successful state object saving."""
+        # Setup existing state
+        existing_state = {"status": "running", "step": 1}
+        mock_get_state.return_value = existing_state
+
+        new_state = {"progress": 75, "current_task": "processing"}
+
+        with patch("builtins.open", mock_open()) as mock_file:
+            result = await StateStore.save_state_object(
+                "test-id", new_state, StateType.WORKFLOWS
+            )
+
+        # Verify state was merged and returned
+        expected_merged_state = {
+            "status": "running",
+            "step": 1,
+            "progress": 75,
+            "current_task": "processing",
+        }
+        assert result == expected_merged_state
+
+        # Verify state was retrieved
+        mock_get_state.assert_called_once_with("test-id", StateType.WORKFLOWS)
+
+        # Verify file operations
+        mock_makedirs.assert_called_once()
+        mock_file.assert_called_once()
+
+        # Verify upload was called
+        mock_upload_file.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch(
+        "application_sdk.services.statestore.StateStore.get_state",
+        new_callable=AsyncMock,
+    )
+    async def test_save_state_get_state_failure(
+        self, mock_get_state: AsyncMock
+    ) -> None:
+        """Test save_state propagates get_state failures."""
+        mock_get_state.side_effect = Exception("Failed to retrieve existing state")
+
+        with pytest.raises(Exception, match="Failed to retrieve existing state"):
+            await StateStore.save_state("key", "value", "test-id", StateType.WORKFLOWS)
+
+    @pytest.mark.asyncio
+    @patch(
+        "application_sdk.services.statestore.ObjectStore.upload_file",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "application_sdk.services.statestore.StateStore.get_state",
+        new_callable=AsyncMock,
+    )
+    @patch("os.makedirs")
+    async def test_save_state_upload_failure(
+        self,
+        mock_makedirs: MagicMock,
+        mock_get_state: AsyncMock,
+        mock_upload_file: AsyncMock,
+    ) -> None:
+        """Test save_state propagates upload failures."""
+        mock_get_state.return_value = {}
+        mock_upload_file.side_effect = Exception("Upload failed")
+
+        with patch("builtins.open", mock_open()):
+            with pytest.raises(Exception, match="Upload failed"):
+                await StateStore.save_state(
+                    "key", "value", "test-id", StateType.WORKFLOWS
+                )
+
+    def test_build_state_store_path_workflows(self) -> None:
+        """Test build_state_store_path for workflows."""
+        path = build_state_store_path("workflow-123", StateType.WORKFLOWS)
+        assert "workflows" in path
+        assert "workflow-123" in path
+        assert path.endswith("config.json")
+
+    def test_build_state_store_path_credentials(self) -> None:
+        """Test build_state_store_path for credentials."""
+        path = build_state_store_path("cred-456", StateType.CREDENTIALS)
+        assert "credentials" in path
+        assert "cred-456" in path
+        assert path.endswith("config.json")
+
+    def test_state_type_is_member_valid(self) -> None:
+        """Test StateType.is_member with valid values."""
+        assert StateType.is_member("workflows") is True
+        assert StateType.is_member("credentials") is True
+
+    def test_state_type_is_member_invalid(self) -> None:
+        """Test StateType.is_member with invalid values."""
+        assert StateType.is_member("invalid") is False
+        assert StateType.is_member("") is False
+        assert StateType.is_member("WORKFLOWS") is False  # Case sensitive


### PR DESCRIPTION
### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- fixes the error handling issues with `file/blob/object not found` across cloud providers
- Add suppress_error parameter to ObjectStore.get_content() method that returns None instead of raising exception when file not found
- Add comprehensive tests for both suppress_error=True and suppress_error=False scenarios
- Test coverage includes file not found, empty data, and connection error cases


closes #685

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [x] Additional tests added
- [x] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->