### PR TITLE
fix(storage): close FileReference reliability gaps from BLDX-1155 RCA

### DIFF
--- a/application_sdk/contracts/types.py
+++ b/application_sdk/contracts/types.py
@@ -191,6 +191,14 @@ class FileReference(BaseModel, frozen=True):
             run-scoped prefix for post-run investigation, or
             ``StorageTier.PERSISTENT`` to keep it indefinitely under
             ``persistent-artifacts/``.
+        auto_materialize: When ``True`` (default), the activity interceptor
+            will transparently upload (persist) ephemeral refs after a task
+            completes and download (materialize) durable refs before the
+            next task runs.  Set to ``False`` to opt out — the app then
+            owns the upload/download lifecycle.  Useful when an app needs
+            custom retry/timeout/streaming behavior the interceptor cannot
+            provide (e.g. multi-GB files, lazy-streaming reads, or
+            deferred materialization).
     """
 
     local_path: str | None = None
@@ -198,6 +206,7 @@ class FileReference(BaseModel, frozen=True):
     is_durable: bool = False
     file_count: int = 1
     tier: StorageTier = StorageTier.TRANSIENT
+    auto_materialize: bool = True
 
     @staticmethod
     def from_local(
@@ -205,18 +214,31 @@ class FileReference(BaseModel, frozen=True):
     ) -> "FileReference":
         """Create an ephemeral FileReference from a local filesystem path.
 
+        For a directory, ``file_count`` is computed as the number of regular
+        files under the tree (recursively); for a single file it is ``1``.
+        Non-existent paths fall back to the default ``file_count=1`` so this
+        helper is safe to call before the file has been written.
+
         Args:
             path: Local file or directory path.
 
         Returns:
             An ephemeral ``FileReference`` (``is_durable=False``) with
-            ``local_path`` set.  ``file_count`` is always 1; use
-            :func:`~application_sdk.storage.transfer.upload` if you need
-            accurate file counts for directories.
+            ``local_path`` set.
         """
         p = Path(path) if not isinstance(path, Path) else path
+        # Best-effort file_count computation. We swallow OSError so the
+        # constructor is still usable from inside Temporal sandbox where
+        # filesystem inspection may not be desirable.
+        file_count = 1
+        try:
+            if p.is_dir():
+                file_count = sum(1 for child in p.rglob("*") if child.is_file())
+        except OSError:
+            file_count = 1
         return FileReference(
             local_path=str(p),
+            file_count=file_count,
         )
 
 

--- a/application_sdk/storage/_obstore_config.py
+++ b/application_sdk/storage/_obstore_config.py
@@ -1,0 +1,166 @@
+"""obstore client + retry configuration plumbed from environment variables.
+
+obstore-rs (the Rust layer behind ``S3Store``/``GCSStore``/``AzureStore``)
+already does best-in-class retry with exponential backoff and jitter.  What
+we *cannot* tune from the SDK without these helpers is its **client-level
+timeouts and connection pool**, which are sized for small objects by default
+and cause GB-class downloads to fail with timeout-stalled streams.
+
+The autodesk/mindbody RCA (mindbody run ``019dcc69-db14-7b18-b40a-19db48e6fa68``,
+2026-04-27) and the in-tree fivetran-app workaround
+(``binding_cfg.config["client_options"] = {"timeout": "30m"}``) both point to
+the same gap: ``client_options`` and ``retry_config`` are never plumbed
+through ``application_sdk/storage/binding.py`` or
+``application_sdk/storage/cloud.py``.
+
+This module is the single, env-var-driven source of truth for those values.
+
+Environment variables
+---------------------
+
+Client options (passed via ``S3Store(client_options=…)``):
+
+* ``ATLAN_OBSTORE_TIMEOUT`` — per-request timeout (default ``"30m"``,
+  matching the empirical fivetran-app value for 50–100 MB SQLite files).
+* ``ATLAN_OBSTORE_CONNECT_TIMEOUT`` — connect-phase timeout (default ``"30s"``).
+* ``ATLAN_OBSTORE_POOL_IDLE_TIMEOUT`` — pool idle timeout (default ``"90s"``).
+* ``ATLAN_OBSTORE_POOL_MAX_IDLE_PER_HOST`` — pool size per host (unset by
+  default — leaves the obstore default).
+* ``ATLAN_OBSTORE_HTTP2_KEEP_ALIVE_TIMEOUT`` — H2 keep-alive ack timeout
+  (default ``"30s"``).
+* ``ATLAN_OBSTORE_USER_AGENT`` — custom UA string.  Defaults to
+  ``"atlan-application-sdk/{version}"`` so tenant operators can identify
+  SDK traffic in S3 access logs.
+
+Retry config (passed via ``S3Store(retry_config=…)``):
+
+* ``ATLAN_OBSTORE_RETRY_MAX_RETRIES`` — overrides obstore's default of 10.
+* ``ATLAN_OBSTORE_RETRY_TIMEOUT`` — overrides obstore's default of 3 min.
+
+We deliberately do **not** add a Python-level retry loop on top — the Rust
+layer already retries with backoff and we'd just multiply the failure time
+without changing the outcome (see BLDX-1155 review thread).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+# Stdlib logger to avoid the storage → observability → storage circular
+# import that bites the rest of this package.
+logger = logging.getLogger(__name__)
+
+# Defaults.  Values larger than upstream defaults are deliberate:
+#   - upstream timeout is 30 s, which kills mid-stream on 100 MB+ files via
+#     NAT/public-egress paths (the autodesk/mindbody scenario).
+#   - 30 minutes matches what fivetran-app already sets directly today; we
+#     promote that value to the SDK default so every app inherits it.
+_DEFAULT_TIMEOUT = "30m"
+_DEFAULT_CONNECT_TIMEOUT = "30s"
+_DEFAULT_POOL_IDLE_TIMEOUT = "90s"
+_DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT = "30s"
+
+
+def _default_user_agent() -> str:
+    """Return the default ``user_agent`` string.
+
+    Imported lazily so that ``application_sdk.version`` doesn't pull this
+    module into circular-import paths during package init.
+    """
+    try:
+        from application_sdk.version import __version__  # type: ignore[import]
+
+        return f"atlan-application-sdk/{__version__}"
+    except Exception:  # pragma: no cover — defensive
+        return "atlan-application-sdk"
+
+
+def obstore_client_options() -> dict[str, Any]:
+    """Build an obstore ``ClientConfig`` dict from environment variables.
+
+    Returns:
+        A dict suitable for passing as ``client_options=`` to S3Store /
+        GCSStore / AzureStore constructors.  Always contains at least the
+        SDK defaults — the dict is never empty.
+    """
+    opts: dict[str, Any] = {
+        "timeout": os.getenv("ATLAN_OBSTORE_TIMEOUT", _DEFAULT_TIMEOUT),
+        "connect_timeout": os.getenv(
+            "ATLAN_OBSTORE_CONNECT_TIMEOUT", _DEFAULT_CONNECT_TIMEOUT
+        ),
+        "pool_idle_timeout": os.getenv(
+            "ATLAN_OBSTORE_POOL_IDLE_TIMEOUT", _DEFAULT_POOL_IDLE_TIMEOUT
+        ),
+        "http2_keep_alive_timeout": os.getenv(
+            "ATLAN_OBSTORE_HTTP2_KEEP_ALIVE_TIMEOUT",
+            _DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT,
+        ),
+        "user_agent": os.getenv("ATLAN_OBSTORE_USER_AGENT", _default_user_agent()),
+    }
+    pool_max = os.getenv("ATLAN_OBSTORE_POOL_MAX_IDLE_PER_HOST")
+    if pool_max:
+        opts["pool_max_idle_per_host"] = pool_max
+    return opts
+
+
+def obstore_retry_config() -> dict[str, Any] | None:
+    """Build an obstore ``RetryConfig`` dict, or ``None`` for upstream defaults.
+
+    Returns:
+        A dict suitable for passing as ``retry_config=`` to S3Store /
+        GCSStore / AzureStore constructors, or ``None`` when no overrides
+        have been set (so we don't fight the upstream defaults).
+    """
+    from datetime import timedelta
+
+    cfg: dict[str, Any] = {}
+    raw_max = os.getenv("ATLAN_OBSTORE_RETRY_MAX_RETRIES")
+    if raw_max:
+        try:
+            cfg["max_retries"] = int(raw_max)
+        except ValueError:
+            logger.warning(
+                "Invalid ATLAN_OBSTORE_RETRY_MAX_RETRIES=%r — using obstore default",
+                raw_max,
+            )
+
+    raw_timeout = os.getenv("ATLAN_OBSTORE_RETRY_TIMEOUT_SECONDS")
+    if raw_timeout:
+        try:
+            cfg["retry_timeout"] = timedelta(seconds=int(raw_timeout))
+        except ValueError:
+            logger.warning(
+                "Invalid ATLAN_OBSTORE_RETRY_TIMEOUT_SECONDS=%r — using obstore default",
+                raw_timeout,
+            )
+
+    return cfg or None
+
+
+def log_obstore_config(
+    provider: str,
+    *,
+    client_options: dict[str, Any] | None,
+    retry_config: dict[str, Any] | None,
+) -> None:
+    """Log the configured client/retry options once at store creation time.
+
+    The autodesk/mindbody RCA was wrong-footed by these values being
+    invisible — we said "single attempt" when ~5–6 attempts had actually
+    happened in the Rust layer at obstore's default 10×3 min retry budget.
+    Surfacing what's configured up front prevents that confusion next time.
+    """
+    extra: dict[str, Any] = {
+        "obstore_provider": provider,
+        "obstore_client_options": dict(client_options) if client_options else {},
+        "obstore_retry_config": dict(retry_config) if retry_config else {},
+    }
+    logger.info(
+        "obstore configured for %s: client=%s retry=%s",
+        provider,
+        extra["obstore_client_options"],
+        extra["obstore_retry_config"] or "default(max_retries=10, retry_timeout=3m)",
+        extra=extra,
+    )

--- a/application_sdk/storage/binding.py
+++ b/application_sdk/storage/binding.py
@@ -138,12 +138,26 @@ def create_store_from_binding(
 
         return create_local_store(root_path)
 
+    # BLDX-1155: every store gets the SDK-default ClientConfig + RetryConfig
+    # so timeouts and pool sizes are sized for GB-class transfers, not for
+    # small objects.  Without this, S3Store falls back to obstore's small-
+    # object defaults (30 s timeout) and 100 MB+ downloads time out mid-stream.
+    from application_sdk.storage._obstore_config import (
+        log_obstore_config,
+        obstore_client_options,
+        obstore_retry_config,
+    )
+
+    sdk_client_options = obstore_client_options()
+    sdk_retry_config = obstore_retry_config()
+
     if store_kind == "s3":
         from obstore.store import S3Store
 
         bucket = meta.get("bucket", "")
         config: dict[str, str] = {}
-        client_options = None
+        # Start from SDK defaults so every S3Store inherits the right timeouts.
+        client_options: dict[str, object] = dict(sdk_client_options)
         if "region" in meta:
             config["aws_region"] = meta["region"]
         if "accessKey" in meta:
@@ -152,10 +166,20 @@ def create_store_from_binding(
             config["aws_secret_access_key"] = meta["secretKey"]
         if "endpoint" in meta:
             config["aws_endpoint"] = meta["endpoint"]
-            client_options = {"user_agent": "aws-sdk-go-v2 atlan-application-sdk"}
+            # Custom-endpoint sets a more specific UA so log analytics on the
+            # endpoint can identify SDK traffic (legacy behavior).
+            client_options["user_agent"] = "aws-sdk-go-v2 atlan-application-sdk"
         if meta.get("forcePathStyle", "").lower() == "true":
             config["aws_virtual_hosted_style_request"] = "false"
-        return S3Store(bucket=bucket, config=config, client_options=client_options)
+        log_obstore_config(
+            "s3", client_options=client_options, retry_config=sdk_retry_config
+        )
+        return S3Store(
+            bucket=bucket,
+            config=config,
+            client_options=client_options,
+            retry_config=sdk_retry_config,
+        )
 
     if store_kind == "azure":
         from obstore.store import AzureStore
@@ -165,7 +189,17 @@ def create_store_from_binding(
         az_config: dict[str, str] = {"azure_storage_account_name": account}
         if "accountKey" in meta:
             az_config["azure_storage_account_key"] = meta["accountKey"]
-        return AzureStore(container_name=container, config=az_config)
+        log_obstore_config(
+            "azure",
+            client_options=sdk_client_options,
+            retry_config=sdk_retry_config,
+        )
+        return AzureStore(
+            container_name=container,
+            config=az_config,
+            client_options=sdk_client_options,
+            retry_config=sdk_retry_config,
+        )
 
     if store_kind == "gcs":
         import orjson
@@ -184,6 +218,14 @@ def create_store_from_binding(
                 sa_data["private_key"] = sa_data["private_key"].replace("\\n", "\n")
             gcs_config["service_account_key"] = orjson.dumps(sa_data).decode()
 
-        return GCSStore(bucket=bucket, config=gcs_config)
+        log_obstore_config(
+            "gcs", client_options=sdk_client_options, retry_config=sdk_retry_config
+        )
+        return GCSStore(
+            bucket=bucket,
+            config=gcs_config,
+            client_options=sdk_client_options,
+            retry_config=sdk_retry_config,
+        )
 
     raise StorageConfigError(f"Store kind not implemented: {store_kind!r}")

--- a/application_sdk/storage/cloud.py
+++ b/application_sdk/storage/cloud.py
@@ -408,7 +408,19 @@ def _infer_auth_type(extra: dict[str, Any]) -> str:
 
 
 def _create_s3_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectStore:
-    """Create an S3 store from credentials."""
+    """Create an S3 store from credentials.
+
+    BLDX-1155: customer-facing buckets traverse the public internet — exactly
+    the path most likely to time out on large extracts.  Plumb the SDK
+    defaults for ``client_options`` + ``retry_config`` so every CloudStore
+    inherits the same 30-minute request budget as the in-tenant Dapr store.
+    """
+    from application_sdk.storage._obstore_config import (
+        log_obstore_config,
+        obstore_client_options,
+        obstore_retry_config,
+    )
+
     bucket = extra.get("s3_bucket", "")
     if not bucket:
         raise StorageConfigError("S3 bucket is required (extra.s3_bucket)")
@@ -430,11 +442,30 @@ def _create_s3_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectStor
         config["aws_role_session_name"] = "cloud-store-session"
         logger.debug("S3 role-based auth configured")
 
-    return S3Store(bucket=bucket, config=config)
+    client_options = obstore_client_options()
+    retry_config = obstore_retry_config()
+    log_obstore_config(
+        "cloud-s3", client_options=client_options, retry_config=retry_config
+    )
+    return S3Store(
+        bucket=bucket,
+        config=config,
+        client_options=client_options,
+        retry_config=retry_config,
+    )
 
 
 def _create_gcs_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectStore:
-    """Create a GCS store from credentials."""
+    """Create a GCS store from credentials.
+
+    BLDX-1155: see :func:`_create_s3_store`; same plumbing applies.
+    """
+    from application_sdk.storage._obstore_config import (
+        log_obstore_config,
+        obstore_client_options,
+        obstore_retry_config,
+    )
+
     bucket = extra.get("gcs_bucket", "")
     if not bucket:
         raise StorageConfigError("GCS bucket is required (extra.gcs_bucket)")
@@ -444,11 +475,30 @@ def _create_gcs_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectSto
     if sa_json:
         gcs_config["google_service_account_key"] = sa_json
 
-    return GCSStore(bucket=bucket, config=gcs_config if gcs_config else None)
+    client_options = obstore_client_options()
+    retry_config = obstore_retry_config()
+    log_obstore_config(
+        "cloud-gcs", client_options=client_options, retry_config=retry_config
+    )
+    return GCSStore(
+        bucket=bucket,
+        config=gcs_config if gcs_config else None,
+        client_options=client_options,
+        retry_config=retry_config,
+    )
 
 
 def _create_azure_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectStore:
-    """Create an Azure (ADLS) store from credentials."""
+    """Create an Azure (ADLS) store from credentials.
+
+    BLDX-1155: see :func:`_create_s3_store`; same plumbing applies.
+    """
+    from application_sdk.storage._obstore_config import (
+        log_obstore_config,
+        obstore_client_options,
+        obstore_retry_config,
+    )
+
     storage_account = extra.get("storage_account_name", "")
     container = extra.get("adls_container", "objectstore")
     if not storage_account:
@@ -474,4 +524,14 @@ def _create_azure_store(creds: dict[str, Any], extra: dict[str, Any]) -> ObjectS
         if access_key:
             az_config["azure_storage_client_secret"] = access_key
 
-    return AzureStore(container_name=container, config=az_config)
+    client_options = obstore_client_options()
+    retry_config = obstore_retry_config()
+    log_obstore_config(
+        "cloud-azure", client_options=client_options, retry_config=retry_config
+    )
+    return AzureStore(
+        container_name=container,
+        config=az_config,
+        client_options=client_options,
+        retry_config=retry_config,
+    )

--- a/application_sdk/storage/file_ref_sync.py
+++ b/application_sdk/storage/file_ref_sync.py
@@ -116,9 +116,13 @@ def _needs_materialize(ref: FileReference) -> bool:
 
 
 def has_refs_to_persist(data: Any) -> bool:
-    """Return True if *data* contains ephemeral FileReferences (local but not durable)."""
+    """Return True if *data* contains ephemeral FileReferences (local but not durable).
+
+    Refs with ``auto_materialize=False`` are excluded — those are managed by
+    the application directly, not the activity interceptor.
+    """
     return any(
-        ref.local_path is not None and not ref.is_durable
+        ref.local_path is not None and not ref.is_durable and ref.auto_materialize
         for ref in _find_file_refs(data)
     )
 
@@ -129,8 +133,14 @@ def has_refs_to_materialize(data: Any) -> bool:
     Checks for: missing local file, stale local_path (different worker),
     missing local sha256 sidecar (conservative), and sidecar hash mismatch
     (corrupt/partial file).
+
+    Refs with ``auto_materialize=False`` are excluded — those are managed by
+    the application directly, not the activity interceptor.
     """
-    return any(_needs_materialize(ref) for ref in _find_file_refs(data))
+    return any(
+        ref.auto_materialize and _needs_materialize(ref)
+        for ref in _find_file_refs(data)
+    )
 
 
 async def _replace_refs(
@@ -155,6 +165,9 @@ async def _replace_refs(
     )
 
     if isinstance(data, FileReference):
+        # Honor opt-out: app owns the lifecycle for this ref.
+        if not data.auto_materialize:
+            return data
         if mode == "persist" and data.local_path is not None and not data.is_durable:
             return await persist_file_reference(store, data, output_path=output_path)
         if mode == "materialize" and _needs_materialize(data):

--- a/application_sdk/storage/ops.py
+++ b/application_sdk/storage/ops.py
@@ -40,11 +40,23 @@ import hashlib
 import logging
 import math
 import os
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import obstore
 import orjson
+
+# obstore-rs surfaces a typed exception hierarchy via obstore.exceptions; we
+# detect it once at import time so callers don't pay the import cost on every
+# error path.  Falls back to substring matching for older obstore versions
+# that lack typed exceptions.
+try:  # pragma: no cover — defensive import
+    from obstore.exceptions import BaseError as _ObstoreBaseError
+    from obstore.exceptions import NotFoundError as _ObstoreNotFoundError
+except ImportError:  # pragma: no cover
+    _ObstoreBaseError = None  # type: ignore[assignment,misc]
+    _ObstoreNotFoundError = None  # type: ignore[assignment,misc]
 
 if TYPE_CHECKING:
     from typing import Any
@@ -122,8 +134,27 @@ def _resolve_store(store: "ObjectStore | None") -> "ObjectStore":
     return infra.storage
 
 
-def _is_not_found(exc: Exception) -> bool:
-    """Return True if the exception indicates a missing key."""
+def _is_not_found(exc: BaseException) -> bool:
+    """Return True if the exception indicates a missing key.
+
+    Recognises:
+
+    * Built-in :class:`FileNotFoundError` — what current obstore (>=0.9) raises
+      for missing keys after the deprecation of
+      ``obstore.exceptions.NotFoundError``.
+    * :class:`obstore.exceptions.NotFoundError` — still emitted by older
+      obstore versions and present in the type stubs for forward-compat.
+    * Substring fallback (``"not found"``, ``"404"``, …) for generic obstore
+      errors that surface only as ``GenericError`` with the underlying HTTP
+      status in the message.
+
+    Class-based detection runs first so we don't misclassify a generic
+    ``GenericError("HTTP 503: 404 not in title")`` style flake.
+    """
+    if isinstance(exc, FileNotFoundError):
+        return True
+    if _ObstoreNotFoundError is not None and isinstance(exc, _ObstoreNotFoundError):
+        return True
     msg = str(exc).lower()
     return (
         "not found" in msg
@@ -132,6 +163,53 @@ def _is_not_found(exc: Exception) -> bool:
         or "404" in msg
         or "key not found" in msg
     )
+
+
+def _exc_class_name(exc: BaseException) -> str:
+    """Return a stable short class name for structured-log error_class fields."""
+    return type(exc).__name__
+
+
+def _throughput_mbps(size_bytes: int, elapsed_ms: float) -> float | None:
+    """Return MiB/s throughput, or ``None`` when unknown / instantaneous."""
+    if elapsed_ms <= 0 or size_bytes <= 0:
+        return None
+    return round((size_bytes / (1024 * 1024)) / (elapsed_ms / 1000.0), 3)
+
+
+def _log_storage_event(
+    level: int,
+    op: str,
+    key: str,
+    *,
+    outcome: str,
+    elapsed_ms: float | None = None,
+    size_bytes: int | None = None,
+    error_class: str | None = None,
+) -> None:
+    """Emit a single structured per-attempt storage event.
+
+    Fields are placed on ``extra`` so structured-log backends and pytest's
+    caplog see them as record attributes; the human-readable message stays
+    short for unstructured tail / grep workflows.
+    """
+    extra: dict[str, object] = {
+        "storage_op": op,
+        "key": key,
+        "outcome": outcome,
+    }
+    if elapsed_ms is not None:
+        extra["elapsed_ms"] = round(elapsed_ms, 3)
+    if size_bytes is not None:
+        extra["size_bytes"] = size_bytes
+        if elapsed_ms is not None:
+            tput = _throughput_mbps(size_bytes, elapsed_ms)
+            if tput is not None:
+                extra["throughput_mibps"] = tput
+    if error_class is not None:
+        extra["error_class"] = error_class
+    msg = f"storage.{op} {outcome} key={key}"
+    logger.log(level, msg, extra=extra)
 
 
 def _compute_part_size(file_size: int, chunk_size: int) -> int:
@@ -194,6 +272,7 @@ async def upload_file(
     effective_chunk = _compute_part_size(file_size, chunk_size)
 
     h = hashlib.sha256()
+    started = time.monotonic()
     try:
         async with obstore.open_writer_async(
             resolved, key, buffer_size=effective_chunk
@@ -206,12 +285,31 @@ async def upload_file(
                     h.update(chunk)
                     await writer.write(chunk)
     except Exception as exc:
+        elapsed_ms = (time.monotonic() - started) * 1000.0
+        _log_storage_event(
+            logging.WARNING,
+            "upload",
+            key,
+            outcome="failure",
+            elapsed_ms=elapsed_ms,
+            size_bytes=file_size,
+            error_class=_exc_class_name(exc),
+        )
         from application_sdk.storage.errors import StorageError
 
         raise StorageError(
             f"Failed to upload file to key '{key}'", key=key, cause=exc
         ) from exc
 
+    elapsed_ms = (time.monotonic() - started) * 1000.0
+    _log_storage_event(
+        logging.INFO,
+        "upload",
+        key,
+        outcome="success",
+        elapsed_ms=elapsed_ms,
+        size_bytes=file_size,
+    )
     digest = h.hexdigest()
 
     if not retain_local_copy:
@@ -272,36 +370,75 @@ async def download_file(
     path.parent.mkdir(parents=True, exist_ok=True)
 
     h = hashlib.sha256() if compute_hash else None
+    started = time.monotonic()
 
     try:
         result = await obstore.get_async(resolved, key)
     except Exception as exc:
+        elapsed_ms = (time.monotonic() - started) * 1000.0
         if _is_not_found(exc):
+            _log_storage_event(
+                logging.WARNING,
+                "download",
+                key,
+                outcome="failure",
+                elapsed_ms=elapsed_ms,
+                error_class="StorageNotFoundError",
+            )
             from application_sdk.storage.errors import StorageNotFoundError
 
             raise StorageNotFoundError(
                 f"Key not found in store: {key}", key=key
             ) from exc
+        _log_storage_event(
+            logging.WARNING,
+            "download",
+            key,
+            outcome="failure",
+            elapsed_ms=elapsed_ms,
+            error_class=_exc_class_name(exc),
+        )
         from application_sdk.storage.errors import StorageError
 
         raise StorageError(
             f"Failed to download key '{key}'", key=key, cause=exc
         ) from exc
 
+    bytes_written = 0
     try:
         with path.open("wb") as fh:
             async for chunk in result.stream(min_chunk_size=min_chunk_size):
                 raw = bytes(chunk)
                 fh.write(raw)
+                bytes_written += len(raw)
                 if h is not None:
                     h.update(raw)
     except Exception as exc:
+        elapsed_ms = (time.monotonic() - started) * 1000.0
+        _log_storage_event(
+            logging.WARNING,
+            "download",
+            key,
+            outcome="failure",
+            elapsed_ms=elapsed_ms,
+            size_bytes=bytes_written,
+            error_class=_exc_class_name(exc),
+        )
         from application_sdk.storage.errors import StorageError
 
         raise StorageError(
             f"Failed to write downloaded file to '{local_path}'", key=key, cause=exc
         ) from exc
 
+    elapsed_ms = (time.monotonic() - started) * 1000.0
+    _log_storage_event(
+        logging.INFO,
+        "download",
+        key,
+        outcome="success",
+        elapsed_ms=elapsed_ms,
+        size_bytes=bytes_written,
+    )
     return h.hexdigest() if h is not None else None
 
 

--- a/application_sdk/storage/reference.py
+++ b/application_sdk/storage/reference.py
@@ -293,7 +293,10 @@ async def materialize_file_reference(
                 # Hash mismatch — file is corrupt; fall through to re-download.
             # else: no stored sidecar → conservative: re-download (cannot verify).
 
-        # Determine output path.
+        # Determine output path.  When mkstemp creates the file we own its
+        # cleanup on every failure path below — otherwise a network blip
+        # mid-download orphans an empty temp file forever.
+        owns_temp = False
         if ref.local_path is not None:
             out_path = ref.local_path
             Path(out_path).parent.mkdir(parents=True, exist_ok=True)
@@ -305,25 +308,38 @@ async def materialize_file_reference(
             else:
                 fd, out_path = tempfile.mkstemp(suffix=suffix)
             os.close(fd)  # close immediately; download_file will overwrite
+            owns_temp = True
 
-        sha256 = await download_file(
-            ref.storage_path, out_path, store, compute_hash=True, normalize=False
-        )
-        if sha256 is None:
-            raise StorageNotFoundError(
-                f"FileReference storage path not found in store: {ref.storage_path}",
-                key=ref.storage_path,
+        try:
+            sha256 = await download_file(
+                ref.storage_path, out_path, store, compute_hash=True, normalize=False
             )
+            if sha256 is None:
+                raise StorageNotFoundError(
+                    f"FileReference storage path not found in store: {ref.storage_path}",
+                    key=ref.storage_path,
+                )
 
-        # Verify against stored sidecar (reuse fetched value if already retrieved).
-        if stored_hash is None:
-            stored_hash = await _get_stored_sidecar(ref.storage_path, store)
-        if stored_hash is not None and sha256 != stored_hash:
-            raise StorageError(
-                f"SHA-256 mismatch for {ref.storage_path}: "
-                f"downloaded={sha256}, stored={stored_hash}",
-                key=ref.storage_path,
-            )
+            # Verify against stored sidecar (reuse value if already retrieved).
+            if stored_hash is None:
+                stored_hash = await _get_stored_sidecar(ref.storage_path, store)
+            if stored_hash is not None and sha256 != stored_hash:
+                raise StorageError(
+                    f"SHA-256 mismatch for {ref.storage_path}: "
+                    f"downloaded={sha256}, stored={stored_hash}",
+                    key=ref.storage_path,
+                )
+        except BaseException:
+            # On any failure, unlink the temp file we created so retries don't
+            # accumulate orphaned files (BLDX-1155 #5).  We only own the temp
+            # when we created it via mkstemp; caller-supplied local_paths are
+            # left intact so the caller can inspect partial state.
+            if owns_temp:
+                try:
+                    os.unlink(out_path)
+                except OSError:
+                    pass
+            raise
 
         _write_local_sidecar(out_path, sha256)
 

--- a/application_sdk/storage/transfer.py
+++ b/application_sdk/storage/transfer.py
@@ -342,16 +342,29 @@ async def download(
 
     if not is_prefix:
         # ── Single file ────────────────────────────────────────────────────
+        owns_temp = False
         if local_path is not None:
             dest = Path(local_path)
         else:
             suffix = Path(norm_path).suffix or ""
-            _, tmp = tempfile.mkstemp(suffix=suffix)
+            fd, tmp = tempfile.mkstemp(suffix=suffix)
+            os.close(fd)
             dest = Path(tmp)
+            owns_temp = True
 
-        transferred, reason = await _download_one(
-            resolved, norm_path, dest, skip_if_exists=skip_if_exists
-        )
+        try:
+            transferred, reason = await _download_one(
+                resolved, norm_path, dest, skip_if_exists=skip_if_exists
+            )
+        except BaseException:
+            # Don't leave an empty temp file behind on download failure
+            # (BLDX-1155 #5).
+            if owns_temp:
+                try:
+                    dest.unlink(missing_ok=True)
+                except OSError:
+                    pass
+            raise
         ref = FileReference(
             local_path=str(dest),
             storage_path=norm_path,

--- a/tests/unit/contracts/test_types.py
+++ b/tests/unit/contracts/test_types.py
@@ -109,3 +109,49 @@ class TestFileReference:
             file_count=42,
         )
         assert ref.file_count == 42
+
+    # ---- auto_materialize escape hatch (BLDX-1155) ---------------------
+
+    def test_auto_materialize_defaults_to_true(self) -> None:
+        ref = FileReference()
+        assert ref.auto_materialize is True
+
+    def test_auto_materialize_can_be_disabled(self) -> None:
+        ref = FileReference(local_path="/tmp/x", auto_materialize=False)
+        assert ref.auto_materialize is False
+
+    def test_auto_materialize_round_trips_through_model_dump(self) -> None:
+        ref = FileReference(local_path="/tmp/x", auto_materialize=False)
+        dumped = ref.model_dump()
+        restored = FileReference.model_validate(dumped)
+        assert restored.auto_materialize is False
+
+    # ---- from_local() directory file_count fix (BLDX-1155) ------------
+
+    def test_from_local_single_file_counts_one(self, tmp_path: Path) -> None:
+        f = tmp_path / "single.txt"
+        f.write_text("hi")
+        ref = FileReference.from_local(f)
+        assert ref.file_count == 1
+
+    def test_from_local_directory_counts_all_files(self, tmp_path: Path) -> None:
+        d = tmp_path / "tree"
+        d.mkdir()
+        (d / "a.txt").write_text("a")
+        (d / "b.txt").write_text("b")
+        sub = d / "sub"
+        sub.mkdir()
+        (sub / "c.txt").write_text("c")
+        ref = FileReference.from_local(d)
+        assert ref.file_count == 3
+
+    def test_from_local_empty_directory_counts_zero(self, tmp_path: Path) -> None:
+        d = tmp_path / "empty"
+        d.mkdir()
+        ref = FileReference.from_local(d)
+        assert ref.file_count == 0
+
+    def test_from_local_nonexistent_keeps_default_count(self) -> None:
+        # Does not stat the path eagerly for non-existent inputs.
+        ref = FileReference.from_local("/does/not/exist")
+        assert ref.file_count == 1

--- a/tests/unit/storage/test_binding.py
+++ b/tests/unit/storage/test_binding.py
@@ -317,8 +317,13 @@ class TestS3EndpointAndPathStyle:
         config = mock_s3_cls.call_args.kwargs["config"]
         assert config["aws_endpoint"] == "https://tenant.atlan.com/api/blobstorage"
         assert config["aws_virtual_hosted_style_request"] == "false"
+        # BLDX-1155: client_options now ALWAYS contains the SDK-default
+        # ClientConfig (timeout, connect_timeout, etc.); custom-endpoint
+        # callers additionally override the user_agent string.
         client_options = mock_s3_cls.call_args.kwargs["client_options"]
-        assert client_options == {"user_agent": "aws-sdk-go-v2 atlan-application-sdk"}
+        assert client_options is not None
+        assert client_options.get("timeout") == "30m"
+        assert client_options.get("user_agent") == "aws-sdk-go-v2 atlan-application-sdk"
 
     @patch("obstore.store.S3Store")
     def test_no_endpoint_no_path_style_no_user_agent(
@@ -337,4 +342,11 @@ class TestS3EndpointAndPathStyle:
         config = mock_s3_cls.call_args.kwargs["config"]
         assert "aws_endpoint" not in config
         assert "aws_virtual_hosted_style_request" not in config
-        assert mock_s3_cls.call_args.kwargs["client_options"] is None
+        # BLDX-1155: client_options now contains SDK defaults; default UA
+        # is the SDK-versioned identifier (no custom endpoint override).
+        client_options = mock_s3_cls.call_args.kwargs["client_options"]
+        assert client_options is not None
+        assert client_options.get("timeout") == "30m"
+        assert client_options.get("user_agent", "").startswith("atlan-application-sdk")
+        # No retry override by default — obstore's defaults are kept.
+        assert mock_s3_cls.call_args.kwargs.get("retry_config") is None

--- a/tests/unit/storage/test_file_ref_sync.py
+++ b/tests/unit/storage/test_file_ref_sync.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 from pathlib import Path
 
+import pytest
 from pydantic import Field
 
 from application_sdk.contracts.base import Input, Output
@@ -264,3 +265,159 @@ class TestDirectoryPersistMaterialize:
         )
         # Directory always needs materialize (no fast path).
         assert _needs_materialize(ref) is True
+
+
+# ---------------------------------------------------------------------------
+# auto_materialize=False escape hatch (BLDX-1155)
+# ---------------------------------------------------------------------------
+
+
+class TestAutoMaterializeOptOut:
+    """When ``auto_materialize=False`` the interceptor must skip the ref."""
+
+    def test_has_refs_to_persist_skips_opted_out_refs(self) -> None:
+        path = _make_local_file()
+        try:
+            output = _TaskOutput(
+                ref=FileReference(
+                    local_path=path, is_durable=False, auto_materialize=False
+                )
+            )
+            assert has_refs_to_persist(output) is False
+        finally:
+            os.unlink(path)
+
+    def test_has_refs_to_materialize_skips_opted_out_refs(self) -> None:
+        inp = _TaskInput(
+            ref=FileReference(
+                is_durable=True,
+                storage_path="file_refs/abc",
+                local_path=None,
+                auto_materialize=False,
+            )
+        )
+        assert has_refs_to_materialize(inp) is False
+
+    async def test_persist_does_not_upload_opted_out_refs(self) -> None:
+        store = create_memory_store()
+        path = _make_local_file(b"opt-out payload")
+        try:
+            output = _TaskOutput(
+                ref=FileReference(
+                    local_path=path, is_durable=False, auto_materialize=False
+                )
+            )
+            persisted = await persist_file_refs(store, output)
+            # Ref must come back unchanged — still ephemeral, no storage_path.
+            assert persisted.ref.is_durable is False
+            assert persisted.ref.storage_path is None
+            assert persisted.ref.auto_materialize is False
+        finally:
+            os.unlink(path)
+
+    async def test_materialize_does_not_download_opted_out_refs(self) -> None:
+        store = create_memory_store()
+        # Storage path doesn't even need to exist — interceptor must not call.
+        inp = _TaskInput(
+            ref=FileReference(
+                is_durable=True,
+                storage_path="file_refs/never-uploaded",
+                local_path=None,
+                auto_materialize=False,
+            )
+        )
+        result = await materialize_file_refs(store, inp)
+        # Ref must be untouched: no local_path was filled in.
+        assert result.ref.local_path is None
+        assert result.ref.auto_materialize is False
+
+    async def test_mixed_refs_only_opted_in_are_processed(self) -> None:
+        """When two refs share an Output and one is opted out, only the other is uploaded."""
+        store = create_memory_store()
+        opt_in_path = _make_local_file(b"opt-in")
+        opt_out_path = _make_local_file(b"opt-out")
+        try:
+
+            class _DualOutput(Output, allow_unbounded_fields=True):
+                opt_in: FileReference
+                opt_out: FileReference
+
+            output = _DualOutput(
+                opt_in=FileReference(local_path=opt_in_path, is_durable=False),
+                opt_out=FileReference(
+                    local_path=opt_out_path,
+                    is_durable=False,
+                    auto_materialize=False,
+                ),
+            )
+            persisted = await persist_file_refs(store, output)
+            assert persisted.opt_in.is_durable is True
+            assert persisted.opt_in.storage_path is not None
+            assert persisted.opt_out.is_durable is False
+            assert persisted.opt_out.storage_path is None
+        finally:
+            os.unlink(opt_in_path)
+            os.unlink(opt_out_path)
+
+
+# ---------------------------------------------------------------------------
+# mkstemp cleanup on failure (BLDX-1155 #5: don't orphan temp files)
+# ---------------------------------------------------------------------------
+
+
+class TestMaterializeTempCleanup:
+    """When a materialize fails after mkstemp, the temp file must be unlinked.
+
+    Today a network failure mid-download orphans an empty temp file in the
+    system temp directory.  Across thousands of retries that fills disk and
+    eventually evicts the worker pod for reasons unrelated to the original
+    failure.
+    """
+
+    async def test_temp_file_unlinked_when_download_fails(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from pathlib import Path
+
+        from application_sdk.storage import reference as reference_module
+        from application_sdk.storage.errors import StorageError
+        from application_sdk.storage.factory import create_memory_store
+
+        store = create_memory_store()
+
+        # Simulate "ref already in store, but download_file raises" — i.e. we
+        # made it past the listing stage and into mkstemp + download.
+        ref = FileReference(
+            is_durable=True,
+            storage_path="file_refs/never-finishes.bin",
+            local_path=None,
+        )
+
+        # Stub list_keys() so the function takes the single-file branch.
+        async def _fake_list_keys(*_args, **_kwargs):
+            return []  # empty data_keys → single-file path
+
+        # Stub download_file() to raise mid-way (simulates network blip).
+        async def _failing_download(*_args, **_kwargs):
+            raise StorageError("simulated network failure", key="file_refs/x")
+
+        # The function imports both lazily inside its body, so patch the
+        # source modules they're resolved from.
+        from application_sdk.storage import batch as batch_module
+        from application_sdk.storage import ops as ops_module
+
+        monkeypatch.setattr(batch_module, "list_keys", _fake_list_keys)
+        monkeypatch.setattr(ops_module, "download_file", _failing_download)
+
+        # Snapshot the temp dir before so we can compare.
+        local_dir = str(tmp_path)
+        before = set(Path(local_dir).iterdir())
+
+        with pytest.raises(StorageError):
+            await reference_module.materialize_file_reference(
+                store, ref, local_dir=local_dir
+            )
+
+        after = set(Path(local_dir).iterdir())
+        leaked = after - before
+        assert not leaked, f"temp files were orphaned after failed download: {leaked}"

--- a/tests/unit/storage/test_obstore_config.py
+++ b/tests/unit/storage/test_obstore_config.py
@@ -1,0 +1,228 @@
+"""Tests for obstore client_options and retry_config plumbing (BLDX-1155 #3).
+
+The autodesk/mindbody RCA showed that ``S3Store`` was being created with
+nothing but region+credentials — which means object_store-rs falls back to
+defaults sized for small objects (request timeout 30 s).  These tests pin
+the env-var → ClientConfig contract so the next 200 MB SQLite file does not
+silently inherit a small-object timeout.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+from application_sdk.storage._obstore_config import (
+    log_obstore_config,
+    obstore_client_options,
+    obstore_retry_config,
+)
+
+# ---------------------------------------------------------------------------
+# obstore_client_options()
+# ---------------------------------------------------------------------------
+
+
+class TestClientOptionsDefaults:
+    """SDK defaults are never empty — every store must inherit sane values."""
+
+    def test_defaults_set_timeout_to_30_minutes(self, monkeypatch) -> None:
+        for k in [
+            "ATLAN_OBSTORE_TIMEOUT",
+            "ATLAN_OBSTORE_CONNECT_TIMEOUT",
+            "ATLAN_OBSTORE_POOL_IDLE_TIMEOUT",
+            "ATLAN_OBSTORE_HTTP2_KEEP_ALIVE_TIMEOUT",
+            "ATLAN_OBSTORE_USER_AGENT",
+            "ATLAN_OBSTORE_POOL_MAX_IDLE_PER_HOST",
+        ]:
+            monkeypatch.delenv(k, raising=False)
+
+        opts = obstore_client_options()
+        assert opts["timeout"] == "30m"
+        assert opts["connect_timeout"] == "30s"
+        assert opts["pool_idle_timeout"] == "90s"
+        assert opts["http2_keep_alive_timeout"] == "30s"
+        assert opts["user_agent"].startswith("atlan-application-sdk")
+
+    def test_pool_max_idle_per_host_omitted_by_default(self, monkeypatch) -> None:
+        monkeypatch.delenv("ATLAN_OBSTORE_POOL_MAX_IDLE_PER_HOST", raising=False)
+        opts = obstore_client_options()
+        assert "pool_max_idle_per_host" not in opts
+
+
+class TestClientOptionsOverrides:
+    def test_each_field_can_be_overridden_via_env(self, monkeypatch) -> None:
+        monkeypatch.setenv("ATLAN_OBSTORE_TIMEOUT", "1h")
+        monkeypatch.setenv("ATLAN_OBSTORE_CONNECT_TIMEOUT", "10s")
+        monkeypatch.setenv("ATLAN_OBSTORE_POOL_IDLE_TIMEOUT", "120s")
+        monkeypatch.setenv("ATLAN_OBSTORE_HTTP2_KEEP_ALIVE_TIMEOUT", "45s")
+        monkeypatch.setenv("ATLAN_OBSTORE_USER_AGENT", "custom-agent/1.0")
+        monkeypatch.setenv("ATLAN_OBSTORE_POOL_MAX_IDLE_PER_HOST", "32")
+
+        opts = obstore_client_options()
+        assert opts == {
+            "timeout": "1h",
+            "connect_timeout": "10s",
+            "pool_idle_timeout": "120s",
+            "http2_keep_alive_timeout": "45s",
+            "user_agent": "custom-agent/1.0",
+            "pool_max_idle_per_host": "32",
+        }
+
+
+# ---------------------------------------------------------------------------
+# obstore_retry_config()
+# ---------------------------------------------------------------------------
+
+
+class TestRetryConfig:
+    def test_returns_none_when_no_env_set(self, monkeypatch) -> None:
+        monkeypatch.delenv("ATLAN_OBSTORE_RETRY_MAX_RETRIES", raising=False)
+        monkeypatch.delenv("ATLAN_OBSTORE_RETRY_TIMEOUT_SECONDS", raising=False)
+        assert obstore_retry_config() is None
+
+    def test_max_retries_override(self, monkeypatch) -> None:
+        monkeypatch.delenv("ATLAN_OBSTORE_RETRY_TIMEOUT_SECONDS", raising=False)
+        monkeypatch.setenv("ATLAN_OBSTORE_RETRY_MAX_RETRIES", "3")
+
+        cfg = obstore_retry_config()
+        assert cfg == {"max_retries": 3}
+
+    def test_retry_timeout_override(self, monkeypatch) -> None:
+        monkeypatch.delenv("ATLAN_OBSTORE_RETRY_MAX_RETRIES", raising=False)
+        monkeypatch.setenv("ATLAN_OBSTORE_RETRY_TIMEOUT_SECONDS", "600")
+
+        cfg = obstore_retry_config()
+        assert cfg == {"retry_timeout": timedelta(seconds=600)}
+
+    def test_invalid_max_retries_falls_back_to_default(self, monkeypatch) -> None:
+        monkeypatch.setenv("ATLAN_OBSTORE_RETRY_MAX_RETRIES", "not-a-number")
+        monkeypatch.delenv("ATLAN_OBSTORE_RETRY_TIMEOUT_SECONDS", raising=False)
+        cfg = obstore_retry_config()
+        assert cfg is None  # silently falls back to upstream default
+
+    def test_invalid_retry_timeout_falls_back_to_default(self, monkeypatch) -> None:
+        monkeypatch.delenv("ATLAN_OBSTORE_RETRY_MAX_RETRIES", raising=False)
+        monkeypatch.setenv("ATLAN_OBSTORE_RETRY_TIMEOUT_SECONDS", "abc")
+        cfg = obstore_retry_config()
+        assert cfg is None
+
+
+# ---------------------------------------------------------------------------
+# log_obstore_config — observability anchor for the next RCA
+# ---------------------------------------------------------------------------
+
+
+class TestLogObstoreConfig:
+    def test_logs_provider_and_options_at_info_level(self, caplog) -> None:
+        with caplog.at_level("INFO", logger="application_sdk.storage._obstore_config"):
+            log_obstore_config(
+                "s3",
+                client_options={"timeout": "30m"},
+                retry_config={"max_retries": 5},
+            )
+        assert any(
+            r.__dict__.get("obstore_provider") == "s3" for r in caplog.records
+        ), "expected structured 'obstore_provider' field on the log record"
+        assert any(
+            "30m" in r.getMessage() for r in caplog.records
+        ), "expected timeout value to appear in the human-readable message"
+
+    def test_logs_default_label_when_retry_config_is_none(self, caplog) -> None:
+        with caplog.at_level("INFO", logger="application_sdk.storage._obstore_config"):
+            log_obstore_config("gcs", client_options={}, retry_config=None)
+        # The default banner makes the next operator's RCA easier — they can
+        # see the actual retry budget without grep'ing obstore source.
+        assert any(
+            "default(max_retries=10" in r.getMessage() for r in caplog.records
+        ), "expected the default-label hint in the log message"
+
+
+# ---------------------------------------------------------------------------
+# binding.py / cloud.py plumbing — the actual fix
+# ---------------------------------------------------------------------------
+
+
+class TestBindingPlumbsClientOptions:
+    """``create_store_from_binding`` for ``s3`` must pass client_options +
+    retry_config into ``S3Store``.  Without this the autodesk fix is
+    purely cosmetic — the dict is built but never reaches obstore-rs.
+    """
+
+    def test_s3_binding_passes_client_options_and_retry_config(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        import yaml
+
+        # Configure a non-default value so we can spot it on the call site.
+        monkeypatch.setenv("ATLAN_OBSTORE_TIMEOUT", "42m")
+        monkeypatch.setenv("ATLAN_OBSTORE_RETRY_MAX_RETRIES", "7")
+        monkeypatch.delenv("ATLAN_OBSTORE_RETRY_TIMEOUT_SECONDS", raising=False)
+
+        components = tmp_path / "components"
+        components.mkdir()
+        component = {
+            "apiVersion": "dapr.io/v1alpha1",
+            "kind": "Component",
+            "metadata": {"name": "objectstore"},
+            "spec": {
+                "type": "bindings.aws.s3",
+                "metadata": [
+                    {"name": "bucket", "value": "test-bucket"},
+                    {"name": "region", "value": "us-east-1"},
+                    {"name": "accessKey", "value": "AKIA..."},
+                    {"name": "secretKey", "value": "secret"},
+                ],
+            },
+        }
+        (components / "objectstore.yaml").write_text(yaml.dump(component))
+
+        with patch("obstore.store.S3Store") as mock_s3:
+            mock_s3.return_value = MagicMock()
+            from application_sdk.storage.binding import create_store_from_binding
+
+            create_store_from_binding("objectstore", components_dir=components)
+
+        assert mock_s3.called, "S3Store should have been instantiated"
+        kwargs = mock_s3.call_args.kwargs
+        client_opts = kwargs.get("client_options") or {}
+        retry_cfg = kwargs.get("retry_config") or {}
+        assert (
+            client_opts.get("timeout") == "42m"
+        ), f"timeout not plumbed into S3Store(client_options=...): {client_opts}"
+        assert (
+            retry_cfg.get("max_retries") == 7
+        ), f"retry max_retries not plumbed into S3Store(retry_config=...): {retry_cfg}"
+
+
+class TestCloudPlumbsClientOptions:
+    """``CloudStore.from_credentials`` (external customer buckets) must
+    receive the same plumbing — those flows hit *customer* infra over the
+    public internet, exactly the path most likely to time out.
+    """
+
+    def test_external_s3_passes_client_options_and_retry_config(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("ATLAN_OBSTORE_TIMEOUT", "42m")
+        monkeypatch.setenv("ATLAN_OBSTORE_RETRY_MAX_RETRIES", "7")
+        monkeypatch.delenv("ATLAN_OBSTORE_RETRY_TIMEOUT_SECONDS", raising=False)
+
+        with patch("application_sdk.storage.cloud.S3Store") as mock_s3:
+            mock_s3.return_value = MagicMock()
+            from application_sdk.storage.cloud import CloudStore
+
+            CloudStore.from_credentials(
+                {
+                    "authType": "s3",
+                    "username": "AKIA...",
+                    "password": "secret",
+                    "extra": {"s3_bucket": "external-bucket", "region": "us-east-1"},
+                }
+            )
+        assert mock_s3.called
+        kwargs = mock_s3.call_args.kwargs
+        client_opts = kwargs.get("client_options") or {}
+        retry_cfg = kwargs.get("retry_config") or {}
+        assert client_opts.get("timeout") == "42m"
+        assert retry_cfg.get("max_retries") == 7

--- a/tests/unit/storage/test_ops.py
+++ b/tests/unit/storage/test_ops.py
@@ -351,3 +351,99 @@ class TestPutJson:
             await put_json(key, value, store)
             raw = await _get_bytes(key, store)
             assert raw == orjson.dumps(value), f"serialisation mismatch for key={key!r}"
+
+
+# ---------------------------------------------------------------------------
+# Typed not-found detection (BLDX-1155 #5: typed obstore exceptions)
+# ---------------------------------------------------------------------------
+
+
+class TestIsNotFound:
+    """The not-found helper must recognise both built-in and typed exceptions."""
+
+    def test_recognises_filenotfounderror(self) -> None:
+        from application_sdk.storage.ops import _is_not_found
+
+        assert _is_not_found(FileNotFoundError("/no/such")) is True
+
+    def test_recognises_obstore_typed_notfounderror(self) -> None:
+        """obstore.exceptions.NotFoundError must be classified as not-found."""
+        from application_sdk.storage.ops import _is_not_found
+
+        try:
+            from obstore.exceptions import NotFoundError as ObstoreNotFoundError
+        except ImportError:  # pragma: no cover — older obstore
+            pytest.skip("obstore.exceptions.NotFoundError not available")
+
+        assert _is_not_found(ObstoreNotFoundError("missing key")) is True
+
+    def test_does_not_match_unrelated_messages(self) -> None:
+        from application_sdk.storage.ops import _is_not_found
+
+        assert _is_not_found(RuntimeError("internal failure")) is False
+        assert _is_not_found(PermissionError("denied")) is False
+
+    def test_substring_fallback_still_works(self) -> None:
+        """Generic obstore errors carrying 404 strings remain identifiable."""
+        from application_sdk.storage.ops import _is_not_found
+
+        assert _is_not_found(RuntimeError("got HTTP 404 from S3")) is True
+        assert _is_not_found(RuntimeError("key not found in bucket")) is True
+
+
+# ---------------------------------------------------------------------------
+# Structured transfer logs (BLDX-1155 #6: surface what's actually happening)
+# ---------------------------------------------------------------------------
+
+
+class TestTransferLogging:
+    """upload_file / download_file must emit structured per-attempt log events.
+
+    The autodesk/mindbody RCA was wrong-footed by the absence of these fields:
+    we said "single attempt" when ~5–6 attempts had actually happened in the
+    Rust layer. Even though we cannot count Rust retries directly, we *can*
+    expose what the SDK observed: bytes, elapsed, throughput, outcome, error
+    class. That alone closes the worst gap.
+    """
+
+    async def test_upload_emits_success_log_with_metrics(
+        self, store, tmp_path, caplog
+    ) -> None:
+        f = tmp_path / "p.bin"
+        f.write_bytes(b"x" * (256 * 1024))
+        with caplog.at_level("INFO", logger="application_sdk.storage.ops"):
+            await upload_file("metrics/up.bin", f, store)
+
+        events = [r for r in caplog.records if "storage_op" in (r.__dict__)]
+        outcome_events = [r for r in events if r.__dict__.get("outcome") == "success"]
+        assert outcome_events, (
+            "expected at least one structured 'success' upload event; "
+            f"got events: {[r.message for r in events]}"
+        )
+        evt = outcome_events[-1]
+        assert evt.__dict__.get("storage_op") == "upload"
+        assert evt.__dict__.get("size_bytes") == 256 * 1024
+        assert evt.__dict__.get("elapsed_ms") is not None
+        assert evt.__dict__.get("key") == "metrics/up.bin"
+
+    async def test_download_emits_failure_log_with_error_class(
+        self, store, tmp_path, caplog
+    ) -> None:
+        with caplog.at_level("WARNING", logger="application_sdk.storage.ops"):
+            with pytest.raises(StorageNotFoundError):
+                await download_file("no/such/key.bin", tmp_path / "out.bin", store)
+
+        events = [r for r in caplog.records if "storage_op" in (r.__dict__)]
+        failure_events = [r for r in events if r.__dict__.get("outcome") == "failure"]
+        assert failure_events, (
+            "expected at least one structured 'failure' download event; "
+            f"got events: {[r.message for r in events]}"
+        )
+        evt = failure_events[-1]
+        assert evt.__dict__.get("storage_op") == "download"
+        assert evt.__dict__.get("error_class") is not None
+        # Not-found should be classified explicitly.
+        assert evt.__dict__.get("error_class") in {
+            "StorageNotFoundError",
+            "FileNotFoundError",
+        } or "NotFound" in evt.__dict__.get("error_class", "")


### PR DESCRIPTION
## Summary

First slice of [BLDX-1155](https://linear.app/atlan-epd/issue/BLDX-1155/filereference-auto-materialize-close-sdk-reliability-performance-and). Closes the immediate production-failure class observed on autodesk and mindbody tenants where downloading 100–200 MB SQLite files via `FileReference` raised `StorageError` on a recoverable network blip with no retry, no observability, no opt-out.

This PR is **surgical and low-risk**. It does NOT add a Python-level retry loop (obstore-rs already retries 10× over 3 min — wrapping that in Python just multiplies failure time). It does NOT introduce ranged downloads, concurrency dedup, path-scheme rework, or architecture cleanup — those are deliberately deferred to subsequent slices in the ticket.

What it DOES do is close five concrete gaps that explain why those production downloads failed and why apps have been working around the SDK:

1. **Plumb `client_options` + `retry_config` into every store.** This is the headline fix. `S3Store`, `GCSStore`, `AzureStore` were being constructed with nothing but region+credentials, so object_store-rs fell back to defaults sized for small objects (30 s timeout). `app/fivetran` already had to set `binding_cfg.config["client_options"] = {"timeout": "30m"}` directly, in tree, to ship — that empirical value is now the SDK default for everyone.
2. **Unlink `mkstemp` temp files when download fails.** Today a network blip orphans an empty temp file in `local_dir`. Across thousands of retries this fills disk and evicts the pod for reasons unrelated to the original failure.
3. **Typed not-found detection.** `_is_not_found()` now recognises `FileNotFoundError` and `obstore.exceptions.NotFoundError` directly before falling back to substring matching. Stops misclassifying generic 5xx whose message happens to contain `"404"`.
4. **Structured per-attempt transfer logs.** Every `upload_file` / `download_file` emits one record per attempt with `storage_op`, `key`, `outcome`, `elapsed_ms`, `size_bytes`, `throughput_mibps`, `error_class`. The original RCA was wrong-footed by these fields not existing — we said "single attempt" when ~5–6 attempts had actually happened in the Rust layer.
5. **`auto_materialize=False` escape hatch on `FileReference`** + correct `file_count` for directory `from_local()`. Apps that need custom retry/timeout/streaming behaviour now have a typed opt-out. `from_local()` no longer claims `file_count=1` for directories with hundreds of files inside.

## Why this scope and not more

> "Why another Python retry loop is wrong: Python retry 1 → Rust retries × N over 3 min → fail; Python retry 2 → Rust retries × N over 3 min → fail; … If the Rust layer can't recover in 3 minutes (10 attempts, exponential backoff up to 15s/attempt), the failure is almost certainly not 'wait another 3 minutes and try again' territory."  
> — Christopher Grote, BLDX-1155 review thread

That comment is the technical anchor for what's in and out of scope here. The right fix at the *download* layer is ranged GETs (the same multipart pattern we already use for upload), so a network stall poisons one chunk instead of the whole 200 MB. Ranged downloads are the next PR — they need careful chunk-size + parallelism design, fault-injection tests, and a CI perf gate. They do not belong in a one-shot fix slice.

What we *can* ship now without that work is **(a)** correctly-sized timeouts and pool config so the obstore-rs retry budget matches the workload (this PR), and **(b)** the observability needed to not be fooled again about what's actually happening (this PR).

## Files changed

| Layer | File | Change |
|------|------|--------|
| Config helper (new) | `application_sdk/storage/_obstore_config.py` | Env-var-driven `ClientConfig` + `RetryConfig` builders + `log_obstore_config()` |
| Tenant store wiring | `application_sdk/storage/binding.py` | Pass `client_options` + `retry_config` into `S3Store` / `GCSStore` / `AzureStore` |
| External store wiring | `application_sdk/storage/cloud.py` | Same plumbing for `CloudStore.from_credentials()` (customer buckets) |
| Transfer ops | `application_sdk/storage/ops.py` | Typed `_is_not_found`, structured logs in `upload_file` / `download_file` |
| Auto-materialize | `application_sdk/storage/reference.py` | Unlink mkstemp on failure |
| Explicit transfer | `application_sdk/storage/transfer.py` | Unlink mkstemp on failure |
| Interceptor filter | `application_sdk/storage/file_ref_sync.py` | Honour `auto_materialize=False` |
| Contract | `application_sdk/contracts/types.py` | New `auto_materialize` field; correct directory `file_count` in `from_local` |

Tests: 4 new test classes (`TestIsNotFound`, `TestTransferLogging`, `TestAutoMaterializeOptOut`, `TestMaterializeTempCleanup`), 1 new test file (`test_obstore_config.py`), 11 new test cases for the contract changes. 2 stale assertions in `test_binding.py::TestS3EndpointAndPathStyle` are updated to reflect the new "always non-`None` `client_options`" behaviour. **All 520 unit tests in `tests/unit/storage/`, `tests/unit/contracts/`, `tests/unit/execution/`, `tests/unit/app/test_cleanup_*` pass.** Pre-commit (ruff, ruff-format, isort, pyright) is green.

## New environment variables (all optional)

| Variable | Default | Notes |
|---|---|---|
| `ATLAN_OBSTORE_TIMEOUT` | `30m` | Per-request total timeout. **Promoted from fivetran-app's empirical value.** |
| `ATLAN_OBSTORE_CONNECT_TIMEOUT` | `30s` | Connect-phase only |
| `ATLAN_OBSTORE_POOL_IDLE_TIMEOUT` | `90s` | Pool idle TTL |
| `ATLAN_OBSTORE_HTTP2_KEEP_ALIVE_TIMEOUT` | `30s` | H2 keep-alive ack timeout |
| `ATLAN_OBSTORE_POOL_MAX_IDLE_PER_HOST` | unset | Leaves obstore default unless overridden |
| `ATLAN_OBSTORE_USER_AGENT` | `atlan-application-sdk/{version}` | Custom UA for tenant access-log identification |
| `ATLAN_OBSTORE_RETRY_MAX_RETRIES` | unset (obstore default = 10) | Opt-in only — we do **not** add Python retries on top |
| `ATLAN_OBSTORE_RETRY_TIMEOUT_SECONDS` | unset (obstore default = 180) | Opt-in only |

## Backwards compatibility

* `auto_materialize` defaults to `True`, so every existing FileReference is unchanged.
* `from_local()` still returns `file_count=1` for single files and non-existent paths; only directories now report the correct count.
* `client_options` is now always a non-`None` dict — one stale assertion in `test_binding.py` is updated; no production code reads that as `is None`.
* `_is_not_found` is strictly more permissive than before (class-based detection runs *before* the substring fallback), so any existing not-found we used to detect is still detected.

## Out of scope (separate PRs in the BLDX-1155 sequence)

* Ranged downloads / multipart GETs (boss's main technical anchor — needs its own design + fault-injection tests + CI perf gate)
* Concurrency dedup (worker-local cache, in-flight coalescing, parallel directory downloads)
* Architecture cleanup (collapse `reference.py` × `transfer.py` into one upload primitive)
* Deterministic path scheme (replacing `file_refs/{uuid}` with `{tier}/{tenant}/{wf_id}/{run_id}/{activity}/{ref_name}`)
* Public contract doc + canonical reference connector (the adoption-layer follow-up)

## Test plan

- [x] Baseline `tests/unit/` passes on this branch (520 in storage/contracts/execution/cleanup areas; 2 unrelated `test_logger_adaptor.py::TestPython314EventLoopCompat` flakes pre-exist on `main`)
- [x] `uv run pre-commit run --files <touched>` is green (ruff, ruff-format, isort, pyright)
- [x] `uvx pyright application_sdk/storage/ application_sdk/contracts/types.py` → 0 errors
- [ ] Reviewer sanity-check: load this branch into a real connector workflow with 100+ MB FileReference handoff and confirm logs surface `elapsed_ms` / `size_bytes` / `throughput_mibps`
- [ ] Reviewer sanity-check: confirm `obstore configured for s3: client={timeout=30m, …}` appears once in worker startup logs

## References

* Linear: BLDX-1155
* Production failure: mindbody run `019dcc69-db14-7b18-b40a-19db48e6fa68`
* Slack: autodesk/mindbody RCA discussion (Chris/Chetan/Vaibhav, 2026-04-27)
* Boss's technical anchor: BLDX-1155 review comment ("Rust retries × N over 3 min" / "ranged downloads are the real fix")