### PR TITLE
fix: include Snyk results in security gate — both scanners block PRs

### DIFF
--- a/.github/scripts/check_allowlist.py
+++ b/.github/scripts/check_allowlist.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Allowlist gate: check Trivy scan results against base-allowlist.json.
+"""Allowlist gate: check Trivy + Snyk scan results against base-allowlist.json.
 
 Usage:
-    python3 check_allowlist.py --trivy-results <path> [--write-comment]
+    python3 check_allowlist.py --trivy-results <path> [--snyk-results <path>] [--write-comment]
 
 Environment:
     FAIL_ON_FINDINGS  "true" (default) to exit 1 on blockers; "false" for warning only.
@@ -19,6 +19,9 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--trivy-results", required=True, help="Path to Trivy JSON output"
+    )
+    parser.add_argument(
+        "--snyk-results", required=False, default=None, help="Path to Snyk JSON output"
     )
     parser.add_argument(
         "--write-comment",
@@ -47,6 +50,8 @@ def main() -> None:
 
     today = datetime.now().strftime("%Y-%m-%d")
     all_vulns: dict = {}
+
+    # Parse Trivy results
     trivy_count = 0
     try:
         with open(args.trivy_results) as f:
@@ -61,6 +66,7 @@ def main() -> None:
                         "package": vuln.get("PkgName", ""),
                         "installed": vuln.get("InstalledVersion", ""),
                         "fixed": vuln.get("FixedVersion", ""),
+                        "source": "trivy",
                     }
                     trivy_count += 1
     except FileNotFoundError:
@@ -72,7 +78,49 @@ def main() -> None:
         print(f"Error: Trivy results have invalid JSON: {e}")
         sys.exit(1)
 
+    # Parse Snyk results
+    snyk_count = 0
+    if args.snyk_results:
+        try:
+            with open(args.snyk_results) as f:
+                snyk = json.load(f)
+            if not snyk.get("error"):
+                for vuln in snyk.get("vulnerabilities", []):
+                    vid = vuln.get("id")
+                    if vid and vid not in all_vulns:
+                        cves = vuln.get("identifiers", {}).get("CVE", [])
+                        if not any(c in all_vulns for c in cves):
+                            all_vulns[vid] = {
+                                "id": vid,
+                                "severity": vuln.get("severity", "").upper(),
+                                "package": vuln.get("packageName") or vuln.get("name", ""),
+                                "installed": vuln.get("version", ""),
+                                "fixed": ", ".join(vuln.get("fixedIn", [])) if vuln.get("fixedIn") else "",
+                                "source": "snyk",
+                            }
+                            snyk_count += 1
+                for app in snyk.get("applications", []):
+                    for vuln in app.get("vulnerabilities", []):
+                        vid = vuln.get("id")
+                        if vid and vid not in all_vulns:
+                            all_vulns[vid] = {
+                                "id": vid,
+                                "severity": vuln.get("severity", "").upper(),
+                                "package": vuln.get("packageName") or vuln.get("name", ""),
+                                "installed": vuln.get("version", ""),
+                                "fixed": ", ".join(vuln.get("fixedIn", [])) if vuln.get("fixedIn") else "",
+                                "source": "snyk",
+                            }
+                            snyk_count += 1
+        except FileNotFoundError:
+            print("Warning: Snyk results not found — skipping Snyk findings")
+        except json.JSONDecodeError as e:
+            print(f"Warning: Snyk results have invalid JSON: {e}")
+
     unique = list(all_vulns.values())
+    scanner_summary = f"Trivy: {trivy_count}"
+    if snyk_count:
+        scanner_summary += f" + Snyk: {snyk_count}"
 
     if allowlist is None:
         summary = (
@@ -82,7 +130,7 @@ def main() -> None:
         for v in sorted(
             unique, key=lambda x: {"CRITICAL": 0, "HIGH": 1}.get(x["severity"], 9)
         ):
-            print(f"  {v['severity']:8s} {v['id']} {v['package']}@{v['installed']}")
+            print(f"  {v['severity']:8s} [{v['source']:5s}] {v['id']} {v['package']}@{v['installed']}")
         _write_summary(summary, args.write_comment)
         sys.exit(0)
 
@@ -102,7 +150,7 @@ def main() -> None:
     expired.sort(key=lambda x: sev_order.get(x["severity"], 9))
 
     print(
-        f"Trivy: {trivy_count} findings | Total: {len(unique)} | "
+        f"{scanner_summary} | Total: {len(unique)} | "
         f"Allowlisted: {len(allowed)} | Expired: {len(expired)} | New: {len(new_vulns)}"
     )
 
@@ -111,17 +159,17 @@ def main() -> None:
         status = "Failed" if fail_on_findings else "Warning"
         summary = f"### \U0001f6e1\ufe0f Security Gate {status}\n\n"
         summary += (
-            f"Trivy: {trivy_count} findings | Total: {len(unique)} | "
+            f"{scanner_summary} | Total: {len(unique)} | "
             f"Allowlisted: {len(allowed)} | **New: {len(new_vulns)}**"
         )
         if expired:
             summary += f" | Expired: {len(expired)}"
         summary += "\n\n"
-        summary += "| Severity | ID | Package | Fix Available |\n"
-        summary += "|----------|----|---------|---------------|\n"
+        summary += "| Severity | Scanner | ID | Package | Fix Available |\n"
+        summary += "|----------|---------|-----|---------|---------------|\n"
         for v in blockers:
             fix = v["fixed"] if v["fixed"] else "No fix"
-            summary += f"| {v['severity']} | `{v['id']}` | `{v['package']}@{v['installed']}` | {fix} |\n"
+            summary += f"| {v['severity']} | {v['source']} | `{v['id']}` | `{v['package']}@{v['installed']}` | {fix} |\n"
         summary += (
             "\n**To resolve:** fix the vulnerability or open a PR against "
             "`atlanhq/application-sdk` to add it to `.security/base-allowlist.json` "
@@ -138,7 +186,7 @@ def main() -> None:
     else:
         summary = (
             f"### \U0001f6e1\ufe0f Security Gate Passed\n\n"
-            f"Trivy: {trivy_count} findings | Total: {len(unique)} CRITICAL/HIGH | All allowlisted \u2705\n"
+            f"{scanner_summary} | Total: {len(unique)} CRITICAL/HIGH | All allowlisted \u2705\n"
         )
         _write_summary(summary, args.write_comment)
         print(f"GATE PASSED: All {len(unique)} vulnerabilities are allowlisted")

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -264,7 +264,7 @@ jobs:
       - name: Check against allowlist
         env:
           FAIL_ON_FINDINGS: ${{ inputs.fail_on_findings }}
-        run: python3 _sdk/.github/scripts/check_allowlist.py --trivy-results /tmp/trivy_results.json --write-comment
+        run: python3 _sdk/.github/scripts/check_allowlist.py --trivy-results /tmp/trivy_results.json --snyk-results /tmp/snyk_results.json --write-comment
 
       - name: Report Snyk findings (informational)
         if: always()


### PR DESCRIPTION
## What
The security gate now checks both Trivy AND Snyk results against the allowlist. Previously only Trivy was gated (Chris's April 18 refactor).

## Changes
- `check_allowlist.py` — added `--snyk-results` parameter, parses Snyk vulnerabilities + applications, deduplicates with Trivy by CVE ID
- `build-and-scan.yaml` — passes `--snyk-results /tmp/snyk_results.json` to the gate

## Why
Snyk catches CVEs that Trivy misses (Go packages like go-jose, pgx, otel). Without this, those findings are informational only and don't block PRs.

## Backward compatible
- `--snyk-results` is optional — if not passed or file not found, gate works with Trivy only (same as before)
- No changes needed in any app repo