### PR TITLE
chore(security): allowlist 8 dapr/otel/rustls transitive vulns

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -307,5 +307,61 @@
     "reason": "Connector transitive — lxml pulled in by redshift-connector (aws/amazon-redshift-python-driver). Fix is in lxml>=6.1.0, but redshift-connector 2.1.10 pins lxml<6.0.0 in its package metadata. Bumping lxml in connector apps forces a downgrade of redshift-connector to 2.1.7. Allowlisting until upstream relaxes the cap; tracking via aws/amazon-redshift-python-driver. Connector code uses lxml only for SOAP/XML parsing of trusted Redshift IAM responses, not untrusted input.",
     "expires": "2026-05-28",
     "added_by": "anuj-atlan"
+  },
+  "GHSA-82j2-j2ch-gfr8": {
+    "package": "rustls-webpki",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr Rust transitive dep (rustls-webpki@0.103.4). Fix available in 0.103.13; awaiting Wolfi rebuild of dapr-1.17 with newer rustls-webpki.",
+    "expires": "2026-06-05",
+    "added_by": "sachi-atlan"
+  },
+  "CVE-2026-41491": {
+    "package": "github.com/dapr/dapr",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr runtime (1.17.0). Fix available in 1.17.5; awaiting Wolfi rebuild of dapr-1.17.",
+    "expires": "2026-06-05",
+    "added_by": "sachi-atlan"
+  },
+  "CVE-2026-29181": {
+    "package": "go.opentelemetry.io/otel",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr OpenTelemetry Go transitive dep (otel@1.40.0). Fix available in 1.41.0; awaiting Wolfi rebuild of dapr-1.17 with newer otel.",
+    "expires": "2026-06-05",
+    "added_by": "sachi-atlan"
+  },
+  "SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGACL-16394931": {
+    "package": "github.com/dapr/dapr/pkg/acl",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr runtime transitive (1.17.0). Fix available in 1.17.5; awaiting Wolfi rebuild of dapr-1.17.",
+    "expires": "2026-06-05",
+    "added_by": "sachi-atlan"
+  },
+  "SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGACTORSTARGETSAPP-16394932": {
+    "package": "github.com/dapr/dapr/pkg/actors/targets/app",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr runtime transitive (1.17.0). Fix available in 1.17.5; awaiting Wolfi rebuild of dapr-1.17.",
+    "expires": "2026-06-05",
+    "added_by": "sachi-atlan"
+  },
+  "SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGAPIGRPC-16394933": {
+    "package": "github.com/dapr/dapr/pkg/api/grpc",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr runtime transitive (1.17.0). Fix available in 1.17.5; awaiting Wolfi rebuild of dapr-1.17.",
+    "expires": "2026-06-05",
+    "added_by": "sachi-atlan"
+  },
+  "SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGAPIHTTP-16394934": {
+    "package": "github.com/dapr/dapr/pkg/api/http",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr runtime transitive (1.17.0). Fix available in 1.17.5; awaiting Wolfi rebuild of dapr-1.17.",
+    "expires": "2026-06-05",
+    "added_by": "sachi-atlan"
+  },
+  "SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGMESSAGING-16394937": {
+    "package": "github.com/dapr/dapr/pkg/messaging",
+    "severity": "HIGH",
+    "reason": "Base image — Dapr runtime transitive (1.17.0). Fix available in 1.17.5; awaiting Wolfi rebuild of dapr-1.17.",
+    "expires": "2026-06-05",
+    "added_by": "sachi-atlan"
   }
 }


### PR DESCRIPTION
## Summary

Add HIGH-severity allowlist entries (expires **2026-06-05**, 30 days from today) for 8 transitive Go and Rust vulnerabilities surfaced by trivy/snyk on the application-sdk base image. All originate from the Wolfi `dapr-1.17` base bundle and are awaiting an upstream Wolfi rebuild.

Triggered by trivy/snyk container scan failures on atlanhq/native-migration-app PR #22 — https://github.com/atlanhq/native-migration-app/pull/22

## Entries added

| ID | Package | Current -> Fixed |
|---|---|---|
| `GHSA-82j2-j2ch-gfr8` | `rustls-webpki` | 0.103.4 -> 0.103.13 |
| `CVE-2026-41491` | `github.com/dapr/dapr` | 1.17.0 -> 1.17.5 |
| `CVE-2026-29181` | `go.opentelemetry.io/otel` | 1.40.0 -> 1.41.0 |
| `SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGACL-16394931` | `github.com/dapr/dapr/pkg/acl` | 1.17.0 -> 1.17.5 |
| `SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGACTORSTARGETSAPP-16394932` | `github.com/dapr/dapr/pkg/actors/targets/app` | 1.17.0 -> 1.17.5 |
| `SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGAPIGRPC-16394933` | `github.com/dapr/dapr/pkg/api/grpc` | 1.17.0 -> 1.17.5 |
| `SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGAPIHTTP-16394934` | `github.com/dapr/dapr/pkg/api/http` | 1.17.0 -> 1.17.5 |
| `SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGMESSAGING-16394937` | `github.com/dapr/dapr/pkg/messaging` | 1.17.0 -> 1.17.5 |

The five Snyk Dapr findings are all fixed in dapr 1.17.5 — once the Wolfi `dapr-1.17` package is rebuilt with 1.17.5 + newer otel/rustls, these entries can be removed.

## Approval

Per `.security/README.md`, this PR requires approval from an SDK security owner listed in `.security/approvers.json` (CODEOWNERS for `.security/`).

## Validation

- `python3 .github/scripts/validate_allowlist.py` -> passes (51 entries, all within HIGH <= 30d / CRITICAL <= 15d policy)
- JSON parses cleanly

## Test plan

- [ ] Allowlist validator green in CI
- [ ] CODEOWNERS approval from a `.security/approvers.json` owner
- [ ] After merge, re-run native-migration-app PR #22 trivy/snyk gate to confirm the 8 findings are now allowlisted