### PR TITLE
fix: nest extra.* keys in credential flat dict conversion

### DIFF
--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -103,6 +103,10 @@ def _pairs_to_flat(pairs: list[dict[str, str]]) -> dict[str, Any]:
 
     Reverse of ``_flatten_to_pairs``.  ``extra.*`` keys are nested under
     an ``extra`` dict so ``parse_credentials_extra()`` works correctly.
+
+    Note: all values remain strings — no type coercion is performed.
+    A round-trip through ``_flatten_to_pairs`` then ``_pairs_to_flat``
+    will stringify non-string values (e.g. ``int 5432`` → ``str "5432"``).
     """
     flat: dict[str, Any] = {}
     extra: dict[str, Any] = {}

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -98,6 +98,25 @@ def _flatten_to_pairs(creds_dict: dict[str, Any]) -> list[dict[str, str]]:
     return pairs
 
 
+def _pairs_to_flat(pairs: list[dict[str, str]]) -> dict[str, Any]:
+    """Convert v3 [{key, value}] pairs to a flat credential dict.
+
+    Reverse of ``_flatten_to_pairs``.  ``extra.*`` keys are nested under
+    an ``extra`` dict so ``parse_credentials_extra()`` works correctly.
+    """
+    flat: dict[str, Any] = {}
+    extra: dict[str, Any] = {}
+    for p in pairs:
+        key, value = p["key"], p["value"]
+        if key.startswith("extra."):
+            extra[key[len("extra.") :]] = value
+        else:
+            flat[key] = value
+    if extra:
+        flat["extra"] = extra
+    return flat
+
+
 def _normalize_credentials(body: dict[str, Any]) -> dict[str, Any]:
     """Normalize v2 credential formats to v3 list[{key, value}] format.
 
@@ -652,10 +671,10 @@ def create_app_handler_service(
             if "credentials" in body and body["credentials"]:
                 if _secret_store is not None and hasattr(_secret_store, "set"):
                     credential_guid = str(uuid4())
-                    # Convert v3 list [{key, value}] to flat dict {key: value}
-                    # so get_secret() returns the same format as production
-                    # (Dapr/Vault), where credentials are stored as flat dicts.
-                    flat_creds = {p["key"]: p["value"] for p in body["credentials"]}
+                    # Convert v3 list [{key, value}] to flat dict so
+                    # get_secret() returns the same format as production
+                    # (Dapr/Vault). extra.* keys nested under "extra".
+                    flat_creds = _pairs_to_flat(body["credentials"])
                     _secret_store.set(credential_guid, json.dumps(flat_creds))
                     body["credential_guid"] = credential_guid
                     del body["credentials"]

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -27,7 +27,9 @@ from application_sdk.handler.contracts import (
     SubscriptionConfig,
 )
 from application_sdk.handler.service import (
+    _flatten_to_pairs,
     _normalize_credentials,
+    _pairs_to_flat,
     _wrap_response,
     create_app_handler_service,
 )
@@ -919,6 +921,74 @@ class TestNormalizeCredentials:
         )
         assert response.status_code == 200
         assert response.json()["data"]["status"] == "success"
+
+
+class TestFlattenToPairs:
+    """Tests for _flatten_to_pairs (flat dict → v3 list)."""
+
+    def test_simple_keys(self) -> None:
+        result = _flatten_to_pairs({"host": "db.example.com", "username": "admin"})
+        keys = {p["key"]: p["value"] for p in result}
+        assert keys == {"host": "db.example.com", "username": "admin"}
+
+    def test_extra_nested(self) -> None:
+        creds = dict(host="db.example.com", extra={"role": "ADMIN", "warehouse": "WH"})
+        result = _flatten_to_pairs(creds)
+        keys = {p["key"]: p["value"] for p in result}
+        assert keys["extra.role"] == "ADMIN"
+        assert keys["extra.warehouse"] == "WH"
+        assert "extra" not in keys
+
+    def test_none_values_skipped(self) -> None:
+        result = _flatten_to_pairs({"host": "db.example.com", "port": None})
+        keys = [p["key"] for p in result]
+        assert "port" not in keys
+
+    def test_empty_dict(self) -> None:
+        assert _flatten_to_pairs({}) == []
+
+
+class TestPairsToFlat:
+    """Tests for _pairs_to_flat (v3 list → flat dict)."""
+
+    def test_simple_keys(self) -> None:
+        pairs = [{"key": "host", "value": "db.example.com"}, {"key": "username", "value": "admin"}]
+        result = _pairs_to_flat(pairs)
+        assert result == {"host": "db.example.com", "username": "admin"}
+
+    def test_extra_keys_nested(self) -> None:
+        pairs = [
+            {"key": "host", "value": "db.example.com"},
+            {"key": "extra.role", "value": "ACCOUNTADMIN"},
+            {"key": "extra.warehouse", "value": "MINER_WH"},
+        ]
+        result = _pairs_to_flat(pairs)
+        assert result["host"] == "db.example.com"
+        assert result["extra"] == {"role": "ACCOUNTADMIN", "warehouse": "MINER_WH"}
+        assert "extra.role" not in result
+        assert "extra.warehouse" not in result
+
+    def test_no_extra_keys(self) -> None:
+        pairs = [{"key": "host", "value": "db.example.com"}]
+        result = _pairs_to_flat(pairs)
+        assert "extra" not in result
+        assert result == {"host": "db.example.com"}
+
+    def test_empty_list(self) -> None:
+        assert _pairs_to_flat([]) == {}
+
+    def test_round_trip_with_flatten_to_pairs(self) -> None:
+        """_pairs_to_flat should reverse _flatten_to_pairs."""
+        original = {
+            "host": "snow.example.com",
+            "authType": "basic",
+            "username": "admin",
+            "password": "secret",
+            "extra": {"role": "ACCOUNTADMIN", "warehouse": "COMPUTE_WH", "database": "PROD"},
+        }
+        pairs = _flatten_to_pairs(dict(original))  # dict() because _flatten_to_pairs pops extra
+        restored = _pairs_to_flat(pairs)
+        assert restored == original
 
 
 class TestStartCredentialPersistence:

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -1023,7 +1023,9 @@ class TestPairsToFlat:
                 "database": "PROD",
             },
         }
-        pairs = _flatten_to_pairs(dict(original))  # dict() because _flatten_to_pairs pops extra
+        pairs = _flatten_to_pairs(
+            dict(original)
+        )  # dict() because _flatten_to_pairs pops extra
         restored = _pairs_to_flat(pairs)
         assert restored == original
 

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -947,12 +947,27 @@ class TestFlattenToPairs:
     def test_empty_dict(self) -> None:
         assert _flatten_to_pairs({}) == []
 
+    def test_non_dict_extra_dropped(self) -> None:
+        """Non-dict extra values are silently ignored."""
+        result = _flatten_to_pairs({"host": "db.example.com", "extra": "string"})
+        keys = {p["key"] for p in result}
+        assert keys == {"host"}
+
+    def test_mutates_input_extra_key(self) -> None:
+        """_flatten_to_pairs pops 'extra' from the input dict."""
+        creds = {"host": "db.example.com", "extra": {"role": "ADMIN"}}
+        _flatten_to_pairs(creds)
+        assert "extra" not in creds
+
 
 class TestPairsToFlat:
     """Tests for _pairs_to_flat (v3 list → flat dict)."""
 
     def test_simple_keys(self) -> None:
-        pairs = [{"key": "host", "value": "db.example.com"}, {"key": "username", "value": "admin"}]
+        pairs = [
+            {"key": "host", "value": "db.example.com"},
+            {"key": "username", "value": "admin"},
+        ]
         result = _pairs_to_flat(pairs)
         assert result == {"host": "db.example.com", "username": "admin"}
 
@@ -977,18 +992,50 @@ class TestPairsToFlat:
     def test_empty_list(self) -> None:
         assert _pairs_to_flat([]) == {}
 
+    def test_single_extra_key(self) -> None:
+        """A single extra.* key still produces a nested extra dict."""
+        pairs = [
+            {"key": "host", "value": "db.example.com"},
+            {"key": "extra.role", "value": "ADMIN"},
+        ]
+        result = _pairs_to_flat(pairs)
+        assert result == {"host": "db.example.com", "extra": {"role": "ADMIN"}}
+
+    def test_malformed_pair_raises_key_error(self) -> None:
+        """Pairs missing 'key' or 'value' raise KeyError."""
+        import pytest
+
+        with pytest.raises(KeyError):
+            _pairs_to_flat([{"key": "host"}])  # missing "value"
+        with pytest.raises(KeyError):
+            _pairs_to_flat([{"value": "db.example.com"}])  # missing "key"
+
     def test_round_trip_with_flatten_to_pairs(self) -> None:
-        """_pairs_to_flat should reverse _flatten_to_pairs."""
+        """_pairs_to_flat reverses _flatten_to_pairs for string values."""
         original = {
             "host": "snow.example.com",
             "authType": "basic",
             "username": "admin",
             "password": "secret",
-            "extra": {"role": "ACCOUNTADMIN", "warehouse": "COMPUTE_WH", "database": "PROD"},
+            "extra": {
+                "role": "ACCOUNTADMIN",
+                "warehouse": "COMPUTE_WH",
+                "database": "PROD",
+            },
         }
         pairs = _flatten_to_pairs(dict(original))  # dict() because _flatten_to_pairs pops extra
         restored = _pairs_to_flat(pairs)
         assert restored == original
+
+    def test_round_trip_lossy_for_non_string_values(self) -> None:
+        """Non-string values are stringified by _flatten_to_pairs and stay strings."""
+        original = {"host": "db.example.com", "port": 5432, "ssl": True}
+        pairs = _flatten_to_pairs(dict(original))
+        restored = _pairs_to_flat(pairs)
+        # Values are stringified — not equal to original types
+        assert restored["port"] == "5432"  # int → str
+        assert restored["ssl"] == "true"  # bool → str (json.dumps)
+        assert restored["host"] == "db.example.com"  # str stays str
 
 
 class TestStartCredentialPersistence:


### PR DESCRIPTION
## Summary

Follow-up to PR #1301. The `/start` handler's flat dict conversion used a naive `{p["key"]: p["value"]}` comprehension that doesn't handle `extra.*` keys correctly.

**Before (broken):** `"extra.role"` stays as a top-level key
```json
{"host": "...", "extra.role": "ACCOUNTADMIN", "extra.warehouse": "MINER_BENCH_100M"}
```

**After (fixed):** `extra.*` keys nested under `"extra"` dict
```json
{"host": "...", "extra": {"role": "ACCOUNTADMIN", "warehouse": "MINER_BENCH_100M"}}
```

Without this, `parse_credentials_extra()` returns `{}` and role/warehouse are silently lost.

## Changes

Add `_pairs_to_flat()` (reverse of `_flatten_to_pairs()`) and use it in the `/start` handler. One file, one function, one line changed.

## Test plan

- [x] POST `/start` with `extra.role` and `extra.warehouse` → verify `get_secret()` returns nested `extra` dict

🤖 Generated with [Claude Code](https://claude.com/claude-code)