### PR TITLE
chore(security): extend daily scan to cover SDK Python deps

### DIFF
--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -105,7 +105,7 @@ jobs:
         id: parse
         run: |
           count_trivy_file() { jq "[.Results[]?.Vulnerabilities[]? | select(.Severity == \"$2\")] | length" "$1" 2>/dev/null || echo 0; }
-          count_snyk_file()  { jq "[.vulnerabilities[]? | select(.severity == \"$2\")] | length" "$1"  2>/dev/null || echo 0; }
+          count_snyk_file()  { jq "[.vulnerabilities[]? | select(.severity == \"$2\") | select((.type // \"vuln\") != \"license\")] | length" "$1" 2>/dev/null || echo 0; }
 
           TI_CRIT=0; TI_HIGH=0; TI_MED=0; TI_LOW=0
           TF_CRIT=0; TF_HIGH=0; TF_MED=0; TF_LOW=0

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -75,7 +75,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Export Python deps for Snyk
-        run: uv export --format requirements-txt --no-dev --frozen --output-file=/tmp/snyk-requirements.txt
+        run: uv export --format requirements-txt --no-dev --frozen --no-hashes --output-file=/tmp/snyk-requirements.txt
 
       - name: Run Snyk Python deps scan (pyproject.toml / uv.lock)
         env:

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -74,8 +74,10 @@ jobs:
       - name: Set up uv (for Snyk Python dep resolution)
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
-      - name: Export requirements for Snyk
+      - name: Install Python deps and export requirements for Snyk
         run: |
+          uv sync --no-dev --frozen
+          uv pip install pip
           uv export --format requirements-txt --no-dev --frozen --no-hashes --no-emit-project --output-file=/tmp/snyk-requirements.txt
 
       - name: Run Snyk Python deps scan (pyproject.toml / uv.lock)
@@ -86,6 +88,7 @@ jobs:
           snyk test \
             --file=/tmp/snyk-requirements.txt \
             --package-manager=pip \
+            --command=.venv/bin/python3 \
             --severity-threshold=low \
             --org=bu-apps \
             --json-file-output=snyk-python-results.json || true

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -1,4 +1,4 @@
-name: Daily Security Scan — app-runtime-base
+name: Daily Security Scan — app-runtime-base + SDK Python Deps
 
 on:
   schedule:
@@ -13,14 +13,17 @@ env:
 
 jobs:
   scan-and-ticket:
-    name: Scan app-runtime-base:3 for vulnerabilities and raise alerts
+    name: Scan app-runtime-base:3 and SDK Python deps for vulnerabilities
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
       - name: Pull target image
         run: docker pull "$TARGET_IMAGE"
 
-      # ── Trivy scan (all severities for full picture) ──────────────────────
+      # ── Trivy image scan ──────────────────────────────────────────────────
 
       - name: Trivy image scan (JSON)
         uses: aquasecurity/trivy-action@0.35.0
@@ -29,14 +32,31 @@ jobs:
           scanners: vuln
           ignore-unfixed: true
           format: json
-          output: trivy-results.json
+          output: trivy-image-results.json
           severity: CRITICAL,HIGH,MEDIUM,LOW
           exit-code: '0'
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
 
-      # ── Snyk scan (all severities) ────────────────────────────────────────
+      # ── Trivy filesystem scan (uv.lock / pyproject.toml) ─────────────────
+
+      - name: Trivy filesystem scan (uv.lock / pyproject.toml)
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln
+          ignore-unfixed: true
+          format: json
+          output: trivy-fs-results.json
+          severity: CRITICAL,HIGH,MEDIUM,LOW
+          exit-code: '0'
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
+
+      # ── Snyk scans ────────────────────────────────────────────────────────
 
       - name: Set up Snyk CLI
         uses: snyk/actions/setup@b98d498629f1c368650224d6d212bf7dfa89e4bf # 0.4.0
@@ -49,78 +69,136 @@ jobs:
           snyk container test "$TARGET_IMAGE" \
             --severity-threshold=low \
             --org=partner-images \
-            --json-file-output=snyk-results.json || true
+            --json-file-output=snyk-image-results.json || true
+
+      - name: Run Snyk Python deps scan (pyproject.toml / uv.lock)
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_API: https://api.us.snyk.io
+        run: |
+          snyk test \
+            --severity-threshold=low \
+            --org=partner-images \
+            --json-file-output=snyk-python-results.json || true
 
       # ── Parse results ─────────────────────────────────────────────────────
 
       - name: Parse scan results
         id: parse
         run: |
-          count_trivy() { jq "[.Results[]?.Vulnerabilities[]? | select(.Severity == \"$1\")] | length" trivy-results.json 2>/dev/null || echo 0; }
-          count_snyk()  { jq "[.vulnerabilities[]? | select(.severity == \"$1\")] | length" snyk-results.json  2>/dev/null || echo 0; }
+          count_trivy_file() { jq "[.Results[]?.Vulnerabilities[]? | select(.Severity == \"$2\")] | length" "$1" 2>/dev/null || echo 0; }
+          count_snyk_file()  { jq "[.vulnerabilities[]? | select(.severity == \"$2\")] | length" "$1"  2>/dev/null || echo 0; }
 
-          T_CRIT=0; T_HIGH=0; T_MED=0; T_LOW=0
-          S_CRIT=0; S_HIGH=0; S_MED=0; S_LOW=0
+          TI_CRIT=0; TI_HIGH=0; TI_MED=0; TI_LOW=0
+          TF_CRIT=0; TF_HIGH=0; TF_MED=0; TF_LOW=0
+          SI_CRIT=0; SI_HIGH=0; SI_MED=0; SI_LOW=0
+          SP_CRIT=0; SP_HIGH=0; SP_MED=0; SP_LOW=0
 
-          if [ -f trivy-results.json ]; then
-            T_CRIT=$(count_trivy CRITICAL)
-            T_HIGH=$(count_trivy HIGH)
-            T_MED=$(count_trivy  MEDIUM)
-            T_LOW=$(count_trivy  LOW)
+          if [ -f trivy-image-results.json ]; then
+            TI_CRIT=$(count_trivy_file trivy-image-results.json CRITICAL)
+            TI_HIGH=$(count_trivy_file trivy-image-results.json HIGH)
+            TI_MED=$(count_trivy_file  trivy-image-results.json MEDIUM)
+            TI_LOW=$(count_trivy_file  trivy-image-results.json LOW)
           fi
 
-          if [ -f snyk-results.json ]; then
-            S_CRIT=$(count_snyk critical)
-            S_HIGH=$(count_snyk high)
-            S_MED=$(count_snyk  medium)
-            S_LOW=$(count_snyk  low)
+          if [ -f trivy-fs-results.json ]; then
+            TF_CRIT=$(count_trivy_file trivy-fs-results.json CRITICAL)
+            TF_HIGH=$(count_trivy_file trivy-fs-results.json HIGH)
+            TF_MED=$(count_trivy_file  trivy-fs-results.json MEDIUM)
+            TF_LOW=$(count_trivy_file  trivy-fs-results.json LOW)
           fi
 
-          TOTAL_CRIT=$((T_CRIT + S_CRIT))
-          TOTAL_HIGH=$((T_HIGH + S_HIGH))
-          TOTAL_MED=$((T_MED  + S_MED))
-          TOTAL_LOW=$((T_LOW  + S_LOW))
+          if [ -f snyk-image-results.json ]; then
+            SI_CRIT=$(count_snyk_file snyk-image-results.json critical)
+            SI_HIGH=$(count_snyk_file snyk-image-results.json high)
+            SI_MED=$(count_snyk_file  snyk-image-results.json medium)
+            SI_LOW=$(count_snyk_file  snyk-image-results.json low)
+          fi
+
+          if [ -f snyk-python-results.json ]; then
+            SP_CRIT=$(count_snyk_file snyk-python-results.json critical)
+            SP_HIGH=$(count_snyk_file snyk-python-results.json high)
+            SP_MED=$(count_snyk_file  snyk-python-results.json medium)
+            SP_LOW=$(count_snyk_file  snyk-python-results.json low)
+          fi
+
+          TOTAL_CRIT=$((TI_CRIT + TF_CRIT + SI_CRIT + SP_CRIT))
+          TOTAL_HIGH=$((TI_HIGH + TF_HIGH + SI_HIGH + SP_HIGH))
+          TOTAL_MED=$((TI_MED  + TF_MED  + SI_MED  + SP_MED))
+          TOTAL_LOW=$((TI_LOW  + TF_LOW  + SI_LOW  + SP_LOW))
           TOTAL_ACTIONABLE=$((TOTAL_CRIT + TOTAL_HIGH))
 
-          echo "t_crit=$T_CRIT"   >> "$GITHUB_OUTPUT"
-          echo "t_high=$T_HIGH"   >> "$GITHUB_OUTPUT"
-          echo "t_med=$T_MED"     >> "$GITHUB_OUTPUT"
-          echo "t_low=$T_LOW"     >> "$GITHUB_OUTPUT"
-          echo "s_crit=$S_CRIT"   >> "$GITHUB_OUTPUT"
-          echo "s_high=$S_HIGH"   >> "$GITHUB_OUTPUT"
-          echo "s_med=$S_MED"     >> "$GITHUB_OUTPUT"
-          echo "s_low=$S_LOW"     >> "$GITHUB_OUTPUT"
-          echo "total_crit=$TOTAL_CRIT"           >> "$GITHUB_OUTPUT"
-          echo "total_high=$TOTAL_HIGH"           >> "$GITHUB_OUTPUT"
-          echo "total_med=$TOTAL_MED"             >> "$GITHUB_OUTPUT"
-          echo "total_low=$TOTAL_LOW"             >> "$GITHUB_OUTPUT"
+          echo "ti_crit=$TI_CRIT" >> "$GITHUB_OUTPUT"
+          echo "ti_high=$TI_HIGH" >> "$GITHUB_OUTPUT"
+          echo "ti_med=$TI_MED"   >> "$GITHUB_OUTPUT"
+          echo "ti_low=$TI_LOW"   >> "$GITHUB_OUTPUT"
+          echo "tf_crit=$TF_CRIT" >> "$GITHUB_OUTPUT"
+          echo "tf_high=$TF_HIGH" >> "$GITHUB_OUTPUT"
+          echo "tf_med=$TF_MED"   >> "$GITHUB_OUTPUT"
+          echo "tf_low=$TF_LOW"   >> "$GITHUB_OUTPUT"
+          echo "si_crit=$SI_CRIT" >> "$GITHUB_OUTPUT"
+          echo "si_high=$SI_HIGH" >> "$GITHUB_OUTPUT"
+          echo "si_med=$SI_MED"   >> "$GITHUB_OUTPUT"
+          echo "si_low=$SI_LOW"   >> "$GITHUB_OUTPUT"
+          echo "sp_crit=$SP_CRIT" >> "$GITHUB_OUTPUT"
+          echo "sp_high=$SP_HIGH" >> "$GITHUB_OUTPUT"
+          echo "sp_med=$SP_MED"   >> "$GITHUB_OUTPUT"
+          echo "sp_low=$SP_LOW"   >> "$GITHUB_OUTPUT"
+          echo "total_crit=$TOTAL_CRIT"             >> "$GITHUB_OUTPUT"
+          echo "total_high=$TOTAL_HIGH"             >> "$GITHUB_OUTPUT"
+          echo "total_med=$TOTAL_MED"               >> "$GITHUB_OUTPUT"
+          echo "total_low=$TOTAL_LOW"               >> "$GITHUB_OUTPUT"
           echo "total_actionable=$TOTAL_ACTIONABLE" >> "$GITHUB_OUTPUT"
 
           if [ "$TOTAL_ACTIONABLE" -gt 0 ]; then
             {
               echo 'vuln_detail<<VULN_EOF'
 
-              if [ "$((T_CRIT + T_HIGH))" -gt 0 ]; then
-                echo "### Trivy — CRITICAL/HIGH"
+              if [ "$((TI_CRIT + TI_HIGH))" -gt 0 ]; then
+                echo "### Trivy — Image CRITICAL/HIGH"
                 echo ""
                 echo "| Severity | Package | Installed | Fixed | CVE |"
                 echo "|----------|---------|-----------|-------|-----|"
                 jq -r '.Results[]?.Vulnerabilities[]?
                   | select(.Severity == "CRITICAL" or .Severity == "HIGH")
                   | "| \(.Severity) | \(.PkgName) | \(.InstalledVersion) | \(.FixedVersion // "N/A") | \(.VulnerabilityID) |"' \
-                  trivy-results.json | sort -t'|' -k2,2 | head -50
+                  trivy-image-results.json | sort -t'|' -k2,2 | head -50
                 echo ""
               fi
 
-              if [ "$((S_CRIT + S_HIGH))" -gt 0 ]; then
-                echo "### Snyk — CRITICAL/HIGH"
+              if [ "$((TF_CRIT + TF_HIGH))" -gt 0 ]; then
+                echo "### Trivy — Python Deps CRITICAL/HIGH"
+                echo ""
+                echo "| Severity | Package | Installed | Fixed | CVE |"
+                echo "|----------|---------|-----------|-------|-----|"
+                jq -r '.Results[]?.Vulnerabilities[]?
+                  | select(.Severity == "CRITICAL" or .Severity == "HIGH")
+                  | "| \(.Severity) | \(.PkgName) | \(.InstalledVersion) | \(.FixedVersion // "N/A") | \(.VulnerabilityID) |"' \
+                  trivy-fs-results.json | sort -t'|' -k2,2 | head -50
+                echo ""
+              fi
+
+              if [ "$((SI_CRIT + SI_HIGH))" -gt 0 ]; then
+                echo "### Snyk — Image CRITICAL/HIGH"
                 echo ""
                 echo "| Severity | Package | Version | CVE |"
                 echo "|----------|---------|---------|-----|"
                 jq -r '.vulnerabilities[]?
                   | select(.severity == "critical" or .severity == "high")
                   | "| \(.severity) | \(.packageName) | \(.version // "N/A") | \(.id) |"' \
-                  snyk-results.json | sort -t'|' -k2,2 | head -50
+                  snyk-image-results.json | sort -t'|' -k2,2 | head -50
+                echo ""
+              fi
+
+              if [ "$((SP_CRIT + SP_HIGH))" -gt 0 ]; then
+                echo "### Snyk — Python Deps CRITICAL/HIGH"
+                echo ""
+                echo "| Severity | Package | Version | CVE |"
+                echo "|----------|---------|---------|-----|"
+                jq -r '.vulnerabilities[]?
+                  | select(.severity == "critical" or .severity == "high")
+                  | "| \(.severity) | \(.packageName) | \(.version // "N/A") | \(.id) |"' \
+                  snyk-python-results.json | sort -t'|' -k2,2 | head -50
                 echo ""
               fi
 
@@ -128,8 +206,10 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
-          echo "Trivy  — C:$T_CRIT H:$T_HIGH M:$T_MED L:$T_LOW"
-          echo "Snyk   — C:$S_CRIT H:$S_HIGH M:$S_MED L:$S_LOW"
+          echo "Trivy Image  — C:$TI_CRIT H:$TI_HIGH M:$TI_MED L:$TI_LOW"
+          echo "Trivy Python — C:$TF_CRIT H:$TF_HIGH M:$TF_MED L:$TF_LOW"
+          echo "Snyk  Image  — C:$SI_CRIT H:$SI_HIGH M:$SI_MED L:$SI_LOW"
+          echo "Snyk  Python — C:$SP_CRIT H:$SP_HIGH M:$SP_MED L:$SP_LOW"
           echo "Actionable (C+H): $TOTAL_ACTIONABLE"
 
       # ── Workflow summary ──────────────────────────────────────────────────
@@ -138,16 +218,16 @@ jobs:
         if: always()
         run: |
           {
-            echo "## Daily Security Scan — \`$TARGET_IMAGE\`"
+            echo "## Daily Security Scan — \`$TARGET_IMAGE\` + SDK Python Deps"
             echo ""
             echo "### Vulnerability Summary"
             echo ""
-            echo "| Severity | Trivy | Snyk | Total |"
-            echo "|----------|------:|-----:|------:|"
-            echo "| 🔴 Critical | ${{ steps.parse.outputs.t_crit || 0 }} | ${{ steps.parse.outputs.s_crit || 0 }} | **${{ steps.parse.outputs.total_crit || 0 }}** |"
-            echo "| 🟠 High     | ${{ steps.parse.outputs.t_high || 0 }} | ${{ steps.parse.outputs.s_high || 0 }} | **${{ steps.parse.outputs.total_high || 0 }}** |"
-            echo "| 🟡 Medium   | ${{ steps.parse.outputs.t_med  || 0 }} | ${{ steps.parse.outputs.s_med  || 0 }} | **${{ steps.parse.outputs.total_med  || 0 }}** |"
-            echo "| 🔵 Low      | ${{ steps.parse.outputs.t_low  || 0 }} | ${{ steps.parse.outputs.s_low  || 0 }} | **${{ steps.parse.outputs.total_low  || 0 }}** |"
+            echo "| Severity | Trivy (Image) | Trivy (Python) | Snyk (Image) | Snyk (Python) | Total |"
+            echo "|----------|:-------------:|:--------------:|:------------:|:-------------:|------:|"
+            echo "| 🔴 Critical | ${{ steps.parse.outputs.ti_crit || 0 }} | ${{ steps.parse.outputs.tf_crit || 0 }} | ${{ steps.parse.outputs.si_crit || 0 }} | ${{ steps.parse.outputs.sp_crit || 0 }} | **${{ steps.parse.outputs.total_crit || 0 }}** |"
+            echo "| 🟠 High     | ${{ steps.parse.outputs.ti_high || 0 }} | ${{ steps.parse.outputs.tf_high || 0 }} | ${{ steps.parse.outputs.si_high || 0 }} | ${{ steps.parse.outputs.sp_high || 0 }} | **${{ steps.parse.outputs.total_high || 0 }}** |"
+            echo "| 🟡 Medium   | ${{ steps.parse.outputs.ti_med  || 0 }} | ${{ steps.parse.outputs.tf_med  || 0 }} | ${{ steps.parse.outputs.si_med  || 0 }} | ${{ steps.parse.outputs.sp_med  || 0 }} | **${{ steps.parse.outputs.total_med  || 0 }}** |"
+            echo "| 🔵 Low      | ${{ steps.parse.outputs.ti_low  || 0 }} | ${{ steps.parse.outputs.tf_low  || 0 }} | ${{ steps.parse.outputs.si_low  || 0 }} | ${{ steps.parse.outputs.sp_low  || 0 }} | **${{ steps.parse.outputs.total_low  || 0 }}** |"
             echo ""
             if [ "${{ steps.parse.outputs.total_actionable || 0 }}" -gt 0 ]; then
               echo "> ⚠️ **${{ steps.parse.outputs.total_actionable }} CRITICAL/HIGH findings — Linear issue created**"
@@ -172,12 +252,13 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           TOTAL="${{ steps.parse.outputs.total_actionable }}"
 
-          TITLE="[Security] app-runtime-base:3 — ${TOTAL} CRITICAL/HIGH vulnerabilities (${DATE})"
+          TITLE="[Security] app-runtime-base:3 + SDK Python deps — ${TOTAL} CRITICAL/HIGH vulnerabilities (${DATE})"
 
           DESCRIPTION=$(
             echo "## Daily Security Scan Results"
             echo ""
             echo "**Image:** \`${TARGET_IMAGE}\`"
+            echo "**Python deps:** \`pyproject.toml\` / \`uv.lock\` (application-sdk)"
             echo "**Scan date:** ${DATE}"
             echo "**Workflow run:** [View logs](${RUN_URL})"
             echo ""
@@ -185,12 +266,12 @@ jobs:
             echo ""
             echo "### Vulnerability Summary"
             echo ""
-            echo "| Severity | Trivy | Snyk | Total |"
-            echo "|----------|------:|-----:|------:|"
-            echo "| 🔴 Critical | ${{ steps.parse.outputs.t_crit }} | ${{ steps.parse.outputs.s_crit }} | **${{ steps.parse.outputs.total_crit }}** |"
-            echo "| 🟠 High     | ${{ steps.parse.outputs.t_high }} | ${{ steps.parse.outputs.s_high }} | **${{ steps.parse.outputs.total_high }}** |"
-            echo "| 🟡 Medium   | ${{ steps.parse.outputs.t_med  }} | ${{ steps.parse.outputs.s_med  }} | **${{ steps.parse.outputs.total_med  }}** |"
-            echo "| 🔵 Low      | ${{ steps.parse.outputs.t_low  }} | ${{ steps.parse.outputs.s_low  }} | **${{ steps.parse.outputs.total_low  }}** |"
+            echo "| Severity | Trivy (Image) | Trivy (Python) | Snyk (Image) | Snyk (Python) | Total |"
+            echo "|----------|:-------------:|:--------------:|:------------:|:-------------:|------:|"
+            echo "| 🔴 Critical | ${{ steps.parse.outputs.ti_crit }} | ${{ steps.parse.outputs.tf_crit }} | ${{ steps.parse.outputs.si_crit }} | ${{ steps.parse.outputs.sp_crit }} | **${{ steps.parse.outputs.total_crit }}** |"
+            echo "| 🟠 High     | ${{ steps.parse.outputs.ti_high }} | ${{ steps.parse.outputs.tf_high }} | ${{ steps.parse.outputs.si_high }} | ${{ steps.parse.outputs.sp_high }} | **${{ steps.parse.outputs.total_high }}** |"
+            echo "| 🟡 Medium   | ${{ steps.parse.outputs.ti_med  }} | ${{ steps.parse.outputs.tf_med  }} | ${{ steps.parse.outputs.si_med  }} | ${{ steps.parse.outputs.sp_med  }} | **${{ steps.parse.outputs.total_med  }}** |"
+            echo "| 🔵 Low      | ${{ steps.parse.outputs.ti_low  }} | ${{ steps.parse.outputs.tf_low  }} | ${{ steps.parse.outputs.si_low  }} | ${{ steps.parse.outputs.sp_low  }} | **${{ steps.parse.outputs.total_low  }}** |"
             echo ""
             printf '%s\n' "${VULN_DETAIL}"
             echo ""

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           snyk container test "$TARGET_IMAGE" \
             --severity-threshold=low \
-            --org=partner-images \
+            --org=bu-apps \
             --json-file-output=snyk-image-results.json || true
 
       - name: Set up uv (for Snyk Python dep resolution)
@@ -84,7 +84,7 @@ jobs:
         run: |
           snyk test \
             --severity-threshold=low \
-            --org=partner-images \
+            --org=bu-apps \
             --command=.venv/bin/python3 \
             --json-file-output=snyk-python-results.json || true
           if [ ! -f snyk-python-results.json ]; then

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   scan-and-ticket:
-    name: Scan app-runtime-base:3
+    name: Scan SDK for vulnerabilities
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -74,8 +74,10 @@ jobs:
       - name: Set up uv (for Snyk Python dep resolution)
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
-      - name: Export Python deps for Snyk
-        run: uv export --format requirements-txt --no-dev --frozen --no-hashes --output-file=/tmp/snyk-requirements.txt
+      - name: Install Python deps and export requirements for Snyk
+        run: |
+          uv sync --no-dev --frozen
+          uv export --format requirements-txt --no-dev --frozen --no-hashes --output-file=/tmp/snyk-requirements.txt
 
       - name: Run Snyk Python deps scan (pyproject.toml / uv.lock)
         env:
@@ -85,6 +87,7 @@ jobs:
           snyk test \
             --file=/tmp/snyk-requirements.txt \
             --package-manager=pip \
+            --command=.venv/bin/python3 \
             --severity-threshold=low \
             --org=bu-apps \
             --json-file-output=snyk-python-results.json || true

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run Snyk container scan
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN_BU_APPS }}
           SNYK_API: https://api.us.snyk.io
         run: |
           snyk container test "$TARGET_IMAGE" \
@@ -79,7 +79,7 @@ jobs:
 
       - name: Run Snyk Python deps scan (pyproject.toml / uv.lock)
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN_BU_APPS }}
           SNYK_API: https://api.us.snyk.io
         run: |
           snyk test \

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   scan-and-ticket:
-    name: Scan app-runtime-base:3 and SDK Python deps for vulnerabilities
+    name: Scan app-runtime-base:3
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Pull target image
         run: docker pull "$TARGET_IMAGE"
@@ -26,7 +26,7 @@ jobs:
       # ── Trivy image scan ──────────────────────────────────────────────────
 
       - name: Trivy image scan (JSON)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.TARGET_IMAGE }}
           scanners: vuln
@@ -42,7 +42,7 @@ jobs:
       # ── Trivy filesystem scan (uv.lock / pyproject.toml) ─────────────────
 
       - name: Trivy filesystem scan (uv.lock / pyproject.toml)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -74,10 +74,9 @@ jobs:
       - name: Set up uv (for Snyk Python dep resolution)
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
-      - name: Install Python deps and export requirements for Snyk
+      - name: Export requirements for Snyk
         run: |
-          uv sync --no-dev --frozen
-          uv export --format requirements-txt --no-dev --frozen --no-hashes --output-file=/tmp/snyk-requirements.txt
+          uv export --format requirements-txt --no-dev --frozen --no-hashes --no-emit-project --output-file=/tmp/snyk-requirements.txt
 
       - name: Run Snyk Python deps scan (pyproject.toml / uv.lock)
         env:
@@ -87,7 +86,6 @@ jobs:
           snyk test \
             --file=/tmp/snyk-requirements.txt \
             --package-manager=pip \
-            --command=.venv/bin/python3 \
             --severity-threshold=low \
             --org=bu-apps \
             --json-file-output=snyk-python-results.json || true

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -71,6 +71,12 @@ jobs:
             --org=partner-images \
             --json-file-output=snyk-image-results.json || true
 
+      - name: Set up uv (for Snyk Python dep resolution)
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Install Python deps for Snyk resolution
+        run: uv sync --no-dev --frozen
+
       - name: Run Snyk Python deps scan (pyproject.toml / uv.lock)
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -79,7 +85,14 @@ jobs:
           snyk test \
             --severity-threshold=low \
             --org=partner-images \
+            --command=.venv/bin/python3 \
             --json-file-output=snyk-python-results.json || true
+          if [ ! -f snyk-python-results.json ]; then
+            echo "::warning::Snyk Python scan produced no output — check SNYK_TOKEN and org access"
+          elif jq -e '.error' snyk-python-results.json >/dev/null 2>&1; then
+            ERR=$(jq -r '.error' snyk-python-results.json)
+            echo "::warning::Snyk Python deps scan failed: $ERR — python counts will be 0"
+          fi
 
       # ── Parse results ─────────────────────────────────────────────────────
 

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Set up uv (for Snyk Python dep resolution)
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
-      - name: Install Python deps for Snyk resolution
-        run: uv sync --no-dev --frozen
+      - name: Export Python deps for Snyk
+        run: uv export --format requirements-txt --no-dev --frozen --output-file=/tmp/snyk-requirements.txt
 
       - name: Run Snyk Python deps scan (pyproject.toml / uv.lock)
         env:
@@ -83,9 +83,10 @@ jobs:
           SNYK_API: https://api.us.snyk.io
         run: |
           snyk test \
+            --file=/tmp/snyk-requirements.txt \
+            --package-manager=pip \
             --severity-threshold=low \
             --org=bu-apps \
-            --command=.venv/bin/python3 \
             --json-file-output=snyk-python-results.json || true
           if [ ! -f snyk-python-results.json ]; then
             echo "::warning::Snyk Python scan produced no output — check SNYK_TOKEN and org access"

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.6.0
-source-sha:    6d866f18ec7ead285faf0f7df85f570e2a74cca9
-source-date:   2026-05-06T12:53:53+01:00
+sdk-version:   3.6.1
+source-sha:    8482d576282b97fbbe784ffb43b840dc743cab48
+source-date:   2026-05-06T18:31:17+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 


### PR DESCRIPTION
## Summary

The daily security scan previously only scanned the `app-runtime-base:3` container image. This left a gap: Python dependencies declared in `pyproject.toml` / `uv.lock` were only checked on PRs (via `build-and-scan.yaml`), not in the nightly monitoring run.

- Adds a **Trivy filesystem scan** (`trivy fs .`) targeting `pyproject.toml` and `uv.lock` in the repo root
- Adds a **Snyk Python deps scan** (`snyk test`) for the same dependencies
- Renames result files from `trivy-results.json` → `trivy-image-results.json` and `snyk-results.json` → `snyk-image-results.json` for clarity
- Updates the parse step, workflow summary table, and Linear issue body to show both image and Python dep findings split by scanner

**Coverage before vs after:**

| What's scanned | Before | After |
|---|---|---|
| Base OS packages (`app-runtime-base:3`) | Trivy + Snyk | Trivy + Snyk |
| SDK Python deps (`pyproject.toml` / `uv.lock`) | No | **Trivy + Snyk** |

Tested it here: https://github.com/atlanhq/application-sdk/actions/runs/25456615732
<img width="3024" height="1552" alt="image" src="https://github.com/user-attachments/assets/d69aa644-2035-48f5-aaae-714c37fe5063" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)