### PR TITLE
fix: delete stale data.json from S3 dashboard

### DIFF
--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -283,4 +283,7 @@ jobs:
               "s3://kryptonite-store/${{ inputs.dashboard_path }}/index.html"
           fi
 
+          # Remove stale legacy data.json (replaced by per-repo files in repos/)
+          aws s3 rm "s3://kryptonite-store/${{ inputs.dashboard_path }}/data.json" 2>/dev/null || true
+
           echo "Dashboard updated at https://k.atlan.dev/${{ inputs.dashboard_path }}/"


### PR DESCRIPTION
Old data.json from before the per-repo file migration is still on S3 with stale source_type labels. Dashboard falls back to it when repos/ directory listing doesn't work on Kryptonite. This deletes it on every deploy.