### PR TITLE
[WIP][DO NOT MERGE] HYP-488: SDK fixes for Teradata v3 multi-entrypoint

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -100,14 +100,15 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Checkout SDK helper scripts
-        # Pull only ``.github/scripts/`` from the SDK at main.
+        # Pull only ``.github/scripts/`` from the SDK.
         # github.workflow_ref and github.workflow_sha both resolve to the *caller's*
-        # ref in a reusable workflow context (GitHub bug) — ref is pinned to main
-        # so it always picks up the latest released version of the scripts.
+        # ref in a reusable workflow context (GitHub bug) — ref is pinned to HYP-488
+        # (branched from refactor-v3) which has parse_atlan_yaml.py.
+        # Revert to main once refactor-v3 is merged to main.
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           repository: atlanhq/application-sdk
-          ref: main
+          ref: HYP-488
           path: .sdk-entrypoint
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — Workaround Branch

This PR is a **temporary workaround** and will be **deleted when `refactor-v3` is merged to `main`**. At that point the issue resolves automatically since `parse_atlan_yaml.py` will be on `main` and the reusable workflow's `ref: main` checkout will work correctly.

---

## Problem

The reusable workflow in `refactor-v3` checkouts SDK helper scripts (`parse_atlan_yaml.py`) at `ref: main` to work around a GitHub bug where `github.workflow_sha` / `github.workflow_ref` resolve to the caller's ref inside a reusable workflow context. However, `parse_atlan_yaml.py` only exists in `refactor-v3`, not yet on `main`.

This causes the `Prepare` step to fail with:
```
python3: can't open file '.sdk-entrypoint/.github/scripts/parse_atlan_yaml.py': No such file or directory
```

## Fix

Checkout SDK scripts from `HYP-488` (this branch, based on `refactor-v3`) instead of `main`. Apps using this branch get the correct scripts.

## Usage

Apps using this branch in their `pyproject.toml` and `build-and-publish.yaml`:
```yaml
uses: atlanhq/application-sdk/.github/workflows/build-and-publish-app.yaml@HYP-488
```
```toml
atlan-application-sdk = { git = "https://github.com/atlanhq/application-sdk", branch = "HYP-488" }
```

## Tracked fixes on this branch

- CI scripts (`parse_atlan_yaml.py`) accessible for reusable workflow
- See HYP-488 in Linear for full list

## Deletion plan

Delete this branch and close this PR once `refactor-v3` → `main` is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)