### PR TITLE
fix: workflow output path schedule mode

### DIFF
--- a/application_sdk/activities/common/utils.py
+++ b/application_sdk/activities/common/utils.py
@@ -84,7 +84,7 @@ def build_output_path() -> str:
 
     # Fallback to raw workflow_id if sanitization results in empty string
     if not sanitized_workflow_id:
-        sanitized_workflow_id = raw_workflow_id
+        sanitized_workflow_id = "unknown-workflow"
 
     return WORKFLOW_OUTPUT_PATH_TEMPLATE.format(
         application_name=APPLICATION_NAME,

--- a/application_sdk/activities/common/utils.py
+++ b/application_sdk/activities/common/utils.py
@@ -10,6 +10,7 @@ import os
 from datetime import timedelta
 from functools import wraps
 from typing import Any, Awaitable, Callable, List, Optional, TypeVar, cast
+import re
 
 from temporalio import activity
 
@@ -71,9 +72,15 @@ def build_output_path() -> str:
         >>> build_output_path()
         "artifacts/apps/appName/workflows/wf-123/run-456"
     """
+    # Sanitize workflow_id to remove any schedule/timestamp suffix
+    raw_workflow_id = get_workflow_id()
+    
+    # If workflow_id contains a timestamp (e.g., '-YYYY-MM-DDTHH:MM:SSZ'), remove it
+    sanitized_workflow_id = re.sub(r'-\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$', '', raw_workflow_id)
+    
     return WORKFLOW_OUTPUT_PATH_TEMPLATE.format(
         application_name=APPLICATION_NAME,
-        workflow_id=get_workflow_id(),
+        workflow_id=sanitized_workflow_id,
         run_id=get_workflow_run_id(),
     )
 

--- a/tests/unit/activities/common/test_utils.py
+++ b/tests/unit/activities/common/test_utils.py
@@ -65,7 +65,7 @@ class TestBuildOutputPath:
         mock_activity.info.return_value.workflow_id = ""
         mock_activity.info.return_value.workflow_run_id = "run-000"
         result = build_output_path()
-        assert result == "artifacts/apps/test-app/workflows//run-000"
+        assert result == "artifacts/apps/test-app/workflows/unknown-workflow/run-000"
 
 
 class TestGetObjectStorePrefix:


### PR DESCRIPTION
### Changelog
-Ensures consistent workflow output path for both manual and scheduled runs. 
-Removes any timestamp or schedule-specific suffix from workflow_id when generating the output path. 
-Output path now always follows the format: artifacts/apps/{application_name}/workflows/{workflow_id}/{run_id}.

### Additional context (e.g. screenshots, logs, links)
<img width="1718" height="426" alt="image" src="https://github.com/user-attachments/assets/0eef5c41-3604-4cd2-8309-7f1e3dad1123" />

closes #719 


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sanitizes `workflow_id` in `build_output_path` by stripping schedule timestamp suffix and adds unit tests covering standard, scheduled, and empty IDs.
> 
> - **Utilities (`application_sdk/activities/common/utils.py`)**:
>   - **`build_output_path`**: Strip schedule timestamp suffix from `workflow_id` using `TIMESTAMP_PATTERN`; fallback to `"unknown-workflow"` if empty.
>   - Add compiled regex `TIMESTAMP_PATTERN` and required import.
> - **Tests (`tests/unit/activities/common/test_utils.py`)**:
>   - Add tests for `build_output_path` covering standard IDs, scheduled IDs with timestamps, and empty `workflow_id` fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b257dcc0dec7d8d2ee325e119c5ce1bc0a5ebf04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->