### PR TITLE
chore(security): add CVE-2026-42583 to allowlist (HIGH, no upstream fix)

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -307,5 +307,12 @@
     "reason": "Connector transitive — lxml pulled in by redshift-connector (aws/amazon-redshift-python-driver). Fix is in lxml>=6.1.0, but redshift-connector 2.1.10 pins lxml<6.0.0 in its package metadata. Bumping lxml in connector apps forces a downgrade of redshift-connector to 2.1.7. Allowlisting until upstream relaxes the cap; tracking via aws/amazon-redshift-python-driver. Connector code uses lxml only for SOAP/XML parsing of trusted Redshift IAM responses, not untrusted input.",
     "expires": "2026-05-28",
     "added_by": "anuj-atlan"
+  },
+  "CVE-2026-42583": {
+    "package": "unknown",
+    "severity": "HIGH",
+    "reason": "Base image — scanner reported the CVE without package attribution or installed version, and no upstream fix is available. Allowlisting to unblock publishes; re-evaluate at expiry once package attribution is clarified or an upstream fix lands.",
+    "expires": "2026-06-06",
+    "added_by": "vishalkatlan"
   }
 }


### PR DESCRIPTION
## Why

The latest scan flagged `CVE-2026-42583` (HIGH) on the SDK base image. The scanner did not report a package, installed version, or fix version — and there is no upstream fix available. Adding to the central allowlist with the standard 30-day HIGH expiry so dependent connector apps can publish; expiry forces a re-evaluation when the scanner clarifies attribution or an upstream fix lands.

## What this adds

1 entry to `.security/base-allowlist.json`:

| CVE | Package | Severity | Expires |
|---|---|---|---|
| `CVE-2026-42583` | `unknown` (not reported by scanner) | HIGH | 2026-06-06 |

30-day HIGH expiry per the policy enforced by `.github/scripts/validate_allowlist.py`.

## Risk justification

- Scanner reported the CVE without package attribution, installed version, or fix version. Cannot determine which component is affected from the scan output alone.
- No upstream fix exists ("No fix available" per scan), so even with attribution there would be nothing to upgrade to today.
- 30-day expiry forces re-evaluation; goal is to either (a) get clearer attribution from the scanner, or (b) catch an upstream fix when it lands.

## Test plan

- [x] Allowlist validator (`.github/scripts/validate_allowlist.py`) passes locally — "✅ Allowlist valid: 44 entries"
- [ ] After merge, retry the blocked publish — confirm scan unblock

## Out-of-scope follow-ups

1. Drill into the scan output to identify the actual package and component path for `CVE-2026-42583` so the `package` field can be filled in (currently `unknown`).
2. Re-evaluate at expiry — drop if upstream fix is in, or refresh with attribution if still unfixed.