### PR TITLE
ci(build-and-publish-app): block 'all'-channel publish from non-main branches

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -83,8 +83,79 @@ permissions:
   pull-requests: write
 
 jobs:
+  # ── Job 0: Channel + branch gate ─────────────────────────────────────────────
+  # 'all'-channel releases reach every production tenant, so they MUST come
+  # from the protected `main` branch. Fail here (before the multi-arch build
+  # spends ~10 min) when channel=='all' and the build ref is not main.
+  # Only runs when `publish: true` — build-only invocations are unaffected.
+  # Beta, staging, and tenant-targeted publishes are unrestricted.
+  validate-channel:
+    name: Validate Channel + Branch
+    if: inputs.publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Enforce main-branch invariant for channel='all'
+        env:
+          # REF and CHANNEL/TENANTS are passed via env (not interpolated into
+          # the script body) — protects against shell injection from branch
+          # names containing backticks/$().
+          REF: ${{ inputs.ref || github.ref }}
+          CHANNEL: ${{ inputs.channel }}
+          TENANTS: ${{ inputs.tenants }}
+        run: |
+          set -euo pipefail
+
+          # Mirror the channel-resolution rules used at publish time:
+          #   tenants  -> specific  (skip gate)
+          #   channel='' or 'all' -> all  (enforce gate)
+          #   beta/staging/anything else -> skip gate
+          if [ -n "${TENANTS}" ]; then
+            echo "Tenants targeting (${TENANTS}) — main-branch gate skipped."
+            exit 0
+          fi
+          EFFECTIVE_CHANNEL="${CHANNEL:-all}"
+          if [ "${EFFECTIVE_CHANNEL}" != "all" ]; then
+            echo "Channel '${EFFECTIVE_CHANNEL}' — main-branch gate skipped."
+            exit 0
+          fi
+
+          # Accept both the short ('main') and qualified ('refs/heads/main')
+          # forms. Tags ('refs/tags/...') and feature branches are rejected.
+          case "${REF}" in
+            main|refs/heads/main)
+              echo "Channel 'all' on main — proceeding."
+              ;;
+            *)
+              echo "::error title=Publish blocked::Channel 'all' requires the main branch — got ref '${REF}'."
+              {
+                echo "### Publish blocked"
+                echo ""
+                echo "Releases to the **all** channel must be built from the **main** branch."
+                echo ""
+                echo "| Field | Value |"
+                echo "|-------|-------|"
+                echo "| Ref | \`${REF}\` |"
+                echo "| Channel | \`${EFFECTIVE_CHANNEL}\` |"
+                echo ""
+                echo "Re-run with one of:"
+                echo "- \`channel: beta\` or \`channel: staging\` (non-prod)"
+                echo "- \`tenants: <comma-separated-ids>\` (targeted)"
+                echo "- merge to \`main\` and let the push-trigger run"
+              } >> "${GITHUB_STEP_SUMMARY}"
+              exit 1
+              ;;
+          esac
+
   # ── Job 1: Read atlan.yaml, validate secrets, compute all image tags ──────────
   prepare:
+    needs: [validate-channel]
+    # `needs: [validate-channel]` only enforces ordering when that job runs.
+    # When publish=false, validate-channel is skipped via its `if:` — which by
+    # default would propagate "skipped" to dependents. The condition below
+    # explicitly allows prepare to run when validate-channel is skipped OR
+    # successful, but NOT when it failed.
+    if: ${{ !failure() && !cancelled() }}
     name: Prepare
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -110,18 +110,27 @@ jobs:
           #   tenants  -> specific  (skip gate)
           #   channel='' or 'all' -> all  (enforce gate)
           #   beta/staging/anything else -> skip gate
+          #
+          # Channel is lowercased before comparison so a stray 'ALL'/'All'
+          # can't slip past — the downstream API treats target_channel
+          # case-sensitively, so we normalize here.
           if [ -n "${TENANTS}" ]; then
             echo "Tenants targeting (${TENANTS}) — main-branch gate skipped."
             exit 0
           fi
           EFFECTIVE_CHANNEL="${CHANNEL:-all}"
+          EFFECTIVE_CHANNEL="${EFFECTIVE_CHANNEL,,}"  # bash 4+ lowercase
           if [ "${EFFECTIVE_CHANNEL}" != "all" ]; then
             echo "Channel '${EFFECTIVE_CHANNEL}' — main-branch gate skipped."
             exit 0
           fi
 
           # Accept both the short ('main') and qualified ('refs/heads/main')
-          # forms. Tags ('refs/tags/...') and feature branches are rejected.
+          # forms. Anything else falls through to the reject arm, including:
+          #   - feature branches (refs/heads/feat-foo, feat/foo, …)
+          #   - tag refs (refs/tags/v1.2.3) — by design: tag-triggered builds
+          #     should not auto-publish to all tenants; cut a release from
+          #     main and let the push-trigger run instead.
           case "${REF}" in
             main|refs/heads/main)
               echo "Channel 'all' on main — proceeding."
@@ -140,7 +149,7 @@ jobs:
                 echo ""
                 echo "Re-run with one of:"
                 echo "- \`channel: beta\` or \`channel: staging\` (non-prod)"
-                echo "- \`tenants: <comma-separated-ids>\` (targeted)"
+                echo "- \`tenants: <comma-separated-ids>\` (targeted to specific tenants)"
                 echo "- merge to \`main\` and let the push-trigger run"
               } >> "${GITHUB_STEP_SUMMARY}"
               exit 1


### PR DESCRIPTION
## Summary

Add a pre-flight `validate-channel` job to the unified `build-and-publish-app.yaml` workflow. When the effective channel is `all` (default when no flags are passed) and the build ref is not `main` / `refs/heads/main`, the job fails the run with a `::error::` annotation and a step-summary block — **before** checkout, multi-arch build, and publish run.

This is the workflow used by Atlan first-party app pipelines. It calls the GM publish API directly via curl (no atlan CLI), so the workflow-level gate is the only pre-server defense for these apps.

This is **layer 3 of 3** in a defense-in-depth rollout:

| Layer | Repo | Status |
|---|---|---|
| 1. Server (authoritative) | [global-marketplace#169](https://github.com/atlanhq/global-marketplace/pull/169) | 🟢 |
| 2. CLI (early fail, for repos still on the standalone path) | [atlan-cli#216](https://github.com/atlanhq/atlan-cli/pull/216) | 🟢 |
| 3. Reusable workflow | `application-sdk` (this PR) | 🟢 |

### What gets rejected

| Invocation | Verdict |
|---|---|
| Push to `main` (auto-trigger) | ✅ |
| `workflow_dispatch` from `main`, default channel | ✅ |
| `workflow_dispatch` from `feat/foo`, channel=`all` | ❌ blocked at `validate-channel` |
| `workflow_dispatch` from `feat/foo`, channel=`beta` | ✅ |
| `workflow_dispatch` from `feat/foo`, tenants=`t1` | ✅ (tenants overrides channel) |
| `workflow_dispatch` from a tag | ❌ blocked at `validate-channel` |
| Any build-only run (`publish: false`) | ✅ (gate is skipped) |

### UX

When blocked, the run shows:

> **Publish blocked**: Channel 'all' requires the main branch — got ref 'feat/foo'.
>
> Re-run with one of:
> - `channel: beta` or `channel: staging` (non-prod)
> - `tenants: <comma-separated-ids>` (targeted)
> - merge to `main` and let the push-trigger run

### Implementation notes

- Inputs are passed via `env:` (not interpolated into the shell body) — safe from shell injection via branch names.
- `validate-channel` is a small dedicated job (~10s); downstream jobs depend on it via `needs:` so the heavy work only starts once the gate passes.
- Gate is itself gated by `if: inputs.publish` so build-only runs aren't affected. `prepare` uses `if: !failure() && !cancelled()` so a skipped gate still allows the build to run.

## Test plan

- [x] YAML validates (`yaml.safe_load`)
- [x] Case-statement logic walked through manually for all 6 inputs above
- [ ] CI green on this branch
- [ ] After merge: trigger publish from a feature branch with `channel: all` and confirm the gate fires
- [ ] Confirm build-only runs (`publish: false`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)