### PR TITLE
feat(incremental): remove ancestral merge, add deletion detection [PART-460]

### DIFF
--- a/application_sdk/activities/metadata_extraction/incremental.py
+++ b/application_sdk/activities/metadata_extraction/incremental.py
@@ -504,7 +504,7 @@ class IncrementalSQLMetadataExtractionActivities(BaseSQLMetadataExtractionActivi
     async def write_current_state(
         self, workflow_args: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Create current-state snapshot with ancestral merge and upload to S3.
+        """Create lightweight current-state snapshot and upload to S3.
 
         Args:
             workflow_args: Workflow arguments containing paths and configuration
@@ -517,8 +517,9 @@ class IncrementalSQLMetadataExtractionActivities(BaseSQLMetadataExtractionActivi
         args = IncrementalWorkflowArgs.model_validate(workflow_args)
 
         logger.info(
-            f"Starting write_current_state with ancestral merge "
-            f"(workflow: {workflow_id}, run: {run_id})"
+            "Starting write_current_state " "(workflow: %s, run: %s)",
+            workflow_id,
+            run_id,
         )
 
         previous_state_dir = None

--- a/application_sdk/common/incremental/models.py
+++ b/application_sdk/common/incremental/models.py
@@ -177,25 +177,45 @@ class IncrementalDiffResult(BaseModel):
 
     Tracks counts of changed assets written to incremental-diff folder.
     This folder contains only assets that changed in this specific run
-    (CREATED, UPDATED, or BACKFILL).
+    (CREATED, UPDATED, BACKFILL, or DELETED).
 
     Attributes:
         tables_created: Count of CREATED tables
         tables_updated: Count of UPDATED tables
         tables_backfill: Count of BACKFILL tables
+        tables_deleted: Count of DELETED tables (in previous but not in current)
         columns_total: Total columns for changed tables
+        columns_deleted: Total deleted columns (from deleted/updated tables)
         schemas_total: Total schemas in diff
         databases_total: Total databases in diff
         total_files: Total JSON files written
+        is_incremental: Whether this diff was produced from incremental extraction
     """
 
     tables_created: int = 0
     tables_updated: int = 0
     tables_backfill: int = 0
+    tables_deleted: int = 0
     columns_total: int = 0
+    columns_deleted: int = 0
     schemas_total: int = 0
     databases_total: int = 0
     total_files: int = 0
+    is_incremental: bool = True
+
+    @property
+    def total_changed_entities(self) -> int:
+        """Total number of changed entities (tables + columns, including deletes)."""
+        return (
+            self.tables_created
+            + self.tables_updated
+            + self.tables_backfill
+            + self.tables_deleted
+            + self.columns_total
+            + self.columns_deleted
+            + self.schemas_total
+            + self.databases_total
+        )
 
 
 class IncrementalWorkflowArgs(BaseModel):

--- a/application_sdk/common/incremental/state/incremental_diff.py
+++ b/application_sdk/common/incremental/state/incremental_diff.py
@@ -5,18 +5,35 @@ from the current extraction run. The incremental-diff is used for efficient
 publishing of only what changed, rather than the full current state.
 
 Key concepts:
-- Tables: CREATED, UPDATED, or BACKFILL (not NO CHANGE)
-- Columns: Only for CREATED/UPDATED/BACKFILL tables
+- Tables: CREATED, UPDATED, BACKFILL, or DELETED
+- Columns: For CREATED/UPDATED/BACKFILL tables + deleted columns
 - Schemas/Databases: All (they're small and provide context)
+- Deletions: Tables in previous state but not in current, plus cascade to columns
 
 BACKFILL tables are detected by comparing current vs previous state:
 tables that exist now but weren't in previous state (e.g., due to filter changes).
+
+Deletion detection:
+- Table-level: Tables in previous state but not in current extraction scope
+- Column-level for deleted tables: All columns cascade-deleted
+- Column-level for UPDATED tables: Columns in previous but not in current
+
+Output structure:
+    incremental-diff/{run_id}/
+        table/          - CREATED/UPDATED/BACKFILL tables
+        column/         - Columns for changed tables
+        schema/         - All schemas
+        database/       - All databases
+        delete/table/   - Deleted table entities
+        delete/column/  - Deleted column entities
+        metadata.json   - Entity counts for Argo routing
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
-from typing import Callable, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set
 
 from application_sdk.common.incremental.helpers import (
     copy_directory_parallel,
@@ -53,21 +70,20 @@ def create_incremental_diff(
         Callable[[Path, Optional[Path]], Optional[Set[str]]]
     ] = None,
 ) -> IncrementalDiffResult:
-    """Create incremental-diff folder with only changed assets from this run.
+    """Create incremental-diff folder with changed and deleted assets from this run.
 
     The incremental-diff contains assets that changed in this specific run:
     - Tables: CREATED, UPDATED, or BACKFILL (not NO CHANGE)
     - Columns: Only for CREATED/UPDATED/BACKFILL tables
     - Schemas/Databases: All (they're small and provide context)
-
-    BACKFILL tables are detected by comparing current vs previous state:
-    tables that exist now but weren't in previous state (e.g., due to filter changes).
+    - Deleted tables: Tables in previous state but not in current scope
+    - Deleted columns: Cascade from deleted tables + missing from UPDATED tables
 
     Args:
         transformed_dir: Path to current run's transformed output
         incremental_diff_dir: Path to write incremental diff
         table_scope: Current table scope with incremental states
-        previous_state_dir: Path to previous run's current-state (for backfill detection)
+        previous_state_dir: Path to previous run's current-state (for backfill/deletion)
         conn: Optional DuckDB connection to reuse. If None, creates a new connection.
         copy_workers: Number of parallel workers for file copy operations (default: 3)
         get_backfill_tables_fn: Optional function to detect backfill tables.
@@ -90,10 +106,13 @@ def create_incremental_diff(
         )
 
     changed_tables: Set[str] = set()
+    updated_tables: Set[str] = set()
     for qn in iter_scope_table_qns(table_scope):
         state = get_table_state(table_scope, qn)
         if state in ("CREATED", "UPDATED"):
             changed_tables.add(qn)
+        if state == "UPDATED":
+            updated_tables.add(qn)
 
     backfill_only_tables = backfill_tables - changed_tables
     all_changed_tables = changed_tables | backfill_only_tables
@@ -145,20 +164,422 @@ def create_incremental_diff(
             elif entity_type == EntityType.DATABASE:
                 result.databases_total = count
 
+    # ------------------------------------------------------------------
+    # Step 5: Detect deleted tables and cascade to columns
+    # ------------------------------------------------------------------
+    current_table_qns = set(iter_scope_table_qns(table_scope))
+
+    if previous_state_dir and previous_state_dir.exists():
+        deletion_counts = _detect_deletions(
+            previous_state_dir=previous_state_dir,
+            current_table_qns=current_table_qns,
+            updated_table_qns=updated_tables,
+            current_column_dir=transformed_dir.joinpath(EntityType.COLUMN.value),
+            delete_dir=incremental_diff_dir.joinpath("delete"),
+            conn=conn,
+        )
+        result.tables_deleted = deletion_counts.get("tables_deleted", 0)
+        result.columns_deleted = deletion_counts.get("columns_deleted", 0)
+
+    # ------------------------------------------------------------------
+    # Step 6: Count total files and write metadata.json
+    # ------------------------------------------------------------------
     result.total_files = count_json_files_recursive(incremental_diff_dir)
 
+    _write_metadata(incremental_diff_dir, result)
+
     logger.info(
-        "Incremental-diff created: %d tables (created=%d, updated=%d, backfill=%d), "
-        "%d columns, %d total files",
+        "Incremental-diff created: %d tables (created=%d, updated=%d, "
+        "backfill=%d, deleted=%d), %d columns, %d deleted columns, "
+        "%d total files, %d total changed entities",
         result.tables_created + result.tables_updated + result.tables_backfill,
         result.tables_created,
         result.tables_updated,
         result.tables_backfill,
+        result.tables_deleted,
         result.columns_total,
+        result.columns_deleted,
         result.total_files,
+        result.total_changed_entities,
     )
 
     return result
+
+
+def _detect_deletions(
+    previous_state_dir: Path,
+    current_table_qns: Set[str],
+    updated_table_qns: Set[str],
+    current_column_dir: Path,
+    delete_dir: Path,
+    conn: DuckDBConnection = None,
+) -> Dict[str, int]:
+    """Detect deleted tables and columns by comparing previous vs current state.
+
+    Deletion detection covers two scenarios:
+    1. Table-level: Tables in previous state but not in current scope.
+       Their columns are cascade-deleted.
+    2. Column-level for UPDATED tables: Columns in previous state but
+       not in current extraction for tables that were re-extracted.
+
+    Args:
+        previous_state_dir: Path to previous run's current-state
+        current_table_qns: Set of table QNs in the current extraction
+        updated_table_qns: Set of table QNs with UPDATED state
+        current_column_dir: Path to current run's transformed column directory
+        delete_dir: Path to write delete records (delete/table/, delete/column/)
+        conn: Optional DuckDB connection to reuse.
+
+    Returns:
+        Dictionary with tables_deleted and columns_deleted counts
+    """
+    counts: Dict[str, int] = {"tables_deleted": 0, "columns_deleted": 0}
+
+    prev_table_dir = previous_state_dir.joinpath(EntityType.TABLE.value)
+    if not prev_table_dir.exists():
+        return counts
+
+    prev_table_files = list(prev_table_dir.glob("*.json"))
+    if not prev_table_files:
+        return counts
+
+    with managed_duckdb_connection(conn) as active_conn:
+        # ------------------------------------------------------------------
+        # Load previous state tables
+        # ------------------------------------------------------------------
+        del_prev_tables = "del_prev_tables"
+        del_current_qns = "del_current_qns"
+
+        active_conn.execute(f"DROP TABLE IF EXISTS {del_prev_tables}")
+        active_conn.execute(f"DROP TABLE IF EXISTS {del_current_qns}")
+
+        active_conn.execute(f"""
+            CREATE TABLE {del_prev_tables} AS
+            SELECT *
+            FROM {json_scan(prev_table_files)}
+            WHERE attributes.qualifiedName IS NOT NULL
+        """)
+
+        # Create lookup of current table QNs
+        active_conn.execute(f"CREATE TABLE {del_current_qns} (qualified_name VARCHAR)")
+        if current_table_qns:
+            active_conn.executemany(
+                f"INSERT INTO {del_current_qns} VALUES (?)",
+                [(qn,) for qn in current_table_qns],
+            )
+
+        # ------------------------------------------------------------------
+        # Step A: Find deleted tables (in previous but not in current)
+        # ------------------------------------------------------------------
+        deleted_count_result = active_conn.execute(f"""
+            SELECT COUNT(*)
+            FROM {del_prev_tables} pt
+            LEFT JOIN {del_current_qns} cq
+              ON pt.attributes.qualifiedName = cq.qualified_name
+            WHERE cq.qualified_name IS NULL
+        """).fetchone()
+
+        deleted_table_count = deleted_count_result[0] if deleted_count_result else 0
+
+        if deleted_table_count > 0:
+            delete_table_dir = delete_dir.joinpath(EntityType.TABLE.value)
+            delete_table_dir.mkdir(parents=True, exist_ok=True)
+
+            dest_file = delete_table_dir.joinpath("chunk-0.json")
+            dest_file_str = str(dest_file).replace("'", "''")
+
+            active_conn.execute(f"""
+                COPY (
+                    SELECT pt.*
+                    FROM {del_prev_tables} pt
+                    LEFT JOIN {del_current_qns} cq
+                      ON pt.attributes.qualifiedName = cq.qualified_name
+                    WHERE cq.qualified_name IS NULL
+                )
+                TO '{dest_file_str}'
+                (FORMAT JSON, ARRAY false)
+            """)
+
+            counts["tables_deleted"] = deleted_table_count
+            logger.info("Detected %d deleted tables", deleted_table_count)
+
+            # Get the deleted table QNs for column cascade
+            deleted_table_qns_result = active_conn.execute(f"""
+                SELECT pt.attributes.qualifiedName
+                FROM {del_prev_tables} pt
+                LEFT JOIN {del_current_qns} cq
+                  ON pt.attributes.qualifiedName = cq.qualified_name
+                WHERE cq.qualified_name IS NULL
+            """).fetchall()
+            deleted_table_qns = {row[0] for row in deleted_table_qns_result}
+
+            # Cascade: delete columns belonging to deleted tables
+            cascade_count = _detect_deleted_columns_for_tables(
+                previous_state_dir=previous_state_dir,
+                table_qns=deleted_table_qns,
+                delete_column_dir=delete_dir.joinpath(EntityType.COLUMN.value),
+                chunk_idx=0,
+                conn=active_conn,
+            )
+            counts["columns_deleted"] += cascade_count
+
+        # ------------------------------------------------------------------
+        # Step B: Find deleted columns for UPDATED tables
+        # ------------------------------------------------------------------
+        if updated_table_qns:
+            updated_deleted = _detect_deleted_columns_for_updated_tables(
+                previous_state_dir=previous_state_dir,
+                current_column_dir=current_column_dir,
+                updated_table_qns=updated_table_qns,
+                delete_column_dir=delete_dir.joinpath(EntityType.COLUMN.value),
+                chunk_idx=1,
+                conn=active_conn,
+            )
+            counts["columns_deleted"] += updated_deleted
+
+    return counts
+
+
+def _detect_deleted_columns_for_tables(
+    previous_state_dir: Path,
+    table_qns: Set[str],
+    delete_column_dir: Path,
+    chunk_idx: int = 0,
+    conn: DuckDBConnection = None,
+) -> int:
+    """Write delete records for all columns belonging to specified tables.
+
+    Used for cascade deletion when tables are removed.
+
+    Args:
+        previous_state_dir: Path to previous run's current-state
+        table_qns: Set of table QNs whose columns should be deleted
+        delete_column_dir: Path to write deleted column records
+        chunk_idx: Starting chunk index for output files
+        conn: Optional DuckDB connection to reuse.
+
+    Returns:
+        Number of deleted column records written
+    """
+    if not table_qns:
+        return 0
+
+    prev_col_dir = previous_state_dir.joinpath(EntityType.COLUMN.value)
+    if not prev_col_dir.exists():
+        return 0
+
+    prev_col_files = list(prev_col_dir.glob("*.json"))
+    if not prev_col_files:
+        return 0
+
+    with managed_duckdb_connection(conn) as active_conn:
+        del_cascade_cols = "del_cascade_cols"
+        del_cascade_tables = "del_cascade_tables"
+
+        active_conn.execute(f"DROP TABLE IF EXISTS {del_cascade_cols}")
+        active_conn.execute(f"DROP TABLE IF EXISTS {del_cascade_tables}")
+
+        table_qn_expr = get_parent_table_qn_expr()
+
+        active_conn.execute(f"""
+            CREATE TABLE {del_cascade_cols} AS
+            SELECT *, {table_qn_expr} AS parent_table_qn
+            FROM {json_scan(prev_col_files)}
+            WHERE {table_qn_expr} IS NOT NULL
+        """)
+
+        active_conn.execute(f"CREATE TABLE {del_cascade_tables} (table_qn VARCHAR)")
+        active_conn.executemany(
+            f"INSERT INTO {del_cascade_tables} VALUES (?)",
+            [(qn,) for qn in table_qns],
+        )
+
+        count_result = active_conn.execute(f"""
+            SELECT COUNT(*)
+            FROM {del_cascade_cols} c
+            JOIN {del_cascade_tables} dt ON c.parent_table_qn = dt.table_qn
+        """).fetchone()
+
+        count = count_result[0] if count_result else 0
+        if count == 0:
+            return 0
+
+        delete_column_dir.mkdir(parents=True, exist_ok=True)
+        dest_file = delete_column_dir.joinpath(f"chunk-{chunk_idx}.json")
+        dest_file_str = str(dest_file).replace("'", "''")
+
+        active_conn.execute(f"""
+            COPY (
+                SELECT c.* EXCLUDE (parent_table_qn)
+                FROM {del_cascade_cols} c
+                JOIN {del_cascade_tables} dt ON c.parent_table_qn = dt.table_qn
+            )
+            TO '{dest_file_str}'
+            (FORMAT JSON, ARRAY false)
+        """)
+
+        logger.info(
+            "Cascade-deleted %d columns from %d deleted tables",
+            count,
+            len(table_qns),
+        )
+        return count
+
+
+def _detect_deleted_columns_for_updated_tables(
+    previous_state_dir: Path,
+    current_column_dir: Path,
+    updated_table_qns: Set[str],
+    delete_column_dir: Path,
+    chunk_idx: int = 1,
+    conn: DuckDBConnection = None,
+) -> int:
+    """Detect columns deleted from UPDATED tables.
+
+    Compares previous state columns vs current columns for UPDATED tables.
+    Columns present in previous but absent in current are written as deletes.
+
+    Args:
+        previous_state_dir: Path to previous run's current-state
+        current_column_dir: Path to current run's transformed column directory
+        updated_table_qns: Set of table QNs with UPDATED state
+        delete_column_dir: Path to write deleted column records
+        chunk_idx: Chunk index for output file naming
+        conn: Optional DuckDB connection to reuse.
+
+    Returns:
+        Number of deleted column records written
+    """
+    if not updated_table_qns:
+        return 0
+
+    prev_col_dir = previous_state_dir.joinpath(EntityType.COLUMN.value)
+    if not prev_col_dir.exists():
+        return 0
+
+    prev_col_files = list(prev_col_dir.glob("*.json"))
+    if not prev_col_files:
+        return 0
+
+    # Current columns may not exist (e.g., incremental run with no column extraction)
+    current_col_files: List[Path] = []
+    if current_column_dir.exists():
+        current_col_files = list(current_column_dir.glob("*.json"))
+
+    if not current_col_files:
+        return 0
+
+    with managed_duckdb_connection(conn) as active_conn:
+        del_upd_prev_cols = "del_upd_prev_cols"
+        del_upd_curr_cols = "del_upd_curr_cols"
+        del_upd_tables = "del_upd_tables"
+
+        active_conn.execute(f"DROP TABLE IF EXISTS {del_upd_prev_cols}")
+        active_conn.execute(f"DROP TABLE IF EXISTS {del_upd_curr_cols}")
+        active_conn.execute(f"DROP TABLE IF EXISTS {del_upd_tables}")
+
+        table_qn_expr = get_parent_table_qn_expr()
+
+        # Load previous columns with parent table QN
+        active_conn.execute(f"""
+            CREATE TABLE {del_upd_prev_cols} AS
+            SELECT *, {table_qn_expr} AS parent_table_qn
+            FROM {json_scan(prev_col_files)}
+            WHERE {table_qn_expr} IS NOT NULL
+        """)
+
+        # Load current columns QNs for comparison
+        active_conn.execute(f"""
+            CREATE TABLE {del_upd_curr_cols} AS
+            SELECT attributes.qualifiedName AS qualified_name
+            FROM {json_scan(current_col_files)}
+            WHERE attributes.qualifiedName IS NOT NULL
+        """)
+
+        # Lookup of updated table QNs
+        active_conn.execute(f"CREATE TABLE {del_upd_tables} (table_qn VARCHAR)")
+        active_conn.executemany(
+            f"INSERT INTO {del_upd_tables} VALUES (?)",
+            [(qn,) for qn in updated_table_qns],
+        )
+
+        # Find columns from previous state for UPDATED tables that are
+        # missing in current extraction
+        count_result = active_conn.execute(f"""
+            SELECT COUNT(*)
+            FROM {del_upd_prev_cols} pc
+            JOIN {del_upd_tables} ut ON pc.parent_table_qn = ut.table_qn
+            LEFT JOIN {del_upd_curr_cols} cc
+              ON pc.attributes.qualifiedName = cc.qualified_name
+            WHERE cc.qualified_name IS NULL
+        """).fetchone()
+
+        count = count_result[0] if count_result else 0
+        if count == 0:
+            return 0
+
+        delete_column_dir.mkdir(parents=True, exist_ok=True)
+        dest_file = delete_column_dir.joinpath(f"chunk-{chunk_idx}.json")
+        dest_file_str = str(dest_file).replace("'", "''")
+
+        active_conn.execute(f"""
+            COPY (
+                SELECT pc.* EXCLUDE (parent_table_qn)
+                FROM {del_upd_prev_cols} pc
+                JOIN {del_upd_tables} ut ON pc.parent_table_qn = ut.table_qn
+                LEFT JOIN {del_upd_curr_cols} cc
+                  ON pc.attributes.qualifiedName = cc.qualified_name
+                WHERE cc.qualified_name IS NULL
+            )
+            TO '{dest_file_str}'
+            (FORMAT JSON, ARRAY false)
+        """)
+
+        logger.info(
+            "Detected %d deleted columns from %d updated tables",
+            count,
+            len(updated_table_qns),
+        )
+        return count
+
+
+def _write_metadata(
+    incremental_diff_dir: Path,
+    result: IncrementalDiffResult,
+) -> None:
+    """Write metadata.json with entity counts for Argo routing.
+
+    The metadata file is used by Argo templates to decide:
+    - Stream publish: incremental-diff exists + has entities
+    - Batch publish: no incremental-diff (full extraction)
+    - Skip publish: incremental-diff exists + zero entities
+
+    Args:
+        incremental_diff_dir: Path to incremental-diff directory
+        result: IncrementalDiffResult with entity counts
+    """
+    metadata: Dict[str, Any] = {
+        "is_incremental": result.is_incremental,
+        "tables_created": result.tables_created,
+        "tables_updated": result.tables_updated,
+        "tables_backfill": result.tables_backfill,
+        "tables_deleted": result.tables_deleted,
+        "columns_total": result.columns_total,
+        "columns_deleted": result.columns_deleted,
+        "schemas_total": result.schemas_total,
+        "databases_total": result.databases_total,
+        "total_changed_entities": result.total_changed_entities,
+        "total_files": result.total_files,
+    }
+
+    metadata_path = incremental_diff_dir.joinpath("metadata.json")
+    metadata_path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+    logger.info("Wrote metadata.json: %s", metadata_path)
+
+
+# =============================================================================
+# Existing helper functions (unchanged)
+# =============================================================================
 
 
 def _filter_entities_by_qualified_names(

--- a/tests/unit/common/incremental/test_incremental_diff.py
+++ b/tests/unit/common/incremental/test_incremental_diff.py
@@ -1,0 +1,719 @@
+"""Tests for incremental diff generation with deletion detection.
+
+Tests cover:
+- create_incremental_diff: Changed tables, columns, schemas, databases
+- _detect_deletions: Table-level and column-level deletion detection
+- _detect_deleted_columns_for_tables: Cascade column deletion
+- _detect_deleted_columns_for_updated_tables: Column diff for updated tables
+- _write_metadata: metadata.json generation for Argo routing
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+from application_sdk.common.incremental.models import IncrementalDiffResult, TableScope
+from application_sdk.common.incremental.state.incremental_diff import (
+    _detect_deleted_columns_for_tables,
+    _detect_deleted_columns_for_updated_tables,
+    _detect_deletions,
+    _write_metadata,
+    create_incremental_diff,
+)
+from application_sdk.common.incremental.state.table_scope import add_table_to_scope
+
+
+def _make_table_entity(qualified_name: str, state: str = "CREATED") -> str:
+    """Create a single table entity JSON line."""
+    return json.dumps(
+        {
+            "typeName": "Table",
+            "status": "ACTIVE",
+            "attributes": {"qualifiedName": qualified_name, "name": qualified_name},
+            "customAttributes": json.dumps({"incremental_state": state}),
+        }
+    )
+
+
+def _make_column_entity(qualified_name: str, table_qualified_name: str) -> str:
+    """Create a single column entity JSON line."""
+    return json.dumps(
+        {
+            "typeName": "Column",
+            "status": "ACTIVE",
+            "attributes": {
+                "qualifiedName": qualified_name,
+                "name": qualified_name,
+                "tableQualifiedName": table_qualified_name,
+            },
+            "customAttributes": "{}",
+        }
+    )
+
+
+def _write_entities(directory: Path, entity_type: str, lines: list[str]) -> None:
+    """Write entity JSON lines to a chunk file."""
+    entity_dir = directory / entity_type
+    entity_dir.mkdir(parents=True, exist_ok=True)
+    (entity_dir / "chunk-0.json").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _make_scope(tables: dict[str, str]) -> TableScope:
+    """Create a TableScope from a dict of {qualified_name: state}.
+
+    Uses a plain dict for table_states to avoid requiring rocksdict in tests.
+    """
+    scope = TableScope(table_states={})
+    state_counts: dict[str, int] = {}
+    for qn, state in tables.items():
+        add_table_to_scope(scope, qn, state)
+        state_counts[state] = state_counts.get(state, 0) + 1
+    scope.state_counts = state_counts
+    return scope
+
+
+# ---------------------------------------------------------------------------
+# create_incremental_diff: basic behavior
+# ---------------------------------------------------------------------------
+
+
+class TestCreateIncrementalDiff:
+    """Tests for create_incremental_diff (main orchestrator)."""
+
+    def test_creates_diff_for_changed_tables(self):
+        """Changed tables and their columns appear in the diff."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            transformed = Path(temp_dir) / "transformed"
+            diff_dir = Path(temp_dir) / "diff"
+
+            _write_entities(
+                transformed,
+                "table",
+                [
+                    _make_table_entity("db.schema.t1", "CREATED"),
+                    _make_table_entity("db.schema.t2", "NO CHANGE"),
+                ],
+            )
+            _write_entities(
+                transformed,
+                "column",
+                [
+                    _make_column_entity("db.schema.t1.col1", "db.schema.t1"),
+                    _make_column_entity("db.schema.t2.col2", "db.schema.t2"),
+                ],
+            )
+            _write_entities(
+                transformed,
+                "schema",
+                [
+                    json.dumps(
+                        {
+                            "typeName": "Schema",
+                            "attributes": {"qualifiedName": "db.schema"},
+                        }
+                    )
+                ],
+            )
+
+            scope = _make_scope(
+                {"db.schema.t1": "CREATED", "db.schema.t2": "NO CHANGE"}
+            )
+
+            result = create_incremental_diff(
+                transformed_dir=transformed,
+                incremental_diff_dir=diff_dir,
+                table_scope=scope,
+            )
+
+            assert result.tables_created == 1
+            assert result.columns_total == 1
+            assert result.schemas_total == 1
+            assert (diff_dir / "table" / "chunk-0.json").exists()
+            assert (diff_dir / "column" / "chunk-0.json").exists()
+            assert (diff_dir / "metadata.json").exists()
+
+    def test_empty_diff_writes_metadata_with_zero_entities(self):
+        """An empty diff still writes metadata.json."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            transformed = Path(temp_dir) / "transformed"
+            diff_dir = Path(temp_dir) / "diff"
+
+            _write_entities(
+                transformed,
+                "table",
+                [_make_table_entity("db.schema.t1", "NO CHANGE")],
+            )
+
+            scope = _make_scope({"db.schema.t1": "NO CHANGE"})
+
+            result = create_incremental_diff(
+                transformed_dir=transformed,
+                incremental_diff_dir=diff_dir,
+                table_scope=scope,
+            )
+
+            assert result.tables_created == 0
+            assert result.tables_updated == 0
+            assert result.total_changed_entities == 0
+            metadata = json.loads(
+                (diff_dir / "metadata.json").read_text(encoding="utf-8")
+            )
+            assert metadata["total_changed_entities"] == 0
+            assert metadata["is_incremental"] is True
+
+    def test_deletion_detection_with_previous_state(self):
+        """Deleted tables and their columns appear in delete/ directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            transformed = Path(temp_dir) / "transformed"
+            previous = Path(temp_dir) / "previous"
+            diff_dir = Path(temp_dir) / "diff"
+
+            # Current: only t1
+            _write_entities(
+                transformed,
+                "table",
+                [_make_table_entity("db.schema.t1", "NO CHANGE")],
+            )
+
+            # Previous: t1 + t2 (t2 will be detected as deleted)
+            _write_entities(
+                previous,
+                "table",
+                [
+                    _make_table_entity("db.schema.t1", "NO CHANGE"),
+                    _make_table_entity("db.schema.t2", "NO CHANGE"),
+                ],
+            )
+            _write_entities(
+                previous,
+                "column",
+                [
+                    _make_column_entity("db.schema.t2.col1", "db.schema.t2"),
+                    _make_column_entity("db.schema.t2.col2", "db.schema.t2"),
+                ],
+            )
+
+            scope = _make_scope({"db.schema.t1": "NO CHANGE"})
+
+            result = create_incremental_diff(
+                transformed_dir=transformed,
+                incremental_diff_dir=diff_dir,
+                table_scope=scope,
+                previous_state_dir=previous,
+            )
+
+            assert result.tables_deleted == 1
+            assert result.columns_deleted == 2
+            assert (diff_dir / "delete" / "table" / "chunk-0.json").exists()
+            assert (diff_dir / "delete" / "column" / "chunk-0.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# _detect_deletions
+# ---------------------------------------------------------------------------
+
+
+class TestDetectDeletions:
+    """Tests for _detect_deletions (table and column deletion detection)."""
+
+    def test_no_previous_state_returns_empty(self):
+        """No previous state dir means no deletions."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            delete_dir = Path(temp_dir) / "delete"
+            counts = _detect_deletions(
+                previous_state_dir=Path(temp_dir) / "nonexistent",
+                current_table_qns={"t1"},
+                updated_table_qns=set(),
+                current_column_dir=Path(temp_dir) / "columns",
+                delete_dir=delete_dir,
+            )
+            assert counts["tables_deleted"] == 0
+            assert counts["columns_deleted"] == 0
+
+    def test_no_deleted_tables(self):
+        """When all previous tables still exist, no deletions."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            previous = Path(temp_dir) / "previous"
+            delete_dir = Path(temp_dir) / "delete"
+
+            _write_entities(
+                previous,
+                "table",
+                [_make_table_entity("db.schema.t1")],
+            )
+
+            counts = _detect_deletions(
+                previous_state_dir=previous,
+                current_table_qns={"db.schema.t1"},
+                updated_table_qns=set(),
+                current_column_dir=Path(temp_dir) / "columns",
+                delete_dir=delete_dir,
+            )
+            assert counts["tables_deleted"] == 0
+
+    def test_deleted_table_cascade_to_columns(self):
+        """Deleted tables cascade to their columns."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            previous = Path(temp_dir) / "previous"
+            delete_dir = Path(temp_dir) / "delete"
+
+            _write_entities(
+                previous,
+                "table",
+                [
+                    _make_table_entity("db.schema.t1"),
+                    _make_table_entity("db.schema.t2"),
+                ],
+            )
+            _write_entities(
+                previous,
+                "column",
+                [
+                    _make_column_entity("db.schema.t2.col_a", "db.schema.t2"),
+                    _make_column_entity("db.schema.t2.col_b", "db.schema.t2"),
+                    _make_column_entity("db.schema.t1.col_x", "db.schema.t1"),
+                ],
+            )
+
+            counts = _detect_deletions(
+                previous_state_dir=previous,
+                current_table_qns={"db.schema.t1"},
+                updated_table_qns=set(),
+                current_column_dir=Path(temp_dir) / "columns",
+                delete_dir=delete_dir,
+            )
+
+            assert counts["tables_deleted"] == 1
+            # Only t2's columns (2) should be cascade-deleted, not t1's
+            assert counts["columns_deleted"] == 2
+
+    def test_deleted_columns_for_updated_tables(self):
+        """Columns missing from UPDATED tables are detected as deleted."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            previous = Path(temp_dir) / "previous"
+            delete_dir = Path(temp_dir) / "delete"
+
+            # Previous: t1 had 3 columns
+            _write_entities(
+                previous,
+                "table",
+                [_make_table_entity("db.schema.t1")],
+            )
+            _write_entities(
+                previous,
+                "column",
+                [
+                    _make_column_entity("db.schema.t1.col_a", "db.schema.t1"),
+                    _make_column_entity("db.schema.t1.col_b", "db.schema.t1"),
+                    _make_column_entity("db.schema.t1.col_c", "db.schema.t1"),
+                ],
+            )
+
+            # Current: t1 has only 2 columns (col_b removed)
+            _write_entities(
+                Path(temp_dir) / "wrapper",
+                "column",
+                [
+                    _make_column_entity("db.schema.t1.col_a", "db.schema.t1"),
+                    _make_column_entity("db.schema.t1.col_c", "db.schema.t1"),
+                ],
+            )
+
+            counts = _detect_deletions(
+                previous_state_dir=previous,
+                current_table_qns={"db.schema.t1"},
+                updated_table_qns={"db.schema.t1"},
+                current_column_dir=Path(temp_dir) / "wrapper" / "column",
+                delete_dir=delete_dir,
+            )
+
+            assert counts["tables_deleted"] == 0
+            assert counts["columns_deleted"] == 1  # col_b deleted
+
+
+# ---------------------------------------------------------------------------
+# _detect_deleted_columns_for_tables (cascade)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectDeletedColumnsForTables:
+    """Tests for cascade column deletion from deleted tables."""
+
+    def test_no_columns_returns_zero(self):
+        """No columns in previous state means no cascades."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            previous = Path(temp_dir) / "previous"
+            previous.mkdir()
+            delete_col_dir = Path(temp_dir) / "delete_cols"
+
+            count = _detect_deleted_columns_for_tables(
+                previous_state_dir=previous,
+                table_qns={"db.schema.t1"},
+                delete_column_dir=delete_col_dir,
+            )
+            assert count == 0
+
+    def test_empty_table_qns_returns_zero(self):
+        """Empty table QN set returns zero."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            previous = Path(temp_dir) / "previous"
+            _write_entities(
+                previous,
+                "column",
+                [_make_column_entity("db.schema.t1.col", "db.schema.t1")],
+            )
+            delete_col_dir = Path(temp_dir) / "delete_cols"
+
+            count = _detect_deleted_columns_for_tables(
+                previous_state_dir=previous,
+                table_qns=set(),
+                delete_column_dir=delete_col_dir,
+            )
+            assert count == 0
+
+    def test_cascades_all_columns(self):
+        """All columns for deleted tables are written to delete dir."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            previous = Path(temp_dir) / "previous"
+            _write_entities(
+                previous,
+                "column",
+                [
+                    _make_column_entity("db.schema.t1.col1", "db.schema.t1"),
+                    _make_column_entity("db.schema.t1.col2", "db.schema.t1"),
+                    _make_column_entity("db.schema.t2.col3", "db.schema.t2"),
+                ],
+            )
+            delete_col_dir = Path(temp_dir) / "delete_cols"
+
+            count = _detect_deleted_columns_for_tables(
+                previous_state_dir=previous,
+                table_qns={"db.schema.t1"},
+                delete_column_dir=delete_col_dir,
+            )
+            assert count == 2
+            assert (delete_col_dir / "chunk-0.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# _detect_deleted_columns_for_updated_tables
+# ---------------------------------------------------------------------------
+
+
+class TestDetectDeletedColumnsForUpdatedTables:
+    """Tests for column-level deletion detection on UPDATED tables."""
+
+    def test_no_missing_columns_returns_zero(self):
+        """When all previous columns still exist, returns zero."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            previous = Path(temp_dir) / "previous"
+            current = Path(temp_dir) / "current"
+            delete_col_dir = Path(temp_dir) / "delete_cols"
+
+            _write_entities(
+                previous,
+                "column",
+                [_make_column_entity("db.schema.t1.col1", "db.schema.t1")],
+            )
+            _write_entities(
+                current,
+                "column",
+                [_make_column_entity("db.schema.t1.col1", "db.schema.t1")],
+            )
+
+            count = _detect_deleted_columns_for_updated_tables(
+                previous_state_dir=previous,
+                current_column_dir=current / "column",
+                updated_table_qns={"db.schema.t1"},
+                delete_column_dir=delete_col_dir,
+            )
+            assert count == 0
+
+    def test_detects_missing_columns(self):
+        """Columns in previous but not in current are detected as deleted."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            previous = Path(temp_dir) / "previous"
+            current = Path(temp_dir) / "current"
+            delete_col_dir = Path(temp_dir) / "delete_cols"
+
+            _write_entities(
+                previous,
+                "column",
+                [
+                    _make_column_entity("db.schema.t1.col1", "db.schema.t1"),
+                    _make_column_entity("db.schema.t1.col2", "db.schema.t1"),
+                    _make_column_entity("db.schema.t1.col3", "db.schema.t1"),
+                ],
+            )
+            _write_entities(
+                current,
+                "column",
+                [_make_column_entity("db.schema.t1.col1", "db.schema.t1")],
+            )
+
+            count = _detect_deleted_columns_for_updated_tables(
+                previous_state_dir=previous,
+                current_column_dir=current / "column",
+                updated_table_qns={"db.schema.t1"},
+                delete_column_dir=delete_col_dir,
+            )
+            assert count == 2  # col2 and col3 deleted
+            assert (delete_col_dir / "chunk-1.json").exists()
+
+    def test_only_checks_updated_tables(self):
+        """Columns from non-updated tables are not checked for deletion."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            previous = Path(temp_dir) / "previous"
+            current = Path(temp_dir) / "current"
+            delete_col_dir = Path(temp_dir) / "delete_cols"
+
+            # Previous: t1 had col1, t2 had col2
+            _write_entities(
+                previous,
+                "column",
+                [
+                    _make_column_entity("db.schema.t1.col1", "db.schema.t1"),
+                    _make_column_entity("db.schema.t2.col2", "db.schema.t2"),
+                ],
+            )
+
+            # Current: t1 has new_col (col1 was removed), t2 not re-extracted
+            _write_entities(
+                current,
+                "column",
+                [_make_column_entity("db.schema.t1.new_col", "db.schema.t1")],
+            )
+
+            count = _detect_deleted_columns_for_updated_tables(
+                previous_state_dir=previous,
+                current_column_dir=current / "column",
+                updated_table_qns={"db.schema.t1"},
+                delete_column_dir=delete_col_dir,
+            )
+            # Only t1's col1 should be detected as deleted, not t2's col2
+            assert count == 1
+
+    def test_no_updated_tables_returns_zero(self):
+        """Empty updated table set returns zero."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            previous = Path(temp_dir) / "previous"
+            current = Path(temp_dir) / "current"
+            delete_col_dir = Path(temp_dir) / "delete_cols"
+
+            _write_entities(
+                previous,
+                "column",
+                [_make_column_entity("db.schema.t1.col1", "db.schema.t1")],
+            )
+            _write_entities(
+                current,
+                "column",
+                [],
+            )
+
+            count = _detect_deleted_columns_for_updated_tables(
+                previous_state_dir=previous,
+                current_column_dir=current / "column",
+                updated_table_qns=set(),
+                delete_column_dir=delete_col_dir,
+            )
+            assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# _write_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestWriteMetadata:
+    """Tests for metadata.json generation."""
+
+    def test_writes_all_fields(self):
+        """Metadata contains all expected fields."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            diff_dir = Path(temp_dir) / "diff"
+            diff_dir.mkdir()
+
+            result = IncrementalDiffResult(
+                tables_created=5,
+                tables_updated=3,
+                tables_backfill=1,
+                tables_deleted=2,
+                columns_total=50,
+                columns_deleted=10,
+                schemas_total=3,
+                databases_total=1,
+                total_files=10,
+                is_incremental=True,
+            )
+
+            _write_metadata(diff_dir, result)
+
+            metadata = json.loads(
+                (diff_dir / "metadata.json").read_text(encoding="utf-8")
+            )
+            assert metadata["is_incremental"] is True
+            assert metadata["tables_created"] == 5
+            assert metadata["tables_updated"] == 3
+            assert metadata["tables_deleted"] == 2
+            assert metadata["columns_total"] == 50
+            assert metadata["columns_deleted"] == 10
+            assert metadata["total_changed_entities"] == 75
+
+    def test_empty_diff_metadata(self):
+        """Empty diff produces metadata with zero counts."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            diff_dir = Path(temp_dir) / "diff"
+            diff_dir.mkdir()
+
+            result = IncrementalDiffResult()
+            _write_metadata(diff_dir, result)
+
+            metadata = json.loads(
+                (diff_dir / "metadata.json").read_text(encoding="utf-8")
+            )
+            assert metadata["total_changed_entities"] == 0
+            assert metadata["is_incremental"] is True
+
+
+# ---------------------------------------------------------------------------
+# Integration: multiple deletion scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestDeletionIntegration:
+    """Integration tests combining table and column deletions."""
+
+    def test_multiple_deleted_tables_with_columns(self):
+        """Multiple deleted tables cascade-delete all their columns."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            transformed = Path(temp_dir) / "transformed"
+            previous = Path(temp_dir) / "previous"
+            diff_dir = Path(temp_dir) / "diff"
+
+            # Current: only t1
+            _write_entities(
+                transformed,
+                "table",
+                [_make_table_entity("db.s.t1", "NO CHANGE")],
+            )
+
+            # Previous: t1, t2, t3
+            _write_entities(
+                previous,
+                "table",
+                [
+                    _make_table_entity("db.s.t1"),
+                    _make_table_entity("db.s.t2"),
+                    _make_table_entity("db.s.t3"),
+                ],
+            )
+            _write_entities(
+                previous,
+                "column",
+                [
+                    _make_column_entity("db.s.t1.c1", "db.s.t1"),
+                    _make_column_entity("db.s.t2.c2", "db.s.t2"),
+                    _make_column_entity("db.s.t2.c3", "db.s.t2"),
+                    _make_column_entity("db.s.t3.c4", "db.s.t3"),
+                ],
+            )
+
+            scope = _make_scope({"db.s.t1": "NO CHANGE"})
+
+            result = create_incremental_diff(
+                transformed_dir=transformed,
+                incremental_diff_dir=diff_dir,
+                table_scope=scope,
+                previous_state_dir=previous,
+            )
+
+            assert result.tables_deleted == 2  # t2 and t3
+            assert result.columns_deleted == 3  # t2's 2 cols + t3's 1 col
+
+    def test_updated_and_deleted_tables_together(self):
+        """Both table deletions and column deletions from updated tables."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            transformed = Path(temp_dir) / "transformed"
+            previous = Path(temp_dir) / "previous"
+            diff_dir = Path(temp_dir) / "diff"
+
+            # Current: t1 (UPDATED), t2 gone
+            _write_entities(
+                transformed,
+                "table",
+                [_make_table_entity("db.s.t1", "UPDATED")],
+            )
+            _write_entities(
+                transformed,
+                "column",
+                [
+                    # t1 lost col_b in this run
+                    _make_column_entity("db.s.t1.col_a", "db.s.t1"),
+                ],
+            )
+
+            # Previous: t1 (with 2 cols), t2 (with 1 col)
+            _write_entities(
+                previous,
+                "table",
+                [
+                    _make_table_entity("db.s.t1"),
+                    _make_table_entity("db.s.t2"),
+                ],
+            )
+            _write_entities(
+                previous,
+                "column",
+                [
+                    _make_column_entity("db.s.t1.col_a", "db.s.t1"),
+                    _make_column_entity("db.s.t1.col_b", "db.s.t1"),
+                    _make_column_entity("db.s.t2.col_x", "db.s.t2"),
+                ],
+            )
+
+            scope = _make_scope({"db.s.t1": "UPDATED"})
+
+            result = create_incremental_diff(
+                transformed_dir=transformed,
+                incremental_diff_dir=diff_dir,
+                table_scope=scope,
+                previous_state_dir=previous,
+            )
+
+            # t2 deleted
+            assert result.tables_deleted == 1
+            # t2's col_x (cascade) + t1's col_b (column diff) = 2
+            assert result.columns_deleted == 2
+            # t1 is UPDATED → its current col_a is in the diff
+            assert result.columns_total == 1
+
+    def test_no_previous_state_no_deletions(self):
+        """First run (no previous state) has no deletions."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            transformed = Path(temp_dir) / "transformed"
+            diff_dir = Path(temp_dir) / "diff"
+
+            _write_entities(
+                transformed,
+                "table",
+                [_make_table_entity("db.s.t1", "CREATED")],
+            )
+            _write_entities(
+                transformed,
+                "column",
+                [_make_column_entity("db.s.t1.col1", "db.s.t1")],
+            )
+
+            scope = _make_scope({"db.s.t1": "CREATED"})
+
+            result = create_incremental_diff(
+                transformed_dir=transformed,
+                incremental_diff_dir=diff_dir,
+                table_scope=scope,
+                previous_state_dir=None,
+            )
+
+            assert result.tables_deleted == 0
+            assert result.columns_deleted == 0
+            assert result.tables_created == 1


### PR DESCRIPTION
## Summary

- **PART-461 — Remove Ancestral Merge**: Replaces the ancestral column merge in `create_current_state_snapshot` with a lightweight column copy. Current-state now contains columns only for CREATED/UPDATED tables. Publish-cache becomes the single source of truth for what's in Atlas.
- **PART-462 — Deletion Detection**: Adds table-level and column-level deletion detection to `create_incremental_diff`. Deleted tables (present in previous state but absent in current scope) and deleted columns (removed from UPDATED tables) are written to `incremental-diff/delete/` directories. A `metadata.json` file is written with entity counts for Argo routing decisions (stream vs batch vs skip).
- Updated `IncrementalDiffResult` model with `tables_deleted`, `columns_deleted`, `is_incremental` fields and `total_changed_entities` property.
- 19 new tests for deletion detection + 3 new tests for column copy. All 37 tests passing.

## Changed Files

| File | Change |
|------|--------|
| `state_writer.py` | Removed ancestral merge call, added `_copy_columns_from_transformed()` |
| `incremental_diff.py` | Added `_detect_deletions()`, `_detect_deleted_columns_for_tables()`, `_detect_deleted_columns_for_updated_tables()`, `_write_metadata()` |
| `models.py` | Extended `IncrementalDiffResult` with deletion fields + property |
| `incremental.py` (activities) | Updated docstring and logging |
| `test_incremental_diff.py` | New — 19 tests covering deletion detection |
| `test_state_writer.py` | Added 3 tests for `_copy_columns_from_transformed` |

## Linear Issues

- [PART-461](https://linear.app/atlan/issue/PART-461) — Remove ancestral merge from current-state
- [PART-462](https://linear.app/atlan/issue/PART-462) — Add deletion detection to incremental diff

## Test plan

- [x] All 37 unit tests passing (`uv run pytest tests/unit/common/incremental/ -v`)
- [x] Pre-commit checks passing (ruff, ruff-format, isort, pyright)
- [ ] Integration test with Oracle connector on staging
- [ ] Verify metadata.json output format matches Argo template expectations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core incremental state/diff semantics (columns no longer preserved via merge; new delete outputs affect publishing), so regressions could impact what gets published or removed despite good unit test coverage.
> 
> **Overview**
> **Incremental current-state snapshots are simplified** by removing ancestral column merging and instead copying whatever column files the transformer produced (so current-state only contains columns for `CREATED`/`UPDATED` tables).
> 
> **Incremental diffs now include deletions and routing metadata**: `create_incremental_diff` compares previous vs current state to write deleted tables and cascade/removed columns under `incremental-diff/delete/`, and always emits a `metadata.json` with entity counts (including a new `total_changed_entities`).
> 
> `IncrementalDiffResult` is extended with deleted-entity counters and an `is_incremental` flag, logging is updated accordingly, and unit test coverage is added for deletion detection, metadata output, and the new column-copy behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29bf8c9e8ca02756a2fa6d806655e1d97c049eba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->