### PR TITLE
feat: enable Dapr hot reload and add error resilience to components

### DIFF
--- a/components/atlan-storage.yaml
+++ b/components/atlan-storage.yaml
@@ -3,8 +3,9 @@ kind: Component
 metadata:
   name: atlan-storage
 spec:
-  type: bindings.aws.s3
   version: v1
+  type: bindings.aws.s3
+  ignoreErrors: true
   metadata:
     - name: accessKey
       value: "{{clientId}}"

--- a/components/aws-secrets.yaml
+++ b/components/aws-secrets.yaml
@@ -3,6 +3,9 @@ kind: Component
 metadata:
   name: aws-secrets
 spec:
+  version: v1
+  type: secretstores.aws.secretmanager
+  ignoreErrors: true
   metadata:
   - name: region
     value: ap-south-1
@@ -12,5 +15,3 @@ spec:
     value: ''
   - name: sessionToken
     value: ''
-  type: secretstores.aws.secretmanager
-  version: v1

--- a/components/configuration.yaml
+++ b/components/configuration.yaml
@@ -1,0 +1,12 @@
+# This configuration is used to enable hot reload for the application
+# Note:
+# - components have ignoreErrors: true, in case of any errors, the application will continue to run with
+#   a warning and the component will be ignored.
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: hotreload-config
+spec:
+  features:
+    - name: HotReload
+      enabled: true

--- a/components/configuration.yaml
+++ b/components/configuration.yaml
@@ -5,7 +5,7 @@
 apiVersion: dapr.io/v1alpha1
 kind: Configuration
 metadata:
-  name: hotreload-config
+  name: configuration
 spec:
   features:
     - name: HotReload

--- a/components/deployment-secrets.yaml
+++ b/components/deployment-secrets.yaml
@@ -3,5 +3,6 @@ kind: Component
 metadata:
   name: deployment-secret-store
 spec:
-  type: secretstores.local.env
   version: v1
+  type: secretstores.local.env
+  ignoreErrors: true

--- a/components/eventstore.yaml
+++ b/components/eventstore.yaml
@@ -3,8 +3,9 @@ kind: Component
 metadata:
   name: eventstore
 spec:
-  type: bindings.localstorage
   version: v1
+  type: bindings.localstorage
+  ignoreErrors: true
   metadata:
   - name: rootPath
     value: "./local/dapr/eventstore"
@@ -15,8 +16,9 @@ spec:
 # metadata:
 #   name: eventstore
 # spec:
-#   type: bindings.http
 #   version: v1
+#   type: bindings.http
+#   ignoreErrors: true
 #   metadata:
 #   - name: url
 #     value: https://atlan.url/eventurl

--- a/components/objectstore.yaml
+++ b/components/objectstore.yaml
@@ -3,8 +3,9 @@ kind: Component
 metadata:
   name: objectstore
 spec:
-  type: bindings.localstorage
   version: v1
+  type: bindings.localstorage
+  ignoreErrors: true
   metadata:
     - name: rootPath
       value: "./local/dapr/objectstore"

--- a/components/secretstore.yaml
+++ b/components/secretstore.yaml
@@ -3,8 +3,9 @@
 # metadata:
 #   name: secretstore
 # spec:
-#   type: secretstores.local.file
 #   version: v1
+#   type: secretstores.local.file
+#   ignoreErrors: true
 #   metadata:
 #   - name: secretsFile
 #     value: dapr/components/secrets.json

--- a/components/statestore.yaml
+++ b/components/statestore.yaml
@@ -3,8 +3,9 @@ kind: Component
 metadata:
   name: statestore
 spec:
-  type: state.sqlite
   version: v1
+  type: state.sqlite
+  ignoreErrors: true
   metadata:
     # Connection string
     - name: connectionString

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,10 +107,10 @@ mcp = [
 [tool.poe.tasks]
 download-components.shell = "ls -l components/*.yaml"
 # Dapr and Temporal service tasks
-start-dapr = "dapr run --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi --resources-path components"
+start-dapr = "dapr run --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi --config components/configuration.yaml --resources-path components"
 
 # if you need to test dapr with environment values for an app
-#start-dapr.shell = "set -a && source .env && set +a && dapr run --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi --resources-path components"
+#start-dapr.shell = "set -a && source .env && set +a && dapr run --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi --config components/configuration.yaml --resources-path components"
 
 start-temporal = "temporal server start-dev --db-filename ./temporal.db"
 start-deps.shell = "poe start-dapr & poe start-temporal &"


### PR DESCRIPTION
### Changelog
- Add new configuration.yaml with HotReload feature enabled
- Add ignoreErrors flag to all component definitions for graceful error handling
- Standardize component YAML structure (version before type)
- Update dapr run commands to use configuration file for hot reload support

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Dapr hot reload via a new configuration and makes component definitions resilient with ignoreErrors, updating run commands to use the config.
> 
> - **Dapr configuration**:
>   - Add `components/configuration.yaml` enabling `HotReload`.
> - **Component resilience**:
>   - Add `ignoreErrors: true` to `components/{atlan-storage.yaml,aws-secrets.yaml,deployment-secrets.yaml,eventstore.yaml,objectstore.yaml,statestore.yaml}`.
>   - Normalize spec fields (`type`, `version`) across component YAMLs.
> - **Tooling**:
>   - Update `pyproject.toml` `start-dapr` tasks to use `--config components/configuration.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a1eb536709d2de13e54f84fc948d39cd6479fec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->