### PR TITLE
fix: lowercase app_name in build-and-publish dispatch payload

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -116,7 +116,7 @@ jobs:
               print(f'::error::atlan.yaml is invalid YAML: {e}', file=sys.stderr)
               sys.exit(1)
 
-          app_name   = d.get('name', '')
+          app_name   = d.get('name', '').lower()
           app_id     = d.get('app_id', '')
           build_tag  = d.get('build_tag', 'v1')
           dockerfile = d.get('dockerfile', './Dockerfile')


### PR DESCRIPTION
## Summary
- Lowercases `app_name` when reading from `atlan.yaml` in the `build-and-publish-app.yaml` workflow
- Fixes S3 upload path in `atlan-apps-deployment` using uppercase app names (e.g. `Kafka-app.yaml` instead of `kafka-app.yaml`)
- Same fix as PR #1185 but applied to the current unified workflow (that PR only fixed the old `build-apps-image.yaml`)

## Test plan
- [ ] Trigger a build for an app with uppercase name in atlan.yaml (e.g. kafka-app)
- [ ] Verify the dispatch payload sends lowercase app_name
- [ ] Verify S3 upload at `s3://atlan-public/apps/` uses lowercase filename

🤖 Generated with [Claude Code](https://claude.com/claude-code)