### PR TITLE
feat: convention-based serving from contract/generated/

### DIFF
--- a/application_sdk/application/__init__.py
+++ b/application_sdk/application/__init__.py
@@ -78,9 +78,19 @@ class BaseApplication:
     def get_manifest(self) -> Optional[Dict[str, Any]]:
         """Return the manifest dict for the GET /manifest endpoint.
 
-        Override this in subclasses to serve an app-specific manifest.
-        Return None (default) to disable the /manifest endpoint.
+        Priority:
+        1. contract/generated/manifest.json (if exists)
+        2. Subclass override (e.g., BaseSQLMetadataExtractionApplication)
+        3. None (disables the /manifest endpoint)
         """
+        import json
+        from pathlib import Path
+
+        manifest_path = Path.cwd() / "contract" / "generated" / "manifest.json"
+        if manifest_path.exists():
+            logger.info(f"Serving manifest from contract: {manifest_path}")
+            with open(manifest_path) as f:
+                return json.load(f)
         return None
 
     def bootstrap_event_registration(self):

--- a/application_sdk/application/metadata_extraction/sql.py
+++ b/application_sdk/application/metadata_extraction/sql.py
@@ -78,10 +78,18 @@ class BaseSQLMetadataExtractionApplication(BaseApplication):
         return f"atlan-{app_name}-{DEPLOYMENT_NAME}" if DEPLOYMENT_NAME else app_name
 
     def get_manifest(self) -> Optional[Dict[str, Any]]:
-        """Return the default extract + publish manifest for SQL extraction apps.
+        """Return the manifest for SQL extraction apps.
 
-        Override this in subclasses to customize args or the entire manifest.
+        Priority:
+        1. contract/generated/manifest.json (if exists)
+        2. Default hardcoded extract + publish DAG
+        3. None (if no workflow class set)
         """
+        # Check contract-generated manifest first
+        contract_manifest = super().get_manifest()
+        if contract_manifest is not None:
+            return contract_manifest
+
         workflow_class = getattr(self, "_primary_workflow_class", None)
         if workflow_class is None:
             return None

--- a/application_sdk/handlers/__init__.py
+++ b/application_sdk/handlers/__init__.py
@@ -1,6 +1,13 @@
 import json
+import logging
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+# Convention: generated contract files live here
+CONTRACT_GENERATED_DIR = Path.cwd() / "contract" / "generated"
 
 
 class HandlerInterface(ABC):
@@ -63,8 +70,15 @@ class HandlerInterface(ABC):
     async def get_configmap(config_map_id: str) -> Dict[str, Any]:
         """Return the K8s ConfigMap for the given config_map_id.
 
-        Override in subclass to load app-specific template JSON, then call
-        HandlerInterface._wrap_configmap(config_map_id, raw) to produce the
-        correct shape.
+        Priority:
+        1. contract/generated/{config_map_id}.json (if exists)
+        2. Subclass override (call _wrap_configmap to produce correct shape)
+        3. Empty dict
         """
+        if CONTRACT_GENERATED_DIR.exists():
+            for json_file in CONTRACT_GENERATED_DIR.rglob("*.json"):
+                if json_file.stem == config_map_id:
+                    logger.debug(f"Serving configmap from contract: {json_file}")
+                    with open(json_file) as f:
+                        return json.load(f)
         return {}

--- a/application_sdk/server/fastapi/__init__.py
+++ b/application_sdk/server/fastapi/__init__.py
@@ -423,6 +423,12 @@ class APIServer(ServerInterface):
         )
 
         self.workflow_router.add_api_route(
+            "/configmaps",
+            self.list_configmaps,
+            methods=["GET"],
+        )
+
+        self.workflow_router.add_api_route(
             "/file",
             self.upload_file,
             methods=["POST"],
@@ -737,6 +743,21 @@ class APIServer(ServerInterface):
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"File upload failed: {str(e)}",
             )
+
+    async def list_configmaps(self):
+        """List available configmap IDs from contract/generated/.
+
+        Returns a JSON array of configmap IDs (filenames without .json)
+        that are available for fetching via GET /configmap/{id}.
+        """
+        from application_sdk.handlers import CONTRACT_GENERATED_DIR
+
+        ids = []
+        if CONTRACT_GENERATED_DIR.exists():
+            for json_file in CONTRACT_GENERATED_DIR.rglob("*.json"):
+                if json_file.stem != "manifest":
+                    ids.append(json_file.stem)
+        return {"success": True, "data": ids}
 
     async def get_configmap(self, config_map_id: str) -> ConfigMapResponse:
         """Get a configuration map by its ID.


### PR DESCRIPTION
## Summary
- SDK auto-serves configmap and manifest from `contract/generated/` directory
- Apps with PKL contracts no longer need `get_configmap()` or `get_manifest()` overrides
- Fully backward compatible — falls back to existing behavior when directory doesn't exist

## Changes
- `handlers/__init__.py`: `get_configmap()` scans `contract/generated/` for `{config_map_id}.json`
- `application/__init__.py`: `get_manifest()` reads `contract/generated/manifest.json`
- `metadata_extraction/sql.py`: `get_manifest()` calls `super()` first so contract takes priority over hardcoded Python DAG
- `server/fastapi/__init__.py`: new `GET /configmaps` list endpoint for contract discovery

## Fallback chain
```
configmap: contract/generated/{id}.json → handler override → {}
manifest:  contract/generated/manifest.json → Python get_manifest() → None
```

## Depends on
- Built on top of #1088 (native AE routes) — base branch is `native_routes`
- Companion to [app-contract-toolkit](https://github.com/atlanhq/app-contract-toolkit)

## Test plan
- [ ] App without `contract/generated/` behaves identically to before
- [ ] App with `contract/generated/` serves configmap and manifest from files
- [ ] SQL app's hardcoded manifest is overridden when contract file exists
- [ ] `GET /configmaps` returns list of available configmap IDs