### PR TITLE
fix(ci): remove continue-on-error from reusable workflow call

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -355,6 +355,8 @@ jobs:
           echo "| SDR push | \`${{ needs.prepare.outputs.enable_sdr }}\` |" >> $GITHUB_STEP_SUMMARY
 
   # ── Job 4: Security scan — Trivy + Snyk + allowlist gate (non-blocking on merge path) ──
+  # Note: continue-on-error is not supported on reusable workflow calls (uses:).
+  # Downstream jobs use if: always() to avoid being blocked by scan failures.
   security-scan:
     name: Security Scan
     needs: [prepare, merge]
@@ -364,7 +366,6 @@ jobs:
       snyk_org: partner-images
       snyk_monitor: ${{ inputs.snyk_monitor }}
     secrets: inherit
-    continue-on-error: true
 
   # ── Job 5: Dispatch deployment to atlan-apps-deployment (main only) ───────────
   app-deployment-dispatcher:


### PR DESCRIPTION
## Summary

`continue-on-error: true` on the `security-scan` job (line 367) is not supported by GitHub Actions on reusable workflow calls (`uses:`). This causes a YAML parse error that breaks `workflow_dispatch` for **all downstream app repos**:

```
error parsing called workflow: Unexpected value 'continue-on-error' (Line: 367, Col: 5)
```

Affected repos: every app repo that calls `build-and-publish-app.yaml@main` via `workflow_dispatch`.

## Fix

Remove `continue-on-error: true` from the `security-scan` job. The job is already non-blocking — no downstream jobs depend on it (`app-deployment-dispatcher` and `publish` both use `needs: [prepare, merge]`, not `needs: [security-scan]`).

## Test plan

- [x] Verified `workflow_dispatch` fails with the current YAML
- [ ] After merge, trigger `workflow_dispatch` on any app repo to confirm it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)