### PR TITLE
feat: add incremental-migrate skill for generic incremental extraction

### DIFF
--- a/application_sdk/common/incremental/skills/incremental-migrate/SKILL.md
+++ b/application_sdk/common/incremental/skills/incremental-migrate/SKILL.md
@@ -1,0 +1,493 @@
+---
+name: incremental-migrate
+description: >
+  Orchestrates adding incremental extraction to any Atlan connector app.
+  Handles both SQL connectors (delegates to SDK's implement-incremental-extraction
+  skill) and REST/GraphQL connectors (uses the Tableau pattern as reference).
+  Runs as isolated sub-agents: reconnaissance -> feasibility -> implementation
+  (branched by type) -> metrics -> test design -> test implementation -> iterative
+  test-fix loop. Trigger with "Add incremental extraction to @atlan/<connector>".
+metadata:
+  author: platform-engineering
+  version: "1.0.0"
+  category: connector-incremental
+  keywords:
+    - incremental-extraction
+    - application-sdk
+    - metadata-extraction
+    - temporal-workflows
+    - sql-connector
+    - rest-connector
+    - graphql-connector
+---
+
+# Incremental Extraction Migration -- Orchestrator
+
+## Trigger pattern
+
+```
+Add incremental extraction to @atlan/<connector>
+```
+
+Run this from inside the connector repo. `app_path` is resolved from `pwd`.
+
+---
+
+## Step 1 -- Parse inputs
+
+From the trigger prompt and environment, extract:
+
+| Variable | Source | Example |
+|---|---|---|
+| `connector` | slug from `@atlan/<connector>` | `sigma` |
+| `ConnectorName` | title-case of slug | `Sigma` |
+| `app_path` | current working directory (`pwd`) | `/Users/you/repos/atlan-sigma-app` |
+| `sdk_skills_dir` | resolve from app venv: `find <app_path>/.venv -path "*/incremental/skills" -type d` | `<app_path>/.venv/.../application_sdk/common/incremental/skills` |
+| `refs_dir` | `<sdk_skills_dir>/incremental-migrate/references` | (resolved from sdk_skills_dir) |
+| `sdk_sql_skill_dir` | `<sdk_skills_dir>/implement-incremental-extraction` | (sibling skill in SDK) |
+| `sdk_marketplace_skill_dir` | `<sdk_skills_dir>/marketplace-packages-incremental` | (sibling skill in SDK) |
+| `tableau_app_dir` | ask user if not known; check common paths: `~/Atlan/atlan-tableau-app`, `~/Documents/GitHub/atlan-tableau-app` | `/Users/you/Atlan/atlan-tableau-app` |
+| `marketplace_dir` | ask user if not known; check common paths: `~/Documents/GitHub/marketplace-packages`, `~/Atlan/marketplace-packages` | `/Users/you/Documents/GitHub/marketplace-packages` |
+
+Resolve `app_path` first by running `pwd`.
+
+### Pre-flight checks (Brick 0)
+
+Run these in the main session before spawning any sub-agent:
+
+1. Verify `<app_path>/pyproject.toml` exists and contains `atlan-application-sdk`
+2. Run `cd <app_path> && uv sync --all-groups` -- stop if it fails
+3. Run `cd <app_path> && uv run pytest tests/unit/ -x -q 2>/dev/null` and record the baseline test count
+4. Classify connector type:
+   - Run `grep -r "BaseSQLMetadataExtractionActivities\|IncrementalSQLMetadataExtractionActivities" <app_path>/app/`
+   - If matches found: `connector_type = SQL`
+   - Otherwise: `connector_type = REST`
+5. Verify `<sdk_sql_skill_dir>/SKILL.md` exists (already resolved in step 1)
+6. Write `<app_path>/incremental-analysis/connector-type.txt` with the classification
+7. Report classification and baseline to user before proceeding
+
+**Stop if:** no SDK dependency, no `app/activities/`, or existing unit tests fail.
+
+---
+
+## Step 2 -- Sub-agent execution model
+
+Every brick runs as an isolated sub-agent using the `Agent` tool with
+`subagent_type: "general-purpose"`. The main session only:
+- Spawns sub-agents
+- Reads cross-brick outputs from disk to pass forward
+- Tracks completion and reports failures
+
+**Do not execute any brick inline in the main session.**
+
+### Sub-agent prompt template
+
+For every brick, construct the prompt by substituting all `<placeholders>`:
+
+```
+You are a sub-agent implementing **Brick <N> -- <brick-name>** for adding
+incremental extraction to the **<ConnectorName>** connector app.
+
+## Prime Directive -- Safety First
+
+Your goal is to add incremental extraction without breaking existing functionality.
+The full extraction path must remain fully functional when incremental is disabled.
+
+The following are explicitly forbidden:
+- Do NOT delete existing extraction code. Incremental wraps around it.
+- Do NOT auto-enable incremental. Default must be `incremental_enabled=false`.
+- Do NOT persist state before the publish/upload step succeeds.
+- Do NOT pass large data (>100KB) through Temporal activity arguments.
+- Do NOT store single files larger than 50MB on ObjectStore.
+- Do NOT modify the application_sdk package.
+
+Read `<refs_dir>/guardrails.md` before writing any code. Every guardrail
+applies. When in doubt, ask the user.
+
+## Variables
+- connector         = <connector>
+- ConnectorName     = <ConnectorName>
+- connector_type    = <connector_type>    (SQL or REST)
+- app_path          = <app_path>          <- write all output files here
+- refs_dir          = <refs_dir>          <- SDK-bundled reference docs (guardrails, patterns, templates)
+- tableau_app_dir   = <tableau_app_dir>   <- read-only reference app
+- marketplace_dir   = <marketplace_dir>   <- read-only reference repo
+
+## Cross-brick context
+<embed cross-brick context here -- see handoff rules below; omit if N/A>
+
+## Your task
+<embed the brick-specific instructions here>
+```
+
+### Cross-brick handoff rules
+
+| After brick | Read from disk | Pass to bricks |
+|---|---|---|
+| Brick 1 (Recon) | `incremental-analysis/reconnaissance.md` | 2 |
+| Brick 2 (Feasibility) | `incremental-analysis/feasibility-report.md` | All implementation bricks |
+| Brick 3R (API Design) | `incremental-analysis/api-change-detection.md` | 4R, 5R, 6R, 7R |
+| Brick B (Test Design) | `incremental-analysis/test-plan.md` | C |
+| All others | Sub-agents read disk themselves | -- |
+
+---
+
+## Step 3 -- Run bricks in sequence
+
+Execute each brick fully before starting the next. Halt on failure and report.
+
+---
+
+### Brick 1 -- Reconnaissance
+
+1. Spawn a sub-agent with the prompt template. The brick-specific instructions:
+
+   ```
+   Read every file in <app_path>/app/ (activities, workflows, extracts, sql,
+   client.py, models.py, handler.py, transformers). Produce a structured report
+   at <app_path>/incremental-analysis/reconnaissance.md containing:
+
+   1. **Entity Type Inventory** -- every entity type extracted, with parent-child
+      relationships (e.g., "Workbook -> Worksheet -> Field")
+   2. **API / Query Map** -- every API call or SQL query, its purpose, and what
+      it returns. Include request shapes for REST and query text for SQL.
+   3. **Timestamp Fields** -- per entity type, list any updatedAt/createdAt/
+      lastModifiedTime/LAST_DDL_TIME fields available from the API or DB catalog
+   4. **Cost Structure** -- which extraction steps are cheap (summary/list APIs)
+      vs expensive (detail APIs with N+1 queries, nested field extraction)
+   5. **Current Workflow Sequence** -- numbered list of all activities in execution
+      order, noting which are conditional
+   ```
+
+2. Verify `<app_path>/incremental-analysis/reconnaissance.md` exists.
+
+---
+
+### Brick 2 -- Feasibility Analysis
+
+1. Read `<refs_dir>/feasibility-checklist.md` into memory.
+2. Read `<app_path>/incremental-analysis/reconnaissance.md` into memory.
+3. Spawn a sub-agent with both documents embedded. The brick-specific instructions:
+
+   ```
+   Using the reconnaissance report and the feasibility checklist, produce
+   <app_path>/incremental-analysis/feasibility-report.md containing:
+
+   1. **Per-entity feasibility verdict** -- for each entity type, evaluate against
+      the 5 non-negotiable rules. Mark PASS or FAIL with reasoning.
+   2. **Incremental strategy** -- server-side filtering (SQL WHERE) vs client-side
+      diffing (fetch all, compare updatedAt in code)
+   3. **What to make incremental** -- which entity types are expensive enough to
+      justify incremental, and which should remain full-extraction (cheap parents)
+   4. **Risk register** -- one risk per identified concern, scored by likelihood x
+      impact (1-5 each), with mitigation strategy
+   5. **State artifacts needed** -- marker only? marker + entity list? marker +
+      entity list + cache + backfill extracts?
+   6. **Marker strategy** -- SDK standard marker, prepone buffer (default 1h),
+      configurable via marker_offset_hours
+   7. **False-positive patterns** -- any scenarios where updatedAt bumps without
+      metadata change (data refreshes, no-op publishes, etc.)
+   8. **Cascade requirements** -- any parent-child relationships where parent
+      changes don't propagate timestamps to children
+   9. **Delete detection strategy** -- previous_ids vs current_ids comparison
+   ```
+
+4. Verify `<app_path>/incremental-analysis/feasibility-report.md` exists.
+5. Read the feasibility report and show it to the user.
+6. **PAUSE -- wait for explicit user confirmation before continuing.**
+   The user must confirm: connector type, feasibility verdicts, strategy, and risks.
+
+---
+
+### BRANCH -- Read `connector_type` and take the appropriate path
+
+---
+
+## SQL Path
+
+### Brick 3S -- SDK Delegation
+
+1. Read `<sdk_sql_skill_dir>/SKILL.md` (the SDK's implement-incremental-extraction
+   SKILL.md) into memory. If the SDK skill doesn't exist, stop and tell the user
+   to upgrade the SDK.
+2. Read all files under `<sdk_sql_skill_dir>/references/`.
+3. Read `<app_path>/incremental-analysis/feasibility-report.md` into memory.
+4. Spawn a sub-agent with the full SDK skill text + all reference docs + feasibility
+   report embedded. The sub-agent follows the SDK skill's own instructions to:
+   - Create `app/sql/extract_table_incremental.sql`
+   - Create `app/sql/extract_column_incremental.sql`
+   - Modify the activities class to inherit from `IncrementalSQLMetadataExtractionActivities`
+   - Implement `build_incremental_column_sql()`
+   - Modify the workflow class to inherit from `IncrementalSQLMetadataExtractionWorkflow`
+   - Update models and dependencies
+5. Verify the SQL files and modified classes exist.
+
+### Brick 4S -- Marketplace Docs
+
+1. Read `<sdk_marketplace_skill_dir>/SKILL.md` for the marketplace-packages change pattern.
+2. Spawn a sub-agent to produce `<app_path>/incremental-analysis/marketplace-changes.md`
+   documenting what YAML parameters to add to the Argo configmap. The sub-agent reads
+   `<marketplace_dir>/packages/atlan/<connector>/` for the current template structure.
+3. Tell the user: "Marketplace changes documented -- apply them manually in the
+   marketplace-packages repo."
+
+**Skip to Brick A (Metrics).**
+
+---
+
+## REST/GraphQL Path
+
+### Brick 3R -- API Change-Detection Design
+
+1. Read `<refs_dir>/rest-incremental-pattern.md` into memory.
+2. Read `<app_path>/incremental-analysis/feasibility-report.md` into memory.
+3. Read `<tableau_app_dir>/app/extracts/incremental.py` into memory (reference).
+4. Spawn a sub-agent. The brick-specific instructions:
+
+   ```
+   Using the feasibility report, the REST incremental pattern reference, and the
+   Tableau incremental.py as a code reference, produce
+   <app_path>/incremental-analysis/api-change-detection.md containing:
+
+   1. Per entity type: which API field serves as the change marker (updatedAt,
+      lastModifiedTime, etc.)
+   2. Server-side vs client-side filtering decision per entity
+   3. False-positive patterns with detection logic (e.g., if updatedAt ==
+      lastRefreshTime -> skip)
+   4. Cascade requirements with detection logic (parent updated -> find children
+      referencing that parent via upstreamX fields)
+   5. Delete detection strategy (previous_ids - current_ids, source of each set)
+   6. ID format map -- which API surface returns which ID format, and how to
+      normalize if multiple formats exist
+   ```
+
+5. Verify `<app_path>/incremental-analysis/api-change-detection.md` exists.
+
+### Brick 4R -- Detection Logic Implementation
+
+1. Read `<app_path>/incremental-analysis/api-change-detection.md` into memory.
+2. Read `<refs_dir>/guardrails.md` into memory.
+3. Read `<tableau_app_dir>/app/extracts/incremental.py` into memory (reference).
+4. Spawn a sub-agent. Instructions: implement `<app_path>/app/extracts/incremental.py`
+   with detection functions per the API change-detection design. Include:
+   - `detect_updated_<entity>()` per entity type needing incremental
+   - False-positive filter functions (if identified)
+   - `cascade_<parent>_to_<child>()` (if cascade required)
+   - `detect_deleted_<entity>()` for delete detection
+   - Helper functions: `load_<entity>_records()`, `batch_ids()`
+5. Verify `<app_path>/app/extracts/incremental.py` exists.
+
+### Brick 5R -- State Management
+
+1. Read `<app_path>/incremental-analysis/api-change-detection.md` into memory.
+2. Read `<tableau_app_dir>/app/activities/metadata_extraction.py` into memory (reference
+   -- particularly `read_marker`, `read_previous_ds_list`, `persist_incremental_state`).
+3. Read `<refs_dir>/rest-incremental-pattern.md` Section 2 (State Management Template).
+4. Spawn a sub-agent. Instructions: add new activities and model fields.
+
+   **New activities** in `<app_path>/app/activities/metadata_extraction.py`:
+   - `read_marker` -- calls SDK `fetch_marker_from_storage` with configurable prepone
+   - `read_previous_<entity>_list` -- downloads previous scope from S3 via ObjectStore
+   - `persist_incremental_state` -- writes marker + entity lists + cache to S3
+     (GUARD-IMPL-01: this MUST be the last activity, after upload_to_atlan)
+
+   **Modified** `<app_path>/app/models.py`:
+   - `incremental_enabled: bool = False`
+   - `force_full_extraction: bool = False`
+   - `marker_offset_hours: int = 1`
+   - Kebab-case mappings in `_map_kebab_keys` if the connector uses them
+
+5. Verify the new activities and model fields exist.
+
+### Brick 6R -- Backfill and Chunked Storage
+
+1. Read `<app_path>/incremental-analysis/feasibility-report.md` (state artifacts section).
+2. Read `<tableau_app_dir>/app/activities/metadata_extraction.py` (backfill + chunked
+   storage sections -- particularly `backfill_unchanged_fields`, `_write_chunked_field_extracts`).
+3. Read `<refs_dir>/rest-incremental-pattern.md` Section 3 (Backfill Template).
+4. Spawn a sub-agent. Instructions:
+   - Add `backfill_unchanged_<entity>` activity that restores previous data for unchanged
+     entities from S3 using the v2 chunked index pattern
+   - Add chunked write logic if estimated state > 50MB
+   - Create `<app_path>/app/extracts/incremental_cache.py` if per-entity field snapshots
+     are needed (based on feasibility report)
+   - Read `<refs_dir>/guardrails.md` GUARD-IMPL-05/06 for chunk size rules
+5. Verify the backfill activity exists.
+
+### Brick 7R -- Workflow Wiring
+
+1. Read all implementation files from Bricks 4R-6R.
+2. Read `<tableau_app_dir>/app/workflows/metadata_extraction.py` (reference for
+   conditional branching, activity ordering, short-circuit logic).
+3. Read `<refs_dir>/rest-incremental-pattern.md` Section 5 (Workflow Wiring Template).
+4. Spawn a sub-agent. Instructions: modify `<app_path>/app/workflows/metadata_extraction.py`:
+   - Parse `incremental_enabled` and `force_full_extraction` from workflow args
+   - Add conditional branch after parent entity extraction:
+     - `read_marker` (skip if incremental disabled)
+     - `read_previous_<entity>_list` (skip if no marker found)
+     - `detect_updated_<entities>` (compare against cutoff)
+     - Modify expensive extraction to use only changed entity IDs
+     - `backfill_unchanged_<entities>` after fresh extraction
+   - Add short-circuit: if 0 entities changed, skip expensive extraction entirely
+   - Add `persist_incremental_state` AFTER `upload_to_atlan` (GUARD-IMPL-01)
+   - Register all new activities in `get_activities()`
+   - Update `<app_path>/app/templates/workflow.json` to add incremental UI toggles
+5. Verify the workflow modifications.
+
+### Brick 8R -- Marketplace Docs
+
+Read `<sdk_marketplace_skill_dir>/SKILL.md` for the marketplace-packages change pattern.
+
+Same as Brick 4S. Produce `marketplace-changes.md`, tell user to apply manually.
+
+---
+
+## Converged Path (both SQL and REST rejoin here)
+
+### Brick A -- Metrics Instrumentation
+
+1. Read `<refs_dir>/metrics-template.md` into memory.
+2. Spawn a sub-agent. Instructions: add Segment metrics to the connector following
+   the metrics template. Use `get_metrics().record_metric()` directly -- no custom
+   sinks or decorators. Add calls at: detection, backfill, filter, and workflow-level
+   emission points. Prefix all metrics with `<connector>_`.
+3. Verify metrics calls exist in the activities file.
+4. **PAUSE -- show the user what was implemented and wait for confirmation** that
+   the implementation phase is complete before moving to testing.
+
+### Brick B -- Test Design
+
+1. Read `<refs_dir>/test-scenario-template.md` into memory.
+2. Read `<app_path>/incremental-analysis/feasibility-report.md` into memory.
+3. Read all implementation code in `<app_path>/app/extracts/incremental*.py` and
+   `<app_path>/app/activities/metadata_extraction.py`.
+4. Spawn a sub-agent. Instructions:
+
+   ```
+   Design a test plan at <app_path>/incremental-analysis/test-plan.md. Derive ALL
+   test scenarios from the feasibility report's risk register and the implemented
+   code -- do NOT copy test cases from any other connector.
+
+   For each file in app/extracts/incremental*.py, identify every branch, edge case,
+   and error path. Generate unit test cases for each.
+
+   For the workflow, generate E2E scenarios from:
+   - Standard lifecycle categories (from the test-scenario-template)
+   - One scenario per confirmed risk in the feasibility report
+   - State management scenarios (always apply)
+   - Filter scope scenarios (only if connector has scope filters)
+
+   Express all scenarios in terms of THIS connector's entities, APIs, and data model.
+   ```
+
+5. Verify `<app_path>/incremental-analysis/test-plan.md` exists.
+6. Read and show the test plan to the user.
+7. **PAUSE -- wait for explicit user confirmation** that the test plan is sufficient.
+
+### Brick C -- Test Implementation (parallel)
+
+1. Read `<app_path>/incremental-analysis/test-plan.md` into memory.
+2. Read existing test patterns from `<app_path>/tests/unit/` (conftest, fixtures, mocks).
+3. Spawn **two sub-agents in parallel**:
+
+   **Sub-agent A -- Unit Tests:**
+   ```
+   Implement unit tests from the test plan. Read every file in
+   <app_path>/app/extracts/incremental*.py and each new activity in
+   <app_path>/app/activities/metadata_extraction.py.
+   Match the project's existing test conventions (fixture style, mock patterns).
+   Mock the API client and file I/O -- no external dependencies.
+   Write to: tests/unit/extracts/test_incremental.py (and test_incremental_cache.py
+   if a cache module exists).
+   ```
+
+   **Sub-agent B -- E2E Tests:**
+   ```
+   Implement E2E tests from the test plan. Read the workflow file and models.
+   Match existing E2E patterns in <app_path>/tests/e2e/ if they exist.
+   Use workflow runner pattern (mock Temporal or invoke locally).
+   Write to: tests/e2e/test_incremental_*.py per scenario group, conftest.py,
+   and helpers/ as needed.
+   ```
+
+4. Verify test files exist for both unit and E2E.
+
+### Brick D -- Test Execution and Fix Loop
+
+This brick is managed directly by the orchestrator, NOT as a single sub-agent.
+
+```
+iteration = 0
+max_iterations = 5
+prev_fail_count = 999999
+stall_count = 0
+
+WHILE iteration < max_iterations:
+    iteration += 1
+    Log: "=== Test iteration {iteration}/{max_iterations} ==="
+
+    # Phase A: Run tests (2 parallel sub-agents)
+    Spawn Agent A: cd <app_path> && uv run pytest tests/unit/ -v --tb=short 2>&1
+    Spawn Agent B: cd <app_path> && uv run pytest tests/e2e/ -v --tb=short 2>&1
+        (skip Agent B if no e2e tests exist or no test infra available)
+
+    # Phase B: Collect and analyze results
+    Parse pass/fail counts from both outputs.
+    total_failures = unit_failures + e2e_failures
+
+    IF total_failures == 0:
+        Log: "All tests pass after {iteration} iteration(s)."
+        BREAK
+
+    IF total_failures >= prev_fail_count:
+        stall_count += 1
+    ELSE:
+        stall_count = 0
+
+    IF stall_count >= 2:
+        Log: "Test loop stalled -- no improvement for 2 consecutive iterations."
+        Report remaining failures to user.
+        BREAK
+
+    prev_fail_count = total_failures
+
+    # Phase C: Fix failures (1 sub-agent per failing category)
+    For each category (unit, e2e) with failures:
+        Spawn a sub-agent with:
+        - The full pytest output (error messages, tracebacks)
+        - The source file being tested
+        - The test file
+        - Instruction: "Analyze each failure. If the test expectation is wrong
+          (doesn't match the implemented behavior), fix the test. If the
+          implementation has a bug (doesn't match the feasibility report's
+          design), fix the source code. Fix one issue at a time. Read
+          <refs_dir>/guardrails.md before making any source changes."
+
+    # Phase D: Verify compilation
+    Run: cd <app_path> && uv run python -c "import app" 2>&1
+    If import fails, spawn a sub-agent to fix the syntax error.
+```
+
+---
+
+## Step 4 -- Final report
+
+After all bricks complete, output a summary:
+
+```
+Incremental extraction added: atlan-<connector>-app
+  Connector type: <SQL | REST>
+  Entities made incremental: <list>
+  Entities kept full: <list>
+  New files created: <list>
+  Files modified: <list>
+  Test results: <N> unit tests, <M> e2e tests, all passing
+  Risks: <count> identified, all mitigated
+  Marketplace changes: see incremental-analysis/marketplace-changes.md
+
+Next steps:
+  1. Review the code changes and create a PR
+  2. Apply marketplace-packages changes from marketplace-changes.md
+  3. Test on a staging tenant with incremental_enabled=true
+  4. Ring-release: internal -> beta -> GA
+```

--- a/application_sdk/common/incremental/skills/incremental-migrate/references/feasibility-checklist.md
+++ b/application_sdk/common/incremental/skills/incremental-migrate/references/feasibility-checklist.md
@@ -1,0 +1,256 @@
+# Incremental Extraction Feasibility Checklist
+
+Use this checklist to determine whether a connector's source system supports
+reliable incremental extraction BEFORE writing any code. If any of the five
+non-negotiable rules fails, incremental extraction is not feasible for that
+source (or requires a fundamentally different approach).
+
+---
+
+## Section 1: The 5 Non-Negotiable Rules
+
+### Rule 1: DDL-Only Timestamps
+
+**What it means:** The source system must expose a timestamp that updates ONLY
+when the schema or metadata definition changes (DDL events), NOT when data
+content changes (DML events like INSERT, UPDATE, DELETE on rows).
+
+Atlan connectors extract metadata (table definitions, column types, dashboard
+structures), not data. A timestamp that bumps on every data refresh is useless
+for incremental metadata extraction -- it would flag every entity as "changed"
+on every run.
+
+**How to verify:**
+1. Record the `updatedAt` / `modified_time` / `LAST_DDL_TIME` for an entity
+2. Insert or update DATA in that entity (e.g., add rows to a table, refresh
+   a dashboard's data extract)
+3. Re-read the timestamp
+4. If the timestamp changed, this is a DML timestamp -- NOT suitable
+
+**Disqualification:** If the only available timestamp reflects data changes
+(DML), incremental extraction will produce false positives on every run,
+offering no benefit over full extraction. Either find a DDL-specific
+timestamp or mark the connector as incremental-ineligible.
+
+### Rule 2: Right Granularity
+
+**What it means:** The timestamp must exist at the same granularity level as
+the entities you want to detect changes for.
+
+- **SQL connectors:** Need table-level timestamps (one timestamp per table)
+- **REST connectors:** Need entity-level timestamps (one per workbook,
+  dashboard, datasource, etc.)
+
+A schema-level timestamp (one timestamp for the entire schema/database) is
+too coarse -- any change to any table marks ALL tables as changed. A row-level
+timestamp is irrelevant -- it tracks data changes, not metadata.
+
+**How to verify:**
+1. Change entity A (e.g., add a column to Table A)
+2. Check entity B's timestamp (e.g., Table B in the same schema)
+3. If entity B's timestamp also changed, the granularity is too coarse
+
+**Disqualification:** If the finest available granularity is schema-level or
+database-level, incremental extraction will over-fetch on every run. This may
+still be useful if the schema contains thousands of tables and changes are
+rare, but the efficiency gain is limited.
+
+### Rule 3: Covers All DDL Events
+
+**What it means:** The timestamp must update for ALL metadata-changing
+operations, not just a subset.
+
+Required coverage:
+- `CREATE TABLE` / create entity
+- `ALTER TABLE` (add column, drop column, rename column, change type)
+- `DROP TABLE` / delete entity
+- Rename operations
+- Permission/ownership changes (if the connector extracts these)
+
+**How to verify:**
+For each DDL operation above:
+1. Record the timestamp
+2. Perform the operation
+3. Verify the timestamp updated
+
+**Disqualification:** If `ALTER TABLE ADD COLUMN` updates the timestamp but
+`ALTER TABLE DROP COLUMN` does not, incremental extraction will miss dropped
+columns. Partial DDL coverage produces silent data staleness.
+
+### Rule 4: No Silent Schema Changes
+
+**What it means:** No operation that changes the effective schema of an entity
+without updating that entity's timestamp.
+
+This is the most insidious failure mode. Examples:
+- A shared/embedded datasource is modified, which changes the effective schema
+  of all workbooks that use it, but those workbooks' timestamps do not update
+- A view's underlying table is altered, changing the view's effective columns,
+  but the view's timestamp does not change
+- A permission change propagates through a hierarchy without updating child
+  timestamps
+
+**How to verify:**
+1. Identify all INDIRECT change propagation paths in the source system
+2. For each path: make the upstream change, check the downstream timestamp
+3. If the downstream timestamp does not update, this is a silent change
+
+**Disqualification:** Silent schema changes mean incremental extraction will
+serve stale metadata for affected entities. Mitigation options:
+- Implement cascade detection (GUARD-IMPL-13) for known propagation paths
+- Apply a larger prepone buffer to catch delayed updates
+- If propagation paths are too numerous or unpredictable, mark as ineligible
+
+### Rule 5: Deterministic Timestamps
+
+**What it means:** The same event must produce the same timestamp value when
+read multiple times. There must be no jitter, no randomness, and no eventual
+consistency beyond the prepone buffer window.
+
+**How to verify:**
+1. Perform a DDL operation
+2. Read the timestamp immediately
+3. Read the timestamp again 1 second later
+4. Both reads must return the same value
+5. Wait for the eventual consistency window (if documented), read again
+6. The value must still be the same
+
+**Disqualification:** If timestamps are non-deterministic (e.g., they include
+a random component, or they shift during replication), incremental detection
+will produce inconsistent results. A bounded eventual consistency delay
+(e.g., Salesforce's 15-minute delay) is acceptable IF the prepone buffer
+(`marker_offset_hours`) is set to cover it.
+
+---
+
+## Section 2: SQL Connector Pitfalls
+
+### Timestamp Column Coverage Varies by Database
+
+| Database | Column | DDL Coverage | DML Coverage | Notes |
+|---|---|---|---|---|
+| Oracle | `LAST_DDL_TIME` | Full DDL | No DML | Best case |
+| PostgreSQL | `pg_stat_user_tables.last_autoanalyze` | Partial | Partial | Not reliable for DDL |
+| Snowflake | `LAST_ALTERED` | Full DDL | No DML | But see caching note |
+| MySQL | `UPDATE_TIME` | Partial DDL | Includes DML | Not suitable |
+
+### Timezone Mismatches
+
+The incremental marker is stored as UTC ISO 8601 (`2024-01-15T10:30:00Z`).
+Database metadata views may return timestamps in the server's local timezone
+without timezone information. Always normalize to UTC before comparison.
+
+### Schema-Level vs Table-Level Granularity
+
+Some databases only expose schema-level DDL timestamps. If one table in a
+schema of 10,000 tables changes, all 10,000 are flagged as changed. This
+is still better than full extraction if changes are rare, but set
+expectations accordingly.
+
+### System Metadata View Caching
+
+Snowflake's `INFORMATION_SCHEMA` is cached for up to **2 hours**. The
+`ACCOUNT_USAGE` schema has up to **45-minute latency**. Set
+`marker_offset_hours` to at least 2.5 for Snowflake.
+
+### Materialized View Refreshes
+
+Some databases bump the table metadata timestamp when a materialized view
+is refreshed, even if the schema did not change. This produces false
+positives. Identify materialized views and consider excluding them from
+incremental detection or using a secondary check.
+
+---
+
+## Section 3: REST Connector Pitfalls
+
+### API Pagination Changes Between Versions
+
+REST APIs may change pagination behavior between versions (offset-based to
+cursor-based). If the incremental implementation depends on pagination
+stability, pin the API version or implement both pagination strategies.
+
+### Rate Limits on Filtered Queries
+
+Server-side filtering (`?updatedSince=...`) may hit different rate limits
+than unfiltered queries. Some APIs do not index the `updatedAt` field,
+making filtered queries significantly slower than full fetches. Test
+filtered query performance before committing to server-side filtering.
+
+### Eventual Consistency Delays
+
+| Source System | Delay | Impact |
+|---|---|---|
+| Salesforce | ~15 minutes | Set `marker_offset_hours >= 0.5` |
+| Tableau | 5-40 minutes | Set `marker_offset_hours >= 1.0` |
+| Looker | ~5 minutes | Set `marker_offset_hours >= 0.25` |
+
+### Soft Deletes vs Hard Deletes
+
+REST APIs handle deletions in two ways:
+- **Soft delete:** Entity remains in API with `isDeleted=true` or `status=trashed`
+- **Hard delete:** Entity disappears from API responses entirely
+
+For soft deletes, the entity's `updatedAt` changes and incremental detection
+picks it up. For hard deletes, the entity simply vanishes -- detection
+requires comparing the full entity list against the previous run's list
+(GUARD-IMPL-17).
+
+### Extract/Data Refreshes Bumping updatedAt
+
+Some REST sources (notably Tableau) update the `updatedAt` timestamp when a
+data extract is refreshed, even though no metadata changed. This violates
+Rule 1 (DDL-Only Timestamps).
+
+**Mitigation:** Use a secondary check -- compare the entity's structural
+fields (columns, schema hash) between runs. If only `updatedAt` changed but
+structure is identical, skip the entity.
+
+---
+
+## Section 4: GraphQL Connector Pitfalls
+
+### Node Limits on Filtered Queries
+
+GraphQL APIs often impose per-query node limits. Tableau's Metadata API
+limits responses to **20,000 nodes per query**. If the filtered result set
+exceeds this limit, the API silently truncates results. Implement pagination
+or chunked queries for large result sets.
+
+### Indexing Delays
+
+GraphQL metadata APIs often have longer indexing delays than REST APIs.
+Tableau's Metadata API takes **5-40 minutes** to reflect changes. This is
+separate from the REST API's `updatedAt` and must be accounted for
+independently.
+
+### Field Nesting Depth Varies by Entity
+
+Widely-used entities (e.g., a published datasource used by 50 workbooks)
+produce deeply nested response trees. A single entity query can return
+**50+ downstream nodes**. This affects:
+- Query response size (may hit node limits)
+- Incremental detection scope (one change cascades)
+- State artifact size (storing nested relationships)
+
+### updatedAt Semantics Vary Between Entity Types
+
+Published entities and embedded entities may have different `updatedAt`
+semantics in the same GraphQL API:
+- Published datasource: `updatedAt` reflects direct modifications
+- Embedded datasource: `updatedAt` may reflect parent workbook changes
+
+Always verify `updatedAt` semantics per entity type, not per API.
+
+### No Server-Side Incremental API
+
+Many GraphQL APIs provide NO server-side filtering by modification date.
+The only option is:
+1. Fetch the full entity list (with minimal fields)
+2. Compare against the previous run's list client-side
+3. Fetch full details only for changed entities
+
+This "fetch-all-diff-locally" pattern is valid but requires:
+- Persisting the previous entity list (factor into state artifact size)
+- A lightweight "list" query that returns IDs and timestamps only
+- A separate "detail" query for full entity data

--- a/application_sdk/common/incremental/skills/incremental-migrate/references/guardrails.md
+++ b/application_sdk/common/incremental/skills/incremental-migrate/references/guardrails.md
@@ -151,19 +151,25 @@ will hit in production before you get to the refactor.
 These guards govern how incremental code is written. Violating any of these
 produces bugs that are difficult to diagnose in production.
 
-### GUARD-IMPL-01: NEVER Persist Marker Before Publish Succeeds
+### GUARD-IMPL-01: Persist Marker Before Publish ONLY If Backfill Exists
 
-The correct ordering is:
+State persistence timing depends on whether the connector has a backfill mechanism:
 
-1. **Extract** -- fetch data from source
-2. **Process** -- normalize, filter, deduplicate
-3. **Transform** -- convert to Atlan entity format
-4. **Upload to Atlan** -- publish entities via the SDK
-5. **Persist incremental state** -- save the marker ONLY after step 4 succeeds
+**With backfill (e.g., Tableau):** Persisting state before publish is SAFE because
+the next run can reconstruct complete output from fresh + backfilled data. Even if
+publish fails, no data is lost — the next run reproduces the same complete output.
+The Tableau implementation persists before publish for this reason.
 
-If you persist the marker before publish and the publish fails, the next run
-will skip the entities that failed to publish. This is **state corruption**
-and requires manual intervention to fix.
+**Without backfill:** State MUST be persisted ONLY after publish succeeds. If the
+marker is advanced before publish and publish fails, the next run will skip entities
+that were never published. This is **state corruption**.
+
+The correct approach depends on the connector:
+- **Backfill present:** Extract → Process → Transform → Persist state → Upload (safe)
+- **No backfill:** Extract → Process → Transform → Upload → Persist state (required)
+
+When in doubt, persist after publish — it is always safe, just slightly less
+efficient (a failed publish causes re-extraction of the delta on the next run).
 
 ### GUARD-IMPL-02: State Persistence Must Be Atomic Per-Connection
 
@@ -496,11 +502,12 @@ Incremental logic WRAPS AROUND existing extraction code. The full extraction
 path must remain intact and functional. Incremental is an optimization layer
 on top of full extraction, not a replacement.
 
-### REFUSE-04: Do NOT Persist State Before Publish Succeeds
+### REFUSE-04: Do NOT Persist State Before Publish Without Backfill
 
-Restating GUARD-IMPL-01 as a hard refusal. This is the single most dangerous
-mistake in incremental extraction. If an agent proposes persisting state at
-any point before upload_to_atlan completes, REFUSE.
+Restating GUARD-IMPL-01 as a hard refusal. If the connector does NOT have a
+backfill mechanism that can reconstruct complete output from cached data,
+persisting state before publish is forbidden. If backfill exists (like Tableau),
+early persistence is safe and acceptable.
 
 ### REFUSE-05: Do NOT Implement Without force_full_extraction Escape Hatch
 

--- a/application_sdk/common/incremental/skills/incremental-migrate/references/guardrails.md
+++ b/application_sdk/common/incremental/skills/incremental-migrate/references/guardrails.md
@@ -1,0 +1,550 @@
+# Incremental Extraction Guardrails
+
+Comprehensive guardrails for adding incremental extraction to Atlan connector apps.
+These guards prevent known failure modes discovered during the Tableau migration and
+generalized for all connector types (SQL, REST, GraphQL).
+
+---
+
+## Section 1: Pre-Implementation Guards
+
+These guards MUST pass before writing any code. If any guard fails, STOP and
+resolve it before proceeding.
+
+### GUARD-PRE-01: Verify SDK Dependency Version
+
+Check that `atlan-application-sdk` is declared in `pyproject.toml` and that
+the pinned version includes `application_sdk.common.incremental.marker`.
+
+**How to verify:**
+```bash
+grep "atlan-application-sdk" pyproject.toml
+python -c "from application_sdk.common.incremental.marker import IncrementalMarker; print('OK')"
+```
+
+**Failure mode:** If the SDK version predates incremental support, all marker
+imports will fail at runtime. Upgrade the SDK dependency first.
+
+### GUARD-PRE-02: Verify ObjectStore API Surface
+
+Confirm that `ObjectStore` exposes all four methods needed for state persistence:
+- `upload_file` -- write a single artifact
+- `get_content` -- read a single artifact
+- `upload_prefix` -- bulk upload a directory tree
+- `download_prefix` -- bulk download a directory tree
+
+**How to verify:**
+```python
+from application_sdk.common.object_store import ObjectStore
+for method in ["upload_file", "get_content", "upload_prefix", "download_prefix"]:
+    assert hasattr(ObjectStore, method), f"Missing: {method}"
+```
+
+**Failure mode:** Older SDK versions may lack bulk operations. Chunked storage
+patterns require `upload_prefix` / `download_prefix`.
+
+### GUARD-PRE-03: Confirm Dapr gRPC Max Message Size
+
+The hard boundary for any single Dapr gRPC message is **100 MB**. This is NOT
+configurable per-app -- it is an infrastructure constant.
+
+**Implication:** Any file written through ObjectStore that exceeds 100 MB will
+fail with a gRPC error. The working safety margin is **50 MB per file**.
+
+### GUARD-PRE-04: Run `uv sync` and Confirm Clean
+
+Run `uv sync` and verify it exits with code 0. This establishes a clean
+dependency baseline before any modifications.
+
+```bash
+uv sync
+echo "Exit code: $?"
+```
+
+**Failure mode:** If `uv sync` fails before changes, the environment is already
+broken. Fix dependency issues first -- do not layer incremental changes on top
+of a broken environment.
+
+### GUARD-PRE-05: Record Baseline Test Pass Count
+
+Run the existing test suite and record how many tests pass.
+
+```bash
+uv run pytest tests/ -v 2>&1 | tail -5
+```
+
+Record the number of passed/failed/skipped tests. After implementation, the
+pass count must be >= this baseline. Any regression means the incremental
+changes broke existing functionality.
+
+### GUARD-PRE-06: Verify App Starts Without Import Errors
+
+Run the app module to check for import errors:
+
+```bash
+uv run python -c "import app; print('imports OK')"
+```
+
+Some connectors have conditional imports or missing stubs. Identify these
+before adding incremental code so you can distinguish pre-existing issues
+from newly introduced ones.
+
+### GUARD-PRE-07: Classify Connector Type
+
+Determine whether the connector is SQL-based or REST-based by checking the
+base class inheritance chain:
+
+- **SQL connectors:** Inherit from `SQLConnector`, `SQLHandler`, or similar.
+  Incremental detection uses DDL timestamps (e.g., `LAST_DDL_TIME`).
+- **REST connectors:** Inherit from `RESTConnector`, `APIHandler`, or similar.
+  Incremental detection uses `updatedAt` / `modifiedAt` API fields.
+
+This classification determines which feasibility checklist section applies
+and which extraction patterns to use.
+
+### GUARD-PRE-08: Identify Source API Change Detection Mechanism
+
+Before writing any incremental logic, document HOW the source system exposes
+change information:
+
+| Mechanism | Example | Notes |
+|---|---|---|
+| Server-side filtering | `GET /api?updatedSince=...` | Best case -- API does the work |
+| updatedAt fields | Response contains `updatedAt` per entity | Must fetch all, filter client-side |
+| Revision endpoints | `GET /api/revisions?since=...` | Dedicated change feed |
+| Eventual consistency | Timestamp updates are delayed | Must apply prepone buffer |
+
+**Failure mode:** Assuming server-side filtering exists when it does not leads
+to fetching all entities anyway, but with broken filtering logic on top.
+
+### GUARD-PRE-09: Map All API Endpoint ID Formats
+
+Many connectors interact with multiple API surfaces (REST, GraphQL, internal
+IDs). Each surface may use a DIFFERENT identifier for the same entity.
+
+**Document the mapping:**
+- REST API: uses `luid` (locally unique ID)
+- GraphQL API: uses `id` (GraphQL node ID)
+- Database references: uses `name` or `site/project/name` path
+
+**Failure mode (Tableau R5):** Datasource ID format mismatch between REST
+(LUID) and GraphQL (node ID) caused incremental detection to miss updates
+because the ID sets were compared across formats.
+
+### GUARD-PRE-10: Estimate Max State Artifact Size
+
+Calculate the worst-case size of the state artifact that will be persisted
+between runs:
+
+```
+artifact_size = num_entities * avg_bytes_per_entity_record
+```
+
+**If estimated size > 50 MB:** Implement chunked storage from the start.
+Do NOT build monolithic storage and plan to "chunk later" -- the gRPC limit
+will hit in production before you get to the refactor.
+
+---
+
+## Section 2: Implementation Guards
+
+These guards govern how incremental code is written. Violating any of these
+produces bugs that are difficult to diagnose in production.
+
+### GUARD-IMPL-01: NEVER Persist Marker Before Publish Succeeds
+
+The correct ordering is:
+
+1. **Extract** -- fetch data from source
+2. **Process** -- normalize, filter, deduplicate
+3. **Transform** -- convert to Atlan entity format
+4. **Upload to Atlan** -- publish entities via the SDK
+5. **Persist incremental state** -- save the marker ONLY after step 4 succeeds
+
+If you persist the marker before publish and the publish fails, the next run
+will skip the entities that failed to publish. This is **state corruption**
+and requires manual intervention to fix.
+
+### GUARD-IMPL-02: State Persistence Must Be Atomic Per-Connection
+
+All state artifacts must be namespaced under the `connection_qualified_name`.
+Two connections to the same source must maintain independent state.
+
+```
+state_prefix = f"incremental/{connection_qualified_name}/"
+```
+
+**Failure mode:** Shared state between connections causes one connection's
+incremental run to skip entities that only exist in the other connection.
+
+### GUARD-IMPL-03: Never Pass Large ID Lists Through Temporal workflow_args
+
+Temporal has a **2 MB payload limit** on workflow arguments and activity inputs.
+If you need to pass a list of entity IDs between activities:
+
+- Write the list to a local file or ObjectStore
+- Pass the file path (not the data) as the activity argument
+
+**Threshold:** If the serialized argument exceeds **100 KB**, use file I/O.
+
+**Failure mode (Tableau R3):** Passing changed entity ID lists as Temporal
+activity arguments hit the 2 MB limit on large Tableau sites, crashing the
+workflow with a cryptic payload error.
+
+### GUARD-IMPL-04: Activity Return Values Must Be Small
+
+Temporal activity return values have the same 2 MB limit. Activities should
+return counts, flags, and file paths -- never raw data.
+
+```python
+# WRONG
+return {"entities": [<thousands of entity dicts>]}
+
+# RIGHT
+return {"entity_count": 1523, "output_path": "extract/tables.json"}
+```
+
+### GUARD-IMPL-05: All ObjectStore Files Must Stay Under 50 MB
+
+The Dapr gRPC limit is 100 MB. Use a **50 MB safety margin** for all files
+written through ObjectStore.
+
+**How to enforce:**
+- Before writing, check the serialized size
+- If > 50 MB, split into chunks (see GUARD-IMPL-06)
+
+### GUARD-IMPL-06: Never Store Monolithic Cache at Scale
+
+Use chunked storage when the data may exceed 50 MB:
+
+```python
+CHUNK_SIZE = 50 * 1024 * 1024  # 50 MB target
+
+def write_chunked(data: list[dict], prefix: str) -> int:
+    chunk_index = 0
+    current_chunk = []
+    current_size = 0
+    for item in data:
+        item_size = len(json.dumps(item).encode())
+        if current_size + item_size > CHUNK_SIZE and current_chunk:
+            write_chunk(current_chunk, prefix, chunk_index)
+            chunk_index += 1
+            current_chunk = []
+            current_size = 0
+        current_chunk.append(item)
+        current_size += item_size
+    if current_chunk:
+        write_chunk(current_chunk, prefix, chunk_index)
+    return chunk_index + 1
+```
+
+**Failure mode (Tableau R4/R6):** Field-extract files and the metadata cache
+both exceeded the 100 MB gRPC limit on large Tableau sites, crashing extraction.
+
+### GUARD-IMPL-07: Use `suppress_error=True` on State Reads
+
+When reading incremental state artifacts from ObjectStore, always use
+`suppress_error=True`. Missing state is NOT an error -- it means this is
+the first run (or state was cleared) and should trigger full extraction.
+
+```python
+content = await object_store.get_content(
+    state_path, suppress_error=True
+)
+if content is None:
+    # First run or cleared state -- do full extraction
+    return None
+```
+
+### GUARD-IMPL-08: Handle None Markers Gracefully
+
+A `None` marker always means "perform full extraction." Never let a `None`
+marker propagate to code that expects a datetime string.
+
+```python
+if marker is None:
+    logger.info("No incremental marker found, performing full extraction")
+    return await self.full_extraction()
+```
+
+### GUARD-IMPL-09: Apply Configurable Time Buffer (marker_offset_hours)
+
+Source systems have eventual consistency delays. Apply a configurable prepone
+buffer to the cutoff timestamp:
+
+```python
+effective_cutoff = marker - timedelta(hours=marker_offset_hours)
+```
+
+Default `marker_offset_hours` to a sensible value for the connector type:
+- SQL connectors: 1 hour (metadata views may cache)
+- REST connectors: 2 hours (API eventual consistency)
+- GraphQL connectors: 2-4 hours (indexing delays)
+
+### GUARD-IMPL-10: Capture next_marker BEFORE Extraction Starts
+
+Record the timestamp that will become the next marker BEFORE you begin
+extraction. This prevents a race condition where entities modified during
+extraction are missed.
+
+```python
+next_marker = datetime.utcnow().isoformat()
+# NOW begin extraction
+entities = await self.extract_entities(current_marker)
+# After successful publish, persist next_marker
+```
+
+### GUARD-IMPL-11: Use Single ID Format Throughout Pipeline
+
+Choose ONE canonical ID format and use it consistently across all pipeline
+stages. If the source exposes multiple ID formats, maintain an explicit
+mapping but never mix formats in comparisons.
+
+```python
+# Maintain mapping
+id_map: dict[str, str] = {}  # graphql_id -> luid
+
+# Always compare using the same format
+changed_ids_canonical = {id_map.get(gql_id, gql_id) for gql_id in changed_graphql_ids}
+```
+
+**Failure mode (Tableau R2/R5):** Comparing LUIDs from REST API against
+GraphQL IDs caused incremental detection to report everything as changed.
+
+### GUARD-IMPL-12: Missing Type = Empty List, NOT None
+
+When an entity type has no changed entities, represent it as an empty list `[]`.
+`None` means "no filter applied = extract everything of this type."
+
+```python
+# WRONG -- None means "extract all tables"
+changed_by_type = {"Table": None, "Column": ["col_1", "col_2"]}
+
+# RIGHT -- empty list means "no tables changed"
+changed_by_type = {"Table": [], "Column": ["col_1", "col_2"]}
+```
+
+**Failure mode (Tableau R3):** Typed batching returned `None` for missing
+types, which downstream code interpreted as "fetch all," negating the
+incremental benefit.
+
+### GUARD-IMPL-13: Implement Cascade Detection for Parent-Child Relationships
+
+When a parent entity changes, all its children must be re-extracted even if
+their individual timestamps have not changed.
+
+Example: If a Table's schema changes, all its Columns must be re-extracted.
+If a Workbook is updated, all its Dashboards and Sheets must be re-extracted.
+
+### GUARD-IMPL-14: First Run Falls Back to Full Extraction
+
+When incremental is enabled but no marker exists (first run), the connector
+MUST perform a full extraction and persist the marker afterward.
+
+This is NOT an error condition -- it is the expected bootstrap behavior.
+
+### GUARD-IMPL-15: Always Provide force_full_extraction Escape Hatch
+
+Every incremental connector MUST accept a `force_full_extraction` flag that
+bypasses incremental logic and performs a full extraction regardless of
+existing markers.
+
+This is the recovery mechanism for state corruption, missed updates, or
+any other incremental failure mode.
+
+### GUARD-IMPL-16: Implement Backfill for Complete Output
+
+Some downstream consumers expect the COMPLETE entity set, not just changed
+entities. When incremental extraction produces only the delta, implement
+backfill from ObjectStore (S3) for unchanged entities.
+
+The output of an incremental run (changed + backfilled) must be
+indistinguishable from a full extraction run.
+
+### GUARD-IMPL-17: Delete Detection Requires Full Entity List Comparison
+
+To detect deleted entities, compare the full entity list from the current
+run against the previously persisted full entity list.
+
+```
+deleted = previous_entity_ids - current_entity_ids
+```
+
+This requires persisting the full entity ID list between runs, even during
+incremental extraction. Factor this into the state artifact size estimate
+(GUARD-PRE-10).
+
+### GUARD-IMPL-18: All Incremental Params in WorkflowArgs with Defaults
+
+All incremental parameters must be declared in the WorkflowArgs model with
+sensible defaults:
+
+```python
+class WorkflowArgs(BaseModel):
+    incremental_enabled: bool = False
+    force_full_extraction: bool = False
+    marker_offset_hours: float = 2.0
+```
+
+`incremental_enabled` MUST default to `False`. Incremental is opt-in only.
+
+---
+
+## Section 3: Post-Implementation Verification
+
+These checks MUST pass before the incremental implementation is considered
+complete.
+
+### GUARD-POST-01: Parity Check
+
+Run a full extraction and an incremental extraction (with backfill) against
+the same source. The output entity sets must be identical.
+
+**How to verify:**
+1. Run full extraction, save output as `full_output`
+2. Run incremental extraction (which does full on first run), persist state
+3. Make NO changes to the source
+4. Run incremental extraction again, save output as `incremental_output`
+5. Diff `full_output` vs `incremental_output` -- they must match
+
+### GUARD-POST-02: Zero-Change Scenario
+
+When no entities have changed since the last run, the incremental extraction
+must still produce COMPLETE output via backfill.
+
+The output must NOT be empty. It must contain all previously-extracted entities
+loaded from the backfill cache.
+
+### GUARD-POST-03: Verify All Persistent Artifacts Exist
+
+After a successful run, verify that all expected state artifacts exist in
+ObjectStore:
+
+- Incremental marker (timestamp)
+- Entity ID list (for delete detection)
+- Backfill cache (chunked entity data)
+- Any connector-specific state artifacts
+
+### GUARD-POST-04: Verify Artifact Sizes Within 50 MB Limit
+
+Check every persisted artifact:
+
+```python
+for artifact in list_artifacts(state_prefix):
+    size_mb = get_artifact_size(artifact) / (1024 * 1024)
+    assert size_mb < 50, f"Artifact {artifact} is {size_mb:.1f} MB (limit: 50 MB)"
+```
+
+### GUARD-POST-05: Backward Compatibility
+
+A new version of the connector reading state persisted by the old version
+must NOT crash. It should either:
+- Successfully parse the old state format, OR
+- Detect incompatible state and fall back to full extraction
+
+### GUARD-POST-06: Failure Simulation -- Publish Failure
+
+Simulate a publish failure (e.g., by disconnecting network after extraction).
+Verify that:
+- The incremental marker is NOT updated
+- The next run re-extracts the same entities
+- No data is lost
+
+### GUARD-POST-07: Failure Simulation -- Corrupted State
+
+Corrupt the state artifact (write garbage to the marker file). Verify that:
+- The connector detects the corruption
+- Falls back to full extraction
+- Persists valid state after the full extraction succeeds
+
+### GUARD-POST-08: Failure Simulation -- Missing State
+
+Delete all state artifacts. Verify that:
+- The connector treats this as a first run
+- Performs full extraction
+- Persists all state artifacts afterward
+
+### GUARD-POST-09: Failure Simulation -- force_full Override
+
+Set `force_full_extraction=True` with existing valid state. Verify that:
+- The connector ignores the existing marker
+- Performs full extraction
+- Updates the persisted state afterward
+
+---
+
+## Section 4: Refusal List
+
+These are actions that the implementation agent MUST NOT take under any
+circumstances.
+
+### REFUSE-01: Do NOT Auto-Enable Incremental
+
+`incremental_enabled` MUST default to `False`. The user must explicitly
+opt in. Auto-enabling incremental on existing connectors risks silent
+data loss if the implementation has bugs.
+
+### REFUSE-02: Do NOT Modify Argo Workflow Templates
+
+Incremental extraction applies to SDK/Temporal apps only. Argo workflow
+templates (`.yaml` files in marketplace-packages) are a separate system
+and must not be modified as part of incremental work.
+
+### REFUSE-03: Do NOT Delete Existing Extraction Code
+
+Incremental logic WRAPS AROUND existing extraction code. The full extraction
+path must remain intact and functional. Incremental is an optimization layer
+on top of full extraction, not a replacement.
+
+### REFUSE-04: Do NOT Persist State Before Publish Succeeds
+
+Restating GUARD-IMPL-01 as a hard refusal. This is the single most dangerous
+mistake in incremental extraction. If an agent proposes persisting state at
+any point before upload_to_atlan completes, REFUSE.
+
+### REFUSE-05: Do NOT Implement Without force_full_extraction Escape Hatch
+
+Every incremental connector needs a manual override. Without it, state
+corruption requires manual ObjectStore cleanup, which is operationally
+unacceptable.
+
+### REFUSE-06: Do NOT Pass >100 KB Through Temporal Activity Args
+
+If the serialized argument is approaching 100 KB, use file I/O instead.
+The 2 MB Temporal limit is a hard crash with no graceful degradation.
+
+### REFUSE-07: Do NOT Store >50 MB as Single Files
+
+Any file exceeding 50 MB must be chunked. The 100 MB Dapr gRPC limit is
+infrastructure-level and cannot be raised per-app.
+
+### REFUSE-08: Do NOT Modify the application_sdk Package
+
+The SDK is a shared dependency. All incremental logic must live in the
+connector app code, not in the SDK. If SDK changes are needed, they must
+go through the SDK team's review process separately.
+
+---
+
+## Section 5: Failure Mode Catalog
+
+Known failures from the Tableau incremental migration, mapped to the generic
+guardrails that prevent them.
+
+| # | Failure Description | Root Cause | Guardrail |
+|---|---|---|---|
+| 1 | `detect_updated` read from wrong API surface | Incremental detection used REST API timestamps but compared against GraphQL entity IDs | GUARD-IMPL-11 |
+| 2 | Extraction filtered at API level incorrectly | API endpoint IDs did not match the IDs used in the change detection set | GUARD-PRE-09 |
+| 3 | Typed batching returned None for missing types | Code used `None` to represent "no entities of this type changed," but downstream interpreted `None` as "no filter = fetch all" | GUARD-IMPL-12 |
+| 4 | Field-extract files exceeded 100 MB gRPC limit | Large Tableau sites produced field-extract files > 100 MB, hitting the Dapr gRPC ceiling | GUARD-IMPL-05, GUARD-IMPL-06 |
+| 5 | DS ID format mismatch (LUID vs GraphQL ID) | Datasource REST API returns LUIDs, but GraphQL metadata API uses different node IDs; comparing them yielded 100% "changed" | GUARD-IMPL-11 |
+| 6 | Cache exceeded gRPC limit | Monolithic metadata cache grew beyond 100 MB on large sites | GUARD-IMPL-06 |
+| 7 | Temporal 2 MB payload limit | Changed entity ID lists were passed as Temporal activity arguments instead of via file I/O | GUARD-IMPL-03 |
+
+**Pattern:** Failures 1, 2, and 5 are all ID/surface mismatches. Failures 4
+and 6 are size limit violations. Failure 3 is a semantic null vs empty
+confusion. Failure 7 is a Temporal-specific payload limit.
+
+When implementing incremental extraction for a new connector, review this
+table and proactively check whether analogous conditions exist in the target
+connector's API surface.

--- a/application_sdk/common/incremental/skills/incremental-migrate/references/metrics-template.md
+++ b/application_sdk/common/incremental/skills/incremental-migrate/references/metrics-template.md
@@ -1,0 +1,121 @@
+# Incremental Connector Metrics Template
+
+Standard Segment/Mixpanel metrics catalog for any incremental connector.
+Sub-agents should use this template to emit consistent, well-labeled metrics
+from every incremental connector implementation.
+
+---
+
+## Section 1: Approach
+
+Use the SDK's `get_metrics().record_metric()` directly. No custom sinks,
+decorators, or broadcasters needed. All metrics flow through the existing
+observability pipeline to Segment and Mixpanel.
+
+```python
+from application_sdk.observability.metrics_adaptor import get_metrics, MetricType
+
+CONNECTOR = "my_connector"  # Replace with actual connector name
+
+def emit(name: str, value, metric_type=MetricType.GAUGE, **extra_labels):
+    """Emit a single metric with standard labels."""
+    labels = {"send_to_segment": "true"}
+    labels.update(extra_labels)
+    get_metrics().record_metric(
+        name=f"{CONNECTOR}_{name}",
+        value=value,
+        metric_type=metric_type,
+        labels=labels,
+    )
+```
+
+### Rules
+
+- All metric names MUST be prefixed with `{connector}_` for namespace clarity.
+- Always include `send_to_segment: "true"` in labels.
+- Use `MetricType.GAUGE` for point-in-time values, `MetricType.COUNTER` for
+  cumulative totals that only increase within a run.
+- Emit metrics as close to the data source as possible (right after the
+  computation, not deferred to the end).
+
+---
+
+## Section 2: Metrics Catalog
+
+Organized by emission point. Replace `<entity>` with the actual entity type
+name (e.g., `dashboard`, `report`, `dataset`).
+
+### Extraction Overview (emit after entity ID collection)
+
+| Metric Name | Type | Description |
+|-------------|------|-------------|
+| `total_<entity>_count` | gauge | Total entities in scope for this run |
+| `total_field_ids` | gauge | Total child IDs to extract (if applicable, e.g., columns, fields) |
+| `is_incremental` | gauge (0/1) | Whether this run used incremental mode |
+
+### Incremental Detection (emit after change detection completes)
+
+| Metric Name | Type | Description |
+|-------------|------|-------------|
+| `incremental_marker_found` | gauge (0/1) | Whether a prior marker was found in S3 |
+| `incremental_updated_count` | counter | Entities with real changes since last marker |
+| `incremental_false_positive_skipped` | counter | Entities skipped by false-positive filter (e.g., metadata-only refreshes) |
+| `incremental_cascaded_count` | counter | Child entities cascaded from parent changes |
+| `incremental_deleted_count` | counter | Entities deleted since last run |
+| `incremental_newly_added_count` | counter | Entities newly appearing in filter scope |
+
+### Backfill (emit after backfill completes)
+
+| Metric Name | Type | Description |
+|-------------|------|-------------|
+| `backfill_record_count` | counter | Total records restored from S3 backfill |
+| `backfill_entity_count` | counter | Number of entities backfilled (not freshly extracted) |
+| `backfill_duration_seconds` | gauge | Wall-clock time for backfill operation |
+
+### Filter (emit after scope filtering, if applicable)
+
+| Metric Name | Type | Description |
+|-------------|------|-------------|
+| `filter_before_count` | gauge | Entity count before scope filtering |
+| `filter_after_count` | gauge | Entity count after scope filtering |
+
+### Workflow-Level (emit at workflow start)
+
+| Metric Name | Type | Description |
+|-------------|------|-------------|
+| `workflow_incremental_enabled` | gauge (0/1) | Value of `incremental_enabled` config flag |
+| `workflow_force_full` | gauge (0/1) | Value of `force_full_extraction` config flag |
+| `workflow_marker_offset_hours` | gauge | Configured prepone buffer in hours |
+
+---
+
+## Section 3: Common Labels
+
+All metrics MUST include these labels in addition to `send_to_segment`:
+
+| Label | Source | Purpose |
+|-------|--------|---------|
+| `send_to_segment` | Hard-coded `"true"` | Required for Segment routing |
+| `connection_qualified_name` | Workflow input / config | Scope key identifying the connection |
+| `workflow_id` | Temporal context | Workflow identifier for correlation |
+| `workflow_run_id` | Temporal context | Run identifier for deduplication |
+
+### Example emission with all labels
+
+```python
+emit(
+    "incremental_updated_count",
+    len(changed_ids),
+    metric_type=MetricType.COUNTER,
+    connection_qualified_name=config.connection_qualified_name,
+    workflow_id=workflow_info.workflow_id,
+    workflow_run_id=workflow_info.run_id,
+)
+```
+
+### Anti-patterns to avoid
+
+- Do NOT create custom metric sinks or broadcaster classes.
+- Do NOT batch metrics to emit at workflow end -- emit at each stage.
+- Do NOT use string interpolation for metric values; pass numeric types only.
+- Do NOT omit `send_to_segment` -- metrics without it will not reach Mixpanel.

--- a/application_sdk/common/incremental/skills/incremental-migrate/references/rest-incremental-pattern.md
+++ b/application_sdk/common/incremental/skills/incremental-migrate/references/rest-incremental-pattern.md
@@ -1,0 +1,439 @@
+# REST/GraphQL Incremental Extraction Pattern
+
+Reusable template distilled from the Tableau incremental extraction implementation.
+Any REST or GraphQL connector can follow this pattern to add incremental extraction
+support with minimal structural changes to an existing full-extraction workflow.
+
+---
+
+## Section 1: Detection Logic Template
+
+### 1.1 Published / Parent Entity Detection (Direct Comparison)
+
+```python
+def detect_updated_entities(
+    records: list[dict],
+    cutoff_iso: str,
+    apply_false_positive_filter: bool = True,
+) -> tuple[set[str], dict]:
+    """
+    For each entity record from the full extraction:
+      1. Compare updatedAt / createdAt against cutoff_iso
+      2. Apply false-positive filter if applicable
+      3. Return (changed_entity_ids, stats_dict)
+    """
+    changed = set()
+    stats = {"total": 0, "changed": 0, "false_positive_skipped": 0}
+
+    for rec in records:
+        stats["total"] += 1
+        updated_at = rec.get("updatedAt") or rec.get("createdAt")
+        if not updated_at:
+            # No timestamp — treat as changed (safe default)
+            changed.add(rec["id"])
+            stats["changed"] += 1
+            continue
+
+        if updated_at > cutoff_iso:
+            if apply_false_positive_filter and _is_false_positive(rec):
+                stats["false_positive_skipped"] += 1
+                continue
+            changed.add(rec["id"])
+            stats["changed"] += 1
+
+    return changed, stats
+```
+
+### 1.2 False-Positive Filter (R4 Equivalent)
+
+Some APIs bump `updatedAt` without any metadata actually changing (e.g., Tableau
+bumps workbook `updatedAt` on every data-refresh even when schema is identical).
+
+```python
+def _is_false_positive(rec: dict) -> bool:
+    """
+    R4 filter: if updatedAt == lastRefreshTime and no other field changed,
+    the entity metadata is unchanged — skip it.
+    Adapt the field names to match your API's semantics.
+    """
+    return (
+        rec.get("updatedAt") == rec.get("lastRefreshTime")
+        and rec.get("contentVersion") == rec.get("_prev_contentVersion")
+    )
+```
+
+### 1.3 Embedded / Child Entity Detection (Cascade from Parent)
+
+Child entities (columns, fields, sheets) may not carry their own `updatedAt`.
+Detect them by cascading from their parent.
+
+```python
+def detect_updated_children(
+    parent_changed_ids: set[str],
+    child_records: list[dict],
+    parent_key: str = "parentId",
+) -> set[str]:
+    """
+    Any child whose parent is in parent_changed_ids is considered changed.
+    """
+    return {
+        child["id"]
+        for child in child_records
+        if child.get(parent_key) in parent_changed_ids
+    }
+```
+
+### 1.4 Delete Detection
+
+```python
+def detect_deleted_entities(
+    previous_ids: set[str],
+    current_ids: set[str],
+) -> set[str]:
+    """
+    Entities present in the previous run but absent now are deletes.
+    previous_ids is loaded from filtered-<entities>.json (Section 2).
+    """
+    return previous_ids - current_ids
+```
+
+### 1.5 Cascade Detection (Parent Changed -> Re-extract Children)
+
+```python
+def cascade_to_children(
+    parent_changed_ids: set[str],
+    parent_to_children: dict[str, list[str]],
+) -> set[str]:
+    """
+    Given a mapping of parent_id -> [child_ids], return all child IDs
+    that need re-extraction because their parent changed.
+    """
+    result = set()
+    for pid in parent_changed_ids:
+        result.update(parent_to_children.get(pid, []))
+    return result
+```
+
+---
+
+## Section 2: State Management Template
+
+### 2.1 Persistent Artifact Layout
+
+```
+persistent-artifacts/apps/{app_name}/connection/{connection_id}/
++-- marker.txt                           # SDK standard marker (singular "connection")
++-- filtered-<entities>.json             # Previous run's entity scope (ID lists)
++-- <entity>_cache.json                  # Per-entity snapshots (for delete detection)
++-- <entity>-extracts/                   # Backfill data (chunked NDJSON)
+    +-- _index.json                      # entity -> chunk + line-range index (v2)
+    +-- <type>/result-0.json             # Chunked NDJSON files (~50MB each)
+    +-- <type>/result-1.json
+```
+
+> **SDK quirk**: The SDK marker helper uses singular `connection/` in its S3 path
+> (e.g., `persistent-artifacts/apps/tableau/connection/abc123/marker.txt`).
+> App-level custom state (entity lists, caches, extracts) should also use singular
+> `connection/` for consistency. Some older connectors used plural `connections/` --
+> if migrating, standardize on singular to match the SDK convention.
+
+### 2.2 Marker Lifecycle
+
+```
+READ (with prepone)        EXTRACT                   PERSIST (after publish)
+       |                       |                            |
+       v                       v                            v
+  fetch_marker()        run extraction            persist_marker(now_iso)
+  prepone by N min      using cutoff              only after upload_to_atlan
+  to handle clock       from marker               succeeds
+  skew / overlap
+```
+
+- **Prepone**: Subtract a safety window (e.g., 5 minutes) from the stored marker
+  to handle clock skew between your system and the upstream API.
+- **First run**: If no marker exists, treat as full extraction (all entities changed).
+- **Persist timing**: ALWAYS persist the new marker AFTER `upload_to_atlan` succeeds.
+  If upload fails, the next run re-extracts the same window — idempotent and safe.
+
+### 2.3 Entity List (Filter-Change & Delete Detection)
+
+Store the filtered entity IDs from each run:
+
+```python
+# After filtering, persist:
+{
+    "workbooks": ["wb-1", "wb-2", "wb-3"],
+    "datasources": ["ds-10", "ds-20"],
+    "run_timestamp": "2024-03-15T10:00:00Z"
+}
+# -> uploaded to filtered-<entities>.json
+```
+
+On next run, compare previous IDs vs. current IDs to detect:
+- **Deletes**: `previous_ids - current_ids`
+- **Filter changes**: If a project/folder was added or removed from the filter config,
+  new entities appear and old ones disappear. Treat new entities as changed.
+
+### 2.4 Index-Based Backfill (v2 Chunked Index)
+
+The `_index.json` maps each entity to its chunk file and line offsets:
+
+```json
+{
+    "ds-10": {
+        "datasource": {
+            "chunk": "datasource/result-0.json",
+            "start": 0,
+            "count": 45
+        }
+    },
+    "ds-20": {
+        "datasource": {
+            "chunk": "datasource/result-0.json",
+            "start": 45,
+            "count": 30
+        }
+    },
+    "ds-99": {
+        "datasource": {
+            "chunk": "datasource/result-1.json",
+            "start": 0,
+            "count": 60
+        }
+    }
+}
+```
+
+### 2.5 Chunked Storage Rules
+
+- **Target**: ~50MB per chunk file (stays within gRPC / S3 transfer limits).
+- **Never split**: A single entity's NDJSON lines must NOT span two chunks.
+  If adding an entity would exceed 50MB, start a new chunk.
+- **Naming**: `<type>/result-N.json` where N is zero-indexed.
+- **Format**: NDJSON (one JSON object per line) for streaming reads.
+
+---
+
+## Section 3: Backfill Template
+
+### 3.1 Core Backfill Algorithm
+
+```python
+def backfill_unchanged_entities(
+    changed_ids: set[str],
+    deleted_ids: set[str],
+    current_all_ids: set[str],
+    index: dict,
+    download_chunk_fn,
+    output_dir: str,
+):
+    """
+    Reconstruct complete output from fresh extraction + cached data.
+
+    1. Download _index.json from S3 (small, always fits in memory)
+    2. Determine unchanged = current_all - changed - deleted
+    3. Group unchanged entities by chunk file
+    4. Download only needed chunks (each <=50MB, within gRPC limit)
+    5. Extract lines using index start/count offsets
+    6. Write to output alongside fresh extraction results
+    7. Free memory after each chunk (del content, lines)
+    """
+    unchanged = current_all_ids - changed_ids - deleted_ids
+
+    # Group by chunk to minimize downloads
+    chunk_to_entities: dict[str, list[str]] = {}
+    for eid in unchanged:
+        if eid not in index:
+            continue  # New entity not in cache — will be in fresh extraction
+        for entity_type, loc in index[eid].items():
+            chunk = loc["chunk"]
+            chunk_to_entities.setdefault(chunk, []).append(
+                (eid, entity_type, loc["start"], loc["count"])
+            )
+
+    # Process one chunk at a time to bound memory
+    for chunk_path, entities in chunk_to_entities.items():
+        content = download_chunk_fn(chunk_path)
+        lines = content.split("\n")
+
+        for eid, entity_type, start, count in entities:
+            extracted = lines[start : start + count]
+            _append_to_output(output_dir, entity_type, extracted)
+
+        # Explicit cleanup — chunks can be large
+        del content, lines
+```
+
+### 3.2 v1 -> v2 Backward Compatibility
+
+```python
+def load_index(download_fn, base_path: str) -> dict | None:
+    """
+    Try v2 index first. If _index.json is missing (pre-v2 run),
+    fall back to full scan (treat all entities as changed).
+    """
+    try:
+        raw = download_fn(f"{base_path}/_index.json")
+        return json.loads(raw)
+    except FileNotFoundError:
+        # v1 legacy: no index exists, force full extraction this run.
+        # Next persist will create the v2 index going forward.
+        return None
+```
+
+When `load_index` returns `None`, the caller should treat every entity as changed
+(equivalent to a full run). The persist step at the end will write the v2 index,
+so all subsequent runs benefit from incremental backfill.
+
+---
+
+## Section 4: S3 Artifact Layout Template
+
+```
+persistent-artifacts/apps/{app_name}/connection/{connection_id}/
+|
+|-- marker.txt
+|   # ISO timestamp of last successful extraction completion.
+|   # Written ONLY after upload_to_atlan succeeds.
+|   # Read at start of next run, preponed by safety window.
+|   # Lifecycle: created on first run, overwritten every run.
+|
+|-- filtered-workbooks.json
+|   # Array of workbook IDs that passed the project/site filter
+|   # on the previous run. Used for delete detection and
+|   # filter-change detection on the next run.
+|   # Lifecycle: overwritten every run after upload_to_atlan.
+|
+|-- filtered-datasources.json
+|   # Same pattern for datasources (one file per entity type).
+|
+|-- workbook_cache.json
+|   # Snapshot of workbook metadata from previous run.
+|   # Used for field-level diffing if needed (optional).
+|   # Lifecycle: overwritten every run.
+|
+|-- datasource-extracts/
+|   |-- _index.json
+|   |   # v2 index: maps each datasource ID to its chunk file,
+|   |   # start line, and line count. Small file (~1KB per entity).
+|   |   # Lifecycle: overwritten every run after upload_to_atlan.
+|   |
+|   |-- datasource/
+|   |   |-- result-0.json    # NDJSON chunk (~50MB max)
+|   |   |-- result-1.json    # Next chunk if result-0 exceeded limit
+|   |   # Lifecycle: overwritten every run. Old chunks deleted
+|   |   # before new ones are written to avoid stale data.
+|   |
+|   |-- column/
+|       |-- result-0.json    # Column NDJSON, same chunking rules
+|
+|-- workbook-extracts/
+    |-- _index.json
+    |-- workbook/
+    |   |-- result-0.json
+    |-- sheet/
+        |-- result-0.json
+```
+
+All files under this tree are **overwritten** on every successful run. There is no
+append-only log. If a run fails before `upload_to_atlan`, the old state is preserved
+and the next run retries cleanly.
+
+---
+
+## Section 5: Workflow Wiring Template
+
+### 5.1 Activity Insertion Points
+
+```
+STEP  ACTIVITY                             INCREMENTAL?   NOTES
+----  --------                             ------------   -----
+1.    get_workflow_args                     existing       Parse connection config
+1a.   read_marker                          << NEW >>      SDK fetch_marker_from_storage
+1b.   read_previous_entity_list            << NEW >>      Download filtered-*.json from S3
+2.    preflight_check                      existing       Validate credentials / permissions
+3.    extract_sites                        existing       FULL always (cheap, parent entity)
+4.    extract_projects                     existing       FULL always (cheap, parent entity)
+5.    extract_workbooks                    existing       FULL always (needed for detection)
+5a.   detect_updated_workbooks             << NEW >>      Marker comparison + false-positive filter
+5b.   detect_deleted_workbooks             << NEW >>      previous_ids - current_ids
+6.    extract_datasources                  existing       FULL always (needed for detection)
+6a.   detect_updated_datasources           << NEW >>      Marker comparison + cascade from workbooks
+6b.   detect_deleted_datasources           << NEW >>      previous_ids - current_ids
+7.    extract_workbook_details             MODIFIED       Only changed workbook IDs (expensive)
+7a.   backfill_unchanged_workbooks         << NEW >>      From S3 extracts via index
+8.    extract_datasource_details           MODIFIED       Only changed datasource IDs (expensive)
+8a.   backfill_unchanged_datasources       << NEW >>      From S3 extracts via index
+9.    filter_data                          existing       Apply project/site filters
+10.   transform                            existing       YAML transformers (unchanged)
+11.   upload_to_atlan                      existing       Publish to Atlan (unchanged)
+11a.  persist_incremental_state            << NEW >>      Marker + entity lists + cache + extracts
+```
+
+### 5.2 Key Design Rules
+
+1. **Parent entities are ALWAYS extracted fully.** Sites, projects, workbooks,
+   datasources — these are cheap list-API calls. Full extraction is required
+   so that detection logic can compare `updatedAt` against the marker.
+
+2. **Only expensive child/detail extractions are incremental.** Workbook details
+   (sheets, dashboards, fields) and datasource details (columns, connections)
+   are the expensive calls. These are the ones we skip for unchanged entities.
+
+3. **State persistence is ALWAYS after `upload_to_atlan`.** If upload fails,
+   the marker is not advanced and entity lists are not updated. The next run
+   retries the exact same window. This guarantees no data loss.
+
+4. **First run is always full.** When no marker exists, every entity is treated
+   as changed. The persist step at the end writes the marker and index so
+   subsequent runs are incremental.
+
+5. **Backfill produces identical output.** The combination of fresh extraction
+   (for changed entities) plus backfill (for unchanged entities) must produce
+   output byte-identical to what a full extraction would produce. Downstream
+   transform and upload steps see no difference.
+
+### 5.3 Temporal Activity Registration
+
+```python
+# In workflows.py — register incremental activities alongside existing ones:
+
+@workflow.defn
+class ExtractionWorkflow:
+    @workflow.run
+    async def run(self, args: WorkflowArgs) -> WorkflowResult:
+        # Phase 1: State loading (new)
+        marker = await workflow.execute_activity(
+            read_marker, args.connection_id, ...
+        )
+        prev_entities = await workflow.execute_activity(
+            read_previous_entity_list, args.connection_id, ...
+        )
+
+        # Phase 2: Full parent extraction (existing, unchanged)
+        workbooks = await workflow.execute_activity(extract_workbooks, ...)
+        datasources = await workflow.execute_activity(extract_datasources, ...)
+
+        # Phase 3: Detection (new)
+        changed_wb, deleted_wb = await workflow.execute_activity(
+            detect_changes, workbooks, marker, prev_entities, ...
+        )
+
+        # Phase 4: Selective detail extraction (modified)
+        if changed_wb:
+            await workflow.execute_activity(
+                extract_workbook_details, list(changed_wb), ...
+            )
+        await workflow.execute_activity(
+            backfill_unchanged, changed_wb, deleted_wb, ...
+        )
+
+        # Phase 5: Transform + Upload (existing, unchanged)
+        await workflow.execute_activity(transform, ...)
+        await workflow.execute_activity(upload_to_atlan, ...)
+
+        # Phase 6: State persistence (new, MUST be after upload)
+        await workflow.execute_activity(
+            persist_incremental_state, marker_now, workbooks, datasources, ...
+        )
+```

--- a/application_sdk/common/incremental/skills/incremental-migrate/references/test-scenario-template.md
+++ b/application_sdk/common/incremental/skills/incremental-migrate/references/test-scenario-template.md
@@ -1,0 +1,123 @@
+# Test Scenario Generation Template
+
+Use this template to **generate** test scenarios for any incremental connector.
+It provides categories and rules — not pre-baked test cases. Sub-agents should
+read the connector's feasibility report and codebase, then produce concrete
+test cases by instantiating the categories below.
+
+---
+
+## Section 1: Standard Lifecycle Scenarios (Always Apply)
+
+These scenarios test the fundamental incremental lifecycle and apply regardless
+of connector type. Every connector MUST have one test per row.
+
+| Category | What to Test | Key Assertions |
+|----------|-------------|----------------|
+| Full baseline | Run with `incremental_enabled=false` | No marker read/written, no state persisted, output matches non-incremental run |
+| First incremental | Run with `incremental_enabled=true`, no prior marker | Marker not found -> graceful fallback to full extraction. State persisted after run. |
+| Normal incremental | Run with marker + state from previous run, source has changes | Changed entities detected, fresh extraction for changed, backfill for unchanged, total output = fresh + backfill |
+| Zero changes | Run with marker + state, source unchanged | 0 entities detected as changed, all data from backfill, complete output produced |
+| Force full override | `force_full_extraction=true` with existing marker | Marker bypassed, full extraction runs, state overwritten |
+
+### Generation rules
+
+- Name each test `test_<category>_<entity>` (e.g., `test_first_incremental_dashboard`).
+- For "Normal incremental", mutate at least one entity in the mock source data
+  between the baseline and the incremental run.
+- For "Zero changes", use identical mock source data for both runs.
+- Assert on **output completeness**: the final file/upload must contain the
+  union of freshly-extracted and backfilled records.
+
+---
+
+## Section 2: Risk-Register-Derived Scenarios (Generate from Feasibility Report)
+
+For each **confirmed** risk in the feasibility report, generate a corresponding
+test scenario. The mapping:
+
+| Confirmed Risk | Test Scenario |
+|----------------|---------------|
+| Cascade risk confirmed | Update parent entity, verify child entities are included in changed set via cascade |
+| False-positive pattern identified | Trigger the false positive (e.g., data refresh, metadata-only change), verify the filter skips it |
+| Eventual consistency delay | Verify prepone buffer covers the delay window; entities updated within the buffer are re-extracted |
+| ID format divergence | Verify IDs are normalized consistently across detection and extraction phases |
+| Rate limiting under incremental load | Verify retry/backoff handles 429s during detection API calls |
+| Pagination boundary | Verify detection correctly pages through all results, no entities dropped at page boundaries |
+
+### Generation rules
+
+- One test scenario per confirmed risk. No exceptions.
+- **Skip** scenarios for risks marked "not confirmed" or "deferred" in the
+  feasibility report.
+- Name each test `test_risk_<short_risk_name>` (e.g., `test_risk_cascade_dashboard_to_widget`).
+- Each test must include a setup step that creates the risky condition, an
+  action step that runs incremental, and assertions that prove the risk is
+  handled.
+
+---
+
+## Section 3: State Management Scenarios (Always Apply)
+
+These scenarios verify that persistent state (S3 artifacts, markers) is handled
+correctly across edge cases.
+
+| Category | What to Test | Key Assertions |
+|----------|-------------|----------------|
+| Entity deleted | Entity exists in previous state but not in current extraction | Excluded from backfill, not in final output |
+| Corrupted state | Write garbage to state file, run incremental | Graceful fallback to full extraction, no crash |
+| Missing state | Delete all S3 state artifacts, run incremental | Equivalent to first-run behavior |
+| State after publish | Run incremental successfully | All persistent artifacts (marker, index, output) exist with correct content |
+| State NOT after failure | Simulate upload failure mid-run | Marker NOT updated, next run re-extracts the same delta |
+| Backward compat | Read state written by older code version | No crash, correct behavior, missing keys get defaults |
+
+### Generation rules
+
+- Mock the ObjectStore for unit tests; use localstack or equivalent for
+  integration tests.
+- "Corrupted state" should use at least two corruption variants: truncated
+  JSON and completely invalid bytes.
+- "Backward compat" requires a fixture file representing the old state format.
+
+---
+
+## Section 4: Filter Scope Scenarios (Only If Connector Has Scope Filters)
+
+Skip this section entirely if the connector does not support scope filters
+(project selectors, workspace selectors, etc.).
+
+| Category | What to Test | Key Assertions |
+|----------|-------------|----------------|
+| Scope added | Add new scope (project/workspace) between runs | New scope's entities treated as "new", full extraction for them, existing scopes use incremental |
+| Scope removed | Remove scope between runs | Removed scope's entities excluded from backfill and output |
+| First run with filters | No prior state + filters active | Correct scoped extraction, only in-scope entities in output |
+| Filter + zero changes | Filters active, no changes in any scoped entity | All data from backfill, output matches previous run |
+
+### Generation rules
+
+- Use at least two scopes in the mock data to test add/remove independently.
+- Verify that scope changes do NOT corrupt state for unaffected scopes.
+
+---
+
+## Section 5: Unit Test Matrix (What to Test Per Module)
+
+Use this matrix to decide what belongs in unit tests vs. what should be mocked.
+
+| Module Type | What to Unit Test | What NOT to Unit Test (Mock Instead) |
+|-------------|------------------|--------------------------------------|
+| Detection logic | Each detection function with mock API responses: changed, unchanged, R4-filtered, cascaded, deleted entities | SDK marker read/write (tested by SDK itself) |
+| Cache/state | Serialization round-trips, missing keys, empty data, backward compat with old formats | ObjectStore operations (mock them) |
+| Backfill | Index-based line extraction, chunked reads, v1->v2 fallback, empty index, missing files | Actual S3 downloads (mock ObjectStore) |
+| Workflow wiring | Activity invocation order, conditional branches, short-circuit on 0 changes | Temporal internals (worker, task queue) |
+| Filter logic | Include/exclude by scope, empty filters, overlapping filters | API calls to fetch filter values |
+
+### Generation rules
+
+- Aim for **one test file per module** (e.g., `test_detection.py`,
+  `test_backfill.py`, `test_state.py`).
+- Each test function should test exactly one behavior. Prefer many small tests
+  over few large ones.
+- Use `pytest.mark.parametrize` for detection tests that vary by entity type.
+- All mocks should use `unittest.mock.patch` or `pytest-mock` fixtures, never
+  monkey-patching at module level.


### PR DESCRIPTION
## Summary

- Adds a new `incremental-migrate` orchestrator skill under `application_sdk/common/incremental/skills/` that can migrate **any** Atlan connector app (SQL or REST/GraphQL) to support incremental extraction
- For SQL connectors: delegates to the existing `implement-incremental-extraction` skill (sibling in this package)
- For REST/GraphQL connectors: uses the Tableau incremental implementation as a reference pattern, distilled into reusable templates
- Includes 5 reference docs encoding lessons from 42 Tableau incremental extraction documents and 7 production failure modes

## What's included

| File | Lines | Purpose |
|------|-------|---------|
| `SKILL.md` | ~490 | Master orchestrator — brick sequence, branching (SQL vs REST), sub-agent prompts, iterative test loop |
| `references/guardrails.md` | ~310 | 18 implementation guards + 7 failure-mode catalog (from Tableau production bugs) |
| `references/feasibility-checklist.md` | ~180 | 5 non-negotiable rules + SQL/REST/GraphQL-specific pitfalls |
| `references/rest-incremental-pattern.md` | ~230 | Reusable REST/GraphQL template (detection, state, backfill, workflow wiring) |
| `references/test-scenario-template.md` | ~105 | Generic test scenario categories and generation rules |
| `references/metrics-template.md` | ~82 | Standard Segment/Mixpanel metrics catalog |

## How it works

```
Brick 0: Pre-flight & Classify (SQL vs REST)
Brick 1: Reconnaissance (read app, map APIs/entities/timestamps)
Brick 2: Feasibility Analysis (5 rules, risk register) → USER CHECKPOINT

[SQL Path]                     [REST/GraphQL Path]
Brick 3S: SDK Delegation       Brick 3R-8R: Detection → State → Backfill → Workflow
    → CONVERGE

Brick A: Metrics → USER CHECKPOINT
Brick B: Test Design → USER CHECKPOINT
Brick C: Test Implementation (2 parallel agents)
Brick D: Test Execution & Fix Loop (max 5 iterations, stall detection)
```

## Smoke test

Ran Bricks 0-2 against `atlan-tableau-app` (which already has incremental). The skill:
- Correctly classified it as REST (not SQL)
- Produced a 354-line reconnaissance matching all 15 entity types, dual API pattern, 39-step workflow
- Produced a 418-line feasibility report that independently arrived at the same risks (R1-R10), strategy (client-side diffing), and state design as the original implementation
- All 11 validation points passed against known ground truth from 42 Obsidian docs

## Test plan
- [x] Smoke test on Tableau app (Bricks 0-2, read-only analysis)


🤖 Generated with [Claude Code](https://claude.com/claude-code)