### PR TITLE
BLDX-1130 feat(contracts): add staging_data_prefix to PublishInputMixin

### DIFF
--- a/application_sdk/contracts/base.py
+++ b/application_sdk/contracts/base.py
@@ -714,9 +714,9 @@ class PublishInputMixin(BaseModel):
     include a ``publish`` step in their AE manifest should use this
     as a mixin alongside their own output fields.
 
-    ``publish_state_prefix`` and ``current_state_prefix`` are auto-derived
-    from ``connection_qualified_name`` via a model validator. Apps only
-    need to set ``connection_qualified_name`` and ``transformed_data_prefix``.
+    ``publish_state_prefix``, ``staging_data_prefix``, and ``current_state_prefix``
+    are auto-derived from ``connection_qualified_name`` via a model validator.
+    Apps only need to set ``connection_qualified_name`` and ``transformed_data_prefix``.
 
     Example::
 
@@ -732,6 +732,9 @@ class PublishInputMixin(BaseModel):
     PUBLISH_STATE_PREFIX_TEMPLATE: ClassVar[str] = (
         "persistent-artifacts/apps/atlan-publish-app/state"
         "/{connection_qn}/publish-state"
+    )
+    STAGING_DATA_PREFIX_TEMPLATE: ClassVar[str] = (
+        "persistent-artifacts/apps/atlan-publish-app/state/{connection_qn}"
     )
     CURRENT_STATE_PREFIX_TEMPLATE: ClassVar[str] = (
         "argo-artifacts/{connection_qn}/current-state"
@@ -756,6 +759,11 @@ class PublishInputMixin(BaseModel):
 
     publish_state_prefix: str = ""
     """Auto-derived from ``connection_qualified_name`` if not set."""
+
+    staging_data_prefix: str = ""
+    """Auto-derived from ``connection_qualified_name`` if not set.
+    Same as ``publish_state_prefix`` but only up to the connection QN
+    (without the ``/publish-state`` suffix)."""
 
     current_state_prefix: str = ""
     """Auto-derived from ``connection_qualified_name`` if not set."""
@@ -798,6 +806,10 @@ class PublishInputMixin(BaseModel):
             return self
         if not self.publish_state_prefix:
             self.publish_state_prefix = self.PUBLISH_STATE_PREFIX_TEMPLATE.format(
+                connection_qn=cqn
+            )
+        if not self.staging_data_prefix:
+            self.staging_data_prefix = self.STAGING_DATA_PREFIX_TEMPLATE.format(
                 connection_qn=cqn
             )
         if not self.current_state_prefix:

--- a/tests/unit/templates/test_sql_metadata_extractor.py
+++ b/tests/unit/templates/test_sql_metadata_extractor.py
@@ -499,25 +499,30 @@ class TestPublishInputMixin:
     def test_auto_derives_state_prefixes(self) -> None:
         out = PublishInputMixin(connection_qualified_name="default/snowflake/123")
         assert "default/snowflake/123" in out.publish_state_prefix
+        assert "default/snowflake/123" in out.staging_data_prefix
         assert "default/snowflake/123" in out.current_state_prefix
 
     def test_empty_connection_yields_empty_prefixes(self) -> None:
         out = PublishInputMixin()
         assert out.publish_state_prefix == ""
+        assert out.staging_data_prefix == ""
         assert out.current_state_prefix == ""
 
     def test_explicit_values_not_overridden(self) -> None:
         out = PublishInputMixin(
             connection_qualified_name="default/pg/456",
             publish_state_prefix="custom/publish",
+            staging_data_prefix="custom/staging",
             current_state_prefix="custom/current",
         )
         assert out.publish_state_prefix == "custom/publish"
+        assert out.staging_data_prefix == "custom/staging"
         assert out.current_state_prefix == "custom/current"
 
     def test_unsafe_connection_qn_no_derivation(self) -> None:
         out = PublishInputMixin(connection_qualified_name="../../attack")
         assert out.publish_state_prefix == ""
+        assert out.staging_data_prefix == ""
         assert out.current_state_prefix == ""
 
     def test_used_as_mixin(self) -> None:
@@ -563,6 +568,7 @@ class TestPublishInputMixin:
         )
         # Auto-resolve fails gracefully outside Temporal
         assert out.publish_state_prefix != ""
+        assert out.staging_data_prefix != ""
         assert out.current_state_prefix != ""
         # transformed_data_prefix empty since output_path couldn't be resolved
         assert out.transformed_data_prefix == ""
@@ -574,6 +580,18 @@ class TestPublishInputMixin:
             transformed_data_prefix="custom/transformed",
         )
         assert out.transformed_data_prefix == "custom/transformed"
+
+    def test_staging_data_prefix_is_publish_without_suffix(self) -> None:
+        """staging_data_prefix is publish_state_prefix up to connection QN only."""
+        out = PublishInputMixin(connection_qualified_name="default/snowflake/123")
+        assert out.staging_data_prefix == (
+            "persistent-artifacts/apps/atlan-publish-app/state/default/snowflake/123"
+        )
+        assert out.publish_state_prefix == (
+            "persistent-artifacts/apps/atlan-publish-app/state"
+            "/default/snowflake/123/publish-state"
+        )
+        assert out.publish_state_prefix.startswith(out.staging_data_prefix)
 
     def test_path_traversal_in_output_path_yields_empty(self) -> None:
         out = PublishInputMixin(
@@ -731,4 +749,5 @@ class TestExtractionOutputFields:
             connection_qualified_name="default/postgres/prod",
         )
         assert "default/postgres/prod" in output.publish_state_prefix
+        assert "default/postgres/prod" in output.staging_data_prefix
         assert "default/postgres/prod" in output.current_state_prefix


### PR DESCRIPTION
## Summary                                                                                                                                                                     
  - Added `staging_data_prefix` field to `PublishInputMixin` in `application_sdk/contracts/base.py`                                                                              
  - The field is auto-derived from `connection_qualified_name`, using the same path as `publish_state_prefix` but truncated at the connection QN (without the `/publish-state`   
  suffix)                                                                                                                                                                        
  - Added `STAGING_DATA_PREFIX_TEMPLATE` class variable: `persistent-artifacts/apps/atlan-publish-app/state/{connection_qn}`                                                     
                                                                                                                                                                                 
  ## Example                                                                                                                                                                     

  For `connection_qualified_name="default/snowflake/123"`:

  | Field | Value |
  |---|---|
  | `publish_state_prefix` | `persistent-artifacts/apps/atlan-publish-app/state/default/snowflake/123/publish-state` |
  | `staging_data_prefix` | `persistent-artifacts/apps/atlan-publish-app/state/default/snowflake/123` |

  ## Test plan
  - [ ] Verify `staging_data_prefix` is auto-derived correctly when `connection_qualified_name` is set
  - [ ] Verify `staging_data_prefix` remains empty when `connection_qualified_name` is empty
  - [ ] Verify manually set `staging_data_prefix` is not overwritten by the validator
  - [ ] Run existing `PublishInputMixin` tests to confirm no regressions