### PR TITLE
BLDX-547: feat: SDK UI config fetch route added

### DIFF
--- a/application_sdk/handlers/__init__.py
+++ b/application_sdk/handlers/__init__.py
@@ -44,3 +44,10 @@ class HandlerInterface(ABC):
         Static method to get the configmap
         """
         return {}
+
+    @staticmethod
+    async def get_uiconfig(config_name: str) -> Dict[str, Any]:
+        """
+        Static method to get the UI config
+        """
+        return {}

--- a/application_sdk/handlers/__init__.py
+++ b/application_sdk/handlers/__init__.py
@@ -46,7 +46,7 @@ class HandlerInterface(ABC):
         return {}
 
     @staticmethod
-    async def get_uiconfig(config_name: str) -> Dict[str, Any]:
+    async def get_uiconfig() -> Dict[str, Any]:
         """
         Static method to get the UI config
         """

--- a/application_sdk/server/fastapi/__init__.py
+++ b/application_sdk/server/fastapi/__init__.py
@@ -442,7 +442,7 @@ class APIServer(ServerInterface):
         )
 
         self.workflow_router.add_api_route(
-            "/uiconfigs/{config_name}",
+            "/uiconfigs",
             self.get_uiconfig,
             methods=["GET"],
             response_model=UIConfigResponse,
@@ -735,11 +735,8 @@ class APIServer(ServerInterface):
                 data={},
             )
 
-    async def get_uiconfig(self, config_name: str) -> UIConfigResponse:
-        """Get a UI configuration by its name.
-
-        Args:
-            config_name (str): The name of the UI configuration to retrieve.
+    async def get_uiconfig(self) -> UIConfigResponse:
+        """Get the UI configuration for this application.
 
         Returns:
             UIConfigResponse: Response containing the UI configuration.
@@ -748,7 +745,7 @@ class APIServer(ServerInterface):
             if not self.handler:
                 raise Exception("Handler not initialized")
 
-            uiconfig_data = await self.handler.get_uiconfig(config_name)
+            uiconfig_data = await self.handler.get_uiconfig()
 
             return UIConfigResponse(
                 success=True,

--- a/application_sdk/server/fastapi/__init__.py
+++ b/application_sdk/server/fastapi/__init__.py
@@ -54,6 +54,7 @@ from application_sdk.server.fastapi.models import (
     Subscription,
     TestAuthRequest,
     TestAuthResponse,
+    UIConfigResponse,
     WorkflowConfigRequest,
     WorkflowConfigResponse,
     WorkflowData,
@@ -441,6 +442,13 @@ class APIServer(ServerInterface):
         )
 
         self.workflow_router.add_api_route(
+            "/uiconfigs/{config_name}",
+            self.get_uiconfig,
+            methods=["GET"],
+            response_model=UIConfigResponse,
+        )
+
+        self.workflow_router.add_api_route(
             "/schedule",
             self.add_schedule,
             methods=["POST"],
@@ -724,6 +732,34 @@ class APIServer(ServerInterface):
             return ConfigMapResponse(
                 success=False,
                 message=f"Failed to fetch configuration map: {str(e)}",
+                data={},
+            )
+
+    async def get_uiconfig(self, config_name: str) -> UIConfigResponse:
+        """Get a UI configuration by its name.
+
+        Args:
+            config_name (str): The name of the UI configuration to retrieve.
+
+        Returns:
+            UIConfigResponse: Response containing the UI configuration.
+        """
+        try:
+            if not self.handler:
+                raise Exception("Handler not initialized")
+
+            uiconfig_data = await self.handler.get_uiconfig(config_name)
+
+            return UIConfigResponse(
+                success=True,
+                message="UI configuration fetched successfully",
+                data=uiconfig_data,
+            )
+        except Exception as e:
+            logger.error(f"Error fetching UI configuration: {e}")
+            return UIConfigResponse(
+                success=False,
+                message=f"Failed to fetch UI configuration: {str(e)}",
                 data={},
             )
 

--- a/application_sdk/server/fastapi/models.py
+++ b/application_sdk/server/fastapi/models.py
@@ -222,6 +222,29 @@ class ConfigMapResponse(BaseModel):
         }
 
 
+class UIConfigResponse(BaseModel):
+    success: bool = Field(
+        ..., description="Indicates whether the operation was successful"
+    )
+    message: str = Field(
+        ..., description="Message describing the result of the operation"
+    )
+    data: Dict[str, Any] = Field(..., description="UI configuration object")
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "success": True,
+                "message": "UI configuration fetched successfully",
+                "data": {
+                    "kind": "ConfigMap",
+                    "metadata": {"name": "atlan-example-connector"},
+                    "data": {"config": '{"properties": {}, "steps": []}'},
+                },
+            }
+        }
+
+
 class AddScheduleRequest(BaseModel):
     schedule_id: str = Field(..., description="Unique identifier for the schedule")
     cron_expression: str = Field(


### PR DESCRIPTION
## Description

Adds a new GET /uiconfigs endpoint to the workflow router that allows apps to serve their UI configuration directly from the application server instead of relying on ConfigMaps stored in Elasticsearch/Argo.

**Changes:**
- Added get_uiconfig() to HandlerInterface — apps override this to return their config
- Added UIConfigResponse model (success, message, data)
- Registered GET /uiconfigs route on workflow_router with handler that delegates to handler.get_uiconfig()

This is part of the migration away from Argo-managed ConfigMaps. Each app bundles its own UI config YAML and serves it via this endpoint.


### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.