### PR TITLE
feat(dapr): use orjson for pub/sub serialization [BLDX-1090]

### DIFF
--- a/application_sdk/infrastructure/_dapr/client.py
+++ b/application_sdk/infrastructure/_dapr/client.py
@@ -244,7 +244,7 @@ class DaprPubSub:
             await self._client.publish_event(
                 pubsub_name=self._pubsub_name,
                 topic=topic,
-                data=json.dumps(data),
+                data=orjson.dumps(data).decode(),
                 metadata=metadata or {},
             )
         except Exception as e:

--- a/tests/unit/infrastructure/test_dapr_wrappers.py
+++ b/tests/unit/infrastructure/test_dapr_wrappers.py
@@ -4,7 +4,6 @@ import json
 from unittest.mock import AsyncMock, MagicMock
 
 import orjson
-
 import pytest
 
 from application_sdk.infrastructure._dapr.client import (

--- a/tests/unit/infrastructure/test_dapr_wrappers.py
+++ b/tests/unit/infrastructure/test_dapr_wrappers.py
@@ -3,6 +3,8 @@
 import json
 from unittest.mock import AsyncMock, MagicMock
 
+import orjson
+
 import pytest
 
 from application_sdk.infrastructure._dapr.client import (
@@ -181,7 +183,7 @@ class TestDaprPubSub:
         self.client.publish_event.assert_awaited_once_with(
             pubsub_name="mypubsub",
             topic="orders",
-            data=json.dumps(data),
+            data=orjson.dumps(data).decode(),
             metadata={},
         )
 
@@ -192,7 +194,7 @@ class TestDaprPubSub:
         self.client.publish_event.assert_awaited_once_with(
             pubsub_name="mypubsub",
             topic="orders",
-            data=json.dumps(data),
+            data=orjson.dumps(data).decode(),
             metadata=meta,
         )
 


### PR DESCRIPTION
## What was found

**Rule:** PERF-008
**File:** `application_sdk/infrastructure/_dapr/client.py:247`

`DaprPubSub.publish()` used `json.dumps(data)` while `orjson` was already imported and used elsewhere in the same file (line 159).

## What was fixed

Replaced `json.dumps(data)` with `orjson.dumps(data).decode()` — consistent with the rest of the module.

## Validation

- [x] Pre-commit passes
- [x] pyright clean
- Category (performance) does not require new tests per policy
- Existing tests verified: ALL PASSING

## Linear

https://linear.app/atlan-epd/issue/BLDX-1090