### PR TITLE
fix(dashboard): cache-bust per-repo and history fetches

### DIFF
--- a/.security/dashboard/index.html
+++ b/.security/dashboard/index.html
@@ -261,11 +261,14 @@ const esc=s=>String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'
 
 function animateCount(el,target){let cur=0;const step=Math.max(1,Math.ceil(target/30));const timer=setInterval(()=>{cur+=step;if(cur>=target){cur=target;clearInterval(timer);}el.textContent=cur;},30);}
 
+// Cache-bust every fetch. Browsers aggressively cache the per-repo / per-history JSON
+// responses across hard refreshes — only incognito tabs would otherwise see updates.
+const cb=()=>'?t='+Date.now();
 async function load(){
     try{
-        const mr=await fetch('repos.json');
+        const mr=await fetch('repos.json'+cb());
         if(mr.ok){const files=await mr.json();
-            for(const f of files){try{const rr=await fetch('repos/'+f);const d=await rr.json();if(d.repo){D.repos[d.repo]=d;D.generated_at=d.scanned_at;}}catch(e){}}}
+            for(const f of files){try{const rr=await fetch('repos/'+f+cb());const d=await rr.json();if(d.repo){D.repos[d.repo]=d;D.generated_at=d.scanned_at;}}catch(e){}}}
         buildVM();renderAll();
     }catch(e){document.getElementById('empty').style.display='block';document.getElementById('empty').textContent='No data yet.';}
 }
@@ -514,13 +517,13 @@ let historyData={};
 
 async function loadHistory(){
     try{
-        const mr=await fetch('repos.json');
+        const mr=await fetch('repos.json'+cb());
         if(!mr.ok)return;
         const files=await mr.json();
         for(const f of files){
             const repo=f.replace('.json','').replace('atlanhq_','atlanhq/');
             try{
-                const r=await fetch('history/'+f.replace('.json','.jsonl'));
+                const r=await fetch('history/'+f.replace('.json','.jsonl')+cb());
                 if(r.ok){const txt=await r.text();historyData[repo]=txt.trim().split('\n').filter(l=>l).map(l=>JSON.parse(l));}
             }catch(e){}
         }


### PR DESCRIPTION
## Problem
After a connector merges and the dashboard data is refreshed on Kryptonite, hard-reloading https://k.atlan.dev/security-dashboard/ in a normal browser still shows the old per-repo numbers. Only incognito tabs (which don't share cache) pick up the new data.

Reported on saphana-app today: PR #60 merged, scan reported 0 vulnerabilities, dashboard JSON updated to `total: 0` at 07:52 UTC, but normal browser kept showing 1 even after Cmd+Shift+R.

## Root cause
Hard reload forces the browser to revalidate the HTML and JS, but `fetch()` calls inside the JS go through the regular HTTP cache. S3 ships these JSON files with a `Cache-Control` header that lets browsers serve them stale, and our fetches didn't pass any cache-busting hint.

## Fix
Append `?t=Date.now()` to every fetch URL on every page load. Browsers always revalidate when the URL is novel, and the timestamp ensures novelty.

```diff
+const cb = () => '?t=' + Date.now();
-await fetch('repos.json');
+await fetch('repos.json' + cb());
-await fetch('repos/' + f);
+await fetch('repos/' + f + cb());
-await fetch('history/' + ...);
+await fetch('history/' + ... + cb());
```

## Test plan
- [x] Reproduced the stickiness locally; appending `?t=…` makes refreshes pick up fresh data.
- [ ] After merge: confirm a normal browser tab on https://k.atlan.dev/security-dashboard/ shows fresh per-repo numbers immediately after a connector merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)