### PR TITLE
fix(observability): restore secondary OTLP log exporter for S3 archival [ARUN-539]

### DIFF
--- a/application_sdk/common/env_warnings.py
+++ b/application_sdk/common/env_warnings.py
@@ -38,10 +38,6 @@ _REMOVED_ENV_VARS: frozenset[str] = frozenset(
         "ATLAN_TRACES_CLEANUP_ENABLED",
         "ATLAN_TRACES_FLUSH_INTERVAL_SECONDS",
         "ATLAN_TRACES_RETENTION_DAYS",
-        # Workflow-logs dual-export pipeline was removed; use the standard
-        # OTLP log endpoint instead.
-        "ENABLE_OTLP_WORKFLOW_LOGS",
-        "OTEL_WORKFLOW_LOGS_ENDPOINT",
         # CorrelationContextInterceptor was folded into LogInterceptor;
         # no longer toggleable.
         "APPLICATION_SDK_ENABLE_CORRELATION_INTERCEPTOR",

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -353,6 +353,14 @@ OTEL_EXPORTER_OTLP_ENDPOINT: str = os.getenv(
 )
 #: Whether to enable OpenTelemetry log export
 ENABLE_OTLP_LOGS: bool = os.getenv("ENABLE_OTLP_LOGS", "false").lower() == "true"
+#: Whether to enable a secondary OpenTelemetry log exporter for workflow-log
+#: archival (e.g. S3 sink). When true, logs are emitted to both the primary
+#: OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_WORKFLOW_LOGS_ENDPOINT.
+ENABLE_OTLP_WORKFLOW_LOGS: bool = (
+    os.getenv("ENABLE_OTLP_WORKFLOW_LOGS", "false").lower() == "true"
+)
+#: Endpoint for the secondary archival OTel collector
+OTEL_WORKFLOW_LOGS_ENDPOINT: str = os.getenv("OTEL_WORKFLOW_LOGS_ENDPOINT", "")
 
 # OTEL Constants
 #: Node name for workflow telemetry

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -16,6 +16,7 @@ from application_sdk.constants import (
     APPLICATION_NAME,
     ENABLE_OBSERVABILITY_STORE_SINK,
     ENABLE_OTLP_LOGS,
+    ENABLE_OTLP_WORKFLOW_LOGS,
     LOG_BATCH_SIZE,
     LOG_CLEANUP_ENABLED,
     LOG_FILE_NAME,
@@ -27,6 +28,7 @@ from application_sdk.constants import (
     OTEL_EXPORTER_OTLP_ENDPOINT,
     OTEL_EXPORTER_TIMEOUT_SECONDS,
     OTEL_QUEUE_SIZE,
+    OTEL_WORKFLOW_LOGS_ENDPOINT,
     SERVICE_NAME,
 )
 from application_sdk.observability.context import correlation_context, request_context
@@ -529,7 +531,9 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
                 except Exception:
                     logging.error("Failed to start flush task", exc_info=True)
 
-        # OTLP log export — single exporter to OTEL_EXPORTER_OTLP_ENDPOINT.
+        # OTLP log export — primary exporter to OTEL_EXPORTER_OTLP_ENDPOINT,
+        # plus an optional secondary exporter to OTEL_WORKFLOW_LOGS_ENDPOINT
+        # for archival pipelines (e.g. an OTel collector that writes to S3).
         try:
             otlp_processors = []
 
@@ -546,6 +550,23 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
                     )
                 )
                 logging.info("OTLP exporter enabled: %s", OTEL_EXPORTER_OTLP_ENDPOINT)
+
+            if ENABLE_OTLP_WORKFLOW_LOGS and OTEL_WORKFLOW_LOGS_ENDPOINT:
+                otlp_processors.append(
+                    BatchLogRecordProcessor(
+                        OTLPLogExporter(
+                            endpoint=OTEL_WORKFLOW_LOGS_ENDPOINT,
+                            timeout=OTEL_EXPORTER_TIMEOUT_SECONDS,
+                        ),
+                        schedule_delay_millis=OTEL_BATCH_DELAY_MS,
+                        max_export_batch_size=OTEL_BATCH_SIZE,
+                        max_queue_size=OTEL_QUEUE_SIZE,
+                    )
+                )
+                logging.info(
+                    "OTLP workflow logs exporter enabled: %s",
+                    OTEL_WORKFLOW_LOGS_ENDPOINT,
+                )
 
             if otlp_processors:
                 self.logger_provider = LoggerProvider(

--- a/docs/adr/0012-observability-consolidation.md
+++ b/docs/adr/0012-observability-consolidation.md
@@ -177,10 +177,17 @@ dev-workstation convenience and unused in production.
 `ATLAN_ENABLE_PROMETHEUS_METRICS` (renamed to
 `ATLAN_ENABLE_TEMPORAL_CORE_METRICS`), `ENABLE_OTLP_METRICS`,
 `ENABLE_OTLP_TRACES` (consolidated to `ATLAN_ENABLE_OTLP_TRACES`),
-`ENABLE_OTLP_WORKFLOW_LOGS`, `OTEL_WORKFLOW_LOGS_ENDPOINT`,
 `METRICS_*` (batch / flush / retention / cleanup),
 `TRACES_*` (batch / flush / retention / cleanup),
 `enable_correlation_interceptor`.
+
+**Retained:** `ENABLE_OTLP_WORKFLOW_LOGS` and `OTEL_WORKFLOW_LOGS_ENDPOINT`
+gate an optional secondary OTLP log exporter that ships logs to an
+archival collector (e.g. one writing to S3) in parallel with the
+primary `OTEL_EXPORTER_OTLP_ENDPOINT` pipeline. They were briefly
+removed in this consolidation but restored once we confirmed the
+production chart wires up an S3-archival collector that depends on
+this dual-export.
 
 **Added:**
 - `ATLAN_ENABLE_TEMPORAL_CORE_METRICS` (default `true`) — replaces

--- a/tests/unit/common/test_env_warnings.py
+++ b/tests/unit/common/test_env_warnings.py
@@ -54,7 +54,7 @@ class TestWarnRemovedEnvVars:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("ATLAN_ENABLE_APP_VITALS", "true")
-        monkeypatch.setenv("OTEL_WORKFLOW_LOGS_ENDPOINT", "http://x")
+        monkeypatch.setenv("ATLAN_ENABLE_OTLP_METRICS", "http://x")
         monkeypatch.setenv("ATLAN_TRACES_BATCH_SIZE", "100")
         ctx, mock_logger = self._patch_logger()
         with ctx:
@@ -62,22 +62,22 @@ class TestWarnRemovedEnvVars:
 
         msg = self._formatted_message(mock_logger)
         assert "ATLAN_ENABLE_APP_VITALS" in msg
-        assert "OTEL_WORKFLOW_LOGS_ENDPOINT" in msg
+        assert "ATLAN_ENABLE_OTLP_METRICS" in msg
         assert "ATLAN_TRACES_BATCH_SIZE" in msg
 
     def test_warning_lists_vars_alphabetically_for_stable_output(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("OTEL_WORKFLOW_LOGS_ENDPOINT", "http://x")
+        monkeypatch.setenv("ATLAN_ENABLE_OTLP_METRICS", "http://x")
         monkeypatch.setenv("ATLAN_ENABLE_APP_VITALS", "true")
         ctx, mock_logger = self._patch_logger()
         with ctx:
             warn_removed_env_vars()
 
         msg = self._formatted_message(mock_logger)
-        # Sorted: ATLAN_ENABLE_APP_VITALS comes before OTEL_WORKFLOW_LOGS_ENDPOINT.
+        # Sorted: ATLAN_ENABLE_APP_VITALS comes before ATLAN_ENABLE_OTLP_METRICS.
         assert msg.index("ATLAN_ENABLE_APP_VITALS") < msg.index(
-            "OTEL_WORKFLOW_LOGS_ENDPOINT"
+            "ATLAN_ENABLE_OTLP_METRICS"
         )
 
     def test_empty_string_value_does_not_trigger_warning(

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -1860,38 +1860,50 @@ class TestSecondaryWorkflowLogsExporter:
             AtlanLoggerAdapter("test_dual_export")
             return mock_exporter
 
+    # Sentinel endpoint identifiers — not URLs. The SDK never opens a
+    # network connection in tests (OTLPLogExporter is mocked), so any
+    # opaque string works for distinguishing the two exporter calls.
+    # Using non-URL sentinels also keeps CodeQL's URL-substring rule from
+    # flagging exact-equality assertions as substring sanitization issues.
+    PRIMARY_SENTINEL = "test-primary-endpoint"
+    SECONDARY_SENTINEL = "test-secondary-endpoint"
+
+    @staticmethod
+    def _endpoints_passed_to_exporter(mock_exporter) -> list[str]:
+        return [call.kwargs["endpoint"] for call in mock_exporter.call_args_list]
+
     def test_dual_export_when_both_endpoints_configured(self):
         """Both primary and secondary OTLPLogExporter instances should be
         constructed when ENABLE_OTLP_WORKFLOW_LOGS=true and the workflow-logs
         endpoint is set."""
         mock_exporter = self._build_with_endpoints(
-            primary="https://otel.example.com:4317",
+            primary=self.PRIMARY_SENTINEL,
             secondary_enabled=True,
-            secondary_endpoint="http://workflow-logs-collector.example.svc:4317",
+            secondary_endpoint=self.SECONDARY_SENTINEL,
         )
-        endpoints = {call.kwargs["endpoint"] for call in mock_exporter.call_args_list}
-        assert "https://otel.example.com:4317" in endpoints
-        assert "http://workflow-logs-collector.example.svc:4317" in endpoints
+        endpoints = self._endpoints_passed_to_exporter(mock_exporter)
+        assert endpoints.count(self.PRIMARY_SENTINEL) == 1
+        assert endpoints.count(self.SECONDARY_SENTINEL) == 1
 
     def test_secondary_skipped_when_flag_false(self):
         """Secondary exporter must not be constructed when the flag is off,
         even if the workflow-logs endpoint is set."""
         mock_exporter = self._build_with_endpoints(
-            primary="https://otel.example.com:4317",
+            primary=self.PRIMARY_SENTINEL,
             secondary_enabled=False,
-            secondary_endpoint="http://workflow-logs-collector.example.svc:4317",
+            secondary_endpoint=self.SECONDARY_SENTINEL,
         )
-        endpoints = {call.kwargs["endpoint"] for call in mock_exporter.call_args_list}
-        assert "http://workflow-logs-collector.example.svc:4317" not in endpoints
+        endpoints = self._endpoints_passed_to_exporter(mock_exporter)
+        assert endpoints.count(self.SECONDARY_SENTINEL) == 0
 
     def test_secondary_skipped_when_endpoint_blank(self):
         """Secondary exporter must not be constructed when the endpoint is
         blank, even if the flag is on (defensive: avoids gRPC bootstrap with
         an empty target)."""
         mock_exporter = self._build_with_endpoints(
-            primary="https://otel.example.com:4317",
+            primary=self.PRIMARY_SENTINEL,
             secondary_enabled=True,
             secondary_endpoint="",
         )
-        endpoints = {call.kwargs["endpoint"] for call in mock_exporter.call_args_list}
+        endpoints = self._endpoints_passed_to_exporter(mock_exporter)
         assert "" not in endpoints

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -1806,3 +1806,92 @@ class TestInterceptHandlerStdlibBridge:
         bind_kwargs = mock_log.opt.return_value.bind.call_args.kwargs
         # Only the SDK-injected key, no spurious built-in record fields.
         assert bind_kwargs == {"logger_name": "vanilla"}
+
+
+class TestSecondaryWorkflowLogsExporter:
+    """The secondary OTLP log exporter sits behind ENABLE_OTLP_WORKFLOW_LOGS +
+    OTEL_WORKFLOW_LOGS_ENDPOINT and fans logs out to a second collector
+    (production wires this to an OTel collector that archives to S3).
+    """
+
+    def _build_with_endpoints(
+        self,
+        *,
+        primary: str,
+        secondary_enabled: bool,
+        secondary_endpoint: str,
+    ):
+        """Construct an adapter with the given primary/secondary endpoints
+        and return the OTLPLogExporter mock so callers can inspect calls."""
+        AtlanLoggerAdapter._reset_for_testing()
+        env = {
+            "LOG_LEVEL": "INFO",
+            "ENABLE_OTLP_LOGS": "true",
+            "OTEL_EXPORTER_OTLP_ENDPOINT": primary,
+            "ENABLE_OTLP_WORKFLOW_LOGS": "true" if secondary_enabled else "false",
+            "OTEL_WORKFLOW_LOGS_ENDPOINT": secondary_endpoint,
+        }
+        with (
+            mock.patch.dict("os.environ", env),
+            mock.patch(
+                "application_sdk.observability.logger_adaptor.ENABLE_OTLP_LOGS",
+                True,
+            ),
+            mock.patch(
+                "application_sdk.observability.logger_adaptor.OTEL_EXPORTER_OTLP_ENDPOINT",
+                primary,
+            ),
+            mock.patch(
+                "application_sdk.observability.logger_adaptor.ENABLE_OTLP_WORKFLOW_LOGS",
+                secondary_enabled,
+            ),
+            mock.patch(
+                "application_sdk.observability.logger_adaptor.OTEL_WORKFLOW_LOGS_ENDPOINT",
+                secondary_endpoint,
+            ),
+            mock.patch(
+                "application_sdk.observability.logger_adaptor.OTLPLogExporter"
+            ) as mock_exporter,
+            mock.patch(
+                "application_sdk.observability.logger_adaptor.BatchLogRecordProcessor"
+            ),
+            mock.patch("application_sdk.observability.logger_adaptor.LoggerProvider"),
+        ):
+            AtlanLoggerAdapter("test_dual_export")
+            return mock_exporter
+
+    def test_dual_export_when_both_endpoints_configured(self):
+        """Both primary and secondary OTLPLogExporter instances should be
+        constructed when ENABLE_OTLP_WORKFLOW_LOGS=true and the workflow-logs
+        endpoint is set."""
+        mock_exporter = self._build_with_endpoints(
+            primary="https://otel.example.com:4317",
+            secondary_enabled=True,
+            secondary_endpoint="http://workflow-logs-collector.example.svc:4317",
+        )
+        endpoints = {call.kwargs["endpoint"] for call in mock_exporter.call_args_list}
+        assert "https://otel.example.com:4317" in endpoints
+        assert "http://workflow-logs-collector.example.svc:4317" in endpoints
+
+    def test_secondary_skipped_when_flag_false(self):
+        """Secondary exporter must not be constructed when the flag is off,
+        even if the workflow-logs endpoint is set."""
+        mock_exporter = self._build_with_endpoints(
+            primary="https://otel.example.com:4317",
+            secondary_enabled=False,
+            secondary_endpoint="http://workflow-logs-collector.example.svc:4317",
+        )
+        endpoints = {call.kwargs["endpoint"] for call in mock_exporter.call_args_list}
+        assert "http://workflow-logs-collector.example.svc:4317" not in endpoints
+
+    def test_secondary_skipped_when_endpoint_blank(self):
+        """Secondary exporter must not be constructed when the endpoint is
+        blank, even if the flag is on (defensive: avoids gRPC bootstrap with
+        an empty target)."""
+        mock_exporter = self._build_with_endpoints(
+            primary="https://otel.example.com:4317",
+            secondary_enabled=True,
+            secondary_endpoint="",
+        )
+        endpoints = {call.kwargs["endpoint"] for call in mock_exporter.call_args_list}
+        assert "" not in endpoints


### PR DESCRIPTION
## Summary

PR #1573's observability consolidation swept `ENABLE_OTLP_WORKFLOW_LOGS` and `OTEL_WORKFLOW_LOGS_ENDPOINT` on the assumption that a single OTLP log endpoint was sufficient. The production chart (`atlanhq/atlan/subcharts/atlan-app/templates/deployment.yaml`) wires both vars to a tenant-side OTel collector that ships logs to S3 in parallel with the central log pipeline — without the secondary exporter, that archival sink silently stops receiving data.

This restores the secondary `BatchLogRecordProcessor` on the same `LoggerProvider`, gated on both the flag and a non-empty endpoint. The primary export to `OTEL_EXPORTER_OTLP_ENDPOINT` is unchanged.

- Re-add `ENABLE_OTLP_WORKFLOW_LOGS` / `OTEL_WORKFLOW_LOGS_ENDPOINT` in `application_sdk/constants.py`.
- Re-add the secondary `BatchLogRecordProcessor` block in `application_sdk/observability/logger_adaptor.py` and import the two constants.
- Drop both vars from `_REMOVED_ENV_VARS` so the startup warning no longer fires for valid configurations that still set these.
- Document the retention in `docs/adr/0012-observability-consolidation.md`.
- Cover the wiring in `TestSecondaryWorkflowLogsExporter` (three cases: both endpoints set, flag false, endpoint blank).

## Test plan

- [x] `uv run pytest tests/unit/observability/test_logger_adaptor.py tests/unit/common/` — 451 passed.
- [x] `uv run pre-commit run --files <touched>` — clean.
- [ ] Once merged, cut a 3.6.1 patch release so charts setting the workflow-logs vars start exporting again.