### PR TITLE
fix: remove long running local activities

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -256,7 +256,7 @@ REDIS_SENTINEL_HOSTS = os.getenv("REDIS_SENTINEL_HOSTS", "")
 #: Whether to enable strict locking
 IS_LOCKING_DISABLED = os.getenv("IS_LOCKING_DISABLED", "true").lower() == "true"
 #: Retry interval for lock acquisition
-LOCK_RETRY_INTERVAL = int(os.getenv("LOCK_RETRY_INTERVAL", "5"))
+LOCK_RETRY_INTERVAL_SECONDS = int(os.getenv("LOCK_RETRY_INTERVAL_SECONDS", "60"))
 
 # MCP Configuration
 #: Flag to indicate if MCP should be enabled or not. Turning this to true will setup an MCP server along

--- a/application_sdk/interceptors/lock.py
+++ b/application_sdk/interceptors/lock.py
@@ -27,7 +27,7 @@ from application_sdk.constants import (
     APPLICATION_NAME,
     IS_LOCKING_DISABLED,
     LOCK_METADATA_KEY,
-    LOCK_RETRY_INTERVAL,
+    LOCK_RETRY_INTERVAL_SECONDS,
 )
 from application_sdk.observability.logger_adaptor import get_logger
 
@@ -119,7 +119,9 @@ class RedisLockOutboundInterceptor(WorkflowOutboundInterceptor):
                 args=[lock_name, max_locks, ttl_seconds, owner_id],
                 start_to_close_timeout=timedelta(seconds=30),
                 retry_policy=RetryPolicy(
-                    initial_interval=timedelta(seconds=int(LOCK_RETRY_INTERVAL)),
+                    initial_interval=timedelta(
+                        seconds=int(LOCK_RETRY_INTERVAL_SECONDS)
+                    ),
                     backoff_coefficient=1.0,
                 ),
                 schedule_to_close_timeout=schedule_to_close_timeout,


### PR DESCRIPTION


### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->

### Changelog


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Redis lock orchestration to non-local activities and renames the retry interval env var with a new default.
> 
> - **Temporal Lock Interceptor**:
>   - Replace `workflow.execute_local_activity` with `workflow.execute_activity` for `acquire_distributed_lock` and `release_distributed_lock` to avoid workflow deadlocks.
>   - Use `LOCK_RETRY_INTERVAL_SECONDS` in retry policy (`initial_interval`).
>   - Add docstring note clarifying use of regular activities for lock operations.
> - **Config Constants**:
>   - Rename `LOCK_RETRY_INTERVAL` -> `LOCK_RETRY_INTERVAL_SECONDS` (default `60`).
>   - Update imports/usages accordingly (`application_sdk/interceptors/lock.py`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bec2cfe8392263a43d871b5dabc96d70abf9235. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->