### PR TITLE
chore(deps): remove psutil, use stdlib resource module [BLDX-1110]

### DIFF
--- a/application_sdk/observability/app_vitals.py
+++ b/application_sdk/observability/app_vitals.py
@@ -256,11 +256,13 @@ def _detect_circuit_breaker(failed_acts: list[dict[str, Any]]) -> bool:
     """
     for a in failed_acts:
         # Build a single searchable string from all error fields
-        searchable = " ".join([
-            str(a.get("error_class", "")).lower(),
-            str(a.get("error_message", "")).lower(),
-            " ".join(str(c).lower() for c in a.get("error_cause_chain", [])),
-        ])
+        searchable = " ".join(
+            [
+                str(a.get("error_class", "")).lower(),
+                str(a.get("error_message", "")).lower(),
+                " ".join(str(c).lower() for c in a.get("error_cause_chain", [])),
+            ]
+        )
         if any(kw in searchable for kw in _CB_KEYWORDS):
             return True
     return False

--- a/application_sdk/observability/error_classifier.py
+++ b/application_sdk/observability/error_classifier.py
@@ -145,5 +145,3 @@ def extract_cause_chain(exc: BaseException, limit: int = 5) -> list[str]:
         current = current.__cause__ or current.__context__
 
     return causes
-
-

--- a/application_sdk/observability/resource_sampler.py
+++ b/application_sdk/observability/resource_sampler.py
@@ -4,28 +4,21 @@ Captures CPU time and memory usage at activity boundaries so the
 interceptor can emit ``activity_cpu_seconds`` and ``activity_mem_gb_sec``
 (RFC metrics #10 and #11 from DESIGN.md §4.1).
 
-Scope limitation: these are **process-level** samples via psutil, not
-per-task attribution. For a worker running one activity at a time, the
-delta is accurate. For a worker running multiple activities concurrently,
-concurrent activities share the same process so the values over-attribute
-CPU/memory to each concurrent activity individually — but the sum across
-activities remains correct for workload-total calculations.
+Uses stdlib ``resource`` module — no external dependencies (psutil removed).
+On Linux, reads ``/proc/self/stat`` for RSS when available. Falls back to
+``resource.getrusage()`` on macOS and other platforms.
 
-Per-activity attribution (cgroup delegation, cgroup v2 PID controllers,
-or per-task CPU accounting in Python 3.12+) is on the look-later list.
+Scope limitation: these are **process-level** samples, not per-task
+attribution. For a worker running one activity at a time, the delta is
+accurate. For concurrent activities, values over-attribute per activity
+but the sum remains correct.
 """
 
 from __future__ import annotations
 
 import os
+import sys
 from dataclasses import dataclass
-
-try:
-    import psutil
-
-    _PROCESS: psutil.Process | None = psutil.Process(os.getpid())
-except Exception:
-    _PROCESS = None
 
 
 @dataclass(frozen=True)
@@ -36,22 +29,44 @@ class ResourceSample:
     rss_bytes: int  # resident set size in bytes (memory currently in RAM)
 
 
+def _read_proc_rss() -> int | None:
+    """Read RSS from /proc/self/stat (Linux only, no dependencies)."""
+    try:
+        with open("/proc/self/stat", "rb") as f:
+            parts = f.read().split()
+        # Field 24 (index 23) is RSS in pages
+        rss_pages = int(parts[23])
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        return rss_pages * page_size
+    except Exception:
+        return None
+
+
 def sample() -> ResourceSample | None:
     """Capture current process CPU time and memory.
 
     Returns:
-        ResourceSample, or None if sampling is unavailable (e.g. psutil
-        import failed or the process handle is invalid).
+        ResourceSample, or None if sampling fails (e.g. on Windows).
     """
-    if _PROCESS is None:
-        return None
     try:
-        times = _PROCESS.cpu_times()
-        mem = _PROCESS.memory_info()
-        return ResourceSample(
-            cpu_time_s=times.user + times.system,
-            rss_bytes=mem.rss,
-        )
+        import resource
+    except ImportError:
+        # resource module not available on Windows
+        return None
+
+    try:
+        usage = resource.getrusage(resource.RUSAGE_SELF)
+        cpu_time = usage.ru_utime + usage.ru_stime
+
+        # Try /proc for accurate RSS on Linux
+        rss = _read_proc_rss()
+        if rss is None:
+            # macOS: ru_maxrss is in bytes; Linux: in KB (but we use /proc above)
+            rss = usage.ru_maxrss
+            if sys.platform == "linux":
+                rss *= 1024  # Linux reports KB
+
+        return ResourceSample(cpu_time_s=cpu_time, rss_bytes=rss)
     except Exception:
         return None
 

--- a/application_sdk/observability/resource_sampler.py
+++ b/application_sdk/observability/resource_sampler.py
@@ -16,9 +16,12 @@ but the sum remains correct.
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from dataclasses import dataclass
+
+_logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -39,6 +42,7 @@ def _read_proc_rss() -> int | None:
         page_size = os.sysconf("SC_PAGE_SIZE")
         return rss_pages * page_size
     except Exception:
+        _logger.debug("Failed to read /proc/self/stat for RSS", exc_info=True)
         return None
 
 
@@ -68,6 +72,7 @@ def sample() -> ResourceSample | None:
 
         return ResourceSample(cpu_time_s=cpu_time, rss_bytes=rss)
     except Exception:
+        _logger.debug("Resource sampling unavailable", exc_info=True)
         return None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "aiohttp>=3.10.0,<3.14.0",
     "opentelemetry-exporter-otlp==1.39.1",
     "opentelemetry-exporter-prometheus==0.60b1",
-    "psutil>=7.0.0,<7.3.0",
     "fastapi[standard]==0.127.0",
     "pyatlan>=9,<10",
     "httpx-retries>=0.4.0,<0.5.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -199,8 +199,6 @@ protobuf==6.33.5
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   temporalio
-psutil==7.2.1
-    # via atlan-application-sdk
 pyatlan==9.3.1
     # via atlan-application-sdk
 pycparser==2.23 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'

--- a/tests/unit/interceptors/test_app_vitals.py
+++ b/tests/unit/interceptors/test_app_vitals.py
@@ -626,8 +626,6 @@ class TestErrorClassifierRichFields:
         assert len(chain) == 3
 
 
-
-
 class TestAppVitalsRichErrorFields:
     """Tests that activity failure events include cause chain + timeout budget."""
 

--- a/tests/unit/interceptors/test_app_vitals.py
+++ b/tests/unit/interceptors/test_app_vitals.py
@@ -413,7 +413,7 @@ class TestResourceSampler:
         from application_sdk.observability.resource_sampler import sample
 
         s = sample()
-        # On Mac/Linux with psutil installed, this should work
+        # On Mac/Linux, stdlib resource module should work
         if s is not None:
             assert s.cpu_time_s >= 0
             assert s.rss_bytes > 0
@@ -483,7 +483,7 @@ class TestAppVitalsEfficiencyMetrics:
 
             await interceptor.execute_activity(MockExecuteActivityInput())
 
-            # Efficiency metrics should be emitted if psutil works on this platform
+            # Efficiency metrics should be emitted if resource sampling works on this platform
             # (may be 0.0 values, but metrics are emitted)
 
 

--- a/tests/unit/observability/test_resource_sampler.py
+++ b/tests/unit/observability/test_resource_sampler.py
@@ -25,11 +25,10 @@ class TestSample:
         assert result.rss_bytes > 0
 
     def test_sample_returns_none_when_resource_unavailable(self):
-        """If resource module can't be imported, return None gracefully."""
+        """If resource module can't be imported, return None."""
         with patch.dict("sys.modules", {"resource": None}):
-            # sample() should never raise, always return None or ResourceSample
             result = sample()
-            assert result is None or isinstance(result, ResourceSample)
+            assert result is None
 
     def test_sample_handles_exception_gracefully(self):
         """If getrusage raises, return None."""

--- a/tests/unit/observability/test_resource_sampler.py
+++ b/tests/unit/observability/test_resource_sampler.py
@@ -1,0 +1,80 @@
+"""Unit tests for resource_sampler (stdlib-based, no psutil)."""
+
+import sys
+from unittest.mock import patch
+
+from application_sdk.observability.resource_sampler import (
+    ResourceSample,
+    compute_deltas,
+    sample,
+)
+
+
+class TestSample:
+    def test_sample_returns_resource_sample_on_unix(self):
+        """On Mac/Linux, sample() should return a ResourceSample."""
+        if sys.platform == "win32":
+            # resource module unavailable on Windows
+            assert sample() is None
+            return
+
+        result = sample()
+        assert result is not None
+        assert isinstance(result, ResourceSample)
+        assert result.cpu_time_s >= 0
+        assert result.rss_bytes > 0
+
+    def test_sample_returns_none_when_resource_unavailable(self):
+        """If resource module can't be imported, return None gracefully."""
+        with patch.dict("sys.modules", {"resource": None}):
+            # Force ImportError on next import attempt
+            import importlib
+
+            # Can't easily force ImportError inside sample() without
+            # mocking builtins.__import__, so test the contract:
+            # sample() should never raise, always return None or ResourceSample
+            result = sample()
+            assert result is None or isinstance(result, ResourceSample)
+
+    def test_sample_handles_exception_gracefully(self):
+        """If getrusage raises, return None."""
+        if sys.platform == "win32":
+            return
+
+        with patch("resource.getrusage", side_effect=OSError("mocked")):
+            result = sample()
+            assert result is None
+
+
+class TestComputeDeltas:
+    def test_both_none_returns_zeros(self):
+        assert compute_deltas(None, None, 10.0) == (0.0, 0.0)
+
+    def test_start_none_returns_zeros(self):
+        end = ResourceSample(cpu_time_s=5.0, rss_bytes=1024 * 1024 * 512)
+        assert compute_deltas(None, end, 10.0) == (0.0, 0.0)
+
+    def test_end_none_returns_zeros(self):
+        start = ResourceSample(cpu_time_s=1.0, rss_bytes=1024 * 1024 * 256)
+        assert compute_deltas(start, None, 10.0) == (0.0, 0.0)
+
+    def test_normal_deltas(self):
+        start = ResourceSample(cpu_time_s=1.0, rss_bytes=1024**3)  # 1 GiB
+        end = ResourceSample(cpu_time_s=3.0, rss_bytes=1024**3)  # 1 GiB
+        cpu, mem = compute_deltas(start, end, 10.0)
+        assert cpu == 2.0
+        assert mem == 10.0  # 1 GiB * 10s = 10 GiB.s
+
+    def test_zero_duration(self):
+        start = ResourceSample(cpu_time_s=1.0, rss_bytes=1024**3)
+        end = ResourceSample(cpu_time_s=2.0, rss_bytes=1024**3)
+        cpu, mem = compute_deltas(start, end, 0.0)
+        assert cpu == 1.0
+        assert mem == 0.0
+
+    def test_negative_cpu_clamped_to_zero(self):
+        """CPU time should never go backwards, but clamp to 0 if it does."""
+        start = ResourceSample(cpu_time_s=5.0, rss_bytes=1024**3)
+        end = ResourceSample(cpu_time_s=3.0, rss_bytes=1024**3)
+        cpu, mem = compute_deltas(start, end, 10.0)
+        assert cpu == 0.0

--- a/tests/unit/observability/test_resource_sampler.py
+++ b/tests/unit/observability/test_resource_sampler.py
@@ -27,11 +27,6 @@ class TestSample:
     def test_sample_returns_none_when_resource_unavailable(self):
         """If resource module can't be imported, return None gracefully."""
         with patch.dict("sys.modules", {"resource": None}):
-            # Force ImportError on next import attempt
-            import importlib
-
-            # Can't easily force ImportError inside sample() without
-            # mocking builtins.__import__, so test the contract:
             # sample() should never raise, always return None or ResourceSample
             result = sample()
             assert result is None or isinstance(result, ResourceSample)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -215,7 +215,6 @@ dependencies = [
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-exporter-prometheus" },
     { name = "orjson" },
-    { name = "psutil" },
     { name = "pyatlan" },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -337,7 +336,6 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2.3,<2.4.0" },
     { name = "pandas", marker = "extra == 'sql'", specifier = ">=2.2.3,<2.4.0" },
     { name = "pandera", extras = ["io"], marker = "extra == 'tests'", specifier = ">=0.23.1,<0.28.0" },
-    { name = "psutil", specifier = ">=7.0.0,<7.3.0" },
     { name = "pyarrow", marker = "extra == 'incremental'", specifier = ">=20.0.0,<23.0.0" },
     { name = "pyarrow", marker = "extra == 'pandas'", specifier = ">=20.0.0,<23.0.0" },
     { name = "pyarrow", marker = "extra == 'sql'", specifier = ">=20.0.0,<23.0.0" },
@@ -3299,34 +3297,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
     { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
     { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
-]
-
-[[package]]
-name = "psutil"
-version = "7.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/cb/09e5184fb5fc0358d110fc3ca7f6b1d033800734d34cac10f4136cfac10e/psutil-7.2.1.tar.gz", hash = "sha256:f7583aec590485b43ca601dd9cea0dcd65bd7bb21d30ef4ddbf4ea6b5ed1bdd3", size = 490253, upload-time = "2025-12-29T08:26:00.169Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/8e/f0c242053a368c2aa89584ecd1b054a18683f13d6e5a318fc9ec36582c94/psutil-7.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ba9f33bb525b14c3ea563b2fd521a84d2fa214ec59e3e6a2858f78d0844dd60d", size = 129624, upload-time = "2025-12-29T08:26:04.255Z" },
-    { url = "https://files.pythonhosted.org/packages/26/97/a58a4968f8990617decee234258a2b4fc7cd9e35668387646c1963e69f26/psutil-7.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:81442dac7abfc2f4f4385ea9e12ddf5a796721c0f6133260687fec5c3780fa49", size = 130132, upload-time = "2025-12-29T08:26:06.228Z" },
-    { url = "https://files.pythonhosted.org/packages/db/6d/ed44901e830739af5f72a85fa7ec5ff1edea7f81bfbf4875e409007149bd/psutil-7.2.1-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea46c0d060491051d39f0d2cff4f98d5c72b288289f57a21556cc7d504db37fc", size = 180612, upload-time = "2025-12-29T08:26:08.276Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/65/b628f8459bca4efbfae50d4bf3feaab803de9a160b9d5f3bd9295a33f0c2/psutil-7.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:35630d5af80d5d0d49cfc4d64c1c13838baf6717a13effb35869a5919b854cdf", size = 183201, upload-time = "2025-12-29T08:26:10.622Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/23/851cadc9764edcc18f0effe7d0bf69f727d4cf2442deb4a9f78d4e4f30f2/psutil-7.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:923f8653416604e356073e6e0bccbe7c09990acef442def2f5640dd0faa9689f", size = 139081, upload-time = "2025-12-29T08:26:12.483Z" },
-    { url = "https://files.pythonhosted.org/packages/59/82/d63e8494ec5758029f31c6cb06d7d161175d8281e91d011a4a441c8a43b5/psutil-7.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:cfbe6b40ca48019a51827f20d830887b3107a74a79b01ceb8cc8de4ccb17b672", size = 134767, upload-time = "2025-12-29T08:26:14.528Z" },
-    { url = "https://files.pythonhosted.org/packages/05/c2/5fb764bd61e40e1fe756a44bd4c21827228394c17414ade348e28f83cd79/psutil-7.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:494c513ccc53225ae23eec7fe6e1482f1b8a44674241b54561f755a898650679", size = 129716, upload-time = "2025-12-29T08:26:16.017Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/d2/935039c20e06f615d9ca6ca0ab756cf8408a19d298ffaa08666bc18dc805/psutil-7.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fce5f92c22b00cdefd1645aa58ab4877a01679e901555067b1bd77039aa589f", size = 130133, upload-time = "2025-12-29T08:26:18.009Z" },
-    { url = "https://files.pythonhosted.org/packages/77/69/19f1eb0e01d24c2b3eacbc2f78d3b5add8a89bf0bb69465bc8d563cc33de/psutil-7.2.1-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93f3f7b0bb07711b49626e7940d6fe52aa9940ad86e8f7e74842e73189712129", size = 181518, upload-time = "2025-12-29T08:26:20.241Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/6d/7e18b1b4fa13ad370787626c95887b027656ad4829c156bb6569d02f3262/psutil-7.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d34d2ca888208eea2b5c68186841336a7f5e0b990edec929be909353a202768a", size = 184348, upload-time = "2025-12-29T08:26:22.215Z" },
-    { url = "https://files.pythonhosted.org/packages/98/60/1672114392dd879586d60dd97896325df47d9a130ac7401318005aab28ec/psutil-7.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2ceae842a78d1603753561132d5ad1b2f8a7979cb0c283f5b52fb4e6e14b1a79", size = 140400, upload-time = "2025-12-29T08:26:23.993Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/7b/d0e9d4513c46e46897b46bcfc410d51fc65735837ea57a25170f298326e6/psutil-7.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:08a2f175e48a898c8eb8eace45ce01777f4785bc744c90aa2cc7f2fa5462a266", size = 135430, upload-time = "2025-12-29T08:26:25.999Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/cf/5180eb8c8bdf6a503c6919f1da28328bd1e6b3b1b5b9d5b01ae64f019616/psutil-7.2.1-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b2e953fcfaedcfbc952b44744f22d16575d3aa78eb4f51ae74165b4e96e55f42", size = 128137, upload-time = "2025-12-29T08:26:27.759Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/2c/78e4a789306a92ade5000da4f5de3255202c534acdadc3aac7b5458fadef/psutil-7.2.1-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:05cc68dbb8c174828624062e73078e7e35406f4ca2d0866c272c2410d8ef06d1", size = 128947, upload-time = "2025-12-29T08:26:29.548Z" },
-    { url = "https://files.pythonhosted.org/packages/29/f8/40e01c350ad9a2b3cb4e6adbcc8a83b17ee50dd5792102b6142385937db5/psutil-7.2.1-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e38404ca2bb30ed7267a46c02f06ff842e92da3bb8c5bfdadbd35a5722314d8", size = 154694, upload-time = "2025-12-29T08:26:32.147Z" },
-    { url = "https://files.pythonhosted.org/packages/06/e4/b751cdf839c011a9714a783f120e6a86b7494eb70044d7d81a25a5cd295f/psutil-7.2.1-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab2b98c9fc19f13f59628d94df5cc4cc4844bc572467d113a8b517d634e362c6", size = 156136, upload-time = "2025-12-29T08:26:34.079Z" },
-    { url = "https://files.pythonhosted.org/packages/44/ad/bbf6595a8134ee1e94a4487af3f132cef7fce43aef4a93b49912a48c3af7/psutil-7.2.1-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f78baafb38436d5a128f837fab2d92c276dfb48af01a240b861ae02b2413ada8", size = 148108, upload-time = "2025-12-29T08:26:36.225Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/15/dd6fd869753ce82ff64dcbc18356093471a5a5adf4f77ed1f805d473d859/psutil-7.2.1-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:99a4cd17a5fdd1f3d014396502daa70b5ec21bf4ffe38393e152f8e449757d67", size = 147402, upload-time = "2025-12-29T08:26:39.21Z" },
-    { url = "https://files.pythonhosted.org/packages/34/68/d9317542e3f2b180c4306e3f45d3c922d7e86d8ce39f941bb9e2e9d8599e/psutil-7.2.1-cp37-abi3-win_amd64.whl", hash = "sha256:b1b0671619343aa71c20ff9767eced0483e4fc9e1f489d50923738caf6a03c17", size = 136938, upload-time = "2025-12-29T08:26:41.036Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/73/2ce007f4198c80fcf2cb24c169884f833fe93fbc03d55d302627b094ee91/psutil-7.2.1-cp37-abi3-win_arm64.whl", hash = "sha256:0d67c1822c355aa6f7314d92018fb4268a76668a536f133599b91edd48759442", size = 133836, upload-time = "2025-12-29T08:26:43.086Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Remove `psutil` from core dependencies. Replace with stdlib `resource` module + `/proc/self/stat` (Linux) for CPU time and memory sampling.

Closes #773

## Changes
- `application_sdk/observability/resource_sampler.py` — rewritten to use `resource.getrusage()` for CPU time and `/proc/self/stat` for RSS on Linux, with `ru_maxrss` fallback on macOS
- `pyproject.toml` — removed `psutil>=7.0.0,<7.3.0` from dependencies
- Test comments updated (psutil → resource sampling)

## Impact
- One fewer C-extension dependency in the install
- Same API: `sample()` returns `ResourceSample | None`, `compute_deltas()` unchanged
- Graceful fallback: returns `None` if sampling fails (same as before when psutil was missing)

## Linear
https://linear.app/atlan-epd/issue/BLDX-1110