### PR TITLE
feat: forward trace_id to Temporal workflow args

### DIFF
--- a/application_sdk/clients/temporal.py
+++ b/application_sdk/clients/temporal.py
@@ -309,9 +309,14 @@ class TemporalWorkflowClient(WorkflowClient):
             if not self.client:
                 raise ValueError("Client is not loaded")
 
+            correlation_fields = {
+                k: v
+                for k, v in workflow_args.items()
+                if k.startswith("atlan-") or k == "trace_id"
+            }
             handle = await self.client.start_workflow(
                 workflow_class,  # type: ignore
-                args=[{"workflow_id": workflow_id}],
+                args=[{"workflow_id": workflow_id, **correlation_fields}],
                 id=workflow_id,
                 task_queue=self.worker_task_queue,
                 cron_schedule=workflow_args.get("cron_schedule", ""),


### PR DESCRIPTION
## Summary
- Extract `trace_id` and `atlan-*` correlation fields from `workflow_args` and include them in the Temporal `start_workflow` args
- Enables `CorrelationContextInterceptor` to propagate trace context for CX1 apps (Publish, QI, Publish-ARS)
- Backward-compatible: no-op if no `atlan-*`/`trace_id` fields are present in the payload

## Test plan
- [ ] Existing workflows continue to work (no `atlan-*` or `trace_id` in payload = no change)
- [ ] CX1 workflows with `trace_id` in payload: verify `trace_id` appears in Temporal workflow args (Temporal UI)
- [ ] Verify `CorrelationContextInterceptor` picks up `trace_id` from `input.args[0]`

Linked ticket: [BLDX-644](https://linear.app/atlan-epd/issue/BLDX-644)

🤖 Generated with [Claude Code](https://claude.com/claude-code)