### PR TITLE
fix(sdk-review): use ORG_PAT_GITHUB for checkout and branch updates

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ORG_PAT_GITHUB }}
 
       # NOTE: VPN connect is intentionally AFTER Resolve PR metadata and
       # Acknowledge trigger. Those first two steps only talk to GitHub
@@ -354,7 +354,7 @@ jobs:
       - name: Conflict pre-flight (Tier 1 + 2)
         id: conflicts
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
           REPO: ${{ github.repository }}
           PR: ${{ steps.pr.outputs.number }}
           BASE: ${{ steps.pr.outputs.base_branch }}
@@ -372,20 +372,6 @@ jobs:
           if [ "$MERGEABLE" = "MERGEABLE" ] && [ "$MERGE_STATE" = "CLEAN" ]; then
             echo "needs_resolution=false" >> "$GITHUB_OUTPUT"
             echo "No conflicts."
-            exit 0
-          fi
-
-          # If the PR touches .github/workflows/*, GITHUB_TOKEN cannot
-          # push a branch update without the `workflows` scope (which
-          # GITHUB_TOKEN does NOT carry). Attempting Tier 1/2 would fail
-          # with a cryptic 403 → cascade into 'empty ident name' →
-          # 'there is no merge to abort'. Skip tier attempts cleanly,
-          # tell the author, and proceed with the review anyway.
-          if [ "$TOUCHES_WORKFLOWS" = "true" ]; then
-            echo "PR modifies .github/workflows/* — skipping branch update (GITHUB_TOKEN lacks workflow scope)."
-            gh pr comment "$PR" --body \
-              "⚠️ This PR modifies \`.github/workflows/*\` files. GitHub's \`GITHUB_TOKEN\` cannot update the branch (lacks \`workflows\` scope). **Review will proceed**, but you will need to **update the branch manually** (or a maintainer with a PAT that has the \`workflow\` scope must do it) before the PR can be merged."
-            echo "needs_resolution=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -1195,7 +1181,7 @@ jobs:
         id: finalize
         if: steps.verdict.outputs.verdict == 'READY_TO_MERGE'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
           PR: ${{ steps.pr.outputs.number }}
           MODE: ${{ steps.pr.outputs.mode }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- GITHUB_TOKEN lacks `workflows` scope → PRs modifying `.github/workflows/*` can't have branches updated
- GITHUB_TOKEN pushes don't trigger CI (GitHub loop-prevention) → same issue as branch-keeper (#1417)
- Switches 3 places to `ORG_PAT_GITHUB`:
  1. **checkout** — so git push has workflows scope
  2. **conflict pre-flight** — API update-branch + git push fallback
  3. **finalize** — branch update before approve
- Removes the workflow-file skip/warning since ORG_PAT_GITHUB has the needed scope

## Test plan
- [ ] Trigger `@sdk-review` on a PR that modifies workflow files → branch should update without the ⚠️ warning
- [ ] CI checks should run after branch update (not stuck on "Expected")

🤖 Generated with [Claude Code](https://claude.com/claude-code)