### PR TITLE
feat: post scan results as PR comment

### DIFF
--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -49,6 +49,7 @@ on:
 permissions:
   contents: read
   packages: read
+  pull-requests: write
 
 jobs:
   # ── Build Docker image (single-arch, no push) ──────────────────────────────
@@ -391,15 +392,22 @@ jobs:
 
           blockers = new_vulns + expired
           if blockers:
-              summary = f"### Security Gate {'Failed' if fail_on_findings else 'Warning'}\n\n"
-              summary += f"Found **{len(blockers)}** CRITICAL/HIGH vulnerabilities not in allowlist:\n\n"
-              summary += "| Severity | Scanner | ID | Package | Fix |\n"
-              summary += "|----------|---------|-----|---------|-----|\n"
+              status = "Failed" if fail_on_findings else "Warning"
+              summary = f"### 🛡️ Security Gate {status}\n\n"
+              summary += f"Scanners: Trivy ({trivy_count} findings) + Snyk ({snyk_count} findings) | "
+              summary += f"Total: {len(unique)} | Allowlisted: {len(allowed)} | **New: {len(new_vulns)}**"
+              if expired:
+                  summary += f" | Expired: {len(expired)}"
+              summary += "\n\n"
+              summary += "| Severity | Scanner | ID | Package | Fix Available |\n"
+              summary += "|----------|---------|-----|---------|---------------|\n"
               for v in blockers:
                   fix = v["fixed"] if v["fixed"] else "No fix"
-                  summary += f"| {v['severity']} | {v['source']} | {v['id']} | {v['package']}@{v['installed']} | {fix} |\n"
-              summary += f"\n**To resolve:** fix the vulnerability or add to `.security/allowlist.json` with owner approval.\n"
+                  summary += f"| {v['severity']} | {v['source']} | `{v['id']}` | `{v['package']}@{v['installed']}` | {fix} |\n"
+              summary += f"\n**To resolve:** fix the vulnerability or add it to `.security/allowlist.json` with owner approval.\n"
               with open(os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null"), "a") as f:
+                  f.write(summary)
+              with open("/tmp/scan_comment.md", "w") as f:
                   f.write(summary)
               if fail_on_findings:
                   print(f"GATE FAILED: {len(blockers)} non-allowlisted vulnerabilities")
@@ -407,5 +415,45 @@ jobs:
               else:
                   print(f"GATE WARNING: {len(blockers)} non-allowlisted vulnerabilities (non-blocking)")
           else:
+              summary = f"### 🛡️ Security Gate Passed\n\n"
+              summary += f"Scanners: Trivy ({trivy_count} findings) + Snyk ({snyk_count} findings) | "
+              summary += f"Total: {len(unique)} CRITICAL/HIGH | All allowlisted ✅\n"
+              with open("/tmp/scan_comment.md", "w") as f:
+                  f.write(summary)
               print(f"GATE PASSED: All {len(unique)} vulnerabilities are allowlisted")
           PYEOF
+
+      - name: Comment on PR
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let body;
+            try {
+              body = fs.readFileSync('/tmp/scan_comment.md', 'utf8');
+            } catch {
+              body = '### 🛡️ Security Gate\n\nScan results unavailable.';
+            }
+            const marker = '### 🛡️ Security Gate';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+            }


### PR DESCRIPTION
Adds a PR comment with scan results table — updates on each push instead of creating duplicate comments.