### PR TITLE
fix: skip dashboard deploy when scan artifacts expired

### DIFF
--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -83,6 +83,12 @@ jobs:
           gh run download "$RUN_ID" --name trivy-results --dir /tmp/scan-artifacts || echo "No trivy results"
           gh run download "$RUN_ID" --name snyk-results --dir /tmp/scan-artifacts || echo "No snyk results"
 
+          # If no scan results at all, skip dashboard update to avoid overwriting with zeros
+          if [ ! -f /tmp/scan-artifacts/trivy_results.json ] && [ ! -f /tmp/scan-artifacts/snyk_results.json ]; then
+            echo "::warning::No scan artifacts found (expired?). Skipping dashboard update to preserve existing data."
+            exit 0
+          fi
+
       - name: Generate per-repo dashboard data
         run: |
           python3 - <<'PYEOF'


### PR DESCRIPTION
Prevents overwriting real vulnerability data with zeros when scan artifacts have expired. If no trivy/snyk results found, the workflow exits early and preserves existing dashboard data.