### PR TITLE
fix: add missing await on execution_options() in AsyncBaseSQLClient.run_query()

### DIFF
--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -650,7 +650,9 @@ class AsyncBaseSQLClient(BaseSQLClient):
                 from sqlalchemy import text
 
                 if use_server_side_cursor:
-                    connection = connection.execution_options(yield_per=batch_size)
+                    connection = await connection.execution_options(
+                        yield_per=batch_size
+                    )
 
                 result = (
                     await connection.stream(text(query))

--- a/tests/unit/clients/test_async_sql_client.py
+++ b/tests/unit/clients/test_async_sql_client.py
@@ -38,14 +38,14 @@ def mock_async_engine_with_connection():
     mock_connection_with_options = AsyncMock()
     mock_connection_with_options.stream = AsyncMock()
     mock_connection_with_options.execute = AsyncMock()
-    mock_connection_with_options.execution_options = MagicMock(
+    mock_connection_with_options.execution_options = AsyncMock(
         return_value=mock_connection_with_options
     )
 
     # Set up the original connection
     mock_connection.stream = AsyncMock()
     mock_connection.execute = AsyncMock()
-    mock_connection.execution_options = MagicMock(
+    mock_connection.execution_options = AsyncMock(
         return_value=mock_connection_with_options
     )
 


### PR DESCRIPTION
## Summary

- Adds missing `await` on `AsyncConnection.execution_options()` in `AsyncBaseSQLClient.run_query()` (line 653 of `application_sdk/clients/sql.py`)
- Without `await`, `connection` becomes a coroutine object, causing `AttributeError: 'coroutine' object has no attribute 'stream'` when server-side cursors are enabled
- Updates test fixture to use `AsyncMock` for `execution_options` to match the corrected async call

## Context

- **Affected**: Postgres miner (first async client + miner calling `run_query()`) and any future async miners
- **Not affected**: Crawlers (use `get_results()`), Teradata miner (sync client), MySQL (no miner yet)
- **Current workaround**: Postgres and Redshift connectors disable server-side cursors (`use_server_side_cursor=False`)

## Follow-up (connector repos, after this SDK fix is released)

1. **Postgres**: Remove `use_server_side_cursor=False` workaround from `app/clients/__init__.py`
2. **Redshift**: Remove `use_server_side_cursor=False` workaround from `app/clients.py`

## Test plan

- [x] All 8 existing `test_async_sql_client.py` tests pass, including `test_run_query_server_side_cursor`

Fixes [HYP-242](https://linear.app/atlan-epd/issue/HYP-242)