### PR TITLE
feat: bump dapr version to 1.16.0

### DIFF
--- a/.cursor/rules/setup.mdc
+++ b/.cursor/rules/setup.mdc
@@ -10,7 +10,7 @@ The Atlan Python Application SDK requires the following components regardless of
 1. Python 3.11.10
 2. uv 0.7.3
 3. Temporal CLI
-4. DAPR CLI 1.14.1
+4. DAPR CLI 1.16.0
 5. Project dependencies
 
 ## OS-Specific Setup Guides

--- a/.github/actions/e2e-examples/action.yaml
+++ b/.github/actions/e2e-examples/action.yaml
@@ -45,16 +45,16 @@ runs:
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s 1.14.1
-        dapr init --runtime-version 1.13.6 --slim
+        wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s 1.16.0
+        dapr init --runtime-version 1.16.0 --slim
 
     - name: Install Dapr CLI (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        $script=iwr -useb https://raw.githubusercontent.com/dapr/cli/master/install/install.ps1; $block=[ScriptBlock]::Create($script); invoke-command -ScriptBlock $block -ArgumentList 1.14.1, "$env:USERPROFILE\.dapr\bin\"
+        $script=iwr -useb https://raw.githubusercontent.com/dapr/cli/master/install/install.ps1; $block=[ScriptBlock]::Create($script); invoke-command -ScriptBlock $block -ArgumentList 1.16.0, "$env:USERPROFILE\.dapr\bin\"
         $env:Path += ";$env:USERPROFILE\.dapr\bin\"
-        dapr init --runtime-version 1.13.6 --slim
+        dapr init --runtime-version 1.16.0 --slim
 
     - name: Install Temporal CLI and Start Server
       if: runner.os != 'Windows'

--- a/.github/workflows/scale-tests.yaml
+++ b/.github/workflows/scale-tests.yaml
@@ -47,8 +47,8 @@ jobs:
       # Install Dapr
       - name: Install Dapr CLI
         run: |
-          wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s 1.14.1
-          dapr init --runtime-version 1.13.6 --slim
+          wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s 1.16.0
+          dapr init --runtime-version 1.16.0 --slim
 
       # Install Temporal
       - name: Install Temporal CLI and Start Server

--- a/docs/docs/setup/LINUX.md
+++ b/docs/docs/setup/LINUX.md
@@ -57,10 +57,10 @@ Install DAPR using the following commands:
 
 ```bash
 # Install DAPR CLI
-wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s 1.14.1
+wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s 1.16.0
 
 # Initialize DAPR (slim mode)
-dapr init --runtime-version 1.13.6 --slim
+dapr init --runtime-version 1.16.0 --slim
 
 # Verify installation
 dapr --version

--- a/docs/docs/setup/MAC.md
+++ b/docs/docs/setup/MAC.md
@@ -52,8 +52,8 @@ brew install temporal
 DAPR (Distributed Application Runtime) simplifies microservice development:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/dapr/cli/master/install/install.sh | /bin/bash -s 1.14.1
-dapr init --runtime-version 1.13.6 --slim
+curl -fsSL https://raw.githubusercontent.com/dapr/cli/master/install/install.sh | /bin/bash -s 1.16.0
+dapr init --runtime-version 1.16.0 --slim
 ```
 
 > [!NOTE]

--- a/docs/docs/setup/WINDOWS.md
+++ b/docs/docs/setup/WINDOWS.md
@@ -59,14 +59,14 @@ Install DAPR using PowerShell:
 Set-ExecutionPolicy RemoteSigned -scope CurrentUser
 
 # Install DAPR CLI
-$script=iwr -useb https://raw.githubusercontent.com/dapr/cli/master/install/install.ps1; $block=[ScriptBlock]::Create($script); invoke-command -ScriptBlock $block -ArgumentList 1.14.1, "$env:USERPROFILE\.dapr\bin\"
+$script=iwr -useb https://raw.githubusercontent.com/dapr/cli/master/install/install.ps1; $block=[ScriptBlock]::Create($script); invoke-command -ScriptBlock $block -ArgumentList 1.16.0, "$env:USERPROFILE\.dapr\bin\"
 
 # Add to PATH
 $env:Path += ";$env:USERPROFILE\.dapr\bin\"
 [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User)
 
 # Initialize DAPR (slim mode)
-dapr init --runtime-version 1.13.6 --slim
+dapr init --runtime-version 1.16.0 --slim
 
 # Verify installation
 dapr --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,10 +107,10 @@ mcp = [
 [tool.poe.tasks]
 download-components.shell = "ls -l components/*.yaml"
 # Dapr and Temporal service tasks
-start-dapr = "dapr run --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --dapr-http-max-request-size 1024 --resources-path components"
+start-dapr = "dapr run --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi --resources-path components"
 
 # if you need to test dapr with environment values for an app
-#start-dapr.shell = "set -a && source .env && set +a && dapr run --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --dapr-http-max-request-size 1024 --resources-path components"
+#start-dapr.shell = "set -a && source .env && set +a && dapr run --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi --resources-path components"
 
 start-temporal = "temporal server start-dev --db-filename ./temporal.db"
 start-deps.shell = "poe start-dapr & poe start-temporal &"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ Documentation = "https://github.com/atlanhq/application-sdk/README.md"
 # Optional dependencies for specific functionality - Install using: uv sync --extra workflows
 [project.optional-dependencies]
 workflows = [
-    "dapr>=1.14.0",
+    "dapr==1.16.0",
     "temporalio>=1.7.1",
     "orjson>=3.10.18",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.10.0" },
     { name = "boto3", marker = "extra == 'iam-auth'", specifier = ">=1.38.6" },
     { name = "daft", marker = "extra == 'daft'", specifier = ">=0.4.12" },
-    { name = "dapr", marker = "extra == 'workflows'", specifier = ">=1.14.0" },
+    { name = "dapr", marker = "extra == 'workflows'", specifier = "==1.16.0" },
     { name = "duckdb", specifier = ">=1.1.3" },
     { name = "duckdb-engine", specifier = ">=0.17.0" },
     { name = "faker", marker = "extra == 'scale-data-generator'", specifier = ">=37.1.0" },
@@ -727,7 +727,7 @@ wheels = [
 
 [[package]]
 name = "dapr"
-version = "1.15.0"
+version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -737,9 +737,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/55/ce908bb140a7ec3f32d2194b6a50b9f7a7fd88fca8c78701d60d3f7c16e3/dapr-1.15.0.tar.gz", hash = "sha256:6b2373084143f164cb00702758b17a14fc4442314a1f3e2be36ee008d486c47a", size = 99424, upload-time = "2025-02-27T18:53:55.782Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/b1/d39ba15d453b67b93d53ec56de7eb9324cb8bbf0599afcb2c0ade990b7ae/dapr-1.16.0.tar.gz", hash = "sha256:c7e3d005552a598d07608d0d502b2bc432e86678f94b2beccc13a096b9198684", size = 122467, upload-time = "2025-09-17T10:59:57.138Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/ad/6923177cfcd2a98f08dbd1c4a580e9fbac93b05798ded77314e848d6eef2/dapr-1.15.0-py3-none-any.whl", hash = "sha256:0093bf6df5eb9a14fbab60191a619438e0b6b336f60a7994e184276bcc35d5fb", size = 141392, upload-time = "2025-02-27T18:53:53.805Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/3e/de39e18e14d07882fcff028227c2dbe7fa202f09413127d4de32b03e0884/dapr-1.16.0-py3-none-any.whl", hash = "sha256:076dd559a0b450eae24b1c2ae779c9299ed3e06a05c1f72719a6613af8d19ced", size = 166710, upload-time = "2025-09-17T10:59:55.473Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Changelog
- bump dapr version to 1.16.0
- https://docs.dapr.io/operations/support/support-release-policy/#supported-versions

⚠️ breaking changes
- `--scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi` as part of the dependency command

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade Dapr to 1.16.0 across docs and CI, pin Python package to 1.16.0, and update dapr run flags to new parameters.
> 
> - **Dependencies**:
>   - Pin `workflows` extra to `dapr==1.16.0` in `pyproject.toml`.
> - **Tooling**:
>   - Update `poe start-dapr` to use `--scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi` and remove `--dapr-http-max-request-size`.
> - **CI**:
>   - Use Dapr CLI/runtime `1.16.0` in `.github/actions/e2e-examples/action.yaml` and `.github/workflows/scale-tests.yaml`.
> - **Docs**:
>   - Update Linux/macOS/Windows setup guides and `.cursor/rules/setup.mdc` to Dapr `1.16.0` and init runtime `1.16.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56718fafa9684a92dedb5e249101fc771670eec9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->