### PR TITLE
feat(ci): pass github.triggering_actor as created_by in publish payload

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -356,6 +356,10 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Resolve triggering actor to email; fall back to GitHub username
+          GH_EMAIL=$(gh api "users/${GITHUB_ACTOR}" --jq '.email // empty' 2>/dev/null || true)
+          CREATED_BY="${GH_EMAIL:-${GITHUB_ACTOR}}"
+
           # Build JSON payload matching the CLI's registerInMarketplace format
           BODY=$(python3 - <<'PYEOF'
           import json, os
@@ -389,9 +393,9 @@ jobs:
           else:
               body["target_channel"] = os.environ.get("CHANNEL", "all") or "all"
 
-          actor = os.environ.get("GITHUB_ACTOR", "").strip()
-          if actor:
-              body["created_by"] = actor
+          created_by = os.environ.get("CREATED_BY", "").strip()
+          if created_by:
+              body["created_by"] = created_by
 
           print(json.dumps(body))
           PYEOF

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -352,6 +352,7 @@ jobs:
           CHANNEL: ${{ inputs.channel }}
           TENANTS: ${{ inputs.tenants }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          GITHUB_ACTOR: ${{ github.triggering_actor }}
         run: |
           set -euo pipefail
 
@@ -387,6 +388,10 @@ jobs:
               body["allowed_tenants"] = [t.strip() for t in tenants.split(",") if t.strip()]
           else:
               body["target_channel"] = os.environ.get("CHANNEL", "all") or "all"
+
+          actor = os.environ.get("GITHUB_ACTOR", "").strip()
+          if actor:
+              body["created_by"] = actor
 
           print(json.dumps(body))
           PYEOF


### PR DESCRIPTION
## Summary

- Add `GITHUB_ACTOR: ${{ github.triggering_actor }}` to the publish step env
- Inject it into the Heracles payload as `created_by` when non-empty

## Why

`APP_PUBLISH_TOKEN` is an API key JWT with no email claim, so Heracles previously had no identity to store and fell back to the `"-"` sentinel. Passing `github.triggering_actor` lets the real GitHub username flow through to GM's `created_by` column, making it visible in the Releases UI.

`github.triggering_actor` is used (over `github.actor`) because it captures who re-triggered a workflow, not just who originally created the commit.

## Test plan
- [ ] Push to main on an app repo — GM release `created_by` shows the committer's GitHub username
- [ ] `workflow_dispatch` trigger — `created_by` shows the dispatching user's username
- [ ] Bot/service account pushes — `created_by` shows the bot's GitHub handle