### PR TITLE
fix: Python 3.14 compat — replace asyncio.get_event_loop() with get_running_loop()

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-22.04, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6.0.2

--- a/application_sdk/clients/azure/client.py
+++ b/application_sdk/clients/azure/client.py
@@ -313,9 +313,8 @@ class AzureClient(ClientInterface):
         )
         # Schedule cleanup but don't wait for it
         try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                loop.create_task(self.close())
+            loop = asyncio.get_running_loop()
+            loop.create_task(self.close())
         except RuntimeError:
             # No event loop running, can't schedule async cleanup
             logger.warning("No event loop running, async cleanup not possible")

--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -506,7 +506,7 @@ class BaseSQLClient(ClientInterface):
         else:
             # Run the blocking operation in a thread pool
             with concurrent.futures.ThreadPoolExecutor() as executor:
-                return await asyncio.get_event_loop().run_in_executor(
+                return await asyncio.get_running_loop().run_in_executor(
                     executor, self._execute_query, query, chunksize
                 )
 

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -381,12 +381,12 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
             # Start flush task only if Dapr sink is enabled
             if not AtlanLoggerAdapter._flush_task_started:
                 try:
-                    loop = asyncio.get_event_loop()
-                    if loop.is_running():
+                    try:
+                        loop = asyncio.get_running_loop()
                         AtlanLoggerAdapter._flush_task = loop.create_task(
                             self._periodic_flush()
                         )
-                    else:
+                    except RuntimeError:
                         threading.Thread(
                             target=self._start_asyncio_flush, daemon=True
                         ).start()

--- a/application_sdk/observability/metrics_adaptor.py
+++ b/application_sdk/observability/metrics_adaptor.py
@@ -100,10 +100,10 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
         # Start periodic flush task if not already started
         if not AtlanMetricsAdapter._flush_task_started:
             try:
-                loop = asyncio.get_event_loop()
-                if loop.is_running():
+                try:
+                    loop = asyncio.get_running_loop()
                     loop.create_task(self._periodic_flush())
-                else:
+                except RuntimeError:
                     threading.Thread(
                         target=self._start_asyncio_flush, daemon=True
                     ).start()

--- a/application_sdk/observability/segment_client.py
+++ b/application_sdk/observability/segment_client.py
@@ -241,12 +241,12 @@ class SegmentClient:
             return
 
         batch: list["MetricRecord"] = []
-        last_send_time = asyncio.get_event_loop().time()
+        last_send_time = asyncio.get_running_loop().time()
 
         while True:
             try:
                 # Calculate remaining time until batch timeout
-                current_time = asyncio.get_event_loop().time()
+                current_time = asyncio.get_running_loop().time()
                 time_since_last_send = current_time - last_send_time
                 timeout = max(0.1, self._batch_timeout_seconds - time_since_last_send)
 
@@ -261,7 +261,7 @@ class SegmentClient:
                     # Timeout - send batch if we have any events
                     pass
 
-                current_time = asyncio.get_event_loop().time()
+                current_time = asyncio.get_running_loop().time()
 
                 # Send batch if we've reached batch size or timeout
                 should_send = len(batch) >= self._batch_size or (
@@ -272,7 +272,7 @@ class SegmentClient:
                 if should_send and batch:
                     await self._send_batch_to_segment(batch)
                     batch = []
-                    last_send_time = asyncio.get_event_loop().time()
+                    last_send_time = asyncio.get_running_loop().time()
 
             except asyncio.CancelledError:
                 # Worker task cancelled - send remaining batch before exit

--- a/application_sdk/observability/traces_adaptor.py
+++ b/application_sdk/observability/traces_adaptor.py
@@ -79,10 +79,10 @@ class AtlanTracesAdapter(AtlanObservability[TraceRecord]):
         # Start periodic flush task if not already started
         if not AtlanTracesAdapter._flush_task_started:
             try:
-                loop = asyncio.get_event_loop()
-                if loop.is_running():
+                try:
+                    loop = asyncio.get_running_loop()
                     loop.create_task(self._periodic_flush())
-                else:
+                except RuntimeError:
                     threading.Thread(
                         target=self._start_asyncio_flush, daemon=True
                     ).start()

--- a/application_sdk/testing/e2e/logs.py
+++ b/application_sdk/testing/e2e/logs.py
@@ -57,7 +57,7 @@ class LogCollector:
         pods = await get_pods(self.namespace, label_selector)
 
         tasks: list[asyncio.Task[None]] = []
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         for pod in pods:
             pod_name: str = pod.get("metadata", {}).get("name", "unknown")

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -1004,3 +1004,76 @@ class TestTemporalAttributePassthrough:
         tenant_keys = [k for k in otel_record.attributes if k.startswith("tenant.")]
         assert len(temporal_keys) == 0
         assert len(tenant_keys) == 0
+
+
+class TestPython314EventLoopCompat:
+    """Tests for Python 3.14 compatibility where asyncio.get_event_loop()
+    raises RuntimeError when no current event loop exists.
+
+    These tests simulate the Python 3.14 behavior by patching
+    asyncio.get_event_loop to raise RuntimeError, verifying that the
+    logger adapter falls back to a threading-based flush instead.
+    """
+
+    def test_flush_task_starts_via_thread_when_no_event_loop(self):
+        """When no running event loop exists (Python 3.14 behavior),
+        the adapter should fall back to starting the flush in a daemon thread."""
+        AtlanLoggerAdapter._reset_for_testing()
+        with mock.patch.dict(
+            "os.environ",
+            {
+                "LOG_LEVEL": "INFO",
+                "ENABLE_OTLP_LOGS": "false",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+            },
+        ):
+            with mock.patch(
+                "application_sdk.observability.logger_adaptor.ENABLE_OBSERVABILITY_STORE_SINK",
+                True,
+            ):
+                with mock.patch(
+                    "application_sdk.observability.logger_adaptor.asyncio.get_running_loop",
+                    side_effect=RuntimeError("no running event loop"),
+                ):
+                    with mock.patch(
+                        "application_sdk.observability.logger_adaptor.threading.Thread"
+                    ) as mock_thread:
+                        mock_thread_instance = mock.MagicMock()
+                        mock_thread.return_value = mock_thread_instance
+
+                        _ = AtlanLoggerAdapter("test_py314")
+
+                        mock_thread.assert_called_once()
+                        _, kwargs = mock_thread.call_args
+                        assert kwargs.get("daemon") is True
+                        mock_thread_instance.start.assert_called_once()
+
+    def test_flush_task_uses_running_loop_when_available(self):
+        """When a running event loop exists, the adapter should create
+        a task on it instead of spawning a thread."""
+        AtlanLoggerAdapter._reset_for_testing()
+        AtlanLoggerAdapter._flush_task_started = False
+        mock_loop = mock.MagicMock()
+        with mock.patch.dict(
+            "os.environ",
+            {
+                "LOG_LEVEL": "INFO",
+                "ENABLE_OTLP_LOGS": "false",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+            },
+        ):
+            with mock.patch(
+                "application_sdk.observability.logger_adaptor.ENABLE_OBSERVABILITY_STORE_SINK",
+                True,
+            ):
+                with mock.patch(
+                    "application_sdk.observability.logger_adaptor.asyncio.get_running_loop",
+                    return_value=mock_loop,
+                ):
+                    with mock.patch(
+                        "application_sdk.observability.logger_adaptor.threading.Thread"
+                    ) as mock_thread:
+                        _ = AtlanLoggerAdapter("test_py314_loop")
+
+                        mock_loop.create_task.assert_called_once()
+                        mock_thread.assert_not_called()

--- a/tests/unit/observability/test_metrics_adaptor.py
+++ b/tests/unit/observability/test_metrics_adaptor.py
@@ -401,3 +401,64 @@ def test_segment_client_disabled_without_write_key():
                         adapter = AtlanMetricsAdapter()
                         assert adapter.segment_client is not None
                         assert adapter.segment_client.enabled is False
+
+
+class TestPython314EventLoopCompat:
+    """Tests for Python 3.14 compatibility where asyncio.get_event_loop()
+    raises RuntimeError when no current event loop exists."""
+
+    def test_flush_task_starts_via_thread_when_no_event_loop(self):
+        """When no running event loop exists (Python 3.14 behavior),
+        the adapter should fall back to starting the flush in a daemon thread."""
+        AtlanMetricsAdapter._flush_task_started = False
+        with mock.patch.dict(
+            "os.environ",
+            {
+                "ENABLE_OTLP_METRICS": "true",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+            },
+        ):
+            with mock.patch("opentelemetry.metrics.set_meter_provider"):
+                with mock.patch("opentelemetry.sdk.metrics.MeterProvider"):
+                    with mock.patch(
+                        "application_sdk.observability.metrics_adaptor.asyncio.get_running_loop",
+                        side_effect=RuntimeError("no running event loop"),
+                    ):
+                        with mock.patch(
+                            "application_sdk.observability.metrics_adaptor.threading.Thread"
+                        ) as mock_thread:
+                            mock_thread_instance = mock.MagicMock()
+                            mock_thread.return_value = mock_thread_instance
+
+                            _ = AtlanMetricsAdapter()
+
+                            mock_thread.assert_called_once()
+                            _, kwargs = mock_thread.call_args
+                            assert kwargs.get("daemon") is True
+                            mock_thread_instance.start.assert_called_once()
+
+    def test_flush_task_uses_running_loop_when_available(self):
+        """When a running event loop exists, the adapter should create
+        a task on it instead of spawning a thread."""
+        AtlanMetricsAdapter._flush_task_started = False
+        mock_loop = mock.MagicMock()
+        with mock.patch.dict(
+            "os.environ",
+            {
+                "ENABLE_OTLP_METRICS": "true",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+            },
+        ):
+            with mock.patch("opentelemetry.metrics.set_meter_provider"):
+                with mock.patch("opentelemetry.sdk.metrics.MeterProvider"):
+                    with mock.patch(
+                        "application_sdk.observability.metrics_adaptor.asyncio.get_running_loop",
+                        return_value=mock_loop,
+                    ):
+                        with mock.patch(
+                            "application_sdk.observability.metrics_adaptor.threading.Thread"
+                        ) as mock_thread:
+                            _ = AtlanMetricsAdapter()
+
+                            mock_loop.create_task.assert_called_once()
+                            mock_thread.assert_not_called()

--- a/tests/unit/observability/test_traces_adaptor.py
+++ b/tests/unit/observability/test_traces_adaptor.py
@@ -210,3 +210,60 @@ async def test_cleanup_old_records():
         # Note: In a real test, we would need to mock the file system operations
         # and verify the cleanup logic. This is just a basic structure.
         assert True
+
+
+class TestPython314EventLoopCompat:
+    """Tests for Python 3.14 compatibility where asyncio.get_event_loop()
+    raises RuntimeError when no current event loop exists."""
+
+    def test_flush_task_starts_via_thread_when_no_event_loop(self):
+        """When no running event loop exists (Python 3.14 behavior),
+        the adapter should fall back to starting the flush in a daemon thread."""
+        AtlanTracesAdapter._flush_task_started = False
+        with mock.patch.dict(
+            "os.environ",
+            {
+                "ENABLE_OTLP_TRACES": "true",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+            },
+        ):
+            with mock.patch(
+                "application_sdk.observability.traces_adaptor.asyncio.get_running_loop",
+                side_effect=RuntimeError("no running event loop"),
+            ):
+                with mock.patch(
+                    "application_sdk.observability.traces_adaptor.threading.Thread"
+                ) as mock_thread:
+                    mock_thread_instance = mock.MagicMock()
+                    mock_thread.return_value = mock_thread_instance
+
+                    _ = AtlanTracesAdapter()
+
+                    mock_thread.assert_called_once()
+                    _, kwargs = mock_thread.call_args
+                    assert kwargs.get("daemon") is True
+                    mock_thread_instance.start.assert_called_once()
+
+    def test_flush_task_uses_running_loop_when_available(self):
+        """When a running event loop exists, the adapter should create
+        a task on it instead of spawning a thread."""
+        AtlanTracesAdapter._flush_task_started = False
+        mock_loop = mock.MagicMock()
+        with mock.patch.dict(
+            "os.environ",
+            {
+                "ENABLE_OTLP_TRACES": "true",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+            },
+        ):
+            with mock.patch(
+                "application_sdk.observability.traces_adaptor.asyncio.get_running_loop",
+                return_value=mock_loop,
+            ):
+                with mock.patch(
+                    "application_sdk.observability.traces_adaptor.threading.Thread"
+                ) as mock_thread:
+                    _ = AtlanTracesAdapter()
+
+                    mock_loop.create_task.assert_called_once()
+                    mock_thread.assert_not_called()


### PR DESCRIPTION
## Summary

- Replace all `asyncio.get_event_loop()` calls with `asyncio.get_running_loop()` across the SDK
- Python 3.14 removes the implicit event loop creation in `get_event_loop()`, raising `RuntimeError` instead
- Affected files: `logger_adaptor.py`, `metrics_adaptor.py`, `traces_adaptor.py`, `segment_client.py`, `sql.py`, `azure/client.py`, `e2e/logs.py`
- Add Python 3.14 to the PR unit test matrix in CI

## Reproduction

```python
# Python 3.14
>>> import asyncio
>>> asyncio.get_event_loop()
RuntimeError: There is no current event loop in thread 'MainThread'.
```

The fix uses `asyncio.get_running_loop()` which:
- Returns the running loop if inside an async context → schedule flush as a task
- Raises `RuntimeError` if no loop is running → fall back to daemon thread

## Test plan

- [x] 6 new tests in `TestPython314EventLoopCompat` across logger, metrics, and traces adaptors
- [x] All 76 observability tests pass
- [x] Pre-commit checks pass
- [ ] CI passes with Python 3.14 in matrix

Fixes BLDX-944
