### PR TITLE
WIP: feat: entrypoint-aware manifest serving via atlan.yaml registry

### DIFF
--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
+import yaml
 from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
@@ -269,6 +270,45 @@ _storage: ObjectStore | None = None
 
 # Directory where generated contract JSON files are stored
 CONTRACT_GENERATED_DIR = Path(_CONTRACT_GENERATED_DIR)
+
+# Path to atlan.yaml at the app repo root. Multi-entrypoint native apps
+# declare each entrypoint's ``generated_dir`` here; the SDK uses that
+# mapping to resolve ``?entrypoint={name}`` to the correct subdir of
+# ``CONTRACT_GENERATED_DIR`` at runtime.
+ATLAN_YAML_PATH = Path.cwd() / "atlan.yaml"
+
+
+def _load_entrypoint_registry() -> dict[str, str]:
+    """Return ``{entrypoint_name: generated_dir}`` from atlan.yaml.
+
+    Empty dict when atlan.yaml doesn't exist, has no ``entrypoints`` key,
+    or is malformed. Read on each call — the file is tiny and only hit on
+    manifest requests.
+    """
+    if not ATLAN_YAML_PATH.exists():
+        return {}
+    try:
+        data = yaml.safe_load(ATLAN_YAML_PATH.read_text()) or {}
+    except yaml.YAMLError as exc:
+        logger.warning(
+            "atlan.yaml is not valid YAML (%s); entrypoint registry empty", exc
+        )
+        return {}
+    packages = data.get("entrypoints") or []
+    if not isinstance(packages, list):
+        logger.warning(
+            "atlan.yaml entrypoints must be a list; entrypoint registry empty"
+        )
+        return {}
+    registry: dict[str, str] = {}
+    for i, pkg in enumerate(packages):
+        if not isinstance(pkg, dict):
+            continue
+        name = pkg.get("name")
+        generated_dir = pkg.get("generated_dir")
+        if isinstance(name, str) and isinstance(generated_dir, str):
+            registry[name] = generated_dir
+    return registry
 
 
 async def _get_temporal_client() -> Client:
@@ -1369,11 +1409,15 @@ def create_app_handler_service(
 
     @app.get("/workflows/v1/configmaps")
     async def list_configmaps() -> JSONResponse:
+        seen: set[str] = set()
         configmap_ids: list[str] = []
         if CONTRACT_GENERATED_DIR.exists():
-            for json_file in CONTRACT_GENERATED_DIR.glob("*.json"):
-                if json_file.stem != "manifest":
-                    configmap_ids.append(json_file.stem)
+            for json_file in CONTRACT_GENERATED_DIR.rglob("*.json"):
+                stem = json_file.stem
+                if stem == "manifest" or stem in seen:
+                    continue
+                seen.add(stem)
+                configmap_ids.append(stem)
         return JSONResponse(
             content=_wrap_response(
                 cast("dict[str, Any]", {"configmaps": configmap_ids}),
@@ -1386,20 +1430,39 @@ def create_app_handler_service(
     # ------------------------------------------------------------------
 
     @app.get("/workflows/v1/manifest")
-    async def get_manifest() -> Response:
+    async def get_manifest(entrypoint: str | None = None) -> Response:
+        deployment = (DEPLOYMENT_NAME or "default").encode()
+
+        if entrypoint:
+            # Multi-entrypoint: look up generated_dir from atlan.yaml registry
+            registry = _load_entrypoint_registry()
+            generated_dir = registry.get(entrypoint)
+            if generated_dir is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"No entrypoint {entrypoint!r} in atlan.yaml",
+                )
+            ep_manifest = (
+                CONTRACT_GENERATED_DIR / generated_dir / "manifest.json"
+            ).resolve()
+            if not ep_manifest.is_relative_to(CONTRACT_GENERATED_DIR.resolve()):
+                raise HTTPException(status_code=404, detail="Invalid generated_dir")
+            if not ep_manifest.exists():
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Entrypoint {entrypoint!r} has no manifest.json in {generated_dir}/",
+                )
+            raw = ep_manifest.read_bytes().replace(b"{deployment_name}", deployment)
+            return Response(content=raw, media_type="application/json")
+
+        # No entrypoint param: single-entrypoint path
         if manifest is not None:
-            # Programmatic: Pydantic model → JSON bytes, single hop.
             return Response(
                 content=manifest.model_dump_json(), media_type="application/json"
             )
         manifest_path = CONTRACT_GENERATED_DIR / "manifest.json"
         if manifest_path.exists():
-            # Disk: contract-generated file — serve raw bytes with deployment
-            # name substitution. No parse/reserialize: the file is already
-            # valid JSON, validated at build time by the contract tooling.
-            raw = manifest_path.read_bytes()
-            deployment = (DEPLOYMENT_NAME or "default").encode()
-            raw = raw.replace(b"{deployment_name}", deployment)
+            raw = manifest_path.read_bytes().replace(b"{deployment_name}", deployment)
             return Response(content=raw, media_type="application/json")
         raise HTTPException(status_code=404, detail="No manifest available")
 
@@ -1413,7 +1476,7 @@ def create_app_handler_service(
     # ------------------------------------------------------------------
 
     @app.get("/manifest", include_in_schema=False)
-    async def get_manifest_legacy() -> Response:
+    async def get_manifest_legacy(entrypoint: str | None = None) -> Response:
         """Unversioned alias for ``GET /workflows/v1/manifest``.
 
         .. deprecated::
@@ -1423,7 +1486,7 @@ def create_app_handler_service(
             orchestrators have been updated to use ``/workflows/v1/manifest``.
             Do **not** add new callers of this endpoint.
         """
-        return await get_manifest()
+        return await get_manifest(entrypoint=entrypoint)
 
     # ------------------------------------------------------------------
     # Health probes

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -6,6 +6,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
+import yaml
 from fastapi.testclient import TestClient
 
 from application_sdk.handler.base import Handler, HandlerError
@@ -28,6 +29,7 @@ from application_sdk.handler.contracts import (
 )
 from application_sdk.handler.service import (
     _flatten_to_pairs,
+    _load_entrypoint_registry,
     _normalize_credentials,
     _pairs_to_flat,
     _wrap_response,
@@ -1138,3 +1140,450 @@ class TestStartCredentialPersistence:
         assert isinstance(result, list)
         assert result[0]["key"] == "host"
         assert result[0]["value"] == "db.example.com"
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadEntrypointRegistry:
+    """Tests for _load_entrypoint_registry()."""
+
+    def test_returns_mapping_from_valid_atlan_yaml(self, tmp_path: Path) -> None:
+        """Valid atlan.yaml with entrypoints returns {name: generated_dir}."""
+        from application_sdk.handler import service as svc_module
+
+        atlan_yaml = tmp_path / "atlan.yaml"
+        atlan_yaml.write_text(
+            yaml.dump(
+                {
+                    "entrypoints": [
+                        {"name": "snowflake", "generated_dir": "snowflake-generated"},
+                        {"name": "bigquery", "generated_dir": "bigquery-generated"},
+                    ]
+                }
+            )
+        )
+
+        original = svc_module.ATLAN_YAML_PATH
+        svc_module.ATLAN_YAML_PATH = atlan_yaml
+        try:
+            registry = _load_entrypoint_registry()
+            assert registry == {
+                "snowflake": "snowflake-generated",
+                "bigquery": "bigquery-generated",
+            }
+        finally:
+            svc_module.ATLAN_YAML_PATH = original
+
+    def test_returns_empty_when_file_missing(self, tmp_path: Path) -> None:
+        """Non-existent atlan.yaml returns empty dict."""
+        from application_sdk.handler import service as svc_module
+
+        original = svc_module.ATLAN_YAML_PATH
+        svc_module.ATLAN_YAML_PATH = tmp_path / "nonexistent" / "atlan.yaml"
+        try:
+            assert _load_entrypoint_registry() == {}
+        finally:
+            svc_module.ATLAN_YAML_PATH = original
+
+    def test_returns_empty_when_malformed_yaml(self, tmp_path: Path) -> None:
+        """Malformed YAML returns empty dict."""
+        from application_sdk.handler import service as svc_module
+
+        atlan_yaml = tmp_path / "atlan.yaml"
+        atlan_yaml.write_text(":::bad yaml{{{")
+
+        original = svc_module.ATLAN_YAML_PATH
+        svc_module.ATLAN_YAML_PATH = atlan_yaml
+        try:
+            assert _load_entrypoint_registry() == {}
+        finally:
+            svc_module.ATLAN_YAML_PATH = original
+
+    def test_returns_empty_when_no_entrypoints_key(self, tmp_path: Path) -> None:
+        """atlan.yaml without entrypoints key returns empty dict."""
+        from application_sdk.handler import service as svc_module
+
+        atlan_yaml = tmp_path / "atlan.yaml"
+        atlan_yaml.write_text(yaml.dump({"name": "my-app", "version": "1.0"}))
+
+        original = svc_module.ATLAN_YAML_PATH
+        svc_module.ATLAN_YAML_PATH = atlan_yaml
+        try:
+            assert _load_entrypoint_registry() == {}
+        finally:
+            svc_module.ATLAN_YAML_PATH = original
+
+    def test_returns_empty_when_entrypoints_is_not_list(self, tmp_path: Path) -> None:
+        """atlan.yaml where entrypoints is a string returns empty dict."""
+        from application_sdk.handler import service as svc_module
+
+        atlan_yaml = tmp_path / "atlan.yaml"
+        atlan_yaml.write_text(yaml.dump({"entrypoints": "not-a-list"}))
+
+        original = svc_module.ATLAN_YAML_PATH
+        svc_module.ATLAN_YAML_PATH = atlan_yaml
+        try:
+            assert _load_entrypoint_registry() == {}
+        finally:
+            svc_module.ATLAN_YAML_PATH = original
+
+    def test_skips_entries_without_name_or_generated_dir(self, tmp_path: Path) -> None:
+        """Entries missing name or generated_dir are silently skipped."""
+        from application_sdk.handler import service as svc_module
+
+        atlan_yaml = tmp_path / "atlan.yaml"
+        atlan_yaml.write_text(
+            yaml.dump(
+                {
+                    "entrypoints": [
+                        {"name": "valid", "generated_dir": "gen"},
+                        {"name": "missing-dir"},
+                        {"generated_dir": "missing-name"},
+                        "not-a-dict",
+                    ]
+                }
+            )
+        )
+
+        original = svc_module.ATLAN_YAML_PATH
+        svc_module.ATLAN_YAML_PATH = atlan_yaml
+        try:
+            registry = _load_entrypoint_registry()
+            assert registry == {"valid": "gen"}
+        finally:
+            svc_module.ATLAN_YAML_PATH = original
+
+    def test_returns_empty_when_yaml_is_empty_file(self, tmp_path: Path) -> None:
+        """Empty atlan.yaml (parses as None) returns empty dict."""
+        from application_sdk.handler import service as svc_module
+
+        atlan_yaml = tmp_path / "atlan.yaml"
+        atlan_yaml.write_text("")
+
+        original = svc_module.ATLAN_YAML_PATH
+        svc_module.ATLAN_YAML_PATH = atlan_yaml
+        try:
+            assert _load_entrypoint_registry() == {}
+        finally:
+            svc_module.ATLAN_YAML_PATH = original
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint manifest resolution tests
+# ---------------------------------------------------------------------------
+
+
+class TestEntrypointManifestResolution:
+    """Tests for GET /workflows/v1/manifest?entrypoint={name}."""
+
+    def test_manifest_with_entrypoint_returns_correct_manifest(
+        self, tmp_path: Path
+    ) -> None:
+        """GET /manifest?entrypoint=snow resolves to correct sub-dir manifest."""
+        from application_sdk.handler import service as svc_module
+
+        # Set up atlan.yaml with entrypoints
+        atlan_yaml = tmp_path / "atlan.yaml"
+        atlan_yaml.write_text(
+            yaml.dump(
+                {
+                    "entrypoints": [
+                        {"name": "snow", "generated_dir": "snow-gen"},
+                    ]
+                }
+            )
+        )
+
+        # Set up contract generated dir with sub-dir manifest
+        contract_dir = tmp_path / "generated"
+        snow_dir = contract_dir / "snow-gen"
+        snow_dir.mkdir(parents=True)
+        manifest_data = {"execution_mode": "dag", "app_name": "snowflake-extractor"}
+        (snow_dir / "manifest.json").write_text(json.dumps(manifest_data))
+
+        original_yaml = svc_module.ATLAN_YAML_PATH
+        original_dir = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.ATLAN_YAML_PATH = atlan_yaml
+        svc_module.CONTRACT_GENERATED_DIR = contract_dir
+        try:
+            client = _make_client()
+            response = client.get("/workflows/v1/manifest?entrypoint=snow")
+            assert response.status_code == 200
+            body = response.json()
+            assert body["execution_mode"] == "dag"
+            assert body["app_name"] == "snowflake-extractor"
+        finally:
+            svc_module.ATLAN_YAML_PATH = original_yaml
+            svc_module.CONTRACT_GENERATED_DIR = original_dir
+
+    def test_manifest_substitutes_deployment_name_for_entrypoint(
+        self, tmp_path: Path
+    ) -> None:
+        """Entrypoint manifest replaces {deployment_name} placeholder."""
+        from application_sdk.handler import service as svc_module
+
+        atlan_yaml = tmp_path / "atlan.yaml"
+        atlan_yaml.write_text(
+            yaml.dump(
+                {
+                    "entrypoints": [
+                        {"name": "ep1", "generated_dir": "ep1-gen"},
+                    ]
+                }
+            )
+        )
+
+        contract_dir = tmp_path / "generated"
+        ep_dir = contract_dir / "ep1-gen"
+        ep_dir.mkdir(parents=True)
+        manifest_data = {"task_queue": "{deployment_name}-queue"}
+        (ep_dir / "manifest.json").write_text(json.dumps(manifest_data))
+
+        original_yaml = svc_module.ATLAN_YAML_PATH
+        original_dir = svc_module.CONTRACT_GENERATED_DIR
+        original_dep = svc_module.DEPLOYMENT_NAME
+        svc_module.ATLAN_YAML_PATH = atlan_yaml
+        svc_module.CONTRACT_GENERATED_DIR = contract_dir
+        svc_module.DEPLOYMENT_NAME = "prod-deploy"
+        try:
+            client = _make_client()
+            response = client.get("/workflows/v1/manifest?entrypoint=ep1")
+            assert response.status_code == 200
+            body = response.json()
+            assert body["task_queue"] == "prod-deploy-queue"
+        finally:
+            svc_module.ATLAN_YAML_PATH = original_yaml
+            svc_module.CONTRACT_GENERATED_DIR = original_dir
+            svc_module.DEPLOYMENT_NAME = original_dep
+
+    def test_unknown_entrypoint_returns_404(self, tmp_path: Path) -> None:
+        """GET /manifest?entrypoint=unknown returns 404."""
+        from application_sdk.handler import service as svc_module
+
+        atlan_yaml = tmp_path / "atlan.yaml"
+        atlan_yaml.write_text(
+            yaml.dump(
+                {
+                    "entrypoints": [
+                        {"name": "snow", "generated_dir": "snow-gen"},
+                    ]
+                }
+            )
+        )
+
+        original_yaml = svc_module.ATLAN_YAML_PATH
+        original_dir = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.ATLAN_YAML_PATH = atlan_yaml
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path / "generated"
+        try:
+            client = _make_client()
+            response = client.get("/workflows/v1/manifest?entrypoint=unknown")
+            assert response.status_code == 404
+        finally:
+            svc_module.ATLAN_YAML_PATH = original_yaml
+            svc_module.CONTRACT_GENERATED_DIR = original_dir
+
+    def test_entrypoint_with_missing_manifest_file_returns_404(
+        self, tmp_path: Path
+    ) -> None:
+        """Entrypoint exists in registry but manifest.json missing on disk."""
+        from application_sdk.handler import service as svc_module
+
+        atlan_yaml = tmp_path / "atlan.yaml"
+        atlan_yaml.write_text(
+            yaml.dump(
+                {
+                    "entrypoints": [
+                        {"name": "snow", "generated_dir": "snow-gen"},
+                    ]
+                }
+            )
+        )
+
+        # Create the contract dir but NOT the sub-dir manifest
+        contract_dir = tmp_path / "generated"
+        contract_dir.mkdir(parents=True)
+
+        original_yaml = svc_module.ATLAN_YAML_PATH
+        original_dir = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.ATLAN_YAML_PATH = atlan_yaml
+        svc_module.CONTRACT_GENERATED_DIR = contract_dir
+        try:
+            client = _make_client()
+            response = client.get("/workflows/v1/manifest?entrypoint=snow")
+            assert response.status_code == 404
+        finally:
+            svc_module.ATLAN_YAML_PATH = original_yaml
+            svc_module.CONTRACT_GENERATED_DIR = original_dir
+
+    def test_path_traversal_in_generated_dir_returns_404(self, tmp_path: Path) -> None:
+        """generated_dir with path traversal (../) is rejected with 404."""
+        from application_sdk.handler import service as svc_module
+
+        atlan_yaml = tmp_path / "atlan.yaml"
+        atlan_yaml.write_text(
+            yaml.dump(
+                {
+                    "entrypoints": [
+                        {"name": "evil", "generated_dir": "../../etc"},
+                    ]
+                }
+            )
+        )
+
+        contract_dir = tmp_path / "generated"
+        contract_dir.mkdir(parents=True)
+
+        original_yaml = svc_module.ATLAN_YAML_PATH
+        original_dir = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.ATLAN_YAML_PATH = atlan_yaml
+        svc_module.CONTRACT_GENERATED_DIR = contract_dir
+        try:
+            client = _make_client()
+            response = client.get("/workflows/v1/manifest?entrypoint=evil")
+            assert response.status_code == 404
+        finally:
+            svc_module.ATLAN_YAML_PATH = original_yaml
+            svc_module.CONTRACT_GENERATED_DIR = original_dir
+
+    def test_legacy_manifest_alias_forwards_entrypoint(self, tmp_path: Path) -> None:
+        """GET /manifest?entrypoint=name uses the legacy alias correctly."""
+        from application_sdk.handler import service as svc_module
+
+        atlan_yaml = tmp_path / "atlan.yaml"
+        atlan_yaml.write_text(
+            yaml.dump(
+                {
+                    "entrypoints": [
+                        {"name": "snow", "generated_dir": "snow-gen"},
+                    ]
+                }
+            )
+        )
+
+        contract_dir = tmp_path / "generated"
+        snow_dir = contract_dir / "snow-gen"
+        snow_dir.mkdir(parents=True)
+        manifest_data = {"app_name": "snow-app"}
+        (snow_dir / "manifest.json").write_text(json.dumps(manifest_data))
+
+        original_yaml = svc_module.ATLAN_YAML_PATH
+        original_dir = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.ATLAN_YAML_PATH = atlan_yaml
+        svc_module.CONTRACT_GENERATED_DIR = contract_dir
+        try:
+            client = _make_client()
+            response = client.get("/manifest?entrypoint=snow")
+            assert response.status_code == 200
+            body = response.json()
+            assert body["app_name"] == "snow-app"
+        finally:
+            svc_module.ATLAN_YAML_PATH = original_yaml
+            svc_module.CONTRACT_GENERATED_DIR = original_dir
+
+    def test_no_entrypoint_param_serves_root_manifest(self, tmp_path: Path) -> None:
+        """Without entrypoint param, serves root manifest unchanged."""
+        from application_sdk.handler import service as svc_module
+
+        contract_dir = tmp_path / "generated"
+        contract_dir.mkdir(parents=True)
+        manifest_data = {"execution_mode": "linear"}
+        (contract_dir / "manifest.json").write_text(json.dumps(manifest_data))
+
+        original_dir = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = contract_dir
+        try:
+            client = _make_client()
+            response = client.get("/workflows/v1/manifest")
+            assert response.status_code == 200
+            body = response.json()
+            assert body["execution_mode"] == "linear"
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original_dir
+
+
+# ---------------------------------------------------------------------------
+# Configmaps deduplication tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigMapsDeduplication:
+    """Tests for list_configmaps deduplication across subdirectories."""
+
+    def test_configmaps_dedupes_across_subdirs(self, tmp_path: Path) -> None:
+        """Configmaps with same stem in different subdirs appear only once."""
+        from application_sdk.handler import service as svc_module
+
+        # Root-level configs
+        (tmp_path / "config-a.json").write_text("{}")
+        (tmp_path / "config-b.json").write_text("{}")
+
+        # Sub-directory with duplicate stem + new config
+        subdir = tmp_path / "snow-gen"
+        subdir.mkdir()
+        (subdir / "config-a.json").write_text("{}")  # duplicate of root
+        (subdir / "config-c.json").write_text("{}")
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            client = _make_client()
+            response = client.get("/workflows/v1/configmaps")
+            assert response.status_code == 200
+            configmaps = response.json()["data"]["configmaps"]
+            # config-a should appear only once despite being in root and subdir
+            assert configmaps.count("config-a") == 1
+            assert "config-b" in configmaps
+            assert "config-c" in configmaps
+            assert "manifest" not in configmaps
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
+    def test_configmaps_rglob_finds_nested_configs(self, tmp_path: Path) -> None:
+        """rglob finds JSON files in nested sub-directories."""
+        from application_sdk.handler import service as svc_module
+
+        # Only sub-directory configs, no root configs
+        subdir = tmp_path / "entrypoint-a"
+        subdir.mkdir()
+        (subdir / "nested-config.json").write_text("{}")
+
+        deep_subdir = tmp_path / "entrypoint-b" / "deep"
+        deep_subdir.mkdir(parents=True)
+        (deep_subdir / "deep-config.json").write_text("{}")
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            client = _make_client()
+            response = client.get("/workflows/v1/configmaps")
+            assert response.status_code == 200
+            configmaps = response.json()["data"]["configmaps"]
+            assert "nested-config" in configmaps
+            assert "deep-config" in configmaps
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
+    def test_configmaps_excludes_manifest_in_subdirs(self, tmp_path: Path) -> None:
+        """manifest.json in subdirectories is also excluded."""
+        from application_sdk.handler import service as svc_module
+
+        subdir = tmp_path / "ep-gen"
+        subdir.mkdir()
+        (subdir / "manifest.json").write_text("{}")
+        (subdir / "real-config.json").write_text("{}")
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            client = _make_client()
+            response = client.get("/workflows/v1/configmaps")
+            assert response.status_code == 200
+            configmaps = response.json()["data"]["configmaps"]
+            assert "manifest" not in configmaps
+            assert "real-config" in configmaps
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original


### PR DESCRIPTION
> **Work in progress** — targets refactor-v3. Part of the Multi-Entrypoint Native App effort.

## Summary

Adds entrypoint-aware manifest resolution to the v3 service layer (`handler/service.py`):

- `_load_entrypoint_registry()`: reads `atlan.yaml.entrypoints[]` → `{name: generated_dir}` map
- `GET /manifest?entrypoint={name}`: resolves via registry to `{CONTRACT_GENERATED_DIR}/{generated_dir}/manifest.json`
- Path traversal defense on `generated_dir`
- `{deployment_name}` substitution on entrypoint manifests
- Legacy `/manifest` alias forwards `?entrypoint=` too
- `list_configmaps`: glob → rglob + dedupe by stem

## Backwards-compat

No `entrypoints` in atlan.yaml → empty registry → no-entrypoint requests serve root manifest unchanged.

## Tests (17 tests across 3 classes)

- `TestLoadEntrypointRegistry` (7): valid yaml, missing file, malformed, no key, not-a-list, missing fields, empty file
- `TestEntrypointManifestResolution` (7): correct resolution, deployment_name substitution, unknown 404, missing manifest 404, path traversal, legacy alias, no-param root
- `TestConfigMapsDeduplication` (3): cross-subdir dedup, rglob nested, manifest exclusion