### PR TITLE
fix: Snyk applications section was hardcoded to source_type=app

### DIFF
--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -209,7 +209,7 @@ jobs:
                                   "installed": vuln.get("version", ""),
                                   "fixed": ", ".join(vuln.get("fixedIn", [])) if vuln.get("fixedIn") else "",
                                   "scanner": "snyk",
-                                  "source_type": "app",
+                                  "source_type": "base_image" if vid in base_ids else "app",
                                   "status": status,
                               })
           except FileNotFoundError:


### PR DESCRIPTION
The Snyk 'applications' section always set source_type to 'app', even for Go packages in the base allowlist. Now checks base_ids before defaulting to app.