### PR TITLE
fix(ci): use release_tag as GM Marketplace version when available

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -406,6 +406,7 @@ jobs:
           ENTRYPOINTS: ${{ needs.prepare.outputs.entrypoints }}
           CHANNEL: ${{ inputs.channel }}
           TENANTS: ${{ inputs.tenants }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
           GITHUB_ACTOR: ${{ github.triggering_actor }}
         run: |
@@ -419,10 +420,15 @@ jobs:
           BODY=$(python3 - <<'PYEOF'
           import json, os
 
+          # Prefer release_tag (e.g. 0.2.0) over commit SHA for the GM version.
+          # Backward compatible: apps that don't pass release_tag get SHA as before.
+          release_tag = os.environ.get("RELEASE_TAG", "").strip()
+          version = release_tag if release_tag else os.environ["IMAGE_TAG"]
+
           body = {
               "app_id": os.environ["APP_ID"],
               "image": os.environ["GHCR_IMAGE"],
-              "version": os.environ["IMAGE_TAG"],
+              "version": version,
               "branch": os.environ["BRANCH"],
               "repo": os.environ["REPO_URL"],
               "source": "ci_publish",


### PR DESCRIPTION
## Summary

The Publish to Marketplace step in `build-and-publish-app.yaml` always uses the commit SHA as the version (e.g. `851899c`). When callers pass `release_tag` (e.g. `0.2.0` from `version.txt`), use that instead for a human-readable version in GM.

## Change

```python
# Before
"version": os.environ["IMAGE_TAG"],  # always SHA hash

# After
release_tag = os.environ.get("RELEASE_TAG", "").strip()
version = release_tag if release_tag else os.environ["IMAGE_TAG"]
"version": version,  # semver when available, SHA fallback
```

## Backward compatibility

| Scenario | RELEASE_TAG | GM version |
|---|---|---|
| App passes `release_tag` (e.g. mysql-app) | `0.2.0` | `0.2.0` |
| App doesn't pass `release_tag` (all existing apps) | empty/unset | `851899c` (SHA — unchanged) |

No change for any app that doesn't opt in.

## Test plan

- [x] `RELEASE_TAG=0.2.0` → GM gets version `0.2.0`
- [x] `RELEASE_TAG=""` → GM gets SHA hash (existing behavior)