### PR TITLE
fix(dapr): wait for sidecar readiness before querying metadata at startup

### DIFF
--- a/application_sdk/infrastructure/_dapr/__init__.py
+++ b/application_sdk/infrastructure/_dapr/__init__.py
@@ -12,10 +12,14 @@ from application_sdk.infrastructure._dapr.credential_vault import (
     DaprCredentialVault,
     create_dapr_credential_vault,
 )
-from application_sdk.infrastructure._dapr.http import AsyncDaprClient
+from application_sdk.infrastructure._dapr.http import (
+    AsyncDaprClient,
+    wait_for_dapr_sidecar,
+)
 
 __all__ = [
     "AsyncDaprClient",
+    "wait_for_dapr_sidecar",
     "DaprBinding",
     "DaprCredentialVault",
     "DaprPubSub",

--- a/application_sdk/infrastructure/_dapr/http.py
+++ b/application_sdk/infrastructure/_dapr/http.py
@@ -9,6 +9,7 @@ Endpoint reference: https://docs.dapr.io/reference/api/
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 from typing import Any
@@ -42,9 +43,42 @@ BINDING_PATH = f"{_API_PREFIX}/bindings/{{binding_name}}"
 METADATA_PATH = f"{_API_PREFIX}/metadata"
 
 
+_HEALTHZ_PATH = "/v1.0/healthz"
+_DEFAULT_SIDECAR_WAIT_TIMEOUT = 10.0
+_DEFAULT_SIDECAR_POLL_INTERVAL = 0.5
+
+
 def _dapr_base_url() -> str:
     port = os.environ.get("DAPR_HTTP_PORT", str(_DEFAULT_DAPR_HTTP_PORT))
     return f"http://localhost:{port}"
+
+
+async def wait_for_dapr_sidecar(
+    timeout: float = _DEFAULT_SIDECAR_WAIT_TIMEOUT,
+    interval: float = _DEFAULT_SIDECAR_POLL_INTERVAL,
+) -> None:
+    """Poll /v1.0/healthz until the Dapr sidecar is ready or timeout elapses.
+
+    Dapr returns 204 when all components have finished initializing.
+    On timeout the function logs a warning and returns — startup proceeds
+    and the subsequent metadata call will surface any remaining errors.
+    """
+    url = f"{_dapr_base_url()}{_HEALTHZ_PATH}"
+    deadline = asyncio.get_event_loop().time() + timeout
+    async with httpx.AsyncClient(timeout=2.0) as client:
+        while True:
+            try:
+                r = await client.get(url)
+                if r.status_code == 204:
+                    return
+            except Exception:
+                pass
+            if asyncio.get_event_loop().time() >= deadline:
+                logger.warning(
+                    "Dapr sidecar not ready after %.0fs — proceeding anyway", timeout
+                )
+                return
+            await asyncio.sleep(interval)
 
 
 # ---------------------------------------------------------------------------

--- a/application_sdk/infrastructure/_dapr/http.py
+++ b/application_sdk/infrastructure/_dapr/http.py
@@ -64,16 +64,17 @@ async def wait_for_dapr_sidecar(
     and the subsequent metadata call will surface any remaining errors.
     """
     url = f"{_dapr_base_url()}{_HEALTHZ_PATH}"
-    deadline = asyncio.get_event_loop().time() + timeout
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
     async with httpx.AsyncClient(timeout=2.0) as client:
         while True:
             try:
                 r = await client.get(url)
                 if r.status_code == 204:
                     return
-            except Exception:
-                pass
-            if asyncio.get_event_loop().time() >= deadline:
+            except Exception as exc:
+                logger.debug("Dapr sidecar poll failed: %s", exc)
+            if loop.time() >= deadline:
                 logger.warning(
                     "Dapr sidecar not ready after %.0fs — proceeding anyway", timeout
                 )

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -419,9 +419,13 @@ async def _create_infrastructure(
             DaprSecretStore,
             DaprStateStore,
         )
-        from application_sdk.infrastructure._dapr.http import AsyncDaprClient
+        from application_sdk.infrastructure._dapr.http import (
+            AsyncDaprClient,
+            wait_for_dapr_sidecar,
+        )
         from application_sdk.storage import create_store_from_binding
 
+        await wait_for_dapr_sidecar()
         dapr_client = AsyncDaprClient()
         components_dir = Path(os.environ.get("DAPR_COMPONENTS_PATH", "./components"))
         registered_components = await _log_dapr_components(dapr_client, components_dir)

--- a/tests/unit/infrastructure/test_dapr_http.py
+++ b/tests/unit/infrastructure/test_dapr_http.py
@@ -16,6 +16,7 @@ from application_sdk.infrastructure._dapr.http import (
     STATE_PATH,
     AsyncDaprClient,
     BindingResult,
+    wait_for_dapr_sidecar,
 )
 
 
@@ -355,3 +356,73 @@ class TestRetryConfiguration:
 
         client = AsyncDaprClient(base_url="http://localhost:3500", retries=0)
         assert isinstance(client._client._transport, RetryTransport)
+
+
+class TestWaitForDaprSidecar:
+    async def test_ready_immediately(self):
+        """Returns as soon as sidecar responds 204 on first poll."""
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_get = AsyncMock(return_value=mock_response)
+        with patch(
+            "application_sdk.infrastructure._dapr.http.httpx.AsyncClient"
+        ) as mock_cls:
+            mock_cls.return_value.__aenter__ = AsyncMock(
+                return_value=MagicMock(get=mock_get)
+            )
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            await wait_for_dapr_sidecar(timeout=5.0, interval=0.01)
+        mock_get.assert_called_once()
+
+    async def test_ready_after_retries(self):
+        """Returns once sidecar eventually responds 204 after non-204 responses."""
+        not_ready = MagicMock()
+        not_ready.status_code = 503
+        ready = MagicMock()
+        ready.status_code = 204
+        mock_get = AsyncMock(side_effect=[not_ready, not_ready, ready])
+        with patch(
+            "application_sdk.infrastructure._dapr.http.httpx.AsyncClient"
+        ) as mock_cls:
+            mock_cls.return_value.__aenter__ = AsyncMock(
+                return_value=MagicMock(get=mock_get)
+            )
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            await wait_for_dapr_sidecar(timeout=5.0, interval=0.01)
+        assert mock_get.call_count == 3
+
+    async def test_timeout_logs_warning(self):
+        """Logs a warning and returns when sidecar never becomes ready."""
+        not_ready = MagicMock()
+        not_ready.status_code = 503
+        mock_get = AsyncMock(return_value=not_ready)
+        with (
+            patch(
+                "application_sdk.infrastructure._dapr.http.httpx.AsyncClient"
+            ) as mock_cls,
+            patch("application_sdk.infrastructure._dapr.http.logger") as mock_logger,
+        ):
+            mock_cls.return_value.__aenter__ = AsyncMock(
+                return_value=MagicMock(get=mock_get)
+            )
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            await wait_for_dapr_sidecar(timeout=0.05, interval=0.01)
+        mock_logger.warning.assert_called_once()
+        assert "not ready" in mock_logger.warning.call_args[0][0]
+
+    async def test_connection_error_does_not_crash(self):
+        """Poll loop survives connection errors and eventually times out cleanly."""
+        import httpx as _httpx
+
+        mock_get = AsyncMock(side_effect=_httpx.ConnectError("refused"))
+        with (
+            patch(
+                "application_sdk.infrastructure._dapr.http.httpx.AsyncClient"
+            ) as mock_cls,
+            patch("application_sdk.infrastructure._dapr.http.logger"),
+        ):
+            mock_cls.return_value.__aenter__ = AsyncMock(
+                return_value=MagicMock(get=mock_get)
+            )
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            await wait_for_dapr_sidecar(timeout=0.05, interval=0.01)


### PR DESCRIPTION
## Summary
- Adds `wait_for_dapr_sidecar()` to `application_sdk/infrastructure/_dapr/http.py` — polls `/v1.0/healthz` with a 10s timeout and 0.5s interval before the app queries the Dapr metadata API
- Calls it once in `_create_infrastructure` (before `_log_dapr_components`), covering both the component-logging path and any downstream `is_dapr_component_registered` calls
- Exports `wait_for_dapr_sidecar` from the `_dapr` package for direct use by callers if needed
- On timeout (sidecar still not ready) the function logs a warning and returns — startup is never blocked

https://linear.app/atlan-epd/issue/ARUN-457/p3-add-dapr-sidecar-readiness-check-before-component-queries-at

## Background
App containers were querying the Dapr metadata API before the sidecar finished initializing, producing ~150 transient `BindingError` / component-not-registered warnings per week on internal tenants (atlanimp01, fifaqa). Each pod saw exactly 1-2 occurrences at startup, never recurred, and had zero customer impact. Investigation: ARUN-450.

The existing `RetryTransport` only retries HTTP 5xx responses — it doesn't handle connection-refused or the window where Dapr returns non-204 from `/v1.0/healthz` while components are still loading. This wait loop fills that gap.

## Test plan
- [ ] Deploy to atlanimp01 and confirm the startup warnings from `_log_dapr_components` are gone
- [ ] Verify normal startup time is not meaningfully increased (sidecar is typically ready well within 1s)
- [ ] Confirm unit tests for `_log_dapr_components` and `is_dapr_component_registered` still pass