### PR TITLE
DISTR-370 | feat(utils): add resolve_credential_file for base64 secret support

### DIFF
--- a/application_sdk/common/utils.py
+++ b/application_sdk/common/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import glob
 import json
 import os
@@ -607,3 +608,69 @@ async def download_file_from_upload_response(
     )
 
     return local_path
+
+
+async def resolve_credential_file(
+    value: Optional[str],
+    filename: str,
+    dest_dir: str = "/tmp/credential_files",
+) -> Optional[str]:
+    """Resolve a credential file field value to a local file path.
+
+    Handles two input formats transparently, allowing customers to choose
+    how they provide sensitive files based on their organisation's security policy:
+
+    1. **Object-store reference** (file uploaded via UI):
+       ``{"key": "some/path", "rawName": "hiveadmin.keytab", "extension": ".keytab"}``
+       Downloads the binary from the Dapr-backed object store.
+
+    2. **Base64-encoded file content** (stored in customer's own secret store):
+       ``"BQIAAAABAAoASElWRS5MT0NBTA..."``
+       Decodes the binary and writes it directly to disk.
+       Used when the customer base64-encodes the file, stores it in their secret
+       store (AWS / Azure / GCP / K8s), and the SDK resolves the value via
+       ``SecretStore.get_credentials()`` + Dapr at activity runtime.
+
+    Args:
+        value:    Raw credential field value — either a JSON object-store reference
+                  or a raw base64-encoded string. Returns ``None`` if empty.
+        filename: Destination filename used for the base64 path
+                  (e.g. ``"keytab.keytab"``, ``"krb5.conf"``, ``"ca_cert.pem"``).
+                  Ignored for the object-store path (filename is derived from the key).
+        dest_dir: Directory to write or download the file into.
+
+    Returns:
+        Absolute path to the resolved file on disk, or ``None`` if ``value`` is
+        empty or resolution fails.
+    """
+    if not value:
+        return None
+
+    # Detect format: JSON object-store reference vs raw base64 string
+    try:
+        parsed = json.loads(value)
+        if isinstance(parsed, dict) and ("key" in parsed or "fileKey" in parsed):
+            # Object-store reference — delegate to existing download utility
+            return await download_file_from_upload_response(value)
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    # Base64-encoded file content — decode and write to disk
+    try:
+        os.makedirs(dest_dir, exist_ok=True)
+        file_path = os.path.join(dest_dir, filename)
+        decoded_bytes = base64.b64decode(value.strip())
+        with open(file_path, "wb") as f:
+            f.write(decoded_bytes)
+        logger.info(
+            "Resolved credential file from base64 content",
+            extra={"path": file_path, "filename": filename},
+        )
+        return file_path
+    except Exception:
+        logger.error(
+            "Failed to resolve credential file from base64 content",
+            extra={"filename": filename},
+            exc_info=True,
+        )
+        return None

--- a/application_sdk/common/utils.py
+++ b/application_sdk/common/utils.py
@@ -4,6 +4,8 @@ import glob
 import json
 import os
 import re
+
+import orjson
 from concurrent.futures import ThreadPoolExecutor
 from typing import (
     Any,
@@ -648,11 +650,11 @@ async def resolve_credential_file(
 
     # Detect format: JSON object-store reference vs raw base64 string
     try:
-        parsed = json.loads(value)
+        parsed = orjson.loads(value)
         if isinstance(parsed, dict) and ("key" in parsed or "fileKey" in parsed):
             # Object-store reference — delegate to existing download utility
             return await download_file_from_upload_response(value)
-    except (json.JSONDecodeError, TypeError):
+    except (orjson.JSONDecodeError, TypeError):
         pass
 
     # Base64-encoded file content — decode and write to disk

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -1,7 +1,8 @@
+import base64
 import os
 from pathlib import Path
 from typing import Dict, List, Union
-from unittest.mock import mock_open, patch
+from unittest.mock import AsyncMock, mock_open, patch
 
 from application_sdk.common.error_codes import CommonError
 from application_sdk.common.utils import (
@@ -11,6 +12,7 @@ from application_sdk.common.utils import (
     prepare_filters,
     prepare_query,
     read_sql_files,
+    resolve_credential_file,
 )
 
 
@@ -931,3 +933,106 @@ class TestParseFilterInput:
 
         with pytest.raises(CommonError, match="Invalid filter JSON"):
             parse_filter_input("not json at all")
+
+
+class TestResolveCredentialFile:
+    """Tests for resolve_credential_file() — handles both object-store refs and base64 content."""
+
+    # ------------------------------------------------------------------
+    # Object-store reference path (delegates to download_file_from_upload_response)
+    # ------------------------------------------------------------------
+
+    @patch(
+        "application_sdk.common.utils.download_file_from_upload_response",
+        new_callable=AsyncMock,
+    )
+    async def test_object_store_reference_with_key(self, mock_download, tmp_path):
+        """JSON with 'key' field routes to download_file_from_upload_response."""
+        mock_download.return_value = str(tmp_path / "keytab.keytab")
+        value = '{"key": "artifacts/hiveadmin.keytab", "rawName": "hiveadmin.keytab", "extension": ".keytab"}'
+
+        result = await resolve_credential_file(value, "keytab.keytab", str(tmp_path))
+
+        mock_download.assert_awaited_once_with(value)
+        assert result == str(tmp_path / "keytab.keytab")
+
+    @patch(
+        "application_sdk.common.utils.download_file_from_upload_response",
+        new_callable=AsyncMock,
+    )
+    async def test_object_store_reference_with_filekey(self, mock_download, tmp_path):
+        """JSON with 'fileKey' field routes to download_file_from_upload_response."""
+        mock_download.return_value = str(tmp_path / "krb5.conf")
+        value = '{"fileKey": "artifacts/krb5.conf", "rawName": "krb5.conf"}'
+
+        result = await resolve_credential_file(value, "krb5.conf", str(tmp_path))
+
+        mock_download.assert_awaited_once_with(value)
+        assert result == str(tmp_path / "krb5.conf")
+
+    # ------------------------------------------------------------------
+    # Base64 content path (SDR / secret store)
+    # ------------------------------------------------------------------
+
+    async def test_base64_binary_file_written_correctly(self, tmp_path):
+        """Valid base64 binary content is decoded and written to disk."""
+        original_bytes = b"\x05\x02\x00\x00\x00\x01\x00\x0a\x00HIVE"  # fake keytab header
+        b64_value = base64.b64encode(original_bytes).decode()
+
+        result = await resolve_credential_file(b64_value, "keytab.keytab", str(tmp_path))
+
+        assert result == str(tmp_path / "keytab.keytab")
+        assert os.path.exists(result)
+        assert open(result, "rb").read() == original_bytes
+
+    async def test_base64_text_file_written_correctly(self, tmp_path):
+        """Valid base64 of a text file (krb5.conf) is decoded and written correctly."""
+        krb5_content = b"[libdefaults]\n default_realm = EXAMPLE.COM\n"
+        b64_value = base64.b64encode(krb5_content).decode()
+
+        result = await resolve_credential_file(b64_value, "krb5.conf", str(tmp_path))
+
+        assert result == str(tmp_path / "krb5.conf")
+        assert open(result, "rb").read() == krb5_content
+
+    async def test_base64_with_leading_trailing_whitespace(self, tmp_path):
+        """Base64 string with surrounding whitespace is stripped before decoding."""
+        content = b"fake-cert-bytes"
+        b64_value = "  " + base64.b64encode(content).decode() + "\n"
+
+        result = await resolve_credential_file(b64_value, "ca_cert.pem", str(tmp_path))
+
+        assert result is not None
+        assert open(result, "rb").read() == content
+
+    async def test_base64_dest_dir_created_if_missing(self, tmp_path):
+        """dest_dir is created automatically if it does not exist."""
+        content = b"some-binary"
+        b64_value = base64.b64encode(content).decode()
+        new_dir = str(tmp_path / "nested" / "dir")
+
+        result = await resolve_credential_file(b64_value, "file.bin", new_dir)
+
+        assert result is not None
+        assert os.path.isdir(new_dir)
+
+    async def test_invalid_base64_returns_none(self, tmp_path):
+        """A string that is neither JSON nor valid base64 returns None without raising."""
+        result = await resolve_credential_file(
+            "this is definitely not base64 !!!###", "keytab.keytab", str(tmp_path)
+        )
+        assert result is None
+
+    # ------------------------------------------------------------------
+    # Empty / None inputs
+    # ------------------------------------------------------------------
+
+    async def test_none_input_returns_none(self, tmp_path):
+        """None input returns None immediately."""
+        result = await resolve_credential_file(None, "keytab.keytab", str(tmp_path))
+        assert result is None
+
+    async def test_empty_string_returns_none(self, tmp_path):
+        """Empty string returns None immediately."""
+        result = await resolve_credential_file("", "keytab.keytab", str(tmp_path))
+        assert result is None


### PR DESCRIPTION
## Summary

- Adds `resolve_credential_file(value, filename, dest_dir)` to `application_sdk/common/utils.py`
- Transparently handles two formats for sensitive credential files (keytab, krb5.conf, TLS certs):
  - **JSON object-store reference** (file uploaded via UI) → delegates to `download_file_from_upload_response`
  - **Raw base64-encoded content** (from customer secret store via SDR `agent_json`) → decodes and writes to disk
- Adds `TestResolveCredentialFile` with 9 unit tests covering both paths, edge cases (whitespace, dir creation), and empty/None inputs

## Motivation

DISTR-370: SDR customers store binary credential files (Kerberos keytab, krb5.conf, TLS certs) as base64 strings in their own secret store (AWS/Azure/GCP/K8s). Previously only UI-uploaded files (object-store refs) were supported. This change makes both formats work transparently.

## Test plan

- [x] 9 new unit tests pass (`TestResolveCredentialFile`)
- [x] All existing unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)