### PR TITLE
feat: add CloudStore for external customer cloud buckets [BLDX-966]

### DIFF
--- a/application_sdk/storage/__init__.py
+++ b/application_sdk/storage/__init__.py
@@ -44,6 +44,7 @@ from application_sdk.storage.batch import (
     upload_prefix,
 )
 from application_sdk.storage.binding import create_store_from_binding
+from application_sdk.storage.cloud import CloudStore
 from application_sdk.storage.errors import (
     StorageConfigError,
     StorageError,
@@ -64,6 +65,8 @@ from application_sdk.storage.ops import (
 list_files = list_keys
 
 __all__ = [
+    # Cloud store (external customer buckets)
+    "CloudStore",
     # Store factories
     "create_store_from_binding",
     "create_local_store",

--- a/application_sdk/storage/cloud.py
+++ b/application_sdk/storage/cloud.py
@@ -7,6 +7,11 @@ This is distinct from the tenant's own Dapr-configured store (``storage.ops``).
 Use ``CloudStore`` when an app needs to access a customer's cloud bucket
 using credentials they provide (e.g., cloud-sourced spec files, data imports).
 
+Note: File I/O (read_bytes/write_bytes) is synchronous within async methods.
+This is acceptable for typical use cases (spec files, config files) but not
+suitable for multi-GB payloads. For large file streaming, use the underlying
+``store`` property with obstore's streaming APIs directly.
+
 Usage::
 
     from application_sdk.storage.cloud import CloudStore
@@ -43,12 +48,17 @@ from pathlib import Path
 from typing import Any
 
 import obstore as obs
-from obstore.store import ObjectStore
+from obstore.store import AzureStore, GCSStore, ObjectStore, S3Store
 
-from application_sdk.storage.errors import StorageError, StorageNotFoundError
+from application_sdk.storage.errors import (
+    StorageConfigError,
+    StorageError,
+    StorageNotFoundError,
+)
 
-# stdlib logger: cannot use get_logger here due to circular import
-# (observability -> storage -> cloud -> observability)
+# TODO(BLDX-966): Cannot use get_logger due to circular import
+# (observability -> storage -> cloud -> observability). Resolve when
+# observability module decouples from storage.
 logger = logging.getLogger(__name__)
 
 
@@ -91,7 +101,7 @@ class CloudStore:
             Configured CloudStore instance.
 
         Raises:
-            ValueError: If auth type cannot be determined or required
+            StorageConfigError: If auth type cannot be determined or required
                 fields are missing.
         """
         extra = credentials.get("extra") or credentials.get("extras") or {}
@@ -111,12 +121,12 @@ class CloudStore:
         elif auth_type == "adls":
             store = _create_azure_store(credentials, extra)
         else:
-            raise ValueError(
+            raise StorageConfigError(
                 f"Cannot determine cloud provider from credentials. "
                 f"Set 'authType' to 's3', 'gcs', or 'adls'. Got: {auth_type!r}"
             )
 
-        logger.info("Created CloudStore provider=%s", auth_type)
+        logger.debug("Created CloudStore provider=%s", auth_type)
         return cls(store, provider=auth_type)
 
     # ------------------------------------------------------------------
@@ -139,7 +149,11 @@ class CloudStore:
             result = await obs.get_async(self._store, key)
             return bytes(await result.bytes_async())
         except Exception as exc:
-            if "not found" in str(exc).lower() or "404" in str(exc):
+            # Check for obstore's NotFoundError first, then fall back to string matching
+            exc_type = type(exc).__name__
+            if exc_type == "NotFoundError" or (
+                "not found" in str(exc).lower() or "404" in str(exc)
+            ):
                 raise StorageNotFoundError(f"Key not found: {key}", key=key) from exc
             raise
 
@@ -367,12 +381,9 @@ def _infer_auth_type(extra: dict[str, Any]) -> str:
 
 def _create_s3_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectStore:
     """Create an S3 store from credentials."""
-    # Lazy import: only load provider SDK when needed
-    from obstore.store import S3Store
-
     bucket = extra.get("s3_bucket", "")
     if not bucket:
-        raise ValueError("S3 bucket is required (extra.s3_bucket)")
+        raise StorageConfigError("S3 bucket is required (extra.s3_bucket)")
 
     config: dict[str, str] = {}
     region = extra.get("region", "")
@@ -396,12 +407,9 @@ def _create_s3_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectStor
 
 def _create_gcs_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectStore:
     """Create a GCS store from credentials."""
-    # Lazy import: only load provider SDK when needed
-    from obstore.store import GCSStore
-
     bucket = extra.get("gcs_bucket", "")
     if not bucket:
-        raise ValueError("GCS bucket is required (extra.gcs_bucket)")
+        raise StorageConfigError("GCS bucket is required (extra.gcs_bucket)")
 
     gcs_config: dict[str, str] = {}
     sa_json = creds.get("password") or ""
@@ -413,13 +421,10 @@ def _create_gcs_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectSto
 
 def _create_azure_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectStore:
     """Create an Azure (ADLS) store from credentials."""
-    # Lazy import: only load provider SDK when needed
-    from obstore.store import AzureStore
-
     storage_account = extra.get("storage_account_name", "")
     container = extra.get("adls_container", "objectstore")
     if not storage_account:
-        raise ValueError(
+        raise StorageConfigError(
             "Azure storage account is required (extra.storage_account_name)"
         )
 

--- a/application_sdk/storage/cloud.py
+++ b/application_sdk/storage/cloud.py
@@ -269,16 +269,21 @@ class CloudStore:
         normalized_filter = (
             {s.lower() for s in suffix_filter} if suffix_filter else None
         )
-        keys: list[str] = []
-        for batch in obs.list(self._store, prefix=list_prefix or None):
-            for item in batch:
-                obj_path = str(item["path"])
-                if normalized_filter:
-                    ext = Path(obj_path).suffix.lower()
-                    if ext not in normalized_filter:
-                        continue
-                keys.append(obj_path)
-        return sorted(keys)
+        try:
+            keys: list[str] = []
+            for batch in obs.list(self._store, prefix=list_prefix or None):
+                for item in batch:
+                    obj_path = str(item["path"])
+                    if normalized_filter:
+                        ext = Path(obj_path).suffix.lower()
+                        if ext not in normalized_filter:
+                            continue
+                    keys.append(obj_path)
+            return sorted(keys)
+        except Exception as exc:
+            raise StorageError(
+                f"Failed to list keys with prefix: {list_prefix!r}", cause=exc
+            ) from exc
 
     async def _list_keys(
         self, list_prefix: str, suffix_filter: set[str] | None = None
@@ -318,9 +323,12 @@ class CloudStore:
         Returns:
             Number of bytes uploaded.
         """
-        path = Path(local_path)
-        data = path.read_bytes()
-        await obs.put_async(self._store, key, data)
+        try:
+            path = Path(local_path)
+            data = path.read_bytes()
+            await obs.put_async(self._store, key, data)
+        except Exception as exc:
+            raise StorageError(f"Failed to upload key: {key}", cause=exc) from exc
         logger.info("Uploaded key=%s size=%d", key, len(data))
         return len(data)
 
@@ -334,7 +342,10 @@ class CloudStore:
         Returns:
             Number of bytes uploaded.
         """
-        await obs.put_async(self._store, key, data)
+        try:
+            await obs.put_async(self._store, key, data)
+        except Exception as exc:
+            raise StorageError(f"Failed to upload key: {key}", cause=exc) from exc
         return len(data)
 
     async def upload_dir(

--- a/application_sdk/storage/cloud.py
+++ b/application_sdk/storage/cloud.py
@@ -1,0 +1,432 @@
+"""Cloud store for accessing external customer-provided object stores.
+
+Provides a high-level async API for downloading/uploading/listing files
+from external S3, GCS, or Azure buckets using customer-provided credentials.
+
+This is distinct from the tenant's own Dapr-configured store (``storage.ops``).
+Use ``CloudStore`` when an app needs to access a customer's cloud bucket
+using credentials they provide (e.g., cloud-sourced spec files, data imports).
+
+Usage::
+
+    from application_sdk.storage.cloud import CloudStore
+
+    store = CloudStore.from_credentials({
+        "authType": "s3",
+        "username": "AKIAIOSFODNN7EXAMPLE",
+        "password": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "extra": {"s3_bucket": "customer-bucket", "region": "us-east-1"},
+    })
+
+    files = await store.download(prefix="specs/", output_dir="/tmp/specs")
+    await store.upload(local_path="/tmp/result.json", key="output/result.json")
+    keys = await store.list(prefix="data/")
+    data = await store.get_bytes(key="config.json")
+
+Credential format (standard ``csa-connectors-objectstore``)::
+
+    S3:   authType="s3",   username=access_key, password=secret_key,
+          extra={s3_bucket, region, aws_role_arn?}
+    GCS:  authType="gcs",  username=project_id,  password=service_account_json,
+          extra={gcs_bucket}
+    ADLS: authType="adls", username=client_id,   password=client_secret,
+          extra={storage_account_name, adls_container, azure_tenant_id}
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import obstore as obs
+from obstore.store import ObjectStore
+
+# stdlib logger: cannot use get_logger here due to circular import
+# (observability -> storage -> cloud -> observability)
+logger = logging.getLogger(__name__)
+
+
+class CloudStore:
+    """Async client for external customer-provided cloud object stores.
+
+    Create via the :meth:`from_credentials` factory method.
+    """
+
+    def __init__(self, store: ObjectStore, *, provider: str = "unknown") -> None:
+        self._store = store
+        self._provider = provider
+
+    @property
+    def provider(self) -> str:
+        """Cloud provider name (``s3``, ``gcs``, ``adls``)."""
+        return self._provider
+
+    @property
+    def store(self) -> ObjectStore:
+        """Underlying obstore instance (for advanced use)."""
+        return self._store
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_credentials(cls, credentials: dict[str, Any]) -> CloudStore:
+        """Create a CloudStore from a credential dict.
+
+        Supports S3, GCS, and Azure (ADLS) with auto-detection of
+        ``authType`` from credential fields when not explicitly set.
+
+        Args:
+            credentials: Credential dict with ``authType``, ``username``,
+                ``password``, and ``extra`` fields.
+
+        Returns:
+            Configured CloudStore instance.
+
+        Raises:
+            ValueError: If auth type cannot be determined or required
+                fields are missing.
+        """
+        extra = credentials.get("extra") or credentials.get("extras") or {}
+        if isinstance(extra, str):
+            extra = json.loads(extra) if extra else {}
+
+        auth_type = (
+            credentials.get("authType")
+            or credentials.get("auth_type")
+            or _infer_auth_type(extra)
+        )
+
+        if auth_type == "s3":
+            store = _create_s3_store(credentials, extra)
+        elif auth_type == "gcs":
+            store = _create_gcs_store(credentials, extra)
+        elif auth_type == "adls":
+            store = _create_azure_store(credentials, extra)
+        else:
+            raise ValueError(
+                f"Cannot determine cloud provider from credentials. "
+                f"Set 'authType' to 's3', 'gcs', or 'adls'. Got: {auth_type!r}"
+            )
+
+        logger.info("Created CloudStore provider=%s", auth_type)
+        return cls(store, provider=auth_type)
+
+    # ------------------------------------------------------------------
+    # Read operations
+    # ------------------------------------------------------------------
+
+    async def get_bytes(self, key: str) -> bytes:
+        """Download a single object and return its contents as bytes.
+
+        Args:
+            key: Object key to download.
+
+        Returns:
+            Raw bytes of the object.
+
+        Raises:
+            FileNotFoundError: If the key does not exist.
+        """
+        try:
+            result = await obs.get_async(self._store, key)
+            return await result.bytes_async()
+        except Exception as exc:
+            if "not found" in str(exc).lower() or "404" in str(exc):
+                raise FileNotFoundError(f"Key not found: {key}") from exc
+            raise
+
+    async def download(
+        self,
+        key: str = "",
+        output_dir: str | Path = ".",
+        *,
+        prefix: str = "",
+        suffix_filter: set[str] | None = None,
+        max_concurrency: int = 4,
+    ) -> list[Path]:
+        """Download file(s) from the cloud store to a local directory.
+
+        If ``key`` is provided, downloads a single file.
+        If only ``prefix`` is provided, lists and downloads all matching files.
+
+        Args:
+            key: Specific object key to download (single file mode).
+            output_dir: Local directory to write files into.
+            prefix: Object key prefix for listing (multi-file mode).
+            suffix_filter: Only download files with these extensions
+                (e.g. ``{".json", ".yaml"}``). Ignored in single-file mode.
+            max_concurrency: Maximum parallel downloads (default 4).
+
+        Returns:
+            List of local file paths that were downloaded.
+
+        Raises:
+            ValueError: If no files found under the prefix.
+        """
+
+        output = Path(output_dir)
+        output.mkdir(parents=True, exist_ok=True)
+
+        if key:
+            return await self._download_single(key, output)
+
+        return await self._download_prefix(
+            prefix, output, suffix_filter, max_concurrency
+        )
+
+    async def _download_single(self, key: str, output: Path) -> list[Path]:
+        """Download a single file."""
+        local_path = output / Path(key).name
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+
+        data = await self.get_bytes(key)
+        local_path.write_bytes(data)
+        logger.info("Downloaded key=%s size=%d local=%s", key, len(data), local_path)
+        return [local_path]
+
+    async def _download_prefix(
+        self,
+        prefix: str,
+        output: Path,
+        suffix_filter: set[str] | None,
+        max_concurrency: int,
+    ) -> list[Path]:
+        """Download all files under a prefix."""
+
+        list_prefix = f"{prefix.strip('/')}/" if prefix else ""
+        logger.info("Listing objects under prefix=%s", list_prefix)
+
+        keys: list[str] = []
+        for batch in obs.list(self._store, prefix=list_prefix or None):
+            for item in batch:
+                obj_path = str(item["path"])
+                if suffix_filter:
+                    ext = Path(obj_path).suffix.lower()
+                    if ext not in suffix_filter:
+                        continue
+                keys.append(obj_path)
+
+        if not keys:
+            raise ValueError(
+                f"No files found under prefix: {list_prefix!r}"
+                + (f" (filter: {suffix_filter})" if suffix_filter else "")
+            )
+
+        sem = asyncio.Semaphore(max_concurrency)
+        downloaded: list[Path] = []
+
+        async def _dl(obj_key: str) -> None:
+            async with sem:
+                rel = (
+                    obj_key[len(list_prefix) :]
+                    if list_prefix and obj_key.startswith(list_prefix)
+                    else Path(obj_key).name
+                )
+                local_path = output / rel
+                local_path.parent.mkdir(parents=True, exist_ok=True)
+                data = await self.get_bytes(obj_key)
+                local_path.write_bytes(data)
+                downloaded.append(local_path)
+
+        await asyncio.gather(*[_dl(k) for k in keys])
+        logger.info("Downloaded %d files from prefix=%s", len(downloaded), list_prefix)
+        return downloaded
+
+    async def list(self, prefix: str = "", *, suffix: str = "") -> list[str]:
+        """List object keys under a prefix.
+
+        Args:
+            prefix: Key prefix to filter by.
+            suffix: Optional extension filter (e.g. ``".json"``).
+
+        Returns:
+            Sorted list of matching object keys.
+        """
+
+        list_prefix = f"{prefix.strip('/')}/" if prefix else ""
+
+        def _collect() -> list[str]:
+            keys: list[str] = []
+            for batch in obs.list(self._store, prefix=list_prefix or None):
+                for item in batch:
+                    key = str(item["path"])
+                    if not suffix or key.endswith(suffix):
+                        keys.append(key)
+            return sorted(keys)
+
+        return await asyncio.to_thread(_collect)
+
+    # ------------------------------------------------------------------
+    # Write operations
+    # ------------------------------------------------------------------
+
+    async def upload(
+        self,
+        local_path: str | Path,
+        key: str,
+    ) -> int:
+        """Upload a local file to the cloud store.
+
+        Args:
+            local_path: Path to the local file.
+            key: Destination object key.
+
+        Returns:
+            Number of bytes uploaded.
+        """
+        path = Path(local_path)
+        data = path.read_bytes()
+        await obs.put_async(self._store, key, data)
+        logger.info("Uploaded key=%s size=%d", key, len(data))
+        return len(data)
+
+    async def upload_bytes(self, key: str, data: bytes) -> int:
+        """Upload raw bytes to the cloud store.
+
+        Args:
+            key: Destination object key.
+            data: Bytes to upload.
+
+        Returns:
+            Number of bytes uploaded.
+        """
+        await obs.put_async(self._store, key, data)
+        return len(data)
+
+    async def upload_dir(
+        self,
+        local_dir: str | Path,
+        prefix: str = "",
+        *,
+        max_concurrency: int = 4,
+    ) -> list[str]:
+        """Upload all files in a local directory to the cloud store.
+
+        Args:
+            local_dir: Local directory to upload from.
+            prefix: Destination key prefix.
+            max_concurrency: Maximum parallel uploads (default 4).
+
+        Returns:
+            List of uploaded object keys.
+        """
+
+        local = Path(local_dir)
+        files: list[tuple[str, Path]] = []
+        for root, _dirs, filenames in os.walk(local, followlinks=False):
+            for fname in filenames:
+                file_path = Path(root) / fname
+                if file_path.is_symlink():
+                    continue
+                rel = file_path.relative_to(local)
+                key = f"{prefix}/{rel}" if prefix else str(rel)
+                files.append((key, file_path))
+
+        sem = asyncio.Semaphore(max_concurrency)
+        uploaded: list[str] = []
+
+        async def _up(key: str, path: Path) -> None:
+            async with sem:
+                await self.upload(path, key)
+                uploaded.append(key)
+
+        await asyncio.gather(*[_up(k, p) for k, p in files])
+        return uploaded
+
+
+# ---------------------------------------------------------------------------
+# Store creation helpers
+# ---------------------------------------------------------------------------
+
+
+def _infer_auth_type(extra: dict[str, Any]) -> str:
+    """Infer cloud provider from extra fields."""
+    if extra.get("s3_bucket"):
+        return "s3"
+    if extra.get("gcs_bucket"):
+        return "gcs"
+    if extra.get("adls_container") or extra.get("storage_account_name"):
+        return "adls"
+    return ""
+
+
+def _create_s3_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectStore:
+    """Create an S3 store from credentials."""
+    from obstore.store import S3Store
+
+    bucket = extra.get("s3_bucket", "")
+    if not bucket:
+        raise ValueError("S3 bucket is required (extra.s3_bucket)")
+
+    config: dict[str, str] = {}
+    region = extra.get("region", "")
+    if region:
+        config["aws_region"] = region
+
+    access_key = creds.get("username") or ""
+    secret_key = creds.get("password") or ""
+    if access_key and secret_key:
+        config["aws_access_key_id"] = access_key
+        config["aws_secret_access_key"] = secret_key
+
+    role_arn = extra.get("aws_role_arn", "")
+    if role_arn:
+        config["aws_role_arn"] = role_arn
+        config["aws_role_session_name"] = "cloud-store-session"
+        logger.info("S3 role-based auth role_arn=%s", role_arn)
+
+    return S3Store(bucket=bucket, config=config)
+
+
+def _create_gcs_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectStore:
+    """Create a GCS store from credentials."""
+    from obstore.store import GCSStore
+
+    bucket = extra.get("gcs_bucket", "")
+    if not bucket:
+        raise ValueError("GCS bucket is required (extra.gcs_bucket)")
+
+    gcs_config: dict[str, str] = {}
+    sa_json = creds.get("password") or ""
+    if sa_json:
+        gcs_config["google_service_account_key"] = sa_json
+
+    return GCSStore(bucket=bucket, config=gcs_config if gcs_config else None)
+
+
+def _create_azure_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectStore:
+    """Create an Azure (ADLS) store from credentials."""
+    from obstore.store import AzureStore
+
+    storage_account = extra.get("storage_account_name", "")
+    container = extra.get("adls_container", "objectstore")
+    if not storage_account:
+        raise ValueError(
+            "Azure storage account is required (extra.storage_account_name)"
+        )
+
+    az_config: dict[str, str] = {
+        "azure_storage_account_name": storage_account,
+    }
+
+    access_key = creds.get("password") or ""
+    client_id = creds.get("username") or ""
+    tenant_id = extra.get("azure_tenant_id") or ""
+
+    if access_key and not tenant_id:
+        # Account key auth
+        az_config["azure_storage_account_key"] = access_key
+    elif tenant_id and client_id:
+        # Service principal auth
+        az_config["azure_storage_client_id"] = client_id
+        az_config["azure_storage_tenant_id"] = tenant_id
+        if access_key:
+            az_config["azure_storage_client_secret"] = access_key
+
+    return AzureStore(container_name=container, config=az_config)

--- a/application_sdk/storage/cloud.py
+++ b/application_sdk/storage/cloud.py
@@ -45,6 +45,8 @@ from typing import Any
 import obstore as obs
 from obstore.store import ObjectStore
 
+from application_sdk.storage.errors import StorageError, StorageNotFoundError
+
 # stdlib logger: cannot use get_logger here due to circular import
 # (observability -> storage -> cloud -> observability)
 logger = logging.getLogger(__name__)
@@ -131,14 +133,14 @@ class CloudStore:
             Raw bytes of the object.
 
         Raises:
-            FileNotFoundError: If the key does not exist.
+            StorageNotFoundError: If the key does not exist.
         """
         try:
             result = await obs.get_async(self._store, key)
             return bytes(await result.bytes_async())
         except Exception as exc:
             if "not found" in str(exc).lower() or "404" in str(exc):
-                raise FileNotFoundError(f"Key not found: {key}") from exc
+                raise StorageNotFoundError(f"Key not found: {key}", key=key) from exc
             raise
 
     async def download(
@@ -167,9 +169,8 @@ class CloudStore:
             List of local file paths that were downloaded.
 
         Raises:
-            ValueError: If no files found under the prefix.
+            StorageError: If no files found under the prefix.
         """
-
         output = Path(output_dir)
         output.mkdir(parents=True, exist_ok=True)
 
@@ -198,10 +199,45 @@ class CloudStore:
         max_concurrency: int,
     ) -> list[Path]:
         """Download all files under a prefix."""
-
         list_prefix = f"{prefix.strip('/')}/" if prefix else ""
         logger.info("Listing objects under prefix=%s", list_prefix)
 
+        keys = await self._list_keys(list_prefix, suffix_filter)
+
+        if not keys:
+            raise StorageError(
+                f"No files found under prefix: {list_prefix!r}"
+                + (f" (filter: {suffix_filter})" if suffix_filter else "")
+            )
+
+        resolved_output = output.resolve()
+        sem = asyncio.Semaphore(max_concurrency)
+
+        async def _dl(obj_key: str) -> Path:
+            async with sem:
+                rel = (
+                    obj_key[len(list_prefix) :]
+                    if list_prefix and obj_key.startswith(list_prefix)
+                    else Path(obj_key).name
+                )
+                local_path = (output / rel).resolve()
+                # Prevent path traversal from malicious remote keys
+                if not local_path.is_relative_to(resolved_output):
+                    raise StorageError(f"Path traversal detected in key: {obj_key!r}")
+                local_path.parent.mkdir(parents=True, exist_ok=True)
+                data = await self.get_bytes(obj_key)
+                local_path.write_bytes(data)
+                return local_path
+
+        results = await asyncio.gather(*[_dl(k) for k in keys])
+        downloaded = list(results)
+        logger.info("Downloaded %d files from prefix=%s", len(downloaded), list_prefix)
+        return downloaded
+
+    def _list_keys_sync(
+        self, list_prefix: str, suffix_filter: set[str] | None = None
+    ) -> list[str]:
+        """Synchronous key listing helper (run via asyncio.to_thread)."""
         keys: list[str] = []
         for batch in obs.list(self._store, prefix=list_prefix or None):
             for item in batch:
@@ -211,32 +247,13 @@ class CloudStore:
                     if ext not in suffix_filter:
                         continue
                 keys.append(obj_path)
+        return sorted(keys)
 
-        if not keys:
-            raise ValueError(
-                f"No files found under prefix: {list_prefix!r}"
-                + (f" (filter: {suffix_filter})" if suffix_filter else "")
-            )
-
-        sem = asyncio.Semaphore(max_concurrency)
-        downloaded: list[Path] = []
-
-        async def _dl(obj_key: str) -> None:
-            async with sem:
-                rel = (
-                    obj_key[len(list_prefix) :]
-                    if list_prefix and obj_key.startswith(list_prefix)
-                    else Path(obj_key).name
-                )
-                local_path = output / rel
-                local_path.parent.mkdir(parents=True, exist_ok=True)
-                data = await self.get_bytes(obj_key)
-                local_path.write_bytes(data)
-                downloaded.append(local_path)
-
-        await asyncio.gather(*[_dl(k) for k in keys])
-        logger.info("Downloaded %d files from prefix=%s", len(downloaded), list_prefix)
-        return downloaded
+    async def _list_keys(
+        self, list_prefix: str, suffix_filter: set[str] | None = None
+    ) -> list[str]:
+        """Async wrapper for key listing."""
+        return await asyncio.to_thread(self._list_keys_sync, list_prefix, suffix_filter)
 
     async def list(self, prefix: str = "", *, suffix: str = "") -> list[str]:
         """List object keys under a prefix.
@@ -248,19 +265,9 @@ class CloudStore:
         Returns:
             Sorted list of matching object keys.
         """
-
         list_prefix = f"{prefix.strip('/')}/" if prefix else ""
-
-        def _collect() -> list[str]:
-            keys: list[str] = []
-            for batch in obs.list(self._store, prefix=list_prefix or None):
-                for item in batch:
-                    key = str(item["path"])
-                    if not suffix or key.endswith(suffix):
-                        keys.append(key)
-            return sorted(keys)
-
-        return await asyncio.to_thread(_collect)
+        suffix_filter = {suffix} if suffix else None
+        return await self._list_keys(list_prefix, suffix_filter)
 
     # ------------------------------------------------------------------
     # Write operations
@@ -308,6 +315,10 @@ class CloudStore:
     ) -> list[str]:
         """Upload all files in a local directory to the cloud store.
 
+        Note: Unlike ``batch.upload_prefix``, this uploads to an *external*
+        store without SHA-256 hashing or key normalization — those features
+        are specific to the tenant's internal storage layer.
+
         Args:
             local_dir: Local directory to upload from.
             prefix: Destination key prefix.
@@ -316,7 +327,6 @@ class CloudStore:
         Returns:
             List of uploaded object keys.
         """
-
         local = Path(local_dir)
         files: list[tuple[str, Path]] = []
         for root, _dirs, filenames in os.walk(local, followlinks=False):
@@ -329,15 +339,14 @@ class CloudStore:
                 files.append((key, file_path))
 
         sem = asyncio.Semaphore(max_concurrency)
-        uploaded: list[str] = []
 
-        async def _up(key: str, path: Path) -> None:
+        async def _up(key: str, path: Path) -> str:
             async with sem:
                 await self.upload(path, key)
-                uploaded.append(key)
+                return key
 
-        await asyncio.gather(*[_up(k, p) for k, p in files])
-        return uploaded
+        results = await asyncio.gather(*[_up(k, p) for k, p in files])
+        return list(results)
 
 
 # ---------------------------------------------------------------------------
@@ -358,6 +367,7 @@ def _infer_auth_type(extra: dict[str, Any]) -> str:
 
 def _create_s3_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectStore:
     """Create an S3 store from credentials."""
+    # Lazy import: only load provider SDK when needed
     from obstore.store import S3Store
 
     bucket = extra.get("s3_bucket", "")
@@ -386,6 +396,7 @@ def _create_s3_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectStor
 
 def _create_gcs_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectStore:
     """Create a GCS store from credentials."""
+    # Lazy import: only load provider SDK when needed
     from obstore.store import GCSStore
 
     bucket = extra.get("gcs_bucket", "")
@@ -402,6 +413,7 @@ def _create_gcs_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectSto
 
 def _create_azure_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectStore:
     """Create an Azure (ADLS) store from credentials."""
+    # Lazy import: only load provider SDK when needed
     from obstore.store import AzureStore
 
     storage_account = extra.get("storage_account_name", "")

--- a/application_sdk/storage/cloud.py
+++ b/application_sdk/storage/cloud.py
@@ -56,7 +56,7 @@ from application_sdk.storage.errors import (
     StorageNotFoundError,
 )
 
-# TODO(BLDX-966): Cannot use get_logger due to circular import
+# Cannot use get_logger due to circular import
 # (observability -> storage -> cloud -> observability). Resolve when
 # observability module decouples from storage.
 logger = logging.getLogger(__name__)
@@ -104,9 +104,18 @@ class CloudStore:
             StorageConfigError: If auth type cannot be determined or required
                 fields are missing.
         """
-        extra = credentials.get("extra") or credentials.get("extras") or {}
+        extra = credentials.get("extra")
+        if extra is None:
+            extra = credentials.get("extras")
+        if extra is None:
+            extra = {}
         if isinstance(extra, str):
-            extra = json.loads(extra) if extra else {}
+            try:
+                extra = json.loads(extra) if extra else {}
+            except json.JSONDecodeError as exc:
+                raise StorageConfigError(
+                    f"Invalid JSON in 'extra' field: {exc}"
+                ) from exc
 
         auth_type = (
             credentials.get("authType")
@@ -148,14 +157,15 @@ class CloudStore:
         try:
             result = await obs.get_async(self._store, key)
             return bytes(await result.bytes_async())
+        except FileNotFoundError as exc:
+            raise StorageNotFoundError(f"Key not found: {key}", key=key) from exc
         except Exception as exc:
-            # Check for obstore's NotFoundError first, then fall back to string matching
-            exc_type = type(exc).__name__
-            if exc_type == "NotFoundError" or (
-                "not found" in str(exc).lower() or "404" in str(exc)
-            ):
+            # obstore backends raise different exception types for not-found:
+            # - LocalStore: FileNotFoundError (caught above)
+            # - S3/GCS/Azure: obstore.exceptions.NotFoundError
+            if type(exc).__name__ == "NotFoundError":
                 raise StorageNotFoundError(f"Key not found: {key}", key=key) from exc
-            raise
+            raise StorageError(f"Failed to get key: {key}", cause=exc) from exc
 
     async def download(
         self,
@@ -185,6 +195,9 @@ class CloudStore:
         Raises:
             StorageError: If no files found under the prefix.
         """
+        if key and prefix:
+            raise StorageConfigError("Provide either 'key' or 'prefix', not both.")
+
         output = Path(output_dir)
         output.mkdir(parents=True, exist_ok=True)
 
@@ -252,13 +265,17 @@ class CloudStore:
         self, list_prefix: str, suffix_filter: set[str] | None = None
     ) -> list[str]:
         """Synchronous key listing helper (run via asyncio.to_thread)."""
+        # Normalize suffix filter to lowercase for case-insensitive matching
+        normalized_filter = (
+            {s.lower() for s in suffix_filter} if suffix_filter else None
+        )
         keys: list[str] = []
         for batch in obs.list(self._store, prefix=list_prefix or None):
             for item in batch:
                 obj_path = str(item["path"])
-                if suffix_filter:
+                if normalized_filter:
                     ext = Path(obj_path).suffix.lower()
-                    if ext not in suffix_filter:
+                    if ext not in normalized_filter:
                         continue
                 keys.append(obj_path)
         return sorted(keys)
@@ -400,7 +417,7 @@ def _create_s3_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectStor
     if role_arn:
         config["aws_role_arn"] = role_arn
         config["aws_role_session_name"] = "cloud-store-session"
-        logger.info("S3 role-based auth role_arn=%s", role_arn)
+        logger.debug("S3 role-based auth configured")
 
     return S3Store(bucket=bucket, config=config)
 

--- a/application_sdk/storage/cloud.py
+++ b/application_sdk/storage/cloud.py
@@ -135,7 +135,7 @@ class CloudStore:
         """
         try:
             result = await obs.get_async(self._store, key)
-            return await result.bytes_async()
+            return bytes(await result.bytes_async())
         except Exception as exc:
             if "not found" in str(exc).lower() or "404" in str(exc):
                 raise FileNotFoundError(f"Key not found: {key}") from exc

--- a/tests/integration/test_cloud_store.py
+++ b/tests/integration/test_cloud_store.py
@@ -10,6 +10,7 @@ import pytest
 from obstore.store import LocalStore
 
 from application_sdk.storage.cloud import CloudStore
+from application_sdk.storage.errors import StorageError, StorageNotFoundError
 
 
 @pytest.fixture
@@ -42,13 +43,11 @@ class TestCloudStoreIntegration:
         assert data == b"hello world"
 
     async def test_upload_file_and_download(self, cloud_store, tmp_path):
-        # Upload
         src = tmp_path / "upload.json"
         src.write_text('{"uploaded": true}')
         size = await cloud_store.upload(src, "data/upload.json")
         assert size > 0
 
-        # Download single file
         dest = tmp_path / "downloaded"
         files = await cloud_store.download(key="data/upload.json", output_dir=dest)
         assert len(files) == 1
@@ -57,15 +56,12 @@ class TestCloudStoreIntegration:
     async def test_upload_dir_and_download_prefix(
         self, cloud_store, sample_files, tmp_path
     ):
-        # Upload directory
         keys = await cloud_store.upload_dir(sample_files, prefix="import")
         assert len(keys) == 3
 
-        # List
         all_keys = await cloud_store.list(prefix="import")
         assert len(all_keys) == 3
 
-        # Download prefix
         dest = tmp_path / "downloaded"
         files = await cloud_store.download(prefix="import", output_dir=dest)
         assert len(files) == 3
@@ -74,7 +70,7 @@ class TestCloudStoreIntegration:
         await cloud_store.upload_dir(sample_files, prefix="mixed")
 
         json_keys = await cloud_store.list(prefix="mixed", suffix=".json")
-        assert len(json_keys) == 2  # file1.json + subdir/nested.json
+        assert len(json_keys) == 2
         assert all(k.endswith(".json") for k in json_keys)
 
         yaml_keys = await cloud_store.list(prefix="mixed", suffix=".yaml")
@@ -91,17 +87,13 @@ class TestCloudStoreIntegration:
             output_dir=dest,
             suffix_filter={".json"},
         )
-        assert len(files) == 2  # only .json files
+        assert len(files) == 2
 
     async def test_get_bytes_not_found(self, cloud_store):
-        from application_sdk.storage.errors import StorageNotFoundError
-
         with pytest.raises(StorageNotFoundError):
             await cloud_store.get_bytes("nonexistent/key.txt")
 
     async def test_download_empty_prefix_raises(self, cloud_store, tmp_path):
-        from application_sdk.storage.errors import StorageError
-
         with pytest.raises(StorageError):
             await cloud_store.download(
                 prefix="empty-prefix", output_dir=tmp_path / "empty"

--- a/tests/integration/test_cloud_store.py
+++ b/tests/integration/test_cloud_store.py
@@ -1,0 +1,122 @@
+"""Integration tests for CloudStore using a real local object store.
+
+No mocks — exercises the full CloudStore API end-to-end with a local
+filesystem-backed obstore store.
+"""
+
+from __future__ import annotations
+
+import pytest
+from obstore.store import LocalStore
+
+from application_sdk.storage.cloud import CloudStore
+
+
+@pytest.fixture
+def cloud_store(tmp_path):
+    """CloudStore backed by a local directory."""
+    store_root = tmp_path / "cloud-bucket"
+    store_root.mkdir()
+    local_store = LocalStore(prefix=str(store_root))
+    return CloudStore(local_store, provider="local")
+
+
+@pytest.fixture
+def sample_files(tmp_path):
+    """Create sample files for upload tests."""
+    src = tmp_path / "source"
+    src.mkdir()
+    (src / "file1.json").write_text('{"a": 1}')
+    (src / "file2.yaml").write_text("key: value")
+    sub = src / "subdir"
+    sub.mkdir()
+    (sub / "nested.json").write_text('{"nested": true}')
+    return src
+
+
+@pytest.mark.integration
+class TestCloudStoreIntegration:
+    async def test_upload_and_get_bytes(self, cloud_store):
+        await cloud_store.upload_bytes("test/hello.txt", b"hello world")
+        data = await cloud_store.get_bytes("test/hello.txt")
+        assert data == b"hello world"
+
+    async def test_upload_file_and_download(self, cloud_store, tmp_path):
+        # Upload
+        src = tmp_path / "upload.json"
+        src.write_text('{"uploaded": true}')
+        size = await cloud_store.upload(src, "data/upload.json")
+        assert size > 0
+
+        # Download single file
+        dest = tmp_path / "downloaded"
+        files = await cloud_store.download(key="data/upload.json", output_dir=dest)
+        assert len(files) == 1
+        assert files[0].read_text() == '{"uploaded": true}'
+
+    async def test_upload_dir_and_download_prefix(
+        self, cloud_store, sample_files, tmp_path
+    ):
+        # Upload directory
+        keys = await cloud_store.upload_dir(sample_files, prefix="import")
+        assert len(keys) == 3
+
+        # List
+        all_keys = await cloud_store.list(prefix="import")
+        assert len(all_keys) == 3
+
+        # Download prefix
+        dest = tmp_path / "downloaded"
+        files = await cloud_store.download(prefix="import", output_dir=dest)
+        assert len(files) == 3
+
+    async def test_list_with_suffix_filter(self, cloud_store, sample_files):
+        await cloud_store.upload_dir(sample_files, prefix="mixed")
+
+        json_keys = await cloud_store.list(prefix="mixed", suffix=".json")
+        assert len(json_keys) == 2  # file1.json + subdir/nested.json
+        assert all(k.endswith(".json") for k in json_keys)
+
+        yaml_keys = await cloud_store.list(prefix="mixed", suffix=".yaml")
+        assert len(yaml_keys) == 1
+
+    async def test_download_with_suffix_filter(
+        self, cloud_store, sample_files, tmp_path
+    ):
+        await cloud_store.upload_dir(sample_files, prefix="filtered")
+
+        dest = tmp_path / "filtered"
+        files = await cloud_store.download(
+            prefix="filtered",
+            output_dir=dest,
+            suffix_filter={".json"},
+        )
+        assert len(files) == 2  # only .json files
+
+    async def test_get_bytes_not_found(self, cloud_store):
+        with pytest.raises(Exception):
+            await cloud_store.get_bytes("nonexistent/key.txt")
+
+    async def test_download_empty_prefix_raises(self, cloud_store, tmp_path):
+        with pytest.raises(ValueError, match="No files found"):
+            await cloud_store.download(
+                prefix="empty-prefix", output_dir=tmp_path / "empty"
+            )
+
+    async def test_list_empty(self, cloud_store):
+        keys = await cloud_store.list(prefix="nothing-here")
+        assert keys == []
+
+    async def test_upload_bytes_roundtrip(self, cloud_store, tmp_path):
+        content = b'{"roundtrip": true}'
+        await cloud_store.upload_bytes("rt/data.json", content)
+
+        dest = tmp_path / "rt"
+        files = await cloud_store.download(key="rt/data.json", output_dir=dest)
+        assert files[0].read_bytes() == content
+
+    async def test_provider_property(self, cloud_store):
+        assert cloud_store.provider == "local"
+
+    async def test_store_property(self, cloud_store):
+        assert cloud_store.store is not None

--- a/tests/integration/test_cloud_store.py
+++ b/tests/integration/test_cloud_store.py
@@ -94,11 +94,15 @@ class TestCloudStoreIntegration:
         assert len(files) == 2  # only .json files
 
     async def test_get_bytes_not_found(self, cloud_store):
-        with pytest.raises(Exception):
+        from application_sdk.storage.errors import StorageNotFoundError
+
+        with pytest.raises(StorageNotFoundError):
             await cloud_store.get_bytes("nonexistent/key.txt")
 
     async def test_download_empty_prefix_raises(self, cloud_store, tmp_path):
-        with pytest.raises(ValueError, match="No files found"):
+        from application_sdk.storage.errors import StorageError
+
+        with pytest.raises(StorageError):
             await cloud_store.download(
                 prefix="empty-prefix", output_dir=tmp_path / "empty"
             )

--- a/tests/unit/storage/test_cloud.py
+++ b/tests/unit/storage/test_cloud.py
@@ -1,0 +1,176 @@
+"""Unit tests for CloudStore."""
+
+import json
+
+import pytest
+
+from application_sdk.storage.cloud import CloudStore, _infer_auth_type
+
+
+class TestInferAuthType:
+    def test_s3(self):
+        assert _infer_auth_type({"s3_bucket": "my-bucket"}) == "s3"
+
+    def test_gcs(self):
+        assert _infer_auth_type({"gcs_bucket": "my-bucket"}) == "gcs"
+
+    def test_adls_container(self):
+        assert _infer_auth_type({"adls_container": "mycontainer"}) == "adls"
+
+    def test_adls_account(self):
+        assert _infer_auth_type({"storage_account_name": "myaccount"}) == "adls"
+
+    def test_unknown(self):
+        assert _infer_auth_type({}) == ""
+
+
+class TestFromCredentials:
+    def test_s3_explicit_auth_type(self):
+        store = CloudStore.from_credentials(
+            {
+                "authType": "s3",
+                "username": "AKID",
+                "password": "secret",
+                "extra": {"s3_bucket": "test-bucket", "region": "us-east-1"},
+            }
+        )
+        assert store.provider == "s3"
+
+    def test_s3_inferred_auth_type(self):
+        store = CloudStore.from_credentials(
+            {
+                "username": "AKID",
+                "password": "secret",
+                "extra": {"s3_bucket": "test-bucket"},
+            }
+        )
+        assert store.provider == "s3"
+
+    def test_gcs(self):
+        store = CloudStore.from_credentials(
+            {
+                "authType": "gcs",
+                "extra": {"gcs_bucket": "test-bucket"},
+            }
+        )
+        assert store.provider == "gcs"
+
+    def test_adls(self):
+        store = CloudStore.from_credentials(
+            {
+                "authType": "adls",
+                "username": "client-id",
+                "password": "client-secret",
+                "extra": {
+                    "storage_account_name": "myaccount",
+                    "adls_container": "mycontainer",
+                    "azure_tenant_id": "tenant-123",
+                },
+            }
+        )
+        assert store.provider == "adls"
+
+    def test_unknown_raises(self):
+        with pytest.raises(ValueError, match="Cannot determine cloud provider"):
+            CloudStore.from_credentials({"username": "x", "password": "y"})
+
+    def test_s3_missing_bucket_raises(self):
+        with pytest.raises(ValueError, match="S3 bucket is required"):
+            CloudStore.from_credentials(
+                {
+                    "authType": "s3",
+                    "username": "AKID",
+                    "password": "secret",
+                    "extra": {},
+                }
+            )
+
+    def test_gcs_missing_bucket_raises(self):
+        with pytest.raises(ValueError, match="GCS bucket is required"):
+            CloudStore.from_credentials(
+                {
+                    "authType": "gcs",
+                    "extra": {},
+                }
+            )
+
+    def test_adls_missing_account_raises(self):
+        with pytest.raises(ValueError, match="Azure storage account is required"):
+            CloudStore.from_credentials(
+                {
+                    "authType": "adls",
+                    "extra": {},
+                }
+            )
+
+    def test_extra_as_json_string(self):
+        store = CloudStore.from_credentials(
+            {
+                "authType": "s3",
+                "username": "AKID",
+                "password": "secret",
+                "extra": json.dumps({"s3_bucket": "test-bucket"}),
+            }
+        )
+        assert store.provider == "s3"
+
+    def test_extras_key_alias(self):
+        store = CloudStore.from_credentials(
+            {
+                "authType": "s3",
+                "username": "AKID",
+                "password": "secret",
+                "extras": {"s3_bucket": "test-bucket"},
+            }
+        )
+        assert store.provider == "s3"
+
+    def test_auth_type_underscore(self):
+        store = CloudStore.from_credentials(
+            {
+                "auth_type": "s3",
+                "username": "AKID",
+                "password": "secret",
+                "extra": {"s3_bucket": "test-bucket"},
+            }
+        )
+        assert store.provider == "s3"
+
+    def test_s3_role_arn(self):
+        store = CloudStore.from_credentials(
+            {
+                "authType": "s3",
+                "extra": {
+                    "s3_bucket": "test-bucket",
+                    "aws_role_arn": "arn:aws:iam::123:role/MyRole",
+                },
+            }
+        )
+        assert store.provider == "s3"
+
+    def test_adls_account_key_auth(self):
+        import base64
+
+        # Azure requires base64-encoded account keys
+        fake_key = base64.b64encode(b"0" * 32).decode()
+        store = CloudStore.from_credentials(
+            {
+                "authType": "adls",
+                "password": fake_key,
+                "extra": {
+                    "storage_account_name": "myaccount",
+                },
+            }
+        )
+        assert store.provider == "adls"
+
+    def test_store_property(self):
+        store = CloudStore.from_credentials(
+            {
+                "authType": "s3",
+                "username": "AKID",
+                "password": "secret",
+                "extra": {"s3_bucket": "test-bucket"},
+            }
+        )
+        assert store.store is not None

--- a/tests/unit/storage/test_cloud.py
+++ b/tests/unit/storage/test_cloud.py
@@ -232,3 +232,46 @@ class TestCloudStoreOps:
         assert len(files) == 1
         # Verify the downloaded file is inside output dir
         assert files[0].resolve().is_relative_to(out.resolve())
+
+    async def test_upload_dir_roundtrip(self, tmp_path):
+        store = self._make_store(tmp_path)
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "a.txt").write_text("aaa")
+        sub = src / "sub"
+        sub.mkdir()
+        (sub / "b.txt").write_text("bbb")
+        # Create symlink — should be skipped
+        (src / "link.txt").symlink_to(src / "a.txt")
+
+        keys = await store.upload_dir(src, prefix="up")
+        assert len(keys) == 2  # symlink skipped
+        assert any("a.txt" in k for k in keys)
+        assert any("b.txt" in k for k in keys)
+
+    async def test_download_key_and_prefix_mutual_exclusion(self, tmp_path):
+        store = self._make_store(tmp_path)
+        with pytest.raises(StorageConfigError, match="not both"):
+            await store.download(
+                key="file.txt", prefix="dir/", output_dir=tmp_path / "out"
+            )
+
+    async def test_suffix_filter_case_insensitive(self, tmp_path):
+        """Suffix filter matches regardless of case (.JSON matches .json filter)."""
+        store = self._make_store(tmp_path)
+        await store.upload_bytes("data/upper.JSON", b"upper")
+        await store.upload_bytes("data/lower.json", b"lower")
+        await store.upload_bytes("data/skip.txt", b"skip")
+
+        keys = await store.list(prefix="data", suffix=".json")
+        assert len(keys) == 2  # both .JSON and .json matched
+        assert all(".json" in k.lower() for k in keys)
+
+    async def test_invalid_extra_json_raises(self, tmp_path):
+        with pytest.raises(StorageConfigError, match="Invalid JSON"):
+            CloudStore.from_credentials(
+                {
+                    "authType": "s3",
+                    "extra": "not-valid-json{{{",
+                }
+            )

--- a/tests/unit/storage/test_cloud.py
+++ b/tests/unit/storage/test_cloud.py
@@ -275,3 +275,8 @@ class TestCloudStoreOps:
                     "extra": "not-valid-json{{{",
                 }
             )
+
+    async def test_upload_nonexistent_file_raises(self, tmp_path):
+        store = self._make_store(tmp_path)
+        with pytest.raises(StorageError):
+            await store.upload(tmp_path / "does-not-exist.txt", "key.txt")

--- a/tests/unit/storage/test_cloud.py
+++ b/tests/unit/storage/test_cloud.py
@@ -1,10 +1,18 @@
 """Unit tests for CloudStore."""
 
+import base64
 import json
+from pathlib import Path
 
 import pytest
+from obstore.store import LocalStore
 
 from application_sdk.storage.cloud import CloudStore, _infer_auth_type
+from application_sdk.storage.errors import (
+    StorageConfigError,
+    StorageError,
+    StorageNotFoundError,
+)
 
 
 class TestInferAuthType:
@@ -71,11 +79,11 @@ class TestFromCredentials:
         assert store.provider == "adls"
 
     def test_unknown_raises(self):
-        with pytest.raises(ValueError, match="Cannot determine cloud provider"):
+        with pytest.raises(StorageConfigError, match="Cannot determine cloud provider"):
             CloudStore.from_credentials({"username": "x", "password": "y"})
 
     def test_s3_missing_bucket_raises(self):
-        with pytest.raises(ValueError, match="S3 bucket is required"):
+        with pytest.raises(StorageConfigError, match="S3 bucket is required"):
             CloudStore.from_credentials(
                 {
                     "authType": "s3",
@@ -86,7 +94,7 @@ class TestFromCredentials:
             )
 
     def test_gcs_missing_bucket_raises(self):
-        with pytest.raises(ValueError, match="GCS bucket is required"):
+        with pytest.raises(StorageConfigError, match="GCS bucket is required"):
             CloudStore.from_credentials(
                 {
                     "authType": "gcs",
@@ -95,7 +103,9 @@ class TestFromCredentials:
             )
 
     def test_adls_missing_account_raises(self):
-        with pytest.raises(ValueError, match="Azure storage account is required"):
+        with pytest.raises(
+            StorageConfigError, match="Azure storage account is required"
+        ):
             CloudStore.from_credentials(
                 {
                     "authType": "adls",
@@ -149,17 +159,13 @@ class TestFromCredentials:
         assert store.provider == "s3"
 
     def test_adls_account_key_auth(self):
-        import base64
-
         # Azure requires base64-encoded account keys
         fake_key = base64.b64encode(b"0" * 32).decode()
         store = CloudStore.from_credentials(
             {
                 "authType": "adls",
                 "password": fake_key,
-                "extra": {
-                    "storage_account_name": "myaccount",
-                },
+                "extra": {"storage_account_name": "myaccount"},
             }
         )
         assert store.provider == "adls"
@@ -174,3 +180,55 @@ class TestFromCredentials:
             }
         )
         assert store.store is not None
+
+
+# ---------------------------------------------------------------------------
+# Async operation tests (with real local store)
+# ---------------------------------------------------------------------------
+
+
+class TestCloudStoreOps:
+    """Unit tests for async operations using a local store."""
+
+    def _make_store(self, tmp_path: Path) -> CloudStore:
+        store_root = tmp_path / "bucket"
+        store_root.mkdir()
+        return CloudStore(LocalStore(prefix=str(store_root)), provider="local")
+
+    async def test_get_bytes_not_found(self, tmp_path):
+        store = self._make_store(tmp_path)
+        with pytest.raises(StorageNotFoundError):
+            await store.get_bytes("nonexistent.txt")
+
+    async def test_upload_and_get_bytes_roundtrip(self, tmp_path):
+        store = self._make_store(tmp_path)
+        await store.upload_bytes("test.txt", b"hello")
+        data = await store.get_bytes("test.txt")
+        assert data == b"hello"
+
+    async def test_list_empty_prefix(self, tmp_path):
+        store = self._make_store(tmp_path)
+        keys = await store.list(prefix="nothing")
+        assert keys == []
+
+    async def test_download_empty_prefix_raises(self, tmp_path):
+        store = self._make_store(tmp_path)
+        with pytest.raises(StorageError, match="No files found"):
+            await store.download(prefix="empty", output_dir=tmp_path / "out")
+
+    async def test_path_traversal_guard_exists(self, tmp_path):
+        """Verify the path traversal guard is in the download code path.
+
+        obstore itself rejects '../' in keys at the protocol level, so
+        we verify the SDK guard exists as defense-in-depth by checking
+        that resolved paths are validated against the output directory.
+        """
+        store = self._make_store(tmp_path)
+        await store.upload_bytes("safe/file.txt", b"ok")
+
+        # Normal download works
+        out = tmp_path / "out"
+        files = await store.download(prefix="safe", output_dir=out)
+        assert len(files) == 1
+        # Verify the downloaded file is inside output dir
+        assert files[0].resolve().is_relative_to(out.resolve())


### PR DESCRIPTION
## Summary

Adds `CloudStore` — a class-based async API for accessing external customer-provided S3/GCS/Azure buckets using their credentials. Replaces per-app implementations (e.g. atlan-openapi-app cloud_storage.py) with a reusable SDK abstraction.

**Motivation** (from Christopher's review on KAA-506):
> We should really provide an abstracted way of doing this directly in the framework itself, rather than needing to implement this level of abstraction in each app.

Multiple apps already build their own obstore factory code: OpenAPI, Fivetran, Databricks, Snowflake, Looker.

## What's different from existing storage APIs

| | Existing (storage.ops / App.upload) | New (CloudStore) |
|---|---|---|
| **Target** | Tenant's own Dapr-configured store | External customer-provided bucket |
| **Auth** | Dapr binding YAML (auto-configured) | Customer credentials (username/password/extra) |
| **Use case** | Workflow artifacts, transformed data | Cloud-sourced imports (spec files, data files) |
| **Setup** | Automatic via InfrastructureContext | Explicit CloudStore.from_credentials(creds) |

## API

```python
from application_sdk.storage.cloud import CloudStore

store = CloudStore.from_credentials({
    "authType": "s3",
    "username": "AKIAIOSFODNN7EXAMPLE",
    "password": "wJalrXUtnFEMI/bPxRfiCYEXAMPLEKEY",
    "extra": {"s3_bucket": "customer-bucket", "region": "us-east-1"},
})

# Read
files = await store.download(prefix="specs/", output_dir="/tmp/specs")
files = await store.download(key="config.json", output_dir="/tmp")
data  = await store.get_bytes("metadata.json")
keys  = await store.list(prefix="data/", suffix=".parquet")

# Write
await store.upload(local_path="/tmp/result.json", key="output/result.json")
await store.upload_bytes("config.json", b'{"key": "value"}')
keys  = await store.upload_dir("/tmp/output", prefix="results")

# Properties
store.provider   # "s3", "gcs", "adls"
store.store      # underlying obstore instance
```

## Supported providers

| Provider | Auth Type | Credential Fields |
|----------|-----------|-------------------|
| S3 | s3 | username=access_key, password=secret_key, extra.s3_bucket, extra.region, extra.aws_role_arn (optional) |
| GCS | gcs | password=service_account_json, extra.gcs_bucket |
| Azure ADLS | adls | username=client_id, password=client_secret, extra.storage_account_name, extra.adls_container, extra.azure_tenant_id |

Auto-detection: if authType is not set, inferred from extra fields.

## Changed Files

| File | Change |
|------|--------|
| storage/cloud.py | NEW — CloudStore class (350 lines) |
| storage/__init__.py | Export CloudStore |
| tests/unit/storage/test_cloud.py | NEW — 19 unit tests |
| tests/integration/test_cloud_store.py | NEW — 11 integration tests |

## Migration for existing apps

```python
# Before (per-app)
from app.cloud_storage import _create_store, _download_from_external_store
store = _create_store(credentials)
files = await _download_from_external_store(store, prefix, key, output_dir)

# After (SDK CloudStore)
from application_sdk.storage.cloud import CloudStore
store = CloudStore.from_credentials(credentials)
files = await store.download(prefix=prefix, output_dir=output_dir)
```

## Test plan

- [x] 19 unit tests (auth type inference, all 3 providers, error cases, credential variants)
- [x] 11 integration tests (real local obstore, upload/download roundtrips, prefix listing)
- [x] Pre-commit checks passing

Linear: [BLDX-966](https://linear.app/atlan-epd/issue/BLDX-966)