### PR TITLE
security: allowlist CVE-2026-41066 (lxml) for connector apps

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -300,5 +300,12 @@
     "reason": "Base image — Dapr 1.17 transitive Go AWS SDK dep in app-framework-golden bundle (consumed by SDK 2.x). Fix available in 1.43.5; awaiting Wolfi rebuild of app-framework-golden with newer aws-sdk-go-v2.",
     "expires": "2026-05-29",
     "added_by": "sachi-atlan"
+  },
+  "CVE-2026-41066": {
+    "package": "lxml",
+    "severity": "HIGH",
+    "reason": "Connector transitive — lxml pulled in by redshift-connector (aws/amazon-redshift-python-driver). Fix is in lxml>=6.1.0, but redshift-connector 2.1.10 pins lxml<6.0.0 in its package metadata. Bumping lxml in connector apps forces a downgrade of redshift-connector to 2.1.7. Allowlisting until upstream relaxes the cap; tracking via aws/amazon-redshift-python-driver. Connector code uses lxml only for SOAP/XML parsing of trusted Redshift IAM responses, not untrusted input.",
+    "expires": "2026-05-28",
+    "added_by": "anuj-atlan"
   }
 }


### PR DESCRIPTION
## Summary

Adds **CVE-2026-41066** (HIGH, lxml) to `.security/base-allowlist.json` so connector repos can pass the security gate without forcing a downgrade of `redshift-connector`.

## Why

- The CVE is fixed in `lxml>=6.1.0`.
- `lxml` is **not** a direct SDK dep — it's pulled into connector apps (e.g. `atlan-redshift-app`) transitively via `redshift-connector`.
- `redshift-connector==2.1.10` (latest) pins `lxml<6.0.0` in its package metadata. Bumping `lxml` in a connector forces uv to downgrade `redshift-connector` to `2.1.7` (last version without the cap).
- We don't control the cap; it has to be relaxed upstream in [aws/amazon-redshift-python-driver](https://github.com/aws/amazon-redshift-python-driver).

## Risk assessment

- The connector uses lxml only for parsing SOAP/XML responses from Redshift IAM endpoints (trusted source, not user input).
- 30-day expiry per the HIGH policy in `_expiry_policy`. If upstream relaxes the cap before then, we drop this entry and bump lxml directly.

## Context

Surfaced by the security gate on https://github.com/atlanhq/atlan-redshift-app/pull/243.

## Test plan

- [x] `python3 -c "import json; json.load(open('.security/base-allowlist.json'))"` — valid JSON
- [x] `python3 .github/scripts/validate_allowlist.py` — passes (`38 entries, all within policy`)
- [ ] Re-run security gate on atlan-redshift-app#243 after merge to confirm gate passes