### PR TITLE
fix: resolve broken event_bus import in token refresh

### DIFF
--- a/application_sdk/execution/_temporal/auth.py
+++ b/application_sdk/execution/_temporal/auth.py
@@ -225,17 +225,18 @@ class TemporalAuthManager:
         await self._emit_token_refresh_event(expires_at)
 
     async def _emit_token_refresh_event(self, expires_at: datetime | None) -> None:
-        """Emit a token_refresh lifecycle event via the EventBus (best-effort)."""
+        """Emit a token_refresh lifecycle event via the event binding (best-effort)."""
         import os
         import time
 
         try:
-            from application_sdk.execution._temporal.interceptors.event_bus import (
-                get_event_bus,
+            from application_sdk.contracts.events import (
+                ApplicationEventNames,
+                Event,
+                EventTypes,
             )
             from application_sdk.execution._temporal.interceptors.events import (
-                TOKEN_REFRESH,
-                LifecycleEvent,
+                _publish_event_via_binding,
             )
 
             app_name = os.environ.get("ATLAN_APP_NAME", "")
@@ -244,11 +245,10 @@ class TemporalAuthManager:
             expires_at_ts = expires_at.timestamp() if expires_at else 0.0
             remaining = max(0.0, expires_at_ts - now)
 
-            event = LifecycleEvent(
-                event_name=TOKEN_REFRESH,
-                app_name=app_name,
-                timestamp_ms=int(now * 1000),
-                extra={
+            event = Event(
+                event_type=EventTypes.APPLICATION_EVENT.value,
+                event_name=ApplicationEventNames.TOKEN_REFRESH.value,
+                data={
                     "force_refresh": "true",
                     "token_expiry_time": str(expires_at_ts),
                     "time_until_expiry": str(remaining),
@@ -257,7 +257,7 @@ class TemporalAuthManager:
                     "deployment_name": deployment_name,
                 },
             )
-            await get_event_bus().emit(event)
+            await _publish_event_via_binding(event)
         except Exception:
             logger.warning("Failed to emit token_refresh event", exc_info=True)
 

--- a/tests/unit/execution/test_auth_token_refresh_event.py
+++ b/tests/unit/execution/test_auth_token_refresh_event.py
@@ -1,0 +1,160 @@
+"""Tests for _emit_token_refresh_event in TemporalAuthManager."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest import mock
+
+import pytest
+
+from application_sdk.contracts.events import ApplicationEventNames, EventTypes
+from application_sdk.execution._temporal.auth import (
+    TemporalAuthConfig,
+    TemporalAuthManager,
+)
+
+# The method imports _publish_event_via_binding locally, so we mock at its
+# source module rather than on the auth module.
+_PUBLISH_TARGET = (
+    "application_sdk.execution._temporal.interceptors.events._publish_event_via_binding"
+)
+
+
+def _make_manager() -> TemporalAuthManager:
+    """Create a TemporalAuthManager with dummy config for testing."""
+    return TemporalAuthManager(
+        config=TemporalAuthConfig(
+            client_id="test-client",
+            client_secret="test-secret",
+            token_url="https://example.com/token",
+        )
+    )
+
+
+class TestEmitTokenRefreshEvent:
+    """Tests for TemporalAuthManager._emit_token_refresh_event."""
+
+    @pytest.mark.asyncio
+    async def test_publishes_event_successfully(self) -> None:
+        """_emit_token_refresh_event calls _publish_event_via_binding with correct event."""
+        manager = _make_manager()
+        expires_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+        with mock.patch(_PUBLISH_TARGET) as mock_publish:
+            mock_publish.return_value = None
+
+            await manager._emit_token_refresh_event(expires_at)
+
+            mock_publish.assert_called_once()
+            event = mock_publish.call_args[0][0]
+
+            assert event.event_type == EventTypes.APPLICATION_EVENT.value
+            assert event.event_name == ApplicationEventNames.TOKEN_REFRESH.value
+
+    @pytest.mark.asyncio
+    async def test_does_not_raise_on_publish_failure(self) -> None:
+        """_emit_token_refresh_event swallows exceptions from publishing."""
+        manager = _make_manager()
+        expires_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+        with mock.patch(
+            _PUBLISH_TARGET,
+            side_effect=RuntimeError("binding unavailable"),
+        ):
+            # Should not raise
+            await manager._emit_token_refresh_event(expires_at)
+
+    @pytest.mark.asyncio
+    async def test_does_not_raise_on_import_failure(self) -> None:
+        """_emit_token_refresh_event handles import errors gracefully."""
+        manager = _make_manager()
+
+        # Simulate the contracts import failing inside the try block
+        with mock.patch.dict(
+            "sys.modules",
+            {"application_sdk.contracts.events": None},
+        ):
+            # Should not raise
+            await manager._emit_token_refresh_event(None)
+
+    @pytest.mark.asyncio
+    async def test_event_metadata_contains_expected_fields(self) -> None:
+        """Event data includes deployment_name, application_name, and timing fields."""
+        manager = _make_manager()
+        expires_at = datetime(2026, 6, 15, 10, 30, 0, tzinfo=UTC)
+
+        env_vars = {
+            "ATLAN_APP_NAME": "my-test-app",
+            "ATLAN_DEPLOYMENT_NAME": "my-deployment",
+        }
+
+        with (
+            mock.patch.dict("os.environ", env_vars, clear=False),
+            mock.patch(_PUBLISH_TARGET) as mock_publish,
+        ):
+            mock_publish.return_value = None
+
+            await manager._emit_token_refresh_event(expires_at)
+
+            event = mock_publish.call_args[0][0]
+            data = event.data
+
+            assert data["application_name"] == "my-test-app"
+            assert data["deployment_name"] == "my-deployment"
+            assert data["force_refresh"] == "true"
+            assert "token_expiry_time" in data
+            assert "time_until_expiry" in data
+            assert "refresh_timestamp" in data
+
+    @pytest.mark.asyncio
+    async def test_deployment_name_falls_back_to_app_name(self) -> None:
+        """When ATLAN_DEPLOYMENT_NAME is unset, deployment_name equals app_name."""
+        manager = _make_manager()
+        expires_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+        # Set only ATLAN_APP_NAME, ensure ATLAN_DEPLOYMENT_NAME is absent
+        env_overrides = {"ATLAN_APP_NAME": "fallback-app"}
+
+        with (
+            mock.patch.dict("os.environ", env_overrides, clear=False),
+            mock.patch(_PUBLISH_TARGET) as mock_publish,
+        ):
+            # Remove ATLAN_DEPLOYMENT_NAME if it happens to be set
+            import os
+
+            os.environ.pop("ATLAN_DEPLOYMENT_NAME", None)
+
+            mock_publish.return_value = None
+
+            await manager._emit_token_refresh_event(expires_at)
+
+            event = mock_publish.call_args[0][0]
+            assert event.data["deployment_name"] == "fallback-app"
+
+    @pytest.mark.asyncio
+    async def test_handles_none_expires_at(self) -> None:
+        """When expires_at is None, event still publishes with zero timestamps."""
+        manager = _make_manager()
+
+        with mock.patch(_PUBLISH_TARGET) as mock_publish:
+            mock_publish.return_value = None
+
+            await manager._emit_token_refresh_event(None)
+
+            mock_publish.assert_called_once()
+            event = mock_publish.call_args[0][0]
+            assert event.data["token_expiry_time"] == "0.0"
+
+    @pytest.mark.asyncio
+    async def test_uses_correct_event_type_and_name(self) -> None:
+        """Verify the exact event_type and event_name string values."""
+        manager = _make_manager()
+
+        with mock.patch(_PUBLISH_TARGET) as mock_publish:
+            mock_publish.return_value = None
+
+            await manager._emit_token_refresh_event(datetime(2026, 1, 1, tzinfo=UTC))
+
+            event = mock_publish.call_args[0][0]
+            assert event.event_type == "application_events"
+            assert event.event_name == "token_refresh"


### PR DESCRIPTION
## Summary

- Fixes `_emit_token_refresh_event` in `auth.py` which imported from a non-existent module `application_sdk.execution._temporal.interceptors.event_bus` and referenced undefined symbols (`get_event_bus`, `TOKEN_REFRESH`, `LifecycleEvent`)
- Refactored to use the existing `_publish_event_via_binding` function from `interceptors/events.py` and standard `Event`/`ApplicationEventNames` types from `contracts/events.py`, matching the pattern used by all other event publishers in the codebase
- `ApplicationEventNames.TOKEN_REFRESH` already existed in `contracts/events.py`, so no new event types were needed
- Added 7 unit tests covering: successful event publishing, graceful failure handling (runtime and import errors), correct event type/name values, expected metadata fields, deployment_name fallback, and None expires_at edge case

Closes #1542

## Test plan

- [x] Unit tests for `_emit_token_refresh_event` added in `tests/unit/execution/test_auth_token_refresh_event.py` (7 tests, all passing)
- [ ] Verify `_emit_token_refresh_event` no longer raises `ModuleNotFoundError` at runtime
- [ ] Confirm token refresh events are published via the Dapr event binding when auth is configured
- [ ] Verify the event payload contains the expected fields (`force_refresh`, `token_expiry_time`, `time_until_expiry`, `refresh_timestamp`, `application_name`, `deployment_name`)
- [x] Pre-commit checks (ruff, pyright, isort) pass