### PR TITLE
allowlist: CVE-2025-59250 mssql-jdbc Trivy false positive (.jreN classifier version mismatch)  

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Updated by SDK team. CODEOWNERS: SDK/security team only.",
   "_base_image": "application-sdk-main",
-  "_updated": "2026-04-21",
+  "_updated": "2026-04-23",
   "_renewal_note": "Expiry dates staggered by severity. CRITICAL: 60 days. HIGH: 90 days. Review before expiry.",
   "SNYK-GOLANG-GOOGLEGOLANGORGGRPC-15691172": {
     "package": "google.golang.org/grpc",
@@ -212,5 +212,12 @@
     "reason": "Base image \u2014 Go dependency, fix available in 0.5.1",
     "expires": "2026-07-21",
     "added_by": "mananjain99"
+  },
+  "CVE-2025-59250": {
+    "package": "com.microsoft.sqlserver:mssql-jdbc",
+    "severity": "HIGH",
+    "reason": "Fabric connector \u2014 mssql-jdbc JDBC dependency; Trivy false positive due to .jreN classifier version mismatch",
+    "expires": "2026-07-22",
+    "added_by": "swata.dash"
   }
 }


### PR DESCRIPTION
## allowlist: add CVE-2025-59250 for mssql-jdbc (Trivy false positive)

Trivy flags mssql-jdbc JARs because `pom.properties` embeds the version without the `.jreN` classifier (e.g. `13.4.0`) while the CVE fix versions in the database include it (e.g. `13.2.1.jre11`). Trivy then sees `13.4.0 < 13.2.1.jre11` which is a version parsing false positive.

The Fabric connector is running `13.4.0.jre11`, newer than the patched `13.2.1.jre11` release. No real vulnerability present.

Expires: 2026-07-22 (HIGH severity, 90-day policy)

### Changelog
- Added `CVE-2025-59250` to `.security/base-allowlist.json` for `com.microsoft.sqlserver:mssql-jdbc`
- Bumped `_updated` date to 2026-04-23

### Additional context
- CVE affects all mssql-jdbc versions according to Trivy, including the latest `13.4.0.jre11` — confirmed by testing `12.10.1`, `12.10.2`, `13.2.1`, and `13.4.0`
- Root cause: Trivy reads `version=13.4.0` from the JAR's `META-INF/maven/.../pom.properties` (no classifier), then compares against fix version `13.2.1.jre11` (with classifier) — version parsing mismatch causes a false positive
- Fabric connector requires mssql-jdbc for Warehouse SQL metadata extraction via JDBC (JPype)
- Raised from `atlanhq/atlan-fabric-app` PR [#61](https://github.com/atlanhq/atlan-fabric-app/pull/61)

### Checklist
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.
