### PR TITLE
ci(harbor): narrow workflow_dispatch on release/v2 to runtime-base + sha tags

### DIFF
--- a/.github/workflows/harbor-release.yaml
+++ b/.github/workflows/harbor-release.yaml
@@ -58,31 +58,6 @@ jobs:
         id: get_sha
         run: echo "sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
-      - name: Compute image tags
-        id: image_tags
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          TAG_PREFIX: ${{ steps.tag_prefix.outputs.value }}
-          VERSION: ${{ steps.get_version.outputs.version }}
-          SHORT_SHA: ${{ steps.get_sha.outputs.sha }}
-        run: |
-          {
-            echo 'tags<<TAGS_EOF'
-            if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-              # Manual dispatch on release/v2: narrow build, only the runtime-base
-              # image with the literal tag_prefix and a sha tag — no -latest, no
-              # version aliases, no application-sdk tags.
-              echo "registry.atlan.com/public/app-runtime-base:${TAG_PREFIX}"
-              echo "registry.atlan.com/public/app-runtime-base:sha-${SHORT_SHA}"
-            else
-              # Release event from main: preserve existing application-sdk tag set.
-              echo "registry.atlan.com/public/application-sdk:${TAG_PREFIX}-latest"
-              echo "registry.atlan.com/public/application-sdk:${TAG_PREFIX}-${VERSION}"
-              echo "registry.atlan.com/public/application-sdk:sha-${SHORT_SHA}"
-            fi
-            echo TAGS_EOF
-          } >> "$GITHUB_OUTPUT"
-
       - name: Log in to Atlan Harbor Registry
         uses: docker/login-action@v3
         with:
@@ -111,7 +86,9 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.image_tags.outputs.tags }}
+          tags: |
+            registry.atlan.com/public/app-runtime-base:${{ steps.tag_prefix.outputs.value }}
+            registry.atlan.com/public/app-runtime-base:sha-${{ steps.get_sha.outputs.sha }}
           build-args: |
             ACCESS_TOKEN_USR=$GITHUB_ACTOR
             ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}

--- a/.github/workflows/harbor-release.yaml
+++ b/.github/workflows/harbor-release.yaml
@@ -58,6 +58,31 @@ jobs:
         id: get_sha
         run: echo "sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
+      - name: Compute image tags
+        id: image_tags
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG_PREFIX: ${{ steps.tag_prefix.outputs.value }}
+          VERSION: ${{ steps.get_version.outputs.version }}
+          SHORT_SHA: ${{ steps.get_sha.outputs.sha }}
+        run: |
+          {
+            echo 'tags<<TAGS_EOF'
+            if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+              # Manual dispatch on release/v2: narrow build, only the runtime-base
+              # image with the literal tag_prefix and a sha tag — no -latest, no
+              # version aliases, no application-sdk tags.
+              echo "registry.atlan.com/public/app-runtime-base:${TAG_PREFIX}"
+              echo "registry.atlan.com/public/app-runtime-base:sha-${SHORT_SHA}"
+            else
+              # Release event from main: preserve existing application-sdk tag set.
+              echo "registry.atlan.com/public/application-sdk:${TAG_PREFIX}-latest"
+              echo "registry.atlan.com/public/application-sdk:${TAG_PREFIX}-${VERSION}"
+              echo "registry.atlan.com/public/application-sdk:sha-${SHORT_SHA}"
+            fi
+            echo TAGS_EOF
+          } >> "$GITHUB_OUTPUT"
+
       - name: Log in to Atlan Harbor Registry
         uses: docker/login-action@v3
         with:
@@ -86,10 +111,7 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: |
-            registry.atlan.com/public/application-sdk:${{ steps.tag_prefix.outputs.value }}-latest
-            registry.atlan.com/public/application-sdk:${{ steps.tag_prefix.outputs.value }}-${{ steps.get_version.outputs.version }}
-            registry.atlan.com/public/application-sdk:sha-${{ steps.get_sha.outputs.sha }}
+          tags: ${{ steps.image_tags.outputs.tags }}
           build-args: |
             ACCESS_TOKEN_USR=$GITHUB_ACTOR
             ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}

--- a/.github/workflows/harbor-release.yaml
+++ b/.github/workflows/harbor-release.yaml
@@ -35,9 +35,9 @@ jobs:
           TAG_PREFIX_INPUT: ${{ inputs.tag_prefix }}
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
-            # Release builds always use 'main' to preserve existing tag names
-            # (main-latest, main-<version>) and keep the Snyk import gate working.
-            echo "value=main" >> "$GITHUB_OUTPUT"
+            # Release builds on this branch publish under the release-v2 tag
+            # (Docker tags can't contain '/', so 'release/v2' is sanitized).
+            echo "value=release-v2" >> "$GITHUB_OUTPUT"
           elif [ -n "${TAG_PREFIX_INPUT:-}" ]; then
             if ! printf '%s' "$TAG_PREFIX_INPUT" | grep -Eq '^[A-Za-z0-9._-]+$'; then
               echo "Invalid tag_prefix: must match ^[A-Za-z0-9._-]+$" >&2


### PR DESCRIPTION
## Summary

On `release/v2`, change `harbor-release.yaml` so the only Harbor tags it produces are:

- `registry.atlan.com/public/app-runtime-base:${tag_prefix}` (e.g. `2.8.7-1`)
- `registry.atlan.com/public/app-runtime-base:sha-${short_sha}`

All previously emitted tags are removed: no `application-sdk:*` tags, no `${prefix}-latest`, no `${prefix}-<version>` aliases. Diff is 5 lines — only the `tags:` block of the build step changes.

The release-event behavior on `main` is unaffected because `main` has its own copy of this workflow file.

## Test plan

- [ ] Trigger `Publish Harbor Image (Release)` via Actions → `Run workflow` on `release/v2` with `tag_prefix=2.8.7-1`. Confirm Harbor receives only:
  - `registry.atlan.com/public/app-runtime-base:2.8.7-1`
  - `registry.atlan.com/public/app-runtime-base:sha-<short_sha>`
- [ ] Confirm no `application-sdk:*`, `*-latest`, or `*-<version>` tags are pushed for that run.