### PR TITLE
fix: allowlist CVE-2024-35515 (sqlitedict 2.1.0 — no fix available)

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Updated by SDK team. CODEOWNERS: SDK/security team only.",
   "_base_image": "application-sdk-main",
-  "_updated": "2026-04-15",
+  "_updated": "2026-04-16",
   "_renewal_note": "Expiry dates staggered by severity. CRITICAL: 60 days. HIGH: 90 days. Review before expiry.",
   "SNYK-GOLANG-GOOGLEGOLANGORGGRPC-15691172": {
     "package": "google.golang.org/grpc",
@@ -128,5 +128,12 @@
     "reason": "Base image \u2014 OpenTelemetry Go dependency",
     "expires": "2026-07-15",
     "added_by": "mananjain99"
+  },
+  "CVE-2024-35515": {
+    "package": "sqlitedict==2.1.0",
+    "severity": "HIGH",
+    "reason": "No patched version of sqlitedict available — upstream has not released a fix as of 2026-04-16",
+    "expires": "2026-07-16",
+    "added_by": "TechyMT"
   }
 }


### PR DESCRIPTION
## Summary

Adds `CVE-2024-35515` (`sqlitedict==2.1.0`) to the base allowlist.

No patched version of `sqlitedict` has been released upstream. This unblocks the security gate on [`atlan-publish-app#526`](https://github.com/atlanhq/atlan-publish-app/pull/526) and any other app using `sqlitedict`.

- **Severity:** HIGH
- **Expiry:** 2026-07-16 (90 days)
- **Action on expiry:** Check if upstream has released a fix; upgrade or re-allowlist

## Test plan

- [ ] Security gate passes on atlan-publish-app after this merges and SDK version is bumped

🤖 Generated with [Claude Code](https://claude.ai/claude-code)