### PR TITLE
fix(dapr): parse JSON data in invoke_binding to prevent double-encoding

### DIFF
--- a/application_sdk/infrastructure/_dapr/http.py
+++ b/application_sdk/infrastructure/_dapr/http.py
@@ -9,6 +9,7 @@ Endpoint reference: https://docs.dapr.io/reference/api/
 
 from __future__ import annotations
 
+import json
 import os
 from typing import Any
 from urllib.parse import quote
@@ -182,17 +183,21 @@ class AsyncDaprClient:
         """Invoke a Dapr output binding.
 
         Note:
-            ``data`` is decoded as UTF-8 text before JSON-encoding into the
-            request body.  This means only text-compatible payloads are
-            supported.  Binary data (protobuf, compressed) should be
-            base64-encoded by the caller before passing to this method.
+            If ``data`` contains valid JSON it is embedded as a parsed
+            object so that Dapr forwards a proper JSON body to HTTP
+            bindings (avoids double-encoding).  Otherwise the raw bytes
+            are decoded as UTF-8 text.  Binary data (protobuf, compressed)
+            should be base64-encoded by the caller.
         """
         body: dict[str, Any] = {
             "operation": operation,
             "metadata": metadata or {},
         }
         if data:
-            body["data"] = data.decode("utf-8", errors="replace")
+            try:
+                body["data"] = json.loads(data)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                body["data"] = data.decode("utf-8", errors="replace")
         resp = await self._client.post(
             BINDING_PATH.format(binding_name=binding_name),
             json=body,

--- a/application_sdk/infrastructure/_dapr/http.py
+++ b/application_sdk/infrastructure/_dapr/http.py
@@ -195,7 +195,11 @@ class AsyncDaprClient:
         }
         if data:
             try:
-                body["data"] = json.loads(data)
+                parsed = json.loads(data)
+                if isinstance(parsed, (dict, list)):
+                    body["data"] = parsed
+                else:
+                    body["data"] = data.decode("utf-8", errors="replace")
             except (json.JSONDecodeError, UnicodeDecodeError):
                 body["data"] = data.decode("utf-8", errors="replace")
         resp = await self._client.post(

--- a/tests/unit/infrastructure/test_dapr_http.py
+++ b/tests/unit/infrastructure/test_dapr_http.py
@@ -171,6 +171,45 @@ class TestAsyncDaprClientBinding:
 
         assert result.data is None
 
+    async def test_invoke_binding_json_data_not_double_encoded(self, mock_client):
+        """JSON bytes must be embedded as a parsed object, not a string.
+
+        Regression test: prior to the fix, ``data.decode()`` produced a
+        string which ``json=body`` then double-encoded, causing Dapr HTTP
+        bindings to forward a JSON string instead of an object (422).
+        """
+        client, mock_http = mock_client
+        mock_http.post.return_value = MagicMock(
+            status_code=200,
+            content=b"",
+            headers={},
+            raise_for_status=MagicMock(),
+        )
+
+        json_payload = b'{"event_name": "worker_start", "nested": {"key": 1}}'
+        await client.invoke_binding("eventstore", "create", data=json_payload)
+
+        body = mock_http.post.call_args[1]["json"]
+        # data must be a dict, NOT a string
+        assert isinstance(body["data"], dict)
+        assert body["data"]["event_name"] == "worker_start"
+        assert body["data"]["nested"] == {"key": 1}
+
+    async def test_invoke_binding_non_json_data_falls_back_to_string(self, mock_client):
+        """Non-JSON bytes should still be sent as a decoded string."""
+        client, mock_http = mock_client
+        mock_http.post.return_value = MagicMock(
+            status_code=200,
+            content=b"",
+            headers={},
+            raise_for_status=MagicMock(),
+        )
+
+        await client.invoke_binding("my-binding", "create", data=b"plain text")
+
+        body = mock_http.post.call_args[1]["json"]
+        assert body["data"] == "plain text"
+
 
 class TestAsyncDaprClientMetadata:
     async def test_get_metadata(self, mock_client):

--- a/tests/unit/infrastructure/test_dapr_http.py
+++ b/tests/unit/infrastructure/test_dapr_http.py
@@ -195,20 +195,69 @@ class TestAsyncDaprClientBinding:
         assert body["data"]["event_name"] == "worker_start"
         assert body["data"]["nested"] == {"key": 1}
 
+    async def test_invoke_binding_json_array_parsed_as_list(self, mock_client):
+        """JSON arrays must be embedded as a parsed list, not a string."""
+        client, mock_http = mock_client
+        mock_http.post.return_value = MagicMock(
+            status_code=200, content=b"", headers={}, raise_for_status=MagicMock()
+        )
+
+        await client.invoke_binding("my-binding", "create", data=b"[1, 2, 3]")
+
+        body = mock_http.post.call_args[1]["json"]
+        assert isinstance(body["data"], list)
+        assert body["data"] == [1, 2, 3]
+
+    async def test_invoke_binding_json_primitive_sent_as_string(self, mock_client):
+        """JSON primitives (numbers, booleans, null) stay as decoded strings."""
+        client, mock_http = mock_client
+        mock_http.post.return_value = MagicMock(
+            status_code=200, content=b"", headers={}, raise_for_status=MagicMock()
+        )
+
+        await client.invoke_binding("my-binding", "create", data=b"42")
+
+        body = mock_http.post.call_args[1]["json"]
+        assert body["data"] == "42"
+
     async def test_invoke_binding_non_json_data_falls_back_to_string(self, mock_client):
         """Non-JSON bytes should still be sent as a decoded string."""
         client, mock_http = mock_client
         mock_http.post.return_value = MagicMock(
-            status_code=200,
-            content=b"",
-            headers={},
-            raise_for_status=MagicMock(),
+            status_code=200, content=b"", headers={}, raise_for_status=MagicMock()
         )
 
         await client.invoke_binding("my-binding", "create", data=b"plain text")
 
         body = mock_http.post.call_args[1]["json"]
         assert body["data"] == "plain text"
+
+    async def test_invoke_binding_empty_bytes_omits_data_key(self, mock_client):
+        """Empty bytes (falsy) should not add a data key to the body."""
+        client, mock_http = mock_client
+        mock_http.post.return_value = MagicMock(
+            status_code=200, content=b"", headers={}, raise_for_status=MagicMock()
+        )
+
+        await client.invoke_binding("my-binding", "create", data=b"")
+
+        body = mock_http.post.call_args[1]["json"]
+        assert "data" not in body
+
+    async def test_invoke_binding_invalid_utf8_falls_back_to_replacement(
+        self, mock_client
+    ):
+        """Invalid UTF-8 bytes should decode with replacement characters."""
+        client, mock_http = mock_client
+        mock_http.post.return_value = MagicMock(
+            status_code=200, content=b"", headers={}, raise_for_status=MagicMock()
+        )
+
+        await client.invoke_binding("my-binding", "create", data=b"\xff\xfe")
+
+        body = mock_http.post.call_args[1]["json"]
+        assert isinstance(body["data"], str)
+        assert "\ufffd" in body["data"]  # replacement character
 
 
 class TestAsyncDaprClientMetadata:


### PR DESCRIPTION
## Summary

- `AsyncDaprClient.invoke_binding` was double-JSON-encoding data: `data.decode("utf-8")` produced a string, then `json=body` serialized it again, so Dapr HTTP bindings forwarded a JSON **string** instead of an object to the target endpoint.
- This caused `eventingress` to return **422 Unprocessable Entity**, silently breaking `worker_start` lifecycle events — self-deployed agents never registered with the Atlan tenant and were invisible in the UI.
- Fix: parse `data` via `json.loads` and embed as a native object when the result is a `dict` or `list`. JSON primitives (numbers, booleans, null) and non-JSON payloads fall back to the decoded string to preserve existing behavior.

**Introduced in:** #1318 (`BLDX-755`, 2026-04-16)
**Affected:** All self-deployed agents using the SDK's Dapr HTTP event binding.

## Test plan

- [x] `test_invoke_binding_json_data_not_double_encoded` — JSON dict bytes embedded as parsed object, not string
- [x] `test_invoke_binding_json_array_parsed_as_list` — JSON array bytes embedded as parsed list
- [x] `test_invoke_binding_json_primitive_sent_as_string` — JSON primitives (e.g. `42`) stay as decoded strings
- [x] `test_invoke_binding_non_json_data_falls_back_to_string` — non-JSON payloads still work
- [x] `test_invoke_binding_empty_bytes_omits_data_key` — empty bytes skip the data key
- [x] `test_invoke_binding_invalid_utf8_falls_back_to_replacement` — invalid UTF-8 uses replacement chars
- [x] All 30 tests pass, pre-commit clean
- [ ] Deploy to a test tenant and verify the agent appears in Workflow center → Deployments