### PR TITLE
fix: allowlist CVE-2026-23949 (jaraco.context) and CVE-2026-24049 (wheel)

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -153,14 +153,14 @@
   "CVE-2026-23949": {
     "package": "jaraco.context",
     "severity": "HIGH",
-    "reason": "Base image — system Python package (jaraco.context 5.3.0) shipped by Chainguard Wolfi in cgr.dev/atlan.com/app-framework-golden:3.13. Fixed in 6.1.0; awaiting Wolfi base image rebuild with patched python3-jaraco-context APK. Not used at runtime by SDK apps (apps install their own deps in .venv).",
+    "reason": "Base image — Chainguard Wolfi system Python package",
     "expires": "2026-07-16",
     "added_by": "anuj-atlan"
   },
   "CVE-2026-24049": {
     "package": "wheel",
     "severity": "HIGH",
-    "reason": "Base image — system Python package (wheel 0.45.1) shipped by Chainguard Wolfi in cgr.dev/atlan.com/app-framework-golden:3.13. Fixed in 0.46.2; awaiting Wolfi base image rebuild with patched python3-wheel APK. Not used at runtime by SDK apps (apps install their own deps in .venv).",
+    "reason": "Base image — Chainguard Wolfi system Python package",
     "expires": "2026-07-16",
     "added_by": "anuj-atlan"
   }

--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Updated by SDK team. CODEOWNERS: SDK/security team only.",
   "_base_image": "application-sdk-main",
-  "_updated": "2026-04-16",
+  "_updated": "2026-04-17",
   "_renewal_note": "Expiry dates staggered by severity. CRITICAL: 60 days. HIGH: 90 days. Review before expiry.",
   "SNYK-GOLANG-GOOGLEGOLANGORGGRPC-15691172": {
     "package": "google.golang.org/grpc",
@@ -149,5 +149,19 @@
     "reason": "No patched version of sqlitedict available — upstream has not released a fix as of 2026-04-16",
     "expires": "2026-07-16",
     "added_by": "TechyMT"
+  },
+  "CVE-2026-23949": {
+    "package": "jaraco.context",
+    "severity": "HIGH",
+    "reason": "Base image — system Python package (jaraco.context 5.3.0) shipped by Chainguard Wolfi in cgr.dev/atlan.com/app-framework-golden:3.13. Fixed in 6.1.0; awaiting Wolfi base image rebuild with patched python3-jaraco-context APK. Not used at runtime by SDK apps (apps install their own deps in .venv).",
+    "expires": "2026-07-16",
+    "added_by": "anuj-atlan"
+  },
+  "CVE-2026-24049": {
+    "package": "wheel",
+    "severity": "HIGH",
+    "reason": "Base image — system Python package (wheel 0.45.1) shipped by Chainguard Wolfi in cgr.dev/atlan.com/app-framework-golden:3.13. Fixed in 0.46.2; awaiting Wolfi base image rebuild with patched python3-wheel APK. Not used at runtime by SDK apps (apps install their own deps in .venv).",
+    "expires": "2026-07-16",
+    "added_by": "anuj-atlan"
   }
 }


### PR DESCRIPTION
## Summary

Adds two HIGH-severity CVEs to `.security/base-allowlist.json`. Both flag system Python packages installed in the Chainguard Wolfi base image (`cgr.dev/atlan.com/app-framework-golden:3.13`), not packages consumed at runtime by SDK apps. Follows the exact pattern established by #1425 for the Go stdlib CVEs.

| CVE | Package | Installed version | Fix version | Severity |
|---|---|---|---|---|
| CVE-2026-23949 | `jaraco.context` | 5.3.0 | 6.1.0 | HIGH |
| CVE-2026-24049 | `wheel` | 0.45.1 | 0.46.2 | HIGH |

## Why allowlist instead of upgrade

**These packages are outside our control.** They're shipped as Wolfi APKs (`python3-jaraco-context`, `python3-wheel`) baked into the Chainguard base image. They are **not** in the SDK's `pyproject.toml`, **not** in any connector's `pyproject.toml`, and **not** in any `uv.lock`. A `uv` constraint or a `pip install --upgrade` at app-build time does not replace the system-installed copies that live next to the interpreter — the scanner still sees them.

Patched versions exist upstream on PyPI (`jaraco.context 6.1.0`, `wheel 0.46.2`), but the Wolfi package build has not yet caught up. The only real fixes are:

1. Wait for Chainguard to roll a refreshed Wolfi base — not something we control.
2. Rebuild our own base image without those system packages — out of scope for a single CVE cycle; risks breaking the Python install surface.

This matches exactly how we handled the Go stdlib CVEs in #1425: allowlist while waiting on a Wolfi rebuild, with a 90-day TTL so we don't forget.

## Runtime risk assessment (why this is safe to allowlist)

SDK-based apps install all their runtime dependencies into an isolated `uv` venv at `/app/.venv`. Neither `jaraco.context` nor `wheel` is imported by any SDK code path at runtime:

- `wheel` is a build-time packaging helper (used by `pip`/`setuptools` to build wheels). Once an image is built, it's never executed on the hot path.
- `jaraco.context` is a dependency of `keyring`, which the system Python ships but the SDK/apps do not use — our credential reads go through Dapr secret stores, not the system keyring.

So even though the vulnerable code is present on disk, the attack surface it exposes is effectively zero for running SDK apps. The finding is a hygiene flag, not an exploitable path.

## Impact / downstream unblock

Currently, **every connector repo scanning against `application-sdk-main:2.8.7` is blocked on exactly these two findings** once they've pinned their own transitive-dep CVEs. Example: `atlanhq/atlan-redshift-app#228` has closed 13 of 15 transitive-dep CVEs via `[tool.uv] constraint-dependencies` and regenerated `uv.lock`; only these 2 remain. Merging this PR unblocks redshift and every other connector simultaneously, since the allowlist is central.

## Follow-up / exit criteria

- **Revisit by `2026-07-16`** (90-day HIGH TTL).
- Before expiry, the SDK/security team should:
  1. Check whether Chainguard has refreshed `app-framework-golden` with patched `python3-jaraco-context` and `python3-wheel` APKs.
  2. If yes, bump the base image tag in `Dockerfile` (or roll a new SDK image version) and delete these entries.
  3. If no, extend TTL with a note on the Chainguard status (matches how #1425 was scoped).

## Test plan

- [ ] `.security/` approval gate passes (requires an authorized approver: `nishantmunjal7`, `anbarasantr`, `AtMrun`, `gaurav-atlan`, `akshay-vishwanath27`, or `louisnow`)
- [ ] `base-allowlist.json` remains valid JSON (23 CVE entries total after merge)
- [ ] Once merged, `atlanhq/atlan-redshift-app#228` CI drops to 0 non-allowlisted findings