### PR TITLE
fest!: use async DaprClient to prevent blocking heartbeats

### DIFF
--- a/application_sdk/clients/atlan_auth.py
+++ b/application_sdk/clients/atlan_auth.py
@@ -174,8 +174,8 @@ class AtlanAuthClient:
 
     async def _extract_auth_credentials(self) -> Optional[Dict[str, str]]:
         """Fetch app credentials from secret store - auth-specific logic"""
-        client_id = SecretStore.get_deployment_secret(WORKFLOW_AUTH_CLIENT_ID_KEY)
-        client_secret = SecretStore.get_deployment_secret(
+        client_id = await SecretStore.get_deployment_secret(WORKFLOW_AUTH_CLIENT_ID_KEY)
+        client_secret = await SecretStore.get_deployment_secret(
             WORKFLOW_AUTH_CLIENT_SECRET_KEY
         )
 

--- a/application_sdk/services/atlan_storage.py
+++ b/application_sdk/services/atlan_storage.py
@@ -11,7 +11,7 @@ detailed reporting through the MigrationSummary model.
 import asyncio
 from typing import Dict, List
 
-from dapr.clients import DaprClient
+from dapr.aio.clients import DaprClient
 from pydantic import BaseModel
 from temporalio import activity
 
@@ -55,9 +55,12 @@ class AtlanStorage:
     """Handles upload operations to Atlan storage and migration from objectstore."""
 
     OBJECT_CREATE_OPERATION = "create"
+    MAX_CONCURRENT_UPLOADS = 5
 
     @classmethod
-    async def _migrate_single_file(cls, file_path: str) -> tuple[str, bool, str]:
+    async def _migrate_single_file(
+        cls, file_path: str, client: DaprClient
+    ) -> tuple[str, bool, str]:
         """Migrate a single file from object store to Atlan storage.
 
         This internal method handles the migration of a single file, including
@@ -66,6 +69,7 @@ class AtlanStorage:
 
         Args:
             file_path (str): The path of the file to migrate in the object store.
+            client (DaprClient): The async Dapr client to use for the upload.
 
         Returns:
             tuple[str, bool, str]: A tuple containing:
@@ -84,21 +88,16 @@ class AtlanStorage:
                 file_path, store_name=DEPLOYMENT_OBJECT_STORE_NAME
             )
 
-            with DaprClient() as client:
-                metadata = {"key": file_path}
+            metadata = {"key": file_path}
 
-                client.invoke_binding(
-                    binding_name=UPSTREAM_OBJECT_STORE_NAME,
-                    operation=cls.OBJECT_CREATE_OPERATION,
-                    data=file_data,
-                    binding_metadata=metadata,
-                )
+            await client.invoke_binding(
+                binding_name=UPSTREAM_OBJECT_STORE_NAME,
+                operation=cls.OBJECT_CREATE_OPERATION,
+                data=file_data or "",
+                binding_metadata=metadata,
+            )
 
-                logger.debug(
-                    f"Successfully uploaded file to Atlan storage: {file_path}"
-                )
-
-            logger.debug(f"Successfully migrated: {file_path}")
+            logger.debug(f"Successfully migrated file to Atlan storage: {file_path}")
             return file_path, True, ""
         except Exception as e:
             error_msg = str(e)
@@ -168,22 +167,36 @@ class AtlanStorage:
                     destination=UPSTREAM_OBJECT_STORE_NAME,
                 )
 
-            # Create migration tasks for all files
-            migration_tasks = [
-                asyncio.create_task(cls._migrate_single_file(file_path))
-                for file_path in files_to_migrate
-            ]
+            # Use a single DaprClient connection for all migrations
+            async with DaprClient() as client:
+                # Limit concurrent uploads to avoid overwhelming the system
+                semaphore = asyncio.Semaphore(cls.MAX_CONCURRENT_UPLOADS)
 
-            # Execute all migrations in parallel
-            logger.info(f"Starting parallel migration of {total_files} files")
-            results = await asyncio.gather(*migration_tasks, return_exceptions=True)
+                async def migrate_with_limit(
+                    file_path: str,
+                ) -> tuple[str, bool, str]:
+                    async with semaphore:
+                        return await cls._migrate_single_file(file_path, client)
+
+                # Create migration tasks for all files
+                migration_tasks = [
+                    asyncio.create_task(migrate_with_limit(file_path))
+                    for file_path in files_to_migrate
+                ]
+
+                # Execute all migrations with concurrency limit
+                logger.info(
+                    f"Starting migration of {total_files} files "
+                    f"(max {cls.MAX_CONCURRENT_UPLOADS} concurrent)"
+                )
+                results = await asyncio.gather(*migration_tasks, return_exceptions=True)
 
             # Process results
             migrated_count = 0
             failed_migrations: List[Dict[str, str]] = []
 
             for result in results:
-                if isinstance(result, Exception):
+                if isinstance(result, BaseException):
                     # Handle unexpected exceptions
                     logger.error(f"Unexpected error during migration: {str(result)}")
                     failed_migrations.append({"file": "unknown", "error": str(result)})

--- a/application_sdk/services/eventstore.py
+++ b/application_sdk/services/eventstore.py
@@ -7,7 +7,7 @@ to a pub/sub system with automatic fallback to HTTP binding.
 import json
 from datetime import datetime
 
-from dapr import clients
+from dapr.aio.clients import DaprClient
 from temporalio import activity, workflow
 
 from application_sdk.common.dapr_utils import is_component_registered
@@ -154,8 +154,8 @@ class EventStore:
             auth_client = AtlanAuthClient()
             binding_metadata.update(await auth_client.get_authenticated_headers())
 
-            with clients.DaprClient() as client:
-                client.invoke_binding(
+            async with DaprClient() as client:
+                await client.invoke_binding(
                     binding_name=EVENT_STORE_NAME,
                     operation=DAPR_BINDING_OPERATION_CREATE,
                     data=payload,

--- a/application_sdk/services/objectstore.py
+++ b/application_sdk/services/objectstore.py
@@ -6,7 +6,7 @@ import shutil
 from typing import List, Union
 
 import orjson
-from dapr.clients import DaprClient
+from dapr.aio.clients import DaprClient
 from temporalio import activity
 
 from application_sdk.constants import (
@@ -520,8 +520,8 @@ class ObjectStore:
                 # Data is within limit, use default DAPR limit
                 max_message_length = DAPR_MAX_GRPC_MESSAGE_LENGTH
 
-            with DaprClient(max_grpc_message_length=max_message_length) as client:
-                response = client.invoke_binding(
+            async with DaprClient(max_grpc_message_length=max_message_length) as client:
+                response = await client.invoke_binding(
                     binding_name=store_name,
                     operation=operation,
                     data=data,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Global test configuration and fixtures."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -9,7 +9,7 @@ import pytest
 def mock_secret_store():
     """Automatically mock SecretStore.get_deployment_secret for all tests."""
 
-    def mock_get_deployment_secret(key: str):
+    async def mock_get_deployment_secret(key: str):
         """Default mock that returns None for all keys."""
         return None
 
@@ -24,16 +24,16 @@ def mock_secret_store():
 def mock_dapr_client():
     """Automatically mock DaprClient for all tests to prevent Dapr health check timeouts."""
     with patch(
-        "application_sdk.services.eventstore.clients.DaprClient",
+        "application_sdk.services.eventstore.DaprClient",
         autospec=True,
     ) as mock_dapr:
-        # Create a mock instance that can be used as a context manager
-        mock_instance = Mock()
-        mock_dapr.return_value.__enter__.return_value = mock_instance
-        mock_dapr.return_value.__exit__.return_value = None
+        # Create a mock instance that can be used as an async context manager
+        mock_instance = AsyncMock()
+        mock_dapr.return_value.__aenter__.return_value = mock_instance
+        mock_dapr.return_value.__aexit__.return_value = None
 
-        # Mock the publish_event method to avoid actual Dapr calls
-        mock_instance.publish_event = Mock()
-        mock_instance.invoke_binding = Mock()
+        # Mock the async methods to avoid actual Dapr calls
+        mock_instance.publish_event = AsyncMock()
+        mock_instance.invoke_binding = AsyncMock()
 
         yield mock_dapr

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,18 +22,33 @@ def mock_secret_store():
 
 @pytest.fixture(autouse=True)
 def mock_dapr_client():
-    """Automatically mock DaprClient for all tests to prevent Dapr health check timeouts."""
+    """Automatically mock all DaprClient usages for all tests to prevent Dapr health check timeouts."""
+    mock_async_client = AsyncMock()
+    mock_sync_client = Mock()
+    mock_sync_client.get_metadata.return_value = Mock(registered_components=[])
+    
     with patch(
-        "application_sdk.services.eventstore.DaprClient",
-        autospec=True,
-    ) as mock_dapr:
-        # Create a mock instance that can be used as an async context manager
-        mock_instance = AsyncMock()
-        mock_dapr.return_value.__aenter__.return_value = mock_instance
-        mock_dapr.return_value.__aexit__.return_value = None
-
-        # Mock the async methods to avoid actual Dapr calls
-        mock_instance.publish_event = AsyncMock()
-        mock_instance.invoke_binding = AsyncMock()
-
-        yield mock_dapr
+        "application_sdk.services.eventstore.is_component_registered", return_value=False
+    ), patch(
+        "application_sdk.services.eventstore.DaprClient"
+    ) as mock_evt_dapr, patch(
+        "application_sdk.services.objectstore.DaprClient"
+    ) as mock_obj_dapr, patch(
+        "application_sdk.services.atlan_storage.DaprClient"
+    ) as mock_atlan_dapr, patch(
+        "application_sdk.services.secretstore.DaprClient"
+    ) as mock_sec_dapr, patch(
+        "application_sdk.observability.observability.DaprClient"
+    ) as mock_obs_dapr, patch(
+        "application_sdk.common.dapr_utils.clients.DaprClient"
+    ) as mock_utils_dapr:
+        # Configure async DaprClients
+        for mock_dapr in [mock_evt_dapr, mock_obj_dapr, mock_atlan_dapr, mock_sec_dapr, mock_obs_dapr]:
+            mock_dapr.return_value.__aenter__.return_value = mock_async_client
+            mock_dapr.return_value.__aexit__.return_value = None
+        
+        # Configure sync DaprClient for dapr_utils
+        mock_utils_dapr.return_value.__enter__.return_value = mock_sync_client
+        mock_utils_dapr.return_value.__exit__.return_value = None
+        
+        yield mock_async_client

--- a/tests/unit/clients/test_atlan_auth.py
+++ b/tests/unit/clients/test_atlan_auth.py
@@ -1,7 +1,7 @@
 """Tests for the AtlanAuthClient class."""
 
 import time
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -12,7 +12,7 @@ from application_sdk.clients.atlan_auth import AtlanAuthClient
 async def auth_client() -> AtlanAuthClient:
     """Create an AtlanAuthClient instance for testing."""
 
-    def mock_get_deployment_secret(key: str):
+    async def mock_get_deployment_secret(key: str):
         """Mock get_deployment_secret to return values based on key."""
         mock_config = {
             "test_app_client_id": "test-client",
@@ -55,6 +55,7 @@ async def test_credential_discovery_failure(auth_client: AtlanAuthClient) -> Non
 
     with patch(
         "application_sdk.clients.atlan_auth.SecretStore.get_deployment_secret",
+        new_callable=AsyncMock,
         return_value=None,  # Empty config means no credentials
     ):
         credentials = await auth_client_no_fallback._extract_auth_credentials()

--- a/tests/unit/clients/test_atlanauth.py
+++ b/tests/unit/clients/test_atlanauth.py
@@ -1,7 +1,7 @@
 """Tests for the AtlanAuthClient class."""
 
 import time
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -12,7 +12,7 @@ from application_sdk.clients.atlan_auth import AtlanAuthClient
 async def auth_client() -> AtlanAuthClient:
     """Create an AtlanAuthClient instance for testing."""
 
-    def mock_get_deployment_secret(key: str):
+    async def mock_get_deployment_secret(key: str):
         mock_config = {
             "test_app_client_id": "test-client",
             "test_app_client_secret": "test-secret",
@@ -42,6 +42,7 @@ async def test_credential_discovery_failure(auth_client: AtlanAuthClient) -> Non
     # Create an auth client with empty config
     with patch(
         "application_sdk.clients.atlan_auth.SecretStore.get_deployment_secret",
+        new_callable=AsyncMock,
         return_value=None,  # Empty config means no credentials
     ):
         auth_client_no_fallback = AtlanAuthClient()

--- a/tests/unit/clients/test_temporal_client.py
+++ b/tests/unit/clients/test_temporal_client.py
@@ -18,7 +18,7 @@ class MockWorkflow(WorkflowInterface):
 def temporal_client() -> TemporalWorkflowClient:
     """Create a TemporalWorkflowClient instance for testing."""
 
-    def mock_get_deployment_secret(key: str):
+    async def mock_get_deployment_secret(key: str):
         # Return None for all keys by default (tests can override if needed)
         return None
 

--- a/tests/unit/outputs/test_output.py
+++ b/tests/unit/outputs/test_output.py
@@ -163,8 +163,8 @@ class TestOutput:
     @pytest.mark.asyncio
     async def test_write_statistics_error(self):
         """Test write_statistics error handling."""
-        with patch("pandas.DataFrame.to_json") as mock_to_json:
-            mock_to_json.side_effect = Exception("Test error")
+        with patch("orjson.dumps") as mock_orjson:
+            mock_orjson.side_effect = Exception("Test error")
 
             with patch("application_sdk.outputs.logger.error") as mock_logger:
                 result = await self.output.write_statistics()

--- a/tests/unit/services/test_objectstore.py
+++ b/tests/unit/services/test_objectstore.py
@@ -12,8 +12,8 @@ from application_sdk.services.objectstore import ObjectStore
 class TestObjectStore:
     @patch("application_sdk.services.objectstore.DaprClient")
     async def test_upload_file_success(self, mock_dapr_client: MagicMock) -> None:
-        mock_client = MagicMock()
-        mock_dapr_client.return_value.__enter__.return_value = mock_client
+        mock_client = AsyncMock()
+        mock_dapr_client.return_value.__aenter__.return_value = mock_client
 
         test_file_content = b"test content"
         m = mock_open(read_data=test_file_content)
@@ -33,8 +33,8 @@ class TestObjectStore:
 
     @patch("application_sdk.services.objectstore.DaprClient")
     async def test_upload_directory_success(self, mock_dapr_client: MagicMock) -> None:
-        mock_client = MagicMock()
-        mock_dapr_client.return_value.__enter__.return_value = mock_client
+        mock_client = AsyncMock()
+        mock_dapr_client.return_value.__aenter__.return_value = mock_client
 
         with patch("os.walk") as mock_walk, patch("os.path.isdir") as mock_isdir, patch(
             "os.path.exists", return_value=True
@@ -70,8 +70,8 @@ class TestObjectStore:
     @patch("application_sdk.services.objectstore.DaprClient")
     async def test_delete_file_success(self, mock_dapr_client: MagicMock) -> None:
         """Test successful deletion of a single file."""
-        mock_client = MagicMock()
-        mock_dapr_client.return_value.__enter__.return_value = mock_client
+        mock_client = AsyncMock()
+        mock_dapr_client.return_value.__aenter__.return_value = mock_client
 
         await ObjectStore.delete_file(key="test/file.txt")
 
@@ -89,9 +89,9 @@ class TestObjectStore:
     @patch("application_sdk.services.objectstore.DaprClient")
     async def test_delete_file_failure(self, mock_dapr_client: MagicMock) -> None:
         """Test delete file failure handling."""
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_client.invoke_binding.side_effect = Exception("Delete failed")
-        mock_dapr_client.return_value.__enter__.return_value = mock_client
+        mock_dapr_client.return_value.__aenter__.return_value = mock_client
 
         with pytest.raises(Exception, match="Delete failed"):
             await ObjectStore.delete_file(key="test/file.txt")
@@ -195,11 +195,11 @@ class TestObjectStore:
     @patch("application_sdk.services.objectstore.DaprClient")
     async def test_get_content_success(self, mock_dapr_client: MagicMock) -> None:
         """Test successful file content retrieval."""
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_response = MagicMock()
         mock_response.data = b"test file content"
         mock_client.invoke_binding.return_value = mock_response
-        mock_dapr_client.return_value.__enter__.return_value = mock_client
+        mock_dapr_client.return_value.__aenter__.return_value = mock_client
 
         result = await ObjectStore.get_content(key="test/file.txt")
 
@@ -220,9 +220,9 @@ class TestObjectStore:
         self, mock_dapr_client: MagicMock
     ) -> None:
         """Test get_content raises exception when file not found and suppress_error=False."""
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_client.invoke_binding.side_effect = Exception("File not found")
-        mock_dapr_client.return_value.__enter__.return_value = mock_client
+        mock_dapr_client.return_value.__aenter__.return_value = mock_client
 
         with pytest.raises(Exception, match="File not found"):
             await ObjectStore.get_content(
@@ -234,9 +234,9 @@ class TestObjectStore:
         self, mock_dapr_client: MagicMock
     ) -> None:
         """Test get_content returns None when file not found and suppress_error=True."""
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_client.invoke_binding.side_effect = Exception("File not found")
-        mock_dapr_client.return_value.__enter__.return_value = mock_client
+        mock_dapr_client.return_value.__aenter__.return_value = mock_client
 
         result = await ObjectStore.get_content(
             key="nonexistent/file.txt", suppress_error=True
@@ -249,11 +249,11 @@ class TestObjectStore:
         self, mock_dapr_client: MagicMock
     ) -> None:
         """Test get_content raises exception when no data returned and suppress_error=False."""
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_response = MagicMock()
         mock_response.data = None
         mock_client.invoke_binding.return_value = mock_response
-        mock_dapr_client.return_value.__enter__.return_value = mock_client
+        mock_dapr_client.return_value.__aenter__.return_value = mock_client
 
         with pytest.raises(Exception, match="No data received for file: test/file.txt"):
             await ObjectStore.get_content(key="test/file.txt", suppress_error=False)
@@ -263,11 +263,11 @@ class TestObjectStore:
         self, mock_dapr_client: MagicMock
     ) -> None:
         """Test get_content returns None when no data returned and suppress_error=True."""
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_response = MagicMock()
         mock_response.data = None
         mock_client.invoke_binding.return_value = mock_response
-        mock_dapr_client.return_value.__enter__.return_value = mock_client
+        mock_dapr_client.return_value.__aenter__.return_value = mock_client
 
         result = await ObjectStore.get_content(key="test/file.txt", suppress_error=True)
 
@@ -278,11 +278,11 @@ class TestObjectStore:
         self, mock_dapr_client: MagicMock
     ) -> None:
         """Test get_content raises exception when empty data returned and suppress_error=False."""
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_response = MagicMock()
         mock_response.data = b""
         mock_client.invoke_binding.return_value = mock_response
-        mock_dapr_client.return_value.__enter__.return_value = mock_client
+        mock_dapr_client.return_value.__aenter__.return_value = mock_client
 
         with pytest.raises(Exception, match="No data received for file: test/file.txt"):
             await ObjectStore.get_content(key="test/file.txt", suppress_error=False)
@@ -292,11 +292,11 @@ class TestObjectStore:
         self, mock_dapr_client: MagicMock
     ) -> None:
         """Test get_content returns None when empty data returned and suppress_error=True."""
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_response = MagicMock()
         mock_response.data = b""
         mock_client.invoke_binding.return_value = mock_response
-        mock_dapr_client.return_value.__enter__.return_value = mock_client
+        mock_dapr_client.return_value.__aenter__.return_value = mock_client
 
         result = await ObjectStore.get_content(key="test/file.txt", suppress_error=True)
 
@@ -309,11 +309,11 @@ class TestObjectStore:
     ) -> None:
         """Test that a warning is logged when data size exceeds DAPR_MAX_GRPC_MESSAGE_LENGTH."""
 
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_response = MagicMock()
         mock_response.data = b"response data"
         mock_client.invoke_binding.return_value = mock_response
-        mock_dapr_client.return_value.__enter__.return_value = mock_client
+        mock_dapr_client.return_value.__aenter__.return_value = mock_client
 
         # Create data that exceeds the DAPR limit
         large_data = b"x" * (DAPR_MAX_GRPC_MESSAGE_LENGTH + 1)
@@ -353,11 +353,11 @@ class TestObjectStore:
         """Test that no warning is logged when data size is within DAPR_MAX_GRPC_MESSAGE_LENGTH."""
         from application_sdk.constants import DAPR_MAX_GRPC_MESSAGE_LENGTH
 
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_response = MagicMock()
         mock_response.data = b"response data"
         mock_client.invoke_binding.return_value = mock_response
-        mock_dapr_client.return_value.__enter__.return_value = mock_client
+        mock_dapr_client.return_value.__aenter__.return_value = mock_client
 
         # Create data that is within the DAPR limit
         small_data = b"x" * (DAPR_MAX_GRPC_MESSAGE_LENGTH - 1000)
@@ -388,11 +388,11 @@ class TestObjectStore:
         """Test that string data is properly handled and size is calculated correctly."""
         from application_sdk.constants import DAPR_MAX_GRPC_MESSAGE_LENGTH
 
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_response = MagicMock()
         mock_response.data = b"response data"
         mock_client.invoke_binding.return_value = mock_response
-        mock_dapr_client.return_value.__enter__.return_value = mock_client
+        mock_dapr_client.return_value.__aenter__.return_value = mock_client
 
         # Create a string that when encoded exceeds the DAPR limit
         # Each character in UTF-8 is typically 1 byte, but we'll use a large string


### PR DESCRIPTION
### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- Use async DaprClient instead of the sync one. Currently we block event loop during any dapr invocation due it using the sync library 

- https://github.com/dapr/python-sdk/pull/553
- Everywhere in sdk I see us not using the async daprclient though it exists

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.