### PR TITLE
fix: use-server-side-cursor is not working

### DIFF
--- a/application_sdk/inputs/sql_query.py
+++ b/application_sdk/inputs/sql_query.py
@@ -2,6 +2,7 @@ import asyncio
 import concurrent
 from typing import TYPE_CHECKING, AsyncIterator, Iterator, Optional, Union
 
+from application_sdk.constants import USE_SERVER_SIDE_CURSOR
 from application_sdk.inputs import Input
 from application_sdk.observability.logger_adaptor import get_logger
 
@@ -120,6 +121,8 @@ class SQLQueryInput(Input):
                 or iterator of DataFrames if chunked.
         """
         with self.engine.connect() as conn:
+            if USE_SERVER_SIDE_CURSOR:
+                conn = conn.execution_options(yield_per=100000)
             return self._execute_pandas_query(conn)
 
     async def get_batched_dataframe(


### PR DESCRIPTION
### Changelog
- Use server_side_cursor was not being taken into account while creating connections in SQLQueryInput class. 
- fetch_assets ( tables / columns / database ) etc use SQLQueryInput and they create their own connection from the given engine.
- They were making this connection without taking into account server_side_cursor 
- As a result irrespective of the server_side_cursor value - all data was being bought into the memory during fetch_methods execution

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Respect `USE_SERVER_SIDE_CURSOR` to execute queries with `yield_per=100000`, avoiding full in-memory fetches.
> 
> - **SQL query execution (`application_sdk/inputs/sql_query.py`)**:
>   - Import `USE_SERVER_SIDE_CURSOR` and, when enabled, set `conn.execution_options(yield_per=100000)` before running pandas read, enabling server-side cursor/batched fetching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f992d89f3451a4b12c017395e9a04781a1e5bb0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->