### PR TITLE
fix: use ORG_PAT_GITHUB for PR comment to fix 403 permission error

### DIFF
--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -294,6 +294,7 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
+          github-token: ${{ secrets.ORG_PAT_GITHUB }}
           script: |
             const fs = require('fs');
             let body;


### PR DESCRIPTION
GITHUB_TOKEN in reusable workflow context doesn't have pull-requests:write despite being declared. Using ORG_PAT_GITHUB instead.