### PR TITLE
fix: ParquetFileWriter data loss — unique filenames + immediate upload per sub-chunk

### DIFF
--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -849,6 +849,22 @@ class ParquetFileWriter(Writer):
         except Exception:
             logger.warning("Error cleaning up temp folders", exc_info=True)
 
+    async def _flush_buffer(self, chunk: "pd.DataFrame", chunk_part: int):
+        """Flush a buffer chunk to a Parquet file with unique filenames.
+
+        Overrides base Writer._flush_buffer because Parquet files cannot be
+        appended to (unlike JSON where _write_chunk uses open("a")).
+        pq.write_table() always overwrites the target file, so without
+        incrementing chunk_part after each flush, _write_dataframe's buffer
+        loop writes every sub-chunk to the same filename, silently losing
+        all data except the last sub-chunk. See HYP-773.
+        """
+        await super()._flush_buffer(chunk, chunk_part)
+        # Advance part so the next sub-chunk gets a unique filename.
+        # JSON's _write_chunk uses append mode ("a") so it can safely reuse
+        # the same file; Parquet's pq.write_table always overwrites.
+        self.chunk_part += 1
+
     async def _write_chunk(self, chunk: "pd.DataFrame", file_name: str):
         """Write a chunk to a Parquet file, casting null-typed columns to string.
 

--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -850,19 +850,29 @@ class ParquetFileWriter(Writer):
             logger.warning("Error cleaning up temp folders", exc_info=True)
 
     async def _flush_buffer(self, chunk: "pd.DataFrame", chunk_part: int):
-        """Flush a buffer chunk to a Parquet file with unique filenames.
+        """Flush a buffer chunk to a Parquet file, upload it, and advance chunk_part.
 
         Overrides base Writer._flush_buffer because Parquet files cannot be
         appended to (unlike JSON where _write_chunk uses open("a")).
-        pq.write_table() always overwrites the target file, so without
-        incrementing chunk_part after each flush, _write_dataframe's buffer
-        loop writes every sub-chunk to the same filename, silently losing
-        all data except the last sub-chunk. See HYP-773.
+        pq.write_table() always overwrites the target file, so without this
+        override _write_dataframe's buffer loop writes every sub-chunk to the
+        same filename, silently losing all data except the last sub-chunk.
+
+        Each parquet sub-chunk file is complete after write (no appending), so
+        we upload it to the object store immediately. The base class post-loop
+        upload only handles the last file and would miss intermediate sub-chunks.
+        See HYP-773.
         """
         await super()._flush_buffer(chunk, chunk_part)
+        # Upload the completed parquet file to object store.
+        output_file_name = f"{self.path}/{path_gen(self.chunk_count, chunk_part, extension=self.extension)}"
+        if os.path.exists(output_file_name):
+            try:
+                await self._upload_file(output_file_name)
+            except RuntimeError:
+                # No object store configured (local dev) — file stays on disk.
+                pass
         # Advance part so the next sub-chunk gets a unique filename.
-        # JSON's _write_chunk uses append mode ("a") so it can safely reuse
-        # the same file; Parquet's pq.write_table always overwrites.
         self.chunk_part += 1
 
     async def _write_chunk(self, chunk: "pd.DataFrame", file_name: str):

--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -871,7 +871,7 @@ class ParquetFileWriter(Writer):
                 await self._upload_file(output_file_name)
             except RuntimeError:
                 # No object store configured (local dev) — file stays on disk.
-                pass
+                logger.debug("No object store configured, skipping upload")
         # Advance part so the next sub-chunk gets a unique filename.
         self.chunk_part += 1
 

--- a/tests/unit/storage/formats/test_writer_data_integrity.py
+++ b/tests/unit/storage/formats/test_writer_data_integrity.py
@@ -13,6 +13,7 @@ Run with:
     uv run pytest tests/unit/storage/formats/test_writer_data_integrity.py -v -s
 """
 
+import glob
 import json
 import os
 import shutil
@@ -289,8 +290,6 @@ class TestParquetWriterDataIntegrity:
         self, temp_dir: str, row_count: int, num_writes: int = 1
     ) -> dict:
         """Run a write scenario and return disk + upload results."""
-        import glob
-
         from application_sdk.storage.formats.parquet import ParquetFileWriter
 
         upload_calls: List[tuple] = []
@@ -369,37 +368,31 @@ class TestParquetWriterDataIntegrity:
 
     # --- Single write() scenarios ---
 
-    @pytest.mark.asyncio
     async def test_single_row(self, temp_dir: str):
         """1 row: minimal case, well under buffer_size."""
         r = await self._run_write_scenario(temp_dir, row_count=1)
         self._assert_no_data_loss(r, 1)
 
-    @pytest.mark.asyncio
     async def test_rows_less_than_buffer_size(self, temp_dir: str):
         """30 rows < buffer_size=50: single sub-chunk, no splitting."""
         r = await self._run_write_scenario(temp_dir, row_count=30)
         self._assert_no_data_loss(r, 30)
 
-    @pytest.mark.asyncio
     async def test_rows_equal_to_buffer_size(self, temp_dir: str):
         """50 rows == buffer_size=50: exactly one sub-chunk, boundary."""
         r = await self._run_write_scenario(temp_dir, row_count=50)
         self._assert_no_data_loss(r, 50)
 
-    @pytest.mark.asyncio
     async def test_rows_just_over_buffer_size(self, temp_dir: str):
         """51 rows: 2 sub-chunks (50+1). First overwrite scenario."""
         r = await self._run_write_scenario(temp_dir, row_count=51)
         self._assert_no_data_loss(r, 51)
 
-    @pytest.mark.asyncio
     async def test_rows_double_buffer_size(self, temp_dir: str):
         """100 rows == 2x buffer_size: exactly 2 sub-chunks (50+50)."""
         r = await self._run_write_scenario(temp_dir, row_count=100)
         self._assert_no_data_loss(r, 100)
 
-    @pytest.mark.asyncio
     async def test_rows_exceeding_buffer_size(self, temp_dir: str):
         """120 rows: 3 sub-chunks (50+50+20). Core HYP-773 regression case.
 
@@ -409,7 +402,6 @@ class TestParquetWriterDataIntegrity:
         r = await self._run_write_scenario(temp_dir, row_count=120)
         self._assert_no_data_loss(r, 120)
 
-    @pytest.mark.asyncio
     async def test_rows_many_sub_chunks(self, temp_dir: str):
         """501 rows: 11 sub-chunks (10x50 + 1). Stress test for part numbering."""
         r = await self._run_write_scenario(temp_dir, row_count=501)
@@ -417,13 +409,11 @@ class TestParquetWriterDataIntegrity:
 
     # --- Multiple write() scenarios ---
 
-    @pytest.mark.asyncio
     async def test_multiple_small_writes(self, temp_dir: str):
         """5 writes of 30 rows each: all under buffer_size, tests chunk_count."""
         r = await self._run_write_scenario(temp_dir, row_count=150, num_writes=5)
         self._assert_no_data_loss(r, 150)
 
-    @pytest.mark.asyncio
     async def test_multiple_writes_each_exceeding_buffer_size(self, temp_dir: str):
         """3 writes of 200 rows each: tests correctness across write() calls.
 
@@ -433,7 +423,6 @@ class TestParquetWriterDataIntegrity:
         r = await self._run_write_scenario(temp_dir, row_count=600, num_writes=3)
         self._assert_no_data_loss(r, 600)
 
-    @pytest.mark.asyncio
     async def test_multiple_writes_mixed_sizes(self, temp_dir: str):
         """4 writes of 75 rows each: 2 sub-chunks per write (50+25).
 

--- a/tests/unit/storage/formats/test_writer_data_integrity.py
+++ b/tests/unit/storage/formats/test_writer_data_integrity.py
@@ -266,13 +266,18 @@ class TestWriterDataIntegrity:
 
 
 class TestParquetWriterDataIntegrity:
-    """Verify ParquetFileWriter preserves all data when DataFrames exceed buffer_size.
+    """Verify ParquetFileWriter preserves all data on disk AND in object store.
 
     Parquet's pq.write_table() overwrites the target file (unlike JSON which
-    appends). Without incrementing chunk_part after each _flush_buffer call,
-    _write_dataframe's buffer loop writes every sub-chunk to the same filename,
-    silently losing all data except the last sub-chunk. See HYP-773.
+    appends). The _flush_buffer override in ParquetFileWriter ensures each
+    sub-chunk gets a unique filename and is uploaded immediately. See HYP-773.
+
+    All tests use buffer_size=50 and verify:
+    - Disk: all rows readable from local parquet files
+    - Upload: all rows sent to object store via _upload_file
     """
+
+    BUFFER_SIZE = 50
 
     @pytest.fixture
     def temp_dir(self):
@@ -280,93 +285,160 @@ class TestParquetWriterDataIntegrity:
         yield temp_path
         shutil.rmtree(temp_path, ignore_errors=True)
 
-    @pytest.mark.asyncio
-    async def test_single_write_exceeding_buffer_size(self, temp_dir: str):
-        """A single write() with rows > buffer_size must preserve all rows.
+    async def _run_write_scenario(
+        self, temp_dir: str, row_count: int, num_writes: int = 1
+    ) -> dict:
+        """Run a write scenario and return disk + upload results."""
+        import glob
 
-        This is the core HYP-773 regression test. With buffer_size=50 and
-        120 rows, the writer creates 3 sub-chunks (50+50+20). Before the
-        fix, all three wrote to chunk-0-part0.parquet and only the last
-        20 rows survived.
-        """
         from application_sdk.storage.formats.parquet import ParquetFileWriter
+
+        upload_calls: List[tuple] = []
+
+        async def mock_upload(source: str, destination: str = "", **kwargs):
+            if os.path.exists(source):
+                with open(source, "rb") as f:
+                    upload_calls.append((source, f.read()))
 
         with patch(
             "application_sdk.storage.formats._upload_file",
             new_callable=AsyncMock,
+            side_effect=mock_upload,
         ):
             writer = ParquetFileWriter(
                 path=temp_dir,
                 typename="test_entity",
-                buffer_size=50,
+                buffer_size=self.BUFFER_SIZE,
                 use_consolidation=False,
             )
 
-            df = pd.DataFrame(
-                {"id": list(range(120)), "value": [f"row_{i}" for i in range(120)]}
-            )
-            await writer.write(df)
-            await writer.close()
-
-            # Read back all parquet files written to disk
-            import glob
-
-            parquet_files = glob.glob(
-                os.path.join(temp_dir, "test_entity", "**", "*.parquet"),
-                recursive=True,
-            )
-            assert len(parquet_files) > 0, "No parquet files written"
-
-            result_df = pd.concat(
-                [pd.read_parquet(f) for f in parquet_files], ignore_index=True
-            )
-            assert len(result_df) == 120, (
-                f"Expected 120 rows, got {len(result_df)}. "
-                f"Data loss: {120 - len(result_df)} rows missing."
-            )
-            assert set(result_df["id"]) == set(range(120))
-
-    @pytest.mark.asyncio
-    async def test_multiple_writes_exceeding_buffer_size(self, temp_dir: str):
-        """Multiple write() calls, each exceeding buffer_size, must preserve all rows."""
-        from application_sdk.storage.formats.parquet import ParquetFileWriter
-
-        with patch(
-            "application_sdk.storage.formats._upload_file",
-            new_callable=AsyncMock,
-        ):
-            writer = ParquetFileWriter(
-                path=temp_dir,
-                typename="test_entity",
-                buffer_size=50,
-                use_consolidation=False,
-            )
-
-            total_records = 0
-            for batch_idx in range(3):
-                start = batch_idx * 200
-                df = pd.DataFrame(
-                    {
-                        "id": list(range(start, start + 200)),
-                        "batch": [f"batch_{batch_idx}"] * 200,
-                    }
-                )
+            rows_per_write = row_count // num_writes
+            total = 0
+            for batch_idx in range(num_writes):
+                start = batch_idx * rows_per_write
+                df = pd.DataFrame({"id": list(range(start, start + rows_per_write))})
                 await writer.write(df)
-                total_records += 200
+                total += rows_per_write
 
             await writer.close()
 
-            import glob
-
-            parquet_files = glob.glob(
-                os.path.join(temp_dir, "test_entity", "**", "*.parquet"),
-                recursive=True,
-            )
-            result_df = pd.concat(
+        # Disk: read back all parquet files
+        parquet_files = glob.glob(
+            os.path.join(temp_dir, "test_entity", "**", "*.parquet"),
+            recursive=True,
+        )
+        if parquet_files:
+            disk_df = pd.concat(
                 [pd.read_parquet(f) for f in parquet_files], ignore_index=True
             )
-            assert len(result_df) == total_records, (
-                f"Expected {total_records} rows, got {len(result_df)}. "
-                f"Data loss: {total_records - len(result_df)} rows missing."
-            )
-            assert set(result_df["id"]) == set(range(total_records))
+        else:
+            disk_df = pd.DataFrame()
+
+        # Upload: reconstruct rows from captured upload content
+        upload_rows = 0
+        upload_ids: Set[int] = set()
+        for source, content in upload_calls:
+            if not source.endswith(".parquet") or "statistics" in source:
+                continue
+            tmp = os.path.join(temp_dir, "_up_" + os.path.basename(source))
+            with open(tmp, "wb") as f:
+                f.write(content)
+            chunk_df = pd.read_parquet(tmp)
+            upload_rows += len(chunk_df)
+            upload_ids.update(chunk_df["id"].tolist())
+
+        return {
+            "disk_rows": len(disk_df),
+            "disk_ids": set(disk_df["id"].tolist()) if len(disk_df) > 0 else set(),
+            "upload_rows": upload_rows,
+            "upload_ids": upload_ids,
+            "expected": total,
+        }
+
+    def _assert_no_data_loss(self, r: dict, expected: int) -> None:
+        """Assert zero data loss on both disk and object store."""
+        expected_ids = set(range(expected))
+        assert (
+            r["disk_rows"] == expected
+        ), f"Disk data loss: {r['disk_rows']}/{expected} rows"
+        assert r["disk_ids"] == expected_ids, "Disk: missing IDs detected"
+        assert (
+            r["upload_rows"] == expected
+        ), f"Upload data loss: {r['upload_rows']}/{expected} rows"
+        assert r["upload_ids"] == expected_ids, "Upload: missing IDs detected"
+
+    # --- Single write() scenarios ---
+
+    @pytest.mark.asyncio
+    async def test_single_row(self, temp_dir: str):
+        """1 row: minimal case, well under buffer_size."""
+        r = await self._run_write_scenario(temp_dir, row_count=1)
+        self._assert_no_data_loss(r, 1)
+
+    @pytest.mark.asyncio
+    async def test_rows_less_than_buffer_size(self, temp_dir: str):
+        """30 rows < buffer_size=50: single sub-chunk, no splitting."""
+        r = await self._run_write_scenario(temp_dir, row_count=30)
+        self._assert_no_data_loss(r, 30)
+
+    @pytest.mark.asyncio
+    async def test_rows_equal_to_buffer_size(self, temp_dir: str):
+        """50 rows == buffer_size=50: exactly one sub-chunk, boundary."""
+        r = await self._run_write_scenario(temp_dir, row_count=50)
+        self._assert_no_data_loss(r, 50)
+
+    @pytest.mark.asyncio
+    async def test_rows_just_over_buffer_size(self, temp_dir: str):
+        """51 rows: 2 sub-chunks (50+1). First overwrite scenario."""
+        r = await self._run_write_scenario(temp_dir, row_count=51)
+        self._assert_no_data_loss(r, 51)
+
+    @pytest.mark.asyncio
+    async def test_rows_double_buffer_size(self, temp_dir: str):
+        """100 rows == 2x buffer_size: exactly 2 sub-chunks (50+50)."""
+        r = await self._run_write_scenario(temp_dir, row_count=100)
+        self._assert_no_data_loss(r, 100)
+
+    @pytest.mark.asyncio
+    async def test_rows_exceeding_buffer_size(self, temp_dir: str):
+        """120 rows: 3 sub-chunks (50+50+20). Core HYP-773 regression case.
+
+        Before the fix, all three sub-chunks wrote to chunk-0-part0.parquet
+        and only the last 20 rows survived (83% data loss).
+        """
+        r = await self._run_write_scenario(temp_dir, row_count=120)
+        self._assert_no_data_loss(r, 120)
+
+    @pytest.mark.asyncio
+    async def test_rows_many_sub_chunks(self, temp_dir: str):
+        """501 rows: 11 sub-chunks (10x50 + 1). Stress test for part numbering."""
+        r = await self._run_write_scenario(temp_dir, row_count=501)
+        self._assert_no_data_loss(r, 501)
+
+    # --- Multiple write() scenarios ---
+
+    @pytest.mark.asyncio
+    async def test_multiple_small_writes(self, temp_dir: str):
+        """5 writes of 30 rows each: all under buffer_size, tests chunk_count."""
+        r = await self._run_write_scenario(temp_dir, row_count=150, num_writes=5)
+        self._assert_no_data_loss(r, 150)
+
+    @pytest.mark.asyncio
+    async def test_multiple_writes_each_exceeding_buffer_size(self, temp_dir: str):
+        """3 writes of 200 rows each: tests correctness across write() calls.
+
+        Each write() produces 4 sub-chunks (50+50+50+50). Verifies data is
+        preserved both within each write() and across write() calls.
+        """
+        r = await self._run_write_scenario(temp_dir, row_count=600, num_writes=3)
+        self._assert_no_data_loss(r, 600)
+
+    @pytest.mark.asyncio
+    async def test_multiple_writes_mixed_sizes(self, temp_dir: str):
+        """4 writes of 75 rows each: 2 sub-chunks per write (50+25).
+
+        Tests that chunk_count advances correctly across write() calls
+        when each write produces a partial last sub-chunk.
+        """
+        r = await self._run_write_scenario(temp_dir, row_count=300, num_writes=4)
+        self._assert_no_data_loss(r, 300)

--- a/tests/unit/storage/formats/test_writer_data_integrity.py
+++ b/tests/unit/storage/formats/test_writer_data_integrity.py
@@ -1,20 +1,16 @@
 """
-Writer Data Integrity Tests - Prevents data loss regression in JsonFileWriter.
+Writer Data Integrity Tests - Prevents data loss regression in file writers.
 
-This test suite verifies that both pandas and daft writers maintain data integrity
-when multiple write() calls are made. It specifically guards against a bug where
-the daft writer would lose data due to:
-1. Not uploading files at the end of each write() call
-2. Not incrementing chunk_count after each write() call
-3. File name collisions causing overwrites in object store
+This test suite verifies that writers maintain data integrity when multiple
+write() calls are made and when DataFrames exceed buffer_size.
 
-The bug manifested when using retain_local_copy=False (production default):
-- Write 1: uploads chunk-0-part0.json with records 0-99
-- Write 2: resets chunk_part, creates NEW chunk-0-part0.json with records 100-199
-- Result: records 0-99 are overwritten and lost
+Guards against two classes of bugs:
+1. JSON/daft writer: file name collisions across write() calls (fixed earlier)
+2. Parquet writer: pq.write_table() overwrites within a single write() call
+   when DataFrame exceeds buffer_size, since parquet cannot append (HYP-773)
 
 Run with:
-    uv run pytest tests/unit/io/test_writer_data_integrity.py -v -s
+    uv run pytest tests/unit/storage/formats/test_writer_data_integrity.py -v -s
 """
 
 import json
@@ -267,3 +263,110 @@ class TestWriterDataIntegrity:
             duplicates = {f: c for f, c in counts.items() if c > 1}
 
             assert not duplicates, f"Duplicate file uploads detected: {duplicates}"
+
+
+class TestParquetWriterDataIntegrity:
+    """Verify ParquetFileWriter preserves all data when DataFrames exceed buffer_size.
+
+    Parquet's pq.write_table() overwrites the target file (unlike JSON which
+    appends). Without incrementing chunk_part after each _flush_buffer call,
+    _write_dataframe's buffer loop writes every sub-chunk to the same filename,
+    silently losing all data except the last sub-chunk. See HYP-773.
+    """
+
+    @pytest.fixture
+    def temp_dir(self):
+        temp_path = tempfile.mkdtemp(prefix="parquet_integrity_")
+        yield temp_path
+        shutil.rmtree(temp_path, ignore_errors=True)
+
+    @pytest.mark.asyncio
+    async def test_single_write_exceeding_buffer_size(self, temp_dir: str):
+        """A single write() with rows > buffer_size must preserve all rows.
+
+        This is the core HYP-773 regression test. With buffer_size=50 and
+        120 rows, the writer creates 3 sub-chunks (50+50+20). Before the
+        fix, all three wrote to chunk-0-part0.parquet and only the last
+        20 rows survived.
+        """
+        from application_sdk.storage.formats.parquet import ParquetFileWriter
+
+        with patch(
+            "application_sdk.storage.formats._upload_file",
+            new_callable=AsyncMock,
+        ):
+            writer = ParquetFileWriter(
+                path=temp_dir,
+                typename="test_entity",
+                buffer_size=50,
+                use_consolidation=False,
+            )
+
+            df = pd.DataFrame(
+                {"id": list(range(120)), "value": [f"row_{i}" for i in range(120)]}
+            )
+            await writer.write(df)
+            await writer.close()
+
+            # Read back all parquet files written to disk
+            import glob
+
+            parquet_files = glob.glob(
+                os.path.join(temp_dir, "test_entity", "**", "*.parquet"),
+                recursive=True,
+            )
+            assert len(parquet_files) > 0, "No parquet files written"
+
+            result_df = pd.concat(
+                [pd.read_parquet(f) for f in parquet_files], ignore_index=True
+            )
+            assert len(result_df) == 120, (
+                f"Expected 120 rows, got {len(result_df)}. "
+                f"Data loss: {120 - len(result_df)} rows missing."
+            )
+            assert set(result_df["id"]) == set(range(120))
+
+    @pytest.mark.asyncio
+    async def test_multiple_writes_exceeding_buffer_size(self, temp_dir: str):
+        """Multiple write() calls, each exceeding buffer_size, must preserve all rows."""
+        from application_sdk.storage.formats.parquet import ParquetFileWriter
+
+        with patch(
+            "application_sdk.storage.formats._upload_file",
+            new_callable=AsyncMock,
+        ):
+            writer = ParquetFileWriter(
+                path=temp_dir,
+                typename="test_entity",
+                buffer_size=50,
+                use_consolidation=False,
+            )
+
+            total_records = 0
+            for batch_idx in range(3):
+                start = batch_idx * 200
+                df = pd.DataFrame(
+                    {
+                        "id": list(range(start, start + 200)),
+                        "batch": [f"batch_{batch_idx}"] * 200,
+                    }
+                )
+                await writer.write(df)
+                total_records += 200
+
+            await writer.close()
+
+            import glob
+
+            parquet_files = glob.glob(
+                os.path.join(temp_dir, "test_entity", "**", "*.parquet"),
+                recursive=True,
+            )
+            result_df = pd.concat(
+                [pd.read_parquet(f) for f in parquet_files], ignore_index=True
+            )
+            assert len(result_df) == total_records, (
+                f"Expected {total_records} rows, got {len(result_df)}. "
+                f"Data loss: {total_records - len(result_df)} rows missing."
+            )
+            assert set(result_df["id"]) == set(range(total_records))


### PR DESCRIPTION
## Summary

`ParquetFileWriter` inherits `_write_dataframe` from the base `Writer`, which splits DataFrames into `buffer_size` (5000) row sub-chunks. Each sub-chunk is flushed via `_flush_buffer` -> `_write_chunk` -> `pq.write_table()`. Unlike JSON's `_write_chunk` (which uses `open("a")` to append), `pq.write_table()` **overwrites** the file. Since `chunk_part` only increments when a byte-size threshold is exceeded (rarely hit due to `compression_factor=0.01`), all sub-chunks write to the same filename and only the last one survives.

Additionally, the base class post-loop upload only handles the last file per `write()` call — intermediate sub-chunk files were never uploaded to the object store.

## Impact observed

While migrating the Teradata connector to SDK v3 (HYP-310):

- **tables**: 11,148 extracted -> 1,148 transformed (90% data loss)
- **columns**: 124,077 extracted -> 8,154 transformed (93% data loss)

## Fix

Override `_flush_buffer` in `ParquetFileWriter` to:
1. Write the sub-chunk to disk (via `super()`)
2. Upload the completed file to object store immediately (parquet files are complete after write, unlike JSON which appends)
3. Increment `chunk_part` for the next sub-chunk

The upload is wrapped in `try/except RuntimeError` with a `logger.debug` message for local dev where no object store is configured — the file stays on disk.

## Tests

10 parquet boundary scenarios in `TestParquetWriterDataIntegrity`, each asserting zero data loss on **both disk and object store upload**:

- 1 row (minimal), 30 rows (< buffer), 50 rows (= buffer), 51 rows (buffer+1)
- 100 rows (2x buffer), 120 rows (core HYP-773 case), 501 rows (11 sub-chunks)
- 5x30 (multi-write small), 3x200 (multi-write large), 4x75 (multi-write mixed)

## Verification

- All 53 tests pass (4 JSON integrity + 10 parquet integrity + 39 parquet writer)
- All pre-commit hooks pass (ruff, ruff-format, isort, pyright)
- End-to-end with Teradata connector: 135,395 extracted = 135,395 transformed

Closes HYP-773