### PR TITLE
fix(file_converter): check converter existence before calling [BLDX-1084]

### DIFF
--- a/application_sdk/common/file_converter.py
+++ b/application_sdk/common/file_converter.py
@@ -55,14 +55,13 @@ async def convert_data_files(
     input_file_type = input_file_paths[0].split(".")[-1]
     convert_file = ConvertFile(f"{input_file_type}_to_{output_file_type.value}")
     converter_func = file_converter_registry.registry.get(convert_file)
-    converted_files = []
-    try:
-        for file in input_file_paths:
-            converted_file = converter_func(file)
-            if converted_file:
-                converted_files.append(converted_file)
-    except KeyError:
+    if converter_func is None:
         raise ValueError(f"No converter found for file type: {convert_file}")
+    converted_files = []
+    for file in input_file_paths:
+        converted_file = converter_func(file)
+        if converted_file:
+            converted_files.append(converted_file)
 
     return converted_files
 

--- a/tests/unit/common/test_file_converter.py
+++ b/tests/unit/common/test_file_converter.py
@@ -131,14 +131,14 @@ class TestConvertDataFiles:
     @pytest.mark.asyncio
     @patch("application_sdk.common.file_converter.file_converter_registry")
     async def test_converter_not_found_error(self, mock_registry):
-        """Test that when converter function is None, AttributeError is raised."""
+        """Test that when converter function is None, ValueError is raised."""
         # Arrange - registry returns None for unknown converter
         mock_registry.registry.get.return_value = None
 
         input_files = ["/path/input.json"]
 
-        # Act & Assert - This should raise AttributeError when trying to call None
-        with pytest.raises(TypeError):  # calling None() raises TypeError
+        # Act & Assert - Should raise ValueError with descriptive message
+        with pytest.raises(ValueError, match="No converter found"):
             await convert_data_files(input_files, FileType.PARQUET)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What was found

**Rule:** BUG-013
**File:** `application_sdk/common/file_converter.py:61`
**Severity:** MEDIUM

`registry.get(convert_file)` returns `None` when not found. Calling `None()` raised `TypeError`, but `except KeyError` never caught it. The descriptive error message was unreachable dead code.

## What was fixed

- Added explicit `if converter_func is None` check before the loop
- Removed the dead `except KeyError` block
- Updated test to expect `ValueError` with descriptive message instead of `TypeError`

## TDD Evidence

- Test: `test_converter_not_found_error` — now expects `ValueError(match="No converter found")`
- Test fails without fix: YES (raises TypeError)
- Test passes with fix: YES

## Linear

https://linear.app/atlan-epd/issue/BLDX-1084