### PR TITLE
ci: set atlan-openapi-app as default e2e-apps matrix target

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -206,7 +206,7 @@ jobs:
           # Get the target branch of PR
           TARGET_BRANCH="${{ github.base_ref }}"
           # Default matrix if no label provided
-          DEFAULT_MATRIX="{\"include\":[{\"repo_name\":\"atlan-postgres-app\",\"target_branch\":\"${TARGET_BRANCH}\"}]}"
+          DEFAULT_MATRIX="{\"include\":[{\"repo_name\":\"atlan-openapi-app\",\"target_branch\":\"${TARGET_BRANCH}\"}]}"
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # Parse labels from GitHub Script output


### PR DESCRIPTION
## Summary

- Replaces `atlan-postgres-app` with `atlan-openapi-app` in the default `e2e-apps` matrix (`pull_request.yaml:209`), so SDK PRs with the `e2e-test` label automatically dispatch `atlan-openapi-app`'s `e2e-integration-test.yaml`.
- `atlan-postgres-app` coverage can still be opted in per-PR via a `atlan-postgres-app:main` label — the existing label-parsing logic is unchanged.

## Companion PR

- **`atlan-openapi-app` #67:** adds `e2e-integration-test.yaml` with `workflow_dispatch` + `distinct_id` support for SDK-rev pinning.

## Test plan

- [ ] Open a test SDK PR, add the `e2e-test` label — confirm the `E2E (Apps)` matrix runs against `atlan-openapi-app` (not `atlan-postgres-app`)
- [ ] Confirm the SDK PR's check links to a run in `atlanhq/atlan-openapi-app`'s Actions tab with the correct SDK SHA in the bump step