### PR TITLE
fix(branch-keeper): use ORG_PAT_GITHUB to trigger CI on branch updates

### DIFF
--- a/.github/workflows/branch-keeper.yml
+++ b/.github/workflows/branch-keeper.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ORG_PAT_GITHUB }}
 
       - name: Find and update auto-maintained PRs that are behind
         run: |
@@ -93,4 +93,4 @@ jobs:
             echo "::endgroup::"
           done
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}


### PR DESCRIPTION
## Summary
- GITHUB_TOKEN pushes don't trigger downstream workflows (GitHub's loop-prevention)
- After branch-keeper updates a PR, CI checks never run → all 15 required checks stuck on "Expected"
- Switching to `ORG_PAT_GITHUB` (repo scope) bypasses loop-prevention so `pull_request.synchronize` fires normally

## Test plan
- [ ] Merge a PR to refactor-v3 while an auto-maintained PR exists → CI checks should run on the updated HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)