### PR TITLE
fix: add missing pull-requests permission to build-and-publish-app

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -70,6 +70,7 @@ permissions:
   contents: read
   packages: write
   actions: write
+  pull-requests: write
 
 jobs:
   # ── Job 1: Read atlan.yaml, validate secrets, compute all image tags ──────────

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -49,7 +49,6 @@ on:
 permissions:
   contents: read
   packages: read
-  pull-requests: write
 
 jobs:
   # ── Build Docker image (single-arch, no push) ──────────────────────────────
@@ -236,6 +235,9 @@ jobs:
     if: always() && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout (for allowlist)
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -49,6 +49,7 @@ on:
 permissions:
   contents: read
   packages: read
+  pull-requests: write
 
 jobs:
   # ── Build Docker image (single-arch, no push) ──────────────────────────────
@@ -235,9 +236,6 @@ jobs:
     if: always() && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
       - name: Checkout (for allowlist)
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds `pull-requests: write` to the `permissions` block in `build-and-publish-app.yaml`
- When a workflow declares an explicit `permissions` block, any unlisted permission defaults to `none`. The block was missing `pull-requests`, so `build-and-scan.yaml` (which needs it for PR comments added in #1263) was denied access.

## Test plan
- [ ] Trigger `build-and-publish` from an app repo (push to main or workflow_dispatch) — should no longer fail with permission error
- [ ] Open a PR in an app repo that uses `build-and-scan.yaml` directly — PR comment should still be posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)