### PR TITLE
fix: avoid reload-time port collisions in local dev

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -318,7 +318,7 @@ METRICS_CLEANUP_ENABLED = (
 )
 METRICS_RETENTION_DAYS = int(os.getenv("ATLAN_METRICS_RETENTION_DAYS", "30"))
 ENABLE_PROMETHEUS_METRICS = (
-    os.getenv("ATLAN_ENABLE_PROMETHEUS_METRICS", "false").lower() == "true"
+    os.getenv("ATLAN_ENABLE_PROMETHEUS_METRICS", "true").lower() == "true"
 )
 
 # Segment Configuration

--- a/application_sdk/execution/_temporal/backend.py
+++ b/application_sdk/execution/_temporal/backend.py
@@ -11,7 +11,10 @@ from temporalio.client import Client
 from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
 
-from application_sdk.constants import TEMPORAL_PROMETHEUS_BIND_ADDRESS
+from application_sdk.constants import (
+    ENABLE_PROMETHEUS_METRICS,
+    TEMPORAL_PROMETHEUS_BIND_ADDRESS,
+)
 from application_sdk.execution.retry import RetryPolicy, _to_temporal_retry_policy
 from application_sdk.observability.logger_adaptor import get_logger
 
@@ -22,27 +25,31 @@ _prometheus_lock = threading.Lock()
 
 
 def _get_prometheus_runtime() -> Runtime:
-    """Get or create the process-level Temporal Runtime with Prometheus metrics.
+    """Get or create the process-level Temporal Runtime.
 
-    The Runtime binds a Prometheus metrics endpoint on the configured address.
-    It is created at most once per process — subsequent calls return the same
-    instance. This prevents port-already-in-use errors when create_temporal_client
-    is called more than once (e.g., after a reconnect or in tests).
+    When Prometheus metrics are enabled, the Runtime binds the configured
+    Prometheus metrics endpoint. It is created at most once per process;
+    subsequent calls return the same instance. This prevents duplicate runtime
+    creation when create_temporal_client is called more than once in a process
+    (e.g., after a reconnect or in tests).
     """
     global _prometheus_runtime
     with _prometheus_lock:
         if _prometheus_runtime is None:
-            _prometheus_runtime = Runtime(
-                telemetry=TelemetryConfig(
-                    metrics=PrometheusConfig(
-                        bind_address=TEMPORAL_PROMETHEUS_BIND_ADDRESS
+            if not ENABLE_PROMETHEUS_METRICS:
+                _prometheus_runtime = Runtime(telemetry=TelemetryConfig())
+            else:
+                _prometheus_runtime = Runtime(
+                    telemetry=TelemetryConfig(
+                        metrics=PrometheusConfig(
+                            bind_address=TEMPORAL_PROMETHEUS_BIND_ADDRESS
+                        )
                     )
                 )
-            )
-            logger.info(
-                "Temporal Prometheus metrics enabled on %s",
-                TEMPORAL_PROMETHEUS_BIND_ADDRESS,
-            )
+                logger.info(
+                    "Temporal Prometheus metrics enabled on %s",
+                    TEMPORAL_PROMETHEUS_BIND_ADDRESS,
+                )
     return _prometheus_runtime
 
 
@@ -334,7 +341,7 @@ async def create_temporal_client(
     if api_key:
         kwargs["api_key"] = api_key
 
-    # Configure Temporal runtime with Prometheus metrics (process-level singleton)
+    # Configure the process-level Temporal runtime, optionally with Prometheus metrics.
     kwargs["runtime"] = _get_prometheus_runtime()
 
     last_exc: Exception | None = None

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -989,6 +989,18 @@ async def run_dev_combined(
     effective_task_queue = task_queue or f"{app_name}-queue"
     app_module = f"{app_class.__module__}:{app_class.__name__}"
 
+    # Disable Prometheus metrics in local dev by default to avoid port
+    # collisions during hot-reload.  Developers can still opt-in by
+    # explicitly setting ATLAN_ENABLE_PROMETHEUS_METRICS=true.
+    if "ATLAN_ENABLE_PROMETHEUS_METRICS" not in os.environ:
+        os.environ["ATLAN_ENABLE_PROMETHEUS_METRICS"] = "false"
+        # Update the already-imported module constant so the Temporal
+        # runtime (which reads the constant, not the env var) also
+        # respects the override.
+        import application_sdk.constants as _constants
+
+        _constants.ENABLE_PROMETHEUS_METRICS = False
+
     config = AppConfig(
         mode="combined",
         app_module=app_module,

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -998,6 +998,7 @@ async def run_dev_combined(
         task_queue=effective_task_queue,
         handler_host=host,
         handler_port=port,
+        health_port=int(os.environ.get("ATLAN_HEALTH_PORT", "0")),
         log_level="DEBUG",
         service_name=_derive_service_name(app_module),
         frontend_assets_path=os.environ.get(

--- a/docs/concepts/common.md
+++ b/docs/concepts/common.md
@@ -156,5 +156,5 @@ token = generate_aws_rds_token_with_iam_user(
 
 | Constant | Env Var | Default | Description |
 |----------|---------|---------|-------------|
-| `ENABLE_PROMETHEUS_METRICS` | `ATLAN_ENABLE_PROMETHEUS_METRICS` | `false` | Enables Prometheus metrics exporters, including the Temporal SDK runtime metrics listener |
+| `ENABLE_PROMETHEUS_METRICS` | `ATLAN_ENABLE_PROMETHEUS_METRICS` | `true` | Enables Prometheus metrics exporters, including the Temporal SDK runtime metrics listener. Set to `false` in local dev to avoid reload port collisions |
 | `TEMPORAL_PROMETHEUS_BIND_ADDRESS` | `ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS` | `0.0.0.0:9464` | Bind address for Temporal SDK Prometheus metrics |

--- a/docs/concepts/common.md
+++ b/docs/concepts/common.md
@@ -156,4 +156,5 @@ token = generate_aws_rds_token_with_iam_user(
 
 | Constant | Env Var | Default | Description |
 |----------|---------|---------|-------------|
+| `ENABLE_PROMETHEUS_METRICS` | `ATLAN_ENABLE_PROMETHEUS_METRICS` | `false` | Enables Prometheus metrics exporters, including the Temporal SDK runtime metrics listener |
 | `TEMPORAL_PROMETHEUS_BIND_ADDRESS` | `ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS` | `0.0.0.0:9464` | Bind address for Temporal SDK Prometheus metrics |

--- a/docs/concepts/monitoring.md
+++ b/docs/concepts/monitoring.md
@@ -4,17 +4,17 @@ The Application SDK exposes built-in metrics for monitoring workflow execution h
 
 ## Temporal Prometheus Metrics
 
-Applications that use `create_temporal_client()` can expose ~40 built-in Temporal SDK metrics when Prometheus metrics are explicitly enabled.
+Applications that use `create_temporal_client()` automatically expose ~40 built-in Temporal SDK metrics via a Prometheus endpoint (enabled by default).
 
-Enable the exporter with:
+Disable the exporter for local development:
 
 ```bash
-ATLAN_ENABLE_PROMETHEUS_METRICS=true
+ATLAN_ENABLE_PROMETHEUS_METRICS=false
 ```
 
 ### Endpoint
 
-When `ATLAN_ENABLE_PROMETHEUS_METRICS=true`, the metrics endpoint is bound at startup when `create_temporal_client()` is called:
+The metrics endpoint is bound at startup when `create_temporal_client()` is called:
 
 ```
 http://<host>:9464/metrics
@@ -28,7 +28,7 @@ Override with `ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS`:
 ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS=0.0.0.0:9464
 ```
 
-For local auto-reload workflows, set `ATLAN_ENABLE_PROMETHEUS_METRICS=false` or leave it unset so the Temporal SDK does not bind a Prometheus socket on each restart.
+For local auto-reload workflows, set `ATLAN_ENABLE_PROMETHEUS_METRICS=false` so the Temporal SDK does not bind a Prometheus socket on each restart.
 
 ### Available Metrics
 

--- a/docs/concepts/monitoring.md
+++ b/docs/concepts/monitoring.md
@@ -4,11 +4,17 @@ The Application SDK exposes built-in metrics for monitoring workflow execution h
 
 ## Temporal Prometheus Metrics
 
-Every application that uses `create_temporal_client()` automatically exposes ~40 built-in Temporal SDK metrics. No code changes are required.
+Applications that use `create_temporal_client()` can expose ~40 built-in Temporal SDK metrics when Prometheus metrics are explicitly enabled.
+
+Enable the exporter with:
+
+```bash
+ATLAN_ENABLE_PROMETHEUS_METRICS=true
+```
 
 ### Endpoint
 
-The metrics endpoint is bound at startup when `create_temporal_client()` is called:
+When `ATLAN_ENABLE_PROMETHEUS_METRICS=true`, the metrics endpoint is bound at startup when `create_temporal_client()` is called:
 
 ```
 http://<host>:9464/metrics
@@ -21,6 +27,8 @@ Override with `ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS`:
 ```bash
 ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS=0.0.0.0:9464
 ```
+
+For local auto-reload workflows, set `ATLAN_ENABLE_PROMETHEUS_METRICS=false` or leave it unset so the Temporal SDK does not bind a Prometheus socket on each restart.
 
 ### Available Metrics
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,7 @@ The Application SDK uses environment variables for configuration. These can be s
 | `ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS` | Maximum duration an activity can run before timing out (in seconds) | `7200` | Prevents activities from running indefinitely |
 | `ATLAN_AUTH_ENABLED` | Whether to enable authentication for Temporal workflows | `false` | Used in production deployments with secure Temporal clusters |
 | `ATLAN_DEPLOYMENT_SECRET_PATH` | Path to deployment secrets in secret store | `ATLAN_DEPLOYMENT_SECRETS` | Contains authentication credentials for production |
-| `ATLAN_ENABLE_PROMETHEUS_METRICS` | Whether to enable Prometheus metrics exporters, including the Temporal SDK runtime exporter | `false` | Opt in when you want Prometheus scraping; leave unset in local reload loops to avoid binding a fixed metrics port on each restart |
+| `ATLAN_ENABLE_PROMETHEUS_METRICS` | Whether to enable Prometheus metrics exporters, including the Temporal SDK runtime exporter | `true` | Enabled by default for production; set to `false` in local dev to avoid binding a fixed metrics port on each restart |
 | `ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS` | Bind address for the Temporal SDK Prometheus metrics endpoint | `0.0.0.0:9464` | Exposes ~40 built-in Temporal SDK metrics (workflow latency, activity retries, worker capacity, etc.) for Prometheus scraping |
 
 ## SQL Client Configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,7 @@ The Application SDK uses environment variables for configuration. These can be s
 | `ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS` | Maximum duration an activity can run before timing out (in seconds) | `7200` | Prevents activities from running indefinitely |
 | `ATLAN_AUTH_ENABLED` | Whether to enable authentication for Temporal workflows | `false` | Used in production deployments with secure Temporal clusters |
 | `ATLAN_DEPLOYMENT_SECRET_PATH` | Path to deployment secrets in secret store | `ATLAN_DEPLOYMENT_SECRETS` | Contains authentication credentials for production |
+| `ATLAN_ENABLE_PROMETHEUS_METRICS` | Whether to enable Prometheus metrics exporters, including the Temporal SDK runtime exporter | `false` | Opt in when you want Prometheus scraping; leave unset in local reload loops to avoid binding a fixed metrics port on each restart |
 | `ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS` | Bind address for the Temporal SDK Prometheus metrics endpoint | `0.0.0.0:9464` | Exposes ~40 built-in Temporal SDK metrics (workflow latency, activity retries, worker capacity, etc.) for Prometheus scraping |
 
 ## SQL Client Configuration
@@ -130,6 +131,7 @@ For local development, most defaults work out of the box. Key configurations to 
 - `ATLAN_APPLICATION_NAME`: Set to a descriptive name for your application
 - `ATLAN_TENANT_ID`: Set to identify your development environment
 - `LOG_LEVEL`: Set to `DEBUG` for detailed logging during development
+- `ATLAN_HEALTH_PORT`: Optional for `run_dev_combined()`; when unset, local dev uses an ephemeral worker health port to avoid reload collisions on `8081`
 
 ### Production Deployment
 For production deployments, consider these essential configurations:

--- a/tests/unit/execution/test_temporal_prometheus.py
+++ b/tests/unit/execution/test_temporal_prometheus.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from temporalio.runtime import Runtime
+from temporalio.runtime import Runtime, TelemetryConfig
 
 import application_sdk.execution._temporal.backend as backend_module
 from application_sdk.execution._temporal.backend import (
@@ -30,6 +30,36 @@ def test_get_prometheus_runtime_creates_singleton(_reset_singleton):
     rt2 = _get_prometheus_runtime()
     assert rt1 is rt2
     _reset_singleton.assert_called_once()
+
+
+def test_get_prometheus_runtime_skips_prometheus_when_disabled(_reset_singleton):
+    """Prometheus-disabled runtimes should not bind a metrics listener."""
+    with patch.object(backend_module, "ENABLE_PROMETHEUS_METRICS", False):
+        runtime = _get_prometheus_runtime()
+
+    assert runtime is backend_module._prometheus_runtime
+    _reset_singleton.assert_called_once()
+    telemetry = _reset_singleton.call_args.kwargs["telemetry"]
+    assert isinstance(telemetry, TelemetryConfig)
+    assert telemetry.metrics is None
+
+
+def test_get_prometheus_runtime_enables_prometheus_when_configured(_reset_singleton):
+    """Prometheus-enabled runtimes should bind the configured metrics address."""
+    bind_address = "127.0.0.1:12345"
+
+    with (
+        patch.object(backend_module, "ENABLE_PROMETHEUS_METRICS", True),
+        patch.object(backend_module, "TEMPORAL_PROMETHEUS_BIND_ADDRESS", bind_address),
+    ):
+        runtime = _get_prometheus_runtime()
+
+    assert runtime is backend_module._prometheus_runtime
+    _reset_singleton.assert_called_once()
+    telemetry = _reset_singleton.call_args.kwargs["telemetry"]
+    assert isinstance(telemetry, TelemetryConfig)
+    assert telemetry.metrics is not None
+    assert telemetry.metrics.bind_address == bind_address
 
 
 @patch(

--- a/tests/unit/observability/test_metrics_adaptor.py
+++ b/tests/unit/observability/test_metrics_adaptor.py
@@ -168,9 +168,7 @@ def test_export_record_with_otlp_disabled():
     ):
         with create_metrics_adapter() as metrics_adapter:
             with mock.patch.object(metrics_adapter, "_send_to_otel") as mock_send:
-                with mock.patch.object(
-                    metrics_adapter, "_log_to_console"
-                ) as mock_log:
+                with mock.patch.object(metrics_adapter, "_log_to_console") as mock_log:
                     record = MetricRecord(
                         timestamp=datetime.now().timestamp(),
                         name="test_metric",

--- a/tests/unit/observability/test_metrics_adaptor.py
+++ b/tests/unit/observability/test_metrics_adaptor.py
@@ -161,22 +161,28 @@ def test_export_record_with_otlp_enabled():
 
 
 def test_export_record_with_otlp_disabled():
-    """Test export_record() method when OTLP is disabled."""
-    with create_metrics_adapter() as metrics_adapter:
-        with mock.patch.object(metrics_adapter, "_send_to_otel") as mock_send:
-            with mock.patch.object(metrics_adapter, "_log_to_console") as mock_log:
-                record = MetricRecord(
-                    timestamp=datetime.now().timestamp(),
-                    name="test_metric",
-                    value=42.0,
-                    type=MetricType.COUNTER,
-                    labels={"test": "label"},
-                    description="Test metric",
-                    unit="count",
-                )
-                metrics_adapter.export_record(record)
-                mock_send.assert_not_called()
-                mock_log.assert_called_once_with(record)
+    """Test export_record() method when OTLP and Prometheus are both disabled."""
+    with mock.patch(
+        "application_sdk.observability.metrics_adaptor.ENABLE_PROMETHEUS_METRICS",
+        False,
+    ):
+        with create_metrics_adapter() as metrics_adapter:
+            with mock.patch.object(metrics_adapter, "_send_to_otel") as mock_send:
+                with mock.patch.object(
+                    metrics_adapter, "_log_to_console"
+                ) as mock_log:
+                    record = MetricRecord(
+                        timestamp=datetime.now().timestamp(),
+                        name="test_metric",
+                        value=42.0,
+                        type=MetricType.COUNTER,
+                        labels={"test": "label"},
+                        description="Test metric",
+                        unit="count",
+                    )
+                    metrics_adapter.export_record(record)
+                    mock_send.assert_not_called()
+                    mock_log.assert_called_once_with(record)
 
 
 def test_send_to_otel_counter():
@@ -450,24 +456,28 @@ class TestPython314EventLoopCompat:
                 "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
             },
         ):
-            with mock.patch("opentelemetry.metrics.set_meter_provider"):
-                with mock.patch("opentelemetry.sdk.metrics.MeterProvider"):
-                    with mock.patch(
-                        "application_sdk.observability.metrics_adaptor.asyncio.get_running_loop",
-                        side_effect=RuntimeError("no running event loop"),
-                    ):
+            with mock.patch(
+                "application_sdk.observability.metrics_adaptor.ENABLE_PROMETHEUS_METRICS",
+                False,
+            ):
+                with mock.patch("opentelemetry.metrics.set_meter_provider"):
+                    with mock.patch("opentelemetry.sdk.metrics.MeterProvider"):
                         with mock.patch(
-                            "application_sdk.observability.metrics_adaptor.threading.Thread"
-                        ) as mock_thread:
-                            mock_thread_instance = mock.MagicMock()
-                            mock_thread.return_value = mock_thread_instance
+                            "application_sdk.observability.metrics_adaptor.asyncio.get_running_loop",
+                            side_effect=RuntimeError("no running event loop"),
+                        ):
+                            with mock.patch(
+                                "application_sdk.observability.metrics_adaptor.threading.Thread"
+                            ) as mock_thread:
+                                mock_thread_instance = mock.MagicMock()
+                                mock_thread.return_value = mock_thread_instance
 
-                            _ = AtlanMetricsAdapter()
+                                _ = AtlanMetricsAdapter()
 
-                            mock_thread.assert_called_once()
-                            _, kwargs = mock_thread.call_args
-                            assert kwargs.get("daemon") is True
-                            mock_thread_instance.start.assert_called_once()
+                                mock_thread.assert_called_once()
+                                _, kwargs = mock_thread.call_args
+                                assert kwargs.get("daemon") is True
+                                mock_thread_instance.start.assert_called_once()
 
     def test_flush_task_uses_running_loop_when_available(self):
         """When a running event loop exists, the adapter should create
@@ -481,19 +491,23 @@ class TestPython314EventLoopCompat:
                 "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
             },
         ):
-            with mock.patch("opentelemetry.metrics.set_meter_provider"):
-                with mock.patch("opentelemetry.sdk.metrics.MeterProvider"):
-                    with mock.patch(
-                        "application_sdk.observability.metrics_adaptor.asyncio.get_running_loop",
-                        return_value=mock_loop,
-                    ):
+            with mock.patch(
+                "application_sdk.observability.metrics_adaptor.ENABLE_PROMETHEUS_METRICS",
+                False,
+            ):
+                with mock.patch("opentelemetry.metrics.set_meter_provider"):
+                    with mock.patch("opentelemetry.sdk.metrics.MeterProvider"):
                         with mock.patch(
-                            "application_sdk.observability.metrics_adaptor.threading.Thread"
-                        ) as mock_thread:
-                            _ = AtlanMetricsAdapter()
+                            "application_sdk.observability.metrics_adaptor.asyncio.get_running_loop",
+                            return_value=mock_loop,
+                        ):
+                            with mock.patch(
+                                "application_sdk.observability.metrics_adaptor.threading.Thread"
+                            ) as mock_thread:
+                                _ = AtlanMetricsAdapter()
 
-                            mock_loop.create_task.assert_called_once()
-                            mock_thread.assert_not_called()
+                                mock_loop.create_task.assert_called_once()
+                                mock_thread.assert_not_called()
 
 
 class TestPrometheusMetrics:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import os
 import signal
 from pathlib import Path
 from unittest import mock
@@ -418,6 +419,86 @@ class TestRunDevCombined:
             await run_dev_combined(MyApp)
 
         assert captured["config"].health_port == 8081
+
+
+    async def test_disables_prometheus_by_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """run_dev_combined() should disable Prometheus metrics when the
+        env var is not explicitly set, to avoid port collisions on reload."""
+        monkeypatch.delenv("ATLAN_ENABLE_PROMETHEUS_METRICS", raising=False)
+
+        class MyApp:
+            _app_name = "my-app"
+
+        async def _fake_create_infrastructure(
+            *args: object, **kwargs: object
+        ) -> object:
+            return object()
+
+        async def _fake_run_combined_mode(config: AppConfig) -> None:
+            pass
+
+        import application_sdk.constants as _constants
+
+        with (
+            patch(
+                "application_sdk.main._create_infrastructure",
+                new=_fake_create_infrastructure,
+            ),
+            patch("application_sdk.infrastructure.context.set_infrastructure"),
+            patch(
+                "application_sdk.main.run_combined_mode",
+                new=_fake_run_combined_mode,
+            ),
+        ):
+            await run_dev_combined(MyApp)
+
+        assert os.environ.get("ATLAN_ENABLE_PROMETHEUS_METRICS") == "false"
+        assert _constants.ENABLE_PROMETHEUS_METRICS is False
+
+        # Cleanup: restore the constant so other tests aren't affected
+        monkeypatch.delenv("ATLAN_ENABLE_PROMETHEUS_METRICS", raising=False)
+        _constants.ENABLE_PROMETHEUS_METRICS = True
+
+    async def test_honors_explicit_prometheus_opt_in(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When ATLAN_ENABLE_PROMETHEUS_METRICS is explicitly set to true,
+        run_dev_combined() should not override it."""
+        monkeypatch.setenv("ATLAN_ENABLE_PROMETHEUS_METRICS", "true")
+
+        class MyApp:
+            _app_name = "my-app"
+
+        async def _fake_create_infrastructure(
+            *args: object, **kwargs: object
+        ) -> object:
+            return object()
+
+        async def _fake_run_combined_mode(config: AppConfig) -> None:
+            pass
+
+        import application_sdk.constants as _constants
+
+        original = _constants.ENABLE_PROMETHEUS_METRICS
+
+        with (
+            patch(
+                "application_sdk.main._create_infrastructure",
+                new=_fake_create_infrastructure,
+            ),
+            patch("application_sdk.infrastructure.context.set_infrastructure"),
+            patch(
+                "application_sdk.main.run_combined_mode",
+                new=_fake_run_combined_mode,
+            ),
+        ):
+            await run_dev_combined(MyApp)
+
+        assert os.environ.get("ATLAN_ENABLE_PROMETHEUS_METRICS") == "true"
+        # Constant should not have been touched
+        assert _constants.ENABLE_PROMETHEUS_METRICS == original
 
 
 class TestParseArgs:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -18,6 +18,7 @@ from application_sdk.main import (
     _install_graceful_signal_handlers,
     _log_dapr_components,
     parse_args,
+    run_dev_combined,
     run_main,
 )
 
@@ -349,6 +350,74 @@ class TestRunMain:
                 mock_run.side_effect = lambda coro: None
                 run_main(config)
                 mock_run.assert_called_once()
+
+
+class TestRunDevCombined:
+    """Tests for run_dev_combined()."""
+
+    async def test_defaults_health_port_to_ephemeral(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ATLAN_HEALTH_PORT", raising=False)
+        captured: dict[str, AppConfig] = {}
+
+        class MyApp:
+            _app_name = "my-app"
+
+        async def _fake_create_infrastructure(
+            *args: object, **kwargs: object
+        ) -> object:
+            return object()
+
+        async def _fake_run_combined_mode(config: AppConfig) -> None:
+            captured["config"] = config
+
+        with (
+            patch(
+                "application_sdk.main._create_infrastructure",
+                new=_fake_create_infrastructure,
+            ),
+            patch("application_sdk.infrastructure.context.set_infrastructure"),
+            patch(
+                "application_sdk.main.run_combined_mode",
+                new=_fake_run_combined_mode,
+            ),
+        ):
+            await run_dev_combined(MyApp)
+
+        assert captured["config"].health_port == 0
+
+    async def test_honors_health_port_env_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATLAN_HEALTH_PORT", "8081")
+        captured: dict[str, AppConfig] = {}
+
+        class MyApp:
+            _app_name = "my-app"
+
+        async def _fake_create_infrastructure(
+            *args: object, **kwargs: object
+        ) -> object:
+            return object()
+
+        async def _fake_run_combined_mode(config: AppConfig) -> None:
+            captured["config"] = config
+
+        with (
+            patch(
+                "application_sdk.main._create_infrastructure",
+                new=_fake_create_infrastructure,
+            ),
+            patch("application_sdk.infrastructure.context.set_infrastructure"),
+            patch(
+                "application_sdk.main.run_combined_mode",
+                new=_fake_run_combined_mode,
+            ),
+        ):
+            await run_dev_combined(MyApp)
+
+        assert captured["config"].health_port == 8081
 
 
 class TestParseArgs:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -420,7 +420,6 @@ class TestRunDevCombined:
 
         assert captured["config"].health_port == 8081
 
-
     async def test_disables_prometheus_by_default(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

Fix local reload failures in `application-sdk` caused by fixed-port listeners that were bound during `run_dev_combined()` / Temporal client startup.

This PR fixes the original `HYP-728` issue in the SDK itself:

- Temporal Prometheus runtime now respects `ATLAN_ENABLE_PROMETHEUS_METRICS`
- When Prometheus metrics are disabled, the Temporal runtime is created without a Prometheus listener
- `run_dev_combined()` now defaults the worker health probe port to an ephemeral port unless `ATLAN_HEALTH_PORT` is explicitly set
- `run_dev_combined()` auto-disables Prometheus metrics for local dev unless explicitly overridden
- `ENABLE_PROMETHEUS_METRICS` defaults to `true` in `constants.py` to match current production behavior

## Root Cause

Two SDK-owned code paths were binding fixed ports during local reload restarts:

1. `application_sdk/execution/_temporal/backend.py`
   - `create_temporal_client()` always called `_get_prometheus_runtime()`
   - `_get_prometheus_runtime()` always created `Runtime(telemetry=TelemetryConfig(metrics=PrometheusConfig(bind_address=...)))`
   - this bound `ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS` even when `ATLAN_ENABLE_PROMETHEUS_METRICS=false`
   - under hot reload, the next process could fail with `Address already in use` on port `9464`

2. `application_sdk/main.py`
   - `run_dev_combined()` inherited the default worker health probe port `8081`
   - under hot reload, the next process could race the previous process and fail binding the health server on `8081`

The CLI was only the trigger. Any file-watcher / auto-reload loop could reproduce these failures.

## Design Decision: Default to Production Values

`ATLAN_ENABLE_PROMETHEUS_METRICS` defaults to `true` in `constants.py` because:

- No deployment today sets this env var — all apps already expose Prometheus on `:9464`
- Defaulting to `false` would silently break KEDA scaling and metric scraping for all deployed apps
- Follows the principle: **defaults should match production; dev overrides when needed**

For local dev, `run_dev_combined()` proactively sets it to `false` (unless the developer explicitly sets `ATLAN_ENABLE_PROMETHEUS_METRICS=true`), so port collisions are avoided automatically without any manual configuration.

## Changes

- Gate Temporal Prometheus runtime binding behind `ATLAN_ENABLE_PROMETHEUS_METRICS`
- Use `Runtime(telemetry=TelemetryConfig())` when metrics are disabled
- Default `ENABLE_PROMETHEUS_METRICS` to `true` in `constants.py` (matches current production behavior)
- `run_dev_combined()` auto-sets `ATLAN_ENABLE_PROMETHEUS_METRICS=false` when the env var is not explicitly set
- Default `run_dev_combined()` health probes to port `0` unless `ATLAN_HEALTH_PORT` is explicitly set
- Add regression tests for:
  - Disabled/enabled Prometheus runtime paths
  - `run_dev_combined()` ephemeral health-port default
  - `ATLAN_HEALTH_PORT` override
  - Auto-disable Prometheus in `run_dev_combined()`
  - Explicit Prometheus opt-in is respected in `run_dev_combined()`
- Update docs to reflect enabled-by-default behavior

## Behavior Summary

| Environment | Prometheus on `:9464` | Health probe port | Notes |
|---|---|---|---|
| **Production** (no env var set) | Enabled (default `true`) | `8081` (existing) | No behavior change |
| **Local dev** via `run_dev_combined()` | Disabled automatically | Ephemeral (`0`) | No port collisions |
| **Local dev** with `ATLAN_ENABLE_PROMETHEUS_METRICS=true` | Enabled | Ephemeral (`0`) | Explicit opt-in respected |

## Validation

```bash
uv run pytest tests/unit/test_main.py tests/unit/execution/test_temporal_prometheus.py -q
```

Also validated against `atlan-trino-app` with hot reload after linking the local SDK checkout:
- No more Prometheus bind failure on `9464`
- No more health server bind failure on `8081`
- Reloads continue successfully through file changes

## Out of Scope

While validating the app reload flow, a separate transient restart race on the main handler port `8000` was observed in the CLI / reload supervision path. That is not addressed in this PR.