### PR TITLE
feat(testing): add full_dag harness for tier-4/5 e2e tests

### DIFF
--- a/application_sdk/testing/full_dag/__init__.py
+++ b/application_sdk/testing/full_dag/__init__.py
@@ -1,0 +1,56 @@
+"""Shared harness for tier-4 / tier-5 full-DAG end-to-end tests.
+
+Tier 4 (e2e-sdr-full) and tier 5 (e2e-full) both validate connectors
+end-to-end against the *tenant's* system apps (publish, query-intelligence,
+lineage, lineage-publish) on top of the connector's own extract step. The
+moving parts are identical:
+
+1. Submit an Automation Engine workflow via
+   ``POST /api/service/package-workflows?submit=true``.
+2. Poll the run via
+   ``GET /api/service/package-workflows/native-status/<run_id>``
+   until every DAG node reaches a terminal status.
+3. Poll Atlas via
+   ``GET /api/meta/entity/uniqueAttribute/type/Connection?attr:qualifiedName=...``
+   until the resulting Connection asset shows up.
+
+The only thing that differs between tier 4 and tier 5 is *where the
+connector image runs* — tier 4 uses a CI-side docker compose worker
+registered on a unique Temporal queue (using the agent flow); tier 5
+uses a tenant-deployed pod (using the direct flow). The submission +
+polling + assertion are the same.
+
+Public surface:
+
+- :class:`BaseFullDAGE2ETest` — pytest base class subclasses configure
+  with connector-specific knobs (app name, Argo template, connection
+  qualifying-name prefix) and then call :meth:`run_full_dag` to execute.
+
+- :func:`build_ae_payload` — payload builder shared between the agent
+  (tier 4) and direct (tier 5) modes.
+
+- :class:`AEWorkflowClient` — thin HTTP wrapper around the three Atlan
+  endpoints used above, with retry on transient 5xx and a structured
+  return shape per DAG node.
+
+See ``application_sdk.testing.sdr`` for the connector-only validation
+that runs in tier 3 (BLDX-1254). Tier 4/5 complement tier 3 by adding
+the tenant-side system-apps validation.
+"""
+
+from application_sdk.testing.full_dag.base import BaseFullDAGE2ETest, RunMode
+from application_sdk.testing.full_dag.client import (
+    AEWorkflowClient,
+    DAGNodeStatus,
+    DAGRunStatus,
+)
+from application_sdk.testing.full_dag.payload import build_ae_payload
+
+__all__ = [
+    "AEWorkflowClient",
+    "BaseFullDAGE2ETest",
+    "DAGNodeStatus",
+    "DAGRunStatus",
+    "RunMode",
+    "build_ae_payload",
+]

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -1,0 +1,327 @@
+"""Pytest base class for full-DAG e2e tests against tenant system apps.
+
+A connector test:
+
+.. code-block:: python
+
+    import os
+    import pytest
+    from application_sdk.testing.full_dag import (
+        BaseFullDAGE2ETest, RunMode,
+    )
+    from application_sdk.testing.full_dag.payload import (
+        ConnectionSpec, DatabaseSpec, AgentSpec,
+    )
+
+    @pytest.mark.full_dag_e2e
+    class TestMySQLFullDAG(BaseFullDAGE2ETest):
+        connector_short_name = "mysql"
+        argo_package_name = "@atlan/mysql"
+        argo_template_name = "atlan-mysql"
+
+        # AGENT for tier 4 (CI-side worker); DIRECT for tier 5 (prod pod).
+        mode = RunMode.AGENT
+        app_service_url = "http://mysql.mysql-app.svc.cluster.local"
+
+        def database_spec(self) -> DatabaseSpec:
+            return DatabaseSpec(
+                host=os.environ["MYSQL_HOST"],
+                port=int(os.environ["MYSQL_PORT"]),
+                username=os.environ["MYSQL_USER"],
+                password=os.environ["MYSQL_PASSWORD"],
+            )
+
+        def agent_spec(self) -> AgentSpec | None:
+            return AgentSpec(agent_name=f"ci-{self.run_id}")
+
+The base class handles submit + native-status poll + Atlas-side
+Connection assertion + per-node duration reporting. Subclasses just
+provide config.
+
+To skip the whole class when the harness env isn't configured (so the
+test class can sit alongside per-PR tier-3 tests without breaking
+``pytest -q``)::
+
+    if not os.environ.get("ATLAN_BASE_URL"):
+        pytest.skip("ATLAN_BASE_URL not set; full-DAG e2e harness disabled",
+                    allow_module_level=True)
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from typing import ClassVar
+
+from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing.full_dag.client import AEWorkflowClient, DAGRunResult
+from application_sdk.testing.full_dag.payload import (
+    AgentSpec,
+    ConnectionSpec,
+    DatabaseSpec,
+    RunMode,
+    build_ae_payload,
+)
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class FullDAGOutcome:
+    """Combined result of a single full-DAG run.
+
+    Returned by :meth:`BaseFullDAGE2ETest.run_full_dag` so subclasses
+    can build their own assertions on top — e.g. "extract took less
+    than X seconds", "all four entity types extracted", etc.
+    """
+
+    ae_result: DAGRunResult
+    connection_qualified_name: str
+    connection_in_atlas: bool
+
+    @property
+    def succeeded(self) -> bool:
+        """True iff every DAG node succeeded *and* Atlas has the Connection."""
+        return self.ae_result.all_nodes_succeeded and self.connection_in_atlas
+
+
+class BaseFullDAGE2ETest:
+    """Pytest base — subclass per connector, set class attrs.
+
+    Class attrs subclasses MUST set:
+
+    Attributes:
+        connector_short_name: ``mysql``, ``mssql``, ``saperp``, etc.
+        argo_package_name: ``@atlan/<connector>``.
+        argo_template_name: Cluster-scoped WorkflowTemplate name
+            (e.g. ``atlan-mysql``). Must match what the tenant has
+            installed.
+        mode: :data:`RunMode.AGENT` for tier 4, :data:`RunMode.DIRECT`
+            for tier 5.
+        app_service_url: HTTP URL the AE workflow's extract activity
+            falls back to. Metadata-only in agent mode; used for
+            credential injection in direct mode.
+
+    Class attrs with defaults:
+
+    Attributes:
+        connection_name_prefix: Prefix applied to the test Connection
+            name and qualifiedName so cleanup sweeps can find them.
+        include_filter / exclude_filter: JSON-encoded dict-shape
+            filter strings (matches the orchestrator's expected wire
+            format). Default = "everything under the default catalog".
+        connection_admin_users / _groups / _roles: ACL on the test
+            Connection. Default empty.
+        ae_poll_interval_seconds / ae_poll_timeout_seconds: How
+            aggressively to poll native-status.
+        atlas_poll_interval_seconds / atlas_poll_timeout_seconds: How
+            aggressively to poll the Atlas Connection endpoint.
+
+    Subclass methods to provide config:
+
+        ``database_spec() -> DatabaseSpec``
+        ``agent_spec() -> AgentSpec | None``  (None for DIRECT mode)
+    """
+
+    # --- required class attrs (must be overridden) ---------------------
+    connector_short_name: ClassVar[str] = ""
+    argo_package_name: ClassVar[str] = ""
+    argo_template_name: ClassVar[str] = ""
+    mode: ClassVar[RunMode] = RunMode.DIRECT
+    app_service_url: ClassVar[str] = ""
+
+    # --- optional class attrs ------------------------------------------
+    connection_name_prefix: ClassVar[str] = "full-dag-e2e"
+    include_filter: ClassVar[str] = '{"^def$":[".*"]}'
+    exclude_filter: ClassVar[str] = "{}"
+    connection_admin_users: ClassVar[tuple[str, ...]] = ()
+    connection_admin_groups: ClassVar[tuple[str, ...]] = ()
+    connection_admin_roles: ClassVar[tuple[str, ...]] = ()
+
+    ae_poll_interval_seconds: ClassVar[int] = 10
+    ae_poll_timeout_seconds: ClassVar[int] = 600
+    atlas_poll_interval_seconds: ClassVar[int] = 30
+    atlas_poll_timeout_seconds: ClassVar[int] = 1500
+
+    # ------------------------------------------------------------------
+    # Setup
+    # ------------------------------------------------------------------
+
+    def setup_method(self) -> None:
+        """Resolve env + build the per-test identity.
+
+        Pytest invokes this before every test method. We re-stamp
+        ``run_id`` on each call so re-running the same test class in a
+        single pytest invocation never collides on Connection QN.
+        """
+        for required in (
+            "connector_short_name",
+            "argo_package_name",
+            "argo_template_name",
+        ):
+            if not getattr(type(self), required, ""):
+                raise RuntimeError(
+                    f"{type(self).__name__}: class attribute '{required}' must be set"
+                )
+
+        tenant_url = os.environ.get("ATLAN_BASE_URL", "").rstrip("/")
+        api_token = os.environ.get("ATLAN_API_KEY", "")
+        if not tenant_url or not api_token:
+            raise RuntimeError(
+                "Full-DAG e2e harness requires ATLAN_BASE_URL + ATLAN_API_KEY"
+            )
+
+        # Prefer GH-provided run identifier (cross-correlatable with
+        # workflow logs) — fall back to seconds-since-epoch.
+        gh_run_id = os.environ.get("GITHUB_RUN_ID")
+        self.run_id = (
+            int(gh_run_id) if gh_run_id and gh_run_id.isdigit() else int(time.time())
+        )
+        self.client = AEWorkflowClient(tenant_url, api_token)
+        self.connection_qualified_name = (
+            f"default/{self.connector_short_name}/"
+            f"{self.connection_name_prefix}-{self.run_id}"
+        )
+        self.connection_display_name = (
+            f"{self.connection_name_prefix}-{self.connector_short_name}-{self.run_id}"
+        )
+
+    # ------------------------------------------------------------------
+    # Subclass hooks — override these
+    # ------------------------------------------------------------------
+
+    def database_spec(self) -> DatabaseSpec:
+        """Real DB the connector will introspect.
+
+        Tier 4 (agent mode): the values you put here go into the AE
+        submit payload but credential resolution actually flows through
+        the SDR agent's local secret store at run time — so what
+        matters here is that ``host`` / ``port`` match what the agent
+        can reach.
+
+        Tier 5 (direct mode): values are sent verbatim to the prod pod
+        as credential overrides; must work as-is.
+        """
+        raise NotImplementedError
+
+    def agent_spec(self) -> AgentSpec | None:
+        """Agent identity (tier 4 only). Return None for direct mode."""
+        if self.mode is RunMode.DIRECT:
+            return None
+        raise NotImplementedError
+
+    def connection_spec(self) -> ConnectionSpec:
+        """Where the resulting Atlas Connection will live.
+
+        Default builds from class attrs + per-run identity. Override if
+        you need a different category / icon / ACL per test.
+        """
+        return ConnectionSpec(
+            name=self.connection_display_name,
+            qualified_name=self.connection_qualified_name,
+            connector_name=self.connector_short_name,
+            source_logo=f"https://assets.atlan.com/assets/{self.connector_short_name}.png",
+            admin_users=self.connection_admin_users,
+            admin_groups=self.connection_admin_groups,
+            admin_roles=self.connection_admin_roles,
+        )
+
+    # ------------------------------------------------------------------
+    # The actual flow
+    # ------------------------------------------------------------------
+
+    def run_full_dag(self) -> FullDAGOutcome:
+        """Submit, poll AE, poll Atlas, return the combined outcome.
+
+        Idempotent failures (AE submit returning a recognizable
+        "duplicate" error, Atlas already having the QN) are *not*
+        special-cased here — the caller is expected to make every
+        ``run_id`` unique.
+
+        Returns:
+            FullDAGOutcome describing AE node status + Atlas presence.
+        """
+        payload = build_ae_payload(
+            run_id=self.run_id,
+            mode=self.mode,
+            connector_short_name=self.connector_short_name,
+            argo_package_name=self.argo_package_name,
+            argo_template_name=self.argo_template_name,
+            app_service_url=self.app_service_url,
+            connection=self.connection_spec(),
+            database=self.database_spec(),
+            include_filter=self.include_filter,
+            exclude_filter=self.exclude_filter,
+            agent=self.agent_spec(),
+        )
+
+        logger.info(
+            "Submitting AE workflow: connector=%s mode=%s qn=%s",
+            self.connector_short_name,
+            self.mode.value,
+            self.connection_qualified_name,
+        )
+        run_id = self.client.submit_workflow(payload)
+        logger.info("AE submit returned run_id=%s", run_id)
+
+        ae_result = self.client.poll_native_status(
+            run_id,
+            interval_seconds=self.ae_poll_interval_seconds,
+            timeout_seconds=self.ae_poll_timeout_seconds,
+        )
+
+        # Only bother probing Atlas if the publish node succeeded —
+        # otherwise we waste 25 min waiting for an asset that won't land.
+        publish_succeeded = any(
+            n.name in {"publish", "publish-stage"} and n.status.is_success
+            for n in ae_result.nodes
+        )
+        if publish_succeeded:
+            connection_in_atlas = self.client.poll_atlas_for_connection(
+                self.connection_qualified_name,
+                interval_seconds=self.atlas_poll_interval_seconds,
+                timeout_seconds=self.atlas_poll_timeout_seconds,
+            )
+        else:
+            logger.warning(
+                "Publish node did not succeed — skipping Atlas probe to save time"
+            )
+            connection_in_atlas = False
+
+        return FullDAGOutcome(
+            ae_result=ae_result,
+            connection_qualified_name=self.connection_qualified_name,
+            connection_in_atlas=connection_in_atlas,
+        )
+
+    # ------------------------------------------------------------------
+    # Default test method
+    # ------------------------------------------------------------------
+
+    def test_full_dag_runs_end_to_end(self) -> None:
+        """Default pytest method — submit, run, assert success.
+
+        Subclasses can override with their own assertions (entity-count
+        thresholds, duration budgets, etc.) — call :meth:`run_full_dag`
+        and inspect the returned :class:`FullDAGOutcome`.
+        """
+        outcome = self.run_full_dag()
+        if not outcome.succeeded:
+            failed = outcome.ae_result.failed_nodes
+            failures_msg = (
+                "\n".join(
+                    f"  - {n.name}: status={n.status.value} error={n.error_message}"
+                    for n in failed
+                )
+                if failed
+                else "  (all DAG nodes succeeded; Connection just didn't land in Atlas)"
+            )
+            raise AssertionError(
+                f"Full-DAG e2e failed for connector={self.connector_short_name}\n"
+                f"AE run_id={outcome.ae_result.run_id} "
+                f"slug={outcome.ae_result.workflow_slug}\n"
+                f"AE status={outcome.ae_result.status.value}\n"
+                f"Connection in Atlas? {outcome.connection_in_atlas}\n"
+                f"Failed nodes:\n{failures_msg}"
+            )

--- a/application_sdk/testing/full_dag/client.py
+++ b/application_sdk/testing/full_dag/client.py
@@ -1,0 +1,384 @@
+"""HTTP client for Atlan tenant endpoints used by tier-4/5 full-DAG tests.
+
+Wraps three endpoints:
+
+* ``POST /api/service/package-workflows?submit=true`` — AE submit.
+* ``GET  /api/service/package-workflows/native-status/<run_id>`` — DAG
+  run status with per-node breakdown (one entry per node in
+  ``manifest.json``'s DAG).
+* ``GET  /api/meta/entity/uniqueAttribute/type/Connection?attr:qualifiedName=<qn>``
+  — Atlas-side check that the resulting Connection asset is queryable.
+
+The shape of the native-status response (captured against devex with a
+real workflow run):
+
+.. code-block:: json
+
+    {
+      "status": "Running",
+      "run_id": "7fd7b893-...",
+      "workflow_slug": "mysql-oUUCLfTn",
+      "temporal_run_id": "...",
+      "dag_nodes": {
+        "extract":         {"status": "Succeeded", "started_at": ..., "completed_at": ..., "error_message": null},
+        "qi":              {"status": "Succeeded", ...},
+        "publish":         {"status": "Succeeded", ...},
+        "lineage-app":     {"status": "Running",   ...},
+        "lineage-publish": {"status": "Pending",   ...}
+      }
+    }
+
+We treat ``"Succeeded" | "Failed" | "Error" | "Cancelled"`` as terminal
+node statuses, ``"Running" | "Pending" | "Scheduled"`` as in-flight.
+"""
+
+from __future__ import annotations
+
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+import orjson
+
+from application_sdk.observability.logger_adaptor import get_logger
+
+logger = get_logger(__name__)
+
+
+# Standard library urllib's default User-Agent (``Python-urllib/<ver>``)
+# is blocked by Cloudflare on most Atlan tenants (Error 1010 — browser
+# signature banned). Spoofing a real UA keeps the request flowing through.
+_USER_AGENT = "atlan-sdk-full-dag-e2e/1.0 (+https://github.com/atlanhq/application-sdk)"
+
+# Timeout budget for individual HTTP calls. Polls run inside outer
+# while-loops so the overall budget is driven by ``poll_native_status``
+# / ``poll_atlas_for_connection``; the per-request timeout just keeps
+# any one call from hanging the whole loop.
+_HTTP_TIMEOUT = 30
+
+
+class DAGNodeStatus(str, Enum):
+    """Status values returned by ``native-status`` per DAG node."""
+
+    PENDING = "Pending"
+    SCHEDULED = "Scheduled"
+    RUNNING = "Running"
+    SUCCEEDED = "Succeeded"
+    FAILED = "Failed"
+    ERROR = "Error"
+    CANCELLED = "Cancelled"
+
+    @property
+    def is_terminal(self) -> bool:
+        """True if this status will not change without re-submission."""
+        return self in {
+            DAGNodeStatus.SUCCEEDED,
+            DAGNodeStatus.FAILED,
+            DAGNodeStatus.ERROR,
+            DAGNodeStatus.CANCELLED,
+        }
+
+    @property
+    def is_success(self) -> bool:
+        """True when the node completed without error."""
+        return self is DAGNodeStatus.SUCCEEDED
+
+
+class DAGRunStatus(str, Enum):
+    """Top-level status of an AE workflow run."""
+
+    PENDING = "Pending"
+    RUNNING = "Running"
+    SUCCEEDED = "Succeeded"
+    FAILED = "Failed"
+    ERROR = "Error"
+    CANCELLED = "Cancelled"
+
+    @property
+    def is_terminal(self) -> bool:
+        return self in {
+            DAGRunStatus.SUCCEEDED,
+            DAGRunStatus.FAILED,
+            DAGRunStatus.ERROR,
+            DAGRunStatus.CANCELLED,
+        }
+
+
+@dataclass(frozen=True)
+class DAGNodeResult:
+    """One row of the per-node breakdown returned by ``native-status``."""
+
+    name: str
+    status: DAGNodeStatus
+    started_at_ms: int | None
+    completed_at_ms: int | None
+    error_message: str | None
+
+    @property
+    def duration_seconds(self) -> float | None:
+        """Wall time if both endpoints are populated."""
+        if self.started_at_ms is None or self.completed_at_ms is None:
+            return None
+        return (self.completed_at_ms - self.started_at_ms) / 1000.0
+
+
+@dataclass(frozen=True)
+class DAGRunResult:
+    """Full result returned by :meth:`AEWorkflowClient.poll_native_status`."""
+
+    run_id: str
+    workflow_slug: str
+    status: DAGRunStatus
+    nodes: list[DAGNodeResult]
+
+    @property
+    def all_nodes_succeeded(self) -> bool:
+        return bool(self.nodes) and all(n.status.is_success for n in self.nodes)
+
+    @property
+    def failed_nodes(self) -> list[DAGNodeResult]:
+        return [n for n in self.nodes if not n.status.is_success]
+
+
+class AEWorkflowClient:
+    """Thin wrapper over the three Atlan endpoints used by full-DAG tests.
+
+    Stateless aside from caching the auth token. Methods are idempotent
+    and safe to retry.
+
+    Args:
+        tenant_url: Base URL of the tenant (e.g. ``https://devex.atlan.com``).
+            Trailing slash is stripped if present.
+        api_token: Bearer token. Accepts either a long-lived API key or a
+            short-lived OAuth ``client_credentials`` access token.
+    """
+
+    def __init__(self, tenant_url: str, api_token: str) -> None:
+        self.tenant_url = tenant_url.rstrip("/")
+        self._api_token = api_token
+
+    # ------------------------------------------------------------------
+    # Low-level HTTP
+    # ------------------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: dict[str, Any] | None = None,
+        timeout: int = _HTTP_TIMEOUT,
+    ) -> tuple[int, dict[str, Any] | str]:
+        """HTTP request returning ``(status_code, parsed_body_or_text)``."""
+        url = f"{self.tenant_url}{path}"
+        data = orjson.dumps(body) if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("Authorization", f"Bearer {self._api_token}")
+        req.add_header("Accept", "application/json")
+        req.add_header("User-Agent", _USER_AGENT)
+        if body is not None:
+            req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                raw = resp.read()
+                try:
+                    return resp.status, orjson.loads(raw)
+                except orjson.JSONDecodeError:
+                    return resp.status, raw.decode(errors="replace")
+        except urllib.error.HTTPError as e:
+            raw = e.read()
+            try:
+                return e.code, orjson.loads(raw)
+            except orjson.JSONDecodeError:
+                return e.code, raw.decode(errors="replace")
+
+    # ------------------------------------------------------------------
+    # Endpoints
+    # ------------------------------------------------------------------
+
+    def submit_workflow(self, payload: dict[str, Any]) -> str:
+        """POST ``/api/service/package-workflows?submit=true``.
+
+        Returns the run UUID from the submit response. The submit
+        response shape is not officially documented; we look for
+        ``run_id`` under either the top level or a nested ``data`` key.
+
+        Raises:
+            RuntimeError: On non-2xx HTTP status or missing ``run_id``.
+        """
+        status, body = self._request(
+            "POST",
+            "/api/service/package-workflows?submit=true",
+            body=payload,
+        )
+        if status >= 300 or not isinstance(body, dict):
+            raise RuntimeError(f"AE submit failed: HTTP {status}\nresponse={body!r}")
+        data = body.get("data") if isinstance(body.get("data"), dict) else body
+        run_id = data.get("run_id") if isinstance(data, dict) else None
+        if not run_id:
+            raise RuntimeError(f"AE submit returned no run_id\nresponse={body!r}")
+        return str(run_id)
+
+    def get_native_status(self, run_id: str) -> DAGRunResult:
+        """GET ``/api/service/package-workflows/native-status/<run_id>``.
+
+        Parses the response into a typed :class:`DAGRunResult` so callers
+        don't have to memorize the wire shape.
+        """
+        status, body = self._request(
+            "GET",
+            f"/api/service/package-workflows/native-status/{run_id}"
+            "?execution_mode=automation-engine",
+        )
+        if status >= 300 or not isinstance(body, dict):
+            raise RuntimeError(
+                f"native-status failed: HTTP {status}\nresponse={body!r}"
+            )
+        nodes_raw = body.get("dag_nodes") or {}
+        nodes = [
+            DAGNodeResult(
+                name=name,
+                status=_safe_node_status(n.get("status")),
+                started_at_ms=_safe_int(n.get("started_at")),
+                completed_at_ms=_safe_int(n.get("completed_at")),
+                error_message=n.get("error_message"),
+            )
+            for name, n in sorted(nodes_raw.items())
+        ]
+        return DAGRunResult(
+            run_id=str(body.get("run_id", run_id)),
+            workflow_slug=str(body.get("workflow_slug", "")),
+            status=_safe_run_status(body.get("status")),
+            nodes=nodes,
+        )
+
+    def poll_native_status(
+        self,
+        run_id: str,
+        *,
+        interval_seconds: int = 10,
+        timeout_seconds: int = 600,
+    ) -> DAGRunResult:
+        """Poll until the run reaches a terminal top-level status.
+
+        Logs a one-line summary per poll only when the status string
+        changes (i.e. progress moments), to avoid spamming logs during
+        long-running publish / lineage stages.
+        """
+        elapsed = 0
+        last_summary: str | None = None
+        last_result: DAGRunResult | None = None
+        while elapsed < timeout_seconds:
+            result = self.get_native_status(run_id)
+            last_result = result
+            summary = "; ".join(f"{n.name}={n.status.value}" for n in result.nodes)
+            if summary != last_summary:
+                logger.info(
+                    "AE run %s (slug=%s) status=%s | %s",
+                    result.run_id,
+                    result.workflow_slug,
+                    result.status.value,
+                    summary,
+                )
+                last_summary = summary
+            if result.status.is_terminal:
+                return result
+            time.sleep(interval_seconds)
+            elapsed += interval_seconds
+        # Timeout: return the last observation so callers can include
+        # node-level state in the failure message rather than just
+        # "timed out after Xs".
+        if last_result is not None:
+            return last_result
+        raise RuntimeError(
+            f"native-status timed out after {timeout_seconds}s with no response"
+        )
+
+    def get_connection_in_atlas(self, qualified_name: str) -> int:
+        """HEAD-style probe for a Connection asset. Returns HTTP status code.
+
+        200 means the Connection exists and is queryable in Atlas. 404
+        means publish hasn't flushed it yet (or the workflow failed).
+        Any other status is a real error worth surfacing.
+        """
+        status, _ = self._request(
+            "GET",
+            "/api/meta/entity/uniqueAttribute/type/Connection"
+            f"?attr:qualifiedName={qualified_name}",
+        )
+        return status
+
+    def poll_atlas_for_connection(
+        self,
+        qualified_name: str,
+        *,
+        interval_seconds: int = 30,
+        timeout_seconds: int = 1500,
+    ) -> bool:
+        """Poll Atlas until the Connection appears or timeout elapses.
+
+        Wide default budget (25 min) because publish runs after the AE
+        DAG completes and can take a while to flush large connections.
+        Callers with smaller datasets can tighten this.
+        """
+        elapsed = 0
+        while elapsed < timeout_seconds:
+            status = self.get_connection_in_atlas(qualified_name)
+            logger.info(
+                "Atlas Connection probe [%ds] qn=%s HTTP %d",
+                elapsed,
+                qualified_name,
+                status,
+            )
+            if status == 200:
+                return True
+            if status >= 500:
+                logger.warning(
+                    "Atlas returned %d for Connection probe; retrying", status
+                )
+            time.sleep(interval_seconds)
+            elapsed += interval_seconds
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Helpers — defensive parsing for forward-compat
+# ---------------------------------------------------------------------------
+
+
+def _safe_node_status(raw: Any) -> DAGNodeStatus:
+    """Map unknown / future status strings to ``Pending`` rather than raising.
+
+    The AE service can introduce new intermediate statuses ahead of SDK
+    releases; treating unknowns as non-terminal keeps polling alive
+    instead of crashing the test on an unexpected enum value.
+    """
+    if not isinstance(raw, str):
+        return DAGNodeStatus.PENDING
+    try:
+        return DAGNodeStatus(raw)
+    except ValueError:
+        return DAGNodeStatus.PENDING
+
+
+def _safe_run_status(raw: Any) -> DAGRunStatus:
+    """Same defensive mapping for the top-level run status."""
+    if not isinstance(raw, str):
+        return DAGRunStatus.PENDING
+    try:
+        return DAGRunStatus(raw)
+    except ValueError:
+        return DAGRunStatus.PENDING
+
+
+def _safe_int(raw: Any) -> int | None:
+    """Cast a JSON number to int, returning None on missing / non-numeric."""
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None

--- a/application_sdk/testing/full_dag/payload.py
+++ b/application_sdk/testing/full_dag/payload.py
@@ -1,0 +1,356 @@
+"""Build the AE submit payload for full-DAG e2e tests.
+
+Captured shape from the devex UI by inspecting the network tab on a real
+"submit MySQL extract" click. The payload nests the same connection
+attributes in three places (top-level ``payload[].body``,
+``parameters['connection']`` as a JSON string, and a long list of flat
+``connection.<key>`` parameter rows) — this duplication is what the
+tenant's package-workflows service expects, so we faithfully reproduce
+it from a single :class:`ConnectionSpec` source of truth.
+
+Two modes:
+
+* :data:`RunMode.DIRECT` — the AE workflow's ``extract`` activity
+  dispatches to ``task_queue: atlan-<app>-<deployment>`` and the
+  tenant's *production-deployed* connector pod picks it up. Tier 5.
+* :data:`RunMode.AGENT` — same queue, but ``agent-name`` routes to a
+  caller-deployed worker (e.g. CI-side compose with a unique
+  agent-name + S3 binding). Tier 4.
+
+The submitter's responsibility is to ensure the connector worker that
+listens on the resulting Temporal queue is actually running before the
+AE DAG dispatches to it. For tier 4 that's the docker compose worker;
+for tier 5 that's the prod-deployed pod.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+import orjson
+
+
+class RunMode(str, Enum):
+    """Whether the connector runs in tenant or in caller-controlled CI."""
+
+    DIRECT = "direct"
+    AGENT = "agent"
+
+
+@dataclass(frozen=True)
+class ConnectionSpec:
+    """Identity of the Connection the AE workflow will create.
+
+    The ``qualified_name`` should be unique per test run — the tenant
+    treats Connection QN as the upsert key, so colliding QNs across
+    test runs will overwrite each other and confuse asset assertions.
+    Convention: ``default/<connector>/<test-prefix>-<run_id>``.
+    """
+
+    name: str
+    qualified_name: str
+    connector_name: str  # mysql, mssql, etc — must match the @atlan/<conn> package
+    source_logo: str
+    admin_users: tuple[str, ...] = ()
+    admin_groups: tuple[str, ...] = ()
+    admin_roles: tuple[str, ...] = ()
+    category: str = "warehouse"
+    row_limit: int = 10_000
+    allow_query: bool = True
+    allow_query_preview: bool = True
+    is_discoverable: bool = True
+    is_editable: bool = False
+
+    def attributes(self) -> dict[str, Any]:
+        """Pyatlan-style ``Connection.attributes`` block."""
+        return {
+            "name": self.name,
+            "qualifiedName": self.qualified_name,
+            "allowQuery": self.allow_query,
+            "allowQueryPreview": self.allow_query_preview,
+            "rowLimit": self.row_limit,
+            "defaultCredentialGuid": "{{credentialGuid}}",
+            "connectorName": self.connector_name,
+            "sourceLogo": self.source_logo,
+            "isDiscoverable": self.is_discoverable,
+            "isEditable": self.is_editable,
+            "category": self.category,
+            "adminUsers": list(self.admin_users),
+            "adminGroups": list(self.admin_groups),
+            "adminRoles": list(self.admin_roles),
+        }
+
+
+@dataclass(frozen=True)
+class DatabaseSpec:
+    """DB connection details for the credential payload."""
+
+    host: str
+    port: int
+    username: str
+    password: str
+    auth_type: str = "basic"
+    extra: dict[str, Any] = field(default_factory=dict)
+    connector_config_name: str = ""  # e.g. atlan-connectors-mysql
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    """Optional agent routing (tier 4 only).
+
+    ``agent_name`` is used by the Argo cluster template to derive the
+    Temporal task queue (``atlan-<app>-<agent_name>``). The CI worker
+    listens on the same queue; AE then dispatches the extract to it.
+    """
+
+    agent_name: str
+    agent_type: str = "new-app-framework"
+    key_type: str = "single-key"
+    aws_auth_method: str = "iam"
+    azure_auth_method: str = "managed_identity"
+
+
+def build_ae_payload(
+    *,
+    run_id: int,
+    mode: RunMode,
+    connector_short_name: str,
+    argo_package_name: str,
+    argo_template_name: str,
+    app_service_url: str,
+    connection: ConnectionSpec,
+    database: DatabaseSpec,
+    include_filter: str = '{"^def$":[".*"]}',
+    exclude_filter: str = "{}",
+    agent: AgentSpec | None = None,
+) -> dict[str, Any]:
+    """Assemble the AE submit body.
+
+    Args:
+        run_id: Run identifier (typically ``int(time.time())`` or
+            ``int(os.environ["GITHUB_RUN_ID"])``). Used as a unique
+            tag in the AE workflow name and labels.
+        mode: ``DIRECT`` (tier 5) or ``AGENT`` (tier 4).
+        connector_short_name: ``mysql``, ``mssql``, ``saperp``, etc.
+            Drives label keys + Argo template selection.
+        argo_package_name: The ``@atlan/<connector>`` Argo package name.
+        argo_template_name: Cluster-scoped WorkflowTemplate name
+            (``atlan-mysql``, ``atlan-mssql``).
+        app_service_url: HTTP URL the AE workflow can reach the
+            connector at. For tier 4 / agent flow this is metadata only
+            (Temporal-queue routing handles dispatch). For tier 5 /
+            direct flow this is the in-cluster service URL of the prod
+            pod (``http://<app>.<app>-app.svc.cluster.local``).
+        connection: Where the Atlas Connection will be created.
+        database: Real DB the connector will introspect.
+        include_filter / exclude_filter: JSON-encoded dict filter
+            strings (the tenant orchestrator deserializes these before
+            handing to the connector). Defaults match the "all schemas
+            in the default catalog" case.
+        agent: Required when ``mode == AGENT``. Ignored in DIRECT mode.
+
+    Returns:
+        Dict ready to ``orjson.dumps`` and POST to
+        ``/api/service/package-workflows?submit=true``.
+    """
+    if mode is RunMode.AGENT and agent is None:
+        raise ValueError("agent mode requires an AgentSpec")
+
+    label_key = f"orchestration.atlan.com/default-{connector_short_name}-{run_id}"
+    ae_workflow_name = f"atlan-{connector_short_name}-{run_id}"
+    ae_atlan_name = (
+        f"atlan-{connector_short_name}-default-{connector_short_name}-{run_id}"
+    )
+
+    parameters: list[dict[str, Any]] = []
+    parameters.append({"name": "extraction-method", "value": mode.value})
+    parameters.append({"name": "credential-guid", "value": "{{credentialGuid}}"})
+
+    if mode is RunMode.AGENT:
+        assert agent is not None
+        agent_json = {
+            "host": database.host,
+            "port": database.port,
+            "auth-type": database.auth_type,
+            "agent-name": agent.agent_name,
+            "agent-type": agent.agent_type,
+            "key-type": agent.key_type,
+            "aws-auth-method": agent.aws_auth_method,
+            "azure-auth-method": agent.azure_auth_method,
+            # In agent mode the username/password fields are *secret-store
+            # keys*, not literal values — the agent's local Dapr
+            # secret-store resolves them at workflow time. Callers should
+            # pre-populate the secret store with these keys.
+            "basic.username": f"{connector_short_name.upper()}_USERNAME",
+            "basic.password": f"{connector_short_name.upper()}_PASSWORD",
+        }
+        parameters.append(
+            {"name": "agent-json", "value": orjson.dumps(agent_json).decode()}
+        )
+
+    # Connection (full nested JSON string)
+    parameters.append(
+        {
+            "name": "connection",
+            "value": orjson.dumps(
+                {"attributes": connection.attributes(), "typeName": "Connection"}
+            ).decode(),
+        }
+    )
+
+    # Filters
+    parameters.append({"name": "include-filter", "value": include_filter})
+    parameters.append({"name": "exclude-filter", "value": exclude_filter})
+
+    # Credential overrides — in DIRECT mode these go straight through to
+    # the prod pod; in AGENT mode they're ignored in favour of the
+    # agent-json secret-store keys above.
+    parameters.append(
+        {
+            "name": "credential-guid.credential-type",
+            "value": database.connector_config_name
+            or f"atlan-connectors-{connector_short_name}",
+        }
+    )
+    parameters.append({"name": "credential-guid.port", "value": database.port})
+    parameters.append(
+        {"name": "credential-guid.auth-type", "value": database.auth_type}
+    )
+    if mode is RunMode.DIRECT:
+        parameters.append({"name": "credential-guid.host", "value": database.host})
+        parameters.append(
+            {
+                "name": "credential-guid.basic.username",
+                "value": database.username,
+            }
+        )
+        parameters.append(
+            {
+                "name": "credential-guid.basic.password",
+                "value": database.password,
+            }
+        )
+    else:
+        # Agent mode duplicates a subset under agent-json.* — the Argo
+        # cluster template reads these flat parameters separately even
+        # though it could also unpack agent-json JSON. Reproducing the
+        # exact UI shape avoids subtle service-side validation drift.
+        assert agent is not None
+        parameters.extend(
+            [
+                {"name": "agent-json.host", "value": database.host},
+                {"name": "agent-json.port", "value": database.port},
+                {"name": "agent-json.auth-type", "value": database.auth_type},
+                {"name": "agent-json.agent-name", "value": agent.agent_name},
+                {"name": "agent-json.agent-type", "value": agent.agent_type},
+                {"name": "agent-json.key-type", "value": agent.key_type},
+                {"name": "agent-json.aws-auth-method", "value": agent.aws_auth_method},
+                {
+                    "name": "agent-json.azure-auth-method",
+                    "value": agent.azure_auth_method,
+                },
+                {
+                    "name": "agent-json.basic.username",
+                    "value": f"{connector_short_name.upper()}_USERNAME",
+                },
+                {
+                    "name": "agent-json.basic.password",
+                    "value": f"{connector_short_name.upper()}_PASSWORD",
+                },
+            ]
+        )
+
+    # Flat connection.* parameter rows (UI sends both the nested JSON
+    # and these for the orchestrator's convenience).
+    attrs = connection.attributes()
+    parameters.extend(
+        [
+            {"name": "connection.name", "value": attrs["name"]},
+            {"name": "connection.qualifiedName", "value": attrs["qualifiedName"]},
+            {"name": "connection.allowQuery", "value": attrs["allowQuery"]},
+            {
+                "name": "connection.allowQueryPreview",
+                "value": attrs["allowQueryPreview"],
+            },
+            {"name": "connection.rowLimit", "value": attrs["rowLimit"]},
+            {"name": "connection.connectorName", "value": attrs["connectorName"]},
+            {"name": "connection.sourceLogo", "value": attrs["sourceLogo"]},
+            {"name": "connection.isDiscoverable", "value": attrs["isDiscoverable"]},
+            {"name": "connection.isEditable", "value": attrs["isEditable"]},
+            {"name": "connection.category", "value": attrs["category"]},
+            {
+                "name": "connection.adminUsers",
+                "value": orjson.dumps(attrs["adminUsers"]).decode(),
+            },
+            {
+                "name": "connection.adminGroups",
+                "value": orjson.dumps(attrs["adminGroups"]).decode(),
+            },
+            {
+                "name": "connection.adminRoles",
+                "value": orjson.dumps(attrs["adminRoles"]).decode(),
+            },
+        ]
+    )
+
+    return {
+        "metadata": {
+            "labels": {
+                label_key: "true",
+                "orchestration.atlan.com/atlan-ui": "true",
+            },
+            "annotations": {
+                "orchestration.atlan.com/name": f"{connector_short_name.title()} Assets (full-DAG e2e)",
+                "package.argoproj.io/name": argo_package_name,
+                "orchestration.atlan.com/atlanName": ae_atlan_name,
+            },
+            "name": ae_workflow_name,
+            "namespace": "default",
+            "ae_workflow_slug": f"{connector_short_name}-e2e-{run_id}",
+            "app_service_url": app_service_url,
+        },
+        "spec": {
+            "templates": [
+                {
+                    "name": "main",
+                    "dag": {
+                        "tasks": [
+                            {
+                                "name": "run",
+                                "arguments": {"parameters": parameters},
+                                "templateRef": {
+                                    "name": argo_template_name,
+                                    "template": "main",
+                                    "clusterScope": True,
+                                },
+                            }
+                        ]
+                    },
+                }
+            ],
+            "entrypoint": "main",
+            "workflowMetadata": {
+                "annotations": {"package.argoproj.io/name": argo_package_name}
+            },
+        },
+        "payload": [
+            {
+                "parameter": "credentialGuid",
+                "type": "credential",
+                "body": {
+                    "name": f"default-{connector_short_name}-{run_id}-0",
+                    "host": database.host,
+                    "port": database.port,
+                    "authType": database.auth_type,
+                    "username": database.username,
+                    "password": database.password,
+                    "extra": dict(database.extra),
+                    "connectorConfigName": database.connector_config_name
+                    or f"atlan-connectors-{connector_short_name}",
+                },
+            }
+        ],
+        "execution_mode": "native",
+    }

--- a/tests/unit/testing/full_dag/test_client.py
+++ b/tests/unit/testing/full_dag/test_client.py
@@ -1,0 +1,195 @@
+"""Unit tests for :mod:`application_sdk.testing.full_dag.client`.
+
+Network is monkeypatched out at ``_request``; we just verify the parse
++ poll-loop logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from application_sdk.testing.full_dag.client import (
+    AEWorkflowClient,
+    DAGNodeStatus,
+    DAGRunStatus,
+)
+
+
+def _make_client(monkeypatch: pytest.MonkeyPatch, responses: list[tuple[int, Any]]):
+    """Build a client whose ``_request`` returns the queued responses in order."""
+    client = AEWorkflowClient("https://tenant.example.com/", "fake-token")
+    queue = list(responses)
+
+    def fake_request(method, path, *, body=None, timeout=30):  # noqa: ARG001
+        if not queue:
+            raise AssertionError("More HTTP calls than queued responses")
+        return queue.pop(0)
+
+    monkeypatch.setattr(client, "_request", fake_request)
+    return client, queue
+
+
+def test_submit_workflow_extracts_run_id_from_top_level(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _ = _make_client(monkeypatch, [(200, {"run_id": "abc-123"})])
+    assert client.submit_workflow({"any": "payload"}) == "abc-123"
+
+
+def test_submit_workflow_extracts_run_id_from_nested_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _ = _make_client(monkeypatch, [(200, {"data": {"run_id": "nested-xyz"}})])
+    assert client.submit_workflow({}) == "nested-xyz"
+
+
+def test_submit_workflow_raises_on_missing_run_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _ = _make_client(monkeypatch, [(200, {"data": {}})])
+    with pytest.raises(RuntimeError, match="no run_id"):
+        client.submit_workflow({})
+
+
+def test_submit_workflow_raises_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    client, _ = _make_client(monkeypatch, [(401, "Unauthorized")])
+    with pytest.raises(RuntimeError, match="HTTP 401"):
+        client.submit_workflow({})
+
+
+def test_get_native_status_parses_dag_nodes(monkeypatch: pytest.MonkeyPatch) -> None:
+    client, _ = _make_client(
+        monkeypatch,
+        [
+            (
+                200,
+                {
+                    "status": "Running",
+                    "run_id": "r-1",
+                    "workflow_slug": "mysql-abc",
+                    "dag_nodes": {
+                        "extract": {
+                            "status": "Succeeded",
+                            "started_at": 1700000000000,
+                            "completed_at": 1700000010000,
+                            "error_message": None,
+                        },
+                        "publish": {
+                            "status": "Running",
+                            "started_at": 1700000010500,
+                            "completed_at": None,
+                            "error_message": None,
+                        },
+                    },
+                },
+            )
+        ],
+    )
+    result = client.get_native_status("r-1")
+    assert result.run_id == "r-1"
+    assert result.workflow_slug == "mysql-abc"
+    assert result.status is DAGRunStatus.RUNNING
+    assert len(result.nodes) == 2
+    extract = next(n for n in result.nodes if n.name == "extract")
+    assert extract.status is DAGNodeStatus.SUCCEEDED
+    assert extract.duration_seconds == 10.0
+    publish = next(n for n in result.nodes if n.name == "publish")
+    assert publish.status is DAGNodeStatus.RUNNING
+    assert publish.duration_seconds is None
+
+
+def test_unknown_status_strings_treated_as_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _ = _make_client(
+        monkeypatch,
+        [
+            (
+                200,
+                {
+                    "status": "MysteryStatus",
+                    "dag_nodes": {"x": {"status": "AlsoUnknown"}},
+                },
+            )
+        ],
+    )
+    result = client.get_native_status("r")
+    assert result.status is DAGRunStatus.PENDING
+    assert result.nodes[0].status is DAGNodeStatus.PENDING
+
+
+def test_poll_native_status_returns_on_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Avoid the real time.sleep — poll interval doesn't matter for the test.
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    client, queue = _make_client(
+        monkeypatch,
+        [
+            (200, {"status": "Running", "dag_nodes": {}}),
+            (200, {"status": "Running", "dag_nodes": {}}),
+            (
+                200,
+                {
+                    "status": "Succeeded",
+                    "dag_nodes": {"extract": {"status": "Succeeded"}},
+                },
+            ),
+        ],
+    )
+    result = client.poll_native_status("r", interval_seconds=1, timeout_seconds=60)
+    assert result.status is DAGRunStatus.SUCCEEDED
+    assert queue == []  # all three responses consumed
+
+
+def test_poll_native_status_returns_last_observation_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    client, _ = _make_client(
+        monkeypatch,
+        # interval=1, timeout=3 → we'll fire 3 polls (elapsed=0,1,2) all Running
+        [
+            (200, {"status": "Running", "dag_nodes": {}}),
+            (200, {"status": "Running", "dag_nodes": {}}),
+            (200, {"status": "Running", "dag_nodes": {}}),
+        ],
+    )
+    result = client.poll_native_status("r", interval_seconds=1, timeout_seconds=3)
+    # Still Running but we got back the last observed state instead of
+    # raising — caller can include node-level diagnostics in their error.
+    assert result.status is DAGRunStatus.RUNNING
+
+
+def test_poll_atlas_for_connection_succeeds_on_200(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    client, _ = _make_client(
+        monkeypatch, [(404, ""), (404, ""), (200, {"any": "thing"})]
+    )
+    assert (
+        client.poll_atlas_for_connection(
+            "default/mysql/test", interval_seconds=1, timeout_seconds=10
+        )
+        is True
+    )
+
+
+def test_poll_atlas_for_connection_returns_false_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    client, _ = _make_client(
+        monkeypatch,
+        # interval=1, timeout=2 → 2 polls; both 404 → returns False
+        [(404, ""), (404, "")],
+    )
+    assert (
+        client.poll_atlas_for_connection(
+            "default/mysql/test", interval_seconds=1, timeout_seconds=2
+        )
+        is False
+    )

--- a/tests/unit/testing/full_dag/test_payload.py
+++ b/tests/unit/testing/full_dag/test_payload.py
@@ -1,0 +1,190 @@
+"""Unit tests for the AE submit-payload builder.
+
+Network-free; just asserts the shape of the dict against the contract
+the tenant's package-workflows service expects (captured from the
+devex UI).
+"""
+
+from __future__ import annotations
+
+import orjson
+import pytest
+
+from application_sdk.testing.full_dag.payload import (
+    AgentSpec,
+    ConnectionSpec,
+    DatabaseSpec,
+    RunMode,
+    build_ae_payload,
+)
+
+_CONNECTION = ConnectionSpec(
+    name="full-dag-e2e-mysql-1234",
+    qualified_name="default/mysql/full-dag-e2e-1234",
+    connector_name="mysql",
+    source_logo="https://assets.atlan.com/assets/mysql.png",
+    admin_users=("aryaman",),
+    admin_roles=("30502f8b-f748-4771-9b71-2a3b3b5faae0",),
+)
+
+
+_DATABASE = DatabaseSpec(
+    host="atlan-mysql.crmgvlgwn1cx.ap-south-1.rds.amazonaws.com",
+    port=3306,
+    username="atlan",
+    password="hunter2",
+)
+
+
+def _params(payload: dict) -> dict[str, object]:
+    """Flatten the Argo task parameters into a name → value dict for assertion."""
+    tasks = payload["spec"]["templates"][0]["dag"]["tasks"]
+    return {p["name"]: p["value"] for p in tasks[0]["arguments"]["parameters"]}
+
+
+def test_direct_mode_payload_basic_shape() -> None:
+    payload = build_ae_payload(
+        run_id=1234,
+        mode=RunMode.DIRECT,
+        connector_short_name="mysql",
+        argo_package_name="@atlan/mysql",
+        argo_template_name="atlan-mysql",
+        app_service_url="http://mysql.mysql-app.svc.cluster.local",
+        connection=_CONNECTION,
+        database=_DATABASE,
+    )
+
+    assert payload["execution_mode"] == "native"
+    assert payload["metadata"]["name"] == "atlan-mysql-1234"
+    assert (
+        payload["metadata"]["app_service_url"]
+        == "http://mysql.mysql-app.svc.cluster.local"
+    )
+    assert (
+        payload["metadata"]["annotations"]["package.argoproj.io/name"] == "@atlan/mysql"
+    )
+
+    params = _params(payload)
+    assert params["extraction-method"] == "direct"
+    # Credential overrides flow through in DIRECT
+    assert params["credential-guid.host"] == _DATABASE.host
+    assert params["credential-guid.basic.username"] == _DATABASE.username
+    assert params["credential-guid.basic.password"] == _DATABASE.password
+    # No agent-json in direct mode
+    assert "agent-json" not in params
+
+
+def test_agent_mode_payload_includes_agent_json() -> None:
+    agent = AgentSpec(agent_name="ci-1234")
+    payload = build_ae_payload(
+        run_id=1234,
+        mode=RunMode.AGENT,
+        connector_short_name="mysql",
+        argo_package_name="@atlan/mysql",
+        argo_template_name="atlan-mysql",
+        app_service_url="http://mysql.mysql-app.svc.cluster.local",
+        connection=_CONNECTION,
+        database=_DATABASE,
+        agent=agent,
+    )
+
+    params = _params(payload)
+    assert params["extraction-method"] == "agent"
+
+    agent_json = orjson.loads(params["agent-json"])
+    assert agent_json["agent-name"] == "ci-1234"
+    assert agent_json["agent-type"] == "new-app-framework"
+    assert agent_json["host"] == _DATABASE.host
+    # Username/password values in agent-json are *secret-store keys*,
+    # not raw credentials — caller's secret store resolves them.
+    assert agent_json["basic.username"] == "MYSQL_USERNAME"
+    assert agent_json["basic.password"] == "MYSQL_PASSWORD"
+
+    # Flat agent-json.* duplicates of the same keys should exist
+    assert params["agent-json.agent-name"] == "ci-1234"
+    assert params["agent-json.basic.username"] == "MYSQL_USERNAME"
+
+
+def test_agent_mode_without_agent_spec_raises() -> None:
+    with pytest.raises(ValueError, match="agent mode requires"):
+        build_ae_payload(
+            run_id=1,
+            mode=RunMode.AGENT,
+            connector_short_name="mysql",
+            argo_package_name="@atlan/mysql",
+            argo_template_name="atlan-mysql",
+            app_service_url="http://mysql.mysql-app.svc.cluster.local",
+            connection=_CONNECTION,
+            database=_DATABASE,
+            agent=None,
+        )
+
+
+def test_connection_attributes_round_trip_through_payload() -> None:
+    """The nested ``connection`` parameter must JSON-parse back to the spec."""
+    payload = build_ae_payload(
+        run_id=99,
+        mode=RunMode.DIRECT,
+        connector_short_name="mysql",
+        argo_package_name="@atlan/mysql",
+        argo_template_name="atlan-mysql",
+        app_service_url="http://mysql.mysql-app.svc.cluster.local",
+        connection=_CONNECTION,
+        database=_DATABASE,
+    )
+    params = _params(payload)
+    parsed = orjson.loads(params["connection"])
+    assert parsed["typeName"] == "Connection"
+    assert parsed["attributes"]["qualifiedName"] == _CONNECTION.qualified_name
+    assert parsed["attributes"]["adminUsers"] == list(_CONNECTION.admin_users)
+
+
+def test_credential_payload_carries_real_credentials() -> None:
+    """The top-level ``payload[]`` is what the orchestrator stores as a credential.
+
+    Even in agent mode, the real DB creds get persisted on the tenant
+    side here — the agent flow just doesn't pass them through to extract.
+    """
+    payload = build_ae_payload(
+        run_id=42,
+        mode=RunMode.AGENT,
+        connector_short_name="mysql",
+        argo_package_name="@atlan/mysql",
+        argo_template_name="atlan-mysql",
+        app_service_url="http://mysql.mysql-app.svc.cluster.local",
+        connection=_CONNECTION,
+        database=_DATABASE,
+        agent=AgentSpec(agent_name="ci-42"),
+    )
+    cred = payload["payload"][0]
+    assert cred["parameter"] == "credentialGuid"
+    assert cred["body"]["username"] == _DATABASE.username
+    assert cred["body"]["password"] == _DATABASE.password
+    assert cred["body"]["host"] == _DATABASE.host
+    assert cred["body"]["connectorConfigName"] == "atlan-connectors-mysql"
+
+
+def test_run_id_drives_uniqueness() -> None:
+    """Two payloads with different run_ids must produce different workflow names."""
+    p1 = build_ae_payload(
+        run_id=1,
+        mode=RunMode.DIRECT,
+        connector_short_name="mysql",
+        argo_package_name="@atlan/mysql",
+        argo_template_name="atlan-mysql",
+        app_service_url="http://mysql.mysql-app.svc.cluster.local",
+        connection=_CONNECTION,
+        database=_DATABASE,
+    )
+    p2 = build_ae_payload(
+        run_id=2,
+        mode=RunMode.DIRECT,
+        connector_short_name="mysql",
+        argo_package_name="@atlan/mysql",
+        argo_template_name="atlan-mysql",
+        app_service_url="http://mysql.mysql-app.svc.cluster.local",
+        connection=_CONNECTION,
+        database=_DATABASE,
+    )
+    assert p1["metadata"]["name"] != p2["metadata"]["name"]
+    assert p1["metadata"]["ae_workflow_slug"] != p2["metadata"]["ae_workflow_slug"]


### PR DESCRIPTION
## Summary

Adds `application_sdk.testing.full_dag` — a shared pytest harness for tier-4 (`e2e-sdr-full`) and tier-5 (`e2e-full`) full-DAG e2e tests that exercise the connector through the tenant's system apps (`extract → qi → publish → lineage-app → lineage-publish`). Sibling to `application_sdk.testing.sdr` which covers the connector-only e2e (tier 3).

## Why

Tier-3 tests (BLDX-1254) prove the connector code works inside an SDR stack. They don't validate the connector against the tenant's system apps — i.e. "did publish actually create the Atlas Connection? did lineage materialise? did qi parse view definitions?". That's what tiers 4 and 5 are for. Both tiers share the same submit → poll → assert flow against three Atlan endpoints; this PR factors that flow out so every connector gets it for free instead of each repo re-implementing 900-line yaml shell scripts (cf. `atlan-mssql-app/.github/workflows/platform-smoke-test.yaml`).

## Public surface

```python
from application_sdk.testing.full_dag import BaseFullDAGE2ETest, RunMode
from application_sdk.testing.full_dag.payload import (
    ConnectionSpec, DatabaseSpec, AgentSpec,
)

class TestMySQLFullDAG(BaseFullDAGE2ETest):
    connector_short_name = "mysql"
    argo_package_name = "@atlan/mysql"
    argo_template_name = "atlan-mysql"
    mode = RunMode.AGENT       # AGENT for tier 4 (CI worker); DIRECT for tier 5 (prod pod)
    app_service_url = "http://mysql.mysql-app.svc.cluster.local"

    def database_spec(self) -> DatabaseSpec: ...
    def agent_spec(self) -> AgentSpec | None: ...
```

The base class's default test method submits + polls + asserts. Subclasses can override for tighter assertions (entity counts, duration budgets).

## What's in the PR

- `application_sdk/testing/full_dag/`
  - `client.py` — `AEWorkflowClient` wrapping the three tenant endpoints (submit, native-status poll, Atlas Connection probe). Defensive enum parsing for forward-compat. Spoofs a real User-Agent header (Cloudflare blocks Python-urllib with Error 1010).
  - `payload.py` — `build_ae_payload()`. Wire-shape identical to UI submits, validated against captured devex payloads. Supports both DIRECT and AGENT modes.
  - `base.py` — `BaseFullDAGE2ETest` pytest base class.
  - `__init__.py` — public re-exports.
- `tests/unit/testing/full_dag/` — 16 unit tests covering payload shape (both modes, error paths, round-trip) and client logic (HTTP parsing, poll-loop with monkeypatched network).

## Test plan

- [ ] `uv run pytest tests/unit/testing/full_dag/ -v` — all 16 unit tests pass locally.
- [ ] Mysql-app PR consumes `BaseFullDAGE2ETest` in `tests/full_dag/test_mysql_full_dag.py` and uses it from both tier-4 and tier-5 workflows.
- [ ] After landing this + the mysql consumer, mssql / other connectors can adopt the same harness.

## Related

- BLDX-1254 — tier 3 (connector SDR e2e). This PR is the tier 4/5 enabler.
- The 5-tier test pyramid: unit / integration / sdr / sdr-full / full.