### PR TITLE
fix: allowlist Next.js CVE (SNYK-JS-NEXT-15954202)

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Updated by SDK team. CODEOWNERS: SDK/security team only.",
   "_base_image": "application-sdk-main",
-  "_updated": "2026-04-17",
+  "_updated": "2026-04-18",
   "_renewal_note": "Expiry dates staggered by severity. CRITICAL: 60 days. HIGH: 90 days. Review before expiry.",
   "SNYK-GOLANG-GOOGLEGOLANGORGGRPC-15691172": {
     "package": "google.golang.org/grpc",
@@ -163,5 +163,12 @@
     "reason": "Base image — Chainguard Wolfi system Python package",
     "expires": "2026-07-16",
     "added_by": "anuj-atlan"
+  },
+  "SNYK-JS-NEXT-15954202": {
+    "package": "next",
+    "severity": "HIGH",
+    "reason": "Next.js pinned to ~16.1.6 due to router.replace static export regression in 16.2.x. Upgrade blocked until Next.js fixes the regression.",
+    "expires": "2026-07-18",
+    "added_by": "bichitra.sahoo"
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,8 @@ USER root
 RUN curl -fsSL https://raw.githubusercontent.com/dapr/cli/master/install/install.sh | DAPR_INSTALL_DIR="/usr/local/bin" /bin/bash -s ${DAPR_CLI_VERSION}
 
 
-# Install Dapr runtime from Chainguard APK and upgrade to latest patch
-RUN apk add --no-cache ${DAPR_RUNTIME_PACKAGE} && \
-    apk upgrade --no-cache ${DAPR_RUNTIME_PACKAGE}
+# Install Dapr runtime from Chainguard APK
+RUN apk add --no-cache ${DAPR_RUNTIME_PACKAGE}
 
 # Create appuser (standardized user for all apps)
 RUN addgroup -g 1000 appuser && adduser -D -u 1000 -G appuser appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ USER root
 RUN curl -fsSL https://raw.githubusercontent.com/dapr/cli/master/install/install.sh | DAPR_INSTALL_DIR="/usr/local/bin" /bin/bash -s ${DAPR_CLI_VERSION}
 
 
-# Install Dapr runtime from Chainguard APK
-RUN apk add --no-cache ${DAPR_RUNTIME_PACKAGE}
+# Install Dapr runtime from Chainguard APK and upgrade to latest patch
+RUN apk add --no-cache ${DAPR_RUNTIME_PACKAGE} && \
+    apk upgrade --no-cache ${DAPR_RUNTIME_PACKAGE}
 
 # Create appuser (standardized user for all apps)
 RUN addgroup -g 1000 appuser && adduser -D -u 1000 -G appuser appuser


### PR DESCRIPTION
## Summary
- Allowlist `SNYK-JS-NEXT-15954202` (next@16.1.x) — upgrade to 16.2.x is blocked by a `router.replace` static export regression in Next.js

## Context
This CVE is one of the remaining blockers on the automation-engine-app security gate. Next.js is pinned to `~16.1.6` because 16.2.x introduced a regression in `router.replace` that breaks the static export build. Allowlisted with 90-day expiry (2026-07-18) pending upstream fix.

## Test plan
- [ ] Security gate passes on automation-engine-app after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)