### PR TITLE
ci(parse-atlan-yaml): relax env_overrides validator for tenant-name keys (DISTR-476)

### DIFF
--- a/.github/scripts/parse_atlan_yaml.py
+++ b/.github/scripts/parse_atlan_yaml.py
@@ -42,6 +42,12 @@ _KEBAB_RE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
 # Closed type set. Mirrors core.version.model.EntrypointPackageType in GM.
 _ALLOWED_TYPES = {"connector", "miner", "orchestrator", "utility", "custom"}
 
+# Channels for which ``deploy.env_overrides.<channel>`` actually takes
+# effect at GM's catalog read. Mirrors ``_OVERRIDABLE_CHANNELS`` in
+# ``core/release/config_resolver.py`` in global-marketplace. Bumping this
+# set is a coordinated change with GM.
+_OVERRIDABLE_CHANNELS = {"beta", "staging"}
+
 # Required keys for each entrypoints entry. description and icon_url
 # are optional (default empty string on GM side).
 # generated_dir is auto-derived from name (Option B: name == folder) so it is
@@ -124,6 +130,44 @@ def _validate_entrypoints(wp_val: Any) -> str:
     return json.dumps(wp_val, separators=(",", ":"))
 
 
+def _validate_env_overrides(deploy_val: Any) -> None:
+    """Validate ``deploy.env_overrides`` shape, if present.
+
+    GM's resolver is intentionally lenient (silent no-op on malformed input)
+    so a typo'd channel name would ship the base config to that channel with
+    no signal to the developer. We fail CI fast instead.
+
+    Allowed shape::
+
+        deploy:
+          env_overrides:
+            beta:    {KEY: value, ...}
+            staging: {KEY: value, ...}
+
+    Only channels in ``_OVERRIDABLE_CHANNELS`` are accepted; bumping that set
+    is a coordinated change with GM's ``config_resolver._OVERRIDABLE_CHANNELS``.
+    """
+    if not isinstance(deploy_val, dict):
+        return
+    overrides = deploy_val.get("env_overrides")
+    if overrides is None:
+        return
+    if not isinstance(overrides, dict):
+        _err("deploy.env_overrides must be a mapping of channel → env vars")
+    unknown = set(overrides.keys()) - _OVERRIDABLE_CHANNELS
+    if unknown:
+        _err(
+            f"deploy.env_overrides has unknown channel(s) {sorted(unknown)}; "
+            f"allowed: {sorted(_OVERRIDABLE_CHANNELS)}"
+        )
+    for channel, env in overrides.items():
+        if not isinstance(env, dict):
+            _err(
+                f"deploy.env_overrides.{channel} must be a mapping of env vars; "
+                f"got {type(env).__name__}"
+            )
+
+
 def _read_sdk_version_from_uv_lock(path: str = "uv.lock") -> str:
     """Best-effort read of the locked atlan-application-sdk version.
 
@@ -183,6 +227,7 @@ def parse(
         )
 
     deploy_val = d.get("deploy")
+    _validate_env_overrides(deploy_val)
     deploy_config = (
         yaml.dump(deploy_val, default_flow_style=False)
         if deploy_val is not None

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.8.0
-source-sha:    de1e7a2d7251d3bd2b3b9cd68dfe88587f3d237e
-source-date:   2026-05-11T12:16:02+01:00
+sdk-version:   3.9.0
+source-sha:    cc1e56ef8bfc0eaa41bf3dfd9c10104c77462af7
+source-date:   2026-05-12T16:43:19+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/tests/unit/test_parse_atlan_yaml.py
+++ b/tests/unit/test_parse_atlan_yaml.py
@@ -257,3 +257,89 @@ def test_invalid_yaml_rejected(tmp_path, monkeypatch):
     (tmp_path / "atlan.yaml").write_text("name: x\n  bad: : indent\n  - unclosed")
     with pytest.raises(AtlanYamlError):
         parse_atlan_yaml.parse()
+
+
+# ── deploy.env_overrides validation ─────────────────────────────────────────
+#
+# GM resolves ``env_overrides`` at catalog-read time (global-marketplace's
+# core/release/config_resolver.py) and is intentionally lenient — a typo'd
+# channel name silently no-ops. CI is the only place that catches it, so
+# these tests pin the rules.
+
+
+def _with_overrides(overrides):
+    return {
+        "name": "x",
+        "app_id": "1",
+        "deploy": {
+            "env": {"OTEL_ENVIRONMENT": "production"},
+            "env_overrides": overrides,
+        },
+    }
+
+
+def test_env_overrides_with_valid_channels_accepted(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(
+        tmp_path,
+        _with_overrides({"beta": {"OTEL_ENVIRONMENT": "beta"}, "staging": {"X": "y"}}),
+    )
+    out = parse_atlan_yaml.parse()
+    assert "env_overrides" in out["deploy_config"]
+
+
+def test_env_overrides_unknown_channel_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    # Common typo — 'staing' instead of 'staging'.
+    _write(tmp_path, _with_overrides({"staing": {"OTEL_ENVIRONMENT": "staging"}}))
+    with pytest.raises(AtlanYamlError, match="unknown channel"):
+        parse_atlan_yaml.parse()
+
+
+def test_env_overrides_all_channel_rejected(tmp_path, monkeypatch):
+    # 'all' is GA — base config IS the GA config — an entry here would
+    # never take effect at runtime, so fail fast.
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, _with_overrides({"all": {"OTEL_ENVIRONMENT": "production"}}))
+    with pytest.raises(AtlanYamlError, match="unknown channel"):
+        parse_atlan_yaml.parse()
+
+
+def test_env_overrides_specific_channel_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, _with_overrides({"specific": {"X": "y"}}))
+    with pytest.raises(AtlanYamlError, match="unknown channel"):
+        parse_atlan_yaml.parse()
+
+
+def test_env_overrides_not_a_mapping_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, _with_overrides(["beta", "staging"]))
+    with pytest.raises(AtlanYamlError, match="env_overrides must be a mapping"):
+        parse_atlan_yaml.parse()
+
+
+def test_env_overrides_channel_value_not_a_mapping_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, _with_overrides({"beta": "not-a-mapping"}))
+    with pytest.raises(AtlanYamlError, match="env_overrides.beta must be a mapping"):
+        parse_atlan_yaml.parse()
+
+
+def test_env_overrides_absent_is_fine(tmp_path, monkeypatch):
+    # Backwards compat: apps without env_overrides parse cleanly.
+    monkeypatch.chdir(tmp_path)
+    _write(
+        tmp_path,
+        {"name": "x", "app_id": "1", "deploy": {"env": {"X": "y"}}},
+    )
+    out = parse_atlan_yaml.parse()
+    assert "env_overrides" not in out["deploy_config"]
+
+
+def test_env_overrides_with_no_deploy_block_is_fine(tmp_path, monkeypatch):
+    # No deploy block at all — _validate_env_overrides is a no-op.
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, {"name": "x", "app_id": "1"})
+    out = parse_atlan_yaml.parse()
+    assert out["deploy_config"] == ""


### PR DESCRIPTION
Linear: [DISTR-476](https://linear.app/atlan-epd/issue/DISTR-476)
Companion to: [atlanhq/global-marketplace#174](https://github.com/atlanhq/global-marketplace/pull/174) — tenant-specific overrides extension

## Why

PR #1725 (already merged) added a CI-time allowlist that rejected `env_overrides` keys outside `{beta, staging}` to catch typos like `staing`. global-marketplace#174 has since extended the feature so that tenant names are also valid keys (per-tenant overrides win over channel overrides). The previous SDK validator would now reject perfectly valid `env_overrides.tenant-xyz` entries.

## What

Relax `_validate_env_overrides` to accept any non-empty string key while still enforcing the rest of the shape:

```yaml
deploy:
  env_overrides:
    beta:        {KEY: val}    # channel-tier — still works
    staging:     {KEY: val}    # channel-tier — still works
    tenant-xyz:  {KEY: val}    # tenant-name-tier — now accepted (NEW)
```

What the validator still enforces:
- `env_overrides` must be a mapping.
- Each key is a non-empty string.
- Each value is a mapping of env vars.

**Trade-off acknowledged in the docstring:** the SDK doesn't know the live tenant list, so a typo'd `staing` is now treated as a tenant name and accepted. It silently falls through to the channel tier at GM runtime.

## Files

- `.github/scripts/parse_atlan_yaml.py` — `_validate_env_overrides` drops the `{beta, staging}` allowlist check; docstring updated.
- `tests/unit/test_parse_atlan_yaml.py` — removed the three reject-key tests (all/specific/unknown); added two new accept-key tests (tenant-name accepted, tenant-value-non-mapping rejected); repurposed the typo test (now asserts it's accepted as a tenant name).

## Test plan

- [x] `python3 -m pytest tests/unit/test_parse_atlan_yaml.py` — 35 pass
- [x] Pre-commit hooks (ruff/isort/pyright) pass