### PR TITLE
chore(sdk-evolution): add missing config.yaml (retro-002)

### DIFF
--- a/.claude/skills/sdk-evolution/config.yaml
+++ b/.claude/skills/sdk-evolution/config.yaml
@@ -1,0 +1,32 @@
+# Autonomous SDK Evolution — Pipeline Configuration
+# Referenced by SKILL.md stages throughout the pipeline.
+
+pipeline:
+  max_prs_per_run: 10
+
+models:
+  primary: opus      # Claude Opus 4.6 — used for discovery agents 1,3,5,7,8
+  secondary: sonnet  # Claude Sonnet 4.6 (or GPT-5 via LiteLLM when available) — agents 2,4,6,9,10
+
+linear:
+  project: "App SDK v3.0"
+  milestone: "Autonomous SDK Evolution"
+  team: "Builder Experience"
+
+priority_map:
+  critical: 1   # Urgent
+  high: 2       # High
+  medium: 3     # Normal
+  low: 4        # Low
+
+pr_strategy:
+  individual:
+    - bug
+    - architecture
+    - security
+    - performance
+  grouped:
+    - code-quality
+    - test-quality
+    - documentation
+    - v2-patterns


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/sdk-evolution/config.yaml` — the pipeline configuration file referenced throughout SKILL.md but never created

## Context

Retrospective finding retro-002 from the 2026-04-20 SDK Evolution run identified that `config.yaml` is referenced in Stages 1.3, 6.2, and 5.4 of the pipeline but never existed. This caused the pipeline to use hardcoded defaults.

Generated by Autonomous SDK Evolution (self-improvement from 2026-04-20 run)