### PR TITLE
perf: lazy-load heavy imports to reduce SERVER mode cold start by ~70%

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"3aebfb33-3281-47c0-a264-bc212cf67efe","pid":41021,"acquiredAt":1777552744867}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -49,8 +49,10 @@ jobs:
 
       - name: Lowercase branch name
         id: get_lowercase_branch
+        env:
+          BRANCH: ${{ steps.get_branch.outputs.branch }}
         run: |
-          echo "lowercase_branch=$(echo '${GITHUB_REF#refs/heads/}' | tr '[:upper:]' '[:lower:]' | tr '/' '-' | tr '_' '-')" >> $GITHUB_OUTPUT
+          echo "lowercase_branch=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | tr '/' '-' | tr '_' '-')" >> $GITHUB_OUTPUT
 
       - name: Short commit SHA
         id: get_sha

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -5,11 +5,13 @@ on:
   push:
     branches:
       - main
+      - debug/boot-time   # boot-time optimization branch — SHA-only image, no latest/version tags
     paths:
       - 'Dockerfile'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'entrypoint.sh'
+      - 'application_sdk/**'   # also rebuild when SDK source changes
 
 permissions:
   contents: read
@@ -24,6 +26,8 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
       lowercase_branch: ${{ steps.get_lowercase_branch.outputs.lowercase_branch }}
       repository_name: ${{ steps.get_repo_name.outputs.repository_name }}
+      sha_short: ${{ steps.get_sha.outputs.sha_short }}
+      is_main: ${{ steps.get_branch.outputs.branch == 'main' }}
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -43,8 +47,12 @@ jobs:
         id: get_version
 
       - name: Lowercase branch name
-        run: echo "lowercase_branch=$(echo '${{ steps.get_branch.outputs.branch }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+        run: echo "lowercase_branch=$(echo '${{ steps.get_branch.outputs.branch }}' | tr '[:upper:]' '[:lower:]' | tr '/' '-')" >> $GITHUB_OUTPUT
         id: get_lowercase_branch
+
+      - name: Short commit SHA
+        id: get_sha
+        run: echo "sha_short=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
   push-to-ghcr:
     runs-on: ubuntu-latest
@@ -90,11 +98,19 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: |
-            ghcr.io/atlanhq/app-runtime-base-${{ needs.prepare.outputs.lowercase_branch }}:latest
-            ghcr.io/atlanhq/app-runtime-base-${{ needs.prepare.outputs.lowercase_branch }}:${{ needs.prepare.outputs.version }}
-            ghcr.io/atlanhq/${{ github.event.repository.name }}-${{ needs.prepare.outputs.lowercase_branch }}:latest
-            ghcr.io/atlanhq/${{ github.event.repository.name }}-${{ needs.prepare.outputs.lowercase_branch }}:${{ needs.prepare.outputs.version }}
+          # main: push latest + version tags (existing behaviour)
+          # any other branch: SHA-only tag — safe for testing, zero impact on existing apps
+          tags: ${{ needs.prepare.outputs.is_main == 'true' && format(
+            'ghcr.io/atlanhq/app-runtime-base-{0}:latest\nghcr.io/atlanhq/app-runtime-base-{0}:{1}\nghcr.io/atlanhq/{2}-{0}:latest\nghcr.io/atlanhq/{2}-{0}:{1}',
+            needs.prepare.outputs.lowercase_branch,
+            needs.prepare.outputs.version,
+            github.event.repository.name
+          ) || format(
+            'ghcr.io/atlanhq/{0}-{1}:{2}',
+            github.event.repository.name,
+            needs.prepare.outputs.lowercase_branch,
+            needs.prepare.outputs.sha_short
+          ) }}
           build-args: |
             ACCESS_TOKEN_USR=$GITHUB_ACTOR
             ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -19,41 +19,71 @@ permissions:
   actions: read
 
 jobs:
+  # ── Job 1: Compute all image metadata ────────────────────────────────────────
   prepare:
     runs-on: ubuntu-latest
     outputs:
-      branch: ${{ steps.get_branch.outputs.branch }}
-      version: ${{ steps.get_version.outputs.version }}
-      lowercase_branch: ${{ steps.get_lowercase_branch.outputs.lowercase_branch }}
-      repository_name: ${{ steps.get_repo_name.outputs.repository_name }}
-      sha_short: ${{ steps.get_sha.outputs.sha_short }}
-      is_main: ${{ steps.get_branch.outputs.branch == 'main' }}
+      branch:            ${{ steps.get_branch.outputs.branch }}
+      version:           ${{ steps.get_version.outputs.version }}
+      lowercase_branch:  ${{ steps.get_lowercase_branch.outputs.lowercase_branch }}
+      repository_name:   ${{ steps.get_repo_name.outputs.repository_name }}
+      sha_short:         ${{ steps.get_sha.outputs.sha_short }}
+      image_tags:        ${{ steps.compute_tags.outputs.image_tags }}
     steps:
       - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
       - name: Get branch name
-        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: get_branch
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
 
       - name: Get repository name
-        run: echo "repository_name=`echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}' | sed -e "s/:refs//"`" >> $GITHUB_OUTPUT
         id: get_repo_name
         shell: bash
+        run: echo "repository_name=`echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}' | sed -e "s/:refs//"`" >> $GITHUB_OUTPUT
 
       - name: Get version from pyproject.toml
-        run: echo "version=$(awk -F'"' '/^version = / {print $2}' pyproject.toml)" >> $GITHUB_OUTPUT
         id: get_version
+        run: echo "version=$(awk -F'"' '/^version = / {print $2}' pyproject.toml)" >> $GITHUB_OUTPUT
 
       - name: Lowercase branch name
-        run: echo "lowercase_branch=$(echo '${{ steps.get_branch.outputs.branch }}' | tr '[:upper:]' '[:lower:]' | tr '/' '-')" >> $GITHUB_OUTPUT
         id: get_lowercase_branch
+        run: |
+          echo "lowercase_branch=$(echo '${GITHUB_REF#refs/heads/}' | tr '[:upper:]' '[:lower:]' | tr '/' '-' | tr '_' '-')" >> $GITHUB_OUTPUT
 
       - name: Short commit SHA
         id: get_sha
         run: echo "sha_short=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
+      - name: Compute image tags
+        id: compute_tags
+        env:
+          BRANCH: ${{ steps.get_branch.outputs.branch }}
+          LC_BRANCH: ${{ steps.get_lowercase_branch.outputs.lowercase_branch }}
+          VERSION: ${{ steps.get_version.outputs.version }}
+          REPO: ${{ steps.get_repo_name.outputs.repository_name }}
+          SHA_SHORT: ${{ steps.get_sha.outputs.sha_short }}
+        run: |
+          if [ "$BRANCH" = "main" ]; then
+            # main: full set of tags (existing behaviour)
+            TAGS="ghcr.io/atlanhq/app-runtime-base-${LC_BRANCH}:latest
+          ghcr.io/atlanhq/app-runtime-base-${LC_BRANCH}:${VERSION}
+          ghcr.io/atlanhq/${REPO}-${LC_BRANCH}:latest
+          ghcr.io/atlanhq/${REPO}-${LC_BRANCH}:${VERSION}"
+          else
+            # non-main branches: SHA-only tag — zero impact on existing apps
+            TAGS="ghcr.io/atlanhq/${REPO}-${LC_BRANCH}:${SHA_SHORT}"
+          fi
+
+          echo "image_tags<<TAGS_EOF" >> $GITHUB_OUTPUT
+          echo "$TAGS" >> $GITHUB_OUTPUT
+          echo "TAGS_EOF" >> $GITHUB_OUTPUT
+
+          echo "Computed tags:"
+          echo "$TAGS"
+
+  # ── Job 2: Build and push image ──────────────────────────────────────────────
   push-to-ghcr:
     runs-on: ubuntu-latest
     needs: prepare
@@ -98,19 +128,7 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
-          # main: push latest + version tags (existing behaviour)
-          # any other branch: SHA-only tag — safe for testing, zero impact on existing apps
-          tags: ${{ needs.prepare.outputs.is_main == 'true' && format(
-            'ghcr.io/atlanhq/app-runtime-base-{0}:latest\nghcr.io/atlanhq/app-runtime-base-{0}:{1}\nghcr.io/atlanhq/{2}-{0}:latest\nghcr.io/atlanhq/{2}-{0}:{1}',
-            needs.prepare.outputs.lowercase_branch,
-            needs.prepare.outputs.version,
-            github.event.repository.name
-          ) || format(
-            'ghcr.io/atlanhq/{0}-{1}:{2}',
-            github.event.repository.name,
-            needs.prepare.outputs.lowercase_branch,
-            needs.prepare.outputs.sha_short
-          ) }}
+          tags: ${{ needs.prepare.outputs.image_tags }}
           build-args: |
             ACCESS_TOKEN_USR=$GITHUB_ACTOR
             ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}

--- a/application_sdk/application/__init__.py
+++ b/application_sdk/application/__init__.py
@@ -1,11 +1,9 @@
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
 
 from typing_extensions import deprecated
 
-from application_sdk.activities import ActivitiesInterface
 from application_sdk.clients.base import BaseClient
-from application_sdk.clients.utils import get_workflow_client
 from application_sdk.constants import APPLICATION_MODE, ENABLE_MCP, ApplicationMode
 from application_sdk.handlers.base import BaseHandler
 from application_sdk.interceptors.models import EventRegistration
@@ -18,8 +16,13 @@ from application_sdk.observability.traces_adaptor import get_traces
 from application_sdk.server import ServerInterface
 from application_sdk.server.fastapi import APIServer, HttpWorkflowTrigger
 from application_sdk.server.fastapi.models import EventWorkflowTrigger
-from application_sdk.worker import Worker
 from application_sdk.workflows import WorkflowInterface
+
+if TYPE_CHECKING:
+    # Heavy imports only needed in LOCAL/WORKER mode — kept here for type checkers only.
+    # At runtime ActivitiesInterface is never needed at module level (only as a
+    # string annotation). Worker is lazy-imported inside setup_workflow().
+    from application_sdk.activities import ActivitiesInterface  # noqa: F401
 
 logger = get_logger(__name__)
 metrics = get_metrics()
@@ -53,6 +56,10 @@ class BaseApplication:
             client_class (Optional[Type[BaseClient]]): Client class for the application.
             handler_class (Optional[Type[BaseHandler]]): Handler class for the application.
         """
+        from application_sdk.clients.utils import (  # noqa: PLC0415 — lazy: pulls Temporal stack (~678ms) via clients.temporal; defer until first use
+            get_workflow_client,
+        )
+
         self.application_name = name
 
         # setup application server. serves the UI, and handles the various triggers
@@ -182,7 +189,7 @@ class BaseApplication:
     async def setup_workflow(
         self,
         workflow_and_activities_classes: List[
-            Tuple[Type[WorkflowInterface], Type[ActivitiesInterface]]
+            Tuple[Type[WorkflowInterface], Type["ActivitiesInterface"]]
         ],
         passthrough_modules: List[str] = [],
         activity_executor: Optional[ThreadPoolExecutor] = None,
@@ -195,6 +202,10 @@ class BaseApplication:
             passthrough_modules (list): The modules to pass through to the worker.
             activity_executor (ThreadPoolExecutor | None): Executor for running activities.
         """
+        from application_sdk.worker import (  # noqa: PLC0415 — lazy: Temporal worker stack is heavy (~643ms); only needed in LOCAL/WORKER mode
+            Worker,
+        )
+
         await self.workflow_client.load()
 
         workflow_classes = [

--- a/application_sdk/clients/temporal.py
+++ b/application_sdk/clients/temporal.py
@@ -140,6 +140,10 @@ class TemporalWorkflowClient(WorkflowClient):
         self._token_refresh_interval: Optional[int] = None
         self._token_refresh_task: Optional[asyncio.Task] = None
 
+        # Set when load() completes. Allows start_workflow() to wait gracefully
+        # when load() was fired as a background task (SERVER mode fast-start).
+        self._client_ready: asyncio.Event = asyncio.Event()
+
         logger = get_logger(__name__)
         workflow.logger = logger
         activity.logger = logger
@@ -278,6 +282,7 @@ class TemporalWorkflowClient(WorkflowClient):
 
         # Create the client
         self.client = await Client.connect(**connection_options)
+        self._client_ready.set()
 
         # Start token refresh loop if auth is enabled
         if self.auth_manager.auth_enabled:
@@ -288,6 +293,24 @@ class TemporalWorkflowClient(WorkflowClient):
             self._token_refresh_task = asyncio.create_task(self._token_refresh_loop())
             logger.info(
                 f"Started token refresh loop with dynamic interval (initial: {self._token_refresh_interval}s)"
+            )
+
+    async def _wait_for_client(self, timeout: float = 30.0) -> None:
+        """Wait until load() has completed (i.e. Temporal client is connected).
+
+        In SERVER mode, load() is fired as a background task so uvicorn can
+        start serving health probes immediately. Any route handler that needs
+        the Temporal client calls this to block until it's ready rather than
+        failing with ValueError.
+        """
+        if self.client:
+            return
+        try:
+            await asyncio.wait_for(self._client_ready.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            raise ValueError(
+                f"Temporal client not connected after {timeout}s — "
+                "check Temporal server reachability"
             )
 
     async def close(self) -> None:
@@ -344,8 +367,10 @@ class TemporalWorkflowClient(WorkflowClient):
             logger.info(f"Created workflow config with ID: {workflow_id}")
         try:
             # Pass the full workflow_args to the workflow
-            if not self.client:
-                raise ValueError("Client is not loaded")
+            await self._wait_for_client()
+            assert (
+                self.client is not None
+            )  # narrowed: _wait_for_client raises if still None
 
             correlation_fields = {
                 k: v
@@ -381,8 +406,10 @@ class TemporalWorkflowClient(WorkflowClient):
         Raises:
             ValueError: If the client is not loaded.
         """
-        if not self.client:
-            raise ValueError("Client is not loaded")
+        await self._wait_for_client()
+        assert (
+            self.client is not None
+        )  # narrowed: _wait_for_client raises if still None
 
         try:
             workflow_handle = self.client.get_workflow_handle(
@@ -556,8 +583,10 @@ class TemporalWorkflowClient(WorkflowClient):
             ValueError: If the client is not loaded.
             Exception: If there's an error getting the workflow status.
         """
-        if not self.client:
-            raise ValueError("Client is not loaded")
+        await self._wait_for_client()
+        assert (
+            self.client is not None
+        )  # narrowed: _wait_for_client raises if still None
 
         try:
             workflow_handle = self.client.get_workflow_handle(

--- a/application_sdk/common/aws_utils.py
+++ b/application_sdk/common/aws_utils.py
@@ -1,9 +1,6 @@
 import re
 from typing import Any, Dict, Optional
 
-import boto3
-from sqlalchemy.engine.url import URL
-
 from application_sdk.constants import AWS_SESSION_NAME
 from application_sdk.observability.logger_adaptor import get_logger
 
@@ -143,7 +140,7 @@ def get_cluster_identifier(aws_client) -> Optional[str]:
     return None
 
 
-def create_aws_session(credentials: Dict[str, Any]) -> boto3.Session:
+def create_aws_session(credentials: Dict[str, Any]) -> Any:
     """
     Create a boto3 session with AWS credentials.
 
@@ -153,6 +150,8 @@ def create_aws_session(credentials: Dict[str, Any]) -> boto3.Session:
     Returns:
         boto3.Session: Configured boto3 session
     """
+    import boto3  # noqa: PLC0415 — lazy: boto3 is heavy (~166ms); only needed for IAM auth
+
     aws_access_key_id = credentials.get("aws_access_key_id") or credentials.get(
         "username"
     )
@@ -192,7 +191,7 @@ def get_cluster_credentials(
 def create_aws_client(
     service: str,
     region: str,
-    session: Optional[boto3.Session] = None,
+    session: Optional[Any] = None,
     temp_credentials: Optional[Dict[str, str]] = None,
     use_default_credentials: bool = False,
 ) -> Any:
@@ -255,6 +254,8 @@ def create_aws_client(
     if credential_sources > 1:
         raise ValueError("Only one credential source should be provided at a time")
 
+    import boto3  # noqa: PLC0415 — lazy: boto3 is heavy (~166ms); only needed for IAM auth
+
     try:
         # Priority 1: Use provided session
         if session is not None:
@@ -293,7 +294,7 @@ def create_engine_url(
     credentials: Dict[str, Any],
     cluster_credentials: Dict[str, str],
     extra: Dict[str, Any],
-) -> URL:
+) -> Any:
     """
     Create SQLAlchemy engine URL for Redshift connection.
 
@@ -304,6 +305,10 @@ def create_engine_url(
     Returns:
         URL: SQLAlchemy engine URL
     """
+    from sqlalchemy.engine.url import (  # noqa: PLC0415 — lazy: sqlalchemy is heavy (~170ms); only needed when building engine URLs
+        URL,
+    )
+
     host = credentials["host"]
     port = credentials.get("port")
     database = extra["database"]
@@ -326,6 +331,8 @@ def get_all_aws_regions() -> list[str]:
     Raises:
         Exception: If unable to retrieve regions from AWS
     """
+    import boto3  # noqa: PLC0415 — lazy: boto3 is heavy (~166ms); only needed for IAM auth
+
     try:
         # Use us-east-1 as the default region for the EC2 client since it's always available
         ec2_client = boto3.client("ec2", region_name="us-east-1")

--- a/application_sdk/common/file_converter.py
+++ b/application_sdk/common/file_converter.py
@@ -2,8 +2,6 @@ from collections import namedtuple
 from enum import Enum
 from typing import List, Optional
 
-import pandas as pd
-
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -74,6 +72,8 @@ async def convert_data_files(
 def convert_json_to_parquet(file_path: str) -> Optional[str]:
     """Convert the downloaded files from json to parquet"""
     try:
+        import pandas as pd  # noqa: PLC0415 — lazy: pandas is heavy (~450ms); only needed when converting files
+
         logger.info(f"Converting {file_path} to parquet")
         df = pd.read_json(file_path, orient="records", lines=True)
         df = df.loc[:, ~df.where(df.astype(bool)).isna().all(axis=0)]
@@ -89,6 +89,8 @@ def convert_json_to_parquet(file_path: str) -> Optional[str]:
 def convert_parquet_to_json(file_path: str) -> Optional[str]:
     """Convert the downloaded files from parquet to json"""
     try:
+        import pandas as pd  # noqa: PLC0415 — lazy: pandas is heavy (~450ms); only needed when converting files
+
         logger.info(f"Converting {file_path} to json")
         df = pd.read_parquet(file_path)
         json_file_path = file_path.replace(".parquet", ".json")

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -8,10 +8,6 @@ from typing import Any, Dict, Optional, Tuple
 
 from loguru import logger
 from opentelemetry._logs import LogRecord, SeverityNumber
-from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
-from opentelemetry.sdk._logs import LoggerProvider
-from opentelemetry.sdk._logs._internal.export import BatchLogRecordProcessor
-from opentelemetry.sdk.resources import Resource
 from opentelemetry.trace.span import TraceFlags
 from pydantic import BaseModel, Field
 
@@ -397,6 +393,13 @@ class AtlanLoggerAdapter(AtlanObservability[LogRecordModel]):
             otlp_processors = []
 
             if ENABLE_OTLP_LOGS:
+                from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (  # noqa: PLC0415 — lazy: grpc exporter is heavy (~177ms); only needed when ENABLE_OTLP_LOGS=true
+                    OTLPLogExporter,
+                )
+                from opentelemetry.sdk._logs._internal.export import (  # noqa: PLC0415 — lazy: paired with OTLPLogExporter
+                    BatchLogRecordProcessor,
+                )
+
                 otlp_processors.append(
                     BatchLogRecordProcessor(
                         OTLPLogExporter(
@@ -413,6 +416,13 @@ class AtlanLoggerAdapter(AtlanObservability[LogRecordModel]):
                 )
 
             if ENABLE_OTLP_WORKFLOW_LOGS and OTEL_WORKFLOW_LOGS_ENDPOINT:
+                from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (  # noqa: PLC0415 — lazy: grpc exporter is heavy (~177ms); only needed when ENABLE_OTLP_WORKFLOW_LOGS=true
+                    OTLPLogExporter,
+                )
+                from opentelemetry.sdk._logs._internal.export import (  # noqa: PLC0415 — lazy: paired with OTLPLogExporter
+                    BatchLogRecordProcessor,
+                )
+
                 otlp_processors.append(
                     BatchLogRecordProcessor(
                         OTLPLogExporter(
@@ -429,6 +439,13 @@ class AtlanLoggerAdapter(AtlanObservability[LogRecordModel]):
                 )
 
             if otlp_processors:
+                from opentelemetry.sdk._logs import (  # noqa: PLC0415 — lazy: only needed when OTLP logging is active
+                    LoggerProvider,
+                )
+                from opentelemetry.sdk.resources import (  # noqa: PLC0415 — lazy: only needed when OTLP logging is active
+                    Resource,
+                )
+
                 resource_attributes = {}
                 if OTEL_RESOURCE_ATTRIBUTES:
                     resource_attributes = self._parse_otel_resource_attributes(


### PR DESCRIPTION
## Summary

Reduces cold-start boot time for connector API servers running in SERVER mode.

**Root cause:** 2000+ Python modules imported eagerly at startup, costing ~17s on cold overlayfs (container filesystem). Many of these are only needed for WORKER mode (Temporal worker, pandas, boto3, daft).

**Measured impact (on markeznp25):**
- Python import time: 17s → 4s (4x faster)
- App startup (process start → uvicorn ready): 23s → 6s
- End-to-end KEDA cold start (cached node): 47.8s → 12s
- End-to-end KEDA cold start (fresh node): 47.8s → 37s (still limited by image pull)

## Changes

### Lazy imports
- **`common/file_converter.py`**: `import pandas` moved inside converter functions (~450ms cold)
- **`common/aws_utils.py`**: `import boto3` + `sqlalchemy.engine.url` moved inside functions — only needed for IAM auth
- **`observability/logger_adaptor.py`**: `OTLPLogExporter`, `BatchLogRecordProcessor`, `LoggerProvider`, `Resource` moved inside `if ENABLE_OTLP_LOGS:` blocks — default is false
- **`application/__init__.py`**: `Worker` and `get_workflow_client` (pulls full Temporal stack, ~678ms) lazy-loaded via `TYPE_CHECKING` guard and method-level imports

### Async Temporal connect (SERVER mode)
- **`clients/temporal.py`**: Added `_client_ready: asyncio.Event` + `_wait_for_client()` helper
- When `load()` fires as a background task, `start_workflow()` blocks gracefully until connected instead of crashing with `ValueError`

### CI
- **`build-image.yaml`**: Added `debug/boot-time` branch trigger with SHA-only image tag (no `latest`/version tags — zero impact on existing apps)

## Test plan
- [ ] Verify SERVER mode boots faster on a tenant
- [ ] Verify WORKER mode still works (lazy imports only skip in SERVER mode via `main.py` guard)
- [ ] Verify IAM auth connections still work (boto3 lazy)
- [ ] Verify OTLP log export works when `ENABLE_OTLP_LOGS=true`