### PR TITLE
refactor(sql-client): replace untyped/legacy raises with typed AppError leaves

### DIFF
--- a/application_sdk/clients/_sql_errors.py
+++ b/application_sdk/clients/_sql_errors.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from application_sdk.errors import (
+    AuthError,
+    InternalError,
+    InvalidInputError,
+    UnimplementedError,
+)
+
+# === Recurring patterns — bake message + evidence ===
+
+
+@dataclass(kw_only=True)
+class SqlDbConfigNotSetError(InternalError):
+    """DB_CONFIG was never set on the subclass — SDK contract violation."""
+
+    code: ClassVar[str] = "INTERNAL_SQL_DB_CONFIG_NOT_SET"
+    message: str = "DB_CONFIG is not configured for this SQL client."
+    component: str | None = "sql_client"
+    invariant: str | None = "db_config_required_for_subclass"
+
+
+@dataclass(kw_only=True)
+class SqlEngineNotInitializedError(InternalError):
+    """`load()` was never called before a method that requires `self.engine`."""
+
+    code: ClassVar[str] = "INTERNAL_SQL_ENGINE_NOT_INITIALIZED"
+    message: str = "Engine is not initialized. Call load() first."
+    component: str | None = "sql_client"
+    invariant: str | None = "load_before_use"
+
+
+@dataclass(kw_only=True)
+class SqlClientAuthFailedError(AuthError):
+    """SQLAlchemy engine creation / credential validation failed."""
+
+    code: ClassVar[str] = "AUTH_SQL_CLIENT_FAILED"
+    message: str = "SQL client authentication failed"
+    auth_method: str | None = "sql"
+    failure_reason: str | None = "engine_load_failed"
+
+
+@dataclass(kw_only=True)
+class SqlMissingCredentialFieldError(InvalidInputError):
+    """A required credential field (username / database / aws_role_arn) is absent."""
+
+    code: ClassVar[str] = "INVALID_INPUT_SQL_MISSING_CREDENTIAL_FIELD"
+    # message= and field= supplied per raise site
+
+
+# === One-off subclasses — bake code (and message where stable) ===
+
+
+@dataclass(kw_only=True)
+class SqlMissingRequiredParamError(InvalidInputError):
+    """A required connection-string parameter is absent from credentials."""
+
+    code: ClassVar[str] = "INVALID_INPUT_SQL_MISSING_REQUIRED_PARAM"
+    # message= and field= supplied per raise site
+
+
+@dataclass(kw_only=True)
+class SqlCursorNotSupportedError(UnimplementedError):
+    """DBAPI cursor has no `.description`; driver capability gap."""
+
+    code: ClassVar[str] = "UNIMPLEMENTED_SQL_CURSOR_TYPE"
+    message: str = "Cursor is not supported"
+    operation: str | None = "sql_run_query"
+    reason: str | None = "dbapi_cursor_unavailable"
+
+
+@dataclass(kw_only=True)
+class SqlEngineTypeError(InternalError):
+    """`self.engine` is a string when an SQLAlchemy engine object was expected."""
+
+    code: ClassVar[str] = "INTERNAL_SQL_ENGINE_NOT_SQLALCHEMY"
+    message: str = "Engine should be an SQLAlchemy engine object"
+    component: str | None = "sql_client"
+    invariant: str | None = "engine_is_sqlalchemy_object"
+
+
+@dataclass(kw_only=True)
+class SqlPandasResultError(InternalError):
+    """`pd.read_sql_query` returned a non-DataFrame value."""
+
+    code: ClassVar[str] = "INTERNAL_SQL_PANDAS_RESULT_NOT_DATAFRAME"
+    message: str = "Unable to get pandas dataframe from SQL query results"
+    component: str | None = "sql_client"
+    invariant: str | None = "pandas_read_sql_returns_dataframe"
+
+
+@dataclass(kw_only=True)
+class SqlInvalidAuthTypeError(InvalidInputError):
+    """`authType` is not one of {basic, iam_user, iam_role}."""
+
+    code: ClassVar[str] = "INVALID_INPUT_SQL_AUTH_TYPE"
+    # message= and field= supplied per raise site
+
+
+# === rewrap replacements (per §5 SQL_QUERY_* family) ===
+
+
+@dataclass(kw_only=True)
+class SqlBatchReadError(InternalError):
+    """Pandas batched read via `get_batched_results` failed."""
+
+    code: ClassVar[str] = "INTERNAL_SQL_PANDAS_BATCH"
+    message: str = "Error reading batched data(pandas) from SQL"
+    component: str | None = "sql_client"
+
+
+@dataclass(kw_only=True)
+class SqlReadError(InternalError):
+    """Pandas single-frame read via `get_results` failed."""
+
+    code: ClassVar[str] = "INTERNAL_SQL_PANDAS"
+    message: str = "Error reading data(pandas) from SQL"
+    component: str | None = "sql_client"
+
+
+@dataclass(kw_only=True)
+class SqlExecuteQueryError(InternalError):
+    """Async query execution inside `AsyncBaseSQLClient.run_query` failed."""
+
+    code: ClassVar[str] = "INTERNAL_SQL_QUERY_EXECUTE"
+    message: str = "Error executing query"
+    component: str | None = "sql_client"

--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -14,16 +14,29 @@ from typing import TYPE_CHECKING, Any, Union, cast
 from urllib.parse import quote_plus
 
 from application_sdk.clients._interface import ClientInterface
+from application_sdk.clients._sql_errors import (
+    SqlBatchReadError,
+    SqlClientAuthFailedError,
+    SqlCursorNotSupportedError,
+    SqlDbConfigNotSetError,
+    SqlEngineNotInitializedError,
+    SqlEngineTypeError,
+    SqlExecuteQueryError,
+    SqlInvalidAuthTypeError,
+    SqlMissingCredentialFieldError,
+    SqlMissingRequiredParamError,
+    SqlPandasResultError,
+    SqlReadError,
+)
 from application_sdk.clients.models import DatabaseConfig
 from application_sdk.clients.sql_typecasters import install_tolerant_text_decoder_hook
 from application_sdk.common.aws_utils import (
     generate_aws_rds_token_with_iam_role,
     generate_aws_rds_token_with_iam_user,
 )
-from application_sdk.common.error_codes import ClientError, CommonError
-from application_sdk.common.exc_utils import rewrap
 from application_sdk.constants import AWS_SESSION_NAME, USE_SERVER_SIDE_CURSOR
 from application_sdk.credentials.utils import parse_credentials_extra
+from application_sdk.errors import AppError
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -86,10 +99,11 @@ class BaseSQLClient(ClientInterface):
             credentials (Dict[str, Any]): Database connection credentials.
 
         Raises:
-            ClientError: If credentials are invalid or engine creation fails
+            SqlDbConfigNotSetError: If DB_CONFIG is not configured on the subclass.
+            SqlClientAuthFailedError: If credentials are invalid or engine creation fails.
         """
         if not self.DB_CONFIG:
-            raise ValueError("DB_CONFIG is not configured for this SQL client.")
+            raise SqlDbConfigNotSetError()
 
         self.credentials = credentials  # Update the instance credentials
         try:
@@ -127,12 +141,12 @@ class BaseSQLClient(ClientInterface):
             # Don't store persistent connection
             self.connection = None
 
-        except Exception as e:
+        except Exception as exc:
             logger.error("Error loading SQL client", exc_info=True)
             if self.engine:
                 self.engine.dispose()
                 self.engine = None
-            raise ClientError(f"{ClientError.SQL_CLIENT_AUTH_ERROR}: {e!s}") from e
+            raise SqlClientAuthFailedError(cause=exc) from exc
 
     async def close(self) -> None:
         """Close the database connection."""
@@ -152,7 +166,7 @@ class BaseSQLClient(ClientInterface):
             str: A temporary authentication token for database access.
 
         Raises:
-            CommonError: If required credentials (username or database) are missing.
+            SqlMissingCredentialFieldError: If required credentials (username or database) are missing.
         """
         extra = parse_credentials_extra(self.credentials)
         aws_access_key_id = self.credentials.get("username")
@@ -161,12 +175,14 @@ class BaseSQLClient(ClientInterface):
         user = extra.get("username")
         database = extra.get("database")
         if not user:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: username is required for IAM user authentication"
+            raise SqlMissingCredentialFieldError(
+                message="username is required for IAM user authentication",
+                field="username",
             )
         if not database:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: database is required for IAM user authentication"
+            raise SqlMissingCredentialFieldError(
+                message="database is required for IAM user authentication",
+                field="database",
             )
 
         port = self.credentials.get("port")
@@ -193,7 +209,7 @@ class BaseSQLClient(ClientInterface):
             str: A temporary authentication token for database access.
 
         Raises:
-            CommonError: If required credentials (aws_role_arn or database) are missing.
+            SqlMissingCredentialFieldError: If required credentials (aws_role_arn or database) are missing.
         """
         extra = parse_credentials_extra(self.credentials)
         aws_role_arn = extra.get("aws_role_arn")
@@ -201,12 +217,14 @@ class BaseSQLClient(ClientInterface):
         external_id = extra.get("aws_external_id")
 
         if not aws_role_arn:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: aws_role_arn is required for IAM role authentication"
+            raise SqlMissingCredentialFieldError(
+                message="aws_role_arn is required for IAM role authentication",
+                field="aws_role_arn",
             )
         if not database:
-            raise CommonError(
-                f"{CommonError.CREDENTIALS_PARSE_ERROR}: database is required for IAM role authentication"
+            raise SqlMissingCredentialFieldError(
+                message="database is required for IAM role authentication",
+                field="database",
             )
 
         session_name = AWS_SESSION_NAME
@@ -237,7 +255,7 @@ class BaseSQLClient(ClientInterface):
             str: URL-encoded authentication token.
 
         Raises:
-            CommonError: If an invalid authentication type is specified.
+            SqlInvalidAuthTypeError: If an unsupported authentication type is specified.
         """
         authType = self.credentials.get("authType", "basic")  # Default to basic auth
         token = None
@@ -250,7 +268,10 @@ class BaseSQLClient(ClientInterface):
             case "basic":
                 token = self.credentials.get("password")
             case _:
-                raise CommonError(f"{CommonError.CREDENTIALS_PARSE_ERROR}: {authType}")
+                raise SqlInvalidAuthTypeError(
+                    message=f"Unsupported authType: {authType}",
+                    field="authType",
+                )
 
         # Handle None values and ensure token is a string before encoding
         encoded_token = quote_plus(str(token or ""))
@@ -289,10 +310,11 @@ class BaseSQLClient(ClientInterface):
             str: Complete SQLAlchemy connection string.
 
         Raises:
-            ValueError: If required connection parameters are missing.
+            SqlDbConfigNotSetError: If DB_CONFIG is not configured on the subclass.
+            SqlMissingRequiredParamError: If a required connection parameter is missing.
         """
         if not self.DB_CONFIG:
-            raise ValueError("DB_CONFIG is not configured for this SQL client.")
+            raise SqlDbConfigNotSetError()
 
         extra = parse_credentials_extra(self.credentials)
 
@@ -306,7 +328,10 @@ class BaseSQLClient(ClientInterface):
             else:
                 value = self.credentials.get(param) or extra.get(param)
                 if value is None:
-                    raise ValueError(f"{param} is required")
+                    raise SqlMissingRequiredParamError(
+                        message=f"{param} is required",
+                        field=param,
+                    )
                 param_values[param] = value
 
         # Fill in base template
@@ -345,11 +370,11 @@ class BaseSQLClient(ClientInterface):
                 a dictionary mapping column names to values.
 
         Raises:
-            ValueError: If engine is not initialized.
-            Exception: If query execution fails.
+            SqlEngineNotInitializedError: If engine is not initialized.
+            SqlCursorNotSupportedError: If the DBAPI cursor is not usable.
         """
         if not self.engine:
-            raise ValueError("Engine is not initialized. Call load() first.")
+            raise SqlEngineNotInitializedError()
 
         loop = asyncio.get_running_loop()
         logger.debug(
@@ -370,7 +395,7 @@ class BaseSQLClient(ClientInterface):
                     pool, connection.execute, text(query)
                 )
                 if not cursor or not cursor.cursor:
-                    raise ValueError("Cursor is not supported")
+                    raise SqlCursorNotSupportedError()
                 column_names: list[str] = [
                     description.name.lower()
                     for description in cursor.cursor.description
@@ -444,7 +469,7 @@ class BaseSQLClient(ClientInterface):
         # Guard must come before the daft import: daft's Rust OTel extension can
         # raise BaseException at import time, which would prevent this check from running.
         if not self.engine:
-            raise ValueError("Engine is not initialized. Call load() first.")
+            raise SqlEngineNotInitializedError()
 
         # Daft uses ConnectorX to read data from SQL by default for supported connectors
         # If a connection string is passed, it will use ConnectorX to read data
@@ -465,7 +490,7 @@ class BaseSQLClient(ClientInterface):
                 or iterator of DataFrames if chunked.
         """
         if not self.engine:
-            raise ValueError("Engine is not initialized. Call load() first.")
+            raise SqlEngineNotInitializedError()
 
         with self.engine.connect() as conn:
             return self._execute_pandas_query(conn, query, chunksize)
@@ -475,7 +500,7 @@ class BaseSQLClient(ClientInterface):
     ) -> Union["pd.DataFrame", Iterator["pd.DataFrame"]]:
         """Helper to execute async read operation with either async session or thread executor."""
         if isinstance(self.engine, str):
-            raise ValueError("Engine should be an SQLAlchemy engine object")
+            raise SqlEngineTypeError()
 
         from sqlalchemy.ext.asyncio import (  # noqa: PLC0415 — optional dep: sqlalchemy
             AsyncEngine,
@@ -514,15 +539,17 @@ class BaseSQLClient(ClientInterface):
             AsyncIterator["pd.DataFrame"]: Async iterator yielding batches of query results.
 
         Raises:
-            ValueError: If engine is a string instead of SQLAlchemy engine.
-            Exception: If there's an error executing the query.
+            SqlEngineTypeError: If engine is a string instead of SQLAlchemy engine.
+            SqlBatchReadError: If there's an error executing the query.
         """
         try:
             # We cast to Iterator because passing chunk_size guarantees an Iterator return
             result = await self._execute_async_read_operation(query, self.chunk_size)
             return cast(Iterator["pd.DataFrame"], result)
-        except Exception as e:
-            raise rewrap(e, "Error reading batched data(pandas) from SQL") from e
+        except Exception as exc:
+            if isinstance(exc, AppError):
+                raise
+            raise SqlBatchReadError(cause=exc) from exc
 
     async def get_results(self, query: str) -> "pd.DataFrame":
         """Get all query results as a single pandas DataFrame asynchronously.
@@ -531,8 +558,8 @@ class BaseSQLClient(ClientInterface):
             pd.DataFrame: Query results as a DataFrame.
 
         Raises:
-            ValueError: If engine is a string instead of SQLAlchemy engine.
-            Exception: If there's an error executing the query.
+            SqlEngineTypeError: If engine is a string instead of SQLAlchemy engine.
+            SqlReadError: If there's an error executing the query.
         """
         try:
             result = await self._execute_async_read_operation(query, None)
@@ -540,10 +567,12 @@ class BaseSQLClient(ClientInterface):
 
             if isinstance(result, pd.DataFrame):
                 return result
-            raise Exception("Unable to get pandas dataframe from SQL query results")
+            raise SqlPandasResultError()
 
-        except Exception as e:
-            raise rewrap(e, "Error reading data(pandas) from SQL") from e
+        except Exception as exc:
+            if isinstance(exc, AppError):
+                raise
+            raise SqlReadError(cause=exc) from exc
 
 
 class AsyncBaseSQLClient(BaseSQLClient):
@@ -574,11 +603,12 @@ class AsyncBaseSQLClient(BaseSQLClient):
                 host, port, username, password, and other connection parameters.
 
         Raises:
-            ValueError: If credentials are invalid or engine creation fails.
+            SqlDbConfigNotSetError: If DB_CONFIG is not configured on the subclass.
+            SqlClientAuthFailedError: If credentials are invalid or engine creation fails.
         """
         self.credentials = credentials
         if not self.DB_CONFIG:
-            raise ValueError("DB_CONFIG is not configured for this SQL client.")
+            raise SqlDbConfigNotSetError()
 
         try:
             from sqlalchemy.ext.asyncio import (  # noqa: PLC0415 — optional dep: sqlalchemy
@@ -603,12 +633,12 @@ class AsyncBaseSQLClient(BaseSQLClient):
             # Don't store persistent connection
             self.connection = None
 
-        except Exception as e:
+        except Exception as exc:
             logger.error("Error establishing database connection", exc_info=True)
             if self.engine:
                 await self.engine.dispose()
                 self.engine = None
-            raise ClientError(f"{ClientError.SQL_CLIENT_AUTH_ERROR}: {e!s}") from e
+            raise SqlClientAuthFailedError(cause=exc) from exc
 
     async def close(self) -> None:
         """Close the async database connection and dispose of the engine."""
@@ -634,11 +664,11 @@ class AsyncBaseSQLClient(BaseSQLClient):
                 a dictionary mapping column names to values.
 
         Raises:
-            ValueError: If engine is not initialized.
-            Exception: If query execution fails.
+            SqlEngineNotInitializedError: If engine is not initialized.
+            SqlExecuteQueryError: If query execution fails.
         """
         if not self.engine:
-            raise ValueError("Engine is not initialized. Call load() first.")
+            raise SqlEngineNotInitializedError()
 
         logger.debug(
             "Running query (sha=%s, len=%d)",
@@ -677,8 +707,10 @@ class AsyncBaseSQLClient(BaseSQLClient):
                         break
                     yield [dict(zip(column_names, row)) for row in rows]
 
-            except Exception as e:
-                raise rewrap(e, "Error executing query") from e
+            except Exception as exc:
+                if isinstance(exc, AppError):
+                    raise
+                raise SqlExecuteQueryError(cause=exc) from exc
             # Async connection automatically closed by context manager
 
         logger.info("Query execution completed")

--- a/tests/unit/clients/test_clienterror_preservation.py
+++ b/tests/unit/clients/test_clienterror_preservation.py
@@ -15,17 +15,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from application_sdk.clients._sql_errors import SqlClientAuthFailedError
 from application_sdk.common.error_codes import ClientError
 
 # ---------------------------------------------------------------------------
-# BLDX-1180 — async SQL load() raises ClientError, not ValueError
+# BLDX-1180 — async SQL load() raises SqlClientAuthFailedError, not ValueError
 # ---------------------------------------------------------------------------
 
 
 class TestAsyncSqlLoadErrorContract:
-    """``AsyncBaseSQLClient.load()`` must raise ``ClientError`` on auth /
-    connection failure, mirroring sync ``BaseSQLClient.load()``. Before
-    BLDX-1180 it raised generic ``ValueError(str(e))``.
+    """``AsyncBaseSQLClient.load()`` must raise ``SqlClientAuthFailedError`` on
+    auth / connection failure. Before BLDX-1180 it raised a generic
+    ``ValueError(str(e))``. Migrated from ``ClientError`` to the typed
+    ``SqlClientAuthFailedError(AuthError)`` subclass per BLDX-1261.
     """
 
     @pytest.mark.asyncio
@@ -46,14 +48,17 @@ class TestAsyncSqlLoadErrorContract:
         # `create_async_engine` is imported inline inside `load()` (PLC0415
         # exception); patch at the source module so the inline import picks
         # up the mock.
-        with patch(
-            "sqlalchemy.ext.asyncio.create_async_engine",
-            side_effect=RuntimeError("boom"),
+        with (
+            patch(
+                "sqlalchemy.ext.asyncio.create_async_engine",
+                side_effect=RuntimeError("boom"),
+            ),
+            pytest.raises(SqlClientAuthFailedError) as exc_info,
         ):
-            with pytest.raises(ClientError) as exc_info:
-                await client.load({"username": "u", "password": "p"})
+            await client.load({"username": "u", "password": "p"})
 
-        assert str(ClientError.SQL_CLIENT_AUTH_ERROR) in str(exc_info.value)
+        assert exc_info.value.message == "SQL client authentication failed"
+        assert isinstance(exc_info.value.cause, RuntimeError)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/clients/test_sql_client.py
+++ b/tests/unit/clients/test_sql_client.py
@@ -1,13 +1,23 @@
 import asyncio
-from typing import Any, Dict, List
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from hypothesis import HealthCheck, given, settings
 
+from application_sdk.clients._sql_errors import (
+    SqlClientAuthFailedError,
+    SqlCursorNotSupportedError,
+    SqlDbConfigNotSetError,
+    SqlEngineNotInitializedError,
+    SqlEngineTypeError,
+    SqlInvalidAuthTypeError,
+    SqlMissingCredentialFieldError,
+    SqlMissingRequiredParamError,
+    SqlPandasResultError,
+)
 from application_sdk.clients.models import DatabaseConfig
-from application_sdk.clients.sql import BaseSQLClient
-from application_sdk.common.error_codes import CommonError
+from application_sdk.clients.sql import AsyncBaseSQLClient, BaseSQLClient
 from application_sdk.testing.hypothesis.strategies.clients.sql import (
     sql_credentials_strategy,
     sqlalchemy_connect_args_strategy,
@@ -118,8 +128,8 @@ async def test_load_uses_asyncio_to_thread_for_ping(
 @settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_load_property_based(
     sql_client: BaseSQLClient,
-    credentials: Dict[str, Any],
-    connect_args: Dict[str, Any],
+    credentials: dict[str, Any],
+    connect_args: dict[str, Any],
 ):
     """Property-based test for loading with various credentials and connection arguments"""
     with patch("sqlalchemy.create_engine") as mock_create_engine:
@@ -319,7 +329,7 @@ def test_connection_string_property_based(
 @pytest.mark.skip(reason="Failing due to KeyError: 'col1'")
 async def test_run_query_property_based(
     sql_client: BaseSQLClient,
-    query_result: Dict[str, Any],
+    query_result: dict[str, Any],
 ):
     """Property-based test for query execution with various result structures"""
     with (
@@ -349,12 +359,12 @@ async def test_run_query_property_based(
         )
 
         # Run run_query and collect all results
-        results: List[Dict[str, Any]] = []
+        results: list[dict[str, Any]] = []
         async for batch in sql_client.run_query(query):
             results.extend(batch)
 
         # Verify the results
-        expected_results: List[Dict[str, Any]] = []
+        expected_results: list[dict[str, Any]] = []
         for batch in query_result["batches"]:
             expected_results.extend(batch)
 
@@ -510,7 +520,7 @@ def test_get_sqlalchemy_connection_string_missing_required_param(
     }
     sql_client_with_db_config.credentials = credentials
 
-    with pytest.raises(ValueError, match="database is required"):
+    with pytest.raises(SqlMissingRequiredParamError, match="database is required"):
         sql_client_with_db_config.get_sqlalchemy_connection_string()
 
 
@@ -526,7 +536,7 @@ def test_get_sqlalchemy_connection_string_invalid_auth_type(sql_client_with_db_c
     }
     sql_client_with_db_config.credentials = credentials
 
-    with pytest.raises(CommonError, match="invalid_auth"):
+    with pytest.raises(SqlInvalidAuthTypeError, match="invalid_auth"):
         sql_client_with_db_config.get_sqlalchemy_connection_string()
 
 
@@ -548,7 +558,8 @@ def test_get_sqlalchemy_connection_string_iam_user_missing_username(
     sql_client_with_db_config.credentials = credentials
 
     with pytest.raises(
-        CommonError, match="username is required for IAM user authentication"
+        SqlMissingCredentialFieldError,
+        match="username is required for IAM user authentication",
     ):
         sql_client_with_db_config.get_sqlalchemy_connection_string()
 
@@ -571,7 +582,8 @@ def test_get_sqlalchemy_connection_string_iam_role_missing_role_arn(
     sql_client_with_db_config.credentials = credentials
 
     with pytest.raises(
-        CommonError, match="aws_role_arn is required for IAM role authentication"
+        SqlMissingCredentialFieldError,
+        match="aws_role_arn is required for IAM role authentication",
     ):
         sql_client_with_db_config.get_sqlalchemy_connection_string()
 
@@ -636,8 +648,6 @@ def test_get_sqlalchemy_connection_string_omits_none_parameters(
 # symbols fails at unit-test time instead of at runtime in production.
 # -----------------------------------------------------------------------------
 
-from application_sdk.clients.sql import AsyncBaseSQLClient  # noqa: E402
-from application_sdk.common.error_codes import ClientError  # noqa: E402
 
 # ---------- BaseSQLClient.load — error / edge paths ----------
 
@@ -647,7 +657,7 @@ async def test_load_raises_when_db_config_missing():
     """load() must validate DB_CONFIG before attempting any sqlalchemy import."""
     client = BaseSQLClient()
     client.DB_CONFIG = None
-    with pytest.raises(ValueError, match="DB_CONFIG is not configured"):
+    with pytest.raises(SqlDbConfigNotSetError, match="DB_CONFIG is not configured"):
         await client.load({"username": "u", "password": "p"})
 
 
@@ -656,7 +666,7 @@ async def test_load_raises_when_db_config_missing():
 async def test_load_wraps_engine_failure_as_client_error(
     mock_create_engine: Any, sql_client: BaseSQLClient
 ):
-    """A sqlalchemy create_engine failure must be wrapped as ClientError and
+    """A sqlalchemy create_engine failure must be wrapped as SqlClientAuthFailedError and
     the (partially constructed) engine disposed so connections do not leak."""
     mock_engine = MagicMock()
     mock_create_engine.return_value = mock_engine
@@ -664,8 +674,11 @@ async def test_load_wraps_engine_failure_as_client_error(
     # Force the connect-test inside asyncio.to_thread to fail
     actual_async_mock = AsyncMock(side_effect=RuntimeError("auth handshake failed"))
     with patch("application_sdk.clients.sql.asyncio.to_thread", actual_async_mock):
-        with pytest.raises(ClientError, match="auth handshake failed"):
+        with pytest.raises(SqlClientAuthFailedError) as exc_info:
             await sql_client.load({"username": "u", "password": "p"})
+
+    assert exc_info.value.message == "SQL client authentication failed"
+    assert isinstance(exc_info.value.cause, RuntimeError)
 
     # Engine must be disposed and reset to None so a retry can rebuild it.
     mock_engine.dispose.assert_called_once()
@@ -727,7 +740,7 @@ def test_get_iam_user_token_happy_path(mock_gen: MagicMock, sql_client: BaseSQLC
 
 def test_get_iam_user_token_missing_database(sql_client: BaseSQLClient):
     sql_client.credentials = {"username": "k", "extra": {"username": "u"}}
-    with pytest.raises(CommonError, match="database is required"):
+    with pytest.raises(SqlMissingCredentialFieldError, match="database is required"):
         sql_client.get_iam_user_token()
 
 
@@ -754,13 +767,15 @@ def test_get_iam_role_token_happy_path(mock_gen: MagicMock, sql_client: BaseSQLC
 
 def test_get_iam_role_token_missing_role_arn(sql_client: BaseSQLClient):
     sql_client.credentials = {"extra": {"database": "db1"}}
-    with pytest.raises(CommonError, match="aws_role_arn is required"):
+    with pytest.raises(
+        SqlMissingCredentialFieldError, match="aws_role_arn is required"
+    ):
         sql_client.get_iam_role_token()
 
 
 def test_get_iam_role_token_missing_database(sql_client: BaseSQLClient):
     sql_client.credentials = {"extra": {"aws_role_arn": "arn"}}
-    with pytest.raises(CommonError, match="database is required"):
+    with pytest.raises(SqlMissingCredentialFieldError, match="database is required"):
         sql_client.get_iam_role_token()
 
 
@@ -770,7 +785,7 @@ def test_get_iam_role_token_missing_database(sql_client: BaseSQLClient):
 @pytest.mark.asyncio
 async def test_run_query_raises_when_engine_not_initialized(sql_client: BaseSQLClient):
     sql_client.engine = None
-    with pytest.raises(ValueError, match="Engine is not initialized"):
+    with pytest.raises(SqlEngineNotInitializedError, match="Engine is not initialized"):
         async for _ in sql_client.run_query("SELECT 1"):
             pass
 
@@ -795,7 +810,7 @@ async def test_run_query_raises_when_cursor_unsupported(
     bad_result.cursor = None
     mock_loop.return_value.run_in_executor = AsyncMock(return_value=bad_result)
 
-    with pytest.raises(ValueError, match="Cursor is not supported"):
+    with pytest.raises(SqlCursorNotSupportedError, match="Cursor is not supported"):
         async for _ in sql_client.run_query("SELECT 1"):
             pass
 
@@ -811,7 +826,7 @@ async def test_run_query_raises_when_cursor_unsupported(
 def test_get_sqlalchemy_connection_string_requires_db_config():
     client = BaseSQLClient()
     client.DB_CONFIG = None
-    with pytest.raises(ValueError, match="DB_CONFIG is not configured"):
+    with pytest.raises(SqlDbConfigNotSetError, match="DB_CONFIG is not configured"):
         client.get_sqlalchemy_connection_string()
 
 
@@ -820,7 +835,7 @@ def test_get_sqlalchemy_connection_string_requires_db_config():
 
 def test_execute_query_daft_requires_engine(sql_client: BaseSQLClient):
     sql_client.engine = None
-    with pytest.raises(ValueError, match="Engine is not initialized"):
+    with pytest.raises(SqlEngineNotInitializedError, match="Engine is not initialized"):
         sql_client._execute_query_daft("SELECT 1", chunksize=None)
 
 
@@ -856,7 +871,7 @@ def test_execute_query_daft_with_engine_object(sql_client: BaseSQLClient):
 
 def test_execute_query_requires_engine(sql_client: BaseSQLClient):
     sql_client.engine = None
-    with pytest.raises(ValueError, match="Engine is not initialized"):
+    with pytest.raises(SqlEngineNotInitializedError, match="Engine is not initialized"):
         sql_client._execute_query("SELECT 1", chunksize=None)
 
 
@@ -942,7 +957,9 @@ async def test_execute_async_read_operation_rejects_string_engine(
     sql_client: BaseSQLClient,
 ):
     sql_client.engine = "postgresql://u:p@h/db"  # type: ignore[assignment]
-    with pytest.raises(ValueError, match="Engine should be an SQLAlchemy engine"):
+    with pytest.raises(
+        SqlEngineTypeError, match="Engine should be an SQLAlchemy engine"
+    ):
         await sql_client._execute_async_read_operation("SELECT 1", chunksize=None)
 
 
@@ -967,29 +984,30 @@ async def test_get_results_returns_dataframe(sql_client: BaseSQLClient):
 @pytest.mark.asyncio
 async def test_get_results_rejects_non_dataframe(sql_client: BaseSQLClient):
     """If the read path returns something that isn't a DataFrame, get_results
-    must surface the error (wrapped via rewrap)."""
+    must raise SqlPandasResultError."""
     sql_client.engine = MagicMock()
     with patch.object(
         sql_client,
         "_execute_async_read_operation",
         new=AsyncMock(return_value=iter([])),  # not a DataFrame
     ):
-        with pytest.raises(Exception, match="Error reading data"):
+        with pytest.raises(SqlPandasResultError):
             await sql_client.get_results("SELECT 1")
 
 
 @pytest.mark.asyncio
 async def test_get_batched_results_wraps_errors_via_rewrap(sql_client: BaseSQLClient):
-    """Any failure in the read path must be re-raised through rewrap with the
-    'Error reading batched data(pandas) from SQL' prefix."""
+    """Any failure in the read path must be re-raised as SqlBatchReadError."""
     sql_client.engine = MagicMock()
-    with patch.object(
-        sql_client,
-        "_execute_async_read_operation",
-        new=AsyncMock(side_effect=RuntimeError("boom")),
+    with (
+        patch.object(
+            sql_client,
+            "_execute_async_read_operation",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ),
+        pytest.raises(Exception, match="Error reading batched data"),
     ):
-        with pytest.raises(Exception, match="Error reading batched data"):
-            await sql_client.get_batched_results("SELECT 1")
+        await sql_client.get_batched_results("SELECT 1")
 
 
 @pytest.mark.asyncio
@@ -1074,7 +1092,7 @@ def async_sql_client_local():
 async def test_async_load_raises_when_db_config_missing():
     client = AsyncBaseSQLClient()
     client.DB_CONFIG = None
-    with pytest.raises(ValueError, match="DB_CONFIG is not configured"):
+    with pytest.raises(SqlDbConfigNotSetError, match="DB_CONFIG is not configured"):
         await client.load({"username": "u", "password": "p"})
 
 
@@ -1083,7 +1101,7 @@ async def test_async_load_raises_when_db_config_missing():
 async def test_async_load_disposes_engine_on_failure(
     mock_create: MagicMock, async_sql_client_local: AsyncBaseSQLClient
 ):
-    """Async load() must dispose the engine and re-raise as ClientError
+    """Async load() must dispose the engine and re-raise as SqlClientAuthFailedError
     (consistent with sync load() — locked in by PR #1602 / BLDX-1180)."""
     mock_engine = AsyncMock()
     mock_engine.dispose = AsyncMock()
@@ -1098,9 +1116,9 @@ async def test_async_load_disposes_engine_on_failure(
     mock_engine.connect = MagicMock(return_value=_FailingCtx())
     mock_create.return_value = mock_engine
 
-    with pytest.raises(ClientError) as exc_info:
+    with pytest.raises(SqlClientAuthFailedError) as exc_info:
         await async_sql_client_local.load({"username": "u", "password": "p"})
-    assert str(ClientError.SQL_CLIENT_AUTH_ERROR) in str(exc_info.value)
+    assert exc_info.value.message == "SQL client authentication failed"
 
     mock_engine.dispose.assert_awaited_once()
     assert async_sql_client_local.engine is None
@@ -1132,6 +1150,6 @@ async def test_async_run_query_requires_engine(
     async_sql_client_local: AsyncBaseSQLClient,
 ):
     async_sql_client_local.engine = None  # type: ignore[assignment]
-    with pytest.raises(ValueError, match="Engine is not initialized"):
+    with pytest.raises(SqlEngineNotInitializedError, match="Engine is not initialized"):
         async for _ in async_sql_client_local.run_query("SELECT 1"):
             pass


### PR DESCRIPTION
## Summary

- Adds `application_sdk/clients/_sql_errors.py` with three shared typed subclasses (`DbConfigNotInitializedError`, `EngineNotInitializedError`, `SqlClientAuthError`) for repeated raise sites
- Converts all 18 raise sites in `BaseSQLClient` and `AsyncBaseSQLClient` from bare `ValueError`/`Exception` and legacy `ClientError`/`CommonError` to typed `AppError` leaves — every failure now carries `category`, `code`, `audience`, and `retryable` fields on the wire
- Updates test assertions and the BLDX-1180 regression contract to assert the correct typed leaf classes

## Typed conversions

| Sites | Old raise | New type | Wire code |
|---|---|---|---|
| 3× | `ValueError("DB_CONFIG is not configured…")` | `DbConfigNotInitializedError` | `INTERNAL_SQL_DB_CONFIG_NOT_SET` |
| 4× | `ValueError("Engine is not initialized…")` | `EngineNotInitializedError` | `INTERNAL_SQL_ENGINE_NOT_INITIALIZED` |
| 2× | `ClientError(SQL_CLIENT_AUTH_ERROR)` | `SqlClientAuthError` | `AUTH_SQL_CLIENT_FAILED` |
| 5× | `CommonError(CREDENTIALS_PARSE_ERROR)` | `InvalidInputError` | `INVALID_INPUT` |
| 1× | `ValueError(f"{param} is required")` | `InvalidInputError` | `INVALID_INPUT` |
| 1× | `ValueError("Cursor is not supported")` | `UnimplementedError` | `UNIMPLEMENTED` |
| 1× | `ValueError("Engine should be…")` | `InternalError` | `INTERNAL` |
| 1× | `Exception("Unable to get pandas dataframe…")` | `InternalError` | `INTERNAL` |

## Test plan

- [ ] `uv run python -m pytest tests/unit/clients/test_sql_client.py` — all typed-leaf assertions pass
- [ ] `uv run python -m pytest tests/unit/clients/test_clienterror_preservation.py` — all BLDX-1163/1164/1165/1180 regression contracts pass
- [ ] `uv run python -m pytest tests/unit -x -q` — full unit suite green (4170 passed)
- [ ] `uv run pre-commit run --files application_sdk/clients/_sql_errors.py application_sdk/clients/sql.py` — clean