### PR TITLE
fix: dashboard — wrap repos column for long lists

### DIFF
--- a/.github/scripts/check_allowlist.py
+++ b/.github/scripts/check_allowlist.py
@@ -93,9 +93,12 @@ def main() -> None:
                             all_vulns[vid] = {
                                 "id": vid,
                                 "severity": vuln.get("severity", "").upper(),
-                                "package": vuln.get("packageName") or vuln.get("name", ""),
+                                "package": vuln.get("packageName")
+                                or vuln.get("name", ""),
                                 "installed": vuln.get("version", ""),
-                                "fixed": ", ".join(vuln.get("fixedIn", [])) if vuln.get("fixedIn") else "",
+                                "fixed": ", ".join(vuln.get("fixedIn", []))
+                                if vuln.get("fixedIn")
+                                else "",
                                 "source": "snyk",
                             }
                             snyk_count += 1
@@ -106,9 +109,12 @@ def main() -> None:
                             all_vulns[vid] = {
                                 "id": vid,
                                 "severity": vuln.get("severity", "").upper(),
-                                "package": vuln.get("packageName") or vuln.get("name", ""),
+                                "package": vuln.get("packageName")
+                                or vuln.get("name", ""),
                                 "installed": vuln.get("version", ""),
-                                "fixed": ", ".join(vuln.get("fixedIn", [])) if vuln.get("fixedIn") else "",
+                                "fixed": ", ".join(vuln.get("fixedIn", []))
+                                if vuln.get("fixedIn")
+                                else "",
                                 "source": "snyk",
                             }
                             snyk_count += 1
@@ -130,7 +136,9 @@ def main() -> None:
         for v in sorted(
             unique, key=lambda x: {"CRITICAL": 0, "HIGH": 1}.get(x["severity"], 9)
         ):
-            print(f"  {v['severity']:8s} [{v['source']:5s}] {v['id']} {v['package']}@{v['installed']}")
+            print(
+                f"  {v['severity']:8s} [{v['source']:5s}] {v['id']} {v['package']}@{v['installed']}"
+            )
         _write_summary(summary, args.write_comment)
         sys.exit(0)
 

--- a/.security/dashboard/index.html
+++ b/.security/dashboard/index.html
@@ -285,7 +285,7 @@ function renderTable(){
             <td><span class="badge b-${v.scanner}">${v.scanner}</span></td>
             <td><span class="badge b-${v.source_type==='base_image'?'base':'app'}">${v.source_type==='base_image'?'Base':'App'}</span></td>
             <td><span class="badge b-${status}">${status}</span></td>
-            <td>${v.repos.map(r=>'<span class="repo-tag">'+esc(r.split('/').pop())+'</span>').join(' ')}</td>
+            <td>${v.repos.length<=3?v.repos.map(r=>'<span class="repo-tag">'+esc(r.split('/').pop())+'</span>').join(' '):'<span class="repo-tag">'+esc(v.repos[0].split('/').pop())+'</span> <span class="repo-tag">'+esc(v.repos[1].split('/').pop())+'</span> <span class="repo-tag" style="background:#e0e2ff;color:#6366f1">+'+(v.repos.length-2)+' more</span>'}</td>
             <td>${v.fixed?esc(v.fixed):'<span style="color:#b0b3c6">None</span>'}</td>`;
         tb.appendChild(r);
         const dr=document.createElement('tr');dr.className='detail-row';dr.id='d'+i;

--- a/.security/dashboard/index.html
+++ b/.security/dashboard/index.html
@@ -124,8 +124,9 @@
         .b-expired{background:linear-gradient(135deg,#fffbeb,#fef3c7);color:#d97706;}
         .b-base{background:#f0f2f5;color:#5c5f77;}
         .b-app{background:linear-gradient(135deg,#fffbeb,#fef3c7);color:#d97706;}
-        .repo-tag{display:inline-block;padding:3px 10px;border-radius:20px;font-size:10px;font-weight:600;background:#f0f2f5;color:#5c5f77;margin:1px 2px;transition:all 0.2s;}
+        .repo-tag{display:inline-block;padding:3px 8px;border-radius:20px;font-size:9px;font-weight:600;background:#f0f2f5;color:#5c5f77;margin:1px 2px;transition:all 0.2s;white-space:nowrap;}
         .repo-tag:hover{background:#e2e6ea;transform:scale(1.05);}
+        .repos-cell{max-width:200px;display:flex;flex-wrap:wrap;gap:2px;}
         code{background:#f0f2f5;padding:2px 7px;border-radius:6px;font-size:11px;font-family:'SF Mono',Menlo,monospace;font-weight:500;}
 
         .empty{text-align:center;padding:60px;color:#8c8fa3;font-size:14px;}
@@ -285,7 +286,7 @@ function renderTable(){
             <td><span class="badge b-${v.scanner}">${v.scanner}</span></td>
             <td><span class="badge b-${v.source_type==='base_image'?'base':'app'}">${v.source_type==='base_image'?'Base':'App'}</span></td>
             <td><span class="badge b-${status}">${status}</span></td>
-            <td>${v.repos.length<=3?v.repos.map(r=>'<span class="repo-tag">'+esc(r.split('/').pop())+'</span>').join(' '):'<span class="repo-tag">'+esc(v.repos[0].split('/').pop())+'</span> <span class="repo-tag">'+esc(v.repos[1].split('/').pop())+'</span> <span class="repo-tag" style="background:#e0e2ff;color:#6366f1">+'+(v.repos.length-2)+' more</span>'}</td>
+            <td><div class="repos-cell">${v.repos.length<=3?v.repos.map(r=>'<span class="repo-tag">'+esc(r.split('/').pop())+'</span>').join(''):'<span class="repo-tag">'+esc(v.repos[0].split('/').pop())+'</span><span class="repo-tag">'+esc(v.repos[1].split('/').pop())+'</span><span class="repo-tag" style="background:#e0e2ff;color:#6366f1;cursor:default" title="'+v.repos.map(r=>r.split('/').pop()).join(', ')+'">+'+(v.repos.length-2)+' more</span>'}</div></td>
             <td>${v.fixed?esc(v.fixed):'<span style="color:#b0b3c6">None</span>'}</td>`;
         tb.appendChild(r);
         const dr=document.createElement('tr');dr.className='detail-row';dr.id='d'+i;


### PR DESCRIPTION
Shows first 2 repos + '+N more' badge when a CVE affects more than 3 repos. Full list visible on row expand.