### PR TITLE
chore(security): temporary allowlist for atlan-context-studio-app PR #101

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -293,5 +293,201 @@
     "reason": "Base image — Dapr 1.17 transitive Go AWS SDK dep in app-framework-golden bundle (consumed by SDK 2.x). Fix available in 1.43.5; awaiting Wolfi rebuild of app-framework-golden with newer aws-sdk-go-v2.",
     "expires": "2026-05-29",
     "added_by": "sachi-atlan"
+  },
+  "CVE-2025-68121": {
+    "package": "stdlib (Go)",
+    "severity": "CRITICAL",
+    "reason": "atlan-context-studio-app PR #101 — connector uses cgr.dev/chainguard/wolfi-base; upstream fix via SDK v3.x app-framework-golden:3.13. Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-14",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2026-32597": {
+    "package": "PyJWT",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector pinned to atlan-application-sdk==0.1.1rc51; upstream fix in SDK v3.x (pyjwt>=2.12.0). Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2025-69223": {
+    "package": "aiohttp",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector pinned to atlan-application-sdk==0.1.1rc51; upstream fix in SDK v3.x (aiohttp>=3.13.3). Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2026-32274": {
+    "package": "black",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector pinned to atlan-application-sdk==0.1.1rc51; upstream fix in SDK v3.x (black>=26.3.1). Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2026-26007": {
+    "package": "cryptography",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector pinned to atlan-application-sdk==0.1.1rc51; upstream fix in SDK v3.x (cryptography>=46.0.5). Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2025-67221": {
+    "package": "orjson",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector pinned to atlan-application-sdk==0.1.1rc51; upstream fix in SDK v3.x (orjson>=3.11.6). Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2026-0994": {
+    "package": "protobuf",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector pinned to atlan-application-sdk==0.1.1rc51; upstream fix in SDK v3.x (protobuf>=6.33.5). Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2026-24486": {
+    "package": "python-multipart",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector pinned to atlan-application-sdk==0.1.1rc51; upstream fix in SDK v3.x (python-multipart>=0.0.26). Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2026-32640": {
+    "package": "simpleeval",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector pinned to atlan-application-sdk==0.1.1rc51; upstream fix in SDK v3.x (simpleeval>=1.0.5). Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2025-62727": {
+    "package": "starlette",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector pinned to atlan-application-sdk==0.1.1rc51; upstream fix in SDK v3.x (starlette>=0.49.1). Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2025-66418": {
+    "package": "urllib3",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector pinned to atlan-application-sdk==0.1.1rc51; upstream fix in SDK v3.x (urllib3>=2.6.0). Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2025-66471": {
+    "package": "urllib3",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector pinned to atlan-application-sdk==0.1.1rc51; upstream fix in SDK v3.x (urllib3>=2.6.0). Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2026-21441": {
+    "package": "urllib3",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector pinned to atlan-application-sdk==0.1.1rc51; upstream fix in SDK v3.x (urllib3>=2.6.3). Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2025-63811": {
+    "package": "github.com/dvsekhvalnov/jose2go",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector uses cgr.dev/chainguard/wolfi-base; upstream fix via SDK v3.x app-framework-golden:3.13. Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2026-24051": {
+    "package": "go.opentelemetry.io/otel/sdk",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector uses cgr.dev/chainguard/wolfi-base; upstream fix via SDK v3.x app-framework-golden:3.13. Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2025-58183": {
+    "package": "stdlib (Go)",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector uses cgr.dev/chainguard/wolfi-base; upstream fix via SDK v3.x app-framework-golden:3.13. Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2025-61726": {
+    "package": "stdlib (Go)",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector uses cgr.dev/chainguard/wolfi-base; upstream fix via SDK v3.x app-framework-golden:3.13. Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2025-61728": {
+    "package": "stdlib (Go)",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector uses cgr.dev/chainguard/wolfi-base; upstream fix via SDK v3.x app-framework-golden:3.13. Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2025-61729": {
+    "package": "stdlib (Go)",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector uses cgr.dev/chainguard/wolfi-base; upstream fix via SDK v3.x app-framework-golden:3.13. Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2024-25621": {
+    "package": "github.com/containerd/containerd",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector uses cgr.dev/chainguard/wolfi-base; upstream fix via SDK v3.x app-framework-golden:3.13. Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "CVE-2025-15558": {
+    "package": "github.com/docker/cli",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector uses cgr.dev/chainguard/wolfi-base; upstream fix via SDK v3.x app-framework-golden:3.13. Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "SNYK-GOLANG-GITHUBCOMMOBYSPDYSTREAMSPDY-16304822": {
+    "package": "github.com/moby/spdystream/spdy",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector uses cgr.dev/chainguard/wolfi-base; upstream fix via SDK v3.x app-framework-golden:3.13. Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "SNYK-GOLANG-GOOPENTELEMETRYIOOTELSDKRESOURCE-15182758": {
+    "package": "go.opentelemetry.io/otel/sdk/resource",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector uses cgr.dev/chainguard/wolfi-base; upstream fix via SDK v3.x app-framework-golden:3.13. Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "SNYK-GOLANG-HELMSHHELMV3PKGCHARTUTIL-11799535": {
+    "package": "helm.sh/helm/v3/pkg/chartutil",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector uses cgr.dev/chainguard/wolfi-base; upstream fix via SDK v3.x app-framework-golden:3.13. Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "SNYK-GOLANG-HELMSHHELMV3PKGCHARTUTIL-11799536": {
+    "package": "helm.sh/helm/v3/pkg/chartutil",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector uses cgr.dev/chainguard/wolfi-base; upstream fix via SDK v3.x app-framework-golden:3.13. Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "SNYK-GOLANG-HELMSHHELMV3PKGDOWNLOADER-10734107": {
+    "package": "helm.sh/helm/v3/pkg/downloader",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector uses cgr.dev/chainguard/wolfi-base; upstream fix via SDK v3.x app-framework-golden:3.13. Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "SNYK-GOLANG-HELMSHHELMV3PKGLINTRULES-11799538": {
+    "package": "helm.sh/helm/v3/pkg/lint/rules",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector uses cgr.dev/chainguard/wolfi-base; upstream fix via SDK v3.x app-framework-golden:3.13. Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
+  },
+  "SNYK-GOLANG-HELMSHHELMV3PKGREPO-11799541": {
+    "package": "helm.sh/helm/v3/pkg/repo",
+    "severity": "HIGH",
+    "reason": "atlan-context-studio-app PR #101 — connector uses cgr.dev/chainguard/wolfi-base; upstream fix via SDK v3.x app-framework-golden:3.13. Allowlist requested to unblock current PR while team scopes SDK upgrade.",
+    "expires": "2026-05-29",
+    "added_by": "deb-atlan"
   }
 }


### PR DESCRIPTION
## Why

Adds 28 temporary allowlist entries to unblock [atlanhq/atlan-context-studio-app#101](https://github.com/atlanhq/atlan-context-studio-app/pull/101) (Databricks deploy resilience, asset-search, joins UI). The Security Gate is currently blocking that PR on a mix of stale-dependency findings — none of which are introduced by the PR's code changes.

## What's flagging

**Python deps (10) — pinned via `atlan-application-sdk==0.1.1rc51`:**

| CVE | Package | Fix in SDK v3.x |
|---|---|---|
| `CVE-2026-32597` | PyJWT | `pyjwt>=2.12.0` |
| `CVE-2025-69223` | aiohttp | `aiohttp>=3.13.3` |
| `CVE-2026-32274` | black | `black>=26.3.1` |
| `CVE-2026-26007` | cryptography | `cryptography>=46.0.5` |
| `CVE-2025-67221` | orjson | `orjson>=3.11.6` |
| `CVE-2026-0994` | protobuf | `protobuf>=6.33.5` |
| `CVE-2026-24486` | python-multipart | `python-multipart>=0.0.26` |
| `CVE-2026-32640` | simpleeval | `simpleeval>=1.0.5` |
| `CVE-2025-62727` | starlette | `starlette>=0.49.1` |
| `CVE-2025-66418` / `CVE-2025-66471` / `CVE-2026-21441` | urllib3 | `urllib3>=2.6.3` |

**Go / base-image (18) — connector still uses `cgr.dev/chainguard/wolfi-base` rather than `cgr.dev/atlan.com/app-framework-golden:3.13`:**

- `CVE-2025-68121` (CRITICAL), `CVE-2025-58183`, `CVE-2025-61726`, `CVE-2025-61728`, `CVE-2025-61729` — Go stdlib
- `CVE-2025-63811` — `dvsekhvalnov/jose2go`
- `CVE-2026-24051`, `SNYK-GOLANG-GOOPENTELEMETRYIOOTELSDKRESOURCE-15182758` — OpenTelemetry Go
- `CVE-2024-25621` — containerd
- `CVE-2025-15558` — docker/cli
- `SNYK-GOLANG-GITHUBCOMMOBYSPDYSTREAMSPDY-16304822` — moby/spdystream
- 5 × Helm v3 (chartutil ×2, downloader, lint/rules, repo)

## Scope and expectation

The team is scoping the SDK v3.x upgrade for atlan-context-studio-app, but **no firm decision or commitment yet**. This allowlist is requested as a short bridge to unblock PR #101 (in-flight Databricks deploy fix for a Databricks customer issue) while that scoping continues.

- **1 CRITICAL** expires `2026-05-14` (15-day max per `_expiry_policy`)
- **27 HIGH** expires `2026-05-29` (30-day max per `_expiry_policy`)

If the SDK upgrade lands before expiry, these entries become moot and can be removed. If not, we will reassess at expiry — either renew (with continued unresolvability rationale), proceed with the SDK migration, or downgrade scope on the connector.

## Validation

- `python3 -c "import json; json.load(open('.security/base-allowlist.json'))"` passes
- `python3 .github/scripts/validate_allowlist.py` reports: `✅ Allowlist valid: 68 entries, all within policy (CRITICAL ≤ 15d, HIGH ≤ 30d)`

## Approval

Per [.security/approvers.json](https://github.com/atlanhq/application-sdk/blob/main/.security/approvers.json), requesting review from one of the SDK security approvers:

@nishantmunjal7 @anbarasantr @AtMrun @gaurav-atlan @akshay-vishwanath27 @louisnow @cmgrote @mananjain99 @vaibhavatlan @Aryamanz29