### PR TITLE
chore(dashboard): skip empty initial scans when picking trend baseline

### DIFF
--- a/.security/dashboard/index.html
+++ b/.security/dashboard/index.html
@@ -541,11 +541,14 @@ function renderTrends(){
     const cutoffStr=cutoff.toISOString().slice(0,10);
 
     // Per-repo "old total" lookup: most recent history entry at/before cutoff;
-    // if no entry exists at/before cutoff, fall back to the oldest available entry
-    // so longer windows naturally include the change captured in shorter windows.
+    // if no entry exists at/before cutoff, fall back to the oldest available entry.
+    // Skip leading total=0 entries when non-zero entries exist — those are typically
+    // failed/empty initial scans (no artifacts), not a true clean baseline. A genuinely
+    // clean repo will have all-zero entries and the fallback will still pick 0 honestly.
     function getOldTotal(r){
-        const all=(historyData[r]||[]).slice().sort((a,b)=>a.date.localeCompare(b.date));
+        let all=(historyData[r]||[]).slice().sort((a,b)=>a.date.localeCompare(b.date));
         if(!all.length)return D.repos[r].total||0;
+        if(all.some(e=>(e.total||0)>0))all=all.filter(e=>(e.total||0)>0);
         const before=all.filter(e=>e.date<=cutoffStr);
         return (before.length?before[before.length-1].total:all[0].total)||0;
     }


### PR DESCRIPTION
## Problem
Needs Attention shows misleading regressions like:
```
atlan-mssql-app  ▲ 20  (0 → 20)
```

But mssql actually **improved** today (49 → 20 after the Wolfi base-image migration). The `0` baseline comes from `04-23: total=0`, which was the very first onboarding scan — no artifacts, no actual data. Treating it as a clean-state baseline is wrong: every repo "regresses from 0" the moment its first real scan finds anything.

## Fix
When picking the regression baseline, **skip leading total=0 entries if the repo has any non-zero entry**. A genuinely clean repo with all-zero history still falls back to 0 honestly.

## Result for mssql
| | Before this PR | After this PR |
|---|---|---|
| Baseline | `04-23: 0` (empty first scan) | `04-24: 49` (first real scan) |
| Needs Attention | `▲ 20 (0 → 20)` ❌ | not shown (no real regression) ✅ |
| Biggest Improvements | `▼ 29 (49 → 20)` ✅ | `▼ 29 (49 → 20)` ✅ (unchanged) |

Same fix benefits any other repo whose history starts with an empty onboarding scan.

## Test plan
- [x] Verified locally with synced production data — mssql drops out of Needs Attention, stays in Improvements.
- [x] Repos with all-zero history (genuinely clean) still show `0 → 0` correctly.
- [ ] After merge: confirm on https://k.atlan.dev/security-dashboard/ that mssql is no longer in Needs Attention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)