### PR TITLE
fix(sdk-review): remove invalid 'workflows' permission, use git merge fallback

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,7 +42,6 @@ permissions:
   pull-requests: write
   statuses: write
   actions: write      # sdk-review-stop needs this to cancel runs
-  workflows: write    # sdk-review needs this to update branches on workflow-touching PRs
 
 env:
   ANTHROPIC_BASE_URL: https://llmproxy.atlan.dev
@@ -110,7 +109,6 @@ jobs:
       id-token: write
       statuses: write
       actions: write        # needed to dispatch workflow_dispatch iterations
-      workflows: write      # needed to update branches on PRs that touch .github/workflows/
     timeout-minutes: 30
     concurrency:
       group: sdk-review-${{ github.event.issue.number }}
@@ -1254,11 +1252,25 @@ jobs:
           MODE: ${{ steps.pr.outputs.mode }}
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          HEAD_BRANCH: ${{ steps.pr.outputs.head_branch }}
+          BASE_BRANCH: ${{ steps.pr.outputs.base_branch }}
         run: |
-          # Update branch (workflows: write permission allows this even
-          # for PRs that touch .github/workflows/).
-          gh api "repos/${REPO}/pulls/$PR/update-branch" \
-            -X PUT -f update_method=merge 2>/dev/null || echo "Branch already up to date"
+          # Update branch. Try the API first (fast, no checkout needed).
+          # If it 403s (e.g. PR touches .github/workflows/ — the API
+          # requires a PAT with 'workflows' OAuth scope for that), fall
+          # back to git merge + push which works with contents: write.
+          if ! gh api "repos/${REPO}/pulls/$PR/update-branch" \
+               -X PUT -f update_method=merge 2>/dev/null; then
+            echo "API update-branch failed (likely workflow-touching PR). Falling back to git merge."
+            git fetch origin "$BASE_BRANCH" "$HEAD_BRANCH"
+            git checkout "$HEAD_BRANCH"
+            if git merge "origin/$BASE_BRANCH" --no-edit; then
+              git push origin "$HEAD_BRANCH"
+            else
+              echo "Merge conflict during branch update — aborting."
+              git merge --abort
+            fi
+          fi
 
           # Wait for CI after branch update
           sleep 15


### PR DESCRIPTION
## Summary
**CRITICAL** — the entire `claude.yml` workflow is broken on both `main` and `refactor-v3`. No runs trigger at all.

**Root cause:** `workflows` is not a valid `GITHUB_TOKEN` permission scope (it's only an OAuth scope for PATs). Adding it in #1367/#1369 caused GitHub Actions to reject the entire workflow file:
```
(Line: 45, Col: 3): Unexpected value 'workflows'
(Line: 113, Col: 7): Unexpected value 'workflows'
```

**Fix:**
1. Remove `workflows: write` from both top-level and job-level permissions
2. Replace the `update-branch` API call (which 403s on workflow-touching PRs) with a `git merge` + `git push` fallback that works with `contents: write`

## Test plan
- [ ] After merge, `push` events should produce normal runs (not "workflow file issue")
- [ ] `@sdk-review` comments should trigger runs again
- [ ] Branch update should work even for PRs that touch `.github/workflows/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)