### PR TITLE
chore: make aiohttp an optional dependency for REST 

### DIFF
--- a/application_sdk/clients/atlan_auth.py
+++ b/application_sdk/clients/atlan_auth.py
@@ -1,11 +1,27 @@
 """OAuth2 token manager with automatic secret store discovery."""
 
 import time
-from typing import Dict, Optional
-
-import aiohttp
+from typing import TYPE_CHECKING, Dict, Optional
 
 from application_sdk.common.error_codes import ClientError
+
+if TYPE_CHECKING:
+    import aiohttp
+
+
+def _get_aiohttp() -> "aiohttp":
+    """Lazy import aiohttp with helpful error message."""
+    try:
+        import aiohttp
+
+        return aiohttp
+    except ImportError:
+        raise ImportError(
+            "aiohttp is required for REST authentication. "
+            "Install it with: pip install 'atlan-application-sdk[rest]'"
+        ) from None
+
+
 from application_sdk.constants import (
     APPLICATION_NAME,
     AUTH_ENABLED,
@@ -94,6 +110,7 @@ class AtlanAuthClient:
         # Refresh token
         logger.info("Refreshing OAuth2 token")
 
+        aiohttp = _get_aiohttp()
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 self.auth_url,

--- a/docs/docs/concepts/temporal_auth.md
+++ b/docs/docs/concepts/temporal_auth.md
@@ -194,19 +194,21 @@ await worker.run()
 
 ### Manual Token Management
 
+> **Note**: Manual token management with HTTP requests requires the `rest` extra:
+> `pip install 'atlan-application-sdk[rest]'`
+
 ```python
 from application_sdk.clients.atlan_auth import AtlanAuthClient
 
 # Create auth client directly
 # Credentials are automatically fetched from the configured secret store component
 auth_client = AtlanAuthClient()
-```
 
 # Get token for external API calls
 token = await auth_manager.get_access_token()
 headers = await auth_manager.get_authenticated_headers()
 
-# Use with HTTP requests
+# Use with HTTP requests (requires 'rest' extra: pip install 'atlan-application-sdk[rest]')
 async with aiohttp.ClientSession() as session:
     await session.get("https://api.company.com/data", headers=headers)
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
 ]
 keywords = ["atlan", "sdk", "platform", "app", "development"]
 dependencies = [
-    "aiohttp>=3.10.0,<3.14.0",
     "opentelemetry-exporter-otlp==1.39.1",
     "psutil>=7.0.0,<7.3.0",
     "fastapi[standard]==0.127.0",
@@ -40,6 +39,9 @@ Documentation = "https://github.com/atlanhq/application-sdk/README.md"
 
 # Optional dependencies for specific functionality - Install using: uv sync --extra workflows
 [project.optional-dependencies]
+rest = [
+    "aiohttp>=3.10.0,<3.14.0",
+]
 workflows = [
     "dapr==1.16.0",
     "temporalio>=1.7.1,<1.22.0",


### PR DESCRIPTION
Related: #771 

### Changelog
- Move aiohttp from main dependencies to optional 'rest' extra group
- Add lazy import with helpful error message in AtlanAuthClient
- Update documentation to indicate 'rest' extra requirement

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.