### PR TITLE
ci: rename secret to LITELLM_API_KEY in reusable review workflow

### DIFF
--- a/.github/workflows/reusable-claude-review.yml
+++ b/.github/workflows/reusable-claude-review.yml
@@ -12,7 +12,7 @@ on:
         default: 25
         description: 'Timeout for the review job in minutes'
     secrets:
-      AI_GATEWAY_KEY:
+      LITELLM_API_KEY:
         required: true
 
 jobs:
@@ -45,7 +45,7 @@ jobs:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.AI_GATEWAY_KEY }}
+          anthropic_api_key: ${{ secrets.LITELLM_API_KEY }}
           model: ${{ inputs.model }}
           timeout_minutes: ${{ inputs.timeout_minutes }}
           prompt: |


### PR DESCRIPTION
## Summary
Rename `AI_GATEWAY_KEY` to `LITELLM_API_KEY` in the reusable Claude review workflow to match the application-sdk convention. This way connector repos that already have `LITELLM_API_KEY` configured don't need a new secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)