### PR TITLE
BLDX-590: restructure observability class hierarchy & per-signal flags

### DIFF
--- a/application_sdk/clients/temporal.py
+++ b/application_sdk/clients/temporal.py
@@ -309,9 +309,14 @@ class TemporalWorkflowClient(WorkflowClient):
             if not self.client:
                 raise ValueError("Client is not loaded")
 
+            correlation_fields = {
+                k: v
+                for k, v in workflow_args.items()
+                if k.startswith("atlan-") or k == "trace_id"
+            }
             handle = await self.client.start_workflow(
                 workflow_class,  # type: ignore
-                args=[{"workflow_id": workflow_id}],
+                args=[{"workflow_id": workflow_id, **correlation_fields}],
                 id=workflow_id,
                 task_queue=self.worker_task_queue,
                 cron_schedule=workflow_args.get("cron_schedule", ""),

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -223,7 +223,7 @@ LOG_RETENTION_DAYS = int(os.environ.get("ATLAN_LOG_RETENTION_DAYS", 30))
 LOG_CLEANUP_ENABLED = bool(os.environ.get("ATLAN_LOG_CLEANUP_ENABLED", False))
 
 # Log Location configuration
-LOG_FILE_NAME = os.environ.get("ATLAN_LOG_FILE_NAME", "log.jsonl.gz")
+LOG_FILE_NAME = os.environ.get("ATLAN_LOG_FILE_NAME", "log.parquet")
 # Hive Partitioning Configuration
 ENABLE_HIVE_PARTITIONING = (
     os.getenv("ATLAN_ENABLE_HIVE_PARTITIONING", "true").lower() == "true"
@@ -270,6 +270,19 @@ TRACES_FILE_NAME = "traces.parquet"
 # Dapr Sink Configuration
 ENABLE_OBSERVABILITY_DAPR_SINK = (
     os.getenv("ATLAN_ENABLE_OBSERVABILITY_DAPR_SINK", "true").lower() == "true"
+)
+# Per-signal sink flags — default to the shared flag when not set explicitly
+ENABLE_LOG_SINK = (
+    os.getenv("ATLAN_ENABLE_LOG_SINK", str(ENABLE_OBSERVABILITY_DAPR_SINK)).lower()
+    == "true"
+)
+ENABLE_METRICS_SINK = (
+    os.getenv("ATLAN_ENABLE_METRICS_SINK", str(ENABLE_OBSERVABILITY_DAPR_SINK)).lower()
+    == "true"
+)
+ENABLE_TRACES_SINK = (
+    os.getenv("ATLAN_ENABLE_TRACES_SINK", str(ENABLE_OBSERVABILITY_DAPR_SINK)).lower()
+    == "true"
 )
 
 # atlan_client configuration (non ATLAN_ prefix are rooted in pyatlan SDK, to be revisited)

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -82,7 +82,7 @@ STATE_STORE_PATH_TEMPLATE = (
 
 # Observability Constants
 #: Directory for storing observability data
-OBSERVABILITY_DIR = "artifacts/apps/{application_name}/{deployment_name}/observability"
+OBSERVABILITY_DIR = "artifacts/apps/observability"
 
 # Workflow Client Constants
 #: Host address for the Temporal server

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -223,7 +223,7 @@ LOG_RETENTION_DAYS = int(os.environ.get("ATLAN_LOG_RETENTION_DAYS", 30))
 LOG_CLEANUP_ENABLED = bool(os.environ.get("ATLAN_LOG_CLEANUP_ENABLED", False))
 
 # Log Location configuration
-LOG_FILE_NAME = os.environ.get("ATLAN_LOG_FILE_NAME", "log.parquet")
+LOG_FILE_NAME = os.environ.get("ATLAN_LOG_FILE_NAME", "log.jsonl.gz")
 # Hive Partitioning Configuration
 ENABLE_HIVE_PARTITIONING = (
     os.getenv("ATLAN_ENABLE_HIVE_PARTITIONING", "true").lower() == "true"

--- a/application_sdk/observability/decorators/observability_decorator.py
+++ b/application_sdk/observability/decorators/observability_decorator.py
@@ -87,7 +87,7 @@ def _record_error_observability(
     duration_ms = (time.time() - start_time) * 1000
 
     # Debug logging for error case
-    logger.error(f"Error in function {func_name}: {str(error)}")
+    logger.error(f"Error in function {func_name}: {str(error)}", exc_info=error)
 
     try:
         # Record failure trace
@@ -134,7 +134,7 @@ def _record_error_observability(
         )
 
     # Log error
-    logger.error(f"Error in {func_name}: {str(error)}")
+    logger.error(f"Error in {func_name}: {str(error)}", exc_info=error)
 
 
 def observability(

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -1,10 +1,15 @@
 import asyncio
+import gzip
 import logging
+import os
+import socket
 import sys
 import threading
+from datetime import datetime
 from time import time_ns
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
+import orjson
 from loguru import logger
 from opentelemetry._logs import LogRecord, SeverityNumber
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
@@ -15,6 +20,8 @@ from opentelemetry.trace.span import TraceFlags
 from pydantic import BaseModel, Field
 
 from application_sdk.constants import (
+    APPLICATION_NAME,
+    ENABLE_ATLAN_UPLOAD,
     ENABLE_OBSERVABILITY_DAPR_SINK,
     ENABLE_OTLP_LOGS,
     LOG_BATCH_SIZE,
@@ -32,6 +39,7 @@ from application_sdk.constants import (
     OTEL_WF_NODE_NAME,
     SERVICE_NAME,
     SERVICE_VERSION,
+    UPSTREAM_OBJECT_STORE_NAME,
 )
 from application_sdk.observability.context import correlation_context, request_context
 from application_sdk.observability.observability import AtlanObservability
@@ -73,8 +81,10 @@ class LogExtraModel(BaseModel):
     heartbeat_timeout: Optional[str] = None
     # Other fields
     log_type: Optional[str] = None
+    app_name: Optional[str] = None
     # Trace context
     trace_id: Optional[str] = None
+    correlation_id: Optional[str] = None
 
 
 class LogRecordModel(BaseModel):
@@ -526,6 +536,7 @@ class AtlanLoggerAdapter(AtlanObservability[LogRecordModel]):
         - Adds correlation context if available
         """
         kwargs["logger_name"] = self.logger_name
+        kwargs["app_name"] = APPLICATION_NAME
 
         # Get request context
         ctx = request_context.get()
@@ -558,6 +569,7 @@ class AtlanLoggerAdapter(AtlanObservability[LogRecordModel]):
             # Add trace_id if present (for log format display)
             if "trace_id" in corr_ctx and corr_ctx["trace_id"]:
                 kwargs["trace_id"] = str(corr_ctx["trace_id"])
+                kwargs["correlation_id"] = str(corr_ctx["trace_id"])
             # Add atlan-* headers for OTEL
             for key, value in corr_ctx.items():
                 if key.startswith("atlan-") and value:
@@ -737,6 +749,70 @@ class AtlanLoggerAdapter(AtlanObservability[LogRecordModel]):
                     loop.close()
         except Exception as e:
             logging.error(f"Error during sync flush: {e}")
+
+    async def _flush_records(self, records: List[Dict[str, Any]]):
+        """Flush records to jsonl.gz files and upload to object store.
+
+        Overrides the base class parquet implementation to write compressed
+        JSON Lines files instead.
+        """
+        if not ENABLE_OBSERVABILITY_DAPR_SINK:
+            return
+        try:
+            # Group records by partition
+            partition_records: Dict[str, List[Dict[str, Any]]] = {}
+            for record in records:
+                record_time = datetime.fromtimestamp(record["timestamp"])
+                partition_path = self._get_partition_path(record_time)
+                if partition_path not in partition_records:
+                    partition_records[partition_path] = []
+                partition_records[partition_path].append(record)
+
+            hostname = socket.gethostname()
+
+            for partition_path, partition_data in partition_records.items():
+                try:
+                    timestamp_ns = time_ns()
+                    custom_filename = (
+                        f"{timestamp_ns}_{hostname}_{APPLICATION_NAME}_logs.jsonl.gz"
+                    )
+
+                    os.makedirs(partition_path, exist_ok=True)
+                    file_path = os.path.join(partition_path, custom_filename)
+
+                    with gzip.open(file_path, "wb") as f:
+                        for record in partition_data:
+                            f.write(orjson.dumps(record) + b"\n")
+
+                    # Lazy imports for upload
+                    from application_sdk.activities.common.utils import (
+                        get_object_store_prefix,
+                    )
+                    from application_sdk.services.objectstore import ObjectStore
+
+                    if ENABLE_ATLAN_UPLOAD:
+                        await ObjectStore.upload_file(
+                            source=file_path,
+                            store_name=UPSTREAM_OBJECT_STORE_NAME,
+                            destination=get_object_store_prefix(file_path),
+                            retain_local_copy=True,
+                        )
+                    await ObjectStore.upload_file(
+                        source=file_path,
+                        destination=get_object_store_prefix(file_path),
+                    )
+
+                except Exception as partition_error:
+                    logging.error(
+                        f"Error processing partition {partition_path}: {str(partition_error)}"
+                    )
+
+            # Clean up old records if enabled
+            if self._cleanup_enabled:
+                await self._check_and_cleanup()
+
+        except Exception as e:
+            logging.error(f"Error flushing records batch: {e}")
 
     def tracing(self, msg: str, *args: Any, **kwargs: Any):
         """Log a trace-specific message with trace context.

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -108,7 +108,7 @@ class LogRecordModel(BaseModel):
         for k, v in message.record["extra"].items():
             if k != "logger_name" and hasattr(extra, k):
                 setattr(extra, k, v)
-            # Include atlan- prefixed and exception. prefixed fields as extra attributes
+            # Include atlan- prefixed fields as extra attributes
             elif k.startswith("atlan-") and v is not None:
                 setattr(extra, k, str(v))
         for key, value in _extract_exception_attributes(
@@ -161,13 +161,13 @@ def _extract_exception_attributes(exception: Any) -> Dict[str, str]:
     qualname = getattr(exc_type, "__qualname__", getattr(exc_type, "__name__", None))
     type_name = f"{module}.{qualname}" if module and qualname else str(exc_type)
 
-    attrs: Dict[str, str] = {"exception.type": type_name}
+    attrs: Dict[str, str] = {"exception_type": type_name}
     if exc_value is not None:
-        attrs["exception.message"] = str(exc_value)
+        attrs["exception_message"] = str(exc_value)
 
     stacktrace = _format_exception_stacktrace(exception)
     if stacktrace:
-        attrs["exception.stacktrace"] = stacktrace
+        attrs["exception_stacktrace"] = stacktrace
 
     return attrs
 
@@ -454,9 +454,7 @@ class AtlanLoggerAdapter(AtlanParquetObservability[LogRecordModel]):
             for k, v in record.record["extra"].items():
                 if k != "logger_name" and hasattr(extra, k):
                     setattr(extra, k, v)
-                elif (
-                    k.startswith("atlan-") or k.startswith("exception.")
-                ) and v is not None:
+                elif k.startswith("atlan-") and v is not None:
                     setattr(extra, k, str(v))
             for key, value in _extract_exception_attributes(
                 record.record.get("exception")
@@ -480,9 +478,7 @@ class AtlanLoggerAdapter(AtlanParquetObservability[LogRecordModel]):
             for k, v in record.get("extra", {}).items():
                 if hasattr(extra, k):
                     setattr(extra, k, v)
-                elif (
-                    k.startswith("atlan-") or k.startswith("exception.")
-                ) and v is not None:
+                elif k.startswith("atlan-") and v is not None:
                     setattr(extra, k, str(v))
             for key, value in _extract_exception_attributes(
                 record.get("exception")

--- a/application_sdk/observability/observability.py
+++ b/application_sdk/observability/observability.py
@@ -321,7 +321,7 @@ class AtlanObservability(Generic[T], ABC):
         if buffer_copy:
             await self._flush_records(buffer_copy)
 
-    async def parquet_sink(self, message: Any):
+    def parquet_sink(self, message: Any):
         """Process and buffer a log message for parquet storage.
 
         Args:
@@ -362,7 +362,11 @@ class AtlanObservability(Generic[T], ABC):
                     buffer_copy = None
 
             if buffer_copy is not None:
-                await self._flush_records(buffer_copy)
+                try:
+                    asyncio.create_task(self._flush_records(buffer_copy))
+                except RuntimeError:
+                    with self._buffer_lock:
+                        self._buffer.extend(buffer_copy)
         except Exception as e:
             logging.error(f"Error buffering log: {e}")
 
@@ -498,7 +502,8 @@ class AtlanObservability(Generic[T], ABC):
         This method:
         - Processes the record
         - Adds it to the buffer
-        - Triggers flush if needed
+        - Triggers async flush if buffer threshold is reached
+        - Falls back to periodic flush if no event loop is available
         - Exports the record
         """
         try:
@@ -519,9 +524,15 @@ class AtlanObservability(Generic[T], ABC):
                 else:
                     buffer_copy = None
 
-            # Flush if needed
+            # Flush if needed — try async dispatch, fall back to periodic flush
             if buffer_copy is not None:
-                asyncio.create_task(self._flush_records(buffer_copy))
+                try:
+                    asyncio.create_task(self._flush_records(buffer_copy))
+                except RuntimeError:
+                    # No running event loop (e.g. Temporal activity thread).
+                    # Put records back so the periodic flush picks them up.
+                    with self._buffer_lock:
+                        self._buffer.extend(buffer_copy)
 
             # Export the record
             self.export_record(record)

--- a/application_sdk/observability/observability.py
+++ b/application_sdk/observability/observability.py
@@ -2,12 +2,13 @@ import asyncio
 import logging
 import os
 import signal
+import socket
 import sys
 import threading
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 from pathlib import Path
-from time import time
+from time import time, time_ns
 from typing import Any, Dict, Generic, List, TypeVar
 
 import duckdb
@@ -16,12 +17,15 @@ from dapr.clients import DaprClient
 from pydantic import BaseModel
 
 from application_sdk.constants import (
+    APPLICATION_NAME,
     DEPLOYMENT_OBJECT_STORE_NAME,
+    ENABLE_ATLAN_UPLOAD,
     ENABLE_OBSERVABILITY_DAPR_SINK,
     LOG_FILE_NAME,
     METRICS_FILE_NAME,
     STATE_STORE_NAME,
     TRACES_FILE_NAME,
+    UPSTREAM_OBJECT_STORE_NAME,
 )
 from application_sdk.observability.utils import get_observability_dir
 
@@ -363,31 +367,24 @@ class AtlanObservability(Generic[T], ABC):
             logging.error(f"Error buffering log: {e}")
 
     async def _flush_records(self, records: List[Dict[str, Any]]):
-        """Flush records to parquet file and object store using ParquetFileWriter.
+        """Flush records to parquet file and upload to object store.
 
         Args:
             records: List of records to flush
 
         This method:
         - Groups records by partition (year/month/day)
-        - Uses ParquetFileWriter for efficient writing
-        - Automatically handles chunking, compression, and dual upload
+        - Writes parquet files with descriptive filenames encoding app identity
+        - Handles dual upload (deployment store + upstream for SDR)
         - Provides robust error handling per partition
         - Cleans up old records if enabled
-
-        Features:
-        - Automatic chunking for large datasets
-        - Dual upload support (primary + upstream if enabled)
-        - Advanced consolidation for optimal performance
-        - Fault-tolerant processing (continues on partition errors)
         """
         if not ENABLE_OBSERVABILITY_DAPR_SINK:
             return
         try:
             # Group records by partition
-            partition_records = {}
+            partition_records: Dict[str, List[Dict[str, Any]]] = {}
             for record in records:
-                # Convert timestamp to datetime
                 record_time = datetime.fromtimestamp(record["timestamp"])
                 partition_path = self._get_partition_path(record_time)
 
@@ -395,39 +392,50 @@ class AtlanObservability(Generic[T], ABC):
                     partition_records[partition_path] = []
                 partition_records[partition_path].append(record)
 
-                # Write records to each partition using ParquetFileWriter
+            # Determine suffix from file type
+            if self.file_name == LOG_FILE_NAME:
+                suffix = "logs"
+            elif self.file_name == METRICS_FILE_NAME:
+                suffix = "metrics"
+            elif self.file_name == TRACES_FILE_NAME:
+                suffix = "traces"
+            else:
+                suffix = "data"
+
+            hostname = socket.gethostname()
+
             for partition_path, partition_data in partition_records.items():
-                # Create new dataframe from current records
-                new_df = pd.DataFrame(partition_data)
-
-                # Extract partition values from path and add to dataframe
-                partition_parts = os.path.basename(
-                    os.path.dirname(partition_path)
-                ).split(os.sep)
-                for part in partition_parts:
-                    if part.startswith("year="):
-                        new_df["year"] = int(part.split("=")[1])
-                    elif part.startswith("month="):
-                        new_df["month"] = int(part.split("=")[1])
-                    elif part.startswith("day="):
-                        new_df["day"] = int(part.split("=")[1])
-
-                # Use new data directly - let ParquetFileWriter handle consolidation and merging
-                df = new_df
-
-                # Use ParquetFileWriter for efficient writing and uploading
-                # Set the output path for this partition
                 try:
-                    # Lazy import and instantiation of ParquetFileWriter
-                    from application_sdk.io.parquet import ParquetFileWriter
+                    df = pd.DataFrame(partition_data)
 
-                    parquet_writer = ParquetFileWriter(
-                        path=partition_path,
-                        chunk_start=0,
-                        chunk_part=int(time()),
+                    # Build unique filename: {timestamp_ns}_{hostname}_{app}_{suffix}.parquet
+                    timestamp_ns = time_ns()
+                    custom_filename = (
+                        f"{timestamp_ns}_{hostname}_{APPLICATION_NAME}_{suffix}.parquet"
                     )
 
-                    await parquet_writer._write_dataframe(dataframe=df)
+                    os.makedirs(partition_path, exist_ok=True)
+                    file_path = os.path.join(partition_path, custom_filename)
+                    df.to_parquet(file_path, index=False, compression="snappy")
+
+                    # Lazy imports for upload
+                    from application_sdk.activities.common.utils import (
+                        get_object_store_prefix,
+                    )
+                    from application_sdk.services.objectstore import ObjectStore
+
+                    # Dual upload: upstream (SDR) + deployment store
+                    if ENABLE_ATLAN_UPLOAD:
+                        await ObjectStore.upload_file(
+                            source=file_path,
+                            store_name=UPSTREAM_OBJECT_STORE_NAME,
+                            destination=get_object_store_prefix(file_path),
+                            retain_local_copy=True,
+                        )
+                    await ObjectStore.upload_file(
+                        source=file_path,
+                        destination=get_object_store_prefix(file_path),
+                    )
 
                 except Exception as partition_error:
                     logging.error(

--- a/application_sdk/observability/utils.py
+++ b/application_sdk/observability/utils.py
@@ -3,12 +3,7 @@ import os
 from pydantic import BaseModel, Field
 from temporalio import activity, workflow
 
-from application_sdk.constants import (
-    APPLICATION_NAME,
-    DEPLOYMENT_NAME,
-    OBSERVABILITY_DIR,
-    TEMPORARY_PATH,
-)
+from application_sdk.constants import OBSERVABILITY_DIR, TEMPORARY_PATH
 from application_sdk.observability.context import correlation_context
 
 
@@ -34,17 +29,12 @@ class WorkflowContext(BaseModel):
 
 
 def get_observability_dir() -> str:
-    """Build the observability path using deployment name.
+    """Build the observability directory path.
 
     Returns:
-        str: The built observability path using deployment name.
+        str: The observability directory path.
     """
-    return os.path.join(
-        TEMPORARY_PATH,
-        OBSERVABILITY_DIR.format(
-            application_name=APPLICATION_NAME, deployment_name=DEPLOYMENT_NAME
-        ),
-    )
+    return os.path.join(TEMPORARY_PATH, OBSERVABILITY_DIR)
 
 
 def get_workflow_context() -> WorkflowContext:

--- a/tests/unit/observability/test_observability.py
+++ b/tests/unit/observability/test_observability.py
@@ -1,0 +1,294 @@
+"""Tests for AtlanParquetObservability intermediate class.
+
+Covers:
+- Master toggle (ENABLE_OBSERVABILITY_DAPR_SINK) gating
+- Per-signal flag gating in leaf adapters
+- Timestamp float→int64 nanosecond conversion in parquet output
+- Class hierarchy (all adapters inherit from AtlanParquetObservability)
+"""
+
+from contextlib import contextmanager
+from datetime import datetime
+from typing import Any, Dict, Generator, List
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+from application_sdk.observability.metrics_adaptor import AtlanMetricsAdapter
+from application_sdk.observability.models import MetricRecord, MetricType
+from application_sdk.observability.observability import (
+    AtlanObservability,
+    AtlanParquetObservability,
+)
+from application_sdk.observability.traces_adaptor import AtlanTracesAdapter, TraceRecord
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _patched_metrics_adapter() -> Generator[AtlanMetricsAdapter, None, None]:
+    """Create a metrics adapter with mocked OTel and env."""
+    with mock.patch.dict(
+        "os.environ",
+        {
+            "ENABLE_OTLP_METRICS": "false",
+            "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+        },
+    ):
+        with mock.patch("opentelemetry.metrics.set_meter_provider"):
+            with mock.patch("opentelemetry.sdk.metrics.MeterProvider") as mock_provider:
+                mock_provider.return_value.get_meter.return_value = mock.MagicMock()
+                adapter = AtlanMetricsAdapter()
+                yield adapter
+
+
+@contextmanager
+def _patched_traces_adapter() -> Generator[AtlanTracesAdapter, None, None]:
+    """Create a traces adapter with mocked OTel and env."""
+    with mock.patch.dict(
+        "os.environ",
+        {
+            "ENABLE_OTLP_TRACES": "false",
+            "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+        },
+    ):
+        with mock.patch("opentelemetry.trace.set_tracer_provider"):
+            with mock.patch("opentelemetry.sdk.trace.TracerProvider") as mock_provider:
+                mock_provider.return_value.get_tracer.return_value = mock.MagicMock()
+                adapter = AtlanTracesAdapter()
+                yield adapter
+
+
+def _make_metric_records(n: int = 3) -> List[Dict[str, Any]]:
+    ts = datetime(2026, 2, 21, 12, 0, 0).timestamp()
+    return [
+        MetricRecord(
+            timestamp=ts + i,
+            name=f"metric_{i}",
+            value=float(i),
+            type=MetricType.COUNTER,
+            labels={"env": "test"},
+        ).model_dump()
+        for i in range(n)
+    ]
+
+
+def _make_trace_records(n: int = 3) -> List[Dict[str, Any]]:
+    ts = datetime(2026, 2, 21, 12, 0, 0).timestamp()
+    return [
+        TraceRecord(
+            timestamp=ts + i,
+            trace_id=f"trace_{i}",
+            span_id=f"span_{i}",
+            name=f"span_{i}",
+            kind="SERVER",
+            status_code="OK",
+            attributes={"test": "value"},
+            duration_ms=100.0,
+        ).model_dump()
+        for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Class hierarchy
+# ---------------------------------------------------------------------------
+
+
+class TestClassHierarchy:
+    """Verify the inheritance chain is correct."""
+
+    def test_metrics_adapter_inherits_parquet(self):
+        assert issubclass(AtlanMetricsAdapter, AtlanParquetObservability)
+
+    def test_traces_adapter_inherits_parquet(self):
+        assert issubclass(AtlanTracesAdapter, AtlanParquetObservability)
+
+    def test_parquet_observability_inherits_base(self):
+        assert issubclass(AtlanParquetObservability, AtlanObservability)
+
+    def test_logger_adapter_inherits_parquet(self):
+        from application_sdk.observability.logger_adaptor import AtlanLoggerAdapter
+
+        assert issubclass(AtlanLoggerAdapter, AtlanParquetObservability)
+
+
+# ---------------------------------------------------------------------------
+# Master toggle gating
+# ---------------------------------------------------------------------------
+
+
+class TestMasterToggle:
+    """ENABLE_OBSERVABILITY_DAPR_SINK must gate all writes."""
+
+    @pytest.mark.asyncio
+    async def test_master_off_skips_flush_metrics(self):
+        with _patched_metrics_adapter() as adapter:
+            records = _make_metric_records()
+            with mock.patch(
+                "application_sdk.observability.observability.ENABLE_OBSERVABILITY_DAPR_SINK",
+                False,
+            ):
+                with mock.patch("pandas.DataFrame.to_parquet") as mock_write:
+                    await adapter._flush_records(records)
+                    mock_write.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_master_off_skips_flush_traces(self):
+        with _patched_traces_adapter() as adapter:
+            records = _make_trace_records()
+            with mock.patch(
+                "application_sdk.observability.observability.ENABLE_OBSERVABILITY_DAPR_SINK",
+                False,
+            ):
+                with mock.patch("pandas.DataFrame.to_parquet") as mock_write:
+                    await adapter._flush_records(records)
+                    mock_write.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Per-signal flag gating
+# ---------------------------------------------------------------------------
+
+
+class TestPerSignalFlags:
+    """Per-signal flags gate before reaching the parquet layer."""
+
+    @pytest.mark.asyncio
+    async def test_metrics_sink_disabled_skips_super(self):
+        with _patched_metrics_adapter() as adapter:
+            records = _make_metric_records()
+            with mock.patch(
+                "application_sdk.observability.metrics_adaptor.ENABLE_METRICS_SINK",
+                False,
+            ):
+                with mock.patch.object(
+                    AtlanParquetObservability,
+                    "_flush_records",
+                ) as mock_parent:
+                    await adapter._flush_records(records)
+                    mock_parent.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_traces_sink_disabled_skips_super(self):
+        with _patched_traces_adapter() as adapter:
+            records = _make_trace_records()
+            with mock.patch(
+                "application_sdk.observability.traces_adaptor.ENABLE_TRACES_SINK",
+                False,
+            ):
+                with mock.patch.object(
+                    AtlanParquetObservability,
+                    "_flush_records",
+                ) as mock_parent:
+                    await adapter._flush_records(records)
+                    mock_parent.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_metrics_sink_enabled_calls_super(self):
+        with _patched_metrics_adapter() as adapter:
+            records = _make_metric_records()
+            with mock.patch(
+                "application_sdk.observability.metrics_adaptor.ENABLE_METRICS_SINK",
+                True,
+            ):
+                with mock.patch.object(
+                    AtlanParquetObservability,
+                    "_flush_records",
+                ) as mock_parent:
+                    await adapter._flush_records(records)
+                    mock_parent.assert_called_once_with(records)
+
+    @pytest.mark.asyncio
+    async def test_traces_sink_enabled_calls_super(self):
+        with _patched_traces_adapter() as adapter:
+            records = _make_trace_records()
+            with mock.patch(
+                "application_sdk.observability.traces_adaptor.ENABLE_TRACES_SINK",
+                True,
+            ):
+                with mock.patch.object(
+                    AtlanParquetObservability,
+                    "_flush_records",
+                ) as mock_parent:
+                    await adapter._flush_records(records)
+                    mock_parent.assert_called_once_with(records)
+
+
+# ---------------------------------------------------------------------------
+# Timestamp conversion
+# ---------------------------------------------------------------------------
+
+
+class TestTimestampConversion:
+    """Parquet files must have timestamp as int64 nanoseconds."""
+
+    @pytest.mark.asyncio
+    async def test_timestamp_written_as_int64_nanoseconds(self, tmp_path):
+        with _patched_metrics_adapter() as adapter:
+            adapter.data_dir = str(tmp_path)
+            records = _make_metric_records(1)
+            original_ts = records[0]["timestamp"]
+
+            with mock.patch(
+                "application_sdk.observability.observability.ENABLE_OBSERVABILITY_DAPR_SINK",
+                True,
+            ):
+                # Mock uploads to avoid Dapr dependency
+                with mock.patch(
+                    "application_sdk.observability.metrics_adaptor.ENABLE_METRICS_SINK",
+                    True,
+                ):
+                    with mock.patch(
+                        "application_sdk.services.objectstore.ObjectStore.upload_file"
+                    ):
+                        await adapter._flush_records(records)
+
+            # Find the written parquet file
+            parquet_files = list(tmp_path.rglob("*.parquet"))
+            assert len(parquet_files) == 1
+
+            df = pd.read_parquet(parquet_files[0])
+            assert df["timestamp"].dtype == "int64"
+
+            expected_ns = int(original_ts * 1_000_000_000)
+            assert df["timestamp"].iloc[0] == expected_ns
+
+    @pytest.mark.asyncio
+    async def test_timestamp_precision_preserved(self, tmp_path):
+        """Verify sub-second precision survives the conversion."""
+        with _patched_metrics_adapter() as adapter:
+            adapter.data_dir = str(tmp_path)
+            # Use a timestamp with fractional seconds
+            ts = 1740153600.123456
+            records = [
+                MetricRecord(
+                    timestamp=ts,
+                    name="precision_test",
+                    value=1.0,
+                    type=MetricType.COUNTER,
+                    labels={"env": "test"},
+                ).model_dump()
+            ]
+
+            with mock.patch(
+                "application_sdk.observability.observability.ENABLE_OBSERVABILITY_DAPR_SINK",
+                True,
+            ):
+                with mock.patch(
+                    "application_sdk.observability.metrics_adaptor.ENABLE_METRICS_SINK",
+                    True,
+                ):
+                    with mock.patch(
+                        "application_sdk.services.objectstore.ObjectStore.upload_file"
+                    ):
+                        await adapter._flush_records(records)
+
+            parquet_files = list(tmp_path.rglob("*.parquet"))
+            df = pd.read_parquet(parquet_files[0])
+            # Microsecond precision from float should be preserved
+            stored_ns = df["timestamp"].iloc[0]
+            assert stored_ns == int(ts * 1_000_000_000)


### PR DESCRIPTION
## Summary
- Introduces `AtlanParquetObservability` intermediate class — parquet flush logic moves out of the ABC helper into a proper class. All three signals (logs, metrics, traces) inherit from it.
- Adds per-signal sink flags (`ENABLE_LOG_SINK`, `ENABLE_METRICS_SINK`, `ENABLE_TRACES_SINK`) that default to the existing `ENABLE_OBSERVABILITY_DAPR_SINK` master toggle.
- Converts `timestamp` from `float` (DOUBLE in parquet) to `int64` nanoseconds (INT64) for OTel/S3-Iceberg compatibility.
- S3 path simplified to `artifacts/apps/observability/{signal}/year=.../` with app identity encoded in the filename.

## Test plan
- [x] Pre-commit passes on all changed files
- [x] `pytest tests/unit/observability/ -v` — 43 passed, 1 skipped
- [ ] Verify ingestion pipeline reads new path + INT64 timestamps correctly
- [ ] Validate per-signal flags work independently (disable one, others still flush)

🤖 Generated with [Claude Code](https://claude.com/claude-code)