### PR TITLE
draft: combine PR 1586 and SQL pool pre-ping for testing

### DIFF
--- a/application_sdk/clients/models.py
+++ b/application_sdk/clients/models.py
@@ -37,6 +37,10 @@ class DatabaseConfig(BaseModel):
         default_factory=dict,
         description="Additional connection arguments to be passed to SQLAlchemy. ex: {'sslmode': 'require'}",
     )
+    pool_pre_ping: bool = Field(
+        default=True,
+        description="Whether SQLAlchemy should test pooled connections for liveness before checkout. Disable for dialects or endpoints where the driver's ping/close path is unsafe.",
+    )
 
     model_config = {
         "extra": "forbid",

--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -106,7 +106,7 @@ class BaseSQLClient(ClientInterface):
             self.engine = create_engine(
                 self.get_sqlalchemy_connection_string(),
                 connect_args=self.DB_CONFIG.connect_args,
-                pool_pre_ping=True,
+                pool_pre_ping=self.DB_CONFIG.pool_pre_ping,
             )
 
             # Test connection briefly to validate credentials.
@@ -605,7 +605,7 @@ class AsyncBaseSQLClient(BaseSQLClient):
             self.engine = create_async_engine(
                 self.get_sqlalchemy_connection_string(),
                 connect_args=self.DB_CONFIG.connect_args,
-                pool_pre_ping=True,
+                pool_pre_ping=self.DB_CONFIG.pool_pre_ping,
             )
             if not self.engine:
                 raise ValueError("Failed to create async engine")

--- a/application_sdk/observability/metrics_adaptor.py
+++ b/application_sdk/observability/metrics_adaptor.py
@@ -242,6 +242,7 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
             Exception: If sending fails, logs error and continues
         """
         try:
+            description, unit = self._get_otel_instrument_metadata(metric_record)
             otel_attrs = {
                 k: v
                 for k, v in metric_record.labels.items()
@@ -250,26 +251,30 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
             if metric_record.type == MetricType.COUNTER:
                 counter = self.meter.create_counter(
                     name=metric_record.name,
-                    description=metric_record.description,
-                    unit=metric_record.unit,
+                    description=description,
+                    unit=unit,
                 )
                 counter.add(metric_record.value, otel_attrs)
             elif metric_record.type == MetricType.GAUGE:
-                gauge = self.meter.create_observable_gauge(
+                gauge = self.meter.create_gauge(
                     name=metric_record.name,
-                    description=metric_record.description,
-                    unit=metric_record.unit,
+                    description=description,
+                    unit=unit,
                 )
-                gauge.add(metric_record.value, otel_attrs)
+                gauge.set(metric_record.value, otel_attrs)
             elif metric_record.type == MetricType.HISTOGRAM:
                 histogram = self.meter.create_histogram(
                     name=metric_record.name,
-                    description=metric_record.description,
-                    unit=metric_record.unit,
+                    description=description,
+                    unit=unit,
                 )
                 histogram.record(metric_record.value, otel_attrs)
         except Exception:
             logging.error("Error sending metric to OpenTelemetry", exc_info=True)
+
+    @staticmethod
+    def _get_otel_instrument_metadata(metric_record: MetricRecord) -> tuple[str, str]:
+        return metric_record.description or "", metric_record.unit or ""
 
     def _log_to_console(self, metric_record: MetricRecord):
         """Log metric to console using the logger.

--- a/docs/concepts/clients.md
+++ b/docs/concepts/clients.md
@@ -36,6 +36,7 @@ Both SQL client classes are typically **subclassed** for specific database types
     *   **`parameters` (list[str], optional):** Optional keys appended as URL query parameters when present in `credentials`/`extra`.
     *   **`defaults` (dict[str, Any], optional):** Default URL parameters always appended unless already in the template.
     *   **`connect_args` (dict[str, Any], optional):** Additional connection arguments to be passed directly to SQLAlchemy's `create_engine` or `create_async_engine`. Useful for driver-specific connection parameters that are not part of the connection URL. Defaults to `{}`.
+    *   **`pool_pre_ping` (bool, optional):** Whether SQLAlchemy should test pooled connections for liveness before checkout. Defaults to `True` for backward compatibility; connector subclasses can set this to `False` when a dialect or endpoint has an unsafe ping/close path and the connector performs its own explicit validation query.
     *   **Credentials Note:** The `credentials` dictionary can include an `extra` field (JSON or dict). Lookups for `required` and `parameters` first check `credentials`, then `extra`.
 
 2.  **Loading (`load` method):**
@@ -62,6 +63,7 @@ class SnowflakeClient(BaseSQLClient):
         parameters=["warehouse", "role"],
         defaults={"client_session_keep_alive": "true"},
         connect_args={"sslmode": "require"},  # Optional: driver-specific connection arguments
+        pool_pre_ping=True,  # Optional: disable only if the dialect's pre-ping path is unsafe
     )
 ```
 

--- a/tests/unit/clients/test_async_sql_client.py
+++ b/tests/unit/clients/test_async_sql_client.py
@@ -83,6 +83,34 @@ async def test_load(
     assert async_sql_client.connection is None
 
 
+@patch("sqlalchemy.ext.asyncio.create_async_engine")
+@pytest.mark.asyncio
+async def test_load_respects_pool_pre_ping_override(
+    create_async_engine: Any,
+    async_sql_client: AsyncBaseSQLClient,
+    mock_async_engine_with_connection,
+):
+    assert async_sql_client.DB_CONFIG is not None
+    async_sql_client.DB_CONFIG = DatabaseConfig(
+        template="test://{username}:{password}@{host}:{port}/{database}",
+        required=["username", "password", "host", "port", "database"],
+        connect_args={},
+        pool_pre_ping=False,
+    )
+    mock_engine, _, _ = mock_async_engine_with_connection
+    create_async_engine.return_value = mock_engine
+
+    await async_sql_client.load({"username": "test_user", "password": "test_password"})
+
+    create_async_engine.assert_called_once_with(
+        async_sql_client.get_sqlalchemy_connection_string(),
+        connect_args=async_sql_client.DB_CONFIG.connect_args,
+        pool_pre_ping=False,
+    )
+    assert async_sql_client.engine == mock_engine
+    assert async_sql_client.connection is None
+
+
 @pytest.mark.asyncio
 @patch(
     "sqlalchemy.text",

--- a/tests/unit/clients/test_sql_client.py
+++ b/tests/unit/clients/test_sql_client.py
@@ -56,6 +56,31 @@ def test_load(mock_create_engine: Any, sql_client: BaseSQLClient):
     assert sql_client.connection is None
 
 
+@patch("sqlalchemy.create_engine")
+def test_load_respects_pool_pre_ping_override(
+    mock_create_engine: Any, sql_client: BaseSQLClient
+):
+    assert sql_client.DB_CONFIG is not None
+    sql_client.DB_CONFIG = DatabaseConfig(
+        template="test://{username}:{password}@{host}:{port}/{database}",
+        required=["username", "password", "host", "port", "database"],
+        connect_args={},
+        pool_pre_ping=False,
+    )
+    mock_engine = MagicMock()
+    mock_create_engine.return_value = mock_engine
+
+    asyncio.run(sql_client.load({"username": "test_user", "password": "test_password"}))
+
+    mock_create_engine.assert_called_once_with(
+        sql_client.get_sqlalchemy_connection_string(),
+        connect_args=sql_client.DB_CONFIG.connect_args,
+        pool_pre_ping=False,
+    )
+    assert sql_client.engine == mock_engine
+    assert sql_client.connection is None
+
+
 @pytest.mark.asyncio
 @patch("application_sdk.clients.sql.asyncio.to_thread")
 @patch("sqlalchemy.create_engine")

--- a/tests/unit/observability/test_metrics_adaptor.py
+++ b/tests/unit/observability/test_metrics_adaptor.py
@@ -217,9 +217,7 @@ def test_send_to_otel_counter():
 def test_send_to_otel_gauge():
     """Test _send_to_otel() method with gauge metric."""
     with create_metrics_adapter() as metrics_adapter:
-        with mock.patch.object(
-            metrics_adapter.meter, "create_observable_gauge"
-        ) as mock_create:
+        with mock.patch.object(metrics_adapter.meter, "create_gauge") as mock_create:
             mock_gauge = mock.MagicMock()
             mock_create.return_value = mock_gauge
 
@@ -239,7 +237,7 @@ def test_send_to_otel_gauge():
                 description="Test gauge",
                 unit="count",
             )
-            mock_gauge.add.assert_called_once_with(42.0, {"test": "label"})
+            mock_gauge.set.assert_called_once_with(42.0, {"test": "label"})
 
 
 def test_send_to_otel_histogram():
@@ -268,6 +266,110 @@ def test_send_to_otel_histogram():
                 unit="count",
             )
             mock_histogram.record.assert_called_once_with(42.0, {"test": "label"})
+
+
+def test_send_to_otel_normalizes_optional_metadata():
+    """Test unset description and unit are normalized before creating OTel instruments."""
+    with create_metrics_adapter() as metrics_adapter:
+        with (
+            mock.patch.object(metrics_adapter.meter, "create_counter") as mock_counter,
+            mock.patch.object(metrics_adapter.meter, "create_gauge") as mock_gauge,
+            mock.patch.object(
+                metrics_adapter.meter, "create_histogram"
+            ) as mock_histogram,
+        ):
+            mock_counter_instance = mock.MagicMock()
+            mock_gauge_instance = mock.MagicMock()
+            mock_histogram_instance = mock.MagicMock()
+            mock_counter.return_value = mock_counter_instance
+            mock_gauge.return_value = mock_gauge_instance
+            mock_histogram.return_value = mock_histogram_instance
+
+            counter_record = MetricRecord(
+                timestamp=datetime.now().timestamp(),
+                name="optional_counter",
+                value=1.0,
+                type=MetricType.COUNTER,
+                labels={},
+            )
+            gauge_record = MetricRecord(
+                timestamp=datetime.now().timestamp(),
+                name="optional_gauge",
+                value=2.0,
+                type=MetricType.GAUGE,
+                labels={},
+            )
+            histogram_record = MetricRecord(
+                timestamp=datetime.now().timestamp(),
+                name="optional_histogram",
+                value=3.0,
+                type=MetricType.HISTOGRAM,
+                labels={},
+            )
+
+            metrics_adapter._send_to_otel(counter_record)
+            metrics_adapter._send_to_otel(gauge_record)
+            metrics_adapter._send_to_otel(histogram_record)
+
+            mock_counter.assert_called_once_with(
+                name="optional_counter",
+                description="",
+                unit="",
+            )
+            mock_gauge.assert_called_once_with(
+                name="optional_gauge",
+                description="",
+                unit="",
+            )
+            mock_histogram.assert_called_once_with(
+                name="optional_histogram",
+                description="",
+                unit="",
+            )
+            mock_counter_instance.add.assert_called_once_with(1.0, {})
+            mock_gauge_instance.set.assert_called_once_with(2.0, {})
+            mock_histogram_instance.record.assert_called_once_with(3.0, {})
+
+
+def test_record_metric_with_optional_metadata_uses_real_otel_meter():
+    """Regression test for OTel rejecting None unit or description."""
+    from opentelemetry.sdk.metrics import MeterProvider
+
+    previous_flush_task_started = AtlanMetricsAdapter._flush_task_started
+    AtlanMetricsAdapter._flush_task_started = True
+    try:
+        with mock.patch(
+            "application_sdk.observability.metrics_adaptor.ENABLE_OTLP_METRICS",
+            False,
+        ):
+            with mock.patch(
+                "application_sdk.observability.metrics_adaptor.ENABLE_PROMETHEUS_METRICS",
+                False,
+            ):
+                metrics_adapter = AtlanMetricsAdapter()
+        metrics_adapter.meter = MeterProvider().get_meter("test_optional_metadata")
+
+        with mock.patch(
+            "application_sdk.observability.metrics_adaptor.ENABLE_OTLP_METRICS",
+            True,
+        ):
+            with mock.patch(
+                "application_sdk.observability.metrics_adaptor.ENABLE_PROMETHEUS_METRICS",
+                False,
+            ):
+                with mock.patch(
+                    "application_sdk.observability.metrics_adaptor.logging.error"
+                ) as mock_error:
+                    metrics_adapter.record_metric(
+                        name="optional_metadata_counter",
+                        value=1.0,
+                        metric_type=MetricType.COUNTER,
+                        labels={},
+                    )
+
+        mock_error.assert_not_called()
+    finally:
+        AtlanMetricsAdapter._flush_task_started = previous_flush_task_started
 
 
 def test_send_to_otel_filters_non_scalar_labels():


### PR DESCRIPTION
## Testing-only draft

Do not merge. This PR is only for Faizan testing and combines:
- #1586: fix(observability): HYP-851 handle unset OTel metric metadata
- #1591: feat(sql): make pool pre-ping configurable

## Validation
- uv run pytest tests/unit/clients/test_sql_client.py tests/unit/clients/test_async_sql_client.py tests/unit/observability/test_metrics_adaptor.py
- uv run pre-commit run --files application_sdk/clients/models.py application_sdk/clients/sql.py application_sdk/observability/metrics_adaptor.py docs/concepts/clients.md tests/unit/clients/test_sql_client.py tests/unit/clients/test_async_sql_client.py tests/unit/observability/test_metrics_adaptor.py

Note: pytest passed with a runtime warning about AtlanObservability._periodic_flush coroutine cleanup during metrics tests.