### PR TITLE
fix(ci): skip secret-dependent jobs on fork PRs [BLDX-1113]

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -35,9 +35,10 @@ jobs:
               - 'uv.lock'
               - 'examples/**'
 
-  # Conventional Commits
+  # Conventional Commits (skipped on fork PRs — no org PAT available)
   commits:
     name: Conventional Commits
+    if: github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -74,7 +75,7 @@ jobs:
   trivy-container:
     name: Trivy Container Scan
     needs: changes
-    if: needs.changes.outputs.container == 'true'
+    if: needs.changes.outputs.container == 'true' && github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -252,7 +253,7 @@ jobs:
   run-examples:
     name: Run Examples
     needs: matrix-builder
-    if: ((github.event.action == 'labeled' && github.event.label.name == 'run-examples') || contains(github.event.pull_request.labels.*.name, 'run-examples'))
+    if: ((github.event.action == 'labeled' && github.event.label.name == 'run-examples') || contains(github.event.pull_request.labels.*.name, 'run-examples')) && github.event.pull_request.head.repo.fork != true
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -274,7 +275,7 @@ jobs:
   e2e-apps:
     name: E2E (Apps)
     needs: [changes, matrix-builder]
-    if: ((github.event.action == 'labeled' && github.event.label.name == 'e2e-test') || contains(github.event.pull_request.labels.*.name, 'e2e-test'))
+    if: ((github.event.action == 'labeled' && github.event.label.name == 'e2e-test') || contains(github.event.pull_request.labels.*.name, 'e2e-test')) && github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -34,6 +34,7 @@ jobs:
               - 'pyproject.toml'
               - 'uv.lock'
               - 'examples/**'
+              - '.github/**'
 
   # Conventional Commits (skipped on fork PRs — no org PAT available)
   commits:


### PR DESCRIPTION
## Summary
Fork PRs fail because org secrets aren't available. This adds fork detection so secret-dependent jobs skip gracefully instead of crashing.

## Changes
Added `github.event.pull_request.head.repo.fork != true` condition to 4 jobs:
- **Conventional Commits** — needs `ORG_PAT_GITHUB`
- **Trivy Container Scan** — needs `CHAINGUARD_*` credentials
- **Run Examples** — needs Postgres/Snowflake credentials
- **E2E Apps** — needs `ORG_PAT_GITHUB` to trigger external workflows

## What still runs on forks
Changes detection, docstring coverage, Trivy code scan, unit tests, integration tests, Helm lint, E2E K8s — all work without secrets.

Closes #756

## Linear
https://linear.app/atlan-epd/issue/BLDX-1113