### PR TITLE
fix:  issue with path is returned from download_files is always set t…

### DIFF
--- a/application_sdk/inputs/parquet.py
+++ b/application_sdk/inputs/parquet.py
@@ -89,11 +89,10 @@ class ParquetInput(Input):
         try:
             import pandas as pd
 
-            path = self.path
             if self.input_prefix and self.path:
-                path = await self.download_files(self.path)
+                await self.download_files(self.path)
             # Use pandas native read_parquet which can handle both single files and directories
-            return pd.read_parquet(path)
+            return pd.read_parquet(self.path)
         except Exception as e:
             logger.error(f"Error reading data from parquet file(s): {str(e)}")
             # Re-raise to match IcebergInput behavior


### PR DESCRIPTION


### Changelog

path was always set to none as the underlying methods inside `download_files` is returning None




### Additional context (e.g. screenshots, logs, links)
<img width="747" height="803" alt="Screenshot 2025-09-23 at 10 35 39 AM" src="https://github.com/user-attachments/assets/ed9e1b59-0eee-4c47-9e4b-e5499921c9e2" />
<img width="733" height="554" alt="Screenshot 2025-09-23 at 10 35 31 AM" src="https://github.com/user-attachments/assets/edfee22e-72ba-4554-92c9-db07db8c838c" />
<img width="777" height="625" alt="Screenshot 2025-09-23 at 10 35 14 AM" src="https://github.com/user-attachments/assets/4f24625e-12e6-4fba-8e9b-c54e72415cdd" />



### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->