### PR TITLE
chore(security): allowlist x/net/http2 infinite-loop CVE in daprd 1.17.6

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Updated by SDK team. CODEOWNERS: SDK/security team only.",
   "_base_image": "application-sdk-main",
-  "_updated": "2026-04-29",
+  "_updated": "2026-05-08",
   "_renewal_note": "Expiry dates staggered by severity. CRITICAL: 15 days. HIGH: 30 days. Review before expiry. Enforced by .github/scripts/validate_allowlist.py via _expiry_policy below.",
   "_expiry_policy": {
     "CRITICAL": 15,
@@ -307,5 +307,12 @@
     "reason": "Connector transitive — lxml pulled in by redshift-connector (aws/amazon-redshift-python-driver). Fix is in lxml>=6.1.0, but redshift-connector 2.1.10 pins lxml<6.0.0 in its package metadata. Bumping lxml in connector apps forces a downgrade of redshift-connector to 2.1.7. Allowlisting until upstream relaxes the cap; tracking via aws/amazon-redshift-python-driver. Connector code uses lxml only for SOAP/XML parsing of trusted Redshift IAM responses, not untrusted input.",
     "expires": "2026-05-28",
     "added_by": "anuj-atlan"
+  },
+  "SNYK-GOLANG-GOLANGORGXNETHTTP2-16535157": {
+    "package": "golang.org/x/net/http2",
+    "severity": "HIGH",
+    "reason": "Base image — daprd 1.17.6 (Wolfi dapr-daprd-1.17, already on latest -r2 revision). HTTP/2 infinite loop pinned upstream in dapr/dapr go.mod across v1.17.6, v1.18.0-rc.2, and master. Fix is in golang.org/x/net 0.53.0; awaiting upstream Dapr bump and subsequent Wolfi rebuild.",
+    "expires": "2026-06-07",
+    "added_by": "fyzanshaik-atlan"
   }
 }

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.6.1
-source-sha:    94c8e90cc4ecea7b3fd56e4265c5a3fe47a45002
-source-date:   2026-05-06T23:22:36+05:30
+sdk-version:   3.7.0
+source-sha:    7ebbf567b1f8c4ef6627757f3b14d96305443309
+source-date:   2026-05-08T12:29:20+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 


### PR DESCRIPTION
## Summary
- Adds `SNYK-GOLANG-GOLANGORGXNETHTTP2-16535157` (HIGH, x/net/http2 infinite loop) to `.security/base-allowlist.json` with a 30-day expiry (2026-06-07).
- Vuln surfaces in the base image's `/usr/bin/daprd` binary (`dapr-daprd-1.17` 1.17.6-r2 from Wolfi — already the latest available revision).
- Bumps `_updated` to 2026-05-08.

## Why this can't be fixed today
- The vulnerable `golang.org/x/net@v0.52.0` is pinned upstream in `dapr/dapr` `go.mod` across `v1.17.6` (latest stable), `v1.18.0-rc.2`, and `master`. Fix is in `golang.org/x/net@0.53.0`.
- Chainguard's apk repo lists `dapr-daprd-1.17-1.17.6-r2` as the newest revision; no `1.18` package exists yet. Even when one ships, the RC still pins 0.52.0, so a Wolfi rebuild alone won't help — needs an upstream Dapr `go get golang.org/x/net@v0.53.0` first.
- Verified via local `snyk container test app-sdk-scan:local --file=Dockerfile`: 1 HIGH (this one), apk packages clean, Python deps clean.

## Verification
- `python3 .github/scripts/validate_allowlist.py` → ✅ 44 entries, all within policy (HIGH ≤ 30d)
- `uv run pre-commit run --files .security/base-allowlist.json` → ✅

## Follow-up
- Track upstream Dapr `x/net` bump; refresh or remove this entry on/before 2026-06-07.

## Test plan
- [ ] CI allowlist validation passes
- [ ] Daily security scan no longer fails on `SNYK-GOLANG-GOLANGORGXNETHTTP2-16535157`