### PR TITLE
WIP: feat(ci): forward workflow_packages from atlan.yaml to marketplace publish

### DIFF
--- a/.github/scripts/parse_atlan_yaml.py
+++ b/.github/scripts/parse_atlan_yaml.py
@@ -45,10 +45,17 @@ _ALLOWED_TYPES = {"connector", "miner", "orchestrator", "utility", "custom"}
 _REQUIRED_PACKAGE_KEYS = {"name", "display_name", "type", "generated_dir"}
 
 
+class AtlanYamlError(Exception):
+    """Raised when atlan.yaml validation fails."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
 def _err(msg: str) -> None:
-    """Emit a GitHub Actions error annotation and exit non-zero."""
-    print(f"::error::{msg}", file=sys.stderr)
-    sys.exit(1)
+    """Raise :class:`AtlanYamlError` with *msg*."""
+    raise AtlanYamlError(msg)
 
 
 def _validate_workflow_packages(wp_val: Any) -> str:
@@ -136,7 +143,8 @@ def parse(
 ) -> dict[str, str]:
     """Parse atlan.yaml + uv.lock and return the workflow-output dict.
 
-    Pure function — no I/O on stdout / GITHUB_OUTPUT. Test entry point.
+    Raises :class:`AtlanYamlError` on validation failures.  No I/O on
+    stdout / GITHUB_OUTPUT — test entry point.
     """
     if not os.path.isfile(atlan_yaml_path):
         _err("atlan.yaml not found in repo root")
@@ -204,7 +212,11 @@ def _write_outputs(outputs: dict[str, str]) -> None:
 
 
 def main() -> None:
-    outputs = parse()
+    try:
+        outputs = parse()
+    except AtlanYamlError as e:
+        print(f"::error::{e.message}", file=sys.stderr)
+        sys.exit(1)
     _write_outputs(outputs)
     print(f"App: {outputs['app_name']}")
     print(f"App ID: {outputs['app_id']}")

--- a/.github/scripts/parse_atlan_yaml.py
+++ b/.github/scripts/parse_atlan_yaml.py
@@ -16,7 +16,7 @@ Outputs (single-line, append-safe):
     dockerfile         ``dockerfile`` (default ``./Dockerfile``)
     enable_sdr         ``true``/``false`` from ``self_deployed_runtime``
     sdk_version        atlan-application-sdk version pinned in uv.lock (or empty)
-    workflow_packages  JSON-encoded list (single line) or empty string
+    workflows  JSON-encoded list (single line) or empty string
     deploy_config      YAML-dumped ``deploy:`` block (multiline; heredoc'd by caller)
 
 Validation errors are emitted as ``::error::`` annotations and exit non-zero.
@@ -40,7 +40,7 @@ _KEBAB_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 # Closed type set. Mirrors core.version.model.WorkflowPackageType in GM.
 _ALLOWED_TYPES = {"connector", "miner", "orchestrator", "utility", "custom"}
 
-# Required keys for each workflow_packages entry. description and icon_url
+# Required keys for each workflows entry. description and icon_url
 # are optional (default empty string on GM side).
 _REQUIRED_PACKAGE_KEYS = {"name", "display_name", "type", "generated_dir"}
 
@@ -58,8 +58,8 @@ def _err(msg: str) -> None:
     raise AtlanYamlError(msg)
 
 
-def _validate_workflow_packages(wp_val: Any) -> str:
-    """Validate ``workflow_packages`` and return its JSON-encoded form (single line).
+def _validate_workflows(wp_val: Any) -> str:
+    """Validate ``workflows`` and return its JSON-encoded form (single line).
 
     Returns empty string if the field is absent or empty (single-package apps).
     Same rules as ``core.version.model.WorkflowPackage`` in GM — validating
@@ -69,41 +69,41 @@ def _validate_workflow_packages(wp_val: Any) -> str:
     if not wp_val:
         return ""
     if not isinstance(wp_val, list):
-        _err("atlan.yaml workflow_packages must be a list")
+        _err("atlan.yaml workflows must be a list")
 
     seen_names: set[str] = set()
     for i, pkg in enumerate(wp_val):
         if not isinstance(pkg, dict):
-            _err(f"workflow_packages[{i}] must be a mapping")
+            _err(f"workflows[{i}] must be a mapping")
 
         missing = _REQUIRED_PACKAGE_KEYS - set(pkg.keys())
         if missing:
-            _err(f"workflow_packages[{i}] missing required keys: {sorted(missing)}")
+            _err(f"workflows[{i}] missing required keys: {sorted(missing)}")
 
         name = pkg.get("name")
         if not isinstance(name, str) or not _KEBAB_RE.match(name):
             _err(
-                f"workflow_packages[{i}].name must be kebab-case "
+                f"workflows[{i}].name must be kebab-case "
                 f"(lowercase a-z, 0-9, hyphens); got {name!r}"
             )
         if name in seen_names:
-            _err(f"workflow_packages[{i}].name {name!r} is duplicated")
+            _err(f"workflows[{i}].name {name!r} is duplicated")
         seen_names.add(name)
 
         pkg_type = pkg.get("type")
         if pkg_type not in _ALLOWED_TYPES:
             _err(
-                f"workflow_packages[{i}].type must be one of "
+                f"workflows[{i}].type must be one of "
                 f"{sorted(_ALLOWED_TYPES)}; got {pkg_type!r}"
             )
 
         generated_dir = pkg.get("generated_dir")
         if not isinstance(generated_dir, str) or not generated_dir.strip():
-            _err(f"workflow_packages[{i}].generated_dir must be a non-empty string")
+            _err(f"workflows[{i}].generated_dir must be a non-empty string")
 
         display_name = pkg.get("display_name")
         if not isinstance(display_name, str) or not display_name.strip():
-            _err(f"workflow_packages[{i}].display_name must be a non-empty string")
+            _err(f"workflows[{i}].display_name must be a non-empty string")
 
     # Compact JSON: single-line so it survives the workflow's
     # ``$GITHUB_OUTPUT`` ``key=value`` append (multi-line outputs need
@@ -176,7 +176,7 @@ def parse(
         else ""
     )
 
-    workflow_packages = _validate_workflow_packages(d.get("workflow_packages"))
+    workflows = _validate_workflows(d.get("workflows"))
     sdk_version = _read_sdk_version_from_uv_lock(uv_lock_path)
 
     return {
@@ -186,7 +186,7 @@ def parse(
         "dockerfile": dockerfile,
         "enable_sdr": enable_sdr,
         "sdk_version": sdk_version,
-        "workflow_packages": workflow_packages,
+        "workflows": workflows,
         "deploy_config": deploy_config,
     }
 
@@ -225,10 +225,7 @@ def main() -> None:
     print(f"SDK version: {outputs['sdk_version'] or '(not pinned)'}")
     print(
         "Workflow packages: "
-        + (
-            outputs["workflow_packages"]
-            or "(none — falling back to argo_package_names)"
-        )
+        + (outputs["workflows"] or "(none — falling back to argo_package_names)")
     )
 
 

--- a/.github/scripts/parse_atlan_yaml.py
+++ b/.github/scripts/parse_atlan_yaml.py
@@ -1,0 +1,224 @@
+"""
+Parse atlan.yaml for the Build & Publish reusable workflow.
+
+Reads atlan.yaml from CWD (and uv.lock for sdk_version) and emits the values
+the workflow needs as ``key=value`` lines on stdout. The workflow appends
+those lines to ``$GITHUB_OUTPUT`` (deploy_config is multiline and uses the
+GHA heredoc-delimiter syntax).
+
+Lives outside the YAML so it can be unit-tested. Keep this file dependency-
+light — only PyYAML is available in the workflow runner by default.
+
+Outputs (single-line, append-safe):
+    app_name           lowercased ``name`` from atlan.yaml
+    app_id             ``app_id``
+    build_tag          ``build_tag`` (only ``v1`` supported today)
+    dockerfile         ``dockerfile`` (default ``./Dockerfile``)
+    enable_sdr         ``true``/``false`` from ``self_deployed_runtime``
+    sdk_version        atlan-application-sdk version pinned in uv.lock (or empty)
+    workflow_packages  JSON-encoded list (single line) or empty string
+    deploy_config      YAML-dumped ``deploy:`` block (multiline; heredoc'd by caller)
+
+Validation errors are emitted as ``::error::`` annotations and exit non-zero.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from typing import Any
+
+import yaml
+
+# Strict kebab-case: lowercase a-z, 0-9, hyphen separators only. Mirrors the
+# Pydantic validator on the GM side. Tile name flows downstream as a URL/route
+# param + configmap filename stem — must stay safe for both.
+_KEBAB_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+# Closed type set. Mirrors core.version.model.WorkflowPackageType in GM.
+_ALLOWED_TYPES = {"connector", "miner", "orchestrator", "utility", "custom"}
+
+# Required keys for each workflow_packages entry. description and icon_url
+# are optional (default empty string on GM side).
+_REQUIRED_PACKAGE_KEYS = {"name", "display_name", "type", "generated_dir"}
+
+
+def _err(msg: str) -> None:
+    """Emit a GitHub Actions error annotation and exit non-zero."""
+    print(f"::error::{msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def _validate_workflow_packages(wp_val: Any) -> str:
+    """Validate ``workflow_packages`` and return its JSON-encoded form (single line).
+
+    Returns empty string if the field is absent or empty (single-package apps).
+    Same rules as ``core.version.model.WorkflowPackage`` in GM — validating
+    here means failures surface at CI time with annotated errors instead of
+    a 422 from the publish endpoint.
+    """
+    if not wp_val:
+        return ""
+    if not isinstance(wp_val, list):
+        _err("atlan.yaml workflow_packages must be a list")
+
+    seen_names: set[str] = set()
+    for i, pkg in enumerate(wp_val):
+        if not isinstance(pkg, dict):
+            _err(f"workflow_packages[{i}] must be a mapping")
+
+        missing = _REQUIRED_PACKAGE_KEYS - set(pkg.keys())
+        if missing:
+            _err(f"workflow_packages[{i}] missing required keys: {sorted(missing)}")
+
+        name = pkg.get("name")
+        if not isinstance(name, str) or not _KEBAB_RE.match(name):
+            _err(
+                f"workflow_packages[{i}].name must be kebab-case "
+                f"(lowercase a-z, 0-9, hyphens); got {name!r}"
+            )
+        if name in seen_names:
+            _err(f"workflow_packages[{i}].name {name!r} is duplicated")
+        seen_names.add(name)
+
+        pkg_type = pkg.get("type")
+        if pkg_type not in _ALLOWED_TYPES:
+            _err(
+                f"workflow_packages[{i}].type must be one of "
+                f"{sorted(_ALLOWED_TYPES)}; got {pkg_type!r}"
+            )
+
+        generated_dir = pkg.get("generated_dir")
+        if not isinstance(generated_dir, str) or not generated_dir.strip():
+            _err(f"workflow_packages[{i}].generated_dir must be a non-empty string")
+
+        display_name = pkg.get("display_name")
+        if not isinstance(display_name, str) or not display_name.strip():
+            _err(f"workflow_packages[{i}].display_name must be a non-empty string")
+
+    # Compact JSON: single-line so it survives the workflow's
+    # ``$GITHUB_OUTPUT`` ``key=value`` append (multi-line outputs need
+    # delimiter syntax).
+    return json.dumps(wp_val, separators=(",", ":"))
+
+
+def _read_sdk_version_from_uv_lock(path: str = "uv.lock") -> str:
+    """Best-effort read of the locked atlan-application-sdk version.
+
+    Reads the precise version regardless of how the dependency is declared in
+    pyproject.toml (==, >=, git ref, etc.). Returns empty string if uv.lock
+    isn't present — non-fatal.
+    """
+    re_ver = re.compile(r'^version\s*=\s*"([^"]+)"')
+    try:
+        with open(path) as f:
+            in_sdk_block = False
+            for raw in f:
+                line = raw.rstrip()
+                if line == 'name = "atlan-application-sdk"':
+                    in_sdk_block = True
+                    continue
+                if in_sdk_block:
+                    m = re_ver.match(line)
+                    if m:
+                        return m.group(1)
+                    if line.startswith("name = ") or line.startswith("[["):
+                        break
+    except FileNotFoundError:
+        pass
+    return ""
+
+
+def parse(
+    atlan_yaml_path: str = "atlan.yaml", uv_lock_path: str = "uv.lock"
+) -> dict[str, str]:
+    """Parse atlan.yaml + uv.lock and return the workflow-output dict.
+
+    Pure function — no I/O on stdout / GITHUB_OUTPUT. Test entry point.
+    """
+    if not os.path.isfile(atlan_yaml_path):
+        _err("atlan.yaml not found in repo root")
+
+    try:
+        with open(atlan_yaml_path) as f:
+            d = yaml.safe_load(f) or {}
+    except yaml.YAMLError as e:
+        _err(f"atlan.yaml is invalid YAML: {e}")
+
+    app_name = (d.get("name") or "").lower()
+    app_id = d.get("app_id", "")
+    build_tag = d.get("build_tag", "v1")
+    dockerfile = d.get("dockerfile", "./Dockerfile")
+    enable_sdr = "true" if d.get("self_deployed_runtime", False) else "false"
+
+    if not app_name:
+        _err('atlan.yaml is missing required "name" field')
+
+    if build_tag != "v1":
+        _err(
+            f"Unsupported build_tag {build_tag!r}. Only 'v1' is supported by this template version."
+        )
+
+    deploy_val = d.get("deploy")
+    deploy_config = (
+        yaml.dump(deploy_val, default_flow_style=False)
+        if deploy_val is not None
+        else ""
+    )
+
+    workflow_packages = _validate_workflow_packages(d.get("workflow_packages"))
+    sdk_version = _read_sdk_version_from_uv_lock(uv_lock_path)
+
+    return {
+        "app_name": app_name,
+        "app_id": str(app_id),
+        "build_tag": build_tag,
+        "dockerfile": dockerfile,
+        "enable_sdr": enable_sdr,
+        "sdk_version": sdk_version,
+        "workflow_packages": workflow_packages,
+        "deploy_config": deploy_config,
+    }
+
+
+def _write_outputs(outputs: dict[str, str]) -> None:
+    """Write outputs to ``$GITHUB_OUTPUT``. ``deploy_config`` is multiline → heredoc."""
+    gh_output = os.environ.get("GITHUB_OUTPUT")
+    if not gh_output:
+        # Local dry-run: just dump key=value lines to stdout.
+        for k, v in outputs.items():
+            if "\n" in v:
+                print(f"{k}<<DEPLOY_EOF\n{v}\nDEPLOY_EOF")
+            else:
+                print(f"{k}={v}")
+        return
+
+    with open(gh_output, "a") as out:
+        for k, v in outputs.items():
+            if k == "deploy_config":
+                out.write(f"deploy_config<<DEPLOY_EOF\n{v}\nDEPLOY_EOF\n")
+            else:
+                out.write(f"{k}={v}\n")
+
+
+def main() -> None:
+    outputs = parse()
+    _write_outputs(outputs)
+    print(f"App: {outputs['app_name']}")
+    print(f"App ID: {outputs['app_id']}")
+    print(f"Dockerfile: {outputs['dockerfile']}")
+    print(f"SDR: {outputs['enable_sdr']}")
+    print(f"SDK version: {outputs['sdk_version'] or '(not pinned)'}")
+    print(
+        "Workflow packages: "
+        + (
+            outputs["workflow_packages"]
+            or "(none — falling back to argo_package_names)"
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/parse_atlan_yaml.py
+++ b/.github/scripts/parse_atlan_yaml.py
@@ -1,13 +1,13 @@
 """
-Parse atlan.yaml for the Build & Publish reusable workflow.
+Parse atlan.yaml for the Build & Publish reusable entrypoint.
 
 Reads atlan.yaml from CWD (and uv.lock for sdk_version) and emits the values
-the workflow needs as ``key=value`` lines on stdout. The workflow appends
+the entrypoint needs as ``key=value`` lines on stdout. The entrypoint appends
 those lines to ``$GITHUB_OUTPUT`` (deploy_config is multiline and uses the
 GHA heredoc-delimiter syntax).
 
 Lives outside the YAML so it can be unit-tested. Keep this file dependency-
-light — only PyYAML is available in the workflow runner by default.
+light — only PyYAML is available in the entrypoint runner by default.
 
 Outputs (single-line, append-safe):
     app_name           lowercased ``name`` from atlan.yaml
@@ -16,7 +16,7 @@ Outputs (single-line, append-safe):
     dockerfile         ``dockerfile`` (default ``./Dockerfile``)
     enable_sdr         ``true``/``false`` from ``self_deployed_runtime``
     sdk_version        atlan-application-sdk version pinned in uv.lock (or empty)
-    workflows  JSON-encoded list (single line) or empty string
+    entrypoints  JSON-encoded list (single line) or empty string
     deploy_config      YAML-dumped ``deploy:`` block (multiline; heredoc'd by caller)
 
 Validation errors are emitted as ``::error::`` annotations and exit non-zero.
@@ -37,10 +37,10 @@ import yaml
 # param + configmap filename stem — must stay safe for both.
 _KEBAB_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 
-# Closed type set. Mirrors core.version.model.WorkflowPackageType in GM.
+# Closed type set. Mirrors core.version.model.EntrypointPackageType in GM.
 _ALLOWED_TYPES = {"connector", "miner", "orchestrator", "utility", "custom"}
 
-# Required keys for each workflows entry. description and icon_url
+# Required keys for each entrypoints entry. description and icon_url
 # are optional (default empty string on GM side).
 _REQUIRED_PACKAGE_KEYS = {"name", "display_name", "type", "generated_dir"}
 
@@ -58,54 +58,54 @@ def _err(msg: str) -> None:
     raise AtlanYamlError(msg)
 
 
-def _validate_workflows(wp_val: Any) -> str:
-    """Validate ``workflows`` and return its JSON-encoded form (single line).
+def _validate_entrypoints(wp_val: Any) -> str:
+    """Validate ``entrypoints`` and return its JSON-encoded form (single line).
 
     Returns empty string if the field is absent or empty (single-package apps).
-    Same rules as ``core.version.model.WorkflowPackage`` in GM — validating
+    Same rules as ``core.version.model.EntrypointPackage`` in GM — validating
     here means failures surface at CI time with annotated errors instead of
     a 422 from the publish endpoint.
     """
     if not wp_val:
         return ""
     if not isinstance(wp_val, list):
-        _err("atlan.yaml workflows must be a list")
+        _err("atlan.yaml entrypoints must be a list")
 
     seen_names: set[str] = set()
     for i, pkg in enumerate(wp_val):
         if not isinstance(pkg, dict):
-            _err(f"workflows[{i}] must be a mapping")
+            _err(f"entrypoints[{i}] must be a mapping")
 
         missing = _REQUIRED_PACKAGE_KEYS - set(pkg.keys())
         if missing:
-            _err(f"workflows[{i}] missing required keys: {sorted(missing)}")
+            _err(f"entrypoints[{i}] missing required keys: {sorted(missing)}")
 
         name = pkg.get("name")
         if not isinstance(name, str) or not _KEBAB_RE.match(name):
             _err(
-                f"workflows[{i}].name must be kebab-case "
+                f"entrypoints[{i}].name must be kebab-case "
                 f"(lowercase a-z, 0-9, hyphens); got {name!r}"
             )
         if name in seen_names:
-            _err(f"workflows[{i}].name {name!r} is duplicated")
+            _err(f"entrypoints[{i}].name {name!r} is duplicated")
         seen_names.add(name)
 
         pkg_type = pkg.get("type")
         if pkg_type not in _ALLOWED_TYPES:
             _err(
-                f"workflows[{i}].type must be one of "
+                f"entrypoints[{i}].type must be one of "
                 f"{sorted(_ALLOWED_TYPES)}; got {pkg_type!r}"
             )
 
         generated_dir = pkg.get("generated_dir")
         if not isinstance(generated_dir, str) or not generated_dir.strip():
-            _err(f"workflows[{i}].generated_dir must be a non-empty string")
+            _err(f"entrypoints[{i}].generated_dir must be a non-empty string")
 
         display_name = pkg.get("display_name")
         if not isinstance(display_name, str) or not display_name.strip():
-            _err(f"workflows[{i}].display_name must be a non-empty string")
+            _err(f"entrypoints[{i}].display_name must be a non-empty string")
 
-    # Compact JSON: single-line so it survives the workflow's
+    # Compact JSON: single-line so it survives the entrypoint's
     # ``$GITHUB_OUTPUT`` ``key=value`` append (multi-line outputs need
     # delimiter syntax).
     return json.dumps(wp_val, separators=(",", ":"))
@@ -141,7 +141,7 @@ def _read_sdk_version_from_uv_lock(path: str = "uv.lock") -> str:
 def parse(
     atlan_yaml_path: str = "atlan.yaml", uv_lock_path: str = "uv.lock"
 ) -> dict[str, str]:
-    """Parse atlan.yaml + uv.lock and return the workflow-output dict.
+    """Parse atlan.yaml + uv.lock and return the entrypoint-output dict.
 
     Raises :class:`AtlanYamlError` on validation failures.  No I/O on
     stdout / GITHUB_OUTPUT — test entry point.
@@ -176,7 +176,7 @@ def parse(
         else ""
     )
 
-    workflows = _validate_workflows(d.get("workflows"))
+    entrypoints = _validate_entrypoints(d.get("entrypoints"))
     sdk_version = _read_sdk_version_from_uv_lock(uv_lock_path)
 
     return {
@@ -186,7 +186,7 @@ def parse(
         "dockerfile": dockerfile,
         "enable_sdr": enable_sdr,
         "sdk_version": sdk_version,
-        "workflows": workflows,
+        "entrypoints": entrypoints,
         "deploy_config": deploy_config,
     }
 
@@ -224,8 +224,8 @@ def main() -> None:
     print(f"SDR: {outputs['enable_sdr']}")
     print(f"SDK version: {outputs['sdk_version'] or '(not pinned)'}")
     print(
-        "Workflow packages: "
-        + (outputs["workflows"] or "(none — falling back to argo_package_names)")
+        "Entrypoint packages: "
+        + (outputs["entrypoints"] or "(none — falling back to argo_package_names)")
     )
 
 

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -103,7 +103,7 @@ jobs:
         # Pull only ``.github/scripts/`` from the SDK at the same SHA this
         # reusable workflow is running (so the parser stays versioned with the
         # workflow, not the caller's repo). Sparse checkout keeps it cheap.
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           repository: atlanhq/application-sdk
           ref: ${{ github.workflow_sha || 'main' }}

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -85,7 +85,7 @@ jobs:
       enable_sdr:       ${{ steps.manifest.outputs.enable_sdr }}
       deploy_config:    ${{ steps.manifest.outputs.deploy_config }}
       sdk_version:      ${{ steps.manifest.outputs.sdk_version }}
-      workflow_packages: ${{ steps.manifest.outputs.workflow_packages }}
+      workflows: ${{ steps.manifest.outputs.workflows }}
       branch:           ${{ steps.tags.outputs.branch }}
       image_tag:        ${{ steps.tags.outputs.image_tag }}
       ghcr_base:        ${{ steps.tags.outputs.ghcr_base }}
@@ -347,7 +347,7 @@ jobs:
           APP_NAME: ${{ needs.prepare.outputs.app_name }}
           DEPLOY_CONFIG: ${{ needs.prepare.outputs.deploy_config }}
           SDK_VERSION: ${{ needs.prepare.outputs.sdk_version }}
-          WORKFLOW_PACKAGES: ${{ needs.prepare.outputs.workflow_packages }}
+          WORKFLOWS: ${{ needs.prepare.outputs.workflows }}
           CHANNEL: ${{ inputs.channel }}
           TENANTS: ${{ inputs.tenants }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
@@ -375,11 +375,11 @@ jobs:
           if sdk:
               body["sdk_version"] = sdk
 
-          # workflow_packages: native multi-package declarations from atlan.yaml.
+          # workflows: native multi-package declarations from atlan.yaml.
           # Absent → GM falls back to App.argo_package_names for tile expansion.
-          wp = os.environ.get("WORKFLOW_PACKAGES", "").strip()
+          wp = os.environ.get("WORKFLOWS", "").strip()
           if wp:
-              body["workflow_packages"] = json.loads(wp)
+              body["workflows"] = json.loads(wp)
 
           tenants = os.environ.get("TENANTS", "").strip()
           if tenants:

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -1,7 +1,7 @@
-# Unified build-and-publish workflow for Atlan first-party app repos.
+# Unified build-and-publish entrypoint for Atlan first-party app repos.
 #
 # Combines image build (build-apps-image.yaml) and marketplace publish (publish-app.yaml)
-# into a single workflow to eliminate double builds on push to main.
+# into a single entrypoint to eliminate double builds on push to main.
 #
 # Image tag:  {branch}-{sha7}  (e.g. main-abc1234) — immutable, used by deploy systems
 # Image URI:  ghcr.io/atlanhq/{repo}:{branch}-{sha7}
@@ -10,11 +10,11 @@
 # Build: parallel matrix (amd64 + arm64), merged into a multi-arch manifest.
 # Publish: after build succeeds, registers the version in the Global Marketplace via API.
 #
-# Usage in each app repo (.github/workflows/build-and-publish.yaml):
+# Usage in each app repo (.github/entrypoints/build-and-publish.yaml):
 #
 #   jobs:
 #     build-and-publish:
-#       uses: atlanhq/application-sdk/.github/workflows/build-and-publish-app.yaml@main
+#       uses: atlanhq/application-sdk/.github/entrypoints/build-and-publish-app.yaml@main
 #       with:
 #         publish: ${{ github.event.inputs.publish != 'false' }}
 #         channel: ${{ inputs.channel || 'all' }}
@@ -24,7 +24,7 @@
 name: Build & Publish Atlan App
 
 on:
-  workflow_call:
+  entrypoint_call:
     inputs:
       ref:
         description: "Branch or SHA to checkout and build (default: caller's ref)"
@@ -85,7 +85,7 @@ jobs:
       enable_sdr:       ${{ steps.manifest.outputs.enable_sdr }}
       deploy_config:    ${{ steps.manifest.outputs.deploy_config }}
       sdk_version:      ${{ steps.manifest.outputs.sdk_version }}
-      workflows: ${{ steps.manifest.outputs.workflows }}
+      entrypoints: ${{ steps.manifest.outputs.entrypoints }}
       branch:           ${{ steps.tags.outputs.branch }}
       image_tag:        ${{ steps.tags.outputs.image_tag }}
       ghcr_base:        ${{ steps.tags.outputs.ghcr_base }}
@@ -101,22 +101,22 @@ jobs:
 
       - name: Checkout SDK helper scripts
         # Pull only ``.github/scripts/`` from the SDK at the same SHA this
-        # reusable workflow is running (so the parser stays versioned with the
-        # workflow, not the caller's repo). Sparse checkout keeps it cheap.
+        # reusable entrypoint is running (so the parser stays versioned with the
+        # entrypoint, not the caller's repo). Sparse checkout keeps it cheap.
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           repository: atlanhq/application-sdk
-          ref: ${{ github.workflow_sha || 'main' }}
-          path: .sdk-workflow
+          ref: ${{ github.entrypoint_sha || 'main' }}
+          path: .sdk-entrypoint
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
 
       - name: Read atlan.yaml
         id: manifest
         # Inputs validated and outputs written by parse_atlan_yaml.py — see
-        # .sdk-workflow/.github/scripts/parse_atlan_yaml.py for rules.
+        # .sdk-entrypoint/.github/scripts/parse_atlan_yaml.py for rules.
         # Unit-tested in tests/test_parse_atlan_yaml.py in the SDK repo.
-        run: python3 .sdk-workflow/.github/scripts/parse_atlan_yaml.py
+        run: python3 .sdk-entrypoint/.github/scripts/parse_atlan_yaml.py
 
       - name: Validate SDR secrets
         if: steps.manifest.outputs.enable_sdr == 'true'
@@ -146,7 +146,7 @@ jobs:
         run: |
           # Resolve SHA from the checked-out HEAD rather than github.sha.
           # github.sha is always the trigger branch (main), not the ref input —
-          # so for workflow_dispatch with a custom ref, github.sha would be wrong.
+          # so for entrypoint_dispatch with a custom ref, github.sha would be wrong.
           SHA=$(git rev-parse HEAD)
           if ! [[ "$REF" =~ ^(refs/heads/|refs/tags/)?[a-zA-Z0-9/_.-]+$ ]]; then
             echo "::error::Invalid ref format: ${REF}"
@@ -297,7 +297,7 @@ jobs:
   security-scan:
     name: Security Scan
     needs: [prepare, merge]
-    uses: atlanhq/application-sdk/.github/workflows/build-and-scan.yaml@main
+    uses: atlanhq/application-sdk/.github/entrypoints/build-and-scan.yaml@main
     with:
       image: ${{ needs.prepare.outputs.ghcr_image }}
       snyk_org: partner-images
@@ -320,7 +320,7 @@ jobs:
         with:
           token: ${{ secrets.ORG_PAT_GITHUB }}
           repository: ${{ matrix.repo }}
-          event-type: dispatch_app_builder_workflow
+          event-type: dispatch_app_builder_entrypoint
           client-payload: |-
             {
                 "app_name": "${{ needs.prepare.outputs.app_name }}",
@@ -347,7 +347,7 @@ jobs:
           APP_NAME: ${{ needs.prepare.outputs.app_name }}
           DEPLOY_CONFIG: ${{ needs.prepare.outputs.deploy_config }}
           SDK_VERSION: ${{ needs.prepare.outputs.sdk_version }}
-          WORKFLOWS: ${{ needs.prepare.outputs.workflows }}
+          ENTRYPOINTS: ${{ needs.prepare.outputs.entrypoints }}
           CHANNEL: ${{ inputs.channel }}
           TENANTS: ${{ inputs.tenants }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
@@ -375,11 +375,11 @@ jobs:
           if sdk:
               body["sdk_version"] = sdk
 
-          # workflows: native multi-package declarations from atlan.yaml.
-          # Absent → GM falls back to App.argo_package_names for tile expansion.
-          wp = os.environ.get("WORKFLOWS", "").strip()
+          # entrypoints: native multi-package declarations from atlan.yaml.
+          # Absent → GM falls back to App.argo_package_names for entrypoint expansion.
+          wp = os.environ.get("ENTRYPOINTS", "").strip()
           if wp:
-              body["workflows"] = json.loads(wp)
+              body["entrypoints"] = json.loads(wp)
 
           tenants = os.environ.get("TENANTS", "").strip()
           if tenants:

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -85,6 +85,7 @@ jobs:
       enable_sdr:       ${{ steps.manifest.outputs.enable_sdr }}
       deploy_config:    ${{ steps.manifest.outputs.deploy_config }}
       sdk_version:      ${{ steps.manifest.outputs.sdk_version }}
+      workflow_packages: ${{ steps.manifest.outputs.workflow_packages }}
       branch:           ${{ steps.tags.outputs.branch }}
       image_tag:        ${{ steps.tags.outputs.image_tag }}
       ghcr_base:        ${{ steps.tags.outputs.ghcr_base }}
@@ -136,6 +137,27 @@ jobs:
           if deploy_val is not None:
               deploy_config = yaml.dump(deploy_val, default_flow_style=False)
 
+          # Serialize workflow_packages (multi-package native apps, e.g. Teradata
+          # crawler + miner) as a single-line JSON string for the publish curl
+          # body. Absent or empty → emit empty string; the publish step will
+          # omit the field and GM will fall back to App.argo_package_names.
+          workflow_packages = ''
+          wp_val = d.get('workflow_packages')
+          if wp_val:
+              if not isinstance(wp_val, list):
+                  print('::error::atlan.yaml workflow_packages must be a list', file=sys.stderr)
+                  sys.exit(1)
+              required_keys = {'name', 'display_name', 'type', 'generated_dir'}
+              for i, pkg in enumerate(wp_val):
+                  if not isinstance(pkg, dict):
+                      print(f'::error::workflow_packages[{i}] must be a mapping', file=sys.stderr)
+                      sys.exit(1)
+                  missing = required_keys - set(pkg.keys())
+                  if missing:
+                      print(f'::error::workflow_packages[{i}] missing required keys: {sorted(missing)}', file=sys.stderr)
+                      sys.exit(1)
+              workflow_packages = json.dumps(wp_val, separators=(',', ':'))
+
           # Read exact SDK version from uv.lock (non-fatal).
           # uv.lock contains the precise locked version regardless of how the dep
           # is specified in pyproject.toml (==, >=, git ref, etc.).
@@ -167,6 +189,8 @@ jobs:
               out.write(f'dockerfile={dockerfile}\n')
               out.write(f'enable_sdr={enable_sdr}\n')
               out.write(f'sdk_version={sdk_version}\n')
+              # workflow_packages JSON is single-line by construction (separators=(',', ':'))
+              out.write(f'workflow_packages={workflow_packages}\n')
               # deploy_config may be multiline — use delimiter syntax
           with open(os.environ['GITHUB_OUTPUT'], 'a') as out:
               out.write(f'deploy_config<<DEPLOY_EOF\n')
@@ -178,6 +202,7 @@ jobs:
           print(f'Dockerfile: {dockerfile}')
           print(f'SDR: {enable_sdr}')
           print(f'SDK version: {sdk_version}')
+          print(f'Workflow packages: {workflow_packages or "(none — falling back to argo_package_names)"}')
           PYEOF
 
       - name: Validate SDR secrets
@@ -409,6 +434,7 @@ jobs:
           APP_NAME: ${{ needs.prepare.outputs.app_name }}
           DEPLOY_CONFIG: ${{ needs.prepare.outputs.deploy_config }}
           SDK_VERSION: ${{ needs.prepare.outputs.sdk_version }}
+          WORKFLOW_PACKAGES: ${{ needs.prepare.outputs.workflow_packages }}
           CHANNEL: ${{ inputs.channel }}
           TENANTS: ${{ inputs.tenants }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
@@ -435,6 +461,12 @@ jobs:
           sdk = os.environ.get("SDK_VERSION", "").strip()
           if sdk:
               body["sdk_version"] = sdk
+
+          # workflow_packages: native multi-package declarations from atlan.yaml.
+          # Absent → GM falls back to App.argo_package_names for tile expansion.
+          wp = os.environ.get("WORKFLOW_PACKAGES", "").strip()
+          if wp:
+              body["workflow_packages"] = json.loads(wp)
 
           tenants = os.environ.get("TENANTS", "").strip()
           if tenants:

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -141,6 +141,11 @@ jobs:
           # crawler + miner) as a single-line JSON string for the publish curl
           # body. Absent or empty → emit empty string; the publish step will
           # omit the field and GM will fall back to App.argo_package_names.
+          #
+          # Validation here fails fast at CI time with annotated errors (better
+          # UX than a publish-time 422 from GM). The same rules are enforced
+          # again by Pydantic on the GM side — this is defence-in-depth, not
+          # duplication for its own sake.
           workflow_packages = ''
           wp_val = d.get('workflow_packages')
           if wp_val:
@@ -148,6 +153,9 @@ jobs:
                   print('::error::atlan.yaml workflow_packages must be a list', file=sys.stderr)
                   sys.exit(1)
               required_keys = {'name', 'display_name', 'type', 'generated_dir'}
+              allowed_types = {'connector', 'miner', 'orchestrator', 'utility', 'custom'}
+              name_re = re.compile(r'^[a-z0-9]+(-[a-z0-9]+)*$')
+              seen_names = set()
               for i, pkg in enumerate(wp_val):
                   if not isinstance(pkg, dict):
                       print(f'::error::workflow_packages[{i}] must be a mapping', file=sys.stderr)
@@ -155,6 +163,26 @@ jobs:
                   missing = required_keys - set(pkg.keys())
                   if missing:
                       print(f'::error::workflow_packages[{i}] missing required keys: {sorted(missing)}', file=sys.stderr)
+                      sys.exit(1)
+                  name = pkg.get('name')
+                  if not isinstance(name, str) or not name_re.match(name):
+                      print(f'::error::workflow_packages[{i}].name must be kebab-case (lowercase a-z, 0-9, hyphens); got {name!r}', file=sys.stderr)
+                      sys.exit(1)
+                  if name in seen_names:
+                      print(f'::error::workflow_packages[{i}].name {name!r} is duplicated', file=sys.stderr)
+                      sys.exit(1)
+                  seen_names.add(name)
+                  pkg_type = pkg.get('type')
+                  if pkg_type not in allowed_types:
+                      print(f'::error::workflow_packages[{i}].type must be one of {sorted(allowed_types)}; got {pkg_type!r}', file=sys.stderr)
+                      sys.exit(1)
+                  generated_dir = pkg.get('generated_dir')
+                  if not isinstance(generated_dir, str) or not generated_dir.strip():
+                      print(f'::error::workflow_packages[{i}].generated_dir must be a non-empty string', file=sys.stderr)
+                      sys.exit(1)
+                  display_name = pkg.get('display_name')
+                  if not isinstance(display_name, str) or not display_name.strip():
+                      print(f'::error::workflow_packages[{i}].display_name must be a non-empty string', file=sys.stderr)
                       sys.exit(1)
               workflow_packages = json.dumps(wp_val, separators=(',', ':'))
 

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -99,139 +99,24 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - name: Checkout SDK helper scripts
+        # Pull only ``.github/scripts/`` from the SDK at the same SHA this
+        # reusable workflow is running (so the parser stays versioned with the
+        # workflow, not the caller's repo). Sparse checkout keeps it cheap.
+        uses: actions/checkout@v4
+        with:
+          repository: atlanhq/application-sdk
+          ref: ${{ github.workflow_sha || 'main' }}
+          path: .sdk-workflow
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
       - name: Read atlan.yaml
         id: manifest
-        run: |
-          if [ ! -f atlan.yaml ]; then
-            echo "::error::atlan.yaml not found in repo root"
-            exit 1
-          fi
-
-          python3 - <<'PYEOF'
-          import yaml, sys, os, json, re
-
-          try:
-              with open('atlan.yaml') as f:
-                  d = yaml.safe_load(f) or {}
-          except yaml.YAMLError as e:
-              print(f'::error::atlan.yaml is invalid YAML: {e}', file=sys.stderr)
-              sys.exit(1)
-
-          app_name   = d.get('name', '').lower()
-          app_id     = d.get('app_id', '')
-          build_tag  = d.get('build_tag', 'v1')
-          dockerfile = d.get('dockerfile', './Dockerfile')
-          enable_sdr = 'true' if d.get('self_deployed_runtime', False) else 'false'
-
-          if not app_name:
-              print('::error::atlan.yaml is missing required "name" field', file=sys.stderr)
-              sys.exit(1)
-
-          if build_tag != 'v1':
-              print(f"::error::Unsupported build_tag '{build_tag}'. Only 'v1' is supported by this template version.", file=sys.stderr)
-              sys.exit(1)
-
-          # Serialize deploy config block (if present) for publish
-          deploy_config = ''
-          deploy_val = d.get('deploy')
-          if deploy_val is not None:
-              deploy_config = yaml.dump(deploy_val, default_flow_style=False)
-
-          # Serialize workflow_packages (multi-package native apps, e.g. Teradata
-          # crawler + miner) as a single-line JSON string for the publish curl
-          # body. Absent or empty → emit empty string; the publish step will
-          # omit the field and GM will fall back to App.argo_package_names.
-          #
-          # Validation here fails fast at CI time with annotated errors (better
-          # UX than a publish-time 422 from GM). The same rules are enforced
-          # again by Pydantic on the GM side — this is defence-in-depth, not
-          # duplication for its own sake.
-          workflow_packages = ''
-          wp_val = d.get('workflow_packages')
-          if wp_val:
-              if not isinstance(wp_val, list):
-                  print('::error::atlan.yaml workflow_packages must be a list', file=sys.stderr)
-                  sys.exit(1)
-              required_keys = {'name', 'display_name', 'type', 'generated_dir'}
-              allowed_types = {'connector', 'miner', 'orchestrator', 'utility', 'custom'}
-              name_re = re.compile(r'^[a-z0-9]+(-[a-z0-9]+)*$')
-              seen_names = set()
-              for i, pkg in enumerate(wp_val):
-                  if not isinstance(pkg, dict):
-                      print(f'::error::workflow_packages[{i}] must be a mapping', file=sys.stderr)
-                      sys.exit(1)
-                  missing = required_keys - set(pkg.keys())
-                  if missing:
-                      print(f'::error::workflow_packages[{i}] missing required keys: {sorted(missing)}', file=sys.stderr)
-                      sys.exit(1)
-                  name = pkg.get('name')
-                  if not isinstance(name, str) or not name_re.match(name):
-                      print(f'::error::workflow_packages[{i}].name must be kebab-case (lowercase a-z, 0-9, hyphens); got {name!r}', file=sys.stderr)
-                      sys.exit(1)
-                  if name in seen_names:
-                      print(f'::error::workflow_packages[{i}].name {name!r} is duplicated', file=sys.stderr)
-                      sys.exit(1)
-                  seen_names.add(name)
-                  pkg_type = pkg.get('type')
-                  if pkg_type not in allowed_types:
-                      print(f'::error::workflow_packages[{i}].type must be one of {sorted(allowed_types)}; got {pkg_type!r}', file=sys.stderr)
-                      sys.exit(1)
-                  generated_dir = pkg.get('generated_dir')
-                  if not isinstance(generated_dir, str) or not generated_dir.strip():
-                      print(f'::error::workflow_packages[{i}].generated_dir must be a non-empty string', file=sys.stderr)
-                      sys.exit(1)
-                  display_name = pkg.get('display_name')
-                  if not isinstance(display_name, str) or not display_name.strip():
-                      print(f'::error::workflow_packages[{i}].display_name must be a non-empty string', file=sys.stderr)
-                      sys.exit(1)
-              workflow_packages = json.dumps(wp_val, separators=(',', ':'))
-
-          # Read exact SDK version from uv.lock (non-fatal).
-          # uv.lock contains the precise locked version regardless of how the dep
-          # is specified in pyproject.toml (==, >=, git ref, etc.).
-          sdk_version = ''
-          try:
-              import re as _re
-              re_ver = _re.compile(r'^version\s*=\s*"([^"]+)"')
-              in_sdk_block = False
-              with open('uv.lock') as f:
-                  for line in f:
-                      line = line.rstrip()
-                      if line == 'name = "atlan-application-sdk"':
-                          in_sdk_block = True
-                          continue
-                      if in_sdk_block:
-                          m = re_ver.match(line)
-                          if m:
-                              sdk_version = m.group(1)
-                              break
-                          if line.startswith('name = ') or line.startswith('[['):
-                              break
-          except FileNotFoundError:
-              pass
-
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as out:
-              out.write(f'app_name={app_name}\n')
-              out.write(f'app_id={app_id}\n')
-              out.write(f'build_tag={build_tag}\n')
-              out.write(f'dockerfile={dockerfile}\n')
-              out.write(f'enable_sdr={enable_sdr}\n')
-              out.write(f'sdk_version={sdk_version}\n')
-              # workflow_packages JSON is single-line by construction (separators=(',', ':'))
-              out.write(f'workflow_packages={workflow_packages}\n')
-              # deploy_config may be multiline — use delimiter syntax
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as out:
-              out.write(f'deploy_config<<DEPLOY_EOF\n')
-              out.write(f'{deploy_config}\n')
-              out.write(f'DEPLOY_EOF\n')
-
-          print(f'App: {app_name}')
-          print(f'App ID: {app_id}')
-          print(f'Dockerfile: {dockerfile}')
-          print(f'SDR: {enable_sdr}')
-          print(f'SDK version: {sdk_version}')
-          print(f'Workflow packages: {workflow_packages or "(none — falling back to argo_package_names)"}')
-          PYEOF
+        # Inputs validated and outputs written by parse_atlan_yaml.py — see
+        # .sdk-workflow/.github/scripts/parse_atlan_yaml.py for rules.
+        # Unit-tested in tests/test_parse_atlan_yaml.py in the SDK repo.
+        run: python3 .sdk-workflow/.github/scripts/parse_atlan_yaml.py
 
       - name: Validate SDR secrets
         if: steps.manifest.outputs.enable_sdr == 'true'

--- a/tests/unit/test_parse_atlan_yaml.py
+++ b/tests/unit/test_parse_atlan_yaml.py
@@ -1,0 +1,215 @@
+"""Unit tests for .github/scripts/parse_atlan_yaml.py.
+
+The parser is invoked from the Build & Publish reusable workflow to read
+``atlan.yaml`` (and optionally ``uv.lock``) and emit values that downstream
+jobs forward to GHCR + the marketplace publish endpoint. Validation here
+fails fast at CI time with annotated errors — these tests pin the rules
+that any future tweak must keep honouring.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Load the script as a module without forcing a package layout under .github.
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "scripts" / "parse_atlan_yaml.py"
+)
+_spec = importlib.util.spec_from_file_location("parse_atlan_yaml", _SCRIPT_PATH)
+parse_atlan_yaml = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+sys.modules["parse_atlan_yaml"] = parse_atlan_yaml
+assert _spec and _spec.loader
+_spec.loader.exec_module(parse_atlan_yaml)  # type: ignore[union-attr]
+
+
+def _write(tmp_path: Path, payload: dict, name: str = "atlan.yaml") -> Path:
+    p = tmp_path / name
+    p.write_text(yaml.safe_dump(payload))
+    return p
+
+
+# ── happy path ──────────────────────────────────────────────────────────────
+
+
+def test_parse_minimal_atlan_yaml(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(
+        tmp_path, {"name": "Postgres", "app_id": "abc", "self_deployed_runtime": False}
+    )
+    out = parse_atlan_yaml.parse()
+    assert out["app_name"] == "postgres"  # lowercased
+    assert out["app_id"] == "abc"
+    assert out["enable_sdr"] == "false"
+    assert out["dockerfile"] == "./Dockerfile"
+    assert out["build_tag"] == "v1"
+    assert out["sdk_version"] == ""  # no uv.lock
+    assert (
+        out["workflow_packages"] == ""
+    )  # absent → consumers fall back to argo_package_names
+    assert out["deploy_config"] == ""
+
+
+def test_parse_emits_deploy_config_yaml(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(
+        tmp_path,
+        {
+            "name": "x",
+            "app_id": "1",
+            "self_deployed_runtime": True,
+            "deploy": {"replicaCount": 2, "containerPort": 8000},
+        },
+    )
+    out = parse_atlan_yaml.parse()
+    assert out["enable_sdr"] == "true"
+    assert "replicaCount: 2" in out["deploy_config"]
+
+
+def test_parse_reads_sdk_version_from_uv_lock(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, {"name": "x", "app_id": "1"})
+    (tmp_path / "uv.lock").write_text(
+        "[[package]]\n" 'name = "atlan-application-sdk"\n' 'version = "0.1.10"\n'
+    )
+    out = parse_atlan_yaml.parse()
+    assert out["sdk_version"] == "0.1.10"
+
+
+# ── workflow_packages happy path ────────────────────────────────────────────
+
+
+def _pkg(
+    name="teradata-crawler", display="Teradata Crawler", typ="connector", gen="crawler"
+):
+    return {
+        "name": name,
+        "display_name": display,
+        "description": f"{name} description",
+        "icon_url": "https://assets.atlan.com/assets/Teradata.svg",
+        "type": typ,
+        "generated_dir": gen,
+    }
+
+
+def test_workflow_packages_round_trips_as_compact_json(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    pkgs = [_pkg(), _pkg("teradata-miner", "Teradata Miner", "miner", "miner")]
+    _write(tmp_path, {"name": "teradata", "app_id": "1", "workflow_packages": pkgs})
+    out = parse_atlan_yaml.parse()
+    # Single line — required because the workflow appends to $GITHUB_OUTPUT
+    # via simple key=value (multiline values would need delimiter syntax).
+    assert "\n" not in out["workflow_packages"]
+    assert json.loads(out["workflow_packages"]) == pkgs
+
+
+# ── workflow_packages validation rules (must mirror GM Pydantic) ────────────
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    ["Teradata-Miner", "teradata_miner", "teradata miner", "-tera", "tera-", "UPPER"],
+)
+def test_kebab_case_name_rejected(tmp_path, monkeypatch, bad_name):
+    monkeypatch.chdir(tmp_path)
+    _write(
+        tmp_path,
+        {
+            "name": "x",
+            "app_id": "1",
+            "workflow_packages": [_pkg(name=bad_name)],
+        },
+    )
+    with pytest.raises(SystemExit):
+        parse_atlan_yaml.parse()
+
+
+@pytest.mark.parametrize(
+    "bad_type",
+    ["Connector", "database", "", None, "miner-v2"],
+)
+def test_type_must_be_in_closed_set(tmp_path, monkeypatch, bad_type):
+    monkeypatch.chdir(tmp_path)
+    pkg = _pkg()
+    pkg["type"] = bad_type
+    _write(tmp_path, {"name": "x", "app_id": "1", "workflow_packages": [pkg]})
+    with pytest.raises(SystemExit):
+        parse_atlan_yaml.parse()
+
+
+def test_duplicate_names_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(
+        tmp_path,
+        {
+            "name": "x",
+            "app_id": "1",
+            "workflow_packages": [_pkg(), _pkg()],  # two identical names
+        },
+    )
+    with pytest.raises(SystemExit):
+        parse_atlan_yaml.parse()
+
+
+def test_missing_required_keys_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(
+        tmp_path,
+        {
+            "name": "x",
+            "app_id": "1",
+            "workflow_packages": [{"name": "x", "type": "connector"}],
+        },
+    )
+    with pytest.raises(SystemExit):
+        parse_atlan_yaml.parse()
+
+
+def test_workflow_packages_must_be_list(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, {"name": "x", "app_id": "1", "workflow_packages": {"name": "x"}})
+    with pytest.raises(SystemExit):
+        parse_atlan_yaml.parse()
+
+
+def test_empty_display_name_or_generated_dir_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    pkg = _pkg(display="")
+    _write(tmp_path, {"name": "x", "app_id": "1", "workflow_packages": [pkg]})
+    with pytest.raises(SystemExit):
+        parse_atlan_yaml.parse()
+
+
+# ── top-level required fields ───────────────────────────────────────────────
+
+
+def test_missing_atlan_yaml_name_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, {"app_id": "1"})
+    with pytest.raises(SystemExit):
+        parse_atlan_yaml.parse()
+
+
+def test_unsupported_build_tag_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, {"name": "x", "app_id": "1", "build_tag": "v2"})
+    with pytest.raises(SystemExit):
+        parse_atlan_yaml.parse()
+
+
+def test_missing_atlan_yaml_file_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)  # empty dir, no atlan.yaml
+    with pytest.raises(SystemExit):
+        parse_atlan_yaml.parse()
+
+
+def test_invalid_yaml_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "atlan.yaml").write_text("name: x\n  bad: : indent\n  - unclosed")
+    with pytest.raises(SystemExit):
+        parse_atlan_yaml.parse()

--- a/tests/unit/test_parse_atlan_yaml.py
+++ b/tests/unit/test_parse_atlan_yaml.py
@@ -51,9 +51,7 @@ def test_parse_minimal_atlan_yaml(tmp_path, monkeypatch):
     assert out["dockerfile"] == "./Dockerfile"
     assert out["build_tag"] == "v1"
     assert out["sdk_version"] == ""  # no uv.lock
-    assert (
-        out["workflow_packages"] == ""
-    )  # absent → consumers fall back to argo_package_names
+    assert out["workflows"] == ""  # absent → consumers fall back to argo_package_names
     assert out["deploy_config"] == ""
 
 
@@ -83,7 +81,7 @@ def test_parse_reads_sdk_version_from_uv_lock(tmp_path, monkeypatch):
     assert out["sdk_version"] == "0.1.10"
 
 
-# ── workflow_packages happy path ────────────────────────────────────────────
+# ── workflows happy path ────────────────────────────────────────────
 
 
 def _pkg(
@@ -99,18 +97,18 @@ def _pkg(
     }
 
 
-def test_workflow_packages_round_trips_as_compact_json(tmp_path, monkeypatch):
+def test_workflows_round_trips_as_compact_json(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     pkgs = [_pkg(), _pkg("teradata-miner", "Teradata Miner", "miner", "miner")]
-    _write(tmp_path, {"name": "teradata", "app_id": "1", "workflow_packages": pkgs})
+    _write(tmp_path, {"name": "teradata", "app_id": "1", "workflows": pkgs})
     out = parse_atlan_yaml.parse()
     # Single line — required because the workflow appends to $GITHUB_OUTPUT
     # via simple key=value (multiline values would need delimiter syntax).
-    assert "\n" not in out["workflow_packages"]
-    assert json.loads(out["workflow_packages"]) == pkgs
+    assert "\n" not in out["workflows"]
+    assert json.loads(out["workflows"]) == pkgs
 
 
-# ── workflow_packages validation rules (must mirror GM Pydantic) ────────────
+# ── workflows validation rules (must mirror GM Pydantic) ────────────
 
 
 @pytest.mark.parametrize(
@@ -124,7 +122,7 @@ def test_kebab_case_name_rejected(tmp_path, monkeypatch, bad_name):
         {
             "name": "x",
             "app_id": "1",
-            "workflow_packages": [_pkg(name=bad_name)],
+            "workflows": [_pkg(name=bad_name)],
         },
     )
     with pytest.raises(AtlanYamlError):
@@ -139,7 +137,7 @@ def test_type_must_be_in_closed_set(tmp_path, monkeypatch, bad_type):
     monkeypatch.chdir(tmp_path)
     pkg = _pkg()
     pkg["type"] = bad_type
-    _write(tmp_path, {"name": "x", "app_id": "1", "workflow_packages": [pkg]})
+    _write(tmp_path, {"name": "x", "app_id": "1", "workflows": [pkg]})
     with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
 
@@ -151,7 +149,7 @@ def test_duplicate_names_rejected(tmp_path, monkeypatch):
         {
             "name": "x",
             "app_id": "1",
-            "workflow_packages": [_pkg(), _pkg()],  # two identical names
+            "workflows": [_pkg(), _pkg()],  # two identical names
         },
     )
     with pytest.raises(AtlanYamlError):
@@ -165,16 +163,16 @@ def test_missing_required_keys_rejected(tmp_path, monkeypatch):
         {
             "name": "x",
             "app_id": "1",
-            "workflow_packages": [{"name": "x", "type": "connector"}],
+            "workflows": [{"name": "x", "type": "connector"}],
         },
     )
     with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
 
 
-def test_workflow_packages_must_be_list(tmp_path, monkeypatch):
+def test_workflows_must_be_list(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    _write(tmp_path, {"name": "x", "app_id": "1", "workflow_packages": {"name": "x"}})
+    _write(tmp_path, {"name": "x", "app_id": "1", "workflows": {"name": "x"}})
     with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
 
@@ -182,7 +180,7 @@ def test_workflow_packages_must_be_list(tmp_path, monkeypatch):
 def test_empty_display_name_or_generated_dir_rejected(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     pkg = _pkg(display="")
-    _write(tmp_path, {"name": "x", "app_id": "1", "workflow_packages": [pkg]})
+    _write(tmp_path, {"name": "x", "app_id": "1", "workflows": [pkg]})
     with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
 

--- a/tests/unit/test_parse_atlan_yaml.py
+++ b/tests/unit/test_parse_atlan_yaml.py
@@ -27,6 +27,8 @@ sys.modules["parse_atlan_yaml"] = parse_atlan_yaml
 assert _spec and _spec.loader
 _spec.loader.exec_module(parse_atlan_yaml)  # type: ignore[union-attr]
 
+AtlanYamlError = parse_atlan_yaml.AtlanYamlError
+
 
 def _write(tmp_path: Path, payload: dict, name: str = "atlan.yaml") -> Path:
     p = tmp_path / name
@@ -125,7 +127,7 @@ def test_kebab_case_name_rejected(tmp_path, monkeypatch, bad_name):
             "workflow_packages": [_pkg(name=bad_name)],
         },
     )
-    with pytest.raises(SystemExit):
+    with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
 
 
@@ -138,7 +140,7 @@ def test_type_must_be_in_closed_set(tmp_path, monkeypatch, bad_type):
     pkg = _pkg()
     pkg["type"] = bad_type
     _write(tmp_path, {"name": "x", "app_id": "1", "workflow_packages": [pkg]})
-    with pytest.raises(SystemExit):
+    with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
 
 
@@ -152,7 +154,7 @@ def test_duplicate_names_rejected(tmp_path, monkeypatch):
             "workflow_packages": [_pkg(), _pkg()],  # two identical names
         },
     )
-    with pytest.raises(SystemExit):
+    with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
 
 
@@ -166,14 +168,14 @@ def test_missing_required_keys_rejected(tmp_path, monkeypatch):
             "workflow_packages": [{"name": "x", "type": "connector"}],
         },
     )
-    with pytest.raises(SystemExit):
+    with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
 
 
 def test_workflow_packages_must_be_list(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     _write(tmp_path, {"name": "x", "app_id": "1", "workflow_packages": {"name": "x"}})
-    with pytest.raises(SystemExit):
+    with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
 
 
@@ -181,7 +183,7 @@ def test_empty_display_name_or_generated_dir_rejected(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     pkg = _pkg(display="")
     _write(tmp_path, {"name": "x", "app_id": "1", "workflow_packages": [pkg]})
-    with pytest.raises(SystemExit):
+    with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
 
 
@@ -191,25 +193,25 @@ def test_empty_display_name_or_generated_dir_rejected(tmp_path, monkeypatch):
 def test_missing_atlan_yaml_name_rejected(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     _write(tmp_path, {"app_id": "1"})
-    with pytest.raises(SystemExit):
+    with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
 
 
 def test_unsupported_build_tag_rejected(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     _write(tmp_path, {"name": "x", "app_id": "1", "build_tag": "v2"})
-    with pytest.raises(SystemExit):
+    with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
 
 
 def test_missing_atlan_yaml_file_rejected(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)  # empty dir, no atlan.yaml
-    with pytest.raises(SystemExit):
+    with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
 
 
 def test_invalid_yaml_rejected(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     (tmp_path / "atlan.yaml").write_text("name: x\n  bad: : indent\n  - unclosed")
-    with pytest.raises(SystemExit):
+    with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()

--- a/tests/unit/test_parse_atlan_yaml.py
+++ b/tests/unit/test_parse_atlan_yaml.py
@@ -1,6 +1,6 @@
 """Unit tests for .github/scripts/parse_atlan_yaml.py.
 
-The parser is invoked from the Build & Publish reusable workflow to read
+The parser is invoked from the Build & Publish reusable entrypoint to read
 ``atlan.yaml`` (and optionally ``uv.lock``) and emit values that downstream
 jobs forward to GHCR + the marketplace publish endpoint. Validation here
 fails fast at CI time with annotated errors — these tests pin the rules
@@ -51,7 +51,9 @@ def test_parse_minimal_atlan_yaml(tmp_path, monkeypatch):
     assert out["dockerfile"] == "./Dockerfile"
     assert out["build_tag"] == "v1"
     assert out["sdk_version"] == ""  # no uv.lock
-    assert out["workflows"] == ""  # absent → consumers fall back to argo_package_names
+    assert (
+        out["entrypoints"] == ""
+    )  # absent → consumers fall back to argo_package_names
     assert out["deploy_config"] == ""
 
 
@@ -81,7 +83,7 @@ def test_parse_reads_sdk_version_from_uv_lock(tmp_path, monkeypatch):
     assert out["sdk_version"] == "0.1.10"
 
 
-# ── workflows happy path ────────────────────────────────────────────
+# ── entrypoints happy path ────────────────────────────────────────────
 
 
 def _pkg(
@@ -97,18 +99,18 @@ def _pkg(
     }
 
 
-def test_workflows_round_trips_as_compact_json(tmp_path, monkeypatch):
+def test_entrypoints_round_trips_as_compact_json(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     pkgs = [_pkg(), _pkg("teradata-miner", "Teradata Miner", "miner", "miner")]
-    _write(tmp_path, {"name": "teradata", "app_id": "1", "workflows": pkgs})
+    _write(tmp_path, {"name": "teradata", "app_id": "1", "entrypoints": pkgs})
     out = parse_atlan_yaml.parse()
-    # Single line — required because the workflow appends to $GITHUB_OUTPUT
+    # Single line — required because the entrypoint appends to $GITHUB_OUTPUT
     # via simple key=value (multiline values would need delimiter syntax).
-    assert "\n" not in out["workflows"]
-    assert json.loads(out["workflows"]) == pkgs
+    assert "\n" not in out["entrypoints"]
+    assert json.loads(out["entrypoints"]) == pkgs
 
 
-# ── workflows validation rules (must mirror GM Pydantic) ────────────
+# ── entrypoints validation rules (must mirror GM Pydantic) ────────────
 
 
 @pytest.mark.parametrize(
@@ -122,7 +124,7 @@ def test_kebab_case_name_rejected(tmp_path, monkeypatch, bad_name):
         {
             "name": "x",
             "app_id": "1",
-            "workflows": [_pkg(name=bad_name)],
+            "entrypoints": [_pkg(name=bad_name)],
         },
     )
     with pytest.raises(AtlanYamlError):
@@ -137,7 +139,7 @@ def test_type_must_be_in_closed_set(tmp_path, monkeypatch, bad_type):
     monkeypatch.chdir(tmp_path)
     pkg = _pkg()
     pkg["type"] = bad_type
-    _write(tmp_path, {"name": "x", "app_id": "1", "workflows": [pkg]})
+    _write(tmp_path, {"name": "x", "app_id": "1", "entrypoints": [pkg]})
     with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
 
@@ -149,7 +151,7 @@ def test_duplicate_names_rejected(tmp_path, monkeypatch):
         {
             "name": "x",
             "app_id": "1",
-            "workflows": [_pkg(), _pkg()],  # two identical names
+            "entrypoints": [_pkg(), _pkg()],  # two identical names
         },
     )
     with pytest.raises(AtlanYamlError):
@@ -163,16 +165,16 @@ def test_missing_required_keys_rejected(tmp_path, monkeypatch):
         {
             "name": "x",
             "app_id": "1",
-            "workflows": [{"name": "x", "type": "connector"}],
+            "entrypoints": [{"name": "x", "type": "connector"}],
         },
     )
     with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
 
 
-def test_workflows_must_be_list(tmp_path, monkeypatch):
+def test_entrypoints_must_be_list(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    _write(tmp_path, {"name": "x", "app_id": "1", "workflows": {"name": "x"}})
+    _write(tmp_path, {"name": "x", "app_id": "1", "entrypoints": {"name": "x"}})
     with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
 
@@ -180,7 +182,7 @@ def test_workflows_must_be_list(tmp_path, monkeypatch):
 def test_empty_display_name_or_generated_dir_rejected(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     pkg = _pkg(display="")
-    _write(tmp_path, {"name": "x", "app_id": "1", "workflows": [pkg]})
+    _write(tmp_path, {"name": "x", "app_id": "1", "entrypoints": [pkg]})
     with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
 


### PR DESCRIPTION
> **Work in progress** — part of the Multi-Manifest & Multi-Tile Native App effort. Paired with atlanhq/global-marketplace#101 (GM storage + catalog side). Runtime changes (tile-aware manifest serving) are in a separate PR [#1307](https://github.com/atlanhq/application-sdk/pull/1307) targeting refactor-v3.

## Summary

Extends the Build & Publish reusable workflow to parse, validate, and forward `workflow_packages` from `atlan.yaml` to the marketplace publish endpoint.

- **`prepare` job**: parses `workflow_packages` from `atlan.yaml` via [.github/scripts/parse_atlan_yaml.py](https://github.com/atlanhq/application-sdk/blob/feat/workflow-packages-publish/.github/scripts/parse_atlan_yaml.py). Validates each entry has `name` (kebab-case), `display_name` (non-empty), `type` (closed set), `generated_dir` (non-empty); rejects duplicate names. Emits the list as a single-line JSON output.
- **`publish` job**: includes `"workflow_packages": [...]` in the `curl` POST body to `/api/service/marketplace/publish` when non-empty.
- Parser extracted to a real Python module (217 lines, 23 unit tests). The workflow sparse-checks-out only `.github/scripts/` from the SDK at `github.workflow_sha`, then runs the script.

## Backwards-compat

`workflow_packages` absent from `atlan.yaml` → field omitted from publish payload → GM stores NULL → consumers fall back to `App.argo_package_names`. Zero changes for any existing app.

## Test plan

- [x] Workflow YAML syntax validated locally
- [x] Parser unit tests — 23 tests covering happy path, every validation rule, top-level required-field gating
- [ ] Run against a test app with multi-tile `atlan.yaml`; confirm publish body contains `workflow_packages`
- [ ] Run against existing single-package app (e.g. oracle); confirm no `workflow_packages` in body