### PR TITLE
fix(contracts): warn on unknown-extra keys in Input payloads [ARUN-527]

### DIFF
--- a/application_sdk/contracts/base.py
+++ b/application_sdk/contracts/base.py
@@ -57,6 +57,7 @@ Evolution:
 """
 
 import hashlib
+import logging
 import re
 from enum import StrEnum
 from typing import (
@@ -77,6 +78,8 @@ from pydantic_core import PydanticUndefined
 
 from application_sdk.contracts.types import MaxItems  # noqa: TC001
 from application_sdk.errors import CONTRACT_VALIDATION, PAYLOAD_SAFETY, ErrorCode
+
+_logger = logging.getLogger(__name__)
 
 # =============================================================================
 # Serializable Enum Base Class
@@ -165,6 +168,66 @@ class Input(BaseModel):
     volatile/per-run fields that shouldn't affect checkpoint identity.
     config_hash() unions this set across the full MRO, so subclass entries
     are merged with (not replaced by) base-class exclusions."""
+
+    _unknown_keys_seen: ClassVar[set[tuple[str, tuple[str, ...]]]] = set()
+    """Dedup set for the unknown-key warning: at most one log line per
+    (subclass name, sorted unknown keys) pair across the process lifetime."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _warn_on_unknown_keys(cls, data: Any) -> Any:
+        """Warn when the incoming payload contains keys not declared on the model.
+
+        Pydantic silently drops unknown keys by default. That default masks
+        contract drift between the SDK and upstream payload producers (the
+        Automation Engine, Heracles, the Kill-Argo native dispatcher, or the
+        manifest generator in app-contract-toolkit) — the symptom is an empty
+        field at runtime with no trace of why.
+
+        We don't rewrite the payload here. Normalization belongs at the source.
+        This validator only emits a one-time ``WARNING`` per (class, extras)
+        pair so the drift is visible in logs and the root cause can be fixed
+        upstream.
+
+        Kebab-case keys get an extra hint in the log line — they're the
+        most common form of drift today (AE payloads built from kebab-case
+        UI form field names). See ARUN-527.
+        """
+        if not isinstance(data, dict):
+            return data
+        if cls.model_config.get("extra") == "allow":
+            return data
+        known = {name for name in cls.model_fields}
+        known.update(
+            field.alias
+            for field in cls.model_fields.values()
+            if field.alias is not None
+        )
+        extras = sorted(
+            str(k) for k in data if k not in known and not str(k).startswith("_")
+        )
+        if not extras:
+            return data
+        seen_key = (cls.__name__, tuple(extras))
+        if seen_key in Input._unknown_keys_seen:
+            return data
+        Input._unknown_keys_seen.add(seen_key)
+        kebab = [k for k in extras if "-" in k]
+        hint = ""
+        if kebab:
+            mapped = {k: k.replace("-", "_") for k in kebab}
+            hint = (
+                f" Kebab-case keys detected — producer likely meant {mapped}."
+                " Fix at the source (manifest generator / payload producer),"
+                " not in the SDK."
+            )
+        _logger.warning(
+            "Unknown keys in payload for %s, silently dropped by Pydantic: %s.%s",
+            cls.__name__,
+            extras,
+            hint,
+        )
+        return data
 
     def _log_summary(self) -> dict[str, Any]:
         """Return a dict of field values safe for logging.

--- a/tests/unit/contracts/test_base.py
+++ b/tests/unit/contracts/test_base.py
@@ -1,9 +1,10 @@
 """Unit tests for application_sdk.contracts.base."""
 
+import logging
 from typing import Annotated, Any, Optional
 
 import pytest
-from pydantic import Field, ValidationError
+from pydantic import ConfigDict, Field, ValidationError
 
 from application_sdk.contracts.base import (
     ContractMetadata,
@@ -490,3 +491,119 @@ class TestContractMetadata:
         )
         with pytest.raises((ValidationError, AttributeError, TypeError)):
             meta.name = "other"  # type: ignore[misc]
+
+
+# =============================================================================
+# Unknown-key warning (ARUN-527)
+# =============================================================================
+
+
+@pytest.fixture(autouse=False)
+def _reset_unknown_keys_seen() -> Any:
+    """Isolate the class-level dedup set so tests don't leak into each other."""
+    original = Input._unknown_keys_seen.copy()
+    Input._unknown_keys_seen.clear()
+    try:
+        yield
+    finally:
+        Input._unknown_keys_seen.clear()
+        Input._unknown_keys_seen.update(original)
+
+
+class TestUnknownKeyWarning:
+    def test_kebab_case_extra_warns_with_snake_case_hint(
+        self, caplog: pytest.LogCaptureFixture, _reset_unknown_keys_seen: Any
+    ) -> None:
+        class ExtractionInput(Input):
+            credential_guid: str = ""
+            include_filter: str = "{}"
+
+        payload = {
+            "credential-guid": "abc-123",
+            "include-filter": '{"^qa$":[".*"]}',
+        }
+        with caplog.at_level(logging.WARNING, logger="application_sdk.contracts.base"):
+            obj = ExtractionInput.model_validate(payload)
+
+        # Silent drop still happens — we only observe, not normalize.
+        assert obj.credential_guid == ""
+        assert obj.include_filter == "{}"
+
+        assert len(caplog.records) == 1
+        msg = caplog.records[0].getMessage()
+        assert "ExtractionInput" in msg
+        assert "credential-guid" in msg
+        assert "include-filter" in msg
+        assert "credential_guid" in msg
+        assert "include_filter" in msg
+
+    def test_arbitrary_extras_warn_without_kebab_hint(
+        self, caplog: pytest.LogCaptureFixture, _reset_unknown_keys_seen: Any
+    ) -> None:
+        class MyInput(Input):
+            name: str = ""
+
+        with caplog.at_level(logging.WARNING, logger="application_sdk.contracts.base"):
+            MyInput.model_validate({"name": "ok", "stray_key": 1})
+
+        assert len(caplog.records) == 1
+        msg = caplog.records[0].getMessage()
+        assert "stray_key" in msg
+        assert "Kebab-case" not in msg
+
+    def test_no_warning_when_all_keys_known(
+        self, caplog: pytest.LogCaptureFixture, _reset_unknown_keys_seen: Any
+    ) -> None:
+        class MyInput(Input):
+            name: str = ""
+
+        with caplog.at_level(logging.WARNING, logger="application_sdk.contracts.base"):
+            MyInput.model_validate({"name": "ok", "workflow_id": "wf-1"})
+
+        assert caplog.records == []
+
+    def test_no_warning_when_extra_allow(
+        self, caplog: pytest.LogCaptureFixture, _reset_unknown_keys_seen: Any
+    ) -> None:
+        class PermissiveInput(Input):
+            model_config = ConfigDict(extra="allow")
+
+            name: str = ""
+
+        with caplog.at_level(logging.WARNING, logger="application_sdk.contracts.base"):
+            PermissiveInput.model_validate({"name": "ok", "anything": 1})
+
+        assert caplog.records == []
+
+    def test_non_dict_input_does_not_crash(self, _reset_unknown_keys_seen: Any) -> None:
+        class MyInput(Input):
+            name: str = ""
+
+        # Passing an existing instance through model_validate should be a no-op
+        # for our validator (data is not a dict at that stage).
+        original = MyInput(name="x")
+        assert MyInput.model_validate(original).name == "x"
+
+    def test_same_extras_logged_once_per_process(
+        self, caplog: pytest.LogCaptureFixture, _reset_unknown_keys_seen: Any
+    ) -> None:
+        class MyInput(Input):
+            name: str = ""
+
+        with caplog.at_level(logging.WARNING, logger="application_sdk.contracts.base"):
+            for _ in range(5):
+                MyInput.model_validate({"name": "ok", "stray": 1})
+
+        assert len(caplog.records) == 1
+
+    def test_different_extras_each_warn_once(
+        self, caplog: pytest.LogCaptureFixture, _reset_unknown_keys_seen: Any
+    ) -> None:
+        class MyInput(Input):
+            name: str = ""
+
+        with caplog.at_level(logging.WARNING, logger="application_sdk.contracts.base"):
+            MyInput.model_validate({"name": "ok", "a": 1})
+            MyInput.model_validate({"name": "ok", "b": 2})
+
+        assert len(caplog.records) == 2


### PR DESCRIPTION
## Summary

Pydantic silently drops keys that don't match the model's declared fields. That default masks contract drift between the SDK and upstream payload producers — the symptom is an empty field at runtime with no trace of why.

ARUN-527 surfaced exactly this: AE dispatches v3 native-connector payloads with kebab-case keys (`credential-guid`, `include-filter`, `exclude-filter`), the SDK's `ExtractionInput` declares snake_case fields, and the kebab keys are silently dropped → credentials resolve to empty → workflows fail.

This PR does **not** normalize kebab → snake. The canonical fix lives upstream — `app-contract-toolkit` PR #21, shipped in `v0.4.1` — and adding a second translation layer in the SDK was explicitly rejected in the [Slack thread](https://atlanhq.slack.com/archives/C0AHHBDBP9Q/p1776759020122989) (Vaibhav, Chris Grote). What the SDK was missing was *observability*: drift was invisible until a workflow failed.

## What changed

- `Input` now runs a `model_validator(mode="before")` that logs a one-time `WARNING` per `(subclass, sorted extras)` pair when the incoming dict has keys not declared on the model.
- The payload is returned unchanged — Pydantic's default drop-behavior is preserved.
- Kebab-case keys get an extra hint in the log line (`{'credential-guid': 'credential_guid', ...}`), since that's the current repeat offender.
- `model_config = ConfigDict(extra="allow")` subclasses are not warned — opted-in behavior.
- Class-level dedup set (`Input._unknown_keys_seen`) prevents log spam when Temporal replays the same bad payload.

Philosophy: don't translate, but don't silently accept garbage either. Future drift from any producer (AE, Heracles, the toolkit, a new internal service) will show up in logs immediately instead of as an empty field three activities deep.

## Why not normalize in the SDK?

The Slack thread ([link](https://atlanhq.slack.com/archives/C0AHHBDBP9Q/p1776759020122989)) landed on a clear conclusion:
- Vaibhav: "we don't have to do the above changes in SDK" (after toolkit PR #21 was merged).
- Chris Grote: "every other team deciding how to format and name fields means we end up with translation layers everywhere — one more hop / potential failure point."
- PR #1493 (the earlier SDK normalizer) was closed intentionally.

Warning ≠ translation. This PR keeps the SDK honest without reintroducing the translation layer the team rejected.

## Test plan

- [x] Kebab-case extras warn once with a snake_case mapping hint in the message
- [x] Arbitrary extras warn without the kebab hint
- [x] No warning when all keys are known (including `workflow_id` / `correlation_id`)
- [x] No warning when subclass declares `ConfigDict(extra="allow")`
- [x] Passing an existing model instance through `model_validate` doesn't crash the validator (data-not-a-dict path)
- [x] Same `(class, extras)` replayed 5x logs once (dedup)
- [x] Different extras on the same class each log once
- [x] All 50 pre-existing `test_base.py` tests still pass
- [x] All 111 tests under `tests/unit/contracts` pass
- [x] All 97 tests under `tests/unit/templates` (which exercise `ExtractionInput`) pass
- [x] `ruff`, `ruff-format`, `isort`, `pyright` clean on changed files

## Linear

https://linear.app/atlan-epd/issue/ARUN-527