### PR TITLE
test(sdk-review): T1 — findings sampler fixture (DO NOT MERGE)

### DIFF
--- a/tests/unit/sdk_review_tests/test_findings_sampler.py
+++ b/tests/unit/sdk_review_tests/test_findings_sampler.py
@@ -1,0 +1,31 @@
+"""Test fixture for sdk-review — intentionally contains multiple
+low-severity quality issues so the review pipeline has something to
+flag. NEVER merge; this is a fixture for smoke-testing @sdk-review."""
+
+import logging
+import os  # unused import — F401
+
+logger = logging.getLogger(__name__)
+
+
+def get_cwd_with_bare_except():
+    """Function with a bare except — E722 violation."""
+    try:
+        return os.getcwd()
+    except:  # noqa — intentional for test, but should be flagged by SDK review
+        return None
+
+
+def log_user(user: str) -> None:
+    """f-string in logger call — should be %-style."""
+    logger.info(f"processing user {user}")
+
+
+def debug_helper():  # missing return type annotation
+    """Uses print() instead of logger."""
+    print("debug output")
+    return {"a": 1}
+
+
+def no_docstring_no_types(x):
+    return x * 2


### PR DESCRIPTION
## Test PR — do not merge

Test fixture for SDK Review pipeline smoke tests. Contains intentional low-severity code-quality issues:

- Unused import (`os`)
- Bare `except:` clause (E722)
- f-string in `logger.info()` call
- `print()` statement
- Missing type hints / return annotations
- Missing docstring on one function

## How it's used

Scenarios exercised by commenting on this PR:

1. `@sdk-review` → verdict should be **NEEDS_FIXES**, status `failure`, inline comments on each finding
2. `@sdk-review auto-complete` → Claude should fix each finding, commit, push, re-review loop, eventually approve
3. `@sdk-review challenge: all of these are intentional for test purposes` (after #1345 merges) → verify challenge mode re-evaluates

## Do not merge
This fixture file would introduce quality violations if merged. Close without merging after tests complete.