### PR TITLE
fix: dashboard only updates on merge to main

### DIFF
--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -45,6 +45,7 @@ permissions:
 jobs:
   update:
     name: Update Dashboard
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.head_branch == github.event.repository.default_branch
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
Adds condition to skip dashboard update when the triggering scan was on a PR branch. Only runs when scan completes on the default branch (merge) or on manual dispatch.