### PR TITLE
fix(credentials): prevent CredentialResolver shortcut from bypassing DaprCredentialVault in prod

### DIFF
--- a/application_sdk/credentials/resolver.py
+++ b/application_sdk/credentials/resolver.py
@@ -178,15 +178,19 @@ class CredentialResolver:
     async def _resolve_by_guid(self, ref: "CredentialRef") -> dict[str, Any]:
         """Resolve credentials by GUID.
 
-        Checks the local secret store first (covers in-process credential
-        injection from handler/service.py in combined-mode and local dev), then
-        falls back to DaprCredentialVault for production platform-issued GUIDs.
-        """
+        In local-dev only, checks two in-process stores first (state_store
+        under ``cred:{guid}`` — where handler/service.py writes today — and
+        secret_store under ``{guid}`` — where older SDK versions wrote).
+        Falls back to :class:`DaprCredentialVault` for platform-issued GUIDs,
+        which merges the S3 non-secret config with the Vault secret blob.
 
-        # State store check — handler/service.py stores inline credentials here
-        # under the "cred:" prefix + UUID that becomes ref.name / ref.credential_guid.
-        # Guarded to local-dev only (symmetric with the write guard in handler/service.py)
-        # to avoid unnecessary state store round-trips in production.
+        Both in-process checks MUST remain local-only: in production the
+        secret_store is Dapr/Vault-backed and returns the *secret-only*
+        portion of the credential (``username``/``password``/``extra``).
+        Short-circuiting on that bypasses the DaprCredentialVault merge and
+        produces a credential dict missing non-secret fields such as ``host``
+        and ``port`` — breaking downstream clients.
+        """
 
         from application_sdk.infrastructure.context import get_infrastructure
 
@@ -195,41 +199,47 @@ class CredentialResolver:
             "1",
         )
         infra = get_infrastructure()
-        if is_local_dev and infra and infra.state_store:
+
+        if is_local_dev:
+            # 1. State store — current SDK handler write path. Credentials
+            # written by POST /workflows/v1/start when local dev is enabled.
+            if infra and infra.state_store:
+                try:
+                    data = await infra.state_store.load(f"cred:{ref.name}")
+                    if data is not None:
+                        return data
+                except Exception:
+                    logger.debug(
+                        "State store lookup failed for GUID %r; trying secret store",
+                        ref.name,
+                        exc_info=True,
+                    )
+
+            # 2. Secret store — legacy SDK handler write path / explicit
+            # InMemorySecretStore injection in combined-mode tests. Local-only
+            # to avoid hitting Dapr/Vault in production (see docstring).
+            from application_sdk.infrastructure.secrets import SecretNotFoundError
+
             try:
-                data = await infra.state_store.load(f"cred:{ref.name}")
-                if data is not None:
-                    return data
+                raw = await self._secret_store.get(ref.name)
+                data_parsed: dict[str, Any] = json.loads(raw)
+                return data_parsed
+            except SecretNotFoundError:
+                pass
+            except json.JSONDecodeError:
+                logger.debug(
+                    "Local secret_store value for GUID %r is not valid JSON; trying Dapr",
+                    ref.name,
+                )
             except Exception:
                 logger.debug(
-                    "State store lookup failed for GUID %r; trying secret store",
+                    "Local secret_store lookup failed for GUID %r; trying Dapr",
                     ref.name,
                     exc_info=True,
                 )
 
-        # Secret store check (backward compat) — handler/service.py previously
-        # stored inline credentials here under the same UUID.
-        from application_sdk.infrastructure.secrets import SecretNotFoundError
-
-        try:
-            raw = await self._secret_store.get(ref.name)
-            data_parsed: dict[str, Any] = json.loads(raw)
-            return data_parsed
-        except SecretNotFoundError:
-            pass
-        except json.JSONDecodeError:
-            logger.debug(
-                "Local store value for GUID %r is not valid JSON; trying Dapr",
-                ref.name,
-            )
-        except Exception:
-            logger.debug(
-                "Local store lookup failed for GUID %r; trying Dapr",
-                ref.name,
-                exc_info=True,
-            )
-
-        # Fall back to DaprCredentialVault for platform-issued GUIDs.
+        # Fall back to DaprCredentialVault for platform-issued GUIDs. This
+        # always runs in production and as the final fallback in local-dev.
         from application_sdk.credentials.errors import CredentialNotFoundError
         from application_sdk.infrastructure import AsyncDaprClient, DaprCredentialVault
 

--- a/tests/unit/credentials/test_agent.py
+++ b/tests/unit/credentials/test_agent.py
@@ -690,13 +690,17 @@ class TestCredentialResolverAgentBranch:
         }
         assert resolved["extra"]["database"] == "real_pg_db"
 
-    async def test_resolve_raw_legacy_guid_ref_still_works(self) -> None:
+    async def test_resolve_raw_legacy_guid_ref_still_works(
+        self, monkeypatch
+    ) -> None:
         """Legacy GUID refs continue to resolve via the local secret
-        store path — agent branch is additive, not a replacement.
+        store path (local-dev only) — agent branch is additive, not a
+        replacement.
         """
         from application_sdk.credentials.ref import CredentialRef
         from application_sdk.credentials.resolver import CredentialResolver
 
+        monkeypatch.setenv("ATLAN_LOCAL_DEVELOPMENT", "true")
         store = _store_with(**{"my-guid-123": _bundle(username="real_user", host="h")})
         ref = CredentialRef.from_workflow_args(
             {"extraction_method": "direct", "credential_guid": "my-guid-123"}

--- a/tests/unit/credentials/test_resolver.py
+++ b/tests/unit/credentials/test_resolver.py
@@ -120,11 +120,14 @@ class TestGuidResolutionPath:
     credentials), then falls back to DaprCredentialVault for platform GUIDs.
     """
 
-    async def test_local_store_takes_precedence_over_vault(self, store, resolver):
-        """Inline credentials stored in the local secret store are resolved
-        directly — DaprCredentialVault is never called."""
+    async def test_local_store_takes_precedence_over_vault(
+        self, store, resolver, monkeypatch
+    ):
+        """In local-dev, inline credentials stored in the local secret store
+        are resolved directly — DaprCredentialVault is never called."""
         import json
 
+        monkeypatch.setenv("ATLAN_LOCAL_DEVELOPMENT", "true")
         store.set("guid-abc", json.dumps({"host": "local.example.com", "port": 5432}))
         ref = legacy_credential_ref("guid-abc")
         # No Dapr mock needed — local store should return before Dapr is reached.
@@ -132,6 +135,61 @@ class TestGuidResolutionPath:
 
         assert raw["host"] == "local.example.com"
         assert raw["port"] == 5432
+
+    async def test_prod_bypasses_secret_store_and_uses_vault(
+        self, store, resolver, monkeypatch
+    ):
+        """In prod (no ATLAN_LOCAL_DEVELOPMENT) the resolver MUST NOT call
+        secret_store.get — it goes straight to DaprCredentialVault so the
+        S3+Vault merge runs. Regression test for the partial-creds bug where
+        Vault returns only secrets and the resolver short-circuited, missing
+        host/port from the S3 config.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        monkeypatch.delenv("ATLAN_LOCAL_DEVELOPMENT", raising=False)
+
+        # Seed the secret store with a "partial" blob (what Dapr/Vault would
+        # actually return) — if the resolver reads this it'll lose host/port.
+        store.set(
+            "prod-guid",
+            json.dumps({"username": "u", "password": "p", "extra": {}}),
+        )
+        store_get_spy = AsyncMock(wraps=store.get)
+        store.get = store_get_spy  # type: ignore[method-assign]
+
+        full_merged = {
+            "host": "h.example.com",
+            "port": 443,
+            "username": "u",
+            "password": "p",
+            "extra": {},
+        }
+        p_vault, p_dapr, mock_vault = _make_vault_patches(vault_return=full_merged)
+        with p_vault, p_dapr:
+            ref = legacy_credential_ref("prod-guid")
+            raw = await resolver.resolve_raw(ref)
+
+        store_get_spy.assert_not_called()
+        mock_vault.get_credentials.assert_awaited_once_with("prod-guid")
+        assert raw["host"] == "h.example.com"
+        assert raw["port"] == 443
+
+    async def test_local_falls_through_to_vault_on_secret_store_miss(
+        self, store, resolver, monkeypatch
+    ):
+        """In local-dev, if the secret store has no entry for the GUID, the
+        resolver falls through to DaprCredentialVault."""
+        monkeypatch.setenv("ATLAN_LOCAL_DEVELOPMENT", "true")
+
+        expected = {"host": "vault.example.com", "port": 5432}
+        p_vault, p_dapr, mock_vault = _make_vault_patches(vault_return=expected)
+        with p_vault, p_dapr:
+            ref = legacy_credential_ref("missing-guid")
+            raw = await resolver.resolve_raw(ref)
+
+        assert raw == expected
+        mock_vault.get_credentials.assert_awaited_once_with("missing-guid")
 
     async def test_get_credentials_receives_string_not_dict(self, store, resolver):
         """Regression: resolver must pass the GUID as a plain string, not a dict."""

--- a/tests/unit/infrastructure/test_credential_state_store.py
+++ b/tests/unit/infrastructure/test_credential_state_store.py
@@ -86,14 +86,16 @@ class TestCredentialStateStoreRoundtrip:
 
         assert result["source"] == "state_store"
 
-    async def test_fallback_to_secret_store(self):
-        """Falls back to secret store when not in state store."""
+    async def test_fallback_to_secret_store(self, monkeypatch):
+        """In local-dev, falls back to secret store when not in state store."""
         from application_sdk.credentials.ref import CredentialRef
         from application_sdk.credentials.resolver import CredentialResolver
         from application_sdk.infrastructure.context import (
             InfrastructureContext,
             set_infrastructure,
         )
+
+        monkeypatch.setenv("ATLAN_LOCAL_DEVELOPMENT", "true")
 
         state_store = MockStateStore()
         secret_store = MockSecretStore()
@@ -110,8 +112,14 @@ class TestCredentialStateStoreRoundtrip:
 
         assert result["host"] == "from-secret"
 
-    async def test_resolver_skips_state_store_in_prod(self, monkeypatch):
-        """In non-local mode, resolver skips state store even if cred: key exists."""
+    async def test_resolver_skips_local_stores_in_prod(self, monkeypatch):
+        """In non-local mode, resolver skips BOTH state_store and secret_store
+        and goes straight to DaprCredentialVault, which merges S3 config +
+        Vault secrets. This prevents the bug where Vault-backed secret_store
+        returns only the secret-only blob (missing host/port).
+        """
+        from unittest.mock import AsyncMock, MagicMock, patch
+
         from application_sdk.credentials.ref import CredentialRef
         from application_sdk.credentials.resolver import CredentialResolver
         from application_sdk.infrastructure.context import (
@@ -127,18 +135,46 @@ class TestCredentialStateStoreRoundtrip:
         guid = "prod-guid"
         # Cred exists in state store but should NOT be read in prod
         await state_store.save(f"cred:{guid}", {"source": "state_store"})
-        # Secret store has the "real" credential
-        secret_store.set(guid, json.dumps({"source": "secret_store"}))
+        # Secret-only blob in secret_store (what Dapr/Vault would actually
+        # return) — must NOT be read either.
+        secret_store.set(guid, json.dumps({"username": "u", "password": "p"}))
 
         ctx = InfrastructureContext(state_store=state_store, secret_store=secret_store)
         set_infrastructure(ctx)
 
+        # Spy to assert secret_store.get is never awaited in prod.
+        secret_store.get = AsyncMock(wraps=secret_store.get)  # type: ignore[method-assign]
+
+        # Mock DaprCredentialVault — this is what actually serves prod GUIDs.
+        full_merged = {
+            "host": "h.example.com",
+            "port": 443,
+            "username": "u",
+            "password": "p",
+        }
+        mock_vault = MagicMock()
+        mock_vault.get_credentials = AsyncMock(return_value=full_merged)
+        mock_dapr = MagicMock()
+        mock_dapr.close = AsyncMock()
+
         resolver = CredentialResolver(secret_store=secret_store)
         ref = CredentialRef(name=guid, credential_type="unknown", credential_guid=guid)
-        result = await resolver.resolve_raw(ref)
 
-        # Secret store should win in prod — state store skipped
-        assert result["source"] == "secret_store"
+        with (
+            patch(
+                "application_sdk.infrastructure.DaprCredentialVault",
+                MagicMock(return_value=mock_vault),
+            ),
+            patch(
+                "application_sdk.infrastructure._dapr.http.AsyncDaprClient",
+                MagicMock(return_value=mock_dapr),
+            ),
+        ):
+            result = await resolver.resolve_raw(ref)
+
+        secret_store.get.assert_not_called()
+        mock_vault.get_credentials.assert_awaited_once_with(guid)
+        assert result == full_merged
 
 
 class TestLocalDevGuard:


### PR DESCRIPTION
## Summary

`CredentialResolver._resolve_by_guid` was unconditionally reading `self._secret_store.get(ref.name)` before falling back to `DaprCredentialVault`. In production `secret_store` is a `DaprSecretStore` backed by Vault, which returns only the secret-only blob (``{username, password, extra}``) for a GUID. ``json.loads`` parses that successfully, the resolver returns early, and the S3+Vault merge done inside `DaprCredentialVault.get_credentials()` is skipped. The resulting credential dict is missing non-secret fields such as ``host`` and ``port``, which breaks connectors.

Downstream symptom reported by the Looker app:

```
POST :19999/api/4.0/login
No connection adapters were found for ':19999/api/4.0/login'
```

(See background doc referenced in the Looker app repo: `docs/credential-resolution-issue.md`.)

## Fix

Gate the `self._secret_store.get` branch in `_resolve_by_guid` behind the same `ATLAN_LOCAL_DEVELOPMENT` env-var guard that already wraps the sibling `state_store` lookup. Both in-process stores are now local-dev-only; production always routes platform-issued GUIDs through `DaprCredentialVault` so the S3 (non-secret) + Vault (secret) merge always runs.

The intent of the short-circuit — supporting in-process inline creds written by `handler/service.py` in combined-mode / local dev — is preserved; it just no longer leaks into prod.

## Test plan

- [x] `uv run pytest tests/unit/credentials tests/unit/infrastructure tests/unit/templates tests/unit/handler -q` → 626 passed locally.
- [x] New regression test `test_prod_bypasses_secret_store_and_uses_vault` seeds the secret_store with a partial blob, asserts `secret_store.get` is never called and `DaprCredentialVault.get_credentials` is called exactly once.
- [x] New test `test_local_falls_through_to_vault_on_secret_store_miss` covers the local-dev fallthrough path.
- [x] Updated `test_local_store_takes_precedence_over_vault` and `test_resolve_raw_legacy_guid_ref_still_works` to set `ATLAN_LOCAL_DEVELOPMENT=true` (the new contract for the local-dev path).
- [x] Rewrote `test_resolver_skips_state_store_in_prod` → `test_resolver_skips_local_stores_in_prod` to assert the full new prod behavior (both state_store and secret_store skipped; DaprCredentialVault drives the resolution).

## Rollout

After this lands, the workaround in the Looker app (`app/looker.py::_resolve_credentials` calling `DaprCredentialVault` directly) can be reverted back to `CredentialResolver`.