### PR TITLE
fix(sdk-review): add missing top-level permissions (actions, workflows) (port)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,6 +41,8 @@ permissions:
   issues: write
   pull-requests: write
   statuses: write
+  actions: write      # sdk-review-stop needs this to cancel runs
+  workflows: write    # sdk-review needs this to update branches on workflow-touching PRs
 
 env:
   ANTHROPIC_BASE_URL: https://llmproxy.atlan.dev


### PR DESCRIPTION
## Summary
Port of permissions fix to `refactor-v3`.

- The prior commit (#1368) added `actions: write` and `workflows: write` to the **job-level** permissions but not to the **top-level** `permissions:` block
- GitHub Actions requires job-level permissions to be a subset of top-level — otherwise the workflow is silently rejected
- This was causing `@sdk-review` comments to be completely ignored on refactor-v3 PRs

## Test plan
- [ ] After merge, comment `@sdk-review` on PR #1358 — a run should trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)