### PR TITLE
feat(ci): validate base-allowlist expiry policy on PRs

### DIFF
--- a/.github/scripts/validate_allowlist.py
+++ b/.github/scripts/validate_allowlist.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Validate base-allowlist.json entries against the expiry policy.
+
+Rules enforced:
+  1. Every entry must have: package, severity, reason, expires, added_by
+  2. `expires` must be a valid YYYY-MM-DD date
+  3. `expires` must not already be in the past
+  4. `expires` must be within the max window for the entry's severity:
+       CRITICAL → _expiry_policy.CRITICAL days (default 30)
+       HIGH     → _expiry_policy.HIGH days     (default 60)
+
+The expiry policy is read from the `_expiry_policy` metadata key in the
+allowlist itself so the security team can adjust limits without touching code:
+
+  {
+    "_expiry_policy": { "CRITICAL": 30, "HIGH": 60 },
+    "CVE-2026-12345": { ... }
+  }
+"""
+
+import json
+import sys
+from datetime import datetime, timedelta
+
+ALLOWLIST_PATH = ".security/base-allowlist.json"
+DEFAULT_POLICY = {"CRITICAL": 30, "HIGH": 60}
+REQUIRED_FIELDS = ["package", "severity", "reason", "expires", "added_by"]
+
+
+def main() -> int:
+    try:
+        with open(ALLOWLIST_PATH) as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        print(f"No {ALLOWLIST_PATH} found — nothing to validate.")
+        return 0
+    except json.JSONDecodeError as e:
+        print(f"❌ {ALLOWLIST_PATH} is not valid JSON: {e}")
+        return 1
+
+    policy = {**DEFAULT_POLICY, **data.get("_expiry_policy", {})}
+    today = datetime.utcnow().date()
+    errors = []
+
+    entries = {k: v for k, v in data.items() if not k.startswith("_")}
+
+    for cve_id, entry in entries.items():
+        if not isinstance(entry, dict):
+            errors.append(f"{cve_id}: entry must be a JSON object")
+            continue
+
+        # 1. Required fields
+        missing = [f for f in REQUIRED_FIELDS if not entry.get(f)]
+        if missing:
+            errors.append(f"{cve_id}: missing required field(s): {', '.join(missing)}")
+            continue
+
+        severity = entry["severity"].upper()
+        expires_str = entry["expires"]
+
+        # 2. Valid date format
+        try:
+            exp_date = datetime.strptime(expires_str, "%Y-%m-%d").date()
+        except ValueError:
+            errors.append(
+                f"{cve_id}: invalid expires format '{expires_str}' — use YYYY-MM-DD"
+            )
+            continue
+
+        # 3. Not already expired
+        if exp_date < today:
+            errors.append(
+                f"{cve_id}: already expired ({expires_str}) — remove the entry or renew it"
+            )
+            continue
+
+        # 4. Within policy window
+        max_days = policy.get(severity)
+        if max_days is None:
+            errors.append(
+                f"{cve_id}: unknown severity '{severity}' — must be CRITICAL or HIGH"
+            )
+            continue
+
+        days_from_now = (exp_date - today).days
+        max_date = today + timedelta(days=max_days)
+
+        if exp_date > max_date:
+            errors.append(
+                f"{cve_id} ({severity}): expires {expires_str} is {days_from_now} days away "
+                f"— max allowed for {severity} is {max_days} days (by {max_date})"
+            )
+
+    if errors:
+        print(f"❌ Allowlist validation failed ({len(errors)} error(s)):\n")
+        for e in errors:
+            print(f"  • {e}")
+        print(
+            f"\nPolicy: CRITICAL ≤ {policy['CRITICAL']} days, HIGH ≤ {policy['HIGH']} days"
+            f"\nTo change limits, update '_expiry_policy' in {ALLOWLIST_PATH}."
+        )
+        return 1
+
+    print(
+        f"✅ Allowlist valid: {len(entries)} entr{'y' if len(entries) == 1 else 'ies'}, "
+        f"all within policy (CRITICAL ≤ {policy['CRITICAL']}d, HIGH ≤ {policy['HIGH']}d)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/validate-allowlist.yaml
+++ b/.github/workflows/validate-allowlist.yaml
@@ -1,0 +1,53 @@
+# Validate Allowlist — enforces expiry policy on base-allowlist.json entries.
+#
+# Triggers on every PR (no paths filter — required status checks must always
+# report a result, or PRs that don't touch .security/ would be permanently
+# blocked waiting for a status that never fires).
+#
+# The check exits early with success when the PR doesn't modify
+# .security/base-allowlist.json, so there's no noise on unrelated PRs.
+#
+# Rules (enforced by .github/scripts/validate_allowlist.py):
+#   - Required fields: package, severity, reason, expires, added_by
+#   - expires must be a valid YYYY-MM-DD date, not already past
+#   - CRITICAL entries: expires ≤ 30 days from today (configurable via _expiry_policy)
+#   - HIGH entries:     expires ≤ 60 days from today (configurable via _expiry_policy)
+#
+# Make "Allowlist Expiry Check" a required status check on main to enforce.
+#
+name: Allowlist Expiry Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  validate:
+    name: Allowlist Expiry Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Check if PR modifies base-allowlist.json
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+            const modified = files.some(f => f.filename === '.security/base-allowlist.json');
+            core.setOutput('modified', modified.toString());
+            if (!modified) {
+              console.log('base-allowlist.json not modified — skipping validation');
+            }
+
+      - name: Checkout
+        if: steps.check.outputs.modified == 'true'
+        uses: actions/checkout@v4
+
+      - name: Validate allowlist expiry policy
+        if: steps.check.outputs.modified == 'true'
+        run: python3 .github/scripts/validate_allowlist.py


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow + Python script that enforces severity-based expiry windows on `base-allowlist.json` entries. Runs on every PR; exits early when the PR doesn't touch the allowlist.

## What's enforced

| Severity | Max window | Configurable via |
|---|---|---|
| CRITICAL | 30 days | `_expiry_policy.CRITICAL` in the allowlist |
| HIGH | 60 days | `_expiry_policy.HIGH` in the allowlist |

**Required fields on every entry:** `package`, `severity`, `reason`, `expires`, `added_by`

If any of these are missing, the check fails — so someone can't accidentally add an entry without an expiry date.

## Policy configuration

The limits live in the allowlist itself under `_expiry_policy`, so the security team can adjust them without touching code:

```json
{
  "_expiry_policy": { "CRITICAL": 30, "HIGH": 60 },
  "CVE-2026-XXXXX": { ... }
}
```

## Files

- `.github/scripts/validate_allowlist.py` — validation logic (runs locally too: `python3 .github/scripts/validate_allowlist.py`)
- `.github/workflows/validate-allowlist.yaml` — workflow that calls the script on PRs

## After merging

Make **`Allowlist Expiry Check`** a required status check on `main` branch protection.

## Known issue — existing entries

Running the script against the current `base-allowlist.json` shows 24 failures because the existing entries were added with 60–90 day windows before this policy was established. These need to be updated separately (shorter `expires` dates). Tracked as a follow-up to this PR.