### PR TITLE
refactor: move mcp from dependency-groups to optional-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,10 @@ distributed_lock = [
     "redis[hiredis]>=5.2.0",
 ]
 
+mcp = [
+    "fastmcp>=2.12.3",
+]
+
 # Development dependencies - Install using: uv sync --group dev
 [dependency-groups]
 dev = [
@@ -99,9 +103,6 @@ test = [
 examples = [
     "snowflake-sqlalchemy>=1.7.0",
     "psycopg[binary]>=3.2.7",
-]
-mcp = [
-    "fastmcp>=2.12.3",
 ]
 
 [tool.poe.tasks]

--- a/uv.lock
+++ b/uv.lock
@@ -169,6 +169,9 @@ iam-auth = [
 iceberg = [
     { name = "pyiceberg" },
 ]
+mcp = [
+    { name = "fastmcp" },
+]
 pandas = [
     { name = "pandas" },
 ]
@@ -208,9 +211,6 @@ examples = [
     { name = "psycopg", extra = ["binary"] },
     { name = "snowflake-sqlalchemy" },
 ]
-mcp = [
-    { name = "fastmcp" },
-]
 test = [
     { name = "coverage" },
     { name = "hypothesis" },
@@ -229,6 +229,7 @@ requires-dist = [
     { name = "duckdb-engine", specifier = ">=0.17.0" },
     { name = "faker", marker = "extra == 'scale-data-generator'", specifier = ">=37.1.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
+    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.12.3" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "numpy", marker = "extra == 'scale-data-generator'", specifier = ">=1.23.5,<3.0.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.27.0" },
@@ -250,7 +251,7 @@ requires-dist = [
     { name = "temporalio", marker = "extra == 'workflows'", specifier = ">=1.7.1" },
     { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.21.0" },
 ]
-provides-extras = ["workflows", "pandas", "daft", "iceberg", "sqlalchemy", "iam-auth", "tests", "scale-data-generator", "distributed-lock"]
+provides-extras = ["workflows", "pandas", "daft", "iceberg", "sqlalchemy", "iam-auth", "tests", "scale-data-generator", "distributed-lock", "mcp"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -267,7 +268,6 @@ examples = [
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.7" },
     { name = "snowflake-sqlalchemy", specifier = ">=1.7.0" },
 ]
-mcp = [{ name = "fastmcp", specifier = ">=2.12.3" }]
 test = [
     { name = "coverage", specifier = ">=7.6.1" },
     { name = "hypothesis", specifier = ">=6.114.0" },


### PR DESCRIPTION
### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- _to be added_

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves `fastmcp` from a dev dependency group to an optional extra `mcp`, updating metadata and lockfile accordingly.
> 
> - **Packaging/Build**:
>   - Add optional extra `mcp` with `fastmcp>=2.12.3` in `pyproject.toml` (`[project.optional-dependencies]`).
>   - Remove `mcp` from `[dependency-groups]`.
>   - Update `uv.lock` and `package.metadata`:
>     - Add `fastmcp` to `requires-dist` with marker `extra == 'mcp'`.
>     - Include `mcp` in `provides-extras`.
>     - Adjust groups to reflect the move from dev group to optional extra.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 548b919021cb20023d51bfcc87a643a269a4ec5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->