### PR TITLE
ci(sdr): pin Temporal + auth hosts to IPv4 to fix temporalio 1.27 IPv6 fallback

### DIFF
--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -184,6 +184,43 @@ runs:
         # are simple paths, no whitespace issues).
         echo "files=${FILES[*]}" >> "$GITHUB_OUTPUT"
 
+    # GH-runner docker bridges have no global IPv6 routing, but
+    # temporalio's bundled Rust gRPC resolver returns AAAA records and
+    # tries them first. With temporalio 1.27.x, the IPv6 → IPv4 fallback
+    # doesn't fit inside the container-health timeout and the worker
+    # never finishes connecting. Resolve the Temporal + auth hostnames
+    # to IPv4 on the runner (which has working IPv4) and inject them
+    # into /etc/hosts via compose extra_hosts so the resolver only ever
+    # sees A records.
+    #
+    # Hostnames are derived from CI_TENANT_DOMAIN
+    # (convention: <tenant>.atlan.com → <tenant>-temporal.atlan.com).
+    - name: Resolve Temporal + auth hostnames to IPv4
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -z "${CI_TENANT_DOMAIN:-}" ]; then
+          echo "::error::CI_TENANT_DOMAIN is not set; the caller workflow must export it as a job-level env var."
+          exit 1
+        fi
+        AUTH_HOST="$CI_TENANT_DOMAIN"
+        TEMPORAL_HOST="${CI_TENANT_DOMAIN%.atlan.com}-temporal.atlan.com"
+        AUTH_IPV4=$(dig +short A "$AUTH_HOST" | head -1)
+        TEMPORAL_IPV4=$(dig +short A "$TEMPORAL_HOST" | head -1)
+        if [ -z "$AUTH_IPV4" ] || [ -z "$TEMPORAL_IPV4" ]; then
+          echo "::error::Failed to resolve TEMPORAL_HOST=$TEMPORAL_HOST or AUTH_HOST=$AUTH_HOST"
+          exit 1
+        fi
+        echo "Resolved $AUTH_HOST -> $AUTH_IPV4"
+        echo "Resolved $TEMPORAL_HOST -> $TEMPORAL_IPV4"
+        # Export for compose extra_hosts substitution.
+        {
+          echo "AUTH_HOST=$AUTH_HOST"
+          echo "AUTH_IPV4=$AUTH_IPV4"
+          echo "TEMPORAL_HOST=$TEMPORAL_HOST"
+          echo "TEMPORAL_IPV4=$TEMPORAL_IPV4"
+        } >> "$GITHUB_ENV"
+
     - name: Start SDR container
       shell: bash
       run: docker compose ${{ steps.compose_files.outputs.files }} up -d

--- a/.github/actions/sdr-e2e/docker-compose.ci.yml
+++ b/.github/actions/sdr-e2e/docker-compose.ci.yml
@@ -23,6 +23,14 @@ services:
     # Ensure CWD is /app so that Path("./components") in create_store_from_binding
     # resolves to /app/components (the bind-mounted Dapr components directory).
     working_dir: /app
+    # Pin Temporal + auth hostnames to IPv4 so the bundled Rust gRPC
+    # resolver in temporalio 1.27.x doesn't try AAAA records the
+    # GH-runner docker bridge can't reach. The composite action's
+    # "Resolve Temporal + auth hostnames to IPv4" step exports
+    # TEMPORAL_HOST/IPV4 + AUTH_HOST/IPV4 for the substitution below.
+    extra_hosts:
+      - "${TEMPORAL_HOST}:${TEMPORAL_IPV4}"
+      - "${AUTH_HOST}:${AUTH_IPV4}"
     # Mount CI-generated secrets file for the local.file Dapr secret store.
     volumes:
       - ${GITHUB_WORKSPACE}/.github/e2e/secrets:/app/secrets:ro

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.6.0
-source-sha:    6d866f18ec7ead285faf0f7df85f570e2a74cca9
-source-date:   2026-05-06T12:53:53+01:00
+sdk-version:   3.6.1
+source-sha:    8482d576282b97fbbe784ffb43b840dc743cab48
+source-date:   2026-05-06T18:31:17+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 


### PR DESCRIPTION
## Summary

GitHub-hosted runners' docker bridges have no global IPv6 routing, but temporalio's bundled Rust gRPC resolver returns AAAA records for Cloudflare-fronted hostnames and tries them first. With temporalio 1.27.x the IPv6→IPv4 fallback doesn't fit inside the 180s container-health timeout, so the SDR worker never finishes connecting and the container fails health checks.

This PR bypasses the resolver: a new step in the SDR composite action resolves the Temporal + auth hostnames to IPv4 on the runner (which has working IPv4), and the SDK's compose layer injects those via `extra_hosts` so the container's `/etc/hosts` short-circuits the AAAA lookups.

Hostnames are derived from `CI_TENANT_DOMAIN` (convention: `<tenant>.atlan.com` → `<tenant>-temporal.atlan.com`).

## Knock-on benefits

- Apps can now safely use temporalio 1.27.0 → clears `GHSA-82j2-j2ch-gfr8` / `rustls-webpki@0.103.10` (HIGH) which is bundled in temporalio 1.26.x's Rust core.
- Validated on [`atlanhq/atlan-saperp-app#75`](https://github.com/atlanhq/atlan-saperp-app/pull/75): container starts within timeout, both ECC + S4 suites run end-to-end on temporalio 1.27.0.

## Test plan

- [ ] `atlanhq/atlan-mssql-app#118` re-run with the new SDK pin → all 10 scenarios green
- [ ] `atlanhq/atlan-saperp-app#75` re-run with the new SDK pin → ECC suite green, S4 surface its known instance issue cleanly