### PR TITLE
feat(temporal): add custom_interceptors parameter to create_worker

### DIFF
--- a/application_sdk/clients/temporal.py
+++ b/application_sdk/clients/temporal.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, Sequence, Type
 from temporalio import activity, workflow
 from temporalio.client import Client, WorkflowExecutionStatus, WorkflowFailureError
 from temporalio.types import CallableType, ClassType
-from temporalio.worker import Worker
+from temporalio.worker import Interceptor, Worker
 from temporalio.worker.workflow_sandbox import (
     SandboxedWorkflowRunner,
     SandboxRestrictions,
@@ -358,6 +358,7 @@ class TemporalWorkflowClient(WorkflowClient):
         max_concurrent_activities: Optional[int] = MAX_CONCURRENT_ACTIVITIES,
         activity_executor: Optional[ThreadPoolExecutor] = None,
         auto_start_token_refresh: bool = True,
+        custom_interceptors: Sequence[Interceptor] = (),
     ) -> Worker:
         """Create a Temporal worker with automatic token refresh and graceful shutdown.
 
@@ -369,6 +370,8 @@ class TemporalWorkflowClient(WorkflowClient):
             activity_executor (ThreadPoolExecutor | None): Executor for running activities.
             auto_start_token_refresh (bool): Whether to automatically start token refresh.
                 Set to False if you've already started it via load().
+            custom_interceptors (Sequence[Interceptor]): Custom interceptors to append
+                after the SDK's built-in interceptors.
         Returns:
             Worker: The created worker instance.
 
@@ -442,7 +445,8 @@ class TemporalWorkflowClient(WorkflowClient):
                 EventInterceptor(),
                 CleanupInterceptor(),
                 RedisLockInterceptor(activities_dict),
-            ],
+            ]
+            + list(custom_interceptors),
         )
 
     async def get_workflow_run_status(


### PR DESCRIPTION
## Summary
- Add `custom_interceptors` parameter to `TemporalWorkflowClient.create_worker()` method
- Custom interceptors are appended after the SDK's built-in interceptors (CorrelationContextInterceptor, EventInterceptor, CleanupInterceptor, RedisLockInterceptor)
- Enables applications to inject custom Temporal interceptors without needing to override the client

## Test plan
- [x] Existing unit tests pass (`tests/unit/clients/test_temporal_client.py`)
- [x] Pre-commit checks pass (ruff, ruff-format, isort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive API change that only affects worker creation when the new optional parameter is used.
> 
> **Overview**
> `TemporalWorkflowClient.create_worker()` now accepts a `custom_interceptors` parameter and appends any provided interceptors after the SDK’s built-in ones when constructing the Temporal `Worker`.
> 
> Imports and docstrings were updated accordingly to type and document the new interceptor extension point.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 367280756db4f91853d9a2be98faeeb2d5a20925. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->