### PR TITLE
ci: remove docs publishing job from PR and push workflows (BLDX-1019)

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -331,37 +331,3 @@ jobs:
         with:
           name: e2e-test-logs
           path: test-logs/
-
-  # Documentation
-  docs:
-    name: Docs
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: "./.github/actions/setup-deps"
-      - name: Install graphviz
-        run: |
-          sudo apt install graphviz
-      - name: Generate Sphinx Docs and UML Diagrams
-        run: |
-          uv run poe generate-apidocs
-
-      - name: Setup AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          aws-region: ap-south-1
-          # Only usable in atlanhq repositories
-          role-to-assume: arn:aws:iam::733936409301:role/kryptonite-store_FullAccess
-
-      - name: Upload Docs to Kryptonite Bucket
-        run: |
-          aws s3 sync ./site s3://kryptonite-store/application-sdk/${{ github.head_ref }} --delete
-
-      - name: Comment Kryptonite URL on PR
-        uses: mshick/add-pr-comment@v2
-        with:
-          message-id: "docs"
-          message: |
-            🛠 Docs available at: https://k.atlan.dev/application-sdk/${{ github.head_ref }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -53,28 +53,3 @@ jobs:
           github-token: ${{ secrets.ORG_PAT_GITHUB }}
           repo-name: ${{ matrix.repo_name }}
           target-branch: ${{ github.ref_name }}
-
-  # Documentation
-  docs:
-    name: Docs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: "./.github/actions/setup-deps"
-      - name: Install graphviz
-        run: |
-          sudo apt install graphviz
-      - name: Generate Sphinx Docs and UML Diagrams
-        run: |
-          uv run poe generate-apidocs
-
-      - name: Setup AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          aws-region: ap-south-1
-          # Only usable in atlanhq repositories
-          role-to-assume: arn:aws:iam::733936409301:role/kryptonite-store_FullAccess
-
-      - name: Upload Docs to Kryptonite Bucket
-        run: |
-          aws s3 sync ./site s3://kryptonite-store/application-sdk/${{ github.head_ref }} --delete


### PR DESCRIPTION
## Summary
- Remove the `docs` job from `.github/workflows/pull_request.yaml` and `.github/workflows/push.yaml`.
- This job was publishing MkDocs + pydoctor output to `s3://kryptonite-store/application-sdk/<branch>` and posting a preview URL comment on PRs.

## Why
- SDK docs are migrating to the `atlan-docs` repo; this CI publishing pipeline is the piece we can safely retire now.
- `push.yaml` already uses `github.head_ref` (empty on push events), so the `main` uploads don't actually land at `/main/` — the publishing is partially broken already.
- Every PR with code changes was triggering an AWS OIDC assume-role + S3 sync + bot comment, adding CI cost / noise with diminishing value.

## Scope (deliberately minimal)
Kept in place so the `atlan-docs` migration can wire them up later without another revert:
- `mkdocs.yml`
- `docs/` (conceptual markdown)
- `generate-apidocs` poe task in `pyproject.toml`
- `.github/actions/docgen/` + `.github/actions/doclint/` + `.github/styles/` (Vale)

## Prior art
- `2f94c849` (Nishchith, 2025-10-20) — attempted full removal + move to `atlan-docs`
- `20d5fe9f` (Sachi, 2025-12-05) — reverted, because the removal deleted the entire `docs/` tree + mkdocs config before the `atlan-docs` replacement was ready

This PR removes **only** the CI publishing piece so the same situation doesn't repeat.

## Impact
- `k.atlan.dev/application-sdk` freezes at the last build. The "API Reference" link in the MkDocs nav (`/main/api`) will go stale. No known external consumers; SDK API reference is moving to `atlan-docs`.
- Local `uv run poe generate-apidocs` continues to work for developers who want to preview docs.

## Test plan
- [ ] CI (`PR Checks`) runs without the `docs` job and stays green
- [ ] No other workflow references the removed job (grep confirms: only `pull_request.yaml` and `push.yaml` defined the `docs:` job)

Linear: BLDX-1019