### PR TITLE
fix: allowlist Go stdlib CVE-2026-27137 and CVE-2026-33810

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -115,6 +115,20 @@
     "expires": "2026-07-15",
     "added_by": "mananjain99"
   },
+  "CVE-2026-27137": {
+    "package": "stdlib (Go)",
+    "severity": "HIGH",
+    "reason": "Base image \u2014 Go stdlib in daprd 1.17.4-r0 (Wolfi dapr-daprd-1.17). Fixed in Go 1.26.1; awaiting Wolfi rebuild of dapr-1.17 on newer Go toolchain.",
+    "expires": "2026-07-15",
+    "added_by": "louisnow"
+  },
+  "CVE-2026-33810": {
+    "package": "stdlib (Go)",
+    "severity": "HIGH",
+    "reason": "Base image \u2014 Go stdlib in daprd 1.17.4-r0 (Wolfi dapr-daprd-1.17). Fixed in Go 1.26.2; awaiting Wolfi rebuild of dapr-1.17 on newer Go toolchain.",
+    "expires": "2026-07-15",
+    "added_by": "louisnow"
+  },
   "SNYK-GOLANG-GOOPENTELEMETRYIOOTELEXPORTERSOTLPOTLPTRACEOTLPTRACEHTTP-15954196": {
     "package": "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp",
     "severity": "HIGH",


### PR DESCRIPTION
## Summary

Allowlist two HIGH Go stdlib CVEs newly flagged against the `application-sdk-main:2.8.7` base image:

| CVE | Package | Fix in Go | Present in |
|---|---|---|---|
| `CVE-2026-27137` | `stdlib (Go)` | 1.26.1 | `daprd 1.17.4-r0` |
| `CVE-2026-33810` | `stdlib (Go)` | 1.26.2 | `daprd 1.17.4-r0` |

## Root cause

The `2.8.7` base image ([build run #24501688945](https://github.com/atlanhq/application-sdk/actions/runs/24501688945/job/71609837207)) installed `dapr-daprd-1.17 (1.17.4-r0)` from Wolfi — see log line `#9 1.775 (1/1) Installing dapr-daprd-1.17 (1.17.4-r0)`. That APK ships a daprd binary compiled against Go stdlib 1.26.0. The two CVEs above are patched in Go 1.26.1 / 1.26.2 respectively, so the fix is an upstream Wolfi rebuild of `dapr-1.17` on a newer Go toolchain.

The older `2.8.2` image pins the same `dapr-daprd-1.17` stream but was built earlier, when Wolfi's stream resolved to a patch built on an earlier Go toolchain that doesn't match these CVE signatures — which is why publish-app's scan (still on `2.8.2`) passes while any consumer that bumps to `2.8.7` fails the gate.

## Why allowlist

- **Not fixable in this repo.** `apk add dapr-daprd=1.17.3-r0` would fail on future rebuilds — Wolfi only retains the latest patch per stream.
- **Matches existing pattern.** Three Go stdlib CVEs (25679, 32280, 32282) are already allowlisted with identical shape — 90-day expiry, reason `"Base image — Go stdlib"`.
- **Self-healing when Wolfi ships.** Once `wolfi-dev/os/dapr-1.17.yaml` rebuilds on Go ≥1.26.2, the next SDK image build automatically picks up the patched binary, scanners stop flagging, and these entries can be removed at expiry review.

## Downstream impact

Unblocks `native-migration-app` PR #6 which currently fails the reusable `build-and-scan.yaml` gate on exactly these two findings. Any connector bumping to the `2.8.7+` base image would hit the same block.

## Test plan

- [ ] JSON validates (verified locally — 21 entries, parse clean)
- [ ] Re-run `build-and-scan` on `native-migration-app` PR #6 after merge — gate should pass with `Total: 21 CRITICAL/HIGH | All allowlisted ✅`
- [ ] Expiry calendar reminder set for 2026-07-15 to re-verify Wolfi has rebuilt `dapr-1.17` and retire these entries