### PR TITLE
chore(security): allowlist rustls-webpki transitive HIGH vuln

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -307,5 +307,12 @@
     "reason": "Connector transitive — lxml pulled in by redshift-connector (aws/amazon-redshift-python-driver). Fix is in lxml>=6.1.0, but redshift-connector 2.1.10 pins lxml<6.0.0 in its package metadata. Bumping lxml in connector apps forces a downgrade of redshift-connector to 2.1.7. Allowlisting until upstream relaxes the cap; tracking via aws/amazon-redshift-python-driver. Connector code uses lxml only for SOAP/XML parsing of trusted Redshift IAM responses, not untrusted input.",
     "expires": "2026-05-28",
     "added_by": "anuj-atlan"
+  },
+  "GHSA-82j2-j2ch-gfr8": {
+    "package": "rustls-webpki",
+    "severity": "HIGH",
+    "reason": "Base image — transitive Rust dep (rustls-webpki@0.103.4) in app-runtime-base:2.8.7-5. Fix available in 0.103.13; resolved upstream by future runtime-base bumps. Tracking via native-migration-app PR #22 (https://github.com/atlanhq/native-migration-app/pull/22) — base image bump to 2.8.7-5 cleared 7 of 8 sibling Go vulns; this is the residual.",
+    "expires": "2026-06-05",
+    "added_by": "sachi-atlan"
   }
 }


### PR DESCRIPTION
## Summary

Add a single allowlist entry (expires **2026-06-05**, 30 days) for `GHSA-82j2-j2ch-gfr8` — a HIGH-severity transitive Rust dep (`rustls-webpki@0.103.4`) in the SDK base image.

## Context

This is the residual single vuln after atlanhq/native-migration-app PR #22 (https://github.com/atlanhq/native-migration-app/pull/22) bumped its Docker base image to `registry.atlan.com/public/app-runtime-base:2.8.7-5`. That image carries patched dapr 1.17.5+ and otel 1.41.0+, which cleared 7 of the 8 Go HIGH findings originally surfaced by trivy/snyk:

| ID | Package | Status after base-image bump |
|---|---|---|
| `GHSA-82j2-j2ch-gfr8` | `rustls-webpki@0.103.4` -> 0.103.13 | **still present — this PR** |
| `CVE-2026-41491` | `github.com/dapr/dapr` 1.17.0 -> 1.17.5 | resolved |
| `CVE-2026-29181` | `go.opentelemetry.io/otel` 1.40.0 -> 1.41.0 | resolved |
| `SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGACL-16394931` | `github.com/dapr/dapr/pkg/acl` | resolved |
| `SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGACTORSTARGETSAPP-16394932` | `github.com/dapr/dapr/pkg/actors/targets/app` | resolved |
| `SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGAPIGRPC-16394933` | `github.com/dapr/dapr/pkg/api/grpc` | resolved |
| `SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGAPIHTTP-16394934` | `github.com/dapr/dapr/pkg/api/http` | resolved |
| `SNYK-GOLANG-GITHUBCOMDAPRDAPRPKGMESSAGING-16394937` | `github.com/dapr/dapr/pkg/messaging` | resolved |

This PR replaces the prior 8-entry batch in #1677 (closed) with just the single residual finding.

## Entry added

| ID | Package | Current -> Fixed | Expires |
|---|---|---|---|
| `GHSA-82j2-j2ch-gfr8` | `rustls-webpki` | 0.103.4 -> 0.103.13 | 2026-06-05 |

Will be removed once a future `app-runtime-base` bump pulls in rustls-webpki >= 0.103.13.

## Approval

Per `.security/README.md`, this PR requires CODEOWNERS approval from a `.security/approvers.json` owner. `sachi-atlan` is not in approvers.json.

## Validation

- `python3 .github/scripts/validate_allowlist.py` -> passes (44 entries, all within HIGH <= 30d / CRITICAL <= 15d policy)
- `uv run pre-commit run --files .security/base-allowlist.json` -> passes

## Test plan

- [ ] Allowlist validator green in CI
- [ ] CODEOWNERS approval from a `.security/approvers.json` owner
- [ ] After merge, re-run native-migration-app PR #22 trivy/snyk gate to confirm the residual finding is now allowlisted