### PR TITLE
deps: make pyatlan an optional dependency [BLDX-1111]

### DIFF
--- a/application_sdk/transformers/atlas/__init__.py
+++ b/application_sdk/transformers/atlas/__init__.py
@@ -9,10 +9,9 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, Optional, Type
 
-from pyatlan.model.enums import AtlanConnectorType, EntityStatus
-
 if TYPE_CHECKING:
     import daft
+    from pyatlan.model.enums import AtlanConnectorType, EntityStatus
 
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.transformers import TransformerInterface
@@ -175,6 +174,8 @@ class AtlasTransformer(TransformerInterface):
                     enriched_data["custom_attributes"]
                 )
 
+                from pyatlan.model.enums import EntityStatus  # deferred: pyatlan is optional
+
                 entity = entity_attributes["entity_class"](
                     attributes=entity_attributes["attributes"],
                     custom_attributes=entity_attributes["custom_attributes"],
@@ -211,6 +212,11 @@ class AtlasTransformer(TransformerInterface):
 
         attributes = {}
         custom_attributes = {}
+
+        from pyatlan.model.enums import (  # deferred: pyatlan is optional
+            AtlanConnectorType,
+            EntityStatus,
+        )
 
         attributes["status"] = EntityStatus.ACTIVE
         attributes["tenant_id"] = self.tenant_id

--- a/application_sdk/transformers/query/__init__.py
+++ b/application_sdk/transformers/query/__init__.py
@@ -5,8 +5,6 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
 
 import yaml
-from pyatlan.model.enums import AtlanConnectorType
-
 if TYPE_CHECKING:
     import daft
 
@@ -372,6 +370,7 @@ class QueryBasedTransformer(TransformerInterface):
             Tuple[daft.DataFrame, str]: DataFrame with default attributes added and the entity SQL template
         """
         import daft
+        from pyatlan.model.enums import AtlanConnectorType  # deferred: pyatlan is optional
 
         # prepare default attributes
         default_attributes = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "opentelemetry-exporter-prometheus==0.60b1",
     "psutil>=7.0.0,<7.3.0",
     "fastapi[standard]==0.127.0",
-    "pyatlan>=9,<10",
     "httpx-retries>=0.4.0,<0.5.0",
     "pydantic>=2.10.6,<2.13.0",
     "loguru>=0.7.3,<0.8.0",
@@ -53,8 +52,13 @@ workflows = [
     "temporalio>=1.7.1,<1.24.0",
     "orjson>=3.11.6,<3.12.0",
 ]
+# pyatlan: required by Atlas transformers, handler contracts, and connectors that use pyatlan models
+pyatlan = [
+    "pyatlan>=9,<10",
+]
 # SQL connectors: SqlMetadataExtractor, SqlQueryExtractor, and any SQL-based connector
 sql = [
+    "pyatlan>=9,<10",
     "pandas>=2.2.3,<2.4.0",
     "pyarrow>=20.0.0,<23.0.0",
     "sqlalchemy[asyncio]>=2.0.36,<2.1.0",
@@ -67,6 +71,7 @@ daft = [
 ]
 # Incremental extraction: sql + daft + RocksDB state store
 incremental = [
+    "pyatlan>=9,<10",
     "pandas>=2.2.3,<2.4.0",
     "pyarrow>=20.0.0,<23.0.0",
     "sqlalchemy[asyncio]>=2.0.36,<2.1.0",


### PR DESCRIPTION
## Summary
Move `pyatlan` from core to optional dependency. Apps that don't use Atlas transformers or pyatlan models no longer pull in pyatlan and its transitive deps.

## Changes
- `pyproject.toml`: removed `pyatlan>=9,<10` from core `dependencies`
- New `[pyatlan]` optional extra for connectors that need it directly
- `pyatlan` included in `[sql]` and `[incremental]` extras (transformers need it)
- `transformers/atlas/__init__.py`: deferred pyatlan imports (EntityStatus, AtlanConnectorType)
- `transformers/query/__init__.py`: deferred AtlanConnectorType import

## Impact
- `pip install atlan-application-sdk` — no pyatlan (lighter install for utilities/pipelines)
- `pip install atlan-application-sdk[sql]` — includes pyatlan (SQL connectors)
- `pip install atlan-application-sdk[pyatlan]` — includes pyatlan (asset-mapper connectors)
- Existing apps that use `[sql]`, `[incremental]`, or `[daft,iam-auth,workflows,pandas]` with pyatlan explicitly — no change needed

Closes #772

## Linear
https://linear.app/atlan-epd/issue/BLDX-1111