### PR TITLE
fix: pass secret_store directly to handler — ContextVar not propagated through uvicorn

### DIFF
--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -56,7 +56,6 @@ from application_sdk.handler.contracts import (
     SubscriptionConfig,
 )
 from application_sdk.handler.manifest import AppManifest
-from application_sdk.infrastructure.context import get_infrastructure
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -146,6 +145,7 @@ if TYPE_CHECKING:
     from temporalio.converter import DataConverter
 
     from application_sdk.app.base import App
+    from application_sdk.infrastructure.secrets import SecretStore
     from application_sdk.infrastructure.state import StateStore
 
 
@@ -240,6 +240,7 @@ _temporal_client: Client | None = None
 _workflow_config: WorkflowClientConfig = WorkflowClientConfig()
 _handler_auth_manager: Any | None = None
 _state_store: StateStore | None = None
+_secret_store: SecretStore | None = None
 _storage: ObjectStore | None = None
 
 # Directory where generated contract JSON files are stored
@@ -324,6 +325,7 @@ def create_app_handler_service(
     auth_base_url: str = "",
     auth_scopes: str = "",
     state_store: StateStore | None = None,
+    secret_store: "SecretStore | None" = None,
     storage: ObjectStore | None = None,
     event_triggers: list[EventTriggerConfig] | None = None,
     subscriptions: list[SubscriptionConfig] | None = None,
@@ -344,6 +346,11 @@ def create_app_handler_service(
         task_queue: Task queue name (default: "{app_name}-queue").
         data_converter: Optional custom Temporal DataConverter.
         state_store: Optional state store for workflow config persistence.
+        secret_store: Optional secret store for credential interception.
+            When provided, the ``/start`` handler stores inline credentials
+            here and replaces them with a ``credential_guid`` so secrets
+            never travel over Temporal.  Passed directly to avoid ContextVar
+            propagation issues with uvicorn ASGI request handlers.
         storage: Optional obstore store for file uploads.
         title: OpenAPI title.
         description: OpenAPI description.
@@ -355,9 +362,10 @@ def create_app_handler_service(
     Returns:
         Configured FastAPI application.
     """
-    global _workflow_config, _state_store, _storage
+    global _workflow_config, _state_store, _secret_store, _storage
 
     _state_store = state_store
+    _secret_store = secret_store
     _storage = storage
     _workflow_config = WorkflowClientConfig(
         host=temporal_host,
@@ -410,16 +418,13 @@ def create_app_handler_service(
     app.add_middleware(LogMiddleware)
 
     def _create_context(credentials: list[Credential]) -> HandlerContext:
-        from application_sdk.infrastructure.context import get_infrastructure
-
-        infra = get_infrastructure()
         return HandlerContext(
             app_name=app_name,
             request_id=uuid4(),
             started_at=datetime.now(UTC),
             _credentials=credentials,
-            _secret_store=infra.secret_store if infra else None,
-            _state_store=infra.state_store if infra else None,
+            _secret_store=_secret_store,
+            _state_store=_state_store,
         )
 
     # ------------------------------------------------------------------
@@ -636,19 +641,17 @@ def create_app_handler_service(
                     detail=f"App class {app_cls.__name__} does not define _input_type.",
                 )
 
-            # Save inline credentials to the v3 secret store and replace
-            # with a credential_guid so raw secrets never travel over Temporal.
-            # Normalize to v3 list format first (same as auth/preflight),
-            # then store. Apps use their Pydantic credential model to
-            # convert back to the shape they need.
-            # Only works with writable stores (InMemorySecretStore in local dev).
+            # Save inline credentials to the secret store and replace with a
+            # credential_guid so raw secrets never travel over Temporal.
+            # Uses the closure-captured _secret_store (passed directly to
+            # create_app_handler_service) instead of get_infrastructure()
+            # because ContextVar does not propagate to uvicorn ASGI request
+            # handlers.
             body = _normalize_credentials(body)
             if "credentials" in body and body["credentials"]:
-                infra = get_infrastructure()
-                secret_store = infra.secret_store if infra else None
-                if secret_store is not None and hasattr(secret_store, "set"):
+                if _secret_store is not None and hasattr(_secret_store, "set"):
                     credential_guid = str(uuid4())
-                    secret_store.set(credential_guid, json.dumps(body["credentials"]))
+                    _secret_store.set(credential_guid, json.dumps(body["credentials"]))
                     body["credential_guid"] = credential_guid
                     del body["credentials"]
                     logger.debug(

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -325,7 +325,7 @@ def create_app_handler_service(
     auth_base_url: str = "",
     auth_scopes: str = "",
     state_store: StateStore | None = None,
-    secret_store: "SecretStore | None" = None,
+    secret_store: SecretStore | None = None,
     storage: ObjectStore | None = None,
     event_triggers: list[EventTriggerConfig] | None = None,
     subscriptions: list[SubscriptionConfig] | None = None,

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -651,7 +651,13 @@ def create_app_handler_service(
             if "credentials" in body and body["credentials"]:
                 if _secret_store is not None and hasattr(_secret_store, "set"):
                     credential_guid = str(uuid4())
-                    _secret_store.set(credential_guid, json.dumps(body["credentials"]))
+                    # Convert v3 list [{key, value}] to flat dict {key: value}
+                    # so get_secret() returns the same format as production
+                    # (Dapr/Vault), where credentials are stored as flat dicts.
+                    flat_creds = {
+                        p["key"]: p["value"] for p in body["credentials"]
+                    }
+                    _secret_store.set(credential_guid, json.dumps(flat_creds))
                     body["credential_guid"] = credential_guid
                     del body["credentials"]
                     logger.debug(

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -761,6 +761,7 @@ def run_handler_mode(config: AppConfig) -> None:
         auth_base_url=config.auth_base_url,
         auth_scopes=config.auth_scopes,
         state_store=infra.state_store,
+        secret_store=infra.secret_store,
         storage=infra.storage,
         frontend_assets_path=config.frontend_assets_path,
     )
@@ -907,6 +908,7 @@ async def run_combined_mode(config: AppConfig) -> None:
         auth_base_url=config.auth_base_url,
         auth_scopes=config.auth_scopes,
         state_store=infra.state_store,
+        secret_store=infra.secret_store,
         storage=infra.storage,
         frontend_assets_path=config.frontend_assets_path,
     )

--- a/tests/integration/test_handler_service.py
+++ b/tests/integration/test_handler_service.py
@@ -42,6 +42,7 @@ def _reset_service_globals():
     svc._temporal_client = None
     svc._workflow_config = svc.WorkflowClientConfig()
     svc._state_store = None
+    svc._secret_store = None
     svc._storage = None
     _infrastructure_ctx.set(None)
 
@@ -50,6 +51,7 @@ def _reset_service_globals():
     svc._temporal_client = None
     svc._workflow_config = svc.WorkflowClientConfig()
     svc._state_store = None
+    svc._secret_store = None
     svc._storage = None
     _infrastructure_ctx.set(None)
 
@@ -343,6 +345,18 @@ class TrivialApp(App):
         return TrivialOutput(greeting=f"Hello, {input.name}!")
 
 
+class CredentialAwareInput(Input):
+    """Input for G6.12: carries credential_guid so we can verify it reaches Temporal."""
+
+    name: str = "world"
+    credential_guid: str = ""
+
+
+class CredentialAwareApp(App):
+    async def run(self, input: CredentialAwareInput) -> TrivialOutput:
+        return TrivialOutput(greeting=f"Hello, {input.name}!")
+
+
 class LongInput(Input):
     pass
 
@@ -512,3 +526,86 @@ async def test_start_saves_config_to_state_store(run_worker, trivial_wf_client):
     # Safety guard: credentials must never be persisted to the state store,
     # even if a migrating connector accidentally passes them in the /start body
     assert "credentials" not in saved
+
+
+@pytest.fixture
+async def credential_wf_client(temporal_client, task_queue, reregister_app):
+    """Handler service configured with CredentialAwareApp and a live InMemorySecretStore."""
+    from application_sdk.handler import service as svc
+    from application_sdk.handler.service import create_app_handler_service
+    from application_sdk.infrastructure.secrets import InMemorySecretStore
+
+    reregister_app(CredentialAwareApp)
+
+    secret_store = InMemorySecretStore()
+    handler = DefaultHandler()
+    app = create_app_handler_service(
+        handler,
+        app_name="cred-aware",
+        app_class=CredentialAwareApp,
+        temporal_host="localhost:7233",
+        task_queue=task_queue,
+        secret_store=secret_store,
+    )
+    svc._temporal_client = temporal_client
+
+    return app, secret_store
+
+
+@pytest.mark.integration
+async def test_start_intercepts_inline_credentials(
+    run_worker, credential_wf_client, temporal_client
+):
+    """G6.12: POST /start with inline credentials intercepts them into the secret store,
+    replaces with a UUID credential_guid, and dispatches to Temporal without raw credentials.
+
+    Verifies:
+    - credentials are stored in the secret store under a freshly generated UUID
+    - stored format is a flat dict {key: value}, matching production Dapr/Vault format
+    - Temporal start event payload carries credential_guid (not raw credentials)
+    """
+    import json
+
+    app, secret_store = credential_wf_client
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        async with run_worker():
+            resp = await client.post(
+                "/workflows/v1/start",
+                json={
+                    "name": "cred-test",
+                    "credentials": [{"key": "password", "value": "s3cr3t"}],
+                },
+            )
+
+    assert resp.status_code == 200
+    wf_id = resp.json()["data"]["workflow_id"]
+    assert wf_id
+
+    # Secret store must have exactly one entry — the intercepted credential
+    stored_names = await secret_store.list_names()
+    assert len(stored_names) == 1
+    credential_guid = stored_names[0]
+
+    # The key must be a valid UUID
+    UUID(credential_guid)
+
+    # Stored value must be flat dict {key: value}, not the v3 list [{key, value}]
+    stored = json.loads(await secret_store.get(credential_guid))
+    assert stored == {"password": "s3cr3t"}
+
+    # Confirm the Temporal workflow start event carries credential_guid and no raw
+    # credentials. CredentialAwareInput declares credential_guid as a named field,
+    # so the UUID propagates through Pydantic into the serialised Temporal payload.
+    handle = temporal_client.get_workflow_handle(wf_id)
+    history = await handle.fetch_history()
+    start_payload_data = b"".join(
+        p.data
+        for p in history.events[
+            0
+        ].workflow_execution_started_event_attributes.input.payloads
+    )
+    assert credential_guid.encode() in start_payload_data
+    assert b'"credentials"' not in start_payload_data


### PR DESCRIPTION
## Summary

- PR #1227 (BLDX-911) added credential interception to `/start` but relied on `get_infrastructure()` (ContextVar) to access the secret store
- **ContextVar values do not propagate to uvicorn ASGI request handlers** — `get_infrastructure()` returns `None`, so credential interception is silently skipped
- Raw credentials (including passwords) bleed into Temporal workflow history — visible in the workflow start event AND every activity input
- Fix: pass `secret_store` directly to `create_app_handler_service()`, matching the existing pattern for `state_store` and `storage`

## Root Cause

```python
# main.py — state_store and storage passed directly, secret_store was MISSING
fastapi_app = create_app_handler_service(
    handler,
    state_store=infra.state_store,   # ✅ direct ref — works in uvicorn
    storage=infra.storage,           # ✅ direct ref — works in uvicorn
    # secret_store NOT passed        # ❌ relied on ContextVar — fails in uvicorn
)
```

Python `ContextVar.set()` in the parent coroutine (`run_combined_mode`) does not propagate to uvicorn's ASGI request tasks. Confirmed via reproduction test:

```python
# Inside uvicorn request handler:
get_infrastructure()  # → None (ContextVar not inherited)
```

## Evidence

Temporal workflow `snowflake-au-metadata-extraction-d3db9f2c2ecb4521-374759c5`:
- `credential_guid: ""` (empty — interception never ran)
- `credentials: [{"key": "password", "value": "..."}]` — plaintext in workflow start + all 18 activity inputs

## Changes

- **`handler/service.py`**: Add `secret_store` parameter to `create_app_handler_service()`. Use closure-captured `_secret_store` in `/start` handler and `_create_context()` instead of `get_infrastructure()`. Remove now-unused `get_infrastructure` import.
- **`main.py`**: Pass `infra.secret_store` in both `run_handler_mode()` and `run_combined_mode()`.

## Test plan

- [x] Reproduction test confirms `get_infrastructure()` returns `None` in uvicorn (root cause validated)
- [x] Integration test: POST `/start` with inline credentials → verify `credential_guid` is UUID and `credentials` absent from Temporal history
- [x] Existing handler unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)