### PR TITLE
refactor(templates): type SQL filter fields as dict | str union [BLDX-1125]

### DIFF
--- a/application_sdk/templates/contracts/sql_metadata.py
+++ b/application_sdk/templates/contracts/sql_metadata.py
@@ -24,6 +24,40 @@ FilterMap = dict[str, list[str]]
 _SAFE_FILTER_PATTERN = r"^[^']*$"
 
 
+def _coerce_filter_value(v: Any) -> FilterMap | str:
+    """Coerce filter input to FilterMap | str.
+
+    - ``dict`` → pass through (structured filter map from AE)
+    - ``list`` → wrap as ``{".*": <list>}``
+    - ``str`` → pass through (JSON string or raw regex)
+    - ``None`` → empty string
+    """
+    if v is None:
+        return ""
+    if isinstance(v, list):
+        return {".*": v}
+    return v
+
+
+def _validate_filter_no_sql_injection(v: FilterMap | str) -> FilterMap | str:
+    """Block single quotes in filter values to prevent SQL injection."""
+    if isinstance(v, str):
+        if "'" in v:
+            msg = f"Single quotes not allowed in filter value: {v}"
+            raise ValueError(msg)
+    elif isinstance(v, dict):
+        for key, values in v.items():
+            if "'" in key:
+                msg = f"Single quotes not allowed in filter key: {key}"
+                raise ValueError(msg)
+            if isinstance(values, list):
+                for val in values:
+                    if isinstance(val, str) and "'" in val:
+                        msg = f"Single quotes not allowed in filter value: {val}"
+                        raise ValueError(msg)
+    return v
+
+
 class ExtractionInput(Input, allow_unbounded_fields=True):
     """Top-level input for a SQL metadata extraction run."""
 
@@ -98,38 +132,12 @@ class ExtractionInput(Input, allow_unbounded_fields=True):
     @field_validator("include_filter", "exclude_filter", mode="before")
     @classmethod
     def _coerce_filter(cls, v: Any) -> FilterMap | str:
-        """Accept dict, JSON string, raw regex string, list, or None.
-
-        - ``dict`` → pass through (structured filter map from AE)
-        - ``list`` → pass through as dict ``{".*": <list>}``
-        - ``str`` → pass through (JSON string or raw regex)
-        - ``None`` → empty string
-        """
-        if v is None:
-            return ""
-        if isinstance(v, list):
-            return {".*": v}
-        return v
+        return _coerce_filter_value(v)
 
     @field_validator("include_filter", "exclude_filter", mode="after")
     @classmethod
     def _validate_no_sql_injection(cls, v: FilterMap | str) -> FilterMap | str:
-        """Block single quotes in filter values to prevent SQL injection."""
-        if isinstance(v, str):
-            if "'" in v:
-                msg = f"Single quotes not allowed in filter value: {v}"
-                raise ValueError(msg)
-        elif isinstance(v, dict):
-            for key, values in v.items():
-                if "'" in key:
-                    msg = f"Single quotes not allowed in filter key: {key}"
-                    raise ValueError(msg)
-                if isinstance(values, list):
-                    for val in values:
-                        if isinstance(val, str) and "'" in val:
-                            msg = f"Single quotes not allowed in filter value: {val}"
-                            raise ValueError(msg)
-        return v
+        return _validate_filter_no_sql_injection(v)
 
 
 class ExtractionOutput(Output, PublishInputMixin):
@@ -170,14 +178,12 @@ class ExtractionTaskInput(Input, allow_unbounded_fields=True):
     @field_validator("include_filter", "exclude_filter", mode="before")
     @classmethod
     def _coerce_filter(cls, v: Any) -> FilterMap | str:
-        """Reuse the same coercion logic as ExtractionInput."""
-        return ExtractionInput._coerce_filter(v)
+        return _coerce_filter_value(v)
 
     @field_validator("include_filter", "exclude_filter", mode="after")
     @classmethod
     def _validate_no_sql_injection(cls, v: FilterMap | str) -> FilterMap | str:
-        """Reuse the same SQL injection guard as ExtractionInput."""
-        return ExtractionInput._validate_no_sql_injection(v)
+        return _validate_filter_no_sql_injection(v)
 
 
 class FetchDatabasesInput(ExtractionTaskInput, allow_unbounded_fields=True):

--- a/application_sdk/templates/contracts/sql_metadata.py
+++ b/application_sdk/templates/contracts/sql_metadata.py
@@ -6,24 +6,21 @@ These replace the ``Dict[str, Any]`` interfaces used by
 
 from __future__ import annotations
 
-import json
 from typing import Annotated, Any
 
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from application_sdk.contracts.base import Input, Output, PublishInputMixin
 from application_sdk.contracts.types import ConnectionRef, MaxItems
 from application_sdk.credentials.ref import CredentialRef
 from application_sdk.credentials.spec import AgentCredentialSpec
 
-# Disallow single quotes in filter/regex fields to prevent SQL injection when
+# Type alias for SQL filter maps: database-regex → list of schema-regexes.
+# Example: {"^prod$": ["^analytics$", "^reporting$"]}
+FilterMap = dict[str, list[str]]
+
+# Disallow single quotes in temp_table_regex to prevent SQL injection when
 # values are substituted into SQL templates via _prepare_sql (str.replace).
-# Safety invariant: every fetch_*_sql template MUST wrap substituted values in
-# single quotes (e.g. ``'{normalized_exclude_regex}'``).  This pattern blocks
-# the only character that would escape that wrapping.  If a connector template
-# omits the surrounding quotes this guard provides no protection — the wrapping
-# is a required connector contract, not optional.  Real-world DB name patterns
-# never require single quotes, so the restriction is not a practical limitation.
 _SAFE_FILTER_PATTERN = r"^[^']*$"
 
 
@@ -68,43 +65,71 @@ class ExtractionInput(Input, allow_unbounded_fields=True):
                 data = {**data, "agent_json": None}
         return data
 
-    @model_validator(mode="before")
-    @classmethod
-    def _coerce_filter_values_to_str(cls, data: Any) -> Any:
-        """Convert pre-parsed JSON filter values back to strings.
-
-        AE pre-parses JSON string filter values into dicts/lists before
-        passing them to Temporal (e.g. ``{"^qa$": ["^public$"]}`` instead
-        of the string ``'{"^qa$": ["^public$"]}'``). Pydantic expects
-        ``str`` for these fields, so we JSON-serialize them back.
-        """
-        if not isinstance(data, dict):
-            return data
-        for key in ("include_filter", "exclude_filter", "temp_table_regex"):
-            val = data.get(key)
-            if isinstance(val, (dict, list)):
-                data = {**data, key: json.dumps(val)}
-            elif val is None:
-                data = {**data, key: ""}
-        return data
-
     output_prefix: str = ""
     """Object store prefix for all output artifacts."""
 
     output_path: str = ""
     """Local or object store path for output files."""
 
-    exclude_filter: Annotated[str, Field(pattern=_SAFE_FILTER_PATTERN)] = ""
-    """Regex filter for excluding schemas/tables."""
+    exclude_filter: FilterMap | str = Field(default="")
+    """Filter for excluding schemas/tables.
 
-    include_filter: Annotated[str, Field(pattern=_SAFE_FILTER_PATTERN)] = ""
-    """Regex filter for including schemas/tables."""
+    Accepts:
+    - ``dict[str, list[str]]`` — structured filter map from AE
+    - ``str`` — JSON string or raw regex (backward compat)
+    - ``None`` → empty string
+    """
+
+    include_filter: FilterMap | str = Field(default="")
+    """Filter for including schemas/tables.
+
+    Accepts:
+    - ``dict[str, list[str]]`` — structured filter map from AE
+    - ``str`` — JSON string or raw regex (backward compat)
+    - ``None`` → empty string
+    """
 
     temp_table_regex: Annotated[str, Field(pattern=_SAFE_FILTER_PATTERN)] = ""
     """Regex pattern identifying temporary tables."""
 
     source_tag_prefix: str = ""
     """Tag prefix for source-level metadata."""
+
+    @field_validator("include_filter", "exclude_filter", mode="before")
+    @classmethod
+    def _coerce_filter(cls, v: Any) -> FilterMap | str:
+        """Accept dict, JSON string, raw regex string, list, or None.
+
+        - ``dict`` → pass through (structured filter map from AE)
+        - ``list`` → pass through as dict ``{".*": <list>}``
+        - ``str`` → pass through (JSON string or raw regex)
+        - ``None`` → empty string
+        """
+        if v is None:
+            return ""
+        if isinstance(v, list):
+            return {".*": v}
+        return v
+
+    @field_validator("include_filter", "exclude_filter", mode="after")
+    @classmethod
+    def _validate_no_sql_injection(cls, v: FilterMap | str) -> FilterMap | str:
+        """Block single quotes in filter values to prevent SQL injection."""
+        if isinstance(v, str):
+            if "'" in v:
+                msg = f"Single quotes not allowed in filter value: {v}"
+                raise ValueError(msg)
+        elif isinstance(v, dict):
+            for key, values in v.items():
+                if "'" in key:
+                    msg = f"Single quotes not allowed in filter key: {key}"
+                    raise ValueError(msg)
+                if isinstance(values, list):
+                    for val in values:
+                        if isinstance(val, str) and "'" in val:
+                            msg = f"Single quotes not allowed in filter value: {val}"
+                            raise ValueError(msg)
+        return v
 
 
 class ExtractionOutput(Output, PublishInputMixin):
@@ -137,10 +162,22 @@ class ExtractionTaskInput(Input, allow_unbounded_fields=True):
     credential_ref: CredentialRef | None = None
     output_prefix: str = ""
     output_path: str = ""
-    exclude_filter: Annotated[str, Field(pattern=_SAFE_FILTER_PATTERN)] = ""
-    include_filter: Annotated[str, Field(pattern=_SAFE_FILTER_PATTERN)] = ""
+    exclude_filter: FilterMap | str = Field(default="")
+    include_filter: FilterMap | str = Field(default="")
     temp_table_regex: Annotated[str, Field(pattern=_SAFE_FILTER_PATTERN)] = ""
     source_tag_prefix: str = ""
+
+    @field_validator("include_filter", "exclude_filter", mode="before")
+    @classmethod
+    def _coerce_filter(cls, v: Any) -> FilterMap | str:
+        """Reuse the same coercion logic as ExtractionInput."""
+        return ExtractionInput._coerce_filter(v)
+
+    @field_validator("include_filter", "exclude_filter", mode="after")
+    @classmethod
+    def _validate_no_sql_injection(cls, v: FilterMap | str) -> FilterMap | str:
+        """Reuse the same SQL injection guard as ExtractionInput."""
+        return ExtractionInput._validate_no_sql_injection(v)
 
 
 class FetchDatabasesInput(ExtractionTaskInput, allow_unbounded_fields=True):

--- a/application_sdk/templates/sql_metadata_extractor.py
+++ b/application_sdk/templates/sql_metadata_extractor.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 
 from application_sdk.app.task import task
 from application_sdk.common.exc_utils import rewrap
+from application_sdk.common.sql_filters import normalize_filters
 from application_sdk.credentials import CredentialResolver, legacy_credential_ref
 from application_sdk.infrastructure.context import get_infrastructure
 from application_sdk.observability.logger_adaptor import get_logger
@@ -181,7 +182,7 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
             SQL templates that use these placeholders MUST wrap each substitution
             in single quotes, e.g. ``WHERE name !~ '{normalized_exclude_regex}'``.
             Single quotes in filter values are blocked by the SQL injection guard
-            in ``_validate_filter_values``. Templates that omit the surrounding
+            in ``_validate_no_sql_injection``. Templates that omit the surrounding
             quotes are not protected.
         """
         # Filters can be dict (structured from AE) or str (raw regex / JSON string).
@@ -189,8 +190,6 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
         if isinstance(input.include_filter, dict) or isinstance(
             input.exclude_filter, dict
         ):
-            from application_sdk.common.sql_filters import normalize_filters
-
             if isinstance(input.include_filter, dict):
                 inc_list = normalize_filters(input.include_filter, is_include=True)
                 include_regex = "|".join(inc_list) if inc_list else ".*"

--- a/application_sdk/templates/sql_metadata_extractor.py
+++ b/application_sdk/templates/sql_metadata_extractor.py
@@ -180,12 +180,31 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
         Warning:
             SQL templates that use these placeholders MUST wrap each substitution
             in single quotes, e.g. ``WHERE name !~ '{normalized_exclude_regex}'``.
-            The ``_SAFE_FILTER_PATTERN`` guard blocks single quotes in filter
-            values but only prevents injection when this wrapping is present.
-            Templates that omit the surrounding quotes are not protected.
+            Single quotes in filter values are blocked by the SQL injection guard
+            in ``_validate_filter_values``. Templates that omit the surrounding
+            quotes are not protected.
         """
-        exclude_regex = input.exclude_filter or "^$"
-        include_regex = input.include_filter or ".*"
+        # Filters can be dict (structured from AE) or str (raw regex / JSON string).
+        # Dict filters are normalized via sql_filters; strings are used directly.
+        if isinstance(input.include_filter, dict) or isinstance(
+            input.exclude_filter, dict
+        ):
+            from application_sdk.common.sql_filters import normalize_filters
+
+            if isinstance(input.include_filter, dict):
+                inc_list = normalize_filters(input.include_filter, is_include=True)
+                include_regex = "|".join(inc_list) if inc_list else ".*"
+            else:
+                include_regex = input.include_filter or ".*"
+
+            if isinstance(input.exclude_filter, dict):
+                exc_list = normalize_filters(input.exclude_filter, is_include=False)
+                exclude_regex = "|".join(exc_list) if exc_list else "^$"
+            else:
+                exclude_regex = input.exclude_filter or "^$"
+        else:
+            exclude_regex = input.exclude_filter or "^$"
+            include_regex = input.include_filter or ".*"
 
         temp_table_sql = ""
         if input.temp_table_regex:

--- a/tests/unit/templates/test_extraction_input_filters.py
+++ b/tests/unit/templates/test_extraction_input_filters.py
@@ -1,90 +1,115 @@
-"""Tests for ExtractionInput filter value coercion (BLDX-1118).
+"""Tests for ExtractionInput filter value handling (BLDX-1125).
 
-AE pre-parses JSON filter strings into dicts before passing to Temporal.
-ExtractionInput must coerce them back to strings.
+Filters accept dict (structured from AE), JSON string, raw regex string,
+list, and None. SQL injection is guarded by rejecting single quotes.
 """
 
-import json
+import pytest
 
-from application_sdk.templates.contracts.sql_metadata import ExtractionInput
+from application_sdk.templates.contracts.sql_metadata import (
+    ExtractionInput,
+    ExtractionTaskInput,
+)
 
 
-class TestFilterValueCoercion:
-    def test_dict_include_filter_coerced_to_json_string(self):
-        """AE sends include_filter as dict — should be JSON-serialized."""
-        payload = {
-            "include_filter": {"^qa_test_db$": ["^public$"]},
-        }
+class TestFilterCoercion:
+    """ExtractionInput accepts multiple filter formats."""
+
+    def test_dict_filter_passes_through(self):
+        """Native dict format from AE — pass through."""
+        payload = {"include_filter": {"^qa$": ["^public$"]}}
         result = ExtractionInput.model_validate(payload)
-        assert isinstance(result.include_filter, str)
-        assert json.loads(result.include_filter) == {"^qa_test_db$": ["^public$"]}
+        assert result.include_filter == {"^qa$": ["^public$"]}
 
-    def test_dict_exclude_filter_coerced_to_json_string(self):
-        """AE sends exclude_filter as dict — should be JSON-serialized."""
-        payload = {
-            "exclude_filter": {"^temp_.*$": [".*"]},
-        }
+    def test_string_filter_passes_through(self):
+        """Raw regex string — pass through as string."""
+        payload = {"exclude_filter": "^temp_.*$"}
         result = ExtractionInput.model_validate(payload)
-        assert isinstance(result.exclude_filter, str)
-        assert json.loads(result.exclude_filter) == {"^temp_.*$": [".*"]}
-
-    def test_list_filter_coerced_to_json_string(self):
-        """Filter value as list should also be JSON-serialized."""
-        payload = {
-            "include_filter": ["^db1$", "^db2$"],
-        }
-        result = ExtractionInput.model_validate(payload)
-        assert isinstance(result.include_filter, str)
-        assert json.loads(result.include_filter) == ["^db1$", "^db2$"]
-
-    def test_string_filter_unchanged(self):
-        """Normal string filter should pass through unchanged."""
-        payload = {
-            "include_filter": '{"^qa$": ["^public$"]}',
-            "exclude_filter": "^temp_.*$",
-        }
-        result = ExtractionInput.model_validate(payload)
-        assert result.include_filter == '{"^qa$": ["^public$"]}'
         assert result.exclude_filter == "^temp_.*$"
 
-    def test_empty_string_filter_unchanged(self):
-        """Empty string defaults should work."""
+    def test_json_string_stays_as_string(self):
+        """JSON string — stays as string (parsed at usage time by sql_filters)."""
+        payload = {"include_filter": '{"^qa$": ["^public$"]}'}
+        result = ExtractionInput.model_validate(payload)
+        assert result.include_filter == '{"^qa$": ["^public$"]}'
+
+    def test_list_wrapped_as_dict(self):
+        """List of regexes — wrapped as match-all-databases dict."""
+        payload = {"include_filter": ["^db1$", "^db2$"]}
+        result = ExtractionInput.model_validate(payload)
+        assert result.include_filter == {".*": ["^db1$", "^db2$"]}
+
+    def test_none_becomes_empty_string(self):
+        """None → empty string."""
+        payload = {"include_filter": None}
+        result = ExtractionInput.model_validate(payload)
+        assert result.include_filter == ""
+
+    def test_empty_string_unchanged(self):
+        """Empty string → stays empty string."""
+        payload = {"include_filter": ""}
+        result = ExtractionInput.model_validate(payload)
+        assert result.include_filter == ""
+
+    def test_default_is_empty_string(self):
+        """No filter provided → default empty string."""
         result = ExtractionInput.model_validate({})
         assert result.include_filter == ""
         assert result.exclude_filter == ""
-        assert result.temp_table_regex == ""
 
-    def test_dict_temp_table_regex_coerced(self):
-        """temp_table_regex as dict should be JSON-serialized."""
-        payload = {
-            "temp_table_regex": {"pattern": "^tmp_.*"},
-        }
-        result = ExtractionInput.model_validate(payload)
-        assert isinstance(result.temp_table_regex, str)
 
-    def test_multiple_filters_all_coerced(self):
-        """All three filter fields coerced in single payload."""
-        payload = {
-            "include_filter": {"^prod$": ["^analytics$"]},
-            "exclude_filter": {"^test_.*$": [".*"]},
-            "temp_table_regex": ["^tmp_", "^temp_"],
-        }
-        result = ExtractionInput.model_validate(payload)
-        assert isinstance(result.include_filter, str)
-        assert isinstance(result.exclude_filter, str)
-        assert isinstance(result.temp_table_regex, str)
+class TestFilterSQLInjectionGuard:
+    """Single quotes blocked in filter values."""
 
-    def test_none_filter_stays_default(self):
-        """None filter values should fall through to default empty string."""
-        payload = {
-            "include_filter": None,
-        }
-        result = ExtractionInput.model_validate(payload)
-        # None is not dict/list, so validator doesn't touch it — Pydantic uses default
+    def test_single_quote_in_string_rejected(self):
+        payload = {"include_filter": "prefix'injection"}
+        with pytest.raises(ValueError, match="Single quotes not allowed"):
+            ExtractionInput.model_validate(payload)
+
+    def test_single_quote_in_dict_key_rejected(self):
+        payload = {"include_filter": {"db'; DROP TABLE--": ["^public$"]}}
+        with pytest.raises(ValueError, match="Single quotes not allowed"):
+            ExtractionInput.model_validate(payload)
+
+    def test_single_quote_in_dict_value_rejected(self):
+        payload = {"include_filter": {"^db$": ["schema'; DROP TABLE--"]}}
+        with pytest.raises(ValueError, match="Single quotes not allowed"):
+            ExtractionInput.model_validate(payload)
+
+    def test_clean_string_passes(self):
+        result = ExtractionInput.model_validate({"include_filter": "^prod_.*$"})
+        assert result.include_filter == "^prod_.*$"
+
+    def test_clean_dict_passes(self):
+        result = ExtractionInput.model_validate(
+            {"include_filter": {"^prod$": ["^analytics$"]}}
+        )
+        assert result.include_filter == {"^prod$": ["^analytics$"]}
+
+
+class TestExtractionTaskInputFilters:
+    """ExtractionTaskInput has the same filter coercion."""
+
+    def test_dict_filter_accepted(self):
+        result = ExtractionTaskInput.model_validate(
+            {"include_filter": {"^qa$": ["^public$"]}}
+        )
+        assert result.include_filter == {"^qa$": ["^public$"]}
+
+    def test_string_filter_accepted(self):
+        result = ExtractionTaskInput.model_validate({"exclude_filter": "^temp_.*$"})
+        assert result.exclude_filter == "^temp_.*$"
+
+    def test_none_becomes_empty_string(self):
+        result = ExtractionTaskInput.model_validate({"include_filter": None})
         assert result.include_filter == ""
 
-    def test_real_ae_payload(self):
-        """Simulate a real AE payload with pre-parsed filters."""
+
+class TestRealAEPayload:
+    """Simulate real AE payloads."""
+
+    def test_ae_payload_with_pre_parsed_filters(self):
+        """AE sends pre-parsed dicts — works natively."""
         payload = {
             "workflow_id": "test-wf-123",
             "credential_guid": "abc-def",
@@ -93,8 +118,15 @@ class TestFilterValueCoercion:
             "extraction_method": "direct",
         }
         result = ExtractionInput.model_validate(payload)
-        assert result.workflow_id == "test-wf-123"
-        assert result.credential_guid == "abc-def"
+        assert result.include_filter == {"^qa_test_db$": ["^public$"]}
+        assert result.exclude_filter == {}
+
+    def test_legacy_payload_with_string_filters(self):
+        """Legacy connectors send strings — works as before."""
+        payload = {
+            "include_filter": '{"^prod$": ["^analytics$"]}',
+            "exclude_filter": "^temp_.*$",
+        }
+        result = ExtractionInput.model_validate(payload)
         assert isinstance(result.include_filter, str)
-        assert result.include_filter == '{"^qa_test_db$": ["^public$"]}'
-        assert result.exclude_filter == "{}"
+        assert isinstance(result.exclude_filter, str)

--- a/tests/unit/templates/test_sql_metadata_extractor.py
+++ b/tests/unit/templates/test_sql_metadata_extractor.py
@@ -325,6 +325,35 @@ class TestSqlMetadataExtractorPrepareSql:
         )
         assert result == "x  y"
 
+    def test_substitutes_dict_filters_via_normalize(self) -> None:
+        """Dict filters (from AE) are normalized into regex via sql_filters."""
+        sql = "{normalized_exclude_regex}|{normalized_include_regex}"
+        result = self._extractor()._prepare_sql(
+            sql,
+            ExtractionTaskInput(
+                include_filter={"^prod$": ["^analytics$", "^reporting$"]},
+                exclude_filter={"^temp_db$": [".*"]},
+            ),
+        )
+        # normalize_filters produces "db\.schema" patterns
+        assert "prod" in result
+        assert "analytics" in result
+        assert "temp_db" in result
+
+    def test_mixed_dict_include_string_exclude(self) -> None:
+        """Dict include + string exclude — each handled by its type."""
+        sql = "{normalized_exclude_regex}|{normalized_include_regex}"
+        result = self._extractor()._prepare_sql(
+            sql,
+            ExtractionTaskInput(
+                include_filter={"^prod$": ["^public$"]},
+                exclude_filter="^temp_.*$",
+            ),
+        )
+        assert "prod" in result
+        assert "public" in result
+        assert "^temp_.*$" in result
+
 
 class TestSqlMetadataExtractorLoadSqlClient:
     """Tests for ``_load_sql_client`` and default fetch task execution."""


### PR DESCRIPTION
## Summary
Follow-up to BLDX-1118. Instead of coercing everything to strings, `ExtractionInput` filter fields now natively accept the structured `dict[str, list[str]]` format that AE sends, while preserving backward compatibility with raw regex strings.

## Changes

### `application_sdk/templates/contracts/sql_metadata.py`
- `include_filter` / `exclude_filter` type: `str` → `FilterMap | str` (`dict[str, list[str]] | str`)
- `_coerce_filter` validator: handles None→"", list→dict, passes dict and str through
- `_validate_no_sql_injection` validator: guards both dict keys/values and string values against single quotes
- Applied to both `ExtractionInput` and `ExtractionTaskInput`

### `application_sdk/templates/sql_metadata_extractor.py`
- `_prepare_sql` detects filter type at usage time:
  - `dict` → normalized via `sql_filters.normalize_filters()` into regex
  - `str` → used directly (same as before)

### Tests
- 17 new tests covering: dict, string, JSON string, list, None, empty, SQL injection on both formats, real AE payloads, legacy payloads

## Why now
Few v3 connectors deployed — safe to change the contract type without breaking many consumers.

## Backward Compatibility
- String filters work exactly as before
- Dict filters from AE now work natively (no round-trip through JSON serialization)
- `temp_table_regex` stays `str` (it's always a raw regex)

## Linear
https://linear.app/atlan-epd/issue/BLDX-1125