### PR TITLE
fix(sdk-review): add 8-min timeout to adversarial review step

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -866,6 +866,7 @@ jobs:
           steps.pr.outputs.mode != 'override' &&
           steps.pr.outputs.mode != 'challenge' &&
           steps.pr.outputs.complexity != 'tests-only'
+        timeout-minutes: 8
         continue-on-error: true
         env:
           LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}


### PR DESCRIPTION
## Summary
- Large PRs cause the Codex adversarial `curl` to hang ~10 min waiting for a response
- With `continue-on-error: true` already set, adding `timeout-minutes: 8` lets the pipeline proceed without the adversarial review on slow requests
- Root cause of exit code 143 on PR #1288 (2633 additions, 16 files)

## Test plan
- [ ] Re-trigger `@sdk-review` on a large PR — adversarial should timeout gracefully and pipeline continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)