### PR TITLE
feat: parity test framework for regression detection (v3)

### DIFF
--- a/.github/actions/parity-extract/action.yaml
+++ b/.github/actions/parity-extract/action.yaml
@@ -42,7 +42,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.ref }}
         fetch-depth: 0
@@ -153,7 +153,7 @@ runs:
         kill "$APP_PID" 2>/dev/null || true
         wait "$APP_PID" 2>/dev/null || true
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ inputs.artifact-name }}
         path: ./parity-output/

--- a/.github/actions/parity-extract/action.yaml
+++ b/.github/actions/parity-extract/action.yaml
@@ -42,15 +42,17 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
       with:
         ref: ${{ inputs.ref }}
         fetch-depth: 0
 
     - name: Restore ref after submodule setup
       shell: bash
+      env:
+        PARITY_REF: ${{ inputs.ref }}
       run: |
-        git checkout ${{ inputs.ref }}
+        git checkout "$PARITY_REF"
         echo "Checked out: $(git log --oneline -1)"
 
     - name: Start app and extract
@@ -59,6 +61,12 @@ runs:
         ATLAN_LOCAL_DEVELOPMENT: "true"
         ATLAN_APPLICATION_NAME: ${{ inputs.app-name }}
         ATLAN_MAX_CONCURRENT_ACTIVITIES: "1"
+        PARITY_STARTUP_WAIT: ${{ inputs.app-startup-wait }}
+        PARITY_CREDENTIALS: ${{ inputs.credentials-json }}
+        PARITY_CONNECTION: ${{ inputs.connection-json }}
+        PARITY_METADATA: ${{ inputs.metadata-json }}
+        PARITY_POLL_TIMEOUT: ${{ inputs.poll-timeout }}
+        PARITY_POLL_INTERVAL: ${{ inputs.poll-interval }}
       run: |
         set -euo pipefail
         APP_URL="http://localhost:8000"
@@ -67,7 +75,7 @@ runs:
         echo ">> Starting application..."
         uv run python main.py &
         APP_PID=$!
-        sleep ${{ inputs.app-startup-wait }}
+        sleep "$PARITY_STARTUP_WAIT"
 
         # Health check
         if ! curl -sf "${APP_URL}/server/health" > /dev/null 2>&1; then
@@ -82,9 +90,9 @@ runs:
         RESPONSE=$(curl -sf -X POST \
           -H "Content-Type: application/json" \
           -d "{
-            \"credentials\": ${{ inputs.credentials-json }},
-            \"connection\": ${{ inputs.connection-json }},
-            \"metadata\": ${{ inputs.metadata-json }}
+            \"credentials\": ${PARITY_CREDENTIALS},
+            \"connection\": ${PARITY_CONNECTION},
+            \"metadata\": ${PARITY_METADATA}
           }" \
           "${APP_URL}/workflows/v1/start")
 
@@ -100,8 +108,8 @@ runs:
 
         # Poll for completion
         ELAPSED=0
-        TIMEOUT=${{ inputs.poll-timeout }}
-        INTERVAL=${{ inputs.poll-interval }}
+        TIMEOUT="$PARITY_POLL_TIMEOUT"
+        INTERVAL="$PARITY_POLL_INTERVAL"
         STATUS="RUNNING"
 
         while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
@@ -126,7 +134,7 @@ runs:
         echo ">> Workflow completed."
 
         # Copy transformed output
-        ARTIFACTS_BASE="./local/dapr/objectstore/artifacts/apps/${{ inputs.app-name }}/workflows"
+        ARTIFACTS_BASE="./local/dapr/objectstore/artifacts/apps/${ATLAN_APPLICATION_NAME}/workflows"
         TRANSFORMED_SRC="${ARTIFACTS_BASE}/${WORKFLOW_ID}/${RUN_ID}/transformed"
 
         if [ ! -d "$TRANSFORMED_SRC" ]; then

--- a/.github/actions/parity-extract/action.yaml
+++ b/.github/actions/parity-extract/action.yaml
@@ -1,0 +1,152 @@
+name: Parity Extract
+description: |
+  Starts a connector app, triggers a metadata extraction workflow,
+  polls until complete, and uploads the transformed output as an artifact.
+  Used by the parity test framework to extract from both baseline and candidate branches.
+
+inputs:
+  ref:
+    description: "Git ref (SHA or branch) to checkout and extract from"
+    required: true
+  artifact-name:
+    description: "Name for the uploaded artifact"
+    required: true
+    default: "parity-output"
+  app-name:
+    description: "Application name (e.g., postgres, tableau)"
+    required: true
+  credentials-json:
+    description: "JSON string with credentials for /workflows/v1/start"
+    required: true
+  metadata-json:
+    description: "JSON string with metadata filters for /workflows/v1/start"
+    required: false
+    default: '{"exclude-filter":"{}","include-filter":"{}","temp-table-regex":"","extraction-method":"direct"}'
+  connection-json:
+    description: "JSON string with connection config for /workflows/v1/start"
+    required: false
+    default: '{"connection_name":"parity-test","connection_qualified_name":"default/parity/0"}'
+  poll-interval:
+    description: "Seconds between status polls"
+    required: false
+    default: "10"
+  poll-timeout:
+    description: "Max seconds to wait for workflow completion"
+    required: false
+    default: "300"
+  app-startup-wait:
+    description: "Seconds to wait for app to start"
+    required: false
+    default: "25"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
+        fetch-depth: 0
+
+    - name: Restore ref after submodule setup
+      shell: bash
+      run: |
+        git checkout ${{ inputs.ref }}
+        echo "Checked out: $(git log --oneline -1)"
+
+    - name: Start app and extract
+      shell: bash
+      env:
+        ATLAN_LOCAL_DEVELOPMENT: "true"
+        ATLAN_APPLICATION_NAME: ${{ inputs.app-name }}
+        ATLAN_MAX_CONCURRENT_ACTIVITIES: "1"
+      run: |
+        set -euo pipefail
+        APP_URL="http://localhost:8000"
+
+        # Start the application
+        echo ">> Starting application..."
+        uv run python main.py &
+        APP_PID=$!
+        sleep ${{ inputs.app-startup-wait }}
+
+        # Health check
+        if ! curl -sf "${APP_URL}/server/health" > /dev/null 2>&1; then
+          echo "ERROR: App failed health check"
+          kill "$APP_PID" 2>/dev/null || true
+          exit 1
+        fi
+        echo ">> App is healthy."
+
+        # Trigger extraction
+        echo ">> Triggering extraction..."
+        RESPONSE=$(curl -sf -X POST \
+          -H "Content-Type: application/json" \
+          -d "{
+            \"credentials\": ${{ inputs.credentials-json }},
+            \"connection\": ${{ inputs.connection-json }},
+            \"metadata\": ${{ inputs.metadata-json }}
+          }" \
+          "${APP_URL}/workflows/v1/start")
+
+        WORKFLOW_ID=$(echo "$RESPONSE" | jq -r '.data.workflow_id')
+        RUN_ID=$(echo "$RESPONSE" | jq -r '.data.run_id')
+
+        if [ -z "$WORKFLOW_ID" ] || [ "$WORKFLOW_ID" = "null" ]; then
+          echo "ERROR: Failed to start workflow. Response: $RESPONSE"
+          kill "$APP_PID" 2>/dev/null || true
+          exit 1
+        fi
+        echo ">> Workflow started: $WORKFLOW_ID / $RUN_ID"
+
+        # Poll for completion
+        ELAPSED=0
+        TIMEOUT=${{ inputs.poll-timeout }}
+        INTERVAL=${{ inputs.poll-interval }}
+        STATUS="RUNNING"
+
+        while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+          STATUS_RESPONSE=$(curl -sf "${APP_URL}/workflows/v1/status/${WORKFLOW_ID}/${RUN_ID}" || echo '{}')
+          STATUS=$(echo "$STATUS_RESPONSE" | jq -r '.data.status // "UNKNOWN"')
+          LAST_RUN_ID=$(echo "$STATUS_RESPONSE" | jq -r '.data.last_executed_run_id // empty')
+          [ -n "$LAST_RUN_ID" ] && RUN_ID="$LAST_RUN_ID"
+
+          if [ "$STATUS" != "RUNNING" ]; then
+            break
+          fi
+          echo "   Still running... (${ELAPSED}s)"
+          sleep "$INTERVAL"
+          ELAPSED=$((ELAPSED + INTERVAL))
+        done
+
+        if [ "$STATUS" != "COMPLETED" ]; then
+          echo "ERROR: Workflow ended with status: $STATUS"
+          kill "$APP_PID" 2>/dev/null || true
+          exit 1
+        fi
+        echo ">> Workflow completed."
+
+        # Copy transformed output
+        ARTIFACTS_BASE="./local/dapr/objectstore/artifacts/apps/${{ inputs.app-name }}/workflows"
+        TRANSFORMED_SRC="${ARTIFACTS_BASE}/${WORKFLOW_ID}/${RUN_ID}/transformed"
+
+        if [ ! -d "$TRANSFORMED_SRC" ]; then
+          echo "ERROR: Output not found at $TRANSFORMED_SRC"
+          find "$ARTIFACTS_BASE" -type d -name "transformed" 2>/dev/null || true
+          kill "$APP_PID" 2>/dev/null || true
+          exit 1
+        fi
+
+        mkdir -p ./parity-output
+        cp -r "$TRANSFORMED_SRC"/* ./parity-output/
+        echo ">> Output:"
+        find ./parity-output -type f | head -20
+
+        # Cleanup
+        kill "$APP_PID" 2>/dev/null || true
+        wait "$APP_PID" 2>/dev/null || true
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ./parity-output/
+        retention-days: 7

--- a/application_sdk/testing/parity/__init__.py
+++ b/application_sdk/testing/parity/__init__.py
@@ -19,11 +19,7 @@ from application_sdk.testing.parity.comparator import (
     discover_categories,
     run_comparison,
 )
-from application_sdk.testing.parity.models import (
-    AssetDiff,
-    CategoryResult,
-    FieldDiff,
-)
+from application_sdk.testing.parity.models import AssetDiff, CategoryResult, FieldDiff
 from application_sdk.testing.parity.report import (
     generate_json_report,
     generate_markdown,

--- a/application_sdk/testing/parity/__init__.py
+++ b/application_sdk/testing/parity/__init__.py
@@ -1,0 +1,41 @@
+"""Parity test framework for regression detection in connector output.
+
+Compares transformed metadata output from two extraction runs (baseline vs candidate)
+and reports ADDED, REMOVED, and MODIFIED assets per category.
+
+Usage as CLI:
+    python -m application_sdk.testing.parity \\
+        --baseline ./baseline/ --candidate ./candidate/
+
+Usage as library:
+    from application_sdk.testing.parity import run_comparison, generate_markdown
+
+    results = run_comparison(baseline_dir, candidate_dir)
+    report = generate_markdown(results)
+"""
+
+from application_sdk.testing.parity.comparator import (
+    compare_category,
+    discover_categories,
+    run_comparison,
+)
+from application_sdk.testing.parity.models import (
+    AssetDiff,
+    CategoryResult,
+    FieldDiff,
+)
+from application_sdk.testing.parity.report import (
+    generate_json_report,
+    generate_markdown,
+)
+
+__all__ = [
+    "run_comparison",
+    "compare_category",
+    "discover_categories",
+    "generate_markdown",
+    "generate_json_report",
+    "AssetDiff",
+    "CategoryResult",
+    "FieldDiff",
+]

--- a/application_sdk/testing/parity/__main__.py
+++ b/application_sdk/testing/parity/__main__.py
@@ -1,0 +1,89 @@
+"""CLI entry point for parity comparison.
+
+Usage:
+    python -m application_sdk.testing.parity \\
+        --baseline ./baseline/ --candidate ./candidate/ \\
+        [--output-json report.json] [--output-md report.md]
+
+Exit codes:
+    0 = parity (no differences)
+    1 = differences found
+    2 = input error
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from application_sdk.testing.parity.comparator import run_comparison
+from application_sdk.testing.parity.report import (
+    generate_json_report,
+    generate_markdown,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Parity Test — Compare extraction outputs"
+    )
+    parser.add_argument(
+        "--baseline", required=True, help="Path to baseline transformed output"
+    )
+    parser.add_argument(
+        "--candidate", required=True, help="Path to candidate transformed output"
+    )
+    parser.add_argument("--output-json", help="Write JSON report to file")
+    parser.add_argument("--output-md", help="Write markdown report to file")
+    parser.add_argument(
+        "--baseline-ref", default="main", help="Git ref for baseline (for report)"
+    )
+    parser.add_argument(
+        "--candidate-ref", default="PR", help="Git ref for candidate (for report)"
+    )
+    args = parser.parse_args()
+
+    baseline_dir = Path(args.baseline)
+    candidate_dir = Path(args.candidate)
+
+    if not baseline_dir.exists():
+        print(f"ERROR: Baseline directory not found: {baseline_dir}", file=sys.stderr)
+        sys.exit(2)
+    if not candidate_dir.exists():
+        print(
+            f"ERROR: Candidate directory not found: {candidate_dir}", file=sys.stderr
+        )
+        sys.exit(2)
+
+    print(f"Comparing: {baseline_dir} (baseline) vs {candidate_dir} (candidate)")
+    results = run_comparison(baseline_dir, candidate_dir)
+
+    md_report = generate_markdown(results, args.baseline_ref, args.candidate_ref)
+    json_report = generate_json_report(results, args.baseline_ref, args.candidate_ref)
+
+    print(md_report)
+
+    if args.output_md:
+        Path(args.output_md).write_text(md_report)
+        print(f"Markdown report written to {args.output_md}", file=sys.stderr)
+
+    if args.output_json:
+        Path(args.output_json).write_text(
+            json.dumps(json_report, indent=2, default=str)
+        )
+        print(f"JSON report written to {args.output_json}", file=sys.stderr)
+
+    is_parity = not any(r.has_diffs for r in results)
+    if is_parity:
+        print("\nPARITY: No differences found.", file=sys.stderr)
+        sys.exit(0)
+    else:
+        total = sum(
+            len(r.added) + len(r.removed) + len(r.modified) for r in results
+        )
+        print(f"\nPARITY BROKEN: {total} differences found.", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/application_sdk/testing/parity/__main__.py
+++ b/application_sdk/testing/parity/__main__.py
@@ -47,41 +47,39 @@ def main() -> None:
     candidate_dir = Path(args.candidate)
 
     if not baseline_dir.exists():
-        print(f"ERROR: Baseline directory not found: {baseline_dir}", file=sys.stderr)
+        print(f"ERROR: Baseline directory not found: {baseline_dir}", file=sys.stderr)  # noqa: T201
         sys.exit(2)
     if not candidate_dir.exists():
-        print(
+        print(  # noqa: T201
             f"ERROR: Candidate directory not found: {candidate_dir}", file=sys.stderr
         )
         sys.exit(2)
 
-    print(f"Comparing: {baseline_dir} (baseline) vs {candidate_dir} (candidate)")
+    print(f"Comparing: {baseline_dir} (baseline) vs {candidate_dir} (candidate)")  # noqa: T201
     results = run_comparison(baseline_dir, candidate_dir)
 
     md_report = generate_markdown(results, args.baseline_ref, args.candidate_ref)
     json_report = generate_json_report(results, args.baseline_ref, args.candidate_ref)
 
-    print(md_report)
+    print(md_report)  # noqa: T201
 
     if args.output_md:
         Path(args.output_md).write_text(md_report)
-        print(f"Markdown report written to {args.output_md}", file=sys.stderr)
+        print(f"Markdown report written to {args.output_md}", file=sys.stderr)  # noqa: T201
 
     if args.output_json:
         Path(args.output_json).write_text(
             json.dumps(json_report, indent=2, default=str)
         )
-        print(f"JSON report written to {args.output_json}", file=sys.stderr)
+        print(f"JSON report written to {args.output_json}", file=sys.stderr)  # noqa: T201
 
     is_parity = not any(r.has_diffs for r in results)
     if is_parity:
-        print("\nPARITY: No differences found.", file=sys.stderr)
+        print("\nPARITY: No differences found.", file=sys.stderr)  # noqa: T201
         sys.exit(0)
     else:
-        total = sum(
-            len(r.added) + len(r.removed) + len(r.modified) for r in results
-        )
-        print(f"\nPARITY BROKEN: {total} differences found.", file=sys.stderr)
+        total = sum(len(r.added) + len(r.removed) + len(r.modified) for r in results)
+        print(f"\nPARITY BROKEN: {total} differences found.", file=sys.stderr)  # noqa: T201
         sys.exit(1)
 
 

--- a/application_sdk/testing/parity/__main__.py
+++ b/application_sdk/testing/parity/__main__.py
@@ -64,12 +64,12 @@ def main() -> None:
     print(md_report)  # noqa: T201
 
     if args.output_md:
-        Path(args.output_md).write_text(md_report)
+        Path(args.output_md).write_text(md_report, encoding="utf-8")
         print(f"Markdown report written to {args.output_md}", file=sys.stderr)  # noqa: T201
 
     if args.output_json:
         Path(args.output_json).write_text(
-            json.dumps(json_report, indent=2, default=str)
+            json.dumps(json_report, indent=2, default=str), encoding="utf-8"
         )
         print(f"JSON report written to {args.output_json}", file=sys.stderr)  # noqa: T201
 

--- a/application_sdk/testing/parity/comparator.py
+++ b/application_sdk/testing/parity/comparator.py
@@ -9,11 +9,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict, List, Set
 
-from application_sdk.testing.parity.models import (
-    AssetDiff,
-    CategoryResult,
-    FieldDiff,
-)
+from application_sdk.testing.parity.models import AssetDiff, CategoryResult, FieldDiff
 
 # Fields that change every run and must be ignored in comparison.
 VOLATILE_FIELDS: Set[str] = {
@@ -31,19 +27,31 @@ def load_ndjson(directory: Path) -> List[Dict[str, Any]]:
     for json_file in sorted(directory.glob("*.json")):
         if "statistics" in json_file.name:
             continue
-        with open(json_file) as f:
-            for line in f:
+        with open(json_file, encoding="utf-8") as f:
+            for line_num, line in enumerate(f, 1):
                 line = line.strip()
-                if line:
+                if not line:
+                    continue
+                try:
                     assets.append(json.loads(line))
+                except json.JSONDecodeError:
+                    import logging
+
+                    logging.getLogger(__name__).warning(
+                        "Skipping malformed JSON at %s:%d", json_file.name, line_num
+                    )
     return assets
 
 
 def strip_volatile(obj: Any) -> Any:
-    """Recursively remove volatile fields from a dict."""
-    if not isinstance(obj, dict):
-        return obj
-    return {k: strip_volatile(v) for k, v in obj.items() if k not in VOLATILE_FIELDS}
+    """Recursively remove volatile fields from dicts and lists."""
+    if isinstance(obj, dict):
+        return {
+            k: strip_volatile(v) for k, v in obj.items() if k not in VOLATILE_FIELDS
+        }
+    if isinstance(obj, list):
+        return [strip_volatile(item) for item in obj]
+    return obj
 
 
 def get_qualified_name(asset: Dict[str, Any]) -> str:

--- a/application_sdk/testing/parity/comparator.py
+++ b/application_sdk/testing/parity/comparator.py
@@ -1,0 +1,170 @@
+"""Core comparison engine for parity testing.
+
+Loads NDJSON output from two extraction runs, strips volatile fields,
+joins on qualifiedName, and classifies each asset as ADDED, REMOVED,
+MODIFIED, or UNCHANGED.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+from application_sdk.testing.parity.models import (
+    AssetDiff,
+    CategoryResult,
+    FieldDiff,
+)
+
+# Fields that change every run and must be ignored in comparison.
+VOLATILE_FIELDS: Set[str] = {
+    "lastSyncWorkflowName",
+    "lastSyncRun",
+    "lastSyncRunAt",
+}
+
+
+def load_ndjson(directory: Path) -> List[Dict[str, Any]]:
+    """Load all NDJSON files from a directory, skipping statistics files."""
+    assets: List[Dict[str, Any]] = []
+    if not directory.exists():
+        return assets
+    for json_file in sorted(directory.glob("*.json")):
+        if "statistics" in json_file.name:
+            continue
+        with open(json_file) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    assets.append(json.loads(line))
+    return assets
+
+
+def strip_volatile(obj: Any) -> Any:
+    """Recursively remove volatile fields from a dict."""
+    if not isinstance(obj, dict):
+        return obj
+    return {k: strip_volatile(v) for k, v in obj.items() if k not in VOLATILE_FIELDS}
+
+
+def get_qualified_name(asset: Dict[str, Any]) -> str:
+    """Extract qualifiedName from an asset."""
+    return asset.get("attributes", {}).get("qualifiedName", "")
+
+
+def diff_dicts(
+    baseline: Dict[str, Any],
+    candidate: Dict[str, Any],
+    prefix: str = "",
+) -> List[FieldDiff]:
+    """Deep diff two dicts, returning a list of field differences."""
+    diffs: List[FieldDiff] = []
+    all_keys = set(baseline.keys()) | set(candidate.keys())
+
+    for key in sorted(all_keys):
+        path = f"{prefix}.{key}" if prefix else key
+        b_val = baseline.get(key)
+        c_val = candidate.get(key)
+
+        if b_val == c_val:
+            continue
+
+        if isinstance(b_val, dict) and isinstance(c_val, dict):
+            diffs.extend(diff_dicts(b_val, c_val, path))
+        else:
+            diffs.append(
+                FieldDiff(
+                    field_path=path,
+                    baseline_value=b_val,
+                    candidate_value=c_val,
+                )
+            )
+
+    return diffs
+
+
+def compare_category(
+    category: str,
+    baseline_dir: Path,
+    candidate_dir: Path,
+) -> CategoryResult:
+    """Compare a single category (e.g., 'table', 'column') between two runs."""
+    baseline_assets = load_ndjson(baseline_dir)
+    candidate_assets = load_ndjson(candidate_dir)
+
+    baseline_map: Dict[str, Dict[str, Any]] = {}
+    for asset in baseline_assets:
+        qn = get_qualified_name(asset)
+        if qn:
+            baseline_map[qn] = strip_volatile(asset)
+
+    candidate_map: Dict[str, Dict[str, Any]] = {}
+    for asset in candidate_assets:
+        qn = get_qualified_name(asset)
+        if qn:
+            candidate_map[qn] = strip_volatile(asset)
+
+    result = CategoryResult(
+        category=category,
+        baseline_count=len(baseline_map),
+        candidate_count=len(candidate_map),
+    )
+
+    # REMOVED: in baseline but not in candidate
+    for qn in sorted(set(baseline_map) - set(candidate_map)):
+        asset = baseline_map[qn]
+        result.removed.append(
+            AssetDiff(
+                qualified_name=qn,
+                type_name=asset.get("typeName", "?"),
+                diff_type="REMOVED",
+            )
+        )
+
+    # ADDED: in candidate but not in baseline
+    for qn in sorted(set(candidate_map) - set(baseline_map)):
+        asset = candidate_map[qn]
+        result.added.append(
+            AssetDiff(
+                qualified_name=qn,
+                type_name=asset.get("typeName", "?"),
+                diff_type="ADDED",
+            )
+        )
+
+    # MODIFIED: in both, check for field diffs
+    for qn in sorted(set(baseline_map) & set(candidate_map)):
+        field_diffs = diff_dicts(baseline_map[qn], candidate_map[qn])
+        if field_diffs:
+            result.modified.append(
+                AssetDiff(
+                    qualified_name=qn,
+                    type_name=baseline_map[qn].get("typeName", "?"),
+                    diff_type="MODIFIED",
+                    field_diffs=field_diffs,
+                )
+            )
+
+    return result
+
+
+def discover_categories(baseline_dir: Path, candidate_dir: Path) -> List[str]:
+    """Find all category subdirectories across both dirs."""
+    categories: Set[str] = set()
+    for d in [baseline_dir, candidate_dir]:
+        if d.exists():
+            for subdir in d.iterdir():
+                if subdir.is_dir() and not subdir.name.startswith("."):
+                    categories.add(subdir.name)
+    return sorted(categories)
+
+
+def run_comparison(
+    baseline_dir: Path,
+    candidate_dir: Path,
+) -> List[CategoryResult]:
+    """Run full parity comparison across all categories."""
+    categories = discover_categories(baseline_dir, candidate_dir)
+    return [
+        compare_category(cat, baseline_dir / cat, candidate_dir / cat)
+        for cat in categories
+    ]

--- a/application_sdk/testing/parity/comparator.py
+++ b/application_sdk/testing/parity/comparator.py
@@ -6,22 +6,25 @@ MODIFIED, or UNCHANGED.
 """
 
 import json
+import logging
 from pathlib import Path
-from typing import Any, Dict, List, Set
+from typing import Any
 
 from application_sdk.testing.parity.models import AssetDiff, CategoryResult, FieldDiff
 
+logger = logging.getLogger(__name__)
+
 # Fields that change every run and must be ignored in comparison.
-VOLATILE_FIELDS: Set[str] = {
+VOLATILE_FIELDS: set[str] = {
     "lastSyncWorkflowName",
     "lastSyncRun",
     "lastSyncRunAt",
 }
 
 
-def load_ndjson(directory: Path) -> List[Dict[str, Any]]:
+def load_ndjson(directory: Path) -> list[dict[str, Any]]:
     """Load all NDJSON files from a directory, skipping statistics files."""
-    assets: List[Dict[str, Any]] = []
+    assets: list[dict[str, Any]] = []
     if not directory.exists():
         return assets
     for json_file in sorted(directory.glob("*.json")):
@@ -35,9 +38,7 @@ def load_ndjson(directory: Path) -> List[Dict[str, Any]]:
                 try:
                     assets.append(json.loads(line))
                 except json.JSONDecodeError:
-                    import logging
-
-                    logging.getLogger(__name__).warning(
+                    logger.warning(
                         "Skipping malformed JSON at %s:%d", json_file.name, line_num
                     )
     return assets
@@ -54,18 +55,18 @@ def strip_volatile(obj: Any) -> Any:
     return obj
 
 
-def get_qualified_name(asset: Dict[str, Any]) -> str:
+def get_qualified_name(asset: dict[str, Any]) -> str:
     """Extract qualifiedName from an asset."""
     return asset.get("attributes", {}).get("qualifiedName", "")
 
 
 def diff_dicts(
-    baseline: Dict[str, Any],
-    candidate: Dict[str, Any],
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
     prefix: str = "",
-) -> List[FieldDiff]:
+) -> list[FieldDiff]:
     """Deep diff two dicts, returning a list of field differences."""
-    diffs: List[FieldDiff] = []
+    diffs: list[FieldDiff] = []
     all_keys = set(baseline.keys()) | set(candidate.keys())
 
     for key in sorted(all_keys):
@@ -99,13 +100,13 @@ def compare_category(
     baseline_assets = load_ndjson(baseline_dir)
     candidate_assets = load_ndjson(candidate_dir)
 
-    baseline_map: Dict[str, Dict[str, Any]] = {}
+    baseline_map: dict[str, dict[str, Any]] = {}
     for asset in baseline_assets:
         qn = get_qualified_name(asset)
         if qn:
             baseline_map[qn] = strip_volatile(asset)
 
-    candidate_map: Dict[str, Dict[str, Any]] = {}
+    candidate_map: dict[str, dict[str, Any]] = {}
     for asset in candidate_assets:
         qn = get_qualified_name(asset)
         if qn:
@@ -155,9 +156,9 @@ def compare_category(
     return result
 
 
-def discover_categories(baseline_dir: Path, candidate_dir: Path) -> List[str]:
+def discover_categories(baseline_dir: Path, candidate_dir: Path) -> list[str]:
     """Find all category subdirectories across both dirs."""
-    categories: Set[str] = set()
+    categories: set[str] = set()
     for d in [baseline_dir, candidate_dir]:
         if d.exists():
             for subdir in d.iterdir():
@@ -169,7 +170,7 @@ def discover_categories(baseline_dir: Path, candidate_dir: Path) -> List[str]:
 def run_comparison(
     baseline_dir: Path,
     candidate_dir: Path,
-) -> List[CategoryResult]:
+) -> list[CategoryResult]:
     """Run full parity comparison across all categories."""
     categories = discover_categories(baseline_dir, candidate_dir)
     return [

--- a/application_sdk/testing/parity/models.py
+++ b/application_sdk/testing/parity/models.py
@@ -1,0 +1,39 @@
+"""Data models for parity comparison results."""
+
+from dataclasses import dataclass, field
+from typing import Any, List
+
+
+@dataclass
+class FieldDiff:
+    """A single field-level difference between baseline and candidate."""
+
+    field_path: str
+    baseline_value: Any
+    candidate_value: Any
+
+
+@dataclass
+class AssetDiff:
+    """A difference for a single asset (identified by qualifiedName)."""
+
+    qualified_name: str
+    type_name: str
+    diff_type: str  # ADDED, REMOVED, MODIFIED
+    field_diffs: List[FieldDiff] = field(default_factory=list)
+
+
+@dataclass
+class CategoryResult:
+    """Comparison result for a single category (e.g., table, column)."""
+
+    category: str
+    baseline_count: int
+    candidate_count: int
+    added: List[AssetDiff] = field(default_factory=list)
+    removed: List[AssetDiff] = field(default_factory=list)
+    modified: List[AssetDiff] = field(default_factory=list)
+
+    @property
+    def has_diffs(self) -> bool:
+        return bool(self.added or self.removed or self.modified)

--- a/application_sdk/testing/parity/models.py
+++ b/application_sdk/testing/parity/models.py
@@ -1,7 +1,7 @@
 """Data models for parity comparison results."""
 
 from dataclasses import dataclass, field
-from typing import Any, List
+from typing import Any, List, Literal
 
 
 @dataclass
@@ -19,7 +19,7 @@ class AssetDiff:
 
     qualified_name: str
     type_name: str
-    diff_type: str  # ADDED, REMOVED, MODIFIED
+    diff_type: Literal["ADDED", "REMOVED", "MODIFIED"]
     field_diffs: List[FieldDiff] = field(default_factory=list)
 
 

--- a/application_sdk/testing/parity/models.py
+++ b/application_sdk/testing/parity/models.py
@@ -1,7 +1,7 @@
 """Data models for parity comparison results."""
 
 from dataclasses import dataclass, field
-from typing import Any, List, Literal
+from typing import Any, Literal
 
 
 @dataclass
@@ -20,7 +20,7 @@ class AssetDiff:
     qualified_name: str
     type_name: str
     diff_type: Literal["ADDED", "REMOVED", "MODIFIED"]
-    field_diffs: List[FieldDiff] = field(default_factory=list)
+    field_diffs: list[FieldDiff] = field(default_factory=list)
 
 
 @dataclass
@@ -30,9 +30,9 @@ class CategoryResult:
     category: str
     baseline_count: int
     candidate_count: int
-    added: List[AssetDiff] = field(default_factory=list)
-    removed: List[AssetDiff] = field(default_factory=list)
-    modified: List[AssetDiff] = field(default_factory=list)
+    added: list[AssetDiff] = field(default_factory=list)
+    removed: list[AssetDiff] = field(default_factory=list)
+    modified: list[AssetDiff] = field(default_factory=list)
 
     @property
     def has_diffs(self) -> bool:

--- a/application_sdk/testing/parity/report.py
+++ b/application_sdk/testing/parity/report.py
@@ -1,6 +1,6 @@
 """Report generation for parity comparison results."""
 
-from typing import Any, Dict, List
+from typing import Any
 
 from application_sdk.testing.parity.models import CategoryResult
 
@@ -14,7 +14,7 @@ def _format_value(val: Any) -> str:
 
 
 def generate_markdown(
-    results: List[CategoryResult],
+    results: list[CategoryResult],
     baseline_ref: str = "main",
     candidate_ref: str = "PR",
 ) -> str:
@@ -24,7 +24,7 @@ def generate_markdown(
     total_removed = sum(len(r.removed) for r in results)
     total_modified = sum(len(r.modified) for r in results)
 
-    lines: List[str] = []
+    lines: list[str] = []
     lines.append("## Parity Test Results\n")
 
     if has_any_diffs:
@@ -104,10 +104,10 @@ def generate_markdown(
 
 
 def generate_json_report(
-    results: List[CategoryResult],
+    results: list[CategoryResult],
     baseline_ref: str = "main",
     candidate_ref: str = "PR",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Generate a JSON report from comparison results."""
     has_any_diffs = any(r.has_diffs for r in results)
     return {

--- a/application_sdk/testing/parity/report.py
+++ b/application_sdk/testing/parity/report.py
@@ -35,9 +35,7 @@ def generate_markdown(
     else:
         lines.append("**Verdict: PARITY** — no differences found\n")
 
-    lines.append(
-        f"**Baseline**: `{baseline_ref}` | **Candidate**: `{candidate_ref}`\n"
-    )
+    lines.append(f"**Baseline**: `{baseline_ref}` | **Candidate**: `{candidate_ref}`\n")
 
     # Summary table
     lines.append("### Summary\n")
@@ -92,9 +90,7 @@ def generate_markdown(
                     c_str = _format_value(fd.candidate_value)
                     lines.append(f"  - `{fd.field_path}`: {b_str} → {c_str}")
                 if len(a.field_diffs) > 10:
-                    lines.append(
-                        f"  - ... and {len(a.field_diffs) - 10} more fields"
-                    )
+                    lines.append(f"  - ... and {len(a.field_diffs) - 10} more fields")
             if len(r.modified) > 30:
                 lines.append(f"- ... and {len(r.modified) - 30} more")
             lines.append("")
@@ -102,9 +98,7 @@ def generate_markdown(
         lines.append("</details>\n")
 
     if has_any_diffs:
-        lines.append(
-            "> Add label `parity-accepted` to acknowledge these changes.\n"
-        )
+        lines.append("> Add label `parity-accepted` to acknowledge these changes.\n")
 
     return "\n".join(lines)
 

--- a/application_sdk/testing/parity/report.py
+++ b/application_sdk/testing/parity/report.py
@@ -1,0 +1,159 @@
+"""Report generation for parity comparison results."""
+
+from typing import Any, Dict, List
+
+from application_sdk.testing.parity.models import CategoryResult
+
+
+def _format_value(val: Any) -> str:
+    """Format a value for display, truncating long strings."""
+    s = repr(val)
+    if len(s) > 80:
+        return s[:77] + "..."
+    return s
+
+
+def generate_markdown(
+    results: List[CategoryResult],
+    baseline_ref: str = "main",
+    candidate_ref: str = "PR",
+) -> str:
+    """Generate a markdown report from comparison results."""
+    has_any_diffs = any(r.has_diffs for r in results)
+    total_added = sum(len(r.added) for r in results)
+    total_removed = sum(len(r.removed) for r in results)
+    total_modified = sum(len(r.modified) for r in results)
+
+    lines: List[str] = []
+    lines.append("## Parity Test Results\n")
+
+    if has_any_diffs:
+        lines.append(
+            f"**Verdict: PARITY BROKEN** — "
+            f"{total_added} added, {total_removed} removed, {total_modified} modified\n"
+        )
+    else:
+        lines.append("**Verdict: PARITY** — no differences found\n")
+
+    lines.append(
+        f"**Baseline**: `{baseline_ref}` | **Candidate**: `{candidate_ref}`\n"
+    )
+
+    # Summary table
+    lines.append("### Summary\n")
+    lines.append("| Category | Baseline | Candidate | Added | Removed | Modified |")
+    lines.append("|----------|----------|-----------|-------|---------|----------|")
+    for r in results:
+        lines.append(
+            f"| {r.category} | {r.baseline_count} | {r.candidate_count} "
+            f"| {len(r.added)} | {len(r.removed)} | {len(r.modified)} |"
+        )
+    lines.append("")
+
+    # Details per category (collapsible)
+    for r in results:
+        if not r.has_diffs:
+            continue
+
+        parts = []
+        if r.added:
+            parts.append(f"{len(r.added)} added")
+        if r.removed:
+            parts.append(f"{len(r.removed)} removed")
+        if r.modified:
+            parts.append(f"{len(r.modified)} modified")
+        summary = ", ".join(parts)
+
+        lines.append("<details>")
+        lines.append(f"<summary><b>{r.category}</b>: {summary}</summary>\n")
+
+        if r.added:
+            lines.append("**Added:**")
+            for a in r.added[:50]:
+                lines.append(f"- `{a.qualified_name}` ({a.type_name})")
+            if len(r.added) > 50:
+                lines.append(f"- ... and {len(r.added) - 50} more")
+            lines.append("")
+
+        if r.removed:
+            lines.append("**Removed:**")
+            for a in r.removed[:50]:
+                lines.append(f"- `{a.qualified_name}` ({a.type_name})")
+            if len(r.removed) > 50:
+                lines.append(f"- ... and {len(r.removed) - 50} more")
+            lines.append("")
+
+        if r.modified:
+            lines.append("**Modified:**")
+            for a in r.modified[:30]:
+                lines.append(f"- `{a.qualified_name}` ({a.type_name}):")
+                for fd in a.field_diffs[:10]:
+                    b_str = _format_value(fd.baseline_value)
+                    c_str = _format_value(fd.candidate_value)
+                    lines.append(f"  - `{fd.field_path}`: {b_str} → {c_str}")
+                if len(a.field_diffs) > 10:
+                    lines.append(
+                        f"  - ... and {len(a.field_diffs) - 10} more fields"
+                    )
+            if len(r.modified) > 30:
+                lines.append(f"- ... and {len(r.modified) - 30} more")
+            lines.append("")
+
+        lines.append("</details>\n")
+
+    if has_any_diffs:
+        lines.append(
+            "> Add label `parity-accepted` to acknowledge these changes.\n"
+        )
+
+    return "\n".join(lines)
+
+
+def generate_json_report(
+    results: List[CategoryResult],
+    baseline_ref: str = "main",
+    candidate_ref: str = "PR",
+) -> Dict[str, Any]:
+    """Generate a JSON report from comparison results."""
+    has_any_diffs = any(r.has_diffs for r in results)
+    return {
+        "is_parity": not has_any_diffs,
+        "baseline_ref": baseline_ref,
+        "candidate_ref": candidate_ref,
+        "summary": {
+            "total_added": sum(len(r.added) for r in results),
+            "total_removed": sum(len(r.removed) for r in results),
+            "total_modified": sum(len(r.modified) for r in results),
+        },
+        "categories": [
+            {
+                "category": r.category,
+                "baseline_count": r.baseline_count,
+                "candidate_count": r.candidate_count,
+                "added": [
+                    {"qualified_name": a.qualified_name, "type_name": a.type_name}
+                    for a in r.added
+                ],
+                "removed": [
+                    {"qualified_name": a.qualified_name, "type_name": a.type_name}
+                    for a in r.removed
+                ],
+                "modified": [
+                    {
+                        "qualified_name": a.qualified_name,
+                        "type_name": a.type_name,
+                        "field_diffs": [
+                            {
+                                "field": fd.field_path,
+                                "baseline": fd.baseline_value,
+                                "candidate": fd.candidate_value,
+                            }
+                            for fd in a.field_diffs
+                        ],
+                    }
+                    for a in r.modified
+                ],
+            }
+            for r in results
+        ],
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,12 +53,6 @@ distlib==0.4.0
     # via virtualenv
 dnspython==2.8.0
     # via email-validator
-duckdb==1.4.3
-    # via
-    #   atlan-application-sdk
-    #   duckdb-engine
-duckdb-engine==0.17.0
-    # via atlan-application-sdk
 email-validator==2.3.0
     # via
     #   fastapi
@@ -81,8 +75,6 @@ googleapis-common-protos==1.72.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-greenlet==3.3.0 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'
-    # via sqlalchemy
 grpcio==1.76.0
     # via opentelemetry-exporter-otlp-proto-grpc
 h11==0.16.0
@@ -142,10 +134,10 @@ multidict==6.7.0
     #   yarl
 nanoid==2.0.0
     # via pyatlan
+nexus-rpc==1.3.0
+    # via temporalio
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.1
-    # via pandas
 obstore==0.9.2
     # via atlan-application-sdk
 opentelemetry-api==1.39.1
@@ -179,13 +171,12 @@ opentelemetry-sdk==1.39.1
     #   opentelemetry-exporter-prometheus
 opentelemetry-semantic-conventions==0.60b1
     # via opentelemetry-sdk
+orjson==3.11.7
+    # via atlan-application-sdk
 packaging==25.0
     # via
-    #   duckdb-engine
     #   lazy-loader
     #   pytest
-pandas==2.3.3
-    # via atlan-application-sdk
 pastel==0.2.1
     # via poethepoet
 platformdirs==4.5.1
@@ -194,7 +185,7 @@ pluggy==1.6.0
     # via pytest
 poethepoet==0.39.0
 pre-commit==4.5.1
-prometheus-client==0.25.0
+prometheus-client==0.23.1
     # via opentelemetry-exporter-prometheus
 propcache==0.4.1
     # via
@@ -204,11 +195,10 @@ protobuf==6.33.5
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
+    #   temporalio
 psutil==7.2.1
     # via atlan-application-sdk
-pyarrow==22.0.0
-    # via atlan-application-sdk
-pyatlan==9.4.0
+pyatlan==9.3.1
     # via atlan-application-sdk
 pycparser==2.23 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'
     # via cffi
@@ -237,9 +227,7 @@ pytest==9.0.2
 pytest-asyncio==1.3.0
 pytest-timeout==2.4.0
 python-dateutil==2.9.0.post0
-    # via
-    #   pandas
-    #   pyatlan
+    # via pyatlan
 python-dotenv==1.2.1
     # via
     #   atlan-application-sdk
@@ -248,9 +236,7 @@ python-dotenv==1.2.1
 python-multipart==0.0.22
     # via fastapi
 pytz==2026.1.post1
-    # via
-    #   pandas
-    #   pyatlan
+    # via pyatlan
 pyyaml==6.0.3
     # via
     #   atlan-application-sdk
@@ -279,10 +265,10 @@ six==1.17.0
     # via python-dateutil
 sortedcontainers==2.4.0
     # via hypothesis
-sqlalchemy==2.0.45
-    # via duckdb-engine
 starlette==0.50.0
     # via fastapi
+temporalio==1.21.1
+    # via atlan-application-sdk
 tenacity==9.1.2
     # via pyatlan
 typer==0.21.1
@@ -291,6 +277,8 @@ typer==0.21.1
     #   fastapi-cloud-cli
 types-awscrt==0.31.0
     # via botocore-stubs
+types-protobuf==6.32.1.20251210
+    # via temporalio
 types-s3transfer==0.16.0
     # via boto3-stubs
 typing-extensions==4.15.0
@@ -300,6 +288,7 @@ typing-extensions==4.15.0
     #   boto3-stubs
     #   fastapi
     #   grpcio
+    #   nexus-rpc
     #   obstore
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -311,16 +300,14 @@ typing-extensions==4.15.0
     #   pydantic-extra-types
     #   pytest-asyncio
     #   rich-toolkit
-    #   sqlalchemy
     #   starlette
+    #   temporalio
     #   typer
     #   typing-inspection
 typing-inspection==0.4.2
     # via
     #   pydantic
     #   pydantic-settings
-tzdata==2025.3
-    # via pandas
 urllib3==2.6.3
     # via
     #   requests

--- a/tests/unit/testing/test_parity.py
+++ b/tests/unit/testing/test_parity.py
@@ -1,0 +1,287 @@
+"""Unit tests for the parity test framework."""
+
+import json
+from pathlib import Path
+
+from application_sdk.testing.parity.comparator import (
+    compare_category,
+    diff_dicts,
+    discover_categories,
+    load_ndjson,
+    run_comparison,
+    strip_volatile,
+)
+from application_sdk.testing.parity.models import AssetDiff, CategoryResult, FieldDiff
+from application_sdk.testing.parity.report import (
+    generate_json_report,
+    generate_markdown,
+)
+
+# ---------------------------------------------------------------------------
+# strip_volatile
+# ---------------------------------------------------------------------------
+
+
+class TestStripVolatile:
+    def test_removes_volatile_fields(self):
+        obj = {"name": "t1", "lastSyncRun": "run-1", "status": "ACTIVE"}
+        result = strip_volatile(obj)
+        assert result == {"name": "t1", "status": "ACTIVE"}
+
+    def test_nested_dict(self):
+        obj = {"a": {"lastSyncRunAt": "2026-01-01", "b": 1}}
+        result = strip_volatile(obj)
+        assert result == {"a": {"b": 1}}
+
+    def test_list_of_dicts(self):
+        obj = [{"lastSyncRun": "x", "keep": True}, {"keep": False}]
+        result = strip_volatile(obj)
+        assert result == [{"keep": True}, {"keep": False}]
+
+    def test_passthrough_scalar(self):
+        assert strip_volatile(42) == 42
+        assert strip_volatile("hello") == "hello"
+        assert strip_volatile(None) is None
+
+
+# ---------------------------------------------------------------------------
+# load_ndjson
+# ---------------------------------------------------------------------------
+
+
+class TestLoadNdjson:
+    def test_loads_valid_ndjson(self, tmp_path):
+        f = tmp_path / "chunk-0.json"
+        f.write_text(
+            '{"typeName":"Table","attributes":{"qualifiedName":"t1"}}\n'
+            '{"typeName":"Table","attributes":{"qualifiedName":"t2"}}\n',
+            encoding="utf-8",
+        )
+        assets = load_ndjson(tmp_path)
+        assert len(assets) == 2
+        assert assets[0]["attributes"]["qualifiedName"] == "t1"
+
+    def test_skips_statistics_files(self, tmp_path):
+        (tmp_path / "statistics.json").write_text('{"count":5}\n', encoding="utf-8")
+        (tmp_path / "chunk-0.json").write_text(
+            '{"typeName":"Table","attributes":{"qualifiedName":"t1"}}\n',
+            encoding="utf-8",
+        )
+        assets = load_ndjson(tmp_path)
+        assert len(assets) == 1
+
+    def test_empty_dir(self, tmp_path):
+        assert load_ndjson(tmp_path) == []
+
+    def test_nonexistent_dir(self, tmp_path):
+        assert load_ndjson(tmp_path / "nope") == []
+
+    def test_skips_malformed_lines(self, tmp_path):
+        f = tmp_path / "chunk-0.json"
+        f.write_text(
+            '{"valid": true}\nnot json at all\n{"also_valid": true}\n',
+            encoding="utf-8",
+        )
+        assets = load_ndjson(tmp_path)
+        assert len(assets) == 2
+
+
+# ---------------------------------------------------------------------------
+# diff_dicts
+# ---------------------------------------------------------------------------
+
+
+class TestDiffDicts:
+    def test_identical(self):
+        assert diff_dicts({"a": 1}, {"a": 1}) == []
+
+    def test_value_changed(self):
+        diffs = diff_dicts({"a": 1}, {"a": 2})
+        assert len(diffs) == 1
+        assert diffs[0].field_path == "a"
+        assert diffs[0].baseline_value == 1
+        assert diffs[0].candidate_value == 2
+
+    def test_nested_diff(self):
+        diffs = diff_dicts({"a": {"b": 1}}, {"a": {"b": 2}})
+        assert len(diffs) == 1
+        assert diffs[0].field_path == "a.b"
+
+    def test_added_key(self):
+        diffs = diff_dicts({}, {"new": "val"})
+        assert len(diffs) == 1
+        assert diffs[0].field_path == "new"
+        assert diffs[0].baseline_value is None
+
+    def test_removed_key(self):
+        diffs = diff_dicts({"old": "val"}, {})
+        assert len(diffs) == 1
+        assert diffs[0].baseline_value == "val"
+        assert diffs[0].candidate_value is None
+
+
+# ---------------------------------------------------------------------------
+# compare_category
+# ---------------------------------------------------------------------------
+
+
+class TestCompareCategory:
+    def _write_asset(self, directory: Path, qn: str, extra: dict | None = None):
+        directory.mkdir(parents=True, exist_ok=True)
+        asset = {"typeName": "Table", "attributes": {"qualifiedName": qn}}
+        if extra:
+            asset["attributes"].update(extra)
+        f = directory / "chunk-0.json"
+        mode = "a" if f.exists() else "w"
+        with open(f, mode, encoding="utf-8") as fh:
+            fh.write(json.dumps(asset) + "\n")
+
+    def test_parity(self, tmp_path):
+        baseline = tmp_path / "baseline"
+        candidate = tmp_path / "candidate"
+        self._write_asset(baseline, "db/s/t1")
+        self._write_asset(candidate, "db/s/t1")
+
+        result = compare_category("table", baseline, candidate)
+        assert not result.has_diffs
+        assert result.baseline_count == 1
+        assert result.candidate_count == 1
+
+    def test_added(self, tmp_path):
+        baseline = tmp_path / "baseline"
+        candidate = tmp_path / "candidate"
+        baseline.mkdir()
+        self._write_asset(candidate, "db/s/new")
+
+        result = compare_category("table", baseline, candidate)
+        assert len(result.added) == 1
+        assert result.added[0].diff_type == "ADDED"
+
+    def test_removed(self, tmp_path):
+        baseline = tmp_path / "baseline"
+        candidate = tmp_path / "candidate"
+        self._write_asset(baseline, "db/s/old")
+        candidate.mkdir()
+
+        result = compare_category("table", baseline, candidate)
+        assert len(result.removed) == 1
+        assert result.removed[0].diff_type == "REMOVED"
+
+    def test_modified(self, tmp_path):
+        baseline = tmp_path / "baseline"
+        candidate = tmp_path / "candidate"
+        self._write_asset(baseline, "db/s/t1", {"name": "old"})
+        self._write_asset(candidate, "db/s/t1", {"name": "new"})
+
+        result = compare_category("table", baseline, candidate)
+        assert len(result.modified) == 1
+        assert result.modified[0].field_diffs[0].field_path == "attributes.name"
+
+
+# ---------------------------------------------------------------------------
+# run_comparison + discover_categories
+# ---------------------------------------------------------------------------
+
+
+class TestRunComparison:
+    def test_discovers_categories(self, tmp_path):
+        baseline = tmp_path / "baseline"
+        candidate = tmp_path / "candidate"
+        (baseline / "table").mkdir(parents=True)
+        (baseline / "column").mkdir(parents=True)
+        (candidate / "table").mkdir(parents=True)
+        (candidate / "schema").mkdir(parents=True)
+
+        cats = discover_categories(baseline, candidate)
+        assert cats == ["column", "schema", "table"]
+
+    def test_end_to_end(self, tmp_path):
+        baseline = tmp_path / "baseline" / "table"
+        candidate = tmp_path / "candidate" / "table"
+        baseline.mkdir(parents=True)
+        candidate.mkdir(parents=True)
+
+        (baseline / "chunk-0.json").write_text(
+            '{"typeName":"Table","attributes":{"qualifiedName":"t1"}}\n',
+            encoding="utf-8",
+        )
+        (candidate / "chunk-0.json").write_text(
+            '{"typeName":"Table","attributes":{"qualifiedName":"t1"}}\n',
+            encoding="utf-8",
+        )
+
+        results = run_comparison(tmp_path / "baseline", tmp_path / "candidate")
+        assert len(results) == 1
+        assert results[0].category == "table"
+        assert not results[0].has_diffs
+
+
+# ---------------------------------------------------------------------------
+# models
+# ---------------------------------------------------------------------------
+
+
+class TestModels:
+    def test_has_diffs_true(self):
+        r = CategoryResult(category="table", baseline_count=1, candidate_count=2)
+        r.added.append(
+            AssetDiff(qualified_name="t1", type_name="Table", diff_type="ADDED")
+        )
+        assert r.has_diffs is True
+
+    def test_has_diffs_false(self):
+        r = CategoryResult(category="table", baseline_count=1, candidate_count=1)
+        assert r.has_diffs is False
+
+
+# ---------------------------------------------------------------------------
+# report
+# ---------------------------------------------------------------------------
+
+
+class TestReport:
+    def _make_results(self) -> list[CategoryResult]:
+        r = CategoryResult(category="table", baseline_count=2, candidate_count=3)
+        r.added.append(
+            AssetDiff(qualified_name="db/s/new", type_name="Table", diff_type="ADDED")
+        )
+        r.modified.append(
+            AssetDiff(
+                qualified_name="db/s/t1",
+                type_name="Table",
+                diff_type="MODIFIED",
+                field_diffs=[
+                    FieldDiff(
+                        field_path="attributes.name",
+                        baseline_value="old",
+                        candidate_value="new",
+                    )
+                ],
+            )
+        )
+        return [r]
+
+    def test_generate_markdown_with_diffs(self):
+        md = generate_markdown(self._make_results())
+        assert "added" in md.lower()
+        assert "modified" in md.lower()
+        assert "db/s/new" in md
+        assert "PARITY BROKEN" in md
+
+    def test_generate_markdown_parity(self):
+        results = [
+            CategoryResult(category="table", baseline_count=1, candidate_count=1)
+        ]
+        md = generate_markdown(results)
+        assert (
+            "Parity" in md
+            or "parity" in md
+            or "No differences" in md.lower()
+            or "✅" in md
+        )
+
+    def test_generate_json_report(self):
+        report = generate_json_report(self._make_results())
+        assert isinstance(report, dict)
+        assert "categories" in report
+        assert report["categories"][0]["category"] == "table"


### PR DESCRIPTION
## Summary
- Forward-ports the parity test framework to v3 at `application_sdk/testing/parity/`
- Same comparison engine as v2 (#1246), adapted for v3 module paths
- Includes reusable GHA extraction action at `.github/actions/parity-extract/`

## v3 path
`application_sdk.testing.parity` (peer of `testing.e2e`, following v3 conventions)

## Modules

| Module | Purpose |
|--------|---------|
| `testing/parity/comparator.py` | Load NDJSON, strip volatile fields, outer-join on qualifiedName, classify diffs |
| `testing/parity/models.py` | `AssetDiff`, `CategoryResult`, `FieldDiff` dataclasses |
| `testing/parity/report.py` | Markdown + JSON report generation |
| `testing/parity/__main__.py` | CLI: `python -m application_sdk.testing.parity` |
| `actions/parity-extract/action.yaml` | Composite GHA action for extraction |

## Usage
```python
from application_sdk.testing.parity import run_comparison, generate_markdown

results = run_comparison(baseline_dir, candidate_dir)
report = generate_markdown(results)
```

## Test plan
- [x] Proven on Postgres connector (v2): 100 tables, 10K columns, ~3 min
- [x] Pass case: identical output → exit 0
- [x] Fail case: databaseName change → 100 modified tables, merge blocked
- [ ] v3 connector integration (once a v3 app is available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)