### PR TITLE
feat(templates): add EntityDef and entity-driven orchestration to SqlMetadataExtractor

### DIFF
--- a/application_sdk/templates/entity.py
+++ b/application_sdk/templates/entity.py
@@ -1,0 +1,80 @@
+"""Declarative entity definitions for metadata extraction.
+
+An ``EntityDef`` describes a single entity type to extract (e.g. databases,
+schemas, tables, columns, stages, streams).  Templates like
+``SqlMetadataExtractor`` use a list of these to orchestrate extraction
+automatically — no need to override ``run()``.
+
+Example::
+
+    class SnowflakeExtractor(SqlMetadataExtractor):
+        entities = [
+            EntityDef(name="databases", phase=1),
+            EntityDef(name="schemas",   phase=1),
+            EntityDef(name="tables",    phase=1),
+            EntityDef(name="columns",   phase=1),
+            EntityDef(name="stages",    sql="SELECT ... FROM STAGES", phase=2),
+            EntityDef(name="streams",   sql="SELECT ... FROM STREAMS", phase=2),
+        ]
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class EntityDef:
+    """Declares an extractable entity type.
+
+    Protocol-agnostic: works for SQL connectors (set ``sql``),
+    REST API connectors (set ``endpoint``), or custom logic
+    (leave both empty, implement ``fetch_{name}()`` method).
+    """
+
+    name: str
+    """Entity name used in output keys, logging, and method dispatch
+    (e.g. ``'databases'`` → ``fetch_databases()``)."""
+
+    # --- Fetch strategy (exactly one should be set, or none for custom method) ---
+
+    sql: str = ""
+    """SQL query template for SQL connectors.  Supports
+    ``{normalized_include_regex}``, ``{normalized_exclude_regex}``,
+    ``{temp_table_regex_sql}``, ``{database_name}`` placeholders."""
+
+    endpoint: str = ""
+    """REST API endpoint path for API connectors (e.g. ``'/api/3.1/workbooks'``).
+    Relative to the client's ``BASE_URL``."""
+
+    pagination: str = "none"
+    """Pagination strategy for API endpoints:
+    ``'none'``, ``'cursor'``, ``'offset'``, ``'page_token'``.
+    Ignored for SQL entities."""
+
+    response_items_key: str = ""
+    """JSON key containing the array of items in API response
+    (e.g. ``'workbooks.workbook'``).  Empty = response is the array.
+    Ignored for SQL entities."""
+
+    # --- Orchestration ---
+
+    phase: int = 1
+    """Execution phase (1 = parallel with core entities, 2 = after phase 1, etc.).
+    Entities in the same phase run concurrently."""
+
+    depends_on: tuple[str, ...] = ()
+    """Entity names that must complete before this one starts.
+    Empty = runs in the first parallel batch of its phase."""
+
+    enabled: bool = True
+    """Set to False to skip this entity (e.g. exclude_views toggle)."""
+
+    timeout_seconds: int = 1800
+    """Task timeout for this entity's extraction."""
+
+    # --- Output ---
+
+    result_key: str = ""
+    """Key in ExtractionOutput for the count.
+    Defaults to ``'{name}_extracted'`` if empty."""

--- a/application_sdk/templates/entity.py
+++ b/application_sdk/templates/entity.py
@@ -1,82 +1,67 @@
 """Declarative entity definitions for metadata extraction.
 
-An ``EntityDef`` describes a single entity type to extract (e.g. databases,
-schemas, tables, columns, stages, streams).  Templates like
-``SqlMetadataExtractor`` use a list of these to orchestrate extraction
-automatically — no need to override ``run()``.
+An ``ExtractableEntity`` describes a single entity type to extract
+(e.g. databases, schemas, tables, columns, stages, streams).  Templates
+like ``SqlMetadataExtractor`` use a list of these to orchestrate
+extraction automatically — no need to override ``run()``.
+
+Each entity maps **explicitly** to a task method via ``task_name`` —
+no naming-convention magic.
 
 Example::
 
     class SnowflakeExtractor(SqlMetadataExtractor):
         entities = [
-            EntityDef(name="databases", phase=1),
-            EntityDef(name="schemas",   phase=1),
-            EntityDef(name="tables",    phase=1),
-            EntityDef(name="columns",   phase=1),
-            EntityDef(name="stages",    sql="SELECT ... FROM STAGES", phase=2),
-            EntityDef(name="streams",   sql="SELECT ... FROM STREAMS", phase=2),
+            ExtractableEntity(task_name="fetch_databases", phase=1),
+            ExtractableEntity(task_name="fetch_schemas",   phase=1),
+            ExtractableEntity(task_name="fetch_tables",    phase=1),
+            ExtractableEntity(task_name="fetch_columns",   phase=1),
+            ExtractableEntity(task_name="fetch_stages",    phase=2),
+            ExtractableEntity(task_name="fetch_streams",   phase=2),
         ]
 """
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
+from typing import Any
+
+from application_sdk.observability.logger_adaptor import get_logger
+
+logger = get_logger(__name__)
 
 
 @dataclass(frozen=True)
-class EntityDef:
+class ExtractableEntity:
     """Declares an extractable entity type.
 
-    Protocol-agnostic: works for SQL connectors (set ``sql``),
-    REST API connectors (set ``endpoint``), or custom logic
-    (leave both empty, implement ``fetch_{name}()`` method).
+    Each entity maps explicitly to a method on the App subclass via
+    ``task_name``.  No naming conventions — the entity tells the
+    orchestrator exactly which method to call.
     """
 
-    name: str
-    """Entity name used in output keys, logging, and method dispatch
-    (e.g. ``'databases'`` → ``fetch_databases()``)."""
-
-    # --- Fetch strategy (exactly one should be set, or none for custom method) ---
-
-    sql: str = ""
-    """SQL query template for SQL connectors.  Supports
-    ``{normalized_include_regex}``, ``{normalized_exclude_regex}``,
-    ``{temp_table_regex_sql}``, ``{database_name}`` placeholders."""
-
-    endpoint: str = ""
-    """REST API endpoint path for API connectors (e.g. ``'/api/3.1/workbooks'``).
-    Relative to the client's ``BASE_URL``."""
-
-    pagination: str = "none"
-    """Pagination strategy for API endpoints:
-    ``'none'``, ``'cursor'``, ``'offset'``, ``'page_token'``.
-    Ignored for SQL entities."""
-
-    response_items_key: str = ""
-    """JSON key containing the array of items in API response
-    (e.g. ``'workbooks.workbook'``).  Empty = response is the array.
-    Ignored for SQL entities."""
+    task_name: str
+    """The exact method name on the App subclass to call for this entity
+    (e.g. ``'fetch_databases'``, ``'fetch_stages'``)."""
 
     # --- Orchestration ---
 
     phase: int = 1
-    """Execution phase (1 = parallel with core entities, 2 = after phase 1, etc.).
+    """Execution phase (1 = first, 2 = after phase 1 completes, etc.).
     Entities in the same phase run concurrently."""
 
     depends_on: tuple[str, ...] = ()
-    """Entity names that must complete before this one starts.
-    Empty = runs in the first parallel batch of its phase.
+    """Task names that must complete before this one starts.
     Not yet implemented in orchestration — reserved for future use.
 
     Example::
 
         entities = [
-            EntityDef(name="databases", phase=1),
-            EntityDef(name="schemas",   phase=1),
-            # stages waits only for databases, not all of phase 1
-            EntityDef(name="stages",  phase=2, depends_on=("databases",)),
-            # streams waits for both databases and schemas
-            EntityDef(name="streams", phase=2, depends_on=("databases", "schemas")),
+            ExtractableEntity(task_name="fetch_databases", phase=1),
+            ExtractableEntity(task_name="fetch_schemas",   phase=1),
+            ExtractableEntity(task_name="fetch_stages",  phase=2,
+                              depends_on=("fetch_databases",)),
         ]
     """
 
@@ -89,5 +74,65 @@ class EntityDef:
     # --- Output ---
 
     result_key: str = ""
-    """Key in ExtractionOutput for the count.
-    Defaults to ``'{name}_extracted'`` if empty."""
+    """Key in the output model for the count.
+    Defaults to ``'{base}_extracted'`` where *base* is ``task_name``
+    with the ``fetch_`` prefix stripped
+    (e.g. ``'fetch_databases'`` -> ``'databases_extracted'``)."""
+
+
+def default_result_key(task_name: str) -> str:
+    """Derive a default result key from a task name.
+
+    ``'fetch_databases'`` -> ``'databases_extracted'``
+    ``'fetch_stages'``    -> ``'stages_extracted'``
+    """
+    base = task_name.removeprefix("fetch_")
+    return f"{base}_extracted"
+
+
+async def run_entity_phases(
+    app: Any,
+    entities: list[ExtractableEntity],
+    base_input: Any,
+) -> dict[str, int]:
+    """Execute entities grouped by phase, returning ``{result_key: count}``.
+
+    Entities in the same phase run concurrently via ``asyncio.gather``.
+    If any entity in a phase fails, sibling entities in that phase still
+    run to completion before the first error is re-raised
+    (``return_exceptions=True``).
+
+    The *app* must implement ``_fetch_entity(entity, base_input)``
+    returning ``(result_key, count)``.
+    """
+    phases: dict[int, list[ExtractableEntity]] = {}
+    for entity in entities:
+        phases.setdefault(entity.phase, []).append(entity)
+
+    results: dict[str, int] = {}
+    for phase_num in sorted(phases):
+        phase_entities = phases[phase_num]
+        phase_results = await asyncio.gather(
+            *[app._fetch_entity(entity, base_input) for entity in phase_entities],
+            return_exceptions=True,
+        )
+
+        errors: list[tuple[ExtractableEntity, BaseException]] = []
+        for entity, result in zip(phase_entities, phase_results):
+            if isinstance(result, BaseException):
+                errors.append((entity, result))
+            else:
+                result_key, count = result
+                results[result_key] = count
+
+        if errors:
+            for entity, err in errors[1:]:
+                logger.error(
+                    "Entity '%s' also failed in phase %d: %s",
+                    entity.task_name,
+                    phase_num,
+                    err,
+                )
+            raise errors[0][1]
+
+    return results

--- a/application_sdk/templates/entity.py
+++ b/application_sdk/templates/entity.py
@@ -65,7 +65,20 @@ class EntityDef:
 
     depends_on: tuple[str, ...] = ()
     """Entity names that must complete before this one starts.
-    Empty = runs in the first parallel batch of its phase."""
+    Empty = runs in the first parallel batch of its phase.
+    Not yet implemented in orchestration — reserved for future use.
+
+    Example::
+
+        entities = [
+            EntityDef(name="databases", phase=1),
+            EntityDef(name="schemas",   phase=1),
+            # stages waits only for databases, not all of phase 1
+            EntityDef(name="stages",  phase=2, depends_on=("databases",)),
+            # streams waits for both databases and schemas
+            EntityDef(name="streams", phase=2, depends_on=("databases", "schemas")),
+        ]
+    """
 
     enabled: bool = True
     """Set to False to skip this entity (e.g. exclude_views toggle)."""

--- a/application_sdk/templates/sql_metadata_extractor.py
+++ b/application_sdk/templates/sql_metadata_extractor.py
@@ -257,15 +257,16 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
             else:
                 records_uploaded = 0
 
+            # Build output dynamically — any result key matching an
+            # ExtractionOutput field gets populated automatically.
+            output_fields = ExtractionOutput.model_fields
+            entity_counts = {k: v for k, v in results.items() if k in output_fields}
+
             return ExtractionOutput(
                 workflow_id=workflow_id,
                 success=True,
-                databases_extracted=results.get("databases_extracted", 0),
-                schemas_extracted=results.get("schemas_extracted", 0),
-                tables_extracted=results.get("tables_extracted", 0),
-                columns_extracted=results.get("columns_extracted", 0),
-                procedures_extracted=results.get("procedures_extracted", 0),
                 records_uploaded=records_uploaded,
+                **entity_counts,
             )
 
         except Exception as e:

--- a/application_sdk/templates/sql_metadata_extractor.py
+++ b/application_sdk/templates/sql_metadata_extractor.py
@@ -3,37 +3,34 @@
 Replaces the v2 ``BaseSQLMetadataExtractionWorkflow`` +
 ``BaseSQLMetadataExtractionActivities`` split with a single typed ``App`` class.
 
-Migration from v2::
-
-    # v2: separate workflow + activities, all Dict[str, Any]
-    from application_sdk.workflows.metadata_extraction.sql import (
-        BaseSQLMetadataExtractionWorkflow,
-    )
-    from application_sdk.activities.metadata_extraction.sql import (
-        BaseSQLMetadataExtractionActivities,
-    )
-
-    # v3: single App class with typed contracts
-    from application_sdk.templates import SqlMetadataExtractor
-
 Subclass ``SqlMetadataExtractor`` to implement connector-specific logic::
 
     from application_sdk.templates import SqlMetadataExtractor
-    from application_sdk.templates.contracts.sql_metadata import (
-        ExtractionInput, ExtractionOutput, FetchDatabasesInput, FetchDatabasesOutput,
-    )
-    from application_sdk.app import task
+    from application_sdk.templates.entity import EntityDef
 
-    class MyConnectorExtractor(SqlMetadataExtractor):
+    class MyExtractor(SqlMetadataExtractor):
+        entities = [
+            EntityDef(name="databases", phase=1),
+            EntityDef(name="schemas",   phase=1),
+            EntityDef(name="tables",    phase=1),
+            EntityDef(name="columns",   phase=1),
+            EntityDef(name="stages",    sql="SELECT ...", phase=2),
+        ]
+
         @task(timeout_seconds=1800)
-        async def fetch_databases(self, input: FetchDatabasesInput) -> FetchDatabasesOutput:
-            # connector-specific implementation
-            return FetchDatabasesOutput(chunk_count=1, total_record_count=10)
+        async def fetch_databases(self, input): ...
+
+Or use the legacy class-attribute SQL pattern (still supported)::
+
+    class MyExtractor(SqlMetadataExtractor):
+        fetch_database_sql = "SELECT ..."
+        fetch_schema_sql   = "SELECT ..."
 """
 
 from __future__ import annotations
 
 import asyncio
+from typing import ClassVar
 
 from application_sdk.app.task import task
 from application_sdk.common.exc_utils import rewrap
@@ -43,6 +40,7 @@ from application_sdk.templates.contracts.base_metadata_extraction import UploadI
 from application_sdk.templates.contracts.sql_metadata import (
     ExtractionInput,
     ExtractionOutput,
+    ExtractionTaskInput,
     FetchColumnsInput,
     FetchColumnsOutput,
     FetchDatabasesInput,
@@ -56,8 +54,26 @@ from application_sdk.templates.contracts.sql_metadata import (
     TransformInput,
     TransformOutput,
 )
+from application_sdk.templates.entity import EntityDef
 
 logger = get_logger(__name__)
+
+# Default entity definitions — the 4 core SQL entity types.
+_DEFAULT_ENTITIES = [
+    EntityDef(name="databases", phase=1),
+    EntityDef(name="schemas", phase=1),
+    EntityDef(name="tables", phase=1),
+    EntityDef(name="columns", phase=1),
+]
+
+# Maps entity name → (InputClass, OutputClass) for built-in entities.
+_ENTITY_CONTRACTS: dict[str, tuple[type[ExtractionTaskInput], type]] = {
+    "databases": (FetchDatabasesInput, FetchDatabasesOutput),
+    "schemas": (FetchSchemasInput, FetchSchemasOutput),
+    "tables": (FetchTablesInput, FetchTablesOutput),
+    "columns": (FetchColumnsInput, FetchColumnsOutput),
+    "procedures": (FetchProceduresInput, FetchProceduresOutput),
+}
 
 
 class SqlMetadataExtractor(BaseMetadataExtractor):
@@ -65,26 +81,38 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
 
     Inherits ``upload_to_atlan`` from ``BaseMetadataExtractor``.
 
-    The ``run()`` method orchestrates the full extraction:
-    fetch (databases, schemas, tables, columns) → transform → upload.
-    Override ``run()`` to change the orchestration.
+    **Entity-driven orchestration:**
 
-    All task timeouts default to 30 minutes. Override via::
+    Set the ``entities`` class variable to declare what to extract.
+    The ``run()`` method automatically orchestrates all registered
+    entities by phase — no need to override ``run()``.
 
-        @task(timeout_seconds=3600)
-        async def fetch_tables(self, input: FetchTablesInput) -> FetchTablesOutput:
-            ...
+    Entities in the same phase run concurrently.  Phase 2 entities
+    start only after all phase 1 entities complete, and so on.
+
+    For each entity, ``run()`` dispatches to ``fetch_{name}()`` if
+    a ``@task`` method with that name exists on the subclass.
+
+    **Legacy class-attribute SQL (still supported):**
+
+    If ``entities`` is not overridden (empty list), the extractor
+    falls back to the default 4 entities (databases, schemas, tables,
+    columns) and dispatches to the existing ``fetch_*`` task methods.
     """
+
+    entities: ClassVar[list[EntityDef]] = []
+    """Override with a list of ``EntityDef`` to declare entities.
+    Empty = use defaults (databases, schemas, tables, columns)."""
+
+    # ------------------------------------------------------------------
+    # Task methods — override in subclass
+    # ------------------------------------------------------------------
 
     @task(timeout_seconds=1800)
     async def fetch_databases(self, input: FetchDatabasesInput) -> FetchDatabasesOutput:
-        """Fetch databases from the source system.
-
-        Override this method in your connector subclass.
-        """
+        """Fetch databases from the source system."""
         raise NotImplementedError(
-            f"{type(self).__name__} must implement fetch_databases(). "
-            "See application_sdk.templates.sql_metadata_extractor for examples."
+            f"{type(self).__name__} must implement fetch_databases()."
         )
 
     @task(timeout_seconds=1800)
@@ -112,22 +140,13 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
     async def fetch_procedures(
         self, input: FetchProceduresInput
     ) -> FetchProceduresOutput:
-        """Fetch stored procedures from the source system.
+        """Fetch stored procedures (optional).
 
-        This task is optional — connectors that do not support stored procedures
-        should return ``FetchProceduresOutput()`` with zero counts rather than
-        raising an error.
-
-        This task is NOT called from the base ``run()`` method. Connectors that
-        need it should call it from their own ``run()`` override.
-
-        Override this method in your connector subclass if procedure extraction
-        is required.
+        Not called from the base ``run()``.  Include an ``EntityDef``
+        with ``name="procedures"`` in ``entities`` if needed.
         """
         raise NotImplementedError(
-            f"{type(self).__name__} must implement fetch_procedures(), "
-            "or return FetchProceduresOutput() with zero counts for connectors "
-            "that do not support stored procedures."
+            f"{type(self).__name__} must implement fetch_procedures()."
         )
 
     @task(timeout_seconds=1800)
@@ -137,99 +156,96 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
             f"{type(self).__name__} must implement transform_data()."
         )
 
+    # ------------------------------------------------------------------
+    # Orchestration
+    # ------------------------------------------------------------------
+
+    def _get_entities(self) -> list[EntityDef]:
+        """Return the effective entity list.
+
+        If the subclass sets ``entities``, use that.
+        Otherwise fall back to the 4 default entities.
+        """
+        entities = self.entities if self.entities else _DEFAULT_ENTITIES
+        return [e for e in entities if e.enabled]
+
+    async def _fetch_entity(
+        self,
+        entity: EntityDef,
+        base_input: ExtractionInput,
+    ) -> tuple[str, int]:
+        """Dispatch to the correct ``fetch_{name}()`` task method.
+
+        Returns:
+            Tuple of (result_key, record_count).
+        """
+        method_name = f"fetch_{entity.name}"
+        method = getattr(self, method_name, None)
+        if method is None:
+            raise NotImplementedError(
+                f"{type(self).__name__} has no fetch_{entity.name}() method "
+                f"for entity '{entity.name}'."
+            )
+
+        # Build the typed task input
+        input_cls = _ENTITY_CONTRACTS.get(entity.name, (ExtractionTaskInput, None))[0]
+
+        # Prefer credential_ref; fall back to legacy credential_guid
+        cred_ref = base_input.credential_ref
+        if cred_ref is None and base_input.credential_guid:
+            from application_sdk.credentials import legacy_credential_ref
+
+            cred_ref = legacy_credential_ref(base_input.credential_guid)
+
+        task_input = input_cls(
+            workflow_id=base_input.workflow_id,
+            connection=base_input.connection,
+            credential_guid=base_input.credential_guid,
+            credential_ref=cred_ref,
+            output_prefix=base_input.output_prefix,
+            output_path=base_input.output_path,
+            exclude_filter=base_input.exclude_filter,
+            include_filter=base_input.include_filter,
+            temp_table_regex=base_input.temp_table_regex,
+            source_tag_prefix=base_input.source_tag_prefix,
+        )
+
+        result = await method(task_input)
+        result_key = entity.result_key or f"{entity.name}_extracted"
+        count = getattr(result, "total_record_count", 0)
+        return (result_key, count)
+
     async def run(self, input: ExtractionInput) -> ExtractionOutput:  # type: ignore[override]
         """Orchestrate the full metadata extraction pipeline.
 
-        Default orchestration:
-        1. Fetch all metadata types in parallel (databases, schemas, tables, columns)
-        2. Transform data
-        3. Return aggregated output
-
-        Override to customize the orchestration order or add additional steps.
+        Executes entities grouped by phase.  All entities in the same
+        phase run concurrently.  Phase N+1 starts only after phase N
+        completes.  After extraction, uploads results to Atlan.
         """
         workflow_id = input.workflow_id
         logger.info("Starting SQL metadata extraction: %s", workflow_id)
 
         try:
-            # Prefer credential_ref; fall back to legacy credential_guid
-            cred_ref = input.credential_ref
-            if cred_ref is None and input.credential_guid:
-                from application_sdk.credentials import legacy_credential_ref
+            entities = self._get_entities()
 
-                cred_ref = legacy_credential_ref(input.credential_guid)
+            # Group by phase
+            phases: dict[int, list[EntityDef]] = {}
+            for entity in entities:
+                phases.setdefault(entity.phase, []).append(entity)
 
-            # Fetch all metadata types in parallel
-            (
-                db_result,
-                schema_result,
-                table_result,
-                column_result,
-            ) = await asyncio.gather(
-                self.fetch_databases(
-                    FetchDatabasesInput(
-                        workflow_id=workflow_id,
-                        connection=input.connection,
-                        credential_guid=input.credential_guid,
-                        credential_ref=cred_ref,
-                        output_prefix=input.output_prefix,
-                        output_path=input.output_path,
-                        exclude_filter=input.exclude_filter,
-                        include_filter=input.include_filter,
-                        temp_table_regex=input.temp_table_regex,
-                        source_tag_prefix=input.source_tag_prefix,
-                    )
-                ),
-                self.fetch_schemas(
-                    FetchSchemasInput(
-                        workflow_id=workflow_id,
-                        connection=input.connection,
-                        credential_guid=input.credential_guid,
-                        credential_ref=cred_ref,
-                        output_prefix=input.output_prefix,
-                        output_path=input.output_path,
-                        exclude_filter=input.exclude_filter,
-                        include_filter=input.include_filter,
-                        temp_table_regex=input.temp_table_regex,
-                        source_tag_prefix=input.source_tag_prefix,
-                    )
-                ),
-                self.fetch_tables(
-                    FetchTablesInput(
-                        workflow_id=workflow_id,
-                        connection=input.connection,
-                        credential_guid=input.credential_guid,
-                        credential_ref=cred_ref,
-                        output_prefix=input.output_prefix,
-                        output_path=input.output_path,
-                        exclude_filter=input.exclude_filter,
-                        include_filter=input.include_filter,
-                        temp_table_regex=input.temp_table_regex,
-                        source_tag_prefix=input.source_tag_prefix,
-                    )
-                ),
-                self.fetch_columns(
-                    FetchColumnsInput(
-                        workflow_id=workflow_id,
-                        connection=input.connection,
-                        credential_guid=input.credential_guid,
-                        credential_ref=cred_ref,
-                        output_prefix=input.output_prefix,
-                        output_path=input.output_path,
-                        exclude_filter=input.exclude_filter,
-                        include_filter=input.include_filter,
-                        temp_table_regex=input.temp_table_regex,
-                        source_tag_prefix=input.source_tag_prefix,
-                    )
-                ),
-            )
+            # Execute phase by phase
+            results: dict[str, int] = {}
+            for phase_num in sorted(phases):
+                phase_results = await asyncio.gather(
+                    *[self._fetch_entity(entity, input) for entity in phases[phase_num]]
+                )
+                for result_key, count in phase_results:
+                    results[result_key] = count
 
             logger.info(
                 "Metadata extraction completed",
                 workflow_id=workflow_id,
-                databases=db_result.total_record_count,
-                schemas=schema_result.total_record_count,
-                tables=table_result.total_record_count,
-                columns=column_result.total_record_count,
+                results=results,
             )
 
             # Upload extracted data to Atlan
@@ -244,10 +260,11 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
             return ExtractionOutput(
                 workflow_id=workflow_id,
                 success=True,
-                databases_extracted=db_result.total_record_count,
-                schemas_extracted=schema_result.total_record_count,
-                tables_extracted=table_result.total_record_count,
-                columns_extracted=column_result.total_record_count,
+                databases_extracted=results.get("databases_extracted", 0),
+                schemas_extracted=results.get("schemas_extracted", 0),
+                tables_extracted=results.get("tables_extracted", 0),
+                columns_extracted=results.get("columns_extracted", 0),
+                procedures_extracted=results.get("procedures_extracted", 0),
                 records_uploaded=records_uploaded,
             )
 

--- a/application_sdk/templates/sql_metadata_extractor.py
+++ b/application_sdk/templates/sql_metadata_extractor.py
@@ -6,15 +6,15 @@ Replaces the v2 ``BaseSQLMetadataExtractionWorkflow`` +
 Subclass ``SqlMetadataExtractor`` to implement connector-specific logic::
 
     from application_sdk.templates import SqlMetadataExtractor
-    from application_sdk.templates.entity import EntityDef
+    from application_sdk.templates.entity import ExtractableEntity
 
     class MyExtractor(SqlMetadataExtractor):
         entities = [
-            EntityDef(name="databases", phase=1),
-            EntityDef(name="schemas",   phase=1),
-            EntityDef(name="tables",    phase=1),
-            EntityDef(name="columns",   phase=1),
-            EntityDef(name="stages",    sql="SELECT ...", phase=2),
+            ExtractableEntity(task_name="fetch_databases", phase=1),
+            ExtractableEntity(task_name="fetch_schemas",   phase=1),
+            ExtractableEntity(task_name="fetch_tables",    phase=1),
+            ExtractableEntity(task_name="fetch_columns",   phase=1),
+            ExtractableEntity(task_name="fetch_stages",    phase=2),
         ]
 
         @task(timeout_seconds=1800)
@@ -29,7 +29,6 @@ Or use the legacy class-attribute SQL pattern (still supported)::
 
 from __future__ import annotations
 
-import asyncio
 from typing import ClassVar
 
 from application_sdk.app.task import task
@@ -54,25 +53,29 @@ from application_sdk.templates.contracts.sql_metadata import (
     TransformInput,
     TransformOutput,
 )
-from application_sdk.templates.entity import EntityDef
+from application_sdk.templates.entity import (
+    ExtractableEntity,
+    default_result_key,
+    run_entity_phases,
+)
 
 logger = get_logger(__name__)
 
 # Default entity definitions — the 4 core SQL entity types.
 _DEFAULT_ENTITIES = [
-    EntityDef(name="databases", phase=1),
-    EntityDef(name="schemas", phase=1),
-    EntityDef(name="tables", phase=1),
-    EntityDef(name="columns", phase=1),
+    ExtractableEntity(task_name="fetch_databases", phase=1),
+    ExtractableEntity(task_name="fetch_schemas", phase=1),
+    ExtractableEntity(task_name="fetch_tables", phase=1),
+    ExtractableEntity(task_name="fetch_columns", phase=1),
 ]
 
-# Maps entity name → (InputClass, OutputClass) for built-in entities.
+# Maps task_name → (InputClass, OutputClass) for built-in entities.
 _ENTITY_CONTRACTS: dict[str, tuple[type[ExtractionTaskInput], type]] = {
-    "databases": (FetchDatabasesInput, FetchDatabasesOutput),
-    "schemas": (FetchSchemasInput, FetchSchemasOutput),
-    "tables": (FetchTablesInput, FetchTablesOutput),
-    "columns": (FetchColumnsInput, FetchColumnsOutput),
-    "procedures": (FetchProceduresInput, FetchProceduresOutput),
+    "fetch_databases": (FetchDatabasesInput, FetchDatabasesOutput),
+    "fetch_schemas": (FetchSchemasInput, FetchSchemasOutput),
+    "fetch_tables": (FetchTablesInput, FetchTablesOutput),
+    "fetch_columns": (FetchColumnsInput, FetchColumnsOutput),
+    "fetch_procedures": (FetchProceduresInput, FetchProceduresOutput),
 }
 
 
@@ -90,8 +93,8 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
     Entities in the same phase run concurrently.  Phase 2 entities
     start only after all phase 1 entities complete, and so on.
 
-    For each entity, ``run()`` dispatches to ``fetch_{name}()`` if
-    a ``@task`` method with that name exists on the subclass.
+    Each entity's ``task_name`` maps directly to a method on the
+    subclass — no naming-convention magic.
 
     **Legacy class-attribute SQL (still supported):**
 
@@ -100,8 +103,8 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
     columns) and dispatches to the existing ``fetch_*`` task methods.
     """
 
-    entities: ClassVar[list[EntityDef]] = []
-    """Override with a list of ``EntityDef`` to declare entities.
+    entities: ClassVar[list[ExtractableEntity]] = []
+    """Override with a list of ``ExtractableEntity`` to declare entities.
     Empty = use defaults (databases, schemas, tables, columns)."""
 
     # ------------------------------------------------------------------
@@ -142,8 +145,9 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
     ) -> FetchProceduresOutput:
         """Fetch stored procedures (optional).
 
-        Not called from the base ``run()``.  Include an ``EntityDef``
-        with ``name="procedures"`` in ``entities`` if needed.
+        Not called from the base ``run()``.  Include an
+        ``ExtractableEntity(task_name="fetch_procedures")`` in
+        ``entities`` if needed.
         """
         raise NotImplementedError(
             f"{type(self).__name__} must implement fetch_procedures()."
@@ -160,7 +164,7 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
     # Orchestration
     # ------------------------------------------------------------------
 
-    def _get_entities(self) -> list[EntityDef]:
+    def _get_entities(self) -> list[ExtractableEntity]:
         """Return the effective entity list.
 
         If the subclass sets ``entities``, use that.
@@ -171,24 +175,25 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
 
     async def _fetch_entity(
         self,
-        entity: EntityDef,
+        entity: ExtractableEntity,
         base_input: ExtractionInput,
     ) -> tuple[str, int]:
-        """Dispatch to the correct ``fetch_{name}()`` task method.
+        """Dispatch to the task method specified by ``entity.task_name``.
 
         Returns:
             Tuple of (result_key, record_count).
         """
-        method_name = f"fetch_{entity.name}"
-        method = getattr(self, method_name, None)
+        method = getattr(self, entity.task_name, None)
         if method is None:
             raise NotImplementedError(
-                f"{type(self).__name__} has no fetch_{entity.name}() method "
-                f"for entity '{entity.name}'."
+                f"{type(self).__name__} has no '{entity.task_name}' method "
+                f"for entity with task_name='{entity.task_name}'."
             )
 
         # Build the typed task input
-        input_cls = _ENTITY_CONTRACTS.get(entity.name, (ExtractionTaskInput, None))[0]
+        input_cls = _ENTITY_CONTRACTS.get(
+            entity.task_name, (ExtractionTaskInput, None)
+        )[0]
 
         # Prefer credential_ref; fall back to legacy credential_guid
         cred_ref = base_input.credential_ref
@@ -211,7 +216,7 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
         )
 
         result = await method(task_input)
-        result_key = entity.result_key or f"{entity.name}_extracted"
+        result_key = entity.result_key or default_result_key(entity.task_name)
         count = getattr(result, "total_record_count", 0)
         return (result_key, count)
 
@@ -227,20 +232,7 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
 
         try:
             entities = self._get_entities()
-
-            # Group by phase
-            phases: dict[int, list[EntityDef]] = {}
-            for entity in entities:
-                phases.setdefault(entity.phase, []).append(entity)
-
-            # Execute phase by phase
-            results: dict[str, int] = {}
-            for phase_num in sorted(phases):
-                phase_results = await asyncio.gather(
-                    *[self._fetch_entity(entity, input) for entity in phases[phase_num]]
-                )
-                for result_key, count in phase_results:
-                    results[result_key] = count
+            results = await run_entity_phases(self, entities, input)
 
             logger.info(
                 "Metadata extraction completed",
@@ -260,7 +252,18 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
             # Build output dynamically — any result key matching an
             # ExtractionOutput field gets populated automatically.
             output_fields = ExtractionOutput.model_fields
-            entity_counts = {k: v for k, v in results.items() if k in output_fields}
+            entity_counts = {}
+            for k, v in results.items():
+                if k in output_fields:
+                    entity_counts[k] = v
+                else:
+                    logger.warning(
+                        "Result key '%s' has no matching field in %s — "
+                        "define the field on the output class or set "
+                        "result_key explicitly.",
+                        k,
+                        ExtractionOutput.__name__,
+                    )
 
             return ExtractionOutput(
                 workflow_id=workflow_id,

--- a/application_sdk/templates/sql_query_extractor.py
+++ b/application_sdk/templates/sql_query_extractor.py
@@ -3,25 +3,27 @@
 Replaces the v2 ``SQLQueryExtractionWorkflow`` + ``SQLQueryExtractionActivities``
 split with a single typed ``App`` class.
 
-Migration from v2::
-
-    # v2
-    from application_sdk.workflows.query_extraction.sql import SQLQueryExtractionWorkflow
-    from application_sdk.activities.query_extraction.sql import SQLQueryExtractionActivities
-
-    # v3
-    from application_sdk.templates import SqlQueryExtractor
-
 Subclass to implement connector-specific logic::
 
+    from application_sdk.templates import SqlQueryExtractor
+    from application_sdk.templates.entity import EntityDef
+
     class MyQueryExtractor(SqlQueryExtractor):
+        entities = [
+            EntityDef(name="queries", phase=1),
+        ]
+
+        @task(timeout_seconds=600)
+        async def get_query_batches(self, input): ...
+
         @task(timeout_seconds=3600)
-        async def fetch_queries(self, input: QueryFetchInput) -> QueryFetchOutput:
-            # connector-specific query fetching
-            return QueryFetchOutput(queries_fetched=100)
+        async def fetch_queries(self, input): ...
 """
 
 from __future__ import annotations
+
+import asyncio
+from typing import ClassVar
 
 from application_sdk.app.task import task
 from application_sdk.common.exc_utils import rewrap
@@ -35,19 +37,44 @@ from application_sdk.templates.contracts.sql_query import (
     QueryFetchInput,
     QueryFetchOutput,
 )
+from application_sdk.templates.entity import EntityDef
 
 logger = get_logger(__name__)
+
+# Default entity definitions for query extraction.
+_DEFAULT_QUERY_ENTITIES = [
+    EntityDef(name="queries", phase=1),
+]
 
 
 class SqlQueryExtractor(BaseMetadataExtractor):
     """Base class for SQL query extraction apps.
 
-    Inherits ``upload_to_atlan``, ``client_class``, ``handler_class``,
-    and ``transformer_class`` from ``BaseMetadataExtractor``.
+    Inherits ``upload_to_atlan`` from ``BaseMetadataExtractor``.
 
-    The ``run()`` method orchestrates the full extraction:
-    get_query_batches → fetch_queries (per batch) → aggregate output.
+    **Entity-driven orchestration:**
+
+    Set the ``entities`` class variable to declare what to extract.
+    The ``run()`` method automatically orchestrates all registered
+    entities by phase — no need to override ``run()``.
+
+    For the ``queries`` entity, orchestration calls
+    ``get_query_batches()`` then loops ``fetch_queries()`` per batch.
+    Custom entities dispatch to ``fetch_{name}()`` by convention.
+
+    **Default behavior:**
+
+    If ``entities`` is not overridden (empty list), the extractor
+    falls back to a single ``queries`` entity.
     """
+
+    entities: ClassVar[list[EntityDef]] = []
+    """Override with a list of ``EntityDef`` to declare entities.
+    Empty = use default (queries only)."""
+
+    # ------------------------------------------------------------------
+    # Task methods — override in subclass
+    # ------------------------------------------------------------------
 
     @task(timeout_seconds=600)
     async def get_query_batches(self, input: QueryBatchInput) -> QueryBatchOutput:
@@ -69,15 +96,88 @@ class SqlQueryExtractor(BaseMetadataExtractor):
             f"{type(self).__name__} must implement fetch_queries()."
         )
 
+    # ------------------------------------------------------------------
+    # Orchestration
+    # ------------------------------------------------------------------
+
+    def _get_entities(self) -> list[EntityDef]:
+        """Return the effective entity list.
+
+        If the subclass sets ``entities``, use that.
+        Otherwise fall back to the default (queries only).
+        """
+        entities = self.entities if self.entities else _DEFAULT_QUERY_ENTITIES
+        return [e for e in entities if e.enabled]
+
+    async def _fetch_entity(
+        self,
+        entity: EntityDef,
+        base_input: QueryExtractionInput,
+        workflow_args: dict,
+    ) -> tuple[str, int]:
+        """Dispatch to the correct fetch method for an entity.
+
+        For the ``queries`` entity, runs the batch loop
+        (get_query_batches → fetch_queries per batch).
+        For other entities, dispatches to ``fetch_{name}()``.
+
+        Returns:
+            Tuple of (result_key, count).
+        """
+        if entity.name == "queries":
+            return await self._fetch_queries_batched(workflow_args)
+
+        # Standard dispatch for custom entities
+        method_name = f"fetch_{entity.name}"
+        method = getattr(self, method_name, None)
+        if method is None:
+            raise NotImplementedError(
+                f"{type(self).__name__} has no fetch_{entity.name}() method "
+                f"for entity '{entity.name}'."
+            )
+
+        result = await method(base_input)
+        result_key = entity.result_key or f"{entity.name}_extracted"
+        count = getattr(result, "total_record_count", 0) or getattr(
+            result, "queries_fetched", 0
+        )
+        return (result_key, count)
+
+    async def _fetch_queries_batched(
+        self,
+        workflow_args: dict,
+    ) -> tuple[str, int]:
+        """Run the batch loop for query extraction.
+
+        Calls ``get_query_batches()`` to determine batch count,
+        then ``fetch_queries()`` for each batch sequentially.
+
+        Returns:
+            Tuple of ("total_queries", total_queries_fetched).
+        """
+        batch_result = await self.get_query_batches(
+            QueryBatchInput(workflow_args=workflow_args)
+        )
+
+        total_queries = 0
+        for batch_num in range(batch_result.total_batches):
+            fetch_result = await self.fetch_queries(
+                QueryFetchInput(
+                    workflow_args=workflow_args,
+                    batch_number=batch_num,
+                    batch_size=batch_result.batch_size,
+                )
+            )
+            total_queries += fetch_result.queries_fetched
+
+        return ("total_queries", total_queries)
+
     async def run(self, input: QueryExtractionInput) -> QueryExtractionOutput:  # type: ignore[override]
         """Orchestrate the full query extraction pipeline.
 
-        Default orchestration:
-        1. Get batch count
-        2. Fetch each batch sequentially
-        3. Return aggregated output
-
-        Override to customize batch processing (e.g., parallel batches).
+        Executes entities grouped by phase.  All entities in the same
+        phase run concurrently.  Phase N+1 starts only after phase N
+        completes.
         """
         workflow_id = input.workflow_id
         logger.info("Starting SQL query extraction: %s", workflow_id)
@@ -101,33 +201,40 @@ class SqlQueryExtractor(BaseMetadataExtractor):
                 "batch_size": input.batch_size,
             }
 
-            batch_result = await self.get_query_batches(
-                QueryBatchInput(workflow_args=workflow_args)
-            )
+            entities = self._get_entities()
 
-            total_queries = 0
-            for batch_num in range(batch_result.total_batches):
-                fetch_result = await self.fetch_queries(
-                    QueryFetchInput(
-                        workflow_args=workflow_args,
-                        batch_number=batch_num,
-                        batch_size=batch_result.batch_size,
-                    )
+            # Group by phase
+            phases: dict[int, list[EntityDef]] = {}
+            for entity in entities:
+                phases.setdefault(entity.phase, []).append(entity)
+
+            # Execute phase by phase
+            results: dict[str, int] = {}
+            for phase_num in sorted(phases):
+                phase_results = await asyncio.gather(
+                    *[
+                        self._fetch_entity(entity, input, workflow_args)
+                        for entity in phases[phase_num]
+                    ]
                 )
-                total_queries += fetch_result.queries_fetched
+                for result_key, count in phase_results:
+                    results[result_key] = count
 
             logger.info(
                 "Query extraction completed",
                 workflow_id=workflow_id,
-                total_batches=batch_result.total_batches,
-                total_queries=total_queries,
+                results=results,
             )
+
+            # Build output dynamically — any result key matching a
+            # QueryExtractionOutput field gets populated automatically.
+            output_fields = QueryExtractionOutput.model_fields
+            entity_counts = {k: v for k, v in results.items() if k in output_fields}
 
             return QueryExtractionOutput(
                 workflow_id=workflow_id,
                 success=True,
-                total_batches=batch_result.total_batches,
-                total_queries=total_queries,
+                **entity_counts,
             )
 
         except Exception as e:

--- a/application_sdk/templates/sql_query_extractor.py
+++ b/application_sdk/templates/sql_query_extractor.py
@@ -6,11 +6,12 @@ split with a single typed ``App`` class.
 Subclass to implement connector-specific logic::
 
     from application_sdk.templates import SqlQueryExtractor
-    from application_sdk.templates.entity import EntityDef
+    from application_sdk.templates.entity import ExtractableEntity
 
     class MyQueryExtractor(SqlQueryExtractor):
         entities = [
-            EntityDef(name="queries", phase=1),
+            ExtractableEntity(task_name="_fetch_queries_batched",
+                              result_key="total_queries"),
         ]
 
         @task(timeout_seconds=600)
@@ -22,7 +23,6 @@ Subclass to implement connector-specific logic::
 
 from __future__ import annotations
 
-import asyncio
 from typing import ClassVar
 
 from application_sdk.app.task import task
@@ -37,13 +37,17 @@ from application_sdk.templates.contracts.sql_query import (
     QueryFetchInput,
     QueryFetchOutput,
 )
-from application_sdk.templates.entity import EntityDef
+from application_sdk.templates.entity import (
+    ExtractableEntity,
+    default_result_key,
+    run_entity_phases,
+)
 
 logger = get_logger(__name__)
 
 # Default entity definitions for query extraction.
 _DEFAULT_QUERY_ENTITIES = [
-    EntityDef(name="queries", phase=1),
+    ExtractableEntity(task_name="_fetch_queries_batched", result_key="total_queries"),
 ]
 
 
@@ -58,18 +62,19 @@ class SqlQueryExtractor(BaseMetadataExtractor):
     The ``run()`` method automatically orchestrates all registered
     entities by phase — no need to override ``run()``.
 
-    For the ``queries`` entity, orchestration calls
-    ``get_query_batches()`` then loops ``fetch_queries()`` per batch.
-    Custom entities dispatch to ``fetch_{name}()`` by convention.
+    The default entity (``_fetch_queries_batched``) handles the
+    batch loop: ``get_query_batches()`` then ``fetch_queries()``
+    per batch.  Custom entities dispatch directly to the method
+    named by ``task_name``.
 
     **Default behavior:**
 
     If ``entities`` is not overridden (empty list), the extractor
-    falls back to a single ``queries`` entity.
+    falls back to a single ``_fetch_queries_batched`` entity.
     """
 
-    entities: ClassVar[list[EntityDef]] = []
-    """Override with a list of ``EntityDef`` to declare entities.
+    entities: ClassVar[list[ExtractableEntity]] = []
+    """Override with a list of ``ExtractableEntity`` to declare entities.
     Empty = use default (queries only)."""
 
     # ------------------------------------------------------------------
@@ -100,7 +105,7 @@ class SqlQueryExtractor(BaseMetadataExtractor):
     # Orchestration
     # ------------------------------------------------------------------
 
-    def _get_entities(self) -> list[EntityDef]:
+    def _get_entities(self) -> list[ExtractableEntity]:
         """Return the effective entity list.
 
         If the subclass sets ``entities``, use that.
@@ -111,33 +116,30 @@ class SqlQueryExtractor(BaseMetadataExtractor):
 
     async def _fetch_entity(
         self,
-        entity: EntityDef,
+        entity: ExtractableEntity,
         base_input: QueryExtractionInput,
-        workflow_args: dict,
     ) -> tuple[str, int]:
-        """Dispatch to the correct fetch method for an entity.
-
-        For the ``queries`` entity, runs the batch loop
-        (get_query_batches → fetch_queries per batch).
-        For other entities, dispatches to ``fetch_{name}()``.
+        """Dispatch to the method specified by ``entity.task_name``.
 
         Returns:
             Tuple of (result_key, count).
         """
-        if entity.name == "queries":
-            return await self._fetch_queries_batched(workflow_args)
-
-        # Standard dispatch for custom entities
-        method_name = f"fetch_{entity.name}"
-        method = getattr(self, method_name, None)
+        method = getattr(self, entity.task_name, None)
         if method is None:
             raise NotImplementedError(
-                f"{type(self).__name__} has no fetch_{entity.name}() method "
-                f"for entity '{entity.name}'."
+                f"{type(self).__name__} has no '{entity.task_name}' method "
+                f"for entity with task_name='{entity.task_name}'."
             )
 
         result = await method(base_input)
-        result_key = entity.result_key or f"{entity.name}_extracted"
+
+        # Internal orchestration methods (like _fetch_queries_batched)
+        # return (result_key, count) directly.
+        if isinstance(result, tuple):
+            return result
+
+        # Standard @task methods return a contract object.
+        result_key = entity.result_key or default_result_key(entity.task_name)
         count = getattr(result, "total_record_count", 0) or getattr(
             result, "queries_fetched", 0
         )
@@ -145,7 +147,7 @@ class SqlQueryExtractor(BaseMetadataExtractor):
 
     async def _fetch_queries_batched(
         self,
-        workflow_args: dict,
+        base_input: QueryExtractionInput,
     ) -> tuple[str, int]:
         """Run the batch loop for query extraction.
 
@@ -155,6 +157,24 @@ class SqlQueryExtractor(BaseMetadataExtractor):
         Returns:
             Tuple of ("total_queries", total_queries_fetched).
         """
+        # Prefer credential_ref; fall back to legacy credential_guid
+        cred_ref = base_input.credential_ref
+        if cred_ref is None and base_input.credential_guid:
+            from application_sdk.credentials import legacy_credential_ref
+
+            cred_ref = legacy_credential_ref(base_input.credential_guid)
+
+        workflow_args = {
+            "workflow_id": base_input.workflow_id,
+            "connection": base_input.connection,
+            "credential_guid": base_input.credential_guid,
+            "credential_ref": cred_ref,
+            "output_prefix": base_input.output_prefix,
+            "output_path": base_input.output_path,
+            "lookback_days": base_input.lookback_days,
+            "batch_size": base_input.batch_size,
+        }
+
         batch_result = await self.get_query_batches(
             QueryBatchInput(workflow_args=workflow_args)
         )
@@ -183,42 +203,8 @@ class SqlQueryExtractor(BaseMetadataExtractor):
         logger.info("Starting SQL query extraction: %s", workflow_id)
 
         try:
-            # Prefer credential_ref; fall back to legacy credential_guid
-            cred_ref = input.credential_ref
-            if cred_ref is None and input.credential_guid:
-                from application_sdk.credentials import legacy_credential_ref
-
-                cred_ref = legacy_credential_ref(input.credential_guid)
-
-            workflow_args = {
-                "workflow_id": workflow_id,
-                "connection": input.connection,
-                "credential_guid": input.credential_guid,
-                "credential_ref": cred_ref,
-                "output_prefix": input.output_prefix,
-                "output_path": input.output_path,
-                "lookback_days": input.lookback_days,
-                "batch_size": input.batch_size,
-            }
-
             entities = self._get_entities()
-
-            # Group by phase
-            phases: dict[int, list[EntityDef]] = {}
-            for entity in entities:
-                phases.setdefault(entity.phase, []).append(entity)
-
-            # Execute phase by phase
-            results: dict[str, int] = {}
-            for phase_num in sorted(phases):
-                phase_results = await asyncio.gather(
-                    *[
-                        self._fetch_entity(entity, input, workflow_args)
-                        for entity in phases[phase_num]
-                    ]
-                )
-                for result_key, count in phase_results:
-                    results[result_key] = count
+            results = await run_entity_phases(self, entities, input)
 
             logger.info(
                 "Query extraction completed",
@@ -229,7 +215,18 @@ class SqlQueryExtractor(BaseMetadataExtractor):
             # Build output dynamically — any result key matching a
             # QueryExtractionOutput field gets populated automatically.
             output_fields = QueryExtractionOutput.model_fields
-            entity_counts = {k: v for k, v in results.items() if k in output_fields}
+            entity_counts = {}
+            for k, v in results.items():
+                if k in output_fields:
+                    entity_counts[k] = v
+                else:
+                    logger.warning(
+                        "Result key '%s' has no matching field in %s — "
+                        "define the field on the output class or set "
+                        "result_key explicitly.",
+                        k,
+                        QueryExtractionOutput.__name__,
+                    )
 
             return QueryExtractionOutput(
                 workflow_id=workflow_id,

--- a/docs/guides/sql-application-guide.md
+++ b/docs/guides/sql-application-guide.md
@@ -255,12 +255,12 @@ Each mapper function is a pure function: easy to unit test, no framework depende
 
 ## App (Extractor)
 
-The core of your connector is a `SqlMetadataExtractor` subclass. Declare which entities to extract using `EntityDef`, then implement `@task` methods for each. The base `run()` method handles orchestration automatically --- no need to override it.
+The core of your connector is a `SqlMetadataExtractor` subclass. Declare which entities to extract using `ExtractableEntity`, then implement `@task` methods for each. Each entity's `task_name` maps directly to a method on the class --- no naming-convention magic. The base `run()` method handles orchestration automatically --- no need to override it.
 
 ```python
 # app/connector.py
 from application_sdk.templates import SqlMetadataExtractor
-from application_sdk.templates.entity import EntityDef
+from application_sdk.templates.entity import ExtractableEntity
 from application_sdk.templates.contracts.sql_metadata import (
     FetchDatabasesOutput,
     FetchSchemasOutput,
@@ -278,12 +278,12 @@ logger = get_logger(__name__)
 
 class PostgresApp(SqlMetadataExtractor):
     # Declare entities --- grouped by phase, concurrent within each phase.
-    # Phase 1 entities all run in parallel, then phase 2 starts, etc.
+    # Each task_name maps directly to the method that fetches this entity.
     entities = [
-        EntityDef(name="databases", phase=1),
-        EntityDef(name="schemas",   phase=1),
-        EntityDef(name="tables",    phase=1),
-        EntityDef(name="columns",   phase=1),
+        ExtractableEntity(task_name="fetch_databases", phase=1),
+        ExtractableEntity(task_name="fetch_schemas",   phase=1),
+        ExtractableEntity(task_name="fetch_tables",    phase=1),
+        ExtractableEntity(task_name="fetch_columns",   phase=1),
     ]
 
     @task(timeout_seconds=1800)
@@ -382,11 +382,12 @@ Each `@task` method becomes a Temporal activity. The `entities` list drives orch
 
 1. Entities are grouped by `phase`. All entities in the same phase run **concurrently** via `asyncio.gather`.
 2. Phase N+1 starts only after all phase N entities complete.
-3. For each entity, `run()` dispatches to `fetch_{name}()` (e.g. `EntityDef(name="databases")` calls `fetch_databases()`).
+3. For each entity, `run()` dispatches to the method named by `task_name` (e.g. `ExtractableEntity(task_name="fetch_databases")` calls `fetch_databases()`).
 4. After all entities complete, results are uploaded to Atlan.
-5. Any result key matching an `ExtractionOutput` field (e.g. `databases_extracted`) is populated automatically.
+5. Any result key matching an `ExtractionOutput` field (e.g. `databases_extracted`) is populated automatically. Unmatched keys are logged as warnings.
+6. If one entity in a phase fails, sibling entities still run to completion before the error is raised.
 
-If `entities` is not set (empty list), the extractor falls back to the default 4 entities: databases, schemas, tables, columns.
+If `entities` is not set (empty list), the extractor falls back to the default 4 entities: fetch_databases, fetch_schemas, fetch_tables, fetch_columns.
 
 ### Available task methods
 
@@ -396,31 +397,31 @@ If `entities` is not set (empty list), the extractor falls back to the default 4
 | `fetch_schemas` | `FetchSchemasInput` | `FetchSchemasOutput` | Required --- raises `NotImplementedError` |
 | `fetch_tables` | `FetchTablesInput` | `FetchTablesOutput` | Required --- raises `NotImplementedError` |
 | `fetch_columns` | `FetchColumnsInput` | `FetchColumnsOutput` | Required --- raises `NotImplementedError` |
-| `fetch_procedures` | `FetchProceduresInput` | `FetchProceduresOutput` | Optional --- add `EntityDef(name="procedures")` |
-| `fetch_views` | `FetchViewsInput` | `FetchViewsOutput` | Optional --- add `EntityDef(name="views")` |
+| `fetch_procedures` | `FetchProceduresInput` | `FetchProceduresOutput` | Optional --- add `ExtractableEntity(task_name="fetch_procedures")` |
+| `fetch_views` | `FetchViewsInput` | `FetchViewsOutput` | Optional --- add `ExtractableEntity(task_name="fetch_views")` |
 | `transform_data` | `TransformInput` | `TransformOutput` | Override to map raw results via asset mapper |
 
 ### Adding custom entities
 
-Add new entity types by extending the `entities` list and implementing the matching `fetch_{name}()` method. No need to override `run()`.
+Add new entity types by extending the `entities` list and implementing the method named by `task_name`. No need to override `run()`.
 
 ```python
-from application_sdk.templates.entity import EntityDef
+from application_sdk.templates.entity import ExtractableEntity
 from application_sdk.templates.contracts.sql_metadata import FetchViewsOutput
 
 
 class SnowflakeApp(SqlMetadataExtractor):
     entities = [
         # Phase 1: core entities (run in parallel)
-        EntityDef(name="databases", phase=1),
-        EntityDef(name="schemas",   phase=1),
-        EntityDef(name="tables",    phase=1),
-        EntityDef(name="columns",   phase=1),
+        ExtractableEntity(task_name="fetch_databases", phase=1),
+        ExtractableEntity(task_name="fetch_schemas",   phase=1),
+        ExtractableEntity(task_name="fetch_tables",    phase=1),
+        ExtractableEntity(task_name="fetch_columns",   phase=1),
         # Phase 2: connector-specific entities (run after phase 1)
-        EntityDef(name="stages",  phase=2),
-        EntityDef(name="streams", phase=2),
+        ExtractableEntity(task_name="fetch_stages",  phase=2),
+        ExtractableEntity(task_name="fetch_streams", phase=2),
         # Disabled entity (skipped at runtime)
-        EntityDef(name="views", phase=1, enabled=False),
+        ExtractableEntity(task_name="fetch_views", phase=1, enabled=False),
     ]
 
     @task(timeout_seconds=1800)
@@ -436,18 +437,16 @@ class SnowflakeApp(SqlMetadataExtractor):
         return FetchDatabasesOutput(total_record_count=len(streams))
 ```
 
-### EntityDef fields
+### ExtractableEntity fields
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `name` | `str` | (required) | Entity name, used for method dispatch (`fetch_{name}()`) and result key |
-| `sql` | `str` | `""` | SQL query template (for SQL connectors) |
-| `endpoint` | `str` | `""` | REST API endpoint (for API connectors) |
+| `task_name` | `str` | (required) | Exact method name to call (e.g. `"fetch_databases"`) |
 | `phase` | `int` | `1` | Execution phase --- entities in the same phase run concurrently |
 | `enabled` | `bool` | `True` | Set to `False` to skip this entity |
 | `timeout_seconds` | `int` | `1800` | Task timeout for this entity |
-| `result_key` | `str` | `""` | Key in `ExtractionOutput` for the count (defaults to `{name}_extracted`) |
-| `depends_on` | `tuple[str, ...]` | `()` | Entity names that must complete before this one |
+| `result_key` | `str` | `""` | Key in `ExtractionOutput` for the count (defaults to `{base}_extracted` where base is task_name minus `fetch_` prefix) |
+| `depends_on` | `tuple[str, ...]` | `()` | Task names that must complete before this one (reserved for future use) |
 
 ## Typed Contracts
 

--- a/docs/guides/sql-application-guide.md
+++ b/docs/guides/sql-application-guide.md
@@ -255,39 +255,37 @@ Each mapper function is a pure function: easy to unit test, no framework depende
 
 ## App (Extractor)
 
-The core of your connector is a `SqlMetadataExtractor` subclass. Override `@task` methods for fetching metadata and transforming it via asset mappers. The `run()` method orchestrates the full pipeline.
+The core of your connector is a `SqlMetadataExtractor` subclass. Declare which entities to extract using `EntityDef`, then implement `@task` methods for each. The base `run()` method handles orchestration automatically --- no need to override it.
 
 ```python
 # app/connector.py
-import asyncio
 from application_sdk.templates import SqlMetadataExtractor
+from application_sdk.templates.entity import EntityDef
 from application_sdk.templates.contracts.sql_metadata import (
-    ExtractionInput,
-    ExtractionOutput,
-    FetchDatabasesInput,
     FetchDatabasesOutput,
-    FetchSchemasInput,
     FetchSchemasOutput,
-    FetchTablesInput,
     FetchTablesOutput,
-    FetchColumnsInput,
     FetchColumnsOutput,
-    TransformInput,
-    TransformOutput,
 )
 from application_sdk.app import task
 from application_sdk.observability.logger_adaptor import get_logger
 
 from app.clients import PostgresClient
-from app.contracts import MyCredential, MetadataConfig, MyFetchInput
-from app.asset_mapper import (
-    map_database, map_schema, map_table, map_column, serialize_entity,
-)
+from app.contracts import MyFetchInput
 
 logger = get_logger(__name__)
 
 
 class PostgresApp(SqlMetadataExtractor):
+    # Declare entities --- grouped by phase, concurrent within each phase.
+    # Phase 1 entities all run in parallel, then phase 2 starts, etc.
+    entities = [
+        EntityDef(name="databases", phase=1),
+        EntityDef(name="schemas",   phase=1),
+        EntityDef(name="tables",    phase=1),
+        EntityDef(name="columns",   phase=1),
+    ]
+
     @task(timeout_seconds=1800)
     async def fetch_databases(self, input: MyFetchInput) -> FetchDatabasesOutput:
         """Fetch the current database name from PostgreSQL."""
@@ -376,55 +374,19 @@ class PostgresApp(SqlMetadataExtractor):
             chunk_count=1,
             total_record_count=len(rows),
         )
-
-    @task(timeout_seconds=3600)
-    async def transform(self, input: TransformInput) -> TransformOutput:
-        """Transform raw extraction results into pyatlan entities using asset mappers."""
-        conn_qn = input.connection_qualified_name
-
-        # Map raw rows to pyatlan entity objects, then serialize for publishing
-        entities = []
-        for db_row in input.databases:
-            entities.append(serialize_entity(map_database(db_row, conn_qn)))
-        for schema_row in input.schemas:
-            entities.append(serialize_entity(map_schema(schema_row, conn_qn, schema_row["database"])))
-        for table_row in input.tables:
-            entities.append(serialize_entity(map_table(table_row, conn_qn)))
-        for col_row in input.columns:
-            entities.append(serialize_entity(map_column(col_row, conn_qn)))
-
-        return TransformOutput(entity_count=len(entities))
-
-    async def run(self, input: ExtractionInput) -> ExtractionOutput:
-        """Orchestrate the full extraction + transformation pipeline."""
-        # Phase 1: Fetch metadata in parallel
-        db_result, schema_result, table_result, col_result = await asyncio.gather(
-            self.fetch_databases(MyFetchInput.from_extraction(input)),
-            self.fetch_schemas(MyFetchInput.from_extraction(input)),
-            self.fetch_tables(MyFetchInput.from_extraction(input)),
-            self.fetch_columns(MyFetchInput.from_extraction(input)),
-        )
-
-        # Phase 2: Transform using asset mappers
-        transform_result = await self.transform(
-            TransformInput(workflow_id=input.workflow_id, connection=input.connection)
-        )
-
-        return ExtractionOutput(
-            databases_extracted=db_result.total_record_count,
-            schemas_extracted=schema_result.total_record_count,
-            tables_extracted=table_result.total_record_count,
-            columns_extracted=col_result.total_record_count,
-        )
 ```
 
 ### What happens under the hood
 
-Each `@task` method becomes a Temporal activity. The `run()` method orchestrates the full pipeline:
+Each `@task` method becomes a Temporal activity. The `entities` list drives orchestration:
 
-1. **Fetch phase** --- fetch databases, schemas, tables, and columns **in parallel** via `asyncio.gather`
-2. **Transform phase** --- map raw results to pyatlan entities using the asset mapper
-3. **Return** --- aggregate counts into an `ExtractionOutput`
+1. Entities are grouped by `phase`. All entities in the same phase run **concurrently** via `asyncio.gather`.
+2. Phase N+1 starts only after all phase N entities complete.
+3. For each entity, `run()` dispatches to `fetch_{name}()` (e.g. `EntityDef(name="databases")` calls `fetch_databases()`).
+4. After all entities complete, results are uploaded to Atlan.
+5. Any result key matching an `ExtractionOutput` field (e.g. `databases_extracted`) is populated automatically.
+
+If `entities` is not set (empty list), the extractor falls back to the default 4 entities: databases, schemas, tables, columns.
 
 ### Available task methods
 
@@ -434,41 +396,58 @@ Each `@task` method becomes a Temporal activity. The `run()` method orchestrates
 | `fetch_schemas` | `FetchSchemasInput` | `FetchSchemasOutput` | Required --- raises `NotImplementedError` |
 | `fetch_tables` | `FetchTablesInput` | `FetchTablesOutput` | Required --- raises `NotImplementedError` |
 | `fetch_columns` | `FetchColumnsInput` | `FetchColumnsOutput` | Required --- raises `NotImplementedError` |
-| `fetch_views` | `FetchViewsInput` | `FetchViewsOutput` | Optional --- add for databases with views |
-| `transform` | `TransformInput` | `TransformOutput` | Override to map raw results via asset mapper |
+| `fetch_procedures` | `FetchProceduresInput` | `FetchProceduresOutput` | Optional --- add `EntityDef(name="procedures")` |
+| `fetch_views` | `FetchViewsInput` | `FetchViewsOutput` | Optional --- add `EntityDef(name="views")` |
+| `transform_data` | `TransformInput` | `TransformOutput` | Override to map raw results via asset mapper |
 
-### Adding custom tasks
+### Adding custom entities
 
-Use `@task` to define additional extraction steps and override `run()` to include them:
+Add new entity types by extending the `entities` list and implementing the matching `fetch_{name}()` method. No need to override `run()`.
 
 ```python
-from application_sdk.templates.contracts.sql_metadata import (
-    FetchViewsInput,
-    FetchViewsOutput,
-)
+from application_sdk.templates.entity import EntityDef
+from application_sdk.templates.contracts.sql_metadata import FetchViewsOutput
 
-class PostgresApp(SqlMetadataExtractor):
+
+class SnowflakeApp(SqlMetadataExtractor):
+    entities = [
+        # Phase 1: core entities (run in parallel)
+        EntityDef(name="databases", phase=1),
+        EntityDef(name="schemas",   phase=1),
+        EntityDef(name="tables",    phase=1),
+        EntityDef(name="columns",   phase=1),
+        # Phase 2: connector-specific entities (run after phase 1)
+        EntityDef(name="stages",  phase=2),
+        EntityDef(name="streams", phase=2),
+        # Disabled entity (skipped at runtime)
+        EntityDef(name="views", phase=1, enabled=False),
+    ]
+
     @task(timeout_seconds=1800)
-    async def fetch_views(self, input: MyFetchInput) -> FetchViewsOutput:
-        """Fetch views from PostgreSQL."""
+    async def fetch_stages(self, input) -> FetchDatabasesOutput:
+        """Fetch Snowflake stages."""
         # ... implementation
-        return FetchViewsOutput(chunk_count=1, total_record_count=len(views))
+        return FetchDatabasesOutput(total_record_count=len(stages))
 
-    async def run(self, input: ExtractionInput) -> ExtractionOutput:
-        """Override run() to include views in the extraction."""
-        result = await super().run(input)
-
-        views_result = await self.fetch_views(
-            MyFetchInput.from_extraction(input)
-        )
-        result.views_extracted = views_result.total_record_count
-
-        # Transform all results (including views) via asset mappers
-        await self.transform(TransformInput(
-            workflow_id=input.workflow_id, connection=input.connection,
-        ))
-        return result
+    @task(timeout_seconds=1800)
+    async def fetch_streams(self, input) -> FetchDatabasesOutput:
+        """Fetch Snowflake streams."""
+        # ... implementation
+        return FetchDatabasesOutput(total_record_count=len(streams))
 ```
+
+### EntityDef fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `str` | (required) | Entity name, used for method dispatch (`fetch_{name}()`) and result key |
+| `sql` | `str` | `""` | SQL query template (for SQL connectors) |
+| `endpoint` | `str` | `""` | REST API endpoint (for API connectors) |
+| `phase` | `int` | `1` | Execution phase --- entities in the same phase run concurrently |
+| `enabled` | `bool` | `True` | Set to `False` to skip this entity |
+| `timeout_seconds` | `int` | `1800` | Task timeout for this entity |
+| `result_key` | `str` | `""` | Key in `ExtractionOutput` for the count (defaults to `{name}_extracted`) |
+| `depends_on` | `tuple[str, ...]` | `()` | Entity names that must complete before this one |
 
 ## Typed Contracts
 

--- a/examples/application_sql.py
+++ b/examples/application_sql.py
@@ -1,7 +1,7 @@
 """SQL metadata extraction example using v3 SqlMetadataExtractor template.
 
 Demonstrates how to build a PostgreSQL metadata extractor by subclassing
-SqlMetadataExtractor with declarative EntityDef-driven orchestration.
+SqlMetadataExtractor with declarative ExtractableEntity-driven orchestration.
 
 Key components:
 - PostgresExtractor: Single class with entity definitions and @task methods
@@ -10,9 +10,9 @@ Key components:
 
 Entity-driven orchestration:
 - Declare entities via the ``entities`` class variable
+- Each entity's ``task_name`` maps directly to a method on the class
 - Entities in the same phase run concurrently
 - Phase N+1 starts only after phase N completes
-- For each entity, run() dispatches to fetch_{name}()
 
 Usage:
     python examples/application_sql.py
@@ -49,7 +49,7 @@ from application_sdk.templates.contracts.sql_metadata import (
     FetchTablesInput,
     FetchTablesOutput,
 )
-from application_sdk.templates.entity import EntityDef
+from application_sdk.templates.entity import ExtractableEntity
 
 logger = get_logger(__name__)
 
@@ -66,16 +66,16 @@ class SQLClient(BaseSQLClient):
 class PostgresExtractor(SqlMetadataExtractor):
     """PostgreSQL metadata extractor.
 
-    Declares entities and implements fetch tasks with Postgres-specific SQL.
-    The orchestration (run method) is inherited from SqlMetadataExtractor
-    and dispatches to fetch_{name}() for each entity, grouped by phase.
+    Declares entities with explicit task_name mapping and implements
+    the corresponding @task methods with Postgres-specific SQL.
+    The orchestration (run method) is inherited from SqlMetadataExtractor.
     """
 
     entities = [
-        EntityDef(name="databases", phase=1),
-        EntityDef(name="schemas", phase=1),
-        EntityDef(name="tables", phase=1),
-        EntityDef(name="columns", phase=1),
+        ExtractableEntity(task_name="fetch_databases", phase=1),
+        ExtractableEntity(task_name="fetch_schemas", phase=1),
+        ExtractableEntity(task_name="fetch_tables", phase=1),
+        ExtractableEntity(task_name="fetch_columns", phase=1),
     ]
 
     @task(timeout_seconds=1800)

--- a/examples/application_sql.py
+++ b/examples/application_sql.py
@@ -1,27 +1,25 @@
 """SQL metadata extraction example using v3 SqlMetadataExtractor template.
 
 Demonstrates how to build a PostgreSQL metadata extractor by subclassing
-SqlMetadataExtractor. In v3, the workflow + activities split collapses into
-a single App class. Override only the @task methods you need to customize.
+SqlMetadataExtractor with declarative EntityDef-driven orchestration.
 
 Key components:
-- PostgresExtractor: Single class replacing both workflow and activities
+- PostgresExtractor: Single class with entity definitions and @task methods
 - SampleSQLHandler: Handler for auth, preflight, and metadata endpoints
 - SQLClient: Database connection configuration
 
-Extraction steps (orchestrated by SqlMetadataExtractor.run()):
-1. Fetch databases
-2. Fetch schemas
-3. Fetch tables
-4. Fetch columns
-5. Transform metadata
-6. Upload results to object store
+Entity-driven orchestration:
+- Declare entities via the ``entities`` class variable
+- Entities in the same phase run concurrently
+- Phase N+1 starts only after phase N completes
+- For each entity, run() dispatches to fetch_{name}()
 
 Usage:
     python examples/application_sql.py
 """
 
 import asyncio
+from typing import Any
 
 from application_sdk.app import task
 from application_sdk.clients.models import DatabaseConfig
@@ -51,6 +49,7 @@ from application_sdk.templates.contracts.sql_metadata import (
     FetchTablesInput,
     FetchTablesOutput,
 )
+from application_sdk.templates.entity import EntityDef
 
 logger = get_logger(__name__)
 
@@ -67,61 +66,93 @@ class SQLClient(BaseSQLClient):
 class PostgresExtractor(SqlMetadataExtractor):
     """PostgreSQL metadata extractor.
 
-    Overrides fetch tasks with Postgres-specific SQL queries.
-    The orchestration (run method) is inherited from SqlMetadataExtractor.
+    Declares entities and implements fetch tasks with Postgres-specific SQL.
+    The orchestration (run method) is inherited from SqlMetadataExtractor
+    and dispatches to fetch_{name}() for each entity, grouped by phase.
     """
 
-    fetch_database_sql = """
-    SELECT datname as database_name FROM pg_database WHERE datname = current_database();
-    """
-
-    fetch_schema_sql = """
-    SELECT s.*
-    FROM information_schema.schemata s
-    WHERE s.schema_name NOT LIKE 'pg_%'
-      AND s.schema_name != 'information_schema'
-      AND concat(s.CATALOG_NAME, concat('.', s.SCHEMA_NAME)) !~ '{normalized_exclude_regex}'
-      AND concat(s.CATALOG_NAME, concat('.', s.SCHEMA_NAME)) ~ '{normalized_include_regex}';
-    """
-
-    fetch_table_sql = """
-    SELECT t.*
-    FROM information_schema.tables t
-    WHERE concat(current_database(), concat('.', t.table_schema)) !~ '{normalized_exclude_regex}'
-      AND concat(current_database(), concat('.', t.table_schema)) ~ '{normalized_include_regex}'
-      {temp_table_regex_sql};
-    """
-
-    extract_temp_table_regex_table_sql = "AND t.table_name !~ '{exclude_table_regex}'"
-    extract_temp_table_regex_column_sql = "AND c.table_name !~ '{exclude_table_regex}'"
-
-    fetch_column_sql = """
-    SELECT c.*
-    FROM information_schema.columns c
-    WHERE concat(current_database(), concat('.', c.table_schema)) !~ '{normalized_exclude_regex}'
-      AND concat(current_database(), concat('.', c.table_schema)) ~ '{normalized_include_regex}'
-      {temp_table_regex_sql};
-    """
+    entities = [
+        EntityDef(name="databases", phase=1),
+        EntityDef(name="schemas", phase=1),
+        EntityDef(name="tables", phase=1),
+        EntityDef(name="columns", phase=1),
+    ]
 
     @task(timeout_seconds=1800)
     async def fetch_databases(self, input: FetchDatabasesInput) -> FetchDatabasesOutput:
         """Fetch PostgreSQL databases."""
-        return await super().fetch_databases(input)
+        client = SQLClient(credentials={"host": "localhost", "port": 5432})
+        await client.load(credentials=client.credentials)
+        rows: list[dict[str, Any]] = []
+        async for batch in client.run_query(
+            "SELECT datname AS database_name "
+            "FROM pg_database WHERE datname = current_database()"
+        ):
+            rows.extend(batch)
+        databases = [r["database_name"] for r in rows]
+        return FetchDatabasesOutput(
+            databases=databases,
+            chunk_count=1,
+            total_record_count=len(databases),
+        )
 
     @task(timeout_seconds=1800)
     async def fetch_schemas(self, input: FetchSchemasInput) -> FetchSchemasOutput:
         """Fetch PostgreSQL schemas."""
-        return await super().fetch_schemas(input)
+        client = SQLClient(credentials={"host": "localhost", "port": 5432})
+        await client.load(credentials=client.credentials)
+        rows: list[dict[str, Any]] = []
+        async for batch in client.run_query(
+            "SELECT s.schema_name "
+            "FROM information_schema.schemata s "
+            "WHERE s.schema_name NOT LIKE 'pg_%' "
+            "AND s.schema_name != 'information_schema'"
+        ):
+            rows.extend(batch)
+        schemas = [r["schema_name"] for r in rows]
+        return FetchSchemasOutput(
+            schemas=schemas,
+            chunk_count=1,
+            total_record_count=len(schemas),
+        )
 
     @task(timeout_seconds=1800)
     async def fetch_tables(self, input: FetchTablesInput) -> FetchTablesOutput:
         """Fetch PostgreSQL tables."""
-        return await super().fetch_tables(input)
+        client = SQLClient(credentials={"host": "localhost", "port": 5432})
+        await client.load(credentials=client.credentials)
+        rows: list[dict[str, Any]] = []
+        async for batch in client.run_query(
+            "SELECT t.table_schema, t.table_name "
+            "FROM information_schema.tables t "
+            "WHERE t.table_schema NOT LIKE 'pg_%' "
+            "AND t.table_schema != 'information_schema'"
+        ):
+            rows.extend(batch)
+        tables = [f"{r['table_schema']}.{r['table_name']}" for r in rows]
+        return FetchTablesOutput(
+            tables=tables,
+            chunk_count=1,
+            total_record_count=len(tables),
+        )
 
     @task(timeout_seconds=1800)
     async def fetch_columns(self, input: FetchColumnsInput) -> FetchColumnsOutput:
         """Fetch PostgreSQL columns."""
-        return await super().fetch_columns(input)
+        client = SQLClient(credentials={"host": "localhost", "port": 5432})
+        await client.load(credentials=client.credentials)
+        rows: list[dict[str, Any]] = []
+        async for batch in client.run_query(
+            "SELECT c.table_schema, c.table_name, c.column_name, c.data_type "
+            "FROM information_schema.columns c "
+            "WHERE c.table_schema NOT LIKE 'pg_%' "
+            "AND c.table_schema != 'information_schema'"
+        ):
+            rows.extend(batch)
+        return FetchColumnsOutput(
+            chunk_count=1,
+            total_record_count=len(rows),
+        )
 
 
 class SampleSQLHandler(Handler):

--- a/examples/application_sql_miner.py
+++ b/examples/application_sql_miner.py
@@ -1,19 +1,20 @@
 """SQL query extraction (mining) example using v3 SqlQueryExtractor template.
 
 Demonstrates how to build a Snowflake query miner by subclassing
-SqlQueryExtractor. In v3, the workflow + activities split collapses into
-a single App class with typed contracts.
+SqlQueryExtractor with declarative EntityDef-driven orchestration.
 
-Extraction steps (orchestrated by SqlQueryExtractor.run()):
-1. Determine query batches (get_query_batches)
-2. Fetch queries for each batch (fetch_queries)
-3. Aggregate and upload results
+Entity-driven orchestration:
+- Declare entities via the ``entities`` class variable
+- The "queries" entity handles batching internally
+  (get_query_batches → fetch_queries per batch)
+- Custom entities dispatch to fetch_{name}() by convention
 
 Usage:
     python examples/application_sql_miner.py
 """
 
 import asyncio
+from typing import Any
 
 from application_sdk.app import task
 from application_sdk.clients.models import DatabaseConfig
@@ -39,6 +40,7 @@ from application_sdk.templates.contracts.sql_query import (
     QueryFetchInput,
     QueryFetchOutput,
 )
+from application_sdk.templates.entity import EntityDef
 
 logger = get_logger(__name__)
 
@@ -121,21 +123,50 @@ class SQLClient(BaseSQLClient):
 class SnowflakeQueryExtractor(SqlQueryExtractor):
     """Snowflake query miner.
 
-    Overrides get_query_batches and fetch_queries to implement
-    Snowflake-specific query history extraction.
+    Declares a single "queries" entity. The base run() orchestrates
+    the batch loop: get_query_batches → fetch_queries per batch.
     """
 
-    fetch_queries_sql = FETCH_QUERIES_SQL
+    entities = [
+        EntityDef(name="queries", phase=1),
+    ]
 
     @task(timeout_seconds=600)
     async def get_query_batches(self, input: QueryBatchInput) -> QueryBatchOutput:
         """Determine batch count from Snowflake query history."""
-        return await super().get_query_batches(input)
+        client = SQLClient(credentials={"account_id": "demo.snowflakecomputing.com"})
+        await client.load(credentials=client.credentials)
+        rows: list[dict[str, Any]] = []
+        async for batch in client.run_query(
+            "SELECT COUNT(*) AS total FROM QUERY_HISTORY "
+            "WHERE START_TIME >= CURRENT_DATE - INTERVAL '2 WEEK'"
+        ):
+            rows.extend(batch)
+        total_count = rows[0]["total"] if rows else 0
+        batch_size = input.workflow_args.get("batch_size", 5000)
+        total_batches = max(1, (total_count + batch_size - 1) // batch_size)
+        return QueryBatchOutput(
+            total_batches=total_batches,
+            batch_size=batch_size,
+            total_count=total_count,
+        )
 
     @task(timeout_seconds=3600, heartbeat_timeout_seconds=60, auto_heartbeat_seconds=10)
     async def fetch_queries(self, input: QueryFetchInput) -> QueryFetchOutput:
         """Fetch one batch of queries from Snowflake."""
-        return await super().fetch_queries(input)
+        client = SQLClient(credentials={"account_id": "demo.snowflakecomputing.com"})
+        await client.load(credentials=client.credentials)
+        rows: list[dict[str, Any]] = []
+        offset = input.batch_number * input.batch_size
+        async for batch in client.run_query(
+            f"{FETCH_QUERIES_SQL} LIMIT {input.batch_size} OFFSET {offset}"
+        ):
+            rows.extend(batch)
+        return QueryFetchOutput(
+            batch_number=input.batch_number,
+            queries_fetched=len(rows),
+            chunk_count=1,
+        )
 
 
 class SampleSnowflakeHandler(Handler):

--- a/examples/application_sql_miner.py
+++ b/examples/application_sql_miner.py
@@ -1,13 +1,13 @@
 """SQL query extraction (mining) example using v3 SqlQueryExtractor template.
 
 Demonstrates how to build a Snowflake query miner by subclassing
-SqlQueryExtractor with declarative EntityDef-driven orchestration.
+SqlQueryExtractor with declarative ExtractableEntity-driven orchestration.
 
 Entity-driven orchestration:
 - Declare entities via the ``entities`` class variable
-- The "queries" entity handles batching internally
+- Each entity's ``task_name`` maps directly to a method on the class
+- The default queries entity handles batching internally
   (get_query_batches → fetch_queries per batch)
-- Custom entities dispatch to fetch_{name}() by convention
 
 Usage:
     python examples/application_sql_miner.py
@@ -40,7 +40,6 @@ from application_sdk.templates.contracts.sql_query import (
     QueryFetchInput,
     QueryFetchOutput,
 )
-from application_sdk.templates.entity import EntityDef
 
 logger = get_logger(__name__)
 
@@ -123,13 +122,11 @@ class SQLClient(BaseSQLClient):
 class SnowflakeQueryExtractor(SqlQueryExtractor):
     """Snowflake query miner.
 
-    Declares a single "queries" entity. The base run() orchestrates
-    the batch loop: get_query_batches → fetch_queries per batch.
+    Uses the default entity (``_fetch_queries_batched``) which
+    orchestrates the batch loop: get_query_batches → fetch_queries
+    per batch.  No need to declare entities explicitly when using
+    the default single-entity query extraction.
     """
-
-    entities = [
-        EntityDef(name="queries", phase=1),
-    ]
 
     @task(timeout_seconds=600)
     async def get_query_batches(self, input: QueryBatchInput) -> QueryBatchOutput:

--- a/tests/unit/templates/test_entity_registry.py
+++ b/tests/unit/templates/test_entity_registry.py
@@ -1,4 +1,4 @@
-"""Tests for EntityDef and entity-driven orchestration in SqlMetadataExtractor."""
+"""Tests for ExtractableEntity and entity-driven orchestration in SqlMetadataExtractor."""
 
 import pytest
 
@@ -6,69 +6,77 @@ from application_sdk.templates.contracts.sql_metadata import (
     ExtractionInput,
     FetchDatabasesOutput,
 )
-from application_sdk.templates.entity import EntityDef
+from application_sdk.templates.entity import ExtractableEntity, default_result_key
 from application_sdk.templates.sql_metadata_extractor import SqlMetadataExtractor
 
 # ---------------------------------------------------------------------------
-# EntityDef tests
+# ExtractableEntity tests
 # ---------------------------------------------------------------------------
 
 
-class TestEntityDef:
+class TestExtractableEntity:
     def test_defaults(self):
-        e = EntityDef(name="databases")
+        e = ExtractableEntity(task_name="fetch_databases")
         assert e.phase == 1
         assert e.enabled is True
         assert e.timeout_seconds == 1800
-        assert e.sql == ""
-        assert e.endpoint == ""
         assert e.result_key == ""
         assert e.depends_on == ()
 
     def test_frozen(self):
-        e = EntityDef(name="databases")
+        e = ExtractableEntity(task_name="fetch_databases")
         with pytest.raises(AttributeError):
-            e.name = "schemas"  # type: ignore[misc]
+            e.task_name = "fetch_schemas"  # type: ignore[misc]
 
     def test_custom_fields(self):
-        e = EntityDef(
-            name="stages",
-            sql="SELECT * FROM STAGES",
+        e = ExtractableEntity(
+            task_name="fetch_stages",
             phase=2,
             timeout_seconds=3600,
             result_key="stages_count",
         )
-        assert e.name == "stages"
-        assert e.sql == "SELECT * FROM STAGES"
+        assert e.task_name == "fetch_stages"
         assert e.phase == 2
         assert e.timeout_seconds == 3600
         assert e.result_key == "stages_count"
 
     def test_disabled_entity(self):
-        e = EntityDef(name="ai_models", enabled=False)
+        e = ExtractableEntity(task_name="fetch_ai_models", enabled=False)
         assert e.enabled is False
 
-    def test_api_entity(self):
-        e = EntityDef(
-            name="workbooks",
-            endpoint="/api/3.1/workbooks",
-            pagination="offset",
-            response_items_key="workbooks.workbook",
-        )
-        assert e.endpoint == "/api/3.1/workbooks"
-        assert e.pagination == "offset"
-        assert e.response_items_key == "workbooks.workbook"
-
     def test_result_key_default_derivation(self):
-        """Empty result_key should default to '{name}_extracted' at runtime."""
-        e = EntityDef(name="stages")
-        expected = f"{e.name}_extracted"
-        actual = e.result_key or f"{e.name}_extracted"
+        """Empty result_key should default to '{base}_extracted' at runtime."""
+        e = ExtractableEntity(task_name="fetch_stages")
+        expected = "stages_extracted"
+        actual = e.result_key or default_result_key(e.task_name)
         assert actual == expected
 
     def test_depends_on(self):
-        e = EntityDef(name="dynamic_tables", phase=2, depends_on=("tables",))
-        assert e.depends_on == ("tables",)
+        e = ExtractableEntity(
+            task_name="fetch_dynamic_tables",
+            phase=2,
+            depends_on=("fetch_tables",),
+        )
+        assert e.depends_on == ("fetch_tables",)
+
+
+# ---------------------------------------------------------------------------
+# default_result_key tests
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultResultKey:
+    def test_strips_fetch_prefix(self):
+        assert default_result_key("fetch_databases") == "databases_extracted"
+
+    def test_no_prefix(self):
+        assert default_result_key("stages") == "stages_extracted"
+
+    def test_private_method(self):
+        assert (
+            default_result_key("_fetch_queries_batched")
+            == "_fetch_queries_batched_extracted"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -82,38 +90,43 @@ class TestGetEntities:
         assert ext.entities == []
         entities = ext._get_entities()
         assert len(entities) == 4
-        names = [e.name for e in entities]
-        assert names == ["databases", "schemas", "tables", "columns"]
+        task_names = [e.task_name for e in entities]
+        assert task_names == [
+            "fetch_databases",
+            "fetch_schemas",
+            "fetch_tables",
+            "fetch_columns",
+        ]
 
     def test_custom_entities_used(self):
         class Custom(SqlMetadataExtractor):
             entities = [
-                EntityDef(name="databases", phase=1),
-                EntityDef(name="stages", phase=2),
+                ExtractableEntity(task_name="fetch_databases", phase=1),
+                ExtractableEntity(task_name="fetch_stages", phase=2),
             ]
 
         ext = Custom()
         entities = ext._get_entities()
         assert len(entities) == 2
-        assert entities[1].name == "stages"
+        assert entities[1].task_name == "fetch_stages"
 
     def test_disabled_entity_filtered(self):
         class WithDisabled(SqlMetadataExtractor):
             entities = [
-                EntityDef(name="databases", phase=1),
-                EntityDef(name="schemas", phase=1, enabled=False),
-                EntityDef(name="tables", phase=1),
+                ExtractableEntity(task_name="fetch_databases", phase=1),
+                ExtractableEntity(task_name="fetch_schemas", phase=1, enabled=False),
+                ExtractableEntity(task_name="fetch_tables", phase=1),
             ]
 
         ext = WithDisabled()
         entities = ext._get_entities()
         assert len(entities) == 2
-        assert all(e.name != "schemas" for e in entities)
+        assert all(e.task_name != "fetch_schemas" for e in entities)
 
     def test_all_disabled_returns_empty(self):
         class AllDisabled(SqlMetadataExtractor):
             entities = [
-                EntityDef(name="databases", enabled=False),
+                ExtractableEntity(task_name="fetch_databases", enabled=False),
             ]
 
         ext = AllDisabled()
@@ -145,7 +158,7 @@ class TestFetchEntity:
                 return FetchDatabasesOutput(total_record_count=42)
 
         ext = Ext()
-        entity = EntityDef(name="databases")
+        entity = ExtractableEntity(task_name="fetch_databases")
         result_key, count = await ext._fetch_entity(entity, _make_input())
         assert result_key == "databases_extracted"
         assert count == 42
@@ -157,7 +170,7 @@ class TestFetchEntity:
                 return FetchDatabasesOutput(total_record_count=7)
 
         ext = Ext()
-        entity = EntityDef(name="databases", result_key="db_count")
+        entity = ExtractableEntity(task_name="fetch_databases", result_key="db_count")
         result_key, count = await ext._fetch_entity(entity, _make_input())
         assert result_key == "db_count"
         assert count == 7
@@ -165,20 +178,20 @@ class TestFetchEntity:
     @pytest.mark.asyncio
     async def test_missing_method_raises(self):
         ext = SqlMetadataExtractor()
-        entity = EntityDef(name="nonexistent_thing")
-        with pytest.raises(NotImplementedError, match="no fetch_nonexistent_thing"):
+        entity = ExtractableEntity(task_name="fetch_nonexistent_thing")
+        with pytest.raises(NotImplementedError, match="no 'fetch_nonexistent_thing'"):
             await ext._fetch_entity(entity, _make_input())
 
     @pytest.mark.asyncio
     async def test_extra_entity_with_custom_method(self):
-        """Custom entities dispatch to custom fetch methods."""
+        """Custom entities dispatch to the method named by task_name."""
 
         class Ext(SqlMetadataExtractor):
             async def fetch_stages(self, input):
                 return FetchDatabasesOutput(total_record_count=15)
 
         ext = Ext()
-        entity = EntityDef(name="stages", phase=2)
+        entity = ExtractableEntity(task_name="fetch_stages", phase=2)
         result_key, count = await ext._fetch_entity(entity, _make_input())
         assert result_key == "stages_extracted"
         assert count == 15
@@ -197,7 +210,7 @@ class TestFetchEntity:
 
         ext = Ext()
         ref = CredentialRef(name="my-cred", credential_type="basic")
-        entity = EntityDef(name="databases")
+        entity = ExtractableEntity(task_name="fetch_databases")
         await ext._fetch_entity(entity, _make_input(credential_ref=ref))
         assert captured_input["cred_ref"].name == "my-cred"
 
@@ -210,14 +223,14 @@ class TestFetchEntity:
 class TestPhaseGrouping:
     def test_entities_grouped_by_phase(self):
         entities = [
-            EntityDef(name="databases", phase=1),
-            EntityDef(name="schemas", phase=1),
-            EntityDef(name="stages", phase=2),
-            EntityDef(name="streams", phase=2),
-            EntityDef(name="dynamic_tables", phase=3),
+            ExtractableEntity(task_name="fetch_databases", phase=1),
+            ExtractableEntity(task_name="fetch_schemas", phase=1),
+            ExtractableEntity(task_name="fetch_stages", phase=2),
+            ExtractableEntity(task_name="fetch_streams", phase=2),
+            ExtractableEntity(task_name="fetch_dynamic_tables", phase=3),
         ]
 
-        phases: dict[int, list[EntityDef]] = {}
+        phases: dict[int, list[ExtractableEntity]] = {}
         for e in entities:
             phases.setdefault(e.phase, []).append(e)
 
@@ -225,4 +238,66 @@ class TestPhaseGrouping:
         assert len(phases[1]) == 2
         assert len(phases[2]) == 2
         assert len(phases[3]) == 1
-        assert phases[3][0].name == "dynamic_tables"
+        assert phases[3][0].task_name == "fetch_dynamic_tables"
+
+
+# ---------------------------------------------------------------------------
+# run_entity_phases tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunEntityPhases:
+    @pytest.mark.asyncio
+    async def test_collects_results_across_phases(self):
+        class Ext(SqlMetadataExtractor):
+            async def fetch_databases(self, input):
+                return FetchDatabasesOutput(total_record_count=10)
+
+            async def fetch_schemas(self, input):
+                return FetchDatabasesOutput(total_record_count=20)
+
+            async def fetch_stages(self, input):
+                return FetchDatabasesOutput(total_record_count=5)
+
+        ext = Ext()
+        ext.__class__.entities = [
+            ExtractableEntity(task_name="fetch_databases", phase=1),
+            ExtractableEntity(task_name="fetch_schemas", phase=1),
+            ExtractableEntity(task_name="fetch_stages", phase=2),
+        ]
+
+        from application_sdk.templates.entity import run_entity_phases
+
+        results = await run_entity_phases(ext, ext._get_entities(), _make_input())
+        assert results["databases_extracted"] == 10
+        assert results["schemas_extracted"] == 20
+        assert results["stages_extracted"] == 5
+
+    @pytest.mark.asyncio
+    async def test_error_in_phase_still_completes_siblings(self):
+        """If one entity fails, siblings in the same phase still run."""
+        call_log = []
+
+        class Ext(SqlMetadataExtractor):
+            async def fetch_databases(self, input):
+                call_log.append("databases")
+                raise ValueError("db error")
+
+            async def fetch_schemas(self, input):
+                call_log.append("schemas")
+                return FetchDatabasesOutput(total_record_count=5)
+
+        ext = Ext()
+        ext.__class__.entities = [
+            ExtractableEntity(task_name="fetch_databases", phase=1),
+            ExtractableEntity(task_name="fetch_schemas", phase=1),
+        ]
+
+        from application_sdk.templates.entity import run_entity_phases
+
+        with pytest.raises(ValueError, match="db error"):
+            await run_entity_phases(ext, ext._get_entities(), _make_input())
+
+        # Both methods should have been called (return_exceptions=True)
+        assert "databases" in call_log
+        assert "schemas" in call_log

--- a/tests/unit/templates/test_entity_registry.py
+++ b/tests/unit/templates/test_entity_registry.py
@@ -1,0 +1,228 @@
+"""Tests for EntityDef and entity-driven orchestration in SqlMetadataExtractor."""
+
+import pytest
+
+from application_sdk.templates.contracts.sql_metadata import (
+    ExtractionInput,
+    FetchDatabasesOutput,
+)
+from application_sdk.templates.entity import EntityDef
+from application_sdk.templates.sql_metadata_extractor import SqlMetadataExtractor
+
+# ---------------------------------------------------------------------------
+# EntityDef tests
+# ---------------------------------------------------------------------------
+
+
+class TestEntityDef:
+    def test_defaults(self):
+        e = EntityDef(name="databases")
+        assert e.phase == 1
+        assert e.enabled is True
+        assert e.timeout_seconds == 1800
+        assert e.sql == ""
+        assert e.endpoint == ""
+        assert e.result_key == ""
+        assert e.depends_on == ()
+
+    def test_frozen(self):
+        e = EntityDef(name="databases")
+        with pytest.raises(AttributeError):
+            e.name = "schemas"  # type: ignore[misc]
+
+    def test_custom_fields(self):
+        e = EntityDef(
+            name="stages",
+            sql="SELECT * FROM STAGES",
+            phase=2,
+            timeout_seconds=3600,
+            result_key="stages_count",
+        )
+        assert e.name == "stages"
+        assert e.sql == "SELECT * FROM STAGES"
+        assert e.phase == 2
+        assert e.timeout_seconds == 3600
+        assert e.result_key == "stages_count"
+
+    def test_disabled_entity(self):
+        e = EntityDef(name="ai_models", enabled=False)
+        assert e.enabled is False
+
+    def test_api_entity(self):
+        e = EntityDef(
+            name="workbooks",
+            endpoint="/api/3.1/workbooks",
+            pagination="offset",
+            response_items_key="workbooks.workbook",
+        )
+        assert e.endpoint == "/api/3.1/workbooks"
+        assert e.pagination == "offset"
+        assert e.response_items_key == "workbooks.workbook"
+
+    def test_result_key_default_derivation(self):
+        """Empty result_key should default to '{name}_extracted' at runtime."""
+        e = EntityDef(name="stages")
+        expected = f"{e.name}_extracted"
+        actual = e.result_key or f"{e.name}_extracted"
+        assert actual == expected
+
+    def test_depends_on(self):
+        e = EntityDef(name="dynamic_tables", phase=2, depends_on=("tables",))
+        assert e.depends_on == ("tables",)
+
+
+# ---------------------------------------------------------------------------
+# _get_entities tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetEntities:
+    def test_empty_entities_falls_back_to_defaults(self):
+        ext = SqlMetadataExtractor()
+        assert ext.entities == []
+        entities = ext._get_entities()
+        assert len(entities) == 4
+        names = [e.name for e in entities]
+        assert names == ["databases", "schemas", "tables", "columns"]
+
+    def test_custom_entities_used(self):
+        class Custom(SqlMetadataExtractor):
+            entities = [
+                EntityDef(name="databases", phase=1),
+                EntityDef(name="stages", phase=2),
+            ]
+
+        ext = Custom()
+        entities = ext._get_entities()
+        assert len(entities) == 2
+        assert entities[1].name == "stages"
+
+    def test_disabled_entity_filtered(self):
+        class WithDisabled(SqlMetadataExtractor):
+            entities = [
+                EntityDef(name="databases", phase=1),
+                EntityDef(name="schemas", phase=1, enabled=False),
+                EntityDef(name="tables", phase=1),
+            ]
+
+        ext = WithDisabled()
+        entities = ext._get_entities()
+        assert len(entities) == 2
+        assert all(e.name != "schemas" for e in entities)
+
+    def test_all_disabled_returns_empty(self):
+        class AllDisabled(SqlMetadataExtractor):
+            entities = [
+                EntityDef(name="databases", enabled=False),
+            ]
+
+        ext = AllDisabled()
+        assert ext._get_entities() == []
+
+
+# ---------------------------------------------------------------------------
+# _fetch_entity tests
+# ---------------------------------------------------------------------------
+
+
+def _make_input(**overrides):
+    defaults = {
+        "workflow_id": "test-wf",
+        "connection": {
+            "connection_name": "test",
+            "connection_qualified_name": "default/pg/123",
+        },
+    }
+    defaults.update(overrides)
+    return ExtractionInput(**defaults)
+
+
+class TestFetchEntity:
+    @pytest.mark.asyncio
+    async def test_dispatches_to_named_method(self):
+        class Ext(SqlMetadataExtractor):
+            async def fetch_databases(self, input):
+                return FetchDatabasesOutput(total_record_count=42)
+
+        ext = Ext()
+        entity = EntityDef(name="databases")
+        result_key, count = await ext._fetch_entity(entity, _make_input())
+        assert result_key == "databases_extracted"
+        assert count == 42
+
+    @pytest.mark.asyncio
+    async def test_custom_result_key(self):
+        class Ext(SqlMetadataExtractor):
+            async def fetch_databases(self, input):
+                return FetchDatabasesOutput(total_record_count=7)
+
+        ext = Ext()
+        entity = EntityDef(name="databases", result_key="db_count")
+        result_key, count = await ext._fetch_entity(entity, _make_input())
+        assert result_key == "db_count"
+        assert count == 7
+
+    @pytest.mark.asyncio
+    async def test_missing_method_raises(self):
+        ext = SqlMetadataExtractor()
+        entity = EntityDef(name="nonexistent_thing")
+        with pytest.raises(NotImplementedError, match="no fetch_nonexistent_thing"):
+            await ext._fetch_entity(entity, _make_input())
+
+    @pytest.mark.asyncio
+    async def test_extra_entity_with_custom_method(self):
+        """Custom entities dispatch to custom fetch methods."""
+
+        class Ext(SqlMetadataExtractor):
+            async def fetch_stages(self, input):
+                return FetchDatabasesOutput(total_record_count=15)
+
+        ext = Ext()
+        entity = EntityDef(name="stages", phase=2)
+        result_key, count = await ext._fetch_entity(entity, _make_input())
+        assert result_key == "stages_extracted"
+        assert count == 15
+
+    @pytest.mark.asyncio
+    async def test_credential_ref_passed_to_task_input(self):
+        """Verify credential_ref from ExtractionInput is forwarded."""
+        from application_sdk.credentials.ref import CredentialRef
+
+        captured_input = {}
+
+        class Ext(SqlMetadataExtractor):
+            async def fetch_databases(self, input):
+                captured_input["cred_ref"] = input.credential_ref
+                return FetchDatabasesOutput(total_record_count=1)
+
+        ext = Ext()
+        ref = CredentialRef(name="my-cred", credential_type="basic")
+        entity = EntityDef(name="databases")
+        await ext._fetch_entity(entity, _make_input(credential_ref=ref))
+        assert captured_input["cred_ref"].name == "my-cred"
+
+
+# ---------------------------------------------------------------------------
+# Phase grouping (unit test without Temporal)
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseGrouping:
+    def test_entities_grouped_by_phase(self):
+        entities = [
+            EntityDef(name="databases", phase=1),
+            EntityDef(name="schemas", phase=1),
+            EntityDef(name="stages", phase=2),
+            EntityDef(name="streams", phase=2),
+            EntityDef(name="dynamic_tables", phase=3),
+        ]
+
+        phases: dict[int, list[EntityDef]] = {}
+        for e in entities:
+            phases.setdefault(e.phase, []).append(e)
+
+        assert sorted(phases.keys()) == [1, 2, 3]
+        assert len(phases[1]) == 2
+        assert len(phases[2]) == 2
+        assert len(phases[3]) == 1
+        assert phases[3][0].name == "dynamic_tables"


### PR DESCRIPTION
## Summary
- Introduces `EntityDef` frozen dataclass for declarative entity definitions (name, sql, endpoint, phase, enabled, timeout, result_key, depends_on)
- Replaces hardcoded `asyncio.gather` of 4 entities in `SqlMetadataExtractor.run()` with phased orchestration — entities grouped by phase run concurrently within phase, sequentially across phases
- `_fetch_entity()` dispatches to `fetch_{name}()` methods by convention; `_get_entities()` falls back to default 4 (databases, schemas, tables, columns) when `entities` is empty
- Preserves v3-specific features: `BaseMetadataExtractor` base class, `upload_to_atlan` step, `rewrap` error handling
- Port of #1297 adapted for refactor-v3

## Test plan
- [x] 17 new unit tests in `test_entity_registry.py` covering EntityDef, `_get_entities`, `_fetch_entity`, and phase grouping
- [x] All 37 existing `test_sql_metadata_extractor.py` tests pass
- [x] Pre-commit (ruff, ruff-format, isort, pyright) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)