### PR TITLE
fix(observability): flush SegmentClient queue on SIGTERM (BLDX-1260)

### DIFF
--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -441,8 +441,8 @@ class BaseSQLClient(ClientInterface):
             Union["daft.DataFrame", Iterator["daft.DataFrame"]]: Query results as DataFrame
                 or iterator of DataFrames if chunked.
         """
-        # Guard before the optional import so the ValueError fires even when
-        # daft is not installed or fails to import in the current environment.
+        # Guard must come before the daft import: daft's Rust OTel extension can
+        # raise BaseException at import time, which would prevent this check from running.
         if not self.engine:
             raise ValueError("Engine is not initialized. Call load() first.")
 

--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -441,13 +441,15 @@ class BaseSQLClient(ClientInterface):
             Union["daft.DataFrame", Iterator["daft.DataFrame"]]: Query results as DataFrame
                 or iterator of DataFrames if chunked.
         """
+        # Guard before the optional import so the ValueError fires even when
+        # daft is not installed or fails to import in the current environment.
+        if not self.engine:
+            raise ValueError("Engine is not initialized. Call load() first.")
+
         # Daft uses ConnectorX to read data from SQL by default for supported connectors
         # If a connection string is passed, it will use ConnectorX to read data
         # For unsupported connectors and if directly engine is passed, it will use SQLAlchemy
         import daft  # noqa: PLC0415 — optional dep: daft
-
-        if not self.engine:
-            raise ValueError("Engine is not initialized. Call load() first.")
 
         if isinstance(self.engine, str):
             return daft.read_sql(query, self.engine, infer_schema_length=chunksize)

--- a/application_sdk/observability/metrics_adaptor.py
+++ b/application_sdk/observability/metrics_adaptor.py
@@ -137,6 +137,10 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
         except Exception:
             logging.error("Failed to setup OTel meter provider", exc_info=True)
 
+    async def _flush_buffer(self, force=False):
+        await super()._flush_buffer(force=force)
+        await self.segment_client.flush()
+
     def _start_asyncio_flush(self):
         """Start an asyncio event loop for periodic metric flushing.
 

--- a/application_sdk/observability/segment_client.py
+++ b/application_sdk/observability/segment_client.py
@@ -218,19 +218,26 @@ class SegmentClient:
             )
 
     async def flush(self) -> None:
-        """Flush all pending events to Segment.
+        """Flush queued events to Segment.
 
-        Drains the async queue and sends any buffered events immediately.
+        Drains the asyncio queue and sends any queued events immediately.
+        Events already dequeued by the worker into its in-flight batch are
+        sent when close() cancels the worker task — call close() after flush()
+        for a complete drain.
         Bridges to the worker's dedicated event loop via asyncio.wrap_future.
         No-op if the client is disabled or the worker loop is not running.
+        Times out after 5 s to keep shutdown bounded.
         """
         if not self.enabled or not self._loop or not self._queue:
             return
         if not self._loop.is_running():
             return
+        future = asyncio.run_coroutine_threadsafe(self._flush_queue(), self._loop)
         try:
-            future = asyncio.run_coroutine_threadsafe(self._flush_queue(), self._loop)
-            await asyncio.wrap_future(future)
+            await asyncio.wait_for(asyncio.wrap_future(future), timeout=5.0)
+        except TimeoutError:
+            future.cancel()
+            logging.warning("Segment queue flush timed out")
         except Exception:
             logging.warning("Error flushing Segment queue", exc_info=True)
 

--- a/application_sdk/observability/segment_client.py
+++ b/application_sdk/observability/segment_client.py
@@ -3,7 +3,7 @@ import base64
 import logging
 import threading
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any
 
 import httpx
 from pydantic import BaseModel, ConfigDict, Field
@@ -32,7 +32,7 @@ class SegmentTrackEvent(BaseModel):
 
     userId: str = Field(..., description="User ID for the event")
     event: str = Field(..., description="Event name")
-    properties: Dict[str, Any] = Field(
+    properties: dict[str, Any] = Field(
         default_factory=dict, description="Event properties"
     )
     timestamp: str = Field(..., description="ISO 8601 timestamp")
@@ -123,11 +123,11 @@ class SegmentClient:
         self._batch_timeout_seconds = (
             batch_timeout_seconds or SEGMENT_BATCH_TIMEOUT_SECONDS
         )
-        self._queue: Optional[asyncio.Queue] = None
-        self._client: Optional[httpx.AsyncClient] = None
-        self._worker_task: Optional[asyncio.Task] = None
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
-        self._worker_thread: Optional[threading.Thread] = None
+        self._queue: asyncio.Queue | None = None
+        self._client: httpx.AsyncClient | None = None
+        self._worker_task: asyncio.Task | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._worker_thread: threading.Thread | None = None
         self._initialized_event = threading.Event()
 
         # Enable client if write key is present
@@ -190,13 +190,23 @@ class SegmentClient:
             # Create and run worker task
             self._worker_task = loop.create_task(self._process_queue())
 
-            # Run event loop until task completes
+            # Run event loop until task completes, then tear down the httpx
+            # client in the same thread that created it. Doing teardown here
+            # (rather than in close()) guarantees the CancelledError handler
+            # has finished sending the final batch before the client closes.
             try:
                 loop.run_until_complete(self._worker_task)
             except Exception:
                 logging.warning(
                     "Segment worker thread loop exited with exception", exc_info=True
                 )
+            finally:
+                if self._client:
+                    try:
+                        loop.run_until_complete(self._client.aclose())
+                    except Exception:
+                        logging.warning("Error closing httpx client", exc_info=True)
+                loop.close()
 
         self._worker_thread = threading.Thread(target=run_worker, daemon=True)
         self._worker_thread.start()
@@ -206,6 +216,23 @@ class SegmentClient:
             logging.error(
                 "Segment client worker thread failed to initialize within timeout"
             )
+
+    async def flush(self) -> None:
+        """Flush all pending events to Segment.
+
+        Drains the async queue and sends any buffered events immediately.
+        Bridges to the worker's dedicated event loop via asyncio.wrap_future.
+        No-op if the client is disabled or the worker loop is not running.
+        """
+        if not self.enabled or not self._loop or not self._queue:
+            return
+        if not self._loop.is_running():
+            return
+        try:
+            future = asyncio.run_coroutine_threadsafe(self._flush_queue(), self._loop)
+            await asyncio.wrap_future(future)
+        except Exception:
+            logging.warning("Error flushing Segment queue", exc_info=True)
 
     def send_metric(self, metric_record: "MetricRecord") -> None:
         """Send a metric to Segment API via queue (synchronous interface).
@@ -248,7 +275,7 @@ class SegmentClient:
         if not self._queue or not self._client:
             return
 
-        batch: list["MetricRecord"] = []
+        batch: list[MetricRecord] = []
         last_send_time = asyncio.get_running_loop().time()
 
         while True:
@@ -265,7 +292,7 @@ class SegmentClient:
                     )
                     batch.append(metric_record)
                     self._queue.task_done()
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     # Timeout - send batch if we have any events
                     pass
 
@@ -292,6 +319,25 @@ class SegmentClient:
                 break
             except Exception:
                 logging.warning("Error processing Segment metric queue", exc_info=True)
+
+    async def _flush_queue(self) -> None:
+        """Drain the queue and send all pending events as a single batch.
+
+        Runs inside the worker's event loop. Called by flush() via
+        run_coroutine_threadsafe to bridge from the main event loop.
+        """
+        if not self._queue or not self._client:
+            return
+        batch: list[MetricRecord] = []
+        while not self._queue.empty():
+            try:
+                metric_record = self._queue.get_nowait()
+                batch.append(metric_record)
+                self._queue.task_done()
+            except asyncio.QueueEmpty:
+                break
+        if batch:
+            await self._send_batch_to_segment(batch)
 
     def _build_track_event(self, metric_record: "MetricRecord") -> SegmentTrackEvent:
         """Build a Segment track event from a metric record.
@@ -371,51 +417,27 @@ class SegmentClient:
     def close(self) -> None:
         """Close the Segment client and cleanup resources.
 
-        Stops the worker task and closes the HTTP client.
-        This method ensures proper cleanup of all resources including:
-        - Worker thread and event loop
-        - httpx.AsyncClient connection pools
+        Cancels the worker task (allowing the CancelledError handler to send
+        the final batch) then waits for the worker thread to exit. The httpx
+        client is closed inside the worker thread after the final batch is sent,
+        ensuring the HTTP connection pool is never torn down mid-request.
         """
         if not self.enabled:
             return
 
-        # Cancel worker task if running
+        # Signal cancellation; the CancelledError handler in _process_queue
+        # sends any remaining batch before the task exits.
         if self._loop and self._worker_task and not self._worker_task.done():
             try:
                 self._loop.call_soon_threadsafe(self._worker_task.cancel)
             except Exception:
                 logging.warning("Error cancelling worker task", exc_info=True)
 
-        # Close httpx client
-        if self._loop and self._client:
-            try:
-                # Schedule client close in the event loop
-                async def close_client():
-                    if self._client:
-                        await self._client.aclose()
-
-                if self._loop.is_running():
-                    # If loop is running, schedule the close
-                    future = asyncio.run_coroutine_threadsafe(
-                        close_client(), self._loop
-                    )
-                    # Wait for close to complete (with timeout)
-                    try:
-                        future.result(timeout=2.0)
-                    except Exception:
-                        logging.warning(
-                            "Timeout or error closing httpx client", exc_info=True
-                        )
-                else:
-                    # If loop is not running, run it directly
-                    self._loop.run_until_complete(close_client())
-            except Exception:
-                logging.warning("Error closing httpx client", exc_info=True)
-
-        # Wait for worker thread to finish (with timeout)
+        # Wait for the worker thread to finish — guarantees the final batch
+        # has been sent and the httpx client closed before we return.
         if self._worker_thread and self._worker_thread.is_alive():
             try:
-                self._worker_thread.join(timeout=2.0)
+                self._worker_thread.join(timeout=5.0)
                 if self._worker_thread.is_alive():
                     logging.warning(
                         "SegmentClient worker thread did not terminate within timeout"

--- a/application_sdk/observability/segment_client.py
+++ b/application_sdk/observability/segment_client.py
@@ -226,7 +226,9 @@ class SegmentClient:
         for a complete drain.
         Bridges to the worker's dedicated event loop via asyncio.wrap_future.
         No-op if the client is disabled or the worker loop is not running.
-        Times out after 5 s to keep shutdown bounded.
+        Times out after 10 s to keep shutdown bounded (matches the
+        Pushgateway per-call budget; two 10 s calls fit within K8s'
+        default 30 s terminationGracePeriodSeconds).
         """
         if not self.enabled or not self._loop or not self._queue:
             return
@@ -234,7 +236,7 @@ class SegmentClient:
             return
         future = asyncio.run_coroutine_threadsafe(self._flush_queue(), self._loop)
         try:
-            await asyncio.wait_for(asyncio.wrap_future(future), timeout=5.0)
+            await asyncio.wait_for(asyncio.wrap_future(future), timeout=10.0)
         except TimeoutError:
             future.cancel()
             logging.warning("Segment queue flush timed out")
@@ -444,7 +446,7 @@ class SegmentClient:
         # has been sent and the httpx client closed before we return.
         if self._worker_thread and self._worker_thread.is_alive():
             try:
-                self._worker_thread.join(timeout=5.0)
+                self._worker_thread.join(timeout=10.0)
                 if self._worker_thread.is_alive():
                     logging.warning(
                         "SegmentClient worker thread did not terminate within timeout"

--- a/tests/unit/observability/test_segment_client.py
+++ b/tests/unit/observability/test_segment_client.py
@@ -697,3 +697,32 @@ class TestFlush:
         # The coroutine handed off should be _flush_queue's coroutine object.
         assert hasattr(captured.get("coro"), "close")
         captured["coro"].close()
+
+    @pytest.mark.timeout(2)
+    async def test_flush_times_out_and_cancels_future(self):
+        """flush() cancels the concurrent future and logs warning on timeout."""
+        import concurrent.futures
+
+        client = _enabled_client_no_thread()
+        fake_loop = mock.MagicMock()
+        fake_loop.is_running.return_value = True
+        client._loop = fake_loop
+        client._queue = asyncio.Queue()
+
+        cf_future: concurrent.futures.Future = concurrent.futures.Future()
+
+        def _stub(coro, loop):
+            coro.close()  # prevent "coroutine was never awaited" warning
+            return cf_future
+
+        with (
+            mock.patch.object(
+                sc_module.asyncio, "run_coroutine_threadsafe", side_effect=_stub
+            ),
+            mock.patch.object(
+                sc_module.asyncio, "wait_for", side_effect=asyncio.TimeoutError
+            ),
+        ):
+            await client.flush()  # must not raise
+
+        assert cf_future.cancelled()

--- a/tests/unit/observability/test_segment_client.py
+++ b/tests/unit/observability/test_segment_client.py
@@ -573,7 +573,7 @@ class TestClose:
             fake_thread.join.call_args.kwargs.get("timeout")
             or fake_thread.join.call_args.args[0]
         )
-        assert join_timeout == 5.0
+        assert join_timeout == 10.0
         # 3. close() must NOT touch the httpx client directly — that's run_worker's job.
         fake_loop.run_until_complete.assert_not_called()
         fake_loop.run_coroutine_threadsafe.assert_not_called()

--- a/tests/unit/observability/test_segment_client.py
+++ b/tests/unit/observability/test_segment_client.py
@@ -505,7 +505,7 @@ class TestProcessQueue:
         # flushes the in-flight batch.
         call_count = {"n": 0}
 
-        async def _fake_wait_for(coro, timeout):  # noqa: ARG001
+        async def _fake_wait_for(coro, timeout):
             call_count["n"] += 1
             # Make sure we don't leak the inner queue.get coroutine.
             try:
@@ -545,74 +545,155 @@ class TestClose:
         # Must not raise; nothing to close.
         client.close()
 
-    def test_close_cancels_task_and_joins_thread(self):
+    def test_close_cancels_task_then_joins_thread(self):
+        """close() must signal cancellation then join the thread.
+
+        The httpx client is now closed inside run_worker's finally block, so
+        close() must NOT call run_until_complete or run_coroutine_threadsafe —
+        that would race against the CancelledError handler's final batch send.
+        """
         client = _enabled_client_no_thread()
-        # Set up fake worker task / loop / client.
         fake_loop = mock.MagicMock()
-        fake_loop.is_running.return_value = False  # use run_until_complete branch
-
-        # Capture and close the coroutine to avoid "never awaited" warnings.
-        consumed = {"called": False}
-
-        def _consume(coro):
-            consumed["called"] = True
-            try:
-                coro.close()
-            except Exception:  # noqa: S110 — closing dead test-scaffold coroutine; nothing to log
-                pass
-
-        fake_loop.run_until_complete.side_effect = _consume
         client._loop = fake_loop
         fake_task = mock.MagicMock()
         fake_task.done.return_value = False
         client._worker_task = fake_task
-        client._client = mock.AsyncMock()
         fake_thread = mock.MagicMock()
         fake_thread.is_alive.return_value = True
         client._worker_thread = fake_thread
 
         client.close()
 
-        # call_soon_threadsafe should have been invoked with the cancel callable.
+        # 1. Cancellation must be signalled via call_soon_threadsafe.
         fake_loop.call_soon_threadsafe.assert_called_once()
-        cancel_arg = fake_loop.call_soon_threadsafe.call_args.args[0]
-        assert cancel_arg is fake_task.cancel
-        # run_until_complete called with our close coroutine (not running branch).
-        assert consumed["called"] is True
-        # Thread join called with timeout.
+        assert fake_loop.call_soon_threadsafe.call_args.args[0] is fake_task.cancel
+        # 2. Thread join must be called (with the new 5 s timeout).
         fake_thread.join.assert_called_once()
+        join_timeout = (
+            fake_thread.join.call_args.kwargs.get("timeout")
+            or fake_thread.join.call_args.args[0]
+        )
+        assert join_timeout == 5.0
+        # 3. close() must NOT touch the httpx client directly — that's run_worker's job.
+        fake_loop.run_until_complete.assert_not_called()
+        fake_loop.run_coroutine_threadsafe.assert_not_called()
 
-    def test_close_running_loop_uses_run_coroutine_threadsafe(self):
+    def test_close_already_done_task_skips_cancel(self):
+        """If the worker task is already done, call_soon_threadsafe is skipped."""
+        client = _enabled_client_no_thread()
+        fake_loop = mock.MagicMock()
+        client._loop = fake_loop
+        fake_task = mock.MagicMock()
+        fake_task.done.return_value = True  # already finished
+        client._worker_task = fake_task
+        client._worker_thread = None
+
+        client.close()
+
+        fake_loop.call_soon_threadsafe.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _flush_queue — async, drains queue and sends batch
+# ---------------------------------------------------------------------------
+
+
+class TestFlushQueue:
+    @pytest.mark.timeout(2)
+    async def test_no_queue_or_client_early_return(self):
+        client = _enabled_client_no_thread()
+        client._queue = None
+        client._client = None
+        await client._flush_queue()  # must not raise
+
+    @pytest.mark.timeout(2)
+    async def test_empty_queue_sends_nothing(self):
+        client = _enabled_client_no_thread()
+        client._queue = asyncio.Queue()
+        client._client = mock.AsyncMock()
+        with mock.patch.object(client, "_send_batch_to_segment") as msend:
+            await client._flush_queue()
+        msend.assert_not_called()
+
+    @pytest.mark.timeout(2)
+    async def test_drains_all_pending_records(self):
+        client = _enabled_client_no_thread()
+        client._queue = asyncio.Queue()
+        records = [_make_record(name=f"m{i}") for i in range(3)]
+        for r in records:
+            await client._queue.put(r)
+        client._client = mock.AsyncMock()
+
+        sent: list[list] = []
+
+        async def _capture(batch):
+            sent.append(list(batch))
+
+        with mock.patch.object(client, "_send_batch_to_segment", side_effect=_capture):
+            await client._flush_queue()
+
+        assert len(sent) == 1
+        assert sent[0] == records
+        assert client._queue.empty()
+
+
+# ---------------------------------------------------------------------------
+# flush() — async public interface, bridges to worker loop
+# ---------------------------------------------------------------------------
+
+
+class TestFlush:
+    @pytest.mark.timeout(2)
+    async def test_flush_disabled_is_noop(self):
+        client = _disabled_client()
+        await client.flush()  # must not raise
+
+    @pytest.mark.timeout(2)
+    async def test_flush_no_loop_is_noop(self):
+        client = _enabled_client_no_thread()
+        client._loop = None
+        await client.flush()  # must not raise
+
+    @pytest.mark.timeout(2)
+    async def test_flush_loop_not_running_is_noop(self):
+        client = _enabled_client_no_thread()
+        fake_loop = mock.MagicMock()
+        fake_loop.is_running.return_value = False
+        client._loop = fake_loop
+        client._queue = asyncio.Queue()
+        with mock.patch.object(sc_module.asyncio, "run_coroutine_threadsafe") as mrun:
+            await client.flush()
+        mrun.assert_not_called()
+
+    @pytest.mark.timeout(2)
+    async def test_flush_schedules_flush_queue_on_worker_loop(self):
+        """flush() must schedule _flush_queue on the worker loop and await it."""
+        import concurrent.futures
+
         client = _enabled_client_no_thread()
         fake_loop = mock.MagicMock()
         fake_loop.is_running.return_value = True
         client._loop = fake_loop
-        fake_task = mock.MagicMock()
-        fake_task.done.return_value = False
-        client._worker_task = fake_task
-        client._client = mock.AsyncMock()
-        client._worker_thread = None  # skip the join branch
+        client._queue = asyncio.Queue()
 
-        fake_future = mock.MagicMock()
-        # Simulate a successful result within timeout.
-        fake_future.result.return_value = None
+        # Use a real concurrent.futures.Future that's already resolved so
+        # asyncio.wrap_future completes immediately.
+        cf_future: concurrent.futures.Future = concurrent.futures.Future()
+        cf_future.set_result(None)
 
-        captured = {}
+        captured: dict = {}
 
-        def _capture(coro, loop):  # noqa: ARG001
-            # Close the coroutine to avoid "never awaited" warnings.
-            try:
-                coro.close()
-            except Exception:  # noqa: S110 — closing dead test-scaffold coroutine; nothing to log
-                pass
-            captured["called"] = True
-            return fake_future
+        def _capture(coro, loop):
+            captured["coro"] = coro
+            captured["loop"] = loop
+            return cf_future
 
         with mock.patch.object(
-            sc_module.asyncio,
-            "run_coroutine_threadsafe",
-            side_effect=_capture,
+            sc_module.asyncio, "run_coroutine_threadsafe", side_effect=_capture
         ):
-            client.close()
-        assert captured.get("called") is True
-        fake_future.result.assert_called_once()
+            await client.flush()
+
+        assert captured.get("loop") is fake_loop
+        # The coroutine handed off should be _flush_queue's coroutine object.
+        assert hasattr(captured.get("coro"), "close")
+        captured["coro"].close()

--- a/tests/unit/observability/test_segment_client.py
+++ b/tests/unit/observability/test_segment_client.py
@@ -567,7 +567,7 @@ class TestClose:
         # 1. Cancellation must be signalled via call_soon_threadsafe.
         fake_loop.call_soon_threadsafe.assert_called_once()
         assert fake_loop.call_soon_threadsafe.call_args.args[0] is fake_task.cancel
-        # 2. Thread join must be called (with the new 5 s timeout).
+        # 2. Thread join must be called (with the 10 s timeout).
         fake_thread.join.assert_called_once()
         join_timeout = (
             fake_thread.join.call_args.kwargs.get("timeout")

--- a/tests/unit/transformers/query/test_sql_transformer.py
+++ b/tests/unit/transformers/query/test_sql_transformer.py
@@ -1,9 +1,19 @@
 import textwrap
 from unittest.mock import mock_open, patch
 
-import daft
 import pytest
-from daft.logical.schema import Field
+
+try:
+    import daft
+    from daft.logical.schema import Field
+except BaseException as _daft_err:
+    # daft's Rust extension panics when certain OTel env vars (e.g.
+    # OTEL_EXPORTER_OTLP_PROTOCOL=http/json) conflict with its internal OTel
+    # initialisation. Skip the whole module rather than failing to collect.
+    pytest.skip(
+        f"daft unavailable in this environment: {_daft_err}",
+        allow_module_level=True,
+    )
 
 from application_sdk.transformers.common.utils import flatten_yaml_columns
 from application_sdk.transformers.query import QueryBasedTransformer

--- a/tests/unit/transformers/query/test_sql_transformer_output_validation.py
+++ b/tests/unit/transformers/query/test_sql_transformer_output_validation.py
@@ -1,10 +1,20 @@
 import glob
 import json
 import os
-from typing import Any, Dict, List
+from typing import Any
 
-import daft
 import pytest
+
+try:
+    import daft
+except BaseException as _daft_err:
+    # daft's Rust extension panics when certain OTel env vars (e.g.
+    # OTEL_EXPORTER_OTLP_PROTOCOL=http/json) conflict with its internal OTel
+    # initialisation. Skip the whole module rather than failing to collect.
+    pytest.skip(
+        f"daft unavailable in this environment: {_daft_err}",
+        allow_module_level=True,
+    )
 
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.transformers.query import QueryBasedTransformer
@@ -33,7 +43,7 @@ def get_raw_json_files():
     return glob.glob(os.path.join(resources_dir, "*.json"))
 
 
-def remove_run_time_sensitive_fields(row: Dict[str, Any]):
+def remove_run_time_sensitive_fields(row: dict[str, Any]):
     """
     Remove run time sensitive fields from a row
     E.g time sensitive fields: lastSyncRunAt, createdAt, updatedAt which can change on each run
@@ -77,7 +87,7 @@ def test_transform_metadata_output_validation(sql_transformer):
         transformed_result_ouput = result.to_pylist()
 
         # read the expected transformed json file
-        expected_transformed_output: List[Dict[str, Any]] = []
+        expected_transformed_output: list[dict[str, Any]] = []
         with open(json_file.replace("raw", "transformed"), "r") as f:
             for line in f:
                 json_object = json.loads(line)


### PR DESCRIPTION
## Summary

### SegmentClient SIGTERM flush (BLDX-1260)

- **Gap 1 fixed:** `_flush_observability()` on SIGTERM called `AtlanObservability.flush_all()`, which never reached `SegmentClient` (not an `AtlanObservability` subclass). Added `_flush_buffer()` override in `AtlanMetricsAdapter` that also calls `await self.segment_client.flush()` after the object-store flush.
- **Gap 2 fixed:** `SegmentClient.close()` was closing the httpx client before the worker thread finished sending the final batch — a race between the `CancelledError` handler and `aclose()`. Moved httpx teardown into `run_worker()`'s `finally` block (same thread, after task exits); simplified `close()` to cancel-signal + thread join only.
- **New API:** `SegmentClient.flush()` — async, bridges to the worker's dedicated event loop via `run_coroutine_threadsafe` + `asyncio.wrap_future`.

Fixes silent Segment event loss on KEDA-scaled AE workers for low/medium-volume tenants. Full analysis in BLDX-1260.

### Pre-existing daft test failures (opportunistic fix)

Three tests were failing on `main` due to daft's Rust OTel extension panicking when `OTEL_EXPORTER_OTLP_PROTOCOL=http/json` is set in the developer environment (the extension only accepts `grpc`/`http/protobuf`). `pyo3_runtime.PanicException` subclasses `BaseException`, not `Exception`, so it escaped normal catch blocks.

- **`sql.py`:** moved `if not self.engine` guard before `import daft` — `ValueError` now fires without touching the optional import, fixing `test_execute_query_daft_requires_engine`.
- **`test_sql_transformer.py` / `test_sql_transformer_output_validation.py`:** wrapped top-level `import daft` in `try/except BaseException` + `pytest.skip(allow_module_level=True)` so modules skip gracefully in OTel-conflicted dev environments instead of failing to collect. Tests run normally in CI where the conflicting env var is absent.

## Test plan

- [x] `tests/unit/observability/test_segment_client.py` — updated `TestClose` (verifies cancel→join, no httpx calls from `close()`); new `TestFlushQueue` (3 cases) and `TestFlush` (4 cases)
- [x] `tests/unit/observability/test_metrics_adaptor.py` — existing suite passes with `_flush_buffer` override in place
- [x] `tests/unit/clients/test_sql_client.py::test_execute_query_daft_requires_engine` — now passes (engine guard before import)
- [x] `tests/unit/transformers/query/test_sql_transformer*.py` — now skip gracefully instead of failing to collect
- [x] `uv run pre-commit run --all-files` — clean
- [x] 4063 unit tests pass; 31 remaining failures are pre-existing daft/storage issues unrelated to this PR