### PR TITLE
fix(handler): resolve credential_guid on /workflows/v1/check via DaprCredentialVault

### DIFF
--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -534,6 +534,20 @@ def create_app_handler_service(
     @app.post("/workflows/v1/check")
     async def preflight_check(request: Request) -> JSONResponse:
         body = _normalize_credentials(await request.json())
+        credential_guid = body.get("credential_guid")
+        if credential_guid and not body.get("credentials"):
+            from application_sdk.infrastructure import (
+                AsyncDaprClient,
+                DaprCredentialVault,
+            )
+
+            dapr_client = AsyncDaprClient()
+            try:
+                vault = DaprCredentialVault(dapr_client)
+                resolved = await vault.get_credentials(credential_guid)
+                body["credentials"] = _flatten_to_pairs(resolved)
+            finally:
+                await dapr_client.close()
         preflight_input = PreflightInput.model_validate(body)
         credentials = [
             HandlerCredential(key=c.key, value=c.value)

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -85,6 +85,23 @@ class _FailingHandler(Handler):
         raise HandlerError("metadata failed")
 
 
+class _CapturingPreflightHandler(Handler):
+    """Handler that records the PreflightInput credentials it received."""
+
+    def __init__(self) -> None:
+        self.received_credentials: list[tuple[str, str]] = []
+
+    async def test_auth(self, input: AuthInput) -> AuthOutput:
+        return AuthOutput(status=AuthStatus.SUCCESS)
+
+    async def preflight_check(self, input: PreflightInput) -> PreflightOutput:
+        self.received_credentials = [(c.key, c.value) for c in input.credentials]
+        return PreflightOutput(status=PreflightStatus.READY)
+
+    async def fetch_metadata(self, input: MetadataInput) -> MetadataOutput:
+        return SqlMetadataOutput(objects=[])
+
+
 # ---------------------------------------------------------------------------
 # Module-level contract types for routing tests
 # (locally-defined dataclasses fail get_type_hints() when
@@ -214,6 +231,74 @@ class TestPreflightEndpoint:
             json={"credentials": []},
         )
         assert response.status_code == 500
+
+    def test_preflight_resolves_credential_guid_via_vault(self) -> None:
+        """credential_guid (no inline credentials) is resolved via the vault."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_vault = MagicMock()
+        mock_vault.get_credentials = AsyncMock(
+            return_value={
+                "host": "h.example.com",
+                "authType": "basic",
+                "extra": {"db": "prod"},
+            }
+        )
+        mock_dapr_client = MagicMock()
+        mock_dapr_client.close = AsyncMock()
+
+        handler = _CapturingPreflightHandler()
+        with (
+            patch(
+                "application_sdk.infrastructure.DaprCredentialVault",
+                return_value=mock_vault,
+            ),
+            patch(
+                "application_sdk.infrastructure.AsyncDaprClient",
+                return_value=mock_dapr_client,
+            ),
+        ):
+            client = _make_client(handler=handler)
+            response = client.post(
+                "/workflows/v1/check",
+                json={"credential_guid": "the-guid"},
+            )
+
+        assert response.status_code == 200
+        mock_vault.get_credentials.assert_awaited_once_with("the-guid")
+        received_keys = {k for k, _ in handler.received_credentials}
+        assert {"host", "authType", "extra.db"} <= received_keys
+
+    def test_preflight_inline_credentials_skip_vault(self) -> None:
+        """Inline credentials win over credential_guid — vault is not touched."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_vault = MagicMock()
+        mock_vault.get_credentials = AsyncMock(return_value={})
+        mock_dapr_client = MagicMock()
+        mock_dapr_client.close = AsyncMock()
+
+        with (
+            patch(
+                "application_sdk.infrastructure.DaprCredentialVault",
+                return_value=mock_vault,
+            ),
+            patch(
+                "application_sdk.infrastructure.AsyncDaprClient",
+                return_value=mock_dapr_client,
+            ),
+        ):
+            client = _make_client()
+            response = client.post(
+                "/workflows/v1/check",
+                json={
+                    "credentials": [{"key": "host", "value": "inline.example"}],
+                    "credential_guid": "ignored",
+                },
+            )
+
+        assert response.status_code == 200
+        mock_vault.get_credentials.assert_not_awaited()
 
 
 class TestMetadataEndpoint:


### PR DESCRIPTION
### Changelog
  - `/workflows/v1/check` now resolves `credential_guid` via `DaprCredentialVault` when the request body has no inline `credentials`, mirroring the `/workflows/v1/start` flow.                                                                                                                                          
  - Inline `credentials` continue to win over `credential_guid` (vault is not called) to preserve the legacy path.                                                     
  - Added unit tests (`tests/unit/handler/test_service.py`) covering both branches: vault-resolved guid and inline-credentials bypass.                                 
                                                                                                                                                                       
  ### Additional context                                                                                                                                               
  - Companion to [application-sdk#1480](https://github.com/atlanhq/application-sdk/pull/1480) (BLDX-1077), which introduced the `/dev/local-vault` provisioning endpoint and vault-only resolution for `/start`. Before this PR, `/check` only accepted inline `credentials`, so clients that had already provisioned a guid via `/dev/local-vault` failed preflight with a 500.                                                                                                                      
  - Paired with[ blaze PR](https://github.com/atlanhq/blaze/pull/new/hyp-744), which updates the playground `Sage` widget to provision creds via `/dev/local-vault` → guid before calling `/check`. The blaze PR falls back to inline credentials on 404/405 so it keeps working against SDKs that predate this change.                                                                                                                                                              
                                                                                                                                                                       
  ### Checklist                                          
  - [x] Additional tests added
  - [x] All CI checks passed  
  - [x] Relevant documentation updated (no user-facing docs changed — internal handler contract)
                                                                                                
  ---                                                                                                                                                                  
     
  ### Copyleft License Compliance                                                                                                                                      
  - [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
  - [ ] If yes, have you modified the code in the context of this project? please share additional details.