### PR TITLE
fix: allowlist 5 HIGH CVEs blocking publish-app PR #576 security gate

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Updated by SDK team. CODEOWNERS: SDK/security team only.",
   "_base_image": "application-sdk-main",
-  "_updated": "2026-05-08",
+  "_updated": "2026-05-09",
   "_renewal_note": "Expiry dates staggered by severity. CRITICAL: 15 days. HIGH: 30 days. Review before expiry. Enforced by .github/scripts/validate_allowlist.py via _expiry_policy below.",
   "_expiry_policy": {
     "CRITICAL": 15,
@@ -10,161 +10,161 @@
   "SNYK-GOLANG-GOOGLEGOLANGORGGRPC-15691172": {
     "package": "google.golang.org/grpc",
     "severity": "CRITICAL",
-    "reason": "Base image — Dapr runtime dependency",
+    "reason": "Base image \u2014 Dapr runtime dependency",
     "expires": "2026-05-08",
     "added_by": "mananjain99"
   },
   "CVE-2026-33186": {
     "package": "google.golang.org/grpc",
     "severity": "CRITICAL",
-    "reason": "Base image — Dapr runtime dependency",
+    "reason": "Base image \u2014 Dapr runtime dependency",
     "expires": "2026-05-08",
     "added_by": "mananjain99"
   },
   "SNYK-GOLANG-GITHUBCOMGOJOSEGOJOSEV4-15875221": {
     "package": "github.com/go-jose/go-jose/v4",
     "severity": "HIGH",
-    "reason": "Base image — Dapr runtime dependency",
+    "reason": "Base image \u2014 Dapr runtime dependency",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "SNYK-GOLANG-GITHUBCOMJACKCPGXV5PGPROTO3-15923570": {
     "package": "github.com/jackc/pgx/v5/pgproto3",
     "severity": "HIGH",
-    "reason": "Base image — Dapr runtime dependency",
+    "reason": "Base image \u2014 Dapr runtime dependency",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "SNYK-GOLANG-GITHUBCOMJACKCPGXV5PGPROTO3-15923580": {
     "package": "github.com/jackc/pgx/v5/pgproto3",
     "severity": "HIGH",
-    "reason": "Base image — Dapr runtime dependency",
+    "reason": "Base image \u2014 Dapr runtime dependency",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "CVE-2026-34986": {
     "package": "dapr-daprd-1.17",
     "severity": "HIGH",
-    "reason": "Base image — Dapr runtime package",
+    "reason": "Base image \u2014 Dapr runtime package",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "CVE-2026-4519": {
     "package": "python-3.10-base",
     "severity": "HIGH",
-    "reason": "Base image — Python runtime",
+    "reason": "Base image \u2014 Python runtime",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "CVE-2026-31812": {
     "package": "quinn-proto",
     "severity": "HIGH",
-    "reason": "Base image — Dapr Rust dependency",
+    "reason": "Base image \u2014 Dapr Rust dependency",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "CVE-2026-34040": {
     "package": "github.com/docker/docker",
     "severity": "HIGH",
-    "reason": "Base image — Docker Go dependency",
+    "reason": "Base image \u2014 Docker Go dependency",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "CVE-2026-25679": {
     "package": "stdlib (Go)",
     "severity": "HIGH",
-    "reason": "Base image — Go stdlib",
+    "reason": "Base image \u2014 Go stdlib",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "SNYK-GOLANG-GOOPENTELEMETRYIOOTELBAGGAGE-15928416": {
     "package": "go.opentelemetry.io/otel/baggage",
     "severity": "HIGH",
-    "reason": "Base image — OpenTelemetry Go dependency",
+    "reason": "Base image \u2014 OpenTelemetry Go dependency",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "SNYK-GOLANG-GOOPENTELEMETRYIOOTELINTERNALGLOBAL-15928418": {
     "package": "go.opentelemetry.io/otel/internal/global",
     "severity": "HIGH",
-    "reason": "Base image — OpenTelemetry Go dependency",
+    "reason": "Base image \u2014 OpenTelemetry Go dependency",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "SNYK-GOLANG-GOOPENTELEMETRYIOOTELPROPAGATION-15928420": {
     "package": "go.opentelemetry.io/otel/propagation",
     "severity": "HIGH",
-    "reason": "Base image — OpenTelemetry Go dependency",
+    "reason": "Base image \u2014 OpenTelemetry Go dependency",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "CVE-2026-39883": {
     "package": "go.opentelemetry.io/otel/sdk",
     "severity": "HIGH",
-    "reason": "Base image — OpenTelemetry Go dependency",
+    "reason": "Base image \u2014 OpenTelemetry Go dependency",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "CVE-2026-32280": {
     "package": "stdlib (Go)",
     "severity": "HIGH",
-    "reason": "Base image — Go stdlib",
+    "reason": "Base image \u2014 Go stdlib",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "CVE-2026-32282": {
     "package": "stdlib (Go)",
     "severity": "HIGH",
-    "reason": "Base image — Go stdlib",
+    "reason": "Base image \u2014 Go stdlib",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "SNYK-GOLANG-GOOPENTELEMETRYIOOTELEXPORTERSOTLPOTLPTRACEOTLPTRACEHTTP-15954196": {
     "package": "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp",
     "severity": "HIGH",
-    "reason": "Base image — OpenTelemetry Go dependency",
+    "reason": "Base image \u2014 OpenTelemetry Go dependency",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "SNYK-GOLANG-GOOPENTELEMETRYIOOTELSDKRESOURCE-15954212": {
     "package": "go.opentelemetry.io/otel/sdk/resource",
     "severity": "HIGH",
-    "reason": "Base image — OpenTelemetry Go dependency",
+    "reason": "Base image \u2014 OpenTelemetry Go dependency",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "CVE-2026-27137": {
     "package": "stdlib (Go)",
     "severity": "HIGH",
-    "reason": "Base image — Go stdlib in daprd 1.17.4-r0 (Wolfi dapr-daprd-1.17). Fixed in Go 1.26.1; awaiting Wolfi rebuild of dapr-1.17 on newer Go toolchain.",
+    "reason": "Base image \u2014 Go stdlib in daprd 1.17.4-r0 (Wolfi dapr-daprd-1.17). Fixed in Go 1.26.1; awaiting Wolfi rebuild of dapr-1.17 on newer Go toolchain.",
     "expires": "2026-05-23",
     "added_by": "louisnow"
   },
   "CVE-2026-33810": {
     "package": "stdlib (Go)",
     "severity": "HIGH",
-    "reason": "Base image — Go stdlib in daprd 1.17.4-r0 (Wolfi dapr-daprd-1.17). Fixed in Go 1.26.2; awaiting Wolfi rebuild of dapr-1.17 on newer Go toolchain.",
+    "reason": "Base image \u2014 Go stdlib in daprd 1.17.4-r0 (Wolfi dapr-daprd-1.17). Fixed in Go 1.26.2; awaiting Wolfi rebuild of dapr-1.17 on newer Go toolchain.",
     "expires": "2026-05-23",
     "added_by": "louisnow"
   },
   "CVE-2024-35515": {
     "package": "sqlitedict==2.1.0",
     "severity": "HIGH",
-    "reason": "No patched version of sqlitedict available — upstream has not released a fix as of 2026-04-16",
+    "reason": "No patched version of sqlitedict available \u2014 upstream has not released a fix as of 2026-04-16",
     "expires": "2026-05-23",
     "added_by": "TechyMT"
   },
   "CVE-2026-23949": {
     "package": "jaraco.context",
     "severity": "HIGH",
-    "reason": "Base image — Chainguard Wolfi system Python package",
+    "reason": "Base image \u2014 Chainguard Wolfi system Python package",
     "expires": "2026-05-23",
     "added_by": "anuj-atlan"
   },
   "CVE-2026-24049": {
     "package": "wheel",
     "severity": "HIGH",
-    "reason": "Base image — Chainguard Wolfi system Python package",
+    "reason": "Base image \u2014 Chainguard Wolfi system Python package",
     "expires": "2026-05-23",
     "added_by": "anuj-atlan"
   },
@@ -178,141 +178,176 @@
   "CVE-2026-33816": {
     "package": "github.com/jackc/pgx/v5",
     "severity": "CRITICAL",
-    "reason": "Base image — Dapr Go dependency, fix available in 5.9.0",
+    "reason": "Base image \u2014 Dapr Go dependency, fix available in 5.9.0",
     "expires": "2026-05-08",
     "added_by": "mananjain99"
   },
   "CVE-2026-27140": {
     "package": "dapr-daprd-1.17",
     "severity": "HIGH",
-    "reason": "Base image — Dapr runtime, fix available in 1.17.5-r0",
+    "reason": "Base image \u2014 Dapr runtime, fix available in 1.17.5-r0",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "CVE-2026-32281": {
     "package": "dapr-daprd-1.17",
     "severity": "HIGH",
-    "reason": "Base image — Dapr runtime, fix available in 1.17.5-r0",
+    "reason": "Base image \u2014 Dapr runtime, fix available in 1.17.5-r0",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "CVE-2026-32283": {
     "package": "dapr-daprd-1.17",
     "severity": "HIGH",
-    "reason": "Base image — Dapr runtime, fix available in 1.17.5-r0",
+    "reason": "Base image \u2014 Dapr runtime, fix available in 1.17.5-r0",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "GHSA-85gx-3qv6-4463": {
     "package": "github.com/dapr/dapr",
     "severity": "HIGH",
-    "reason": "Base image — Dapr runtime, fix available in 1.17.5",
+    "reason": "Base image \u2014 Dapr runtime, fix available in 1.17.5",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "CVE-2026-35469": {
     "package": "github.com/moby/spdystream",
     "severity": "HIGH",
-    "reason": "Base image — Go dependency, fix available in 0.5.1",
+    "reason": "Base image \u2014 Go dependency, fix available in 0.5.1",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "SNYK-GOLANG-GITHUBCOMMOBYSPDYSTREAMSPDY-16304822": {
     "package": "github.com/moby/spdystream/spdy",
     "severity": "HIGH",
-    "reason": "Base image — Go dependency. Same underlying issue as CVE-2026-35469 reported under Snyk's ID. Fix available in 0.5.1, awaiting SDK base rebuild.",
+    "reason": "Base image \u2014 Go dependency. Same underlying issue as CVE-2026-35469 reported under Snyk's ID. Fix available in 0.5.1, awaiting SDK base rebuild.",
     "expires": "2026-05-23",
     "added_by": "mananjain99"
   },
   "CVE-2023-45853": {
     "package": "zlib1g (Debian bookworm-slim)",
     "severity": "CRITICAL",
-    "reason": "MiniZip heap overflow in zlib contrib. The zlib1g binary package ships only libz.so.1 and does NOT contain the vulnerable zipOpenNewFileInZip4_64 code — that lives in the separate minizip/libminizip1 packages, which are not installed in connector images (verified via Debian package file-list). No fix available upstream: zlib maintainers consider MiniZip contrib, Debian has tracked this without a patch for 18+ months. Blocks atlan-mssql-app releases.",
+    "reason": "MiniZip heap overflow in zlib contrib. The zlib1g binary package ships only libz.so.1 and does NOT contain the vulnerable zipOpenNewFileInZip4_64 code \u2014 that lives in the separate minizip/libminizip1 packages, which are not installed in connector images (verified via Debian package file-list). No fix available upstream: zlib maintainers consider MiniZip contrib, Debian has tracked this without a patch for 18+ months. Blocks atlan-mssql-app releases.",
     "expires": "2026-05-08",
     "added_by": "Divyanshu-Patel"
   },
   "CVE-2026-6100": {
     "package": "python-3.x-base (Chainguard)",
     "severity": "HIGH",
-    "reason": "Base image — Chainguard python-3.10/3.11/3.12/3.13-base. Upstream fix available (3.10.20-r3, 3.11.15-r2, 3.13.13-r2), pending SDK v2.8.x base rebuild. Note: v3.2.0 base already includes the patched packages.",
+    "reason": "Base image \u2014 Chainguard python-3.10/3.11/3.12/3.13-base. Upstream fix available (3.10.20-r3, 3.11.15-r2, 3.13.13-r2), pending SDK v2.8.x base rebuild. Note: v3.2.0 base already includes the patched packages.",
     "expires": "2026-05-24",
     "added_by": "mananjain99"
   },
   "CVE-2026-4786": {
     "package": "python-3.x-base (Chainguard)",
     "severity": "HIGH",
-    "reason": "Base image — Chainguard python-3.11/3.13-base. Upstream fix available (3.11.15-r2, 3.13.13-r2), pending SDK v2.8.x base rebuild. Note: v3.2.0 base already includes the patched packages.",
+    "reason": "Base image \u2014 Chainguard python-3.11/3.13-base. Upstream fix available (3.11.15-r2, 3.13.13-r2), pending SDK v2.8.x base rebuild. Note: v3.2.0 base already includes the patched packages.",
     "expires": "2026-05-24",
     "added_by": "mananjain99"
   },
   "SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551": {
     "package": "com.fasterxml.jackson.core:jackson-core",
     "severity": "HIGH",
-    "reason": "Base image — Jackson Java transitive in application-sdk-main:2.7.3 (likely via Dapr tooling). No fix released upstream. Connector apps are Python at runtime and do not invoke Jackson code paths; review at expiry to track upstream patch availability.",
+    "reason": "Base image \u2014 Jackson Java transitive in application-sdk-main:2.7.3 (likely via Dapr tooling). No fix released upstream. Connector apps are Python at runtime and do not invoke Jackson code paths; review at expiry to track upstream patch availability.",
     "expires": "2026-05-27",
     "added_by": "vishalkatlan"
   },
   "SNYK-JAVA-COMFASTERXMLJACKSONCORE-15365924": {
     "package": "com.fasterxml.jackson.core:jackson-core",
     "severity": "HIGH",
-    "reason": "Base image — Jackson Java transitive in application-sdk-main:2.7.3 (likely via Dapr tooling). No fix released upstream. Connector apps are Python at runtime and do not invoke Jackson code paths; review at expiry to track upstream patch availability.",
+    "reason": "Base image \u2014 Jackson Java transitive in application-sdk-main:2.7.3 (likely via Dapr tooling). No fix released upstream. Connector apps are Python at runtime and do not invoke Jackson code paths; review at expiry to track upstream patch availability.",
     "expires": "2026-05-27",
     "added_by": "vishalkatlan"
   },
   "CVE-2026-33871": {
     "package": "com.fasterxml.jackson.core:jackson-databind",
     "severity": "HIGH",
-    "reason": "Base image — Jackson Java transitive in application-sdk-main:2.7.3 (likely via Dapr tooling). No fix released upstream. Connector apps are Python at runtime and do not invoke Jackson code paths; review at expiry to track upstream patch availability.",
+    "reason": "Base image \u2014 Jackson Java transitive in application-sdk-main:2.7.3 (likely via Dapr tooling). No fix released upstream. Connector apps are Python at runtime and do not invoke Jackson code paths; review at expiry to track upstream patch availability.",
     "expires": "2026-05-27",
     "added_by": "vishalkatlan"
   },
   "CVE-2026-33870": {
     "package": "com.fasterxml.jackson.core:jackson-databind",
     "severity": "HIGH",
-    "reason": "Base image — Jackson Java transitive in application-sdk-main:2.7.3 (likely via Dapr tooling). No fix released upstream. Connector apps are Python at runtime and do not invoke Jackson code paths; review at expiry to track upstream patch availability.",
+    "reason": "Base image \u2014 Jackson Java transitive in application-sdk-main:2.7.3 (likely via Dapr tooling). No fix released upstream. Connector apps are Python at runtime and do not invoke Jackson code paths; review at expiry to track upstream patch availability.",
     "expires": "2026-05-27",
     "added_by": "vishalkatlan"
   },
   "SNYK-GOLANG-GITHUBCOMAWSAWSSDKGOV2SERVICES3-16316411": {
     "package": "github.com/aws/aws-sdk-go-v2/service/s3",
     "severity": "HIGH",
-    "reason": "Base image — Dapr 1.17 transitive Go AWS SDK dep in app-framework-golden bundle (consumed by SDK 2.x). Fix available in 1.97.3; awaiting Wolfi rebuild of app-framework-golden with newer aws-sdk-go-v2.",
+    "reason": "Base image \u2014 Dapr 1.17 transitive Go AWS SDK dep in app-framework-golden bundle (consumed by SDK 2.x). Fix available in 1.97.3; awaiting Wolfi rebuild of app-framework-golden with newer aws-sdk-go-v2.",
     "expires": "2026-05-29",
     "added_by": "sachi-atlan"
   },
   "SNYK-GOLANG-GITHUBCOMAWSAWSSDKGOV2AWSPROTOCOLEVENTSTREAM-16316402": {
     "package": "github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream",
     "severity": "HIGH",
-    "reason": "Base image — Dapr 1.17 transitive Go AWS SDK dep in app-framework-golden bundle (consumed by SDK 2.x). Fix available in 1.7.8; awaiting Wolfi rebuild of app-framework-golden with newer aws-sdk-go-v2.",
+    "reason": "Base image \u2014 Dapr 1.17 transitive Go AWS SDK dep in app-framework-golden bundle (consumed by SDK 2.x). Fix available in 1.7.8; awaiting Wolfi rebuild of app-framework-golden with newer aws-sdk-go-v2.",
     "expires": "2026-05-29",
     "added_by": "sachi-atlan"
   },
   "SNYK-GOLANG-GITHUBCOMAWSAWSSDKGOV2SERVICEBEDROCKRUNTIME-16316405": {
     "package": "github.com/aws/aws-sdk-go-v2/service/bedrockruntime",
     "severity": "HIGH",
-    "reason": "Base image — Dapr 1.17 transitive Go AWS SDK dep in app-framework-golden bundle (consumed by SDK 2.x). Fix available in 1.50.4; awaiting Wolfi rebuild of app-framework-golden with newer aws-sdk-go-v2.",
+    "reason": "Base image \u2014 Dapr 1.17 transitive Go AWS SDK dep in app-framework-golden bundle (consumed by SDK 2.x). Fix available in 1.50.4; awaiting Wolfi rebuild of app-framework-golden with newer aws-sdk-go-v2.",
     "expires": "2026-05-29",
     "added_by": "sachi-atlan"
   },
   "SNYK-GOLANG-GITHUBCOMAWSAWSSDKGOV2SERVICEKINESIS-16316408": {
     "package": "github.com/aws/aws-sdk-go-v2/service/kinesis",
     "severity": "HIGH",
-    "reason": "Base image — Dapr 1.17 transitive Go AWS SDK dep in app-framework-golden bundle (consumed by SDK 2.x). Fix available in 1.43.5; awaiting Wolfi rebuild of app-framework-golden with newer aws-sdk-go-v2.",
+    "reason": "Base image \u2014 Dapr 1.17 transitive Go AWS SDK dep in app-framework-golden bundle (consumed by SDK 2.x). Fix available in 1.43.5; awaiting Wolfi rebuild of app-framework-golden with newer aws-sdk-go-v2.",
     "expires": "2026-05-29",
     "added_by": "sachi-atlan"
   },
   "CVE-2026-41066": {
     "package": "lxml",
     "severity": "HIGH",
-    "reason": "Connector transitive — lxml pulled in by redshift-connector (aws/amazon-redshift-python-driver). Fix is in lxml>=6.1.0, but redshift-connector 2.1.10 pins lxml<6.0.0 in its package metadata. Bumping lxml in connector apps forces a downgrade of redshift-connector to 2.1.7. Allowlisting until upstream relaxes the cap; tracking via aws/amazon-redshift-python-driver. Connector code uses lxml only for SOAP/XML parsing of trusted Redshift IAM responses, not untrusted input.",
+    "reason": "Connector transitive \u2014 lxml pulled in by redshift-connector (aws/amazon-redshift-python-driver). Fix is in lxml>=6.1.0, but redshift-connector 2.1.10 pins lxml<6.0.0 in its package metadata. Bumping lxml in connector apps forces a downgrade of redshift-connector to 2.1.7. Allowlisting until upstream relaxes the cap; tracking via aws/amazon-redshift-python-driver. Connector code uses lxml only for SOAP/XML parsing of trusted Redshift IAM responses, not untrusted input.",
     "expires": "2026-05-28",
     "added_by": "anuj-atlan"
   },
   "SNYK-GOLANG-GOLANGORGXNETHTTP2-16535157": {
     "package": "golang.org/x/net/http2",
     "severity": "HIGH",
-    "reason": "Base image — daprd 1.17.6 (Wolfi dapr-daprd-1.17, already on latest -r2 revision). HTTP/2 infinite loop pinned upstream in dapr/dapr go.mod across v1.17.6, v1.18.0-rc.2, and master. Fix is in golang.org/x/net 0.53.0; awaiting upstream Dapr bump and subsequent Wolfi rebuild.",
+    "reason": "Base image \u2014 daprd 1.17.6 (Wolfi dapr-daprd-1.17, already on latest -r2 revision). HTTP/2 infinite loop pinned upstream in dapr/dapr go.mod across v1.17.6, v1.18.0-rc.2, and master. Fix is in golang.org/x/net 0.53.0; awaiting upstream Dapr bump and subsequent Wolfi rebuild.",
     "expires": "2026-06-07",
     "added_by": "fyzanshaik-atlan"
+  },
+  "CVE-2025-66418": {
+    "package": "py3-pip-wheel (Alpine/Wolfi)",
+    "severity": "HIGH",
+    "reason": "Base image \u2014 Chainguard Wolfi py3-pip-wheel@26.0.1-r2. Fix available in 26.1.1-r0; awaiting SDK base image rebuild.",
+    "expires": "2026-06-08",
+    "added_by": "mustafahasankhan"
+  },
+  "CVE-2025-66471": {
+    "package": "py3-pip-wheel (Alpine/Wolfi)",
+    "severity": "HIGH",
+    "reason": "Base image \u2014 Chainguard Wolfi py3-pip-wheel@26.0.1-r2. Fix available in 26.1.1-r0; awaiting SDK base image rebuild.",
+    "expires": "2026-06-08",
+    "added_by": "mustafahasankhan"
+  },
+  "CVE-2026-21441": {
+    "package": "py3-pip-wheel (Alpine/Wolfi)",
+    "severity": "HIGH",
+    "reason": "Base image \u2014 Chainguard Wolfi py3-pip-wheel@26.0.1-r2. Fix available in 26.1.1-r0; awaiting SDK base image rebuild.",
+    "expires": "2026-06-08",
+    "added_by": "mustafahasankhan"
+  },
+  "CVE-2026-42304": {
+    "package": "Twisted",
+    "severity": "HIGH",
+    "reason": "Python transitive dependency. Fix available only in Twisted 26.4.0rc2 (pre-release); no stable fix yet. Used by Dapr/SDK runtime. Review at expiry for stable release.",
+    "expires": "2026-06-08",
+    "added_by": "mustafahasankhan"
+  },
+  "GHSA-82j2-j2ch-gfr8": {
+    "package": "rustls-webpki",
+    "severity": "HIGH",
+    "reason": "Base image \u2014 Rust dependency in Dapr runtime. Fix available in 0.103.13/0.104.0-alpha.7; awaiting SDK base image rebuild with updated Dapr.",
+    "expires": "2026-06-08",
+    "added_by": "mustafahasankhan"
   }
 }


### PR DESCRIPTION
## Summary

Allowlists 5 new HIGH CVEs surfaced by the publish-app PR #576 (`fix/ordering-custom-atlas-lineage-non-ars`) security gate. All are base image or transitive-only with no available stable fix.

Note: `CVE-2026-42561` (python-multipart) was fixed directly in the publish-app repo (bumped to >=0.0.27). `SNYK-GOLANG-GOLANGORGXNETHTTP2-16535157` is already in this allowlist (expires 2026-06-07).

## New entries

| ID | Package | Reason |
|----|---------|--------|
| `CVE-2025-66418` | py3-pip-wheel@26.0.1-r2 | Wolfi base image; fix in 26.1.1-r0, awaiting SDK rebuild |
| `CVE-2025-66471` | py3-pip-wheel@26.0.1-r2 | Wolfi base image; fix in 26.1.1-r0, awaiting SDK rebuild |
| `CVE-2026-21441` | py3-pip-wheel@26.0.1-r2 | Wolfi base image; fix in 26.1.1-r0, awaiting SDK rebuild |
| `CVE-2026-42304` | Twisted@25.5.0 | Only fix is in RC 26.4.0rc2 — no stable release yet |
| `GHSA-82j2-j2ch-gfr8` | rustls-webpki@0.103.4 | Dapr Rust dep in base image; fix in 0.103.13, awaiting rebuild |

All set to expire 2026-06-08 (30-day HIGH window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)