### PR TITLE
fix: Adjust max file size buffer in ParquetOutput to 75% of DAPR limit

### DIFF
--- a/application_sdk/outputs/parquet.py
+++ b/application_sdk/outputs/parquet.py
@@ -98,7 +98,7 @@ class ParquetOutput(Output):
         self.current_buffer_size = 0
         self.current_buffer_size_bytes = 0  # Track estimated buffer size in bytes
         self.max_file_size_bytes = int(
-            DAPR_MAX_GRPC_MESSAGE_LENGTH * 0.9
+            DAPR_MAX_GRPC_MESSAGE_LENGTH * 0.75
         )  # 90% of DAPR limit as safety buffer
         self.chunk_start = chunk_start
         self.chunk_part = 0

--- a/application_sdk/outputs/parquet.py
+++ b/application_sdk/outputs/parquet.py
@@ -99,7 +99,7 @@ class ParquetOutput(Output):
         self.current_buffer_size_bytes = 0  # Track estimated buffer size in bytes
         self.max_file_size_bytes = int(
             DAPR_MAX_GRPC_MESSAGE_LENGTH * 0.75
-        )  # 90% of DAPR limit as safety buffer
+        )  # 75% of DAPR limit as safety buffer
         self.chunk_start = chunk_start
         self.chunk_part = 0
         self.start_marker = start_marker


### PR DESCRIPTION
### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- _to be added_

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lowers `max_file_size_bytes` from 90% to 75% of the DAPR gRPC message limit for Parquet output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f342f409ee6749108dce40ca33a4b7bd2026464c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->