### PR TITLE
fix(contracts): normalize hyphenated keys in Input model validator

### DIFF
--- a/application_sdk/contracts/base.py
+++ b/application_sdk/contracts/base.py
@@ -163,15 +163,21 @@ class Input(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _normalize_hyphenated_keys(cls, data: Any) -> Any:
-        """Map hyphenated keys to underscored field names.
+    def _normalize_ae_payload(cls, data: Any) -> Any:
+        """Normalize Automation Engine payloads before Pydantic validation.
 
-        The Automation Engine sends payload keys with hyphens
-        (e.g. ``credential-guid``, ``include-filter``) but Pydantic
-        models define fields with underscores.  This validator runs
-        before field assignment and copies hyphenated values into the
-        corresponding underscored key when the underscored key is
-        absent or empty.
+        Handles two AE quirks:
+
+        1. **Hyphenated keys**: AE dispatches payload keys with hyphens
+           (e.g. ``credential-guid``, ``include-filter``) but Pydantic
+           models use underscored field names.  Hyphenated values are
+           mapped to their underscored equivalents when absent or empty.
+
+        2. **JSON string coercion**: AE parses JSON strings in the payload
+           into dicts/lists before dispatching.  Fields typed as ``str``
+           (e.g. ``include_filter``, ``exclude_filter``) receive parsed
+           objects instead of the original JSON string.  This validator
+           re-serializes them back to JSON strings.
         """
         if not isinstance(data, dict):
             return data
@@ -179,6 +185,7 @@ class Input(BaseModel):
         field_names = set(cls.model_fields)
         updates: dict[str, Any] = {}
 
+        # 1. Map hyphenated keys to underscored field names
         for key, value in data.items():
             if "-" not in key:
                 continue
@@ -192,6 +199,30 @@ class Input(BaseModel):
 
         if updates:
             data = {**data, **updates}
+
+        # 2. Coerce dict/list values back to JSON strings for str-typed fields
+        import json
+
+        for field_name, field_info in cls.model_fields.items():
+            val = data.get(field_name)
+            if val is None or not isinstance(val, (dict, list)):
+                continue
+            # Only coerce if the field's annotation is str (or Annotated[str, ...])
+            annotation = field_info.annotation
+            # Unwrap Annotated types
+            origin = getattr(annotation, "__origin__", None)
+            if origin is not None:
+                # typing.Annotated has __args__[0] as the base type
+                import typing
+
+                if origin is typing.Annotated or (
+                    hasattr(typing, "get_origin")
+                    and typing.get_origin(annotation) is typing.Annotated
+                ):
+                    annotation = typing.get_args(annotation)[0]
+            if annotation is str:
+                data[field_name] = json.dumps(val)
+
         return data
 
     workflow_id: str = ""

--- a/application_sdk/contracts/base.py
+++ b/application_sdk/contracts/base.py
@@ -140,6 +140,13 @@ class Input(BaseModel):
     2. Backwards-compatible evolution via Pydantic fields with defaults
     3. Proper serialization through Temporal
 
+    Key normalization:
+        Hyphenated keys in incoming data (e.g. ``credential-guid``) are
+        automatically mapped to their underscored Pydantic field equivalents
+        (``credential_guid``).  This is needed because the Automation Engine
+        dispatches payloads with hyphenated keys while Pydantic models use
+        underscored field names.
+
     Example:
         class ExtractInput(Input):
             source_url: str
@@ -153,6 +160,39 @@ class Input(BaseModel):
     """
 
     model_config = ConfigDict()
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_hyphenated_keys(cls, data: Any) -> Any:
+        """Map hyphenated keys to underscored field names.
+
+        The Automation Engine sends payload keys with hyphens
+        (e.g. ``credential-guid``, ``include-filter``) but Pydantic
+        models define fields with underscores.  This validator runs
+        before field assignment and copies hyphenated values into the
+        corresponding underscored key when the underscored key is
+        absent or empty.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        field_names = set(cls.model_fields)
+        updates: dict[str, Any] = {}
+
+        for key, value in data.items():
+            if "-" not in key:
+                continue
+            underscore_key = key.replace("-", "_")
+            if underscore_key not in field_names:
+                continue
+            # Only fill in if the underscored key is missing or falsy
+            existing = data.get(underscore_key)
+            if not existing:
+                updates[underscore_key] = value
+
+        if updates:
+            data = {**data, **updates}
+        return data
 
     workflow_id: str = ""
     """Temporal workflow ID for the current run. Populated by the framework at dispatch time."""

--- a/tests/unit/contracts/test_base.py
+++ b/tests/unit/contracts/test_base.py
@@ -490,3 +490,78 @@ class TestContractMetadata:
         )
         with pytest.raises((ValidationError, AttributeError, TypeError)):
             meta.name = "other"  # type: ignore[misc]
+
+
+# =============================================================================
+# Hyphenated key normalization
+# =============================================================================
+
+
+class TestHyphenatedKeyNormalization:
+    """Test that Input normalizes hyphenated keys from AE payloads."""
+
+    def test_hyphenated_keys_mapped_to_underscored(self) -> None:
+        class MyInput(Input):
+            credential_guid: str = ""
+            include_filter: str = ""
+
+        obj = MyInput.model_validate(
+            {"credential-guid": "abc-123", "include-filter": '{"db": ["schema"]}'}
+        )
+        assert obj.credential_guid == "abc-123"
+        assert obj.include_filter == '{"db": ["schema"]}'
+
+    def test_underscored_keys_still_work(self) -> None:
+        class MyInput(Input):
+            credential_guid: str = ""
+
+        obj = MyInput.model_validate({"credential_guid": "abc-123"})
+        assert obj.credential_guid == "abc-123"
+
+    def test_underscored_takes_precedence_over_hyphenated(self) -> None:
+        class MyInput(Input):
+            credential_guid: str = ""
+
+        obj = MyInput.model_validate(
+            {"credential_guid": "from-underscore", "credential-guid": "from-hyphen"}
+        )
+        assert obj.credential_guid == "from-underscore"
+
+    def test_hyphenated_key_without_matching_field_ignored(self) -> None:
+        class MyInput(Input):
+            name: str = ""
+
+        obj = MyInput.model_validate({"no-such-field": "value", "name": "test"})
+        assert obj.name == "test"
+
+    def test_works_with_json_string(self) -> None:
+        class MyInput(Input):
+            credential_guid: str = ""
+
+        obj = MyInput.model_validate_json('{"credential-guid": "abc-123"}')
+        assert obj.credential_guid == "abc-123"
+
+    def test_non_dict_input_passthrough(self) -> None:
+        class MyInput(Input):
+            name: str = ""
+
+        obj = MyInput(name="test")
+        assert obj.name == "test"
+
+    def test_nested_hyphens_normalized(self) -> None:
+        class MyInput(Input):
+            temp_table_regex: str = ""
+
+        obj = MyInput.model_validate({"temp-table-regex": "^tmp_.*"})
+        assert obj.temp_table_regex == "^tmp_.*"
+
+    def test_allow_unbounded_fields_still_normalizes(self) -> None:
+        class MyInput(Input, allow_unbounded_fields=True):
+            credential_guid: str = ""
+            metadata: dict[str, Any] = {}
+
+        obj = MyInput.model_validate(
+            {"credential-guid": "abc", "metadata": {"key": "val"}}
+        )
+        assert obj.credential_guid == "abc"
+        assert obj.metadata == {"key": "val"}

--- a/tests/unit/contracts/test_base.py
+++ b/tests/unit/contracts/test_base.py
@@ -565,3 +565,69 @@ class TestHyphenatedKeyNormalization:
         )
         assert obj.credential_guid == "abc"
         assert obj.metadata == {"key": "val"}
+
+
+# =============================================================================
+# AE filter coercion (dict/list → JSON string)
+# =============================================================================
+
+
+class TestAEFilterCoercion:
+    """Test that Input coerces dict/list values back to JSON strings for
+    str-typed fields.  The Automation Engine parses JSON strings in the
+    payload into Python objects before dispatching."""
+
+    def test_dict_coerced_to_json_string(self) -> None:
+        class MyInput(Input):
+            include_filter: str = ""
+
+        obj = MyInput.model_validate({"include_filter": {"^qa_test_db$": ["^public$"]}})
+        assert obj.include_filter == '{"^qa_test_db$": ["^public$"]}'
+
+    def test_list_coerced_to_json_string(self) -> None:
+        class MyInput(Input):
+            include_filter: str = ""
+
+        obj = MyInput.model_validate({"include_filter": ["db1", "db2"]})
+        assert obj.include_filter == '["db1", "db2"]'
+
+    def test_annotated_str_field_coerced(self) -> None:
+        from typing import Annotated
+
+        from pydantic import Field
+
+        class MyInput(Input):
+            include_filter: Annotated[str, Field(description="filter")] = ""
+
+        obj = MyInput.model_validate({"include_filter": {"^db$": ["^schema$"]}})
+        assert obj.include_filter == '{"^db$": ["^schema$"]}'
+
+    def test_non_str_dict_field_not_coerced(self) -> None:
+        class MyInput(Input, allow_unbounded_fields=True):
+            metadata: dict[str, Any] = {}
+
+        obj = MyInput.model_validate({"metadata": {"key": "val"}})
+        assert obj.metadata == {"key": "val"}  # stays as dict
+
+    def test_string_value_not_double_encoded(self) -> None:
+        class MyInput(Input):
+            include_filter: str = ""
+
+        obj = MyInput.model_validate({"include_filter": '{"^db$": ["^schema$"]}'})
+        assert obj.include_filter == '{"^db$": ["^schema$"]}'
+
+    def test_combined_hyphen_and_coercion(self) -> None:
+        """Both normalizations work together: hyphen → underscore, then dict → JSON."""
+
+        class MyInput(Input):
+            include_filter: str = ""
+            exclude_filter: str = ""
+
+        obj = MyInput.model_validate(
+            {
+                "include-filter": {"^db$": ["^public$"]},
+                "exclude-filter": {},
+            }
+        )
+        assert obj.include_filter == '{"^db$": ["^public$"]}'
+        assert obj.exclude_filter == "{}"


### PR DESCRIPTION
## Summary

- Normalize hyphenated keys from AE payloads to underscored Pydantic field names
- Coerce dict/list values back to JSON strings for str-typed fields (AE pre-parses JSON)
- Both normalizations combined in a single `_normalize_ae_payload` model validator on the `Input` base class

## Issue 1: Hyphenated Keys

The Automation Engine dispatches workflow payloads with hyphenated keys (e.g. `credential-guid`, `include-filter`, `temp-table-regex`) but Pydantic `Input` models define fields with underscores (`credential_guid`, `include_filter`, `temp_table_regex`). The `Input` base class had no alias support or key normalization, so hyphenated keys were silently dropped, leaving fields at their default empty values.

**Impact:** `_get_credentials()` raised `ValueError: No credential reference or GUID available in task input` and SQL filters were empty (extracting all schemas instead of the filtered set).

## Issue 2: AE Filter Coercion (NEW)

The Automation Engine parses JSON strings in the payload into Python objects before dispatching to Temporal. Fields like `include_filter` and `exclude_filter` are typed as `str` but receive dicts/lists from AE, causing Pydantic validation failure:

```
Input should be a valid string [type=string_type]
```

**Example:** AE sends `include_filter: {"^qa_test_db$": ["^public$"]}` (parsed dict) instead of the JSON string `'{"^qa_test_db$": ["^public$"]}'`.

**Fix:** The validator detects str-typed fields receiving dict/list values and re-serializes them to JSON strings via `json.dumps()`. Works with both plain `str` and `Annotated[str, ...]` fields.

## Reproduction

```python
from application_sdk.templates.contracts.sql_metadata import ExtractionInput

# Issue 1: Hyphenated keys
payload = {
    "credential-guid": "110e6e49-...",
    "include-filter": '{"^qa_test_db$":["^public$"]}',
}
inp = ExtractionInput.model_validate(payload)
assert inp.credential_guid == ""  # BUG: empty despite being in payload

# Issue 2: Filter coercion
payload2 = {
    "credential_guid": "110e6e49-...",
    "include_filter": {"^qa_test_db$": ["^public$"]},  # AE parsed it
}
inp2 = ExtractionInput.model_validate(payload2)  # BUG: ValidationError
```

## Discovered During

Migration of `atlan-alloydb-postgres-app` to v3 SDK on `atlanimp01` (devex.atlan.com).

**Failing workflow:** AlloyDB Postgres metadata extraction — dispatched by AE to Temporal queue, failed immediately because credential and filter fields were empty (issue 1) or type-invalid (issue 2).

## Test Plan

- [x] Hyphenated keys mapped to underscored field names
- [x] Underscored keys take precedence when both forms present
- [x] Dict values coerced to JSON string for str-typed fields
- [x] List values coerced to JSON string for str-typed fields
- [x] Annotated[str, ...] fields also coerced correctly
- [x] Non-str dict fields (e.g. `metadata: dict[str, Any]`) NOT coerced
- [x] String values not double-encoded
- [x] Combined hyphen normalization + filter coercion works end-to-end
- [x] All 57 contract base tests pass
- [x] Pre-commit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)