### PR TITLE
fix(docs): correct API drift in handler service and run_dev_combined examples [BLDX-1086]

### DIFF
--- a/docs/concepts/entry-points.md
+++ b/docs/concepts/entry-points.md
@@ -67,7 +67,6 @@ For local development and integration tests, use `run_dev_combined()`:
 import asyncio
 from application_sdk.main import run_dev_combined
 from my_package.apps import MyExtractor
-from my_package.handlers import MyHandler
 
 asyncio.run(run_dev_combined(MyExtractor))
 ```
@@ -84,7 +83,6 @@ from application_sdk.main import run_dev_combined
 
 asyncio.run(run_dev_combined(
     MyExtractor,
-    handler_class=MyHandler,
     secret_store=MockSecretStore({"my-api-key": "dev-secret"}),
     state_store=MockStateStore(),
 ))

--- a/docs/concepts/entry-points.md
+++ b/docs/concepts/entry-points.md
@@ -69,7 +69,7 @@ from application_sdk.main import run_dev_combined
 from my_package.apps import MyExtractor
 from my_package.handlers import MyHandler
 
-asyncio.run(run_dev_combined(MyExtractor, handler_class=MyHandler))
+asyncio.run(run_dev_combined(MyExtractor))
 ```
 
 This starts both the Temporal worker and the HTTP handler service in a single process. It derives the module path automatically from the class.

--- a/docs/concepts/server.md
+++ b/docs/concepts/server.md
@@ -10,7 +10,7 @@ The handler service auto-wires routes from your `Handler` methods:
 from application_sdk.handler import create_app_handler_service
 from my_package.handlers import MyHandler
 
-app = create_app_handler_service(handler_class=MyHandler)
+app = create_app_handler_service(handler=MyHandler())
 ```
 
 When started (via the CLI `--mode handler` or `--mode combined`), this creates a FastAPI application with:
@@ -70,7 +70,7 @@ from my_package.apps import MyExtractor
 from my_package.handlers import MyHandler
 
 import asyncio
-asyncio.run(run_dev_combined(MyExtractor, handler_class=MyHandler))
+asyncio.run(run_dev_combined(MyExtractor))
 ```
 
 ## Error Handling

--- a/docs/concepts/server.md
+++ b/docs/concepts/server.md
@@ -67,7 +67,6 @@ For integration tests or custom setups:
 ```python
 from application_sdk.main import run_dev_combined
 from my_package.apps import MyExtractor
-from my_package.handlers import MyHandler
 
 import asyncio
 asyncio.run(run_dev_combined(MyExtractor))

--- a/docs/upgrade-guide-v3.md
+++ b/docs/upgrade-guide-v3.md
@@ -406,7 +406,7 @@ For local dev, pass the class directly — `run_dev_combined` derives the module
 ```python
 from application_sdk.main import run_dev_combined
 
-asyncio.run(run_dev_combined(MyMetadataExtractor, handler_class=MyHandler))
+asyncio.run(run_dev_combined(MyMetadataExtractor))
 ```
 
 Three modes are available:

--- a/docs/upgrade-guide-v3.md
+++ b/docs/upgrade-guide-v3.md
@@ -1084,7 +1084,6 @@ from application_sdk.main import run_dev_combined
 
 asyncio.run(run_dev_combined(
     MyConnector,
-    handler_class=MyHandler,
     secret_store=MockSecretStore({"my-api-key": "test-value"}),
     state_store=MockStateStore(),
 ))

--- a/docs/whats-new-v3.md
+++ b/docs/whats-new-v3.md
@@ -390,7 +390,7 @@ class MyHandler(Handler):
         return PreflightOutput(status=PreflightStatus.READY)
 
     async def fetch_metadata(self, input: MetadataInput) -> MetadataOutput:
-        return MetadataOutput(fields=[])
+        return MetadataOutput(objects=[])
 ```
 
 **What changed and why:**
@@ -456,7 +456,7 @@ application-sdk --mode combined --app my_package.apps:MyExtractor
 # Programmatic (local dev, integration tests)
 from application_sdk.main import run_dev_combined
 
-asyncio.run(run_dev_combined(MyExtractor, handler_class=MyHandler))
+asyncio.run(run_dev_combined(MyExtractor))
 ```
 
 **Three modes:**

--- a/docs/whats-new-v3.md
+++ b/docs/whats-new-v3.md
@@ -341,7 +341,6 @@ from application_sdk.main import run_dev_combined
 
 asyncio.run(run_dev_combined(
     MyConnector,
-    handler_class=MyHandler,
     secret_store=MockSecretStore({"my-api-key": "dev-secret"}),
 ))
 ```


### PR DESCRIPTION
## What was found

Documentation code examples don't match the actual v3 API:

1. `create_app_handler_service(handler_class=MyHandler)` — param is `handler` (instance, not class)
2. `run_dev_combined(..., handler_class=MyHandler)` — `handler_class` kwarg doesn't exist (4 locations)
3. `MetadataOutput(fields=[])` — correct field is `objects`

## What was fixed

- `server.md`: `handler_class=MyHandler` -> `handler=MyHandler()`
- `server.md`, `entry-points.md`, `whats-new-v3.md`, `upgrade-guide-v3.md`: removed nonexistent `handler_class` kwarg
- `whats-new-v3.md`: `fields=[]` -> `objects=[]`

## Linear

https://linear.app/atlan-epd/issue/BLDX-1086