### PR TITLE
perf(observability): lazy-load OTEL exporter classes to reduce cold-start import time

### DIFF
--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -7,9 +7,6 @@ from typing import Any, ClassVar
 
 from loguru import logger
 from opentelemetry._logs import LogRecord, SeverityNumber
-from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
-from opentelemetry.sdk._logs import LoggerProvider
-from opentelemetry.sdk._logs._internal.export import BatchLogRecordProcessor
 from opentelemetry.trace.span import TraceFlags
 
 from application_sdk.constants import (
@@ -539,6 +536,13 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
             otlp_processors = []
 
             if ENABLE_OTLP_LOGS or _has_remote_otlp_endpoint():
+                from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (  # noqa: PLC0415
+                    OTLPLogExporter,
+                )
+                from opentelemetry.sdk._logs._internal.export import (  # noqa: PLC0415
+                    BatchLogRecordProcessor,
+                )
+
                 otlp_processors.append(
                     BatchLogRecordProcessor(
                         OTLPLogExporter(
@@ -553,6 +557,13 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
                 logging.info("OTLP exporter enabled: %s", OTEL_EXPORTER_OTLP_ENDPOINT)
 
             if ENABLE_OTLP_WORKFLOW_LOGS and OTEL_WORKFLOW_LOGS_ENDPOINT:
+                from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (  # noqa: PLC0415
+                    OTLPLogExporter,
+                )
+                from opentelemetry.sdk._logs._internal.export import (  # noqa: PLC0415
+                    BatchLogRecordProcessor,
+                )
+
                 otlp_processors.append(
                     BatchLogRecordProcessor(
                         OTLPLogExporter(
@@ -570,6 +581,8 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
                 )
 
             if otlp_processors:
+                from opentelemetry.sdk._logs import LoggerProvider  # noqa: PLC0415
+
                 self.logger_provider = LoggerProvider(
                     resource=build_otel_resource(
                         extra_attrs={"sdk.version": _SDK_VERSION}


### PR DESCRIPTION
## Summary

Reduces server pod cold-start time by lazy-loading heavy OTEL imports that are only needed when `ENABLE_OTLP_LOGS=true`.

**What changes:**
- `OTLPLogExporter`, `BatchLogRecordProcessor`, `LoggerProvider` moved inside the `if ENABLE_OTLP_LOGS` conditional blocks in `logger_adaptor.py` (~177ms saved on cold starts)

**What's already lazy in v3 (no change needed):**
- `file_converter.py` — pandas already imported inside functions ✅
- `aws_utils.py` — boto3 already under `TYPE_CHECKING` ✅

## Measured impact (v2, cold overlayfs container)
- Python import time: 17s → 4s
- Server cold start (process → uvicorn): 23s → 6s
- KEDA end-to-end cold start: 47.8s → 12s (cached node)

## Related
- ARUN-591: server scale to 0