### PR TITLE
fix: include release_id in event metadata

### DIFF
--- a/application_sdk/contracts/events.py
+++ b/application_sdk/contracts/events.py
@@ -9,7 +9,11 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
-from application_sdk.constants import APPLICATION_NAME, WORKER_START_EVENT_VERSION
+from application_sdk.constants import (
+    APPLICATION_NAME,
+    RELEASE_ID,
+    WORKER_START_EVENT_VERSION,
+)
 
 
 class EventTypes(Enum):
@@ -46,6 +50,7 @@ class EventMetadata(BaseModel):
 
     Attributes:
         application_name: Name of the application the event belongs to.
+        release_id: Release UUID from Global Marketplace (empty if not injected).
         created_timestamp: Timestamp when the event was created.
         workflow_type: Type of the workflow.
         workflow_id: ID of the workflow.
@@ -58,6 +63,7 @@ class EventMetadata(BaseModel):
     """
 
     application_name: str = Field(init=True, default=APPLICATION_NAME)
+    release_id: str = Field(init=True, default=RELEASE_ID)
     created_timestamp: int = Field(init=True, default=0)
 
     # Workflow information


### PR DESCRIPTION
## Summary

- Adds `release_id` (sourced from `ATLAN_RELEASE_ID` env var, already wired via `constants.RELEASE_ID`) to `EventMetadata` so it ships on **every** application event — `workflow_start`, `workflow_end`, `activity_*`, `worker_*`, etc.
- No changes to `EventWorkflowInboundInterceptor` or any event-specific `data` payload. The field travels on the generic envelope alongside `application_name`, `workflow_id`, `workflow_state`.

## Why metadata, not `data.release_id`

`release_id` describes the deployment, not a workflow outcome — same category as `application_name`. Putting it in `EventMetadata` means:

1. One edit covers all event types; no per-event plumbing as new events are added.
2. Downstream consumers (e.g. workflow-analytics Numaflow pipeline) already parse `metadata` and get it for free.
3. Enables attributing events to a specific Global Marketplace release without any join/enrichment step on the consumer side.

## Downstream follow-up (separate repo, not this PR)

The `WORKFLOW_ENDED` Kafka schema and the `marketplace_scripts.workflow_analytics` Numaflow writer will need to read `metadata.release_id` off the event and write it into `horizon.workflows` (either as a dedicated column or into `workflow_metadata.releaseId`). That lives in the marketplace/numaflow repo.

## Test plan

- [ ] CI green (ruff, ruff-format, isort, pyright all passed locally via pre-commit)
- [ ] Deploy to a canary environment with `ATLAN_RELEASE_ID` set and confirm `metadata.release_id` is populated on a `workflow_end` event
- [ ] Confirm events without the env var set continue to publish (field defaults to empty string, matching existing `WorkerStartEventData.release_id` behavior)