### PR TITLE
BLDX-469 feat(temporal): Temporal SDK initial connect does not retry on errors

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -146,6 +146,13 @@ GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS = int(
     os.getenv("ATLAN_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS", 12 * 60 * 60)  # 12 hours
 )
 
+#: Maximum number of retry attempts for initial Temporal connection (optional)
+#: This handles transient network errors during startup
+#: Default: 5 retries. Set to 0 to disable retries.
+WORKFLOW_CONNECTION_MAX_RETRIES: int = int(
+    os.getenv("ATLAN_WORKFLOW_CONNECTION_MAX_RETRIES", "5")
+)
+
 # SQL Client Constants
 #: Whether to use server-side cursors for SQL operations
 USE_SERVER_SIDE_CURSOR = bool(os.getenv("ATLAN_SQL_USE_SERVER_SIDE_CURSOR", "true"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ workflows = [
     "dapr==1.16.0",
     "temporalio>=1.7.1,<1.22.0",
     "orjson>=3.10.18,<3.12.0",
+    "tenacity>=8.0.0,<10.0.0",
 ]
 pandas = [
     "pandas>=2.2.3,<2.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -238,6 +238,7 @@ workflows = [
     { name = "dapr" },
     { name = "orjson" },
     { name = "temporalio" },
+    { name = "tenacity" },
 ]
 
 [package.dev-dependencies]
@@ -298,6 +299,7 @@ requires-dist = [
     { name = "redis", extras = ["hiredis"], marker = "extra == 'distributed-lock'", specifier = ">=5.2.0,<7.2.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'sqlalchemy'", specifier = ">=2.0.36,<2.1.0" },
     { name = "temporalio", marker = "extra == 'workflows'", specifier = ">=1.7.1,<1.22.0" },
+    { name = "tenacity", marker = "extra == 'workflows'", specifier = ">=8.0.0,<10.0.0" },
     { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.21.0,<0.23.0" },
 ]
 provides-extras = ["workflows", "pandas", "daft", "sqlalchemy", "iam-auth", "azure", "tests", "scale-data-generator", "distributed-lock", "mcp"]


### PR DESCRIPTION
## Summary
- Added exponential backoff retry logic to the Temporal SDK initial connection
- Fixes workflow failures caused by transient network errors during startup
- Configurable retry parameters via environment variables for production tuning

## Related
- Linear: BLDX-469
- Slack thread: https://atlanhq.slack.com/archives/C07NC6EN278/p1770043952453169?thread_ts=1769750850.920719&cid=C07NC6EN278