### PR TITLE
fix: resilient thread-based heartbeater for all activities

### DIFF
--- a/application_sdk/activities/common/utils.py
+++ b/application_sdk/activities/common/utils.py
@@ -142,6 +142,7 @@ def _get_heartbeat_timeout() -> timedelta:
 
 def _start_heartbeat_thread(
     stop_event: threading.Event,
+    thread_failed: threading.Event,
 ) -> threading.Thread:
     """Start a daemon thread that sends heartbeats at regular intervals.
 
@@ -149,25 +150,47 @@ def _start_heartbeat_thread(
     are never blocked by event loop starvation (e.g. sync code running
     inside an async activity).
 
+    If the heartbeat thread exits unexpectedly (e.g. due to a BaseException
+    that escapes the retry logic), it sets ``thread_failed`` so that the
+    calling activity can detect the failure and stop early.
+
     Args:
         stop_event: Threading event used to signal the thread to stop.
+        thread_failed: Threading event set by the thread on unexpected exit.
 
     Returns:
         The started heartbeat thread.
     """
     heartbeat_timeout = _get_heartbeat_timeout()
+    delay = heartbeat_timeout.total_seconds() / 3
     ctx = contextvars.copy_context()
-    heartbeat_thread = threading.Thread(
-        target=ctx.run,
-        args=(
-            send_periodic_heartbeat_sync,
-            heartbeat_timeout.total_seconds() / 3,
-            stop_event,
-        ),
-        daemon=True,
-    )
+
+    def _run_heartbeat():
+        try:
+            ctx.run(send_periodic_heartbeat_sync, delay, stop_event)
+        except BaseException as e:
+            logger.error("Heartbeat thread crashed unexpectedly: %s", e, exc_info=e)
+            thread_failed.set()
+
+    heartbeat_thread = threading.Thread(target=_run_heartbeat, daemon=True)
     heartbeat_thread.start()
     return heartbeat_thread
+
+
+async def _wait_for_thread_failure(
+    thread_failed: threading.Event, check_interval: float = 1.0
+) -> None:
+    """Poll until the heartbeat thread signals an unexpected exit.
+
+    Used as a concurrent task inside the async activity wrapper so that
+    ``asyncio.wait`` can race the activity against heartbeat-thread health.
+
+    Args:
+        thread_failed: Event that the heartbeat thread sets on crash.
+        check_interval: Seconds between polls.
+    """
+    while not thread_failed.is_set():
+        await asyncio.sleep(check_interval)
 
 
 def auto_heartbeater(fn: F) -> F:
@@ -217,9 +240,28 @@ def auto_heartbeater(fn: F) -> F:
         @wraps(fn)
         async def async_wrapper(*args: Any, **kwargs: Any):
             stop_event = threading.Event()
-            heartbeat_thread = _start_heartbeat_thread(stop_event)
+            thread_failed = threading.Event()
+            heartbeat_thread = _start_heartbeat_thread(stop_event, thread_failed)
             try:
-                return await fn(*args, **kwargs)
+                activity_task = asyncio.ensure_future(fn(*args, **kwargs))
+                monitor_task = asyncio.ensure_future(
+                    _wait_for_thread_failure(thread_failed)
+                )
+                done, pending = await asyncio.wait(
+                    {activity_task, monitor_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                for p in pending:
+                    p.cancel()
+                    try:
+                        await p
+                    except (asyncio.CancelledError, Exception):
+                        pass
+
+                if activity_task in done:
+                    return activity_task.result()
+
+                raise RuntimeError("Heartbeat thread stopped unexpectedly")
             except Exception as e:
                 logger.error("Error in activity: %s", e, exc_info=e)
                 raise
@@ -233,15 +275,19 @@ def auto_heartbeater(fn: F) -> F:
         @wraps(fn)
         def sync_wrapper(*args: Any, **kwargs: Any):
             stop_event = threading.Event()
-            heartbeat_thread = _start_heartbeat_thread(stop_event)
+            thread_failed = threading.Event()
+            heartbeat_thread = _start_heartbeat_thread(stop_event, thread_failed)
             try:
-                return fn(*args, **kwargs)
+                result = fn(*args, **kwargs)
             except Exception as e:
                 logger.error("Error in activity: %s", e, exc_info=e)
                 raise
             finally:
                 stop_event.set()
                 heartbeat_thread.join(timeout=5)
+            if thread_failed.is_set():
+                raise RuntimeError("Heartbeat thread stopped unexpectedly")
+            return result
 
         return cast(F, sync_wrapper)
 

--- a/application_sdk/activities/common/utils.py
+++ b/application_sdk/activities/common/utils.py
@@ -292,43 +292,6 @@ def auto_heartbeater(fn: F) -> F:
         return cast(F, sync_wrapper)
 
 
-async def send_periodic_heartbeat(delay: float, *details: Any) -> None:
-    """Sends heartbeat signals at regular intervals until cancelled.
-
-    This function runs in an infinite loop, sleeping for the specified delay between
-    heartbeats. The heartbeat signals help Temporal track the activity's progress
-    and detect failures.
-
-    Args:
-        delay: The delay between heartbeats in seconds.
-        *details: Optional details to include in the heartbeat signal. These can be
-            used to provide progress information or state that should be available
-            if the activity needs to be retried.
-
-    Note:
-        This function is typically used internally by the @auto_heartbeater decorator
-        and should not need to be called directly in most cases.
-
-    Example:
-        >>> # Send heartbeats every 30 seconds with a status message
-        >>> heartbeat_task = asyncio.create_task(
-        ...     send_periodic_heartbeat(30, "Processing items...")
-        ... )
-        >>> try:
-        ...     await main_task
-        ... finally:
-        ...     heartbeat_task.cancel()
-        ...     await asyncio.wait([heartbeat_task])
-    """
-    # Heartbeat every so often while not cancelled
-    while True:
-        await asyncio.sleep(delay)
-        try:
-            activity.heartbeat(*details)
-        except Exception as e:
-            logger.warning("Heartbeat failed, will retry next interval: %s", e)
-
-
 def send_periodic_heartbeat_sync(
     delay: float, stop_event: threading.Event, *details: Any
 ) -> None:
@@ -351,7 +314,9 @@ def send_periodic_heartbeat_sync(
         sync activity functions and should not need to be called directly.
     """
     consecutive_failures = 0
-    max_backoff_multiplier = 5
+    # Cap backoff at the heartbeat timeout (delay * 3) so we never wait
+    # longer than Temporal's patience window before retrying.
+    max_delay = delay * 3
     current_delay = delay
 
     while not stop_event.wait(timeout=current_delay):
@@ -366,8 +331,7 @@ def send_periodic_heartbeat_sync(
             current_delay = delay
         except Exception as e:
             consecutive_failures += 1
-            backoff_multiplier = min(2**consecutive_failures, max_backoff_multiplier)
-            current_delay = delay * backoff_multiplier
+            current_delay = min(delay * 2**consecutive_failures, max_delay)
             logger.warning(
                 "Heartbeat failed (attempt %d), retrying in %.1fs: %s",
                 consecutive_failures,

--- a/application_sdk/activities/common/utils.py
+++ b/application_sdk/activities/common/utils.py
@@ -291,6 +291,10 @@ def send_periodic_heartbeat_sync(
     This function runs in a loop, waiting on the stop_event for the specified delay.
     When the event is set, the loop exits cleanly.
 
+    On transient failures, applies exponential backoff (capped at 5x the base delay)
+    to avoid hammering an unhealthy Temporal server. Resets to normal interval after
+    a successful heartbeat.
+
     Args:
         delay: The delay between heartbeats in seconds.
         stop_event: Threading event used to signal the thread to stop.
@@ -300,8 +304,27 @@ def send_periodic_heartbeat_sync(
         This function is used internally by the @auto_heartbeater decorator for
         sync activity functions and should not need to be called directly.
     """
-    while not stop_event.wait(timeout=delay):
+    consecutive_failures = 0
+    max_backoff_multiplier = 5
+    current_delay = delay
+
+    while not stop_event.wait(timeout=current_delay):
         try:
             activity.heartbeat(*details)
+            if consecutive_failures > 0:
+                logger.info(
+                    "Heartbeat recovered after %d consecutive failures",
+                    consecutive_failures,
+                )
+            consecutive_failures = 0
+            current_delay = delay
         except Exception as e:
-            logger.warning("Heartbeat failed, will retry next interval: %s", e)
+            consecutive_failures += 1
+            backoff_multiplier = min(2**consecutive_failures, max_backoff_multiplier)
+            current_delay = delay * backoff_multiplier
+            logger.warning(
+                "Heartbeat failed (attempt %d), retrying in %.1fs: %s",
+                consecutive_failures,
+                current_delay,
+                e,
+            )

--- a/application_sdk/activities/common/utils.py
+++ b/application_sdk/activities/common/utils.py
@@ -140,6 +140,36 @@ def _get_heartbeat_timeout() -> timedelta:
         return default_heartbeat_timeout
 
 
+def _start_heartbeat_thread(
+    stop_event: threading.Event,
+) -> threading.Thread:
+    """Start a daemon thread that sends heartbeats at regular intervals.
+
+    Uses a background thread instead of an asyncio task so that heartbeats
+    are never blocked by event loop starvation (e.g. sync code running
+    inside an async activity).
+
+    Args:
+        stop_event: Threading event used to signal the thread to stop.
+
+    Returns:
+        The started heartbeat thread.
+    """
+    heartbeat_timeout = _get_heartbeat_timeout()
+    ctx = contextvars.copy_context()
+    heartbeat_thread = threading.Thread(
+        target=ctx.run,
+        args=(
+            send_periodic_heartbeat_sync,
+            heartbeat_timeout.total_seconds() / 3,
+            stop_event,
+        ),
+        daemon=True,
+    )
+    heartbeat_thread.start()
+    return heartbeat_thread
+
+
 def auto_heartbeater(fn: F) -> F:
     """Decorator that automatically sends heartbeats during activity execution.
 
@@ -151,9 +181,9 @@ def auto_heartbeater(fn: F) -> F:
     heartbeat timeout. If no timeout is configured, it defaults to 120 seconds
     (resulting in a 40-second heartbeat interval).
 
-    Supports both async and sync activity functions. For async functions, heartbeats
-    are sent via an asyncio task. For sync functions, heartbeats are sent via a
-    background thread, preserving Temporal's thread pool execution model.
+    Heartbeats are always sent from a background thread, regardless of whether
+    the activity is async or sync. This ensures heartbeats are never starved
+    by event loop blocking (e.g. sync calls inside async activities).
 
     Args:
         fn: The activity function to be decorated. Can be sync or async.
@@ -186,39 +216,24 @@ def auto_heartbeater(fn: F) -> F:
 
         @wraps(fn)
         async def async_wrapper(*args: Any, **kwargs: Any):
-            heartbeat_timeout = _get_heartbeat_timeout()
-            heartbeat_task = asyncio.create_task(
-                send_periodic_heartbeat(heartbeat_timeout.total_seconds() / 3)
-            )
+            stop_event = threading.Event()
+            heartbeat_thread = _start_heartbeat_thread(stop_event)
             try:
                 return await fn(*args, **kwargs)
             except Exception as e:
                 logger.error("Error in activity: %s", e, exc_info=e)
                 raise
             finally:
-                heartbeat_task.cancel()
-                await asyncio.wait([heartbeat_task])
+                stop_event.set()
+                heartbeat_thread.join(timeout=5)
 
         return cast(F, async_wrapper)
     else:
 
         @wraps(fn)
         def sync_wrapper(*args: Any, **kwargs: Any):
-            heartbeat_timeout = _get_heartbeat_timeout()
             stop_event = threading.Event()
-            # Copy the current context so the heartbeat thread can access
-            # the Temporal activity context (stored in contextvars)
-            ctx = contextvars.copy_context()
-            heartbeat_thread = threading.Thread(
-                target=ctx.run,
-                args=(
-                    send_periodic_heartbeat_sync,
-                    heartbeat_timeout.total_seconds() / 3,
-                    stop_event,
-                ),
-                daemon=True,
-            )
-            heartbeat_thread.start()
+            heartbeat_thread = _start_heartbeat_thread(stop_event)
             try:
                 return fn(*args, **kwargs)
             except Exception as e:
@@ -262,7 +277,10 @@ async def send_periodic_heartbeat(delay: float, *details: Any) -> None:
     # Heartbeat every so often while not cancelled
     while True:
         await asyncio.sleep(delay)
-        activity.heartbeat(*details)
+        try:
+            activity.heartbeat(*details)
+        except Exception as e:
+            logger.warning("Heartbeat failed, will retry next interval: %s", e)
 
 
 def send_periodic_heartbeat_sync(
@@ -286,5 +304,4 @@ def send_periodic_heartbeat_sync(
         try:
             activity.heartbeat(*details)
         except Exception as e:
-            logger.error("Error sending heartbeat: %s", e, exc_info=e)
-            return
+            logger.warning("Heartbeat failed, will retry next interval: %s", e)

--- a/tests/unit/activities/common/test_utils.py
+++ b/tests/unit/activities/common/test_utils.py
@@ -352,6 +352,79 @@ class TestAutoHeartbeater:
         result = await test_activity("a", "b", kwarg1="c")
         assert result == "a_b_c"
 
+    @patch("application_sdk.activities.common.utils.activity")
+    async def test_heartbeat_continues_when_event_loop_blocked(self, mock_activity):
+        """Test that heartbeats are sent from a background thread even when
+        the event loop is blocked by synchronous code inside an async activity.
+
+        This is the core scenario the thread-based heartbeater fixes: an async
+        activity that calls blocking (sync) code would starve an asyncio-task
+        heartbeater, but a thread-based heartbeater keeps running.
+        """
+        mock_activity.info.return_value.heartbeat_timeout = timedelta(seconds=0.3)
+        heartbeat_count = 0
+
+        def count_heartbeat(*args, **kwargs):
+            nonlocal heartbeat_count
+            heartbeat_count += 1
+
+        mock_activity.heartbeat = count_heartbeat
+
+        @auto_heartbeater
+        async def blocking_async_activity():
+            # Block the event loop — an asyncio-task heartbeater would starve
+            time.sleep(0.5)
+            return "done"
+
+        result = await blocking_async_activity()
+        assert result == "done"
+        # heartbeat_interval = 0.3/3 = 0.1s; activity blocks for 0.5s
+        # Thread-based heartbeater should have sent at least 3 heartbeats
+        assert heartbeat_count >= 3, (
+            f"Expected >= 3 heartbeats during 0.5s event-loop block "
+            f"with 0.1s interval, got {heartbeat_count}"
+        )
+
+    @patch("application_sdk.activities.common.utils.activity")
+    async def test_async_activity_stops_when_heartbeat_thread_crashes(
+        self, mock_activity
+    ):
+        """Test that an async activity is cancelled when the heartbeat thread
+        exits unexpectedly (e.g. a BaseException that escapes the retry logic).
+        """
+        mock_activity.info.return_value.heartbeat_timeout = timedelta(seconds=0.3)
+        # SystemExit is a BaseException — it escapes `except Exception` in the
+        # heartbeat loop and triggers the thread_failed event.
+        mock_activity.heartbeat.side_effect = SystemExit("simulated crash")
+
+        @auto_heartbeater
+        async def long_activity():
+            await asyncio.sleep(10)
+            return "should not reach"
+
+        with pytest.raises(RuntimeError, match="Heartbeat thread stopped unexpectedly"):
+            await long_activity()
+
+    @patch("application_sdk.activities.common.utils.activity")
+    def test_sync_activity_stops_when_heartbeat_thread_crashes(self, mock_activity):
+        """Test that a sync activity raises after completion when the heartbeat
+        thread crashed during execution.
+
+        Note: Python cannot safely interrupt a running sync function mid-
+        execution, so the failure is detected after the function returns.
+        """
+        mock_activity.info.return_value.heartbeat_timeout = timedelta(seconds=0.3)
+        mock_activity.heartbeat.side_effect = SystemExit("simulated crash")
+
+        @auto_heartbeater
+        def sync_activity():
+            # Give heartbeat thread time to crash (interval = 0.1s)
+            time.sleep(0.5)
+            return "done"
+
+        with pytest.raises(RuntimeError, match="Heartbeat thread stopped unexpectedly"):
+            sync_activity()
+
 
 class TestSendPeriodicHeartbeat:
     """Test cases for send_periodic_heartbeat function."""

--- a/tests/unit/activities/common/test_utils.py
+++ b/tests/unit/activities/common/test_utils.py
@@ -441,3 +441,35 @@ class TestSendPeriodicHeartbeatSync:
         stop_event.set()
         send_periodic_heartbeat_sync(1.0, stop_event)
         mock_activity.heartbeat.assert_not_called()
+
+    @patch("application_sdk.activities.common.utils.activity")
+    def test_retries_on_transient_failure(self, mock_activity):
+        """Test that heartbeat retries after transient failure instead of dying."""
+        call_count = 0
+
+        def heartbeat_side_effect(*args):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise Exception("transient gRPC error")
+            # Succeeds on 3rd+ call
+
+        mock_activity.heartbeat.side_effect = heartbeat_side_effect
+
+        stop_event = threading.Event()
+        thread = threading.Thread(
+            target=send_periodic_heartbeat_sync,
+            args=(0.05, stop_event),
+            daemon=True,
+        )
+        thread.start()
+        # Wait for at least 4 calls (2 failures + 2 successes)
+        deadline = time.monotonic() + 10
+        while mock_activity.heartbeat.call_count < 4 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        stop_event.set()
+        thread.join(timeout=2)
+        assert not thread.is_alive(), "Heartbeat thread failed to terminate"
+        assert (
+            mock_activity.heartbeat.call_count >= 4
+        ), "Heartbeat should have retried and recovered"

--- a/tests/unit/activities/common/test_utils.py
+++ b/tests/unit/activities/common/test_utils.py
@@ -12,7 +12,6 @@ from application_sdk.activities.common.utils import (
     auto_heartbeater,
     get_object_store_prefix,
     get_workflow_id,
-    send_periodic_heartbeat,
     send_periodic_heartbeat_sync,
 )
 
@@ -424,65 +423,6 @@ class TestAutoHeartbeater:
 
         with pytest.raises(RuntimeError, match="Heartbeat thread stopped unexpectedly"):
             sync_activity()
-
-
-class TestSendPeriodicHeartbeat:
-    """Test cases for send_periodic_heartbeat function."""
-
-    @patch("application_sdk.activities.common.utils.activity")
-    @patch("application_sdk.activities.common.utils.asyncio.sleep")
-    async def test_send_periodic_heartbeat_success(self, mock_sleep, mock_activity):
-        mock_sleep.return_value = None
-        task = asyncio.create_task(send_periodic_heartbeat(0.1, "test_detail"))
-        await asyncio.sleep(0.01)
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
-        # Just ensure no exception is raised (heartbeat may not be called before cancel)
-
-    @patch("application_sdk.activities.common.utils.activity")
-    @patch("application_sdk.activities.common.utils.asyncio.sleep")
-    async def test_send_periodic_heartbeat_multiple_details(
-        self, mock_sleep, mock_activity
-    ):
-        mock_sleep.return_value = None
-        task = asyncio.create_task(send_periodic_heartbeat(0.1, "detail1", "detail2"))
-        await asyncio.sleep(0.01)
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
-        # Just ensure no exception is raised
-
-    @patch("application_sdk.activities.common.utils.activity")
-    @patch("application_sdk.activities.common.utils.asyncio.sleep")
-    async def test_send_periodic_heartbeat_no_details(self, mock_sleep, mock_activity):
-        mock_sleep.return_value = None
-        task = asyncio.create_task(send_periodic_heartbeat(0.1))
-        await asyncio.sleep(0.01)
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
-        # Just ensure no exception is raised
-
-    @patch("application_sdk.activities.common.utils.activity")
-    @patch("application_sdk.activities.common.utils.asyncio.sleep")
-    async def test_send_periodic_heartbeat_sleep_error(self, mock_sleep, mock_activity):
-        """Test periodic heartbeat when sleep raises an error."""
-        mock_sleep.side_effect = asyncio.CancelledError()
-
-        task = asyncio.create_task(send_periodic_heartbeat(0.1))
-
-        with pytest.raises(asyncio.CancelledError):
-            await task
-
-        # Heartbeat should not be called if sleep fails
-        mock_activity.heartbeat.assert_not_called()
 
 
 class TestSendPeriodicHeartbeatSync:

--- a/tests/unit/activities/common/test_utils.py
+++ b/tests/unit/activities/common/test_utils.py
@@ -207,29 +207,51 @@ class TestAutoHeartbeater:
     """Test cases for auto_heartbeater decorator."""
 
     @patch("application_sdk.activities.common.utils.activity")
-    @patch("application_sdk.activities.common.utils.send_periodic_heartbeat")
-    async def test_auto_heartbeater_success(self, mock_send_heartbeat, mock_activity):
-        """Test successful auto_heartbeater decorator."""
-        # Mock activity info
-        mock_activity.info.return_value.heartbeat_timeout = timedelta(seconds=60)
+    async def test_auto_heartbeater_async_success(self, mock_activity):
+        """Test successful auto_heartbeater decorator with async function."""
+        mock_activity.info.return_value.heartbeat_timeout = timedelta(seconds=0.3)
 
-        # Create a mock async function
         @auto_heartbeater
         async def test_activity():
+            await asyncio.sleep(0.2)
             return "success"
 
         result = await test_activity()
 
         assert result == "success"
-        mock_send_heartbeat.assert_called_once()
+        mock_activity.heartbeat.assert_called()
 
     @patch("application_sdk.activities.common.utils.activity")
-    @patch("application_sdk.activities.common.utils.send_periodic_heartbeat")
-    async def test_auto_heartbeater_default_timeout(
-        self, mock_send_heartbeat, mock_activity
-    ):
+    async def test_auto_heartbeater_async_uses_thread(self, mock_activity):
+        """Test that async auto_heartbeater uses a background thread, not asyncio task."""
+        mock_activity.info.return_value.heartbeat_timeout = timedelta(seconds=0.3)
+        heartbeat_thread_ids = []
+        main_thread_id = threading.current_thread().ident
+
+        original_heartbeat = mock_activity.heartbeat
+
+        def capture_thread(*args, **kwargs):
+            heartbeat_thread_ids.append(threading.current_thread().ident)
+            return original_heartbeat(*args, **kwargs)
+
+        mock_activity.heartbeat = capture_thread
+
+        @auto_heartbeater
+        async def test_activity():
+            await asyncio.sleep(0.3)
+            return "done"
+
+        result = await test_activity()
+        assert result == "done"
+        assert len(heartbeat_thread_ids) > 0, "Heartbeat should have been called"
+        for tid in heartbeat_thread_ids:
+            assert (
+                tid != main_thread_id
+            ), "Heartbeat should run on a background thread, not the main thread"
+
+    @patch("application_sdk.activities.common.utils.activity")
+    async def test_auto_heartbeater_default_timeout(self, mock_activity):
         """Test auto_heartbeater with default timeout."""
-        # Mock activity info with no heartbeat timeout
         mock_activity.info.return_value.heartbeat_timeout = None
 
         @auto_heartbeater
@@ -237,15 +259,10 @@ class TestAutoHeartbeater:
             return "success"
 
         result = await test_activity()
-
         assert result == "success"
-        mock_send_heartbeat.assert_called_once()
 
     @patch("application_sdk.activities.common.utils.activity")
-    @patch("application_sdk.activities.common.utils.send_periodic_heartbeat")
-    async def test_auto_heartbeater_runtime_error(
-        self, mock_send_heartbeat, mock_activity
-    ):
+    async def test_auto_heartbeater_runtime_error(self, mock_activity):
         """Test auto_heartbeater when activity.info() raises RuntimeError."""
         mock_activity.info.side_effect = RuntimeError("No activity context")
 
@@ -254,15 +271,10 @@ class TestAutoHeartbeater:
             return "success"
 
         result = await test_activity()
-
         assert result == "success"
-        mock_send_heartbeat.assert_called_once()
 
     @patch("application_sdk.activities.common.utils.activity")
-    @patch("application_sdk.activities.common.utils.send_periodic_heartbeat")
-    async def test_auto_heartbeater_function_error(
-        self, mock_send_heartbeat, mock_activity
-    ):
+    async def test_auto_heartbeater_function_error(self, mock_activity):
         """Test auto_heartbeater when the decorated function raises an error."""
         mock_activity.info.return_value.heartbeat_timeout = timedelta(seconds=60)
 
@@ -272,9 +284,6 @@ class TestAutoHeartbeater:
 
         with pytest.raises(ValueError, match="Function error"):
             await test_activity()
-
-        # Heartbeat task should still be created and cancelled
-        mock_send_heartbeat.assert_called_once()
 
     @patch("application_sdk.activities.common.utils.activity")
     def test_auto_heartbeater_sync_function_returns_value(self, mock_activity):
@@ -332,11 +341,8 @@ class TestAutoHeartbeater:
         assert result == "a_b_c"
 
     @patch("application_sdk.activities.common.utils.activity")
-    @patch("application_sdk.activities.common.utils.send_periodic_heartbeat")
-    async def test_auto_heartbeater_with_arguments(
-        self, mock_send_heartbeat, mock_activity
-    ):
-        """Test auto_heartbeater with function arguments."""
+    async def test_auto_heartbeater_async_with_arguments(self, mock_activity):
+        """Test auto_heartbeater with async function arguments."""
         mock_activity.info.return_value.heartbeat_timeout = timedelta(seconds=60)
 
         @auto_heartbeater
@@ -344,9 +350,7 @@ class TestAutoHeartbeater:
             return f"{arg1}_{arg2}_{kwarg1}"
 
         result = await test_activity("a", "b", kwarg1="c")
-
         assert result == "a_b_c"
-        mock_send_heartbeat.assert_called_once()
 
 
 class TestSendPeriodicHeartbeat:


### PR DESCRIPTION
## Summary

- **Thread-based heartbeater for all activities**: Both async and sync activities now use a background `threading.Thread` for heartbeats instead of the previous split approach (asyncio task for async, thread for sync). This prevents heartbeat starvation when async activities call blocking/sync code (DaprClient, subprocess, requests.post, etc.)
- **Resilient heartbeat on transient failures**: Both `send_periodic_heartbeat` (async) and `send_periodic_heartbeat_sync` now catch exceptions and log a warning instead of dying permanently. Previously, one transient gRPC blip would kill heartbeats for the rest of the activity's lifetime.
- **Shared `_start_heartbeat_thread` helper**: Deduplicates the thread setup logic between async and sync wrappers.

## Context

Root causes addressed:
1. **Event loop starvation (RC#1)**: Async activities calling blocking sync code (Looker SDK, MongoDB inference, DaprClient, subprocess.run) would starve the asyncio heartbeat task. Moving to a thread makes heartbeats immune to this.
2. **Silent heartbeat death (RC#2)**: `send_periodic_heartbeat_sync` did `return` on any exception, permanently stopping heartbeats. The async version had zero error handling -- one exception killed the task silently.

Immediate impact: QI `parse_queries` (sync activity running for hours) was losing heartbeats due to RC#2. `send_to_segment` (async with blocking `requests.post`) was losing heartbeats due to RC#1. 37 pod failures across 6 tenants traced to these bugs.

Relates to: ARUN-425, ARUN-388, AUT-841, DBBI-310

## Test plan

- [x] All 24 existing unit tests pass
- [x] New test `test_auto_heartbeater_async_uses_thread` verifies heartbeats run on a background thread (not main thread) for async activities
- [x] Pre-commit checks pass (ruff, ruff-format, pyright, isort)
- [ ] Verify on a QI tenant with previously-failing `parse_queries` activity
- [ ] Verify on a connector with async activities calling blocking Dapr/HTTP code