### PR TITLE
perf: parallelize sequential I/O loops across storage/credentials/templates [BLDX-1032]

### DIFF
--- a/application_sdk/infrastructure/_dapr/credential_vault.py
+++ b/application_sdk/infrastructure/_dapr/credential_vault.py
@@ -231,30 +231,47 @@ class DaprCredentialVault:
         self, credential_config: dict[str, Any]
     ) -> dict[str, Any]:
         """Fetch secrets in single-key mode — one lookup per string field value."""
+        import asyncio
+
         logger.debug("Single-key mode: fetching secrets per field")
         collected: dict[str, Any] = {}
         failed_lookups: list[str] = []
 
-        async def _try_fetch(label: str, value: str) -> None:
+        async def _try_fetch(
+            label: str, value: str
+        ) -> tuple[str, dict[str, Any] | None, str | None]:
             if not value.strip():
-                return
+                return label, None, None
             try:
                 single_secret = await self._get_secret(value)
-                if single_secret:
-                    for k, v in single_secret.items():
-                        if v is None or v == "":
-                            continue
-                        collected[k] = v
+                return label, single_secret, None
             except Exception as e:
-                failed_lookups.append("  '%s' → '%s': %s" % (label, value, e))
+                return label, None, "  '%s' → '%s': %s" % (label, value, e)
 
+        # Collect all tasks for parallel execution
+        tasks: list = []
         for field, value in credential_config.items():
             if isinstance(value, str):
-                await _try_fetch(field, value)
+                tasks.append(_try_fetch(field, value))
             elif field == "extra" and isinstance(value, dict):
                 for extra_key, extra_value in value.items():
                     if isinstance(extra_value, str):
-                        await _try_fetch(f"extra.{extra_key}", extra_value)
+                        tasks.append(_try_fetch(f"extra.{extra_key}", extra_value))
+
+        # Run all secret fetches in parallel
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        for result in results:
+            if isinstance(result, Exception):
+                continue
+            label, single_secret, error_msg = result
+            if error_msg is not None:
+                failed_lookups.append(error_msg)
+            elif single_secret:
+                for k, v in single_secret.items():
+                    if v is None or v == "":
+                        continue
+                    collected[k] = v
 
         if not collected and failed_lookups:
             logger.error(

--- a/application_sdk/storage/batch.py
+++ b/application_sdk/storage/batch.py
@@ -131,6 +131,13 @@ async def delete_prefix(
             return await delete(k, resolved, normalize=False)
 
     results = await asyncio.gather(*[_del(k) for k in keys], return_exceptions=True)
+    errors = [r for r in results if isinstance(r, Exception)]
+    if errors:
+        from application_sdk.storage.errors import StorageError
+
+        raise StorageError(
+            f"{len(errors)} delete(s) failed under prefix '{prefix}'"
+        ) from errors[0]
     return sum(1 for r in results if r is True)
 
 

--- a/application_sdk/storage/batch.py
+++ b/application_sdk/storage/batch.py
@@ -18,6 +18,7 @@ both follow this — the data source is always the first positional argument.
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -31,6 +32,8 @@ from application_sdk.storage.ops import (
     normalize_key,
     upload_file,
 )
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from obstore.store import ObjectStore
@@ -131,14 +134,21 @@ async def delete_prefix(
             return await delete(k, resolved, normalize=False)
 
     results = await asyncio.gather(*[_del(k) for k in keys], return_exceptions=True)
-    errors = [r for r in results if isinstance(r, Exception)]
+    deleted = 0
+    errors = []
+    for i, r in enumerate(results):
+        if isinstance(r, Exception):
+            errors.append((keys[i], r))
+        elif r is True:
+            deleted += 1
     if errors:
         from application_sdk.storage.errors import StorageError
 
+        logger.warning("delete_prefix: %d/%d deletes failed", len(errors), len(keys))
         raise StorageError(
             f"{len(errors)} delete(s) failed under prefix '{prefix}'"
-        ) from errors[0]
-    return sum(1 for r in results if r is True)
+        ) from errors[0][1]
+    return deleted
 
 
 async def download_prefix(

--- a/application_sdk/storage/batch.py
+++ b/application_sdk/storage/batch.py
@@ -119,13 +119,19 @@ async def delete_prefix(
         StorageError: If the listing or any deletion fails.
         RuntimeError: If *store* is ``None`` and no infrastructure store is set.
     """
+    import asyncio
+
     resolved = _resolve_store(store)
     keys = await list_keys(prefix, resolved, normalize=normalize)
-    count = 0
-    for key in keys:
-        if await delete(key, resolved, normalize=False):
-            count += 1
-    return count
+
+    sem = asyncio.Semaphore(20)
+
+    async def _del(k: str) -> bool:
+        async with sem:
+            return await delete(k, resolved, normalize=False)
+
+    results = await asyncio.gather(*[_del(k) for k in keys], return_exceptions=True)
+    return sum(1 for r in results if r is True)
 
 
 async def download_prefix(

--- a/application_sdk/storage/transfer.py
+++ b/application_sdk/storage/transfer.py
@@ -18,12 +18,15 @@ identically for single files and directories.
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from application_sdk.contracts.types import FileReference, StorageTier
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from obstore.store import ObjectStore
@@ -270,9 +273,24 @@ async def upload(
             upload_tasks.append(_upload_bounded(file_path, key))
 
         results = await asyncio.gather(*upload_tasks, return_exceptions=True)
-        for r in results:
-            if r is True:
+        errors = []
+        for i, r in enumerate(results):
+            if isinstance(r, Exception):
+                errors.append((str(files[i]), r))
+            elif r is True:
                 transferred_count += 1
+        if errors:
+            from application_sdk.storage.errors import StorageError
+
+            logger.warning(
+                "upload: %d/%d uploads failed under %s",
+                len(errors),
+                len(files),
+                prefix,
+            )
+            raise StorageError(
+                f"{len(errors)} upload(s) failed under prefix '{prefix}'"
+            ) from errors[0][1]
 
         store_prefix = (prefix.rstrip("/") + "/") if prefix else ""
         reason = "uploaded" if transferred_count > 0 else "skipped:hash_match"
@@ -381,6 +399,7 @@ async def download(
                 )
                 return ok
 
+        transferred_count = 0
         download_tasks = []
         for key in data_keys:
             rel = key[len(strip) :] if key.startswith(strip) else key
@@ -388,7 +407,24 @@ async def download(
             download_tasks.append(_download_bounded(key, local_file))
 
         results = await asyncio.gather(*download_tasks, return_exceptions=True)
-        transferred_count = sum(1 for r in results if r is True)
+        errors = []
+        for i, r in enumerate(results):
+            if isinstance(r, Exception):
+                errors.append((data_keys[i], r))
+            elif r is True:
+                transferred_count += 1
+        if errors:
+            from application_sdk.storage.errors import StorageError
+
+            logger.warning(
+                "download: %d/%d downloads failed under %s",
+                len(errors),
+                len(data_keys),
+                prefix,
+            )
+            raise StorageError(
+                f"{len(errors)} download(s) failed under prefix '{prefix}'"
+            ) from errors[0][1]
 
         reason = "downloaded" if transferred_count > 0 else "skipped:hash_match"
         ref = FileReference(

--- a/application_sdk/storage/transfer.py
+++ b/application_sdk/storage/transfer.py
@@ -249,15 +249,29 @@ async def upload(
         else:
             prefix = src.name
 
+        import asyncio
+
         files = [p for p in src.rglob("*") if p.is_file()]
         transferred_count = 0
+
+        sem = asyncio.Semaphore(5)
+
+        async def _upload_bounded(file_path: Path, key: str) -> bool:
+            async with sem:
+                ok, _ = await _upload_one(
+                    resolved, file_path, key, skip_if_exists=skip_if_exists
+                )
+                return ok
+
+        upload_tasks = []
         for file_path in files:
             relative = str(file_path.relative_to(src)).replace(os.sep, "/")
             key = f"{prefix}/{relative}" if prefix else relative
-            ok, _ = await _upload_one(
-                resolved, file_path, key, skip_if_exists=skip_if_exists
-            )
-            if ok:
+            upload_tasks.append(_upload_bounded(file_path, key))
+
+        results = await asyncio.gather(*upload_tasks, return_exceptions=True)
+        for r in results:
+            if r is True:
                 transferred_count += 1
 
         store_prefix = (prefix.rstrip("/") + "/") if prefix else ""
@@ -353,18 +367,28 @@ async def download(
         else:
             dest_dir = Path(tempfile.mkdtemp())
 
+        import asyncio
+
         dest_dir.mkdir(parents=True, exist_ok=True)
         strip = prefix
 
-        transferred_count = 0
+        sem = asyncio.Semaphore(5)
+
+        async def _download_bounded(key: str, local_file: Path) -> bool:
+            async with sem:
+                ok, _ = await _download_one(
+                    resolved, key, local_file, skip_if_exists=skip_if_exists
+                )
+                return ok
+
+        download_tasks = []
         for key in data_keys:
             rel = key[len(strip) :] if key.startswith(strip) else key
             local_file = dest_dir / rel
-            ok, _ = await _download_one(
-                resolved, key, local_file, skip_if_exists=skip_if_exists
-            )
-            if ok:
-                transferred_count += 1
+            download_tasks.append(_download_bounded(key, local_file))
+
+        results = await asyncio.gather(*download_tasks, return_exceptions=True)
+        transferred_count = sum(1 for r in results if r is True)
 
         reason = "downloaded" if transferred_count > 0 else "skipped:hash_match"
         ref = FileReference(

--- a/application_sdk/storage/transfer.py
+++ b/application_sdk/storage/transfer.py
@@ -283,14 +283,11 @@ async def upload(
             from application_sdk.storage.errors import StorageError
 
             logger.warning(
-                "upload: %d/%d uploads failed under %s",
+                "upload: %d/%d uploads failed",
                 len(errors),
                 len(files),
-                prefix,
             )
-            raise StorageError(
-                f"{len(errors)} upload(s) failed under prefix '{prefix}'"
-            ) from errors[0][1]
+            raise StorageError(f"{len(errors)} upload(s) failed") from errors[0][1]
 
         store_prefix = (prefix.rstrip("/") + "/") if prefix else ""
         reason = "uploaded" if transferred_count > 0 else "skipped:hash_match"
@@ -417,14 +414,11 @@ async def download(
             from application_sdk.storage.errors import StorageError
 
             logger.warning(
-                "download: %d/%d downloads failed under %s",
+                "download: %d/%d downloads failed",
                 len(errors),
                 len(data_keys),
-                prefix,
             )
-            raise StorageError(
-                f"{len(errors)} download(s) failed under prefix '{prefix}'"
-            ) from errors[0][1]
+            raise StorageError(f"{len(errors)} download(s) failed") from errors[0][1]
 
         reason = "downloaded" if transferred_count > 0 else "skipped:hash_match"
         ref = FileReference(

--- a/application_sdk/templates/base_metadata_extractor.py
+++ b/application_sdk/templates/base_metadata_extractor.py
@@ -92,15 +92,15 @@ class BaseMetadataExtractor(App):
         semaphore = asyncio.Semaphore(5)
 
         async def _migrate_one(file_path: str) -> None:
-            with tempfile.NamedTemporaryFile(delete=False) as tmp:
-                tmp_path = tmp.name
-            try:
-                async with semaphore:
+            async with semaphore:
+                with tempfile.NamedTemporaryFile(delete=False) as tmp:
+                    tmp_path = tmp.name
+                try:
                     await download_file(file_path, tmp_path, store=deployment_store)
                     await upload_file(file_path, tmp_path, store=upstream_store)
-            finally:
-                if os.path.exists(tmp_path):
-                    os.unlink(tmp_path)
+                finally:
+                    if os.path.exists(tmp_path):
+                        os.unlink(tmp_path)
 
         results = await asyncio.gather(
             *[_migrate_one(fp) for fp in files_to_migrate],

--- a/application_sdk/templates/base_metadata_extractor.py
+++ b/application_sdk/templates/base_metadata_extractor.py
@@ -82,23 +82,35 @@ class BaseMetadataExtractor(App):
         deployment_store = create_store_from_binding(DEPLOYMENT_OBJECT_STORE_NAME)
         upstream_store = create_store_from_binding(UPSTREAM_OBJECT_STORE_NAME)
 
+        import asyncio
+
         files_to_migrate = await list_keys(input.output_path, store=deployment_store)
         total_files = len(files_to_migrate)
         migrated_files = 0
         failures = []
 
-        for file_path in files_to_migrate:
+        semaphore = asyncio.Semaphore(5)
+
+        async def _migrate_one(file_path: str) -> None:
             with tempfile.NamedTemporaryFile(delete=False) as tmp:
                 tmp_path = tmp.name
             try:
-                await download_file(file_path, tmp_path, store=deployment_store)
-                await upload_file(file_path, tmp_path, store=upstream_store)
-                migrated_files += 1
-            except Exception as e:
-                failures.append({"file": file_path, "error": str(e)})
+                async with semaphore:
+                    await download_file(file_path, tmp_path, store=deployment_store)
+                    await upload_file(file_path, tmp_path, store=upstream_store)
             finally:
                 if os.path.exists(tmp_path):
                     os.unlink(tmp_path)
+
+        results = await asyncio.gather(
+            *[_migrate_one(fp) for fp in files_to_migrate],
+            return_exceptions=True,
+        )
+        for fp, result in zip(files_to_migrate, results):
+            if isinstance(result, Exception):
+                failures.append({"file": fp, "error": str(result)})
+            else:
+                migrated_files += 1
 
         if failures:
             from application_sdk.common.error_codes import ActivityError


### PR DESCRIPTION
## What was found

**Rules:** PERF-016 (sequential parallelizable ops), PERF-004 (connection pooling)
**Files:** 5 findings across storage, credentials, templates
**Severity:** High (confidence 88-92%)

Sequential await loops that should use asyncio.gather for parallelism.

## What was fixed

1. `credential_vault.py`: Parallel secret fetches via asyncio.gather
2. `base_metadata_extractor.py`: Parallel download+upload with Semaphore(5)
3. `batch.py`: Parallel delete in delete_prefix with Semaphore(20)
4. `transfer.py`: Parallel upload and download for directory operations

**Deferred:** BaseClient connection pooling (perf-010) — requires test mock updates.

## Validation

- [x] Pre-commit passes
- [x] All unit tests pass (1987 passed, 6 skipped)
- [x] pyright clean

## Linear

https://linear.app/atlan-epd/issue/BLDX-1032