### PR TITLE
fix(ci): push mutable {branch}-latest tag to DockerHub on every build for SDR

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -274,11 +274,15 @@ jobs:
         env:
           GHCR_IMAGE:      ${{ needs.prepare.outputs.ghcr_image }}
           DOCKERHUB_IMAGE: ${{ needs.prepare.outputs.dockerhub_image }}
+          BRANCH:          ${{ needs.prepare.outputs.branch }}
         run: |
+          DOCKERHUB_BASE="${DOCKERHUB_IMAGE%:*}"
           docker buildx imagetools create \
             --tag "${DOCKERHUB_IMAGE}" \
+            --tag "${DOCKERHUB_BASE}:${BRANCH}-latest" \
             "${GHCR_IMAGE}"
           echo "Pushed to DockerHub: ${DOCKERHUB_IMAGE}"
+          echo "Pushed to DockerHub: ${DOCKERHUB_BASE}:${BRANCH}-latest"
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Problem

The DockerHub push step only pushed the immutable \`{branch}-{sha7}\` tag (e.g. \`main-c0c123a\`). The mutable \`main-latest\` tag was never updated by CI, leaving it perpetually stale for SDR deployments that reference it.

GHCR already got both tags (immutable + mutable branch tag) — DockerHub was inconsistent.

## Fix

Derive the DockerHub base from the immutable image name and push a second \`{branch}-latest\` tag alongside the immutable one:

\`\`\`sh
DOCKERHUB_BASE="\${DOCKERHUB_IMAGE%:*}"
docker buildx imagetools create \
  --tag "\${DOCKERHUB_IMAGE}" \
  --tag "\${DOCKERHUB_BASE}:\${BRANCH}-latest" \
  "\${GHCR_IMAGE}"
\`\`\`

After this, every merge to \`main\` will update both \`main-c0c123a\` and \`main-latest\` on DockerHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)