### PR TITLE
fix(sql-app): resolve credentials in SDR mode via CredentialRef.resolve

### DIFF
--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -64,6 +64,7 @@ from application_sdk.constants import (
     WORKFLOW_OUTPUT_PATH_TEMPLATE,
 )
 from application_sdk.credentials import CredentialResolver, legacy_credential_ref
+from application_sdk.credentials.ref import CredentialRef
 from application_sdk.execution import build_output_path
 from application_sdk.execution._temporal.activity_utils import get_object_store_prefix
 from application_sdk.infrastructure.context import get_infrastructure
@@ -557,25 +558,22 @@ class SqlApp(App):
 
         client = self.sql_client_class()
 
-        # Resolve credentials
+        # Route through CredentialRef.resolve() so direct (credential_guid) and
+        # SDR (agent_spec) modes both flow through one path. The earlier branch
+        # only resolved when credential_guid was set, which left SDR runs with
+        # creds={} and a downstream "username is required" failure.
         creds: dict[str, Any] = {}
-        if input.credential_ref and input.credential_ref.credential_guid:
+        try:
+            ref = CredentialRef.resolve(input)
+        except (ValueError, TypeError):
+            ref = None
+
+        if ref is not None:
             infra = get_infrastructure()
             secret_store = infra.secret_store if infra else None
             if secret_store:
                 resolver = CredentialResolver(secret_store)
-                creds = await resolver.resolve_raw(input.credential_ref) or {}
-        elif input.credential_guid:
-            infra = get_infrastructure()
-            secret_store = infra.secret_store if infra else None
-            if secret_store:
-                resolver = CredentialResolver(secret_store)
-                creds = (
-                    await resolver.resolve_raw(
-                        legacy_credential_ref(input.credential_guid)
-                    )
-                    or {}
-                )
+                creds = await resolver.resolve_raw(ref) or {}
 
         await client.load(credentials=creds)
         return client


### PR DESCRIPTION
## Why

`SqlApp._init_sql_client` only resolved credentials when `input.credential_ref.credential_guid` or `input.credential_guid` was set. In SDR mode (`extraction_method = "agent"`) both are empty and only `agent_json` carries the credential payload, so the resolver was skipped entirely and `client.load(credentials={})` was called with an empty dict.

The downstream connection-string builder in `BaseSQLClient.get_sqlalchemy_connection_string` then raised `ValueError: username is required`, every `fetch_*` activity failed, and the workflow surfaced as `app_vitals.wf.completed status=failed`.

Reproduced end-to-end on a Self-Deployed Runtime install of `atlan-mysql-app` against a tenant: `agent_json` arrived shaped correctly (`{"auth-type":"basic","basic.username":"…","basic.password":"…","host":"…","port":3306}`), `extraction_method="agent"`, `credential_guid=""`, but the activity logged `creds={}` and exited with `username is required`.

## What changed

Route through `CredentialRef.resolve(input)` so direct (credential_guid) and SDR (agent_spec) modes both flow through one path. `CredentialResolver.resolve_raw` already branches on `agent_spec` to look up secret paths via the configured Dapr secret store.

```python
# Before
creds: dict[str, Any] = {}
if input.credential_ref and input.credential_ref.credential_guid:
    creds = await resolver.resolve_raw(input.credential_ref) or {}
elif input.credential_guid:
    creds = await resolver.resolve_raw(legacy_credential_ref(input.credential_guid)) or {}

# After
creds: dict[str, Any] = {}
try:
    ref = CredentialRef.resolve(input)
except (ValueError, TypeError):
    ref = None

if ref is not None:
    infra = get_infrastructure()
    secret_store = infra.secret_store if infra else None
    if secret_store:
        resolver = CredentialResolver(secret_store)
        creds = await resolver.resolve_raw(ref) or {}
```

`CredentialRef.resolve` raises when neither agent_json nor credential_guid is populated (the legitimate "no credentials" path). The `try/except` swallows that and falls through to `creds={}`, preserving the prior behavior for inputs without any credential source.

## Test plan
- [x] `uv run pytest tests/unit/templates/test_sql_app.py` — 31 passed
- [x] `uv run pre-commit run --files application_sdk/templates/sql_app.py` — clean
- [ ] After release: the SDR install of `atlan-mysql-app` should fetch databases / schemas / tables / columns successfully end-to-end (verified locally that the secret store resolves `ATLAN_MYSQL_USERNAME` / `ATLAN_MYSQL_PASSWORD` via the Dapr API; the only blocker was this resolver skip)