### PR TITLE
fix(sdk-review): pre-fetch PR diff before Claude session

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -506,6 +506,20 @@ jobs:
 
           exit 1  # Stop the workflow here
 
+      # Pre-fetch the PR diff and file list so the Claude session can
+      # read them from disk instead of fetching via gh CLI. This avoids
+      # permission/sandbox issues with chained commands and output
+      # redirection inside claude-code-action.
+      - name: Pre-fetch PR diff and file list
+        if: steps.pr.outputs.mode != 'override' && steps.pr.outputs.mode != 'challenge'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p /tmp/sdkreview
+          gh pr diff ${{ steps.pr.outputs.number }} > /tmp/sdkreview/diff.patch
+          gh pr view ${{ steps.pr.outputs.number }} --json files --jq '.files[].path' > /tmp/sdkreview/files.txt
+          echo "Pre-fetched diff ($(wc -l < /tmp/sdkreview/diff.patch) lines) and file list ($(wc -l < /tmp/sdkreview/files.txt) files)"
+
       # Main review session (Opus)
       # v1 implementation: single-session review (no Agent subagents).
       # The Agent tool (for subagents) caused auth failures because subagents
@@ -693,12 +707,12 @@ jobs:
                 additional evidence beyond what was present in the
                 prior false-positive case.)
 
-            Run once so all 3 subagents read from disk instead of
-            re-fetching through gh:
+            The PR diff and file list have been pre-fetched to disk by a
+            prior workflow step. They are already available at:
+              - /tmp/sdkreview/diff.patch (the full PR diff)
+              - /tmp/sdkreview/files.txt (list of changed file paths)
 
-                mkdir -p /tmp/sdkreview
-                gh pr diff ${{ steps.pr.outputs.number }} > /tmp/sdkreview/diff.patch
-                gh pr view ${{ steps.pr.outputs.number }} --json files --jq '.files[].path' > /tmp/sdkreview/files.txt
+            Do NOT re-fetch these — just read them directly.
 
             ### Step 2 — Dispatch 3 subagents in PARALLEL
 


### PR DESCRIPTION
## Summary
- Adds a workflow step to pre-fetch the PR diff and file list to `/tmp/sdkreview/` **before** the Claude Code review session starts
- Updates the prompt to tell Claude the files are already on disk — no need to fetch them
- Fixes the cascading failure where chained bash commands (`mkdir && gh pr diff > file`) were rejected by `allowedTools` permission patterns, and output redirection was blocked by the sandbox

**Root cause**: Run [24499864306](https://github.com/atlanhq/application-sdk/actions/runs/24499864306) (PR #1288) was cancelled because the Claude session tried to run `mkdir -p /tmp/sdkreview && gh pr diff 1288 > /tmp/sdkreview/diff.patch` as a single chained command, which doesn't match the individual `Bash(mkdir:*)` / `Bash(gh pr diff:*)` allowedTools patterns. Retries with output redirection were also blocked by the sandbox.

## Test plan
- [ ] Trigger `@sdk-review` on a test PR and verify the pre-fetch step runs successfully
- [ ] Verify the Claude session reads from `/tmp/sdkreview/diff.patch` instead of fetching
- [ ] Verify `@sdk-review override:` and `@sdk-review challenge:` still work (pre-fetch step is skipped for these modes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)