### PR TITLE
[SDK Evolution] fix: wrap blocking Dapr gRPC calls in asyncio.to_thread()

### DIFF
--- a/application_sdk/infrastructure/_dapr/client.py
+++ b/application_sdk/infrastructure/_dapr/client.py
@@ -1,5 +1,6 @@
 """Dapr client implementations."""
 
+import asyncio
 import json
 from typing import Any
 
@@ -56,7 +57,8 @@ class DaprStateStore:
     async def save(self, key: str, value: dict[str, Any]) -> None:
         """Save state via Dapr."""
         try:
-            self._client.save_state(
+            await asyncio.to_thread(
+                self._client.save_state,
                 store_name=self._store_name,
                 key=key,
                 value=json.dumps(value),
@@ -72,7 +74,8 @@ class DaprStateStore:
     async def load(self, key: str) -> dict[str, Any] | None:
         """Load state via Dapr."""
         try:
-            result = self._client.get_state(
+            result = await asyncio.to_thread(
+                self._client.get_state,
                 store_name=self._store_name,
                 key=key,
             )
@@ -90,7 +93,8 @@ class DaprStateStore:
     async def delete(self, key: str) -> bool:
         """Delete state via Dapr."""
         try:
-            self._client.delete_state(
+            await asyncio.to_thread(
+                self._client.delete_state,
                 store_name=self._store_name,
                 key=key,
             )
@@ -136,7 +140,8 @@ class DaprSecretStore:
     async def get(self, name: str) -> str:
         """Get a secret via Dapr."""
         try:
-            result = self._client.get_secret(
+            result = await asyncio.to_thread(
+                self._client.get_secret,
                 store_name=self._store_name,
                 key=name,
             )
@@ -162,7 +167,9 @@ class DaprSecretStore:
     async def get_bulk(self, names: list[str]) -> dict[str, str]:
         """Get multiple secrets via Dapr."""
         try:
-            result = self._client.get_bulk_secret(store_name=self._store_name)
+            result = await asyncio.to_thread(
+                self._client.get_bulk_secret, store_name=self._store_name
+            )
             return {
                 name: result.secrets.get(name, {}).get(name, "")
                 for name in names
@@ -177,7 +184,9 @@ class DaprSecretStore:
     async def list_names(self) -> list[str]:
         """List secret names via Dapr."""
         try:
-            result = self._client.get_bulk_secret(store_name=self._store_name)
+            result = await asyncio.to_thread(
+                self._client.get_bulk_secret, store_name=self._store_name
+            )
             return list(result.secrets.keys())
         except Exception as e:
             raise SecretStoreError(
@@ -212,7 +221,8 @@ class DaprPubSub:
     ) -> None:
         """Publish a message via Dapr."""
         try:
-            self._client.publish_event(
+            await asyncio.to_thread(
+                self._client.publish_event,
                 pubsub_name=self._pubsub_name,
                 topic_name=topic,
                 data=json.dumps(data),
@@ -299,7 +309,8 @@ class DaprBinding:
     ) -> BindingResponse:
         """Invoke the binding via Dapr."""
         try:
-            result = self._client.invoke_binding(
+            result = await asyncio.to_thread(
+                self._client.invoke_binding,
                 binding_name=self._binding_name,
                 operation=operation,
                 data=data or b"",


### PR DESCRIPTION
## Autonomous SDK Evolution — 2026-04-09

### Pipeline provenance
- **Discovery:** 10 parallel agents scanned refactor-v3 → 117 raw findings
- **Gate 1 (Devil's Advocate):** 58 challenged → 34 killed as false positives → 24 survived
- **Gate 2 (Consolidation):** 23 unique findings → 8 Linear tickets → 7 PRs
- **Parent ticket:** [BLDX-946](https://linear.app/atlan-epd/issue/BLDX-946)

### Finding
**Rule:** BUG-017 | **Severity:** High (dual-confirmed)

All async methods in `DaprStateStore`, `DaprSecretStore`, `DaprPubSub`, and `DaprBinding` call **synchronous blocking gRPC** under the hood (Dapr SDK's `DaprClient` is sync). When called from async `@task` methods, these block the event loop and stall heartbeats, potentially causing Temporal to timeout the task.

### Fix
Wrapped all 8 blocking Dapr calls in `asyncio.to_thread()` so they run in a thread pool and don't block the event loop.

### What to review
- [ ] Verify all 8 call sites are correctly wrapped (get_state, save_state, get_secret, publish_event, invoke_binding for each Dapr service)
- [ ] Check thread safety of `DaprClient` — is it safe to call from multiple threads if the event loop dispatches concurrent `to_thread()` calls?
- [ ] Confirm this doesn't break the Dapr health check flow (which may expect synchronous behavior during startup)
- [ ] Consider whether a shared `DaprClient` instance needs a lock when accessed from threads

### Linear
[BLDX-948](https://linear.app/atlan-epd/issue/BLDX-948)

---
🤖 Generated by [Autonomous SDK Evolution](https://github.com/atlanhq/application-sdk/blob/refactor-v3/.claude/skills/sdk-evolution/SKILL.md) · Gate 1 survived · CI passing