### PR TITLE
feat(handler): expose form metadata in PreflightInput

### DIFF
--- a/application_sdk/handler/contracts.py
+++ b/application_sdk/handler/contracts.py
@@ -135,6 +135,16 @@ class PreflightInput(BaseModel):
     connection_config: dict[str, Any] = {}
     """Connection configuration (host, port, database, etc.)."""
 
+    metadata: dict[str, Any] = {}
+    """Form-level metadata forwarded by heracles alongside the credential.
+
+    Contains the full UI form state (extraction type, source, user-entered
+    prefixes, filter keys, etc.) as sent by the frontend. Handlers that need
+    form fields unavailable in the credential body — for example a storage
+    prefix entered as a plain text input rather than inside a credential form
+    — can read them here. All other handlers can ignore this field safely.
+    """
+
     checks_to_run: list[str] = []
     """Specific checks to run (empty = run all)."""
 

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -368,6 +368,26 @@ class TestPreflightEndpoint:
         )
         assert response.status_code == 500
 
+    def test_preflight_metadata_forwarded_to_handler(self) -> None:
+        """metadata from the request body is forwarded to the handler via PreflightInput."""
+        received: list[dict] = []
+
+        class _MetadataCapture(_TestHandler):
+            async def preflight_check(self, input: PreflightInput) -> PreflightOutput:
+                received.append(dict(input.metadata))
+                return PreflightOutput(status=PreflightStatus.READY, message="ready")
+
+        client = _make_client(handler=_MetadataCapture())
+        response = client.post(
+            "/workflows/v1/check",
+            json={
+                "credentials": [],
+                "metadata": {"extraction-type": "objectstore", "manifest-source": "atlan", "core-extract-output-prefix": "artifacts/dbt/prod"},
+            },
+        )
+        assert response.status_code == 200
+        assert received == [{"extraction-type": "objectstore", "manifest-source": "atlan", "core-extract-output-prefix": "artifacts/dbt/prod"}]
+
 
 class TestMetadataEndpoint:
     """Tests for POST /workflows/v1/metadata."""

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -398,11 +398,13 @@ class TestPreflightEndpoint:
             },
         )
         assert response.status_code == 200
-        assert received == [{
-            "extraction-type": "objectstore",
-            "manifest-source": "atlan",
-            "core-extract-output-prefix": "artifacts/dbt/prod",
-        }]
+        assert received == [
+            {
+                "extraction-type": "objectstore",
+                "manifest-source": "atlan",
+                "core-extract-output-prefix": "artifacts/dbt/prod",
+            }
+        ]
 
     def test_preflight_metadata_absent_defaults_to_empty(self) -> None:
         """Callers that don't send metadata get an empty dict — no regression."""

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -369,7 +369,12 @@ class TestPreflightEndpoint:
         assert response.status_code == 500
 
     def test_preflight_metadata_forwarded_to_handler(self) -> None:
-        """metadata from the request body is forwarded to the handler via PreflightInput."""
+        """metadata survives _normalize_credentials and reaches the handler.
+
+        Uses Format 2 credentials (nested dict) — the format heracles sends for
+        native-app preflight calls — to verify that {**body, "credentials": ...}
+        preserves the metadata key through normalization.
+        """
         received: list[dict] = []
 
         class _MetadataCapture(_TestHandler):
@@ -380,13 +385,41 @@ class TestPreflightEndpoint:
         client = _make_client(handler=_MetadataCapture())
         response = client.post(
             "/workflows/v1/check",
+            # Format 2: credentials as a nested dict, which is what heracles sends
+            # for native-app preflight calls. _normalize_credentials converts this
+            # to v3 list via {**body, "credentials": ...}, metadata must survive.
             json={
-                "credentials": [],
-                "metadata": {"extraction-type": "objectstore", "manifest-source": "atlan", "core-extract-output-prefix": "artifacts/dbt/prod"},
+                "credentials": {"connectorConfigName": "atlan-connectors-dbt"},
+                "metadata": {
+                    "extraction-type": "objectstore",
+                    "manifest-source": "atlan",
+                    "core-extract-output-prefix": "artifacts/dbt/prod",
+                },
             },
         )
         assert response.status_code == 200
-        assert received == [{"extraction-type": "objectstore", "manifest-source": "atlan", "core-extract-output-prefix": "artifacts/dbt/prod"}]
+        assert received == [{
+            "extraction-type": "objectstore",
+            "manifest-source": "atlan",
+            "core-extract-output-prefix": "artifacts/dbt/prod",
+        }]
+
+    def test_preflight_metadata_absent_defaults_to_empty(self) -> None:
+        """Callers that don't send metadata get an empty dict — no regression."""
+        received: list[dict] = []
+
+        class _MetadataCapture(_TestHandler):
+            async def preflight_check(self, input: PreflightInput) -> PreflightOutput:
+                received.append(dict(input.metadata))
+                return PreflightOutput(status=PreflightStatus.READY, message="ready")
+
+        client = _make_client(handler=_MetadataCapture())
+        response = client.post(
+            "/workflows/v1/check",
+            json={"credentials": []},
+        )
+        assert response.status_code == 200
+        assert received == [{}]
 
 
 class TestMetadataEndpoint:


### PR DESCRIPTION
## Summary

- Adds `metadata: dict[str, Any] = {}` field to `PreflightInput`
- Heracles always forwards the full UI form state as `metadata` in `/workflows/v1/check` request bodies — this field was previously silently dropped by `model_validate` because it didn't exist on the model
- Any connector handler can now read form-level values (extraction type, source selector, user-entered prefixes, etc.) from `preflight_input.metadata`
- All existing handlers that don't reference this field are unaffected — fully backward-compatible

**Motivation:** The dbt connector has a Core → Atlan Object Storage path where the user enters a storage prefix as a plain text input (not inside a credential form). The prefix reaches heracles as form data but had no way to reach the handler. Other connectors may hit the same pattern whenever a form field lives outside a credential widget.

---

## Why just adding this field is sufficient — full trace

**What heracles sends to `/workflows/v1/check` (native app path):**
```json
{
  "connector": "atlan-connectors-dbt",
  "credentials": {"connectorConfigName": "atlan-connectors-dbt"},
  "metadata": {
    "extraction-type": "objectstore",
    "manifest-source": "atlan",
    "core-extract-output-prefix": "artifacts/apps/dbt/...",
    ...all other form fields...
  }
}
```

**Through `_normalize_credentials`:**

`credentials` is a `dict` (not `None`, not a list) → **Format 2 path**:
```python
return {**body, "credentials": _flatten_to_pairs(dict(creds))}
```
`{**body, ...}` spreads the entire original body — `metadata` rides through unchanged. Only `credentials` is replaced with the v3 `[{key, value}]` list.

Format 3 (flat top-level) only triggers when `credentials is None` — never the case here.

**`_CREDENTIAL_KEYS`** is `{host, port, authType, username, password, connectorType, connectorConfigName, extra}` — `metadata` is not in the set, so it is never accidentally consumed as a credential field.

**`_flatten_to_pairs`** only operates on the `creds` dict passed to it — it never touches `body["metadata"]`.

**After `_normalize_credentials`, body is:**
```json
{
  "connector": "...",
  "credentials": [{"key": "connectorConfigName", "value": "atlan-connectors-dbt"}],
  "metadata": {"extraction-type": "objectstore", "manifest-source": "atlan", "core-extract-output-prefix": "..."}
}
```

**`PreflightInput.model_validate(body)`** maps `body["metadata"]` → `preflight_input.metadata` directly. ✓

---

## Test plan

- [x] New test `test_preflight_metadata_forwarded_to_handler` — verifies the field is populated from the request body and reaches the handler
- [x] Existing `test_preflight_success` and `test_preflight_handler_error_returns_500` still pass unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)