### PR TITLE
fix(clients): migrate sql.py raises to typed AppError subclasses (BLDX-1261)

### DIFF
--- a/application_sdk/clients/_sql_errors.py
+++ b/application_sdk/clients/_sql_errors.py
@@ -1,0 +1,105 @@
+"""Typed SQL client error subclasses.
+
+Each subclass encodes the static defaults (message, evidence fields) plus a
+specific ``code`` that lands on the FailureDetails wire envelope. Raise sites
+override only what is genuinely dynamic. Follows the WorkerEvictedError
+precedent in application_sdk/errors/leaves.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from application_sdk.errors import (
+    AuthError,
+    InternalError,
+    InvalidInputError,
+    UnimplementedError,
+)
+
+
+@dataclass(kw_only=True)
+class DBConfigNotSetError(InternalError):
+    """SQL client subclass did not set DB_CONFIG before use."""
+
+    code: ClassVar[str] = "INTERNAL_DB_CONFIG_NOT_SET"
+    message: str = "DB_CONFIG is not configured for this SQL client."
+    component: str | None = "sql_client"
+    invariant: str | None = "db_config_must_be_set"
+
+
+@dataclass(kw_only=True)
+class EngineNotInitializedError(InternalError):
+    """run_query / _execute_query called before load() initialised the engine."""
+
+    code: ClassVar[str] = "INTERNAL_ENGINE_NOT_INITIALIZED"
+    message: str = "Engine is not initialized. Call load() first."
+    component: str | None = "sql_client"
+    invariant: str | None = "load_before_use"
+
+
+@dataclass(kw_only=True)
+class EngineWrongTypeError(InternalError):
+    """Engine is a connection string when an SQLAlchemy engine object is required."""
+
+    code: ClassVar[str] = "INTERNAL_ENGINE_WRONG_TYPE"
+    message: str = "Engine should be an SQLAlchemy engine object, got str"
+    component: str | None = "sql_client"
+    invariant: str | None = "async_read_requires_engine_object"
+
+
+@dataclass(kw_only=True)
+class PandasResultTypeError(InternalError):
+    """_execute_async_read_operation(query, None) returned a non-DataFrame."""
+
+    code: ClassVar[str] = "INTERNAL_SQL_PANDAS"
+    message: str = "Unable to get pandas dataframe from SQL query results"
+    component: str | None = "sql_client"
+    invariant: str | None = "get_results_returns_dataframe"
+
+
+@dataclass(kw_only=True)
+class SqlClientAuthFailedError(AuthError):
+    """SQLAlchemy engine creation / first-connect failed during load().
+
+    Raise sites typically pass only ``cause=exc`` — the upstream exception
+    detail flows to the FailureDetails ``cause_repr`` via the base ``cause``
+    field, so the message stays static.
+    """
+
+    code: ClassVar[str] = "AUTH_SQL_CLIENT_FAILED"
+    message: str = "SQL client authentication failed"
+    auth_method: str | None = "sql"
+    failure_reason: str | None = "engine_load_failed"
+
+
+@dataclass(kw_only=True)
+class MissingRequiredFieldError(InvalidInputError):
+    """Required credential / connection-string parameter not provided.
+
+    Raise sites supply ``field=`` and an explicit ``message=`` that names
+    the user-facing context (e.g. "for IAM user authentication"); the
+    subclass only fixes the wire ``code``.
+    """
+
+    code: ClassVar[str] = "INVALID_INPUT_MISSING_FIELD"
+
+
+@dataclass(kw_only=True)
+class InvalidAuthTypeError(InvalidInputError):
+    """credentials.authType not in {basic, iam_user, iam_role}."""
+
+    code: ClassVar[str] = "INVALID_INPUT_AUTH_TYPE"
+    field: str | None = "authType"
+    constraint: str | None = "one_of:basic,iam_user,iam_role"
+
+
+@dataclass(kw_only=True)
+class UnsupportedCursorError(UnimplementedError):
+    """DBAPI driver did not return a usable cursor for server-side cursor mode."""
+
+    code: ClassVar[str] = "UNIMPLEMENTED_CURSOR_TYPE"
+    message: str = "Cursor is not supported by this driver"
+    operation: str | None = "sql_cursor"
+    reason: str | None = "dbapi_cursor_unavailable"

--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -95,7 +95,8 @@ class BaseSQLClient(ClientInterface):
             credentials (Dict[str, Any]): Database connection credentials.
 
         Raises:
-            ClientError: If credentials are invalid or engine creation fails
+            DBConfigNotSetError: If DB_CONFIG is not set on the client subclass.
+            SqlClientAuthFailedError: If engine creation or initial connection fails.
         """
         if not self.DB_CONFIG:
             raise DBConfigNotSetError()
@@ -161,7 +162,7 @@ class BaseSQLClient(ClientInterface):
             str: A temporary authentication token for database access.
 
         Raises:
-            CommonError: If required credentials (username or database) are missing.
+            MissingRequiredFieldError: If username or database is not present in credentials.
         """
         extra = parse_credentials_extra(self.credentials)
         aws_access_key_id = self.credentials.get("username")
@@ -204,7 +205,7 @@ class BaseSQLClient(ClientInterface):
             str: A temporary authentication token for database access.
 
         Raises:
-            CommonError: If required credentials (aws_role_arn or database) are missing.
+            MissingRequiredFieldError: If aws_role_arn or database is not present in credentials.
         """
         extra = parse_credentials_extra(self.credentials)
         aws_role_arn = extra.get("aws_role_arn")
@@ -250,7 +251,7 @@ class BaseSQLClient(ClientInterface):
             str: URL-encoded authentication token.
 
         Raises:
-            CommonError: If an invalid authentication type is specified.
+            InvalidAuthTypeError: If authType is not one of basic, iam_user, or iam_role.
         """
         authType = self.credentials.get("authType", "basic")  # Default to basic auth
         token = None
@@ -302,7 +303,8 @@ class BaseSQLClient(ClientInterface):
             str: Complete SQLAlchemy connection string.
 
         Raises:
-            ValueError: If required connection parameters are missing.
+            DBConfigNotSetError: If DB_CONFIG is not set on the client subclass.
+            MissingRequiredFieldError: If a required connection parameter is absent from credentials.
         """
         if not self.DB_CONFIG:
             raise DBConfigNotSetError()
@@ -361,8 +363,7 @@ class BaseSQLClient(ClientInterface):
                 a dictionary mapping column names to values.
 
         Raises:
-            ValueError: If engine is not initialized.
-            Exception: If query execution fails.
+            EngineNotInitializedError: If load() has not been called before run_query().
         """
         if not self.engine:
             raise EngineNotInitializedError()
@@ -530,8 +531,7 @@ class BaseSQLClient(ClientInterface):
             AsyncIterator["pd.DataFrame"]: Async iterator yielding batches of query results.
 
         Raises:
-            ValueError: If engine is a string instead of SQLAlchemy engine.
-            Exception: If there's an error executing the query.
+            EngineWrongTypeError: If engine is a connection string rather than an AsyncEngine.
         """
         try:
             # We cast to Iterator because passing chunk_size guarantees an Iterator return
@@ -547,8 +547,8 @@ class BaseSQLClient(ClientInterface):
             pd.DataFrame: Query results as a DataFrame.
 
         Raises:
-            ValueError: If engine is a string instead of SQLAlchemy engine.
-            Exception: If there's an error executing the query.
+            EngineWrongTypeError: If engine is a connection string rather than an AsyncEngine.
+            PandasResultTypeError: If the query result is not a DataFrame when chunksize is None.
         """
         try:
             result = await self._execute_async_read_operation(query, None)
@@ -590,7 +590,8 @@ class AsyncBaseSQLClient(BaseSQLClient):
                 host, port, username, password, and other connection parameters.
 
         Raises:
-            ValueError: If credentials are invalid or engine creation fails.
+            DBConfigNotSetError: If DB_CONFIG is not set on the client subclass.
+            SqlClientAuthFailedError: If async engine creation or initial connection fails.
         """
         self.credentials = credentials
         if not self.DB_CONFIG:
@@ -650,8 +651,7 @@ class AsyncBaseSQLClient(BaseSQLClient):
                 a dictionary mapping column names to values.
 
         Raises:
-            ValueError: If engine is not initialized.
-            Exception: If query execution fails.
+            EngineNotInitializedError: If load() has not been called before run_query().
         """
         if not self.engine:
             raise EngineNotInitializedError()

--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -14,13 +14,22 @@ from typing import TYPE_CHECKING, Any, Union, cast
 from urllib.parse import quote_plus
 
 from application_sdk.clients._interface import ClientInterface
+from application_sdk.clients._sql_errors import (
+    DBConfigNotSetError,
+    EngineNotInitializedError,
+    EngineWrongTypeError,
+    InvalidAuthTypeError,
+    MissingRequiredFieldError,
+    PandasResultTypeError,
+    SqlClientAuthFailedError,
+    UnsupportedCursorError,
+)
 from application_sdk.clients.models import DatabaseConfig
 from application_sdk.clients.sql_typecasters import install_tolerant_text_decoder_hook
 from application_sdk.common.aws_utils import (
     generate_aws_rds_token_with_iam_role,
     generate_aws_rds_token_with_iam_user,
 )
-from application_sdk.common.error_codes import ClientError, CommonError
 from application_sdk.common.exc_utils import rewrap
 from application_sdk.constants import AWS_SESSION_NAME, USE_SERVER_SIDE_CURSOR
 from application_sdk.credentials.utils import parse_credentials_extra
@@ -89,7 +98,7 @@ class BaseSQLClient(ClientInterface):
             ClientError: If credentials are invalid or engine creation fails
         """
         if not self.DB_CONFIG:
-            raise ValueError("DB_CONFIG is not configured for this SQL client.")
+            raise DBConfigNotSetError()
 
         self.credentials = credentials  # Update the instance credentials
         try:
@@ -132,7 +141,7 @@ class BaseSQLClient(ClientInterface):
             if self.engine:
                 self.engine.dispose()
                 self.engine = None
-            raise ClientError(f"{ClientError.SQL_CLIENT_AUTH_ERROR}: {e!s}") from e
+            raise SqlClientAuthFailedError(cause=e) from e
 
     async def close(self) -> None:
         """Close the database connection."""
@@ -161,12 +170,14 @@ class BaseSQLClient(ClientInterface):
         user = extra.get("username")
         database = extra.get("database")
         if not user:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: username is required for IAM user authentication"
+            raise MissingRequiredFieldError(
+                message="username is required for IAM user authentication",
+                field="username",
             )
         if not database:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: database is required for IAM user authentication"
+            raise MissingRequiredFieldError(
+                message="database is required for IAM user authentication",
+                field="database",
             )
 
         port = self.credentials.get("port")
@@ -201,12 +212,14 @@ class BaseSQLClient(ClientInterface):
         external_id = extra.get("aws_external_id")
 
         if not aws_role_arn:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: aws_role_arn is required for IAM role authentication"
+            raise MissingRequiredFieldError(
+                message="aws_role_arn is required for IAM role authentication",
+                field="aws_role_arn",
             )
         if not database:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: database is required for IAM role authentication"
+            raise MissingRequiredFieldError(
+                message="database is required for IAM role authentication",
+                field="database",
             )
 
         session_name = AWS_SESSION_NAME
@@ -250,7 +263,7 @@ class BaseSQLClient(ClientInterface):
             case "basic":
                 token = self.credentials.get("password")
             case _:
-                raise CommonError(f"{CommonError.CREDENTIALS_PARSE_ERROR}: {authType}")
+                raise InvalidAuthTypeError(message=f"Unsupported authType: {authType}")
 
         # Handle None values and ensure token is a string before encoding
         encoded_token = quote_plus(str(token or ""))
@@ -292,7 +305,7 @@ class BaseSQLClient(ClientInterface):
             ValueError: If required connection parameters are missing.
         """
         if not self.DB_CONFIG:
-            raise ValueError("DB_CONFIG is not configured for this SQL client.")
+            raise DBConfigNotSetError()
 
         extra = parse_credentials_extra(self.credentials)
 
@@ -306,7 +319,10 @@ class BaseSQLClient(ClientInterface):
             else:
                 value = self.credentials.get(param) or extra.get(param)
                 if value is None:
-                    raise ValueError(f"{param} is required")
+                    raise MissingRequiredFieldError(
+                        message=f"{param} is required",
+                        field=param,
+                    )
                 param_values[param] = value
 
         # Fill in base template
@@ -349,7 +365,7 @@ class BaseSQLClient(ClientInterface):
             Exception: If query execution fails.
         """
         if not self.engine:
-            raise ValueError("Engine is not initialized. Call load() first.")
+            raise EngineNotInitializedError()
 
         loop = asyncio.get_running_loop()
         logger.debug(
@@ -370,7 +386,7 @@ class BaseSQLClient(ClientInterface):
                     pool, connection.execute, text(query)
                 )
                 if not cursor or not cursor.cursor:
-                    raise ValueError("Cursor is not supported")
+                    raise UnsupportedCursorError()
                 column_names: list[str] = [
                     description.name.lower()
                     for description in cursor.cursor.description
@@ -444,7 +460,7 @@ class BaseSQLClient(ClientInterface):
         # Guard must come before the daft import: daft's Rust OTel extension can
         # raise BaseException at import time, which would prevent this check from running.
         if not self.engine:
-            raise ValueError("Engine is not initialized. Call load() first.")
+            raise EngineNotInitializedError()
 
         # Daft uses ConnectorX to read data from SQL by default for supported connectors
         # If a connection string is passed, it will use ConnectorX to read data
@@ -465,7 +481,7 @@ class BaseSQLClient(ClientInterface):
                 or iterator of DataFrames if chunked.
         """
         if not self.engine:
-            raise ValueError("Engine is not initialized. Call load() first.")
+            raise EngineNotInitializedError()
 
         with self.engine.connect() as conn:
             return self._execute_pandas_query(conn, query, chunksize)
@@ -475,7 +491,7 @@ class BaseSQLClient(ClientInterface):
     ) -> Union["pd.DataFrame", Iterator["pd.DataFrame"]]:
         """Helper to execute async read operation with either async session or thread executor."""
         if isinstance(self.engine, str):
-            raise ValueError("Engine should be an SQLAlchemy engine object")
+            raise EngineWrongTypeError()
 
         from sqlalchemy.ext.asyncio import (  # noqa: PLC0415 — optional dep: sqlalchemy
             AsyncEngine,
@@ -540,7 +556,7 @@ class BaseSQLClient(ClientInterface):
 
             if isinstance(result, pd.DataFrame):
                 return result
-            raise Exception("Unable to get pandas dataframe from SQL query results")
+            raise PandasResultTypeError()
 
         except Exception as e:
             raise rewrap(e, "Error reading data(pandas) from SQL") from e
@@ -578,7 +594,7 @@ class AsyncBaseSQLClient(BaseSQLClient):
         """
         self.credentials = credentials
         if not self.DB_CONFIG:
-            raise ValueError("DB_CONFIG is not configured for this SQL client.")
+            raise DBConfigNotSetError()
 
         try:
             from sqlalchemy.ext.asyncio import (  # noqa: PLC0415 — optional dep: sqlalchemy
@@ -608,7 +624,7 @@ class AsyncBaseSQLClient(BaseSQLClient):
             if self.engine:
                 await self.engine.dispose()
                 self.engine = None
-            raise ClientError(f"{ClientError.SQL_CLIENT_AUTH_ERROR}: {e!s}") from e
+            raise SqlClientAuthFailedError(cause=e) from e
 
     async def close(self) -> None:
         """Close the async database connection and dispose of the engine."""
@@ -638,7 +654,7 @@ class AsyncBaseSQLClient(BaseSQLClient):
             Exception: If query execution fails.
         """
         if not self.engine:
-            raise ValueError("Engine is not initialized. Call load() first.")
+            raise EngineNotInitializedError()
 
         logger.debug(
             "Running query (sha=%s, len=%d)",

--- a/tests/unit/clients/test_clienterror_preservation.py
+++ b/tests/unit/clients/test_clienterror_preservation.py
@@ -23,13 +23,14 @@ from application_sdk.common.error_codes import ClientError
 
 
 class TestAsyncSqlLoadErrorContract:
-    """``AsyncBaseSQLClient.load()`` must raise ``ClientError`` on auth /
-    connection failure, mirroring sync ``BaseSQLClient.load()``. Before
+    """``AsyncBaseSQLClient.load()`` must raise ``SqlClientAuthFailedError`` on
+    auth / connection failure, mirroring sync ``BaseSQLClient.load()``. Before
     BLDX-1180 it raised generic ``ValueError(str(e))``.
     """
 
     @pytest.mark.asyncio
     async def test_async_load_failure_raises_client_error_not_value_error(self):
+        from application_sdk.clients._sql_errors import SqlClientAuthFailedError
         from application_sdk.clients.models import DatabaseConfig
         from application_sdk.clients.sql import AsyncBaseSQLClient
 
@@ -46,14 +47,16 @@ class TestAsyncSqlLoadErrorContract:
         # `create_async_engine` is imported inline inside `load()` (PLC0415
         # exception); patch at the source module so the inline import picks
         # up the mock.
-        with patch(
-            "sqlalchemy.ext.asyncio.create_async_engine",
-            side_effect=RuntimeError("boom"),
+        with (
+            patch(
+                "sqlalchemy.ext.asyncio.create_async_engine",
+                side_effect=RuntimeError("boom"),
+            ),
+            pytest.raises(SqlClientAuthFailedError) as exc_info,
         ):
-            with pytest.raises(ClientError) as exc_info:
-                await client.load({"username": "u", "password": "p"})
+            await client.load({"username": "u", "password": "p"})
 
-        assert str(ClientError.SQL_CLIENT_AUTH_ERROR) in str(exc_info.value)
+        assert "SQL client authentication failed" in str(exc_info.value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/clients/test_sql_client.py
+++ b/tests/unit/clients/test_sql_client.py
@@ -1,13 +1,21 @@
 import asyncio
-from typing import Any, Dict, List
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from hypothesis import HealthCheck, given, settings
 
+from application_sdk.clients._sql_errors import (
+    DBConfigNotSetError,
+    EngineNotInitializedError,
+    EngineWrongTypeError,
+    InvalidAuthTypeError,
+    MissingRequiredFieldError,
+    SqlClientAuthFailedError,
+    UnsupportedCursorError,
+)
 from application_sdk.clients.models import DatabaseConfig
-from application_sdk.clients.sql import BaseSQLClient
-from application_sdk.common.error_codes import CommonError
+from application_sdk.clients.sql import AsyncBaseSQLClient, BaseSQLClient
 from application_sdk.testing.hypothesis.strategies.clients.sql import (
     sql_credentials_strategy,
     sqlalchemy_connect_args_strategy,
@@ -118,8 +126,8 @@ async def test_load_uses_asyncio_to_thread_for_ping(
 @settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_load_property_based(
     sql_client: BaseSQLClient,
-    credentials: Dict[str, Any],
-    connect_args: Dict[str, Any],
+    credentials: dict[str, Any],
+    connect_args: dict[str, Any],
 ):
     """Property-based test for loading with various credentials and connection arguments"""
     with patch("sqlalchemy.create_engine") as mock_create_engine:
@@ -319,7 +327,7 @@ def test_connection_string_property_based(
 @pytest.mark.skip(reason="Failing due to KeyError: 'col1'")
 async def test_run_query_property_based(
     sql_client: BaseSQLClient,
-    query_result: Dict[str, Any],
+    query_result: dict[str, Any],
 ):
     """Property-based test for query execution with various result structures"""
     with (
@@ -349,12 +357,12 @@ async def test_run_query_property_based(
         )
 
         # Run run_query and collect all results
-        results: List[Dict[str, Any]] = []
+        results: list[dict[str, Any]] = []
         async for batch in sql_client.run_query(query):
             results.extend(batch)
 
         # Verify the results
-        expected_results: List[Dict[str, Any]] = []
+        expected_results: list[dict[str, Any]] = []
         for batch in query_result["batches"]:
             expected_results.extend(batch)
 
@@ -510,7 +518,7 @@ def test_get_sqlalchemy_connection_string_missing_required_param(
     }
     sql_client_with_db_config.credentials = credentials
 
-    with pytest.raises(ValueError, match="database is required"):
+    with pytest.raises(MissingRequiredFieldError, match="database is required"):
         sql_client_with_db_config.get_sqlalchemy_connection_string()
 
 
@@ -526,7 +534,7 @@ def test_get_sqlalchemy_connection_string_invalid_auth_type(sql_client_with_db_c
     }
     sql_client_with_db_config.credentials = credentials
 
-    with pytest.raises(CommonError, match="invalid_auth"):
+    with pytest.raises(InvalidAuthTypeError, match="invalid_auth"):
         sql_client_with_db_config.get_sqlalchemy_connection_string()
 
 
@@ -548,7 +556,8 @@ def test_get_sqlalchemy_connection_string_iam_user_missing_username(
     sql_client_with_db_config.credentials = credentials
 
     with pytest.raises(
-        CommonError, match="username is required for IAM user authentication"
+        MissingRequiredFieldError,
+        match="username is required for IAM user authentication",
     ):
         sql_client_with_db_config.get_sqlalchemy_connection_string()
 
@@ -571,7 +580,8 @@ def test_get_sqlalchemy_connection_string_iam_role_missing_role_arn(
     sql_client_with_db_config.credentials = credentials
 
     with pytest.raises(
-        CommonError, match="aws_role_arn is required for IAM role authentication"
+        MissingRequiredFieldError,
+        match="aws_role_arn is required for IAM role authentication",
     ):
         sql_client_with_db_config.get_sqlalchemy_connection_string()
 
@@ -636,8 +646,6 @@ def test_get_sqlalchemy_connection_string_omits_none_parameters(
 # symbols fails at unit-test time instead of at runtime in production.
 # -----------------------------------------------------------------------------
 
-from application_sdk.clients.sql import AsyncBaseSQLClient  # noqa: E402
-from application_sdk.common.error_codes import ClientError  # noqa: E402
 
 # ---------- BaseSQLClient.load — error / edge paths ----------
 
@@ -647,7 +655,7 @@ async def test_load_raises_when_db_config_missing():
     """load() must validate DB_CONFIG before attempting any sqlalchemy import."""
     client = BaseSQLClient()
     client.DB_CONFIG = None
-    with pytest.raises(ValueError, match="DB_CONFIG is not configured"):
+    with pytest.raises(DBConfigNotSetError, match="DB_CONFIG is not configured"):
         await client.load({"username": "u", "password": "p"})
 
 
@@ -656,7 +664,7 @@ async def test_load_raises_when_db_config_missing():
 async def test_load_wraps_engine_failure_as_client_error(
     mock_create_engine: Any, sql_client: BaseSQLClient
 ):
-    """A sqlalchemy create_engine failure must be wrapped as ClientError and
+    """A sqlalchemy create_engine failure must be wrapped as SqlClientAuthFailedError and
     the (partially constructed) engine disposed so connections do not leak."""
     mock_engine = MagicMock()
     mock_create_engine.return_value = mock_engine
@@ -664,7 +672,7 @@ async def test_load_wraps_engine_failure_as_client_error(
     # Force the connect-test inside asyncio.to_thread to fail
     actual_async_mock = AsyncMock(side_effect=RuntimeError("auth handshake failed"))
     with patch("application_sdk.clients.sql.asyncio.to_thread", actual_async_mock):
-        with pytest.raises(ClientError, match="auth handshake failed"):
+        with pytest.raises(SqlClientAuthFailedError):
             await sql_client.load({"username": "u", "password": "p"})
 
     # Engine must be disposed and reset to None so a retry can rebuild it.
@@ -727,7 +735,7 @@ def test_get_iam_user_token_happy_path(mock_gen: MagicMock, sql_client: BaseSQLC
 
 def test_get_iam_user_token_missing_database(sql_client: BaseSQLClient):
     sql_client.credentials = {"username": "k", "extra": {"username": "u"}}
-    with pytest.raises(CommonError, match="database is required"):
+    with pytest.raises(MissingRequiredFieldError, match="database is required"):
         sql_client.get_iam_user_token()
 
 
@@ -754,13 +762,13 @@ def test_get_iam_role_token_happy_path(mock_gen: MagicMock, sql_client: BaseSQLC
 
 def test_get_iam_role_token_missing_role_arn(sql_client: BaseSQLClient):
     sql_client.credentials = {"extra": {"database": "db1"}}
-    with pytest.raises(CommonError, match="aws_role_arn is required"):
+    with pytest.raises(MissingRequiredFieldError, match="aws_role_arn is required"):
         sql_client.get_iam_role_token()
 
 
 def test_get_iam_role_token_missing_database(sql_client: BaseSQLClient):
     sql_client.credentials = {"extra": {"aws_role_arn": "arn"}}
-    with pytest.raises(CommonError, match="database is required"):
+    with pytest.raises(MissingRequiredFieldError, match="database is required"):
         sql_client.get_iam_role_token()
 
 
@@ -770,7 +778,7 @@ def test_get_iam_role_token_missing_database(sql_client: BaseSQLClient):
 @pytest.mark.asyncio
 async def test_run_query_raises_when_engine_not_initialized(sql_client: BaseSQLClient):
     sql_client.engine = None
-    with pytest.raises(ValueError, match="Engine is not initialized"):
+    with pytest.raises(EngineNotInitializedError, match="Engine is not initialized"):
         async for _ in sql_client.run_query("SELECT 1"):
             pass
 
@@ -795,7 +803,7 @@ async def test_run_query_raises_when_cursor_unsupported(
     bad_result.cursor = None
     mock_loop.return_value.run_in_executor = AsyncMock(return_value=bad_result)
 
-    with pytest.raises(ValueError, match="Cursor is not supported"):
+    with pytest.raises(UnsupportedCursorError, match="Cursor is not supported"):
         async for _ in sql_client.run_query("SELECT 1"):
             pass
 
@@ -811,7 +819,7 @@ async def test_run_query_raises_when_cursor_unsupported(
 def test_get_sqlalchemy_connection_string_requires_db_config():
     client = BaseSQLClient()
     client.DB_CONFIG = None
-    with pytest.raises(ValueError, match="DB_CONFIG is not configured"):
+    with pytest.raises(DBConfigNotSetError, match="DB_CONFIG is not configured"):
         client.get_sqlalchemy_connection_string()
 
 
@@ -820,7 +828,7 @@ def test_get_sqlalchemy_connection_string_requires_db_config():
 
 def test_execute_query_daft_requires_engine(sql_client: BaseSQLClient):
     sql_client.engine = None
-    with pytest.raises(ValueError, match="Engine is not initialized"):
+    with pytest.raises(EngineNotInitializedError, match="Engine is not initialized"):
         sql_client._execute_query_daft("SELECT 1", chunksize=None)
 
 
@@ -856,7 +864,7 @@ def test_execute_query_daft_with_engine_object(sql_client: BaseSQLClient):
 
 def test_execute_query_requires_engine(sql_client: BaseSQLClient):
     sql_client.engine = None
-    with pytest.raises(ValueError, match="Engine is not initialized"):
+    with pytest.raises(EngineNotInitializedError, match="Engine is not initialized"):
         sql_client._execute_query("SELECT 1", chunksize=None)
 
 
@@ -942,7 +950,9 @@ async def test_execute_async_read_operation_rejects_string_engine(
     sql_client: BaseSQLClient,
 ):
     sql_client.engine = "postgresql://u:p@h/db"  # type: ignore[assignment]
-    with pytest.raises(ValueError, match="Engine should be an SQLAlchemy engine"):
+    with pytest.raises(
+        EngineWrongTypeError, match="Engine should be an SQLAlchemy engine"
+    ):
         await sql_client._execute_async_read_operation("SELECT 1", chunksize=None)
 
 
@@ -983,13 +993,15 @@ async def test_get_batched_results_wraps_errors_via_rewrap(sql_client: BaseSQLCl
     """Any failure in the read path must be re-raised through rewrap with the
     'Error reading batched data(pandas) from SQL' prefix."""
     sql_client.engine = MagicMock()
-    with patch.object(
-        sql_client,
-        "_execute_async_read_operation",
-        new=AsyncMock(side_effect=RuntimeError("boom")),
+    with (
+        patch.object(
+            sql_client,
+            "_execute_async_read_operation",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ),
+        pytest.raises(Exception, match="Error reading batched data"),
     ):
-        with pytest.raises(Exception, match="Error reading batched data"):
-            await sql_client.get_batched_results("SELECT 1")
+        await sql_client.get_batched_results("SELECT 1")
 
 
 @pytest.mark.asyncio
@@ -1074,7 +1086,7 @@ def async_sql_client_local():
 async def test_async_load_raises_when_db_config_missing():
     client = AsyncBaseSQLClient()
     client.DB_CONFIG = None
-    with pytest.raises(ValueError, match="DB_CONFIG is not configured"):
+    with pytest.raises(DBConfigNotSetError, match="DB_CONFIG is not configured"):
         await client.load({"username": "u", "password": "p"})
 
 
@@ -1083,7 +1095,7 @@ async def test_async_load_raises_when_db_config_missing():
 async def test_async_load_disposes_engine_on_failure(
     mock_create: MagicMock, async_sql_client_local: AsyncBaseSQLClient
 ):
-    """Async load() must dispose the engine and re-raise as ClientError
+    """Async load() must dispose the engine and re-raise as SqlClientAuthFailedError
     (consistent with sync load() — locked in by PR #1602 / BLDX-1180)."""
     mock_engine = AsyncMock()
     mock_engine.dispose = AsyncMock()
@@ -1098,9 +1110,8 @@ async def test_async_load_disposes_engine_on_failure(
     mock_engine.connect = MagicMock(return_value=_FailingCtx())
     mock_create.return_value = mock_engine
 
-    with pytest.raises(ClientError) as exc_info:
+    with pytest.raises(SqlClientAuthFailedError):
         await async_sql_client_local.load({"username": "u", "password": "p"})
-    assert str(ClientError.SQL_CLIENT_AUTH_ERROR) in str(exc_info.value)
 
     mock_engine.dispose.assert_awaited_once()
     assert async_sql_client_local.engine is None
@@ -1132,6 +1143,6 @@ async def test_async_run_query_requires_engine(
     async_sql_client_local: AsyncBaseSQLClient,
 ):
     async_sql_client_local.engine = None  # type: ignore[assignment]
-    with pytest.raises(ValueError, match="Engine is not initialized"):
+    with pytest.raises(EngineNotInitializedError, match="Engine is not initialized"):
         async for _ in async_sql_client_local.run_query("SELECT 1"):
             pass


### PR DESCRIPTION
## Summary

- Introduces `application_sdk/clients/_sql_errors.py` with 7 typed `AppError` leaf subclasses (`DBConfigNotSetError`, `SqlClientAuthFailedError`, `MissingRequiredFieldError`, `InvalidAuthTypeError`, `EngineNotInitializedError`, `EngineWrongTypeError`, `PandasResultTypeError`), each carrying a stable wire code and baked-in message + evidence field defaults
- Replaces 18 untyped `ValueError`/`Exception`/`ClientError`/`CommonError` raises in `sql.py` with the new typed subclasses, reducing raise sites to minimal form (`raise XError()`)
- Updates SQL client tests to assert the new typed subclasses instead of the old generic exceptions
- Updates `Raises:` docstrings in `sql.py` to match the actual subclasses now raised

## Test plan

- [ ] `uv run poe test tests/unit/clients/` passes
- [ ] Confirm `pytest.raises(DBConfigNotSetError)` etc. catch correctly at each annotated raise site
- [ ] Merge BLDX-1262 (skill changes) first; rebase this branch on `main` after, then regenerate capability manifest with `/capability-manifest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)