### PR TITLE
docs: add v3 readiness checklist for app owners

### DIFF
--- a/.github/workflows/v3-readiness-check.yaml
+++ b/.github/workflows/v3-readiness-check.yaml
@@ -1,0 +1,213 @@
+name: v3 Readiness Check
+
+# Runs docs/standards/v3-readiness.md against an external app repo.
+#
+# Usage (manual):
+#   GitHub UI → Actions → "v3 Readiness Check" → Run workflow, supply:
+#     app_repo = atlanhq/atlan-openapi-app   (or full https://github.com/... URL)
+#     branch   = main                        (any ref — branch, tag, or SHA)
+#
+# Usage (from another workflow):
+#   jobs:
+#     check:
+#       uses: atlanhq/application-sdk/.github/workflows/v3-readiness-check.yaml@main
+#       with:
+#         app_repo: atlanhq/atlan-openapi-app
+#         branch: main
+#       secrets:
+#         app_repo_token: ${{ secrets.APP_REPO_READ_TOKEN }}
+#
+# Secret requirements:
+#   APP_REPO_READ_TOKEN — PAT (or GitHub App installation token) with
+#   `contents: read` access to the target app repo. Required for private
+#   repos; public repos can pass GITHUB_TOKEN instead.
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_repo:
+        description: "App repo (e.g. atlanhq/atlan-openapi-app or full github.com URL)"
+        required: true
+        type: string
+      branch:
+        description: "Branch, tag, or SHA to check"
+        required: true
+        type: string
+        default: main
+  workflow_call:
+    inputs:
+      app_repo:
+        required: true
+        type: string
+      branch:
+        required: true
+        type: string
+    secrets:
+      app_repo_token:
+        description: "Token with contents:read on the target repo"
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: v3-readiness-${{ inputs.app_repo }}-${{ inputs.branch }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: ${{ inputs.app_repo }}@${{ inputs.branch }}
+    runs-on: ubuntu-latest
+    steps:
+      # --------------------------------------------------------------------
+      # Normalize inputs — accept "owner/repo", "https://github.com/owner/repo",
+      # or "...owner/repo.git" and reduce to canonical "owner/repo".
+      # --------------------------------------------------------------------
+      - name: Parse app_repo
+        id: parse
+        env:
+          RAW_APP_REPO: ${{ inputs.app_repo }}
+        run: |
+          set -euo pipefail
+          raw="$RAW_APP_REPO"
+          repo="${raw#https://github.com/}"
+          repo="${repo#http://github.com/}"
+          repo="${repo%.git}"
+          repo="${repo%/}"
+          if [[ ! "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+            echo "::error::app_repo must be 'owner/repo' or a github.com URL; got '$raw'"
+            exit 1
+          fi
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+          echo "Checking v3 readiness for $repo @ ${{ inputs.branch }}"
+
+      - name: Checkout application-sdk (this repo)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: sdk
+
+      - name: Checkout target app
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ steps.parse.outputs.repo }}
+          ref: ${{ inputs.branch }}
+          token: ${{ secrets.app_repo_token || secrets.GITHUB_TOKEN }}
+          path: app
+          fetch-depth: 1
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install application-sdk
+        working-directory: sdk
+        run: uv sync --all-extras --all-groups
+
+      # --------------------------------------------------------------------
+      # §1 — static check
+      # --------------------------------------------------------------------
+      - name: "§1 Static check — tools.migrate_v3.check_migration"
+        id: static
+        working-directory: sdk
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/report"
+          report="$RUNNER_TEMP/report/check_migration.txt"
+          if uv run python -m tools.migrate_v3.check_migration --no-color ../app | tee "$report"; then
+            echo "result=pass" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=fail" >> "$GITHUB_OUTPUT"
+            echo "::error::check_migration reported FAILs — see the uploaded report artifact"
+            exit 1
+          fi
+
+      # --------------------------------------------------------------------
+      # §1 — SDK pin must be ==3.0.0 (extras OK; [tool.uv.sources] OK)
+      # --------------------------------------------------------------------
+      - name: "§1 SDK pin — atlan-application-sdk[...]==3.0.0"
+        working-directory: app
+        run: |
+          set -euo pipefail
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::error::app repo has no pyproject.toml at root"
+            exit 1
+          fi
+          if ! grep -E '^[^#]*\batlan-application-sdk[^"'\'' ]*==[[:space:]]*3\.0\.0\b' pyproject.toml; then
+            echo "::error::pyproject.toml must pin atlan-application-sdk[...]==3.0.0 (exact version)"
+            echo "Found atlan-application-sdk entries:"
+            grep -n atlan-application-sdk pyproject.toml || true
+            exit 1
+          fi
+
+      # --------------------------------------------------------------------
+      # §3 — Dockerfile base image must be app-runtime-base:3.0.0 (when present)
+      # --------------------------------------------------------------------
+      - name: "§3 Dockerfile base — app-runtime-base:3.0.0"
+        working-directory: app
+        run: |
+          set -euo pipefail
+          if [[ ! -f Dockerfile ]]; then
+            echo "No Dockerfile — skipping §3 check"
+            exit 0
+          fi
+          if ! grep -E '^FROM[[:space:]]+registry\.atlan\.com/public/app-runtime-base:3\.0\.0[[:space:]]*$' Dockerfile; then
+            echo "::error::Dockerfile must 'FROM registry.atlan.com/public/app-runtime-base:3.0.0' (exact tag)"
+            grep -n '^FROM' Dockerfile || true
+            exit 1
+          fi
+
+      # --------------------------------------------------------------------
+      # §2 — contract drift (only when the app ships a PKL contract)
+      # --------------------------------------------------------------------
+      - name: "§2 Contract drift — poe generate must be a no-op"
+        working-directory: app
+        run: |
+          set -euo pipefail
+          if [[ ! -f contract/app.pkl ]]; then
+            echo "No contract/app.pkl — skipping §2 check"
+            exit 0
+          fi
+          if ! uv run --project . poe --help >/dev/null 2>&1; then
+            echo "::warning::'poe' task runner not available in app — cannot run drift check"
+            exit 0
+          fi
+          uv run --project . poe generate || {
+            echo "::error::'poe generate' failed"
+            exit 1
+          }
+          if ! git -C . diff --exit-code -- contract/generated/ app/contracts/_input.py; then
+            echo "::error::contract/generated artifacts are stale — run 'poe generate' locally and commit"
+            exit 1
+          fi
+
+      # --------------------------------------------------------------------
+      # Step summary + artifact upload
+      # --------------------------------------------------------------------
+      - name: Write step summary
+        if: always()
+        working-directory: sdk
+        run: |
+          {
+            echo "# v3 Readiness — ${{ steps.parse.outputs.repo }}@${{ inputs.branch }}"
+            echo ""
+            echo "Checklist: [docs/standards/v3-readiness.md](./docs/standards/v3-readiness.md)"
+            echo ""
+            echo "## check_migration output"
+            echo ""
+            echo '```'
+            cat "$RUNNER_TEMP/report/check_migration.txt" 2>/dev/null || echo "(no report)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: v3-readiness-report
+          path: ${{ runner.temp }}/report/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/v3-readiness-check.yaml
+++ b/.github/workflows/v3-readiness-check.yaml
@@ -160,6 +160,23 @@ jobs:
             exit 1
           fi
 
+      - name: "§3 Dockerfile entry — no CMD/ENTRYPOINT override"
+        working-directory: app
+        run: |
+          set -euo pipefail
+          if [[ ! -f Dockerfile ]]; then
+            exit 0
+          fi
+          # Ignore comments; detect real CMD / ENTRYPOINT instructions only.
+          if grep -Ein '^[[:space:]]*(CMD|ENTRYPOINT)[[:space:]]' Dockerfile; then
+            echo "::error::Dockerfile must NOT override CMD or ENTRYPOINT — the base image's entrypoint launches the SDK CLI and co-runs daprd with graceful-shutdown handling"
+            exit 1
+          fi
+          if ! grep -Eq '^[[:space:]]*ENV[[:space:]]+ATLAN_APP_MODULE\b' Dockerfile; then
+            echo "::error::Dockerfile must set 'ENV ATLAN_APP_MODULE=<module>:<AppClass>' so the base entrypoint knows what to load"
+            exit 1
+          fi
+
       # --------------------------------------------------------------------
       # §2 — contract drift (only when the app ships a PKL contract)
       # --------------------------------------------------------------------

--- a/.github/workflows/v3-readiness-check.yaml
+++ b/.github/workflows/v3-readiness-check.yaml
@@ -179,8 +179,8 @@ jobs:
             echo "::error::'poe generate' failed"
             exit 1
           }
-          if ! git -C . diff --exit-code -- contract/generated/ app/contracts/_input.py; then
-            echo "::error::contract/generated artifacts are stale — run 'poe generate' locally and commit"
+          if ! git -C . diff --exit-code -- app/generated/; then
+            echo "::error::app/generated artifacts are stale — run 'poe generate' locally and commit"
             exit 1
           fi
 

--- a/docs/standards/v3-readiness.md
+++ b/docs/standards/v3-readiness.md
@@ -90,6 +90,8 @@ E2E coverage is **not** limited to the happy path. Every user-observable scenari
 
 App owners and CI run these commands against the app repo. All must exit 0 for the app to be v3-ready.
 
+**One-click runner:** the SDK ships a GitHub Action at [`.github/workflows/v3-readiness-check.yaml`](../../.github/workflows/v3-readiness-check.yaml). Trigger it from the application-sdk repo's Actions tab with two inputs — `app_repo` (e.g. `atlanhq/atlan-openapi-app` or a full GitHub URL) and `branch` — and it runs §5.1 — §5.2 plus the §1 SDK pin and §3 Dockerfile base-image checks against the target ref, writes a summary, and uploads the `check_migration` report as an artifact. Private app repos require an `APP_REPO_READ_TOKEN` repo secret with `contents: read` on the target.
+
 ### 5.1 Static check (mandatory)
 
 ```bash

--- a/docs/standards/v3-readiness.md
+++ b/docs/standards/v3-readiness.md
@@ -16,7 +16,14 @@ An app is **v3-ready** when every item below is either ✅ (done) or ➖ (not ap
 
 Each item corresponds to a `FAIL`/`WARN` rule in `tools/migrate_v3/check_migration.py`. Run the checker (see §5) and fix every `FAIL` before continuing.
 
-- [ ] **SDK pin** — `pyproject.toml` depends on `atlan-application-sdk>=3.0.0,<4.0.0` from PyPI. No `[tool.uv.sources]` git override to a dev branch (e.g. `refactor-v3`, `main`).
+- [ ] **SDK version `3.0.0` or newer** — `pyproject.toml` must declare
+  ```toml
+  [project]
+  dependencies = [
+      "atlan-application-sdk>=3.0.0,<4.0.0",
+  ]
+  ```
+  Resolved from PyPI — **no** `[tool.uv.sources]` git override pointing at a branch (e.g. `main`, `refactor-v3`). Verify with `uv tree | grep atlan-application-sdk` and confirm the resolved version is `3.0.0+`.
 - [ ] **No deprecated imports** — no `application_sdk.{application,worker,workflows,activities,handlers,services,interceptors,test_utils}` or `application_sdk.clients.{atlan,temporal,workflow}` anywhere (including tests). Rewrite with `python -m tools.migrate_v3.rewrite_imports`.
 - [ ] **App subclass** — exactly one class inherits from `App` (or a template: `SqlMetadataExtractor`, `IncrementalSqlMetadataExtractor`, `SqlQueryExtractor`, `BaseMetadataExtractor`). Class-level `name: ClassVar[str]` is set.
 - [ ] **`@task` only** — no `@workflow.defn`, `@activity.defn`, `@auto_heartbeater` decorators. No `workflow.execute_activity_method()` calls. No `from temporalio import workflow / activity` in app code.
@@ -60,14 +67,23 @@ The SDK ships test doubles in `application_sdk.testing.mocks` (`MockSecretStore`
 - [ ] **Credential registration** — import the app's credentials module and assert `CredentialTypeRegistry().get_class("<type>")` is not None.
 - [ ] **Deterministic `run()`** — verify the orchestrator is free of non-determinism (no `datetime.now`, `uuid4`, `random`, direct I/O). This is enforced by Temporal at runtime; a unit test that imports the module under Temporal's sandbox (`WorkflowEnvironment`) catches regressions.
 
-### Integration / E2E tests (at least one must pass in CI)
+### Integration / E2E tests (must cover every supported scenario)
+
+E2E coverage is **not** limited to the happy path. Every user-observable scenario the app supports must have a dedicated end-to-end test that drives it through `run_dev_combined` (or a full container) and asserts the final artifact / HTTP response — not just intermediate function returns. A scenario is "supported" if it appears in the workflow form, the handler's `test_auth`/`preflight_check` surface, the Dockerfile, or any branch of `run()`.
 
 - [ ] **Boot probe** — start the app via `run_dev_combined` in-process (or as a subprocess) and confirm:
   - `GET /health` returns 200
   - `GET /manifest` returns the committed `contract/generated/manifest.json` verbatim
   - `GET /workflows/v1/configmap/{name}` returns the committed workflow config
 - [ ] **Golden contract drift** — re-run `poe generate` in CI and `git diff --exit-code contract/generated/ app/contracts/_input.py` must be clean.
-- [ ] **Happy-path workflow** — `POST /workflows/v1/start` with a minimal valid payload drives the workflow to completion against a fake/mock source; assert the NDJSON artifact uploaded to `MockObjectStore` matches the expected schema.
+- [ ] **Scenario matrix** — one E2E test per supported scenario. Each drives `POST /workflows/v1/start` with a realistic payload and asserts the final outcome (NDJSON artifacts, uploaded object-store keys, publish-app state, response codes). Cover at minimum:
+  - Happy path for every `import_type` / extraction mode the app exposes (e.g. URL vs CLOUD, full vs incremental, agent vs GUID credentials).
+  - Each credential / auth flow the `Handler.test_auth` accepts (success and failure).
+  - Each entry in `preflight_check` (success and each failure mode the UI can render).
+  - Every explicit branch in `run()` — e.g. `connection_usage=CREATE` vs `REUSE`, `load_to_atlan=True` vs `False`, empty-result short-circuit, retryable vs non-retryable task failures.
+  - Error / edge cases the app is expected to handle: invalid spec, empty source, network timeout, missing credential, downstream publish-app failure. Each must produce a deterministic, user-facing outcome (workflow fails cleanly, error propagates, logs include correlation ID).
+  - Multi-tenant isolation (if applicable): two tenants running concurrently never see each other's artifacts or state.
+- [ ] **Scenario coverage matrix in the repo** — `tests/e2e/README.md` (or equivalent) lists each scenario above and the test that covers it. Reviewers use this table to confirm coverage is complete; missing rows block v3-readiness.
 - [ ] **Replay test** — at least one workflow uses `TestWorkflowEnvironment` + a pinned history JSON to prove determinism across SDK upgrades.
 
 ## 5 — SDK-triggered validation
@@ -130,7 +146,7 @@ Paste this into the description of the PR that declares an app v3-ready. Reviewe
 ## v3-readiness sign-off (docs/standards/v3-readiness.md)
 
 ### App shape (§1)
-- [ ] SDK pin is `atlan-application-sdk>=3.0.0,<4.0.0` from PyPI, no git override
+- [ ] `pyproject.toml` resolves `atlan-application-sdk>=3.0.0,<4.0.0` from PyPI, no git override (`uv tree` shows a 3.x resolution)
 - [ ] `python -m tools.migrate_v3.check_migration` reports zero FAILs
 - [ ] One `App` subclass, `@task`-only, typed Input/Output at every boundary
 
@@ -144,7 +160,8 @@ Paste this into the description of the PR that declares an app v3-ready. Reviewe
 
 ### Tests (§4)
 - [ ] Unit tests cover App instantiation, every `@task`, and contract round-trips
-- [ ] At least one integration test boots the app and verifies `/health`, `/manifest`, happy-path workflow
+- [ ] E2E scenario matrix documented (`tests/e2e/README.md`) and **every listed scenario has a passing E2E test** — happy path + each branch of `run()` + each `Handler` flow + error/edge cases + multi-tenant isolation
+- [ ] Boot probe verifies `/health`, `/manifest`, and `/workflows/v1/configmap/{name}` match committed artifacts
 - [ ] Replay test pinned for every workflow that runs in production
 
 ### SDK-triggered checks (§5)

--- a/docs/standards/v3-readiness.md
+++ b/docs/standards/v3-readiness.md
@@ -54,7 +54,20 @@ The SDK generates workflow/credential/manifest/input artifacts from a single `co
   No `*-latest` tags, no dev-branch tags (e.g. `refactor-v3-latest`), no other `app-runtime-base` image. Bump this pin in lockstep with the SDK `>=3.0.0,<4.0.0` major version.
 - [ ] **Non-root `appuser`** runs the app process.
 - [ ] **No secrets in build layers** — credentials resolved at runtime via Dapr / `SecretStore`.
-- [ ] **Container entry** runs the SDK CLI (`application-sdk --mode combined` via `ATLAN_APP_MODULE`), not a custom asyncio bootstrap.
+- [ ] **No `ENTRYPOINT` / `CMD` override** — the app Dockerfile inherits the base image's entrypoint (`/usr/local/bin/entrypoint.sh`, which launches `python -m application_sdk.main` and co-runs `daprd` with graceful-shutdown handling). The app only needs `ENV ATLAN_APP_MODULE=<module>:<AppClass>`; the runtime mode (`worker`/`handler`/`combined`) is supplied by Helm via `ATLAN_APP_MODE`.
+
+  ❌ Do not do this — it bypasses daprd co-launch and graceful shutdown:
+  ```dockerfile
+  CMD ["python", "main.py"]
+  ENTRYPOINT ["uv", "run", "application-sdk"]
+  ```
+
+  ✅ Correct — inherit everything from the base image:
+  ```dockerfile
+  FROM registry.atlan.com/public/app-runtime-base:3.0.0
+  ENV ATLAN_APP_MODULE=app.connector:OpenAPIConnector
+  # (no CMD or ENTRYPOINT)
+  ```
 
 ## 4 — Tests that must pass
 
@@ -160,7 +173,7 @@ Paste this into the description of the PR that declares an app v3-ready. Reviewe
 
 ### Deployment (§3)
 - [ ] Dockerfile `FROM registry.atlan.com/public/app-runtime-base:3.0.0` (exact tag)
-- [ ] Container entry uses `application-sdk --mode combined`
+- [ ] No `CMD`/`ENTRYPOINT` override; `ENV ATLAN_APP_MODULE` set; mode comes from `ATLAN_APP_MODE` at runtime
 
 ### Tests (§4)
 - [ ] Unit tests cover App instantiation, every `@task`, and contract round-trips

--- a/docs/standards/v3-readiness.md
+++ b/docs/standards/v3-readiness.md
@@ -37,8 +37,10 @@ Each item corresponds to a `FAIL`/`WARN` rule in `tools/migrate_v3/check_migrati
 
 The SDK generates workflow/credential/manifest/input artifacts from a single `contract/app.pkl`. See [`.claude/skills/contract/SKILL.md`](../../.claude/skills/contract/SKILL.md).
 
+> **Output directory is `app/generated/`**, importable as `app.generated`. The SDK reads it via `ATLAN_CONTRACT_GENERATED_DIR` (default defined in [`application_sdk/constants.py`](../../application_sdk/constants.py) as `app/generated`). If an app writes generated artifacts elsewhere, either set `ATLAN_CONTRACT_GENERATED_DIR` to match or (preferred) point `poe generate` at `app/generated/` so the runtime finds them without extra config.
+
 - [ ] **`contract/app.pkl`** exists and is the source of truth for the app's metadata, credentials, and workflow form.
-- [ ] **Generated artifacts are committed** — `contract/generated/{name}.json`, `atlan-connectors-{name}.json`, `manifest.json` and `app/contracts/_input.py` are present.
+- [ ] **Generated artifacts are committed** — `app/generated/{name}.json`, `atlan-connectors-{name}.json`, `manifest.json` and `app/generated/_input.py` are present.
 - [ ] **`poe generate` task wired** in `pyproject.toml` and produces no diff on a clean checkout (i.e. generated files are not stale).
 - [ ] **`PklProject.deps.json`** lockfile committed.
 - [ ] **No stale overrides** — `app/templates/`, `get_configmap()` / `get_manifest()` handler overrides are removed; the SDK auto-serves generated artifacts.
@@ -73,9 +75,9 @@ E2E coverage is **not** limited to the happy path. Every user-observable scenari
 
 - [ ] **Boot probe** — start the app via `run_dev_combined` in-process (or as a subprocess) and confirm:
   - `GET /health` returns 200
-  - `GET /manifest` returns the committed `contract/generated/manifest.json` verbatim
+  - `GET /manifest` returns the committed `app/generated/manifest.json` verbatim
   - `GET /workflows/v1/configmap/{name}` returns the committed workflow config
-- [ ] **Golden contract drift** — re-run `poe generate` in CI and `git diff --exit-code contract/generated/ app/contracts/_input.py` must be clean.
+- [ ] **Golden contract drift** — re-run `poe generate` in CI and `git diff --exit-code app/generated/ app/generated/_input.py` must be clean.
 - [ ] **Scenario matrix** — one E2E test per supported scenario. Each drives `POST /workflows/v1/start` with a realistic payload and asserts the final outcome (NDJSON artifacts, uploaded object-store keys, publish-app state, response codes). Cover at minimum:
   - Happy path for every `import_type` / extraction mode the app exposes (e.g. URL vs CLOUD, full vs incremental, agent vs GUID credentials).
   - Each credential / auth flow the `Handler.test_auth` accepts (success and failure).
@@ -108,7 +110,7 @@ Wire this into CI (GitHub Actions job, pre-commit hook, or `poe check-v3`) so re
 
 ```bash
 uv run poe generate
-git diff --exit-code contract/generated/ app/contracts/_input.py
+git diff --exit-code app/generated/ app/generated/_input.py
 ```
 
 Non-zero exit = generated artifacts are stale relative to `contract/app.pkl`. Regenerate and commit.
@@ -125,7 +127,7 @@ trap "kill $APP_PID" EXIT
 until curl -sf http://127.0.0.1:8000/health; do sleep 1; done
 
 # Fetch manifest + configmaps and diff against committed artifacts
-curl -sf http://127.0.0.1:8000/manifest | diff - contract/generated/manifest.json
+curl -sf http://127.0.0.1:8000/manifest | diff - app/generated/manifest.json
 ```
 
 Mismatches mean the SDK serves something different from what the repo committed — a readiness failure.

--- a/docs/standards/v3-readiness.md
+++ b/docs/standards/v3-readiness.md
@@ -16,14 +16,14 @@ An app is **v3-ready** when every item below is either ✅ (done) or ➖ (not ap
 
 Each item corresponds to a `FAIL`/`WARN` rule in `tools/migrate_v3/check_migration.py`. Run the checker (see §5) and fix every `FAIL` before continuing.
 
-- [ ] **SDK version `3.0.0` or newer** — `pyproject.toml` must declare
+- [ ] **SDK pinned to `==3.0.0`** — `pyproject.toml` must pin the exact version (optionally with extras):
   ```toml
   [project]
   dependencies = [
-      "atlan-application-sdk>=3.0.0,<4.0.0",
+      "atlan-application-sdk[workflows]==3.0.0",
   ]
   ```
-  Resolved from PyPI — **no** `[tool.uv.sources]` git override pointing at a branch (e.g. `main`, `refactor-v3`). Verify with `uv tree | grep atlan-application-sdk` and confirm the resolved version is `3.0.0+`.
+  `[tool.uv.sources]` overrides **are allowed** (e.g. to resolve from a git ref or an internal mirror) — the constraint is on the resolved version, not the source. Verify with `uv tree | grep atlan-application-sdk` and confirm the resolved version is exactly `3.0.0`.
 - [ ] **No deprecated imports** — no `application_sdk.{application,worker,workflows,activities,handlers,services,interceptors,test_utils}` or `application_sdk.clients.{atlan,temporal,workflow}` anywhere (including tests). Rewrite with `python -m tools.migrate_v3.rewrite_imports`.
 - [ ] **App subclass** — exactly one class inherits from `App` (or a template: `SqlMetadataExtractor`, `IncrementalSqlMetadataExtractor`, `SqlQueryExtractor`, `BaseMetadataExtractor`). Class-level `name: ClassVar[str]` is set.
 - [ ] **`@task` only** — no `@workflow.defn`, `@activity.defn`, `@auto_heartbeater` decorators. No `workflow.execute_activity_method()` calls. No `from temporalio import workflow / activity` in app code.
@@ -146,7 +146,7 @@ Paste this into the description of the PR that declares an app v3-ready. Reviewe
 ## v3-readiness sign-off (docs/standards/v3-readiness.md)
 
 ### App shape (§1)
-- [ ] `pyproject.toml` resolves `atlan-application-sdk>=3.0.0,<4.0.0` from PyPI, no git override (`uv tree` shows a 3.x resolution)
+- [ ] `pyproject.toml` pins `atlan-application-sdk[...]==3.0.0` (exact version); `uv tree` confirms the resolved version is `3.0.0` (any source allowed — `[tool.uv.sources]` OK)
 - [ ] `python -m tools.migrate_v3.check_migration` reports zero FAILs
 - [ ] One `App` subclass, `@task`-only, typed Input/Output at every boundary
 

--- a/docs/standards/v3-readiness.md
+++ b/docs/standards/v3-readiness.md
@@ -1,0 +1,154 @@
+# v3 Readiness Checklist
+
+Use this page to decide whether an application-sdk-based app is ready to ship on v3.
+
+It complements three existing resources:
+
+- [`upgrade-guide-v3.md`](../upgrade-guide-v3.md) — the canonical v2 → v3 how-to with before/after code.
+- [`whats-new-v3.md`](../whats-new-v3.md) — the conceptual rationale for the changes.
+- [`tools/migrate_v3/check_migration.py`](../../tools/migrate_v3/check_migration.py) — the static checker that enforces most of §1 automatically.
+
+An app is **v3-ready** when every item below is either ✅ (done) or ➖ (not applicable to this app). A single ❌ blocks the v3 cutover.
+
+---
+
+## 1 — App shape
+
+Each item corresponds to a `FAIL`/`WARN` rule in `tools/migrate_v3/check_migration.py`. Run the checker (see §5) and fix every `FAIL` before continuing.
+
+- [ ] **SDK pin** — `pyproject.toml` depends on `atlan-application-sdk>=3.0.0,<4.0.0` from PyPI. No `[tool.uv.sources]` git override to a dev branch (e.g. `refactor-v3`, `main`).
+- [ ] **No deprecated imports** — no `application_sdk.{application,worker,workflows,activities,handlers,services,interceptors,test_utils}` or `application_sdk.clients.{atlan,temporal,workflow}` anywhere (including tests). Rewrite with `python -m tools.migrate_v3.rewrite_imports`.
+- [ ] **App subclass** — exactly one class inherits from `App` (or a template: `SqlMetadataExtractor`, `IncrementalSqlMetadataExtractor`, `SqlQueryExtractor`, `BaseMetadataExtractor`). Class-level `name: ClassVar[str]` is set.
+- [ ] **`@task` only** — no `@workflow.defn`, `@activity.defn`, `@auto_heartbeater` decorators. No `workflow.execute_activity_method()` calls. No `from temporalio import workflow / activity` in app code.
+- [ ] **Typed contracts** — every `@task` parameter and return value is a subclass of `application_sdk.app.Input` / `Output`. No `Dict[str, Any]` / `dict[str, Any]` at contract boundaries. No `allow_unbounded_fields=True`.
+- [ ] **Handler signatures** — if a `Handler` subclass exists, `test_auth`, `preflight_check`, and `fetch_metadata` use typed `Input` contracts — not `*args`/`**kwargs`.
+- [ ] **Async clients** — no sync `get_client()`. Use `create_async_atlan_client()` with an `AtlanApiToken` credential.
+- [ ] **Entry point** — dev uses `run_dev_combined(...)`; containers invoke the `application-sdk --mode combined` CLI (usually via `ATLAN_APP_MODULE`). No `BaseApplication(...)`.
+- [ ] **No direct infrastructure** — no `DaprClient()`, `self._state`, or raw `loguru`/`logging.getLogger()` in app code. Go through `self.context.*` and `application_sdk.observability.logger_adaptor.get_logger()`.
+
+## 2 — Contract & config
+
+The SDK generates workflow/credential/manifest/input artifacts from a single `contract/app.pkl`. See [`.claude/skills/contract/SKILL.md`](../../.claude/skills/contract/SKILL.md).
+
+- [ ] **`contract/app.pkl`** exists and is the source of truth for the app's metadata, credentials, and workflow form.
+- [ ] **Generated artifacts are committed** — `contract/generated/{name}.json`, `atlan-connectors-{name}.json`, `manifest.json` and `app/contracts/_input.py` are present.
+- [ ] **`poe generate` task wired** in `pyproject.toml` and produces no diff on a clean checkout (i.e. generated files are not stale).
+- [ ] **`PklProject.deps.json`** lockfile committed.
+- [ ] **No stale overrides** — `app/templates/`, `get_configmap()` / `get_manifest()` handler overrides are removed; the SDK auto-serves generated artifacts.
+
+## 3 — Dockerfile & deployment
+
+- [ ] **Base image is `app-runtime-base:3.0.0`** — the Dockerfile must pin to
+  ```dockerfile
+  FROM registry.atlan.com/public/app-runtime-base:3.0.0
+  ```
+  No `*-latest` tags, no dev-branch tags (e.g. `refactor-v3-latest`), no other `app-runtime-base` image. Bump this pin in lockstep with the SDK `>=3.0.0,<4.0.0` major version.
+- [ ] **Non-root `appuser`** runs the app process.
+- [ ] **No secrets in build layers** — credentials resolved at runtime via Dapr / `SecretStore`.
+- [ ] **Container entry** runs the SDK CLI (`application-sdk --mode combined` via `ATLAN_APP_MODULE`), not a custom asyncio bootstrap.
+
+## 4 — Tests that must pass
+
+The SDK ships test doubles in `application_sdk.testing.mocks` (`MockSecretStore`, `MockStateStore`, `MockPubSub`, …) so unit tests run without Dapr or Temporal.
+
+### Unit tests (must exist; must all pass)
+
+- [ ] **App instantiation** — construct the `App` subclass with `MockSecretStore({...})` + `MockStateStore()` and assert `context.app_name` / `context.run_id` are populated.
+- [ ] **Each `@task` method** — at least one happy-path test per `@task`, invoked with a typed `Input` and asserting the typed `Output`. Use `app.run_in_thread` only where the real implementation does.
+- [ ] **Contract serialization** — round-trip every `Input`/`Output` through `model_dump()` + `model_validate()` to catch unbounded fields and ensure Temporal-safe payloads (<2 MB).
+- [ ] **Handler methods** — if the app exposes a `Handler`, cover `test_auth`, `preflight_check`, and `fetch_metadata` with typed inputs and mocked credentials.
+- [ ] **Credential registration** — import the app's credentials module and assert `CredentialTypeRegistry().get_class("<type>")` is not None.
+- [ ] **Deterministic `run()`** — verify the orchestrator is free of non-determinism (no `datetime.now`, `uuid4`, `random`, direct I/O). This is enforced by Temporal at runtime; a unit test that imports the module under Temporal's sandbox (`WorkflowEnvironment`) catches regressions.
+
+### Integration / E2E tests (at least one must pass in CI)
+
+- [ ] **Boot probe** — start the app via `run_dev_combined` in-process (or as a subprocess) and confirm:
+  - `GET /health` returns 200
+  - `GET /manifest` returns the committed `contract/generated/manifest.json` verbatim
+  - `GET /workflows/v1/configmap/{name}` returns the committed workflow config
+- [ ] **Golden contract drift** — re-run `poe generate` in CI and `git diff --exit-code contract/generated/ app/contracts/_input.py` must be clean.
+- [ ] **Happy-path workflow** — `POST /workflows/v1/start` with a minimal valid payload drives the workflow to completion against a fake/mock source; assert the NDJSON artifact uploaded to `MockObjectStore` matches the expected schema.
+- [ ] **Replay test** — at least one workflow uses `TestWorkflowEnvironment` + a pinned history JSON to prove determinism across SDK upgrades.
+
+## 5 — SDK-triggered validation
+
+App owners and CI run these commands against the app repo. All must exit 0 for the app to be v3-ready.
+
+### 5.1 Static check (mandatory)
+
+```bash
+uv run python -m tools.migrate_v3.check_migration --no-color <path-to-app-src>
+```
+
+- **Exit 0** — all `FAIL` rules pass. `WARN` rules may remain but should be reviewed.
+- **Exit 1** — one or more `FAIL`s. Read the report; fix before re-running.
+- **Exit 2** — usage/argument error.
+
+Wire this into CI (GitHub Actions job, pre-commit hook, or `poe check-v3`) so regressions are blocked at PR time.
+
+### 5.2 Contract drift check (mandatory)
+
+```bash
+uv run poe generate
+git diff --exit-code contract/generated/ app/contracts/_input.py
+```
+
+Non-zero exit = generated artifacts are stale relative to `contract/app.pkl`. Regenerate and commit.
+
+### 5.3 Boot probe (recommended)
+
+```bash
+# From the app repo root, in a scratch environment:
+uv run python -m app.run_dev &
+APP_PID=$!
+trap "kill $APP_PID" EXIT
+
+# Poll /health for up to 30s
+until curl -sf http://127.0.0.1:8000/health; do sleep 1; done
+
+# Fetch manifest + configmaps and diff against committed artifacts
+curl -sf http://127.0.0.1:8000/manifest | diff - contract/generated/manifest.json
+```
+
+Mismatches mean the SDK serves something different from what the repo committed — a readiness failure.
+
+### 5.4 Test suite (mandatory)
+
+```bash
+uv run pytest tests/unit tests/integration
+```
+
+Unit tests must pass without Dapr or Temporal running. Integration tests may spin up the dev Temporal + Dapr stack via `uv run poe start-deps`.
+
+---
+
+## PR sign-off block
+
+Paste this into the description of the PR that declares an app v3-ready. Reviewers check each box.
+
+```markdown
+## v3-readiness sign-off (docs/standards/v3-readiness.md)
+
+### App shape (§1)
+- [ ] SDK pin is `atlan-application-sdk>=3.0.0,<4.0.0` from PyPI, no git override
+- [ ] `python -m tools.migrate_v3.check_migration` reports zero FAILs
+- [ ] One `App` subclass, `@task`-only, typed Input/Output at every boundary
+
+### Contract (§2)
+- [ ] `contract/app.pkl` + generated artifacts committed
+- [ ] `poe generate` produces no diff on a clean checkout
+
+### Deployment (§3)
+- [ ] Dockerfile `FROM registry.atlan.com/public/app-runtime-base:3.0.0` (exact tag)
+- [ ] Container entry uses `application-sdk --mode combined`
+
+### Tests (§4)
+- [ ] Unit tests cover App instantiation, every `@task`, and contract round-trips
+- [ ] At least one integration test boots the app and verifies `/health`, `/manifest`, happy-path workflow
+- [ ] Replay test pinned for every workflow that runs in production
+
+### SDK-triggered checks (§5)
+- [ ] `check_migration` exit 0 (CI job)
+- [ ] Contract drift check exit 0 (CI job)
+- [ ] `pytest tests/unit tests/integration` exit 0 (CI job)
+```

--- a/docs/upgrade-guide-v3.md
+++ b/docs/upgrade-guide-v3.md
@@ -8,6 +8,8 @@ Application SDK v3.0 introduces three major improvements:
 
 v3.0 is a clean break from v2. All v2 modules and APIs have been removed — there is no deprecation shim or compatibility layer. Update all imports to their v3 equivalents using the quick reference below.
 
+> **Shipping an app?** Run through [`standards/v3-readiness.md`](standards/v3-readiness.md) before declaring the upgrade complete — it's the sign-off checklist for app owners and reviewers.
+
 ---
 
 ## Quick Reference

--- a/docs/whats-new-v3.md
+++ b/docs/whats-new-v3.md
@@ -5,6 +5,7 @@ If you know v2 well, this guide will orient you quickly — it explains *what* c
 and shows each change side-by-side.
 
 > For a step-by-step upgrade checklist, see [`upgrade-guide-v3.md`](upgrade-guide-v3.md).
+> For the ship-it sign-off checklist, see [`standards/v3-readiness.md`](standards/v3-readiness.md).
 > For automated tooling, see [`tools/migrate_v3/`](../tools/migrate_v3/README.md).
 
 ---


### PR DESCRIPTION
## Summary

Adds `docs/standards/v3-readiness.md` — a single sign-off checklist that tells an app owner (and a reviewer) whether a connector/app is actually ready to ship on v3.

The SDK already ships the static checker (`tools/migrate_v3/check_migration.py`), the upgrade how-to (`docs/upgrade-guide-v3.md`), and the conceptual overview (`docs/whats-new-v3.md`). What was missing was a consolidated *"ready to cut over?"* page — one place that enumerates what the app should have, which tests must pass, and what the SDK can automate in CI.

## What the checklist covers

1. **App shape (§1)** — mirrors the `FAIL`/`WARN` rules in `check_migration.py`: SDK pin (`atlan-application-sdk>=3.0.0,<4.0.0`, no git override), no deprecated imports, one `App` subclass, `@task`-only, typed `Input`/`Output` contracts, typed `Handler` signatures, async clients, `run_dev_combined` / CLI entry, no raw Dapr / loguru.
2. **Contract & config (§2)** — `contract/app.pkl` + committed `contract/generated/*` + `app/contracts/_input.py`; `poe generate` must be a no-op on a clean checkout.
3. **Dockerfile (§3)** — **`FROM registry.atlan.com/public/app-runtime-base:3.0.0`** (exact tag, no `*-latest`, no dev-branch tags), non-root `appuser`, SDK CLI as container entry.
4. **Required tests (§4)** —
   - **Unit:** App instantiation with `MockSecretStore`/`MockStateStore`; one happy-path per `@task`; contract round-trip; `Handler` method coverage; credential-registry registration.
   - **Integration/E2E:** boot probe (`/health`, `/manifest`, `/workflows/v1/configmap/{name}`); contract-drift check; happy-path workflow; at least one replay test with `TestWorkflowEnvironment`.
5. **SDK-triggered validation (§5)** — the exact commands an app owner or a CI job runs, with exit-code expectations:
   - `python -m tools.migrate_v3.check_migration` (static, mandatory)
   - `poe generate && git diff --exit-code contract/generated/ app/contracts/_input.py` (drift, mandatory)
   - Boot probe via `run_dev_combined` + `curl /health` + `diff` against committed manifest (recommended)
   - `pytest tests/unit tests/integration` (mandatory)

The page ends with a copy-pasta PR sign-off block reviewers can tick through when an app PR declares v3-readiness.

## Why the Dockerfile pin is called out explicitly

`app-runtime-base:refactor-v3-latest` and similar dev-branch tags still exist in some connector repos. The checklist pins the exact tag (`3.0.0`) so reviewers don't have to interpret "concrete version" — it's a grep-able requirement, and a future `4.x` bump updates one number in one file.

## Discoverability

Added a one-line pointer from both `docs/upgrade-guide-v3.md` and `docs/whats-new-v3.md` so anyone starting the upgrade naturally lands on this page.

## Test plan

- [ ] Links in the new doc resolve (`upgrade-guide-v3.md`, `whats-new-v3.md`, `tools/migrate_v3/check_migration.py`, `.claude/skills/contract/SKILL.md`)
- [ ] Pick an existing connector (e.g., `atlan-openapi-app`) and walk through the checklist to confirm each item is answerable from the repo state alone
- [ ] Confirm the `check_migration` exit-code expectations match the current implementation