### PR TITLE
fix(sdk-review): make GraphQL auto-resolve non-fatal

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1153,42 +1153,35 @@ jobs:
 
           # Auto-resolve ALL remaining bot inline comment threads.
           # PR is approved → all findings are either fixed or accepted.
-          # No reason to leave resolved/stale threads cluttering the
-          # Files Changed tab.
-          # Use GITHUB_TOKEN for GraphQL — ORG_PAT_GITHUB lacks read:org
-          # scope needed for author.login fields in the GraphQL schema.
-          # Export it as GH_TOKEN temporarily for the GraphQL calls only,
-          # then restore the original.
-          ORIG_GH_TOKEN="$GH_TOKEN"
-          export GH_TOKEN="$GITHUB_TOKEN"
-
-          THREADS=$(gh api graphql -f query='
-            query($owner:String!,$name:String!,$num:Int!) {
-              repository(owner:$owner, name:$name) {
-                pullRequest(number:$num) {
-                  reviewThreads(first:100) {
-                    nodes { id isResolved
-                      comments(first:1) {
-                        nodes { author{login} }
+          # Wrapped in a subshell so GraphQL failures (e.g. token scope
+          # issues) never crash the Finalize step — thread resolution
+          # is cosmetic, the approval and status update must not fail.
+          (
+            THREADS=$(gh api graphql -f query='
+              query($owner:String!,$name:String!,$num:Int!) {
+                repository(owner:$owner, name:$name) {
+                  pullRequest(number:$num) {
+                    reviewThreads(first:100) {
+                      nodes { id isResolved
+                        comments(first:1) {
+                          nodes { author{login} }
+                        }
                       }
                     }
                   }
                 }
-              }
-            }' -F owner=atlanhq -F name=application-sdk -F num="$PR" \
-            --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login == "claude[bot]" or .comments.nodes[0].author.login == "github-actions[bot]" or .comments.nodes[0].author.login == "atlan-ci") | .id' 2>/dev/null || echo "")
+              }' -F owner=atlanhq -F name=application-sdk -F num="$PR" \
+              --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login == "claude[bot]" or .comments.nodes[0].author.login == "github-actions[bot]" or .comments.nodes[0].author.login == "atlan-ci") | .id' 2>/dev/null || echo "")
 
-          for thread_id in $THREADS; do
-            gh api graphql -f query='
-              mutation($id:ID!) {
-                resolveReviewThread(input:{threadId:$id}) {
-                  thread { id isResolved }
-                }
-              }' -F id="$thread_id" 2>/dev/null || true
-          done
-
-          # Restore ORG_PAT for remaining operations (status update)
-          export GH_TOKEN="$ORIG_GH_TOKEN"
+            for thread_id in $THREADS; do
+              gh api graphql -f query='
+                mutation($id:ID!) {
+                  resolveReviewThread(input:{threadId:$id}) {
+                    thread { id isResolved }
+                  }
+                }' -F id="$thread_id" 2>/dev/null || true
+            done
+          ) || echo "::warning::Auto-resolve threads failed (non-fatal). Threads may remain unresolved."
 
           # Final status on the (possibly updated) HEAD SHA
           NEW_SHA=$(gh pr view "$PR" --json headRefOid -q .headRefOid)


### PR DESCRIPTION
## Summary
- ORG_PAT_GITHUB lacks `read:org` → GraphQL `author.login` fails
- Previous token-swap attempts didn't work (actions/checkout overrides GITHUB_TOKEN)
- Wraps the entire auto-resolve block in a `( ... ) || warn` subshell
- GraphQL failure prints a warning but Finalize continues — approval, status, labels all succeed
- Thread resolution is cosmetic; the critical path (approve + status) must not fail because of it

## Test plan
- [ ] `@sdk-review` on any PR with READY_TO_MERGE verdict → Finalize should succeed
- [ ] Warning "Auto-resolve threads failed (non-fatal)" may appear in logs — that's expected until `read:org` scope is added to ORG_PAT

🤖 Generated with [Claude Code](https://claude.com/claude-code)