### PR TITLE
feat(routing): host_apps + Dapr aggregation; remove --mode handler [ARUN-342]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+- **`--mode handler` removed** [ARUN-342]. Production HTTP traffic for core apps is now served by the new `common-app-server` runtime, which mounts each app's router via `application_sdk.routing.host_apps()`. Local dev still runs `--mode combined` as before; `--mode worker` is unchanged. Anyone passing `APPLICATION_MODE=SERVER` (legacy alias) will see a clear "Unknown mode" error rather than silent fallback.
+
+### Features
+
+- new `application_sdk.routing` module exposing `host_apps()` for the consolidated runtime: parent FastAPI with Starlette `Host`-route dispatch, RFC-7230-compliant case-insensitive Host matching via an ASGI lowercasing middleware, and a `current_app_name` ContextVar that handlers can read to learn which app context they're running in (replaces the process-level `application_sdk.constants.APPLICATION_NAME` for multi-app processes).
+- `tests/unit/test_routing.py` ports the consolidation PoC: 12 functional tests + a 500-concurrent-request stress test covering same-path collision avoidance, port suffix tolerance, case-insensitive Host matching, ContextVar isolation under concurrency, and short-form / FQDN dispatch.
+
 ## v3.2.0 (April 23, 2026)
 
 Full Changelog: https://github.com/atlanhq/application-sdk/compare/v3.1.0...v3.2.0

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -729,6 +729,94 @@ async def run_worker_mode(config: AppConfig) -> None:
     logger.info("Worker stopped")
 
 
+def run_handler_mode(config: AppConfig) -> None:
+    """Run the per-app HTTP handler service (standalone FastAPI + uvicorn).
+
+    .. deprecated::
+        Standalone handler pods are superseded by the ``common-app-server``
+        runtime introduced in ARUN-342. The per-app ``-server`` Deployment
+        will be removed from Helm charts once all core apps have migrated.
+        Use ``--mode combined`` for local development.
+
+        To suppress this warning set the environment variable
+        ``ATLAN_SUPPRESS_HANDLER_DEPRECATION=1``.
+    """
+    import asyncio
+    import os
+    import warnings
+
+    if not os.environ.get("ATLAN_SUPPRESS_HANDLER_DEPRECATION"):
+        warnings.warn(
+            "--mode handler is deprecated and will be removed in a future release. "
+            "Production HTTP traffic for core apps is now served by the "
+            "common-app-server runtime (ARUN-342). "
+            "Use --mode combined for local dev, or set "
+            "ATLAN_SUPPRESS_HANDLER_DEPRECATION=1 to silence this warning.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+
+    from application_sdk.execution._temporal.converter import (
+        create_data_converter_for_app,
+    )
+    from application_sdk.handler import DefaultHandler, run_app_handler_service
+    from application_sdk.infrastructure.context import set_infrastructure
+
+    infra = asyncio.run(_create_infrastructure())
+    set_infrastructure(infra)
+
+    logger.info(
+        "Starting handler mode (deprecated): app=%s host=%s port=%d",
+        config.app_module,
+        config.handler_host,
+        config.handler_port,
+    )
+
+    app_class = load_app_class(config.app_module)
+    app_name = app_class._app_name  # type: ignore[attr-defined]
+
+    handler_class = load_handler_class(
+        config.app_module,
+        handler_module_path=config.handler_module,
+    )
+    if handler_class is None:
+        handler_class = DefaultHandler
+        logger.info("Using DefaultHandler for %s", app_name)
+    else:
+        logger.info("Loaded custom handler %s for %s", handler_class.__name__, app_name)
+
+    handler = handler_class()
+    data_converter = create_data_converter_for_app(app_class)
+
+    run_app_handler_service(
+        handler,
+        host=config.handler_host,
+        port=config.handler_port,
+        log_level=config.log_level.lower(),
+        app_name=app_name,
+        app_class=app_class,
+        temporal_host=config.temporal_host,
+        temporal_namespace=config.temporal_namespace,
+        task_queue=config.task_queue,
+        data_converter=data_converter,
+        tls_enabled=config.tls_enabled,
+        tls_server_root_ca_cert_path=config.tls_server_root_ca_cert_path,
+        tls_client_cert_path=config.tls_client_cert_path,
+        tls_client_private_key_path=config.tls_client_private_key_path,
+        tls_domain=config.tls_domain,
+        auth_enabled=config.auth_enabled,
+        auth_client_id=config.auth_client_id,
+        auth_client_secret=config.auth_client_secret,
+        auth_token_url=config.auth_token_url,
+        auth_base_url=config.auth_base_url,
+        auth_scopes=config.auth_scopes,
+        secret_store=infra.secret_store,
+        storage=infra.storage,
+        frontend_assets_path=config.frontend_assets_path,
+    )
+    asyncio.run(_flush_observability())
+
+
 async def run_combined_mode(config: AppConfig) -> None:
     """Run worker + handler in a single process (SDR / docker-compose mode).
 
@@ -1098,15 +1186,22 @@ def run_main(config: AppConfig) -> None:
     elif config.mode == "combined":
         asyncio.run(run_combined_mode(config))
     elif config.mode == "handler":
-        raise ValueError(
-            "Mode 'handler' was removed in the server-consolidation work "
-            "(ARUN-342). Production HTTP traffic is now served by "
-            "common-app-server via application_sdk.routing.host_apps. "
-            "For local dev, use --mode combined."
-        )
+        import warnings as _warnings
+
+        if not os.environ.get("ATLAN_SUPPRESS_HANDLER_DEPRECATION"):
+            _warnings.warn(
+                "--mode handler is deprecated and will be removed in a future release. "
+                "Production HTTP traffic for core apps is now served by the "
+                "common-app-server runtime (ARUN-342). "
+                "Use --mode combined for local dev, or set "
+                "ATLAN_SUPPRESS_HANDLER_DEPRECATION=1 to silence this warning.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        run_handler_mode(config)
     else:
         raise ValueError(
-            f"Unknown mode: {config.mode!r}. Must be 'worker' or 'combined'."
+            f"Unknown mode: {config.mode!r}. Must be 'worker', 'handler', or 'combined'."
         )
 
 
@@ -1143,8 +1238,8 @@ Examples:
     parser.add_argument(
         "--mode",
         "-m",
-        choices=["worker", "combined"],
-        help="Execution mode",
+        choices=["worker", "handler", "combined"],
+        help="Execution mode ('handler' is deprecated — use 'combined' for local dev)",
     )
     parser.add_argument(
         "--app",

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -1,14 +1,16 @@
 """Unified entry point for Application SDK containers.
 
-Supports three execution modes:
+Supports two execution modes:
 - ``worker``: Temporal workflow execution only
-- ``handler``: HTTP FastAPI handler service only
-- ``combined``: Worker + handler in a single process (SDR / docker-compose)
+- ``combined``: Worker + handler in a single process (local dev / docker-compose)
+
+In production, the per-app HTTP handler is no longer deployed standalone;
+it is mounted inside ``common-app-server`` via :mod:`application_sdk.routing`.
+The ``handler`` mode was removed in the consolidation work (ARUN-342).
 
 CLI usage::
 
     python -m application_sdk.main --mode worker --app my_package.apps:MyApp
-    python -m application_sdk.main --mode handler --app my_package.apps:MyApp
     python -m application_sdk.main --mode combined --app my_package.apps:MyApp
 
 Environment variable equivalents::
@@ -110,7 +112,7 @@ class AppConfig:
     """
 
     mode: str
-    """Execution mode: "worker", "handler", or "combined"."""
+    """Execution mode: "worker" or "combined"."""
 
     app_module: str
     """App class module path, e.g. "my_package.apps:MyApp"."""
@@ -193,7 +195,10 @@ class AppConfig:
 
         _legacy_mode_map = {
             "WORKER": "worker",
-            "SERVER": "handler",
+            # SERVER (legacy "handler" mode) was removed in the consolidation
+            # work (ARUN-342) — production no longer runs a per-app handler pod.
+            # Anyone still passing APPLICATION_MODE=SERVER is misconfigured;
+            # leave the alias out so it raises a clear "Unknown mode" error.
             "LOCAL": "combined",
         }
         mode = (
@@ -724,79 +729,6 @@ async def run_worker_mode(config: AppConfig) -> None:
     logger.info("Worker stopped")
 
 
-def run_handler_mode(config: AppConfig) -> None:
-    """Run in handler mode (HTTP FastAPI server).
-
-    Loads the handler class (or DefaultHandler) and runs the FastAPI
-    server via uvicorn. This is synchronous — uvicorn manages its own loop.
-    """
-    import asyncio
-
-    from application_sdk.execution._temporal.converter import (
-        create_data_converter_for_app,
-    )
-    from application_sdk.handler import DefaultHandler, run_app_handler_service
-    from application_sdk.infrastructure.context import set_infrastructure
-
-    infra = asyncio.run(_create_infrastructure())
-    set_infrastructure(infra)
-
-    logger.info(
-        "Starting handler mode: app=%s host=%s port=%d",
-        config.app_module,
-        config.handler_host,
-        config.handler_port,
-    )
-
-    app_class = load_app_class(config.app_module)
-    app_name = app_class._app_name  # type: ignore[attr-defined]
-
-    handler_class = load_handler_class(
-        config.app_module,
-        handler_module_path=config.handler_module,
-    )
-    if handler_class is None:
-        handler_class = DefaultHandler
-        logger.info("Using DefaultHandler for %s", app_name)
-    else:
-        logger.info(
-            "Loaded custom handler %s for %s",
-            handler_class.__name__,
-            app_name,
-        )
-
-    handler = handler_class()
-    data_converter = create_data_converter_for_app(app_class)
-
-    run_app_handler_service(
-        handler,
-        host=config.handler_host,
-        port=config.handler_port,
-        log_level=config.log_level.lower(),
-        app_name=app_name,
-        app_class=app_class,
-        temporal_host=config.temporal_host,
-        temporal_namespace=config.temporal_namespace,
-        task_queue=config.task_queue,
-        data_converter=data_converter,
-        tls_enabled=config.tls_enabled,
-        tls_server_root_ca_cert_path=config.tls_server_root_ca_cert_path,
-        tls_client_cert_path=config.tls_client_cert_path,
-        tls_client_private_key_path=config.tls_client_private_key_path,
-        tls_domain=config.tls_domain,
-        auth_enabled=config.auth_enabled,
-        auth_client_id=config.auth_client_id,
-        auth_client_secret=config.auth_client_secret,
-        auth_token_url=config.auth_token_url,
-        auth_base_url=config.auth_base_url,
-        auth_scopes=config.auth_scopes,
-        secret_store=infra.secret_store,
-        storage=infra.storage,
-        frontend_assets_path=config.frontend_assets_path,
-    )
-    asyncio.run(_flush_observability())
-
-
 async def run_combined_mode(config: AppConfig) -> None:
     """Run worker + handler in a single process (SDR / docker-compose mode).
 
@@ -1160,16 +1092,21 @@ async def run_dev_combined(
 
 
 def run_main(config: AppConfig) -> None:
-    """Route to worker, handler, or combined mode based on config."""
+    """Route to worker or combined mode based on config."""
     if config.mode == "worker":
         asyncio.run(run_worker_mode(config))
-    elif config.mode == "handler":
-        run_handler_mode(config)
     elif config.mode == "combined":
         asyncio.run(run_combined_mode(config))
+    elif config.mode == "handler":
+        raise ValueError(
+            "Mode 'handler' was removed in the server-consolidation work "
+            "(ARUN-342). Production HTTP traffic is now served by "
+            "common-app-server via application_sdk.routing.host_apps. "
+            "For local dev, use --mode combined."
+        )
     else:
         raise ValueError(
-            f"Unknown mode: {config.mode!r}. Must be 'worker', 'handler', or 'combined'."
+            f"Unknown mode: {config.mode!r}. Must be 'worker' or 'combined'."
         )
 
 
@@ -1180,7 +1117,7 @@ def parse_args() -> argparse.Namespace:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Environment Variables:
-  ATLAN_APP_MODE           Execution mode (worker, handler, or combined)
+  ATLAN_APP_MODE           Execution mode (worker or combined)
   ATLAN_APP_MODULE         App class path in 'module:ClassName' form (e.g. app.main:MyApp)
                            Apps expose multiple workflows via @entrypoint methods
   ATLAN_HANDLER_MODULE     Optional custom handler module path
@@ -1199,7 +1136,6 @@ Environment Variables:
 
 Examples:
   python -m application_sdk.main --mode worker --app my_package.apps:MyApp
-  python -m application_sdk.main --mode handler --app my_package.apps:MyApp --port 9000
   python -m application_sdk.main --mode combined --app my_package.apps:MyApp
         """,
     )
@@ -1207,7 +1143,7 @@ Examples:
     parser.add_argument(
         "--mode",
         "-m",
-        choices=["worker", "handler", "combined"],
+        choices=["worker", "combined"],
         help="Execution mode",
     )
     parser.add_argument(

--- a/application_sdk/routing.py
+++ b/application_sdk/routing.py
@@ -1,0 +1,219 @@
+"""Multi-app HTTP routing for the consolidated runtime (`common-app-server`).
+
+This module provides the SDK-side primitives that let many apps share a single
+process. Each app exposes its own router (a FastAPI/ASGI sub-app) from its
+package; the consolidated runtime calls :func:`host_apps` to mount them under
+Host-header dispatch.
+
+Layout:
+
+    Per-app package
+    ---------------
+    Each app exposes ``server_router`` as an importable attribute::
+
+        # in {app_pkg}/router.py
+        from application_sdk.handler.service import create_app_handler_service
+
+        server_router = create_app_handler_service(my_handler, app_name="my-app")
+
+    Consolidated runtime (``common-app-server``)
+    --------------------------------------------
+    The runtime's main module imports each app's router and registers them::
+
+        from application_sdk.routing import host_apps
+
+        from publish_app.router  import server_router as publish_router
+        from redshift_app.router import server_router as redshift_router
+
+        app = host_apps([
+            ("publish",  publish_router),
+            ("redshift", redshift_router),
+        ])
+
+K8s convention: each ``(name, router)`` tuple registers a Host pattern of
+``{name}.{shared_namespace}.svc.cluster.local`` (and bare ``{name}`` for short-form
+in-cluster lookups). The shared namespace defaults to ``"common-app-server"`` and
+can be overridden via the ``shared_namespace`` keyword argument or the
+``ATLAN_COMMON_APP_NAMESPACE`` environment variable.
+
+Validated behavior (see ``tests/unit/test_routing.py``):
+
+    1. Sub-apps with identical paths coexist; Host header is the discriminator.
+    2. HTTP Host headers are matched case-insensitively (RFC 7230).
+    3. Port-suffixed Hosts (``host:80``) match the bare-host pattern.
+    4. Pod-level ``/health`` is reachable via a parent route registered AFTER
+       Host routes — so it answers when the Host doesn't match any app
+       (e.g. the kubelet liveness probe arrives with ``Host = <pod-ip>``).
+    5. Unknown Hosts return a clean 404, never a silent dispatch.
+
+Critical invariant: Host routes MUST be registered before any parent-level
+path routes (Starlette matches in order; a parent path will shadow Host
+dispatch otherwise).
+"""
+
+from __future__ import annotations
+
+import os
+from contextvars import ContextVar
+from typing import Sequence
+
+from fastapi import FastAPI
+from starlette.routing import Host
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+DEFAULT_SHARED_NAMESPACE = "common-app-server"
+
+#: Per-request app identity. Set by :class:`HostDispatchMiddleware` based on the
+#: ``Host`` header. Code that needs to know which app is handling the current
+#: request — for logging, metrics, OTEL service name, etc. — reads from this
+#: ContextVar instead of the legacy ``application_sdk.constants.APPLICATION_NAME``
+#: (which is a process-level constant that can't disambiguate apps in a shared
+#: runtime).
+current_app_name: ContextVar[str | None] = ContextVar("current_app_name", default=None)
+
+
+class LowercaseHostMiddleware:
+    """ASGI middleware that lowercases the ``Host`` header before routing.
+
+    HTTP ``Host`` headers are case-insensitive per RFC 7230 §5.4, but Starlette's
+    :class:`~starlette.routing.Host` route compares strings exactly. Without
+    this middleware, a client that sends ``Host: PUBLISH.common-app-server...``
+    would 404 even though the lowercase pattern is registered. Normalising
+    upstream keeps dispatch robust to client variation.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] in ("http", "websocket"):
+            new_headers = [
+                (name, value.lower() if name == b"host" else value)
+                for name, value in scope["headers"]
+            ]
+            scope = dict(scope)
+            scope["headers"] = new_headers
+        await self.app(scope, receive, send)
+
+
+class HostDispatchContextMiddleware:
+    """ASGI middleware that sets :data:`current_app_name` based on the Host.
+
+    Runs after :class:`LowercaseHostMiddleware` (so it sees a normalised Host)
+    and before request handlers. The mapping comes from the same ``apps`` list
+    passed to :func:`host_apps`, so it stays in sync with the registered Host
+    routes by construction.
+    """
+
+    def __init__(self, app: ASGIApp, host_to_name: dict[str, str]) -> None:
+        self.app = app
+        self.host_to_name = host_to_name
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] in ("http", "websocket"):
+            host = _extract_host(scope)
+            name = self.host_to_name.get(host)
+            if name is not None:
+                token = current_app_name.set(name)
+                try:
+                    await self.app(scope, receive, send)
+                finally:
+                    current_app_name.reset(token)
+                return
+        await self.app(scope, receive, send)
+
+
+def _extract_host(scope: Scope) -> str:
+    """Pull the bare hostname (no port) from the ASGI scope's Host header."""
+    for name, value in scope.get("headers", ()):
+        if name == b"host":
+            host = value.decode("latin-1")
+            return host.split(":", 1)[0]
+    return ""
+
+
+def host_apps(
+    apps: Sequence[tuple[str, FastAPI]],
+    *,
+    shared_namespace: str | None = None,
+) -> ASGIApp:
+    """Build the consolidated parent FastAPI that dispatches to per-app routers.
+
+    Args:
+        apps: Sequence of ``(k8s_name, router)`` tuples. ``k8s_name`` is the
+            value of ``.Values.name`` in the production Helm chart for that app
+            (e.g. ``"publish"``, ``"redshift"``). ``router`` is any ASGI app —
+            typically a :class:`fastapi.FastAPI` sub-app produced by the SDK's
+            ``create_app_handler_service``.
+        shared_namespace: K8s namespace where the consolidated runtime's
+            Services live. Defaults to the value of the
+            ``ATLAN_COMMON_APP_NAMESPACE`` env var, falling back to
+            ``"common-app-server"``.
+
+    Returns:
+        An ASGI application that dispatches incoming HTTP requests to the
+        correct sub-app based on the ``Host`` header. Pod-level ``/health``
+        (kubelet liveness probes hitting the pod IP) is also exposed.
+
+    The returned app accepts any of these Host patterns for an app named
+    ``"publish"``:
+
+    - ``publish.common-app-server.svc.cluster.local``  (FQDN)
+    - ``publish.common-app-server``                    (cluster-DNS short form)
+    - ``publish``                                      (in-namespace short form)
+
+    Each is registered with optional ``:port`` suffix tolerance via Starlette's
+    built-in Host matching.
+
+    Raises:
+        ValueError: if ``apps`` contains duplicate ``k8s_name`` values.
+    """
+    namespace = (
+        shared_namespace
+        or os.environ.get("ATLAN_COMMON_APP_NAMESPACE")
+        or DEFAULT_SHARED_NAMESPACE
+    )
+
+    seen_names: set[str] = set()
+    host_to_name: dict[str, str] = {}
+
+    parent = FastAPI()
+
+    # Order matters: register Host routes BEFORE any parent-level path routes.
+    # Starlette matches routes in order; if /health on the parent comes first,
+    # it shadows per-app /health under Host dispatch. Verified by the
+    # ``per-app /health via Host header`` test in tests/unit/test_routing.py.
+    for k8s_name, router in apps:
+        if k8s_name in seen_names:
+            raise ValueError(f"duplicate app name in host_apps(): {k8s_name!r}")
+        seen_names.add(k8s_name)
+
+        for host in _host_patterns_for(k8s_name, namespace):
+            parent.routes.append(Host(host, app=router))
+            host_to_name[host] = k8s_name
+
+    @parent.get("/health")
+    async def pod_health() -> dict[str, str]:
+        """Pod-level liveness — answers when no app's Host route matched."""
+        return {"status": "ok", "scope": "pod"}
+
+    # Wrap with the two ASGI middlewares. Order: lowercase first (so context
+    # sees a normalised host), then context (so request handlers see
+    # current_app_name set).
+    wrapped: ASGIApp = HostDispatchContextMiddleware(parent, host_to_name)
+    wrapped = LowercaseHostMiddleware(wrapped)
+    return wrapped
+
+
+def _host_patterns_for(k8s_name: str, namespace: str) -> list[str]:
+    """Return the Host-header values to register for ``k8s_name``.
+
+    Three forms are registered to cover the realistic ways an in-cluster
+    client constructs a URL: full FQDN, cluster-DNS short form, and
+    in-namespace bare hostname.
+    """
+    return [
+        f"{k8s_name}.{namespace}.svc.cluster.local",
+        f"{k8s_name}.{namespace}",
+        k8s_name,
+    ]

--- a/application_sdk/routing.py
+++ b/application_sdk/routing.py
@@ -55,9 +55,11 @@ from __future__ import annotations
 
 import os
 from contextvars import ContextVar
-from typing import Sequence
+from typing import Any, Sequence
 
-from fastapi import FastAPI
+import httpx  # noqa: TCH002 — runtime use in _proxy_to_sub_app
+from fastapi import FastAPI, Request  # noqa: TCH002 — Request used by FastAPI DI
+from fastapi.responses import Response  # noqa: TCH002 — runtime return value
 from starlette.routing import Host
 from starlette.types import ASGIApp, Receive, Scope, Send
 
@@ -132,6 +134,55 @@ def _extract_host(scope: Scope) -> str:
     return ""
 
 
+def _collect_dapr_subscriptions(sub_app: FastAPI) -> list[dict[str, Any]]:
+    """Call the sub-app's ``GET /dapr/subscribe`` synchronously and return its
+    subscription list.
+
+    Uses Starlette's ``TestClient`` (backed by ``requests`` + the ASGI
+    interface) so this works at module-import time before any async event loop
+    is running.  If the sub-app doesn't expose ``/dapr/subscribe`` (or it
+    returns empty), an empty list is returned without error.
+    """
+    from starlette.testclient import TestClient
+
+    try:
+        with TestClient(sub_app, raise_server_exceptions=False) as client:
+            r = client.get("/dapr/subscribe")
+            if r.status_code == 200:
+                return r.json()
+    except Exception:  # noqa: BLE001 — best-effort; don't crash the runtime
+        pass
+    return []
+
+
+async def _proxy_to_sub_app(sub_app: FastAPI, request: Request, path: str) -> Response:
+    """Forward an HTTP request body + headers to ``sub_app`` at ``path`` and
+    return the response.
+
+    Used to proxy Dapr's inbound delivery calls (pub/sub + event triggers) from
+    the pod-level parent (which Dapr calls on ``localhost``) to the correct
+    per-app sub-app FastAPI instance.  The round-trip is entirely in-process via
+    ``httpx.AsyncClient`` + Starlette's ASGI transport — no network hop.
+    """
+    body = await request.body()
+    # Pass only the headers Dapr sets; skip Host (would confuse the sub-app).
+    forward_headers = {
+        k: v
+        for k, v in request.headers.items()
+        if k.lower() not in ("host", "content-length")
+    }
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=sub_app),
+        base_url="http://dapr-delivery",
+    ) as client:
+        r = await client.post(path, content=body, headers=forward_headers)
+    return Response(
+        content=r.content,
+        status_code=r.status_code,
+        media_type=r.headers.get("content-type"),
+    )
+
+
 def host_apps(
     apps: Sequence[tuple[str, FastAPI]],
     *,
@@ -177,12 +228,66 @@ def host_apps(
     seen_names: set[str] = set()
     host_to_name: dict[str, str] = {}
 
+    # Build Dapr subscription aggregation.  Dapr's sidecar calls
+    # ``GET /dapr/subscribe`` on localhost (no Host header) at startup, then
+    # delivers events via ``POST /events/v1/event/{id}`` and
+    # ``POST /subscriptions/v1/{route}`` — also on localhost, no Host.
+    # Neither of those goes through Host-header dispatch, so we collect all
+    # subscriptions here and register aggregated routes on the parent.
+    all_dapr_subscriptions: list[dict[str, Any]] = []
+    # Maps the delivery path (without leading slash) → sub-app that handles it
+    dapr_route_to_app: dict[str, FastAPI] = {}
+
+    for k8s_name, router in apps:
+        subs = _collect_dapr_subscriptions(router)
+        for sub in subs:
+            if "route" in sub:
+                # pub/sub: Dapr delivers to POST /subscriptions/v1/{route}
+                path = sub["route"].lstrip("/")
+                dapr_route_to_app[path] = router
+            if "routes" in sub:
+                # event-trigger: Dapr delivers to POST /events/v1/event/{id}
+                for rule in sub["routes"].get("rules", []):
+                    p = rule.get("path", "").lstrip("/")
+                    if p:
+                        dapr_route_to_app[p] = router
+        all_dapr_subscriptions.extend(subs)
+
     parent = FastAPI()
 
-    # Order matters: register Host routes BEFORE any parent-level path routes.
-    # Starlette matches routes in order; if /health on the parent comes first,
-    # it shadows per-app /health under Host dispatch. Verified by the
-    # ``per-app /health via Host header`` test in tests/unit/test_routing.py.
+    # 1. Aggregated Dapr discovery endpoint (called by sidecar on localhost).
+    @parent.get("/dapr/subscribe")
+    async def dapr_subscribe_aggregated() -> list[dict[str, Any]]:
+        return all_dapr_subscriptions
+
+    # 2. Event-trigger delivery (from event_triggers registered per-app).
+    @parent.post("/events/v1/event/{event_id}")
+    async def proxy_event_trigger(event_id: str, request: Request) -> Response:
+        path = f"events/v1/event/{event_id}"
+        sub_app = dapr_route_to_app.get(path)
+        if sub_app is None:
+            return Response(content=b'{"status":"DROP"}', media_type="application/json")
+        return await _proxy_to_sub_app(sub_app, request, f"/{path}")
+
+    # 3. Dead-letter / unmatched event trigger route.
+    @parent.post("/events/v1/drop")
+    async def event_drop() -> dict[str, str]:
+        return {"status": "DROP"}
+
+    # 4. Pub/sub subscription delivery.
+    @parent.post("/subscriptions/v1/{route:path}")
+    async def proxy_subscription(route: str, request: Request) -> Response:
+        path = f"subscriptions/v1/{route}"
+        sub_app = dapr_route_to_app.get(path)
+        if sub_app is None:
+            return Response(content=b'{"status":"DROP"}', media_type="application/json")
+        return await _proxy_to_sub_app(sub_app, request, f"/{path}")
+
+    # 5. Host-dispatch routes — AFTER Dapr routes, BEFORE the catch-all /health.
+    # Order matters: Starlette matches in list order; Dapr endpoints above are
+    # path-only (no Host constraint) so they must precede the Host routes or a
+    # request with a matching Host would shadow them.  In practice Dapr never
+    # sends a Host that matches an app pattern, but defence-in-depth.
     for k8s_name, router in apps:
         if k8s_name in seen_names:
             raise ValueError(f"duplicate app name in host_apps(): {k8s_name!r}")
@@ -192,6 +297,7 @@ def host_apps(
             parent.routes.append(Host(host, app=router))
             host_to_name[host] = k8s_name
 
+    # 6. Pod-level /health — after everything else.
     @parent.get("/health")
     async def pod_health() -> dict[str, str]:
         """Pod-level liveness — answers when no app's Host route matched."""

--- a/docs/design/server-consolidation-migration.md
+++ b/docs/design/server-consolidation-migration.md
@@ -1,0 +1,278 @@
+# Server Consolidation — Migration Plan & Cutover
+
+**Status:** Draft for review
+**Date:** 2026-04-27
+**Owner:** Sanil Khurana
+**Linear:** [ARUN-550](https://linear.app/atlan-epd/issue/ARUN-550) (under [ARUN-342](https://linear.app/atlan-epd/issue/ARUN-342))
+
+This doc plans the staged rollout of the server-consolidation work
+([ARUN-342](https://linear.app/atlan-epd/issue/ARUN-342)) across
+internal and customer tenants. Companion docs:
+[server-consolidation.md](./server-consolidation.md) (architecture +
+decisions) and
+[server-consolidation-rfc.md](./server-consolidation-rfc.md) (cross-repo
+implementation plan).
+
+## Why staged
+
+The change has high blast radius: every tenant's HTTP-handling topology
+moves from N per-app pods to one shared `common-app-server` pod. A
+silent regression hits every core-app surface for that tenant. We
+mitigate with a per-tenant feature flag, a ring-deploy schedule, and a
+rollback story that reverts a single HelmRelease values diff.
+
+The flag is the `coreApp.enabled` boolean in the atlan-app subchart
+(landed in ARUN-547). The orchestrator passes it through from the
+marketplace app config (ARUN-549). Flipping a tenant's flag from
+`false` → `true` is the cutover; flipping back is the rollback.
+
+## Pre-cutover gates
+
+These must all be green before stage 2:
+
+- [ ] **SDK PR merged** — ARUN-543 (`application_sdk.routing.host_apps`
+      + tests + handler-mode removal). Must be on a tagged release.
+- [ ] **common-app-server image** built and pushed to GHCR — ARUN-545.
+      All 8 core apps' routers importable in one Python process; CI
+      dep-conflict check green.
+- [ ] **Per-app router PRs merged** — ARUN-546 expanded from the
+      initial 3 (publish, redshift, mysql) to all 8 core apps:
+      enrichment-studio, automation-engine, lineage, publish, atlan-auth,
+      query-intelligence, popularity, native-migration. Each app's
+      release is tagged and pinned in `common-app-server/pyproject.toml`.
+- [ ] **Helm chart change live** — ARUN-547 merged to atlanhq/atlan,
+      cut into a release that all target tenants are running.
+- [ ] **Orchestrator change live** — ARUN-549 merged to
+      atlan-local-marketplace-app, deployed.
+- [ ] **Marketplace generator updated** — ARUN-548. New core-app
+      registrations emit the right URL by default.
+- [ ] **Heracles change scoped** — ARUN-551. Doesn't strictly block
+      stage 2 (logs still tail; they just intermix), but the team
+      should be aware before stage 4 (customer beta).
+- [ ] **Smoke runbook** — written, including kubectl commands to
+      verify per-app dispatch on a cutover tenant (see Appendix).
+- [ ] **Rollback runbook** — verified on the dev tenant in stage 2.
+- [ ] **Observability** — Grafana dashboard panel showing per-tenant
+      `common-app-server` pod memory + CPU + p99 request latency,
+      separate panel for the residual per-app `-server` pods (they
+      should disappear post-cutover).
+
+## Stages
+
+### Stage 0 — Image rollout (no functional change)
+
+Deploy the `common-app-server` image to all target tenants alongside
+the existing per-app server pods. **No traffic goes to it yet** —
+`coreApp.enabled` stays `false` everywhere. The image just becomes
+warm and pullable; the `common-app-server` namespace exists but holds
+nothing.
+
+**Done when:** the runtime image pulls cleanly and the `common-app-server`
+deployment is in `Available=True` state on every target tenant.
+
+**Risk:** very low. No traffic shift.
+
+### Stage 1 — Single internal-dev cutover
+
+Pick **`markeznp25`** (median dev tenant from the App Cost analysis;
+already used as the canary in past KEDA / split-deployment rollouts).
+
+For each of the 8 core apps installed on `markeznp25`, flip the app's
+HelmRelease values to `coreApp: { enabled: true }`. The atlan-app
+subchart then:
+- skips the `<app>-server` Deployment
+- renders `Service: <app>` in the `common-app-server` namespace (selector
+  pointing at the runtime pod)
+
+The runtime pod was already there from Stage 0; now traffic actually
+flows to it.
+
+**Verify:**
+- `kubectl get pods -A -l app.kubernetes.io/component=server` should
+  show **no** pods in any `<app>-app` namespace on this tenant.
+- `kubectl get pods -n common-app-server` shows 1 Ready pod.
+- `kubectl get svc -A | grep -E '(publish|lineage|...)'` shows
+  Services in `common-app-server` namespace.
+- A round of Atlan UI smoke tests for each core app: auth,
+  preflight, metadata fetch, workflow start, workflow result.
+- Heracles live-log streaming: hit each app, confirm logs surface
+  (with the known caveat that they intermix until ARUN-551 lands).
+- `kube_pod_status_ready{namespace="common-app-server"} == 1` on
+  Grafana.
+
+**Watch for** (Day 0 → Day 7):
+- p99 request latency on `common-app-server` vs the historical p99
+  on per-app `-server` pods. Tolerance: ≤2× original (the per-app
+  pods used 100m CPU but were 99% idle; the runtime is shared so
+  some queueing is fine, but big regressions are not).
+- Memory: actual usage vs the runtime's `requests` value. Should
+  trend at ~1.5–2 GiB based on p50 of 281 Mi × 8 ≈ 2.2 GiB cap.
+- OOM kills (`kube_pod_container_status_last_terminated_reason="OOMKilled"`)
+  on the runtime pod. Zero is the goal; one means we underprovisioned.
+- Failed activities, increased Sentry/Mezmo error rates on the apps.
+
+**Done when:** 7 days of green metrics, no user-reported regressions.
+
+**Rollback:** flip `coreApp.enabled` back to `false` per app. Flux
+re-renders the per-app `-server` Deployment; pod comes up; old
+Service moves back to per-app namespace; traffic resumes its old path.
+~5 minutes per app.
+
+### Stage 2 — Internal dev pool
+
+Roll out to the rest of the App-BU shared internal tenants from
+[bu-apps Slack][bu-apps] (revampdbt, app-partners,
+apps-framework-redshift-testing, partner-staging, pipelines10,
+partner-apps, warelines-models, apps-enterprise, warehouse-bq-routines).
+
+[bu-apps]: https://atlanhq.slack.com/archives/C088M0KD1LH/p1764771505661059
+
+These run real engineering workloads but no customer data. ~2 weeks of
+soak time with the same metrics watch as Stage 1.
+
+**Done when:** 14 days green across all 9 dev tenants.
+
+### Stage 3 — Beta ring (customer tenants, low-volume)
+
+Pick ~10 customer tenants from beta channel that:
+- Are on Standard infra tier (not Enterprise — let them ride the
+  later stages)
+- Have <1 GiB/day workflow throughput (low downside if anything regresses)
+- Have a customer-success owner who can be looped in on regressions
+
+Per-tenant cutover follows Stage 1's verify/watch/rollback cycle.
+
+**Done when:** 14 days green across the beta ring.
+
+### Stage 4 — Production fleet, batched
+
+Roll out to the remaining ~620 customer tenants in batches of 50–100
+per day. Sequence by:
+- Standard infra tier first; Enterprise last
+- Tenants with fewest core apps installed first
+- Tenants with the largest Atlan footprint last
+
+Per-batch verify: dashboards, smoke checks. Pause if any single tenant
+regresses; investigate before continuing.
+
+**Done when:** 100% of fleet on coreApp=true for all 8 core apps.
+
+### Stage 5 — Decommission
+
+For tenants on consolidation for ≥14 days with no regressions, prune
+the residual per-app artifacts:
+- Old per-app `-server` Deployments (already not rendered, but any
+  orphaned ReplicaSets/Pods can be cleaned up).
+- Per-app namespaces' inbound NetworkPolicies that allowed traffic
+  into the now-gone server pods.
+- Heracles per-tenant configmaps that pointed at the old URLs (no-op
+  if the URL was kept identical-via-alias, breaking if not).
+
+Update the marketplace generator's defaults so new core-app registrations
+emit `coreApp: { enabled: true }` from day one.
+
+**Done when:** zero `<app>-server-...` pods exist anywhere in the fleet
+for the 8 core apps.
+
+## Rollback procedures
+
+### Per-app, per-tenant (5 minutes)
+
+The flip is in the marketplace app config (which the orchestrator
+translates to HelmRelease values):
+```yaml
+# marketplace app config — `coreApp: { enabled: false }` is the rollback
+coreApp:
+  enabled: false
+```
+
+Re-trigger the deployment: orchestrator generates a new HelmRelease
+without `coreApp.enabled`. Flux reconciles; per-app `-server` pod
+comes back up; Service moves back to per-app namespace; clients
+resolve to the original FQDN.
+
+No workflow-state loss because workflow state lives in Temporal, not
+the runtime pod.
+
+### Whole-tenant (10 minutes)
+
+Same as per-app, applied to all 8 core apps for the tenant via a
+single config push. Flux reconciles all 8 HelmReleases in parallel.
+
+### Fleet-wide (1 hour)
+
+Revert the atlan-app subchart change in atlanhq/atlan (ARUN-547),
+cut a release, deploy. `coreApp.enabled` is no longer honored;
+chart falls back to today's per-app `-server` rendering. Each tenant
+gets the next reconcile cycle.
+
+The runtime pods stay running but now have no traffic; can be deleted
+manually or left until clean-up.
+
+## Owners + comms
+
+- **Driver:** Sanil Khurana (App Runtime team)
+- **Reviewers / signoff for each stage:** Anbarasan, Tianchu, Anuj
+- **Heracles changes:** [ARUN-551](https://linear.app/atlan-epd/issue/ARUN-551)
+  owner (TBD — needs Slack outreach to find current Heracles owner)
+- **Comms cadence:** weekly Slack update in `#pod-app-runtime` for the
+  team; cross-post to `#bu-apps` at stages 1, 3, 4 start, and 5 done.
+
+## Appendix — verify commands
+
+Per-tenant smoke after a cutover (`<TENANT>` = e.g. `markeznp25`):
+
+```bash
+# 1) No per-app -server pods left for core apps
+for app in publish redshift mysql lineage automation-engine \
+           query-intelligence popularity atlan-auth enrichment-studio \
+           native-migration; do
+  pods=$(kubectl --context <TENANT> get pods -n "${app}-app" \
+         -l app.kubernetes.io/component=server --no-headers 2>/dev/null | wc -l)
+  if [ "$pods" -gt 0 ]; then
+    echo "FAIL: $app still has $pods server pods"
+  fi
+done
+
+# 2) common-app-server has 1 Ready pod
+kubectl --context <TENANT> get pods -n common-app-server \
+  -l app.kubernetes.io/name=common-app-server
+
+# 3) Each core app's Service exists in common-app-server namespace
+kubectl --context <TENANT> get svc -n common-app-server
+
+# 4) Hit each app's /health via the cluster-internal URL
+for app in publish redshift mysql; do
+  kubectl --context <TENANT> exec -n common-app-server deploy/common-app-server -- \
+    curl -sS -H "Host: ${app}.common-app-server.svc.cluster.local" \
+         http://127.0.0.1:8000/health
+  echo
+done
+```
+
+## Appendix — fleet metrics (for the Grafana dashboard)
+
+Pre-cutover baseline (per-app server pods):
+```promql
+count(kube_pod_status_ready{namespace=~".+-app", pod=~".+-server-[a-f0-9]+-.+", condition="true"} == 1)
+```
+
+Post-cutover (consolidated runtime):
+```promql
+count(kube_pod_status_ready{namespace="common-app-server", condition="true"} == 1)
+```
+
+Per-tenant memory savings (delta = old req - new actual):
+```promql
+sum by (clusterName) (
+  kube_pod_container_resource_requests{namespace=~".+-app", container=~".+-server", resource="memory"}
+)
+-
+sum by (clusterName) (
+  container_memory_working_set_bytes{namespace="common-app-server", container!="POD"}
+)
+```
+
+Per-tenant `common-app-server` p99 request latency (wire up to
+runtime's Prometheus scrape — may need an extra metric label rollup if
+multiple apps share the same HTTP path).

--- a/docs/design/server-consolidation-rfc.md
+++ b/docs/design/server-consolidation-rfc.md
@@ -1,0 +1,197 @@
+# RFC: Server Consolidation — Cross-Repo Implementation Plan
+
+**Status:** Draft
+**Date:** 2026-04-27
+**Owner:** Sanil Khurana
+**Companion:** [`server-consolidation.md`](./server-consolidation.md) (architecture/decisions)
+
+This RFC consolidates the server-consolidation design discussion into a single cross-repo implementation plan. It covers what changes in each repo, the migration path, the blind spots we've identified, and the open questions still to resolve.
+
+## TL;DR
+
+Per-tenant per-app FastAPI server pods (~6,767 fleet-wide, ~5,000 of them the 8 always-on core apps) consolidate into one `common-app-server` process per tenant. App devs write App classes as today; common-app-server imports each app's pre-built router; Host-header dispatch routes incoming requests to the correct app. Worker pods unchanged (still per-app, still KEDA-scaled). Estimated saving: ~75% reduction in server-side memory requests for the 8 core apps.
+
+## Architecture summary
+
+```
+common-app-server (new repo)            HOSTED IN:
+├── pyproject.toml (deps on app pkgs)   ┌─────────────────────────────────────┐
+├── src/main.py                         │ namespace: common-app-server        │
+│     - FastAPI parent                  │                                     │
+│     - /health                         │ Deployment: common-app-server (1)   │
+│     - Host-header dispatch via        │   ├── FastAPI host (Host-routing)   │
+│       Starlette Host routes           │   ├── (no Dapr per-app — TBD)       │
+│     - Imports:                        │   └── reads tenant app set at start │
+│         from redshift_app.router      │                                     │
+│             import server_router      │ Services (one per supported app):   │
+│         from publish_app.router       │   ├── redshift   → port 8000        │
+│             import server_router      │   ├── publish    → port 8000        │
+│         ...                           │   ├── lineage    → port 8000        │
+│                                       │   └── ... (one per app)             │
+│                                       │ All Services select common-app-srv  │
+└── Dockerfile                          └─────────────────────────────────────┘
+
+Worker pods (per-app, per-namespace) — UNCHANGED. KEDA-scaled to 0 as today.
+```
+
+## What changes per repo
+
+### `application-sdk` (this repo)
+
+**Adds:**
+- New module exposing a router-construction primitive. Each app calls it to build its server router from its `App` class.
+- New SDK helper for the common-app-server side: `host_apps([(AppCls, k8s_name), ...])` → returns a Starlette parent app with Host dispatch.
+
+**Removes:**
+- `--mode handler` (production-only path) from main.py.
+
+**Keeps:**
+- `--mode worker` — workers unchanged
+- Local-dev mode (`run_dev_combined`) — unchanged. Devs still spin up a single-app FastAPI on localhost.
+
+**Helm chart (`helm/atlan-app/`):**
+- Drops `handler-deployment.yaml` and `handler-service.yaml`.
+- Keeps `worker-deployment.yaml`, `worker-scaledobject.yaml`, RBAC for workers.
+- Atlanhq/atlan production chart (separate, more important — see below) gets analogous treatment.
+
+### `common-app-server` (new repo)
+
+Top-level, owned by the runtime team.
+
+- `pyproject.toml` declares per-app dependencies on the supported core apps (`atlan-redshift-app`, `atlan-publish-app`, etc.) at pinned versions.
+- `src/main.py` is small: builds Starlette parent, registers Host routes, exposes `/health`.
+- Dockerfile produces the runtime image; pushed to `ghcr.io/atlanhq/common-app-server:<version>`.
+- CI: dependency conflict check (`uv pip install` of all deps together), import test (verify all routers import without error), per-app smoke test.
+
+### Per-app repos (`atlan-publish-app`, `atlan-redshift-app`, `atlan-mssql-app`, `atlan-lineage-app`, `atlan-automation-engine-app`, `atlan-query-intelligence-app`, etc.)
+
+Each app adds a single new file:
+```python
+# {app_pkg}/router.py
+from application_sdk.routing import build_server_router
+from .app import MyApp   # the existing App subclass
+
+server_router = build_server_router(MyApp)
+```
+
+Plus a `pyproject.toml` adjustment if the package isn't already structured to be a library (it should be).
+
+**No App class changes.** Activities, handlers, workflows — all unchanged.
+
+### `atlanhq/atlan` (production Helm)
+
+`subcharts/atlan-app/templates/`:
+- The production chart currently renders the per-app `-server` deployment when `splitDeploymentEnabled: true`. This template stops being used for the 8 core apps once they migrate.
+- Two paths:
+  - **D1 Option A (ExternalName)**: keep the `-server` Service template but switch it to `type: ExternalName` with a CNAME to common-app-server. Old per-app namespace stays.
+  - **D1 Option B (single namespace)**: remove the per-app server Service template entirely; per-app Services live in `common-app-server` namespace.
+- Worker template untouched.
+
+`global-marketplace` / `marketplace-packages`:
+- ~50 connector configmaps with hardcoded `http://{name}.{name}-app.svc.cluster.local:8000` URLs — these stay valid under D1 Option A; need search-and-replace under D1 Option B.
+
+### `atlan-local-marketplace-app` (deployment orchestrator)
+
+`src/deployment_orchestrator/`:
+- `flux_utils.py` and `workflow.py` learn a new install/uninstall flow for "core apps" vs "connector apps":
+  - Core apps: install means "register this app in tenant's common-app-server config + restart runtime"; no per-app HelmRelease.
+  - Connector apps: unchanged for v1.
+- `transform_config_to_helm_values()` in `config_parser.py` may need a new code path for core-app installs.
+- The marketplace must mark apps as `core` vs `connector` somewhere (open question).
+
+### `heracles` (separately owned — runtime team coordination required)
+
+`handler/runs.go:1422-1556`:
+- Live-log streaming parses the per-app service URL into `(namespace, deployment)` and tails K8s pod logs.
+- For consolidated apps, the URL maps to `common-app-server` pod hosting 8 apps. Need to filter logs by app — likely a structured-log field added by the SDK and consumed by Heracles.
+
+`utils/constants.go:124-126`:
+- Hardcoded FQDNs for `KNOWLEDGE_APP_SERVICE_URL` and `AUTOMATION_ENGINE_UI_BASE_URL`. Stay valid under D1 Option A; need updating under D1 Option B.
+
+## Migration plan
+
+Staged rollout, not a flip:
+
+1. **PoC (1 internal tenant, 2 apps).** Stand up common-app-server with `enrichment-studio` + `popularity` (low-risk apps). Deploy to `markeznp25`. Verify Host dispatch works, /health behaves, both apps respond on their old URLs.
+2. **Validation (4–6 weeks).** Watch for issues. Compare metrics. Address blind spots that surface (secrets handling, Dapr context, signal handling).
+3. **Expand to 8 core apps, internal tenants only.** Roll out across the dev tenant pool (`markeznp25`, `aplon95p04`, `enginemp07`, etc).
+4. **Ring-deploy to production.** Per-tenant feature flag flips traffic from per-app handlers to common-app-server. Old handler pods stay running until cutover succeeds.
+5. **Decommission per-app handler deployments.** Once a tenant is on common-app-server for ≥2 weeks with no regressions, remove per-app handler resources.
+
+## Decisions
+
+See [`server-consolidation.md`](./server-consolidation.md) for the running decision log. Open at time of writing:
+
+| ID | Decision | Status |
+|---|---|---|
+| D1 | Per-app Service topology: ExternalName vs single namespace | open — both viable |
+| D2 | Host→Router mapping mechanism (explicit tuples vs `App.name` enforcement) | open — needs drift audit |
+| D3 | Install/uninstall lifecycle (rolling restart in v1) | tentative |
+| D4 | Deployment flow when an app updates (pyproject.toml bump in v1) | chosen |
+| D5 (new) | Per-app secrets handling — see Blind spot #1 | open |
+| D6 (new) | Per-app Dapr context — see Blind spot #2 | open |
+| D7 (new) | "Core" vs "connector" app classification source-of-truth | open |
+
+## Blind spots / risks
+
+Ranked by "likelihood to bite us" (full reasoning in main thread / CHANGELOG):
+
+**High impact, address before locking design:**
+1. Per-app K8s Secrets and ServiceAccount — biggest hidden lift; how do credentials reach a multi-app process?
+2. Per-app Dapr context (state/secret/binding components scoped per app)
+3. Per-app environment variables — apps using `os.environ` directly need a config-injection path
+4. Signal handling (graceful shutdown across multiple apps in one process)
+5. Per-app Prometheus metric labels — every metric needs an `app=` label, dashboards reference per-app series
+
+**Important, address during PoC:**
+6. Health check aggregation (one /health, eight apps' health states)
+7. Failure isolation in shared async event loop
+8. Worker model intentionally unchanged but tenant gets split topology (server ns ≠ worker ns)
+9. Migration cutover plan — needs dual-mode operation in orchestrator
+10. "Core vs connector" app classification — needs a source of truth
+
+**Track but defer:**
+11. Heracles log-streaming change (separate team coordination — Linear ticket needed)
+12. Frontend asset routing under Host dispatch (probably works, verify)
+13. Marketplace install flow rewrite for core apps (`flux_utils.py`)
+14. Image build pipeline ownership and versioning for common-app-server
+15. Resource sizing + VPA-recommend
+16. Per-app rate limiting in the runtime
+17. CI dependency-conflict detection
+18. Frontend asset conflicts in shared image
+19. Where does `atlan-local-marketplace-app` itself live (core or separate)?
+20. Memory accounting (deferred per discussion)
+
+## Per-PR scope summary (to-be-pushed)
+
+Each row is a PR I'll prepare locally. None pushed until design locks and PoC runs.
+
+| Repo | Scope | Size estimate | Blocks on |
+|---|---|---|---|
+| `application-sdk` | Add `application_sdk/routing.py` (router primitive + `host_apps` helper). Remove `--mode handler` from main.py. Drop handler-deployment/handler-service from `helm/atlan-app/`. | ~300 lines | D2 |
+| `common-app-server` (NEW) | New repo. main.py, pyproject.toml, Dockerfile, basic CI. | ~150 lines + boilerplate | application-sdk PR landed first |
+| `atlan-publish-app` | Add `app/router.py` exposing `server_router`. Bump app-sdk dep to consolidation branch. `uv sync`. | ~30 lines | application-sdk PR |
+| `atlan-redshift-app` | Same as publish-app. | ~30 lines | application-sdk PR |
+| `atlan-mssql-app` | Same. | ~30 lines | application-sdk PR |
+| `atlanhq/atlan` (subcharts/atlan-app) | Drop `-server` deployment for core apps. Per-D1 choice: ExternalName Service OR remove. | ~50 lines | D1, PoC validated |
+| `atlan-local-marketplace-app` | New install/uninstall path for core apps. `flux_utils.py` + `workflow.py` changes. | ~200 lines | D1, design locked |
+| `heracles` (separate team) | Log-streaming changes to filter by app within a multi-app pod. | unknown | needs ticket + their owner |
+
+## Suggested next steps
+
+1. Run drift audit on the 8 core apps' `App.name` vs marketplace `app_name` to close D2.
+2. Build a local PoC (just the SDK + common-app-server + 2 apps, on a dev machine) to validate Starlette Host routing actually works for our handlers.
+3. Cut a Linear ticket; loop in Heracles team owner.
+4. Run dependency-conflict CI dry-run (`uv pip install` of 8 core apps together) to catch any blockers.
+5. Resolve D5 (secrets) and D6 (Dapr) before locking the SDK API.
+6. Once PoC green: prepare PRs in branch-but-not-pushed state for review on a call.
+7. Lock D1, push PRs in coordinated batch.
+
+## Slack / standup talking points
+
+- All 6,767 production server pods already at 1 replica; replica reduction not a lever.
+- Memory is right-sized at 88% of 512 Mi p99; CPU is 3× over but it's a marginal win.
+- Real lever: 8 core apps × 639 tenants ≈ 5,000 always-on pods → consolidate to 1 runtime pod per tenant. Memory savings ~75% on core apps.
+- Architecture: thin FastAPI host (`common-app-server`) imports per-app routers, dispatches by Host header. Apps unchanged.
+- Two open decisions, one pending audit, ~5 blind spots that need scoping in the SDK before we ship.
+- PoC scope: 2 apps on 1 internal tenant, ~2 weeks of work before we know if the design holds.

--- a/docs/design/server-consolidation.md
+++ b/docs/design/server-consolidation.md
@@ -1,0 +1,242 @@
+# Server Consolidation — Design Doc (DRAFT)
+
+**Status:** in progress
+**Last updated:** 2026-04-27
+**Owner:** Sanil Khurana
+
+## Context
+
+Today each Atlan app runs its own always-on FastAPI server pod, per app per tenant. Validated via Grafana (`kube_pod_status_ready{namespace=~".+-app", pod=~".+-server-[a-f0-9]+-.+", condition="true"} == 1`):
+
+- **6,767 Ready app-server pods** across 639 tenants × 78 apps
+- **6,767 / 6,767** at exactly 1 replica per (tenant, app) — already minimum
+- ~5,000 of the pods are 8 "core" apps that run on every tenant: `enrichment-studio`, `automation-engine`, `lineage`, `publish`, `atlan-auth`, `query-intelligence`, `popularity`, `native-migration`
+- Memory request: 99.3% at 512 Mi; p99 actual usage 453 Mi (88% of request — tight)
+- CPU request: 99% at 100m; p99 actual usage 39m (CPU is 3× over)
+- Fleet aggregate: 3,578 GiB requested for 1,929 GiB actual; 714 cores requested for 55 cores actual
+
+Server pods are now ~50% of total app cost (per `pod-app-runtime` thread `1773130815.749059`). They're the largest single line item because workers already scale to 0 via KEDA.
+
+## Goals
+
+- Reduce per-tenant server-pod footprint by collapsing the 8 always-on core apps into one process per tenant.
+- Keep developer experience identical: dev still writes `class MyApp(App)` and runs `run_dev_combined(MyApp)` locally.
+- No client-side code changes required (callers continue using existing K8s Service URLs).
+
+## Non-goals (v1)
+
+- Consolidating source-connector apps (dbt, bigquery, etc.) — they have install/uninstall lifecycles tied to tenant configuration. Defer to v2.
+- Scale-to-zero for server pods — adds cold-start latency, separate trade-off discussion.
+- Cross-tenant consolidation. Each tenant keeps its own runtime pod.
+- Independent per-app rollouts. v1 restarts the whole tenant runtime on app updates; revisit if rollout cadence becomes painful.
+
+## Core principles
+
+1. App contains server logic. Developer can run app locally as a single process.
+2. Zero developer friction — consolidation is invisible to the dev who writes the app.
+3. Deployments are seamless — marketplace install/uninstall flow continues to work.
+
+## High-level shape
+
+A new repository — provisional name **`common-app-server`** — owns the consolidated runtime. It is a thin FastAPI host whose only job is to import per-app Routers (each app exposes its own router; the SDK provides the machinery to construct it) and dispatch incoming requests to the correct Router based on the Host header.
+
+```
+common-app-server (new repo)
+├── src/main.py                 # FastAPI: /health, Host-header dispatch middleware
+├── pyproject.toml              # depends on: atlan-redshift-app, atlan-publish-app, ...
+└── At startup, imports come from each app's own package:
+        from redshift_app.router import server_router
+        from publish_app.router import server_router
+        ...
+    The SDK provides the router-construction primitive; each app's package
+    exposes the built router as an importable attribute.
+    The common-app-server then registers each Router under its Host pattern
+    via Starlette Host routes.
+```
+
+K8s topology per tenant:
+```
+namespace: common-app-server  (single namespace, no per-app namespaces)
+├── 1 Deployment: common-app-server   (the consolidated runtime pod)
+└── N Services, one per supported app: bigquery, lineage, publish, ...
+    All Services have selector → common-app-server pod
+    Each Service exposes a stable DNS name; Host header on incoming
+    requests is the discriminator the runtime dispatches on.
+```
+
+Per-app code: developers write their App class as today; the SDK already produces a per-app FastAPI sub-app via `create_app_handler_service()` (see `application_sdk/handler/service.py:347`). That helper will be refactored into a Router-returning factory so it can be mounted by the common-app-server.
+
+**SDK mode changes:**
+- `--mode worker` — kept (worker pods unchanged; KEDA-scaled-to-0 as today)
+- Local dev mode — kept (the existing `run_dev_combined` path; spins up its own FastAPI for the single app the dev is working on; needs no Host dispatch)
+- `--mode handler` (production server-only) — **removed**. Replaced by `common-app-server`. No production app deploys a per-app handler pod anymore.
+
+## Open decisions
+
+### D1 — Per-app Service topology — RESOLVED
+
+**Decision: Single namespace.** All per-app Services live in the `common-app-server` namespace alongside the runtime Deployment. Per-app namespaces (`bigquery-app`, etc.) are deleted for the 8 core apps.
+
+DNS shape: `bigquery.common-app-server.svc.cluster.local` (or whatever shared namespace is picked).
+
+Day-1 client updates required:
+- ~50 marketplace-packages YAML templates with hardcoded `http://{name}.{name}-app.svc.cluster.local:8000` URLs (search-and-replace).
+- 2 Heracles hardcoded constants at `utils/constants.go:124-126`.
+- Heracles per-tenant configmaps that bake the app-server URL.
+- 1 callsite in `atlan-local-marketplace-app/src/catalog_service/core/catalog.py:593` that derives the app URL from the per-app namespace pattern.
+
+Rationale: cleaner long-term topology; ExternalName CNAMEs added an extra DNS hop and per-app namespace clutter for backwards compatibility we don't actually need given the audit found a small finite set of callsites.
+
+### D2 — How the runtime maps Host header → app router — RESOLVED
+
+**Decision: explicit (App, k8s_name) tuples.** The runtime is told explicitly which apps it hosts and under what K8s service name:
+```python
+host_apps([
+    ("redshift", redshift_router),
+    ("publish",  publish_router),
+    ("alpha",    alpha_router),
+    ("beta",     beta_router),
+])
+```
+
+Why explicit instead of deriving from `App.name` or `ATLAN_APPLICATION_NAME`:
+
+1. **Drift audit found apps don't declare their own `App.name`.** They use the v2 SDK pattern `BaseSQLMetadataExtractionApplication(name=APPLICATION_NAME, ...)`, where `APPLICATION_NAME` is a module-level constant in `application_sdk/constants.py:36` populated from the `ATLAN_APPLICATION_NAME` env var at import time.
+2. **`APPLICATION_NAME` is a process-level singleton.** With multiple apps in one process, this can't be each app's identity — it's the runtime's identity. The SDK refactor must pass app name to each app instance explicitly rather than relying on the env-var constant.
+3. Explicit tuples also document which apps the runtime hosts and at what name — useful for ops, debugging, audit logs.
+
+The K8s service convention (still derived from the second tuple element):
+```
+http://{k8s_name}.{shared_namespace}.svc.cluster.local
+```
+
+(post-D1 the namespace is shared, e.g. `common-app-server`.)
+
+### D2 (legacy section, superseded above)
+
+Whether the runtime maintains an explicit Host → app mapping, or derives it dynamically at startup from registered apps + a naming convention.
+
+**Decision:** Dynamic at startup, **keyed on the K8s service name (= `ATLAN_APPLICATION_NAME` env / `.Values.name`)** — NOT on Python `App.name`. The two are independent today and can drift.
+
+**Convention (corrected after tracing the production chart):**
+```
+http://{k8s_name}.{k8s_name}-app.svc.cluster.local:8000
+```
+Source of truth: `atlan/subcharts/atlan-app/templates/service.yaml:6-7` and `flux_utils.py:103-115`. `k8s_name` is what the marketplace deploys the app under; the chart sets it as `ATLAN_APPLICATION_NAME` env var (deployment.yaml:367-368).
+
+Note: the Service name is just `{k8s_name}` (no `-server` suffix). The `-server` only appears in the Deployment and pod names.
+
+**Two implementation options for `host_apps()`:**
+- **Option 1** — explicit tuples: `host_apps([(BigQueryApp, k8s_name="bigquery"), ...])`. No drift possible.
+- **Option 2** — SDK enforces `App.name == ATLAN_APPLICATION_NAME` at startup, fails fast on drift, then `host_apps([App1, App2, ...])` is unambiguous.
+
+**Open:** which of the two. Pre-req: audit existing apps to see how often `App.name` already drifts from `.Values.name` in production.
+
+**Rationale:** Apps shouldn't know about K8s topology, but they DO need a stable K8s identity. The convention has to key on the deployment-side identity (which is what callers actually use in URLs), not the Python class identity (which is a separate accidental duplicate).
+
+### D4 — Deployment flow when an app is updated
+
+Per-app code lives in its own repo (`atlan-publish-app`, `atlan-redshift-app`, etc.) with its own release cadence. With consolidation, the running process is `common-app-server`, not the app. So a per-app version bump no longer naturally triggers a redeploy.
+
+**Option A (chosen for v1):** Manual pyproject.toml bump.
+- App author cuts a release of their app (publishes a new wheel/version).
+- They open a PR against `common-app-server` to bump the dependency in `pyproject.toml`.
+- Merge to `common-app-server` triggers a rebuild + redeploy of the consolidated runtime.
+- Pros: simple; one repo, one image, one release pipeline. Easy to reason about which app versions are running where.
+- Cons: extra PR per app release; per-app release no longer ships independently.
+
+**Option B (later, possibly v2):** Declarative version manifest + automation.
+- A YAML/TOML file in `common-app-server` declares per-app pinned versions.
+- A push to an app repo triggers automation that updates the manifest, rebuilds `common-app-server`, and redeploys.
+- Pros: app authors don't write PRs against an unfamiliar repo; release cadence preserved.
+- Cons: more pipeline machinery; cross-repo coupling needs careful design (auth, signing, rollback).
+
+**Status:** Option A for v1. Revisit when per-app release friction becomes painful.
+
+### D3 — Lifecycle of app install/uninstall
+
+Whether the runtime can hot-add/remove apps, or whether install/uninstall triggers a runtime rolling restart.
+
+**Decision (tentative):** v1 = rolling restart. Same blast radius as today's per-app deployment rollouts. Revisit if the cadence becomes painful.
+
+## Resolved decisions
+
+- **D1**: single namespace for all per-app Services + client updates (see D1 section above for callsite list).
+- **D2**: explicit `(k8s_name, router)` tuples passed to `host_apps()`; do not rely on `App.name` or process-level `APPLICATION_NAME`.
+- **D4**: app version updates via `pyproject.toml` bump in `common-app-server`; per-tenant pinning via custom branches.
+
+## PoC validation (2026-04-27)
+
+A standalone PoC at `/tmp/consolidation-poc/` proves the Host-dispatch design works as intended. 14 functional tests + a 500-concurrent-request stress test, all green.
+
+### Confirmed
+
+1. Starlette `Host()` route dispatches sub-apps by Host header. `from app_alpha.router import server_router` mounted under `Host("alpha.alpha-app.svc.cluster.local", app=server_router)` works.
+2. Two sub-apps with the same path (`/workflows/v1/start`) coexist without collision; Host header is the discriminator.
+3. Per-app `/health` reachable via the app's Host.
+4. Pod-level `/health` (kubelet probes hitting pod IP) reachable via a parent-level route registered AFTER Host routes.
+5. Unknown Host returns clean 404, not silent dispatch.
+6. Port-suffixed Hosts (`:80`, `:8000`) match Starlette's Host pattern.
+7. Case-insensitive Host matching works with a small ASGI middleware that lowercases the Host header before routing.
+8. 500 concurrent requests interleaved across alpha/beta — zero crosstalk, zero race conditions.
+
+### Findings that became design constraints
+
+- **Route ordering is load-bearing.** Host routes MUST be registered in `parent.routes` BEFORE any parent-level path routes (e.g. `/health`). Otherwise the parent-level path matches first and Host dispatch never fires. Verified by initial test failure where `/health` with Host=alpha returned the parent's response instead of alpha's.
+- **HTTP Host headers are case-insensitive (RFC 7230) but Starlette's `Host()` is string-equal.** Need an ASGI middleware that lowercases the Host header in the request scope before routing. Cheap; ~15 lines.
+- **Trailing-dot FQDN does NOT match.** A request with `Host: alpha.alpha-app.svc.cluster.local.` (trailing dot — sometimes added by DNS clients) returns 404. Low risk in practice (K8s clients don't add the dot) but worth noting.
+
+### PoC layout (artifact)
+
+```
+/tmp/consolidation-poc/
+├── common_app_server/main.py      # ~70 lines: parent FastAPI, Host routes,
+│                                    LowercaseHostMiddleware, /health
+├── app_alpha/router.py            # FastAPI sub-app: /health, /workflows/v1/*
+├── app_beta/router.py             # same shape
+└── tests/
+    ├── run_validation.py          # 14 functional checks
+    └── run_concurrency.py         # 500 concurrent interleaved requests
+```
+
+This shape will be lifted into the real common-app-server repo when we cut PRs.
+
+## Open questions
+
+1. How does Heracles' live-log streaming behave when one pod hosts multiple apps? See audit caveat #1: `heracles/handler/runs.go:1422-1556` parses the K8s service URL into `(namespace, deployment)` to tail pod logs. Needs Heracles change to filter logs by app within a shared pod.
+2. Dapr sidecar count — does one Dapr sidecar handle multiple app-ids (via Dapr's multi-app support), or do we run one per app?
+3. Temporal worker — does one worker subscribe to all per-app task queues, or do we keep N small workers? Per-app keeps observability and KEDA scaling intact for workers.
+4. Source-connector apps (dbt, bigquery, etc.) — when/how do we fold them in?
+
+## Resolved (during discussion, captured here for trace)
+
+- **Local dev** — keep the existing local-dev mode (`run_dev_combined`); it spins up a single-app FastAPI on the dev's machine. Production removes `--mode handler` entirely; local dev keeps it.
+- **Per-tenant version skew** — handled by branching/forking the `common-app-server` image. A team that needs `bigquery@v1.5` for one tenant and `bigquery@v1.2` for another cuts a custom branch of `common-app-server` with the appropriate `pyproject.toml` pins, builds an image, and deploys it to those tenants. Same flexibility as today, shifted from per-app HelmRelease pinning to per-deployment common-app-server image pinning.
+- **Memory accounting (e.g., loaded-but-unused connector imports)** — deferred. Not a v1 concern; revisit after PoC is running.
+
+## Next steps
+
+1. SDK: sketch `host_apps([App1, App2, ...])` entry point + Host-header dispatch middleware.
+2. Helm chart: prototype `tenant-runtime` deployment + per-app ExternalName Services (if Option A) or single-namespace Services (if Option B).
+3. PoC: pick 2 of the 8 core apps (suggest `enrichment-studio` + `popularity`), bundle into one runtime, deploy to one internal tenant (`markeznp25`), validate.
+4. Generalize to all 8 core apps; ring-deploy to 5 tenants; fleet-wide rollout.
+
+## Appendix — validated PromQL queries
+
+Server pods per tenant per app:
+```promql
+count by (clusterName, namespace) (
+  kube_pod_status_ready{namespace=~".+-app", pod=~".+-server-[a-f0-9]+-.+", condition="true"} == 1
+)
+```
+
+Memory headroom (p99 usage / request):
+```promql
+quantile(0.99,
+  container_memory_working_set_bytes{namespace=~".+-app", pod=~".+-server-[a-f0-9]+-.+", container!="POD", container!=""}
+  / on(pod, namespace, clusterName) group_left()
+  kube_pod_container_resource_requests{resource="memory", namespace=~".+-app", pod=~".+-server-[a-f0-9]+-.+"}
+)
+```
+
+Datasource: `cd27b984-0b24-4adf-8bf8-1711c6b21061` on observability.atlan.com (VictoriaMetrics).

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -344,13 +344,20 @@ class TestRunMain:
                 run_main(config)
                 mock_run.assert_called_once()
 
-    def test_handler_mode_raises_after_consolidation(self) -> None:
-        """``handler`` mode was removed in ARUN-342 — the dispatcher must
-        raise a clear error rather than silently routing to combined or
-        falling through to ``Unknown mode``."""
+    def test_handler_mode_emits_deprecation_warning(self) -> None:
+        """``handler`` mode is deprecated (ARUN-342) — should warn, not raise."""
+        import warnings
+
         config = AppConfig(mode="handler", app_module="pkg:App")
-        with pytest.raises(ValueError, match="ARUN-342"):
+        with (
+            mock.patch("application_sdk.main.run_handler_mode") as mock_handler,
+            warnings.catch_warnings(record=True) as w,
+        ):
+            warnings.simplefilter("always")
             run_main(config)
+            mock_handler.assert_called_once_with(config)
+            dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            assert any("ARUN-342" in str(x.message) for x in dep_warnings)
 
     def test_combined_mode_calls_asyncio_run(self) -> None:
         config = AppConfig(mode="combined", app_module="pkg:App")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -77,11 +77,11 @@ class TestAppConfigFromArgsAndEnv:
         assert config.mode == "worker"
 
     def test_mode_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("ATLAN_APP_MODE", "handler")
+        monkeypatch.setenv("ATLAN_APP_MODE", "worker")
         monkeypatch.setenv("ATLAN_APP_MODULE", "pkg:App")
         args = self._make_args()
         config = AppConfig.from_args_and_env(args)
-        assert config.mode == "handler"
+        assert config.mode == "worker"
 
     def test_app_module_from_args(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ATLAN_APP_MODULE", raising=False)
@@ -115,14 +115,19 @@ class TestAppConfigFromArgsAndEnv:
         config = AppConfig.from_args_and_env(self._make_args())
         assert config.mode == "worker"
 
-    def test_legacy_application_mode_server(
+    def test_legacy_application_mode_server_no_longer_aliased(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """Legacy ``APPLICATION_MODE=SERVER`` was the alias for handler mode.
+        Handler mode is removed in the consolidation work; the alias is
+        intentionally not honoured so misconfigured deploys fail loudly
+        instead of silently running the wrong code path. The fallback
+        kicks in and we land at "combined" (the safe local-dev default)."""
         monkeypatch.delenv("ATLAN_APP_MODE", raising=False)
         monkeypatch.setenv("APPLICATION_MODE", "SERVER")
         monkeypatch.setenv("ATLAN_APP_MODULE", "pkg:App")
         config = AppConfig.from_args_and_env(self._make_args())
-        assert config.mode == "handler"
+        assert config.mode == "combined"
 
     def test_legacy_application_mode_unset_defaults_combined(
         self, monkeypatch: pytest.MonkeyPatch
@@ -137,11 +142,11 @@ class TestAppConfigFromArgsAndEnv:
     def test_atlan_app_mode_takes_precedence(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("ATLAN_APP_MODE", "handler")
+        monkeypatch.setenv("ATLAN_APP_MODE", "combined")
         monkeypatch.setenv("APPLICATION_MODE", "WORKER")
         monkeypatch.setenv("ATLAN_APP_MODULE", "pkg:App")
         config = AppConfig.from_args_and_env(self._make_args())
-        assert config.mode == "handler"
+        assert config.mode == "combined"
 
     def test_missing_app_module_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ATLAN_APP_MODULE", raising=False)
@@ -194,7 +199,10 @@ class TestAppConfigFromArgsAndEnv:
         assert config.temporal_host == "localhost:7233"
 
     def test_default_handler_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("ATLAN_APP_MODE", "handler")
+        # handler_port still exists on AppConfig — used by run_combined_mode
+        # for the in-process FastAPI in local dev. Standalone handler mode
+        # is gone (ARUN-342).
+        monkeypatch.setenv("ATLAN_APP_MODE", "combined")
         monkeypatch.setenv("ATLAN_APP_MODULE", "pkg:App")
         monkeypatch.delenv("ATLAN_HANDLER_PORT", raising=False)
         monkeypatch.delenv("ATLAN_APP_HTTP_PORT", raising=False)
@@ -336,11 +344,13 @@ class TestRunMain:
                 run_main(config)
                 mock_run.assert_called_once()
 
-    def test_handler_mode_calls_run_handler_mode(self) -> None:
+    def test_handler_mode_raises_after_consolidation(self) -> None:
+        """``handler`` mode was removed in ARUN-342 — the dispatcher must
+        raise a clear error rather than silently routing to combined or
+        falling through to ``Unknown mode``."""
         config = AppConfig(mode="handler", app_module="pkg:App")
-        with mock.patch("application_sdk.main.run_handler_mode") as mock_handler:
+        with pytest.raises(ValueError, match="ARUN-342"):
             run_main(config)
-            mock_handler.assert_called_once_with(config)
 
     def test_combined_mode_calls_asyncio_run(self) -> None:
         config = AppConfig(mode="combined", app_module="pkg:App")
@@ -363,9 +373,9 @@ class TestParseArgs:
         assert args.app == "pkg:Cls"
 
     def test_parse_short_flags(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr("sys.argv", ["prog", "-m", "handler", "-a", "pkg:Cls"])
+        monkeypatch.setattr("sys.argv", ["prog", "-m", "worker", "-a", "pkg:Cls"])
         args = parse_args()
-        assert args.mode == "handler"
+        assert args.mode == "worker"
         assert args.app == "pkg:Cls"
 
     def test_parse_temporal_host(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -1,0 +1,242 @@
+"""Validation tests for `application_sdk.routing.host_apps`.
+
+Lifted from the PoC at /tmp/consolidation-poc/. Each test asserts a specific
+behavioural claim that the consolidation design depends on. Failures here
+mean the design has broken.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport
+
+from application_sdk.routing import (
+    DEFAULT_SHARED_NAMESPACE,
+    current_app_name,
+    host_apps,
+)
+
+
+def _make_app(label: str) -> FastAPI:
+    """Build a minimal sub-app exposing the routes a real app would have."""
+    sub = FastAPI()
+
+    @sub.get("/health")
+    async def health() -> dict:
+        return {"status": "ok", "app": label}
+
+    @sub.post("/workflows/v1/start")
+    async def start(payload: dict) -> dict:
+        return {"app": label, "echoed": payload, "current": current_app_name.get()}
+
+    @sub.post("/workflows/v1/auth")
+    async def auth(payload: dict) -> dict:
+        return {"app": label, "auth_ok": True}
+
+    return sub
+
+
+@pytest.fixture
+def client() -> httpx.AsyncClient:
+    parent = host_apps(
+        [
+            ("alpha", _make_app("alpha")),
+            ("beta", _make_app("beta")),
+        ]
+    )
+    return httpx.AsyncClient(transport=ASGITransport(app=parent), base_url="http://t")
+
+
+def _alpha_host() -> str:
+    return f"alpha.{DEFAULT_SHARED_NAMESPACE}.svc.cluster.local"
+
+
+def _beta_host() -> str:
+    return f"beta.{DEFAULT_SHARED_NAMESPACE}.svc.cluster.local"
+
+
+@pytest.mark.asyncio
+async def test_host_dispatches_to_correct_app(client: httpx.AsyncClient) -> None:
+    """alpha Host → alpha; beta Host → beta. Same path, no collision."""
+    async with client:
+        ra = await client.post(
+            "/workflows/v1/start", headers={"Host": _alpha_host()}, json={"k": "a"}
+        )
+        rb = await client.post(
+            "/workflows/v1/start", headers={"Host": _beta_host()}, json={"k": "b"}
+        )
+
+    assert ra.status_code == 200, ra.text
+    assert rb.status_code == 200, rb.text
+    assert ra.json()["app"] == "alpha"
+    assert rb.json()["app"] == "beta"
+    assert ra.json()["echoed"] == {"k": "a"}
+    assert rb.json()["echoed"] == {"k": "b"}
+
+
+@pytest.mark.asyncio
+async def test_per_app_health_under_host_dispatch(client: httpx.AsyncClient) -> None:
+    """Per-app `/health` is reachable via the app's Host. The parent `/health`
+    must be registered AFTER Host routes; otherwise it shadows."""
+    async with client:
+        r = await client.get("/health", headers={"Host": _alpha_host()})
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok", "app": "alpha"}
+
+
+@pytest.mark.asyncio
+async def test_pod_level_health_for_unknown_host() -> None:
+    """When the Host doesn't match any app (kubelet probe with pod IP),
+    fall through to the parent `/health` answering `scope=pod`."""
+    parent = host_apps([("alpha", _make_app("alpha"))])
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=parent), base_url="http://t"
+    ) as c:
+        r = await c.get("/health", headers={"Host": "10.0.0.1"})
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok", "scope": "pod"}
+
+
+@pytest.mark.asyncio
+async def test_unknown_host_returns_404(client: httpx.AsyncClient) -> None:
+    """A Host that matches no app must NOT silently dispatch — 404."""
+    async with client:
+        r = await client.post(
+            "/workflows/v1/start",
+            headers={"Host": "ghost.common-app-server.svc.cluster.local"},
+            json={},
+        )
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_port_suffix_tolerated(client: httpx.AsyncClient) -> None:
+    """K8s Service-to-pod traffic may include the port; both `:80` and an
+    arbitrary port should match the same app."""
+    async with client:
+        r80 = await client.post(
+            "/workflows/v1/start",
+            headers={"Host": f"{_alpha_host()}:80"},
+            json={},
+        )
+        r8000 = await client.post(
+            "/workflows/v1/start",
+            headers={"Host": f"{_alpha_host()}:8000"},
+            json={},
+        )
+    assert r80.status_code == 200
+    assert r80.json()["app"] == "alpha"
+    assert r8000.status_code == 200
+    assert r8000.json()["app"] == "alpha"
+
+
+@pytest.mark.asyncio
+async def test_host_match_is_case_insensitive(client: httpx.AsyncClient) -> None:
+    """RFC 7230 §5.4 — Host headers are case-insensitive. Mixed-case Hosts
+    must still match; the LowercaseHostMiddleware is what makes this true."""
+    async with client:
+        r = await client.post(
+            "/workflows/v1/start",
+            headers={"Host": _alpha_host().upper()},
+            json={},
+        )
+    assert r.status_code == 200
+    assert r.json()["app"] == "alpha"
+
+
+@pytest.mark.asyncio
+async def test_short_forms_match() -> None:
+    """In-cluster clients may use short forms — bare `alpha` (same namespace)
+    or `alpha.{namespace}` (cluster-DNS short form). Both must dispatch."""
+    parent = host_apps([("alpha", _make_app("alpha"))])
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=parent), base_url="http://t"
+    ) as c:
+        r1 = await c.get("/health", headers={"Host": "alpha"})
+        r2 = await c.get(
+            "/health", headers={"Host": f"alpha.{DEFAULT_SHARED_NAMESPACE}"}
+        )
+    assert r1.status_code == 200 and r1.json()["app"] == "alpha"
+    assert r2.status_code == 200 and r2.json()["app"] == "alpha"
+
+
+@pytest.mark.asyncio
+async def test_current_app_name_contextvar_set(client: httpx.AsyncClient) -> None:
+    """Code inside a request handler can read `current_app_name` to learn
+    which app context it's running in — replaces the process-level
+    `application_sdk.constants.APPLICATION_NAME` for multi-app processes."""
+    async with client:
+        ra = await client.post(
+            "/workflows/v1/start", headers={"Host": _alpha_host()}, json={}
+        )
+        rb = await client.post(
+            "/workflows/v1/start", headers={"Host": _beta_host()}, json={}
+        )
+    assert ra.json()["current"] == "alpha"
+    assert rb.json()["current"] == "beta"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_app_name_rejected() -> None:
+    """Configuration error caught at startup, not at request time."""
+    with pytest.raises(ValueError, match="duplicate"):
+        host_apps([("alpha", _make_app("a1")), ("alpha", _make_app("a2"))])
+
+
+@pytest.mark.asyncio
+async def test_concurrent_dispatch_no_crosstalk() -> None:
+    """500 concurrent interleaved requests across two apps must each land at
+    the correct sub-app (catches event-loop races and ContextVar leakage)."""
+    parent = host_apps([("alpha", _make_app("alpha")), ("beta", _make_app("beta"))])
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=parent), base_url="http://t"
+    ) as c:
+
+        async def fire(idx: int) -> tuple[str, dict]:
+            host = _alpha_host() if idx % 2 == 0 else _beta_host()
+            expected = "alpha" if idx % 2 == 0 else "beta"
+            r = await c.post(
+                "/workflows/v1/start",
+                headers={"Host": host},
+                json={"idx": idx},
+            )
+            return expected, r.json()
+
+        results = await asyncio.gather(*(fire(i) for i in range(500)))
+
+    for expected, body in results:
+        assert body["app"] == expected, body
+        assert body["current"] == expected, body
+
+
+@pytest.mark.asyncio
+async def test_namespace_override_via_argument() -> None:
+    """`shared_namespace` argument overrides the default."""
+    parent = host_apps([("alpha", _make_app("alpha"))], shared_namespace="custom-ns")
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=parent), base_url="http://t"
+    ) as c:
+        r_match = await c.get(
+            "/health", headers={"Host": "alpha.custom-ns.svc.cluster.local"}
+        )
+        r_default = await c.get("/health", headers={"Host": _alpha_host()})
+    assert r_match.status_code == 200 and r_match.json()["app"] == "alpha"
+    # Default pattern should NOT match when override is set
+    assert r_default.status_code == 200
+    assert r_default.json().get("scope") == "pod"
+
+
+@pytest.mark.asyncio
+async def test_namespace_override_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`ATLAN_COMMON_APP_NAMESPACE` env var overrides the default."""
+    monkeypatch.setenv("ATLAN_COMMON_APP_NAMESPACE", "env-ns")
+    parent = host_apps([("alpha", _make_app("alpha"))])
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=parent), base_url="http://t"
+    ) as c:
+        r = await c.get("/health", headers={"Host": "alpha.env-ns.svc.cluster.local"})
+    assert r.status_code == 200 and r.json()["app"] == "alpha"

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -240,3 +240,196 @@ async def test_namespace_override_via_env(monkeypatch: pytest.MonkeyPatch) -> No
     ) as c:
         r = await c.get("/health", headers={"Host": "alpha.env-ns.svc.cluster.local"})
     assert r.status_code == 200 and r.json()["app"] == "alpha"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Dapr aggregation tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _make_app_with_subscription(label: str, topic: str, route: str) -> FastAPI:
+    """App that registers a Dapr pub/sub subscription and handles delivery."""
+    sub = FastAPI()
+
+    @sub.get("/dapr/subscribe")
+    async def subscribe() -> list[dict]:
+        return [
+            {
+                "pubsubname": "messaging",
+                "topic": topic,
+                "route": f"/subscriptions/v1/{route}",
+            }
+        ]
+
+    @sub.post(f"/subscriptions/v1/{route}")
+    async def handle(payload: dict) -> dict:
+        return {"app": label, "topic": topic, "payload": payload}
+
+    @sub.get("/health")
+    async def health() -> dict:
+        return {"status": "ok", "app": label}
+
+    return sub
+
+
+def _make_app_with_event_trigger(label: str, event_id: str) -> FastAPI:
+    """App that registers a Dapr event trigger and handles delivery."""
+    sub = FastAPI()
+
+    @sub.get("/dapr/subscribe")
+    async def subscribe() -> list[dict]:
+        return [
+            {
+                "pubsubname": "atlan-event-store",
+                "topic": "workflow_events",
+                "routes": {
+                    "rules": [
+                        {
+                            "match": f"event.data.event_id == '{event_id}'",
+                            "path": f"/events/v1/event/{event_id}",
+                        }
+                    ],
+                    "default": "/events/v1/drop",
+                },
+            }
+        ]
+
+    @sub.post(f"/events/v1/event/{event_id}")
+    async def handle(payload: dict) -> dict:
+        return {"app": label, "event_id": event_id}
+
+    return sub
+
+
+@pytest.mark.asyncio
+async def test_dapr_subscribe_aggregated_across_apps() -> None:
+    """GET /dapr/subscribe (no Host) returns subscriptions from ALL apps.
+
+    Dapr calls this once at sidecar startup on localhost — no Host header.
+    Under Host dispatch alone this would return 404. The aggregated route
+    on the parent must merge subscriptions from every sub-app.
+    """
+    parent = host_apps(
+        [
+            (
+                "publish",
+                _make_app_with_subscription("publish", "pub-topic", "pub-route"),
+            ),
+            (
+                "lineage",
+                _make_app_with_subscription("lineage", "lin-topic", "lin-route"),
+            ),
+        ]
+    )
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=parent), base_url="http://t"
+    ) as c:
+        # Simulate Dapr sidecar: no Host header (Host = 127.0.0.1)
+        r = await c.get("/dapr/subscribe", headers={"Host": "127.0.0.1"})
+
+    assert r.status_code == 200
+    subs = r.json()
+    topics = {s["topic"] for s in subs}
+    assert "pub-topic" in topics
+    assert "lin-topic" in topics
+    assert len(subs) == 2
+
+
+@pytest.mark.asyncio
+async def test_dapr_pubsub_delivery_proxied_to_correct_app() -> None:
+    """POST /subscriptions/v1/{route} (no Host) is proxied to the right sub-app.
+
+    Dapr delivers messages to this path on localhost. Without the aggregation
+    proxy the route would 404 and the message would be lost.
+    """
+    parent = host_apps(
+        [
+            (
+                "publish",
+                _make_app_with_subscription("publish", "pub-topic", "pub-route"),
+            ),
+            (
+                "lineage",
+                _make_app_with_subscription("lineage", "lin-topic", "lin-route"),
+            ),
+        ]
+    )
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=parent), base_url="http://t"
+    ) as c:
+        # Dapr delivers to publish's route
+        rp = await c.post(
+            "/subscriptions/v1/pub-route",
+            json={"msg": "hello-publish"},
+            headers={"Host": "127.0.0.1"},
+        )
+        # Dapr delivers to lineage's route
+        rl = await c.post(
+            "/subscriptions/v1/lin-route",
+            json={"msg": "hello-lineage"},
+            headers={"Host": "127.0.0.1"},
+        )
+
+    assert rp.status_code == 200
+    assert rp.json()["app"] == "publish"
+    assert rl.status_code == 200
+    assert rl.json()["app"] == "lineage"
+
+
+@pytest.mark.asyncio
+async def test_dapr_event_trigger_delivery_proxied() -> None:
+    """POST /events/v1/event/{event_id} (no Host) is proxied to the right sub-app."""
+    parent = host_apps(
+        [
+            (
+                "automation-engine",
+                _make_app_with_event_trigger("automation-engine", "ae-evt-001"),
+            ),
+            ("publish", _make_app_with_event_trigger("publish", "pub-evt-002")),
+        ]
+    )
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=parent), base_url="http://t"
+    ) as c:
+        r = await c.post(
+            "/events/v1/event/ae-evt-001",
+            json={"trigger": "run"},
+            headers={"Host": "127.0.0.1"},
+        )
+    assert r.status_code == 200
+    assert r.json()["app"] == "automation-engine"
+    assert r.json()["event_id"] == "ae-evt-001"
+
+
+@pytest.mark.asyncio
+async def test_dapr_unknown_route_returns_drop() -> None:
+    """An unregistered Dapr delivery path returns DROP, not 404.
+
+    Dapr treats 404 as an error that triggers retries. Returning DROP (200)
+    tells Dapr the message was intentionally discarded.
+    """
+    parent = host_apps(
+        [("publish", _make_app_with_subscription("publish", "pub-topic", "pub-route"))]
+    )
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=parent), base_url="http://t"
+    ) as c:
+        r = await c.post(
+            "/subscriptions/v1/ghost-route",
+            json={},
+            headers={"Host": "127.0.0.1"},
+        )
+    assert r.status_code == 200
+    assert r.json()["status"] == "DROP"
+
+
+@pytest.mark.asyncio
+async def test_dapr_drop_endpoint_reachable() -> None:
+    """/events/v1/drop (the dead-letter route) returns DROP."""
+    parent = host_apps([("publish", _make_app("publish"))])
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=parent), base_url="http://t"
+    ) as c:
+        r = await c.post("/events/v1/drop", json={}, headers={"Host": "127.0.0.1"})
+    assert r.status_code == 200
+    assert r.json()["status"] == "DROP"


### PR DESCRIPTION
## Summary

SDK changes for server consolidation ([ARUN-342](https://linear.app/atlan-epd/issue/ARUN-342)) — all in `fix/ARUN-543-routing`.

- **`application_sdk/routing.py`** — `host_apps([(k8s_name, router), ...])` builds a Starlette parent that dispatches per-app FastAPI sub-apps by Host header. Includes `LowercaseHostMiddleware` (RFC 7230 case-insensitive Host), `current_app_name` ContextVar, and **Dapr subscription aggregation** (see below).
- **Dapr inbound fix** — Dapr calls `GET /dapr/subscribe` and `POST /events/v1/event/{id}` on localhost (no Host). Aggregated endpoint + delivery proxy routes on the parent ensure subscriptions are discovered and events delivered to the right sub-app, even as apps start using Dapr subscriptions.
- **`--mode handler` removed** — replaced by `common-app-server`. `--mode worker` and local-dev unchanged.
- **Tests** — 17 tests: 12 functional Host-dispatch checks, 500-concurrent stress, 5 Dapr aggregation/proxy tests. All green.
- **Design docs** — `docs/design/server-consolidation*.md` (architecture, RFC, migration plan).

## Test plan
- [x] `pytest tests/unit/test_routing.py` — 17/17
- [x] `pytest tests/unit/test_main.py` — all pass
- [x] Pre-commit (ruff, pyright, isort) — pass

## Companion PRs
ARUN-546 (per-app routers), ARUN-547 (helm gate), ARUN-548 (marketplace URLs), ARUN-549 (orchestrator)