### PR TITLE
fix(observability): skip None values in OTEL attribute build instead of stringifying

### DIFF
--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -638,16 +638,15 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
         if "extra" in record and "error_code" in record["extra"]:
             attributes["error.code"] = record["extra"]["error_code"]
 
-        # Add extra attributes at the same level
-
-        # Add extra attributes at the same level
+        # Skip None — str(None) leaks the literal "None" string downstream.
         if "extra" in record:
             for key, value in record["extra"].items():
-                if key != "error_code":  # Skip error_code as it's already handled
-                    if isinstance(value, (bool, int, float, str, bytes)):
-                        attributes[key] = value
-                    else:
-                        attributes[key] = str(value)
+                if key == "error_code" or value is None:
+                    continue
+                if isinstance(value, (bool, int, float, str, bytes)):
+                    attributes[key] = value
+                else:
+                    attributes[key] = str(value)
 
         return LogRecord(
             timestamp=int(record["timestamp"] * 1e9),

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -911,6 +911,35 @@ def test_create_log_record_does_not_parse_exception_from_message(
     assert "exception.stacktrace" not in otel_record.attributes
 
 
+def test_create_log_record_skips_none_extra_values(
+    logger_adapter: AtlanLoggerAdapter,
+):
+    """None extras must be dropped, not stringified to "None"."""
+    record = {
+        "timestamp": 1739971200.0,
+        "level": "INFO",
+        "message": "request handled",
+        "file": "server.py",
+        "line": 1,
+        "function": "handle",
+        "extra": {
+            "request_id": "abc-123",
+            "correlation_id": None,
+            "workflow_id": None,
+            "run_id": None,
+            "duration_ms": 12,
+            "status_code": None,
+        },
+    }
+
+    otel_record = logger_adapter._create_log_record(record)
+
+    assert otel_record.attributes["request_id"] == "abc-123"
+    assert otel_record.attributes["duration_ms"] == 12
+    for key in ("correlation_id", "workflow_id", "run_id", "status_code"):
+        assert key not in otel_record.attributes
+
+
 class TestTemporalAttributePassthrough:
     """Tests for temporal.* and tenant.* attribute passthrough to OTEL."""
 


### PR DESCRIPTION
## Summary

In `_create_log_record`, `None`-valued extras fell through the `isinstance` typecheck and got `str(None)` = the literal `"None"` string. OTLP attributes don't carry a null type, so the string was faithfully forwarded all the way into Iceberg.

`LogExtraModel` exposes most workflow/HTTP fields as `Optional[...] = None`; on any log emitted outside that context, all of them serialize to `None`. The bug therefore touched essentially every emitted record:

```
workflow_id    = "None"
run_id         = "None"
correlation_id = "None"
status_code    = "None"
...
```

## Confirmed in production

Tenant Iceberg `observability.app_logs` on a SDK 2.8.7 deployment, 30-minute slice:

| app | total | real correlation_id | null | literal "None" |
|---|---|---|---|---|
| redshift (3.4.0) | 90 | 36 | 54 | 0 |
| mysql (3.x) | 766 | 82 | 684 | 0 |
| query-intelligence (3.x) | 790 | 611 | 0 | **179** |
| notification-app (2.8.7) | 720 | 0 | 0 | **720** |

For SDK 3.x apps with active workflow runs, real `correlation_id` lands fine. For SDK 2.x apps and for any 3.x code path that misses the v3 bridge, the `None`-stringification bug overrides the column with `"None"`.

## Impact downstream

- `WHERE correlation_id IS NULL` skips the contaminated rows
- `COUNT(DISTINCT correlation_id)` over-counts by 1 per affected app
- correlation/aggregation joins silently drop rows because `"None"` is treated as a real id
- Grafana `correlation_id` template dropdown surfaced `"None"` as the only available value across multiple tenants

## Fix

Skip `None` attributes entirely. OTEL collectors, the OTLP-JSON S3 archive, and Iceberg all honor missing attributes as SQL `NULL` — which is what the schema (`required: false`) expects, and what `IS NULL` / `IS NOT NULL` filters assume.

Diff is 8 logical lines and reorders the existing checks slightly so the `None` short-circuit is obvious. The error_code special-case is now an explicit `continue` instead of an outer `if`, which removes a level of nesting and made `pyright` happy.

## Tests

Added `test_create_log_record_skips_none_extra_values` covering the representative HTTP server log shape (request_id real, workflow context all None). Asserts None-valued extras are absent from the OTEL attributes while real values pass through.

```
3 passed, 108 deselected in 0.77s
```

`pre-commit` clean (ruff, ruff-format, pyright, isort, etc.).

## Test plan

- [ ] Build a snapshot wheel from this branch and pin into one v2.x app (e.g. notification-app) and one v3.x app (e.g. query-intelligence)
- [ ] Roll to a sandbox tenant; confirm new records in `observability.app_logs` show SQL `NULL` for unset fields (not `"None"`)
- [ ] Run a workflow with a real correlation_id and confirm the value still lands in the column
- [ ] Verify Grafana correlation_id variable dropdown only lists real GUIDs after backfill window expires