### PR TITLE
fix(security): auto-fix pyproject pin regex no longer corrupts the file

### DIFF
--- a/.github/workflows/auto-fix-vulnerabilities.yaml
+++ b/.github/workflows/auto-fix-vulnerabilities.yaml
@@ -230,11 +230,14 @@ jobs:
                   # Check if package already exists (case-insensitive)
                   existing = re.search(rf'"{pkg}[><=!]', content, re.IGNORECASE)
                   if existing:
-                      # Update existing entry
+                      # Update existing entry. Group 1 already captures the leading `"`
+                      # plus the package name (e.g. `"black`), so the replacement MUST NOT
+                      # prepend another `"`. The previous f'"\\1>=...' produced
+                      # `""black>=26.3.1"` and corrupted pyproject.toml on every run.
                       patterns = [
-                          (rf'("{pkg})(>=[\d.]+)"', f'"\\1>={min_version}"'),
-                          (rf'("{pkg})(==[\d.]+)"', f'"\\1>={min_version}"'),
-                          (rf'("{pkg})"', f'"\\1>={min_version}"'),
+                          (rf'("{pkg})(>=[\d.]+)"', f'\\1>={min_version}"'),
+                          (rf'("{pkg})(==[\d.]+)"', f'\\1>={min_version}"'),
+                          (rf'("{pkg})"', f'\\1>={min_version}"'),
                       ]
                       for pattern, replacement in patterns:
                           new_content, count = re.subn(pattern, replacement, content, flags=re.IGNORECASE)


### PR DESCRIPTION
## Bug
The `/fix-vulnerabilities` workflow corrupts `pyproject.toml` after the first successful pin in a given run. Subsequent package updates fail with:

```
TOML parse error at line N, column 7
   |
N  |     ""black>=26.3.1",
   |       ^
missing comma between array elements
```

## Root cause
In the existing-dep update path:

```python
patterns = [
    (rf'("{pkg})(>=[\d.]+)"', f'"\\1>={min_version}"'),
    ...
]
```

- Group 1 captures `"{pkg}` — **including the leading `"`** (e.g. `"black`)
- Replacement is `"\1>={min_version}"` — also prepends a literal `"`
- Result: `""black>=26.3.1"` ← double quote, broken TOML

After the first malformed write, every later `uv lock --upgrade-package` invocation fails because uv can't parse the file.

## Fix
Drop the extra `"` from the three replacement strings. Group 1 already provides it.

```diff
-(rf'("{pkg})(>=[\d.]+)"', f'"\\1>={min_version}"'),
+(rf'("{pkg})(>=[\d.]+)"', f'\\1>={min_version}"'),
```

## Verified locally
Simulated updating an existing `"black>=24.0.0"` entry → produces clean `"black>=26.3.1"` (no double quote).

## Reproduced on
- [atlanhq/atlan-bigquery-app#76](https://github.com/atlanhq/atlan-bigquery-app/pull/76) — most recent. PyJWT and aiohttp pinned successfully, then black through urllib3 all failed once black corruption broke the file.
- [atlanhq/atlan-s3-app#15](https://github.com/atlanhq/atlan-s3-app/pull/15) — earlier; we manually fixed the file at the time.

## After this merges
The bigquery PR will need its `pyproject.toml` cleaned up manually (or the bot's bad commit reverted) before re-running `/fix-vulnerabilities`. Future runs across all repos won't hit this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)