### PR TITLE
feat(observability): add ObjectStore metric exporter for OTel instruments

### DIFF
--- a/application_sdk/observability/_objectstore_metric_exporter.py
+++ b/application_sdk/observability/_objectstore_metric_exporter.py
@@ -1,0 +1,300 @@
+"""ObjectStore metric exporter for the OTel SDK.
+
+Receives ``MetricsData`` from ``PeriodicExportingMetricReader`` on a
+background thread, serializes each data point as an NDJSON record,
+writes a ``.json.gz`` file to local disk, and uploads it to the
+deployment and (optionally) upstream object stores.
+
+Best-effort: upload failures are logged and swallowed — the exporter
+always returns ``SUCCESS`` so a flaky store never blocks metric
+collection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import logging
+import os
+import threading
+from collections.abc import Sequence
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+import orjson
+from opentelemetry.sdk.metrics.export import (
+    AggregationTemporality,
+    Gauge,
+    Histogram,
+    MetricExporter,
+    MetricExportResult,
+    MetricsData,
+    Sum,
+)
+
+from application_sdk.constants import (
+    APPLICATION_NAME,
+    DEPLOYMENT_NAME,
+    DEPLOYMENT_OBJECT_STORE_NAME,
+    ENABLE_ATLAN_UPLOAD,
+    ENABLE_OBSERVABILITY_STORE_SINK,
+    UPSTREAM_OBJECT_STORE_NAME,
+)
+from application_sdk.observability.observability import OBSERVABILITY_S3_PREFIX_MAP
+from application_sdk.observability.utils import get_observability_dir
+from application_sdk.storage import upload_file
+from application_sdk.storage.binding import create_store_from_binding
+
+if TYPE_CHECKING:
+    from opentelemetry.sdk.metrics.export import HistogramDataPoint, NumberDataPoint
+    from opentelemetry.sdk.resources import Resource
+
+logger = logging.getLogger(__name__)
+
+#: S3 prefix for OTel-sourced Prometheus metrics.  Kept separate from the
+#: ``metrics/`` prefix used by ``record_metric()`` data so consumers can
+#: distinguish the two streams.
+_S3_PREFIX = OBSERVABILITY_S3_PREFIX_MAP.get(
+    "metrics", "artifacts/apps/observability/sdr/metrics"
+).replace("/metrics", "/prometheus-metrics")
+
+
+def _resource_attrs(resource: Resource) -> dict[str, str]:
+    """Extract resource attributes as a plain string dict."""
+    return {str(k): str(v) for k, v in resource.attributes.items()}
+
+
+def _number_record(
+    name: str,
+    description: str | None,
+    unit: str | None,
+    metric_type: str,
+    dp: NumberDataPoint,
+    resource_attributes: dict[str, str],
+    is_monotonic: bool | None = None,
+    aggregation_temporality: str | None = None,
+) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "timestamp": dp.time_unix_nano / 1e9,
+        "name": name,
+        "type": metric_type,
+        "value": dp.value,
+        "attributes": dict(dp.attributes) if dp.attributes else {},
+        "resource_attributes": resource_attributes,
+    }
+    if description:
+        record["description"] = description
+    if unit:
+        record["unit"] = unit
+    if is_monotonic is not None:
+        record["is_monotonic"] = is_monotonic
+    if aggregation_temporality:
+        record["aggregation_temporality"] = aggregation_temporality
+    return record
+
+
+def _histogram_record(
+    name: str,
+    description: str | None,
+    unit: str | None,
+    dp: HistogramDataPoint,
+    resource_attributes: dict[str, str],
+    aggregation_temporality: str | None = None,
+) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "timestamp": dp.time_unix_nano / 1e9,
+        "name": name,
+        "type": "histogram",
+        "value": {
+            "count": dp.count,
+            "sum": dp.sum,
+            "bucket_counts": list(dp.bucket_counts),
+            "explicit_bounds": list(dp.explicit_bounds),
+        },
+        "attributes": dict(dp.attributes) if dp.attributes else {},
+        "resource_attributes": resource_attributes,
+    }
+    if description:
+        record["description"] = description
+    if unit:
+        record["unit"] = unit
+    if aggregation_temporality:
+        record["aggregation_temporality"] = aggregation_temporality
+    return record
+
+
+def _temporality_name(t: AggregationTemporality) -> str:
+    if t == AggregationTemporality.DELTA:
+        return "delta"
+    return "cumulative"
+
+
+def _serialize_metrics_data(metrics_data: MetricsData | None) -> list[dict[str, Any]]:
+    """Flatten ``MetricsData`` into a list of JSON-serializable dicts."""
+    if metrics_data is None:
+        return []
+    records: list[dict[str, Any]] = []
+    for rm in metrics_data.resource_metrics:
+        res_attrs = _resource_attrs(rm.resource)
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                data = metric.data
+                if isinstance(data, Sum):
+                    temp = _temporality_name(data.aggregation_temporality)
+                    for dp in data.data_points:
+                        records.append(
+                            _number_record(
+                                metric.name,
+                                metric.description,
+                                metric.unit,
+                                "sum",
+                                dp,
+                                res_attrs,
+                                is_monotonic=data.is_monotonic,
+                                aggregation_temporality=temp,
+                            )
+                        )
+                elif isinstance(data, Gauge):
+                    for dp in data.data_points:
+                        records.append(
+                            _number_record(
+                                metric.name,
+                                metric.description,
+                                metric.unit,
+                                "gauge",
+                                dp,
+                                res_attrs,
+                            )
+                        )
+                elif isinstance(data, Histogram):
+                    temp = _temporality_name(data.aggregation_temporality)
+                    for dp in data.data_points:
+                        records.append(
+                            _histogram_record(
+                                metric.name,
+                                metric.description,
+                                metric.unit,
+                                dp,
+                                res_attrs,
+                                aggregation_temporality=temp,
+                            )
+                        )
+    return records
+
+
+def _write_ndjson_gz(records: Sequence[dict[str, Any]], path: str) -> None:
+    """Write records as gzip-compressed NDJSON to *path*."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with gzip.open(path, "wb") as f:
+        for record in records:
+            f.write(orjson.dumps(record) + b"\n")
+
+
+def _upload_sync(local_path: str, remote_key: str) -> None:
+    """Upload *local_path* to object stores, bridging async→sync.
+
+    Called from the ``PeriodicExportingMetricReader`` background thread,
+    which is not an asyncio thread.  We use ``asyncio.run()`` to drive
+    the async ``upload_file`` from a synchronous context.
+    """
+
+    async def _upload() -> None:
+        try:
+            store = create_store_from_binding(DEPLOYMENT_OBJECT_STORE_NAME)
+            await upload_file(remote_key, local_path, store=store)
+        except Exception:
+            logger.warning(
+                "ObjectStore metric upload to deployment store failed", exc_info=True
+            )
+
+        if ENABLE_ATLAN_UPLOAD:
+            try:
+                store = create_store_from_binding(UPSTREAM_OBJECT_STORE_NAME)
+                await upload_file(remote_key, local_path, store=store)
+            except Exception:
+                logger.warning(
+                    "ObjectStore metric upload to upstream store failed", exc_info=True
+                )
+
+    asyncio.run(_upload())
+
+
+class ObjectStoreMetricExporter(MetricExporter):
+    """Exports OTel metrics as NDJSON.gz files to ObjectStore.
+
+    Intended to be paired with ``PeriodicExportingMetricReader``.
+    Uses **delta** temporality for counters so each export is
+    self-contained (no ever-growing cumulative values in files).
+    """
+
+    def __init__(self, *, data_dir: str | None = None) -> None:
+        super().__init__(
+            preferred_temporality={
+                Sum: AggregationTemporality.DELTA,
+                Histogram: AggregationTemporality.DELTA,
+                Gauge: AggregationTemporality.CUMULATIVE,
+            },
+        )
+        self._data_dir = data_dir or get_observability_dir()
+        self._lock = threading.Lock()
+
+    def export(
+        self,
+        metrics_data: MetricsData,
+        timeout_millis: float = 10_000,
+        **kwargs: Any,
+    ) -> MetricExportResult:
+        if not ENABLE_OBSERVABILITY_STORE_SINK:
+            return MetricExportResult.SUCCESS
+
+        try:
+            records = _serialize_metrics_data(metrics_data)
+            if not records:
+                return MetricExportResult.SUCCESS
+
+            now = datetime.now()
+            ts_ns = int(now.timestamp() * 1e9)
+            filename = f"{ts_ns}_{DEPLOYMENT_NAME}_{APPLICATION_NAME}.json.gz"
+
+            local_dir = os.path.join(
+                self._data_dir,
+                "sdr" if ENABLE_ATLAN_UPLOAD else "non-sdr",
+                "prometheus-metrics",
+                f"year={now.year}",
+                f"month={now.month:02d}",
+                f"day={now.day:02d}",
+                f"hour={now.hour:02d}",
+            )
+            local_path = os.path.join(local_dir, filename)
+
+            remote_key = os.path.join(
+                _S3_PREFIX,
+                f"year={now.year}",
+                f"month={now.month:02d}",
+                f"day={now.day:02d}",
+                f"hour={now.hour:02d}",
+                filename,
+            )
+
+            _write_ndjson_gz(records, local_path)
+
+            try:
+                _upload_sync(local_path, remote_key)
+            finally:
+                # Always clean up local file
+                try:
+                    os.unlink(local_path)
+                except OSError:
+                    pass
+
+        except Exception:
+            logger.warning("ObjectStore metric export failed", exc_info=True)
+
+        # Always succeed — never block metric collection.
+        return MetricExportResult.SUCCESS
+
+    def force_flush(self, timeout_millis: float = 10_000) -> bool:
+        return True
+
+    def shutdown(self, timeout_millis: float = 30_000, **kwargs: Any) -> None:
+        pass

--- a/application_sdk/observability/_objectstore_metric_exporter.py
+++ b/application_sdk/observability/_objectstore_metric_exporter.py
@@ -16,7 +16,7 @@ import asyncio
 import gzip
 import logging
 import os
-import threading
+import posixpath
 from collections.abc import Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
@@ -190,12 +190,13 @@ def _write_ndjson_gz(records: Sequence[dict[str, Any]], path: str) -> None:
             f.write(orjson.dumps(record) + b"\n")
 
 
-def _upload_sync(local_path: str, remote_key: str) -> None:
+def _upload_sync(local_path: str, remote_key: str, timeout_s: float) -> None:
     """Upload *local_path* to object stores, bridging async→sync.
 
     Called from the ``PeriodicExportingMetricReader`` background thread,
     which is not an asyncio thread.  We use ``asyncio.run()`` to drive
-    the async ``upload_file`` from a synchronous context.
+    the async ``upload_file`` from a synchronous context.  The upload is
+    bounded by ``timeout_s`` so a hanging store never blocks the reader.
     """
 
     async def _upload() -> None:
@@ -216,7 +217,10 @@ def _upload_sync(local_path: str, remote_key: str) -> None:
                     "ObjectStore metric upload to upstream store failed", exc_info=True
                 )
 
-    asyncio.run(_upload())
+    try:
+        asyncio.run(asyncio.wait_for(_upload(), timeout=timeout_s))
+    except TimeoutError:
+        logger.warning("ObjectStore metric upload timed out after %.1fs", timeout_s)
 
 
 class ObjectStoreMetricExporter(MetricExporter):
@@ -236,7 +240,6 @@ class ObjectStoreMetricExporter(MetricExporter):
             },
         )
         self._data_dir = data_dir or get_observability_dir()
-        self._lock = threading.Lock()
 
     def export(
         self,
@@ -267,7 +270,7 @@ class ObjectStoreMetricExporter(MetricExporter):
             )
             local_path = os.path.join(local_dir, filename)
 
-            remote_key = os.path.join(
+            remote_key = posixpath.join(
                 _S3_PREFIX,
                 f"year={now.year}",
                 f"month={now.month:02d}",
@@ -279,7 +282,7 @@ class ObjectStoreMetricExporter(MetricExporter):
             _write_ndjson_gz(records, local_path)
 
             try:
-                _upload_sync(local_path, remote_key)
+                _upload_sync(local_path, remote_key, timeout_millis / 1000.0)
             finally:
                 # Always clean up local file
                 try:

--- a/application_sdk/observability/_objectstore_metric_reader.py
+++ b/application_sdk/observability/_objectstore_metric_reader.py
@@ -1,0 +1,32 @@
+"""Factory for the ObjectStore-backed periodic metric reader.
+
+Pairs :class:`ObjectStoreMetricExporter` with OTel's
+``PeriodicExportingMetricReader`` so the caller just gets back a
+ready-to-use reader to plug into the ``MeterProvider``.
+"""
+
+from __future__ import annotations
+
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+
+from application_sdk.observability._objectstore_metric_exporter import (
+    ObjectStoreMetricExporter,
+)
+
+
+def create_objectstore_metric_reader(
+    *,
+    export_interval_millis: int = 60_000,
+    export_timeout_millis: int = 30_000,
+) -> PeriodicExportingMetricReader:
+    """Create a ``PeriodicExportingMetricReader`` backed by ObjectStore.
+
+    Default export interval is 60 s — deliberately longer than the
+    Pushgateway interval (30 s) because ObjectStore writes are heavier
+    and the data is durable.
+    """
+    return PeriodicExportingMetricReader(
+        ObjectStoreMetricExporter(),
+        export_interval_millis=export_interval_millis,
+        export_timeout_millis=export_timeout_millis,
+    )

--- a/application_sdk/observability/metrics_adaptor.py
+++ b/application_sdk/observability/metrics_adaptor.py
@@ -9,6 +9,7 @@ from opentelemetry import metrics
 from opentelemetry.sdk.metrics import MeterProvider
 
 from application_sdk.constants import (
+    ENABLE_OBSERVABILITY_STORE_SINK,
     METRICS_BATCH_SIZE,
     METRICS_CLEANUP_ENABLED,
     METRICS_FILE_NAME,
@@ -127,9 +128,19 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
             # ``* on(instance) group_left(...)`` join. See the cardinality
             # rationale in observability/utils.py:METRIC_ENRICHMENT_KEYS.
             self._prometheus_reader = EnrichedPrometheusMetricReader(resource=resource)
+            readers = [self._prometheus_reader]
+
+            if ENABLE_OBSERVABILITY_STORE_SINK:
+                from application_sdk.observability._objectstore_metric_reader import (  # noqa: PLC0415 — cold path
+                    create_objectstore_metric_reader,
+                )
+
+                self._objectstore_reader = create_objectstore_metric_reader()
+                readers.append(self._objectstore_reader)
+
             self.meter_provider = MeterProvider(
                 resource=resource,
-                metric_readers=[self._prometheus_reader],
+                metric_readers=readers,
             )
             metrics.set_meter_provider(self.meter_provider)
             self.meter = self.meter_provider.get_meter(SERVICE_NAME)

--- a/tests/unit/observability/test_objectstore_metric_exporter.py
+++ b/tests/unit/observability/test_objectstore_metric_exporter.py
@@ -1,0 +1,211 @@
+"""Tests for ObjectStoreMetricExporter."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import (
+    AggregationTemporality,
+    InMemoryMetricReader,
+)
+from opentelemetry.sdk.resources import Resource
+
+from application_sdk.observability._objectstore_metric_exporter import (
+    ObjectStoreMetricExporter,
+    _serialize_metrics_data,
+)
+
+
+@pytest.fixture()
+def resource() -> Resource:
+    return Resource.create(
+        {"app.name": "test-app", "app.version": "1.0.0", "service.name": "test"}
+    )
+
+
+@pytest.fixture()
+def exporter(tmp_path) -> ObjectStoreMetricExporter:
+    return ObjectStoreMetricExporter(data_dir=str(tmp_path))
+
+
+@pytest.fixture()
+def in_memory_reader() -> InMemoryMetricReader:
+    return InMemoryMetricReader(
+        preferred_temporality={
+            # Match the exporter's temporality so we can reuse the same
+            # MetricsData for serialization tests.
+        }
+    )
+
+
+@pytest.fixture()
+def provider(resource: Resource, in_memory_reader: InMemoryMetricReader):
+    p = MeterProvider(resource=resource, metric_readers=[in_memory_reader])
+    yield p
+    try:
+        p.shutdown()
+    except Exception:  # noqa: S110 — shutdown may fail if already cleaned up
+        pass
+
+
+class TestSerialization:
+    """Verify MetricsData → JSON serialization."""
+
+    def test_counter_serialized(
+        self, provider: MeterProvider, in_memory_reader: InMemoryMetricReader
+    ) -> None:
+        meter = provider.get_meter("test")
+        counter = meter.create_counter(
+            "test.counter", unit="1", description="A test counter"
+        )
+        counter.add(5, {"endpoint": "/api"})
+
+        metrics_data = in_memory_reader.get_metrics_data()
+        records = _serialize_metrics_data(metrics_data)
+
+        assert len(records) == 1
+        r = records[0]
+        assert r["name"] == "test.counter"
+        assert r["type"] == "sum"
+        assert r["value"] == 5
+        assert r["attributes"]["endpoint"] == "/api"
+        assert r["resource_attributes"]["app.name"] == "test-app"
+        assert r["description"] == "A test counter"
+        assert r["unit"] == "1"
+
+    def test_histogram_serialized(
+        self, provider: MeterProvider, in_memory_reader: InMemoryMetricReader
+    ) -> None:
+        meter = provider.get_meter("test")
+        hist = meter.create_histogram("test.duration", unit="s")
+        hist.record(0.5, {"status": "ok"})
+        hist.record(1.5, {"status": "ok"})
+
+        metrics_data = in_memory_reader.get_metrics_data()
+        records = _serialize_metrics_data(metrics_data)
+
+        hist_records = [r for r in records if r["name"] == "test.duration"]
+        assert len(hist_records) == 1
+        r = hist_records[0]
+        assert r["type"] == "histogram"
+        assert r["value"]["count"] == 2
+        assert r["value"]["sum"] == 2.0
+        assert isinstance(r["value"]["bucket_counts"], list)
+        assert isinstance(r["value"]["explicit_bounds"], list)
+
+    def test_gauge_serialized(
+        self, provider: MeterProvider, in_memory_reader: InMemoryMetricReader
+    ) -> None:
+        meter = provider.get_meter("test")
+        gauge = meter.create_gauge("test.gauge")
+        gauge.set(42.0, {"region": "us-east"})
+
+        metrics_data = in_memory_reader.get_metrics_data()
+        records = _serialize_metrics_data(metrics_data)
+
+        gauge_records = [r for r in records if r["name"] == "test.gauge"]
+        assert len(gauge_records) == 1
+        r = gauge_records[0]
+        assert r["type"] == "gauge"
+        assert r["value"] == 42.0
+
+    def test_empty_metrics_returns_empty_list(
+        self,
+        provider: MeterProvider,
+        in_memory_reader: InMemoryMetricReader,
+    ) -> None:
+        # No metrics recorded — should produce an empty list.
+        metrics_data = in_memory_reader.get_metrics_data()
+        records = _serialize_metrics_data(metrics_data)
+        assert records == []
+
+
+class TestExport:
+    """Verify the export() method writes files and calls upload."""
+
+    @patch(
+        "application_sdk.observability._objectstore_metric_exporter.ENABLE_OBSERVABILITY_STORE_SINK",
+        True,
+    )
+    @patch(
+        "application_sdk.observability._objectstore_metric_exporter._upload_sync",
+    )
+    def test_export_writes_ndjson_gz(
+        self,
+        mock_upload: AsyncMock,
+        provider: MeterProvider,
+        in_memory_reader: InMemoryMetricReader,
+        exporter: ObjectStoreMetricExporter,
+    ) -> None:
+        meter = provider.get_meter("test")
+        counter = meter.create_counter("export.test")
+        counter.add(1, {"k": "v"})
+
+        metrics_data = in_memory_reader.get_metrics_data()
+        result = exporter.export(metrics_data)
+
+        from opentelemetry.sdk.metrics.export import MetricExportResult
+
+        assert result == MetricExportResult.SUCCESS
+        assert mock_upload.called
+        # Verify the local file was cleaned up
+        local_path = mock_upload.call_args[0][0]
+        assert not os.path.exists(local_path)
+
+    @patch(
+        "application_sdk.observability._objectstore_metric_exporter.ENABLE_OBSERVABILITY_STORE_SINK",
+        False,
+    )
+    def test_export_noop_when_sink_disabled(
+        self,
+        provider: MeterProvider,
+        in_memory_reader: InMemoryMetricReader,
+        exporter: ObjectStoreMetricExporter,
+    ) -> None:
+        meter = provider.get_meter("test")
+        counter = meter.create_counter("noop.test")
+        counter.add(1)
+
+        metrics_data = in_memory_reader.get_metrics_data()
+        from opentelemetry.sdk.metrics.export import MetricExportResult
+
+        result = exporter.export(metrics_data)
+        assert result == MetricExportResult.SUCCESS
+
+    @patch(
+        "application_sdk.observability._objectstore_metric_exporter.ENABLE_OBSERVABILITY_STORE_SINK",
+        True,
+    )
+    @patch(
+        "application_sdk.observability._objectstore_metric_exporter._upload_sync",
+        side_effect=Exception("upload boom"),
+    )
+    def test_export_swallows_upload_failure(
+        self,
+        mock_upload: AsyncMock,
+        provider: MeterProvider,
+        in_memory_reader: InMemoryMetricReader,
+        exporter: ObjectStoreMetricExporter,
+    ) -> None:
+        meter = provider.get_meter("test")
+        counter = meter.create_counter("fail.test")
+        counter.add(1)
+
+        metrics_data = in_memory_reader.get_metrics_data()
+        from opentelemetry.sdk.metrics.export import MetricExportResult
+
+        result = exporter.export(metrics_data)
+        assert result == MetricExportResult.SUCCESS
+
+
+class TestExporterTemporality:
+    """Verify delta temporality preference."""
+
+    def test_preferred_temporality_is_delta_for_sum(self) -> None:
+        from opentelemetry.sdk.metrics.export import Sum
+
+        e = ObjectStoreMetricExporter()
+        assert e._preferred_temporality.get(Sum) == AggregationTemporality.DELTA


### PR DESCRIPTION
## Summary

- Adds a second `MetricReader` on the `MeterProvider` that writes all OTel metric data points (including the 5 Temporal interceptor metrics) as NDJSON.gz to ObjectStore
- Enables Temporal business metrics to be durably stored in customer infra without Prometheus/Pushgateway/VictoriaMetrics
- Existing Prometheus path is completely unchanged

## What Changes

| File | Change |
|------|--------|
| `_objectstore_metric_exporter.py` | **New.** Custom `MetricExporter` — serializes `MetricsData` to NDJSON.gz, uploads to deployment + upstream stores. Delta temporality. Best-effort (swallows upload errors). |
| `_objectstore_metric_reader.py` | **New.** Factory wrapping exporter in `PeriodicExportingMetricReader` (60s interval). |
| `metrics_adaptor.py` | Register the second reader when `ENABLE_OBSERVABILITY_STORE_SINK` is true. |
| `test_objectstore_metric_exporter.py` | 8 unit tests: serialization, export, error handling, temporality. |

## Not Covered

- Temporal Rust-core metrics (`:9464`) bypass OTel — not captured by this change
- Downstream ingestion (upstream bucket → VictoriaMetrics) — separate service
- Retention/cleanup of `prometheus-metrics/` prefix — TBD

## Test plan

- [x] 8 unit tests pass (`test_objectstore_metric_exporter.py`)
- [x] Existing Prometheus enrichment tests pass (no regression)
- [x] Pre-commit (ruff, pyright, isort) all pass
- [ ] Manual verification on a tenant with ObjectStore enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)