### PR TITLE
ci(docker): make GHCR builds immutable — SHA tags only, no :latest or version tags

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -24,6 +24,7 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
       lowercase_branch: ${{ steps.get_lowercase_branch.outputs.lowercase_branch }}
       repository_name: ${{ steps.get_repo_name.outputs.repository_name }}
+      sha: ${{ steps.get_sha.outputs.sha }}
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -46,6 +47,10 @@ jobs:
         run: echo "lowercase_branch=$(echo '${{ steps.get_branch.outputs.branch }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
         id: get_lowercase_branch
 
+      - name: Get short SHA
+        id: get_sha
+        run: echo "sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
   push-to-ghcr:
     runs-on: ubuntu-latest
     needs: prepare
@@ -60,17 +65,17 @@ jobs:
 
       - name: Set up Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to GitHub Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
-          username: $GITHUB_ACTOR
+          username: ${{ github.actor }}
           password: ${{ secrets.ORG_PAT_GITHUB }}
 
       - name: Log in to Chainguard Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: cgr.dev
           username: ${{ secrets.CHAINGUARD_USERNAME }}
@@ -91,10 +96,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/atlanhq/app-runtime-base-${{ needs.prepare.outputs.lowercase_branch }}:latest
-            ghcr.io/atlanhq/app-runtime-base-${{ needs.prepare.outputs.lowercase_branch }}:${{ needs.prepare.outputs.version }}
-            ghcr.io/atlanhq/${{ github.event.repository.name }}-${{ needs.prepare.outputs.lowercase_branch }}:latest
-            ghcr.io/atlanhq/${{ github.event.repository.name }}-${{ needs.prepare.outputs.lowercase_branch }}:${{ needs.prepare.outputs.version }}
+            ghcr.io/atlanhq/app-runtime-base-${{ needs.prepare.outputs.lowercase_branch }}:sha-${{ needs.prepare.outputs.sha }}
+            ghcr.io/atlanhq/${{ github.event.repository.name }}-${{ needs.prepare.outputs.lowercase_branch }}:sha-${{ needs.prepare.outputs.sha }}
           build-args: |
             ACCESS_TOKEN_USR=$GITHUB_ACTOR
             ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -20,10 +20,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
-      branch: ${{ steps.get_branch.outputs.branch }}
-      version: ${{ steps.get_version.outputs.version }}
       lowercase_branch: ${{ steps.get_lowercase_branch.outputs.lowercase_branch }}
-      repository_name: ${{ steps.get_repo_name.outputs.repository_name }}
       sha: ${{ steps.get_sha.outputs.sha }}
     steps:
       - uses: actions/checkout@v6.0.2
@@ -31,25 +28,17 @@ jobs:
           fetch-depth: 0
 
       - name: Get branch name
-        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
         id: get_branch
 
-      - name: Get repository name
-        run: echo "repository_name=`echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}' | sed -e "s/:refs//"`" >> $GITHUB_OUTPUT
-        id: get_repo_name
-        shell: bash
-
-      - name: Get version from pyproject.toml
-        run: echo "version=$(awk -F'"' '/^version = / {print $2}' pyproject.toml)" >> $GITHUB_OUTPUT
-        id: get_version
-
       - name: Lowercase branch name
-        run: echo "lowercase_branch=$(echo '${{ steps.get_branch.outputs.branch }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+        run: echo "lowercase_branch=$(echo '${{ steps.get_branch.outputs.branch }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
         id: get_lowercase_branch
 
       - name: Get short SHA
         id: get_sha
-        run: echo "sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+        shell: bash
+        run: echo "sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
   push-to-ghcr:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -97,7 +97,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/atlanhq/app-runtime-base-${{ needs.prepare.outputs.lowercase_branch }}:sha-${{ needs.prepare.outputs.sha }}
-            ghcr.io/atlanhq/${{ github.event.repository.name }}-${{ needs.prepare.outputs.lowercase_branch }}:sha-${{ needs.prepare.outputs.sha }}
           build-args: |
             ACCESS_TOKEN_USR=$GITHUB_ACTOR
             ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}

--- a/.github/workflows/harbor-release.yaml
+++ b/.github/workflows/harbor-release.yaml
@@ -75,29 +75,19 @@ jobs:
               "registry.atlan.com/public/app-runtime-base:${VERSION}" \
               "registry.atlan.com/public/app-runtime-base:${MINOR}" \
               "registry.atlan.com/public/app-runtime-base:${MAJOR}" \
-              "registry.atlan.com/public/app-runtime-base:sha-${SHA}" \
-              "registry.atlan.com/public/application-sdk:latest" \
-              "registry.atlan.com/public/application-sdk:${VERSION}" \
-              "registry.atlan.com/public/application-sdk:${MINOR}" \
-              "registry.atlan.com/public/application-sdk:${MAJOR}" \
-              "registry.atlan.com/public/application-sdk:sha-${SHA}" > /tmp/tags.txt
+              "registry.atlan.com/public/app-runtime-base:sha-${SHA}" > /tmp/tags.txt
           elif [ "$EVENT_NAME" = "release" ]; then
             # Pre-release (rc/alpha/beta): exact version + sha only — no aliases that could
             # cause :latest or major/minor tags to point at a non-stable image
             printf '%s\n' \
               "registry.atlan.com/public/app-runtime-base:${VERSION}" \
-              "registry.atlan.com/public/app-runtime-base:sha-${SHA}" \
-              "registry.atlan.com/public/application-sdk:${VERSION}" \
-              "registry.atlan.com/public/application-sdk:sha-${SHA}" > /tmp/tags.txt
+              "registry.atlan.com/public/app-runtime-base:sha-${SHA}" > /tmp/tags.txt
           else
             # workflow_dispatch: prefix-scoped tags for branch/dev builds
             printf '%s\n' \
               "registry.atlan.com/public/app-runtime-base:${PREFIX}-latest" \
               "registry.atlan.com/public/app-runtime-base:${PREFIX}-${VERSION}" \
-              "registry.atlan.com/public/app-runtime-base:sha-${SHA}" \
-              "registry.atlan.com/public/application-sdk:${PREFIX}-latest" \
-              "registry.atlan.com/public/application-sdk:${PREFIX}-${VERSION}" \
-              "registry.atlan.com/public/application-sdk:sha-${SHA}" > /tmp/tags.txt
+              "registry.atlan.com/public/app-runtime-base:sha-${SHA}" > /tmp/tags.txt
           fi
           DELIM=$(openssl rand -hex 8)
           { echo "value<<${DELIM}"; cat /tmp/tags.txt; echo "${DELIM}"; } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/harbor-release.yaml
+++ b/.github/workflows/harbor-release.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Set up Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Compute tag prefix
         id: tag_prefix
@@ -35,8 +35,8 @@ jobs:
           TAG_PREFIX_INPUT: ${{ inputs.tag_prefix }}
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
-            # Release builds always use 'main' to preserve existing tag names
-            # (main-latest, main-<version>) and keep the Snyk import gate working.
+            # Release builds use 'main' as the branch label for the Snyk import gate.
+            # Actual image tags are computed separately in the 'Compute image tags' step.
             echo "value=main" >> "$GITHUB_OUTPUT"
           elif [ -n "${TAG_PREFIX_INPUT:-}" ]; then
             if ! printf '%s' "$TAG_PREFIX_INPUT" | grep -Eq '^[A-Za-z0-9._-]+$'; then
@@ -58,15 +58,59 @@ jobs:
         id: get_sha
         run: echo "sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
+      - name: Compute image tags
+        id: image_tags
+        env:
+          VERSION: ${{ steps.get_version.outputs.version }}
+          PREFIX: ${{ steps.tag_prefix.outputs.value }}
+          SHA: ${{ steps.get_sha.outputs.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f1-2)
+          if [ "$EVENT_NAME" = "release" ] && echo "$VERSION" | grep -qvF '-'; then
+            # Stable release: publish full alias ladder (exact, minor, major, latest) + immutable sha
+            printf '%s\n' \
+              "registry.atlan.com/public/app-runtime-base:latest" \
+              "registry.atlan.com/public/app-runtime-base:${VERSION}" \
+              "registry.atlan.com/public/app-runtime-base:${MINOR}" \
+              "registry.atlan.com/public/app-runtime-base:${MAJOR}" \
+              "registry.atlan.com/public/app-runtime-base:sha-${SHA}" \
+              "registry.atlan.com/public/application-sdk:latest" \
+              "registry.atlan.com/public/application-sdk:${VERSION}" \
+              "registry.atlan.com/public/application-sdk:${MINOR}" \
+              "registry.atlan.com/public/application-sdk:${MAJOR}" \
+              "registry.atlan.com/public/application-sdk:sha-${SHA}" > /tmp/tags.txt
+          elif [ "$EVENT_NAME" = "release" ]; then
+            # Pre-release (rc/alpha/beta): exact version + sha only — no aliases that could
+            # cause :latest or major/minor tags to point at a non-stable image
+            printf '%s\n' \
+              "registry.atlan.com/public/app-runtime-base:${VERSION}" \
+              "registry.atlan.com/public/app-runtime-base:sha-${SHA}" \
+              "registry.atlan.com/public/application-sdk:${VERSION}" \
+              "registry.atlan.com/public/application-sdk:sha-${SHA}" > /tmp/tags.txt
+          else
+            # workflow_dispatch: prefix-scoped tags for branch/dev builds
+            printf '%s\n' \
+              "registry.atlan.com/public/app-runtime-base:${PREFIX}-latest" \
+              "registry.atlan.com/public/app-runtime-base:${PREFIX}-${VERSION}" \
+              "registry.atlan.com/public/app-runtime-base:sha-${SHA}" \
+              "registry.atlan.com/public/application-sdk:${PREFIX}-latest" \
+              "registry.atlan.com/public/application-sdk:${PREFIX}-${VERSION}" \
+              "registry.atlan.com/public/application-sdk:sha-${SHA}" > /tmp/tags.txt
+          fi
+          DELIM=$(openssl rand -hex 8)
+          { echo "value<<${DELIM}"; cat /tmp/tags.txt; echo "${DELIM}"; } >> "$GITHUB_OUTPUT"
+
       - name: Log in to Atlan Harbor Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: registry.atlan.com
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_PASSWORD }}
 
       - name: Log in to Chainguard Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: cgr.dev
           username: ${{ secrets.CHAINGUARD_USERNAME }}
@@ -86,13 +130,7 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: |
-            registry.atlan.com/public/app-runtime-base:${{ steps.tag_prefix.outputs.value }}-latest
-            registry.atlan.com/public/app-runtime-base:${{ steps.tag_prefix.outputs.value }}-${{ steps.get_version.outputs.version }}
-            registry.atlan.com/public/app-runtime-base:sha-${{ steps.get_sha.outputs.sha }}
-            registry.atlan.com/public/application-sdk:${{ steps.tag_prefix.outputs.value }}-latest
-            registry.atlan.com/public/application-sdk:${{ steps.tag_prefix.outputs.value }}-${{ steps.get_version.outputs.version }}
-            registry.atlan.com/public/application-sdk:sha-${{ steps.get_sha.outputs.sha }}
+          tags: ${{ steps.image_tags.outputs.value }}
           build-args: |
             ACCESS_TOKEN_USR=$GITHUB_ACTOR
             ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}

--- a/.github/workflows/harbor-release.yaml
+++ b/.github/workflows/harbor-release.yaml
@@ -52,11 +52,11 @@ jobs:
 
       - name: Get SDK version
         id: get_version
-        run: echo "version=$(awk -F'"' '/^version = / {print $2}' pyproject.toml)" >> $GITHUB_OUTPUT
+        run: echo "version=$(awk -F'"' '/^version = / {print $2}' pyproject.toml)" >> "$GITHUB_OUTPUT"
 
       - name: Get short commit SHA
         id: get_sha
-        run: echo "sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+        run: echo "sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Compute image tags
         id: image_tags


### PR DESCRIPTION
## Summary

- **GHCR is now CI/dev-only** — every push to \`main\` produces a single immutable \`sha-<7char>\` tag; no \`:latest\` or version tags
- **Harbor owns all release tags** — \`registry.atlan.com\` is the only registry that publishes \`:latest\`, version, and alias tags, gated on GitHub release events
- **Semver alias ladder** — stable releases now publish four tags per version so consumers can pin at their preferred stability level
- **\`application-sdk\` image retired** — it was always identical to \`app-runtime-base\` (same Dockerfile, same build step); the duplicate push is removed

## Background

\`build-image.yaml\` was publishing version-specific tags (e.g. \`:2.8.7\`, \`:3.0.0\`) on every push to \`main\` that touched \`Dockerfile\`, \`pyproject.toml\`, \`uv.lock\`, or \`entrypoint.sh\`. This made version tags **mutable** — each triggered push overwrote them with whatever code happened to be on \`main\` at that moment.

When the version-bump PR for \`3.0.0\` merged, it touched \`pyproject.toml\` + \`uv.lock\`, triggered \`build-image.yaml\`, and pushed images tagged \`:3.0.0\` **and** moved \`:latest\` — clobbering the previously stable \`2.8.7\` \`:latest\` pointer.

## Tag behaviour after this PR

### GHCR (`ghcr.io/atlanhq/app-runtime-base-main`) — CI/dev only

| Tag | Mutable? | Set by |
|---|---|---|
| \`sha-<7char>\` | No | Every push to \`main\` |

### Harbor (`registry.atlan.com/public/app-runtime-base`) — production

| Tag | Mutable? | Set by |
|---|---|---|
| \`:latest\` | Yes | Stable release only |
| \`:3.0.0\` | No | Stable release only |
| \`:3.0\` | Yes — rolls on patch releases | Stable release only |
| \`:3\` | Yes — rolls on minor + patch releases | Stable release only |
| \`sha-<7char>\` | No | Every release |

Pre-releases (\`rc\`, \`alpha\`, \`beta\`) get only the exact version tag + \`sha-*\` — \`:latest\` and the major/minor aliases are never pointed at a non-stable image.

\`workflow_dispatch\` builds (branch dev builds) continue to use the existing \`<prefix>-latest\` / \`<prefix>-<version>\` format.

## Changes

- \`build-image.yaml\`: tags reduced to \`sha-<7char>\` only; removes \`:latest\` and \`:<version>\`; removes duplicate \`application-sdk\` image push
- \`harbor-release.yaml\`: adds semver alias ladder (\`:X.Y.Z\`, \`:X.Y\`, \`:X\`, \`:latest\`); handles pre-releases (exact tag only); removes duplicate \`application-sdk\` image push; drops \`main-\` prefix from version tags
- Both workflows: \`docker/setup-buildx-action\` and \`docker/login-action\` pinned to SHA (supply chain hardening)
- \`build-image.yaml\`: GHCR login \`username\` corrected from unexpanded \`\$GITHUB_ACTOR\` to \`\${{ github.actor }}\`

## Migration inventory

Connectors still referencing the retired \`application-sdk\` image name or sourcing from \`ghcr.io\` are tracked in:
- BLDX-1074 — migrate \`application-sdk\` → \`app-runtime-base\`
- BLDX-1075 — migrate \`ghcr.io\` → \`registry.atlan.com\`

## Test plan

- [ ] Next push to \`main\` produces only \`sha-*\` tags on GHCR — no \`:latest\`, no version tags
- [ ] Next stable release publishes \`:X.Y.Z\`, \`:X.Y\`, \`:X\`, \`:latest\`, \`sha-*\` on Harbor; no \`application-sdk\` image
- [ ] Next pre-release publishes only \`:X.Y.Z-rc.N\` + \`sha-*\` on Harbor — \`:latest\` and aliases unchanged
- [ ] \`workflow_dispatch\` build still produces \`<prefix>-latest\` / \`<prefix>-<version>\` on Harbor

🤖 Generated with [Claude Code](https://claude.com/claude-code)