### PR TITLE
SEC-138: fix SQL template injection in query extraction

### DIFF
--- a/application_sdk/activities/common/__init__.py
+++ b/application_sdk/activities/common/__init__.py
@@ -1,0 +1,48 @@
+"""Common activities utilities and models.
+
+This module provides shared utilities and models for SDK activities,
+including SQL validation, structured configuration models, and helper functions.
+"""
+
+from application_sdk.activities.common.sql_models import (
+    Identifier,
+    MinerConfig,
+    RangeExpression,
+    SQLDialect,
+)
+from application_sdk.activities.common.sql_validation import (
+    SAFE_IDENTIFIER_PATTERN,
+    SAFE_PLACEHOLDER_PATTERN,
+    UNSAFE_SQL_FRAGMENT_PATTERN,
+    UNSAFE_TEMPLATE_PATTERN,
+    require_identifier_if_placeholder,
+    validate_custom_template,
+    validate_identifier,
+    validate_marker_value,
+    validate_numeric_value,
+    validate_placeholder,
+    validate_range_placeholders,
+    validate_sql_fragment,
+)
+
+__all__ = [
+    # SQL Models
+    "Identifier",
+    "MinerConfig",
+    "RangeExpression",
+    "SQLDialect",
+    # Validation patterns
+    "SAFE_IDENTIFIER_PATTERN",
+    "SAFE_PLACEHOLDER_PATTERN",
+    "UNSAFE_SQL_FRAGMENT_PATTERN",
+    "UNSAFE_TEMPLATE_PATTERN",
+    # Validation functions
+    "require_identifier_if_placeholder",
+    "validate_custom_template",
+    "validate_identifier",
+    "validate_marker_value",
+    "validate_numeric_value",
+    "validate_placeholder",
+    "validate_range_placeholders",
+    "validate_sql_fragment",
+]

--- a/application_sdk/activities/common/sql_models.py
+++ b/application_sdk/activities/common/sql_models.py
@@ -1,0 +1,427 @@
+"""Structured SQL models for secure query extraction.
+
+This module provides validated SQL configuration models that replace the
+vulnerable string-based MinerArgs approach. These models enforce strict
+validation to prevent SQL injection attacks.
+
+Classes:
+    SQLDialect: Supported SQL dialects for identifier quoting.
+    Identifier: Validated SQL identifier with dialect-specific rendering.
+    RangeExpression: Structured range filtering with custom template support.
+    MinerConfig: Complete structured configuration for SQL query mining.
+"""
+
+from __future__ import annotations
+
+import re
+import warnings
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Any, ClassVar, Dict, Optional, Tuple
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from application_sdk.activities.common.sql_validation import (
+    SAFE_IDENTIFIER_PATTERN,
+    SAFE_PLACEHOLDER_PATTERN,
+)
+
+
+class SQLDialect(str, Enum):
+    """Supported SQL dialects for identifier quoting.
+
+    Each dialect has specific quoting rules for identifiers:
+    - SNOWFLAKE, REDSHIFT, POSTGRES: Use double quotes ("identifier")
+    - BIGQUERY, MYSQL: Use backticks (`identifier`)
+    - GENERIC: No quoting (returns validated identifier as-is)
+    """
+
+    GENERIC = "generic"
+    SNOWFLAKE = "snowflake"
+    REDSHIFT = "redshift"
+    POSTGRES = "postgres"
+    BIGQUERY = "bigquery"
+    MYSQL = "mysql"
+
+
+class Identifier(BaseModel):
+    """Validated SQL identifier with dialect-specific rendering.
+
+    This class ensures SQL identifiers only contain safe characters and
+    provides proper quoting for different database dialects.
+
+    Attributes:
+        value: The identifier value (e.g., "ACCOUNT_USAGE", "query_history")
+    """
+
+    value: str = Field(..., description="The SQL identifier value")
+
+    model_config = ConfigDict(frozen=True)
+
+    @field_validator("value")
+    @classmethod
+    def validate_identifier_value(cls, v: str) -> str:
+        """Validate identifier against safe pattern."""
+        if not v or not v.strip():
+            raise ValueError("Identifier cannot be empty")
+        if not SAFE_IDENTIFIER_PATTERN.match(v):
+            raise ValueError(
+                f"Invalid identifier '{v}': must start with letter or underscore, "
+                "contain only alphanumeric characters, underscores, or dollar signs"
+            )
+        return v
+
+    def render(self, dialect: SQLDialect = SQLDialect.GENERIC) -> str:
+        """Render the identifier with dialect-specific quoting.
+
+        Args:
+            dialect: The SQL dialect for quoting rules.
+
+        Returns:
+            Quoted identifier string safe for SQL.
+        """
+        if dialect in (SQLDialect.MYSQL, SQLDialect.BIGQUERY):
+            return f"`{self.value}`"
+        elif dialect in (
+            SQLDialect.SNOWFLAKE,
+            SQLDialect.POSTGRES,
+            SQLDialect.REDSHIFT,
+        ):
+            return f'"{self.value}"'
+        else:
+            # Generic: return as-is (already validated)
+            return self.value
+
+    def __str__(self) -> str:
+        """Return unquoted value for string representation."""
+        return self.value
+
+
+# Pattern to detect unsafe SQL tokens in custom templates
+UNSAFE_TEMPLATE_PATTERN: re.Pattern[str] = re.compile(
+    r"(;|--|/\*|\*/|\bUNION\b|\bSELECT\b|\bINSERT\b|\bUPDATE\b|\bDELETE\b"
+    r"|\bDROP\b|\bCREATE\b|\bALTER\b|\bGRANT\b|\bTRUNCATE\b|\bEXEC\b)",
+    re.IGNORECASE,
+)
+
+
+class RangeExpression(BaseModel):
+    """Structured range filtering expression with custom template support.
+
+    This class replaces the vulnerable sql_replace_from/sql_replace_to pattern
+    with a structured approach that validates custom templates.
+
+    Attributes:
+        timestamp_column: The column used for time-based filtering.
+        start_placeholder: Placeholder string for range start.
+        end_placeholder: Placeholder string for range end.
+        custom_template: Optional custom SQL template for the range expression.
+    """
+
+    timestamp_column: Identifier = Field(
+        ..., description="Column for time-based filtering"
+    )
+    start_placeholder: str = Field(
+        default="[START_MARKER]", description="Placeholder for range start value"
+    )
+    end_placeholder: str = Field(
+        default="[END_MARKER]", description="Placeholder for range end value"
+    )
+    custom_template: Optional[str] = Field(
+        default=None, description="Custom SQL template for range expression"
+    )
+
+    model_config = ConfigDict(frozen=True)
+
+    @field_validator("start_placeholder", "end_placeholder")
+    @classmethod
+    def validate_placeholder(cls, v: str) -> str:
+        """Validate placeholder tokens."""
+        if not v or not v.strip():
+            raise ValueError("Placeholder cannot be empty")
+        if not SAFE_PLACEHOLDER_PATTERN.match(v):
+            raise ValueError(
+                f"Invalid placeholder '{v}': must match pattern [\\[\\]{{}}A-Za-z0-9_]+"
+            )
+        return v
+
+    @field_validator("custom_template")
+    @classmethod
+    def validate_custom_template_safety(cls, v: Optional[str]) -> Optional[str]:
+        """Validate custom template for unsafe SQL patterns."""
+        if v is None:
+            return v
+        if not v.strip():
+            raise ValueError("custom_template cannot be empty if provided")
+        if UNSAFE_TEMPLATE_PATTERN.search(v):
+            raise ValueError(
+                "custom_template contains unsafe SQL tokens. "
+                "Templates must not contain: ;, --, /*, */, "
+                "UNION, SELECT, INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, GRANT, "
+                "TRUNCATE, EXEC"
+            )
+        return v
+
+    @model_validator(mode="after")
+    def validate_template_placeholders(self) -> RangeExpression:
+        """Ensure custom template contains required placeholders."""
+        if self.custom_template is not None:
+            if self.start_placeholder not in self.custom_template:
+                raise ValueError(
+                    f"custom_template must contain start_placeholder "
+                    f"'{self.start_placeholder}'"
+                )
+            if self.end_placeholder not in self.custom_template:
+                raise ValueError(
+                    f"custom_template must contain end_placeholder "
+                    f"'{self.end_placeholder}'"
+                )
+        return self
+
+    def render(
+        self, dialect: SQLDialect, start: int, end: int
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Render the range expression with values.
+
+        Args:
+            dialect: SQL dialect for identifier quoting.
+            start: Start timestamp value (must be non-negative integer).
+            end: End timestamp value (must be non-negative integer).
+
+        Returns:
+            Tuple of (SQL fragment string, empty dict for compatibility).
+
+        Raises:
+            ValueError: If start or end is not a non-negative integer.
+
+        Note:
+            Values are validated as numeric and directly substituted.
+            The SQL client doesn't support parameterized queries, so we
+            rely on strict numeric validation instead.
+        """
+        # Validate numeric values
+        if not isinstance(start, int) or start < 0:
+            raise ValueError(f"start must be a non-negative integer, got {start}")
+        if not isinstance(end, int) or end < 0:
+            raise ValueError(f"end must be a non-negative integer, got {end}")
+
+        col = str(self.timestamp_column)
+
+        if self.custom_template:
+            # Use custom template with placeholder replacement
+            sql = self.custom_template.replace("{column}", col)
+            sql = sql.replace(self.start_placeholder, str(start))
+            sql = sql.replace(self.end_placeholder, str(end))
+        else:
+            # Default BETWEEN expression
+            sql = f"{col} >= {start} AND {col} <= {end}"
+
+        return sql, {}
+
+    def render_template_only(self, dialect: SQLDialect) -> str:
+        """Render template with placeholders intact (for chunking logic).
+
+        Args:
+            dialect: SQL dialect for identifier quoting.
+
+        Returns:
+            SQL template string with placeholders preserved.
+        """
+        col = str(self.timestamp_column)
+
+        if self.custom_template:
+            return self.custom_template.replace("{column}", col)
+        else:
+            return (
+                f"{col} >= {self.start_placeholder} AND {col} <= {self.end_placeholder}"
+            )
+
+
+class MinerConfig(BaseModel):
+    """Structured configuration for SQL query mining operations.
+
+    This class replaces the vulnerable MinerArgs model with a structured
+    approach that eliminates SQL injection risks.
+
+    Attributes:
+        database: Optional database identifier.
+        schema_name: Optional schema identifier.
+        timestamp_column: Column for time-based filtering.
+        range_expression: Structured range filtering.
+        chunk_size: Records per processing chunk.
+        current_marker: Current timestamp marker position.
+        miner_start_time_epoch: Mining start time (epoch seconds).
+    """
+
+    database: Optional[Identifier] = Field(
+        default=None, description="Target database identifier"
+    )
+    schema_name: Optional[Identifier] = Field(
+        default=None, description="Target schema identifier"
+    )
+    timestamp_column: Identifier = Field(
+        ..., description="Column containing timestamps for ordering"
+    )
+    range_expression: RangeExpression = Field(
+        ..., description="Structured range filtering expression"
+    )
+    chunk_size: int = Field(
+        default=5000, gt=0, description="Number of records per chunk"
+    )
+    current_marker: int = Field(
+        default=0, ge=0, description="Current timestamp marker for processing"
+    )
+    miner_start_time_epoch: int = Field(
+        default_factory=lambda: int((datetime.now() - timedelta(days=14)).timestamp()),
+        ge=0,
+        description="Mining start time in epoch seconds",
+    )
+    # Legacy field for backward compatibility with templates using {sql_replace_from}
+    sql_replace_from: Optional[str] = Field(
+        default=None,
+        description="Legacy: Original SQL fragment to be replaced (for backward compatibility)",
+    )
+
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+
+    # Class variable for default epoch calculation
+    _DEFAULT_DAYS_BACK: ClassVar[int] = 14
+
+    @classmethod
+    def from_legacy_miner_args(
+        cls, miner_args: Dict[str, Any], emit_warning: bool = True
+    ) -> MinerConfig:
+        """Create MinerConfig from legacy MinerArgs dictionary.
+
+        This adapter enables backward compatibility during migration.
+
+        Args:
+            miner_args: Legacy miner_args dictionary.
+            emit_warning: Whether to emit deprecation warning.
+
+        Returns:
+            New MinerConfig instance.
+
+        Raises:
+            ValueError: If legacy args cannot be converted.
+        """
+        if emit_warning:
+            warnings.warn(
+                "Legacy miner_args format is deprecated. "
+                "Please migrate to MinerConfig for improved security.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        # Extract identifiers
+        database = None
+        if miner_args.get("database_name_cleaned"):
+            database = Identifier(value=miner_args["database_name_cleaned"])
+
+        schema_name = None
+        if miner_args.get("schema_name_cleaned"):
+            schema_name = Identifier(value=miner_args["schema_name_cleaned"])
+
+        timestamp_col = Identifier(value=miner_args["timestamp_column"])
+
+        # Build RangeExpression from sql_replace_* fields
+        range_expr = cls._build_range_expression(miner_args, timestamp_col)
+
+        return cls(
+            database=database,
+            schema_name=schema_name,
+            timestamp_column=timestamp_col,
+            range_expression=range_expr,
+            chunk_size=miner_args.get("chunk_size", 5000),
+            current_marker=miner_args.get("current_marker", 0),
+            miner_start_time_epoch=miner_args.get(
+                "miner_start_time_epoch",
+                int(
+                    (
+                        datetime.now() - timedelta(days=cls._DEFAULT_DAYS_BACK)
+                    ).timestamp()
+                ),
+            ),
+            sql_replace_from=miner_args.get("sql_replace_from"),
+        )
+
+    @classmethod
+    def _build_range_expression(
+        cls, miner_args: Dict[str, Any], timestamp_col: Identifier
+    ) -> RangeExpression:
+        """Build RangeExpression from legacy sql_replace_* fields."""
+        sql_replace_to = miner_args.get("sql_replace_to", "")
+        start_key = miner_args.get("ranged_sql_start_key", "[START_MARKER]")
+        end_key = miner_args.get("ranged_sql_end_key", "[END_MARKER]")
+
+        if sql_replace_to:
+            # Use sql_replace_to as custom template
+            return RangeExpression(
+                timestamp_column=timestamp_col,
+                start_placeholder=start_key,
+                end_placeholder=end_key,
+                custom_template=sql_replace_to,
+            )
+        else:
+            # Default range expression
+            return RangeExpression(
+                timestamp_column=timestamp_col,
+                start_placeholder=start_key,
+                end_placeholder=end_key,
+            )
+
+    def format_query(
+        self,
+        template: str,
+        dialect: SQLDialect,
+        start_marker: Optional[int] = None,
+        end_marker: Optional[int] = None,
+    ) -> str:
+        """Format a SQL template with validated values.
+
+        Args:
+            template: SQL template with placeholders.
+            dialect: SQL dialect for quoting.
+            start_marker: Range start value (if using ranges).
+            end_marker: Range end value (if using ranges).
+
+        Returns:
+            Formatted SQL string.
+        """
+        # Build format arguments
+        format_args: Dict[str, Any] = {
+            "miner_start_time_epoch": self.miner_start_time_epoch,
+            "chunk_size": self.chunk_size,
+            "current_marker": self.current_marker,
+            "timestamp_column": str(self.timestamp_column),
+        }
+
+        if self.database:
+            format_args["database_name_cleaned"] = str(self.database)
+        if self.schema_name:
+            format_args["schema_name_cleaned"] = str(self.schema_name)
+
+        # For legacy templates that use {sql_replace_from} and {sql_replace_to}
+        sql_replace_to = self.range_expression.custom_template or ""
+        if self.sql_replace_from:
+            format_args["sql_replace_from"] = self.sql_replace_from
+            format_args["sql_replace_to"] = sql_replace_to
+
+        # Format the base template
+        result = template.format(**format_args)
+
+        # Legacy: Replace sql_replace_from with sql_replace_to (custom_template)
+        if self.sql_replace_from and sql_replace_to:
+            result = result.replace(self.sql_replace_from, sql_replace_to)
+
+        # Handle range expression if markers provided
+        if start_marker is not None and end_marker is not None:
+            # Replace the placeholders with actual values
+            result = result.replace(
+                self.range_expression.start_placeholder, str(start_marker)
+            )
+            result = result.replace(
+                self.range_expression.end_placeholder, str(end_marker)
+            )
+
+        return result

--- a/application_sdk/activities/common/sql_validation.py
+++ b/application_sdk/activities/common/sql_validation.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+SAFE_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
+SAFE_PLACEHOLDER_PATTERN = re.compile(r"^[\[\]{}A-Za-z0-9_]+$")
+UNSAFE_SQL_FRAGMENT_PATTERN = re.compile(r"(;|--|/\*|\*/)")
+
+
+def validate_identifier(
+    value: Optional[str], field_name: str, *, allow_empty: bool = False
+) -> Optional[str]:
+    """Validate SQL identifiers only contain safe characters."""
+    if value is None or value == "":
+        if allow_empty:
+            return value
+        raise ValueError(f"{field_name} is required")
+    if not SAFE_IDENTIFIER_PATTERN.match(value):
+        raise ValueError(f"Invalid {field_name} value: {value}")
+    return value
+
+
+def validate_sql_fragment(value: str, field_name: str) -> str:
+    """Reject SQL fragments containing unsafe tokens."""
+    if not value or not value.strip():
+        raise ValueError(f"{field_name} cannot be empty")
+    if UNSAFE_SQL_FRAGMENT_PATTERN.search(value):
+        raise ValueError(f"{field_name} contains unsafe SQL tokens")
+    return value
+
+
+def validate_placeholder(value: str, field_name: str) -> str:
+    """Validate placeholder tokens used for ranged SQL replacements."""
+    if not SAFE_PLACEHOLDER_PATTERN.match(value):
+        raise ValueError(f"Invalid {field_name} value: {value}")
+    return value
+
+
+def validate_marker_value(value: object, field_name: str) -> str:
+    """Validate that marker values are numeric strings."""
+    if value is None:
+        raise ValueError(f"{field_name} is required")
+    marker_value = str(value)
+    if not marker_value.isdigit():
+        raise ValueError(f"{field_name} must be a numeric value")
+    return marker_value
+
+
+def require_identifier_if_placeholder(
+    template: str, placeholder: str, value: Optional[str]
+) -> None:
+    """Validate identifier only if its placeholder appears in the template."""
+    if f"{{{placeholder}}}" not in template:
+        return
+    validate_identifier(value, placeholder, allow_empty=False)
+
+
+def validate_range_placeholders(
+    template: str,
+    sql_replace_from: str,
+    sql_replace_to: str,
+    ranged_sql_start_key: str,
+    ranged_sql_end_key: str,
+) -> None:
+    """Ensure sql_replace_to includes both range placeholders when used."""
+    uses_replace = "{sql_replace_from}" in template or (
+        sql_replace_from and sql_replace_from in template
+    )
+    if uses_replace:
+        if ranged_sql_start_key not in sql_replace_to:
+            raise ValueError("sql_replace_to must include ranged_sql_start_key")
+        if ranged_sql_end_key not in sql_replace_to:
+            raise ValueError("sql_replace_to must include ranged_sql_end_key")

--- a/application_sdk/activities/common/sql_validation.py
+++ b/application_sdk/activities/common/sql_validation.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 import re
-from typing import Optional
+from typing import Any, Optional
 
 SAFE_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
 SAFE_PLACEHOLDER_PATTERN = re.compile(r"^[\[\]{}A-Za-z0-9_]+$")
 UNSAFE_SQL_FRAGMENT_PATTERN = re.compile(r"(;|--|/\*|\*/)")
+
+# Extended pattern for custom templates - blocks DDL/DML keywords
+UNSAFE_TEMPLATE_PATTERN = re.compile(
+    r"(;|--|/\*|\*/|\bUNION\b|\bSELECT\b|\bINSERT\b|\bUPDATE\b|\bDELETE\b"
+    r"|\bDROP\b|\bCREATE\b|\bALTER\b|\bGRANT\b|\bTRUNCATE\b|\bEXEC\b)",
+    re.IGNORECASE,
+)
 
 
 def validate_identifier(
@@ -72,3 +79,72 @@ def validate_range_placeholders(
             raise ValueError("sql_replace_to must include ranged_sql_start_key")
         if ranged_sql_end_key not in sql_replace_to:
             raise ValueError("sql_replace_to must include ranged_sql_end_key")
+
+
+def validate_numeric_value(value: Any, field_name: str) -> int:
+    """Validate that a value is a non-negative integer.
+
+    Args:
+        value: Value to validate.
+        field_name: Name for error messages.
+
+    Returns:
+        Validated integer value.
+
+    Raises:
+        ValueError: If value is not a non-negative integer.
+    """
+    if value is None:
+        raise ValueError(f"{field_name} is required")
+    try:
+        result = int(str(value).strip())
+        if result < 0:
+            raise ValueError(f"{field_name} must be non-negative, got {result}")
+        return result
+    except (ValueError, TypeError) as e:
+        raise ValueError(f"{field_name} must be a numeric value, got: {value}") from e
+
+
+def validate_custom_template(
+    template: str,
+    start_placeholder: str,
+    end_placeholder: str,
+    field_name: str = "custom_template",
+) -> str:
+    """Validate a custom SQL template for safety.
+
+    Args:
+        template: The SQL template to validate.
+        start_placeholder: Required start placeholder.
+        end_placeholder: Required end placeholder.
+        field_name: Name for error messages.
+
+    Returns:
+        Validated template string.
+
+    Raises:
+        ValueError: If template is invalid or unsafe.
+    """
+    if not template or not template.strip():
+        raise ValueError(f"{field_name} cannot be empty")
+
+    # Check for unsafe SQL tokens
+    if UNSAFE_TEMPLATE_PATTERN.search(template):
+        raise ValueError(
+            f"{field_name} contains unsafe SQL tokens. "
+            "Templates must not contain: ;, --, /*, */, "
+            "UNION, SELECT, INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, GRANT, "
+            "TRUNCATE, EXEC"
+        )
+
+    # Check for required placeholders
+    if start_placeholder not in template:
+        raise ValueError(
+            f"{field_name} must contain start placeholder '{start_placeholder}'"
+        )
+    if end_placeholder not in template:
+        raise ValueError(
+            f"{field_name} must contain end placeholder '{end_placeholder}'"
+        )
+
+    return template

--- a/application_sdk/activities/query_extraction/sql.py
+++ b/application_sdk/activities/query_extraction/sql.py
@@ -1,9 +1,10 @@
 import json
 import os
+import re
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Type
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
 from temporalio import activity
 
 from application_sdk.activities import ActivitiesInterface, ActivitiesState
@@ -26,6 +27,10 @@ from application_sdk.transformers.atlas import AtlasTransformer
 
 logger = get_logger(__name__)
 
+SAFE_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
+SAFE_PLACEHOLDER_PATTERN = re.compile(r"^[\[\]{}A-Za-z0-9_]+$")
+UNSAFE_SQL_FRAGMENT_PATTERN = re.compile(r"(;|--|/\*|\*/)")
+
 
 class MinerArgs(BaseModel):
     """Arguments for SQL query mining operations.
@@ -47,8 +52,8 @@ class MinerArgs(BaseModel):
             Defaults to 14 days ago.
     """
 
-    database_name_cleaned: str
-    schema_name_cleaned: str
+    database_name_cleaned: Optional[str] = None
+    schema_name_cleaned: Optional[str] = None
     timestamp_column: str
     chunk_size: int
     current_marker: int
@@ -59,6 +64,60 @@ class MinerArgs(BaseModel):
     miner_start_time_epoch: int = Field(
         default_factory=lambda: int((datetime.now() - timedelta(days=14)).timestamp())
     )
+
+    @field_validator("database_name_cleaned", "schema_name_cleaned")
+    @classmethod
+    def _validate_optional_identifier(
+        cls, value: Optional[str], info: ValidationInfo
+    ) -> Optional[str]:
+        """Validate that SQL identifiers only contain safe characters."""
+        if value is None or value == "":
+            return value
+        if not SAFE_IDENTIFIER_PATTERN.match(value):
+            raise ValueError(f"Invalid {info.field_name} value: {value}")
+        return value
+
+    @field_validator("timestamp_column")
+    @classmethod
+    def _validate_timestamp_column(cls, value: str, info: ValidationInfo) -> str:
+        """Validate timestamp column identifier."""
+        if not SAFE_IDENTIFIER_PATTERN.match(value):
+            raise ValueError(f"Invalid {info.field_name} value: {value}")
+        return value
+
+    @field_validator("sql_replace_from", "sql_replace_to")
+    @classmethod
+    def _validate_sql_fragment(cls, value: str, info: ValidationInfo) -> str:
+        """Reject SQL fragments containing unsafe tokens."""
+        if not value or not value.strip():
+            raise ValueError(f"{info.field_name} cannot be empty")
+        if UNSAFE_SQL_FRAGMENT_PATTERN.search(value):
+            raise ValueError(f"{info.field_name} contains unsafe SQL tokens")
+        return value
+
+    @field_validator("ranged_sql_start_key", "ranged_sql_end_key")
+    @classmethod
+    def _validate_placeholder(cls, value: str, info: ValidationInfo) -> str:
+        """Validate placeholder tokens used for ranged SQL replacements."""
+        if not SAFE_PLACEHOLDER_PATTERN.match(value):
+            raise ValueError(f"Invalid {info.field_name} value: {value}")
+        return value
+
+    @field_validator("chunk_size")
+    @classmethod
+    def _validate_chunk_size(cls, value: int) -> int:
+        """Ensure chunk_size is positive."""
+        if value <= 0:
+            raise ValueError("chunk_size must be greater than 0")
+        return value
+
+    @field_validator("current_marker", "miner_start_time_epoch")
+    @classmethod
+    def _validate_non_negative(cls, value: int, info: ValidationInfo) -> int:
+        """Ensure marker values are non-negative integers."""
+        if value < 0:
+            raise ValueError(f"{info.field_name} must be non-negative")
+        return value
 
 
 class BaseSQLQueryExtractionActivitiesState(ActivitiesState):
@@ -153,6 +212,15 @@ class SQLQueryExtractionActivities(ActivitiesInterface):
             workflow_args (Dict[str, Any]): The workflow arguments.
         """
         miner_args = MinerArgs(**workflow_args.get("miner_args", {}))
+        self._validate_required_identifiers(query, miner_args)
+        start_marker = self._validate_marker_value(
+            workflow_args.get("start_marker"), "start_marker"
+        )
+        end_marker = self._validate_marker_value(
+            workflow_args.get("end_marker"), "end_marker"
+        )
+        self._validate_range_placeholders(query, miner_args)
+
         temp_query = query.format(
             miner_start_time_epoch=miner_args.miner_start_time_epoch,
             database_name_cleaned=miner_args.database_name_cleaned,
@@ -168,13 +236,46 @@ class SQLQueryExtractionActivities(ActivitiesInterface):
             miner_args.sql_replace_from, miner_args.sql_replace_to
         )
 
-        temp_query = temp_query.replace(
-            miner_args.ranged_sql_start_key, workflow_args["start_marker"]
-        )
-        temp_query = temp_query.replace(
-            miner_args.ranged_sql_end_key, workflow_args["end_marker"]
-        )
+        temp_query = temp_query.replace(miner_args.ranged_sql_start_key, start_marker)
+        temp_query = temp_query.replace(miner_args.ranged_sql_end_key, end_marker)
         return temp_query
+
+    def _validate_marker_value(self, value: Any, field_name: str) -> str:
+        """Validate that marker values are numeric strings."""
+        if value is None:
+            raise ValueError(f"{field_name} is required")
+        marker_value = str(value)
+        if not marker_value.isdigit():
+            raise ValueError(f"{field_name} must be a numeric value")
+        return marker_value
+
+    def _validate_range_placeholders(self, query: str, miner_args: MinerArgs) -> None:
+        """Ensure sql_replace_to includes both range placeholders when replacement is used."""
+        if miner_args.sql_replace_from and miner_args.sql_replace_from in query:
+            if miner_args.ranged_sql_start_key not in miner_args.sql_replace_to:
+                raise ValueError("sql_replace_to must include ranged_sql_start_key")
+            if miner_args.ranged_sql_end_key not in miner_args.sql_replace_to:
+                raise ValueError("sql_replace_to must include ranged_sql_end_key")
+
+    def _validate_required_identifiers(self, query: str, miner_args: MinerArgs) -> None:
+        """Validate identifiers only if their placeholders are present in the query."""
+        self._require_identifier(
+            query, "database_name_cleaned", miner_args.database_name_cleaned
+        )
+        self._require_identifier(
+            query, "schema_name_cleaned", miner_args.schema_name_cleaned
+        )
+        self._require_identifier(query, "timestamp_column", miner_args.timestamp_column)
+
+    def _require_identifier(
+        self, query: str, placeholder: str, value: Optional[str]
+    ) -> None:
+        if f"{{{placeholder}}}" not in query:
+            return
+        if value is None or value == "":
+            raise ValueError(f"{placeholder} is required for query formatting")
+        if not SAFE_IDENTIFIER_PATTERN.match(value):
+            raise ValueError(f"Invalid {placeholder} value: {value}")
 
     @activity.defn
     @auto_heartbeater
@@ -488,6 +589,8 @@ class SQLQueryExtractionActivities(ActivitiesInterface):
         sql_client = state.sql_client
 
         miner_args = MinerArgs(**workflow_args.get("miner_args", {}))
+        self._validate_required_identifiers(self.fetch_queries_sql, miner_args)
+        self._validate_range_placeholders(self.fetch_queries_sql, miner_args)
 
         current_marker = await self.read_marker(workflow_args)
         if current_marker:

--- a/application_sdk/activities/query_extraction/sql.py
+++ b/application_sdk/activities/query_extraction/sql.py
@@ -7,10 +7,11 @@ from pydantic import BaseModel, Field, ValidationInfo, field_validator
 from temporalio import activity
 
 from application_sdk.activities import ActivitiesInterface, ActivitiesState
+from application_sdk.activities.common.sql_models import MinerConfig, SQLDialect
 from application_sdk.activities.common.sql_validation import (
     require_identifier_if_placeholder,
     validate_identifier,
-    validate_marker_value,
+    validate_numeric_value,
     validate_placeholder,
     validate_range_placeholders,
     validate_sql_fragment,
@@ -202,61 +203,110 @@ class SQLQueryExtractionActivities(ActivitiesInterface):
     def get_formatted_query(self, query: str, workflow_args: Dict[str, Any]) -> str:
         """Formats the query with the workflow arguments.
 
+        Supports both the new MinerConfig format and the legacy MinerArgs format.
+        When using MinerConfig, the query is formatted using validated identifiers
+        and structured range expressions for improved security.
+
         Args:
-            query (str): The query to format.
-            workflow_args (Dict[str, Any]): The workflow arguments.
+            query (str): The query template to format.
+            workflow_args (Dict[str, Any]): The workflow arguments containing either:
+                - "miner_config": New MinerConfig object or dict (preferred)
+                - "miner_args": Legacy dictionary format (deprecated)
+
+        Returns:
+            str: The formatted SQL query string.
         """
-        miner_args = MinerArgs(**workflow_args.get("miner_args", {}))
-        require_identifier_if_placeholder(
-            query, "database_name_cleaned", miner_args.database_name_cleaned
-        )
-        require_identifier_if_placeholder(
-            query, "schema_name_cleaned", miner_args.schema_name_cleaned
-        )
-        require_identifier_if_placeholder(
-            query, "timestamp_column", miner_args.timestamp_column
-        )
-        validate_range_placeholders(
-            query,
-            miner_args.sql_replace_from,
-            miner_args.sql_replace_to,
-            miner_args.ranged_sql_start_key,
-            miner_args.ranged_sql_end_key,
-        )
-        start_marker: Optional[str] = None
-        end_marker: Optional[str] = None
-        uses_replace = "{sql_replace_from}" in query or (
-            miner_args.sql_replace_from and miner_args.sql_replace_from in query
-        )
-        if uses_replace:
-            start_marker = validate_marker_value(
-                workflow_args.get("start_marker"), "start_marker"
+        # Check for new MinerConfig format first
+        if "miner_config" in workflow_args:
+            config = workflow_args["miner_config"]
+            if isinstance(config, dict):
+                config = MinerConfig(**config)
+            return self._format_with_miner_config(query, config, workflow_args)
+
+        # Fall back to legacy MinerArgs format
+        return self._format_with_legacy_args(query, workflow_args)
+
+    def _format_with_miner_config(
+        self,
+        query: str,
+        config: MinerConfig,
+        workflow_args: Dict[str, Any],
+    ) -> str:
+        """Format query using the new MinerConfig model.
+
+        Args:
+            query: The query template to format.
+            config: The MinerConfig instance.
+            workflow_args: The workflow arguments.
+
+        Returns:
+            The formatted SQL query string.
+        """
+        dialect = self._detect_dialect()
+
+        # Validate and extract markers if present
+        start_marker: Optional[int] = None
+        end_marker: Optional[int] = None
+
+        if workflow_args.get("start_marker") is not None:
+            start_marker = validate_numeric_value(
+                workflow_args["start_marker"], "start_marker"
             )
-            end_marker = validate_marker_value(
-                workflow_args.get("end_marker"), "end_marker"
+        if workflow_args.get("end_marker") is not None:
+            end_marker = validate_numeric_value(
+                workflow_args["end_marker"], "end_marker"
             )
 
-        temp_query = query.format(
-            miner_start_time_epoch=miner_args.miner_start_time_epoch,
-            database_name_cleaned=miner_args.database_name_cleaned,
-            schema_name_cleaned=miner_args.schema_name_cleaned,
-            timestamp_column=miner_args.timestamp_column,
-            chunk_size=miner_args.chunk_size,
-            current_marker=miner_args.current_marker,
-            sql_replace_from=miner_args.sql_replace_from,
-            sql_replace_to=miner_args.sql_replace_to,
+        return config.format_query(
+            template=query,
+            dialect=dialect,
+            start_marker=start_marker,
+            end_marker=end_marker,
         )
 
-        temp_query = temp_query.replace(
-            miner_args.sql_replace_from, miner_args.sql_replace_to
-        )
+    def _format_with_legacy_args(
+        self, query: str, workflow_args: Dict[str, Any]
+    ) -> str:
+        """Format query using legacy MinerArgs (backward compatibility).
 
-        if start_marker is not None and end_marker is not None:
-            temp_query = temp_query.replace(
-                miner_args.ranged_sql_start_key, start_marker
-            )
-            temp_query = temp_query.replace(miner_args.ranged_sql_end_key, end_marker)
-        return temp_query
+        This method emits a deprecation warning and converts the legacy
+        format to the new MinerConfig internally.
+
+        Args:
+            query: The query template to format.
+            workflow_args: The workflow arguments with miner_args.
+
+        Returns:
+            The formatted SQL query string.
+        """
+        miner_args_dict = workflow_args.get("miner_args", {})
+
+        # Convert to MinerConfig (emits deprecation warning)
+        config = MinerConfig.from_legacy_miner_args(miner_args_dict)
+
+        return self._format_with_miner_config(query, config, workflow_args)
+
+    def _detect_dialect(self) -> SQLDialect:
+        """Detect SQL dialect from the client class.
+
+        Returns:
+            The detected SQLDialect, defaulting to GENERIC.
+        """
+        # Try to detect from client class name
+        client_class_name = self.sql_client_class.__name__.lower()
+
+        if "redshift" in client_class_name:
+            return SQLDialect.REDSHIFT
+        elif "snowflake" in client_class_name:
+            return SQLDialect.SNOWFLAKE
+        elif "postgres" in client_class_name or "pg" in client_class_name:
+            return SQLDialect.POSTGRES
+        elif "bigquery" in client_class_name or "bq" in client_class_name:
+            return SQLDialect.BIGQUERY
+        elif "mysql" in client_class_name:
+            return SQLDialect.MYSQL
+
+        return SQLDialect.GENERIC
 
     @activity.defn
     @auto_heartbeater

--- a/tests/unit/activities/common/test_sql_injection_security.py
+++ b/tests/unit/activities/common/test_sql_injection_security.py
@@ -1,0 +1,328 @@
+"""Security tests for SQL injection prevention.
+
+These tests verify that the structured SQL models properly block
+all known SQL injection attack patterns.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from application_sdk.activities.common.sql_models import (
+    Identifier,
+    MinerConfig,
+    RangeExpression,
+    SQLDialect,
+)
+
+
+class TestIdentifierSQLInjection:
+    """Security tests for Identifier SQL injection prevention."""
+
+    @pytest.mark.parametrize(
+        "malicious_input",
+        [
+            # Statement terminators
+            "users; DROP TABLE users;",
+            "schema; DELETE FROM secrets;",
+            "table;--",
+            # Comment injection
+            "table--comment",
+            "table/* inline comment */name",
+            "col/**/name",
+            # Quote escaping
+            "table'name",
+            'table"name',
+            "table`name",
+            # SQL keywords with spaces
+            "table OR 1=1",
+            "col AND true",
+            # Special characters
+            "table\nname",
+            "table\r\nname",
+            "table\x00name",
+            # Unicode tricks
+            "table\u0000name",
+            # Parentheses
+            "table()",
+            "(SELECT * FROM users)",
+            # Equals and comparisons
+            "col=1",
+            "table<>",
+        ],
+    )
+    def test_identifier_blocks_injection(self, malicious_input: str) -> None:
+        """Ensure Identifier blocks all injection attempts."""
+        with pytest.raises(ValidationError):
+            Identifier(value=malicious_input)
+
+    @pytest.mark.parametrize(
+        "valid_input",
+        [
+            "users",
+            "ACCOUNT_USAGE",
+            "_private_table",
+            "table123",
+            "my_table_v2",
+            "Table$Special",
+            "T",
+            "_",
+        ],
+    )
+    def test_identifier_allows_valid(self, valid_input: str) -> None:
+        """Ensure Identifier allows valid identifiers."""
+        ident = Identifier(value=valid_input)
+        assert ident.value == valid_input
+
+
+class TestRangeExpressionSQLInjection:
+    """Security tests for RangeExpression SQL injection prevention."""
+
+    @pytest.mark.parametrize(
+        "malicious_template",
+        [
+            # Statement terminators
+            "[START_MARKER]; DROP TABLE users; [END_MARKER]",
+            "[START_MARKER]; DELETE FROM secrets WHERE 1=1; [END_MARKER]",
+            "ts >= [START_MARKER]; INSERT INTO logs VALUES('hacked'); --[END_MARKER]",
+            # SQL comment injection
+            "[START_MARKER]-- comment\n[END_MARKER]",
+            "[START_MARKER]/* block comment */[END_MARKER]",
+            "ts >= [START_MARKER] /*injected*/ AND ts < [END_MARKER]",
+            # UNION-based injection
+            "[START_MARKER] UNION SELECT * FROM passwords WHERE x=[END_MARKER]",
+            "ts >= [START_MARKER] UNION ALL SELECT password FROM users--[END_MARKER]",
+            # Subquery injection
+            "ts >= [START_MARKER] AND (SELECT COUNT(*) FROM users) > 0 AND ts < [END_MARKER]",
+            # DDL/DML injection
+            "[START_MARKER] DROP TABLE users [END_MARKER]",
+            "[START_MARKER] CREATE TABLE hacked(data TEXT) [END_MARKER]",
+            "[START_MARKER] ALTER TABLE users ADD COLUMN hacked TEXT [END_MARKER]",
+            "[START_MARKER] GRANT ALL ON users TO attacker [END_MARKER]",
+            "[START_MARKER] TRUNCATE TABLE users [END_MARKER]",
+            "[START_MARKER] INSERT INTO users VALUES('hacked') [END_MARKER]",
+            "[START_MARKER] UPDATE users SET password='hacked' [END_MARKER]",
+            "[START_MARKER] DELETE FROM users [END_MARKER]",
+            # EXEC injection (SQL Server style)
+            "[START_MARKER] EXEC xp_cmdshell 'dir' [END_MARKER]",
+        ],
+    )
+    def test_range_expression_blocks_injection_in_template(
+        self, malicious_template: str
+    ) -> None:
+        """Ensure RangeExpression blocks injection in templates."""
+        with pytest.raises(ValidationError):
+            RangeExpression(
+                timestamp_column=Identifier(value="ts"),
+                custom_template=malicious_template,
+            )
+
+    @pytest.mark.parametrize(
+        "valid_template",
+        [
+            "ts >= [START_MARKER] AND ts < [END_MARKER]",
+            "CAST(EXTRACT(epoch from {column}) as INT8) * 1000 >= [START_MARKER] AND CAST(EXTRACT(epoch from {column}) as INT8) * 1000 < [END_MARKER]",
+            "{column} BETWEEN [START_MARKER] AND [END_MARKER]",
+            "TO_TIMESTAMP_TZ([START_MARKER], 3) <= {column} AND {column} < TO_TIMESTAMP_TZ([END_MARKER], 3)",
+        ],
+    )
+    def test_range_expression_allows_valid_templates(self, valid_template: str) -> None:
+        """Ensure RangeExpression allows valid templates."""
+        expr = RangeExpression(
+            timestamp_column=Identifier(value="ts"),
+            custom_template=valid_template,
+        )
+        assert expr.custom_template == valid_template
+
+
+class TestMarkerValueSQLInjection:
+    """Security tests for marker value SQL injection prevention."""
+
+    @pytest.mark.parametrize(
+        "malicious_start",
+        [
+            "0 OR 1=1",
+            "100; DROP TABLE",
+            "200--comment",
+            "300/*block*/",
+            "0) OR (1=1",
+            "1' OR '1'='1",
+            "-1 UNION SELECT",
+        ],
+    )
+    def test_render_rejects_non_numeric_start(self, malicious_start: str) -> None:
+        """Ensure render rejects non-numeric start values."""
+        expr = RangeExpression(timestamp_column=Identifier(value="ts"))
+        with pytest.raises((ValueError, TypeError)):
+            expr.render(SQLDialect.GENERIC, start=malicious_start, end=100)  # type: ignore
+
+    @pytest.mark.parametrize(
+        "malicious_end",
+        [
+            "0 OR 1=1",
+            "100; DROP TABLE",
+            "200--comment",
+            "300/*block*/",
+            "0) OR (1=1",
+            "1' OR '1'='1",
+            "-1 UNION SELECT",
+        ],
+    )
+    def test_render_rejects_non_numeric_end(self, malicious_end: str) -> None:
+        """Ensure render rejects non-numeric end values."""
+        expr = RangeExpression(timestamp_column=Identifier(value="ts"))
+        with pytest.raises((ValueError, TypeError)):
+            expr.render(SQLDialect.GENERIC, start=100, end=malicious_end)  # type: ignore
+
+    def test_render_rejects_negative_start(self) -> None:
+        """Ensure render rejects negative start values."""
+        expr = RangeExpression(timestamp_column=Identifier(value="ts"))
+        with pytest.raises(ValueError) as exc_info:
+            expr.render(SQLDialect.GENERIC, start=-1, end=100)
+        assert "non-negative" in str(exc_info.value)
+
+    def test_render_rejects_negative_end(self) -> None:
+        """Ensure render rejects negative end values."""
+        expr = RangeExpression(timestamp_column=Identifier(value="ts"))
+        with pytest.raises(ValueError) as exc_info:
+            expr.render(SQLDialect.GENERIC, start=0, end=-1)
+        assert "non-negative" in str(exc_info.value)
+
+    def test_render_accepts_valid_markers(self) -> None:
+        """Ensure render accepts valid numeric markers."""
+        expr = RangeExpression(timestamp_column=Identifier(value="ts"))
+        sql, _ = expr.render(SQLDialect.GENERIC, start=1700000000, end=1700000100)
+        assert "1700000000" in sql
+        assert "1700000100" in sql
+
+
+class TestMinerConfigSQLInjection:
+    """Security tests for MinerConfig SQL injection prevention."""
+
+    def test_config_rejects_invalid_database(self) -> None:
+        """Ensure MinerConfig rejects invalid database identifiers."""
+        with pytest.raises(ValidationError):
+            MinerConfig(
+                database=Identifier(value="db; DROP TABLE"),
+                timestamp_column=Identifier(value="ts"),
+                range_expression=RangeExpression(
+                    timestamp_column=Identifier(value="ts")
+                ),
+            )
+
+    def test_config_rejects_invalid_schema(self) -> None:
+        """Ensure MinerConfig rejects invalid schema identifiers."""
+        with pytest.raises(ValidationError):
+            MinerConfig(
+                schema_name=Identifier(value="schema; DROP TABLE"),
+                timestamp_column=Identifier(value="ts"),
+                range_expression=RangeExpression(
+                    timestamp_column=Identifier(value="ts")
+                ),
+            )
+
+    def test_config_rejects_invalid_timestamp_column(self) -> None:
+        """Ensure MinerConfig rejects invalid timestamp column."""
+        with pytest.raises(ValidationError):
+            MinerConfig(
+                timestamp_column=Identifier(value="col; DROP TABLE"),
+                range_expression=RangeExpression(
+                    timestamp_column=Identifier(value="ts")
+                ),
+            )
+
+    def test_legacy_conversion_rejects_invalid_database(self) -> None:
+        """Ensure legacy conversion rejects invalid database."""
+        legacy = {
+            "database_name_cleaned": "db; DROP TABLE users",
+            "timestamp_column": "ts",
+            "sql_replace_to": "[START_MARKER] [END_MARKER]",
+            "ranged_sql_start_key": "[START_MARKER]",
+            "ranged_sql_end_key": "[END_MARKER]",
+        }
+        with pytest.raises(ValidationError):
+            MinerConfig.from_legacy_miner_args(legacy, emit_warning=False)
+
+    def test_legacy_conversion_rejects_invalid_schema(self) -> None:
+        """Ensure legacy conversion rejects invalid schema."""
+        legacy = {
+            "schema_name_cleaned": "schema; DROP TABLE users",
+            "timestamp_column": "ts",
+            "sql_replace_to": "[START_MARKER] [END_MARKER]",
+            "ranged_sql_start_key": "[START_MARKER]",
+            "ranged_sql_end_key": "[END_MARKER]",
+        }
+        with pytest.raises(ValidationError):
+            MinerConfig.from_legacy_miner_args(legacy, emit_warning=False)
+
+    def test_legacy_conversion_rejects_unsafe_template(self) -> None:
+        """Ensure legacy conversion rejects unsafe sql_replace_to."""
+        legacy = {
+            "timestamp_column": "ts",
+            "sql_replace_to": "[START_MARKER]; DROP TABLE users; [END_MARKER]",
+            "ranged_sql_start_key": "[START_MARKER]",
+            "ranged_sql_end_key": "[END_MARKER]",
+        }
+        with pytest.raises(ValidationError):
+            MinerConfig.from_legacy_miner_args(legacy, emit_warning=False)
+
+
+class TestRealWorldAttackPatterns:
+    """Tests for real-world SQL injection attack patterns."""
+
+    def test_redshift_epoch_extraction_attack(self) -> None:
+        """Test attack attempting to exploit Redshift epoch extraction."""
+        malicious = (
+            "CAST(EXTRACT(epoch from starttime) as INT8) * 1000 >= [START_MARKER]; "
+            "DROP TABLE stl_query; -- [END_MARKER]"
+        )
+        with pytest.raises(ValidationError):
+            RangeExpression(
+                timestamp_column=Identifier(value="starttime"),
+                custom_template=malicious,
+            )
+
+    def test_snowflake_timestamp_attack(self) -> None:
+        """Test attack attempting to exploit Snowflake timestamp functions."""
+        malicious = (
+            "TO_TIMESTAMP_TZ([START_MARKER], 3) <= SESSION_CREATED_ON; "
+            "INSERT INTO QUERY_HISTORY SELECT * FROM SECRETS; -- [END_MARKER]"
+        )
+        with pytest.raises(ValidationError):
+            RangeExpression(
+                timestamp_column=Identifier(value="SESSION_CREATED_ON"),
+                custom_template=malicious,
+            )
+
+    def test_boolean_based_blind_injection(self) -> None:
+        """Test boolean-based blind SQL injection in identifiers."""
+        with pytest.raises(ValidationError):
+            Identifier(value="users WHERE 1=1 OR username")
+
+    def test_stacked_queries_attack(self) -> None:
+        """Test stacked queries attack."""
+        malicious = (
+            "[START_MARKER]; "
+            "CREATE USER attacker WITH PASSWORD 'pwned'; "
+            "GRANT ALL PRIVILEGES TO attacker; "
+            "[END_MARKER]"
+        )
+        with pytest.raises(ValidationError):
+            RangeExpression(
+                timestamp_column=Identifier(value="ts"),
+                custom_template=malicious,
+            )
+
+    def test_valid_redshift_template(self) -> None:
+        """Ensure valid Redshift-style template is accepted."""
+        valid = (
+            "CAST(EXTRACT(epoch from {column}) as INT8) * 1000 >= [START_MARKER] "
+            "AND CAST(EXTRACT(epoch from {column}) as INT8) * 1000 < [END_MARKER]"
+        )
+        expr = RangeExpression(
+            timestamp_column=Identifier(value="starttime"),
+            custom_template=valid,
+        )
+        sql, _ = expr.render(SQLDialect.REDSHIFT, start=1700000000, end=1700000100)
+        assert "1700000000" in sql
+        assert "1700000100" in sql
+        assert "starttime" in sql

--- a/tests/unit/activities/common/test_sql_models.py
+++ b/tests/unit/activities/common/test_sql_models.py
@@ -1,0 +1,443 @@
+"""Unit tests for SQL models (Identifier, RangeExpression, MinerConfig).
+
+These tests verify that the structured SQL models properly validate inputs
+and prevent SQL injection attacks.
+"""
+
+import warnings
+from typing import Any, Dict
+
+import pytest
+from pydantic import ValidationError
+
+from application_sdk.activities.common.sql_models import (
+    Identifier,
+    MinerConfig,
+    RangeExpression,
+    SQLDialect,
+)
+
+
+class TestIdentifier:
+    """Unit tests for Identifier class."""
+
+    def test_valid_simple_identifier(self) -> None:
+        """Test valid simple identifiers."""
+        ident = Identifier(value="ACCOUNT_USAGE")
+        assert ident.value == "ACCOUNT_USAGE"
+        assert str(ident) == "ACCOUNT_USAGE"
+
+    def test_valid_identifier_with_underscore(self) -> None:
+        """Test identifiers starting with underscore."""
+        ident = Identifier(value="_my_table")
+        assert ident.value == "_my_table"
+
+    def test_valid_identifier_with_dollar(self) -> None:
+        """Test identifiers with dollar sign."""
+        ident = Identifier(value="table$1")
+        assert ident.value == "table$1"
+
+    def test_valid_identifier_with_numbers(self) -> None:
+        """Test identifiers with numbers (not at start)."""
+        ident = Identifier(value="table123")
+        assert ident.value == "table123"
+
+    def test_invalid_identifier_empty(self) -> None:
+        """Reject empty identifiers."""
+        with pytest.raises(ValidationError):
+            Identifier(value="")
+
+    def test_invalid_identifier_whitespace_only(self) -> None:
+        """Reject whitespace-only identifiers."""
+        with pytest.raises(ValidationError):
+            Identifier(value="   ")
+
+    def test_invalid_identifier_starts_with_number(self) -> None:
+        """Reject identifiers starting with a number."""
+        with pytest.raises(ValidationError):
+            Identifier(value="123table")
+
+    def test_invalid_identifier_with_spaces(self) -> None:
+        """Reject identifiers with spaces."""
+        with pytest.raises(ValidationError):
+            Identifier(value="my table")
+
+    def test_invalid_identifier_with_dash(self) -> None:
+        """Reject identifiers with dashes."""
+        with pytest.raises(ValidationError):
+            Identifier(value="my-table")
+
+    def test_render_generic_dialect(self) -> None:
+        """Test generic dialect (no quoting)."""
+        ident = Identifier(value="QUERY_HISTORY")
+        assert ident.render(SQLDialect.GENERIC) == "QUERY_HISTORY"
+
+    def test_render_snowflake_dialect(self) -> None:
+        """Test Snowflake quoting (double quotes)."""
+        ident = Identifier(value="QUERY_HISTORY")
+        assert ident.render(SQLDialect.SNOWFLAKE) == '"QUERY_HISTORY"'
+
+    def test_render_redshift_dialect(self) -> None:
+        """Test Redshift quoting (double quotes)."""
+        ident = Identifier(value="query_history")
+        assert ident.render(SQLDialect.REDSHIFT) == '"query_history"'
+
+    def test_render_postgres_dialect(self) -> None:
+        """Test PostgreSQL quoting (double quotes)."""
+        ident = Identifier(value="pg_stat_statements")
+        assert ident.render(SQLDialect.POSTGRES) == '"pg_stat_statements"'
+
+    def test_render_mysql_dialect(self) -> None:
+        """Test MySQL quoting (backticks)."""
+        ident = Identifier(value="query_history")
+        assert ident.render(SQLDialect.MYSQL) == "`query_history`"
+
+    def test_render_bigquery_dialect(self) -> None:
+        """Test BigQuery quoting (backticks)."""
+        ident = Identifier(value="JOBS_BY_PROJECT")
+        assert ident.render(SQLDialect.BIGQUERY) == "`JOBS_BY_PROJECT`"
+
+    def test_identifier_is_frozen(self) -> None:
+        """Verify Identifier is immutable."""
+        ident = Identifier(value="table")
+        with pytest.raises(ValidationError):
+            ident.value = "other_table"  # type: ignore
+
+
+class TestRangeExpression:
+    """Unit tests for RangeExpression class."""
+
+    def test_default_range_expression(self) -> None:
+        """Test default BETWEEN expression without custom template."""
+        expr = RangeExpression(timestamp_column=Identifier(value="start_time"))
+        sql, _ = expr.render(SQLDialect.GENERIC, start=100, end=200)
+        assert sql == "start_time >= 100 AND start_time <= 200"
+
+    def test_default_placeholders(self) -> None:
+        """Test default placeholder values."""
+        expr = RangeExpression(timestamp_column=Identifier(value="ts"))
+        assert expr.start_placeholder == "[START_MARKER]"
+        assert expr.end_placeholder == "[END_MARKER]"
+
+    def test_custom_template_valid(self) -> None:
+        """Test valid custom template."""
+        template = (
+            "CAST(EXTRACT(epoch from {column}) as INT8) * 1000 >= [START_MARKER] "
+            "AND CAST(EXTRACT(epoch from {column}) as INT8) * 1000 < [END_MARKER]"
+        )
+        expr = RangeExpression(
+            timestamp_column=Identifier(value="starttime"),
+            custom_template=template,
+        )
+        assert expr.custom_template == template
+
+    def test_custom_template_render(self) -> None:
+        """Test rendering custom template with values."""
+        template = "{column} >= [START_MARKER] AND {column} < [END_MARKER]"
+        expr = RangeExpression(
+            timestamp_column=Identifier(value="ts"),
+            custom_template=template,
+        )
+        sql, _ = expr.render(SQLDialect.GENERIC, start=100, end=200)
+        assert sql == "ts >= 100 AND ts < 200"
+
+    def test_custom_template_missing_start_placeholder(self) -> None:
+        """Reject template missing start placeholder."""
+        with pytest.raises(ValidationError) as exc_info:
+            RangeExpression(
+                timestamp_column=Identifier(value="ts"),
+                custom_template="col >= 100 AND col < [END_MARKER]",
+            )
+        assert "start_placeholder" in str(exc_info.value)
+
+    def test_custom_template_missing_end_placeholder(self) -> None:
+        """Reject template missing end placeholder."""
+        with pytest.raises(ValidationError) as exc_info:
+            RangeExpression(
+                timestamp_column=Identifier(value="ts"),
+                custom_template="col >= [START_MARKER] AND col < 200",
+            )
+        assert "end_placeholder" in str(exc_info.value)
+
+    def test_custom_placeholder_values(self) -> None:
+        """Test custom placeholder strings."""
+        expr = RangeExpression(
+            timestamp_column=Identifier(value="ts"),
+            start_placeholder="{BEGIN}",
+            end_placeholder="{FINISH}",
+            custom_template="ts >= {BEGIN} AND ts < {FINISH}",
+        )
+        sql, _ = expr.render(SQLDialect.GENERIC, start=100, end=200)
+        assert sql == "ts >= 100 AND ts < 200"
+
+    def test_render_template_only(self) -> None:
+        """Test rendering template with placeholders intact."""
+        expr = RangeExpression(timestamp_column=Identifier(value="ts"))
+        template = expr.render_template_only(SQLDialect.GENERIC)
+        assert template == "ts >= [START_MARKER] AND ts <= [END_MARKER]"
+
+    def test_render_with_negative_start(self) -> None:
+        """Reject negative start value."""
+        expr = RangeExpression(timestamp_column=Identifier(value="ts"))
+        with pytest.raises(ValueError) as exc_info:
+            expr.render(SQLDialect.GENERIC, start=-1, end=100)
+        assert "non-negative" in str(exc_info.value)
+
+    def test_render_with_negative_end(self) -> None:
+        """Reject negative end value."""
+        expr = RangeExpression(timestamp_column=Identifier(value="ts"))
+        with pytest.raises(ValueError) as exc_info:
+            expr.render(SQLDialect.GENERIC, start=0, end=-1)
+        assert "non-negative" in str(exc_info.value)
+
+    def test_render_with_non_integer_start(self) -> None:
+        """Reject non-integer start value."""
+        expr = RangeExpression(timestamp_column=Identifier(value="ts"))
+        with pytest.raises(ValueError):
+            expr.render(SQLDialect.GENERIC, start="100", end=200)  # type: ignore
+
+    def test_invalid_placeholder_with_semicolon(self) -> None:
+        """Reject placeholder with semicolon."""
+        with pytest.raises(ValidationError):
+            RangeExpression(
+                timestamp_column=Identifier(value="ts"),
+                start_placeholder="[START;DROP]",
+            )
+
+
+class TestMinerConfig:
+    """Unit tests for MinerConfig class."""
+
+    @pytest.fixture
+    def base_config_dict(self) -> Dict[str, Any]:
+        """Provide a valid MinerConfig dictionary."""
+        return {
+            "database": Identifier(value="SNOWFLAKE"),
+            "schema_name": Identifier(value="ACCOUNT_USAGE"),
+            "timestamp_column": Identifier(value="START_TIME"),
+            "range_expression": RangeExpression(
+                timestamp_column=Identifier(value="START_TIME"),
+                custom_template="ts >= [START_MARKER] AND ts < [END_MARKER]",
+            ),
+            "chunk_size": 5000,
+            "current_marker": 0,
+        }
+
+    def test_valid_config(self, base_config_dict: Dict[str, Any]) -> None:
+        """Test valid MinerConfig instantiation."""
+        config = MinerConfig(**base_config_dict)
+        assert config.database is not None
+        assert config.database.value == "SNOWFLAKE"
+        assert config.chunk_size == 5000
+
+    def test_optional_database(self) -> None:
+        """Test MinerConfig without database."""
+        config = MinerConfig(
+            timestamp_column=Identifier(value="ts"),
+            range_expression=RangeExpression(timestamp_column=Identifier(value="ts")),
+        )
+        assert config.database is None
+
+    def test_optional_schema(self) -> None:
+        """Test MinerConfig without schema."""
+        config = MinerConfig(
+            timestamp_column=Identifier(value="ts"),
+            range_expression=RangeExpression(timestamp_column=Identifier(value="ts")),
+        )
+        assert config.schema_name is None
+
+    def test_default_chunk_size(self) -> None:
+        """Test default chunk_size value."""
+        config = MinerConfig(
+            timestamp_column=Identifier(value="ts"),
+            range_expression=RangeExpression(timestamp_column=Identifier(value="ts")),
+        )
+        assert config.chunk_size == 5000
+
+    def test_default_current_marker(self) -> None:
+        """Test default current_marker value."""
+        config = MinerConfig(
+            timestamp_column=Identifier(value="ts"),
+            range_expression=RangeExpression(timestamp_column=Identifier(value="ts")),
+        )
+        assert config.current_marker == 0
+
+    def test_invalid_chunk_size_zero(self) -> None:
+        """Reject chunk_size of zero."""
+        with pytest.raises(ValidationError):
+            MinerConfig(
+                timestamp_column=Identifier(value="ts"),
+                range_expression=RangeExpression(
+                    timestamp_column=Identifier(value="ts")
+                ),
+                chunk_size=0,
+            )
+
+    def test_invalid_chunk_size_negative(self) -> None:
+        """Reject negative chunk_size."""
+        with pytest.raises(ValidationError):
+            MinerConfig(
+                timestamp_column=Identifier(value="ts"),
+                range_expression=RangeExpression(
+                    timestamp_column=Identifier(value="ts")
+                ),
+                chunk_size=-1,
+            )
+
+    def test_invalid_current_marker_negative(self) -> None:
+        """Reject negative current_marker."""
+        with pytest.raises(ValidationError):
+            MinerConfig(
+                timestamp_column=Identifier(value="ts"),
+                range_expression=RangeExpression(
+                    timestamp_column=Identifier(value="ts")
+                ),
+                current_marker=-1,
+            )
+
+    def test_format_query_basic(self) -> None:
+        """Test basic query formatting."""
+        config = MinerConfig(
+            database=Identifier(value="mydb"),
+            schema_name=Identifier(value="myschema"),
+            timestamp_column=Identifier(value="ts"),
+            range_expression=RangeExpression(timestamp_column=Identifier(value="ts")),
+            miner_start_time_epoch=1700000000,
+        )
+        template = "SELECT * FROM {database_name_cleaned}.{schema_name_cleaned}"
+        result = config.format_query(template, SQLDialect.GENERIC)
+        assert result == "SELECT * FROM mydb.myschema"
+
+    def test_format_query_with_markers(self) -> None:
+        """Test query formatting with range markers."""
+        config = MinerConfig(
+            timestamp_column=Identifier(value="ts"),
+            range_expression=RangeExpression(
+                timestamp_column=Identifier(value="ts"),
+                custom_template="ts >= [START_MARKER] AND ts < [END_MARKER]",
+            ),
+        )
+        template = (
+            "SELECT * FROM table WHERE ts >= [START_MARKER] AND ts < [END_MARKER]"
+        )
+        result = config.format_query(
+            template, SQLDialect.GENERIC, start_marker=100, end_marker=200
+        )
+        assert "ts >= 100" in result
+        assert "ts < 200" in result
+
+    def test_extra_fields_forbidden(self) -> None:
+        """Verify extra fields are rejected."""
+        with pytest.raises(ValidationError):
+            MinerConfig(
+                timestamp_column=Identifier(value="ts"),
+                range_expression=RangeExpression(
+                    timestamp_column=Identifier(value="ts")
+                ),
+                unknown_field="value",  # type: ignore
+            )
+
+
+class TestBackwardCompatibility:
+    """Tests for legacy MinerArgs compatibility."""
+
+    @pytest.fixture
+    def legacy_miner_args(self) -> Dict[str, Any]:
+        """Provide a valid legacy miner_args dictionary."""
+        return {
+            "database_name_cleaned": "SNOWFLAKE",
+            "schema_name_cleaned": "ACCOUNT_USAGE",
+            "timestamp_column": "START_TIME",
+            "chunk_size": 5000,
+            "current_marker": 0,
+            "sql_replace_from": "condition",
+            "sql_replace_to": "ts >= [START_MARKER] AND ts < [END_MARKER]",
+            "ranged_sql_start_key": "[START_MARKER]",
+            "ranged_sql_end_key": "[END_MARKER]",
+            "miner_start_time_epoch": 1700000000,
+        }
+
+    def test_convert_simple_legacy_args(
+        self, legacy_miner_args: Dict[str, Any]
+    ) -> None:
+        """Test basic conversion from legacy format."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            config = MinerConfig.from_legacy_miner_args(legacy_miner_args)
+
+            # Verify deprecation warning was emitted
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "deprecated" in str(w[0].message).lower()
+
+        # Verify conversion
+        assert config.database is not None
+        assert config.database.value == "SNOWFLAKE"
+        assert config.schema_name is not None
+        assert config.schema_name.value == "ACCOUNT_USAGE"
+        assert config.chunk_size == 5000
+
+    def test_convert_without_warning(self, legacy_miner_args: Dict[str, Any]) -> None:
+        """Test conversion with warning suppressed."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            config = MinerConfig.from_legacy_miner_args(
+                legacy_miner_args, emit_warning=False
+            )
+            assert len(w) == 0
+
+        assert config.database is not None
+        assert config.database.value == "SNOWFLAKE"
+
+    def test_convert_without_database(self) -> None:
+        """Test conversion without database."""
+        legacy = {
+            "timestamp_column": "ts",
+            "chunk_size": 100,
+            "current_marker": 0,
+            "sql_replace_from": "",
+            "sql_replace_to": "",
+            "ranged_sql_start_key": "[START_MARKER]",
+            "ranged_sql_end_key": "[END_MARKER]",
+        }
+        config = MinerConfig.from_legacy_miner_args(legacy, emit_warning=False)
+        assert config.database is None
+
+    def test_convert_preserves_custom_template(
+        self, legacy_miner_args: Dict[str, Any]
+    ) -> None:
+        """Test that sql_replace_to becomes custom_template."""
+        config = MinerConfig.from_legacy_miner_args(
+            legacy_miner_args, emit_warning=False
+        )
+        assert config.range_expression.custom_template is not None
+        assert "[START_MARKER]" in config.range_expression.custom_template
+        assert "[END_MARKER]" in config.range_expression.custom_template
+
+    def test_convert_with_invalid_identifier(self) -> None:
+        """Ensure conversion fails for invalid legacy identifiers."""
+        legacy = {
+            "database_name_cleaned": "db; DROP TABLE",
+            "timestamp_column": "ts",
+            "sql_replace_from": "",
+            "sql_replace_to": "",
+            "ranged_sql_start_key": "[START_MARKER]",
+            "ranged_sql_end_key": "[END_MARKER]",
+        }
+        with pytest.raises(ValidationError):
+            MinerConfig.from_legacy_miner_args(legacy, emit_warning=False)
+
+    def test_convert_with_empty_sql_replace_to(self) -> None:
+        """Test conversion with empty sql_replace_to (uses default range)."""
+        legacy = {
+            "timestamp_column": "ts",
+            "chunk_size": 100,
+            "current_marker": 0,
+            "sql_replace_from": "",
+            "sql_replace_to": "",
+            "ranged_sql_start_key": "[START_MARKER]",
+            "ranged_sql_end_key": "[END_MARKER]",
+        }
+        config = MinerConfig.from_legacy_miner_args(legacy, emit_warning=False)
+        # Should use default range expression (no custom template)
+        assert config.range_expression.custom_template is None

--- a/tests/unit/activities/query_extraction/test_sql_query_extraction.py
+++ b/tests/unit/activities/query_extraction/test_sql_query_extraction.py
@@ -1,0 +1,85 @@
+from typing import Any, Dict
+
+import pytest
+from pydantic import ValidationError
+
+from application_sdk.activities.query_extraction.sql import SQLQueryExtractionActivities
+
+BASE_QUERY = (
+    "SELECT * FROM {database_name_cleaned}.{schema_name_cleaned} "
+    "WHERE {timestamp_column} >= {miner_start_time_epoch} AND {sql_replace_from}"
+)
+
+
+@pytest.fixture()
+def activities() -> SQLQueryExtractionActivities:
+    """Create a SQLQueryExtractionActivities instance for tests."""
+    return SQLQueryExtractionActivities()
+
+
+@pytest.fixture()
+def base_workflow_args() -> Dict[str, Any]:
+    """Provide a baseline workflow_args payload for formatting tests."""
+    return {
+        "miner_args": {
+            "database_name_cleaned": "SNOWFLAKE",
+            "schema_name_cleaned": "ACCOUNT_USAGE",
+            "timestamp_column": "START_TIME",
+            "chunk_size": 100,
+            "current_marker": 0,
+            "sql_replace_from": "SQL_RANGE_CLAUSE",
+            "sql_replace_to": "START_TIME >= [START_MARKER] AND START_TIME <= [END_MARKER]",
+            "ranged_sql_start_key": "[START_MARKER]",
+            "ranged_sql_end_key": "[END_MARKER]",
+            "miner_start_time_epoch": 1700000000,
+        },
+        "start_marker": "1700000001",
+        "end_marker": "1700000100",
+    }
+
+
+def test_get_formatted_query_formats_valid_inputs(
+    activities: SQLQueryExtractionActivities, base_workflow_args: Dict[str, Any]
+) -> None:
+    """Ensure valid inputs are formatted and replaced as expected."""
+    formatted = activities.get_formatted_query(BASE_QUERY, base_workflow_args)
+
+    assert (
+        formatted
+        == "SELECT * FROM SNOWFLAKE.ACCOUNT_USAGE WHERE START_TIME >= 1700000000 "
+        "AND START_TIME >= 1700000001 AND START_TIME <= 1700000100"
+    )
+
+
+def test_get_formatted_query_rejects_injected_identifier(
+    activities: SQLQueryExtractionActivities, base_workflow_args: Dict[str, Any]
+) -> None:
+    """Reject schema identifiers containing SQL injection payloads."""
+    base_workflow_args["miner_args"]["schema_name_cleaned"] = (
+        "users; DROP TABLE users; --"
+    )
+
+    with pytest.raises(ValidationError):
+        activities.get_formatted_query(BASE_QUERY, base_workflow_args)
+
+
+def test_get_formatted_query_rejects_dangerous_replace_fragment(
+    activities: SQLQueryExtractionActivities, base_workflow_args: Dict[str, Any]
+) -> None:
+    """Reject sql_replace_to fragments containing statement terminators."""
+    base_workflow_args["miner_args"]["sql_replace_to"] = (
+        "START_TIME >= [START_MARKER]; DROP TABLE users"
+    )
+
+    with pytest.raises(ValidationError):
+        activities.get_formatted_query(BASE_QUERY, base_workflow_args)
+
+
+def test_get_formatted_query_rejects_non_numeric_markers(
+    activities: SQLQueryExtractionActivities, base_workflow_args: Dict[str, Any]
+) -> None:
+    """Reject start/end markers that are not numeric."""
+    base_workflow_args["start_marker"] = "0 OR 1=1"
+
+    with pytest.raises(ValueError, match="start_marker"):
+        activities.get_formatted_query(BASE_QUERY, base_workflow_args)


### PR DESCRIPTION
## Summary

Fixes SQL injection vulnerability in the query extraction workflow where user-controlled `miner_args` values were directly interpolated into SQL via `.format()` and `.replace()`.

## Changes

- Add `MinerConfig` model with `Identifier`, `RangeExpression` classes for structured SQL configuration
- Add validation for SQL identifiers (alphanumeric + underscore/dollar only)
- Add validation for custom templates (blocks `;`, `--`, `/*`, DDL/DML keywords)
- Add validation for numeric marker values (non-negative integers only)
- Update `get_formatted_query()` for dual-mode support (new + legacy formats)
- Legacy `miner_args` auto-converts with deprecation warning

## Backward Compatibility

- Existing apps continue working without breaking changes
- Legacy format emits `DeprecationWarning` with migration guide reference

## Test plan

- [x] 45 unit tests for `sql_models.py` (Identifier, RangeExpression, MinerConfig)
- [x] 77 security tests covering SQL injection attack patterns
- [x] 4 existing query extraction tests pass
- [x] Integration tests with Redshift app (16 tests)
- [x] Integration tests with Postgres app (12 tests)

```bash
uv run pytest tests/unit/activities/common/test_sql_models.py tests/unit/activities/common/test_sql_injection_security.py tests/unit/activities/query_extraction/test_sql_query_extraction.py -v
```