### PR TITLE
fix(security): allowlist 5 Snyk Dapr 1.17.0 per-package IDs (siblings of GHSA-85gx-3qv6-4463)

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -210,6 +210,41 @@
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
+  "SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGACL-16394931": {
+    "package": "github.com/dapr/dapr/pkg/acl",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr 1.17.0 sub-package. Same root issue as GHSA-85gx-3qv6-4463 reported under Snyk's per-package IDs. Fix available in 1.17.5, awaiting SDK base rebuild.",
+    "expires": "2026-05-23",
+    "added_by": "mananjain99"
+  },
+  "SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGACTORSTARGETSAPP-16394932": {
+    "package": "github.com/dapr/dapr/pkg/actors/targets/app",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr 1.17.0 sub-package. Same root issue as GHSA-85gx-3qv6-4463 reported under Snyk's per-package IDs. Fix available in 1.17.5, awaiting SDK base rebuild.",
+    "expires": "2026-05-23",
+    "added_by": "mananjain99"
+  },
+  "SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGAPIGRPC-16394933": {
+    "package": "github.com/dapr/dapr/pkg/api/grpc",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr 1.17.0 sub-package. Same root issue as GHSA-85gx-3qv6-4463 reported under Snyk's per-package IDs. Fix available in 1.17.5, awaiting SDK base rebuild.",
+    "expires": "2026-05-23",
+    "added_by": "mananjain99"
+  },
+  "SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGAPIHTTP-16394934": {
+    "package": "github.com/dapr/dapr/pkg/api/http",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr 1.17.0 sub-package. Same root issue as GHSA-85gx-3qv6-4463 reported under Snyk's per-package IDs. Fix available in 1.17.5, awaiting SDK base rebuild.",
+    "expires": "2026-05-23",
+    "added_by": "mananjain99"
+  },
+  "SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGMESSAGING-16394937": {
+    "package": "github.com/dapr/dapr/pkg/messaging",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr 1.17.0 sub-package. Same root issue as GHSA-85gx-3qv6-4463 reported under Snyk's per-package IDs. Fix available in 1.17.5, awaiting SDK base rebuild.",
+    "expires": "2026-05-23",
+    "added_by": "mananjain99"
+  },
   "CVE-2026-35469": {
     "package": "github.com/moby/spdystream",
     "severity": "HIGH",


### PR DESCRIPTION
## Why
Snyk reports the Dapr 1.17.0 → 1.17.5 vulnerability under **per-package IDs**, one per sub-module:

- \`SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGACL-16394931\` — \`github.com/dapr/dapr/pkg/acl\`
- \`SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGACTORSTARGETSAPP-16394932\` — \`pkg/actors/targets/app\`
- \`SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGAPIGRPC-16394933\` — \`pkg/api/grpc\`
- \`SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGAPIHTTP-16394934\` — \`pkg/api/http\`
- \`SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGMESSAGING-16394937\` — \`pkg/messaging\`

We already cover the same root issue under multiple existing entries:
- \`GHSA-85gx-3qv6-4463\` (github.com/dapr/dapr root)
- \`CVE-2026-27140\`, \`CVE-2026-32281\`, \`CVE-2026-32283\` (Wolfi \`dapr-daprd-1.17\` package)
- \`CVE-2026-34986\` (dapr-daprd-1.17 runtime)

But the gate matches by exact key, so the Snyk-format findings bypass them.

Currently blocking [atlanhq/atlan-bigquery-app#76](https://github.com/atlanhq/atlan-bigquery-app/pull/76) — these are the only 5 remaining blockers after auto-fix cleared the 8 app-level Python deps.

## Change
Adds the 5 Snyk per-package IDs as sibling entries pointing at the same root issue (Dapr 1.17.0, fix in 1.17.5). Same 30-day HIGH expiry (\`2026-05-23\`) so all Dapr-related entries fall off together when the SDK base is rebuilt with Dapr 1.17.5.

## Test plan
- [x] \`validate_allowlist.py\` passes (48 entries, within policy)
- [x] JSON syntactically valid
- [ ] After merge: rerun \`Security Gate\` on \`atlan-bigquery-app#76\` — gate should pass green

🤖 Generated with [Claude Code](https://claude.com/claude-code)