### PR TITLE
feat: read app vitals release metadata from env vars

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -138,6 +138,18 @@ WORKFLOW_TLS_ENABLED = (
     os.getenv("ATLAN_WORKFLOW_TLS_ENABLED", "false").lower() == "true"
 )
 
+# App Vitals / Release metadata (injected by Local Marketplace into HelmRelease)
+#: Semantic version of the app release (e.g., "1.2.3")
+APPLICATION_VERSION = os.getenv("ATLAN_APPLICATION_VERSION", "")
+#: Release UUID from Global Marketplace
+RELEASE_ID = os.getenv("ATLAN_RELEASE_ID", "")
+#: Release channel (all, beta, staging, specific)
+RELEASE_CHANNEL = os.getenv("ATLAN_RELEASE_CHANNEL", "")
+#: SDK version used to build this app image
+APP_SDK_VERSION = os.getenv("ATLAN_SDK_VERSION", "")
+#: App type from Global Marketplace (connector, system, etc.)
+APP_TYPE = os.getenv("ATLAN_APP_TYPE", "")
+
 # Deployment Secret Store Key Names
 #: Key name for OAuth2 client ID in deployment secrets (can be overridden via ATLAN_AUTH_CLIENT_ID_KEY)
 WORKFLOW_AUTH_CLIENT_ID_KEY = os.getenv(

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -149,6 +149,8 @@ RELEASE_CHANNEL = os.getenv("ATLAN_RELEASE_CHANNEL", "")
 APP_SDK_VERSION = os.getenv("ATLAN_SDK_VERSION", "")
 #: App type from Global Marketplace (connector, system, etc.)
 APP_TYPE = os.getenv("ATLAN_APP_TYPE", "")
+#: Release publication timestamp from Global Marketplace (ISO 8601)
+PUBLISHED_AT = os.getenv("ATLAN_PUBLISHED_AT", "")
 
 # Deployment Secret Store Key Names
 #: Key name for OAuth2 client ID in deployment secrets (can be overridden via ATLAN_AUTH_CLIENT_ID_KEY)

--- a/application_sdk/interceptors/models.py
+++ b/application_sdk/interceptors/models.py
@@ -9,7 +9,15 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
-from application_sdk.constants import APPLICATION_NAME, WORKER_START_EVENT_VERSION
+from application_sdk.constants import (
+    APP_SDK_VERSION,
+    APP_TYPE,
+    APPLICATION_NAME,
+    APPLICATION_VERSION,
+    RELEASE_CHANNEL,
+    RELEASE_ID,
+    WORKER_START_EVENT_VERSION,
+)
 
 
 class EventTypes(Enum):
@@ -179,6 +187,12 @@ class WorkerStartEventData(BaseModel):
     activity_count: int
     build_id: Optional[str] = None
     use_worker_versioning: bool = False
+    # App vitals metadata (injected by Local Marketplace via env vars)
+    application_version: str = APPLICATION_VERSION
+    release_id: str = RELEASE_ID
+    release_channel: str = RELEASE_CHANNEL
+    sdk_version: str = APP_SDK_VERSION
+    app_type: str = APP_TYPE
 
 
 class WorkerTokenRefreshEventData(BaseModel):

--- a/application_sdk/interceptors/models.py
+++ b/application_sdk/interceptors/models.py
@@ -14,6 +14,7 @@ from application_sdk.constants import (
     APP_TYPE,
     APPLICATION_NAME,
     APPLICATION_VERSION,
+    PUBLISHED_AT,
     RELEASE_CHANNEL,
     RELEASE_ID,
     WORKER_START_EVENT_VERSION,
@@ -193,6 +194,7 @@ class WorkerStartEventData(BaseModel):
     release_channel: str = RELEASE_CHANNEL
     sdk_version: str = APP_SDK_VERSION
     app_type: str = APP_TYPE
+    published_at: str = PUBLISHED_AT
 
 
 class WorkerTokenRefreshEventData(BaseModel):

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -15,7 +15,10 @@ from opentelemetry.trace.span import TraceFlags
 from pydantic import BaseModel, Field
 
 from application_sdk.constants import (
+    APP_SDK_VERSION,
+    APP_TYPE,
     APPLICATION_NAME,
+    APPLICATION_VERSION,
     ENABLE_OBSERVABILITY_DAPR_SINK,
     ENABLE_OTLP_LOGS,
     ENABLE_OTLP_WORKFLOW_LOGS,
@@ -33,6 +36,8 @@ from application_sdk.constants import (
     OTEL_RESOURCE_ATTRIBUTES,
     OTEL_WF_NODE_NAME,
     OTEL_WORKFLOW_LOGS_ENDPOINT,
+    RELEASE_CHANNEL,
+    RELEASE_ID,
     SERVICE_NAME,
     SERVICE_VERSION,
 )
@@ -438,6 +443,17 @@ class AtlanLoggerAdapter(AtlanObservability[LogRecordModel]):
                 if "service.version" not in resource_attributes:
                     resource_attributes["service.version"] = SERVICE_VERSION
                 resource_attributes["sdk.version"] = _SDK_VERSION
+                # App vitals metadata from Local Marketplace
+                if APPLICATION_VERSION:
+                    resource_attributes["app.version"] = APPLICATION_VERSION
+                if RELEASE_ID:
+                    resource_attributes["app.release_id"] = RELEASE_ID
+                if RELEASE_CHANNEL:
+                    resource_attributes["app.release_channel"] = RELEASE_CHANNEL
+                if APP_SDK_VERSION:
+                    resource_attributes["app.sdk_version"] = APP_SDK_VERSION
+                if APP_TYPE:
+                    resource_attributes["app.type"] = APP_TYPE
                 workflow_node_name = OTEL_WF_NODE_NAME
                 if workflow_node_name:
                     resource_attributes["k8s.workflow.node.name"] = workflow_node_name

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -36,6 +36,7 @@ from application_sdk.constants import (
     OTEL_RESOURCE_ATTRIBUTES,
     OTEL_WF_NODE_NAME,
     OTEL_WORKFLOW_LOGS_ENDPOINT,
+    PUBLISHED_AT,
     RELEASE_CHANNEL,
     RELEASE_ID,
     SERVICE_NAME,
@@ -454,6 +455,8 @@ class AtlanLoggerAdapter(AtlanObservability[LogRecordModel]):
                     resource_attributes["app.sdk_version"] = APP_SDK_VERSION
                 if APP_TYPE:
                     resource_attributes["app.type"] = APP_TYPE
+                if PUBLISHED_AT:
+                    resource_attributes["app.published_at"] = PUBLISHED_AT
                 workflow_node_name = OTEL_WF_NODE_NAME
                 if workflow_node_name:
                     resource_attributes["k8s.workflow.node.name"] = workflow_node_name

--- a/application_sdk/observability/metrics_adaptor.py
+++ b/application_sdk/observability/metrics_adaptor.py
@@ -12,6 +12,9 @@ from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
 
 from application_sdk.constants import (
+    APP_SDK_VERSION,
+    APP_TYPE,
+    APPLICATION_VERSION,
     ENABLE_OTLP_METRICS,
     METRICS_BATCH_SIZE,
     METRICS_CLEANUP_ENABLED,
@@ -23,6 +26,8 @@ from application_sdk.constants import (
     OTEL_EXPORTER_TIMEOUT_SECONDS,
     OTEL_RESOURCE_ATTRIBUTES,
     OTEL_WF_NODE_NAME,
+    RELEASE_CHANNEL,
+    RELEASE_ID,
     SEGMENT_API_URL,
     SEGMENT_BATCH_SIZE,
     SEGMENT_BATCH_TIMEOUT_SECONDS,
@@ -136,6 +141,18 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
                 resource_attributes["service.name"] = SERVICE_NAME
             if "service.version" not in resource_attributes:
                 resource_attributes["service.version"] = SERVICE_VERSION
+
+            # App vitals metadata from Local Marketplace
+            if APPLICATION_VERSION:
+                resource_attributes["app.version"] = APPLICATION_VERSION
+            if RELEASE_ID:
+                resource_attributes["app.release_id"] = RELEASE_ID
+            if RELEASE_CHANNEL:
+                resource_attributes["app.release_channel"] = RELEASE_CHANNEL
+            if APP_SDK_VERSION:
+                resource_attributes["app.sdk_version"] = APP_SDK_VERSION
+            if APP_TYPE:
+                resource_attributes["app.type"] = APP_TYPE
 
             # Add workflow node name if running in Argo
             if workflow_node_name:

--- a/application_sdk/observability/metrics_adaptor.py
+++ b/application_sdk/observability/metrics_adaptor.py
@@ -26,6 +26,7 @@ from application_sdk.constants import (
     OTEL_EXPORTER_TIMEOUT_SECONDS,
     OTEL_RESOURCE_ATTRIBUTES,
     OTEL_WF_NODE_NAME,
+    PUBLISHED_AT,
     RELEASE_CHANNEL,
     RELEASE_ID,
     SEGMENT_API_URL,
@@ -153,6 +154,8 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
                 resource_attributes["app.sdk_version"] = APP_SDK_VERSION
             if APP_TYPE:
                 resource_attributes["app.type"] = APP_TYPE
+            if PUBLISHED_AT:
+                resource_attributes["app.published_at"] = PUBLISHED_AT
 
             # Add workflow node name if running in Argo
             if workflow_node_name:

--- a/application_sdk/observability/traces_adaptor.py
+++ b/application_sdk/observability/traces_adaptor.py
@@ -13,12 +13,17 @@ from opentelemetry.trace import SpanKind
 from pydantic import BaseModel
 
 from application_sdk.constants import (
+    APP_SDK_VERSION,
+    APP_TYPE,
+    APPLICATION_VERSION,
     ENABLE_OTLP_TRACES,
     OTEL_BATCH_DELAY_MS,
     OTEL_EXPORTER_OTLP_ENDPOINT,
     OTEL_EXPORTER_TIMEOUT_SECONDS,
     OTEL_RESOURCE_ATTRIBUTES,
     OTEL_WF_NODE_NAME,
+    RELEASE_CHANNEL,
+    RELEASE_ID,
     SERVICE_NAME,
     SERVICE_VERSION,
     TRACES_BATCH_SIZE,
@@ -142,6 +147,18 @@ class AtlanTracesAdapter(AtlanObservability[TraceRecord]):
                 resource_attributes["service.name"] = SERVICE_NAME
             if "service.version" not in resource_attributes:
                 resource_attributes["service.version"] = SERVICE_VERSION
+
+            # App vitals metadata from Local Marketplace
+            if APPLICATION_VERSION:
+                resource_attributes["app.version"] = APPLICATION_VERSION
+            if RELEASE_ID:
+                resource_attributes["app.release_id"] = RELEASE_ID
+            if RELEASE_CHANNEL:
+                resource_attributes["app.release_channel"] = RELEASE_CHANNEL
+            if APP_SDK_VERSION:
+                resource_attributes["app.sdk_version"] = APP_SDK_VERSION
+            if APP_TYPE:
+                resource_attributes["app.type"] = APP_TYPE
 
             # Add workflow node name if running in Argo
             if workflow_node_name:

--- a/application_sdk/observability/traces_adaptor.py
+++ b/application_sdk/observability/traces_adaptor.py
@@ -22,6 +22,7 @@ from application_sdk.constants import (
     OTEL_EXPORTER_TIMEOUT_SECONDS,
     OTEL_RESOURCE_ATTRIBUTES,
     OTEL_WF_NODE_NAME,
+    PUBLISHED_AT,
     RELEASE_CHANNEL,
     RELEASE_ID,
     SERVICE_NAME,
@@ -159,6 +160,8 @@ class AtlanTracesAdapter(AtlanObservability[TraceRecord]):
                 resource_attributes["app.sdk_version"] = APP_SDK_VERSION
             if APP_TYPE:
                 resource_attributes["app.type"] = APP_TYPE
+            if PUBLISHED_AT:
+                resource_attributes["app.published_at"] = PUBLISHED_AT
 
             # Add workflow node name if running in Argo
             if workflow_node_name:


### PR DESCRIPTION
## Summary
- Adds constants for `ATLAN_APPLICATION_VERSION`, `ATLAN_RELEASE_ID`, `ATLAN_RELEASE_CHANNEL`, `ATLAN_SDK_VERSION`, and `ATLAN_APP_TYPE` env vars (injected by Local Marketplace)
- Includes these in `WorkerStartEventData` (published on worker startup)
- Includes as OTEL resource attributes (`app.version`, `app.release_id`, `app.release_channel`, `app.sdk_version`, `app.type`) on all logs, metrics, and traces

## Context
Part of [ARUN-481](https://linear.app/atlan-epd/issue/ARUN-481/inject-atlan-application-version-env-var-into-helmrelease) — enables app-vitals observability.

**Depends on**: atlanhq/atlan-local-marketplace-app PR (injects env vars into HelmRelease).

Apps must be rebuilt with this SDK version to emit the new metadata. Existing apps continue to work (all new fields have empty string defaults).

## Changes
| File | Change |
|------|--------|
| `application_sdk/constants.py` | Add 5 new env var constants |
| `application_sdk/interceptors/models.py` | Add 5 fields to `WorkerStartEventData` |
| `application_sdk/observability/logger_adaptor.py` | Add `app.*` resource attributes to OTEL logs |
| `application_sdk/observability/metrics_adaptor.py` | Add `app.*` resource attributes to OTEL metrics |
| `application_sdk/observability/traces_adaptor.py` | Add `app.*` resource attributes to OTEL traces |

## Test plan
- [ ] Verify constants load correctly when env vars are set/unset
- [ ] Verify `WorkerStartEventData` includes new fields with defaults
- [ ] Verify OTEL resource attributes include `app.*` fields when env vars are set
- [ ] Verify no change in behavior when env vars are not set (empty string defaults, attributes not added)