### PR TITLE
fix: graceful shutdown and lazy-load heavy SDK dependencies

### DIFF
--- a/application_sdk/application/__init__.py
+++ b/application_sdk/application/__init__.py
@@ -1,5 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type, cast
 
 from typing_extensions import deprecated
 
@@ -22,8 +22,24 @@ from application_sdk.worker import Worker
 from application_sdk.workflows import WorkflowInterface
 
 logger = get_logger(__name__)
-metrics = get_metrics()
-traces = get_traces()
+
+
+class _LazyMetricsProxy:
+    """Lazy proxy for metrics adapter initialization."""
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(get_metrics(), name)
+
+
+class _LazyTracesProxy:
+    """Lazy proxy for traces adapter initialization."""
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(get_traces(), name)
+
+
+metrics = cast(Any, _LazyMetricsProxy())
+traces = cast(Any, _LazyTracesProxy())
 
 
 class BaseApplication:

--- a/application_sdk/application/__init__.py
+++ b/application_sdk/application/__init__.py
@@ -12,9 +12,8 @@ from application_sdk.interceptors.models import EventRegistration
 from application_sdk.observability.decorators.observability_decorator import (
     observability,
 )
+from application_sdk.observability.lazy_proxies import LazyMetricsProxy, LazyTracesProxy
 from application_sdk.observability.logger_adaptor import get_logger
-from application_sdk.observability.metrics_adaptor import get_metrics
-from application_sdk.observability.traces_adaptor import get_traces
 from application_sdk.server import ServerInterface
 from application_sdk.server.fastapi import APIServer, HttpWorkflowTrigger
 from application_sdk.server.fastapi.models import EventWorkflowTrigger
@@ -22,24 +21,8 @@ from application_sdk.worker import Worker
 from application_sdk.workflows import WorkflowInterface
 
 logger = get_logger(__name__)
-
-
-class _LazyMetricsProxy:
-    """Lazy proxy for metrics adapter initialization."""
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(get_metrics(), name)
-
-
-class _LazyTracesProxy:
-    """Lazy proxy for traces adapter initialization."""
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(get_traces(), name)
-
-
-metrics = cast(Any, _LazyMetricsProxy())
-traces = cast(Any, _LazyTracesProxy())
+metrics = cast(Any, LazyMetricsProxy())
+traces = cast(Any, LazyTracesProxy())
 
 
 class BaseApplication:

--- a/application_sdk/application/metadata_extraction/sql.py
+++ b/application_sdk/application/metadata_extraction/sql.py
@@ -11,9 +11,8 @@ from application_sdk.handlers.sql import BaseSQLHandler
 from application_sdk.observability.decorators.observability_decorator import (
     observability,
 )
+from application_sdk.observability.lazy_proxies import LazyMetricsProxy, LazyTracesProxy
 from application_sdk.observability.logger_adaptor import get_logger
-from application_sdk.observability.metrics_adaptor import get_metrics
-from application_sdk.observability.traces_adaptor import get_traces
 from application_sdk.server.fastapi import APIServer, HttpWorkflowTrigger
 from application_sdk.transformers.query import QueryBasedTransformer
 from application_sdk.worker import Worker
@@ -23,24 +22,8 @@ from application_sdk.workflows.metadata_extraction.sql import (
 )
 
 logger = get_logger(__name__)
-
-
-class _LazyMetricsProxy:
-    """Lazy proxy for metrics adapter initialization."""
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(get_metrics(), name)
-
-
-class _LazyTracesProxy:
-    """Lazy proxy for traces adapter initialization."""
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(get_traces(), name)
-
-
-metrics = cast(Any, _LazyMetricsProxy())
-traces = cast(Any, _LazyTracesProxy())
+metrics = cast(Any, LazyMetricsProxy())
+traces = cast(Any, LazyTracesProxy())
 
 
 class BaseSQLMetadataExtractionApplication(BaseApplication):

--- a/application_sdk/application/metadata_extraction/sql.py
+++ b/application_sdk/application/metadata_extraction/sql.py
@@ -1,5 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type, cast
 
 from typing_extensions import deprecated
 
@@ -23,8 +23,24 @@ from application_sdk.workflows.metadata_extraction.sql import (
 )
 
 logger = get_logger(__name__)
-metrics = get_metrics()
-traces = get_traces()
+
+
+class _LazyMetricsProxy:
+    """Lazy proxy for metrics adapter initialization."""
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(get_metrics(), name)
+
+
+class _LazyTracesProxy:
+    """Lazy proxy for traces adapter initialization."""
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(get_traces(), name)
+
+
+metrics = cast(Any, _LazyMetricsProxy())
+traces = cast(Any, _LazyTracesProxy())
 
 
 class BaseSQLMetadataExtractionApplication(BaseApplication):

--- a/application_sdk/common/aws_utils.py
+++ b/application_sdk/common/aws_utils.py
@@ -1,13 +1,23 @@
-import re
-from typing import Any, Dict, Optional
+from __future__ import annotations
 
-import boto3
+import re
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
 from sqlalchemy.engine.url import URL
 
 from application_sdk.constants import AWS_SESSION_NAME
 from application_sdk.observability.logger_adaptor import get_logger
 
+if TYPE_CHECKING:
+    import boto3
+
 logger = get_logger(__name__)
+
+
+def _get_boto3() -> Any:
+    import boto3
+
+    return boto3
 
 
 def get_region_name_from_hostname(hostname: str) -> str:
@@ -153,6 +163,8 @@ def create_aws_session(credentials: Dict[str, Any]) -> boto3.Session:
     Returns:
         boto3.Session: Configured boto3 session
     """
+    boto3 = _get_boto3()
+
     aws_access_key_id = credentials.get("aws_access_key_id") or credentials.get(
         "username"
     )
@@ -256,6 +268,8 @@ def create_aws_client(
         raise ValueError("Only one credential source should be provided at a time")
 
     try:
+        boto3 = _get_boto3()
+
         # Priority 1: Use provided session
         if session is not None:
             logger.debug(
@@ -327,6 +341,8 @@ def get_all_aws_regions() -> list[str]:
         Exception: If unable to retrieve regions from AWS
     """
     try:
+        boto3 = _get_boto3()
+
         # Use us-east-1 as the default region for the EC2 client since it's always available
         ec2_client = boto3.client("ec2", region_name="us-east-1")
         response = ec2_client.describe_regions()

--- a/application_sdk/common/file_converter.py
+++ b/application_sdk/common/file_converter.py
@@ -1,12 +1,26 @@
 from collections import namedtuple
 from enum import Enum
-from typing import List, Optional
-
-import pandas as pd
+from typing import Any, List, Optional, cast
 
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
+
+
+class _PandasProxy:
+    """Lazy proxy for pandas.
+
+    Keeps the existing `pd.*` call pattern while deferring the pandas import
+    until a pandas attribute is actually used.
+    """
+
+    def __getattr__(self, name: str) -> Any:
+        import pandas
+
+        return getattr(pandas, name)
+
+
+pd = cast(Any, _PandasProxy())
 
 
 def enum_register():

--- a/application_sdk/observability/lazy_proxies.py
+++ b/application_sdk/observability/lazy_proxies.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+from application_sdk.observability.metrics_adaptor import get_metrics
+from application_sdk.observability.traces_adaptor import get_traces
+
+
+class LazyMetricsProxy:
+    """Lazy proxy for metrics adapter initialization."""
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(get_metrics(), name)
+
+
+class LazyTracesProxy:
+    """Lazy proxy for traces adapter initialization."""
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(get_traces(), name)

--- a/application_sdk/observability/metrics_adaptor.py
+++ b/application_sdk/observability/metrics_adaptor.py
@@ -5,12 +5,6 @@ import threading
 from time import time
 from typing import Any, Dict, Optional
 
-from opentelemetry import metrics
-from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
-from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-from opentelemetry.sdk.resources import Resource
-
 from application_sdk.constants import (
     ENABLE_OTLP_METRICS,
     METRICS_BATCH_SIZE,
@@ -123,6 +117,14 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
             Exception: If setup fails, logs error and continues without OTLP
         """
         try:
+            from opentelemetry import metrics as otel_metrics
+            from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+                OTLPMetricExporter,
+            )
+            from opentelemetry.sdk.metrics import MeterProvider
+            from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+            from opentelemetry.sdk.resources import Resource
+
             # Get workflow node name for Argo environment
             workflow_node_name = OTEL_WF_NODE_NAME
 
@@ -163,7 +165,7 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
             )
 
             # Set global meter provider
-            metrics.set_meter_provider(self.meter_provider)
+            otel_metrics.set_meter_provider(self.meter_provider)
 
             # Create meter
             self.meter = self.meter_provider.get_meter(SERVICE_NAME)

--- a/application_sdk/observability/observability.py
+++ b/application_sdk/observability/observability.py
@@ -10,8 +10,6 @@ from pathlib import Path
 from time import time
 from typing import Any, Dict, Generic, List, TypeVar
 
-import duckdb
-import pandas as pd
 from dapr.clients import DaprClient
 from pydantic import BaseModel
 
@@ -384,6 +382,8 @@ class AtlanObservability(Generic[T], ABC):
         if not ENABLE_OBSERVABILITY_DAPR_SINK:
             return
         try:
+            import pandas as pd
+
             # Group records by partition
             partition_records = {}
             for record in records:
@@ -614,6 +614,8 @@ class DuckDBUI:
     def start_ui(self):
         """Start DuckDB UI and create views for Hive partitioned parquet files."""
         if not self._is_duckdb_ui_running():
+            import duckdb
+
             os.makedirs(self.observability_dir, exist_ok=True)
             con = duckdb.connect(self.db_path)
 

--- a/application_sdk/observability/traces_adaptor.py
+++ b/application_sdk/observability/traces_adaptor.py
@@ -4,12 +4,6 @@ import threading
 import time
 from typing import Any, Dict, Optional
 
-from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
-from opentelemetry.trace import SpanKind
 from pydantic import BaseModel
 
 from application_sdk.constants import (
@@ -129,6 +123,17 @@ class AtlanTracesAdapter(AtlanObservability[TraceRecord]):
         Falls back to console-only tracing if setup fails.
         """
         try:
+            from opentelemetry import trace
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+                OTLPSpanExporter,
+            )
+            from opentelemetry.sdk.resources import Resource
+            from opentelemetry.sdk.trace import TracerProvider
+            from opentelemetry.sdk.trace.export import (
+                BatchSpanProcessor,
+                ConsoleSpanExporter,
+            )
+
             # Get workflow node name for Argo environment
             workflow_node_name = OTEL_WF_NODE_NAME
 
@@ -210,6 +215,14 @@ class AtlanTracesAdapter(AtlanObservability[TraceRecord]):
         - Creates tracer for the service
         """
         try:
+            from opentelemetry import trace
+            from opentelemetry.sdk.resources import Resource
+            from opentelemetry.sdk.trace import TracerProvider
+            from opentelemetry.sdk.trace.export import (
+                BatchSpanProcessor,
+                ConsoleSpanExporter,
+            )
+
             # Create resource with basic attributes
             resource = Resource.create(
                 {
@@ -326,7 +339,7 @@ class AtlanTracesAdapter(AtlanObservability[TraceRecord]):
         # Log to console
         self._log_to_console(record)
 
-    def _str_to_span_kind(self, kind: str) -> SpanKind:
+    def _str_to_span_kind(self, kind: str) -> Any:
         """Convert string kind to OpenTelemetry SpanKind enum.
 
         Args:
@@ -337,6 +350,8 @@ class AtlanTracesAdapter(AtlanObservability[TraceRecord]):
 
         Defaults to INTERNAL if kind is not recognized.
         """
+        from opentelemetry.trace import SpanKind
+
         kind_map = {
             "INTERNAL": SpanKind.INTERNAL,
             "SERVER": SpanKind.SERVER,
@@ -373,6 +388,8 @@ class AtlanTracesAdapter(AtlanObservability[TraceRecord]):
             Exception: If sending fails, logs error and continues
         """
         try:
+            from opentelemetry import trace
+
             # Convert string kind to SpanKind enum
             span_kind = self._str_to_span_kind(trace_record.kind)
 

--- a/application_sdk/server/fastapi/middleware/metrics.py
+++ b/application_sdk/server/fastapi/middleware/metrics.py
@@ -6,8 +6,6 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from application_sdk.observability.metrics_adaptor import MetricType, get_metrics
 from application_sdk.server.fastapi.utils import EXCLUDED_LOG_PATHS
 
-metrics = get_metrics()
-
 
 class MetricsMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):

--- a/application_sdk/transformers/atlas/__init__.py
+++ b/application_sdk/transformers/atlas/__init__.py
@@ -4,10 +4,11 @@ This module provides the Atlas transformer implementation for converting metadat
 into Atlas entities using the pyatlan library.
 """
 
-from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Type
+from __future__ import annotations
 
-import daft
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type
+
 from pyatlan.model.enums import AtlanConnectorType, EntityStatus
 
 from application_sdk.observability.logger_adaptor import get_logger
@@ -15,6 +16,15 @@ from application_sdk.transformers import TransformerInterface
 from application_sdk.transformers.common.utils import process_text
 
 logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    import daft
+
+
+def _import_daft() -> Any:
+    import daft
+
+    return daft
 
 
 class AtlasTransformer(TransformerInterface):
@@ -84,6 +94,7 @@ class AtlasTransformer(TransformerInterface):
         self.entity_class_definitions = (
             entity_class_definitions or self.entity_class_definitions
         )
+        daft = _import_daft()
         connection_name = kwargs.get("connection", {}).get("connection_name", None)
         connection_qualified_name = kwargs.get("connection", {}).get(
             "connection_qualified_name", None

--- a/application_sdk/transformers/query/__init__.py
+++ b/application_sdk/transformers/query/__init__.py
@@ -1,10 +1,10 @@
+from __future__ import annotations
+
 import textwrap
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
 
-import daft
 import yaml
-from daft.functions import to_struct, when
 from pyatlan.model.enums import AtlanConnectorType
 
 from application_sdk.observability.logger_adaptor import get_logger
@@ -15,6 +15,27 @@ from application_sdk.transformers.common.utils import (
 )
 
 logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    import daft
+
+
+def _import_daft() -> Any:
+    import daft
+
+    return daft
+
+
+def to_struct(*args: Any, **kwargs: Any) -> Any:
+    from daft.functions import to_struct as _to_struct
+
+    return _to_struct(*args, **kwargs)
+
+
+def when(*args: Any, **kwargs: Any) -> Any:
+    from daft.functions import when as _when
+
+    return _when(*args, **kwargs)
 
 
 class QueryBasedTransformer(TransformerInterface):
@@ -216,6 +237,7 @@ class QueryBasedTransformer(TransformerInterface):
             logger.error("ERROR: prefix is None in _build_struct!")
             raise ValueError("prefix cannot be None in _build_struct")
 
+        daft = _import_daft()
         struct_fields = []
         non_null_fields = []
 
@@ -296,6 +318,8 @@ class QueryBasedTransformer(TransformerInterface):
             daft.DataFrame: DataFrame with columns grouped into structs
         """
         try:
+            daft = _import_daft()
+
             # Get all column names
             columns = dataframe.column_names
             logger.debug("=== DEBUG: get_grouped_dataframe_by_prefix ===")
@@ -371,6 +395,8 @@ class QueryBasedTransformer(TransformerInterface):
         Returns:
             Tuple[daft.DataFrame, str]: DataFrame with default attributes added and the entity SQL template
         """
+        daft = _import_daft()
+
         # prepare default attributes
         default_attributes = {
             "connection_qualified_name": daft.lit(connection_qualified_name),
@@ -419,6 +445,8 @@ class QueryBasedTransformer(TransformerInterface):
     ) -> Optional[daft.DataFrame]:
         """Transform records using SQL executed through Daft"""
         try:
+            daft = _import_daft()
+
             if dataframe.count_rows() == 0:
                 return None
 

--- a/tests/unit/application/metadata_extraction/test_sql.py
+++ b/tests/unit/application/metadata_extraction/test_sql.py
@@ -448,6 +448,8 @@ class TestSQLApplicationModeStart:
         app.worker.start.assert_called_once_with(daemon=True)
         # In LOCAL mode, server should also be started
         mock_server_instance.start.assert_called_once()
+        # LOCAL mode should stop worker when server exits
+        app.worker.stop.assert_called_once()
 
     @patch("application_sdk.application.metadata_extraction.sql.get_workflow_client")
     @patch("application_sdk.application.metadata_extraction.sql.APIServer")


### PR DESCRIPTION
## Summary
- fix `APIServer.start()` shutdown path so Ctrl+C / task cancellation triggers explicit uvicorn shutdown (`server.should_exit` + `await server.shutdown()`)
- update `BaseApplication.start()` local-mode lifecycle to always stop the worker when server exits/fails
- add `Worker.stop()` support for both same-loop and cross-thread (daemon) worker shutdown
- lazy-load heavy dependencies to reduce eager memory/runtime overhead: `pandas`, `duckdb`, OpenTelemetry modules, `boto3`, and `daft`
- replace eager module-level observability singleton initialization with lazy proxies (`get_metrics()` / `get_traces()` only when used)

## Why
- Ctrl+C previously left local runs hanging because embedded uvicorn/worker shutdown was not coordinated.
- several heavyweight imports were loaded at startup even on code paths that never used them, increasing baseline memory and startup cost.

## Validation
- `uv run pytest tests/unit/observability tests/unit/application/test_application.py tests/unit/application/metadata_extraction/test_sql.py tests/unit/common/test_aws_utils.py tests/unit/common/test_file_converter.py tests/unit/transformers -q`
- `uv run pre-commit run --files application_sdk/application/__init__.py application_sdk/application/metadata_extraction/sql.py application_sdk/common/aws_utils.py application_sdk/common/file_converter.py application_sdk/observability/logger_adaptor.py application_sdk/observability/metrics_adaptor.py application_sdk/observability/observability.py application_sdk/observability/traces_adaptor.py application_sdk/server/fastapi/middleware/metrics.py application_sdk/transformers/atlas/__init__.py application_sdk/transformers/query/__init__.py`
