### PR TITLE
feat(skills): extend audit-consumers with tool.uv.sources version detection and triage

### DIFF
--- a/.claude/skills/audit-consumers/SKILL.md
+++ b/.claude/skills/audit-consumers/SKILL.md
@@ -162,64 +162,134 @@ compatible major versions using the following rules:
 | `>=2.8.0` (no upper bound)      | `{2, 3, 4, …}` — treat as current major and later; always includes `target_major` |
 | git tag `v3.7.0`                | `{3}` |
 | git branch `release/v2`         | `{2}` |
-| git branch `main`               | `{target_major}` — tip-of-default-branch tracks current major |
+| git branch `main`               | `{target_major}` — tip of main tracks current major |
+| git branch (any other name, incl. `master`, `develop`) | unknown — skip analysis; see `[tool.uv.sources]` dict rules below |
 | path editable `../application-sdk` | `{target_major}` — local dev, assume current major |
-| missing / unparseable           | unknown — fall through to analysis; status becomes `analyzed-pin-unknown` |
+| missing / unparseable (string pin) | unknown — fall through to analysis; status becomes `analyzed-pin-unknown` |
+
+When the pin comes from a `[tool.uv.sources]` TOML dict (see Phase B Step 1), apply these
+additional rules (evaluated before the string-form rules above):
+
+| `[tool.uv.sources]` entry | Compatible majors | Coverage display string |
+|---|---|---|
+| `{git, tag = "vN.M.P"}`                                       | `{N}`      | `tag vN.M.P` |
+| `{git, branch = "release/vN"}`                                | `{N}`      | `branch release/vN` |
+| `{git, branch = "main"}`                                      | `{target}` | `branch main` |
+| `{git, branch = <any other>}` (incl. `master`, `develop`, feature branches) | `None` | `branch <name>` |
+| `{git, rev = "<hash>"}`                                       | `None`     | `rev <hash[:8]>` |
+| `{path = "...", editable = true}` or `{path = "..."}`         | `{target}` | `editable <path>` |
+| anything else                                                  | `None`     | the raw repr |
+
+When `compatible_majors()` returns `None` for a dict-form pin, record status
+`skipped-pin-source-unknown` and **stop** — do not analyze the repo. This is distinct from
+string-form `None` (which falls through to `analyzed-pin-unknown` with conservative analysis)
+because a rev hash or non-standard branch makes it impossible to know which SDK code the
+consumer is actually running against.
 
 Implementation pseudocode (inline, not stored as a separate file):
 
 ```python
 import re
 
-def compatible_majors(pin: str, target: int):
-    """Return set of compatible majors, or None if unparseable."""
-    pin = pin.strip()
-    # Editable / path install
+def compatible_majors(pin, target: int):
+    """Return (set_of_compatible_majors_or_None, display_str).
+
+    `pin` is one of:
+      • str  — a PEP 440 specifier, branch name, git tag string, or path string
+      • dict — a parsed [tool.uv.sources] entry, e.g.
+               {"git": "...", "branch": "release/v2"}
+               {"git": "...", "rev":    "91e9c4a9..."}
+               {"git": "...", "tag":    "v3.7.0"}
+               {"path": "../application-sdk", "editable": True}
+
+    Returns:
+      (set_or_None, display_str)
+      • set  — compatible major versions
+      • None — major undetermined (behaviour depends on pin type: str → analyze
+                conservatively; dict → skip; see Phase B Step 1 gate table)
+    """
+    # --- Dict form: [tool.uv.sources] entry ---
+    if isinstance(pin, dict):
+        tag    = pin.get("tag")
+        branch = pin.get("branch")
+        rev    = pin.get("rev")
+        path   = pin.get("path")
+
+        if tag:
+            m = re.match(r"v(\d+)\.", str(tag))
+            if m:
+                n = int(m.group(1))
+                return {n}, f"tag {tag}"
+            return None, f"tag {tag}"
+
+        if branch:
+            if branch == "main":
+                return {target}, f"branch {branch}"
+            m = re.match(r"release/v(\d+)", branch)
+            if m:
+                n = int(m.group(1))
+                return {n}, f"branch {branch}"
+            # Any other branch (master, develop, feature/…) — unknown major
+            return None, f"branch {branch}"
+
+        if rev:
+            short = str(rev)[:8]
+            return None, f"rev {short}"
+
+        if path:
+            return {target}, f"editable {path}"
+
+        return None, repr(pin)
+
+    # --- String form: [project].dependencies / requirements.txt ---
+    pin = str(pin).strip()
+    display = pin
+
     if pin.startswith(("../", "./", "/")):
-        return {target}
-    # Default-branch markers
-    if pin in ("main", "master", "develop"):
-        return {target}
-    # Branch: release/vN
+        return {target}, display
+    if pin == "main":
+        return {target}, display
+    # release/vN branch
     m = re.match(r"release/v(\d+)", pin)
     if m:
-        return {int(m.group(1))}
+        return {int(m.group(1))}, display
     # Git tag: vN.M.P
     m = re.match(r"v(\d+)\.", pin)
     if m:
-        return {int(m.group(1))}
-    # Commit hash — unknown which branch
+        return {int(m.group(1))}, display
+    # Commit hash marker — unknown major
     if pin.startswith("rev:"):
-        return None
-    # Extract operator and lower-bound major
+        return None, display
+    # PEP 440 specifier
     first = pin.split(",")[0].strip()
     op_m = re.match(r"^([=!<>~^]+)", first)
     operator = op_m.group(1) if op_m else ""
     first_clean = re.sub(r"^[=!<>~^]+", "", first).strip()
     m = re.match(r"(\d+)", first_clean)
     if not m:
-        return None
+        return None, display
     lower = int(m.group(1))
-    # Exact pin: == means exactly this major
     if operator == "==":
-        return {lower}
-    # Upper bound: <N means up to (not including) major N
-    # If upper bound has the same major as lower (e.g. >=3.6.1,<3.7.0),
-    # it's a minor/patch constraint — still only major lower.
+        return {lower}, display
     ub = re.search(r",\s*<\s*(\d+)", pin)
     if ub:
         upper = int(ub.group(1))
         if upper > lower:
-            return set(range(lower, upper))
+            return set(range(lower, upper)), display
         else:
-            return {lower}   # same-major minor/patch constraint
-    # No upper bound — includes lower through target and beyond
-    return set(range(lower, target + 1))
+            return {lower}, display   # same-major minor/patch constraint
+    return set(range(lower, target + 1)), display
 ```
 
-If `compatible_majors()` returns `None`, proceed with analysis and record status
-`analyzed-pin-unknown`. If it returns a set that does **not** contain `target_major`,
-record status `skipped-major-mismatch` and stop processing that repo.
+Gate decisions after calling `compatible_majors(pin, target_major)`:
+
+| Result | Pin source | Action |
+|---|---|---|
+| Set contains `target_major` | either | Proceed to Step 2 |
+| Set is non-empty, excludes `target_major` | either | Status `skipped-major-mismatch` — stop |
+| `None` | dict (`[tool.uv.sources]` rev or unknown branch) | Status `skipped-pin-source-unknown` — stop |
+| `None` | str (`[project].dependencies` / `requirements.txt`) | Status `analyzed-pin-unknown` — proceed conservatively |
+| API call failed | — | Status `analyzed-error` — stop |
 
 ---
 
@@ -287,26 +357,96 @@ For each candidate repo in `/tmp/audit-repos.txt`:
 
 ### Step 1 — Read SDK pin and apply major-version gate
 
-```bash
-gh api repos/atlanhq/<repo>/contents/pyproject.toml --jq '.content' | base64 -d \
-  | grep -A2 'application.sdk\|application-sdk'
-# fall back to requirements.txt if pyproject.toml is absent:
-gh api repos/atlanhq/<repo>/contents/requirements.txt --jq '.content' | base64 -d \
-  | grep 'application.sdk\|application-sdk'
+Fetch `pyproject.toml` first; fall back to `requirements.txt` if absent. Parse in two
+stages using the Python helper that is already running in this phase:
+
+```python
+import base64, re, subprocess
+
+# --- Fetch pyproject.toml ---
+raw = subprocess.run(
+    ["gh", "api", f"repos/atlanhq/{repo}/contents/pyproject.toml",
+     "--jq", ".content"],
+    capture_output=True, text=True,
+)
+text = base64.b64decode(raw.stdout.strip()).decode() if raw.returncode == 0 else ""
+
+# --- Stage 1: [tool.uv.sources] (authoritative when present) ---
+uv_source = None
+src_block = re.search(
+    r"\[tool\.uv\.sources\](.+?)(?:\n\[|\Z)", text, flags=re.DOTALL,
+)
+if src_block:
+    for line in src_block.group(1).splitlines():
+        line = line.split("#", 1)[0].strip()   # drop comments; skip blanks
+        if not line:
+            continue
+        m = re.match(
+            r'(?:atlan[-_]application[-_]sdk|application[-_]sdk)\s*=\s*\{(.+)\}',
+            line, flags=re.IGNORECASE,
+        )
+        if m:
+            uv_source = {}
+            for kv in re.finditer(
+                r'(\w+)\s*=\s*(?:"([^"]*)"|(true|false))', m.group(1)
+            ):
+                uv_source[kv.group(1)] = (
+                    kv.group(2) if kv.group(2) is not None
+                    else (kv.group(3) == "true")
+                )
+            break   # first uncommented match wins; ignore commented alternatives
+
+# --- Stage 2: [project].dependencies or requirements.txt (fallback) ---
+project_pin = None
+if uv_source is None and text:
+    # look for the SDK dep inside the [project] or [project.dependencies] block
+    m = re.search(
+        r'["\']atlan[-_]application[-_]sdk[^"\']*["\']', text, re.IGNORECASE
+    )
+    if m:
+        # extract the version specifier portion, e.g. ">=3.0.0,<4.0.0"
+        ver = re.search(r'((?:[><=!~^,\s\d\.\*]+)+)', m.group().split("[")[0].split('"')[-1])
+        project_pin = ver.group(1).strip() if ver else None
+
+if uv_source is None and project_pin is None and not text:
+    # Try requirements.txt
+    req = subprocess.run(
+        ["gh", "api", f"repos/atlanhq/{repo}/contents/requirements.txt",
+         "--jq", ".content"],
+        capture_output=True, text=True,
+    )
+    if req.returncode == 0:
+        req_text = base64.b64decode(req.stdout.strip()).decode()
+        m = re.search(r'atlan[-_]application[-_]sdk([^\n]*)', req_text, re.IGNORECASE)
+        project_pin = m.group(1).strip() if m else None
+
+pin = uv_source if uv_source is not None else project_pin
+majors, pin_display = compatible_majors(pin, target_major)
 ```
 
-Record the raw pin string for the coverage table. Then call `compatible_majors(pin,
-target_major)` (see Phase 0b pseudocode):
+**Key rules for the two-stage parse:**
+- `[tool.uv.sources]` overrides `[project].dependencies` — when an entry for the SDK is
+  found in the sources table, use it exclusively. The deps entry typically carries no
+  version specifier when a source override is present.
+- Match the SDK package under either `atlan-application-sdk` or `application-sdk`
+  (case-insensitive, hyphen or underscore).
+- Commented-out lines (common for keeping an editable-path fallback around) are stripped
+  before matching — only the active, uncommented source is used.
+- `pin_display` (from `compatible_majors`) is what goes in the Coverage table's SDK pin
+  column. For dict-form pins it is a short human-readable string (`tag v3.7.0`,
+  `branch release/v2`, `rev 91e9c4a9`, `editable ../application-sdk`); for string-form
+  pins it is the verbatim pin string.
 
-- **Pin parses + target_major NOT in compatible set** → status `skipped-major-mismatch`.
-  Record in coverage table with the pin string and compatible majors set. **Stop — do not
-  run anchor check or fetch any files.**
-- **Pin unparseable / missing** → proceed with analysis; final status will be
-  `analyzed-pin-unknown`.
-- **Pin parses + target_major in compatible set** → proceed to Step 2.
+Apply the gate decisions from Phase 0b after calling `compatible_majors`:
 
-If the `gh api` call for both pin files fails → record status `analyzed-error` with the
-error. Never silently drop.
+- **Set contains `target_major`** → proceed to Step 2.
+- **Set is non-empty but excludes `target_major`** → status `skipped-major-mismatch`.
+  Record `pin_display` and the compatible-majors set. **Stop.**
+- **`None` + dict-form pin** → status `skipped-pin-source-unknown`. Record `pin_display`
+  and `?` for compatible majors. **Stop.**
+- **`None` + string-form pin** → status `analyzed-pin-unknown`. Proceed conservatively.
+- **Both API calls fail** → status `analyzed-error` with the error message. Never
+  silently drop.
 
 ### Step 2 — Anchor check (cheap, via GitHub API)
 
@@ -344,19 +484,89 @@ For each check in the spec, against each fetched file:
 rg -nP '<pattern>' /tmp/audit-file.py
 ```
 
-Record every hit as `(file_path, line_number, matched_line, check_id)`. For hits where
-`require_anchor: false`, run the patterns against all Python files in the repo, not just
+Record every hit as an extended record (implemented in the same Python helper that parses `rg` output — read the file once, slice around each match):
+
+```
+(file_path, line_number, matched_line, check_id,
+ context_before,      # 3 source lines preceding the match
+ context_after,       # 3 source lines following the match
+ enclosing_symbol,    # nearest def/class header above the match, if any
+ try_body_excerpt)    # for `except …` patterns: the lines between `try:` and the matched
+                      # `except` (best-effort); empty string otherwise
+```
+
+For hits where `require_anchor: false`, run the patterns against all Python files in the repo, not just
 anchored ones (requires a clone or a separate `gh search code` call per pattern).
+
+### Step 4b — Triage each finding
+
+For each captured hit, assign a `triage` field and a one-line `triage_reason`:
+
+| Value | Meaning |
+|---|---|
+| `confirmed`      | The hit represents real exposure to the SDK change being audited. |
+| `false_positive` | The pattern matched, but the code is not exposed to the SDK change (see heuristics). |
+| `needs_review`   | Insufficient signal in the captured context — flag for human review. |
+
+#### Default heuristics (conservative — when in doubt, return `needs_review`)
+
+**For `except <SpecificException>` patterns (definite-break checks):**
+- `false_positive` if `try_body_excerpt` contains none of the spec's anchor patterns AND
+  contains at least one of: `urllib`, `urlparse`, `os.path`, `int(`, `float(`,
+  `json.loads`, `CredentialRef`, `re.compile`, `datetime.`, `uuid.`, `Decimal(`,
+  `pathlib.`, `yaml.safe_load`, `Enum(`. These are standard sources of
+  `ValueError`/`KeyError` unrelated to the SDK.
+- `confirmed` if `try_body_excerpt` contains an anchor pattern (e.g. the class/symbol
+  named in the spec) or a method call on a variable typed as the SDK class.
+- `needs_review` otherwise.
+
+**For literal message-string patterns (silent-break checks):**
+- `false_positive` if the match is inside a `"""..."""` docstring, a `#` comment, or a
+  regex literal assigned to a variable whose surrounding code does not invoke `str(e)`,
+  `e.args[0]`, `.message`, `re.search`, `re.match`, or string `in` against an exception.
+- `confirmed` otherwise — message-string inspection rarely produces FPs.
+
+**For broad-catch patterns (review checks):**
+- `false_positive` if `try_body_excerpt` contains only the consumer's own `raise <X>(...)`
+  statement (catching to add context to a self-raise, not to inspect an SDK error).
+- `confirmed` if `try_body_excerpt` calls an SDK anchor method.
+- `needs_review` otherwise — broad catches are intrinsically ambiguous.
+
+#### Spec-supplied heuristics (optional override)
+
+A check spec MAY include a `triage:` block for project-specific FP signals. Spec heuristics
+are evaluated **before** the defaults; defaults only fire when the spec rules are silent.
+
+```markdown
+### check: R1 — Narrow catch of old exception types
+…
+- triage:
+    false_positive_if_try_body_contains:
+      - `urllib\.parse`
+      - `CredentialRef\.resolve`
+    confirmed_if_try_body_contains:
+      - `\.run_query\s*\(`
+      - `\.load\s*\(`
+```
+
+#### Surfacing the triage outcome
+
+- Per-repo findings (Phase C) MUST list every hit, annotated inline:
+  `[confirmed]`, `[false_positive — <reason>]`, or `[needs_review — <reason>]`.
+- `false_positive` hits do NOT count toward the action summary or the executive-summary
+  "Repos needing action" metric — but they are still listed so reviewers can challenge
+  a triage call without re-running the audit.
 
 ### Step 5 — Classify status
 
 | Status | Condition |
 |---|---|
 | `analyzed-no-usage` | major-match; no anchor match anywhere in the repo |
-| `analyzed-no-findings` | major-match; anchor present, zero check hits |
-| `analyzed-has-findings` | major-match; at least one check hit |
+| `analyzed-no-findings` | major-match; anchor present, zero check hits — OR all hits classified `false_positive` (note `(N hits, all FPs)` in the coverage table) |
+| `analyzed-has-findings` | major-match; at least one `confirmed` or `needs_review` check hit after Step 4b triage |
 | `skipped-major-mismatch` | pin parsed; compatible majors do not include `target_major` |
-| `analyzed-pin-unknown` | pin missing or unparseable; analyzed conservatively |
+| `skipped-pin-source-unknown` | `[tool.uv.sources]` pins to a rev hash or non-`release/vN`/non-`main` branch; major undetermined — skip analysis, record the rev/branch verbatim |
+| `analyzed-pin-unknown` | string-form pin missing or unparseable; analyzed conservatively |
 | `analyzed-error` | GitHub API call failed (log the error) |
 
 ---
@@ -381,15 +591,22 @@ Write the report to the path specified by `--report` (or the default slug-based 
 |---|---|
 | Candidate repos discovered | N |
 | Skipped (major mismatch — not on v`<target_major>`) | N |
+| Skipped (uv source pin — major undetermined) | N |
 | Pin unknown (analyzed conservatively) | N |
 | Repos with anchor-matched files | N |
-| Repos with findings | N |
-| <check_id> hits (<impact>) | N across M repos |
+| Repos needing action (after FP exclusion) | N |
+| False-positive hits filtered out | N across M repos |
+| <check_id> confirmed hits (<impact>) | N across M repos |
 | … | … |
 
-<2–3 sentence narrative: what matters, what's safe, what needs action. Include a note like:
-"Skipped N repos pinned to other majors — those will be re-audited when they migrate to
-v<target_major>.">
+<2–3 sentence narrative: what matters, what's safe, what needs action. Note the FP filter
+ratio if non-trivial (e.g. ">50% of R1 hits were false positives — narrow `except ValueError`
+on non-SDK code such as URL parsing"). Include a note like: "Skipped N repos pinned to other
+majors — those will be re-audited when they migrate to v<target_major>." When the "uv source
+pin — major undetermined" count is non-zero, note: "N repos pinned via `[tool.uv.sources]`
+to a specific rev or non-`release/vX` branch — major version cannot be derived without
+checking out the pinned ref, so they are listed in Coverage with their rev/branch and
+excluded from analysis.">
 
 ---
 
@@ -402,17 +619,46 @@ v<target_major>.">
 ## Coverage — every repo we looked at
 
 Every candidate repo from Phase A is listed here regardless of outcome. Repos are sorted
-alphabetically. `analyzed-error` rows include the error so follow-up is possible. The
-"Compatible majors" column shows the parsed set from the pin string so the filter decision
-is auditable; `?` means unparseable.
+alphabetically. `analyzed-error` rows include the error so follow-up is possible.
+
+**Column notes:**
+- **SDK pin** — for `[project].dependencies` / `requirements.txt` entries, the verbatim
+  version specifier (e.g. `>=3.0.0,<4.0.0`). For `[tool.uv.sources]` entries, the
+  `pin_display` string from `compatible_majors()` (e.g. `tag v3.7.0`, `branch release/v2`,
+  `rev 91e9c4a9`, `editable ../application-sdk`). This lets a reviewer re-derive the major
+  decision without re-fetching the file.
+- **Compatible majors** — the set derived from the pin. `?` means major undetermined
+  (`skipped-pin-source-unknown` or `analyzed-pin-unknown`).
 
 | Repo | SDK pin | Compatible majors | Status |
 |---|---|---|---|
-| atlanhq/<repo-a> | `>=3.0.0,<4.0.0` | {3} | analyzed-has-findings |
-| atlanhq/<repo-b> | `2.7.4`          | {2} | skipped-major-mismatch |
-| atlanhq/<repo-c> | (none)           | ?   | analyzed-pin-unknown |
-| atlanhq/<repo-d> | `3.0.0a1`        | {3} | analyzed-no-usage |
-| atlanhq/<repo-e> | —                | —   | analyzed-error: 403 from gh api |
+| atlanhq/<repo-a> | `>=3.0.0,<4.0.0`  | {3} | analyzed-has-findings |
+| atlanhq/<repo-b> | `2.7.4`           | {2} | skipped-major-mismatch |
+| atlanhq/<repo-c> | `branch release/v2` | {2} | skipped-major-mismatch |
+| atlanhq/<repo-d> | `rev 91e9c4a9`    | ?   | skipped-pin-source-unknown |
+| atlanhq/<repo-e> | `tag v3.7.0`      | {3} | analyzed-no-usage |
+| atlanhq/<repo-f> | (none)            | ?   | analyzed-pin-unknown |
+| atlanhq/<repo-g> | —                 | —   | analyzed-error: 403 from gh api |
+
+---
+
+## Action summary — repos that need a migration PR
+
+Only repos with at least one `confirmed` or `needs_review` finding appear here.
+False-positive-only repos are excluded (see Coverage table for full traceability).
+Sorted by priority descending, then by repo name.
+
+| Repo | SDK pin | Definite breaks | Silent breaks | Review items | Needs review | Fix sites | Priority | Recommended action |
+|---|---|---|---|---|---|---|---|---|
+| atlanhq/<repo-a> | `>=3.0.0,<4.0.0` | 3 | 1 | 0 | 0 | `clients/foo.py:42`, `clients/foo.py:108`, `handlers/bar.py:17` (+1 more) | P0 | Catch `AuthError` instead of `ClientError`; replace `SQL_CLIENT_AUTH_ERROR` string match with `isinstance(e, SqlClientAuthFailedError)`. |
+| atlanhq/<repo-b> | `>=3.5.0,<4`     | 0 | 0 | 2 | 1 | `app/init.py:88`, `app/init.py:140`, `tests/test_conn.py:24` | P2 | Review broad `except Exception` blocks near SDK calls; confirm whether they re-raise legacy types. |
+
+**Column definitions:**
+- **Definite breaks / Silent breaks / Review items** — count of `confirmed` findings at each impact level.
+- **Needs review** — count of `needs_review` findings (any impact level).
+- **Fix sites** — file:line list, capped at 6; if more, append `(+N more)`.
+- **Priority** — P0: ≥1 confirmed definite-break. P1: ≥1 confirmed silent-break, 0 definite-breaks. P2: review-only or `needs_review`-only.
+- **Recommended action** — the `recommendation:` lines from each check that produced a confirmed hit, deduplicated and joined with `; `.
 
 ---
 
@@ -426,8 +672,10 @@ is auditable; `?` means unparseable.
 
 #### <check_id> — <check name> (impact: <impact>)
 
-- `<file>:<line>` — `<matched line>`
+- `<file>:<line>` — `<matched line>` [confirmed]
   - Recommendation: <from spec>
+- `<file>:<line>` — `<matched line>` [false_positive — try body calls only urllib.parse.urlparse]
+- `<file>:<line>` — `<matched line>` [needs_review — try body context ambiguous]
 
 ---
 
@@ -442,9 +690,10 @@ with the gap warning. Omit this section if there were no gaps.>
 After writing the report, print to chat:
 
 1. The executive summary table.
-2. The top 3–5 highest-impact hits (definite-break first, then silent-break, then review),
-   with file:line and recommendation inline.
-3. The report file path.
+2. The Action summary table (only confirmed/needs-review repos).
+3. The top 3–5 highest-impact **confirmed** hits (definite-break first, then silent-break,
+   then review), with file:line and recommendation inline.
+4. The report file path.
 
 ---
 
@@ -455,12 +704,14 @@ These steps are offered but NOT run automatically. Invoke them by asking:
 
 ### D1 — Spot-check via GitHub URLs
 
-For each top finding, construct the direct link:
+For each `needs_review` finding, and for a sample of `false_positive` findings (to verify
+the triage logic is correct), construct the direct link:
 ```
 https://github.com/atlanhq/<repo>/blob/<default-branch>/<path>#L<line>
 ```
-Open in browser or present as a list. Lets the reviewer confirm the grep match is not in a
-comment or string literal, and that the `try` body actually calls the SDK method.
+Open in browser or present as a list. Lets the reviewer confirm the triage classification
+is accurate — e.g. that a `false_positive` tagged hit truly does not call an SDK method,
+or that a `needs_review` hit warrants confirmation/dismissal.
 
 ### D2 — Behaviour simulation
 


### PR DESCRIPTION
## Summary

- Parses `[tool.uv.sources]` in `pyproject.toml` as the authoritative SDK pin when present (overrides `[project].dependencies`, which carries no version specifier when a source override exists)
- New dict-form pin rules: `tag vN.M.P` → `{N}`; `branch release/vN` → `{N}`; `branch main` → `{target}`; any other branch or rev hash → `skipped-pin-source-unknown` (do not analyze)
- String-form correction: only `main` maps to `target_major`; `master`/`develop` now treated as unknown major
- New status: `skipped-pin-source-unknown` — uv source pinned to rev hash or non-standard branch
- New executive-summary metric row: _Skipped (uv source pin — major undetermined)_
- Adds triage step (Step 4b): classifies each finding as `confirmed` / `false_positive` / `needs_review` with default heuristics for except-patterns, message-string patterns, and broad catches
- Adds Action summary table to the report template: only repos with confirmed/needs_review findings, with priority (P0/P1/P2), fix-site list, and recommended action per check
- Coverage table SDK pin column now shows a human-readable display string for uv-source entries (`tag v3.7.0`, `branch release/v2`, `rev 91e9c4a9`, `editable ../application-sdk`)

## Test plan

- [ ] Run `/audit-consumers` against a spec; confirm Coverage table shows `skipped-pin-source-unknown` for repos pinned via `[tool.uv.sources]` rev hash or non-main branch
- [ ] Confirm repos with `[tool.uv.sources]` tag (e.g. `tag v3.7.0`) are analyzed normally with correct major derived from tag
- [ ] Confirm `[tool.uv.sources]` `branch release/v2` repos show `skipped-major-mismatch` (not `analyzed-pin-unknown`) when auditing against v3
- [ ] Confirm Action summary table appears in report between Coverage and Per-repo findings sections
- [ ] Confirm false-positive findings are excluded from Action summary and executive-summary "Repos needing action" count