### PR TITLE
fix: remove per-repo allowlist — base-allowlist is single source of truth

### DIFF
--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -273,49 +273,27 @@ jobs:
           import json, sys, os
           from datetime import datetime
 
-          # Load base allowlist (from SDK) — base entries always win on conflict
-          base_allowlist = {}
+          # Load base allowlist (from SDK) — single source of truth for all apps.
+          # Per-repo allowlists are not supported; all CVE exceptions must go
+          # through the centralized base-allowlist maintained by the SDK team.
+          allowlist = {}
           base_path = "_sdk/.security/base-allowlist.json"
           try:
               with open(base_path) as f:
                   base_raw = json.load(f)
-              base_allowlist = {k: v for k, v in base_raw.items() if not k.startswith("_")}
-              print(f"Base allowlist: {len(base_allowlist)} entries")
+              allowlist = {k: v for k, v in base_raw.items() if not k.startswith("_")}
+              print(f"Base allowlist: {len(allowlist)} entries")
           except FileNotFoundError:
-              print(f"Warning: {base_path} not found — no base allowlist")
+              print(f"Warning: {base_path} not found — no allowlist")
           except json.JSONDecodeError as e:
               print(f"Error: base allowlist has invalid JSON: {e}")
               sys.exit(1)
 
-          # Load repo allowlist
-          repo_allowlist = {}
-          repo_path = ".security/allowlist.json"
-          try:
-              if os.path.exists(repo_path):
-                  with open(repo_path) as f:
-                      repo_raw = json.load(f)
-                  repo_allowlist = {k: v for k, v in repo_raw.items() if not k.startswith("_")}
-                  print(f"Repo allowlist: {len(repo_allowlist)} entries")
-              else:
-                  print("No .security/allowlist.json in repo")
-          except json.JSONDecodeError as e:
-              print(f"Error: repo allowlist has invalid JSON: {e}")
-              sys.exit(1)
-
-          # Merge: repo first, then base overwrites — base always wins on conflict
-          allowlist = {}
-          allowlist.update(repo_allowlist)
-          conflicts = [k for k in base_allowlist if k in repo_allowlist]
-          if conflicts:
-              for c in conflicts:
-                  print(f"Warning: conflict on {c} — base allowlist wins (repo entry ignored)")
-          allowlist.update(base_allowlist)
-
           if not allowlist:
-              print("No allowlists found — all vulnerabilities will be reported but not blocked.")
+              print("No allowlist found — all vulnerabilities will be reported but not blocked.")
               allowlist = None
 
-          print(f"Total allowlist: {len(allowlist) if allowlist else 0} entries")
+          print(f"Allowlist: {len(allowlist) if allowlist else 0} entries")
 
           today = datetime.now().strftime("%Y-%m-%d")
           all_vulns = {}


### PR DESCRIPTION
## Summary

Removes per-repo `.security/allowlist.json` support from the security gate. The centralized `base-allowlist.json` in application-sdk is now the **single source of truth** for all CVE exceptions.

## What changed

In `build-and-scan.yaml`'s Security Gate step:
- Removed the block that reads `.security/allowlist.json` from the caller repo
- Removed the merge logic (base + repo allowlists)
- Gate now only checks against `base-allowlist.json` from SDK

**-31 lines / +9 lines** — simplification, not new behavior.

## Policy

- **Base-image CVEs** → allowlisted centrally in `application-sdk/.security/base-allowlist.json` by SDK team
- **App-level CVEs** → must be fixed directly (via `/fix-vulnerabilities` or manual upgrade), not allowlisted at repo level
- If an app has a `.security/allowlist.json`, it will be **ignored** after this change

## Impact

All ~45 apps consuming `build-and-scan.yaml@main` pick this up immediately. No app-side changes needed. Apps that already removed their repo allowlist (like postgres via #337) see no behavior change.