### PR TITLE
feat: centralize base allowlist and dashboard template

### DIFF
--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -242,6 +242,12 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - name: Fetch base allowlist from SDK
+        run: |
+          curl -sH "Authorization: token ${{ secrets.ORG_PAT_GITHUB || github.token }}" \
+            "https://raw.githubusercontent.com/atlanhq/application-sdk/main/.security/base-allowlist.json" \
+            -o /tmp/base-allowlist.json 2>/dev/null || echo "{}" > /tmp/base-allowlist.json
+
       - name: Download Trivy results
         uses: actions/download-artifact@v4
         continue-on-error: true
@@ -264,14 +270,31 @@ jobs:
           import json, sys, os
           from datetime import datetime
 
-          allowlist_path = ".security/allowlist.json"
-          if os.path.exists(allowlist_path):
-              with open(allowlist_path) as f:
-                  allowlist = json.load(f)
+          # Merge base allowlist (from SDK) + repo allowlist
+          allowlist = {}
+          try:
+              with open("/tmp/base-allowlist.json") as f:
+                  base = json.load(f)
+              allowlist.update({k: v for k, v in base.items() if not k.startswith("_")})
+              print(f"Base allowlist: {len(allowlist)} entries")
+          except:
+              pass
+
+          repo_allowlist_path = ".security/allowlist.json"
+          if os.path.exists(repo_allowlist_path):
+              with open(repo_allowlist_path) as f:
+                  repo_al = json.load(f)
+              repo_entries = {k: v for k, v in repo_al.items() if not k.startswith("_")}
+              allowlist.update(repo_entries)
+              print(f"Repo allowlist: {len(repo_entries)} entries")
           else:
-              print("No .security/allowlist.json found — all vulnerabilities will be reported but not blocked.")
-              print("To enable the security gate, add .security/allowlist.json to your repo.")
+              print("No .security/allowlist.json in repo")
+
+          if not allowlist:
+              print("No allowlists found — all vulnerabilities will be reported but not blocked.")
               allowlist = None
+
+          print(f"Total allowlist: {len(allowlist) if allowlist else 0} entries")
 
           today = datetime.now().strftime("%Y-%m-%d")
           all_vulns = {}

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -246,6 +246,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: atlanhq/application-sdk
+          ref: ${{ github.workflow_sha || 'main' }}
           sparse-checkout: .security
           path: _sdk
           token: ${{ secrets.ORG_PAT_GITHUB || github.token }}

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -242,11 +242,13 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Fetch base allowlist from SDK
-        run: |
-          curl -sH "Authorization: token ${{ secrets.ORG_PAT_GITHUB || github.token }}" \
-            "https://raw.githubusercontent.com/atlanhq/application-sdk/main/.security/base-allowlist.json" \
-            -o /tmp/base-allowlist.json 2>/dev/null || echo "{}" > /tmp/base-allowlist.json
+      - name: Checkout base allowlist from SDK
+        uses: actions/checkout@v4
+        with:
+          repository: atlanhq/application-sdk
+          sparse-checkout: .security/base-allowlist.json
+          path: _sdk
+          token: ${{ secrets.ORG_PAT_GITHUB || github.token }}
 
       - name: Download Trivy results
         uses: actions/download-artifact@v4
@@ -270,25 +272,43 @@ jobs:
           import json, sys, os
           from datetime import datetime
 
-          # Merge base allowlist (from SDK) + repo allowlist
-          allowlist = {}
+          # Load base allowlist (from SDK) — base entries always win on conflict
+          base_allowlist = {}
+          base_path = "_sdk/.security/base-allowlist.json"
           try:
-              with open("/tmp/base-allowlist.json") as f:
-                  base = json.load(f)
-              allowlist.update({k: v for k, v in base.items() if not k.startswith("_")})
-              print(f"Base allowlist: {len(allowlist)} entries")
-          except:
-              pass
+              with open(base_path) as f:
+                  base_raw = json.load(f)
+              base_allowlist = {k: v for k, v in base_raw.items() if not k.startswith("_")}
+              print(f"Base allowlist: {len(base_allowlist)} entries")
+          except FileNotFoundError:
+              print(f"Warning: {base_path} not found — no base allowlist")
+          except json.JSONDecodeError as e:
+              print(f"Error: base allowlist has invalid JSON: {e}")
+              sys.exit(1)
 
-          repo_allowlist_path = ".security/allowlist.json"
-          if os.path.exists(repo_allowlist_path):
-              with open(repo_allowlist_path) as f:
-                  repo_al = json.load(f)
-              repo_entries = {k: v for k, v in repo_al.items() if not k.startswith("_")}
-              allowlist.update(repo_entries)
-              print(f"Repo allowlist: {len(repo_entries)} entries")
-          else:
-              print("No .security/allowlist.json in repo")
+          # Load repo allowlist
+          repo_allowlist = {}
+          repo_path = ".security/allowlist.json"
+          try:
+              if os.path.exists(repo_path):
+                  with open(repo_path) as f:
+                      repo_raw = json.load(f)
+                  repo_allowlist = {k: v for k, v in repo_raw.items() if not k.startswith("_")}
+                  print(f"Repo allowlist: {len(repo_allowlist)} entries")
+              else:
+                  print("No .security/allowlist.json in repo")
+          except json.JSONDecodeError as e:
+              print(f"Error: repo allowlist has invalid JSON: {e}")
+              sys.exit(1)
+
+          # Merge: repo first, then base overwrites — base always wins on conflict
+          allowlist = {}
+          allowlist.update(repo_allowlist)
+          conflicts = [k for k in base_allowlist if k in repo_allowlist]
+          if conflicts:
+              for c in conflicts:
+                  print(f"Warning: conflict on {c} — base allowlist wins (repo entry ignored)")
+          allowlist.update(base_allowlist)
 
           if not allowlist:
               print("No allowlists found — all vulnerabilities will be reported but not blocked.")

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -246,7 +246,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: atlanhq/application-sdk
-          sparse-checkout: .security/base-allowlist.json
+          sparse-checkout: .security
           path: _sdk
           token: ${{ secrets.ORG_PAT_GITHUB || github.token }}
 

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -246,7 +246,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: atlanhq/application-sdk
-          ref: ${{ github.workflow_sha || 'main' }}
+          ref: main
           sparse-checkout: .security
           path: _sdk
           token: ${{ secrets.ORG_PAT_GITHUB || github.token }}

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -1,7 +1,7 @@
 # Update Security Dashboard — reusable workflow.
 #
 # Triggered after a vulnerability scan completes. Downloads scan results,
-# generates dashboard data, and deploys to Kryptonite (k.atlan.dev).
+# generates per-repo dashboard data, and deploys to Kryptonite (k.atlan.dev).
 #
 # Usage in each app repo:
 #   on:
@@ -9,6 +9,10 @@
 #       workflows: ["Vulnerability Scan"]
 #       types: [completed]
 #     workflow_dispatch:
+#   permissions:
+#     id-token: write
+#     actions: read
+#     contents: read
 #   jobs:
 #     dashboard:
 #       uses: atlanhq/application-sdk/.github/workflows/update-dashboard.yaml@main
@@ -24,6 +28,11 @@ on:
         required: false
         type: string
         default: "security-dashboard"
+      scan_workflow:
+        description: "Name of the scan workflow file to download artifacts from"
+        required: false
+        type: string
+        default: "vulnerability-scan.yml"
     secrets:
       ORG_PAT_GITHUB:
         required: false
@@ -39,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Checkout
+      - name: Checkout repo
         uses: actions/checkout@v4
 
       - name: Checkout dashboard assets from SDK
@@ -47,42 +56,33 @@ jobs:
         with:
           repository: atlanhq/application-sdk
           path: _sdk
-          sparse-checkout: .security/dashboard
+          sparse-checkout: .security
           token: ${{ secrets.ORG_PAT_GITHUB || secrets.GITHUB_TOKEN }}
 
       - name: Download latest scan artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SCAN_WORKFLOW: ${{ inputs.scan_workflow }}
         run: |
           mkdir -p /tmp/scan-artifacts
 
           RUN_ID=$(gh run list \
-            --workflow="vulnerability-scan.yml" \
+            --workflow="${SCAN_WORKFLOW}" \
             --status=completed \
             --limit=5 \
             --json databaseId,conclusion \
             --jq '[.[] | select(.conclusion=="success" or .conclusion=="failure")] | .[0].databaseId')
 
           if [ -z "$RUN_ID" ]; then
-            echo "No scan runs found"
-            exit 0
+            echo "::error::No completed runs found for workflow ${SCAN_WORKFLOW}"
+            exit 1
           fi
 
           echo "Downloading artifacts from run $RUN_ID"
           gh run download "$RUN_ID" --name trivy-results --dir /tmp/scan-artifacts || echo "No trivy results"
           gh run download "$RUN_ID" --name snyk-results --dir /tmp/scan-artifacts || echo "No snyk results"
 
-      - name: Fetch base allowlist from SDK
-        run: |
-          if [ -f _sdk/.security/base-allowlist.json ]; then
-            cp _sdk/.security/base-allowlist.json /tmp/base-allowlist.json
-            echo "Base allowlist loaded"
-          else
-            echo "{}" > /tmp/base-allowlist.json
-            echo "No base allowlist found"
-          fi
-
-      - name: Generate dashboard data
+      - name: Generate per-repo dashboard data
         run: |
           python3 - <<'PYEOF'
           import json, os
@@ -93,15 +93,25 @@ jobs:
           # Merge base + repo allowlists
           allowlist = {}
           try:
-              with open("/tmp/base-allowlist.json") as f:
+              with open("_sdk/.security/base-allowlist.json") as f:
                   base = json.load(f)
               allowlist.update({k: v for k, v in base.items() if not k.startswith("_")})
-          except: pass
+          except FileNotFoundError:
+              print("Warning: base allowlist not found")
+          except json.JSONDecodeError as e:
+              print(f"Warning: base allowlist invalid JSON: {e}")
 
-          if os.path.exists(".security/allowlist.json"):
-              with open(".security/allowlist.json") as f:
-                  repo_al = json.load(f)
-              allowlist.update({k: v for k, v in repo_al.items() if not k.startswith("_")})
+          try:
+              if os.path.exists(".security/allowlist.json"):
+                  with open(".security/allowlist.json") as f:
+                      repo_al = json.load(f)
+                  repo_entries = {k: v for k, v in repo_al.items() if not k.startswith("_")}
+                  # Base wins on conflict
+                  for k in list(repo_entries.keys()):
+                      if k not in allowlist:
+                          allowlist[k] = repo_entries[k]
+          except json.JSONDecodeError as e:
+              print(f"Warning: repo allowlist invalid JSON: {e}")
 
           today = datetime.now().strftime("%Y-%m-%d")
           all_vulns = []
@@ -131,21 +141,28 @@ jobs:
                               "source_type": "app" if is_app else "base_image",
                               "status": status,
                           })
-          except Exception as e:
-              print(f"Trivy: {e}")
+          except FileNotFoundError:
+              print("Warning: no Trivy results")
+          except json.JSONDecodeError as e:
+              print(f"Warning: Trivy results invalid JSON: {e}")
 
           # Parse Snyk
           try:
               with open("/tmp/scan-artifacts/snyk_results.json") as f:
                   snyk = json.load(f)
               if not snyk.get("error"):
+                  trivy_ids = {v["id"] for v in all_vulns}
+
+                  # Top-level vulns — infer source_type from package manager
                   for vuln in snyk.get("vulnerabilities", []):
                       vid = vuln.get("id")
                       if vid:
-                          trivy_ids = {v["id"] for v in all_vulns}
                           cves = vuln.get("identifiers", {}).get("CVE", [])
                           if vid in trivy_ids or any(c in trivy_ids for c in cves):
                               continue
+                          lang = vuln.get("language", "").lower()
+                          pkg_manager = vuln.get("packageManager", "").lower()
+                          is_app = lang in ("python", "js", "ruby") or pkg_manager in ("pip", "npm", "yarn", "poetry", "uv")
                           entry = allowlist.get(vid)
                           if entry:
                               status = "expired" if today > entry.get("expires", "9999-12-31") else "allowlisted"
@@ -158,11 +175,34 @@ jobs:
                               "installed": vuln.get("version", ""),
                               "fixed": ", ".join(vuln.get("fixedIn", [])) if vuln.get("fixedIn") else "",
                               "scanner": "snyk",
-                              "source_type": "base_image",
+                              "source_type": "app" if is_app else "base_image",
                               "status": status,
                           })
-          except Exception as e:
-              print(f"Snyk: {e}")
+
+                  # Application dependencies
+                  for app in snyk.get("applications", []):
+                      for vuln in app.get("vulnerabilities", []):
+                          vid = vuln.get("id")
+                          if vid and vid not in trivy_ids:
+                              entry = allowlist.get(vid)
+                              if entry:
+                                  status = "expired" if today > entry.get("expires", "9999-12-31") else "allowlisted"
+                              else:
+                                  status = "new"
+                              all_vulns.append({
+                                  "id": vid,
+                                  "severity": vuln.get("severity", "").upper(),
+                                  "package": vuln.get("packageName") or vuln.get("name", ""),
+                                  "installed": vuln.get("version", ""),
+                                  "fixed": ", ".join(vuln.get("fixedIn", [])) if vuln.get("fixedIn") else "",
+                                  "scanner": "snyk",
+                                  "source_type": "app",
+                                  "status": status,
+                              })
+          except FileNotFoundError:
+              print("Warning: no Snyk results")
+          except json.JSONDecodeError as e:
+              print(f"Warning: Snyk results invalid JSON: {e}")
 
           # Deduplicate
           seen = set()
@@ -172,15 +212,10 @@ jobs:
                   seen.add(v["id"])
                   unique.append(v)
 
-          # Build data
-          data_path = "_sdk/.security/dashboard/data.json"
-          if os.path.exists(data_path):
-              with open(data_path) as f:
-                  data = json.load(f)
-          else:
-              data = {"repos": {}, "generated_at": ""}
-
-          data["repos"][repo_name] = {
+          # Write per-repo data file (not shared data.json)
+          repo_slug = repo_name.replace("/", "_")
+          repo_data = {
+              "repo": repo_name,
               "vulnerabilities": unique,
               "scanned_at": datetime.now().isoformat() + "Z",
               "total": len(unique),
@@ -189,13 +224,24 @@ jobs:
               "allowlisted": sum(1 for v in unique if v["status"] == "allowlisted"),
               "new": sum(1 for v in unique if v["status"] == "new"),
           }
-          data["generated_at"] = datetime.now().isoformat() + "Z"
 
-          os.makedirs("_sdk/.security/dashboard", exist_ok=True)
-          with open(data_path, "w") as f:
-              json.dump(data, f, indent=2)
+          os.makedirs("/tmp/dashboard-deploy/repos", exist_ok=True)
 
-          print(f"Dashboard updated: {len(unique)} vulnerabilities for {repo_name}")
+          # Write this repo's data
+          with open(f"/tmp/dashboard-deploy/repos/{repo_slug}.json", "w") as f:
+              json.dump(repo_data, f, indent=2)
+
+          # Copy dashboard HTML
+          html_src = "_sdk/.security/dashboard/index.html"
+          if os.path.exists(html_src):
+              import shutil
+              shutil.copy(html_src, "/tmp/dashboard-deploy/index.html")
+
+          print(f"Dashboard data generated: {len(unique)} vulnerabilities for {repo_name}")
+          print(f"  CRITICAL: {repo_data['critical']}")
+          print(f"  HIGH: {repo_data['high']}")
+          print(f"  Allowlisted: {repo_data['allowlisted']}")
+          print(f"  New: {repo_data['new']}")
           PYEOF
 
       - name: Setup AWS Credentials
@@ -205,6 +251,19 @@ jobs:
           role-to-assume: arn:aws:iam::733936409301:role/kryptonite-store_FullAccess
 
       - name: Deploy to Kryptonite
+        env:
+          REPO_SLUG: ${{ github.repository }}
         run: |
-          aws s3 sync _sdk/.security/dashboard/ s3://kryptonite-store/${{ inputs.dashboard_path }}/ --delete
-          echo "Dashboard deployed to https://k.atlan.dev/${{ inputs.dashboard_path }}/"
+          SLUG=$(echo "$REPO_SLUG" | tr '/' '_')
+
+          # Upload per-repo data (no --delete, doesn't clobber other repos)
+          aws s3 cp "/tmp/dashboard-deploy/repos/${SLUG}.json" \
+            "s3://kryptonite-store/${{ inputs.dashboard_path }}/repos/${SLUG}.json"
+
+          # Upload dashboard HTML (shared, idempotent)
+          if [ -f /tmp/dashboard-deploy/index.html ]; then
+            aws s3 cp /tmp/dashboard-deploy/index.html \
+              "s3://kryptonite-store/${{ inputs.dashboard_path }}/index.html"
+          fi
+
+          echo "Dashboard updated at https://k.atlan.dev/${{ inputs.dashboard_path }}/"

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -1,0 +1,210 @@
+# Update Security Dashboard — reusable workflow.
+#
+# Triggered after a vulnerability scan completes. Downloads scan results,
+# generates dashboard data, and deploys to Kryptonite (k.atlan.dev).
+#
+# Usage in each app repo:
+#   on:
+#     workflow_run:
+#       workflows: ["Vulnerability Scan"]
+#       types: [completed]
+#     workflow_dispatch:
+#   jobs:
+#     dashboard:
+#       uses: atlanhq/application-sdk/.github/workflows/update-dashboard.yaml@main
+#       secrets: inherit
+#
+name: Update Security Dashboard
+
+on:
+  workflow_call:
+    inputs:
+      dashboard_path:
+        description: "S3 path for dashboard deployment"
+        required: false
+        type: string
+        default: "security-dashboard"
+    secrets:
+      ORG_PAT_GITHUB:
+        required: false
+
+permissions:
+  contents: read
+  id-token: write
+  actions: read
+
+jobs:
+  update:
+    name: Update Dashboard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Checkout dashboard assets from SDK
+        uses: actions/checkout@v4
+        with:
+          repository: atlanhq/application-sdk
+          path: _sdk
+          sparse-checkout: .security/dashboard
+          token: ${{ secrets.ORG_PAT_GITHUB || secrets.GITHUB_TOKEN }}
+
+      - name: Download latest scan artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p /tmp/scan-artifacts
+
+          RUN_ID=$(gh run list \
+            --workflow="vulnerability-scan.yml" \
+            --status=completed \
+            --limit=5 \
+            --json databaseId,conclusion \
+            --jq '[.[] | select(.conclusion=="success" or .conclusion=="failure")] | .[0].databaseId')
+
+          if [ -z "$RUN_ID" ]; then
+            echo "No scan runs found"
+            exit 0
+          fi
+
+          echo "Downloading artifacts from run $RUN_ID"
+          gh run download "$RUN_ID" --name trivy-results --dir /tmp/scan-artifacts || echo "No trivy results"
+          gh run download "$RUN_ID" --name snyk-results --dir /tmp/scan-artifacts || echo "No snyk results"
+
+      - name: Fetch base allowlist from SDK
+        run: |
+          if [ -f _sdk/.security/base-allowlist.json ]; then
+            cp _sdk/.security/base-allowlist.json /tmp/base-allowlist.json
+            echo "Base allowlist loaded"
+          else
+            echo "{}" > /tmp/base-allowlist.json
+            echo "No base allowlist found"
+          fi
+
+      - name: Generate dashboard data
+        run: |
+          python3 - <<'PYEOF'
+          import json, os
+          from datetime import datetime
+
+          repo_name = os.environ.get("GITHUB_REPOSITORY", "unknown")
+
+          # Merge base + repo allowlists
+          allowlist = {}
+          try:
+              with open("/tmp/base-allowlist.json") as f:
+                  base = json.load(f)
+              allowlist.update({k: v for k, v in base.items() if not k.startswith("_")})
+          except: pass
+
+          if os.path.exists(".security/allowlist.json"):
+              with open(".security/allowlist.json") as f:
+                  repo_al = json.load(f)
+              allowlist.update({k: v for k, v in repo_al.items() if not k.startswith("_")})
+
+          today = datetime.now().strftime("%Y-%m-%d")
+          all_vulns = []
+
+          # Parse Trivy
+          try:
+              with open("/tmp/scan-artifacts/trivy_results.json") as f:
+                  trivy = json.load(f)
+              for result in trivy.get("Results", []):
+                  result_type = result.get("Type", "")
+                  is_app = result_type in ("pip", "pipenv", "poetry", "uv", "python-pkg")
+                  for vuln in result.get("Vulnerabilities", []):
+                      vid = vuln.get("VulnerabilityID")
+                      if vid:
+                          entry = allowlist.get(vid)
+                          if entry:
+                              status = "expired" if today > entry.get("expires", "9999-12-31") else "allowlisted"
+                          else:
+                              status = "new"
+                          all_vulns.append({
+                              "id": vid,
+                              "severity": vuln.get("Severity", ""),
+                              "package": vuln.get("PkgName", ""),
+                              "installed": vuln.get("InstalledVersion", ""),
+                              "fixed": vuln.get("FixedVersion", ""),
+                              "scanner": "trivy",
+                              "source_type": "app" if is_app else "base_image",
+                              "status": status,
+                          })
+          except Exception as e:
+              print(f"Trivy: {e}")
+
+          # Parse Snyk
+          try:
+              with open("/tmp/scan-artifacts/snyk_results.json") as f:
+                  snyk = json.load(f)
+              if not snyk.get("error"):
+                  for vuln in snyk.get("vulnerabilities", []):
+                      vid = vuln.get("id")
+                      if vid:
+                          trivy_ids = {v["id"] for v in all_vulns}
+                          cves = vuln.get("identifiers", {}).get("CVE", [])
+                          if vid in trivy_ids or any(c in trivy_ids for c in cves):
+                              continue
+                          entry = allowlist.get(vid)
+                          if entry:
+                              status = "expired" if today > entry.get("expires", "9999-12-31") else "allowlisted"
+                          else:
+                              status = "new"
+                          all_vulns.append({
+                              "id": vid,
+                              "severity": vuln.get("severity", "").upper(),
+                              "package": vuln.get("packageName") or vuln.get("name", ""),
+                              "installed": vuln.get("version", ""),
+                              "fixed": ", ".join(vuln.get("fixedIn", [])) if vuln.get("fixedIn") else "",
+                              "scanner": "snyk",
+                              "source_type": "base_image",
+                              "status": status,
+                          })
+          except Exception as e:
+              print(f"Snyk: {e}")
+
+          # Deduplicate
+          seen = set()
+          unique = []
+          for v in all_vulns:
+              if v["id"] not in seen:
+                  seen.add(v["id"])
+                  unique.append(v)
+
+          # Build data
+          data_path = "_sdk/.security/dashboard/data.json"
+          if os.path.exists(data_path):
+              with open(data_path) as f:
+                  data = json.load(f)
+          else:
+              data = {"repos": {}, "generated_at": ""}
+
+          data["repos"][repo_name] = {
+              "vulnerabilities": unique,
+              "scanned_at": datetime.now().isoformat() + "Z",
+              "total": len(unique),
+              "critical": sum(1 for v in unique if v["severity"] == "CRITICAL"),
+              "high": sum(1 for v in unique if v["severity"] == "HIGH"),
+              "allowlisted": sum(1 for v in unique if v["status"] == "allowlisted"),
+              "new": sum(1 for v in unique if v["status"] == "new"),
+          }
+          data["generated_at"] = datetime.now().isoformat() + "Z"
+
+          os.makedirs("_sdk/.security/dashboard", exist_ok=True)
+          with open(data_path, "w") as f:
+              json.dump(data, f, indent=2)
+
+          print(f"Dashboard updated: {len(unique)} vulnerabilities for {repo_name}")
+          PYEOF
+
+      - name: Setup AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ap-south-1
+          role-to-assume: arn:aws:iam::733936409301:role/kryptonite-store_FullAccess
+
+      - name: Deploy to Kryptonite
+        run: |
+          aws s3 sync _sdk/.security/dashboard/ s3://kryptonite-store/${{ inputs.dashboard_path }}/ --delete
+          echo "Dashboard deployed to https://k.atlan.dev/${{ inputs.dashboard_path }}/"

--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,0 +1,132 @@
+{
+  "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Updated by SDK team.",
+  "_base_image": "application-sdk-main",
+  "_updated": "2026-04-15",
+
+  "SNYK-GOLANG-GOOGLEGOLANGORGGRPC-15691172": {
+    "package": "google.golang.org/grpc",
+    "severity": "CRITICAL",
+    "reason": "Base image — Dapr runtime dependency",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  },
+  "CVE-2026-33186": {
+    "package": "google.golang.org/grpc",
+    "severity": "CRITICAL",
+    "reason": "Base image — Dapr runtime dependency",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  },
+  "SNYK-GOLANG-GITHUBCOMGOJOSEGOJOSEV4-15875221": {
+    "package": "github.com/go-jose/go-jose/v4",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr runtime dependency",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  },
+  "SNYK-GOLANG-GITHUBCOMJACKCPGXV5PGPROTO3-15923570": {
+    "package": "github.com/jackc/pgx/v5/pgproto3",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr runtime dependency",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  },
+  "SNYK-GOLANG-GITHUBCOMJACKCPGXV5PGPROTO3-15923580": {
+    "package": "github.com/jackc/pgx/v5/pgproto3",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr runtime dependency",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  },
+  "CVE-2026-34986": {
+    "package": "dapr-daprd-1.17",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr runtime package",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  },
+  "CVE-2026-4519": {
+    "package": "python-3.10-base",
+    "severity": "HIGH",
+    "reason": "Base image — Python runtime",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  },
+  "CVE-2026-31812": {
+    "package": "quinn-proto",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr Rust dependency",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  },
+  "CVE-2026-34040": {
+    "package": "github.com/docker/docker",
+    "severity": "HIGH",
+    "reason": "Base image — Docker Go dependency",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  },
+  "CVE-2026-25679": {
+    "package": "stdlib (Go)",
+    "severity": "HIGH",
+    "reason": "Base image — Go stdlib",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  },
+  "SNYK-GOLANG-GOOPENTELEMETRYIOOTELBAGGAGE-15928416": {
+    "package": "go.opentelemetry.io/otel/baggage",
+    "severity": "HIGH",
+    "reason": "Base image — OpenTelemetry Go dependency",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  },
+  "SNYK-GOLANG-GOOPENTELEMETRYIOOTELINTERNALGLOBAL-15928418": {
+    "package": "go.opentelemetry.io/otel/internal/global",
+    "severity": "HIGH",
+    "reason": "Base image — OpenTelemetry Go dependency",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  },
+  "SNYK-GOLANG-GOOPENTELEMETRYIOOTELPROPAGATION-15928420": {
+    "package": "go.opentelemetry.io/otel/propagation",
+    "severity": "HIGH",
+    "reason": "Base image — OpenTelemetry Go dependency",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  },
+  "CVE-2026-39883": {
+    "package": "go.opentelemetry.io/otel/sdk",
+    "severity": "HIGH",
+    "reason": "Base image — OpenTelemetry Go dependency",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  },
+  "CVE-2026-32280": {
+    "package": "stdlib (Go)",
+    "severity": "HIGH",
+    "reason": "Base image — Go stdlib",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  },
+  "CVE-2026-32282": {
+    "package": "stdlib (Go)",
+    "severity": "HIGH",
+    "reason": "Base image — Go stdlib",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  },
+  "SNYK-GOLANG-GOOPENTELEMETRYIOOTELEXPORTERSOTLPOTLPTRACEOTLPTRACEHTTP-15954196": {
+    "package": "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp",
+    "severity": "HIGH",
+    "reason": "Base image — OpenTelemetry Go dependency",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  },
+  "SNYK-GOLANG-GOOPENTELEMETRYIOOTELSDKRESOURCE-15954212": {
+    "package": "go.opentelemetry.io/otel/sdk/resource",
+    "severity": "HIGH",
+    "reason": "Base image — OpenTelemetry Go dependency",
+    "expires": "2026-07-15",
+    "added_by": "mananjain99"
+  }
+}

--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,131 +1,131 @@
 {
-  "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Updated by SDK team.",
+  "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Updated by SDK team. CODEOWNERS: SDK/security team only.",
   "_base_image": "application-sdk-main",
   "_updated": "2026-04-15",
-
+  "_renewal_note": "Expiry dates staggered by severity. CRITICAL: 60 days. HIGH: 90 days. Review before expiry.",
   "SNYK-GOLANG-GOOGLEGOLANGORGGRPC-15691172": {
     "package": "google.golang.org/grpc",
     "severity": "CRITICAL",
-    "reason": "Base image — Dapr runtime dependency",
-    "expires": "2026-07-15",
+    "reason": "Base image \u2014 Dapr runtime dependency",
+    "expires": "2026-06-15",
     "added_by": "mananjain99"
   },
   "CVE-2026-33186": {
     "package": "google.golang.org/grpc",
     "severity": "CRITICAL",
-    "reason": "Base image — Dapr runtime dependency",
-    "expires": "2026-07-15",
+    "reason": "Base image \u2014 Dapr runtime dependency",
+    "expires": "2026-06-15",
     "added_by": "mananjain99"
   },
   "SNYK-GOLANG-GITHUBCOMGOJOSEGOJOSEV4-15875221": {
     "package": "github.com/go-jose/go-jose/v4",
     "severity": "HIGH",
-    "reason": "Base image — Dapr runtime dependency",
+    "reason": "Base image \u2014 Dapr runtime dependency",
     "expires": "2026-07-15",
     "added_by": "mananjain99"
   },
   "SNYK-GOLANG-GITHUBCOMJACKCPGXV5PGPROTO3-15923570": {
     "package": "github.com/jackc/pgx/v5/pgproto3",
     "severity": "HIGH",
-    "reason": "Base image — Dapr runtime dependency",
+    "reason": "Base image \u2014 Dapr runtime dependency",
     "expires": "2026-07-15",
     "added_by": "mananjain99"
   },
   "SNYK-GOLANG-GITHUBCOMJACKCPGXV5PGPROTO3-15923580": {
     "package": "github.com/jackc/pgx/v5/pgproto3",
     "severity": "HIGH",
-    "reason": "Base image — Dapr runtime dependency",
+    "reason": "Base image \u2014 Dapr runtime dependency",
     "expires": "2026-07-15",
     "added_by": "mananjain99"
   },
   "CVE-2026-34986": {
     "package": "dapr-daprd-1.17",
     "severity": "HIGH",
-    "reason": "Base image — Dapr runtime package",
+    "reason": "Base image \u2014 Dapr runtime package",
     "expires": "2026-07-15",
     "added_by": "mananjain99"
   },
   "CVE-2026-4519": {
     "package": "python-3.10-base",
     "severity": "HIGH",
-    "reason": "Base image — Python runtime",
+    "reason": "Base image \u2014 Python runtime",
     "expires": "2026-07-15",
     "added_by": "mananjain99"
   },
   "CVE-2026-31812": {
     "package": "quinn-proto",
     "severity": "HIGH",
-    "reason": "Base image — Dapr Rust dependency",
+    "reason": "Base image \u2014 Dapr Rust dependency",
     "expires": "2026-07-15",
     "added_by": "mananjain99"
   },
   "CVE-2026-34040": {
     "package": "github.com/docker/docker",
     "severity": "HIGH",
-    "reason": "Base image — Docker Go dependency",
+    "reason": "Base image \u2014 Docker Go dependency",
     "expires": "2026-07-15",
     "added_by": "mananjain99"
   },
   "CVE-2026-25679": {
     "package": "stdlib (Go)",
     "severity": "HIGH",
-    "reason": "Base image — Go stdlib",
+    "reason": "Base image \u2014 Go stdlib",
     "expires": "2026-07-15",
     "added_by": "mananjain99"
   },
   "SNYK-GOLANG-GOOPENTELEMETRYIOOTELBAGGAGE-15928416": {
     "package": "go.opentelemetry.io/otel/baggage",
     "severity": "HIGH",
-    "reason": "Base image — OpenTelemetry Go dependency",
+    "reason": "Base image \u2014 OpenTelemetry Go dependency",
     "expires": "2026-07-15",
     "added_by": "mananjain99"
   },
   "SNYK-GOLANG-GOOPENTELEMETRYIOOTELINTERNALGLOBAL-15928418": {
     "package": "go.opentelemetry.io/otel/internal/global",
     "severity": "HIGH",
-    "reason": "Base image — OpenTelemetry Go dependency",
+    "reason": "Base image \u2014 OpenTelemetry Go dependency",
     "expires": "2026-07-15",
     "added_by": "mananjain99"
   },
   "SNYK-GOLANG-GOOPENTELEMETRYIOOTELPROPAGATION-15928420": {
     "package": "go.opentelemetry.io/otel/propagation",
     "severity": "HIGH",
-    "reason": "Base image — OpenTelemetry Go dependency",
+    "reason": "Base image \u2014 OpenTelemetry Go dependency",
     "expires": "2026-07-15",
     "added_by": "mananjain99"
   },
   "CVE-2026-39883": {
     "package": "go.opentelemetry.io/otel/sdk",
     "severity": "HIGH",
-    "reason": "Base image — OpenTelemetry Go dependency",
+    "reason": "Base image \u2014 OpenTelemetry Go dependency",
     "expires": "2026-07-15",
     "added_by": "mananjain99"
   },
   "CVE-2026-32280": {
     "package": "stdlib (Go)",
     "severity": "HIGH",
-    "reason": "Base image — Go stdlib",
+    "reason": "Base image \u2014 Go stdlib",
     "expires": "2026-07-15",
     "added_by": "mananjain99"
   },
   "CVE-2026-32282": {
     "package": "stdlib (Go)",
     "severity": "HIGH",
-    "reason": "Base image — Go stdlib",
+    "reason": "Base image \u2014 Go stdlib",
     "expires": "2026-07-15",
     "added_by": "mananjain99"
   },
   "SNYK-GOLANG-GOOPENTELEMETRYIOOTELEXPORTERSOTLPOTLPTRACEOTLPTRACEHTTP-15954196": {
     "package": "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp",
     "severity": "HIGH",
-    "reason": "Base image — OpenTelemetry Go dependency",
+    "reason": "Base image \u2014 OpenTelemetry Go dependency",
     "expires": "2026-07-15",
     "added_by": "mananjain99"
   },
   "SNYK-GOLANG-GOOPENTELEMETRYIOOTELSDKRESOURCE-15954212": {
     "package": "go.opentelemetry.io/otel/sdk/resource",
     "severity": "HIGH",
-    "reason": "Base image — OpenTelemetry Go dependency",
+    "reason": "Base image \u2014 OpenTelemetry Go dependency",
     "expires": "2026-07-15",
     "added_by": "mananjain99"
   }

--- a/.security/dashboard/index.html
+++ b/.security/dashboard/index.html
@@ -1,0 +1,621 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Security Vulnerability Dashboard</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f6f8fa; color: #1f2328; }
+        .container { max-width: 1400px; margin: 0 auto; padding: 24px; }
+
+        /* Header */
+        .header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 24px; }
+        .header-left h1 { font-size: 22px; color: #1f2328; display: flex; align-items: center; gap: 8px; }
+        .header-left h1 span { font-size: 20px; }
+        .subtitle { color: #656d76; font-size: 13px; margin-top: 4px; }
+        .last-updated { color: #8b949e; font-size: 11px; margin-top: 2px; }
+        .header-right { display: flex; gap: 8px; }
+        .view-btn { background: #fff; border: 1px solid #d0d7de; color: #1f2328; padding: 6px 14px; border-radius: 6px; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+        .view-btn:hover { background: #f3f4f6; }
+        .view-btn.active { background: #ddf4ff; border-color: #54aeff; color: #0969da; }
+
+        /* Stats */
+        .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; margin-bottom: 20px; }
+        .stat-card { background: #fff; border: 1px solid #d0d7de; border-radius: 8px; padding: 14px 16px; cursor: pointer; transition: all 0.15s; position: relative; overflow: hidden; box-shadow: 0 1px 2px rgba(0,0,0,0.04); }
+        .stat-card:hover { border-color: #8b949e; transform: translateY(-1px); box-shadow: 0 2px 6px rgba(0,0,0,0.08); }
+        .stat-card.active { border-color: #0969da; }
+        .stat-card .label { font-size: 11px; color: #656d76; text-transform: uppercase; letter-spacing: 0.5px; }
+        .stat-card .value { font-size: 26px; font-weight: 600; margin-top: 2px; }
+        .stat-card .bar { position: absolute; bottom: 0; left: 0; height: 3px; border-radius: 0 0 8px 8px; }
+        .critical { color: #cf222e; }
+        .high { color: #bf5000; }
+        .allowlisted-color { color: #1a7f37; }
+        .new-color { color: #cf222e; }
+
+        /* Charts section */
+        .charts { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 20px; }
+        .chart-card { background: #fff; border: 1px solid #d0d7de; border-radius: 8px; padding: 16px; box-shadow: 0 1px 2px rgba(0,0,0,0.04); }
+        .chart-card h3 { font-size: 13px; color: #656d76; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 12px; }
+        .chart-bar-container { display: flex; flex-direction: column; gap: 8px; }
+        .chart-bar-row { display: flex; align-items: center; gap: 10px; }
+        .chart-bar-label { font-size: 12px; color: #656d76; min-width: 120px; text-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        .chart-bar-track { flex: 1; height: 20px; background: #eef1f5; border-radius: 4px; overflow: hidden; position: relative; }
+        .chart-bar-fill { height: 100%; border-radius: 4px; transition: width 0.5s ease; display: flex; align-items: center; padding-left: 8px; }
+        .chart-bar-fill span { font-size: 11px; font-weight: 600; white-space: nowrap; color: #fff; }
+        .chart-bar-value { font-size: 12px; color: #1f2328; min-width: 30px; font-weight: 600; }
+
+        /* Donut chart */
+        .donut-container { display: flex; align-items: center; gap: 24px; }
+        .donut { width: 120px; height: 120px; position: relative; }
+        .donut svg { transform: rotate(-90deg); }
+        .donut-center { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; }
+        .donut-center .num { font-size: 24px; font-weight: 700; color: #1f2328; }
+        .donut-center .txt { font-size: 10px; color: #656d76; }
+        .donut-legend { display: flex; flex-direction: column; gap: 6px; }
+        .legend-item { display: flex; align-items: center; gap: 8px; font-size: 12px; color: #1f2328; }
+        .legend-dot { width: 10px; height: 10px; border-radius: 50%; }
+
+        /* Repo comparison */
+        .repo-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px; margin-bottom: 20px; }
+        .repo-card { background: #fff; border: 1px solid #d0d7de; border-radius: 8px; padding: 16px; cursor: pointer; transition: all 0.15s; box-shadow: 0 1px 2px rgba(0,0,0,0.04); }
+        .repo-card:hover { border-color: #8b949e; box-shadow: 0 2px 6px rgba(0,0,0,0.08); }
+        .repo-card.selected { border-color: #0969da; background: #f6fcff; }
+        .repo-card-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; }
+        .repo-card-name { font-size: 14px; font-weight: 600; color: #1f2328; }
+        .repo-card-time { font-size: 11px; color: #8b949e; }
+        .repo-card-stats { display: flex; gap: 12px; }
+        .repo-card-stat { text-align: center; }
+        .repo-card-stat .num { font-size: 18px; font-weight: 600; }
+        .repo-card-stat .lbl { font-size: 10px; color: #656d76; text-transform: uppercase; }
+        .repo-card-bar { display: flex; height: 4px; border-radius: 2px; overflow: hidden; margin-top: 10px; gap: 2px; }
+        .repo-card-bar div { height: 100%; border-radius: 2px; }
+
+        /* Filters */
+        .filters { display: flex; gap: 10px; margin-bottom: 12px; flex-wrap: wrap; align-items: center; background: #fff; border: 1px solid #d0d7de; border-radius: 8px; padding: 10px 14px; box-shadow: 0 1px 2px rgba(0,0,0,0.04); }
+        .filters label { font-size: 11px; color: #656d76; text-transform: uppercase; letter-spacing: 0.5px; }
+        select, input[type="text"] { background: #f6f8fa; border: 1px solid #d0d7de; color: #1f2328; padding: 5px 10px; border-radius: 6px; font-size: 12px; }
+        select:focus, input:focus { outline: none; border-color: #0969da; box-shadow: 0 0 0 3px rgba(9,105,218,0.15); }
+        .filter-clear { background: none; border: 1px solid #d0d7de; color: #656d76; padding: 5px 10px; border-radius: 6px; font-size: 11px; cursor: pointer; margin-left: auto; }
+        .filter-clear:hover { color: #1f2328; border-color: #8b949e; }
+
+        /* Table */
+        .table-container { background: #fff; border: 1px solid #d0d7de; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 2px rgba(0,0,0,0.04); }
+        .table-header { display: flex; justify-content: space-between; align-items: center; padding: 10px 14px; border-bottom: 1px solid #d0d7de; }
+        .table-header .count { font-size: 12px; color: #656d76; }
+        .table-header .sort-info { font-size: 11px; color: #8b949e; }
+        table { width: 100%; border-collapse: collapse; }
+        th { background: #f6f8fa; text-align: left; padding: 8px 14px; font-size: 11px; color: #656d76; text-transform: uppercase; letter-spacing: 0.5px; cursor: pointer; user-select: none; transition: color 0.15s; white-space: nowrap; border-bottom: 1px solid #d0d7de; }
+        th:hover { color: #1f2328; }
+        th.sorted { color: #0969da; }
+        th .sort-arrow { margin-left: 4px; font-size: 10px; }
+        td { padding: 8px 14px; border-bottom: 1px solid #eef1f5; font-size: 12px; }
+        tr { cursor: pointer; transition: background 0.1s; }
+        tr:hover { background: #f6f8fa; }
+        tr.expanded { background: #f6f8fa; }
+        .detail-row { display: none; }
+        .detail-row.visible { display: table-row; }
+        .detail-row td { padding: 12px 14px 12px 28px; background: #fafbfc; border-bottom: 1px solid #eef1f5; }
+        .detail-content { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+        .detail-field { }
+        .detail-field .field-label { font-size: 10px; color: #8b949e; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 2px; }
+        .detail-field .field-value { font-size: 12px; color: #1f2328; }
+
+        /* Badges */
+        .badge { padding: 2px 8px; border-radius: 12px; font-size: 10px; font-weight: 600; white-space: nowrap; }
+        .badge-critical { background: #ffebe9; color: #cf222e; }
+        .badge-high { background: #fff1e5; color: #bf5000; }
+        .badge-trivy { background: #ddf4ff; color: #0969da; }
+        .badge-snyk { background: #fbefff; color: #8250df; }
+        .badge-new { background: #ffebe9; color: #cf222e; }
+        .badge-allowlisted { background: #dafbe1; color: #1a7f37; }
+        .badge-expired { background: #fff8c5; color: #9a6700; }
+        .badge-base { background: #eef1f5; color: #656d76; }
+        .badge-app { background: #fff8c5; color: #9a6700; }
+        .repo-tag { padding: 2px 8px; border-radius: 12px; font-size: 10px; background: #eef1f5; color: #656d76; margin: 1px; display: inline-block; }
+        code { background: #eef1f5; padding: 1px 5px; border-radius: 3px; font-size: 11px; color: #1f2328; }
+
+        .empty-state { text-align: center; padding: 48px; color: #656d76; font-size: 13px; }
+        .dedup-note { background: #fff; border: 1px solid #d0d7de; border-radius: 8px; padding: 10px 14px; margin-bottom: 16px; font-size: 12px; color: #656d76; display: flex; align-items: center; gap: 8px; }
+        .dedup-note strong { color: #1f2328; }
+
+        /* Tabs */
+        .tabs { display: flex; gap: 0; margin-bottom: 20px; border-bottom: 1px solid #d0d7de; }
+        .tab { padding: 8px 16px; font-size: 13px; color: #656d76; cursor: pointer; border-bottom: 2px solid transparent; transition: all 0.15s; }
+        .tab:hover { color: #1f2328; }
+        .tab.active { color: #1f2328; border-bottom-color: #d4763c; font-weight: 600; }
+        .tab-content { display: none; }
+        .tab-content.active { display: block; }
+
+        @media (max-width: 768px) {
+            .charts { grid-template-columns: 1fr; }
+            .detail-content { grid-template-columns: 1fr; }
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="header">
+        <div class="header-left">
+            <h1><span>&#128737;</span> Security Vulnerability Dashboard</h1>
+            <p class="subtitle">CRITICAL and HIGH vulnerabilities across scanned repositories</p>
+            <p class="last-updated" id="lastUpdated"></p>
+        </div>
+    </div>
+
+    <div class="stats" id="stats"></div>
+
+    <div class="tabs">
+        <div class="tab active" data-tab="overview">Overview</div>
+        <div class="tab" data-tab="repos">Repo Comparison</div>
+        <div class="tab" data-tab="vulns">All Vulnerabilities</div>
+    </div>
+
+    <!-- Tab 1: Overview -->
+    <div class="tab-content active" id="tab-overview">
+        <div class="charts">
+            <div class="chart-card">
+                <h3>By Source</h3>
+                <div class="donut-container" id="sourceDonut"></div>
+            </div>
+            <div class="chart-card">
+                <h3>By Scanner</h3>
+                <div class="donut-container" id="scannerDonut"></div>
+            </div>
+        </div>
+        <div class="charts">
+            <div class="chart-card">
+                <h3>Top Vulnerable Packages</h3>
+                <div class="chart-bar-container" id="packageChart"></div>
+            </div>
+            <div class="chart-card">
+                <h3>Vulnerabilities per Repo</h3>
+                <div class="chart-bar-container" id="repoChart"></div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Tab 2: Repo Comparison -->
+    <div class="tab-content" id="tab-repos">
+        <div class="repo-cards" id="repoCards"></div>
+        <div id="repoDetail"></div>
+    </div>
+
+    <!-- Tab 3: All Vulnerabilities -->
+    <div class="tab-content" id="tab-vulns">
+        <div class="filters">
+            <label>Repo:</label>
+            <select id="repoFilter"><option value="all">All repos</option></select>
+            <label>Severity:</label>
+            <select id="severityFilter">
+                <option value="all">All</option>
+                <option value="CRITICAL">Critical</option>
+                <option value="HIGH">High</option>
+            </select>
+            <label>Status:</label>
+            <select id="statusFilter">
+                <option value="all">All</option>
+                <option value="new">New</option>
+                <option value="allowlisted">Allowlisted</option>
+                <option value="expired">Expired</option>
+            </select>
+            <label>Source:</label>
+            <select id="sourceFilter">
+                <option value="all">All</option>
+                <option value="base_image">Base image</option>
+                <option value="app">App dep</option>
+            </select>
+            <label>Search:</label>
+            <input type="text" id="searchFilter" placeholder="CVE or package..." style="width: 160px;">
+            <button class="filter-clear" onclick="clearFilters()">Clear</button>
+        </div>
+
+        <div class="table-container">
+            <div class="table-header">
+                <span class="count" id="tableCount"></span>
+                <span class="sort-info">Click column headers to sort. Click rows to expand.</span>
+            </div>
+            <table>
+                <thead>
+                    <tr>
+                        <th data-sort="severity" class="sorted">Severity <span class="sort-arrow">&#9650;</span></th>
+                        <th data-sort="id">ID</th>
+                        <th data-sort="package">Package</th>
+                        <th data-sort="scanner">Scanner</th>
+                        <th data-sort="source_type">Source</th>
+                        <th data-sort="status">Status</th>
+                        <th>Repos</th>
+                        <th data-sort="fixed">Fix</th>
+                    </tr>
+                </thead>
+                <tbody id="vulnTable"></tbody>
+            </table>
+        </div>
+        <div class="empty-state" id="emptyState" style="display:none">No vulnerabilities match the current filters.</div>
+    </div>
+</div>
+
+<script>
+    let allData = { repos: {}, generated_at: '' };
+    let vulnMap = {};
+    let sortCol = 'severity';
+    let sortDir = 'asc';
+
+    async function loadData() {
+        try {
+            // Load per-repo files from repos/ directory
+            const indexResp = await fetch('repos/');
+            if (indexResp.ok) {
+                const html = await indexResp.text();
+                const files = [...html.matchAll(/href="([^"]+\.json)"/g)].map(m => m[1]);
+                for (const file of files) {
+                    try {
+                        const resp = await fetch('repos/' + file);
+                        const repoData = await resp.json();
+                        if (repoData.repo) {
+                            allData.repos[repoData.repo] = repoData;
+                            allData.generated_at = repoData.scanned_at;
+                        }
+                    } catch (e) { console.warn('Failed to load', file, e); }
+                }
+            }
+            // Fallback: try legacy data.json
+            if (Object.keys(allData.repos).length === 0) {
+                const resp = await fetch('data.json');
+                allData = await resp.json();
+            }
+            buildVulnMap();
+            renderAll();
+        } catch (e) {
+            document.getElementById('emptyState').style.display = 'block';
+            document.getElementById('emptyState').textContent = 'No scan data available. Run the vulnerability scan to populate.';
+        }
+    }
+
+    function buildVulnMap() {
+        vulnMap = {};
+        const repos = Object.keys(allData.repos);
+        repos.forEach(repo => {
+            (allData.repos[repo].vulnerabilities || []).forEach(v => {
+                if (!vulnMap[v.id]) {
+                    vulnMap[v.id] = { ...v, repos: [repo], statuses: {} };
+                } else {
+                    if (!vulnMap[v.id].repos.includes(repo)) vulnMap[v.id].repos.push(repo);
+                }
+                vulnMap[v.id].statuses[repo] = v.status || 'new';
+            });
+        });
+    }
+
+    function renderAll() {
+        renderStats();
+        renderOverview();
+        renderRepos();
+        renderTable();
+        document.getElementById('lastUpdated').textContent = 'Last updated: ' + formatDate(allData.generated_at);
+    }
+
+    function formatDate(d) {
+        if (!d) return 'N/A';
+        try { return new Date(d).toLocaleString(); } catch { return d; }
+    }
+
+    // ── Stats ──
+    function renderStats() {
+        const vulns = Object.values(vulnMap);
+        const repos = Object.keys(allData.repos);
+        const crit = vulns.filter(v => v.severity === 'CRITICAL').length;
+        const high = vulns.filter(v => v.severity === 'HIGH').length;
+        const newCount = vulns.filter(v => Object.values(v.statuses).includes('new')).length;
+        const allowlisted = vulns.filter(v => !Object.values(v.statuses).includes('new')).length;
+        const base = vulns.filter(v => v.source_type === 'base_image').length;
+
+        document.getElementById('stats').innerHTML = `
+            <div class="stat-card" onclick="quickFilter('all')">
+                <div class="label">Total Unique</div><div class="value">${vulns.length}</div>
+                <div class="bar" style="width:100%;background:#30363d"></div>
+            </div>
+            <div class="stat-card" onclick="quickFilter('CRITICAL')">
+                <div class="label">Critical</div><div class="value critical">${crit}</div>
+                <div class="bar" style="width:${pct(crit, vulns.length)}%;background:#f85149"></div>
+            </div>
+            <div class="stat-card" onclick="quickFilter('HIGH')">
+                <div class="label">High</div><div class="value high">${high}</div>
+                <div class="bar" style="width:${pct(high, vulns.length)}%;background:#db6d28"></div>
+            </div>
+            <div class="stat-card" onclick="quickFilter('new')">
+                <div class="label">New (Blocking)</div><div class="value new-color">${newCount}</div>
+                <div class="bar" style="width:${pct(newCount, vulns.length)}%;background:#f85149"></div>
+            </div>
+            <div class="stat-card" onclick="quickFilter('allowlisted')">
+                <div class="label">Allowlisted</div><div class="value allowlisted-color">${allowlisted}</div>
+                <div class="bar" style="width:${pct(allowlisted, vulns.length)}%;background:#3fb950"></div>
+            </div>
+            <div class="stat-card">
+                <div class="label">Base Image</div><div class="value">${base}</div>
+                <div class="bar" style="width:${pct(base, vulns.length)}%;background:#8b949e"></div>
+            </div>
+            <div class="stat-card">
+                <div class="label">Repos Scanned</div><div class="value">${repos.length}</div>
+            </div>
+        `;
+    }
+
+    function pct(n, total) { return total > 0 ? Math.round((n / total) * 100) : 0; }
+
+    function quickFilter(type) {
+        document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(t => t.classList.remove('active'));
+        document.querySelector('[data-tab="vulns"]').classList.add('active');
+        document.getElementById('tab-vulns').classList.add('active');
+        clearFilters();
+        if (type === 'CRITICAL' || type === 'HIGH') document.getElementById('severityFilter').value = type;
+        else if (type === 'new' || type === 'allowlisted') document.getElementById('statusFilter').value = type;
+        renderTable();
+    }
+
+    // ── Overview Charts ──
+    function renderOverview() {
+        const vulns = Object.values(vulnMap);
+        renderDonut('sourceDonut', [
+            { label: 'Base image', count: vulns.filter(v => v.source_type === 'base_image').length, color: '#8b949e' },
+            { label: 'App dependency', count: vulns.filter(v => v.source_type === 'app').length, color: '#d29922' },
+        ]);
+        renderDonut('scannerDonut', [
+            { label: 'Trivy', count: vulns.filter(v => v.scanner === 'trivy').length, color: '#58a6ff' },
+            { label: 'Snyk', count: vulns.filter(v => v.scanner === 'snyk').length, color: '#a371f7' },
+        ]);
+        renderBarChart('packageChart', getTopPackages(vulns, 6));
+        renderRepoBarChart('repoChart');
+    }
+
+    function renderDonut(id, items) {
+        const total = items.reduce((s, i) => s + i.count, 0);
+        const el = document.getElementById(id);
+        let offset = 0;
+        const circles = items.map(item => {
+            const pctVal = total > 0 ? (item.count / total) * 100 : 0;
+            const dash = `${pctVal * 2.83} ${283 - pctVal * 2.83}`;
+            const c = `<circle cx="45" cy="45" r="36" fill="none" stroke="${item.color}" stroke-width="18" stroke-dasharray="${dash}" stroke-dashoffset="${-offset * 2.83}" opacity="0.85"/>`;
+            offset += pctVal;
+            return c;
+        });
+        const legend = items.map(i => `<div class="legend-item"><div class="legend-dot" style="background:${i.color}"></div>${i.label}: <strong>${i.count}</strong></div>`).join('');
+        el.innerHTML = `
+            <div class="donut">
+                <svg viewBox="0 0 90 90"><circle cx="45" cy="45" r="36" fill="none" stroke="#21262d" stroke-width="18"/>${circles.join('')}</svg>
+                <div class="donut-center"><div class="num">${total}</div><div class="txt">total</div></div>
+            </div>
+            <div class="donut-legend">${legend}</div>
+        `;
+    }
+
+    function getTopPackages(vulns, limit) {
+        const pkgMap = {};
+        vulns.forEach(v => { pkgMap[v.package] = (pkgMap[v.package] || 0) + 1; });
+        return Object.entries(pkgMap).sort((a, b) => b[1] - a[1]).slice(0, limit)
+            .map(([pkg, count]) => ({ label: pkg, value: count }));
+    }
+
+    function renderBarChart(id, items) {
+        const max = Math.max(...items.map(i => i.value), 1);
+        document.getElementById(id).innerHTML = items.map(i => `
+            <div class="chart-bar-row">
+                <div class="chart-bar-label" title="${i.label}">${i.label}</div>
+                <div class="chart-bar-track">
+                    <div class="chart-bar-fill" style="width:${pct(i.value, max)}%;background:${i.color || '#58a6ff40'}">
+                        <span>${i.value}</span>
+                    </div>
+                </div>
+            </div>
+        `).join('');
+    }
+
+    function renderRepoBarChart(id) {
+        const repos = Object.keys(allData.repos);
+        const items = repos.map(r => {
+            const d = allData.repos[r];
+            return { label: r.split('/').pop(), value: d.total, crit: d.critical, high: d.high };
+        }).sort((a, b) => b.value - a.value);
+        const max = Math.max(...items.map(i => i.value), 1);
+        document.getElementById(id).innerHTML = items.map(i => `
+            <div class="chart-bar-row">
+                <div class="chart-bar-label" title="${i.label}">${i.label}</div>
+                <div class="chart-bar-track">
+                    <div class="chart-bar-fill" style="width:${pct(i.crit, max)}%;background:rgba(248,81,73,0.6)"></div>
+                    <div class="chart-bar-fill" style="width:${pct(i.high - i.crit, max)}%;background:rgba(219,109,40,0.5);position:absolute;left:${pct(i.crit, max)}%"></div>
+                </div>
+                <div class="chart-bar-value">${i.value}</div>
+            </div>
+        `).join('');
+    }
+
+    // ── Repo Comparison ──
+    function renderRepos() {
+        const repos = Object.keys(allData.repos);
+        document.getElementById('repoCards').innerHTML = repos.map(r => {
+            const d = allData.repos[r];
+            const total = d.total || 0;
+            const critW = pct(d.critical, total);
+            const highW = pct(d.high, total);
+            return `
+                <div class="repo-card" onclick="selectRepo('${r}')">
+                    <div class="repo-card-header">
+                        <div class="repo-card-name">${r.split('/').pop()}</div>
+                        <div class="repo-card-time">${formatDate(d.scanned_at)}</div>
+                    </div>
+                    <div class="repo-card-stats">
+                        <div class="repo-card-stat"><div class="num">${total}</div><div class="lbl">Total</div></div>
+                        <div class="repo-card-stat"><div class="num critical">${d.critical}</div><div class="lbl">Critical</div></div>
+                        <div class="repo-card-stat"><div class="num high">${d.high}</div><div class="lbl">High</div></div>
+                        <div class="repo-card-stat"><div class="num allowlisted-color">${d.allowlisted}</div><div class="lbl">Allowed</div></div>
+                        <div class="repo-card-stat"><div class="num new-color">${d.new || 0}</div><div class="lbl">New</div></div>
+                    </div>
+                    <div class="repo-card-bar">
+                        <div style="width:${critW}%;background:#f85149"></div>
+                        <div style="width:${highW}%;background:#db6d28"></div>
+                        <div style="width:${100-critW-highW}%;background:#21262d"></div>
+                    </div>
+                </div>
+            `;
+        }).join('');
+    }
+
+    function selectRepo(repo) {
+        document.querySelectorAll('.repo-card').forEach(c => c.classList.remove('selected'));
+        event.currentTarget.classList.add('selected');
+        document.getElementById('repoFilter').value = repo;
+        document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(t => t.classList.remove('active'));
+        document.querySelector('[data-tab="vulns"]').classList.add('active');
+        document.getElementById('tab-vulns').classList.add('active');
+        renderTable();
+    }
+
+    // ── Table ──
+    function getFilteredVulns() {
+        let vulns = Object.values(vulnMap);
+        const selRepo = document.getElementById('repoFilter').value;
+        const selSev = document.getElementById('severityFilter').value;
+        const selStatus = document.getElementById('statusFilter').value;
+        const selSource = document.getElementById('sourceFilter').value;
+        const search = document.getElementById('searchFilter').value.toLowerCase();
+
+        if (selRepo !== 'all') vulns = vulns.filter(v => v.repos.includes(selRepo));
+        if (selSev !== 'all') vulns = vulns.filter(v => v.severity === selSev);
+        if (selStatus !== 'all') {
+            vulns = vulns.filter(v => {
+                if (selRepo !== 'all') return v.statuses[selRepo] === selStatus;
+                return Object.values(v.statuses).includes(selStatus);
+            });
+        }
+        if (selSource !== 'all') vulns = vulns.filter(v => v.source_type === selSource);
+        if (search) vulns = vulns.filter(v => v.id.toLowerCase().includes(search) || v.package.toLowerCase().includes(search));
+
+        const order = { CRITICAL: 0, HIGH: 1 };
+        const scannerOrder = { trivy: 0, snyk: 1 };
+        vulns.sort((a, b) => {
+            let av, bv;
+            if (sortCol === 'severity') { av = order[a.severity] || 9; bv = order[b.severity] || 9; }
+            else if (sortCol === 'scanner') { av = scannerOrder[a.scanner] || 9; bv = scannerOrder[b.scanner] || 9; }
+            else { av = (a[sortCol] || '').toString().toLowerCase(); bv = (b[sortCol] || '').toString().toLowerCase(); }
+            if (av < bv) return sortDir === 'asc' ? -1 : 1;
+            if (av > bv) return sortDir === 'asc' ? 1 : -1;
+            return 0;
+        });
+        return vulns;
+    }
+
+    function renderTable() {
+        const repos = Object.keys(allData.repos);
+        const repoFilter = document.getElementById('repoFilter');
+        const currentVal = repoFilter.value;
+        repoFilter.innerHTML = '<option value="all">All repos (' + repos.length + ')</option>';
+        repos.forEach(r => {
+            const opt = document.createElement('option');
+            opt.value = r; opt.textContent = r.split('/').pop();
+            if (r === currentVal) opt.selected = true;
+            repoFilter.appendChild(opt);
+        });
+
+        const vulns = getFilteredVulns();
+        const selRepo = document.getElementById('repoFilter').value;
+
+        document.getElementById('tableCount').textContent = `${vulns.length} vulnerabilities`;
+        const tbody = document.getElementById('vulnTable');
+        tbody.innerHTML = '';
+
+        if (vulns.length === 0) {
+            document.getElementById('emptyState').style.display = 'block';
+            return;
+        }
+        document.getElementById('emptyState').style.display = 'none';
+
+        vulns.forEach((v, i) => {
+            const status = selRepo !== 'all' ? (v.statuses[selRepo] || 'new') :
+                Object.values(v.statuses).includes('new') ? 'new' :
+                Object.values(v.statuses).includes('expired') ? 'expired' : 'allowlisted';
+
+            const row = document.createElement('tr');
+            row.onclick = () => toggleDetail(i);
+            row.innerHTML = `
+                <td><span class="badge badge-${v.severity.toLowerCase()}">${v.severity}</span></td>
+                <td><code>${v.id.length > 35 ? v.id.slice(0,35)+'...' : v.id}</code></td>
+                <td><code>${v.package}</code></td>
+                <td><span class="badge badge-${v.scanner}">${v.scanner}</span></td>
+                <td><span class="badge badge-${v.source_type === 'base_image' ? 'base' : 'app'}">${v.source_type === 'base_image' ? 'Base' : 'App'}</span></td>
+                <td><span class="badge badge-${status}">${status}</span></td>
+                <td>${v.repos.map(r => '<span class="repo-tag">' + r.split('/').pop() + '</span>').join(' ')}</td>
+                <td>${v.fixed || '<span style="color:#484f58">No fix</span>'}</td>
+            `;
+            tbody.appendChild(row);
+
+            const detailRow = document.createElement('tr');
+            detailRow.className = 'detail-row';
+            detailRow.id = `detail-${i}`;
+            detailRow.innerHTML = `<td colspan="8">
+                <div class="detail-content">
+                    <div class="detail-field"><div class="field-label">Full ID</div><div class="field-value"><code>${v.id}</code></div></div>
+                    <div class="detail-field"><div class="field-label">Installed Version</div><div class="field-value">${v.installed}</div></div>
+                    <div class="detail-field"><div class="field-label">Fix Available</div><div class="field-value">${v.fixed || 'No fix available'}</div></div>
+                    <div class="detail-field"><div class="field-label">Scanner</div><div class="field-value">${v.scanner}</div></div>
+                    <div class="detail-field"><div class="field-label">Source</div><div class="field-value">${v.source_type === 'base_image' ? 'SDK Base Image' : 'App Dependency'}</div></div>
+                    <div class="detail-field"><div class="field-label">Affected Repos</div><div class="field-value">${v.repos.join(', ')}</div></div>
+                </div>
+            </td>`;
+            tbody.appendChild(detailRow);
+        });
+
+        // Update sort indicators
+        document.querySelectorAll('th[data-sort]').forEach(th => {
+            th.classList.toggle('sorted', th.dataset.sort === sortCol);
+            const arrow = th.querySelector('.sort-arrow');
+            if (arrow) arrow.textContent = th.dataset.sort === sortCol ? (sortDir === 'asc' ? '\u25B2' : '\u25BC') : '';
+        });
+    }
+
+    function toggleDetail(i) {
+        const row = document.getElementById(`detail-${i}`);
+        row.classList.toggle('visible');
+        row.previousElementSibling.classList.toggle('expanded');
+    }
+
+    function clearFilters() {
+        document.getElementById('repoFilter').value = 'all';
+        document.getElementById('severityFilter').value = 'all';
+        document.getElementById('statusFilter').value = 'all';
+        document.getElementById('sourceFilter').value = 'all';
+        document.getElementById('searchFilter').value = '';
+        renderTable();
+    }
+
+    // ── Sorting ──
+    document.querySelectorAll('th[data-sort]').forEach(th => {
+        th.addEventListener('click', () => {
+            const col = th.dataset.sort;
+            if (sortCol === col) sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+            else { sortCol = col; sortDir = 'asc'; }
+            renderTable();
+        });
+    });
+
+    // ── Tabs ──
+    document.querySelectorAll('.tab').forEach(tab => {
+        tab.addEventListener('click', () => {
+            document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+            document.querySelectorAll('.tab-content').forEach(t => t.classList.remove('active'));
+            tab.classList.add('active');
+            document.getElementById('tab-' + tab.dataset.tab).classList.add('active');
+        });
+    });
+
+    // ── Filters ──
+    document.querySelectorAll('.filters select, .filters input').forEach(el => {
+        el.addEventListener('change', renderTable);
+        el.addEventListener('input', renderTable);
+    });
+
+    loadData();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What
Centralizes base image allowlist and dashboard deployment in application-sdk.

## Changes

### `.security/base-allowlist.json` (new)
Central allowlist for SDK base image CVEs shared across all connector repos. 18 entries covering gRPC, Dapr, Go stdlib, OpenTelemetry, etc.

**Update once here → all repos get it.** No more duplicating base image CVEs in every repo's allowlist.

### `.github/workflows/update-dashboard.yaml` (new)
Reusable dashboard template. Each repo calls it after a scan — it fetches base allowlist, merges with repo allowlist, generates data, deploys to Kryptonite.

### `.github/workflows/build-and-scan.yaml` (modified)
Security gate now fetches `base-allowlist.json` from SDK and merges it with the repo's `.security/allowlist.json`. Repos only need to maintain their own app-level CVEs.

## How it works
```
Scan runs → Security Gate:
  1. Fetch base-allowlist.json from SDK (base image CVEs)
  2. Load .security/allowlist.json from repo (app CVEs)
  3. Merge both
  4. Check scan results against merged allowlist
```

## Impact on repos
- Repos can **remove base image entries** from their allowlist — SDK handles them
- Repos only maintain app-specific CVEs
- When SDK team fixes a base image CVE, remove from base-allowlist.json → all repos benefit