### PR TITLE
fix(templates): set connection_qualified_name on ExtractionOutput

### DIFF
--- a/application_sdk/templates/sql_metadata_extractor.py
+++ b/application_sdk/templates/sql_metadata_extractor.py
@@ -401,6 +401,13 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
                 column_result.total_record_count,
             )
 
+            # Extract connection_qualified_name from the input connection.
+            # PublishInputMixin auto-derives publish_state_prefix and
+            # current_state_prefix from this value.
+            connection_qn = ""
+            if input.connection and input.connection.attributes:
+                connection_qn = input.connection.attributes.qualified_name or ""
+
             # Upload extracted data to Atlan
             if input.output_path:
                 upload_result = await self.upload_to_atlan(
@@ -418,6 +425,9 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
                 tables_extracted=table_result.total_record_count,
                 columns_extracted=column_result.total_record_count,
                 records_uploaded=records_uploaded,
+                connection_qualified_name=connection_qn,
+                output_path=input.output_path,
+                output_prefix=input.output_prefix,
             )
 
         except Exception as e:

--- a/tests/unit/templates/test_sql_metadata_extractor.py
+++ b/tests/unit/templates/test_sql_metadata_extractor.py
@@ -642,3 +642,93 @@ class TestGetCredentials:
             await extractor._get_credentials(
                 ExtractionTaskInput(credential_guid="some-guid-that-needs-a-store")
             )
+
+
+class TestConnectionQnExtraction:
+    """Tests for connection_qualified_name extraction logic in run().
+
+    The run() method extracts connection_qualified_name from input.connection
+    using this inline pattern:
+        connection_qn = ""
+        if input.connection and input.connection.attributes:
+            connection_qn = input.connection.attributes.qualified_name or ""
+    These tests verify the ExtractionInput → connection_qn derivation.
+    """
+
+    @staticmethod
+    def _extract_connection_qn(inp: ExtractionInput) -> str:
+        """Replicate the inline connection_qn extraction from run()."""
+        connection_qn = ""
+        if inp.connection and inp.connection.attributes:
+            connection_qn = inp.connection.attributes.qualified_name or ""
+        return connection_qn
+
+    def test_returns_qualified_name_from_connection(self) -> None:
+        from application_sdk.contracts.types import ConnectionAttributes, ConnectionRef
+
+        inp = ExtractionInput(
+            connection=ConnectionRef(
+                attributes=ConnectionAttributes(
+                    qualified_name="default/alloydb-postgres/my-conn"
+                )
+            )
+        )
+        assert self._extract_connection_qn(inp) == "default/alloydb-postgres/my-conn"
+
+    def test_returns_empty_when_no_connection(self) -> None:
+        inp = ExtractionInput()
+        assert self._extract_connection_qn(inp) == ""
+
+    def test_returns_empty_when_no_attributes(self) -> None:
+        from application_sdk.contracts.types import ConnectionRef
+
+        inp = ExtractionInput(connection=ConnectionRef())
+        assert self._extract_connection_qn(inp) == ""
+
+    def test_returns_empty_when_qualified_name_is_empty(self) -> None:
+        from application_sdk.contracts.types import ConnectionAttributes, ConnectionRef
+
+        inp = ExtractionInput(
+            connection=ConnectionRef(attributes=ConnectionAttributes(qualified_name=""))
+        )
+        assert self._extract_connection_qn(inp) == ""
+
+
+class TestExtractionOutputFields:
+    """Tests for connection_qualified_name, output_path, output_prefix on ExtractionOutput.
+
+    The fix ensures run() passes these fields to ExtractionOutput so that
+    PublishInputMixin can auto-derive publish_state_prefix and current_state_prefix.
+    """
+
+    def test_sets_connection_qualified_name(self) -> None:
+        output = ExtractionOutput(
+            success=True,
+            connection_qualified_name="default/postgres/prod",
+            databases_extracted=2,
+            schemas_extracted=5,
+            records_uploaded=10,
+        )
+        assert output.connection_qualified_name == "default/postgres/prod"
+
+    def test_sets_output_path_and_prefix(self) -> None:
+        output = ExtractionOutput(
+            success=True,
+            output_path="artifacts/apps/my-app/workflows/wf1/run1",
+            output_prefix="/tmp",
+        )
+        assert output.output_path == "artifacts/apps/my-app/workflows/wf1/run1"
+        assert output.output_prefix == "/tmp"
+
+    def test_defaults_to_empty_strings(self) -> None:
+        output = ExtractionOutput()
+        assert output.connection_qualified_name == ""
+        assert output.output_path == ""
+        assert output.output_prefix == ""
+
+    def test_publish_state_prefix_derived_from_connection_qn(self) -> None:
+        output = ExtractionOutput(
+            connection_qualified_name="default/postgres/prod",
+        )
+        assert "default/postgres/prod" in output.publish_state_prefix
+        assert "default/postgres/prod" in output.current_state_prefix


### PR DESCRIPTION
## Summary
- `SqlMetadataExtractor.run()` returned `ExtractionOutput` without setting `connection_qualified_name`, `output_path`, or `output_prefix`
- `PublishInputMixin` could not auto-derive `transformed_data_prefix`, `publish_state_prefix`, or `current_state_prefix` — causing the Publish App to receive empty paths and complete with 0 entities
- Extracts `connection_qualified_name` from `input.connection.attributes.qualified_name` and passes `output_path`/`output_prefix` so the mixin derives all publish fields automatically

## Context
- Discovered during AlloyDB Postgres v3 + AE upgrade on devex.atlan.com
- Same issue hit by GCS app (Angad Sethi) and Coalesce app (Sanober Bhogle) — see Slack thread in #project-killargo
- Prateek Rai confirmed the fix pattern: use `PublishInputMixin` fields on the extractor output
- Linear: BLDX-1100

## Note
This fixes connectors using the **default** `run()`. Connectors that override `run()` (like AlloyDB) must still set `connection_qualified_name` themselves — but this ensures the base template does the right thing out of the box.

## Test plan
- [x] Existing tests pass (60/60)
- [x] Pre-commit passes (ruff, ruff-format, pyright)
- [ ] Verify on a connector using default `run()` that publish fields are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)