### PR TITLE
fix(security): allowlist CVE-2026-4786 and CVE-2026-6100 (python-3.11-base)

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -56,6 +56,20 @@
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
+  "CVE-2026-4786": {
+    "package": "python-3.11-base",
+    "severity": "HIGH",
+    "reason": "Base image — Python 3.11 runtime (python-3.11-base@3.11.15-r1). Fixed in 3.11.15-r2 upstream; awaiting Wolfi rebuild of app-runtime-base.",
+    "expires": "2026-05-24",
+    "added_by": "hritika-atlan"
+  },
+  "CVE-2026-6100": {
+    "package": "python-3.11-base",
+    "severity": "HIGH",
+    "reason": "Base image — Python 3.11 runtime (python-3.11-base@3.11.15-r1). Fixed in 3.11.15-r2 upstream; awaiting Wolfi rebuild of app-runtime-base.",
+    "expires": "2026-05-24",
+    "added_by": "hritika-atlan"
+  },
   "CVE-2026-31812": {
     "package": "quinn-proto",
     "severity": "HIGH",


### PR DESCRIPTION
## Summary

Adds 2 HIGH-severity CVEs to `.security/base-allowlist.json` for `python-3.11-base@3.11.15-r1` — the Wolfi APK that ships the Python 3.11 interpreter in the `app-runtime-base` image.

| CVE | Package | Installed | Fix | Severity |
|---|---|---|---|---|
| [CVE-2026-4786](https://nvd.nist.gov/vuln/detail/CVE-2026-4786) | `python-3.11-base` | 3.11.15-r1 | 3.11.15-r2 | HIGH |
| [CVE-2026-6100](https://nvd.nist.gov/vuln/detail/CVE-2026-6100) | `python-3.11-base` | 3.11.15-r1 | 3.11.15-r2 | HIGH |

## Why allowlist instead of upgrade

The fix (`3.11.15-r2`) exists upstream but the Wolfi APK in the `app-runtime-base` image hasn't rebuilt yet. Pinned repos in the base image mean we can't `apk upgrade` directly from connector Dockerfiles. Follows the exact precedent set for `CVE-2026-4519` (python-3.10-base) already in this file.

## Runtime risk

`python-3.11-base` provides the system Python interpreter. SDK-based connector apps install all runtime deps into an isolated `uv` venv at `/app/.venv`; the system interpreter is only used by the entrypoint and Dapr glue, not on the request path processing user input.

## Expiry

30 days (`2026-05-24`) per `_expiry_policy.HIGH`. Validator passes locally:

```
✅ Allowlist valid: 33 entries, all within policy (CRITICAL ≤ 15d, HIGH ≤ 30d)
```

## Impact

Unblocks the Security Gate on connector repos pulling `app-runtime-base` — currently blocking [atlanhq/atlan-athena-app#44](https://github.com/atlanhq/atlan-athena-app/pull/44).

## Follow-up

Revisit before `2026-05-24`. If Wolfi has published `python-3.11-base@3.11.15-r2` by then, bump the base image and drop these entries. Otherwise renew with an updated Wolfi status.

## Test plan

- [x] `python3 .github/scripts/validate_allowlist.py` — passes
- [x] `python3 -c "import json; json.load(open('.security/base-allowlist.json'))"` — valid JSON
- [ ] Security Gate re-runs on `atlan-athena-app#44` after merge and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)