### PR TITLE
feat(sdk-review): add @sdk-review challenge mode + retrospective learning

### DIFF
--- a/.claude/skills/sdk-review/references/retro-log.md
+++ b/.claude/skills/sdk-review/references/retro-log.md
@@ -1,0 +1,24 @@
+# SDK Review — Learned-not-to-flag log
+
+> A running record of findings that were **withdrawn** after `@sdk-review challenge`
+> pushback, with the author's objection and Claude's reason for agreeing.
+>
+> **Purpose**: teach future reviews to avoid re-flagging the same false-positive
+> pattern without strong new evidence.
+>
+> **Format**: each entry is a YAML block appended by the challenge flow
+> (`@sdk-review challenge: <reason>` → when Claude decides a finding should be
+> withdrawn, the retrospective YAML block is emitted in the challenge response
+> comment). For v1, entries are aggregated here manually from those comments.
+> A future automation can parse the YAML blocks and append automatically.
+>
+> When running a fresh `@sdk-review`, the session is instructed to consult this
+> log as part of its rule set — if a candidate finding matches a withdrawn
+> pattern here, require **additional evidence** before raising it.
+
+---
+
+## Entries
+
+<!-- No entries yet. The first entries will appear after the challenge
+     command is used and Claude withdraws at least one finding. -->

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,6 +32,13 @@ jobs:
   #   @sdk-review                     → Review only
   #   @sdk-review auto-complete       → Review + fix loop until clean
   #   @sdk-review stop                → Cancel an in-progress auto-complete
+  #   @sdk-review challenge: <reason> → Re-evaluate prior review's findings
+  #                                      against author pushback. Claude
+  #                                      can STAND BY / WITHDRAW / SOFTEN
+  #                                      each finding. Withdrawn findings
+  #                                      are emitted as YAML for the
+  #                                      retrospective learned-not-to-flag
+  #                                      list (manual aggregation for v1).
   #   @sdk-review override: <reason>  → Admin force-pass
   #
   # Aliases (backward-compat): `resolve all issues` == `auto-complete`,
@@ -119,6 +126,8 @@ jobs:
           #   (none of the above) → review-only
           if printf '%s' "$COMMENT_BODY" | grep -qi "override"; then
             MODE=override
+          elif printf '%s' "$COMMENT_BODY" | grep -qi "challenge"; then
+            MODE=challenge
           elif printf '%s' "$COMMENT_BODY" | grep -qiE "auto[- ]?complete|resolve"; then
             MODE=auto-fix
           elif printf '%s' "$COMMENT_BODY" | grep -qi "\-\-iteration="; then
@@ -181,6 +190,7 @@ jobs:
             auto-fix)     LABEL="auto-complete" ;;
             review-only)  LABEL="review" ;;
             override)     LABEL="override (admin)" ;;
+            challenge)    LABEL="challenge re-review" ;;
             *)            LABEL="$MODE" ;;
           esac
 
@@ -406,6 +416,93 @@ jobs:
                "Only repo admins can override the sdk-review check."
                Output VERDICT:NEEDS_FIXES and stop.
 
+            If the mode is "challenge":
+            A challenge is a formal pushback on a prior review — the
+            author believes one or more findings were wrong. You must
+            re-evaluate the PR in light of their pushback, honestly
+            and without sycophancy.
+
+            1. Fetch the most recent prior SDK_REVIEW_V2 comment:
+               gh api repos/${{ github.repository }}/issues/${{ steps.pr.outputs.number }}/comments \
+                 --jq '[.[] | select(.body | contains("SDK_REVIEW_V2"))] | last | .body'
+
+            2. Fetch the triggering challenge comment body via $GITHUB_EVENT_PATH
+               (same as any @sdk-review comment — mode=challenge was
+               detected because it contains "challenge"). Extract any
+               reason the author gave after "@sdk-review challenge:".
+
+            3. Fetch author's replies on bot-posted inline review comments:
+               gh api repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/comments \
+                 --jq '[.[] | select(.user.login != "github-actions[bot]")] | .[] | {path, line, body, in_reply_to_id}'
+
+            4. Re-read the changed files (not just the diff) so you can
+               evaluate findings in context again with fresh eyes.
+
+            5. For EACH finding in the prior review, decide one of:
+               - **STAND BY**: the finding is still valid. Explain WHY,
+                 addressing the author's specific objection.
+               - **WITHDRAW**: the finding was wrong. Acknowledge
+                 explicitly (e.g. "I initially flagged this as a bare
+                 except; on re-read, the exception is intentional and
+                 narrowly scoped — retracting this finding.").
+               - **SOFTEN**: downgrade severity (e.g. Critical → Minor).
+                 Explain what changed your assessment.
+
+            6. Post a new SDK_REVIEW_V2 comment with this format (use
+               \$SDK_REVIEW_VERB = "Re-review" since challenge implies
+               prior review exists):
+
+               <!-- SDK_REVIEW_V2 -->
+               ## SDK Re-review (challenge response): PR #<num> — <title>
+
+               ### Verdict: <updated verdict>
+
+               > Re-evaluated prior findings against the author's
+               > challenge: "<quote their reason if given>".
+               > <1-line summary of outcome — how many stood, withdrawn, softened>
+
+               ### Changes from prior review
+
+               - **[STAND BY]** `file:line` — <original finding> — <why it still holds>
+               - **[WITHDRAWN]** `file:line` — <original finding> — <why you now agree>
+               - **[SOFTENED]** `file:line` — <original> (was Critical, now Minor) — <why>
+
+               ### Findings by File (current state)
+
+               <same format as review mode, but reflecting post-challenge state>
+
+               ### Retrospective (for learned-not-to-flag list)
+
+               \`\`\`yaml
+               # For each WITHDRAWN finding, emit an entry. This YAML
+               # block is machine-parseable so a future step can append
+               # these to a learned-not-to-flag log.
+               withdrawn_findings:
+                 - file: <path>
+                   line: <N>
+                   original_text: <verbatim prior finding>
+                   author_challenge: <quote author's objection>
+                   why_withdrawn: <your reasoning>
+               \`\`\`
+               (Omit the whole "Retrospective" section if no findings
+               were withdrawn in this pass.)
+
+            7. Verdict logic for challenge mode:
+               - If ALL prior blockers are withdrawn/softened below
+                 Critical → verdict is READY_TO_MERGE.
+               - If some challenges are valid but others stand, and
+                 remaining findings meet the normal bar → NEEDS_FIXES
+                 or READY_TO_MERGE as appropriate.
+               - Output the verdict as the LAST LINE: VERDICT:<verdict>
+
+            8. Do NOT re-post inline comments (the original ones from
+               the prior review still stand on the lines that haven't
+               changed). If you withdraw a finding, you may OPTIONALLY
+               reply to its inline thread acknowledging the retraction.
+
+            Stop here if mode is "challenge". Do not proceed to the
+            regular review flow below.
+
             Otherwise, do the review:
 
             1. Get the diff:
@@ -420,6 +517,11 @@ jobs:
                - .claude/skills/sdk-review/references/test-quality-rules.md
                - .claude/skills/sdk-review/references/dx-rules.md
                - .claude/skills/sdk-review/references/structural-rules.md
+               - .claude/skills/sdk-review/references/retro-log.md
+                 (learned-not-to-flag — patterns previously withdrawn
+                 after author challenges. DO NOT flag these again
+                 without additional evidence beyond what was present
+                 in the prior false-positive case.)
 
             4. Analyze the PR across these 3 dimensions:
                - CORRECTNESS: architecture (ADR compliance, contract safety, determinism), security (secrets, injection, isolation), logical bugs
@@ -700,6 +802,8 @@ jobs:
             fi
 
             APPROVE_BODY="⚠️ **SDK Review — Admin override.** Approving because @${OVERRIDE_ADMIN} explicitly invoked \`@sdk-review override\`. Reason: _${OVERRIDE_REASON}_. This bypasses normal review findings; the reason above is recorded for audit. CI passing. Branch up to date."
+          elif [ "$MODE" = "challenge" ]; then
+            APPROVE_BODY="SDK Re-review (challenge response): blocking findings withdrawn or softened after re-evaluating author pushback. CI passing. Branch up to date. Approved."
           else
             PRIOR_REVIEWS=$(gh api "repos/${REPO}/issues/${PR}/comments" \
               --jq '[.[] | select(.body | contains("SDK_REVIEW_V2"))] | length' 2>/dev/null || echo 1)


### PR DESCRIPTION
## The feature

```
@sdk-review challenge: <optional reason>
```

Formal pushback mechanism. Author believes one or more findings in the prior review are wrong; trigger `challenge` instead of arguing in comments. Claude re-reads the code + the prior SDK_REVIEW_V2 comment + author replies on inline findings + the challenge reason, then decides per finding:

| Decision | Meaning |
|---|---|
| **STAND BY** | Finding still valid, rephrased with stronger justification |
| **WITHDRAW** | Finding was wrong, explicitly retracted |
| **SOFTEN** | Downgrade severity (e.g. Critical → Minor) |

## Response format

```markdown
<!-- SDK_REVIEW_V2 -->
## SDK Re-review (challenge response): PR #… — …

### Verdict: READY TO MERGE | NEEDS FIXES | BLOCKED

> Re-evaluated prior findings against the author's challenge: "…quoted…".
> 2 stand, 1 withdrawn, 1 softened.

### Changes from prior review
- **[STAND BY]** `file:L42` — bare `except` → still incorrect because it swallows KeyboardInterrupt
- **[WITHDRAWN]** `file:L55` — 'f-string in logger' → this is actually a .format() call, I misread
- **[SOFTENED]** `file:L89` — 'missing type hints' (Critical → Minor) — private helper, less impactful

### Findings by File (current state)
…

### Retrospective
```yaml
withdrawn_findings:
  - file: application_sdk/foo.py
    line: 55
    original_text: 'f-string in logger call'
    author_challenge: 'This is a .format() call, not an f-string'
    why_withdrawn: 'I misread the % sign as part of a format spec'
```
```

## Self-improvement loop (v1 manual, v2 automated)

**Retro-log**: new file `.claude/skills/sdk-review/references/retro-log.md` tracks patterns Claude has previously withdrawn. Main review prompt now reads it as part of its rule set: *"Patterns previously withdrawn — DO NOT flag again without additional evidence."*

For v1 the YAML from challenge responses is aggregated manually into retro-log.md. v2 can parse the YAML blocks and append automatically on merge.

## Verdict handling

Challenge mode uses the same Parse verdict → Finalize flow as review-only. If Finalize determines verdict is READY_TO_MERGE, it approves with a distinct body:

> `SDK Re-review (challenge response): blocking findings withdrawn or softened after re-evaluating author pushback. CI passing. Branch up to date. Approved.`

## Test plan (after merge)

- [ ] On a PR that already has findings (e.g. T1 from the test suite), comment `@sdk-review challenge: I intentionally used bare except to catch KeyboardInterrupt`.
- [ ] Verify new SDK_REVIEW_V2 comment posted with `## SDK Re-review (challenge response):` heading.
- [ ] Verify per-finding STAND BY / WITHDRAW / SOFTEN decisions are present.
- [ ] If any finding withdrawn → verify Retrospective YAML block is emitted.
- [ ] If verdict becomes READY_TO_MERGE → verify Finalize approved with the distinct challenge body.
- [ ] On a fresh PR with a similar pattern to a withdrawn one → verify the new review consults retro-log.md and doesn't re-flag without extra evidence.

## Will port to refactor-v3 in a follow-up PR once this lands.