### PR TITLE
feat: phase out Dapr CLI in favour of direct daprd invocation

### DIFF
--- a/.github/actions/e2e-examples/action.yaml
+++ b/.github/actions/e2e-examples/action.yaml
@@ -41,20 +41,27 @@ runs:
   steps:
     - uses: actions/checkout@v4
 
-    - name: Install Dapr CLI (Linux/macOS)
+    - name: Install daprd (Linux/macOS)
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s 1.17.1
-        dapr init --runtime-version 1.17.3 --slim
+        DAPRD_VERSION=1.17.3
+        OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+        ARCH=$(uname -m)
+        if [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then ARCH="arm64"; fi
+        mkdir -p "$HOME/.daprd/bin"
+        wget -q "https://github.com/dapr/dapr/releases/download/v${DAPRD_VERSION}/daprd_${OS}_${ARCH}.tar.gz" -O /tmp/daprd.tar.gz
+        tar -xzf /tmp/daprd.tar.gz -C "$HOME/.daprd/bin" daprd
+        chmod +x "$HOME/.daprd/bin/daprd"
 
-    - name: Install Dapr CLI (Windows)
+    - name: Install daprd (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        $script=iwr -useb https://raw.githubusercontent.com/dapr/cli/master/install/install.ps1; $block=[ScriptBlock]::Create($script); invoke-command -ScriptBlock $block -ArgumentList 1.17.1, "$env:USERPROFILE\.dapr\bin\"
-        $env:Path += ";$env:USERPROFILE\.dapr\bin\"
-        dapr init --runtime-version 1.17.3 --slim
+        $DAPRD_VERSION = "1.17.3"
+        New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.daprd\bin"
+        Invoke-WebRequest -Uri "https://github.com/dapr/dapr/releases/download/v${DAPRD_VERSION}/daprd_windows_amd64.zip" -OutFile "$env:TEMP\daprd.zip"
+        Expand-Archive -Path "$env:TEMP\daprd.zip" -DestinationPath "$env:USERPROFILE\.daprd\bin" -Force
 
     - name: Install Temporal CLI and Start Server
       if: runner.os != 'Windows'
@@ -93,19 +100,19 @@ runs:
       shell: bash
       run: uv sync --all-extras --all-groups
 
-    # Set up PATH for DAPR and Temporal globally
-    - name: Setup PATH for DAPR and Temporal (Linux/macOS)
+    # Set up PATH for daprd and Temporal globally
+    - name: Setup PATH for daprd and Temporal (Linux/macOS)
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        echo "$HOME/.dapr/bin" >> $GITHUB_PATH
+        echo "$HOME/.daprd/bin" >> $GITHUB_PATH
         echo "$HOME/.temporalio/bin" >> $GITHUB_PATH
 
-    - name: Setup PATH for DAPR and Temporal (Windows)
+    - name: Setup PATH for daprd and Temporal (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        echo "$env:USERPROFILE\.dapr\bin" >> $env:GITHUB_PATH
+        echo "$env:USERPROFILE\.daprd\bin" >> $env:GITHUB_PATH
         echo "$env:USERPROFILE\.temporalio\bin" >> $env:GITHUB_PATH
 
     # Start all services

--- a/.github/workflows/scale-tests.yaml
+++ b/.github/workflows/scale-tests.yaml
@@ -44,11 +44,15 @@ jobs:
           pip install testcontainers psutil
 
 
-      # Install Dapr
-      - name: Install Dapr CLI
+      # Install daprd
+      - name: Install daprd
         run: |
-          wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s 1.17.1
-          dapr init --runtime-version 1.17.3 --slim
+          DAPRD_VERSION=1.17.3
+          mkdir -p "$HOME/.daprd/bin"
+          wget -q "https://github.com/dapr/dapr/releases/download/v${DAPRD_VERSION}/daprd_linux_amd64.tar.gz" -O /tmp/daprd.tar.gz
+          tar -xzf /tmp/daprd.tar.gz -C "$HOME/.daprd/bin" daprd
+          chmod +x "$HOME/.daprd/bin/daprd"
+          echo "$HOME/.daprd/bin" >> $GITHUB_PATH
 
       # Install Temporal
       - name: Install Temporal CLI and Start Server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,15 @@
 FROM cgr.dev/atlan.com/app-framework-golden:3.13
 
-# Dapr version arguments
-ARG DAPR_CLI_VERSION=1.17.1
+# Dapr runtime package from Chainguard APK
 ARG DAPR_RUNTIME_PACKAGE=dapr-daprd-1.17
 
 # Switch to root for installation
 USER root
 
-# Install Dapr CLI (latest version for apps to use)
-RUN curl -fsSL https://raw.githubusercontent.com/dapr/cli/master/install/install.sh | DAPR_INSTALL_DIR="/usr/local/bin" /bin/bash -s ${DAPR_CLI_VERSION}
-
-
-# Install Dapr runtime from Chainguard APK
-RUN apk add --no-cache ${DAPR_RUNTIME_PACKAGE}
+# Install Dapr runtime from Chainguard APK and remove attack-surface tools
+RUN apk add --no-cache ${DAPR_RUNTIME_PACKAGE} && \
+    apk del curl bash && \
+    rm -rf /var/cache/apk/*
 
 # Create appuser (standardized user for all apps)
 RUN addgroup -g 1000 appuser && adduser -D -u 1000 -G appuser appuser
@@ -21,25 +18,11 @@ RUN addgroup -g 1000 appuser && adduser -D -u 1000 -G appuser appuser
 RUN mkdir -p /app /home/appuser/.local/bin && \
     chown -R appuser:appuser /app /home/appuser
 
-# Remove curl and bash (no longer needed) and clean apk cache
-RUN apk del curl bash && rm -rf /var/cache/apk/*
-
 # Switch to appuser before venv creation
 USER appuser
 
 # Default working directory for applications
 WORKDIR /app
-
-# Ensure Dapr directories exist for components/runtime
-RUN mkdir -p /home/appuser/.dapr/components /home/appuser/.dapr/bin && \
-    ln -s /usr/bin/daprd /home/appuser/.dapr/bin/daprd && \
-    cat <<'EOF' > /home/appuser/.dapr/config.yaml
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: daprConfig
-spec: {}
-EOF
 
 # Common environment variables for all apps
 ENV UV_NO_CACHE=1 \
@@ -48,7 +31,7 @@ ENV UV_NO_CACHE=1 \
     ATLAN_DAPR_METRICS_PORT=3100 \
     DAPR_LOG_LEVEL=info \
     DAPR_APP_ID=app \
-    DAPR_MAX_BODY_SIZE="1024Mi" \
+    DAPR_MAX_BODY_SIZE_MB=1024 \
     DO_NOT_TRACK=true \
     SCARF_NO_ANALYTICS=true \
     DAFT_ANALYTICS_ENABLED=0

--- a/application_sdk/common/utils.py
+++ b/application_sdk/common/utils.py
@@ -1,8 +1,11 @@
 import asyncio
+import base64
 import glob
 import json
 import os
 import re
+
+import orjson
 from concurrent.futures import ThreadPoolExecutor
 from typing import (
     Any,
@@ -607,3 +610,69 @@ async def download_file_from_upload_response(
     )
 
     return local_path
+
+
+async def resolve_credential_file(
+    value: Optional[str],
+    filename: str,
+    dest_dir: str = "/tmp/credential_files",
+) -> Optional[str]:
+    """Resolve a credential file field value to a local file path.
+
+    Handles two input formats transparently, allowing customers to choose
+    how they provide sensitive files based on their organisation's security policy:
+
+    1. **Object-store reference** (file uploaded via UI):
+       ``{"key": "some/path", "rawName": "hiveadmin.keytab", "extension": ".keytab"}``
+       Downloads the binary from the Dapr-backed object store.
+
+    2. **Base64-encoded file content** (stored in customer's own secret store):
+       ``"BQIAAAABAAoASElWRS5MT0NBTA..."``
+       Decodes the binary and writes it directly to disk.
+       Used when the customer base64-encodes the file, stores it in their secret
+       store (AWS / Azure / GCP / K8s), and the SDK resolves the value via
+       ``SecretStore.get_credentials()`` + Dapr at activity runtime.
+
+    Args:
+        value:    Raw credential field value — either a JSON object-store reference
+                  or a raw base64-encoded string. Returns ``None`` if empty.
+        filename: Destination filename used for the base64 path
+                  (e.g. ``"keytab.keytab"``, ``"krb5.conf"``, ``"ca_cert.pem"``).
+                  Ignored for the object-store path (filename is derived from the key).
+        dest_dir: Directory to write or download the file into.
+
+    Returns:
+        Absolute path to the resolved file on disk, or ``None`` if ``value`` is
+        empty or resolution fails.
+    """
+    if not value:
+        return None
+
+    # Detect format: JSON object-store reference vs raw base64 string
+    try:
+        parsed = orjson.loads(value)
+        if isinstance(parsed, dict) and ("key" in parsed or "fileKey" in parsed):
+            # Object-store reference — delegate to existing download utility
+            return await download_file_from_upload_response(value)
+    except (orjson.JSONDecodeError, TypeError):
+        pass
+
+    # Base64-encoded file content — decode and write to disk
+    try:
+        os.makedirs(dest_dir, exist_ok=True)
+        file_path = os.path.join(dest_dir, filename)
+        decoded_bytes = base64.b64decode(value.strip())
+        with open(file_path, "wb") as f:
+            f.write(decoded_bytes)
+        logger.info(
+            "Resolved credential file from base64 content",
+            extra={"path": file_path, "filename": filename},
+        )
+        return file_path
+    except Exception:
+        logger.error(
+            "Failed to resolve credential file from base64 content",
+            extra={"filename": filename},
+            exc_info=True,
+        )
+        return None

--- a/docs/setup/LINUX.md
+++ b/docs/setup/LINUX.md
@@ -51,19 +51,20 @@ export PATH="$HOME/.temporalio/bin:$PATH"
 echo 'export PATH="$HOME/.temporalio/bin:$PATH"' >> ~/.bashrc
 ```
 
-### 4. Install DAPR CLI
+### 4. Install daprd
 
-Install DAPR using the following commands:
+daprd is the Dapr sidecar runtime (Distributed Application Runtime):
 
 ```bash
-# Install DAPR CLI
-wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s 1.17.1
-
-# Initialize DAPR (slim mode)
-dapr init --runtime-version 1.17.3 --slim
+DAPRD_VERSION=1.17.3
+mkdir -p "$HOME/.daprd/bin"
+wget -q "https://github.com/dapr/dapr/releases/download/v${DAPRD_VERSION}/daprd_linux_amd64.tar.gz" -O /tmp/daprd.tar.gz
+tar -xzf /tmp/daprd.tar.gz -C "$HOME/.daprd/bin" daprd
+chmod +x "$HOME/.daprd/bin/daprd"
+echo 'export PATH="$HOME/.daprd/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
 
 # Verify installation
-dapr --version
+daprd --version
 ```
 
 > [!NOTE]

--- a/docs/setup/MAC.md
+++ b/docs/setup/MAC.md
@@ -47,13 +47,18 @@ Temporal is the workflow orchestration platform:
 brew install temporal
 ```
 
-### 4. Install DAPR CLI
+### 4. Install daprd
 
-DAPR (Distributed Application Runtime) simplifies microservice development:
+daprd is the Dapr sidecar runtime (Distributed Application Runtime):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/dapr/cli/master/install/install.sh | /bin/bash -s 1.17.1
-dapr init --runtime-version 1.17.3 --slim
+DAPRD_VERSION=1.17.3
+ARCH=$(uname -m)
+if [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; elif [ "$ARCH" = "arm64" ]; then ARCH="arm64"; fi
+mkdir -p "$HOME/.daprd/bin"
+curl -fsSL "https://github.com/dapr/dapr/releases/download/v${DAPRD_VERSION}/daprd_darwin_${ARCH}.tar.gz" | tar -xz -C "$HOME/.daprd/bin" daprd
+chmod +x "$HOME/.daprd/bin/daprd"
+echo 'export PATH="$HOME/.daprd/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
 ```
 
 > [!NOTE]

--- a/docs/setup/WINDOWS.md
+++ b/docs/setup/WINDOWS.md
@@ -50,26 +50,22 @@ $env:Path += ";$env:USERPROFILE\.temporalio\bin"
 temporal --version
 ```
 
-### 3. Install DAPR CLI
+### 3. Install daprd
 
-Install DAPR using PowerShell:
+daprd is the Dapr sidecar runtime (Distributed Application Runtime):
 
 ```powershell
-# Set required execution policy
-Set-ExecutionPolicy RemoteSigned -scope CurrentUser
-
-# Install DAPR CLI
-$script=iwr -useb https://raw.githubusercontent.com/dapr/cli/master/install/install.ps1; $block=[ScriptBlock]::Create($script); invoke-command -ScriptBlock $block -ArgumentList 1.17.1, "$env:USERPROFILE\.dapr\bin\"
+$DAPRD_VERSION = "1.17.3"
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.daprd\bin"
+Invoke-WebRequest -Uri "https://github.com/dapr/dapr/releases/download/v${DAPRD_VERSION}/daprd_windows_amd64.zip" -OutFile "$env:TEMP\daprd.zip"
+Expand-Archive -Path "$env:TEMP\daprd.zip" -DestinationPath "$env:USERPROFILE\.daprd\bin" -Force
 
 # Add to PATH
-$env:Path += ";$env:USERPROFILE\.dapr\bin\"
+$env:Path += ";$env:USERPROFILE\.daprd\bin"
 [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User)
 
-# Initialize DAPR (slim mode)
-dapr init --runtime-version 1.17.3 --slim
-
 # Verify installation
-dapr --version
+daprd --version
 ```
 
 > [!NOTE]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,49 +5,69 @@ set -e
 # =============================================================================
 # Graceful Shutdown Wrapper for Atlan Application SDK
 #
-# This script wraps any command and ensures SIGTERM is forwarded to the
-# Python/uv process for graceful shutdown of Temporal activities.
-#
-# Usage: entrypoint.sh <command> [args...]
-#
-# Examples:
-#   entrypoint.sh dapr run ... -- uv run main.py
-#   entrypoint.sh sh -c "dapr run ... -- uv run main.py"
+# Starts the Dapr sidecar (daprd) directly, waits for it to be ready,
+# then launches the application. Handles graceful shutdown on SIGTERM.
 # =============================================================================
+
+DAPRD_PID=""
+APP_PID=""
 
 term_handler() {
     echo "[entrypoint] Received SIGTERM, initiating graceful shutdown..."
 
-    # Find the Python process
-    APP_PID=$(ps aux | grep "[p]ython.*main.py" | awk '{print $1}' | head -1)
+    if [ -n "$APP_PID" ]; then
+        echo "[entrypoint] Forwarding SIGTERM to application (PID: $APP_PID)..."
+        kill -TERM "$APP_PID" 2>/dev/null || true
+        wait "$APP_PID" 2>/dev/null || true
+        echo "[entrypoint] Application shutdown complete"
+    fi
 
-    echo "[entrypoint] Forwarding SIGTERM to application (PID: $APP_PID)..."
-    kill -TERM "$APP_PID" 2>/dev/null || true
-
-    # Wait for graceful shutdown to complete
-    tail --pid="$APP_PID" -f /dev/null 2>/dev/null || true
-    echo "[entrypoint] Application shutdown complete"
+    if [ -n "$DAPRD_PID" ]; then
+        echo "[entrypoint] Stopping Dapr sidecar (PID: $DAPRD_PID)..."
+        kill -TERM "$DAPRD_PID" 2>/dev/null || true
+    fi
 
     exit 0
 }
 
 trap term_handler SIGTERM SIGINT
 
-# Run the provided command in background
-dapr run  \
-    --log-level $DAPR_LOG_LEVEL \
-    --app-id $DAPR_APP_ID \
+# Start daprd sidecar in the background
+daprd \
+    --log-level "$DAPR_LOG_LEVEL" \
+    --app-id "$DAPR_APP_ID" \
     --scheduler-host-address '' \
     --placement-host-address '' \
-    --max-body-size $DAPR_MAX_BODY_SIZE \
-    --app-port $ATLAN_APP_HTTP_PORT \
-    --dapr-http-port $ATLAN_DAPR_HTTP_PORT \
-    --dapr-grpc-port $ATLAN_DAPR_GRPC_PORT \
-    --metrics-port $ATLAN_DAPR_METRICS_PORT \
+    --max-body-size "$DAPR_MAX_BODY_SIZE_MB" \
+    --app-port "$ATLAN_APP_HTTP_PORT" \
+    --dapr-http-port "$ATLAN_DAPR_HTTP_PORT" \
+    --dapr-grpc-port "$ATLAN_DAPR_GRPC_PORT" \
+    --metrics-port "$ATLAN_DAPR_METRICS_PORT" \
     --resources-path /app/components \
-    -- uv run --no-sync main.py $EXTRA_ARGS &
+    &
+DAPRD_PID=$!
 
-CMD_PID=$!
+# Wait for daprd gRPC port to be ready before starting the application.
+# We check the gRPC port (not /v1.0/healthz) because daprd binds gRPC before
+# it begins waiting for the app on --app-port, so healthz would block until
+# the app itself is up — creating a deadlock with our startup sequence.
+echo "[entrypoint] Waiting for Dapr sidecar gRPC port..."
+RETRIES=0
+MAX_RETRIES=60
+until python3 -c "import socket; s=socket.create_connection(('localhost', ${ATLAN_DAPR_GRPC_PORT}), timeout=1); s.close()" 2>/dev/null; do
+    RETRIES=$((RETRIES + 1))
+    if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+        echo "[entrypoint] ERROR: Dapr sidecar gRPC port not ready after ${MAX_RETRIES} seconds"
+        kill -TERM "$DAPRD_PID" 2>/dev/null || true
+        exit 1
+    fi
+    sleep 1
+done
+echo "[entrypoint] Dapr sidecar is ready"
 
-# Wait for the command
-wait $CMD_PID
+# Start the application
+uv run --no-sync main.py $EXTRA_ARGS &
+APP_PID=$!
+
+# Wait for the application to complete
+wait $APP_PID

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,10 +121,10 @@ generate.shell = "cd contract && pkl eval -m generated app.pkl && mkdir -p ../ap
 
 download-components.shell = "ls -l components/*.yaml"
 # Dapr and Temporal service tasks
-start-dapr = "daprd --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024 --config components/configuration.yaml --resources-path components"
+start-dapr.shell = "PATH=\"$HOME/.daprd/bin:$HOME/.dapr/bin:$PATH\" daprd --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024 --config components/configuration.yaml --resources-path components"
 
 # if you need to test dapr with environment values for an app
-#start-dapr.shell = "set -a && source .env && set +a && daprd --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024 --config components/configuration.yaml --resources-path components"
+#start-dapr.shell = "set -a && source .env && set +a && PATH=\"$HOME/.daprd/bin:$HOME/.dapr/bin:$PATH\" daprd --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024 --config components/configuration.yaml --resources-path components"
 
 start-temporal = "temporal server start-dev --db-filename ./temporal.db"
 start-deps.shell = "poe start-dapr & poe start-temporal &"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,10 +121,10 @@ generate.shell = "cd contract && pkl eval -m generated app.pkl && mkdir -p ../ap
 
 download-components.shell = "ls -l components/*.yaml"
 # Dapr and Temporal service tasks
-start-dapr = "dapr run --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi --config components/configuration.yaml --resources-path components"
+start-dapr = "daprd --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024 --config components/configuration.yaml --resources-path components"
 
 # if you need to test dapr with environment values for an app
-#start-dapr.shell = "set -a && source .env && set +a && dapr run --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi --config components/configuration.yaml --resources-path components"
+#start-dapr.shell = "set -a && source .env && set +a && daprd --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024 --config components/configuration.yaml --resources-path components"
 
 start-temporal = "temporal server start-dev --db-filename ./temporal.db"
 start-deps.shell = "poe start-dapr & poe start-temporal &"

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -1,7 +1,8 @@
+import base64
 import os
 from pathlib import Path
 from typing import Dict, List, Union
-from unittest.mock import mock_open, patch
+from unittest.mock import AsyncMock, mock_open, patch
 
 from application_sdk.common.error_codes import CommonError
 from application_sdk.common.utils import (
@@ -11,6 +12,7 @@ from application_sdk.common.utils import (
     prepare_filters,
     prepare_query,
     read_sql_files,
+    resolve_credential_file,
 )
 
 
@@ -931,3 +933,106 @@ class TestParseFilterInput:
 
         with pytest.raises(CommonError, match="Invalid filter JSON"):
             parse_filter_input("not json at all")
+
+
+class TestResolveCredentialFile:
+    """Tests for resolve_credential_file() — handles both object-store refs and base64 content."""
+
+    # ------------------------------------------------------------------
+    # Object-store reference path (delegates to download_file_from_upload_response)
+    # ------------------------------------------------------------------
+
+    @patch(
+        "application_sdk.common.utils.download_file_from_upload_response",
+        new_callable=AsyncMock,
+    )
+    async def test_object_store_reference_with_key(self, mock_download, tmp_path):
+        """JSON with 'key' field routes to download_file_from_upload_response."""
+        mock_download.return_value = str(tmp_path / "keytab.keytab")
+        value = '{"key": "artifacts/hiveadmin.keytab", "rawName": "hiveadmin.keytab", "extension": ".keytab"}'
+
+        result = await resolve_credential_file(value, "keytab.keytab", str(tmp_path))
+
+        mock_download.assert_awaited_once_with(value)
+        assert result == str(tmp_path / "keytab.keytab")
+
+    @patch(
+        "application_sdk.common.utils.download_file_from_upload_response",
+        new_callable=AsyncMock,
+    )
+    async def test_object_store_reference_with_filekey(self, mock_download, tmp_path):
+        """JSON with 'fileKey' field routes to download_file_from_upload_response."""
+        mock_download.return_value = str(tmp_path / "krb5.conf")
+        value = '{"fileKey": "artifacts/krb5.conf", "rawName": "krb5.conf"}'
+
+        result = await resolve_credential_file(value, "krb5.conf", str(tmp_path))
+
+        mock_download.assert_awaited_once_with(value)
+        assert result == str(tmp_path / "krb5.conf")
+
+    # ------------------------------------------------------------------
+    # Base64 content path (SDR / secret store)
+    # ------------------------------------------------------------------
+
+    async def test_base64_binary_file_written_correctly(self, tmp_path):
+        """Valid base64 binary content is decoded and written to disk."""
+        original_bytes = b"\x05\x02\x00\x00\x00\x01\x00\x0a\x00HIVE"  # fake keytab header
+        b64_value = base64.b64encode(original_bytes).decode()
+
+        result = await resolve_credential_file(b64_value, "keytab.keytab", str(tmp_path))
+
+        assert result == str(tmp_path / "keytab.keytab")
+        assert os.path.exists(result)
+        assert open(result, "rb").read() == original_bytes
+
+    async def test_base64_text_file_written_correctly(self, tmp_path):
+        """Valid base64 of a text file (krb5.conf) is decoded and written correctly."""
+        krb5_content = b"[libdefaults]\n default_realm = EXAMPLE.COM\n"
+        b64_value = base64.b64encode(krb5_content).decode()
+
+        result = await resolve_credential_file(b64_value, "krb5.conf", str(tmp_path))
+
+        assert result == str(tmp_path / "krb5.conf")
+        assert open(result, "rb").read() == krb5_content
+
+    async def test_base64_with_leading_trailing_whitespace(self, tmp_path):
+        """Base64 string with surrounding whitespace is stripped before decoding."""
+        content = b"fake-cert-bytes"
+        b64_value = "  " + base64.b64encode(content).decode() + "\n"
+
+        result = await resolve_credential_file(b64_value, "ca_cert.pem", str(tmp_path))
+
+        assert result is not None
+        assert open(result, "rb").read() == content
+
+    async def test_base64_dest_dir_created_if_missing(self, tmp_path):
+        """dest_dir is created automatically if it does not exist."""
+        content = b"some-binary"
+        b64_value = base64.b64encode(content).decode()
+        new_dir = str(tmp_path / "nested" / "dir")
+
+        result = await resolve_credential_file(b64_value, "file.bin", new_dir)
+
+        assert result is not None
+        assert os.path.isdir(new_dir)
+
+    async def test_invalid_base64_returns_none(self, tmp_path):
+        """A string that is neither JSON nor valid base64 returns None without raising."""
+        result = await resolve_credential_file(
+            "this is definitely not base64 !!!###", "keytab.keytab", str(tmp_path)
+        )
+        assert result is None
+
+    # ------------------------------------------------------------------
+    # Empty / None inputs
+    # ------------------------------------------------------------------
+
+    async def test_none_input_returns_none(self, tmp_path):
+        """None input returns None immediately."""
+        result = await resolve_credential_file(None, "keytab.keytab", str(tmp_path))
+        assert result is None
+
+    async def test_empty_string_returns_none(self, tmp_path):
+        """Empty string returns None immediately."""
+        result = await resolve_credential_file("", "keytab.keytab", str(tmp_path))
+        assert result is None


### PR DESCRIPTION
## What & Why

The Dapr CLI binary is installed in the base image via a `curl|bash` pipeline from GitHub — a supply-chain pattern that introduces CRITICAL/HIGH CVEs and is flagged by Trivy on every scan. The CLI itself is only ever used as a process launcher (`dapr run ... -- uv run main.py`); the actual runtime is `daprd`, which is already installed separately via the Chainguard APK (`dapr-daprd-1.17`).

This PR removes the Dapr CLI entirely and invokes `daprd` directly, eliminating the vulnerability surface with no change to SDK behaviour.

## How

- **`entrypoint.sh`**: replaces `dapr run` with a direct `daprd` invocation. Readiness is detected by polling the gRPC port via TCP (rather than `/v1.0/healthz`, which blocks until the app is up when `--app-port` is set). SIGTERM handler now uses tracked PIDs instead of a `ps aux` grep.
- **`Dockerfile`**: removes the CLI install block and its `.dapr/` scaffolding. `curl` and `bash` removal is consolidated into the `apk add` step. Fixes a pre-existing `ATPR_DAPR_GRPC_PORT` typo. Renames `DAPR_MAX_BODY_SIZE` → `DAPR_MAX_BODY_SIZE_MB` (`daprd --max-body-size` takes an integer, not an "Mi"-suffixed string).
- **CI**: replaces `dapr init --slim` steps in e2e and scale-test workflows with a direct `daprd` binary download from GitHub Releases.
- **Local dev / docs**: `poe start-dapr` and setup guides updated to use `daprd` directly.

## Test results

| Test | Result |
|---|---|
| Unit tests (1,269) | PASS |
| Sidecar smoke test — gRPC ready, all 7 components loaded, clean SIGTERM | PASS |
| Container checks — CLI absent, `daprd` v1.17.6 present, `curl`/`bash` removed, env vars correct | PASS |
| Trivy (CRITICAL+HIGH, ignore-unfixed, latest DB) | **0 findings** |