### PR TITLE
security(allowlist): add 4 Jackson HIGH CVEs from base image (QI unblock)

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -237,5 +237,33 @@
     "reason": "Base image — Chainguard python-3.11/3.13-base. Upstream fix available (3.11.15-r2, 3.13.13-r2), pending SDK v2.8.x base rebuild. Note: v3.2.0 base already includes the patched packages.",
     "expires": "2026-05-24",
     "added_by": "mananjain99"
+  },
+  "SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551": {
+    "package": "com.fasterxml.jackson.core:jackson-core",
+    "severity": "HIGH",
+    "reason": "Base image — Jackson Java transitive in application-sdk-main:2.7.3 (likely via Dapr tooling). No fix released upstream. Connector apps are Python at runtime and do not invoke Jackson code paths; review at expiry to track upstream patch availability.",
+    "expires": "2026-05-27",
+    "added_by": "vishalkatlan"
+  },
+  "SNYK-JAVA-COMFASTERXMLJACKSONCORE-15365924": {
+    "package": "com.fasterxml.jackson.core:jackson-core",
+    "severity": "HIGH",
+    "reason": "Base image — Jackson Java transitive in application-sdk-main:2.7.3 (likely via Dapr tooling). No fix released upstream. Connector apps are Python at runtime and do not invoke Jackson code paths; review at expiry to track upstream patch availability.",
+    "expires": "2026-05-27",
+    "added_by": "vishalkatlan"
+  },
+  "CVE-2026-33871": {
+    "package": "com.fasterxml.jackson.core:jackson-databind",
+    "severity": "HIGH",
+    "reason": "Base image — Jackson Java transitive in application-sdk-main:2.7.3 (likely via Dapr tooling). No fix released upstream. Connector apps are Python at runtime and do not invoke Jackson code paths; review at expiry to track upstream patch availability.",
+    "expires": "2026-05-27",
+    "added_by": "vishalkatlan"
+  },
+  "CVE-2026-33870": {
+    "package": "com.fasterxml.jackson.core:jackson-databind",
+    "severity": "HIGH",
+    "reason": "Base image — Jackson Java transitive in application-sdk-main:2.7.3 (likely via Dapr tooling). No fix released upstream. Connector apps are Python at runtime and do not invoke Jackson code paths; review at expiry to track upstream patch availability.",
+    "expires": "2026-05-27",
+    "added_by": "vishalkatlan"
   }
 }


### PR DESCRIPTION
## Why

The Phase 3 scan flagged 4 HIGH Jackson CVEs in the SDK base image (`application-sdk-main:2.7.3`). All four have **no upstream fix released** as of 2026-04-27. Adding them to the central allowlist with the standard 30-day expiry so dependent connector apps can publish; expiry forces a re-evaluation when upstream may have a fix.

## What this adds

4 entries to `.security/base-allowlist.json`:

| CVE / Snyk ID | Package | Expires |
|---|---|---|
| `SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551` | `com.fasterxml.jackson.core:jackson-core` | 2026-05-27 |
| `SNYK-JAVA-COMFASTERXMLJACKSONCORE-15365924` | `com.fasterxml.jackson.core:jackson-core` | 2026-05-27 |
| `CVE-2026-33871` | `com.fasterxml.jackson.core:jackson-databind` | 2026-05-27 |
| `CVE-2026-33870` | `com.fasterxml.jackson.core:jackson-databind` | 2026-05-27 |

All HIGH, 30-day expiry per the policy enforced by `.github/scripts/validate_allowlist.py`.

## Risk justification

- Jackson is a Java library; this base image runs Python at the application layer. Jackson is transitive in the base (likely via Java tooling shipped with the runtime sidecar) and **dependent connector apps do not invoke Jackson code paths at runtime**.
- Exposure is bounded to whatever in-base process loads the affected Jackson modules. None known so far.
- No upstream fix exists ("No fix available" per Snyk); waiting for either an upstream Jackson patch or a base rebuild to drop the dependency.
- Worth re-validating at expiry — these may be false-positive flags against unused code paths.

## Test plan

- [ ] Allowlist validator (`.github/scripts/validate_allowlist.py`) passes
- [ ] After merge, retry the blocked publish — confirm "Scan Failed" → "Draft" transition

## Out-of-scope follow-ups

1. Investigate which Java-bundled tool in the base actually pulls Jackson. May allow removing it entirely, eliminating the CVE class.
2. Re-evaluate at expiry — confirm whether the modules are actually loaded; may be removable as false positive.