### PR TITLE
fix(storage): HEAD-check before single-file download in materialize_file_reference

### DIFF
--- a/application_sdk/storage/reference.py
+++ b/application_sdk/storage/reference.py
@@ -308,8 +308,8 @@ async def materialize_file_reference(
                 # File is intact — stamp local sidecar and reuse.
                 _write_local_sidecar(ref.local_path, local_hash)
                 return ref
-                # Hash mismatch — file is corrupt; fall through to re-download.
-            # else: no stored sidecar → conservative: re-download (cannot verify).
+            # Otherwise (no stored sidecar OR hash mismatch) fall through
+            # to re-download — conservative since we cannot verify.
 
         # Determine output path.
         if ref.local_path is not None:

--- a/application_sdk/storage/reference.py
+++ b/application_sdk/storage/reference.py
@@ -98,7 +98,7 @@ def _sha256_hex_file(path: Path) -> str:
     return h.hexdigest()
 
 
-async def _get_stored_sidecar(storage_path: str, store: "ObjectStore") -> str | None:
+async def _get_stored_sidecar(storage_path: str, store: ObjectStore) -> str | None:
     """Fetch the stored sha256 sidecar for *storage_path*, or None if absent."""
     from application_sdk.storage.ops import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
         _get_bytes,
@@ -123,7 +123,7 @@ def _write_local_sidecar(local_path: str, sha256: str) -> None:
 
 
 async def persist_file_reference(
-    store: "ObjectStore",
+    store: ObjectStore,
     ref: FileReference,
     *,
     key: str | None = None,
@@ -239,7 +239,7 @@ async def persist_file_reference(
 
 
 async def materialize_file_reference(
-    store: "ObjectStore",
+    store: ObjectStore,
     ref: FileReference,
     *,
     local_dir: str | None = None,
@@ -279,6 +279,7 @@ async def materialize_file_reference(
     )
     from application_sdk.storage.ops import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
         download_file,
+        exists,
     )
 
     if not ref.is_durable or ref.storage_path is None:
@@ -303,11 +304,10 @@ async def materialize_file_reference(
             local_hash = _sha256_hex_file(Path(ref.local_path))
             stored_hash = await _get_stored_sidecar(ref.storage_path, store)
 
-            if stored_hash is not None:
-                if local_hash == stored_hash:
-                    # File is intact — stamp local sidecar and reuse.
-                    _write_local_sidecar(ref.local_path, local_hash)
-                    return ref
+            if stored_hash is not None and local_hash == stored_hash:
+                # File is intact — stamp local sidecar and reuse.
+                _write_local_sidecar(ref.local_path, local_hash)
+                return ref
                 # Hash mismatch — file is corrupt; fall through to re-download.
             # else: no stored sidecar → conservative: re-download (cannot verify).
 
@@ -323,6 +323,23 @@ async def materialize_file_reference(
             else:
                 fd, out_path = tempfile.mkstemp(suffix=suffix)
             os.close(fd)  # close immediately; download_file will overwrite
+
+        # list_keys() with empty result alone cannot distinguish "single
+        # file at this exact key" from "no objects under this prefix":
+        # list_keys appends a trailing slash so a real single file always
+        # lists empty here, AND some stores (notably GCS with conditional
+        # IAM) silently return an empty listing when the caller lacks
+        # permission. Without this HEAD, that ambiguity collapses into a
+        # misleading 404 from download_file on a bare prefix.
+        if not await exists(ref.storage_path, store, normalize=False):
+            raise StorageNotFoundError(
+                f"FileReference path '{ref.storage_path}' resolved to no "
+                f"objects under the prefix and no single file at the exact "
+                f"key. Either the upstream writer has not deposited files "
+                f"yet, the path is wrong, or the store credentials lack "
+                f"list/read permission on this location.",
+                key=ref.storage_path,
+            )
 
         sha256 = await download_file(
             ref.storage_path, out_path, store, compute_hash=True, normalize=False
@@ -366,7 +383,7 @@ async def materialize_file_reference(
 
         prefix = ref.storage_path.rstrip("/") + "/"
         for key in data_keys:
-            rel = key[len(prefix) :] if key.startswith(prefix) else key
+            rel = key.removeprefix(prefix)
             dest = os.path.join(local_directory, rel)
             await download_file(key, dest, store, compute_hash=False, normalize=False)
 

--- a/tests/unit/storage/test_reference.py
+++ b/tests/unit/storage/test_reference.py
@@ -1,0 +1,103 @@
+"""Unit tests for materialize_file_reference using MemoryStore."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from application_sdk.contracts.types import FileReference
+from application_sdk.storage.errors import StorageNotFoundError
+from application_sdk.storage.factory import create_memory_store
+from application_sdk.storage.ops import _put
+from application_sdk.storage.reference import (
+    materialize_file_reference,
+    persist_file_reference,
+)
+
+
+@pytest.fixture
+def store():
+    return create_memory_store()
+
+
+class TestMaterializeFileReferenceEmptyPrefix:
+    """Empty-list-from-list_keys must not collapse into a misleading
+    download_file on the bare prefix.
+
+    Before the fix, a `FileReference` whose `storage_path` resolved to a
+    prefix with no objects (because the writer hasn't run, or because the
+    store credentials don't have list/read permission on that prefix) would
+    fall into the single-file branch and call `download_file(prefix, ...)`
+    on the bare path. That GET returns 404 from the underlying store and
+    surfaces as a generic "Key not found in store: <prefix>" error,
+    obscuring the real cause.
+    """
+
+    async def test_empty_prefix_with_missing_key_raises_descriptive_error(
+        self, store
+    ) -> None:
+        ref = FileReference(
+            storage_path="argo-artifacts/missing/run-123",
+            is_durable=True,
+        )
+        with pytest.raises(StorageNotFoundError) as exc_info:
+            await materialize_file_reference(store, ref)
+
+        err = str(exc_info.value)
+        # Path is mentioned so operators can see what was missing.
+        assert "argo-artifacts/missing/run-123" in err
+        # Disambiguates from the generic "Key not found in store" message
+        # by naming the empty-prefix case explicitly.
+        msg = err.lower()
+        assert ("no objects" in msg) or ("no single file" in msg)
+
+
+class TestMaterializeFileReferenceRegressions:
+    """Cases that already worked must keep working after the HEAD check."""
+
+    async def test_directory_prefix_downloads_all_files(
+        self, store, tmp_path: Path
+    ) -> None:
+        await _put("dir/a.txt", b"alpha", store)
+        await _put("dir/sub/b.txt", b"beta", store)
+
+        ref = FileReference(storage_path="dir", is_durable=True)
+        out = await materialize_file_reference(store, ref, local_dir=str(tmp_path))
+
+        assert out.local_path is not None
+        local = Path(out.local_path)
+        assert (local / "a.txt").read_bytes() == b"alpha"
+        assert (local / "sub" / "b.txt").read_bytes() == b"beta"
+
+    async def test_single_file_at_exact_key_downloads(
+        self, store, tmp_path: Path
+    ) -> None:
+        # Listing "solo.txt/" returns empty because list_keys appends a
+        # trailing slash; the function must HEAD the bare key, see it
+        # exists, and proceed with download_file.
+        await _put("solo.txt", b"hello", store)
+
+        ref = FileReference(storage_path="solo.txt", is_durable=True)
+        out = await materialize_file_reference(store, ref, local_dir=str(tmp_path))
+
+        assert out.local_path is not None
+        assert Path(out.local_path).read_bytes() == b"hello"
+
+    async def test_local_fast_path_skips_head_and_download(
+        self, store, tmp_path: Path
+    ) -> None:
+        # Persist a file so the store has both the file and its sidecar.
+        f = tmp_path / "data.txt"
+        f.write_bytes(b"payload")
+
+        ephemeral = FileReference(local_path=str(f), is_durable=False)
+        durable = await persist_file_reference(store, ephemeral, key="cached/data.txt")
+
+        # Materialise — the local file already matches the stored sidecar
+        # so the function must return early without touching the store
+        # for the bare key (i.e. no HEAD/GET that would 404 on a different
+        # path).
+        out = await materialize_file_reference(store, durable)
+        assert out.local_path == str(f)
+        assert Path(out.local_path).read_bytes() == b"payload"


### PR DESCRIPTION
## Summary
- `materialize_file_reference` confused "empty prefix" with "single file": when `list_keys()` returned `[]`, it fell into the single-file branch and `download_file`'d the bare prefix → misleading `Key not found in store: <prefix>` 404.
- Adds a `HEAD` on the bare key before the single-file download. When HEAD also 404s, raises `StorageNotFoundError` with a message that names all three real causes (writer hasn't deposited, wrong path, missing list/read permission).
- HEAD is placed *after* the local-fast-path early return, so cached materialises pay no extra round trip.

## Why this matters
Two store behaviors make the empty-list ambiguous:
1. `list_keys()` appends a trailing slash, so a real single-file key always lists empty.
2. GCS with conditional IAM silently returns an empty listing when the caller lacks `objects.list` on the prefix (no 403).

Combined, the SDK silently took the wrong branch and emitted the wrong error. Caller-side, this surfaced as a `StorageNotFoundError` that pointed at a *prefix* but said *"key"* — which made it look like the upstream object was missing when the real cause was usually permission filtering or a writer race.

This was hit by `atlan-dbt-app` calling `materialize_file_reference` with `core_extract_prefix = argo-artifacts/...` whose SA only has IAM on `artifacts/`. The dbt app should also switch to `download_prefix` for an external directory tree (separate PR on their side) — this SDK change converts their failure into an actionable error message but does not by itself unblock them.

## Test plan
- [x] `tests/unit/storage/test_reference.py` — new failing test for the empty-prefix + missing-key case (fails before fix, passes after)
- [x] Regression: directory prefix downloads all files
- [x] Regression: single file at exact key (no children) still downloads (depends on HEAD-true → continue)
- [x] Regression: local fast path with intact sidecar returns early (no HEAD/GET)
- [x] Full `tests/unit/storage/` suite: 263 passed, 3 skipped
- [x] `pre-commit run --files application_sdk/storage/reference.py tests/unit/storage/test_reference.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)