### PR TITLE
feat(ci): gate publish and SDR dispatch on security scan — enforcement enabled

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -357,10 +357,8 @@ jobs:
 
   # ── Job 4: Security scan — Trivy + Snyk + allowlist gate ─────────────────────
   # Runs after merge; publish and SDR dispatch both wait for it.
-  # fail_on_findings is kept false during the Phase 2 structural rollout so the
-  # scan is informational but publish/dispatch still block on job completion.
-  # Enforcement (fail_on_findings: true) flips after Phase 1 allowlist rollout
-  # reaches adequate adoption — tracked separately.
+  # If the scan finds CRITICAL/HIGH CVEs not covered by the allowlist, it fails
+  # and publish + SDR dispatch are skipped — no vulnerable image reaches GM.
   security-scan:
     name: Security Scan
     needs: [prepare, merge]
@@ -369,7 +367,7 @@ jobs:
       image: ${{ needs.prepare.outputs.ghcr_image }}
       snyk_org: partner-images
       snyk_monitor: ${{ inputs.snyk_monitor }}
-      fail_on_findings: false
+      fail_on_findings: true
     secrets: inherit
 
   # ── Job 5: Dispatch deployment to atlan-apps-deployment (main only) ───────────

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -355,7 +355,12 @@ jobs:
           echo "| Dockerfile | \`${{ needs.prepare.outputs.dockerfile }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| SDR push | \`${{ needs.prepare.outputs.enable_sdr }}\` |" >> $GITHUB_STEP_SUMMARY
 
-  # ── Job 4: Security scan — Trivy + Snyk + allowlist gate (non-blocking on merge path) ──
+  # ── Job 4: Security scan — Trivy + Snyk + allowlist gate ─────────────────────
+  # Runs after merge; publish and SDR dispatch both wait for it.
+  # fail_on_findings is kept false during the Phase 2 structural rollout so the
+  # scan is informational but publish/dispatch still block on job completion.
+  # Enforcement (fail_on_findings: true) flips after Phase 1 allowlist rollout
+  # reaches adequate adoption — tracked separately.
   security-scan:
     name: Security Scan
     needs: [prepare, merge]
@@ -370,7 +375,7 @@ jobs:
   # ── Job 5: Dispatch deployment to atlan-apps-deployment (main only) ───────────
   app-deployment-dispatcher:
     name: Dispatch App Deployment
-    needs: [prepare, merge]
+    needs: [prepare, merge, security-scan]
     if: github.ref == 'refs/heads/main' && needs.prepare.outputs.enable_sdr == 'true'
     runs-on: ubuntu-latest
     strategy:
@@ -390,9 +395,13 @@ jobs:
             }
 
   # ── Job 7: Publish to Global Marketplace ────────────────────────────────────
+  # Waits for security-scan. While fail_on_findings stays false, this is an
+  # ordering constraint only; once enforcement flips, a failing scan blocks
+  # publish outright. The publish payload carries ci_scan_status / ci_scan_run_url
+  # so downstream (GM) can record which CI scan covered this release.
   publish:
     name: Publish to Marketplace
-    needs: [prepare, merge]
+    needs: [prepare, merge, security-scan]
     if: inputs.publish
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -412,6 +421,8 @@ jobs:
           CHANNEL: ${{ inputs.channel }}
           TENANTS: ${{ inputs.tenants }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          CI_SCAN_STATUS: ${{ needs.security-scan.result }}
+          CI_SCAN_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
 
@@ -441,6 +452,14 @@ jobs:
               body["allowed_tenants"] = [t.strip() for t in tenants.split(",") if t.strip()]
           else:
               body["target_channel"] = os.environ.get("CHANNEL", "all") or "all"
+
+          # CI scan attestation — GM persists these for audit (Phase 3)
+          scan_status = os.environ.get("CI_SCAN_STATUS", "").strip()
+          if scan_status:
+              body["ci_scan_status"] = scan_status
+          scan_run_url = os.environ.get("CI_SCAN_RUN_URL", "").strip()
+          if scan_run_url:
+              body["ci_scan_run_url"] = scan_run_url
 
           print(json.dumps(body))
           PYEOF

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -397,8 +397,7 @@ jobs:
   # ── Job 7: Publish to Global Marketplace ────────────────────────────────────
   # Waits for security-scan. While fail_on_findings stays false, this is an
   # ordering constraint only; once enforcement flips, a failing scan blocks
-  # publish outright. The publish payload carries ci_scan_status / ci_scan_run_url
-  # so downstream (GM) can record which CI scan covered this release.
+  # publish outright.
   publish:
     name: Publish to Marketplace
     needs: [prepare, merge, security-scan]
@@ -421,8 +420,6 @@ jobs:
           CHANNEL: ${{ inputs.channel }}
           TENANTS: ${{ inputs.tenants }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
-          CI_SCAN_STATUS: ${{ needs.security-scan.result }}
-          CI_SCAN_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
 
@@ -452,14 +449,6 @@ jobs:
               body["allowed_tenants"] = [t.strip() for t in tenants.split(",") if t.strip()]
           else:
               body["target_channel"] = os.environ.get("CHANNEL", "all") or "all"
-
-          # CI scan attestation — GM persists these for audit (Phase 3)
-          scan_status = os.environ.get("CI_SCAN_STATUS", "").strip()
-          if scan_status:
-              body["ci_scan_status"] = scan_status
-          scan_run_url = os.environ.get("CI_SCAN_RUN_URL", "").strip()
-          if scan_run_url:
-              body["ci_scan_run_url"] = scan_run_url
 
           print(json.dumps(body))
           PYEOF


### PR DESCRIPTION
## Summary

Makes the build-and-publish pipeline **block on security scan findings**. If the scan finds CRITICAL/HIGH CVEs not covered by the allowlist, publish and SDR dispatch are skipped — no vulnerable image reaches Global Marketplace.

Part of the vulnerability-scan enforcement project. Phase 1 (PR gate + base allowlist) is live on postgres via #1325. This PR is Phase 2 — extending the gate to the build-and-publish pipeline.

## Changes (`.github/workflows/build-and-publish-app.yaml`)

1. **`publish.needs += security-scan`** — publish waits for scan; skipped if scan fails
2. **`app-deployment-dispatcher.needs += security-scan`** — SDR dispatch also waits and is skipped on scan failure
3. **`fail_on_findings: true`** — the security gate now fails hard on new/expired CRITICAL/HIGH CVEs not in the allowlist

## What this means for app teams

When this merges, any app whose build-and-publish pipeline runs (push to main or workflow_dispatch with publish=true) will:

- **Scan passes (no new CVEs, or all covered by allowlist):** publish proceeds as normal
- **Scan fails (new CRITICAL/HIGH CVEs found):** publish and SDR dispatch are **skipped**, workflow marked failed

Apps with pre-existing app-level CVEs must fix them before their next publish succeeds:
- Comment `/fix-vulnerabilities` on a PR to auto-bump vulnerable Python packages
- Or manually upgrade the affected dependencies
- Base-image CVEs are already covered by the central `base-allowlist.json` in application-sdk

## Relationship to other PRs

- **#1325 (base allowlist centralization)** — **merged** ✅. Provides the shared base-allowlist that covers base-image CVEs across all apps.
- **#1261 (earlier draft)** — superseded by this PR. Recommend closing.
- **atlan-cli #198** — CLI-side defense-in-depth. Checks the security-scan job conclusion before registering in marketplace. Belt-and-suspenders with this PR.
- **atlan-postgres-app #341** — dashboard fix that also feeds Phase 2 scan results to Kryptonite.

## Test plan (postgres)

Postgres is the reference app with Phase 1 fully live (vulnerability-scan.yml + auto-fix.yml + base-allowlist).

- [ ] Trigger `Build & Publish` on postgres via `workflow_dispatch` with `publish=false`
- [ ] `security-scan` job runs after merge; if app-level CVEs exist and aren't fixed, it fails
- [ ] `publish` job shows as **skipped** (because `needs: security-scan` failed)
- [ ] `app-deployment-dispatcher` also skipped
- [ ] Overall workflow: **failed**
- [ ] After fixing CVEs (via `/fix-vulnerabilities` or manual bump), re-trigger → scan passes → publish runs

## Scope note — no GM changes

No changes to `global-marketplace`, `heracles`, or `atlan-local-marketplace-app`. GM-side scanning was deliberately scoped out — same image + same scanners + same allowlist as CI makes re-scanning duplicated work. Full rationale in the plan doc.

## Follow-ups

- `connector-os` / `atlan-app-template` — add the 3 thin caller files so new apps get scanning infra out of the box
- Fleet rollout — copy the 3 caller files across ~44 existing repos
- `application-sdk` release tag cut