### PR TITLE
fix: propagate ContextVars through run_in_thread [BLDX-1150]

### DIFF
--- a/application_sdk/app/context.py
+++ b/application_sdk/app/context.py
@@ -529,34 +529,56 @@ class TaskExecutionContext:
     async def run_in_thread(
         self, func: Callable[..., T], *args: Any, **kwargs: Any
     ) -> T:
-        """Run a blocking function in a thread pool.
+        """Last-resort escape hatch: run a blocking function in a thread pool.
 
-        Use this for blocking I/O or CPU-bound operations to keep the
-        event loop responsive for auto-heartbeating.
+        .. warning::
+            **Use only when no async-native alternative exists.** Per ADR-0010,
+            the SDK is async-first. Reach for an async library before reaching
+            for this:
 
-        CRITICAL: Auto-heartbeats only work when the event loop yields.
-        Without this wrapper, blocking operations will prevent heartbeats
-        from being sent, potentially causing Temporal to restart your activity.
+            - HTTP → ``httpx`` / ``aiohttp`` (not ``requests``)
+            - AWS  → ``aioboto3`` / ``aiobotocore`` (not ``boto3``)
+            - Postgres → ``asyncpg`` (not ``psycopg2``)
+            - File I/O → ``aiofiles`` (not blocking ``open()``)
+
+            Many SDK helpers are also already async — ``self.context.storage``,
+            ``self.context.state``, credential resolution. Don't wrap them.
+
+        Only use this wrapper for genuinely sync-only libraries (e.g.
+        ``pyatlan`` today, some C extensions, vendor SDKs without async
+        support). The wrapper exists to keep the event loop responsive for
+        auto-heartbeating; it is not a substitute for using async libraries.
+
+        ContextVars (ObjectStore, logger context, correlation ID, infrastructure
+        handles) are propagated to the worker thread automatically.
+
+        **CRITICAL: your blocking code MUST have its own timeout.** Python
+        threads cannot be forcibly killed; a hang here hangs the thread
+        forever.
 
         Args:
-            func: Blocking function to run.
-            *args: Positional arguments for func.
-            **kwargs: Keyword arguments for func.
+            func: Blocking function to run. MUST have internal timeout handling.
+            *args: Positional arguments for ``func``.
+            **kwargs: Keyword arguments for ``func``.
 
         Returns:
             Result of ``func(*args, **kwargs)``.
 
         Example::
 
-            # Instead of: response = requests.get(url)  # BLOCKS!
-            response = await self.task_context.run_in_thread(
-                requests.get, url, timeout=30
+            # OK — pyatlan client is sync-only today.
+            assets = await self.task_context.run_in_thread(
+                pyatlan_client.search, request
             )
 
-            # For pandas operations:
-            df = await self.task_context.run_in_thread(
-                pd.read_csv, path, sep=",", header=0
-            )
+            # WRONG — boto3 has aioboto3; use that instead.
+            # await self.task_context.run_in_thread(s3.put_object, ...)
+
+            # WRONG — requests has httpx; use that instead.
+            # await self.task_context.run_in_thread(requests.get, url, timeout=30)
+
+        See Also:
+            ``docs/adr/0010-async-first-blocking-code.md`` for full rationale.
         """
         from application_sdk.execution.heartbeat import run_in_thread
 

--- a/application_sdk/app/context.py
+++ b/application_sdk/app/context.py
@@ -544,10 +544,10 @@ class TaskExecutionContext:
             Many SDK helpers are also already async — ``self.context.storage``,
             ``self.context.state``, credential resolution. Don't wrap them.
 
-        Only use this wrapper for genuinely sync-only libraries (e.g.
-        ``pyatlan`` today, some C extensions, vendor SDKs without async
-        support). The wrapper exists to keep the event loop responsive for
-        auto-heartbeating; it is not a substitute for using async libraries.
+        Only use this wrapper after confirming no async-native alternative
+        exists for the library you're calling. The wrapper exists to keep
+        the event loop responsive for auto-heartbeating; it is not a
+        substitute for using async libraries.
 
         ContextVars (ObjectStore, logger context, correlation ID, infrastructure
         handles) are propagated to the worker thread automatically.
@@ -565,11 +565,6 @@ class TaskExecutionContext:
             Result of ``func(*args, **kwargs)``.
 
         Example::
-
-            # OK — pyatlan client is sync-only today.
-            assets = await self.task_context.run_in_thread(
-                pyatlan_client.search, request
-            )
 
             # WRONG — boto3 has aioboto3; use that instead.
             # await self.task_context.run_in_thread(s3.put_object, ...)

--- a/application_sdk/execution/heartbeat.py
+++ b/application_sdk/execution/heartbeat.py
@@ -174,26 +174,84 @@ async def auto_heartbeat_loop(
 
 
 async def run_in_thread(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
-    """Run a blocking function in a thread pool.
+    """Last-resort escape hatch: run a blocking function in a thread pool.
 
-    Use this for blocking I/O or CPU-bound operations to keep the event loop
-    responsive for heartbeating.
+    .. warning::
+        **Use only when no async-native alternative exists.** This is the
+        bottom of the preference list, not the default tool for "I have I/O
+        to do". Per ADR-0010 (async-first design), the SDK runs on Temporal's
+        asyncio event loop; blocking the loop breaks auto-heartbeats and
+        causes activities to be retried even though they are making progress.
 
-    ContextVars (ObjectStore, logger context, correlation ID, infrastructure
-    handles) are automatically propagated to the worker thread via
-    ``contextvars.copy_context()``.
+    **Decision order for blocking work (apps and SDK alike):**
 
-    CRITICAL: YOUR BLOCKING CODE MUST HAVE ITS OWN TIMEOUTS.
-    Python threads cannot be forcibly killed. If your blocking code hangs
-    indefinitely, the thread will run forever.
+    1. **Prefer an async-native library.** If one exists, use it. No
+       ``run_in_thread`` needed:
+
+       =========================  ======================  ====================
+       Need                       Use (async)             Avoid (blocking)
+       =========================  ======================  ====================
+       HTTP requests              ``httpx``, ``aiohttp``  ``requests``
+       AWS SDK                    ``aioboto3``,           ``boto3``
+                                  ``aiobotocore``
+       PostgreSQL                 ``asyncpg``             ``psycopg2``
+       MySQL                      ``aiomysql``            ``pymysql``
+       File I/O                   ``aiofiles``            ``open()``
+       =========================  ======================  ====================
+
+    2. **Then check the SDK.** Many helpers are already async — for example,
+       ``self.context.storage`` (ObjectStore), ``self.context.state``
+       (StateStore), and credential resolution all expose ``await``-able
+       methods. Don't wrap them in ``run_in_thread``.
+    3. **Only then** fall back to ``run_in_thread`` — for genuinely sync-only
+       libraries (e.g. ``pyatlan`` today, some C extensions, third-party
+       SDKs without async support).
+
+    **Examples of incorrect use (do not do this):**
+
+    .. code-block:: python
+
+        # WRONG — boto3 has aioboto3; use that instead.
+        await self.task_context.run_in_thread(s3_client.put_object, ...)
+
+        # WRONG — requests has httpx; use that instead.
+        await self.task_context.run_in_thread(requests.get, url, timeout=30)
+
+    **Examples of correct use:**
+
+    .. code-block:: python
+
+        # OK — pyatlan client is sync-only today.
+        await self.task_context.run_in_thread(pyatlan_client.search, request)
+
+        # OK — CPU-bound work that must yield to the event loop.
+        await self.task_context.run_in_thread(parse_huge_csv, path)
+
+    **Behavior:**
+
+    - ContextVars (ObjectStore, logger context, correlation ID, infrastructure
+      handles) are propagated to the worker thread via
+      ``contextvars.copy_context()``. Mutations inside the thread stay
+      isolated from the caller (copy semantics).
+    - Threads run on a dedicated ``sdk-blocking-*`` pool, separate from
+      Temporal's activity pool, to avoid deadlocking the worker.
+
+    **CRITICAL: your blocking code MUST have its own timeout.**
+    Python threads cannot be forcibly killed. If the wrapped call hangs
+    forever, the thread runs forever — this orphans state and consumes
+    pool slots even after the activity is retried.
 
     Args:
         func: Blocking function to run. MUST have internal timeout handling.
-        *args: Positional arguments for func.
-        **kwargs: Keyword arguments for func.
+        *args: Positional arguments for ``func``.
+        **kwargs: Keyword arguments for ``func``.
 
     Returns:
         Result of ``func(*args, **kwargs)``.
+
+    See Also:
+        - ``docs/adr/0010-async-first-blocking-code.md`` — full rationale.
+        - ``self.context.storage`` / ``self.context.state`` — already async.
     """
     ctx = contextvars.copy_context()
     loop = asyncio.get_running_loop()

--- a/application_sdk/execution/heartbeat.py
+++ b/application_sdk/execution/heartbeat.py
@@ -203,9 +203,9 @@ async def run_in_thread(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
        ``self.context.storage`` (ObjectStore), ``self.context.state``
        (StateStore), and credential resolution all expose ``await``-able
        methods. Don't wrap them in ``run_in_thread``.
-    3. **Only then** fall back to ``run_in_thread`` — for genuinely sync-only
-       libraries (e.g. ``pyatlan`` today, some C extensions, third-party
-       SDKs without async support).
+    3. **Only then** fall back to ``run_in_thread`` — and only after
+       confirming there is no async-native alternative for the library
+       you're calling.
 
     **Examples of incorrect use (do not do this):**
 
@@ -216,16 +216,6 @@ async def run_in_thread(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
 
         # WRONG — requests has httpx; use that instead.
         await self.task_context.run_in_thread(requests.get, url, timeout=30)
-
-    **Examples of correct use:**
-
-    .. code-block:: python
-
-        # OK — pyatlan client is sync-only today.
-        await self.task_context.run_in_thread(pyatlan_client.search, request)
-
-        # OK — CPU-bound work that must yield to the event loop.
-        await self.task_context.run_in_thread(parse_huge_csv, path)
 
     **Behavior:**
 

--- a/application_sdk/execution/heartbeat.py
+++ b/application_sdk/execution/heartbeat.py
@@ -10,6 +10,7 @@ Two modes of heartbeating are supported:
 
 import asyncio
 import concurrent.futures
+import contextvars
 import functools
 import os
 import time
@@ -178,6 +179,10 @@ async def run_in_thread(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
     Use this for blocking I/O or CPU-bound operations to keep the event loop
     responsive for heartbeating.
 
+    ContextVars (ObjectStore, logger context, correlation ID, infrastructure
+    handles) are automatically propagated to the worker thread via
+    ``contextvars.copy_context()``.
+
     CRITICAL: YOUR BLOCKING CODE MUST HAVE ITS OWN TIMEOUTS.
     Python threads cannot be forcibly killed. If your blocking code hangs
     indefinitely, the thread will run forever.
@@ -190,8 +195,9 @@ async def run_in_thread(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
     Returns:
         Result of ``func(*args, **kwargs)``.
     """
+    ctx = contextvars.copy_context()
     loop = asyncio.get_running_loop()
     return await loop.run_in_executor(
         _BLOCKING_EXECUTOR,
-        functools.partial(func, *args, **kwargs),
+        functools.partial(ctx.run, functools.partial(func, *args, **kwargs)),
     )

--- a/tests/unit/execution/test_run_in_thread.py
+++ b/tests/unit/execution/test_run_in_thread.py
@@ -1,0 +1,51 @@
+"""Tests for run_in_thread ContextVar propagation."""
+
+import contextvars
+
+import pytest
+
+from application_sdk.execution.heartbeat import run_in_thread
+
+_test_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "_test_var", default="unset"
+)
+
+
+def _read_contextvar() -> str:
+    """Blocking function that reads a ContextVar — runs in worker thread."""
+    return _test_var.get()
+
+
+@pytest.mark.asyncio
+async def test_run_in_thread_propagates_contextvars():
+    """ContextVars set in the calling coroutine must be visible inside run_in_thread."""
+    token = _test_var.set("propagated")
+    try:
+        result = await run_in_thread(_read_contextvar)
+        assert result == "propagated"
+    finally:
+        _test_var.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_run_in_thread_does_not_leak_back():
+    """Mutations inside the thread must NOT leak back to the caller."""
+
+    def _mutate_contextvar() -> str:
+        _test_var.set("mutated-in-thread")
+        return _test_var.get()
+
+    token = _test_var.set("original")
+    try:
+        thread_result = await run_in_thread(_mutate_contextvar)
+        assert thread_result == "mutated-in-thread"
+        assert _test_var.get() == "original"
+    finally:
+        _test_var.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_run_in_thread_default_value():
+    """Without setting the ContextVar, the thread sees the default."""
+    result = await run_in_thread(_read_contextvar)
+    assert result == "unset"


### PR DESCRIPTION
## Summary

`run_in_thread()` dispatches blocking work to a `ThreadPoolExecutor` via `loop.run_in_executor()`. Python's `run_in_executor` does **not** propagate `ContextVar` values to worker threads. This causes SDK infrastructure stored in ContextVars to be invisible inside the thread:

- `_correlation_ctx` — correlation ID propagation
- `_execution_ctx` — execution type (workflow vs activity)
- `_infrastructure_ctx` — infrastructure handles (ObjectStore, StateStore, SecretStore)
- `_current_outputs` — output collection (metrics, artifacts)

### The fix

Wrap the dispatched callable with `contextvars.copy_context().run()` so the worker thread inherits a snapshot of the calling coroutine's context. Mutations inside the thread stay isolated (copy semantics — the thread gets its own copy, changes don't leak back).

```python
# Before:
loop.run_in_executor(_BLOCKING_EXECUTOR, functools.partial(func, *args, **kwargs))

# After:
ctx = contextvars.copy_context()
loop.run_in_executor(_BLOCKING_EXECUTOR, functools.partial(ctx.run, functools.partial(func, *args, **kwargs)))
```

### Plus: `run_in_thread` is a last-resort escape hatch

Per ADR-0010, the SDK is async-first. This PR also strengthens the docstrings on both `run_in_thread` and `TaskExecutionContext.run_in_thread` so apps and AI agents see that guidance at the API surface, including:

- The full async-library reference table (`httpx`, `aioboto3`, `asyncpg`, `aiomysql`, `aiofiles`).
- Explicit `# WRONG` examples for the common mistakes (`run_in_thread(s3.put_object, ...)` → use `aioboto3`; `run_in_thread(requests.get, ...)` → use `httpx`).
- Generic guidance: "Only use this wrapper after confirming no async-native alternative exists for the library you're calling." No named "OK"-case examples — naming a specific library risks the same failure mode (the library may already have async support, or add it next quarter).

The `atlan-s3-app`'s current `boto3 + run_in_thread` pattern is one of those "WRONG" cases — it should migrate to `aioboto3` and won't need this fix at all. The ContextVar propagation fix stands on its own merit because broken context propagation silently corrupts logs / ObjectStore handles inside any thread it runs in. CHANGELOG already has a prior fix for the same class of bug ("pass secret_store directly to handler — ContextVar not propagated through uvicorn (#1301)").

### Linear issue

[BLDX-1150](https://linear.app/atlan-epd/issue/BLDX-1150/fix-run-in-thread-to-propagate-contextvars)

## Test plan

- [x] `test_run_in_thread_propagates_contextvars` — ContextVar set in caller is visible in thread
- [x] `test_run_in_thread_does_not_leak_back` — mutations in thread don't affect caller
- [x] `test_run_in_thread_default_value` — default ContextVar value works correctly