### PR TITLE
chore(allowlist): add 3 AWS Go SDK HIGH CVEs from dapr-1.17 base image

### DIFF
--- a/.security/approvers.json
+++ b/.security/approvers.json
@@ -9,6 +9,7 @@
     "louisnow",
     "cmgrote",
     "mananjain99",
-    "vaibhavatlan"
+    "vaibhavatlan",
+    "Aryamanz29"
   ]
 }

--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -265,5 +265,26 @@
     "reason": "Base image — Jackson Java transitive in application-sdk-main:2.7.3 (likely via Dapr tooling). No fix released upstream. Connector apps are Python at runtime and do not invoke Jackson code paths; review at expiry to track upstream patch availability.",
     "expires": "2026-05-27",
     "added_by": "vishalkatlan"
+  },
+  "SNYK-GOLANG-GITHUBCOMAWSAWSSDKGOV2AWSPROTOCOLEVENTSTREAM-16316402": {
+    "package": "github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr 1.17 transitive Go AWS SDK dep in app-framework-golden bundle (consumed by SDK 2.x). Fix available in 1.7.8; awaiting Wolfi rebuild of app-framework-golden with newer aws-sdk-go-v2.",
+    "expires": "2026-05-29",
+    "added_by": "sachi-atlan"
+  },
+  "SNYK-GOLANG-GITHUBCOMAWSAWSSDKGOV2SERVICEBEDROCKRUNTIME-16316405": {
+    "package": "github.com/aws/aws-sdk-go-v2/service/bedrockruntime",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr 1.17 transitive Go AWS SDK dep in app-framework-golden bundle (consumed by SDK 2.x). Fix available in 1.50.4; awaiting Wolfi rebuild of app-framework-golden with newer aws-sdk-go-v2.",
+    "expires": "2026-05-29",
+    "added_by": "sachi-atlan"
+  },
+  "SNYK-GOLANG-GITHUBCOMAWSAWSSDKGOV2SERVICEKINESIS-16316408": {
+    "package": "github.com/aws/aws-sdk-go-v2/service/kinesis",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr 1.17 transitive Go AWS SDK dep in app-framework-golden bundle (consumed by SDK 2.x). Fix available in 1.43.5; awaiting Wolfi rebuild of app-framework-golden with newer aws-sdk-go-v2.",
+    "expires": "2026-05-29",
+    "added_by": "sachi-atlan"
   }
 }


### PR DESCRIPTION
## Summary
- Allowlist 3 new HIGH Go AWS SDK CVEs found inside the dapr-1.17 layer of `app-framework-golden`.
- Surfaced by today's Snyk DB update — none are introduced by any connector PR.
- Currently blocking connectors on SDK 2.x, including [native-migration-app #16](https://github.com/atlanhq/native-migration-app/pull/16) (run [25043729511](https://github.com/atlanhq/native-migration-app/actions/runs/25043729511/job/73353755120?pr=16)).

## Entries added
| Snyk ID | Package | Current | Fix |
|---|---|---|---|
| `SNYK-GOLANG-...EVENTSTREAM-16316402` | `github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream` | v1.7.4 | 1.7.8 |
| `SNYK-GOLANG-...BEDROCKRUNTIME-16316405` | `github.com/aws/aws-sdk-go-v2/service/bedrockruntime` | v1.24.3 | 1.50.4 |
| `SNYK-GOLANG-...KINESIS-16316408` | `github.com/aws/aws-sdk-go-v2/service/kinesis` | v1.42.10 | 1.43.5 |

30-day expiry (`2026-05-29`) per the HIGH policy in `5bc88360`.

## Why allowlist instead of fix
These are transitive Go deps inside the Chainguard Wolfi `app-framework-golden:3.13` bundle — not direct SDK deps. Resolution requires Chainguard to rebuild the bundle with newer `aws-sdk-go-v2`. Allowlist entry expires in 30 days so we re-evaluate.

## Test plan
- [ ] JSON validates (`python3 -c "import json; json.load(open('.security/base-allowlist.json'))"`)
- [ ] `check_allowlist.py` recognizes the 3 IDs as allowlisted on a re-run of the failing scan
- [ ] CODEOWNERS / SDK security approver review