### PR TITLE
fix: add trailing comma before inserting new dep in pyproject.toml

### DIFF
--- a/.github/workflows/auto-fix-vulnerabilities.yaml
+++ b/.github/workflows/auto-fix-vulnerabilities.yaml
@@ -247,6 +247,12 @@ jobs:
                               insert_idx = i
                               break
                       if insert_idx is not None:
+                          # Add trailing comma to the last dep if missing
+                          prev = insert_idx - 1
+                          while prev >= 0 and not lines[prev].strip():
+                              prev -= 1
+                          if prev >= 0 and lines[prev].strip().endswith('"') and not lines[prev].strip().endswith(','):
+                              lines[prev] = lines[prev].rstrip() + ','
                           lines.insert(insert_idx, f'    "{pkg}>={min_version}",')
                           with open("pyproject.toml", "w") as f:
                               f.write("\n".join(lines))


### PR DESCRIPTION
Fixes TOML parse error when last dependency in pyproject.toml has no trailing comma. Now adds comma to previous line before inserting the new dep.