### PR TITLE
fix(sdk-review): parse verdict from PR comment + restore status check

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,6 +14,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  statuses: write
 
 env:
   ANTHROPIC_BASE_URL: https://llmproxy.atlan.dev
@@ -61,6 +62,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+      statuses: write
     timeout-minutes: 30
     concurrency:
       group: sdk-review-${{ github.event.issue.number }}
@@ -127,15 +129,16 @@ jobs:
           echo "iteration=$ITERATION" >> "$GITHUB_OUTPUT"
           echo "max_iter=$MAX_ITER" >> "$GITHUB_OUTPUT"
 
-      # Instant UX feedback: 👀 reaction + acknowledgment comment.
-      # No status check is posted yet — we'll add that back once the
-      # pipeline is proven stable.
+      # Instant UX feedback: 👀 reaction + pending status check + ack comment.
+      # All three happen in the first ~5 s so the user sees @sdk-review
+      # was picked up.
       - name: Acknowledge trigger
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           MODE: ${{ steps.pr.outputs.mode }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -150,6 +153,13 @@ jobs:
             override)     LABEL="override (admin)" ;;
             *)            LABEL="$MODE" ;;
           esac
+
+          # Set sdk-review status check to pending
+          gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+            -f state=pending \
+            -f context=sdk-review \
+            -f description="SDK Review starting (${LABEL})... (takes ~5-8 min)" \
+            -f target_url="${RUN_URL}" 2>/dev/null || true
 
           # Add a "stop" hint when auto-complete is running
           STOP_HINT=""
@@ -281,8 +291,15 @@ jobs:
           contains(steps.resolve.outputs.result, 'ABORTED')
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           PR: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         run: |
+          gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+            -f state=failure \
+            -f context=sdk-review \
+            -f description="Conflicts require manual resolution." 2>/dev/null || true
+
           gh label create "needs-rebase" --color "e4e669" --force 2>/dev/null
           gh pr edit "$PR" --add-label "needs-rebase"
 
@@ -406,17 +423,42 @@ jobs:
           # (which is now the bot's acknowledgment).
           SDK_REVIEW_COMMENTER: ${{ steps.pr.outputs.commenter }}
 
-      # Parse verdict from review output.
-      # SECURITY: steps.review.outputs.result is the full Claude session
-      # output — which can contain shell metacharacters from PR content
-      # the model echoes back. Never interpolate it into shell via Actions template syntax;
-      # always pass it through env: so it's just a string to the shell.
+      # Parse verdict by reading the SDK_REVIEW_V2 comment Claude posted.
+      # The action output 'result' isn't reliably exposed by
+      # anthropics/claude-code-action@v1 — it resolved to empty string
+      # in testing, causing the pipeline to always fall through to
+      # NEEDS_FIXES and skip Finalize. Fetching the comment we just
+      # posted gives a stable, authoritative source for the verdict.
       - name: Parse verdict
         id: verdict
         env:
-          REVIEW_RESULT: ${{ steps.review.outputs.result }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
-          VERDICT=$(printf '%s' "$REVIEW_RESULT" | grep -oP 'VERDICT:\K.*' | tail -1 || echo "NEEDS_FIXES")
+          # Find the most recent SDK_REVIEW_V2 comment on this PR
+          REVIEW_COMMENT=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq '[.[] | select(.body | contains("SDK_REVIEW_V2"))] | last | .body // ""')
+
+          if [ -z "$REVIEW_COMMENT" ]; then
+            echo "::warning::No SDK_REVIEW_V2 comment found — defaulting to NEEDS_FIXES."
+            VERDICT="NEEDS_FIXES"
+          else
+            # Extract the verdict line. Claude posts e.g.:
+            #   ### Verdict: READY TO MERGE
+            # Normalize to READY_TO_MERGE / NEEDS_FIXES / BLOCKED / NEEDS_HUMAN_REVIEW.
+            RAW=$(printf '%s' "$REVIEW_COMMENT" | grep -oiP '###\s*Verdict:\s*\K[A-Z][A-Z _]+' | head -1 | tr '[:lower:]' '[:upper:]')
+            # Collapse whitespace to underscores
+            VERDICT=$(printf '%s' "$RAW" | tr -s ' ' '_' | sed 's/_*$//')
+
+            case "$VERDICT" in
+              READY_TO_MERGE|NEEDS_FIXES|BLOCKED|NEEDS_HUMAN_REVIEW) ;;
+              *)
+                echo "::warning::Could not parse verdict from comment — got '$VERDICT'. Defaulting to NEEDS_FIXES."
+                VERDICT="NEEDS_FIXES" ;;
+            esac
+          fi
+
           echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
           echo "Review verdict: $VERDICT"
 
@@ -527,7 +569,7 @@ jobs:
           gh pr comment "$PR_NUMBER" --body \
             "@sdk-review auto-complete --iteration=$NEXT --max=$MAX"
 
-      # Finalize if clean (approve + update branch)
+      # Finalize if clean (approve + update branch + status = success)
       - name: Finalize (approve if clean)
         if: steps.verdict.outputs.verdict == 'READY_TO_MERGE'
         env:
@@ -535,6 +577,7 @@ jobs:
           PR: ${{ steps.pr.outputs.number }}
           MODE: ${{ steps.pr.outputs.mode }}
           REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         run: |
           # Update branch
           gh api "repos/${REPO}/pulls/$PR/update-branch" \
@@ -545,6 +588,9 @@ jobs:
           echo "Checking CI status..."
           if ! gh pr checks "$PR" --required --watch --fail-fast 2>/dev/null; then
             echo "CI checks failing after branch update. Not approving."
+            gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+              -f state=failure -f context=sdk-review \
+              -f description="SDK Review: Clean but CI failing after branch update" 2>/dev/null || true
             exit 0
           fi
 
@@ -556,7 +602,7 @@ jobs:
           gh label create "sdk-review-approved" --color "0e8a16" --force 2>/dev/null
           gh pr edit "$PR" --add-label "sdk-review-approved"
 
-          # Auto-maintained label only for resolve-all flow
+          # Auto-maintained label only for auto-complete flow
           if [ "$MODE" = "auto-fix" ]; then
             gh label create "sdk-review-auto-maintained" --color "1d76db" --force 2>/dev/null
             gh pr edit "$PR" --add-label "sdk-review-auto-maintained"
@@ -565,6 +611,40 @@ jobs:
           # Clean up lingering labels
           gh pr edit "$PR" --remove-label "needs-human-review" 2>/dev/null || true
           gh pr edit "$PR" --remove-label "needs-rebase" 2>/dev/null || true
+
+          # Final status on the (possibly updated) HEAD SHA
+          NEW_SHA=$(gh pr view "$PR" --json headRefOid -q .headRefOid)
+          gh api "repos/${REPO}/statuses/${NEW_SHA}" \
+            -f state=success -f context=sdk-review \
+            -f description="SDK Review: Approved. Ready to merge." 2>/dev/null || true
+
+      # Mark status = failure for BLOCKED verdict
+      - name: Set status (BLOCKED)
+        if: steps.verdict.outputs.verdict == 'BLOCKED'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+            -f state=failure -f context=sdk-review \
+            -f description="SDK Review: BLOCKED — critical security finding." 2>/dev/null || true
+
+      # Mark status = failure and add label for NEEDS_FIXES in review-only mode
+      # (so the PR visibly blocks on merge until author fixes & re-runs)
+      - name: Set status (NEEDS_FIXES, review-only)
+        if: |
+          steps.verdict.outputs.verdict == 'NEEDS_FIXES' &&
+          steps.pr.outputs.mode == 'review-only'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+            -f state=failure -f context=sdk-review \
+            -f description="SDK Review: NEEDS_FIXES — see review comment." 2>/dev/null || true
 
   # ── Reset review status on new commits ──────────────────────
   # When the author pushes new code, reset the sdk-review check
@@ -584,6 +664,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      statuses: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -619,14 +700,23 @@ jobs:
             echo "is_bot=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Reset sdk-review labels (author commits only)
+      - name: Reset sdk-review status + labels (author commits only)
         if: steps.check.outputs.is_bot == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-
           # Check if PR was previously approved (we'll notify only on first reset)
           WAS_APPROVED=$(gh pr view "$PR_NUMBER" --json labels \
             --jq '.labels[].name' | grep -c "sdk-review-approved" || true)
+
+          # Set status to pending — PR is blocked until @sdk-review runs
+          gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+            -f state=pending \
+            -f context=sdk-review \
+            -f description="New commits pushed. Comment @sdk-review to unblock." 2>/dev/null || true
 
           # Remove approved and auto-maintained labels
           gh pr edit "$PR_NUMBER" --remove-label "sdk-review-approved" 2>/dev/null || true
@@ -638,8 +728,27 @@ jobs:
             gh pr comment "$PR_NUMBER" --body \
               "New commits detected. The previous SDK Review approval has been reset because the code changed. Comment \`@sdk-review\` (or \`@sdk-review auto-complete\`) to re-review."
           fi
+
+      - name: Preserve approval for bot commits (branch updates)
+        if: steps.check.outputs.is_bot == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Re-set the status to success on the NEW commit SHA so the
+          # required check stays green on the updated branch (only if
+          # the PR was previously approved).
+          HAS_LABEL=$(gh pr view "$PR_NUMBER" --json labels \
+            --jq '.labels[].name' | grep -c "sdk-review-approved" || true)
+
+          if [ "$HAS_LABEL" -gt 0 ]; then
+            gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+              -f state=success \
+              -f context=sdk-review \
+              -f description="SDK Review: Approved. Branch updated automatically." 2>/dev/null || true
+          fi
 
   # ── @sdk-review stop handler ────────────────────────────────
   # Cancels an in-progress sdk-review / auto-complete run for this PR.


### PR DESCRIPTION
## Root cause of today's broken pipeline on PR #1326

After all prior fixes, the pipeline was running end-to-end but **skipping Finalize** — so no approve, no label, no status check. I traced the issue through the run logs:

```
Parse verdict:
  env:
    REVIEW_RESULT:   ← EMPTY
```

`${{ steps.review.outputs.result }}` resolves to an empty string at runtime because `anthropics/claude-code-action@v1` doesn't actually expose `.result`. Actionlint had warned about this earlier; I should have acted on it then.

With `REVIEW_RESULT` empty, `grep -oP 'VERDICT:\K.*'` finds nothing → default `NEEDS_FIXES` → `Finalize` skipped → no approve, no labels, no status.

## Changes

| # | Change | Why |
|---|--------|-----|
| 1 | Parse verdict reads the `SDK_REVIEW_V2` PR comment (via `gh api`) and extracts from the `### Verdict:` line | Authoritative, doesn't depend on undocumented action outputs |
| 2 | `statuses: write` permission restored (top-level + both jobs) | User asked to bring status check back |
| 3 | Status check posted at all lifecycle points (pending, failure, success) | Visual merge gate |
| 4 | New `Set status (BLOCKED)` step | BLOCKED verdict now blocks merge |
| 5 | New `Set status (NEEDS_FIXES, review-only)` step | Review-only NEEDS_FIXES blocks merge until author fixes + re-runs |
| 6 | `Preserve approval for bot commits` step added to `reset-review-status` job | Branch-keeper merges won't kill approval |

## Test plan
- [ ] Merge this
- [ ] Comment `@sdk-review` on a clean PR → `sdk-review` status check should go `pending` → `success`, PR auto-approved, `sdk-review-approved` label added
- [ ] Comment `@sdk-review auto-complete` on a PR with minor issues → fix loop runs → `sdk-review-auto-maintained` label added on approve