### PR TITLE
fix: allowlist CVE-2026-23949 (jaraco.context) and CVE-2026-24049 (wheel)

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Updated by SDK team. CODEOWNERS: SDK/security team only.",
   "_base_image": "application-sdk-main",
-  "_updated": "2026-04-16",
+  "_updated": "2026-04-17",
   "_renewal_note": "Expiry dates staggered by severity. CRITICAL: 60 days. HIGH: 90 days. Review before expiry.",
   "SNYK-GOLANG-GOOGLEGOLANGORGGRPC-15691172": {
     "package": "google.golang.org/grpc",
@@ -149,5 +149,19 @@
     "reason": "No patched version of sqlitedict available — upstream has not released a fix as of 2026-04-16",
     "expires": "2026-07-16",
     "added_by": "TechyMT"
+  },
+  "CVE-2026-23949": {
+    "package": "jaraco.context",
+    "severity": "HIGH",
+    "reason": "Base image — system Python package (jaraco.context 5.3.0) shipped by Chainguard Wolfi in cgr.dev/atlan.com/app-framework-golden:3.13. Fixed in 6.1.0; awaiting Wolfi base image rebuild with patched python3-jaraco-context. Not used at runtime by SDK apps (apps install their own deps in .venv).",
+    "expires": "2026-07-16",
+    "added_by": "anuj-atlan"
+  },
+  "CVE-2026-24049": {
+    "package": "wheel",
+    "severity": "HIGH",
+    "reason": "Base image — system Python package (wheel 0.45.1) shipped by Chainguard Wolfi in cgr.dev/atlan.com/app-framework-golden:3.13. Fixed in 0.46.2; awaiting Wolfi base image rebuild with patched python3-wheel. Not used at runtime by SDK apps (apps install their own deps in .venv).",
+    "expires": "2026-07-16",
+    "added_by": "anuj-atlan"
   }
 }


### PR DESCRIPTION
## Summary

Adds 2 HIGH-severity base-image CVEs to `.security/base-allowlist.json`. Both flag system Python packages installed in the Chainguard Wolfi base (`cgr.dev/atlan.com/app-framework-golden:3.13`), not packages used by SDK apps at runtime.

| CVE | Package | Installed | Fix | Severity |
|---|---|---|---|---|
| CVE-2026-23949 | `jaraco.context` | 5.3.0 | 6.1.0 | HIGH |
| CVE-2026-24049 | `wheel` | 0.45.1 | 0.46.2 | HIGH |

## Why allowlist instead of upgrade

Both are shipped as Wolfi APK packages by Chainguard (`python3-jaraco-context`, `python3-wheel`). We can't bump them independently of the base image. Patched versions exist upstream on PyPI but the Wolfi package build hasn't caught up. SDK apps run in their own `uv` venv so the system-level copies are never imported at runtime — risk is limited to the image surface area.

This matches the existing pattern established for the Go stdlib CVEs (#1425) — allowlist while waiting on a Wolfi rebuild.

## Impact

Unblocks connector repo security gates that inherit this base allowlist (e.g. atlan-redshift-app currently blocked by these 2 findings after its own transitive-dep fixes land).

## Follow-up

Revisit before `2026-07-16` (90-day HIGH expiry). If Chainguard hasn't rebuilt by then, extend with a note; otherwise remove these entries once the base image rolls to a patched `app-framework-golden` tag.

## Test plan

- [ ] `.security/` approval gate passes (requires authorized approver)
- [ ] `base-allowlist.json` remains valid JSON
- [ ] Downstream repo CI (redshift-app) drops these 2 findings from the NEW bucket