### PR TITLE
feat(handler): port v2.8.2 → v3 [BLDX-1004]

### DIFF
--- a/.github/workflows/build-apps-image.yaml
+++ b/.github/workflows/build-apps-image.yaml
@@ -87,7 +87,7 @@ jobs:
               print(f'::error::atlan.yaml is invalid YAML: {e}', file=sys.stderr)
               sys.exit(1)
 
-          app_name   = d.get('name', '')
+          app_name   = d.get('name', '').lower()
           build_tag  = d.get('build_tag', 'v1')
           dockerfile = d.get('dockerfile', './Dockerfile')
           # self_deployed_runtime: true → push image to shared external registry

--- a/.github/workflows/publish-app.yaml
+++ b/.github/workflows/publish-app.yaml
@@ -49,7 +49,7 @@ on:
         description: "Atlan CLI version to install"
         required: false
         type: string
-        default: "v0.1.10"
+        default: "v0.1.11"
     secrets:
       ORG_PAT_GITHUB:
         required: true
@@ -100,8 +100,9 @@ jobs:
         env:
           APP_PUBLISH_TOKEN: ${{ secrets.APP_PUBLISH_TOKEN }}
         run: |
-          atlan config set atlan_base_url "${{ inputs.base_url }}"
-          atlan config set atlan_api_key "$APP_PUBLISH_TOKEN"
+          set -euo pipefail
+          atlan config atlan_base_url "${{ inputs.base_url }}"
+          atlan config atlan_api_key "$APP_PUBLISH_TOKEN"
 
       - name: Publish
         env:

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -1448,6 +1448,7 @@ def create_app_handler_service(
             raw = manifest_path.read_bytes()
             deployment = (DEPLOYMENT_NAME or "default").encode()
             raw = raw.replace(b"{deployment_name}", deployment)
+            raw = raw.replace(b"{app_name}", (app_name or "").encode())
             return Response(content=raw, media_type="application/json")
         raise HTTPException(status_code=404, detail="No manifest available")
 

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -869,6 +869,40 @@ class TestManifestEndpoint:
             svc_module.CONTRACT_GENERATED_DIR = original_dir
             svc_module.DEPLOYMENT_NAME = original_dep
 
+    def test_manifest_disk_substitutes_app_name(self, tmp_path: Path) -> None:
+        from application_sdk.handler import service as svc_module
+
+        manifest_data = {
+            "execution_mode": "dag",
+            "dag": {
+                "extract": {
+                    "activity_name": "execute_workflow",
+                    "activity_display_name": "Extract",
+                    "app_name": "{app_name}",
+                    "inputs": {
+                        "workflow_type": "extraction",
+                        "task_queue": "{deployment_name}-queue",
+                    },
+                }
+            },
+        }
+        (tmp_path / "manifest.json").write_text(__import__("json").dumps(manifest_data))
+
+        original_dir = svc_module.CONTRACT_GENERATED_DIR
+        original_dep = svc_module.DEPLOYMENT_NAME
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        svc_module.DEPLOYMENT_NAME = "prod-deploy"
+        try:
+            client = _make_client()
+            response = client.get("/workflows/v1/manifest")
+            assert response.status_code == 200
+            body = response.json()
+            assert body["dag"]["extract"]["app_name"] == "test-app"
+            assert body["dag"]["extract"]["inputs"]["task_queue"] == "prod-deploy-queue"
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original_dir
+            svc_module.DEPLOYMENT_NAME = original_dep
+
     def test_manifest_programmatic_takes_priority(self, tmp_path: Path) -> None:
         """When both programmatic and disk manifest exist, programmatic wins."""
         from application_sdk.handler import service as svc_module


### PR DESCRIPTION
## Summary

Forward-ports the applicable v2.8.2 changes onto the v3 line (Linear: BLDX-1004). Of 8 commits in the `v2.8.1…v2.8.2` range, 3 needed porting, 1 needed adaptation, and the rest were already ported or made obsolete by v3's restructure.

- **`handler/service.py`** — expose `{app_name}` placeholder substitution in disk-served manifest (adapted from aa61a40; the `BaseSQLMetadataExtractionApplication` DAG-node half is obsolete in v3)
- **`publish-app.yaml`** — fix `atlan config set X` → `atlan config X` syntax + `set -euo pipefail` (c3f07ef); bump CLI default `v0.1.10` → `v0.1.11` (dc1dd9f)
- **`build-apps-image.yaml`** — lowercase `app_name` from `atlan.yaml` to prevent image-tag casing issues (afa7977)

### Skipped (with rationale)

| Commit | Reason skipped |
|--------|----------------|
| cd41503 (AE metrics OutputInterceptor) | Already ported in v3 PR #1221 (`369dc59`) |
| 6c329af (BaseTest health check) | `test_utils/e2e/base.py` removed with v2 shim purge (`b5ed0e4`) |
| 614c264 (unified build-and-publish workflow) | Superseded by v3-native rewrite on `feat/entrypoints-ci-publish` which also deletes both workflow files |
| 734b8ca (version bump) | v3 has its own version track |

> **Note:** `feat/entrypoints-ci-publish` plans to delete `build-apps-image.yaml` and `publish-app.yaml`. The fixes in this PR are harmless and the sibling branch will cleanly overwrite them.

## Test plan

- [ ] `uv run pytest tests/unit/handler/test_service.py -k manifest -v` — 7 manifest tests pass (includes new `test_manifest_disk_substitutes_app_name`)
- [ ] `uv run python -m pytest tests/unit -x -q` — 2054 passed, 6 skipped
- [ ] `uv run pre-commit run --all-files` — all hooks pass
- [ ] Manual: deploy an app with `{app_name}` in `manifest.json`; confirm `/workflows/v1/manifest` returns the substituted value