### PR TITLE
fix(ci): stop downstream jobs cascade-skipping when validate-channel skips

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -315,6 +315,11 @@ jobs:
   build:
     name: Build (${{ matrix.arch }})
     needs: prepare
+    # Explicit override needed: when publish=false, validate-channel is skipped
+    # via its `if:`. The default `success()` propagates that skip through the
+    # needs chain, so without this override `build` skips even though `prepare`
+    # successfully ran with its own override.
+    if: ${{ !failure() && !cancelled() && needs.prepare.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -364,6 +369,7 @@ jobs:
   merge:
     name: Merge & Push Manifest
     needs: [prepare, build]
+    if: ${{ !failure() && !cancelled() && needs.build.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -446,6 +452,7 @@ jobs:
   security-scan:
     name: Security Scan
     needs: [prepare, merge]
+    if: ${{ !failure() && !cancelled() && needs.merge.result == 'success' }}
     uses: atlanhq/application-sdk/.github/workflows/build-and-scan.yaml@main
     with:
       image: ${{ needs.prepare.outputs.ghcr_image }}
@@ -458,7 +465,7 @@ jobs:
   app-deployment-dispatcher:
     name: Dispatch App Deployment
     needs: [prepare, merge, security-scan]
-    if: github.ref == 'refs/heads/main' && needs.prepare.outputs.enable_sdr == 'true'
+    if: ${{ !failure() && !cancelled() && needs.merge.result == 'success' && needs.security-scan.result == 'success' && github.ref == 'refs/heads/main' && needs.prepare.outputs.enable_sdr == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Build-only runs of \`build-and-publish-app.yaml\` (workflow_dispatch with \`publish: false\`) produce **only** the Prepare job and skip everything downstream — including Build and Merge & Push Manifest — so users never get the image they wanted.

## Root cause

When \`publish: false\`:

| Job | \`if:\` | Result |
|---|---|---|
| \`validate-channel\` | \`if: inputs.publish\` | skipped (by design) |
| \`prepare\` | \`if: \${{ !failure() && !cancelled() }}\` | runs (override correctly bypasses skip propagation) |
| **\`build\`** | _(none — default \`success()\`)_ | **skipped** ❌ |
| \`merge\` | _(none)_ | skipped |
| \`security-scan\` | _(none)_ | skipped |
| \`app-deployment-dispatcher\` | branch+sdr check, no status fn | skipped (default \`success()\` still applies even with custom \`if\`) |
| \`publish\` | \`if: inputs.publish\` | skipped ✓ correct |

GitHub's default \`success()\` returns false when **any transitive ancestor** in the \`needs\` chain was skipped — even when a direct parent succeeded. \`prepare\` succeeds explicitly, but the skipped \`validate-channel\` upstream cascades through into \`build\`.

## Change

Add the same \`!failure() && !cancelled() && needs.X.result == 'success'\` guard that \`prepare\` already uses, to:

- \`build\` (gates on \`prepare\`)
- \`merge\` (gates on \`build\`)
- \`security-scan\` (gates on \`merge\`)
- \`app-deployment-dispatcher\` (combined with its existing branch+sdr check)

\`publish\` is unchanged — its existing \`if: inputs.publish\` correctly skips it in build-only mode.

## Repro

Any \`workflow_dispatch\` run of an app's \`build-and-publish.yaml\` with the publish checkbox unchecked. Examples:

- https://github.com/atlanhq/atlan-oracle-app/actions/runs/25784613341 (every job after Prepare skipped)
- https://github.com/atlanhq/atlan-dynamodb-app/actions/runs/25663743015 (same symptom)

This affects **every** app repo that calls this reusable workflow.

## Test plan

- [ ] Merge, then re-run [atlan-oracle-app build with publish=false](https://github.com/atlanhq/atlan-oracle-app/actions/workflows/build-and-publish.yaml). Expect: \`validate-channel\` and \`publish\` skipped; \`prepare\` → \`build\` (both archs) → \`merge\` all run; image lands at \`ghcr.io/atlanhq/atlan-oracle-app:<branch>-<sha7>\`.
- [ ] Re-run any app's build with publish=true on \`main\`. Expect: all jobs run as before (no regression).
- [ ] Re-run any app's build with publish=true on a non-main branch. Expect: \`validate-channel\` fails the \`channel='all'\` invariant as today (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)