### PR TITLE
refactor(errors): replace untyped raises with typed AppError leaves (BLDX-1261)

### DIFF
--- a/.claude/skills/signal-over-noise/SKILL.md
+++ b/.claude/skills/signal-over-noise/SKILL.md
@@ -101,7 +101,7 @@ Pattern catalogue, severity criteria, fix templates, and linting rules are in:
 
 #### Step 1.2 — Pattern Detection
 
-Run all 10 grep searches in parallel against `TARGET_PATH` (`*.py` files only):
+Run all 13 grep searches in parallel against `TARGET_PATH` (`*.py` files only):
 
 | # | Pattern ID | Grep |
 |---|------------|------|
@@ -163,7 +163,7 @@ Pattern:  P12
 Current:
     raise ValueError("Engine is not initialized. Call load() first.")
 Prescribed:
-    InternalError(code="INTERNAL_ENGINE_NOT_INITIALIZED")
+    InternalError  (wire code: INTERNAL_ENGINE_NOT_INITIALIZED — ClassVar, not a constructor arg)
     audience=APP_OWNER  retryable=False
 Fix (FT-8):
     raise InternalError(
@@ -250,7 +250,7 @@ TODO comment format for swallow/logging findings:
 
 TODO comment format for untyped/legacy raise findings — include the prescribed leaf:
 ```python
-# TODO(signal-over-noise): [P12] convert to typed AppError. Suggested: InternalError(code="INTERNAL_ENGINE_NOT_INITIALIZED"). See references/typed-error-prescription.md#4
+# TODO(signal-over-noise): [P12] convert to typed AppError. Leaf: InternalError (wire code: INTERNAL_ENGINE_NOT_INITIALIZED). See references/typed-error-prescription.md#4
 # TODO(signal-over-noise): [P13] legacy AtlanError — migrate to DependencyUnavailableError. See references/typed-error-prescription.md#5
 ```
 

--- a/.claude/skills/signal-over-noise/SKILL.md
+++ b/.claude/skills/signal-over-noise/SKILL.md
@@ -95,8 +95,9 @@ Pattern catalogue, severity criteria, fix templates, and linting rules are in:
 #### Step 1.1 — Setup
 
 1. Read `.claude/skills/signal-over-noise/references/error-recovery-patterns.md` in full.
-2. Resolve `TARGET_PATH` from arguments (default: current directory). Confirm it exists.
-3. Set `SEVERITY_FILTER` from `--severity` (default: `all`).
+2. Read `.claude/skills/signal-over-noise/references/typed-error-prescription.md` in full.
+3. Resolve `TARGET_PATH` from arguments (default: current directory). Confirm it exists.
+4. Set `SEVERITY_FILTER` from `--severity` (default: `all`).
 
 #### Step 1.2 — Pattern Detection
 
@@ -115,8 +116,11 @@ Run all 10 grep searches in parallel against `TARGET_PATH` (`*.py` files only):
 | 9 | P9 | except block with only an assignment — collect hits for Step 1.3 |
 | 10 | P10 | `return_exceptions=True` |
 | 11 | P11 | `class\s+\w+.*logging\.Filter` or `def filter\(self` inside a Filter subclass |
+| 12 | P12 | `raise\s+(ValueError\|RuntimeError\|Exception\|TypeError\|NotImplementedError\|OSError\|KeyError\|LookupError)\b` |
+| 13 | P13 | `raise\s+(ClientError\|ApiError\|OrchestratorError\|WorkflowError\|IOError\|CommonError\|DocGenError\|ActivityError\|AtlanError)\b` |
 
-For P5, P7, P9, P11: raw grep over-matches. Collect `file:line` hits and read context in Step 1.3.
+For P5, P7, P9, P11, P12: raw grep over-matches. Collect `file:line` hits and read context in Step 1.3.
+P13 is mechanical — every hit is a finding (no context reading needed).
 
 Collect all hits as a flat list: `(file, line_number, pattern_id, raw_snippet)`.
 
@@ -128,27 +132,51 @@ Classify each finding:
 - **Severity:** CRITICAL, HIGH, MEDIUM, or LOW (from §Severity Classification in reference)
 - **Legitimacy:** `genuine-bug` or `acceptable` (from §Legitimacy in reference)
 - **Category:** `silent-swallow`, `missing-traceback`, `overly-broad-catch`,
-  `error-to-return-value`, `suppress-operational`, `optional-import`, `asyncio-unexamined`
+  `error-to-return-value`, `suppress-operational`, `optional-import`,
+  `asyncio-unexamined`, `untyped-raise`, `legacy-raise`
+- **Typed-error prescription:** for every `genuine-bug` finding whose fix involves
+  a `raise` (FT-1b, FT-3b, FT-5b, FT-8, FT-9), look up the prescribed leaf and
+  code from `references/typed-error-prescription.md`. Record as `Prescribed:` on
+  the remediation entry so the user sees the target class in the plan.
 
 Apply `SEVERITY_FILTER`: discard findings below the threshold before proceeding.
 
+P12 classification notes:
+- Inside `__post_init__` / stdlib dataclass validators: check for a comment
+  explaining the stdlib-interop need. If present → `acceptable`. If absent →
+  flag as `genuine-bug` (MEDIUM — add the comment).
+- Inside an `@task`-decorated activity body → escalate to CRITICAL.
+
+P13: all hits are `genuine-bug` (HIGH). Use the §5 migration table from
+`typed-error-prescription.md` for the `Prescribed:` field.
+
 #### Step 1.4 — Build Remediation Plan
 
-For each `genuine-bug` finding, produce a remediation entry:
+For each `genuine-bug` finding, produce a remediation entry. Include `Prescribed:`
+whenever the fix involves raising an exception:
 
 ```
-File:     src/foo/bar.py:42
+File:     application_sdk/clients/sql.py:142
 Severity: HIGH
-Category: missing-traceback
+Category: untyped-raise
+Pattern:  P12
 Current:
-    except ValueError as e:
-        logger.warning(f"Parse failed: {e}")
-Fix (FT-2):
-    except ValueError:
-        logger.warning("Parse failed", exc_info=True)
-Auto-fixable: yes
+    raise ValueError("Engine is not initialized. Call load() first.")
+Prescribed:
+    InternalError(code="INTERNAL_ENGINE_NOT_INITIALIZED")
+    audience=APP_OWNER  retryable=False
+Fix (FT-8):
+    raise InternalError(
+        message="Engine is not initialized. Call load() first.",
+        component="sql_client",
+        invariant="load_before_use",
+    )
+Auto-fixable: no  (leaf choice needs context — manual review)
 Priority: P1
 ```
+
+For existing-pattern (P1–P11) findings whose fix re-raises, also include
+`Prescribed:` with the leaf selected from `typed-error-prescription.md` §4.
 
 Priority mapping:
 - **P0** — CRITICAL: fix immediately, block merges
@@ -200,19 +228,30 @@ Call `ExitPlanMode` to request user approval. Wait for approval before proceedin
 Apply the remediation plan that was approved. Only fix what was listed in the approved plan.
 
 #### Auto-fixable patterns — apply directly:
-- **FT-1:** Add logging to silent-swallow (`except X: pass` → add `logger.warning`)
+- **FT-1a:** Add logging to silent-swallow (log-and-continue, best-effort paths)
 - **FT-2:** Add `exc_info=True` to existing log call in except block
-- **FT-3:** Add logging before error-to-return-value (`except X: return Y`)
+- **FT-3a:** Add logging before error-to-return-value (when caller treats default as valid)
 - **FT-4:** Add exception inspection after `asyncio.gather(..., return_exceptions=True)`
-- **FT-5:** Replace broad `contextlib.suppress(Exception)` with logged try/except
+- **FT-5a:** Replace broad `contextlib.suppress(Exception)` with logged try/except (best-effort)
 
 #### Manual review required — leave TODO comments:
+- **FT-1b** (log + typed re-raise): leaf choice is contextual
+- **FT-3b** (convert swallow to typed raise): default for error-to-return-value when caller trusts result
+- **FT-5b** (typed re-raise for non-best-effort suppress): leaf choice is contextual
 - **FT-6** (narrow broad catch): `# TODO(signal-over-noise): [P4] narrow this catch`
 - **FT-7** (Filter exception safety): `# TODO(signal-over-noise): [P11] wrap filter body in try/except`
+- **FT-8** (convert untyped builtin raise to typed `AppError`): leaf from `typed-error-prescription.md` §4
+- **FT-9** (convert legacy `AtlanError` raise to typed `AppError`): leaf from `typed-error-prescription.md` §5
 
-TODO comment format:
+TODO comment format for swallow/logging findings:
 ```python
 # TODO(signal-over-noise): [P2] silent swallow — add logging. See references/error-recovery-patterns.md#P2
+```
+
+TODO comment format for untyped/legacy raise findings — include the prescribed leaf:
+```python
+# TODO(signal-over-noise): [P12] convert to typed AppError. Suggested: InternalError(code="INTERNAL_ENGINE_NOT_INITIALIZED"). See references/typed-error-prescription.md#4
+# TODO(signal-over-noise): [P13] legacy AtlanError — migrate to DependencyUnavailableError. See references/typed-error-prescription.md#5
 ```
 
 #### After applying fixes:
@@ -518,3 +557,11 @@ Report a brief summary: N files changed, N auto-fixes applied, N TODO comments a
 7. **Phase ordering matters:** Run Surface before Tune. A silent-swallow in an except block (P1/P2)
    overlaps with a missing-exc_info finding (L4). Surface fixes the structural problem; Tune then
    verifies the logging quality of the fix. Avoid double-reporting the same line.
+
+8. **Typed-error prescription is mandatory.** Every fix that re-raises must name an `AppError`
+   leaf from `application_sdk.errors`. The skill never recommends raising a bare builtin or a
+   legacy `AtlanError`. The leaf catalogue (§2), litmus tests (§3), SDK-context cookbook (§4),
+   and exhaustive legacy-constant migration table (§5) all live in
+   `references/typed-error-prescription.md`. P12 (untyped builtin raises) and P13 (legacy
+   `AtlanError` raises) fold the BLDX-1261 audit into surface mode — every finding gets a
+   `Prescribed:` entry naming the target leaf and suggested code string.

--- a/.claude/skills/signal-over-noise/SKILL.md
+++ b/.claude/skills/signal-over-noise/SKILL.md
@@ -163,15 +163,12 @@ Pattern:  P12
 Current:
     raise ValueError("Engine is not initialized. Call load() first.")
 Prescribed:
-    InternalError  (wire code: INTERNAL_ENGINE_NOT_INITIALIZED — ClassVar, not a constructor arg)
-    audience=APP_OWNER  retryable=False
+    EngineNotInitializedError(InternalError)  →  code=INTERNAL_ENGINE_NOT_INITIALIZED
+    Subclass bakes message + component + invariant. Place in a sibling
+    module (e.g. _<area>_errors.py); follow the WorkerEvictedError precedent.
 Fix (FT-8):
-    raise InternalError(
-        message="Engine is not initialized. Call load() first.",
-        component="sql_client",
-        invariant="load_before_use",
-    )
-Auto-fixable: no  (leaf choice needs context — manual review)
+    raise EngineNotInitializedError()
+Auto-fixable: no  (leaf + subclass choice needs context — manual review)
 Priority: P1
 ```
 
@@ -240,8 +237,8 @@ Apply the remediation plan that was approved. Only fix what was listed in the ap
 - **FT-5b** (typed re-raise for non-best-effort suppress): leaf choice is contextual
 - **FT-6** (narrow broad catch): `# TODO(signal-over-noise): [P4] narrow this catch`
 - **FT-7** (Filter exception safety): `# TODO(signal-over-noise): [P11] wrap filter body in try/except`
-- **FT-8** (convert untyped builtin raise to typed `AppError`): leaf from `typed-error-prescription.md` §4
-- **FT-9** (convert legacy `AtlanError` raise to typed `AppError`): leaf from `typed-error-prescription.md` §5
+- **FT-8** (convert untyped builtin raise to typed `AppError`): leaf from `typed-error-prescription.md` §4. If the same leaf+message+evidence recurs across ≥2 raise sites, define a subclass that bakes the defaults in a sibling `_<area>_errors.py` and reduce raise sites to the minimal form (`raise XError()`).
+- **FT-9** (convert legacy `AtlanError` raise to typed `AppError`): leaf from `typed-error-prescription.md` §5. Same subclassing rule applies when the same error recurs.
 
 TODO comment format for swallow/logging findings:
 ```python

--- a/.claude/skills/signal-over-noise/references/error-recovery-patterns.md
+++ b/.claude/skills/signal-over-noise/references/error-recovery-patterns.md
@@ -257,6 +257,68 @@ results are not subsequently checked for exception instances.
 
 ---
 
+### P12 — Untyped builtin raise where a typed `AppError` code applies
+
+**Grep:** `raise\s+(ValueError|RuntimeError|Exception|TypeError|NotImplementedError|OSError|KeyError|LookupError)\b`
+**Severity:** HIGH (CRITICAL when inside an `@task`-decorated activity body)
+**What it is:** SDK code raises a bare Python builtin. The Automation Engine
+receives an opaque string — no `category`, no `code`, no `audience`, no
+`retryable`. Dashboards are blind; on-call routing is impossible. Direct
+expression of the BLDX-1261 audit scope.
+
+```python
+# BAD — unattributable on the wire
+raise ValueError("Engine is not initialized. Call load() first.")
+
+# GOOD — typed, attributable
+from application_sdk.errors import InternalError
+raise InternalError(
+    message="Engine is not initialized. Call load() first.",
+    component="sql_client",
+    invariant="load_before_use",
+)
+```
+
+**Acceptable?** Only inside dataclass `__post_init__` / stdlib validator methods
+where Python semantics require `TypeError` / `ValueError` for stdlib
+interoperability (e.g. Pydantic validators, `__init__` argument checks at the
+Python level). Must have a comment explaining why the builtin is required.
+
+**Fix:** FT-8. Use `typed-error-prescription.md` §4 (cookbook) or §3 (litmus
+tests) to select the leaf.
+
+---
+
+### P13 — Legacy `AtlanError` subclass raise (deprecated stack)
+
+**Grep:** `raise\s+(ClientError|ApiError|OrchestratorError|WorkflowError|IOError|CommonError|DocGenError|ActivityError|AtlanError)\b`
+**Severity:** HIGH (deprecated; scheduled for removal in v4.0 per
+`application_sdk/common/error_codes.py:51-63`)
+**What it is:** `AtlanError` and its subclasses emit a `DeprecationWarning` at
+construction time and reach AE as opaque strings. They produce no typed wire
+envelope.
+
+```python
+# BAD
+raise IOError("Object store download failed")
+
+# GOOD
+from application_sdk.errors import DependencyUnavailableError
+raise DependencyUnavailableError(
+    message="Object store download failed",
+    service="object_store",
+    cause=exc,
+) from exc
+```
+
+**Acceptable?** Never. Every legacy raise has a deterministic target in the
+`typed-error-prescription.md` §5 migration table.
+
+**Fix:** FT-9. Look up the legacy constant in the §5 migration table — the
+mapping is exhaustive and deterministic.
+
+---
+
 ### P11 — `logging.Filter` Exceptions Propagate to Caller (CRASH)
 
 **Grep:** `class\s+\w+.*logging\.Filter` or `def filter\(self` inside a class that inherits `logging.Filter`
@@ -335,16 +397,51 @@ When a finding is acceptable, note the justification and skip it from the remedi
 
 Mechanical fixes per category. Apply exactly — don't over-engineer.
 
-### FT-1: Add logging to silent-swallow
+**Typed-error requirement.** Whenever a fix surfaces or re-raises an exception,
+the replacement **must** use a typed `AppError` subclass from
+`application_sdk.errors`. See
+[`typed-error-prescription.md`](typed-error-prescription.md) for the full
+catalogue (14 SDK leaves), litmus tests, SDK-context cookbook (§4), the
+exhaustive legacy `AtlanError` → `AppError` migration table (§5), and the
+mandatory `cause`/`from` rules (§6). **Never** propose raising bare
+`Exception` / `ValueError` / `RuntimeError`; **never** propose raising legacy
+`AtlanError` subclasses (`ClientError`, `IOError`, `CommonError`, etc.).
+Use the §8 surface-or-swallow decision tree to choose between FT-1a and FT-1b.
+
+### FT-1a: Add logging to silent-swallow (log-and-continue — best-effort paths)
+
+Use when the §8 decision tree confirms "best-effort / caller does not depend
+on success". Log at WARNING if the failure is unexpected; DEBUG if it is
+fully anticipated.
 
 ```python
 # Before
 except SomeError:
     pass
 
-# After
+# After (log-and-continue)
 except SomeError:
     logger.warning("<context: what was being attempted>", exc_info=True)
+```
+
+### FT-1b: Log and re-raise as typed `AppError` (surfacing paths)
+
+Use when the §8 decision tree says the caller depends on the operation or this
+is inside an activity body. Pick the leaf from `typed-error-prescription.md` §4.
+
+```python
+# Before
+except SomeError:
+    pass
+
+# After (log + typed re-raise)
+except SomeError as exc:
+    logger.warning("<context: what was being attempted>", exc_info=True)
+    raise <TypedLeaf>(
+        message="<context: what was being attempted>",
+        cause=exc,
+        # evidence fields from leaves.py
+    ) from exc
 ```
 
 ### FT-2: Add `exc_info=True` to existing log
@@ -359,17 +456,39 @@ except SomeError:
     logger.warning("Failed: <static description>", exc_info=True)
 ```
 
-### FT-3: Add logging before error-to-return-value
+### FT-3a: Add logging before error-to-return-value (log-and-continue — caller treats default as valid)
+
+Use when the caller genuinely treats the fallback return value as a valid
+outcome. Log at WARNING.
 
 ```python
 # Before
 except Exception:
     return {}
 
-# After
+# After (log-and-continue)
 except Exception:
     logger.warning("<context>", exc_info=True)
     return {}
+```
+
+### FT-3b: Convert error-to-return-value to typed re-raise (dominant fix)
+
+The default fix — use unless FT-3a's condition is clearly met. Convert the
+swallow into a typed raise so callers see a real failure rather than a silently
+wrong result.
+
+```python
+# Before
+except Exception:
+    return {}
+
+# After (typed re-raise — caller must handle or propagate)
+except Exception as exc:
+    raise <TypedLeaf>(
+        message="<context: what was being attempted>",
+        cause=exc,
+    ) from exc
 ```
 
 ### FT-4: Add exception inspection to `asyncio.gather` results
@@ -381,18 +500,39 @@ for _r in _results:
         logger.warning("Async task failed", exc_info=_r)
 ```
 
-### FT-5: Replace broad `contextlib.suppress(Exception)` with logged try/except
+### FT-5a: Replace broad `contextlib.suppress(Exception)` with logged try/except (best-effort)
+
+Use when §8 confirms best-effort / caller does not depend on success.
 
 ```python
 # Before
 with contextlib.suppress(Exception):
     do_thing()
 
-# After
+# After (log-and-continue)
 try:
     do_thing()
 except Exception:
     logger.warning("<context>", exc_info=True)
+```
+
+### FT-5b: Replace broad `contextlib.suppress(Exception)` with typed re-raise (surfacing)
+
+Use when the call is not genuinely best-effort.
+
+```python
+# Before
+with contextlib.suppress(Exception):
+    do_thing()
+
+# After (typed re-raise)
+try:
+    do_thing()
+except Exception as exc:
+    raise <TypedLeaf>(
+        message="<context: what failed>",
+        cause=exc,
+    ) from exc
 ```
 
 ### FT-6: Narrow overly-broad catch (manual — requires knowing the right exception types)
@@ -438,6 +578,71 @@ class EnvFilter(logging.Filter):
         return getattr(record, "environment", None) == "production"
 ```
 
+### FT-8: Convert untyped builtin raise to typed `AppError` (manual — leaf choice needs context)
+
+Look up the right leaf in `typed-error-prescription.md` §4 (SDK-context cookbook)
+or §3 (litmus tests). Preserve the original message verbatim.
+
+```python
+# Before
+raise ValueError("aws_role_arn is required")
+
+# After
+from application_sdk.errors import InvalidInputError
+raise InvalidInputError(
+    message="aws_role_arn is required",
+    field="aws_role_arn",
+)
+```
+
+```python
+# Before
+raise RuntimeError("Engine is not initialized. Call load() first.")
+
+# After
+from application_sdk.errors import InternalError
+raise InternalError(
+    message="Engine is not initialized. Call load() first.",
+    component="sql_client",
+    invariant="load_before_use",
+)
+```
+
+When wrapping an upstream exception, always use both `cause=exc` **and**
+`raise ... from exc` (see `typed-error-prescription.md` §6).
+
+### FT-9: Convert legacy `AtlanError` raise to typed `AppError` (manual — use migration table)
+
+Look up the legacy constant in `typed-error-prescription.md` §5. The table
+is exhaustive and covers every constant in
+`application_sdk/common/error_codes.py`.
+
+```python
+# Before
+raise ClientError("Engine not initialized. Call load() first.")
+
+# After
+from application_sdk.errors import InternalError
+raise InternalError(
+    message="Engine not initialized. Call load() first.",
+    component="sql_client",
+    invariant="load_before_use",
+)
+```
+
+```python
+# Before
+raise IOError("Object store download failed")
+
+# After
+from application_sdk.errors import DependencyUnavailableError
+raise DependencyUnavailableError(
+    message="Object store download failed",
+    service="object_store",
+    cause=exc,
+) from exc
+```
+
 ---
 
 ## Linting Rules to Enable
@@ -469,3 +674,17 @@ select = [
 
 Note: `TRY300` and `TRY302` can be noisy on existing codebases — introduce separately after
 fixing the higher-severity issues.
+
+To prevent regressions on P12 (untyped builtin raises inside `application_sdk/`),
+a CI-level grep is more practical than a ruff rule (false-positive rate is high
+without a per-file allowlist). A targeted check:
+
+```bash
+# Fail if any bare builtin raise survives in application_sdk/ (outside __post_init__ / validators)
+grep -rnE "raise\s+(ValueError|RuntimeError|Exception)\b" application_sdk/ \
+  | grep -v "__post_init__" | grep -v "# stdlib-interop"
+```
+
+This is tracked under BLDX-1261; enforcement is out of scope for this skill.
+P13 (legacy `AtlanError`) will disappear once BLDX-1261 lands and can be
+enforced by deleting `application_sdk/common/error_codes.py` in v4.0.

--- a/.claude/skills/signal-over-noise/references/error-recovery-patterns.md
+++ b/.claude/skills/signal-over-noise/references/error-recovery-patterns.md
@@ -681,7 +681,7 @@ without a per-file allowlist). A targeted check:
 
 ```bash
 # Fail if any bare builtin raise survives in application_sdk/ (outside __post_init__ / validators)
-grep -rnE "raise\s+(ValueError|RuntimeError|Exception)\b" application_sdk/ \
+grep -rnP "raise\s+(ValueError|RuntimeError|Exception)\b" application_sdk/ \
   | grep -v "__post_init__" | grep -v "# stdlib-interop"
 ```
 

--- a/.claude/skills/signal-over-noise/references/typed-error-prescription.md
+++ b/.claude/skills/signal-over-noise/references/typed-error-prescription.md
@@ -1,0 +1,631 @@
+# Typed Error Prescription Reference
+
+Authoritative reference for "which `AppError` should I raise here?" — used by
+the signal-over-noise skill when producing prescriptive fix entries for raise
+sites and silent-swallow → re-raise conversions.
+
+Source of truth: `application_sdk/errors/{base,categories,leaves,wire}.py`.
+Companion for connector apps (not the SDK itself): `.claude/skills/typed-failures/SKILL.md`.
+
+---
+
+## §1 — Why typed errors
+
+Every `AppError` subclass produces a `FailureDetails` wire envelope via
+`AppError.to_failure_details()` (`application_sdk/errors/base.py:78-108`).
+Temporal serialises that envelope into `ApplicationError.details=[…]`. The
+Automation Engine reads `category`, `code`, `audience`, and `retryable` as
+typed, queryable fields — it **never** parses exception strings.
+
+Bare builtin raises (`ValueError`, `RuntimeError`, `Exception`) and legacy
+`AtlanError` subclasses (`ClientError`, `IOError`, etc.) reach AE as opaque
+strings. Dashboard cuts, SLA attribution, and on-call routing are all blind to
+them. Typed errors are not a style preference — they are the failure-attribution
+contract between the SDK and the Automation Engine.
+
+The `FailureDetails` envelope:
+
+```python
+FailureDetails(
+    category: FailureCategory,   # what happened (closed enum)
+    code: str,                   # fine-grained app-owned identifier
+    retryable: bool,             # should the orchestrator retry?
+    audience: Audience,          # who must act: USER / PLATFORM / APP_OWNER
+    message: str,
+    suggested_action: str | None,
+    evidence: dict[str, Any],    # leaf's dataclass fields (auto-populated)
+    cause_repr: str | None,      # sanitised upstream exception string
+)
+```
+
+---
+
+## §2 — The 14 SDK leaves
+
+All defined in `application_sdk/errors/leaves.py`. Import path:
+`from application_sdk.errors import <Leaf>`.
+
+**You may not invent new categories.** The `FailureCategory` enum is closed
+(`application_sdk/errors/categories.py`). If you need a sharper distinction,
+subclass a leaf and override `code` — never add a new category value.
+
+| Leaf class | Category | Default `audience` | Default `retryable` | Raise this when… |
+|---|---|---|---|---|
+| `CancelledError` | CANCELLED | APP_OWNER | False | Caller / workflow signalled cancellation; not a failure |
+| `AppTimeoutError` | TIMEOUT | APP_OWNER | **True** | A bounded wait elapsed (network read, activity start-to-close, heartbeat) |
+| `RateLimitedError` | RATE_LIMITED | USER | **True** | Source or dependency returned 429 or per-key quota signal |
+| `AuthError` | AUTH | USER | False | Credentials missing, expired, or rejected |
+| `AppPermissionDeniedError` | PERMISSION | USER | False | Authenticated but not authorised for the resource or action |
+| `NotFoundError` | NOT_FOUND | USER | False | Targeted entity does not exist |
+| `AlreadyExistsError` | ALREADY_EXISTS | USER | False | Entity the caller tried to create already exists (idempotent-create path) |
+| `InvalidInputError` | INVALID_INPUT | USER | False | Argument or payload malformed irrespective of system state |
+| `PreconditionError` | PRECONDITION | USER | False | Inputs syntactically valid but system state forbids the action |
+| `DependencyUnavailableError` | DEPENDENCY_UNAVAILABLE | **PLATFORM** | **True** | Required platform service down or degraded (Dapr, Temporal, object store, source DB) |
+| `ResourceExhaustedError` | RESOURCE_EXHAUSTED | **PLATFORM** | **True** | Local resource limit hit (OOM, disk full, file handles, worker slots) |
+| `DataIntegrityError` | DATA_INTEGRITY | APP_OWNER | False | Returned data is corrupt or violates expected invariants |
+| `InternalError` | INTERNAL | APP_OWNER | False | SDK or app bug; invariant broken in our code |
+| `UnimplementedError` | UNIMPLEMENTED | APP_OWNER | False | Operation not supported or capability not yet built (known gap, not a bug) |
+
+**Special SDK subclass** — `WorkerEvictedError` (`leaves.py:175-195`) subclasses
+`DependencyUnavailableError` with `code = "WORKER_EVICTED"`. This is the
+precedent for when the SDK itself should subclass a leaf: when a stable wire
+`code` string is needed for cross-process recognition (Temporal serialises only
+the type string, not the Python class). Do not add further SDK subclasses without
+this specific need.
+
+**`audience` override pattern** — when an SDK base default doesn't fit the locus,
+override `audience` on a minimal subclass. Example from the SDK itself:
+`WorkerEvictedError` inherits PLATFORM from `DependencyUnavailableError` and
+keeps it (correct — the pod is platform infrastructure). For connector apps that
+source-side network is `audience=USER` (the customer controls it), so they
+override in their `failures.py`. The SDK's own code should follow the same logic.
+
+---
+
+## §3 — Litmus tests for ambiguous categories
+
+Use these in order. Pick the first rule that applies.
+
+**`DEPENDENCY_UNAVAILABLE` vs `PRECONDITION`**
+If retrying *the same call* without any state change is expected to succeed →
+`DependencyUnavailableError`. If explicit state must change before the call can
+succeed (schema must be updated, version must match, entity must be in a
+different state) → `PreconditionError`.
+
+**`RATE_LIMITED` vs `RESOURCE_EXHAUSTED`**
+429 from a remote endpoint (per-key quota signal) → `RateLimitedError`.
+Local resource limit (OOM, disk full, file handles, worker-slot exhaustion) →
+`ResourceExhaustedError`.
+
+**`ALREADY_EXISTS` vs `PRECONDITION`**
+Entity already exists on an idempotent-create path → `AlreadyExistsError`.
+Resource exists but is in the wrong *state* for the operation →
+`PreconditionError`.
+
+**`UNIMPLEMENTED` vs `INTERNAL`**
+Known capability gap (feature not yet built, dialect not yet supported) →
+`UnimplementedError`. Unexpected invariant violation (our code has a bug) →
+`InternalError`.
+
+**`INVALID_INPUT` vs `PRECONDITION`**
+Payload itself is malformed irrespective of system state (missing required
+field, wrong type, out-of-range value) → `InvalidInputError`. Payload
+syntactically valid but system state blocks the operation → `PreconditionError`.
+
+**`AUTH` vs `PERMISSION`**
+Identity cannot be established (credentials missing, expired, or invalid;
+authentication handshake failed) → `AuthError`. Identity established but the
+principal lacks permission for the resource or action → `AppPermissionDeniedError`.
+
+---
+
+## §4 — SDK raise-context → leaf cookbook
+
+Common situations in `application_sdk/`. Each entry gives a worked example.
+Use the `code` suggestion as-is or append a more specific suffix.
+
+**Code naming rule**: always start with the category prefix
+(`AUTH_`, `INTERNAL_`, `DEPENDENCY_UNAVAILABLE_`, etc.) so the code is
+self-describing without joining against the category column. No vendor name in
+the code (vendor identity lives in `evidence`). Generic subtypes reused across
+callers are better than hyper-specific ones.
+
+---
+
+### Required field / config missing
+
+```python
+# Situation: raise ValueError("X is required")
+raise InvalidInputError(
+    message="aws_role_arn is required",
+    field="aws_role_arn",
+)
+```
+Code: `INVALID_INPUT_MISSING_FIELD`. Use `field=` evidence to name the param.
+
+---
+
+### SDK invariant violated (caller misused the API)
+
+```python
+# Situation: "Engine is not initialized. Call load() first."
+raise InternalError(
+    message="Engine is not initialized. Call load() first.",
+    component="sql_client",
+    invariant="load_before_use",
+)
+```
+Code: `INTERNAL_ENGINE_NOT_INITIALIZED`. Audience: APP_OWNER.
+`component=` names the SDK layer; `invariant=` is a short stable key suitable
+for runbook lookup.
+
+---
+
+### Credentials missing or invalid (no HTTP response)
+
+```python
+raise AuthError(
+    message="No credentials found for connection",
+    auth_method="connection_config",
+    failure_reason="credentials_absent",
+)
+```
+Code: `AUTH_MISSING_CREDENTIALS`. Audience: USER (default — correct).
+
+---
+
+### 401 from source (rejected by remote)
+
+```python
+except HTTPError as exc:
+    raise AuthError(
+        message="Source rejected credentials",
+        auth_method="api_key",
+        failure_reason="http_401",
+        cause=exc,
+    ) from exc
+```
+Code: `AUTH_REJECTED`. Set `cause=exc` + `from exc` (see §6).
+
+---
+
+### 403 from source
+
+```python
+raise AppPermissionDeniedError(
+    message="Permission denied by source",
+    resource=endpoint,
+    required_action="read",
+    cause=exc,
+) from exc
+```
+Code: `PERMISSION_DENIED`. Audience: USER (default — correct).
+
+---
+
+### 404 from source
+
+```python
+raise NotFoundError(
+    message=f"Resource not found: {resource_id}",
+    resource_type="table",
+    resource_identifier=resource_id,
+    cause=exc,
+) from exc
+```
+Code: `NOT_FOUND_RESOURCE`. Evidence: `resource_type=` and `resource_identifier=`.
+
+---
+
+### 409 / idempotent-create conflict
+
+```python
+raise AlreadyExistsError(
+    message=f"Entity already exists: {entity_id}",
+    resource_type="connection",
+    resource_identifier=entity_id,
+)
+```
+Code: `ALREADY_EXISTS_RESOURCE`.
+
+---
+
+### 429 / quota exceeded
+
+```python
+raise RateLimitedError(
+    message="API quota exceeded",
+    limit_type="requests_per_minute",
+    retry_after_seconds=float(retry_after) if retry_after else None,
+    cause=exc,
+) from exc
+```
+Code: `RATE_LIMITED_API`. Set `retry_after_seconds=` from response header when
+available.
+
+---
+
+### Network unreachable / 5xx from source
+
+```python
+raise DependencyUnavailableError(
+    message="Source database unreachable",
+    service="source_db",
+    target=host,
+    network_error=str(exc),
+    cause=exc,
+) from exc
+```
+Code: `DEPENDENCY_UNAVAILABLE_NETWORK`. Audience: default PLATFORM.
+**Override to USER** when the unreachable host is the customer's own source
+(their firewall / VPC). Add `audience: ClassVar[Audience] = Audience.USER`
+on a minimal subclass if doing this consistently.
+
+---
+
+### Dapr / Temporal / object-store outage
+
+```python
+raise DependencyUnavailableError(
+    message="Dapr state store unavailable",
+    service="dapr_state_store",
+    network_error=str(exc),
+    cause=exc,
+) from exc
+```
+Code: `DEPENDENCY_UNAVAILABLE_DAPR` / `DEPENDENCY_UNAVAILABLE_TEMPORAL` /
+`DEPENDENCY_UNAVAILABLE_OBJECT_STORE`. Audience: PLATFORM (default — correct).
+
+---
+
+### Schema mismatch / version conflict
+
+```python
+raise PreconditionError(
+    message="Schema version mismatch; re-run migration",
+    resource="output_schema",
+    expected_state="v2",
+    actual_state="v1",
+)
+```
+Code: `PRECONDITION_SCHEMA_MISMATCH`.
+
+---
+
+### Bounded-wait elapsed (timeout)
+
+```python
+raise AppTimeoutError(
+    message="Query execution exceeded timeout",
+    operation="sql_query",
+    timeout_seconds=30.0,
+    cause=exc,
+) from exc
+```
+Code: `TIMEOUT_QUERY`. Set `operation=` and `timeout_seconds=` from the
+configured limit.
+
+---
+
+### Local OOM / disk full / handle exhaustion
+
+```python
+raise ResourceExhaustedError(
+    message="Worker ran out of memory processing batch",
+    resource="heap_memory",
+    limit="container_limit",
+    observed=str(exc),
+    cause=exc,
+) from exc
+```
+Code: `RESOURCE_EXHAUSTED_MEMORY`. Audience: PLATFORM (default — correct).
+
+---
+
+### Returned data corrupt / invariant violated
+
+```python
+raise DataIntegrityError(
+    message="Row count mismatch after transform",
+    expectation="row_count == source_count",
+    observed=f"{actual} rows vs {expected} expected",
+    location="transformer:finalize",
+)
+```
+Code: `DATA_INTEGRITY_ROW_COUNT_MISMATCH`. Audience: APP_OWNER (default).
+
+---
+
+### Known capability gap
+
+```python
+raise UnimplementedError(
+    message="Cursor type 'server-side' not yet supported",
+    operation="sql_fetch_cursor",
+    reason="server_side_cursor_not_implemented",
+)
+```
+Code: `UNIMPLEMENTED_CURSOR_TYPE`. Audience: APP_OWNER. Use this — **not**
+`InternalError` — for known feature gaps so on-call is not paged for an
+expected absence.
+
+---
+
+### Workflow / caller cancellation
+
+Rarely raised manually — usually propagated from Temporal. If the SDK raises it:
+
+```python
+raise CancelledError(
+    message="Activity cancelled by workflow signal",
+    cancelled_by="workflow",
+    reason="graceful_shutdown",
+)
+```
+Code: `CANCELLED`.
+
+---
+
+## §5 — Exhaustive legacy `AtlanError` → `AppError` migration table
+
+Full mapping of every constant in
+`application_sdk/common/error_codes.py`. Use this as a deterministic lookup
+when converting P13 (legacy `AtlanError`) raise sites.
+
+Columns: `legacy constant` | `target leaf` | `suggested code` |
+`audience override?` | `notes`
+
+### `ClientError` → (`application_sdk/common/error_codes.py:66-105`)
+
+| Legacy constant | Target leaf | Suggested code | Audience override? | Notes |
+|---|---|---|---|---|
+| `REQUEST_VALIDATION_ERROR` | `InvalidInputError` | `INVALID_INPUT_REQUEST_VALIDATION` | — | set `constraint=` with validation details |
+| `INPUT_VALIDATION_ERROR` | `InvalidInputError` | `INVALID_INPUT_VALIDATION` | — | set `field=` if field-level |
+| `CLIENT_AUTH_ERROR` | `AuthError` | `AUTH_CLIENT_FAILED` | — | set `auth_method=` |
+| `HANDLER_AUTH_ERROR` | `AuthError` | `AUTH_HANDLER_FAILED` | — | HTTP handler auth failure |
+| `SQL_CLIENT_AUTH_ERROR` | `AuthError` | `AUTH_SQL_CLIENT_FAILED` | — | set `auth_method="sql"` |
+| `AUTH_TOKEN_REFRESH_ERROR` | `AuthError` | `AUTH_TOKEN_REFRESH_FAILED` | — | set `failure_reason="token_refresh"` |
+| `AUTH_CREDENTIALS_ERROR` | `AuthError` | `AUTH_CREDENTIALS_NOT_FOUND` | — | set `failure_reason="credentials_absent"` |
+| `AUTH_CONFIG_ERROR` | `InvalidInputError` | `INVALID_INPUT_AUTH_CONFIG` | — | configuration error, not a credentials error |
+| `REDIS_CONNECTION_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_REDIS` | — | set `service="redis"` |
+| `REDIS_TIMEOUT_ERROR` | `AppTimeoutError` | `TIMEOUT_REDIS` | — | set `operation="redis_op"` |
+| `REDIS_AUTH_ERROR` | `AuthError` | `AUTH_REDIS_FAILED` | — | set `auth_method="redis_auth"` |
+| `REDIS_PROTOCOL_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_REDIS_PROTOCOL` | — | set `service="redis"`, `network_error=` |
+
+### `ApiError` → (`application_sdk/common/error_codes.py:107-144`)
+
+| Legacy constant | Target leaf | Suggested code | Audience override? | Notes |
+|---|---|---|---|---|
+| `SERVER_START_ERROR` | `InternalError` | `INTERNAL_SERVER_START` | — | server startup invariant |
+| `SERVER_SHUTDOWN_ERROR` | `InternalError` | `INTERNAL_SERVER_SHUTDOWN` | — | |
+| `SERVER_CONFIG_ERROR` | `InvalidInputError` | `INVALID_INPUT_SERVER_CONFIG` | — | bad configuration supplied |
+| `CONFIGURATION_ERROR` | `InvalidInputError` | `INVALID_INPUT_CONFIG` | — | general config error |
+| `LOGGER_SETUP_ERROR` | `InternalError` | `INTERNAL_LOGGER_SETUP` | — | observability setup invariant |
+| `LOGGER_PROCESSING_ERROR` | `InternalError` | `INTERNAL_LOGGER_PROCESSING` | — | |
+| `LOGGER_OTLP_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_OTLP` | — | OTLP collector unreachable |
+| `LOGGER_RESOURCE_ERROR` | `ResourceExhaustedError` | `RESOURCE_EXHAUSTED_LOGGER` | — | |
+| `UNKNOWN_ERROR` | `InternalError` | `INTERNAL_UNKNOWN` | — | set `classification_pending=True` pending triage |
+| `SQL_FILE_ERROR` | `InternalError` | `INTERNAL_SQL_FILE` | — | SQL template / file read failure |
+| `ENDPOINT_ERROR` | `InternalError` | `INTERNAL_ENDPOINT` | — | HTTP endpoint setup/dispatch |
+| `EVENT_TRIGGER_ERROR` | `InternalError` | `INTERNAL_EVENT_TRIGGER` | — | |
+| `MIDDLEWARE_ERROR` | `InternalError` | `INTERNAL_MIDDLEWARE` | — | |
+| `ROUTE_HANDLER_ERROR` | `InternalError` | `INTERNAL_ROUTE_HANDLER` | — | |
+| `LOG_MIDDLEWARE_ERROR` | `InternalError` | `INTERNAL_LOG_MIDDLEWARE` | — | |
+
+### `OrchestratorError` → (`application_sdk/common/error_codes.py:147-159`)
+
+| Legacy constant | Target leaf | Suggested code | Audience override? | Notes |
+|---|---|---|---|---|
+| `ORCHESTRATOR_CLIENT_CONNECTION_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_TEMPORAL` | — | set `service="temporal"` |
+| `ORCHESTRATOR_CLIENT_ACTIVITY_ERROR` | `InternalError` | `INTERNAL_ORCHESTRATOR_ACTIVITY` | — | activity dispatch failure |
+| `ORCHESTRATOR_CLIENT_WORKER_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_TEMPORAL_WORKER` | — | set `service="temporal_worker"` |
+
+### `WorkflowError` → (`application_sdk/common/error_codes.py:161-188`)
+
+| Legacy constant | Target leaf | Suggested code | Audience override? | Notes |
+|---|---|---|---|---|
+| `WORKFLOW_EXECUTION_ERROR` | `InternalError` | `INTERNAL_WORKFLOW_EXECUTION` | — | unexpected workflow failure |
+| `WORKFLOW_CONFIG_ERROR` | `InvalidInputError` | `INVALID_INPUT_WORKFLOW_CONFIG` | — | bad workflow configuration |
+| `WORKFLOW_VALIDATION_ERROR` | `InvalidInputError` | `INVALID_INPUT_WORKFLOW_VALIDATION` | — | set `constraint=` with validation detail |
+| `WORKFLOW_CLIENT_START_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_TEMPORAL_START` | — | set `service="temporal"` |
+| `WORKFLOW_CLIENT_STOP_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_TEMPORAL_STOP` | — | set `service="temporal"` |
+| `WORKFLOW_CLIENT_STATUS_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_TEMPORAL_STATUS` | — | set `service="temporal"` |
+| `WORKFLOW_CLIENT_WORKER_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_TEMPORAL_WORKER` | — | set `service="temporal_worker"` |
+| `WORKFLOW_CLIENT_NOT_FOUND_ERROR` | `NotFoundError` | `NOT_FOUND_WORKFLOW` | — | set `resource_type="workflow"` |
+
+### `IOError` → (`application_sdk/common/error_codes.py:190-277`)
+
+| Legacy constant | Target leaf | Suggested code | Audience override? | Notes |
+|---|---|---|---|---|
+| `INPUT_ERROR` | `InvalidInputError` | `INVALID_INPUT_IO` | — | generic IO input error |
+| `INPUT_LOAD_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_INPUT_LOAD` | — | source load failure (retryable) |
+| `INPUT_PROCESSING_ERROR` | `InternalError` | `INTERNAL_INPUT_PROCESSING` | — | processing invariant |
+| `SQL_QUERY_ERROR` | `InvalidInputError` | `INVALID_INPUT_SQL_QUERY` | USER | bad query from caller |
+| `SQL_QUERY_BATCH_ERROR` | `InternalError` | `INTERNAL_SQL_BATCH` | — | SDK batch execution bug |
+| `SQL_QUERY_PANDAS_ERROR` | `InternalError` | `INTERNAL_SQL_PANDAS` | — | |
+| `SQL_QUERY_DAFT_ERROR` | `InternalError` | `INTERNAL_SQL_DAFT` | — | Daft engine invariant |
+| `JSON_READ_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_JSON_READ` | — | malformed JSON on read |
+| `JSON_BATCH_ERROR` | `InternalError` | `INTERNAL_JSON_BATCH` | — | |
+| `JSON_DAFT_ERROR` | `InternalError` | `INTERNAL_JSON_DAFT` | — | |
+| `JSON_DOWNLOAD_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_JSON_DOWNLOAD` | — | download from object store |
+| `PARQUET_READ_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_PARQUET_READ` | — | corrupt/malformed Parquet |
+| `PARQUET_BATCH_ERROR` | `InternalError` | `INTERNAL_PARQUET_BATCH` | — | |
+| `PARQUET_DAFT_ERROR` | `InternalError` | `INTERNAL_PARQUET_DAFT` | — | |
+| `PARQUET_VALIDATION_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_PARQUET_VALIDATION` | — | schema / row validation |
+| `ICEBERG_READ_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_ICEBERG_READ` | — | |
+| `ICEBERG_DAFT_ERROR` | `InternalError` | `INTERNAL_ICEBERG_DAFT` | — | |
+| `ICEBERG_TABLE_ERROR` | `PreconditionError` | `PRECONDITION_ICEBERG_TABLE` | — | table state blocks operation |
+| `OBJECT_STORE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_OBJECT_STORE` | — | set `service="object_store"` |
+| `OBJECT_STORE_DOWNLOAD_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_OBJECT_STORE_DOWNLOAD` | — | set `service="object_store"` |
+| `OBJECT_STORE_READ_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_OBJECT_STORE_READ` | — | set `service="object_store"` |
+| `STATE_STORE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_STATE_STORE` | — | set `service="dapr_state_store"` |
+| `STATE_STORE_EXTRACT_ERROR` | `InternalError` | `INTERNAL_STATE_STORE_EXTRACT` | — | extraction-phase invariant |
+| `STATE_STORE_VALIDATION_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_STATE_STORE` | — | state data corrupt |
+| `OUTPUT_ERROR` | `InternalError` | `INTERNAL_OUTPUT` | — | generic output failure |
+| `OUTPUT_WRITE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_OUTPUT_WRITE` | — | write destination unavailable |
+| `OUTPUT_STATISTICS_ERROR` | `InternalError` | `INTERNAL_OUTPUT_STATISTICS` | — | stats computation |
+| `OUTPUT_VALIDATION_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_OUTPUT_VALIDATION` | — | output data fails validation |
+| `JSON_WRITE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_JSON_WRITE` | — | write destination |
+| `JSON_BATCH_WRITE_ERROR` | `InternalError` | `INTERNAL_JSON_BATCH_WRITE` | — | |
+| `JSON_DAFT_WRITE_ERROR` | `InternalError` | `INTERNAL_JSON_DAFT_WRITE` | — | |
+| `PARQUET_WRITE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_PARQUET_WRITE` | — | |
+| `PARQUET_DAFT_WRITE_ERROR` | `InternalError` | `INTERNAL_PARQUET_DAFT_WRITE` | — | |
+| `ICEBERG_WRITE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_ICEBERG_WRITE` | — | |
+| `ICEBERG_DAFT_WRITE_ERROR` | `InternalError` | `INTERNAL_ICEBERG_DAFT_WRITE` | — | |
+| `ICEBERG_TABLE_ERROR_OUT` | `PreconditionError` | `PRECONDITION_ICEBERG_TABLE_OUT` | — | table state blocks write |
+| `OBJECT_STORE_WRITE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_OBJECT_STORE_WRITE` | — | set `service="object_store"` |
+| `STATE_STORE_WRITE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_STATE_STORE_WRITE` | — | set `service="dapr_state_store"` |
+
+### `CommonError` → (`application_sdk/common/error_codes.py:279-307`)
+
+| Legacy constant | Target leaf | Suggested code | Audience override? | Notes |
+|---|---|---|---|---|
+| `AWS_REGION_ERROR` | `InvalidInputError` | `INVALID_INPUT_AWS_REGION` | — | bad or missing region config |
+| `AWS_ROLE_ERROR` | `AppPermissionDeniedError` | `PERMISSION_AWS_ROLE` | — | IAM assume-role denied |
+| `AWS_CREDENTIALS_ERROR` | `AuthError` | `AUTH_AWS_CREDENTIALS` | — | set `auth_method="aws_iam"` |
+| `AWS_TOKEN_ERROR` | `AuthError` | `AUTH_AWS_TOKEN` | — | STS token error |
+| `QUERY_PREPARATION_ERROR` | `InternalError` | `INTERNAL_QUERY_PREP` | — | query templating / preparation |
+| `FILTER_PREPARATION_ERROR` | `InternalError` | `INTERNAL_FILTER_PREP` | — | filter expression build |
+| `CREDENTIALS_PARSE_ERROR` | `InvalidInputError` | `INVALID_INPUT_CREDENTIALS_PARSE` | — | malformed credentials config |
+| `CREDENTIALS_RESOLUTION_ERROR` | `AuthError` | `AUTH_CREDENTIALS_RESOLUTION` | — | Dapr secret store / vault |
+| `AZURE_CREDENTIAL_ERROR` | `AuthError` | `AUTH_AZURE_CREDENTIAL` | — | set `auth_method="azure"` |
+| `AZURE_CONNECTION_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_AZURE` | — | set `service="azure"` |
+| `AZURE_SERVICE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_AZURE_SERVICE` | — | Azure API failure |
+
+### `DocGenError` → (`application_sdk/common/error_codes.py:311-358`)
+
+| Legacy constant | Target leaf | Suggested code | Audience override? | Notes |
+|---|---|---|---|---|
+| `DOCGEN_ERROR` | `InternalError` | `INTERNAL_DOCGEN` | — | generic docgen failure |
+| `DOCGEN_EXPORT_ERROR` | `InternalError` | `INTERNAL_DOCGEN_EXPORT` | — | |
+| `DOCGEN_BUILD_ERROR` | `InternalError` | `INTERNAL_DOCGEN_BUILD` | — | |
+| `MANIFEST_NOT_FOUND_ERROR` | `NotFoundError` | `NOT_FOUND_MANIFEST` | — | set `resource_type="manifest"` |
+| `MANIFEST_PARSE_ERROR` | `InvalidInputError` | `INVALID_INPUT_MANIFEST_PARSE` | — | malformed manifest YAML/JSON |
+| `MANIFEST_VALIDATION_ERROR` | `InvalidInputError` | `INVALID_INPUT_MANIFEST_VALIDATION` | — | set `constraint=` |
+| `MANIFEST_YAML_ERROR` | `InvalidInputError` | `INVALID_INPUT_MANIFEST_YAML` | — | YAML parse error |
+| `DIRECTORY_VALIDATION_ERROR` | `InvalidInputError` | `INVALID_INPUT_DIRECTORY_VALIDATION` | — | |
+| `DIRECTORY_CONTENT_ERROR` | `InvalidInputError` | `INVALID_INPUT_DIRECTORY_CONTENT` | — | |
+| `DIRECTORY_STRUCTURE_ERROR` | `InvalidInputError` | `INVALID_INPUT_DIRECTORY_STRUCTURE` | — | |
+| `DIRECTORY_FILE_ERROR` | `InvalidInputError` | `INVALID_INPUT_DIRECTORY_FILE` | — | missing / malformed file |
+| `MKDOCS_CONFIG_ERROR` | `InvalidInputError` | `INVALID_INPUT_MKDOCS_CONFIG` | — | |
+| `MKDOCS_EXPORT_ERROR` | `InternalError` | `INTERNAL_MKDOCS_EXPORT` | — | MkDocs export subprocess |
+| `MKDOCS_NAV_ERROR` | `InternalError` | `INTERNAL_MKDOCS_NAV` | — | navigation generation |
+| `MKDOCS_BUILD_ERROR` | `InternalError` | `INTERNAL_MKDOCS_BUILD` | — | |
+
+### `ActivityError` → (`application_sdk/common/error_codes.py:361-409`)
+
+| Legacy constant | Target leaf | Suggested code | Audience override? | Notes |
+|---|---|---|---|---|
+| `ACTIVITY_START_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_ACTIVITY_START` | — | Temporal activity start failure |
+| `ACTIVITY_END_ERROR` | `InternalError` | `INTERNAL_ACTIVITY_END` | — | activity teardown invariant |
+| `QUERY_EXTRACTION_ERROR` | `InternalError` | `INTERNAL_QUERY_EXTRACTION` | — | query extraction activity |
+| `QUERY_EXTRACTION_SQL_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_QUERY_SQL` | — | SQL source unreachable during extraction |
+| `QUERY_EXTRACTION_PARSE_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_QUERY_EXTRACTION_PARSE` | — | returned data unparseable |
+| `QUERY_EXTRACTION_VALIDATION_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_QUERY_EXTRACTION_VALIDATION` | — | extracted data fails schema check |
+| `METADATA_EXTRACTION_ERROR` | `InternalError` | `INTERNAL_METADATA_EXTRACTION` | — | generic extraction failure |
+| `METADATA_EXTRACTION_SQL_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_METADATA_SQL` | — | SQL source unreachable |
+| `METADATA_EXTRACTION_REST_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_METADATA_REST` | — | REST source unreachable |
+| `METADATA_EXTRACTION_PARSE_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_METADATA_EXTRACTION_PARSE` | — | |
+| `METADATA_EXTRACTION_VALIDATION_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_METADATA_EXTRACTION_VALIDATION` | — | |
+| `ATLAN_UPLOAD_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_ATLAN_UPLOAD` | — | set `service="atlan_api"` |
+| `LOCK_ACQUISITION_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_LOCK_ACQUISITION` | — | set `service="dapr_lock"` |
+| `LOCK_RELEASE_ERROR` | `InternalError` | `INTERNAL_LOCK_RELEASE` | — | lock release invariant |
+| `LOCK_TIMEOUT_ERROR` | `AppTimeoutError` | `TIMEOUT_LOCK_ACQUISITION` | — | set `operation="lock_acquire"` |
+
+---
+
+## §6 — Mandatory raise-site rules
+
+These rules apply to every raise site in `application_sdk/` and in connector
+apps. Enforce them whenever creating or reviewing a raise.
+
+**`message=` is always required.** Set it to the same human-readable text the
+legacy raise used. Don't re-engineer the message during a migration — preserve
+it verbatim. The message is visible in logs, AE, and Temporal history.
+
+**`cause=exc` AND `raise typed from exc` when wrapping.** Always apply both.
+They serve different consumers:
+- `cause=exc` → populates `FailureDetails.cause_repr` (sanitised, length-capped
+  string in the wire envelope; visible to AE dashboards).
+- `from exc` → sets Python's `__cause__` (preserves the in-process traceback
+  for `exc_info=True` in logs and local debugging).
+
+```python
+# Correct — both bindings
+except SomeSourceError as exc:
+    raise DependencyUnavailableError(
+        message="Source unreachable",
+        service="source_db",
+        cause=exc,
+    ) from exc
+```
+
+**Never set `app_name`, `run_id`, or `suggested_action` from inside the SDK.**
+- `app_name` — AE provides via DAG node label (single source of truth).
+- `run_id` — AE attaches from Temporal context at ingest time.
+- `suggested_action` — only set at a *raise site* when the call site has specific
+  user-facing guidance ("regrant Glue read access on the IAM role"). Never
+  default it on the class definition.
+
+**Evidence fields.** Add dataclass fields when the call site has obvious context
+that aids debugging. Use the leaf's existing fields first (`field` on
+`InvalidInputError`, `service`/`target` on `DependencyUnavailableError`, etc.).
+Add a subclass field only when the leaf's existing fields are insufficient.
+Match the restraint in the Athena reference.
+
+**Secret-named evidence keys are rejected by the wire layer.** `wire.py:67-84`
+blocks any evidence key matching the exact denylist or the suffix denylist
+(`_secret`, `_password`, `_token`). Use a safe proxy name (e.g.
+`credential_name` instead of `credential_token`) or omit.
+
+---
+
+## §7 — SDK vs app subclassing rule
+
+**Connector apps** build `app/failures.py` with their own subclasses using
+the `/typed-failures` skill. Every connector app's typed classes live there,
+not in the SDK.
+
+**The SDK** raises leaves directly in most cases. The exception: when a stable
+wire `code` string is needed for *cross-process* recognition across the
+activity/workflow boundary — `WorkerEvictedError` is the only current example
+(`leaves.py:172`, `code = "WORKER_EVICTED"`). The wire type string lets
+workflow code identify the failure without depending on the Python class name.
+
+If you are tempted to subclass a leaf in the SDK:
+1. Is there a cross-process recognition need? If not, raise the leaf directly
+   and set `code` via a keyword arg at the raise site (not supported on the
+   current `ClassVar` design — so if `code` truly needs to vary, subclass).
+2. Does the new subclass add evidence fields? If yes, that justifies a subclass.
+3. Otherwise: raise the existing leaf directly.
+
+---
+
+## §8 — Surface or swallow? Decision tree
+
+When surface mode identifies a silent-swallow pattern and the right fix might
+involve re-raising (FT-1b, FT-3b, FT-5b), use this decision tree:
+
+```
+Does the caller depend on the operation succeeding?
+  YES → typed re-raise (FT-1b / FT-3b / FT-5b)
+  NO  ↓
+Is the exception from an activity body that reaches AE?
+  YES → typed re-raise — failure attribution depends on it
+  NO  ↓
+Does the surrounding code produce a visibly wrong result
+on failure (returns empty/None/False that callers trust)?
+  YES → typed re-raise
+  NO  ↓
+Is this a module-load / __init__ site?
+  YES → typed re-raise (deferred crashes are worse)
+  NO  ↓
+Is this genuinely best-effort cleanup (cache invalidation,
+stats flush, optional side-effect)?
+  YES → log-and-continue (FT-1a / FT-3a / FT-5a)
+        log at DEBUG if failure is expected; WARNING if unexpected
+  NO  → typed re-raise (default — lean toward surfacing)
+```
+
+When uncertain, lean toward typing and surfacing. A `classification_pending=True`
+`InternalError` is better than a silent swallow.

--- a/.claude/skills/signal-over-noise/references/typed-error-prescription.md
+++ b/.claude/skills/signal-over-noise/references/typed-error-prescription.md
@@ -143,6 +143,31 @@ self-describing without joining against the category column. No vendor name in
 the code (vendor identity lives in `evidence`). Generic subtypes reused across
 callers are better than hyper-specific ones.
 
+### When to bake defaults into a subclass
+
+If the same leaf will be raised with the same message and evidence at ≥2 call
+sites, encode those defaults on the subclass itself so each raise site collapses
+to one line. Raise sites pass only what is genuinely dynamic (typically
+`cause=` or a per-site message that names a specific field). Use
+`@dataclass(kw_only=True)` so the subclass can provide defaults for parent
+default-less fields like `message: str` (Python 3.10+).
+
+```python
+# Subclass — typically in a sibling module (see WorkerEvictedError precedent).
+@dataclass(kw_only=True)
+class EngineNotInitializedError(InternalError):
+    code: ClassVar[str] = "INTERNAL_ENGINE_NOT_INITIALIZED"
+    message: str = "Engine is not initialized. Call load() first."
+    component: str | None = "sql_client"
+    invariant: str | None = "load_before_use"
+
+# Raise sites — minimal.
+raise EngineNotInitializedError()
+```
+
+Raise inline (no subclass) only when the leaf's default code is adequate and
+the site appears once; the cookbook entries below show the inline form.
+
 ---
 
 ### Required field / config missing

--- a/.claude/skills/signal-over-noise/references/typed-error-prescription.md
+++ b/.claude/skills/signal-over-noise/references/typed-error-prescription.md
@@ -122,7 +122,20 @@ principal lacks permission for the resource or action → `AppPermissionDeniedEr
 ## §4 — SDK raise-context → leaf cookbook
 
 Common situations in `application_sdk/`. Each entry gives a worked example.
-Use the `code` suggestion as-is or append a more specific suffix.
+
+Each entry includes a **Code:** annotation. `code` is a `ClassVar[str]` on the leaf
+class — it cannot be passed to the constructor. To use a specific code, subclass the
+leaf and override it:
+
+```python
+@dataclass(kw_only=True)
+class EngineNotInitializedError(InternalError):
+    code: ClassVar[str] = "INTERNAL_ENGINE_NOT_INITIALIZED"
+```
+
+If the leaf's default code is adequate for triage, use the leaf directly without
+subclassing. Subclass only when a stable, recognisable wire code is required for
+cross-process routing or dashboard attribution.
 
 **Code naming rule**: always start with the category prefix
 (`AUTH_`, `INTERNAL_`, `DEPENDENCY_UNAVAILABLE_`, etc.) so the code is

--- a/.github/scripts/parse_atlan_yaml.py
+++ b/.github/scripts/parse_atlan_yaml.py
@@ -42,6 +42,12 @@ _KEBAB_RE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
 # Closed type set. Mirrors core.version.model.EntrypointPackageType in GM.
 _ALLOWED_TYPES = {"connector", "miner", "orchestrator", "utility", "custom"}
 
+# Channels for which ``deploy.env_overrides.<channel>`` actually takes
+# effect at GM's catalog read. Mirrors ``_OVERRIDABLE_CHANNELS`` in
+# ``core/release/config_resolver.py`` in global-marketplace. Bumping this
+# set is a coordinated change with GM.
+_OVERRIDABLE_CHANNELS = {"beta", "staging"}
+
 # Required keys for each entrypoints entry. description and icon_url
 # are optional (default empty string on GM side).
 # generated_dir is auto-derived from name (Option B: name == folder) so it is
@@ -124,6 +130,44 @@ def _validate_entrypoints(wp_val: Any) -> str:
     return json.dumps(wp_val, separators=(",", ":"))
 
 
+def _validate_env_overrides(deploy_val: Any) -> None:
+    """Validate ``deploy.env_overrides`` shape, if present.
+
+    GM's resolver is intentionally lenient (silent no-op on malformed input)
+    so a typo'd channel name would ship the base config to that channel with
+    no signal to the developer. We fail CI fast instead.
+
+    Allowed shape::
+
+        deploy:
+          env_overrides:
+            beta:    {KEY: value, ...}
+            staging: {KEY: value, ...}
+
+    Only channels in ``_OVERRIDABLE_CHANNELS`` are accepted; bumping that set
+    is a coordinated change with GM's ``config_resolver._OVERRIDABLE_CHANNELS``.
+    """
+    if not isinstance(deploy_val, dict):
+        return
+    overrides = deploy_val.get("env_overrides")
+    if overrides is None:
+        return
+    if not isinstance(overrides, dict):
+        _err("deploy.env_overrides must be a mapping of channel → env vars")
+    unknown = set(overrides.keys()) - _OVERRIDABLE_CHANNELS
+    if unknown:
+        _err(
+            f"deploy.env_overrides has unknown channel(s) {sorted(unknown)}; "
+            f"allowed: {sorted(_OVERRIDABLE_CHANNELS)}"
+        )
+    for channel, env in overrides.items():
+        if not isinstance(env, dict):
+            _err(
+                f"deploy.env_overrides.{channel} must be a mapping of env vars; "
+                f"got {type(env).__name__}"
+            )
+
+
 def _read_sdk_version_from_uv_lock(path: str = "uv.lock") -> str:
     """Best-effort read of the locked atlan-application-sdk version.
 
@@ -183,6 +227,7 @@ def parse(
         )
 
     deploy_val = d.get("deploy")
+    _validate_env_overrides(deploy_val)
     deploy_config = (
         yaml.dump(deploy_val, default_flow_style=False)
         if deploy_val is not None

--- a/application_sdk/app/_context_errors.py
+++ b/application_sdk/app/_context_errors.py
@@ -1,0 +1,29 @@
+"""Typed precondition error subclasses for missing store configurations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from application_sdk.errors import PreconditionError
+
+
+@dataclass(kw_only=True)
+class NoStateStoreError(PreconditionError):
+    """No state store configured — call App.load() with a state store first."""
+
+    code: ClassVar[str] = "PRECONDITION_NO_STATE_STORE"
+
+
+@dataclass(kw_only=True)
+class NoSecretStoreError(PreconditionError):
+    """No secret store configured — call App.load() with a secret store first."""
+
+    code: ClassVar[str] = "PRECONDITION_NO_SECRET_STORE"
+
+
+@dataclass(kw_only=True)
+class NoObjectStoreError(PreconditionError):
+    """No object store configured — call App.load() with an object store first."""
+
+    code: ClassVar[str] = "PRECONDITION_NO_OBJECT_STORE"

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -20,6 +20,7 @@ import obstore as obs
 from temporalio import activity, workflow
 from temporalio.exceptions import FailureError
 
+from application_sdk.app._context_errors import NoObjectStoreError
 from application_sdk.app.context import (
     AppContext,
     TaskExecutionContext,
@@ -52,6 +53,7 @@ from application_sdk.errors import (
     APP_ERROR,
     APP_NON_RETRYABLE,
     ErrorCode,
+    UnimplementedError,
 )
 from application_sdk.errors.base import AppError as _NewAppError
 from application_sdk.errors.leaves import InternalError as _InternalError
@@ -897,8 +899,10 @@ class App(ABC):
         Returns:
             The typed output dataclass.
         """
-        raise NotImplementedError(
-            f"{type(self).__name__} must implement run() or define @entrypoint methods."
+        raise UnimplementedError(
+            message="Subclass must implement run()",
+            operation="run",
+            reason="subclass_must_override",
         )
 
     def continue_with(self, input: Input) -> Never:
@@ -983,10 +987,7 @@ class App(ABC):
 
         store = self.context.storage
         if store is None:
-            raise RuntimeError(
-                "No object store configured. "
-                "Ensure the deployment has a storage binding or APP_STORAGE_ROOT set."
-            )
+            raise NoObjectStoreError(message="No object store configured")
         run_prefix = f"artifacts/apps/{self._app_name}/workflows/{self.context.run_id}"
         app_prefix = input.tier.upload_prefix(
             run_prefix=run_prefix, app_name=self._app_name
@@ -1044,10 +1045,7 @@ class App(ABC):
 
         store = self.context.storage
         if store is None:
-            raise RuntimeError(
-                "No object store configured. "
-                "Ensure the deployment has a storage binding or APP_STORAGE_ROOT set."
-            )
+            raise NoObjectStoreError(message="No object store configured")
 
         # Resolve storage_path: explicit field takes precedence over ref.storage_path
         storage_path = input.storage_path

--- a/application_sdk/app/context.py
+++ b/application_sdk/app/context.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 from loguru import logger as _loguru_logger
 from temporalio import workflow as _workflow
 
+from application_sdk.app._context_errors import NoSecretStoreError, NoStateStoreError
 from application_sdk.contracts.base import HeartbeatDetails
 from application_sdk.credentials.resolver import CredentialResolver
 from application_sdk.observability.context import get_execution_context
@@ -263,7 +264,7 @@ class AppContext:
             RuntimeError: If no state store is configured.
         """
         if self._state_store is None:
-            raise RuntimeError("No state store configured")
+            raise NoStateStoreError(message="No state store configured")
         namespaced_key = f"{self.app_name}:{self.run_id}:{key}"
         await self._state_store.save(namespaced_key, value)
 
@@ -280,7 +281,7 @@ class AppContext:
             RuntimeError: If no state store is configured.
         """
         if self._state_store is None:
-            raise RuntimeError("No state store configured")
+            raise NoStateStoreError(message="No state store configured")
         namespaced_key = f"{self.app_name}:{self.run_id}:{key}"
         return await self._state_store.load(namespaced_key)
 
@@ -297,7 +298,7 @@ class AppContext:
             RuntimeError: If no secret store is configured.
         """
         if self._secret_store is None:
-            raise RuntimeError("No secret store configured")
+            raise NoSecretStoreError(message="No secret store configured")
         return await self._secret_store.get(name)
 
     async def get_secret_optional(self, name: str) -> str | None:
@@ -353,7 +354,7 @@ class AppContext:
             CredentialParseError: If parsing fails.
         """
         if self._secret_store is None:
-            raise RuntimeError("No secret store configured")
+            raise NoSecretStoreError(message="No secret store configured")
         resolver = CredentialResolver(self._secret_store)
         return await resolver.resolve(ref)
 
@@ -370,7 +371,7 @@ class AppContext:
             RuntimeError: If no secret store is configured.
         """
         if self._secret_store is None:
-            raise RuntimeError("No secret store configured")
+            raise NoSecretStoreError(message="No secret store configured")
         resolver = CredentialResolver(self._secret_store)
         return await resolver.resolve_raw(ref)
 

--- a/application_sdk/clients/_interface.py
+++ b/application_sdk/clients/_interface.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
+from application_sdk.errors import UnimplementedError
+
 
 class ClientInterface(ABC):
     """Base interface class for implementing client connections.
@@ -17,9 +19,13 @@ class ClientInterface(ABC):
         for the specific client implementation.
 
         Raises:
-            NotImplementedError: If the subclass does not implement this method.
+            UnimplementedError: If the subclass does not implement this method.
         """
-        raise NotImplementedError("load method is not implemented")
+        raise UnimplementedError(
+            message="Subclass must implement load()",
+            operation="load",
+            reason="subclass_must_override",
+        )
 
     async def close(self, *args: Any, **kwargs: Any) -> None:
         """Close the client connection.

--- a/application_sdk/clients/_redis_errors.py
+++ b/application_sdk/clients/_redis_errors.py
@@ -1,0 +1,48 @@
+"""Typed Redis error subclasses — stable wire codes for the Redis client."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from application_sdk.errors import (
+    AppTimeoutError,
+    AuthError,
+    DependencyUnavailableError,
+    InvalidInputError,
+)
+
+
+@dataclass(kw_only=True)
+class RedisConnectionError(DependencyUnavailableError):
+    """Redis service is unreachable or the connection failed."""
+
+    code: ClassVar[str] = "DEPENDENCY_UNAVAILABLE_REDIS_CONNECTION"
+
+
+@dataclass(kw_only=True)
+class RedisTimeoutError(AppTimeoutError):
+    """Redis operation timed out."""
+
+    code: ClassVar[str] = "TIMEOUT_REDIS_OPERATION"
+
+
+@dataclass(kw_only=True)
+class RedisAuthError(AuthError):
+    """Redis authentication failed."""
+
+    code: ClassVar[str] = "AUTH_REDIS"
+
+
+@dataclass(kw_only=True)
+class RedisProtocolError(DependencyUnavailableError):
+    """Redis returned an unexpected response or protocol error."""
+
+    code: ClassVar[str] = "DEPENDENCY_UNAVAILABLE_REDIS_PROTOCOL"
+
+
+@dataclass(kw_only=True)
+class RedisConfigError(InvalidInputError):
+    """Redis configuration is missing or invalid."""
+
+    code: ClassVar[str] = "INVALID_INPUT_REDIS_CONFIG"

--- a/application_sdk/clients/_sql_errors.py
+++ b/application_sdk/clients/_sql_errors.py
@@ -1,0 +1,105 @@
+"""Typed SQL client error subclasses.
+
+Each subclass encodes the static defaults (message, evidence fields) plus a
+specific ``code`` that lands on the FailureDetails wire envelope. Raise sites
+override only what is genuinely dynamic. Follows the WorkerEvictedError
+precedent in application_sdk/errors/leaves.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from application_sdk.errors import (
+    AuthError,
+    InternalError,
+    InvalidInputError,
+    UnimplementedError,
+)
+
+
+@dataclass(kw_only=True)
+class DBConfigNotSetError(InternalError):
+    """SQL client subclass did not set DB_CONFIG before use."""
+
+    code: ClassVar[str] = "INTERNAL_DB_CONFIG_NOT_SET"
+    message: str = "DB_CONFIG is not configured for this SQL client."
+    component: str | None = "sql_client"
+    invariant: str | None = "db_config_must_be_set"
+
+
+@dataclass(kw_only=True)
+class EngineNotInitializedError(InternalError):
+    """run_query / _execute_query called before load() initialised the engine."""
+
+    code: ClassVar[str] = "INTERNAL_ENGINE_NOT_INITIALIZED"
+    message: str = "Engine is not initialized. Call load() first."
+    component: str | None = "sql_client"
+    invariant: str | None = "load_before_use"
+
+
+@dataclass(kw_only=True)
+class EngineWrongTypeError(InternalError):
+    """Engine is a connection string when an SQLAlchemy engine object is required."""
+
+    code: ClassVar[str] = "INTERNAL_ENGINE_WRONG_TYPE"
+    message: str = "Engine should be an SQLAlchemy engine object, got str"
+    component: str | None = "sql_client"
+    invariant: str | None = "async_read_requires_engine_object"
+
+
+@dataclass(kw_only=True)
+class PandasResultTypeError(InternalError):
+    """_execute_async_read_operation(query, None) returned a non-DataFrame."""
+
+    code: ClassVar[str] = "INTERNAL_SQL_PANDAS"
+    message: str = "Unable to get pandas dataframe from SQL query results"
+    component: str | None = "sql_client"
+    invariant: str | None = "get_results_returns_dataframe"
+
+
+@dataclass(kw_only=True)
+class SqlClientAuthFailedError(AuthError):
+    """SQLAlchemy engine creation / first-connect failed during load().
+
+    Raise sites typically pass only ``cause=exc`` — the upstream exception
+    detail flows to the FailureDetails ``cause_repr`` via the base ``cause``
+    field, so the message stays static.
+    """
+
+    code: ClassVar[str] = "AUTH_SQL_CLIENT_FAILED"
+    message: str = "SQL client authentication failed"
+    auth_method: str | None = "sql"
+    failure_reason: str | None = "engine_load_failed"
+
+
+@dataclass(kw_only=True)
+class MissingRequiredFieldError(InvalidInputError):
+    """Required credential / connection-string parameter not provided.
+
+    Raise sites supply ``field=`` and an explicit ``message=`` that names
+    the user-facing context (e.g. "for IAM user authentication"); the
+    subclass only fixes the wire ``code``.
+    """
+
+    code: ClassVar[str] = "INVALID_INPUT_MISSING_FIELD"
+
+
+@dataclass(kw_only=True)
+class InvalidAuthTypeError(InvalidInputError):
+    """credentials.authType not in {basic, iam_user, iam_role}."""
+
+    code: ClassVar[str] = "INVALID_INPUT_AUTH_TYPE"
+    field: str | None = "authType"
+    constraint: str | None = "one_of:basic,iam_user,iam_role"
+
+
+@dataclass(kw_only=True)
+class UnsupportedCursorError(UnimplementedError):
+    """DBAPI driver did not return a usable cursor for server-side cursor mode."""
+
+    code: ClassVar[str] = "UNIMPLEMENTED_CURSOR_TYPE"
+    message: str = "Cursor is not supported by this driver"
+    operation: str | None = "sql_cursor"
+    reason: str | None = "dbapi_cursor_unavailable"

--- a/application_sdk/clients/azure/_azure_errors.py
+++ b/application_sdk/clients/azure/_azure_errors.py
@@ -1,0 +1,41 @@
+"""Typed Azure error subclasses — stable wire codes for the Azure client."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from application_sdk.errors import (
+    AuthError,
+    DependencyUnavailableError,
+    InvalidInputError,
+    PreconditionError,
+)
+
+
+@dataclass(kw_only=True)
+class AzureAuthError(AuthError):
+    """Azure authentication failed (token or service principal)."""
+
+    code: ClassVar[str] = "AUTH_AZURE"
+
+
+@dataclass(kw_only=True)
+class AzureConnectionError(DependencyUnavailableError):
+    """Azure service is unreachable or returned an error."""
+
+    code: ClassVar[str] = "DEPENDENCY_UNAVAILABLE_AZURE"
+
+
+@dataclass(kw_only=True)
+class AzureCredentialParseError(InvalidInputError):
+    """Azure credential parameters are missing or malformed."""
+
+    code: ClassVar[str] = "INVALID_INPUT_AZURE_CREDENTIALS"
+
+
+@dataclass(kw_only=True)
+class AzureNoCredentialError(PreconditionError):
+    """No Azure credential available — call load() first."""
+
+    code: ClassVar[str] = "PRECONDITION_AZURE_NO_CREDENTIAL"

--- a/application_sdk/clients/azure/auth.py
+++ b/application_sdk/clients/azure/auth.py
@@ -42,7 +42,7 @@ Example:
     ...         auth_type="service_principal",
     ...         credentials={"tenant_id": "only-tenant"}  # Missing client_id and client_secret
     ...     )
-    ... except CommonError as e:
+    ... except AzureCredentialParseError as e:
     ...     print(f"Authentication failed: {e}")
     ...     # Output: Authentication failed: Missing required credential keys: client_id, client_secret
     >>>
@@ -52,12 +52,12 @@ Example:
     ...         auth_type="unsupported_type",
     ...         credentials=credentials
     ...     )
-    ... except CommonError as e:
+    ... except AzureCredentialParseError as e:
     ...     print(f"Authentication failed: {e}")
     ...     # Output: Authentication failed: Only 'service_principal' authentication is supported. Received: unsupported_type
 """
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 from azure.core.credentials import TokenCredential
 from azure.core.exceptions import ClientAuthenticationError
@@ -65,7 +65,10 @@ from azure.identity import ClientSecretCredential
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from application_sdk.clients.azure import AZURE_MANAGEMENT_API_ENDPOINT
-from application_sdk.common.error_codes import CommonError
+from application_sdk.clients.azure._azure_errors import (
+    AzureAuthError,
+    AzureCredentialParseError,
+)
 from application_sdk.execution.heartbeat import run_in_thread
 from application_sdk.observability.logger_adaptor import get_logger
 
@@ -121,12 +124,11 @@ class AzureAuthProvider:
 
     def __init__(self):
         """Initialize the Azure authentication provider."""
-        pass
 
     async def create_credential(
         self,
         auth_type: str = "service_principal",
-        credentials: Optional[Dict[str, Any]] = None,
+        credentials: dict[str, Any] | None = None,
     ) -> TokenCredential:
         """
         Create Azure credential using Service Principal authentication.
@@ -141,44 +143,54 @@ class AzureAuthProvider:
             TokenCredential: Azure credential instance.
 
         Raises:
-            CommonError: If authentication type is not supported or credentials are invalid.
-            ClientAuthenticationError: If credential creation fails.
+            AzureCredentialParseError: If authentication type is not supported or credentials are invalid.
+            AzureAuthError: If credential creation fails.
         """
         try:
             logger.debug("Creating Azure credential: %s", auth_type)
 
             if auth_type.lower() != "service_principal":
-                raise CommonError(
-                    f"{CommonError.CREDENTIALS_PARSE_ERROR}: "
-                    f"Only 'service_principal' authentication is supported. "
-                    f"Received: {auth_type}"
+                raise AzureCredentialParseError(
+                    message=f"Only 'service_principal' authentication is supported. Received: {auth_type!r}",
+                    field="auth_type",
+                    value_summary=auth_type,
                 )
 
             if not credentials:
-                raise CommonError(
-                    f"{CommonError.CREDENTIALS_PARSE_ERROR}: "
-                    "Credentials required for service principal authentication"
+                raise AzureCredentialParseError(
+                    message="Credentials required for service principal authentication",
+                    field="credentials",
                 )
 
             return await self._create_service_principal_credential(credentials)
 
         except ClientAuthenticationError as e:
-            raise CommonError(f"{CommonError.AZURE_CREDENTIAL_ERROR}: {str(e)}") from e
+            raise AzureAuthError(
+                message=str(e),
+                auth_method="azure_service_principal",
+                cause=e,
+            ) from e
         except ValueError as e:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: Invalid credential parameters - {str(e)}"
+            raise AzureCredentialParseError(
+                message=f"Invalid credential parameters: {e!s}",
+                field="credentials",
+                cause=e,
             ) from e
         except TypeError as e:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: Invalid credential parameter types - {str(e)}"
+            raise AzureCredentialParseError(
+                message=f"Invalid credential parameter types: {e!s}",
+                field="credentials",
+                cause=e,
             ) from e
         except Exception as e:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: Unexpected error - {str(e)}"
+            raise AzureCredentialParseError(
+                message=f"Unexpected error during credential creation: {e!s}",
+                field="credentials",
+                cause=e,
             ) from e
 
     async def _create_service_principal_credential(
-        self, credentials: Dict[str, Any]
+        self, credentials: dict[str, Any]
     ) -> ClientSecretCredential:
         """
         Create service principal credential.
@@ -191,12 +203,12 @@ class AzureAuthProvider:
             ClientSecretCredential: Service principal credential.
 
         Raises:
-            CommonError: If required credentials are missing or invalid.
+            AzureCredentialParseError: If required credentials are missing or invalid.
         """
         if not credentials:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: "
-                "Credentials required for service principal authentication"
+            raise AzureCredentialParseError(
+                message="Credentials required for service principal authentication",
+                field="credentials",
             )
 
         try:
@@ -212,8 +224,10 @@ class AzureAuthProvider:
                 ]
             )
             error_message = f"Invalid credential parameters: {error_details}"
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: {error_message}"
+            raise AzureCredentialParseError(
+                message=error_message,
+                field="credentials",
+                cause=e,
             ) from e
 
         logger.debug(
@@ -229,18 +243,28 @@ class AzureAuthProvider:
                 validated_credentials.client_secret,
             )
         except ValueError as e:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: Invalid credential parameters - {str(e)}"
+            raise AzureCredentialParseError(
+                message=f"Invalid credential parameters: {e!s}",
+                field="credentials",
+                cause=e,
             ) from e
         except TypeError as e:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: Invalid credential parameter types - {str(e)}"
+            raise AzureCredentialParseError(
+                message=f"Invalid credential parameter types: {e!s}",
+                field="credentials",
+                cause=e,
             ) from e
         except ClientAuthenticationError as e:
-            raise CommonError(f"{CommonError.AZURE_CREDENTIAL_ERROR}: {str(e)}") from e
+            raise AzureAuthError(
+                message=str(e),
+                auth_method="azure_service_principal",
+                cause=e,
+            ) from e
         except Exception as e:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: Unexpected error - {str(e)}"
+            raise AzureCredentialParseError(
+                message=f"Unexpected error during credential creation: {e!s}",
+                field="credentials",
+                cause=e,
             ) from e
 
     async def validate_credential(self, credential: TokenCredential) -> bool:

--- a/application_sdk/clients/azure/client.py
+++ b/application_sdk/clients/azure/client.py
@@ -41,8 +41,13 @@ from pydantic import BaseModel
 
 from application_sdk.clients._interface import ClientInterface
 from application_sdk.clients.azure import AZURE_MANAGEMENT_API_ENDPOINT
+from application_sdk.clients.azure._azure_errors import (
+    AzureAuthError,
+    AzureCredentialParseError,
+    AzureNoCredentialError,
+)
 from application_sdk.clients.azure.auth import AzureAuthProvider
-from application_sdk.common.error_codes import ClientError
+from application_sdk.errors import AppError
 from application_sdk.execution.heartbeat import run_in_thread
 from application_sdk.observability.logger_adaptor import get_logger
 
@@ -129,14 +134,18 @@ class AzureClient(ClientInterface):
                 Must include tenant_id, client_id, and client_secret.
 
         Raises:
-            ClientError: If connection fails due to authentication or connection issues
+            AzureNoCredentialError: If the client has been closed.
+            AzureAuthError: If connection fails due to authentication issues.
+            AzureCredentialParseError: If credential parameters are invalid.
         """
         if credentials:
             self.credentials = credentials
 
         if self._executor is None:
-            raise ClientError(
-                f"{ClientError.CLIENT_AUTH_ERROR}: client has been closed; instantiate a new AzureClient"
+            raise AzureNoCredentialError(
+                message="Azure client has been closed; instantiate a new AzureClient",
+                resource="azure_client",
+                expected_state="open",
             )
 
         try:
@@ -182,22 +191,36 @@ class AzureClient(ClientInterface):
             logger.info("Azure client loaded successfully")
 
         except ClientAuthenticationError as e:
-            raise ClientError(f"{ClientError.CLIENT_AUTH_ERROR}: {e!s}") from e
+            raise AzureAuthError(
+                message=str(e),
+                auth_method="azure_service_principal",
+                cause=e,
+            ) from e
         except AzureError as e:
-            raise ClientError(f"{ClientError.CLIENT_AUTH_ERROR}: {e!s}") from e
+            raise AzureAuthError(
+                message=str(e),
+                auth_method="azure_service_principal",
+                cause=e,
+            ) from e
         except ValueError as e:
-            raise ClientError(
-                f"{ClientError.INPUT_VALIDATION_ERROR}: Invalid parameters - {e!s}"
+            raise AzureCredentialParseError(
+                message=f"Invalid parameters: {e!s}",
+                field="credentials",
+                cause=e,
             ) from e
         except TypeError as e:
-            raise ClientError(
-                f"{ClientError.INPUT_VALIDATION_ERROR}: Invalid parameter types - {e!s}"
+            raise AzureCredentialParseError(
+                message=f"Invalid parameter types: {e!s}",
+                field="credentials",
+                cause=e,
             ) from e
-        except ClientError:
+        except AppError:
             raise
         except Exception as e:
-            raise ClientError(
-                f"{ClientError.CLIENT_AUTH_ERROR}: Unexpected error - {e!s}"
+            raise AzureAuthError(
+                message=f"Unexpected error: {e!s}",
+                auth_method="azure_service_principal",
+                cause=e,
             ) from e
 
     async def close(self) -> None:
@@ -296,11 +319,14 @@ class AzureClient(ClientInterface):
         Test the Azure connection by attempting to get a token.
 
         Raises:
-            ClientAuthenticationError: If connection test fails.
+            AzureNoCredentialError: If no credential is available.
+            AzureAuthError: If connection test fails.
         """
         if not self.credential:
-            raise ClientError(
-                f"{ClientError.AUTH_CREDENTIALS_ERROR}: No credential available for connection test"
+            raise AzureNoCredentialError(
+                message="No credential available for connection test",
+                resource="azure_credential",
+                expected_state="credential_loaded",
             )
 
         try:
@@ -309,16 +335,28 @@ class AzureClient(ClientInterface):
                 self.credential.get_token, AZURE_MANAGEMENT_API_ENDPOINT
             )
         except ClientAuthenticationError as e:
-            raise ClientError(f"{ClientError.CLIENT_AUTH_ERROR}: {e!s}") from e
+            raise AzureAuthError(
+                message=str(e),
+                auth_method="azure_service_principal",
+                cause=e,
+            ) from e
         except AzureError as e:
-            raise ClientError(f"{ClientError.CLIENT_AUTH_ERROR}: {e!s}") from e
+            raise AzureAuthError(
+                message=str(e),
+                auth_method="azure_service_principal",
+                cause=e,
+            ) from e
         except ValueError as e:
-            raise ClientError(
-                f"{ClientError.INPUT_VALIDATION_ERROR}: Invalid parameters - {e!s}"
+            raise AzureCredentialParseError(
+                message=f"Invalid parameters: {e!s}",
+                field="credentials",
+                cause=e,
             ) from e
         except Exception as e:
-            raise ClientError(
-                f"{ClientError.CLIENT_AUTH_ERROR}: Unexpected error - {e!s}"
+            raise AzureAuthError(
+                message=f"Unexpected error: {e!s}",
+                auth_method="azure_service_principal",
+                cause=e,
             ) from e
 
     def __enter__(self):

--- a/application_sdk/clients/base.py
+++ b/application_sdk/clients/base.py
@@ -13,6 +13,7 @@ from httpx._types import (
 from application_sdk.clients._interface import ClientInterface
 from application_sdk.clients.ssl_utils import get_ssl_context
 from application_sdk.constants import _HTTP_POOL_LIMITS, _HTTP_POOL_TIMEOUT_SECONDS
+from application_sdk.errors import UnimplementedError
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -137,9 +138,13 @@ class BaseClient(ClientInterface):
                 create a custom http_retry_transport.
 
         Raises:
-            NotImplementedError: If the subclass does not implement this method.
+            UnimplementedError: If the subclass does not implement this method.
         """
-        raise NotImplementedError("load method is not implemented")
+        raise UnimplementedError(
+            message="Subclass must implement load()",
+            operation="load",
+            reason="subclass_must_override",
+        )
 
     async def execute_http_get_request(
         self,

--- a/application_sdk/clients/redis.py
+++ b/application_sdk/clients/redis.py
@@ -1,13 +1,18 @@
 """Redis client for distributed locking with high availability support."""
 
 from enum import Enum
-from typing import NoReturn, Union
+from typing import NoReturn
 
 import redis
 import redis.asyncio as async_redis
 from redis.exceptions import ConnectionError, RedisError, TimeoutError
 
-from application_sdk.common.error_codes import ClientError
+from application_sdk.clients._redis_errors import (
+    RedisConfigError,
+    RedisConnectionError,
+    RedisProtocolError,
+    RedisTimeoutError,
+)
 from application_sdk.common.exc_utils import rewrap
 from application_sdk.constants import (
     IS_LOCKING_DISABLED,
@@ -17,6 +22,7 @@ from application_sdk.constants import (
     REDIS_SENTINEL_HOSTS,
     REDIS_SENTINEL_SERVICE_NAME,
 )
+from application_sdk.errors import AppError
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -29,16 +35,35 @@ def _handle_redis_error(e: Exception) -> NoReturn:
         e: The Redis exception that occurred
 
     Raises:
-        ClientError: Appropriate ClientError based on exception type
+        AppError subclass: Appropriate typed error based on exception type
     """
-    if isinstance(e, ConnectionError):
-        raise ClientError(f"{ClientError.REDIS_CONNECTION_ERROR}: {e}") from e
-    elif isinstance(e, TimeoutError):
-        raise ClientError(f"{ClientError.REDIS_TIMEOUT_ERROR}: {e}") from e
+    if isinstance(e, TimeoutError):
+        raise RedisTimeoutError(
+            message=f"Redis operation timed out: {e}",
+            operation="redis_operation",
+            cause=e,
+        ) from e
+    elif isinstance(e, ConnectionError):
+        raise RedisConnectionError(
+            message=f"Redis connection failed: {e}",
+            service="redis",
+            network_error=str(e),
+            cause=e,
+        ) from e
     elif isinstance(e, RedisError):
-        raise ClientError(f"{ClientError.REDIS_PROTOCOL_ERROR}: {e}") from e
+        raise RedisProtocolError(
+            message=f"Redis protocol error: {e}",
+            service="redis",
+            network_error=str(e),
+            cause=e,
+        ) from e
     else:
-        raise ClientError(f"{ClientError.REDIS_CONNECTION_ERROR}: {e}") from e
+        raise RedisConnectionError(
+            message=f"Redis connection failed: {e}",
+            service="redis",
+            network_error=str(e),
+            cause=e,
+        ) from e
 
 
 class LockReleaseResult(Enum):
@@ -74,8 +99,9 @@ class BaseRedisClient:
         if not REDIS_PASSWORD or (
             not REDIS_SENTINEL_HOSTS and not (REDIS_HOST and REDIS_PORT)
         ):
-            raise ClientError(
-                f"{ClientError.REQUEST_VALIDATION_ERROR}: Redis configuration invalid - REDIS_PASSWORD is required and either REDIS_SENTINEL_HOSTS or REDIS_HOST/REDIS_PORT must be configured"
+            raise RedisConfigError(
+                message="Redis configuration invalid - REDIS_PASSWORD is required and either REDIS_SENTINEL_HOSTS or REDIS_HOST/REDIS_PORT must be configured",
+                field="REDIS_HOST_or_REDIS_SENTINEL_HOSTS",
             )
 
     def _parse_sentinel_hosts(self) -> list[tuple[str, int]]:
@@ -86,7 +112,7 @@ class BaseRedisClient:
 
         Raises:
             ValueError: If host format is invalid
-            ClientError: If no hosts are configured
+            RedisConfigError: If no hosts are configured
         """
         try:
             sentinel_hosts = [
@@ -100,14 +126,15 @@ class BaseRedisClient:
             ) from e
 
         if not sentinel_hosts:
-            raise ClientError(
-                f"{ClientError.REQUEST_VALIDATION_ERROR}: No Sentinel hosts configured"
+            raise RedisConfigError(
+                message="No Sentinel hosts configured",
+                field="REDIS_SENTINEL_HOSTS",
             )
 
         return sentinel_hosts
 
     def _process_lock_release_result(
-        self, result: Union[int, None], resource_id: str
+        self, result: int | None, resource_id: str
     ) -> tuple[bool, LockReleaseResult]:
         """Process lock release Lua script result.
 
@@ -119,7 +146,7 @@ class BaseRedisClient:
             tuple[bool, LockReleaseResult]: A tuple ``(success, outcome)``.
 
         Raises:
-            ClientError: If result type is unexpected or unknown.
+            RedisConnectionError: If result type is unexpected or unknown.
         """
         if not isinstance(result, int):
             logger.error(
@@ -128,8 +155,9 @@ class BaseRedisClient:
                 type(result),
                 result,
             )
-            raise ClientError(
-                f"{ClientError.REDIS_CONNECTION_ERROR}: Redis connection failed"
+            raise RedisConnectionError(
+                message="Redis connection failed: unexpected eval result",
+                service="redis",
             )
 
         if result >= 1:
@@ -147,8 +175,9 @@ class BaseRedisClient:
                 resource_id,
                 result,
             )
-            raise ClientError(
-                f"{ClientError.REDIS_CONNECTION_ERROR}: Redis connection failed"
+            raise RedisConnectionError(
+                message="Redis connection failed: unexpected eval result",
+                service="redis",
             )
 
 
@@ -174,14 +203,15 @@ class RedisClient(BaseRedisClient):
 
             # Test connection
             if not self.redis_client:
-                raise ClientError(
-                    f"{ClientError.REDIS_CONNECTION_ERROR}: Redis connection failed"
+                raise RedisConnectionError(
+                    message="Redis connection failed: no client after connect",
+                    service="redis",
                 )
 
             self.redis_client.ping()
             logger.info("Sync Redis connection established for strict locking")
 
-        except ClientError:
+        except AppError:
             raise
         except (ConnectionError, TimeoutError, RedisError, Exception) as e:
             _handle_redis_error(e)
@@ -256,11 +286,12 @@ class RedisClient(BaseRedisClient):
             True if lock was acquired, False if lock is already held by another owner
 
         Raises:
-            ClientError: If Redis connection or operation fails
+            RedisConnectionError: If Redis connection or operation fails
         """
         if not self.redis_client:
-            raise ClientError(
-                f"{ClientError.REDIS_CONNECTION_ERROR}: Redis connection failed"
+            raise RedisConnectionError(
+                message="Redis connection failed: no client for lock acquire",
+                service="redis",
             )
 
         try:
@@ -287,11 +318,12 @@ class RedisClient(BaseRedisClient):
                 - (False, LockReleaseResult.WRONG_OWNER): Lock owned by a different owner.
 
         Raises:
-            ClientError: If Redis connection or operation fails.
+            RedisConnectionError: If Redis connection or operation fails.
         """
         if not self.redis_client:
-            raise ClientError(
-                f"{ClientError.REDIS_CONNECTION_ERROR}: Redis connection failed"
+            raise RedisConnectionError(
+                message="Redis connection failed: no client for lock release",
+                service="redis",
             )
 
         try:
@@ -299,8 +331,8 @@ class RedisClient(BaseRedisClient):
                 _LOCK_RELEASE_LUA_SCRIPT, 1, resource_id, owner_id
             )
             return self._process_lock_release_result(result, resource_id)
-        except ClientError:
-            # `_process_lock_release_result` raises ClientError on unexpected
+        except AppError:
+            # `_process_lock_release_result` raises AppError subclasses on unexpected
             # results (carries a structured error code). Re-raise unchanged
             # instead of letting `_handle_redis_error` re-wrap it.
             raise
@@ -330,19 +362,18 @@ class RedisClientAsync(BaseRedisClient):
 
             # Test connection
             if not self.redis_client:
-                raise ClientError(
-                    f"{ClientError.REDIS_CONNECTION_ERROR}: Redis connection failed"
+                raise RedisConnectionError(
+                    message="Redis connection failed: no client after connect",
+                    service="redis",
                 )
 
             await self.redis_client.ping()
             logger.info("Async Redis connection established for strict locking")
 
-        except ClientError:
-            # Internal ClientError raised above (e.g. REDIS_CONNECTION_ERROR
-            # for missing redis_client) carries a structured error code that
-            # callers depend on. Re-raise unchanged instead of letting
-            # `_handle_redis_error` re-wrap it. Mirrors the sync `_connect`
-            # fix from BLDX-1165.
+        except AppError:
+            # Internal AppError raised above (e.g. RedisConnectionError for missing
+            # redis_client) carries a structured error code that callers depend on.
+            # Re-raise unchanged instead of letting `_handle_redis_error` re-wrap it.
             raise
         except (ConnectionError, TimeoutError, RedisError, Exception) as e:
             _handle_redis_error(e)
@@ -417,11 +448,12 @@ class RedisClientAsync(BaseRedisClient):
             True if lock was acquired, False if lock is already held by another owner
 
         Raises:
-            ClientError: If Redis connection or operation fails
+            RedisConnectionError: If Redis connection or operation fails
         """
         if not self.redis_client:
-            raise ClientError(
-                f"{ClientError.REDIS_CONNECTION_ERROR}: Redis connection failed"
+            raise RedisConnectionError(
+                message="Redis connection failed: no client for lock acquire",
+                service="redis",
             )
 
         try:
@@ -448,11 +480,12 @@ class RedisClientAsync(BaseRedisClient):
                 - (False, LockReleaseResult.WRONG_OWNER): Lock owned by a different owner.
 
         Raises:
-            ClientError: If Redis connection or operation fails.
+            RedisConnectionError: If Redis connection or operation fails.
         """
         if not self.redis_client:
-            raise ClientError(
-                f"{ClientError.REDIS_CONNECTION_ERROR}: Redis connection failed"
+            raise RedisConnectionError(
+                message="Redis connection failed: no client for lock release",
+                service="redis",
             )
 
         try:
@@ -460,8 +493,8 @@ class RedisClientAsync(BaseRedisClient):
                 _LOCK_RELEASE_LUA_SCRIPT, 1, resource_id, owner_id
             )
             return self._process_lock_release_result(result, resource_id)
-        except ClientError:
-            # `_process_lock_release_result` raises ClientError on unexpected
+        except AppError:
+            # `_process_lock_release_result` raises AppError subclasses on unexpected
             # results (carries a structured error code). Re-raise unchanged
             # instead of letting `_handle_redis_error` re-wrap it.
             raise

--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -95,7 +95,8 @@ class BaseSQLClient(ClientInterface):
             credentials (Dict[str, Any]): Database connection credentials.
 
         Raises:
-            ClientError: If credentials are invalid or engine creation fails
+            DBConfigNotSetError: If DB_CONFIG is not set on the client subclass.
+            SqlClientAuthFailedError: If engine creation or initial connection fails.
         """
         if not self.DB_CONFIG:
             raise DBConfigNotSetError()
@@ -161,7 +162,7 @@ class BaseSQLClient(ClientInterface):
             str: A temporary authentication token for database access.
 
         Raises:
-            CommonError: If required credentials (username or database) are missing.
+            MissingRequiredFieldError: If username or database is not present in credentials.
         """
         extra = parse_credentials_extra(self.credentials)
         aws_access_key_id = self.credentials.get("username")
@@ -204,7 +205,7 @@ class BaseSQLClient(ClientInterface):
             str: A temporary authentication token for database access.
 
         Raises:
-            CommonError: If required credentials (aws_role_arn or database) are missing.
+            MissingRequiredFieldError: If aws_role_arn or database is not present in credentials.
         """
         extra = parse_credentials_extra(self.credentials)
         aws_role_arn = extra.get("aws_role_arn")
@@ -250,7 +251,7 @@ class BaseSQLClient(ClientInterface):
             str: URL-encoded authentication token.
 
         Raises:
-            CommonError: If an invalid authentication type is specified.
+            InvalidAuthTypeError: If authType is not one of basic, iam_user, or iam_role.
         """
         authType = self.credentials.get("authType", "basic")  # Default to basic auth
         token = None
@@ -302,7 +303,8 @@ class BaseSQLClient(ClientInterface):
             str: Complete SQLAlchemy connection string.
 
         Raises:
-            ValueError: If required connection parameters are missing.
+            DBConfigNotSetError: If DB_CONFIG is not set on the client subclass.
+            MissingRequiredFieldError: If a required connection parameter is absent from credentials.
         """
         if not self.DB_CONFIG:
             raise DBConfigNotSetError()
@@ -361,8 +363,7 @@ class BaseSQLClient(ClientInterface):
                 a dictionary mapping column names to values.
 
         Raises:
-            ValueError: If engine is not initialized.
-            Exception: If query execution fails.
+            EngineNotInitializedError: If load() has not been called before run_query().
         """
         if not self.engine:
             raise EngineNotInitializedError()
@@ -530,8 +531,7 @@ class BaseSQLClient(ClientInterface):
             AsyncIterator["pd.DataFrame"]: Async iterator yielding batches of query results.
 
         Raises:
-            ValueError: If engine is a string instead of SQLAlchemy engine.
-            Exception: If there's an error executing the query.
+            EngineWrongTypeError: If engine is a connection string rather than an AsyncEngine.
         """
         try:
             # We cast to Iterator because passing chunk_size guarantees an Iterator return
@@ -547,8 +547,8 @@ class BaseSQLClient(ClientInterface):
             pd.DataFrame: Query results as a DataFrame.
 
         Raises:
-            ValueError: If engine is a string instead of SQLAlchemy engine.
-            Exception: If there's an error executing the query.
+            EngineWrongTypeError: If engine is a connection string rather than an AsyncEngine.
+            PandasResultTypeError: If the query result is not a DataFrame when chunksize is None.
         """
         try:
             result = await self._execute_async_read_operation(query, None)
@@ -590,7 +590,8 @@ class AsyncBaseSQLClient(BaseSQLClient):
                 host, port, username, password, and other connection parameters.
 
         Raises:
-            ValueError: If credentials are invalid or engine creation fails.
+            DBConfigNotSetError: If DB_CONFIG is not set on the client subclass.
+            SqlClientAuthFailedError: If async engine creation or initial connection fails.
         """
         self.credentials = credentials
         if not self.DB_CONFIG:
@@ -650,8 +651,7 @@ class AsyncBaseSQLClient(BaseSQLClient):
                 a dictionary mapping column names to values.
 
         Raises:
-            ValueError: If engine is not initialized.
-            Exception: If query execution fails.
+            EngineNotInitializedError: If load() has not been called before run_query().
         """
         if not self.engine:
             raise EngineNotInitializedError()

--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -14,13 +14,22 @@ from typing import TYPE_CHECKING, Any, Union, cast
 from urllib.parse import quote_plus
 
 from application_sdk.clients._interface import ClientInterface
+from application_sdk.clients._sql_errors import (
+    DBConfigNotSetError,
+    EngineNotInitializedError,
+    EngineWrongTypeError,
+    InvalidAuthTypeError,
+    MissingRequiredFieldError,
+    PandasResultTypeError,
+    SqlClientAuthFailedError,
+    UnsupportedCursorError,
+)
 from application_sdk.clients.models import DatabaseConfig
 from application_sdk.clients.sql_typecasters import install_tolerant_text_decoder_hook
 from application_sdk.common.aws_utils import (
     generate_aws_rds_token_with_iam_role,
     generate_aws_rds_token_with_iam_user,
 )
-from application_sdk.common.error_codes import ClientError, CommonError
 from application_sdk.common.exc_utils import rewrap
 from application_sdk.constants import AWS_SESSION_NAME, USE_SERVER_SIDE_CURSOR
 from application_sdk.credentials.utils import parse_credentials_extra
@@ -89,7 +98,7 @@ class BaseSQLClient(ClientInterface):
             ClientError: If credentials are invalid or engine creation fails
         """
         if not self.DB_CONFIG:
-            raise ValueError("DB_CONFIG is not configured for this SQL client.")
+            raise DBConfigNotSetError()
 
         self.credentials = credentials  # Update the instance credentials
         try:
@@ -132,7 +141,7 @@ class BaseSQLClient(ClientInterface):
             if self.engine:
                 self.engine.dispose()
                 self.engine = None
-            raise ClientError(f"{ClientError.SQL_CLIENT_AUTH_ERROR}: {e!s}") from e
+            raise SqlClientAuthFailedError(cause=e) from e
 
     async def close(self) -> None:
         """Close the database connection."""
@@ -161,12 +170,14 @@ class BaseSQLClient(ClientInterface):
         user = extra.get("username")
         database = extra.get("database")
         if not user:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: username is required for IAM user authentication"
+            raise MissingRequiredFieldError(
+                message="username is required for IAM user authentication",
+                field="username",
             )
         if not database:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: database is required for IAM user authentication"
+            raise MissingRequiredFieldError(
+                message="database is required for IAM user authentication",
+                field="database",
             )
 
         port = self.credentials.get("port")
@@ -201,12 +212,14 @@ class BaseSQLClient(ClientInterface):
         external_id = extra.get("aws_external_id")
 
         if not aws_role_arn:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: aws_role_arn is required for IAM role authentication"
+            raise MissingRequiredFieldError(
+                message="aws_role_arn is required for IAM role authentication",
+                field="aws_role_arn",
             )
         if not database:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: database is required for IAM role authentication"
+            raise MissingRequiredFieldError(
+                message="database is required for IAM role authentication",
+                field="database",
             )
 
         session_name = AWS_SESSION_NAME
@@ -250,7 +263,7 @@ class BaseSQLClient(ClientInterface):
             case "basic":
                 token = self.credentials.get("password")
             case _:
-                raise CommonError(f"{CommonError.CREDENTIALS_PARSE_ERROR}: {authType}")
+                raise InvalidAuthTypeError(message=f"Unsupported authType: {authType}")
 
         # Handle None values and ensure token is a string before encoding
         encoded_token = quote_plus(str(token or ""))
@@ -292,7 +305,7 @@ class BaseSQLClient(ClientInterface):
             ValueError: If required connection parameters are missing.
         """
         if not self.DB_CONFIG:
-            raise ValueError("DB_CONFIG is not configured for this SQL client.")
+            raise DBConfigNotSetError()
 
         extra = parse_credentials_extra(self.credentials)
 
@@ -306,7 +319,10 @@ class BaseSQLClient(ClientInterface):
             else:
                 value = self.credentials.get(param) or extra.get(param)
                 if value is None:
-                    raise ValueError(f"{param} is required")
+                    raise MissingRequiredFieldError(
+                        message=f"{param} is required",
+                        field=param,
+                    )
                 param_values[param] = value
 
         # Fill in base template
@@ -349,7 +365,7 @@ class BaseSQLClient(ClientInterface):
             Exception: If query execution fails.
         """
         if not self.engine:
-            raise ValueError("Engine is not initialized. Call load() first.")
+            raise EngineNotInitializedError()
 
         loop = asyncio.get_running_loop()
         logger.debug(
@@ -370,7 +386,7 @@ class BaseSQLClient(ClientInterface):
                     pool, connection.execute, text(query)
                 )
                 if not cursor or not cursor.cursor:
-                    raise ValueError("Cursor is not supported")
+                    raise UnsupportedCursorError()
                 column_names: list[str] = [
                     description.name.lower()
                     for description in cursor.cursor.description
@@ -444,7 +460,7 @@ class BaseSQLClient(ClientInterface):
         # Guard must come before the daft import: daft's Rust OTel extension can
         # raise BaseException at import time, which would prevent this check from running.
         if not self.engine:
-            raise ValueError("Engine is not initialized. Call load() first.")
+            raise EngineNotInitializedError()
 
         # Daft uses ConnectorX to read data from SQL by default for supported connectors
         # If a connection string is passed, it will use ConnectorX to read data
@@ -465,7 +481,7 @@ class BaseSQLClient(ClientInterface):
                 or iterator of DataFrames if chunked.
         """
         if not self.engine:
-            raise ValueError("Engine is not initialized. Call load() first.")
+            raise EngineNotInitializedError()
 
         with self.engine.connect() as conn:
             return self._execute_pandas_query(conn, query, chunksize)
@@ -475,7 +491,7 @@ class BaseSQLClient(ClientInterface):
     ) -> Union["pd.DataFrame", Iterator["pd.DataFrame"]]:
         """Helper to execute async read operation with either async session or thread executor."""
         if isinstance(self.engine, str):
-            raise ValueError("Engine should be an SQLAlchemy engine object")
+            raise EngineWrongTypeError()
 
         from sqlalchemy.ext.asyncio import (  # noqa: PLC0415 — optional dep: sqlalchemy
             AsyncEngine,
@@ -540,7 +556,7 @@ class BaseSQLClient(ClientInterface):
 
             if isinstance(result, pd.DataFrame):
                 return result
-            raise Exception("Unable to get pandas dataframe from SQL query results")
+            raise PandasResultTypeError()
 
         except Exception as e:
             raise rewrap(e, "Error reading data(pandas) from SQL") from e
@@ -578,7 +594,7 @@ class AsyncBaseSQLClient(BaseSQLClient):
         """
         self.credentials = credentials
         if not self.DB_CONFIG:
-            raise ValueError("DB_CONFIG is not configured for this SQL client.")
+            raise DBConfigNotSetError()
 
         try:
             from sqlalchemy.ext.asyncio import (  # noqa: PLC0415 — optional dep: sqlalchemy
@@ -608,7 +624,7 @@ class AsyncBaseSQLClient(BaseSQLClient):
             if self.engine:
                 await self.engine.dispose()
                 self.engine = None
-            raise ClientError(f"{ClientError.SQL_CLIENT_AUTH_ERROR}: {e!s}") from e
+            raise SqlClientAuthFailedError(cause=e) from e
 
     async def close(self) -> None:
         """Close the async database connection and dispose of the engine."""
@@ -638,7 +654,7 @@ class AsyncBaseSQLClient(BaseSQLClient):
             Exception: If query execution fails.
         """
         if not self.engine:
-            raise ValueError("Engine is not initialized. Call load() first.")
+            raise EngineNotInitializedError()
 
         logger.debug(
             "Running query (sha=%s, len=%d)",

--- a/application_sdk/common/aws_utils.py
+++ b/application_sdk/common/aws_utils.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any
 
 from application_sdk.constants import AWS_SESSION_NAME
+from application_sdk.errors import (
+    AppPermissionDeniedError,
+    AuthError,
+    DependencyUnavailableError,
+    InvalidInputError,
+)
 
 if TYPE_CHECKING:
     import boto3
@@ -32,7 +38,11 @@ def get_region_name_from_hostname(hostname: str) -> str:
     match = re.search(r"-([a-z]{2}-[a-z]+-\d)\.", hostname)
     if match:
         return match.group(1)
-    raise ValueError("Could not find valid AWS region from hostname")
+    raise InvalidInputError(
+        message="Could not find valid AWS region from hostname",
+        field="hostname",
+        value_summary=hostname,
+    )
 
 
 def generate_aws_rds_token_with_iam_role(
@@ -84,7 +94,12 @@ def generate_aws_rds_token_with_iam_role(
         return token
 
     except ClientError as e:
-        raise Exception(f"Failed to assume role: {str(e)}") from e
+        raise AppPermissionDeniedError(
+            message=f"Failed to assume role: {e!s}",
+            resource=role_arn,
+            required_action="sts:AssumeRole",
+            cause=e,
+        ) from e
 
 
 def generate_aws_rds_token_with_iam_user(
@@ -122,10 +137,14 @@ def generate_aws_rds_token_with_iam_user(
         )
         return token
     except Exception as e:
-        raise Exception(f"Failed to get user credentials: {str(e)}") from e
+        raise AuthError(
+            message=f"Failed to get user credentials: {e!s}",
+            auth_method="aws_iam_user",
+            cause=e,
+        ) from e
 
 
-def get_cluster_identifier(aws_client) -> Optional[str]:
+def get_cluster_identifier(aws_client) -> str | None:
     """
     Retrieve the cluster identifier from AWS Redshift clusters.
 
@@ -149,7 +168,7 @@ def get_cluster_identifier(aws_client) -> Optional[str]:
     return None
 
 
-def create_aws_session(credentials: Dict[str, Any]) -> boto3.Session:
+def create_aws_session(credentials: dict[str, Any]) -> boto3.Session:
     """
     Create a boto3 session with AWS credentials.
 
@@ -175,8 +194,8 @@ def create_aws_session(credentials: Dict[str, Any]) -> boto3.Session:
 
 
 def get_cluster_credentials(
-    aws_client, credentials: Dict[str, Any], extra: Dict[str, Any]
-) -> Dict[str, str]:
+    aws_client, credentials: dict[str, Any], extra: dict[str, Any]
+) -> dict[str, str]:
     """
     Retrieve cluster credentials using IAM authentication.
 
@@ -200,8 +219,8 @@ def get_cluster_credentials(
 def create_aws_client(
     service: str,
     region: str,
-    session: Optional[boto3.Session] = None,
-    temp_credentials: Optional[Dict[str, str]] = None,
+    session: boto3.Session | None = None,
+    temp_credentials: dict[str, str] | None = None,
     use_default_credentials: bool = False,
 ) -> Any:
     """
@@ -259,9 +278,15 @@ def create_aws_client(
     )
 
     if credential_sources == 0:
-        raise ValueError("At least one credential source must be provided")
+        raise InvalidInputError(
+            message="At least one credential source must be provided",
+            field="credential_sources",
+        )
     if credential_sources > 1:
-        raise ValueError("Only one credential source should be provided at a time")
+        raise InvalidInputError(
+            message="Only one credential source should be provided at a time",
+            field="credential_sources",
+        )
 
     import boto3  # noqa: PLC0415 — optional dep: boto3
 
@@ -300,14 +325,18 @@ def create_aws_client(
             return boto3.client(service, region_name=region)  # type: ignore
 
     except Exception as e:
-        raise Exception(f"Failed to create {service} client: {str(e)}") from e
+        raise DependencyUnavailableError(
+            message=f"Failed to create {service} client: {e!s}",
+            service=service,
+            cause=e,
+        ) from e
 
 
 def create_engine_url(
     drivername: str,
-    credentials: Dict[str, Any],
-    cluster_credentials: Dict[str, str],
-    extra: Dict[str, Any],
+    credentials: dict[str, Any],
+    cluster_credentials: dict[str, str],
+    extra: dict[str, Any],
 ) -> URL:
     """
     Create SQLAlchemy engine URL for Redshift connection.

--- a/application_sdk/common/file_converter.py
+++ b/application_sdk/common/file_converter.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 from enum import Enum
-from typing import List, Optional
 
+from application_sdk.errors import InvalidInputError
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -40,8 +40,8 @@ class ConvertFile(Enum):
 
 
 async def convert_data_files(
-    input_file_paths: List[str], output_file_type: FileType
-) -> List[str]:
+    input_file_paths: list[str], output_file_type: FileType
+) -> list[str]:
     """
     Convert the input files to the specified file type
     Args:
@@ -56,7 +56,11 @@ async def convert_data_files(
     convert_file = ConvertFile(f"{input_file_type}_to_{output_file_type.value}")
     converter_func = file_converter_registry.registry.get(convert_file)
     if converter_func is None:
-        raise ValueError(f"No converter found for file type: {convert_file}")
+        raise InvalidInputError(
+            message=f"No converter found for file type: {convert_file}",
+            field="file_type",
+            value_summary=str(convert_file),
+        )
     converted_files = []
     for file in input_file_paths:
         converted_file = converter_func(file)
@@ -68,7 +72,7 @@ async def convert_data_files(
 
 # Add the main logic here to convert the files here
 @file_converter_registry.add(ConvertFile.JSON_TO_PARQUET)
-def convert_json_to_parquet(file_path: str) -> Optional[str]:
+def convert_json_to_parquet(file_path: str) -> str | None:
     """Convert the downloaded files from json to parquet"""
     try:
         import pandas as pd  # noqa: PLC0415 — optional dep: pandas
@@ -85,7 +89,7 @@ def convert_json_to_parquet(file_path: str) -> Optional[str]:
 
 
 @file_converter_registry.add(ConvertFile.PARQUET_TO_JSON)
-def convert_parquet_to_json(file_path: str) -> Optional[str]:
+def convert_parquet_to_json(file_path: str) -> str | None:
     """Convert the downloaded files from parquet to json"""
     try:
         import pandas as pd  # noqa: PLC0415 — optional dep: pandas

--- a/application_sdk/common/incremental/column_extraction/backfill.py
+++ b/application_sdk/common/incremental/column_extraction/backfill.py
@@ -11,9 +11,10 @@ Functions:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Set
+from typing import TYPE_CHECKING
 
 from application_sdk.common.exc_utils import rewrap
+from application_sdk.errors import InvalidInputError
 
 if TYPE_CHECKING:
     import duckdb
@@ -28,7 +29,7 @@ logger = get_logger(__name__)
 
 def get_backfill_tables(
     current_transformed_dir: Path, previous_current_state_dir: Path | None
-) -> Set[str] | None:
+) -> set[str] | None:
     """Use DuckDB to compare current tables vs previous current-state.
 
     Returns qualified names of tables that need backfilling
@@ -58,8 +59,9 @@ def get_backfill_tables(
             )
 
             if current_tables is None or current_tables == 0:
-                raise ValueError(
-                    "No transformed tables found for finding backfill tables"
+                raise InvalidInputError(
+                    message="No transformed tables found for finding backfill tables",
+                    field="current_tables",
                 )
 
             if previous_tables is None or previous_tables == 0:
@@ -101,7 +103,7 @@ def get_backfill_tables(
 
             return backfill_qns
 
-    except ValueError:
+    except (ValueError, InvalidInputError):
         logger.warning(
             "Backfill analysis: legitimate skip (no transformed tables); "
             "returning None",

--- a/application_sdk/common/incremental/helpers.py
+++ b/application_sdk/common/incremental/helpers.py
@@ -13,9 +13,8 @@ import os
 import re
 import shutil
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Optional
 
 from application_sdk.constants import (
     APPLICATION_NAME,
@@ -24,6 +23,7 @@ from application_sdk.constants import (
     PERSISTENT_ARTIFACTS_S3_PREFIX_TEMPLATE,
     TEMPORARY_PATH,
 )
+from application_sdk.errors import InvalidInputError
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.storage.batch import list_keys
 from application_sdk.storage.ops import download_file
@@ -50,14 +50,21 @@ def extract_epoch_id_from_qualified_name(connection_qualified_name: str) -> str:
         ValueError: If the qualified name doesn't have the expected format
     """
     if not connection_qualified_name:
-        raise ValueError("connection_qualified_name cannot be empty")
+        raise InvalidInputError(
+            message="connection_qualified_name cannot be empty",
+            field="connection_qualified_name",
+        )
 
     parts = connection_qualified_name.split("/")
 
     if len(parts) < 3:
-        raise ValueError(
-            f"Could not extract epoch ID from connection_qualified_name: '{connection_qualified_name}'. "
-            f"Expected format: 'tenant/connector/epoch'"
+        raise InvalidInputError(
+            message=(
+                f"Could not extract epoch ID from connection_qualified_name: '{connection_qualified_name}'. "
+                f"Expected format: 'tenant/connector/epoch'"
+            ),
+            field="connection_qualified_name",
+            value_summary=connection_qualified_name,
         )
 
     connection_id = parts[-1]
@@ -92,7 +99,10 @@ def get_persistent_s3_prefix(
         ValueError: If connection_qualified_name is not provided
     """
     if not connection_qualified_name:
-        raise ValueError("connection_qualified_name is required")
+        raise InvalidInputError(
+            message="connection_qualified_name is required",
+            field="connection_qualified_name",
+        )
 
     connection_id = extract_epoch_id_from_qualified_name(connection_qualified_name)
 
@@ -165,7 +175,7 @@ def prepone_marker_timestamp(marker: str, hours: float) -> str:
         '2025-01-15T07:30:00Z'
     """
     # Parse the timestamp
-    dt = datetime.strptime(marker, MARKER_TIMESTAMP_FORMAT).replace(tzinfo=timezone.utc)
+    dt = datetime.strptime(marker, MARKER_TIMESTAMP_FORMAT).replace(tzinfo=UTC)
 
     # Move back by specified hours
     adjusted = dt - timedelta(hours=hours)
@@ -180,7 +190,7 @@ def prepone_marker_timestamp(marker: str, hours: float) -> str:
 async def download_marker_from_s3(
     connection_qualified_name: str,
     application_name: str = "",
-) -> Optional[str]:
+) -> str | None:
     """Download marker.txt from S3 and return its content, or None if not found.
 
     Args:

--- a/application_sdk/common/incremental/storage/duckdb_utils.py
+++ b/application_sdk/common/incremental/storage/duckdb_utils.py
@@ -10,14 +10,16 @@ from __future__ import annotations
 import os
 import shutil
 import uuid
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Generator, List, Optional, Union
+from typing import Any, Optional
 
 from application_sdk.constants import (
     DUCKDB_COMMON_TEMP_FOLDER,
     DUCKDB_DEFAULT_MEMORY_LIMIT,
 )
+from application_sdk.errors import PreconditionError
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -93,10 +95,14 @@ class DuckDBConnectionManager:
         )
 
     @property
-    def connection(self) -> "duckdb.DuckDBPyConnection":
+    def connection(self) -> duckdb.DuckDBPyConnection:
         """Get the underlying DuckDB connection."""
         if self._is_closed:
-            raise RuntimeError("DuckDB connection has been closed")
+            raise PreconditionError(
+                message="DuckDB connection has been closed",
+                resource="duckdb_connection",
+                expected_state="open",
+            )
         return self._connection
 
     def close(self) -> None:
@@ -114,10 +120,10 @@ class DuckDBConnectionManager:
             if self._auto_cleanup:
                 shutil.rmtree(self._instance_path, ignore_errors=True)
 
-    def __enter__(self) -> "DuckDBConnectionManager":
+    def __enter__(self) -> DuckDBConnectionManager:
         return self
 
-    def __exit__(self, *_: Any) -> None:
+    def __exit__(self, *_: object) -> None:
         self.close()
 
 
@@ -158,7 +164,7 @@ def escape_sql_string(value: str) -> str:
     return value.replace("'", "''")
 
 
-def json_scan(files: Union[List[Path], List[str]]) -> str:
+def json_scan(files: list[Path] | list[str]) -> str:
     """Generate DuckDB read_json_auto SQL fragment.
 
     Args:

--- a/application_sdk/common/path.py
+++ b/application_sdk/common/path.py
@@ -1,12 +1,12 @@
 import os
 import sys
 from pathlib import Path
-from typing import Union
 
 from application_sdk.constants import WINDOWS_EXTENDED_PATH_PREFIX
+from application_sdk.errors import InvalidInputError
 
 
-def convert_to_extended_path(path: Union[str, Path]) -> str:
+def convert_to_extended_path(path: str | Path) -> str:
     """
     Robust conversion to Windows extended-length path ({WINDOWS_EXTENDED_PATH_PREFIX}).
 
@@ -21,7 +21,7 @@ def convert_to_extended_path(path: Union[str, Path]) -> str:
         Optional[str]: The converted path string, or None if input is empty.
     """
     if not path:
-        raise ValueError("Path cannot be empty")
+        raise InvalidInputError(message="Path cannot be empty", field="path")
 
     path_str = str(path)
 

--- a/application_sdk/common/sql_filters.py
+++ b/application_sdk/common/sql_filters.py
@@ -9,9 +9,10 @@ import glob
 import json
 import os
 import re
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any
 
 from application_sdk.common.error_codes import CommonError
+from application_sdk.errors import InvalidInputError
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -39,7 +40,7 @@ def extract_database_names_from_regex_common(
         if normalized_regex == ".*":
             return "'.*'"
 
-        database_names: Set[str] = set()
+        database_names: set[str] = set()
         patterns = normalized_regex.split("|")
 
         for pattern in patterns:
@@ -116,11 +117,11 @@ def transform_posix_regex(regex_pattern: str) -> str:
 
 
 def prepare_query(
-    query: Optional[str],
-    workflow_args: Dict[str, Any],
-    temp_table_regex_sql: Optional[str] = "",
-    use_posix_regex: Optional[bool] = False,
-) -> Optional[str]:
+    query: str | None,
+    workflow_args: dict[str, Any],
+    temp_table_regex_sql: str | None = "",
+    use_posix_regex: bool | None = False,
+) -> str | None:
     """Prepare a SQL query by applying include/exclude filters.
 
     Modifies the provided SQL query using filters and settings defined in
@@ -198,7 +199,7 @@ def prepare_query(
                 exclude_empty_tables=exclude_empty_tables,
                 exclude_views=exclude_views,
             )
-    except CommonError as e:
+    except (CommonError, InvalidInputError) as e:
         error_message = str(e).split(": ", 1)[-1] if ": " in str(e) else str(e)
         logger.error(
             "Error preparing query: error_code=%s error_message=%s",
@@ -211,7 +212,7 @@ def prepare_query(
 
 async def get_database_names(
     sql_client, workflow_args, fetch_database_sql
-) -> Optional[List[str]]:
+) -> list[str] | None:
     """Get database names from include-filter or by running a SQL query.
 
     Args:
@@ -246,8 +247,8 @@ async def get_database_names(
 
 
 def parse_filter_input(
-    filter_input: Union[str, Dict[str, Any], None],
-) -> Dict[str, Any]:
+    filter_input: str | dict[str, Any] | None,
+) -> dict[str, Any]:
     """Robustly parse filter input from various formats.
 
     Args:
@@ -266,12 +267,16 @@ def parse_filter_input(
         try:
             return json.loads(filter_input)
         except json.JSONDecodeError as e:
-            raise CommonError(f"Invalid filter JSON: {str(e)}") from e
+            raise InvalidInputError(
+                message=f"Invalid filter JSON: {e!s}",
+                field="filter_input",
+                cause=e,
+            ) from e
 
 
 def prepare_filters(
     include_filter_str: str, exclude_filter_str: str
-) -> Tuple[str, str]:
+) -> tuple[str, str]:
     """Prepare include/exclude filters for SQL queries.
 
     Args:
@@ -305,8 +310,8 @@ def prepare_filters(
 
 
 def normalize_filters(
-    filter_dict: Dict[str, List[str] | str], is_include: bool
-) -> List[str]:
+    filter_dict: dict[str, list[str] | str], is_include: bool
+) -> list[str]:
     """Normalize filter dict to fully-anchored ``db.schema`` regex patterns.
 
     Each emitted pattern is anchored with ``^`` and ``$`` so that callers
@@ -330,7 +335,7 @@ def normalize_filters(
     Returns:
         List of anchored regex segments suitable for joining with ``|``.
     """
-    normalized_filter_list: List[str] = []
+    normalized_filter_list: list[str] = []
     for filtered_db, filtered_schemas in filter_dict.items():
         db = filtered_db.strip("^$")
 
@@ -348,7 +353,7 @@ def normalize_filters(
 
 def read_sql_files(
     queries_prefix: str = f"{os.path.dirname(os.path.abspath(__file__))}/queries",
-) -> Dict[str, str]:
+) -> dict[str, str]:
     """Read all SQL files from a directory and return as a name→content mapping.
 
     Args:
@@ -357,12 +362,12 @@ def read_sql_files(
     Returns:
         Dictionary mapping SQL file names (uppercase, without extension) to contents.
     """
-    sql_files: List[str] = glob.glob(
+    sql_files: list[str] = glob.glob(
         os.path.join(queries_prefix, "**/*.sql"),
         recursive=True,
     )
 
-    result: Dict[str, str] = {}
+    result: dict[str, str] = {}
     for file in sql_files:
         with open(file, encoding="utf-8") as f:
             result[os.path.basename(file).upper().replace(".SQL", "")] = (

--- a/application_sdk/common/utils.py
+++ b/application_sdk/common/utils.py
@@ -9,9 +9,9 @@ Most functions previously in this module have been moved to more logical homes:
 
 import json
 import os
-from typing import Union
 
 from application_sdk.constants import TEMPORARY_PATH
+from application_sdk.errors import DataIntegrityError, InvalidInputError
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.server.fastapi.models import FileUploadResponse
 from application_sdk.storage.ops import download_file
@@ -20,7 +20,7 @@ logger = get_logger(__name__)
 
 
 async def download_file_from_upload_response(
-    response: Union[dict, str, FileUploadResponse],
+    response: dict | str | FileUploadResponse,
 ) -> str:
     """Download a file that was uploaded via the /file endpoint.
 
@@ -43,16 +43,26 @@ async def download_file_from_upload_response(
         try:
             response = json.loads(response)
         except json.JSONDecodeError as e:
-            raise ValueError(f"Invalid JSON string: {e}") from e
+            raise InvalidInputError(
+                message=f"Invalid JSON string: {e}", field="response"
+            ) from e
 
     if isinstance(response, FileUploadResponse):
         key = response.key
     elif isinstance(response, dict):
         if "key" not in response:
-            raise ValueError("Response dict is missing required 'key' field")
+            raise DataIntegrityError(
+                message="Response dict is missing required 'key' field",
+                expectation="key present in response",
+                location="response",
+            )
         key = response["key"]
     else:
-        raise ValueError(f"Unsupported response type: {type(response)}")
+        raise DataIntegrityError(
+            message=f"Unsupported response type: {type(response)}",
+            expectation="FileUploadResponse or dict",
+            observed=str(type(response)),
+        )
 
     local_path = os.path.join(TEMPORARY_PATH, key)
 

--- a/application_sdk/contracts/types.py
+++ b/application_sdk/contracts/types.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
 from application_sdk.credentials.ref import CredentialRef
+from application_sdk.errors import InvalidInputError
 
 T = TypeVar("T")
 K = TypeVar("K")
@@ -76,8 +77,9 @@ class StorageTier(StrEnum):
             return "file_refs"
         if self is StorageTier.RETAINED:
             if not run_prefix:
-                raise ValueError(
-                    "run_prefix is required when computing upload prefix for RETAINED tier"
+                raise InvalidInputError(
+                    message="run_prefix is required when computing upload prefix for RETAINED tier",
+                    field="run_prefix",
                 )
             return run_prefix
         # PERSISTENT
@@ -130,8 +132,9 @@ class StorageTier(StrEnum):
             return "file_refs"
         if self is StorageTier.RETAINED:
             if not run_prefix:
-                raise ValueError(
-                    "run_prefix is required when persisting a RETAINED-tier FileReference"
+                raise InvalidInputError(
+                    message="run_prefix is required when persisting a RETAINED-tier FileReference",
+                    field="run_prefix",
                 )
             return f"{run_prefix}/file_refs"
         # PERSISTENT

--- a/application_sdk/credentials/atlan_client.py
+++ b/application_sdk/credentials/atlan_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from application_sdk.errors import InvalidInputError
 from application_sdk.observability.logger_adaptor import get_logger
 
 if TYPE_CHECKING:
@@ -18,7 +19,7 @@ logger = get_logger(__name__)
 _VALIDATED_ASYNC_CLIENT_KEY = "validated_async_atlan_client"
 
 
-def create_async_atlan_client(cred: "Credential") -> "object":
+def create_async_atlan_client(cred: Credential) -> object:
     """Create an AsyncAtlanClient from a resolved Atlan credential.
 
     Args:
@@ -56,9 +57,13 @@ def create_async_atlan_client(cred: "Credential") -> "object":
             oauth_client_id=cred.client_id,
             oauth_client_secret=cred.client_secret,
         )
-    raise TypeError(
-        f"Unsupported Atlan credential type: {type(cred).__name__}. "
-        "Expected AtlanApiToken or AtlanOAuthClient."
+    raise InvalidInputError(
+        message=(
+            f"Unsupported Atlan credential type: {type(cred).__name__}. "
+            "Expected AtlanApiToken or AtlanOAuthClient."
+        ),
+        field="credential_type",
+        value_summary=type(cred).__name__,
     )
 
 
@@ -75,8 +80,8 @@ class AtlanClientMixin:
     """
 
     async def get_or_create_async_atlan_client(
-        self, credential: "CredentialRef"
-    ) -> "object":
+        self, credential: CredentialRef
+    ) -> object:
         """Return a cached AsyncAtlanClient for the given credential ref.
 
         Lookup order:

--- a/application_sdk/credentials/ref.py
+++ b/application_sdk/credentials/ref.py
@@ -8,6 +8,7 @@ from typing import Any, Protocol, runtime_checkable
 from pydantic import BaseModel, ConfigDict
 
 from application_sdk.credentials.spec import AgentCredentialSpec
+from application_sdk.errors import InvalidInputError
 from application_sdk.observability.logger_adaptor import get_logger
 
 
@@ -81,7 +82,7 @@ class CredentialRef(BaseModel, frozen=True):
     credential_guid: str = ""
     """Platform-issued credential GUID — non-empty triggers GUID resolution path."""
 
-    agent_spec: "AgentCredentialSpec | None" = None
+    agent_spec: AgentCredentialSpec | None = None
     """Typed agent credential spec — non-None triggers v3 agent resolution.
 
     Parsed from the ``agent_json`` workflow field.  Contains the typed
@@ -110,7 +111,7 @@ class CredentialRef(BaseModel, frozen=True):
     # ------------------------------------------------------------------
 
     @classmethod
-    def resolve(cls, source: CredentialResolvable) -> "CredentialRef":
+    def resolve(cls, source: CredentialResolvable) -> CredentialRef:
         """Resolve a :class:`CredentialRef` from a workflow input.
 
         Routes to agent resolution (via ``agent_json``) or direct GUID
@@ -131,9 +132,13 @@ class CredentialRef(BaseModel, frozen=True):
             ValueError: If no routable credential source is present.
         """
         if not isinstance(source, CredentialResolvable):
-            raise TypeError(
-                f"Expected a CredentialResolvable (with extraction_method, "
-                f"agent_json, credential_guid), got {type(source).__name__}"
+            raise InvalidInputError(
+                message=(
+                    f"Expected a CredentialResolvable (with extraction_method, "
+                    f"agent_json, credential_guid), got {type(source).__name__}"
+                ),
+                field="source",
+                value_summary=type(source).__name__,
             )
 
         method = (source.extraction_method or "direct").strip().lower()
@@ -152,14 +157,17 @@ class CredentialRef(BaseModel, frozen=True):
                 credential_guid=guid,
             )
 
-        raise ValueError(
-            "No routable credential source: need either "
-            "extraction_method='agent' with a non-empty agent_json, "
-            "or extraction_method='direct' with a non-empty credential_guid"
+        raise InvalidInputError(
+            message=(
+                "No routable credential source: need either "
+                "extraction_method='agent' with a non-empty agent_json, "
+                "or extraction_method='direct' with a non-empty credential_guid"
+            ),
+            field="extraction_method_or_credential_guid",
         )
 
     @classmethod
-    def from_workflow_args(cls, workflow_args: dict[str, Any]) -> "CredentialRef":
+    def from_workflow_args(cls, workflow_args: dict[str, Any]) -> CredentialRef:
         """Build a :class:`CredentialRef` from a Temporal workflow payload.
 
         .. deprecated::
@@ -247,10 +255,13 @@ class CredentialRef(BaseModel, frozen=True):
                 credential_guid=guid,
             )
 
-        raise ValueError(
-            "workflow_args has no routable credential source: need either "
-            "extraction_method='agent' with a non-empty agent_json, "
-            "or a non-empty credential_guid"
+        raise InvalidInputError(
+            message=(
+                "workflow_args has no routable credential source: need either "
+                "extraction_method='agent' with a non-empty agent_json, "
+                "or a non-empty credential_guid"
+            ),
+            field="extraction_method_or_credential_guid",
         )
 
 

--- a/application_sdk/credentials/utils.py
+++ b/application_sdk/credentials/utils.py
@@ -7,9 +7,9 @@ from typing import Any
 
 import orjson
 
-from application_sdk.common.error_codes import CommonError
 from application_sdk.common.utils import download_file_from_upload_response
 from application_sdk.constants import DEPLOYMENT_OBJECT_STORE_NAME, TEMPORARY_PATH
+from application_sdk.errors import InvalidInputError
 from application_sdk.observability import get_logger
 from application_sdk.storage.binding import create_store_from_binding
 from application_sdk.storage.ops import download_file
@@ -41,8 +41,10 @@ def parse_credentials_extra(credentials: dict[str, Any]) -> dict[str, Any]:
         try:
             return json.loads(extra)
         except json.JSONDecodeError as e:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: Invalid JSON in credentials extra field: {e}"
+            raise InvalidInputError(
+                message=f"Invalid JSON in credentials extra field: {e}",
+                field="extra",
+                cause=e,
             ) from e
 
     return extra

--- a/application_sdk/execution/_temporal/activity_utils.py
+++ b/application_sdk/execution/_temporal/activity_utils.py
@@ -33,16 +33,17 @@
 """
 
 import os
-from typing import Any, Callable, TypeVar
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 from temporalio import activity
 
-from application_sdk.common.exc_utils import rewrap
 from application_sdk.constants import (
     APPLICATION_NAME,
     TEMPORARY_PATH,
     WORKFLOW_OUTPUT_PATH_TEMPLATE,
 )
+from application_sdk.errors import PreconditionError
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -71,18 +72,17 @@ def get_workflow_id() -> str:
         The workflow ID of the current activity.
 
     Raises:
-        Exception: If called outside an activity context, or if the
-            workflow ID cannot be retrieved.
+        PreconditionError: If called outside an activity context, or if the
+            workflow ID is unavailable.
     """
-    try:
-        wf_id = activity.info().workflow_id
-        if wf_id is None:
-            raise ValueError(
-                "workflow_id unavailable outside a workflow-backed activity"
-            )
-        return wf_id
-    except Exception as e:
-        raise rewrap(e, "Failed to get workflow id") from e
+    wf_id = activity.info().workflow_id
+    if wf_id is None:
+        raise PreconditionError(
+            message="workflow_id unavailable outside a workflow-backed activity",
+            resource="activity_context",
+            expected_state="running inside a workflow-backed activity",
+        )
+    return wf_id
 
 
 def get_workflow_run_id() -> str:
@@ -99,16 +99,19 @@ def get_workflow_run_id() -> str:
     Used by SDK framework code that genuinely needs the per-attempt
     run ID (e.g. cleanup of artifacts written under the current
     attempt's prefix).
+
+    Raises:
+        PreconditionError: If called outside an activity context, or if the
+            workflow run ID is unavailable.
     """
-    try:
-        wf_run_id = activity.info().workflow_run_id
-        if wf_run_id is None:
-            raise ValueError(
-                "workflow_run_id unavailable outside a workflow-backed activity"
-            )
-        return wf_run_id
-    except Exception as e:
-        raise rewrap(e, "Failed to get workflow run id") from e
+    wf_run_id = activity.info().workflow_run_id
+    if wf_run_id is None:
+        raise PreconditionError(
+            message="workflow_run_id unavailable outside a workflow-backed activity",
+            resource="activity_context",
+            expected_state="running inside a workflow-backed activity",
+        )
+    return wf_run_id
 
 
 def build_output_path() -> str:

--- a/application_sdk/execution/_temporal/auth.py
+++ b/application_sdk/execution/_temporal/auth.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from application_sdk.errors import AuthError, InvalidInputError
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -81,7 +82,7 @@ class TemporalAuthManager:
             The access_token string for Temporal client auth.
 
         Raises:
-            RuntimeError: If token acquisition fails.
+            AuthError: If token acquisition fails.
         """
         token_url = self._resolve_token_url()
 
@@ -94,8 +95,10 @@ class TemporalAuthManager:
         try:
             access_token = await self._get_token_service().get_token(force_refresh=True)
         except Exception as exc:
-            raise RuntimeError(
-                f"Failed to acquire initial Temporal auth token: {exc}"
+            raise AuthError(
+                message=f"Failed to acquire initial Temporal auth token: {exc}",
+                auth_method="oauth_client_credentials",
+                cause=exc,
             ) from exc
 
         expires_at = self._get_token_service().current_expires_at
@@ -173,8 +176,9 @@ class TemporalAuthManager:
         if self.config.base_url:
             base = self.config.base_url.rstrip("/")
             return f"{base}/auth/realms/default/protocol/openid-connect/token"
-        raise ValueError(
-            "Either token_url or base_url must be set in TemporalAuthConfig"
+        raise InvalidInputError(
+            message="Either token_url or base_url must be set in TemporalAuthConfig",
+            field="token_url_or_base_url",
         )
 
     async def _refresh_loop(self, client: Client) -> None:

--- a/application_sdk/execution/_temporal/backend.py
+++ b/application_sdk/execution/_temporal/backend.py
@@ -13,6 +13,7 @@ from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
 
 from application_sdk.constants import TEMPORAL_PROMETHEUS_BIND_ADDRESS
+from application_sdk.errors import DependencyUnavailableError, InvalidInputError
 from application_sdk.execution.retry import RetryPolicy, _to_temporal_retry_policy
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.observability.utils import get_metric_enrichment_labels
@@ -139,9 +140,10 @@ class TemporalExecutorBackend:
         )
         if entry_point is not None and ep_meta is None:
             available = list(app_cls._app_metadata.entry_points)
-            raise ValueError(
-                f"Unknown entry point '{entry_point}' for app '{app_cls._app_name}'. "
-                f"Available: {available}"
+            raise InvalidInputError(
+                message=f"Unknown entry point {entry_point!r} for app {app_cls._app_name!r}. Available: {available}",
+                field="entry_point",
+                value_summary=entry_point,
             )
         output_type = (
             ep_meta.output_type
@@ -250,9 +252,9 @@ def _build_tls_config(
     has_cert = bool(client_cert_path)
     has_key = bool(client_private_key_path)
     if has_cert != has_key:
-        raise ValueError(
-            "mTLS requires both client cert and client private key. "
-            f"Got cert={client_cert_path!r}, key={client_private_key_path!r}"
+        raise InvalidInputError(
+            message=f"mTLS requires both client cert and client private key. Got cert={client_cert_path!r}, key={client_private_key_path!r}",
+            field="client_cert_path_or_client_private_key_path",
         )
 
     if client_cert_path:
@@ -411,6 +413,9 @@ async def create_temporal_client(
                     exc_info=True,
                 )
 
-    raise RuntimeError(
-        f"Failed to connect to Temporal at {host!r} after {connect_max_attempts} attempts"
+    raise DependencyUnavailableError(
+        message=f"Failed to connect to Temporal at {host!r} after {connect_max_attempts} attempts",
+        service="temporal",
+        target=host,
+        cause=last_exc,
     ) from last_exc

--- a/application_sdk/execution/_temporal/interceptors/lock.py
+++ b/application_sdk/execution/_temporal/interceptors/lock.py
@@ -10,7 +10,7 @@ when all lock slots are taken.
 """
 
 from datetime import timedelta
-from typing import Any, Dict, Optional, Type
+from typing import Any
 
 from temporalio import workflow
 from temporalio.common import RetryPolicy
@@ -22,13 +22,13 @@ from temporalio.worker import (
     WorkflowOutboundInterceptor,
 )
 
-from application_sdk.common.error_codes import WorkflowError
 from application_sdk.constants import (
     APPLICATION_NAME,
     IS_LOCKING_DISABLED,
     LOCK_METADATA_KEY,
     LOCK_RETRY_INTERVAL_SECONDS,
 )
+from application_sdk.errors import InvalidInputError
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -37,7 +37,7 @@ logger = get_logger(__name__)
 class RedisLockInterceptor(Interceptor):
     """Main interceptor class for Redis distributed locking."""
 
-    def __init__(self, activities: Dict[str, Any]):
+    def __init__(self, activities: dict[str, Any]):
         """Initialize Redis lock interceptor.
 
         Args:
@@ -47,7 +47,7 @@ class RedisLockInterceptor(Interceptor):
 
     def workflow_interceptor_class(
         self, input: WorkflowInterceptorClassInput
-    ) -> Optional[Type[WorkflowInboundInterceptor]]:
+    ) -> type[WorkflowInboundInterceptor] | None:
         activities = self.activities
 
         class RedisLockWorkflowInboundInterceptor(WorkflowInboundInterceptor):
@@ -64,7 +64,7 @@ class RedisLockInterceptor(Interceptor):
 class RedisLockOutboundInterceptor(WorkflowOutboundInterceptor):
     """Outbound interceptor that acquires Redis locks before activity execution."""
 
-    def __init__(self, next: WorkflowOutboundInterceptor, activities: Dict[str, Any]):
+    def __init__(self, next: WorkflowOutboundInterceptor, activities: dict[str, Any]):
         super().__init__(next)
         self.activities = activities
 
@@ -90,9 +90,9 @@ class RedisLockOutboundInterceptor(WorkflowOutboundInterceptor):
                 "Activity %s with @needs_lock decorator requires schedule_to_close_timeout",
                 input.activity,
             )
-            raise WorkflowError(
-                f"{WorkflowError.WORKFLOW_CONFIG_ERROR}: Activity '{input.activity}' with @needs_lock decorator must be called with schedule_to_close_timeout parameter. "
-                f"Example: workflow.execute_activity('{input.activity}', schedule_to_close_timeout=timedelta(minutes=10))"
+            raise InvalidInputError(
+                message=f"Activity '{input.activity}' with @needs_lock decorator must be called with schedule_to_close_timeout parameter. Example: workflow.execute_activity('{input.activity}', schedule_to_close_timeout=timedelta(minutes=10))",
+                field="schedule_to_close_timeout",
             )
         ttl_seconds = int(input.schedule_to_close_timeout.total_seconds())
 

--- a/application_sdk/execution/_temporal/lock_activities.py
+++ b/application_sdk/execution/_temporal/lock_activities.py
@@ -6,12 +6,12 @@ deadlock timeout.
 """
 
 import random
-from typing import Any, Dict
+from typing import Any
 
 from temporalio import activity
 
 from application_sdk.clients.redis import RedisClientAsync
-from application_sdk.common.error_codes import ActivityError
+from application_sdk.errors import DependencyUnavailableError
 from application_sdk.execution.errors import ApplicationError
 from application_sdk.observability.logger_adaptor import get_logger
 
@@ -24,7 +24,7 @@ async def acquire_distributed_lock(
     max_locks: int,
     ttl_seconds: int = 100,
     owner_id: str = "default_owner",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Acquire a distributed lock with retry logic.
 
     Args:
@@ -45,7 +45,7 @@ async def acquire_distributed_lock(
     # Input validation
     if max_locks <= 0:
         raise ApplicationError(
-            f"{ActivityError.LOCK_ACQUISITION_ERROR}: max_locks must be greater than 0, got {max_locks}",
+            f"max_locks must be greater than 0, got {max_locks}",
             non_retryable=True,
         )
     slot = random.randint(0, max_locks - 1)
@@ -66,12 +66,13 @@ async def acquire_distributed_lock(
                     "owner_id": owner_id,
                 }
 
-            raise ActivityError(
-                f"{ActivityError.LOCK_ACQUISITION_ERROR}: Lock not acquired for {resource_id}, will retry after some time"
+            raise DependencyUnavailableError(
+                message=f"Lock not acquired for {resource_id}, will retry after some time",
+                service="dapr_lock",
             )
     except Exception as e:
         # Redis connection or operation failed - propagate as activity error
-        if isinstance(e, ActivityError):
+        if isinstance(e, DependencyUnavailableError):
             raise
         raise ApplicationError(
             f"Redis error during lock acquisition for {resource_id}",

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -24,6 +24,7 @@ from application_sdk.constants import (
     APP_DEPLOYMENT_NAME,
     SHUTDOWN_DRAIN_DELAY_SECONDS,
 )
+from application_sdk.errors import InvalidInputError
 from application_sdk.execution._temporal.activities import get_all_task_activities
 from application_sdk.execution._temporal.workflows import get_all_app_workflows
 from application_sdk.execution.sandbox import SandboxConfig
@@ -360,10 +361,14 @@ def create_worker(
         type(i).__name__ for i in (interceptors or []) if isinstance(i, _builtin_types)
     ]
     if _duplicates:
-        raise ValueError(
-            f"create_worker(interceptors=...) contains {_duplicates}, but the SDK "
-            "now adds LogInterceptor / MetricsInterceptor / TraceInterceptor "
-            "automatically. Remove them from your `interceptors` list."
+        raise InvalidInputError(
+            message=(
+                f"create_worker(interceptors=...) contains {_duplicates}, but the SDK "
+                "now adds LogInterceptor / MetricsInterceptor / TraceInterceptor "
+                "automatically. Remove them from your `interceptors` list."
+            ),
+            field="interceptors",
+            value_summary=str(_duplicates),
         )
 
     all_interceptors: list[TemporalInterceptor] = [

--- a/application_sdk/handler/context.py
+++ b/application_sdk/handler/context.py
@@ -15,6 +15,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
+from application_sdk.app._context_errors import NoSecretStoreError
 from application_sdk.observability.logger_adaptor import get_logger
 
 if TYPE_CHECKING:
@@ -98,7 +99,7 @@ class HandlerContext:
             RuntimeError: If no secret store is configured.
         """
         if self._secret_store is None:
-            raise RuntimeError("No secret store configured")
+            raise NoSecretStoreError(message="No secret store configured")
         return await self._secret_store.get(name)
 
     async def get_secret_optional(self, name: str) -> str | None:

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -54,6 +54,7 @@ from temporalio.client import WorkflowFailureError
 
 from application_sdk.constants import CONTRACT_GENERATED_DIR as _CONTRACT_GENERATED_DIR
 from application_sdk.constants import DEPLOYMENT_NAME, LOCAL_ENVIRONMENT
+from application_sdk.errors import InvalidInputError
 from application_sdk.handler.base import Handler, HandlerError
 from application_sdk.handler.context import HandlerContext, bind_handler_context
 from application_sdk.handler.contracts import (
@@ -322,7 +323,9 @@ def _validated_temp_path(path: str) -> str:
     tmp_root = os.path.realpath(tempfile.gettempdir())
     real = os.path.realpath(path)
     if real != tmp_root and not real.startswith(tmp_root + os.sep):
-        raise ValueError("Temp file path escapes system temp directory")
+        raise InvalidInputError(
+            message="Temp file path escapes system temp directory", field="path"
+        )
     return real
 
 
@@ -1184,9 +1187,17 @@ def create_app_handler_service(
         Path: persistent-artifacts/apps/{app_name}/{type}/{id}/config.json
         """
         if not _CONFIG_KEY_RE.match(config_id):
-            raise ValueError(f"Invalid config_id: {config_id!r}")
+            raise InvalidInputError(
+                message=f"Invalid config_id: {config_id!r}",
+                field="config_id",
+                value_summary=str(config_id),
+            )
         if not _CONFIG_KEY_RE.match(config_type):
-            raise ValueError(f"Invalid config_type: {config_type!r}")
+            raise InvalidInputError(
+                message=f"Invalid config_type: {config_type!r}",
+                field="config_type",
+                value_summary=str(config_type),
+            )
         from application_sdk.constants import (  # noqa: PLC0415 — cold path: only when computing app paths
             APPLICATION_NAME,
         )

--- a/application_sdk/infrastructure/_dapr/client.py
+++ b/application_sdk/infrastructure/_dapr/client.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import orjson
 
+from application_sdk.errors import UnimplementedError
 from application_sdk.infrastructure._dapr.http import AsyncDaprClient
 from application_sdk.infrastructure.bindings import BindingError, BindingResponse
 from application_sdk.infrastructure.pubsub import MessageHandler, PubSubError
@@ -102,12 +103,14 @@ class DaprStateStore:
         """List keys via Dapr.
 
         Note: Not all Dapr state stores support listing keys.
-        This may raise NotImplementedError for some backends.
+        This may raise UnimplementedError for some backends.
         """
         # Dapr doesn't have a native list operation for all stores
         # This would need to be implemented per-backend
-        raise NotImplementedError(
-            "Key listing is not supported by all Dapr state stores"
+        raise UnimplementedError(
+            message="Key listing is not supported by all Dapr state stores",
+            operation="list_keys",
+            reason="not_supported_by_all_backends",
         )
 
 

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -39,6 +39,7 @@ from application_sdk.discovery import (
     load_handler_class,
     validate_app_class,
 )
+from application_sdk.errors import InvalidInputError, PreconditionError
 from application_sdk.observability.logger_adaptor import get_logger
 
 # Enable faulthandler so C-level crashes dump a traceback to stderr.
@@ -208,17 +209,22 @@ class AppConfig:
 
         app_module_raw = args.app or _env("ATLAN_APP_MODULE")
         if not app_module_raw:
-            raise ValueError(
-                "App module is required. Use --app or set ATLAN_APP_MODULE."
+            raise InvalidInputError(
+                message="App module is required. Use --app or set ATLAN_APP_MODULE.",
+                field="app_module",
             )
 
         app_module = app_module_raw.strip()
 
         if "," in app_module:
-            raise ValueError(
-                f"ATLAN_APP_MODULE contains a comma: {app_module!r}. "
-                "The multi-app pattern is not supported in v3. "
-                "Define multiple @entrypoint methods on a single App subclass instead."
+            raise InvalidInputError(
+                message=(
+                    f"ATLAN_APP_MODULE contains a comma: {app_module!r}. "
+                    "The multi-app pattern is not supported in v3. "
+                    "Define multiple @entrypoint methods on a single App subclass instead."
+                ),
+                field="app_module",
+                value_summary=app_module,
             )
 
         service_name = (
@@ -509,10 +515,14 @@ async def _create_infrastructure(
         )
     else:
         # No Dapr sidecar — require it for all modes
-        raise RuntimeError(
-            "Dapr sidecar not detected (DAPR_HTTP_PORT not set). "
-            "Run 'poe start-deps' to start local Dapr + Temporal, "
-            "or set DAPR_HTTP_PORT if running daprd manually."
+        raise PreconditionError(
+            message=(
+                "Dapr sidecar not detected (DAPR_HTTP_PORT not set). "
+                "Run 'poe start-deps' to start local Dapr + Temporal, "
+                "or set DAPR_HTTP_PORT if running daprd manually."
+            ),
+            resource="dapr_sidecar",
+            expected_state="running",
         )
 
 
@@ -1384,8 +1394,10 @@ def run_main(config: AppConfig) -> None:
     elif config.mode == "combined":
         asyncio.run(run_combined_mode(config))
     else:
-        raise ValueError(
-            f"Unknown mode: {config.mode!r}. Must be 'worker', 'handler', or 'combined'."
+        raise InvalidInputError(
+            message=f"Unknown mode: {config.mode!r}. Must be 'worker', 'handler', or 'combined'.",
+            field="mode",
+            value_summary=config.mode,
         )
 
 
@@ -1471,7 +1483,7 @@ def main() -> NoReturn:
 
     try:
         config = AppConfig.from_args_and_env(args)
-    except ValueError:
+    except (ValueError, InvalidInputError):
         logger.error("Configuration error", exc_info=True)
         sys.exit(1)
 

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -31,6 +31,7 @@ from application_sdk.constants import (
     OTEL_WORKFLOW_LOGS_ENDPOINT,
     SERVICE_NAME,
 )
+from application_sdk.errors import InternalError
 from application_sdk.observability.context import correlation_context, request_context
 from application_sdk.observability.observability import AtlanObservability
 from application_sdk.observability.utils import (
@@ -606,7 +607,11 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
         if isinstance(record, dict):
             return record
 
-        raise ValueError(f"Unsupported record format: {type(record)}")
+        raise InternalError(
+            message=f"Unsupported record format: {type(record)}",
+            component="logger_adaptor",
+            invariant="record must be logging.LogRecord or dict",
+        )
 
     def export_record(self, record: Any) -> None:
         """Export a log record to external systems.

--- a/application_sdk/observability/pushgateway.py
+++ b/application_sdk/observability/pushgateway.py
@@ -35,6 +35,7 @@ from prometheus_client import (
 from prometheus_client.exposition import default_handler
 from prometheus_client.parser import text_string_to_metric_families
 
+from application_sdk.errors import InvalidInputError
 from application_sdk.observability.logger_adaptor import get_logger
 
 #: Regex extracting ``push_time_seconds{labels} value`` lines from a
@@ -76,6 +77,9 @@ class TemporalCoreCollector:
             yield from text_string_to_metric_families(resp.text)
         except Exception:
             # Silent — a transient Temporal core hiccup must not poison the push.
+            logger.debug(
+                "Temporal core metrics scrape failed (non-fatal)", exc_info=True
+            )
             return
 
 
@@ -154,9 +158,13 @@ class PushGatewayClient:
         task_queue: str = "",
     ) -> None:
         if not url:
-            raise ValueError("PushGatewayClient requires a non-empty url")
+            raise InvalidInputError(
+                message="PushGatewayClient requires a non-empty url", field="url"
+            )
         if not job:
-            raise ValueError("PushGatewayClient requires a non-empty job")
+            raise InvalidInputError(
+                message="PushGatewayClient requires a non-empty job", field="job"
+            )
         self._url = url
         self._job = job
         self._grouping_key = grouping_key or _default_grouping_key(task_queue)

--- a/application_sdk/storage/formats/__init__.py
+++ b/application_sdk/storage/formats/__init__.py
@@ -17,8 +17,17 @@ import orjson
 from application_sdk.common.exc_utils import rewrap
 from application_sdk.common.models import TaskStatistics
 from application_sdk.common.types import DataframeType
+from application_sdk.errors import InternalError as InternalError
+from application_sdk.errors import InvalidInputError as InvalidInputError
+from application_sdk.errors import UnimplementedError as UnimplementedError
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.observability.metrics_adaptor import MetricType
+from application_sdk.storage.formats._format_errors import (
+    ClosedReaderError as ClosedReaderError,
+)
+from application_sdk.storage.formats._format_errors import (
+    ClosedWriterError as ClosedWriterError,
+)
 from application_sdk.storage.formats.utils import (
     estimate_dataframe_record_size,
     is_empty_dataframe,
@@ -163,10 +172,14 @@ class Reader(ABC):
             Iterator["pd.DataFrame"]: An iterator of batched pandas DataFrames.
 
         Raises:
-            NotImplementedError: If the method is not implemented.
-            ValueError: If the reader has been closed.
+            UnimplementedError: If the method is not implemented.
+            ClosedReaderError: If the reader has been closed.
         """
-        raise NotImplementedError
+        raise UnimplementedError(
+            message="Subclass must implement read_batches",
+            operation="read_batches",
+            reason="subclass_must_override",
+        )
 
     @abstractmethod
     async def read(self) -> Union["pd.DataFrame", "daft.DataFrame"]:
@@ -176,10 +189,14 @@ class Reader(ABC):
             Union["pd.DataFrame", "daft.DataFrame"]: A pandas or daft DataFrame.
 
         Raises:
-            NotImplementedError: If the method is not implemented.
-            ValueError: If the reader has been closed.
+            UnimplementedError: If the method is not implemented.
+            ClosedReaderError: If the reader has been closed.
         """
-        raise NotImplementedError
+        raise UnimplementedError(
+            message="Subclass must implement read",
+            operation="read",
+            reason="subclass_must_override",
+        )
 
 
 class WriteMode(Enum):
@@ -283,9 +300,11 @@ class Writer(ABC):
 
                     return daft.from_pandas(data)
                 except ImportError:
-                    raise TypeError(
-                        "daft is not installed. Please install daft to use DataframeType.daft, "
-                        "or use DataframeType.pandas instead."
+                    raise InvalidInputError(
+                        message="daft is not installed. Please install daft to use DataframeType.daft, "
+                        "or use DataframeType.pandas instead.",
+                        field="dataframe_type",
+                        value_summary="daft",
                     )
             return data
 
@@ -321,16 +340,19 @@ class Writer(ABC):
                                 columnar_data[key].append(value)
                     return daft.from_pydict(columnar_data)
                 except ImportError:
-                    raise TypeError(
-                        "Dict and list inputs require daft to be installed when using DataframeType.daft. "
-                        "Please install daft or use DataframeType.pandas instead."
+                    raise InvalidInputError(
+                        message="Dict and list inputs require daft to be installed when using DataframeType.daft. "
+                        "Please install daft or use DataframeType.pandas instead.",
+                        field="dataframe_type",
+                        value_summary="daft",
                     )
             # For pandas dataframe_type, convert to pandas DataFrame
             return pd.DataFrame([data] if isinstance(data, dict) else data)
 
-        raise TypeError(
-            f"Unsupported data type: {type(data).__name__}. "
-            "Expected DataFrame, dict, or list of dicts."
+        raise InvalidInputError(
+            message=f"Unsupported data type: {type(data).__name__}. Expected DataFrame, dict, or list of dicts.",
+            field="data",
+            value_summary=type(data).__name__,
         )
 
     async def write(
@@ -354,7 +376,7 @@ class Writer(ABC):
             TypeError: If data type is not supported.
         """
         if self._is_closed:
-            raise ValueError("Cannot write to a closed writer")
+            raise ClosedWriterError(message="Cannot write to a closed writer")
 
         # Convert to DataFrame if needed
         dataframe = self._convert_to_dataframe(data)
@@ -364,7 +386,11 @@ class Writer(ABC):
         elif self.dataframe_type == DataframeType.daft:
             await self._write_daft_dataframe(dataframe, **kwargs)
         else:
-            raise ValueError(f"Unsupported dataframe_type: {self.dataframe_type}")
+            raise InvalidInputError(
+                message=f"Unsupported dataframe_type: {self.dataframe_type}",
+                field="dataframe_type",
+                value_summary=str(self.dataframe_type),
+            )
 
     async def write_batches(
         self,
@@ -382,14 +408,18 @@ class Writer(ABC):
             ValueError: If the writer has been closed or dataframe_type is unsupported.
         """
         if self._is_closed:
-            raise ValueError("Cannot write to a closed writer")
+            raise ClosedWriterError(message="Cannot write to a closed writer")
 
         if self.dataframe_type == DataframeType.pandas:
             await self._write_batched_dataframe(dataframe)
         elif self.dataframe_type == DataframeType.daft:
             await self._write_batched_daft_dataframe(dataframe)
         else:
-            raise ValueError(f"Unsupported dataframe_type: {self.dataframe_type}")
+            raise InvalidInputError(
+                message=f"Unsupported dataframe_type: {self.dataframe_type}",
+                field="dataframe_type",
+                value_summary=str(self.dataframe_type),
+            )
 
     async def _write_batched_dataframe(
         self,
@@ -611,7 +641,11 @@ class Writer(ABC):
             # Write statistics to file and object store
             statistics_dict = await self._write_statistics(typename)
             if not statistics_dict:
-                raise ValueError("No statistics data available")
+                raise InternalError(
+                    message="No statistics data available",
+                    component="Writer._write_statistics",
+                    invariant="statistics_dict must be non-empty after _write_statistics",
+                )
 
             self._statistics = TaskStatistics(**statistics_dict)
             if typename:

--- a/application_sdk/storage/formats/_format_errors.py
+++ b/application_sdk/storage/formats/_format_errors.py
@@ -1,0 +1,29 @@
+"""Typed precondition errors for closed format readers/writers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from application_sdk.errors import DependencyUnavailableError, PreconditionError
+
+
+@dataclass(kw_only=True)
+class ClosedWriterError(PreconditionError):
+    """Operation called on a writer that has already been closed."""
+
+    code: ClassVar[str] = "PRECONDITION_WRITER_CLOSED"
+
+
+@dataclass(kw_only=True)
+class ClosedReaderError(PreconditionError):
+    """Operation called on a reader that has already been closed."""
+
+    code: ClassVar[str] = "PRECONDITION_READER_CLOSED"
+
+
+@dataclass(kw_only=True)
+class ObjectStoreReadError(DependencyUnavailableError):
+    """Object store read or download operation failed."""
+
+    code: ClassVar[str] = "DEPENDENCY_UNAVAILABLE_OBJECT_STORE_READ"

--- a/application_sdk/storage/formats/json.py
+++ b/application_sdk/storage/formats/json.py
@@ -22,7 +22,9 @@ if TYPE_CHECKING:
     import pandas as pd
 
 from application_sdk.common.exc_utils import rewrap
+from application_sdk.errors import InvalidInputError
 from application_sdk.storage.formats import Reader, Writer
+from application_sdk.storage.formats._format_errors import ClosedReaderError
 
 logger = get_logger(__name__)
 
@@ -87,9 +89,11 @@ class JsonFileReader(Reader):
 
         # Validate that single file path and file_names are not both specified
         if path.endswith(self.extension) and file_names:
-            raise ValueError(
-                f"Cannot specify both a single file path ('{path}') and file_names filter. "
-                f"Either provide a directory path with file_names, or specify the exact file path without file_names."
+            raise InvalidInputError(
+                message=f"Cannot specify both a single file path ('{path}') and file_names filter. "
+                f"Either provide a directory path with file_names, or specify the exact file path without file_names.",
+                field="path",
+                value_summary=path,
             )
 
         # Initialise the Reader base class so `_is_closed` and
@@ -112,14 +116,18 @@ class JsonFileReader(Reader):
             ValueError: If the reader has been closed or dataframe_type is unsupported.
         """
         if self._is_closed:
-            raise ValueError("Cannot read from a closed reader")
+            raise ClosedReaderError(message="Cannot read from a closed reader")
 
         if self.dataframe_type == DataframeType.pandas:
             return await self._get_dataframe()
         elif self.dataframe_type == DataframeType.daft:
             return await self._get_daft_dataframe()
         else:
-            raise ValueError(f"Unsupported dataframe_type: {self.dataframe_type}")
+            raise InvalidInputError(
+                message=f"Unsupported dataframe_type: {self.dataframe_type}",
+                field="dataframe_type",
+                value_summary=str(self.dataframe_type),
+            )
 
     def read_batches(
         self,
@@ -134,14 +142,18 @@ class JsonFileReader(Reader):
             ValueError: If the reader has been closed or dataframe_type is unsupported.
         """
         if self._is_closed:
-            raise ValueError("Cannot read from a closed reader")
+            raise ClosedReaderError(message="Cannot read from a closed reader")
 
         if self.dataframe_type == DataframeType.pandas:
             return self._get_batched_dataframe()
         elif self.dataframe_type == DataframeType.daft:
             return self._get_batched_daft_dataframe()
         else:
-            raise ValueError(f"Unsupported dataframe_type: {self.dataframe_type}")
+            raise InvalidInputError(
+                message=f"Unsupported dataframe_type: {self.dataframe_type}",
+                field="dataframe_type",
+                value_summary=str(self.dataframe_type),
+            )
 
     async def _get_batched_dataframe(
         self,
@@ -314,7 +326,7 @@ class JsonFileWriter(Writer):
         self._statistics = None
 
         if not self.path:
-            raise ValueError("path is required")
+            raise InvalidInputError(message="path is required", field="path")
 
         if typename:
             self.path = os.path.join(self.path, typename)

--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -6,10 +6,12 @@ from typing import TYPE_CHECKING, Union, cast
 from application_sdk.common.exc_utils import rewrap
 from application_sdk.common.file_ops import SafeFileOps
 from application_sdk.constants import DAPR_MAX_GRPC_MESSAGE_LENGTH
+from application_sdk.errors import InternalError, InvalidInputError
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.observability.metrics_adaptor import MetricType, get_metrics
 from application_sdk.storage.batch import delete_prefix as _delete_prefix
 from application_sdk.storage.formats import DataframeType, Reader, WriteMode, Writer
+from application_sdk.storage.formats._format_errors import ClosedReaderError
 from application_sdk.storage.formats.utils import (
     PARQUET_FILE_EXTENSION,
     _download_files,
@@ -88,9 +90,11 @@ class ParquetFileReader(Reader):
 
         # Validate that single file path and file_names are not both specified
         if path.endswith(PARQUET_FILE_EXTENSION) and file_names:
-            raise ValueError(
-                f"Cannot specify both a single file path ('{path}') and file_names filter. "
-                f"Either provide a directory path with file_names, or specify the exact file path without file_names."
+            raise InvalidInputError(
+                message=f"Cannot specify both a single file path ('{path}') and file_names filter. "
+                f"Either provide a directory path with file_names, or specify the exact file path without file_names.",
+                field="path",
+                value_summary=path,
             )
 
         # Initialise the Reader base class so `_is_closed` and
@@ -114,14 +118,18 @@ class ParquetFileReader(Reader):
             ValueError: If the reader has been closed or dataframe_type is unsupported.
         """
         if self._is_closed:
-            raise ValueError("Cannot read from a closed reader")
+            raise ClosedReaderError(message="Cannot read from a closed reader")
 
         if self.dataframe_type == DataframeType.pandas:
             return await self._get_dataframe()
         elif self.dataframe_type == DataframeType.daft:
             return await self._get_daft_dataframe()
         else:
-            raise ValueError(f"Unsupported dataframe_type: {self.dataframe_type}")
+            raise InvalidInputError(
+                message=f"Unsupported dataframe_type: {self.dataframe_type}",
+                field="dataframe_type",
+                value_summary=str(self.dataframe_type),
+            )
 
     def read_batches(
         self,
@@ -136,14 +144,18 @@ class ParquetFileReader(Reader):
             ValueError: If the reader has been closed or dataframe_type is unsupported.
         """
         if self._is_closed:
-            raise ValueError("Cannot read from a closed reader")
+            raise ClosedReaderError(message="Cannot read from a closed reader")
 
         if self.dataframe_type == DataframeType.pandas:
             return self._get_batched_dataframe()
         elif self.dataframe_type == DataframeType.daft:
             return self._get_batched_daft_dataframe()
         else:
-            raise ValueError(f"Unsupported dataframe_type: {self.dataframe_type}")
+            raise InvalidInputError(
+                message=f"Unsupported dataframe_type: {self.dataframe_type}",
+                field="dataframe_type",
+                value_summary=str(self.dataframe_type),
+            )
 
     async def _get_dataframe(self) -> "pd.DataFrame":
         """Read data from parquet file(s) and return as pandas DataFrame.
@@ -499,7 +511,7 @@ class ParquetFileWriter(Writer):
             self.chunk_count = self.chunk_start + self.chunk_count
 
         if not self.path:
-            raise ValueError("path is required")
+            raise InvalidInputError(message="path is required", field="path")
         # Create output directory
         if self.typename:
             self.path = os.path.join(self.path, self.typename)
@@ -512,8 +524,10 @@ class ParquetFileWriter(Writer):
 
         normalized_prefix = normalize_key(self.path)
         if not normalized_prefix:
-            raise ValueError(
-                "replace_prefix=True requires a non-empty object-store prefix"
+            raise InvalidInputError(
+                message="replace_prefix=True requires a non-empty object-store prefix",
+                field="path",
+                value_summary=self.path,
             )
 
         try:
@@ -759,7 +773,11 @@ class ParquetFileWriter(Writer):
     async def _write_chunk_to_temp_folder(self, chunk: "pd.DataFrame"):
         """Write a chunk to the current temp folder."""
         if self.current_temp_folder_path is None:
-            raise ValueError("No temp folder path available")
+            raise InternalError(
+                message="No temp folder path available",
+                component="ParquetFileWriter._write_chunk_to_temp_folder",
+                invariant="current_temp_folder_path must be set before writing a chunk",
+            )
 
         # Generate file name for this chunk within the temp folder
         existing_files = len(

--- a/application_sdk/storage/formats/utils.py
+++ b/application_sdk/storage/formats/utils.py
@@ -2,12 +2,13 @@ import glob
 import os
 import uuid
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Union
 
-from application_sdk.common.error_codes import IOError
 from application_sdk.constants import TEMPORARY_PATH
+from application_sdk.errors import InvalidInputError
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.storage.batch import list_keys as _list_keys
+from application_sdk.storage.formats._format_errors import ObjectStoreReadError
 from application_sdk.storage.ops import _resolve_store, normalize_key
 from application_sdk.storage.transfer import _download_one
 
@@ -25,8 +26,8 @@ logger = get_logger(__name__)
 def find_local_files_by_extension(
     path: str,
     extension: str,
-    file_names: Optional[List[str]] = None,
-) -> List[str]:
+    file_names: list[str] | None = None,
+) -> list[str]:
     """Find local files at the specified local path, optionally filtering by file names.
 
     Args:
@@ -91,8 +92,8 @@ def find_local_files_by_extension(
 async def _download_files(
     path: str,
     file_extension: str,
-    file_names: Optional[List[str]] = None,
-) -> List[str]:
+    file_names: list[str] | None = None,
+) -> list[str]:
     """Download files from object store if not available locally.
 
     Uses SHA-256 sidecar integrity checking (via transfer._download_one) for
@@ -112,7 +113,7 @@ async def _download_files(
     from pathlib import Path as _Path  # noqa: PLC0415 — stdlib pathlib; lazy use only
 
     # Step 1: Check if files exist locally
-    local_files: List[str] = find_local_files_by_extension(
+    local_files: list[str] = find_local_files_by_extension(
         path, file_extension, file_names
     )
     if local_files:
@@ -133,7 +134,7 @@ async def _download_files(
 
     try:
         resolved = _resolve_store(None)
-        downloaded_paths: List[str] = []
+        downloaded_paths: list[str] = []
 
         # Use a unique download directory per invocation to prevent race
         # conditions when multiple activities download files concurrently
@@ -179,14 +180,16 @@ async def _download_files(
             )
             return downloaded_paths
         else:
-            raise IOError(
-                f"{IOError.OBJECT_STORE_READ_ERROR}: Downloaded from object store but no {file_extension} files found"
+            raise ObjectStoreReadError(
+                message=f"Downloaded from object store but no {file_extension} files found",
+                service="object_store",
             )
 
     except Exception as e:
-        raise IOError(
-            f"{IOError.OBJECT_STORE_DOWNLOAD_ERROR}: No {file_extension} files found locally at '{path}' and failed to download from object store. "
-            f"Error: {str(e)}"
+        raise ObjectStoreReadError(
+            message=f"No {file_extension} files found locally at '{path}' and failed to download from object store. Error: {e!s}",
+            service="object_store",
+            cause=e,
         ) from e
 
 
@@ -213,7 +216,11 @@ def estimate_dataframe_record_size(
     elif file_extension == PARQUET_FILE_EXTENSION:
         sample_file = sample.to_parquet(index=False, compression="snappy")
     else:
-        raise ValueError(f"Unsupported file extension: {file_extension}")
+        raise InvalidInputError(
+            message=f"Unsupported file extension: {file_extension}",
+            field="file_extension",
+            value_summary=file_extension,
+        )
 
     if sample_file is not None:
         # Parquet samples are already snappy-compressed above, so use the
@@ -225,10 +232,10 @@ def estimate_dataframe_record_size(
 
 
 def path_gen(
-    chunk_count: Optional[int] = None,
+    chunk_count: int | None = None,
     chunk_part: int = 0,
-    start_marker: Optional[str] = None,
-    end_marker: Optional[str] = None,
+    start_marker: str | None = None,
+    end_marker: str | None = None,
     extension: str = ".json",
 ) -> str:
     """Generate a file path for a chunk.
@@ -248,15 +255,15 @@ def path_gen(
 
     # For regular chunking - include chunk count
     if chunk_count is None:
-        return f"{str(chunk_part)}{extension}"
+        return f"{chunk_part!s}{extension}"
     else:
-        return f"chunk-{str(chunk_count)}-part{str(chunk_part)}{extension}"
+        return f"chunk-{chunk_count!s}-part{chunk_part!s}{extension}"
 
 
 def process_null_fields(
     obj: Any,
-    preserve_fields: Optional[List[str]] = None,
-    null_to_empty_dict_fields: Optional[List[str]] = None,
+    preserve_fields: list[str] | None = None,
+    null_to_empty_dict_fields: list[str] | None = None,
 ) -> Any:
     """
     By default the method removes null values from dictionaries and lists.
@@ -310,7 +317,7 @@ def convert_datetime_to_epoch(data: Any) -> Any:
     return data
 
 
-def is_empty_dataframe(dataframe: Union["pd.DataFrame", "daft.DataFrame"]) -> bool:  # noqa: F821
+def is_empty_dataframe(dataframe: Union["pd.DataFrame", "daft.DataFrame"]) -> bool:
     """Check if a DataFrame is empty.
 
     This function determines whether a DataFrame has any rows, supporting both

--- a/application_sdk/storage/ops.py
+++ b/application_sdk/storage/ops.py
@@ -59,12 +59,15 @@ except ImportError:  # pragma: no cover
     _ObstoreBaseError = None  # type: ignore[assignment,misc]
     _ObstoreNotFoundError = None  # type: ignore[assignment,misc]
 
+
 if TYPE_CHECKING:
     from typing import Any
 
     from obstore.store import ObjectStore
 
     JsonValue = dict[str, Any] | list[Any] | str | int | float | bool | None
+
+from application_sdk.app._context_errors import NoObjectStoreError
 
 # stdlib logger: cannot use get_logger here due to circular import
 # (observability -> storage -> batch -> ops -> observability)
@@ -144,10 +147,7 @@ def _resolve_store(store: ObjectStore | None) -> ObjectStore:
 
     infra = get_infrastructure()
     if infra is None or infra.storage is None:
-        raise RuntimeError(
-            "No ObjectStore provided and no infrastructure storage is configured. "
-            "Pass store= explicitly or call set_infrastructure() with a storage store."
-        )
+        raise NoObjectStoreError(message="No ObjectStore provided")
     return infra.storage
 
 

--- a/application_sdk/storage/reference.py
+++ b/application_sdk/storage/reference.py
@@ -47,6 +47,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from application_sdk.app._context_errors import NoObjectStoreError
 from application_sdk.contracts.types import FileReference
 
 if TYPE_CHECKING:
@@ -640,10 +641,7 @@ async def fetch(
 
         infra = get_infrastructure()
         if infra is None or infra.storage is None:
-            raise RuntimeError(
-                "fetch(): no object store available — pass store= explicitly "
-                "or call from inside a Temporal activity."
-            )
+            raise NoObjectStoreError(message="fetch(): no object store available")
         store = infra.storage
 
     return await materialize_file_reference(store, ref)

--- a/application_sdk/storage/transfer.py
+++ b/application_sdk/storage/transfer.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING
 
 from application_sdk.constants import MAX_CONCURRENT_STORAGE_TRANSFERS
 from application_sdk.contracts.types import FileReference, StorageTier
+from application_sdk.errors import InvalidInputError
 
 if TYPE_CHECKING:
     from obstore.store import ObjectStore
@@ -147,26 +148,37 @@ def _parse_blocked_paths() -> list[str]:
 def _validate_upload_path(path: Path) -> None:
     """Block uploads from sensitive system paths, credential dirs, and env files."""
     if ".." in path.parts:
-        raise ValueError(f"Path traversal detected in upload path: {path!r}")
+        raise InvalidInputError(
+            message=f"Path traversal detected in upload path: {path!r}", field="path"
+        )
 
     resolved = path.resolve()
     resolved_str = str(resolved)
 
     if resolved_str.startswith(_SENSITIVE_SYSTEM_PREFIXES):
-        raise ValueError(f"Upload from sensitive system path blocked: {path!r}")
+        raise InvalidInputError(
+            message=f"Upload from sensitive system path blocked: {path!r}", field="path"
+        )
 
     if any(part in _SENSITIVE_DIR_NAMES for part in resolved.parts):
-        raise ValueError(f"Upload from sensitive directory blocked: {path!r}")
+        raise InvalidInputError(
+            message=f"Upload from sensitive directory blocked: {path!r}", field="path"
+        )
 
     if resolved.is_file() and resolved.name.startswith(_SENSITIVE_FILE_PREFIXES):
-        raise ValueError(f"Upload of sensitive file blocked: {path!r}")
+        raise InvalidInputError(
+            message=f"Upload of sensitive file blocked: {path!r}", field="path"
+        )
 
     # User-defined blocked paths via ATLAN_UPLOAD_FILE_BLOCKED_PATHS (comma-separated).
     # Each entry is matched as a substring against the full resolved path.
     # e.g. ATLAN_UPLOAD_FILE_BLOCKED_PATHS="/custom/secrets/,.vault,.credentials"
     user_blocked = _parse_blocked_paths()
     if any(pattern in resolved_str for pattern in user_blocked):
-        raise ValueError(f"Upload blocked by ATLAN_UPLOAD_FILE_BLOCKED_PATHS: {path!r}")
+        raise InvalidInputError(
+            message=f"Upload blocked by ATLAN_UPLOAD_FILE_BLOCKED_PATHS: {path!r}",
+            field="path",
+        )
 
 
 async def upload(
@@ -230,8 +242,9 @@ async def upload(
             or ".." in PurePosixPath(cleaned).parts
             or "\x00" in storage_subdir
         ):
-            raise ValueError(
-                f"storage_subdir must not contain path traversal segments: {storage_subdir!r}"
+            raise InvalidInputError(
+                message=f"storage_subdir must not contain path traversal segments: {storage_subdir!r}",
+                field="storage_subdir",
             )
         storage_subdir = cleaned
 

--- a/application_sdk/templates/incremental_sql_metadata_extractor.py
+++ b/application_sdk/templates/incremental_sql_metadata_extractor.py
@@ -53,10 +53,11 @@ import asyncio
 import os
 import warnings
 from abc import abstractmethod
-from typing import Any, ClassVar, List, Optional
+from typing import Any, ClassVar
 
 from application_sdk.app.task import task
 from application_sdk.common.exc_utils import rewrap
+from application_sdk.errors import InvalidInputError, UnimplementedError
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.templates.contracts.incremental_sql import (
     ExecuteColumnBatchInput,
@@ -133,8 +134,8 @@ class IncrementalSqlMetadataExtractor(SqlMetadataExtractor):
             ``None`` means fall back to full SQL.
     """
 
-    incremental_table_sql: ClassVar[Optional[str]] = None
-    incremental_column_sql: ClassVar[Optional[str]] = None
+    incremental_table_sql: ClassVar[str | None] = None
+    incremental_column_sql: ClassVar[str | None] = None
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -165,8 +166,10 @@ class IncrementalSqlMetadataExtractor(SqlMetadataExtractor):
         filters, paths). Use ``input.connection``, ``input.credential_ref``,
         ``input.exclude_filter``, and ``input.include_filter`` as appropriate.
         """
-        raise NotImplementedError(
-            f"{type(self).__name__} must implement fetch_databases()."
+        raise UnimplementedError(
+            message=f"{type(self).__name__} must implement fetch_databases()",
+            operation="fetch_databases",
+            reason="subclass_must_override",
         )
 
     @task(timeout_seconds=1800)
@@ -176,8 +179,10 @@ class IncrementalSqlMetadataExtractor(SqlMetadataExtractor):
         Override this method in your connector subclass to execute the
         schema-listing SQL and return the results.
         """
-        raise NotImplementedError(
-            f"{type(self).__name__} must implement fetch_schemas()."
+        raise UnimplementedError(
+            message=f"{type(self).__name__} must implement fetch_schemas()",
+            operation="fetch_schemas",
+            reason="subclass_must_override",
         )
 
     @task(timeout_seconds=1800)
@@ -223,9 +228,10 @@ class IncrementalSqlMetadataExtractor(SqlMetadataExtractor):
         mutation would bleed between concurrent executions. Always resolve SQL into
         a local variable.
         """
-        raise NotImplementedError(
-            f"{type(self).__name__} must implement fetch_tables(). "
-            "See the docstring for the incremental SQL switching pattern."
+        raise UnimplementedError(
+            message=f"{type(self).__name__} must implement fetch_tables()",
+            operation="fetch_tables",
+            reason="subclass_must_override",
         )
 
     @task(timeout_seconds=1800)
@@ -252,8 +258,10 @@ class IncrementalSqlMetadataExtractor(SqlMetadataExtractor):
                     raw_path = os.path.join(input.output_path, "raw", input.typename)
                 # ... read from raw_path and write to transformed/ ...
         """
-        raise NotImplementedError(
-            f"{type(self).__name__} must implement transform_data()."
+        raise UnimplementedError(
+            message=f"{type(self).__name__} must implement transform_data()",
+            operation="transform_data",
+            reason="subclass_must_override",
         )
 
     # ------------------------------------------------------------------
@@ -263,7 +271,7 @@ class IncrementalSqlMetadataExtractor(SqlMetadataExtractor):
     @abstractmethod
     def build_incremental_column_sql(
         self,
-        table_ids: List[str],
+        table_ids: list[str],
         ctx: IncrementalRunContext,
     ) -> str:
         """Build the SQL query string for extracting columns for a batch of tables.
@@ -285,8 +293,10 @@ class IncrementalSqlMetadataExtractor(SqlMetadataExtractor):
         Returns:
             Fully rendered SQL query string ready for execution.
         """
-        raise NotImplementedError(
-            f"{type(self).__name__} must implement build_incremental_column_sql()."
+        raise UnimplementedError(
+            message=f"{type(self).__name__} must implement build_incremental_column_sql()",
+            operation="build_incremental_column_sql",
+            reason="subclass_must_override",
         )
 
     # ------------------------------------------------------------------
@@ -296,7 +306,7 @@ class IncrementalSqlMetadataExtractor(SqlMetadataExtractor):
     def resolve_database_placeholders(
         self,
         sql: str,
-        input: FetchTablesIncrementalInput,  # noqa: A002
+        input: FetchTablesIncrementalInput,
     ) -> str:
         """Replace database-specific placeholders in SQL templates.
 
@@ -354,9 +364,10 @@ class IncrementalSqlMetadataExtractor(SqlMetadataExtractor):
                 "columns will be extracted per-batch by execute_single_column_batch()"
             )
             return FetchColumnsOutput()
-        raise NotImplementedError(
-            f"{type(self).__name__} must implement fetch_columns() for full extraction. "
-            "See the docstring for the expected implementation pattern."
+        raise UnimplementedError(
+            message=f"{type(self).__name__} must implement fetch_columns() for full extraction",
+            operation="fetch_columns",
+            reason="subclass_must_override",
         )
 
     # ------------------------------------------------------------------
@@ -606,7 +617,11 @@ class IncrementalSqlMetadataExtractor(SqlMetadataExtractor):
         )
 
         if not input.output_path:
-            raise ValueError("output_path is required in ExecuteColumnBatchInput")
+            raise InvalidInputError(
+                message="output_path is required in ExecuteColumnBatchInput",
+                field="output_path",
+                constraint="must be set",
+            )
 
         # Reconstruct IncrementalRunContext from input fields for SQL building
         ctx = IncrementalRunContext(
@@ -674,7 +689,7 @@ class IncrementalSqlMetadataExtractor(SqlMetadataExtractor):
     async def execute_column_sql(
         self,
         sql: str,
-        input: ExecuteColumnBatchInput,  # noqa: A002
+        input: ExecuteColumnBatchInput,
         ctx: IncrementalRunContext,
     ) -> int:
         """Execute a column SQL query and return the record count.
@@ -693,9 +708,10 @@ class IncrementalSqlMetadataExtractor(SqlMetadataExtractor):
         Returns:
             Number of column records extracted.
         """
-        raise NotImplementedError(
-            f"{type(self).__name__} must implement execute_column_sql() "
-            "to execute the SQL built by build_incremental_column_sql()."
+        raise UnimplementedError(
+            message=f"{type(self).__name__} must implement execute_column_sql()",
+            operation="execute_column_sql",
+            reason="subclass_must_override",
         )
 
     @task(timeout_seconds=3600)

--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -74,6 +74,7 @@ from application_sdk.constants import (
 )
 from application_sdk.credentials import CredentialResolver, legacy_credential_ref
 from application_sdk.credentials.ref import CredentialRef
+from application_sdk.errors import PreconditionError, UnimplementedError
 from application_sdk.execution import build_output_path, get_object_store_prefix
 from application_sdk.infrastructure.context import get_infrastructure
 from application_sdk.observability.logger_adaptor import get_logger
@@ -404,25 +405,41 @@ class SqlApp(App):
         self, record: dict[str, Any], connection_qn: str
     ) -> Asset | dict[str, Any]:
         """Map a raw database record to a pyatlan_v9 Asset. Override in subclass."""
-        raise NotImplementedError("Override map_database() in your SqlApp subclass")
+        raise UnimplementedError(
+            message="Override map_database() in your SqlApp subclass",
+            operation="map_database",
+            reason="subclass_must_override",
+        )
 
     def map_schema(
         self, record: dict[str, Any], connection_qn: str
     ) -> Asset | dict[str, Any]:
         """Map a raw schema record to a pyatlan_v9 Asset. Override in subclass."""
-        raise NotImplementedError("Override map_schema() in your SqlApp subclass")
+        raise UnimplementedError(
+            message="Override map_schema() in your SqlApp subclass",
+            operation="map_schema",
+            reason="subclass_must_override",
+        )
 
     def map_table(
         self, record: dict[str, Any], connection_qn: str
     ) -> Asset | dict[str, Any]:
         """Map a raw table record to a pyatlan_v9 Asset. Override in subclass."""
-        raise NotImplementedError("Override map_table() in your SqlApp subclass")
+        raise UnimplementedError(
+            message="Override map_table() in your SqlApp subclass",
+            operation="map_table",
+            reason="subclass_must_override",
+        )
 
     def map_column(
         self, record: dict[str, Any], connection_qn: str
     ) -> Asset | dict[str, Any]:
         """Map a raw column record to a pyatlan_v9 Asset. Override in subclass."""
-        raise NotImplementedError("Override map_column() in your SqlApp subclass")
+        raise UnimplementedError(
+            message="Override map_column() in your SqlApp subclass",
+            operation="map_column",
+            reason="subclass_must_override",
+        )
 
     def map_procedure(
         self, record: dict[str, Any], connection_qn: str
@@ -430,9 +447,13 @@ class SqlApp(App):
         """Map a raw procedure record to a pyatlan_v9 Asset. Override in
         subclass if your connector emits procedures via the
         ``transform_procedures()`` task. Without an override the task
-        raises ``NotImplementedError`` rather than ``AttributeError``.
+        raises ``UnimplementedError`` rather than ``AttributeError``.
         """
-        raise NotImplementedError("Override map_procedure() in your SqlApp subclass")
+        raise UnimplementedError(
+            message="Override map_procedure() in your SqlApp subclass",
+            operation="map_procedure",
+            reason="subclass_must_override",
+        )
 
     # =====================================================================
     # run() — default orchestration
@@ -551,7 +572,10 @@ class SqlApp(App):
         ``build_task_input``. So here we just consume that ref.
         """
         if self.sql_client_class is None:
-            raise ValueError("sql_client_class must be set on the SqlApp subclass")
+            raise PreconditionError(
+                message="sql_client_class must be set on the SqlApp subclass",
+                expected_state="sql_client_class is not None",
+            )
 
         client = self.sql_client_class()
         creds: dict[str, Any] = {}

--- a/application_sdk/templates/sql_metadata_extractor.py
+++ b/application_sdk/templates/sql_metadata_extractor.py
@@ -37,6 +37,11 @@ from application_sdk.common.sql_filters import normalize_filters
 from application_sdk.contracts.storage import UploadInput
 from application_sdk.contracts.types import StorageTier
 from application_sdk.credentials import CredentialResolver, legacy_credential_ref
+from application_sdk.errors import (
+    InvalidInputError,
+    PreconditionError,
+    UnimplementedError,
+)
 from application_sdk.infrastructure.context import get_infrastructure
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.templates.base_metadata_extractor import BaseMetadataExtractor
@@ -165,11 +170,20 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
             legacy_credential_ref(cred_guid) if cred_guid else None
         )
         if ref is None:
-            raise ValueError("No credential reference or GUID available in task input")
+            raise InvalidInputError(
+                message="No credential reference or GUID available in task input",
+                field="credential_ref",
+                constraint="must be set via credential_ref or credential_guid",
+            )
 
         secret_store = infra.secret_store if infra else None
         if secret_store is None:
-            raise ValueError("No secret store available for credential resolution")
+            raise PreconditionError(
+                message="No secret store available for credential resolution",
+                resource="secret_store",
+                expected_state="configured",
+                actual_state="unavailable",
+            )
 
         resolver = CredentialResolver(secret_store)
         return await resolver.resolve_raw(ref)
@@ -178,12 +192,13 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
         """Create and load a SQL client using resolved credentials.
 
         Raises:
-            NotImplementedError: If ``sql_client_class`` is not set.
+            UnimplementedError: If ``sql_client_class`` is not set.
         """
         if self.sql_client_class is None:
-            raise NotImplementedError(
-                f"{type(self).__name__} must set sql_client_class to use "
-                "default SQL execution from super()."
+            raise UnimplementedError(
+                message=f"{type(self).__name__} must set sql_client_class to use default SQL execution from super()",
+                operation="_load_sql_client",
+                reason="subclass_must_override",
             )
         credentials = await self._get_credentials(input)
         client = self.sql_client_class()
@@ -257,10 +272,10 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
         two class attributes and call ``super()`` — to use this default.
         """
         if not self.fetch_database_sql:
-            raise NotImplementedError(
-                f"{type(self).__name__} must implement fetch_databases() "
-                "or set fetch_database_sql. "
-                "See application_sdk.templates.sql_metadata_extractor for examples."
+            raise UnimplementedError(
+                message=f"{type(self).__name__} must implement fetch_databases() or set fetch_database_sql",
+                operation="fetch_databases",
+                reason="subclass_must_override",
             )
         client = await self._load_sql_client(input)
         try:
@@ -287,9 +302,10 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
         Default implementation executes ``self.fetch_schema_sql``.
         """
         if not self.fetch_schema_sql:
-            raise NotImplementedError(
-                f"{type(self).__name__} must implement fetch_schemas() "
-                "or set fetch_schema_sql."
+            raise UnimplementedError(
+                message=f"{type(self).__name__} must implement fetch_schemas() or set fetch_schema_sql",
+                operation="fetch_schemas",
+                reason="subclass_must_override",
             )
         client = await self._load_sql_client(input)
         try:
@@ -316,9 +332,10 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
         Default implementation executes ``self.fetch_table_sql``.
         """
         if not self.fetch_table_sql:
-            raise NotImplementedError(
-                f"{type(self).__name__} must implement fetch_tables() "
-                "or set fetch_table_sql."
+            raise UnimplementedError(
+                message=f"{type(self).__name__} must implement fetch_tables() or set fetch_table_sql",
+                operation="fetch_tables",
+                reason="subclass_must_override",
             )
         client = await self._load_sql_client(input)
         try:
@@ -345,9 +362,10 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
         Default implementation executes ``self.fetch_column_sql``.
         """
         if not self.fetch_column_sql:
-            raise NotImplementedError(
-                f"{type(self).__name__} must implement fetch_columns() "
-                "or set fetch_column_sql."
+            raise UnimplementedError(
+                message=f"{type(self).__name__} must implement fetch_columns() or set fetch_column_sql",
+                operation="fetch_columns",
+                reason="subclass_must_override",
             )
         client = await self._load_sql_client(input)
         try:
@@ -377,17 +395,19 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
         Override this method in your connector subclass if procedure extraction
         is required.
         """
-        raise NotImplementedError(
-            f"{type(self).__name__} must implement fetch_procedures(), "
-            "or return FetchProceduresOutput() with zero counts for connectors "
-            "that do not support stored procedures."
+        raise UnimplementedError(
+            message=f"{type(self).__name__} must implement fetch_procedures()",
+            operation="fetch_procedures",
+            reason="subclass_must_override",
         )
 
     @task(timeout_seconds=1800)
     async def transform_data(self, input: TransformInput) -> TransformOutput:
         """Transform raw extracted data into the target format."""
-        raise NotImplementedError(
-            f"{type(self).__name__} must implement transform_data()."
+        raise UnimplementedError(
+            message=f"{type(self).__name__} must implement transform_data()",
+            operation="transform_data",
+            reason="subclass_must_override",
         )
 
     async def run(self, input: ExtractionInput) -> ExtractionOutput:  # type: ignore[override]

--- a/application_sdk/templates/sql_query_extractor.py
+++ b/application_sdk/templates/sql_query_extractor.py
@@ -25,6 +25,7 @@ from typing import Any, ClassVar
 from application_sdk.app.task import task
 from application_sdk.common.exc_utils import rewrap
 from application_sdk.credentials import legacy_credential_ref
+from application_sdk.errors import UnimplementedError
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.templates.base_metadata_extractor import BaseMetadataExtractor
 from application_sdk.templates.contracts.sql_query import (
@@ -78,8 +79,10 @@ class SqlQueryExtractor(BaseMetadataExtractor):
 
         Override in your subclass to implement connector-specific batch counting.
         """
-        raise NotImplementedError(
-            f"{type(self).__name__} must implement get_query_batches()."
+        raise UnimplementedError(
+            message=f"{type(self).__name__} must implement get_query_batches().",
+            operation="get_query_batches",
+            reason="subclass_must_override",
         )
 
     @task(timeout_seconds=3600)
@@ -88,8 +91,10 @@ class SqlQueryExtractor(BaseMetadataExtractor):
 
         Override this method in your connector subclass.
         """
-        raise NotImplementedError(
-            f"{type(self).__name__} must implement fetch_queries()."
+        raise UnimplementedError(
+            message=f"{type(self).__name__} must implement fetch_queries().",
+            operation="fetch_queries",
+            reason="subclass_must_override",
         )
 
     async def run(self, input: QueryExtractionInput) -> QueryExtractionOutput:  # type: ignore[override]

--- a/application_sdk/testing/integration/client.py
+++ b/application_sdk/testing/integration/client.py
@@ -10,19 +10,20 @@ It wraps the existing APIServerClient and provides:
 """
 
 import json
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 from urllib.parse import urljoin
 
 import requests
 
+from application_sdk.errors import InvalidInputError
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
 
 
 def _to_v3_credentials(
-    creds: Union[Dict[str, Any], List[Dict[str, str]]],
-) -> List[Dict[str, str]]:
+    creds: dict[str, Any] | list[dict[str, str]],
+) -> list[dict[str, str]]:
     """Convert a flat credential dict to v3 ``[{"key": k, "value": v}]`` format.
 
     If *creds* is already a list (v3 format), it is returned as-is.
@@ -39,7 +40,7 @@ def _to_v3_credentials(
     if isinstance(creds, list):
         return creds
 
-    pairs: List[Dict[str, str]] = []
+    pairs: list[dict[str, str]] = []
     # Shallow-copy to avoid mutating the caller's dict
     creds = dict(creds)
     extra = creds.pop("extra", None)
@@ -115,9 +116,9 @@ class IntegrationTestClient:
     def call_api(
         self,
         api: str,
-        args: Dict[str, Any],
-        endpoint_override: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        args: dict[str, Any],
+        endpoint_override: str | None = None,
+    ) -> dict[str, Any]:
         """Call an API based on the API type.
 
         This is the main entry point for the test framework. It routes
@@ -148,12 +149,13 @@ class IntegrationTestClient:
         elif api_lower == "config":
             return self._call_config(args)
         else:
-            raise ValueError(
-                f"Unsupported API type: '{api}'. "
-                f"Must be one of: auth, metadata, preflight, workflow, config"
+            raise InvalidInputError(
+                message=f"Unsupported API type: '{api}'. Must be one of: auth, metadata, preflight, workflow, config",
+                field="api",
+                value_summary=api,
             )
 
-    def _call_auth(self, args: Dict[str, Any]) -> Dict[str, Any]:
+    def _call_auth(self, args: dict[str, Any]) -> dict[str, Any]:
         """Call the authentication API.
 
         Sends v3-native credential format (list of key-value pairs).
@@ -169,7 +171,7 @@ class IntegrationTestClient:
         data = {"credentials": _to_v3_credentials(creds)}
         return self._post("/auth", data=data)
 
-    def _call_metadata(self, args: Dict[str, Any]) -> Dict[str, Any]:
+    def _call_metadata(self, args: dict[str, Any]) -> dict[str, Any]:
         """Call the metadata API.
 
         Sends v3-native credential format and optional connection_config.
@@ -182,14 +184,14 @@ class IntegrationTestClient:
             Dict[str, Any]: The API response.
         """
         creds = args.get("credentials", {})
-        data: Dict[str, Any] = {"credentials": _to_v3_credentials(creds)}
+        data: dict[str, Any] = {"credentials": _to_v3_credentials(creds)}
         if "connection_config" in args:
             data["connection_config"] = args["connection_config"]
         if "object_filter" in args:
             data["object_filter"] = args["object_filter"]
         return self._post("/metadata", data=data)
 
-    def _call_preflight(self, args: Dict[str, Any]) -> Dict[str, Any]:
+    def _call_preflight(self, args: dict[str, Any]) -> dict[str, Any]:
         """Call the preflight check API.
 
         Sends v3-native credential format and connection_config.
@@ -205,7 +207,7 @@ class IntegrationTestClient:
             Dict[str, Any]: The API response.
         """
         creds = args.get("credentials", {})
-        data: Dict[str, Any] = {
+        data: dict[str, Any] = {
             "credentials": _to_v3_credentials(creds),
             "connection_config": args.get(
                 "connection_config", args.get("metadata", {})
@@ -219,9 +221,9 @@ class IntegrationTestClient:
 
     def _call_workflow(
         self,
-        args: Dict[str, Any],
-        endpoint_override: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        args: dict[str, Any],
+        endpoint_override: str | None = None,
+    ) -> dict[str, Any]:
         """Call the workflow start API.
 
         Converts flat credential dicts to v3 key-value format before sending.
@@ -240,7 +242,7 @@ class IntegrationTestClient:
             data["credentials"] = _to_v3_credentials(data["credentials"])
         return self._post(endpoint, data=data)
 
-    def _call_config(self, args: Dict[str, Any]) -> Dict[str, Any]:
+    def _call_config(self, args: dict[str, Any]) -> dict[str, Any]:
         """Call the config GET or POST API.
 
         Args:
@@ -270,7 +272,7 @@ class IntegrationTestClient:
                 "error": f"Invalid config_action: '{action}'. Must be 'get' or 'update'",
             }
 
-    def get_config(self, workflow_id: str) -> Dict[str, Any]:
+    def get_config(self, workflow_id: str) -> dict[str, Any]:
         """Get the configuration for a workflow.
 
         Args:
@@ -282,8 +284,8 @@ class IntegrationTestClient:
         return self._get(f"/config/{workflow_id}")
 
     def update_config(
-        self, workflow_id: str, payload: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, workflow_id: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
         """Update the configuration for a workflow.
 
         Args:
@@ -299,7 +301,7 @@ class IntegrationTestClient:
         self,
         workflow_id: str,
         run_id: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Get the status of a workflow execution.
 
         Args:
@@ -311,7 +313,7 @@ class IntegrationTestClient:
         """
         return self._get(f"/status/{workflow_id}/{run_id}")
 
-    def _get(self, endpoint: str) -> Dict[str, Any]:
+    def _get(self, endpoint: str) -> dict[str, Any]:
         """Make a GET request to the API.
 
         Args:
@@ -364,7 +366,7 @@ class IntegrationTestClient:
                 },
             }
 
-    def _post(self, endpoint: str, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _post(self, endpoint: str, data: dict[str, Any]) -> dict[str, Any]:
         """Make a POST request to the API.
 
         Args:
@@ -420,7 +422,7 @@ class IntegrationTestClient:
                 },
             }
 
-    def _handle_response(self, response: requests.Response) -> Dict[str, Any]:
+    def _handle_response(self, response: requests.Response) -> dict[str, Any]:
         """Handle the HTTP response and convert to dictionary.
 
         Args:

--- a/application_sdk/testing/integration/comparison.py
+++ b/application_sdk/testing/integration/comparison.py
@@ -35,16 +35,17 @@ Usage::
 import os
 from dataclasses import dataclass, field
 from glob import glob
-from typing import Any, Dict, List, Optional, Set
+from typing import Any
 
 import orjson
 
+from application_sdk.errors import DataIntegrityError
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
 
 # Fields that change between runs and should be ignored by default
-DEFAULT_IGNORED_FIELDS: Set[str] = {
+DEFAULT_IGNORED_FIELDS: set[str] = {
     "qualifiedName",
     "connectionQualifiedName",
     "lastSyncWorkflowName",
@@ -59,7 +60,7 @@ DEFAULT_IGNORED_FIELDS: Set[str] = {
 }
 
 # Nested reference fields that contain run-specific qualified names
-DEFAULT_IGNORED_NESTED_FIELDS: Set[str] = {
+DEFAULT_IGNORED_NESTED_FIELDS: set[str] = {
     "atlanSchema",
     "database",
     "table",
@@ -88,7 +89,7 @@ class AssetDiff:
     asset_type: str
     asset_name: str
     diff_type: str
-    field: Optional[str] = None
+    field: str | None = None
     expected: Any = None
     actual: Any = None
 
@@ -110,9 +111,9 @@ class GapReport:
         summary: Count of diffs by type.
     """
 
-    diffs: List[AssetDiff] = field(default_factory=list)
-    summary: Dict[str, int] = field(default_factory=dict)
-    expected_file: Optional[str] = None
+    diffs: list[AssetDiff] = field(default_factory=list)
+    summary: dict[str, int] = field(default_factory=dict)
+    expected_file: str | None = None
 
     @property
     def has_gaps(self) -> bool:
@@ -138,7 +139,7 @@ class GapReport:
         lines.append("")
 
         # Group diffs by asset type
-        by_type: Dict[str, List[AssetDiff]] = {}
+        by_type: dict[str, list[AssetDiff]] = {}
         for diff in self.diffs:
             by_type.setdefault(diff.asset_type, []).append(diff)
 
@@ -152,11 +153,11 @@ class GapReport:
 
 
 def compare_metadata(
-    expected: Dict[str, List[Dict[str, Any]]],
-    actual: List[Dict[str, Any]],
+    expected: dict[str, list[dict[str, Any]]],
+    actual: list[dict[str, Any]],
     strict: bool = True,
-    ignored_fields: Optional[Set[str]] = None,
-    expected_file: Optional[str] = None,
+    ignored_fields: set[str] | None = None,
+    expected_file: str | None = None,
 ) -> GapReport:
     """Compare actual extracted metadata against an expected baseline.
 
@@ -180,7 +181,7 @@ def compare_metadata(
     report = GapReport(expected_file=expected_file)
 
     # Group actual assets by typeName
-    actual_by_type: Dict[str, List[Dict[str, Any]]] = {}
+    actual_by_type: dict[str, list[dict[str, Any]]] = {}
     for record in actual:
         type_name = record.get("typeName", "Unknown")
         actual_by_type.setdefault(type_name, []).append(record)
@@ -203,14 +204,14 @@ def compare_metadata(
             _increment_summary(report, "count_mismatch")
 
         # Build lookup dict for actual assets keyed by attributes.name
-        actual_by_name: Dict[str, Dict[str, Any]] = {}
+        actual_by_name: dict[str, dict[str, Any]] = {}
         for asset in actual_assets:
             name = _get_asset_name(asset)
             if name:
                 actual_by_name[name] = asset
 
         # Check each expected asset
-        expected_names: Set[str] = set()
+        expected_names: set[str] = set()
         for expected_asset in expected_assets:
             name = _get_asset_name(expected_asset)
             if not name:
@@ -289,7 +290,7 @@ def compare_metadata(
     return report
 
 
-def load_expected_data(file_path: str) -> Dict[str, List[Dict[str, Any]]]:
+def load_expected_data(file_path: str) -> dict[str, list[dict[str, Any]]]:
     """Load expected metadata from a JSON file.
 
     The file should contain a JSON object mapping asset type names to lists
@@ -312,16 +313,20 @@ def load_expected_data(file_path: str) -> Dict[str, List[Dict[str, Any]]]:
         data = orjson.loads(f.read())
 
     if not isinstance(data, dict):
-        raise ValueError(
-            f"Expected data file must contain a JSON object mapping asset types "
-            f"to lists, got {type(data).__name__}"
+        raise DataIntegrityError(
+            message=f"Expected data file must contain a JSON object mapping asset types to lists, got {type(data).__name__}",
+            expectation="JSON object at top level",
+            observed=type(data).__name__,
+            location=file_path,
         )
 
     for key, value in data.items():
         if not isinstance(value, list):
-            raise ValueError(
-                f"Expected data for asset type '{key}' must be a list, "
-                f"got {type(value).__name__}"
+            raise DataIntegrityError(
+                message=f"Expected data for asset type '{key}' must be a list, got {type(value).__name__}",
+                expectation="list value per asset type",
+                observed=type(value).__name__,
+                location=f"{file_path}[{key}]",
             )
 
     return data
@@ -332,7 +337,7 @@ def load_actual_output(
     workflow_id: str,
     run_id: str,
     subdirectory: str = "transformed",
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Load all extracted metadata from the output directory.
 
     Reads JSONL files from ``{base_path}/{workflow_id}/{run_id}/{subdirectory}/``
@@ -373,7 +378,7 @@ def load_actual_output(
                 output_dir,
             )
 
-    records: List[Dict[str, Any]] = []
+    records: list[dict[str, Any]] = []
     json_files = glob(os.path.join(search_dir, "**", "*.json"), recursive=True)
 
     for json_file in sorted(json_files):
@@ -392,7 +397,7 @@ def load_actual_output(
     return records
 
 
-def _get_asset_name(asset: Dict[str, Any]) -> Optional[str]:
+def _get_asset_name(asset: dict[str, Any]) -> str | None:
     """Extract a unique lookup key from an asset's attributes.
 
     For child assets like Columns that share names across parents (e.g.,
@@ -423,10 +428,10 @@ def _compare_attributes(
     report: GapReport,
     asset_type: str,
     asset_name: str,
-    expected_attrs: Dict[str, Any],
-    actual_attrs: Dict[str, Any],
+    expected_attrs: dict[str, Any],
+    actual_attrs: dict[str, Any],
     prefix: str,
-    ignored_fields: Set[str],
+    ignored_fields: set[str],
 ) -> None:
     """Compare attributes between expected and actual, adding diffs to report."""
     if not expected_attrs:

--- a/application_sdk/testing/integration/lazy.py
+++ b/application_sdk/testing/integration/lazy.py
@@ -18,7 +18,10 @@ Example:
     >>> actual_creds_again = creds.evaluate()  # Returns cached value
 """
 
-from typing import Any, Callable, Generic, TypeVar
+from collections.abc import Callable
+from typing import Any, Generic, TypeVar
+
+from application_sdk.errors import InvalidInputError
 
 T = TypeVar("T")
 
@@ -48,7 +51,10 @@ class Lazy(Generic[T]):
             fn: A callable that takes no arguments and returns the value.
         """
         if not callable(fn):
-            raise TypeError("Lazy wrapper requires a callable")
+            raise InvalidInputError(
+                message="Lazy wrapper requires a callable",
+                field="fn",
+            )
         self._fn = fn
         self._cached: T = None  # type: ignore
         self._evaluated: bool = False

--- a/application_sdk/testing/integration/models.py
+++ b/application_sdk/testing/integration/models.py
@@ -7,7 +7,10 @@ in a declarative, data-driven manner.
 import os
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any
+
+from application_sdk.errors import InvalidInputError
+from application_sdk.testing.integration.assertions import Predicate
 
 
 class APIType(Enum):
@@ -39,13 +42,12 @@ class APIType(Enum):
             return cls(value.lower())
         except ValueError:
             valid_values = [e.value for e in cls]
-            raise ValueError(
-                f"Invalid API type: '{value}'. Must be one of: {valid_values}"
+            raise InvalidInputError(
+                message=f"Invalid API type: '{value}'. Must be one of: {valid_values}",
+                field="api_type",
+                value_summary=value,
             )
 
-
-# Import from assertions to avoid duplicate definition
-from application_sdk.testing.integration.assertions import Predicate  # noqa: E402
 
 # Type alias for lazy evaluation wrapper (forward reference)
 LazyValue = Any  # Will be Lazy type from lazy.py
@@ -129,52 +131,63 @@ class Scenario:
 
     name: str
     api: str
-    assert_that: Dict[str, Predicate]
-    credentials: Optional[Dict[str, Any]] = None
-    metadata: Optional[Dict[str, Any]] = None
-    connection: Optional[Dict[str, Any]] = None
-    args: Optional[Union[Dict[str, Any], LazyValue]] = None
-    endpoint: Optional[str] = None
+    assert_that: dict[str, Predicate]
+    credentials: dict[str, Any] | None = None
+    metadata: dict[str, Any] | None = None
+    connection: dict[str, Any] | None = None
+    args: dict[str, Any] | LazyValue | None = None
+    endpoint: str | None = None
     description: str = ""
     skip: bool = False
     skip_reason: str = ""
-    expected_data: Optional[str] = None
-    extracted_output_base_path: Optional[str] = None
+    expected_data: str | None = None
+    extracted_output_base_path: str | None = None
     output_subdirectory: str = "transformed"
     strict_comparison: bool = True
     workflow_timeout: int = 300
     polling_interval: int = 10
-    ignored_fields: Optional[Set[str]] = None
-    config_action: Optional[str] = None
-    config_workflow_id: Optional[Any] = None
-    config_payload: Optional[Dict[str, Any]] = None
-    schema_base_path: Optional[str] = None
-    connection_config: Optional[Dict[str, Any]] = None
-    checks_to_run: Optional[List[str]] = None
+    ignored_fields: set[str] | None = None
+    config_action: str | None = None
+    config_workflow_id: Any | None = None
+    config_payload: dict[str, Any] | None = None
+    schema_base_path: str | None = None
+    connection_config: dict[str, Any] | None = None
+    checks_to_run: list[str] | None = None
     preflight_timeout: int = 60
 
     def __post_init__(self):
         """Validate the scenario after initialization."""
         if not self.name:
-            raise ValueError("Scenario name cannot be empty")
+            raise InvalidInputError(
+                message="Scenario name cannot be empty",
+                field="name",
+            )
 
         if not self.api:
-            raise ValueError("Scenario api cannot be empty")
+            raise InvalidInputError(
+                message="Scenario api cannot be empty",
+                field="api",
+            )
 
         # Validate API type
         valid_apis = [e.value for e in APIType]
         if self.api.lower() not in valid_apis:
-            raise ValueError(
-                f"Invalid API type: '{self.api}'. Must be one of: {valid_apis}"
+            raise InvalidInputError(
+                message=f"Invalid API type: '{self.api}'. Must be one of: {valid_apis}",
+                field="api",
+                value_summary=self.api,
             )
 
         if not self.assert_that:
-            raise ValueError("Scenario must have at least one assertion")
+            raise InvalidInputError(
+                message="Scenario must have at least one assertion",
+                field="assert_that",
+            )
 
         if self.expected_data and self.api.lower() != "workflow":
-            raise ValueError(
-                "expected_data can only be set for workflow scenarios, "
-                f"but api is '{self.api}'"
+            raise InvalidInputError(
+                message=f"expected_data can only be set for workflow scenarios, but api is '{self.api}'",
+                field="expected_data",
             )
 
         if self.expected_data and not os.path.isfile(self.expected_data):
@@ -185,12 +198,16 @@ class Scenario:
 
         if self.api.lower() == "config":
             if self.config_action not in ("get", "update"):
-                raise ValueError(
-                    f"config_action must be 'get' or 'update' for config scenarios, "
-                    f"got: {self.config_action!r}"
+                raise InvalidInputError(
+                    message=f"config_action must be 'get' or 'update' for config scenarios, got: {self.config_action!r}",
+                    field="config_action",
+                    value_summary=str(self.config_action),
                 )
             if self.config_workflow_id is None:
-                raise ValueError("config_workflow_id is required for config scenarios")
+                raise InvalidInputError(
+                    message="config_workflow_id is required for config scenarios",
+                    field="config_workflow_id",
+                )
 
     @property
     def api_type(self) -> APIType:
@@ -218,9 +235,9 @@ class ScenarioResult:
 
     scenario: Scenario
     success: bool
-    response: Optional[Dict[str, Any]] = None
-    assertion_results: Dict[str, Any] = field(default_factory=dict)
-    error: Optional[Exception] = None
+    response: dict[str, Any] | None = None
+    assertion_results: dict[str, Any] = field(default_factory=dict)
+    error: Exception | None = None
     duration_ms: float = 0.0
 
     def __str__(self) -> str:

--- a/application_sdk/testing/integration/validation.py
+++ b/application_sdk/testing/integration/validation.py
@@ -29,13 +29,14 @@ Usage:
 
 import os
 from glob import glob
-from typing import Any, Dict, List
+from typing import Any
 
 import orjson
 import pandas as pd
-import pandera.extensions as extensions
+from pandera import extensions
 from pandera.io import from_yaml  # pyright: ignore[reportPrivateImportUsage]
 
+from application_sdk.errors import DataIntegrityError
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -69,8 +70,10 @@ def check_record_count_ge(df: pd.DataFrame, *, expected_record_count: int) -> bo
     """
     if df.shape[0] >= expected_record_count:
         return True
-    raise ValueError(
-        f"Expected record count >= {expected_record_count}, got: {df.shape[0]}"
+    raise DataIntegrityError(
+        message=f"Expected record count >= {expected_record_count}, got: {df.shape[0]}",
+        expectation=f">= {expected_record_count} records",
+        observed=str(df.shape[0]),
     )
 
 
@@ -94,7 +97,7 @@ def get_normalised_dataframe(extracted_file_path: str) -> pd.DataFrame:
     Raises:
         FileNotFoundError: If no data files are found.
     """
-    data: List[Dict[str, Any]] = []
+    data: list[dict[str, Any]] = []
 
     # Search for JSON and parquet files
     json_files = glob(f"{extracted_file_path}/**/*.json", recursive=True)
@@ -117,7 +120,7 @@ def get_normalised_dataframe(extracted_file_path: str) -> pd.DataFrame:
     return pd.json_normalize(data)
 
 
-def get_schema_file_paths(schema_base_path: str) -> List[str]:
+def get_schema_file_paths(schema_base_path: str) -> list[str]:
     """Find all pandera YAML schema files in the given directory.
 
     Recursively searches for .yaml and .yml files.
@@ -151,7 +154,7 @@ def validate_with_pandera(
     schema_base_path: str,
     extracted_output_path: str,
     subdirectory: str = "transformed",
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Validate extracted output against pandera YAML schemas.
 
     For each schema file found under `schema_base_path`, the validator:
@@ -187,7 +190,7 @@ def validate_with_pandera(
         raise FileNotFoundError(f"Schema base path not found: {schema_base_path}")
 
     schema_files = get_schema_file_paths(schema_base_path)
-    results: List[Dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
 
     output_base = (
         os.path.join(extracted_output_path, subdirectory)
@@ -219,7 +222,7 @@ def validate_with_pandera(
 
         extracted_file_path = os.path.join(output_base, extracted_path_suffix)
 
-        result: Dict[str, Any] = {
+        result: dict[str, Any] = {
             "schema_file": schema_file,
             "entity": entity,
             "success": False,
@@ -264,7 +267,7 @@ def validate_with_pandera(
     return results
 
 
-def format_validation_report(results: List[Dict[str, Any]]) -> str:
+def format_validation_report(results: list[dict[str, Any]]) -> str:
     """Format pandera validation results into a human-readable report.
 
     Args:

--- a/application_sdk/testing/scale_data_generator/config_loader.py
+++ b/application_sdk/testing/scale_data_generator/config_loader.py
@@ -1,8 +1,10 @@
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any
 
 import yaml
+
+from application_sdk.errors import InvalidInputError
 
 
 class OutputFormat(Enum):
@@ -14,7 +16,7 @@ class OutputFormat(Enum):
 class ConfigLoader:
     def __init__(self, config_path: str):
         self.config_path = Path(config_path)
-        self.config: Optional[Dict[str, Any]] = None
+        self.config: dict[str, Any] | None = None
         self._load_config()
 
     def _load_config(self) -> None:
@@ -26,24 +28,34 @@ class ConfigLoader:
         except FileNotFoundError:
             raise FileNotFoundError(f"Config file not found at: {self.config_path}")
         except yaml.YAMLError as e:
-            raise ValueError(f"Invalid YAML format: {str(e)}")
+            raise InvalidInputError(
+                message=f"Invalid YAML format: {e!s}",
+                field="config_path",
+                value_summary=str(self.config_path),
+            ) from e
 
     def _validate_config(self) -> None:
         """Validate the configuration structure."""
         required_sections = ["database", "hierarchy", "schema"]
         for section in required_sections:
             if section not in self.config:
-                raise ValueError(f"Missing required section: {section}")
+                raise InvalidInputError(
+                    message=f"Missing required section: {section}",
+                    field=section,
+                )
 
         # Validate schema references
         schema_tables = {schema["name"] for schema in self.config["schema"]}
         hierarchy_tables = self._get_hierarchy_tables(self.config["hierarchy"][0])
 
         if schema_tables != hierarchy_tables:
-            raise ValueError("Mismatch between schema and hierarchy table definitions")
+            raise InvalidInputError(
+                message="Mismatch between schema and hierarchy table definitions",
+                field="schema_or_hierarchy",
+            )
 
     def _get_hierarchy_tables(
-        self, hierarchy: Dict[str, Any], tables: Optional[set[str]] = None
+        self, hierarchy: dict[str, Any], tables: set[str] | None = None
     ) -> set[str]:
         """Recursively get all table names from hierarchy."""
         if tables is None:
@@ -56,17 +68,21 @@ class ConfigLoader:
 
         return tables
 
-    def get_table_schema(self, table_name: str) -> Dict[str, Any]:
+    def get_table_schema(self, table_name: str) -> dict[str, Any]:
         """Get schema definition for a specific table."""
         for schema in self.config["schema"]:
             if schema["name"] == table_name:
                 return schema
-        raise ValueError(f"Schema not found for table: {table_name}")
+        raise InvalidInputError(
+            message=f"Schema not found for table: {table_name}",
+            field="table_name",
+            value_summary=table_name,
+        )
 
-    def get_hierarchy(self) -> Dict[str, Any]:
+    def get_hierarchy(self) -> dict[str, Any]:
         """Get the hierarchy configuration."""
         return self.config["hierarchy"][0]
 
-    def get_database(self) -> Dict[str, Any]:
+    def get_database(self) -> dict[str, Any]:
         """Get the database configuration."""
         return self.config["database"][0]

--- a/application_sdk/transformers/__init__.py
+++ b/application_sdk/transformers/__init__.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, Type
+from typing import TYPE_CHECKING, Any
+
+from application_sdk.errors import UnimplementedError
 
 if TYPE_CHECKING:
     import daft
@@ -23,7 +25,7 @@ class TransformerInterface(ABC):
         dataframe: "daft.DataFrame",
         workflow_id: str,
         workflow_run_id: str,
-        entity_class_definitions: Dict[str, Type[Any]] | None = None,
+        entity_class_definitions: dict[str, type[Any]] | None = None,
         **kwargs: Any,
     ) -> "daft.DataFrame":
         """Transform metadata from one format to another.
@@ -47,6 +49,10 @@ class TransformerInterface(ABC):
                 transformation is not applicable or possible.
 
         Raises:
-            NotImplementedError: If the subclass does not implement this method.
+            UnimplementedError: If the subclass does not implement this method.
         """
-        raise NotImplementedError
+        raise UnimplementedError(
+            message="Subclass must implement transform_metadata",
+            operation="transform_metadata",
+            reason="subclass_must_override",
+        )

--- a/application_sdk/transformers/atlas/_atlas_errors.py
+++ b/application_sdk/transformers/atlas/_atlas_errors.py
@@ -1,0 +1,16 @@
+"""Typed data-integrity errors for atlas entity transformations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from application_sdk.errors import DataIntegrityError
+
+
+@dataclass(kw_only=True)
+class EntityTransformError(DataIntegrityError):
+    """Atlas entity failed invariant validation during transformation."""
+
+    entity_type: str | None = None
+    code: ClassVar[str] = "DATA_INTEGRITY_ENTITY_TRANSFORM"

--- a/application_sdk/transformers/atlas/sql.py
+++ b/application_sdk/transformers/atlas/sql.py
@@ -7,13 +7,15 @@ including databases, schemas, tables, columns, functions, and tag attachments.
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Optional, Set, TypeVar, overload
+from typing import Any, TypeVar, overload
 
 from pyatlan.model import assets
 from pyatlan.model.enums import AtlanConnectorType
 from pyatlan.utils import init_guid, validate_required_fields
 
+from application_sdk.errors import DataIntegrityError, InternalError
 from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.transformers.atlas._atlas_errors import EntityTransformError
 from application_sdk.transformers.common.utils import build_atlas_qualified_name
 
 logger = get_logger(__name__)
@@ -41,7 +43,7 @@ class Procedure(assets.Procedure):
     """
 
     @classmethod
-    def get_attributes(cls, obj: Dict[str, Any]) -> Dict[str, Any]:
+    def get_attributes(cls, obj: dict[str, Any]) -> dict[str, Any]:
         """Parse a dictionary into a Procedure entity's attributes.
 
         This method validates required fields and constructs the procedure's
@@ -63,7 +65,7 @@ class Procedure(assets.Procedure):
                 - entity_class (Type): The Procedure class type
 
         Raises:
-            ValueError: If any required fields are missing or None.
+            EntityTransformError: If any required fields are missing or None.
         """
         try:
             assert (
@@ -124,7 +126,14 @@ class Procedure(assets.Procedure):
                 "entity_class": Procedure,
             }
         except AssertionError as e:
-            raise ValueError(f"Error creating Procedure Entity: {str(e)}") from e
+            raise EntityTransformError(
+                message=f"Error creating Procedure Entity: {e!s}",
+                entity_type="Procedure",
+                expectation="entity invariant",
+                observed=str(e),
+                location="atlas_transformer",
+                cause=e,
+            ) from e
 
 
 class Database(assets.Database):
@@ -134,7 +143,7 @@ class Database(assets.Database):
     """
 
     @classmethod
-    def get_attributes(cls, obj: Dict[str, Any]) -> Dict[str, Any]:
+    def get_attributes(cls, obj: dict[str, Any]) -> dict[str, Any]:
         """Parse a dictionary into a Database entity.
 
         Args:
@@ -144,7 +153,7 @@ class Database(assets.Database):
             assets.Database: The created Database entity.
 
         Raises:
-            ValueError: If required fields are missing or invalid.
+            EntityTransformError: If required fields are missing or invalid.
         """
         try:
             assert obj.get("database_name") is not None and isinstance(
@@ -176,7 +185,14 @@ class Database(assets.Database):
                 "entity_class": Database,
             }
         except AssertionError as e:
-            raise ValueError(f"Error creating Database Entity: {str(e)}") from e
+            raise EntityTransformError(
+                message=f"Error creating Database Entity: {e!s}",
+                entity_type="Database",
+                expectation="entity invariant",
+                observed=str(e),
+                location="atlas_transformer:database",
+                cause=e,
+            ) from e
 
 
 class Schema(assets.Schema):
@@ -186,7 +202,7 @@ class Schema(assets.Schema):
     """
 
     @classmethod
-    def get_attributes(cls, obj: Dict[str, Any]) -> Dict[str, Any]:
+    def get_attributes(cls, obj: dict[str, Any]) -> dict[str, Any]:
         """Parse a dictionary into a Schema entity.
 
         Args:
@@ -196,7 +212,7 @@ class Schema(assets.Schema):
             assets.Schema: The created Schema entity.
 
         Raises:
-            ValueError: If required fields are missing or invalid.
+            EntityTransformError: If required fields are missing or invalid.
         """
         try:
             assert obj.get("schema_name") is not None and isinstance(
@@ -245,7 +261,14 @@ class Schema(assets.Schema):
                 "entity_class": Schema,
             }
         except AssertionError as e:
-            raise ValueError(f"Error creating Schema Entity: {str(e)}") from e
+            raise EntityTransformError(
+                message=f"Error creating Schema Entity: {e!s}",
+                entity_type="Schema",
+                expectation="entity invariant",
+                observed=str(e),
+                location="atlas_transformer:schema",
+                cause=e,
+            ) from e
 
 
 class Table(assets.Table):
@@ -256,7 +279,7 @@ class Table(assets.Table):
     """
 
     @classmethod
-    def get_attributes(cls, obj: Dict[str, Any]) -> Dict[str, Any]:
+    def get_attributes(cls, obj: dict[str, Any]) -> dict[str, Any]:
         """Parse a dictionary into a Table entity.
 
         Args:
@@ -267,7 +290,7 @@ class Table(assets.Table):
                 The created Table entity.
 
         Raises:
-            ValueError: If required fields are missing or invalid.
+            EntityTransformError: If required fields are missing or invalid.
         """
         try:
             # Needed? Sequences don't have a table_name, table_schema
@@ -481,7 +504,14 @@ class Table(assets.Table):
                 "entity_class": table_type,
             }
         except AssertionError as e:
-            raise ValueError(f"Error creating Table Entity: {str(e)}") from e
+            raise EntityTransformError(
+                message=f"Error creating Table Entity: {e!s}",
+                entity_type="Table",
+                expectation="entity invariant",
+                observed=str(e),
+                location="atlas_transformer:table",
+                cause=e,
+            ) from e
 
 
 class Column(assets.Column):
@@ -491,7 +521,7 @@ class Column(assets.Column):
     """
 
     @classmethod
-    def get_attributes(cls, obj: Dict[str, Any]) -> Dict[str, Any]:
+    def get_attributes(cls, obj: dict[str, Any]) -> dict[str, Any]:
         """Parse a dictionary into a Column entity.
 
         Args:
@@ -501,7 +531,7 @@ class Column(assets.Column):
             assets.Column: The created Column entity.
 
         Raises:
-            ValueError: If required fields are missing or invalid.
+            EntityTransformError: If required fields are missing or invalid.
         """
         try:
             assert obj.get("column_name") is not None, "Column name cannot be None"
@@ -648,7 +678,14 @@ class Column(assets.Column):
                 "entity_class": Column,
             }
         except AssertionError as e:
-            raise ValueError(f"Error creating Column Entity: {str(e)}") from e
+            raise EntityTransformError(
+                message=f"Error creating Column Entity: {e!s}",
+                entity_type="Column",
+                expectation="entity invariant",
+                observed=str(e),
+                location="atlas_transformer:column",
+                cause=e,
+            ) from e
 
 
 class Function(assets.Function):
@@ -688,7 +725,7 @@ class Function(assets.Function):
         database_name: None = None,
         database_qualified_name: None = None,
         connection_qualified_name: None = None,
-    ) -> "Function": ...
+    ) -> Function: ...
 
     @overload
     @classmethod
@@ -701,7 +738,7 @@ class Function(assets.Function):
         database_name: str,
         database_qualified_name: str,
         connection_qualified_name: str,
-    ) -> "Function": ...
+    ) -> Function: ...
 
     @classmethod
     @init_guid
@@ -710,11 +747,11 @@ class Function(assets.Function):
         *,
         name: str,
         schema_qualified_name: str,
-        schema_name: Optional[str] = None,
-        database_name: Optional[str] = None,
-        database_qualified_name: Optional[str] = None,
-        connection_qualified_name: Optional[str] = None,
-    ) -> "Function":
+        schema_name: str | None = None,
+        database_name: str | None = None,
+        database_qualified_name: str | None = None,
+        connection_qualified_name: str | None = None,
+    ) -> Function:
         """Create a new Function entity.
 
         Args:
@@ -756,7 +793,7 @@ class Function(assets.Function):
         """
 
         # overriding function_arguments same as in super class
-        function_arguments: Optional[Set[str]] = None
+        function_arguments: set[str] | None = None
 
         @classmethod
         @init_guid
@@ -765,11 +802,11 @@ class Function(assets.Function):
             *,
             name: str,
             schema_qualified_name: str,
-            schema_name: Optional[str] = None,
-            database_name: Optional[str] = None,
-            database_qualified_name: Optional[str] = None,
-            connection_qualified_name: Optional[str] = None,
-        ) -> "Function.Attributes":
+            schema_name: str | None = None,
+            database_name: str | None = None,
+            database_qualified_name: str | None = None,
+            connection_qualified_name: str | None = None,
+        ) -> Function.Attributes:
             """Create a new Function.Attributes instance.
 
             Args:
@@ -805,8 +842,10 @@ class Function(assets.Function):
                         else "unknown"
                     )
                 else:
-                    raise ValueError(
-                        f"Invalid result from AtlanConnectorType.get_connector_name: {result}"
+                    raise InternalError(
+                        message=f"Invalid result from AtlanConnectorType.get_connector_name: {result!r}",
+                        component="atlas_transformer:Function",
+                        invariant="get_connector_name returns (connection_qn, connector_name) tuple",
                     )
 
             fields = schema_qualified_name.split("/")
@@ -833,7 +872,7 @@ class Function(assets.Function):
             )
 
     @classmethod
-    def get_attributes(cls, obj: Dict[str, Any]) -> Dict[str, Any]:
+    def get_attributes(cls, obj: dict[str, Any]) -> dict[str, Any]:
         """Parse a dictionary into a Function entity.
 
         Args:
@@ -843,7 +882,7 @@ class Function(assets.Function):
             assets.Function: The created Function entity.
 
         Raises:
-            ValueError: If required fields are missing or invalid.
+            EntityTransformError: If required fields are missing or invalid.
         """
         try:
             assert (
@@ -911,8 +950,10 @@ class Function(assets.Function):
             if not (
                 argument_signature.startswith("(") and argument_signature.endswith(")")
             ):
-                raise ValueError(
-                    f"Malformed argument_signature: {argument_signature!r}"
+                raise DataIntegrityError(
+                    message=f"Malformed argument_signature: {argument_signature!r}",
+                    expectation="argument_signature starts with '(' and ends with ')'",
+                    observed=argument_signature,
                 )
             inner = argument_signature[1:-1]
             function_attributes["function_arguments"] = list(inner.split(","))
@@ -935,7 +976,14 @@ class Function(assets.Function):
                 "entity_class": Function,
             }
         except AssertionError as e:
-            raise ValueError(f"Error creating Function Entity: {str(e)}") from e
+            raise EntityTransformError(
+                message=f"Error creating Function Entity: {e!s}",
+                entity_type="Function",
+                expectation="entity invariant",
+                observed=str(e),
+                location="atlas_transformer:function",
+                cause=e,
+            ) from e
 
 
 class TagAttachment(assets.TagAttachment):
@@ -956,7 +1004,7 @@ class TagAttachment(assets.TagAttachment):
         database_name: None = None,
         database_qualified_name: None = None,
         connection_qualified_name: None = None,
-    ) -> "TagAttachment": ...
+    ) -> TagAttachment: ...
 
     @overload
     @classmethod
@@ -969,7 +1017,7 @@ class TagAttachment(assets.TagAttachment):
         database_name: str,
         database_qualified_name: str,
         connection_qualified_name: str,
-    ) -> "TagAttachment": ...
+    ) -> TagAttachment: ...
 
     @classmethod
     @init_guid
@@ -978,11 +1026,11 @@ class TagAttachment(assets.TagAttachment):
         *,
         name: str,
         schema_qualified_name: str,
-        schema_name: Optional[str] = None,
-        database_name: Optional[str] = None,
-        database_qualified_name: Optional[str] = None,
-        connection_qualified_name: Optional[str] = None,
-    ) -> "TagAttachment":
+        schema_name: str | None = None,
+        database_name: str | None = None,
+        database_qualified_name: str | None = None,
+        connection_qualified_name: str | None = None,
+    ) -> TagAttachment:
         """Create a new TagAttachment entity.
 
         Args:
@@ -1021,8 +1069,8 @@ class TagAttachment(assets.TagAttachment):
             *,
             name: str,
             schema_qualified_name: str,
-            connection_qualified_name: Optional[str] = None,
-        ) -> "TagAttachment.Attributes":
+            connection_qualified_name: str | None = None,
+        ) -> TagAttachment.Attributes:
             """Create a new TagAttachment.Attributes instance.
 
             Args:
@@ -1055,8 +1103,10 @@ class TagAttachment(assets.TagAttachment):
                     )
                 else:
                     # Handle the case where result is not a tuple
-                    raise ValueError(
-                        f"Invalid result from AtlanConnectorType.get_connector_name: {result}"
+                    raise InternalError(
+                        message=f"Invalid result from AtlanConnectorType.get_connector_name: {result!r}",
+                        component="atlas_transformer:TagAttachment",
+                        invariant="get_connector_name returns (connection_qn, connector_name) tuple",
                     )
 
             qualified_name = f"{schema_qualified_name}/{name}"
@@ -1070,7 +1120,7 @@ class TagAttachment(assets.TagAttachment):
             )
 
     @classmethod
-    def get_attributes(cls, obj: Dict[str, Any]) -> Dict[str, Any]:
+    def get_attributes(cls, obj: dict[str, Any]) -> dict[str, Any]:
         """Parse a dictionary into a TagAttachment entity.
 
         Args:
@@ -1080,7 +1130,7 @@ class TagAttachment(assets.TagAttachment):
             assets.TagAttachment: The created TagAttachment entity.
 
         Raises:
-            ValueError: If required fields are missing or invalid.
+            EntityTransformError: If required fields are missing or invalid.
         """
         try:
             assert (
@@ -1161,14 +1211,11 @@ class TagAttachment(assets.TagAttachment):
                     object_qualified_name = build_atlas_qualified_name(
                         obj["connection_qualified_name"], object_cat, object_name
                     )
-                elif object_domain == "SCHEMA":
-                    object_qualified_name = build_atlas_qualified_name(
-                        obj["connection_qualified_name"],
-                        object_cat,
-                        object_schema,
-                        object_name,
-                    )
-                elif object_domain in ["TABLE", "STREAM", "PIPE"]:
+                elif object_domain == "SCHEMA" or object_domain in [
+                    "TABLE",
+                    "STREAM",
+                    "PIPE",
+                ]:
                     object_qualified_name = build_atlas_qualified_name(
                         obj["connection_qualified_name"],
                         object_cat,
@@ -1218,4 +1265,11 @@ class TagAttachment(assets.TagAttachment):
                 "entity_class": TagAttachment,
             }
         except AssertionError as e:
-            raise ValueError(f"Error creating TagAttachment Entity: {str(e)}") from e
+            raise EntityTransformError(
+                message=f"Error creating TagAttachment Entity: {e!s}",
+                entity_type="TagAttachment",
+                expectation="entity invariant",
+                observed=str(e),
+                location="atlas_transformer:tag_attachment",
+                cause=e,
+            ) from e

--- a/application_sdk/transformers/query/__init__.py
+++ b/application_sdk/transformers/query/__init__.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import textwrap
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
 
 import yaml
 from pyatlan.model.enums import AtlanConnectorType
@@ -10,6 +10,7 @@ from pyatlan.model.enums import AtlanConnectorType
 if TYPE_CHECKING:
     import daft
 
+from application_sdk.errors import InvalidInputError, UnimplementedError
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.transformers import TransformerInterface
 from application_sdk.transformers.common.utils import (
@@ -47,7 +48,7 @@ class QueryBasedTransformer(TransformerInterface):
     def __init__(self, connector_name: str, tenant_id: str, **kwargs: Any):
         self.connector_name = connector_name
         self.tenant_id = tenant_id
-        self.entity_class_definitions: Dict[str, str] = (
+        self.entity_class_definitions: dict[str, str] = (
             get_yaml_query_template_path_mappings(
                 assets=[
                     "TABLE",
@@ -74,7 +75,7 @@ class QueryBasedTransformer(TransformerInterface):
         return column_name
 
     def convert_to_sql_expression(
-        self, column: Dict[str, str], is_literal: bool = False
+        self, column: dict[str, str], is_literal: bool = False
     ) -> str:
         """Process a single column definition into a SQL column expression.
 
@@ -91,10 +92,10 @@ class QueryBasedTransformer(TransformerInterface):
 
     def get_sql_column_expressions(
         self,
-        sql_template: Dict[str, Any],
+        sql_template: dict[str, Any],
         dataframe: daft.DataFrame,
-        default_attributes: Dict[str, Any],
-    ) -> Tuple[List[str], Optional[List[Dict[str, str]]]]:
+        default_attributes: dict[str, Any],
+    ) -> tuple[list[str], list[dict[str, str]] | None]:
         """Get the columns and literal columns for the SQL query.
 
         Args:
@@ -105,8 +106,8 @@ class QueryBasedTransformer(TransformerInterface):
         Returns:
             A list of column expressions for the SQL query
         """
-        columns: List[str] = []
-        literal_columns: List[Dict[str, str]] = []
+        columns: list[str] = []
+        literal_columns: list[dict[str, str]] = []
         column_names = dataframe.column_names + list(default_attributes.keys())
 
         # Add the columns from the SQL template to the columns list only if they are present in the dataframe
@@ -118,17 +119,11 @@ class QueryBasedTransformer(TransformerInterface):
             # - name: attributes.qualifiedName
             #   source_query: concat(connection_qualified_name, '/', table_catalog, '/', table_schema, '/', table_name)
             #   source_columns: [connection_qualified_name, table_catalog, table_schema, table_name]
-            if column.get("source_columns") and (
-                all(col in column_names for col in column["source_columns"])
+            if (
+                column.get("source_columns")
+                and (all(col in column_names for col in column["source_columns"]))
+                or column["source_query"] in column_names
             ):
-                columns.append(self.convert_to_sql_expression(column))
-
-            # Else if the column has a source_query attribute and the source_query is present in the dataframe,
-            # then add the column to the columns list
-            # E.g
-            # - name: attributes.tableName
-            #   source_query: table_name
-            elif column["source_query"] in column_names:
                 columns.append(self.convert_to_sql_expression(column))
 
             # Else if the column has a string literal, then add the column to the literal_columns list
@@ -159,8 +154,8 @@ class QueryBasedTransformer(TransformerInterface):
         self,
         yaml_path: str,
         dataframe: daft.DataFrame,
-        default_attributes: Dict[str, Any],
-    ) -> Tuple[str, Optional[List[Dict[str, str]]]]:
+        default_attributes: dict[str, Any],
+    ) -> tuple[str, list[dict[str, str]] | None]:
         """
         Generate a SQL query from a YAML template and a DataFrame.
 
@@ -193,7 +188,7 @@ class QueryBasedTransformer(TransformerInterface):
         """)
         return sql_query, literal_columns or None
 
-    def _build_struct(self, level: dict, prefix: str = "") -> Optional[daft.Expression]:
+    def _build_struct(self, level: dict, prefix: str = "") -> daft.Expression | None:
         """
         Recursively build nested struct expressions.
 
@@ -207,11 +202,17 @@ class QueryBasedTransformer(TransformerInterface):
 
         # Check if level is None
         if level is None:
-            raise ValueError("level cannot be None in _build_struct")
+            raise InvalidInputError(
+                message="level cannot be None in _build_struct",
+                field="level",
+            )
 
         # Check if prefix is None
         if prefix is None:
-            raise ValueError("prefix cannot be None in _build_struct")
+            raise InvalidInputError(
+                message="prefix cannot be None in _build_struct",
+                field="prefix",
+            )
 
         import daft  # noqa: PLC0415 — optional dep: daft
         from daft.functions import to_struct, when  # noqa: PLC0415 — optional dep: daft
@@ -354,10 +355,10 @@ class QueryBasedTransformer(TransformerInterface):
         dataframe: daft.DataFrame,
         workflow_id: str,
         workflow_run_id: str,
-        connection_qualified_name: Optional[str] = None,
-        connection_name: Optional[str] = None,
-        entity_sql_template_path: Optional[str] = None,
-    ) -> Tuple[daft.DataFrame, str]:
+        connection_qualified_name: str | None = None,
+        connection_name: str | None = None,
+        entity_sql_template_path: str | None = None,
+    ) -> tuple[daft.DataFrame, str]:
         """
         Prepare the entity SQL template and the default attributes for the DataFrame.
 
@@ -380,9 +381,7 @@ class QueryBasedTransformer(TransformerInterface):
             "tenant_id": daft.lit(self.tenant_id),
             "last_sync_workflow_name": daft.lit(workflow_id),
             "last_sync_run": daft.lit(workflow_run_id),
-            "last_sync_run_at": daft.lit(
-                int(datetime.now(timezone.utc).timestamp() * 1000)
-            ),
+            "last_sync_run_at": daft.lit(int(datetime.now(UTC).timestamp() * 1000)),
             "connector_name": daft.lit(
                 AtlanConnectorType.get_connector_name(connection_qualified_name)
             ),
@@ -416,9 +415,9 @@ class QueryBasedTransformer(TransformerInterface):
         dataframe: daft.DataFrame,
         workflow_id: str,
         workflow_run_id: str,
-        entity_class_definitions: Dict[str, Type[Any]] | None = None,
+        entity_class_definitions: dict[str, type[Any]] | None = None,
         **kwargs: Any,
-    ) -> Optional[daft.DataFrame]:
+    ) -> daft.DataFrame | None:
         """Transform records using SQL executed through Daft"""
         if dataframe.count_rows() == 0:
             return None
@@ -430,7 +429,10 @@ class QueryBasedTransformer(TransformerInterface):
         )
         entity_sql_template_path = self.entity_class_definitions.get(typename)
         if not entity_sql_template_path:
-            raise ValueError(f"No SQL transformation registered for {typename}")
+            raise UnimplementedError(
+                message=f"No SQL transformation registered for {typename}",
+                operation=f"transform_metadata:{typename}",
+            )
 
         # prepare the SQL to run on the dataframe and the default attributes
         dataframe, entity_sql_template = self.prepare_template_and_attributes(

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.8.0
-source-sha:    de1e7a2d7251d3bd2b3b9cd68dfe88587f3d237e
-source-date:   2026-05-11T12:16:02+01:00
+sdk-version:   3.9.0
+source-sha:    239d2902d7da024dd255706de0a31505dca0b028
+source-date:   2026-05-12T16:47:23+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/tests/unit/app/test_base.py
+++ b/tests/unit/app/test_base.py
@@ -39,7 +39,7 @@ from application_sdk.app.entrypoint import (
 from application_sdk.app.registry import AppNotFoundError, AppRegistry
 from application_sdk.app.task import task
 from application_sdk.contracts.base import Input, Output
-from application_sdk.errors import APP_ERROR, APP_NON_RETRYABLE
+from application_sdk.errors import APP_ERROR, APP_NON_RETRYABLE, UnimplementedError
 
 # =============================================================================
 # Test fixtures
@@ -208,7 +208,7 @@ class TestAppRegistration:
         """
 
         class AbstractSubApp(App):
-            # No run() override — inherits the default raise NotImplementedError
+            # No run() override — inherits the default raise UnimplementedError
             pass
 
         registry = AppRegistry.get_instance()
@@ -726,7 +726,7 @@ class TestAppConvenience:
 
 
 # =============================================================================
-# default run() — raises NotImplementedError when not overridden
+# default run() — raises UnimplementedError when not overridden
 # =============================================================================
 
 
@@ -734,11 +734,11 @@ class TestRunStub:
     @pytest.mark.asyncio
     async def test_default_run_raises_not_implemented(self) -> None:
         # NoRunApp inherits the App.run stub silently; call it directly to
-        # exercise the NotImplementedError branch.
+        # exercise the UnimplementedError branch.
         class _NoRun(App):
             pass
 
-        with pytest.raises(NotImplementedError, match="must implement run"):
+        with pytest.raises(UnimplementedError, match="must implement run"):
             await _NoRun().run(_BLDXInput())
 
 

--- a/tests/unit/app/test_context.py
+++ b/tests/unit/app/test_context.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from application_sdk.app._context_errors import NoSecretStoreError, NoStateStoreError
 from application_sdk.app.context import (
     AppContext,
     AppMetadata,
@@ -149,13 +150,13 @@ class TestAppContextStateStore:
     @pytest.mark.asyncio
     async def test_save_state_without_store_raises(self) -> None:
         ctx = AppContext(app_name="a", app_version="1")
-        with pytest.raises(RuntimeError, match="No state store configured"):
+        with pytest.raises(NoStateStoreError, match="No state store configured"):
             await ctx.save_state("k", {})
 
     @pytest.mark.asyncio
     async def test_load_state_without_store_raises(self) -> None:
         ctx = AppContext(app_name="a", app_version="1")
-        with pytest.raises(RuntimeError, match="No state store configured"):
+        with pytest.raises(NoStateStoreError, match="No state store configured"):
             await ctx.load_state("k")
 
 
@@ -175,7 +176,7 @@ class TestAppContextSecretStore:
     @pytest.mark.asyncio
     async def test_get_secret_without_store_raises(self) -> None:
         ctx = AppContext(app_name="a", app_version="1")
-        with pytest.raises(RuntimeError, match="No secret store configured"):
+        with pytest.raises(NoSecretStoreError, match="No secret store configured"):
             await ctx.get_secret("anything")
 
     @pytest.mark.asyncio
@@ -227,7 +228,7 @@ class TestAppContextCredentialResolution:
         cred_store = MockCredentialStore()
         ref = cred_store.add_basic("svc", username="u", password="p")
         ctx = AppContext(app_name="a", app_version="1")
-        with pytest.raises(RuntimeError, match="No secret store configured"):
+        with pytest.raises(NoSecretStoreError, match="No secret store configured"):
             await ctx.resolve_credential(ref)
 
     @pytest.mark.asyncio
@@ -235,7 +236,7 @@ class TestAppContextCredentialResolution:
         cred_store = MockCredentialStore()
         ref = cred_store.add_basic("svc", username="u", password="p")
         ctx = AppContext(app_name="a", app_version="1")
-        with pytest.raises(RuntimeError, match="No secret store configured"):
+        with pytest.raises(NoSecretStoreError, match="No secret store configured"):
             await ctx.resolve_credential_raw(ref)
 
 
@@ -478,13 +479,13 @@ class TestModuleHelpers:
 
     def test_is_atlan_logger_duck_type(self) -> None:
         class Atlan:
-            def process(self):  # noqa: D401
+            def process(self):
                 return None
 
             logger_name = "x"
 
         class NotAtlan:
-            def process(self):  # noqa: D401
+            def process(self):
                 return None
 
         assert _is_atlan_logger(Atlan()) is True
@@ -671,7 +672,7 @@ class TestTaskExecutionContextRunInThread:
         ``application_sdk.execution.heartbeat`` without updating ``context.py``,
         this assertion fails fast with a clear error.
         """
-        from application_sdk.execution.heartbeat import run_in_thread  # noqa: PLC0415
+        from application_sdk.execution.heartbeat import run_in_thread
 
         assert callable(run_in_thread)
 

--- a/tests/unit/clients/test_azure_auth.py
+++ b/tests/unit/clients/test_azure_auth.py
@@ -6,7 +6,7 @@ import pytest
 from azure.core.exceptions import ClientAuthenticationError
 
 from application_sdk.clients.azure.auth import AzureAuthProvider
-from application_sdk.common.error_codes import CommonError
+from application_sdk.errors import AppError
 
 
 class TestAzureAuthProvider:
@@ -20,12 +20,12 @@ class TestAzureAuthProvider:
     @pytest.mark.asyncio
     async def test_unsupported_auth_type(self, auth_provider):
         """Test that unsupported authentication types raise appropriate errors."""
-        with pytest.raises(CommonError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             await auth_provider.create_credential("unsupported_type", {})
 
         error_message = str(exc_info.value)
         assert "Only 'service_principal' authentication is supported" in error_message
-        assert "Received: unsupported_type" in error_message
+        assert "unsupported_type" in error_message
 
     @pytest.mark.asyncio
     async def test_missing_tenant_id(self, auth_provider):
@@ -35,7 +35,7 @@ class TestAzureAuthProvider:
             "client_secret": "test_client_secret",
         }
 
-        with pytest.raises(CommonError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             await auth_provider._create_service_principal_credential(credentials)
 
         error_message = str(exc_info.value)
@@ -51,7 +51,7 @@ class TestAzureAuthProvider:
             "client_secret": "test_client_secret",
         }
 
-        with pytest.raises(CommonError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             await auth_provider._create_service_principal_credential(credentials)
 
         error_message = str(exc_info.value)
@@ -64,7 +64,7 @@ class TestAzureAuthProvider:
         """Test error message when client_secret is missing."""
         credentials = {"tenant_id": "test_tenant_id", "client_id": "test_client_id"}
 
-        with pytest.raises(CommonError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             await auth_provider._create_service_principal_credential(credentials)
 
         error_message = str(exc_info.value)
@@ -82,7 +82,7 @@ class TestAzureAuthProvider:
             # Missing client_id and client_secret
         }
 
-        with pytest.raises(CommonError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             await auth_provider._create_service_principal_credential(credentials)
 
         error_message = str(exc_info.value)
@@ -95,7 +95,7 @@ class TestAzureAuthProvider:
         """Test error message when all keys are missing."""
         credentials = {}
 
-        with pytest.raises(CommonError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             await auth_provider._create_service_principal_credential(credentials)
 
         error_message = str(exc_info.value)
@@ -107,7 +107,7 @@ class TestAzureAuthProvider:
     @pytest.mark.asyncio
     async def test_none_credentials(self, auth_provider):
         """Test error message when credentials is None."""
-        with pytest.raises(CommonError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             await auth_provider._create_service_principal_credential(None)
 
         error_message = str(exc_info.value)
@@ -118,7 +118,7 @@ class TestAzureAuthProvider:
     @pytest.mark.asyncio
     async def test_empty_credentials(self, auth_provider):
         """Test error message when credentials is empty dict."""
-        with pytest.raises(CommonError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             await auth_provider._create_service_principal_credential({})
 
         error_message = str(exc_info.value)
@@ -185,8 +185,8 @@ class TestAzureAuthProvider:
 
     @pytest.mark.asyncio
     async def test_create_credential_none_credentials_raises(self, auth_provider):
-        """create_credential with no credentials must raise CommonError."""
-        with pytest.raises(CommonError) as exc_info:
+        """create_credential with no credentials must raise AppError."""
+        with pytest.raises(AppError) as exc_info:
             await auth_provider.create_credential(
                 auth_type="service_principal", credentials=None
             )
@@ -196,8 +196,8 @@ class TestAzureAuthProvider:
 
     @pytest.mark.asyncio
     async def test_create_credential_empty_credentials_raises(self, auth_provider):
-        """create_credential with empty dict credentials must raise CommonError."""
-        with pytest.raises(CommonError) as exc_info:
+        """create_credential with empty dict credentials must raise AppError."""
+        with pytest.raises(AppError) as exc_info:
             await auth_provider.create_credential(
                 auth_type="service_principal", credentials={}
             )
@@ -211,7 +211,7 @@ class TestAzureAuthProvider:
         self, auth_provider
     ):
         """Unsupported auth type with non-empty creds reaches the auth_type guard."""
-        with pytest.raises(CommonError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             await auth_provider.create_credential(
                 auth_type="oauth",
                 credentials={
@@ -242,78 +242,86 @@ class TestAzureAuthProvider:
 
     @pytest.mark.asyncio
     async def test_create_credential_wraps_value_error(self, auth_provider):
-        """ValueError from inner method becomes CommonError CREDENTIALS_PARSE_ERROR."""
-        with patch.object(
-            auth_provider,
-            "_create_service_principal_credential",
-            new=AsyncMock(side_effect=ValueError("bad")),
+        """ValueError from inner method becomes AppError CREDENTIALS_PARSE_ERROR."""
+        with (
+            patch.object(
+                auth_provider,
+                "_create_service_principal_credential",
+                new=AsyncMock(side_effect=ValueError("bad")),
+            ),
+            pytest.raises(AppError) as exc_info,
         ):
-            with pytest.raises(CommonError) as exc_info:
-                await auth_provider.create_credential(
-                    auth_type="service_principal",
-                    credentials={
-                        "tenant_id": "t",
-                        "client_id": "c",
-                        "client_secret": "s",
-                    },
-                )
+            await auth_provider.create_credential(
+                auth_type="service_principal",
+                credentials={
+                    "tenant_id": "t",
+                    "client_id": "c",
+                    "client_secret": "s",
+                },
+            )
         assert "Invalid credential parameters" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_create_credential_wraps_type_error(self, auth_provider):
-        """TypeError from inner method becomes CommonError CREDENTIALS_PARSE_ERROR."""
-        with patch.object(
-            auth_provider,
-            "_create_service_principal_credential",
-            new=AsyncMock(side_effect=TypeError("bad type")),
+        """TypeError from inner method becomes AppError CREDENTIALS_PARSE_ERROR."""
+        with (
+            patch.object(
+                auth_provider,
+                "_create_service_principal_credential",
+                new=AsyncMock(side_effect=TypeError("bad type")),
+            ),
+            pytest.raises(AppError) as exc_info,
         ):
-            with pytest.raises(CommonError) as exc_info:
-                await auth_provider.create_credential(
-                    auth_type="service_principal",
-                    credentials={
-                        "tenant_id": "t",
-                        "client_id": "c",
-                        "client_secret": "s",
-                    },
-                )
+            await auth_provider.create_credential(
+                auth_type="service_principal",
+                credentials={
+                    "tenant_id": "t",
+                    "client_id": "c",
+                    "client_secret": "s",
+                },
+            )
         assert "Invalid credential parameter types" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_create_credential_wraps_client_auth_error(self, auth_provider):
         """ClientAuthenticationError gets mapped to AZURE_CREDENTIAL_ERROR."""
-        with patch.object(
-            auth_provider,
-            "_create_service_principal_credential",
-            new=AsyncMock(side_effect=ClientAuthenticationError("auth fail")),
+        with (
+            patch.object(
+                auth_provider,
+                "_create_service_principal_credential",
+                new=AsyncMock(side_effect=ClientAuthenticationError("auth fail")),
+            ),
+            pytest.raises(AppError) as exc_info,
         ):
-            with pytest.raises(CommonError) as exc_info:
-                await auth_provider.create_credential(
-                    auth_type="service_principal",
-                    credentials={
-                        "tenant_id": "t",
-                        "client_id": "c",
-                        "client_secret": "s",
-                    },
-                )
+            await auth_provider.create_credential(
+                auth_type="service_principal",
+                credentials={
+                    "tenant_id": "t",
+                    "client_id": "c",
+                    "client_secret": "s",
+                },
+            )
         assert "auth fail" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_create_credential_wraps_unexpected_error(self, auth_provider):
         """Generic Exception is wrapped as 'Unexpected error'."""
-        with patch.object(
-            auth_provider,
-            "_create_service_principal_credential",
-            new=AsyncMock(side_effect=RuntimeError("boom")),
+        with (
+            patch.object(
+                auth_provider,
+                "_create_service_principal_credential",
+                new=AsyncMock(side_effect=RuntimeError("boom")),
+            ),
+            pytest.raises(AppError) as exc_info,
         ):
-            with pytest.raises(CommonError) as exc_info:
-                await auth_provider.create_credential(
-                    auth_type="service_principal",
-                    credentials={
-                        "tenant_id": "t",
-                        "client_id": "c",
-                        "client_secret": "s",
-                    },
-                )
+            await auth_provider.create_credential(
+                auth_type="service_principal",
+                credentials={
+                    "tenant_id": "t",
+                    "client_id": "c",
+                    "client_secret": "s",
+                },
+            )
         assert "Unexpected error" in str(exc_info.value)
 
     # ------------------------------------------------------------------
@@ -340,45 +348,51 @@ class TestAzureAuthProvider:
     async def test_create_service_principal_run_in_thread_value_error(
         self, auth_provider
     ):
-        """ValueError from run_in_thread becomes CommonError."""
-        with patch(
-            "application_sdk.clients.azure.auth.run_in_thread",
-            new=AsyncMock(side_effect=ValueError("bad value")),
+        """ValueError from run_in_thread becomes AppError."""
+        with (
+            patch(
+                "application_sdk.clients.azure.auth.run_in_thread",
+                new=AsyncMock(side_effect=ValueError("bad value")),
+            ),
+            pytest.raises(AppError) as exc_info,
         ):
-            with pytest.raises(CommonError) as exc_info:
-                await auth_provider._create_service_principal_credential(
-                    {"tenant_id": "t", "client_id": "c", "client_secret": "s"}
-                )
+            await auth_provider._create_service_principal_credential(
+                {"tenant_id": "t", "client_id": "c", "client_secret": "s"}
+            )
         assert "Invalid credential parameters" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_create_service_principal_run_in_thread_type_error(
         self, auth_provider
     ):
-        """TypeError from run_in_thread becomes CommonError."""
-        with patch(
-            "application_sdk.clients.azure.auth.run_in_thread",
-            new=AsyncMock(side_effect=TypeError("bad type")),
+        """TypeError from run_in_thread becomes AppError."""
+        with (
+            patch(
+                "application_sdk.clients.azure.auth.run_in_thread",
+                new=AsyncMock(side_effect=TypeError("bad type")),
+            ),
+            pytest.raises(AppError) as exc_info,
         ):
-            with pytest.raises(CommonError) as exc_info:
-                await auth_provider._create_service_principal_credential(
-                    {"tenant_id": "t", "client_id": "c", "client_secret": "s"}
-                )
+            await auth_provider._create_service_principal_credential(
+                {"tenant_id": "t", "client_id": "c", "client_secret": "s"}
+            )
         assert "Invalid credential parameter types" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_create_service_principal_run_in_thread_client_auth_error(
         self, auth_provider
     ):
-        """ClientAuthenticationError from run_in_thread becomes CommonError."""
-        with patch(
-            "application_sdk.clients.azure.auth.run_in_thread",
-            new=AsyncMock(side_effect=ClientAuthenticationError("nope")),
+        """ClientAuthenticationError from run_in_thread becomes AppError."""
+        with (
+            patch(
+                "application_sdk.clients.azure.auth.run_in_thread",
+                new=AsyncMock(side_effect=ClientAuthenticationError("nope")),
+            ),
+            pytest.raises(AppError) as exc_info,
         ):
-            with pytest.raises(CommonError) as exc_info:
-                await auth_provider._create_service_principal_credential(
-                    {"tenant_id": "t", "client_id": "c", "client_secret": "s"}
-                )
+            await auth_provider._create_service_principal_credential(
+                {"tenant_id": "t", "client_id": "c", "client_secret": "s"}
+            )
         assert "nope" in str(exc_info.value)
 
     @pytest.mark.asyncio
@@ -386,14 +400,16 @@ class TestAzureAuthProvider:
         self, auth_provider
     ):
         """Generic exception in run_in_thread becomes 'Unexpected error'."""
-        with patch(
-            "application_sdk.clients.azure.auth.run_in_thread",
-            new=AsyncMock(side_effect=RuntimeError("boom")),
+        with (
+            patch(
+                "application_sdk.clients.azure.auth.run_in_thread",
+                new=AsyncMock(side_effect=RuntimeError("boom")),
+            ),
+            pytest.raises(AppError) as exc_info,
         ):
-            with pytest.raises(CommonError) as exc_info:
-                await auth_provider._create_service_principal_credential(
-                    {"tenant_id": "t", "client_id": "c", "client_secret": "s"}
-                )
+            await auth_provider._create_service_principal_credential(
+                {"tenant_id": "t", "client_id": "c", "client_secret": "s"}
+            )
         assert "Unexpected error" in str(exc_info.value)
 
     # ------------------------------------------------------------------

--- a/tests/unit/clients/test_azure_client_contracts.py
+++ b/tests/unit/clients/test_azure_client_contracts.py
@@ -16,25 +16,28 @@ These tests:
 * Cover ``_test_connection`` happy-path and every error class.
 * Cover both context managers, including the ``__exit__`` branch where no
   event loop is running.
-* Document one suspected bug (re-wrap of internal ``ClientError``) as a
-  SKIP — source is not modified.
 
 All Azure SDK / Dapr / heartbeat collaborators are mocked. No real I/O.
 """
 
 import asyncio
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from azure.core.exceptions import AzureError, ClientAuthenticationError
 
+from application_sdk.clients.azure._azure_errors import (
+    AzureAuthError,
+    AzureCredentialParseError,
+    AzureNoCredentialError,
+)
 from application_sdk.clients.azure.client import (
     AzureClient,
     HealthStatus,
     ServiceHealth,
 )
-from application_sdk.common.error_codes import ClientError
+from application_sdk.errors import AppError
 
 # ---------------------------------------------------------------------------
 # Inline-import contract
@@ -106,9 +109,9 @@ class TestInfrastructureSymbolContract:
                 "application_sdk.infrastructure.DaprCredentialVault",
                 return_value=fake_vault,
             ),
+            pytest.raises(AppError),
         ):
-            with pytest.raises(ClientError):
-                await client.load()
+            await client.load()
         fake_dapr.close.assert_awaited_once()
 
 
@@ -144,7 +147,7 @@ class TestInit:
 # ---------------------------------------------------------------------------
 
 
-def _direct_credentials() -> Dict[str, Any]:
+def _direct_credentials() -> dict[str, Any]:
     return {"tenant_id": "t", "client_id": "c", "client_secret": "s"}
 
 
@@ -224,54 +227,51 @@ class TestLoadErrorMapping:
         c.auth_provider = MagicMock()
         return c
 
-    async def test_client_authentication_error_maps_to_auth_code(self, loaded_client):
+    async def test_client_authentication_error_maps_to_auth_error(self, loaded_client):
         loaded_client.auth_provider.create_credential = AsyncMock(
             side_effect=ClientAuthenticationError("bad creds")
         )
-        with pytest.raises(ClientError) as ei:
+        with pytest.raises(AzureAuthError) as ei:
             await loaded_client.load()
-        assert "ATLAN-CLIENT-401-00" in str(ei.value)
+        assert "bad creds" in str(ei.value)
 
-    async def test_azure_error_maps_to_auth_code(self, loaded_client):
+    async def test_azure_error_maps_to_auth_error(self, loaded_client):
         loaded_client.auth_provider.create_credential = AsyncMock(
             side_effect=AzureError("svc down")
         )
-        with pytest.raises(ClientError) as ei:
+        with pytest.raises(AzureAuthError) as ei:
             await loaded_client.load()
-        assert "ATLAN-CLIENT-401-00" in str(ei.value)
+        assert "svc down" in str(ei.value)
 
-    async def test_value_error_maps_to_input_validation(self, loaded_client):
+    async def test_value_error_maps_to_credential_parse_error(self, loaded_client):
         loaded_client.auth_provider.create_credential = AsyncMock(
             side_effect=ValueError("bad input")
         )
-        with pytest.raises(ClientError) as ei:
+        with pytest.raises(AzureCredentialParseError) as ei:
             await loaded_client.load()
-        assert "ATLAN-CLIENT-403-01" in str(ei.value)
         assert "Invalid parameters" in str(ei.value)
 
-    async def test_type_error_maps_to_input_validation(self, loaded_client):
+    async def test_type_error_maps_to_credential_parse_error(self, loaded_client):
         loaded_client.auth_provider.create_credential = AsyncMock(
             side_effect=TypeError("bad type")
         )
-        with pytest.raises(ClientError) as ei:
+        with pytest.raises(AzureCredentialParseError) as ei:
             await loaded_client.load()
-        assert "ATLAN-CLIENT-403-01" in str(ei.value)
         assert "Invalid parameter types" in str(ei.value)
 
-    async def test_generic_exception_maps_to_unexpected(self, loaded_client):
+    async def test_generic_exception_maps_to_auth_error(self, loaded_client):
         loaded_client.auth_provider.create_credential = AsyncMock(
             side_effect=RuntimeError("?!?!")
         )
-        with pytest.raises(ClientError) as ei:
+        with pytest.raises(AzureAuthError) as ei:
             await loaded_client.load()
-        assert "ATLAN-CLIENT-401-00" in str(ei.value)
         assert "Unexpected error" in str(ei.value)
 
     async def test_load_failure_does_not_set_connection_health(self, loaded_client):
         loaded_client.auth_provider.create_credential = AsyncMock(
             side_effect=RuntimeError("nope")
         )
-        with pytest.raises(ClientError):
+        with pytest.raises(AppError):
             await loaded_client.load()
         assert loaded_client._connection_health is False
 
@@ -279,13 +279,15 @@ class TestLoadErrorMapping:
         loaded_client.auth_provider.create_credential = AsyncMock(
             return_value=MagicMock()
         )
-        with patch(
-            "application_sdk.clients.azure.client.run_in_thread",
-            new=AsyncMock(side_effect=ClientAuthenticationError("test failed")),
+        with (
+            patch(
+                "application_sdk.clients.azure.client.run_in_thread",
+                new=AsyncMock(side_effect=ClientAuthenticationError("test failed")),
+            ),
+            pytest.raises(AzureAuthError) as ei,
         ):
-            with pytest.raises(ClientError) as ei:
-                await loaded_client.load()
-        assert "ATLAN-CLIENT-401-00" in str(ei.value)
+            await loaded_client.load()
+        assert "test failed" in str(ei.value)
 
 
 # ---------------------------------------------------------------------------
@@ -294,13 +296,12 @@ class TestLoadErrorMapping:
 
 
 class TestTestConnection:
-    async def test_no_credential_raises_client_error(self):
+    async def test_no_credential_raises_no_credential_error(self):
         client = AzureClient()
         client.credential = None
-        with pytest.raises(ClientError) as ei:
+        with pytest.raises(AzureNoCredentialError) as ei:
             await client._test_connection()
-        # AUTH_CREDENTIALS_ERROR — 401-04
-        assert "ATLAN-CLIENT-401-04" in str(ei.value)
+        assert "No credential available" in str(ei.value)
 
     async def test_success_path_calls_run_in_thread_with_endpoint(self):
         from application_sdk.clients.azure import AZURE_MANAGEMENT_API_ENDPOINT
@@ -321,46 +322,54 @@ class TestTestConnection:
     async def test_client_authentication_error_mapped(self):
         client = AzureClient()
         client.credential = MagicMock()
-        with patch(
-            "application_sdk.clients.azure.client.run_in_thread",
-            new=AsyncMock(side_effect=ClientAuthenticationError("bad")),
+        with (
+            patch(
+                "application_sdk.clients.azure.client.run_in_thread",
+                new=AsyncMock(side_effect=ClientAuthenticationError("bad")),
+            ),
+            pytest.raises(AzureAuthError) as ei,
         ):
-            with pytest.raises(ClientError) as ei:
-                await client._test_connection()
-        assert "ATLAN-CLIENT-401-00" in str(ei.value)
+            await client._test_connection()
+        assert "bad" in str(ei.value)
 
     async def test_azure_error_mapped(self):
         client = AzureClient()
         client.credential = MagicMock()
-        with patch(
-            "application_sdk.clients.azure.client.run_in_thread",
-            new=AsyncMock(side_effect=AzureError("down")),
+        with (
+            patch(
+                "application_sdk.clients.azure.client.run_in_thread",
+                new=AsyncMock(side_effect=AzureError("down")),
+            ),
+            pytest.raises(AzureAuthError) as ei,
         ):
-            with pytest.raises(ClientError) as ei:
-                await client._test_connection()
-        assert "ATLAN-CLIENT-401-00" in str(ei.value)
+            await client._test_connection()
+        assert "down" in str(ei.value)
 
     async def test_value_error_mapped(self):
         client = AzureClient()
         client.credential = MagicMock()
-        with patch(
-            "application_sdk.clients.azure.client.run_in_thread",
-            new=AsyncMock(side_effect=ValueError("nope")),
+        with (
+            patch(
+                "application_sdk.clients.azure.client.run_in_thread",
+                new=AsyncMock(side_effect=ValueError("nope")),
+            ),
+            pytest.raises(AzureCredentialParseError) as ei,
         ):
-            with pytest.raises(ClientError) as ei:
-                await client._test_connection()
-        assert "ATLAN-CLIENT-403-01" in str(ei.value)
+            await client._test_connection()
+        assert "Invalid parameters" in str(ei.value)
 
     async def test_unexpected_error_mapped(self):
         client = AzureClient()
         client.credential = MagicMock()
-        with patch(
-            "application_sdk.clients.azure.client.run_in_thread",
-            new=AsyncMock(side_effect=RuntimeError("?!?!")),
+        with (
+            patch(
+                "application_sdk.clients.azure.client.run_in_thread",
+                new=AsyncMock(side_effect=RuntimeError("?!?!")),
+            ),
+            pytest.raises(AzureAuthError) as ei,
         ):
-            with pytest.raises(ClientError) as ei:
-                await client._test_connection()
-        assert "ATLAN-CLIENT-401-00" in str(ei.value)
+            await client._test_connection()
+        assert "Unexpected error" in str(ei.value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/clients/test_base_client.py
+++ b/tests/unit/clients/test_base_client.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -7,6 +7,7 @@ from httpx import Headers
 from hypothesis import HealthCheck, given, settings
 
 from application_sdk.clients.base import BaseClient
+from application_sdk.errors import UnimplementedError
 from application_sdk.testing.hypothesis.strategies.clients.sql import (
     sql_credentials_strategy,
 )
@@ -42,10 +43,10 @@ class TestBaseClient:
 
     @pytest.mark.asyncio
     async def test_load_not_implemented(self, base_client):
-        """Test that load method raises NotImplementedError."""
+        """Test that load method raises UnimplementedError."""
         credentials = {"username": "test", "password": "secret"}
 
-        with pytest.raises(NotImplementedError, match="load method is not implemented"):
+        with pytest.raises(UnimplementedError):
             await base_client.load(credentials=credentials)
 
     @pytest.mark.asyncio
@@ -353,7 +354,7 @@ class TestBaseClient:
     @settings(
         max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture]
     )
-    def test_initialization_with_various_credentials(self, credentials: Dict[str, Any]):
+    def test_initialization_with_various_credentials(self, credentials: dict[str, Any]):
         """Property-based test for initialization with various credentials."""
         client = BaseClient(credentials=credentials)
         assert client.credentials == credentials
@@ -380,11 +381,11 @@ class TestBaseClient:
         credentials = {"username": "test", "password": "secret"}
 
         # Should not raise TypeError for wrong parameters
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(UnimplementedError):
             await base_client.load(credentials=credentials)
 
         # Test with additional kwargs
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(UnimplementedError):
             await base_client.load(credentials=credentials, extra_param="value")
 
     def test_http_retry_transport_initialization(self, base_client):

--- a/tests/unit/clients/test_clienterror_preservation.py
+++ b/tests/unit/clients/test_clienterror_preservation.py
@@ -23,13 +23,14 @@ from application_sdk.common.error_codes import ClientError
 
 
 class TestAsyncSqlLoadErrorContract:
-    """``AsyncBaseSQLClient.load()`` must raise ``ClientError`` on auth /
-    connection failure, mirroring sync ``BaseSQLClient.load()``. Before
+    """``AsyncBaseSQLClient.load()`` must raise ``SqlClientAuthFailedError`` on
+    auth / connection failure, mirroring sync ``BaseSQLClient.load()``. Before
     BLDX-1180 it raised generic ``ValueError(str(e))``.
     """
 
     @pytest.mark.asyncio
     async def test_async_load_failure_raises_client_error_not_value_error(self):
+        from application_sdk.clients._sql_errors import SqlClientAuthFailedError
         from application_sdk.clients.models import DatabaseConfig
         from application_sdk.clients.sql import AsyncBaseSQLClient
 
@@ -46,14 +47,16 @@ class TestAsyncSqlLoadErrorContract:
         # `create_async_engine` is imported inline inside `load()` (PLC0415
         # exception); patch at the source module so the inline import picks
         # up the mock.
-        with patch(
-            "sqlalchemy.ext.asyncio.create_async_engine",
-            side_effect=RuntimeError("boom"),
+        with (
+            patch(
+                "sqlalchemy.ext.asyncio.create_async_engine",
+                side_effect=RuntimeError("boom"),
+            ),
+            pytest.raises(SqlClientAuthFailedError) as exc_info,
         ):
-            with pytest.raises(ClientError) as exc_info:
-                await client.load({"username": "u", "password": "p"})
+            await client.load({"username": "u", "password": "p"})
 
-        assert str(ClientError.SQL_CLIENT_AUTH_ERROR) in str(exc_info.value)
+        assert "SQL client authentication failed" in str(exc_info.value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/clients/test_clienterror_preservation.py
+++ b/tests/unit/clients/test_clienterror_preservation.py
@@ -1,10 +1,10 @@
 """Regression tests for the BLDX-1163 / BLDX-1164 / BLDX-1165 / BLDX-1180 fixes.
 
-Each test asserts that an internal ``ClientError`` raised inside the client
+Each test asserts that an internal ``AppError`` raised inside the client
 propagates *unchanged* to the caller — the structured error code is not
 swallowed by an outer broad ``except Exception`` that re-emits a generic
-``CLIENT_AUTH_ERROR`` / generic ``ValueError``. These tests lock the
-contract documented in PR #1602 and prevent re-introduction of the bugs.
+auth error. These tests lock the contract documented in PR #1602 and
+prevent re-introduction of the bugs.
 """
 
 from __future__ import annotations
@@ -15,10 +15,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from application_sdk.common.error_codes import ClientError
+from application_sdk.clients._redis_errors import RedisConnectionError
+from application_sdk.clients.azure._azure_errors import (
+    AzureAuthError,
+    AzureNoCredentialError,
+)
+from application_sdk.errors import AppError
 
 # ---------------------------------------------------------------------------
-# BLDX-1180 — async SQL load() raises ClientError, not ValueError
+# BLDX-1180 — async SQL load() raises AppError, not ValueError
 # ---------------------------------------------------------------------------
 
 
@@ -60,25 +65,27 @@ class TestAsyncSqlLoadErrorContract:
 
 
 # ---------------------------------------------------------------------------
-# BLDX-1163 / BLDX-1164 — Azure ClientError preservation + use-after-close guard
+# BLDX-1163 / BLDX-1164 — Azure AppError preservation + use-after-close guard
 # ---------------------------------------------------------------------------
 
 
 class TestAzureClientErrorContract:
-    """``AzureClient.load()`` must propagate the structured ``ClientError``
+    """``AzureClient.load()`` must propagate the structured ``AppError``
     raised internally by ``_test_connection``, and must reject re-load
     after ``close()``.
     """
 
     @pytest.mark.asyncio
-    async def test_load_preserves_internal_client_error_code(self):
+    async def test_load_preserves_internal_app_error(self):
         from application_sdk.clients.azure.client import AzureClient
 
         client = AzureClient()
-        # _test_connection is invoked from inside load(); make it raise the
-        # exact structured ClientError that load() previously re-wrapped.
-        sentinel = ClientError(
-            f"{ClientError.AUTH_CREDENTIALS_ERROR}: missing credential"
+        # _test_connection is invoked from inside load(); make it raise a
+        # typed AppError subclass. load() has `except AppError: raise` so
+        # the sentinel must propagate unchanged.
+        sentinel = AzureAuthError(
+            message="missing credential",
+            auth_method="azure_service_principal",
         )
 
         # `_test_connection` is async — use AsyncMock so awaiting it works
@@ -90,18 +97,18 @@ class TestAzureClientErrorContract:
             client.auth_provider = MagicMock()
             client.auth_provider.create_credential = AsyncMock(return_value=object())
 
-            with pytest.raises(ClientError) as exc_info:
+            with pytest.raises(AzureAuthError) as exc_info:
                 await client.load({"auth_type": "service_principal"})
 
-        # The original structured code must survive the broad except
+        # The original structured error must survive the broad except
         # Exception in load(); pre-fix it was re-wrapped as
         # CLIENT_AUTH_ERROR ("Unexpected error – ...").
-        assert str(ClientError.AUTH_CREDENTIALS_ERROR) in str(exc_info.value)
-        # Sanity: it is the same ClientError instance, not a re-wrap.
+        assert "missing credential" in str(exc_info.value)
+        # Sanity: it is the same AppError instance, not a re-wrap.
         assert exc_info.value is sentinel
 
     @pytest.mark.asyncio
-    async def test_load_after_close_raises_client_error_not_silent_dead_executor(
+    async def test_load_after_close_raises_app_error_not_silent_dead_executor(
         self,
     ):
         from application_sdk.clients.azure.client import AzureClient
@@ -114,59 +121,58 @@ class TestAzureClientErrorContract:
             client._executor.shutdown(wait=False)
         client._executor = None
 
-        with pytest.raises(ClientError) as exc_info:
+        with pytest.raises(AzureNoCredentialError) as exc_info:
             await client.load({"auth_type": "service_principal"})
 
         # Pre-fix this would silently submit work to a dead executor and
         # surface a confusing error far from the cause. After the fix the
-        # client raises ClientError with an actionable message.
-        assert "instantiate a new" in str(exc_info.value).lower() or (
-            str(ClientError.CLIENT_AUTH_ERROR) in str(exc_info.value)
-        )
+        # client raises AzureNoCredentialError with an actionable message.
+        assert "instantiate a new" in str(exc_info.value).lower()
 
 
 # ---------------------------------------------------------------------------
-# BLDX-1165 — Redis _connect / _release_lock ClientError preservation
+# BLDX-1165 — Redis _connect / _release_lock AppError preservation
 # ---------------------------------------------------------------------------
 
 
 class TestRedisSyncClientErrorContract:
     """Sync ``RedisClient._connect`` / ``_release_lock`` must propagate
-    internal ``ClientError`` instead of re-routing through
+    internal ``AppError`` instead of re-routing through
     ``_handle_redis_error``.
     """
 
-    def test_sync_connect_preserves_internal_client_error(self):
+    def test_sync_connect_preserves_internal_app_error(self):
         from application_sdk.clients.redis import RedisClient
 
         client = RedisClient()
 
         # Force the no-redis_client branch inside _connect so the internal
-        # ClientError(REDIS_CONNECTION_ERROR) is raised.
+        # RedisConnectionError is raised.
         with (
             patch.object(client, "_connect_standalone", return_value=None),
             patch("application_sdk.clients.redis.IS_LOCKING_DISABLED", False),
             patch("application_sdk.clients.redis.REDIS_SENTINEL_HOSTS", ""),
         ):
             client.redis_client = None
-            with pytest.raises(ClientError) as exc_info:
+            with pytest.raises(RedisConnectionError) as exc_info:
                 client._connect()
 
-        assert str(ClientError.REDIS_CONNECTION_ERROR) in str(exc_info.value)
+        assert "Redis connection failed" in str(exc_info.value)
 
-    def test_sync_release_lock_preserves_process_result_client_error(self):
+    def test_sync_release_lock_preserves_process_result_app_error(self):
         from application_sdk.clients.redis import RedisClient
 
         client = RedisClient()
         client.redis_client = MagicMock()
         # The eval result triggers `_process_lock_release_result` which
-        # raises ClientError for unexpected payloads.
-        sentinel = ClientError(
-            f"{ClientError.REDIS_CONNECTION_ERROR}: unexpected lock release result"
+        # raises AppError subclasses for unexpected payloads.
+        sentinel = RedisConnectionError(
+            message="Redis connection failed: unexpected lock release result",
+            service="redis",
         )
         client.redis_client.eval = MagicMock(return_value="garbage")
         with patch.object(client, "_process_lock_release_result", side_effect=sentinel):
-            with pytest.raises(ClientError) as exc_info:
+            with pytest.raises(RedisConnectionError) as exc_info:
                 client._release_lock("rid", "oid")
 
         assert exc_info.value is sentinel
@@ -174,12 +180,12 @@ class TestRedisSyncClientErrorContract:
 
 class TestRedisAsyncClientErrorContract:
     """Async ``RedisClientAsync._connect`` / ``_release_lock`` must
-    propagate internal ``ClientError`` — this is the path the SDK review
+    propagate internal ``AppError`` — this is the path the SDK review
     flagged as missed in the original PR.
     """
 
     @pytest.mark.asyncio
-    async def test_async_connect_preserves_internal_client_error(self):
+    async def test_async_connect_preserves_internal_app_error(self):
         from application_sdk.clients.redis import RedisClientAsync
 
         client = RedisClientAsync()
@@ -193,23 +199,24 @@ class TestRedisAsyncClientErrorContract:
             patch("application_sdk.clients.redis.REDIS_SENTINEL_HOSTS", ""),
         ):
             client.redis_client = None
-            with pytest.raises(ClientError) as exc_info:
+            with pytest.raises(RedisConnectionError) as exc_info:
                 await client._connect()
 
-        assert str(ClientError.REDIS_CONNECTION_ERROR) in str(exc_info.value)
+        assert "Redis connection failed" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_async_release_lock_preserves_process_result_client_error(self):
+    async def test_async_release_lock_preserves_process_result_app_error(self):
         from application_sdk.clients.redis import RedisClientAsync
 
         client = RedisClientAsync()
         client.redis_client = MagicMock()
         client.redis_client.eval = AsyncMock(return_value="garbage")
-        sentinel = ClientError(
-            f"{ClientError.REDIS_CONNECTION_ERROR}: unexpected lock release result"
+        sentinel = RedisConnectionError(
+            message="Redis connection failed: unexpected lock release result",
+            service="redis",
         )
         with patch.object(client, "_process_lock_release_result", side_effect=sentinel):
-            with pytest.raises(ClientError) as exc_info:
+            with pytest.raises(RedisConnectionError) as exc_info:
                 await client._release_lock("rid", "oid")
 
         assert exc_info.value is sentinel
@@ -217,3 +224,5 @@ class TestRedisAsyncClientErrorContract:
 
 # Avoid `unused asyncio` warning when pytest-asyncio handles the awaits.
 _ = asyncio
+# Avoid unused import warning — AppError is imported for type documentation.
+_ = AppError

--- a/tests/unit/clients/test_redis_client.py
+++ b/tests/unit/clients/test_redis_client.py
@@ -10,7 +10,7 @@ from application_sdk.clients.redis import (
     RedisClient,
     RedisClientAsync,
 )
-from application_sdk.common.error_codes import ClientError
+from application_sdk.errors import AppError
 
 
 class TestRedisClientConfiguration:
@@ -32,17 +32,17 @@ class TestRedisClientConfiguration:
     @patch("application_sdk.clients.redis.REDIS_PASSWORD", None)
     def test_missing_password_raises_error_sync(self):
         """Test sync initialization fails without password."""
-        with pytest.raises(ClientError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             RedisClient()
-        assert "ATLAN-CLIENT-403-00" in str(exc_info.value)
+        assert "Redis configuration invalid" in str(exc_info.value)
 
     @patch("application_sdk.clients.redis.IS_LOCKING_DISABLED", False)
     @patch("application_sdk.clients.redis.REDIS_PASSWORD", None)
     def test_missing_password_raises_error_async(self):
         """Test async initialization fails without password."""
-        with pytest.raises(ClientError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             RedisClientAsync()
-        assert "ATLAN-CLIENT-403-00" in str(exc_info.value)
+        assert "Redis configuration invalid" in str(exc_info.value)
 
     @patch("application_sdk.clients.redis.IS_LOCKING_DISABLED", False)
     @patch("application_sdk.clients.redis.REDIS_PASSWORD", "password")
@@ -150,9 +150,9 @@ class TestSyncRedisClientLockOperations:
         """Test lock acquisition error handling."""
         redis_client.redis_client.set.side_effect = ConnectionError("Connection failed")
 
-        with pytest.raises(ClientError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             redis_client._acquire_lock("resource", "owner", 60)
-        assert "ATLAN-CLIENT-503-00" in str(exc_info.value)
+        assert "Connection failed" in str(exc_info.value)
 
     def test_release_lock_success(self, redis_client):
         """Test successful lock release."""
@@ -185,9 +185,9 @@ class TestSyncRedisClientLockOperations:
         """Test lock release error handling."""
         redis_client.redis_client.eval.side_effect = TimeoutError("Timeout")
 
-        with pytest.raises(ClientError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             redis_client._release_lock("resource", "owner")
-        assert "ATLAN-CLIENT-408-00" in str(exc_info.value)
+        assert "Timeout" in str(exc_info.value)
 
     def test_complete_lock_cycle(self, redis_client):
         """Test complete acquire -> release cycle."""
@@ -244,9 +244,9 @@ class TestAsyncRedisClientLockOperations:
         """Test lock acquisition error handling."""
         redis_client.redis_client.set.side_effect = ConnectionError("Connection failed")
 
-        with pytest.raises(ClientError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             await redis_client._acquire_lock("resource", "owner", 60)
-        assert "ATLAN-CLIENT-503-00" in str(exc_info.value)
+        assert "Connection failed" in str(exc_info.value)
 
     async def test_release_lock_success(self, redis_client):
         """Test successful lock release."""
@@ -279,9 +279,9 @@ class TestAsyncRedisClientLockOperations:
         """Test lock release error handling."""
         redis_client.redis_client.eval.side_effect = TimeoutError("Timeout")
 
-        with pytest.raises(ClientError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             await redis_client._release_lock("resource", "owner")
-        assert "ATLAN-CLIENT-408-00" in str(exc_info.value)
+        assert "Timeout" in str(exc_info.value)
 
     async def test_complete_lock_cycle(self, redis_client):
         """Test complete acquire -> release cycle."""
@@ -306,36 +306,32 @@ class TestRedisErrorHandling:
         """Test handling of Redis connection errors."""
         from application_sdk.clients.redis import _handle_redis_error
 
-        with pytest.raises(ClientError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             _handle_redis_error(ConnectionError("Connection failed"))
-        assert "ATLAN-CLIENT-503-00" in str(exc_info.value)
         assert "Connection failed" in str(exc_info.value)
 
     def test_handle_timeout_error(self):
         """Test handling of Redis timeout errors."""
         from application_sdk.clients.redis import _handle_redis_error
 
-        with pytest.raises(ClientError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             _handle_redis_error(TimeoutError("Operation timed out"))
-        assert "ATLAN-CLIENT-408-00" in str(exc_info.value)
         assert "Operation timed out" in str(exc_info.value)
 
     def test_handle_redis_protocol_error(self):
         """Test handling of Redis protocol errors."""
         from application_sdk.clients.redis import _handle_redis_error
 
-        with pytest.raises(ClientError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             _handle_redis_error(RedisError("Protocol error"))
-        assert "ATLAN-CLIENT-502-00" in str(exc_info.value)
         assert "Protocol error" in str(exc_info.value)
 
     def test_handle_generic_error(self):
         """Test handling of generic errors."""
         from application_sdk.clients.redis import _handle_redis_error
 
-        with pytest.raises(ClientError) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             _handle_redis_error(ValueError("Some other error"))
-        assert "ATLAN-CLIENT-503-00" in str(exc_info.value)
         assert "Some other error" in str(exc_info.value)
 
 

--- a/tests/unit/clients/test_redis_client_contracts.py
+++ b/tests/unit/clients/test_redis_client_contracts.py
@@ -13,7 +13,7 @@ focuses on:
 * ``_connect`` / ``_connect_via_sentinel`` / ``_connect_standalone`` for both
   sync and async clients (mocking the ``redis``/``redis.asyncio`` SDK).
 * ``close`` behaviour: idempotency, exception swallowing.
-* Lock operations against an unconnected client (early ``ClientError``).
+* Lock operations against an unconnected client (early ``AppError``).
 * Symbol contracts at module load.
 
 All tests mock ``redis``/``redis.asyncio`` — no real I/O.
@@ -33,7 +33,7 @@ from application_sdk.clients.redis import (
     RedisClientAsync,
     _handle_redis_error,
 )
-from application_sdk.common.error_codes import ClientError
+from application_sdk.errors import AppError
 
 # ---------------------------------------------------------------------------
 # Module-level symbol contract
@@ -113,12 +113,14 @@ class TestParseSentinelHosts:
     def test_invalid_port_raises(self):
         """Non-integer port must surface as a wrapped error, not silently pass."""
         client = _make_base_client("a.example:not-a-port")
-        with patch(
-            "application_sdk.clients.redis.REDIS_SENTINEL_HOSTS",
-            "a.example:not-a-port",
-        ):
-            with pytest.raises(Exception):  # rewrap-wrapped ValueError
-                client._parse_sentinel_hosts()
+        with (
+            patch(
+                "application_sdk.clients.redis.REDIS_SENTINEL_HOSTS",
+                "a.example:not-a-port",
+            ),
+            pytest.raises(Exception),
+        ):  # rewrap-wrapped ValueError
+            client._parse_sentinel_hosts()
 
     def test_ipv6_host_with_port(self):
         """rsplit(':', 1) supports ``host:port`` even with colons in host."""
@@ -145,20 +147,20 @@ class TestProcessLockReleaseResult:
 
     def test_none_result_raises_client_error(self, base):
         """``None`` is not an int — must raise (no silent success)."""
-        with pytest.raises(ClientError) as ei:
+        with pytest.raises(AppError) as ei:
             base._process_lock_release_result(None, "resource-id")
-        assert "ATLAN-CLIENT-503-00" in str(ei.value)
+        assert "unexpected eval result" in str(ei.value)
 
     def test_string_result_raises_client_error(self, base):
         """Unexpected string return must raise."""
-        with pytest.raises(ClientError):
+        with pytest.raises(AppError):
             base._process_lock_release_result("OK", "resource-id")
 
     def test_zero_result_falls_through_to_unknown(self, base):
         """``0`` matches no defined branch — must raise, not silently lie."""
-        with pytest.raises(ClientError) as ei:
+        with pytest.raises(AppError) as ei:
             base._process_lock_release_result(0, "resource-id")
-        assert "ATLAN-CLIENT-503-00" in str(ei.value)
+        assert "unexpected eval result" in str(ei.value)
 
     def test_large_positive_is_success(self, base):
         ok, outcome = base._process_lock_release_result(2, "rid")
@@ -258,9 +260,9 @@ class TestSyncConnect:
             patch("application_sdk.clients.redis.REDIS_SENTINEL_HOSTS", ""),
             patch("application_sdk.clients.redis.redis.Redis", return_value=fake_redis),
         ):
-            with pytest.raises(ClientError) as ei:
+            with pytest.raises(AppError) as ei:
                 standalone_client._connect()
-        assert "ATLAN-CLIENT-503-00" in str(ei.value)
+        assert "nope" in str(ei.value)
 
     def test_connect_timeout_failure_maps_to_timeout_code(self, standalone_client):
         fake_redis = MagicMock()
@@ -269,9 +271,9 @@ class TestSyncConnect:
             patch("application_sdk.clients.redis.REDIS_SENTINEL_HOSTS", ""),
             patch("application_sdk.clients.redis.redis.Redis", return_value=fake_redis),
         ):
-            with pytest.raises(ClientError) as ei:
+            with pytest.raises(AppError) as ei:
                 standalone_client._connect()
-        assert "ATLAN-CLIENT-408-00" in str(ei.value)
+        assert "slow" in str(ei.value)
 
     def test_connect_redis_protocol_error_maps_to_protocol_code(
         self, standalone_client
@@ -282,9 +284,9 @@ class TestSyncConnect:
             patch("application_sdk.clients.redis.REDIS_SENTINEL_HOSTS", ""),
             patch("application_sdk.clients.redis.redis.Redis", return_value=fake_redis),
         ):
-            with pytest.raises(ClientError) as ei:
+            with pytest.raises(AppError) as ei:
                 standalone_client._connect()
-        assert "ATLAN-CLIENT-502-00" in str(ei.value)
+        assert "proto" in str(ei.value)
 
     def test_connect_standalone_ctor_failure_wrapped(self, standalone_client):
         with (
@@ -293,9 +295,9 @@ class TestSyncConnect:
                 "application_sdk.clients.redis.redis.Redis",
                 side_effect=RedisConnectionError("ctor failed"),
             ),
+            pytest.raises(AppError),
         ):
-            with pytest.raises(ClientError):
-                standalone_client._connect()
+            standalone_client._connect()
 
     def test_connect_via_sentinel_ctor_failure_wrapped(self, sentinel_client):
         with (
@@ -307,9 +309,9 @@ class TestSyncConnect:
                 "application_sdk.clients.redis.redis.sentinel.Sentinel",
                 side_effect=RedisConnectionError("sentinel down"),
             ),
+            pytest.raises(AppError),
         ):
-            with pytest.raises(ClientError):
-                sentinel_client._connect()
+            sentinel_client._connect()
 
 
 class TestSyncClose:
@@ -462,10 +464,10 @@ class TestAsyncConnect:
                 "application_sdk.clients.redis.async_redis.Redis",
                 return_value=fake_redis,
             ),
+            pytest.raises(AppError) as ei,
         ):
-            with pytest.raises(ClientError) as ei:
-                await standalone_client._connect()
-        assert "ATLAN-CLIENT-503-00" in str(ei.value)
+            await standalone_client._connect()
+        assert "nope" in str(ei.value)
 
 
 class TestAsyncClose:
@@ -541,9 +543,9 @@ class TestUnconnectedLockOperations:
             patch("application_sdk.clients.redis.REDIS_PORT", "6379"),
         ):
             client = RedisClient()
-        with pytest.raises(ClientError) as ei:
+        with pytest.raises(AppError) as ei:
             client._acquire_lock("rid")
-        assert "ATLAN-CLIENT-503-00" in str(ei.value)
+        assert "no client" in str(ei.value)
 
     def test_sync_release_unconnected_raises_client_error(self):
         with (
@@ -553,9 +555,9 @@ class TestUnconnectedLockOperations:
             patch("application_sdk.clients.redis.REDIS_PORT", "6379"),
         ):
             client = RedisClient()
-        with pytest.raises(ClientError) as ei:
+        with pytest.raises(AppError) as ei:
             client._release_lock("rid")
-        assert "ATLAN-CLIENT-503-00" in str(ei.value)
+        assert "no client" in str(ei.value)
 
     async def test_async_acquire_unconnected_raises_client_error(self):
         with (
@@ -565,7 +567,7 @@ class TestUnconnectedLockOperations:
             patch("application_sdk.clients.redis.REDIS_PORT", "6379"),
         ):
             client = RedisClientAsync()
-        with pytest.raises(ClientError):
+        with pytest.raises(AppError):
             await client._acquire_lock("rid")
 
     async def test_async_release_unconnected_raises_client_error(self):
@@ -576,7 +578,7 @@ class TestUnconnectedLockOperations:
             patch("application_sdk.clients.redis.REDIS_PORT", "6379"),
         ):
             client = RedisClientAsync()
-        with pytest.raises(ClientError):
+        with pytest.raises(AppError):
             await client._release_lock("rid")
 
 
@@ -590,13 +592,13 @@ class TestHandleRedisErrorChaining:
 
     def test_chain_preserved_for_connection_error(self):
         original = RedisConnectionError("low-level")
-        with pytest.raises(ClientError) as ei:
+        with pytest.raises(AppError) as ei:
             _handle_redis_error(original)
         assert ei.value.__cause__ is original
 
     def test_chain_preserved_for_generic_error(self):
         original = RuntimeError("weird")
-        with pytest.raises(ClientError) as ei:
+        with pytest.raises(AppError) as ei:
             _handle_redis_error(original)
         assert ei.value.__cause__ is original
 

--- a/tests/unit/clients/test_sql_client.py
+++ b/tests/unit/clients/test_sql_client.py
@@ -1,13 +1,21 @@
 import asyncio
-from typing import Any, Dict, List
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from hypothesis import HealthCheck, given, settings
 
+from application_sdk.clients._sql_errors import (
+    DBConfigNotSetError,
+    EngineNotInitializedError,
+    EngineWrongTypeError,
+    InvalidAuthTypeError,
+    MissingRequiredFieldError,
+    SqlClientAuthFailedError,
+    UnsupportedCursorError,
+)
 from application_sdk.clients.models import DatabaseConfig
-from application_sdk.clients.sql import BaseSQLClient
-from application_sdk.common.error_codes import CommonError
+from application_sdk.clients.sql import AsyncBaseSQLClient, BaseSQLClient
 from application_sdk.testing.hypothesis.strategies.clients.sql import (
     sql_credentials_strategy,
     sqlalchemy_connect_args_strategy,
@@ -118,8 +126,8 @@ async def test_load_uses_asyncio_to_thread_for_ping(
 @settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_load_property_based(
     sql_client: BaseSQLClient,
-    credentials: Dict[str, Any],
-    connect_args: Dict[str, Any],
+    credentials: dict[str, Any],
+    connect_args: dict[str, Any],
 ):
     """Property-based test for loading with various credentials and connection arguments"""
     with patch("sqlalchemy.create_engine") as mock_create_engine:
@@ -319,7 +327,7 @@ def test_connection_string_property_based(
 @pytest.mark.skip(reason="Failing due to KeyError: 'col1'")
 async def test_run_query_property_based(
     sql_client: BaseSQLClient,
-    query_result: Dict[str, Any],
+    query_result: dict[str, Any],
 ):
     """Property-based test for query execution with various result structures"""
     with (
@@ -349,12 +357,12 @@ async def test_run_query_property_based(
         )
 
         # Run run_query and collect all results
-        results: List[Dict[str, Any]] = []
+        results: list[dict[str, Any]] = []
         async for batch in sql_client.run_query(query):
             results.extend(batch)
 
         # Verify the results
-        expected_results: List[Dict[str, Any]] = []
+        expected_results: list[dict[str, Any]] = []
         for batch in query_result["batches"]:
             expected_results.extend(batch)
 
@@ -510,7 +518,7 @@ def test_get_sqlalchemy_connection_string_missing_required_param(
     }
     sql_client_with_db_config.credentials = credentials
 
-    with pytest.raises(ValueError, match="database is required"):
+    with pytest.raises(MissingRequiredFieldError, match="database is required"):
         sql_client_with_db_config.get_sqlalchemy_connection_string()
 
 
@@ -526,7 +534,7 @@ def test_get_sqlalchemy_connection_string_invalid_auth_type(sql_client_with_db_c
     }
     sql_client_with_db_config.credentials = credentials
 
-    with pytest.raises(CommonError, match="invalid_auth"):
+    with pytest.raises(InvalidAuthTypeError, match="invalid_auth"):
         sql_client_with_db_config.get_sqlalchemy_connection_string()
 
 
@@ -548,7 +556,8 @@ def test_get_sqlalchemy_connection_string_iam_user_missing_username(
     sql_client_with_db_config.credentials = credentials
 
     with pytest.raises(
-        CommonError, match="username is required for IAM user authentication"
+        MissingRequiredFieldError,
+        match="username is required for IAM user authentication",
     ):
         sql_client_with_db_config.get_sqlalchemy_connection_string()
 
@@ -571,7 +580,8 @@ def test_get_sqlalchemy_connection_string_iam_role_missing_role_arn(
     sql_client_with_db_config.credentials = credentials
 
     with pytest.raises(
-        CommonError, match="aws_role_arn is required for IAM role authentication"
+        MissingRequiredFieldError,
+        match="aws_role_arn is required for IAM role authentication",
     ):
         sql_client_with_db_config.get_sqlalchemy_connection_string()
 
@@ -636,8 +646,6 @@ def test_get_sqlalchemy_connection_string_omits_none_parameters(
 # symbols fails at unit-test time instead of at runtime in production.
 # -----------------------------------------------------------------------------
 
-from application_sdk.clients.sql import AsyncBaseSQLClient  # noqa: E402
-from application_sdk.common.error_codes import ClientError  # noqa: E402
 
 # ---------- BaseSQLClient.load — error / edge paths ----------
 
@@ -647,7 +655,7 @@ async def test_load_raises_when_db_config_missing():
     """load() must validate DB_CONFIG before attempting any sqlalchemy import."""
     client = BaseSQLClient()
     client.DB_CONFIG = None
-    with pytest.raises(ValueError, match="DB_CONFIG is not configured"):
+    with pytest.raises(DBConfigNotSetError, match="DB_CONFIG is not configured"):
         await client.load({"username": "u", "password": "p"})
 
 
@@ -656,7 +664,7 @@ async def test_load_raises_when_db_config_missing():
 async def test_load_wraps_engine_failure_as_client_error(
     mock_create_engine: Any, sql_client: BaseSQLClient
 ):
-    """A sqlalchemy create_engine failure must be wrapped as ClientError and
+    """A sqlalchemy create_engine failure must be wrapped as SqlClientAuthFailedError and
     the (partially constructed) engine disposed so connections do not leak."""
     mock_engine = MagicMock()
     mock_create_engine.return_value = mock_engine
@@ -664,7 +672,7 @@ async def test_load_wraps_engine_failure_as_client_error(
     # Force the connect-test inside asyncio.to_thread to fail
     actual_async_mock = AsyncMock(side_effect=RuntimeError("auth handshake failed"))
     with patch("application_sdk.clients.sql.asyncio.to_thread", actual_async_mock):
-        with pytest.raises(ClientError, match="auth handshake failed"):
+        with pytest.raises(SqlClientAuthFailedError):
             await sql_client.load({"username": "u", "password": "p"})
 
     # Engine must be disposed and reset to None so a retry can rebuild it.
@@ -727,7 +735,7 @@ def test_get_iam_user_token_happy_path(mock_gen: MagicMock, sql_client: BaseSQLC
 
 def test_get_iam_user_token_missing_database(sql_client: BaseSQLClient):
     sql_client.credentials = {"username": "k", "extra": {"username": "u"}}
-    with pytest.raises(CommonError, match="database is required"):
+    with pytest.raises(MissingRequiredFieldError, match="database is required"):
         sql_client.get_iam_user_token()
 
 
@@ -754,13 +762,13 @@ def test_get_iam_role_token_happy_path(mock_gen: MagicMock, sql_client: BaseSQLC
 
 def test_get_iam_role_token_missing_role_arn(sql_client: BaseSQLClient):
     sql_client.credentials = {"extra": {"database": "db1"}}
-    with pytest.raises(CommonError, match="aws_role_arn is required"):
+    with pytest.raises(MissingRequiredFieldError, match="aws_role_arn is required"):
         sql_client.get_iam_role_token()
 
 
 def test_get_iam_role_token_missing_database(sql_client: BaseSQLClient):
     sql_client.credentials = {"extra": {"aws_role_arn": "arn"}}
-    with pytest.raises(CommonError, match="database is required"):
+    with pytest.raises(MissingRequiredFieldError, match="database is required"):
         sql_client.get_iam_role_token()
 
 
@@ -770,7 +778,7 @@ def test_get_iam_role_token_missing_database(sql_client: BaseSQLClient):
 @pytest.mark.asyncio
 async def test_run_query_raises_when_engine_not_initialized(sql_client: BaseSQLClient):
     sql_client.engine = None
-    with pytest.raises(ValueError, match="Engine is not initialized"):
+    with pytest.raises(EngineNotInitializedError, match="Engine is not initialized"):
         async for _ in sql_client.run_query("SELECT 1"):
             pass
 
@@ -795,7 +803,7 @@ async def test_run_query_raises_when_cursor_unsupported(
     bad_result.cursor = None
     mock_loop.return_value.run_in_executor = AsyncMock(return_value=bad_result)
 
-    with pytest.raises(ValueError, match="Cursor is not supported"):
+    with pytest.raises(UnsupportedCursorError, match="Cursor is not supported"):
         async for _ in sql_client.run_query("SELECT 1"):
             pass
 
@@ -811,7 +819,7 @@ async def test_run_query_raises_when_cursor_unsupported(
 def test_get_sqlalchemy_connection_string_requires_db_config():
     client = BaseSQLClient()
     client.DB_CONFIG = None
-    with pytest.raises(ValueError, match="DB_CONFIG is not configured"):
+    with pytest.raises(DBConfigNotSetError, match="DB_CONFIG is not configured"):
         client.get_sqlalchemy_connection_string()
 
 
@@ -820,7 +828,7 @@ def test_get_sqlalchemy_connection_string_requires_db_config():
 
 def test_execute_query_daft_requires_engine(sql_client: BaseSQLClient):
     sql_client.engine = None
-    with pytest.raises(ValueError, match="Engine is not initialized"):
+    with pytest.raises(EngineNotInitializedError, match="Engine is not initialized"):
         sql_client._execute_query_daft("SELECT 1", chunksize=None)
 
 
@@ -856,7 +864,7 @@ def test_execute_query_daft_with_engine_object(sql_client: BaseSQLClient):
 
 def test_execute_query_requires_engine(sql_client: BaseSQLClient):
     sql_client.engine = None
-    with pytest.raises(ValueError, match="Engine is not initialized"):
+    with pytest.raises(EngineNotInitializedError, match="Engine is not initialized"):
         sql_client._execute_query("SELECT 1", chunksize=None)
 
 
@@ -942,7 +950,9 @@ async def test_execute_async_read_operation_rejects_string_engine(
     sql_client: BaseSQLClient,
 ):
     sql_client.engine = "postgresql://u:p@h/db"  # type: ignore[assignment]
-    with pytest.raises(ValueError, match="Engine should be an SQLAlchemy engine"):
+    with pytest.raises(
+        EngineWrongTypeError, match="Engine should be an SQLAlchemy engine"
+    ):
         await sql_client._execute_async_read_operation("SELECT 1", chunksize=None)
 
 
@@ -983,13 +993,15 @@ async def test_get_batched_results_wraps_errors_via_rewrap(sql_client: BaseSQLCl
     """Any failure in the read path must be re-raised through rewrap with the
     'Error reading batched data(pandas) from SQL' prefix."""
     sql_client.engine = MagicMock()
-    with patch.object(
-        sql_client,
-        "_execute_async_read_operation",
-        new=AsyncMock(side_effect=RuntimeError("boom")),
+    with (
+        patch.object(
+            sql_client,
+            "_execute_async_read_operation",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ),
+        pytest.raises(Exception, match="Error reading batched data"),
     ):
-        with pytest.raises(Exception, match="Error reading batched data"):
-            await sql_client.get_batched_results("SELECT 1")
+        await sql_client.get_batched_results("SELECT 1")
 
 
 @pytest.mark.asyncio
@@ -1074,7 +1086,7 @@ def async_sql_client_local():
 async def test_async_load_raises_when_db_config_missing():
     client = AsyncBaseSQLClient()
     client.DB_CONFIG = None
-    with pytest.raises(ValueError, match="DB_CONFIG is not configured"):
+    with pytest.raises(DBConfigNotSetError, match="DB_CONFIG is not configured"):
         await client.load({"username": "u", "password": "p"})
 
 
@@ -1083,7 +1095,7 @@ async def test_async_load_raises_when_db_config_missing():
 async def test_async_load_disposes_engine_on_failure(
     mock_create: MagicMock, async_sql_client_local: AsyncBaseSQLClient
 ):
-    """Async load() must dispose the engine and re-raise as ClientError
+    """Async load() must dispose the engine and re-raise as SqlClientAuthFailedError
     (consistent with sync load() — locked in by PR #1602 / BLDX-1180)."""
     mock_engine = AsyncMock()
     mock_engine.dispose = AsyncMock()
@@ -1098,9 +1110,8 @@ async def test_async_load_disposes_engine_on_failure(
     mock_engine.connect = MagicMock(return_value=_FailingCtx())
     mock_create.return_value = mock_engine
 
-    with pytest.raises(ClientError) as exc_info:
+    with pytest.raises(SqlClientAuthFailedError):
         await async_sql_client_local.load({"username": "u", "password": "p"})
-    assert str(ClientError.SQL_CLIENT_AUTH_ERROR) in str(exc_info.value)
 
     mock_engine.dispose.assert_awaited_once()
     assert async_sql_client_local.engine is None
@@ -1132,6 +1143,6 @@ async def test_async_run_query_requires_engine(
     async_sql_client_local: AsyncBaseSQLClient,
 ):
     async_sql_client_local.engine = None  # type: ignore[assignment]
-    with pytest.raises(ValueError, match="Engine is not initialized"):
+    with pytest.raises(EngineNotInitializedError, match="Engine is not initialized"):
         async for _ in async_sql_client_local.run_query("SELECT 1"):
             pass

--- a/tests/unit/common/incremental/test_helpers.py
+++ b/tests/unit/common/incremental/test_helpers.py
@@ -25,6 +25,7 @@ from application_sdk.common.incremental.helpers import (
     normalize_marker_timestamp,
     prepone_marker_timestamp,
 )
+from application_sdk.errors import InvalidInputError
 
 # ---------------------------------------------------------------------------
 # extract_epoch_id_from_qualified_name
@@ -56,18 +57,18 @@ class TestExtractEpochId:
         assert result == "abc-def"
 
     def test_empty_string_raises(self):
-        """Empty string raises ValueError."""
-        with pytest.raises(ValueError, match="cannot be empty"):
+        """Empty string raises InvalidInputError."""
+        with pytest.raises(InvalidInputError, match="cannot be empty"):
             extract_epoch_id_from_qualified_name("")
 
     def test_too_few_segments_raises(self):
-        """Fewer than 3 segments raises ValueError."""
-        with pytest.raises(ValueError, match="Expected format"):
+        """Fewer than 3 segments raises InvalidInputError."""
+        with pytest.raises(InvalidInputError, match="Expected format"):
             extract_epoch_id_from_qualified_name("only/two")
 
     def test_single_segment_raises(self):
-        """Single segment raises ValueError."""
-        with pytest.raises(ValueError, match="Expected format"):
+        """Single segment raises InvalidInputError."""
+        with pytest.raises(InvalidInputError, match="Expected format"):
             extract_epoch_id_from_qualified_name("just-one")
 
 
@@ -92,8 +93,8 @@ class TestGetPersistentS3Prefix:
         assert "999" in result
 
     def test_missing_qualified_name_raises(self):
-        """Raises ValueError when connection_qualified_name is empty."""
-        with pytest.raises(ValueError):
+        """Raises InvalidInputError when connection_qualified_name is empty."""
+        with pytest.raises(InvalidInputError):
             get_persistent_s3_prefix("")
 
 
@@ -307,26 +308,25 @@ class TestDownloadS3PrefixWithStructure:
             nonlocal max_concurrent, current_concurrent
             async with lock:
                 current_concurrent += 1
-                if current_concurrent > max_concurrent:
-                    max_concurrent = current_concurrent
+                max_concurrent = max(max_concurrent, current_concurrent)
             await asyncio.sleep(0.01)
             async with lock:
                 current_concurrent -= 1
 
         file_list = [f"prefix/file{i}.json" for i in range(50)]
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            with (
-                patch(
-                    "application_sdk.common.incremental.helpers.list_keys",
-                    AsyncMock(return_value=file_list),
-                ),
-                patch(
-                    "application_sdk.common.incremental.helpers.download_file",
-                    side_effect=_tracking_download,
-                ),
-            ):
-                await download_s3_prefix_with_structure("prefix/", Path(temp_dir))
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch(
+                "application_sdk.common.incremental.helpers.list_keys",
+                AsyncMock(return_value=file_list),
+            ),
+            patch(
+                "application_sdk.common.incremental.helpers.download_file",
+                side_effect=_tracking_download,
+            ),
+        ):
+            await download_s3_prefix_with_structure("prefix/", Path(temp_dir))
 
         assert max_concurrent <= 4
 

--- a/tests/unit/common/test_aws_utils.py
+++ b/tests/unit/common/test_aws_utils.py
@@ -13,6 +13,7 @@ from application_sdk.common.aws_utils import (
     get_cluster_identifier,
     get_region_name_from_hostname,
 )
+from application_sdk.errors import InvalidInputError
 
 
 class TestAWSUtils:
@@ -27,7 +28,7 @@ class TestAWSUtils:
     def test_get_region_name_from_hostname_invalid(self):
         """Test extracting region from invalid hostname."""
         hostname = "invalid.hostname.com"
-        with pytest.raises(ValueError, match="Could not find valid AWS region"):
+        with pytest.raises(InvalidInputError, match="Could not find valid AWS region"):
             get_region_name_from_hostname(hostname)
 
     @patch("boto3.client")
@@ -320,7 +321,7 @@ class TestAWSUtils:
     def test_create_aws_client_no_credentials(self):
         """Test creating AWS client with no credentials provided."""
         with pytest.raises(
-            ValueError, match="At least one credential source must be provided"
+            InvalidInputError, match="At least one credential source must be provided"
         ):
             create_aws_client(service="s3", region="us-east-1")
 
@@ -334,7 +335,8 @@ class TestAWSUtils:
         }
 
         with pytest.raises(
-            ValueError, match="Only one credential source should be provided at a time"
+            InvalidInputError,
+            match="Only one credential source should be provided at a time",
         ):
             create_aws_client(
                 service="s3",

--- a/tests/unit/common/test_file_converter.py
+++ b/tests/unit/common/test_file_converter.py
@@ -38,6 +38,7 @@ from application_sdk.common.file_converter import (
     convert_parquet_to_json,
     file_converter_registry,
 )
+from application_sdk.errors import InvalidInputError
 
 # Only mark async tests individually
 
@@ -131,14 +132,14 @@ class TestConvertDataFiles:
     @pytest.mark.asyncio
     @patch("application_sdk.common.file_converter.file_converter_registry")
     async def test_converter_not_found_error(self, mock_registry):
-        """Test that when converter function is None, ValueError is raised."""
+        """Test that when converter function is None, InvalidInputError is raised."""
         # Arrange - registry returns None for unknown converter
         mock_registry.registry.get.return_value = None
 
         input_files = ["/path/input.json"]
 
-        # Act & Assert - Should raise ValueError with descriptive message
-        with pytest.raises(ValueError, match="No converter found"):
+        # Act & Assert - Should raise InvalidInputError with descriptive message
+        with pytest.raises(InvalidInputError, match="No converter found"):
             await convert_data_files(input_files, FileType.PARQUET)
 
     @pytest.mark.asyncio

--- a/tests/unit/common/test_path.py
+++ b/tests/unit/common/test_path.py
@@ -6,14 +6,15 @@ import pytest
 
 from application_sdk.common.path import convert_to_extended_path
 from application_sdk.constants import WINDOWS_EXTENDED_PATH_PREFIX
+from application_sdk.errors import InvalidInputError
 
 
 class TestConvertToExtendedPath:
     """Test suite for convert_to_extended_path function."""
 
     def test_raises_value_error_for_empty_path(self) -> None:
-        """Test that empty path raises ValueError."""
-        with pytest.raises(ValueError, match="Path cannot be empty"):
+        """Test that empty path raises InvalidInputError."""
+        with pytest.raises(InvalidInputError, match="Path cannot be empty"):
             convert_to_extended_path("")
 
     def test_returns_path_as_is_on_non_windows(self) -> None:

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -1,7 +1,6 @@
 import os
 import re
 from pathlib import Path
-from typing import Dict, List, Union
 from unittest.mock import mock_open, patch
 
 import pytest
@@ -15,13 +14,14 @@ from application_sdk.common.sql_filters import (
     prepare_query,
     read_sql_files,
 )
+from application_sdk.errors import InvalidInputError
 
 
 class TestPrepareQuery:
     def test_successful_query_preparation(self) -> None:
         """Test successful query preparation with all parameters"""
         query = "SELECT * FROM {normalized_include_regex} WHERE {normalized_exclude_regex} {temp_table_regex_sql}"
-        workflow_args: Dict[str, Dict[str, Union[str, bool]]] = {
+        workflow_args: dict[str, dict[str, str | bool]] = {
             "metadata": {
                 "include-filter": '{"db1": ["schema1"]}',
                 "exclude-filter": '{"db2": ["schema2"]}',
@@ -42,7 +42,7 @@ class TestPrepareQuery:
     def test_query_preparation_without_filters(self) -> None:
         """Test query preparation without any filters"""
         query = "SELECT * FROM {normalized_include_regex}"
-        workflow_args: Dict[str, Dict[str, str]] = {"metadata": {}}
+        workflow_args: dict[str, dict[str, str]] = {"metadata": {}}
 
         result = prepare_query(query, workflow_args)
 
@@ -54,7 +54,7 @@ class TestPrepareQuery:
         query = (
             "SELECT * FROM {normalized_include_regex} WHERE {normalized_exclude_regex}"
         )
-        workflow_args: Dict[str, Dict[str, str]] = {
+        workflow_args: dict[str, dict[str, str]] = {
             "metadata": {
                 "include-filter": "",
                 "exclude-filter": "",
@@ -70,7 +70,7 @@ class TestPrepareQuery:
     def test_query_preparation_with_invalid_json(self) -> None:
         """Test query preparation with invalid JSON in filters"""
         query = "SELECT * FROM {normalized_include_regex}"
-        workflow_args: Dict[str, Dict[str, str]] = {
+        workflow_args: dict[str, dict[str, str]] = {
             "metadata": {
                 "include-filter": "invalid json",
             }
@@ -89,7 +89,7 @@ class TestPrepareQuery:
     def test_query_preparation_with_missing_metadata(self) -> None:
         """Test query preparation with missing metadata"""
         query = "SELECT * FROM {normalized_include_regex}"
-        workflow_args: Dict[str, Dict[str, str]] = {}
+        workflow_args: dict[str, dict[str, str]] = {}
 
         result = prepare_query(query, workflow_args)
 
@@ -142,7 +142,7 @@ class TestPrepareFilters:
 class TestNormalizeFilters:
     def test_normalize_filters_with_specific_schemas(self) -> None:
         """Test normalize_filters with specific schema list"""
-        filter_dict: Dict[str, Union[List[str], str]] = {
+        filter_dict: dict[str, list[str] | str] = {
             "db1": ["schema1", "schema2"],
             "db2": ["schema3"],
         }
@@ -154,21 +154,21 @@ class TestNormalizeFilters:
 
     def test_normalize_filters_with_wildcard(self) -> None:
         """Test normalize_filters with wildcard schema"""
-        filter_dict: Dict[str, Union[List[str], str]] = {"db1": "*"}
+        filter_dict: dict[str, list[str] | str] = {"db1": "*"}
         result = normalize_filters(filter_dict, True)
 
         assert result == ["^db1\\..*$"]
 
     def test_normalize_filters_with_empty_list(self) -> None:
         """Test normalize_filters with empty schema list"""
-        filter_dict: Dict[str, Union[List[str], str]] = {"db1": []}
+        filter_dict: dict[str, list[str] | str] = {"db1": []}
         result = normalize_filters(filter_dict, True)
 
         assert result == ["^db1\\..*$"]
 
     def test_normalize_filters_with_regex_patterns(self) -> None:
         """Test normalize_filters with anchored regex patterns in keys/values."""
-        filter_dict: Dict[str, Union[List[str], str]] = {"^db1$": ["^schema1$"]}
+        filter_dict: dict[str, list[str] | str] = {"^db1$": ["^schema1$"]}
         result = normalize_filters(filter_dict, True)
 
         # ``^``/``$`` are stripped from both the db key and each schema entry,
@@ -909,7 +909,7 @@ def test_read_sql_files_with_multiple_files(tmp_path: Path):
     ):
         # Configure glob to return our mock files
         mock_glob.return_value = [
-            os.path.join("/mock/path", file_path) for file_path in mock_files.keys()
+            os.path.join("/mock/path", file_path) for file_path in mock_files
         ]
 
         # Configure file open to return different content for different files
@@ -981,7 +981,7 @@ def test_read_sql_files_case_sensitivity():
         patch("os.path.dirname", return_value="/mock/path"),
     ):
         mock_glob.return_value = [
-            os.path.join("/mock/path", file_path) for file_path in mock_files.keys()
+            os.path.join("/mock/path", file_path) for file_path in mock_files
         ]
 
         mock_file = mock_file_open.return_value
@@ -1013,13 +1013,13 @@ class TestParseFilterInput:
         assert parse_filter_input('{"db1": ["s1", "s2"]}') == {"db1": ["s1", "s2"]}
 
     def test_invalid_json_strings(self) -> None:
-        """Test invalid JSON strings raise CommonError."""
+        """Test invalid JSON strings raise InvalidInputError."""
 
-        with pytest.raises(CommonError, match="Invalid filter JSON"):
+        with pytest.raises(InvalidInputError, match="Invalid filter JSON"):
             parse_filter_input("invalid json")
 
-        with pytest.raises(CommonError, match="Invalid filter JSON"):
+        with pytest.raises(InvalidInputError, match="Invalid filter JSON"):
             parse_filter_input('{"invalid": }')
 
-        with pytest.raises(CommonError, match="Invalid filter JSON"):
+        with pytest.raises(InvalidInputError, match="Invalid filter JSON"):
             parse_filter_input("not json at all")

--- a/tests/unit/credentials/test_agent.py
+++ b/tests/unit/credentials/test_agent.py
@@ -894,11 +894,12 @@ class TestCredentialRefFromWorkflowArgs:
         import pytest
 
         from application_sdk.credentials.ref import CredentialRef
+        from application_sdk.errors import InvalidInputError
 
-        with pytest.raises(ValueError, match="no routable credential source"):
+        with pytest.raises(InvalidInputError, match="no routable credential source"):
             CredentialRef.from_workflow_args({})
 
-        with pytest.raises(ValueError, match="no routable credential source"):
+        with pytest.raises(InvalidInputError, match="no routable credential source"):
             CredentialRef.from_workflow_args(
                 {"extraction_method": "direct", "agent_json": "", "credential_guid": ""}
             )
@@ -907,8 +908,9 @@ class TestCredentialRefFromWorkflowArgs:
         import pytest
 
         from application_sdk.credentials.ref import CredentialRef
+        from application_sdk.errors import InvalidInputError
 
-        with pytest.raises(ValueError, match="no routable credential source"):
+        with pytest.raises(InvalidInputError, match="no routable credential source"):
             CredentialRef.from_workflow_args(
                 {"extraction_method": "agent", "agent_json": "{}"}
             )

--- a/tests/unit/credentials/test_atlan_client.py
+++ b/tests/unit/credentials/test_atlan_client.py
@@ -85,8 +85,12 @@ class TestCreateAsyncAtlanClient:
         assert result is mock_client
 
     def test_unsupported_type_raises_type_error(self) -> None:
+        from application_sdk.errors import InvalidInputError
+
         cred = BasicCredential(username="user", password="pass")
-        with pytest.raises(TypeError, match="Unsupported Atlan credential type"):
+        with pytest.raises(
+            InvalidInputError, match="Unsupported Atlan credential type"
+        ):
             with patch("pyatlan_v9.client.aio.AsyncAtlanClient"):
                 create_async_atlan_client(cred)  # type: ignore[arg-type]
 

--- a/tests/unit/credentials/test_ref.py
+++ b/tests/unit/credentials/test_ref.py
@@ -179,23 +179,29 @@ class TestCredentialRefResolve:
         assert ref.credential_guid == "abc-123"
 
     def test_resolve_no_credential_source_raises(self):
+        from application_sdk.errors import InvalidInputError
+
         inp = ExtractionInput(
             extraction_method="direct",
             credential_guid="",
         )
-        with pytest.raises(ValueError, match="No routable credential source"):
+        with pytest.raises(InvalidInputError, match="No routable credential source"):
             CredentialRef.resolve(inp)
 
     def test_resolve_non_resolvable_raises_type_error(self):
-        with pytest.raises(TypeError, match="Expected a CredentialResolvable"):
+        from application_sdk.errors import InvalidInputError
+
+        with pytest.raises(InvalidInputError, match="Expected a CredentialResolvable"):
             CredentialRef.resolve("not-a-model")  # type: ignore[arg-type]
 
     def test_resolve_agent_with_empty_spec_and_guid_falls_through(self):
         """Agent mode with unpopulated agent_json but valid guid should fail
         because resolve() requires explicit direct mode for GUID resolution."""
+        from application_sdk.errors import InvalidInputError
+
         inp = ExtractionInput(
             extraction_method="agent",
             credential_guid="abc-123",
         )
-        with pytest.raises(ValueError, match="No routable credential source"):
+        with pytest.raises(InvalidInputError, match="No routable credential source"):
             CredentialRef.resolve(inp)

--- a/tests/unit/execution/test_auth_token_refresh_event.py
+++ b/tests/unit/execution/test_auth_token_refresh_event.py
@@ -15,6 +15,7 @@ from unittest import mock
 import pytest
 
 from application_sdk.contracts.events import ApplicationEventNames, EventTypes
+from application_sdk.errors import AuthError, InvalidInputError
 from application_sdk.execution._temporal.auth import (
     TemporalAuthConfig,
     TemporalAuthManager,
@@ -289,7 +290,7 @@ class TestResolveTokenUrl:
 
     def test_raises_when_neither_set(self) -> None:
         manager = _make_manager(token_url="", base_url="")
-        with pytest.raises(ValueError, match="token_url or base_url"):
+        with pytest.raises(InvalidInputError, match="token_url or base_url"):
             manager._resolve_token_url()
 
 
@@ -379,7 +380,7 @@ class TestAcquireInitialToken:
         svc = _stub_token_service(manager)
         svc.get_token = mock.AsyncMock(side_effect=ValueError("bad creds"))
 
-        with pytest.raises(RuntimeError, match="Failed to acquire initial"):
+        with pytest.raises(AuthError, match="Failed to acquire initial"):
             await manager.acquire_initial_token()
 
     @pytest.mark.asyncio
@@ -399,7 +400,7 @@ class TestAcquireInitialToken:
         svc = _stub_token_service(manager)
         svc.get_token = mock.AsyncMock(side_effect=original)
 
-        with pytest.raises(RuntimeError) as ei:
+        with pytest.raises(AuthError) as ei:
             await manager.acquire_initial_token()
 
         assert ei.value.__cause__ is original

--- a/tests/unit/execution/test_backend.py
+++ b/tests/unit/execution/test_backend.py
@@ -20,6 +20,7 @@ import pytest
 
 # These tests intentionally import a private Temporal backend module because
 # they verify internal client/runtime wiring that is not exposed publicly.
+from application_sdk.errors import DependencyUnavailableError, InvalidInputError
 from application_sdk.execution._temporal import backend as backend_module
 from application_sdk.execution._temporal.backend import (
     TemporalExecutorBackend,
@@ -134,7 +135,7 @@ class TestTemporalExecutorBackendExecute:
         backend = TemporalExecutorBackend(client=client)
         app_cls = _make_app_cls(name="noeps", entry_points={"a": mock.MagicMock()})
         ctx = mock.MagicMock(app_name="noeps", correlation_id="c")
-        with pytest.raises(ValueError, match="Unknown entry point"):
+        with pytest.raises(InvalidInputError, match="Unknown entry point"):
             await backend.execute(
                 app_cls,
                 _make_input_data(),
@@ -247,11 +248,11 @@ class TestBuildTlsConfig:
             _build_tls_config(server_root_ca_cert_path=str(tmp_path / "missing.pem"))
 
     def test_raises_when_client_cert_without_key(self, tmp_path: Any) -> None:
-        with pytest.raises(ValueError, match="mTLS requires both"):
+        with pytest.raises(InvalidInputError, match="mTLS requires both"):
             _build_tls_config(client_cert_path=str(tmp_path / "client.pem"))
 
     def test_raises_when_client_key_without_cert(self, tmp_path: Any) -> None:
-        with pytest.raises(ValueError, match="mTLS requires both"):
+        with pytest.raises(InvalidInputError, match="mTLS requires both"):
             _build_tls_config(client_private_key_path=str(tmp_path / "key.pem"))
 
     def test_raises_when_client_cert_missing(self, tmp_path: Any) -> None:
@@ -455,7 +456,9 @@ class TestCreateTemporalClient:
             mock.patch.object(backend_module.Client, "connect", new=connect_mock),
             mock.patch.object(backend_module.asyncio, "sleep", new=mock.AsyncMock()),
         ):
-            with pytest.raises(RuntimeError, match="Failed to connect to Temporal"):
+            with pytest.raises(
+                DependencyUnavailableError, match="Failed to connect to Temporal"
+            ):
                 await create_temporal_client(
                     connect_max_attempts=2,
                     connect_retry_delay_seconds=0.0,

--- a/tests/unit/execution/test_lock_interceptor.py
+++ b/tests/unit/execution/test_lock_interceptor.py
@@ -139,18 +139,20 @@ class TestStartActivityWithLock:
 
     async def test_missing_schedule_to_close_raises(self):
         """Activity with @needs_lock but no schedule_to_close_timeout raises."""
-        from application_sdk.common.error_codes import WorkflowError
+        from application_sdk.errors import InvalidInputError
 
         lock_fn = _make_activity_fn()
         interceptor, _ = _make_outbound_interceptor(activities={"my_activity": lock_fn})
         inp = _make_start_activity_input(schedule_to_close_timeout=None)
 
-        with patch(
-            "application_sdk.execution._temporal.interceptors.lock.IS_LOCKING_DISABLED",
-            False,
+        with (
+            patch(
+                "application_sdk.execution._temporal.interceptors.lock.IS_LOCKING_DISABLED",
+                False,
+            ),
+            pytest.raises(InvalidInputError),
         ):
-            with pytest.raises(WorkflowError):
-                await interceptor.start_activity(inp)
+            await interceptor.start_activity(inp)
 
     async def test_acquire_execute_release_sequence(self):
         """Lock is acquired, business activity runs, then lock is released."""
@@ -308,7 +310,6 @@ class TestStartActivityWithLock:
                 raise TimeoutError("could not acquire lock")
             if activity_name == "release_distributed_lock":
                 released.append(True)
-            return None
 
         wf_info = MagicMock()
         wf_info.run_id = "run-4"

--- a/tests/unit/execution/test_worker.py
+++ b/tests/unit/execution/test_worker.py
@@ -12,6 +12,7 @@ from application_sdk.app.base import App
 from application_sdk.app.registry import AppRegistry, TaskRegistry
 from application_sdk.app.task import task
 from application_sdk.contracts.base import Input, Output
+from application_sdk.errors import InvalidInputError
 from application_sdk.execution._temporal.worker import AppWorker, create_worker
 
 DRAIN_DELAY_PATCH = (
@@ -220,7 +221,7 @@ class TestCreateWorker:
                 return _WorkerOutput()
 
         client = _make_mock_client()
-        with pytest.raises(ValueError, match="LogInterceptor"):
+        with pytest.raises(InvalidInputError, match="LogInterceptor"):
             create_worker(client, interceptors=[LogInterceptor()])
 
     def test_rejects_caller_supplied_metrics_interceptor(self) -> None:
@@ -233,7 +234,7 @@ class TestCreateWorker:
                 return _WorkerOutput()
 
         client = _make_mock_client()
-        with pytest.raises(ValueError, match="MetricsInterceptor"):
+        with pytest.raises(InvalidInputError, match="MetricsInterceptor"):
             create_worker(client, interceptors=[MetricsInterceptor()])
 
     def test_rejects_caller_supplied_trace_interceptor(self) -> None:
@@ -246,7 +247,7 @@ class TestCreateWorker:
                 return _WorkerOutput()
 
         client = _make_mock_client()
-        with pytest.raises(ValueError, match="TraceInterceptor"):
+        with pytest.raises(InvalidInputError, match="TraceInterceptor"):
             create_worker(client, interceptors=[TraceInterceptor()])
 
     def test_sdr_workflows_skipped_when_no_handler(self) -> None:

--- a/tests/unit/infrastructure/test_credential_state_store.py
+++ b/tests/unit/infrastructure/test_credential_state_store.py
@@ -57,22 +57,26 @@ class TestDaprRequiredStartup:
         """_create_infrastructure raises when DAPR_HTTP_PORT not set."""
         import pytest
 
+        from application_sdk.errors import PreconditionError
+
         monkeypatch.delenv("DAPR_HTTP_PORT", raising=False)
 
         from application_sdk.main import _create_infrastructure
 
-        with pytest.raises(RuntimeError, match="Dapr sidecar not detected"):
+        with pytest.raises(PreconditionError, match="Dapr sidecar not detected"):
             await _create_infrastructure()
 
     async def test_error_message_includes_poe_command(self, monkeypatch):
         """Error message tells developer how to fix it."""
+        from application_sdk.errors import PreconditionError
+
         monkeypatch.delenv("DAPR_HTTP_PORT", raising=False)
 
         from application_sdk.main import _create_infrastructure
 
         try:
             await _create_infrastructure()
-        except RuntimeError as e:
+        except PreconditionError as e:
             assert "poe start-deps" in str(e)
             assert "DAPR_HTTP_PORT" in str(e)
 

--- a/tests/unit/infrastructure/test_dapr_wrappers.py
+++ b/tests/unit/infrastructure/test_dapr_wrappers.py
@@ -89,7 +89,9 @@ class TestDaprStateStore:
             await self.store.delete("k1")
 
     async def test_list_keys_raises_not_implemented(self):
-        with pytest.raises(NotImplementedError):
+        from application_sdk.errors.leaves import UnimplementedError
+
+        with pytest.raises(UnimplementedError):
             await self.store.list_keys()
 
 

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -10,6 +10,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 from loguru import logger
 
+from application_sdk.errors import InternalError
 from application_sdk.observability.context import (
     ExecutionContext,
     set_execution_context,
@@ -1564,7 +1565,7 @@ class TestProcessRecord:
     def test_unsupported_type_raises_value_error(
         self, logger_adapter: AtlanLoggerAdapter
     ):
-        with pytest.raises(ValueError):
+        with pytest.raises(InternalError):
             logger_adapter.process_record(12345)
 
     def test_loguru_like_record_is_normalized(self, logger_adapter: AtlanLoggerAdapter):

--- a/tests/unit/observability/test_pushgateway.py
+++ b/tests/unit/observability/test_pushgateway.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
+from application_sdk.errors import InvalidInputError
 from application_sdk.observability.pushgateway import (
     PushGatewayClient,
     TemporalCoreCollector,
@@ -106,11 +107,11 @@ class TestTemporalCoreCollector:
 
 class TestPushGatewayClientInit:
     def test_empty_url_raises(self):
-        with pytest.raises(ValueError, match="url"):
+        with pytest.raises(InvalidInputError, match="url"):
             PushGatewayClient(url="", job="job")
 
     def test_empty_job_raises(self):
-        with pytest.raises(ValueError, match="job"):
+        with pytest.raises(InvalidInputError, match="job"):
             PushGatewayClient(url="http://localhost:9091", job="")
 
     def test_default_grouping_key_excludes_task_queue_to_avoid_label_conflict(self):

--- a/tests/unit/server/fastapi/test_fastapi_utils.py
+++ b/tests/unit/server/fastapi/test_fastapi_utils.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi import UploadFile
 
 from application_sdk.common.utils import download_file_from_upload_response
+from application_sdk.errors import DataIntegrityError, InvalidInputError
 from application_sdk.server.fastapi.models import FileUploadResponse
 from application_sdk.server.fastapi.utils import (
     _build_object_store_key,
@@ -580,12 +581,12 @@ class TestDownloadFileFromUploadResponse:
 
     async def test_download_missing_key_error(self):
         """Test that ValueError is raised when 'key' is missing from dict."""
-        with pytest.raises(ValueError, match="missing required 'key' field"):
+        with pytest.raises(DataIntegrityError, match="missing required 'key' field"):
             await download_file_from_upload_response({"id": "abc123"})
 
     async def test_download_invalid_json_error(self):
         """Test that ValueError is raised for invalid JSON string."""
-        with pytest.raises(ValueError, match="Invalid JSON string"):
+        with pytest.raises(InvalidInputError, match="Invalid JSON string"):
             await download_file_from_upload_response("not valid json")
 
     @patch("application_sdk.common.utils.download_file")

--- a/tests/unit/storage/formats/readers/test_json_reader.py
+++ b/tests/unit/storage/formats/readers/test_json_reader.py
@@ -1,12 +1,11 @@
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from hypothesis import HealthCheck, given, settings
 
-from application_sdk.common.error_codes import IOError as SDKIOError
 from application_sdk.common.types import DataframeType
 from application_sdk.storage.formats.json import JsonFileReader
 from application_sdk.storage.formats.utils import _download_files
@@ -27,7 +26,7 @@ settings.load_profile("json_input_tests")
 
 
 @given(config=json_input_config_strategy)
-def test_init(config: Dict[str, Any]) -> None:
+def test_init(config: dict[str, Any]) -> None:
     json_input = JsonFileReader(
         path=config["path"],
         file_names=config["file_names"],
@@ -38,8 +37,12 @@ def test_init(config: Dict[str, Any]) -> None:
 
 
 def test_init_single_file_with_file_names_raises_error() -> None:
-    """Test that JsonFileReader raises ValueError when single file path is combined with file_names."""
-    with pytest.raises(ValueError, match="Cannot specify both a single file path"):
+    """Test that JsonFileReader raises InvalidInputError when single file path is combined with file_names."""
+    from application_sdk.errors import InvalidInputError
+
+    with pytest.raises(
+        InvalidInputError, match="Cannot specify both a single file path"
+    ):
         JsonFileReader(path="/data/test.json", file_names=["other.json"])
 
 
@@ -163,7 +166,9 @@ async def test_download_file_error_propagation() -> None:
             path=path, file_names=file_names, dataframe_type=DataframeType.daft
         )
 
-        with pytest.raises(SDKIOError, match="ATLAN-IO-503-00"):
+        from application_sdk.storage.formats._format_errors import ObjectStoreReadError
+
+        with pytest.raises(ObjectStoreReadError):
             await _download_files(json_input.path, ".json", json_input.file_names)
 
 
@@ -182,12 +187,12 @@ def _install_dummy_pandas(monkeypatch):
     dummy_pandas = types.ModuleType("pandas")
     call_log: list[dict] = []
 
-    def read_json(path, chunksize=None, lines=None):  # noqa: D401, ANN001
+    def read_json(path, chunksize=None, lines=None):
         call_log.append({"path": path, "chunksize": chunksize, "lines": lines})
         # Return two synthetic chunks for iteration
         return [f"chunk1-{os.path.basename(path)}", f"chunk2-{os.path.basename(path)}"]
 
-    def concat(objs, ignore_index=None):  # noqa: D401, ANN001
+    def concat(objs, ignore_index=None):
         return "combined:" + ",".join(objs)
 
     dummy_pandas.read_json = read_json  # type: ignore[attr-defined]
@@ -208,7 +213,7 @@ async def test_read_batches_with_mocked_pandas(monkeypatch) -> None:
     expected_chunksize = 5
     call_log = _install_dummy_pandas(monkeypatch)
 
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return [os.path.join(path, fn) for fn in file_names] if file_names else []
 
     # Mock the base Input class method since JsonFileReader calls super()._download_files()
@@ -247,7 +252,7 @@ async def test_read_batches_empty_file_list(monkeypatch) -> None:
 
     call_log = _install_dummy_pandas(monkeypatch)
 
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return []
 
     # Mock the base Input class method since JsonFileReader calls super()._download_files()
@@ -274,14 +279,14 @@ async def test_read_batches_empty_file_list(monkeypatch) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _install_dummy_daft(monkeypatch):  # noqa: D401, ANN001
+def _install_dummy_daft(monkeypatch):
     import sys
     import types
 
     dummy_daft = types.ModuleType("daft")
     call_log: list[dict] = []
 
-    def read_json(path, _chunk_size=None):  # noqa: D401, ANN001
+    def read_json(path, _chunk_size=None):
         call_log.append({"path": path, "_chunk_size": _chunk_size})
         return f"daft_df:{path}"
 
@@ -298,7 +303,7 @@ async def test_read(monkeypatch) -> None:
 
     call_log = _install_dummy_daft(monkeypatch)
 
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return (
             [os.path.join(path, fn).replace(os.path.sep, "/") for fn in file_names]
             if file_names
@@ -333,7 +338,7 @@ async def test_read_no_files(monkeypatch) -> None:
 
     call_log = _install_dummy_daft(monkeypatch)
 
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return []  # Return empty list when no files found
 
     # Mock the base Input class method since JsonFileReader calls super()._download_files()
@@ -360,7 +365,7 @@ async def test_read_batches(monkeypatch) -> None:
 
     call_log = _install_dummy_daft(monkeypatch)
 
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return [os.path.join(path, fn) for fn in file_names] if file_names else []
 
     # Mock the base Input class method since JsonFileReader calls super()._download_files()
@@ -404,7 +409,7 @@ async def test_context_manager_calls_close(monkeypatch) -> None:
     """Verify that using async with calls close() on exit."""
     _install_dummy_daft(monkeypatch)
 
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return [os.path.join(path, fn) for fn in file_names] if file_names else []
 
     monkeypatch.setattr(
@@ -448,7 +453,7 @@ async def test_read_after_close_raises_error(monkeypatch) -> None:
     """Verify that reading after close raises ValueError."""
     _install_dummy_daft(monkeypatch)
 
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return [os.path.join(path, fn) for fn in file_names] if file_names else []
 
     monkeypatch.setattr(
@@ -470,13 +475,17 @@ async def test_read_after_close_raises_error(monkeypatch) -> None:
     await reader.close()
 
     # Read should raise after close
-    with pytest.raises(ValueError, match="Cannot read from a closed reader"):
+    from application_sdk.storage.formats._format_errors import ClosedReaderError
+
+    with pytest.raises(ClosedReaderError, match="Cannot read from a closed reader"):
         await reader.read()
 
 
 @pytest.mark.asyncio
 async def test_read_batches_after_close_raises_error() -> None:
-    """Verify that read_batches after close raises ValueError."""
+    """Verify that read_batches after close raises ClosedReaderError."""
+    from application_sdk.storage.formats._format_errors import ClosedReaderError
+
     path = "/data"
     reader = JsonFileReader(path=path, dataframe_type=DataframeType.pandas)
 
@@ -484,7 +493,7 @@ async def test_read_batches_after_close_raises_error() -> None:
     await reader.close()
 
     # read_batches should raise after close
-    with pytest.raises(ValueError, match="Cannot read from a closed reader"):
+    with pytest.raises(ClosedReaderError, match="Cannot read from a closed reader"):
         reader.read_batches()
 
 
@@ -504,7 +513,7 @@ async def test_cleanup_on_close_false_retains_files(monkeypatch) -> None:
 
     downloaded_files = ["/tmp/downloaded/file1.json", "/tmp/downloaded/file2.json"]
 
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return downloaded_files
 
     monkeypatch.setattr(
@@ -549,7 +558,7 @@ async def test_cleanup_on_close_true_cleans_files(monkeypatch) -> None:
 
     downloaded_files = ["/tmp/downloaded/file1.json", "/tmp/downloaded/file2.json"]
 
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return downloaded_files
 
     monkeypatch.setattr(
@@ -595,7 +604,7 @@ async def test_downloaded_files_tracked_on_read(monkeypatch) -> None:
 
     downloaded_files = ["/tmp/downloaded/file1.json"]
 
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return downloaded_files
 
     monkeypatch.setattr(

--- a/tests/unit/storage/formats/readers/test_parquet_reader.py
+++ b/tests/unit/storage/formats/readers/test_parquet_reader.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -26,7 +26,7 @@ settings.load_profile("parquet_input_tests")
 
 
 @given(config=parquet_input_config_strategy)
-def test_init(config: Dict[str, Any]) -> None:
+def test_init(config: dict[str, Any]) -> None:
     parquet_input = ParquetFileReader(
         path=config["path"],
         chunk_size=config["chunk_size"],
@@ -40,8 +40,12 @@ def test_init(config: Dict[str, Any]) -> None:
 
 
 def test_init_single_file_with_file_names_raises_error() -> None:
-    """Test that ParquetFileReader raises ValueError when single file path is combined with file_names."""
-    with pytest.raises(ValueError, match="Cannot specify both a single file path"):
+    """Test that ParquetFileReader raises InvalidInputError when single file path is combined with file_names."""
+    from application_sdk.errors import InvalidInputError
+
+    with pytest.raises(
+        InvalidInputError, match="Cannot specify both a single file path"
+    ):
         ParquetFileReader(
             path="/data/test.parquet",
             file_names=["other.parquet"],
@@ -151,7 +155,7 @@ def _install_dummy_pandas(monkeypatch):
         def __getitem__(self, slice_obj):
             return f"chunk-{slice_obj.start}-{slice_obj.stop}"
 
-    def read_parquet(path):  # noqa: D401, ANN001
+    def read_parquet(path):
         call_log.append({"path": path})
 
         # Return a mock DataFrame with length for chunking
@@ -168,7 +172,7 @@ def _install_dummy_pandas(monkeypatch):
 
         return MockDataFrame()
 
-    def concat(objs, ignore_index=None):  # noqa: D401, ANN001
+    def concat(objs, ignore_index=None):
         # Return a mock DataFrame that combines all input DataFrames
         class CombinedMockDataFrame:
             def __init__(self):
@@ -206,7 +210,7 @@ async def test_read_with_mocked_pandas(monkeypatch) -> None:
     call_log = _install_dummy_pandas(monkeypatch)
 
     # Mock _download_files to return the path
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return [path]  # Return the path as a list of files
 
     # Mock the base Input class method since ParquetFileReader calls super()._download_files()
@@ -237,7 +241,7 @@ async def test_read_batches_with_mocked_pandas(monkeypatch) -> None:
     call_log = _install_dummy_pandas(monkeypatch)
 
     # Mock _download_files to return the path
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return [path]  # Return the path as a list of files
 
     # Mock the base Input class method since ParquetFileReader calls super()._download_files()
@@ -275,7 +279,7 @@ async def test_read_batches_with_chunk_size(monkeypatch) -> None:
     call_log = _install_dummy_pandas(monkeypatch)
 
     # Mock _download_files to return the path
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return [path]  # Return the path as a list of files
 
     # Mock the base Input class method since ParquetFileReader calls super()._download_files()
@@ -308,7 +312,7 @@ async def test_read_batches_with_chunk_size(monkeypatch) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _install_dummy_daft(monkeypatch):  # noqa: D401, ANN001
+def _install_dummy_daft(monkeypatch):
     import sys
     import types
 
@@ -346,7 +350,7 @@ def _install_dummy_daft(monkeypatch):  # noqa: D401, ANN001
                 return f"daft_df:{self.path[0] if self.path else 'unknown'}"
             return f"daft_df:{self.path}"
 
-    def read_parquet(path, _chunk_size=None, **kwargs):  # noqa: D401, ANN001
+    def read_parquet(path, _chunk_size=None, **kwargs):
         call_log.append({"path": path})
         if isinstance(path, list) and len(path) > 1:
             # For read_batches tests that need MockDaftDataFrame
@@ -370,7 +374,7 @@ async def test_read(monkeypatch) -> None:
     call_log = _install_dummy_pandas(monkeypatch)
 
     # Mock _download_files to return a list of files
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return [f"{path}/file1.parquet", f"{path}/file2.parquet"]
 
     # Mock the base Input class method since ParquetFileReader calls super()._download_files()
@@ -401,7 +405,7 @@ async def test_read_with_file_names(monkeypatch) -> None:
     call_log = _install_dummy_daft(monkeypatch)
 
     # Mock _download_files to return the specific files
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return (
             [os.path.join(path, fn).replace(os.path.sep, "/") for fn in file_names]
             if file_names
@@ -440,7 +444,7 @@ async def test_read_with_input_prefix(monkeypatch) -> None:
     call_log = _install_dummy_pandas(monkeypatch)
 
     # Mock _download_files to return a list of files
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return [f"{path}/file1.parquet", f"{path}/file2.parquet"]
 
     # Mock the base Input class method since ParquetFileReader calls super()._download_files()
@@ -471,7 +475,7 @@ async def test_read_batches_with_file_names(monkeypatch) -> None:
     call_log = _install_dummy_daft(monkeypatch)
 
     # Mock _download_files to return the specific files
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return (
             [os.path.join(path, fn).replace(os.path.sep, "/") for fn in file_names]
             if file_names
@@ -516,7 +520,7 @@ async def test_read_batches_without_file_names(monkeypatch) -> None:
     call_log = _install_dummy_daft(monkeypatch)
 
     # Mock _download_files to return a list of files
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return [f"{path}/file1.parquet", f"{path}/file2.parquet"]
 
     # Mock the base Input class method since ParquetFileReader calls super()._download_files()
@@ -550,7 +554,7 @@ async def test_read_batches_no_input_prefix(monkeypatch) -> None:
     call_log = _install_dummy_daft(monkeypatch)
 
     # Mock _download_files to return a list of files
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return [f"{path}/file1.parquet", f"{path}/file2.parquet"]
 
     # Mock the base Input class method since ParquetFileReader calls super()._download_files()
@@ -587,7 +591,7 @@ async def test_context_manager_calls_close(monkeypatch) -> None:
     """Verify that using async with calls close() on exit."""
     _install_dummy_pandas(monkeypatch)
 
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return [path]
 
     monkeypatch.setattr(
@@ -630,7 +634,7 @@ async def test_read_after_close_raises_error(monkeypatch) -> None:
     """Verify that reading after close raises ValueError."""
     _install_dummy_pandas(monkeypatch)
 
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return [path]
 
     monkeypatch.setattr(
@@ -649,13 +653,17 @@ async def test_read_after_close_raises_error(monkeypatch) -> None:
     await reader.close()
 
     # Read should raise after close
-    with pytest.raises(ValueError, match="Cannot read from a closed reader"):
+    from application_sdk.storage.formats._format_errors import ClosedReaderError
+
+    with pytest.raises(ClosedReaderError, match="Cannot read from a closed reader"):
         await reader.read()
 
 
 @pytest.mark.asyncio
 async def test_read_batches_after_close_raises_error() -> None:
-    """Verify that read_batches after close raises ValueError."""
+    """Verify that read_batches after close raises ClosedReaderError."""
+    from application_sdk.storage.formats._format_errors import ClosedReaderError
+
     path = "/data/test.parquet"
     reader = ParquetFileReader(path=path, dataframe_type=DataframeType.pandas)
 
@@ -663,7 +671,7 @@ async def test_read_batches_after_close_raises_error() -> None:
     await reader.close()
 
     # read_batches should raise after close
-    with pytest.raises(ValueError, match="Cannot read from a closed reader"):
+    with pytest.raises(ClosedReaderError, match="Cannot read from a closed reader"):
         reader.read_batches()
 
 
@@ -686,7 +694,7 @@ async def test_cleanup_on_close_false_retains_files(monkeypatch) -> None:
         "/tmp/downloaded/file2.parquet",
     ]
 
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return downloaded_files
 
     monkeypatch.setattr(
@@ -734,7 +742,7 @@ async def test_cleanup_on_close_true_cleans_files(monkeypatch) -> None:
         "/tmp/downloaded/file2.parquet",
     ]
 
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return downloaded_files
 
     monkeypatch.setattr(
@@ -780,7 +788,7 @@ async def test_downloaded_files_tracked_on_read(monkeypatch) -> None:
 
     downloaded_files = ["/tmp/downloaded/file1.parquet"]
 
-    async def dummy_download(path, file_extension, file_names=None):  # noqa: D401, ANN001
+    async def dummy_download(path, file_extension, file_names=None):
         return downloaded_files
 
     monkeypatch.setattr(

--- a/tests/unit/storage/formats/test_base_io.py
+++ b/tests/unit/storage/formats/test_base_io.py
@@ -17,7 +17,8 @@ threads or loops beyond pytest-asyncio.
 
 from __future__ import annotations
 
-from typing import Any, AsyncGenerator
+from collections.abc import AsyncGenerator
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -191,8 +192,10 @@ class TestConvertToDataframe:
         assert list(result["a"]) == [1, 2]
 
     def test_unsupported_type_raises_typeerror(self) -> None:
+        from application_sdk.errors import InvalidInputError
+
         writer = _StubWriter(dataframe_type=DataframeType.pandas)
-        with pytest.raises(TypeError, match="Unsupported data type"):
+        with pytest.raises(InvalidInputError, match="Unsupported data type"):
             writer._convert_to_dataframe(42)
 
     def test_pandas_input_with_daft_type_without_daft_raises(self) -> None:
@@ -200,6 +203,8 @@ class TestConvertToDataframe:
         import builtins
 
         import pandas as pd
+
+        from application_sdk.errors import InvalidInputError
 
         writer = _StubWriter(dataframe_type=DataframeType.daft)
         df = pd.DataFrame({"a": [1]})
@@ -212,12 +217,14 @@ class TestConvertToDataframe:
             return original_import(name, *args, **kwargs)
 
         with patch.object(builtins, "__import__", side_effect=_raise_for_daft):
-            with pytest.raises(TypeError, match="daft is not installed"):
+            with pytest.raises(InvalidInputError, match="daft is not installed"):
                 writer._convert_to_dataframe(df)
 
     def test_dict_input_with_daft_type_without_daft_raises(self) -> None:
         """Inline ``import daft`` ImportError on dict→daft conversion path."""
         import builtins
+
+        from application_sdk.errors import InvalidInputError
 
         writer = _StubWriter(dataframe_type=DataframeType.daft)
         original_import = builtins.__import__
@@ -228,7 +235,9 @@ class TestConvertToDataframe:
             return original_import(name, *args, **kwargs)
 
         with patch.object(builtins, "__import__", side_effect=_raise_for_daft):
-            with pytest.raises(TypeError, match="Dict and list inputs require daft"):
+            with pytest.raises(
+                InvalidInputError, match="Dict and list inputs require daft"
+            ):
                 writer._convert_to_dataframe({"a": 1})
 
 
@@ -240,17 +249,21 @@ class TestConvertToDataframe:
 class TestWriterWrite:
     @pytest.mark.asyncio
     async def test_write_to_closed_writer_raises(self) -> None:
+        from application_sdk.storage.formats._format_errors import ClosedWriterError
+
         writer = _StubWriter()
         writer._is_closed = True
-        with pytest.raises(ValueError, match="closed writer"):
+        with pytest.raises(ClosedWriterError, match="closed writer"):
             await writer.write({"a": 1})
 
     @pytest.mark.asyncio
     async def test_write_unsupported_dtype_raises(self) -> None:
+        from application_sdk.errors import InvalidInputError
+
         writer = _StubWriter()
         # Replace with an arbitrary value the dispatcher does not understand.
         writer.dataframe_type = "unknown"
-        with pytest.raises(ValueError, match="Unsupported dataframe_type"):
+        with pytest.raises(InvalidInputError, match="Unsupported dataframe_type"):
             await writer.write({"a": 1})
 
     @pytest.mark.asyncio
@@ -286,24 +299,28 @@ class TestWriterWrite:
 class TestWriteBatches:
     @pytest.mark.asyncio
     async def test_write_batches_to_closed_writer_raises(self) -> None:
+        from application_sdk.storage.formats._format_errors import ClosedWriterError
+
         writer = _StubWriter()
         writer._is_closed = True
 
         async def _gen() -> AsyncGenerator[Any, None]:  # pragma: no cover
             yield None
 
-        with pytest.raises(ValueError, match="closed writer"):
+        with pytest.raises(ClosedWriterError, match="closed writer"):
             await writer.write_batches(_gen())
 
     @pytest.mark.asyncio
     async def test_write_batches_unsupported_dtype_raises(self) -> None:
+        from application_sdk.errors import InvalidInputError
+
         writer = _StubWriter()
         writer.dataframe_type = "weird"
 
         def _gen():
             yield None
 
-        with pytest.raises(ValueError, match="Unsupported dataframe_type"):
+        with pytest.raises(InvalidInputError, match="Unsupported dataframe_type"):
             await writer.write_batches(_gen())
 
     @pytest.mark.asyncio
@@ -377,14 +394,16 @@ class TestFlushBuffer:
         import pandas as pd
 
         writer = _StubWriter()
-        with patch.object(
-            writer,
-            "_write_chunk",
-            new_callable=AsyncMock,
-            side_effect=RuntimeError("disk full"),
+        with (
+            patch.object(
+                writer,
+                "_write_chunk",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("disk full"),
+            ),
+            pytest.raises(RuntimeError, match="disk full"),
         ):
-            with pytest.raises(RuntimeError, match="disk full"):
-                await writer._flush_buffer(pd.DataFrame({"a": [1]}), 0)
+            await writer._flush_buffer(pd.DataFrame({"a": [1]}), 0)
 
         # Last metric call should record write_errors.
         names = [
@@ -448,14 +467,16 @@ class TestWriterClose:
     @pytest.mark.asyncio
     async def test_close_rewraps_finalize_failure(self) -> None:
         writer = _StubWriter()
-        with patch.object(
-            writer,
-            "_finalize",
-            new_callable=AsyncMock,
-            side_effect=RuntimeError("flush fail"),
+        with (
+            patch.object(
+                writer,
+                "_finalize",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("flush fail"),
+            ),
+            pytest.raises(Exception) as excinfo,
         ):
-            with pytest.raises(Exception) as excinfo:
-                await writer.close()
+            await writer.close()
         assert "Error closing writer" in str(excinfo.value)
 
     @pytest.mark.asyncio

--- a/tests/unit/storage/formats/writers/test_json_writer.py
+++ b/tests/unit/storage/formats/writers/test_json_writer.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import patch
 
 import pandas as pd
@@ -28,7 +28,7 @@ def base_output_path(tmp_path_factory: pytest.TempPathFactory) -> str:
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 @given(config=json_output_config_strategy)
 @pytest.mark.asyncio
-async def test_init(base_output_path: str, config: Dict[str, Any]) -> None:
+async def test_init(base_output_path: str, config: dict[str, Any]) -> None:
     # Create a safe output path by joining base_output_path with config's output_path
     safe_path = str(Path(base_output_path) / config["output_path"])
     json_output = JsonFileWriter(  # type: ignore
@@ -128,8 +128,10 @@ async def test_write_error(base_output_path: str) -> None:
         total_record_count=0,
         chunk_start=None,
     )
+    from application_sdk.errors import InvalidInputError
+
     invalid_df = "not_a_dataframe"
-    with pytest.raises(TypeError, match="Unsupported data type: str"):
+    with pytest.raises(InvalidInputError, match="Unsupported data type: str"):
         await json_output.write(invalid_df)  # type: ignore
     # Verify counts remain unchanged after error
     assert json_output.chunk_count == 0

--- a/tests/unit/storage/formats/writers/test_parquet_writer.py
+++ b/tests/unit/storage/formats/writers/test_parquet_writer.py
@@ -208,6 +208,9 @@ class TestParquetFileWriterWriteDataframe:
             patch(
                 "application_sdk.storage.formats.parquet._upload_file"
             ) as mock_upload,
+            patch(
+                "application_sdk.storage.formats._upload_file", new_callable=AsyncMock
+            ),
             patch("pyarrow.parquet.write_table") as mock_write_table,
         ):
             mock_upload.return_value = AsyncMock()
@@ -771,7 +774,9 @@ class TestParquetFileWriterConsolidation:
         parquet_output = ParquetFileWriter(path=base_output_path)
 
         # Should raise error when no temp folder path is set
-        with pytest.raises(ValueError, match="No temp folder path available"):
+        from application_sdk.errors.leaves import InternalError
+
+        with pytest.raises(InternalError, match="No temp folder path available"):
             await parquet_output._write_chunk_to_temp_folder(sample_dataframe)
 
     @pytest.mark.asyncio

--- a/tests/unit/storage/test_reference.py
+++ b/tests/unit/storage/test_reference.py
@@ -134,10 +134,12 @@ class TestPersistFileReference:
         assert a_side.decode().strip() == _hash_bytes(b"a")
 
     async def test_retained_tier_requires_run_prefix(self, store, tmp_path) -> None:
+        from application_sdk.errors import InvalidInputError
+
         f = tmp_path / "data.bin"
         f.write_bytes(b"x")
         ref = FileReference(local_path=str(f), tier=StorageTier.RETAINED)
-        with pytest.raises(ValueError):
+        with pytest.raises(InvalidInputError):
             await persist_file_reference(store, ref)
 
     async def test_retained_tier_with_output_path(self, store, tmp_path) -> None:

--- a/tests/unit/storage/test_transfer.py
+++ b/tests/unit/storage/test_transfer.py
@@ -183,9 +183,11 @@ class TestUploadStorageSubdir:
     async def test_storage_subdir_path_traversal_rejected(
         self, store, tmp_path
     ) -> None:
+        from application_sdk.errors import InvalidInputError
+
         f = tmp_path / "data.txt"
         f.write_bytes(b"x")
-        with pytest.raises(ValueError, match="path traversal"):
+        with pytest.raises(InvalidInputError, match="path traversal"):
             await upload(
                 str(f), store=store, _app_prefix="run/123", storage_subdir="../../etc"
             )
@@ -196,44 +198,58 @@ class TestUploadSensitivePathBlocking:
 
     @pytest.mark.skipif(_IS_WINDOWS, reason="Unix-only sensitive paths")
     async def test_etc_blocked(self, store) -> None:
-        with pytest.raises(ValueError, match="sensitive system path"):
+        from application_sdk.errors import InvalidInputError
+
+        with pytest.raises(InvalidInputError, match="sensitive system path"):
             await upload("/etc/passwd", store=store)
 
     @pytest.mark.skipif(_IS_WINDOWS, reason="Unix-only sensitive paths")
     async def test_proc_blocked(self, store) -> None:
-        with pytest.raises(ValueError, match="sensitive system path"):
+        from application_sdk.errors import InvalidInputError
+
+        with pytest.raises(InvalidInputError, match="sensitive system path"):
             await upload("/proc/self/environ", store=store)
 
     async def test_aws_dir_blocked(self, store, tmp_path) -> None:
+        from application_sdk.errors import InvalidInputError
+
         aws_dir = tmp_path / ".aws"
         aws_dir.mkdir()
         creds = aws_dir / "credentials"
         creds.write_bytes(b"secret")
-        with pytest.raises(ValueError, match="sensitive directory"):
+        with pytest.raises(InvalidInputError, match="sensitive directory"):
             await upload(str(creds), store=store)
 
     async def test_ssh_dir_blocked(self, store, tmp_path) -> None:
+        from application_sdk.errors import InvalidInputError
+
         ssh_dir = tmp_path / ".ssh"
         ssh_dir.mkdir()
         key = ssh_dir / "id_rsa"
         key.write_bytes(b"private-key")
-        with pytest.raises(ValueError, match="sensitive directory"):
+        with pytest.raises(InvalidInputError, match="sensitive directory"):
             await upload(str(key), store=store)
 
     async def test_env_file_blocked(self, store, tmp_path) -> None:
+        from application_sdk.errors import InvalidInputError
+
         env_file = tmp_path / ".env"
         env_file.write_bytes(b"SECRET=value")
-        with pytest.raises(ValueError, match="sensitive file"):
+        with pytest.raises(InvalidInputError, match="sensitive file"):
             await upload(str(env_file), store=store)
 
     async def test_env_local_file_blocked(self, store, tmp_path) -> None:
+        from application_sdk.errors import InvalidInputError
+
         env_file = tmp_path / ".env.local"
         env_file.write_bytes(b"SECRET=value")
-        with pytest.raises(ValueError, match="sensitive file"):
+        with pytest.raises(InvalidInputError, match="sensitive file"):
             await upload(str(env_file), store=store)
 
     async def test_path_traversal_blocked(self, store, tmp_path) -> None:
-        with pytest.raises(ValueError, match="Path traversal"):
+        from application_sdk.errors import InvalidInputError
+
+        with pytest.raises(InvalidInputError, match="Path traversal"):
             await upload(str(tmp_path / ".." / "etc" / "passwd"), store=store)
 
     async def test_normal_path_allowed(self, store, tmp_path) -> None:
@@ -262,7 +278,9 @@ class TestUploadSensitivePathBlocking:
         monkeypatch.setenv(
             "ATLAN_UPLOAD_FILE_BLOCKED_PATHS", "custom_secrets,.credentials"
         )
-        with pytest.raises(ValueError, match="ATLAN_UPLOAD_FILE_BLOCKED_PATHS"):
+        from application_sdk.errors import InvalidInputError
+
+        with pytest.raises(InvalidInputError, match="ATLAN_UPLOAD_FILE_BLOCKED_PATHS"):
             await upload(str(secret), store=store)
 
 

--- a/tests/unit/templates/test_incremental_sql_metadata_extractor.py
+++ b/tests/unit/templates/test_incremental_sql_metadata_extractor.py
@@ -11,6 +11,7 @@ import pytest
 from application_sdk.app.task import is_task, task
 from application_sdk.contracts.base import Input, Output
 from application_sdk.contracts.types import ConnectionAttributes, ConnectionRef
+from application_sdk.errors import InvalidInputError, UnimplementedError
 from application_sdk.templates.contracts.incremental_sql import (
     ExecuteColumnBatchInput,
     ExecuteColumnBatchOutput,
@@ -202,23 +203,23 @@ class TestFetchColumnsSkip:
         assert result.chunk_count == 0
 
     def test_raises_not_implemented_when_full_extraction(self) -> None:
-        """fetch_columns must raise NotImplementedError on full extraction."""
+        """fetch_columns must raise UnimplementedError on full extraction."""
         extractor = self._make_extractor()
         inp = FetchColumnsIncrementalInput(
             marker_timestamp="",
             current_state_available=False,
         )
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(UnimplementedError):
             asyncio.run(extractor.fetch_columns(inp))
 
     def test_raises_not_implemented_when_marker_but_no_state(self) -> None:
-        """fetch_columns must raise NotImplementedError if state not available."""
+        """fetch_columns must raise UnimplementedError if state not available."""
         extractor = self._make_extractor()
         inp = FetchColumnsIncrementalInput(
             marker_timestamp="2025-01-01T00:00:00Z",
             current_state_available=False,
         )
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(UnimplementedError):
             asyncio.run(extractor.fetch_columns(inp))
 
 
@@ -477,7 +478,7 @@ class TestExecuteSingleColumnBatchInlineImports:
 
     async def test_raises_when_output_path_missing(self) -> None:
         extractor = _make_extractor()
-        with pytest.raises(ValueError, match="output_path"):
+        with pytest.raises(InvalidInputError, match="output_path"):
             await extractor.execute_single_column_batch(
                 ExecuteColumnBatchInput(output_path="", batch_index=0, total_batches=1)
             )
@@ -490,7 +491,7 @@ class TestExecuteSingleColumnBatchInlineImports:
         batch_file = batches_dir / "batch-0.json"
         batch_file.write_text('["t1", "t2", "t3"]', encoding="utf-8")
 
-        async def fake_execute_column_sql(self, sql, inp, ctx):  # noqa: ARG001
+        async def fake_execute_column_sql(self, sql, inp, ctx):
             return 42
 
         # bind execute_column_sql at instance level
@@ -568,7 +569,7 @@ class TestExecuteSingleColumnBatchInlineImports:
                 "application_sdk.storage.ops.download_file",
                 new=AsyncMock(return_value=None),
             ),
-            pytest.raises(NotImplementedError, match="execute_column_sql"),
+            pytest.raises(UnimplementedError, match="execute_column_sql"),
         ):
             await extractor.execute_single_column_batch(
                 ExecuteColumnBatchInput(

--- a/tests/unit/templates/test_sql_app.py
+++ b/tests/unit/templates/test_sql_app.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from application_sdk.credentials.ref import CredentialRef
+from application_sdk.errors import UnimplementedError
 from application_sdk.templates.contracts.sql_metadata import (
     ExtractionInput,
     ExtractionTaskInput,
@@ -287,31 +288,31 @@ class TestTransformTasks:
 
 
 class TestAssetMapperStubs:
-    """Asset mapper stubs raise NotImplementedError on base SqlApp."""
+    """Asset mapper stubs raise UnimplementedError on base SqlApp."""
 
     def test_base_map_database_raises(self):
         base = SqlApp()
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(UnimplementedError):
             base.map_database({}, "conn/qn")
 
     def test_base_map_schema_raises(self):
         base = SqlApp()
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(UnimplementedError):
             base.map_schema({}, "conn/qn")
 
     def test_base_map_table_raises(self):
         base = SqlApp()
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(UnimplementedError):
             base.map_table({}, "conn/qn")
 
     def test_base_map_column_raises(self):
         base = SqlApp()
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(UnimplementedError):
             base.map_column({}, "conn/qn")
 
     def test_base_map_procedure_raises(self):
         base = SqlApp()
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(UnimplementedError):
             base.map_procedure({}, "conn/qn")
 
     def test_subclass_mappers_work(self, app):

--- a/tests/unit/templates/test_sql_metadata_extractor.py
+++ b/tests/unit/templates/test_sql_metadata_extractor.py
@@ -12,6 +12,11 @@ import application_sdk.templates.sql_metadata_extractor as mod
 from application_sdk.app.base import App
 from application_sdk.app.task import get_task_metadata, is_task
 from application_sdk.contracts.base import Output, PublishInputMixin
+from application_sdk.errors import (
+    InvalidInputError,
+    PreconditionError,
+    UnimplementedError,
+)
 from application_sdk.templates.contracts.sql_metadata import (
     ExtractionInput,
     ExtractionOutput,
@@ -103,7 +108,7 @@ class TestFetchProceduresTask:
 
     async def test_fetch_procedures_raises_not_implemented(self) -> None:
         extractor = SqlMetadataExtractor.__new__(SqlMetadataExtractor)
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(UnimplementedError):
             await extractor.fetch_procedures(FetchProceduresInput())
 
     def test_fetch_procedures_input_has_no_workflow_args(self) -> None:
@@ -224,7 +229,7 @@ class TestSqlMetadataExtractorSubclass:
 
     async def test_fetch_databases_raises_not_implemented_by_default(self) -> None:
         extractor = SqlMetadataExtractor.__new__(SqlMetadataExtractor)
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(UnimplementedError):
             await extractor.fetch_databases(FetchDatabasesInput())
 
 
@@ -361,7 +366,7 @@ class TestSqlMetadataExtractorLoadSqlClient:
 
     async def test_load_sql_client_raises_when_class_not_set(self) -> None:
         extractor = SqlMetadataExtractor.__new__(SqlMetadataExtractor)
-        with pytest.raises(NotImplementedError, match="sql_client_class"):
+        with pytest.raises(UnimplementedError, match="sql_client_class"):
             await extractor._load_sql_client(ExtractionTaskInput())
 
     async def test_load_sql_client_instantiates_and_loads(self) -> None:
@@ -677,7 +682,7 @@ class TestGetCredentials:
         monkeypatch.setattr(mod, "get_infrastructure", lambda: None)
         extractor = SqlMetadataExtractor.__new__(SqlMetadataExtractor)
         with pytest.raises(
-            ValueError, match="No credential reference or GUID available"
+            InvalidInputError, match="No credential reference or GUID available"
         ):
             await extractor._get_credentials(ExtractionTaskInput())
 
@@ -686,7 +691,7 @@ class TestGetCredentials:
     ) -> None:
         monkeypatch.setattr(mod, "get_infrastructure", lambda: None)
         extractor = SqlMetadataExtractor.__new__(SqlMetadataExtractor)
-        with pytest.raises(ValueError, match="No secret store available"):
+        with pytest.raises(PreconditionError, match="No secret store available"):
             await extractor._get_credentials(
                 ExtractionTaskInput(credential_guid="some-guid-that-needs-a-store")
             )
@@ -899,7 +904,7 @@ class TestFetchTablesHappyPath:
         )
 
         extractor = SqlMetadataExtractor.__new__(SqlMetadataExtractor)
-        with pytest.raises(NotImplementedError, match="fetch_table_sql"):
+        with pytest.raises(UnimplementedError, match="fetch_table_sql"):
             await extractor.fetch_tables(FetchTablesInput())
 
     async def test_fetch_schemas_raises_when_sql_not_set(self) -> None:
@@ -909,7 +914,7 @@ class TestFetchTablesHappyPath:
         )
 
         extractor = SqlMetadataExtractor.__new__(SqlMetadataExtractor)
-        with pytest.raises(NotImplementedError, match="fetch_schema_sql"):
+        with pytest.raises(UnimplementedError, match="fetch_schema_sql"):
             await extractor.fetch_schemas(FetchSchemasInput())
 
     async def test_fetch_columns_raises_when_sql_not_set(self) -> None:
@@ -919,7 +924,7 @@ class TestFetchTablesHappyPath:
         )
 
         extractor = SqlMetadataExtractor.__new__(SqlMetadataExtractor)
-        with pytest.raises(NotImplementedError, match="fetch_column_sql"):
+        with pytest.raises(UnimplementedError, match="fetch_column_sql"):
             await extractor.fetch_columns(FetchColumnsInput())
 
 

--- a/tests/unit/templates/test_sql_query_extractor.py
+++ b/tests/unit/templates/test_sql_query_extractor.py
@@ -6,6 +6,7 @@ import pytest
 
 from application_sdk.app.base import App
 from application_sdk.app.task import is_task
+from application_sdk.errors import UnimplementedError
 from application_sdk.templates.contracts.sql_query import (
     QueryBatchInput,
     QueryBatchOutput,
@@ -86,11 +87,11 @@ class TestSqlQueryExtractorSubclass:
     ) -> None:
         extractor = SqlQueryExtractor.__new__(SqlQueryExtractor)
         with pytest.raises(
-            NotImplementedError, match="must implement get_query_batches"
+            UnimplementedError, match="must implement get_query_batches"
         ):
             await extractor.get_query_batches(QueryBatchInput())
 
     async def test_fetch_queries_raises_not_implemented_by_default(self) -> None:
         extractor = SqlQueryExtractor.__new__(SqlQueryExtractor)
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(UnimplementedError):
             await extractor.fetch_queries(QueryFetchInput())

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from application_sdk.errors import InvalidInputError, PreconditionError
 from application_sdk.main import (
     AppConfig,
     _create_infrastructure,
@@ -157,7 +158,7 @@ class TestAppConfigFromArgsAndEnv:
         monkeypatch.delenv("ATLAN_APP_MODULE", raising=False)
         monkeypatch.setenv("ATLAN_APP_MODE", "worker")
         args = self._make_args(mode="worker")
-        with pytest.raises(ValueError, match="App module is required"):
+        with pytest.raises(InvalidInputError, match="App module is required"):
             AppConfig.from_args_and_env(args)
 
     def test_app_module_parsed_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -335,7 +336,7 @@ class TestRunMain:
 
     def test_unknown_mode_raises_value_error(self) -> None:
         config = AppConfig(mode="invalid", app_module="pkg:App")
-        with pytest.raises(ValueError, match="Unknown mode"):
+        with pytest.raises(InvalidInputError, match="Unknown mode"):
             run_main(config)
 
     def test_worker_mode_calls_asyncio_run(self) -> None:
@@ -593,7 +594,7 @@ class TestAppConfigCommaRejection:
             log_level=None,
             service_name=None,
         )
-        with pytest.raises(ValueError, match="comma"):
+        with pytest.raises(InvalidInputError, match="comma"):
             AppConfig.from_args_and_env(args)
 
     def test_post_init_derives_task_queue(self) -> None:
@@ -615,7 +616,7 @@ class TestCreateInfrastructureNoDapr:
     ) -> None:
         """Without DAPR_HTTP_PORT, _create_infrastructure must raise RuntimeError."""
         monkeypatch.delenv("DAPR_HTTP_PORT", raising=False)
-        with pytest.raises(RuntimeError, match="Dapr sidecar not detected"):
+        with pytest.raises(PreconditionError, match="Dapr sidecar not detected"):
             await _create_infrastructure()
 
 

--- a/tests/unit/test_parse_atlan_yaml.py
+++ b/tests/unit/test_parse_atlan_yaml.py
@@ -257,3 +257,89 @@ def test_invalid_yaml_rejected(tmp_path, monkeypatch):
     (tmp_path / "atlan.yaml").write_text("name: x\n  bad: : indent\n  - unclosed")
     with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
+
+
+# ── deploy.env_overrides validation ─────────────────────────────────────────
+#
+# GM resolves ``env_overrides`` at catalog-read time (global-marketplace's
+# core/release/config_resolver.py) and is intentionally lenient — a typo'd
+# channel name silently no-ops. CI is the only place that catches it, so
+# these tests pin the rules.
+
+
+def _with_overrides(overrides):
+    return {
+        "name": "x",
+        "app_id": "1",
+        "deploy": {
+            "env": {"OTEL_ENVIRONMENT": "production"},
+            "env_overrides": overrides,
+        },
+    }
+
+
+def test_env_overrides_with_valid_channels_accepted(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(
+        tmp_path,
+        _with_overrides({"beta": {"OTEL_ENVIRONMENT": "beta"}, "staging": {"X": "y"}}),
+    )
+    out = parse_atlan_yaml.parse()
+    assert "env_overrides" in out["deploy_config"]
+
+
+def test_env_overrides_unknown_channel_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    # Common typo — 'staing' instead of 'staging'.
+    _write(tmp_path, _with_overrides({"staing": {"OTEL_ENVIRONMENT": "staging"}}))
+    with pytest.raises(AtlanYamlError, match="unknown channel"):
+        parse_atlan_yaml.parse()
+
+
+def test_env_overrides_all_channel_rejected(tmp_path, monkeypatch):
+    # 'all' is GA — base config IS the GA config — an entry here would
+    # never take effect at runtime, so fail fast.
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, _with_overrides({"all": {"OTEL_ENVIRONMENT": "production"}}))
+    with pytest.raises(AtlanYamlError, match="unknown channel"):
+        parse_atlan_yaml.parse()
+
+
+def test_env_overrides_specific_channel_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, _with_overrides({"specific": {"X": "y"}}))
+    with pytest.raises(AtlanYamlError, match="unknown channel"):
+        parse_atlan_yaml.parse()
+
+
+def test_env_overrides_not_a_mapping_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, _with_overrides(["beta", "staging"]))
+    with pytest.raises(AtlanYamlError, match="env_overrides must be a mapping"):
+        parse_atlan_yaml.parse()
+
+
+def test_env_overrides_channel_value_not_a_mapping_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, _with_overrides({"beta": "not-a-mapping"}))
+    with pytest.raises(AtlanYamlError, match="env_overrides.beta must be a mapping"):
+        parse_atlan_yaml.parse()
+
+
+def test_env_overrides_absent_is_fine(tmp_path, monkeypatch):
+    # Backwards compat: apps without env_overrides parse cleanly.
+    monkeypatch.chdir(tmp_path)
+    _write(
+        tmp_path,
+        {"name": "x", "app_id": "1", "deploy": {"env": {"X": "y"}}},
+    )
+    out = parse_atlan_yaml.parse()
+    assert "env_overrides" not in out["deploy_config"]
+
+
+def test_env_overrides_with_no_deploy_block_is_fine(tmp_path, monkeypatch):
+    # No deploy block at all — _validate_env_overrides is a no-op.
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, {"name": "x", "app_id": "1"})
+    out = parse_atlan_yaml.parse()
+    assert out["deploy_config"] == ""

--- a/tests/unit/testing/integration/test_comparison.py
+++ b/tests/unit/testing/integration/test_comparison.py
@@ -6,6 +6,7 @@ import tempfile
 
 import pytest
 
+from application_sdk.errors import DataIntegrityError
 from application_sdk.testing.integration.comparison import (
     AssetDiff,
     GapReport,
@@ -366,12 +367,12 @@ class TestLoadExpectedData:
             load_expected_data("/nonexistent/path.json")
 
     def test_invalid_json_structure(self):
-        """Non-dict JSON raises ValueError."""
+        """Non-dict JSON raises DataIntegrityError."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump([1, 2, 3], f)
             f.flush()
 
-        with pytest.raises(ValueError, match="JSON object"):
+        with pytest.raises(DataIntegrityError, match="JSON object"):
             load_expected_data(f.name)
 
         os.unlink(f.name)
@@ -391,8 +392,7 @@ class TestLoadActualOutput:
                 {"typeName": "Table", "attributes": {"name": "users"}},
             ]
             with open(os.path.join(workflow_dir, "table.json"), "wb") as f:
-                for r in records:
-                    f.write(json.dumps(r).encode() + b"\n")
+                f.writelines(json.dumps(r).encode() + b"\n" for r in records)
 
             result = load_actual_output(tmpdir, "wf1", "run1")
             assert len(result) == 2

--- a/tests/unit/transformers/atlas/test_function.py
+++ b/tests/unit/transformers/atlas/test_function.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 from pyatlan.model.assets import Function
@@ -14,13 +14,13 @@ def resources_dir() -> str:
 
 
 @pytest.fixture
-def raw_data(resources_dir: str) -> Dict[str, Any]:
+def raw_data(resources_dir: str) -> dict[str, Any]:
     with open(os.path.join(resources_dir, "raw_functions.json")) as f:
         return json.load(f)
 
 
 @pytest.fixture
-def expected_data(resources_dir: str) -> Dict[str, Any]:
+def expected_data(resources_dir: str) -> dict[str, Any]:
     with open(os.path.join(resources_dir, "transformed_functions.json")) as f:
         return json.load(f)
 
@@ -31,8 +31,8 @@ def transformer() -> AtlasTransformer:
 
 
 def assert_attributes(
-    transformed_data: Dict[str, Any],
-    expected_data: Dict[str, Any],
+    transformed_data: dict[str, Any],
+    expected_data: dict[str, Any],
     attributes: list[str],
     is_custom: bool = False,
 ) -> None:
@@ -180,7 +180,7 @@ def test_function_get_attributes_malformed_argument_signature_raises(
     """
     from application_sdk.transformers.atlas.sql import Function as SqlFunction
 
-    obj: Dict[str, Any] = {
+    obj: dict[str, Any] = {
         "function_name": "test_function",
         "argument_signature": bad_signature,
         "function_definition": "SELECT 1",
@@ -193,7 +193,9 @@ def test_function_get_attributes_malformed_argument_signature_raises(
         "data_type": "NUMBER",
     }
 
-    with pytest.raises(ValueError, match="Malformed argument_signature"):
+    from application_sdk.errors import DataIntegrityError
+
+    with pytest.raises(DataIntegrityError, match="Malformed argument_signature"):
         SqlFunction.get_attributes(obj)
 
 
@@ -202,7 +204,7 @@ def test_function_get_attributes_well_formed_signature_succeeds():
     after the BLDX-1170 paren-validation guard."""
     from application_sdk.transformers.atlas.sql import Function as SqlFunction
 
-    obj: Dict[str, Any] = {
+    obj: dict[str, Any] = {
         "function_name": "test_function",
         "argument_signature": "(arg1 type1)",
         "function_definition": "SELECT 1",

--- a/tests/unit/transformers/atlas/test_sql_extra.py
+++ b/tests/unit/transformers/atlas/test_sql_extra.py
@@ -16,10 +16,11 @@ class methods. No threads, no asyncio, no HTTP, no file I/O.
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
+from application_sdk.transformers.atlas._atlas_errors import EntityTransformError
 from application_sdk.transformers.atlas.sql import (
     Column,
     Database,
@@ -39,7 +40,7 @@ CONN = "default/snowflake/1728518400"
 
 
 def test_procedure_missing_field_raises_value_error():
-    with pytest.raises(ValueError, match="Procedure name"):
+    with pytest.raises(EntityTransformError, match="Procedure name"):
         Procedure.get_attributes({})
 
 
@@ -64,7 +65,7 @@ def test_procedure_uses_default_sub_type_when_procedure_type_absent():
 
 
 def test_database_non_string_name_raises():
-    with pytest.raises(ValueError, match="Database name"):
+    with pytest.raises(EntityTransformError, match="Database name"):
         Database.get_attributes(
             {"database_name": 123, "connection_qualified_name": CONN}
         )
@@ -99,7 +100,7 @@ def test_schema_managed_access_and_catalog_id_populated():
 
 
 def test_schema_missing_required_raises():
-    with pytest.raises(ValueError, match="Schema name"):
+    with pytest.raises(EntityTransformError, match="Schema name"):
         Schema.get_attributes({"connection_qualified_name": CONN})
 
 
@@ -108,7 +109,7 @@ def test_schema_missing_required_raises():
 # ---------------------------------------------------------------------------
 
 
-def _table_base() -> Dict[str, Any]:
+def _table_base() -> dict[str, Any]:
     return {
         "table_name": "T",
         "table_schema": "S",
@@ -217,7 +218,7 @@ def test_table_collects_optional_custom_attributes():
 
 
 def test_table_missing_required_field_raises():
-    with pytest.raises(ValueError, match="Table name"):
+    with pytest.raises(EntityTransformError, match="Table name"):
         Table.get_attributes({})
 
 
@@ -226,7 +227,7 @@ def test_table_missing_required_field_raises():
 # ---------------------------------------------------------------------------
 
 
-def _column_base() -> Dict[str, Any]:
+def _column_base() -> dict[str, Any]:
     return {
         "column_name": "C",
         "table_catalog": "DB",
@@ -239,7 +240,7 @@ def _column_base() -> Dict[str, Any]:
 
 
 def test_column_missing_required_raises():
-    with pytest.raises(ValueError, match="Column name"):
+    with pytest.raises(EntityTransformError, match="Column name"):
         Column.get_attributes({})
 
 
@@ -329,7 +330,7 @@ def test_column_primary_foreign_nullable_partition_flags():
 # ---------------------------------------------------------------------------
 
 
-def _function_base() -> Dict[str, Any]:
+def _function_base() -> dict[str, Any]:
     return {
         "function_name": "FN",
         "argument_signature": "(a INT, b INT)",
@@ -344,7 +345,7 @@ def _function_base() -> Dict[str, Any]:
 
 
 def test_function_missing_required_raises():
-    with pytest.raises(ValueError, match="Function name"):
+    with pytest.raises(EntityTransformError, match="Function name"):
         Function.get_attributes({})
 
 
@@ -403,7 +404,7 @@ def test_function_creator_with_explicit_connection_qualified_name():
 # ---------------------------------------------------------------------------
 
 
-def _tag_base() -> Dict[str, Any]:
+def _tag_base() -> dict[str, Any]:
     return {
         "tag_name": "PII",
         "tag_database": "TAGDB",
@@ -415,7 +416,9 @@ def _tag_base() -> Dict[str, Any]:
 
 
 def test_tag_attachment_missing_field_caught_by_broad_except_returns_value_error():
-    with pytest.raises(ValueError, match="Error creating TagAttachment Entity"):
+    with pytest.raises(
+        EntityTransformError, match="Error creating TagAttachment Entity"
+    ):
         TagAttachment.get_attributes({})
 
 
@@ -557,9 +560,11 @@ def test_bug_tag_attachment_swallows_non_assertion_errors():
 
 
 def test_bug_function_argument_signature_without_parens_corrupts_arguments():
+    from application_sdk.errors import DataIntegrityError
+
     obj = _function_base()
     obj["argument_signature"] = "AB"
-    # Fix raises ValueError on malformed input rather than silently
+    # Fix raises DataIntegrityError on malformed input rather than silently
     # producing a one-char field "B".
-    with pytest.raises(ValueError, match="Malformed argument_signature"):
+    with pytest.raises(DataIntegrityError, match="Malformed argument_signature"):
         Function.get_attributes(obj)

--- a/tests/unit/transformers/query/test_sql_transformer.py
+++ b/tests/unit/transformers/query/test_sql_transformer.py
@@ -15,6 +15,7 @@ except BaseException as _daft_err:
         allow_module_level=True,
     )
 
+from application_sdk.errors import InvalidInputError
 from application_sdk.transformers.common.utils import flatten_yaml_columns
 from application_sdk.transformers.query import QueryBasedTransformer
 
@@ -165,20 +166,24 @@ def test_build_struct(sql_transformer):
 
 
 def test_build_struct_with_none_level(sql_transformer):
-    """Test the _build_struct method raises ValueError when level is None"""
-    with pytest.raises(ValueError, match="level cannot be None in _build_struct"):
+    """Test the _build_struct method raises InvalidInputError when level is None"""
+    with pytest.raises(
+        InvalidInputError, match="level cannot be None in _build_struct"
+    ):
         sql_transformer._build_struct(level=None, prefix="test")
 
 
 def test_build_struct_with_none_prefix(sql_transformer):
-    """Test the _build_struct method raises ValueError when prefix is None"""
+    """Test the _build_struct method raises InvalidInputError when prefix is None"""
     level = {
         "columns": [
             ("attributes.name", "name"),
             ("attributes.qualifiedName", "qualifiedName"),
         ],
     }
-    with pytest.raises(ValueError, match="prefix cannot be None in _build_struct"):
+    with pytest.raises(
+        InvalidInputError, match="prefix cannot be None in _build_struct"
+    ):
         sql_transformer._build_struct(level=level, prefix=None)
 
 


### PR DESCRIPTION
## Summary

- Converts ~188 raise sites from `ValueError`/`RuntimeError`/`Exception`/`NotImplementedError` and legacy `AtlanError` subclasses (`ClientError`, `CommonError`, `WorkflowError`, `ActivityError`, `IOError`) to typed `AppError` leaves with structured wire envelopes (`category`, `code`, `audience`, `retryable`, `evidence`)
- Introduces 5 new sibling error modules for grouped subclasses: `_context_errors`, `_redis_errors`, `_azure/_azure_errors`, `storage/formats/_format_errors`, `transformers/atlas/_atlas_errors`
- Updates all affected unit tests (4122 passing)

## Modules changed

| Group | Files | Leaves used |
|---|---|---|
| Execution | `activity_utils`, `auth`, `backend`, `worker`, `lock_activities`, `interceptors/lock` | `PreconditionError`, `AuthError`, `InvalidInputError`, `DependencyUnavailableError` |
| Clients | `redis`, `azure/auth`, `azure/client`, `_interface`, `base` | `RedisConnectionError`, `AzureAuthError`, `AzureConnectionError`, etc. |
| App/handler | `app/context`, `app/base`, `handler/context`, `handler/service` | `NoStateStoreError`, `NoSecretStoreError`, `NoObjectStoreError` |
| Storage | `transfer`, `ops`, `reference`, `formats/*` | `InvalidInputError`, `PreconditionError`, `ClosedWriterError`, `ClosedReaderError` |
| Templates | `sql_app`, `sql_metadata_extractor`, `incremental_sql_metadata_extractor`, `sql_query_extractor` | `UnimplementedError`, `PreconditionError`, `InvalidInputError` |
| Transformers | `atlas/sql`, `query/__init__` | `EntityTransformError`, `DataIntegrityError`, `InvalidInputError` |
| Observability | `pushgateway`, `logger_adaptor` | `InvalidInputError`, `InternalError` |
| Common/credentials | `aws_utils`, `sql_filters`, `path`, `utils`, `credentials/*`, `contracts/*` | `InvalidInputError`, `DataIntegrityError`, `AppPermissionDeniedError` |
| Testing infra | `integration/models`, `comparison`, `validation`, `client`, `lazy`, `scale_data_generator` | `InvalidInputError`, `DataIntegrityError` |

## Test plan

- [x] `uv run python -m pytest tests/unit -q` — 4122 passed, 8 skipped
- [x] `uv run pre-commit run --all-files` — all checks passed