### PR TITLE
BLDX-590: observability improvements — jsonl.gz logs, correlation context, dual OTEL export

### DIFF
--- a/application_sdk/clients/temporal.py
+++ b/application_sdk/clients/temporal.py
@@ -309,9 +309,14 @@ class TemporalWorkflowClient(WorkflowClient):
             if not self.client:
                 raise ValueError("Client is not loaded")
 
+            correlation_fields = {
+                k: v
+                for k, v in workflow_args.items()
+                if k.startswith("atlan-") or k == "trace_id"
+            }
             handle = await self.client.start_workflow(
                 workflow_class,  # type: ignore
-                args=[{"workflow_id": workflow_id}],
+                args=[{"workflow_id": workflow_id, **correlation_fields}],
                 id=workflow_id,
                 task_queue=self.worker_task_queue,
                 cron_schedule=workflow_args.get("cron_schedule", ""),

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -194,14 +194,8 @@ OTEL_RESOURCE_ATTRIBUTES: str = os.getenv("OTEL_RESOURCE_ATTRIBUTES", "")
 OTEL_EXPORTER_OTLP_ENDPOINT: str = os.getenv(
     "OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"
 )
-#: Secondary endpoint for workflow logs (optional, for dual export to tenant-level collector)
-OTEL_WORKFLOW_LOGS_ENDPOINT: str = os.getenv("OTEL_WORKFLOW_LOGS_ENDPOINT", "")
 #: Whether to enable OpenTelemetry log export
 ENABLE_OTLP_LOGS: bool = os.getenv("ENABLE_OTLP_LOGS", "false").lower() == "true"
-#: Whether to enable workflow logs export to secondary endpoint (for S3 archival + live streaming)
-ENABLE_WORKFLOW_LOGS_EXPORT: bool = (
-    os.getenv("ENABLE_WORKFLOW_LOGS_EXPORT", "false").lower() == "true"
-)
 
 # OTEL Constants
 #: Node name for workflow telemetry
@@ -252,10 +246,6 @@ METRICS_RETENTION_DAYS = int(os.getenv("ATLAN_METRICS_RETENTION_DAYS", "30"))
 SEGMENT_API_URL = os.getenv("ATLAN_SEGMENT_API_URL", "https://api.segment.io/v1/batch")
 #: Segment write key for authentication
 SEGMENT_WRITE_KEY = os.getenv("ATLAN_SEGMENT_WRITE_KEY", "")
-#: Whether to enable Segment metrics export
-ENABLE_SEGMENT_METRICS = (
-    os.getenv("ATLAN_ENABLE_SEGMENT_METRICS", "false").lower() == "true"
-)
 #: Default user ID for Segment events
 SEGMENT_DEFAULT_USER_ID = "atlan.automation"
 #: Maximum batch size for Segment events

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -194,8 +194,14 @@ OTEL_RESOURCE_ATTRIBUTES: str = os.getenv("OTEL_RESOURCE_ATTRIBUTES", "")
 OTEL_EXPORTER_OTLP_ENDPOINT: str = os.getenv(
     "OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"
 )
+#: Secondary endpoint for workflow logs (optional, for dual export to tenant-level collector)
+OTEL_WORKFLOW_LOGS_ENDPOINT: str = os.getenv("OTEL_WORKFLOW_LOGS_ENDPOINT", "")
 #: Whether to enable OpenTelemetry log export
 ENABLE_OTLP_LOGS: bool = os.getenv("ENABLE_OTLP_LOGS", "false").lower() == "true"
+#: Whether to enable workflow logs export to secondary endpoint (for S3 archival + live streaming)
+ENABLE_WORKFLOW_LOGS_EXPORT: bool = (
+    os.getenv("ENABLE_WORKFLOW_LOGS_EXPORT", "false").lower() == "true"
+)
 
 # OTEL Constants
 #: Node name for workflow telemetry
@@ -244,8 +250,12 @@ METRICS_RETENTION_DAYS = int(os.getenv("ATLAN_METRICS_RETENTION_DAYS", "30"))
 # Segment Configuration
 #: Segment API URL for sending events. Defaults to https://api.segment.io/v1/batch
 SEGMENT_API_URL = os.getenv("ATLAN_SEGMENT_API_URL", "https://api.segment.io/v1/batch")
-#: Segment write key for authentication. If set, Segment metrics are automatically enabled.
+#: Segment write key for authentication
 SEGMENT_WRITE_KEY = os.getenv("ATLAN_SEGMENT_WRITE_KEY", "")
+#: Whether to enable Segment metrics export
+ENABLE_SEGMENT_METRICS = (
+    os.getenv("ATLAN_ENABLE_SEGMENT_METRICS", "false").lower() == "true"
+)
 #: Default user ID for Segment events
 SEGMENT_DEFAULT_USER_ID = "atlan.automation"
 #: Maximum batch size for Segment events

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -82,7 +82,7 @@ STATE_STORE_PATH_TEMPLATE = (
 
 # Observability Constants
 #: Directory for storing observability data
-OBSERVABILITY_DIR = "artifacts/apps/{application_name}/{deployment_name}/observability"
+OBSERVABILITY_DIR = "artifacts/apps/observability"
 
 # Workflow Client Constants
 #: Host address for the Temporal server

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -223,7 +223,7 @@ LOG_RETENTION_DAYS = int(os.environ.get("ATLAN_LOG_RETENTION_DAYS", 30))
 LOG_CLEANUP_ENABLED = bool(os.environ.get("ATLAN_LOG_CLEANUP_ENABLED", False))
 
 # Log Location configuration
-LOG_FILE_NAME = os.environ.get("ATLAN_LOG_FILE_NAME", "log.parquet")
+LOG_FILE_NAME = os.environ.get("ATLAN_LOG_FILE_NAME", "log.jsonl.gz")
 # Hive Partitioning Configuration
 ENABLE_HIVE_PARTITIONING = (
     os.getenv("ATLAN_ENABLE_HIVE_PARTITIONING", "true").lower() == "true"

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -24,7 +24,6 @@ from application_sdk.constants import (
     ENABLE_ATLAN_UPLOAD,
     ENABLE_OBSERVABILITY_DAPR_SINK,
     ENABLE_OTLP_LOGS,
-    ENABLE_WORKFLOW_LOGS_EXPORT,
     LOG_BATCH_SIZE,
     LOG_CLEANUP_ENABLED,
     LOG_FILE_NAME,
@@ -38,7 +37,6 @@ from application_sdk.constants import (
     OTEL_QUEUE_SIZE,
     OTEL_RESOURCE_ATTRIBUTES,
     OTEL_WF_NODE_NAME,
-    OTEL_WORKFLOW_LOGS_ENDPOINT,
     SERVICE_NAME,
     SERVICE_VERSION,
     UPSTREAM_OBJECT_STORE_NAME,
@@ -368,29 +366,6 @@ class AtlanLoggerAdapter(AtlanObservability[LogRecordModel]):
                 )
 
                 self.logger_provider.add_log_record_processor(batch_processor)
-
-                # Secondary exporter for workflow logs (optional dual export)
-                # Sends to tenant-level collector for S3 archival and live streaming
-                # Requires both ENABLE_WORKFLOW_LOGS_EXPORT=true and OTEL_WORKFLOW_LOGS_ENDPOINT set
-                if ENABLE_WORKFLOW_LOGS_EXPORT and OTEL_WORKFLOW_LOGS_ENDPOINT:
-                    workflow_logs_exporter = OTLPLogExporter(
-                        endpoint=OTEL_WORKFLOW_LOGS_ENDPOINT,
-                        timeout=OTEL_EXPORTER_TIMEOUT_SECONDS,
-                    )
-
-                    workflow_logs_processor = BatchLogRecordProcessor(
-                        workflow_logs_exporter,
-                        schedule_delay_millis=OTEL_BATCH_DELAY_MS,
-                        max_export_batch_size=OTEL_BATCH_SIZE,
-                        max_queue_size=OTEL_QUEUE_SIZE,
-                    )
-
-                    self.logger_provider.add_log_record_processor(
-                        workflow_logs_processor
-                    )
-                    logging.info(
-                        f"Dual OTEL export enabled: workflow logs also sent to {OTEL_WORKFLOW_LOGS_ENDPOINT}"
-                    )
 
                 # Add OTLP sink
                 self.logger.add(self.otlp_sink, level=SEVERITY_MAPPING[LOG_LEVEL])

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -1,10 +1,15 @@
 import asyncio
+import gzip
 import logging
+import os
+import socket
 import sys
 import threading
+from datetime import datetime
 from time import time_ns
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
+import orjson
 from loguru import logger
 from opentelemetry._logs import LogRecord, SeverityNumber
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
@@ -15,6 +20,8 @@ from opentelemetry.trace.span import TraceFlags
 from pydantic import BaseModel, Field
 
 from application_sdk.constants import (
+    APPLICATION_NAME,
+    ENABLE_ATLAN_UPLOAD,
     ENABLE_OBSERVABILITY_DAPR_SINK,
     ENABLE_OTLP_LOGS,
     LOG_BATCH_SIZE,
@@ -32,6 +39,7 @@ from application_sdk.constants import (
     OTEL_WF_NODE_NAME,
     SERVICE_NAME,
     SERVICE_VERSION,
+    UPSTREAM_OBJECT_STORE_NAME,
 )
 from application_sdk.observability.context import correlation_context, request_context
 from application_sdk.observability.observability import AtlanObservability
@@ -73,8 +81,10 @@ class LogExtraModel(BaseModel):
     heartbeat_timeout: Optional[str] = None
     # Other fields
     log_type: Optional[str] = None
+    app_name: Optional[str] = None
     # Trace context
     trace_id: Optional[str] = None
+    correlation_id: Optional[str] = None
 
 
 class LogRecordModel(BaseModel):
@@ -526,6 +536,7 @@ class AtlanLoggerAdapter(AtlanObservability[LogRecordModel]):
         - Adds correlation context if available
         """
         kwargs["logger_name"] = self.logger_name
+        kwargs["app_name"] = APPLICATION_NAME
 
         # Get request context
         ctx = request_context.get()
@@ -558,6 +569,7 @@ class AtlanLoggerAdapter(AtlanObservability[LogRecordModel]):
             # Add trace_id if present (for log format display)
             if "trace_id" in corr_ctx and corr_ctx["trace_id"]:
                 kwargs["trace_id"] = str(corr_ctx["trace_id"])
+                kwargs["correlation_id"] = str(corr_ctx["trace_id"])
             # Add atlan-* headers for OTEL
             for key, value in corr_ctx.items():
                 if key.startswith("atlan-") and value:
@@ -737,6 +749,70 @@ class AtlanLoggerAdapter(AtlanObservability[LogRecordModel]):
                     loop.close()
         except Exception as e:
             logging.error(f"Error during sync flush: {e}")
+
+    async def _flush_records(self, records: List[Dict[str, Any]]):
+        """Flush records to jsonl.gz files and upload to object store.
+
+        Overrides the base class parquet implementation to write compressed
+        JSON Lines files instead.
+        """
+        if not ENABLE_OBSERVABILITY_DAPR_SINK:
+            return
+        try:
+            # Group records by partition
+            partition_records: Dict[str, List[Dict[str, Any]]] = {}
+            for record in records:
+                record_time = datetime.fromtimestamp(record["timestamp"])
+                partition_path = self._get_partition_path(record_time)
+                if partition_path not in partition_records:
+                    partition_records[partition_path] = []
+                partition_records[partition_path].append(record)
+
+            hostname = socket.gethostname()
+
+            for partition_path, partition_data in partition_records.items():
+                try:
+                    timestamp_ns = time_ns()
+                    custom_filename = (
+                        f"{timestamp_ns}_{hostname}_{APPLICATION_NAME}_logs.jsonl.gz"
+                    )
+
+                    os.makedirs(partition_path, exist_ok=True)
+                    file_path = os.path.join(partition_path, custom_filename)
+
+                    with gzip.open(file_path, "wb") as f:
+                        for record in partition_data:
+                            f.write(orjson.dumps(record) + b"\n")
+
+                    # Lazy imports for upload
+                    from application_sdk.activities.common.utils import (
+                        get_object_store_prefix,
+                    )
+                    from application_sdk.services.objectstore import ObjectStore
+
+                    if ENABLE_ATLAN_UPLOAD:
+                        await ObjectStore.upload_file(
+                            source=file_path,
+                            store_name=UPSTREAM_OBJECT_STORE_NAME,
+                            destination=get_object_store_prefix(file_path),
+                            retain_local_copy=True,
+                        )
+                    await ObjectStore.upload_file(
+                        source=file_path,
+                        destination=get_object_store_prefix(file_path),
+                    )
+
+                except Exception as partition_error:
+                    logging.error(
+                        f"Error processing partition {partition_path}: {str(partition_error)}"
+                    )
+
+            # Clean up old records if enabled
+            if self._cleanup_enabled:
+                await self._check_and_cleanup()
+
+        except Exception as e:
+            logging.error(f"Error flushing records batch: {e}")
 
     def tracing(self, msg: str, *args: Any, **kwargs: Any):
         """Log a trace-specific message with trace context.

--- a/application_sdk/observability/observability.py
+++ b/application_sdk/observability/observability.py
@@ -2,12 +2,13 @@ import asyncio
 import logging
 import os
 import signal
+import socket
 import sys
 import threading
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 from pathlib import Path
-from time import time
+from time import time, time_ns
 from typing import Any, Dict, Generic, List, TypeVar
 
 import duckdb
@@ -16,12 +17,15 @@ from dapr.clients import DaprClient
 from pydantic import BaseModel
 
 from application_sdk.constants import (
+    APPLICATION_NAME,
     DEPLOYMENT_OBJECT_STORE_NAME,
+    ENABLE_ATLAN_UPLOAD,
     ENABLE_OBSERVABILITY_DAPR_SINK,
     LOG_FILE_NAME,
     METRICS_FILE_NAME,
     STATE_STORE_NAME,
     TRACES_FILE_NAME,
+    UPSTREAM_OBJECT_STORE_NAME,
 )
 from application_sdk.observability.utils import get_observability_dir
 
@@ -363,31 +367,24 @@ class AtlanObservability(Generic[T], ABC):
             logging.error(f"Error buffering log: {e}")
 
     async def _flush_records(self, records: List[Dict[str, Any]]):
-        """Flush records to parquet file and object store using ParquetFileWriter.
+        """Flush records to parquet file and upload to object store.
 
         Args:
             records: List of records to flush
 
         This method:
         - Groups records by partition (year/month/day)
-        - Uses ParquetFileWriter for efficient writing
-        - Automatically handles chunking, compression, and dual upload
+        - Writes parquet files with descriptive filenames encoding app identity
+        - Handles dual upload (deployment store + upstream for SDR)
         - Provides robust error handling per partition
         - Cleans up old records if enabled
-
-        Features:
-        - Automatic chunking for large datasets
-        - Dual upload support (primary + upstream if enabled)
-        - Advanced consolidation for optimal performance
-        - Fault-tolerant processing (continues on partition errors)
         """
         if not ENABLE_OBSERVABILITY_DAPR_SINK:
             return
         try:
             # Group records by partition
-            partition_records = {}
+            partition_records: Dict[str, List[Dict[str, Any]]] = {}
             for record in records:
-                # Convert timestamp to datetime
                 record_time = datetime.fromtimestamp(record["timestamp"])
                 partition_path = self._get_partition_path(record_time)
 
@@ -395,39 +392,50 @@ class AtlanObservability(Generic[T], ABC):
                     partition_records[partition_path] = []
                 partition_records[partition_path].append(record)
 
-                # Write records to each partition using ParquetFileWriter
+            # Determine suffix from file type
+            if self.file_name == LOG_FILE_NAME:
+                suffix = "logs"
+            elif self.file_name == METRICS_FILE_NAME:
+                suffix = "metrics"
+            elif self.file_name == TRACES_FILE_NAME:
+                suffix = "traces"
+            else:
+                suffix = "data"
+
+            hostname = socket.gethostname()
+
             for partition_path, partition_data in partition_records.items():
-                # Create new dataframe from current records
-                new_df = pd.DataFrame(partition_data)
-
-                # Extract partition values from path and add to dataframe
-                partition_parts = os.path.basename(
-                    os.path.dirname(partition_path)
-                ).split(os.sep)
-                for part in partition_parts:
-                    if part.startswith("year="):
-                        new_df["year"] = int(part.split("=")[1])
-                    elif part.startswith("month="):
-                        new_df["month"] = int(part.split("=")[1])
-                    elif part.startswith("day="):
-                        new_df["day"] = int(part.split("=")[1])
-
-                # Use new data directly - let ParquetFileWriter handle consolidation and merging
-                df = new_df
-
-                # Use ParquetFileWriter for efficient writing and uploading
-                # Set the output path for this partition
                 try:
-                    # Lazy import and instantiation of ParquetFileWriter
-                    from application_sdk.io.parquet import ParquetFileWriter
+                    df = pd.DataFrame(partition_data)
 
-                    parquet_writer = ParquetFileWriter(
-                        path=partition_path,
-                        chunk_start=0,
-                        chunk_part=int(time()),
+                    # Build unique filename: {timestamp_ns}_{hostname}_{app}_{suffix}.parquet
+                    timestamp_ns = time_ns()
+                    custom_filename = (
+                        f"{timestamp_ns}_{hostname}_{APPLICATION_NAME}_{suffix}.parquet"
                     )
 
-                    await parquet_writer._write_dataframe(dataframe=df)
+                    os.makedirs(partition_path, exist_ok=True)
+                    file_path = os.path.join(partition_path, custom_filename)
+                    df.to_parquet(file_path, index=False, compression="snappy")
+
+                    # Lazy imports for upload
+                    from application_sdk.activities.common.utils import (
+                        get_object_store_prefix,
+                    )
+                    from application_sdk.services.objectstore import ObjectStore
+
+                    # Dual upload: upstream (SDR) + deployment store
+                    if ENABLE_ATLAN_UPLOAD:
+                        await ObjectStore.upload_file(
+                            source=file_path,
+                            store_name=UPSTREAM_OBJECT_STORE_NAME,
+                            destination=get_object_store_prefix(file_path),
+                            retain_local_copy=True,
+                        )
+                    await ObjectStore.upload_file(
+                        source=file_path,
+                        destination=get_object_store_prefix(file_path),
+                    )
 
                 except Exception as partition_error:
                     logging.error(

--- a/application_sdk/observability/utils.py
+++ b/application_sdk/observability/utils.py
@@ -3,12 +3,7 @@ import os
 from pydantic import BaseModel, Field
 from temporalio import activity, workflow
 
-from application_sdk.constants import (
-    APPLICATION_NAME,
-    DEPLOYMENT_NAME,
-    OBSERVABILITY_DIR,
-    TEMPORARY_PATH,
-)
+from application_sdk.constants import OBSERVABILITY_DIR, TEMPORARY_PATH
 from application_sdk.observability.context import correlation_context
 
 
@@ -34,17 +29,12 @@ class WorkflowContext(BaseModel):
 
 
 def get_observability_dir() -> str:
-    """Build the observability path using deployment name.
+    """Build the observability directory path.
 
     Returns:
-        str: The built observability path using deployment name.
+        str: The observability directory path.
     """
-    return os.path.join(
-        TEMPORARY_PATH,
-        OBSERVABILITY_DIR.format(
-            application_name=APPLICATION_NAME, deployment_name=DEPLOYMENT_NAME
-        ),
-    )
+    return os.path.join(TEMPORARY_PATH, OBSERVABILITY_DIR)
 
 
 def get_workflow_context() -> WorkflowContext:

--- a/poc/dual-export-test/README.md
+++ b/poc/dual-export-test/README.md
@@ -1,0 +1,99 @@
+# Dual Export Test Setup
+
+Tests the SDK's dual OTEL export functionality with two separate collectors.
+
+## Architecture
+
+```
+                              ┌─────────────────────────────┐
+                              │   Application (SDK)         │
+                              │                             │
+                              │ OTEL_EXPORTER_OTLP_ENDPOINT │
+                              │ = localhost:4317            │
+                              │                             │
+                              │ OTEL_WORKFLOW_LOGS_ENDPOINT │
+                              │ = localhost:5317            │
+                              └──────────┬──────────────────┘
+                                         │
+                    ┌────────────────────┼────────────────────┐
+                    │                    │                    │
+                    ▼                    │                    ▼
+    ┌───────────────────────────┐       │    ┌───────────────────────────┐
+    │  Primary Collector        │       │    │  Workflow Logs Collector  │
+    │  (port 4317)              │       │    │  (port 5317)              │
+    │                           │       │    │                           │
+    │  Simulates: DaemonSet     │       │    │  Simulates: Tenant-level  │
+    │  Export: debug (console)  │       │    │  Export: awss3 (MinIO)    │
+    └───────────────────────────┘       │    └─────────────┬─────────────┘
+                                        │                  │
+                                        │                  ▼
+                                        │    ┌───────────────────────────┐
+                                        │    │  MinIO (S3)               │
+                                        │    │  Bucket: workflow-logs    │
+                                        │    │  Console: localhost:9001  │
+                                        │    └───────────────────────────┘
+```
+
+## Quick Start
+
+```bash
+# 1. Start the collectors and MinIO
+cd poc/dual-export-test
+docker-compose up -d
+
+# 2. Verify services are running
+docker-compose ps
+
+# 3. Run the test script (from repo root)
+cd /path/to/application-sdk
+source .venv/bin/activate
+python poc/dual-export-test/test_dual_export.py
+
+# 4. Check both collectors received logs
+docker logs primary-collector
+docker logs workflow-logs-collector
+
+# 5. Check MinIO for S3 files
+# Open http://localhost:9001 (login: minioadmin/minioadmin)
+# Browse to 'workflow-logs' bucket
+```
+
+## Manual Testing with MSSQL App
+
+```bash
+# 1. Start collectors (if not already running)
+cd application-sdk/poc/dual-export-test
+docker-compose up -d
+
+# 2. Go to mssql app
+cd atlan-mssql-app
+source .venv/bin/activate
+
+# 3. Set environment variables
+export ENABLE_OTLP_LOGS=true
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+export OTEL_WORKFLOW_LOGS_ENDPOINT=http://localhost:5317
+
+# 4. Run your workflow/app
+# ... your normal commands ...
+
+# 5. Check logs in collectors
+docker logs primary-collector -f
+docker logs workflow-logs-collector -f
+```
+
+## Cleanup
+
+```bash
+cd poc/dual-export-test
+docker-compose down -v
+```
+
+## Port Mapping
+
+| Service | Port | Description |
+|---------|------|-------------|
+| Primary Collector | 4317 | OTLP gRPC (simulates DaemonSet) |
+| Workflow Logs Collector | 5317 | OTLP gRPC (simulates tenant-level) |
+| MinIO API | 9000 | S3-compatible API |
+| MinIO Console | 9001 | Web UI (minioadmin/minioadmin) |

--- a/poc/dual-export-test/docker-compose.yaml
+++ b/poc/dual-export-test/docker-compose.yaml
@@ -1,0 +1,86 @@
+version: "3.8"
+
+# Dual Export Test Setup
+# Tests the SDK's dual OTEL export functionality:
+# - Primary collector (port 4317): Simulates DaemonSet/central collector
+# - Workflow logs collector (port 5317): Simulates tenant-level collector -> S3
+
+services:
+  # ===========================================
+  # MinIO - S3-compatible object storage
+  # ===========================================
+  minio:
+    image: minio/minio:latest
+    container_name: minio-dual-test
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Create buckets in MinIO
+  createbuckets:
+    image: minio/mc:latest
+    container_name: createbuckets-dual-test
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set myminio http://minio:9000 minioadmin minioadmin;
+      mc mb myminio/artifacts --ignore-existing;
+      mc anonymous set public myminio/artifacts;
+      echo 'Bucket artifacts created';
+      exit 0;
+      "
+
+  # ===========================================
+  # PRIMARY OTEL Collector (simulates DaemonSet)
+  # Port 4317 - Just logs to console (debug exporter)
+  # ===========================================
+  primary-collector:
+    image: otel/opentelemetry-collector-contrib:0.140.0
+    container_name: primary-collector
+    command: ["--config=/etc/otel/config.yaml"]
+    volumes:
+      - ./primary-collector-config.yaml:/etc/otel/config.yaml:ro
+    ports:
+      - "4317:4317"   # OTLP gRPC (primary)
+      - "8888:8888"   # Prometheus metrics
+
+  # ===========================================
+  # WORKFLOW LOGS OTEL Collector (tenant-level)
+  # Port 5317 - Writes to S3 (MinIO)
+  # ===========================================
+  workflow-logs-collector:
+    image: otel/opentelemetry-collector-contrib:0.140.0
+    container_name: workflow-logs-collector
+    command: ["--config=/etc/otel/config.yaml"]
+    volumes:
+      - ./workflow-logs-collector-config.yaml:/etc/otel/config.yaml:ro
+    ports:
+      - "5317:4317"   # OTLP gRPC (workflow logs)
+      - "5318:4318"   # OTLP HTTP
+      - "8889:8888"   # Prometheus metrics
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      - AWS_ACCESS_KEY_ID=minioadmin
+      - AWS_SECRET_ACCESS_KEY=minioadmin
+
+volumes:
+  minio-data:
+
+networks:
+  default:
+    name: dual-export-test-network

--- a/poc/dual-export-test/primary-collector-config.yaml
+++ b/poc/dual-export-test/primary-collector-config.yaml
@@ -1,0 +1,34 @@
+# Primary OTEL Collector Configuration
+# Simulates the DaemonSet/central collector
+# Just receives logs and prints them to console (debug exporter)
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 100
+
+exporters:
+  # Debug exporter - prints logs to console
+  debug:
+    verbosity: detailed
+    sampling_initial: 10
+    sampling_thereafter: 50
+
+service:
+  telemetry:
+    logs:
+      level: info
+
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]

--- a/poc/dual-export-test/test_dual_export.py
+++ b/poc/dual-export-test/test_dual_export.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Test script for dual OTEL export functionality.
+
+This script tests that logs are sent to both:
+1. Primary collector (port 4317) - simulates DaemonSet
+2. Workflow logs collector (port 5317) - simulates tenant-level collector
+
+Usage:
+    # Start the collectors first
+    cd poc/dual-export-test
+    docker-compose up -d
+
+    # Then run this test (from application-sdk root)
+    cd /path/to/application-sdk
+    source .venv/bin/activate
+
+    # Set environment variables
+    export ENABLE_OTLP_LOGS=true
+    export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+    export OTEL_WORKFLOW_LOGS_ENDPOINT=http://localhost:5317
+
+    # Run the test
+    python poc/dual-export-test/test_dual_export.py
+
+    # Check logs in both collectors:
+    docker logs primary-collector
+    docker logs workflow-logs-collector
+
+    # Check S3 (MinIO) for archived logs:
+    # Open http://localhost:9001 (login: minioadmin/minioadmin)
+    # Browse to workflow-logs bucket
+"""
+
+import os
+import time
+
+# Set environment variables BEFORE importing the SDK
+os.environ["ENABLE_OTLP_LOGS"] = "true"
+os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = os.environ.get(
+    "OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"
+)
+os.environ["OTEL_WORKFLOW_LOGS_ENDPOINT"] = os.environ.get(
+    "OTEL_WORKFLOW_LOGS_ENDPOINT", "http://localhost:5317"
+)
+
+# Disable Dapr sink for this test
+os.environ["ATLAN_ENABLE_OBSERVABILITY_DAPR_SINK"] = "false"
+
+print("=" * 60)
+print("Dual Export Test")
+print("=" * 60)
+print(f"ENABLE_OTLP_LOGS: {os.environ.get('ENABLE_OTLP_LOGS')}")
+print(f"OTEL_EXPORTER_OTLP_ENDPOINT: {os.environ.get('OTEL_EXPORTER_OTLP_ENDPOINT')}")
+print(f"OTEL_WORKFLOW_LOGS_ENDPOINT: {os.environ.get('OTEL_WORKFLOW_LOGS_ENDPOINT')}")
+print("=" * 60)
+
+# Now import the SDK logger
+from application_sdk.observability.logger_adaptor import get_logger  # noqa: E402
+
+logger = get_logger("dual-export-test")
+
+print("\nSending test logs...")
+
+# Send some test logs
+for i in range(5):
+    logger.info(
+        f"Test log message {i+1}/5",
+        workflow_id="test-workflow-123",
+        run_id="test-run-456",
+    )
+    print(f"  Sent log {i+1}/5")
+    time.sleep(0.5)
+
+logger.warning("This is a warning message", workflow_id="test-workflow-123")
+logger.error("This is an error message", workflow_id="test-workflow-123")
+
+print("\nWaiting for logs to be exported (10 seconds)...")
+time.sleep(10)
+
+print("\n" + "=" * 60)
+print("Test complete!")
+print("=" * 60)
+print("""
+Next steps:
+1. Check primary collector logs:
+   docker logs primary-collector
+
+2. Check workflow logs collector:
+   docker logs workflow-logs-collector
+
+3. Check MinIO for S3 files:
+   Open http://localhost:9001 (login: minioadmin/minioadmin)
+   Browse to 'workflow-logs' bucket -> 'logs' folder
+
+If you see logs in BOTH collectors, dual export is working!
+""")

--- a/poc/dual-export-test/workflow-logs-collector-config.yaml
+++ b/poc/dual-export-test/workflow-logs-collector-config.yaml
@@ -1,0 +1,61 @@
+# Workflow Logs OTEL Collector Configuration
+# Simulates the tenant-level collector
+# Writes logs to S3 (MinIO) with hive partitions and UUID v7 file names
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 100
+
+  resourcedetection:
+    detectors: [env, system]
+    system:
+      hostname_sources: [os]
+
+exporters:
+  # Archive to S3 (MinIO) with UUID v7 file names (lexicographically sortable)
+  awss3:
+    s3uploader:
+      region: us-east-1
+      s3_bucket: artifacts
+      s3_prefix: apps/workflow-logs
+      # Hive-style time partitions (key=value format for Spark/Trino/Iceberg)
+      s3_partition_format: "year=%Y/month=%m/day=%d/hour=%H"
+      endpoint: http://minio:9000
+      s3_force_path_style: true
+      # UUID v7 for lexicographically sortable file names (time-ordered)
+      unique_key_func_name: uuidv7
+    marshaler: otlp_json
+
+  # Debug exporter for verification
+  debug:
+    verbosity: basic
+    sampling_initial: 5
+    sampling_thereafter: 100
+
+service:
+  telemetry:
+    logs:
+      level: info
+    metrics:
+      level: detailed
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: "0.0.0.0"
+                port: 8888
+
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [resourcedetection, batch]
+      exporters: [awss3, debug]


### PR DESCRIPTION
## Summary

- **jsonl.gz log format**: Switch SDK log output from parquet to compressed JSON Lines (`.jsonl.gz`), adding `correlation_id` and `app_name` fields to every log record
- **S3 path restructure**: Single shared prefix for all observability data (logs, metrics, traces) under `artifacts/apps/{app}/workflows/{wf_id}/{run_id}/observability/`
- **Dual OTEL export**: Optional second OTEL log exporter for tenant-level collector (workflow log streaming + S3 archival), gated by `ENABLE_WORKFLOW_LOGS_EXPORT` + `OTEL_WORKFLOW_LOGS_ENDPOINT`
- **Correlation context forwarding**: Forward `trace_id` and `atlan-*` fields from workflow config into Temporal `start_workflow` args so `CorrelationContextInterceptor` propagates them to all activities

## Commits

1. `7896755` — restructure S3 observability path to single shared prefix
2. `de406e2` — switch logs to jsonl.gz, add correlation_id and app_name
3. `19afb94` — add dual OTEL export for workflow logs (BLDX-580)
4. `90531af` — forward trace_id and atlan-* fields to Temporal workflow args (BLDX-644)

## Test plan

- [ ] Unit tests pass (`tests/unit/observability/`, `tests/unit/common/`, `tests/unit/services/`)
- [ ] Verify jsonl.gz files are written to correct S3 path in vcluster
- [ ] Verify `correlation_id` and `app_name` present in log records
- [ ] Verify dual OTEL export sends to both endpoints when configured
- [ ] Verify trace_id propagates from workflow start through activity logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)