### PR TITLE
chore(security): allowlist Chainguard python-*-base CVEs

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Updated by SDK team. CODEOWNERS: SDK/security team only.",
   "_base_image": "application-sdk-main",
-  "_updated": "2026-04-23",
+  "_updated": "2026-04-24",
   "_renewal_note": "Expiry dates staggered by severity. CRITICAL: 15 days. HIGH: 30 days. Review before expiry. Enforced by .github/scripts/validate_allowlist.py via _expiry_policy below.",
   "_expiry_policy": {
     "CRITICAL": 15,
@@ -223,5 +223,19 @@
     "reason": "MiniZip heap overflow in zlib contrib. The zlib1g binary package ships only libz.so.1 and does NOT contain the vulnerable zipOpenNewFileInZip4_64 code — that lives in the separate minizip/libminizip1 packages, which are not installed in connector images (verified via Debian package file-list). No fix available upstream: zlib maintainers consider MiniZip contrib, Debian has tracked this without a patch for 18+ months. Blocks atlan-mssql-app releases.",
     "expires": "2026-05-08",
     "added_by": "Divyanshu-Patel"
+  },
+  "CVE-2026-6100": {
+    "package": "python-3.x-base (Chainguard)",
+    "severity": "HIGH",
+    "reason": "Base image — Chainguard python-3.10/3.11/3.12/3.13-base. Upstream fix available (3.10.20-r3, 3.11.15-r2, 3.13.13-r2), pending SDK v2.8.x base rebuild. Note: v3.2.0 base already includes the patched packages.",
+    "expires": "2026-05-24",
+    "added_by": "mananjain99"
+  },
+  "CVE-2026-4786": {
+    "package": "python-3.x-base (Chainguard)",
+    "severity": "HIGH",
+    "reason": "Base image — Chainguard python-3.11/3.13-base. Upstream fix available (3.11.15-r2, 3.13.13-r2), pending SDK v2.8.x base rebuild. Note: v3.2.0 base already includes the patched packages.",
+    "expires": "2026-05-24",
+    "added_by": "mananjain99"
   }
 }


### PR DESCRIPTION
## Summary
Adds two HIGH-severity Chainguard `python-*-base` CVEs to the central base allowlist. Both have upstream fixes already, but the current v2.8.7 SDK base image (cut 2026-04-16) was built before Chainguard published those patches. The v3.2.0 base already includes the patched packages.

| CVE | Package | Fix version | Current status |
|---|---|---|---|
| CVE-2026-6100 | python-3.10/3.11/3.12/3.13-base | 3.10.20-r3 / 3.11.15-r2 / 3.13.13-r2 | Pending v2.8.x base rebuild |
| CVE-2026-4786 | python-3.11/3.13-base | 3.11.15-r2 / 3.13.13-r2 | Pending v2.8.x base rebuild |

## Why allowlist (short-term)
Both CVEs block PRs on connector repos that are on the v2.8.x SDK base line. Example: [atlanhq/atlan-cloudsql-postgres-app#29](https://github.com/atlanhq/atlan-cloudsql-postgres-app/pull/29) — after bumping base 2.6.0 → 2.8.7 and auto-fixing Python deps, these are the only remaining blockers.

Allowlisting with 30-day expiry (2026-05-24) per existing HIGH policy. Once a v2.8.x rebuild lands with the patched Chainguard packages, these entries can be removed.

## Resolution path
1. **This PR (short-term):** 30-day allowlist to unblock affected connectors on v2.8.x.
2. **SDK team (medium-term):** rebuild v2.8.x base with refreshed Chainguard `python-*-base` packages, then drop these allowlist entries.
3. **Long-term:** connectors migrate to the v3 base where these are already patched.

## Test plan
- [x] `validate_allowlist.py` passes (33 entries, all within policy)
- [x] JSON is syntactically valid
- [ ] PR #29 on atlan-cloudsql-postgres-app gate passes after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)