### PR TITLE
fix(sdk-review): use string params for workflow_dispatch inputs (port)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1173,10 +1173,10 @@ jobs:
           if gh api "repos/${REPO}/actions/workflows/claude.yml/dispatches" \
                -X POST \
                -f ref="${DEFAULT_BRANCH}" \
-               -F "inputs[pr_number]=${PR_NUMBER}" \
-               -F "inputs[iteration]=${NEXT}" \
-               -F "inputs[max_iter]=${MAX}" \
-               -F "inputs[trigger_reason]=auto-complete iteration ${NEXT}/${MAX}"; then
+               -f "inputs[pr_number]=${PR_NUMBER}" \
+               -f "inputs[iteration]=${NEXT}" \
+               -f "inputs[max_iter]=${MAX}" \
+               -f "inputs[trigger_reason]=auto-complete iteration ${NEXT}/${MAX}"; then
             # Post a short informational comment on the PR (not a
             # trigger — just user-facing visibility).
             gh pr comment "$PR_NUMBER" --body \
@@ -1451,10 +1451,10 @@ jobs:
           if gh api "repos/${REPO}/actions/workflows/claude.yml/dispatches" \
                -X POST \
                -f ref="${DEFAULT_BRANCH}" \
-               -F "inputs[pr_number]=${PR_NUMBER}" \
-               -F "inputs[iteration]=${NEXT}" \
-               -F "inputs[max_iter]=${MAX}" \
-               -F "inputs[trigger_reason]=CI remediation iteration ${NEXT}/${MAX}"; then
+               -f "inputs[pr_number]=${PR_NUMBER}" \
+               -f "inputs[iteration]=${NEXT}" \
+               -f "inputs[max_iter]=${MAX}" \
+               -f "inputs[trigger_reason]=CI remediation iteration ${NEXT}/${MAX}"; then
             gh pr comment "$PR_NUMBER" --body \
               "🔁 **CI fix pushed — re-review iteration ${NEXT}/${MAX} dispatched.** [Watch live progress](${{ github.server_url }}/${{ github.repository }}/actions/workflows/claude.yml)"
           else


### PR DESCRIPTION
## Summary
- Port of #1399 to refactor-v3
- `gh api -F` sends numeric values as JSON integers, but workflow_dispatch inputs with `type: string` reject non-string values with HTTP 422
- Changes `-F` to `-f` for all `inputs[*]` fields in both retrigger locations

## Test plan
- [ ] Verified on main via #1399 first

🤖 Generated with [Claude Code](https://claude.com/claude-code)