### PR TITLE
fix(ci): build-and-publish fails on non-release push (empty RELEASE_TAGS)

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -216,7 +216,7 @@ jobs:
           echo "Immutable image: ${GHCR_IMAGE}"
           echo "Mutable branch tag: ${GHCR_BRANCH_TAG}"
           echo "DockerHub image: ${DOCKERHUB_IMAGE}"
-          [ -n "${RELEASE_TAGS}" ] && printf 'Release tags:\n%s\n' "${RELEASE_TAGS}"
+          if [ -n "${RELEASE_TAGS}" ]; then printf 'Release tags:\n%s\n' "${RELEASE_TAGS}"; fi
 
   # ── Job 2: Build — parallel per architecture ──────────────────────────────────
   build:
@@ -321,7 +321,7 @@ jobs:
           echo "  Branch:    ${GHCR_BRANCH_TAG}"
           if [ -n "${RELEASE_TAGS}" ]; then
             echo "  Release tags:"
-            while IFS= read -r tag; do [ -n "$tag" ] && echo "    ${tag}"; done <<< "${RELEASE_TAGS}"
+            while IFS= read -r tag; do if [ -n "$tag" ]; then echo "    ${tag}"; fi; done <<< "${RELEASE_TAGS}"
           fi
 
       - name: Push to Docker Hub (re-tag, no rebuild)


### PR DESCRIPTION
## Summary

PR #1597 introduced two issues in `build-and-publish-app.yaml`:

### Bug 1: Build fails on non-release push (empty RELEASE_TAGS)

**Before:**
```bash
[ -n "${RELEASE_TAGS}" ] && printf 'Release tags:\n%s\n' "${RELEASE_TAGS}"
```
`[ -n "" ]` returns exit 1 → under `set -e`, kills the entire build on every normal push to main.

**After:**
```bash
if [ -n "${RELEASE_TAGS}" ]; then printf 'Release tags:\n%s\n' "${RELEASE_TAGS}"; fi
```
Returns 0 when condition is false — safe under `set -e`.

**Repro:**
```bash
bash -e -c '[ -n "" ] && echo hi; echo "never runs"'   # exit 1
bash -e -c 'if [ -n "" ]; then echo hi; fi; echo "ok"' # exit 0
```

### Bug 2: GM Marketplace publishes SHA hash instead of semver version

**Before:** `"version": IMAGE_TAG` → always publishes SHA hash (e.g. `851899c`) to GM

**After:** Prefers `release_tag` (stripped of `v` prefix) when available, falls back to SHA:
```python
release_tag = os.environ.get("RELEASE_TAG", "").strip().lstrip("v")
version = release_tag if release_tag else os.environ["IMAGE_TAG"]
```

### Backward compatibility

| Scenario | RELEASE_TAG env | GM version |
|---|---|---|
| App passes `release_tag` (e.g. mysql) | `v0.2.0` | `0.2.0` |
| App doesn't pass `release_tag` (all existing apps) | `""` (empty/unset) | `851899c` (SHA — unchanged) |

No change in behavior for any app that doesn't opt in to `release_tag`. Fully backward compatible.

## Test plan

- [x] Empty RELEASE_TAGS: `bash -e` no longer exits with code 1
- [x] GM publish with `RELEASE_TAG=v0.2.0` → version `0.2.0`
- [x] GM publish without `RELEASE_TAG` → falls back to SHA hash (existing behavior)