### PR TITLE
fix(credentials): resolve_by_guid must merge S3 config with Vault secrets

### DIFF
--- a/application_sdk/credentials/resolver.py
+++ b/application_sdk/credentials/resolver.py
@@ -31,13 +31,13 @@ class CredentialResolver:
        contract.  Typed resolution uses the ``auth_type`` field on the
        spec when ``credential_type`` is empty.
 
-    2. **GUID path** (``credential_guid`` is non-empty): First checks
-       ``secret_store.get(ref.name)`` to cover in-process inline credentials
-       stored by the handler layer (combined-mode / local dev). If not found
-       there, uses ``DaprCredentialVault.get_credentials(guid)`` to resolve
-       platform-issued GUIDs from the upstream store. → if
-       ``credential_type != "unknown"`` parses into typed Credential, otherwise
-       wraps in ``RawCredential``.
+    2. **GUID path** (``credential_guid`` is non-empty): Checks the
+       state store (local-dev inline creds), then the secret store (returns
+       immediately if the result is complete — i.e. contains ``authType``),
+       then falls through to ``DaprCredentialVault.get_credentials(guid)``
+       which merges S3 config with Vault secrets.  → if
+       ``credential_type != "unknown"`` parses into typed Credential,
+       otherwise wraps in ``RawCredential``.
 
     3. **Named path** (both routing fields empty): Calls
        ``secret_store.get(ref.name)`` → parses JSON → looks up parser in
@@ -178,9 +178,14 @@ class CredentialResolver:
     async def _resolve_by_guid(self, ref: "CredentialRef") -> dict[str, Any]:
         """Resolve credentials by GUID.
 
-        Checks the local secret store first (covers in-process credential
-        injection from handler/service.py in combined-mode and local dev), then
-        falls back to DaprCredentialVault for production platform-issued GUIDs.
+        Resolution order:
+        1. State store (local-dev only) — inline credentials from handler
+        2. Secret store — returns immediately if result is complete (has authType)
+        3. DaprCredentialVault — merges S3 config + Vault secrets (production path)
+
+        In production, the secret store (Vault) only holds the sensitive half
+        of the credential.  The completeness check (``authType in result``)
+        ensures we fall through to DaprCredentialVault for the full merge.
         """
 
         # State store check — handler/service.py stores inline credentials here
@@ -207,29 +212,40 @@ class CredentialResolver:
                     exc_info=True,
                 )
 
-        # Secret store check (backward compat) — handler/service.py previously
-        # stored inline credentials here under the same UUID.
+        # Secret store check — backward compat path.  In production the Dapr
+        # secret store resolves to Vault which only holds the *sensitive* half
+        # of the credential (e.g. username, tokens).  If the result looks
+        # incomplete (missing authType — a key config field that always lives
+        # in S3), fall through to DaprCredentialVault which merges both halves.
         from application_sdk.infrastructure.secrets import SecretNotFoundError
 
         try:
             raw = await self._secret_store.get(ref.name)
             data_parsed: dict[str, Any] = json.loads(raw)
-            return data_parsed
+            if "authType" in data_parsed:
+                # Complete credential (e.g. local dev inline or full bundle)
+                return data_parsed
+            logger.debug(
+                "Secret store returned partial creds for GUID %r "
+                "(missing authType); falling through to credential vault",
+                ref.name,
+            )
         except SecretNotFoundError:
             pass
         except json.JSONDecodeError:
             logger.debug(
-                "Local store value for GUID %r is not valid JSON; trying Dapr",
+                "Local store value for GUID %r is not valid JSON; trying vault",
                 ref.name,
             )
         except Exception:
             logger.debug(
-                "Local store lookup failed for GUID %r; trying Dapr",
+                "Local store lookup failed for GUID %r; trying vault",
                 ref.name,
                 exc_info=True,
             )
 
-        # Fall back to DaprCredentialVault for platform-issued GUIDs.
+        # Fall back to DaprCredentialVault which merges S3 config (authType,
+        # host, port, etc.) with Vault secrets (passwords, tokens, etc.).
         from application_sdk.credentials.errors import CredentialNotFoundError
         from application_sdk.infrastructure import AsyncDaprClient, DaprCredentialVault
 

--- a/tests/unit/credentials/test_agent.py
+++ b/tests/unit/credentials/test_agent.py
@@ -690,10 +690,16 @@ class TestCredentialResolverAgentBranch:
         }
         assert resolved["extra"]["database"] == "real_pg_db"
 
-    async def test_resolve_raw_legacy_guid_ref_still_works(self) -> None:
-        """Legacy GUID refs continue to resolve via the local secret
-        store path — agent branch is additive, not a replacement.
+    async def test_resolve_raw_legacy_guid_ref_requires_credential_vault(
+        self,
+    ) -> None:
+        """GUID refs resolve via DaprCredentialVault (merging S3 config +
+        Vault secrets), NOT the secret store alone.  Without a running Dapr
+        sidecar, this raises CredentialNotFoundError.
         """
+        import pytest
+
+        from application_sdk.credentials.errors import CredentialNotFoundError
         from application_sdk.credentials.ref import CredentialRef
         from application_sdk.credentials.resolver import CredentialResolver
 
@@ -703,8 +709,8 @@ class TestCredentialResolverAgentBranch:
         )
         resolver = CredentialResolver(store)
 
-        resolved = await resolver.resolve_raw(ref)
-        assert resolved == {"username": "real_user", "host": "h"}
+        with pytest.raises(CredentialNotFoundError):
+            await resolver.resolve_raw(ref)
 
     async def test_resolve_typed_agent_ref_uses_auth_type_for_parser(self) -> None:
         """When ``credential_type`` is empty on an agent ref (which is

--- a/tests/unit/credentials/test_resolver.py
+++ b/tests/unit/credentials/test_resolver.py
@@ -116,22 +116,45 @@ def _make_vault_patches(vault_return=None, vault_side_effect=None):
 class TestGuidResolutionPath:
     """Tests for the GUID-based resolution path.
 
-    The resolver checks the local secret store first (in-process inline
-    credentials), then falls back to DaprCredentialVault for platform GUIDs.
+    The resolver checks the state store (local dev), then the secret store
+    (returns immediately if complete — has authType), then falls through to
+    DaprCredentialVault which merges S3 config + Vault secrets.
     """
 
-    async def test_local_store_takes_precedence_over_vault(self, store, resolver):
-        """Inline credentials stored in the local secret store are resolved
-        directly — DaprCredentialVault is never called."""
+    async def test_complete_secret_store_creds_returned(self, store, resolver):
+        """Secret store credentials with authType are returned directly."""
         import json
 
-        store.set("guid-abc", json.dumps({"host": "local.example.com", "port": 5432}))
+        store.set(
+            "guid-abc",
+            json.dumps(
+                {"host": "local.example.com", "port": 5432, "authType": "basic"}
+            ),
+        )
         ref = legacy_credential_ref("guid-abc")
-        # No Dapr mock needed — local store should return before Dapr is reached.
         raw = await resolver.resolve_raw(ref)
 
         assert raw["host"] == "local.example.com"
         assert raw["port"] == 5432
+        assert raw["authType"] == "basic"
+
+    async def test_partial_secret_store_creds_fall_through(self, store, resolver):
+        """Secret store credentials without authType fall through to
+        DaprCredentialVault (which fails in unit tests without Dapr)."""
+        import json
+
+        import pytest
+
+        from application_sdk.credentials.errors import CredentialNotFoundError
+
+        # Vault-only creds: missing authType → should NOT be returned directly
+        store.set(
+            "guid-abc", json.dumps({"username": "user", "extra": {"database": "db"}})
+        )
+        ref = legacy_credential_ref("guid-abc")
+
+        with pytest.raises(CredentialNotFoundError):
+            await resolver.resolve_raw(ref)
 
     async def test_get_credentials_receives_string_not_dict(self, store, resolver):
         """Regression: resolver must pass the GUID as a plain string, not a dict."""


### PR DESCRIPTION
## Summary

- Fixed the secret-store shortcut in `_resolve_by_guid()` that returned **incomplete credentials** in production
- Added a completeness check: secret store result must contain `authType` to be returned directly; otherwise falls through to `DaprCredentialVault` which merges S3 config + Vault secrets
- Preserves existing local-dev behavior (inline creds have `authType` → returned immediately)

## Root Cause Analysis

### The Bug
`CredentialResolver._resolve_by_guid()` had a secret-store shortcut that called `self._secret_store.get(ref.name)` and returned the result unconditionally. In production, the Dapr secret store resolves directly to **Vault**, which only stores the sensitive half of the credential — returning it yielded incomplete credentials missing `authType`, `host`, `port`, etc.

### Production Credential Storage (Verified via kubectl exec + boto3/Dapr API)
| Store | Contents (verified) |
|-------|----------|
| **S3** `config.json` | `authType: "iam_service_account"`, `host`, `port`, `connectorConfigName`, `credentialSource`, `extra` (partial), `name` |
| **Vault** secret | `username`, `extra.__gcp_service_account`, `extra.__name`, `extra.compiled_url`, `extra.database` |

### The Fix
Keep the secret store lookup but add a **completeness check**: if the returned dict is missing `authType` (a key config field that always lives in S3, never in Vault), log a debug message and fall through to `DaprCredentialVault.get_credentials()` which merges both halves.

**Resolution order (unchanged for local dev, fixed for production):**
1. State store (local-dev only, gated by `ATLAN_LOCAL_DEVELOPMENT`) → full inline creds
2. Secret store → return immediately if complete (has `authType`), else fall through
3. `DaprCredentialVault` → merges S3 config + Vault secrets → complete credential

### Impact — Failing Workflow
**Connector:** AlloyDB Postgres (`atlan-alloydb-postgres-app`)
**Environment:** `atlanimp01` (devex.atlan.com)
**Credential GUID:** `81e6a9ba-fa75-4f83-952f-4225fe687b0d`
**Error:**
```
connect() got an unexpected keyword argument 'ip_type'
```

**Chain of failure:**
1. `_resolve_by_guid()` → secret store shortcut → Vault-only creds returned (**missing `authType`**)
2. `SQLClient.load()` defaults `authType` to `"basic"` (fallback when key missing)
3. `BasicAuthStrategy` selected → calls `asyncpg.connect(**driver_properties)` with `ip_type=PUBLIC`
4. `asyncpg.connect()` rejects `ip_type` → **crash**

### Why Local Testing Didn't Catch It
- **Local dev:** Credentials seeded to state store (step 1) have full config → returned immediately → secret store shortcut never reached
- **Production:** State store check skipped (no `ATLAN_LOCAL_DEVELOPMENT`), secret store returns Vault-only partial creds → **no completeness check → returned as-is** → broken

### Why handler `test_auth` passed but worker failed
- Handler receives credentials **directly from the frontend request** → `authType` present → correct strategy → works
- Worker resolves via `CredentialResolver._resolve_by_guid()` → secret store shortcut → Vault-only → missing `authType` → wrong strategy → crash

## Test Plan

- [x] Complete creds in secret store (has `authType`) → returned directly
- [x] Partial creds in secret store (no `authType`) → falls through to DaprCredentialVault
- [x] Legacy GUID refs with partial creds → falls through correctly
- [x] All 163 credential tests pass
- [x] Pre-commit passes
- [ ] **E2E: Deploy to atlanimp01 and verify AlloyDB workflow completes** (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)