### PR TITLE
fix(ci): v3-readiness pulls APP_REPO_READ_TOKEN on workflow_dispatch

### DIFF
--- a/.github/workflows/v3-readiness-check.yaml
+++ b/.github/workflows/v3-readiness-check.yaml
@@ -91,7 +91,11 @@ jobs:
         with:
           repository: ${{ steps.parse.outputs.repo }}
           ref: ${{ inputs.branch }}
-          token: ${{ secrets.app_repo_token || secrets.GITHUB_TOKEN }}
+          # Token fallback chain:
+          #   1. secrets.app_repo_token — passed by workflow_call callers
+          #   2. secrets.APP_REPO_READ_TOKEN — repo secret, used on workflow_dispatch
+          #   3. secrets.GITHUB_TOKEN — only works for public targets
+          token: ${{ secrets.app_repo_token || secrets.APP_REPO_READ_TOKEN || secrets.GITHUB_TOKEN }}
           path: app
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary

The `v3-readiness-check` workflow's token fallback only referenced `secrets.app_repo_token` (the `workflow_call` alias) and `GITHUB_TOKEN`. Manual dispatches never populated `app_repo_token`, so private-repo checkouts always fell through to `GITHUB_TOKEN` and failed with `repository not found`.

Extend the fallback chain to pick up `APP_REPO_READ_TOKEN` — the repo secret operators set for cross-repo read access on manual dispatches.

```yaml
token: ${{ secrets.app_repo_token || secrets.APP_REPO_READ_TOKEN || secrets.GITHUB_TOKEN }}
```

## Test plan

- [ ] Re-dispatch against `atlanhq/atlan-openapi-app@main` — target checkout step succeeds (run 24701887845 was the failing baseline)
- [ ] Full pipeline runs: static check + SDK pin + Dockerfile base + Dockerfile entry + contract drift