### PR TITLE
refactor: remove psutil from core dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v2.3.0
+
+Full Changelog: https://github.com/atlanhq/application-sdk/compare/v2.2.0...v2.3.0
+
+### Breaking Changes
+
+- **Removed `psutil` from core dependencies** (#773)
+  - The `/server/health` endpoint no longer returns the `ram` field
+  - `psutil` has been moved to the new `argo` optional dependency group
+  - Install with: `pip install atlan-application-sdk[argo]` if you need psutil functionality
+
+### Bug Fixes
+
+- Improved cross-platform compatibility for process termination in shutdown endpoint (#773)
+
+---
+
 ## v2.2.0 (January 14, 2026)
 
 Full Changelog: https://github.com/atlanhq/application-sdk/compare/v2.1.1...v2.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ keywords = ["atlan", "sdk", "platform", "app", "development"]
 dependencies = [
     "aiohttp>=3.10.0,<3.14.0",
     "opentelemetry-exporter-otlp==1.39.1",
-    "psutil>=7.0.0,<7.3.0",
     "fastapi[standard]==0.127.0",
     "pyatlan>=8.0.2,<8.5.0",
     "pydantic>=2.10.6,<2.13.0",
@@ -81,6 +80,10 @@ distributed_lock = [
 
 mcp = [
     "fastmcp>=2.12.3,<2.15.0",
+]
+
+argo = [
+    "psutil>=7.0.0,<7.3.0",
 ]
 
 # Development dependencies - Install using: uv sync --group dev


### PR DESCRIPTION
## Summary

Removes `psutil` from core dependencies and refactors healthcheck/shutdown functionality to use Python standard library, addressing the unnecessary dependency overhead.

## Changelog

- Removed `psutil` dependency from core `[project.dependencies]`
- Added new `argo` optional dependency group for psutil (`pip install atlan-application-sdk[argo]`)
- Removed `ram` field from `/server/health` endpoint response
- Replaced `psutil.Process()` with cross-platform `os.kill()`/`os._exit()` for process termination
- Added comprehensive tests for health and shutdown endpoints

## Breaking Changes

> [!WARNING]
> The `/server/health` endpoint no longer returns the `ram` field. If you need psutil functionality, install with `pip install atlan-application-sdk[argo]`.

## Additional context

- Closes #773
- Part of: Optimise dependencies and dependency groups initiative
- Cross-platform compatible (Windows/Unix)

## Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated (CHANGELOG.md)

---

## Copyleft License Compliance

- [x] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)? **No**
- [ ] If yes, have you modified the code in the context of this project? **N/A**
