### PR TITLE
fix(observability): coerce None unit/description in metrics adaptor

### DIFF
--- a/application_sdk/observability/metrics_adaptor.py
+++ b/application_sdk/observability/metrics_adaptor.py
@@ -247,25 +247,33 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
                 for k, v in metric_record.labels.items()
                 if isinstance(v, (str, int, float, bool))
             }
+            # OTel's Meter.create_*() builds an instrument identifier via
+            # ``",".join((name, type, unit, description))`` — passing ``None``
+            # for either ``unit`` or ``description`` raises ``TypeError``.
+            # Coerce to empty strings (which OTel treats as "unset"). Without
+            # this guard, every middleware-emitted metric tracebacks because
+            # ``record_metric()`` defaults both kwargs to ``None``.
+            unit = metric_record.unit or ""
+            description = metric_record.description or ""
             if metric_record.type == MetricType.COUNTER:
                 counter = self.meter.create_counter(
                     name=metric_record.name,
-                    description=metric_record.description,
-                    unit=metric_record.unit,
+                    description=description,
+                    unit=unit,
                 )
                 counter.add(metric_record.value, otel_attrs)
             elif metric_record.type == MetricType.GAUGE:
                 gauge = self.meter.create_observable_gauge(
                     name=metric_record.name,
-                    description=metric_record.description,
-                    unit=metric_record.unit,
+                    description=description,
+                    unit=unit,
                 )
                 gauge.add(metric_record.value, otel_attrs)
             elif metric_record.type == MetricType.HISTOGRAM:
                 histogram = self.meter.create_histogram(
                     name=metric_record.name,
-                    description=metric_record.description,
-                    unit=metric_record.unit,
+                    description=description,
+                    unit=unit,
                 )
                 histogram.record(metric_record.value, otel_attrs)
         except Exception:

--- a/tests/unit/observability/test_metrics_adaptor.py
+++ b/tests/unit/observability/test_metrics_adaptor.py
@@ -270,6 +270,36 @@ def test_send_to_otel_histogram():
             mock_histogram.record.assert_called_once_with(42.0, {"test": "label"})
 
 
+def test_send_to_otel_coerces_none_unit_and_description():
+    """``MetricRecord.unit`` / ``description`` default to ``None``; the SDK
+    must coerce them to empty strings before handing off to OTel, otherwise
+    OTel's ``_register_instrument`` does ``",".join((..., unit, description))``
+    and raises ``TypeError``. Regression test for the middleware traceback
+    flood seen against application-sdk 3.3.0.
+    """
+    with create_metrics_adapter() as metrics_adapter:
+        with mock.patch.object(metrics_adapter.meter, "create_counter") as mock_create:
+            mock_create.return_value = mock.MagicMock()
+
+            record = MetricRecord(
+                timestamp=datetime.now().timestamp(),
+                name="http_requests_total",
+                value=1,
+                type=MetricType.COUNTER,
+                labels={"path": "/", "method": "GET", "status": "200"},
+                description=None,
+                unit=None,
+            )
+            # Should not raise — unit/description coerced to "" before OTel call.
+            metrics_adapter._send_to_otel(record)
+
+            mock_create.assert_called_once_with(
+                name="http_requests_total",
+                description="",
+                unit="",
+            )
+
+
 def test_send_to_otel_filters_non_scalar_labels():
     """Test that _send_to_otel() filters out non-scalar label values before passing to OTel."""
     with create_metrics_adapter() as metrics_adapter:


### PR DESCRIPTION
## Summary

`MetricRecord.unit` / `description` both default to `None`. `_send_to_otel` was forwarding those Nones straight into `meter.create_counter` / `create_observable_gauge` / `create_histogram`, and OpenTelemetry's `_register_instrument` does:

```python
instrument_id = ",".join((name, type, unit, description))
```

— which raises `TypeError: sequence item 2: expected str instance, NoneType found` on every record. The `try/except` in `_send_to_otel` swallows it so requests still return 200, but the traceback floods the logs.

The most visible repro is `application_sdk/server/middleware/metrics.py:35`, where the middleware records `http_requests_total` without a `unit` kwarg. Every connector dev server I run against 3.3.0 spams the console with one traceback per HTTP request (fonts, JS, manifest, configmap — anything middleware sees).

## Fix

Coerce both kwargs to `""` before the OTel call. OTel treats an empty string as "unset" — same end-state as `None` but parseable.

## Test

Adds `test_send_to_otel_coerces_none_unit_and_description` that asserts the http_requests_total-style record (no unit, no description) doesn't raise and that the OTel call receives `unit=""`, `description=""`.

## Test plan

- [x] `pytest tests/unit/observability/test_metrics_adaptor.py -k send_to_otel` — 5 passed
- [x] Cassandra dev server against the patched branch — middleware metric records cleanly, no tracebacks