### PR TITLE
fix(observability): remove time_ns() to prevent Temporal determinism violation

### DIFF
--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -3,7 +3,6 @@ import logging
 import sys
 import threading
 import traceback as tb_module
-from time import time_ns
 from typing import Any, ClassVar, Dict, Tuple
 
 from loguru import logger
@@ -568,7 +567,7 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
 
         return LogRecord(
             timestamp=int(record["timestamp"] * 1e9),
-            observed_timestamp=time_ns(),
+            observed_timestamp=int(record["timestamp"] * 1e9),
             trace_id=0,
             span_id=0,
             trace_flags=TraceFlags(0),


### PR DESCRIPTION
## Summary

- Removes `time_ns()` from `observed_timestamp` in `LogRecord` construction in `logger_adaptor.py`
- Replaces with `int(record["timestamp"] * 1e9)` — consistent with how `timestamp` is already set
- Prevents a Temporal determinism violation: `time_ns()` returns different values on replay, breaking Temporal's deterministic execution model

Port of v2.8.3 fix ([#1203](https://github.com/atlanhq/application-sdk/pull/1203)), as analysed in [BLDX-1002](https://linear.app/atlan-epd/issue/BLDX-1002).

## Test plan

- [x] Pre-commit checks pass (ruff, pyright, isort)
- [x] All 2053 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)