### PR TITLE
fix(ci): export CREATED_BY so Python subprocess can read it

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -358,7 +358,7 @@ jobs:
 
           # Resolve triggering actor to email; fall back to GitHub username
           GH_EMAIL=$(gh api "users/${GITHUB_ACTOR}" --jq '.email // empty' 2>/dev/null || true)
-          CREATED_BY="${GH_EMAIL:-${GITHUB_ACTOR}}"
+          export CREATED_BY="${GH_EMAIL:-${GITHUB_ACTOR}}"
 
           # Build JSON payload matching the CLI's registerInMarketplace format
           BODY=$(python3 - <<'PYEOF'


### PR DESCRIPTION
## Summary

One-line fix: `export CREATED_BY` instead of plain assignment.

## Bug

`CREATED_BY` was set as a shell-local variable. Child processes (`python3`) don't inherit unexported bash variables, so `os.environ.get('CREATED_BY')` always returned empty string — `created_by` was never added to the publish payload. Heracles received no `created_by`, fell back to Keycloak-resolved API key owner email (whoever created `APP_PUBLISH_TOKEN`), and sent that to GM instead of the actual triggering actor.

## Fix

```bash
export CREATED_BY="${GH_EMAIL:-${GITHUB_ACTOR}}"
```