### PR TITLE
fix(worker): force worker mode onto main thread

### DIFF
--- a/application_sdk/worker.py
+++ b/application_sdk/worker.py
@@ -17,11 +17,13 @@ from temporalio.worker import Worker as TemporalWorker
 
 from application_sdk.clients.workflow import WorkflowClient
 from application_sdk.constants import (
+    APPLICATION_MODE,
     DEPLOYMENT_NAME,
     GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS,
     MAX_CONCURRENT_ACTIVITIES,
     TEMPORAL_BUILD_ID,
     TEMPORAL_DEPLOYMENT_NAME,
+    ApplicationMode,
 )
 from application_sdk.interceptors.models import (
     ApplicationEventNames,
@@ -252,6 +254,13 @@ class Worker:
             2. In-flight activities complete within graceful_shutdown_timeout
             3. Worker exits early if activities finish, or at timeout
         """
+        if daemon and APPLICATION_MODE == ApplicationMode.WORKER:
+            logger.warning(
+                "APPLICATION_MODE=WORKER requested daemon worker startup; "
+                "forcing daemon=False so the worker owns the main thread."
+            )
+            daemon = False
+
         if daemon:
 
             def _run_daemon() -> None:

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from application_sdk.clients.workflow import WorkflowClient
+from application_sdk.constants import ApplicationMode
 from application_sdk.worker import Worker
 
 
@@ -82,6 +83,24 @@ async def test_worker_start_with_daemon_true(mock_workflow_client: WorkflowClien
     # On some platforms, the daemon thread might not have started yet
     # So we check if it was called at least once (allowing for timing differences)
     assert mock_workflow_client.create_worker.call_count >= 0  # type: ignore
+
+
+@patch("application_sdk.worker.APPLICATION_MODE", ApplicationMode.WORKER)
+async def test_worker_mode_forces_non_daemon_start(
+    mock_workflow_client: WorkflowClient,
+):
+    """APPLICATION_MODE=WORKER should keep the worker on the main thread."""
+    worker = Worker(
+        workflow_client=mock_workflow_client,
+        workflow_activities=[AsyncMock()],
+        workflow_classes=[AsyncMock()],
+    )
+
+    with patch("application_sdk.worker.threading.Thread") as mock_thread:
+        await worker.start(daemon=True)
+
+    mock_thread.assert_not_called()
+    assert mock_workflow_client.create_worker.call_count == 1  # type: ignore
 
 
 async def test_worker_start_with_daemon_false(mock_workflow_client: WorkflowClient):


### PR DESCRIPTION
## Summary
This hardens the v2 SDK worker startup path for apps that still use the older manual `setup_workflow() -> start_worker() -> setup_server()` entrypoint pattern.

When `APPLICATION_MODE=WORKER`, the SDK now forces `Worker.start()` to run with `daemon=False` even if the caller passed `daemon=True`.

## Why
We hit a production outage on `cbrands-pov` after `atlan-fabric-app` upgraded to SDK `2.8.x` and continued using a custom `main.py` that always called `start_worker()` and then server startup. On worker pods, `ATLAN_APP_HTTP_PORT=-1` caused the process to fall through into server startup and crash before the pod could stay healthy.

The immediate outage was app-side, but v2 makes this class of bug too easy:
- apps can still manually orchestrate worker + server startup
- the older manual startup pattern remains widely usable
- custom app startup does not always compose cleanly with the official `BaseApplication.start()` mode path

This PR adds an SDK-side safety net for v2 without changing the behavior of apps that already use `BaseApplication.start()` correctly.

## Behavior change
- `APPLICATION_MODE=WORKER` + `Worker.start(daemon=True)` now logs a warning and behaves as `daemon=False`
- `LOCAL` behavior is unchanged
- apps already following the correct mode-based path are unchanged

This means worker pods keep the worker on the main thread and do not fall through into later server startup code in older/manual entrypoints like Fabric's.

## Scope
This is a v2 hardening fix only.

`refactor-v3` already handles startup correctly via the unified `application_sdk.main` entrypoint with explicit `worker` / `handler` / `combined` modes, so this failure mode should not exist there.

## Validation
- `uv run pytest tests/unit/test_worker.py -q`
- `uv run pytest tests/unit/application/test_application.py -q`
- `uv run pre-commit run --files application_sdk/worker.py tests/unit/test_worker.py`

## Tests added
- verifies `APPLICATION_MODE=WORKER` prevents daemon thread startup even if the caller requested `daemon=True`
- preserves existing worker startup behavior for other modes

## Follow-up
Apps on v2 should consume the patched SDK release rather than carrying app-local `APP_PORT == -1` / `asyncio.Event().wait()` workarounds.