### PR TITLE
chore(deps): bump temporalio cap to <1.28.0 for rustls-webpki fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "pyyaml>=6.0.2,<6.1.0",
     "obstore>=0.9.1,<0.10.0",
     # Temporal runtime (httpx-retries at L29 is the Dapr HTTP client replacement)
-    "temporalio>=1.25.0,<1.27.0",
+    "temporalio>=1.25.0,<1.28.0",
     "orjson>=3.11.6,<3.12.0",
 ]
 
@@ -49,7 +49,7 @@ Documentation = "https://github.com/atlanhq/application-sdk/README.md"
 [project.optional-dependencies]
 # Backwards-compatibility shims (dapr/temporalio/orjson promoted to core in v3.1)
 workflows = [
-    "temporalio>=1.25.0,<1.27.0",
+    "temporalio>=1.25.0,<1.28.0",
     "orjson>=3.11.6,<3.12.0",
 ]
 # SQL connectors: SqlMetadataExtractor, SqlQueryExtractor, and any SQL-based connector

--- a/requirements.txt
+++ b/requirements.txt
@@ -276,7 +276,7 @@ sortedcontainers==2.4.0
     # via hypothesis
 starlette==0.50.0
     # via fastapi
-temporalio==1.26.0
+temporalio==1.27.0
     # via atlan-application-sdk
 tenacity==9.1.4
     # via pyatlan

--- a/uv.lock
+++ b/uv.lock
@@ -351,8 +351,8 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'incremental'", specifier = ">=2.0.36,<2.1.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'sql'", specifier = ">=2.0.36,<2.1.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'sqlalchemy'", specifier = ">=2.0.36,<2.1.0" },
-    { name = "temporalio", specifier = ">=1.25.0,<1.27.0" },
-    { name = "temporalio", marker = "extra == 'workflows'", specifier = ">=1.25.0,<1.27.0" },
+    { name = "temporalio", specifier = ">=1.25.0,<1.28.0" },
+    { name = "temporalio", marker = "extra == 'workflows'", specifier = ">=1.25.0,<1.28.0" },
     { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.21.0,<0.23.0" },
 ]
 provides-extras = ["workflows", "sql", "daft", "incremental", "iam-auth", "azure", "distributed-lock", "mcp", "tests", "scale-data-generator", "sqlalchemy", "pandas"]
@@ -4594,7 +4594,7 @@ wheels = [
 
 [[package]]
 name = "temporalio"
-version = "1.26.0"
+version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nexus-rpc" },
@@ -4602,13 +4602,13 @@ dependencies = [
     { name = "types-protobuf" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/d4/fa21150a225393f87732ed6fef3cc9735d9e751edc6be415fe6e375105c6/temporalio-1.26.0.tar.gz", hash = "sha256:f4bfb35125e6f5e8c7f7ed1277c7354d812c6fac7ed5f8dbd50536cf289aaaa7", size = 2388994, upload-time = "2026-04-15T23:43:00.911Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/a1/6d59768d97ebb03676a33d10fec22a12ba6e7062801adc5946aa99138431/temporalio-1.27.0.tar.gz", hash = "sha256:fb92ae1077967ec626375a034af7e7108fe65f7b4ab1d98798ac2eecab247a65", size = 2497835, upload-time = "2026-04-30T22:39:56.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/27/8c421c622d18cc8e034247d5d72b89e6456937344b5bec1de40abef3c085/temporalio-1.26.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:5489040c0cf621edeb36984199dd9e4fbd2b3a07d61a4f2a8da1f2cb9820ef26", size = 14221070, upload-time = "2026-04-15T23:42:26.21Z" },
-    { url = "https://files.pythonhosted.org/packages/49/7c/d2b691d16ec5db87198c2e08dbfba58e286c096faee15753613a581abdce/temporalio-1.26.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b18dd85771509c19ef059a31908bcd4e6130d1f67037c4db519702f3f2ad6d4a", size = 13583991, upload-time = "2026-04-15T23:42:34.357Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ca/b8728451320ca9d8bb6e1680b9bd23767118f86d5b8644edf2304d533f1b/temporalio-1.26.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46187d5f82ca2ae81f35ea5916a76db0e2f067210dc6b1852c3749475721946e", size = 13808036, upload-time = "2026-04-15T23:42:42.757Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/54/3113f5e0ac58655790abac64656373e06191b351d74bfb94692e81bd6784/temporalio-1.26.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03300c3e5237443367ac61bb20bd726c656b3daa50310bdd436599d5bdc7cf97", size = 14336604, upload-time = "2026-04-15T23:42:49.851Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/9b/c50840a26af3587c0c8d9af04d9976743e22496996dc1a377efc75dcd316/temporalio-1.26.0-cp310-abi3-win_amd64.whl", hash = "sha256:1c4a0d82f0a3796cbf78864c799f8dca0b94cdaec68e7b8b224c859005686ec4", size = 14525849, upload-time = "2026-04-15T23:42:57.589Z" },
+    { url = "https://files.pythonhosted.org/packages/60/07/6f2a59c250b1383f7da1a607cb03a9e7bc9bd9811ce8a4fdd4e951a334b4/temporalio-1.27.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7daa4345b377b74602626326357c49ea1864bf1277fb7cb0b9f659f505c3dfb5", size = 14594920, upload-time = "2026-04-30T22:40:25.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e2/16d881961ff4a8f64ab4205e5519ac6330e1cccc8c50808884e649bfc487/temporalio-1.27.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:17bed16eaf340dd48ad59178c3928ecf848674bce31f80529ea057848a29399b", size = 13940741, upload-time = "2026-04-30T22:40:35.578Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/bf/33c66ef5dcd5a63e5d4d171660e81302e4909545e6400e531d7d609d0a62/temporalio-1.27.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:449c1e4c0d4f4d6545442060b74760f491b67c075ebde6765be16468454e2874", size = 14238127, upload-time = "2026-04-30T22:40:46.198Z" },
+    { url = "https://files.pythonhosted.org/packages/db/5f/a8b7f9e26e6b7a1d0fa8e5e9e280fac3439114318fc0e65ae4c97905ebee/temporalio-1.27.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5302035f8c2fdadd69a1362309ea5514bb4129bd4e494e6b69f9a5bb85e8cb85", size = 14782764, upload-time = "2026-04-30T22:40:05.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/ba/9428864f1d79c92b1a2f987aab5ab8f57911c0deb8dcf738cb0d89556ed6/temporalio-1.27.0-cp310-abi3-win_amd64.whl", hash = "sha256:0f125e82ff616dd46fb45ac4d253319e989bf3734a4eb25af703d5bc27147af9", size = 14974832, upload-time = "2026-04-30T22:40:14.921Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps `temporalio` upper bound from `<1.27.0` to `<1.28.0` in `pyproject.toml` (core deps + `workflows` extra). `uv.lock` resolves to `temporalio==1.27.0`.
- Closes **GHSA-82j2-j2ch-gfr8** (rustls-webpki) by transitively bumping the crate inside temporalio's Rust bridge from `0.103.10` → `0.103.13`.
- `requirements.txt` re-synced via pre-commit.

## Why

The CVE is a DoS panic in `rustls-webpki`'s CRL parsing. Per the upstream advisory, **"the default rustls configuration (no `RevocationOptions`) is not affected"** — temporalio's bridge doesn't opt into CRL checking, so this isn't actually exploitable in our deployment. However:

- The fix already shipped (temporalio 1.27.0, 2026-04-30)
- Our `<1.27.0` cap was a pre-1.27 defensive pin, not a known-bad signal
- Bumping is the proportional fix; allowlisting would defer for 30 days only to come back to the same bump

## What's in temporalio 1.27.0

- 💥 External Storage Reference Format Change — experimental codec for offloaded payloads; **not used by this SDK**
- New: Workflow Streams contrib library, OTel for standalone activities, typed `continue_as_new`, LangGraph plugin
- Cargo lock bumps (rustls-webpki, etc.)

No SDK-side code changes were needed.

## Test plan

- [x] `uv lock` clean; resolves to `temporalio==1.27.0`
- [x] Installed wheel's `temporalio/bridge/Cargo.lock` confirms `rustls-webpki = 0.103.13`
- [x] `uv run pre-commit run --files pyproject.toml uv.lock` — passed (auto-synced `requirements.txt`)
- [x] `uv run pytest tests/unit/` — **3826 passed, 7 skipped, 0 failures**
- [ ] CI: pyright (could not run locally — pyright not in venv)
- [ ] CI: trivy + snyk re-scan should drop GHSA-82j2-j2ch-gfr8
- [ ] Smoke test by a connector consumer of `application-sdk` after merge