### PR TITLE
fix(credentials): normalize agent-wire kebab-case keys to camelCase

### DIFF
--- a/application_sdk/credentials/agent.py
+++ b/application_sdk/credentials/agent.py
@@ -114,7 +114,8 @@ async def resolve_agent_credential(
     bundle = await _fetch_bundle(secret_store, spec.secret_path)
     resolved_flat = _substitute(raw, bundle)
     expanded = _expand_dotted(resolved_flat)
-    return _flatten_auth_section(expanded)
+    result = _flatten_auth_section(expanded)
+    return _normalize_keys(result)
 
 
 # Keep backward-compatible alias for existing callers and tests
@@ -260,6 +261,41 @@ def _expand_dotted(flat: dict[str, Any]) -> dict[str, Any]:
             cursor[parts[-1]] = value
 
     return out
+
+
+def _kebab_to_camel(key: str) -> str:
+    """Convert a kebab-case key to camelCase.
+
+    ``"auth-type"`` → ``"authType"``, ``"agent-name"`` → ``"agentName"``.
+    Keys without hyphens are returned unchanged.
+    """
+    parts = key.split("-")
+    return parts[0] + "".join(p.capitalize() for p in parts[1:])
+
+
+def _normalize_keys(creds: dict[str, Any]) -> dict[str, Any]:
+    """Convert all hyphenated root-level keys to camelCase.
+
+    The agent wire format uses kebab-case (``auth-type``, ``key-type``,
+    ``agent-name``).  ``DaprCredentialVault.get_credentials()`` (direct
+    flow) returns camelCase (``authType``).  Connectors are written
+    against the direct-flow format.
+
+    This normalization ensures both resolution paths produce the same
+    key format so downstream consumers don't need dual-key lookups.
+    """
+    normalized: dict[str, Any] = {}
+    for key, value in creds.items():
+        if "-" in key:
+            camel_key = _kebab_to_camel(key)
+            # Only rename if the camelCase key doesn't already exist
+            if camel_key not in creds:
+                normalized[camel_key] = value
+            else:
+                normalized[key] = value
+        else:
+            normalized[key] = value
+    return normalized
 
 
 def _flatten_auth_section(creds: dict[str, Any]) -> dict[str, Any]:

--- a/tests/unit/credentials/test_agent.py
+++ b/tests/unit/credentials/test_agent.py
@@ -160,11 +160,11 @@ class TestResolveAgentJsonHappyPath:
 
         resolved = await resolve_agent_json(CLOUDSQL_POSTGRES_AGENT_JSON, store)
 
-        # Literal fields are preserved as-is.
+        # Literal fields preserved; hyphenated keys normalized to camelCase.
         assert resolved["host"] == "34.122.182.89"
         assert resolved["port"] == 5432
-        assert resolved["auth-type"] == "basic"
-        assert resolved["aws-region"] == "ap-south-1"
+        assert resolved["authType"] == "basic"
+        assert resolved["awsRegion"] == "ap-south-1"
 
         # Ref-keys substituted and collapsed into nested dicts.
         assert resolved["basic"] == {
@@ -239,7 +239,7 @@ class TestResolveAgentJsonHappyPath:
         resolved = await resolve_agent_json(agent_json, store)
 
         assert resolved["host"] == "literal.example.com"
-        assert resolved["aws-region"] == "ap-south-1"
+        assert resolved["awsRegion"] == "ap-south-1"
         assert resolved["basic"] == {"username": "real_user"}
 
     async def test_missing_ref_key_stays_as_ref(self) -> None:


### PR DESCRIPTION
## Bug: Agent credential resolution produces `auth-type` instead of `authType`

### What broke
The SDK's two credential resolution paths produce different key formats for the same logical field:
- **Direct flow** (`DaprCredentialVault.get_credentials(guid)`) → `authType` (camelCase)
- **Agent flow** (`resolve_agent_credential()`) → `auth-type` (hyphenated)

Connectors use `credentials.get("authType")` to select auth strategy. In agent mode this key is missing → defaults to `"basic"` → wrong strategy → crash.

### Reproduction
1. Deploy any v3 connector in SDR/agent mode with non-basic auth (e.g. WIF, IAM)
2. Trigger a workflow — agent credential resolution produces `auth-type` key
3. Connector's `credentials.get("authType", "basic")` misses it → `BasicAuthStrategy` selected → crash

Verified on SDR pod by exec'ing in and running `resolve_agent_credential()` with real payload:
```
Has authType? False
Has auth-type? True
auth-type value: workload_identity_federation
```

### Root cause
`AgentCredentialSpec.to_raw_dict()` uses `model_dump(by_alias=True)`. The field is `auth_type: str = Field(alias="auth-type")` — so output uses the wire-format hyphenated key. This flows through `_expand_dotted()` and `_flatten_auth_section()` unchanged.

### Fix
Generic `_normalize_keys()` post-processing step that converts ALL hyphenated root-level keys to camelCase (`auth-type` → `authType`, `aws-region` → `awsRegion`, etc.). No hardcoded mapping. Applied at the end of `resolve_agent_credential()` so both resolution paths produce consistent output.

Same pattern as the toolkit fix for BLDX-1091 — normalize at the source, not in each connector.

### Discovered during
AlloyDB Postgres v3 SDR deployment — WIF auth failing because `BasicAuthStrategy` was selected instead of `IAMUserAuthStrategy`.

Temporal workflow: https://apps-typedef.atlan.com/api/temporal/namespaces/default/workflows/d8777361-694f-400d-90c5-54f9af47567a-extract/019dbe7a-be7c-7ae5-99b6-39507de9cd41/history

Related thread: https://atlanhq.slack.com/archives/C0AHHBDBP9Q/p1776759020122989

🤖 Generated with [Claude Code](https://claude.com/claude-code)