### PR TITLE
feat(handler): workflow-level retry policy with typed exceptions

### DIFF
--- a/application_sdk/app/__init__.py
+++ b/application_sdk/app/__init__.py
@@ -21,7 +21,15 @@ Usage::
             return await self.fetch_data(input)
 """
 
-from application_sdk.app.base import App, AppError, NonRetryableError, RetryableError
+from application_sdk.app.base import (
+    App,
+    AppError,
+    AuthError,
+    NonRetryableError,
+    RateLimited,
+    RetryableError,
+    UpstreamUnavailable,
+)
 from application_sdk.app.context import AppContext
 from application_sdk.app.entrypoint import EntryPointMetadata, entrypoint
 from application_sdk.app.registry import AppRegistry, TaskRegistry
@@ -36,14 +44,17 @@ __all__ = [
     "AtlanClientMixin",
     "AppError",
     "AppRegistry",
+    "AuthError",
     "EntryPointMetadata",
     "Input",
     "NonRetryableError",
     "Output",
+    "RateLimited",
     "RetryableError",
     "RetryPolicy",
     "TaskMetadata",
     "TaskRegistry",
+    "UpstreamUnavailable",
     "entrypoint",
     "task",
 ]

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -47,9 +47,12 @@ from application_sdk.contracts.storage import (
 )
 from application_sdk.contracts.types import FileReference, StorageTier
 from application_sdk.errors import (
+    APP_AUTH,
     APP_CONTEXT_ERROR,
     APP_ERROR,
     APP_NON_RETRYABLE,
+    APP_RATE_LIMITED,
+    APP_UPSTREAM_UNAVAILABLE,
     ErrorCode,
 )
 from application_sdk.observability.logger_adaptor import get_logger
@@ -262,6 +265,40 @@ class RetryableError(AppError):
     """
 
     DEFAULT_ERROR_CODE: ClassVar[ErrorCode] = APP_ERROR
+
+
+class AuthError(NonRetryableError):
+    """Tenant-side authentication or authorization failure.
+
+    Use for 401/403 from upstream APIs, expired credentials, or revoked tokens.
+    Workflow-level and activity-level retries both stop on this exception
+    (configure RetryPolicy ``non_retryable_error_types`` to include
+    ``"AuthError"``). Resolution requires tenant config change, not retry.
+    """
+
+    DEFAULT_ERROR_CODE: ClassVar[ErrorCode] = APP_AUTH
+
+
+class RateLimited(RetryableError):
+    """Upstream rate limit hit (HTTP 429 or equivalent).
+
+    Activity-level retry with exponential backoff usually clears this; if the
+    activity exhausts attempts, workflow-level retry gets a fresh budget after
+    a longer cooldown.
+    """
+
+    DEFAULT_ERROR_CODE: ClassVar[ErrorCode] = APP_RATE_LIMITED
+
+
+class UpstreamUnavailable(RetryableError):
+    """Upstream dependency is down or unreachable (HTTP 5xx, connection refused).
+
+    Examples: Atlas metadata store, Iceberg metastore, source DB. Pair with a
+    long-tailed retry policy on dependent activities so the workflow naturally
+    succeeds when the upstream returns.
+    """
+
+    DEFAULT_ERROR_CODE: ClassVar[ErrorCode] = APP_UPSTREAM_UNAVAILABLE
 
 
 # =============================================================================

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -272,8 +272,10 @@ class AuthError(NonRetryableError):
 
     Use for 401/403 from upstream APIs, expired credentials, or revoked tokens.
     Workflow-level and activity-level retries both stop on this exception
-    (configure RetryPolicy ``non_retryable_error_types`` to include
-    ``"AuthError"``). Resolution requires tenant config change, not retry.
+    (configure :class:`~application_sdk.execution.retry.RetryPolicy`
+    ``non_retryable_errors`` to include ``"AuthError"``;
+    :data:`~application_sdk.execution.retry.DEFAULT_WORKFLOW_RETRY` already
+    does). Resolution requires tenant config change, not retry.
     """
 
     DEFAULT_ERROR_CODE: ClassVar[ErrorCode] = APP_AUTH
@@ -1774,10 +1776,14 @@ __all__ = [
     "App",
     "AppError",
     "AppStateAccessor",
+    "AuthError",
     "FileReference",
     "NonRetryableError",
     "PersistentStateAccessor",
+    "RateLimited",
+    "RetryableError",
     "TaskStateAccessor",
+    "UpstreamUnavailable",
     "_app_state",
     "_app_state_lock",
     "_apply_app_registration",

--- a/application_sdk/errors.py
+++ b/application_sdk/errors.py
@@ -32,6 +32,9 @@ APP_CONTEXT_ERROR = ErrorCode("APP", 3)
 APP_NOT_FOUND = ErrorCode("APP", 4)
 APP_ALREADY_REGISTERED = ErrorCode("APP", 5)
 TASK_NOT_FOUND = ErrorCode("APP", 6)
+APP_AUTH = ErrorCode("APP", 7)
+APP_RATE_LIMITED = ErrorCode("APP", 8)
+APP_UPSTREAM_UNAVAILABLE = ErrorCode("APP", 9)
 
 # STR - Storage errors
 STORAGE_NOT_FOUND = ErrorCode("STR", 1)

--- a/application_sdk/execution/retry.py
+++ b/application_sdk/execution/retry.py
@@ -82,6 +82,29 @@ AGGRESSIVE_RETRY = RetryPolicy(
 """Aggressive retry policy for transient failures."""
 
 
+DEFAULT_WORKFLOW_RETRY = RetryPolicy(
+    max_attempts=2,
+    initial_interval=timedelta(minutes=2),
+    max_interval=timedelta(minutes=10),
+    backoff_coefficient=2.0,
+    non_retryable_errors=(
+        "NonRetryableError",
+        "AuthError",
+        "ValidationError",
+    ),
+)
+"""Default workflow-level retry policy.
+
+Applied to ``client.start_workflow()`` so a workflow that fails for a transient
+reason (activity exhausted retries, worker host crashed, etc.) gets one fresh
+attempt with a clean activity-retry budget. Deterministic failures
+(``NonRetryableError`` and its subclasses) skip the retry.
+
+Apps that are not idempotent across full workflow restart should pass
+``workflow_retry_policy=NO_RETRY`` to ``create_app_handler_service`` to opt out.
+"""
+
+
 def _to_temporal_retry_policy(policy: RetryPolicy) -> _TemporalRetryPolicy:
     """Convert a framework :class:`RetryPolicy` to ``temporalio.common.RetryPolicy``.
 

--- a/application_sdk/execution/retry.py
+++ b/application_sdk/execution/retry.py
@@ -90,6 +90,7 @@ DEFAULT_WORKFLOW_RETRY = RetryPolicy(
     non_retryable_errors=(
         "NonRetryableError",
         "AuthError",
+        "ContractValidationError",
         "ValidationError",
     ),
 )
@@ -97,8 +98,27 @@ DEFAULT_WORKFLOW_RETRY = RetryPolicy(
 
 Applied to ``client.start_workflow()`` so a workflow that fails for a transient
 reason (activity exhausted retries, worker host crashed, etc.) gets one fresh
-attempt with a clean activity-retry budget. Deterministic failures
-(``NonRetryableError`` and its subclasses) skip the retry.
+attempt with a clean activity-retry budget. Deterministic failures skip the
+retry and fail terminally on first attempt.
+
+Note: Temporal matches ``non_retryable_errors`` against the failed
+``ApplicationFailure.error_type`` by *exact class name*, not by isinstance. New
+``NonRetryableError`` subclasses introduced by app code are NOT auto-covered by
+the ``"NonRetryableError"`` entry — their concrete class name must be added
+here (or apps should raise ``NonRetryableError`` directly).
+
+Listed entries:
+
+- ``"NonRetryableError"`` — explicit non-retryable raises from app code
+- ``"AuthError"`` — auth/credential failures (subclass of ``NonRetryableError``)
+- ``"ContractValidationError"`` — SDK contract validation failure
+  (``application_sdk/contracts/base.py``)
+- ``"ValidationError"`` — pydantic input validation failure
+  (``pydantic.ValidationError``)
+
+The ``backoff_coefficient`` and ``max_interval`` values are inert at the
+default ``max_attempts=2`` (only one wait period elapses) and are reserved
+for future increases to ``max_attempts``.
 
 Apps that are not idempotent across full workflow restart should pass
 ``workflow_retry_policy=NO_RETRY`` to ``create_app_handler_service`` to opt out.

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -255,6 +255,12 @@ class WorkflowClientConfig:
         default=None, repr=False
     )
 
+    # Pre-converted Temporal RetryPolicy. Computed once in
+    # create_app_handler_service after default resolution so per-request
+    # handlers don't repeat the conversion. None when workflow_retry_policy
+    # is explicitly set to None (no workflow retry).
+    temporal_workflow_retry_policy: Any = dataclasses.field(default=None, repr=False)
+
     def is_configured(self) -> bool:
         return bool(self.host and self.app_class)
 
@@ -431,12 +437,21 @@ def create_app_handler_service(
     _secret_store = secret_store
     _storage = storage
 
+    # Sentinel default → use framework default. Callers that want NO retry
+    # must pass NO_RETRY explicitly.
     if workflow_retry_policy is None:
         from application_sdk.execution.retry import (  # noqa: PLC0415 — cold path: handler-service init
             DEFAULT_WORKFLOW_RETRY,
+            _to_temporal_retry_policy,
         )
 
         workflow_retry_policy = DEFAULT_WORKFLOW_RETRY
+    else:
+        from application_sdk.execution.retry import (  # noqa: PLC0415 — cold path: handler-service init
+            _to_temporal_retry_policy,
+        )
+
+    _temporal_workflow_retry_policy = _to_temporal_retry_policy(workflow_retry_policy)
 
     _workflow_config = WorkflowClientConfig(
         host=temporal_host,
@@ -456,6 +471,7 @@ def create_app_handler_service(
         auth_base_url=auth_base_url,
         auth_scopes=auth_scopes,
         workflow_retry_policy=workflow_retry_policy,
+        temporal_workflow_retry_policy=_temporal_workflow_retry_policy,
     )
 
     from application_sdk.constants import (  # noqa: PLC0415 — cold path: only at handler service startup
@@ -833,23 +849,13 @@ def create_app_handler_service(
                 _workflow_config.task_queue,
             )
 
-            from application_sdk.execution.retry import (  # noqa: PLC0415 — cold path: per-request workflow start
-                _to_temporal_retry_policy,
-            )
-
-            _temporal_retry = (
-                _to_temporal_retry_policy(_workflow_config.workflow_retry_policy)
-                if _workflow_config.workflow_retry_policy is not None
-                else None
-            )
-
             handle = await client.start_workflow(
                 workflow_name,
                 args=[input_data],
                 id=workflow_id,
                 task_queue=_workflow_config.task_queue,
                 memo=corr_ctx.to_temporal_memo(),
-                retry_policy=_temporal_retry,
+                retry_policy=_workflow_config.temporal_workflow_retry_policy,
             )
 
             logger.info(
@@ -1441,22 +1447,12 @@ def create_app_handler_service(
             # Inject workflow_id so run() can access it via input.workflow_id
             input_data.workflow_id = workflow_id
 
-            from application_sdk.execution.retry import (  # noqa: PLC0415 — cold path: per-request workflow start
-                _to_temporal_retry_policy,
-            )
-
-            _temporal_retry = (
-                _to_temporal_retry_policy(_workflow_config.workflow_retry_policy)
-                if _workflow_config.workflow_retry_policy is not None
-                else None
-            )
-
             handle = await client.start_workflow(
                 app_cls._app_name,  # type: ignore[attr-defined]
                 args=[input_data],
                 id=workflow_id,
                 task_queue=_workflow_config.task_queue,
-                retry_policy=_temporal_retry,
+                retry_policy=_workflow_config.temporal_workflow_retry_policy,
             )
             return JSONResponse(
                 content={

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -161,6 +161,7 @@ if TYPE_CHECKING:
     from temporalio.converter import DataConverter
 
     from application_sdk.app.base import App
+    from application_sdk.execution.retry import RetryPolicy
     from application_sdk.infrastructure.secrets import SecretStore
 
 
@@ -246,6 +247,13 @@ class WorkflowClientConfig:
     auth_token_url: str = ""
     auth_base_url: str = ""
     auth_scopes: str = ""
+
+    # Workflow-level retry: applied at client.start_workflow(). When None, no
+    # workflow-level retry runs; the framework's DEFAULT_WORKFLOW_RETRY is used
+    # if create_app_handler_service is called without overriding the kwarg.
+    workflow_retry_policy: RetryPolicy | None = dataclasses.field(
+        default=None, repr=False
+    )
 
     def is_configured(self) -> bool:
         return bool(self.host and self.app_class)
@@ -381,6 +389,7 @@ def create_app_handler_service(
     description: str = "Per-app handler service for authentication, preflight, and metadata operations",
     version: str = "1.0.0",
     frontend_assets_path: str = "app/generated/frontend/static",
+    workflow_retry_policy: RetryPolicy | None = None,
     # Deprecated: state_store is no longer used. Credential resolution now
     # goes through DaprCredentialVault exclusively. Passing this parameter
     # emits a DeprecationWarning. Will be removed in v3.2.0.
@@ -421,6 +430,14 @@ def create_app_handler_service(
 
     _secret_store = secret_store
     _storage = storage
+
+    if workflow_retry_policy is None:
+        from application_sdk.execution.retry import (  # noqa: PLC0415 — cold path: handler-service init
+            DEFAULT_WORKFLOW_RETRY,
+        )
+
+        workflow_retry_policy = DEFAULT_WORKFLOW_RETRY
+
     _workflow_config = WorkflowClientConfig(
         host=temporal_host,
         namespace=temporal_namespace,
@@ -438,6 +455,7 @@ def create_app_handler_service(
         auth_token_url=auth_token_url,
         auth_base_url=auth_base_url,
         auth_scopes=auth_scopes,
+        workflow_retry_policy=workflow_retry_policy,
     )
 
     from application_sdk.constants import (  # noqa: PLC0415 — cold path: only at handler service startup
@@ -815,12 +833,23 @@ def create_app_handler_service(
                 _workflow_config.task_queue,
             )
 
+            from application_sdk.execution.retry import (  # noqa: PLC0415 — cold path: per-request workflow start
+                _to_temporal_retry_policy,
+            )
+
+            _temporal_retry = (
+                _to_temporal_retry_policy(_workflow_config.workflow_retry_policy)
+                if _workflow_config.workflow_retry_policy is not None
+                else None
+            )
+
             handle = await client.start_workflow(
                 workflow_name,
                 args=[input_data],
                 id=workflow_id,
                 task_queue=_workflow_config.task_queue,
                 memo=corr_ctx.to_temporal_memo(),
+                retry_policy=_temporal_retry,
             )
 
             logger.info(
@@ -1412,11 +1441,22 @@ def create_app_handler_service(
             # Inject workflow_id so run() can access it via input.workflow_id
             input_data.workflow_id = workflow_id
 
+            from application_sdk.execution.retry import (  # noqa: PLC0415 — cold path: per-request workflow start
+                _to_temporal_retry_policy,
+            )
+
+            _temporal_retry = (
+                _to_temporal_retry_policy(_workflow_config.workflow_retry_policy)
+                if _workflow_config.workflow_retry_policy is not None
+                else None
+            )
+
             handle = await client.start_workflow(
                 app_cls._app_name,  # type: ignore[attr-defined]
                 args=[input_data],
                 id=workflow_id,
                 task_queue=_workflow_config.task_queue,
+                retry_policy=_temporal_retry,
             )
             return JSONResponse(
                 content={

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -58,6 +58,10 @@ from application_sdk.constants import (
     ENABLE_PROMETHEUS_METRICS,
     LOCAL_ENVIRONMENT,
 )
+from application_sdk.execution.retry import (
+    DEFAULT_WORKFLOW_RETRY,
+    _to_temporal_retry_policy,
+)
 from application_sdk.handler.base import Handler, HandlerError
 from application_sdk.handler.context import HandlerContext
 from application_sdk.handler.contracts import (
@@ -248,17 +252,16 @@ class WorkflowClientConfig:
     auth_base_url: str = ""
     auth_scopes: str = ""
 
-    # Workflow-level retry: applied at client.start_workflow(). When None, no
-    # workflow-level retry runs; the framework's DEFAULT_WORKFLOW_RETRY is used
-    # if create_app_handler_service is called without overriding the kwarg.
+    # Construction default. create_app_handler_service resolves None to
+    # DEFAULT_WORKFLOW_RETRY; pass NO_RETRY to disable workflow-level retry.
+    # After init, this field reflects the resolved policy used at runtime.
     workflow_retry_policy: RetryPolicy | None = dataclasses.field(
         default=None, repr=False
     )
 
     # Pre-converted Temporal RetryPolicy. Computed once in
     # create_app_handler_service after default resolution so per-request
-    # handlers don't repeat the conversion. None when workflow_retry_policy
-    # is explicitly set to None (no workflow retry).
+    # /start handlers don't repeat the conversion.
     temporal_workflow_retry_policy: Any = dataclasses.field(default=None, repr=False)
 
     def is_configured(self) -> bool:
@@ -419,6 +422,13 @@ def create_app_handler_service(
         frontend_assets_path: Path to the directory containing frontend static assets.
             Serves ``index.html`` at ``GET /`` and mounts remaining assets as static
             files. Defaults to ``"app/generated/frontend/static"``.
+        workflow_retry_policy: Retry policy applied at workflow level via
+            ``client.start_workflow()``. Defaults to
+            :data:`~application_sdk.execution.retry.DEFAULT_WORKFLOW_RETRY` (one
+            retry after a 2-minute backoff, skipping deterministic failures).
+            Pass :data:`~application_sdk.execution.retry.NO_RETRY` to disable
+            workflow-level retry — recommended for apps that are not idempotent
+            across a full workflow restart.
 
     Returns:
         Configured FastAPI application.
@@ -440,16 +450,7 @@ def create_app_handler_service(
     # Sentinel default → use framework default. Callers that want NO retry
     # must pass NO_RETRY explicitly.
     if workflow_retry_policy is None:
-        from application_sdk.execution.retry import (  # noqa: PLC0415 — cold path: handler-service init
-            DEFAULT_WORKFLOW_RETRY,
-            _to_temporal_retry_policy,
-        )
-
         workflow_retry_policy = DEFAULT_WORKFLOW_RETRY
-    else:
-        from application_sdk.execution.retry import (  # noqa: PLC0415 — cold path: handler-service init
-            _to_temporal_retry_policy,
-        )
 
     _temporal_workflow_retry_policy = _to_temporal_retry_policy(workflow_retry_policy)
 

--- a/tests/integration/test_handler_service.py
+++ b/tests/integration/test_handler_service.py
@@ -762,3 +762,165 @@ async def test_get_infrastructure_visible_in_http_handler():
 
     assert resp.status_code == 200
     assert resp.json()["found"] is True
+
+
+# ---------------------------------------------------------------------------
+# Workflow-level RetryPolicy plumbing (PR #1648)
+# ---------------------------------------------------------------------------
+# Verifies the workflow_retry_policy kwarg on create_app_handler_service
+# reaches Temporal as a real RetryPolicy on the WorkflowExecutionStarted
+# event. Reading from history (rather than asserting on the mocked client
+# call) confirms the wire-format conversion via _to_temporal_retry_policy
+# works end-to-end against a live Temporal server.
+
+
+async def _started_event_retry_policy(temporal_client, wf_id: str):
+    """Return ``RetryPolicy`` from the WorkflowExecutionStarted event, or
+    None if the event has no policy attached."""
+    handle = temporal_client.get_workflow_handle(wf_id)
+    history = await handle.fetch_history()
+    for event in history.events:
+        if event.HasField("workflow_execution_started_event_attributes"):
+            attrs = event.workflow_execution_started_event_attributes
+            if attrs.HasField("retry_policy"):
+                return attrs.retry_policy
+            return None
+    raise AssertionError(f"No WorkflowExecutionStarted event for {wf_id}")
+
+
+async def _build_retry_client(
+    temporal_client,
+    task_queue: str,
+    reregister_app,
+    *,
+    workflow_retry_policy=None,
+    override: bool = False,
+):
+    """Build a TestClient for TrivialApp configured with an optional retry
+    policy. Returns (httpx.AsyncClient, app)."""
+    from application_sdk.handler import service as svc
+    from application_sdk.handler.service import create_app_handler_service
+
+    reregister_app(TrivialApp)
+
+    handler = DefaultHandler()
+    kwargs: dict = {
+        "app_name": "trivial-retry",
+        "app_class": TrivialApp,
+        "temporal_host": "localhost:7233",
+        "task_queue": task_queue,
+    }
+    if override:
+        kwargs["workflow_retry_policy"] = workflow_retry_policy
+
+    app = create_app_handler_service(handler, **kwargs)
+    svc._temporal_client = temporal_client
+    return app
+
+
+@pytest.mark.integration
+async def test_workflow_retry_policy_default_lands_in_history(
+    run_worker, temporal_client, task_queue, reregister_app
+):
+    """Default DEFAULT_WORKFLOW_RETRY is recorded in Temporal's start event."""
+    app = await _build_retry_client(temporal_client, task_queue, reregister_app)
+
+    async with run_worker():
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/workflows/v1/start", json={"name": "retry-default"}
+            )
+            assert resp.status_code == 200
+            wf_id = resp.json()["data"]["workflow_id"]
+
+        retry = await _started_event_retry_policy(temporal_client, wf_id)
+
+    assert (
+        retry is not None
+    ), "Default workflow_retry_policy was not forwarded to Temporal"
+    assert retry.maximum_attempts == 2
+    expected_non_retryable = {
+        "NonRetryableError",
+        "AuthError",
+        "ContractValidationError",
+        "ValidationError",
+    }
+    assert expected_non_retryable.issubset(set(retry.non_retryable_error_types))
+    # initial_interval is a google.protobuf.Duration in the history payload
+    assert retry.initial_interval.seconds == 120
+
+
+@pytest.mark.integration
+async def test_workflow_retry_policy_no_retry_disables_workflow_retry(
+    run_worker, temporal_client, task_queue, reregister_app
+):
+    """workflow_retry_policy=NO_RETRY → maximum_attempts=1 in start event."""
+    from application_sdk.execution.retry import NO_RETRY
+
+    app = await _build_retry_client(
+        temporal_client,
+        task_queue,
+        reregister_app,
+        workflow_retry_policy=NO_RETRY,
+        override=True,
+    )
+
+    async with run_worker():
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/workflows/v1/start", json={"name": "no-retry"})
+            assert resp.status_code == 200
+            wf_id = resp.json()["data"]["workflow_id"]
+
+        retry = await _started_event_retry_policy(temporal_client, wf_id)
+
+    assert retry is not None
+    assert retry.maximum_attempts == 1
+
+
+@pytest.mark.integration
+async def test_workflow_retry_policy_custom_reaches_temporal(
+    run_worker, temporal_client, task_queue, reregister_app
+):
+    """Custom RetryPolicy is preserved through the conversion to Temporal."""
+    from datetime import timedelta
+
+    from application_sdk.execution.retry import RetryPolicy
+
+    custom = RetryPolicy(
+        max_attempts=5,
+        initial_interval=timedelta(seconds=7),
+        max_interval=timedelta(minutes=3),
+        backoff_coefficient=3.0,
+        non_retryable_errors=("AuthError", "PreflightError"),
+    )
+
+    app = await _build_retry_client(
+        temporal_client,
+        task_queue,
+        reregister_app,
+        workflow_retry_policy=custom,
+        override=True,
+    )
+
+    async with run_worker():
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/workflows/v1/start", json={"name": "custom-retry"}
+            )
+            assert resp.status_code == 200
+            wf_id = resp.json()["data"]["workflow_id"]
+
+        retry = await _started_event_retry_policy(temporal_client, wf_id)
+
+    assert retry is not None
+    assert retry.maximum_attempts == 5
+    assert retry.initial_interval.seconds == 7
+    assert retry.maximum_interval.seconds == 180
+    assert retry.backoff_coefficient == 3.0
+    assert set(retry.non_retryable_error_types) == {"AuthError", "PreflightError"}

--- a/tests/integration/test_handler_service.py
+++ b/tests/integration/test_handler_service.py
@@ -765,13 +765,8 @@ async def test_get_infrastructure_visible_in_http_handler():
 
 
 # ---------------------------------------------------------------------------
-# Workflow-level RetryPolicy plumbing (PR #1648)
+# Workflow-level RetryPolicy plumbing
 # ---------------------------------------------------------------------------
-# Verifies the workflow_retry_policy kwarg on create_app_handler_service
-# reaches Temporal as a real RetryPolicy on the WorkflowExecutionStarted
-# event. Reading from history (rather than asserting on the mocked client
-# call) confirms the wire-format conversion via _to_temporal_retry_policy
-# works end-to-end against a live Temporal server.
 
 
 async def _started_event_retry_policy(temporal_client, wf_id: str):

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import warnings
 from dataclasses import dataclass
@@ -3457,7 +3458,11 @@ class TestWorkflowRetryPolicy:
         AppRegistry.reset()
         TaskRegistry.reset()
 
+    @contextlib.contextmanager
     def _build_client(self, *, workflow_retry_policy=None, override=False):
+        """Yield (TestClient, mock_temporal_client). Patch lifetime is scoped
+        to the ``with`` block — exceptions in the test body don't leak the
+        patch into other tests."""
         from unittest.mock import AsyncMock, MagicMock, patch
 
         from application_sdk.app.base import App
@@ -3481,17 +3486,15 @@ class TestWorkflowRetryPolicy:
         mock_handle.id = "wf-retry"
         mock_handle.result_run_id = "run-retry"
         mock_client.start_workflow = AsyncMock(return_value=mock_handle)
-        patcher = patch(
+        with patch(
             "application_sdk.handler.service._get_temporal_client",
             new=AsyncMock(return_value=mock_client),
-        )
-        patcher.start()
-        return TestClient(svc, raise_server_exceptions=False), mock_client, patcher
+        ):
+            yield TestClient(svc, raise_server_exceptions=False), mock_client
 
     def test_default_workflow_retry_applied(self) -> None:
         """Default DEFAULT_WORKFLOW_RETRY is forwarded to start_workflow."""
-        client, mock_client, patcher = self._build_client()
-        try:
+        with self._build_client() as (client, mock_client):
             response = client.post("/workflows/v1/start", json={"name": "x"})
             assert response.status_code == 200
             kwargs = mock_client.start_workflow.call_args.kwargs
@@ -3500,25 +3503,23 @@ class TestWorkflowRetryPolicy:
             assert retry.maximum_attempts == 2
             assert "NonRetryableError" in (retry.non_retryable_error_types or [])
             assert "AuthError" in (retry.non_retryable_error_types or [])
-        finally:
-            patcher.stop()
+            assert "ContractValidationError" in (retry.non_retryable_error_types or [])
+            assert "ValidationError" in (retry.non_retryable_error_types or [])
 
-    def test_explicit_none_disables_workflow_retry(self) -> None:
+    def test_explicit_no_retry_disables_workflow_retry(self) -> None:
         """workflow_retry_policy=NO_RETRY → maximum_attempts=1 (no workflow retry)."""
         from application_sdk.execution.retry import NO_RETRY
 
-        client, mock_client, patcher = self._build_client(
-            workflow_retry_policy=NO_RETRY, override=True
-        )
-        try:
+        with self._build_client(workflow_retry_policy=NO_RETRY, override=True) as (
+            client,
+            mock_client,
+        ):
             response = client.post("/workflows/v1/start", json={"name": "x"})
             assert response.status_code == 200
             kwargs = mock_client.start_workflow.call_args.kwargs
             retry = kwargs["retry_policy"]
             assert retry is not None
             assert retry.maximum_attempts == 1
-        finally:
-            patcher.stop()
 
     def test_custom_policy_with_extra_non_retryables(self) -> None:
         """Custom RetryPolicy reaches start_workflow unchanged."""
@@ -3531,10 +3532,10 @@ class TestWorkflowRetryPolicy:
             initial_interval=timedelta(seconds=10),
             non_retryable_errors=("AuthError", "PreflightError"),
         )
-        client, mock_client, patcher = self._build_client(
-            workflow_retry_policy=custom, override=True
-        )
-        try:
+        with self._build_client(workflow_retry_policy=custom, override=True) as (
+            client,
+            mock_client,
+        ):
             response = client.post("/workflows/v1/start", json={"name": "x"})
             assert response.status_code == 200
             kwargs = mock_client.start_workflow.call_args.kwargs
@@ -3545,5 +3546,3 @@ class TestWorkflowRetryPolicy:
                 "AuthError",
                 "PreflightError",
             }
-        finally:
-            patcher.stop()

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -6,13 +6,16 @@ import contextlib
 import json
 import warnings
 from dataclasses import dataclass
+from datetime import timedelta
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from application_sdk.app.base import App
 from application_sdk.contracts.base import Input, Output
+from application_sdk.execution.retry import NO_RETRY, RetryPolicy
 from application_sdk.handler.base import Handler, HandlerError
 from application_sdk.handler.contracts import (
     ApiMetadataObject,
@@ -3518,9 +3521,6 @@ class TestWorkflowRetryPolicy:
         """Yield (TestClient, mock_temporal_client). Patch lifetime is scoped
         to the ``with`` block — exceptions in the test body don't leak the
         patch into other tests."""
-        from unittest.mock import AsyncMock, MagicMock, patch
-
-        from application_sdk.app.base import App
 
         class _RetryApp(App):
             async def run(self, input: _RoutingInput) -> _RoutingOutput:
@@ -3563,8 +3563,6 @@ class TestWorkflowRetryPolicy:
 
     def test_explicit_no_retry_disables_workflow_retry(self) -> None:
         """workflow_retry_policy=NO_RETRY → maximum_attempts=1 (no workflow retry)."""
-        from application_sdk.execution.retry import NO_RETRY
-
         with self._build_client(workflow_retry_policy=NO_RETRY, override=True) as (
             client,
             mock_client,
@@ -3578,10 +3576,6 @@ class TestWorkflowRetryPolicy:
 
     def test_custom_policy_with_extra_non_retryables(self) -> None:
         """Custom RetryPolicy reaches start_workflow unchanged."""
-        from datetime import timedelta
-
-        from application_sdk.execution.retry import RetryPolicy
-
         custom = RetryPolicy(
             max_attempts=5,
             initial_interval=timedelta(seconds=10),

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -14,6 +14,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from application_sdk.app.base import App
+from application_sdk.app.registry import AppRegistry, TaskRegistry
 from application_sdk.contracts.base import Input, Output
 from application_sdk.execution.retry import NO_RETRY, RetryPolicy
 from application_sdk.handler.base import Handler, HandlerError
@@ -3505,14 +3506,10 @@ class TestWorkflowRetryPolicy:
     """workflow_retry_policy plumbed from create_app_handler_service into start_workflow."""
 
     def setup_method(self) -> None:
-        from application_sdk.app.registry import AppRegistry, TaskRegistry
-
         AppRegistry.reset()
         TaskRegistry.reset()
 
     def teardown_method(self) -> None:
-        from application_sdk.app.registry import AppRegistry, TaskRegistry
-
         AppRegistry.reset()
         TaskRegistry.reset()
 

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -3440,3 +3440,110 @@ class TestConfigEndpointPersistence:
             response = client.get("/workflows/v1/config/round-trip")
         assert response.status_code == 200
         assert response.json()["data"] == {"hello": "world"}
+
+
+class TestWorkflowRetryPolicy:
+    """workflow_retry_policy plumbed from create_app_handler_service into start_workflow."""
+
+    def setup_method(self) -> None:
+        from application_sdk.app.registry import AppRegistry, TaskRegistry
+
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    def teardown_method(self) -> None:
+        from application_sdk.app.registry import AppRegistry, TaskRegistry
+
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    def _build_client(self, *, workflow_retry_policy=None, override=False):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from application_sdk.app.base import App
+
+        class _RetryApp(App):
+            async def run(self, input: _RoutingInput) -> _RoutingOutput:
+                return _RoutingOutput()
+
+        handler = _TestHandler()
+        kwargs: dict = {
+            "app_name": "retry-test",
+            "app_class": _RetryApp,
+            "temporal_host": "temporal:7233",
+        }
+        if override:
+            kwargs["workflow_retry_policy"] = workflow_retry_policy
+
+        svc = create_app_handler_service(handler, **kwargs)
+        mock_client = MagicMock()
+        mock_handle = MagicMock()
+        mock_handle.id = "wf-retry"
+        mock_handle.result_run_id = "run-retry"
+        mock_client.start_workflow = AsyncMock(return_value=mock_handle)
+        patcher = patch(
+            "application_sdk.handler.service._get_temporal_client",
+            new=AsyncMock(return_value=mock_client),
+        )
+        patcher.start()
+        return TestClient(svc, raise_server_exceptions=False), mock_client, patcher
+
+    def test_default_workflow_retry_applied(self) -> None:
+        """Default DEFAULT_WORKFLOW_RETRY is forwarded to start_workflow."""
+        client, mock_client, patcher = self._build_client()
+        try:
+            response = client.post("/workflows/v1/start", json={"name": "x"})
+            assert response.status_code == 200
+            kwargs = mock_client.start_workflow.call_args.kwargs
+            retry = kwargs["retry_policy"]
+            assert retry is not None
+            assert retry.maximum_attempts == 2
+            assert "NonRetryableError" in (retry.non_retryable_error_types or [])
+            assert "AuthError" in (retry.non_retryable_error_types or [])
+        finally:
+            patcher.stop()
+
+    def test_explicit_none_disables_workflow_retry(self) -> None:
+        """workflow_retry_policy=NO_RETRY → maximum_attempts=1 (no workflow retry)."""
+        from application_sdk.execution.retry import NO_RETRY
+
+        client, mock_client, patcher = self._build_client(
+            workflow_retry_policy=NO_RETRY, override=True
+        )
+        try:
+            response = client.post("/workflows/v1/start", json={"name": "x"})
+            assert response.status_code == 200
+            kwargs = mock_client.start_workflow.call_args.kwargs
+            retry = kwargs["retry_policy"]
+            assert retry is not None
+            assert retry.maximum_attempts == 1
+        finally:
+            patcher.stop()
+
+    def test_custom_policy_with_extra_non_retryables(self) -> None:
+        """Custom RetryPolicy reaches start_workflow unchanged."""
+        from datetime import timedelta
+
+        from application_sdk.execution.retry import RetryPolicy
+
+        custom = RetryPolicy(
+            max_attempts=5,
+            initial_interval=timedelta(seconds=10),
+            non_retryable_errors=("AuthError", "PreflightError"),
+        )
+        client, mock_client, patcher = self._build_client(
+            workflow_retry_policy=custom, override=True
+        )
+        try:
+            response = client.post("/workflows/v1/start", json={"name": "x"})
+            assert response.status_code == 200
+            kwargs = mock_client.start_workflow.call_args.kwargs
+            retry = kwargs["retry_policy"]
+            assert retry.maximum_attempts == 5
+            assert retry.initial_interval == timedelta(seconds=10)
+            assert set(retry.non_retryable_error_types or []) == {
+                "AuthError",
+                "PreflightError",
+            }
+        finally:
+            patcher.stop()


### PR DESCRIPTION
## Summary

- Wire workflow-level Temporal `RetryPolicy` into `client.start_workflow()` so a workflow that fails for a transient reason (activity-retry exhaustion, worker host crash, brief upstream outage) gets one fresh attempt with a clean activity-retry budget instead of failing terminally on the first exception.
- Add typed exceptions (`AuthError`, `RateLimited`, `UpstreamUnavailable`) and matching error codes (`APP_AUTH`, `APP_RATE_LIMITED`, `APP_UPSTREAM_UNAVAILABLE`) so app code can express retry intent at upstream boundaries.
- Expose `workflow_retry_policy` kwarg on `create_app_handler_service` so non-idempotent apps can opt out (`NO_RETRY`) or supply a custom policy.

## Why

Today every transient infra event (Atlas blip > activity retry window, pod OOM-killed mid-activity, worker host crash) fails the workflow terminally and pages a customer. Activity-level retry alone can't recover from these classes — they need a fresh activity-retry budget on a (potentially different) worker. Workflow-level retry is the existing Temporal primitive for that; we just weren't using it.

## Default policy

```python
DEFAULT_WORKFLOW_RETRY = RetryPolicy(
    max_attempts=2,
    initial_interval=timedelta(minutes=2),
    max_interval=timedelta(minutes=10),
    backoff_coefficient=2.0,
    non_retryable_errors=(
        \"NonRetryableError\",
        \"AuthError\",
        \"ValidationError\",
    ),
)
```

- One free retry after a 2 min cooldown.
- Auth / validation / explicit `NonRetryableError` skip the retry and fail fast.
- Apps inherit this on SDK bump unless they override.

## What apps need to do

- **Crawl-style apps** (output keyed by `workflow_id`, overwrite-safe): nothing — bump SDK and the default applies.
- **Apps not safe to re-run from scratch** (e.g. `flip_publish_cache`-style mutations without idempotency guards): pass `workflow_retry_policy=NO_RETRY` to `create_app_handler_service` until idempotency is verified.
- **Recommended (any app)**: raise typed exceptions at upstream boundaries — `AuthError` for 401/403, `RateLimited` for 429, `UpstreamUnavailable` for 5xx / connection refused — so the retry policy reaches the right decision.

## Test plan

- [x] `tests/unit/handler/test_service.py::TestWorkflowRetryPolicy` — default applied, `NO_RETRY` disables, custom policy reaches `start_workflow` unchanged.
- [x] Full `tests/unit/handler/` and `tests/unit/app/test_base.py` pass (312 tests).
- [x] `pre-commit run` clean (ruff, ruff-format, isort, pyright).
- [ ] Bake on dev: bump SDK in one crawl connector (redshift), watch healed-without-page metrics for 1 week before broader rollout.
- [ ] Audit `atlan-publish-app` `flip_publish_cache` second-run safety before enabling default policy there.