### PR TITLE
BLDX-831: feat: add GET /manifest/version endpoint for manifest hash

### DIFF
--- a/application_sdk/application/__init__.py
+++ b/application_sdk/application/__init__.py
@@ -75,6 +75,13 @@ class BaseApplication:
 
             self.mcp_server = MCPServer(application_name=name)
 
+    def _get_manifest_path(self) -> Optional[Any]:
+        """Return the manifest file path (pathlib.Path) if it exists, else None."""
+        from pathlib import Path
+
+        manifest_path = Path.cwd() / "contract" / "generated" / "manifest.json"
+        return manifest_path if manifest_path.exists() else None
+
     def get_manifest(self) -> Optional[Dict[str, Any]]:
         """Return the manifest dict for the GET /manifest endpoint.
 
@@ -87,12 +94,11 @@ class BaseApplication:
         with actual values at serve time.
         """
         import json
-        from pathlib import Path
 
         from application_sdk.constants import DEPLOYMENT_NAME
 
-        manifest_path = Path.cwd() / "contract" / "generated" / "manifest.json"
-        if manifest_path.exists():
+        manifest_path = self._get_manifest_path()
+        if manifest_path is not None:
             logger.info(f"Serving manifest from contract: {manifest_path}")
             with open(manifest_path) as f:
                 raw = f.read()
@@ -109,10 +115,9 @@ class BaseApplication:
         """
         import hashlib
         import json
-        from pathlib import Path
 
-        manifest_path = Path.cwd() / "contract" / "generated" / "manifest.json"
-        if not manifest_path.exists():
+        manifest_path = self._get_manifest_path()
+        if manifest_path is None:
             return None
 
         with open(manifest_path) as f:

--- a/application_sdk/application/__init__.py
+++ b/application_sdk/application/__init__.py
@@ -101,6 +101,30 @@ class BaseApplication:
             return json.loads(raw)
         return None
 
+    def get_manifest_version(self) -> Optional[Dict[str, Any]]:
+        """Return a stable hash of the DAG portion of the raw manifest.
+
+        Uses the raw manifest (no placeholder substitution) so the hash
+        is deterministic across deployments.
+        """
+        import hashlib
+        import json
+        from pathlib import Path
+
+        manifest_path = Path.cwd() / "contract" / "generated" / "manifest.json"
+        if not manifest_path.exists():
+            return None
+
+        with open(manifest_path) as f:
+            raw = json.load(f)
+
+        dag = raw.get("dag")
+        if dag is None:
+            return None
+
+        version = hashlib.sha256(json.dumps(dag, sort_keys=True).encode()).hexdigest()
+        return {"manifest_version": version}
+
     def bootstrap_event_registration(self):
         self.event_subscriptions: Dict[str, EventWorkflowTrigger] = {}
         if self.application_manifest is None:
@@ -303,6 +327,7 @@ class BaseApplication:
             handler=self.handler_class(client=self.client_class()),
             has_configmap=has_configmap,
             manifest=self.get_manifest(),
+            manifest_version=self.get_manifest_version(),
         )
 
         # Mount MCP at root

--- a/application_sdk/application/metadata_extraction/sql.py
+++ b/application_sdk/application/metadata_extraction/sql.py
@@ -310,6 +310,7 @@ class BaseSQLMetadataExtractionApplication(BaseApplication):
             ui_enabled=ui_enabled,
             has_configmap=has_configmap,
             manifest=self.get_manifest(),
+            manifest_version=self.get_manifest_version(),
         )
 
         # register the workflow on the application server

--- a/application_sdk/server/fastapi/__init__.py
+++ b/application_sdk/server/fastapi/__init__.py
@@ -123,6 +123,7 @@ class APIServer(ServerInterface):
         has_configmap: bool = False,
         subscriptions: List[Subscription] = [],
         manifest: Optional[dict[str, Any]] = None,
+        manifest_version: Optional[dict[str, Any]] = None,
     ):
         """Initialize the FastAPI application.
 
@@ -139,6 +140,7 @@ class APIServer(ServerInterface):
         self.ui_enabled = ui_enabled
         self.has_configmap = has_configmap
         self.manifest = manifest
+        self.manifest_version = manifest_version
 
         # Create the FastAPI app using the renamed import
         if isinstance(lifespan, Callable):
@@ -455,6 +457,14 @@ class APIServer(ServerInterface):
             self.app.add_api_route(
                 "/manifest",
                 lambda: manifest_data,
+                methods=["GET"],
+            )
+
+        if self.manifest_version is not None:
+            manifest_version_data = self.manifest_version
+            self.app.add_api_route(
+                "/manifest/version",
+                lambda: manifest_version_data,
                 methods=["GET"],
             )
 

--- a/tests/unit/server/fastapi/test_manifest_and_configmaps.py
+++ b/tests/unit/server/fastapi/test_manifest_and_configmaps.py
@@ -32,14 +32,15 @@ class _MockWorkflow(WorkflowInterface):
         return []
 
 
-def _make_server(manifest=None, has_configmap=False):
-    """Create an APIServer with optional manifest."""
+def _make_server(manifest=None, manifest_version=None, has_configmap=False):
+    """Create an APIServer with optional manifest and manifest_version."""
     server = APIServer(
         handler=_MockHandler(),
         workflow_client=Mock(),
         ui_enabled=False,
         has_configmap=has_configmap,
         manifest=manifest,
+        manifest_version=manifest_version,
     )
     return server
 
@@ -88,6 +89,33 @@ class TestManifestRoute:
 
         assert response.status_code == 200
         assert response.json() == manifest_data
+
+
+class TestManifestVersionRoute:
+    """Tests for the /manifest/version endpoint registration and response."""
+
+    async def test_manifest_version_route_registered_when_provided(self):
+        """When manifest_version is not None, /manifest/version route should be registered."""
+        version_data = {"manifest_version": "abc123hash"}
+        server = _make_server(manifest_version=version_data)
+
+        transport = ASGITransport(app=server.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/manifest/version")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["manifest_version"] == "abc123hash"
+
+    async def test_manifest_version_route_not_registered_when_none(self):
+        """When manifest_version is None, /manifest/version route should not exist."""
+        server = _make_server(manifest_version=None)
+
+        transport = ASGITransport(app=server.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/manifest/version")
+
+        assert response.status_code in (404, 405)
 
 
 class TestListConfigmaps:


### PR DESCRIPTION
## Summary

Adds a `GET /manifest/version` endpoint that returns a SHA-256 hash of the DAG portion of `manifest.json`. The hash is computed from the raw manifest (no placeholder substitution) so it's deterministic across deployments.

AE calls this on every workflow run to detect manifest changes without fetching the full manifest. If the hash differs from the stored `manifest_version`, AE fetches the full manifest and performs an auto-upgrade.

### Implementation
- `get_manifest_version()` on `BaseApplication`: reads raw `manifest.json`, extracts `dag`, computes `SHA-256(json.dumps(dag, sort_keys=True))`
- `_get_manifest_path()` shared between `get_manifest()` and `get_manifest_version()` — single file source
- `BaseSQLMetadataExtractionApplication.start()` passes `manifest_version` to `APIServer` (without this, SQL connector apps would not get the endpoint)
- Only registered if manifest exists (same pattern as `/manifest`)

## Related PRs
- app-contract-toolkit: atlanhq/app-contract-toolkit#16
- heracles: atlanhq/heracles#5583
- atlan-automation-engine-app: atlanhq/atlan-automation-engine-app#657

## Test plan
- [ ] App with `contract/generated/manifest.json` → `GET /manifest/version` returns `{"manifest_version": "<sha256>"}`
- [ ] App without manifest → endpoint not registered (404)
- [ ] SQL connector app (extends `BaseSQLMetadataExtractionApplication`) → endpoint works
- [ ] Hash is stable across restarts (deterministic)
- [ ] Hash changes when DAG content changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)