### PR TITLE
fix(ci): guard capability-manifest grep pipeline against pipefail

### DIFF
--- a/.github/workflows/capability-manifest-check.yaml
+++ b/.github/workflows/capability-manifest-check.yaml
@@ -71,10 +71,13 @@ jobs:
           # source-sha / source-date are excluded: with squash merges the final
           # SHA doesn't exist during the PR, so these fields are always stale
           # until the manifest is regenerated post-merge.
+          # || true: grep exits 1 on no matches; with pipefail that would kill the
+          # script before the [ -z ] check, producing a false drift failure.
           SEMANTIC=$(git diff -- docs/agents/sdk-capabilities.md \
             | grep '^[+-]' \
             | grep -v '^+++\|^---' \
-            | grep -v '^[+-]source-sha:\|^[+-]source-date:')
+            | grep -v '^[+-]source-sha:\|^[+-]source-date:' \
+            || true)
           if [ -z "$SEMANTIC" ]; then
             echo "status=clean" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #1653 that caused the capability manifest drift check to fail on all PRs.

GitHub Actions runs `bash -eo pipefail`. When `git diff` produces no output (or only `source-sha`/`source-date` lines that get filtered out), `grep` finds no matching lines and exits 1. With `pipefail` active that kills the script before the `if [ -z "$SEMANTIC" ]` check runs — producing a false drift failure on every clean PR.

Fix: add `|| true` at the end of the grep pipeline so an empty result is treated as exit 0.

## Test plan

- [ ] CI passes on a PR that doesn't touch `application_sdk/` at all
- [ ] CI passes on a PR that touches `application_sdk/` without changing the public surface
- [ ] CI still fails on a PR where the manifest content genuinely drifts