### PR TITLE
[Fix] s3 prefix issue while downloading from ObjectStore

### DIFF
--- a/application_sdk/activities/common/utils.py
+++ b/application_sdk/activities/common/utils.py
@@ -116,11 +116,11 @@ def get_object_store_prefix(path: str) -> str:
             return relative_path.replace(os.path.sep, "/")
         else:
             # Path is already a relative object store path, return as-is
-            return path.strip("/")
+            return path.lstrip("/")
     except ValueError:
         # os.path.commonpath or os.path.relpath can raise ValueError on Windows with different drives
         # In this case, treat as user-provided path, return as-is
-        return path.strip("/")
+        return path.lstrip("/")
 
 
 def auto_heartbeater(fn: F) -> F:


### PR DESCRIPTION
### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- _to be added_

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.


<!-- for any questions, reach out to us at connect@atlan.com -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace strip with lstrip in get_object_store_prefix to avoid trimming trailing slashes, fixing S3 prefix handling.
> 
> - **Utilities**:
>   - Update `get_object_store_prefix` in `application_sdk/activities/common/utils.py`:
>     - Use `path.lstrip("/")` instead of `path.strip("/")` for non-temp and exception paths to preserve trailing slashes in object store prefixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5890142dc8780c8a8ef800ab49d8f4a327640f96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->