### PR TITLE
fix: security scan must pass before marketplace publish

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -354,7 +354,7 @@ jobs:
           echo "| Dockerfile | \`${{ needs.prepare.outputs.dockerfile }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| SDR push | \`${{ needs.prepare.outputs.enable_sdr }}\` |" >> $GITHUB_STEP_SUMMARY
 
-  # ── Job 4: Security scan — Trivy + Snyk + allowlist gate (non-blocking on merge path) ──
+  # ── Job 4: Security scan — Trivy + Snyk + allowlist gate ──────────────────────
   security-scan:
     name: Security Scan
     needs: [prepare, merge]
@@ -363,7 +363,7 @@ jobs:
       image: ${{ needs.prepare.outputs.ghcr_image }}
       snyk_org: partner-images
       snyk_monitor: ${{ inputs.snyk_monitor }}
-      fail_on_findings: false
+      fail_on_findings: true
     secrets: inherit
 
   # ── Job 5: Dispatch deployment to atlan-apps-deployment (main only) ───────────
@@ -391,7 +391,7 @@ jobs:
   # ── Job 7: Publish to Global Marketplace ────────────────────────────────────
   publish:
     name: Publish to Marketplace
-    needs: [prepare, merge]
+    needs: [prepare, merge, security-scan]
     if: inputs.publish
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
## Changes
- `fail_on_findings: true` — security gate fails hard on non-allowlisted CRITICAL/HIGH vulns
- `publish` job now `needs: [prepare, merge, security-scan]` — skipped if scan fails

## Behavior after this change

| Scenario | Security scan | Publish | Overall run | CLI behavior |
|---|---|---|---|---|
| Scan passes | success | runs | success | CLI proceeds to marketplace |
| Scan finds new vulns | failure | **skipped** | **failure** | CLI stops with workflow failed error |
| Scan passes, publish=false (CLI) | success | skipped (no inputs) | success | CLI does own marketplace registration |
| Scan fails, publish=false (CLI) | failure | skipped | **failure** | CLI stops — no marketplace registration |

## Why
Ensures no vulnerable image gets published to Global Marketplace — whether triggered by push to main, manual dispatch, or local CLI.