### PR TITLE
fix: lift AE metadata fields in ExtractionInput

### DIFF
--- a/application_sdk/templates/contracts/sql_metadata.py
+++ b/application_sdk/templates/contracts/sql_metadata.py
@@ -99,6 +99,51 @@ class ExtractionInput(Input, allow_unbounded_fields=True):
                 data = {**data, "agent_json": None}
         return data
 
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_ae_payload(cls, data: Any) -> Any:
+        """Lift fields from AE's ``metadata{}`` wrapper to model fields.
+
+        AE app manifests put extraction config under ``args.metadata`` while
+        this SDK contract exposes those fields at the top level. Normalize both
+        snake_case and kebab-case keys to the model's snake_case field names so
+        Pydantic can bind them. Explicit top-level values take priority.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        field_names = set(cls.model_fields)
+        normalized = dict(data)
+        updates: dict[str, Any] = {}
+
+        metadata = data.get("metadata")
+        metadata_has_unknown_keys = False
+        if isinstance(metadata, dict):
+            for key, value in metadata.items():
+                underscore_key = key.replace("-", "_")
+                if underscore_key not in field_names:
+                    metadata_has_unknown_keys = True
+                    continue
+                if underscore_key not in normalized:
+                    updates[underscore_key] = value
+
+            if not metadata_has_unknown_keys:
+                normalized.pop("metadata", None)
+
+        for key, value in data.items():
+            if "-" not in key:
+                continue
+            underscore_key = key.replace("-", "_")
+            if underscore_key not in field_names:
+                continue
+            if underscore_key not in normalized:
+                updates[underscore_key] = value
+            normalized.pop(key, None)
+
+        if updates:
+            normalized.update(updates)
+        return normalized
+
     output_prefix: str = ""
     """Object store prefix for all output artifacts."""
 

--- a/tests/unit/templates/test_extraction_input_filters.py
+++ b/tests/unit/templates/test_extraction_input_filters.py
@@ -4,8 +4,11 @@ Filters accept dict (structured from AE), JSON string, raw regex string,
 list, and None. SQL injection is guarded by rejecting single quotes.
 """
 
+import logging
+
 import pytest
 
+from application_sdk.contracts.base import Input
 from application_sdk.templates.contracts.sql_metadata import (
     ExtractionInput,
     ExtractionTaskInput,
@@ -130,3 +133,145 @@ class TestRealAEPayload:
         result = ExtractionInput.model_validate(payload)
         assert isinstance(result.include_filter, str)
         assert isinstance(result.exclude_filter, str)
+
+
+class TestAENestedMetadataLift:
+    """AE wraps extraction config under ``metadata``; SDK must lift it."""
+
+    def test_dict_filters_nested_in_metadata_are_lifted(self):
+        payload = {
+            "connection": {
+                "typeName": "Connection",
+                "attributes": {"qualifiedName": "default/x/1", "name": "n"},
+            },
+            "credential_guid": "g",
+            "metadata": {
+                "include_filter": {"^prod$": ["^analytics$"]},
+                "exclude_filter": {"^temp$": [".*"]},
+                "extraction_method": "direct",
+            },
+        }
+
+        result = ExtractionInput.model_validate(payload)
+
+        assert result.include_filter == {"^prod$": ["^analytics$"]}
+        assert result.exclude_filter == {"^temp$": [".*"]}
+        assert result.extraction_method == "direct"
+
+    def test_top_level_value_wins_over_nested(self):
+        payload = {
+            "connection": {
+                "typeName": "Connection",
+                "attributes": {"qualifiedName": "default/x/1", "name": "n"},
+            },
+            "credential_guid": "g",
+            "extraction_method": "agent",
+            "metadata": {"extraction_method": "direct"},
+        }
+
+        assert ExtractionInput.model_validate(payload).extraction_method == "agent"
+
+    def test_hyphenated_keys_in_metadata_are_normalised(self):
+        payload = {
+            "connection": {
+                "typeName": "Connection",
+                "attributes": {"qualifiedName": "default/x/1", "name": "n"},
+            },
+            "credential_guid": "g",
+            "metadata": {
+                "include-filter": {"^prod$": ["^a$"]},
+                "extraction-method": "direct",
+            },
+        }
+
+        result = ExtractionInput.model_validate(payload)
+
+        assert result.include_filter == {"^prod$": ["^a$"]}
+        assert result.extraction_method == "direct"
+
+    def test_top_level_hyphenated_keys_are_normalised(self):
+        payload = {
+            "credential-guid": "g",
+            "include-filter": {"^prod$": ["^a$"]},
+            "extraction-method": "direct",
+        }
+
+        result = ExtractionInput.model_validate(payload)
+
+        assert result.credential_guid == "g"
+        assert result.include_filter == {"^prod$": ["^a$"]}
+        assert result.extraction_method == "direct"
+
+    def test_string_filters_in_metadata_still_work(self):
+        payload = {
+            "connection": {
+                "typeName": "Connection",
+                "attributes": {"qualifiedName": "default/x/1", "name": "n"},
+            },
+            "credential_guid": "g",
+            "metadata": {"include_filter": "^prod_.*$"},
+        }
+
+        assert ExtractionInput.model_validate(payload).include_filter == "^prod_.*$"
+
+    def test_empty_metadata_does_not_overwrite_defaults(self):
+        payload = {
+            "connection": {
+                "typeName": "Connection",
+                "attributes": {"qualifiedName": "default/x/1", "name": "n"},
+            },
+            "credential_guid": "g",
+            "metadata": {},
+        }
+
+        result = ExtractionInput.model_validate(payload)
+
+        assert result.include_filter == ""
+        assert result.exclude_filter == ""
+
+    def test_nested_direct_agent_json_is_skipped_after_lift(self):
+        payload = {
+            "credential_guid": "g",
+            "metadata": {
+                "extraction_method": "direct",
+                "agent_json": '{"host": "host", "port": "port"}',
+            },
+        }
+
+        result = ExtractionInput.model_validate(payload)
+
+        assert result.extraction_method == "direct"
+        assert result.agent_json is None
+
+    def test_known_metadata_wrapper_does_not_warn(self, caplog):
+        Input._unknown_keys_seen.clear()
+        caplog.set_level(logging.WARNING, logger="application_sdk.contracts.base")
+
+        ExtractionInput.model_validate(
+            {
+                "metadata": {
+                    "include_filter": {"^prod$": ["^analytics$"]},
+                    "exclude_filter": {"^temp$": [".*"]},
+                    "extraction_method": "direct",
+                }
+            }
+        )
+
+        assert "Unknown keys in payload for ExtractionInput" not in caplog.text
+
+    def test_unknown_metadata_key_still_warns(self, caplog):
+        Input._unknown_keys_seen.clear()
+        caplog.set_level(logging.WARNING, logger="application_sdk.contracts.base")
+
+        result = ExtractionInput.model_validate(
+            {
+                "metadata": {
+                    "include_filter": {"^prod$": ["^analytics$"]},
+                    "future_field": "new-ae-config",
+                }
+            }
+        )
+
+        assert result.include_filter == {"^prod$": ["^analytics$"]}
+        assert "Unknown keys in payload for ExtractionInput" in caplog.text
+        assert "['metadata']" in caplog.text


### PR DESCRIPTION
## Summary
- lift recognized AE `metadata` fields into `ExtractionInput` top-level snake_case fields
- support kebab-case as tolerant input while keeping snake_case canonical
- preserve top-level precedence and keep warning behavior for unknown metadata fields

## App validation context
- AE preserves manifest keys when passing `args` to child workflows
- v3 SQL manifests for Trino, MSSQL, and CloudSQL Postgres send `include_filter` / `exclude_filter` under `metadata`
- ThoughtSpot works because its generated manifest sends snake_case fields top-level, matching `_input.py`

## Validation
- reproduction payload now prints non-empty `include_filter`, `exclude_filter`, and `extraction_method`
- `uv run pytest tests/unit/templates/test_extraction_input_filters.py`
- `uv run pytest tests/unit/templates/`
- `uv run pre-commit run --all-files`

Fixes HYP-806.