### PR TITLE
WARE-282 : Remove redundant logs

### DIFF
--- a/application_sdk/activities/query_extraction/sql.py
+++ b/application_sdk/activities/query_extraction/sql.py
@@ -202,12 +202,15 @@ class SQLQueryExtractionActivities(ActivitiesInterface):
 
         try:
             state = await self._get_state(workflow_args)
+
             sql_input = SQLQueryInput(
                 engine=state.sql_client.engine,
                 query=self.get_formatted_query(self.fetch_queries_sql, workflow_args),
                 chunk_size=None,
             )
             sql_input = await sql_input.get_dataframe()
+
+            sql_input.columns = [str(c).upper() for c in sql_input.columns]
 
             raw_output = ParquetOutput(
                 output_path=workflow_args["output_path"],

--- a/application_sdk/activities/query_extraction/sql.py
+++ b/application_sdk/activities/query_extraction/sql.py
@@ -213,7 +213,7 @@ class SQLQueryExtractionActivities(ActivitiesInterface):
                 output_path=workflow_args["output_path"],
                 output_suffix="raw/query",
                 chunk_size=workflow_args["miner_args"].get("chunk_size", 100000),
-                start_marker=workflow_args["start_marker"],
+                start_marker=str(workflow_args["start_marker"]),
                 end_marker=workflow_args["end_marker"],
             )
             await raw_output.write_dataframe(sql_input)

--- a/application_sdk/activities/query_extraction/sql.py
+++ b/application_sdk/activities/query_extraction/sql.py
@@ -283,7 +283,6 @@ class SQLQueryExtractionActivities(ActivitiesInterface):
                 new_marker = str(int(timestamp.timestamp() * 1000))
 
                 if last_marker == new_marker:
-                    logger.info("Skipping duplicate start time")
                     record_count += 1
                     continue
 

--- a/application_sdk/outputs/__init__.py
+++ b/application_sdk/outputs/__init__.py
@@ -109,9 +109,11 @@ class Output(ABC):
         Returns:
             str: Generated file path for the chunk.
         """
-        # For Query Extraction - use start and end markers without chunk count
-        if start_marker and end_marker:
-            return f"{start_marker}_{end_marker}{self._EXTENSION}"
+        # For Query Extraction - use start marker
+        if chunk_count is None:
+            return f"atlan_raw_mined_{str(start_marker)}_{str(chunk_part)}{self._EXTENSION}"
+        else:
+            return f"atlan_raw_mined_{str(start_marker)}_{str(chunk_count)}_{str(chunk_part)}{self._EXTENSION}"
 
         # For regular chunking - include chunk count
         if chunk_count is None:
@@ -213,7 +215,7 @@ class Output(ABC):
                     self.current_buffer_size_bytes + chunk_size_bytes
                     > self.max_file_size_bytes
                 ):
-                    output_file_name = f"{self.output_path}/{self.path_gen(self.chunk_count, self.chunk_part)}"
+                    output_file_name = f"{self.output_path}/{self.path_gen(self.chunk_count, self.chunk_part, self.start_marker, self.end_marker)}"
                     if os.path.exists(output_file_name):
                         await self._upload_file(output_file_name)
                         self.chunk_part += 1


### PR DESCRIPTION
PR by Abhishek - https://github.com/atlanhq/application-sdk/pull/754/
### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- _to be added_

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renames output files and changes `Output.path_gen`’s signature/behavior, which can break downstream consumers and other outputs still calling it with `end_marker` (e.g., JSON output) if not updated/tested.
> 
> **Overview**
> Updates SQL query extraction to normalize fetched DataFrame column names to uppercase and to always treat `start_marker` as a string when writing raw query parquet output.
> 
> Changes output chunk file naming for query extraction: `Output.path_gen` now keys filenames off `start_marker` (and chunk metadata) rather than `start_marker`+`end_marker`, and Parquet output writes are updated to pass the marker through; also removes a redundant “duplicate start time” log during query parallelization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e9df20e41bb995e92641439b757c215eae34d6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->