### PR TITLE
fix(sdk-review): fix gh api per_page param for adversarial step

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -921,7 +921,7 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
-          CLAUDE_REVIEW=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --per-page 100 \
+          CLAUDE_REVIEW=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
             | jq -r '[.[] | select(.body | contains("SDK_REVIEW_V2"))
               | select(.body | contains("SDK_REVIEW_V2_ADVERSARIAL") | not)
               | select(.body | contains("SDK_REVIEW_V2_RECONCILED") | not)] | last | .body // ""')


### PR DESCRIPTION
gh api uses URL query `?per_page=100`, not `--per-page 100` flag. The invalid flag silently broke the adversarial step.