### PR TITLE
fix(storage): remove parquet size double-discount

### DIFF
--- a/application_sdk/storage/formats/utils.py
+++ b/application_sdk/storage/formats/utils.py
@@ -216,6 +216,8 @@ def estimate_dataframe_record_size(
         raise ValueError(f"Unsupported file extension: {file_extension}")
 
     if sample_file is not None:
+        # Parquet samples are already snappy-compressed above, so use the
+        # measured sample size directly instead of applying another factor.
         avg_record_size = len(sample_file) / sample_size
         return int(avg_record_size)
 

--- a/application_sdk/storage/formats/utils.py
+++ b/application_sdk/storage/formats/utils.py
@@ -208,17 +208,15 @@ def estimate_dataframe_record_size(
     # Sample up to 10 records to estimate average size
     sample_size = min(10, len(dataframe))
     sample = dataframe.head(sample_size)
-    compression_factor = 1
     if file_extension == JSON_FILE_EXTENSION:
         sample_file = sample.to_json(orient="records", lines=True)
     elif file_extension == PARQUET_FILE_EXTENSION:
         sample_file = sample.to_parquet(index=False, compression="snappy")
-        compression_factor = 0.01
     else:
         raise ValueError(f"Unsupported file extension: {file_extension}")
 
     if sample_file is not None:
-        avg_record_size = len(sample_file) / sample_size * compression_factor
+        avg_record_size = len(sample_file) / sample_size
         return int(avg_record_size)
 
     return 0

--- a/tests/unit/storage/formats/test_utils.py
+++ b/tests/unit/storage/formats/test_utils.py
@@ -1,0 +1,24 @@
+import pandas as pd
+
+from application_sdk.storage.formats.utils import (
+    PARQUET_FILE_EXTENSION,
+    estimate_dataframe_record_size,
+)
+
+
+def test_parquet_record_size_uses_snappy_sample_without_extra_factor() -> None:
+    dataframe = pd.DataFrame(
+        {
+            "id": range(25),
+            "query_text": [f"select * from table_{i}" for i in range(25)],
+        }
+    )
+    sample = dataframe.head(10)
+    expected_size = int(
+        len(sample.to_parquet(index=False, compression="snappy")) / len(sample)
+    )
+
+    assert (
+        estimate_dataframe_record_size(dataframe, PARQUET_FILE_EXTENSION)
+        == expected_size
+    )


### PR DESCRIPTION
## Summary
- remove the extra 0.01 multiplier from parquet record-size estimation
- use the actual snappy parquet sample byte size, since pandas/pyarrow already applies compression when producing the sample
- add a regression test for parquet size estimation

## Context
PR #1073 identified that the old parquet write path was applying an additional compression factor while estimating parquet record sizes. In v3, the data-loss issue from that PR is already fixed by #1547, which gives every parquet sub-chunk a unique part file and uploads it immediately.

This cleanup removes the stale multiplier because keeping it still underestimates parquet output by 100x, and it is no longer needed for chunk safety after #1547.

## Downstream Risk
Risk is low and bounded, but not literally zero.

What changes: only the estimate returned by `estimate_dataframe_record_size()` for parquet. It now uses the actual snappy-compressed parquet sample size instead of multiplying that already-compressed sample by `0.01`.

Why this should be safe:
- the v3 parquet data-loss fix is independent: `ParquetFileWriter._flush_buffer()` already writes unique part files and uploads each sub-chunk immediately
- current call-site audit shows this estimator is only used by the base pandas writer path
- for parquet, the change makes size accounting more conservative; if behavior changes, it should rotate/upload earlier rather than drop data
- consolidation paths do not rely on this estimator

The realistic downstream impact is operational: some workloads may produce a different number of parquet part files if they were relying on the underestimated size accounting. That is intended, because the previous value undercounted parquet output by 100x.

## Validation
- `uv run pytest tests/unit/storage/formats/test_utils.py tests/unit/storage/formats/test_writer_data_integrity.py::TestParquetWriterDataIntegrity -q`
- `uv run pytest tests/unit/storage/formats/writers/test_parquet_writer.py -q`
- `uv run pytest tests/unit/storage/formats -q` (116 passed, 3 skipped)
- `git diff --check`

Note: `uv run ruff` was not available in the local environment (ruff executable missing).
