### PR TITLE
fix(observability): split logger sinks by severity

### DIFF
--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -497,10 +497,23 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
                 " - {message}\n{exception}"
             )
 
+        # Split sinks by severity so cloud log collectors (GCP Cloud Logging,
+        # AWS CloudWatch Logs Insights, etc.) that infer severity from the file
+        # descriptor classify benign records as INFO instead of ERROR. Records
+        # at WARNING and below go to stdout; ERROR/CRITICAL/exception records
+        # stay on stderr. Matches uvicorn/gunicorn conventions.
+        _ERROR_LEVEL_NO = SEVERITY_MAPPING["ERROR"]
+        self.logger.add(
+            sys.stdout,
+            format=get_log_format,
+            level=SEVERITY_MAPPING[LOG_LEVEL],
+            colorize=colorize,
+            filter=lambda record: record["level"].no < _ERROR_LEVEL_NO,
+        )
         self.logger.add(
             sys.stderr,
             format=get_log_format,
-            level=SEVERITY_MAPPING[LOG_LEVEL],
+            level=max(SEVERITY_MAPPING[LOG_LEVEL], _ERROR_LEVEL_NO),
             colorize=colorize,
         )
 

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -682,17 +682,49 @@ def test_exception_keeps_explicit_exc_info(logger_adapter: AtlanLoggerAdapter):
 
 
 def test_warning_with_exc_info_emits_traceback(capsys: pytest.CaptureFixture[str]):
-    """warning(..., exc_info=True) should render traceback in stderr output."""
+    """warning(..., exc_info=True) should render traceback in stdout output."""
     with create_logger_adapter() as logger_adapter:
         try:
             raise ValueError("traceback-check")
         except ValueError:
             logger_adapter.warning("Completing activity as failed", exc_info=True)
 
-    stderr = capsys.readouterr().err
-    assert "Completing activity as failed" in stderr
-    assert "Traceback (most recent call last):" in stderr
-    assert "ValueError: traceback-check" in stderr
+    captured = capsys.readouterr()
+    stdout = captured.out
+    assert "Completing activity as failed" in stdout
+    assert "Traceback (most recent call last):" in stdout
+    assert "ValueError: traceback-check" in stdout
+    assert "Completing activity as failed" not in captured.err
+
+
+@pytest.mark.parametrize(
+    "token,call,expected_stream",
+    [
+        ("info-record", lambda lg: lg.info("info-record"), "out"),
+        ("warn-record", lambda lg: lg.warning("warn-record"), "out"),
+        ("err-record", lambda lg: lg.error("err-record"), "err"),
+        ("crit-record", lambda lg: lg.critical("crit-record"), "err"),
+    ],
+)
+def test_log_records_route_by_severity(
+    token: str,
+    call,
+    expected_stream: str,
+    capsys: pytest.CaptureFixture[str],
+):
+    """Records below ERROR go to stdout; ERROR/CRITICAL go to stderr.
+
+    Cloud log collectors that infer severity from the file descriptor (GCP
+    Cloud Logging is the motivating case) classify stderr lines as ERROR, so
+    benign records must land on stdout.
+    """
+    with create_logger_adapter() as logger_adapter:
+        call(logger_adapter)
+
+    captured = capsys.readouterr()
+    assert token in getattr(captured, expected_stream)
+    other = "err" if expected_stream == "out" else "out"
+    assert token not in getattr(captured, other)
 
 
 def test_log_record_model_extracts_exception_attrs_from_loguru_record():


### PR DESCRIPTION
## Summary
- Route loguru records below ERROR to **stdout** and ERROR/CRITICAL to **stderr** (uvicorn/gunicorn convention).
- Previously every record went to a single `sys.stderr` sink — cloud log collectors that infer severity from the file descriptor (notably GCP Cloud Logging) reported every INFO/WARNING line as `severity: ERROR`.
- The bug was masked when the SDK container ran under `dapr run`, which merged child stdout/stderr onto its own stdout with an `== APP ==` prefix. The direct-daprd entrypoint introduced in 2.7.x exposed the long-standing sink choice.

Linked Linear: ARUN-538

## Behaviour change
| Level | Before | After |
|---|---|---|
| DEBUG / INFO / WARNING | stderr | **stdout** |
| ERROR / CRITICAL | stderr | stderr (unchanged) |
| Custom ACTIVITY/METRIC/TRACING (mapped to ≤INFO) | stderr | **stdout** |
| `exc_info=True` traceback | stderr | follows the record's level |

Filter is `record["level"].no < SEVERITY_MAPPING["ERROR"]`, so any future custom level inherits the rule based on its numeric severity.

## Tests
- `test_warning_with_exc_info_emits_traceback` updated: WARNING tracebacks now assert on stdout and confirm absence from stderr.
- New `test_log_records_route_by_severity` parametrised over INFO / WARNING / ERROR / CRITICAL pins the routing contract.
- Full `tests/unit/observability/` suite passes (306 tests).
- `pre-commit` (ruff / ruff-format / pyright / isort) passes.

## Test plan
- [ ] `uv run pytest tests/unit/observability/`
- [ ] After merge + image bump, deploy a connector app on GCP and confirm informational SDK records show `severity: INFO` while genuine errors stay `severity: ERROR`.
- [ ] Confirm console output during local dev still renders WARNING/ERROR colour formatting (colorize only enables under `LOG_LEVEL=DEBUG`, unchanged).

## Notes
- No public API or signature change.
- No CHANGELOG edit per repo convention (CI generates it).
- The downstream noisy log line that motivated the report (`Error reading file ... [Errno 2] No such file or directory` from a poll-before-write race in the v2 ObjectStore upload path) is *not* fixed here — that file no longer exists on `main`. Worth a follow-up to downgrade `FileNotFoundError` paths to WARNING/DEBUG where the absence is expected.