### PR TITLE
fix(ci): pin all actions in build-apps-image to full semver [BLDX-1028]

### DIFF
--- a/.github/workflows/build-apps-image.yaml
+++ b/.github/workflows/build-apps-image.yaml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.ref }}
 
@@ -179,22 +179,22 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.0.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.ORG_PAT_GITHUB }}
 
       - name: Build and push arch image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7.1.0
         with:
           context: .
           file: ${{ needs.prepare.outputs.dockerfile }}
@@ -222,10 +222,10 @@ jobs:
 
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.0.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -233,7 +233,7 @@ jobs:
 
       - name: Log in to Docker Hub
         if: needs.prepare.outputs.enable_sdr == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.1.0
         with:
           registry: docker.io
           username: atlanhq
@@ -297,7 +297,7 @@ jobs:
 
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -333,7 +333,7 @@ jobs:
       - name: Upload Trivy SARIF to GitHub Security
         if: always() && hashFiles('trivy-results.sarif') != ''
         continue-on-error: true  # codeql telemetry endpoint is not accessible in reusable workflow context
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v3.28.19
         with:
           sarif_file: trivy-results.sarif
           category: trivy-container


### PR DESCRIPTION
## What was found

**Rule:** dependency-security (pin supply chain)
**File:** `.github/workflows/build-apps-image.yaml`
**Severity:** High (confidence 90%)

Floating major tags (@v4, @v3, @v5) on actions that receive ORG_PAT_GITHUB and DOCKER_HUB_PAT_RW secrets.

## What was fixed

Pinned all actions to full semver:
- `actions/checkout`: v4 → v6.0.2
- `docker/setup-buildx-action`: v3 → v4.0.0
- `docker/login-action`: v3 → v4.1.0
- `docker/build-push-action`: v5 → v7.1.0
- `github/codeql-action/upload-sarif`: v3 → v3.28.19

## Linear

https://linear.app/atlan-epd/issue/BLDX-1028