### PR TITLE
feat(skill): port signal-over-noise from awesome-ai

### DIFF
--- a/.claude/skills/signal-over-noise/SKILL.md
+++ b/.claude/skills/signal-over-noise/SKILL.md
@@ -1,0 +1,520 @@
+---
+name: signal-over-noise
+description: >
+  Good investigations depend on good signals. Use this skill to improve the quality of
+  observability in a Python codebase — surfacing failures that are currently hidden, and
+  removing noise that buries the signals you need. Errors swallowed silently, stack traces
+  discarded, log output that can't be queried, credentials leaking into logs, INFO-level
+  chatter drowning out what matters: all of these slow down debugging and erode trust in
+  your observability stack. Standardising log levels means DEBUG stays out of production,
+  INFO marks genuine lifecycle events, and ERROR only fires when something actually failed
+  — so when you filter to WARNING or above during an incident, you see exactly what you
+  need and nothing you don't. Run this before an incident review, before onboarding a
+  service, or any time investigations feel harder than they should.
+argument-hint: "[--mode surface|tune] [--severity critical|high|medium|all] [path]"
+mandatory_triggers:
+  - "/signal-over-noise"
+  - "audit observability"
+  - "surface swallowed exceptions"
+  - "tune logging noise"
+optional_triggers:
+  - "find hidden errors"
+  - "clean up log levels"
+  - "improve signal to noise"
+  - "remove logging anti-patterns"
+owner: connector-platform-team
+last_updated: "2026-05-12"
+staleness_days: 90
+inputs:
+  - target_path: "first positional arg — directory to audit (default: current working directory)"
+  - mode: "surface | tune (default: surface)"
+  - severity: "critical | high | medium | all (default: all)"
+outputs:
+  - remediation plan presented in plan mode for user review
+  - edits applied to caught/silent exception sites (surface mode) or logging call sites (tune mode), left uncommitted
+  - TODO comments at sites that require manual review
+  - optional pyproject.toml ruff rule additions (tune mode, if approved)
+gates:
+  - "No edits applied before the user approves the remediation plan."
+  - "Each phase runs pre-commit on changed files before handing back to the user."
+  - "All changes left uncommitted — the user reviews and commits."
+---
+
+# Skill: `/signal-over-noise`
+
+A two-phase Python observability audit that improves the ratio of meaningful signal to noise
+in your error handling and logging. Each phase analyzes the codebase, presents a remediation
+plan for your review, and — after approval — executes the fixes.
+
+- **`--mode surface` (default):** uncovers suppressed exceptions that make failures invisible
+- **`--mode tune`:** fixes logging anti-patterns that pollute or obscure your log stream
+
+## Invocation
+
+```
+/signal-over-noise                                      # surface audit, current directory
+/signal-over-noise packages/app-framework/src           # surface audit, specific path
+/signal-over-noise --mode surface                       # same as default
+/signal-over-noise --mode tune                          # logging quality audit
+/signal-over-noise --mode tune --severity high          # HIGH + CRITICAL findings only
+/signal-over-noise --mode surface packages/foo/src      # surface audit, specific path
+```
+
+**Argument parsing:**
+- First positional token (not a flag): target path. Default: `.`
+- `--mode surface|tune`: which phase to run. Default: `surface`
+- `--severity <level>`: filter findings; levels: `critical`, `high`, `medium`, `all`. Default: `all`
+
+---
+
+## How each mode works
+
+Both modes follow the same two-stage structure:
+
+1. **Analysis** — grep the codebase, read context, classify findings, build a remediation plan.
+   Enter plan mode and present the plan for user review. The user can iterate on the plan.
+
+2. **Execution** — after the user approves the plan, apply the agreed fixes. Run pre-commit on
+   changed files. Leave all changes uncommitted for the user to review before committing.
+
+---
+
+## Mode: surface
+
+Finds every pattern where exceptions are caught and silently discarded, converting failures
+into invisible state.
+
+Pattern catalogue, severity criteria, fix templates, and linting rules are in:
+
+`.claude/skills/signal-over-noise/references/error-recovery-patterns.md`
+
+---
+
+### Stage 1 — Analysis
+
+#### Step 1.1 — Setup
+
+1. Read `.claude/skills/signal-over-noise/references/error-recovery-patterns.md` in full.
+2. Resolve `TARGET_PATH` from arguments (default: current directory). Confirm it exists.
+3. Set `SEVERITY_FILTER` from `--severity` (default: `all`).
+
+#### Step 1.2 — Pattern Detection
+
+Run all 10 grep searches in parallel against `TARGET_PATH` (`*.py` files only):
+
+| # | Pattern ID | Grep |
+|---|------------|------|
+| 1 | P1 | `except\s*:\s*pass` |
+| 2 | P2 | `except\s+\w.*:\s*pass` |
+| 3 | P3 | `contextlib\.suppress\(` |
+| 4 | P4 | `except\s+(Exception\|BaseException)\s*:` |
+| 5 | P5 | `logger\.(warning\|error\|critical)\(` inside except blocks — collect hits for Step 1.3 |
+| 6 | P6 | `^\s*except\s*:` |
+| 7 | P7 | except block with `return` and no log — collect hits for Step 1.3 |
+| 8 | P8 | `except\s+ImportError` |
+| 9 | P9 | except block with only an assignment — collect hits for Step 1.3 |
+| 10 | P10 | `return_exceptions=True` |
+| 11 | P11 | `class\s+\w+.*logging\.Filter` or `def filter\(self` inside a Filter subclass |
+
+For P5, P7, P9, P11: raw grep over-matches. Collect `file:line` hits and read context in Step 1.3.
+
+Collect all hits as a flat list: `(file, line_number, pattern_id, raw_snippet)`.
+
+#### Step 1.3 — Context Reading and Classification
+
+For each hit, read 10–15 lines of surrounding context.
+
+Classify each finding:
+- **Severity:** CRITICAL, HIGH, MEDIUM, or LOW (from §Severity Classification in reference)
+- **Legitimacy:** `genuine-bug` or `acceptable` (from §Legitimacy in reference)
+- **Category:** `silent-swallow`, `missing-traceback`, `overly-broad-catch`,
+  `error-to-return-value`, `suppress-operational`, `optional-import`, `asyncio-unexamined`
+
+Apply `SEVERITY_FILTER`: discard findings below the threshold before proceeding.
+
+#### Step 1.4 — Build Remediation Plan
+
+For each `genuine-bug` finding, produce a remediation entry:
+
+```
+File:     src/foo/bar.py:42
+Severity: HIGH
+Category: missing-traceback
+Current:
+    except ValueError as e:
+        logger.warning(f"Parse failed: {e}")
+Fix (FT-2):
+    except ValueError:
+        logger.warning("Parse failed", exc_info=True)
+Auto-fixable: yes
+Priority: P1
+```
+
+Priority mapping:
+- **P0** — CRITICAL: fix immediately, block merges
+- **P1** — HIGH: fix in current sprint
+- **P2** — MEDIUM/LOW: fix when touching the file
+
+#### Step 1.5 — Enter Plan Mode
+
+Call `EnterPlanMode`.
+
+Present the Surface Report as the plan:
+
+```markdown
+# Surface Report — <TARGET_PATH>
+
+## Executive Summary
+- Files scanned: N
+- Total findings: N (N genuine bugs, N acceptable patterns)
+- By severity: CRITICAL: N | HIGH: N | MEDIUM: N | LOW: N
+- By category: silent-swallow: N | missing-traceback: N | ...
+- Auto-fixable: N | Needs manual review: N
+
+## Findings
+| # | File | Line | Severity | Category | Pattern | Auto-fixable | Notes |
+|---|------|------|----------|----------|---------|--------------|-------|
+
+## Remediation Plan
+
+### P0 — Fix Immediately (CRITICAL)
+[entries]
+
+### P1 — Fix This Sprint (HIGH)
+[entries]
+
+### P2 — Fix When Touching (MEDIUM/LOW)
+[entries]
+
+## Acceptable Patterns (no action required)
+| File | Line | Pattern | Justification |
+|------|------|---------|---------------|
+```
+
+Call `ExitPlanMode` to request user approval. Wait for approval before proceeding to Stage 2.
+
+---
+
+### Stage 2 — Execution (after plan approval)
+
+Apply the remediation plan that was approved. Only fix what was listed in the approved plan.
+
+#### Auto-fixable patterns — apply directly:
+- **FT-1:** Add logging to silent-swallow (`except X: pass` → add `logger.warning`)
+- **FT-2:** Add `exc_info=True` to existing log call in except block
+- **FT-3:** Add logging before error-to-return-value (`except X: return Y`)
+- **FT-4:** Add exception inspection after `asyncio.gather(..., return_exceptions=True)`
+- **FT-5:** Replace broad `contextlib.suppress(Exception)` with logged try/except
+
+#### Manual review required — leave TODO comments:
+- **FT-6** (narrow broad catch): `# TODO(signal-over-noise): [P4] narrow this catch`
+- **FT-7** (Filter exception safety): `# TODO(signal-over-noise): [P11] wrap filter body in try/except`
+
+TODO comment format:
+```python
+# TODO(signal-over-noise): [P2] silent swallow — add logging. See references/error-recovery-patterns.md#P2
+```
+
+#### After applying fixes:
+
+Run pre-commit on every file that was changed:
+```bash
+uv run pre-commit run --files <file1> <file2> ...
+```
+
+If pre-commit is not available, skip this step (do not fail).
+
+Leave all changes **uncommitted** — the user reviews before committing.
+
+#### Finish
+
+Report a brief summary: N files changed, N auto-fixes applied, N TODO comments added.
+
+Then recommend the next step:
+
+> **Next:** Run `/signal-over-noise --mode tune` to audit logging quality (f-strings, missing `exc_info`, log levels, credential leaks, and more).
+
+---
+
+## Mode: tune
+
+Finds logging anti-patterns that pollute your log stream, obscure structured fields, or create
+security risks.
+
+Pattern catalogue, severity criteria, fix templates, and linting rules are in:
+
+- `.claude/skills/signal-over-noise/references/logging-patterns.md` — detectable patterns (L1–L23)
+- `.claude/skills/signal-over-noise/references/logging-level-guidelines.md` — level philosophy and framework awareness notes
+
+---
+
+### Stage 1 — Analysis
+
+#### Step 2.1 — Setup and Discovery
+
+1. Read both reference files listed above in full.
+2. Resolve `TARGET_PATH` from arguments (default: current directory). Confirm it exists.
+3. Set `SEVERITY_FILTER` from `--severity` (default: `all`).
+
+**Discover the project's logging framework** — do not assume any specific one:
+
+Grep for common logger factory patterns and count occurrences:
+- `structlog\.get_logger\(`
+- `logging\.getLogger\(`
+- `loguru` (import or usage)
+- `get_logger\(` (custom wrapper)
+
+The factory with the highest count is `CANONICAL_FACTORY`.
+
+Check `pyproject.toml` and `requirements.txt` / `uv.lock` for logging framework dependencies:
+- `structlog` in deps → `LOGGER_FRAMEWORK = structlog`
+- `loguru` in deps → `LOGGER_FRAMEWORK = loguru`
+- Neither → `LOGGER_FRAMEWORK = stdlib`
+
+Determine `SUPPORTS_KWARGS`:
+- structlog or loguru: `SUPPORTS_KWARGS = true`
+- stdlib: `SUPPORTS_KWARGS = false`
+
+**Determine `FRAMEWORK_SPECIFIC_PATTERNS`** — which additional patterns (L13–L23) to run:
+- stdlib: L13, L14, L16, L17, L20, L23
+- structlog: L15, L19
+- loguru: L19, L21, L22
+- All frameworks: L18
+
+**Discover logger variable names** — grep for assignments:
+```
+logger\s*=\s*
+log\s*=\s*
+_logger\s*=\s*
+_log\s*=\s*
+```
+
+Collect distinct prefixes (e.g. `logger`, `log`, `_logger`). Build `LOGGER_VAR_PATTERN` by
+joining them: `(logger|log|_logger|_log)\.` — use this in all Step 2.2 greps.
+
+#### Step 2.2 — Pattern Detection
+
+Run the universal patterns (L1–L12) plus `FRAMEWORK_SPECIFIC_PATTERNS` (L13–L23) in parallel
+against `TARGET_PATH`. Use `LOGGER_VAR_PATTERN` in place of hardcoded `logger\.` in each pattern.
+
+**Universal patterns (all frameworks):**
+
+| Pattern | Grep | Type |
+|---------|------|------|
+| L1 f-string | `LOGGER_VAR_PATTERN\.\w+\(f["']` | mechanical |
+| L2 inconsistent factory | Files not using `CANONICAL_FACTORY` | mechanical |
+| L3 `extra={}` | `extra=\{` near a logger call | heuristic |
+| L4 missing exc_info | multiline: `except` + log call without `exc_info` | heuristic |
+| L5 print() | `^\s*print\(` (exclude test files, CLI scripts) | mechanical |
+| L6 INFO in loop | `LOGGER_VAR_PATTERN\.info\(` inside for/while | heuristic |
+| L7 critical() | `LOGGER_VAR_PATTERN\.critical\(` | mechanical |
+| L8 expensive debug | `LOGGER_VAR_PATTERN\.debug\(.*(?:json\.dumps\|repr\|\.to_dict\|\.model_dump)` | heuristic |
+| L9 warn-then-raise | multiline: log call within 3 lines before `raise` | heuristic |
+| L10 credential in log | `LOGGER_VAR_PATTERN\.\w+\(.*(?:password\|secret\|token\|api_key\|credential\|bearer\|private_key)` (case-insensitive) | heuristic |
+| L11 concatenation | `LOGGER_VAR_PATTERN\.\w+\(["'].*["']\s*\+` | mechanical |
+| L12 %-style (non-stdlib only) | `LOGGER_VAR_PATTERN\.\w+\(["'].*%[sdfr]` — skip if `LOGGER_FRAMEWORK == stdlib` | heuristic |
+| L18 exception() outside except | `LOGGER_VAR_PATTERN\.exception\(` | heuristic |
+| L24 kwargs in application log calls | `LOGGER_VAR_PATTERN\.\w+\([^)]*,\s*\w+=` (non-stdlib only) — collect hits for Step 2.3 | heuristic |
+
+**Framework-specific patterns (run only for the indicated framework):**
+
+| Pattern | Grep | Framework | Type |
+|---------|------|-----------|------|
+| L13 extra reserved key | `extra=\{` — check keys against 22 reserved list | stdlib | heuristic |
+| L14 arbitrary kwargs | `LOGGER_VAR_PATTERN\.\w+\([^)]*,\s*\w+=` | stdlib | heuristic |
+| L15 event= kwarg | `LOGGER_VAR_PATTERN\.\w+\(.*event=` | structlog | mechanical |
+| L16 dictConfig disable_existing | `dictConfig\(` | stdlib | heuristic |
+| L17 basicConfig no-op | `basicConfig\(` (collect all across codebase) | stdlib | heuristic |
+| L19 bind() discarded | `^\s+\w+\.bind\(` as bare statement | structlog/loguru | heuristic |
+| L20 propagate=False | `propagate\s*=\s*False` | stdlib | heuristic |
+| L21 logger.remove() | `logger\.remove\(\s*\)` (no args) | loguru | mechanical |
+| L22 loguru kwargs as format | `LOGGER_VAR_PATTERN\.\w+\("[^"]*"[^)]*,\s*\w+=` | loguru | heuristic |
+| L23 warn() deprecated | `\.warn\(` | stdlib | mechanical |
+
+For **heuristic patterns**: collect `file:line` hits for Step 2.3 context reading.
+
+For **mechanical patterns** (L1, L2, L5, L7, L11, L15, L21, L23): record directly as findings.
+
+#### Step 2.3 — Context Reading and Classification
+
+For each heuristic hit, read 10–15 lines of surrounding context.
+
+Classify each hit:
+- **Severity:** apply the severity from the pattern catalogue, adjusted by context
+- **Legitimacy:** genuine finding or acceptable pattern (see §Legitimacy in `logging-patterns.md`)
+
+**Universal framework adjustments:**
+- L3: if `LOGGER_FRAMEWORK == stdlib` → ACCEPTABLE. If structlog/loguru → MEDIUM. Fix direction: %-style message body, not "unwrap to kwargs".
+- L12: if `LOGGER_FRAMEWORK == stdlib` → ACCEPTABLE. If the log call goes through `CANONICAL_FACTORY` (e.g. `get_logger()`) AND that factory has a %-style bridge (look for `_format_printf_args` or similar in the adapter) → ACCEPTABLE. If the log call uses a direct loguru import (`from loguru import logger` / `loguru.logger`) even when a bridge adapter exists → HIGH (the bridge is bypassed; positional args are silently dropped because loguru uses `str.format()` not `%`). If vanilla loguru (no bridge) → HIGH. If vanilla structlog → MEDIUM.
+- L10: read context — `token_name=name` is acceptable; `token=value` is CRITICAL.
+- L6: if loop is clearly bounded to ≤10 items → ACCEPTABLE.
+- L18: read 5 lines before the `.exception()` call — if inside an `except` block → ACCEPTABLE.
+- L24: skip `exc_info=True/False`. Skip files that define the logging factory/adapter (the file containing `get_logger` or the logger adapter class). Flag all other kwargs as MEDIUM.
+
+**Framework-specific classification rules:**
+- L13: Read the `extra={}` dict literal. Flag CRITICAL for each key that matches any of the 22 reserved LogRecord attributes. Keys not in the reserved list → ACCEPTABLE.
+- L14: Read the log call kwargs. Flag CRITICAL for any kwarg not in `{exc_info, extra, stack_info, stacklevel}`. Do NOT flag structlog or loguru projects.
+- L16: Check the config dict passed to `dictConfig()`. If `"disable_existing_loggers"` is absent or `True` → HIGH. If `False` → ACCEPTABLE.
+- L17: Collect all `basicConfig()` calls across the codebase. If more than one → flag the second+ as HIGH. Single call in `if __name__ == "__main__":` → ACCEPTABLE.
+- L19: Check if the `.bind()` call is a bare statement (result not assigned) → HIGH. If assigned (`x = logger.bind(...)`) → ACCEPTABLE.
+- L20: Read 10 lines around `propagate = False`. Check if `addHandler()` is called on the same logger. If no handler → HIGH. If handler present → ACCEPTABLE.
+- L22: Read the message string. If any kwarg name has no matching `{kwarg_name}` placeholder in the message → MEDIUM. If all kwargs have placeholders → ACCEPTABLE (used for formatting).
+
+Apply `SEVERITY_FILTER`: drop findings below the threshold.
+
+#### Step 2.4 — Build Remediation Plan
+
+For each genuine finding, produce an entry:
+- **Location:** `file:line`
+- **Severity:** CRITICAL / HIGH / MEDIUM / LOW
+- **Category:** L1–L23 code + name
+- **Current code:** offending lines
+- **Fix template:** reference to FT-L1 through FT-L23 from `logging-patterns.md`
+- **Auto-fixable:** yes/no
+
+Group into priority tiers:
+- **P0** — Fix Immediately: CRITICAL — L10 (credential leak), L13 (reserved key crash), L14 (stdlib kwargs crash)
+- **P1** — Fix This Sprint: HIGH — L1, L2, L4, L15, L16, L17, L19, L20, L21
+- **P2** — Fix When Touching File: MEDIUM/LOW — L3, L5, L6, L7, L8, L9, L11, L12, L18, L22, L23, L24
+
+Also compute linting recommendations: read `pyproject.toml` for existing ruff or flake8 rule
+selections. List any missing rules from §Linting Rules in `logging-patterns.md`:
+- G001, G003, G004, T201, LOG009 — recommend if not present
+- G002 — do NOT recommend (%-style is the preferred formatting; G002 would produce false positives)
+- LOG015 — recommend if stdlib and ruff version supports it
+
+Include the minimal `pyproject.toml` diff and suggested `lint-logging` Makefile target in the plan.
+
+#### Step 2.5 — Enter Plan Mode
+
+Call `EnterPlanMode`.
+
+Present the Tune Report as the plan:
+
+```markdown
+# Tune Report — <TARGET_PATH>
+
+## Project Logging Profile
+- Framework: <LOGGER_FRAMEWORK>
+- Canonical factory: <CANONICAL_FACTORY>
+- Supports kwargs: <yes/no>
+- Logger variable names found: logger, log, ...
+
+## Executive Summary
+- Files scanned: N
+- Total hits: N (N genuine findings, N acceptable patterns)
+- By severity: CRITICAL: N | HIGH: N | MEDIUM: N | LOW: N
+- Auto-fixable: N | Needs manual review: N
+
+## Logger Consistency
+- Files using canonical factory: N
+- Files using non-canonical factory: N (list)
+
+## Findings
+| # | File | Line | Severity | Pattern | Auto-fixable | Notes |
+|---|------|------|----------|---------|--------------|-------|
+
+## Remediation Plan
+
+### P0 — Fix Immediately (CRITICAL)
+[L10, L13, L14 findings with exact lines and fix template]
+
+### P1 — Fix This Sprint (HIGH)
+[L1, L2, L4, L15, L16, L17, L19, L20, L21 findings]
+
+### P2 — Fix When Touching File (MEDIUM/LOW)
+[L3, L5, L6, L7, L8, L9, L11, L12, L18, L22, L23 findings]
+
+## Linting Recommendations
+[pyproject.toml diff]
+[Makefile target suggestion]
+
+## Acceptable Patterns (no action required)
+| File | Line | Pattern | Justification |
+|------|------|---------|---------------|
+```
+
+Call `ExitPlanMode` to request user approval. Wait for approval before proceeding to Stage 2.
+
+---
+
+### Stage 2 — Execution (after plan approval)
+
+Apply the remediation plan that was approved. Only fix what was listed in the approved plan.
+
+#### Auto-fixable patterns — apply directly:
+- **FT-L1:** f-string → rewrite as %-style message body (embed context in message, not kwargs)
+- **FT-L2:** Import swap to canonical factory
+- **FT-L4:** Add `exc_info=True` to `logger.warning(` / `logger.error(` in except blocks
+- **FT-L5:** Simple `print("...")` → `logger.info("...")` using %-style for any embedded values
+- **FT-L7:** `.critical(` → `.error(`
+- **FT-L11:** String concatenation → %-style message body
+- **FT-L14:** Wrap stdlib log call kwargs in `extra={}` (stdlib only)
+- **FT-L16:** Add `"disable_existing_loggers": False` to dictConfig call
+- **FT-L19:** Capture `bind()` return value — `logger.bind(...)` → `logger = logger.bind(...)`
+- **FT-L22:** loguru kwargs → %-style message body
+- **FT-L23:** `.warn(` → `.warning(`
+- **FT-L24:** Application kwargs → %-style message body (keep `exc_info=True`)
+
+**Do not auto-fix L10 (credential leak)** — always flag for human review only.
+
+#### Manual review required — leave TODO comments:
+- FT-L3, FT-L6, FT-L8, FT-L9, FT-L10, FT-L12, FT-L13, FT-L15, FT-L17, FT-L18, FT-L20, FT-L21
+
+TODO comment format:
+```python
+# TODO(signal-over-noise): [L6] INFO inside loop — consider DEBUG + summary. See references/logging-patterns.md#L6
+```
+
+#### Apply linting config changes (if approved in the plan):
+Update `pyproject.toml` with the recommended ruff rules.
+
+#### After applying fixes:
+
+Run pre-commit on every file that was changed:
+```bash
+uv run pre-commit run --files <file1> <file2> ...
+```
+
+If pre-commit is not available, skip this step (do not fail).
+
+Leave all changes **uncommitted** — the user reviews before committing.
+
+#### Finish
+
+Report a brief summary: N files changed, N auto-fixes applied, N TODO comments added.
+
+---
+
+## Key Design Notes
+
+1. **Plan mode is the fix gate.** The user approves the remediation plan before any files are
+   touched. The plan shows exact file:line locations, current code, and proposed fixes.
+
+2. **Two invocations, not one.** Surface and Tune are separate `--mode` values. This keeps each
+   plan focused and reviewable. Run Surface first; its execution recommends Tune as the next step.
+
+3. **Framework-agnostic:** Tune's Step 2.1 discovers the logging framework and canonical factory
+   from the codebase itself. Nothing is hardcoded.
+
+4. **kwargs are a universal anti-pattern in application code:** Always embed context in the
+   message body via %-style. Framework context (Temporal workflow_id, run_id, activity_type,
+   task_queue, attempt, etc.) is auto-injected by the logging adapter — never pass it manually.
+   All other application kwargs land in an unindexed JSON blob in the observability platform,
+   making them invisible to log stream scanning. The only accepted kwarg is `exc_info=True`.
+   L24 detects kwargs in application log calls (non-stdlib, outside the adapter file itself).
+
+   **L3 and L12 are still framework-dependent for classification:** `extra={}` is correct in
+   stdlib and wrong in structlog/loguru (use %-style body instead). %-style is the universal
+   preferred format; in vanilla loguru (without a custom adapter bridge) %-style args are
+   silently dropped — flag as HIGH. In stdlib and projects with a custom %-bridge adapter,
+   %-style is already correct.
+
+5. **L13 and L14 are crash-level stdlib patterns:** `extra={}` key collisions with reserved
+   LogRecord attributes raise `KeyError` that propagates to the caller. Treat as P0.
+
+6. **L10 is security-critical:** Never auto-fix credential patterns. Always flag for human review.
+
+7. **Phase ordering matters:** Run Surface before Tune. A silent-swallow in an except block (P1/P2)
+   overlaps with a missing-exc_info finding (L4). Surface fixes the structural problem; Tune then
+   verifies the logging quality of the fix. Avoid double-reporting the same line.

--- a/.claude/skills/signal-over-noise/references/error-recovery-patterns.md
+++ b/.claude/skills/signal-over-noise/references/error-recovery-patterns.md
@@ -1,0 +1,471 @@
+# Error Recovery Patterns Reference
+
+Catalogue of Python silent-error patterns used by the signal-over-noise skill (Phase 1: Surface).
+Covers how to detect each pattern, classify it, and fix it. Eleven patterns (P1–P11).
+
+---
+
+## Pattern Catalogue
+
+Eleven patterns to search for. Each entry lists the grep pattern, what it means, and when it is
+a genuine bug vs an acceptable idiom.
+
+---
+
+### P1 — Bare `except: pass`
+
+**Grep:** `except\s*:\s*pass`
+**Severity:** CRITICAL
+**What it is:** Catches *every* exception including `KeyboardInterrupt`, `SystemExit`,
+`GeneratorExit`, and discards it silently. The hardest class of bugs to debug.
+
+```python
+# BAD
+try:
+    connect()
+except:
+    pass
+
+# GOOD
+try:
+    connect()
+except Exception:
+    logger.warning("Failed to connect", exc_info=True)
+```
+
+**Acceptable?** Never. Even cleanup paths should log at DEBUG.
+
+---
+
+### P2 — `except SomeException: pass` (typed but silent)
+
+**Grep:** `except\s+\w.*:\s*pass`
+**Severity:** HIGH
+**What it is:** Typed catch that still discards silently. Slightly better than P1 (at least it
+won't swallow `SystemExit`) but still loses the stack trace entirely.
+
+```python
+# BAD
+try:
+    parse_config()
+except ValueError:
+    pass
+
+# GOOD
+try:
+    parse_config()
+except ValueError:
+    logger.warning("Config parse failed, using defaults", exc_info=True)
+```
+
+**Acceptable?** Only for truly trivial "best-effort" operations where failure is 100% expected
+AND the surrounding code handles the missing result (e.g. optional cache warm-up). Must have a
+comment explaining the reasoning.
+
+---
+
+### P3 — `contextlib.suppress(Exception)` (broad)
+
+**Grep:** `contextlib\.suppress\(`
+**Severity:** HIGH when broad (`Exception`, `BaseException`); LOW when narrow (`FileNotFoundError`)
+**What it is:** Syntactic sugar for `except X: pass`. The problem is it suppresses *silently*.
+
+```python
+# BAD — no visibility into what was suppressed
+with contextlib.suppress(Exception):
+    cache.invalidate(key)
+
+# GOOD — narrow + log
+try:
+    cache.invalidate(key)
+except CacheError:
+    logger.debug("Cache invalidation skipped", exc_info=True)
+```
+
+**Acceptable?** `suppress(FileNotFoundError)` on a `os.remove()` cleanup path is fine.
+`suppress(Exception)` almost never is.
+
+---
+
+### P4 — Overly broad `except Exception` / `except BaseException` (without logging)
+
+**Grep:** `except\s+(Exception|BaseException)\s*:`
+**Severity:** HIGH (no logging) / MEDIUM (logged but missing `exc_info`)
+**What it is:** Catches everything but the specific type is unknown. Even when logged, the
+exception type is often omitted.
+
+```python
+# BAD — too broad, no traceback
+except Exception as e:
+    logger.warning(f"Something failed: {e}")
+
+# GOOD — log with full traceback
+except Exception:
+    logger.warning("Unexpected error during fetch", exc_info=True)
+    raise   # or handle specifically
+```
+
+**Acceptable?** At top-level handlers (worker main loops, HTTP request handlers) as a catch-all
+*if* properly logged with `exc_info=True`. Not acceptable anywhere else.
+
+---
+
+### P5 — `except` block logs without `exc_info=True`
+
+**Grep:** `except.*:` paired with `logger\.(warning|error|critical|exception)` in the block
+but missing `exc_info=True`
+**Severity:** MEDIUM
+**What it is:** The message is logged, but the stack trace is discarded. When debugging at
+3 AM, you get the message but not where the error originated.
+
+```python
+# BAD — message logged but traceback lost
+except ValueError as e:
+    logger.warning(f"Validation failed: {e}")
+
+# GOOD — full traceback preserved
+except ValueError:
+    logger.warning("Validation failed", exc_info=True)
+```
+
+**Special case:** `logger.exception(...)` automatically includes `exc_info=True` — no fix needed.
+
+**Acceptable?** Only when the exception is 100% expected and carries no diagnostic value
+(e.g. `except StopIteration` in a manual iterator — but prefer `for` loops instead).
+
+---
+
+### P6 — Bare `except:` (no type, no pass — but still bad)
+
+**Grep:** `^\s*except\s*:`
+**Severity:** CRITICAL
+**What it is:** Like P1 but may have a body. Still catches `KeyboardInterrupt`, `SystemExit`, etc.
+
+```python
+# BAD
+except:
+    logger.warning("Error")   # still catches SystemExit!
+
+# GOOD
+except Exception:
+    logger.warning("Error", exc_info=True)
+```
+
+**Acceptable?** Never. Always specify at least `Exception`.
+
+---
+
+### P7 — `except` block that only returns a value (error-to-return-value)
+
+**Grep:** `except.*:` followed by `return` (with no log call in between)
+**Severity:** HIGH
+**What it is:** Exception is converted to a return value (None, {}, [], False) with no trace.
+Callers see a wrong result and have no idea why.
+
+```python
+# BAD
+try:
+    return parse(data)
+except Exception:
+    return {}
+
+# GOOD
+try:
+    return parse(data)
+except Exception:
+    logger.warning("Parse failed, returning empty", exc_info=True)
+    return {}
+```
+
+**Acceptable?** Rarely. Consider raising a domain-specific exception instead so callers can
+decide whether to handle or propagate.
+
+---
+
+### P8 — `except ImportError` without logging
+
+**Grep:** `except\s+ImportError`
+**Severity:** LOW
+**What it is:** Optional-dependency guard. Usually intentional — but if the module is expected
+to be present, silent suppression hides environment problems.
+
+```python
+# ACCEPTABLE — truly optional dependency
+try:
+    import uvloop
+    uvloop.install()
+except ImportError:
+    pass   # uvloop is optional; asyncio default is fine
+
+# BAD — expected dependency silently missing
+try:
+    import pandas
+except ImportError:
+    pass   # will fail later with confusing AttributeError
+```
+
+**Acceptable?** Yes, when the import is genuinely optional AND the fallback path is correct.
+Add a comment. Log at DEBUG if the module is preferred but not required.
+
+---
+
+### P9 — `except` block that only assigns a variable (no logging)
+
+**Grep:** `except.*:` followed only by an assignment (`\w+ = `)
+**Severity:** HIGH
+**What it is:** Exception sets a flag or default value with no trace. Combines P7's
+error-hiding with no logging.
+
+```python
+# BAD
+try:
+    result = fetch()
+except Exception:
+    result = None
+
+# GOOD
+try:
+    result = fetch()
+except Exception:
+    logger.warning("Fetch failed, proceeding with None", exc_info=True)
+    result = None
+```
+
+---
+
+### P10 — `asyncio.gather` with `return_exceptions=True` (unexamined)
+
+**Grep:** `return_exceptions=True`
+**Severity:** MEDIUM
+**What it is:** Exceptions from coroutines are returned as values in the results list instead
+of being raised. If the results list is not inspected for `Exception` instances, errors vanish.
+
+```python
+# BAD — exceptions silently discarded
+results = await asyncio.gather(*tasks, return_exceptions=True)
+process(results)  # results may contain Exception objects
+
+# GOOD — check for exceptions
+results = await asyncio.gather(*tasks, return_exceptions=True)
+for r in results:
+    if isinstance(r, Exception):
+        logger.warning("Task failed: %s", r, exc_info=r)
+```
+
+**Acceptable?** `return_exceptions=True` is fine; the pattern only becomes a bug when the
+results are not subsequently checked for exception instances.
+
+---
+
+### P11 — `logging.Filter` Exceptions Propagate to Caller (CRASH)
+
+**Grep:** `class\s+\w+.*logging\.Filter` or `def filter\(self` inside a class that inherits `logging.Filter`
+**Severity:** HIGH
+**What it is:** Custom `logging.Filter.filter()` methods that raise an unhandled exception crash
+the logging call site — unlike handler errors, filter exceptions are NOT caught by `handleError()`.
+The `Logger.handle()` method calls `self.filter(record)` without any try/except.
+
+This means a buggy filter (one that fails on an unexpected record format, a missing attribute,
+or a network call that times out) will propagate the exception directly to whatever code called
+`logger.info()` (or similar), crashing the caller.
+
+```python
+# BAD — if SomeExternalService raises, so does logger.info()
+class RequestContextFilter(logging.Filter):
+    def filter(self, record):
+        record.request_id = SomeExternalService.get_current_request_id()  # can raise!
+        return True
+
+# GOOD — wrap filter body in try/except with a safe fallback
+class RequestContextFilter(logging.Filter):
+    def filter(self, record):
+        try:
+            record.request_id = SomeExternalService.get_current_request_id()
+        except Exception:
+            record.request_id = "unknown"
+        return True
+
+# BAD — attribute access on record that might not exist
+class EnvFilter(logging.Filter):
+    def filter(self, record):
+        if record.environment == "production":  # AttributeError if not set!
+            return True
+        return False
+
+# GOOD — use getattr with a default
+class EnvFilter(logging.Filter):
+    def filter(self, record):
+        if getattr(record, "environment", None) == "production":
+            return True
+        return False
+```
+
+**Acceptable?** Never — filter methods must never let exceptions propagate.
+
+---
+
+## Severity Classification
+
+| Severity | Criteria |
+|----------|----------|
+| **CRITICAL** | Exception silently discarded with zero logging; catches `BaseException`/bare `except`; will actively hide crashes |
+| **HIGH** | Exception logged without `exc_info` (stack trace lost); error converted to return value silently; broad catch in non-top-level code; filter that can crash caller |
+| **MEDIUM** | Broad catch that is properly logged; `asyncio.gather` results unchecked; `contextlib.suppress` with narrow type but no logging |
+| **LOW** | Optional-import guard with comment; broad catch at documented top-level handler; suppress on truly expected transient errors |
+
+---
+
+## Legitimacy — Acceptable Patterns
+
+Not every match is a bug. Classify as **acceptable** when ALL conditions hold:
+
+| Pattern | Acceptable when |
+|---------|----------------|
+| `except ImportError: pass` | Module is genuinely optional; fallback path is correct; comment explains |
+| `except SomeError: pass` | 100% expected (e.g. `StopIteration`); comment explains; no diagnostic value lost |
+| `contextlib.suppress(FileNotFoundError)` | File absence is a normal non-error condition (cleanup, cache miss) |
+| Broad catch at top level | Worker main loop or HTTP request handler with `exc_info=True` and re-raise or graceful shutdown |
+| `except X: cleanup(); raise` | Reraises after cleanup — exception is not swallowed |
+
+When a finding is acceptable, note the justification and skip it from the remediation plan.
+
+---
+
+## Fix Templates
+
+Mechanical fixes per category. Apply exactly — don't over-engineer.
+
+### FT-1: Add logging to silent-swallow
+
+```python
+# Before
+except SomeError:
+    pass
+
+# After
+except SomeError:
+    logger.warning("<context: what was being attempted>", exc_info=True)
+```
+
+### FT-2: Add `exc_info=True` to existing log
+
+```python
+# Before
+except SomeError as e:
+    logger.warning(f"Failed: {e}")
+
+# After
+except SomeError:
+    logger.warning("Failed: <static description>", exc_info=True)
+```
+
+### FT-3: Add logging before error-to-return-value
+
+```python
+# Before
+except Exception:
+    return {}
+
+# After
+except Exception:
+    logger.warning("<context>", exc_info=True)
+    return {}
+```
+
+### FT-4: Add exception inspection to `asyncio.gather` results
+
+```python
+# After gather call, add:
+for _r in _results:
+    if isinstance(_r, Exception):
+        logger.warning("Async task failed", exc_info=_r)
+```
+
+### FT-5: Replace broad `contextlib.suppress(Exception)` with logged try/except
+
+```python
+# Before
+with contextlib.suppress(Exception):
+    do_thing()
+
+# After
+try:
+    do_thing()
+except Exception:
+    logger.warning("<context>", exc_info=True)
+```
+
+### FT-6: Narrow overly-broad catch (manual — requires knowing the right exception types)
+
+```python
+# Before
+except Exception:
+    ...
+
+# After — use the specific exception the called code raises
+except (SpecificError, OtherError):
+    ...
+```
+
+Leave as `# TODO(signal-over-noise): [P4] narrow this catch` when auto-fixing.
+
+### FT-7: Wrap logging.Filter body in try/except
+
+```python
+# Before — filter exception propagates to logging call site, crashing caller
+class RequestContextFilter(logging.Filter):
+    def filter(self, record):
+        record.request_id = get_current_request_id()  # can raise!
+        return True
+
+# After — always provide a safe fallback
+class RequestContextFilter(logging.Filter):
+    def filter(self, record):
+        try:
+            record.request_id = get_current_request_id()
+        except Exception:
+            record.request_id = "unknown"
+        return True
+
+# Before — attribute access without default
+class EnvFilter(logging.Filter):
+    def filter(self, record):
+        return record.environment == "production"  # AttributeError if not set!
+
+# After — use getattr with a default
+class EnvFilter(logging.Filter):
+    def filter(self, record):
+        return getattr(record, "environment", None) == "production"
+```
+
+---
+
+## Linting Rules to Enable
+
+Add to `pyproject.toml` `[tool.ruff.lint]` `select` list to prevent regressions:
+
+| Rule | Description | Category |
+|------|-------------|----------|
+| `BLE001` | Blind exception caught | Broad catch |
+| `S110` | `try`-`except`-`pass` detected | Silent swallow |
+| `S112` | `try`-`except`-`continue` detected | Silent swallow in loop |
+| `TRY400` | Use `logging.exception` instead of `logging.error` | Missing exc_info |
+| `TRY401` | Redundant `exc_info` in `logging.exception` | Cleanup |
+| `TRY300` | Consider moving `return` out of `try` | Error-hiding return |
+| `TRY302` | Useless `try`-`except` (just reraises) | Dead code |
+
+Minimal addition to `pyproject.toml`:
+
+```toml
+[tool.ruff.lint]
+select = [
+  # ... existing rules ...
+  "BLE",    # blind exceptions
+  "S110",   # try-except-pass
+  "S112",   # try-except-continue
+  "TRY400", "TRY401",  # logging with exc_info
+]
+```
+
+Note: `TRY300` and `TRY302` can be noisy on existing codebases — introduce separately after
+fixing the higher-severity issues.

--- a/.claude/skills/signal-over-noise/references/logging-level-guidelines.md
+++ b/.claude/skills/signal-over-noise/references/logging-level-guidelines.md
@@ -1,0 +1,405 @@
+# Logging Level Guidelines
+
+Used by the signal-over-noise skill (Phase 2: Tune). Universal guidance on logging levels,
+when to use each, and anti-patterns. Applies regardless of framework (stdlib logging, structlog,
+loguru, or custom wrappers).
+
+Detectable anti-patterns with grep patterns and fix templates are in `logging-patterns.md`
+(same directory).
+
+---
+
+## The Four Levels
+
+Use exactly four levels: **DEBUG**, **INFO**, **WARNING**, **ERROR**.
+
+**Never use CRITICAL** — if the process must die, use ERROR and then exit. CRITICAL is not a
+meaningful distinction in distributed systems where every service failure is "critical". It
+creates confusion about severity tiers without adding value.
+
+**Never use TRACE** — DEBUG already serves this purpose. Sub-DEBUG levels are not portable
+across frameworks and create fragmentation.
+
+---
+
+## Level Definitions
+
+### DEBUG
+
+**What it is:** Internal state captured for step-by-step debugging. Invisible in production by default.
+
+**Use when:**
+- Entering/exiting a non-trivial function with its arguments and result
+- Loop iteration state (every N iterations, not every item)
+- Cache hit/miss decisions
+- Branching logic decisions ("chose path X because condition Y")
+- Intermediate computation values
+
+**Do not use when:**
+- The same information is always emitted at INFO
+- The log line would appear millions of times per second in a healthy system
+
+**Example — good:**
+```python
+logger.debug("page fetched", page=offset // page_size, row_count=len(rows))
+```
+
+**Example — bad:**
+```python
+for row in rows:
+    logger.debug("processing row", row_id=row["id"])  # millions of log lines
+```
+
+### INFO
+
+**What it is:** Lifecycle milestones that an operator monitors in a healthy, working system.
+
+**Use when:**
+- Application startup and shutdown (with key configuration values)
+- Phase transitions (extraction started, extraction complete, load started)
+- Periodic progress summaries (every N records, not every record)
+- External dependency connections established
+- Scheduled jobs triggered and completed
+
+**Do not use when:**
+- Processing every individual record, item, or row — use DEBUG
+- Reporting "nothing to do" or empty results — these are DEBUG
+- Inside tight loops — should be DEBUG or a batched summary
+
+**Example — good:**
+```python
+logger.info("extraction complete", record_count=total, duration_s=elapsed)
+```
+
+**Example — bad:**
+```python
+for asset in assets:
+    logger.info("processing asset", name=asset.name)  # use DEBUG
+```
+
+### WARNING
+
+**What it is:** Something unexpected happened, but the system recovered and continued. An
+operator should be aware but does not need to act immediately.
+
+**Use when:**
+- A retry succeeded after a transient failure
+- A fallback was used because a preferred path failed
+- A deprecated code path was invoked
+- A rate limit was hit and the system backed off
+- An optional external dependency is unavailable and the system degraded gracefully
+
+**Always include `exc_info=True`** when downgrading an exception to WARNING — the stack trace
+is essential for diagnosing what triggered the warning.
+
+**Do not use when:**
+- You are immediately re-raising the exception — that's an ERROR, or just re-raise without logging
+- The condition is expected in normal operations — use DEBUG
+
+**Example — good:**
+```python
+except TransientConnectionError:
+    logger.warning("connection failed, retrying", attempt=attempt, exc_info=True)
+```
+
+**Example — bad:**
+```python
+except Exception as e:
+    logger.warning("something went wrong")  # no exc_info, no context
+    raise  # you're raising anyway — either use ERROR or just re-raise
+```
+
+### ERROR
+
+**What it is:** A unit of work failed and cannot be recovered. The system is still running
+but this operation is done.
+
+**Use when:**
+- An exception is caught at a terminal handler and the operation is abandoned
+- A required external dependency is permanently unavailable for this request
+- Data validation failed and the record must be skipped or the job aborted
+- A workflow step failed after all retries were exhausted
+
+**Always include `exc_info=True`** (or use `logger.exception()` which does this automatically).
+
+**Do not use when:**
+- The condition is expected (e.g., "entity not found" when checking existence) — use DEBUG or INFO
+- You are going to retry — use WARNING, then ERROR after exhausting retries
+
+**Example — good:**
+```python
+except Exception:
+    logger.error("failed to load batch", batch_id=batch_id, exc_info=True)
+    return LoadResult(failed=True)
+```
+
+---
+
+## Context in Log Messages — Always Use %-style
+
+**Rule: always embed context in the message body using %-style formatting. kwargs in application
+log calls are an anti-pattern.** The only accepted kwarg is `exc_info=True`.
+
+### Why kwargs are an anti-pattern in application code
+
+In typical OpenTelemetry→Grafana/ClickHouse pipelines (and similar), the log record has:
+- **Top-level indexed fields:** a small fixed set — `level`, `service.name`, plus framework
+  context fields explicitly promoted by the logging adapter (e.g. Temporal's `workflow_id`,
+  `run_id`, `activity_type`, `task_queue`, `attempt`)
+- **`LogAttributes` (JSON blob):** all other kwargs land here as a serialised dict — present but
+  NOT individually indexed; requires JSON extraction to query
+- **`Body`:** the log message string — text-searchable at full scan speed
+
+**Framework context is auto-injected.** The logging adapter automatically propagates all
+Temporal/platform context (workflow_id, run_id, activity_type, task_queue, attempt, trace_id,
+correlation_id, etc.) onto every log record via its `process()` method. Application code never
+needs to pass these fields manually — they are always there.
+
+**Application kwargs land in the JSON blob.** Any kwargs that are not framework-propagated
+fields end up in an unindexed JSON blob, not as top-level queryable columns. They require slow
+JSON extraction to filter on and are invisible when scanning the raw log stream.
+
+**The message body is always available.** The `Body` field is text-searchable at full scan
+speed. Context embedded in the message is immediately readable in any log viewer, without
+needing to expand structured fields.
+
+### The correct pattern: %-style in the message body
+
+Always embed context directly in the message string using %-style formatting:
+
+```python
+# Good — context visible at a glance, no JSON blob needed
+logger.info("loaded %d records from %s", count, table)
+logger.warning("connection to %s:%d failed on attempt %d, retrying", host, port, n, exc_info=True)
+logger.error("discovery error for connector %s", connector_name, exc_info=True)
+
+# Good — literal string when values are known at the call site
+logger.info("published asset_updated event to topic application_events")
+```
+
+### What NOT to do
+
+```python
+# Bad — context buried in JSON blob, invisible in log stream
+logger.info("records loaded", count=count, table=table)
+
+# Bad — framework context already injected by adapter; this is a no-op at best
+logger.info("activity started", workflow_id=workflow_id, activity_type=activity_type)
+
+# Bad — f-string breaks log grouping (unique message per call) and evaluates eagerly
+logger.info(f"loaded {count} records from {table}")
+
+# Bad — concatenation has the same problems as f-string
+logger.info("loaded " + str(count) + " records")
+```
+
+### The one accepted kwarg: `exc_info=True`
+
+`exc_info=True` is always correct in except blocks — it attaches the stack trace and is not
+application data:
+
+```python
+except ConnectionError:
+    logger.warning("connection to %s:%d failed, retrying", host, port, exc_info=True)
+```
+
+### f-strings and concatenation are also problematic
+
+Even when not using kwargs, **avoid f-strings and concatenation** — they create a unique message
+string per call, breaking log grouping and aggregation:
+
+```python
+# Bad
+logger.info(f"published {event_type} event to {topic}")
+logger.info("loaded " + str(count) + " records")
+
+# Good — %-style keeps a static template for grouping
+logger.info("published %s event to %s", event_type, topic)
+```
+
+### Summary rule
+
+> **Always embed context in the message body via %-style.** kwargs in application log calls
+> are an anti-pattern — framework context is auto-injected by the adapter, and all other kwargs
+> land in an unindexed JSON blob. The only exception is `exc_info=True`.
+
+---
+
+## `logger.exception()` vs `logger.error(..., exc_info=True)`
+
+These are functionally equivalent — both log at ERROR level with the current exception's traceback.
+
+**Use `logger.exception()`** only at **terminal catch sites where you are NOT re-raising** the
+exception. It signals "this is where the exception stops".
+
+**Use `logger.error(..., exc_info=True)`** when you want to embed additional context in the
+message alongside the traceback.
+
+**Use `logger.warning(..., exc_info=True)`** when downgrading a caught exception to a warning
+(and not re-raising).
+
+**Never use** `logger.exception()` and then re-raise — you'll get a duplicate traceback downstream.
+
+```python
+# Terminal handler — use .exception()
+except Exception:
+    logger.exception("batch load failed for batch %s", batch_id)
+    return FailedResult()
+
+# Embedding context in message — use exc_info=True
+except ConnectionError:
+    logger.error("connection to %s:%d failed", host, port, exc_info=True)
+    raise
+
+# Downgrading to warning — use exc_info=True
+except TransientError:
+    logger.warning("transient error on attempt %d, retrying", n, exc_info=True)
+```
+
+---
+
+## Performance: Lazy Evaluation
+
+Avoid eagerly computing values that are only used if the log line is emitted.
+
+**Bad — argument always evaluated even when DEBUG is off:**
+```python
+logger.debug("state dump: %s", json.dumps(large_object))  # json.dumps always runs
+```
+
+**Good — guard expensive computation:**
+```python
+if logger.isEnabledFor(logging.DEBUG):
+    logger.debug("state dump", state=large_object)
+```
+
+**Good — stdlib %-style is lazy (message formatted only if level is enabled):**
+```python
+logger.debug("processing %s", record_id)  # format string only evaluated if DEBUG enabled
+```
+
+**Critical clarification:** None of the three frameworks (stdlib, structlog, loguru) provide
+lazy argument evaluation. In all three, `expensive_call()` in `logger.debug("msg", x=expensive_call())`
+runs at call time regardless of log level. The only protection is an explicit `isEnabledFor`
+guard. Structlog and loguru have zero lazy evaluation at any layer.
+
+loguru provides `logger.opt(lazy=True)` which accepts callables:
+```python
+logger.opt(lazy=True).debug("data: {}", lambda: json.dumps(huge))
+```
+But if you forget `lazy=True` and pass a lambda, the output will be the lambda's repr, not its
+result.
+
+---
+
+## Security: Never Log Credential Values
+
+**Never log:** passwords, tokens, API keys, secrets, connection strings with credentials,
+bearer tokens, private keys.
+
+**Always acceptable:** credential names, credential types, whether a credential was found/missing.
+
+```python
+# BAD — logs the actual secret
+logger.debug("using token", token=api_token)
+logger.info("connecting", connection_string=conn_str_with_password)
+
+# GOOD — logs the name or type only
+logger.debug("credential loaded", credential_name="snowflake-prod-token")
+logger.info("connecting", host=host, credential_type="service_account")
+```
+
+This applies regardless of log level — credential values must never appear in any log output,
+even DEBUG.
+
+---
+
+## Anti-patterns per Level (Summary)
+
+These are summarized here for reference. Full detectable patterns with grep queries are in
+`logging-patterns.md` (same directory).
+
+| Level | Anti-pattern |
+|-------|-------------|
+| DEBUG | Logging every item in a tight loop without sampling or batching |
+| DEBUG | Expensive argument computation without an `isEnabledFor` guard |
+| INFO | Per-item log lines that should be DEBUG |
+| INFO | "Nothing happened" messages that add noise to operator dashboards |
+| WARNING | Missing `exc_info=True` when catching an exception |
+| WARNING | Logging a warning immediately before re-raising (redundant with downstream ERROR) |
+| ERROR | Expected, handled conditions logged as ERROR (raises alert fatigue) |
+| ERROR | Error logged and then exception silently swallowed (hides failures) |
+| Any | f-string or concatenation in log message (breaks log grouping; use %-style or literal) |
+| Any | kwargs in application log calls other than `exc_info=True` (buries context in JSON blob; framework context is auto-injected by the adapter; embed other context in message body via %-style) |
+| Any | Credential values embedded in log output (security violation) |
+| Any | `print()` in production code instead of structured logging |
+| Any | `logger.critical()` usage |
+
+---
+
+## Framework Awareness Notes
+
+These are non-grep-detectable runtime risks. The skill does not produce findings for them, but
+they are documented here for developer awareness when reviewing logging code.
+
+### fork() + Logging = Potential Deadlock
+
+Forking a process while another thread holds a logging handler lock creates a permanent deadlock
+in the child process. The child inherits a copy of the locked `RLock`, but the thread that held
+the lock does not exist in the child — so the lock can never be released.
+
+**Affected:** Python < 3.12 when using `multiprocessing`, `os.fork()`, gunicorn prefork mode,
+celery prefork worker pool, or any code that forks after importing the `logging` module.
+
+**Python 3.12+** mitigates this via `os.register_at_fork()` which reinitializes logging locks
+in the child process. Older versions are vulnerable.
+
+**Safe patterns:**
+- Configure logging AFTER forking (in the child)
+- Use `QueueHandler` / `QueueListener` to serialize all logging through a single non-forked thread
+- Switch to gunicorn's gthread or gevent worker class instead of prefork
+
+### Logging in Signal Handlers
+
+Signal handlers interrupt the current thread at an arbitrary point — including mid-logging-call.
+If the interrupted thread holds a logging lock, and the signal handler also tries to log, the
+behavior is undefined. The module-level `logging._lock` is an `RLock` (reentrant for the same
+thread), which means same-thread re-entry is safe. But if the signal handler modifies the logger
+hierarchy (adds handlers, changes levels) while the main thread iterates `c.handlers` in
+`callHandlers()`, you can get "dictionary changed size during iteration" or similar errors.
+
+**Safe pattern:** Signal handlers should set a flag or write to `signal.set_wakeup_fd()`;
+the main event loop reads the flag and does the logging, not the signal handler itself.
+
+### Async Context and Thread-Local State
+
+Both `structlog.threadlocal` and any `threading.local()` based context solution are broken in
+asyncio. All async tasks run on the same thread, so thread-local context is shared across
+concurrent tasks. Context set in one task overwrites context in another at every `await` point.
+
+**Use instead:**
+- `structlog.contextvars` (structlog ≥ 21.1) — uses Python's `contextvars.ContextVar`
+- `loguru.contextualize()` — uses `contextvars` under the hood
+- `contextvars.ContextVar` directly for custom context
+
+---
+
+## Configuration Convention
+
+Log level should be configurable at runtime without code changes:
+
+- Read from environment variable (e.g., `LOG_LEVEL`, `ATLAN_LOG_LEVEL`)
+- Default to `INFO` in production
+- `DEBUG` available for local development and troubleshooting
+- Never hardcode `DEBUG` in production code paths
+
+```python
+import os
+import logging
+
+log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
+```
+
+For structlog/loguru — configure the level on the underlying stdlib handler or on the
+framework's own level filter at startup. Never set level inside application logic.

--- a/.claude/skills/signal-over-noise/references/logging-patterns.md
+++ b/.claude/skills/signal-over-noise/references/logging-patterns.md
@@ -1,0 +1,1258 @@
+# Logging Anti-Patterns Catalogue
+
+Used by the signal-over-noise skill (Phase 2: Tune). Covers **detectable anti-patterns**: grep
+patterns, severity, examples, fix templates, and linting rules.
+
+Level philosophy and when-to-use guidance is in `logging-level-guidelines.md` (same directory).
+
+Framework-agnostic — patterns apply to stdlib logging, structlog, loguru, and custom wrappers.
+The skill's Phase 2 Step 2.1 discovers which framework the project uses before applying
+framework-dependent classifications.
+
+---
+
+## Pattern Catalogue
+
+### L1 — f-string in Log Message
+
+**Grep:** `logger\.\w+\(f["']` (also match `log\.`, `_logger\.`, `_log\.` — use discovered variable names)
+
+**Severity:** HIGH
+
+**Auto-fixable:** Yes (rewrite as %-style message body)
+
+**Description:** Using an f-string as the log message creates a unique message string per call,
+breaking log grouping and aggregation. It also always evaluates eagerly.
+
+**Fix direction: always rewrite as %-style message body.** Do not move values to kwargs —
+framework context (Temporal fields, correlation IDs, etc.) is auto-injected by the logging
+adapter, and all other kwargs land in an unindexed JSON blob that is invisible in the log
+stream. Embed context directly in the message string using %-style formatting.
+
+```python
+# BAD — f-string, unique message per call, breaks aggregation
+logger.info(f"published {event_type} event to topic {topic}")
+logger.info(f"loaded {count} records from {table}")
+logger.warning(f"connection to {host}:{port} failed")
+
+# GOOD — %-style keeps a static template for grouping, embeds context in body
+logger.info("published %s event to topic %s", event_type, topic)
+logger.info("loaded %d records from %s", count, table)
+logger.warning("connection to %s:%d failed", host, port, exc_info=True)
+
+# ALSO GOOD — literal string when values are known at the call site
+logger.info("published asset_updated event to topic application_events")
+```
+
+**Detection note:** Adjust the regex to match logger variable names discovered in Step 2.1. The
+pattern `\.\w+\(f["']` catches any method call receiving an f-string literal.
+
+---
+
+### L2 — Inconsistent Logger Factory
+
+**Detection:** Step 2.1 discovers the **canonical factory** (the dominant one by occurrence count). Any file using a different factory is a finding.
+
+**Severity:** HIGH
+
+**Auto-fixable:** Yes (import swap)
+
+**Description:** Mixing logger factories in one codebase produces inconsistent log formats, loses structured fields, and makes log correlation harder. A file using `logging.getLogger(__name__)` while the rest of the project uses `structlog.get_logger()` will emit plain text instead of structured JSON.
+
+**Common factories to detect in Step 2.1:**
+- `structlog.get_logger(`
+- `logging.getLogger(`
+- `loguru.logger` (singleton, not a factory call)
+- `get_logger(` (custom project wrapper)
+- `getLogger(`
+
+**Example (project uses structlog; this file uses stdlib):**
+```python
+# BAD — inconsistent with project convention
+import logging
+logger = logging.getLogger(__name__)
+
+# GOOD — use project's canonical factory
+import structlog
+logger = structlog.get_logger()
+```
+
+---
+
+### L3 — `extra={}` When Framework Expects kwargs (or vice versa)
+
+**Grep:** `extra=\{`
+
+**Severity:** MEDIUM
+
+**Auto-fixable:** No (requires framework judgment)
+
+**Description:** Whether `extra={}` is correct depends on the logging framework:
+- **stdlib logging**: `extra={}` is the correct way to pass structured fields
+- **structlog**: `extra={}` is usually wrong — structlog expects keyword arguments directly; `extra` is a plain dict that is not indexed as structured context
+- **loguru**: `extra={}` has no special meaning — use keyword arguments
+
+**Framework-dependent classification:**
+- If `LOGGER_FRAMEWORK == stdlib`: `extra={}` is acceptable — skip or LOW
+- If `LOGGER_FRAMEWORK == structlog` or `loguru`: `extra={}` is likely wrong — MEDIUM
+
+**Structlog nesting trap:** In structlog, `extra={"count": n}` does NOT unpack into structured
+fields. It becomes a single key whose value is the dict:
+```json
+{"event": "batch complete", "extra": {"count": 5}}
+```
+The data is present in the raw log but **invisible to aggregation queries** — a dashboard
+filtering on `count > 100` will find nothing.
+
+```python
+# stdlib — CORRECT
+logger.info("batch complete", extra={"count": n, "table": t})
+
+# structlog — WRONG (extra nested, not indexed at top level)
+logger.info("batch complete", extra={"count": n})
+
+# structlog — CORRECT (fields at top level)
+logger.info("batch complete", count=n, table=t)
+```
+
+---
+
+### L4 — Missing `exc_info=True` in except-block log
+
+**Grep (multiline):** `except` block containing `logger\.\(warning\|error\)` without `exc_info`
+
+**Severity:** HIGH
+
+**Auto-fixable:** Yes (add `exc_info=True`)
+
+**Description:** Logging an exception without `exc_info=True` produces a message with no stack trace, making the root cause invisible. This is one of the most common debugging blockers.
+
+**Heuristic detection:** Flag any `logger.warning(` or `logger.error(` call that appears within 5 lines of an `except` clause and does not contain `exc_info=True` or `exc_info=exc`.
+
+```python
+# BAD — no stack trace
+except ConnectionError as e:
+    logger.warning("connection failed")  # WHERE did it fail? Unknown.
+
+# BAD — no stack trace; str(e) is not a stack trace
+except Exception:
+    logger.error("operation failed", error=str(e))
+
+# GOOD — exc_info=True attaches the stack trace; context embedded in message via %-style
+except ConnectionError:
+    logger.warning("connection to %s:%d failed on attempt %d, retrying", host, port, n, exc_info=True)
+
+# GOOD — .exception() implies exc_info=True
+except Exception:
+    logger.exception("operation failed for batch %s", batch_id)
+```
+
+---
+
+### L5 — `print()` in Production Code
+
+**Grep:** `^\s*print\(`
+
+**Severity:** MEDIUM
+
+**Auto-fixable:** Yes (simple cases)
+
+**Description:** `print()` bypasses the logging framework — no level, no structured fields, no correlation IDs, no output routing. In production services, `print()` output may go to stdout unformatted, be lost entirely, or interleave with structured log lines.
+
+**Acceptable exceptions:**
+- CLI tools where stdout is the intended output (e.g., `print(result)` in a command-line script)
+- Test/debug scripts explicitly not meant for production
+- `if __name__ == "__main__":` blocks
+
+**Auto-fix heuristic:** Replace `print("message")` with `logger.info("message")` — flag for human review.
+
+```python
+# BAD — production service code
+def process_batch(records):
+    print(f"Processing {len(records)} records")  # not observable
+
+# GOOD
+def process_batch(records):
+    logger.info("processing batch", count=len(records))
+```
+
+---
+
+### L6 — INFO Inside Tight Loop
+
+**Detection (heuristic):** `logger\.info\(` appearing inside a `for` or `while` block
+
+**Severity:** MEDIUM
+
+**Auto-fixable:** No (requires judgment — need to understand loop volume)
+
+**Description:** Per-item INFO logging in a loop that iterates over many items generates enormous log volume, drowns out meaningful signals, and can cause significant performance degradation. INFO is for lifecycle milestones, not per-item events.
+
+**Heuristic:** Flag `logger.info(` calls indented inside a `for` or `while` loop. Step 2.3 context reading should check whether this is a clearly-bounded small loop or an unbounded/large-scale loop.
+
+```python
+# BAD — INFO per item in a potentially large loop
+for asset in assets:
+    logger.info("processing asset", name=asset.name)
+
+# GOOD — DEBUG per item, INFO for summary
+for asset in assets:
+    logger.debug("processing asset", name=asset.name)
+logger.info("batch processed", count=len(assets))
+```
+
+---
+
+### L7 — `logger.critical()` Usage
+
+**Grep:** `\.critical\(`
+
+**Severity:** MEDIUM
+
+**Auto-fixable:** Yes (replace with `.error()`)
+
+**Description:** `CRITICAL` is not a meaningful level in distributed systems. Every service failure is "critical" from some perspective. Using it creates a false tier that confuses alerting thresholds and log aggregation. Use ERROR and handle severity through alerting rules on the downstream observability platform.
+
+```python
+# BAD
+logger.critical("database unreachable — shutting down")
+
+# GOOD
+logger.error("database unreachable — shutting down", exc_info=True)
+sys.exit(1)
+```
+
+---
+
+### L8 — Unguarded Expensive DEBUG Computation
+
+**Detection (heuristic):** `logger.debug(` with function calls in argument position (e.g., `json.dumps(`, `repr(`, `.to_dict(`)
+
+**Severity:** LOW
+
+**Auto-fixable:** No (requires judgment)
+
+**Description:** Arguments to log calls are evaluated eagerly at call time, regardless of whether the log level is enabled. An expensive serialization or computation that only serves a DEBUG log line wastes CPU even when DEBUG is disabled.
+
+**Heuristic:** Flag `logger.debug(` calls whose arguments contain known-expensive patterns: `json.dumps(`, `json.loads(`, `repr(`, `str(large_`, `.to_dict(`, `.model_dump(`.
+
+```python
+# BAD — json.dumps() runs even when DEBUG is disabled
+logger.debug("payload dump", payload=json.dumps(large_object))
+
+# GOOD — guard expensive computation
+if logger.isEnabledFor(logging.DEBUG):
+    logger.debug("payload dump", payload=json.dumps(large_object))
+```
+
+---
+
+### L9 — Warn-then-Raise Duplication
+
+**Detection (heuristic):** `logger.warning(` or `logger.error(` within 3 lines before a `raise` statement
+
+**Severity:** MEDIUM
+
+**Auto-fixable:** No (requires judgment)
+
+**Description:** Logging an error immediately before re-raising creates duplicate records in the log stream — once where it was logged, and again where it is eventually caught and handled. This inflates error counts in dashboards and makes root-cause analysis harder.
+
+**Exception:** Acceptable to add structured context before re-raising if the caller won't have it:
+```python
+# ACCEPTABLE — adding context not available to caller
+except DatabaseError as e:
+    logger.warning("query failed", query_id=query_id, exc_info=True)
+    raise  # caller logs again, but this context would be lost otherwise
+```
+
+```python
+# BAD — pure duplication, no added context
+except Exception:
+    logger.error("operation failed", exc_info=True)
+    raise  # caller will log this again
+
+# GOOD — just re-raise, let the terminal handler log
+except Exception:
+    raise
+
+# GOOD — wrap with context, then raise
+except Exception as e:
+    raise OperationError(f"failed during phase {phase}") from e
+```
+
+---
+
+### L10 — Credential/Secret Values in Log Output
+
+**Grep (case-insensitive):** `logger\.\w+\(.*(?:password|secret|token|api_key|credential|auth|bearer|private_key)` with value-like context
+
+**Severity:** CRITICAL
+
+**Auto-fixable:** No (security review required)
+
+**Description:** Credentials in log output are a security vulnerability — logs are often stored in plaintext in log aggregation systems, accessible to more people than the credential store itself.
+
+**Detection notes:**
+- The grep is intentionally broad to minimize false negatives
+- Step 2.3 context reading distinguishes acceptable from critical:
+  - `logger.info("token refreshed", token_name=name)` — ACCEPTABLE (logging the name)
+  - `logger.info("token refreshed", token=actual_token_value)` — CRITICAL
+  - `logger.debug("auth header", authorization=f"Bearer {token}")` — CRITICAL
+- Any finding in this category requires human security review before marking acceptable
+
+```python
+# CRITICAL — logs actual credential
+logger.debug("snowflake connection", password=credentials.password)
+logger.info("connecting", token=api_token, url=endpoint)
+
+# ACCEPTABLE — logs name/type only
+logger.debug("credential loaded", credential_name="snowflake-prod")
+logger.info("auth configured", method="service_account", scopes=scopes)
+```
+
+---
+
+### L11 — String Concatenation in Log Message
+
+**Grep:** `logger\.\w+\(".*" \+` or `logger\.\w+\('.*' \+`
+
+**Severity:** MEDIUM
+
+**Auto-fixable:** Yes
+
+**Description:** Like f-strings (L1), string concatenation embeds values into the message string
+in a way that breaks log grouping. The fix is the same as L1: rewrite as %-style message body.
+
+```python
+# BAD
+logger.info("loaded " + str(count) + " records from " + table)
+
+# GOOD — %-style message body (all frameworks)
+logger.info("loaded %d records from %s", count, table)
+```
+
+---
+
+### L12 — %-style Formatting in Non-stdlib Logger
+
+**Grep:** `logger\.\w+\(".*%[sdfr]` (only flag when `LOGGER_FRAMEWORK != stdlib`)
+
+**Severity:** LOW
+
+**Auto-fixable:** No (verify logger type first)
+
+**Description:** `%-style` formatting is a stdlib logging feature — it performs **lazy** formatting (only evaluates the format string if the level is enabled). However, structlog and loguru do **not** support %-style substitution.
+
+**Per-framework behavior:**
+
+- **structlog:** The `%s` appears **literally** in log output. The positional arg (`count`) may be
+  stored as `_positional_args` internally or silently dropped, depending on the processor chain.
+  Either way, the substituted value is never visible in the formatted message. No error is raised.
+
+- **loguru:** loguru uses `str.format()` for message templates. `%s` is not a `{}` placeholder,
+  so `str.format()` finds nothing to substitute. The positional argument is **silently ignored
+  entirely**. No error is raised. `"loaded %s records"` appears verbatim in output.
+
+- **stdlib + `raiseExceptions=False`** (production default): Format mismatches (too many args,
+  wrong types, too few args) are caught by `handleError()` and **silently swallowed** — the
+  entire log message is dropped with no indication. Only visible with `raiseExceptions=True`
+  (which prints a traceback to stderr but still does not propagate to the caller).
+
+**Framework-dependent classification:**
+- If `LOGGER_FRAMEWORK == stdlib`: %-style is **correct and preferred** — mark as ACCEPTABLE
+- If `LOGGER_FRAMEWORK == structlog`: %-style means **literal `%s` in output** — mark as MEDIUM
+- If `LOGGER_FRAMEWORK == loguru` AND call goes through `CANONICAL_FACTORY` (e.g. `get_logger()`)
+  AND that factory has a %-style bridge (look for `_format_printf_args` or `msg % args` in the
+  adapter implementation) → mark as ACCEPTABLE (bridge pre-formats before handing to loguru)
+- If `LOGGER_FRAMEWORK == loguru` AND call uses a **direct loguru import** (`from loguru import
+  logger` / `loguru.logger`) even when a bridge adapter exists elsewhere in the project → mark
+  as HIGH (the bridge is never invoked; positional args are silently dropped)
+- If vanilla loguru (no bridge anywhere) → mark as HIGH
+
+```python
+# structlog — WRONG (% not substituted, appears literally as "%s")
+logger.info("loaded %s records", count)
+
+# loguru — WRONG (count silently ignored, no error)
+logger.info("loaded %s records", count)
+
+# structlog — CORRECT
+logger.info("records loaded", count=count)
+
+# loguru — CORRECT (uses str.format() style)
+logger.info("loaded {} records", count)
+# or with structured fields:
+logger.bind(count=count).info("records loaded")
+
+# stdlib — CORRECT (lazy evaluation)
+logger.info("loaded %s records", count)
+```
+
+---
+
+## Framework Compatibility Patterns
+
+These patterns are framework-specific. The skill's Step 2.1 discovers the logging framework and
+enables only the applicable patterns. They are numbered L13–L23.
+
+---
+
+### L13 — stdlib `extra={}` Reserved Key Collision (CRASH)
+
+**Grep:** `extra=\{` — then check keys against the reserved list in Step 2.3
+
+**Severity:** CRITICAL
+
+**Auto-fixable:** No (requires renaming the field)
+
+**Applies to:** stdlib only
+
+**Description:** stdlib's `Logger.makeRecord()` explicitly raises `KeyError` if any key in
+`extra={}` matches a `LogRecord` attribute. This error propagates **directly to the caller**
+and is NOT caught by `handleError()` — meaning it crashes your application code even when
+`logging.raiseExceptions = False`.
+
+**The 22 forbidden keys:**
+`name`, `msg`, `args`, `levelname`, `levelno`, `pathname`, `filename`, `module`, `lineno`,
+`funcName`, `created`, `msecs`, `relativeCreated`, `thread`, `threadName`, `process`,
+`processName`, `exc_info`, `exc_text`, `stack_info`, `message`, `asctime`
+
+The most commonly collided names in production code: `name`, `message`, `module`, `args`,
+`filename`, `process`, `thread`.
+
+```python
+# CRASH — KeyError: "Attempt to overwrite 'name' in LogRecord"
+logger.info("user action", extra={"name": "alice"})
+
+# CRASH — KeyError: "Attempt to overwrite 'message' in LogRecord"
+logger.info("event", extra={"message": "the payload"})
+
+# CRASH — KeyError: "Attempt to overwrite 'args' in LogRecord"
+logger.info("call", extra={"args": [1, 2, 3]})
+
+# GOOD — use a namespaced key that doesn't collide
+logger.info("user action", extra={"user_name": "alice"})
+logger.info("event", extra={"event_message": "the payload"})
+```
+
+**Acceptable?** Any `extra={}` key that is NOT in the forbidden list is fine.
+
+**Fix guidance:** Rename the offending key. Common safe pattern: prefix with an app-specific
+namespace (e.g., `user_name` instead of `name`, `app_module` instead of `module`).
+
+---
+
+### L14 — Arbitrary kwargs in stdlib Logger (CRASH)
+
+**Grep:** `LOGGER_VAR_PATTERN\.\w+\([^)]*,\s*\w+=` — kwargs other than `exc_info`, `extra`,
+`stack_info`, `stacklevel` in stdlib log calls
+
+**Severity:** CRITICAL
+
+**Auto-fixable:** Yes (wrap kwargs in `extra={}`)
+
+**Applies to:** stdlib only
+
+**Description:** stdlib `logger.info()` and family only accept four keyword arguments:
+`exc_info`, `extra`, `stack_info`, and `stacklevel`. Any other kwarg raises `TypeError`
+immediately — crashing the caller. This is a very common bug when code is migrated from
+structlog or loguru (which support arbitrary kwargs) to stdlib, or when a developer assumes
+structlog-style kwargs work everywhere.
+
+```python
+# CRASH — TypeError: _log() got an unexpected keyword argument 'user_id'
+logger.info("user logged in", user_id="alice")
+
+# CRASH — TypeError: _log() got an unexpected keyword argument 'request_id'
+logger.warning("slow response", request_id="abc", duration_ms=450)
+
+# GOOD — wrap in extra={}
+logger.info("user logged in", extra={"user_id": "alice"})
+logger.warning("slow response", extra={"request_id": "abc", "duration_ms": 450})
+```
+
+**Special double-crash cases:**
+- `logger.info("msg", level="DEBUG")` — `TypeError: multiple values for argument 'level'`
+- `logger.info("msg", msg="other")` — `TypeError: multiple values for argument 'msg'`
+
+**Context reading:** Flag all kwargs in stdlib log calls that are not in `{exc_info, extra,
+stack_info, stacklevel}`. Do NOT flag structlog or loguru projects — kwargs are correct there.
+
+---
+
+### L15 — `event=` kwarg Overwrites structlog Message
+
+**Grep:** `LOGGER_VAR_PATTERN\.\w+\(.*event=`
+
+**Severity:** HIGH
+
+**Auto-fixable:** No (rename the field)
+
+**Applies to:** structlog only
+
+**Description:** In structlog, the first positional argument to a log call is stored as the
+`event` key — it IS the log message. If you pass `event=` as a keyword argument, it silently
+overwrites the message with your domain value. No error is raised.
+
+This is extremely common in event-driven systems where "event" is a meaningful domain concept.
+
+```python
+# BAD — domain_event silently replaces the log message
+logger.info("processing", event=domain_event)
+# Output: {"event": <DomainEvent object>, "level": "info", ...}
+# The message "processing" is completely lost.
+
+# GOOD — use a non-colliding field name
+logger.info("processing", domain_event=domain_event)
+logger.info("processing", event_type=domain_event.type, event_id=domain_event.id)
+```
+
+**Acceptable?** Only if intentional — e.g., `event=event.name` where you explicitly want
+the event name to BE the log message. This should be clearly commented.
+
+---
+
+### L16 — `dictConfig` with `disable_existing_loggers=True` (the default)
+
+**Grep:** `dictConfig\(` — then check config dict in Step 2.3
+
+**Severity:** HIGH
+
+**Auto-fixable:** Yes (add `"disable_existing_loggers": False`)
+
+**Applies to:** stdlib only
+
+**Description:** `logging.config.dictConfig()` has a `disable_existing_loggers` key that
+**defaults to `True`**. When `True`, all loggers created before `dictConfig()` is called
+have their `.disabled` attribute set to `True` — they silently drop all messages forever.
+
+This is the single most common source of "why is my logging not working?" in Python. In
+Django, Flask, FastAPI, and any framework where modules do `logger = logging.getLogger(__name__)`
+at import time (before the app configures logging), ALL those loggers are silently disabled.
+
+```python
+# BAD — all pre-existing loggers silently disabled after this call
+logging.config.dictConfig({
+    "version": 1,
+    "handlers": {"console": {"class": "logging.StreamHandler"}},
+    "root": {"handlers": ["console"], "level": "DEBUG"},
+    # disable_existing_loggers not set — defaults to True!
+})
+
+# GOOD — explicitly preserve existing loggers
+logging.config.dictConfig({
+    "version": 1,
+    "disable_existing_loggers": False,   # <-- required
+    "handlers": {"console": {"class": "logging.StreamHandler"}},
+    "root": {"handlers": ["console"], "level": "DEBUG"},
+})
+```
+
+**Context reading:** Flag any `dictConfig()` call where the config dict does not contain
+`"disable_existing_loggers": False`. If the key is absent or set to `True`, flag HIGH.
+
+---
+
+### L17 — `basicConfig()` No-op After First Call
+
+**Grep:** `basicConfig\(` — collect all occurrences across the codebase; flag if >1 found
+
+**Severity:** HIGH
+
+**Auto-fixable:** No (requires understanding call order)
+
+**Applies to:** stdlib only
+
+**Description:** `logging.basicConfig()` is silently ignored if the root logger already has
+handlers. The second and subsequent calls do nothing — no error, no warning. This means
+whichever call runs first "wins" and all subsequent calls are silently dropped.
+
+Common in practice:
+- A library calls `basicConfig()` at import time, before the application configures logging
+- A function that configures logging is called multiple times (e.g., in tests)
+- Both app startup code and a library call `basicConfig()`
+
+```python
+# File: some_library.py (imported before your app)
+logging.basicConfig(level=logging.WARNING)  # This runs first
+
+# File: your_app.py
+logging.basicConfig(level=logging.DEBUG)    # SILENT NO-OP — library already configured
+# Result: DEBUG messages never appear
+```
+
+**Fix:** Use `logging.basicConfig(force=True)` (Python 3.8+) to override existing config,
+or switch to `dictConfig()` with `"disable_existing_loggers": False`.
+
+**Context reading:** Flag the second+ occurrence in call order (by file import order heuristic).
+If `basicConfig()` appears in multiple files, flag all but the earliest-imported one as HIGH.
+Single calls in `if __name__ == "__main__":` blocks are acceptable.
+
+---
+
+### L18 — `logger.exception()` Called Outside an `except` Block
+
+**Grep:** `\.exception\(` — then verify context in Step 2.3
+
+**Severity:** MEDIUM
+
+**Auto-fixable:** No
+
+**Applies to:** all frameworks
+
+**Description:** `logger.exception()` is equivalent to `logger.error(..., exc_info=True)`. When
+called outside an `except` block, `sys.exc_info()` returns `(None, None, None)`, so the log
+output appends `NoneType: None` — a meaningless traceback that actively misleads debugging.
+
+The call itself does not crash, but the output is misleading. Use `logger.error()` when you
+want to log an error without an active exception context.
+
+```python
+# BAD — outside except block, logs "NoneType: None" as the traceback
+def validate(data):
+    if not data:
+        logger.exception("validation failed")  # misleading output
+
+# GOOD — use logger.error() outside except blocks
+def validate(data):
+    if not data:
+        logger.error("validation failed")
+
+# GOOD — logger.exception() is appropriate inside except
+try:
+    process(data)
+except ValueError:
+    logger.exception("processing failed")  # correct — has exception context
+```
+
+**Context reading:** Read 5 lines before the `.exception()` call. If there is no `except`
+clause in scope, flag MEDIUM.
+
+---
+
+### L19 — `bind()` Return Value Discarded
+
+**Grep:** `^\s+\w+\.bind\(` (bare statement — no assignment)
+
+**Severity:** HIGH
+
+**Auto-fixable:** Yes (add `logger = ` assignment)
+
+**Applies to:** structlog, loguru
+
+**Description:** Both structlog and loguru's `bind()` method returns a **new** logger with the
+bound context. The original logger is not modified. If the return value is discarded, the
+binding is a silent no-op — the context is never attached to any subsequent log call.
+
+```python
+# BAD — return value discarded; request_id never attached
+logger.bind(request_id="abc")    # structlog
+logger.bind(request_id="abc")    # loguru
+logger.info("handling request")  # request_id NOT present in output
+
+# GOOD — capture the return value
+logger = logger.bind(request_id="abc")
+logger.info("handling request")  # request_id IS present
+
+# GOOD (loguru) — use contextualize() for scope-bound context
+with logger.contextualize(request_id="abc"):
+    logger.info("handling request")
+
+# GOOD (structlog) — use contextvars for async-safe binding
+structlog.contextvars.bind_contextvars(request_id="abc")
+```
+
+**Context reading:** The grep matches lines where `something.bind(...)` is a bare expression
+(not assigned). Confirm it is a `bind()` call on a logger variable (not an unrelated `.bind()`
+method on another object type).
+
+---
+
+### L20 — `propagate=False` Without Handlers
+
+**Grep:** `propagate\s*=\s*False`
+
+**Severity:** HIGH
+
+**Auto-fixable:** No
+
+**Applies to:** stdlib only
+
+**Description:** Setting `logger.propagate = False` prevents log records from bubbling up to
+the parent logger's handlers. If the logger has no handlers of its own, the message falls
+through to `lastResort` (WARNING+ only) or is silently dropped entirely for DEBUG/INFO.
+
+```python
+# BAD — messages from this logger silently dropped
+child_logger = logging.getLogger("app.worker")
+child_logger.propagate = False
+# No handlers added — all messages are lost
+
+# GOOD — add a handler before disabling propagation
+child_logger = logging.getLogger("app.worker")
+child_logger.addHandler(logging.StreamHandler())
+child_logger.propagate = False
+
+# GOOD — or keep propagate=True and let the root handler receive
+child_logger = logging.getLogger("app.worker")
+# propagate=True (default) — no explicit handler needed
+```
+
+**Context reading:** Read 10 lines around the `propagate = False` assignment. Check whether
+`addHandler()` is called on the same logger object. If no handler is added, flag HIGH.
+
+---
+
+### L21 — `logger.remove()` Kills All Loguru Sinks
+
+**Grep:** `logger\.remove\(\s*\)` (no arguments)
+
+**Severity:** HIGH
+
+**Auto-fixable:** No
+
+**Applies to:** loguru only
+
+**Description:** `logger.remove()` with no arguments removes ALL sinks, including the default
+stderr sink that loguru installs at startup. After this call, log output goes nowhere. No
+error or warning is issued.
+
+This is commonly done intentionally to replace the default sink, but when the replacement
+`logger.add()` call is conditional, fails, or is in a different code path, all logging
+silently stops.
+
+```python
+# BAD — if logger.add() is never reached (exception, wrong branch, etc.)
+logger.remove()
+logger.add("app.log")      # If this fails or is skipped, all output is lost
+
+# GOOD — use a specific handler ID to remove only the default sink
+handler_id = logger.add("app.log")
+logger.remove(0)  # Remove only the default stderr sink (ID=0)
+
+# GOOD — add the new sink before removing the default
+logger.add("app.log")
+logger.remove(0)
+```
+
+**Acceptable?** `logger.remove(handler_id)` with a specific ID is fine — it only removes
+that one sink. Only flag bare `logger.remove()` (no arguments).
+
+---
+
+### L22 — kwargs in loguru Log Calls (Silently Ignored or Consumed)
+
+**Grep:** `LOGGER_VAR_PATTERN\.\w+\([^)]*,\s*\w+=` (log call with kwargs other than `exc_info`) — collect hits for Step 2.3
+
+**Severity:** MEDIUM
+
+**Auto-fixable:** Yes (move to %-style message body)
+
+**Applies to:** loguru (and custom loguru-based adapters)
+
+**Description:** In loguru, keyword arguments to log calls are used for `str.format()` message
+interpolation — NOT stored as structured fields. If the message has no matching `{kwarg_name}`
+placeholder, the kwarg is **silently ignored entirely**. It does not appear in structured output.
+
+Beyond the loguru-specific silent-ignore problem, kwargs in application log calls are an
+anti-pattern regardless: framework context (Temporal fields, correlation IDs, etc.) is
+auto-injected by the logging adapter, and all other kwargs land in an unindexed JSON blob.
+**The correct fix is always to embed context in the message body via %-style**, not to use
+`.bind()` or `{}` placeholders.
+
+```python
+# BAD — user_id silently ignored; not in structured output
+logger.info("user logged in", user_id=123)
+
+# BAD — even with {} placeholder, value is consumed by formatting, not a queryable field
+logger.info("user {user_id} logged in", user_id=123)
+
+# BAD — .bind() stores in JSON blob, not a top-level indexed field
+logger.bind(user_id=123).info("user logged in")
+
+# GOOD — embed context directly in the message body using %-style
+logger.info("user %d logged in", user_id)
+logger.info("user %s logged in from %s", username, ip_address)
+```
+
+**Context reading:** Flag any log call kwargs other than `exc_info`. Exempt: code inside the
+logging adapter/factory file itself (the file that defines `get_logger`).
+
+---
+
+### L23 — `logging.warn()` Deprecated
+
+**Grep:** `\.warn\(`
+
+**Severity:** LOW
+
+**Auto-fixable:** Yes (→ `.warning()`)
+
+**Applies to:** stdlib only
+
+**Description:** `Logger.warn()` and `logging.warn()` are deprecated aliases for `.warning()`.
+They emit a `DeprecationWarning` and will be removed in a future Python version. Use
+`.warning()` consistently.
+
+```python
+# BAD — deprecated, emits DeprecationWarning
+logger.warn("retrying connection")
+logging.warn("configuration missing")
+
+# GOOD
+logger.warning("retrying connection")
+logging.warning("configuration missing")
+```
+
+**Acceptable?** Never — it's always a direct rename.
+
+---
+
+### L24 — kwargs in Application Log Calls
+
+**Grep:** `LOGGER_VAR_PATTERN\.\w+\([^)]*,\s*\w+=` (log call with kwargs other than `exc_info`) — collect hits for Step 2.3
+
+**Severity:** MEDIUM
+
+**Auto-fixable:** Yes (move values to %-style message body)
+
+**Applies to:** all non-stdlib frameworks (structlog, loguru, custom adapters)
+
+**Description:** kwargs in application-level log calls are an anti-pattern:
+
+1. **Framework context is auto-injected.** Logging adapters for platforms like Temporal
+   automatically propagate all platform context (workflow_id, run_id, activity_type, task_queue,
+   attempt, trace_id, correlation_id, etc.) onto every log record. Application code never needs
+   to pass these fields manually.
+
+2. **Application kwargs land in a JSON blob.** In typical OTel→Grafana/ClickHouse pipelines,
+   only a small fixed set of fields are promoted to top-level indexed columns. All other kwargs
+   land in a `LogAttributes` JSON blob — present but not individually queryable without JSON
+   extraction. They are invisible when scanning the raw log stream.
+
+3. **%-style message body is always more discoverable.** The `Body` field is text-searchable at
+   full scan speed. Context embedded in the message is immediately readable in any log viewer.
+
+**Acceptable exceptions:**
+- `exc_info=True` (attaches stack trace, not application data)
+- Code inside the logging adapter/factory itself (the file that defines `get_logger`)
+- stdlib projects using `extra={}` for the stdlib-specific structured fields API
+
+```python
+# BAD — context buried in JSON blob
+logger.info("batch loaded", count=total, table=table_name)
+logger.warning("connection failed", host=host, port=port, attempt=n, exc_info=True)
+
+# GOOD — embed context directly in message body using %-style
+logger.info("loaded %d records from %s", total, table_name)
+logger.warning("connection to %s:%d failed on attempt %d", host, port, n, exc_info=True)
+```
+
+**Context reading:** Skip `exc_info=True/False`. Skip files that define the logging factory
+(e.g. the file containing `get_logger` or the logger adapter class). Flag all other kwargs.
+
+---
+
+## Severity Classification
+
+| ID | Name | Severity | Framework | Rationale |
+|----|------|----------|-----------|-----------|
+| L1 | f-string in log message | HIGH | all | Destroys structured indexing; pervasive impact |
+| L2 | Inconsistent logger factory | HIGH | all | Mixed formats break log correlation at scale |
+| L3 | `extra={}` in wrong framework | MEDIUM | structlog/loguru | Silently nests data; invisible to aggregation queries |
+| L4 | Missing `exc_info=True` in except | HIGH | all | Makes root-cause analysis impossible |
+| L5 | `print()` in production | MEDIUM | all | Bypasses observability; not critical but noisy |
+| L6 | INFO inside tight loop | MEDIUM | all | Log volume explosion; performance impact |
+| L7 | `logger.critical()` | MEDIUM | all | Confuses alerting; no operational value over ERROR |
+| L8 | Unguarded expensive DEBUG | LOW | all | Performance waste only when DEBUG enabled |
+| L9 | Warn-then-raise duplication | MEDIUM | all | Inflated error counts in dashboards |
+| L10 | Credential value in log | CRITICAL | all | Security vulnerability; data exposure |
+| L11 | String concatenation in log | MEDIUM | all | Same impact as L1 |
+| L12 | %-style in non-stdlib logger | MEDIUM (structlog) / HIGH (loguru) | structlog/loguru | structlog: literal %s; loguru: args silently dropped |
+| L13 | `extra={}` reserved key collision | CRITICAL | stdlib | Crashes caller; not caught by handleError() |
+| L14 | Arbitrary kwargs in stdlib logger | CRITICAL | stdlib | TypeError crashes caller; common after migration from structlog/loguru |
+| L15 | `event=` kwarg overwrites message | HIGH | structlog | Silently replaces log message with domain value |
+| L16 | `dictConfig` with `disable_existing_loggers` default | HIGH | stdlib | Silently disables all pre-existing loggers |
+| L17 | `basicConfig()` no-op after first call | HIGH | stdlib | Configuration silently ignored; wrong config in effect |
+| L18 | `logger.exception()` outside except | MEDIUM | all | Logs `NoneType: None`; misleads debugging |
+| L19 | `bind()` return value discarded | HIGH | structlog/loguru | Context silently not attached to any log call |
+| L20 | `propagate=False` without handlers | HIGH | stdlib | Messages silently dropped at DEBUG/INFO |
+| L21 | `logger.remove()` kills all sinks | HIGH | loguru | All log output silently stops |
+| L22 | loguru kwargs silently ignored or consumed | MEDIUM | loguru | kwargs silently ignored; correct fix is %-style message body |
+| L23 | `logging.warn()` deprecated | LOW | stdlib | DeprecationWarning; will be removed in future Python |
+| L24 | kwargs in application log calls | MEDIUM | non-stdlib | Framework context auto-injected; kwargs land in unindexed JSON blob; use %-style |
+
+---
+
+## Legitimacy — Acceptable Patterns
+
+Not every grep match is a real finding. These patterns look like violations but are not:
+
+| Pattern | Looks like | Why acceptable |
+|---------|-----------|----------------|
+| `logger.info("token refreshed", token_name=name)` | L10 | Logs the name, not the value |
+| `logger.debug("processing %s", item_id)` | L12 | Only flag if framework is not stdlib |
+| `logger.exception("failed")` (no `exc_info=True`) | L4 | `.exception()` implies `exc_info=True` |
+| `extra={"count": n}` in stdlib project | L3 | Correct stdlib pattern |
+| `logger.info("...")` in a loop of known size ≤ 10 | L6 | Loop is bounded and small |
+| `print(result)` in `if __name__ == "__main__":` | L5 | CLI output, not logging |
+| `print(result)` in test files | L5 | Test output, acceptable |
+| `extra={"user_name": val}` (non-reserved key) | L13 | Key is not in the 22 forbidden LogRecord attributes |
+| `logger.info("msg", exc_info=True)` | L14, L22, L24 | `exc_info` is the one allowed kwarg — attaches stack trace, not application data |
+| `logger.info("event", event="startup")` where event is intentionally the message | L15 | Intentional — must be commented explaining the choice |
+| `dictConfig({..., "disable_existing_loggers": False, ...})` | L16 | Explicitly opts out of the dangerous default |
+| Single `basicConfig()` in `if __name__ == "__main__":` | L17 | Controlled entrypoint, no competing calls |
+| `logger.exception("msg")` inside an `except` block | L18 | Correct use — has exception context |
+| `bound = logger.bind(request_id="abc")` (return captured) | L19 | Return value captured; context properly attached |
+| `logger.remove(handler_id)` (specific ID) | L21 | Removes only that sink; default may still be present |
+| `logger.info("user %d logged in", user_id)` | L22, L24 | Correct pattern — context in message body via %-style, no kwargs |
+| Code inside the logging adapter/factory file (defines `get_logger`) | L22, L24 | Exempt — this is the framework setup, not application code |
+
+---
+
+## Fix Templates
+
+### FT-L1 — f-string → %-style message body
+
+```python
+# Before
+logger.info(f"loaded {count} records from {table}")
+
+# After — embed context in message body using %-style (all frameworks)
+logger.info("loaded %d records from %s", count, table)
+
+# Also good — literal string when values are known at call site
+logger.info("extraction complete")
+```
+
+### FT-L2 — Import swap to canonical factory
+
+```python
+# Before (if canonical is structlog)
+import logging
+logger = logging.getLogger(__name__)
+
+# After
+import structlog
+logger = structlog.get_logger()
+```
+
+### FT-L3 — `extra={}` ↔ kwargs (manual — framework-dependent)
+
+```python
+# Before (structlog — extra not indexed)
+logger.info("batch complete", extra={"count": n})
+
+# After (structlog)
+logger.info("batch complete", count=n)
+```
+
+### FT-L4 — Add `exc_info=True`
+
+```python
+# Before
+except ConnectionError:
+    logger.warning("connection failed")
+
+# After
+except ConnectionError:
+    logger.warning("connection failed", exc_info=True)
+```
+
+### FT-L5 — `print()` → logger
+
+```python
+# Before
+print(f"Processing {len(records)} records")
+
+# After — embed context in message body
+logger.info("processing batch of %d records", len(records))
+```
+
+### FT-L6 — INFO → DEBUG in loop
+
+```python
+# Before
+for asset in assets:
+    logger.info("processing asset", name=asset.name)
+
+# After — DEBUG per item (%-style), INFO for summary
+for asset in assets:
+    logger.debug("processing asset %s", asset.name)
+logger.info("batch of %d assets processed", len(assets))
+```
+
+### FT-L7 — `critical()` → `error()`
+
+```python
+# Before
+logger.critical("database unreachable")
+
+# After
+logger.error("database unreachable", exc_info=True)
+```
+
+### FT-L8 — Guard expensive DEBUG args
+
+```python
+# Before
+logger.debug("payload", data=json.dumps(large_obj))
+
+# After
+if logger.isEnabledFor(logging.DEBUG):
+    logger.debug("payload", data=json.dumps(large_obj))
+```
+
+### FT-L9 — Remove log before raise
+
+```python
+# Before
+except Exception:
+    logger.error("operation failed", exc_info=True)
+    raise
+
+# After (simple re-raise — let caller log)
+except Exception:
+    raise
+
+# After (adding context — wrap and raise)
+except Exception as e:
+    raise OperationError(f"failed during {phase}") from e
+```
+
+### FT-L10 — Remove credential value
+
+```python
+# Before
+logger.debug("auth configured", token=api_token)
+
+# After
+logger.debug("auth configured", credential_name=credential_name, token_present=bool(api_token))
+```
+
+### FT-L11 — Concatenation → %-style message body
+
+```python
+# Before
+logger.info("loaded " + str(count) + " records")
+
+# After — %-style (all frameworks)
+logger.info("loaded %d records", count)
+logger.info("loaded %d records from %s", count, table)
+```
+
+### FT-L12 — %-style in structlog/loguru (check call site, not just project)
+
+```python
+# Before (loguru direct import — arg silently ignored even if a bridge adapter exists)
+from loguru import logger
+logger.info("loaded %s records", count)
+
+# After — use CANONICAL_FACTORY so the %-bridge is applied
+from myproject.observability import get_logger
+logger = get_logger(__name__)
+logger.info("loaded %s records", count)   # adapter pre-formats before handing to loguru
+
+# Before (vanilla loguru, no bridge — arg silently ignored)
+logger.info("loaded %s records", count)
+
+# After (vanilla loguru, no bridge)
+logger.info("loaded {} records", count)   # loguru uses str.format() style
+
+# Before (structlog — % appears literally)
+logger.info("loaded %s records", count)
+
+# After (structlog)
+logger.info("loaded {} records", count)
+```
+
+**Note:** A %-style bridge in the adapter only helps calls that go **through** that adapter.
+Direct `from loguru import logger` calls bypass the bridge entirely — the fix is to use
+`CANONICAL_FACTORY` (e.g. `get_logger(__name__)`), not just to note that a bridge exists.
+
+### FT-L13 — Rename reserved extra key
+
+```python
+# Before — crashes with KeyError
+logger.info("action", extra={"name": user.name})
+
+# After — prefix to avoid collision
+logger.info("action", extra={"user_name": user.name})
+```
+
+### FT-L14 — Wrap arbitrary kwargs in extra={} (stdlib)
+
+```python
+# Before — crashes with TypeError in stdlib
+logger.info("user login", user_id="alice", request_id="abc")
+
+# After — wrap in extra={}
+logger.info("user login", extra={"user_id": "alice", "request_id": "abc"})
+```
+
+### FT-L15 — Rename `event` kwarg in structlog
+
+```python
+# Before — silently replaces log message
+logger.info("processing", event=domain_event)
+
+# After — use a non-colliding key
+logger.info("processing", domain_event=domain_event)
+logger.info("processing", event_type=domain_event.type, event_id=domain_event.id)
+```
+
+### FT-L16 — Add `disable_existing_loggers: False` to dictConfig
+
+```python
+# Before
+logging.config.dictConfig({
+    "version": 1,
+    "handlers": {...},
+    "root": {...},
+})
+
+# After
+logging.config.dictConfig({
+    "version": 1,
+    "disable_existing_loggers": False,   # <-- add this
+    "handlers": {...},
+    "root": {...},
+})
+```
+
+### FT-L17 — Consolidate basicConfig calls (manual)
+
+```python
+# Before — second call is silently ignored
+logging.basicConfig(level=logging.WARNING)  # in library
+logging.basicConfig(level=logging.DEBUG)    # in app — no-op
+
+# After (Python 3.8+) — force override
+logging.basicConfig(level=logging.DEBUG, force=True)
+# or switch to dictConfig with disable_existing_loggers=False
+```
+
+### FT-L18 — Replace exception() with error() outside except block
+
+```python
+# Before — outside except, logs "NoneType: None"
+logger.exception("validation failed")
+
+# After — use error() when no exception context
+logger.error("validation failed")
+```
+
+### FT-L19 — Capture bind() return value
+
+```python
+# Before — return value discarded, context not attached
+logger.bind(request_id="abc")
+logger.info("handling request")
+
+# After — capture return value
+logger = logger.bind(request_id="abc")
+logger.info("handling request")
+
+# Or (loguru) — use contextualize for scoped binding
+with logger.contextualize(request_id="abc"):
+    logger.info("handling request")
+```
+
+### FT-L20 — Add handler before propagate=False (manual)
+
+```python
+# Before — messages silently dropped
+child = logging.getLogger("app.worker")
+child.propagate = False
+
+# After — add handler first
+child = logging.getLogger("app.worker")
+child.addHandler(logging.StreamHandler())
+child.propagate = False
+```
+
+### FT-L21 — Use specific sink ID with logger.remove()
+
+```python
+# Before — removes ALL sinks including default stderr
+logger.remove()
+logger.add("app.log")
+
+# After — add new sink first, then remove default by ID
+logger.add("app.log")
+logger.remove(0)   # 0 is loguru's default stderr sink ID
+```
+
+### FT-L22 — kwargs in loguru → %-style message body
+
+```python
+# Before — kwarg silently ignored (no {} placeholder)
+logger.info("user logged in", user_id=123)
+
+# After — embed context in message body using %-style
+logger.info("user %d logged in", user_id)
+logger.info("user %s logged in from %s", username, ip_address)
+```
+
+### FT-L23 — Replace warn() with warning()
+
+```python
+# Before — deprecated
+logger.warn("retrying")
+
+# After
+logger.warning("retrying")
+```
+
+### FT-L24 — kwargs in application log call → %-style message body
+
+```python
+# Before — context buried in JSON blob
+logger.info("batch loaded", count=total, table=table_name)
+logger.warning("connection failed", host=host, port=port, attempt=n, exc_info=True)
+logger.error("auth failed", user=username, reason=str(e))
+
+# After — embed context in message body using %-style; keep exc_info=True
+logger.info("loaded %d records from %s", total, table_name)
+logger.warning("connection to %s:%d failed on attempt %d", host, port, n, exc_info=True)
+logger.error("auth failed for user %s: %s", username, str(e), exc_info=True)
+```
+
+---
+
+## Linting Rules to Enable
+
+These ruff/flake8-logging-format rules directly enforce the patterns above:
+
+| Rule | Pattern | Notes |
+|------|---------|-------|
+| `G001` | `.format()` in logging call | Catches format-string anti-pattern |
+| `G002` | `%` formatting in logging call | **False-positive risk in stdlib projects** — %-style is correct there |
+| `G003` | `+` concatenation in logging | Maps to L11 |
+| `G004` | f-string in logging | Maps to L1 (ruff natively supports this) |
+| `T201` | `print()` found | Maps to L5 |
+| `LOG009` | `WARN` deprecated | Use `WARNING` — maps to L23 |
+| `LOG015` | `basicConfig()` called without `force=True` | Maps to L17 (if available in ruff version) |
+
+**Enable in `pyproject.toml`:**
+```toml
+[tool.ruff.lint]
+select = [
+    # existing rules...
+    "G",      # flake8-logging-format
+    "T201",   # print statements
+    "LOG",    # logging anti-patterns
+]
+# If project uses stdlib-only logging, suppress G002 to avoid false positives:
+ignore = ["G002"]
+```
+
+**Suggested Makefile target:**
+```makefile
+lint-logging:
+    uv run ruff check --select G,T201,LOG $(SRC_DIRS)
+```
+
+**Note on G002:** If the project uses stdlib logging, `%-style` is correct and G002 will produce
+false positives. Add `G002` to `ignore` in that case. Step 2.5 will note this recommendation
+based on the detected `LOGGER_FRAMEWORK`.


### PR DESCRIPTION
## Summary

Ports the `signal-over-noise` observability-audit skill from `atlanhq/awesome-ai` into `application-sdk/.claude/skills/` so it auto-discovers when developers run Claude Code from inside this repo (or any app repo that vendors the SDK's skills directory).

Motivation, from #bu-application-sdk thread: *"we may actually pull the signal-over-noise skill into the app-sdk itself — to simplify usage (i.e., across other skills), tailor it even further to application SDK specifics, ease its targeted reuse for app developers."*

This PR is **the faithful-port step only** — no SDK-specific tailoring yet. Tailoring (Loguru patterns, `AppError` taxonomy from `typed-failures`, Temporal activity/heartbeat context, composition hooks for `sdk-review` / `typed-failures`) will follow in a separate PR once the port is in place.

## What's in the diff

- `.claude/skills/signal-over-noise/SKILL.md` — two-phase audit (surface + tune), plan-mode-gated execution
- `.claude/skills/signal-over-noise/references/`
  - `error-recovery-patterns.md` — 11 surface-mode patterns (P1–P11) with severity, fix templates, ruff rules
  - `logging-patterns.md` — 23 tune-mode patterns (L1–L23) with detection, fix, lint config
  - `logging-level-guidelines.md` — DEBUG/INFO/WARNING/ERROR philosophy and framework-awareness notes

Net change: **+2654 lines, all under `.claude/skills/signal-over-noise/`**. No production code, no CI, no `pyproject.toml`.

## Differences from the awesome-ai source

1. **`reference/` → `references/`** to match the repo convention used by `capability-manifest`, `sdk-evolution`, and `sdk-review`.
2. **6 in-doc paths rewritten** from `~/.claude/skills/signal-over-noise/reference/...` (the user-home install layout that awesome-ai uses) to `.claude/skills/signal-over-noise/references/...` (repo-relative).
3. **Frontmatter upgraded** to match the `typed-failures` shape — `mandatory_triggers`, `optional_triggers`, `owner: connector-platform-team`, `last_updated`, `staleness_days`, `inputs`, `outputs`, `gates`.

No content edits to the pattern catalogues themselves.

## How to use it once merged

Run Claude Code from inside `application-sdk/`:

```
/signal-over-noise                                  # surface audit, cwd
/signal-over-noise application_sdk/                 # specific path
/signal-over-noise --mode tune                      # logging-quality phase
/signal-over-noise --mode surface --severity high   # HIGH+ findings only
```

The skill greps the codebase, classifies findings, enters plan mode for user approval, then applies edits and runs pre-commit. All changes are left uncommitted for review.

## Test plan

- [ ] Pre-commit passes on the four new markdown files (verified locally: all Python hooks skipped, whitespace/BOM/merge-conflict hooks pass)
- [ ] Inside `application-sdk/`, run `/signal-over-noise` in a fresh Claude Code session and confirm the skill is discovered and the plan-mode flow runs against `application_sdk/`
- [ ] Inside `application-sdk/`, run `/signal-over-noise --mode tune --severity high` and confirm the logging-quality phase executes
- [ ] Verify the three `references/*.md` paths are reachable from the SKILL.md links

## Follow-ups (out of scope for this PR)

- SDK-tailoring PR: Loguru-aware patterns, `AppError` mapping, Temporal context, composition with `typed-failures` phase-2 punch list
- Decide what to do with `signal-over-noise` in `awesome-ai` — delete, stub-with-pointer, or leave for now