### PR TITLE
fix(observability): HYP-851 handle unset OTel metric metadata

### DIFF
--- a/application_sdk/observability/metrics_adaptor.py
+++ b/application_sdk/observability/metrics_adaptor.py
@@ -242,7 +242,6 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
             Exception: If sending fails, logs error and continues
         """
         try:
-            description, unit = self._get_otel_instrument_metadata(metric_record)
             otel_attrs = {
                 k: v
                 for k, v in metric_record.labels.items()
@@ -251,30 +250,26 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
             if metric_record.type == MetricType.COUNTER:
                 counter = self.meter.create_counter(
                     name=metric_record.name,
-                    description=description,
-                    unit=unit,
+                    description=metric_record.otel_description,
+                    unit=metric_record.otel_unit,
                 )
                 counter.add(metric_record.value, otel_attrs)
             elif metric_record.type == MetricType.GAUGE:
                 gauge = self.meter.create_gauge(
                     name=metric_record.name,
-                    description=description,
-                    unit=unit,
+                    description=metric_record.otel_description,
+                    unit=metric_record.otel_unit,
                 )
                 gauge.set(metric_record.value, otel_attrs)
             elif metric_record.type == MetricType.HISTOGRAM:
                 histogram = self.meter.create_histogram(
                     name=metric_record.name,
-                    description=description,
-                    unit=unit,
+                    description=metric_record.otel_description,
+                    unit=metric_record.otel_unit,
                 )
                 histogram.record(metric_record.value, otel_attrs)
         except Exception:
             logging.error("Error sending metric to OpenTelemetry", exc_info=True)
-
-    @staticmethod
-    def _get_otel_instrument_metadata(metric_record: MetricRecord) -> tuple[str, str]:
-        return metric_record.description or "", metric_record.unit or ""
 
     def _log_to_console(self, metric_record: MetricRecord):
         """Log metric to console using the logger.

--- a/application_sdk/observability/metrics_adaptor.py
+++ b/application_sdk/observability/metrics_adaptor.py
@@ -242,6 +242,7 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
             Exception: If sending fails, logs error and continues
         """
         try:
+            description, unit = self._get_otel_instrument_metadata(metric_record)
             otel_attrs = {
                 k: v
                 for k, v in metric_record.labels.items()
@@ -250,26 +251,30 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
             if metric_record.type == MetricType.COUNTER:
                 counter = self.meter.create_counter(
                     name=metric_record.name,
-                    description=metric_record.description,
-                    unit=metric_record.unit,
+                    description=description,
+                    unit=unit,
                 )
                 counter.add(metric_record.value, otel_attrs)
             elif metric_record.type == MetricType.GAUGE:
-                gauge = self.meter.create_observable_gauge(
+                gauge = self.meter.create_gauge(
                     name=metric_record.name,
-                    description=metric_record.description,
-                    unit=metric_record.unit,
+                    description=description,
+                    unit=unit,
                 )
-                gauge.add(metric_record.value, otel_attrs)
+                gauge.set(metric_record.value, otel_attrs)
             elif metric_record.type == MetricType.HISTOGRAM:
                 histogram = self.meter.create_histogram(
                     name=metric_record.name,
-                    description=metric_record.description,
-                    unit=metric_record.unit,
+                    description=description,
+                    unit=unit,
                 )
                 histogram.record(metric_record.value, otel_attrs)
         except Exception:
             logging.error("Error sending metric to OpenTelemetry", exc_info=True)
+
+    @staticmethod
+    def _get_otel_instrument_metadata(metric_record: MetricRecord) -> tuple[str, str]:
+        return metric_record.description or "", metric_record.unit or ""
 
     def _log_to_console(self, metric_record: MetricRecord):
         """Log metric to console using the logger.

--- a/application_sdk/observability/models.py
+++ b/application_sdk/observability/models.py
@@ -40,6 +40,16 @@ class MetricRecord:
     description: Optional[str] = None
     unit: Optional[str] = None
 
+    @property
+    def otel_description(self) -> str:
+        """Return an OpenTelemetry-safe description for instrument creation."""
+        return self.description or ""
+
+    @property
+    def otel_unit(self) -> str:
+        """Return an OpenTelemetry-safe unit for instrument creation."""
+        return self.unit or ""
+
 
 @dataclass
 class TraceRecord:

--- a/tests/unit/observability/test_metrics_adaptor.py
+++ b/tests/unit/observability/test_metrics_adaptor.py
@@ -217,9 +217,7 @@ def test_send_to_otel_counter():
 def test_send_to_otel_gauge():
     """Test _send_to_otel() method with gauge metric."""
     with create_metrics_adapter() as metrics_adapter:
-        with mock.patch.object(
-            metrics_adapter.meter, "create_observable_gauge"
-        ) as mock_create:
+        with mock.patch.object(metrics_adapter.meter, "create_gauge") as mock_create:
             mock_gauge = mock.MagicMock()
             mock_create.return_value = mock_gauge
 
@@ -239,7 +237,7 @@ def test_send_to_otel_gauge():
                 description="Test gauge",
                 unit="count",
             )
-            mock_gauge.add.assert_called_once_with(42.0, {"test": "label"})
+            mock_gauge.set.assert_called_once_with(42.0, {"test": "label"})
 
 
 def test_send_to_otel_histogram():
@@ -268,6 +266,110 @@ def test_send_to_otel_histogram():
                 unit="count",
             )
             mock_histogram.record.assert_called_once_with(42.0, {"test": "label"})
+
+
+def test_send_to_otel_normalizes_optional_metadata():
+    """Test unset description and unit are normalized before creating OTel instruments."""
+    with create_metrics_adapter() as metrics_adapter:
+        with (
+            mock.patch.object(metrics_adapter.meter, "create_counter") as mock_counter,
+            mock.patch.object(metrics_adapter.meter, "create_gauge") as mock_gauge,
+            mock.patch.object(
+                metrics_adapter.meter, "create_histogram"
+            ) as mock_histogram,
+        ):
+            mock_counter_instance = mock.MagicMock()
+            mock_gauge_instance = mock.MagicMock()
+            mock_histogram_instance = mock.MagicMock()
+            mock_counter.return_value = mock_counter_instance
+            mock_gauge.return_value = mock_gauge_instance
+            mock_histogram.return_value = mock_histogram_instance
+
+            counter_record = MetricRecord(
+                timestamp=datetime.now().timestamp(),
+                name="optional_counter",
+                value=1.0,
+                type=MetricType.COUNTER,
+                labels={},
+            )
+            gauge_record = MetricRecord(
+                timestamp=datetime.now().timestamp(),
+                name="optional_gauge",
+                value=2.0,
+                type=MetricType.GAUGE,
+                labels={},
+            )
+            histogram_record = MetricRecord(
+                timestamp=datetime.now().timestamp(),
+                name="optional_histogram",
+                value=3.0,
+                type=MetricType.HISTOGRAM,
+                labels={},
+            )
+
+            metrics_adapter._send_to_otel(counter_record)
+            metrics_adapter._send_to_otel(gauge_record)
+            metrics_adapter._send_to_otel(histogram_record)
+
+            mock_counter.assert_called_once_with(
+                name="optional_counter",
+                description="",
+                unit="",
+            )
+            mock_gauge.assert_called_once_with(
+                name="optional_gauge",
+                description="",
+                unit="",
+            )
+            mock_histogram.assert_called_once_with(
+                name="optional_histogram",
+                description="",
+                unit="",
+            )
+            mock_counter_instance.add.assert_called_once_with(1.0, {})
+            mock_gauge_instance.set.assert_called_once_with(2.0, {})
+            mock_histogram_instance.record.assert_called_once_with(3.0, {})
+
+
+def test_record_metric_with_optional_metadata_uses_real_otel_meter():
+    """Regression test for OTel rejecting None unit or description."""
+    from opentelemetry.sdk.metrics import MeterProvider
+
+    previous_flush_task_started = AtlanMetricsAdapter._flush_task_started
+    AtlanMetricsAdapter._flush_task_started = True
+    try:
+        with mock.patch(
+            "application_sdk.observability.metrics_adaptor.ENABLE_OTLP_METRICS",
+            False,
+        ):
+            with mock.patch(
+                "application_sdk.observability.metrics_adaptor.ENABLE_PROMETHEUS_METRICS",
+                False,
+            ):
+                metrics_adapter = AtlanMetricsAdapter()
+        metrics_adapter.meter = MeterProvider().get_meter("test_optional_metadata")
+
+        with mock.patch(
+            "application_sdk.observability.metrics_adaptor.ENABLE_OTLP_METRICS",
+            True,
+        ):
+            with mock.patch(
+                "application_sdk.observability.metrics_adaptor.ENABLE_PROMETHEUS_METRICS",
+                False,
+            ):
+                with mock.patch(
+                    "application_sdk.observability.metrics_adaptor.logging.error"
+                ) as mock_error:
+                    metrics_adapter.record_metric(
+                        name="optional_metadata_counter",
+                        value=1.0,
+                        metric_type=MetricType.COUNTER,
+                        labels={},
+                    )
+
+        mock_error.assert_not_called()
+    finally:
+        AtlanMetricsAdapter._flush_task_started = previous_flush_task_started
 
 
 def test_send_to_otel_filters_non_scalar_labels():

--- a/tests/unit/observability/test_metrics_adaptor.py
+++ b/tests/unit/observability/test_metrics_adaptor.py
@@ -98,6 +98,22 @@ def test_process_record_with_dict():
         assert processed == record
 
 
+def test_metric_record_exposes_otel_safe_metadata():
+    """Unset SDK metric metadata should map to OTel's empty-string defaults."""
+    record = MetricRecord(
+        timestamp=datetime.now().timestamp(),
+        name="test_metric",
+        value=1.0,
+        type=MetricType.COUNTER,
+        labels={},
+    )
+
+    assert record.description is None
+    assert record.unit is None
+    assert record.otel_description == ""
+    assert record.otel_unit == ""
+
+
 @given(
     st.text(min_size=1),
     st.floats(),


### PR DESCRIPTION
## Summary
- Model OTel-safe metric metadata on `MetricRecord` with `otel_description` and `otel_unit`.
- Use those model-level OTel metadata projections when creating counter, gauge, and histogram instruments.
- Keep SDK metric records unchanged: `description=None` and `unit=None` remain valid for storage, Segment, and callers.
- Keep gauge emission on the synchronous OTel gauge API: `create_gauge().set(...)`.

## Why
Writer metrics such as `json_chunks_written`, `chunks_written`, and `consolidated_files` can omit `unit`. With Prometheus or OTLP metrics enabled, OpenTelemetry rejects `unit=None` during instrument registration, logs repeated errors, and drops those metric points.

This is modeled at `MetricRecord` instead of only inside the adapter so the SDK type owns the OpenTelemetry projection while preserving the public `record_metric(..., unit=None)` contract. We intentionally do not stamp `unit="count"` onto existing counters because the Prometheus exporter includes units in exported metric names, which can rename metrics such as `http_requests_total` to `http_requests_count_total`.

## Tests
- `uv run pytest tests/unit/observability/test_metrics_adaptor.py -q`
- `uv run pre-commit run --files application_sdk/observability/models.py application_sdk/observability/metrics_adaptor.py tests/unit/observability/test_metrics_adaptor.py`
- Real OTel smoke: counter, gauge, and histogram with unset description/unit produced `logging_errors 0`.
- Prometheus exporter smoke: empty unit preserved `http_requests_total`.

Linear: HYP-851