### PR TITLE
fix(security): remove internal error details from 500 response [BLDX-1081]

### DIFF
--- a/application_sdk/server/fastapi/utils.py
+++ b/application_sdk/server/fastapi/utils.py
@@ -34,12 +34,16 @@ def internal_server_error_handler(_, exc: Exception) -> JSONResponse:
             - error (str): A generic error message
             - details (str): The string representation of the exception
     """
+    from application_sdk.observability.logger_adaptor import get_logger
+
+    logger = get_logger(__name__)
+    logger.error("Internal server error: %s", exc, exc_info=True)
+
     return JSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         content={
             "success": False,
             "error": "An internal error has occurred.",
-            "details": str(exc),
         },
     )
 

--- a/application_sdk/server/fastapi/utils.py
+++ b/application_sdk/server/fastapi/utils.py
@@ -14,6 +14,7 @@ from typing import Optional
 from fastapi import UploadFile, status
 from fastapi.responses import JSONResponse
 
+from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.server.fastapi.models import FileUploadResponse
 from application_sdk.storage.batch import upload_file_from_bytes
 
@@ -32,10 +33,7 @@ def internal_server_error_handler(_, exc: Exception) -> JSONResponse:
         JSONResponse: A formatted error response with the following structure:
             - success (bool): Always False for errors
             - error (str): A generic error message
-            - details (str): The string representation of the exception
     """
-    from application_sdk.observability.logger_adaptor import get_logger
-
     logger = get_logger(__name__)
     logger.error("Internal server error: %s", exc, exc_info=True)
 

--- a/tests/unit/server/fastapi/test_fastapi_utils.py
+++ b/tests/unit/server/fastapi/test_fastapi_utils.py
@@ -15,6 +15,28 @@ from application_sdk.server.fastapi.utils import (
 )
 
 
+class TestInternalServerErrorHandler:
+    """Test cases for internal_server_error_handler."""
+
+    def test_does_not_leak_exception_details(self):
+        """Regression test: 500 handler must not expose internal error details to clients."""
+        from application_sdk.server.fastapi.utils import internal_server_error_handler
+
+        sensitive_exc = Exception(
+            "OperationalError: connection to host 10.0.1.42:5432 failed: "
+            "password authentication failed for user 'admin'"
+        )
+        response = internal_server_error_handler(None, sensitive_exc)
+        import json as _json
+
+        body = _json.loads(response.body)
+        assert response.status_code == 500
+        assert body["success"] is False
+        assert "10.0.1.42" not in body.get("details", "")
+        assert "password" not in body.get("details", "")
+        assert body["error"] == "An internal error has occurred."
+
+
 class TestResolveExtension:
     """Test cases for _resolve_extension helper."""
 

--- a/tests/unit/server/fastapi/test_fastapi_utils.py
+++ b/tests/unit/server/fastapi/test_fastapi_utils.py
@@ -27,9 +27,7 @@ class TestInternalServerErrorHandler:
             "password authentication failed for user 'admin'"
         )
         response = internal_server_error_handler(None, sensitive_exc)
-        import json as _json
-
-        body = _json.loads(response.body)
+        body = json.loads(response.body)
         assert response.status_code == 500
         assert body["success"] is False
         assert "10.0.1.42" not in body.get("details", "")


### PR DESCRIPTION
## What was found

**Rule:** SEC-ERROR-DISCLOSURE
**File:** `application_sdk/server/fastapi/utils.py:42`
**Severity:** HIGH

The `internal_server_error_handler` returns `str(exc)` as the `details` field in 500 JSON responses. Exception strings can contain internal file paths, SQL queries, connection strings with hostnames/ports, and infrastructure details.

## Why it matters

Information disclosure helps attackers map internal architecture. Even within a cluster network, this violates defense-in-depth.

## What was fixed

- Removed the `details` field from the 500 error response
- Added server-side logging with `exc_info=True` for debugging
- Response now returns only `{"success": false, "error": "An internal error has occurred."}`

## TDD Evidence

- Test: `TestInternalServerErrorHandler::test_does_not_leak_exception_details`
- Test fails without fix: YES (sensitive IP and password in response)
- Test passes with fix: YES

## Linear

https://linear.app/atlan-epd/issue/BLDX-1081