### PR TITLE
feat: add AE payload normalization to Input base class

### DIFF
--- a/application_sdk/contracts/base.py
+++ b/application_sdk/contracts/base.py
@@ -57,6 +57,7 @@ Evolution:
 """
 
 import hashlib
+import json
 import logging
 import re
 from enum import StrEnum
@@ -169,9 +170,92 @@ class Input(BaseModel):
     config_hash() unions this set across the full MRO, so subclass entries
     are merged with (not replaced by) base-class exclusions."""
 
+    normalize_input: ClassVar[bool] = True
+    """When True (default), the ``_normalize_input_payload`` validator
+    runs before field validation to align the raw AE/Heracles payload
+    with the SDK's snake_case Pydantic models.  Set to ``False`` on a
+    subclass to disable normalization for edge-case inputs."""
+
     _unknown_keys_seen: ClassVar[set[tuple[str, tuple[str, ...]]]] = set()
     """Dedup set for the unknown-key warning: at most one log line per
     (subclass name, sorted unknown keys) pair across the process lifetime."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_input_payload(cls, data: Any) -> Any:
+        """Normalize raw AE/Heracles payloads before Pydantic validation.
+
+        Every app that receives input from the Automation Engine or Heracles
+        independently normalizes the payload today.  This validator
+        centralizes that logic in the SDK so individual apps don't need to.
+
+        Steps (in order):
+        1. Lift ``metadata`` dict contents to top level (without overriding
+           existing top-level keys).
+        2. Convert kebab-case keys to snake_case (keep originals for
+           backward compatibility).
+        3. Parse JSON strings — values starting with ``{`` or ``[`` are
+           attempted through ``json.loads``.
+        4. Coerce string booleans — ``"true"``/``"false"`` (case-insensitive)
+           become Python ``True``/``False``.
+
+        The validator is opt-out via the ``normalize_input`` class variable.
+        """
+        if not isinstance(data, dict):
+            return data
+        if not cls.normalize_input:
+            return data
+
+        # 1. Lift metadata dict to top level
+        metadata = data.get("metadata")
+        if isinstance(metadata, dict):
+            for key, value in metadata.items():
+                if key not in data:
+                    data[key] = value
+
+        # 2. Kebab-case → snake_case (keep originals for backward compat)
+        kebab_additions: dict[str, Any] = {}
+        for key in list(data.keys()):
+            if isinstance(key, str) and "-" in key:
+                snake_key = key.replace("-", "_")
+                if snake_key not in data:
+                    kebab_additions[snake_key] = data[key]
+        data.update(kebab_additions)
+
+        # Build a set of field names whose annotation is plain ``str`` so
+        # JSON parsing and bool coercion don't convert values that Pydantic
+        # expects to receive as strings.
+        _str_fields: set[str] = set()
+        for fname, finfo in cls.model_fields.items():
+            if finfo.annotation is str:
+                _str_fields.add(fname)
+                if finfo.alias is not None:
+                    _str_fields.add(finfo.alias)
+
+        # 3. Parse JSON strings (skip known str-typed fields)
+        for key in list(data.keys()):
+            if key in _str_fields:
+                continue
+            value = data[key]
+            if isinstance(value, str) and value and value[0] in ("{", "["):
+                try:
+                    data[key] = json.loads(value)
+                except (json.JSONDecodeError, ValueError):
+                    pass  # Keep original string on parse failure
+
+        # 4. Coerce string booleans (skip known str-typed fields)
+        for key in list(data.keys()):
+            if key in _str_fields:
+                continue
+            value = data[key]
+            if isinstance(value, str):
+                lower = value.lower()
+                if lower == "true":
+                    data[key] = True
+                elif lower == "false":
+                    data[key] = False
+
+        return data
 
     @model_validator(mode="before")
     @classmethod

--- a/application_sdk/contracts/types.py
+++ b/application_sdk/contracts/types.py
@@ -308,6 +308,20 @@ class ConnectionRef(BaseModel, frozen=True):
         serialize_by_alias=True,
     )
 
+    @property
+    def qualified_name(self) -> str:
+        """Resolve the connection's qualified name from attributes.
+
+        Convenience accessor so callers don't need to traverse
+        ``ref.attributes.qualified_name`` and handle ``None`` attributes.
+
+        Returns:
+            The qualified name string, or ``""`` if unavailable.
+        """
+        if self.attributes:
+            return self.attributes.qualified_name or ""
+        return ""
+
     @staticmethod
     def from_connection(conn: Any) -> "ConnectionRef":
         """Convert a pyatlan_v9 Connection (msgspec.Struct) to ConnectionRef.

--- a/tests/unit/contracts/test_base.py
+++ b/tests/unit/contracts/test_base.py
@@ -511,7 +511,7 @@ def _reset_unknown_keys_seen() -> Any:
 
 
 class TestUnknownKeyWarning:
-    def test_kebab_case_extra_warns_with_snake_case_hint(
+    def test_kebab_case_extra_normalised_and_warns(
         self, caplog: pytest.LogCaptureFixture, _reset_unknown_keys_seen: Any
     ) -> None:
         class ExtractionInput(Input):
@@ -525,17 +525,19 @@ class TestUnknownKeyWarning:
         with caplog.at_level(logging.WARNING, logger="application_sdk.contracts.base"):
             obj = ExtractionInput.model_validate(payload)
 
-        # Silent drop still happens — we only observe, not normalize.
-        assert obj.credential_guid == ""
-        assert obj.include_filter == "{}"
+        # Normalization converts kebab-case → snake_case, populating
+        # the declared model fields.  str-typed fields keep their
+        # original string value (JSON parsing is skipped for str fields).
+        assert obj.credential_guid == "abc-123"
+        assert obj.include_filter == '{"^qa$":[".*"]}'
 
+        # The original kebab-case keys are still present (and unknown to
+        # the model), so _warn_on_unknown_keys fires for them.
         assert len(caplog.records) == 1
         msg = caplog.records[0].getMessage()
         assert "ExtractionInput" in msg
         assert "credential-guid" in msg
         assert "include-filter" in msg
-        assert "credential_guid" in msg
-        assert "include_filter" in msg
 
     def test_arbitrary_extras_warn_without_kebab_hint(
         self, caplog: pytest.LogCaptureFixture, _reset_unknown_keys_seen: Any

--- a/tests/unit/contracts/test_input_normalization.py
+++ b/tests/unit/contracts/test_input_normalization.py
@@ -1,0 +1,215 @@
+"""Unit tests for Input._normalize_input_payload.
+
+Covers:
+- Metadata dict lifting to top level
+- Kebab-case key conversion to snake_case
+- JSON string parsing for dict/list values
+- String boolean coercion
+- Opt-out via normalize_input = False
+- Metadata does not override existing top-level keys
+- ConnectionRef.qualified_name property
+"""
+
+from __future__ import annotations
+
+import json
+from typing import ClassVar
+
+from pydantic import ConfigDict
+
+from application_sdk.contracts.base import Input
+from application_sdk.contracts.types import ConnectionAttributes, ConnectionRef
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FlexInput(Input, allow_unbounded_fields=True):
+    """Permissive Input subclass used by normalization tests.
+
+    ``allow_unbounded_fields=True`` silences payload-safety validation so
+    we can pass arbitrary fields without annotating them.  ``extra="allow"``
+    lets Pydantic accept keys that aren't declared as model fields.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+
+class _NoNormInput(Input, allow_unbounded_fields=True):
+    """Input subclass that opts out of normalization."""
+
+    normalize_input: ClassVar[bool] = False
+
+    model_config = ConfigDict(extra="allow")
+
+
+# ---------------------------------------------------------------------------
+# Metadata lifting
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataLifting:
+    def test_metadata_dict_lifted_to_top_level(self) -> None:
+        data = {"metadata": {"include_filter": ".*", "batch_size": "10"}}
+        obj = _FlexInput.model_validate(data)
+        # Fields from metadata should be accessible at top level
+        assert obj.__pydantic_extra__["include_filter"] == ".*"
+
+    def test_metadata_does_not_override_existing(self) -> None:
+        data = {"workflow_id": "original", "metadata": {"workflow_id": "override"}}
+        obj = _FlexInput.model_validate(data)
+        assert obj.workflow_id == "original"
+
+    def test_metadata_non_dict_ignored(self) -> None:
+        """metadata that is not a dict should not be lifted."""
+        data = {"metadata": "just-a-string"}
+        obj = _FlexInput.model_validate(data)
+        # Should survive as-is, not cause an error
+        assert obj.__pydantic_extra__["metadata"] == "just-a-string"
+
+
+# ---------------------------------------------------------------------------
+# Kebab-case conversion
+# ---------------------------------------------------------------------------
+
+
+class TestKebabCaseConversion:
+    def test_kebab_to_snake(self) -> None:
+        data = {"include-filter": ".*"}
+        obj = _FlexInput.model_validate(data)
+        assert obj.__pydantic_extra__["include_filter"] == ".*"
+
+    def test_kebab_original_preserved(self) -> None:
+        """Original kebab-case key is kept for backward compatibility."""
+        data = {"include-filter": ".*"}
+        obj = _FlexInput.model_validate(data)
+        assert obj.__pydantic_extra__["include-filter"] == ".*"
+
+    def test_kebab_does_not_override_existing_snake(self) -> None:
+        data = {"include_filter": "existing", "include-filter": "kebab"}
+        obj = _FlexInput.model_validate(data)
+        assert obj.__pydantic_extra__["include_filter"] == "existing"
+
+
+# ---------------------------------------------------------------------------
+# JSON string parsing
+# ---------------------------------------------------------------------------
+
+
+class TestJsonStringParsing:
+    def test_json_dict_string_parsed(self) -> None:
+        payload = json.dumps({"qualifiedName": "default/sf/123"})
+        data = {"connection": payload}
+        obj = _FlexInput.model_validate(data)
+        assert isinstance(obj.__pydantic_extra__["connection"], dict)
+        assert obj.__pydantic_extra__["connection"]["qualifiedName"] == "default/sf/123"
+
+    def test_json_list_string_parsed(self) -> None:
+        payload = json.dumps(["a", "b", "c"])
+        data = {"items": payload}
+        obj = _FlexInput.model_validate(data)
+        assert obj.__pydantic_extra__["items"] == ["a", "b", "c"]
+
+    def test_invalid_json_string_kept(self) -> None:
+        data = {"bad_json": "{not valid json"}
+        obj = _FlexInput.model_validate(data)
+        assert obj.__pydantic_extra__["bad_json"] == "{not valid json"
+
+    def test_non_json_string_untouched(self) -> None:
+        data = {"plain": "hello world"}
+        obj = _FlexInput.model_validate(data)
+        assert obj.__pydantic_extra__["plain"] == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# Bool coercion
+# ---------------------------------------------------------------------------
+
+
+class TestBoolCoercion:
+    def test_true_string(self) -> None:
+        data = {"flag": "true"}
+        obj = _FlexInput.model_validate(data)
+        assert obj.__pydantic_extra__["flag"] is True
+
+    def test_false_string(self) -> None:
+        data = {"flag": "false"}
+        obj = _FlexInput.model_validate(data)
+        assert obj.__pydantic_extra__["flag"] is False
+
+    def test_case_insensitive(self) -> None:
+        data = {"a": "TRUE", "b": "False", "c": "TRUE"}
+        obj = _FlexInput.model_validate(data)
+        assert obj.__pydantic_extra__["a"] is True
+        assert obj.__pydantic_extra__["b"] is False
+        assert obj.__pydantic_extra__["c"] is True
+
+    def test_non_bool_string_untouched(self) -> None:
+        data = {"name": "trueman"}
+        obj = _FlexInput.model_validate(data)
+        assert obj.__pydantic_extra__["name"] == "trueman"
+
+
+# ---------------------------------------------------------------------------
+# Opt-out
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeOptOut:
+    def test_normalization_skipped(self) -> None:
+        data = {"include-filter": ".*", "flag": "true"}
+        obj = _NoNormInput.model_validate(data)
+        # Kebab key NOT converted — normalization was skipped
+        assert obj.__pydantic_extra__["include-filter"] == ".*"
+        assert "include_filter" not in (obj.__pydantic_extra__ or {})
+        # Bool NOT coerced
+        assert obj.__pydantic_extra__["flag"] == "true"
+
+
+# ---------------------------------------------------------------------------
+# Combined normalization
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedNormalization:
+    def test_all_steps_together(self) -> None:
+        data = {
+            "metadata": {"source-tag": "v1"},
+            "include-filter": '{"db": ["schema"]}',
+            "enabled": "true",
+        }
+        obj = _FlexInput.model_validate(data)
+        # metadata lifted
+        assert obj.__pydantic_extra__["source_tag"] == "v1"
+        # kebab converted
+        assert obj.__pydantic_extra__["include_filter"] == {"db": ["schema"]}
+        # JSON parsed on the kebab-converted key too
+        assert isinstance(obj.__pydantic_extra__["include_filter"], dict)
+        # bool coerced
+        assert obj.__pydantic_extra__["enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# ConnectionRef.qualified_name
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionRefQualifiedName:
+    def test_qualified_name_from_attributes(self) -> None:
+        ref = ConnectionRef.model_validate(
+            {
+                "typeName": "Connection",
+                "attributes": {"qualifiedName": "default/snowflake/123"},
+            }
+        )
+        assert ref.qualified_name == "default/snowflake/123"
+
+    def test_qualified_name_default_empty(self) -> None:
+        ref = ConnectionRef()
+        assert ref.qualified_name == ""
+
+    def test_qualified_name_snake_case_construction(self) -> None:
+        attrs = ConnectionAttributes(qualified_name="default/pg/456")
+        ref = ConnectionRef(attributes=attrs)
+        assert ref.qualified_name == "default/pg/456"


### PR DESCRIPTION
## Summary

Every app that receives input from the Automation Engine or Heracles independently normalizes the payload (metadata lifting, kebab-to-snake conversion, JSON string parsing, bool coercion). This PR centralizes that normalization in the SDK's `Input` base class so individual apps no longer need to duplicate it.

### What the normalization does

The new `_normalize_input_payload` `@model_validator(mode="before")` on `Input` runs before `_warn_on_unknown_keys` and applies four steps:

1. **Metadata dict lifting** -- if the payload contains a `metadata` key that's a dict, its contents are merged to the top level (without overriding existing keys)
2. **Kebab-case to snake_case** -- keys like `include-filter` get a `include_filter` alias added (originals kept for backward compat)
3. **JSON string parsing** -- string values starting with `{` or `[` are parsed via `json.loads` (skipped for fields typed as `str`)
4. **String bool coercion** -- `"true"`/`"false"` (case-insensitive) become Python `True`/`False` (skipped for fields typed as `str`)

Opt-out via `normalize_input: ClassVar[bool] = False` on any subclass.

### Examples of repos with manual normalization today

`atlan-snowflake-miner`, `atlan-databricks-miner`, `atlan-redshift-miner`, `atlan-bigquery-miner`, `atlan-postgres-miner`, `atlan-mysql-miner`, `atlan-mssql-miner`, `atlan-oracle-miner`, `atlan-hive-miner`, `atlan-presto-miner`, `atlan-trino-miner`, `atlan-athena-miner`, `atlan-glue-miner`, `atlan-synapse-miner`, `atlan-saphana-miner`, `atlan-teradata-miner`, `atlan-vertica-miner`, `atlan-clickhouse-miner`, `atlan-dbt-miner`, `atlan-looker-miner`, `atlan-tableau-miner`, `atlan-powerbi-miner`, `atlan-metabase-miner`, `atlan-fivetran-miner`, `atlan-airflow-miner`, `atlan-monte-carlo-miner`

### Other changes

- **`ConnectionRef.qualified_name`** -- convenience property that resolves `ref.attributes.qualified_name` with safe fallback to `""`
- **Updated existing test** -- `test_kebab_case_extra_warns_with_snake_case_hint` now reflects that kebab keys are normalized (not just warned about)

### Linear issue

https://linear.app/atlan-epd/issue/BLDX-1147

### Follow-up

`allow_unbounded_fields` deprecation will come in a follow-up (GAP-08 phase 2).

## Test plan

- [x] 19 new tests in `tests/unit/contracts/test_input_normalization.py` covering all normalization steps, opt-out, edge cases, and `ConnectionRef.qualified_name`
- [x] All 130 existing contract tests pass (including the updated kebab-case test)
- [x] Pre-commit (ruff, ruff-format, isort, pyright) passes on all changed files
- [ ] CI pipeline passes