### PR TITLE
fix(temporal): switch default versioning behavior from AUTO_UPGRADE to PINNED

### DIFF
--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -288,7 +288,7 @@ def create_worker(
                 build_id=APP_BUILD_ID,
             ),
             use_worker_versioning=True,
-            default_versioning_behavior=VersioningBehavior.AUTO_UPGRADE,
+            default_versioning_behavior=VersioningBehavior.PINNED,
         )
         logger.info(
             "Worker Deployment versioning enabled: deployment=%s build_id=%s",
@@ -302,7 +302,7 @@ def create_worker(
                 build_id=APP_BUILD_ID,
             ),
             use_worker_versioning=True,
-            default_versioning_behavior=VersioningBehavior.AUTO_UPGRADE,
+            default_versioning_behavior=VersioningBehavior.PINNED,
         )
         logger.info("Worker versioning enabled: build_id=%s", APP_BUILD_ID)
 


### PR DESCRIPTION
## Summary

- Changes `default_versioning_behavior` from `VersioningBehavior.AUTO_UPGRADE` to `VersioningBehavior.PINNED` in both Worker Deployment versioning paths (`worker.py:291` and `worker.py:305`)

## Why

`AUTO_UPGRADE` causes in-flight workflows to be routed to new build-id workers at the next workflow task boundary after a deploy. If the new build has incompatible activity type names (or any other history-visible change), this results in non-determinism errors and silent workflow failures until the execution timeout — with no errors visible until the 2h timeout is hit.

Observed on `markeznp29` for `atlan-athena-app`: a deploy of `fix-iam-role-auth` while a crawl workflow was in-flight caused the workflow to be auto-upgraded to the new build, which had different activity type naming. The workflow failed silently for 1h36m until timeout.

## What PINNED does

- In-flight workflows stay on their original build-id until completion
- New workflows start on the new Current build-id as usual
- Progressive rollouts (ramp %) continue to work — they only affect routing of new workflow starts

## Compatibility

- **TWC (`1.2.0-atlan-1.6`)**: scaledown is gated on `VersionStatusDrained` from Temporal Server — old pods stay alive while pinned workflows are running, scale down after `scaledownDelay` once drained. No TWC changes needed.
- **Temporal Server (`1.29.4`)**: PINNED drainage fully supported.

## Impact

All apps using application-sdk will get PINNED behavior after bumping to this SDK version. Apps with long-running workflows (crawls) will have old worker pods stay alive until those workflows complete before scaling down.

## Test plan

- [ ] Deploy an app with the new SDK to a test tenant
- [ ] Start a long-running workflow, then deploy a new build
- [ ] Verify the in-flight workflow completes on the old build-id
- [ ] Verify old worker pod stays alive until workflow completes, then scales down after `scaledownDelay`
- [ ] Verify new workflows start on the new build-id