### PR TITLE
Add optional frontend setup instructions to OS guides

### DIFF
--- a/docs/docs/setup/LINUX.md
+++ b/docs/docs/setup/LINUX.md
@@ -66,6 +66,24 @@ dapr init --runtime-version 1.16.0 --slim
 dapr --version
 ```
 
+### 5. Setup Frontend (Optional)
+
+> [!NOTE]
+> This step is only required if you plan to write and implement config maps for workflow setup forms.
+
+Install the frontend playground for your application:
+
+```bash
+# Create the frontend static directory
+mkdir -p frontend/static
+
+# Install the app playground
+npx @atlanhq/app-playground install-to frontend/static
+```
+
+> [!NOTE]
+> `frontend/static` is the default directory. You can change this to a different location, but you'll need to update the path in your workflow definition accordingly.
+
 > [!NOTE]
 > Your development environment is now ready! Head over to our [Getting Started Guide](../guides/getting-started.md) to learn how to:
 > - Install project dependencies

--- a/docs/docs/setup/MAC.md
+++ b/docs/docs/setup/MAC.md
@@ -56,6 +56,24 @@ curl -fsSL https://raw.githubusercontent.com/dapr/cli/master/install/install.sh 
 dapr init --runtime-version 1.16.0 --slim
 ```
 
+### 5. Setup Frontend (Optional)
+
+> [!NOTE]
+> This step is only required if you plan to write and implement config maps for workflow setup forms.
+
+Install the frontend playground for your application:
+
+```bash
+# Create the frontend static directory
+mkdir -p frontend/static
+
+# Install the app playground
+npx @atlanhq/app-playground install-to frontend/static
+```
+
+> [!NOTE]
+> `frontend/static` is the default directory. You can change this to a different location, but you'll need to update the path in your workflow definition accordingly.
+
 > [!NOTE]
 > Your development environment is now ready! Head over to our [Getting Started Guide](../guides/getting-started.md) to learn how to:
 > - Install project dependencies

--- a/docs/docs/setup/WINDOWS.md
+++ b/docs/docs/setup/WINDOWS.md
@@ -72,6 +72,24 @@ dapr init --runtime-version 1.16.0 --slim
 dapr --version
 ```
 
+### 4. Setup Frontend (Optional)
+
+> [!NOTE]
+> This step is only required if you plan to write and implement config maps for workflow setup forms.
+
+Install the frontend playground for your application:
+
+```powershell
+# Create the frontend static directory
+New-Item -ItemType Directory -Force -Path "frontend\static"
+
+# Install the app playground
+npx @atlanhq/app-playground install-to frontend/static
+```
+
+> [!NOTE]
+> `frontend/static` is the default directory. You can change this to a different location, but you'll need to update the path in your workflow definition accordingly.
+
 > [!NOTE]
 > Your development environment is now ready! Head over to our [Getting Started Guide](../guides/getting-started.md) to learn how to:
 > - Install project dependencies


### PR DESCRIPTION
### Changelog
- Added optional frontend setup instructions to macOS, Windows, and Linux guides.

### Additional context (e.g. screenshots, logs, links)
- _to be added_

### Checklist
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional frontend playground setup steps to Linux, macOS, and Windows setup guides.
> 
> - **Documentation**:
>   - **Setup Guides** (`docs/docs/setup/LINUX.md`, `docs/docs/setup/MAC.md`, `docs/docs/setup/WINDOWS.md`):
>     - Add optional frontend setup section with commands to create `frontend/static` and install playground via `npx @atlanhq/app-playground install-to frontend/static`.
>     - Include note that the `frontend/static` path is configurable and must match workflow definitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e003f477d61aa4fc2281f9d9ea949b6cdfcbc81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->