### PR TITLE
fix(ci): pin Dapr/Temporal install scripts and Snyk reusable workflow [BLDX-1026]

### DIFF
--- a/.github/workflows/scale-tests.yaml
+++ b/.github/workflows/scale-tests.yaml
@@ -47,13 +47,13 @@ jobs:
       # Install Dapr
       - name: Install Dapr CLI
         run: |
-          wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s 1.17.1
+          wget -q https://raw.githubusercontent.com/dapr/cli/refs/tags/v1.17.1/install/install.sh -O - | /bin/bash -s 1.17.1
           dapr init --runtime-version 1.17.3 --slim
 
       # Install Temporal
       - name: Install Temporal CLI and Start Server
         run: |
-          curl -sSf https://temporal.download/cli.sh | sh
+          curl -sSf https://temporal.download/cli.sh | sh -s -- --version v1.3.0
           export PATH="$HOME/.temporalio/bin:$PATH"
           temporal server start-dev --ip 0.0.0.0 --db-filename /tmp/temporal.db &
           sleep 10  # Give some time for Temporal to start

--- a/.github/workflows/scale-tests.yaml
+++ b/.github/workflows/scale-tests.yaml
@@ -46,15 +46,21 @@ jobs:
 
       # Install Dapr
       - name: Install Dapr CLI
-        run: |
-          wget -q https://raw.githubusercontent.com/dapr/cli/refs/tags/v1.17.1/install/install.sh -O - | /bin/bash -s 1.17.1
-          dapr init --runtime-version 1.17.3 --slim
+        uses: dapr/setup-dapr@8d980918fd43a2765c143ce7f687665b2d46a6b9 # v2
+        with:
+          version: "1.17.1"
+
+      - name: Initialize Dapr
+        run: dapr init --runtime-version 1.17.3 --slim
 
       # Install Temporal
-      - name: Install Temporal CLI and Start Server
+      - name: Install Temporal CLI
+        uses: temporalio/setup-temporal@6d04211d9dfbd5cb2493a4a6637b2ad784a60ccc # v0
+        with:
+          version: "v1.3.0"
+
+      - name: Start Temporal dev server
         run: |
-          curl -sSf https://temporal.download/cli.sh | sh -s -- --version v1.3.0
-          export PATH="$HOME/.temporalio/bin:$PATH"
           temporal server start-dev --ip 0.0.0.0 --db-filename /tmp/temporal.db &
           sleep 10  # Give some time for Temporal to start
 

--- a/.github/workflows/verify-snyk-status.yml
+++ b/.github/workflows/verify-snyk-status.yml
@@ -12,6 +12,6 @@ jobs:
     # This 'name' is what appears in the pull request's check list.
     name: Snyk Scan Results
     # Calls the reusable workflow from your central .github repository.
-    uses: atlanhq/.github/.github/workflows/reusable-verify-snyk-scans.yml@main
+    uses: atlanhq/.github/.github/workflows/reusable-verify-snyk-scans.yml@679a881895053cd1083eeb1fc847fc0887084fab # pin to SHA instead of @main
     # Allows the reusable workflow to use the GITHUB_TOKEN from this repository.
     secrets: inherit


### PR DESCRIPTION
## What was found

**Rules:** supply-chain, dependency-security
**Files:** `.github/workflows/scale-tests.yaml`, `.github/workflows/verify-snyk-status.yml`
**Severity:** High (confidence 95%)

1. Dapr CLI installed via `wget | bash` from mutable ref — supply chain risk
2. Temporal CLI installed via `curl | sh` without version pin (unlike pull_request.yaml which pins v1.3.0)
3. Snyk reusable workflow pinned to `@main` with `secrets: inherit` — any push to .github repo main could access all inherited secrets

## What was fixed

- **Dapr**: Replaced `wget | bash` install script with official `dapr/setup-dapr` action, SHA-pinned (`@8d980918`, v2), version `1.17.1`
- **Temporal**: Replaced `curl | sh` install script with official `temporalio/setup-temporal` action, SHA-pinned (`@6d04211d`, v0), version `v1.3.0`
- **Snyk**: Pinned reusable workflow to SHA `679a881` instead of `@main`

## Validation

- [x] Pre-commit passes
- [x] No code changes — CI-only

## Linear

https://linear.app/atlan-epd/issue/BLDX-1026