### PR TITLE
chore(ci): always run unit-tests matrix on PRs

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -94,8 +94,6 @@ jobs:
   # Testing
   unit:
     name: Unit Tests
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:


### PR DESCRIPTION
## Summary

- Drop the `needs: changes` + `if: needs.changes.outputs.code == 'true'` gate on the `unit` job in `.github/workflows/pull_request.yaml` so the matrix always expands.

## Why

When a PR only touches paths outside the `code` paths-filter (`application_sdk/**`, `tests/**`, `pyproject.toml`, `uv.lock`, `examples/**`, `.github/**`, `.security/**`) — e.g. a `contract-toolkit/**`-only change like #1700 — the `unit` job is skipped at the **job level**, before matrix expansion. GitHub then never creates the per-cell statuses (`Unit Tests (3.11, ubuntu-22.04)`, etc.).

Branch protection requires those 12 cell names → they remain in *"Expected — Waiting for status to be reported"* forever → the PR cannot merge.

Removing the gate makes the matrix expand on every PR so each required cell posts a real pass/fail status.

## Behavioral delta

| Scenario | Before | After |
|---|---|---|
| PR touches `application_sdk/**`, `tests/**`, etc. | 12 cells run | 12 cells run (unchanged) |
| PR touches only `contract-toolkit/**` / docs / configs | 0 cells run; required checks stuck → PR cannot merge | 12 cells run; statuses post; PR can merge |

## Trade-off

CI cost goes up on docs/config/contract-toolkit-only PRs (12 runner jobs across Linux/macOS/Windows). If that becomes painful later, the alternative is to keep the job unconditional but gate individual steps on `changes.outputs.code == 'true'` so the job still completes (success) and emits cell statuses without doing the work.

## Test plan

- [ ] CI on this PR runs the full unit-tests matrix and reports all 12 `Unit Tests (X.Y, OS)` statuses.
- [ ] Re-trigger CI on a contract-toolkit-only PR (e.g. #1700) after this merges and confirm all 12 statuses post and clear branch protection.