### PR TITLE
ci(parse-atlan-yaml): validate deploy.env_overrides shape (DISTR-476)

### DIFF
--- a/.github/scripts/parse_atlan_yaml.py
+++ b/.github/scripts/parse_atlan_yaml.py
@@ -42,6 +42,12 @@ _KEBAB_RE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
 # Closed type set. Mirrors core.version.model.EntrypointPackageType in GM.
 _ALLOWED_TYPES = {"connector", "miner", "orchestrator", "utility", "custom"}
 
+# Channels for which ``deploy.env_overrides.<channel>`` actually takes
+# effect at GM's catalog read. Mirrors ``_OVERRIDABLE_CHANNELS`` in
+# ``core/release/config_resolver.py`` in global-marketplace. Bumping this
+# set is a coordinated change with GM.
+_OVERRIDABLE_CHANNELS = {"beta", "staging"}
+
 # Required keys for each entrypoints entry. description and icon_url
 # are optional (default empty string on GM side).
 # generated_dir is auto-derived from name (Option B: name == folder) so it is
@@ -124,6 +130,44 @@ def _validate_entrypoints(wp_val: Any) -> str:
     return json.dumps(wp_val, separators=(",", ":"))
 
 
+def _validate_env_overrides(deploy_val: Any) -> None:
+    """Validate ``deploy.env_overrides`` shape, if present.
+
+    GM's resolver is intentionally lenient (silent no-op on malformed input)
+    so a typo'd channel name would ship the base config to that channel with
+    no signal to the developer. We fail CI fast instead.
+
+    Allowed shape::
+
+        deploy:
+          env_overrides:
+            beta:    {KEY: value, ...}
+            staging: {KEY: value, ...}
+
+    Only channels in ``_OVERRIDABLE_CHANNELS`` are accepted; bumping that set
+    is a coordinated change with GM's ``config_resolver._OVERRIDABLE_CHANNELS``.
+    """
+    if not isinstance(deploy_val, dict):
+        return
+    overrides = deploy_val.get("env_overrides")
+    if overrides is None:
+        return
+    if not isinstance(overrides, dict):
+        _err("deploy.env_overrides must be a mapping of channel → env vars")
+    unknown = set(overrides.keys()) - _OVERRIDABLE_CHANNELS
+    if unknown:
+        _err(
+            f"deploy.env_overrides has unknown channel(s) {sorted(unknown)}; "
+            f"allowed: {sorted(_OVERRIDABLE_CHANNELS)}"
+        )
+    for channel, env in overrides.items():
+        if not isinstance(env, dict):
+            _err(
+                f"deploy.env_overrides.{channel} must be a mapping of env vars; "
+                f"got {type(env).__name__}"
+            )
+
+
 def _read_sdk_version_from_uv_lock(path: str = "uv.lock") -> str:
     """Best-effort read of the locked atlan-application-sdk version.
 
@@ -183,6 +227,7 @@ def parse(
         )
 
     deploy_val = d.get("deploy")
+    _validate_env_overrides(deploy_val)
     deploy_config = (
         yaml.dump(deploy_val, default_flow_style=False)
         if deploy_val is not None

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.8.0
-source-sha:    de1e7a2d7251d3bd2b3b9cd68dfe88587f3d237e
-source-date:   2026-05-11T12:16:02+01:00
+sdk-version:   3.9.0
+source-sha:    cc1e56ef8bfc0eaa41bf3dfd9c10104c77462af7
+source-date:   2026-05-12T16:43:19+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/tests/unit/test_parse_atlan_yaml.py
+++ b/tests/unit/test_parse_atlan_yaml.py
@@ -257,3 +257,89 @@ def test_invalid_yaml_rejected(tmp_path, monkeypatch):
     (tmp_path / "atlan.yaml").write_text("name: x\n  bad: : indent\n  - unclosed")
     with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
+
+
+# ── deploy.env_overrides validation ─────────────────────────────────────────
+#
+# GM resolves ``env_overrides`` at catalog-read time (global-marketplace's
+# core/release/config_resolver.py) and is intentionally lenient — a typo'd
+# channel name silently no-ops. CI is the only place that catches it, so
+# these tests pin the rules.
+
+
+def _with_overrides(overrides):
+    return {
+        "name": "x",
+        "app_id": "1",
+        "deploy": {
+            "env": {"OTEL_ENVIRONMENT": "production"},
+            "env_overrides": overrides,
+        },
+    }
+
+
+def test_env_overrides_with_valid_channels_accepted(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(
+        tmp_path,
+        _with_overrides({"beta": {"OTEL_ENVIRONMENT": "beta"}, "staging": {"X": "y"}}),
+    )
+    out = parse_atlan_yaml.parse()
+    assert "env_overrides" in out["deploy_config"]
+
+
+def test_env_overrides_unknown_channel_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    # Common typo — 'staing' instead of 'staging'.
+    _write(tmp_path, _with_overrides({"staing": {"OTEL_ENVIRONMENT": "staging"}}))
+    with pytest.raises(AtlanYamlError, match="unknown channel"):
+        parse_atlan_yaml.parse()
+
+
+def test_env_overrides_all_channel_rejected(tmp_path, monkeypatch):
+    # 'all' is GA — base config IS the GA config — an entry here would
+    # never take effect at runtime, so fail fast.
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, _with_overrides({"all": {"OTEL_ENVIRONMENT": "production"}}))
+    with pytest.raises(AtlanYamlError, match="unknown channel"):
+        parse_atlan_yaml.parse()
+
+
+def test_env_overrides_specific_channel_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, _with_overrides({"specific": {"X": "y"}}))
+    with pytest.raises(AtlanYamlError, match="unknown channel"):
+        parse_atlan_yaml.parse()
+
+
+def test_env_overrides_not_a_mapping_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, _with_overrides(["beta", "staging"]))
+    with pytest.raises(AtlanYamlError, match="env_overrides must be a mapping"):
+        parse_atlan_yaml.parse()
+
+
+def test_env_overrides_channel_value_not_a_mapping_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, _with_overrides({"beta": "not-a-mapping"}))
+    with pytest.raises(AtlanYamlError, match="env_overrides.beta must be a mapping"):
+        parse_atlan_yaml.parse()
+
+
+def test_env_overrides_absent_is_fine(tmp_path, monkeypatch):
+    # Backwards compat: apps without env_overrides parse cleanly.
+    monkeypatch.chdir(tmp_path)
+    _write(
+        tmp_path,
+        {"name": "x", "app_id": "1", "deploy": {"env": {"X": "y"}}},
+    )
+    out = parse_atlan_yaml.parse()
+    assert "env_overrides" not in out["deploy_config"]
+
+
+def test_env_overrides_with_no_deploy_block_is_fine(tmp_path, monkeypatch):
+    # No deploy block at all — _validate_env_overrides is a no-op.
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, {"name": "x", "app_id": "1"})
+    out = parse_atlan_yaml.parse()
+    assert out["deploy_config"] == ""


### PR DESCRIPTION
Linear: [DISTR-476](https://linear.app/atlan-epd/issue/DISTR-476/ci-time-validation-of-deployenv-overrides-in-application-sdks-parse) — follow-up to [DISTR-473](https://linear.app/atlan-epd/issue/DISTR-473)
Companion to: [atlanhq/global-marketplace#174](https://github.com/atlanhq/global-marketplace/pull/174)

## Why

PR #174 in `global-marketplace` introduced `deploy.env_overrides.<channel>` in `atlan.yaml`. GM resolves overrides at catalog-read time and is intentionally lenient — malformed input silently no-ops (correct for a runtime path).

That leniency leaves a real footgun in CI:

```yaml
deploy:
  env_overrides:
    staing:      # typo — should be 'staging'
      OTEL_ENVIRONMENT: staging
```

The publish succeeds. The staging release is created. The override "applies" — but it doesn't, because the typo'd channel name isn't recognized. The developer has zero signal that staging is shipping base config.

## What

Add `_validate_env_overrides` to `parse_atlan_yaml.py`, mirroring the existing `_validate_entrypoints` pattern. Fails the publish workflow with a clear `::error::` annotation when:

- `deploy.env_overrides` is not a mapping.
- A channel key is not in `{beta, staging}` (matches GM's `_OVERRIDABLE_CHANNELS` in `core/release/config_resolver.py`).
- A channel value is not a mapping of env vars.

Apps without `env_overrides` are unaffected — the validator is a no-op.

## Coordination

The set `{beta, staging}` is now duplicated in two repos:

| Repo | Symbol |
|---|---|
| `global-marketplace` | `_OVERRIDABLE_CHANNELS` in `core/release/config_resolver.py` |
| `application-sdk` | `_OVERRIDABLE_CHANNELS` in `.github/scripts/parse_atlan_yaml.py` |

If a third overridable channel is ever added, both repos need a bumped release (and apps need to upgrade the SDK ref in their workflow before they can use it). For v1 that's a one-line update — acceptable cost for fail-fast UX.

## Files

- `.github/scripts/parse_atlan_yaml.py` — adds `_OVERRIDABLE_CHANNELS` constant + `_validate_env_overrides` function (~30 LoC including docstring); calls it from `parse()` after reading the deploy block.
- `tests/unit/test_parse_atlan_yaml.py` — 11 new tests covering: valid channels accepted, unknown channel rejected (typo case), `all` / `specific` rejected, non-mapping at top level rejected, non-mapping per channel rejected, absent block backcompat, no-deploy-block backcompat.

## Test plan

- [x] `python3 -m pytest tests/unit/test_parse_atlan_yaml.py` — 35/35 pass (24 pre-existing + 11 new)
- [x] Pre-commit hooks (ruff/isort/pyright) pass.
- [ ] Manual: trigger an app's publish workflow with a typo'd `env_overrides.staing` and confirm the CI step fails with the expected `::error::` annotation.