### PR TITLE
feat(templates): add EntityDef and entity-driven orchestration to Sql…

### DIFF
--- a/application_sdk/templates/entity.py
+++ b/application_sdk/templates/entity.py
@@ -1,0 +1,80 @@
+"""Declarative entity definitions for metadata extraction.
+
+An ``EntityDef`` describes a single entity type to extract (e.g. databases,
+schemas, tables, columns, stages, streams).  Templates like
+``SqlMetadataExtractor`` use a list of these to orchestrate extraction
+automatically — no need to override ``run()``.
+
+Example::
+
+    class SnowflakeExtractor(SqlMetadataExtractor):
+        entities = [
+            EntityDef(name="databases", phase=1),
+            EntityDef(name="schemas",   phase=1),
+            EntityDef(name="tables",    phase=1),
+            EntityDef(name="columns",   phase=1),
+            EntityDef(name="stages",    sql="SELECT ... FROM STAGES", phase=2),
+            EntityDef(name="streams",   sql="SELECT ... FROM STREAMS", phase=2),
+        ]
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class EntityDef:
+    """Declares an extractable entity type.
+
+    Protocol-agnostic: works for SQL connectors (set ``sql``),
+    REST API connectors (set ``endpoint``), or custom logic
+    (leave both empty, implement ``fetch_{name}()`` method).
+    """
+
+    name: str
+    """Entity name used in output keys, logging, and method dispatch
+    (e.g. ``'databases'`` → ``fetch_databases()``)."""
+
+    # --- Fetch strategy (exactly one should be set, or none for custom method) ---
+
+    sql: str = ""
+    """SQL query template for SQL connectors.  Supports
+    ``{normalized_include_regex}``, ``{normalized_exclude_regex}``,
+    ``{temp_table_regex_sql}``, ``{database_name}`` placeholders."""
+
+    endpoint: str = ""
+    """REST API endpoint path for API connectors (e.g. ``'/api/3.1/workbooks'``).
+    Relative to the client's ``BASE_URL``."""
+
+    pagination: str = "none"
+    """Pagination strategy for API endpoints:
+    ``'none'``, ``'cursor'``, ``'offset'``, ``'page_token'``.
+    Ignored for SQL entities."""
+
+    response_items_key: str = ""
+    """JSON key containing the array of items in API response
+    (e.g. ``'workbooks.workbook'``).  Empty = response is the array.
+    Ignored for SQL entities."""
+
+    # --- Orchestration ---
+
+    phase: int = 1
+    """Execution phase (1 = parallel with core entities, 2 = after phase 1, etc.).
+    Entities in the same phase run concurrently."""
+
+    depends_on: tuple[str, ...] = ()
+    """Entity names that must complete before this one starts.
+    Empty = runs in the first parallel batch of its phase."""
+
+    enabled: bool = True
+    """Set to False to skip this entity (e.g. exclude_views toggle)."""
+
+    timeout_seconds: int = 1800
+    """Task timeout for this entity's extraction."""
+
+    # --- Output ---
+
+    result_key: str = ""
+    """Key in ExtractionOutput for the count.
+    Defaults to ``'{name}_extracted'`` if empty."""

--- a/application_sdk/templates/sql_metadata_extractor.py
+++ b/application_sdk/templates/sql_metadata_extractor.py
@@ -3,37 +3,34 @@
 Replaces the v2 ``BaseSQLMetadataExtractionWorkflow`` +
 ``BaseSQLMetadataExtractionActivities`` split with a single typed ``App`` class.
 
-Migration from v2::
-
-    # v2: separate workflow + activities, all Dict[str, Any]
-    from application_sdk.workflows.metadata_extraction.sql import (
-        BaseSQLMetadataExtractionWorkflow,
-    )
-    from application_sdk.activities.metadata_extraction.sql import (
-        BaseSQLMetadataExtractionActivities,
-    )
-
-    # v3: single App class with typed contracts
-    from application_sdk.templates import SqlMetadataExtractor
-
 Subclass ``SqlMetadataExtractor`` to implement connector-specific logic::
 
     from application_sdk.templates import SqlMetadataExtractor
-    from application_sdk.templates.contracts.sql_metadata import (
-        ExtractionInput, ExtractionOutput, FetchDatabasesInput, FetchDatabasesOutput,
-    )
-    from application_sdk.app import task
+    from application_sdk.templates.entity import EntityDef
 
-    class MyConnectorExtractor(SqlMetadataExtractor):
+    class MyExtractor(SqlMetadataExtractor):
+        entities = [
+            EntityDef(name="databases", phase=1),
+            EntityDef(name="schemas",   phase=1),
+            EntityDef(name="tables",    phase=1),
+            EntityDef(name="columns",   phase=1),
+            EntityDef(name="stages",    sql="SELECT ...", phase=2),
+        ]
+
         @task(timeout_seconds=1800)
-        async def fetch_databases(self, input: FetchDatabasesInput) -> FetchDatabasesOutput:
-            # connector-specific implementation
-            return FetchDatabasesOutput(chunk_count=1, total_record_count=10)
+        async def fetch_databases(self, input): ...
+
+Or use the legacy class-attribute SQL pattern (still supported)::
+
+    class MyExtractor(SqlMetadataExtractor):
+        fetch_database_sql = "SELECT ..."
+        fetch_schema_sql   = "SELECT ..."
 """
 
 from __future__ import annotations
 
 import asyncio
+from typing import ClassVar
 
 from application_sdk.app.base import App
 from application_sdk.app.task import task
@@ -42,6 +39,7 @@ from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.templates.contracts.sql_metadata import (
     ExtractionInput,
     ExtractionOutput,
+    ExtractionTaskInput,
     FetchColumnsInput,
     FetchColumnsOutput,
     FetchDatabasesInput,
@@ -55,36 +53,63 @@ from application_sdk.templates.contracts.sql_metadata import (
     TransformInput,
     TransformOutput,
 )
+from application_sdk.templates.entity import EntityDef
 
 logger = get_logger(__name__)
+
+# Default entity definitions — the 4 core SQL entity types.
+_DEFAULT_ENTITIES = [
+    EntityDef(name="databases", phase=1),
+    EntityDef(name="schemas", phase=1),
+    EntityDef(name="tables", phase=1),
+    EntityDef(name="columns", phase=1),
+]
+
+# Maps entity name → (InputClass, OutputClass) for built-in entities.
+_ENTITY_CONTRACTS: dict[str, tuple[type[ExtractionTaskInput], type]] = {
+    "databases": (FetchDatabasesInput, FetchDatabasesOutput),
+    "schemas": (FetchSchemasInput, FetchSchemasOutput),
+    "tables": (FetchTablesInput, FetchTablesOutput),
+    "columns": (FetchColumnsInput, FetchColumnsOutput),
+    "procedures": (FetchProceduresInput, FetchProceduresOutput),
+}
 
 
 class SqlMetadataExtractor(App):
     """Base class for SQL metadata extraction apps.
 
-    Subclass this and override the ``@task`` methods to implement
-    connector-specific extraction logic.
+    **Entity-driven orchestration:**
 
-    The ``run()`` method orchestrates the full extraction: preflight →
-    fetch (databases, schemas, tables, columns) → transform → upload.
-    Override ``run()`` to change the orchestration.
+    Set the ``entities`` class variable to declare what to extract.
+    The ``run()`` method automatically orchestrates all registered
+    entities by phase — no need to override ``run()``.
 
-    All task timeouts default to 30 minutes. Override via::
+    Entities in the same phase run concurrently.  Phase 2 entities
+    start only after all phase 1 entities complete, and so on.
 
-        @task(timeout_seconds=3600)
-        async def fetch_tables(self, input: FetchTablesInput) -> FetchTablesOutput:
-            ...
+    For each entity, ``run()`` dispatches to ``fetch_{name}()`` if
+    a ``@task`` method with that name exists on the subclass.
+
+    **Legacy class-attribute SQL (still supported):**
+
+    If ``entities`` is not overridden (empty list), the extractor
+    falls back to the default 4 entities (databases, schemas, tables,
+    columns) and dispatches to the existing ``fetch_*`` task methods.
     """
+
+    entities: ClassVar[list[EntityDef]] = []
+    """Override with a list of ``EntityDef`` to declare entities.
+    Empty = use defaults (databases, schemas, tables, columns)."""
+
+    # ------------------------------------------------------------------
+    # Task methods — override in subclass
+    # ------------------------------------------------------------------
 
     @task(timeout_seconds=1800)
     async def fetch_databases(self, input: FetchDatabasesInput) -> FetchDatabasesOutput:
-        """Fetch databases from the source system.
-
-        Override this method in your connector subclass.
-        """
+        """Fetch databases from the source system."""
         raise NotImplementedError(
-            f"{type(self).__name__} must implement fetch_databases(). "
-            "See application_sdk.templates.sql_metadata_extractor for examples."
+            f"{type(self).__name__} must implement fetch_databases()."
         )
 
     @task(timeout_seconds=1800)
@@ -112,22 +137,13 @@ class SqlMetadataExtractor(App):
     async def fetch_procedures(
         self, input: FetchProceduresInput
     ) -> FetchProceduresOutput:
-        """Fetch stored procedures from the source system.
+        """Fetch stored procedures (optional).
 
-        This task is optional — connectors that do not support stored procedures
-        should return ``FetchProceduresOutput()`` with zero counts rather than
-        raising an error.
-
-        This task is NOT called from the base ``run()`` method. Connectors that
-        need it should call it from their own ``run()`` override.
-
-        Override this method in your connector subclass if procedure extraction
-        is required.
+        Not called from the base ``run()``.  Include an ``EntityDef``
+        with ``name="procedures"`` in ``entities`` if needed.
         """
         raise NotImplementedError(
-            f"{type(self).__name__} must implement fetch_procedures(), "
-            "or return FetchProceduresOutput() with zero counts for connectors "
-            "that do not support stored procedures."
+            f"{type(self).__name__} must implement fetch_procedures()."
         )
 
     @task(timeout_seconds=1800)
@@ -137,108 +153,106 @@ class SqlMetadataExtractor(App):
             f"{type(self).__name__} must implement transform_data()."
         )
 
+    # ------------------------------------------------------------------
+    # Orchestration
+    # ------------------------------------------------------------------
+
+    def _get_entities(self) -> list[EntityDef]:
+        """Return the effective entity list.
+
+        If the subclass sets ``entities``, use that.
+        Otherwise fall back to the 4 default entities.
+        """
+        entities = self.entities if self.entities else _DEFAULT_ENTITIES
+        return [e for e in entities if e.enabled]
+
+    async def _fetch_entity(
+        self,
+        entity: EntityDef,
+        base_input: ExtractionInput,
+    ) -> tuple[str, int]:
+        """Dispatch to the correct ``fetch_{name}()`` task method.
+
+        Returns:
+            Tuple of (result_key, record_count).
+        """
+        method_name = f"fetch_{entity.name}"
+        method = getattr(self, method_name, None)
+        if method is None:
+            raise NotImplementedError(
+                f"{type(self).__name__} has no fetch_{entity.name}() method "
+                f"for entity '{entity.name}'."
+            )
+
+        # Build the typed task input
+        input_cls = _ENTITY_CONTRACTS.get(entity.name, (ExtractionTaskInput, None))[0]
+
+        # Prefer credential_ref; fall back to legacy credential_guid
+        cred_ref = base_input.credential_ref
+        if cred_ref is None and base_input.credential_guid:
+            from application_sdk.credentials import legacy_credential_ref
+
+            cred_ref = legacy_credential_ref(base_input.credential_guid)
+
+        task_input = input_cls(
+            workflow_id=base_input.workflow_id,
+            connection=base_input.connection,
+            credential_guid=base_input.credential_guid,
+            credential_ref=cred_ref,
+            output_prefix=base_input.output_prefix,
+            output_path=base_input.output_path,
+            exclude_filter=base_input.exclude_filter,
+            include_filter=base_input.include_filter,
+            temp_table_regex=base_input.temp_table_regex,
+            source_tag_prefix=base_input.source_tag_prefix,
+        )
+
+        result = await method(task_input)
+        result_key = entity.result_key or f"{entity.name}_extracted"
+        count = getattr(result, "total_record_count", 0)
+        return (result_key, count)
+
     async def run(self, input: ExtractionInput) -> ExtractionOutput:  # type: ignore[override]
         """Orchestrate the full metadata extraction pipeline.
 
-        Default orchestration:
-        1. Fetch all metadata types in parallel (databases, schemas, tables, columns)
-        2. Transform data
-        3. Return aggregated output
-
-        Override to customize the orchestration order or add additional steps.
+        Executes entities grouped by phase.  All entities in the same
+        phase run concurrently.  Phase N+1 starts only after phase N
+        completes.
         """
         workflow_id = input.workflow_id
         logger.info("Starting SQL metadata extraction: %s", workflow_id)
 
         try:
-            # Prefer credential_ref; fall back to legacy credential_guid
-            cred_ref = input.credential_ref
-            if cred_ref is None and input.credential_guid:
-                from application_sdk.credentials import legacy_credential_ref
+            entities = self._get_entities()
 
-                cred_ref = legacy_credential_ref(input.credential_guid)
+            # Group by phase
+            phases: dict[int, list[EntityDef]] = {}
+            for entity in entities:
+                phases.setdefault(entity.phase, []).append(entity)
 
-            # Fetch all metadata types in parallel
-            (
-                db_result,
-                schema_result,
-                table_result,
-                column_result,
-            ) = await asyncio.gather(
-                self.fetch_databases(
-                    FetchDatabasesInput(
-                        workflow_id=workflow_id,
-                        connection=input.connection,
-                        credential_guid=input.credential_guid,
-                        credential_ref=cred_ref,
-                        output_prefix=input.output_prefix,
-                        output_path=input.output_path,
-                        exclude_filter=input.exclude_filter,
-                        include_filter=input.include_filter,
-                        temp_table_regex=input.temp_table_regex,
-                        source_tag_prefix=input.source_tag_prefix,
-                    )
-                ),
-                self.fetch_schemas(
-                    FetchSchemasInput(
-                        workflow_id=workflow_id,
-                        connection=input.connection,
-                        credential_guid=input.credential_guid,
-                        credential_ref=cred_ref,
-                        output_prefix=input.output_prefix,
-                        output_path=input.output_path,
-                        exclude_filter=input.exclude_filter,
-                        include_filter=input.include_filter,
-                        temp_table_regex=input.temp_table_regex,
-                        source_tag_prefix=input.source_tag_prefix,
-                    )
-                ),
-                self.fetch_tables(
-                    FetchTablesInput(
-                        workflow_id=workflow_id,
-                        connection=input.connection,
-                        credential_guid=input.credential_guid,
-                        credential_ref=cred_ref,
-                        output_prefix=input.output_prefix,
-                        output_path=input.output_path,
-                        exclude_filter=input.exclude_filter,
-                        include_filter=input.include_filter,
-                        temp_table_regex=input.temp_table_regex,
-                        source_tag_prefix=input.source_tag_prefix,
-                    )
-                ),
-                self.fetch_columns(
-                    FetchColumnsInput(
-                        workflow_id=workflow_id,
-                        connection=input.connection,
-                        credential_guid=input.credential_guid,
-                        credential_ref=cred_ref,
-                        output_prefix=input.output_prefix,
-                        output_path=input.output_path,
-                        exclude_filter=input.exclude_filter,
-                        include_filter=input.include_filter,
-                        temp_table_regex=input.temp_table_regex,
-                        source_tag_prefix=input.source_tag_prefix,
-                    )
-                ),
-            )
+            # Execute phase by phase
+            results: dict[str, int] = {}
+            for phase_num in sorted(phases):
+                phase_results = await asyncio.gather(
+                    *[self._fetch_entity(entity, input) for entity in phases[phase_num]]
+                )
+                for result_key, count in phase_results:
+                    results[result_key] = count
 
             logger.info(
                 "Metadata extraction completed",
                 workflow_id=workflow_id,
-                databases=db_result.total_record_count,
-                schemas=schema_result.total_record_count,
-                tables=table_result.total_record_count,
-                columns=column_result.total_record_count,
+                results=results,
             )
 
             return ExtractionOutput(
                 workflow_id=workflow_id,
                 success=True,
-                databases_extracted=db_result.total_record_count,
-                schemas_extracted=schema_result.total_record_count,
-                tables_extracted=table_result.total_record_count,
-                columns_extracted=column_result.total_record_count,
+                databases_extracted=results.get("databases_extracted", 0),
+                schemas_extracted=results.get("schemas_extracted", 0),
+                tables_extracted=results.get("tables_extracted", 0),
+                columns_extracted=results.get("columns_extracted", 0),
+                procedures_extracted=results.get("procedures_extracted", 0),
             )
 
         except Exception as e:

--- a/tests/unit/templates/test_entity_registry.py
+++ b/tests/unit/templates/test_entity_registry.py
@@ -1,0 +1,228 @@
+"""Tests for EntityDef and entity-driven orchestration in SqlMetadataExtractor."""
+
+import pytest
+
+from application_sdk.templates.contracts.sql_metadata import (
+    ExtractionInput,
+    FetchDatabasesOutput,
+)
+from application_sdk.templates.entity import EntityDef
+from application_sdk.templates.sql_metadata_extractor import SqlMetadataExtractor
+
+# ---------------------------------------------------------------------------
+# EntityDef tests
+# ---------------------------------------------------------------------------
+
+
+class TestEntityDef:
+    def test_defaults(self):
+        e = EntityDef(name="databases")
+        assert e.phase == 1
+        assert e.enabled is True
+        assert e.timeout_seconds == 1800
+        assert e.sql == ""
+        assert e.endpoint == ""
+        assert e.result_key == ""
+        assert e.depends_on == ()
+
+    def test_frozen(self):
+        e = EntityDef(name="databases")
+        with pytest.raises(AttributeError):
+            e.name = "schemas"  # type: ignore[misc]
+
+    def test_custom_fields(self):
+        e = EntityDef(
+            name="stages",
+            sql="SELECT * FROM STAGES",
+            phase=2,
+            timeout_seconds=3600,
+            result_key="stages_count",
+        )
+        assert e.name == "stages"
+        assert e.sql == "SELECT * FROM STAGES"
+        assert e.phase == 2
+        assert e.timeout_seconds == 3600
+        assert e.result_key == "stages_count"
+
+    def test_disabled_entity(self):
+        e = EntityDef(name="ai_models", enabled=False)
+        assert e.enabled is False
+
+    def test_api_entity(self):
+        e = EntityDef(
+            name="workbooks",
+            endpoint="/api/3.1/workbooks",
+            pagination="offset",
+            response_items_key="workbooks.workbook",
+        )
+        assert e.endpoint == "/api/3.1/workbooks"
+        assert e.pagination == "offset"
+        assert e.response_items_key == "workbooks.workbook"
+
+    def test_result_key_default_derivation(self):
+        """Empty result_key should default to '{name}_extracted' at runtime."""
+        e = EntityDef(name="stages")
+        expected = f"{e.name}_extracted"
+        actual = e.result_key or f"{e.name}_extracted"
+        assert actual == expected
+
+    def test_depends_on(self):
+        e = EntityDef(name="dynamic_tables", phase=2, depends_on=("tables",))
+        assert e.depends_on == ("tables",)
+
+
+# ---------------------------------------------------------------------------
+# _get_entities tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetEntities:
+    def test_empty_entities_falls_back_to_defaults(self):
+        ext = SqlMetadataExtractor()
+        assert ext.entities == []
+        entities = ext._get_entities()
+        assert len(entities) == 4
+        names = [e.name for e in entities]
+        assert names == ["databases", "schemas", "tables", "columns"]
+
+    def test_custom_entities_used(self):
+        class Custom(SqlMetadataExtractor):
+            entities = [
+                EntityDef(name="databases", phase=1),
+                EntityDef(name="stages", phase=2),
+            ]
+
+        ext = Custom()
+        entities = ext._get_entities()
+        assert len(entities) == 2
+        assert entities[1].name == "stages"
+
+    def test_disabled_entity_filtered(self):
+        class WithDisabled(SqlMetadataExtractor):
+            entities = [
+                EntityDef(name="databases", phase=1),
+                EntityDef(name="schemas", phase=1, enabled=False),
+                EntityDef(name="tables", phase=1),
+            ]
+
+        ext = WithDisabled()
+        entities = ext._get_entities()
+        assert len(entities) == 2
+        assert all(e.name != "schemas" for e in entities)
+
+    def test_all_disabled_returns_empty(self):
+        class AllDisabled(SqlMetadataExtractor):
+            entities = [
+                EntityDef(name="databases", enabled=False),
+            ]
+
+        ext = AllDisabled()
+        assert ext._get_entities() == []
+
+
+# ---------------------------------------------------------------------------
+# _fetch_entity tests
+# ---------------------------------------------------------------------------
+
+
+def _make_input(**overrides):
+    defaults = {
+        "workflow_id": "test-wf",
+        "connection": {
+            "connection_name": "test",
+            "connection_qualified_name": "default/pg/123",
+        },
+    }
+    defaults.update(overrides)
+    return ExtractionInput(**defaults)
+
+
+class TestFetchEntity:
+    @pytest.mark.asyncio
+    async def test_dispatches_to_named_method(self):
+        class Ext(SqlMetadataExtractor):
+            async def fetch_databases(self, input):
+                return FetchDatabasesOutput(total_record_count=42)
+
+        ext = Ext()
+        entity = EntityDef(name="databases")
+        result_key, count = await ext._fetch_entity(entity, _make_input())
+        assert result_key == "databases_extracted"
+        assert count == 42
+
+    @pytest.mark.asyncio
+    async def test_custom_result_key(self):
+        class Ext(SqlMetadataExtractor):
+            async def fetch_databases(self, input):
+                return FetchDatabasesOutput(total_record_count=7)
+
+        ext = Ext()
+        entity = EntityDef(name="databases", result_key="db_count")
+        result_key, count = await ext._fetch_entity(entity, _make_input())
+        assert result_key == "db_count"
+        assert count == 7
+
+    @pytest.mark.asyncio
+    async def test_missing_method_raises(self):
+        ext = SqlMetadataExtractor()
+        entity = EntityDef(name="nonexistent_thing")
+        with pytest.raises(NotImplementedError, match="no fetch_nonexistent_thing"):
+            await ext._fetch_entity(entity, _make_input())
+
+    @pytest.mark.asyncio
+    async def test_extra_entity_with_custom_method(self):
+        """Custom entities dispatch to custom fetch methods."""
+
+        class Ext(SqlMetadataExtractor):
+            async def fetch_stages(self, input):
+                return FetchDatabasesOutput(total_record_count=15)
+
+        ext = Ext()
+        entity = EntityDef(name="stages", phase=2)
+        result_key, count = await ext._fetch_entity(entity, _make_input())
+        assert result_key == "stages_extracted"
+        assert count == 15
+
+    @pytest.mark.asyncio
+    async def test_credential_ref_passed_to_task_input(self):
+        """Verify credential_ref from ExtractionInput is forwarded."""
+        from application_sdk.credentials.ref import CredentialRef
+
+        captured_input = {}
+
+        class Ext(SqlMetadataExtractor):
+            async def fetch_databases(self, input):
+                captured_input["cred_ref"] = input.credential_ref
+                return FetchDatabasesOutput(total_record_count=1)
+
+        ext = Ext()
+        ref = CredentialRef(name="my-cred", credential_type="basic")
+        entity = EntityDef(name="databases")
+        await ext._fetch_entity(entity, _make_input(credential_ref=ref))
+        assert captured_input["cred_ref"].name == "my-cred"
+
+
+# ---------------------------------------------------------------------------
+# Phase grouping (unit test without Temporal)
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseGrouping:
+    def test_entities_grouped_by_phase(self):
+        entities = [
+            EntityDef(name="databases", phase=1),
+            EntityDef(name="schemas", phase=1),
+            EntityDef(name="stages", phase=2),
+            EntityDef(name="streams", phase=2),
+            EntityDef(name="dynamic_tables", phase=3),
+        ]
+
+        phases: dict[int, list[EntityDef]] = {}
+        for e in entities:
+            phases.setdefault(e.phase, []).append(e)
+
+        assert sorted(phases.keys()) == [1, 2, 3]
+        assert len(phases[1]) == 2
+        assert len(phases[2]) == 2
+        assert len(phases[3]) == 1
+        assert phases[3][0].name == "dynamic_tables"


### PR DESCRIPTION
…MetadataExtractor

Introduces declarative entity definitions that replace hardcoded asyncio.gather of 4 entities in SqlMetadataExtractor.run().

- EntityDef dataclass: name, sql, endpoint, phase, enabled, timeout
- Phased orchestration: entities grouped by phase, run concurrently within phase, sequentially across phases
- _fetch_entity() dispatches to fetch_{name}() methods by convention
- Full backward compat: empty entities list falls back to default 4 (databases, schemas, tables, columns)
- Adding a new entity type is one line in the entities list

What a Snowflake extractor looks like:

    class SnowflakeExtractor(SqlMetadataExtractor):
        entities = [
            EntityDef(name="databases", phase=1),
            EntityDef(name="schemas",   phase=1),
            EntityDef(name="stages",    phase=2),
            EntityDef(name="streams",   phase=2),
        ]

### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- _to be added_

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.