### PR TITLE
test: smoke test for @sdk-review pipeline

### DIFF
--- a/docs/agents/dev-commands.md
+++ b/docs/agents/dev-commands.md
@@ -3,6 +3,7 @@
 - Setup and local run workflow: `docs/guides/getting-started.md` (uv sync, poe tasks, example run).
 - Task runner and common scripts live in `pyproject.toml` under `[tool.poe.tasks]`.
 - Docs build configuration is in `mkdocs.yml` (install with `uv sync --group docs`, then `uv run poe generate-apidocs`).
+- PR review automation: comment `@sdk-review` on any PR to trigger the review pipeline.
 
 ## Pre-commit Checks
 

--- a/docs/agents/dev-commands.md
+++ b/docs/agents/dev-commands.md
@@ -6,6 +6,7 @@
 - PR review automation: comment `@sdk-review` on any PR to trigger the review pipeline.
   - `@sdk-review auto-complete` — review + fix loop until clean (max 3 iterations).
   - `@sdk-review stop` — cancel an in-progress auto-complete run.
+  - `@sdk-review override: <reason>` — admin override (repo admins only; audit-logged).
 
 ## Pre-commit Checks
 

--- a/docs/agents/dev-commands.md
+++ b/docs/agents/dev-commands.md
@@ -4,6 +4,8 @@
 - Task runner and common scripts live in `pyproject.toml` under `[tool.poe.tasks]`.
 - Docs build configuration is in `mkdocs.yml` (install with `uv sync --group docs`, then `uv run poe generate-apidocs`).
 - PR review automation: comment `@sdk-review` on any PR to trigger the review pipeline.
+  - `@sdk-review auto-complete` — review + fix loop until clean (max 3 iterations).
+  - `@sdk-review stop` — cancel an in-progress auto-complete run.
 
 ## Pre-commit Checks
 


### PR DESCRIPTION
## Test PR for @sdk-review

This is a smoke test PR to verify that the new `@sdk-review` pipeline (shipped in #1323) is working end-to-end.

### Change

Added a single-line doc note in `docs/agents/dev-commands.md` mentioning the `@sdk-review` trigger. Trivial change, no code impact.

### Test Plan

After this PR is open, comment each of these one at a time and verify:

1. **`@sdk-review`** — Review-only mode
   - Expect: status check appears as pending, then success/failure within ~5-8 min
   - Expect: summary comment posted (findings grouped by file)
   - Expect: inline comments posted on any findings

2. **`@sdk-review please resolve all issues`** — Auto-fix mode (only if findings exist)
   - Expect: bot fixes findings, commits, pushes, self-triggers re-review
   - Expect: approves when clean

3. **`@sdk-review override: testing`** — Admin override (admin only)
   - Expect: status forced to success if admin, else polite rejection

4. **Reply to an inline comment** — Inline Q&A
   - Expect: bot answer agent responds in the thread

### Cleanup

After validation, close this PR without merging. It's purely a test.