### PR TITLE
fix: resolve Snyk SNYK-CBI-0014 in build workflow

### DIFF
--- a/.github/workflows/build-apps-image.yaml
+++ b/.github/workflows/build-apps-image.yaml
@@ -300,6 +300,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.ORG_PAT_GITHUB }}
 
+      - name: Pull image for Snyk
+        run: docker pull ${{ needs.prepare.outputs.ghcr_image }}
+
       - name: Snyk container scan
         # Pinned to commit SHA — avoids silent breakage if snyk/actions@master changes
         uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04


### PR DESCRIPTION
## Summary

Pre-pulls the app image from GHCR before the Snyk container scan step to fix `SNYK-CBI-0014` / `404 Not Found` errors.

## Root cause

The Snyk Docker action (`snyk/actions/docker`) runs inside its own container (`snyk/snyk:docker`). Although the workflow logs into GHCR on the host runner, those credentials are stored in the host's `~/.docker/config.json` which is **not** mounted into the Snyk container. When Snyk tries to pull the app image from GHCR, it gets a `404 Not Found` because it has no auth.

The Docker socket (`/var/run/docker.sock`) **is** mounted, so the Snyk container talks to the same Docker daemon as the host. If the image is already pulled on the host, Snyk finds it locally without needing to pull.

## Fix

Add a `docker pull` step before the Snyk scan. This runs on the host (where GHCR login already happened), caching the image in the Docker daemon. Snyk then accesses it locally via the mounted socket.

```yaml
- name: Pull image for Snyk
  run: docker pull <ghcr-image>
```

## Known limitation

The `--file=./Dockerfile` flag tells Snyk to resolve the base image (`FROM registry.atlan.com/public/application-sdk:main-latest`) for layer attribution. Snyk may still warn about being unable to pull the base image (`SNYK-CBI-0014`), but this is a **non-blocking warning** — the scan still runs and reports vulnerabilities. Full base image attribution would require adding `registry.atlan.com` credentials to the workflow.

## Impact

Fixes Snyk container scan for all 40+ app repos using this reusable workflow.

Ref: DISTR-213

## Test plan

- [ ] Merge and trigger a build on `atlan-glue-app` — verify Snyk job no longer fails with 404
- [ ] Verify vulnerability results appear in the Snyk output
- [ ] Verify SARIF upload to GitHub Security tab still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)