### PR TITLE
chore: bump pyatlan constraint to <10.0.0 (latest: 9.3.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "opentelemetry-exporter-otlp==1.39.1",
     "psutil>=7.0.0,<7.3.0",
     "fastapi[standard]==0.127.0",
-    "pyatlan>=8.0.2,<8.5.0",
+    "pyatlan>=8.0.2,<10.0.0",
     "pydantic>=2.10.6,<2.13.0",
     "loguru>=0.7.3,<0.8.0",
     "uvloop>=0.21.0,<0.23.0; sys_platform != 'win32'",


### PR DESCRIPTION
## Summary

Updates the `pyatlan` version constraint in `pyproject.toml`.

| | Before | After |
|---|---|---|
| Constraint | `>=8.0.2,<8.5.0` | `>=8.0.2,<10.0.0` |
| Latest available | `9.3.0` | ✅ included |

The previous upper bound (`<8.5.0`) was blocking adoption of pyatlan `9.x` releases. This PR opens the constraint to allow the full `9.x` series while keeping the existing lower bound.

> ⚠️ Note: pyatlan 9.x may contain breaking changes vs 8.x. Recommend running the test suite and spot-checking any client usage before merging.