### PR TITLE
feat: parity test framework for regression detection (v2)

### DIFF
--- a/.github/actions/parity-extract/action.yaml
+++ b/.github/actions/parity-extract/action.yaml
@@ -1,0 +1,152 @@
+name: Parity Extract
+description: |
+  Starts a connector app, triggers a metadata extraction workflow,
+  polls until complete, and uploads the transformed output as an artifact.
+  Used by the parity test framework to extract from both baseline and candidate branches.
+
+inputs:
+  ref:
+    description: "Git ref (SHA or branch) to checkout and extract from"
+    required: true
+  artifact-name:
+    description: "Name for the uploaded artifact"
+    required: true
+    default: "parity-output"
+  app-name:
+    description: "Application name (e.g., postgres, tableau)"
+    required: true
+  credentials-json:
+    description: "JSON string with credentials for /workflows/v1/start"
+    required: true
+  metadata-json:
+    description: "JSON string with metadata filters for /workflows/v1/start"
+    required: false
+    default: '{"exclude-filter":"{}","include-filter":"{}","temp-table-regex":"","extraction-method":"direct"}'
+  connection-json:
+    description: "JSON string with connection config for /workflows/v1/start"
+    required: false
+    default: '{"connection_name":"parity-test","connection_qualified_name":"default/parity/0"}'
+  poll-interval:
+    description: "Seconds between status polls"
+    required: false
+    default: "10"
+  poll-timeout:
+    description: "Max seconds to wait for workflow completion"
+    required: false
+    default: "300"
+  app-startup-wait:
+    description: "Seconds to wait for app to start"
+    required: false
+    default: "25"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
+        fetch-depth: 0
+
+    - name: Restore ref after submodule setup
+      shell: bash
+      run: |
+        git checkout ${{ inputs.ref }}
+        echo "Checked out: $(git log --oneline -1)"
+
+    - name: Start app and extract
+      shell: bash
+      env:
+        ATLAN_LOCAL_DEVELOPMENT: "true"
+        ATLAN_APPLICATION_NAME: ${{ inputs.app-name }}
+        ATLAN_MAX_CONCURRENT_ACTIVITIES: "1"
+      run: |
+        set -euo pipefail
+        APP_URL="http://localhost:8000"
+
+        # Start the application
+        echo ">> Starting application..."
+        uv run python main.py &
+        APP_PID=$!
+        sleep ${{ inputs.app-startup-wait }}
+
+        # Health check
+        if ! curl -sf "${APP_URL}/server/health" > /dev/null 2>&1; then
+          echo "ERROR: App failed health check"
+          kill "$APP_PID" 2>/dev/null || true
+          exit 1
+        fi
+        echo ">> App is healthy."
+
+        # Trigger extraction
+        echo ">> Triggering extraction..."
+        RESPONSE=$(curl -sf -X POST \
+          -H "Content-Type: application/json" \
+          -d "{
+            \"credentials\": ${{ inputs.credentials-json }},
+            \"connection\": ${{ inputs.connection-json }},
+            \"metadata\": ${{ inputs.metadata-json }}
+          }" \
+          "${APP_URL}/workflows/v1/start")
+
+        WORKFLOW_ID=$(echo "$RESPONSE" | jq -r '.data.workflow_id')
+        RUN_ID=$(echo "$RESPONSE" | jq -r '.data.run_id')
+
+        if [ -z "$WORKFLOW_ID" ] || [ "$WORKFLOW_ID" = "null" ]; then
+          echo "ERROR: Failed to start workflow. Response: $RESPONSE"
+          kill "$APP_PID" 2>/dev/null || true
+          exit 1
+        fi
+        echo ">> Workflow started: $WORKFLOW_ID / $RUN_ID"
+
+        # Poll for completion
+        ELAPSED=0
+        TIMEOUT=${{ inputs.poll-timeout }}
+        INTERVAL=${{ inputs.poll-interval }}
+        STATUS="RUNNING"
+
+        while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+          STATUS_RESPONSE=$(curl -sf "${APP_URL}/workflows/v1/status/${WORKFLOW_ID}/${RUN_ID}" || echo '{}')
+          STATUS=$(echo "$STATUS_RESPONSE" | jq -r '.data.status // "UNKNOWN"')
+          LAST_RUN_ID=$(echo "$STATUS_RESPONSE" | jq -r '.data.last_executed_run_id // empty')
+          [ -n "$LAST_RUN_ID" ] && RUN_ID="$LAST_RUN_ID"
+
+          if [ "$STATUS" != "RUNNING" ]; then
+            break
+          fi
+          echo "   Still running... (${ELAPSED}s)"
+          sleep "$INTERVAL"
+          ELAPSED=$((ELAPSED + INTERVAL))
+        done
+
+        if [ "$STATUS" != "COMPLETED" ]; then
+          echo "ERROR: Workflow ended with status: $STATUS"
+          kill "$APP_PID" 2>/dev/null || true
+          exit 1
+        fi
+        echo ">> Workflow completed."
+
+        # Copy transformed output
+        ARTIFACTS_BASE="./local/dapr/objectstore/artifacts/apps/${{ inputs.app-name }}/workflows"
+        TRANSFORMED_SRC="${ARTIFACTS_BASE}/${WORKFLOW_ID}/${RUN_ID}/transformed"
+
+        if [ ! -d "$TRANSFORMED_SRC" ]; then
+          echo "ERROR: Output not found at $TRANSFORMED_SRC"
+          find "$ARTIFACTS_BASE" -type d -name "transformed" 2>/dev/null || true
+          kill "$APP_PID" 2>/dev/null || true
+          exit 1
+        fi
+
+        mkdir -p ./parity-output
+        cp -r "$TRANSFORMED_SRC"/* ./parity-output/
+        echo ">> Output:"
+        find ./parity-output -type f | head -20
+
+        # Cleanup
+        kill "$APP_PID" 2>/dev/null || true
+        wait "$APP_PID" 2>/dev/null || true
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ./parity-output/
+        retention-days: 7

--- a/application_sdk/test_utils/parity/__init__.py
+++ b/application_sdk/test_utils/parity/__init__.py
@@ -1,0 +1,41 @@
+"""Parity test framework for regression detection in connector output.
+
+Compares transformed metadata output from two extraction runs (baseline vs candidate)
+and reports ADDED, REMOVED, and MODIFIED assets per category.
+
+Usage as CLI:
+    python -m application_sdk.test_utils.parity \\
+        --baseline ./baseline/ --candidate ./candidate/
+
+Usage as library:
+    from application_sdk.test_utils.parity import run_comparison, generate_markdown
+
+    results = run_comparison(baseline_dir, candidate_dir)
+    report = generate_markdown(results)
+"""
+
+from application_sdk.test_utils.parity.comparator import (
+    compare_category,
+    discover_categories,
+    run_comparison,
+)
+from application_sdk.test_utils.parity.models import (
+    AssetDiff,
+    CategoryResult,
+    FieldDiff,
+)
+from application_sdk.test_utils.parity.report import (
+    generate_json_report,
+    generate_markdown,
+)
+
+__all__ = [
+    "run_comparison",
+    "compare_category",
+    "discover_categories",
+    "generate_markdown",
+    "generate_json_report",
+    "AssetDiff",
+    "CategoryResult",
+    "FieldDiff",
+]

--- a/application_sdk/test_utils/parity/__main__.py
+++ b/application_sdk/test_utils/parity/__main__.py
@@ -1,0 +1,89 @@
+"""CLI entry point for parity comparison.
+
+Usage:
+    python -m application_sdk.test_utils.parity \\
+        --baseline ./baseline/ --candidate ./candidate/ \\
+        [--output-json report.json] [--output-md report.md]
+
+Exit codes:
+    0 = parity (no differences)
+    1 = differences found
+    2 = input error
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from application_sdk.test_utils.parity.comparator import run_comparison
+from application_sdk.test_utils.parity.report import (
+    generate_json_report,
+    generate_markdown,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Parity Test — Compare extraction outputs"
+    )
+    parser.add_argument(
+        "--baseline", required=True, help="Path to baseline transformed output"
+    )
+    parser.add_argument(
+        "--candidate", required=True, help="Path to candidate transformed output"
+    )
+    parser.add_argument("--output-json", help="Write JSON report to file")
+    parser.add_argument("--output-md", help="Write markdown report to file")
+    parser.add_argument(
+        "--baseline-ref", default="main", help="Git ref for baseline (for report)"
+    )
+    parser.add_argument(
+        "--candidate-ref", default="PR", help="Git ref for candidate (for report)"
+    )
+    args = parser.parse_args()
+
+    baseline_dir = Path(args.baseline)
+    candidate_dir = Path(args.candidate)
+
+    if not baseline_dir.exists():
+        print(f"ERROR: Baseline directory not found: {baseline_dir}", file=sys.stderr)
+        sys.exit(2)
+    if not candidate_dir.exists():
+        print(
+            f"ERROR: Candidate directory not found: {candidate_dir}", file=sys.stderr
+        )
+        sys.exit(2)
+
+    print(f"Comparing: {baseline_dir} (baseline) vs {candidate_dir} (candidate)")
+    results = run_comparison(baseline_dir, candidate_dir)
+
+    md_report = generate_markdown(results, args.baseline_ref, args.candidate_ref)
+    json_report = generate_json_report(results, args.baseline_ref, args.candidate_ref)
+
+    print(md_report)
+
+    if args.output_md:
+        Path(args.output_md).write_text(md_report)
+        print(f"Markdown report written to {args.output_md}", file=sys.stderr)
+
+    if args.output_json:
+        Path(args.output_json).write_text(
+            json.dumps(json_report, indent=2, default=str)
+        )
+        print(f"JSON report written to {args.output_json}", file=sys.stderr)
+
+    is_parity = not any(r.has_diffs for r in results)
+    if is_parity:
+        print("\nPARITY: No differences found.", file=sys.stderr)
+        sys.exit(0)
+    else:
+        total = sum(
+            len(r.added) + len(r.removed) + len(r.modified) for r in results
+        )
+        print(f"\nPARITY BROKEN: {total} differences found.", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/application_sdk/test_utils/parity/comparator.py
+++ b/application_sdk/test_utils/parity/comparator.py
@@ -1,0 +1,170 @@
+"""Core comparison engine for parity testing.
+
+Loads NDJSON output from two extraction runs, strips volatile fields,
+joins on qualifiedName, and classifies each asset as ADDED, REMOVED,
+MODIFIED, or UNCHANGED.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+from application_sdk.test_utils.parity.models import (
+    AssetDiff,
+    CategoryResult,
+    FieldDiff,
+)
+
+# Fields that change every run and must be ignored in comparison.
+VOLATILE_FIELDS: Set[str] = {
+    "lastSyncWorkflowName",
+    "lastSyncRun",
+    "lastSyncRunAt",
+}
+
+
+def load_ndjson(directory: Path) -> List[Dict[str, Any]]:
+    """Load all NDJSON files from a directory, skipping statistics files."""
+    assets: List[Dict[str, Any]] = []
+    if not directory.exists():
+        return assets
+    for json_file in sorted(directory.glob("*.json")):
+        if "statistics" in json_file.name:
+            continue
+        with open(json_file) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    assets.append(json.loads(line))
+    return assets
+
+
+def strip_volatile(obj: Any) -> Any:
+    """Recursively remove volatile fields from a dict."""
+    if not isinstance(obj, dict):
+        return obj
+    return {k: strip_volatile(v) for k, v in obj.items() if k not in VOLATILE_FIELDS}
+
+
+def get_qualified_name(asset: Dict[str, Any]) -> str:
+    """Extract qualifiedName from an asset."""
+    return asset.get("attributes", {}).get("qualifiedName", "")
+
+
+def diff_dicts(
+    baseline: Dict[str, Any],
+    candidate: Dict[str, Any],
+    prefix: str = "",
+) -> List[FieldDiff]:
+    """Deep diff two dicts, returning a list of field differences."""
+    diffs: List[FieldDiff] = []
+    all_keys = set(baseline.keys()) | set(candidate.keys())
+
+    for key in sorted(all_keys):
+        path = f"{prefix}.{key}" if prefix else key
+        b_val = baseline.get(key)
+        c_val = candidate.get(key)
+
+        if b_val == c_val:
+            continue
+
+        if isinstance(b_val, dict) and isinstance(c_val, dict):
+            diffs.extend(diff_dicts(b_val, c_val, path))
+        else:
+            diffs.append(
+                FieldDiff(
+                    field_path=path,
+                    baseline_value=b_val,
+                    candidate_value=c_val,
+                )
+            )
+
+    return diffs
+
+
+def compare_category(
+    category: str,
+    baseline_dir: Path,
+    candidate_dir: Path,
+) -> CategoryResult:
+    """Compare a single category (e.g., 'table', 'column') between two runs."""
+    baseline_assets = load_ndjson(baseline_dir)
+    candidate_assets = load_ndjson(candidate_dir)
+
+    baseline_map: Dict[str, Dict[str, Any]] = {}
+    for asset in baseline_assets:
+        qn = get_qualified_name(asset)
+        if qn:
+            baseline_map[qn] = strip_volatile(asset)
+
+    candidate_map: Dict[str, Dict[str, Any]] = {}
+    for asset in candidate_assets:
+        qn = get_qualified_name(asset)
+        if qn:
+            candidate_map[qn] = strip_volatile(asset)
+
+    result = CategoryResult(
+        category=category,
+        baseline_count=len(baseline_map),
+        candidate_count=len(candidate_map),
+    )
+
+    # REMOVED: in baseline but not in candidate
+    for qn in sorted(set(baseline_map) - set(candidate_map)):
+        asset = baseline_map[qn]
+        result.removed.append(
+            AssetDiff(
+                qualified_name=qn,
+                type_name=asset.get("typeName", "?"),
+                diff_type="REMOVED",
+            )
+        )
+
+    # ADDED: in candidate but not in baseline
+    for qn in sorted(set(candidate_map) - set(baseline_map)):
+        asset = candidate_map[qn]
+        result.added.append(
+            AssetDiff(
+                qualified_name=qn,
+                type_name=asset.get("typeName", "?"),
+                diff_type="ADDED",
+            )
+        )
+
+    # MODIFIED: in both, check for field diffs
+    for qn in sorted(set(baseline_map) & set(candidate_map)):
+        field_diffs = diff_dicts(baseline_map[qn], candidate_map[qn])
+        if field_diffs:
+            result.modified.append(
+                AssetDiff(
+                    qualified_name=qn,
+                    type_name=baseline_map[qn].get("typeName", "?"),
+                    diff_type="MODIFIED",
+                    field_diffs=field_diffs,
+                )
+            )
+
+    return result
+
+
+def discover_categories(baseline_dir: Path, candidate_dir: Path) -> List[str]:
+    """Find all category subdirectories across both dirs."""
+    categories: Set[str] = set()
+    for d in [baseline_dir, candidate_dir]:
+        if d.exists():
+            for subdir in d.iterdir():
+                if subdir.is_dir() and not subdir.name.startswith("."):
+                    categories.add(subdir.name)
+    return sorted(categories)
+
+
+def run_comparison(
+    baseline_dir: Path,
+    candidate_dir: Path,
+) -> List[CategoryResult]:
+    """Run full parity comparison across all categories."""
+    categories = discover_categories(baseline_dir, candidate_dir)
+    return [
+        compare_category(cat, baseline_dir / cat, candidate_dir / cat)
+        for cat in categories
+    ]

--- a/application_sdk/test_utils/parity/models.py
+++ b/application_sdk/test_utils/parity/models.py
@@ -1,0 +1,39 @@
+"""Data models for parity comparison results."""
+
+from dataclasses import dataclass, field
+from typing import Any, List
+
+
+@dataclass
+class FieldDiff:
+    """A single field-level difference between baseline and candidate."""
+
+    field_path: str
+    baseline_value: Any
+    candidate_value: Any
+
+
+@dataclass
+class AssetDiff:
+    """A difference for a single asset (identified by qualifiedName)."""
+
+    qualified_name: str
+    type_name: str
+    diff_type: str  # ADDED, REMOVED, MODIFIED
+    field_diffs: List[FieldDiff] = field(default_factory=list)
+
+
+@dataclass
+class CategoryResult:
+    """Comparison result for a single category (e.g., table, column)."""
+
+    category: str
+    baseline_count: int
+    candidate_count: int
+    added: List[AssetDiff] = field(default_factory=list)
+    removed: List[AssetDiff] = field(default_factory=list)
+    modified: List[AssetDiff] = field(default_factory=list)
+
+    @property
+    def has_diffs(self) -> bool:
+        return bool(self.added or self.removed or self.modified)

--- a/application_sdk/test_utils/parity/report.py
+++ b/application_sdk/test_utils/parity/report.py
@@ -1,0 +1,159 @@
+"""Report generation for parity comparison results."""
+
+from typing import Any, Dict, List
+
+from application_sdk.test_utils.parity.models import CategoryResult
+
+
+def _format_value(val: Any) -> str:
+    """Format a value for display, truncating long strings."""
+    s = repr(val)
+    if len(s) > 80:
+        return s[:77] + "..."
+    return s
+
+
+def generate_markdown(
+    results: List[CategoryResult],
+    baseline_ref: str = "main",
+    candidate_ref: str = "PR",
+) -> str:
+    """Generate a markdown report from comparison results."""
+    has_any_diffs = any(r.has_diffs for r in results)
+    total_added = sum(len(r.added) for r in results)
+    total_removed = sum(len(r.removed) for r in results)
+    total_modified = sum(len(r.modified) for r in results)
+
+    lines: List[str] = []
+    lines.append("## Parity Test Results\n")
+
+    if has_any_diffs:
+        lines.append(
+            f"**Verdict: PARITY BROKEN** — "
+            f"{total_added} added, {total_removed} removed, {total_modified} modified\n"
+        )
+    else:
+        lines.append("**Verdict: PARITY** — no differences found\n")
+
+    lines.append(
+        f"**Baseline**: `{baseline_ref}` | **Candidate**: `{candidate_ref}`\n"
+    )
+
+    # Summary table
+    lines.append("### Summary\n")
+    lines.append("| Category | Baseline | Candidate | Added | Removed | Modified |")
+    lines.append("|----------|----------|-----------|-------|---------|----------|")
+    for r in results:
+        lines.append(
+            f"| {r.category} | {r.baseline_count} | {r.candidate_count} "
+            f"| {len(r.added)} | {len(r.removed)} | {len(r.modified)} |"
+        )
+    lines.append("")
+
+    # Details per category (collapsible)
+    for r in results:
+        if not r.has_diffs:
+            continue
+
+        parts = []
+        if r.added:
+            parts.append(f"{len(r.added)} added")
+        if r.removed:
+            parts.append(f"{len(r.removed)} removed")
+        if r.modified:
+            parts.append(f"{len(r.modified)} modified")
+        summary = ", ".join(parts)
+
+        lines.append("<details>")
+        lines.append(f"<summary><b>{r.category}</b>: {summary}</summary>\n")
+
+        if r.added:
+            lines.append("**Added:**")
+            for a in r.added[:50]:
+                lines.append(f"- `{a.qualified_name}` ({a.type_name})")
+            if len(r.added) > 50:
+                lines.append(f"- ... and {len(r.added) - 50} more")
+            lines.append("")
+
+        if r.removed:
+            lines.append("**Removed:**")
+            for a in r.removed[:50]:
+                lines.append(f"- `{a.qualified_name}` ({a.type_name})")
+            if len(r.removed) > 50:
+                lines.append(f"- ... and {len(r.removed) - 50} more")
+            lines.append("")
+
+        if r.modified:
+            lines.append("**Modified:**")
+            for a in r.modified[:30]:
+                lines.append(f"- `{a.qualified_name}` ({a.type_name}):")
+                for fd in a.field_diffs[:10]:
+                    b_str = _format_value(fd.baseline_value)
+                    c_str = _format_value(fd.candidate_value)
+                    lines.append(f"  - `{fd.field_path}`: {b_str} → {c_str}")
+                if len(a.field_diffs) > 10:
+                    lines.append(
+                        f"  - ... and {len(a.field_diffs) - 10} more fields"
+                    )
+            if len(r.modified) > 30:
+                lines.append(f"- ... and {len(r.modified) - 30} more")
+            lines.append("")
+
+        lines.append("</details>\n")
+
+    if has_any_diffs:
+        lines.append(
+            "> Add label `parity-accepted` to acknowledge these changes.\n"
+        )
+
+    return "\n".join(lines)
+
+
+def generate_json_report(
+    results: List[CategoryResult],
+    baseline_ref: str = "main",
+    candidate_ref: str = "PR",
+) -> Dict[str, Any]:
+    """Generate a JSON report from comparison results."""
+    has_any_diffs = any(r.has_diffs for r in results)
+    return {
+        "is_parity": not has_any_diffs,
+        "baseline_ref": baseline_ref,
+        "candidate_ref": candidate_ref,
+        "summary": {
+            "total_added": sum(len(r.added) for r in results),
+            "total_removed": sum(len(r.removed) for r in results),
+            "total_modified": sum(len(r.modified) for r in results),
+        },
+        "categories": [
+            {
+                "category": r.category,
+                "baseline_count": r.baseline_count,
+                "candidate_count": r.candidate_count,
+                "added": [
+                    {"qualified_name": a.qualified_name, "type_name": a.type_name}
+                    for a in r.added
+                ],
+                "removed": [
+                    {"qualified_name": a.qualified_name, "type_name": a.type_name}
+                    for a in r.removed
+                ],
+                "modified": [
+                    {
+                        "qualified_name": a.qualified_name,
+                        "type_name": a.type_name,
+                        "field_diffs": [
+                            {
+                                "field": fd.field_path,
+                                "baseline": fd.baseline_value,
+                                "candidate": fd.candidate_value,
+                            }
+                            for fd in a.field_diffs
+                        ],
+                    }
+                    for a in r.modified
+                ],
+            }
+            for r in results
+        ],
+    }


### PR DESCRIPTION
## Summary
- Adds `application_sdk/test_utils/parity/` — a reusable comparison engine for detecting regressions in connector metadata output
- Adds `.github/actions/parity-extract/` — a reusable composite action for extracting metadata in CI

## Modules

| Module | Purpose |
|--------|---------|
| `test_utils/parity/comparator.py` | Load NDJSON, strip volatile fields, outer-join on qualifiedName, classify diffs |
| `test_utils/parity/models.py` | `AssetDiff`, `CategoryResult`, `FieldDiff` dataclasses |
| `test_utils/parity/report.py` | Markdown + JSON report generation |
| `test_utils/parity/__main__.py` | CLI entry point: `python -m application_sdk.test_utils.parity` |
| `actions/parity-extract/action.yaml` | Composite GHA action: start app → trigger → poll → upload artifact |

## How connectors use it
A connector adds a ~50-line `.github/workflows/parity-test.yaml` with 3 jobs:
1. **baseline**: `parity-extract` action with `ref: base.sha`
2. **candidate**: `parity-extract` action with `ref: head.sha`
3. **compare**: `python -m application_sdk.test_utils.parity --baseline ./baseline/ --candidate ./candidate/`

## Proven on
- Postgres connector: 100 tables, 10K columns, ~3 min total
- Demo PRs: atlanhq/atlan-postgres-app#324 (pass) and atlanhq/atlan-postgres-app#325 (fail — caught `databaseName` change on all 100 tables)

## Test plan
- [x] Comparison engine tested locally against real extraction output
- [x] Parity pass: identical output → exit 0, "no differences found"
- [x] Parity fail: different output → exit 1, markdown report with field-level diffs
- [x] End-to-end on GHA: both pass and fail cases verified on Postgres connector PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)