### PR TITLE
[SDK Evolution] docs: fix broken error raising example

### DIFF
--- a/docs/concepts/common.md
+++ b/docs/concepts/common.md
@@ -71,8 +71,8 @@ from application_sdk.common.error_codes import ClientError
 
 try:
     validate_input(data)
-except ValidationError:
-    raise ClientError.INPUT_VALIDATION_ERROR
+except ValidationError as e:
+    raise ClientError(f"{ClientError.REQUEST_VALIDATION_ERROR}: {e}") from e
 ```
 
 ## SQL Utilities


### PR DESCRIPTION
## Autonomous SDK Evolution — 2026-04-09

docs/concepts/common.md had `raise ClientError.INPUT_VALIDATION_ERROR` which would TypeError (ErrorCode is not an Exception). Fixed to use correct pattern: `raise ClientError(f"{ClientError.REQUEST_VALIDATION_ERROR}: {e}") from e`

### Linear
BLDX-950