### PR TITLE
fix: add httpx pool limits and timeout to prevent connection pool deadlock [BLDX-1153]

### DIFF
--- a/application_sdk/clients/base.py
+++ b/application_sdk/clients/base.py
@@ -12,6 +12,7 @@ from httpx._types import (
 
 from application_sdk.clients import ClientInterface
 from application_sdk.clients.ssl_utils import get_ssl_context
+from application_sdk.constants import _HTTP_POOL_LIMITS, _HTTP_POOL_TIMEOUT_SECONDS
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -101,8 +102,11 @@ class BaseClient(ClientInterface):
         self.credentials = credentials
         self.http_headers = http_headers
 
-        # Use httpx default transport (no retries on status codes)
-        self.http_retry_transport: httpx.AsyncBaseTransport = httpx.AsyncHTTPTransport()
+        # Use httpx default transport with pool limits to prevent CLOSE_WAIT
+        # zombie socket accumulation (see BLDX-1153).
+        self.http_retry_transport: httpx.AsyncBaseTransport = httpx.AsyncHTTPTransport(
+            limits=_HTTP_POOL_LIMITS,
+        )
 
     async def load(self, **kwargs: Any) -> None:
         """
@@ -187,7 +191,9 @@ class BaseClient(ClientInterface):
         """
         ssl_context = get_ssl_context()
         async with httpx.AsyncClient(
-            timeout=timeout, transport=self.http_retry_transport, verify=ssl_context
+            timeout=httpx.Timeout(timeout, pool=_HTTP_POOL_TIMEOUT_SECONDS),
+            transport=self.http_retry_transport,
+            verify=ssl_context,
         ) as client:
             merged_headers = Headers(self.http_headers)
             if headers:
@@ -266,7 +272,9 @@ class BaseClient(ClientInterface):
         """
         ssl_context = get_ssl_context()
         async with httpx.AsyncClient(
-            timeout=timeout, transport=self.http_retry_transport, verify=ssl_context
+            timeout=httpx.Timeout(timeout, pool=_HTTP_POOL_TIMEOUT_SECONDS),
+            transport=self.http_retry_transport,
+            verify=ssl_context,
         ) as client:
             merged_headers = Headers(self.http_headers)
             if headers:

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -54,6 +54,7 @@ Example:
 import os
 from enum import Enum
 
+import httpx
 from dotenv import load_dotenv
 
 load_dotenv(dotenv_path=".env")
@@ -207,6 +208,18 @@ EVENT_STORE_NAME = os.getenv("EVENT_STORE_NAME", "eventstore")
 DAPR_BINDING_OPERATION_CREATE = "create"
 #: Version of worker start events used in the application
 WORKER_START_EVENT_VERSION = "v1"
+
+# HTTP Connection Pool Configuration (BLDX-1153).
+# Prevents CLOSE_WAIT zombie socket accumulation and infinite blocking.
+# keepalive_expiry=30s < nginx keepalive_timeout=75s → client retires idle
+# connections before nginx sends FIN that httpcore can't detect.
+# pool timeout=30s → threads raise PoolTimeout instead of blocking forever.
+_HTTP_POOL_LIMITS = httpx.Limits(
+    max_connections=50,
+    max_keepalive_connections=10,
+    keepalive_expiry=30.0,
+)
+_HTTP_POOL_TIMEOUT_SECONDS = 30.0
 
 #: Whether to enable Atlan storage upload
 ENABLE_ATLAN_UPLOAD = os.getenv("ENABLE_ATLAN_UPLOAD", "false").lower() == "true"

--- a/application_sdk/infrastructure/_dapr/http.py
+++ b/application_sdk/infrastructure/_dapr/http.py
@@ -19,6 +19,7 @@ import httpx
 from httpx_retries import Retry, RetryTransport
 from pydantic import BaseModel
 
+from application_sdk.constants import _HTTP_POOL_LIMITS, _HTTP_POOL_TIMEOUT_SECONDS
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -114,7 +115,7 @@ class AsyncDaprClient:
     ):
         self._base_url = base_url or _dapr_base_url()
         transport = RetryTransport(
-            transport=httpx.AsyncHTTPTransport(),
+            transport=httpx.AsyncHTTPTransport(limits=_HTTP_POOL_LIMITS),
             retry=Retry(
                 total=retries,
                 backoff_factor=0.5,
@@ -123,7 +124,7 @@ class AsyncDaprClient:
         )
         self._client = httpx.AsyncClient(
             base_url=self._base_url,
-            timeout=timeout,
+            timeout=httpx.Timeout(timeout, pool=_HTTP_POOL_TIMEOUT_SECONDS),
             transport=transport,
         )
 

--- a/application_sdk/observability/segment_client.py
+++ b/application_sdk/observability/segment_client.py
@@ -171,7 +171,16 @@ class SegmentClient:
 
             # Initialize queue and client in the event loop
             self._queue = asyncio.Queue()
-            self._client = httpx.AsyncClient(timeout=30.0)
+            from application_sdk.constants import _HTTP_POOL_TIMEOUT_SECONDS
+
+            self._client = httpx.AsyncClient(
+                timeout=httpx.Timeout(30.0, pool=_HTTP_POOL_TIMEOUT_SECONDS),
+                limits=httpx.Limits(
+                    max_connections=10,
+                    max_keepalive_connections=5,
+                    keepalive_expiry=30.0,
+                ),
+            )
 
             # Signal that initialization is complete
             self._initialized_event.set()

--- a/tests/unit/clients/test_base_client.py
+++ b/tests/unit/clients/test_base_client.py
@@ -317,10 +317,12 @@ class TestBaseClient:
         result = await base_client.execute_http_post_request(url=url, timeout=timeout)
 
         assert result == mock_response
-        # Verify that timeout was passed to AsyncClient
-        mock_async_client.assert_called_once_with(
-            timeout=timeout, transport=base_client.http_retry_transport, verify=True
-        )
+        # Verify that timeout was passed to AsyncClient (with pool timeout)
+        call_kwargs = mock_async_client.call_args.kwargs
+        assert call_kwargs["transport"] is base_client.http_retry_transport
+        assert call_kwargs["verify"] is True
+        assert call_kwargs["timeout"].pool == 30.0
+        assert call_kwargs["timeout"].connect == timeout
 
     @pytest.mark.asyncio
     @patch("application_sdk.clients.base.httpx.AsyncClient")
@@ -342,9 +344,10 @@ class TestBaseClient:
 
         assert result == mock_response
         mock_get_ssl_context.assert_called_once()
-        mock_async_client.assert_called_once_with(
-            timeout=30, transport=base_client.http_retry_transport, verify=True
-        )
+        call_kwargs = mock_async_client.call_args.kwargs
+        assert call_kwargs["transport"] is base_client.http_retry_transport
+        assert call_kwargs["verify"] is True
+        assert call_kwargs["timeout"].pool == 30.0
 
     @given(credentials=sql_credentials_strategy)
     @settings(

--- a/tests/unit/infrastructure/test_connection_pool_config.py
+++ b/tests/unit/infrastructure/test_connection_pool_config.py
@@ -1,0 +1,120 @@
+"""Unit tests for BLDX-1153: httpx connection pool deadlock prevention.
+
+Verifies that all httpx clients in the SDK have proper pool limits and
+timeouts configured to prevent CLOSE_WAIT zombie socket accumulation
+and infinite blocking on exhausted connection pools.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from application_sdk.clients.base import BaseClient
+from application_sdk.constants import _HTTP_POOL_LIMITS, _HTTP_POOL_TIMEOUT_SECONDS
+from application_sdk.infrastructure._dapr.http import AsyncDaprClient
+
+# ---------------------------------------------------------------------------
+# AsyncDaprClient pool configuration
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncDaprClientPoolConfig:
+    """Verify AsyncDaprClient has pool limits and timeout configured."""
+
+    def test_pool_limits_constants_defined(self):
+        """Pool limits constants must exist with safe values."""
+        assert _HTTP_POOL_LIMITS.max_connections == 50
+        assert _HTTP_POOL_LIMITS.max_keepalive_connections == 10
+        assert _HTTP_POOL_LIMITS.keepalive_expiry == 30.0
+
+    def test_pool_timeout_constant_defined(self):
+        """Pool timeout must be finite (not None)."""
+        assert _HTTP_POOL_TIMEOUT_SECONDS == 30.0
+        assert _HTTP_POOL_TIMEOUT_SECONDS is not None
+
+    def test_client_has_pool_timeout(self):
+        """AsyncDaprClient timeout must include a pool timeout."""
+        client = AsyncDaprClient(base_url="http://localhost:3500")
+        timeout = client._client.timeout
+        assert timeout.pool == _HTTP_POOL_TIMEOUT_SECONDS
+        assert timeout.pool is not None
+
+    def test_client_has_pool_limits(self):
+        """AsyncDaprClient transport must have pool limits configured."""
+        client = AsyncDaprClient(base_url="http://localhost:3500")
+        # RetryTransport wraps AsyncHTTPTransport via _async_transport
+        try:
+            inner = client._client._transport._async_transport  # type: ignore[attr-defined]
+            pool = inner._pool
+            assert pool._max_connections == _HTTP_POOL_LIMITS.max_connections
+            assert pool._keepalive_expiry == _HTTP_POOL_LIMITS.keepalive_expiry
+            assert (
+                pool._max_keepalive_connections
+                == _HTTP_POOL_LIMITS.max_keepalive_connections
+            )
+        except AttributeError:
+            pytest.skip("httpx internal structure changed; update test")
+
+    def test_keepalive_expiry_less_than_nginx(self):
+        """keepalive_expiry must be less than nginx keepalive_timeout (75s)
+        to prevent CLOSE_WAIT zombie accumulation."""
+        assert _HTTP_POOL_LIMITS.keepalive_expiry < 75.0
+
+    def test_pool_timeout_prevents_infinite_blocking(self):
+        """Pool timeout must be finite to prevent threading.Event.wait(None)."""
+        client = AsyncDaprClient(base_url="http://localhost:3500")
+        timeout = client._client.timeout
+        # The deadlock root cause was pool=None → Event.wait(timeout=None)
+        assert timeout.pool is not None
+        assert timeout.pool > 0
+
+
+# ---------------------------------------------------------------------------
+# BaseClient pool configuration
+# ---------------------------------------------------------------------------
+
+
+class TestBaseClientPoolConfig:
+    """Verify BaseClient HTTP transport has pool limits."""
+
+    def test_default_transport_has_limits(self):
+        """BaseClient default transport must have keepalive_expiry set."""
+        client = BaseClient()
+        transport = client.http_retry_transport
+        assert isinstance(transport, httpx.AsyncHTTPTransport)
+        try:
+            pool = transport._pool
+            assert pool._max_connections == 50
+            assert pool._keepalive_expiry == 30.0
+            assert pool._max_keepalive_connections == 10
+        except AttributeError:
+            pytest.skip("httpx internal structure changed; update test")
+
+
+# ---------------------------------------------------------------------------
+# Pool timeout propagation
+# ---------------------------------------------------------------------------
+
+
+class TestPoolTimeoutPropagation:
+    """Verify PoolTimeout exceptions propagate instead of hanging."""
+
+    @pytest.mark.asyncio
+    async def test_dapr_client_pool_timeout_propagates(self):
+        """httpx.PoolTimeout must propagate up, not be swallowed."""
+        client = AsyncDaprClient(base_url="http://localhost:3500")
+
+        # Inject a PoolTimeout-raising transport
+        async def always_pool_timeout(request: httpx.Request) -> httpx.Response:
+            raise httpx.PoolTimeout("simulated pool exhaustion", request=request)
+
+        try:
+            client._client._transport._async_transport.handle_async_request = (  # type: ignore[attr-defined]
+                always_pool_timeout
+            )
+        except AttributeError:
+            pytest.skip("httpx internal structure changed; update test")
+
+        with pytest.raises(Exception):
+            await client._client.get("/v1.0/healthz")


### PR DESCRIPTION
## Summary

Port the pyatlan GOVFOUN-408 connection pool deadlock fix to application-sdk. Same root cause: httpcore pools fill with CLOSE_WAIT zombie sockets when nginx closes idle connections, and `pool=None` timeout means threads block forever.

## Changes

### `application_sdk/infrastructure/_dapr/http.py` (AsyncDaprClient)
- Add `_POOL_LIMITS` (max_connections=50, keepalive_expiry=30s) to `AsyncHTTPTransport`
- Add `pool=30.0` timeout so threads raise `PoolTimeout` instead of blocking forever
- `keepalive_expiry=30s` < nginx `keepalive_timeout=75s` prevents CLOSE_WAIT accumulation

### `application_sdk/clients/base.py` (BaseClient)
- Add pool limits to default `AsyncHTTPTransport` (max_connections=50, keepalive_expiry=30s)
- Add `pool=30.0` to all request timeouts (GET + POST)

### `application_sdk/observability/segment_client.py` (SegmentClient)
- Add pool limits (max_connections=10) and `pool=30.0` timeout to analytics client

## Tests
- 8 new tests in `tests/unit/infrastructure/test_connection_pool_config.py`:
  - Pool limits constants defined with safe values
  - AsyncDaprClient has pool timeout and limits configured
  - keepalive_expiry < nginx 75s
  - BaseClient transport has limits
  - PoolTimeout propagates (not swallowed)
- 2 existing BaseClient tests updated for new timeout format
- 2521 passed, 0 failed

## Linear
https://linear.app/atlan-epd/issue/BLDX-1153