### PR TITLE
perf(sdk-review): use Sonnet for Session C (CI remediation)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1402,7 +1402,7 @@ jobs:
 
             Output: CI_FIXED:<count of files changed> or CI_FIXED:0 if nothing needed fixing.
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-sonnet-4-6
             --allowedTools "Read,Write,Edit,Glob,Grep,Bash(uv run:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git diff:*),Bash(git checkout:*),Bash(git status:*),Bash(gh pr:*),Bash(gh api:*),Bash(cat:*),Bash(jq:*),Bash(python3:*),Bash(python:*),Bash(wc:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(sort:*),Bash(grep:*),Bash(find:*),Bash(echo:*),Bash(tr:*),Bash(cut:*),Bash(uniq:*),Bash(diff:*),Bash(xargs:*),Bash(sed:*),Bash(awk:*),Bash(ruff:*),Bash(pip:*),Bash(mkdir:*),Bash(tee:*),Bash(which:*),Bash(cp:*),Bash(mv:*),Bash(touch:*),Bash(chmod:*)"
         env:
           LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}


### PR DESCRIPTION
## Summary
- Session C only fixes lint/format/test issues — mechanical work that doesn't need Opus
- Changes `--model claude-opus-4-6` → `--model claude-sonnet-4-6` for Session C only
- ~5x cost reduction per CI fix session

## Test plan
- [ ] Trigger `@sdk-review auto-complete` on a PR with failing CI → Session C should run on Sonnet and fix successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)