### PR TITLE
fix(validator): skip vpa.maxAllowed clamp rule when updateMode=Off

### DIFF
--- a/.github/scripts/config_validator.py
+++ b/.github/scripts/config_validator.py
@@ -10,8 +10,10 @@ Rules enforced:
   3. vpa.maxAllowed.memory  <= 27Gi (binary, = 27 * 1024^3 bytes).
   4. requests.cpu           <= 7 cores.
   5. requests.memory        <= 27Gi.
-  6. When vpa.enabled=true: requests.{cpu,memory} <= effective vpa.maxAllowed
-     (chart defaults cpu=2000m, memory=18Gi when not declared).
+  6. When vpa.enabled=true AND updateMode != "Off": requests.{cpu,memory}
+     <= effective vpa.maxAllowed (chart defaults cpu=2000m, memory=18Gi
+     when not declared). Skipped in updateMode=Off — VPA only emits
+     recommendations there and doesn't clamp admission.
   7. requests <= limits per resource.
   8. vpa.minAllowed         <= vpa.maxAllowed per resource.
   9. keda.minReplicaCount   <= keda.maxReplicaCount.
@@ -339,11 +341,30 @@ def _resolve_effective_vpa_max(
     parsed: dict[tuple[str, str], int | None],
     vpa_enabled: bool | None,
 ) -> tuple[int | None, int | None]:
-    """Effective vpa.maxAllowed (cpu_milli, mem_bytes), or (None, None) when vpa disabled.
-    Falls back to DEFAULT_VPA_MAX_* when maxAllowed not declared."""
+    """Effective vpa.maxAllowed (cpu_milli, mem_bytes), or (None, None) when
+    VPA does not clamp requests at admission.
+
+    VPA clamps requests only in updateMode `Initial`, `Recreate`, or `Auto`.
+    In `Off` mode VPA emits recommendations but doesn't apply them — initial
+    requests above maxAllowed deploy as-is. Skip the requests<=vpa.maxAllowed
+    rule in that case. Same when vpa.enabled is false/missing.
+
+    Falls back to DEFAULT_VPA_MAX_* when maxAllowed not declared.
+    """
     if vpa_enabled is not True:
         return None, None
     vpa = cfg.get("vpa") or {}
+    # Match VPA enum case-insensitively. K8s VPA accepts only the canonical
+    # casings (Off/Initial/Recreate/Auto), but app owners typing `off` should
+    # not get a misleading clamp violation — the chart's schema rejects bad
+    # casings later anyway. Also accept bool False: PyYAML's YAML 1.1 loader
+    # coerces unquoted `off` / `no` to False — common gotcha.
+    update_mode = vpa.get("updateMode")
+    is_off = update_mode is False or (
+        isinstance(update_mode, str) and update_mode.strip().lower() == "off"
+    )
+    if is_off:
+        return None, None
     max_allowed = vpa.get("maxAllowed") or {}
     cpu_milli: int | None = (
         parsed.get(("cpu", "maxAllowed"))

--- a/.github/scripts/tests/test_config_validator.py
+++ b/.github/scripts/tests/test_config_validator.py
@@ -278,6 +278,77 @@ resources:
         rules = {v.rule for v in exc.value.violations}
         assert "requests_exceeds_vpa_max_cpu" in rules
 
+    def test_update_mode_off_skips_clamp_rule(self):
+        # VPA updateMode=Off → recommendations only, no admission clamp.
+        # Same request that fires the rule with default mode must pass here.
+        validate_config("""
+vpa:
+  enabled: true
+  updateMode: "Off"
+resources:
+  requests: {cpu: 3,    memory: 500Mi}
+  limits:   {cpu: 3,    memory: 1Gi}
+""")
+
+    def test_update_mode_off_case_insensitive(self):
+        # Lowercase `off` also opts out — chart's schema rejects bad casing
+        # downstream; here we mirror app-owner intent.
+        validate_config("""
+vpa:
+  enabled: true
+  updateMode: off
+resources:
+  requests: {cpu: 3,    memory: 500Mi}
+  limits:   {cpu: 3,    memory: 1Gi}
+""")
+
+    def test_update_mode_auto_still_clamps(self):
+        # Sanity: updateMode=Auto must still fire the rule.
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config("""
+vpa:
+  enabled: true
+  updateMode: "Auto"
+resources:
+  requests: {cpu: 3,    memory: 500Mi}
+  limits:   {cpu: 3,    memory: 1Gi}
+""")
+        rules = {v.rule for v in exc.value.violations}
+        assert "requests_exceeds_vpa_max_cpu" in rules
+
+    def test_update_mode_initial_still_clamps(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config("""
+vpa:
+  enabled: true
+  updateMode: "Initial"
+resources:
+  requests: {cpu: 3,    memory: 500Mi}
+  limits:   {cpu: 3,    memory: 1Gi}
+""")
+        rules = {v.rule for v in exc.value.violations}
+        assert "requests_exceeds_vpa_max_cpu" in rules
+
+    def test_update_mode_off_split_resources_also_skipped(self):
+        # workerResources / serverResources path under split must also honour
+        # the Off opt-out — this is the exact scenario from prod.
+        validate_config(
+            """
+splitDeploymentEnabled: true
+temporalWorkerDeployment: {enabled: true}
+vpa:
+  enabled: true
+  updateMode: "Off"
+resources:
+  requests: {cpu: 100m, memory: 500Mi}
+  limits:   {cpu: 1,    memory: 1Gi}
+workerResources:
+  requests: {cpu: 3,    memory: 500Mi}
+  limits:   {cpu: 3,    memory: 1Gi}
+""",
+            sdk_version="3.6.0",
+        )
+
     def test_memory_request_above_default_max(self):
         with pytest.raises(ConfigValidationError) as exc:
             validate_config("""


### PR DESCRIPTION
## Summary

VPA clamps requests at admission only in updateMode `Initial`, `Recreate`, or `Auto`. In `Off` mode it emits recommendations but does not apply them — initial requests deploy as-is regardless of `vpa.maxAllowed`. The validator was firing `requests_exceeds_vpa_max_*` even when updateMode=Off, blocking apps that intentionally opt out.

Real case: an app with `workerResources.requests.cpu: 3` + `vpa.updateMode: Off` failed CI with `requests_exceeds_vpa_max_cpu (... <= vpa.maxAllowed.cpu (2000m))` despite VPA never clamping at runtime.

## Fix

\`_resolve_effective_vpa_max\` returns \`(None, None)\` when updateMode=Off (case-insensitive). PyYAML coerces unquoted \`off\` → \`False\` under YAML 1.1, so bool \`False\` is also accepted as the Off sentinel.

Other VPA rules (max ceiling, min<=max) still fire — recommendations remain bounded by infra ceilings.

## Test plan

- [x] \`updateMode: "Off"\` (quoted) → rule skipped
- [x] \`updateMode: off\` (unquoted → YAML False) → rule skipped
- [x] \`updateMode: "Auto"\` → rule still fires
- [x] \`updateMode: "Initial"\` → rule still fires
- [x] \`updateMode: "Off"\` under split-worker (workerResources) → rule skipped
- [x] 167 tests pass

## Affected app

teradata-app CI was failing with this exact rule. After this fix, build proceeds.