### PR TITLE
test(sdk-review): T6 — clean large PR fixture (DO NOT MERGE)

### DIFF
--- a/tests/unit/sdk_review_tests/test_another_clean_file.py
+++ b/tests/unit/sdk_review_tests/test_another_clean_file.py
@@ -1,0 +1,21 @@
+"""Companion clean module for the @sdk-review clean-large test."""
+
+from __future__ import annotations
+
+from .test_clean_large_fixture import FixtureRecord, build_fixture
+
+
+def build_default_fixtures() -> list[FixtureRecord]:
+    """Return a canonical set of fixtures used by several tests."""
+    return [
+        build_fixture("a", "Alice"),
+        build_fixture("b", "Bob", extra={"tier": "silver"}),
+        build_fixture("c", "Carol", extra={"tier": "gold"}),
+    ]
+
+
+def filter_by_tier(
+    records: list[FixtureRecord], *, tier: str
+) -> list[FixtureRecord]:
+    """Return only records whose metadata ``tier`` matches."""
+    return [r for r in records if r.metadata.get("tier") == tier]

--- a/tests/unit/sdk_review_tests/test_clean_large_fixture.py
+++ b/tests/unit/sdk_review_tests/test_clean_large_fixture.py
@@ -1,0 +1,92 @@
+"""Clean, idiomatic test fixtures for the application SDK.
+
+This module is part of a test scenario for the @sdk-review pipeline.
+It intentionally contains NO review findings — all code follows
+the SDK's conventions: %-style logging, explicit exception types,
+type hints on public functions, docstrings on public functions.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FixtureRecord:
+    """A minimal record used as test data."""
+
+    id: str
+    name: str
+    metadata: dict[str, Any]
+
+
+def normalize_name(name: str) -> str:
+    """Return a canonical lower-case form of ``name`` with surrounding
+    whitespace stripped.
+
+    >>> normalize_name(" Alice ")
+    'alice'
+    """
+    return name.strip().lower()
+
+
+def merge_metadata(
+    base: dict[str, Any], override: dict[str, Any]
+) -> dict[str, Any]:
+    """Return a new dict with ``base`` merged under ``override``.
+
+    Does not mutate inputs; ``override`` wins on key conflicts.
+    """
+    merged = dict(base)
+    merged.update(override)
+    return merged
+
+
+def build_fixture(
+    record_id: str,
+    name: str,
+    *,
+    extra: dict[str, Any] | None = None,
+) -> FixtureRecord:
+    """Construct a :class:`FixtureRecord` with sensible defaults.
+
+    Args:
+        record_id: Stable identifier for the record.
+        name: Display name (will be normalised).
+        extra: Optional additional metadata merged into the record.
+
+    Returns:
+        A new :class:`FixtureRecord` with normalised name and
+        optional metadata merged.
+    """
+    metadata: dict[str, Any] = {"source": "test-fixture"}
+    if extra is not None:
+        metadata = merge_metadata(metadata, extra)
+
+    return FixtureRecord(
+        id=record_id,
+        name=normalize_name(name),
+        metadata=metadata,
+    )
+
+
+def summarise(records: list[FixtureRecord]) -> dict[str, int]:
+    """Return a small summary of ``records``: count by source.
+
+    Raises:
+        ValueError: if ``records`` is empty.
+    """
+    if not records:
+        raise ValueError("records must be non-empty")
+
+    summary: dict[str, int] = {}
+    for record in records:
+        source = record.metadata.get("source", "unknown")
+        summary[source] = summary.get(source, 0) + 1
+
+    logger.debug("summarised %d records across %d sources", len(records), len(summary))
+    return summary


### PR DESCRIPTION
## Test PR — do not merge

~130 lines across 2 modules, all idiomatic:
- Type hints on every public function
- Docstrings on every public function + module
- %-style logging (no f-strings)
- Explicit exceptions
- No unused imports / no `print`

## Scenario

Comment `@sdk-review` on this PR → should:
1. Return verdict **READY_TO_MERGE**
2. Status check `sdk-review` → **success**
3. Bot approves with body: *"SDK Review: no blocking issues found. CI passing. Branch up to date. Approved."*
4. Label `sdk-review-approved` added

Tests: the happy path on a non-trivial PR size, not just a 1-line doc change.

## Do not merge
Close without merging after tests complete.