### PR TITLE
chore(dashboard): add Newly Onboarded panel on Trends tab

### DIFF
--- a/.security/dashboard/index.html
+++ b/.security/dashboard/index.html
@@ -199,9 +199,10 @@
             <div id="trendChart" style="min-height:200px;position:relative;"></div>
         </div>
         <!-- Top movers -->
-        <div class="grid-2" style="margin-bottom:16px">
+        <div class="grid-2" style="grid-template-columns:repeat(3,1fr);margin-bottom:16px">
             <div class="card"><div class="card-title">Biggest Improvements <span id="trendImprovedCount" style="color:#b0b3c6;font-weight:500"></span></div><div id="trendImproved" style="max-height:340px;overflow-y:auto"></div></div>
             <div class="card"><div class="card-title">Needs Attention <span id="trendDegradedCount" style="color:#b0b3c6;font-weight:500"></span></div><div id="trendDegraded" style="max-height:340px;overflow-y:auto"></div></div>
+            <div class="card"><div class="card-title">Newly Onboarded <span id="trendNewRepoCount" style="color:#b0b3c6;font-weight:500"></span></div><div id="trendNewRepo" style="max-height:340px;overflow-y:auto"></div></div>
         </div>
         <!-- Section 3: Per repo table -->
         <div class="card">
@@ -845,8 +846,16 @@ function renderTrends(){
             app:D.repos[r].app_count||0,base:D.repos[r].base_image_count||0};
     });
 
-    const improved=repoDeltas.filter(r=>r.improvementDelta<0).sort((a,b)=>a.improvementDelta-b.improvementDelta);
-    const degraded=repoDeltas.filter(r=>r.delta>0).sort((a,b)=>b.delta-a.delta);
+    // A repo whose earliest history entry falls inside the comparison window is "newly
+    // onboarded" — it has no real baseline, so showing it under Needs Attention would
+    // misrepresent it as a regression. Surface those separately instead.
+    const isNewlyOnboarded=r=>{
+        const all=(historyData[r]||[]).slice().sort((a,b)=>a.date.localeCompare(b.date));
+        return all.length>0 && all[0].date>cutoffStr;
+    };
+    const improved=repoDeltas.filter(r=>r.improvementDelta<0&&!isNewlyOnboarded(r.repo)).sort((a,b)=>a.improvementDelta-b.improvementDelta);
+    const degraded=repoDeltas.filter(r=>r.delta>0&&!isNewlyOnboarded(r.repo)).sort((a,b)=>b.delta-a.delta);
+    const newlyOnboarded=repoDeltas.filter(r=>isNewlyOnboarded(r.repo)&&r.now>0).sort((a,b)=>b.now-a.now);
 
     document.getElementById('trendImprovedCount').textContent=improved.length?`(${improved.length})`:'';
     document.getElementById('trendImproved').innerHTML=improved.length?improved.map(r=>
@@ -857,6 +866,11 @@ function renderTrends(){
     document.getElementById('trendDegraded').innerHTML=degraded.length?degraded.map(r=>
         `<div class="trend-change"><span class="repo-tag">${esc(r.repo.split('/').pop())}</span><span class="trend-delta up" style="margin-left:auto">&#9650; +${r.delta} (${r.old} → ${r.now})</span></div>`
     ).join(''):'<div class="empty" style="padding:20px;font-size:12px;color:#22c55e">No regressions — all repos stable or improving.</div>';
+
+    document.getElementById('trendNewRepoCount').textContent=newlyOnboarded.length?`(${newlyOnboarded.length})`:'';
+    document.getElementById('trendNewRepo').innerHTML=newlyOnboarded.length?newlyOnboarded.map(r=>
+        `<div class="trend-change"><span class="repo-tag">${esc(r.repo.split('/').pop())}</span><span class="trend-delta up" style="margin-left:auto">+${r.now} (first scan)</span></div>`
+    ).join(''):'<div class="empty" style="padding:20px;font-size:12px">No new repos onboarded in this window.</div>';
 
     // Section 3: Per repo table
     // Apply CVE-count bucket filter before sorting


### PR DESCRIPTION
## Summary
Add a third panel — **Newly Onboarded** — alongside Biggest Improvements and Needs Attention on the Trends tab. Surfaces repos whose earliest history entry falls inside the current comparison window.

## Why
A brand-new repo (e.g. `atlan-powerquery-parser-app`, first-scanned 2026-05-06 with 16 CVEs) silently dropped out of Needs Attention because its only baseline was itself — `delta = now - oldStart = 0`. From a user's perspective, 12 net-new CVEs appearing in the org headline with nothing on the dashboard explaining why is confusing.

Two related fixes:
- **New panel:** lists newly-onboarded repos with `+N (first scan)` so the source of org-wide CVE jumps is visible.
- **Exclusion guard:** newly-onboarded repos are also filtered out of Biggest Improvements / Needs Attention so they don't pollute those lists with self-comparing deltas.

## Behaviour
- A repo stays in the panel as long as its first-ever scan date is `> cutoff` (driven by the existing **Compare** filter).
- Default 7-day window → repos appear for 7 days from first scan.
- Subsequent scans don't extend the window — only the first-ever scan date matters.

## Test plan
- [ ] Open dashboard → Trends tab → confirm 3-column layout (Improvements / Needs Attention / Newly Onboarded)
- [ ] Confirm `atlan-powerquery-parser-app` appears under Newly Onboarded with `+16 (first scan)` (with default 7d Compare)
- [ ] Confirm it does NOT appear under Needs Attention
- [ ] Switch Compare filter to 1 day → repo should disappear from the panel after its scan date passes the cutoff