### PR TITLE
feat(ci): add SDR cross-repo trigger for connector PRs [BLDX-1254]

### DIFF
--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -128,12 +128,17 @@ runs:
           echo "Workflow run $run_id in $repo_name succeeded"
         fi
 
-    # Pull the dispatched run's pytest summary line out of the uploaded
-    # results artifact so the SDK-side sticky shows the actual test
-    # counts, not just pass/fail. Workflow-dispatch can't return step
-    # outputs to the caller, so this is the only path from a dispatched
-    # run's per-step output back to the apps-sdk PR comment.
-    - name: Fetch dispatched-run summary
+    # Pull the dispatched run's rendered PR-comment body out of the
+    # uploaded results artifact so the SDK-side sticky shows the same
+    # markdown as the connector-side sticky (status, summary, asset
+    # tables, lineage coverage, validates block). Workflow-dispatch
+    # can't return step outputs to the caller, so the results artifact
+    # is the only channel from the dispatched run's output back to the
+    # apps-sdk PR comment.
+    #
+    # Falls back to a status-only body when the artifact is missing
+    # (dispatch failed, run cancelled before tests, etc.).
+    - name: Fetch dispatched-run report body
       id: dispatched_summary
       if: always() && steps.return_dispatch.outputs.run_id != ''
       shell: bash
@@ -147,26 +152,19 @@ runs:
           "repos/atlanhq/${REPO_NAME}/actions/runs/${RUN_ID}/artifacts" \
           --jq '.artifacts[] | select(.name | test("results$")) | .id' \
           | head -1)
-        if [ -z "${artifact_id}" ]; then
-          echo "No results artifact on run ${RUN_ID}; skipping summary fetch."
-          echo "summary=" >> "$GITHUB_OUTPUT"
-          exit 0
+        body_path=""
+        if [ -n "${artifact_id}" ]; then
+          work=$(mktemp -d)
+          gh api \
+            "repos/atlanhq/${REPO_NAME}/actions/artifacts/${artifact_id}/zip" \
+            > "${work}/results.zip" 2>/dev/null || true
+          unzip -qq -o "${work}/results.zip" -d "${work}" 2>/dev/null || true
+          if [ -f "${work}/pr-comment-body.md" ]; then
+            body_path="${work}/pr-comment-body.md"
+            echo "Found rendered comment body in artifact."
+          fi
         fi
-        work=$(mktemp -d)
-        gh api \
-          "repos/atlanhq/${REPO_NAME}/actions/artifacts/${artifact_id}/zip" \
-          > "${work}/results.zip" 2>/dev/null || true
-        unzip -qq -o "${work}/results.zip" -d "${work}" 2>/dev/null || true
-        out="${work}/sdr-test-output.txt"
-        if [ ! -f "${out}" ]; then
-          echo "sdr-test-output.txt not in artifact; skipping summary."
-          echo "summary=" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-        summary=$(grep -E "^=+.*(passed|failed|error).*in [0-9.]+s" "${out}" | tail -1 | tr -d '=' | xargs)
-        echo "Captured summary: ${summary}"
-        # Quote multi-line safety: pytest summary is single line.
-        echo "summary=${summary}" >> "$GITHUB_OUTPUT"
+        echo "body_path=${body_path}" >> "$GITHUB_OUTPUT"
 
     # Sticky comment back on the calling SDK PR so reviewers see the
     # cross-repo dispatch outcome without clicking through to the
@@ -182,49 +180,64 @@ runs:
         RUN_URL: ${{ steps.return_dispatch.outputs.run_url }}
         DISPATCHED_CONCLUSION: ${{ steps.status.outputs.conclusion }}
         DISPATCHED_STATUS: ${{ steps.status.outputs.status }}
-        DISPATCHED_SUMMARY: ${{ steps.dispatched_summary.outputs.summary }}
+        RENDERED_BODY_PATH: ${{ steps.dispatched_summary.outputs.body_path }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
+          const fs = require('fs');
           const repoName = process.env.REPO_NAME;
           const workflow = process.env.WORKFLOW;
           const runId    = process.env.RUN_ID;
           const runUrl   = process.env.RUN_URL;
           const conclusion = process.env.DISPATCHED_CONCLUSION || '';
           const status    = process.env.DISPATCHED_STATUS || '';
-          const summary   = (process.env.DISPATCHED_SUMMARY || '').trim();
-
-          const titlesByWorkflow = {
-            "sdr-integration-tests.yaml": `SDR Integration Tests (testcontainer) — ${repoName}`,
-            "e2e-full.yaml":               `E2E Full Tests (system apps) — ${repoName}`,
-          };
-          const title = titlesByWorkflow[workflow] || `${workflow} — ${repoName}`;
-
-          const statusLine =
-              conclusion === "success"   ? "Passed ✅"
-            : conclusion === "failure"   ? "Failed ❌"
-            : conclusion === "cancelled" ? "Cancelled 🚫"
-            : conclusion === "timeout"   ? "Timed out ⏰ (dispatched run still in progress when the SDK side gave up — check the run link)"
-            : `Unknown — status=${status}, conclusion=${conclusion}`;
-
-          const runLine = runId
-            ? `[${runId}](${runUrl})`
-            : `_dispatch failed before a run id was assigned_`;
+          const renderedPath = process.env.RENDERED_BODY_PATH || '';
 
           const sticky = `<!-- e2e-apps-cross-repo:${workflow}:${repoName} -->`;
-          const lines = [
-            sticky,
-            `## 🧪 ${title}`,
-            ``,
-            `**Status:** ${statusLine}`,
-          ];
-          if (summary) {
-            lines.push(`**Summary:** \`${summary}\``);
+
+          // Prefer the connector-side rendered body so both PRs (the
+          // connector PR and this SDK PR) show identical content. The
+          // connector sticky line (e.g. <!-- sdr-integration-tests... -->)
+          // gets stripped and replaced with this side's marker so
+          // sticky-updates don't collide.
+          let body = '';
+          if (renderedPath && fs.existsSync(renderedPath)) {
+            const raw = fs.readFileSync(renderedPath, 'utf8');
+            // Drop a leading HTML-comment marker line so we can prepend
+            // our own; otherwise leave the body untouched.
+            const lines = raw.split('\n');
+            const startsWithMarker = /^<!--\s.*\s-->\s*$/.test(lines[0] || '');
+            const stripped = startsWithMarker ? lines.slice(1).join('\n') : raw;
+            body = sticky + '\n' + stripped.trimStart();
+          } else {
+            // Fallback: status-only body when the artifact wasn't
+            // available (dispatch failed before tests ran, run cancelled
+            // pre-upload, etc.). Keeps the SDK PR informed even when the
+            // connector-side rendering didn't happen.
+            const titlesByWorkflow = {
+              "sdr-integration-tests.yaml": `SDR Integration Tests (testcontainer) — ${repoName}`,
+              "e2e-full.yaml":               `E2E Full Tests (system apps) — ${repoName}`,
+            };
+            const title = titlesByWorkflow[workflow] || `${workflow} — ${repoName}`;
+            const statusLine =
+                conclusion === "success"   ? "Passed ✅"
+              : conclusion === "failure"   ? "Failed ❌"
+              : conclusion === "cancelled" ? "Cancelled 🚫"
+              : conclusion === "timeout"   ? "Timed out ⏰ (dispatched run still in progress when the SDK side gave up — check the run link)"
+              : `Unknown — status=${status}, conclusion=${conclusion}`;
+            const runLine = runId
+              ? `[${runId}](${runUrl})`
+              : `_dispatch failed before a run id was assigned_`;
+            body = [
+              sticky,
+              `## 🧪 ${title}`,
+              ``,
+              `**Status:** ${statusLine}`,
+              `**Dispatched run:** ${runLine}`,
+              ``,
+              `> Cross-repo dispatch from this SDK PR. Detailed report unavailable — the dispatched run did not produce a results artifact.`,
+            ].join('\n');
           }
-          lines.push(`**Dispatched run:** ${runLine}`);
-          lines.push(``);
-          lines.push(`> Cross-repo dispatch from this SDK PR. The connector-side run posts its own sticky comment with asset counts + validates block to [${repoName}](https://github.com/atlanhq/${repoName}) when triggered from a connector PR; this comment is the SDK-side echo.`);
-          const body = lines.join('\n');
 
           const comments = await github.paginate(github.rest.issues.listComments, {
             owner: context.repo.owner,

--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -128,6 +128,46 @@ runs:
           echo "Workflow run $run_id in $repo_name succeeded"
         fi
 
+    # Pull the dispatched run's pytest summary line out of the uploaded
+    # results artifact so the SDK-side sticky shows the actual test
+    # counts, not just pass/fail. Workflow-dispatch can't return step
+    # outputs to the caller, so this is the only path from a dispatched
+    # run's per-step output back to the apps-sdk PR comment.
+    - name: Fetch dispatched-run summary
+      id: dispatched_summary
+      if: always() && steps.return_dispatch.outputs.run_id != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO_NAME: ${{ inputs.repo-name }}
+        RUN_ID: ${{ steps.return_dispatch.outputs.run_id }}
+      run: |
+        set -uo pipefail
+        artifact_id=$(gh api \
+          "repos/atlanhq/${REPO_NAME}/actions/runs/${RUN_ID}/artifacts" \
+          --jq '.artifacts[] | select(.name | test("results$")) | .id' \
+          | head -1)
+        if [ -z "${artifact_id}" ]; then
+          echo "No results artifact on run ${RUN_ID}; skipping summary fetch."
+          echo "summary=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        work=$(mktemp -d)
+        gh api \
+          "repos/atlanhq/${REPO_NAME}/actions/artifacts/${artifact_id}/zip" \
+          > "${work}/results.zip" 2>/dev/null || true
+        unzip -qq -o "${work}/results.zip" -d "${work}" 2>/dev/null || true
+        out="${work}/sdr-test-output.txt"
+        if [ ! -f "${out}" ]; then
+          echo "sdr-test-output.txt not in artifact; skipping summary."
+          echo "summary=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        summary=$(grep -E "^=+.*(passed|failed|error).*in [0-9.]+s" "${out}" | tail -1 | tr -d '=' | xargs)
+        echo "Captured summary: ${summary}"
+        # Quote multi-line safety: pytest summary is single line.
+        echo "summary=${summary}" >> "$GITHUB_OUTPUT"
+
     # Sticky comment back on the calling SDK PR so reviewers see the
     # cross-repo dispatch outcome without clicking through to the
     # connector run. Uses updateComment in-place when a prior marker
@@ -142,6 +182,7 @@ runs:
         RUN_URL: ${{ steps.return_dispatch.outputs.run_url }}
         DISPATCHED_CONCLUSION: ${{ steps.status.outputs.conclusion }}
         DISPATCHED_STATUS: ${{ steps.status.outputs.status }}
+        DISPATCHED_SUMMARY: ${{ steps.dispatched_summary.outputs.summary }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -151,6 +192,7 @@ runs:
           const runUrl   = process.env.RUN_URL;
           const conclusion = process.env.DISPATCHED_CONCLUSION || '';
           const status    = process.env.DISPATCHED_STATUS || '';
+          const summary   = (process.env.DISPATCHED_SUMMARY || '').trim();
 
           const titlesByWorkflow = {
             "sdr-integration-tests.yaml": `SDR Integration Tests (testcontainer) — ${repoName}`,
@@ -170,15 +212,19 @@ runs:
             : `_dispatch failed before a run id was assigned_`;
 
           const sticky = `<!-- e2e-apps-cross-repo:${workflow}:${repoName} -->`;
-          const body = [
+          const lines = [
             sticky,
-            `## ${title}`,
+            `## 🧪 ${title}`,
             ``,
             `**Status:** ${statusLine}`,
-            `**Dispatched run:** ${runLine}`,
-            ``,
-            `> Cross-repo dispatch from this SDK PR. The connector-side run posts its own sticky comment with asset counts + validates block to [${repoName}](https://github.com/atlanhq/${repoName}) when triggered from a connector PR; this comment is the SDK-side echo.`,
-          ].join('\n');
+          ];
+          if (summary) {
+            lines.push(`**Summary:** \`${summary}\``);
+          }
+          lines.push(`**Dispatched run:** ${runLine}`);
+          lines.push(``);
+          lines.push(`> Cross-repo dispatch from this SDK PR. The connector-side run posts its own sticky comment with asset counts + validates block to [${repoName}](https://github.com/atlanhq/${repoName}) when triggered from a connector PR; this comment is the SDK-side echo.`);
+          const body = lines.join('\n');
 
           const comments = await github.paginate(github.rest.issues.listComments, {
             owner: context.repo.owner,

--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -195,25 +195,38 @@ runs:
 
           const sticky = `<!-- e2e-apps-cross-repo:${workflow}:${repoName} -->`;
 
+          const hasRenderedBody = renderedPath && fs.existsSync(renderedPath);
+          const hasKnownConclusion = [
+            "success", "failure", "cancelled", "timeout",
+          ].includes(conclusion);
+
+          // Skip the comment entirely when we have nothing useful to say:
+          // no rendered body from the dispatched run AND no resolved
+          // conclusion. The job check_run on the SDK PR still signals
+          // the failure — a "Status: Unknown" sticky just adds noise.
+          if (!hasRenderedBody && !hasKnownConclusion) {
+            core.info('No rendered body and no resolved conclusion — skipping SDK-side PR comment.');
+            return;
+          }
+
           // Prefer the connector-side rendered body so both PRs (the
           // connector PR and this SDK PR) show identical content. The
           // connector sticky line (e.g. <!-- sdr-integration-tests... -->)
           // gets stripped and replaced with this side's marker so
           // sticky-updates don't collide.
           let body = '';
-          if (renderedPath && fs.existsSync(renderedPath)) {
+          if (hasRenderedBody) {
             const raw = fs.readFileSync(renderedPath, 'utf8');
-            // Drop a leading HTML-comment marker line so we can prepend
-            // our own; otherwise leave the body untouched.
             const lines = raw.split('\n');
             const startsWithMarker = /^<!--\s.*\s-->\s*$/.test(lines[0] || '');
             const stripped = startsWithMarker ? lines.slice(1).join('\n') : raw;
             body = sticky + '\n' + stripped.trimStart();
           } else {
-            // Fallback: status-only body when the artifact wasn't
-            // available (dispatch failed before tests ran, run cancelled
-            // pre-upload, etc.). Keeps the SDK PR informed even when the
-            // connector-side rendering didn't happen.
+            // Resolved conclusion but no artifact — happens when the
+            // dispatched run failed/cancelled before its render step
+            // wrote pr-comment-body.md. Post a status-only sticky so
+            // the reviewer sees the outcome + run link without having
+            // to dig through the SDK PR's check_run list.
             const titlesByWorkflow = {
               "sdr-integration-tests.yaml": `SDR Integration Tests (testcontainer) — ${repoName}`,
               "e2e-full.yaml":               `E2E Full Tests (system apps) — ${repoName}`,
@@ -223,8 +236,7 @@ runs:
                 conclusion === "success"   ? "Passed ✅"
               : conclusion === "failure"   ? "Failed ❌"
               : conclusion === "cancelled" ? "Cancelled 🚫"
-              : conclusion === "timeout"   ? "Timed out ⏰ (dispatched run still in progress when the SDK side gave up — check the run link)"
-              : `Unknown — status=${status}, conclusion=${conclusion}`;
+              :                              "Timed out ⏰ (dispatched run still in progress when the SDK side gave up — check the run link)";
             const runLine = runId
               ? `[${runId}](${runUrl})`
               : `_dispatch failed before a run id was assigned_`;

--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -71,7 +71,11 @@ runs:
         repo: ${{ inputs.repo-name }}
         owner: "atlanhq"
         workflow: "${{ inputs.workflow }}"
-        workflow_timeout_seconds: 300
+        # 300s wasn't enough for the e2e-full path: the dispatched run
+        # spends 1–3 min in the GH-hosted runner queue before its
+        # `distinct-id <sha>` step (step #2) is even visible. Bump to
+        # 600s so return-dispatch can poll past the queue delay.
+        workflow_timeout_seconds: 600
         workflow_job_steps_retry_seconds: 60
         distinct_id: "${{ env.distinct_id }}"
         workflow_inputs: ${{ inputs.workflow-inputs }}

--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -87,6 +87,7 @@ runs:
         echo ${{steps.return_dispatch.outputs.run_url}}
 
     - name: Check Workflow Status
+      id: status
       shell: bash
       run: |
         repo_owner="atlanhq"
@@ -96,6 +97,7 @@ runs:
         echo "Checking status of workflow run $run_id in $repo_name"
 
         status="in_progress"
+        conclusion=""
         start_time=$(date +%s)
         timeout=600
         while [[ "$status" == "in_progress" || "$status" == "queued" || "$status" == "pending" || "$status" == "waiting" ]]; do
@@ -112,13 +114,105 @@ runs:
 
           if [[ $elapsed_time -ge $timeout ]]; then
             echo "Workflow run timeout reached after $timeout seconds"
-            exit 1
+            echo "status=timeout" >> "$GITHUB_OUTPUT"
+            echo "conclusion=timeout" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
         done
 
+        echo "status=$status" >> "$GITHUB_OUTPUT"
+        echo "conclusion=$conclusion" >> "$GITHUB_OUTPUT"
         if [[ "$conclusion" != "success" ]]; then
           echo "Workflow run $run_id in $repo_name failed with conclusion $conclusion"
-          exit 1
         else
           echo "Workflow run $run_id in $repo_name succeeded"
+        fi
+
+    # Sticky comment back on the calling SDK PR so reviewers see the
+    # cross-repo dispatch outcome without clicking through to the
+    # connector run. Uses updateComment in-place when a prior marker
+    # exists so re-pushes don't spam the PR thread.
+    - name: Post dispatched-run status to SDK PR
+      if: always() && github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      env:
+        REPO_NAME: ${{ inputs.repo-name }}
+        WORKFLOW: ${{ inputs.workflow }}
+        RUN_ID: ${{ steps.return_dispatch.outputs.run_id }}
+        RUN_URL: ${{ steps.return_dispatch.outputs.run_url }}
+        DISPATCHED_CONCLUSION: ${{ steps.status.outputs.conclusion }}
+        DISPATCHED_STATUS: ${{ steps.status.outputs.status }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const repoName = process.env.REPO_NAME;
+          const workflow = process.env.WORKFLOW;
+          const runId    = process.env.RUN_ID;
+          const runUrl   = process.env.RUN_URL;
+          const conclusion = process.env.DISPATCHED_CONCLUSION || '';
+          const status    = process.env.DISPATCHED_STATUS || '';
+
+          const titlesByWorkflow = {
+            "sdr-integration-tests.yaml": `SDR Integration Tests (testcontainer) — ${repoName}`,
+            "e2e-full.yaml":               `E2E Full Tests (system apps) — ${repoName}`,
+          };
+          const title = titlesByWorkflow[workflow] || `${workflow} — ${repoName}`;
+
+          const statusLine =
+              conclusion === "success"   ? "Passed ✅"
+            : conclusion === "failure"   ? "Failed ❌"
+            : conclusion === "cancelled" ? "Cancelled 🚫"
+            : conclusion === "timeout"   ? "Timed out ⏰ (dispatched run still in progress when the SDK side gave up — check the run link)"
+            : `Unknown — status=${status}, conclusion=${conclusion}`;
+
+          const runLine = runId
+            ? `[${runId}](${runUrl})`
+            : `_dispatch failed before a run id was assigned_`;
+
+          const sticky = `<!-- e2e-apps-cross-repo:${workflow}:${repoName} -->`;
+          const body = [
+            sticky,
+            `## ${title}`,
+            ``,
+            `**Status:** ${statusLine}`,
+            `**Dispatched run:** ${runLine}`,
+            ``,
+            `> Cross-repo dispatch from this SDK PR. The connector-side run posts its own sticky comment with asset counts + validates block to [${repoName}](https://github.com/atlanhq/${repoName}) when triggered from a connector PR; this comment is the SDK-side echo.`,
+          ].join('\n');
+
+          const comments = await github.paginate(github.rest.issues.listComments, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            per_page: 100,
+          });
+          const existing = comments.find(c => c.body && c.body.includes(sticky));
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+          }
+      continue-on-error: true
+
+    # Re-emit the failure exit code AFTER the comment lands, so the job
+    # still fails the PR check but the reviewer sees a comment either way.
+    - name: Fail job if dispatched run did not succeed
+      if: always()
+      shell: bash
+      env:
+        DISPATCHED_CONCLUSION: ${{ steps.status.outputs.conclusion }}
+      run: |
+        if [[ "$DISPATCHED_CONCLUSION" != "success" ]]; then
+          echo "Dispatched run conclusion: $DISPATCHED_CONCLUSION"
+          exit 1
         fi

--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -23,6 +23,22 @@ inputs:
   target-branch:
     required: true
     description: The target branch to test.
+  workflow:
+    required: false
+    default: e2e-integration-test.yaml
+    description: |
+      Filename of the workflow to dispatch in the target repo. Defaults
+      to the historical e2e-integration-test.yaml. Set to
+      sdr-integration-tests.yaml for the SDR cross-repo path.
+  workflow-inputs:
+    required: false
+    default: "{}"
+    description: |
+      Optional JSON object of inputs to pass to the dispatched workflow
+      (in addition to distinct_id, which is always passed). Used by the
+      SDR path to forward application_sdk_ref so the connector can pin
+      atlan-application-sdk to the apps-sdk PR's head SHA. Defaults to
+      an empty object so codex-/return-dispatch always sees valid JSON.
 
 runs:
   using: "composite"
@@ -54,10 +70,11 @@ runs:
         ref: ${{ inputs.target-branch }}
         repo: ${{ inputs.repo-name }}
         owner: "atlanhq"
-        workflow: "e2e-integration-test.yaml"
+        workflow: "${{ inputs.workflow }}"
         workflow_timeout_seconds: 300
         workflow_job_steps_retry_seconds: 60
         distinct_id: "${{ env.distinct_id }}"
+        workflow_inputs: ${{ inputs.workflow-inputs }}
 
     - name: Check the test logs using the below run URL
       shell: bash

--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -99,21 +99,46 @@ runs:
         status="in_progress"
         conclusion=""
         start_time=$(date +%s)
-        timeout=600
+        # Match the dispatched workflow's own timeout-minutes ceiling.
+        # mysql-app's e2e-full-reusable.yaml sets timeout-minutes: 120
+        # (the full-DAG harness needs ~20-40 min wall-time; the SDR
+        # testcontainer suite stays well under this). 600s was the
+        # earlier value tuned only for SDR — full-DAG was timing out
+        # the SDK-side poll loop while the dispatched run was still
+        # legitimately running.
+        timeout=7200
+        # Heartbeat cadence: 60s matches the connector-side AE poll
+        # cadence emitted by AEWorkflowClient.poll_native_status so
+        # the SDK-side log doesn't out-spam the dispatched run's own
+        # progress glyphs. Drop to 30s only when nearing the timeout.
+        poll_interval=60
+        glyph_for_status() {
+          case "$1" in
+            queued|waiting|pending) echo "🟡" ;;
+            in_progress)            echo "🔄" ;;
+            completed)              echo "✅" ;;
+            *)                      echo "❔" ;;
+          esac
+        }
         while [[ "$status" == "in_progress" || "$status" == "queued" || "$status" == "pending" || "$status" == "waiting" ]]; do
-          sleep 30
+          sleep $poll_interval
           response=$(curl -s -H "Authorization: Bearer ${{ inputs.github-token }}" \
             https://api.github.com/repos/$repo_owner/$repo_name/actions/runs/$run_id)
           status=$(echo $response | jq -r '.status')
           conclusion=$(echo $response | jq -r '.conclusion')
 
-          echo "Status: $status, Conclusion: $conclusion"
-
           current_time=$(date +%s)
           elapsed_time=$((current_time - start_time))
 
+          # Mirror the connector-side poll-line shape:
+          #   🔄 dispatched run [120s] in_progress
+          # so the SDK PR's log scans the same way as the mysql-app
+          # PR's worker log (test-tube emoji + elapsed + status).
+          printf '%s dispatched run [%3ds] %s\n' \
+            "$(glyph_for_status "$status")" "$elapsed_time" "$status"
+
           if [[ $elapsed_time -ge $timeout ]]; then
-            echo "Workflow run timeout reached after $timeout seconds"
+            echo "⏰ Workflow run timeout reached after $timeout seconds"
             echo "status=timeout" >> "$GITHUB_OUTPUT"
             echo "conclusion=timeout" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -762,6 +762,56 @@ runs:
                 lines.append(f"| {entity} | {ext_s} | {tr_s} |")
             lines.append("")
 
+        # Full-DAG runs append the post-lineage Atlas inventory the harness
+        # logs at the end of its run ("Atlas inventory under <qn>: {...}
+        # lineage_present=True"). SDR runs never emit this line, so the
+        # section is added only when a match is found — keeps the SDR
+        # comment unchanged. Reads sdr-test-output.txt (pytest stdout)
+        # because the line comes from the harness logger, not the
+        # docker container.
+        import ast
+
+        test_log = Path("results/sdr-test-output.txt")
+        if test_log.exists():
+            test_text = test_log.read_text(errors="replace")
+            atlas_re = re.compile(
+                r"Atlas inventory under (?P<qn>\S+):\s+(?P<counts>\{.*?\})\s+lineage_present=(?P<lin>True|False)"
+            )
+            last_match = None
+            for m in atlas_re.finditer(test_text):
+                last_match = m  # keep the last one in case retries logged earlier ones
+            if last_match:
+                try:
+                    counts = ast.literal_eval(last_match.group("counts"))
+                    if not isinstance(counts, dict):
+                        counts = {}
+                except (ValueError, SyntaxError):
+                    counts = {}
+                lineage_present = last_match.group("lin") == "True"
+                lineage_count = (
+                    counts.get("Process", 0) + counts.get("ColumnProcess", 0)
+                )
+                lines.append(
+                    f"### Atlas inventory under `{last_match.group('qn')}`"
+                )
+                lines.append("")
+                lines.append("| Type | Count |")
+                lines.append("|------|-------|")
+                for type_name in sorted(counts):
+                    lines.append(f"| {type_name} | {counts[type_name]} |")
+                lines.append("")
+                if lineage_count or lineage_present:
+                    lineage_status = (
+                        f"✅ {lineage_count} edge{'s' if lineage_count != 1 else ''} "
+                        "(`Process` + `ColumnProcess`)"
+                        if lineage_count
+                        else "✅ present"
+                    )
+                else:
+                    lineage_status = "⚠️ none observed (waived for connectors without view-derived lineage)"
+                lines.append(f"**Lineage:** {lineage_status}")
+                lines.append("")
+
         markdown = "\n".join(lines)
         delim = "EOF_ASSETS_" + secrets.token_hex(8)
         with open(os.environ["GITHUB_OUTPUT"], "a") as f:

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -142,6 +142,18 @@ runs:
     # action can't invoke another action mid-sequence with conditional
     # `uses:` — curl install is the simplest fallback that doesn't pin a
     # specific runner image.
+    # Stash the repin script in /tmp before setup-deps' actions/checkout
+    # wipes the entire workspace (which includes ${{ github.action_path }}
+    # when this action is invoked as a LOCAL action via
+    # `uses: ./.application-sdk/.github/actions/sdr-e2e`). The post-setup
+    # repin step exec's from /tmp/sdr-e2e-repin-application-sdk.sh instead.
+    - name: Stash repin script
+      if: inputs.application-sdk-ref != ''
+      shell: bash
+      run: |
+        cp "${{ github.action_path }}/repin-application-sdk.sh" /tmp/sdr-e2e-repin-application-sdk.sh
+        chmod +x /tmp/sdr-e2e-repin-application-sdk.sh
+
     - name: Pin application-sdk to dispatched ref (pre-build)
       if: inputs.application-sdk-ref != ''
       shell: bash
@@ -201,13 +213,25 @@ runs:
     # it again so the host pytest runtime resolves the dispatched SDK
     # (the BaseSDRIntegrationTest, agent contracts, etc.). Followed by
     # an explicit uv sync so the lockfile reflects the new pin.
+    #
+    # Important: when this action is invoked as a LOCAL action (uses:
+    # ./.application-sdk/.github/actions/sdr-e2e), setup-deps' inner
+    # actions/checkout wipes the entire workspace — including
+    # ${{ github.action_path }}/repin-application-sdk.sh itself, so we
+    # can't reference it again here. The "stash repin script" step
+    # below copies the script to /tmp before setup-deps runs; this step
+    # exec's from the stash.
     - name: Pin application-sdk to dispatched ref (post-setup)
       if: inputs.application-sdk-ref != ''
       shell: bash
       env:
         SDK_REF: ${{ inputs.application-sdk-ref }}
       run: |
-        ${{ github.action_path }}/repin-application-sdk.sh
+        if [ -f /tmp/sdr-e2e-repin-application-sdk.sh ]; then
+          /tmp/sdr-e2e-repin-application-sdk.sh
+        else
+          ${{ github.action_path }}/repin-application-sdk.sh
+        fi
         uv lock
         uv sync --all-extras --all-groups
 

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -98,12 +98,29 @@ runs:
     # uv sync resolves atlan-application-sdk to that ref. Repeated again
     # below after setup-deps re-checks-out the workspace (which wipes
     # this edit) so the host pytest runtime also picks up the ref.
+    #
+    # The Docker build runs `uv sync --locked` which requires uv.lock and
+    # pyproject.toml to be consistent. The repin only modifies
+    # pyproject.toml, so install uv inline and run `uv lock` before the
+    # Docker build to keep them aligned. setup-uv@v5 (which installs uv
+    # the "official" way) isn't available here because the composite
+    # action can't invoke another action mid-sequence with conditional
+    # `uses:` — curl install is the simplest fallback that doesn't pin a
+    # specific runner image.
     - name: Pin application-sdk to dispatched ref (pre-build)
       if: inputs.application-sdk-ref != ''
       shell: bash
       env:
         SDK_REF: ${{ inputs.application-sdk-ref }}
-      run: ${{ github.action_path }}/repin-application-sdk.sh
+      run: |
+        ${{ github.action_path }}/repin-application-sdk.sh
+        if ! command -v uv >/dev/null 2>&1; then
+          echo "Installing uv for the pre-build re-lock..."
+          curl -LsSf https://astral.sh/uv/0.7.3/install.sh | sh
+          export PATH="$HOME/.local/bin:$PATH"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        fi
+        uv lock
 
     # Image build runs before setup-deps so the workspace is still pristine —
     # no host .venv yet, so the Dockerfile's COPY . . won't pull in a

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -40,6 +40,19 @@ inputs:
     description: Pytest target directory containing the SDR test suite.
     required: false
     default: tests/sdr/
+  report-title:
+    description: |
+      Short label used in the PR-comment / step-summary report title and
+      the PR comment marker. When empty (the default), the action derives
+      a title from `test-path`:
+        tests/sdr/        → "SDR Integration Tests"
+        tests/full_dag/   → "Full-DAG E2E Tests"
+        tests/<other>/    → "<other> Tests" (with hyphens/underscores
+                            replaced by spaces and the first letter
+                            uppercased).
+      Override to a literal label if the auto-derived one doesn't fit.
+    required: false
+    default: ""
   secrets-script:
     description: |
       Path (relative to repo root) to a bash or python script that writes
@@ -475,6 +488,8 @@ runs:
       env:
         OUTCOME: ${{ steps.tests.outcome }}
         APP_NAME: ${{ inputs.app-name }}
+        REPORT_TITLE_OVERRIDE: ${{ inputs.report-title }}
+        TEST_PATH: ${{ inputs.test-path }}
       run: |
         uv run python3 - <<'PYEOF'
         import os, re, xml.etree.ElementTree as ET
@@ -483,6 +498,26 @@ runs:
         outcome  = os.environ.get("OUTCOME", "unknown")
         app_name = os.environ.get("APP_NAME", "app")
         icon     = "✅" if outcome == "success" else "❌"
+
+        # Title is either explicit (via `report-title` input) or derived
+        # from the pytest target path. Keeps the report self-labelling
+        # when the action is reused across different suites in the same
+        # repo (e.g. tier-3 sdr-integration-tests vs e2e-full).
+        def _title_from_test_path(path: str) -> str:
+            specials = {
+                "sdr": "SDR Integration Tests",
+                "full_dag": "Full-DAG E2E Tests",
+            }
+            seg = path.strip("/").split("/")[-1] if path else ""
+            if seg in specials:
+                return specials[seg]
+            if not seg:
+                return "Tests"
+            return seg.replace("-", " ").replace("_", " ").title() + " Tests"
+
+        report_title = os.environ.get("REPORT_TITLE_OVERRIDE") or (
+            _title_from_test_path(os.environ.get("TEST_PATH", ""))
+        )
 
         totals = {"tests": 0, "failures": 0, "errors": 0, "skipped": 0, "time": 0.0}
         scenarios: list[tuple[str, str, str, float, str]] = []
@@ -529,7 +564,7 @@ runs:
 
         summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/stdout")
         with open(summary_path, "w") as f:
-            f.write(f"## {icon} SDR Integration Tests — {app_name}\n\n")
+            f.write(f"## {icon} {report_title} — {app_name}\n\n")
 
             if totals["tests"]:
                 f.write("### Test results\n\n")
@@ -707,6 +742,8 @@ runs:
         SUMMARY: ${{ steps.tests.outputs.summary }}
         WF_LINKS: ${{ steps.wf_links.outputs.links }}
         ASSET_SUMMARY: ${{ steps.asset_summary.outputs.markdown }}
+        REPORT_TITLE_OVERRIDE: ${{ inputs.report-title }}
+        TEST_PATH: ${{ inputs.test-path }}
       with:
         github-token: ${{ github.token }}
         script: |
@@ -716,7 +753,27 @@ runs:
           const wfLinks = process.env.WF_LINKS || '';
           const assetSummary = process.env.ASSET_SUMMARY || '';
 
-          const sticky = `<!-- sdr-integration-tests:${appName} -->`;
+          // Derive a self-describing title from test-path unless the caller
+          // overrode it explicitly. Mirrors the python helper in the
+          // step-summary step so both report surfaces stay aligned.
+          const titleFromTestPath = (path) => {
+            const specials = {
+              "sdr": "SDR Integration Tests",
+              "full_dag": "Full-DAG E2E Tests",
+            };
+            const seg = (path || "").replace(/\/+$/, "").split("/").pop() || "";
+            if (seg in specials) return specials[seg];
+            if (!seg) return "Tests";
+            return seg.replace(/[-_]/g, " ").replace(/\b\w/g, c => c.toUpperCase()) + " Tests";
+          };
+          const reportTitle = process.env.REPORT_TITLE_OVERRIDE
+            || titleFromTestPath(process.env.TEST_PATH);
+          // Sticky marker uses a slug of the title so different suites
+          // running on the same PR keep their own comments instead of
+          // overwriting each other.
+          const stickySlug = reportTitle.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+
+          const sticky = `<!-- ${stickySlug}:${appName} -->`;
           const status = outcome === 'success' ? 'Passed ✅' : 'Failed ❌';
           const runLink = `[${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})`;
           const linksLine = wfLinks ? `\n**Temporal workflows:** ${wfLinks}\n` : '';
@@ -727,7 +784,7 @@ runs:
 
           const body = [
             sticky,
-            `## SDR Integration Tests — ${appName}`,
+            `## ${reportTitle} — ${appName}`,
             ``,
             `**Status:** ${status}`,
             `**Summary:** \`${summary}\``,

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -59,6 +59,18 @@ inputs:
     description: Extra arguments appended to the pytest invocation.
     required: false
     default: ""
+  application-sdk-ref:
+    description: |
+      Optional application-sdk commit SHA / ref. When supplied, the
+      action re-pins atlan-application-sdk in the caller's pyproject.toml
+      to this ref before building the Docker image and again after
+      setup-deps (which re-checks-out the workspace). Used by cross-repo
+      dispatches from apps-sdk PRs so SDK changes are exercised end-to-end
+      — Docker image, host pytest runtime, and (because the caller
+      already invokes the action via a local-path checkout of this same
+      ref) action.yaml itself.
+    required: false
+    default: ""
 
 outputs:
   test-outcome:
@@ -81,6 +93,18 @@ runs:
         username: ${{ github.actor }}
         password: ${{ github.token }}
 
+    # Cross-repo dispatch from apps-sdk PRs hands us a specific SDK ref;
+    # rewrite the [tool.uv.sources] entry so the Docker build's COPY +
+    # uv sync resolves atlan-application-sdk to that ref. Repeated again
+    # below after setup-deps re-checks-out the workspace (which wipes
+    # this edit) so the host pytest runtime also picks up the ref.
+    - name: Pin application-sdk to dispatched ref (pre-build)
+      if: inputs.application-sdk-ref != ''
+      shell: bash
+      env:
+        SDK_REF: ${{ inputs.application-sdk-ref }}
+      run: ${{ github.action_path }}/repin-application-sdk.sh
+
     # Image build runs before setup-deps so the workspace is still pristine —
     # no host .venv yet, so the Dockerfile's COPY . . won't pull in a
     # host-built virtualenv whose Python symlinks point outside the image.
@@ -98,6 +122,20 @@ runs:
     # uses actions/checkout internally which would wipe generated files.
     - name: Setup Python and dependencies
       uses: atlanhq/application-sdk/.github/actions/setup-deps@v3.0.0
+
+    # setup-deps' actions/checkout wipes the pre-build re-pin above. Do
+    # it again so the host pytest runtime resolves the dispatched SDK
+    # (the BaseSDRIntegrationTest, agent contracts, etc.). Followed by
+    # an explicit uv sync so the lockfile reflects the new pin.
+    - name: Pin application-sdk to dispatched ref (post-setup)
+      if: inputs.application-sdk-ref != ''
+      shell: bash
+      env:
+        SDK_REF: ${{ inputs.application-sdk-ref }}
+      run: |
+        ${{ github.action_path }}/repin-application-sdk.sh
+        uv lock
+        uv sync --all-extras --all-groups
 
     - name: Download atlan-configurator
       shell: bash

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -883,29 +883,32 @@ runs:
             `</details>`,
           ].join('\n');
 
-          // Find prior comments tagged with our sticky marker and delete them.
+          // Sticky update: find an existing comment carrying our marker
+          // and patch its body in-place, otherwise create a fresh one.
+          // Earlier iterations did delete+create, which re-pushed the
+          // PR thread on every retry and pinged subscribers each time.
           const comments = await github.paginate(github.rest.issues.listComments, {
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: context.issue.number,
             per_page: 100,
           });
-          for (const c of comments) {
-            if (c.body && c.body.includes(sticky)) {
-              await github.rest.issues.deleteComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: c.id,
-              });
-            }
+          const existing = comments.find(c => c.body && c.body.includes(sticky));
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
           }
-
-          await github.rest.issues.createComment({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-            body,
-          });
       continue-on-error: true
 
     # No explicit `createCommitStatus` step: the workflow job already

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -145,11 +145,23 @@ runs:
         mv docker-compose-generator/generate atlan-configurator
         chmod +x atlan-configurator
 
-    - name: Resolve app.yaml
+    # Connector repos use atlan.yaml as the canonical app-config filename
+    # (see atlan-mssql-app, atlan-mysql-app). Fall back to app.yaml for any
+    # older repos still on the previous convention.
+    - name: Resolve atlan.yaml
       shell: bash
       env:
         APP_IMAGE: ${{ steps.build.outputs.image }}
-      run: envsubst < app.yaml > app-resolved.yaml
+      run: |
+        if [ -f atlan.yaml ]; then
+          envsubst < atlan.yaml > app-resolved.yaml
+        elif [ -f app.yaml ]; then
+          envsubst < app.yaml > app-resolved.yaml
+        else
+          echo "::error::Neither atlan.yaml nor app.yaml found at repo root; "
+          echo "::error::the SDR action needs the connector's app-config file to feed atlan-configurator."
+          exit 1
+        fi
 
     # Use the app's test-config template if it overrides the SDK default.
     - name: Resolve test-config.yaml

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -144,17 +144,39 @@ runs:
         fi
         uv lock
 
+    # Buildx is required for the GHA cache backend below. Set up once
+    # per run, before the image build that uses `cache-from/cache-to`.
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
     # Image build runs before setup-deps so the workspace is still pristine —
     # no host .venv yet, so the Dockerfile's COPY . . won't pull in a
     # host-built virtualenv whose Python symlinks point outside the image.
+    #
+    # `cache-from/cache-to: type=gha` plugs buildx into GitHub Actions'
+    # cache backend so the expensive `uv sync` layer (~2 min on a cold
+    # build) is reused across PR pushes. `mode=max` saves intermediate
+    # stages too, which matters here because the Dockerfile has a
+    # separate dependency-install layer ahead of the source copy.
+    # `scope:` is keyed on the connector so two repos sharing this
+    # action don't collide caches.
     - name: Build and push PR image
       id: build
       shell: bash
       run: |
         SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
         IMAGE="ghcr.io/atlanhq/${{ inputs.app-image-name }}:sdr-test-${SHORT_SHA}"
-        docker build -t "${IMAGE}" .
-        docker push "${IMAGE}"
+        # --push pushes to GHCR; compose pulls from there at run-time
+        # (atlan-configurator wires app_image into the generated
+        # compose file as a pull target). --load would conflict with
+        # --push under the standard buildx driver, and we don't need
+        # the image in the local daemon since compose handles the pull.
+        docker buildx build \
+          --tag "${IMAGE}" \
+          --push \
+          --cache-from "type=gha,scope=sdr-${{ inputs.app-name }}" \
+          --cache-to "type=gha,mode=max,scope=sdr-${{ inputs.app-name }}" \
+          .
         echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
 
     # Must run before atlan-configurator generates ci-deploy/ — setup-deps

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -642,14 +642,6 @@ runs:
         mkdir -p results
         docker compose ${{ steps.compose_files.outputs.files }} logs >> results/sdr-container.log 2>&1 || true
 
-    - name: Upload test results
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: sdr-integration-tests-${{ inputs.app-name }}-results
-        path: results/
-        retention-days: 14
-
     - name: Tear down SDR container
       if: always()
       shell: bash
@@ -667,7 +659,11 @@ runs:
     # which lets the PR comment link directly into the tenant Temporal UI.
     - name: Compute asset extraction summary
       id: asset_summary
-      if: always() && github.event_name == 'pull_request'
+      # Always runs (no pull_request gate): the workflow_dispatch path
+      # used by apps-sdk cross-repo dispatch also needs the summary
+      # markdown so the rendered pr-comment-body.md captures asset +
+      # lineage tables for the SDK PR's sticky.
+      if: always()
       shell: bash
       env:
         CI_TENANT_DOMAIN: ${{ env.CI_TENANT_DOMAIN }}
@@ -829,8 +825,8 @@ runs:
     # of mshick/add-pr-comment's edit-in-place behaviour: re-runs land as
     # new comments at the bottom of the conversation rather than silently
     # mutating an old one, which makes "what's the latest run" obvious.
-    - name: Post PR comment
-      if: always() && github.event_name == 'pull_request'
+    - name: Render PR comment + post (when on a PR)
+      if: always()
       uses: actions/github-script@v7
       env:
         APP_NAME: ${{ inputs.app-name }}
@@ -938,6 +934,23 @@ runs:
             `</details>`,
           ].join('\n');
 
+          // Always serialise the rendered body to the results artifact
+          // so the cross-repo dispatch caller (apps-sdk side) can post
+          // an identical sticky on its own PR. The artifact upload step
+          // further down packages results/ as-is.
+          const fs = require('fs');
+          fs.mkdirSync('results', { recursive: true });
+          fs.writeFileSync('results/pr-comment-body.md', body);
+
+          // Only post a comment when we're on a pull_request event with
+          // a `context.issue.number` to target — workflow_dispatch runs
+          // (used by the apps-sdk cross-repo path) skip the API call and
+          // rely on the artifact above being consumed by the caller.
+          if (context.eventName !== 'pull_request' || !context.issue.number) {
+            core.info('Not a pull_request event with a PR number — skipping comment post; body persisted to results/pr-comment-body.md for the cross-repo caller to reuse.');
+            return;
+          }
+
           // Sticky update: find an existing comment carrying our marker
           // and patch its body in-place, otherwise create a fresh one.
           // Earlier iterations did delete+create, which re-pushed the
@@ -965,6 +978,20 @@ runs:
             });
           }
       continue-on-error: true
+
+    # Artifact upload deliberately runs AFTER the comment-render step
+    # so results/pr-comment-body.md (written by that step) ships with
+    # the rest of the suite output. apps-sdk's e2e-apps composite
+    # downloads this same artifact and posts the body verbatim on the
+    # SDK PR (only the sticky marker line differs), so both PRs see
+    # the same rendered report.
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: sdr-integration-tests-${{ inputs.app-name }}-results
+        path: results/
+        retention-days: 14
 
     # No explicit `createCommitStatus` step: the workflow job already
     # surfaces a check_run on the PR (e.g. `E2E Full Tests (system

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -142,17 +142,21 @@ runs:
     # action can't invoke another action mid-sequence with conditional
     # `uses:` — curl install is the simplest fallback that doesn't pin a
     # specific runner image.
-    # Stash the repin script in /tmp before setup-deps' actions/checkout
-    # wipes the entire workspace (which includes ${{ github.action_path }}
-    # when this action is invoked as a LOCAL action via
-    # `uses: ./.application-sdk/.github/actions/sdr-e2e`). The post-setup
-    # repin step exec's from /tmp/sdr-e2e-repin-application-sdk.sh instead.
-    - name: Stash repin script
-      if: inputs.application-sdk-ref != ''
+    # Stash the entire action directory to /tmp before setup-deps'
+    # actions/checkout wipes the workspace. When this action is invoked
+    # as a LOCAL action (uses: ./.application-sdk/.github/actions/sdr-e2e),
+    # ${{ github.action_path }} sits inside the workspace and is wiped
+    # along with everything else. Post-setup steps that reference the
+    # repin script, test-config template, Dapr component overlays, or
+    # the compose overlay must fall back to /tmp/sdr-e2e/ — those
+    # references are guarded by env vars (SDR_E2E_ROOT_*) resolved
+    # immediately after setup-deps.
+    - name: Stash action assets
       shell: bash
       run: |
-        cp "${{ github.action_path }}/repin-application-sdk.sh" /tmp/sdr-e2e-repin-application-sdk.sh
-        chmod +x /tmp/sdr-e2e-repin-application-sdk.sh
+        rm -rf /tmp/sdr-e2e
+        cp -R "${{ github.action_path }}" /tmp/sdr-e2e
+        chmod +x /tmp/sdr-e2e/repin-application-sdk.sh || true
 
     - name: Pin application-sdk to dispatched ref (pre-build)
       if: inputs.application-sdk-ref != ''
@@ -221,17 +225,31 @@ runs:
     # can't reference it again here. The "stash repin script" step
     # below copies the script to /tmp before setup-deps runs; this step
     # exec's from the stash.
+    # Resolve the action-asset root after setup-deps. When invoked as a
+    # local action the workspace (and ${{ github.action_path }}) has been
+    # wiped — fall back to the /tmp stash that the "Stash action assets"
+    # step populated before setup-deps ran. Exported as a step output so
+    # downstream steps can reference it as ${{ steps.action_root.outputs.path }}.
+    - name: Resolve action-asset root
+      id: action_root
+      shell: bash
+      run: |
+        if [ -d "${{ github.action_path }}" ] && [ -f "${{ github.action_path }}/test-config.yaml.tmpl" ]; then
+          ROOT="${{ github.action_path }}"
+        else
+          ROOT="/tmp/sdr-e2e"
+        fi
+        echo "Using SDR action assets from: $ROOT"
+        echo "path=$ROOT" >> "$GITHUB_OUTPUT"
+
     - name: Pin application-sdk to dispatched ref (post-setup)
       if: inputs.application-sdk-ref != ''
       shell: bash
       env:
         SDK_REF: ${{ inputs.application-sdk-ref }}
+        SDR_E2E_ROOT: ${{ steps.action_root.outputs.path }}
       run: |
-        if [ -f /tmp/sdr-e2e-repin-application-sdk.sh ]; then
-          /tmp/sdr-e2e-repin-application-sdk.sh
-        else
-          ${{ github.action_path }}/repin-application-sdk.sh
-        fi
+        "$SDR_E2E_ROOT/repin-application-sdk.sh"
         uv lock
         uv sync --all-extras --all-groups
 
@@ -274,7 +292,7 @@ runs:
       shell: bash
       env:
         CI_RUN_SUFFIX: ${{ github.run_id }}
-        SDK_TMPL: ${{ github.action_path }}/test-config.yaml.tmpl
+        SDK_TMPL: ${{ steps.action_root.outputs.path }}/test-config.yaml.tmpl
       run: |
         if [ -f .github/e2e/test-config.yaml.tmpl ]; then
           echo "Using app-level test-config.yaml.tmpl override"
@@ -316,7 +334,7 @@ runs:
     - name: Override CI Dapr components
       shell: bash
       env:
-        SDK_COMPONENTS: ${{ github.action_path }}/components
+        SDK_COMPONENTS: ${{ steps.action_root.outputs.path }}/components
         APP_COMPONENTS: ${{ inputs.components-dir }}
       run: |
         cp "${SDK_COMPONENTS}"/*.yaml ci-deploy/components/
@@ -329,7 +347,7 @@ runs:
       id: compose_files
       shell: bash
       env:
-        SDK_COMPOSE: ${{ github.action_path }}/docker-compose.ci.yml
+        SDK_COMPOSE: ${{ steps.action_root.outputs.path }}/docker-compose.ci.yml
         APP_COMPOSE: ${{ inputs.compose-overlay }}
       run: |
         # Order: configurator-generated base → SDK CI overrides → optional app layer.

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -693,17 +693,24 @@ runs:
             r"correlation_id=(?P<cid>[0-9a-f-]+)[^\n]*?"
             r"Transformed (?P<entity>[A-Za-z0-9_-]+): (?P<n>\d+) records"
         )
-        # Match the workflow_id that appears under the same correlation
-        # block — usually emitted by the handler/service "Starting workflow"
-        # log. Best-effort; if absent we just omit the link.
+        # Match workflow_id + run_id emitted under the same correlation
+        # block — usually from the handler/service "Starting workflow"
+        # log. The Atlan Temporal proxy at
+        # /api/temporal/namespaces/default/workflows/<wf>/<run>/history
+        # rejects requests missing the run_id (just /workflows/<wf>/history
+        # 404s), so we capture both and only link when we have the pair.
         wf_re = re.compile(
             r"correlation_id=(?P<cid>[0-9a-f-]+)[^\n]*?workflow_id=(?P<wf>[\w-]+)"
+        )
+        run_re = re.compile(
+            r"correlation_id=(?P<cid>[0-9a-f-]+)[^\n]*?run_id=(?P<run>[\w-]+)"
         )
 
         cids: list[str] = []  # insertion-ordered for deterministic table order
         extracted: dict[str, dict[str, int]] = defaultdict(dict)
         transformed: dict[str, dict[str, int]] = defaultdict(dict)
         wf_id_by_cid: dict[str, str] = {}
+        run_id_by_cid: dict[str, str] = {}
 
         def _seen(cid: str) -> None:
             if cid not in cids:
@@ -720,6 +727,9 @@ runs:
         for m in wf_re.finditer(text):
             cid = m.group("cid")
             wf_id_by_cid.setdefault(cid, m.group("wf"))
+        for m in run_re.finditer(text):
+            cid = m.group("cid")
+            run_id_by_cid.setdefault(cid, m.group("run"))
 
         # Drop correlation groups that produced no asset rows (handler-level
         # auth / preflight scenarios run through the same scenario runner
@@ -736,14 +746,18 @@ runs:
         lines: list[str] = ["### Extracted + transformed assets", ""]
         for idx, cid in enumerate(cids, start=1):
             wf = wf_id_by_cid.get(cid, "")
+            run = run_id_by_cid.get(cid, "")
             header = f"**Workflow run {idx}**"
-            if wf and tenant:
+            if wf and run and tenant:
                 wf_url = (
                     f"https://{tenant}/api/temporal/namespaces/default"
-                    f"/workflows/{wf}/history"
+                    f"/workflows/{wf}/{run}/history"
                 )
                 header += f" — [{wf}]({wf_url})"
             elif wf:
+                # Workflow id without a run id — show the id verbatim but
+                # don't emit a clickable link; the proxy 404s on
+                # /workflows/<wf>/history without the run id.
                 header += f" — `{wf}`"
             lines.append(header)
             lines.append("")

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -533,6 +533,120 @@ runs:
       shell: bash
       run: docker compose ${{ steps.compose_files.outputs.files }} down -v
 
+    # Scrape the connector container log for per-workflow extract /
+    # transform counts. The SDK's SqlApp logs lines like
+    #
+    #     correlation_id=<uuid> ... - Extracted <entity>: N raw records
+    #     correlation_id=<uuid> ... - Transformed <entity>: N records
+    #
+    # one per entity per workflow scenario. We group by correlation_id so
+    # multi-workflow scenarios show separately, and try to attach each
+    # group to the workflow_id observed in the same correlation block —
+    # which lets the PR comment link directly into the tenant Temporal UI.
+    - name: Compute asset extraction summary
+      id: asset_summary
+      if: always() && github.event_name == 'pull_request'
+      shell: bash
+      env:
+        CI_TENANT_DOMAIN: ${{ env.CI_TENANT_DOMAIN }}
+      run: |
+        uv run python3 - <<'PYEOF'
+        import os
+        import re
+        import secrets
+        from collections import defaultdict
+        from pathlib import Path
+
+        log_path = Path("results/sdr-container.log")
+        if not log_path.exists():
+            print("No container log; skipping asset summary.")
+            with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                f.write("markdown=\n")
+            raise SystemExit
+
+        text = log_path.read_text(errors="replace")
+
+        # correlation_id=<uuid>  ...  Extracted <entity>: N raw records
+        extract_re = re.compile(
+            r"correlation_id=(?P<cid>[0-9a-f-]+)[^\n]*?"
+            r"Extracted (?P<entity>[A-Za-z0-9_-]+): (?P<n>\d+) raw records"
+        )
+        transform_re = re.compile(
+            r"correlation_id=(?P<cid>[0-9a-f-]+)[^\n]*?"
+            r"Transformed (?P<entity>[A-Za-z0-9_-]+): (?P<n>\d+) records"
+        )
+        # Match the workflow_id that appears under the same correlation
+        # block — usually emitted by the handler/service "Starting workflow"
+        # log. Best-effort; if absent we just omit the link.
+        wf_re = re.compile(
+            r"correlation_id=(?P<cid>[0-9a-f-]+)[^\n]*?workflow_id=(?P<wf>[\w-]+)"
+        )
+
+        cids: list[str] = []  # insertion-ordered for deterministic table order
+        extracted: dict[str, dict[str, int]] = defaultdict(dict)
+        transformed: dict[str, dict[str, int]] = defaultdict(dict)
+        wf_id_by_cid: dict[str, str] = {}
+
+        def _seen(cid: str) -> None:
+            if cid not in cids:
+                cids.append(cid)
+
+        for m in extract_re.finditer(text):
+            cid = m.group("cid")
+            _seen(cid)
+            extracted[cid][m.group("entity")] = int(m.group("n"))
+        for m in transform_re.finditer(text):
+            cid = m.group("cid")
+            _seen(cid)
+            transformed[cid][m.group("entity")] = int(m.group("n"))
+        for m in wf_re.finditer(text):
+            cid = m.group("cid")
+            wf_id_by_cid.setdefault(cid, m.group("wf"))
+
+        # Drop correlation groups that produced no asset rows (handler-level
+        # auth / preflight scenarios run through the same scenario runner
+        # but never emit extract/transform lines).
+        cids = [c for c in cids if extracted.get(c) or transformed.get(c)]
+
+        if not cids:
+            print("No extract/transform lines in container log.")
+            with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                f.write("markdown=\n")
+            raise SystemExit
+
+        tenant = os.environ.get("CI_TENANT_DOMAIN", "")
+        lines: list[str] = ["### Extracted + transformed assets", ""]
+        for idx, cid in enumerate(cids, start=1):
+            wf = wf_id_by_cid.get(cid, "")
+            header = f"**Workflow run {idx}**"
+            if wf and tenant:
+                wf_url = (
+                    f"https://{tenant}/api/temporal/namespaces/default"
+                    f"/workflows/{wf}/history"
+                )
+                header += f" — [{wf}]({wf_url})"
+            elif wf:
+                header += f" — `{wf}`"
+            lines.append(header)
+            lines.append("")
+            lines.append("| Entity | Extracted | Transformed |")
+            lines.append("|--------|-----------|-------------|")
+            entities = sorted(set(extracted[cid]) | set(transformed[cid]))
+            for entity in entities:
+                ext = extracted[cid].get(entity)
+                tr = transformed[cid].get(entity)
+                ext_s = "—" if ext is None else str(ext)
+                tr_s = "—" if tr is None else str(tr)
+                lines.append(f"| {entity} | {ext_s} | {tr_s} |")
+            lines.append("")
+
+        markdown = "\n".join(lines)
+        delim = "EOF_ASSETS_" + secrets.token_hex(8)
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+            f.write(f"markdown<<{delim}\n{markdown}\n{delim}\n")
+        print(markdown)
+        PYEOF
+
     # Delete any prior SDR comment (matched by sticky marker) and post a
     # fresh one. Using github-script + a sticky HTML-comment marker instead
     # of mshick/add-pr-comment's edit-in-place behaviour: re-runs land as
@@ -546,6 +660,7 @@ runs:
         OUTCOME: ${{ steps.tests.outcome }}
         SUMMARY: ${{ steps.tests.outputs.summary }}
         WF_LINKS: ${{ steps.wf_links.outputs.links }}
+        ASSET_SUMMARY: ${{ steps.asset_summary.outputs.markdown }}
       with:
         github-token: ${{ github.token }}
         script: |
@@ -553,11 +668,16 @@ runs:
           const outcome = process.env.OUTCOME;
           const summary = process.env.SUMMARY || 'No summary';
           const wfLinks = process.env.WF_LINKS || '';
+          const assetSummary = process.env.ASSET_SUMMARY || '';
 
           const sticky = `<!-- sdr-integration-tests:${appName} -->`;
           const status = outcome === 'success' ? 'Passed ✅' : 'Failed ❌';
           const runLink = `[${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})`;
           const linksLine = wfLinks ? `\n**Temporal workflows:** ${wfLinks}\n` : '';
+          // assetSummary is the multiline markdown table block produced by
+          // the "Compute asset extraction summary" step. Empty string when
+          // no workflow scenarios ran (auth/preflight only).
+          const assetBlock = assetSummary ? `\n${assetSummary}\n` : '';
 
           const body = [
             sticky,
@@ -567,6 +687,7 @@ runs:
             `**Summary:** \`${summary}\``,
             `**Run:** ${runLink}`,
             linksLine,
+            assetBlock,
             `### What this validates`,
             `- **Credential resolution from secret store** — workflow \`username\`/\`password\` resolved via the Dapr \`local.file\` secret store using \`extraction_method=agent\` + \`agent_json\` → \`AgentCredentialSpec\`, not passed inline. Validates the full SDR credential-ref → secret-store → connector-client chain.`,
             `- **Auth** — valid credentials succeed; invalid credentials and unreachable host fail correctly`,

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -762,55 +762,60 @@ runs:
                 lines.append(f"| {entity} | {ext_s} | {tr_s} |")
             lines.append("")
 
-        # Full-DAG runs append the post-lineage Atlas inventory the harness
-        # logs at the end of its run ("Atlas inventory under <qn>: {...}
-        # lineage_present=True"). SDR runs never emit this line, so the
-        # section is added only when a match is found — keeps the SDR
-        # comment unchanged. Reads sdr-test-output.txt (pytest stdout)
-        # because the line comes from the harness logger, not the
-        # docker container.
+        # Full-DAG runs append two Atlas-side sections mirroring the
+        # Atlan workflow-center UI cards (Assets / Lineage coverage):
+        #   "Atlas inventory under <qn>: {<typeName>: <count>, ...}"
+        #   "Lineage inventory under <qn>: {<typeName>: <count>, ...} lineage_present=<bool>"
+        # SDR runs never emit these lines, so the sections are added
+        # only when matches are found — keeps the SDR comment unchanged.
         import ast
+
+        def _safe_dict(literal: str) -> dict[str, int]:
+            try:
+                value = ast.literal_eval(literal)
+            except (ValueError, SyntaxError):
+                return {}
+            return value if isinstance(value, dict) else {}
+
+        def _render_section(title: str, qn: str, counts: dict[str, int]) -> list[str]:
+            total = sum(counts.values())
+            section = [f"### {title}", "", f"**Connection:** `{qn}`", "", f"**Total:** {total}", ""]
+            if counts:
+                section.append("| Type | Count |")
+                section.append("|------|-------|")
+                for type_name in sorted(counts):
+                    section.append(f"| {type_name} | {counts[type_name]} |")
+                section.append("")
+            return section
 
         test_log = Path("results/sdr-test-output.txt")
         if test_log.exists():
             test_text = test_log.read_text(errors="replace")
-            atlas_re = re.compile(
-                r"Atlas inventory under (?P<qn>\S+):\s+(?P<counts>\{.*?\})\s+lineage_present=(?P<lin>True|False)"
+            assets_re = re.compile(
+                r"Atlas inventory under (?P<qn>\S+):\s+(?P<counts>\{.*?\})"
             )
-            last_match = None
-            for m in atlas_re.finditer(test_text):
-                last_match = m  # keep the last one in case retries logged earlier ones
-            if last_match:
-                try:
-                    counts = ast.literal_eval(last_match.group("counts"))
-                    if not isinstance(counts, dict):
-                        counts = {}
-                except (ValueError, SyntaxError):
-                    counts = {}
-                lineage_present = last_match.group("lin") == "True"
-                lineage_count = (
-                    counts.get("Process", 0) + counts.get("ColumnProcess", 0)
-                )
-                lines.append(
-                    f"### Atlas inventory under `{last_match.group('qn')}`"
-                )
-                lines.append("")
-                lines.append("| Type | Count |")
-                lines.append("|------|-------|")
-                for type_name in sorted(counts):
-                    lines.append(f"| {type_name} | {counts[type_name]} |")
-                lines.append("")
-                if lineage_count or lineage_present:
-                    lineage_status = (
-                        f"✅ {lineage_count} edge{'s' if lineage_count != 1 else ''} "
-                        "(`Process` + `ColumnProcess`)"
-                        if lineage_count
-                        else "✅ present"
-                    )
-                else:
-                    lineage_status = "⚠️ none observed (waived for connectors without view-derived lineage)"
-                lines.append(f"**Lineage:** {lineage_status}")
-                lines.append("")
+            lineage_re = re.compile(
+                r"Lineage inventory under (?P<qn>\S+):\s+(?P<counts>\{.*?\})\s+lineage_present=(?P<lin>True|False)"
+            )
+            # Take the last match in case retries logged earlier ones.
+            assets_match = next(iter(list(assets_re.finditer(test_text))[::-1]), None)
+            lineage_match = next(iter(list(lineage_re.finditer(test_text))[::-1]), None)
+            if assets_match:
+                lines.extend(_render_section(
+                    "Assets in Atlas",
+                    assets_match.group("qn"),
+                    _safe_dict(assets_match.group("counts")),
+                ))
+            if lineage_match:
+                lineage_counts = _safe_dict(lineage_match.group("counts"))
+                lines.extend(_render_section(
+                    "Lineage coverage",
+                    lineage_match.group("qn"),
+                    lineage_counts,
+                ))
+                if lineage_match.group("lin") == "False" and sum(lineage_counts.values()) == 0:
+                    lines.append("> No lineage assets observed — waived when the seed dataset has no view-derived lineage.")
+                    lines.append("")
 
         markdown = "\n".join(lines)
         delim = "EOF_ASSETS_" + secrets.token_hex(8)
@@ -915,7 +920,7 @@ runs:
 
           const body = [
             sticky,
-            `## ${reportTitle} — ${appName}`,
+            `## 🧪 ${reportTitle} — ${appName}`,
             ``,
             `**Status:** ${status}`,
             `**Summary:** \`${summary}\``,

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -823,6 +823,44 @@ runs:
           // no workflow scenarios ran (auth/preflight only).
           const assetBlock = assetSummary ? `\n${assetSummary}\n` : '';
 
+          // Validation bullets + stack/re-run footer are pipeline-specific.
+          // SDR exercises auth/preflight/extract against a hermetic
+          // testcontainer DB; Full-DAG additionally drives publish,
+          // query-intelligence, lineage-app and lineage-publish system
+          // apps on a live tenant and asserts asset counts + lineage in
+          // Atlas. Keep the surface narrow per pipeline so reviewers
+          // don't get a misleading "this also validates X" claim.
+          const validatesByPipeline = {
+            "SDR Integration Tests": [
+              `- **Credential resolution from secret store** — workflow \`username\`/\`password\` resolved via the Dapr \`local.file\` secret store using \`extraction_method=agent\` + \`agent_json\` → \`AgentCredentialSpec\`, not passed inline. Validates the full SDR credential-ref → secret-store → connector-client chain.`,
+              `- **Auth** — valid credentials succeed; invalid credentials and unreachable host fail correctly`,
+              `- **Preflight** — connectivity, schema/table checks; bad credentials fail correctly`,
+              `- **Workflow** — full extraction run on the test instance, polled to \`COMPLETED\` on the tenant's Temporal cluster`,
+            ],
+            "Full-DAG E2E Tests": [
+              `- **Connector extract + transform** — workflow polled to \`COMPLETED\` on the tenant's Temporal cluster; asset JSON written to the tenant object store`,
+              `- **System apps DAG** — \`publish\` → \`query-intelligence\` → \`lineage-app\` → \`lineage-publish\` all reach \`Succeeded\` on their respective task queues`,
+              `- **Connection materialised in Atlas** — \`/api/meta/entity\` resolves the Connection QN that the workflow published`,
+              `- **Asset counts in Atlas** — per-typeName descendant counts meet the connector's \`expected_min_asset_counts\` floor (Database, Schema, Table, View, Column, …)`,
+              `- **Lineage in Atlas** — at least one \`Process\` / \`ColumnProcess\` asset under the Connection QN (waived when the seed dataset has no view definitions)`,
+              `- **Agent + connection contract** — \`agent_spec\` / \`connection_spec\` accepted by AE workflow + version create endpoints; credentials resolved via \`AgentCredentialSpec\``,
+            ],
+          };
+          const defaultValidates = validatesByPipeline["SDR Integration Tests"];
+          const validates = validatesByPipeline[reportTitle] || defaultValidates;
+
+          const stackByPipeline = {
+            "SDR Integration Tests": `> Stack: atlan-configurator generated compose, Dapr sidecar embedded, Temporal worker on CI tenant.`,
+            "Full-DAG E2E Tests": `> Stack: atlan-configurator generated compose, Dapr sidecar embedded, worker registered with the CI tenant's Temporal + the live publish/qi/lineage system apps.`,
+          };
+          const stackLine = stackByPipeline[reportTitle] || stackByPipeline["SDR Integration Tests"];
+
+          const rerunHintByPipeline = {
+            "SDR Integration Tests": `Push a new commit, or re-run from the Actions tab.`,
+            "Full-DAG E2E Tests": `Remove and re-add the \`e2e-full-test\` label, or re-run from the Actions tab.`,
+          };
+          const rerunHint = rerunHintByPipeline[reportTitle] || rerunHintByPipeline["SDR Integration Tests"];
+
           const body = [
             sticky,
             `## ${reportTitle} — ${appName}`,
@@ -833,16 +871,13 @@ runs:
             linksLine,
             assetBlock,
             `### What this validates`,
-            `- **Credential resolution from secret store** — workflow \`username\`/\`password\` resolved via the Dapr \`local.file\` secret store using \`extraction_method=agent\` + \`agent_json\` → \`AgentCredentialSpec\`, not passed inline. Validates the full SDR credential-ref → secret-store → connector-client chain.`,
-            `- **Auth** — valid credentials succeed; invalid credentials and unreachable host fail correctly`,
-            `- **Preflight** — connectivity, schema/table checks; bad credentials fail correctly`,
-            `- **Workflow** — full extraction run on the test instance, polled to \`COMPLETED\` on the tenant's Temporal cluster`,
+            ...validates,
             ``,
-            `> Stack: atlan-configurator generated compose, Dapr sidecar embedded, Temporal worker on CI tenant.`,
+            stackLine,
             ``,
             `<details><summary>Re-run</summary>`,
             ``,
-            `Remove and re-add the \`sdr-e2e-test\` label, or re-run from the Actions tab.`,
+            rerunHint,
             `</details>`,
           ].join('\n');
 

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -71,6 +71,28 @@ inputs:
       ref) action.yaml itself.
     required: false
     default: ""
+  components-dir:
+    description: |
+      Directory (relative to repo root) holding app-level Dapr component
+      overrides that are copied OVER the SDK defaults after configurator
+      generation. Per-tier directories let a connector run multiple test
+      stacks side-by-side — e.g. tier-3 uses the default
+      `.github/e2e/components` (localstorage objectstore for hermetic
+      runs), tier-4 sets `.github/e2e/tier-4-components` (S3 binding
+      pointing at the tenant bucket so publish/qi/lineage can read what
+      extract wrote).
+    required: false
+    default: .github/e2e/components
+  compose-overlay:
+    description: |
+      Path (relative to repo root) to an app-level docker-compose overlay
+      that stacks on top of the configurator output + SDK CI defaults.
+      Default fits tier-3 (`docker-compose.ci.yml` — sibling DB with
+      seed). Tier-4 overrides with its own overlay that propagates
+      AWS_* env vars to the worker for the S3 binding + sets a unique
+      agent-name so the worker registers on its own Temporal queue.
+    required: false
+    default: .github/e2e/docker-compose.ci.yml
 
 outputs:
   test-outcome:
@@ -236,11 +258,12 @@ runs:
       shell: bash
       env:
         SDK_COMPONENTS: ${{ github.action_path }}/components
+        APP_COMPONENTS: ${{ inputs.components-dir }}
       run: |
         cp "${SDK_COMPONENTS}"/*.yaml ci-deploy/components/
-        if [ -d .github/e2e/components ] && [ -n "$(ls -A .github/e2e/components 2>/dev/null)" ]; then
-          echo "Applying app-level component overrides"
-          cp .github/e2e/components/*.yaml ci-deploy/components/
+        if [ -d "${APP_COMPONENTS}" ] && [ -n "$(ls -A "${APP_COMPONENTS}" 2>/dev/null)" ]; then
+          echo "Applying app-level component overrides from ${APP_COMPONENTS}"
+          cp "${APP_COMPONENTS}"/*.yaml ci-deploy/components/
         fi
 
     - name: Build compose -f chain
@@ -248,12 +271,13 @@ runs:
       shell: bash
       env:
         SDK_COMPOSE: ${{ github.action_path }}/docker-compose.ci.yml
+        APP_COMPOSE: ${{ inputs.compose-overlay }}
       run: |
         # Order: configurator-generated base → SDK CI overrides → optional app layer.
         FILES=("-f" "ci-deploy/docker-compose.yaml" "-f" "${SDK_COMPOSE}")
-        if [ -f .github/e2e/docker-compose.ci.yml ]; then
-          echo "Adding app-level compose layer"
-          FILES+=("-f" ".github/e2e/docker-compose.ci.yml")
+        if [ -f "${APP_COMPOSE}" ]; then
+          echo "Adding app-level compose layer from ${APP_COMPOSE}"
+          FILES+=("-f" "${APP_COMPOSE}")
         fi
         # Persist the array as a single space-joined string (compose -f flags
         # are simple paths, no whitespace issues).

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -106,6 +106,14 @@ inputs:
       agent-name so the worker registers on its own Temporal queue.
     required: false
     default: .github/e2e/docker-compose.ci.yml
+  commit-status-context:
+    description: |
+      `context` value used when posting the final PR commit status.
+      Each caller workflow should pass a distinct value so multiple
+      pipelines (e.g. `sdr-integration-tests.yaml` + `e2e-full.yaml`)
+      don't overwrite each other's status on the same PR head SHA.
+    required: false
+    default: sdr-e2e-tests
 
 outputs:
   test-outcome:
@@ -875,11 +883,13 @@ runs:
     - name: Set commit status
       if: always() && github.event_name == 'pull_request'
       uses: actions/github-script@v7
+      env:
+        STATUS_CONTEXT: ${{ inputs.commit-status-context }}
       with:
         github-token: ${{ github.token }}
         script: |
           const state = '${{ steps.tests.outcome }}' === 'success' ? 'success' : 'failure';
-          const ctx   = 'sdr-e2e-tests';
+          const ctx   = process.env.STATUS_CONTEXT;
           await github.rest.repos.createCommitStatus({
             owner: context.repo.owner,
             repo:  context.repo.repo,
@@ -890,3 +900,19 @@ runs:
             context: ctx,
           });
       continue-on-error: true
+
+    # GH Actions re-reads ${{ github.action_path }}/action.yaml when
+    # running each step's `post:` hook. When this composite is invoked
+    # as a LOCAL action (`uses: ./.application-sdk/.github/actions/sdr-e2e`),
+    # setup-deps' inner actions/checkout earlier in the run wiped that
+    # path. Restore it from the /tmp/sdr-e2e stash so post-hooks find
+    # the action manifest (otherwise the job fails after a green
+    # test run with "Can't find 'action.yml' under ...").
+    - name: Restore action assets for post-hooks
+      if: always()
+      shell: bash
+      run: |
+        if [ ! -f "${{ github.action_path }}/action.yaml" ] && [ -d /tmp/sdr-e2e ]; then
+          mkdir -p "${{ github.action_path }}"
+          cp -R /tmp/sdr-e2e/. "${{ github.action_path }}/"
+        fi

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -106,15 +106,6 @@ inputs:
       agent-name so the worker registers on its own Temporal queue.
     required: false
     default: .github/e2e/docker-compose.ci.yml
-  commit-status-context:
-    description: |
-      `context` value used when posting the final PR commit status.
-      Each caller workflow should pass a distinct value so multiple
-      pipelines (e.g. `sdr-integration-tests.yaml` + `e2e-full.yaml`)
-      don't overwrite each other's status on the same PR head SHA.
-    required: false
-    default: sdr-e2e-tests
-
 outputs:
   test-outcome:
     description: pytest exit outcome (success/failure)
@@ -880,26 +871,12 @@ runs:
           });
       continue-on-error: true
 
-    - name: Set commit status
-      if: always() && github.event_name == 'pull_request'
-      uses: actions/github-script@v7
-      env:
-        STATUS_CONTEXT: ${{ inputs.commit-status-context }}
-      with:
-        github-token: ${{ github.token }}
-        script: |
-          const state = '${{ steps.tests.outcome }}' === 'success' ? 'success' : 'failure';
-          const ctx   = process.env.STATUS_CONTEXT;
-          await github.rest.repos.createCommitStatus({
-            owner: context.repo.owner,
-            repo:  context.repo.repo,
-            sha:   context.payload.pull_request.head.sha,
-            state,
-            target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-            description: state === 'success' ? `${ctx} passed` : `${ctx} failed`,
-            context: ctx,
-          });
-      continue-on-error: true
+    # No explicit `createCommitStatus` step: the workflow job already
+    # surfaces a check_run on the PR (e.g. `E2E Full with system apps
+    # / e2e-full` or `SDR Integration Tests / sdr-tests`). Posting an
+    # additional commit status duplicates that signal under a separate
+    # `sdr-e2e-tests` row and, when two callers share this composite,
+    # they overwrite each other on the same head SHA.
 
     # GH Actions re-reads ${{ github.action_path }}/action.yaml when
     # running each step's `post:` hook. When this composite is invoked

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -145,23 +145,31 @@ runs:
         mv docker-compose-generator/generate atlan-configurator
         chmod +x atlan-configurator
 
-    # Connector repos use atlan.yaml as the canonical app-config filename
-    # (see atlan-mssql-app, atlan-mysql-app). Fall back to app.yaml for any
-    # older repos still on the previous convention.
-    - name: Resolve atlan.yaml
+    # atlan-configurator's --app input needs a distinct schema (app_name +
+    # app_image at minimum). Connector repos' atlan.yaml is for the k8s
+    # helm deploy and uses a different shape ('name' not 'app_name', no
+    # image field). Generate a configurator-shaped file inline from
+    # known-good defaults; callers can override via
+    # .github/e2e/app-config.yaml.tmpl if a connector needs more fields
+    # (proxy config, extra env, etc.).
+    - name: Resolve app-config for atlan-configurator
       shell: bash
       env:
+        APP_NAME: ${{ inputs.app-name }}
         APP_IMAGE: ${{ steps.build.outputs.image }}
       run: |
-        if [ -f atlan.yaml ]; then
-          envsubst < atlan.yaml > app-resolved.yaml
-        elif [ -f app.yaml ]; then
-          envsubst < app.yaml > app-resolved.yaml
+        if [ -f .github/e2e/app-config.yaml.tmpl ]; then
+          echo "Using app-level app-config.yaml.tmpl override"
+          envsubst < .github/e2e/app-config.yaml.tmpl > app-resolved.yaml
         else
-          echo "::error::Neither atlan.yaml nor app.yaml found at repo root; "
-          echo "::error::the SDR action needs the connector's app-config file to feed atlan-configurator."
-          exit 1
+          echo "Generating default app-config from action inputs"
+          cat > app-resolved.yaml <<EOF
+        app_name: ${APP_NAME}
+        app_image: ${APP_IMAGE}
+        EOF
         fi
+        echo "--- app-resolved.yaml ---"
+        cat app-resolved.yaml
 
     # Use the app's test-config template if it overrides the SDK default.
     - name: Resolve test-config.yaml

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -45,8 +45,8 @@ inputs:
       Short label used in the PR-comment / step-summary report title and
       the PR comment marker. When empty (the default), the action derives
       a title from `test-path`:
-        tests/sdr/        → "SDR Integration Tests"
-        tests/full_dag/   → "Full-DAG E2E Tests"
+        tests/sdr/        → "SDR Integration Tests (testcontainer)"
+        tests/full_dag/   → "E2E Full Tests (system apps)"
         tests/<other>/    → "<other> Tests" (with hyphens/underscores
                             replaced by spaces and the first letter
                             uppercased).
@@ -546,8 +546,8 @@ runs:
         # repo (e.g. tier-3 sdr-integration-tests vs e2e-full).
         def _title_from_test_path(path: str) -> str:
             specials = {
-                "sdr": "SDR Integration Tests",
-                "full_dag": "Full-DAG E2E Tests",
+                "sdr": "SDR Integration Tests (testcontainer)",
+                "full_dag": "E2E Full Tests (system apps)",
             }
             seg = path.strip("/").split("/")[-1] if path else ""
             if seg in specials:
@@ -799,8 +799,8 @@ runs:
           // step-summary step so both report surfaces stay aligned.
           const titleFromTestPath = (path) => {
             const specials = {
-              "sdr": "SDR Integration Tests",
-              "full_dag": "Full-DAG E2E Tests",
+              "sdr": "SDR Integration Tests (testcontainer)",
+              "full_dag": "E2E Full Tests (system apps)",
             };
             const seg = (path || "").replace(/\/+$/, "").split("/").pop() || "";
             if (seg in specials) return specials[seg];
@@ -830,14 +830,17 @@ runs:
           // apps on a live tenant and asserts asset counts + lineage in
           // Atlas. Keep the surface narrow per pipeline so reviewers
           // don't get a misleading "this also validates X" claim.
+          const SDR_TITLE = "SDR Integration Tests (testcontainer)";
+          const FULL_DAG_TITLE = "E2E Full Tests (system apps)";
+
           const validatesByPipeline = {
-            "SDR Integration Tests": [
+            [SDR_TITLE]: [
               `- **Credential resolution from secret store** — workflow \`username\`/\`password\` resolved via the Dapr \`local.file\` secret store using \`extraction_method=agent\` + \`agent_json\` → \`AgentCredentialSpec\`, not passed inline. Validates the full SDR credential-ref → secret-store → connector-client chain.`,
               `- **Auth** — valid credentials succeed; invalid credentials and unreachable host fail correctly`,
               `- **Preflight** — connectivity, schema/table checks; bad credentials fail correctly`,
               `- **Workflow** — full extraction run on the test instance, polled to \`COMPLETED\` on the tenant's Temporal cluster`,
             ],
-            "Full-DAG E2E Tests": [
+            [FULL_DAG_TITLE]: [
               `- **Connector extract + transform** — workflow polled to \`COMPLETED\` on the tenant's Temporal cluster; asset JSON written to the tenant object store`,
               `- **System apps DAG** — \`publish\` → \`query-intelligence\` → \`lineage-app\` → \`lineage-publish\` all reach \`Succeeded\` on their respective task queues`,
               `- **Connection materialised in Atlas** — \`/api/meta/entity\` resolves the Connection QN that the workflow published`,
@@ -846,20 +849,19 @@ runs:
               `- **Agent + connection contract** — \`agent_spec\` / \`connection_spec\` accepted by AE workflow + version create endpoints; credentials resolved via \`AgentCredentialSpec\``,
             ],
           };
-          const defaultValidates = validatesByPipeline["SDR Integration Tests"];
-          const validates = validatesByPipeline[reportTitle] || defaultValidates;
+          const validates = validatesByPipeline[reportTitle] || validatesByPipeline[SDR_TITLE];
 
           const stackByPipeline = {
-            "SDR Integration Tests": `> Stack: atlan-configurator generated compose, Dapr sidecar embedded, Temporal worker on CI tenant.`,
-            "Full-DAG E2E Tests": `> Stack: atlan-configurator generated compose, Dapr sidecar embedded, worker registered with the CI tenant's Temporal + the live publish/qi/lineage system apps.`,
+            [SDR_TITLE]: `> Stack: atlan-configurator generated compose, Dapr sidecar embedded, Temporal worker on CI tenant.`,
+            [FULL_DAG_TITLE]: `> Stack: atlan-configurator generated compose, Dapr sidecar embedded, worker registered with the CI tenant's Temporal + the live publish/qi/lineage system apps.`,
           };
-          const stackLine = stackByPipeline[reportTitle] || stackByPipeline["SDR Integration Tests"];
+          const stackLine = stackByPipeline[reportTitle] || stackByPipeline[SDR_TITLE];
 
           const rerunHintByPipeline = {
-            "SDR Integration Tests": `Push a new commit, or re-run from the Actions tab.`,
-            "Full-DAG E2E Tests": `Remove and re-add the \`e2e-full-test\` label, or re-run from the Actions tab.`,
+            [SDR_TITLE]: `Push a new commit, or re-run from the Actions tab.`,
+            [FULL_DAG_TITLE]: `Remove and re-add the \`e2e-full\` label, or re-run from the Actions tab.`,
           };
-          const rerunHint = rerunHintByPipeline[reportTitle] || rerunHintByPipeline["SDR Integration Tests"];
+          const rerunHint = rerunHintByPipeline[reportTitle] || rerunHintByPipeline[SDR_TITLE];
 
           const body = [
             sticky,
@@ -907,8 +909,8 @@ runs:
       continue-on-error: true
 
     # No explicit `createCommitStatus` step: the workflow job already
-    # surfaces a check_run on the PR (e.g. `E2E Full with system apps
-    # / e2e-full` or `SDR Integration Tests / sdr-tests`). Posting an
+    # surfaces a check_run on the PR (e.g. `E2E Full Tests (system
+    # apps)` or `SDR Integration Tests (testcontainer)`). Posting an
     # additional commit status duplicates that signal under a separate
     # `sdr-e2e-tests` row and, when two callers share this composite,
     # they overwrite each other on the same head SHA.

--- a/.github/actions/sdr-e2e/components/eventstore.yaml
+++ b/.github/actions/sdr-e2e/components/eventstore.yaml
@@ -1,0 +1,18 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: eventstore
+spec:
+  type: bindings.localstorage
+  version: v1
+  # SDK extract/transform activities publish lifecycle events to this
+  # binding. Without the component, Dapr returns 500 on every publish,
+  # which the SDK currently surfaces as a workflow activity failure
+  # (see _temporal/interceptors/events.py). For SDR e2e tests we point
+  # the binding at the same in-container scratch path the objectstore
+  # uses — events get written to local disk and tossed with the
+  # compose stack on teardown.
+  ignoreErrors: true
+  metadata:
+  - name: rootPath
+    value: /tmp/atlan-eventstore

--- a/.github/actions/sdr-e2e/repin-application-sdk.sh
+++ b/.github/actions/sdr-e2e/repin-application-sdk.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Rewrite the [tool.uv.sources] atlan-application-sdk entry in the caller
+# repo's pyproject.toml to point at a specific git ref. Invoked from
+# action.yaml when `application-sdk-ref` is supplied — i.e. on apps-sdk
+# cross-repo dispatches.
+#
+# Reads:  $SDK_REF (the commit / branch / tag to pin to)
+# Writes: pyproject.toml in CWD (the caller workspace)
+#
+# Idempotent: re-running with the same SDK_REF is a no-op diff.
+
+set -euo pipefail
+
+if [ -z "${SDK_REF:-}" ]; then
+  echo "::error::SDK_REF env var not set"
+  exit 1
+fi
+
+if [ ! -f pyproject.toml ]; then
+  echo "::error::pyproject.toml not found in $(pwd)"
+  exit 1
+fi
+
+python3 - <<PYEOF
+import os
+import pathlib
+import re
+
+ref = os.environ["SDK_REF"]
+path = pathlib.Path("pyproject.toml")
+src = path.read_text()
+
+new_line = (
+    'atlan-application-sdk = { git = '
+    f'"https://github.com/atlanhq/application-sdk", rev = "{ref}" }}'
+)
+
+# Match the entire atlan-application-sdk source pin (single-line, any
+# combination of branch/rev/tag/path inside the braces). Anchored to a
+# line start and runs to a closing brace + EOL.
+pattern = re.compile(
+    r'^atlan-application-sdk\s*=\s*\{[^}]*\}\s*$',
+    flags=re.MULTILINE,
+)
+replaced, n = pattern.subn(new_line, src)
+
+if n == 0:
+    raise SystemExit(
+        "atlan-application-sdk source pin not found in pyproject.toml; "
+        "expected a line like:\n"
+        "  atlan-application-sdk = { git = \"...\", branch = \"...\" }\n"
+        "under [tool.uv.sources]."
+    )
+
+if n > 1:
+    # More than one pin is ambiguous — fail loudly rather than rewriting
+    # something the user did not intend.
+    raise SystemExit(
+        f"Multiple atlan-application-sdk source pins matched ({n}); "
+        "expected exactly one."
+    )
+
+path.write_text(replaced)
+print(f"Re-pinned application-sdk to {ref}")
+PYEOF

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -180,12 +180,7 @@ jobs:
           fi
           echo "Using agent-name=$(grep '^name=' "$GITHUB_OUTPUT" | cut -d= -f2)"
 
-      # TODO: switch to @main once BLDX-1254 lands on the SDK default
-      # branch. Branch-pin so the reusable workflow consumes the same
-      # SDR composite action revision as the rest of the PR (e.g. the
-      # `components-dir` / `compose-overlay` / `application-sdk-ref`
-      # inputs that don't exist on @main yet).
-      - uses: atlanhq/application-sdk/.github/actions/sdr-e2e@aryaman/bldx-1254-sdr-cross-repo-trigger
+      - uses: atlanhq/application-sdk/.github/actions/sdr-e2e@main
         with:
           app-name: ${{ inputs.app-name }}
           app-image-name: ${{ inputs.app-image-name }}

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -96,6 +96,16 @@ on:
         required: false
         type: string
         default: ""
+      distinct-id:
+        description: |
+          Identifier passed through from the caller's
+          ``workflow_dispatch.inputs.distinct_id`` so
+          ``codex-/return-dispatch`` on the apps-sdk side can locate
+          this run from the calling workflow. Echoed in the
+          "distinct-id" step name; never read by test code.
+        required: false
+        type: string
+        default: ""
     secrets:
       SDR_TEST_TENANT:
         description: Tenant DNS short name read by the configurator.
@@ -148,6 +158,14 @@ jobs:
       SDR_OAUTH_CLIENT_SECRET: ${{ secrets.SDR_OAUTH_CLIENT_SECRET }}
       ATLAN_BASE_URL: ${{ secrets.ATLAN_BASE_URL }}
     steps:
+      # codex-/return-dispatch on the apps-sdk side scans step *names*
+      # for "distinct-id <value>". Always-run, no-op; lets the SDK PR's
+      # e2e-full-mysql job locate this run via the GH Actions API.
+      - name: distinct-id ${{ inputs.distinct-id }}
+        if: inputs.distinct-id != ''
+        shell: bash
+        run: echo "Dispatched with distinct-id=${{ inputs.distinct-id }}"
+
       - uses: actions/checkout@v4
         with:
           persist-credentials: false

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -202,3 +202,7 @@ jobs:
           # instead of waiting for a final dump.
           pytest-extra-args: "-s"
           application-sdk-ref: ${{ inputs.application-sdk-ref }}
+          # Distinct commit-status context so this pipeline's PR check
+          # doesn't overwrite (or get overwritten by) the SDR
+          # testcontainer pipeline's `sdr-e2e-tests` status.
+          commit-status-context: e2e-full-tests

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -202,7 +202,3 @@ jobs:
           # instead of waiting for a final dump.
           pytest-extra-args: "-s"
           application-sdk-ref: ${{ inputs.application-sdk-ref }}
-          # Distinct commit-status context so this pipeline's PR check
-          # doesn't overwrite (or get overwritten by) the SDR
-          # testcontainer pipeline's `sdr-e2e-tests` status.
-          commit-status-context: e2e-full-tests

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -166,7 +166,7 @@ jobs:
         shell: bash
         run: echo "Dispatched with distinct-id=${{ inputs.distinct-id }}"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -1,0 +1,181 @@
+name: e2e-full-reusable
+
+# Reusable workflow for the connector full-DAG e2e suite. Each connector
+# repo's per-app `e2e-full.yaml` collapses to a 5-line `uses:` call:
+#
+#     name: e2e-full
+#     on:
+#       workflow_dispatch:
+#         inputs:
+#           agent_name_override:
+#             required: false
+#             type: string
+#             default: ""
+#     jobs:
+#       e2e-full:
+#         uses: atlanhq/application-sdk/.github/workflows/e2e-full-reusable.yaml@main
+#         with:
+#           app-name: mysql
+#           app-image-name: atlan-mysql-app
+#           agent-name-override: ${{ inputs.agent_name_override }}
+#         secrets: inherit
+#
+# Boilerplate that lives here so apps don't copy-paste it:
+#   - 120-min job timeout (must be > ae_poll + atlas_poll + build/setup
+#     overhead — see :data:`ae_poll_timeout_seconds` defaults on the
+#     :class:`BaseFullDAGE2ETest`).
+#   - Concurrency group keyed on workflow + ref so re-running on the
+#     same branch queues rather than racing.
+#   - Permissions minimum set the SDR composite action needs (PR
+#     comments, GHCR push, statuses).
+#   - Tenant + OAuth + API-key env wiring.
+#   - The `Resolve agent-name` step that handles the run-id default.
+#   - The SDR composite action invocation with full-DAG defaults
+#     (test-path, components-dir, compose-overlay, secrets-script).
+#
+# Caller overrides any of the input defaults when their layout differs.
+
+on:
+  workflow_call:
+    inputs:
+      app-name:
+        description: Connector short name (e.g. "mysql", "mssql", "postgres").
+        required: true
+        type: string
+      app-image-name:
+        description: GHCR image name (e.g. "atlan-mysql-app").
+        required: true
+        type: string
+      test-path:
+        description: Pytest target directory.
+        required: false
+        type: string
+        default: tests/full_dag/
+      components-dir:
+        description: |
+          Path (relative to the caller repo root) to the Dapr component
+          overrides — typically the OAuth-via-blobstorage objectstore
+          binding. Default matches the convention this repo's apps
+          follow; override if your app stores them elsewhere.
+        required: false
+        type: string
+        default: .github/e2e/e2e-full-components
+      compose-overlay:
+        description: |
+          Path to the docker-compose overlay that brings up the sibling
+          DB and wires ATLAN_AUTH_* env into the worker.
+        required: false
+        type: string
+        default: .github/e2e/e2e-full-docker-compose.yaml
+      secrets-script:
+        description: |
+          Path to the script that writes the local-secret-store bundle
+          (typically just SDR_{CONNECTOR}_USERNAME/PASSWORD).
+        required: false
+        type: string
+        default: .github/e2e/make-secrets-e2e-full.py
+      timeout-minutes:
+        description: |
+          GH job timeout. Must always be > ae_poll_timeout_seconds +
+          atlas_poll_timeout_seconds + ~10 min build/setup overhead.
+          Default 120 fits the SDK's 90 + 30 minute poll budgets.
+        required: false
+        type: number
+        default: 120
+      agent-name-override:
+        description: |
+          Override agent-name (default ci-<run_id>). Useful when re-
+          running against a worker that's already up.
+        required: false
+        type: string
+        default: ""
+      application-sdk-ref:
+        description: |
+          Branch / tag / SHA of application-sdk to pin during the
+          composite-action invocation. Empty = repo's pyproject pin.
+        required: false
+        type: string
+        default: ""
+    secrets:
+      SDR_TEST_TENANT:
+        description: Tenant DNS short name read by the configurator.
+        required: true
+      SDR_CLIENT_ID:
+        description: Configurator OAuth client id (CI_CLIENT_ID).
+        required: true
+      SDR_CLIENT_SECRET:
+        description: Configurator OAuth client secret (CI_CLIENT_SECRET).
+        required: true
+      ATLAN_BASE_URL:
+        description: Tenant base URL (e.g. https://devex.atlan.com).
+        required: true
+      ATLAN_API_KEY:
+        description: |
+          Bearer for AE-management calls (/automation/api/v1/*). The
+          API-key service account carries realm-admin which the OAuth
+          client does not — verified on devex.
+        required: true
+      SDR_OAUTH_CLIENT_ID:
+        description: |
+          OAuth client id used by the Dapr S3 binding (via the tenant's
+          /api/blobstorage proxy) and by pyatlan for asset queries.
+          Optional — falls back to API-key bearer when absent.
+        required: false
+      SDR_OAUTH_CLIENT_SECRET:
+        description: Matching OAuth client secret.
+        required: false
+
+jobs:
+  e2e-full:
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    concurrency:
+      group: e2e-full-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: false
+    permissions:
+      pull-requests: write
+      contents: read
+      statuses: write
+      packages: write
+    env:
+      CI_TENANT_DOMAIN: ${{ secrets.SDR_TEST_TENANT }}
+      CI_CLIENT_ID: ${{ secrets.SDR_CLIENT_ID }}
+      CI_CLIENT_SECRET: ${{ secrets.SDR_CLIENT_SECRET }}
+      ATLAN_AUTH_CLIENT_ID: ${{ secrets.SDR_OAUTH_CLIENT_ID }}
+      ATLAN_AUTH_CLIENT_SECRET: ${{ secrets.SDR_OAUTH_CLIENT_SECRET }}
+      ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
+      SDR_OAUTH_CLIENT_ID: ${{ secrets.SDR_OAUTH_CLIENT_ID }}
+      SDR_OAUTH_CLIENT_SECRET: ${{ secrets.SDR_OAUTH_CLIENT_SECRET }}
+      ATLAN_BASE_URL: ${{ secrets.ATLAN_BASE_URL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Resolve agent-name
+        id: agent
+        run: |
+          if [ -n "${{ inputs.agent-name-override }}" ]; then
+            echo "name=${{ inputs.agent-name-override }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=ci-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Using agent-name=$(grep '^name=' "$GITHUB_OUTPUT" | cut -d= -f2)"
+
+      - uses: atlanhq/application-sdk/.github/actions/sdr-e2e@main
+        with:
+          app-name: ${{ inputs.app-name }}
+          app-image-name: ${{ inputs.app-image-name }}
+          test-path: ${{ inputs.test-path }}
+          secrets-script: ${{ inputs.secrets-script }}
+          components-dir: ${{ inputs.components-dir }}
+          compose-overlay: ${{ inputs.compose-overlay }}
+          # Bump the container-health wait because the worker has to
+          # establish the Temporal connection with TLS + auth before
+          # /server/health turns green.
+          container-health-timeout-seconds: "120"
+          # `-s` streams the harness's poll-loop output in real time so
+          # operators can watch the colour-emoji DAG progression
+          # instead of waiting for a final dump.
+          pytest-extra-args: "-s"
+          application-sdk-ref: ${{ inputs.application-sdk-ref }}

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -180,7 +180,12 @@ jobs:
           fi
           echo "Using agent-name=$(grep '^name=' "$GITHUB_OUTPUT" | cut -d= -f2)"
 
-      - uses: atlanhq/application-sdk/.github/actions/sdr-e2e@main
+      # TODO: switch to @main once BLDX-1254 lands on the SDK default
+      # branch. Branch-pin so the reusable workflow consumes the same
+      # SDR composite action revision as the rest of the PR (e.g. the
+      # `components-dir` / `compose-overlay` / `application-sdk-ref`
+      # inputs that don't exist on @main yet).
+      - uses: atlanhq/application-sdk/.github/actions/sdr-e2e@aryaman/bldx-1254-sdr-cross-repo-trigger
         with:
           app-name: ${{ inputs.app-name }}
           app-image-name: ${{ inputs.app-image-name }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -363,7 +363,7 @@ jobs:
   # application_sdk_ref input and re-pins atlan-application-sdk to that
   # SHA before building the image + running tests.
   sdr-e2e-apps:
-    name: SDR E2E (Apps)
+    name: SDR Integration Test with testcontainer (E&T)
     needs: [changes, sdr-matrix-builder]
     # No label gate — runs on every push to a non-fork, non-dependabot
     # PR. ~3 min per connector and validates the SDR contract end-to-
@@ -392,7 +392,7 @@ jobs:
   # filename + the dispatch label (e2e-full-postgres, e2e-full-mssql,
   # …) when wiring up a new connector.
   e2e-full-mysql:
-    name: e2e-full (mysql)
+    name: E2E Full with system apps (atlan-mysql-app, main)
     needs: [changes]
     if: |
       (

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -406,7 +406,12 @@ jobs:
         with:
           github-token: ${{ secrets.ORG_PAT_GITHUB }}
           repo-name: atlan-mysql-app
-          target-branch: "refs/heads/${{ github.base_ref }}"
+          # TODO: revert to "refs/heads/${{ github.base_ref }}" once
+          # PR #107 on atlan-mysql-app merges. Until then, target the
+          # PR branch so the dispatched run picks up the e2e-full.yaml
+          # that declares the `distinct_id` workflow_dispatch input
+          # codex-/return-dispatch always passes.
+          target-branch: "refs/heads/aryaman/bump-setup-uv-v6"
           workflow: e2e-full.yaml
           workflow-inputs: |
             { "application_sdk_ref": "${{ github.event.pull_request.head.sha }}" }

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -363,7 +363,7 @@ jobs:
   # application_sdk_ref input and re-pins atlan-application-sdk to that
   # SHA before building the image + running tests.
   sdr-e2e-apps:
-    name: SDR Integration Test with testcontainer (E&T)
+    name: SDR Integration Test with testcontainer (E&T) (${{ matrix.repo_name }}, ${{ github.head_ref }})
     needs: [changes, sdr-matrix-builder]
     # No label gate — runs on every push to a non-fork, non-dependabot
     # PR. ~3 min per connector and validates the SDR contract end-to-
@@ -392,7 +392,7 @@ jobs:
   # filename + the dispatch label (e2e-full-postgres, e2e-full-mssql,
   # …) when wiring up a new connector.
   e2e-full-mysql:
-    name: E2E Full with system apps (atlan-mysql-app, main)
+    name: E2E Full with system apps (atlan-mysql-app, ${{ github.head_ref }})
     needs: [changes]
     if: |
       (

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -384,19 +384,20 @@ jobs:
           workflow-inputs: |
             { "application_sdk_ref": "${{ github.event.pull_request.head.sha }}" }
 
-  # Tier-4 full-DAG e2e against the mysql connector. Opt-in via the
-  # `test-e2e-full-mysql-app` label because each run is ~20 min and
-  # creates real Connection assets on the test tenant. Add a similar
-  # job + label per app as more connectors adopt the e2e-full harness
-  # (the e2e-apps composite action is generic; just changes the
-  # `workflow` filename + the dispatch label name).
-  e2e-full-mysql-app:
+  # Full-DAG e2e against the mysql connector. Opt-in via the
+  # `e2e-full-mysql` label because each run is ~20 min and creates
+  # real Connection assets on the test tenant. Add a similar job +
+  # label per app as more connectors adopt the e2e-full harness — the
+  # e2e-apps composite action is generic; just change the `workflow`
+  # filename + the dispatch label (e2e-full-postgres, e2e-full-mssql,
+  # …) when wiring up a new connector.
+  e2e-full-mysql:
     name: e2e-full (mysql)
     needs: [changes]
     if: |
       (
-        (github.event.action == 'labeled' && github.event.label.name == 'test-e2e-full-mysql-app') ||
-        contains(github.event.pull_request.labels.*.name, 'test-e2e-full-mysql-app')
+        (github.event.action == 'labeled' && github.event.label.name == 'e2e-full-mysql') ||
+        contains(github.event.pull_request.labels.*.name, 'e2e-full-mysql')
       ) && github.event.pull_request.head.repo.fork != true && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -412,12 +412,7 @@ jobs:
         with:
           github-token: ${{ secrets.ORG_PAT_GITHUB }}
           repo-name: atlan-mysql-app
-          # TODO: revert to "refs/heads/${{ github.base_ref }}" once
-          # PR #107 on atlan-mysql-app merges. Until then, target the
-          # PR branch so the dispatched run picks up the e2e-full.yaml
-          # that declares the `distinct_id` workflow_dispatch input
-          # codex-/return-dispatch always passes.
-          target-branch: "refs/heads/aryaman/bump-setup-uv-v6"
+          target-branch: "refs/heads/${{ github.base_ref }}"
           workflow: e2e-full.yaml
           workflow-inputs: |
             { "application_sdk_ref": "${{ github.event.pull_request.head.sha }}" }

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -400,6 +400,12 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'e2e-full-mysql')
       ) && github.event.pull_request.head.repo.fork != true && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    # The dispatched mysql-app run budget is timeout-minutes: 120
+    # (matches the SDK's e2e-full-reusable.yaml ceiling). Add ~10 min
+    # of overhead for dispatch + queue + artifact-fetch + comment-post
+    # on this side so the SDK job doesn't get killed before the
+    # dispatched run finishes legitimately.
+    timeout-minutes: 130
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: "./.github/actions/e2e-apps"

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -363,7 +363,7 @@ jobs:
   # application_sdk_ref input and re-pins atlan-application-sdk to that
   # SHA before building the image + running tests.
   sdr-e2e-apps:
-    name: SDR Integration Test with testcontainer (E&T) (${{ matrix.repo_name }}, ${{ github.head_ref }})
+    name: SDR Integration Tests (testcontainer) — ${{ matrix.repo_name }}
     needs: [changes, sdr-matrix-builder]
     # No label gate — runs on every push to a non-fork, non-dependabot
     # PR. ~3 min per connector and validates the SDR contract end-to-
@@ -392,7 +392,7 @@ jobs:
   # filename + the dispatch label (e2e-full-postgres, e2e-full-mssql,
   # …) when wiring up a new connector.
   e2e-full-mysql:
-    name: E2E Full with system apps (atlan-mysql-app, ${{ github.head_ref }})
+    name: E2E Full Tests (system apps) — atlan-mysql-app
     needs: [changes]
     if: |
       (

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -292,9 +292,14 @@ jobs:
   # above, but a different default (the SDR-enabled connector fleet,
   # not openapi-app). Keeping them separate so the SDR path can grow
   # connectors independently of the legacy e2e path.
+  #
+  # No label gate — the SDR connector suite (~3 min per app) auto-runs
+  # on every PR push so SDK changes are validated end-to-end against
+  # the connector fleet by default. Custom <repo>:<branch> labels
+  # still override the default matrix when a contributor wants to pin
+  # an alternate target branch for a specific connector.
   sdr-matrix-builder:
     name: Build SDR Test Matrix
-    if: (github.event.action == 'labeled' && github.event.label.name == 'sdr-e2e-test') || contains(github.event.pull_request.labels.*.name, 'sdr-e2e-test')
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -360,7 +365,10 @@ jobs:
   sdr-e2e-apps:
     name: SDR E2E (Apps)
     needs: [changes, sdr-matrix-builder]
-    if: ((github.event.action == 'labeled' && github.event.label.name == 'sdr-e2e-test') || contains(github.event.pull_request.labels.*.name, 'sdr-e2e-test')) && github.event.pull_request.head.repo.fork != true && github.event.pull_request.user.login != 'dependabot[bot]'
+    # No label gate — runs on every push to a non-fork, non-dependabot
+    # PR. ~3 min per connector and validates the SDR contract end-to-
+    # end, which is worth the spend on every SDK PR.
+    if: github.event.pull_request.head.repo.fork != true && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -373,6 +381,32 @@ jobs:
           repo-name: ${{ matrix.repo_name }}
           target-branch: "refs/heads/${{ matrix.target_branch }}"
           workflow: sdr-integration-tests.yaml
+          workflow-inputs: |
+            { "application_sdk_ref": "${{ github.event.pull_request.head.sha }}" }
+
+  # Tier-4 full-DAG e2e against the mysql connector. Opt-in via the
+  # `test-e2e-full-mysql-app` label because each run is ~20 min and
+  # creates real Connection assets on the test tenant. Add a similar
+  # job + label per app as more connectors adopt the e2e-full harness
+  # (the e2e-apps composite action is generic; just changes the
+  # `workflow` filename + the dispatch label name).
+  e2e-full-mysql-app:
+    name: e2e-full (mysql)
+    needs: [changes]
+    if: |
+      (
+        (github.event.action == 'labeled' && github.event.label.name == 'test-e2e-full-mysql-app') ||
+        contains(github.event.pull_request.labels.*.name, 'test-e2e-full-mysql-app')
+      ) && github.event.pull_request.head.repo.fork != true && github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: "./.github/actions/e2e-apps"
+        with:
+          github-token: ${{ secrets.ORG_PAT_GITHUB }}
+          repo-name: atlan-mysql-app
+          target-branch: "refs/heads/${{ github.base_ref }}"
+          workflow: e2e-full.yaml
           workflow-inputs: |
             { "application_sdk_ref": "${{ github.event.pull_request.head.sha }}" }
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -288,3 +288,91 @@ jobs:
           repo-name: ${{ matrix.repo_name }}
           target-branch: "refs/heads/${{ matrix.target_branch }}"
 
+  # SDR matrix — same <repo>:<branch> label parsing as matrix-builder
+  # above, but a different default (the SDR-enabled connector fleet,
+  # not openapi-app). Keeping them separate so the SDR path can grow
+  # connectors independently of the legacy e2e path.
+  sdr-matrix-builder:
+    name: Build SDR Test Matrix
+    if: (github.event.action == 'labeled' && github.event.label.name == 'sdr-e2e-test') || contains(github.event.pull_request.labels.*.name, 'sdr-e2e-test')
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Get PR Labels
+        id: get-labels
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            const labelNames = labels.map(label => label.name).join(',');
+            console.log(`PR Labels: ${labelNames}`);
+            core.setOutput('labels', labelNames);
+
+      - name: Build matrix from PR labels
+        id: set-matrix
+        run: |
+          TARGET_BRANCH="${{ github.base_ref }}"
+          # SDR-enabled connector fleet — extend this list as new
+          # connectors wire up sdr-integration-tests.yaml.
+          DEFAULT_MATRIX="{\"include\":[{\"repo_name\":\"atlan-mysql-app\",\"target_branch\":\"${TARGET_BRANCH}\"}]}"
+
+          LABELS="${{ steps.get-labels.outputs.labels }}"
+          FOUND_LABEL=false
+          INCLUDES=""
+
+          IFS=',' read -ra LABEL_ARRAY <<< "$LABELS"
+          for LABEL in "${LABEL_ARRAY[@]}"; do
+            if [[ $LABEL =~ ^([^:]+):([^:]+)$ ]]; then
+              REPO="${BASH_REMATCH[1]}"
+              BRANCH="${BASH_REMATCH[2]}"
+              if [[ "$FOUND_LABEL" == "true" ]]; then
+                INCLUDES="${INCLUDES},"
+              fi
+              INCLUDES="${INCLUDES}{\"repo_name\":\"${REPO}\",\"target_branch\":\"${BRANCH}\"}"
+              FOUND_LABEL=true
+              echo "Added SDR matrix entry: $REPO:$BRANCH"
+            fi
+          done
+
+          if [[ "$FOUND_LABEL" == "true" ]]; then
+            MATRIX="{\"include\":[${INCLUDES}]}"
+          else
+            MATRIX="$DEFAULT_MATRIX"
+            echo "No repo:branch labels found, using default SDR matrix"
+          fi
+
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          echo "Matrix output: $MATRIX"
+
+  # SDR E2E Tests: dispatched on the connector repo at the PR's head SHA
+  # so SDK changes are validated end-to-end against the connector fleet.
+  # The connector's sdr-integration-tests.yaml accepts the
+  # application_sdk_ref input and re-pins atlan-application-sdk to that
+  # SHA before building the image + running tests.
+  sdr-e2e-apps:
+    name: SDR E2E (Apps)
+    needs: [changes, sdr-matrix-builder]
+    if: ((github.event.action == 'labeled' && github.event.label.name == 'sdr-e2e-test') || contains(github.event.pull_request.labels.*.name, 'sdr-e2e-test')) && github.event.pull_request.head.repo.fork != true && github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.sdr-matrix-builder.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: "./.github/actions/e2e-apps"
+        with:
+          github-token: ${{ secrets.ORG_PAT_GITHUB }}
+          repo-name: ${{ matrix.repo_name }}
+          target-branch: "refs/heads/${{ matrix.target_branch }}"
+          workflow: sdr-integration-tests.yaml
+          workflow-inputs: |
+            { "application_sdk_ref": "${{ github.event.pull_request.head.sha }}" }
+

--- a/application_sdk/testing/full_dag/__init__.py
+++ b/application_sdk/testing/full_dag/__init__.py
@@ -45,6 +45,7 @@ from application_sdk.testing.full_dag.client import (
     DAGRunStatus,
 )
 from application_sdk.testing.full_dag.payload import build_ae_payload, build_seed_dag
+from application_sdk.testing.full_dag.sql_app import SQLAppE2EFullTest
 
 __all__ = [
     "AEWorkflowClient",
@@ -52,6 +53,7 @@ __all__ = [
     "DAGNodeStatus",
     "DAGRunStatus",
     "RunMode",
+    "SQLAppE2EFullTest",
     "build_ae_payload",
     "build_seed_dag",
 ]

--- a/application_sdk/testing/full_dag/__init__.py
+++ b/application_sdk/testing/full_dag/__init__.py
@@ -1,0 +1,56 @@
+"""Shared harness for tier-4 / tier-5 full-DAG end-to-end tests.
+
+Tier 4 (e2e-sdr-full) and tier 5 (e2e-full) both validate connectors
+end-to-end against the *tenant's* system apps (publish, query-intelligence,
+lineage, lineage-publish) on top of the connector's own extract step. The
+moving parts are identical:
+
+1. Submit an Automation Engine workflow via
+   ``POST /api/service/package-workflows?submit=true``.
+2. Poll the run via
+   ``GET /api/service/package-workflows/native-status/<run_id>``
+   until every DAG node reaches a terminal status.
+3. Poll Atlas via
+   ``GET /api/meta/entity/uniqueAttribute/type/Connection?attr:qualifiedName=...``
+   until the resulting Connection asset shows up.
+
+The only thing that differs between tier 4 and tier 5 is *where the
+connector image runs* — tier 4 uses a CI-side docker compose worker
+registered on a unique Temporal queue (using the agent flow); tier 5
+uses a tenant-deployed pod (using the direct flow). The submission +
+polling + assertion are the same.
+
+Public surface:
+
+- :class:`BaseFullDAGE2ETest` — pytest base class subclasses configure
+  with connector-specific knobs (app name, Argo template, connection
+  qualifying-name prefix) and then call :meth:`run_full_dag` to execute.
+
+- :func:`build_ae_payload` — payload builder shared between the agent
+  (tier 4) and direct (tier 5) modes.
+
+- :class:`AEWorkflowClient` — thin HTTP wrapper around the three Atlan
+  endpoints used above, with retry on transient 5xx and a structured
+  return shape per DAG node.
+
+See ``application_sdk.testing.sdr`` for the connector-only validation
+that runs in tier 3 (BLDX-1254). Tier 4/5 complement tier 3 by adding
+the tenant-side system-apps validation.
+"""
+
+from application_sdk.testing.full_dag.base import BaseFullDAGE2ETest, RunMode
+from application_sdk.testing.full_dag.client import (
+    AEWorkflowClient,
+    DAGNodeStatus,
+    DAGRunStatus,
+)
+from application_sdk.testing.full_dag.payload import build_ae_payload
+
+__all__ = [
+    "AEWorkflowClient",
+    "BaseFullDAGE2ETest",
+    "DAGNodeStatus",
+    "DAGRunStatus",
+    "RunMode",
+    "build_ae_payload",
+]

--- a/application_sdk/testing/full_dag/__init__.py
+++ b/application_sdk/testing/full_dag/__init__.py
@@ -44,7 +44,7 @@ from application_sdk.testing.full_dag.client import (
     DAGNodeStatus,
     DAGRunStatus,
 )
-from application_sdk.testing.full_dag.payload import build_ae_payload
+from application_sdk.testing.full_dag.payload import build_ae_payload, build_seed_dag
 
 __all__ = [
     "AEWorkflowClient",
@@ -53,4 +53,5 @@ __all__ = [
     "DAGRunStatus",
     "RunMode",
     "build_ae_payload",
+    "build_seed_dag",
 ]

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -265,10 +265,40 @@ class BaseFullDAGE2ETest:
                 )
 
         tenant_url = os.environ.get("ATLAN_BASE_URL", "").rstrip("/")
-        api_token = os.environ.get("ATLAN_API_KEY", "")
-        if not tenant_url or not api_token:
+        if not tenant_url:
             raise RuntimeError(
-                "Full-DAG e2e harness requires ATLAN_BASE_URL + ATLAN_API_KEY"
+                "Full-DAG e2e harness requires ATLAN_BASE_URL"
+            )
+
+        # Prefer OAuth-client credentials (long-lived GH repo secrets;
+        # short-lived bearer minted at run time and refreshed by the
+        # harness) over the raw API key. The OAuth-issued service
+        # account has explicit scopes (events-app + temporal-app +
+        # default:read/write) which is enough for every AE / Atlas /
+        # search call the harness makes — and produces predictable
+        # RBAC diagnostics ('service-account-oauth-client-<id>' instead
+        # of the opaque 'service-account-apikey-<uuid>'). Falls back to
+        # the bearer API key when OAuth creds aren't in the env, so
+        # local development with ATLAN_API_KEY still works.
+        oauth_client_id = os.environ.get("SDR_OAUTH_CLIENT_ID", "") or os.environ.get(
+            "ATLAN_AUTH_CLIENT_ID", ""
+        )
+        oauth_client_secret = os.environ.get(
+            "SDR_OAUTH_CLIENT_SECRET", ""
+        ) or os.environ.get("ATLAN_AUTH_CLIENT_SECRET", "")
+        api_key = os.environ.get("ATLAN_API_KEY", "")
+        if oauth_client_id and oauth_client_secret:
+            api_token = self._exchange_oauth_for_token(
+                tenant_url, oauth_client_id, oauth_client_secret
+            )
+        elif api_key:
+            api_token = api_key
+            oauth_client_id = ""
+            oauth_client_secret = ""
+        else:
+            raise RuntimeError(
+                "Full-DAG e2e harness requires either SDR_OAUTH_CLIENT_ID + "
+                "SDR_OAUTH_CLIENT_SECRET (preferred) or ATLAN_API_KEY"
             )
 
         # Prefer GH-provided run identifier (cross-correlatable with
@@ -277,7 +307,12 @@ class BaseFullDAGE2ETest:
         self.run_id = (
             int(gh_run_id) if gh_run_id and gh_run_id.isdigit() else int(time.time())
         )
-        self.client = AEWorkflowClient(tenant_url, api_token)
+        self.client = AEWorkflowClient(
+            tenant_url,
+            api_token,
+            oauth_client_id=oauth_client_id or None,
+            oauth_client_secret=oauth_client_secret or None,
+        )
         self.connection_qualified_name = (
             f"default/{self.connector_short_name}/"
             f"{self.connection_name_prefix}-{self.run_id}"
@@ -285,6 +320,48 @@ class BaseFullDAGE2ETest:
         self.connection_display_name = (
             f"{self.connection_name_prefix}-{self.connector_short_name}-{self.run_id}"
         )
+
+    @staticmethod
+    def _exchange_oauth_for_token(
+        tenant_url: str, client_id: str, client_secret: str
+    ) -> str:
+        """Trade an OAuth client_credentials pair for a bearer access token.
+
+        Used at ``setup_method`` time to mint a short-lived bearer the
+        AE REST client can use directly. The token typically lasts
+        15 min — enough to cover an entire e2e run end-to-end (5-15 min
+        wall-time). For runs that exceed the TTL, the AE-side calls
+        will start returning 401; that's a signal to refresh, but we
+        haven't seen it in practice.
+        """
+        import urllib.parse  # noqa: PLC0415 — cold path: only at setup
+        import urllib.request  # noqa: PLC0415 — cold path: only at setup
+        from json import loads  # noqa: PLC0415 — cold path: only at setup
+
+        body = urllib.parse.urlencode(
+            {
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+            }
+        ).encode()
+        req = urllib.request.Request(
+            f"{tenant_url}/auth/realms/default/protocol/openid-connect/token",
+            data=body,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "User-Agent": "atlan-sdk-full-dag-e2e/1.0",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            payload = loads(resp.read())
+        token = payload.get("access_token")
+        if not isinstance(token, str) or not token:
+            raise RuntimeError(
+                "OAuth token exchange returned no access_token "
+                f"(keys: {list(payload.keys())})"
+            )
+        return token
 
     # ------------------------------------------------------------------
     # Subclass hooks — override these

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -216,11 +216,6 @@ class BaseFullDAGE2ETest:
     lineage_task_queue: ClassVar[str] = "atlan-lineage-production"
     qi_parsing_mode: ClassVar[str] = "competitive"
     qi_input_prefix_field: ClassVar[str] = "view_data_prefix"
-    # Override when the connector's worker registers a non-default
-    # workflow name. Default = connector_short_name (v3 convention,
-    # what mysql uses). Set to e.g. ``"mssql-metadata-extractor"`` for
-    # v2-style connectors. Empty string means "use the SDK default".
-    extract_workflow_type: ClassVar[str] = ""
 
     ae_poll_interval_seconds: ClassVar[int] = 10
     ae_poll_timeout_seconds: ClassVar[int] = 600

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -166,6 +166,11 @@ class BaseFullDAGE2ETest:
     # devex sample) uses ``competitive``. Subclasses override to match
     # their manifest.json.
     qi_parsing_mode: ClassVar[str] = "competitive"
+    # Override when the connector's worker registers a non-default
+    # workflow name. Default = connector_short_name (v3 convention,
+    # what mysql uses). Set to e.g. ``"mssql-metadata-extractor"`` for
+    # v2-style connectors. Empty string means "use the SDK default".
+    extract_workflow_type: ClassVar[str] = ""
 
     ae_poll_interval_seconds: ClassVar[int] = 10
     ae_poll_timeout_seconds: ClassVar[int] = 600
@@ -306,6 +311,7 @@ class BaseFullDAGE2ETest:
             lineage_task_queue=self.lineage_task_queue,
             connection=self.connection_spec(),
             qi_parsing_mode=self.qi_parsing_mode,
+            extract_workflow_type=self.extract_workflow_type or None,
         )
         version = self.client.create_version(
             slug,

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -335,21 +335,28 @@ class BaseFullDAGE2ETest:
 
         Reads ``self.manifest_path`` (relative to the test's cwd —
         typically the connector repo root), parses out the ``dag``
-        block, and substitutes the two curly-brace placeholders the
-        configurator normally fills:
+        block, and substitutes the placeholders the configurator
+        normally fills at deployment time.
 
-          * ``{app_name}`` → :attr:`connector_short_name`
-          * ``{deployment_name}`` →
-            - in ``extract.inputs.task_queue``: the agent / CI worker
-              identity (``atlan-{agent_name}`` style queue derived from
-              :meth:`agent_spec`).
-            - elsewhere (qi / publish / lineage / lineage-publish):
-              :attr:`tenant_deployment_name` (default ``production``).
+        Two substitution passes:
 
-        Mustache placeholders (``{{credentialGuid}}``, ``{{connection}}``,
-        ``{{include-filter}}``, etc.) are left in place — AE substitutes
-        them at submit time from the matching named parameters in the
-        submit payload.
+        1. Curly-brace `{...}` (the configurator's static fills):
+           ``{app_name}`` → :attr:`connector_short_name`; and
+           ``{deployment_name}`` → CI agent queue on ``extract``,
+           :attr:`tenant_deployment_name` elsewhere.
+
+        2. Mustache `{{...}}` (the configurator's dynamic fills): these
+           map to per-run identities the harness owns — connection,
+           agent_json, filters, extraction_method, etc. AE does NOT
+           runtime-substitute these in the seed args; they have to be
+           concrete by the time the seed version is published or the
+           worker receives them as literal placeholder strings and
+           hangs.
+
+        ``{{credential-guid}}`` is special-cased: substituted with
+        ``{{credentialGuid}}`` (camelCase, the AE-recognised
+        Mustache that *is* runtime-substituted from the submit's
+        ``payload[].body``).
 
         Raises:
             RuntimeError: If ``manifest_path`` can't be read or doesn't
@@ -384,9 +391,8 @@ class BaseFullDAGE2ETest:
                 return extract_task_queue
             return raw.replace("{deployment_name}", self.tenant_deployment_name)
 
-        # In-place substitution — manifest's dag is the seed shape we
-        # need to publish. We don't deep-copy because we're parsing a
-        # freshly loaded file each call; nothing reuses this dict.
+        # Pass 1: curly-brace `{...}` substitutions on the per-node
+        # metadata (app_name, task_queue).
         for name, node in dag.items():
             inputs = node.get("inputs")
             if not isinstance(inputs, dict):
@@ -403,6 +409,19 @@ class BaseFullDAGE2ETest:
             if isinstance(tq, str):
                 inputs["task_queue"] = _sub_queue(name, tq)
 
+        # Pass 2: Mustache `{{...}}` substitutions on the per-node args
+        # (the dynamic fills the configurator does at deployment time —
+        # we do them in-process so the published seed has concrete
+        # values the worker can act on).
+        mustache_subs = self._mustache_substitutions()
+        for name, node in dag.items():
+            inputs = node.get("inputs")
+            if not isinstance(inputs, dict):
+                continue
+            args = inputs.get("args")
+            if isinstance(args, dict):
+                inputs["args"] = self._apply_mustache_subs(args, mustache_subs)
+
         logger.info(
             "Loaded seed DAG from %s (%d nodes: %s)",
             path,
@@ -410,6 +429,76 @@ class BaseFullDAGE2ETest:
             ", ".join(sorted(dag.keys())),
         )
         return dag
+
+    def _mustache_substitutions(self) -> dict:
+        """Build the ``{{...}}`` → runtime-value map for seed-DAG fills.
+
+        Acts as the local-CI equivalent of the configurator's
+        deployment-time substitution: takes the per-run identities the
+        harness owns (connection, agent_json, filter strings, etc.) and
+        maps them to the Mustache keys the connector's manifest uses.
+
+        ``{{credential-guid}}`` is the only key we forward to AE rather
+        than fill in directly — its value is ``{{credentialGuid}}``
+        (camelCase), which AE *does* runtime-substitute from the
+        ``payload[].body`` credential it creates at submit time.
+        """
+        agent = self.agent_spec()
+        connection = self.connection_spec()
+        database = self.database_spec()
+
+        # Full Connection entity shape — same JSON we attach as the
+        # `connection` submit parameter in build_ae_payload.
+        connection_entity = {
+            "attributes": connection.attributes(),
+            "typeName": "Connection",
+        }
+
+        # Agent-json shape mirrors what build_seed_dag's hand-crafted
+        # extract_args used pre-manifest: AGENT mode → secret-store
+        # bundle keys; DIRECT mode → None (worker takes credentials
+        # straight from the credential the credential_guid points at).
+        if agent is not None:
+            agent_json: dict | None = {
+                "host": database.host,
+                "port": database.port,
+                "auth-type": database.auth_type,
+                "agent-name": agent.agent_name,
+                "agent-type": agent.agent_type,
+                "key-type": agent.key_type,
+                "aws-auth-method": agent.aws_auth_method,
+                "azure-auth-method": agent.azure_auth_method,
+                "basic.username": (
+                    f"SDR_{self.connector_short_name.upper()}_USERNAME"
+                ),
+                "basic.password": (
+                    f"SDR_{self.connector_short_name.upper()}_PASSWORD"
+                ),
+            }
+        else:
+            agent_json = None
+
+        return {
+            "{{credential}}": None,
+            "{{credential-guid}}": "{{credentialGuid}}",
+            "{{connection}}": connection_entity,
+            "{{extraction-method}}": self.mode.value,
+            "{{agent-json}}": agent_json,
+            "{{include-filter}}": self.include_filter,
+            "{{exclude-filter}}": self.exclude_filter,
+            "{{exclude-table-regex}}": "",
+            "{{preflight-check}}": True,
+        }
+
+    def _apply_mustache_subs(self, obj, subs: dict):
+        """Recursively replace exact-match ``{{...}}`` strings."""
+        if isinstance(obj, dict):
+            return {k: self._apply_mustache_subs(v, subs) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [self._apply_mustache_subs(x, subs) for x in obj]
+        if isinstance(obj, str) and obj in subs:
+            return subs[obj]
+        return obj
 
     # ------------------------------------------------------------------
     # The actual flow

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -1,0 +1,327 @@
+"""Pytest base class for full-DAG e2e tests against tenant system apps.
+
+A connector test:
+
+.. code-block:: python
+
+    import os
+    import pytest
+    from application_sdk.testing.full_dag import (
+        BaseFullDAGE2ETest, RunMode,
+    )
+    from application_sdk.testing.full_dag.payload import (
+        ConnectionSpec, DatabaseSpec, AgentSpec,
+    )
+
+    @pytest.mark.full_dag_e2e
+    class TestMySQLFullDAG(BaseFullDAGE2ETest):
+        connector_short_name = "mysql"
+        argo_package_name = "@atlan/mysql"
+        argo_template_name = "atlan-mysql"
+
+        # AGENT for tier 4 (CI-side worker); DIRECT for tier 5 (prod pod).
+        mode = RunMode.AGENT
+        app_service_url = "http://mysql.mysql-app.svc.cluster.local"
+
+        def database_spec(self) -> DatabaseSpec:
+            return DatabaseSpec(
+                host=os.environ["MYSQL_HOST"],
+                port=int(os.environ["MYSQL_PORT"]),
+                username=os.environ["MYSQL_USER"],
+                password=os.environ["MYSQL_PASSWORD"],
+            )
+
+        def agent_spec(self) -> AgentSpec | None:
+            return AgentSpec(agent_name=f"ci-{self.run_id}")
+
+The base class handles submit + native-status poll + Atlas-side
+Connection assertion + per-node duration reporting. Subclasses just
+provide config.
+
+To skip the whole class when the harness env isn't configured (so the
+test class can sit alongside per-PR tier-3 tests without breaking
+``pytest -q``)::
+
+    if not os.environ.get("ATLAN_BASE_URL"):
+        pytest.skip("ATLAN_BASE_URL not set; full-DAG e2e harness disabled",
+                    allow_module_level=True)
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from typing import ClassVar
+
+from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing.full_dag.client import AEWorkflowClient, DAGRunResult
+from application_sdk.testing.full_dag.payload import (
+    AgentSpec,
+    ConnectionSpec,
+    DatabaseSpec,
+    RunMode,
+    build_ae_payload,
+)
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class FullDAGOutcome:
+    """Combined result of a single full-DAG run.
+
+    Returned by :meth:`BaseFullDAGE2ETest.run_full_dag` so subclasses
+    can build their own assertions on top — e.g. "extract took less
+    than X seconds", "all four entity types extracted", etc.
+    """
+
+    ae_result: DAGRunResult
+    connection_qualified_name: str
+    connection_in_atlas: bool
+
+    @property
+    def succeeded(self) -> bool:
+        """True iff every DAG node succeeded *and* Atlas has the Connection."""
+        return self.ae_result.all_nodes_succeeded and self.connection_in_atlas
+
+
+class BaseFullDAGE2ETest:
+    """Pytest base — subclass per connector, set class attrs.
+
+    Class attrs subclasses MUST set:
+
+    Attributes:
+        connector_short_name: ``mysql``, ``mssql``, ``saperp``, etc.
+        argo_package_name: ``@atlan/<connector>``.
+        argo_template_name: Cluster-scoped WorkflowTemplate name
+            (e.g. ``atlan-mysql``). Must match what the tenant has
+            installed.
+        mode: :data:`RunMode.AGENT` for tier 4, :data:`RunMode.DIRECT`
+            for tier 5.
+        app_service_url: HTTP URL the AE workflow's extract activity
+            falls back to. Metadata-only in agent mode; used for
+            credential injection in direct mode.
+
+    Class attrs with defaults:
+
+    Attributes:
+        connection_name_prefix: Prefix applied to the test Connection
+            name and qualifiedName so cleanup sweeps can find them.
+        include_filter / exclude_filter: JSON-encoded dict-shape
+            filter strings (matches the orchestrator's expected wire
+            format). Default = "everything under the default catalog".
+        connection_admin_users / _groups / _roles: ACL on the test
+            Connection. Default empty.
+        ae_poll_interval_seconds / ae_poll_timeout_seconds: How
+            aggressively to poll native-status.
+        atlas_poll_interval_seconds / atlas_poll_timeout_seconds: How
+            aggressively to poll the Atlas Connection endpoint.
+
+    Subclass methods to provide config:
+
+        ``database_spec() -> DatabaseSpec``
+        ``agent_spec() -> AgentSpec | None``  (None for DIRECT mode)
+    """
+
+    # --- required class attrs (must be overridden) ---------------------
+    connector_short_name: ClassVar[str] = ""
+    argo_package_name: ClassVar[str] = ""
+    argo_template_name: ClassVar[str] = ""
+    mode: ClassVar[RunMode] = RunMode.DIRECT
+    app_service_url: ClassVar[str] = ""
+
+    # --- optional class attrs ------------------------------------------
+    connection_name_prefix: ClassVar[str] = "full-dag-e2e"
+    include_filter: ClassVar[str] = '{"^def$":[".*"]}'
+    exclude_filter: ClassVar[str] = "{}"
+    connection_admin_users: ClassVar[tuple[str, ...]] = ()
+    connection_admin_groups: ClassVar[tuple[str, ...]] = ()
+    connection_admin_roles: ClassVar[tuple[str, ...]] = ()
+
+    ae_poll_interval_seconds: ClassVar[int] = 10
+    ae_poll_timeout_seconds: ClassVar[int] = 600
+    atlas_poll_interval_seconds: ClassVar[int] = 30
+    atlas_poll_timeout_seconds: ClassVar[int] = 1500
+
+    # ------------------------------------------------------------------
+    # Setup
+    # ------------------------------------------------------------------
+
+    def setup_method(self) -> None:
+        """Resolve env + build the per-test identity.
+
+        Pytest invokes this before every test method. We re-stamp
+        ``run_id`` on each call so re-running the same test class in a
+        single pytest invocation never collides on Connection QN.
+        """
+        for required in (
+            "connector_short_name",
+            "argo_package_name",
+            "argo_template_name",
+        ):
+            if not getattr(type(self), required, ""):
+                raise RuntimeError(
+                    f"{type(self).__name__}: class attribute '{required}' must be set"
+                )
+
+        tenant_url = os.environ.get("ATLAN_BASE_URL", "").rstrip("/")
+        api_token = os.environ.get("ATLAN_API_KEY", "")
+        if not tenant_url or not api_token:
+            raise RuntimeError(
+                "Full-DAG e2e harness requires ATLAN_BASE_URL + ATLAN_API_KEY"
+            )
+
+        # Prefer GH-provided run identifier (cross-correlatable with
+        # workflow logs) — fall back to seconds-since-epoch.
+        gh_run_id = os.environ.get("GITHUB_RUN_ID")
+        self.run_id = (
+            int(gh_run_id) if gh_run_id and gh_run_id.isdigit() else int(time.time())
+        )
+        self.client = AEWorkflowClient(tenant_url, api_token)
+        self.connection_qualified_name = (
+            f"default/{self.connector_short_name}/"
+            f"{self.connection_name_prefix}-{self.run_id}"
+        )
+        self.connection_display_name = (
+            f"{self.connection_name_prefix}-{self.connector_short_name}-{self.run_id}"
+        )
+
+    # ------------------------------------------------------------------
+    # Subclass hooks — override these
+    # ------------------------------------------------------------------
+
+    def database_spec(self) -> DatabaseSpec:
+        """Real DB the connector will introspect.
+
+        Tier 4 (agent mode): the values you put here go into the AE
+        submit payload but credential resolution actually flows through
+        the SDR agent's local secret store at run time — so what
+        matters here is that ``host`` / ``port`` match what the agent
+        can reach.
+
+        Tier 5 (direct mode): values are sent verbatim to the prod pod
+        as credential overrides; must work as-is.
+        """
+        raise NotImplementedError
+
+    def agent_spec(self) -> AgentSpec | None:
+        """Agent identity (tier 4 only). Return None for direct mode."""
+        if self.mode is RunMode.DIRECT:
+            return None
+        raise NotImplementedError
+
+    def connection_spec(self) -> ConnectionSpec:
+        """Where the resulting Atlas Connection will live.
+
+        Default builds from class attrs + per-run identity. Override if
+        you need a different category / icon / ACL per test.
+        """
+        return ConnectionSpec(
+            name=self.connection_display_name,
+            qualified_name=self.connection_qualified_name,
+            connector_name=self.connector_short_name,
+            source_logo=f"https://assets.atlan.com/assets/{self.connector_short_name}.png",
+            admin_users=self.connection_admin_users,
+            admin_groups=self.connection_admin_groups,
+            admin_roles=self.connection_admin_roles,
+        )
+
+    # ------------------------------------------------------------------
+    # The actual flow
+    # ------------------------------------------------------------------
+
+    def run_full_dag(self) -> FullDAGOutcome:
+        """Submit, poll AE, poll Atlas, return the combined outcome.
+
+        Idempotent failures (AE submit returning a recognizable
+        "duplicate" error, Atlas already having the QN) are *not*
+        special-cased here — the caller is expected to make every
+        ``run_id`` unique.
+
+        Returns:
+            FullDAGOutcome describing AE node status + Atlas presence.
+        """
+        payload = build_ae_payload(
+            run_id=self.run_id,
+            mode=self.mode,
+            connector_short_name=self.connector_short_name,
+            argo_package_name=self.argo_package_name,
+            argo_template_name=self.argo_template_name,
+            app_service_url=self.app_service_url,
+            connection=self.connection_spec(),
+            database=self.database_spec(),
+            include_filter=self.include_filter,
+            exclude_filter=self.exclude_filter,
+            agent=self.agent_spec(),
+        )
+
+        logger.info(
+            "Submitting AE workflow: connector=%s mode=%s qn=%s",
+            self.connector_short_name,
+            self.mode.value,
+            self.connection_qualified_name,
+        )
+        run_id = self.client.submit_workflow(payload)
+        logger.info("AE submit returned run_id=%s", run_id)
+
+        ae_result = self.client.poll_native_status(
+            run_id,
+            interval_seconds=self.ae_poll_interval_seconds,
+            timeout_seconds=self.ae_poll_timeout_seconds,
+        )
+
+        # Only bother probing Atlas if the publish node succeeded —
+        # otherwise we waste 25 min waiting for an asset that won't land.
+        publish_succeeded = any(
+            n.name in {"publish", "publish-stage"} and n.status.is_success
+            for n in ae_result.nodes
+        )
+        if publish_succeeded:
+            connection_in_atlas = self.client.poll_atlas_for_connection(
+                self.connection_qualified_name,
+                interval_seconds=self.atlas_poll_interval_seconds,
+                timeout_seconds=self.atlas_poll_timeout_seconds,
+            )
+        else:
+            logger.warning(
+                "Publish node did not succeed — skipping Atlas probe to save time"
+            )
+            connection_in_atlas = False
+
+        return FullDAGOutcome(
+            ae_result=ae_result,
+            connection_qualified_name=self.connection_qualified_name,
+            connection_in_atlas=connection_in_atlas,
+        )
+
+    # ------------------------------------------------------------------
+    # Default test method
+    # ------------------------------------------------------------------
+
+    def test_full_dag_runs_end_to_end(self) -> None:
+        """Default pytest method — submit, run, assert success.
+
+        Subclasses can override with their own assertions (entity-count
+        thresholds, duration budgets, etc.) — call :meth:`run_full_dag`
+        and inspect the returned :class:`FullDAGOutcome`.
+        """
+        outcome = self.run_full_dag()
+        if not outcome.succeeded:
+            failed = outcome.ae_result.failed_nodes
+            failures_msg = (
+                "\n".join(
+                    f"  - {n.name}: status={n.status.value} error={n.error_message}"
+                    for n in failed
+                )
+                if failed
+                else "  (all DAG nodes succeeded; Connection just didn't land in Atlas)"
+            )
+            raise AssertionError(
+                f"Full-DAG e2e failed for connector={self.connector_short_name}\n"
+                f"AE run_id={outcome.ae_result.run_id} "
+                f"slug={outcome.ae_result.workflow_slug}\n"
+                f"AE status={outcome.ae_result.status.value}\n"
+                f"Connection in Atlas? {outcome.connection_in_atlas}\n"
+                f"Failed nodes:\n{failures_msg}"
+            )

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -293,13 +293,16 @@ class BaseFullDAGE2ETest:
         logger.info("Created (or reused) AE workflow: name=%s slug=%s", name, slug)
 
         # Derive the extract task_queue from agent_name (tier-4) or
-        # the connector's default tenant queue (tier-5). The seed DAG
-        # is a placeholder — package-workflows replaces it with the
-        # real submit args on every run — so what we plug in here
-        # mostly just needs to be valid syntax + correct queue routing.
+        # the connector's default tenant queue (tier-5). The Argo
+        # cluster template builds queue = `atlan-{agent-name}` (the
+        # agent-name itself is expected to carry the connector
+        # prefix, e.g. `mysql-ci-<run_id>` → `atlan-mysql-ci-<run_id>`)
+        # — confirmed against the devex sample (agent-name `mysql-dev`
+        # → task_queue `atlan-mysql-dev`). Callers' agent_spec() must
+        # produce a name that already includes the connector prefix.
         agent = self.agent_spec()
         if agent is not None:
-            extract_queue = f"atlan-{self.connector_short_name}-{agent.agent_name}"
+            extract_queue = f"atlan-{agent.agent_name}"
         else:
             extract_queue = f"atlan-{self.connector_short_name}-default"
 

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -133,7 +133,11 @@ class BaseFullDAGE2ETest:
     app_service_url: ClassVar[str] = ""
 
     # --- optional class attrs ------------------------------------------
-    connection_name_prefix: ClassVar[str] = "full-dag-e2e"
+    # Per-run identifier prefix. Every name the harness builds
+    # (Connection QN, AE workflow, credential, agent) embeds this
+    # prefix + run_id so cross-system traceability is one grep.
+    # Default fits tier-4 e2e-sdr-full; tier-5 e2e-full overrides.
+    connection_name_prefix: ClassVar[str] = "e2e-full-ci"
     include_filter: ClassVar[str] = '{"^def$":[".*"]}'
     exclude_filter: ClassVar[str] = "{}"
     connection_admin_users: ClassVar[tuple[str, ...]] = ()
@@ -148,11 +152,13 @@ class BaseFullDAGE2ETest:
     ae_workflow_slug: ClassVar[str] = ""
 
     # Workflow name passed to `POST /automation/api/v1/workflows`.
-    # Defaults to the connector short name; AE treats name as the
-    # idempotency key — re-running this test does not create a new
-    # workflow, only a new VERSION + a new RUN. Override to
-    # ``"{connector}-ci-tier-4"`` etc. if you want CI runs to live
-    # under a dedicated test workflow separate from production.
+    # When empty, the harness builds a unique-per-run name as
+    # ``{connector}-{connection_name_prefix}-{run_id}`` so every CI run
+    # creates its own workflow + leaves a clearly-labeled trace in AE
+    # rather than reusing a static name (the latter would also work via
+    # AE's name-idempotency, but obscures which run produced which
+    # version on inspection). Override to a static string if you want
+    # a single shared CI workflow.
     ae_workflow_name_override: ClassVar[str] = ""
 
     # Task queues for the system-app nodes in the seed DAG. Defaults
@@ -285,7 +291,10 @@ class BaseFullDAGE2ETest:
             )
             return self.ae_workflow_slug
 
-        name = self.ae_workflow_name_override or self.connector_short_name
+        name = (
+            self.ae_workflow_name_override
+            or f"{self.connector_short_name}-{self.connection_name_prefix}-{self.run_id}"
+        )
         slug = self.client.create_workflow(
             name=name,
             description=f"Full-DAG e2e harness — {self.connector_short_name}",

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -315,6 +315,9 @@ class BaseFullDAGE2ETest:
             connection=self.connection_spec(),
             qi_parsing_mode=self.qi_parsing_mode,
             extract_workflow_type=self.extract_workflow_type or None,
+            mode=self.mode,
+            agent=agent,
+            database=self.database_spec(),
         )
         version = self.client.create_version(
             slug,

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -327,6 +327,16 @@ class BaseFullDAGE2ETest:
             qi_task_queue=self.qi_task_queue,
             lineage_task_queue=self.lineage_task_queue,
             connection=self.connection_spec(),
+            # The seed is the source of truth for the run's actual
+            # extract_args (submit=true only fills `{{credentialGuid}}`,
+            # not filters) — pass the subclass-configured filters
+            # through so the connector actually receives them at run
+            # time. Mismatch here was the cause of a prior tier-4 run
+            # where extract returned 0 entities, propagating an empty
+            # connection_qualified_name into publish and ultimately
+            # making AE raise ApplicationError.
+            include_filter=self.include_filter,
+            exclude_filter=self.exclude_filter,
             qi_parsing_mode=self.qi_parsing_mode,
             extract_workflow_type=self.extract_workflow_type or None,
             mode=self.mode,

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -51,7 +51,7 @@ from __future__ import annotations
 
 import os
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar
 
 from application_sdk.observability.logger_adaptor import get_logger
@@ -75,11 +75,28 @@ class FullDAGOutcome:
     Returned by :meth:`BaseFullDAGE2ETest.run_full_dag` so subclasses
     can build their own assertions on top — e.g. "extract took less
     than X seconds", "all four entity types extracted", etc.
+
+    Attributes:
+        ae_result: Native-status snapshot from AE for the run.
+        connection_qualified_name: QN of the Connection the seed
+            DAG would have materialised on success.
+        connection_in_atlas: True iff GET /api/meta/entity/
+            uniqueAttribute/type/Connection?attr:qualifiedName=...
+            returned 200 before the harness gave up.
+        asset_counts: Per-typeName counts of descendant assets under
+            the Connection QN (Database, Schema, Table, View, Column
+            by default). Empty when the Connection probe didn't
+            succeed.
+        lineage_present: True iff at least one Process / ColumnProcess
+            asset exists under the Connection QN. Empty (False) when
+            the Connection probe didn't succeed.
     """
 
     ae_result: DAGRunResult
     connection_qualified_name: str
     connection_in_atlas: bool
+    asset_counts: dict[str, int] = field(default_factory=dict)
+    lineage_present: bool = False
 
     @property
     def succeeded(self) -> bool:
@@ -182,6 +199,22 @@ class BaseFullDAGE2ETest:
     ae_poll_timeout_seconds: ClassVar[int] = 600
     atlas_poll_interval_seconds: ClassVar[int] = 30
     atlas_poll_timeout_seconds: ClassVar[int] = 1500
+
+    # Per-typeName minimums for the inventory assertion the default
+    # test runs after Connection lands. Keys must be valid Atlas
+    # typeNames; values are inclusive lower bounds. Override per
+    # connector to encode the hermetic seed dataset's shape — e.g.
+    # mysql's seed.sql under include_filter `e2e_main` produces
+    # at least: Database=1 (e2e_main), Schema=1, Table=2 (customers
+    # + orders), View=1 (v_customer_order_totals), Column=11.
+    expected_min_asset_counts: ClassVar[dict[str, int]] = {}
+
+    # When True, the default test asserts that at least one Process /
+    # ColumnProcess exists under the Connection — i.e. QI + lineage-
+    # app + lineage-publish actually flowed lineage to Atlas, not just
+    # reported success at the DAG level. Set False for connectors whose
+    # seed dataset has no view definitions to drive lineage from.
+    expect_lineage: ClassVar[bool] = True
 
     # ------------------------------------------------------------------
     # Setup
@@ -402,12 +435,32 @@ class BaseFullDAGE2ETest:
         # asset that was never fully materialised wastes CI minutes and
         # buries the real failure under a timeout. Fail fast instead so
         # the assertion message names the failed node.
+        asset_counts: dict[str, int] = {}
+        lineage_present = False
         if ae_result.all_nodes_succeeded:
             connection_in_atlas = self.client.poll_atlas_for_connection(
                 self.connection_qualified_name,
                 interval_seconds=self.atlas_poll_interval_seconds,
                 timeout_seconds=self.atlas_poll_timeout_seconds,
             )
+            if connection_in_atlas:
+                # Connection envelope landed — now confirm descendant
+                # assets and lineage actually flowed through, not just
+                # the empty-connection placeholder. Skipping these
+                # would let an extract that returned zero entities pass
+                # the e2e (Connection lands either way).
+                asset_counts = self.client.count_assets_under_connection(
+                    self.connection_qualified_name
+                )
+                lineage_present = self.client.has_lineage_under_connection(
+                    self.connection_qualified_name
+                )
+                logger.info(
+                    "Atlas inventory under %s: %s lineage_present=%s",
+                    self.connection_qualified_name,
+                    asset_counts,
+                    lineage_present,
+                )
         else:
             failed_names = ", ".join(n.name for n in ae_result.failed_nodes) or "(none)"
             logger.warning(
@@ -422,6 +475,8 @@ class BaseFullDAGE2ETest:
             ae_result=ae_result,
             connection_qualified_name=self.connection_qualified_name,
             connection_in_atlas=connection_in_atlas,
+            asset_counts=asset_counts,
+            lineage_present=lineage_present,
         )
 
     # ------------------------------------------------------------------
@@ -431,9 +486,19 @@ class BaseFullDAGE2ETest:
     def test_full_dag_runs_end_to_end(self) -> None:
         """Default pytest method — submit, run, assert success.
 
-        Subclasses can override with their own assertions (entity-count
-        thresholds, duration budgets, etc.) — call :meth:`run_full_dag`
-        and inspect the returned :class:`FullDAGOutcome`.
+        Asserts (in order, so the first true failure gets the focus):
+          1. Every DAG node succeeded.
+          2. The Connection asset exists in Atlas.
+          3. Per-type asset counts under the Connection meet the
+             subclass-configured ``expected_min_asset_counts`` floor
+             (skipped if that dict is empty — back-compat for
+             connectors that haven't characterised their seed yet).
+          4. At least one Process/ColumnProcess exists under the
+             Connection (skipped when ``expect_lineage`` is False).
+
+        Subclasses can override entirely with their own assertions
+        (duration budgets, per-entity name checks, etc.) — call
+        :meth:`run_full_dag` and inspect the :class:`FullDAGOutcome`.
         """
         outcome = self.run_full_dag()
         if not outcome.succeeded:
@@ -453,4 +518,31 @@ class BaseFullDAGE2ETest:
                 f"AE status={outcome.ae_result.status.value}\n"
                 f"Connection in Atlas? {outcome.connection_in_atlas}\n"
                 f"Failed nodes:\n{failures_msg}"
+            )
+
+        # --- post-success assertions ---------------------------------
+        # Connection landed — now check the descendants did too. A
+        # silently empty Connection (zero tables, no lineage) is an
+        # easy regression to miss with a Connection-only assertion.
+        if self.expected_min_asset_counts:
+            shortfalls = [
+                f"  - {tn}: got {outcome.asset_counts.get(tn, 0)}, expected >= {floor}"
+                for tn, floor in self.expected_min_asset_counts.items()
+                if outcome.asset_counts.get(tn, 0) < floor
+            ]
+            if shortfalls:
+                raise AssertionError(
+                    "Atlas inventory under "
+                    f"{outcome.connection_qualified_name} below thresholds:\n"
+                    + "\n".join(shortfalls)
+                    + f"\nFull counts: {outcome.asset_counts}"
+                )
+
+        if self.expect_lineage and not outcome.lineage_present:
+            raise AssertionError(
+                "No lineage Process/ColumnProcess assets found under "
+                f"{outcome.connection_qualified_name}. The DAG's qi + "
+                "lineage-app + lineage-publish nodes reported success but "
+                "no lineage rows reached Atlas — likely an issue with "
+                "view parsing or the lineage-publish output prefix."
             )

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -178,24 +178,43 @@ class BaseFullDAGE2ETest:
     # a single shared CI workflow.
     ae_workflow_name_override: ClassVar[str] = ""
 
-    # Task queues for the system-app nodes in the seed DAG. Defaults
-    # fit devex / prod-style tenants where publish/qi/lineage all
-    # listen on the ``-production`` queues. Override for tenants that
-    # name queues differently per deployment.
+    # Path to the connector's manifest.json — the canonical source for
+    # the system-app DAG shape (per-node args, depends_on, task queue
+    # templates). The harness loads this file at bootstrap time and
+    # uses it directly as the seed DAG (with placeholder substitution
+    # for ``{app_name}`` and ``{deployment_name}``). This keeps the
+    # test in lockstep with whatever the connector ships — when the
+    # connector adds a new arg or flag to a node, the e2e test picks
+    # it up automatically. No more hand-maintained duplicate.
+    #
+    # Path is resolved relative to the pytest cwd (typically the
+    # connector repo root). Set to ``""`` to fall back to the legacy
+    # hand-crafted seed produced by :func:`build_seed_dag` — useful
+    # for connectors that don't ship a manifest yet.
+    manifest_path: ClassVar[str] = "app/generated/manifest.json"
+
+    # Tenant-side ``{deployment_name}`` value substituted into the
+    # task queues of the qi / publish / lineage / lineage-publish
+    # nodes (everything that's NOT the extract worker). Defaults to
+    # ``production`` because the devex tenant's system apps listen on
+    # ``atlan-publish-production`` etc. Override for tenants that use
+    # a different deployment name.
+    tenant_deployment_name: ClassVar[str] = "production"
+
+    # Override when the connector's worker registers a non-default
+    # workflow name. Default = connector_short_name (v3 convention,
+    # what mysql uses). Set to e.g. ``"mssql-metadata-extractor"`` for
+    # v2-style connectors. Empty string means "use the SDK default".
+    extract_workflow_type: ClassVar[str] = ""
+
+    # The class attributes below only apply when ``manifest_path`` is
+    # unset (i.e. the legacy hand-crafted seed DAG path). With a real
+    # manifest in play these are ignored — the manifest carries the
+    # canonical values.
     publish_task_queue: ClassVar[str] = "atlan-publish-production"
     qi_task_queue: ClassVar[str] = "atlan-query-intelligence-production"
     lineage_task_queue: ClassVar[str] = "atlan-lineage-production"
-    # mssql ships ``lorien-only`` view-lineage parsing; mysql (per
-    # devex sample) uses ``competitive``. Subclasses override to match
-    # their manifest.json.
     qi_parsing_mode: ClassVar[str] = "competitive"
-    # JSONPath field that QI reads view rows from, resolved against
-    # the extract activity's outputs. mssql-style connectors emit a
-    # dedicated ``view_data_prefix`` subfolder; v3 connectors that
-    # bundle views into the main transformed output (e.g. mysql) must
-    # override to ``transformed_data_prefix``. Leaving this mismatched
-    # makes AE fail QI with ``Jsonpath '$.extract.outputs.X' did not
-    # match any value`` before extract assets ever reach Atlas.
     qi_input_prefix_field: ClassVar[str] = "view_data_prefix"
     # Override when the connector's worker registers a non-default
     # workflow name. Default = connector_short_name (v3 convention,
@@ -308,6 +327,91 @@ class BaseFullDAGE2ETest:
         )
 
     # ------------------------------------------------------------------
+    # Seed DAG — loaded from the connector's manifest.json
+    # ------------------------------------------------------------------
+
+    def _seed_dag_from_manifest(self, extract_task_queue: str) -> dict:
+        """Load the connector's manifest.json and use it as the seed DAG.
+
+        Reads ``self.manifest_path`` (relative to the test's cwd —
+        typically the connector repo root), parses out the ``dag``
+        block, and substitutes the two curly-brace placeholders the
+        configurator normally fills:
+
+          * ``{app_name}`` → :attr:`connector_short_name`
+          * ``{deployment_name}`` →
+            - in ``extract.inputs.task_queue``: the agent / CI worker
+              identity (``atlan-{agent_name}`` style queue derived from
+              :meth:`agent_spec`).
+            - elsewhere (qi / publish / lineage / lineage-publish):
+              :attr:`tenant_deployment_name` (default ``production``).
+
+        Mustache placeholders (``{{credentialGuid}}``, ``{{connection}}``,
+        ``{{include-filter}}``, etc.) are left in place — AE substitutes
+        them at submit time from the matching named parameters in the
+        submit payload.
+
+        Raises:
+            RuntimeError: If ``manifest_path`` can't be read or doesn't
+                contain a top-level ``dag`` object.
+        """
+        import json  # noqa: PLC0415 — cold path: only at bootstrap
+        from pathlib import Path  # noqa: PLC0415 — cold path: only at bootstrap
+
+        path = Path(self.manifest_path)
+        if not path.is_absolute():
+            path = Path.cwd() / path
+        if not path.is_file():
+            raise RuntimeError(
+                f"Manifest file not found at {path} — set `manifest_path` on "
+                "the test class to the location of the connector's "
+                "manifest.json, or set it to '' to fall back to the "
+                "hand-crafted seed DAG."
+            )
+        manifest = json.loads(path.read_text())
+        dag = manifest.get("dag")
+        if not isinstance(dag, dict) or not dag:
+            raise RuntimeError(
+                f"Manifest at {path} has no top-level `dag` object — "
+                "can't use as a seed DAG."
+            )
+
+        def _sub_queue(node_name: str, raw: str) -> str:
+            if node_name == "extract":
+                # extract goes to the agent / CI worker queue; manifest's
+                # `{deployment_name}` template is irrelevant here because
+                # CI doesn't use the tenant's deployment identity.
+                return extract_task_queue
+            return raw.replace("{deployment_name}", self.tenant_deployment_name)
+
+        # In-place substitution — manifest's dag is the seed shape we
+        # need to publish. We don't deep-copy because we're parsing a
+        # freshly loaded file each call; nothing reuses this dict.
+        for name, node in dag.items():
+            inputs = node.get("inputs")
+            if not isinstance(inputs, dict):
+                continue
+            if isinstance(inputs.get("app_name"), str):
+                inputs["app_name"] = inputs["app_name"].replace(
+                    "{app_name}", self.connector_short_name
+                )
+            if isinstance(node.get("app_name"), str):
+                node["app_name"] = node["app_name"].replace(
+                    "{app_name}", self.connector_short_name
+                )
+            tq = inputs.get("task_queue")
+            if isinstance(tq, str):
+                inputs["task_queue"] = _sub_queue(name, tq)
+
+        logger.info(
+            "Loaded seed DAG from %s (%d nodes: %s)",
+            path,
+            len(dag),
+            ", ".join(sorted(dag.keys())),
+        )
+        return dag
+
+    # ------------------------------------------------------------------
     # The actual flow
     # ------------------------------------------------------------------
 
@@ -361,30 +465,33 @@ class BaseFullDAGE2ETest:
         else:
             extract_queue = f"atlan-{self.connector_short_name}-default"
 
-        seed_dag = build_seed_dag(
-            connector_short_name=self.connector_short_name,
-            extract_task_queue=extract_queue,
-            publish_task_queue=self.publish_task_queue,
-            qi_task_queue=self.qi_task_queue,
-            lineage_task_queue=self.lineage_task_queue,
-            connection=self.connection_spec(),
-            # The seed is the source of truth for the run's actual
-            # extract_args (submit=true only fills `{{credentialGuid}}`,
-            # not filters) — pass the subclass-configured filters
-            # through so the connector actually receives them at run
-            # time. Mismatch here was the cause of a prior tier-4 run
-            # where extract returned 0 entities, propagating an empty
-            # connection_qualified_name into publish and ultimately
-            # making AE raise ApplicationError.
-            include_filter=self.include_filter,
-            exclude_filter=self.exclude_filter,
-            qi_parsing_mode=self.qi_parsing_mode,
-            qi_input_prefix_field=self.qi_input_prefix_field,
-            extract_workflow_type=self.extract_workflow_type or None,
-            mode=self.mode,
-            agent=agent,
-            database=self.database_spec(),
-        )
+        if self.manifest_path:
+            # DRY: load the connector's manifest.json as the seed DAG
+            # so the test stays in lockstep with whatever the connector
+            # actually ships. Falls back to the hand-crafted seed only
+            # if the manifest is missing or the caller explicitly cleared
+            # `manifest_path`.
+            seed_dag = self._seed_dag_from_manifest(extract_queue)
+        else:
+            logger.info(
+                "manifest_path empty — falling back to hand-crafted build_seed_dag"
+            )
+            seed_dag = build_seed_dag(
+                connector_short_name=self.connector_short_name,
+                extract_task_queue=extract_queue,
+                publish_task_queue=self.publish_task_queue,
+                qi_task_queue=self.qi_task_queue,
+                lineage_task_queue=self.lineage_task_queue,
+                connection=self.connection_spec(),
+                include_filter=self.include_filter,
+                exclude_filter=self.exclude_filter,
+                qi_parsing_mode=self.qi_parsing_mode,
+                qi_input_prefix_field=self.qi_input_prefix_field,
+                extract_workflow_type=self.extract_workflow_type or None,
+                mode=self.mode,
+                agent=agent,
+                database=self.database_spec(),
+            )
         version = self.client.create_version(
             slug,
             {"version": int(time.time()), "dag": seed_dag},

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -492,12 +492,8 @@ class BaseFullDAGE2ETest:
                 "key-type": agent.key_type,
                 "aws-auth-method": agent.aws_auth_method,
                 "azure-auth-method": agent.azure_auth_method,
-                "basic.username": (
-                    f"SDR_{self.connector_short_name.upper()}_USERNAME"
-                ),
-                "basic.password": (
-                    f"SDR_{self.connector_short_name.upper()}_PASSWORD"
-                ),
+                "basic.username": (f"SDR_{self.connector_short_name.upper()}_USERNAME"),
+                "basic.password": (f"SDR_{self.connector_short_name.upper()}_PASSWORD"),
             }
         else:
             agent_json = None

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -138,6 +138,19 @@ class BaseFullDAGE2ETest:
     connection_admin_users: ClassVar[tuple[str, ...]] = ()
     connection_admin_groups: ClassVar[tuple[str, ...]] = ()
     connection_admin_roles: ClassVar[tuple[str, ...]] = ()
+    # When set, the harness uses this slug verbatim instead of generating
+    # a unique-per-run one. Required when the tenant doesn't auto-create
+    # workflows on submit (every tenant we've seen — package-workflows
+    # returns HTTP 404 "Workflow with slug <X> not found. Create the
+    # workflow first." if the slug is new). Subclasses point this at a
+    # pre-existing workflow created via the UI / Heracles. The submit
+    # endpoint creates a new version each call, so different runs
+    # produce distinct Connections without colliding on the slug.
+    #
+    # Follow-up: implement AEWorkflowClient.create_workflow +
+    # publish_seed_version so the harness self-bootstraps + this knob
+    # becomes optional.
+    ae_workflow_slug: ClassVar[str] = ""
 
     ae_poll_interval_seconds: ClassVar[int] = 10
     ae_poll_timeout_seconds: ClassVar[int] = 600
@@ -254,6 +267,7 @@ class BaseFullDAGE2ETest:
             include_filter=self.include_filter,
             exclude_filter=self.exclude_filter,
             agent=self.agent_spec(),
+            ae_workflow_slug=self.ae_workflow_slug,
         )
 
         logger.info(

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -265,41 +265,30 @@ class BaseFullDAGE2ETest:
                 )
 
         tenant_url = os.environ.get("ATLAN_BASE_URL", "").rstrip("/")
-        if not tenant_url:
+        api_token = os.environ.get("ATLAN_API_KEY", "")
+        if not tenant_url or not api_token:
             raise RuntimeError(
-                "Full-DAG e2e harness requires ATLAN_BASE_URL"
+                "Full-DAG e2e harness requires ATLAN_BASE_URL + ATLAN_API_KEY. "
+                "ATLAN_API_KEY is mandatory because /automation/api/v1/* (AE "
+                "workflow management) requires the realm-admin resource_access "
+                "role that only the API-key's service account carries — "
+                "verified via direct probe: OAuth returns AE-COMMON-500-01 "
+                "while API key returns 200."
             )
 
-        # Prefer OAuth-client credentials (long-lived GH repo secrets;
-        # short-lived bearer minted at run time and refreshed by the
-        # harness) over the raw API key. The OAuth-issued service
-        # account has explicit scopes (events-app + temporal-app +
-        # default:read/write) which is enough for every AE / Atlas /
-        # search call the harness makes — and produces predictable
-        # RBAC diagnostics ('service-account-oauth-client-<id>' instead
-        # of the opaque 'service-account-apikey-<uuid>'). Falls back to
-        # the bearer API key when OAuth creds aren't in the env, so
-        # local development with ATLAN_API_KEY still works.
+        # OAuth pair is OPTIONAL and used only for pyatlan asset queries
+        # (search, role_cache) — not for the AE-management REST calls.
+        # When present, the lazily-constructed AsyncAtlanClient
+        # authenticates via OAuth client_credentials instead of bearer
+        # api_token, yielding a different (and easier-to-diagnose)
+        # service-account identity on Atlas RBAC errors. When absent,
+        # pyatlan falls back to the API-key bearer.
         oauth_client_id = os.environ.get("SDR_OAUTH_CLIENT_ID", "") or os.environ.get(
             "ATLAN_AUTH_CLIENT_ID", ""
         )
         oauth_client_secret = os.environ.get(
             "SDR_OAUTH_CLIENT_SECRET", ""
         ) or os.environ.get("ATLAN_AUTH_CLIENT_SECRET", "")
-        api_key = os.environ.get("ATLAN_API_KEY", "")
-        if oauth_client_id and oauth_client_secret:
-            api_token = self._exchange_oauth_for_token(
-                tenant_url, oauth_client_id, oauth_client_secret
-            )
-        elif api_key:
-            api_token = api_key
-            oauth_client_id = ""
-            oauth_client_secret = ""
-        else:
-            raise RuntimeError(
-                "Full-DAG e2e harness requires either SDR_OAUTH_CLIENT_ID + "
-                "SDR_OAUTH_CLIENT_SECRET (preferred) or ATLAN_API_KEY"
-            )
 
         # Prefer GH-provided run identifier (cross-correlatable with
         # workflow logs) — fall back to seconds-since-epoch.
@@ -320,48 +309,6 @@ class BaseFullDAGE2ETest:
         self.connection_display_name = (
             f"{self.connection_name_prefix}-{self.connector_short_name}-{self.run_id}"
         )
-
-    @staticmethod
-    def _exchange_oauth_for_token(
-        tenant_url: str, client_id: str, client_secret: str
-    ) -> str:
-        """Trade an OAuth client_credentials pair for a bearer access token.
-
-        Used at ``setup_method`` time to mint a short-lived bearer the
-        AE REST client can use directly. The token typically lasts
-        15 min — enough to cover an entire e2e run end-to-end (5-15 min
-        wall-time). For runs that exceed the TTL, the AE-side calls
-        will start returning 401; that's a signal to refresh, but we
-        haven't seen it in practice.
-        """
-        import urllib.parse  # noqa: PLC0415 — cold path: only at setup
-        import urllib.request  # noqa: PLC0415 — cold path: only at setup
-        from json import loads  # noqa: PLC0415 — cold path: only at setup
-
-        body = urllib.parse.urlencode(
-            {
-                "grant_type": "client_credentials",
-                "client_id": client_id,
-                "client_secret": client_secret,
-            }
-        ).encode()
-        req = urllib.request.Request(
-            f"{tenant_url}/auth/realms/default/protocol/openid-connect/token",
-            data=body,
-            headers={
-                "Content-Type": "application/x-www-form-urlencoded",
-                "User-Agent": "atlan-sdk-full-dag-e2e/1.0",
-            },
-        )
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            payload = loads(resp.read())
-        token = payload.get("access_token")
-        if not isinstance(token, str) or not token:
-            raise RuntimeError(
-                "OAuth token exchange returned no access_token "
-                f"(keys: {list(payload.keys())})"
-            )
-        return token
 
     # ------------------------------------------------------------------
     # Subclass hooks — override these

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -395,21 +395,26 @@ class BaseFullDAGE2ETest:
             timeout_seconds=self.ae_poll_timeout_seconds,
         )
 
-        # Only bother probing Atlas if the publish node succeeded —
-        # otherwise we waste 25 min waiting for an asset that won't land.
-        publish_succeeded = any(
-            n.name in {"publish", "publish-stage"} and n.status.is_success
-            for n in ae_result.nodes
-        )
-        if publish_succeeded:
+        # Only probe Atlas if every DAG node succeeded — extract feeds
+        # publish, qi feeds lineage-app, lineage-app feeds lineage-
+        # publish, so a partial-success DAG produces a partial-success
+        # Connection (or no Connection at all). Polling 25 min for an
+        # asset that was never fully materialised wastes CI minutes and
+        # buries the real failure under a timeout. Fail fast instead so
+        # the assertion message names the failed node.
+        if ae_result.all_nodes_succeeded:
             connection_in_atlas = self.client.poll_atlas_for_connection(
                 self.connection_qualified_name,
                 interval_seconds=self.atlas_poll_interval_seconds,
                 timeout_seconds=self.atlas_poll_timeout_seconds,
             )
         else:
+            failed_names = ", ".join(n.name for n in ae_result.failed_nodes) or "(none)"
             logger.warning(
-                "Publish node did not succeed — skipping Atlas probe to save time"
+                "Skipping Atlas probe — %d/%d DAG nodes did not succeed (failed: %s)",
+                len(ae_result.failed_nodes),
+                len(ae_result.nodes),
+                failed_names,
             )
             connection_in_atlas = False
 

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -677,13 +677,22 @@ class BaseFullDAGE2ETest:
                 asset_counts = self.client.count_assets_under_connection(
                     self.connection_qualified_name
                 )
-                lineage_present = self.client.has_lineage_under_connection(
+                lineage_counts = self.client.count_lineage_under_connection(
                     self.connection_qualified_name
                 )
+                lineage_present = any(c > 0 for c in lineage_counts.values())
+                # Two separate log lines so the CI PR-comment parser can
+                # surface them as distinct sections ("Assets in Atlas" /
+                # "Lineage") matching the Atlan workflow-center UI.
                 logger.info(
-                    "Atlas inventory under %s: %s lineage_present=%s",
+                    "Atlas inventory under %s: %s",
                     self.connection_qualified_name,
                     asset_counts,
+                )
+                logger.info(
+                    "Lineage inventory under %s: %s lineage_present=%s",
+                    self.connection_qualified_name,
+                    lineage_counts,
                     lineage_present,
                 )
         else:

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -189,6 +189,14 @@ class BaseFullDAGE2ETest:
     # devex sample) uses ``competitive``. Subclasses override to match
     # their manifest.json.
     qi_parsing_mode: ClassVar[str] = "competitive"
+    # JSONPath field that QI reads view rows from, resolved against
+    # the extract activity's outputs. mssql-style connectors emit a
+    # dedicated ``view_data_prefix`` subfolder; v3 connectors that
+    # bundle views into the main transformed output (e.g. mysql) must
+    # override to ``transformed_data_prefix``. Leaving this mismatched
+    # makes AE fail QI with ``Jsonpath '$.extract.outputs.X' did not
+    # match any value`` before extract assets ever reach Atlas.
+    qi_input_prefix_field: ClassVar[str] = "view_data_prefix"
     # Override when the connector's worker registers a non-default
     # workflow name. Default = connector_short_name (v3 convention,
     # what mysql uses). Set to e.g. ``"mssql-metadata-extractor"`` for
@@ -371,6 +379,7 @@ class BaseFullDAGE2ETest:
             include_filter=self.include_filter,
             exclude_filter=self.exclude_filter,
             qi_parsing_mode=self.qi_parsing_mode,
+            qi_input_prefix_field=self.qi_input_prefix_field,
             extract_workflow_type=self.extract_workflow_type or None,
             mode=self.mode,
             agent=agent,

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -62,6 +62,7 @@ from application_sdk.testing.full_dag.payload import (
     DatabaseSpec,
     RunMode,
     build_ae_payload,
+    build_seed_dag,
 )
 
 logger = get_logger(__name__)
@@ -138,19 +139,33 @@ class BaseFullDAGE2ETest:
     connection_admin_users: ClassVar[tuple[str, ...]] = ()
     connection_admin_groups: ClassVar[tuple[str, ...]] = ()
     connection_admin_roles: ClassVar[tuple[str, ...]] = ()
-    # When set, the harness uses this slug verbatim instead of generating
-    # a unique-per-run one. Required when the tenant doesn't auto-create
-    # workflows on submit (every tenant we've seen — package-workflows
-    # returns HTTP 404 "Workflow with slug <X> not found. Create the
-    # workflow first." if the slug is new). Subclasses point this at a
-    # pre-existing workflow created via the UI / Heracles. The submit
-    # endpoint creates a new version each call, so different runs
-    # produce distinct Connections without colliding on the slug.
-    #
-    # Follow-up: implement AEWorkflowClient.create_workflow +
-    # publish_seed_version so the harness self-bootstraps + this knob
-    # becomes optional.
+    # When set, the harness uses this slug verbatim and skips the
+    # create-workflow / publish-seed-version bootstrap. Useful if the
+    # caller has pre-created the workflow via UI / Heracles (matches
+    # the tier-5 pattern where the production-deployed pod registered
+    # the workflow once on first install). Default empty → harness
+    # auto-creates on every run, idempotent on workflow name.
     ae_workflow_slug: ClassVar[str] = ""
+
+    # Workflow name passed to `POST /automation/api/v1/workflows`.
+    # Defaults to the connector short name; AE treats name as the
+    # idempotency key — re-running this test does not create a new
+    # workflow, only a new VERSION + a new RUN. Override to
+    # ``"{connector}-ci-tier-4"`` etc. if you want CI runs to live
+    # under a dedicated test workflow separate from production.
+    ae_workflow_name_override: ClassVar[str] = ""
+
+    # Task queues for the system-app nodes in the seed DAG. Defaults
+    # fit devex / prod-style tenants where publish/qi/lineage all
+    # listen on the ``-production`` queues. Override for tenants that
+    # name queues differently per deployment.
+    publish_task_queue: ClassVar[str] = "atlan-publish-production"
+    qi_task_queue: ClassVar[str] = "atlan-query-intelligence-production"
+    lineage_task_queue: ClassVar[str] = "atlan-lineage-production"
+    # mssql ships ``lorien-only`` view-lineage parsing; mysql (per
+    # devex sample) uses ``competitive``. Subclasses override to match
+    # their manifest.json.
+    qi_parsing_mode: ClassVar[str] = "competitive"
 
     ae_poll_interval_seconds: ClassVar[int] = 10
     ae_poll_timeout_seconds: ClassVar[int] = 600
@@ -244,6 +259,63 @@ class BaseFullDAGE2ETest:
     # The actual flow
     # ------------------------------------------------------------------
 
+    def _bootstrap_workflow(self) -> str:
+        """Ensure an AE workflow exists with a published version.
+
+        Returns the slug to use for the subsequent submit. If
+        ``ae_workflow_slug`` is set on the subclass, returns it
+        verbatim (caller has pre-bootstrapped). Otherwise:
+
+          1. Create the workflow (idempotent on name).
+          2. Publish a seed version with the full 5-node DAG.
+
+        Without a published version, ``POST /api/service/package-
+        workflows?submit=true`` returns HTTP 404 ("Workflow with slug
+        'X' not found. Create the workflow first.").
+        """
+        if self.ae_workflow_slug:
+            logger.info(
+                "Using pre-existing AE workflow slug: %s",
+                self.ae_workflow_slug,
+            )
+            return self.ae_workflow_slug
+
+        name = self.ae_workflow_name_override or self.connector_short_name
+        slug = self.client.create_workflow(
+            name=name,
+            description=f"Full-DAG e2e harness — {self.connector_short_name}",
+        )
+        logger.info("Created (or reused) AE workflow: name=%s slug=%s", name, slug)
+
+        # Derive the extract task_queue from agent_name (tier-4) or
+        # the connector's default tenant queue (tier-5). The seed DAG
+        # is a placeholder — package-workflows replaces it with the
+        # real submit args on every run — so what we plug in here
+        # mostly just needs to be valid syntax + correct queue routing.
+        agent = self.agent_spec()
+        if agent is not None:
+            extract_queue = f"atlan-{self.connector_short_name}-{agent.agent_name}"
+        else:
+            extract_queue = f"atlan-{self.connector_short_name}-default"
+
+        seed_dag = build_seed_dag(
+            connector_short_name=self.connector_short_name,
+            extract_task_queue=extract_queue,
+            publish_task_queue=self.publish_task_queue,
+            qi_task_queue=self.qi_task_queue,
+            lineage_task_queue=self.lineage_task_queue,
+            connection=self.connection_spec(),
+            qi_parsing_mode=self.qi_parsing_mode,
+        )
+        version = self.client.create_version(
+            slug,
+            {"version": int(time.time()), "dag": seed_dag},
+        )
+        logger.info("Created seed version %d under slug %s", version, slug)
+
+        self.client.publish_version(slug, version)
+        return slug
+
     def run_full_dag(self) -> FullDAGOutcome:
         """Submit, poll AE, poll Atlas, return the combined outcome.
 
@@ -255,6 +327,8 @@ class BaseFullDAGE2ETest:
         Returns:
             FullDAGOutcome describing AE node status + Atlas presence.
         """
+        slug = self._bootstrap_workflow()
+
         payload = build_ae_payload(
             run_id=self.run_id,
             mode=self.mode,
@@ -267,7 +341,7 @@ class BaseFullDAGE2ETest:
             include_filter=self.include_filter,
             exclude_filter=self.exclude_filter,
             agent=self.agent_spec(),
-            ae_workflow_slug=self.ae_workflow_slug,
+            ae_workflow_slug=slug,
         )
 
         logger.info(

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -300,6 +300,11 @@ class BaseFullDAGE2ETest:
             description=f"Full-DAG e2e harness — {self.connector_short_name}",
         )
         logger.info("Created (or reused) AE workflow: name=%s slug=%s", name, slug)
+        # AE has a brief indexing window before the slug is queryable
+        # by /versions — sleep 3s here so the first create_version
+        # attempt usually succeeds. create_version also retries on
+        # 404, so this is belt-and-suspenders for cheap-and-fast.
+        time.sleep(3)
 
         # Derive the extract task_queue from agent_name (tier-4) or
         # the connector's default tenant queue (tier-5). The Argo

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -756,25 +756,41 @@ class AEWorkflowClient:
         results = asyncio.run(self._search_counts_async(prefix, type_names))
         return dict(zip(type_names, results))
 
-    def has_lineage_under_connection(self, connection_qualified_name: str) -> bool:
-        """True iff at least one lineage Process exists under this connection.
+    def count_lineage_under_connection(
+        self,
+        connection_qualified_name: str,
+        *,
+        type_names: tuple[str, ...] = ("Database", "Schema", "Table", "View", "Column"),
+    ) -> dict[str, int]:
+        """Per-typeName count of entity assets with lineage attached.
 
-        QI + lineage-app + lineage-publish together produce ``Process``
-        and ``ColumnProcess`` assets whose ``qualifiedName`` is anchored
-        under the Connection. Tells us lineage actually flowed through
-        to Atlas — not just that the lineage nodes returned success at
-        the DAG level.
+        Matches the "Lineage coverage" card in the Atlan workflow-center
+        UI — counts entity assets (Database/Schema/Table/View/Column)
+        whose ``__hasLineage`` is true under the Connection prefix.
+        That's "how many of my assets did QI + lineage-app actually wire
+        up", not "how many Process/ColumnProcess edges exist". The two
+        signals are correlated but the asset-coverage view is what the
+        product surfaces to reviewers, so the PR comment renders it
+        verbatim.
+
+        Returns ``{typeName: count}`` including zeros so missing
+        coverage at a level (e.g. no lineage on Schemas) is visible
+        rather than hidden.
         """
+        if not type_names:
+            return {}
         prefix = f"{connection_qualified_name}/"
-        counts = asyncio.run(
-            self._search_counts_async(prefix, ("Process", "ColumnProcess"))
+        results = asyncio.run(
+            self._search_counts_async(prefix, type_names, has_lineage_only=True)
         )
-        return any(c > 0 for c in counts)
+        return dict(zip(type_names, results))
 
     async def _search_counts_async(
         self,
         prefix: str,
         type_names: tuple[str, ...],
+        *,
+        has_lineage_only: bool = False,
     ) -> list[int]:
         """Parallel per-type ``count`` searches via pyatlan AsyncAtlanClient.
 
@@ -782,6 +798,10 @@ class AEWorkflowClient:
         gathered searches — much cheaper than firing one sync HTTPS
         call per type, and the standard pyatlan pattern for batched
         reads.
+
+        When ``has_lineage_only`` is set, the per-type query also
+        filters ``HAS_LINEAGE.eq(True)`` so the count matches the
+        Atlan UI's "Lineage coverage" card.
         """
         from pyatlan.client.aio.client import AsyncAtlanClient  # noqa: PLC0415
         from pyatlan.model.assets import Asset  # noqa: PLC0415
@@ -789,11 +809,14 @@ class AEWorkflowClient:
 
         async def _count_one(client: AsyncAtlanClient, type_name: str) -> int:
             try:
-                request = (
+                builder = (
                     FluentSearch()
                     .where(Asset.QUALIFIED_NAME.startswith(prefix))
                     .where(Asset.TYPE_NAME.eq(type_name))
-                ).to_request()
+                )
+                if has_lineage_only:
+                    builder = builder.where(Asset.HAS_LINEAGE.eq(True))
+                request = builder.to_request()
                 request.dsl.size = 0  # cheap response: we only want .count
                 return int((await client.asset.search(request)).count)
             except Exception:

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -228,9 +228,7 @@ class AEWorkflowClient:
         data = body.get("data") if isinstance(body.get("data"), dict) else body
         slug = data.get("slug") if isinstance(data, dict) else None
         if not slug:
-            raise RuntimeError(
-                f"create_workflow returned no slug\nresponse={body!r}"
-            )
+            raise RuntimeError(f"create_workflow returned no slug\nresponse={body!r}")
         return str(slug)
 
     def create_version(self, slug: str, version_payload: dict[str, Any]) -> int:
@@ -257,9 +255,7 @@ class AEWorkflowClient:
         data = body.get("data") if isinstance(body.get("data"), dict) else body
         version = data.get("version") if isinstance(data, dict) else None
         if version is None:
-            raise RuntimeError(
-                f"create_version returned no version\nresponse={body!r}"
-            )
+            raise RuntimeError(f"create_version returned no version\nresponse={body!r}")
         return int(version)
 
     def publish_version(

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -71,32 +71,37 @@ _HEARTBEAT_SECONDS = 30
 # quick visual scan of "what's done / what's running" without parsing
 # a long ``a=Succeeded; b=Running; c=Pending`` string. Used by
 # :func:`_node_glyph` (per-node) and :data:`_RUN_GLYPHS` (top-level).
+# Colour emoji rather than monochrome glyphs: GH Actions logs render
+# them inline and the colour signals status faster than the shape.
 _NODE_GLYPHS = {
-    "Succeeded": "✓",
-    "Failed": "✗",
-    "Running": "⟳",
-    "Pending": "·",
-    "Cancelled": "⊘",
-    "TimedOut": "⏱",
+    "Succeeded": "✅",
+    "Failed": "❌",
+    "Running": "🔄",
+    "Pending": "🟡",
+    "Cancelled": "🚫",
+    "TimedOut": "⏰",
 }
 _RUN_GLYPHS = {
-    "Succeeded": "✓",
-    "Failed": "✗",
-    "Running": "⟳",
-    "Pending": "·",
-    "Cancelled": "⊘",
-    "TimedOut": "⏱",
+    "Succeeded": "✅",
+    "Failed": "❌",
+    "Running": "🔄",
+    "Pending": "🟡",
+    "Cancelled": "🚫",
+    "TimedOut": "⏰",
 }
 
 
 def _node_glyph(node) -> str:
-    """Format one node as ``glyph:name`` for the poll-loop summary."""
-    g = _NODE_GLYPHS.get(node.status.value, "?")
+    """Format one node as ``glyph name`` for the poll-loop summary."""
+    g = _NODE_GLYPHS.get(node.status.value, "❔")
     # Trim long node names so the per-poll line stays scannable
     name = node.name.replace("lineage-publish", "lin-pub").replace(
         "lineage-app", "lin-app"
     )
-    return f"{g}{name}"
+    # Space between glyph and name — colour emoji renders wider than
+    # the monochrome glyphs we used before, so the previous tight
+    # "✓extract" lost legibility.
+    return f"{g} {name}"
 
 
 class DAGNodeStatus(str, Enum):

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -67,6 +67,37 @@ _HTTP_TIMEOUT = 30
 # we don't drown the log on a fast happy-path run.
 _HEARTBEAT_SECONDS = 30
 
+# Per-status glyphs for the poll-loop log line — gives the operator a
+# quick visual scan of "what's done / what's running" without parsing
+# a long ``a=Succeeded; b=Running; c=Pending`` string. Used by
+# :func:`_node_glyph` (per-node) and :data:`_RUN_GLYPHS` (top-level).
+_NODE_GLYPHS = {
+    "Succeeded": "✓",
+    "Failed": "✗",
+    "Running": "⟳",
+    "Pending": "·",
+    "Cancelled": "⊘",
+    "TimedOut": "⏱",
+}
+_RUN_GLYPHS = {
+    "Succeeded": "✓",
+    "Failed": "✗",
+    "Running": "⟳",
+    "Pending": "·",
+    "Cancelled": "⊘",
+    "TimedOut": "⏱",
+}
+
+
+def _node_glyph(node) -> str:
+    """Format one node as ``glyph:name`` for the poll-loop summary."""
+    g = _NODE_GLYPHS.get(node.status.value, "?")
+    # Trim long node names so the per-poll line stays scannable
+    name = node.name.replace("lineage-publish", "lin-pub").replace(
+        "lineage-app", "lin-app"
+    )
+    return f"{g}{name}"
+
 
 class DAGNodeStatus(str, Enum):
     """Status values returned by ``native-status`` per DAG node."""
@@ -160,13 +191,30 @@ class AEWorkflowClient:
     Args:
         tenant_url: Base URL of the tenant (e.g. ``https://devex.atlan.com``).
             Trailing slash is stripped if present.
-        api_token: Bearer token. Accepts either a long-lived API key or a
-            short-lived OAuth ``client_credentials`` access token.
+        api_token: Bearer token used for AE / Atlas REST calls. Accepts
+            either a long-lived API key or a short-lived OAuth
+            ``client_credentials`` access token.
+        oauth_client_id / oauth_client_secret: Optional OAuth client pair.
+            When supplied, the lazily-constructed pyatlan ``AtlanClient``
+            (used for asset search + role-cache lookups) authenticates via
+            OAuth ``client_credentials`` instead of the bearer api_token.
+            This yields a *different* service-account identity than the
+            API key — useful when the API key's service account isn't on
+            an asset's admin ACL but the OAuth client is.
     """
 
-    def __init__(self, tenant_url: str, api_token: str) -> None:
+    def __init__(
+        self,
+        tenant_url: str,
+        api_token: str,
+        *,
+        oauth_client_id: str | None = None,
+        oauth_client_secret: str | None = None,
+    ) -> None:
         self.tenant_url = tenant_url.rstrip("/")
         self._api_token = api_token
+        self._oauth_client_id = oauth_client_id
+        self._oauth_client_secret = oauth_client_secret
 
     # ------------------------------------------------------------------
     # Low-level HTTP
@@ -489,7 +537,8 @@ class AEWorkflowClient:
                 continue
             transient_streak = 0
             last_result = result
-            summary = "; ".join(f"{n.name}={n.status.value}" for n in result.nodes)
+            summary = " ".join(_node_glyph(n) for n in result.nodes)
+            run_glyph = _RUN_GLYPHS.get(result.status.value, "•")
             # Log on every status change. Also emit a heartbeat every
             # ``_HEARTBEAT_SECONDS`` even when the status hasn't moved,
             # so long-running stages (lineage takes 2-5 min) don't look
@@ -501,11 +550,10 @@ class AEWorkflowClient:
             )
             if should_log:
                 logger.info(
-                    "AE run %s (slug=%s) status=%s elapsed=%ds | %s",
-                    result.run_id,
-                    result.workflow_slug,
-                    result.status.value,
+                    "%s AE run [%3ds] %s — %s",
+                    run_glyph,
                     elapsed,
+                    result.status.value,
                     summary,
                 )
                 last_summary = summary
@@ -523,19 +571,66 @@ class AEWorkflowClient:
             f"native-status timed out after {timeout_seconds}s with no response"
         )
 
-    def get_connection_in_atlas(self, qualified_name: str) -> int:
-        """HEAD-style probe for a Connection asset. Returns HTTP status code.
+    def connection_exists_in_atlas_via_search(self, qualified_name: str) -> bool:
+        """Search-based Connection probe — works around the direct-fetch ACL.
 
-        200 means the Connection exists and is queryable in Atlas. 404
-        means publish hasn't flushed it yet (or the workflow failed).
-        Any other status is a real error worth surfacing.
+        Hits the indexsearch endpoint with an exact ``qualifiedName`` +
+        ``typeName=Connection`` filter. The search ACL is permissive
+        (anyone with read on the connector namespace can see results)
+        whereas the direct entity-fetch endpoint enforces the
+        Connection's ``adminUsers``/``adminRoles``. Use this when the
+        harness's identity isn't expected to be on the Connection's
+        admin list — e.g. when adminRoles is just ``$admin`` and the
+        OAuth-client service account isn't.
+
+        Returns True iff at least one Connection asset matches the QN.
+        Network errors / search failures return False (treated as
+        "not yet visible").
         """
-        status, _ = self._request(
-            "GET",
-            "/api/meta/entity/uniqueAttribute/type/Connection"
-            f"?attr:qualifiedName={qualified_name}",
+        return asyncio.run(self._connection_search_async(qualified_name))
+
+    async def _connection_search_async(self, qualified_name: str) -> bool:
+        from pyatlan.client.aio.client import AsyncAtlanClient
+        from pyatlan.model.assets import Asset
+        from pyatlan.model.fluent_search import FluentSearch
+
+        try:
+            async with self._build_async_atlan_client() as client:
+                request = (
+                    FluentSearch()
+                    .where(Asset.QUALIFIED_NAME.eq(qualified_name))
+                    .where(Asset.TYPE_NAME.eq("Connection"))
+                ).to_request()
+                request.dsl.size = 0
+                return int((await client.asset.search(request)).count) > 0
+        except Exception:
+            logger.exception(
+                "Connection search for %s failed (treating as not-yet-visible)",
+                qualified_name,
+            )
+            return False
+
+    def _build_async_atlan_client(self) -> "AsyncAtlanClient":  # noqa: F821
+        """Construct an AsyncAtlanClient using OAuth if configured, else bearer.
+
+        Centralised so every pyatlan call (search, role_cache) goes
+        through the same auth path. OAuth-client identity is preferred
+        when both are present because OAuth tokens are explicitly
+        scoped, whereas the API-key bearer often resolves to a
+        broad-permissioned service account whose name confuses RBAC
+        diagnostics.
+        """
+        from pyatlan.client.aio.client import AsyncAtlanClient
+
+        if self._oauth_client_id and self._oauth_client_secret:
+            return AsyncAtlanClient(
+                base_url=self.tenant_url,
+                oauth_client_id=self._oauth_client_id,
+                oauth_client_secret=self._oauth_client_secret,
+            )
+        return AsyncAtlanClient(
+            base_url=self.tenant_url, api_key=self._api_token
         )
-        return status
 
     def poll_atlas_for_connection(
         self,
@@ -545,79 +640,58 @@ class AEWorkflowClient:
         timeout_seconds: int = 1500,
         max_forbidden_attempts: int = 5,
         max_not_found_attempts: int = 10,
+        max_not_found_attempts_override: int | None = None,
     ) -> bool:
         """Poll Atlas until the Connection appears or timeout elapses.
 
-        Wide default budget (25 min) because publish runs after the AE
+        Uses :meth:`connection_exists_in_atlas_via_search` rather than
+        the direct entity-fetch endpoint because the search index ACL
+        is permissive — direct fetch enforces the Connection's
+        ``adminUsers``/``adminRoles`` and would 403 for identities not
+        explicitly on that list. Indirect side-effect: the
+        ``max_forbidden_attempts`` knob is now mostly vestigial since
+        search doesn't surface 403. Kept on the signature for back-
+        compat.
+
+        Wide default timeout (25 min) because publish runs after the AE
         DAG completes and can take a while to flush large connections.
         Callers with smaller datasets can tighten this.
 
-        HTTP 403 and 404 are each tracked separately from generic
-        non-200 responses, and each has its own cap on consecutive
-        occurrences:
-
-        * 403 almost always means the calling identity is not on the
-          Connection's admin ACL — polling through this won't fix it,
-          so bail after ``max_forbidden_attempts`` (default 5).
-        * 404 means publish hasn't materialised the Connection yet.
-          For real workloads that can lag a few seconds while the
-          Atlas indexer catches up; longer streaks mean the publish
-          activity reported success but the entities never actually
-          reached Atlas (proxy mis-routing, wrong storage bucket,
-          asset-server outage). Bail after
-          ``max_not_found_attempts`` (default 10 → ~100s at the
-          default 10s interval, ~5 min at the 30s default) instead of
-          silently burning the full 25 min budget.
+        ``max_not_found_attempts`` caps consecutive empty-search
+        responses (~100s at the default 10s interval, ~5 min at the
+        30s default) so the harness fails fast on a publish that
+        reports success but doesn't actually land the Connection.
         """
+        if max_not_found_attempts_override is not None:
+            max_not_found_attempts = max_not_found_attempts_override
         elapsed = 0
-        forbidden_streak = 0
         not_found_streak = 0
+        # `max_forbidden_attempts` kept on the signature for back-compat
+        # but unused now that the search path doesn't surface 403.
+        del max_forbidden_attempts
         while elapsed < timeout_seconds:
-            status = self.get_connection_in_atlas(qualified_name)
+            found = self.connection_exists_in_atlas_via_search(qualified_name)
             logger.info(
-                "Atlas Connection probe [%ds] qn=%s HTTP %d",
+                "Atlas Connection probe [%ds] qn=%s exists=%s",
                 elapsed,
                 qualified_name,
-                status,
+                found,
             )
-            if status == 200:
+            if found:
                 return True
-            if status == 403:
-                forbidden_streak += 1
-                not_found_streak = 0
-                if forbidden_streak >= max_forbidden_attempts:
-                    logger.error(
-                        "Atlas Connection probe gave HTTP 403 %d times in a row — "
-                        "stopping early. The Connection probably landed in Atlas; "
-                        "the calling identity is just not on its admin ACL. Add "
-                        "$admin (or the API key's role) to adminRoles, or add the "
-                        "service-account username to adminUsers, on the test's "
-                        "connection_spec().",
-                        forbidden_streak,
-                    )
-                    return False
-            elif status == 404:
-                not_found_streak += 1
-                forbidden_streak = 0
-                if not_found_streak >= max_not_found_attempts:
-                    logger.error(
-                        "Atlas Connection probe gave HTTP 404 %d times in a row "
-                        "(%ds elapsed) — stopping early. The Connection never "
-                        "materialised in Atlas: publish likely reported success "
-                        "but the entities did not reach the asset server. Check "
-                        "publish metrics vs the storage bucket the worker wrote "
-                        "to and the one publish reads from.",
-                        not_found_streak,
-                        elapsed,
-                    )
-                    return False
-            else:
-                forbidden_streak = 0
-                not_found_streak = 0
-            if status >= 500:
-                logger.warning(
-                    "Atlas returned %d for Connection probe; retrying", status
+            not_found_streak += 1
+            if not_found_streak >= max_not_found_attempts:
+                logger.error(
+                    "Atlas Connection probe found nothing %d times in a row "
+                    "(%ds elapsed) — stopping early. The Connection never "
+                    "materialised in Atlas: publish likely reported success "
+                    "but the entities did not reach the asset server. Check "
+                    "publish metrics vs the storage bucket the worker wrote "
+                    "to and the one publish reads from.",
+                    not_found_streak,
+                    elapsed,
                 )
+                return False
             time.sleep(interval_seconds)
             elapsed += interval_seconds
         return False

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -509,6 +509,103 @@ class AEWorkflowClient:
             elapsed += interval_seconds
         return False
 
+    def _atlan_client(self) -> "AtlanClient":  # noqa: F821
+        """Lazily construct a pyatlan AtlanClient for downstream queries.
+
+        Cached on the instance so per-call cost is one HTTP-pool
+        instantiation, not one per asset-search. The token is the same
+        bearer the AE-side calls use, so search permissions match the
+        Connection's admin ACL (which is why callers must put the API
+        key's identity on adminRoles/adminUsers, not just adminGroups).
+        """
+        from pyatlan.client.atlan import AtlanClient
+
+        if not hasattr(self, "_pyatlan"):
+            self._pyatlan = AtlanClient(
+                base_url=self.tenant_url, api_key=self._api_token
+            )
+        return self._pyatlan
+
+    def count_assets_under_connection(
+        self,
+        connection_qualified_name: str,
+        *,
+        type_names: tuple[str, ...] = ("Database", "Schema", "Table", "View", "Column"),
+    ) -> dict[str, int]:
+        """Per-typeName counts of assets under a connection's QN prefix.
+
+        Uses pyatlan's ``FluentSearch`` so we don't hand-roll Elastic
+        DSL. Returns ``{typeName: count}`` with zeros for types that
+        produced no matches. One round-trip per type — fine at the
+        single-digit number of types we query here, and clearer than
+        a single aggregations call.
+
+        Used by the harness to assert extract + publish actually landed
+        assets in Atlas, not just the Connection envelope. A Connection
+        with zero descendants is almost always a config bug (filter
+        mismatch, transform error) that the basic ``connection_in_atlas``
+        check would silently pass.
+        """
+        from pyatlan.model.assets import Asset
+        from pyatlan.model.fluent_search import FluentSearch
+
+        client = self._atlan_client()
+        prefix = f"{connection_qualified_name}/"
+        counts: dict[str, int] = {}
+        for type_name in type_names:
+            try:
+                request = (
+                    FluentSearch()
+                    .where(Asset.QUALIFIED_NAME.startswith(prefix))
+                    .where(Asset.TYPE_NAME.eq(type_name))
+                ).to_request()
+                # size=0 keeps the response cheap — we only need .count
+                request.dsl.size = 0
+                results = client.asset.search(request)
+                counts[type_name] = int(results.count)
+            except Exception:
+                logger.exception(
+                    "FluentSearch for %s under %s failed",
+                    type_name,
+                    connection_qualified_name,
+                )
+                counts[type_name] = 0
+        return counts
+
+    def has_lineage_under_connection(
+        self, connection_qualified_name: str
+    ) -> bool:
+        """True iff at least one lineage Process exists under this connection.
+
+        QI + lineage-app + lineage-publish together produce ``Process``
+        and ``ColumnProcess`` assets whose ``qualifiedName`` is anchored
+        under the Connection. Querying for any single Process row tells
+        us lineage actually flowed through to Atlas — not just that the
+        lineage nodes returned success at the DAG level.
+        """
+        from pyatlan.model.assets import Asset
+        from pyatlan.model.fluent_search import FluentSearch
+
+        client = self._atlan_client()
+        prefix = f"{connection_qualified_name}/"
+        for type_name in ("Process", "ColumnProcess"):
+            try:
+                request = (
+                    FluentSearch()
+                    .where(Asset.QUALIFIED_NAME.startswith(prefix))
+                    .where(Asset.TYPE_NAME.eq(type_name))
+                ).to_request()
+                request.dsl.size = 0
+                if int(client.asset.search(request).count) > 0:
+                    return True
+            except Exception:
+                logger.exception(
+                    "FluentSearch for %s under %s failed",
+                    type_name,
+                    connection_qualified_name,
+                )
+        return False
+
 
 # ---------------------------------------------------------------------------
 # Helpers — defensive parsing for forward-compat

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -60,6 +60,13 @@ _USER_AGENT = "atlan-sdk-full-dag-e2e/1.0 (+https://github.com/atlanhq/applicati
 # any one call from hanging the whole loop.
 _HTTP_TIMEOUT = 30
 
+# Cadence for "still polling" heartbeat log lines in
+# ``poll_native_status`` — lineage stages take 2-5 min on small
+# datasets and the status string doesn't change during that time, so
+# the loop would otherwise look wedged in CI output. Long enough that
+# we don't drown the log on a fast happy-path run.
+_HEARTBEAT_SECONDS = 30
+
 
 class DAGNodeStatus(str, Enum):
     """Status values returned by ``native-status`` per DAG node."""
@@ -458,6 +465,7 @@ class AEWorkflowClient:
         last_summary: str | None = None
         last_result: DAGRunResult | None = None
         transient_streak = 0
+        last_log_elapsed = 0  # seconds since the last info log fired
         while elapsed < timeout_seconds:
             try:
                 result = self.get_native_status(run_id)
@@ -482,15 +490,26 @@ class AEWorkflowClient:
             transient_streak = 0
             last_result = result
             summary = "; ".join(f"{n.name}={n.status.value}" for n in result.nodes)
-            if summary != last_summary:
+            # Log on every status change. Also emit a heartbeat every
+            # ``_HEARTBEAT_SECONDS`` even when the status hasn't moved,
+            # so long-running stages (lineage takes 2-5 min) don't look
+            # silent in CI logs. Without the heartbeat the operator
+            # can't distinguish "still polling" from "harness wedged".
+            should_log = (
+                summary != last_summary
+                or (elapsed - last_log_elapsed) >= _HEARTBEAT_SECONDS
+            )
+            if should_log:
                 logger.info(
-                    "AE run %s (slug=%s) status=%s | %s",
+                    "AE run %s (slug=%s) status=%s elapsed=%ds | %s",
                     result.run_id,
                     result.workflow_slug,
                     result.status.value,
+                    elapsed,
                     summary,
                 )
                 last_summary = summary
+                last_log_elapsed = elapsed
             if result.status.is_terminal:
                 return result
             time.sleep(interval_seconds)

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -437,18 +437,49 @@ class AEWorkflowClient:
         *,
         interval_seconds: int = 10,
         timeout_seconds: int = 600,
+        max_transient_failures: int = 5,
     ) -> DAGRunResult:
         """Poll until the run reaches a terminal top-level status.
 
         Logs a one-line summary per poll only when the status string
         changes (i.e. progress moments), to avoid spamming logs during
         long-running publish / lineage stages.
+
+        Tolerates transient HTTP failures from ``get_native_status``:
+        the tenant's Temporal occasionally blips during multi-minute
+        runs and AE then returns ``AE-COMMON-500-01: An unexpected
+        error occurred`` for a few seconds before recovering. We log
+        a warning and keep polling rather than failing the whole test
+        on a single bad response. After ``max_transient_failures``
+        consecutive errors we give up and re-raise — that's a
+        sustained outage, not a blip, and there's no point waiting.
         """
         elapsed = 0
         last_summary: str | None = None
         last_result: DAGRunResult | None = None
+        transient_streak = 0
         while elapsed < timeout_seconds:
-            result = self.get_native_status(run_id)
+            try:
+                result = self.get_native_status(run_id)
+            except RuntimeError as e:
+                transient_streak += 1
+                if transient_streak >= max_transient_failures:
+                    logger.error(
+                        "native-status failed %d times in a row — giving up",
+                        transient_streak,
+                    )
+                    raise
+                logger.warning(
+                    "native-status transient error (streak %d/%d): %s — sleeping %ds and retrying",
+                    transient_streak,
+                    max_transient_failures,
+                    e,
+                    interval_seconds,
+                )
+                time.sleep(interval_seconds)
+                elapsed += interval_seconds
+                continue
+            transient_streak = 0
             last_result = result
             summary = "; ".join(f"{n.name}={n.status.value}" for n in result.nodes)
             if summary != last_summary:

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -322,9 +322,7 @@ class AEWorkflowClient:
                 continue
             break
         status, body = last
-        raise RuntimeError(
-            f"create_workflow failed: HTTP {status}\nresponse={body!r}"
-        )
+        raise RuntimeError(f"create_workflow failed: HTTP {status}\nresponse={body!r}")
 
     def create_version(
         self,
@@ -473,9 +471,7 @@ class AEWorkflowClient:
                     if attempt > 1:
                         logger.info("AE submit succeeded on attempt %d", attempt)
                     return run_id
-                raise RuntimeError(
-                    f"AE submit returned no run_id\nresponse={body!r}"
-                )
+                raise RuntimeError(f"AE submit returned no run_id\nresponse={body!r}")
             if status >= 500 and attempt <= retries:
                 logger.warning(
                     "AE submit attempt %d/%d: HTTP %d (retrying in %ds) body=%r",
@@ -629,9 +625,9 @@ class AEWorkflowClient:
         return asyncio.run(self._connection_search_async(qualified_name))
 
     async def _connection_search_async(self, qualified_name: str) -> bool:
-        from pyatlan.client.aio.client import AsyncAtlanClient
-        from pyatlan.model.assets import Asset
-        from pyatlan.model.fluent_search import FluentSearch
+        # Lazy: pyatlan is a heavy import; testing-time-only.
+        from pyatlan.model.assets import Asset  # noqa: PLC0415
+        from pyatlan.model.fluent_search import FluentSearch  # noqa: PLC0415
 
         try:
             async with self._build_async_atlan_client() as client:
@@ -649,7 +645,7 @@ class AEWorkflowClient:
             )
             return False
 
-    def _build_async_atlan_client(self) -> "AsyncAtlanClient":  # noqa: F821
+    def _build_async_atlan_client(self) -> Any:
         """Construct an AsyncAtlanClient using OAuth if configured, else bearer.
 
         Centralised so every pyatlan call (search, role_cache) goes
@@ -659,7 +655,7 @@ class AEWorkflowClient:
         broad-permissioned service account whose name confuses RBAC
         diagnostics.
         """
-        from pyatlan.client.aio.client import AsyncAtlanClient
+        from pyatlan.client.aio.client import AsyncAtlanClient  # noqa: PLC0415
 
         if self._oauth_client_id and self._oauth_client_secret:
             return AsyncAtlanClient(
@@ -667,9 +663,7 @@ class AEWorkflowClient:
                 oauth_client_id=self._oauth_client_id,
                 oauth_client_secret=self._oauth_client_secret,
             )
-        return AsyncAtlanClient(
-            base_url=self.tenant_url, api_key=self._api_token
-        )
+        return AsyncAtlanClient(base_url=self.tenant_url, api_key=self._api_token)
 
     def poll_atlas_for_connection(
         self,
@@ -762,9 +756,7 @@ class AEWorkflowClient:
         results = asyncio.run(self._search_counts_async(prefix, type_names))
         return dict(zip(type_names, results))
 
-    def has_lineage_under_connection(
-        self, connection_qualified_name: str
-    ) -> bool:
+    def has_lineage_under_connection(self, connection_qualified_name: str) -> bool:
         """True iff at least one lineage Process exists under this connection.
 
         QI + lineage-app + lineage-publish together produce ``Process``
@@ -791,9 +783,9 @@ class AEWorkflowClient:
         call per type, and the standard pyatlan pattern for batched
         reads.
         """
-        from pyatlan.client.aio.client import AsyncAtlanClient
-        from pyatlan.model.assets import Asset
-        from pyatlan.model.fluent_search import FluentSearch
+        from pyatlan.client.aio.client import AsyncAtlanClient  # noqa: PLC0415
+        from pyatlan.model.assets import Asset  # noqa: PLC0415
+        from pyatlan.model.fluent_search import FluentSearch  # noqa: PLC0415
 
         async def _count_one(client: AsyncAtlanClient, type_name: str) -> int:
             try:
@@ -814,9 +806,7 @@ class AEWorkflowClient:
             base_url=self.tenant_url, api_key=self._api_token
         ) as client:
             return list(
-                await asyncio.gather(
-                    *(_count_one(client, tn) for tn in type_names)
-                )
+                await asyncio.gather(*(_count_one(client, tn) for tn in type_names))
             )
 
 

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -255,7 +255,14 @@ class AEWorkflowClient:
     # Endpoints
     # ------------------------------------------------------------------
 
-    def create_workflow(self, name: str, description: str = "") -> str:
+    def create_workflow(
+        self,
+        name: str,
+        description: str = "",
+        *,
+        retries: int = 4,
+        retry_sleep_seconds: int = 5,
+    ) -> str:
         """POST ``/automation/api/v1/workflows`` — create or upsert a workflow.
 
         AE doesn't auto-create workflows on submit: a fresh slug → HTTP
@@ -265,27 +272,54 @@ class AEWorkflowClient:
         idempotent on name — submitting the same name returns the
         existing workflow's slug.
 
+        Retries on HTTP 5xx (same ``AE-COMMON-500-01: An unexpected
+        error occurred`` shape we already handle on ``create_version``
+        / ``submit_workflow`` / ``poll_native_status``). 4 attempts at
+        5s intervals covers the typical AE recovery window without
+        sitting on a hard failure.
+
         Returns:
             The workflow slug (used by subsequent version + submit
             calls).
 
         Raises:
-            RuntimeError: On non-2xx or missing slug in response.
+            RuntimeError: On non-2xx after retries are exhausted or on
+                missing slug in the response body.
         """
-        status, body = self._request(
-            "POST",
-            "/automation/api/v1/workflows",
-            body={"name": name, "description": description},
-        )
-        if status >= 300 or not isinstance(body, dict):
-            raise RuntimeError(
-                f"create_workflow failed: HTTP {status}\nresponse={body!r}"
+        last: tuple[int, Any] = (0, {})
+        for attempt in range(1, retries + 2):
+            status, body = self._request(
+                "POST",
+                "/automation/api/v1/workflows",
+                body={"name": name, "description": description},
             )
-        data = body.get("data") if isinstance(body.get("data"), dict) else body
-        slug = data.get("slug") if isinstance(data, dict) else None
-        if not slug:
-            raise RuntimeError(f"create_workflow returned no slug\nresponse={body!r}")
-        return str(slug)
+            last = (status, body)
+            if status < 300 and isinstance(body, dict):
+                data = body.get("data") if isinstance(body.get("data"), dict) else body
+                slug = data.get("slug") if isinstance(data, dict) else None
+                if not slug:
+                    raise RuntimeError(
+                        f"create_workflow returned no slug\nresponse={body!r}"
+                    )
+                if attempt > 1:
+                    logger.info("create_workflow succeeded on attempt %d", attempt)
+                return str(slug)
+            if status >= 500 and attempt <= retries:
+                logger.warning(
+                    "create_workflow attempt %d/%d: HTTP %d (retrying in %ds) body=%r",
+                    attempt,
+                    retries + 1,
+                    status,
+                    retry_sleep_seconds,
+                    body,
+                )
+                time.sleep(retry_sleep_seconds)
+                continue
+            break
+        status, body = last
+        raise RuntimeError(
+            f"create_workflow failed: HTTP {status}\nresponse={body!r}"
+        )
 
     def create_version(
         self,

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -340,27 +340,62 @@ class AEWorkflowClient:
             f"publish_version failed after {retries} attempts: {last_body!r}"
         )
 
-    def submit_workflow(self, payload: dict[str, Any]) -> str:
+    def submit_workflow(
+        self,
+        payload: dict[str, Any],
+        *,
+        retries: int = 4,
+        retry_sleep_seconds: int = 5,
+    ) -> str:
         """POST ``/api/service/package-workflows?submit=true``.
 
         Returns the run UUID from the submit response. The submit
         response shape is not officially documented; we look for
         ``run_id`` under either the top level or a nested ``data`` key.
 
+        Retries on HTTP 5xx — AE's submit can race with the
+        publish_version indexing window and surface a generic
+        ``AE-COMMON-500-01: An unexpected error occurred`` even after
+        publish_version returned 200. 4 retries at 5s intervals
+        covers the longest indexing lag we've observed (~15s) without
+        sitting on a hard failure.
+
         Raises:
-            RuntimeError: On non-2xx HTTP status or missing ``run_id``.
+            RuntimeError: On non-2xx HTTP status after retries are
+                exhausted, or on missing ``run_id`` in the response.
         """
-        status, body = self._request(
-            "POST",
-            "/api/service/package-workflows?submit=true",
-            body=payload,
-        )
-        if status >= 300 or not isinstance(body, dict):
-            raise RuntimeError(f"AE submit failed: HTTP {status}\nresponse={body!r}")
-        data = body.get("data") if isinstance(body.get("data"), dict) else body
-        run_id = data.get("run_id") if isinstance(data, dict) else None
-        if not run_id:
-            raise RuntimeError(f"AE submit returned no run_id\nresponse={body!r}")
+        last: tuple[int, Any] = (0, {})
+        for attempt in range(1, retries + 2):
+            status, body = self._request(
+                "POST",
+                "/api/service/package-workflows?submit=true",
+                body=payload,
+            )
+            last = (status, body)
+            if status < 300 and isinstance(body, dict):
+                data = body.get("data") if isinstance(body.get("data"), dict) else body
+                run_id = data.get("run_id") if isinstance(data, dict) else None
+                if run_id:
+                    if attempt > 1:
+                        logger.info("AE submit succeeded on attempt %d", attempt)
+                    return run_id
+                raise RuntimeError(
+                    f"AE submit returned no run_id\nresponse={body!r}"
+                )
+            if status >= 500 and attempt <= retries:
+                logger.warning(
+                    "AE submit attempt %d/%d: HTTP %d (retrying in %ds) body=%r",
+                    attempt,
+                    retries + 1,
+                    status,
+                    retry_sleep_seconds,
+                    body,
+                )
+                time.sleep(retry_sleep_seconds)
+                continue
+            break
+        status, body = last
+        raise RuntimeError(f"AE submit failed: HTTP {status}\nresponse={body!r}")
         return str(run_id)
 
     def get_native_status(self, run_id: str) -> DAGRunResult:

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -199,6 +199,119 @@ class AEWorkflowClient:
     # Endpoints
     # ------------------------------------------------------------------
 
+    def create_workflow(self, name: str, description: str = "") -> str:
+        """POST ``/automation/api/v1/workflows`` — create or upsert a workflow.
+
+        AE doesn't auto-create workflows on submit: a fresh slug → HTTP
+        404 ("Workflow with slug 'X' not found. Create the workflow
+        first."). So every full-DAG run begins by creating (or
+        re-creating) the workflow under a stable name. The endpoint is
+        idempotent on name — submitting the same name returns the
+        existing workflow's slug.
+
+        Returns:
+            The workflow slug (used by subsequent version + submit
+            calls).
+
+        Raises:
+            RuntimeError: On non-2xx or missing slug in response.
+        """
+        status, body = self._request(
+            "POST",
+            "/automation/api/v1/workflows",
+            body={"name": name, "description": description},
+        )
+        if status >= 300 or not isinstance(body, dict):
+            raise RuntimeError(
+                f"create_workflow failed: HTTP {status}\nresponse={body!r}"
+            )
+        data = body.get("data") if isinstance(body.get("data"), dict) else body
+        slug = data.get("slug") if isinstance(data, dict) else None
+        if not slug:
+            raise RuntimeError(
+                f"create_workflow returned no slug\nresponse={body!r}"
+            )
+        return str(slug)
+
+    def create_version(self, slug: str, version_payload: dict[str, Any]) -> int:
+        """POST ``/automation/api/v1/workflows/<slug>/versions`` — create a version.
+
+        The version carries the full DAG manifest (extract / qi / publish
+        / lineage-app / lineage-publish nodes). A workflow must have at
+        least one *published* version before package-workflows submit
+        will accept a run against it.
+
+        Returns:
+            The version number assigned by AE (typically a Unix
+            timestamp, but treat as opaque int).
+        """
+        status, body = self._request(
+            "POST",
+            f"/automation/api/v1/workflows/{slug}/versions",
+            body=version_payload,
+        )
+        if status >= 300 or not isinstance(body, dict):
+            raise RuntimeError(
+                f"create_version failed: HTTP {status}\nresponse={body!r}"
+            )
+        data = body.get("data") if isinstance(body.get("data"), dict) else body
+        version = data.get("version") if isinstance(data, dict) else None
+        if version is None:
+            raise RuntimeError(
+                f"create_version returned no version\nresponse={body!r}"
+            )
+        return int(version)
+
+    def publish_version(
+        self,
+        slug: str,
+        version: int,
+        *,
+        retries: int = 5,
+        retry_sleep_seconds: int = 5,
+    ) -> None:
+        """POST ``/automation/api/v1/workflows/<slug>/versions/<v>/publish``.
+
+        AE can lag a few seconds between version-create and version-
+        publish — early calls return 404 (AE-WF-404-02 "version not
+        found"). Retries on failure (mssql platform-smoke does the
+        same: 5 attempts, 5s spacing).
+
+        Raises:
+            RuntimeError: If all retries return a non-success status.
+        """
+        last_body: dict[str, Any] | str = ""
+        for attempt in range(1, retries + 1):
+            status, body = self._request(
+                "POST",
+                f"/automation/api/v1/workflows/{slug}/versions/{version}/publish",
+            )
+            last_body = body
+            if (
+                status < 300
+                and isinstance(body, dict)
+                and body.get("status") == "success"
+            ):
+                logger.info(
+                    "Published workflow %s version %d (attempt %d)",
+                    slug,
+                    version,
+                    attempt,
+                )
+                return
+            logger.warning(
+                "publish_version attempt %d/%d: HTTP %s body=%r",
+                attempt,
+                retries,
+                status,
+                body,
+            )
+            if attempt < retries:
+                time.sleep(retry_sleep_seconds)
+        raise RuntimeError(
+            f"publish_version failed after {retries} attempts: {last_body!r}"
+        )
+
     def submit_workflow(self, payload: dict[str, Any]) -> str:
         """POST ``/api/service/package-workflows?submit=true``.
 

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -486,7 +486,6 @@ class AEWorkflowClient:
             break
         status, body = last
         raise RuntimeError(f"AE submit failed: HTTP {status}\nresponse={body!r}")
-        return str(run_id)
 
     def get_native_status(self, run_id: str) -> DAGRunResult:
         """GET ``/api/service/package-workflows/native-status/<run_id>``.
@@ -803,11 +802,10 @@ class AEWorkflowClient:
         filters ``HAS_LINEAGE.eq(True)`` so the count matches the
         Atlan UI's "Lineage coverage" card.
         """
-        from pyatlan.client.aio.client import AsyncAtlanClient  # noqa: PLC0415
         from pyatlan.model.assets import Asset  # noqa: PLC0415
         from pyatlan.model.fluent_search import FluentSearch  # noqa: PLC0415
 
-        async def _count_one(client: AsyncAtlanClient, type_name: str) -> int:
+        async def _count_one(client: Any, type_name: str) -> int:
             try:
                 builder = (
                     FluentSearch()
@@ -825,9 +823,15 @@ class AEWorkflowClient:
                 )
                 return 0
 
-        async with AsyncAtlanClient(
-            base_url=self.tenant_url, api_key=self._api_token
-        ) as client:
+        # Route through _build_async_atlan_client so the count searches
+        # honour the OAuth client_credentials config when present
+        # (a service account with realm-admin can be missing from an
+        # asset ACL the OAuth client *is* on — the choice between the
+        # two identities is the entire reason _build_async_atlan_client
+        # exists). Using AsyncAtlanClient(api_key=...) here would always
+        # fall back to the API-key identity and silently break asset /
+        # lineage coverage counts for OAuth-only tenants.
+        async with self._build_async_atlan_client() as client:
             return list(
                 await asyncio.gather(*(_count_one(client, tn) for tn in type_names))
             )

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -231,7 +231,14 @@ class AEWorkflowClient:
             raise RuntimeError(f"create_workflow returned no slug\nresponse={body!r}")
         return str(slug)
 
-    def create_version(self, slug: str, version_payload: dict[str, Any]) -> int:
+    def create_version(
+        self,
+        slug: str,
+        version_payload: dict[str, Any],
+        *,
+        retries: int = 5,
+        retry_sleep_seconds: int = 5,
+    ) -> int:
         """POST ``/automation/api/v1/workflows/<slug>/versions`` — create a version.
 
         The version carries the full DAG manifest (extract / qi / publish
@@ -239,24 +246,52 @@ class AEWorkflowClient:
         least one *published* version before package-workflows submit
         will accept a run against it.
 
+        Retries on HTTP 404 because AE has a brief indexing window
+        between ``create_workflow`` returning a slug and that slug
+        being queryable on this endpoint — early calls hit AE-WF-404-02
+        ("Workflow with slug 'X' not found. Create the workflow
+        first.") even though we just created it. mssql platform-smoke
+        bridges the gap with a ``sleep 3`` after create_workflow; we
+        retry on 404 directly so the harness self-recovers regardless
+        of how slow indexing is on a given tenant.
+
         Returns:
             The version number assigned by AE (typically a Unix
             timestamp, but treat as opaque int).
         """
-        status, body = self._request(
-            "POST",
-            f"/automation/api/v1/workflows/{slug}/versions",
-            body=version_payload,
-        )
-        if status >= 300 or not isinstance(body, dict):
-            raise RuntimeError(
-                f"create_version failed: HTTP {status}\nresponse={body!r}"
+        last: tuple[int, dict[str, Any] | str] = (0, "")
+        for attempt in range(1, retries + 1):
+            status, body = self._request(
+                "POST",
+                f"/automation/api/v1/workflows/{slug}/versions",
+                body=version_payload,
             )
-        data = body.get("data") if isinstance(body.get("data"), dict) else body
-        version = data.get("version") if isinstance(data, dict) else None
-        if version is None:
-            raise RuntimeError(f"create_version returned no version\nresponse={body!r}")
-        return int(version)
+            last = (status, body)
+            if status < 300 and isinstance(body, dict):
+                data = (
+                    body.get("data") if isinstance(body.get("data"), dict) else body
+                )
+                version = data.get("version") if isinstance(data, dict) else None
+                if version is not None:
+                    return int(version)
+            # 404 is the indexing-lag case — retry. Other failures are
+            # not retryable (auth, validation, etc.) so bail immediately
+            # with the body for diagnostic.
+            if status != 404:
+                break
+            logger.warning(
+                "create_version attempt %d/%d: HTTP 404 (slug %s indexing); retrying in %ds",
+                attempt,
+                retries,
+                slug,
+                retry_sleep_seconds,
+            )
+            if attempt < retries:
+                time.sleep(retry_sleep_seconds)
+        status, body = last
+        raise RuntimeError(
+            f"create_version failed: HTTP {status}\nresponse={body!r}"
+        )
 
     def publish_version(
         self,

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -1,0 +1,384 @@
+"""HTTP client for Atlan tenant endpoints used by tier-4/5 full-DAG tests.
+
+Wraps three endpoints:
+
+* ``POST /api/service/package-workflows?submit=true`` — AE submit.
+* ``GET  /api/service/package-workflows/native-status/<run_id>`` — DAG
+  run status with per-node breakdown (one entry per node in
+  ``manifest.json``'s DAG).
+* ``GET  /api/meta/entity/uniqueAttribute/type/Connection?attr:qualifiedName=<qn>``
+  — Atlas-side check that the resulting Connection asset is queryable.
+
+The shape of the native-status response (captured against devex with a
+real workflow run):
+
+.. code-block:: json
+
+    {
+      "status": "Running",
+      "run_id": "7fd7b893-...",
+      "workflow_slug": "mysql-oUUCLfTn",
+      "temporal_run_id": "...",
+      "dag_nodes": {
+        "extract":         {"status": "Succeeded", "started_at": ..., "completed_at": ..., "error_message": null},
+        "qi":              {"status": "Succeeded", ...},
+        "publish":         {"status": "Succeeded", ...},
+        "lineage-app":     {"status": "Running",   ...},
+        "lineage-publish": {"status": "Pending",   ...}
+      }
+    }
+
+We treat ``"Succeeded" | "Failed" | "Error" | "Cancelled"`` as terminal
+node statuses, ``"Running" | "Pending" | "Scheduled"`` as in-flight.
+"""
+
+from __future__ import annotations
+
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+import orjson
+
+from application_sdk.observability.logger_adaptor import get_logger
+
+logger = get_logger(__name__)
+
+
+# Standard library urllib's default User-Agent (``Python-urllib/<ver>``)
+# is blocked by Cloudflare on most Atlan tenants (Error 1010 — browser
+# signature banned). Spoofing a real UA keeps the request flowing through.
+_USER_AGENT = "atlan-sdk-full-dag-e2e/1.0 (+https://github.com/atlanhq/application-sdk)"
+
+# Timeout budget for individual HTTP calls. Polls run inside outer
+# while-loops so the overall budget is driven by ``poll_native_status``
+# / ``poll_atlas_for_connection``; the per-request timeout just keeps
+# any one call from hanging the whole loop.
+_HTTP_TIMEOUT = 30
+
+
+class DAGNodeStatus(str, Enum):
+    """Status values returned by ``native-status`` per DAG node."""
+
+    PENDING = "Pending"
+    SCHEDULED = "Scheduled"
+    RUNNING = "Running"
+    SUCCEEDED = "Succeeded"
+    FAILED = "Failed"
+    ERROR = "Error"
+    CANCELLED = "Cancelled"
+
+    @property
+    def is_terminal(self) -> bool:
+        """True if this status will not change without re-submission."""
+        return self in {
+            DAGNodeStatus.SUCCEEDED,
+            DAGNodeStatus.FAILED,
+            DAGNodeStatus.ERROR,
+            DAGNodeStatus.CANCELLED,
+        }
+
+    @property
+    def is_success(self) -> bool:
+        """True when the node completed without error."""
+        return self is DAGNodeStatus.SUCCEEDED
+
+
+class DAGRunStatus(str, Enum):
+    """Top-level status of an AE workflow run."""
+
+    PENDING = "Pending"
+    RUNNING = "Running"
+    SUCCEEDED = "Succeeded"
+    FAILED = "Failed"
+    ERROR = "Error"
+    CANCELLED = "Cancelled"
+
+    @property
+    def is_terminal(self) -> bool:
+        return self in {
+            DAGRunStatus.SUCCEEDED,
+            DAGRunStatus.FAILED,
+            DAGRunStatus.ERROR,
+            DAGRunStatus.CANCELLED,
+        }
+
+
+@dataclass(frozen=True)
+class DAGNodeResult:
+    """One row of the per-node breakdown returned by ``native-status``."""
+
+    name: str
+    status: DAGNodeStatus
+    started_at_ms: int | None
+    completed_at_ms: int | None
+    error_message: str | None
+
+    @property
+    def duration_seconds(self) -> float | None:
+        """Wall time if both endpoints are populated."""
+        if self.started_at_ms is None or self.completed_at_ms is None:
+            return None
+        return (self.completed_at_ms - self.started_at_ms) / 1000.0
+
+
+@dataclass(frozen=True)
+class DAGRunResult:
+    """Full result returned by :meth:`AEWorkflowClient.poll_native_status`."""
+
+    run_id: str
+    workflow_slug: str
+    status: DAGRunStatus
+    nodes: list[DAGNodeResult]
+
+    @property
+    def all_nodes_succeeded(self) -> bool:
+        return bool(self.nodes) and all(n.status.is_success for n in self.nodes)
+
+    @property
+    def failed_nodes(self) -> list[DAGNodeResult]:
+        return [n for n in self.nodes if not n.status.is_success]
+
+
+class AEWorkflowClient:
+    """Thin wrapper over the three Atlan endpoints used by full-DAG tests.
+
+    Stateless aside from caching the auth token. Methods are idempotent
+    and safe to retry.
+
+    Args:
+        tenant_url: Base URL of the tenant (e.g. ``https://devex.atlan.com``).
+            Trailing slash is stripped if present.
+        api_token: Bearer token. Accepts either a long-lived API key or a
+            short-lived OAuth ``client_credentials`` access token.
+    """
+
+    def __init__(self, tenant_url: str, api_token: str) -> None:
+        self.tenant_url = tenant_url.rstrip("/")
+        self._api_token = api_token
+
+    # ------------------------------------------------------------------
+    # Low-level HTTP
+    # ------------------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: dict[str, Any] | None = None,
+        timeout: int = _HTTP_TIMEOUT,
+    ) -> tuple[int, dict[str, Any] | str]:
+        """HTTP request returning ``(status_code, parsed_body_or_text)``."""
+        url = f"{self.tenant_url}{path}"
+        data = orjson.dumps(body) if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("Authorization", f"Bearer {self._api_token}")
+        req.add_header("Accept", "application/json")
+        req.add_header("User-Agent", _USER_AGENT)
+        if body is not None:
+            req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                raw = resp.read()
+                try:
+                    return resp.status, orjson.loads(raw)
+                except orjson.JSONDecodeError:
+                    return resp.status, raw.decode(errors="replace")
+        except urllib.error.HTTPError as e:
+            raw = e.read()
+            try:
+                return e.code, orjson.loads(raw)
+            except orjson.JSONDecodeError:
+                return e.code, raw.decode(errors="replace")
+
+    # ------------------------------------------------------------------
+    # Endpoints
+    # ------------------------------------------------------------------
+
+    def submit_workflow(self, payload: dict[str, Any]) -> str:
+        """POST ``/api/service/package-workflows?submit=true``.
+
+        Returns the run UUID from the submit response. The submit
+        response shape is not officially documented; we look for
+        ``run_id`` under either the top level or a nested ``data`` key.
+
+        Raises:
+            RuntimeError: On non-2xx HTTP status or missing ``run_id``.
+        """
+        status, body = self._request(
+            "POST",
+            "/api/service/package-workflows?submit=true",
+            body=payload,
+        )
+        if status >= 300 or not isinstance(body, dict):
+            raise RuntimeError(f"AE submit failed: HTTP {status}\nresponse={body!r}")
+        data = body.get("data") if isinstance(body.get("data"), dict) else body
+        run_id = data.get("run_id") if isinstance(data, dict) else None
+        if not run_id:
+            raise RuntimeError(f"AE submit returned no run_id\nresponse={body!r}")
+        return str(run_id)
+
+    def get_native_status(self, run_id: str) -> DAGRunResult:
+        """GET ``/api/service/package-workflows/native-status/<run_id>``.
+
+        Parses the response into a typed :class:`DAGRunResult` so callers
+        don't have to memorize the wire shape.
+        """
+        status, body = self._request(
+            "GET",
+            f"/api/service/package-workflows/native-status/{run_id}"
+            "?execution_mode=automation-engine",
+        )
+        if status >= 300 or not isinstance(body, dict):
+            raise RuntimeError(
+                f"native-status failed: HTTP {status}\nresponse={body!r}"
+            )
+        nodes_raw = body.get("dag_nodes") or {}
+        nodes = [
+            DAGNodeResult(
+                name=name,
+                status=_safe_node_status(n.get("status")),
+                started_at_ms=_safe_int(n.get("started_at")),
+                completed_at_ms=_safe_int(n.get("completed_at")),
+                error_message=n.get("error_message"),
+            )
+            for name, n in sorted(nodes_raw.items())
+        ]
+        return DAGRunResult(
+            run_id=str(body.get("run_id", run_id)),
+            workflow_slug=str(body.get("workflow_slug", "")),
+            status=_safe_run_status(body.get("status")),
+            nodes=nodes,
+        )
+
+    def poll_native_status(
+        self,
+        run_id: str,
+        *,
+        interval_seconds: int = 10,
+        timeout_seconds: int = 600,
+    ) -> DAGRunResult:
+        """Poll until the run reaches a terminal top-level status.
+
+        Logs a one-line summary per poll only when the status string
+        changes (i.e. progress moments), to avoid spamming logs during
+        long-running publish / lineage stages.
+        """
+        elapsed = 0
+        last_summary: str | None = None
+        last_result: DAGRunResult | None = None
+        while elapsed < timeout_seconds:
+            result = self.get_native_status(run_id)
+            last_result = result
+            summary = "; ".join(f"{n.name}={n.status.value}" for n in result.nodes)
+            if summary != last_summary:
+                logger.info(
+                    "AE run %s (slug=%s) status=%s | %s",
+                    result.run_id,
+                    result.workflow_slug,
+                    result.status.value,
+                    summary,
+                )
+                last_summary = summary
+            if result.status.is_terminal:
+                return result
+            time.sleep(interval_seconds)
+            elapsed += interval_seconds
+        # Timeout: return the last observation so callers can include
+        # node-level state in the failure message rather than just
+        # "timed out after Xs".
+        if last_result is not None:
+            return last_result
+        raise RuntimeError(
+            f"native-status timed out after {timeout_seconds}s with no response"
+        )
+
+    def get_connection_in_atlas(self, qualified_name: str) -> int:
+        """HEAD-style probe for a Connection asset. Returns HTTP status code.
+
+        200 means the Connection exists and is queryable in Atlas. 404
+        means publish hasn't flushed it yet (or the workflow failed).
+        Any other status is a real error worth surfacing.
+        """
+        status, _ = self._request(
+            "GET",
+            "/api/meta/entity/uniqueAttribute/type/Connection"
+            f"?attr:qualifiedName={qualified_name}",
+        )
+        return status
+
+    def poll_atlas_for_connection(
+        self,
+        qualified_name: str,
+        *,
+        interval_seconds: int = 30,
+        timeout_seconds: int = 1500,
+    ) -> bool:
+        """Poll Atlas until the Connection appears or timeout elapses.
+
+        Wide default budget (25 min) because publish runs after the AE
+        DAG completes and can take a while to flush large connections.
+        Callers with smaller datasets can tighten this.
+        """
+        elapsed = 0
+        while elapsed < timeout_seconds:
+            status = self.get_connection_in_atlas(qualified_name)
+            logger.info(
+                "Atlas Connection probe [%ds] qn=%s HTTP %d",
+                elapsed,
+                qualified_name,
+                status,
+            )
+            if status == 200:
+                return True
+            if status >= 500:
+                logger.warning(
+                    "Atlas returned %d for Connection probe; retrying", status
+                )
+            time.sleep(interval_seconds)
+            elapsed += interval_seconds
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Helpers — defensive parsing for forward-compat
+# ---------------------------------------------------------------------------
+
+
+def _safe_node_status(raw: Any) -> DAGNodeStatus:
+    """Map unknown / future status strings to ``Pending`` rather than raising.
+
+    The AE service can introduce new intermediate statuses ahead of SDK
+    releases; treating unknowns as non-terminal keeps polling alive
+    instead of crashing the test on an unexpected enum value.
+    """
+    if not isinstance(raw, str):
+        return DAGNodeStatus.PENDING
+    try:
+        return DAGNodeStatus(raw)
+    except ValueError:
+        return DAGNodeStatus.PENDING
+
+
+def _safe_run_status(raw: Any) -> DAGRunStatus:
+    """Same defensive mapping for the top-level run status."""
+    if not isinstance(raw, str):
+        return DAGRunStatus.PENDING
+    try:
+        return DAGRunStatus(raw)
+    except ValueError:
+        return DAGRunStatus.PENDING
+
+
+def _safe_int(raw: Any) -> int | None:
+    """Cast a JSON number to int, returning None on missing / non-numeric."""
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -268,9 +268,7 @@ class AEWorkflowClient:
             )
             last = (status, body)
             if status < 300 and isinstance(body, dict):
-                data = (
-                    body.get("data") if isinstance(body.get("data"), dict) else body
-                )
+                data = body.get("data") if isinstance(body.get("data"), dict) else body
                 version = data.get("version") if isinstance(data, dict) else None
                 if version is not None:
                     return int(version)
@@ -289,9 +287,7 @@ class AEWorkflowClient:
             if attempt < retries:
                 time.sleep(retry_sleep_seconds)
         status, body = last
-        raise RuntimeError(
-            f"create_version failed: HTTP {status}\nresponse={body!r}"
-        )
+        raise RuntimeError(f"create_version failed: HTTP {status}\nresponse={body!r}")
 
     def publish_version(
         self,

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -457,14 +457,25 @@ class AEWorkflowClient:
         *,
         interval_seconds: int = 30,
         timeout_seconds: int = 1500,
+        max_forbidden_attempts: int = 5,
     ) -> bool:
         """Poll Atlas until the Connection appears or timeout elapses.
 
         Wide default budget (25 min) because publish runs after the AE
         DAG completes and can take a while to flush large connections.
         Callers with smaller datasets can tighten this.
+
+        HTTP 403 is treated separately from other non-200 responses: it
+        almost always means the calling identity is not on the
+        Connection's admin ACL (the publish step succeeded, but the
+        probe was set up with the wrong adminRoles/adminUsers). Polling
+        through this won't fix it — the ACL won't change mid-run — so
+        the caller bails out after ``max_forbidden_attempts`` 403s with
+        a clear log line, instead of silently burning the full 25 min
+        budget on a config bug.
         """
         elapsed = 0
+        forbidden_streak = 0
         while elapsed < timeout_seconds:
             status = self.get_connection_in_atlas(qualified_name)
             logger.info(
@@ -475,6 +486,21 @@ class AEWorkflowClient:
             )
             if status == 200:
                 return True
+            if status == 403:
+                forbidden_streak += 1
+                if forbidden_streak >= max_forbidden_attempts:
+                    logger.error(
+                        "Atlas Connection probe gave HTTP 403 %d times in a row — "
+                        "stopping early. The Connection probably landed in Atlas; "
+                        "the calling identity is just not on its admin ACL. Add "
+                        "$admin (or the API key's role) to adminRoles, or add the "
+                        "service-account username to adminUsers, on the test's "
+                        "connection_spec().",
+                        forbidden_streak,
+                    )
+                    return False
+            else:
+                forbidden_streak = 0
             if status >= 500:
                 logger.warning(
                     "Atlas returned %d for Connection probe; retrying", status

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -544,6 +544,7 @@ class AEWorkflowClient:
         interval_seconds: int = 30,
         timeout_seconds: int = 1500,
         max_forbidden_attempts: int = 5,
+        max_not_found_attempts: int = 10,
     ) -> bool:
         """Poll Atlas until the Connection appears or timeout elapses.
 
@@ -551,17 +552,26 @@ class AEWorkflowClient:
         DAG completes and can take a while to flush large connections.
         Callers with smaller datasets can tighten this.
 
-        HTTP 403 is treated separately from other non-200 responses: it
-        almost always means the calling identity is not on the
-        Connection's admin ACL (the publish step succeeded, but the
-        probe was set up with the wrong adminRoles/adminUsers). Polling
-        through this won't fix it — the ACL won't change mid-run — so
-        the caller bails out after ``max_forbidden_attempts`` 403s with
-        a clear log line, instead of silently burning the full 25 min
-        budget on a config bug.
+        HTTP 403 and 404 are each tracked separately from generic
+        non-200 responses, and each has its own cap on consecutive
+        occurrences:
+
+        * 403 almost always means the calling identity is not on the
+          Connection's admin ACL — polling through this won't fix it,
+          so bail after ``max_forbidden_attempts`` (default 5).
+        * 404 means publish hasn't materialised the Connection yet.
+          For real workloads that can lag a few seconds while the
+          Atlas indexer catches up; longer streaks mean the publish
+          activity reported success but the entities never actually
+          reached Atlas (proxy mis-routing, wrong storage bucket,
+          asset-server outage). Bail after
+          ``max_not_found_attempts`` (default 10 → ~100s at the
+          default 10s interval, ~5 min at the 30s default) instead of
+          silently burning the full 25 min budget.
         """
         elapsed = 0
         forbidden_streak = 0
+        not_found_streak = 0
         while elapsed < timeout_seconds:
             status = self.get_connection_in_atlas(qualified_name)
             logger.info(
@@ -574,6 +584,7 @@ class AEWorkflowClient:
                 return True
             if status == 403:
                 forbidden_streak += 1
+                not_found_streak = 0
                 if forbidden_streak >= max_forbidden_attempts:
                     logger.error(
                         "Atlas Connection probe gave HTTP 403 %d times in a row — "
@@ -585,8 +596,24 @@ class AEWorkflowClient:
                         forbidden_streak,
                     )
                     return False
+            elif status == 404:
+                not_found_streak += 1
+                forbidden_streak = 0
+                if not_found_streak >= max_not_found_attempts:
+                    logger.error(
+                        "Atlas Connection probe gave HTTP 404 %d times in a row "
+                        "(%ds elapsed) — stopping early. The Connection never "
+                        "materialised in Atlas: publish likely reported success "
+                        "but the entities did not reach the asset server. Check "
+                        "publish metrics vs the storage bucket the worker wrote "
+                        "to and the one publish reads from.",
+                        not_found_streak,
+                        elapsed,
+                    )
+                    return False
             else:
                 forbidden_streak = 0
+                not_found_streak = 0
             if status >= 500:
                 logger.warning(
                     "Atlas returned %d for Connection probe; retrying", status

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -34,6 +34,7 @@ node statuses, ``"Running" | "Pending" | "Scheduled"`` as in-flight.
 
 from __future__ import annotations
 
+import asyncio
 import time
 import urllib.error
 import urllib.request
@@ -509,23 +510,6 @@ class AEWorkflowClient:
             elapsed += interval_seconds
         return False
 
-    def _atlan_client(self) -> "AtlanClient":  # noqa: F821
-        """Lazily construct a pyatlan AtlanClient for downstream queries.
-
-        Cached on the instance so per-call cost is one HTTP-pool
-        instantiation, not one per asset-search. The token is the same
-        bearer the AE-side calls use, so search permissions match the
-        Connection's admin ACL (which is why callers must put the API
-        key's identity on adminRoles/adminUsers, not just adminGroups).
-        """
-        from pyatlan.client.atlan import AtlanClient
-
-        if not hasattr(self, "_pyatlan"):
-            self._pyatlan = AtlanClient(
-                base_url=self.tenant_url, api_key=self._api_token
-            )
-        return self._pyatlan
-
     def count_assets_under_connection(
         self,
         connection_qualified_name: str,
@@ -534,43 +518,24 @@ class AEWorkflowClient:
     ) -> dict[str, int]:
         """Per-typeName counts of assets under a connection's QN prefix.
 
-        Uses pyatlan's ``FluentSearch`` so we don't hand-roll Elastic
-        DSL. Returns ``{typeName: count}`` with zeros for types that
-        produced no matches. One round-trip per type — fine at the
-        single-digit number of types we query here, and clearer than
-        a single aggregations call.
+        Uses pyatlan's async client + ``asyncio.gather`` so all
+        per-type searches share a single HTTPS connection pool and
+        fire concurrently — sequentially this is ~2.7s wall-time for
+        the default 5 types, concurrent should land under 700ms once
+        the TLS handshake is paid (one-time per harness run).
 
-        Used by the harness to assert extract + publish actually landed
-        assets in Atlas, not just the Connection envelope. A Connection
-        with zero descendants is almost always a config bug (filter
-        mismatch, transform error) that the basic ``connection_in_atlas``
-        check would silently pass.
+        Returns ``{typeName: count}`` with zeros for types that
+        produced no matches. Used by the harness to assert extract +
+        publish actually landed assets in Atlas, not just the
+        Connection envelope — a Connection with zero descendants is
+        almost always a config bug (filter mismatch, transform error)
+        that the basic ``connection_in_atlas`` check would pass.
         """
-        from pyatlan.model.assets import Asset
-        from pyatlan.model.fluent_search import FluentSearch
-
-        client = self._atlan_client()
+        if not type_names:
+            return {}
         prefix = f"{connection_qualified_name}/"
-        counts: dict[str, int] = {}
-        for type_name in type_names:
-            try:
-                request = (
-                    FluentSearch()
-                    .where(Asset.QUALIFIED_NAME.startswith(prefix))
-                    .where(Asset.TYPE_NAME.eq(type_name))
-                ).to_request()
-                # size=0 keeps the response cheap — we only need .count
-                request.dsl.size = 0
-                results = client.asset.search(request)
-                counts[type_name] = int(results.count)
-            except Exception:
-                logger.exception(
-                    "FluentSearch for %s under %s failed",
-                    type_name,
-                    connection_qualified_name,
-                )
-                counts[type_name] = 0
-        return counts
+        results = asyncio.run(self._search_counts_async(prefix, type_names))
+        return dict(zip(type_names, results))
 
     def has_lineage_under_connection(
         self, connection_qualified_name: str
@@ -579,32 +544,55 @@ class AEWorkflowClient:
 
         QI + lineage-app + lineage-publish together produce ``Process``
         and ``ColumnProcess`` assets whose ``qualifiedName`` is anchored
-        under the Connection. Querying for any single Process row tells
-        us lineage actually flowed through to Atlas — not just that the
-        lineage nodes returned success at the DAG level.
+        under the Connection. Tells us lineage actually flowed through
+        to Atlas — not just that the lineage nodes returned success at
+        the DAG level.
         """
+        prefix = f"{connection_qualified_name}/"
+        counts = asyncio.run(
+            self._search_counts_async(prefix, ("Process", "ColumnProcess"))
+        )
+        return any(c > 0 for c in counts)
+
+    async def _search_counts_async(
+        self,
+        prefix: str,
+        type_names: tuple[str, ...],
+    ) -> list[int]:
+        """Parallel per-type ``count`` searches via pyatlan AsyncAtlanClient.
+
+        Single async client / connection pool shared across all
+        gathered searches — much cheaper than firing one sync HTTPS
+        call per type, and the standard pyatlan pattern for batched
+        reads.
+        """
+        from pyatlan.client.aio.client import AsyncAtlanClient
         from pyatlan.model.assets import Asset
         from pyatlan.model.fluent_search import FluentSearch
 
-        client = self._atlan_client()
-        prefix = f"{connection_qualified_name}/"
-        for type_name in ("Process", "ColumnProcess"):
+        async def _count_one(client: AsyncAtlanClient, type_name: str) -> int:
             try:
                 request = (
                     FluentSearch()
                     .where(Asset.QUALIFIED_NAME.startswith(prefix))
                     .where(Asset.TYPE_NAME.eq(type_name))
                 ).to_request()
-                request.dsl.size = 0
-                if int(client.asset.search(request).count) > 0:
-                    return True
+                request.dsl.size = 0  # cheap response: we only want .count
+                return int((await client.asset.search(request)).count)
             except Exception:
                 logger.exception(
-                    "FluentSearch for %s under %s failed",
-                    type_name,
-                    connection_qualified_name,
+                    "FluentSearch for %s under %s failed", type_name, prefix
                 )
-        return False
+                return 0
+
+        async with AsyncAtlanClient(
+            base_url=self.tenant_url, api_key=self._api_token
+        ) as client:
+            return list(
+                await asyncio.gather(
+                    *(_count_one(client, tn) for tn in type_names)
+                )
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/application_sdk/testing/full_dag/payload.py
+++ b/application_sdk/testing/full_dag/payload.py
@@ -126,6 +126,7 @@ def build_seed_dag(
     extract_workflow_type: str | None = None,
     qi_parsing_mode: str = "lorien-only",
     qi_mine_output_type: str = "json",
+    qi_input_prefix_field: str = "view_data_prefix",
     lake_provider: str = "aws",
     mode: RunMode = RunMode.DIRECT,
     agent: AgentSpec | None = None,
@@ -222,7 +223,14 @@ def build_seed_dag(
                 "workflow_type": "QueryIntelligenceWorkflow",
                 "task_queue": qi_task_queue,
                 "args": {
-                    "connection_qualified_name": "$.extract.outputs.connection_qualified_name",
+                    # Inline the connection_qualified_name rather than
+                    # reading from `$.extract.outputs.connection_qualified_name`
+                    # — v3 connectors don't echo the input CQN back on
+                    # their output (the field is present but empty),
+                    # which would silently feed empty CQN into publish
+                    # / qi / lineage and produce 0 entities even though
+                    # everything else "succeeded".
+                    "connection_qualified_name": connection.qualified_name,
                     "vendor_name": connector_short_name,
                     "sql_key": "attributes.definition",
                     "catalog_key": "attributes.databaseName",
@@ -232,7 +240,16 @@ def build_seed_dag(
                     "parsing_mode": qi_parsing_mode,
                     "lake_provider": lake_provider,
                     "storage_bucket": "$.extract.outputs.storage_bucket",
-                    "input_prefix": "$.extract.outputs.view_data_prefix",
+                    # `view_data_prefix` is the field name mssql-style
+                    # extracts emit when they write view definitions to
+                    # a dedicated subfolder. v3 connectors that bundle
+                    # views into the main transformed output (e.g.
+                    # mysql) override `qi_input_prefix_field` to
+                    # `transformed_data_prefix`. QI scans rows and
+                    # only acts on those where `sql_key` is non-null,
+                    # so reading from the bundled prefix is harmless
+                    # for non-view rows.
+                    "input_prefix": f"$.extract.outputs.{qi_input_prefix_field}",
                     "output_prefix": "$.extract.outputs.view_lineage_output_prefix",
                 },
             },
@@ -248,7 +265,7 @@ def build_seed_dag(
                 "workflow_type": "PublishWorkflow",
                 "task_queue": publish_task_queue,
                 "args": {
-                    "connection_qualified_name": "$.extract.outputs.connection_qualified_name",
+                    "connection_qualified_name": connection.qualified_name,  # inlined (see qi node)
                     "transformed_data_prefix": "$.extract.outputs.transformed_data_prefix",
                     "publish_state_prefix": "$.extract.outputs.publish_state_prefix",
                     "current_state_prefix": "$.extract.outputs.current_state_prefix",
@@ -266,7 +283,7 @@ def build_seed_dag(
                 "workflow_type": "LineageWorkflow",
                 "task_queue": lineage_task_queue,
                 "args": {
-                    "connection_qualified_name": "$.extract.outputs.connection_qualified_name",
+                    "connection_qualified_name": connection.qualified_name,  # inlined (see qi node)
                     "connector_name": connector_short_name,
                     "session_key": "view-lineage",
                     "sql_unquoted_case": "lower",
@@ -297,7 +314,7 @@ def build_seed_dag(
                 "workflow_type": "PublishWorkflow",
                 "task_queue": publish_task_queue,
                 "args": {
-                    "connection_qualified_name": "$.extract.outputs.connection_qualified_name",
+                    "connection_qualified_name": connection.qualified_name,  # inlined (see qi node)
                     "transformed_data_prefix": "$.extract.outputs.lineage_stage_prefix",
                     "publish_state_prefix": "$.extract.outputs.lineage_publish_state_prefix",
                     "current_state_prefix": "$.extract.outputs.lineage_current_state_prefix",

--- a/application_sdk/testing/full_dag/payload.py
+++ b/application_sdk/testing/full_dag/payload.py
@@ -183,8 +183,8 @@ def build_ae_payload(
             # keys*, not literal values — the agent's local Dapr
             # secret-store resolves them at workflow time. Callers should
             # pre-populate the secret store with these keys.
-            "basic.username": f"{connector_short_name.upper()}_USERNAME",
-            "basic.password": f"{connector_short_name.upper()}_PASSWORD",
+            "basic.username": f"SDR_{connector_short_name.upper()}_USERNAME",
+            "basic.password": f"SDR_{connector_short_name.upper()}_PASSWORD",
         }
         parameters.append(
             {"name": "agent-json", "value": orjson.dumps(agent_json).decode()}
@@ -253,11 +253,11 @@ def build_ae_payload(
                 },
                 {
                     "name": "agent-json.basic.username",
-                    "value": f"{connector_short_name.upper()}_USERNAME",
+                    "value": f"SDR_{connector_short_name.upper()}_USERNAME",
                 },
                 {
                     "name": "agent-json.basic.password",
-                    "value": f"{connector_short_name.upper()}_PASSWORD",
+                    "value": f"SDR_{connector_short_name.upper()}_PASSWORD",
                 },
             ]
         )

--- a/application_sdk/testing/full_dag/payload.py
+++ b/application_sdk/testing/full_dag/payload.py
@@ -452,6 +452,44 @@ def build_ae_payload(
         ]
     )
 
+    # `payload[]` tells the orchestrator to create a credential and
+    # substitute `{{credentialGuid}}` in the parameters with the
+    # resulting GUID. The body shape *differs by mode*:
+    #
+    # - DIRECT: full credential record (host + port + username +
+    #   password) — the prod-deployed connector pod looks up this
+    #   GUID at runtime and uses the full record to connect.
+    # - AGENT: lightweight record (no host/username/password — those
+    #   live in the agent's local secret-store via agent-json). The
+    #   credential carries auth-type + connectorConfigName metadata;
+    #   the actual creds resolve at the worker via
+    #   `secret://<secret-path>/<key>`.
+    #
+    # Mixing these — sending the DIRECT body shape in agent mode —
+    # causes the orchestrator to skip credential creation (insufficient
+    # validation pass), leaving `{{credentialGuid}}` unsubstituted as
+    # the literal "__placeholder__" string the seed DAG defaults to.
+    # The worker then resolves credential_guid=__placeholder__, gets
+    # HTTP 500 from the Dapr credential vault binding, and the
+    # activity fails with AAF-CRD-002. Validated against the devex
+    # AGENT-mode payload sample.
+    credential_body: dict[str, Any] = {
+        "name": f"default-{connector_short_name}-{run_id}-0",
+        "authType": database.auth_type,
+        "extra": dict(database.extra),
+        "connectorConfigName": database.connector_config_name
+        or f"atlan-connectors-{connector_short_name}",
+    }
+    if mode is RunMode.DIRECT:
+        credential_body.update(
+            {
+                "host": database.host,
+                "port": database.port,
+                "username": database.username,
+                "password": database.password,
+            }
+        )
+
     return {
         "metadata": {
             "labels": {
@@ -502,17 +540,7 @@ def build_ae_payload(
             {
                 "parameter": "credentialGuid",
                 "type": "credential",
-                "body": {
-                    "name": f"default-{connector_short_name}-{run_id}-0",
-                    "host": database.host,
-                    "port": database.port,
-                    "authType": database.auth_type,
-                    "username": database.username,
-                    "password": database.password,
-                    "extra": dict(database.extra),
-                    "connectorConfigName": database.connector_config_name
-                    or f"atlan-connectors-{connector_short_name}",
-                },
+                "body": credential_body,
             }
         ],
         "execution_mode": "native",

--- a/application_sdk/testing/full_dag/payload.py
+++ b/application_sdk/testing/full_dag/payload.py
@@ -134,10 +134,12 @@ def build_seed_dag(
     seed is that the DAG topology + task_queue references are correct
     — the actual extract args get overridden at submit time.
 
-    Per-connector overrides (subclasses can pass via kwargs):
-        - ``extract_workflow_type`` — defaults to
-          ``{connector_short_name}-metadata-extractor`` for SQL-style
-          connectors; override for non-SQL apps.
+    Per-connector overrides (subclasses pass via kwargs):
+        - ``extract_workflow_type`` — must match what the connector's
+          worker actually registers as. v3 mysql registers ``"mysql"``
+          (just the connector name); v2 mssql registers
+          ``"mssql-metadata-extractor"``. Default = ``connector_short_name``
+          (the v3 convention); override for v2-style connectors.
         - ``qi_parsing_mode`` — ``"lorien-only"`` (mssql) vs.
           ``"competitive"`` (mysql per devex sample); driven by what
           the connector emits as parseable SQL.
@@ -145,7 +147,7 @@ def build_seed_dag(
           qi/lineage queues; override for non-production tenants.
     """
     if extract_workflow_type is None:
-        extract_workflow_type = f"{connector_short_name}-metadata-extractor"
+        extract_workflow_type = connector_short_name
 
     return {
         "extract": {

--- a/application_sdk/testing/full_dag/payload.py
+++ b/application_sdk/testing/full_dag/payload.py
@@ -265,7 +265,19 @@ def build_seed_dag(
                 "workflow_type": "PublishWorkflow",
                 "task_queue": publish_task_queue,
                 "args": {
-                    "connection_qualified_name": connection.qualified_name,  # inlined (see qi node)
+                    # PublishWorkflow reads the Connection asset from
+                    # the JSONL bundle under `transformed_data_prefix`
+                    # (which includes the full Connection object with
+                    # `qualifiedName` on its attributes). Passing a
+                    # populated `connection_qualified_name` here makes
+                    # the tenant publish app silently switch to an
+                    # "update only" mode where the asset POSTs land in
+                    # an unrelated namespace — confirmed empirically:
+                    # historic runs with CQN="" landed assets in Atlas;
+                    # runs with CQN populated reported entities-created
+                    # in the publish metric but Atlas got nothing. Pass
+                    # empty string so publish takes its QN from JSONL.
+                    "connection_qualified_name": "",
                     "transformed_data_prefix": "$.extract.outputs.transformed_data_prefix",
                     "publish_state_prefix": "$.extract.outputs.publish_state_prefix",
                     "current_state_prefix": "$.extract.outputs.current_state_prefix",

--- a/application_sdk/testing/full_dag/payload.py
+++ b/application_sdk/testing/full_dag/payload.py
@@ -1,0 +1,356 @@
+"""Build the AE submit payload for full-DAG e2e tests.
+
+Captured shape from the devex UI by inspecting the network tab on a real
+"submit MySQL extract" click. The payload nests the same connection
+attributes in three places (top-level ``payload[].body``,
+``parameters['connection']`` as a JSON string, and a long list of flat
+``connection.<key>`` parameter rows) — this duplication is what the
+tenant's package-workflows service expects, so we faithfully reproduce
+it from a single :class:`ConnectionSpec` source of truth.
+
+Two modes:
+
+* :data:`RunMode.DIRECT` — the AE workflow's ``extract`` activity
+  dispatches to ``task_queue: atlan-<app>-<deployment>`` and the
+  tenant's *production-deployed* connector pod picks it up. Tier 5.
+* :data:`RunMode.AGENT` — same queue, but ``agent-name`` routes to a
+  caller-deployed worker (e.g. CI-side compose with a unique
+  agent-name + S3 binding). Tier 4.
+
+The submitter's responsibility is to ensure the connector worker that
+listens on the resulting Temporal queue is actually running before the
+AE DAG dispatches to it. For tier 4 that's the docker compose worker;
+for tier 5 that's the prod-deployed pod.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+import orjson
+
+
+class RunMode(str, Enum):
+    """Whether the connector runs in tenant or in caller-controlled CI."""
+
+    DIRECT = "direct"
+    AGENT = "agent"
+
+
+@dataclass(frozen=True)
+class ConnectionSpec:
+    """Identity of the Connection the AE workflow will create.
+
+    The ``qualified_name`` should be unique per test run — the tenant
+    treats Connection QN as the upsert key, so colliding QNs across
+    test runs will overwrite each other and confuse asset assertions.
+    Convention: ``default/<connector>/<test-prefix>-<run_id>``.
+    """
+
+    name: str
+    qualified_name: str
+    connector_name: str  # mysql, mssql, etc — must match the @atlan/<conn> package
+    source_logo: str
+    admin_users: tuple[str, ...] = ()
+    admin_groups: tuple[str, ...] = ()
+    admin_roles: tuple[str, ...] = ()
+    category: str = "warehouse"
+    row_limit: int = 10_000
+    allow_query: bool = True
+    allow_query_preview: bool = True
+    is_discoverable: bool = True
+    is_editable: bool = False
+
+    def attributes(self) -> dict[str, Any]:
+        """Pyatlan-style ``Connection.attributes`` block."""
+        return {
+            "name": self.name,
+            "qualifiedName": self.qualified_name,
+            "allowQuery": self.allow_query,
+            "allowQueryPreview": self.allow_query_preview,
+            "rowLimit": self.row_limit,
+            "defaultCredentialGuid": "{{credentialGuid}}",
+            "connectorName": self.connector_name,
+            "sourceLogo": self.source_logo,
+            "isDiscoverable": self.is_discoverable,
+            "isEditable": self.is_editable,
+            "category": self.category,
+            "adminUsers": list(self.admin_users),
+            "adminGroups": list(self.admin_groups),
+            "adminRoles": list(self.admin_roles),
+        }
+
+
+@dataclass(frozen=True)
+class DatabaseSpec:
+    """DB connection details for the credential payload."""
+
+    host: str
+    port: int
+    username: str
+    password: str
+    auth_type: str = "basic"
+    extra: dict[str, Any] = field(default_factory=dict)
+    connector_config_name: str = ""  # e.g. atlan-connectors-mysql
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    """Optional agent routing (tier 4 only).
+
+    ``agent_name`` is used by the Argo cluster template to derive the
+    Temporal task queue (``atlan-<app>-<agent_name>``). The CI worker
+    listens on the same queue; AE then dispatches the extract to it.
+    """
+
+    agent_name: str
+    agent_type: str = "new-app-framework"
+    key_type: str = "single-key"
+    aws_auth_method: str = "iam"
+    azure_auth_method: str = "managed_identity"
+
+
+def build_ae_payload(
+    *,
+    run_id: int,
+    mode: RunMode,
+    connector_short_name: str,
+    argo_package_name: str,
+    argo_template_name: str,
+    app_service_url: str,
+    connection: ConnectionSpec,
+    database: DatabaseSpec,
+    include_filter: str = '{"^def$":[".*"]}',
+    exclude_filter: str = "{}",
+    agent: AgentSpec | None = None,
+) -> dict[str, Any]:
+    """Assemble the AE submit body.
+
+    Args:
+        run_id: Run identifier (typically ``int(time.time())`` or
+            ``int(os.environ["GITHUB_RUN_ID"])``). Used as a unique
+            tag in the AE workflow name and labels.
+        mode: ``DIRECT`` (tier 5) or ``AGENT`` (tier 4).
+        connector_short_name: ``mysql``, ``mssql``, ``saperp``, etc.
+            Drives label keys + Argo template selection.
+        argo_package_name: The ``@atlan/<connector>`` Argo package name.
+        argo_template_name: Cluster-scoped WorkflowTemplate name
+            (``atlan-mysql``, ``atlan-mssql``).
+        app_service_url: HTTP URL the AE workflow can reach the
+            connector at. For tier 4 / agent flow this is metadata only
+            (Temporal-queue routing handles dispatch). For tier 5 /
+            direct flow this is the in-cluster service URL of the prod
+            pod (``http://<app>.<app>-app.svc.cluster.local``).
+        connection: Where the Atlas Connection will be created.
+        database: Real DB the connector will introspect.
+        include_filter / exclude_filter: JSON-encoded dict filter
+            strings (the tenant orchestrator deserializes these before
+            handing to the connector). Defaults match the "all schemas
+            in the default catalog" case.
+        agent: Required when ``mode == AGENT``. Ignored in DIRECT mode.
+
+    Returns:
+        Dict ready to ``orjson.dumps`` and POST to
+        ``/api/service/package-workflows?submit=true``.
+    """
+    if mode is RunMode.AGENT and agent is None:
+        raise ValueError("agent mode requires an AgentSpec")
+
+    label_key = f"orchestration.atlan.com/default-{connector_short_name}-{run_id}"
+    ae_workflow_name = f"atlan-{connector_short_name}-{run_id}"
+    ae_atlan_name = (
+        f"atlan-{connector_short_name}-default-{connector_short_name}-{run_id}"
+    )
+
+    parameters: list[dict[str, Any]] = []
+    parameters.append({"name": "extraction-method", "value": mode.value})
+    parameters.append({"name": "credential-guid", "value": "{{credentialGuid}}"})
+
+    if mode is RunMode.AGENT:
+        assert agent is not None
+        agent_json = {
+            "host": database.host,
+            "port": database.port,
+            "auth-type": database.auth_type,
+            "agent-name": agent.agent_name,
+            "agent-type": agent.agent_type,
+            "key-type": agent.key_type,
+            "aws-auth-method": agent.aws_auth_method,
+            "azure-auth-method": agent.azure_auth_method,
+            # In agent mode the username/password fields are *secret-store
+            # keys*, not literal values — the agent's local Dapr
+            # secret-store resolves them at workflow time. Callers should
+            # pre-populate the secret store with these keys.
+            "basic.username": f"{connector_short_name.upper()}_USERNAME",
+            "basic.password": f"{connector_short_name.upper()}_PASSWORD",
+        }
+        parameters.append(
+            {"name": "agent-json", "value": orjson.dumps(agent_json).decode()}
+        )
+
+    # Connection (full nested JSON string)
+    parameters.append(
+        {
+            "name": "connection",
+            "value": orjson.dumps(
+                {"attributes": connection.attributes(), "typeName": "Connection"}
+            ).decode(),
+        }
+    )
+
+    # Filters
+    parameters.append({"name": "include-filter", "value": include_filter})
+    parameters.append({"name": "exclude-filter", "value": exclude_filter})
+
+    # Credential overrides — in DIRECT mode these go straight through to
+    # the prod pod; in AGENT mode they're ignored in favour of the
+    # agent-json secret-store keys above.
+    parameters.append(
+        {
+            "name": "credential-guid.credential-type",
+            "value": database.connector_config_name
+            or f"atlan-connectors-{connector_short_name}",
+        }
+    )
+    parameters.append({"name": "credential-guid.port", "value": database.port})
+    parameters.append(
+        {"name": "credential-guid.auth-type", "value": database.auth_type}
+    )
+    if mode is RunMode.DIRECT:
+        parameters.append({"name": "credential-guid.host", "value": database.host})
+        parameters.append(
+            {
+                "name": "credential-guid.basic.username",
+                "value": database.username,
+            }
+        )
+        parameters.append(
+            {
+                "name": "credential-guid.basic.password",
+                "value": database.password,
+            }
+        )
+    else:
+        # Agent mode duplicates a subset under agent-json.* — the Argo
+        # cluster template reads these flat parameters separately even
+        # though it could also unpack agent-json JSON. Reproducing the
+        # exact UI shape avoids subtle service-side validation drift.
+        assert agent is not None
+        parameters.extend(
+            [
+                {"name": "agent-json.host", "value": database.host},
+                {"name": "agent-json.port", "value": database.port},
+                {"name": "agent-json.auth-type", "value": database.auth_type},
+                {"name": "agent-json.agent-name", "value": agent.agent_name},
+                {"name": "agent-json.agent-type", "value": agent.agent_type},
+                {"name": "agent-json.key-type", "value": agent.key_type},
+                {"name": "agent-json.aws-auth-method", "value": agent.aws_auth_method},
+                {
+                    "name": "agent-json.azure-auth-method",
+                    "value": agent.azure_auth_method,
+                },
+                {
+                    "name": "agent-json.basic.username",
+                    "value": f"{connector_short_name.upper()}_USERNAME",
+                },
+                {
+                    "name": "agent-json.basic.password",
+                    "value": f"{connector_short_name.upper()}_PASSWORD",
+                },
+            ]
+        )
+
+    # Flat connection.* parameter rows (UI sends both the nested JSON
+    # and these for the orchestrator's convenience).
+    attrs = connection.attributes()
+    parameters.extend(
+        [
+            {"name": "connection.name", "value": attrs["name"]},
+            {"name": "connection.qualifiedName", "value": attrs["qualifiedName"]},
+            {"name": "connection.allowQuery", "value": attrs["allowQuery"]},
+            {
+                "name": "connection.allowQueryPreview",
+                "value": attrs["allowQueryPreview"],
+            },
+            {"name": "connection.rowLimit", "value": attrs["rowLimit"]},
+            {"name": "connection.connectorName", "value": attrs["connectorName"]},
+            {"name": "connection.sourceLogo", "value": attrs["sourceLogo"]},
+            {"name": "connection.isDiscoverable", "value": attrs["isDiscoverable"]},
+            {"name": "connection.isEditable", "value": attrs["isEditable"]},
+            {"name": "connection.category", "value": attrs["category"]},
+            {
+                "name": "connection.adminUsers",
+                "value": orjson.dumps(attrs["adminUsers"]).decode(),
+            },
+            {
+                "name": "connection.adminGroups",
+                "value": orjson.dumps(attrs["adminGroups"]).decode(),
+            },
+            {
+                "name": "connection.adminRoles",
+                "value": orjson.dumps(attrs["adminRoles"]).decode(),
+            },
+        ]
+    )
+
+    return {
+        "metadata": {
+            "labels": {
+                label_key: "true",
+                "orchestration.atlan.com/atlan-ui": "true",
+            },
+            "annotations": {
+                "orchestration.atlan.com/name": f"{connector_short_name.title()} Assets (full-DAG e2e)",
+                "package.argoproj.io/name": argo_package_name,
+                "orchestration.atlan.com/atlanName": ae_atlan_name,
+            },
+            "name": ae_workflow_name,
+            "namespace": "default",
+            "ae_workflow_slug": f"{connector_short_name}-e2e-{run_id}",
+            "app_service_url": app_service_url,
+        },
+        "spec": {
+            "templates": [
+                {
+                    "name": "main",
+                    "dag": {
+                        "tasks": [
+                            {
+                                "name": "run",
+                                "arguments": {"parameters": parameters},
+                                "templateRef": {
+                                    "name": argo_template_name,
+                                    "template": "main",
+                                    "clusterScope": True,
+                                },
+                            }
+                        ]
+                    },
+                }
+            ],
+            "entrypoint": "main",
+            "workflowMetadata": {
+                "annotations": {"package.argoproj.io/name": argo_package_name}
+            },
+        },
+        "payload": [
+            {
+                "parameter": "credentialGuid",
+                "type": "credential",
+                "body": {
+                    "name": f"default-{connector_short_name}-{run_id}-0",
+                    "host": database.host,
+                    "port": database.port,
+                    "authType": database.auth_type,
+                    "username": database.username,
+                    "password": database.password,
+                    "extra": dict(database.extra),
+                    "connectorConfigName": database.connector_config_name
+                    or f"atlan-connectors-{connector_short_name}",
+                },
+            }
+        ],
+        "execution_mode": "native",
+    }

--- a/application_sdk/testing/full_dag/payload.py
+++ b/application_sdk/testing/full_dag/payload.py
@@ -120,6 +120,9 @@ def build_seed_dag(
     qi_task_queue: str = "atlan-query-intelligence-production",
     lineage_task_queue: str = "atlan-lineage-production",
     connection: ConnectionSpec,
+    include_filter: str = '{"^def$":[".*"]}',
+    exclude_filter: str = "{}",
+    temp_table_regex: str = "",
     extract_workflow_type: str | None = None,
     qi_parsing_mode: str = "lorien-only",
     qi_mine_output_type: str = "json",
@@ -152,25 +155,32 @@ def build_seed_dag(
     if extract_workflow_type is None:
         extract_workflow_type = connector_short_name
 
-    # The orchestrator's `submit=true` endpoint substitutes only the
-    # placeholder fields it knows about (`{{credentialGuid}}`) when
-    # creating the new version — it does NOT rewrite extraction_method
-    # or agent_json from the submit's parameters. So if the seed
-    # hardcodes `extraction_method: direct` and `agent_json` is
-    # missing, the new version inherits that shape and the runtime
-    # CredentialRef.resolve() falls through to guid mode (since
-    # agent_spec is None) → tries to look up '__placeholder__' →
-    # AAF-CRD-002. Mirror the submit's mode in the seed.
+    # The orchestrator's `submit=true` endpoint only substitutes Mustache
+    # placeholders it recognises (today: `{{credentialGuid}}`). It does
+    # NOT splat the submit's flat parameters back into the seed's
+    # extract_args. So:
+    #   - credential_guid must be `{{credentialGuid}}` (not a string
+    #     literal like `__placeholder__` — that would propagate verbatim
+    #     and the runtime CredentialRef.resolve would later try to look
+    #     up a credential named `__placeholder__` → AAF-CRD-002).
+    #   - include_filter / exclude_filter / temp_table_regex must be the
+    #     ACTUAL values the run should use — leaving them empty here
+    #     makes the connector extract nothing (which then propagates as
+    #     `connection_qualified_name=""` from extract → publish sees no
+    #     entities → AE workflow raises ApplicationError on assert).
+    #   - extraction_method + agent_json must mirror the submit's mode
+    #     (AGENT vs DIRECT) for credential resolution to land on the
+    #     right path at runtime.
     extract_args: dict[str, Any] = {
-        "credential_guid": "__placeholder__",
+        "credential_guid": "{{credentialGuid}}",
         "connection": {
             "connection_name": connection.name,
             "connection_qualified_name": connection.qualified_name,
         },
         "extraction_method": mode.value,
-        "include_filter": "",
-        "exclude_filter": "",
-        "temp_table_regex": "",
+        "include_filter": include_filter,
+        "exclude_filter": exclude_filter,
+        "temp_table_regex": temp_table_regex,
     }
     if mode is RunMode.AGENT and agent is not None and database is not None:
         # Same agent-json shape build_ae_payload uses for the submit

--- a/application_sdk/testing/full_dag/payload.py
+++ b/application_sdk/testing/full_dag/payload.py
@@ -125,6 +125,7 @@ def build_ae_payload(
     include_filter: str = '{"^def$":[".*"]}',
     exclude_filter: str = "{}",
     agent: AgentSpec | None = None,
+    ae_workflow_slug: str = "",
 ) -> dict[str, Any]:
     """Assemble the AE submit body.
 
@@ -308,7 +309,13 @@ def build_ae_payload(
             },
             "name": ae_workflow_name,
             "namespace": "default",
-            "ae_workflow_slug": f"{connector_short_name}-e2e-{run_id}",
+            # If the caller passes an existing slug, the AE submit
+            # endpoint creates a new version under it rather than
+            # rejecting with HTTP 404 ("Workflow not found, create
+            # first"). Per-run slugs only work on tenants that auto-
+            # create workflows on submit (none we've seen).
+            "ae_workflow_slug": ae_workflow_slug
+            or f"{connector_short_name}-e2e-{run_id}",
             "app_service_url": app_service_url,
         },
         "spec": {

--- a/application_sdk/testing/full_dag/payload.py
+++ b/application_sdk/testing/full_dag/payload.py
@@ -124,6 +124,9 @@ def build_seed_dag(
     qi_parsing_mode: str = "lorien-only",
     qi_mine_output_type: str = "json",
     lake_provider: str = "aws",
+    mode: RunMode = RunMode.DIRECT,
+    agent: AgentSpec | None = None,
+    database: DatabaseSpec | None = None,
 ) -> dict[str, Any]:
     """Build a seed-version DAG matching the connector's manifest.json shape.
 
@@ -149,6 +152,43 @@ def build_seed_dag(
     if extract_workflow_type is None:
         extract_workflow_type = connector_short_name
 
+    # The orchestrator's `submit=true` endpoint substitutes only the
+    # placeholder fields it knows about (`{{credentialGuid}}`) when
+    # creating the new version — it does NOT rewrite extraction_method
+    # or agent_json from the submit's parameters. So if the seed
+    # hardcodes `extraction_method: direct` and `agent_json` is
+    # missing, the new version inherits that shape and the runtime
+    # CredentialRef.resolve() falls through to guid mode (since
+    # agent_spec is None) → tries to look up '__placeholder__' →
+    # AAF-CRD-002. Mirror the submit's mode in the seed.
+    extract_args: dict[str, Any] = {
+        "credential_guid": "__placeholder__",
+        "connection": {
+            "connection_name": connection.name,
+            "connection_qualified_name": connection.qualified_name,
+        },
+        "extraction_method": mode.value,
+        "include_filter": "",
+        "exclude_filter": "",
+        "temp_table_regex": "",
+    }
+    if mode is RunMode.AGENT and agent is not None and database is not None:
+        # Same agent-json shape build_ae_payload uses for the submit
+        # parameter — keeps the seed consistent with the new version
+        # so the activity input has a populated agent_spec.
+        extract_args["agent_json"] = {
+            "host": database.host,
+            "port": database.port,
+            "auth-type": database.auth_type,
+            "agent-name": agent.agent_name,
+            "agent-type": agent.agent_type,
+            "key-type": agent.key_type,
+            "aws-auth-method": agent.aws_auth_method,
+            "azure-auth-method": agent.azure_auth_method,
+            "basic.username": f"SDR_{connector_short_name.upper()}_USERNAME",
+            "basic.password": f"SDR_{connector_short_name.upper()}_PASSWORD",
+        }
+
     return {
         "extract": {
             "node_type": "workflow",
@@ -159,17 +199,7 @@ def build_seed_dag(
             "inputs": {
                 "workflow_type": extract_workflow_type,
                 "task_queue": extract_task_queue,
-                "args": {
-                    "credential_guid": "__placeholder__",
-                    "connection": {
-                        "connection_name": connection.name,
-                        "connection_qualified_name": connection.qualified_name,
-                    },
-                    "extraction_method": "direct",
-                    "include_filter": "",
-                    "exclude_filter": "",
-                    "temp_table_regex": "",
-                },
+                "args": extract_args,
             },
         },
         "qi": {

--- a/application_sdk/testing/full_dag/payload.py
+++ b/application_sdk/testing/full_dag/payload.py
@@ -112,6 +112,160 @@ class AgentSpec:
     azure_auth_method: str = "managed_identity"
 
 
+def build_seed_dag(
+    *,
+    connector_short_name: str,
+    extract_task_queue: str,
+    publish_task_queue: str = "atlan-publish-production",
+    qi_task_queue: str = "atlan-query-intelligence-production",
+    lineage_task_queue: str = "atlan-lineage-production",
+    connection: ConnectionSpec,
+    extract_workflow_type: str | None = None,
+    qi_parsing_mode: str = "lorien-only",
+    qi_mine_output_type: str = "json",
+    lake_provider: str = "aws",
+) -> dict[str, Any]:
+    """Build a seed-version DAG matching the connector's manifest.json shape.
+
+    Workflows need at least one PUBLISHED version before package-
+    workflows submit will accept them; the seed version is a no-op
+    placeholder (uses ``credential_guid: __placeholder__``) that
+    package-workflows replaces on every submit. What matters for the
+    seed is that the DAG topology + task_queue references are correct
+    — the actual extract args get overridden at submit time.
+
+    Per-connector overrides (subclasses can pass via kwargs):
+        - ``extract_workflow_type`` — defaults to
+          ``{connector_short_name}-metadata-extractor`` for SQL-style
+          connectors; override for non-SQL apps.
+        - ``qi_parsing_mode`` — ``"lorien-only"`` (mssql) vs.
+          ``"competitive"`` (mysql per devex sample); driven by what
+          the connector emits as parseable SQL.
+        - Task queue names default to the tenant's production publish/
+          qi/lineage queues; override for non-production tenants.
+    """
+    if extract_workflow_type is None:
+        extract_workflow_type = f"{connector_short_name}-metadata-extractor"
+
+    return {
+        "extract": {
+            "node_type": "workflow",
+            "activity_name": "execute_workflow",
+            "activity_display_name": f"Extract {connector_short_name.title()} Metadata",
+            "app_name": connector_short_name,
+            "app_task_queue": extract_task_queue,
+            "inputs": {
+                "workflow_type": extract_workflow_type,
+                "task_queue": extract_task_queue,
+                "args": {
+                    "credential_guid": "__placeholder__",
+                    "connection": {
+                        "connection_name": connection.name,
+                        "connection_qualified_name": connection.qualified_name,
+                    },
+                    "extraction_method": "direct",
+                    "include_filter": "",
+                    "exclude_filter": "",
+                    "temp_table_regex": "",
+                },
+            },
+        },
+        "qi": {
+            "node_type": "workflow",
+            "activity_name": "execute_workflow",
+            "activity_display_name": "Parse View Lineage",
+            "app_name": "query-intelligence",
+            "app_task_queue": qi_task_queue,
+            "inputs": {
+                "workflow_type": "QueryIntelligenceWorkflow",
+                "task_queue": qi_task_queue,
+                "args": {
+                    "connection_qualified_name": "$.extract.outputs.connection_qualified_name",
+                    "vendor_name": connector_short_name,
+                    "sql_key": "attributes.definition",
+                    "catalog_key": "attributes.databaseName",
+                    "schema_key": "attributes.schemaName",
+                    "timestamp_key": "",
+                    "mine_output_type": qi_mine_output_type,
+                    "parsing_mode": qi_parsing_mode,
+                    "lake_provider": lake_provider,
+                    "storage_bucket": "$.extract.outputs.storage_bucket",
+                    "input_prefix": "$.extract.outputs.view_data_prefix",
+                    "output_prefix": "$.extract.outputs.view_lineage_output_prefix",
+                },
+            },
+            "depends_on": {"node_id": "extract"},
+        },
+        "publish": {
+            "node_type": "workflow",
+            "activity_name": "execute_workflow",
+            "activity_display_name": "Publish to Atlas",
+            "app_name": "publish",
+            "app_task_queue": publish_task_queue,
+            "inputs": {
+                "workflow_type": "PublishWorkflow",
+                "task_queue": publish_task_queue,
+                "args": {
+                    "connection_qualified_name": "$.extract.outputs.connection_qualified_name",
+                    "transformed_data_prefix": "$.extract.outputs.transformed_data_prefix",
+                    "publish_state_prefix": "$.extract.outputs.publish_state_prefix",
+                    "current_state_prefix": "$.extract.outputs.current_state_prefix",
+                },
+            },
+            "depends_on": {"node_id": "extract"},
+        },
+        "lineage-app": {
+            "node_type": "workflow",
+            "activity_name": "execute_workflow",
+            "activity_display_name": "Build Lineage Entities",
+            "app_name": "automation-engine",
+            "app_task_queue": lineage_task_queue,
+            "inputs": {
+                "workflow_type": "LineageWorkflow",
+                "task_queue": lineage_task_queue,
+                "args": {
+                    "connection_qualified_name": "$.extract.outputs.connection_qualified_name",
+                    "connector_name": connector_short_name,
+                    "session_key": "view-lineage",
+                    "sql_unquoted_case": "lower",
+                    "ignore_all_case": False,
+                    "input_path": "",
+                    "parsed_views_path": "$.extract.outputs.view_lineage_output_prefix",
+                    "lineage_output_path": "$.extract.outputs.lineage_stage_prefix",
+                    "cache_path": "connection-cache",
+                    "file_type": "json",
+                    "lake_provider": lake_provider,
+                    "cloud_storage_bucket": "$.extract.outputs.storage_bucket",
+                },
+            },
+            "depends_on": {
+                "and_conditions": [
+                    {"node_id": "qi", "tag": "success"},
+                    {"node_id": "publish", "tag": "success"},
+                ]
+            },
+        },
+        "lineage-publish": {
+            "node_type": "workflow",
+            "activity_name": "execute_workflow",
+            "activity_display_name": "Publish Lineage to Atlas",
+            "app_name": "publish",
+            "app_task_queue": publish_task_queue,
+            "inputs": {
+                "workflow_type": "PublishWorkflow",
+                "task_queue": publish_task_queue,
+                "args": {
+                    "connection_qualified_name": "$.extract.outputs.connection_qualified_name",
+                    "transformed_data_prefix": "$.extract.outputs.lineage_stage_prefix",
+                    "publish_state_prefix": "$.extract.outputs.lineage_publish_state_prefix",
+                    "current_state_prefix": "$.extract.outputs.lineage_current_state_prefix",
+                },
+            },
+            "depends_on": {"node_id": "lineage-app", "tag": "success"},
+        },
+    }
+
+
 def build_ae_payload(
     *,
     run_id: int,

--- a/application_sdk/testing/full_dag/sql_app.py
+++ b/application_sdk/testing/full_dag/sql_app.py
@@ -32,11 +32,7 @@ import os
 from typing import ClassVar
 
 from application_sdk.testing.full_dag.base import BaseFullDAGE2ETest
-from application_sdk.testing.full_dag.payload import (
-    AgentSpec,
-    ConnectionSpec,
-    RunMode,
-)
+from application_sdk.testing.full_dag.payload import AgentSpec, ConnectionSpec, RunMode
 
 
 class SQLAppE2EFullTest(BaseFullDAGE2ETest):

--- a/application_sdk/testing/full_dag/sql_app.py
+++ b/application_sdk/testing/full_dag/sql_app.py
@@ -1,0 +1,147 @@
+"""Mid-level base class for SQL-app full-DAG e2e tests.
+
+Sits between :class:`BaseFullDAGE2ETest` and the per-connector test
+classes, capturing the boilerplate every SQL connector needs:
+
+* :meth:`agent_spec` — derives a unique-per-run agent name from
+  ``connector_short_name`` + ``connection_name_prefix`` + ``run_id``,
+  so each CI run gets its own Temporal queue.
+* :meth:`connection_spec` — resolves the tenant's ``$admin`` role
+  GUID via pyatlan's ``role_cache`` so the API-key service account
+  ends up on the Connection's admin ACL. Without this every back-
+  side probe ATLAS-403-00-001s.
+
+Subclasses provide:
+
+* The identity attrs (``connector_short_name``, ``argo_package_name``,
+  ``argo_template_name``).
+* Connector-specific knobs (``include_filter``,
+  ``qi_input_prefix_field``, ``expected_min_asset_counts``).
+* :meth:`database_spec` returning a :class:`DatabaseSpec` — the host /
+  port / credentials of the sibling DB the compose overlay brought up.
+
+Most concrete connector test classes shrink to ~15 lines once they
+extend this. The :class:`BaseFullDAGE2ETest` parent remains the
+canonical entry point for connector tests that aren't SQL (REST, file-
+based, event-driven, etc.) — only the SQL-specific defaults live here.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import ClassVar
+
+from application_sdk.testing.full_dag.base import BaseFullDAGE2ETest
+from application_sdk.testing.full_dag.payload import (
+    AgentSpec,
+    ConnectionSpec,
+    RunMode,
+)
+
+
+class SQLAppE2EFullTest(BaseFullDAGE2ETest):
+    """Full-DAG e2e harness pre-wired for SQL connectors.
+
+    Most concrete connector tests end up looking like this:
+
+    .. code-block:: python
+
+        class TestMySQLFullDAG(SQLAppE2EFullTest):
+            connector_short_name = "mysql"
+            argo_package_name = "@atlan/mysql"
+            argo_template_name = "atlan-mysql"
+            mode = RunMode.AGENT
+            app_service_url = "http://mysql.mysql-app.svc.cluster.local"
+
+            include_filter = r"^def\\.e2e_main$"
+            qi_input_prefix_field = "transformed_data_prefix"
+            expected_min_asset_counts = {
+                "Database": 1, "Schema": 1, "Table": 2, "View": 1, "Column": 10,
+            }
+
+            def database_spec(self) -> DatabaseSpec:
+                return DatabaseSpec(
+                    host="mysql", port=3306,
+                    username="e2e_user", password="e2e_pass",
+                    connector_config_name="atlan-connectors-mysql",
+                )
+
+    Everything else (agent_spec, connection_spec, the $admin role
+    resolution) is inherited from this class.
+    """
+
+    # Connection ACL — the API-key service account that runs the
+    # back-side probe gets onto the Connection via the ``$admin`` role
+    # resolved at run time by :meth:`connection_spec`. Override these
+    # to add tenant-specific human-debug ACLs if needed; the role
+    # path handles the harness-itself case.
+    connection_admin_users: ClassVar[tuple[str, ...]] = ()
+    connection_admin_groups: ClassVar[tuple[str, ...]] = ()
+
+    # Workflow-agent name template applied when :meth:`agent_spec`
+    # runs in AGENT mode. The default formats as
+    # ``{connector}-{prefix}-{run_id}`` (matches what the Argo
+    # cluster template expects: ``task_queue =
+    # atlan-{agent_name}``, with the connector prefix carried on the
+    # agent name itself). Override only if your connector's Argo
+    # template uses a different naming convention.
+    agent_name_template: ClassVar[str] = "{connector}-{prefix}-{run_id}"
+
+    def agent_spec(self) -> AgentSpec | None:
+        """Default AGENT-mode agent identity, or None in DIRECT mode."""
+        if self.mode is RunMode.DIRECT:
+            return None
+        return AgentSpec(
+            agent_name=self.agent_name_template.format(
+                connector=self.connector_short_name,
+                prefix=self.connection_name_prefix,
+                run_id=self.run_id,
+            )
+        )
+
+    def connection_spec(self) -> ConnectionSpec:
+        """Connection identity with ``$admin`` role on the admin ACL.
+
+        Resolves the tenant's ``$admin`` role GUID at run time so the
+        API-key service account (which carries that role by default)
+        can read the Connection back via direct entity-fetch — see
+        :func:`AEWorkflowClient.connection_exists_in_atlas_via_search`
+        for the search-based fallback we use in the poll loop.
+        """
+        if not hasattr(self, "_admin_role_guid"):
+            self._admin_role_guid = self._resolve_admin_role_guid()
+        return ConnectionSpec(
+            name=self.connection_display_name,
+            qualified_name=self.connection_qualified_name,
+            connector_name=self.connector_short_name,
+            source_logo=(
+                f"https://assets.atlan.com/assets/{self.connector_short_name}.png"
+            ),
+            admin_users=self.connection_admin_users,
+            admin_groups=self.connection_admin_groups,
+            admin_roles=(self._admin_role_guid,),
+        )
+
+    @staticmethod
+    def _resolve_admin_role_guid() -> str:
+        """Look up the tenant's ``$admin`` role GUID via pyatlan.
+
+        Raises a remediation-pointing ``RuntimeError`` if the role
+        doesn't exist on the tenant — ``$admin`` is a built-in Atlan
+        role so this only fires on a misconfigured tenant.
+        """
+        from pyatlan.client.atlan import AtlanClient  # noqa: PLC0415
+
+        client = AtlanClient(
+            base_url=os.environ["ATLAN_BASE_URL"],
+            api_key=os.environ["ATLAN_API_KEY"],
+        )
+        guid = client.role_cache.get_id_for_name("$admin")
+        if guid is None:
+            raise RuntimeError(
+                "pyatlan role_cache could not resolve `$admin` role GUID "
+                f"against {os.environ['ATLAN_BASE_URL']} — Connection "
+                "would land with empty adminRoles and the back-side "
+                "direct-fetch probe would 403."
+            )
+        return guid

--- a/application_sdk/testing/integration/validation.py
+++ b/application_sdk/testing/integration/validation.py
@@ -32,9 +32,6 @@ from glob import glob
 from typing import Any, Dict, List
 
 import orjson
-import pandas as pd
-import pandera.extensions as extensions
-from pandera.io import from_yaml  # pyright: ignore[reportPrivateImportUsage]
 
 from application_sdk.observability.logger_adaptor import get_logger
 
@@ -44,34 +41,51 @@ logger = get_logger(__name__)
 # =============================================================================
 # Custom Pandera Check Methods
 # =============================================================================
+#
+# pandera + pandas are heavy optional deps. Importing them at module load
+# time forces every consumer of application_sdk.testing.integration to
+# install them, which then chains into SDR test modules that don't use
+# pandera at all (pytest.importorskip catches the resulting ImportError
+# and silently skips all tests — see BLDX-1254). Defer the imports and
+# the check-method registration to the first validate_with_pandera()
+# call instead.
+
+_pandera_check_method_registered = False
 
 
-@extensions.register_check_method(statistics=["expected_record_count"])  # pyright: ignore[reportPrivateImportUsage]
-def check_record_count_ge(df: pd.DataFrame, *, expected_record_count: int) -> bool:
-    """Validate that a DataFrame has at least the expected number of records.
+def _ensure_pandera_check_methods_registered() -> None:
+    """Register custom pandera check methods on first use.
 
-    This is registered as a custom pandera check method that can be used
-    in YAML schema files:
-
-        checks:
-          check_record_count_ge:
-            expected_record_count: 10
-
-    Args:
-        df: The DataFrame to validate.
-        expected_record_count: Minimum expected row count.
-
-    Returns:
-        bool: True if the record count is sufficient.
-
-    Raises:
-        ValueError: If the record count is below the expected minimum.
+    pandera.extensions.register_check_method is idempotent-safe (each
+    method name registers once); the module-level boolean is purely to
+    avoid the import-once-per-call overhead.
     """
-    if df.shape[0] >= expected_record_count:
-        return True
-    raise ValueError(
-        f"Expected record count >= {expected_record_count}, got: {df.shape[0]}"
-    )
+    global _pandera_check_method_registered
+    if _pandera_check_method_registered:
+        return
+
+    import pandera.extensions as extensions  # noqa: PLC0415
+
+    @extensions.register_check_method(statistics=["expected_record_count"])  # pyright: ignore[reportPrivateImportUsage]
+    def check_record_count_ge(df: Any, *, expected_record_count: int) -> bool:
+        """Validate that a DataFrame has at least the expected number of records.
+
+        Registered as a custom pandera check usable from YAML schema files::
+
+            checks:
+              check_record_count_ge:
+                expected_record_count: 10
+
+        Raises:
+            ValueError: If the record count is below the expected minimum.
+        """
+        if df.shape[0] >= expected_record_count:
+            return True
+        raise ValueError(
+            f"Expected record count >= {expected_record_count}, got: {df.shape[0]}"
+        )
+
+    _pandera_check_method_registered = True
 
 
 # =============================================================================
@@ -79,11 +93,14 @@ def check_record_count_ge(df: pd.DataFrame, *, expected_record_count: int) -> bo
 # =============================================================================
 
 
-def get_normalised_dataframe(extracted_file_path: str) -> pd.DataFrame:
+def get_normalised_dataframe(extracted_file_path: str) -> Any:
     """Read extracted output files and normalize into a DataFrame.
 
     Supports JSON (line-delimited) and Parquet files. All files in the
     directory tree are merged into a single DataFrame.
+
+    pandas is imported lazily — see the note in
+    :func:`_ensure_pandera_check_methods_registered`.
 
     Args:
         extracted_file_path: Directory containing extracted output files.
@@ -94,6 +111,8 @@ def get_normalised_dataframe(extracted_file_path: str) -> pd.DataFrame:
     Raises:
         FileNotFoundError: If no data files are found.
     """
+    import pandas as pd  # noqa: PLC0415
+
     data: List[Dict[str, Any]] = []
 
     # Search for JSON and parquet files
@@ -185,6 +204,16 @@ def validate_with_pandera(
     """
     if not os.path.exists(schema_base_path):
         raise FileNotFoundError(f"Schema base path not found: {schema_base_path}")
+
+    # Lazy import — keeps the module importable without pandera installed
+    # (see module docstring + _ensure_pandera_check_methods_registered).
+    # Import from pandera.io.pandas_io (the canonical export path) so
+    # pyright doesn't flag reportPrivateImportUsage on pandera.io.
+    from pandera.io.pandas_io import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+        from_yaml,
+    )
+
+    _ensure_pandera_check_methods_registered()
 
     schema_files = get_schema_file_paths(schema_base_path)
     results: List[Dict[str, Any]] = []

--- a/tests/unit/testing/full_dag/test_base.py
+++ b/tests/unit/testing/full_dag/test_base.py
@@ -110,6 +110,10 @@ def _bootstrap_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     monkeypatch.setenv("ATLAN_BASE_URL", "https://test.example.invalid")
     monkeypatch.setenv("ATLAN_API_KEY", "test-token")
+    monkeypatch.delenv("SDR_OAUTH_CLIENT_ID", raising=False)
+    monkeypatch.delenv("SDR_OAUTH_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("ATLAN_AUTH_CLIENT_ID", raising=False)
+    monkeypatch.delenv("ATLAN_AUTH_CLIENT_SECRET", raising=False)
     monkeypatch.setenv("GITHUB_RUN_ID", "9999999")
 
 

--- a/tests/unit/testing/full_dag/test_base.py
+++ b/tests/unit/testing/full_dag/test_base.py
@@ -110,10 +110,6 @@ def _bootstrap_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     monkeypatch.setenv("ATLAN_BASE_URL", "https://test.example.invalid")
     monkeypatch.setenv("ATLAN_API_KEY", "test-token")
-    monkeypatch.delenv("SDR_OAUTH_CLIENT_ID", raising=False)
-    monkeypatch.delenv("SDR_OAUTH_CLIENT_SECRET", raising=False)
-    monkeypatch.delenv("ATLAN_AUTH_CLIENT_ID", raising=False)
-    monkeypatch.delenv("ATLAN_AUTH_CLIENT_SECRET", raising=False)
     monkeypatch.setenv("GITHUB_RUN_ID", "9999999")
 
 

--- a/tests/unit/testing/full_dag/test_base.py
+++ b/tests/unit/testing/full_dag/test_base.py
@@ -14,10 +14,7 @@ from typing import Any
 import pytest
 
 from application_sdk.testing.full_dag import BaseFullDAGE2ETest, RunMode
-from application_sdk.testing.full_dag.payload import (
-    AgentSpec,
-    DatabaseSpec,
-)
+from application_sdk.testing.full_dag.payload import AgentSpec, DatabaseSpec
 
 # Minimum-viable manifest mirroring the mysql-app shape with `{app_name}`
 # and `{deployment_name}` placeholders intact. Used by tests that want
@@ -130,9 +127,7 @@ def test_seed_dag_from_manifest_substitutes_app_name(
     instance = cls()
     instance.setup_method()
 
-    dag = instance._seed_dag_from_manifest(
-        extract_task_queue="atlan-mysql-test-queue"
-    )
+    dag = instance._seed_dag_from_manifest(extract_task_queue="atlan-mysql-test-queue")
 
     assert dag["extract"]["app_name"] == "mysql"
     assert dag["extract"]["inputs"]["app_name"] == "mysql"
@@ -153,13 +148,8 @@ def test_seed_dag_substitutes_deployment_name_per_node(
         extract_task_queue="atlan-mysql-e2e-full-ci-9999999"
     )
 
-    assert (
-        dag["extract"]["inputs"]["task_queue"] == "atlan-mysql-e2e-full-ci-9999999"
-    )
-    assert (
-        dag["qi"]["inputs"]["task_queue"]
-        == "atlan-query-intelligence-production"
-    )
+    assert dag["extract"]["inputs"]["task_queue"] == "atlan-mysql-e2e-full-ci-9999999"
+    assert dag["qi"]["inputs"]["task_queue"] == "atlan-query-intelligence-production"
     assert dag["publish"]["inputs"]["task_queue"] == "atlan-publish-production"
     # Default tenant_deployment_name = production. No literal {deployment_name}
     # template strings should leak.
@@ -176,9 +166,7 @@ def test_seed_dag_tenant_deployment_name_override(
     instance = cls()
     instance.setup_method()
 
-    dag = instance._seed_dag_from_manifest(
-        extract_task_queue="atlan-mysql-test"
-    )
+    dag = instance._seed_dag_from_manifest(extract_task_queue="atlan-mysql-test")
 
     assert dag["qi"]["inputs"]["task_queue"] == "atlan-query-intelligence-staging"
     assert dag["publish"]["inputs"]["task_queue"] == "atlan-publish-staging"
@@ -318,8 +306,7 @@ def test_seed_dag_substitution_only_replaces_exact_mustache_keys(
     dag = instance._seed_dag_from_manifest(extract_task_queue="atlan-mysql-test")
     # The substring-containing label is left as-is
     assert (
-        dag["extract"]["inputs"]["args"]["some_label"]
-        == "label-{{connection}}-suffix"
+        dag["extract"]["inputs"]["args"]["some_label"] == "label-{{connection}}-suffix"
     )
     # And the exact-match Mustache field WAS substituted
     assert isinstance(dag["extract"]["inputs"]["args"]["connection"], dict)
@@ -337,10 +324,7 @@ def test_seed_dag_credential_guid_forwards_to_ae(
     instance.setup_method()
 
     dag = instance._seed_dag_from_manifest(extract_task_queue="atlan-mysql-test")
-    assert (
-        dag["extract"]["inputs"]["args"]["credential_guid"]
-        == "{{credentialGuid}}"
-    )
+    assert dag["extract"]["inputs"]["args"]["credential_guid"] == "{{credentialGuid}}"
 
 
 def test_seed_dag_substitution_walks_nested_lists(

--- a/tests/unit/testing/full_dag/test_base.py
+++ b/tests/unit/testing/full_dag/test_base.py
@@ -1,0 +1,303 @@
+"""Unit tests for the BaseFullDAGE2ETest manifest-loading + substitution logic.
+
+Network-free. Exercises only the seed-DAG plumbing — the HTTP-driven
+flow (`run_full_dag`, AE submit + poll, Atlas probe) is covered by
+``test_client.py`` against mocked transports.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from application_sdk.testing.full_dag import BaseFullDAGE2ETest, RunMode
+from application_sdk.testing.full_dag.payload import (
+    AgentSpec,
+    DatabaseSpec,
+)
+
+# Minimum-viable manifest mirroring the mysql-app shape with `{app_name}`
+# and `{deployment_name}` placeholders intact. Used by tests that want
+# to verify substitution semantics in isolation.
+_MANIFEST: dict[str, Any] = {
+    "execution_mode": "automation-engine",
+    "dag": {
+        "extract": {
+            "activity_name": "execute_workflow",
+            "activity_display_name": "Extract MySQL Metadata",
+            "app_name": "{app_name}",
+            "inputs": {
+                "workflow_type": "mysql",
+                "app_name": "{app_name}",
+                "task_queue": "atlan-mysql-{deployment_name}",
+                "args": {
+                    "credential_guid": "{{credential-guid}}",
+                    "connection": "{{connection}}",
+                    "include_filter": "{{include-filter}}",
+                },
+            },
+        },
+        "qi": {
+            "activity_name": "execute_workflow",
+            "app_name": "automation-engine",
+            "inputs": {
+                "workflow_type": "QueryIntelligenceWorkflow",
+                "task_queue": "atlan-query-intelligence-{deployment_name}",
+                "args": {
+                    "connection_qualified_name": "$.extract.outputs.connection_qualified_name",
+                    "input_prefix": "$.extract.outputs.transformed_data_prefix",
+                },
+            },
+            "depends_on": {"node_id": "extract"},
+        },
+        "publish": {
+            "activity_name": "execute_workflow",
+            "app_name": "publish",
+            "inputs": {
+                "workflow_type": "PublishWorkflow",
+                "task_queue": "atlan-publish-{deployment_name}",
+                "args": {
+                    "connection_qualified_name": "$.extract.outputs.connection_qualified_name",
+                    "connection_creation_enabled": True,
+                    "executor_enabled": True,
+                    "connection_entity": "{{connection}}",
+                    "connection_cache_enabled": True,
+                },
+            },
+            "depends_on": {"node_id": "extract"},
+        },
+    },
+}
+
+
+def _make_test(manifest_path: str = "app/generated/manifest.json"):
+    """Build a runnable subclass with minimal required fields stubbed."""
+
+    class _Concrete(BaseFullDAGE2ETest):
+        connector_short_name = "mysql"
+        argo_package_name = "@atlan/mysql"
+        argo_template_name = "atlan-mysql"
+        mode = RunMode.AGENT
+        app_service_url = "http://mysql.mysql-app.svc.cluster.local"
+
+    _Concrete.manifest_path = manifest_path
+
+    def database_spec(self):
+        return DatabaseSpec(host="mysql", port=3306, username="u", password="p")
+
+    def agent_spec(self):
+        return AgentSpec(agent_name="mysql-test")
+
+    _Concrete.database_spec = database_spec
+    _Concrete.agent_spec = agent_spec
+    return _Concrete
+
+
+def _bootstrap_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set the env the base class' setup_method requires.
+
+    Manifest tests don't need a real tenant; the env vars only have to
+    be non-empty so :meth:`setup_method` doesn't bail.
+    """
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://test.example.invalid")
+    monkeypatch.setenv("ATLAN_API_KEY", "test-token")
+    monkeypatch.setenv("GITHUB_RUN_ID", "9999999")
+
+
+@pytest.fixture
+def manifest_file(tmp_path: Path) -> Path:
+    """Write the canonical manifest fixture into a tmp file and return its path."""
+    p = tmp_path / "manifest.json"
+    p.write_text(json.dumps(_MANIFEST))
+    return p
+
+
+def test_seed_dag_from_manifest_substitutes_app_name(
+    manifest_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``{app_name}`` is filled with ``connector_short_name`` everywhere it appears."""
+    _bootstrap_env(monkeypatch)
+    cls = _make_test(str(manifest_file))
+    instance = cls()
+    instance.setup_method()
+
+    dag = instance._seed_dag_from_manifest(
+        extract_task_queue="atlan-mysql-test-queue"
+    )
+
+    assert dag["extract"]["app_name"] == "mysql"
+    assert dag["extract"]["inputs"]["app_name"] == "mysql"
+    # No leftover {app_name} anywhere
+    assert "{app_name}" not in json.dumps(dag)
+
+
+def test_seed_dag_substitutes_deployment_name_per_node(
+    manifest_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Extract uses CI queue; everything else uses ``tenant_deployment_name``."""
+    _bootstrap_env(monkeypatch)
+    cls = _make_test(str(manifest_file))
+    instance = cls()
+    instance.setup_method()
+
+    dag = instance._seed_dag_from_manifest(
+        extract_task_queue="atlan-mysql-e2e-full-ci-9999999"
+    )
+
+    assert (
+        dag["extract"]["inputs"]["task_queue"] == "atlan-mysql-e2e-full-ci-9999999"
+    )
+    assert (
+        dag["qi"]["inputs"]["task_queue"]
+        == "atlan-query-intelligence-production"
+    )
+    assert dag["publish"]["inputs"]["task_queue"] == "atlan-publish-production"
+    # Default tenant_deployment_name = production. No literal {deployment_name}
+    # template strings should leak.
+    assert "{deployment_name}" not in json.dumps(dag)
+
+
+def test_seed_dag_tenant_deployment_name_override(
+    manifest_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Override ``tenant_deployment_name`` to land on a non-prod tenant queue."""
+    _bootstrap_env(monkeypatch)
+    cls = _make_test(str(manifest_file))
+    cls.tenant_deployment_name = "staging"
+    instance = cls()
+    instance.setup_method()
+
+    dag = instance._seed_dag_from_manifest(
+        extract_task_queue="atlan-mysql-test"
+    )
+
+    assert dag["qi"]["inputs"]["task_queue"] == "atlan-query-intelligence-staging"
+    assert dag["publish"]["inputs"]["task_queue"] == "atlan-publish-staging"
+
+
+def test_seed_dag_preserves_mustache_placeholders(
+    manifest_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AE-substituted ``{{...}}`` placeholders must reach AE intact."""
+    _bootstrap_env(monkeypatch)
+    cls = _make_test(str(manifest_file))
+    instance = cls()
+    instance.setup_method()
+
+    dag = instance._seed_dag_from_manifest(
+        extract_task_queue="atlan-mysql-test"
+    )
+
+    extract_args = dag["extract"]["inputs"]["args"]
+    assert extract_args["credential_guid"] == "{{credential-guid}}"
+    assert extract_args["connection"] == "{{connection}}"
+    assert extract_args["include_filter"] == "{{include-filter}}"
+    assert dag["publish"]["inputs"]["args"]["connection_entity"] == "{{connection}}"
+
+
+def test_seed_dag_preserves_publish_creation_flags(
+    manifest_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All six publish flags carry through untouched — regression guard for
+    the silent-update-only-mode bug we hit on run 25788289284."""
+    _bootstrap_env(monkeypatch)
+    cls = _make_test(str(manifest_file))
+    instance = cls()
+    instance.setup_method()
+
+    dag = instance._seed_dag_from_manifest(extract_task_queue="atlan-mysql-test")
+
+    pub_args = dag["publish"]["inputs"]["args"]
+    assert pub_args["connection_creation_enabled"] is True
+    assert pub_args["executor_enabled"] is True
+    assert pub_args["connection_cache_enabled"] is True
+    # connection_entity stays as the Mustache placeholder for AE to fill
+    assert pub_args["connection_entity"] == "{{connection}}"
+
+
+def test_seed_dag_preserves_jsonpath_extract_outputs(
+    manifest_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``$.extract.outputs.X`` references must reach AE intact (AE resolves them)."""
+    _bootstrap_env(monkeypatch)
+    cls = _make_test(str(manifest_file))
+    instance = cls()
+    instance.setup_method()
+
+    dag = instance._seed_dag_from_manifest(extract_task_queue="atlan-mysql-test")
+
+    assert (
+        dag["qi"]["inputs"]["args"]["connection_qualified_name"]
+        == "$.extract.outputs.connection_qualified_name"
+    )
+    assert (
+        dag["publish"]["inputs"]["args"]["connection_qualified_name"]
+        == "$.extract.outputs.connection_qualified_name"
+    )
+
+
+def test_seed_dag_preserves_depends_on(
+    manifest_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``depends_on`` blocks pass through untouched."""
+    _bootstrap_env(monkeypatch)
+    cls = _make_test(str(manifest_file))
+    instance = cls()
+    instance.setup_method()
+
+    dag = instance._seed_dag_from_manifest(extract_task_queue="atlan-mysql-test")
+
+    assert dag["qi"]["depends_on"] == {"node_id": "extract"}
+    assert dag["publish"]["depends_on"] == {"node_id": "extract"}
+
+
+def test_seed_dag_missing_manifest_raises_clear_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing manifest file surfaces a remediation-pointing RuntimeError."""
+    _bootstrap_env(monkeypatch)
+    cls = _make_test(str(tmp_path / "does-not-exist.json"))
+    instance = cls()
+    instance.setup_method()
+
+    with pytest.raises(RuntimeError, match="Manifest file not found"):
+        instance._seed_dag_from_manifest(extract_task_queue="atlan-mysql-test")
+
+
+def test_seed_dag_malformed_manifest_raises_clear_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Manifest without a top-level ``dag`` block fails loud, not silent."""
+    _bootstrap_env(monkeypatch)
+    p = tmp_path / "manifest.json"
+    p.write_text(json.dumps({"execution_mode": "automation-engine"}))
+    cls = _make_test(str(p))
+    instance = cls()
+    instance.setup_method()
+
+    with pytest.raises(RuntimeError, match="no top-level `dag` object"):
+        instance._seed_dag_from_manifest(extract_task_queue="atlan-mysql-test")
+
+
+def test_seed_dag_relative_path_resolved_against_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A relative ``manifest_path`` is resolved against the test's cwd —
+    matches how the harness is invoked from a connector repo root."""
+    _bootstrap_env(monkeypatch)
+    # Put the manifest under a synthetic "connector repo" subdir.
+    repo = tmp_path / "connector-repo"
+    (repo / "app/generated").mkdir(parents=True)
+    (repo / "app/generated/manifest.json").write_text(json.dumps(_MANIFEST))
+    monkeypatch.chdir(repo)
+
+    cls = _make_test()  # default 'app/generated/manifest.json'
+    instance = cls()
+    instance.setup_method()
+
+    dag = instance._seed_dag_from_manifest(extract_task_queue="atlan-mysql-test")
+    assert "extract" in dag
+    assert dag["extract"]["app_name"] == "mysql"

--- a/tests/unit/testing/full_dag/test_base.py
+++ b/tests/unit/testing/full_dag/test_base.py
@@ -34,9 +34,15 @@ _MANIFEST: dict[str, Any] = {
                 "app_name": "{app_name}",
                 "task_queue": "atlan-mysql-{deployment_name}",
                 "args": {
+                    "credential": "{{credential}}",
                     "credential_guid": "{{credential-guid}}",
                     "connection": "{{connection}}",
+                    "extraction_method": "{{extraction-method}}",
+                    "agent_json": "{{agent-json}}",
                     "include_filter": "{{include-filter}}",
+                    "exclude_filter": "{{exclude-filter}}",
+                    "exclude_table_regex": "{{exclude-table-regex}}",
+                    "preflight_check": "{{preflight-check}}",
                 },
             },
         },
@@ -178,31 +184,59 @@ def test_seed_dag_tenant_deployment_name_override(
     assert dag["publish"]["inputs"]["task_queue"] == "atlan-publish-staging"
 
 
-def test_seed_dag_preserves_mustache_placeholders(
+def test_seed_dag_substitutes_mustache_placeholders(
     manifest_file: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """AE-substituted ``{{...}}`` placeholders must reach AE intact."""
+    """Mustache ``{{...}}`` placeholders are filled with runtime values.
+
+    AE does NOT runtime-substitute these in the seed args — they have
+    to be concrete by the time the seed version is published, or the
+    worker receives them as literal placeholder strings and hangs.
+    Only ``{{credentialGuid}}`` (camelCase, set on credential_guid)
+    survives because AE *does* substitute that one from the submit's
+    payload[].body.
+    """
     _bootstrap_env(monkeypatch)
     cls = _make_test(str(manifest_file))
     instance = cls()
     instance.setup_method()
 
-    dag = instance._seed_dag_from_manifest(
-        extract_task_queue="atlan-mysql-test"
-    )
+    dag = instance._seed_dag_from_manifest(extract_task_queue="atlan-mysql-test")
 
     extract_args = dag["extract"]["inputs"]["args"]
-    assert extract_args["credential_guid"] == "{{credential-guid}}"
-    assert extract_args["connection"] == "{{connection}}"
-    assert extract_args["include_filter"] == "{{include-filter}}"
-    assert dag["publish"]["inputs"]["args"]["connection_entity"] == "{{connection}}"
+    # credential_guid forwards to AE via the camelCase placeholder
+    assert extract_args["credential_guid"] == "{{credentialGuid}}"
+    # connection is the full Connection entity, not a placeholder
+    assert isinstance(extract_args["connection"], dict)
+    assert extract_args["connection"]["typeName"] == "Connection"
+    # filter is the literal string the test class configures
+    assert extract_args["include_filter"] == instance.include_filter
+    # extraction_method is filled with the mode value
+    assert extract_args["extraction_method"] == "agent"
+    # agent_json is the actual agent dict in AGENT mode
+    assert isinstance(extract_args["agent_json"], dict)
+    assert extract_args["agent_json"]["agent-name"] == "mysql-test"
+    # publish's connection_entity is the full Connection JSON too
+    assert isinstance(dag["publish"]["inputs"]["args"]["connection_entity"], dict)
+    # No literal {{...}} left anywhere
+    import json as _json
+
+    rendered = _json.dumps(dag)
+    # {{credentialGuid}} is the only acceptable remaining Mustache
+    assert "{{credential-guid}}" not in rendered
+    assert "{{connection}}" not in rendered
+    assert "{{include-filter}}" not in rendered
+    assert "{{extraction-method}}" not in rendered
+    assert "{{agent-json}}" not in rendered
 
 
 def test_seed_dag_preserves_publish_creation_flags(
     manifest_file: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """All six publish flags carry through untouched — regression guard for
-    the silent-update-only-mode bug we hit on run 25788289284."""
+    """All publish flags carry through untouched — regression guard for
+    the silent-update-only-mode bug we hit on run 25788289284. Boolean
+    flags don't get touched by Mustache substitution; only the
+    ``connection_entity`` placeholder is filled."""
     _bootstrap_env(monkeypatch)
     cls = _make_test(str(manifest_file))
     instance = cls()
@@ -214,8 +248,125 @@ def test_seed_dag_preserves_publish_creation_flags(
     assert pub_args["connection_creation_enabled"] is True
     assert pub_args["executor_enabled"] is True
     assert pub_args["connection_cache_enabled"] is True
-    # connection_entity stays as the Mustache placeholder for AE to fill
-    assert pub_args["connection_entity"] == "{{connection}}"
+    # connection_entity is filled with the full Connection JSON
+    assert isinstance(pub_args["connection_entity"], dict)
+    assert pub_args["connection_entity"]["typeName"] == "Connection"
+    attrs = pub_args["connection_entity"]["attributes"]
+    assert attrs["connectorName"] == "mysql"
+    # The QN on the Connection attributes carries the run-stamped id
+    assert attrs["qualifiedName"].startswith("default/mysql/e2e-full-ci-")
+
+
+def test_seed_dag_direct_mode_agent_json_is_null(
+    manifest_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """DIRECT mode (no agent_spec) substitutes ``{{agent-json}}`` with None.
+
+    The worker reads credentials straight from the credential the
+    credential_guid points at, so there's no agent_json bundle to ship.
+    """
+    _bootstrap_env(monkeypatch)
+    cls = _make_test(str(manifest_file))
+    cls.mode = RunMode.DIRECT
+    cls.agent_spec = lambda self: None  # type: ignore[assignment]
+    instance = cls()
+    instance.setup_method()
+
+    dag = instance._seed_dag_from_manifest(extract_task_queue="atlan-mysql-default")
+    extract_args = dag["extract"]["inputs"]["args"]
+    assert extract_args["agent_json"] is None
+    assert extract_args["extraction_method"] == "direct"
+
+
+def test_seed_dag_result_is_json_serialisable(
+    manifest_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The substituted DAG must be a pure JSON tree — it's about to be
+    POSTed as the seed version body. Catches accidentally embedding
+    non-serialisable objects (Enum / dataclass / function) in the subs.
+    """
+    _bootstrap_env(monkeypatch)
+    cls = _make_test(str(manifest_file))
+    instance = cls()
+    instance.setup_method()
+
+    dag = instance._seed_dag_from_manifest(extract_task_queue="atlan-mysql-test")
+    # If this raises TypeError the substitution leaked a non-JSON value
+    rendered = json.dumps(dag)
+    assert len(rendered) > 0
+
+
+def test_seed_dag_substitution_only_replaces_exact_mustache_keys(
+    manifest_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Substring matches inside a longer string are NOT replaced — the
+    substitution only fires on exact ``{{X}}`` string values."""
+    # Add a dummy node arg with a string that *contains* but doesn't
+    # equal a Mustache placeholder. Should be left alone.
+    p = manifest_file
+    raw = json.loads(p.read_text())
+    raw["dag"]["extract"]["inputs"]["args"]["some_label"] = (
+        "label-{{connection}}-suffix"
+    )
+    p.write_text(json.dumps(raw))
+
+    _bootstrap_env(monkeypatch)
+    cls = _make_test(str(p))
+    instance = cls()
+    instance.setup_method()
+
+    dag = instance._seed_dag_from_manifest(extract_task_queue="atlan-mysql-test")
+    # The substring-containing label is left as-is
+    assert (
+        dag["extract"]["inputs"]["args"]["some_label"]
+        == "label-{{connection}}-suffix"
+    )
+    # And the exact-match Mustache field WAS substituted
+    assert isinstance(dag["extract"]["inputs"]["args"]["connection"], dict)
+
+
+def test_seed_dag_credential_guid_forwards_to_ae(
+    manifest_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``{{credential-guid}}`` is the one Mustache we forward — replaced
+    with ``{{credentialGuid}}`` (camelCase) which AE *does* substitute
+    at submit time from the payload[].body credential."""
+    _bootstrap_env(monkeypatch)
+    cls = _make_test(str(manifest_file))
+    instance = cls()
+    instance.setup_method()
+
+    dag = instance._seed_dag_from_manifest(extract_task_queue="atlan-mysql-test")
+    assert (
+        dag["extract"]["inputs"]["args"]["credential_guid"]
+        == "{{credentialGuid}}"
+    )
+
+
+def test_seed_dag_substitution_walks_nested_lists(
+    manifest_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mustache values inside list args are still substituted."""
+    p = manifest_file
+    raw = json.loads(p.read_text())
+    raw["dag"]["extract"]["inputs"]["args"]["nested_list"] = [
+        "{{include-filter}}",
+        "plain-string",
+        ["{{exclude-filter}}", 42],
+    ]
+    p.write_text(json.dumps(raw))
+
+    _bootstrap_env(monkeypatch)
+    cls = _make_test(str(p))
+    instance = cls()
+    instance.setup_method()
+
+    dag = instance._seed_dag_from_manifest(extract_task_queue="atlan-mysql-test")
+    nested = dag["extract"]["inputs"]["args"]["nested_list"]
+    assert nested[0] == instance.include_filter
+    assert nested[1] == "plain-string"
+    assert nested[2][0] == instance.exclude_filter
+    assert nested[2][1] == 42
 
 
 def test_seed_dag_preserves_jsonpath_extract_outputs(

--- a/tests/unit/testing/full_dag/test_client.py
+++ b/tests/unit/testing/full_dag/test_client.py
@@ -163,33 +163,48 @@ def test_poll_native_status_returns_last_observation_on_timeout(
     assert result.status is DAGRunStatus.RUNNING
 
 
-def test_poll_atlas_for_connection_succeeds_on_200(
+def test_poll_atlas_for_connection_succeeds_when_search_finds_it(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """``poll_atlas_for_connection`` returns True as soon as the
+    search-based existence check returns True (indexer may have lagged
+    earlier polls)."""
     monkeypatch.setattr("time.sleep", lambda _: None)
-    client, _ = _make_client(
-        monkeypatch, [(404, ""), (404, ""), (200, {"any": "thing"})]
-    )
+    client, _ = _make_client(monkeypatch, [])
+
+    # Stub the search-based existence check directly — first two polls
+    # return False (indexer lag), third returns True (Connection found).
+    calls = {"n": 0}
+
+    def fake_search(_qn: str) -> bool:
+        calls["n"] += 1
+        return calls["n"] >= 3
+
+    monkeypatch.setattr(client, "connection_exists_in_atlas_via_search", fake_search)
     assert (
         client.poll_atlas_for_connection(
             "default/mysql/test", interval_seconds=1, timeout_seconds=10
         )
         is True
     )
+    assert calls["n"] == 3
 
 
-def test_poll_atlas_for_connection_returns_false_on_timeout(
+def test_poll_atlas_for_connection_bails_after_not_found_streak(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """``max_not_found_attempts`` consecutive empty searches → False fast."""
     monkeypatch.setattr("time.sleep", lambda _: None)
-    client, _ = _make_client(
-        monkeypatch,
-        # interval=1, timeout=2 → 2 polls; both 404 → returns False
-        [(404, ""), (404, "")],
+    client, _ = _make_client(monkeypatch, [])
+    monkeypatch.setattr(
+        client, "connection_exists_in_atlas_via_search", lambda _: False
     )
     assert (
         client.poll_atlas_for_connection(
-            "default/mysql/test", interval_seconds=1, timeout_seconds=2
+            "default/mysql/test",
+            interval_seconds=1,
+            timeout_seconds=1000,
+            max_not_found_attempts_override=3,
         )
         is False
     )

--- a/tests/unit/testing/full_dag/test_client.py
+++ b/tests/unit/testing/full_dag/test_client.py
@@ -1,0 +1,195 @@
+"""Unit tests for :mod:`application_sdk.testing.full_dag.client`.
+
+Network is monkeypatched out at ``_request``; we just verify the parse
++ poll-loop logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from application_sdk.testing.full_dag.client import (
+    AEWorkflowClient,
+    DAGNodeStatus,
+    DAGRunStatus,
+)
+
+
+def _make_client(monkeypatch: pytest.MonkeyPatch, responses: list[tuple[int, Any]]):
+    """Build a client whose ``_request`` returns the queued responses in order."""
+    client = AEWorkflowClient("https://tenant.example.com/", "fake-token")
+    queue = list(responses)
+
+    def fake_request(method, path, *, body=None, timeout=30):  # noqa: ARG001
+        if not queue:
+            raise AssertionError("More HTTP calls than queued responses")
+        return queue.pop(0)
+
+    monkeypatch.setattr(client, "_request", fake_request)
+    return client, queue
+
+
+def test_submit_workflow_extracts_run_id_from_top_level(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _ = _make_client(monkeypatch, [(200, {"run_id": "abc-123"})])
+    assert client.submit_workflow({"any": "payload"}) == "abc-123"
+
+
+def test_submit_workflow_extracts_run_id_from_nested_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _ = _make_client(monkeypatch, [(200, {"data": {"run_id": "nested-xyz"}})])
+    assert client.submit_workflow({}) == "nested-xyz"
+
+
+def test_submit_workflow_raises_on_missing_run_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _ = _make_client(monkeypatch, [(200, {"data": {}})])
+    with pytest.raises(RuntimeError, match="no run_id"):
+        client.submit_workflow({})
+
+
+def test_submit_workflow_raises_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    client, _ = _make_client(monkeypatch, [(401, "Unauthorized")])
+    with pytest.raises(RuntimeError, match="HTTP 401"):
+        client.submit_workflow({})
+
+
+def test_get_native_status_parses_dag_nodes(monkeypatch: pytest.MonkeyPatch) -> None:
+    client, _ = _make_client(
+        monkeypatch,
+        [
+            (
+                200,
+                {
+                    "status": "Running",
+                    "run_id": "r-1",
+                    "workflow_slug": "mysql-abc",
+                    "dag_nodes": {
+                        "extract": {
+                            "status": "Succeeded",
+                            "started_at": 1700000000000,
+                            "completed_at": 1700000010000,
+                            "error_message": None,
+                        },
+                        "publish": {
+                            "status": "Running",
+                            "started_at": 1700000010500,
+                            "completed_at": None,
+                            "error_message": None,
+                        },
+                    },
+                },
+            )
+        ],
+    )
+    result = client.get_native_status("r-1")
+    assert result.run_id == "r-1"
+    assert result.workflow_slug == "mysql-abc"
+    assert result.status is DAGRunStatus.RUNNING
+    assert len(result.nodes) == 2
+    extract = next(n for n in result.nodes if n.name == "extract")
+    assert extract.status is DAGNodeStatus.SUCCEEDED
+    assert extract.duration_seconds == 10.0
+    publish = next(n for n in result.nodes if n.name == "publish")
+    assert publish.status is DAGNodeStatus.RUNNING
+    assert publish.duration_seconds is None
+
+
+def test_unknown_status_strings_treated_as_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _ = _make_client(
+        monkeypatch,
+        [
+            (
+                200,
+                {
+                    "status": "MysteryStatus",
+                    "dag_nodes": {"x": {"status": "AlsoUnknown"}},
+                },
+            )
+        ],
+    )
+    result = client.get_native_status("r")
+    assert result.status is DAGRunStatus.PENDING
+    assert result.nodes[0].status is DAGNodeStatus.PENDING
+
+
+def test_poll_native_status_returns_on_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Avoid the real time.sleep — poll interval doesn't matter for the test.
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    client, queue = _make_client(
+        monkeypatch,
+        [
+            (200, {"status": "Running", "dag_nodes": {}}),
+            (200, {"status": "Running", "dag_nodes": {}}),
+            (
+                200,
+                {
+                    "status": "Succeeded",
+                    "dag_nodes": {"extract": {"status": "Succeeded"}},
+                },
+            ),
+        ],
+    )
+    result = client.poll_native_status("r", interval_seconds=1, timeout_seconds=60)
+    assert result.status is DAGRunStatus.SUCCEEDED
+    assert queue == []  # all three responses consumed
+
+
+def test_poll_native_status_returns_last_observation_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    client, _ = _make_client(
+        monkeypatch,
+        # interval=1, timeout=3 → we'll fire 3 polls (elapsed=0,1,2) all Running
+        [
+            (200, {"status": "Running", "dag_nodes": {}}),
+            (200, {"status": "Running", "dag_nodes": {}}),
+            (200, {"status": "Running", "dag_nodes": {}}),
+        ],
+    )
+    result = client.poll_native_status("r", interval_seconds=1, timeout_seconds=3)
+    # Still Running but we got back the last observed state instead of
+    # raising — caller can include node-level diagnostics in their error.
+    assert result.status is DAGRunStatus.RUNNING
+
+
+def test_poll_atlas_for_connection_succeeds_on_200(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    client, _ = _make_client(
+        monkeypatch, [(404, ""), (404, ""), (200, {"any": "thing"})]
+    )
+    assert (
+        client.poll_atlas_for_connection(
+            "default/mysql/test", interval_seconds=1, timeout_seconds=10
+        )
+        is True
+    )
+
+
+def test_poll_atlas_for_connection_returns_false_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    client, _ = _make_client(
+        monkeypatch,
+        # interval=1, timeout=2 → 2 polls; both 404 → returns False
+        [(404, ""), (404, "")],
+    )
+    assert (
+        client.poll_atlas_for_connection(
+            "default/mysql/test", interval_seconds=1, timeout_seconds=2
+        )
+        is False
+    )

--- a/tests/unit/testing/full_dag/test_payload.py
+++ b/tests/unit/testing/full_dag/test_payload.py
@@ -1,0 +1,190 @@
+"""Unit tests for the AE submit-payload builder.
+
+Network-free; just asserts the shape of the dict against the contract
+the tenant's package-workflows service expects (captured from the
+devex UI).
+"""
+
+from __future__ import annotations
+
+import orjson
+import pytest
+
+from application_sdk.testing.full_dag.payload import (
+    AgentSpec,
+    ConnectionSpec,
+    DatabaseSpec,
+    RunMode,
+    build_ae_payload,
+)
+
+_CONNECTION = ConnectionSpec(
+    name="full-dag-e2e-mysql-1234",
+    qualified_name="default/mysql/full-dag-e2e-1234",
+    connector_name="mysql",
+    source_logo="https://assets.atlan.com/assets/mysql.png",
+    admin_users=("aryaman",),
+    admin_roles=("30502f8b-f748-4771-9b71-2a3b3b5faae0",),
+)
+
+
+_DATABASE = DatabaseSpec(
+    host="atlan-mysql.crmgvlgwn1cx.ap-south-1.rds.amazonaws.com",
+    port=3306,
+    username="atlan",
+    password="hunter2",
+)
+
+
+def _params(payload: dict) -> dict[str, object]:
+    """Flatten the Argo task parameters into a name → value dict for assertion."""
+    tasks = payload["spec"]["templates"][0]["dag"]["tasks"]
+    return {p["name"]: p["value"] for p in tasks[0]["arguments"]["parameters"]}
+
+
+def test_direct_mode_payload_basic_shape() -> None:
+    payload = build_ae_payload(
+        run_id=1234,
+        mode=RunMode.DIRECT,
+        connector_short_name="mysql",
+        argo_package_name="@atlan/mysql",
+        argo_template_name="atlan-mysql",
+        app_service_url="http://mysql.mysql-app.svc.cluster.local",
+        connection=_CONNECTION,
+        database=_DATABASE,
+    )
+
+    assert payload["execution_mode"] == "native"
+    assert payload["metadata"]["name"] == "atlan-mysql-1234"
+    assert (
+        payload["metadata"]["app_service_url"]
+        == "http://mysql.mysql-app.svc.cluster.local"
+    )
+    assert (
+        payload["metadata"]["annotations"]["package.argoproj.io/name"] == "@atlan/mysql"
+    )
+
+    params = _params(payload)
+    assert params["extraction-method"] == "direct"
+    # Credential overrides flow through in DIRECT
+    assert params["credential-guid.host"] == _DATABASE.host
+    assert params["credential-guid.basic.username"] == _DATABASE.username
+    assert params["credential-guid.basic.password"] == _DATABASE.password
+    # No agent-json in direct mode
+    assert "agent-json" not in params
+
+
+def test_agent_mode_payload_includes_agent_json() -> None:
+    agent = AgentSpec(agent_name="ci-1234")
+    payload = build_ae_payload(
+        run_id=1234,
+        mode=RunMode.AGENT,
+        connector_short_name="mysql",
+        argo_package_name="@atlan/mysql",
+        argo_template_name="atlan-mysql",
+        app_service_url="http://mysql.mysql-app.svc.cluster.local",
+        connection=_CONNECTION,
+        database=_DATABASE,
+        agent=agent,
+    )
+
+    params = _params(payload)
+    assert params["extraction-method"] == "agent"
+
+    agent_json = orjson.loads(params["agent-json"])
+    assert agent_json["agent-name"] == "ci-1234"
+    assert agent_json["agent-type"] == "new-app-framework"
+    assert agent_json["host"] == _DATABASE.host
+    # Username/password values in agent-json are *secret-store keys*,
+    # not raw credentials — caller's secret store resolves them.
+    assert agent_json["basic.username"] == "MYSQL_USERNAME"
+    assert agent_json["basic.password"] == "MYSQL_PASSWORD"
+
+    # Flat agent-json.* duplicates of the same keys should exist
+    assert params["agent-json.agent-name"] == "ci-1234"
+    assert params["agent-json.basic.username"] == "MYSQL_USERNAME"
+
+
+def test_agent_mode_without_agent_spec_raises() -> None:
+    with pytest.raises(ValueError, match="agent mode requires"):
+        build_ae_payload(
+            run_id=1,
+            mode=RunMode.AGENT,
+            connector_short_name="mysql",
+            argo_package_name="@atlan/mysql",
+            argo_template_name="atlan-mysql",
+            app_service_url="http://mysql.mysql-app.svc.cluster.local",
+            connection=_CONNECTION,
+            database=_DATABASE,
+            agent=None,
+        )
+
+
+def test_connection_attributes_round_trip_through_payload() -> None:
+    """The nested ``connection`` parameter must JSON-parse back to the spec."""
+    payload = build_ae_payload(
+        run_id=99,
+        mode=RunMode.DIRECT,
+        connector_short_name="mysql",
+        argo_package_name="@atlan/mysql",
+        argo_template_name="atlan-mysql",
+        app_service_url="http://mysql.mysql-app.svc.cluster.local",
+        connection=_CONNECTION,
+        database=_DATABASE,
+    )
+    params = _params(payload)
+    parsed = orjson.loads(params["connection"])
+    assert parsed["typeName"] == "Connection"
+    assert parsed["attributes"]["qualifiedName"] == _CONNECTION.qualified_name
+    assert parsed["attributes"]["adminUsers"] == list(_CONNECTION.admin_users)
+
+
+def test_credential_payload_carries_real_credentials() -> None:
+    """The top-level ``payload[]`` is what the orchestrator stores as a credential.
+
+    Even in agent mode, the real DB creds get persisted on the tenant
+    side here — the agent flow just doesn't pass them through to extract.
+    """
+    payload = build_ae_payload(
+        run_id=42,
+        mode=RunMode.AGENT,
+        connector_short_name="mysql",
+        argo_package_name="@atlan/mysql",
+        argo_template_name="atlan-mysql",
+        app_service_url="http://mysql.mysql-app.svc.cluster.local",
+        connection=_CONNECTION,
+        database=_DATABASE,
+        agent=AgentSpec(agent_name="ci-42"),
+    )
+    cred = payload["payload"][0]
+    assert cred["parameter"] == "credentialGuid"
+    assert cred["body"]["username"] == _DATABASE.username
+    assert cred["body"]["password"] == _DATABASE.password
+    assert cred["body"]["host"] == _DATABASE.host
+    assert cred["body"]["connectorConfigName"] == "atlan-connectors-mysql"
+
+
+def test_run_id_drives_uniqueness() -> None:
+    """Two payloads with different run_ids must produce different workflow names."""
+    p1 = build_ae_payload(
+        run_id=1,
+        mode=RunMode.DIRECT,
+        connector_short_name="mysql",
+        argo_package_name="@atlan/mysql",
+        argo_template_name="atlan-mysql",
+        app_service_url="http://mysql.mysql-app.svc.cluster.local",
+        connection=_CONNECTION,
+        database=_DATABASE,
+    )
+    p2 = build_ae_payload(
+        run_id=2,
+        mode=RunMode.DIRECT,
+        connector_short_name="mysql",
+        argo_package_name="@atlan/mysql",
+        argo_template_name="atlan-mysql",
+        app_service_url="http://mysql.mysql-app.svc.cluster.local",
+        connection=_CONNECTION,
+        database=_DATABASE,
+    )
+    assert p1["metadata"]["name"] != p2["metadata"]["name"]
+    assert p1["metadata"]["ae_workflow_slug"] != p2["metadata"]["ae_workflow_slug"]

--- a/tests/unit/testing/full_dag/test_payload.py
+++ b/tests/unit/testing/full_dag/test_payload.py
@@ -97,12 +97,12 @@ def test_agent_mode_payload_includes_agent_json() -> None:
     assert agent_json["host"] == _DATABASE.host
     # Username/password values in agent-json are *secret-store keys*,
     # not raw credentials — caller's secret store resolves them.
-    assert agent_json["basic.username"] == "MYSQL_USERNAME"
-    assert agent_json["basic.password"] == "MYSQL_PASSWORD"
+    assert agent_json["basic.username"] == "SDR_MYSQL_USERNAME"
+    assert agent_json["basic.password"] == "SDR_MYSQL_PASSWORD"
 
     # Flat agent-json.* duplicates of the same keys should exist
     assert params["agent-json.agent-name"] == "ci-1234"
-    assert params["agent-json.basic.username"] == "MYSQL_USERNAME"
+    assert params["agent-json.basic.username"] == "SDR_MYSQL_USERNAME"
 
 
 def test_agent_mode_without_agent_spec_raises() -> None:

--- a/tests/unit/testing/full_dag/test_payload.py
+++ b/tests/unit/testing/full_dag/test_payload.py
@@ -164,6 +164,43 @@ def test_credential_payload_carries_real_credentials() -> None:
     assert cred["body"]["connectorConfigName"] == "atlan-connectors-mysql"
 
 
+def test_ae_workflow_slug_override() -> None:
+    """When the caller passes a slug, it should land verbatim in metadata.
+
+    Required for tenants that don't auto-create workflows on submit —
+    the engineer pre-creates a workflow via UI / Heracles and the test
+    points at its slug.
+    """
+    payload = build_ae_payload(
+        run_id=1234,
+        mode=RunMode.DIRECT,
+        connector_short_name="mysql",
+        argo_package_name="@atlan/mysql",
+        argo_template_name="atlan-mysql",
+        app_service_url="http://mysql.mysql-app.svc.cluster.local",
+        connection=_CONNECTION,
+        database=_DATABASE,
+        ae_workflow_slug="mysql-existing-prod-slug",
+    )
+    assert payload["metadata"]["ae_workflow_slug"] == "mysql-existing-prod-slug"
+
+
+def test_ae_workflow_slug_defaults_to_per_run_when_blank() -> None:
+    """Empty slug → fall back to the auto-generated unique-per-run slug."""
+    payload = build_ae_payload(
+        run_id=99,
+        mode=RunMode.DIRECT,
+        connector_short_name="mysql",
+        argo_package_name="@atlan/mysql",
+        argo_template_name="atlan-mysql",
+        app_service_url="http://mysql.mysql-app.svc.cluster.local",
+        connection=_CONNECTION,
+        database=_DATABASE,
+        ae_workflow_slug="",
+    )
+    assert payload["metadata"]["ae_workflow_slug"] == "mysql-e2e-99"
+
+
 def test_run_id_drives_uniqueness() -> None:
     """Two payloads with different run_ids must produce different workflow names."""
     p1 = build_ae_payload(

--- a/tests/unit/testing/full_dag/test_payload.py
+++ b/tests/unit/testing/full_dag/test_payload.py
@@ -139,12 +139,34 @@ def test_connection_attributes_round_trip_through_payload() -> None:
     assert parsed["attributes"]["adminUsers"] == list(_CONNECTION.admin_users)
 
 
-def test_credential_payload_carries_real_credentials() -> None:
-    """The top-level ``payload[]`` is what the orchestrator stores as a credential.
+def test_direct_credential_payload_carries_full_record() -> None:
+    """DIRECT mode payload[] body has the full credential — host, port,
+    username, password — so the prod-deployed pod can resolve and
+    connect at runtime."""
+    payload = build_ae_payload(
+        run_id=42,
+        mode=RunMode.DIRECT,
+        connector_short_name="mysql",
+        argo_package_name="@atlan/mysql",
+        argo_template_name="atlan-mysql",
+        app_service_url="http://mysql.mysql-app.svc.cluster.local",
+        connection=_CONNECTION,
+        database=_DATABASE,
+    )
+    cred = payload["payload"][0]
+    assert cred["parameter"] == "credentialGuid"
+    assert cred["body"]["host"] == _DATABASE.host
+    assert cred["body"]["username"] == _DATABASE.username
+    assert cred["body"]["password"] == _DATABASE.password
+    assert cred["body"]["connectorConfigName"] == "atlan-connectors-mysql"
 
-    Even in agent mode, the real DB creds get persisted on the tenant
-    side here — the agent flow just doesn't pass them through to extract.
-    """
+
+def test_agent_credential_payload_omits_db_creds() -> None:
+    """AGENT mode payload[] body is intentionally lightweight — no
+    host/username/password — because those resolve at the agent worker
+    via the local secret-store. Sending the full body causes the
+    orchestrator to skip credential creation and `{{credentialGuid}}`
+    stays unsubstituted as the seed DAG's "__placeholder__" string."""
     payload = build_ae_payload(
         run_id=42,
         mode=RunMode.AGENT,
@@ -154,14 +176,19 @@ def test_credential_payload_carries_real_credentials() -> None:
         app_service_url="http://mysql.mysql-app.svc.cluster.local",
         connection=_CONNECTION,
         database=_DATABASE,
-        agent=AgentSpec(agent_name="ci-42"),
+        agent=AgentSpec(agent_name="mysql-ci-42"),
     )
     cred = payload["payload"][0]
     assert cred["parameter"] == "credentialGuid"
-    assert cred["body"]["username"] == _DATABASE.username
-    assert cred["body"]["password"] == _DATABASE.password
-    assert cred["body"]["host"] == _DATABASE.host
-    assert cred["body"]["connectorConfigName"] == "atlan-connectors-mysql"
+    body = cred["body"]
+    assert body["connectorConfigName"] == "atlan-connectors-mysql"
+    assert body["authType"] == "basic"
+    # Critical: no DB-connection details — those live in agent-json
+    # / secret-store, not in the credential body.
+    assert "host" not in body
+    assert "port" not in body
+    assert "username" not in body
+    assert "password" not in body
 
 
 def test_ae_workflow_slug_override() -> None:

--- a/tests/unit/testing/full_dag/test_sql_app.py
+++ b/tests/unit/testing/full_dag/test_sql_app.py
@@ -8,10 +8,7 @@ from __future__ import annotations
 
 import pytest
 
-from application_sdk.testing.full_dag import (
-    RunMode,
-    SQLAppE2EFullTest,
-)
+from application_sdk.testing.full_dag import RunMode, SQLAppE2EFullTest
 from application_sdk.testing.full_dag.payload import AgentSpec, DatabaseSpec
 
 

--- a/tests/unit/testing/full_dag/test_sql_app.py
+++ b/tests/unit/testing/full_dag/test_sql_app.py
@@ -1,0 +1,131 @@
+"""Unit tests for SQLAppE2EFullTest — the SQL-connector convenience base.
+
+Network-free. The pyatlan ``$admin`` resolution is the only external
+dependency and is monkey-patched out via ``_resolve_admin_role_guid``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from application_sdk.testing.full_dag import (
+    RunMode,
+    SQLAppE2EFullTest,
+)
+from application_sdk.testing.full_dag.payload import AgentSpec, DatabaseSpec
+
+
+def _make_test(role_guid: str = "stub-admin-guid"):
+    """Build a runnable subclass with required attrs + stubbed pyatlan."""
+
+    class _Concrete(SQLAppE2EFullTest):
+        connector_short_name = "mysql"
+        argo_package_name = "@atlan/mysql"
+        argo_template_name = "atlan-mysql"
+        mode = RunMode.AGENT
+        app_service_url = "http://mysql.mysql-app.svc.cluster.local"
+
+    # Stub the pyatlan role-cache lookup so tests stay network-free
+    _Concrete._resolve_admin_role_guid = staticmethod(lambda: role_guid)
+
+    def database_spec(self):
+        return DatabaseSpec(host="mysql", port=3306, username="u", password="p")
+
+    _Concrete.database_spec = database_spec
+    return _Concrete
+
+
+def _bootstrap_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://test.example.invalid")
+    monkeypatch.setenv("ATLAN_API_KEY", "test-token")
+    monkeypatch.setenv("GITHUB_RUN_ID", "9999999")
+
+
+def test_agent_spec_agent_mode_uses_run_id_template(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AGENT mode produces ``{connector}-{prefix}-{run_id}`` agent name."""
+    _bootstrap_env(monkeypatch)
+    cls = _make_test()
+    instance = cls()
+    instance.setup_method()
+    agent = instance.agent_spec()
+    assert isinstance(agent, AgentSpec)
+    # Default connection_name_prefix = "e2e-full-ci"; run_id = 9999999.
+    assert agent.agent_name == "mysql-e2e-full-ci-9999999"
+
+
+def test_agent_spec_direct_mode_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DIRECT mode produces no AgentSpec — worker reads creds inline."""
+    _bootstrap_env(monkeypatch)
+    cls = _make_test()
+    cls.mode = RunMode.DIRECT
+    instance = cls()
+    instance.setup_method()
+    assert instance.agent_spec() is None
+
+
+def test_agent_name_template_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Subclasses can override the agent_name_template for non-standard
+    Argo cluster templates."""
+    _bootstrap_env(monkeypatch)
+    cls = _make_test()
+    cls.agent_name_template = "{prefix}-{connector}-{run_id}"
+    instance = cls()
+    instance.setup_method()
+    agent = instance.agent_spec()
+    assert agent is not None
+    assert agent.agent_name == "e2e-full-ci-mysql-9999999"
+
+
+def test_connection_spec_resolves_admin_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``connection_spec`` injects the resolved ``$admin`` role GUID."""
+    _bootstrap_env(monkeypatch)
+    cls = _make_test(role_guid="role-guid-xyz")
+    instance = cls()
+    instance.setup_method()
+    spec = instance.connection_spec()
+    assert spec.admin_roles == ("role-guid-xyz",)
+    assert spec.connector_name == "mysql"
+    assert spec.qualified_name.startswith("default/mysql/e2e-full-ci-")
+    assert spec.source_logo.endswith("/mysql.png")
+
+
+def test_connection_spec_caches_role_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Role-cache lookup happens once even across multiple calls."""
+    _bootstrap_env(monkeypatch)
+    calls = {"n": 0}
+
+    def stub_lookup() -> str:
+        calls["n"] += 1
+        return "cached-role-guid"
+
+    cls = _make_test()
+    cls._resolve_admin_role_guid = staticmethod(stub_lookup)
+    instance = cls()
+    instance.setup_method()
+    instance.connection_spec()
+    instance.connection_spec()
+    instance.connection_spec()
+    assert calls["n"] == 1
+
+
+def test_connection_admin_users_and_groups_are_pass_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Subclass-set adminUsers/Groups land on the resulting ConnectionSpec."""
+    _bootstrap_env(monkeypatch)
+    cls = _make_test()
+    cls.connection_admin_users = ("dev-team",)
+    cls.connection_admin_groups = ("analytics",)
+    instance = cls()
+    instance.setup_method()
+    spec = instance.connection_spec()
+    assert spec.admin_users == ("dev-team",)
+    assert spec.admin_groups == ("analytics",)


### PR DESCRIPTION
## Summary

BLDX-1254. Builds out the SDK-side infrastructure for two cross-repo testing tiers:

1. **SDR Integration Tests (per-PR auto-run)** — the existing connector SDR suite now runs automatically on every apps-sdk PR push against the SDR-enabled connector fleet. ~3 min per connector; catches SDK breakage on every push without needing a label.

2. **Full-DAG E2E Tests (label-gated)** — new harness that runs a connector's code end-to-end through the tenant's system-apps DAG (extract → qi → publish → lineage-app → lineage-publish), asserts the Connection + descendant assets + lineage actually land in Atlas. Opt-in via the `e2e-full-mysql` label since each run is ~20 min.

The harness ships as `application_sdk.testing.full_dag` and a reusable workflow at `.github/workflows/e2e-full-reusable.yaml`. Mysql is the first consumer ([atlanhq/atlan-mysql-app#106](https://github.com/atlanhq/atlan-mysql-app/pull/106)).

## What's in here

### `application_sdk.testing.full_dag` package

- **`BaseFullDAGE2ETest`** — pytest base. Loads the connector's `app/generated/manifest.json` as the seed DAG (substitutes `{app_name}` / `{deployment_name}` + Mustache placeholders the configurator normally fills at deployment time), publishes a version, submits via AE, polls `native-status`, then asserts the Connection lands in Atlas + per-type descendant counts + a lineage Process exists.

- **`SQLAppE2EFullTest`** — mid-level convenience base. Captures `agent_spec()` (`{connector}-{prefix}-{run_id}` for AGENT mode, `None` for DIRECT) and `connection_spec()` (resolves the tenant's `$admin` role GUID via pyatlan `role_cache` so the API-key service account ends up on the Connection's admin ACL). Concrete connector tests shrink from ~200 → ~120 lines.

- **`AEWorkflowClient`** — thin HTTP wrapper around `/automation/api/v1/workflows`, `/api/service/package-workflows`, and `native-status`. Retries on AE 5xx (`create_workflow` / `create_version` / `submit_workflow` / `poll_native_status` all retry up to 4-5×). Atlas Connection probe goes through pyatlan's search (the direct entity-fetch endpoint enforces the Connection ACL but search has a permissive read path — works for our identity).

- **Auth model** — `ATLAN_API_KEY` (bearer) for AE-management endpoints because `/automation/api/v1/*` requires the `realm-admin` resource_access role the API-key service account carries. `SDR_OAUTH_CLIENT_ID/SECRET` is optional and forwarded to pyatlan asset queries for clearer Atlas RBAC diagnostics. We tested the all-OAuth path and confirmed AE management returns a masked AE-COMMON-500-01 under OAuth; reverted to require API key.

- **Logging** — per-poll log line uses colour emoji glyphs for fast visual scan (`✅ ⟳ 🔄 🟡 ❌ ⏰`) plus a 30s heartbeat so long lineage stages don't look wedged in CI output.

### `.github/workflows/e2e-full-reusable.yaml`

Reusable workflow (`workflow_call`) that wraps the SDR composite action with full-DAG defaults: 120-min job timeout, env wiring, tenant + OAuth + API-key secrets, container-health bump, pytest `-s`. Consumer's `e2e-full.yaml` collapses to a 5-line `uses:` call.

### `.github/actions/sdr-e2e/action.yaml`

- New inputs: `components-dir`, `compose-overlay`, `report-title`, `application-sdk-ref`. Lets one composite action drive both the per-PR SDR suite and the full-DAG suite.
- Report title is derived from `test-path` (`tests/sdr/` → "SDR Integration Tests"; `tests/full_dag/` → "Full-DAG E2E Tests") with an override knob.
- Sticky PR-comment marker is slugged from the resolved title so different suites on the same PR keep their own comments.
- Auto-extracts + posts an "Asset extraction summary" markdown table in the SDR suite's PR comment.

### `.github/workflows/pull_request.yaml`

- **SDR auto-run**: dropped the `sdr-e2e-test` label gate — the suite now fires on every push to a non-fork, non-dependabot PR.
- **`e2e-full-mysql` label**: new job, dispatches mysql-app's `e2e-full.yaml` with `application_sdk_ref = <PR head SHA>` so the run validates this SDK PR's code. Per-app label so future connectors stage adoption independently (`e2e-full-postgres`, `e2e-full-mssql`, …).

## How a new connector adopts this

1. Add a `tests/full_dag/test_<conn>_full_dag.py` extending `SQLAppE2EFullTest` (~15-50 lines).
2. Add `.github/workflows/e2e-full.yaml` with `uses: atlanhq/application-sdk/.github/workflows/e2e-full-reusable.yaml@main` + `with: app-name`, `app-image-name` + `secrets: inherit` (~10 lines).
3. Add `.github/e2e/e2e-full-components/objectstore.yaml` (OAuth-proxy Dapr binding — same shape works for any SQL connector), `e2e-full-docker-compose.yaml` (sibling-DB service), `make-secrets-e2e-full.py`, `seed.sql`.
4. Wire up a per-connector `e2e-full-<conn>` job in this repo's `pull_request.yaml` so apps-sdk PRs can label-trigger the connector's full-DAG run.

## Tests

40 network-free unit tests across the full_dag package:
- `test_base.py` (15) — manifest substitution, Mustache fills, error paths.
- `test_client.py` (10) — AE retry / 5xx handling, search-based probe, status parsing.
- `test_payload.py` (9) — AE submit shape, AGENT vs DIRECT, agent_json.
- `test_sql_app.py` (6) — `SQLAppE2EFullTest` agent_spec / connection_spec / `$admin` resolution.

All pyatlan and HTTP calls are monkey-patched out; tests run in <1s total.

## End-to-end verification

[atlan-mysql-app run 25795760837](https://github.com/atlanhq/atlan-mysql-app/actions/runs/25795760837) — first fully green e2e-full run end-to-end:
- All 5 DAG nodes Succeeded (extract → qi → publish → lineage-app → lineage-publish).
- Atlas inventory under `default/mysql/e2e-full-ci-25795760837`: Database=1, Schema=1, Table=2, View=1, Column=11.
- `lineage_present = True` (view-lineage Process row materialised).
- 21 min wall-time end-to-end (extract <2 min; lineage-app + lineage-publish ~15 min on devex's queue depth).

## Companion mysql-app PR

[atlanhq/atlan-mysql-app#106](https://github.com/atlanhq/atlan-mysql-app/pull/106) consumes this SDK to:
- Subclass `SQLAppE2EFullTest` (test class shrinks ~200 → 120 lines).
- Use the reusable workflow (workflow YAML shrinks ~110 → 40 lines).
- Pick up the label trigger on `e2e-full` PRs + cross-repo dispatch from this SDK's `e2e-full-mysql` label.

## Test plan

- [ ] Pre-commit checks pass (force-pushed `eb7b8111` to align with the pinned ruff 0.6.4 + isort 5.13.2 versions).
- [ ] SDR integration suite auto-runs on this PR's pushes against mysql-app.
- [ ] Label `e2e-full-mysql` triggers the full-DAG suite against mysql-app at this PR's HEAD SHA.