### PR TITLE
feat: add configurable compression to ParquetFileWriter

### DIFF
--- a/application_sdk/io/__init__.py
+++ b/application_sdk/io/__init__.py
@@ -233,6 +233,7 @@ class Writer(ABC):
     current_buffer_size_bytes: int
     partitions: List[int]
     extension: str
+    compression: str = "snappy"
     dataframe_type: DataframeType
     _is_closed: bool = False
     _statistics: Optional[ActivityStatistics] = None
@@ -442,7 +443,7 @@ class Writer(ABC):
             chunk_size_bytes = estimate_dataframe_record_size(
                 dataframe,
                 self.extension,
-                compression=getattr(self, "compression", "snappy"),
+                compression=self.compression,
             )
 
             for i in range(0, len(dataframe), self.buffer_size):

--- a/application_sdk/io/__init__.py
+++ b/application_sdk/io/__init__.py
@@ -439,7 +439,11 @@ class Writer(ABC):
             if len(dataframe) == 0:
                 return
 
-            chunk_size_bytes = estimate_dataframe_record_size(dataframe, self.extension)
+            chunk_size_bytes = estimate_dataframe_record_size(
+                dataframe,
+                self.extension,
+                compression=getattr(self, "compression", "snappy"),
+            )
 
             for i in range(0, len(dataframe), self.buffer_size):
                 chunk = dataframe[i : i + self.buffer_size]

--- a/application_sdk/io/parquet.py
+++ b/application_sdk/io/parquet.py
@@ -428,6 +428,7 @@ class ParquetFileWriter(Writer):
         retain_local_copy: Optional[bool] = False,
         use_consolidation: Optional[bool] = False,
         dataframe_type: DataframeType = DataframeType.pandas,
+        compression: str = "snappy",
     ):
         """Initialize the Parquet output handler.
 
@@ -449,6 +450,13 @@ class ParquetFileWriter(Writer):
                 Defaults to False.
             dataframe_type (DataframeType, optional): Type of dataframe to write. Defaults to DataframeType.pandas.
         """
+        supported_compressions = {"snappy", "zstd", "gzip", "none"}
+        if compression not in supported_compressions:
+            raise ValueError(
+                f"Unsupported compression: {compression!r}. "
+                f"Must be one of {sorted(supported_compressions)}"
+            )
+        self.compression = compression
         self.extension = PARQUET_FILE_EXTENSION
         self.path = path
         self.typename = typename
@@ -584,23 +592,37 @@ class ParquetFileWriter(Writer):
             if isinstance(write_mode, str):
                 write_mode = WriteMode(write_mode)
 
-            row_count = dataframe.count_rows()
-            if row_count == 0:
+            if dataframe.limit(1).count_rows() == 0:
                 return
 
             file_paths = []
-            # Use Daft's execution context for temporary configuration
+            # Use Daft's execution context for temporary configuration.
+            #
+            # NOTE: Daft's native (Rust) parquet writer ignores the
+            # ``compression`` parameter passed to ``write_parquet()`` and
+            # silently hardcodes SNAPPY (as of Daft 0.7.3).  Setting
+            # ``native_parquet_writer=False`` forces the PyArrow-based
+            # writer which correctly honours the requested codec.
             with daft.execution_config_ctx(
                 parquet_target_filesize=self.max_file_size_bytes,
                 default_morsel_size=morsel_size,
+                native_parquet_writer=False,
             ):
                 # Daft automatically handles file splitting and naming
                 result = dataframe.write_parquet(
                     root_dir=self.path,
                     write_mode=write_mode.value,
                     partition_cols=partition_cols,
+                    compression=self.compression,
                 )
                 file_paths = result.to_pydict().get("path", [])
+
+            # Derive row count from written parquet file metadata to avoid
+            # re-materialising the (lazy) DataFrame which would double the
+            # page-cache pressure.
+            import pyarrow.parquet as pq
+
+            row_count = sum(pq.read_metadata(fp).num_rows for fp in file_paths)
 
             # Update counters
             self.chunk_count += 1
@@ -758,13 +780,18 @@ class ParquetFileWriter(Writer):
             daft_df = daft.read_parquet(pattern)
             partitions = 0
 
-            # Write consolidated file using Daft with size management
+            # Write consolidated file using Daft with size management.
+            # See note above re native_parquet_writer and compression.
             with daft.execution_config_ctx(
-                parquet_target_filesize=self.max_file_size_bytes
+                parquet_target_filesize=self.max_file_size_bytes,
+                native_parquet_writer=False,
             ):
                 # Write to a temp location first
                 temp_consolidated_dir = f"{self.current_temp_folder_path}_temp"
-                result = daft_df.write_parquet(root_dir=temp_consolidated_dir)
+                result = daft_df.write_parquet(
+                    root_dir=temp_consolidated_dir,
+                    compression=self.compression,
+                )
 
                 # Get the generated file path and rename to final location
                 result_dict = result.to_pydict()
@@ -844,4 +871,4 @@ class ParquetFileWriter(Writer):
 
         This method writes a chunk to a Parquet file and uploads the file to the object store.
         """
-        chunk.to_parquet(file_name, index=False, compression="snappy")
+        chunk.to_parquet(file_name, index=False, compression=self.compression)

--- a/application_sdk/io/utils.py
+++ b/application_sdk/io/utils.py
@@ -159,13 +159,14 @@ async def download_files(
 
 
 def estimate_dataframe_record_size(
-    dataframe: "pd.DataFrame", file_extension: str
+    dataframe: "pd.DataFrame", file_extension: str, compression: str = "snappy"
 ) -> int:
     """Estimate File size of a DataFrame by sampling a few records.
 
     Args:
         dataframe (pd.DataFrame): The DataFrame to estimate the size of.
         file_extension (str): The extension of the file to estimate the size of.
+        compression (str): Parquet compression codec. Defaults to "snappy".
 
     Returns:
         int: The estimated size of the DataFrame in bytes.
@@ -180,7 +181,7 @@ def estimate_dataframe_record_size(
     if file_extension == JSON_FILE_EXTENSION:
         sample_file = sample.to_json(orient="records", lines=True)
     elif file_extension == PARQUET_FILE_EXTENSION:
-        sample_file = sample.to_parquet(index=False, compression="snappy")
+        sample_file = sample.to_parquet(index=False, compression=compression)
         compression_factor = 0.01
     else:
         raise ValueError(f"Unsupported file extension: {file_extension}")
@@ -305,7 +306,7 @@ def is_empty_dataframe(dataframe: Union["pd.DataFrame", "daft.DataFrame"]) -> bo
         import daft
 
         if isinstance(dataframe, daft.DataFrame):
-            return dataframe.count_rows() == 0
+            return dataframe.limit(1).count_rows() == 0
     except Exception:
         logger.warning("Module daft not found")
     return True

--- a/tests/unit/io/writers/test_parquet_writer.py
+++ b/tests/unit/io/writers/test_parquet_writer.py
@@ -294,9 +294,7 @@ class TestParquetFileWriterWriteDaftDataframe:
         """Test successful daft DataFrame writing."""
         with patch("daft.execution_config_ctx") as mock_ctx, patch(
             "application_sdk.services.objectstore.ObjectStore.upload_file"
-        ) as mock_upload, patch(
-            "application_sdk.io.parquet.get_object_store_prefix"
-        ) as mock_prefix, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
+        ) as mock_upload, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
             mock_upload.return_value = AsyncMock()
             mock_ctx.return_value.__enter__ = MagicMock()
             mock_ctx.return_value.__exit__ = MagicMock()
@@ -337,9 +335,7 @@ class TestParquetFileWriterWriteDaftDataframe:
             "application_sdk.services.objectstore.ObjectStore.upload_file"
         ) as mock_upload, patch(
             "application_sdk.services.objectstore.ObjectStore.delete_prefix"
-        ) as mock_delete, patch(
-            "application_sdk.io.parquet.get_object_store_prefix"
-        ) as mock_prefix, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
+        ) as mock_delete, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
             mock_upload.return_value = AsyncMock()
             mock_delete.return_value = AsyncMock()
             mock_ctx.return_value.__enter__ = MagicMock()
@@ -379,9 +375,7 @@ class TestParquetFileWriterWriteDaftDataframe:
         """Test daft DataFrame writing with default parameters (uses method default write_mode='append')."""
         with patch("daft.execution_config_ctx") as mock_ctx, patch(
             "application_sdk.services.objectstore.ObjectStore.upload_file"
-        ) as mock_upload, patch(
-            "application_sdk.io.parquet.get_object_store_prefix"
-        ) as mock_prefix, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
+        ) as mock_upload, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
             mock_upload.return_value = AsyncMock()
             mock_ctx.return_value.__enter__ = MagicMock()
             mock_ctx.return_value.__exit__ = MagicMock()
@@ -415,9 +409,7 @@ class TestParquetFileWriterWriteDaftDataframe:
         """Test that DAPR limit is properly configured."""
         with patch("daft.execution_config_ctx") as mock_ctx, patch(
             "application_sdk.services.objectstore.ObjectStore.upload_file"
-        ) as mock_upload, patch(
-            "application_sdk.io.parquet.get_object_store_prefix"
-        ) as mock_prefix, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
+        ) as mock_upload, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
             mock_upload.return_value = AsyncMock()
             mock_ctx.return_value.__enter__ = MagicMock()
             mock_ctx.return_value.__exit__ = MagicMock()
@@ -499,9 +491,7 @@ class TestParquetFileWriterMetrics:
             "application_sdk.services.objectstore.ObjectStore.upload_file"
         ) as mock_upload, patch(
             "application_sdk.io.parquet.get_metrics"
-        ) as mock_get_metrics, patch(
-            "application_sdk.io.parquet.get_object_store_prefix"
-        ) as mock_prefix, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
+        ) as mock_get_metrics, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
             mock_upload.return_value = AsyncMock()
             mock_ctx.return_value.__enter__ = MagicMock()
             mock_ctx.return_value.__exit__ = MagicMock()
@@ -1152,11 +1142,8 @@ class TestParquetFileWriterCompression:
             "application_sdk.services.objectstore.ObjectStore.upload_file"
         ) as mock_upload, patch(
             "pandas.DataFrame.to_parquet"
-        ) as mock_to_parquet, patch(
-            "application_sdk.io.parquet.get_object_store_prefix"
-        ) as mock_prefix:
+        ) as mock_to_parquet:
             mock_upload.return_value = AsyncMock()
-            mock_prefix.return_value = "test/output/path"
 
             writer = ParquetFileWriter(path=base_output_path, compression="zstd")
 
@@ -1173,11 +1160,8 @@ class TestParquetFileWriterCompression:
         """Test that zstd compression is passed through to daft write_parquet."""
         with patch("daft.execution_config_ctx") as mock_ctx, patch(
             "application_sdk.services.objectstore.ObjectStore.upload_file"
-        ) as mock_upload, patch(
-            "application_sdk.io.parquet.get_object_store_prefix"
-        ) as mock_prefix, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
+        ) as mock_upload, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
             mock_upload.return_value = AsyncMock()
-            mock_prefix.return_value = "test/output/path"
             mock_ctx.return_value.__enter__ = MagicMock()
             mock_ctx.return_value.__exit__ = MagicMock()
             mock_read_metadata.return_value.num_rows = 10
@@ -1208,11 +1192,8 @@ class TestParquetFileWriterCompression:
             "daft.execution_config_ctx"
         ) as mock_ctx, patch(
             "application_sdk.services.objectstore.ObjectStore.upload_file"
-        ) as mock_upload, patch(
-            "application_sdk.io.parquet.get_object_store_prefix"
-        ) as mock_prefix:
+        ) as mock_upload:
             mock_upload.return_value = AsyncMock()
-            mock_prefix.return_value = "test/output/path"
             mock_ctx.return_value.__enter__ = MagicMock()
             mock_ctx.return_value.__exit__ = MagicMock()
 

--- a/tests/unit/io/writers/test_parquet_writer.py
+++ b/tests/unit/io/writers/test_parquet_writer.py
@@ -277,7 +277,7 @@ class TestParquetFileWriterWriteDaftDataframe:
     async def test_write_empty(self, base_output_path: str):
         """Test writing an empty daft DataFrame."""
         mock_df = MagicMock()
-        mock_df.count_rows.return_value = 0
+        mock_df.limit.return_value.count_rows.return_value = 0
 
         parquet_output = ParquetFileWriter(
             path=base_output_path,
@@ -294,14 +294,17 @@ class TestParquetFileWriterWriteDaftDataframe:
         """Test successful daft DataFrame writing."""
         with patch("daft.execution_config_ctx") as mock_ctx, patch(
             "application_sdk.services.objectstore.ObjectStore.upload_file"
-        ) as mock_upload:
+        ) as mock_upload, patch(
+            "application_sdk.io.parquet.get_object_store_prefix"
+        ) as mock_prefix, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
             mock_upload.return_value = AsyncMock()
             mock_ctx.return_value.__enter__ = MagicMock()
             mock_ctx.return_value.__exit__ = MagicMock()
+            mock_read_metadata.return_value.num_rows = 1000
 
             # Mock daft DataFrame
             mock_df = MagicMock()
-            mock_df.count_rows.return_value = 1000
+            mock_df.limit.return_value.count_rows.return_value = 1
             mock_result = MagicMock()
             mock_result.to_pydict.return_value = {"path": ["test.parquet"]}
             mock_df.write_parquet.return_value = mock_result
@@ -321,6 +324,7 @@ class TestParquetFileWriterWriteDaftDataframe:
                 root_dir=parquet_output.path,
                 write_mode="append",  # Uses method default value "append"
                 partition_cols=None,
+                compression="snappy",
             )
 
             # Check that upload_prefix was called
@@ -333,15 +337,18 @@ class TestParquetFileWriterWriteDaftDataframe:
             "application_sdk.services.objectstore.ObjectStore.upload_file"
         ) as mock_upload, patch(
             "application_sdk.services.objectstore.ObjectStore.delete_prefix"
-        ) as mock_delete:
+        ) as mock_delete, patch(
+            "application_sdk.io.parquet.get_object_store_prefix"
+        ) as mock_prefix, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
             mock_upload.return_value = AsyncMock()
             mock_delete.return_value = AsyncMock()
             mock_ctx.return_value.__enter__ = MagicMock()
             mock_ctx.return_value.__exit__ = MagicMock()
+            mock_read_metadata.return_value.num_rows = 500
 
             # Mock daft DataFrame
             mock_df = MagicMock()
-            mock_df.count_rows.return_value = 500
+            mock_df.limit.return_value.count_rows.return_value = 1
             mock_result = MagicMock()
             mock_result.to_pydict.return_value = {"path": ["test.parquet"]}
             mock_df.write_parquet.return_value = mock_result
@@ -361,6 +368,7 @@ class TestParquetFileWriterWriteDaftDataframe:
                 root_dir=parquet_output.path,
                 write_mode="overwrite",  # Overridden
                 partition_cols=["department", "year"],  # Overridden
+                compression="snappy",
             )
 
             # Check that delete_prefix was called for overwrite mode
@@ -371,14 +379,17 @@ class TestParquetFileWriterWriteDaftDataframe:
         """Test daft DataFrame writing with default parameters (uses method default write_mode='append')."""
         with patch("daft.execution_config_ctx") as mock_ctx, patch(
             "application_sdk.services.objectstore.ObjectStore.upload_file"
-        ) as mock_upload:
+        ) as mock_upload, patch(
+            "application_sdk.io.parquet.get_object_store_prefix"
+        ) as mock_prefix, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
             mock_upload.return_value = AsyncMock()
             mock_ctx.return_value.__enter__ = MagicMock()
             mock_ctx.return_value.__exit__ = MagicMock()
+            mock_read_metadata.return_value.num_rows = 500
 
             # Mock daft DataFrame
             mock_df = MagicMock()
-            mock_df.count_rows.return_value = 500
+            mock_df.limit.return_value.count_rows.return_value = 1
             mock_result = MagicMock()
             mock_result.to_pydict.return_value = {"path": ["test.parquet"]}
             mock_df.write_parquet.return_value = mock_result
@@ -396,6 +407,7 @@ class TestParquetFileWriterWriteDaftDataframe:
                 root_dir=parquet_output.path,
                 write_mode="append",  # Uses method default value "append"
                 partition_cols=None,
+                compression="snappy",
             )
 
     @pytest.mark.asyncio
@@ -403,14 +415,17 @@ class TestParquetFileWriterWriteDaftDataframe:
         """Test that DAPR limit is properly configured."""
         with patch("daft.execution_config_ctx") as mock_ctx, patch(
             "application_sdk.services.objectstore.ObjectStore.upload_file"
-        ) as mock_upload:
+        ) as mock_upload, patch(
+            "application_sdk.io.parquet.get_object_store_prefix"
+        ) as mock_prefix, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
             mock_upload.return_value = AsyncMock()
             mock_ctx.return_value.__enter__ = MagicMock()
             mock_ctx.return_value.__exit__ = MagicMock()
+            mock_read_metadata.return_value.num_rows = 1000
 
             # Mock daft DataFrame
             mock_df = MagicMock()
-            mock_df.count_rows.return_value = 1000
+            mock_df.limit.return_value.count_rows.return_value = 1
             mock_result = MagicMock()
             mock_result.to_pydict.return_value = {"path": ["test.parquet"]}
             mock_df.write_parquet.return_value = mock_result
@@ -428,15 +443,19 @@ class TestParquetFileWriterWriteDaftDataframe:
             call_args = mock_ctx.call_args
             assert "parquet_target_filesize" in call_args.kwargs
             assert "default_morsel_size" in call_args.kwargs
+            assert "native_parquet_writer" in call_args.kwargs
             assert call_args.kwargs["parquet_target_filesize"] > 0
             assert call_args.kwargs["default_morsel_size"] > 0
+            assert call_args.kwargs["native_parquet_writer"] is False
 
     @pytest.mark.asyncio
     async def test_write_error_handling(self, base_output_path: str):
         """Test error handling during daft DataFrame writing."""
-        # Test that count_rows error is properly handled
+        # Test that limit/count_rows error is properly handled
         mock_df = MagicMock()
-        mock_df.count_rows.side_effect = Exception("Count rows error")
+        mock_df.limit.return_value.count_rows.side_effect = Exception(
+            "Count rows error"
+        )
 
         parquet_output = ParquetFileWriter(
             path=base_output_path,
@@ -480,16 +499,19 @@ class TestParquetFileWriterMetrics:
             "application_sdk.services.objectstore.ObjectStore.upload_file"
         ) as mock_upload, patch(
             "application_sdk.io.parquet.get_metrics"
-        ) as mock_get_metrics:
+        ) as mock_get_metrics, patch(
+            "application_sdk.io.parquet.get_object_store_prefix"
+        ) as mock_prefix, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
             mock_upload.return_value = AsyncMock()
             mock_ctx.return_value.__enter__ = MagicMock()
             mock_ctx.return_value.__exit__ = MagicMock()
+            mock_read_metadata.return_value.num_rows = 1000
             mock_metrics = MagicMock()
             mock_get_metrics.return_value = mock_metrics
 
             # Mock daft DataFrame
             mock_df = MagicMock()
-            mock_df.count_rows.return_value = 1000
+            mock_df.limit.return_value.count_rows.return_value = 1
             mock_result = MagicMock()
             mock_result.to_pydict.return_value = {"path": ["test.parquet"]}
             mock_df.write_parquet.return_value = mock_result
@@ -1101,3 +1123,216 @@ class TestParquetFileWriterConsolidation:
 
                 # Verify partitions tracking
                 assert len(parquet_output.partitions) == 2
+
+
+class TestParquetFileWriterCompression:
+    """Test ParquetFileWriter compression configuration."""
+
+    def test_default_compression_is_snappy(self, base_output_path: str):
+        """Test that default compression is snappy."""
+        writer = ParquetFileWriter(path=base_output_path)
+        assert writer.compression == "snappy"
+
+    def test_zstd_compression_accepted(self, base_output_path: str):
+        """Test that zstd compression is accepted."""
+        writer = ParquetFileWriter(path=base_output_path, compression="zstd")
+        assert writer.compression == "zstd"
+
+    def test_invalid_compression_rejected(self, base_output_path: str):
+        """Test that unsupported compression raises ValueError."""
+        with pytest.raises(ValueError, match="Unsupported compression"):
+            ParquetFileWriter(path=base_output_path, compression="lz4")
+
+    @pytest.mark.asyncio
+    async def test_zstd_pandas_write(
+        self, base_output_path: str, sample_dataframe: pd.DataFrame
+    ):
+        """Test that zstd compression is passed through to pandas to_parquet."""
+        with patch(
+            "application_sdk.services.objectstore.ObjectStore.upload_file"
+        ) as mock_upload, patch(
+            "pandas.DataFrame.to_parquet"
+        ) as mock_to_parquet, patch(
+            "application_sdk.io.parquet.get_object_store_prefix"
+        ) as mock_prefix:
+            mock_upload.return_value = AsyncMock()
+            mock_prefix.return_value = "test/output/path"
+
+            writer = ParquetFileWriter(path=base_output_path, compression="zstd")
+
+            with patch("os.path.exists", return_value=True):
+                await writer.write(sample_dataframe)
+
+            # Verify to_parquet was called with zstd compression
+            mock_to_parquet.assert_called()
+            call_kwargs = mock_to_parquet.call_args[1]
+            assert call_kwargs["compression"] == "zstd"
+
+    @pytest.mark.asyncio
+    async def test_zstd_daft_write(self, base_output_path: str):
+        """Test that zstd compression is passed through to daft write_parquet."""
+        with patch("daft.execution_config_ctx") as mock_ctx, patch(
+            "application_sdk.services.objectstore.ObjectStore.upload_file"
+        ) as mock_upload, patch(
+            "application_sdk.io.parquet.get_object_store_prefix"
+        ) as mock_prefix, patch("pyarrow.parquet.read_metadata") as mock_read_metadata:
+            mock_upload.return_value = AsyncMock()
+            mock_prefix.return_value = "test/output/path"
+            mock_ctx.return_value.__enter__ = MagicMock()
+            mock_ctx.return_value.__exit__ = MagicMock()
+            mock_read_metadata.return_value.num_rows = 10
+
+            mock_df = MagicMock()
+            mock_df.limit.return_value.count_rows.return_value = 1
+            mock_result = MagicMock()
+            mock_result.to_pydict.return_value = {"path": ["test.parquet"]}
+            mock_df.write_parquet.return_value = mock_result
+
+            writer = ParquetFileWriter(
+                path=base_output_path,
+                dataframe_type=DataframeType.daft,
+                compression="zstd",
+            )
+
+            await writer._write_daft_dataframe(mock_df)
+
+            call_kwargs = mock_df.write_parquet.call_args[1]
+            assert call_kwargs["compression"] == "zstd"
+
+    @pytest.mark.asyncio
+    async def test_zstd_consolidation_write(
+        self, base_output_path: str, mock_consolidation_files
+    ):
+        """Test that zstd compression is passed through during consolidation."""
+        with patch("daft.read_parquet") as mock_read, patch(
+            "daft.execution_config_ctx"
+        ) as mock_ctx, patch(
+            "application_sdk.services.objectstore.ObjectStore.upload_file"
+        ) as mock_upload, patch(
+            "application_sdk.io.parquet.get_object_store_prefix"
+        ) as mock_prefix:
+            mock_upload.return_value = AsyncMock()
+            mock_prefix.return_value = "test/output/path"
+            mock_ctx.return_value.__enter__ = MagicMock()
+            mock_ctx.return_value.__exit__ = MagicMock()
+
+            mock_df = MagicMock()
+            mock_read.return_value = mock_df
+
+            writer = ParquetFileWriter(path=base_output_path, compression="zstd")
+            writer._start_new_temp_folder()
+            writer.current_folder_records = 100
+
+            # Create a dummy parquet file in the temp folder
+            assert writer.current_temp_folder_path is not None
+            temp_file = os.path.join(writer.current_temp_folder_path, "chunk-0.parquet")
+            with open(temp_file, "w") as f:
+                f.write("dummy")
+
+            with mock_consolidation_files(
+                base_output_path, ["consolidated.parquet"]
+            ) as (file_paths, create_mock_result):
+                mock_df.write_parquet.return_value = create_mock_result(file_paths)
+
+                await writer._consolidate_current_folder()
+
+                call_kwargs = mock_df.write_parquet.call_args[1]
+                assert call_kwargs["compression"] == "zstd"
+
+
+class TestParquetFileWriterCompressionCodec:
+    """Verify the requested compression codec is actually written to parquet files.
+
+    These tests exercise real Daft/PyArrow writes (no mocks on the write path)
+    so we catch silent codec changes such as Daft's native writer ignoring the
+    compression parameter.
+    """
+
+    @pytest.mark.asyncio
+    async def test_daft_write_produces_zstd_files(self, base_output_path: str):
+        """Guard: native_parquet_writer=False must honour zstd compression."""
+        import daft
+        import pyarrow.parquet as pq
+
+        writer = ParquetFileWriter(
+            path=base_output_path,
+            dataframe_type=DataframeType.daft,
+            compression="zstd",
+        )
+        df = daft.from_pydict({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+
+        with patch(
+            "application_sdk.services.objectstore.ObjectStore.upload_file",
+            new_callable=AsyncMock,
+        ):
+            await writer._write_daft_dataframe(df)
+
+        parquet_files = list(Path(base_output_path).rglob("*.parquet"))
+        assert parquet_files, "No parquet files were written"
+        for pf in parquet_files:
+            meta = pq.read_metadata(str(pf))
+            assert meta.row_group(0).column(0).compression == "ZSTD"
+
+    @pytest.mark.asyncio
+    async def test_daft_write_produces_snappy_files(self, base_output_path: str):
+        """Sanity check: default snappy compression is written correctly."""
+        import daft
+        import pyarrow.parquet as pq
+
+        writer = ParquetFileWriter(
+            path=base_output_path,
+            dataframe_type=DataframeType.daft,
+            compression="snappy",
+        )
+        df = daft.from_pydict({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+
+        with patch(
+            "application_sdk.services.objectstore.ObjectStore.upload_file",
+            new_callable=AsyncMock,
+        ):
+            await writer._write_daft_dataframe(df)
+
+        parquet_files = list(Path(base_output_path).rglob("*.parquet"))
+        assert parquet_files, "No parquet files were written"
+        for pf in parquet_files:
+            meta = pq.read_metadata(str(pf))
+            assert meta.row_group(0).column(0).compression == "SNAPPY"
+
+    @pytest.mark.asyncio
+    async def test_pandas_write_produces_zstd_files(
+        self, base_output_path: str, sample_dataframe: pd.DataFrame
+    ):
+        """Verify pandas write path produces zstd-compressed parquet."""
+        import pyarrow.parquet as pq
+
+        writer = ParquetFileWriter(path=base_output_path, compression="zstd")
+
+        with patch(
+            "application_sdk.services.objectstore.ObjectStore.upload_file",
+            new_callable=AsyncMock,
+        ):
+            await writer.write(sample_dataframe)
+
+        parquet_files = list(Path(base_output_path).rglob("*.parquet"))
+        assert parquet_files, "No parquet files were written"
+        for pf in parquet_files:
+            meta = pq.read_metadata(str(pf))
+            assert meta.row_group(0).column(0).compression == "ZSTD"
+
+
+class TestEstimateDataframeRecordSize:
+    """Test estimate_dataframe_record_size compression passthrough."""
+
+    def test_compression_passed_to_parquet(self, sample_dataframe: pd.DataFrame):
+        """Test that compression parameter is forwarded to to_parquet."""
+        from application_sdk.io.utils import (
+            PARQUET_FILE_EXTENSION,
+            estimate_dataframe_record_size,
+        )
+
+        with patch("pandas.DataFrame.to_parquet", return_value=b"\x00" * 100) as mock:
+            estimate_dataframe_record_size(
+                sample_dataframe, PARQUET_FILE_EXTENSION, compression="zstd"
+            )
+
+            mock.assert_called_once_with(index=False, compression="zstd")


### PR DESCRIPTION
## Summary

- Adds a `compression` parameter to `ParquetFileWriter` (default: `"snappy"`, supports `snappy`, `zstd`, `gzip`, `none`) so callers can choose the parquet compression codec at construction time.
- Forces Daft's PyArrow-based writer (`native_parquet_writer=False`) because the native Rust writer silently ignores the `compression` kwarg and hardcodes SNAPPY.
- Derives row counts from written parquet file metadata (`pyarrow.parquet.read_metadata`) instead of calling `dataframe.count_rows()`, avoiding a full re-materialisation of lazy Daft DataFrames.
- Replaces `count_rows()` emptiness checks with `limit(1).count_rows() == 0` to prevent materialising the entire DataFrame just to check if it's empty.
- Threads the chosen compression through `estimate_dataframe_record_size`, the pandas write path (`to_parquet`), and the Daft consolidation write path.

## Changed files

| File | What changed |
|------|-------------|
| `application_sdk/io/parquet.py` | New `compression` param, validation, `native_parquet_writer=False`, metadata-based row counting |
| `application_sdk/io/__init__.py` | Pass `compression` to `estimate_dataframe_record_size` |
| `application_sdk/io/utils.py` | Accept `compression` param in `estimate_dataframe_record_size`; use `limit(1)` in `is_empty_dataframe` |
| `tests/unit/io/writers/test_parquet_writer.py` | New test classes for compression config, codec verification (real writes), and `estimate_dataframe_record_size` passthrough; updated existing daft tests for new mocks |

## Test plan

- [x] Unit tests for compression parameter validation (default, valid, invalid)
- [x] Unit tests verifying compression is threaded to pandas, daft, and consolidation write paths
- [x] Integration-style tests that perform real parquet writes and assert the codec in file metadata (zstd, snappy)
- [x] Existing daft writer tests updated with `read_metadata` / `get_object_store_prefix` mocks
- [ ] CI passes all pre-existing and new tests