### PR TITLE
feat(observability): add AppVitalsInterceptor for Temporal-native wor…

### DIFF
--- a/.github/actions/unit-tests/action.yaml
+++ b/.github/actions/unit-tests/action.yaml
@@ -67,12 +67,15 @@ runs:
 
     - name: Setup AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
+      continue-on-error: true
+      id: aws-creds
       with:
         aws-region: ap-south-1
         # Only usable in atlanhq repositories
         role-to-assume: arn:aws:iam::733936409301:role/kryptonite-store_FullAccess
 
     - name: Upload Coverage Report to Kryptonite Bucket
+      if: steps.aws-creds.outcome == 'success'
       shell: bash
       run: |
         aws s3 sync ./htmlcov s3://kryptonite-store/coverage/application-sdk/pr/${{ github.event.number }} --delete

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -10,8 +10,6 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
       - 'entrypoint.sh'
-      - 'application_sdk/**'
-      - 'tests/**'
 
 permissions:
   contents: read
@@ -44,10 +42,8 @@ jobs:
         run: echo "version=$(awk -F'"' '/^version = / {print $2}' pyproject.toml)" >> $GITHUB_OUTPUT
         id: get_version
 
-      - name: Lowercase and sanitise branch name
-        # Replace '/' and '_' with '-' so feature branches like "gaurav/app-vitals"
-        # produce a valid GHCR image tag (no slashes allowed in tag portion).
-        run: echo "lowercase_branch=$(echo '${{ steps.get_branch.outputs.branch }}' | tr '[:upper:]' '[:lower:]' | tr '/' '-' | tr '_' '-')" >> $GITHUB_OUTPUT
+      - name: Lowercase branch name
+        run: echo "lowercase_branch=$(echo '${{ steps.get_branch.outputs.branch }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
         id: get_lowercase_branch
 
   push-to-ghcr:

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - 'gaurav/app-vitals'  # feature branch — build image on every push for testing
     paths:
       - 'Dockerfile'
       - 'pyproject.toml'

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -5,11 +5,14 @@ on:
   push:
     branches:
       - main
+      - 'gaurav/app-vitals'  # feature branch — build image on every push for testing
     paths:
       - 'Dockerfile'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'entrypoint.sh'
+      - 'application_sdk/**'
+      - 'tests/**'
 
 permissions:
   contents: read
@@ -42,8 +45,10 @@ jobs:
         run: echo "version=$(awk -F'"' '/^version = / {print $2}' pyproject.toml)" >> $GITHUB_OUTPUT
         id: get_version
 
-      - name: Lowercase branch name
-        run: echo "lowercase_branch=$(echo '${{ steps.get_branch.outputs.branch }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+      - name: Lowercase and sanitise branch name
+        # Replace '/' and '_' with '-' so feature branches like "gaurav/app-vitals"
+        # produce a valid GHCR image tag (no slashes allowed in tag portion).
+        run: echo "lowercase_branch=$(echo '${{ steps.get_branch.outputs.branch }}' | tr '[:upper:]' '[:lower:]' | tr '/' '-' | tr '_' '-')" >> $GITHUB_OUTPUT
         id: get_lowercase_branch
 
   push-to-ghcr:

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -49,17 +49,20 @@ APP_TENANT_ID = os.getenv("ATLAN_TENANT_ID", "default")
 # Domain Name of the tenant
 DOMAIN_NAME = os.getenv("ATLAN_DOMAIN_NAME", "atlan.com")
 
-# Marketplace / Release metadata (injected by Helm via Local Marketplace sync)
-#: Semantic version of the app (e.g., "2.14.3")
-APP_VERSION_SEMVER = os.getenv("ATLAN_APPLICATION_VERSION", "")
-#: Release ID from Global Marketplace (unique per release)
-APP_RELEASE_ID = os.getenv("ATLAN_RELEASE_ID", "")
-#: Release channel (e.g., "stable", "beta", "all")
-APP_RELEASE_CHANNEL = os.getenv("ATLAN_RELEASE_CHANNEL", "")
-#: SDK version the app was built against
+# App Vitals / Release metadata (injected by Local Marketplace into HelmRelease).
+# Naming aligned with Anuj's LM-integration PR so they merge cleanly.
+#: Semantic version of the app release (e.g., "1.2.3")
+APPLICATION_VERSION = os.getenv("ATLAN_APPLICATION_VERSION", "")
+#: Release UUID from Global Marketplace
+RELEASE_ID = os.getenv("ATLAN_RELEASE_ID", "")
+#: Release channel (all, beta, staging, specific)
+RELEASE_CHANNEL = os.getenv("ATLAN_RELEASE_CHANNEL", "")
+#: SDK version used to build this app image
 APP_SDK_VERSION = os.getenv("ATLAN_SDK_VERSION", "")
-#: App type from marketplace (e.g., "connector", "governance", "automation")
+#: App type from Global Marketplace (connector, system, etc.)
 APP_TYPE = os.getenv("ATLAN_APP_TYPE", "")
+#: Release publication timestamp from Global Marketplace (ISO 8601)
+PUBLISHED_AT = os.getenv("ATLAN_PUBLISHED_AT", "")
 #: Host address for the application's dashboard
 APP_DASHBOARD_HOST = str(os.getenv("ATLAN_APP_DASHBOARD_HOST", "localhost"))
 #: Port number for the application's dashboard

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -48,6 +48,18 @@ APP_PORT = int(
 APP_TENANT_ID = os.getenv("ATLAN_TENANT_ID", "default")
 # Domain Name of the tenant
 DOMAIN_NAME = os.getenv("ATLAN_DOMAIN_NAME", "atlan.com")
+
+# Marketplace / Release metadata (injected by Helm via Local Marketplace sync)
+#: Semantic version of the app (e.g., "2.14.3")
+APP_VERSION_SEMVER = os.getenv("ATLAN_APPLICATION_VERSION", "")
+#: Release ID from Global Marketplace (unique per release)
+APP_RELEASE_ID = os.getenv("ATLAN_RELEASE_ID", "")
+#: Release channel (e.g., "stable", "beta", "all")
+APP_RELEASE_CHANNEL = os.getenv("ATLAN_RELEASE_CHANNEL", "")
+#: SDK version the app was built against
+APP_SDK_VERSION = os.getenv("ATLAN_SDK_VERSION", "")
+#: App type from marketplace (e.g., "connector", "governance", "automation")
+APP_TYPE = os.getenv("ATLAN_APP_TYPE", "")
 #: Host address for the application's dashboard
 APP_DASHBOARD_HOST = str(os.getenv("ATLAN_APP_DASHBOARD_HOST", "localhost"))
 #: Port number for the application's dashboard

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -256,6 +256,10 @@ ENABLE_OTLP_WORKFLOW_LOGS: bool = (
     os.getenv("ENABLE_OTLP_WORKFLOW_LOGS", "false").lower() == "true"
 )
 
+# App Vitals
+#: Enable App Vitals interceptor for automatic lifecycle metrics
+ENABLE_APP_VITALS: bool = os.getenv("ATLAN_ENABLE_APP_VITALS", "true").lower() == "true"
+
 # OTEL Constants
 #: Node name for workflow telemetry
 OTEL_WF_NODE_NAME = os.getenv("OTEL_WF_NODE_NAME", "")

--- a/application_sdk/execution/_temporal/interceptors/activity_failure_logging.py
+++ b/application_sdk/execution/_temporal/interceptors/activity_failure_logging.py
@@ -1,8 +1,13 @@
 """Activity failure logging interceptor for Temporal activities.
 
 Catches activity failures and emits structured logs with full Temporal context
-(activity type, attempt, workflow ID, timeouts, tenant ID) for queryable
-observability in ClickHouse via the OTEL logging pipeline.
+(activity type, attempt, workflow ID, timeouts, tenant ID) AND App Vitals
+identity (app_name, tenant_id, app_version, error_type, trace_id, span_id) for
+queryable observability in ClickHouse via the OTEL logging pipeline.
+
+This completes RFC P0.4 (07-implementation.md) — "Structured Logs for AI
+Consumption" — by ensuring every activity failure is queryable by the same
+attributes used across App Vitals.
 """
 
 from typing import Any, Optional, Type
@@ -16,8 +21,15 @@ from temporalio.worker import (
     WorkflowInterceptorClassInput,
 )
 
+from application_sdk.constants import APP_BUILD_ID, APP_TENANT_ID, APPLICATION_NAME
 from application_sdk.observability.context import correlation_context
+from application_sdk.observability.error_classifier import (
+    classify_error,
+    extract_cause_chain,
+    is_retriable,
+)
 from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.observability.trace_context import get_trace_context
 
 logger = get_logger(__name__)
 
@@ -38,22 +50,84 @@ class _TaskFailureLoggingActivityInboundInterceptor(ActivityInboundInterceptor):
             raise
 
     def _log_activity_failure(self, exception: BaseException) -> None:
-        """Log activity failure with structured Temporal context.
+        """Log activity failure with structured Temporal + App Vitals context.
 
-        Extracts context from activity.info() and correlation_context, then emits
-        a structured error log. The log flows through the existing OTEL pipeline
-        (PR #1063) where exception attributes are extracted via exc_info=True.
+        Extracts context from activity.info() and correlation_context, classifies
+        the error, and emits a structured error log. The log flows through the
+        existing OTEL pipeline where exception attributes are extracted via
+        exc_info=True.
+
+        The structured attributes are the same ones App Vitals uses everywhere,
+        so failure logs can be filtered/joined with the rest of App Vitals data
+        in ClickHouse by (app_name, tenant_id, workflow_id, error_type, ...).
 
         Args:
             exception: The exception that caused the activity failure.
         """
         try:
             log_attrs = self._collect_temporal_context()
-            # kwargs are temporal.*/tenant.* keys promoted to indexed OTEL fields by _build_extra_dict
-            # TODO(signal-over-noise): [L24] deliberate structured context — temporal.*/tenant.* keys are top-level indexed. See reference/logging-patterns.md#L24
+            log_attrs.update(self._collect_app_vitals_context(exception))
+            # kwargs are temporal.*/tenant.*/app_vitals.* keys promoted to indexed OTEL fields
             logger.error("Temporal activity failed", exc_info=True, **log_attrs)
         except Exception:
             logger.warning("Failed to log activity failure context", exc_info=True)
+
+    def _collect_app_vitals_context(self, exception: BaseException) -> dict[str, Any]:
+        """Collect App Vitals identity + error classification for structured logging.
+
+        Returns the same attributes that the AppVitalsInterceptor emits, so a
+        single ClickHouse query can filter failures by app_name, tenant_id,
+        error_type, etc. without joining across schemas.
+        """
+        trace_id, span_id = get_trace_context()
+        error_type = classify_error(exception)
+        cause_chain = extract_cause_chain(exception)
+
+        attrs: dict[str, Any] = {
+            "app_name": APPLICATION_NAME,
+            "app_version": APP_BUILD_ID or "",
+            "error_type": error_type,
+            "error_class": type(exception).__name__,
+            "is_retriable": is_retriable(exception, error_type),
+            "dimension": "reliability",
+            "source": "temporal",
+            "metric_name": "app_vitals.reliability.activity_completed",
+            "status": "failed",
+        }
+
+        if cause_chain:
+            attrs["error_cause_chain"] = cause_chain
+
+        if trace_id:
+            attrs["trace_id"] = trace_id
+        if span_id:
+            attrs["span_id"] = span_id
+
+        # tenant_id from correlation context, env var fallback
+        try:
+            corr_ctx = correlation_context.get()
+            if corr_ctx:
+                tenant_from_corr = corr_ctx.get("atlan-tenant-id", "")
+                if tenant_from_corr:
+                    attrs["tenant_id"] = tenant_from_corr
+        except Exception:
+            pass
+        if "tenant_id" not in attrs:
+            attrs["tenant_id"] = APP_TENANT_ID
+
+        # correlation_id from v3 CorrelationContext
+        try:
+            from application_sdk.observability.correlation import (
+                get_correlation_context,
+            )
+
+            ctx = get_correlation_context()
+            if ctx and ctx.correlation_id:
+                attrs["correlation_id"] = ctx.correlation_id
+        except Exception:
+            pass
+
+        return attrs
 
     def _collect_temporal_context(self) -> dict[str, Any]:
         """Collect Temporal activity context for structured logging.

--- a/application_sdk/execution/_temporal/interceptors/activity_failure_logging.py
+++ b/application_sdk/execution/_temporal/interceptors/activity_failure_logging.py
@@ -111,7 +111,9 @@ class _TaskFailureLoggingActivityInboundInterceptor(ActivityInboundInterceptor):
                 if tenant_from_corr:
                     attrs["tenant_id"] = tenant_from_corr
         except Exception:
-            pass
+            logger.debug(
+                "Failed to read tenant_id from correlation context", exc_info=True
+            )
         if "tenant_id" not in attrs:
             attrs["tenant_id"] = APP_TENANT_ID
 
@@ -125,7 +127,7 @@ class _TaskFailureLoggingActivityInboundInterceptor(ActivityInboundInterceptor):
             if ctx and ctx.correlation_id:
                 attrs["correlation_id"] = ctx.correlation_id
         except Exception:
-            pass
+            logger.debug("Failed to read correlation_id from context", exc_info=True)
 
         return attrs
 

--- a/application_sdk/execution/_temporal/interceptors/correlation_interceptor.py
+++ b/application_sdk/execution/_temporal/interceptors/correlation_interceptor.py
@@ -40,6 +40,10 @@ from application_sdk.observability.logger_adaptor import get_logger
 logger = get_logger(__name__)
 
 _HEADER_CORRELATION_ID = "x-correlation-id"
+# The AE's older CorrelationContextInterceptor injects the header under this
+# plain key (no x- prefix).  We check it as a fallback so that workflows
+# dispatched by the AE inherit their correlation_id without any AE-side changes.
+_HEADER_CORRELATION_ID_LEGACY = "correlation_id"
 
 
 class _LazyCorrelationOutboundInterceptor(WorkflowOutboundInterceptor):
@@ -103,15 +107,23 @@ class _CorrelationWorkflowInboundInterceptor(WorkflowInboundInterceptor):
             )
             ctx = None
 
-        # Priority 2: inherit from parent via headers (child workflow call path)
+        # Priority 2: inherit from parent via headers (child workflow call path).
+        # Check both the current header key ("x-correlation-id") and the legacy
+        # key ("correlation_id") used by the AE's older interceptor so that
+        # AE-dispatched workflows inherit the same correlation_id without
+        # requiring any changes on the AE side.
         if ctx is None:
             try:
-                payload = input.headers.get(_HEADER_CORRELATION_ID)
-                if payload is not None:
-                    converter = default_converter().payload_converter
-                    correlation_id: str = converter.from_payload(payload, type_hint=str)
-                    if correlation_id:
-                        ctx = CorrelationContext(correlation_id=correlation_id)
+                for _hdr_key in (_HEADER_CORRELATION_ID, _HEADER_CORRELATION_ID_LEGACY):
+                    payload = input.headers.get(_hdr_key)
+                    if payload is not None:
+                        converter = default_converter().payload_converter
+                        correlation_id: str = converter.from_payload(
+                            payload, type_hint=str
+                        )
+                        if correlation_id:
+                            ctx = CorrelationContext(correlation_id=correlation_id)
+                            break
             except Exception:
                 logger.warning(
                     "Failed to read correlation header in workflow", exc_info=True
@@ -137,14 +149,16 @@ class _CorrelationActivityInboundInterceptor(ActivityInboundInterceptor):
         )
 
         try:
-            payload = input.headers.get(_HEADER_CORRELATION_ID)
-            if payload is not None:
-                converter = default_converter().payload_converter
-                correlation_id: str = converter.from_payload(payload, type_hint=str)
-                if correlation_id:
-                    set_correlation_context(
-                        CorrelationContext(correlation_id=correlation_id)
-                    )
+            for _hdr_key in (_HEADER_CORRELATION_ID, _HEADER_CORRELATION_ID_LEGACY):
+                payload = input.headers.get(_hdr_key)
+                if payload is not None:
+                    converter = default_converter().payload_converter
+                    correlation_id: str = converter.from_payload(payload, type_hint=str)
+                    if correlation_id:
+                        set_correlation_context(
+                            CorrelationContext(correlation_id=correlation_id)
+                        )
+                        break
         except Exception:
             logger.warning(
                 "Failed to read correlation header in activity", exc_info=True

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -176,6 +176,37 @@ def create_worker(
 
         all_interceptors.append(CorrelationContextInterceptor())
 
+    # Temporal OTel TracingInterceptor — creates spans for workflow/activity
+    # executions. When enabled, our AppVitalsInterceptor picks up real trace_ids
+    # on every event (otherwise trace_id is empty).
+    # Gated behind ATLAN_ENABLE_OTLP_TRACES so apps not using traces pay nothing.
+    import os
+
+    if os.getenv("ATLAN_ENABLE_OTLP_TRACES", "false").lower() == "true":
+        try:
+            from temporalio.contrib.opentelemetry import TracingInterceptor
+
+            all_interceptors.append(TracingInterceptor())
+            logger.info(
+                "Temporal OTel TracingInterceptor registered — "
+                "App Vitals events will carry real trace_id/span_id"
+            )
+        except ImportError:
+            logger.warning(
+                "ATLAN_ENABLE_OTLP_TRACES=true but temporalio.contrib.opentelemetry "
+                "is not available; falling back to empty trace_ids"
+            )
+
+    # AppVitalsInterceptor — emits lifecycle metrics on workflow/activity completion.
+    # Must come after ExecutionContext, CorrelationContext, and TracingInterceptor
+    # so ContextVars and span context are set when we emit.
+    from application_sdk.constants import ENABLE_APP_VITALS
+
+    if ENABLE_APP_VITALS:
+        from application_sdk.observability.app_vitals import AppVitalsInterceptor
+
+        all_interceptors.append(AppVitalsInterceptor())
+
     if interceptor_settings.enable_output_interceptor:
         from application_sdk.execution._temporal.interceptors.outputs import (
             OutputInterceptor,

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -180,8 +180,6 @@ def create_worker(
     # executions. When enabled, our AppVitalsInterceptor picks up real trace_ids
     # on every event (otherwise trace_id is empty).
     # Gated behind ATLAN_ENABLE_OTLP_TRACES so apps not using traces pay nothing.
-    import os
-
     if os.getenv("ATLAN_ENABLE_OTLP_TRACES", "false").lower() == "true":
         try:
             from temporalio.contrib.opentelemetry import TracingInterceptor

--- a/application_sdk/observability/app_vitals.py
+++ b/application_sdk/observability/app_vitals.py
@@ -377,6 +377,9 @@ class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
             "workflow_type": info.workflow_type or "",
             "task_queue": info.task_queue or "",
             "namespace": info.namespace or "",
+            "parent_workflow_id": info.parent.workflow_id if info.parent else "",
+            "parent_run_id": info.parent.run_id if info.parent else "",
+            "continued_run_id": info.continued_run_id or "",
             "status": wf_status,
             "duration_ms": round(wf_duration_ms, 1),
             "total_activities": len(acts),
@@ -573,12 +576,13 @@ class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
         start_ns = time.monotonic_ns()
         start_resource = sample()
 
-        # Measure input payload size — sum of serialized arg bytes.
+        # Measure input payload size. At the inbound interceptor level,
+        # input.args are deserialized Python objects (not raw Payloads).
+        # Use sys.getsizeof as a rough in-memory size estimate.
         input_payload_bytes: int | None = None
         try:
-            input_payload_bytes = sum(
-                len(p.data) for p in (input.args or []) if hasattr(p, "data")
-            )
+            if input.args:
+                input_payload_bytes = sum(sys.getsizeof(a) for a in input.args)
         except Exception:
             pass
 

--- a/application_sdk/observability/app_vitals.py
+++ b/application_sdk/observability/app_vitals.py
@@ -34,9 +34,7 @@ from temporalio.worker import (
     WorkflowOutboundInterceptor,
 )
 
-# APPLICATION_NAME imported for test compatibility (tests patch this module attr).
-# Deployment-level identity now flows via build_otel_resource(), not per-event attrs.
-from application_sdk.constants import APP_TENANT_ID, APPLICATION_NAME  # noqa: F401
+from application_sdk.constants import APP_TENANT_ID, APPLICATION_NAME
 from application_sdk.observability.error_classifier import (
     classify_error,
     extract_cause_chain,
@@ -153,10 +151,12 @@ def _compute_error_fingerprint(
 def _build_common_attrs() -> dict[str, str]:
     """Build the per-event identity attributes.
 
-    Only workflow/activity-scoped fields live here. Deployment-level attributes
-    (app_name, app_version, release_id, sdk_version, pod_name, domain_name,
-    etc.) are set on the OTel Resource by build_otel_resource() and appear as
-    ResourceAttributes.* in ClickHouse — no need to duplicate in every log row.
+    Deployment-level attributes (app.version, release_id, sdk_version, pod_name,
+    k8s.domain.name, etc.) are set on the OTel Resource by build_otel_resource()
+    and appear as ResourceAttributes.* in ClickHouse — not duplicated here.
+
+    ``app_name`` stays in log attrs (not resource) because a single deployment
+    can host multiple apps; app_name is conceptually per-event, not per-pod.
 
     The ``app_vitals: "true"`` flag is a deterministic marker for filtering
     the materialized view (more reliable than Body LIKE 'app_vitals.%').
@@ -164,6 +164,7 @@ def _build_common_attrs() -> dict[str, str]:
     trace_id, span_id = get_trace_context()
     return {
         "app_vitals": "true",
+        "app_name": APPLICATION_NAME,
         "tenant_id": _get_tenant_id(),
         "correlation_id": _get_correlation_id(),
         "trace_id": trace_id,

--- a/application_sdk/observability/app_vitals.py
+++ b/application_sdk/observability/app_vitals.py
@@ -1,11 +1,11 @@
-"""App Vitals interceptor — automatic lifecycle metrics for workflows and activities.
+"""App Vitals interceptor — automatic lifecycle events for workflows and activities.
 
-Emits two paths on every workflow/activity completion:
-  Path 1: Structured log event via AtlanLoggerAdapter (→ otel_logs in ClickHouse)
-  Path 2: OTel metric via AtlanMetricsAdapter (counter + gauge for dashboards)
+Emits structured log events via AtlanLoggerAdapter on every workflow/activity
+lifecycle transition. Events land in otel_logs.service_logs and are extracted
+into horizon.app_vitals_events via a ClickHouse Materialized View.
 
-Both paths carry the full execution context: app_name, tenant_id, workflow_id,
-activity_id, status, error_type, duration_ms, etc.
+All analytics (success rates, P95 durations, error breakdowns, etc.) are
+computed at query time from the raw events — no pre-aggregated OTel metrics.
 
 Registration order: AFTER ExecutionContextInterceptor and CorrelationContextInterceptor
 (reads from both ContextVars).
@@ -189,41 +189,6 @@ def _emit_log_event(
         logger = get_logger("app_vitals")
         level = "error" if attrs.get("status") == "failed" else "info"
         getattr(logger, level)(event_name, **attrs)
-    except Exception:
-        pass
-
-
-def _emit_metric(
-    name: str,
-    value: float,
-    metric_type_str: str,
-    labels: dict[str, str],
-    unit: str | None = None,
-) -> None:
-    """Emit an OTel metric (Path 2: → metrics pipeline).
-
-    Always passes a non-None description and unit because OTel's
-    ``MeterProvider._register_instrument`` constructs an instrument key as
-    ``",".join([name, type, unit, description])`` which raises ``TypeError``
-    if any element is ``None``.
-    """
-    try:
-        from application_sdk.observability.metrics_adaptor import get_metrics
-        from application_sdk.observability.models import MetricType
-
-        type_map = {
-            "counter": MetricType.COUNTER,
-            "gauge": MetricType.GAUGE,
-            "histogram": MetricType.HISTOGRAM,
-        }
-        get_metrics().record_metric(
-            name=name,
-            value=value,
-            metric_type=type_map[metric_type_str],
-            labels=labels,
-            description="App Vitals signal",
-            unit=unit or "1",
-        )
     except Exception:
         pass
 
@@ -504,40 +469,6 @@ class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
             except Exception:
                 pass  # summary is best-effort; never block the workflow
 
-            # Metric labels: only workflow-scoped fields. Deployment-level
-            # attributes (app_name, app_version, release_id, etc.) are on the
-            # OTel Resource and exported with every metric point automatically.
-            metric_labels = {
-                "workflow_type": info.workflow_type or "",
-                "task_queue": info.task_queue or "",
-                "status": status,
-                "error_type": error_type,
-                "workflow_id": info.workflow_id or "",
-                "workflow_run_id": info.run_id or "",
-                "namespace": info.namespace or "",
-                "correlation_id": common["correlation_id"],
-            }
-
-            _emit_metric(
-                "app_vitals.reliability.wf_completed",
-                1.0,
-                "counter",
-                metric_labels,
-                unit="1",
-            )
-
-            # Histogram — durations need percentile aggregation (p50/p95/p99).
-            # GAUGE here would hit create_observable_gauge() which doesn't support
-            # direct .add()/.record() and silently drops data via the adapter's
-            # exception handler.
-            _emit_metric(
-                "app_vitals.performance.wf_runtime",
-                duration_ms,
-                "histogram",
-                metric_labels,
-                unit="ms",
-            )
-
 
 class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
     """Emits lifecycle events on activity start AND completion."""
@@ -698,94 +629,13 @@ class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
 
             _emit_log_event("app_vitals.act.completed", event_attrs)
 
-            # Metric labels: only activity/workflow-scoped fields. Deployment
-            # attributes live on the OTel Resource.
-            metric_labels = {
-                "workflow_id": info.workflow_id or "",
-                "workflow_run_id": info.workflow_run_id or "",
-                "workflow_type": getattr(info, "workflow_type", ""),
-                "activity_type": info.activity_type or "",
-                "activity_id": info.activity_id or "",
-                "task_queue": info.task_queue or "",
-                "attempt": str(info.attempt),
-                "namespace": getattr(info, "namespace", ""),
-                "status": status,
-                "error_type": error_type,
-                "correlation_id": common["correlation_id"],
-            }
-
-            _emit_metric(
-                "app_vitals.reliability.activity_completed",
-                1.0,
-                "counter",
-                metric_labels,
-                unit="1",
-            )
-
-            # Histogram — durations need p50/p95/p99; GAUGE silently fails
-            # (see wf_runtime comment above).
-            _emit_metric(
-                "app_vitals.performance.activity_runtime",
-                duration_ms,
-                "histogram",
-                metric_labels,
-                unit="ms",
-            )
-
-            if schedule_to_start_ms is not None:
-                _emit_metric(
-                    "app_vitals.performance.activity_schedule_to_start",
-                    schedule_to_start_ms,
-                    "histogram",
-                    metric_labels,
-                    unit="ms",
-                )
-
-            if info.attempt > 1:
-                _emit_metric(
-                    "app_vitals.reliability.activity_retries",
-                    float(info.attempt - 1),
-                    "counter",
-                    metric_labels,
-                    unit="1",
-                )
-
-            # Efficiency signals — RFC DESIGN.md §4.1 #10 and #11.
-            # Process-level samples via psutil; see resource_sampler.py for scope limits.
-            if start_resource is not None and end_resource is not None:
-                _emit_metric(
-                    "app_vitals.efficiency.activity_cpu_seconds",
-                    cpu_seconds,
-                    "counter",
-                    metric_labels,
-                    unit="s",
-                )
-                _emit_metric(
-                    "app_vitals.efficiency.activity_mem_gb_sec",
-                    mem_gb_sec,
-                    "counter",
-                    metric_labels,
-                    unit="GiB.s",
-                )
-
-            # Throughput: assets_processed (L9) — universal denominator for
-            # cost-per-asset and efficiency comparisons across apps.
-            if assets_processed is not None:
-                _emit_metric(
-                    "app_vitals.performance.activity_assets_processed",
-                    float(assets_processed),
-                    "counter",
-                    metric_labels,
-                    unit="{assets}",
-                )
-
 
 class AppVitalsInterceptor(Interceptor):
-    """Temporal interceptor that emits App Vitals lifecycle metrics.
+    """Temporal interceptor that emits App Vitals lifecycle events.
 
-    Emits on every workflow/activity completion:
-      - Structured log event (Path 1) with full execution context
-      - OTel metric (Path 2) for counters, gauges, histograms
+    Emits structured log events (Path 1) on every workflow/activity
+    lifecycle transition. These land in otel_logs.service_logs and are
+    extracted into horizon.app_vitals_events via a ClickHouse MV.
 
     Registration order: AFTER ExecutionContextInterceptor and
     CorrelationContextInterceptor so that ContextVars are populated.

--- a/application_sdk/observability/app_vitals.py
+++ b/application_sdk/observability/app_vitals.py
@@ -13,9 +13,12 @@ Registration order: AFTER ExecutionContextInterceptor and CorrelationContextInte
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 import sys
 import time
+import traceback
 from typing import Any
 
 from temporalio import activity, workflow
@@ -31,7 +34,12 @@ from temporalio.worker import (
     WorkflowOutboundInterceptor,
 )
 
-from application_sdk.constants import APP_BUILD_ID, APP_TENANT_ID, APPLICATION_NAME
+from application_sdk.constants import (
+    APP_BUILD_ID,
+    APP_TENANT_ID,
+    APPLICATION_NAME,
+    DOMAIN_NAME,
+)
 from application_sdk.observability.error_classifier import (
     classify_error,
     extract_cause_chain,
@@ -123,6 +131,33 @@ def _extract_assets_processed(result: Any) -> int | None:
     return None
 
 
+def _get_pod_name() -> str:
+    """Get the pod name from K8s-injected env vars."""
+    return os.environ.get("K8S_POD_NAME", os.environ.get("HOSTNAME", ""))
+
+
+def _format_stack_trace(exc: BaseException) -> str:
+    """Format a full stack trace, truncated to 2000 chars."""
+    try:
+        lines = traceback.format_exception(type(exc), exc, exc.__traceback__)
+        full = "".join(lines)
+        return full[:2000]
+    except Exception:
+        return ""
+
+
+def _compute_error_fingerprint(
+    activity_type: str, error_type: str, error_class: str
+) -> str:
+    """Deterministic fingerprint for error deduplication.
+
+    Same (activity_type, error_type, error_class) → same fingerprint,
+    enabling GROUP BY fingerprint to count distinct failure modes.
+    """
+    raw = f"{activity_type}:{error_type}:{error_class}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
 def _build_common_attrs() -> dict[str, str]:
     """Build the identity attributes present on every event.
 
@@ -135,6 +170,8 @@ def _build_common_attrs() -> dict[str, str]:
         "app_name": APPLICATION_NAME,
         "app_version": APP_BUILD_ID or "",
         "tenant_id": _get_tenant_id(),
+        "domain_name": DOMAIN_NAME,
+        "pod_name": _get_pod_name(),
         "correlation_id": _get_correlation_id(),
         "trace_id": trace_id,
         "span_id": span_id,
@@ -327,6 +364,12 @@ class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
         if acts_with_duration:
             bottleneck = max(acts_with_duration, key=lambda a: a["duration_ms"])
 
+        # Sum of all activity durations — if > wf_duration, activities ran in
+        # parallel; if < wf_duration, difference is orchestration overhead.
+        sum_activity_duration_ms = round(
+            sum(a.get("duration_ms", 0) for a in acts_with_duration), 1
+        )
+
         summary: dict[str, Any] = {
             **common,
             "workflow_id": info.workflow_id or "",
@@ -340,6 +383,7 @@ class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
             "succeeded_activities": len(succeeded),
             "failed_activities": len(failed),
             "total_child_workflows": len(self._child_workflow_records),
+            "sum_activity_duration_ms": sum_activity_duration_ms,
             "dimension": "reliability",
             "source": "temporal",
             "metric_name": "app_vitals.reliability.wf_summary",
@@ -355,6 +399,11 @@ class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
         return summary
 
     async def execute_workflow(self, input: ExecuteWorkflowInput) -> Any:
+        # Skip all observability during Temporal replay — replays re-execute
+        # workflow code for determinism, emitting here would double-count.
+        if workflow.unsafe.is_replaying():
+            return await self.next.execute_workflow(input)
+
         start_ns = time.monotonic_ns()
 
         # Emit wf.started event (L2) — enables "currently running" views that
@@ -369,6 +418,10 @@ class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
                 "workflow_type": info.workflow_type or "",
                 "task_queue": info.task_queue or "",
                 "namespace": info.namespace or "",
+                "parent_workflow_id": info.parent.workflow_id if info.parent else "",
+                "parent_run_id": info.parent.run_id if info.parent else "",
+                "continued_run_id": info.continued_run_id or "",
+                "cron_schedule": info.cron_schedule or "",
                 "dimension": "reliability",
                 "source": "temporal",
                 "metric_name": "app_vitals.reliability.wf_started",
@@ -383,6 +436,7 @@ class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
         error_class = ""
         cause_chain: list[str] = []
         retriable = False
+        stack_trace = ""
 
         try:
             result = await self.next.execute_workflow(input)
@@ -394,6 +448,7 @@ class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
             error_class = type(exc).__name__
             cause_chain = extract_cause_chain(exc)
             retriable = is_retriable(exc, error_type)
+            stack_trace = _format_stack_trace(exc)
             raise
         finally:
             duration_ms = (time.monotonic_ns() - start_ns) / 1_000_000
@@ -405,6 +460,25 @@ class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
 
             common = _build_common_attrs()
 
+            # Workflow-level timeout budget — same pattern as activity timeout
+            wf_timeout_budget_total_ms: float | None = None
+            wf_timeout_budget_used_pct: float | None = None
+            execution_timeout = getattr(info, "execution_timeout", None)
+            if execution_timeout is not None:
+                total_ms = execution_timeout.total_seconds() * 1000
+                wf_timeout_budget_total_ms = total_ms
+                if total_ms > 0:
+                    wf_timeout_budget_used_pct = round(
+                        (duration_ms / total_ms) * 100, 2
+                    )
+
+            # History length — proxy for workflow complexity / CaN pressure
+            history_length: int | None = None
+            try:
+                history_length = info.get_current_history_length()
+            except Exception:
+                pass
+
             event_attrs: dict[str, Any] = {
                 **common,
                 "workflow_id": info.workflow_id or "",
@@ -412,6 +486,10 @@ class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
                 "workflow_type": info.workflow_type or "",
                 "task_queue": info.task_queue or "",
                 "namespace": info.namespace or "",
+                "parent_workflow_id": info.parent.workflow_id if info.parent else "",
+                "parent_run_id": info.parent.run_id if info.parent else "",
+                "continued_run_id": info.continued_run_id or "",
+                "cron_schedule": info.cron_schedule or "",
                 "status": status,
                 "error_type": error_type,
                 "duration_ms": round(duration_ms, 1),
@@ -419,10 +497,22 @@ class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
                 "source": "temporal",
                 "metric_name": "app_vitals.reliability.wf_completed",
             }
+            if wf_timeout_budget_total_ms is not None:
+                event_attrs["wf_timeout_budget_total_ms"] = round(
+                    wf_timeout_budget_total_ms, 1
+                )
+                event_attrs["wf_timeout_budget_used_pct"] = wf_timeout_budget_used_pct
+            if history_length is not None:
+                event_attrs["history_length"] = history_length
             if error_message:
                 event_attrs["error_message"] = error_message
                 event_attrs["error_class"] = error_class
                 event_attrs["is_retriable"] = retriable
+                event_attrs["error_fingerprint"] = _compute_error_fingerprint(
+                    info.workflow_type or "", error_type, error_class
+                )
+                if stack_trace:
+                    event_attrs["stack_trace"] = stack_trace
                 if cause_chain:
                     event_attrs["error_cause_chain"] = cause_chain
 
@@ -483,6 +573,15 @@ class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
         start_ns = time.monotonic_ns()
         start_resource = sample()
 
+        # Measure input payload size — sum of serialized arg bytes.
+        input_payload_bytes: int | None = None
+        try:
+            input_payload_bytes = sum(
+                len(p.data) for p in (input.args or []) if hasattr(p, "data")
+            )
+        except Exception:
+            pass
+
         try:
             info = activity.info()
         except Exception:
@@ -497,6 +596,7 @@ class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
         # without waiting for completion. Carries full context for drill-down.
         try:
             started_common = _build_common_attrs()
+            retry_policy = getattr(info, "retry_policy", None)
             started_attrs: dict[str, Any] = {
                 **started_common,
                 "workflow_id": info.workflow_id or "",
@@ -505,12 +605,17 @@ class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
                 "activity_type": info.activity_type or "",
                 "task_queue": info.task_queue or "",
                 "attempt": info.attempt,
+                "retry_max_attempts": (
+                    retry_policy.maximum_attempts if retry_policy else 0
+                ),
                 "dimension": "reliability",
                 "source": "temporal",
                 "metric_name": "app_vitals.reliability.activity_started",
             }
             if schedule_to_start_ms is not None:
                 started_attrs["schedule_to_start_ms"] = round(schedule_to_start_ms, 1)
+            if input_payload_bytes is not None:
+                started_attrs["input_payload_bytes"] = input_payload_bytes
             _emit_log_event("app_vitals.act.started", started_attrs)
         except Exception:
             pass  # never block activity on observability
@@ -521,6 +626,7 @@ class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
         error_class = ""
         cause_chain: list[str] = []
         retriable = False
+        stack_trace = ""
         assets_processed: int | None = None
 
         try:
@@ -534,6 +640,7 @@ class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
             error_class = type(exc).__name__
             cause_chain = extract_cause_chain(exc)
             retriable = is_retriable(exc, error_type)
+            stack_trace = _format_stack_trace(exc)
             raise
         finally:
             duration_ms = (time.monotonic_ns() - start_ns) / 1_000_000
@@ -558,6 +665,7 @@ class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
 
             common = _build_common_attrs()
 
+            retry_policy = getattr(info, "retry_policy", None)
             event_attrs: dict[str, Any] = {
                 **common,
                 "workflow_id": info.workflow_id or "",
@@ -566,6 +674,9 @@ class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
                 "activity_type": info.activity_type or "",
                 "task_queue": info.task_queue or "",
                 "attempt": info.attempt,
+                "retry_max_attempts": (
+                    retry_policy.maximum_attempts if retry_policy else 0
+                ),
                 "namespace": getattr(info, "namespace", ""),
                 "status": status,
                 "error_type": error_type,
@@ -578,6 +689,11 @@ class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
                 event_attrs["error_message"] = error_message
                 event_attrs["error_class"] = error_class
                 event_attrs["is_retriable"] = retriable
+                event_attrs["error_fingerprint"] = _compute_error_fingerprint(
+                    info.activity_type or "", error_type, error_class
+                )
+                if stack_trace:
+                    event_attrs["stack_trace"] = stack_trace
                 if cause_chain:
                     event_attrs["error_cause_chain"] = cause_chain
 
@@ -593,6 +709,8 @@ class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
 
             if assets_processed is not None:
                 event_attrs["assets_processed"] = assets_processed
+            if input_payload_bytes is not None:
+                event_attrs["input_payload_bytes"] = input_payload_bytes
 
             _emit_log_event("app_vitals.act.completed", event_attrs)
 

--- a/application_sdk/observability/app_vitals.py
+++ b/application_sdk/observability/app_vitals.py
@@ -13,6 +13,8 @@ Registration order: AFTER ExecutionContextInterceptor and CorrelationContextInte
 
 from __future__ import annotations
 
+import json
+import sys
 import time
 from typing import Any
 
@@ -143,7 +145,37 @@ def _emit_log_event(
     event_name: str,
     attrs: dict[str, Any],
 ) -> None:
-    """Emit a structured log event (Path 1: → otel_logs)."""
+    """Emit a structured log event (Path 1: → otel_logs).
+
+    Also prints a compact JSON summary to stdout so the event is visible
+    in the pod console (kubectl logs) without needing the OTLP pipeline.
+    The Loguru console handler strips extras from its format, so without
+    this print the rich payload would be invisible in pod logs.
+    """
+    # Console visibility — key fields only, one line, greppable prefix.
+    _CONSOLE_KEYS = (
+        "app_name",
+        "tenant_id",
+        "workflow_type",
+        "activity_type",
+        "status",
+        "error_type",
+        "duration_ms",
+        "assets_processed",
+        "workflow_id",
+        "correlation_id",
+    )
+    try:
+        summary = {
+            k: attrs[k]
+            for k in _CONSOLE_KEYS
+            if k in attrs and attrs[k] not in (None, "", [])
+        }
+        sys.stdout.write(f"APP_VITALS | {event_name} | {json.dumps(summary)}\n")
+        sys.stdout.flush()
+    except Exception:
+        pass
+
     try:
         from application_sdk.observability.logger_adaptor import get_logger
 

--- a/application_sdk/observability/app_vitals.py
+++ b/application_sdk/observability/app_vitals.py
@@ -34,17 +34,9 @@ from temporalio.worker import (
     WorkflowOutboundInterceptor,
 )
 
-from application_sdk.constants import (
-    APP_BUILD_ID,
-    APP_RELEASE_CHANNEL,
-    APP_RELEASE_ID,
-    APP_SDK_VERSION,
-    APP_TENANT_ID,
-    APP_TYPE,
-    APP_VERSION_SEMVER,
-    APPLICATION_NAME,
-    DOMAIN_NAME,
-)
+# APPLICATION_NAME imported for test compatibility (tests patch this module attr).
+# Deployment-level identity now flows via build_otel_resource(), not per-event attrs.
+from application_sdk.constants import APP_TENANT_ID, APPLICATION_NAME  # noqa: F401
 from application_sdk.observability.error_classifier import (
     classify_error,
     extract_cause_chain,
@@ -136,11 +128,6 @@ def _extract_assets_processed(result: Any) -> int | None:
     return None
 
 
-def _get_pod_name() -> str:
-    """Get the pod name from K8s-injected env vars."""
-    return os.environ.get("K8S_POD_NAME", os.environ.get("HOSTNAME", ""))
-
-
 def _format_stack_trace(exc: BaseException) -> str:
     """Format a full stack trace, truncated to 2000 chars."""
     try:
@@ -164,24 +151,20 @@ def _compute_error_fingerprint(
 
 
 def _build_common_attrs() -> dict[str, str]:
-    """Build the identity attributes present on every event.
+    """Build the per-event identity attributes.
 
-    Includes trace_id and span_id from the current OTel span context (if a
-    tracer is active). These are empty strings when no tracer is running,
-    which is fine — they become useful the moment the traces pipeline lands.
+    Only workflow/activity-scoped fields live here. Deployment-level attributes
+    (app_name, app_version, release_id, sdk_version, pod_name, domain_name,
+    etc.) are set on the OTel Resource by build_otel_resource() and appear as
+    ResourceAttributes.* in ClickHouse — no need to duplicate in every log row.
+
+    The ``app_vitals: "true"`` flag is a deterministic marker for filtering
+    the materialized view (more reliable than Body LIKE 'app_vitals.%').
     """
     trace_id, span_id = get_trace_context()
     return {
-        "app_name": APPLICATION_NAME,
-        "app_version": APP_VERSION_SEMVER or APP_BUILD_ID or "",
-        "app_build_id": APP_BUILD_ID or "",
-        "release_id": APP_RELEASE_ID,
-        "release_channel": APP_RELEASE_CHANNEL,
-        "sdk_version": APP_SDK_VERSION,
-        "app_type": APP_TYPE,
+        "app_vitals": "true",
         "tenant_id": _get_tenant_id(),
-        "domain_name": DOMAIN_NAME,
-        "pod_name": _get_pod_name(),
         "correlation_id": _get_correlation_id(),
         "trace_id": trace_id,
         "span_id": span_id,
@@ -544,9 +527,10 @@ class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
             except Exception:
                 pass  # summary is best-effort; never block the workflow
 
+            # Metric labels: only workflow-scoped fields. Deployment-level
+            # attributes (app_name, app_version, release_id, etc.) are on the
+            # OTel Resource and exported with every metric point automatically.
             metric_labels = {
-                "app_name": common["app_name"],
-                "app_version": common["app_version"],
                 "tenant_id": common["tenant_id"],
                 "workflow_type": info.workflow_type or "",
                 "task_queue": info.task_queue or "",
@@ -728,9 +712,9 @@ class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
 
             _emit_log_event("app_vitals.act.completed", event_attrs)
 
+            # Metric labels: only activity/workflow-scoped fields. Deployment
+            # attributes live on the OTel Resource.
             metric_labels = {
-                "app_name": common["app_name"],
-                "app_version": common["app_version"],
                 "tenant_id": common["tenant_id"],
                 "workflow_id": info.workflow_id or "",
                 "workflow_run_id": info.workflow_run_id or "",

--- a/application_sdk/observability/app_vitals.py
+++ b/application_sdk/observability/app_vitals.py
@@ -19,6 +19,7 @@ import os
 import sys
 import time
 import traceback
+from datetime import datetime, timezone
 from typing import Any
 
 from temporalio import activity, workflow
@@ -34,7 +35,7 @@ from temporalio.worker import (
     WorkflowOutboundInterceptor,
 )
 
-from application_sdk.constants import APP_TENANT_ID, APPLICATION_NAME
+from application_sdk.constants import APP_TENANT_ID, APPLICATION_NAME  # noqa: F401 — APP_TENANT_ID kept for test patch compat
 from application_sdk.observability.error_classifier import (
     classify_error,
     extract_cause_chain,
@@ -42,31 +43,6 @@ from application_sdk.observability.error_classifier import (
 )
 from application_sdk.observability.resource_sampler import compute_deltas, sample
 from application_sdk.observability.trace_context import get_trace_context
-
-
-def _get_tenant_id() -> str:
-    """Get tenant_id from correlation context (preferred) or env var fallback."""
-    try:
-        from application_sdk.observability.context import correlation_context
-
-        corr_ctx = correlation_context.get()
-        if corr_ctx:
-            tenant_id = corr_ctx.get("atlan-tenant-id", "")
-            if tenant_id:
-                return str(tenant_id)
-    except Exception:
-        pass
-
-    try:
-        from application_sdk.observability.correlation import get_correlation_context
-
-        corr = get_correlation_context()
-        if corr and hasattr(corr, "correlation_id"):
-            pass
-    except Exception:
-        pass
-
-    return APP_TENANT_ID
 
 
 def _get_correlation_id() -> str:
@@ -152,8 +128,10 @@ def _build_common_attrs() -> dict[str, str]:
     """Build the per-event identity attributes.
 
     Deployment-level attributes (app.version, release_id, sdk_version, pod_name,
-    k8s.domain.name, etc.) are set on the OTel Resource by build_otel_resource()
-    and appear as ResourceAttributes.* in ClickHouse — not duplicated here.
+    k8s.domain.name, k8s.cluster.name, etc.) are set on the OTel Resource or
+    injected by the collector and appear as ResourceAttributes.* in ClickHouse
+    — not duplicated here. tenant_id is intentionally omitted because
+    k8s.cluster.name identifies the tenant at the deployment level.
 
     ``app_name`` stays in log attrs (not resource) because a single deployment
     can host multiple apps; app_name is conceptually per-event, not per-pod.
@@ -165,7 +143,6 @@ def _build_common_attrs() -> dict[str, str]:
     return {
         "app_vitals": "true",
         "app_name": APPLICATION_NAME,
-        "tenant_id": _get_tenant_id(),
         "correlation_id": _get_correlation_id(),
         "trace_id": trace_id,
         "span_id": span_id,
@@ -186,7 +163,6 @@ def _emit_log_event(
     # Console visibility — key fields only, one line, greppable prefix.
     _CONSOLE_KEYS = (
         "app_name",
-        "tenant_id",
         "workflow_type",
         "activity_type",
         "status",
@@ -532,7 +508,6 @@ class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
             # attributes (app_name, app_version, release_id, etc.) are on the
             # OTel Resource and exported with every metric point automatically.
             metric_labels = {
-                "tenant_id": common["tenant_id"],
                 "workflow_type": info.workflow_type or "",
                 "task_queue": info.task_queue or "",
                 "status": status,
@@ -596,6 +571,9 @@ class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
         try:
             started_common = _build_common_attrs()
             retry_policy = getattr(info, "retry_policy", None)
+            activity_start_time_iso = (
+                info.started_time.isoformat() if info.started_time else ""
+            )
             started_attrs: dict[str, Any] = {
                 **started_common,
                 "workflow_id": info.workflow_id or "",
@@ -607,6 +585,7 @@ class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
                 "retry_max_attempts": (
                     retry_policy.maximum_attempts if retry_policy else 0
                 ),
+                "activity_start_time": activity_start_time_iso,
                 "dimension": "reliability",
                 "source": "temporal",
                 "metric_name": "app_vitals.reliability.activity_started",
@@ -665,6 +644,10 @@ class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
             common = _build_common_attrs()
 
             retry_policy = getattr(info, "retry_policy", None)
+            activity_start_time_iso = (
+                info.started_time.isoformat() if info.started_time else ""
+            )
+            activity_end_time_iso = datetime.now(timezone.utc).isoformat()
             event_attrs: dict[str, Any] = {
                 **common,
                 "workflow_id": info.workflow_id or "",
@@ -676,6 +659,8 @@ class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
                 "retry_max_attempts": (
                     retry_policy.maximum_attempts if retry_policy else 0
                 ),
+                "activity_start_time": activity_start_time_iso,
+                "activity_end_time": activity_end_time_iso,
                 "namespace": getattr(info, "namespace", ""),
                 "status": status,
                 "error_type": error_type,
@@ -716,7 +701,6 @@ class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
             # Metric labels: only activity/workflow-scoped fields. Deployment
             # attributes live on the OTel Resource.
             metric_labels = {
-                "tenant_id": common["tenant_id"],
                 "workflow_id": info.workflow_id or "",
                 "workflow_run_id": info.workflow_run_id or "",
                 "workflow_type": getattr(info, "workflow_type", ""),

--- a/application_sdk/observability/app_vitals.py
+++ b/application_sdk/observability/app_vitals.py
@@ -1,0 +1,670 @@
+"""App Vitals interceptor — automatic lifecycle metrics for workflows and activities.
+
+Emits two paths on every workflow/activity completion:
+  Path 1: Structured log event via AtlanLoggerAdapter (→ otel_logs in ClickHouse)
+  Path 2: OTel metric via AtlanMetricsAdapter (counter + gauge for dashboards)
+
+Both paths carry the full execution context: app_name, tenant_id, workflow_id,
+activity_id, status, error_type, duration_ms, etc.
+
+Registration order: AFTER ExecutionContextInterceptor and CorrelationContextInterceptor
+(reads from both ContextVars).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from temporalio import activity, workflow
+from temporalio.worker import (
+    ActivityInboundInterceptor,
+    ExecuteActivityInput,
+    ExecuteWorkflowInput,
+    Interceptor,
+    StartActivityInput,
+    StartChildWorkflowInput,
+    WorkflowInboundInterceptor,
+    WorkflowInterceptorClassInput,
+    WorkflowOutboundInterceptor,
+)
+
+from application_sdk.constants import APP_BUILD_ID, APP_TENANT_ID, APPLICATION_NAME
+from application_sdk.observability.error_classifier import (
+    classify_error,
+    extract_cause_chain,
+    is_retriable,
+)
+from application_sdk.observability.resource_sampler import compute_deltas, sample
+from application_sdk.observability.trace_context import get_trace_context
+
+
+def _get_tenant_id() -> str:
+    """Get tenant_id from correlation context (preferred) or env var fallback."""
+    try:
+        from application_sdk.observability.context import correlation_context
+
+        corr_ctx = correlation_context.get()
+        if corr_ctx:
+            tenant_id = corr_ctx.get("atlan-tenant-id", "")
+            if tenant_id:
+                return str(tenant_id)
+    except Exception:
+        pass
+
+    try:
+        from application_sdk.observability.correlation import get_correlation_context
+
+        corr = get_correlation_context()
+        if corr and hasattr(corr, "correlation_id"):
+            pass
+    except Exception:
+        pass
+
+    return APP_TENANT_ID
+
+
+def _get_correlation_id() -> str:
+    """Get correlation_id from the v3 CorrelationContext ContextVar."""
+    try:
+        from application_sdk.observability.correlation import get_correlation_context
+
+        ctx = get_correlation_context()
+        if ctx and ctx.correlation_id:
+            return ctx.correlation_id
+    except Exception:
+        pass
+    return ""
+
+
+def _extract_assets_processed(result: Any) -> int | None:
+    """Extract the assets_processed count from an activity return value.
+
+    Convention (RFC DESIGN.md §4.1 — universal throughput denominator):
+    apps can expose their "unit of value" as one of these attribute names
+    on the return value:
+        - ``assets_processed`` (explicit, preferred)
+        - ``total_record_count`` (used by SqlMetadataExtractor subclasses)
+        - ``record_count`` / ``records_processed`` (alternate conventions)
+
+    Returns None if no recognised attribute is present or the value isn't
+    a positive integer-like. No exceptions are raised — extraction is
+    best-effort.
+    """
+    if result is None:
+        return None
+
+    candidates = (
+        "assets_processed",
+        "total_record_count",
+        "record_count",
+        "records_processed",
+    )
+    for name in candidates:
+        value = None
+        # Attribute access (Pydantic models, dataclasses, etc.)
+        if hasattr(result, name):
+            value = getattr(result, name, None)
+        # Dict-like access
+        elif isinstance(result, dict) and name in result:
+            value = result[name]
+
+        if value is None:
+            continue
+        try:
+            n = int(value)
+            if n >= 0:
+                return n
+        except (TypeError, ValueError):
+            continue
+
+    return None
+
+
+def _build_common_attrs() -> dict[str, str]:
+    """Build the identity attributes present on every event.
+
+    Includes trace_id and span_id from the current OTel span context (if a
+    tracer is active). These are empty strings when no tracer is running,
+    which is fine — they become useful the moment the traces pipeline lands.
+    """
+    trace_id, span_id = get_trace_context()
+    return {
+        "app_name": APPLICATION_NAME,
+        "app_version": APP_BUILD_ID or "",
+        "tenant_id": _get_tenant_id(),
+        "correlation_id": _get_correlation_id(),
+        "trace_id": trace_id,
+        "span_id": span_id,
+    }
+
+
+def _emit_log_event(
+    event_name: str,
+    attrs: dict[str, Any],
+) -> None:
+    """Emit a structured log event (Path 1: → otel_logs)."""
+    try:
+        from application_sdk.observability.logger_adaptor import get_logger
+
+        logger = get_logger("app_vitals")
+        level = "error" if attrs.get("status") == "failed" else "info"
+        getattr(logger, level)(event_name, **attrs)
+    except Exception:
+        pass
+
+
+def _emit_metric(
+    name: str,
+    value: float,
+    metric_type_str: str,
+    labels: dict[str, str],
+    unit: str | None = None,
+) -> None:
+    """Emit an OTel metric (Path 2: → metrics pipeline).
+
+    Always passes a non-None description and unit because OTel's
+    ``MeterProvider._register_instrument`` constructs an instrument key as
+    ``",".join([name, type, unit, description])`` which raises ``TypeError``
+    if any element is ``None``.
+    """
+    try:
+        from application_sdk.observability.metrics_adaptor import get_metrics
+        from application_sdk.observability.models import MetricType
+
+        type_map = {
+            "counter": MetricType.COUNTER,
+            "gauge": MetricType.GAUGE,
+            "histogram": MetricType.HISTOGRAM,
+        }
+        get_metrics().record_metric(
+            name=name,
+            value=value,
+            metric_type=type_map[metric_type_str],
+            labels=labels,
+            description="App Vitals signal",
+            unit=unit or "1",
+        )
+    except Exception:
+        pass
+
+
+class _AppVitalsWorkflowOutboundInterceptor(WorkflowOutboundInterceptor):
+    """Tracks each activity/child-workflow call so the inbound interceptor
+    can emit a workflow summary on completion (L1).
+
+    Activities can run concurrently (asyncio.gather); each call gets its own
+    record appended to the list. The list lives on the paired inbound
+    interceptor so its lifetime matches the workflow execution.
+    """
+
+    def __init__(
+        self,
+        next_: WorkflowOutboundInterceptor,
+        inbound: _AppVitalsWorkflowInboundInterceptor,
+    ) -> None:
+        super().__init__(next_)
+        self._inbound = inbound
+
+    def start_activity(self, input: StartActivityInput) -> Any:
+        record: dict[str, Any] = {
+            "activity_type": input.activity,
+            "start_ns": time.monotonic_ns(),
+            "status": "pending",
+        }
+        self._inbound._activity_records.append(record)
+        awaitable = self.next.start_activity(input)
+        return _track_activity_completion(record, awaitable)
+
+    async def start_child_workflow(self, input: StartChildWorkflowInput) -> Any:
+        # Child workflows: track start/complete but don't deeply inspect
+        record: dict[str, Any] = {
+            "child_workflow_type": input.workflow,
+            "start_ns": time.monotonic_ns(),
+            "status": "pending",
+        }
+        self._inbound._child_workflow_records.append(record)
+        try:
+            handle = await self.next.start_child_workflow(input)
+            record["status"] = "started"
+            return handle
+        except Exception as exc:
+            record["status"] = "failed"
+            record["error_type"] = classify_error(exc)
+            record["end_ns"] = time.monotonic_ns()
+            raise
+
+
+async def _track_activity_completion(record: dict[str, Any], awaitable: Any) -> Any:
+    """Await the activity and capture its outcome into the record.
+
+    Must use monotonic_ns (not workflow.time) so it works identically in both
+    workflow and any test contexts. Temporal's sandbox allows time.monotonic_ns.
+    """
+    try:
+        result = await awaitable
+        record["status"] = "succeeded"
+        record["end_ns"] = time.monotonic_ns()
+        record["duration_ms"] = round(
+            (record["end_ns"] - record["start_ns"]) / 1_000_000, 1
+        )
+        return result
+    except Exception as exc:
+        record["status"] = "failed"
+        record["error_type"] = classify_error(exc)
+        record["error_class"] = type(exc).__name__
+        record["end_ns"] = time.monotonic_ns()
+        record["duration_ms"] = round(
+            (record["end_ns"] - record["start_ns"]) / 1_000_000, 1
+        )
+        raise
+
+
+class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
+    """Emits lifecycle events on workflow start AND completion, plus a
+    summary event that rolls up all activities seen during the workflow."""
+
+    def __init__(self, next_: WorkflowInboundInterceptor) -> None:
+        super().__init__(next_)
+        self._activity_records: list[dict[str, Any]] = []
+        self._child_workflow_records: list[dict[str, Any]] = []
+
+    def init(self, outbound: WorkflowOutboundInterceptor) -> None:
+        # Wrap the outbound chain so we can track each start_activity call.
+        super().init(_AppVitalsWorkflowOutboundInterceptor(outbound, self))
+
+    def _build_summary_attrs(
+        self,
+        common: dict[str, Any],
+        info: Any,
+        wf_status: str,
+        wf_duration_ms: float,
+    ) -> dict[str, Any]:
+        """Compute aggregate stats from the tracked activity records."""
+        acts = self._activity_records
+        succeeded = [a for a in acts if a.get("status") == "succeeded"]
+        failed = [a for a in acts if a.get("status") == "failed"]
+
+        first_failure: dict[str, Any] | None = None
+        if failed:
+            # "first" by start time — earliest failure in wall-clock order
+            first_failure = min(failed, key=lambda a: a.get("start_ns", 0))
+
+        bottleneck: dict[str, Any] | None = None
+        acts_with_duration = [a for a in acts if a.get("duration_ms") is not None]
+        if acts_with_duration:
+            bottleneck = max(acts_with_duration, key=lambda a: a["duration_ms"])
+
+        summary: dict[str, Any] = {
+            **common,
+            "workflow_id": info.workflow_id or "",
+            "workflow_run_id": info.run_id or "",
+            "workflow_type": info.workflow_type or "",
+            "task_queue": info.task_queue or "",
+            "namespace": info.namespace or "",
+            "status": wf_status,
+            "duration_ms": round(wf_duration_ms, 1),
+            "total_activities": len(acts),
+            "succeeded_activities": len(succeeded),
+            "failed_activities": len(failed),
+            "total_child_workflows": len(self._child_workflow_records),
+            "dimension": "reliability",
+            "source": "temporal",
+            "metric_name": "app_vitals.reliability.wf_summary",
+        }
+        if first_failure is not None:
+            summary["first_failure_activity_type"] = first_failure.get(
+                "activity_type", ""
+            )
+            summary["first_failure_error_type"] = first_failure.get("error_type", "")
+        if bottleneck is not None:
+            summary["bottleneck_activity_type"] = bottleneck.get("activity_type", "")
+            summary["bottleneck_duration_ms"] = bottleneck["duration_ms"]
+        return summary
+
+    async def execute_workflow(self, input: ExecuteWorkflowInput) -> Any:
+        start_ns = time.monotonic_ns()
+
+        # Emit wf.started event (L2) — enables "currently running" views that
+        # otherwise have to wait for completion to see any signal.
+        try:
+            info = workflow.info()
+            common = _build_common_attrs()
+            started_attrs: dict[str, Any] = {
+                **common,
+                "workflow_id": info.workflow_id or "",
+                "workflow_run_id": info.run_id or "",
+                "workflow_type": info.workflow_type or "",
+                "task_queue": info.task_queue or "",
+                "namespace": info.namespace or "",
+                "dimension": "reliability",
+                "source": "temporal",
+                "metric_name": "app_vitals.reliability.wf_started",
+            }
+            _emit_log_event("app_vitals.wf.started", started_attrs)
+        except Exception:
+            pass  # never block workflow on observability
+
+        status = "succeeded"
+        error_type = ""
+        error_message = ""
+        error_class = ""
+        cause_chain: list[str] = []
+        retriable = False
+
+        try:
+            result = await self.next.execute_workflow(input)
+            return result
+        except Exception as exc:
+            status = "failed"
+            error_type = classify_error(exc)
+            error_message = str(exc)[:500]
+            error_class = type(exc).__name__
+            cause_chain = extract_cause_chain(exc)
+            retriable = is_retriable(exc, error_type)
+            raise
+        finally:
+            duration_ms = (time.monotonic_ns() - start_ns) / 1_000_000
+
+            try:
+                info = workflow.info()
+            except Exception:
+                return
+
+            common = _build_common_attrs()
+
+            event_attrs: dict[str, Any] = {
+                **common,
+                "workflow_id": info.workflow_id or "",
+                "workflow_run_id": info.run_id or "",
+                "workflow_type": info.workflow_type or "",
+                "task_queue": info.task_queue or "",
+                "namespace": info.namespace or "",
+                "status": status,
+                "error_type": error_type,
+                "duration_ms": round(duration_ms, 1),
+                "dimension": "reliability",
+                "source": "temporal",
+                "metric_name": "app_vitals.reliability.wf_completed",
+            }
+            if error_message:
+                event_attrs["error_message"] = error_message
+                event_attrs["error_class"] = error_class
+                event_attrs["is_retriable"] = retriable
+                if cause_chain:
+                    event_attrs["error_cause_chain"] = cause_chain
+
+            _emit_log_event("app_vitals.wf.completed", event_attrs)
+
+            # Workflow summary event (L1) — rolls up all activities observed
+            # during this workflow execution. One row per workflow run with the
+            # full shape of the pipeline: counts, first failure, bottleneck.
+            # Does NOT replace per-activity events — they are still the source
+            # of truth (RFC D2). This is a query-time convenience.
+            try:
+                summary_attrs = self._build_summary_attrs(
+                    common, info, status, duration_ms
+                )
+                _emit_log_event("app_vitals.wf.summary", summary_attrs)
+            except Exception:
+                pass  # summary is best-effort; never block the workflow
+
+            metric_labels = {
+                "app_name": common["app_name"],
+                "app_version": common["app_version"],
+                "tenant_id": common["tenant_id"],
+                "workflow_type": info.workflow_type or "",
+                "task_queue": info.task_queue or "",
+                "status": status,
+                "error_type": error_type,
+                "workflow_id": info.workflow_id or "",
+                "workflow_run_id": info.run_id or "",
+                "namespace": info.namespace or "",
+                "correlation_id": common["correlation_id"],
+            }
+
+            _emit_metric(
+                "app_vitals.reliability.wf_completed",
+                1.0,
+                "counter",
+                metric_labels,
+                unit="1",
+            )
+
+            # Histogram — durations need percentile aggregation (p50/p95/p99).
+            # GAUGE here would hit create_observable_gauge() which doesn't support
+            # direct .add()/.record() and silently drops data via the adapter's
+            # exception handler.
+            _emit_metric(
+                "app_vitals.performance.wf_runtime",
+                duration_ms,
+                "histogram",
+                metric_labels,
+                unit="ms",
+            )
+
+
+class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):
+    """Emits lifecycle events on activity start AND completion."""
+
+    async def execute_activity(self, input: ExecuteActivityInput) -> Any:
+        start_ns = time.monotonic_ns()
+        start_resource = sample()
+
+        try:
+            info = activity.info()
+        except Exception:
+            return await self.next.execute_activity(input)
+
+        schedule_to_start_ms: float | None = None
+        if info.started_time and info.scheduled_time:
+            delta = info.started_time - info.scheduled_time
+            schedule_to_start_ms = delta.total_seconds() * 1000
+
+        # Emit act.started event (L2) — enables "currently running" dashboards
+        # without waiting for completion. Carries full context for drill-down.
+        try:
+            started_common = _build_common_attrs()
+            started_attrs: dict[str, Any] = {
+                **started_common,
+                "workflow_id": info.workflow_id or "",
+                "workflow_run_id": info.workflow_run_id or "",
+                "activity_id": info.activity_id or "",
+                "activity_type": info.activity_type or "",
+                "task_queue": info.task_queue or "",
+                "attempt": info.attempt,
+                "dimension": "reliability",
+                "source": "temporal",
+                "metric_name": "app_vitals.reliability.activity_started",
+            }
+            if schedule_to_start_ms is not None:
+                started_attrs["schedule_to_start_ms"] = round(schedule_to_start_ms, 1)
+            _emit_log_event("app_vitals.act.started", started_attrs)
+        except Exception:
+            pass  # never block activity on observability
+
+        status = "succeeded"
+        error_type = ""
+        error_message = ""
+        error_class = ""
+        cause_chain: list[str] = []
+        retriable = False
+        assets_processed: int | None = None
+
+        try:
+            result = await self.next.execute_activity(input)
+            assets_processed = _extract_assets_processed(result)
+            return result
+        except Exception as exc:
+            status = "failed"
+            error_type = classify_error(exc)
+            error_message = str(exc)[:500]
+            error_class = type(exc).__name__
+            cause_chain = extract_cause_chain(exc)
+            retriable = is_retriable(exc, error_type)
+            raise
+        finally:
+            duration_ms = (time.monotonic_ns() - start_ns) / 1_000_000
+            end_resource = sample()
+            cpu_seconds, mem_gb_sec = compute_deltas(
+                start_resource, end_resource, duration_ms / 1000.0
+            )
+
+            # Timeout budget: compare wall-clock duration against the activity's
+            # configured timeout. Prefer schedule_to_close (total budget); fall
+            # back to start_to_close if that's the only one configured.
+            timeout_budget_total_ms: float | None = None
+            timeout_budget_used_pct: float | None = None
+            effective_timeout = info.schedule_to_close_timeout or getattr(
+                info, "start_to_close_timeout", None
+            )
+            if effective_timeout is not None:
+                total_ms = effective_timeout.total_seconds() * 1000
+                timeout_budget_total_ms = total_ms
+                if total_ms > 0:
+                    timeout_budget_used_pct = round((duration_ms / total_ms) * 100, 2)
+
+            common = _build_common_attrs()
+
+            event_attrs: dict[str, Any] = {
+                **common,
+                "workflow_id": info.workflow_id or "",
+                "workflow_run_id": info.workflow_run_id or "",
+                "activity_id": info.activity_id or "",
+                "activity_type": info.activity_type or "",
+                "task_queue": info.task_queue or "",
+                "attempt": info.attempt,
+                "namespace": getattr(info, "namespace", ""),
+                "status": status,
+                "error_type": error_type,
+                "duration_ms": round(duration_ms, 1),
+                "dimension": "reliability",
+                "source": "temporal",
+                "metric_name": "app_vitals.reliability.activity_completed",
+            }
+            if error_message:
+                event_attrs["error_message"] = error_message
+                event_attrs["error_class"] = error_class
+                event_attrs["is_retriable"] = retriable
+                if cause_chain:
+                    event_attrs["error_cause_chain"] = cause_chain
+
+            if timeout_budget_total_ms is not None:
+                event_attrs["timeout_budget_total_ms"] = round(
+                    timeout_budget_total_ms, 1
+                )
+                event_attrs["timeout_budget_used_pct"] = timeout_budget_used_pct
+
+            if start_resource is not None and end_resource is not None:
+                event_attrs["cpu_seconds"] = round(cpu_seconds, 4)
+                event_attrs["mem_gb_sec"] = round(mem_gb_sec, 4)
+
+            if assets_processed is not None:
+                event_attrs["assets_processed"] = assets_processed
+
+            _emit_log_event("app_vitals.act.completed", event_attrs)
+
+            metric_labels = {
+                "app_name": common["app_name"],
+                "app_version": common["app_version"],
+                "tenant_id": common["tenant_id"],
+                "workflow_id": info.workflow_id or "",
+                "workflow_run_id": info.workflow_run_id or "",
+                "workflow_type": getattr(info, "workflow_type", ""),
+                "activity_type": info.activity_type or "",
+                "activity_id": info.activity_id or "",
+                "task_queue": info.task_queue or "",
+                "attempt": str(info.attempt),
+                "namespace": getattr(info, "namespace", ""),
+                "status": status,
+                "error_type": error_type,
+                "correlation_id": common["correlation_id"],
+            }
+
+            _emit_metric(
+                "app_vitals.reliability.activity_completed",
+                1.0,
+                "counter",
+                metric_labels,
+                unit="1",
+            )
+
+            # Histogram — durations need p50/p95/p99; GAUGE silently fails
+            # (see wf_runtime comment above).
+            _emit_metric(
+                "app_vitals.performance.activity_runtime",
+                duration_ms,
+                "histogram",
+                metric_labels,
+                unit="ms",
+            )
+
+            if schedule_to_start_ms is not None:
+                _emit_metric(
+                    "app_vitals.performance.activity_schedule_to_start",
+                    schedule_to_start_ms,
+                    "histogram",
+                    metric_labels,
+                    unit="ms",
+                )
+
+            if info.attempt > 1:
+                _emit_metric(
+                    "app_vitals.reliability.activity_retries",
+                    float(info.attempt - 1),
+                    "counter",
+                    metric_labels,
+                    unit="1",
+                )
+
+            # Efficiency signals — RFC DESIGN.md §4.1 #10 and #11.
+            # Process-level samples via psutil; see resource_sampler.py for scope limits.
+            if start_resource is not None and end_resource is not None:
+                _emit_metric(
+                    "app_vitals.efficiency.activity_cpu_seconds",
+                    cpu_seconds,
+                    "counter",
+                    metric_labels,
+                    unit="s",
+                )
+                _emit_metric(
+                    "app_vitals.efficiency.activity_mem_gb_sec",
+                    mem_gb_sec,
+                    "counter",
+                    metric_labels,
+                    unit="GiB.s",
+                )
+
+            # Throughput: assets_processed (L9) — universal denominator for
+            # cost-per-asset and efficiency comparisons across apps.
+            if assets_processed is not None:
+                _emit_metric(
+                    "app_vitals.performance.activity_assets_processed",
+                    float(assets_processed),
+                    "counter",
+                    metric_labels,
+                    unit="{assets}",
+                )
+
+
+class AppVitalsInterceptor(Interceptor):
+    """Temporal interceptor that emits App Vitals lifecycle metrics.
+
+    Emits on every workflow/activity completion:
+      - Structured log event (Path 1) with full execution context
+      - OTel metric (Path 2) for counters, gauges, histograms
+
+    Registration order: AFTER ExecutionContextInterceptor and
+    CorrelationContextInterceptor so that ContextVars are populated.
+    """
+
+    def workflow_interceptor_class(
+        self,
+        input: WorkflowInterceptorClassInput,  # noqa: ARG002
+    ) -> type[WorkflowInboundInterceptor] | None:
+        return _AppVitalsWorkflowInboundInterceptor
+
+    def intercept_activity(
+        self, next: ActivityInboundInterceptor
+    ) -> ActivityInboundInterceptor:
+        return _AppVitalsActivityInboundInterceptor(next)

--- a/application_sdk/observability/app_vitals.py
+++ b/application_sdk/observability/app_vitals.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import sys
 import time
 import traceback
@@ -35,7 +34,7 @@ from temporalio.worker import (
     WorkflowOutboundInterceptor,
 )
 
-from application_sdk.constants import APP_TENANT_ID, APPLICATION_NAME  # noqa: F401 — APP_TENANT_ID kept for test patch compat
+from application_sdk.constants import APPLICATION_NAME
 from application_sdk.observability.error_classifier import (
     classify_error,
     extract_cause_chain,
@@ -184,6 +183,8 @@ def _emit_log_event(
         pass
 
     try:
+        # Deferred import: logger_adaptor may not be initialized yet during early
+        # workflow lifecycle events (interceptor runs before full app setup).
         from application_sdk.observability.logger_adaptor import get_logger
 
         logger = get_logger("app_vitals")
@@ -394,80 +395,104 @@ class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
             try:
                 info = workflow.info()
             except Exception:
-                return
+                info = None
 
-            common = _build_common_attrs()
-
-            # Workflow-level timeout budget — same pattern as activity timeout
-            wf_timeout_budget_total_ms: float | None = None
-            wf_timeout_budget_used_pct: float | None = None
-            execution_timeout = getattr(info, "execution_timeout", None)
-            if execution_timeout is not None:
-                total_ms = execution_timeout.total_seconds() * 1000
-                wf_timeout_budget_total_ms = total_ms
-                if total_ms > 0:
-                    wf_timeout_budget_used_pct = round(
-                        (duration_ms / total_ms) * 100, 2
-                    )
-
-            # History length — proxy for workflow complexity / CaN pressure
-            history_length: int | None = None
-            try:
-                history_length = info.get_current_history_length()
-            except Exception:
-                pass
-
-            event_attrs: dict[str, Any] = {
-                **common,
-                "workflow_id": info.workflow_id or "",
-                "workflow_run_id": info.run_id or "",
-                "workflow_type": info.workflow_type or "",
-                "task_queue": info.task_queue or "",
-                "namespace": info.namespace or "",
-                "parent_workflow_id": info.parent.workflow_id if info.parent else "",
-                "parent_run_id": info.parent.run_id if info.parent else "",
-                "continued_run_id": info.continued_run_id or "",
-                "cron_schedule": info.cron_schedule or "",
-                "status": status,
-                "error_type": error_type,
-                "duration_ms": round(duration_ms, 1),
-                "dimension": "reliability",
-                "source": "temporal",
-                "metric_name": "app_vitals.reliability.wf_completed",
-            }
-            if wf_timeout_budget_total_ms is not None:
-                event_attrs["wf_timeout_budget_total_ms"] = round(
-                    wf_timeout_budget_total_ms, 1
+            # Guard: skip event emission if workflow info unavailable.
+            # MUST NOT use `return` in finally — that would swallow exceptions.
+            if info is not None:
+                self._emit_completion_events(
+                    info,
+                    status,
+                    duration_ms,
+                    error_type,
+                    error_message,
+                    error_class,
+                    cause_chain,
+                    retriable,
+                    stack_trace,
                 )
-                event_attrs["wf_timeout_budget_used_pct"] = wf_timeout_budget_used_pct
-            if history_length is not None:
-                event_attrs["history_length"] = history_length
-            if error_message:
-                event_attrs["error_message"] = error_message
-                event_attrs["error_class"] = error_class
-                event_attrs["is_retriable"] = retriable
-                event_attrs["error_fingerprint"] = _compute_error_fingerprint(
-                    info.workflow_type or "", error_type, error_class
-                )
-                if stack_trace:
-                    event_attrs["stack_trace"] = stack_trace
-                if cause_chain:
-                    event_attrs["error_cause_chain"] = cause_chain
 
-            _emit_log_event("app_vitals.wf.completed", event_attrs)
+    def _emit_completion_events(
+        self,
+        info: Any,
+        status: str,
+        duration_ms: float,
+        error_type: str,
+        error_message: str,
+        error_class: str,
+        cause_chain: list[str],
+        retriable: bool,
+        stack_trace: str,
+    ) -> None:
+        """Emit workflow completed + summary events. Extracted to avoid return-in-finally."""
+        common = _build_common_attrs()
 
-            # Workflow summary event (L1) — rolls up all activities observed
-            # during this workflow execution. One row per workflow run with the
-            # full shape of the pipeline: counts, first failure, bottleneck.
-            # Does NOT replace per-activity events — they are still the source
-            # of truth (RFC D2). This is a query-time convenience.
-            try:
-                summary_attrs = self._build_summary_attrs(
-                    common, info, status, duration_ms
-                )
-                _emit_log_event("app_vitals.wf.summary", summary_attrs)
-            except Exception:
-                pass  # summary is best-effort; never block the workflow
+        # Workflow-level timeout budget — same pattern as activity timeout
+        wf_timeout_budget_total_ms: float | None = None
+        wf_timeout_budget_used_pct: float | None = None
+        execution_timeout = getattr(info, "execution_timeout", None)
+        if execution_timeout is not None:
+            total_ms = execution_timeout.total_seconds() * 1000
+            wf_timeout_budget_total_ms = total_ms
+            if total_ms > 0:
+                wf_timeout_budget_used_pct = round((duration_ms / total_ms) * 100, 2)
+
+        # History length — proxy for workflow complexity / CaN pressure
+        history_length: int | None = None
+        try:
+            history_length = info.get_current_history_length()
+        except Exception:
+            pass
+
+        event_attrs: dict[str, Any] = {
+            **common,
+            "workflow_id": info.workflow_id or "",
+            "workflow_run_id": info.run_id or "",
+            "workflow_type": info.workflow_type or "",
+            "task_queue": info.task_queue or "",
+            "namespace": info.namespace or "",
+            "parent_workflow_id": info.parent.workflow_id if info.parent else "",
+            "parent_run_id": info.parent.run_id if info.parent else "",
+            "continued_run_id": info.continued_run_id or "",
+            "cron_schedule": info.cron_schedule or "",
+            "status": status,
+            "error_type": error_type,
+            "duration_ms": round(duration_ms, 1),
+            "dimension": "reliability",
+            "source": "temporal",
+            "metric_name": "app_vitals.reliability.wf_completed",
+        }
+        if wf_timeout_budget_total_ms is not None:
+            event_attrs["wf_timeout_budget_total_ms"] = round(
+                wf_timeout_budget_total_ms, 1
+            )
+            event_attrs["wf_timeout_budget_used_pct"] = wf_timeout_budget_used_pct
+        if history_length is not None:
+            event_attrs["history_length"] = history_length
+        if error_message:
+            event_attrs["error_message"] = error_message
+            event_attrs["error_class"] = error_class
+            event_attrs["is_retriable"] = retriable
+            event_attrs["error_fingerprint"] = _compute_error_fingerprint(
+                info.workflow_type or "", error_type, error_class
+            )
+            if stack_trace:
+                event_attrs["stack_trace"] = stack_trace
+            if cause_chain:
+                event_attrs["error_cause_chain"] = cause_chain
+
+        _emit_log_event("app_vitals.wf.completed", event_attrs)
+
+        # Workflow summary event (L1) — rolls up all activities observed
+        # during this workflow execution. One row per workflow run with the
+        # full shape of the pipeline: counts, first failure, bottleneck.
+        # Does NOT replace per-activity events — they are still the source
+        # of truth (RFC D2). This is a query-time convenience.
+        try:
+            summary_attrs = self._build_summary_attrs(common, info, status, duration_ms)
+            _emit_log_event("app_vitals.wf.summary", summary_attrs)
+        except Exception:
+            pass  # summary is best-effort; never block the workflow
 
 
 class _AppVitalsActivityInboundInterceptor(ActivityInboundInterceptor):

--- a/application_sdk/observability/app_vitals.py
+++ b/application_sdk/observability/app_vitals.py
@@ -95,15 +95,15 @@ def _get_correlation_id() -> str:
 def _extract_assets_processed(result: Any) -> int | None:
     """Extract the assets_processed count from an activity return value.
 
-    Convention (RFC DESIGN.md §4.1 — universal throughput denominator):
+    Convention (RFC DESIGN.md §4.1 - universal throughput denominator):
     apps can expose their "unit of value" as one of these attribute names
-    on the return value:
-        - ``assets_processed`` (explicit, preferred)
-        - ``total_record_count`` (used by SqlMetadataExtractor subclasses)
-        - ``record_count`` / ``records_processed`` (alternate conventions)
+    on the return value. Recognised names checked in order:
+    ``assets_processed`` (explicit, preferred),
+    ``total_record_count`` (SqlMetadataExtractor subclasses),
+    ``record_count``, ``records_processed`` (alternate conventions).
 
     Returns None if no recognised attribute is present or the value isn't
-    a positive integer-like. No exceptions are raised — extraction is
+    a positive integer-like. No exceptions are raised - extraction is
     best-effort.
     """
     if result is None:

--- a/application_sdk/observability/app_vitals.py
+++ b/application_sdk/observability/app_vitals.py
@@ -36,7 +36,12 @@ from temporalio.worker import (
 
 from application_sdk.constants import (
     APP_BUILD_ID,
+    APP_RELEASE_CHANNEL,
+    APP_RELEASE_ID,
+    APP_SDK_VERSION,
     APP_TENANT_ID,
+    APP_TYPE,
+    APP_VERSION_SEMVER,
     APPLICATION_NAME,
     DOMAIN_NAME,
 )
@@ -168,7 +173,12 @@ def _build_common_attrs() -> dict[str, str]:
     trace_id, span_id = get_trace_context()
     return {
         "app_name": APPLICATION_NAME,
-        "app_version": APP_BUILD_ID or "",
+        "app_version": APP_VERSION_SEMVER or APP_BUILD_ID or "",
+        "app_build_id": APP_BUILD_ID or "",
+        "release_id": APP_RELEASE_ID,
+        "release_channel": APP_RELEASE_CHANNEL,
+        "sdk_version": APP_SDK_VERSION,
+        "app_type": APP_TYPE,
         "tenant_id": _get_tenant_id(),
         "domain_name": DOMAIN_NAME,
         "pod_name": _get_pod_name(),

--- a/application_sdk/observability/app_vitals.py
+++ b/application_sdk/observability/app_vitals.py
@@ -148,6 +148,20 @@ def _build_common_attrs() -> dict[str, str]:
     }
 
 
+def _build_workflow_identity_attrs(info: Any) -> dict[str, Any]:
+    """Extract workflow identity attributes from a Temporal WorkflowInfo object."""
+    return {
+        "workflow_id": info.workflow_id or "",
+        "workflow_run_id": info.run_id or "",
+        "workflow_type": info.workflow_type or "",
+        "task_queue": info.task_queue or "",
+        "namespace": info.namespace or "",
+        "parent_workflow_id": info.parent.workflow_id if info.parent else "",
+        "parent_run_id": info.parent.run_id if info.parent else "",
+        "continued_run_id": info.continued_run_id or "",
+    }
+
+
 def _emit_log_event(
     event_name: str,
     attrs: dict[str, Any],
@@ -308,14 +322,7 @@ class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
 
         summary: dict[str, Any] = {
             **common,
-            "workflow_id": info.workflow_id or "",
-            "workflow_run_id": info.run_id or "",
-            "workflow_type": info.workflow_type or "",
-            "task_queue": info.task_queue or "",
-            "namespace": info.namespace or "",
-            "parent_workflow_id": info.parent.workflow_id if info.parent else "",
-            "parent_run_id": info.parent.run_id if info.parent else "",
-            "continued_run_id": info.continued_run_id or "",
+            **_build_workflow_identity_attrs(info),
             "status": wf_status,
             "duration_ms": round(wf_duration_ms, 1),
             "total_activities": len(acts),
@@ -352,14 +359,7 @@ class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
             common = _build_common_attrs()
             started_attrs: dict[str, Any] = {
                 **common,
-                "workflow_id": info.workflow_id or "",
-                "workflow_run_id": info.run_id or "",
-                "workflow_type": info.workflow_type or "",
-                "task_queue": info.task_queue or "",
-                "namespace": info.namespace or "",
-                "parent_workflow_id": info.parent.workflow_id if info.parent else "",
-                "parent_run_id": info.parent.run_id if info.parent else "",
-                "continued_run_id": info.continued_run_id or "",
+                **_build_workflow_identity_attrs(info),
                 "cron_schedule": info.cron_schedule or "",
                 "dimension": "reliability",
                 "source": "temporal",
@@ -446,14 +446,7 @@ class _AppVitalsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
 
         event_attrs: dict[str, Any] = {
             **common,
-            "workflow_id": info.workflow_id or "",
-            "workflow_run_id": info.run_id or "",
-            "workflow_type": info.workflow_type or "",
-            "task_queue": info.task_queue or "",
-            "namespace": info.namespace or "",
-            "parent_workflow_id": info.parent.workflow_id if info.parent else "",
-            "parent_run_id": info.parent.run_id if info.parent else "",
-            "continued_run_id": info.continued_run_id or "",
+            **_build_workflow_identity_attrs(info),
             "cron_schedule": info.cron_schedule or "",
             "status": status,
             "error_type": error_type,

--- a/application_sdk/observability/error_classifier.py
+++ b/application_sdk/observability/error_classifier.py
@@ -1,0 +1,185 @@
+"""Error classification for App Vitals.
+
+Maps exceptions to a fixed set of error_type values so that failure
+breakdowns can be grouped in dashboards and alerts. Also extracts the
+exception cause chain and a retriable-heuristic so downstream debugging
+tools have structured context without reading stack traces manually.
+
+The classifier is deliberately conservative: if it can't confidently
+classify an error, it returns "internal" rather than guessing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+def classify_error(exc: BaseException) -> str:
+    """Classify an exception into an App Vitals error_type.
+
+    If the exception is a Temporal ``ActivityError`` or ``ChildWorkflowError``
+    wrapper, we unwrap to the original cause before classifying, so that a
+    workflow observing a wrapped ``TimeoutError`` still classifies as "timeout".
+
+    Args:
+        exc: The exception to classify.
+
+    Returns:
+        One of: "timeout", "oom", "upstream", "config", "cancelled", "internal".
+    """
+    # Unwrap Temporal wrappers to get to the real cause. The wrapper types are
+    # string-matched (not isinstance) to avoid importing from temporalio here.
+    # ApplicationError stores the original Python exception class name in
+    # `.type` (the actual exception is lost across the wire), so if we end up
+    # stuck at an ApplicationError with no deeper cause, we use `.type` as a
+    # synthetic class-name hint for downstream matching.
+    current = exc
+    original_type_hint: str | None = None
+    for _ in range(5):  # bounded depth
+        cls_name = type(current).__name__
+        if cls_name in ("ActivityError", "ChildWorkflowError", "ApplicationError"):
+            if cls_name == "ApplicationError":
+                # Keep the FIRST (outermost) hint — it represents the actual
+                # error the workflow observed. Inner ApplicationErrors are the
+                # cause chain, not the raised error.
+                if original_type_hint is None:
+                    app_err_type = getattr(current, "type", None)
+                    if app_err_type:
+                        original_type_hint = str(app_err_type)
+            inner = getattr(current, "cause", None) or current.__cause__
+            if inner is None or inner is current:
+                break
+            current = inner
+            continue
+        break
+    exc = current
+
+    exc_type = type(exc).__name__
+    msg = str(exc).lower()
+    # Merge in the ApplicationError `.type` hint (if we unwrapped to one)
+    effective_type_names = {exc_type}
+    if original_type_hint:
+        effective_type_names.add(original_type_hint)
+
+    # Timeout
+    if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
+        return "timeout"
+    if "TimeoutError" in effective_type_names:
+        return "timeout"
+    if exc_type in ("ActivityError", "ChildWorkflowError") and "timeout" in msg:
+        return "timeout"
+    if "timed out" in msg or "deadline exceeded" in msg:
+        return "timeout"
+
+    # OOM / Resource exhaustion
+    if isinstance(exc, MemoryError):
+        return "oom"
+    if "MemoryError" in effective_type_names:
+        return "oom"
+    if (
+        "oomkilled" in msg
+        or "out of memory" in msg
+        or ("memory" in msg and "exceeded" in msg)
+    ):
+        return "oom"
+
+    # Cancellation
+    if isinstance(exc, (asyncio.CancelledError, KeyboardInterrupt)):
+        return "cancelled"
+    if effective_type_names & {"CancelledError", "KeyboardInterrupt"}:
+        return "cancelled"
+    if "cancelled" in msg or "canceled" in msg:
+        return "cancelled"
+
+    # Upstream / connectivity
+    if isinstance(exc, (ConnectionError, ConnectionRefusedError, ConnectionResetError)):
+        return "upstream"
+    upstream_types = {
+        "AuthenticationError",
+        "ConnectionError",
+        "ConnectionRefusedError",
+        "ConnectionResetError",
+        "SSLError",
+        "HTTPError",
+    }
+    if effective_type_names & upstream_types:
+        return "upstream"
+    if "connection refused" in msg or "connection reset" in msg:
+        return "upstream"
+    if "authentication" in msg or "unauthorized" in msg or "403" in msg or "401" in msg:
+        return "upstream"
+
+    # Config / validation
+    if isinstance(exc, (ValueError, KeyError, TypeError)):
+        return "config"
+    config_types = {
+        "ValueError",
+        "KeyError",
+        "TypeError",
+        "ConfigurationError",
+        "ValidationError",
+        "SchemaError",
+    }
+    if effective_type_names & config_types:
+        return "config"
+    if (
+        "invalid config" in msg
+        or "missing required" in msg
+        or "not found in config" in msg
+    ):
+        return "config"
+
+    # Default
+    return "internal"
+
+
+# Error types that never benefit from retry (fix requires code/config change)
+_NON_RETRIABLE_TYPES = frozenset({"config", "cancelled"})
+
+
+def extract_cause_chain(exc: BaseException, limit: int = 5) -> list[str]:
+    """Walk the exception cause chain and return a list of cause descriptions.
+
+    Follows ``__cause__`` (``raise X from Y``) and ``__context__`` (implicit
+    chaining) up to ``limit`` levels. Each entry is ``"<ExceptionClass>: <message>"``.
+
+    Returns an empty list if there's no cause chain.
+    """
+    causes: list[str] = []
+    current = exc.__cause__ or exc.__context__
+    seen: set[int] = {id(exc)}
+
+    while current is not None and len(causes) < limit:
+        if id(current) in seen:
+            break
+        seen.add(id(current))
+        causes.append(f"{type(current).__name__}: {str(current)[:200]}")
+        current = current.__cause__ or current.__context__
+
+    return causes
+
+
+def is_retriable(exc: BaseException, error_type: str | None = None) -> bool:
+    """Heuristic for whether this error is worth retrying.
+
+    - ``config`` / ``cancelled`` errors don't benefit from retry — they need
+      human or code intervention.
+    - ``timeout`` / ``upstream`` / ``oom`` / ``internal`` are retriable by
+      default (retry policy may still cap attempts).
+
+    Respects an explicit ``non_retryable`` flag on the exception if present
+    (Temporal's ApplicationError pattern).
+
+    Args:
+        exc: The exception to evaluate.
+        error_type: Optional pre-computed error_type from classify_error().
+                    If None, classifies internally.
+    """
+    # Explicit Temporal ApplicationError non_retryable flag
+    if getattr(exc, "non_retryable", False):
+        return False
+
+    if error_type is None:
+        error_type = classify_error(exc)
+
+    return error_type not in _NON_RETRIABLE_TYPES

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -52,6 +52,7 @@ _KNOWN_EXTRA_KEYS = frozenset(
         "url",
         "workflow_id",
         "run_id",
+        "workflow_run_id",  # App Vitals uses this alias alongside run_id
         "workflow_type",
         "namespace",
         "task_queue",
@@ -65,7 +66,41 @@ _KNOWN_EXTRA_KEYS = frozenset(
         "log_type",
         "app_name",
         "trace_id",
+        "span_id",
         "correlation_id",
+        # ── App Vitals ───────────────────────────────────────────────────
+        # Identity
+        "app_version",
+        "tenant_id",
+        # Outcome
+        "status",
+        "error_type",
+        "error_class",
+        "error_message",
+        "is_retriable",
+        "error_cause_chain",
+        # Metric classification
+        "dimension",
+        "source",
+        "metric_name",
+        # Throughput
+        "assets_processed",
+        # Efficiency (per-activity resource deltas)
+        "cpu_seconds",
+        "mem_gb_sec",
+        # Performance timings
+        "schedule_to_start_ms",
+        "timeout_budget_total_ms",
+        "timeout_budget_used_pct",
+        # Workflow summary (app_vitals.wf.summary event)
+        "total_activities",
+        "succeeded_activities",
+        "failed_activities",
+        "total_child_workflows",
+        "first_failure_activity_type",
+        "first_failure_error_type",
+        "bottleneck_activity_type",
+        "bottleneck_duration_ms",
     }
 )
 

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -71,8 +71,8 @@ _KNOWN_EXTRA_KEYS = frozenset(
         # ── App Vitals ───────────────────────────────────────────────────
         # Deterministic filter flag — marks every App Vitals log event
         "app_vitals",
-        # Per-workflow identity (deployment-level fields are on OTel Resource)
-        "tenant_id",
+        # Per-workflow identity (deployment-level fields are on OTel Resource;
+        # tenant_id is redundant with ResourceAttributes['k8s.cluster.name'])
         # Outcome
         "status",
         "error_type",
@@ -99,6 +99,9 @@ _KNOWN_EXTRA_KEYS = frozenset(
         "retry_max_attempts",
         # Payload size
         "input_payload_bytes",
+        # Activity wall-clock timestamps (ISO 8601)
+        "activity_start_time",
+        "activity_end_time",
         # Workflow hierarchy
         "parent_workflow_id",
         "parent_run_id",

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -72,6 +72,8 @@ _KNOWN_EXTRA_KEYS = frozenset(
         # Identity
         "app_version",
         "tenant_id",
+        "domain_name",
+        "pod_name",
         # Outcome
         "status",
         "error_type",
@@ -79,6 +81,8 @@ _KNOWN_EXTRA_KEYS = frozenset(
         "error_message",
         "is_retriable",
         "error_cause_chain",
+        "stack_trace",
+        "error_fingerprint",
         # Metric classification
         "dimension",
         "source",
@@ -92,6 +96,21 @@ _KNOWN_EXTRA_KEYS = frozenset(
         "schedule_to_start_ms",
         "timeout_budget_total_ms",
         "timeout_budget_used_pct",
+        # Retry context
+        "retry_max_attempts",
+        # Payload size
+        "input_payload_bytes",
+        # Workflow hierarchy
+        "parent_workflow_id",
+        "parent_run_id",
+        "continued_run_id",
+        "cron_schedule",
+        # Workflow-level timeout budget
+        "wf_timeout_budget_total_ms",
+        "wf_timeout_budget_used_pct",
+        "history_length",
+        # Workflow summary — activity duration rollup
+        "sum_activity_duration_ms",
         # Workflow summary (app_vitals.wf.summary event)
         "total_activities",
         "succeeded_activities",

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -69,16 +69,10 @@ _KNOWN_EXTRA_KEYS = frozenset(
         "span_id",
         "correlation_id",
         # ── App Vitals ───────────────────────────────────────────────────
-        # Identity
-        "app_version",
-        "app_build_id",
-        "release_id",
-        "release_channel",
-        "sdk_version",
-        "app_type",
+        # Deterministic filter flag — marks every App Vitals log event
+        "app_vitals",
+        # Per-workflow identity (deployment-level fields are on OTel Resource)
         "tenant_id",
-        "domain_name",
-        "pod_name",
         # Outcome
         "status",
         "error_type",

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -71,6 +71,11 @@ _KNOWN_EXTRA_KEYS = frozenset(
         # ── App Vitals ───────────────────────────────────────────────────
         # Identity
         "app_version",
+        "app_build_id",
+        "release_id",
+        "release_channel",
+        "sdk_version",
+        "app_type",
         "tenant_id",
         "domain_name",
         "pod_name",

--- a/application_sdk/observability/resource_sampler.py
+++ b/application_sdk/observability/resource_sampler.py
@@ -1,0 +1,82 @@
+"""Process-level resource sampling for App Vitals efficiency metrics.
+
+Captures CPU time and memory usage at activity boundaries so the
+interceptor can emit ``activity_cpu_seconds`` and ``activity_mem_gb_sec``
+(RFC metrics #10 and #11 from DESIGN.md §4.1).
+
+Scope limitation: these are **process-level** samples via psutil, not
+per-task attribution. For a worker running one activity at a time, the
+delta is accurate. For a worker running multiple activities concurrently,
+concurrent activities share the same process so the values over-attribute
+CPU/memory to each concurrent activity individually — but the sum across
+activities remains correct for workload-total calculations.
+
+Per-activity attribution (cgroup delegation, cgroup v2 PID controllers,
+or per-task CPU accounting in Python 3.12+) is on the look-later list.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+try:
+    import psutil
+
+    _PROCESS: psutil.Process | None = psutil.Process(os.getpid())
+except Exception:
+    _PROCESS = None
+
+
+@dataclass(frozen=True)
+class ResourceSample:
+    """A single point-in-time sample of process CPU + memory."""
+
+    cpu_time_s: float  # user + system CPU seconds consumed by the process so far
+    rss_bytes: int  # resident set size in bytes (memory currently in RAM)
+
+
+def sample() -> ResourceSample | None:
+    """Capture current process CPU time and memory.
+
+    Returns:
+        ResourceSample, or None if sampling is unavailable (e.g. psutil
+        import failed or the process handle is invalid).
+    """
+    if _PROCESS is None:
+        return None
+    try:
+        times = _PROCESS.cpu_times()
+        mem = _PROCESS.memory_info()
+        return ResourceSample(
+            cpu_time_s=times.user + times.system,
+            rss_bytes=mem.rss,
+        )
+    except Exception:
+        return None
+
+
+def compute_deltas(
+    start: ResourceSample | None,
+    end: ResourceSample | None,
+    duration_s: float,
+) -> tuple[float, float]:
+    """Compute ``(cpu_seconds, mem_gb_sec)`` for the activity.
+
+    ``cpu_seconds`` = CPU time consumed during the activity window.
+    ``mem_gb_sec`` = average RSS in GiB multiplied by wall-clock duration
+    in seconds. This is the memory-time integral approximation the RFC
+    uses (unit: ``GiB.s``).
+
+    Returns (0.0, 0.0) if either sample is None.
+    """
+    if start is None or end is None:
+        return 0.0, 0.0
+
+    cpu_seconds = max(0.0, end.cpu_time_s - start.cpu_time_s)
+
+    avg_rss_bytes = (start.rss_bytes + end.rss_bytes) / 2.0
+    avg_rss_gib = avg_rss_bytes / (1024**3)
+    mem_gb_sec = avg_rss_gib * max(0.0, duration_s)
+
+    return cpu_seconds, mem_gb_sec

--- a/application_sdk/observability/trace_context.py
+++ b/application_sdk/observability/trace_context.py
@@ -1,0 +1,33 @@
+"""Helper to read current OpenTelemetry trace context.
+
+When Temporal's built-in TracingInterceptor (or any upstream tracer) is
+active, this returns the current trace_id and span_id as hex strings so
+they can be attached to our App Vitals events and metrics.
+
+When no tracer is active, returns empty strings. This is safe — it just
+means our events won't be linkable to traces until a tracer is configured.
+
+Attaching these IDs is free at emission time. When the OTel traces pipeline
+comes online, correlation between our logs and traces becomes automatic.
+"""
+
+from __future__ import annotations
+
+from opentelemetry import trace
+
+
+def get_trace_context() -> tuple[str, str]:
+    """Return (trace_id, span_id) from the current OTel span context.
+
+    Returns:
+        Tuple of (trace_id_hex, span_id_hex). Both empty strings if no
+        valid span context is active.
+    """
+    try:
+        span = trace.get_current_span()
+        ctx = span.get_span_context()
+        if not ctx.is_valid:
+            return "", ""
+        return format(ctx.trace_id, "032x"), format(ctx.span_id, "016x")
+    except Exception:
+        return "", ""

--- a/application_sdk/observability/utils.py
+++ b/application_sdk/observability/utils.py
@@ -5,7 +5,6 @@ from opentelemetry.sdk.resources import Resource
 
 from application_sdk.constants import (
     APP_SDK_VERSION,
-    APP_TENANT_ID,
     APP_TYPE,
     APPLICATION_NAME,
     APPLICATION_VERSION,
@@ -101,10 +100,10 @@ def build_otel_resource(extra_attrs: dict[str, str] | None = None) -> Resource:
         resource_attributes["service.version"] = SERVICE_VERSION
     if OTEL_WF_NODE_NAME:
         resource_attributes["k8s.workflow.node.name"] = OTEL_WF_NODE_NAME
-    # tenant.id — deployment-scoped tenant identifier
-    if "tenant.id" not in resource_attributes:
-        resource_attributes["tenant.id"] = APP_TENANT_ID
     # Deployment-level attributes — constant per pod, don't duplicate in log attrs.
+    # tenant.id is intentionally omitted: k8s.cluster.name (injected by the
+    # central OTel collector's resource processor) identifies the tenant at
+    # the deployment level.
     # NOTE: app.name is intentionally NOT a resource attribute — a deployment
     # can host multiple apps; app_name stays in log attrs per-event.
     # app.build_id is also omitted — app.version carries the same signal.

--- a/application_sdk/observability/utils.py
+++ b/application_sdk/observability/utils.py
@@ -4,12 +4,20 @@ import os
 from opentelemetry.sdk.resources import Resource
 
 from application_sdk.constants import (
+    APP_BUILD_ID,
+    APP_SDK_VERSION,
     APP_TENANT_ID,
+    APP_TYPE,
     APPLICATION_NAME,
+    APPLICATION_VERSION,
     DEPLOYMENT_NAME,
+    DOMAIN_NAME,
     OBSERVABILITY_DIR,
     OTEL_RESOURCE_ATTRIBUTES,
     OTEL_WF_NODE_NAME,
+    PUBLISHED_AT,
+    RELEASE_CHANNEL,
+    RELEASE_ID,
     SERVICE_NAME,
     SERVICE_VERSION,
     TEMPORARY_PATH,
@@ -99,6 +107,27 @@ def build_otel_resource(extra_attrs: dict[str, str] | None = None) -> Resource:
         resource_attributes["app.name"] = APPLICATION_NAME
     if "tenant.id" not in resource_attributes:
         resource_attributes["tenant.id"] = APP_TENANT_ID
+    # Deployment-level attributes — constant per pod, don't duplicate in log attrs.
+    # Only set if the env var was provided (Helm may not always inject these).
+    if APPLICATION_VERSION:
+        resource_attributes["app.version"] = APPLICATION_VERSION
+    if APP_BUILD_ID:
+        resource_attributes["app.build_id"] = APP_BUILD_ID
+    if RELEASE_ID:
+        resource_attributes["app.release_id"] = RELEASE_ID
+    if RELEASE_CHANNEL:
+        resource_attributes["app.release_channel"] = RELEASE_CHANNEL
+    if APP_SDK_VERSION:
+        resource_attributes["app.sdk_version"] = APP_SDK_VERSION
+    if APP_TYPE:
+        resource_attributes["app.type"] = APP_TYPE
+    if PUBLISHED_AT:
+        resource_attributes["app.published_at"] = PUBLISHED_AT
+    if DOMAIN_NAME:
+        resource_attributes["tenant.domain"] = DOMAIN_NAME
+    pod_name = os.environ.get("K8S_POD_NAME") or os.environ.get("HOSTNAME", "")
+    if pod_name:
+        resource_attributes["k8s.pod.name"] = pod_name
     if extra_attrs:
         resource_attributes.update(extra_attrs)
     return Resource.create(resource_attributes)

--- a/application_sdk/observability/utils.py
+++ b/application_sdk/observability/utils.py
@@ -4,7 +4,6 @@ import os
 from opentelemetry.sdk.resources import Resource
 
 from application_sdk.constants import (
-    APP_BUILD_ID,
     APP_SDK_VERSION,
     APP_TENANT_ID,
     APP_TYPE,
@@ -102,17 +101,15 @@ def build_otel_resource(extra_attrs: dict[str, str] | None = None) -> Resource:
         resource_attributes["service.version"] = SERVICE_VERSION
     if OTEL_WF_NODE_NAME:
         resource_attributes["k8s.workflow.node.name"] = OTEL_WF_NODE_NAME
-    # App Vitals: ensure app identity is on every OTLP export
-    if "app.name" not in resource_attributes:
-        resource_attributes["app.name"] = APPLICATION_NAME
+    # tenant.id — deployment-scoped tenant identifier
     if "tenant.id" not in resource_attributes:
         resource_attributes["tenant.id"] = APP_TENANT_ID
     # Deployment-level attributes — constant per pod, don't duplicate in log attrs.
-    # Only set if the env var was provided (Helm may not always inject these).
+    # NOTE: app.name is intentionally NOT a resource attribute — a deployment
+    # can host multiple apps; app_name stays in log attrs per-event.
+    # app.build_id is also omitted — app.version carries the same signal.
     if APPLICATION_VERSION:
         resource_attributes["app.version"] = APPLICATION_VERSION
-    if APP_BUILD_ID:
-        resource_attributes["app.build_id"] = APP_BUILD_ID
     if RELEASE_ID:
         resource_attributes["app.release_id"] = RELEASE_ID
     if RELEASE_CHANNEL:
@@ -124,7 +121,7 @@ def build_otel_resource(extra_attrs: dict[str, str] | None = None) -> Resource:
     if PUBLISHED_AT:
         resource_attributes["app.published_at"] = PUBLISHED_AT
     if DOMAIN_NAME:
-        resource_attributes["tenant.domain"] = DOMAIN_NAME
+        resource_attributes["k8s.domain.name"] = DOMAIN_NAME
     pod_name = os.environ.get("K8S_POD_NAME") or os.environ.get("HOSTNAME", "")
     if pod_name:
         resource_attributes["k8s.pod.name"] = pod_name

--- a/application_sdk/observability/utils.py
+++ b/application_sdk/observability/utils.py
@@ -4,6 +4,7 @@ import os
 from opentelemetry.sdk.resources import Resource
 
 from application_sdk.constants import (
+    APP_TENANT_ID,
     APPLICATION_NAME,
     DEPLOYMENT_NAME,
     OBSERVABILITY_DIR,
@@ -93,6 +94,11 @@ def build_otel_resource(extra_attrs: dict[str, str] | None = None) -> Resource:
         resource_attributes["service.version"] = SERVICE_VERSION
     if OTEL_WF_NODE_NAME:
         resource_attributes["k8s.workflow.node.name"] = OTEL_WF_NODE_NAME
+    # App Vitals: ensure app identity is on every OTLP export
+    if "app.name" not in resource_attributes:
+        resource_attributes["app.name"] = APPLICATION_NAME
+    if "tenant.id" not in resource_attributes:
+        resource_attributes["tenant.id"] = APP_TENANT_ID
     if extra_attrs:
         resource_attributes.update(extra_attrs)
     return Resource.create(resource_attributes)

--- a/application_sdk/templates/contracts/sql_metadata.py
+++ b/application_sdk/templates/contracts/sql_metadata.py
@@ -10,7 +10,7 @@ from typing import Annotated
 
 from pydantic import Field
 
-from application_sdk.contracts.base import Input, Output
+from application_sdk.contracts.base import Input, Output, PublishInputMixin
 from application_sdk.contracts.types import ConnectionRef, MaxItems
 from application_sdk.credentials.ref import CredentialRef
 
@@ -49,7 +49,7 @@ class ExtractionInput(Input, allow_unbounded_fields=True):
     """Tag prefix for source-level metadata."""
 
 
-class ExtractionOutput(Output):
+class ExtractionOutput(Output, PublishInputMixin):
     """Top-level output from a SQL metadata extraction run."""
 
     workflow_id: str = ""

--- a/application_sdk/templates/sql_metadata_extractor.py
+++ b/application_sdk/templates/sql_metadata_extractor.py
@@ -245,3 +245,36 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
             raise rewrap(
                 e, f"SQL metadata extraction failed (workflow_id={workflow_id})"
             ) from e
+
+
+def compute_ae_output_fields(
+    *,
+    output_path: str = "",
+    output_prefix: str = "",
+    connection_qualified_name: str = "",
+) -> dict[str, str]:
+    """Return the AE-facing publish fields derived from workflow output context.
+
+    Wraps ``PublishInputMixin`` to compute the three fields the Automation
+    Engine reads via JSONPath (``$.extract.outputs.*``) when chaining to the
+    Publish App:
+
+    - ``transformed_data_prefix`` — object-store path to transformed files
+    - ``publish_state_prefix``    — path for Publish App state snapshots
+    - ``current_state_prefix``    — path for current-state delta files
+
+    Pass the returned dict as ``**compute_ae_output_fields(...)`` when
+    constructing ``ExtractionOutput`` (which inherits ``PublishInputMixin``).
+    """
+    from application_sdk.contracts.base import PublishInputMixin
+
+    mixin = PublishInputMixin(
+        output_path=output_path,
+        output_prefix=output_prefix,
+        connection_qualified_name=connection_qualified_name,
+    )
+    return {
+        "transformed_data_prefix": mixin.transformed_data_prefix,
+        "publish_state_prefix": mixin.publish_state_prefix,
+        "current_state_prefix": mixin.current_state_prefix,
+    }

--- a/tests/unit/interceptors/test_activity_failure_logging.py
+++ b/tests/unit/interceptors/test_activity_failure_logging.py
@@ -121,6 +121,51 @@ class Test_TaskFailureLoggingActivityInboundInterceptor:
                 assert kwargs["tenant.id"] == "tenant-abc"
 
     @pytest.mark.asyncio
+    async def test_failure_log_includes_app_vitals_context(
+        self, interceptor, mock_next_activity, mock_activity_info
+    ):
+        """Phase 2: structured failure log includes App Vitals identity + error classification."""
+        input_data = MockExecuteActivityInput()
+        test_error = TimeoutError("connection timed out")
+        mock_next_activity.execute_activity.side_effect = test_error
+
+        correlation_context.set({"atlan-tenant-id": "tenant-av"})
+
+        with (
+            mock.patch("temporalio.activity.info", return_value=mock_activity_info),
+            mock.patch(
+                "application_sdk.execution._temporal.interceptors.activity_failure_logging.APPLICATION_NAME",
+                "snowflake",
+            ),
+            mock.patch(
+                "application_sdk.execution._temporal.interceptors.activity_failure_logging.APP_BUILD_ID",
+                "2.4.2",
+            ),
+            mock.patch(
+                "application_sdk.execution._temporal.interceptors.activity_failure_logging.logger"
+            ) as mock_logger,
+        ):
+            with pytest.raises(TimeoutError):
+                await interceptor.execute_activity(input_data)
+
+            kwargs = mock_logger.error.call_args[1]
+
+            # App Vitals identity
+            assert kwargs["app_name"] == "snowflake"
+            assert kwargs["app_version"] == "2.4.2"
+            assert kwargs["tenant_id"] == "tenant-av"
+            assert kwargs["status"] == "failed"
+
+            # Error classification
+            assert kwargs["error_type"] == "timeout"
+            assert kwargs["error_class"] == "TimeoutError"
+
+            # App Vitals classification metadata
+            assert kwargs["dimension"] == "reliability"
+            assert kwargs["source"] == "temporal"
+            assert kwargs["metric_name"] == "app_vitals.reliability.activity_completed"
+
+    @pytest.mark.asyncio
     async def test_failure_reraises_original_exception(
         self, interceptor, mock_next_activity, mock_activity_info
     ):

--- a/tests/unit/interceptors/test_app_vitals.py
+++ b/tests/unit/interceptors/test_app_vitals.py
@@ -176,7 +176,7 @@ class TestAppVitalsActivityInterceptor:
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
-                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
             ),
         ):
             mock_activity_mod.info.return_value = activity_info
@@ -227,7 +227,7 @@ class TestAppVitalsActivityInterceptor:
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
-                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
             ),
         ):
             mock_activity_mod.info.return_value = activity_info
@@ -262,7 +262,7 @@ class TestAppVitalsActivityInterceptor:
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
-                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
             ),
         ):
             mock_activity_mod.info.return_value = activity_info
@@ -312,7 +312,7 @@ class TestAppVitalsWorkflowInterceptor:
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
-                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
             ),
         ):
             mock_wf_mod.info.return_value = workflow_info
@@ -361,7 +361,7 @@ class TestAppVitalsWorkflowInterceptor:
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
-                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
             ),
         ):
             mock_wf_mod.info.return_value = workflow_info
@@ -490,7 +490,7 @@ class TestAppVitalsEfficiencyMetrics:
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
-                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
             ),
         ):
             mock_activity_mod.info.return_value = activity_info
@@ -540,7 +540,7 @@ class TestAppVitalsTraceIdAttachment:
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
-                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
             ),
             mock.patch(
                 "application_sdk.observability.app_vitals.get_trace_context",
@@ -576,7 +576,7 @@ class TestAppVitalsTraceIdAttachment:
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
-                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
             ),
             mock.patch(
                 "application_sdk.observability.app_vitals.get_trace_context",
@@ -699,7 +699,7 @@ class TestAppVitalsRichErrorFields:
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
-                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
             ),
         ):
             mock_activity_mod.info.return_value = activity_info
@@ -744,7 +744,7 @@ class TestAppVitalsRichErrorFields:
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
-                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
             ),
         ):
             mock_activity_mod.info.return_value = activity_info
@@ -781,7 +781,7 @@ class TestAppVitalsRichErrorFields:
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
-                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
             ),
         ):
             mock_activity_mod.info.return_value = activity_info  # 5-min timeout
@@ -832,7 +832,7 @@ class TestLifecycleStartEvents:
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
-                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
             ),
         ):
             mock_activity_mod.info.return_value = info
@@ -931,7 +931,7 @@ class TestAssetsProcessed:
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
-                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
             ),
         ):
             mock_activity_mod.info.return_value = MockActivityInfo()
@@ -980,7 +980,7 @@ class TestWorkflowSummary:
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
-                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
             ),
         ):
             mock_wf_mod.info.return_value = MockWorkflowInfo()

--- a/tests/unit/interceptors/test_app_vitals.py
+++ b/tests/unit/interceptors/test_app_vitals.py
@@ -1093,9 +1093,8 @@ class TestLoggerAdaptorExtraKeysAllowlist:
     """
 
     APP_VITALS_LOG_FIELDS = [
-        # Identity
-        "app_name",
-        "app_version",
+        # Identity — only per-workflow fields. Deployment attrs are on OTel Resource.
+        "app_vitals",
         "tenant_id",
         # Execution context
         "workflow_id",
@@ -1161,8 +1160,7 @@ class TestLoggerAdaptorExtraKeysAllowlist:
 
         # Realistic example: a failed activity event
         sample_extra = {
-            "app_name": "snowflake",
-            "app_version": "2.4.2",
+            "app_vitals": "true",
             "tenant_id": "tenant_123",
             "workflow_id": "wf-abc",
             "run_id": "run-def",

--- a/tests/unit/interceptors/test_app_vitals.py
+++ b/tests/unit/interceptors/test_app_vitals.py
@@ -1093,8 +1093,10 @@ class TestLoggerAdaptorExtraKeysAllowlist:
     """
 
     APP_VITALS_LOG_FIELDS = [
-        # Identity — only per-workflow fields. Deployment attrs are on OTel Resource.
+        # Identity — only per-workflow/per-app fields. Deployment attrs (version,
+        # release_id, pod_name, k8s.domain.name) are on OTel Resource.
         "app_vitals",
+        "app_name",
         "tenant_id",
         # Execution context
         "workflow_id",
@@ -1161,6 +1163,7 @@ class TestLoggerAdaptorExtraKeysAllowlist:
         # Realistic example: a failed activity event
         sample_extra = {
             "app_vitals": "true",
+            "app_name": "snowflake",
             "tenant_id": "tenant_123",
             "workflow_id": "wf-abc",
             "run_id": "run-def",

--- a/tests/unit/interceptors/test_app_vitals.py
+++ b/tests/unit/interceptors/test_app_vitals.py
@@ -1,0 +1,1271 @@
+"""Unit tests for the App Vitals interceptor and error classifier."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Sequence
+from unittest import mock
+
+import pytest
+from temporalio.api.common.v1 import Payload
+
+from application_sdk.observability.error_classifier import (
+    classify_error,
+    extract_cause_chain,
+    is_retriable,
+)
+from application_sdk.observability.resource_sampler import (
+    ResourceSample,
+    compute_deltas,
+)
+from application_sdk.observability.trace_context import get_trace_context
+
+# ---------------------------------------------------------------------------
+# Error Classifier Tests
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyError:
+    """Tests for the error classification function."""
+
+    def test_timeout_error(self):
+        assert classify_error(TimeoutError("connection timed out")) == "timeout"
+
+    def test_asyncio_timeout(self):
+        assert classify_error(asyncio.TimeoutError()) == "timeout"
+
+    def test_timeout_in_message(self):
+        assert classify_error(Exception("request timed out after 30s")) == "timeout"
+
+    def test_deadline_exceeded(self):
+        assert classify_error(Exception("deadline exceeded")) == "timeout"
+
+    def test_memory_error(self):
+        assert classify_error(MemoryError("out of memory")) == "oom"
+
+    def test_oomkilled_in_message(self):
+        assert classify_error(Exception("process oomkilled")) == "oom"
+
+    def test_cancelled_error(self):
+        assert classify_error(asyncio.CancelledError()) == "cancelled"
+
+    def test_cancelled_in_message(self):
+        assert classify_error(Exception("workflow was cancelled")) == "cancelled"
+
+    def test_connection_error(self):
+        assert classify_error(ConnectionError("refused")) == "upstream"
+
+    def test_connection_refused(self):
+        assert classify_error(ConnectionRefusedError()) == "upstream"
+
+    def test_connection_reset(self):
+        assert classify_error(ConnectionResetError()) == "upstream"
+
+    def test_auth_in_message(self):
+        assert classify_error(Exception("authentication failed")) == "upstream"
+
+    def test_unauthorized_in_message(self):
+        assert classify_error(Exception("401 unauthorized")) == "upstream"
+
+    def test_value_error(self):
+        assert classify_error(ValueError("invalid input")) == "config"
+
+    def test_key_error(self):
+        assert classify_error(KeyError("missing_field")) == "config"
+
+    def test_type_error(self):
+        assert classify_error(TypeError("expected str")) == "config"
+
+    def test_generic_exception(self):
+        assert classify_error(Exception("something went wrong")) == "internal"
+
+    def test_runtime_error(self):
+        assert classify_error(RuntimeError("unexpected state")) == "internal"
+
+
+# ---------------------------------------------------------------------------
+# Mock objects for interceptor tests
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MockExecuteActivityInput:
+    fn: Any = None
+    args: Sequence[Any] = field(default_factory=list)
+    headers: Mapping[str, Payload] = field(default_factory=dict)
+    executor: Any = None
+
+
+@dataclass
+class MockExecuteWorkflowInput:
+    type: str = "TestWorkflow"
+    args: Sequence[Any] = field(default_factory=list)
+    headers: Mapping[str, Payload] = field(default_factory=dict)
+
+
+@dataclass
+class MockActivityInfo:
+    activity_type: str = "extract"
+    activity_id: str = "act-001"
+    attempt: int = 1
+    workflow_id: str = "wf-abc-123"
+    workflow_run_id: str = "run-def-456"
+    workflow_type: str = "metadata_crawl"
+    task_queue: str = "atlan-snowflake"
+    scheduled_time: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc) - timedelta(seconds=2)
+    )
+    started_time: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    namespace: str = "default"
+    schedule_to_close_timeout: timedelta | None = timedelta(minutes=5)
+    start_to_close_timeout: timedelta | None = timedelta(minutes=5)
+    heartbeat_timeout: timedelta | None = timedelta(seconds=30)
+
+
+@dataclass
+class MockWorkflowInfo:
+    workflow_id: str = "wf-abc-123"
+    run_id: str = "run-def-456"
+    workflow_type: str = "metadata_crawl"
+    task_queue: str = "atlan-snowflake"
+    namespace: str = "default"
+    attempt: int = 1
+
+
+# ---------------------------------------------------------------------------
+# AppVitalsInterceptor Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAppVitalsActivityInterceptor:
+    """Tests for the activity-level App Vitals interceptor."""
+
+    @pytest.fixture
+    def mock_next_activity(self):
+        mock_next = mock.AsyncMock()
+        mock_next.execute_activity = mock.AsyncMock(return_value="result")
+        return mock_next
+
+    @pytest.fixture
+    def activity_info(self):
+        return MockActivityInfo()
+
+    @pytest.mark.asyncio
+    async def test_successful_activity_emits_events(
+        self, mock_next_activity, activity_info
+    ):
+        from application_sdk.observability.app_vitals import (
+            _AppVitalsActivityInboundInterceptor,
+        )
+
+        interceptor = _AppVitalsActivityInboundInterceptor(mock_next_activity)
+
+        with (
+            mock.patch(
+                "application_sdk.observability.app_vitals.activity"
+            ) as mock_activity_mod,
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_log_event"
+            ) as mock_log,
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_metric"
+            ) as mock_metric,
+            mock.patch(
+                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+            ),
+        ):
+            mock_activity_mod.info.return_value = activity_info
+
+            result = await interceptor.execute_activity(MockExecuteActivityInput())
+
+            assert result == "result"
+
+            # Phase 2/L: 2 log events — started + completed
+            log_event_names = [c[0][0] for c in mock_log.call_args_list]
+            assert "app_vitals.act.started" in log_event_names
+            assert "app_vitals.act.completed" in log_event_names
+
+            # Check the completion event attrs
+            completed_call = next(
+                c
+                for c in mock_log.call_args_list
+                if c[0][0] == "app_vitals.act.completed"
+            )
+            log_attrs = completed_call[0][1]
+            assert log_attrs["status"] == "succeeded"
+            assert log_attrs["activity_type"] == "extract"
+            assert log_attrs["workflow_id"] == "wf-abc-123"
+            assert log_attrs["duration_ms"] >= 0
+
+            assert mock_metric.call_count >= 2
+            metric_calls = [c[0][0] for c in mock_metric.call_args_list]
+            assert "app_vitals.reliability.activity_completed" in metric_calls
+            assert "app_vitals.performance.activity_runtime" in metric_calls
+
+    @pytest.mark.asyncio
+    async def test_failed_activity_emits_error_type(
+        self, mock_next_activity, activity_info
+    ):
+        from application_sdk.observability.app_vitals import (
+            _AppVitalsActivityInboundInterceptor,
+        )
+
+        mock_next_activity.execute_activity = mock.AsyncMock(
+            side_effect=TimeoutError("connection timed out")
+        )
+        interceptor = _AppVitalsActivityInboundInterceptor(mock_next_activity)
+
+        with (
+            mock.patch(
+                "application_sdk.observability.app_vitals.activity"
+            ) as mock_activity_mod,
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_log_event"
+            ) as mock_log,
+            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+            ),
+        ):
+            mock_activity_mod.info.return_value = activity_info
+
+            with pytest.raises(TimeoutError):
+                await interceptor.execute_activity(MockExecuteActivityInput())
+
+            log_attrs = mock_log.call_args[0][1]
+            assert log_attrs["status"] == "failed"
+            assert log_attrs["error_type"] == "timeout"
+            assert "connection timed out" in log_attrs["error_message"]
+
+    @pytest.mark.asyncio
+    async def test_retry_attempt_emits_retry_metric(
+        self, mock_next_activity, activity_info
+    ):
+        from application_sdk.observability.app_vitals import (
+            _AppVitalsActivityInboundInterceptor,
+        )
+
+        activity_info.attempt = 3
+        interceptor = _AppVitalsActivityInboundInterceptor(mock_next_activity)
+
+        with (
+            mock.patch(
+                "application_sdk.observability.app_vitals.activity"
+            ) as mock_activity_mod,
+            mock.patch("application_sdk.observability.app_vitals._emit_log_event"),
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_metric"
+            ) as mock_metric,
+            mock.patch(
+                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+            ),
+        ):
+            mock_activity_mod.info.return_value = activity_info
+
+            await interceptor.execute_activity(MockExecuteActivityInput())
+
+            metric_calls = [c[0][0] for c in mock_metric.call_args_list]
+            assert "app_vitals.reliability.activity_retries" in metric_calls
+
+            retry_call = next(
+                c
+                for c in mock_metric.call_args_list
+                if c[0][0] == "app_vitals.reliability.activity_retries"
+            )
+            assert retry_call[0][1] == 2.0  # attempt 3 means 2 retries
+
+
+class TestAppVitalsWorkflowInterceptor:
+    """Tests for the workflow-level App Vitals interceptor."""
+
+    @pytest.fixture
+    def mock_next_workflow(self):
+        mock_next = mock.AsyncMock()
+        mock_next.execute_workflow = mock.AsyncMock(return_value="wf_result")
+        return mock_next
+
+    @pytest.fixture
+    def workflow_info(self):
+        return MockWorkflowInfo()
+
+    @pytest.mark.asyncio
+    async def test_successful_workflow_emits_events(
+        self, mock_next_workflow, workflow_info
+    ):
+        from application_sdk.observability.app_vitals import (
+            _AppVitalsWorkflowInboundInterceptor,
+        )
+
+        interceptor = _AppVitalsWorkflowInboundInterceptor(mock_next_workflow)
+
+        with (
+            mock.patch(
+                "application_sdk.observability.app_vitals.workflow"
+            ) as mock_wf_mod,
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_log_event"
+            ) as mock_log,
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_metric"
+            ) as mock_metric,
+            mock.patch(
+                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+            ),
+        ):
+            mock_wf_mod.info.return_value = workflow_info
+
+            result = await interceptor.execute_workflow(MockExecuteWorkflowInput())
+
+            assert result == "wf_result"
+
+            # Phase 2/L: now 3 log events — started + completed + summary
+            log_event_names = [c[0][0] for c in mock_log.call_args_list]
+            assert "app_vitals.wf.started" in log_event_names
+            assert "app_vitals.wf.completed" in log_event_names
+            assert "app_vitals.wf.summary" in log_event_names
+
+            completed_call = next(
+                c
+                for c in mock_log.call_args_list
+                if c[0][0] == "app_vitals.wf.completed"
+            )
+            log_attrs = completed_call[0][1]
+            assert log_attrs["status"] == "succeeded"
+            assert log_attrs["workflow_id"] == "wf-abc-123"
+            assert log_attrs["workflow_type"] == "metadata_crawl"
+
+            assert mock_metric.call_count == 2
+            metric_calls = [c[0][0] for c in mock_metric.call_args_list]
+            assert "app_vitals.reliability.wf_completed" in metric_calls
+            assert "app_vitals.performance.wf_runtime" in metric_calls
+
+    @pytest.mark.asyncio
+    async def test_failed_workflow_emits_error(self, mock_next_workflow, workflow_info):
+        from application_sdk.observability.app_vitals import (
+            _AppVitalsWorkflowInboundInterceptor,
+        )
+
+        mock_next_workflow.execute_workflow = mock.AsyncMock(
+            side_effect=ConnectionError("db unreachable")
+        )
+        interceptor = _AppVitalsWorkflowInboundInterceptor(mock_next_workflow)
+
+        with (
+            mock.patch(
+                "application_sdk.observability.app_vitals.workflow"
+            ) as mock_wf_mod,
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_log_event"
+            ) as mock_log,
+            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+            ),
+        ):
+            mock_wf_mod.info.return_value = workflow_info
+
+            with pytest.raises(ConnectionError):
+                await interceptor.execute_workflow(MockExecuteWorkflowInput())
+
+            # Check the completion event (not started, not summary)
+            completed_call = next(
+                c
+                for c in mock_log.call_args_list
+                if c[0][0] == "app_vitals.wf.completed"
+            )
+            log_attrs = completed_call[0][1]
+            assert log_attrs["status"] == "failed"
+            assert log_attrs["error_type"] == "upstream"
+            assert "db unreachable" in log_attrs["error_message"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Trace Context Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTraceContext:
+    """Tests for the OTel trace context helper."""
+
+    def test_no_tracer_returns_empty_strings(self):
+        # With no active tracer, the default span context is invalid
+        trace_id, span_id = get_trace_context()
+        assert trace_id == ""
+        assert span_id == ""
+
+    def test_active_span_returns_hex_ids(self):
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+
+        # Set up a minimal tracer provider
+        provider = TracerProvider()
+        trace.set_tracer_provider(provider)
+        tracer = trace.get_tracer("test")
+
+        with tracer.start_as_current_span("test_span"):
+            trace_id, span_id = get_trace_context()
+            assert len(trace_id) == 32  # 128-bit hex
+            assert len(span_id) == 16  # 64-bit hex
+            assert all(c in "0123456789abcdef" for c in trace_id)
+            assert all(c in "0123456789abcdef" for c in span_id)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Resource Sampler Tests
+# ---------------------------------------------------------------------------
+
+
+class TestResourceSampler:
+    """Tests for process-level CPU/memory sampling."""
+
+    def test_sample_returns_valid_data(self):
+        from application_sdk.observability.resource_sampler import sample
+
+        s = sample()
+        # On Mac/Linux with psutil installed, this should work
+        if s is not None:
+            assert s.cpu_time_s >= 0
+            assert s.rss_bytes > 0
+
+    def test_compute_deltas_normal_case(self):
+        start = ResourceSample(cpu_time_s=10.0, rss_bytes=100 * 1024 * 1024)  # 100 MB
+        end = ResourceSample(cpu_time_s=12.5, rss_bytes=200 * 1024 * 1024)  # 200 MB
+
+        cpu_seconds, mem_gb_sec = compute_deltas(start, end, duration_s=10.0)
+
+        assert cpu_seconds == 2.5
+        # avg RSS = 150 MB = 150/1024 GiB ≈ 0.1465
+        # mem_gb_sec = 0.1465 * 10 = 1.465
+        assert 1.4 < mem_gb_sec < 1.5
+
+    def test_compute_deltas_none_sample_returns_zero(self):
+        cpu_seconds, mem_gb_sec = compute_deltas(None, None, 1.0)
+        assert cpu_seconds == 0.0
+        assert mem_gb_sec == 0.0
+
+    def test_compute_deltas_clamps_negative_cpu(self):
+        # Can happen due to rounding or counter resets
+        start = ResourceSample(cpu_time_s=10.0, rss_bytes=100 * 1024 * 1024)
+        end = ResourceSample(cpu_time_s=9.5, rss_bytes=100 * 1024 * 1024)
+
+        cpu_seconds, _ = compute_deltas(start, end, duration_s=1.0)
+        assert cpu_seconds == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Enhanced Interceptor — Efficiency Metrics
+# ---------------------------------------------------------------------------
+
+
+class TestAppVitalsEfficiencyMetrics:
+    """Tests that activity interceptor emits cpu_seconds and mem_gb_sec."""
+
+    @pytest.fixture
+    def mock_next_activity(self):
+        mock_next = mock.AsyncMock()
+        mock_next.execute_activity = mock.AsyncMock(return_value="result")
+        return mock_next
+
+    @pytest.fixture
+    def activity_info(self):
+        return MockActivityInfo()
+
+    @pytest.mark.asyncio
+    async def test_efficiency_metrics_emitted(self, mock_next_activity, activity_info):
+        from application_sdk.observability.app_vitals import (
+            _AppVitalsActivityInboundInterceptor,
+        )
+
+        interceptor = _AppVitalsActivityInboundInterceptor(mock_next_activity)
+
+        with (
+            mock.patch(
+                "application_sdk.observability.app_vitals.activity"
+            ) as mock_activity_mod,
+            mock.patch("application_sdk.observability.app_vitals._emit_log_event"),
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_metric"
+            ) as mock_metric,
+            mock.patch(
+                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+            ),
+        ):
+            mock_activity_mod.info.return_value = activity_info
+
+            await interceptor.execute_activity(MockExecuteActivityInput())
+
+            metric_names = [c[0][0] for c in mock_metric.call_args_list]
+            # Efficiency metrics should be emitted if psutil works on this platform
+            # (may be 0.0 values, but metrics are emitted)
+            if "app_vitals.efficiency.activity_cpu_seconds" in metric_names:
+                assert "app_vitals.efficiency.activity_mem_gb_sec" in metric_names
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Enhanced Interceptor — Trace ID Attachment
+# ---------------------------------------------------------------------------
+
+
+class TestAppVitalsTraceIdAttachment:
+    """Tests that trace_id and span_id are attached to emitted events."""
+
+    @pytest.fixture
+    def mock_next_activity(self):
+        mock_next = mock.AsyncMock()
+        mock_next.execute_activity = mock.AsyncMock(return_value="result")
+        return mock_next
+
+    @pytest.fixture
+    def activity_info(self):
+        return MockActivityInfo()
+
+    @pytest.mark.asyncio
+    async def test_trace_ids_present_in_event_attrs(
+        self, mock_next_activity, activity_info
+    ):
+        from application_sdk.observability.app_vitals import (
+            _AppVitalsActivityInboundInterceptor,
+        )
+
+        interceptor = _AppVitalsActivityInboundInterceptor(mock_next_activity)
+
+        with (
+            mock.patch(
+                "application_sdk.observability.app_vitals.activity"
+            ) as mock_activity_mod,
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_log_event"
+            ) as mock_log,
+            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.get_trace_context",
+                return_value=("0123456789abcdef0123456789abcdef", "fedcba9876543210"),
+            ),
+        ):
+            mock_activity_mod.info.return_value = activity_info
+
+            await interceptor.execute_activity(MockExecuteActivityInput())
+
+            log_attrs = mock_log.call_args[0][1]
+            assert log_attrs["trace_id"] == "0123456789abcdef0123456789abcdef"
+            assert log_attrs["span_id"] == "fedcba9876543210"
+
+    @pytest.mark.asyncio
+    async def test_trace_ids_empty_when_no_tracer(
+        self, mock_next_activity, activity_info
+    ):
+        from application_sdk.observability.app_vitals import (
+            _AppVitalsActivityInboundInterceptor,
+        )
+
+        interceptor = _AppVitalsActivityInboundInterceptor(mock_next_activity)
+
+        with (
+            mock.patch(
+                "application_sdk.observability.app_vitals.activity"
+            ) as mock_activity_mod,
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_log_event"
+            ) as mock_log,
+            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.get_trace_context",
+                return_value=("", ""),
+            ),
+        ):
+            mock_activity_mod.info.return_value = activity_info
+
+            await interceptor.execute_activity(MockExecuteActivityInput())
+
+            log_attrs = mock_log.call_args[0][1]
+            # Empty strings are OK — they just mean no tracer is running
+            assert log_attrs["trace_id"] == ""
+            assert log_attrs["span_id"] == ""
+
+
+# ---------------------------------------------------------------------------
+# L3: Rich Error Schema (cause chain, is_retriable, timeout budget)
+# ---------------------------------------------------------------------------
+
+
+class TestErrorClassifierRichFields:
+    """Tests for cause chain extraction and is_retriable heuristic."""
+
+    def test_extract_cause_chain_explicit(self):
+        try:
+            try:
+                raise OSError("network unreachable")
+            except OSError as inner:
+                raise ConnectionError("db unreachable") from inner
+        except ConnectionError as e:
+            chain = extract_cause_chain(e)
+
+        assert len(chain) == 1
+        assert "OSError" in chain[0]
+        assert "network unreachable" in chain[0]
+
+    def test_extract_cause_chain_implicit(self):
+        try:
+            try:
+                raise ValueError("bad input")
+            except ValueError:
+                raise RuntimeError("wrapper")  # implicit __context__
+        except RuntimeError as e:
+            chain = extract_cause_chain(e)
+
+        assert len(chain) == 1
+        assert "ValueError" in chain[0]
+
+    def test_extract_cause_chain_none(self):
+        e = Exception("standalone")
+        assert extract_cause_chain(e) == []
+
+    def test_extract_cause_chain_respects_limit(self):
+        # Deeply nested chain
+        e = None
+        for i in range(10):
+            try:
+                if e is None:
+                    raise Exception(f"layer-{i}")
+                raise Exception(f"layer-{i}") from e
+            except Exception as err:
+                e = err
+        chain = extract_cause_chain(e, limit=3)
+        assert len(chain) == 3
+
+    def test_is_retriable_config_error(self):
+        assert is_retriable(ValueError("bad input")) is False
+
+    def test_is_retriable_timeout(self):
+        assert is_retriable(TimeoutError("timed out")) is True
+
+    def test_is_retriable_upstream(self):
+        assert is_retriable(ConnectionError("refused")) is True
+
+    def test_is_retriable_cancelled(self):
+        import asyncio
+
+        assert is_retriable(asyncio.CancelledError()) is False
+
+    def test_is_retriable_respects_non_retryable_flag(self):
+        e = Exception("app error")
+        e.non_retryable = True  # Temporal ApplicationError pattern
+        assert is_retriable(e) is False
+
+
+class TestAppVitalsRichErrorFields:
+    """Tests that activity failure events include cause chain + is_retriable + timeout budget."""
+
+    @pytest.fixture
+    def mock_next_activity(self):
+        mock_next = mock.AsyncMock()
+        return mock_next
+
+    @pytest.fixture
+    def activity_info(self):
+        return MockActivityInfo()
+
+    @pytest.mark.asyncio
+    async def test_failure_carries_error_class_and_retriable(
+        self, mock_next_activity, activity_info
+    ):
+        from application_sdk.observability.app_vitals import (
+            _AppVitalsActivityInboundInterceptor,
+        )
+
+        mock_next_activity.execute_activity = mock.AsyncMock(
+            side_effect=TimeoutError("timed out")
+        )
+        interceptor = _AppVitalsActivityInboundInterceptor(mock_next_activity)
+
+        with (
+            mock.patch(
+                "application_sdk.observability.app_vitals.activity"
+            ) as mock_activity_mod,
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_log_event"
+            ) as mock_log,
+            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+            ),
+        ):
+            mock_activity_mod.info.return_value = activity_info
+
+            with pytest.raises(TimeoutError):
+                await interceptor.execute_activity(MockExecuteActivityInput())
+
+            completed_call = next(
+                c
+                for c in mock_log.call_args_list
+                if c[0][0] == "app_vitals.act.completed"
+            )
+            log_attrs = completed_call[0][1]
+            assert log_attrs["error_class"] == "TimeoutError"
+            assert log_attrs["is_retriable"] is True
+
+    @pytest.mark.asyncio
+    async def test_failure_carries_cause_chain(self, mock_next_activity, activity_info):
+        from application_sdk.observability.app_vitals import (
+            _AppVitalsActivityInboundInterceptor,
+        )
+
+        async def _raise_with_cause(_input):
+            try:
+                raise OSError("network down")
+            except OSError as inner:
+                raise ConnectionError("db unreachable") from inner
+
+        mock_next_activity.execute_activity = mock.AsyncMock(
+            side_effect=_raise_with_cause
+        )
+        interceptor = _AppVitalsActivityInboundInterceptor(mock_next_activity)
+
+        with (
+            mock.patch(
+                "application_sdk.observability.app_vitals.activity"
+            ) as mock_activity_mod,
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_log_event"
+            ) as mock_log,
+            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+            ),
+        ):
+            mock_activity_mod.info.return_value = activity_info
+
+            with pytest.raises(ConnectionError):
+                await interceptor.execute_activity(MockExecuteActivityInput())
+
+            completed_call = next(
+                c
+                for c in mock_log.call_args_list
+                if c[0][0] == "app_vitals.act.completed"
+            )
+            log_attrs = completed_call[0][1]
+            assert "error_cause_chain" in log_attrs
+            assert len(log_attrs["error_cause_chain"]) >= 1
+            assert "OSError" in log_attrs["error_cause_chain"][0]
+
+    @pytest.mark.asyncio
+    async def test_timeout_budget_computed(self, mock_next_activity, activity_info):
+        from application_sdk.observability.app_vitals import (
+            _AppVitalsActivityInboundInterceptor,
+        )
+
+        interceptor = _AppVitalsActivityInboundInterceptor(mock_next_activity)
+
+        with (
+            mock.patch(
+                "application_sdk.observability.app_vitals.activity"
+            ) as mock_activity_mod,
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_log_event"
+            ) as mock_log,
+            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+            ),
+        ):
+            mock_activity_mod.info.return_value = activity_info  # 5-min timeout
+
+            await interceptor.execute_activity(MockExecuteActivityInput())
+
+            completed_call = next(
+                c
+                for c in mock_log.call_args_list
+                if c[0][0] == "app_vitals.act.completed"
+            )
+            log_attrs = completed_call[0][1]
+            assert log_attrs["timeout_budget_total_ms"] == 300000.0  # 5 min
+            assert log_attrs["timeout_budget_used_pct"] is not None
+
+
+# ---------------------------------------------------------------------------
+# L2: Lifecycle Start Events
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycleStartEvents:
+    """Tests that started events are emitted before the activity/workflow runs."""
+
+    @pytest.fixture
+    def mock_next_activity(self):
+        mock_next = mock.AsyncMock()
+        mock_next.execute_activity = mock.AsyncMock(return_value="ok")
+        return mock_next
+
+    @pytest.mark.asyncio
+    async def test_act_started_emitted_before_completed(self, mock_next_activity):
+        from application_sdk.observability.app_vitals import (
+            _AppVitalsActivityInboundInterceptor,
+        )
+
+        interceptor = _AppVitalsActivityInboundInterceptor(mock_next_activity)
+        info = MockActivityInfo()
+
+        with (
+            mock.patch(
+                "application_sdk.observability.app_vitals.activity"
+            ) as mock_activity_mod,
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_log_event"
+            ) as mock_log,
+            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+            ),
+        ):
+            mock_activity_mod.info.return_value = info
+
+            await interceptor.execute_activity(MockExecuteActivityInput())
+
+            event_names = [c[0][0] for c in mock_log.call_args_list]
+            assert event_names.index("app_vitals.act.started") < event_names.index(
+                "app_vitals.act.completed"
+            )
+
+            started_call = next(
+                c
+                for c in mock_log.call_args_list
+                if c[0][0] == "app_vitals.act.started"
+            )
+            started_attrs = started_call[0][1]
+            assert started_attrs["activity_type"] == "extract"
+            assert started_attrs["workflow_id"] == "wf-abc-123"
+            # Started event must NOT have duration_ms or status
+            assert "status" not in started_attrs
+            assert "duration_ms" not in started_attrs
+
+
+# ---------------------------------------------------------------------------
+# L9: assets_processed Convention
+# ---------------------------------------------------------------------------
+
+
+class TestAssetsProcessed:
+    """Tests extraction of assets_processed from activity return values."""
+
+    def test_extract_from_total_record_count(self):
+        from application_sdk.observability.app_vitals import _extract_assets_processed
+
+        class Result:
+            total_record_count = 50000
+
+        assert _extract_assets_processed(Result()) == 50000
+
+    def test_extract_from_assets_processed(self):
+        from application_sdk.observability.app_vitals import _extract_assets_processed
+
+        class Result:
+            assets_processed = 42
+
+        assert _extract_assets_processed(Result()) == 42
+
+    def test_extract_from_dict(self):
+        from application_sdk.observability.app_vitals import _extract_assets_processed
+
+        assert _extract_assets_processed({"assets_processed": 100}) == 100
+
+    def test_extract_returns_none_for_missing(self):
+        from application_sdk.observability.app_vitals import _extract_assets_processed
+
+        class Result:
+            other_field = 1
+
+        assert _extract_assets_processed(Result()) is None
+
+    def test_extract_returns_none_for_none(self):
+        from application_sdk.observability.app_vitals import _extract_assets_processed
+
+        assert _extract_assets_processed(None) is None
+
+    def test_extract_handles_non_int(self):
+        from application_sdk.observability.app_vitals import _extract_assets_processed
+
+        class Result:
+            assets_processed = "not_a_number"
+
+        assert _extract_assets_processed(Result()) is None
+
+    @pytest.mark.asyncio
+    async def test_activity_event_carries_assets_processed(self):
+        from application_sdk.observability.app_vitals import (
+            _AppVitalsActivityInboundInterceptor,
+        )
+
+        class MockResult:
+            total_record_count = 12345
+
+        mock_next = mock.AsyncMock()
+        mock_next.execute_activity = mock.AsyncMock(return_value=MockResult())
+        interceptor = _AppVitalsActivityInboundInterceptor(mock_next)
+
+        with (
+            mock.patch(
+                "application_sdk.observability.app_vitals.activity"
+            ) as mock_activity_mod,
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_log_event"
+            ) as mock_log,
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_metric"
+            ) as mock_metric,
+            mock.patch(
+                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+            ),
+        ):
+            mock_activity_mod.info.return_value = MockActivityInfo()
+
+            await interceptor.execute_activity(MockExecuteActivityInput())
+
+            completed_call = next(
+                c
+                for c in mock_log.call_args_list
+                if c[0][0] == "app_vitals.act.completed"
+            )
+            assert completed_call[0][1]["assets_processed"] == 12345
+
+            metric_names = [c[0][0] for c in mock_metric.call_args_list]
+            assert "app_vitals.performance.activity_assets_processed" in metric_names
+
+
+# ---------------------------------------------------------------------------
+# L1: Workflow Summary Event
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowSummary:
+    """Tests the workflow summary event rollup."""
+
+    @pytest.fixture
+    def mock_next_workflow(self):
+        mock_next = mock.AsyncMock()
+        mock_next.execute_workflow = mock.AsyncMock(return_value="ok")
+        return mock_next
+
+    @pytest.mark.asyncio
+    async def test_summary_event_emitted_with_zero_activities(self, mock_next_workflow):
+        from application_sdk.observability.app_vitals import (
+            _AppVitalsWorkflowInboundInterceptor,
+        )
+
+        interceptor = _AppVitalsWorkflowInboundInterceptor(mock_next_workflow)
+
+        with (
+            mock.patch(
+                "application_sdk.observability.app_vitals.workflow"
+            ) as mock_wf_mod,
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_log_event"
+            ) as mock_log,
+            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+            ),
+        ):
+            mock_wf_mod.info.return_value = MockWorkflowInfo()
+
+            await interceptor.execute_workflow(MockExecuteWorkflowInput())
+
+            summary_call = next(
+                c for c in mock_log.call_args_list if c[0][0] == "app_vitals.wf.summary"
+            )
+            attrs = summary_call[0][1]
+            assert attrs["total_activities"] == 0
+            assert attrs["succeeded_activities"] == 0
+            assert attrs["failed_activities"] == 0
+            assert attrs["status"] == "succeeded"
+
+    def test_build_summary_with_activity_records(self):
+        from application_sdk.observability.app_vitals import (
+            _AppVitalsWorkflowInboundInterceptor,
+        )
+
+        mock_next = mock.AsyncMock()
+        interceptor = _AppVitalsWorkflowInboundInterceptor(mock_next)
+
+        # Seed records as if the outbound interceptor had tracked them
+        interceptor._activity_records = [
+            {
+                "activity_type": "fetch_databases",
+                "status": "succeeded",
+                "start_ns": 1000,
+                "end_ns": 51000,
+                "duration_ms": 50.0,
+            },
+            {
+                "activity_type": "fetch_tables",
+                "status": "failed",
+                "error_type": "timeout",
+                "start_ns": 52000,
+                "end_ns": 82000,
+                "duration_ms": 30.0,
+            },
+            {
+                "activity_type": "fetch_views",
+                "status": "succeeded",
+                "start_ns": 83000,
+                "end_ns": 183000,
+                "duration_ms": 100.0,  # bottleneck (longest)
+            },
+        ]
+
+        common = {"app_name": "snowflake", "tenant_id": "t1"}
+        info = MockWorkflowInfo()
+        summary = interceptor._build_summary_attrs(common, info, "succeeded", 500.0)
+
+        assert summary["total_activities"] == 3
+        assert summary["succeeded_activities"] == 2
+        assert summary["failed_activities"] == 1
+        assert summary["first_failure_activity_type"] == "fetch_tables"
+        assert summary["first_failure_error_type"] == "timeout"
+        assert summary["bottleneck_activity_type"] == "fetch_views"
+        assert summary["bottleneck_duration_ms"] == 100.0
+
+
+# ---------------------------------------------------------------------------
+# Regression: post-audit fixes
+# ---------------------------------------------------------------------------
+
+
+class TestLoggerAdaptorExtraKeysAllowlist:
+    """Regression for audit finding: logger_adaptor._KNOWN_EXTRA_KEYS allowlist
+    was silently dropping ~20 App Vitals fields before they reached OTLP log
+    export. All fields we emit on events must be in the allowlist.
+    """
+
+    APP_VITALS_LOG_FIELDS = [
+        # Identity
+        "app_name",
+        "app_version",
+        "tenant_id",
+        # Execution context
+        "workflow_id",
+        "run_id",
+        "workflow_run_id",
+        "workflow_type",
+        "activity_id",
+        "activity_type",
+        "task_queue",
+        "attempt",
+        "namespace",
+        "correlation_id",
+        "trace_id",
+        "span_id",
+        # Outcome
+        "status",
+        "error_type",
+        "error_class",
+        "error_message",
+        "is_retriable",
+        "error_cause_chain",
+        # Metric classification
+        "dimension",
+        "source",
+        "metric_name",
+        # Throughput / efficiency
+        "assets_processed",
+        "cpu_seconds",
+        "mem_gb_sec",
+        # Performance timings
+        "duration_ms",
+        "schedule_to_start_ms",
+        "timeout_budget_total_ms",
+        "timeout_budget_used_pct",
+        # Workflow summary
+        "total_activities",
+        "succeeded_activities",
+        "failed_activities",
+        "total_child_workflows",
+        "first_failure_activity_type",
+        "first_failure_error_type",
+        "bottleneck_activity_type",
+        "bottleneck_duration_ms",
+    ]
+
+    def test_all_app_vitals_fields_survive_extra_dict_filter(self):
+        """Every attribute we put on an event must come out the other side
+        of _build_extra_dict() unchanged. If this test fails, new events we
+        emit won't reach OTLP/ClickHouse even though the interceptor calls
+        the logger."""
+        from application_sdk.observability.logger_adaptor import (
+            _KNOWN_EXTRA_KEYS,
+            _build_extra_dict,
+        )
+
+        missing_from_allowlist = [
+            f for f in self.APP_VITALS_LOG_FIELDS if f not in _KNOWN_EXTRA_KEYS
+        ]
+        assert missing_from_allowlist == [], (
+            "These App Vitals fields are missing from _KNOWN_EXTRA_KEYS "
+            f"and will be dropped before OTLP export: {missing_from_allowlist}"
+        )
+
+        # Realistic example: a failed activity event
+        sample_extra = {
+            "app_name": "snowflake",
+            "app_version": "2.4.2",
+            "tenant_id": "tenant_123",
+            "workflow_id": "wf-abc",
+            "run_id": "run-def",
+            "activity_type": "fetch_tables",
+            "status": "failed",
+            "error_type": "timeout",
+            "error_class": "TimeoutError",
+            "is_retriable": True,
+            "duration_ms": 30000,
+            "cpu_seconds": 0.5,
+            "assets_processed": 50000,
+            "timeout_budget_used_pct": 95.5,
+            "dimension": "reliability",
+            "metric_name": "app_vitals.reliability.activity_completed",
+            "logger_name": "app_vitals",  # should be filtered
+        }
+        out = _build_extra_dict(sample_extra)
+
+        # logger_name is always filtered — that's the one explicit exclusion
+        assert "logger_name" not in out
+        # Everything else the interceptor emits must pass through
+        for k, v in sample_extra.items():
+            if k == "logger_name":
+                continue
+            assert k in out, f"{k} was dropped by _build_extra_dict"
+
+
+class TestDurationMetricsUseHistogram:
+    """Regression for audit finding: emitting durations as MetricType.GAUGE
+    hits create_observable_gauge() in metrics_adaptor which doesn't support
+    .add() — errors are caught silently. Durations must use HISTOGRAM.
+    """
+
+    @pytest.fixture
+    def mock_next_activity(self):
+        mock_next = mock.AsyncMock()
+        mock_next.execute_activity = mock.AsyncMock(return_value="ok")
+        return mock_next
+
+    @pytest.mark.asyncio
+    async def test_activity_duration_emitted_as_histogram(self, mock_next_activity):
+        from application_sdk.observability.app_vitals import (
+            _AppVitalsActivityInboundInterceptor,
+        )
+
+        interceptor = _AppVitalsActivityInboundInterceptor(mock_next_activity)
+
+        with (
+            mock.patch(
+                "application_sdk.observability.app_vitals.activity"
+            ) as mock_activity_mod,
+            mock.patch("application_sdk.observability.app_vitals._emit_log_event"),
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_metric"
+            ) as mock_metric,
+            mock.patch(
+                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+            ),
+        ):
+            mock_activity_mod.info.return_value = MockActivityInfo()
+
+            await interceptor.execute_activity(MockExecuteActivityInput())
+
+            # Map each emitted metric name to its type
+            by_name = {c[0][0]: c[0][2] for c in mock_metric.call_args_list}
+
+            for duration_metric in (
+                "app_vitals.performance.activity_runtime",
+                "app_vitals.performance.activity_schedule_to_start",
+            ):
+                assert duration_metric in by_name, f"{duration_metric} was not emitted"
+                assert by_name[duration_metric] == "histogram", (
+                    f"{duration_metric} must be histogram, got "
+                    f"{by_name[duration_metric]!r}. ObservableGauge.add() "
+                    f"doesn't exist — gauge emissions are silently dropped."
+                )
+
+    @pytest.mark.asyncio
+    async def test_workflow_duration_emitted_as_histogram(self):
+        from application_sdk.observability.app_vitals import (
+            _AppVitalsWorkflowInboundInterceptor,
+        )
+
+        mock_next = mock.AsyncMock()
+        mock_next.execute_workflow = mock.AsyncMock(return_value="ok")
+        interceptor = _AppVitalsWorkflowInboundInterceptor(mock_next)
+
+        with (
+            mock.patch(
+                "application_sdk.observability.app_vitals.workflow"
+            ) as mock_wf_mod,
+            mock.patch("application_sdk.observability.app_vitals._emit_log_event"),
+            mock.patch(
+                "application_sdk.observability.app_vitals._emit_metric"
+            ) as mock_metric,
+            mock.patch(
+                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
+            ),
+            mock.patch(
+                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
+            ),
+        ):
+            mock_wf_mod.info.return_value = MockWorkflowInfo()
+
+            await interceptor.execute_workflow(MockExecuteWorkflowInput())
+
+            by_name = {c[0][0]: c[0][2] for c in mock_metric.call_args_list}
+
+            assert by_name.get("app_vitals.performance.wf_runtime") == "histogram"

--- a/tests/unit/interceptors/test_app_vitals.py
+++ b/tests/unit/interceptors/test_app_vitals.py
@@ -132,6 +132,9 @@ class MockWorkflowInfo:
     task_queue: str = "atlan-snowflake"
     namespace: str = "default"
     attempt: int = 1
+    parent: None = None
+    continued_run_id: str | None = None
+    cron_schedule: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -327,6 +330,7 @@ class TestAppVitalsWorkflowInterceptor:
             ),
         ):
             mock_wf_mod.info.return_value = workflow_info
+            mock_wf_mod.unsafe.is_replaying.return_value = False
 
             result = await interceptor.execute_workflow(MockExecuteWorkflowInput())
 
@@ -380,6 +384,7 @@ class TestAppVitalsWorkflowInterceptor:
             ),
         ):
             mock_wf_mod.info.return_value = workflow_info
+            mock_wf_mod.unsafe.is_replaying.return_value = False
 
             with pytest.raises(ConnectionError):
                 await interceptor.execute_workflow(MockExecuteWorkflowInput())
@@ -1016,6 +1021,7 @@ class TestWorkflowSummary:
             ),
         ):
             mock_wf_mod.info.return_value = MockWorkflowInfo()
+            mock_wf_mod.unsafe.is_replaying.return_value = False
 
             await interceptor.execute_workflow(MockExecuteWorkflowInput())
 
@@ -1263,6 +1269,7 @@ class TestDurationMetricsUseHistogram:
             ),
         ):
             mock_wf_mod.info.return_value = MockWorkflowInfo()
+            mock_wf_mod.unsafe.is_replaying.return_value = False
 
             await interceptor.execute_workflow(MockExecuteWorkflowInput())
 

--- a/tests/unit/interceptors/test_app_vitals.py
+++ b/tests/unit/interceptors/test_app_vitals.py
@@ -175,9 +175,7 @@ class TestAppVitalsActivityInterceptor:
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
-            mock.patch(
-                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
-            ),
+            mock.patch("application_sdk.constants.APP_TENANT_ID", "tenant_123"),
         ):
             mock_activity_mod.info.return_value = activity_info
 
@@ -202,7 +200,6 @@ class TestAppVitalsActivityInterceptor:
             assert log_attrs["workflow_id"] == "wf-abc-123"
             assert log_attrs["duration_ms"] >= 0
 
-
     @pytest.mark.asyncio
     async def test_failed_activity_emits_error_type(
         self, mock_next_activity, activity_info
@@ -226,9 +223,7 @@ class TestAppVitalsActivityInterceptor:
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
-            mock.patch(
-                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
-            ),
+            mock.patch("application_sdk.constants.APP_TENANT_ID", "tenant_123"),
         ):
             mock_activity_mod.info.return_value = activity_info
 
@@ -261,9 +256,7 @@ class TestAppVitalsActivityInterceptor:
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
-            mock.patch(
-                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
-            ),
+            mock.patch("application_sdk.constants.APP_TENANT_ID", "tenant_123"),
         ):
             mock_activity_mod.info.return_value = activity_info
 
@@ -271,7 +264,8 @@ class TestAppVitalsActivityInterceptor:
 
             # Verify the act.completed event captured the retry attempt
             completed_call = next(
-                c for c in mock_log.call_args_list
+                c
+                for c in mock_log.call_args_list
                 if c[0][0] == "app_vitals.act.completed"
             )
             attrs = completed_call[0][1]
@@ -311,9 +305,7 @@ class TestAppVitalsWorkflowInterceptor:
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
-            mock.patch(
-                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
-            ),
+            mock.patch("application_sdk.constants.APP_TENANT_ID", "tenant_123"),
         ):
             mock_wf_mod.info.return_value = workflow_info
             mock_wf_mod.unsafe.is_replaying.return_value = False
@@ -338,7 +330,6 @@ class TestAppVitalsWorkflowInterceptor:
             assert log_attrs["workflow_id"] == "wf-abc-123"
             assert log_attrs["workflow_type"] == "metadata_crawl"
 
-
     @pytest.mark.asyncio
     async def test_failed_workflow_emits_error(self, mock_next_workflow, workflow_info):
         from application_sdk.observability.app_vitals import (
@@ -360,9 +351,7 @@ class TestAppVitalsWorkflowInterceptor:
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
-            mock.patch(
-                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
-            ),
+            mock.patch("application_sdk.constants.APP_TENANT_ID", "tenant_123"),
         ):
             mock_wf_mod.info.return_value = workflow_info
             mock_wf_mod.unsafe.is_replaying.return_value = False
@@ -489,9 +478,7 @@ class TestAppVitalsEfficiencyMetrics:
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
-            mock.patch(
-                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
-            ),
+            mock.patch("application_sdk.constants.APP_TENANT_ID", "tenant_123"),
         ):
             mock_activity_mod.info.return_value = activity_info
 
@@ -539,9 +526,7 @@ class TestAppVitalsTraceIdAttachment:
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
-            mock.patch(
-                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
-            ),
+            mock.patch("application_sdk.constants.APP_TENANT_ID", "tenant_123"),
             mock.patch(
                 "application_sdk.observability.app_vitals.get_trace_context",
                 return_value=("0123456789abcdef0123456789abcdef", "fedcba9876543210"),
@@ -575,9 +560,7 @@ class TestAppVitalsTraceIdAttachment:
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
-            mock.patch(
-                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
-            ),
+            mock.patch("application_sdk.constants.APP_TENANT_ID", "tenant_123"),
             mock.patch(
                 "application_sdk.observability.app_vitals.get_trace_context",
                 return_value=("", ""),
@@ -698,9 +681,7 @@ class TestAppVitalsRichErrorFields:
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
-            mock.patch(
-                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
-            ),
+            mock.patch("application_sdk.constants.APP_TENANT_ID", "tenant_123"),
         ):
             mock_activity_mod.info.return_value = activity_info
 
@@ -743,9 +724,7 @@ class TestAppVitalsRichErrorFields:
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
-            mock.patch(
-                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
-            ),
+            mock.patch("application_sdk.constants.APP_TENANT_ID", "tenant_123"),
         ):
             mock_activity_mod.info.return_value = activity_info
 
@@ -780,9 +759,7 @@ class TestAppVitalsRichErrorFields:
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
-            mock.patch(
-                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
-            ),
+            mock.patch("application_sdk.constants.APP_TENANT_ID", "tenant_123"),
         ):
             mock_activity_mod.info.return_value = activity_info  # 5-min timeout
 
@@ -831,9 +808,7 @@ class TestLifecycleStartEvents:
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
-            mock.patch(
-                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
-            ),
+            mock.patch("application_sdk.constants.APP_TENANT_ID", "tenant_123"),
         ):
             mock_activity_mod.info.return_value = info
 
@@ -930,9 +905,7 @@ class TestAssetsProcessed:
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
-            mock.patch(
-                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
-            ),
+            mock.patch("application_sdk.constants.APP_TENANT_ID", "tenant_123"),
         ):
             mock_activity_mod.info.return_value = MockActivityInfo()
 
@@ -944,7 +917,6 @@ class TestAssetsProcessed:
                 if c[0][0] == "app_vitals.act.completed"
             )
             assert completed_call[0][1]["assets_processed"] == 12345
-
 
 
 # ---------------------------------------------------------------------------
@@ -979,9 +951,7 @@ class TestWorkflowSummary:
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
-            mock.patch(
-                "application_sdk.constants.APP_TENANT_ID", "tenant_123"
-            ),
+            mock.patch("application_sdk.constants.APP_TENANT_ID", "tenant_123"),
         ):
             mock_wf_mod.info.return_value = MockWorkflowInfo()
             mock_wf_mod.unsafe.is_replaying.return_value = False
@@ -1153,8 +1123,5 @@ class TestLoggerAdaptorExtraKeysAllowlist:
             assert k in out, f"{k} was dropped by _build_extra_dict"
 
 
-
 # TestDurationMetricsUseHistogram removed — Path 2 (OTel metrics) was removed;
 # all analytics are now computed from Path 1 (log events → MV).
-
-

--- a/tests/unit/interceptors/test_app_vitals.py
+++ b/tests/unit/interceptors/test_app_vitals.py
@@ -1068,7 +1068,7 @@ class TestWorkflowSummary:
             },
         ]
 
-        common = {"app_name": "snowflake", "tenant_id": "t1"}
+        common = {"app_name": "snowflake"}
         info = MockWorkflowInfo()
         summary = interceptor._build_summary_attrs(common, info, "succeeded", 500.0)
 
@@ -1094,10 +1094,10 @@ class TestLoggerAdaptorExtraKeysAllowlist:
 
     APP_VITALS_LOG_FIELDS = [
         # Identity — only per-workflow/per-app fields. Deployment attrs (version,
-        # release_id, pod_name, k8s.domain.name) are on OTel Resource.
+        # release_id, pod_name, k8s.domain.name, k8s.cluster.name) are on OTel
+        # Resource. tenant_id is redundant with k8s.cluster.name.
         "app_vitals",
         "app_name",
-        "tenant_id",
         # Execution context
         "workflow_id",
         "run_id",
@@ -1164,7 +1164,6 @@ class TestLoggerAdaptorExtraKeysAllowlist:
         sample_extra = {
             "app_vitals": "true",
             "app_name": "snowflake",
-            "tenant_id": "tenant_123",
             "workflow_id": "wf-abc",
             "run_id": "run-def",
             "activity_type": "fetch_tables",

--- a/tests/unit/interceptors/test_app_vitals.py
+++ b/tests/unit/interceptors/test_app_vitals.py
@@ -173,9 +173,6 @@ class TestAppVitalsActivityInterceptor:
                 "application_sdk.observability.app_vitals._emit_log_event"
             ) as mock_log,
             mock.patch(
-                "application_sdk.observability.app_vitals._emit_metric"
-            ) as mock_metric,
-            mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
@@ -205,10 +202,6 @@ class TestAppVitalsActivityInterceptor:
             assert log_attrs["workflow_id"] == "wf-abc-123"
             assert log_attrs["duration_ms"] >= 0
 
-            assert mock_metric.call_count >= 2
-            metric_calls = [c[0][0] for c in mock_metric.call_args_list]
-            assert "app_vitals.reliability.activity_completed" in metric_calls
-            assert "app_vitals.performance.activity_runtime" in metric_calls
 
     @pytest.mark.asyncio
     async def test_failed_activity_emits_error_type(
@@ -230,7 +223,6 @@ class TestAppVitalsActivityInterceptor:
             mock.patch(
                 "application_sdk.observability.app_vitals._emit_log_event"
             ) as mock_log,
-            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
@@ -263,10 +255,9 @@ class TestAppVitalsActivityInterceptor:
             mock.patch(
                 "application_sdk.observability.app_vitals.activity"
             ) as mock_activity_mod,
-            mock.patch("application_sdk.observability.app_vitals._emit_log_event"),
             mock.patch(
-                "application_sdk.observability.app_vitals._emit_metric"
-            ) as mock_metric,
+                "application_sdk.observability.app_vitals._emit_log_event"
+            ) as mock_log,
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
@@ -278,15 +269,13 @@ class TestAppVitalsActivityInterceptor:
 
             await interceptor.execute_activity(MockExecuteActivityInput())
 
-            metric_calls = [c[0][0] for c in mock_metric.call_args_list]
-            assert "app_vitals.reliability.activity_retries" in metric_calls
-
-            retry_call = next(
-                c
-                for c in mock_metric.call_args_list
-                if c[0][0] == "app_vitals.reliability.activity_retries"
+            # Verify the act.completed event captured the retry attempt
+            completed_call = next(
+                c for c in mock_log.call_args_list
+                if c[0][0] == "app_vitals.act.completed"
             )
-            assert retry_call[0][1] == 2.0  # attempt 3 means 2 retries
+            attrs = completed_call[0][1]
+            assert attrs["attempt"] == 3
 
 
 class TestAppVitalsWorkflowInterceptor:
@@ -320,9 +309,6 @@ class TestAppVitalsWorkflowInterceptor:
                 "application_sdk.observability.app_vitals._emit_log_event"
             ) as mock_log,
             mock.patch(
-                "application_sdk.observability.app_vitals._emit_metric"
-            ) as mock_metric,
-            mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
@@ -352,10 +338,6 @@ class TestAppVitalsWorkflowInterceptor:
             assert log_attrs["workflow_id"] == "wf-abc-123"
             assert log_attrs["workflow_type"] == "metadata_crawl"
 
-            assert mock_metric.call_count == 2
-            metric_calls = [c[0][0] for c in mock_metric.call_args_list]
-            assert "app_vitals.reliability.wf_completed" in metric_calls
-            assert "app_vitals.performance.wf_runtime" in metric_calls
 
     @pytest.mark.asyncio
     async def test_failed_workflow_emits_error(self, mock_next_workflow, workflow_info):
@@ -375,7 +357,6 @@ class TestAppVitalsWorkflowInterceptor:
             mock.patch(
                 "application_sdk.observability.app_vitals._emit_log_event"
             ) as mock_log,
-            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
@@ -506,9 +487,6 @@ class TestAppVitalsEfficiencyMetrics:
             ) as mock_activity_mod,
             mock.patch("application_sdk.observability.app_vitals._emit_log_event"),
             mock.patch(
-                "application_sdk.observability.app_vitals._emit_metric"
-            ) as mock_metric,
-            mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
@@ -519,11 +497,8 @@ class TestAppVitalsEfficiencyMetrics:
 
             await interceptor.execute_activity(MockExecuteActivityInput())
 
-            metric_names = [c[0][0] for c in mock_metric.call_args_list]
             # Efficiency metrics should be emitted if psutil works on this platform
             # (may be 0.0 values, but metrics are emitted)
-            if "app_vitals.efficiency.activity_cpu_seconds" in metric_names:
-                assert "app_vitals.efficiency.activity_mem_gb_sec" in metric_names
 
 
 # ---------------------------------------------------------------------------
@@ -561,7 +536,6 @@ class TestAppVitalsTraceIdAttachment:
             mock.patch(
                 "application_sdk.observability.app_vitals._emit_log_event"
             ) as mock_log,
-            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
@@ -598,7 +572,6 @@ class TestAppVitalsTraceIdAttachment:
             mock.patch(
                 "application_sdk.observability.app_vitals._emit_log_event"
             ) as mock_log,
-            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
@@ -722,7 +695,6 @@ class TestAppVitalsRichErrorFields:
             mock.patch(
                 "application_sdk.observability.app_vitals._emit_log_event"
             ) as mock_log,
-            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
@@ -768,7 +740,6 @@ class TestAppVitalsRichErrorFields:
             mock.patch(
                 "application_sdk.observability.app_vitals._emit_log_event"
             ) as mock_log,
-            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
@@ -806,7 +777,6 @@ class TestAppVitalsRichErrorFields:
             mock.patch(
                 "application_sdk.observability.app_vitals._emit_log_event"
             ) as mock_log,
-            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
@@ -858,7 +828,6 @@ class TestLifecycleStartEvents:
             mock.patch(
                 "application_sdk.observability.app_vitals._emit_log_event"
             ) as mock_log,
-            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
@@ -959,9 +928,6 @@ class TestAssetsProcessed:
                 "application_sdk.observability.app_vitals._emit_log_event"
             ) as mock_log,
             mock.patch(
-                "application_sdk.observability.app_vitals._emit_metric"
-            ) as mock_metric,
-            mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
             mock.patch(
@@ -979,8 +945,6 @@ class TestAssetsProcessed:
             )
             assert completed_call[0][1]["assets_processed"] == 12345
 
-            metric_names = [c[0][0] for c in mock_metric.call_args_list]
-            assert "app_vitals.performance.activity_assets_processed" in metric_names
 
 
 # ---------------------------------------------------------------------------
@@ -1012,7 +976,6 @@ class TestWorkflowSummary:
             mock.patch(
                 "application_sdk.observability.app_vitals._emit_log_event"
             ) as mock_log,
-            mock.patch("application_sdk.observability.app_vitals._emit_metric"),
             mock.patch(
                 "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
             ),
@@ -1190,89 +1153,8 @@ class TestLoggerAdaptorExtraKeysAllowlist:
             assert k in out, f"{k} was dropped by _build_extra_dict"
 
 
-class TestDurationMetricsUseHistogram:
-    """Regression for audit finding: emitting durations as MetricType.GAUGE
-    hits create_observable_gauge() in metrics_adaptor which doesn't support
-    .add() — errors are caught silently. Durations must use HISTOGRAM.
-    """
 
-    @pytest.fixture
-    def mock_next_activity(self):
-        mock_next = mock.AsyncMock()
-        mock_next.execute_activity = mock.AsyncMock(return_value="ok")
-        return mock_next
+# TestDurationMetricsUseHistogram removed — Path 2 (OTel metrics) was removed;
+# all analytics are now computed from Path 1 (log events → MV).
 
-    @pytest.mark.asyncio
-    async def test_activity_duration_emitted_as_histogram(self, mock_next_activity):
-        from application_sdk.observability.app_vitals import (
-            _AppVitalsActivityInboundInterceptor,
-        )
 
-        interceptor = _AppVitalsActivityInboundInterceptor(mock_next_activity)
-
-        with (
-            mock.patch(
-                "application_sdk.observability.app_vitals.activity"
-            ) as mock_activity_mod,
-            mock.patch("application_sdk.observability.app_vitals._emit_log_event"),
-            mock.patch(
-                "application_sdk.observability.app_vitals._emit_metric"
-            ) as mock_metric,
-            mock.patch(
-                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
-            ),
-            mock.patch(
-                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
-            ),
-        ):
-            mock_activity_mod.info.return_value = MockActivityInfo()
-
-            await interceptor.execute_activity(MockExecuteActivityInput())
-
-            # Map each emitted metric name to its type
-            by_name = {c[0][0]: c[0][2] for c in mock_metric.call_args_list}
-
-            for duration_metric in (
-                "app_vitals.performance.activity_runtime",
-                "app_vitals.performance.activity_schedule_to_start",
-            ):
-                assert duration_metric in by_name, f"{duration_metric} was not emitted"
-                assert by_name[duration_metric] == "histogram", (
-                    f"{duration_metric} must be histogram, got "
-                    f"{by_name[duration_metric]!r}. ObservableGauge.add() "
-                    f"doesn't exist — gauge emissions are silently dropped."
-                )
-
-    @pytest.mark.asyncio
-    async def test_workflow_duration_emitted_as_histogram(self):
-        from application_sdk.observability.app_vitals import (
-            _AppVitalsWorkflowInboundInterceptor,
-        )
-
-        mock_next = mock.AsyncMock()
-        mock_next.execute_workflow = mock.AsyncMock(return_value="ok")
-        interceptor = _AppVitalsWorkflowInboundInterceptor(mock_next)
-
-        with (
-            mock.patch(
-                "application_sdk.observability.app_vitals.workflow"
-            ) as mock_wf_mod,
-            mock.patch("application_sdk.observability.app_vitals._emit_log_event"),
-            mock.patch(
-                "application_sdk.observability.app_vitals._emit_metric"
-            ) as mock_metric,
-            mock.patch(
-                "application_sdk.observability.app_vitals.APPLICATION_NAME", "snowflake"
-            ),
-            mock.patch(
-                "application_sdk.observability.app_vitals.APP_TENANT_ID", "tenant_123"
-            ),
-        ):
-            mock_wf_mod.info.return_value = MockWorkflowInfo()
-            mock_wf_mod.unsafe.is_replaying.return_value = False
-
-            await interceptor.execute_workflow(MockExecuteWorkflowInput())
-
-            by_name = {c[0][0]: c[0][2] for c in mock_metric.call_args_list}
-
-            assert by_name.get("app_vitals.performance.wf_runtime") == "histogram"

--- a/tests/unit/interceptors/test_correlation_interceptor.py
+++ b/tests/unit/interceptors/test_correlation_interceptor.py
@@ -1,0 +1,185 @@
+"""Regression tests for the v3 CorrelationContextInterceptor.
+
+Specifically covers the legacy header fallback (BLDX-900 fix): the AE's older
+interceptor injects correlation_id under the plain header key "correlation_id"
+(no x- prefix).  The new interceptor must read that as a fallback so that
+AE-dispatched workflows inherit the correct correlation_id without any AE changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from temporalio.api.common.v1 import Payload
+from temporalio.converter import default as default_converter
+
+from application_sdk.execution._temporal.interceptors.correlation_interceptor import (
+    _HEADER_CORRELATION_ID,
+    _HEADER_CORRELATION_ID_LEGACY,
+    _CorrelationActivityInboundInterceptor,
+    _CorrelationWorkflowInboundInterceptor,
+)
+from application_sdk.observability.correlation import (
+    CorrelationContext,
+    get_correlation_context,
+    set_correlation_context,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _encode(value: str) -> Payload:
+    return default_converter().payload_converter.to_payload(value)
+
+
+@dataclass
+class _WorkflowInput:
+    args: Sequence[Any] = field(default_factory=list)
+    headers: Mapping[str, Payload] = field(default_factory=dict)
+
+
+@dataclass
+class _ActivityInput:
+    args: Sequence[Any] = field(default_factory=list)
+    headers: Mapping[str, Payload] = field(default_factory=dict)
+
+
+def _make_workflow_interceptor() -> _CorrelationWorkflowInboundInterceptor:
+    mock_next = MagicMock()
+    mock_next.execute_workflow = AsyncMock(return_value="result")
+    return _CorrelationWorkflowInboundInterceptor(mock_next)
+
+
+def _make_activity_interceptor() -> _CorrelationActivityInboundInterceptor:
+    mock_next = MagicMock()
+    mock_next.execute_activity = AsyncMock(return_value="result")
+    return _CorrelationActivityInboundInterceptor(mock_next)
+
+
+# ---------------------------------------------------------------------------
+# Workflow inbound — header fallback
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowInboundLegacyHeader:
+    """Workflow interceptor reads correlation_id from the legacy header key."""
+
+    def setup_method(self):
+        set_correlation_context(CorrelationContext(correlation_id=""))
+
+    async def test_new_header_key_works(self):
+        """Primary path: x-correlation-id header is read correctly."""
+        interceptor = _make_workflow_interceptor()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("temporalio.workflow.memo", lambda: {})
+            await interceptor.execute_workflow(
+                _WorkflowInput(
+                    headers={_HEADER_CORRELATION_ID: _encode("new-corr-123")}
+                )
+            )
+
+        assert interceptor._correlation_id == "new-corr-123"
+        ctx = get_correlation_context()
+        assert ctx is not None and ctx.correlation_id == "new-corr-123"
+
+    async def test_legacy_header_key_fallback(self):
+        """BLDX-900 regression: plain 'correlation_id' header (AE style) is read."""
+        interceptor = _make_workflow_interceptor()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("temporalio.workflow.memo", lambda: {})
+            await interceptor.execute_workflow(
+                _WorkflowInput(
+                    headers={_HEADER_CORRELATION_ID_LEGACY: _encode("ae-corr-456")}
+                )
+            )
+
+        assert interceptor._correlation_id == "ae-corr-456"
+        ctx = get_correlation_context()
+        assert ctx is not None and ctx.correlation_id == "ae-corr-456"
+
+    async def test_new_header_takes_precedence_over_legacy(self):
+        """If both headers are present, x-correlation-id wins."""
+        interceptor = _make_workflow_interceptor()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("temporalio.workflow.memo", lambda: {})
+            await interceptor.execute_workflow(
+                _WorkflowInput(
+                    headers={
+                        _HEADER_CORRELATION_ID: _encode("new-wins"),
+                        _HEADER_CORRELATION_ID_LEGACY: _encode("legacy-loses"),
+                    }
+                )
+            )
+
+        assert interceptor._correlation_id == "new-wins"
+
+    async def test_no_header_generates_uuid(self):
+        """Priority 3: no headers → a fresh UUID is generated."""
+        interceptor = _make_workflow_interceptor()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("temporalio.workflow.memo", lambda: {})
+            await interceptor.execute_workflow(_WorkflowInput(headers={}))
+
+        assert interceptor._correlation_id != ""
+        assert len(interceptor._correlation_id) == 36  # UUID4 format
+
+
+# ---------------------------------------------------------------------------
+# Activity inbound — header fallback
+# ---------------------------------------------------------------------------
+
+
+class TestActivityInboundLegacyHeader:
+    """Activity interceptor reads correlation_id from the legacy header key."""
+
+    def setup_method(self):
+        set_correlation_context(CorrelationContext(correlation_id=""))
+
+    async def test_new_header_key_works(self):
+        interceptor = _make_activity_interceptor()
+        await interceptor.execute_activity(
+            _ActivityInput(headers={_HEADER_CORRELATION_ID: _encode("act-new-789")})
+        )
+
+        ctx = get_correlation_context()
+        assert ctx is not None and ctx.correlation_id == "act-new-789"
+
+    async def test_legacy_header_key_fallback(self):
+        """Activity inherits AE correlation_id from the legacy header."""
+        interceptor = _make_activity_interceptor()
+        await interceptor.execute_activity(
+            _ActivityInput(
+                headers={_HEADER_CORRELATION_ID_LEGACY: _encode("ae-act-corr-abc")}
+            )
+        )
+
+        ctx = get_correlation_context()
+        assert ctx is not None and ctx.correlation_id == "ae-act-corr-abc"
+
+    async def test_new_header_takes_precedence_in_activity(self):
+        interceptor = _make_activity_interceptor()
+        await interceptor.execute_activity(
+            _ActivityInput(
+                headers={
+                    _HEADER_CORRELATION_ID: _encode("act-new-wins"),
+                    _HEADER_CORRELATION_ID_LEGACY: _encode("act-legacy-loses"),
+                }
+            )
+        )
+
+        ctx = get_correlation_context()
+        assert ctx is not None and ctx.correlation_id == "act-new-wins"
+
+    async def test_no_header_leaves_context_unchanged(self):
+        """Activity with no correlation header does not wipe existing context."""
+        set_correlation_context(CorrelationContext(correlation_id="pre-existing"))
+        interceptor = _make_activity_interceptor()
+        await interceptor.execute_activity(_ActivityInput(headers={}))
+
+        ctx = get_correlation_context()
+        assert ctx is not None and ctx.correlation_id == "pre-existing"


### PR DESCRIPTION
…kflow metrics

Adds the App Vitals telemetry layer described in app-platform-rfcs/app-vitals. Zero app code changes required — apps get observability on SDK version bump.

New modules:
- observability/app_vitals.py: AppVitalsInterceptor emits workflow/activity lifecycle events (started + completed) + OTel metrics on every execution. Workflow outbound interceptor tracks activities for a summary event.
- observability/error_classifier.py: classify exceptions into 6 error_types (timeout, oom, upstream, config, cancelled, internal). Unwraps Temporal's ActivityError/ApplicationError chain. Also exposes extract_cause_chain() and is_retriable() heuristic.
- observability/resource_sampler.py: psutil-based CPU/memory sampling at activity boundaries (process-level — RFC signals #10, #11).
- observability/trace_context.py: reads current OTel span context so events carry trace_id/span_id for cross-signal correlation.

Enhancements:
- activity_failure_logging.py: failure logs now carry app_name, tenant_id, app_version, error_type, error_class, is_retriable, error_cause_chain, trace_id, span_id — RFC P0.4 structured logs for AI consumption.
- utils.py: build_otel_resource() adds app.name + tenant.id to every OTLP export.
- worker.py: auto-registers Temporal's OTel TracingInterceptor when ATLAN_ENABLE_OTLP_TRACES=true, and AppVitalsInterceptor when ATLAN_ENABLE_APP_VITALS=true (default: on).

Emitted signals:
- Events: app_vitals.{wf,act}.{started,completed}, app_vitals.wf.summary
- Metrics: reliability.{wf,activity}_completed + activity_retries, performance.{wf,activity}_runtime + activity_schedule_to_start + activity_assets_processed, efficiency.{activity_cpu_seconds, activity_mem_gb_sec}

Event attributes: app_name, tenant_id, app_version, workflow_id, workflow_run_id, workflow_type, activity_id, activity_type, task_queue, attempt, namespace, correlation_id, trace_id, span_id, status, error_type, error_class, is_retriable, error_cause_chain, duration_ms, cpu_seconds, mem_gb_sec, assets_processed, timeout_budget_total_ms, timeout_budget_used_pct.

Tests: 113/113 unit pass, 43/43 end-to-end pass against a real Temporal dev server with a 3-activity workflow including a cause-chained failure.

CI: extend build-image.yaml to trigger on pushes to gaurav/app-vitals and on application_sdk/** / tests/** path changes, and sanitise branch names (replace /, _ with -) so feature branch names produce valid GHCR tags.

### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- _to be added_

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.