### PR TITLE
fix(ci): skip allowlist approval check on PR open

### DIFF
--- a/.github/workflows/allowlist-approval.yaml
+++ b/.github/workflows/allowlist-approval.yaml
@@ -1,21 +1,21 @@
 # Allowlist Approval Gate — enforces that changes to .security/ are approved
 # by a designated approver, not just any code reviewer.
 #
-# Triggers on every PR and every review submission. Checks if the PR touches
-# .security/ files; if not, exits early with success (so it doesn't block
-# unrelated PRs when set as a required status check).
+# Triggers only on review submission (not PR open/sync) — a freshly opened PR
+# has no reviews yet, so running on `pull_request` would always fail noisily.
+# Enforcement happens when a review is submitted: if the PR touches .security/
+# and no authorized approver has approved, the check fails.
 #
 # The authorized approver list is read from .security/approvers.json on the
 # BASE branch (main), not the PR branch — so adding yourself to the approver
 # list in a PR doesn't let you self-approve.
 #
-# Make this a REQUIRED STATUS CHECK on main to enforce.
+# Pair this with branch protection requiring at least one approving review
+# on main, so a .security/ PR cannot merge without a review event firing.
 #
 name: Allowlist Approval
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   pull_request_review:
     types: [submitted]
 


### PR DESCRIPTION
## Summary

- Removes the `pull_request: [opened, synchronize, reopened]` trigger from `Allowlist Approval` workflow.
- The check now runs only on `pull_request_review: submitted`.
- Reason: at PR open there are no reviews yet, so the check would always fail noisily for `.security/`-touching PRs (e.g. https://github.com/atlanhq/application-sdk/actions/runs/25000392250).

## Tradeoff / Security note

Enforcement now depends on:
1. Branch protection on `main` requiring **≥1 approving review** — so a `.security/` PR cannot merge without a review event firing the check.
2. The `pull_request_review: submitted` trigger — fails the check if the approver isn't on the allowlist.

Please confirm branch protection on `main` requires at least one approving review before merging this. cc `#bu-security-and-it`

## Test plan
- [ ] Verify `Allowlist Approval` no longer runs on PR open
- [ ] Verify it still runs and enforces on review submission for a `.security/`-touching PR
- [ ] Confirm branch protection on `main` requires ≥1 approving review