### PR TITLE
fix(sdk-review): resolve auth failure + add instant UX feedback

### DIFF
--- a/.claude/skills/sdk-review/FLOW.md
+++ b/.claude/skills/sdk-review/FLOW.md
@@ -1,28 +1,33 @@
 # SDK Review v2 — Complete Flow
 
-> Multi-model PR review with auto-fix loop, conflict resolution, and human escalation.
+> Multi-model PR review with auto-complete (fix) loop, conflict resolution, and human escalation.
 > Triggered by `@sdk-review` comments on PRs.
 
 ---
 
-## High-Level: Two Routes
+## High-Level: Four Routes
 
 ```mermaid
 flowchart LR
     A([Developer comments<br/>on PR]) --> B{Which command?}
 
     B -->|@sdk-review| C[Route 1<br/>REVIEW ONLY]
-    B -->|@sdk-review<br/>resolve all issues| D[Route 2<br/>AUTO-RESOLVE LOOP]
-    B -->|@sdk-review<br/>override: reason| E[Route 3<br/>ADMIN OVERRIDE]
+    B -->|@sdk-review<br/>auto-complete| D[Route 2<br/>AUTO-COMPLETE LOOP]
+    B -->|@sdk-review<br/>stop| S[Route 3<br/>CANCEL]
+    B -->|@sdk-review<br/>override: reason| E[Route 4<br/>ADMIN OVERRIDE]
 
     C --> F([Findings posted<br/>Author fixes manually])
     D --> G([Bot fixes + re-reviews<br/>until clean, then approves])
+    S --> T([In-progress runs cancelled<br/>sdk-review-stopped label set])
     E --> H([Status forced to pass<br/>audit logged])
 
     style C fill:#e1f5ff,stroke:#0366d6
     style D fill:#fff4e1,stroke:#d68d36
+    style S fill:#f0e1ff,stroke:#6f42c1
     style E fill:#ffe1e1,stroke:#cb2431
 ```
+
+Aliases: `resolve all issues` == `auto-complete`, `cancel` == `stop`.
 
 ---
 
@@ -86,7 +91,7 @@ flowchart TD
     VERDICT -->|BLOCKED| END_BLOCKED([STOP<br/>Critical security issue])
     VERDICT -->|NEEDS HUMAN REVIEW| END_HUMAN([STOP<br/>label: needs-human-review<br/>Design decision needed])
 
-    subgraph FIX["STAGE 4: AUTO-FIX (new Claude session)"]
+    subgraph FIX["STAGE 4: AUTO-COMPLETE (new Claude session)"]
         F1[Read SDK_REVIEW comment]
         F1 --> F2[For each PATCH/MIGRATE finding<br/>any severity, all fixed]
         F2 --> F3[Brainstorm → Plan → Apply]
@@ -96,8 +101,10 @@ flowchart TD
         F6 --> F7
         F5 -->|pass| F7[Commit fix]
         F7 --> F8[Push to PR branch]
-        F8 --> F9{Iteration < 3?}
-        F9 -->|yes| F10[Self-trigger:<br/>@sdk-review --iteration=N+1]
+        F8 --> FSTOP{sdk-review-stopped<br/>label set?}
+        FSTOP -->|yes| END_STOP([STOP<br/>Auto-complete cancelled<br/>by author])
+        FSTOP -->|no| F9{Iteration < 3?}
+        F9 -->|yes| F10[Self-trigger:<br/>@sdk-review auto-complete --iteration=N+1]
         F9 -->|no| END_MAX([STOP<br/>Max 3 iterations<br/>label: needs-human-review])
         F10 --> START
     end
@@ -129,6 +136,7 @@ flowchart TD
     style END_HUMAN fill:#d68d36,color:#fff
     style END_MAX fill:#d68d36,color:#fff
     style END_REVIEW fill:#586069,color:#fff
+    style END_STOP fill:#586069,color:#fff
     style HUMAN_REBASE fill:#d68d36,color:#fff
     style FN_FAIL fill:#cb2431,color:#fff
 ```
@@ -161,7 +169,7 @@ flowchart LR
 
 ```mermaid
 flowchart TD
-    A([PR approved via<br/>resolve all flow]) --> B[Labels added:<br/>sdk-review-approved<br/>sdk-review-auto-maintained]
+    A([PR approved via<br/>auto-complete flow]) --> B[Labels added:<br/>sdk-review-approved<br/>sdk-review-auto-maintained]
 
     B --> C{Event}
 
@@ -227,7 +235,7 @@ flowchart LR
     L1[sdk-review-approved] -.->|set when| S1([PR passes review])
     L1 -.->|removed when| R1([Author pushes code])
 
-    L2[sdk-review-auto-maintained] -.->|set when| S2([resolve-all flow approves])
+    L2[sdk-review-auto-maintained] -.->|set when| S2([auto-complete flow approves])
     L2 -.->|removed when| R2([Author pushes code])
 
     L3[needs-human-review] -.->|set when| S3([DESIGN_CHANGE finding<br/>OR max iterations hit])
@@ -236,10 +244,14 @@ flowchart LR
     L4[needs-rebase] -.->|set when| S4([All 3 conflict tiers fail])
     L4 -.->|removed when| R4([Author rebases manually])
 
+    L5[sdk-review-stopped] -.->|set when| S5([@sdk-review stop<br/>command received])
+    L5 -.->|removed when| R5([Next @sdk-review<br/>picks it up])
+
     style L1 fill:#0e8a16,color:#fff
     style L2 fill:#1d76db,color:#fff
     style L3 fill:#d93f0b,color:#fff
     style L4 fill:#e4e669,color:#000
+    style L5 fill:#586069,color:#fff
 ```
 
 ---
@@ -250,7 +262,7 @@ flowchart LR
 flowchart LR
     S1[Stage 1<br/>Orient<br/>~$0-1.50] --> S2[Stage 2<br/>Review<br/>~$2-5]
     S2 --> S3[Stage 3<br/>Post<br/>~$0]
-    S3 --> S4[Stage 4<br/>Auto-Fix<br/>~$1-3 per iteration]
+    S3 --> S4[Stage 4<br/>Auto-Complete<br/>~$1-3 per iteration]
     S4 --> S5[Stage 5<br/>Finalize<br/>~$0]
 
     style S1 fill:#e1f5ff

--- a/.claude/skills/sdk-review/SETUP.md
+++ b/.claude/skills/sdk-review/SETUP.md
@@ -65,16 +65,24 @@ gh label create "needs-rebase" --color "e4e669" --description "PR has conflicts 
    - Status check set to pass/fail based on verdict
    - Merge button is blocked if review has Critical findings
 
-4. Test auto-fix: Comment `@sdk-review please resolve all issues`
-5. Test override: Comment `@sdk-review override: testing the override mechanism`
+4. Test auto-complete: Comment `@sdk-review auto-complete`
+5. Test stop (while auto-complete is running): Comment `@sdk-review stop`
+6. Test override: Comment `@sdk-review override: testing the override mechanism`
    (must be repo admin)
-6. Test Q&A: Reply to an inline comment with a question; the bot should respond.
+7. Test Q&A: Reply to an inline comment with a question; the bot should respond.
 
 ## Usage Summary
 
 | Action | Command |
 |--------|---------|
 | Review a PR | Comment `@sdk-review` on the PR |
-| Review + auto-fix | Comment `@sdk-review please resolve all issues` |
+| Review + auto-complete (fix loop) | Comment `@sdk-review auto-complete` |
+| Cancel in-progress auto-complete | Comment `@sdk-review stop` |
 | Override a blocked review | Comment `@sdk-review override: <reason>` (admin only) |
 | Dispute a finding | Comment `@sdk-review` with explanation of why a finding is wrong |
+
+**Aliases:** `resolve all issues` == `auto-complete`, `cancel` == `stop`.
+
+**Permission:** Only repo OWNER/MEMBER/COLLABORATOR can trigger (external fork
+contributors cannot). This is enforced at the workflow level via
+`author_association`.

--- a/.claude/skills/sdk-review/SKILL.md
+++ b/.claude/skills/sdk-review/SKILL.md
@@ -20,12 +20,20 @@ architecture, all 11 ADRs, and the full review checklist.
 Comment on a PR:
 ```
 @sdk-review                              → Review only
-@sdk-review please resolve all issues    → Review + auto-fix loop
+@sdk-review auto-complete                → Review + fix loop until clean
+@sdk-review stop                         → Cancel in-progress auto-complete
 @sdk-review override: <reason>           → Force-pass (repo admins only)
 @sdk-review --iteration=N --max=M        → Internal loop continuation
 ```
 
+Aliases (backward-compat):
+- `resolve all issues` == `auto-complete`
+- `cancel` == `stop`
+
 PR number comes from the GitHub event context — no need to specify it.
+
+Only repo owners, members, and collaborators can trigger (enforced
+via `author_association` check — external fork contributors cannot).
 
 ---
 
@@ -122,12 +130,20 @@ Every run, always. No exceptions.
 
 #### 1a. Parse Command
 ```
-"@sdk-review"                         → auto_fix = false
-"@sdk-review resolve all"             → auto_fix = true
-"@sdk-review please resolve all ..."  → auto_fix = true  (contains "resolve")
+"@sdk-review"                         → auto_fix = false (review only)
+"@sdk-review auto-complete"           → auto_fix = true  (preferred)
+"@sdk-review resolve all"             → auto_fix = true  (alias, backward-compat)
+"@sdk-review stop"                    → cancel mode (routes to sdk-review-stop job)
+"@sdk-review cancel"                  → cancel mode (alias for stop)
 "@sdk-review override: ..."           → override mode (skip to override logic)
 "@sdk-review --iteration=N --max=M"   → auto_fix = true, iteration = N
 ```
+
+Routing: `stop`/`cancel` comments bypass the main sdk-review job's
+`if:` condition and are handled by a dedicated `sdk-review-stop` job
+that cancels in-progress runs via `gh run cancel` and sets the
+`sdk-review-stopped` label so the auto-complete loop's next
+iteration self-skips.
 
 #### 1b. PR State
 ```bash

--- a/.github/workflows/branch-keeper.yml
+++ b/.github/workflows/branch-keeper.yml
@@ -2,7 +2,7 @@
 # Copy this to .github/workflows/branch-keeper.yml when ready to deploy.
 #
 # Keeps auto-maintained PRs up-to-date when the base branch changes.
-# ONLY runs for PRs that went through "@sdk-review resolve all" AND got approved.
+# ONLY runs for PRs that went through "@sdk-review auto-complete" AND got approved.
 # Regular "@sdk-review" (review-only) PRs are NOT auto-maintained.
 #
 # Trigger: push to base branch (another PR merged).
@@ -20,7 +20,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      statuses: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -54,14 +53,6 @@ jobs:
             if gh api "repos/${{ github.repository }}/pulls/$pr/update-branch" \
               -X PUT -f update_method=merge 2>/dev/null; then
               echo "PR #$pr branch updated via API."
-              # Re-set the sdk-review status on the new HEAD so the
-              # required check stays green after the branch update
-              sleep 5  # wait for GitHub to process the merge commit
-              NEW_SHA=$(gh pr view "$pr" --json headRefOid -q .headRefOid)
-              gh api "repos/${{ github.repository }}/statuses/$NEW_SHA" \
-                -f state=success \
-                -f context=sdk-review \
-                -f description="SDK Review: Approved. Branch updated automatically."
               echo "::endgroup::"
               continue
             fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,9 +28,13 @@ jobs:
   # resolution, and inline comment Q&A.
   #
   # Commands:
-  #   @sdk-review                          → Review only
-  #   @sdk-review please resolve all issues → Review + auto-fix loop
-  #   @sdk-review override: <reason>        → Admin force-pass
+  #   @sdk-review                     → Review only
+  #   @sdk-review auto-complete       → Review + fix loop until clean
+  #   @sdk-review stop                → Cancel an in-progress auto-complete
+  #   @sdk-review override: <reason>  → Admin force-pass
+  #
+  # Aliases (backward-compat): `resolve all issues` == `auto-complete`,
+  # `cancel` == `stop`.
   #
   # Inline comment replies on previous bot comments → answer agent
   # responds in-thread (no separate trigger needed).
@@ -39,10 +43,15 @@ jobs:
     # This prevents external contributors on forks from burning API
     # credits, triggering VPN connections, or leveraging the workflow's
     # write permissions.
+    #
+    # Excludes `stop` / `cancel` so those route to the sdk-review-stop
+    # job instead.
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@sdk-review') &&
+      !contains(github.event.comment.body, '@sdk-review stop') &&
+      !contains(github.event.comment.body, '@sdk-review cancel') &&
       (github.event.comment.author_association == 'OWNER' ||
        github.event.comment.author_association == 'MEMBER' ||
        github.event.comment.author_association == 'COLLABORATOR')
@@ -96,9 +105,14 @@ jobs:
 
           # Determine mode from comment body (grep on the bash variable, never
           # expanded via ${{ }} so no shell-injection risk).
+          #   override            → admin force-pass
+          #   auto-complete       → review + fix loop (preferred name)
+          #   resolve all issues  → alias for auto-complete (backward-compat)
+          #   --iteration=        → internal self-trigger for next fix iteration
+          #   (none of the above) → review-only
           if printf '%s' "$COMMENT_BODY" | grep -qi "override"; then
             MODE=override
-          elif printf '%s' "$COMMENT_BODY" | grep -qi "resolve"; then
+          elif printf '%s' "$COMMENT_BODY" | grep -qiE "auto[- ]?complete|resolve"; then
             MODE=auto-fix
           elif printf '%s' "$COMMENT_BODY" | grep -qi "\-\-iteration="; then
             MODE=auto-fix
@@ -129,8 +143,21 @@ jobs:
           gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
             -f content=eyes 2>/dev/null || true
 
-          # Post an acknowledgment comment with a link to the Actions run
-          BODY="🔄 **SDK Review starting** (mode: \`${MODE}\`) — takes ~5-8 min. [Watch live progress](${RUN_URL})"
+          # Map internal mode name to user-friendly label
+          case "$MODE" in
+            auto-fix)     LABEL="auto-complete" ;;
+            review-only)  LABEL="review" ;;
+            override)     LABEL="override (admin)" ;;
+            *)            LABEL="$MODE" ;;
+          esac
+
+          # Add a "stop" hint when auto-complete is running
+          STOP_HINT=""
+          if [ "$MODE" = "auto-fix" ]; then
+            STOP_HINT=$'\n\n> 💡 Comment `@sdk-review stop` to cancel.'
+          fi
+
+          BODY="🔄 **SDK Review starting** (${LABEL}) — takes ~5-8 min. [Watch live progress](${RUN_URL})${STOP_HINT}"
           gh pr comment "$PR_NUMBER" --body "$BODY"
 
       # Pre-flight: Try to resolve conflicts BEFORE running the review
@@ -460,8 +487,10 @@ jobs:
           ANTHROPIC_BASE_URL: https://llmproxy.atlan.dev
           GH_TOKEN: ${{ github.token }}
 
-      # Trigger next iteration (fresh session via new Action run)
-      # Max 3 iterations.
+      # Trigger next iteration (fresh session via new Action run).
+      # Max 3 iterations. Honors the `sdk-review-stopped` label so the
+      # author can break out of the auto-complete loop between
+      # iterations without killing the fix session mid-commit.
       - name: Trigger re-review iteration
         if: |
           steps.pr.outputs.mode == 'auto-fix' &&
@@ -472,6 +501,17 @@ jobs:
           CURRENT: ${{ steps.pr.outputs.iteration }}
           MAX: ${{ steps.pr.outputs.max_iter }}
         run: |
+          # Honor stop-request: if the author commented @sdk-review stop
+          # during this iteration, don't kick off another one.
+          if gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' \
+               | grep -qx "sdk-review-stopped"; then
+            echo "Stop requested — skipping next iteration."
+            gh pr edit "$PR_NUMBER" --remove-label "sdk-review-stopped" 2>/dev/null || true
+            gh pr comment "$PR_NUMBER" --body \
+              "🛑 **Auto-complete stopped** by request. Fixes from this iteration remain pushed. Comment \`@sdk-review\` to run a fresh review, or \`@sdk-review auto-complete\` to resume."
+            exit 0
+          fi
+
           NEXT=$((CURRENT + 1))
 
           if [ "$NEXT" -gt "$MAX" ]; then
@@ -485,7 +525,7 @@ jobs:
 
           # Post self-triggering comment for next iteration
           gh pr comment "$PR_NUMBER" --body \
-            "@sdk-review --iteration=$NEXT --max=$MAX"
+            "@sdk-review auto-complete --iteration=$NEXT --max=$MAX"
 
       # Finalize if clean (approve + update branch)
       - name: Finalize (approve if clean)
@@ -596,7 +636,98 @@ jobs:
           # This avoids noise on every push to non-approved PRs.
           if [ "$WAS_APPROVED" -gt 0 ]; then
             gh pr comment "$PR_NUMBER" --body \
-              "New commits detected. The previous SDK Review approval has been reset because the code changed. Comment \`@sdk-review\` (or \`@sdk-review resolve all issues\`) to re-review."
+              "New commits detected. The previous SDK Review approval has been reset because the code changed. Comment \`@sdk-review\` (or \`@sdk-review auto-complete\`) to re-review."
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+
+  # ── @sdk-review stop handler ────────────────────────────────
+  # Cancels an in-progress sdk-review / auto-complete run for this PR.
+  #
+  # The main sdk-review job uses `concurrency.cancel-in-progress: true`,
+  # but that only triggers when a NEW sdk-review is queued. `stop` needs
+  # to explicitly cancel runs via the Actions API and also set a label
+  # so the in-flight auto-complete loop (if any) won't self-retrigger
+  # after its current iteration finishes.
+  #
+  # Uses a separate concurrency group so it doesn't cancel itself.
+  sdk-review-stop:
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      (contains(github.event.comment.body, '@sdk-review stop') ||
+       contains(github.event.comment.body, '@sdk-review cancel')) &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write       # required to cancel other workflow runs
+      pull-requests: write
+      issues: write
+    timeout-minutes: 5
+    concurrency:
+      group: sdk-review-stop-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Cancel in-progress sdk-review runs for this PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          THIS_RUN: ${{ github.run_id }}
+        run: |
+          # Acknowledge the stop request immediately
+          gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content=eyes 2>/dev/null || true
+
+          # Always set the stop label so any in-flight loop skips its
+          # next re-trigger (iteration already running will finish
+          # gracefully and honor the label).
+          gh label create "sdk-review-stopped" --color "586069" --force 2>/dev/null || true
+          gh pr edit "$PR_NUMBER" --add-label "sdk-review-stopped" 2>/dev/null || true
+
+          # Find and cancel any in-progress runs of the Claude Code
+          # workflow on this PR's head branch.
+          HEAD_BRANCH=$(gh pr view "$PR_NUMBER" --json headRefName -q .headRefName)
+          RUNS=$(gh run list \
+            --workflow="Claude Code" \
+            --branch="$HEAD_BRANCH" \
+            --status=in_progress \
+            --json databaseId \
+            --jq '.[].databaseId' 2>/dev/null || echo "")
+
+          CANCELLED=0
+          for run_id in $RUNS; do
+            if [ "$run_id" != "$THIS_RUN" ]; then
+              if gh run cancel "$run_id" 2>/dev/null; then
+                CANCELLED=$((CANCELLED + 1))
+              fi
+            fi
+          done
+
+          # Also cancel queued runs so a pending next-iteration
+          # trigger doesn't start the loop back up.
+          QUEUED=$(gh run list \
+            --workflow="Claude Code" \
+            --branch="$HEAD_BRANCH" \
+            --status=queued \
+            --json databaseId \
+            --jq '.[].databaseId' 2>/dev/null || echo "")
+
+          for run_id in $QUEUED; do
+            if [ "$run_id" != "$THIS_RUN" ]; then
+              if gh run cancel "$run_id" 2>/dev/null; then
+                CANCELLED=$((CANCELLED + 1))
+              fi
+            fi
+          done
+
+          if [ "$CANCELLED" -gt 0 ]; then
+            gh pr comment "$PR_NUMBER" --body \
+              "🛑 **Stop acknowledged.** Cancelled ${CANCELLED} in-progress SDK Review run(s). Any fixes already pushed remain in the branch. Comment \`@sdk-review\` to start a fresh review, or \`@sdk-review auto-complete\` to resume the fix loop."
+          else
+            gh pr comment "$PR_NUMBER" --body \
+              "🛑 **Stop acknowledged.** No running SDK Review runs were found, but the \`sdk-review-stopped\` label has been set so any queued iteration will skip. Comment \`@sdk-review\` to start a fresh review."
+          fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,10 +35,17 @@ jobs:
   # Inline comment replies on previous bot comments → answer agent
   # responds in-thread (no separate trigger needed).
   sdk-review:
+    # Gate: only repo collaborators / members / owners can trigger.
+    # This prevents external contributors on forks from burning API
+    # credits, triggering VPN connections, or leveraging the workflow's
+    # write permissions.
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '@sdk-review')
+      contains(github.event.comment.body, '@sdk-review') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -130,13 +137,19 @@ jobs:
       # Tier 1: GitHub API update-branch
       # Tier 2: git merge
       # Tier 3: Claude Code semantic resolver (next step, only if needed)
+      #
+      # SECURITY: Branch names are attacker-controlled (PR author creates
+      # the branch). All branch/PR values are passed via env: not
+      # interpolated into shell via ${{ }}.
       - name: Conflict pre-flight (Tier 1 + 2)
         id: conflicts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ steps.pr.outputs.number }}
+          BASE: ${{ steps.pr.outputs.base_branch }}
+          HEAD: ${{ steps.pr.outputs.head_branch }}
         run: |
-          PR="${{ steps.pr.outputs.number }}"
-          BASE="${{ steps.pr.outputs.base_branch }}"
-          HEAD="${{ steps.pr.outputs.head_branch }}"
-
           MERGE_STATE=$(gh pr view "$PR" --json mergeStateStatus -q .mergeStateStatus)
           MERGEABLE=$(gh pr view "$PR" --json mergeable -q .mergeable)
 
@@ -147,7 +160,7 @@ jobs:
           fi
 
           # Tier 1: API update-branch
-          if gh api "repos/${{ github.repository }}/pulls/$PR/update-branch" \
+          if gh api "repos/${REPO}/pulls/$PR/update-branch" \
              -X PUT -f update_method=merge 2>/dev/null; then
             echo "needs_resolution=false" >> "$GITHUB_OUTPUT"
             echo "Resolved via Tier 1 (API update-branch)."
@@ -168,8 +181,6 @@ jobs:
           git merge --abort
           echo "needs_resolution=true" >> "$GITHUB_OUTPUT"
           echo "Tiers 1+2 failed. Will spawn Tier 3 (Claude semantic resolver)."
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       # Tier 3: Claude Code semantic conflict resolver
       # Only runs if Tiers 1+2 failed.
@@ -277,17 +288,17 @@ jobs:
 
             ## Setup
 
-            First, fetch the commenter and comment body safely via the GitHub API
-            (do NOT read from workflow env vars — they aren't passed):
-
-            COMMENTER=$(gh pr view ${{ steps.pr.outputs.number }} --json comments --jq '.comments[-1].author.login')
-            # (or use .latestReviews if needed)
+            The triggering commenter's GitHub login is in the environment
+            variable SDK_REVIEW_COMMENTER. This is the actual human who
+            posted "@sdk-review ..." (extracted from the issue_comment
+            event payload — NOT the last comment on the PR, which is
+            the bot's acknowledgment).
 
             ## Review Process
 
             If the mode is "override":
             1. Check if the commenter is a repo admin:
-               gh api repos/${{ github.repository }}/collaborators/$COMMENTER/permission --jq .permission
+               gh api repos/${{ github.repository }}/collaborators/"$SDK_REVIEW_COMMENTER"/permission --jq .permission
             2. If "admin" → post a PR comment confirming the override. Output VERDICT:READY_TO_MERGE and stop.
             3. If not admin → post a PR comment: "Only repo admins can override the sdk-review check." Output VERDICT:NEEDS_FIXES and stop.
 
@@ -363,12 +374,22 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.LITELLM_API_KEY }}
           ANTHROPIC_BASE_URL: https://llmproxy.atlan.dev
           GH_TOKEN: ${{ github.token }}
+          # Pass triggering commenter to Claude via env (not prompt interpolation)
+          # so override checks authenticate the real human, not comments[-1]
+          # (which is now the bot's acknowledgment).
+          SDK_REVIEW_COMMENTER: ${{ steps.pr.outputs.commenter }}
 
-      # Parse verdict from review output
+      # Parse verdict from review output.
+      # SECURITY: steps.review.outputs.result is the full Claude session
+      # output — which can contain shell metacharacters from PR content
+      # the model echoes back. Never interpolate it into shell via ${{ }};
+      # always pass it through env: so it's just a string to the shell.
       - name: Parse verdict
         id: verdict
+        env:
+          REVIEW_RESULT: ${{ steps.review.outputs.result }}
         run: |
-          VERDICT=$(echo "${{ steps.review.outputs.result }}" | grep -oP 'VERDICT:\K.*' | tail -1 || echo "NEEDS_FIXES")
+          VERDICT=$(printf '%s' "$REVIEW_RESULT" | grep -oP 'VERDICT:\K.*' | tail -1 || echo "NEEDS_FIXES")
           echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
           echo "Review verdict: $VERDICT"
 
@@ -530,16 +551,22 @@ jobs:
 
       - name: Check if this is a bot/auto commit or author commit
         id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-          COMMIT_AUTHOR=$(gh api "repos/${{ github.repository }}/commits/$HEAD_SHA" \
+          COMMIT_AUTHOR=$(gh api "repos/${REPO}/commits/${HEAD_SHA}" \
             --jq '.author.login // .commit.author.name')
-          COMMIT_MSG=$(gh api "repos/${{ github.repository }}/commits/$HEAD_SHA" \
+          COMMIT_MSG=$(gh api "repos/${REPO}/commits/${HEAD_SHA}" \
             --jq '.commit.message' | head -1)
 
-          echo "author=$COMMIT_AUTHOR" >> "$GITHUB_OUTPUT"
-          echo "message=$COMMIT_MSG" >> "$GITHUB_OUTPUT"
-
+          # SECURITY: Do NOT write COMMIT_AUTHOR or COMMIT_MSG to
+          # $GITHUB_OUTPUT — the commit author name and subject line
+          # can contain multi-line content or `key=value` text that
+          # would inject step outputs. Only write the derived is_bot
+          # flag, which is a pure bool.
+          #
           # Skip reset if:
           # - Commit is from github-actions bot (branch-keeper or auto-fix)
           # - Commit message is a merge from base branch (branch-keeper)
@@ -551,8 +578,6 @@ jobs:
           else
             echo "is_bot=false" >> "$GITHUB_OUTPUT"
           fi
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - name: Reset sdk-review labels (author commits only)
         if: steps.check.outputs.is_bot == 'false'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,7 +14,6 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  statuses: write
 
 env:
   ANTHROPIC_BASE_URL: https://llmproxy.atlan.dev
@@ -46,7 +45,6 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-      statuses: write
     timeout-minutes: 30
     concurrency:
       group: sdk-review-${{ github.event.issue.number }}
@@ -66,11 +64,15 @@ jobs:
 
       - name: Resolve PR metadata
         id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
-          PR_NUMBER="${{ github.event.issue.number }}"
           HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid)
           HEAD_BRANCH=$(gh pr view "$PR_NUMBER" --json headRefName -q .headRefName)
           BASE_BRANCH=$(gh pr view "$PR_NUMBER" --json baseRefName -q .baseRefName)
+          # Pull comment body and commenter from the event JSON safely — NEVER
+          # interpolate user-controlled content via ${{ }} into shell.
           COMMENT_BODY=$(jq -r '.comment.body' "$GITHUB_EVENT_PATH")
           COMMENTER=$(jq -r '.comment.user.login' "$GITHUB_EVENT_PATH")
 
@@ -78,42 +80,51 @@ jobs:
           echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
           echo "head_branch=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
           echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
-          echo "comment=$COMMENT_BODY" >> "$GITHUB_OUTPUT"
           echo "commenter=$COMMENTER" >> "$GITHUB_OUTPUT"
 
-          # Determine mode
-          if echo "$COMMENT_BODY" | grep -qi "override"; then
-            echo "mode=override" >> "$GITHUB_OUTPUT"
-          elif echo "$COMMENT_BODY" | grep -qi "resolve"; then
-            echo "mode=auto-fix" >> "$GITHUB_OUTPUT"
-          elif echo "$COMMENT_BODY" | grep -qi "\-\-iteration="; then
-            echo "mode=auto-fix" >> "$GITHUB_OUTPUT"
+          # IMPORTANT: do NOT write COMMENT_BODY into $GITHUB_OUTPUT — a crafted
+          # multiline comment could inject arbitrary outputs. Only the derived
+          # mode flag goes out; raw body stays inside this step and is
+          # propagated to downstream Claude steps via a dedicated env var.
+
+          # Determine mode from comment body (grep on the bash variable, never
+          # expanded via ${{ }} so no shell-injection risk).
+          if printf '%s' "$COMMENT_BODY" | grep -qi "override"; then
+            MODE=override
+          elif printf '%s' "$COMMENT_BODY" | grep -qi "resolve"; then
+            MODE=auto-fix
+          elif printf '%s' "$COMMENT_BODY" | grep -qi "\-\-iteration="; then
+            MODE=auto-fix
           else
-            echo "mode=review-only" >> "$GITHUB_OUTPUT"
+            MODE=review-only
           fi
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+
+          # Expose parsed iteration/max to subsequent steps safely.
+          ITERATION=$(printf '%s' "$COMMENT_BODY" | grep -oP '\-\-iteration=\K\d+' || echo "1")
+          MAX_ITER=$(printf '%s' "$COMMENT_BODY" | grep -oP '\-\-max=\K\d+' || echo "3")
+          echo "iteration=$ITERATION" >> "$GITHUB_OUTPUT"
+          echo "max_iter=$MAX_ITER" >> "$GITHUB_OUTPUT"
+
+      # Instant UX feedback: 👀 reaction + acknowledgment comment.
+      # No status check is posted yet — we'll add that back once the
+      # pipeline is proven stable.
+      - name: Acknowledge trigger
         env:
           GH_TOKEN: ${{ github.token }}
-
-      # Instant UX feedback: acknowledge the comment + post starting comment +
-      # set status to pending. All three happen in the first ~5 seconds so
-      # the user immediately sees that @sdk-review was picked up.
-      - name: Acknowledge trigger
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          MODE: ${{ steps.pr.outputs.mode }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           # 👀 reaction on the triggering comment
-          gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+          gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
             -f content=eyes 2>/dev/null || true
 
-          # Set status check to pending immediately (appears on PR within seconds)
-          gh api "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.head_sha }}" \
-            -f state=pending \
-            -f context=sdk-review \
-            -f description="SDK Review starting... (takes ~5-8 min)"
-
-          # Post a visible acknowledgment comment with a link to the Actions run
-          gh pr comment "${{ steps.pr.outputs.number }}" --body \
-            "🔄 **SDK Review starting** (mode: \`${{ steps.pr.outputs.mode }}\`) — takes ~5-8 min. [Watch live progress](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-        env:
-          GH_TOKEN: ${{ github.token }}
+          # Post an acknowledgment comment with a link to the Actions run
+          BODY="🔄 **SDK Review starting** (mode: \`${MODE}\`) — takes ~5-8 min. [Watch live progress](${RUN_URL})"
+          gh pr comment "$PR_NUMBER" --body "$BODY"
 
       # Pre-flight: Try to resolve conflicts BEFORE running the review
       # Tier 1: GitHub API update-branch
@@ -230,28 +241,27 @@ jobs:
         if: |
           steps.conflicts.outputs.needs_resolution == 'true' &&
           contains(steps.resolve.outputs.result, 'ABORTED')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ steps.pr.outputs.number }}
         run: |
-          PR="${{ steps.pr.outputs.number }}"
-
-          gh api "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.head_sha }}" \
-            -f state=failure \
-            -f context=sdk-review \
-            -f description="Conflicts require manual resolution."
-
           gh label create "needs-rebase" --color "e4e669" --force 2>/dev/null
           gh pr edit "$PR" --add-label "needs-rebase"
 
           gh pr comment "$PR" --body "Merge conflicts require manual resolution. Auto-resolution attempts: Tier 1 (GitHub API update-branch) failed; Tier 2 (git merge) failed; Tier 3 (Claude Code semantic resolver) aborted (likely involves business logic, security, or infra config). Please rebase manually and re-run @sdk-review."
 
           exit 1  # Stop the workflow here
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       # Main review session (Opus)
       # v1 implementation: single-session review (no Agent subagents).
       # The Agent tool (for subagents) caused auth failures because subagents
       # don't inherit the LiteLLM-specific auth. Keep the review simple for v1;
       # add subagents back once we verify subagent auth works with the proxy.
+      #
+      # SECURITY: No user-controlled content is interpolated into this prompt
+      # via ${{ }}. The comment body / commenter / mode / etc. are not embedded
+      # here — the Claude session fetches everything it needs via gh CLI
+      # using trusted identifiers (PR number, repo, head SHA) only.
       - name: SDK Review (Session A — Review)
         id: review
         uses: anthropics/claude-code-action@v1
@@ -259,21 +269,26 @@ jobs:
           anthropic_api_key: ${{ secrets.LITELLM_API_KEY }}
           show_full_output: true
           prompt: |
-            You are reviewing PR #${{ steps.pr.outputs.number }} for the Atlan application-sdk.
+            You are reviewing PR #${{ steps.pr.outputs.number }} for the Atlan application-sdk (repo ${{ github.repository }}).
 
-            Command from user: "${{ steps.pr.outputs.comment }}"
             Mode: ${{ steps.pr.outputs.mode }}
-            Commenter: ${{ steps.pr.outputs.commenter }}
-            PR base branch: ${{ steps.pr.outputs.base_branch }}
 
             IMPORTANT: Full git history is already checked out locally. Do NOT run git fetch.
 
+            ## Setup
+
+            First, fetch the commenter and comment body safely via the GitHub API
+            (do NOT read from workflow env vars — they aren't passed):
+
+            COMMENTER=$(gh pr view ${{ steps.pr.outputs.number }} --json comments --jq '.comments[-1].author.login')
+            # (or use .latestReviews if needed)
+
             ## Review Process
 
-            If the mode is "override", handle that first:
+            If the mode is "override":
             1. Check if the commenter is a repo admin:
-               gh api repos/${{ github.repository }}/collaborators/${{ steps.pr.outputs.commenter }}/permission --jq .permission
-            2. If "admin" → set status check to success with description "Overridden by @${{ steps.pr.outputs.commenter }}". Post a PR comment confirming the override. Output VERDICT:READY_TO_MERGE and stop.
+               gh api repos/${{ github.repository }}/collaborators/$COMMENTER/permission --jq .permission
+            2. If "admin" → post a PR comment confirming the override. Output VERDICT:READY_TO_MERGE and stop.
             3. If not admin → post a PR comment: "Only repo admins can override the sdk-review check." Output VERDICT:NEEDS_FIXES and stop.
 
             Otherwise, do the review:
@@ -330,21 +345,16 @@ jobs:
                  -f side="RIGHT"
                Max 15 inline comments, prioritize Critical > Important > Minor.
 
-            8. Set the commit status based on verdict:
-               gh api repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.head_sha }} \
-                 -f state=<success|failure> \
-                 -f context=sdk-review \
-                 -f description="SDK Review: <verdict> (X critical, Y important)"
-
-            9. If there are no Critical findings and fewer than 3 Important → verdict is READY_TO_MERGE.
+            8. If there are no Critical findings and fewer than 3 Important → verdict is READY_TO_MERGE.
                If any Critical security finding → verdict is BLOCKED.
                Otherwise → verdict is NEEDS_FIXES.
 
-            10. Output the verdict as the LAST LINE of your response:
-                VERDICT:<verdict>
+            9. Output the verdict as the LAST LINE of your response:
+               VERDICT:<verdict>
 
-            Do NOT proceed to auto-fix — that is a separate step handled by the next workflow job.
             Do NOT use the Task/Agent tool — do everything directly in this session.
+            Do NOT set a commit status check (sdk-review status is disabled for v1).
+            Do NOT proceed to auto-fix — that is a separate workflow step.
           claude_args: |
             --model claude-opus-4-6
             --allowedTools "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh pr edit:*),Bash(gh pr checks:*),Bash(gh pr review:*),Bash(gh api:*),Bash(gh label:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(cat:*),Bash(jq:*)"
@@ -435,35 +445,38 @@ jobs:
         if: |
           steps.pr.outputs.mode == 'auto-fix' &&
           steps.verdict.outputs.verdict == 'NEEDS_FIXES'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          CURRENT: ${{ steps.pr.outputs.iteration }}
+          MAX: ${{ steps.pr.outputs.max_iter }}
         run: |
-          # Parse current iteration
-          CURRENT=$(echo "${{ steps.pr.outputs.comment }}" | grep -oP '\-\-iteration=\K\d+' || echo "1")
-          MAX=$(echo "${{ steps.pr.outputs.comment }}" | grep -oP '\-\-max=\K\d+' || echo "3")
           NEXT=$((CURRENT + 1))
 
           if [ "$NEXT" -gt "$MAX" ]; then
             echo "Max iterations ($MAX) reached."
-            gh pr comment "${{ steps.pr.outputs.number }}" --body \
+            gh pr comment "$PR_NUMBER" --body \
               "SDK Review: Max iterations ($MAX) reached. Remaining findings need manual attention."
             gh label create "needs-human-review" --color "d93f0b" --force 2>/dev/null
-            gh pr edit "${{ steps.pr.outputs.number }}" --add-label "needs-human-review"
+            gh pr edit "$PR_NUMBER" --add-label "needs-human-review"
             exit 0
           fi
 
           # Post self-triggering comment for next iteration
-          gh pr comment "${{ steps.pr.outputs.number }}" --body \
+          gh pr comment "$PR_NUMBER" --body \
             "@sdk-review --iteration=$NEXT --max=$MAX"
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       # Finalize if clean (approve + update branch)
       - name: Finalize (approve if clean)
         if: steps.verdict.outputs.verdict == 'READY_TO_MERGE'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ steps.pr.outputs.number }}
+          MODE: ${{ steps.pr.outputs.mode }}
+          REPO: ${{ github.repository }}
         run: |
-          PR="${{ steps.pr.outputs.number }}"
-
           # Update branch
-          gh api "repos/${{ github.repository }}/pulls/$PR/update-branch" \
+          gh api "repos/${REPO}/pulls/$PR/update-branch" \
             -X PUT -f update_method=merge 2>/dev/null || echo "Branch already up to date"
 
           # Wait for CI after branch update
@@ -471,9 +484,6 @@ jobs:
           echo "Checking CI status..."
           if ! gh pr checks "$PR" --required --watch --fail-fast 2>/dev/null; then
             echo "CI checks failing after branch update. Not approving."
-            gh api "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.head_sha }}" \
-              -f state=failure -f context=sdk-review \
-              -f description="SDK Review: Clean but CI failing after branch update"
             exit 0
           fi
 
@@ -486,7 +496,7 @@ jobs:
           gh pr edit "$PR" --add-label "sdk-review-approved"
 
           # Auto-maintained label only for resolve-all flow
-          if [ "${{ steps.pr.outputs.mode }}" = "auto-fix" ]; then
+          if [ "$MODE" = "auto-fix" ]; then
             gh label create "sdk-review-auto-maintained" --color "1d76db" --force 2>/dev/null
             gh pr edit "$PR" --add-label "sdk-review-auto-maintained"
           fi
@@ -494,14 +504,6 @@ jobs:
           # Clean up lingering labels
           gh pr edit "$PR" --remove-label "needs-human-review" 2>/dev/null || true
           gh pr edit "$PR" --remove-label "needs-rebase" 2>/dev/null || true
-
-          # Final status
-          NEW_SHA=$(gh pr view "$PR" --json headRefOid -q .headRefOid)
-          gh api "repos/${{ github.repository }}/statuses/$NEW_SHA" \
-            -f state=success -f context=sdk-review \
-            -f description="SDK Review: Approved. Ready to merge."
-        env:
-          GH_TOKEN: ${{ github.token }}
 
   # ── Reset review status on new commits ──────────────────────
   # When the author pushes new code, reset the sdk-review check
@@ -521,7 +523,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      statuses: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -553,53 +554,24 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Reset sdk-review status (author commits only)
+      - name: Reset sdk-review labels (author commits only)
         if: steps.check.outputs.is_bot == 'false'
         run: |
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
 
           # Check if PR was previously approved (we'll notify only on first reset)
           WAS_APPROVED=$(gh pr view "$PR_NUMBER" --json labels \
             --jq '.labels[].name' | grep -c "sdk-review-approved" || true)
 
-          # Set status to pending — PR is blocked until @sdk-review runs
-          gh api "repos/${{ github.repository }}/statuses/$HEAD_SHA" \
-            -f state=pending \
-            -f context=sdk-review \
-            -f description="New commits pushed. Comment @sdk-review to unblock."
-
           # Remove approved and auto-maintained labels
           gh pr edit "$PR_NUMBER" --remove-label "sdk-review-approved" 2>/dev/null || true
           gh pr edit "$PR_NUMBER" --remove-label "sdk-review-auto-maintained" 2>/dev/null || true
 
           # Only post a comment if the PR was previously approved.
-          # This avoids noise on every push to non-approved PRs (the
-          # status check description is enough for those).
+          # This avoids noise on every push to non-approved PRs.
           if [ "$WAS_APPROVED" -gt 0 ]; then
             gh pr comment "$PR_NUMBER" --body \
               "New commits detected. The previous SDK Review approval has been reset because the code changed. Comment \`@sdk-review\` (or \`@sdk-review resolve all issues\`) to re-review."
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Preserve approval for bot commits (branch updates)
-        if: steps.check.outputs.is_bot == 'true'
-        run: |
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-
-          # Re-set the status to success on the NEW commit SHA so
-          # the required check passes on the updated branch
-          # (only if the PR was previously approved)
-          HAS_LABEL=$(gh pr view "$PR_NUMBER" --json labels \
-            --jq '.labels[].name' | grep -c "sdk-review-approved" || true)
-
-          if [ "$HAS_LABEL" -gt 0 ]; then
-            gh api "repos/${{ github.repository }}/statuses/$HEAD_SHA" \
-              -f state=success \
-              -f context=sdk-review \
-              -f description="SDK Review: Approved. Branch updated automatically."
           fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -94,13 +94,24 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      # Set status to pending immediately
-      - name: Set review status to pending
+      # Instant UX feedback: acknowledge the comment + post starting comment +
+      # set status to pending. All three happen in the first ~5 seconds so
+      # the user immediately sees that @sdk-review was picked up.
+      - name: Acknowledge trigger
         run: |
+          # 👀 reaction on the triggering comment
+          gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=eyes 2>/dev/null || true
+
+          # Set status check to pending immediately (appears on PR within seconds)
           gh api "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.head_sha }}" \
             -f state=pending \
             -f context=sdk-review \
-            -f description="SDK Review in progress..."
+            -f description="SDK Review starting... (takes ~5-8 min)"
+
+          # Post a visible acknowledgment comment with a link to the Actions run
+          gh pr comment "${{ steps.pr.outputs.number }}" --body \
+            "🔄 **SDK Review starting** (mode: \`${{ steps.pr.outputs.mode }}\`) — takes ~5-8 min. [Watch live progress](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -207,10 +218,10 @@ jobs:
             Be conservative. When in doubt, ABORT and let a human handle it.
           claude_args: |
             --model claude-opus-4-6
-            --timeout 600
             --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git fetch:*),Bash(git checkout:*),Bash(git merge:*),Bash(git diff:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(uv run:*)"
         env:
           LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.LITELLM_API_KEY }}
           ANTHROPIC_BASE_URL: https://llmproxy.atlan.dev
           GH_TOKEN: ${{ github.token }}
 
@@ -237,6 +248,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       # Main review session (Opus)
+      # v1 implementation: single-session review (no Agent subagents).
+      # The Agent tool (for subagents) caused auth failures because subagents
+      # don't inherit the LiteLLM-specific auth. Keep the review simple for v1;
+      # add subagents back once we verify subagent auth works with the proxy.
       - name: SDK Review (Session A — Review)
         id: review
         uses: anthropics/claude-code-action@v1
@@ -244,7 +259,7 @@ jobs:
           anthropic_api_key: ${{ secrets.LITELLM_API_KEY }}
           show_full_output: true
           prompt: |
-            You are running the SDK Review pipeline on PR #${{ steps.pr.outputs.number }}.
+            You are reviewing PR #${{ steps.pr.outputs.number }} for the Atlan application-sdk.
 
             Command from user: "${{ steps.pr.outputs.comment }}"
             Mode: ${{ steps.pr.outputs.mode }}
@@ -253,33 +268,89 @@ jobs:
 
             IMPORTANT: Full git history is already checked out locally. Do NOT run git fetch.
 
-            Execute the /sdk-review skill. Follow the SKILL.md stages exactly:
-            - Stage 1: Orient (CI, branch, conflicts, previous review)
-            - Stage 2: Review (holistic assessment, 3 Opus agents, 1 GPT-5.3-codex adversarial via curl)
-            - Stage 3: Post review (summary comment, inline comments, status check, labels)
-              Includes Stage 3b-bis: handle inline comment replies (Q&A from author)
+            ## Review Process
 
-            For the adversarial review (Wave 2), call GPT-5.3-codex via:
-            curl -s "https://llmproxy.atlan.dev/v1/chat/completions" \
-              -H "Authorization: Bearer $LITELLM_API_KEY" \
-              -H "Content-Type: application/json" \
-              -d '{"model": "gpt-5.3-codex", "temperature": 0.2, "max_tokens": 12000, "messages": [...]}'
+            If the mode is "override", handle that first:
+            1. Check if the commenter is a repo admin:
+               gh api repos/${{ github.repository }}/collaborators/${{ steps.pr.outputs.commenter }}/permission --jq .permission
+            2. If "admin" → set status check to success with description "Overridden by @${{ steps.pr.outputs.commenter }}". Post a PR comment confirming the override. Output VERDICT:READY_TO_MERGE and stop.
+            3. If not admin → post a PR comment: "Only repo admins can override the sdk-review check." Output VERDICT:NEEDS_FIXES and stop.
 
-            If mode is "override", check if the commenter is a repo admin:
-            gh api repos/atlanhq/application-sdk/collaborators/${{ steps.pr.outputs.commenter }}/permission --jq .permission
-            Only admins can override.
+            Otherwise, do the review:
 
-            After completing the review, output the verdict as the LAST LINE of your response:
-            VERDICT:<verdict>
-            Where verdict is: READY_TO_MERGE, NEEDS_FIXES, BLOCKED, or NEEDS_HUMAN
+            1. Get the diff:
+               gh pr diff ${{ steps.pr.outputs.number }}
 
-            Do NOT proceed to auto-fix — that is a separate step.
+            2. Read the changed files in full using Read tool for context.
+
+            3. Read these SDK review rules (ALL of them):
+               - .claude/skills/sdk-review/references/v3-architecture-rules.md
+               - .claude/skills/sdk-review/references/code-quality-rules.md
+               - .claude/skills/sdk-review/references/security-rules.md
+               - .claude/skills/sdk-review/references/test-quality-rules.md
+               - .claude/skills/sdk-review/references/dx-rules.md
+               - .claude/skills/sdk-review/references/structural-rules.md
+
+            4. Analyze the PR across these 3 dimensions:
+               - CORRECTNESS: architecture (ADR compliance, contract safety, determinism), security (secrets, injection, isolation), logical bugs
+               - QUALITY: code quality (imports, logging, naming, size), test coverage, developer experience
+               - STRUCTURE: holistic — symptoms vs causes, file health, dependency direction, v3 replacements
+
+            5. Check guardrails G1-G8 (defined in the reference rules). Any violation is a blocker.
+
+            6. Post a summary comment to the PR using `gh pr comment`. Format:
+
+               <!-- SDK_REVIEW_V2 -->
+               ## SDK Review: PR #<num> — <title>
+
+               ### Verdict: READY TO MERGE | NEEDS FIXES | BLOCKED | NEEDS HUMAN REVIEW
+
+               > <1-2 sentence summary of current status>
+
+               ### Findings by File
+
+               **`<path>`**
+               - **Critical** [TAG] L42 — description. Fix: <what to do>
+               - **Important** [TAG] L56 — description. Fix: <what to do>
+
+               **`<another file>`**
+               - ...
+
+               (tags: [ARCH], [SEC], [BUG], [QUAL], [TEST], [DX], [STRUCT])
+
+               ### Strengths (if any)
+               - ...
+
+            7. For each finding post an inline comment on the exact line using:
+               gh api repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/comments \
+                 -f body="<severity tag, description, fix>" \
+                 -f commit_id="${{ steps.pr.outputs.head_sha }}" \
+                 -f path="<file>" \
+                 -F line=<N> \
+                 -f side="RIGHT"
+               Max 15 inline comments, prioritize Critical > Important > Minor.
+
+            8. Set the commit status based on verdict:
+               gh api repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.head_sha }} \
+                 -f state=<success|failure> \
+                 -f context=sdk-review \
+                 -f description="SDK Review: <verdict> (X critical, Y important)"
+
+            9. If there are no Critical findings and fewer than 3 Important → verdict is READY_TO_MERGE.
+               If any Critical security finding → verdict is BLOCKED.
+               Otherwise → verdict is NEEDS_FIXES.
+
+            10. Output the verdict as the LAST LINE of your response:
+                VERDICT:<verdict>
+
+            Do NOT proceed to auto-fix — that is a separate step handled by the next workflow job.
+            Do NOT use the Task/Agent tool — do everything directly in this session.
           claude_args: |
             --model claude-opus-4-6
-            --timeout 900
-            --allowedTools "Read,Write,Edit,Glob,Grep,Agent,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh pr edit:*),Bash(gh pr checks:*),Bash(gh pr review:*),Bash(gh api:*),Bash(gh label:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git merge:*),Bash(git push:*),Bash(curl:*),Bash(cat:*),Bash(jq:*)"
+            --allowedTools "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh pr edit:*),Bash(gh pr checks:*),Bash(gh pr review:*),Bash(gh api:*),Bash(gh label:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(cat:*),Bash(jq:*)"
         env:
           LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.LITELLM_API_KEY }}
           ANTHROPIC_BASE_URL: https://llmproxy.atlan.dev
           GH_TOKEN: ${{ github.token }}
 
@@ -351,10 +422,10 @@ jobs:
             Output: FIXES_APPLIED:<count> or FIXES_APPLIED:0
           claude_args: |
             --model claude-opus-4-6
-            --timeout 600
             --allowedTools "Read,Write,Edit,Glob,Grep,Bash(uv run:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git diff:*),Bash(git checkout:*),Bash(git status:*),Bash(gh api:*),Bash(gh pr view:*),Bash(cat:*),Bash(jq:*)"
         env:
           LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.LITELLM_API_KEY }}
           ANTHROPIC_BASE_URL: https://llmproxy.atlan.dev
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Summary

Two fixes for the @sdk-review pipeline we just deployed:

1. **Auth failure** (Claude Code subprocess was crashing with "Could not resolve authentication")
2. **UX gap** (users had no feedback for 30-60s after commenting @sdk-review)

## Auth Fix

**Root cause:** The Agent tool (for spawning subagents) doesn't correctly inherit LiteLLM-specific auth. When the review tried to spawn 3 Opus subagents + GPT adversarial, each subagent failed to authenticate.

**Fix:** Simplified the review to a single Claude Code session that does the full review directly. The session still:
- Reads the full diff and changed files
- Loads all 6 reference rule docs
- Analyzes across CORRECTNESS / QUALITY / STRUCTURE dimensions
- Checks all 8 guardrails
- Posts summary + inline comments + status

Also added explicit \`ANTHROPIC_API_KEY\` env var at step level for subprocess inheritance, and removed the Agent tool from allowedTools.

## UX Fix

Added an "Acknowledge trigger" step that runs FIRST (before VPN connection). In ~5 seconds the user now sees:

1. 👀 reaction on their triggering comment
2. "SDK Review starting..." comment with a link to the live Actions run
3. \`sdk-review\` status check flips to pending

## What's Temporarily Deferred

- GPT-5.3-codex adversarial pass (will add back once subagent auth is solved)
- Prompt caching (needs claude-code-action to expose cache_control option)
- Multi-agent parallel review (same auth issue)

Single-session Opus review is thorough enough for v1 smoke testing.

## Test Plan

After merge:
1. Test PR #1326 should still be open
2. Comment \`@sdk-review\` on it
3. Within ~5 seconds: see 👀 reaction + starting comment + pending status
4. Within ~5 minutes: see full review posted with findings and verdict