### PR TITLE
fix: resolve race condition in preflight_check activity

### DIFF
--- a/application_sdk/activities/__init__.py
+++ b/application_sdk/activities/__init__.py
@@ -241,6 +241,16 @@ class ActivitiesInterface(ABC, Generic[ActivitiesStateType]):
             if not handler:
                 raise ValueError("Preflight check handler not found")
 
+            # Verify handler and client are properly initialized
+            if hasattr(handler, "sql_client") and handler.sql_client:
+                if not handler.sql_client.engine:
+                    logger.error("SQL client engine is not initialized")
+                    raise ValueError(
+                        "Preflight check failed: SQL client engine not initialized. "
+                        "This may indicate credentials were not loaded properly."
+                    )
+                logger.info("SQL client engine verified as initialized")
+
             result = await handler.preflight_check(
                 {"metadata": workflow_args["metadata"]}
             )

--- a/application_sdk/activities/metadata_extraction/sql.py
+++ b/application_sdk/activities/metadata_extraction/sql.py
@@ -166,16 +166,17 @@ class BaseSQLMetadataExtractionActivities(ActivitiesInterface):
 
         sql_client = self.sql_client_class()
 
-        handler = self.handler_class(sql_client)
-        self._state[workflow_id].handler = handler
-
+        # Load credentials BEFORE creating handler to avoid race condition
         if "credential_guid" in workflow_args:
             credentials = await SecretStore.get_credentials(
                 workflow_args["credential_guid"]
             )
             await sql_client.load(credentials)
 
+        # Assign sql_client and handler to state AFTER credentials are loaded
         self._state[workflow_id].sql_client = sql_client
+        handler = self.handler_class(sql_client)
+        self._state[workflow_id].handler = handler
 
         # Create transformer with required parameters from ApplicationConstants
         transformer_params = {


### PR DESCRIPTION
### Changelog

- Fix intermittent preflight check failures caused by a race condition where the handler was assigned to state before credentials were fully loaded into the SQL client.

How?
- Load credentials before creating handler in BaseSQLMetadataExtractionActivities
- Add defensive validation in preflight_check to verify SQL client initialization
- Improve error messages for uninitialized client scenarios

The race condition occurred when the handler was created and stored in state before the async credential loading completed, causing preflight_check to sometimes receive a handler with an uninitialized SQL client engine.

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->