### PR TITLE
feat: support ?package= query param on /manifest for multi-package apps

### DIFF
--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -1353,12 +1353,27 @@ def create_app_handler_service(
     # ------------------------------------------------------------------
 
     @app.get("/workflows/v1/manifest")
-    async def get_manifest() -> Response:
+    async def get_manifest(request: Request) -> Response:
         if manifest is not None:
             # Programmatic: Pydantic model → JSON bytes, single hop.
             return Response(
                 content=manifest.model_dump_json(), media_type="application/json"
             )
+
+        # Multi-package support: if ?package=@scope/name is provided, try
+        # serving manifest-{name}.json first (e.g., manifest-mssql-miner.json
+        # for ?package=@atlan/mssql-miner).  Falls back to manifest.json.
+        package_param = request.query_params.get("package", "")
+        if package_param:
+            # Extract the short name: "@atlan/mssql-miner" → "mssql-miner"
+            short_name = package_param.rsplit("/", 1)[-1] if "/" in package_param else package_param
+            pkg_manifest_path = CONTRACT_GENERATED_DIR / f"manifest-{short_name}.json"
+            if pkg_manifest_path.exists():
+                raw = pkg_manifest_path.read_bytes()
+                deployment = (DEPLOYMENT_NAME or "default").encode()
+                raw = raw.replace(b"{deployment_name}", deployment)
+                return Response(content=raw, media_type="application/json")
+
         manifest_path = CONTRACT_GENERATED_DIR / "manifest.json"
         if manifest_path.exists():
             # Disk: contract-generated file — serve raw bytes with deployment
@@ -1380,7 +1395,7 @@ def create_app_handler_service(
     # ------------------------------------------------------------------
 
     @app.get("/manifest", include_in_schema=False)
-    async def get_manifest_legacy() -> Response:
+    async def get_manifest_legacy(request: Request) -> Response:
         """Unversioned alias for ``GET /workflows/v1/manifest``.
 
         .. deprecated::
@@ -1390,7 +1405,7 @@ def create_app_handler_service(
             orchestrators have been updated to use ``/workflows/v1/manifest``.
             Do **not** add new callers of this endpoint.
         """
-        return await get_manifest()
+        return await get_manifest(request)
 
     # ------------------------------------------------------------------
     # Health probes


### PR DESCRIPTION
## Summary
- `/manifest` and `/workflows/v1/manifest` now accept an optional `?package=@scope/name` query parameter
- When provided, serves `manifest-{name}.json` from the generated contract directory (e.g., `manifest-mssql-miner.json` for `?package=@atlan/mssql-miner`)
- Falls back to `manifest.json` if the package-specific file doesn't exist or no param is provided
- Backwards compatible — existing single-package apps are unaffected

## Convention
```
?package=@atlan/mssql-miner → app/generated/manifest-mssql-miner.json
?package=@atlan/mssql       → app/generated/manifest-mssql.json (if exists, else manifest.json)
(no param)                  → app/generated/manifest.json
```

## Context
Native v3 apps like MSSQL serve two Argo packages (`@atlan/mssql` for metadata extraction, `@atlan/mssql-miner` for query history) from the same app service. Both packages have different DAGs (different `workflow_type`). Without this change, the miner package incorrectly starts the metadata extraction workflow.

## Companion PR
- Heracles: atlanhq/heracles#5553 (passes `package.argoproj.io/name` annotation as `?package=` param)

## Test plan
- [ ] Single-package app: `/manifest` returns `manifest.json` as before
- [ ] Single-package app: `/manifest?package=@atlan/foo` returns `manifest.json` (no `manifest-foo.json` exists)
- [ ] Multi-package app: `/manifest?package=@atlan/mssql-miner` returns `manifest-mssql-miner.json`
- [ ] Multi-package app: `/manifest` (no param) returns default `manifest.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)