### PR TITLE
fix(sql-filters): anchor exclude/include regex to prevent substring matches

### DIFF
--- a/application_sdk/common/sql_filters.py
+++ b/application_sdk/common/sql_filters.py
@@ -53,16 +53,19 @@ def extract_database_names_from_regex_common(
                     if len(parts) < 2:
                         logger.warning("Invalid database name format: %s", pattern)
                         continue
-                    db_name = parts[0].strip()
-                    schema_part = parts[1].strip()
+                    db_name = parts[0].strip().lstrip("^")
+                    schema_part = parts[1].strip().rstrip("$")
+                    # Accept both legacy ``*`` and anchored ``.*`` wildcard forms.
                     if not (
-                        db_name and db_name not in (".*", "^$") and schema_part == "*"
+                        db_name
+                        and db_name not in (".*", "^$")
+                        and schema_part in ("*", ".*")
                     ):
                         continue
                 else:
                     if not parts:
                         continue
-                    db_name = parts[0].strip()
+                    db_name = parts[0].strip().lstrip("^")
                     if not (db_name and db_name not in (".*", "^$")):
                         continue
 
@@ -304,31 +307,41 @@ def prepare_filters(
 def normalize_filters(
     filter_dict: Dict[str, List[str] | str], is_include: bool
 ) -> List[str]:
-    """Normalize filter dict to regex patterns.
+    """Normalize filter dict to fully-anchored ``db.schema`` regex patterns.
+
+    Each emitted pattern is anchored with ``^`` and ``$`` so that callers
+    using POSIX ``~`` (substring match by default) get exact ``db.schema``
+    semantics rather than substring matches.
+
+    Mapping:
+        - ``{"^db$": []}`` or ``{"^db$": "*"}`` → ``^db\\..*$`` (every schema in db)
+        - ``{"^db$": ["^sch$"]}`` → ``^db\\.sch$`` (exactly that schema)
+
+    The previous implementation emitted unanchored ``db\\.*`` (literal dot,
+    zero-or-more), which substring-matched targets like ``something.atlan_dev``
+    when the user only meant database ``dev``.
 
     Args:
-        filter_dict: The filter dictionary.
-        is_include: Whether the filter is an include filter.
+        filter_dict: Filter dict, e.g. ``{"^db$": ["^schema$"]}``.
+        is_include: Whether this is an include filter (currently unused — both
+            include and exclude need the same anchored shape; kept for API
+            stability).
 
     Returns:
-        List of normalized filter patterns.
+        List of anchored regex segments suitable for joining with ``|``.
     """
     normalized_filter_list: List[str] = []
     for filtered_db, filtered_schemas in filter_dict.items():
         db = filtered_db.strip("^$")
 
-        if filtered_schemas == "*":
-            normalized_filter_list.append(f"{db}\\.*")
-            continue
-
-        if not filtered_schemas:
-            normalized_filter_list.append(f"{db}\\.*")
+        if filtered_schemas == "*" or not filtered_schemas:
+            normalized_filter_list.append(f"^{db}\\..*$")
             continue
 
         if isinstance(filtered_schemas, list):
             for schema in filtered_schemas:
-                sch = schema.lstrip("^")
-                normalized_filter_list.append(f"{db}\\.{sch}")
+                sch = schema.strip("^$")
+                normalized_filter_list.append(f"^{db}\\.{sch}$")
 
     return normalized_filter_list
 

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 from typing import Dict, List, Union
 from unittest.mock import mock_open, patch
@@ -104,8 +105,8 @@ class TestPrepareFilters:
 
         include_regex, exclude_regex = prepare_filters(include_filter, exclude_filter)
 
-        assert "db1\\.schema1|db1\\.schema2|db2\\.schema3" == include_regex
-        assert "db3\\.schema4" == exclude_regex
+        assert "^db1\\.schema1$|^db1\\.schema2$|^db2\\.schema3$" == include_regex
+        assert "^db3\\.schema4$" == exclude_regex
 
     def test_prepare_filters_with_empty_filters(self) -> None:
         """Test prepare_filters with empty filters"""
@@ -124,7 +125,7 @@ class TestPrepareFilters:
 
         include_regex, exclude_regex = prepare_filters(include_filter, exclude_filter)
 
-        assert "db1\\.*" == include_regex
+        assert "^db1\\..*$" == include_regex
         assert "^$" == exclude_regex
 
     def test_prepare_filters_with_empty_include_and_filled_exclude(self) -> None:
@@ -135,7 +136,7 @@ class TestPrepareFilters:
         include_regex, exclude_regex = prepare_filters(include_filter, exclude_filter)
 
         assert ".*" == include_regex
-        assert "db1\\.schema1|db2\\.schema2" == exclude_regex
+        assert "^db1\\.schema1$|^db2\\.schema2$" == exclude_regex
 
 
 class TestNormalizeFilters:
@@ -148,7 +149,7 @@ class TestNormalizeFilters:
         result = normalize_filters(filter_dict, True)
 
         assert sorted(result) == sorted(
-            ["db1\\.schema1", "db1\\.schema2", "db2\\.schema3"]
+            ["^db1\\.schema1$", "^db1\\.schema2$", "^db2\\.schema3$"]
         )
 
     def test_normalize_filters_with_wildcard(self) -> None:
@@ -156,22 +157,99 @@ class TestNormalizeFilters:
         filter_dict: Dict[str, Union[List[str], str]] = {"db1": "*"}
         result = normalize_filters(filter_dict, True)
 
-        assert result == ["db1\\.*"]
+        assert result == ["^db1\\..*$"]
 
     def test_normalize_filters_with_empty_list(self) -> None:
         """Test normalize_filters with empty schema list"""
         filter_dict: Dict[str, Union[List[str], str]] = {"db1": []}
         result = normalize_filters(filter_dict, True)
 
-        assert result == ["db1\\.*"]
+        assert result == ["^db1\\..*$"]
 
     def test_normalize_filters_with_regex_patterns(self) -> None:
-        """Test normalize_filters with regex patterns in database names"""
+        """Test normalize_filters with anchored regex patterns in keys/values."""
         filter_dict: Dict[str, Union[List[str], str]] = {"^db1$": ["^schema1$"]}
         result = normalize_filters(filter_dict, True)
 
-        # The implementation strips ^ from schema names but keeps $
-        assert result == ["db1\\.schema1$"]
+        # ``^``/``$`` are stripped from both the db key and each schema entry,
+        # then re-anchored on the assembled segment.
+        assert result == ["^db1\\.schema1$"]
+
+    def test_normalize_filters_wildcard_and_empty_list_equivalent(self) -> None:
+        """``"*"`` and an empty list both mean "every schema in this db"."""
+        wildcard = normalize_filters({"^db$": "*"}, False)
+        empty = normalize_filters({"^db$": []}, False)
+        assert wildcard == empty == ["^db\\..*$"]
+
+
+class TestNormalizeFiltersSubstringRegression:
+    """Regression tests for the substring-match bug (BLDX/APP-1014).
+
+    Previously ``normalize_filters`` emitted unanchored ``db\\.*`` segments,
+    which when applied via PostgreSQL POSIX ``~`` (substring match) would
+    match any target string containing ``db`` followed by zero literal dots
+    — e.g. excluding ``{"^dev$": []}`` would incorrectly drop a schema named
+    ``atlan_dev`` because the substring ``dev`` appears at the end.
+
+    These tests pin the new anchored ``^db\\..*$`` shape so the bug cannot
+    silently regress.
+    """
+
+    def test_empty_schemas_does_not_substring_match(self) -> None:
+        # Mirrors the exact failure from the redshift v3 crawler.
+        _, exc = prepare_filters("", '{"^dev$": []}')
+        assert exc == "^dev\\..*$"
+        # The whole point: must NOT match a string whose schema *ends* with "dev".
+        assert re.search(exc, "wide_world_importers.atlan_dev") is None
+        # And must still match a target whose database actually IS "dev".
+        assert re.search(exc, "dev.public") is not None
+        assert re.search(exc, "dev.atlan_test_schema") is not None
+
+    def test_atlan_trial_does_not_substring_match(self) -> None:
+        _, exc = prepare_filters("", '{"^atlan_trial$": []}')
+        assert exc == "^atlan_trial\\..*$"
+        assert re.search(exc, "xyz.atlan_trial_archive") is None
+        assert re.search(exc, "wide_world_importers.atlan_trial_old") is None
+        # Database literally named atlan_trial — should match.
+        assert re.search(exc, "atlan_trial.public") is not None
+
+    def test_explicit_schema_is_exact(self) -> None:
+        _, exc = prepare_filters("", '{"^db$": ["^schema$"]}')
+        assert exc == "^db\\.schema$"
+        assert re.search(exc, "db.schema") is not None
+        # Substring siblings must not match.
+        assert re.search(exc, "db.schema_extra") is None
+        assert re.search(exc, "other_db.schema") is None
+        assert re.search(exc, "prefix.db.schema") is None
+
+    def test_wildcard_and_empty_list_produce_same_regex(self) -> None:
+        _, exc_wildcard = prepare_filters("", '{"^db$": "*"}')
+        _, exc_empty = prepare_filters("", '{"^db$": []}')
+        assert exc_wildcard == exc_empty == "^db\\..*$"
+
+    def test_empty_dict_preserves_defaults(self) -> None:
+        # Empty dict input → callers fall back to ``.*`` (include) / ``^$`` (exclude).
+        inc, exc = prepare_filters("{}", "{}")
+        assert inc == ".*"
+        assert exc == "^$"
+        # And ``normalize_filters`` itself returns an empty list for empty input.
+        assert normalize_filters({}, True) == []
+        assert normalize_filters({}, False) == []
+
+    def test_customer_shape_redshift_regression(self) -> None:
+        """The exact filter shape that broke the redshift v3 crawler in prod.
+
+        Customer config: ``{"^atlan_trial$":[],"^dev$":[]}``. This silently
+        dropped schema ``atlan_dev`` (40 tables, 511 cols) because the old
+        unanchored regex ``dev\\.*|atlan_trial\\.*`` substring-matched it.
+        """
+        _, exc = prepare_filters("", '{"^atlan_trial$": [], "^dev$": []}')
+        # No substring leakage from either prefix.
+        assert re.search(exc, "wide_world_importers.atlan_dev") is None
+        assert re.search(exc, "wide_world_importers.atlan_trial_old") is None
+        # Real matches still work.
+        assert re.search(exc, "dev.public") is not None
+        assert re.search(exc, "atlan_trial.foo") is not None
 
 
 class TestExtractDatabaseNamesFromIncludeRegex:


### PR DESCRIPTION
## Summary

- **Broken:** `normalize_filters` emitted unanchored segments (`db\.*` — literal dot, zero-or-more), which under PostgreSQL POSIX `~` (substring match) matched any target containing the db name followed by zero dots.
- **Fixed:** segments are now fully anchored — `^db\..*$` for empty-list / `"*"` wildcard, `^db\.schema$` for explicit schemas. `extract_database_names_from_regex_common` is hardened to parse both legacy and new shapes.
- **Behavioral consequence:** the regex output of `normalize_filters` and `prepare_filters` changes for every caller — that is the entire point. No compatibility shim; the old behavior was the bug.

## Reproducer (current main, before this PR)

```python
import re, json
from application_sdk.common.sql_filters import prepare_filters
_, exc = prepare_filters('', json.dumps({'^dev$': [], '^atlan_trial$': []}))
print(exc)  # 'dev\\.*|atlan_trial\\.*'
print(bool(re.search(exc, 'wide_world_importers.atlan_dev')))  # True — BUG
```

After this PR, `exc == '^dev\\..*$|^atlan_trial\\..*$'` and the substring match returns False.

## Test plan

New regression tests in `tests/unit/common/test_utils.py::TestNormalizeFiltersSubstringRegression`:

- [x] `test_empty_schemas_does_not_substring_match` — `{"^dev$": []}` must NOT match `wide_world_importers.atlan_dev`; must still match `dev.public`.
- [x] `test_atlan_trial_does_not_substring_match` — `{"^atlan_trial$": []}` must NOT match `xyz.atlan_trial_archive` or `wide_world_importers.atlan_trial_old`; must match `atlan_trial.public`.
- [x] `test_explicit_schema_is_exact` — `{"^db$": ["^schema$"]}` matches only `db.schema`, not `db.schema_extra` or `other_db.schema`.
- [x] `test_wildcard_and_empty_list_produce_same_regex` — `{"^db$": "*"}` and `{"^db$": []}` are equivalent (`^db\..*$`).
- [x] `test_empty_dict_preserves_defaults` — empty dict → empty list; `prepare_filters` falls back to `.*` (include) / `^$` (exclude).
- [x] `test_customer_shape_redshift_regression` — the exact prod filter shape that broke the redshift crawler.

Existing assertions in `TestPrepareFilters` and `TestNormalizeFilters` were updated to reflect the new anchored shape (those previously codified the bug).

Local verification:
- `uv run pytest tests/unit/common/test_utils.py -v` — 74 passed
- `uv run pytest tests/unit/templates/test_sql_metadata_extractor.py tests/unit/templates/test_extraction_input_filters.py -v` — 88 passed
- `uv run pre-commit run --files application_sdk/common/sql_filters.py tests/unit/common/test_utils.py` — all hooks passed

## Caller impact

The redshift v3 crawler (`atlan-redshift-app`) hit this in production with the customer-supplied filter `{"^atlan_trial$": [], "^dev$": []}`. The substring leak silently dropped the `atlan_dev` schema — 40 tables and 511 columns, 552 entities total — from the metadata extract. Any downstream caller of `normalize_filters` / `prepare_filters` that passes structured (dict) filters through to a POSIX `~` query is affected by the same class of bug and benefits from this fix.