### PR TITLE
ci: pin claude-code-action to v1.0.112 (workaround upstream install regression)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -406,7 +406,11 @@ jobs:
       - name: Resolve conflicts (Tier 3 — Claude session)
         id: resolve
         if: steps.conflicts.outputs.needs_resolution == 'true'
-        uses: anthropics/claude-code-action@v1
+        # Pinned to v1.0.112 to avoid the v1.0.113 regression where
+        # `claude install` exits 0 without placing the binary at
+        # ~/.local/bin/claude on Ubuntu 24.04 runners.
+        # Tracking: https://github.com/anthropics/claude-code-action/issues/1290
+        uses: anthropics/claude-code-action@08d635357c8fff73d997923c055449a03e92e0b6  # v1.0.112
         with:
           anthropic_api_key: ${{ secrets.LITELLM_API_KEY }}
           show_full_output: true
@@ -515,7 +519,11 @@ jobs:
       # using trusted identifiers (PR number, repo, head SHA) only.
       - name: SDK Review (Session A — Review)
         id: review
-        uses: anthropics/claude-code-action@v1
+        # Pinned to v1.0.112 to avoid the v1.0.113 regression where
+        # `claude install` exits 0 without placing the binary at
+        # ~/.local/bin/claude on Ubuntu 24.04 runners.
+        # Tracking: https://github.com/anthropics/claude-code-action/issues/1290
+        uses: anthropics/claude-code-action@08d635357c8fff73d997923c055449a03e92e0b6  # v1.0.112
         with:
           anthropic_api_key: ${{ secrets.LITELLM_API_KEY }}
           show_full_output: true
@@ -841,7 +849,11 @@ jobs:
         if: |
           steps.pr.outputs.mode == 'auto-fix' &&
           steps.verdict.outputs.verdict == 'NEEDS_FIXES'
-        uses: anthropics/claude-code-action@v1
+        # Pinned to v1.0.112 to avoid the v1.0.113 regression where
+        # `claude install` exits 0 without placing the binary at
+        # ~/.local/bin/claude on Ubuntu 24.04 runners.
+        # Tracking: https://github.com/anthropics/claude-code-action/issues/1290
+        uses: anthropics/claude-code-action@08d635357c8fff73d997923c055449a03e92e0b6  # v1.0.112
         with:
           anthropic_api_key: ${{ secrets.LITELLM_API_KEY }}
           show_full_output: true
@@ -1129,7 +1141,11 @@ jobs:
           steps.pr.outputs.mode == 'auto-fix' &&
           steps.verdict.outputs.verdict == 'READY_TO_MERGE' &&
           steps.finalize.outputs.ci_failed == 'true'
-        uses: anthropics/claude-code-action@v1
+        # Pinned to v1.0.112 to avoid the v1.0.113 regression where
+        # `claude install` exits 0 without placing the binary at
+        # ~/.local/bin/claude on Ubuntu 24.04 runners.
+        # Tracking: https://github.com/anthropics/claude-code-action/issues/1290
+        uses: anthropics/claude-code-action@08d635357c8fff73d997923c055449a03e92e0b6  # v1.0.112
         with:
           anthropic_api_key: ${{ secrets.LITELLM_API_KEY }}
           show_full_output: true

--- a/.github/workflows/reusable-claude-review.yml
+++ b/.github/workflows/reusable-claude-review.yml
@@ -43,7 +43,11 @@ jobs:
           fetch-depth: 0
 
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
+        # Pinned to v1.0.112 to avoid the v1.0.113 regression where
+        # `claude install` exits 0 without placing the binary at
+        # ~/.local/bin/claude on Ubuntu 24.04 runners.
+        # Tracking: https://github.com/anthropics/claude-code-action/issues/1290
+        uses: anthropics/claude-code-action@08d635357c8fff73d997923c055449a03e92e0b6  # v1.0.112
         with:
           anthropic_api_key: ${{ secrets.AI_GATEWAY_KEY }}
           model: ${{ inputs.model }}


### PR DESCRIPTION
## Summary

The `sdk-review` and other workflows that invoke `anthropics/claude-code-action@v1` started failing on 2026-05-06 with:

```
ReferenceError: Claude Code native binary not found at /home/runner/.local/bin/claude.
```

Example failing run: https://github.com/atlanhq/application-sdk/actions/runs/25420523769/job/74561387076

## Root cause

`claude-code-action` v1.0.113 (released 2026-05-06T01:41:53Z) bumped the bundled Claude Code CLI to `2.1.129`. The new `claude install` regressed: it no longer creates `~/.local/bin/` and exits 0 anyway, leaving the binary unplaced. The action trusts the exit code and tries to spawn a non-existent binary.

Upstream tracking: https://github.com/anthropics/claude-code-action/issues/1290 (3 confirming reports already, all on 2026-05-06).

## Fix

Pin all 5 production invocations of the action to **v1.0.112** (`08d6353`) — the last release before the bump. Revert to `@v1` once the upstream issue is resolved.

| File | Invocations pinned |
|---|---|
| `.github/workflows/claude.yml` | 4 (lines 409, 518, 844, 1132) |
| `.github/workflows/reusable-claude-review.yml` | 1 (line 46) |

## Test plan

- [ ] CI on this PR runs `sdk-review` and other Claude actions on the pinned version successfully.
- [ ] Upstream issue tracked; revert PR ready when fix lands.