### PR TITLE
fix(errors): tighten Audience to 3 values + carry tenant_id on the wire

### DIFF
--- a/.claude/skills/sdk-review/references/dx-rules.md
+++ b/.claude/skills/sdk-review/references/dx-rules.md
@@ -99,7 +99,7 @@ New SDK exceptions must use the most specific leaf from `application_sdk.errors`
 | Feature not yet built | `UnimplementedError` |
 | Unexpected invariant violation / bug | `InternalError` |
 
-Each leaf sets a default `audience` (`USER | PLATFORM | FRAMEWORK | UNKNOWN`) and `retryable` flag that consumers use for routing and retry decisions.
+Each leaf sets a default `audience` (`USER | PLATFORM | APP_OWNER`) and `retryable` flag that consumers use for routing and retry decisions. The audience enum is closed three-valued — there is no `UNKNOWN` escape hatch; if the locus is unclear, use `APP_OWNER` (the team that wrote the code investigates and reclassifies).
 
 ### Debuggable Log Output (Important)
 

--- a/application_sdk/errors/base.py
+++ b/application_sdk/errors/base.py
@@ -62,15 +62,15 @@ class AppError(Exception):
         Non-base fields become ``evidence``. The Error dataclass is the schema
         source — no separate model to keep in sync.
 
-        ``tenant_id`` is read from ``APP_TENANT_ID`` so the wire payload
-        always identifies which tenant's pod produced the failure. Consumers
+        ``domain`` is read from ``DOMAIN_NAME`` (``ATLAN_DOMAIN_NAME``) so the
+        wire payload identifies which tenant produced the failure. Consumers
         reading the failure via Temporal's API (e.g. the Automation Engine
         via ``temporal workflow show``) only see ``ApplicationError.details``
         — k8s resource attributes are not on that wire — so embedding the
         tenant in the payload itself is the only way per-tenant routing
         works for that consumer.
         """
-        from application_sdk.constants import APP_TENANT_ID  # noqa: PLC0415
+        from application_sdk.constants import DOMAIN_NAME  # noqa: PLC0415
         from application_sdk.errors.wire import FailureDetails  # noqa: PLC0415
 
         evidence: dict[str, Any] = {
@@ -87,7 +87,7 @@ class AppError(Exception):
             suggested_action=self.suggested_action,
             evidence=evidence,
             app_name=self.app_name,
-            tenant_id=APP_TENANT_ID,
+            domain=DOMAIN_NAME if DOMAIN_NAME != "atlan.com" else None,
             run_id=self.run_id,
             cause_repr=repr(self.cause) if self.cause else None,
         )

--- a/application_sdk/errors/base.py
+++ b/application_sdk/errors/base.py
@@ -36,7 +36,7 @@ class AppError(Exception):
     category: ClassVar[FailureCategory] = FailureCategory.INTERNAL
     default_retryable: ClassVar[bool] = False
     code: ClassVar[str] = "INTERNAL"
-    audience: ClassVar[Audience] = Audience.UNKNOWN
+    audience: ClassVar[Audience] = Audience.APP_OWNER
 
     def __post_init__(self) -> None:
         Exception.__init__(self, self.message)
@@ -61,7 +61,16 @@ class AppError(Exception):
 
         Non-base fields become ``evidence``. The Error dataclass is the schema
         source — no separate model to keep in sync.
+
+        ``tenant_id`` is read from ``APP_TENANT_ID`` so the wire payload
+        always identifies which tenant's pod produced the failure. Consumers
+        reading the failure via Temporal's API (e.g. the Automation Engine
+        via ``temporal workflow show``) only see ``ApplicationError.details``
+        — k8s resource attributes are not on that wire — so embedding the
+        tenant in the payload itself is the only way per-tenant routing
+        works for that consumer.
         """
+        from application_sdk.constants import APP_TENANT_ID  # noqa: PLC0415
         from application_sdk.errors.wire import FailureDetails  # noqa: PLC0415
 
         evidence: dict[str, Any] = {
@@ -78,6 +87,7 @@ class AppError(Exception):
             suggested_action=self.suggested_action,
             evidence=evidence,
             app_name=self.app_name,
+            tenant_id=APP_TENANT_ID,
             run_id=self.run_id,
             cause_repr=repr(self.cause) if self.cause else None,
         )

--- a/application_sdk/errors/base.py
+++ b/application_sdk/errors/base.py
@@ -62,15 +62,12 @@ class AppError(Exception):
         Non-base fields become ``evidence``. The Error dataclass is the schema
         source — no separate model to keep in sync.
 
-        ``domain`` is read from ``DOMAIN_NAME`` (``ATLAN_DOMAIN_NAME``) so the
-        wire payload identifies which tenant produced the failure. Consumers
-        reading the failure via Temporal's API (e.g. the Automation Engine
-        via ``temporal workflow show``) only see ``ApplicationError.details``
-        — k8s resource attributes are not on that wire — so embedding the
-        tenant in the payload itself is the only way per-tenant routing
-        works for that consumer.
+        Tenant identity is intentionally NOT included here. The producer
+        (the failing app) does not know or carry tenant context; per-tenant
+        attribution is the consumer's responsibility (the Automation Engine
+        or another consumer reading ``ApplicationError.details`` attaches
+        tenant from its own context at ingest time).
         """
-        from application_sdk.constants import DOMAIN_NAME  # noqa: PLC0415
         from application_sdk.errors.wire import FailureDetails  # noqa: PLC0415
 
         evidence: dict[str, Any] = {
@@ -87,7 +84,6 @@ class AppError(Exception):
             suggested_action=self.suggested_action,
             evidence=evidence,
             app_name=self.app_name,
-            domain=DOMAIN_NAME if DOMAIN_NAME != "atlan.com" else None,
             run_id=self.run_id,
             cause_repr=repr(self.cause) if self.cause else None,
         )

--- a/application_sdk/errors/categories.py
+++ b/application_sdk/errors/categories.py
@@ -75,15 +75,18 @@ class Audience(Enum):
     """Who needs to take action to resolve this failure.
 
     Orthogonal to ``FailureCategory`` (what happened) and ``suggested_action``
-    (what to do).  Leaf classes set a per-category default; apps can override
-    per-leaf.  Consumers (AE, SLA dashboards) route on this field without
-    reading every leaf code.
+    (what to do).  Every leaf must pick one of three values — there is no
+    UNKNOWN escape hatch.  If you don't know who owns it, the answer is
+    APP_OWNER (the team that wrote the code investigates and reclassifies).
+    Consumers (AE, SLA dashboards) route on this field without reading
+    every leaf code.
 
     First-responder mapping:
-    - USER     → customer self-service / support ticket to the connector owner
-    - PLATFORM → infra ops: check dashboards (Dapr, Temporal, pod health, S3)
-    - FRAMEWORK → SDK/app engineering: file a bug or add a feature
-    - UNKNOWN  → triage required before routing
+    - USER      → customer self-service / support ticket to the connector owner
+    - PLATFORM  → infra ops: check dashboards (Dapr, Temporal, pod health, S3)
+    - APP_OWNER → the team that wrote the failing code (connector or SDK):
+                  file a bug, add a feature, or add a more specific subclass
+                  to migrate this case out of the catch-all bucket
     """
 
     USER = "USER"
@@ -94,9 +97,9 @@ class Audience(Enum):
     """Infra ops must act — a shared service or infrastructure component is
     unavailable or exhausted (Dapr, Temporal, object store, pod OOM)."""
 
-    FRAMEWORK = "FRAMEWORK"
-    """SDK or application engineering must act — a logic bug, invariant
-    violation, data integrity failure, or unimplemented capability."""
-
-    UNKNOWN = "UNKNOWN"
-    """Not enough information to route; triage required."""
+    APP_OWNER = "APP_OWNER"
+    """The app team that owns the failing code must act — a connector bug,
+    an SDK bug, an unimplemented capability, a data-integrity failure, or
+    a caught-but-unclassified failure pending triage. From production
+    routing's standpoint, SDK and connector code share an owner: the team
+    debugs first, escalates to the SDK team if needed."""

--- a/application_sdk/errors/leaves.py
+++ b/application_sdk/errors/leaves.py
@@ -17,7 +17,7 @@ class CancelledError(AppError):
     category: ClassVar[FailureCategory] = FailureCategory.CANCELLED
     default_retryable: ClassVar[bool] = False
     code: ClassVar[str] = "CANCELLED"
-    audience: ClassVar[Audience] = Audience.UNKNOWN
+    audience: ClassVar[Audience] = Audience.APP_OWNER
 
 
 @dataclass(kw_only=True)
@@ -25,10 +25,11 @@ class AppTimeoutError(AppError):
     """A bounded wait elapsed.
 
     Use for network reads, activity start-to-close limits, and heartbeat
-    timeouts.  Default audience is UNKNOWN because the locus varies: a source
-    network timeout is USER-fixable (increase timeout / check VPC), while an
-    internal Temporal deadline is DEPENDENCY-routed.  Override ``audience``
-    on leaf subclasses when the locus is known.
+    timeouts.  Default audience is APP_OWNER because the locus is rarely
+    obvious and the app team is best placed to investigate and reclassify
+    (a source network timeout is USER-fixable; an internal Temporal deadline
+    is PLATFORM-routed).  Override ``audience`` on leaf subclasses when the
+    locus is known — do not leave it as the default if you can pick.
 
     Builtin ``TimeoutError`` is available as ``application_sdk.errors.TimeoutError``
     for code that catches the SDK name without renaming.
@@ -41,7 +42,7 @@ class AppTimeoutError(AppError):
     category: ClassVar[FailureCategory] = FailureCategory.TIMEOUT
     default_retryable: ClassVar[bool] = True
     code: ClassVar[str] = "TIMEOUT"
-    audience: ClassVar[Audience] = Audience.UNKNOWN
+    audience: ClassVar[Audience] = Audience.APP_OWNER
 
 
 @dataclass(kw_only=True)
@@ -193,7 +194,7 @@ class DataIntegrityError(AppError):
     category: ClassVar[FailureCategory] = FailureCategory.DATA_INTEGRITY
     default_retryable: ClassVar[bool] = False
     code: ClassVar[str] = "DATA_INTEGRITY"
-    audience: ClassVar[Audience] = Audience.FRAMEWORK
+    audience: ClassVar[Audience] = Audience.APP_OWNER
 
 
 @dataclass(kw_only=True)
@@ -205,7 +206,7 @@ class InternalError(AppError):
     category: ClassVar[FailureCategory] = FailureCategory.INTERNAL
     default_retryable: ClassVar[bool] = False
     code: ClassVar[str] = "INTERNAL"
-    audience: ClassVar[Audience] = Audience.FRAMEWORK
+    audience: ClassVar[Audience] = Audience.APP_OWNER
 
 
 @dataclass(kw_only=True)
@@ -222,4 +223,4 @@ class UnimplementedError(AppError):
     category: ClassVar[FailureCategory] = FailureCategory.UNIMPLEMENTED
     default_retryable: ClassVar[bool] = False
     code: ClassVar[str] = "UNIMPLEMENTED"
-    audience: ClassVar[Audience] = Audience.FRAMEWORK
+    audience: ClassVar[Audience] = Audience.APP_OWNER

--- a/application_sdk/errors/wire.py
+++ b/application_sdk/errors/wire.py
@@ -43,10 +43,13 @@ class FailureDetails(BaseModel):
       ``audience=USER``, engineer-facing remediation when ``audience=APP_OWNER``,
       runbook hint when ``audience=PLATFORM``.
     - ``evidence``: per-error context whose schema is the producing dataclass.
-    - ``tenant_id``: identifies which tenant's pod produced the failure.
-      Read from the SDK ``APP_TENANT_ID`` constant; consumers reading the
+    - ``domain``: the customer-facing tenant subdomain (e.g. ``acme.atlan.com``).
+      Read from the SDK ``DOMAIN_NAME`` constant. Consumers reading the
       failure via Temporal's API only see ``ApplicationError.details`` (no
-      k8s resource attributes) so per-tenant routing depends on this field.
+      k8s resource attributes), so per-tenant routing depends on this field.
+      Chosen over ``ATLAN_TENANT_ID`` (which is uniformly ``"default"`` in
+      production) and over ``ATLAN_INSTANCE_NAME`` (which is unset on
+      pre-v3 pods); ``ATLAN_DOMAIN_NAME`` is reliably set across the fleet.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
@@ -59,7 +62,7 @@ class FailureDetails(BaseModel):
     suggested_action: str | None = None
     evidence: dict[str, Any] = Field(default_factory=dict)
     app_name: str | None = None
-    tenant_id: str | None = None
+    domain: str | None = None
     run_id: str | None = None
     cause_repr: str | None = None
 

--- a/application_sdk/errors/wire.py
+++ b/application_sdk/errors/wire.py
@@ -33,12 +33,20 @@ class FailureDetails(BaseModel):
 
     Field semantics:
     - ``category``: the closed FailureCategory enum — what happened.
-    - ``audience``: who needs to act (USER / PLATFORM / FRAMEWORK / UNKNOWN).
+    - ``audience``: who needs to act (USER / PLATFORM / APP_OWNER). Closed
+      three-value enum; every leaf must pick one. There is no UNKNOWN
+      escape hatch — if the locus is unclear the answer is APP_OWNER
+      (the team that wrote the code investigates and reclassifies).
     - ``code``: app-owned string for fine-grained identification.
     - ``suggested_action``: optional imperative hint ("regrant Glue read access").
-      Audience-neutral — survives whether the reader is a customer, an on-call
-      engineer, or a runbook agent.
+      The voice shifts with the audience: customer-facing text when
+      ``audience=USER``, engineer-facing remediation when ``audience=APP_OWNER``,
+      runbook hint when ``audience=PLATFORM``.
     - ``evidence``: per-error context whose schema is the producing dataclass.
+    - ``tenant_id``: identifies which tenant's pod produced the failure.
+      Read from the SDK ``APP_TENANT_ID`` constant; consumers reading the
+      failure via Temporal's API only see ``ApplicationError.details`` (no
+      k8s resource attributes) so per-tenant routing depends on this field.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
@@ -46,11 +54,12 @@ class FailureDetails(BaseModel):
     category: FailureCategory
     code: str
     retryable: bool
-    audience: Audience = Audience.UNKNOWN
+    audience: Audience = Audience.APP_OWNER
     message: str
     suggested_action: str | None = None
     evidence: dict[str, Any] = Field(default_factory=dict)
     app_name: str | None = None
+    tenant_id: str | None = None
     run_id: str | None = None
     cause_repr: str | None = None
 

--- a/application_sdk/errors/wire.py
+++ b/application_sdk/errors/wire.py
@@ -43,13 +43,12 @@ class FailureDetails(BaseModel):
       ``audience=USER``, engineer-facing remediation when ``audience=APP_OWNER``,
       runbook hint when ``audience=PLATFORM``.
     - ``evidence``: per-error context whose schema is the producing dataclass.
-    - ``domain``: the customer-facing tenant subdomain (e.g. ``acme.atlan.com``).
-      Read from the SDK ``DOMAIN_NAME`` constant. Consumers reading the
-      failure via Temporal's API only see ``ApplicationError.details`` (no
-      k8s resource attributes), so per-tenant routing depends on this field.
-      Chosen over ``ATLAN_TENANT_ID`` (which is uniformly ``"default"`` in
-      production) and over ``ATLAN_INSTANCE_NAME`` (which is unset on
-      pre-v3 pods); ``ATLAN_DOMAIN_NAME`` is reliably set across the fleet.
+
+    Tenant identity is intentionally NOT carried on this envelope. Per-tenant
+    attribution is the consumer's job — the producer (the failing app) does
+    not know or carry tenant context. The Automation Engine (or any other
+    consumer that reads ``ApplicationError.details``) attaches tenant from
+    its own context when it ingests the failure.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
@@ -62,7 +61,6 @@ class FailureDetails(BaseModel):
     suggested_action: str | None = None
     evidence: dict[str, Any] = Field(default_factory=dict)
     app_name: str | None = None
-    domain: str | None = None
     run_id: str | None = None
     cause_repr: str | None = None
 

--- a/docs/concepts/common.md
+++ b/docs/concepts/common.md
@@ -73,7 +73,7 @@ raise DependencyUnavailableError(
 
 There is no `UNKNOWN` escape hatch — if the locus is unclear, the answer is `APP_OWNER` (the team investigates and reclassifies).
 
-`FailureDetails` (the Pydantic wire envelope on `AppError.to_failure_details()`) carries `category`, `code`, `retryable`, `audience`, `message`, an optional `suggested_action` (imperative remediation hint whose voice shifts with the audience), `domain` (read from the SDK `DOMAIN_NAME` constant — the customer-facing tenant subdomain like `acme.atlan.com` — so per-tenant routing works for consumers reading `ApplicationError.details`), `app_name`, `run_id`, and `cause_repr`.
+`FailureDetails` (the Pydantic wire envelope on `AppError.to_failure_details()`) carries `category`, `code`, `retryable`, `audience`, `message`, an optional `suggested_action` (imperative remediation hint whose voice shifts with the audience), `app_name`, `run_id`, and `cause_repr`. Tenant identity is intentionally not on this envelope — per-tenant attribution is the consumer's responsibility, not the producer's.
 
 ### Legacy error-code namespaces (backward-compat only)
 

--- a/docs/concepts/common.md
+++ b/docs/concepts/common.md
@@ -51,13 +51,13 @@ from application_sdk.errors import (
     AlreadyExistsError,     # retryable=False, audience=USER
     PreconditionError,      # retryable=False, audience=USER
     RateLimitedError,       # retryable=True,  audience=USER
-    AppTimeoutError,        # retryable=True,  audience=UNKNOWN
+    AppTimeoutError,        # retryable=True,  audience=APP_OWNER
     AppPermissionDeniedError, # retryable=False, audience=USER
     ResourceExhaustedError, # retryable=True,  audience=PLATFORM
-    DataIntegrityError,     # retryable=False, audience=FRAMEWORK
-    InternalError,          # retryable=False, audience=FRAMEWORK
-    UnimplementedError,     # retryable=False, audience=FRAMEWORK
-    CancelledError,         # retryable=False, audience=UNKNOWN
+    DataIntegrityError,     # retryable=False, audience=APP_OWNER
+    InternalError,          # retryable=False, audience=APP_OWNER
+    UnimplementedError,     # retryable=False, audience=APP_OWNER
+    CancelledError,         # retryable=False, audience=APP_OWNER
 )
 
 raise DependencyUnavailableError(
@@ -66,9 +66,14 @@ raise DependencyUnavailableError(
 )
 ```
 
-`Audience` values route failures to: `USER` (customer self-service), `PLATFORM` (infra ops), `FRAMEWORK` (SDK engineering), `UNKNOWN` (triage).
+`Audience` is a closed three-value enum — every leaf must pick one:
+- `USER` — customer self-service (credentials, IAM, source config)
+- `PLATFORM` — infra ops (shared deps down: Dapr, Temporal, object store, pod health)
+- `APP_OWNER` — the team that wrote the failing code (connector or SDK): file a bug, add a more specific subclass, or investigate
 
-`FailureDetails` (the Pydantic wire envelope on `AppError.to_failure_details()`) carries `category`, `code`, `retryable`, `audience`, `message`, and an optional `suggested_action` (imperative remediation hint).
+There is no `UNKNOWN` escape hatch — if the locus is unclear, the answer is `APP_OWNER` (the team investigates and reclassifies).
+
+`FailureDetails` (the Pydantic wire envelope on `AppError.to_failure_details()`) carries `category`, `code`, `retryable`, `audience`, `message`, an optional `suggested_action` (imperative remediation hint whose voice shifts with the audience), `tenant_id` (read from the SDK `APP_TENANT_ID` constant so per-tenant routing works for consumers reading `ApplicationError.details`), `app_name`, `run_id`, and `cause_repr`.
 
 ### Legacy error-code namespaces (backward-compat only)
 

--- a/docs/concepts/common.md
+++ b/docs/concepts/common.md
@@ -73,7 +73,7 @@ raise DependencyUnavailableError(
 
 There is no `UNKNOWN` escape hatch — if the locus is unclear, the answer is `APP_OWNER` (the team investigates and reclassifies).
 
-`FailureDetails` (the Pydantic wire envelope on `AppError.to_failure_details()`) carries `category`, `code`, `retryable`, `audience`, `message`, an optional `suggested_action` (imperative remediation hint whose voice shifts with the audience), `tenant_id` (read from the SDK `APP_TENANT_ID` constant so per-tenant routing works for consumers reading `ApplicationError.details`), `app_name`, `run_id`, and `cause_repr`.
+`FailureDetails` (the Pydantic wire envelope on `AppError.to_failure_details()`) carries `category`, `code`, `retryable`, `audience`, `message`, an optional `suggested_action` (imperative remediation hint whose voice shifts with the audience), `domain` (read from the SDK `DOMAIN_NAME` constant — the customer-facing tenant subdomain like `acme.atlan.com` — so per-tenant routing works for consumers reading `ApplicationError.details`), `app_name`, `run_id`, and `cause_repr`.
 
 ### Legacy error-code namespaces (backward-compat only)
 

--- a/docs/standards/exceptions.md
+++ b/docs/standards/exceptions.md
@@ -246,7 +246,7 @@ When reviewing code, check for:
   ```
   The legacy `application_sdk/common/error_codes.py` `AAF-{COMP}-{ID:03d}` format is retained for backward compatibility only — do not use it in new code.
 
-- **Audience routing**: Each leaf sets a default `audience` (`USER | PLATFORM | FRAMEWORK | UNKNOWN`) that downstream consumers (AE, SLA dashboards) use to route the failure. Override it on a custom subclass when the default doesn't fit.
+- **Audience routing**: Each leaf sets a default `audience` (`USER | PLATFORM | APP_OWNER`) that downstream consumers (AE, SLA dashboards) use to route the failure. Override it on a custom subclass when the default doesn't fit. The enum is closed three-valued — there is no `UNKNOWN` escape hatch; if the locus is unclear, the answer is `APP_OWNER` (the team that wrote the code investigates and reclassifies).
 - **Logging**: Use `AtlanLoggerAdapter` for all logging with proper context
 - **Context**: Always include relevant context in error messages (query, filename, operation, etc.)
 - **Documentation**: Document all exceptions that functions can raise in docstrings

--- a/tests/unit/errors/test_categorical.py
+++ b/tests/unit/errors/test_categorical.py
@@ -26,7 +26,7 @@ _LEAVES = [
         FailureCategory.CANCELLED,
         False,
         "CANCELLED",
-        Audience.UNKNOWN,
+        Audience.APP_OWNER,
         ["cancelled_by", "reason"],
     ),
     (
@@ -34,7 +34,7 @@ _LEAVES = [
         FailureCategory.TIMEOUT,
         True,
         "TIMEOUT",
-        Audience.UNKNOWN,
+        Audience.APP_OWNER,
         ["operation", "timeout_seconds", "elapsed_seconds"],
     ),
     (
@@ -114,7 +114,7 @@ _LEAVES = [
         FailureCategory.DATA_INTEGRITY,
         False,
         "DATA_INTEGRITY",
-        Audience.FRAMEWORK,
+        Audience.APP_OWNER,
         ["expectation", "observed", "location"],
     ),
     (
@@ -122,7 +122,7 @@ _LEAVES = [
         FailureCategory.INTERNAL,
         False,
         "INTERNAL",
-        Audience.FRAMEWORK,
+        Audience.APP_OWNER,
         ["component", "invariant", "classification_pending"],
     ),
     (
@@ -130,7 +130,7 @@ _LEAVES = [
         FailureCategory.UNIMPLEMENTED,
         False,
         "UNIMPLEMENTED",
-        Audience.FRAMEWORK,
+        Audience.APP_OWNER,
         ["operation", "reason"],
     ),
 ]


### PR DESCRIPTION
Two follow-up changes from BLDX-1195 review. Both are additive and small; tests (201 errors-suite, 1691 broader-suite) all pass.

== 1. Audience: 3 values, no UNKNOWN escape hatch ==

Replaces the {USER, PLATFORM, FRAMEWORK, UNKNOWN} 4-value enum with a closed 3-value {USER, PLATFORM, APP_OWNER}.

Rationale: UNKNOWN as a default (on AppTimeoutError, CancelledError, and the AppError base) is an escape hatch — app teams forget to override it and the alerting pipeline accumulates an unowned UNKNOWN bucket, which is the noise this whole effort is trying to eliminate. Every failure should have a clear owner: customer (config / IAM / their source), platform (our shared infra), or the app team that wrote the code (whether SDK or connector). FRAMEWORK collapses into APP_OWNER because from production routing's standpoint, an SDK bug surfaces as a connector bug — the app team debugs first, escalates to SDK if needed.

If the locus is unclear, the answer is APP_OWNER (the team that wrote the code investigates and reclassifies). No escape hatch.

Defaults updated:
  - AppError base:       UNKNOWN  -> APP_OWNER
  - CancelledError:      UNKNOWN  -> APP_OWNER
  - AppTimeoutError:     UNKNOWN  -> APP_OWNER (docstring updated to
                                    instruct subclasses to override
                                    when locus is known)
  - DataIntegrityError:  FRAMEWORK -> APP_OWNER
  - InternalError:       FRAMEWORK -> APP_OWNER
  - UnimplementedError:  FRAMEWORK -> APP_OWNER
  - FailureDetails wire model default: UNKNOWN -> APP_OWNER

USER and PLATFORM defaults unchanged.

== 2. Add tenant_id to FailureDetails ==

Adds optional `tenant_id: str | None` to FailureDetails, populated by to_failure_details() from the existing APP_TENANT_ID constant.

Rationale: the comment at app_vitals.py:144 ("tenant_id is intentionally omitted because k8s.cluster.name identifies the tenant at the deployment level") holds for the SDK's OTel observability pipeline because OTel resource attributes carry it. But the Temporal ApplicationError.details wire is a separate path. When the Automation Engine reads workflow failures via temporal workflow show or the Temporal Python client, it only sees what's in details.payloads[0].data — k8s resource attributes are not on that wire. Without tenant_id in FailureDetails, multi-tenant alert routing has to re-derive tenant from somewhere else.

The SDK already has APP_TENANT_ID set on every connector pod via env var, so this is a single-line read in the serializer plus one optional field on the Pydantic model. Zero impact on connector teams.

== Files touched ==

  application_sdk/errors/categories.py  enum + docstring
  application_sdk/errors/leaves.py      6 audience defaults
  application_sdk/errors/base.py        base default + tenant_id
                                        serializer line
  application_sdk/errors/wire.py        FailureDetails default + new
                                        tenant_id field + docstring
  tests/unit/errors/test_categorical.py parametrize fixture updates
  docs/concepts/common.md               audience + tenant_id docs
  docs/standards/exceptions.md          audience reference
  .claude/skills/sdk-review/references/dx-rules.md  audience reference

### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- _to be added_

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.