### PR TITLE
feat(observability): flatten failure.category/audience/code onto ended logs

### DIFF
--- a/application_sdk/execution/_temporal/interceptors/log.py
+++ b/application_sdk/execution/_temporal/interceptors/log.py
@@ -26,19 +26,27 @@ from uuid import uuid4
 
 from temporalio import activity, workflow
 from temporalio.converter import default as default_converter
-from temporalio.worker import (ActivityInboundInterceptor,
-                               ExecuteActivityInput, ExecuteWorkflowInput,
-                               Interceptor, StartActivityInput,
-                               StartChildWorkflowInput,
-                               WorkflowInboundInterceptor,
-                               WorkflowInterceptorClassInput,
-                               WorkflowOutboundInterceptor)
+from temporalio.worker import (
+    ActivityInboundInterceptor,
+    ExecuteActivityInput,
+    ExecuteWorkflowInput,
+    Interceptor,
+    StartActivityInput,
+    StartChildWorkflowInput,
+    WorkflowInboundInterceptor,
+    WorkflowInterceptorClassInput,
+    WorkflowOutboundInterceptor,
+)
 
-from application_sdk.observability.context import (ExecutionContext,
-                                                   set_execution_context)
-from application_sdk.observability.correlation import (CorrelationContext,
-                                                       get_correlation_context,
-                                                       set_correlation_context)
+from application_sdk.observability.context import (
+    ExecutionContext,
+    set_execution_context,
+)
+from application_sdk.observability.correlation import (
+    CorrelationContext,
+    get_correlation_context,
+    set_correlation_context,
+)
 from application_sdk.observability.logger_adaptor import get_logger
 
 if TYPE_CHECKING:
@@ -67,14 +75,16 @@ def _extract_failure_attrs(exc: BaseException | None) -> dict[str, str]:
     if exc is None:
         return {}
     try:
-        from application_sdk.errors.base import \
-            AppError  # noqa: PLC0415 — avoid import cycle
+        from application_sdk.errors.base import (  # noqa: PLC0415 — avoid import cycle
+            AppError,
+        )
         from application_sdk.errors.wire import FailureDetails  # noqa: PLC0415
     except Exception:  # noqa: BLE001 — observability path; never raise
         return {}
     try:
-        from temporalio.exceptions import \
-            ApplicationError as _TemporalApplicationError  # noqa: PLC0415
+        from temporalio.exceptions import (  # noqa: PLC0415
+            ApplicationError as _TemporalApplicationError,
+        )
     except Exception:  # noqa: BLE001
         _TemporalApplicationError = None  # type: ignore[assignment]
 

--- a/application_sdk/execution/_temporal/interceptors/log.py
+++ b/application_sdk/execution/_temporal/interceptors/log.py
@@ -56,6 +56,60 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+
+def _extract_failure_attrs(exc: BaseException | None) -> dict[str, str]:
+    """Flatten SDK error classification onto OTel attributes for ERROR logs.
+
+    Walks ``__cause__`` and ``__context__`` looking for either:
+      * an :class:`application_sdk.errors.base.AppError` (raised directly), or
+      * a ``temporalio.exceptions.ApplicationError`` whose first ``details``
+        entry is a :class:`application_sdk.errors.wire.FailureDetails` (the
+        shape emitted by the SDK's activity wrapper for ``AppError`` subclasses).
+
+    Returns ``{"failure.category", "failure.audience", "failure.code"}`` —
+    OTel attribute keys that ride the ``failure.`` passthrough prefix in
+    ``logger_adaptor``. Empty dict when no SDK classification is recoverable
+    (e.g. raw ``ValueError`` or non-SDK exception); callers append the result
+    to ``ended_attrs`` unconditionally and the log line simply omits the keys.
+    """
+    if exc is None:
+        return {}
+    try:
+        from application_sdk.errors.base import AppError  # noqa: PLC0415 — avoid import cycle
+        from application_sdk.errors.wire import FailureDetails  # noqa: PLC0415
+    except Exception:  # noqa: BLE001 — observability path; never raise
+        return {}
+    try:
+        from temporalio.exceptions import (  # noqa: PLC0415
+            ApplicationError as _TemporalApplicationError,
+        )
+    except Exception:  # noqa: BLE001
+        _TemporalApplicationError = None  # type: ignore[assignment]
+
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, AppError):
+            return {
+                "failure.category": current.category.value,
+                "failure.audience": type(current).audience.value,
+                "failure.code": current.code,
+            }
+        if _TemporalApplicationError is not None and isinstance(
+            current, _TemporalApplicationError
+        ):
+            for detail in getattr(current, "details", None) or ():
+                if isinstance(detail, FailureDetails):
+                    return {
+                        "failure.category": detail.category.value,
+                        "failure.audience": detail.audience.value,
+                        "failure.code": detail.code,
+                    }
+        current = current.__cause__ or current.__context__
+    return {}
+
+
 _HEADER_CORRELATION_ID = "x-correlation-id"
 # Legacy header used by the AE's older interceptor — kept for compatibility
 # so AE-dispatched workflows inherit correlation_id without AE-side changes.
@@ -222,10 +276,12 @@ class _LogWorkflowInboundInterceptor(WorkflowInboundInterceptor):
 
         start_ns = time.monotonic_ns()
         status = "OK"
+        exc_caught: BaseException | None = None
         try:
             return await self.next.execute_workflow(input)
-        except Exception:
+        except Exception as e:
             status = "ERROR"
+            exc_caught = e
             raise
         finally:
             duration_ms = round((time.monotonic_ns() - start_ns) / 1_000_000, 1)
@@ -236,6 +292,7 @@ class _LogWorkflowInboundInterceptor(WorkflowInboundInterceptor):
             }
             try:
                 if status == "ERROR":
+                    ended_attrs.update(_extract_failure_attrs(exc_caught))
                     logger.error("workflow.ended", exc_info=True, **ended_attrs)
                 else:
                     logger.info("workflow.ended", **ended_attrs)
@@ -326,10 +383,12 @@ class _LogActivityInboundInterceptor(ActivityInboundInterceptor):
 
         start_ns = time.monotonic_ns()
         status = "OK"
+        exc_caught: BaseException | None = None
         try:
             return await self.next.execute_activity(input)
-        except BaseException:
+        except BaseException as e:
             status = "ERROR"
+            exc_caught = e
             raise
         finally:
             duration_ms = round((time.monotonic_ns() - start_ns) / 1_000_000, 1)
@@ -340,6 +399,7 @@ class _LogActivityInboundInterceptor(ActivityInboundInterceptor):
             }
             try:
                 if status == "ERROR":
+                    ended_attrs.update(_extract_failure_attrs(exc_caught))
                     logger.error("activity.ended", exc_info=True, **ended_attrs)
                 else:
                     logger.info("activity.ended", **ended_attrs)

--- a/application_sdk/execution/_temporal/interceptors/log.py
+++ b/application_sdk/execution/_temporal/interceptors/log.py
@@ -26,27 +26,19 @@ from uuid import uuid4
 
 from temporalio import activity, workflow
 from temporalio.converter import default as default_converter
-from temporalio.worker import (
-    ActivityInboundInterceptor,
-    ExecuteActivityInput,
-    ExecuteWorkflowInput,
-    Interceptor,
-    StartActivityInput,
-    StartChildWorkflowInput,
-    WorkflowInboundInterceptor,
-    WorkflowInterceptorClassInput,
-    WorkflowOutboundInterceptor,
-)
+from temporalio.worker import (ActivityInboundInterceptor,
+                               ExecuteActivityInput, ExecuteWorkflowInput,
+                               Interceptor, StartActivityInput,
+                               StartChildWorkflowInput,
+                               WorkflowInboundInterceptor,
+                               WorkflowInterceptorClassInput,
+                               WorkflowOutboundInterceptor)
 
-from application_sdk.observability.context import (
-    ExecutionContext,
-    set_execution_context,
-)
-from application_sdk.observability.correlation import (
-    CorrelationContext,
-    get_correlation_context,
-    set_correlation_context,
-)
+from application_sdk.observability.context import (ExecutionContext,
+                                                   set_execution_context)
+from application_sdk.observability.correlation import (CorrelationContext,
+                                                       get_correlation_context,
+                                                       set_correlation_context)
 from application_sdk.observability.logger_adaptor import get_logger
 
 if TYPE_CHECKING:
@@ -75,14 +67,14 @@ def _extract_failure_attrs(exc: BaseException | None) -> dict[str, str]:
     if exc is None:
         return {}
     try:
-        from application_sdk.errors.base import AppError  # noqa: PLC0415 — avoid import cycle
+        from application_sdk.errors.base import \
+            AppError  # noqa: PLC0415 — avoid import cycle
         from application_sdk.errors.wire import FailureDetails  # noqa: PLC0415
     except Exception:  # noqa: BLE001 — observability path; never raise
         return {}
     try:
-        from temporalio.exceptions import (  # noqa: PLC0415
-            ApplicationError as _TemporalApplicationError,
-        )
+        from temporalio.exceptions import \
+            ApplicationError as _TemporalApplicationError  # noqa: PLC0415
     except Exception:  # noqa: BLE001
         _TemporalApplicationError = None  # type: ignore[assignment]
 

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -127,6 +127,7 @@ _KNOWN_EXTRA_KEYS = frozenset(
 _PREFIXES_PASSTHROUGH = (
     "atlan.",  # SDK convention: atlan.correlation_id and similar dotted keys
     "exception.",  # OTel semconv: exception.type/message/stacktrace
+    "failure.",  # SDK convention: failure.category/audience/code from AppError
     "otel.",  # OTel semconv: otel.status_code
     "temporal.",  # SDK convention: temporal.workflow.id, etc.
     "tenant.",

--- a/tests/unit/interceptors/test_log_interceptor.py
+++ b/tests/unit/interceptors/test_log_interceptor.py
@@ -7,25 +7,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from temporalio.converter import default as default_converter
-
 from temporalio.exceptions import ApplicationError
 
 from application_sdk.errors.leaves import AuthError, InvalidInputError
 from application_sdk.execution._temporal.interceptors.log import (
-    LogInterceptor,
-    _correlation_id_or_empty,
-    _extract_failure_attrs,
-    _LogActivityInboundInterceptor,
-    _LogWorkflowInboundInterceptor,
-    _LogWorkflowOutboundInterceptor,
-)
-from application_sdk.observability.context import ExecutionContext, _execution_ctx
-from application_sdk.observability.correlation import (
-    CorrelationContext,
-    _correlation_ctx,
-    get_correlation_context,
-    set_correlation_context,
-)
+    LogInterceptor, _correlation_id_or_empty, _extract_failure_attrs,
+    _LogActivityInboundInterceptor, _LogWorkflowInboundInterceptor,
+    _LogWorkflowOutboundInterceptor)
+from application_sdk.observability.context import (ExecutionContext,
+                                                   _execution_ctx)
+from application_sdk.observability.correlation import (CorrelationContext,
+                                                       _correlation_ctx,
+                                                       get_correlation_context,
+                                                       set_correlation_context)
 
 # ---------------------------------------------------------------------------
 # Shared mock dataclasses
@@ -264,9 +258,7 @@ class TestLogWorkflowInboundInterceptor:
         # downstream consumers can tell "uncategorised" from a real category.
         assert "failure.category" not in kwargs
 
-    async def test_workflow_ended_flattens_failure_attrs_for_apperror(
-        self, mock_next
-    ):
+    async def test_workflow_ended_flattens_failure_attrs_for_apperror(self, mock_next):
         # AppError raised directly inside the workflow → interceptor extracts
         # category/audience/code from the class-level ClassVars onto the
         # workflow.ended ERROR log.
@@ -493,9 +485,7 @@ class TestLogActivityInboundInterceptor:
         assert kwargs["otel.status_code"] == "ERROR"
         assert kwargs["exc_info"] is True
 
-    async def test_activity_ended_flattens_failure_attrs_for_apperror(
-        self, mock_next
-    ):
+    async def test_activity_ended_flattens_failure_attrs_for_apperror(self, mock_next):
         mock_next.execute_activity = AsyncMock(
             side_effect=AuthError(message="bad creds")
         )

--- a/tests/unit/interceptors/test_log_interceptor.py
+++ b/tests/unit/interceptors/test_log_interceptor.py
@@ -11,15 +11,20 @@ from temporalio.exceptions import ApplicationError
 
 from application_sdk.errors.leaves import AuthError, InvalidInputError
 from application_sdk.execution._temporal.interceptors.log import (
-    LogInterceptor, _correlation_id_or_empty, _extract_failure_attrs,
-    _LogActivityInboundInterceptor, _LogWorkflowInboundInterceptor,
-    _LogWorkflowOutboundInterceptor)
-from application_sdk.observability.context import (ExecutionContext,
-                                                   _execution_ctx)
-from application_sdk.observability.correlation import (CorrelationContext,
-                                                       _correlation_ctx,
-                                                       get_correlation_context,
-                                                       set_correlation_context)
+    LogInterceptor,
+    _correlation_id_or_empty,
+    _extract_failure_attrs,
+    _LogActivityInboundInterceptor,
+    _LogWorkflowInboundInterceptor,
+    _LogWorkflowOutboundInterceptor,
+)
+from application_sdk.observability.context import ExecutionContext, _execution_ctx
+from application_sdk.observability.correlation import (
+    CorrelationContext,
+    _correlation_ctx,
+    get_correlation_context,
+    set_correlation_context,
+)
 
 # ---------------------------------------------------------------------------
 # Shared mock dataclasses

--- a/tests/unit/interceptors/test_log_interceptor.py
+++ b/tests/unit/interceptors/test_log_interceptor.py
@@ -8,9 +8,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from temporalio.converter import default as default_converter
 
+from temporalio.exceptions import ApplicationError
+
+from application_sdk.errors.leaves import AuthError, InvalidInputError
 from application_sdk.execution._temporal.interceptors.log import (
     LogInterceptor,
     _correlation_id_or_empty,
+    _extract_failure_attrs,
     _LogActivityInboundInterceptor,
     _LogWorkflowInboundInterceptor,
     _LogWorkflowOutboundInterceptor,
@@ -112,6 +116,57 @@ class TestCorrelationIdOrEmpty:
 
 
 # ---------------------------------------------------------------------------
+# TestExtractFailureAttrs
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFailureAttrs:
+    def test_none_returns_empty(self):
+        assert _extract_failure_attrs(None) == {}
+
+    def test_non_app_exception_returns_empty(self):
+        assert _extract_failure_attrs(ValueError("oops")) == {}
+
+    def test_direct_apperror(self):
+        attrs = _extract_failure_attrs(AuthError(message="bad creds"))
+        assert attrs == {
+            "failure.category": "AUTH",
+            "failure.audience": "USER",
+            "failure.code": "AUTH",
+        }
+
+    def test_unwraps_cause_chain(self):
+        # Common shape: outer wrapper raised "from" the SDK error.
+        leaf = InvalidInputError(message="missing field")
+        outer = RuntimeError("wrapped")
+        outer.__cause__ = leaf
+        attrs = _extract_failure_attrs(outer)
+        assert attrs["failure.category"] == "INVALID_INPUT"
+
+    def test_extracts_from_application_error_details(self):
+        leaf = AuthError(message="bad creds")
+        app_err = ApplicationError(
+            "bad creds",
+            leaf.to_failure_details(),
+            type="AuthError",
+            non_retryable=True,
+        )
+        attrs = _extract_failure_attrs(app_err)
+        assert attrs == {
+            "failure.category": "AUTH",
+            "failure.audience": "USER",
+            "failure.code": "AUTH",
+        }
+
+    def test_handles_self_cycle(self):
+        # Pathological case — exception that points to itself via __context__.
+        # Helper must not loop forever.
+        exc = RuntimeError("loop")
+        exc.__context__ = exc
+        assert _extract_failure_attrs(exc) == {}
+
+
+# ---------------------------------------------------------------------------
 # TestLogWorkflowInboundInterceptor
 # ---------------------------------------------------------------------------
 
@@ -205,6 +260,80 @@ class TestLogWorkflowInboundInterceptor:
         kwargs = ended_calls[0][1]
         assert kwargs["otel.status_code"] == "ERROR"
         assert kwargs["exc_info"] is True
+        # Raw ValueError has no SDK classification — failure.* keys absent so
+        # downstream consumers can tell "uncategorised" from a real category.
+        assert "failure.category" not in kwargs
+
+    async def test_workflow_ended_flattens_failure_attrs_for_apperror(
+        self, mock_next
+    ):
+        # AppError raised directly inside the workflow → interceptor extracts
+        # category/audience/code from the class-level ClassVars onto the
+        # workflow.ended ERROR log.
+        mock_next.execute_workflow = AsyncMock(
+            side_effect=AuthError(message="bad creds")
+        )
+        interceptor = _LogWorkflowInboundInterceptor(mock_next)
+
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = False
+            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.memo.return_value = {}
+            with (
+                patch(
+                    "application_sdk.execution._temporal.interceptors.log.logger"
+                ) as mock_logger,
+                pytest.raises(AuthError),
+            ):
+                await interceptor.execute_workflow(MockExecuteWorkflowInput())
+
+        ended_calls = [
+            c for c in mock_logger.error.call_args_list if c[0][0] == "workflow.ended"
+        ]
+        assert len(ended_calls) == 1
+        kwargs = ended_calls[0][1]
+        assert kwargs["failure.category"] == "AUTH"
+        assert kwargs["failure.audience"] == "USER"
+        assert kwargs["failure.code"] == "AUTH"
+
+    async def test_workflow_ended_flattens_failure_attrs_from_application_error(
+        self, mock_next
+    ):
+        # Activity wrappers re-raise as ApplicationError(..., FailureDetails) —
+        # workflow-side propagation must still surface the original category.
+        leaf = InvalidInputError(message="missing field", field="hostname")
+        app_err = ApplicationError(
+            "missing field",
+            leaf.to_failure_details(),
+            type="InvalidInputError",
+            non_retryable=True,
+        )
+        mock_next.execute_workflow = AsyncMock(side_effect=app_err)
+        interceptor = _LogWorkflowInboundInterceptor(mock_next)
+
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = False
+            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.memo.return_value = {}
+            with (
+                patch(
+                    "application_sdk.execution._temporal.interceptors.log.logger"
+                ) as mock_logger,
+                pytest.raises(ApplicationError),
+            ):
+                await interceptor.execute_workflow(MockExecuteWorkflowInput())
+
+        ended_calls = [
+            c for c in mock_logger.error.call_args_list if c[0][0] == "workflow.ended"
+        ]
+        kwargs = ended_calls[0][1]
+        assert kwargs["failure.category"] == "INVALID_INPUT"
+        assert kwargs["failure.audience"] == "USER"
+        assert kwargs["failure.code"] == "INVALID_INPUT"
 
     async def test_generates_new_correlation_id_when_no_headers_no_memo(
         self, interceptor
@@ -363,6 +492,34 @@ class TestLogActivityInboundInterceptor:
         kwargs = ended_calls[0][1]
         assert kwargs["otel.status_code"] == "ERROR"
         assert kwargs["exc_info"] is True
+
+    async def test_activity_ended_flattens_failure_attrs_for_apperror(
+        self, mock_next
+    ):
+        mock_next.execute_activity = AsyncMock(
+            side_effect=AuthError(message="bad creds")
+        )
+        interceptor = _LogActivityInboundInterceptor(mock_next)
+
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.activity"
+        ) as mock_act:
+            mock_act.info.return_value = MockActivityInfo()
+            with (
+                patch(
+                    "application_sdk.execution._temporal.interceptors.log.logger"
+                ) as mock_logger,
+                pytest.raises(AuthError),
+            ):
+                await interceptor.execute_activity(MockExecuteActivityInput())
+
+        ended_calls = [
+            c for c in mock_logger.error.call_args_list if c[0][0] == "activity.ended"
+        ]
+        kwargs = ended_calls[0][1]
+        assert kwargs["failure.category"] == "AUTH"
+        assert kwargs["failure.audience"] == "USER"
+        assert kwargs["failure.code"] == "AUTH"
 
     async def test_reads_correlation_id_from_header(self, interceptor):
         payload = _encode_header("from-header")


### PR DESCRIPTION
## Summary

- LogInterceptor now emits `failure.category` / `failure.audience` / `failure.code` as top-level OTel attributes on `workflow.ended` and `activity.ended` ERROR logs.
- Reads from either an `AppError` raised directly or an `ApplicationError` whose `details[0]` is a `FailureDetails` (the shape produced by the SDK's activity wrapper).
- `logger_adaptor` passthrough prefix list gains `\"failure.\"` so the new keys ride the existing extra-key flattening machinery.

## Why

The SDK already owns the error vocabulary (`FailureCategory`, `Audience`, 14 leaf classes, `FailureDetails` wire envelope). The data is in the exception chain, but it never reaches downstream consumers — they see `exception.type`, `exception.message`, `exception.stacktrace` and that's it. To classify a failure (USER-fixable config vs APP_OWNER/PLATFORM-fixable real bug) consumers have to:

- regex-parse the stacktrace, or
- join `activity.ended` ERROR rows back to their parent `workflow.ended` row and hope the leaf class name survived the FQN, or
- redo the entire error taxonomy locally.

All of which is brittle and duplicates the SDK's classification logic.

This PR flattens the existing `to_failure_details()` output onto the OTel log so any consumer can read `LogAttributes['failure.audience']` directly.

## Use cases that benefit

- **Canary health gate** (`global-marketplace`): needs to distinguish config failures (user fault, don't rollback) from real failures (rollback signal). Currently has a fragile message-substring filter against `horizon.workflows.failure_category`; AE-native apps land in `otel_logs.service_logs` where no equivalent column exists.
- **SLA dashboards / on-call routing**: route by audience (`USER` → support, `PLATFORM` → infra, `APP_OWNER` → app team).
- **AE failure ingestion**: read structured category from logs instead of unpacking the Temporal ApplicationError details payload.

## Behavior when the exception isn't classified

If the active exception is a raw `ValueError` (or anything else not in the SDK taxonomy), the helper returns an empty dict and the three keys are simply absent from the log. Lets consumers distinguish "uncategorised" from a real category rather than fabricating a default.

## Implementation notes

- Cycle-safe walk via `id()` seen-set — avoids infinite loops on pathological `__context__` self-references.
- Lazy imports of `application_sdk.errors.*` and `temporalio.exceptions` inside the helper to keep `interceptors/log.py` free of error/Temporal-import side effects at module load.
- All exceptions in the extractor are caught (`# noqa: BLE001`) — this is an observability path; never raise into user code.

## Test plan

- [x] New unit tests: `test_extract_failure_attrs` (5 cases — None, non-AppError, direct AppError, cause-chain, ApplicationError-details, self-cycle guard).
- [x] New interceptor tests: workflow.ended + activity.ended ERROR cases flatten attrs for both `AppError` and `ApplicationError(FailureDetails)`.
- [x] Existing `workflow.ended` ERROR test asserts `failure.category` is absent for raw `ValueError` — guards the "uncategorised stays uncategorised" property.
- [x] `tests/unit/interceptors/test_log_interceptor.py` — 38 passed.
- [x] `tests/unit/observability/test_logger_adaptor.py` — 111 passed.