### PR TITLE
part-412 : handle tuple-based cursor.description in BaseSQLClient.run_query

### DIFF
--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -38,6 +38,54 @@ from application_sdk.observability.logger_adaptor import get_logger
 logger = get_logger(__name__)
 activity.logger = logger
 
+
+def _extract_column_name(description_item: Any) -> str:
+    """Extract column name from a cursor description item.
+
+    DB-API 2.0 (PEP 249) specifies that cursor.description returns a sequence of
+    7-item sequences: (name, type_code, display_size, internal_size, precision, scale, null_ok).
+
+    However, different database drivers implement this differently:
+    - Some return named tuples with a `.name` attribute (e.g., psycopg2, cx_Oracle)
+    - Some return plain tuples where name is at index 0 (e.g., clickhouse-connect)
+    - SQLAlchemy's CursorResult wraps these and may provide `.name` attribute
+
+    This function handles both formats to ensure compatibility across all drivers.
+
+    Args:
+        description_item: A single item from cursor.description, which can be either:
+            - A named tuple/object with a `.name` attribute
+            - A plain tuple/sequence where name is at index 0
+
+    Returns:
+        str: The column name in lowercase.
+
+    Example:
+        >>> # Named tuple format (psycopg2, cx_Oracle)
+        >>> _extract_column_name(Column(name='ID', type_code=1))
+        'id'
+
+        >>> # Plain tuple format (clickhouse-connect)
+        >>> _extract_column_name(('ID', 'UInt64', None, None, None, None, True))
+        'id'
+    """
+    # Try .name attribute first (SQLAlchemy wrapped cursors, psycopg2, cx_Oracle, etc.)
+    if hasattr(description_item, "name"):
+        return str(description_item.name).lower()
+
+    # Fall back to index 0 for plain tuples (clickhouse-connect, some ODBC drivers)
+    # PEP 249 specifies name is always the first element
+    if isinstance(description_item, (tuple, list)) and len(description_item) > 0:
+        return str(description_item[0]).lower()
+
+    # Last resort: convert to string
+    logger.warning(
+        f"Unexpected cursor description format: {type(description_item)}. "
+        "Falling back to string conversion."
+    )
+    return str(description_item).lower()
+
+
 if TYPE_CHECKING:
     import daft
     import pandas as pd
@@ -381,8 +429,7 @@ class BaseSQLClient(ClientInterface):
                     if not cursor or not cursor.cursor:
                         raise ValueError("Cursor is not supported")
                     column_names: List[str] = [
-                        description.name.lower()
-                        for description in cursor.cursor.description
+                        _extract_column_name(desc) for desc in cursor.cursor.description
                     ]
 
                     while True:

--- a/application_sdk/clients/utils.py
+++ b/application_sdk/clients/utils.py
@@ -49,6 +49,7 @@ def extract_column_name(description_item: Any) -> str:
 
     raise ValueError(f"Unexpected cursor description format: {type(description_item)}")
 
+
 def get_workflow_client(
     engine_type: WorkflowEngineType = WorkflowEngineType.TEMPORAL,
     application_name: str = APPLICATION_NAME,

--- a/application_sdk/clients/utils.py
+++ b/application_sdk/clients/utils.py
@@ -47,13 +47,7 @@ def extract_column_name(description_item: Any) -> str:
     if isinstance(description_item, (tuple, list)) and len(description_item) > 0:
         return str(description_item[0]).lower()
 
-    # Last resort: convert to string
-    logger.warning(
-        f"Unexpected cursor description format: {type(description_item)}. "
-        "Falling back to string conversion."
-    )
-    return str(description_item).lower()
-
+    raise ValueError(f"Unexpected cursor description format: {type(description_item)}")
 
 def get_workflow_client(
     engine_type: WorkflowEngineType = WorkflowEngineType.TEMPORAL,

--- a/application_sdk/clients/utils.py
+++ b/application_sdk/clients/utils.py
@@ -1,6 +1,58 @@
+from typing import Any
+
 from application_sdk.clients.temporal import TemporalWorkflowClient
 from application_sdk.clients.workflow import WorkflowEngineType
 from application_sdk.constants import APPLICATION_NAME
+from application_sdk.observability.logger_adaptor import get_logger
+
+logger = get_logger(__name__)
+
+
+def extract_column_name(description_item: Any) -> str:
+    """Extract column name from a cursor description item.
+
+    DB-API 2.0 (PEP 249) specifies that cursor.description returns a sequence of
+    7-item sequences: (name, type_code, display_size, internal_size, precision, scale, null_ok).
+
+    However, different database drivers implement this differently:
+    - Some return named tuples with a `.name` attribute (e.g., psycopg2, cx_Oracle)
+    - Some return plain tuples where name is at index 0 (e.g., clickhouse-connect)
+    - SQLAlchemy's CursorResult wraps these and may provide `.name` attribute
+
+    This function handles both formats to ensure compatibility across all drivers.
+
+    Args:
+        description_item: A single item from cursor.description, which can be either:
+            - A named tuple/object with a `.name` attribute
+            - A plain tuple/sequence where name is at index 0
+
+    Returns:
+        str: The column name in lowercase.
+
+    Example:
+        >>> # Named tuple format (psycopg2, cx_Oracle)
+        >>> extract_column_name(Column(name='ID', type_code=1))
+        'id'
+
+        >>> # Plain tuple format (clickhouse-connect)
+        >>> extract_column_name(('ID', 'UInt64', None, None, None, None, True))
+        'id'
+    """
+    # Try .name attribute first (SQLAlchemy wrapped cursors, psycopg2, cx_Oracle, etc.)
+    if hasattr(description_item, "name"):
+        return str(description_item.name).lower()
+
+    # Fall back to index 0 for plain tuples (clickhouse-connect, some ODBC drivers)
+    # PEP 249 specifies name is always the first element
+    if isinstance(description_item, (tuple, list)) and len(description_item) > 0:
+        return str(description_item[0]).lower()
+
+    # Last resort: convert to string
+    logger.warning(
+        f"Unexpected cursor description format: {type(description_item)}. "
+        "Falling back to string conversion."
+    )
+    return str(description_item).lower()
 
 
 def get_workflow_client(

--- a/application_sdk/common/file_ops.py
+++ b/application_sdk/common/file_ops.py
@@ -68,9 +68,11 @@ class SafeFileOps:
         onerror: Optional[Any] = None,
     ) -> None:
         """Safely remove a directory tree, supporting long paths on Windows."""
-        shutil.rmtree(
-            convert_to_extended_path(path), ignore_errors=ignore_errors, onerror=onerror
-        )
+        # Use keyword arguments to avoid pyright issues with shutil.rmtree signature
+        kwargs: dict[str, Any] = {"ignore_errors": ignore_errors}
+        if onerror is not None:
+            kwargs["onerror"] = onerror
+        shutil.rmtree(convert_to_extended_path(path), **kwargs)
 
     @staticmethod
     def copy(


### PR DESCRIPTION
## Summary

Fixes an incompatibility in `BaseSQLClient.run_query()` where certain database drivers that return plain tuples in `cursor.description` (instead of named tuples with `.name` attribute) would cause an `AttributeError`.

### Problem

The SDK's `run_query()` assumed all drivers return cursor description items with a `.name` attribute:

```python
column_names = [description.name.lower() for description in cursor.cursor.description]
```

However, [PEP 249 (DB-API 2.0)](https://peps.python.org/pep-0249/#description) only specifies that `cursor.description` returns a sequence of 7-item sequences `(name, type_code, ...)` - it doesn't mandate named tuples.

### Affected Drivers

| Driver | Format | Status |
|--------|--------|--------|
| `clickhouse-connect` | Plain tuples `('col', 'Type', ...)` | **Broken** before this fix |
| Some ODBC drivers | Plain tuples | **Broken** before this fix |
| `psycopg2` / `psycopg` | Objects with `.name` | Works |
| `cx_Oracle` / `oracledb` | Objects with `.name` | Works |

### Solution

Introduced `_extract_column_name()` helper that handles both formats:
1. **Try `.name` attribute first** - backward compatible with existing drivers
2. **Fall back to index `[0]`** - for PEP 249 compliant plain tuples
3. **Last resort: string conversion** - with warning log

## Changes

- Added `_extract_column_name()` helper function in `application_sdk/clients/sql.py`
- Updated `BaseSQLClient.run_query()` to use the new helper
- Added comprehensive unit tests for the helper function
- Added integration test for `run_query()` with tuple-based descriptions

## Test Plan

- [x] All existing `test_sql_client.py` tests pass (37 passed, 3 skipped)
- [x] New `TestExtractColumnName` test class with 17 test cases
- [x] New `test_run_query_with_tuple_description` integration test
- [x] `ruff check` passes
- [x] `ruff format` passes

## Related

- Linear Issue: [PART-412](https://linear.app/atlan-epd/issue/PART-412)
- ClickHouse App PR: atlanhq/atlan-clickhouse-app#3 (contains workaround that can be removed after this is merged)
- Parent Issue: PART-332 (App Agnostic)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to column-name parsing plus additional tests; main risk is unexpected column naming behavior for edge-case cursor description formats.
> 
> **Overview**
> Fixes `BaseSQLClient.run_query()` to support DB drivers that return tuple/list items in `cursor.description` by routing column-name extraction through a new `extract_column_name()` helper (prefers `.name`, falls back to index `0`).
> 
> Adds focused unit coverage for the helper plus an additional `run_query` test that simulates tuple-based descriptions, and tweaks `SafeFileOps.rmtree()` to pass `shutil.rmtree` args via keywords to satisfy type checking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6162e0246c86240d6de04fc47048e94392f019b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->