### PR TITLE
feat: sandbox-safe env access + auto-passthrough drivers [BLDX-1148]

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -449,6 +449,9 @@ class App(ABC):
     tags: ClassVar[dict[str, str] | None] = None
     passthrough_modules: ClassVar[set[str] | None] = None
 
+    # Pre-sandbox snapshot of os.environ, captured during worker startup.
+    _env_snapshot: ClassVar[dict[str, str]] = {}
+
     # Marker to track if class has been registered
     _app_registered: ClassVar[bool] = False
 
@@ -650,6 +653,34 @@ class App(ABC):
                 "Do not access task_context in run() or outside of task methods."
             )
         return self._task_context
+
+    # =========================================================================
+    # Environment access (sandbox-safe)
+    # =========================================================================
+
+    @classmethod
+    def _capture_env_snapshot(cls) -> None:
+        """Capture ``os.environ`` before Temporal sandbox activates.
+
+        Called automatically by ``create_worker()`` during worker startup.
+        """
+        cls._env_snapshot = dict(os.environ)
+
+    def env(self, key: str, default: str = "") -> str:
+        """Read an environment variable safely inside workflow code.
+
+        Temporal's deterministic sandbox blocks direct ``os.environ`` access
+        inside ``run()``.  This method reads from a pre-sandbox snapshot
+        captured during worker startup.
+
+        Args:
+            key: Environment variable name.
+            default: Value returned when *key* is absent (default ``""``).
+
+        Returns:
+            The environment variable value, or *default* if not set.
+        """
+        return self._env_snapshot.get(key, default)
 
     # =========================================================================
     # Convenience accessors for common context properties

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -247,6 +247,12 @@ def create_worker(
 
     all_interceptors.append(TaskFailureLoggingInterceptor())
 
+    # Capture os.environ snapshot before sandbox activates so that
+    # App.env() can read environment variables inside workflow code.
+    from application_sdk.app.base import App
+
+    App._capture_env_snapshot()
+
     # Build sandbox configuration
     config = SandboxConfig()
 

--- a/application_sdk/execution/sandbox.py
+++ b/application_sdk/execution/sandbox.py
@@ -49,6 +49,29 @@ _FRAMEWORK_MODULES: frozenset[str] = frozenset(
     }
 )
 
+# Common native database driver packages that use C extensions or
+# ctypes and must pass through the sandbox to work correctly.
+_KNOWN_DRIVER_MODULES: frozenset[str] = frozenset(
+    {
+        "snowflake",
+        "oracledb",
+        "hdbcli",
+        "pyodbc",
+        "cassandra",
+        "clickhouse_connect",
+        "teradatasql",
+        "pyhive",
+        "impyla",
+        "pymssql",
+        "psycopg",
+        "psycopg2",
+        "asyncpg",
+        "aiomysql",
+        "cx_Oracle",
+        "sqlanydb",
+    }
+)
+
 
 @dataclass(frozen=True)
 class SandboxConfig:
@@ -87,5 +110,7 @@ class SandboxConfig:
         """
         from temporalio.worker.workflow_sandbox import SandboxRestrictions
 
-        all_modules = _FRAMEWORK_MODULES | self.passthrough_modules
+        all_modules = (
+            _FRAMEWORK_MODULES | _KNOWN_DRIVER_MODULES | self.passthrough_modules
+        )
         return SandboxRestrictions.default.with_passthrough_modules(*all_modules)

--- a/tests/unit/app/test_env_snapshot.py
+++ b/tests/unit/app/test_env_snapshot.py
@@ -1,0 +1,111 @@
+"""Tests for App._capture_env_snapshot() and App.env() sandbox-safe env access."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import pytest
+
+from application_sdk.app.base import App
+from application_sdk.contracts.base import Input, Output
+
+
+@dataclass
+class _SnapshotInput(Input):
+    value: str = ""
+
+
+@dataclass
+class _SnapshotOutput(Output):
+    result: str = ""
+
+
+class _SnapshotApp(App):
+    name = "snapshot-test-app"
+
+    async def run(self, input: _SnapshotInput) -> _SnapshotOutput:
+        return _SnapshotOutput(result="ok")
+
+
+@pytest.fixture(autouse=True)
+def _restore_snapshot():
+    """Restore _env_snapshot to its original value after each test."""
+    original = App._env_snapshot.copy()
+    yield
+    App._env_snapshot = original
+
+
+class TestCaptureEnvSnapshot:
+    """Tests for App._capture_env_snapshot()."""
+
+    def test_captures_current_environ(self) -> None:
+        """_capture_env_snapshot captures os.environ at call time."""
+        with patch.dict(os.environ, {"TEST_SNAPSHOT_VAR": "hello"}, clear=False):
+            App._capture_env_snapshot()
+
+        assert App._env_snapshot["TEST_SNAPSHOT_VAR"] == "hello"
+
+    def test_snapshot_is_a_copy(self) -> None:
+        """Snapshot is an independent copy, not a reference to os.environ."""
+        App._capture_env_snapshot()
+
+        # Mutating os.environ after capture should not affect the snapshot
+        os.environ["__SNAPSHOT_POST_CAPTURE__"] = "after"
+        assert "__SNAPSHOT_POST_CAPTURE__" not in App._env_snapshot
+
+        # Clean up
+        os.environ.pop("__SNAPSHOT_POST_CAPTURE__", None)
+
+    def test_overwrites_previous_snapshot(self) -> None:
+        """Calling _capture_env_snapshot again overwrites the previous one."""
+        App._env_snapshot = {"OLD_KEY": "old_value"}
+        App._capture_env_snapshot()
+
+        assert "OLD_KEY" not in App._env_snapshot
+        # Should contain real env vars instead
+        assert "PATH" in App._env_snapshot or len(App._env_snapshot) >= 0
+
+
+class TestEnvMethod:
+    """Tests for App.env() instance method."""
+
+    def test_returns_value_from_snapshot(self) -> None:
+        """env() returns the value from the pre-captured snapshot."""
+        App._env_snapshot = {"MY_DB_HOST": "localhost", "MY_DB_PORT": "5432"}
+        app = _SnapshotApp()
+
+        assert app.env("MY_DB_HOST") == "localhost"
+        assert app.env("MY_DB_PORT") == "5432"
+
+    def test_returns_default_when_key_missing(self) -> None:
+        """env() returns the default when the key is not in the snapshot."""
+        App._env_snapshot = {}
+        app = _SnapshotApp()
+
+        assert app.env("NONEXISTENT_KEY") == ""
+        assert app.env("NONEXISTENT_KEY", "fallback") == "fallback"
+
+    def test_default_is_empty_string(self) -> None:
+        """env() default parameter defaults to empty string."""
+        App._env_snapshot = {}
+        app = _SnapshotApp()
+
+        assert app.env("MISSING") == ""
+
+    def test_reads_from_class_level_snapshot(self) -> None:
+        """env() reads from the class-level _env_snapshot, not os.environ."""
+        App._env_snapshot = {"SNAPSHOT_ONLY": "yes"}
+        app = _SnapshotApp()
+
+        # Even if os.environ has a different value, env() uses the snapshot
+        with patch.dict(os.environ, {"SNAPSHOT_ONLY": "no"}, clear=False):
+            assert app.env("SNAPSHOT_ONLY") == "yes"
+
+    def test_shared_across_subclasses(self) -> None:
+        """_env_snapshot is shared across all App subclasses (ClassVar)."""
+        App._env_snapshot = {"SHARED_VAR": "shared_value"}
+        app = _SnapshotApp()
+
+        assert app.env("SHARED_VAR") == "shared_value"


### PR DESCRIPTION
## Summary

- Add `self.env(key, default)` method on `App` for reading environment variables safely inside `run()` — Temporal's sandbox blocks direct `os.environ` access, so this reads from a pre-sandbox snapshot captured during worker startup
- Add `_KNOWN_DRIVER_MODULES` frozenset (16 common native database drivers: snowflake, oracledb, psycopg2, pyodbc, etc.) to `application_sdk/execution/sandbox.py` and merge into the sandbox passthrough config automatically
- Call `App._capture_env_snapshot()` in `create_worker()` before the sandbox activates

## Motivation

10+ apps currently set `TEMPORAL_DISABLE_SANDBOX=1` or use module-level `os.environ` reads to work around two sandbox pain points:
1. `os.environ` access inside `run()` is blocked by the deterministic sandbox
2. Native database drivers (C extensions / ctypes) fail when re-imported inside the sandbox

This change eliminates both workarounds without requiring any app-level code changes for the driver passthrough, and provides a simple `self.env()` API for the env var case.

## What already exists

The `passthrough_modules` ClassVar on `App` is already wired — `__init_subclass__` captures it, `AppRegistry.get_all_passthrough_modules()` aggregates it, and `create_worker()` feeds it into `SandboxConfig`. No changes were needed to that flow.

## Changes

| File | Change |
|------|--------|
| `application_sdk/app/base.py` | Add `_env_snapshot` ClassVar, `_capture_env_snapshot()` classmethod, `env()` instance method |
| `application_sdk/execution/_temporal/worker.py` | Call `App._capture_env_snapshot()` before sandbox config build |
| `application_sdk/execution/sandbox.py` | Add `_KNOWN_DRIVER_MODULES` frozenset, merge into `to_temporal_restrictions()` |
| `tests/unit/app/test_env_snapshot.py` | 8 unit tests for snapshot capture and `env()` method |

## Test plan

- [x] `test_captures_current_environ` — snapshot includes env vars present at capture time
- [x] `test_snapshot_is_a_copy` — mutations to `os.environ` after capture do not affect snapshot
- [x] `test_overwrites_previous_snapshot` — re-calling capture replaces old snapshot
- [x] `test_returns_value_from_snapshot` — `env()` returns correct value
- [x] `test_returns_default_when_key_missing` — `env()` returns default for absent keys
- [x] `test_default_is_empty_string` — default parameter defaults to `""`
- [x] `test_reads_from_class_level_snapshot` — `env()` reads snapshot, not live `os.environ`
- [x] `test_shared_across_subclasses` — snapshot is shared via ClassVar
- [x] All 131 existing `tests/unit/app/` tests pass (no regressions)
- [x] Pre-commit (ruff, ruff-format, pyright, isort) passes on all changed files

## Linear

https://linear.app/atlan-epd/issue/BLDX-1148