### PR TITLE
fix(skill): evolve signal-over-noise typed-error prescription

### DIFF
--- a/.claude/skills/signal-over-noise/SKILL.md
+++ b/.claude/skills/signal-over-noise/SKILL.md
@@ -119,8 +119,8 @@ Run all 13 grep searches in parallel against `TARGET_PATH` (`*.py` files only):
 | 12 | P12 | `raise\s+(ValueError\|RuntimeError\|Exception\|TypeError\|NotImplementedError\|OSError\|KeyError\|LookupError)\b` |
 | 13 | P13 | `raise\s+(ClientError\|ApiError\|OrchestratorError\|WorkflowError\|IOError\|CommonError\|DocGenError\|ActivityError\|AtlanError)\b` |
 
-For P5, P7, P9, P11, P12: raw grep over-matches. Collect `file:line` hits and read context in Step 1.3.
-P13 is mechanical — every hit is a finding (no context reading needed).
+For P5, P7, P9, P11, P12, P13: raw grep over-matches. Collect `file:line` hits and read context in Step 1.3.
+P13 context note: `IOError` is also a Python builtin alias for `OSError` — confirm the hit imports from `application_sdk.common.error_codes` before classifying as legacy. Bare `AtlanError` raises (no constant) require litmus-test classification (§3 of `typed-error-prescription.md`).
 
 Collect all hits as a flat list: `(file, line_number, pattern_id, raw_snippet)`.
 
@@ -142,13 +142,13 @@ Classify each finding:
 Apply `SEVERITY_FILTER`: discard findings below the threshold before proceeding.
 
 P12 classification notes:
-- Inside `__post_init__` / stdlib dataclass validators: check for a comment
+- Inside `__post_init__`, stdlib dataclass validators, or Pydantic `@field_validator` / `@validator` methods: check for a comment
   explaining the stdlib-interop need. If present → `acceptable`. If absent →
   flag as `genuine-bug` (MEDIUM — add the comment).
-- Inside an `@task`-decorated activity body → escalate to CRITICAL.
+- Inside an `@task`-decorated activity body or `@activity.defn`-decorated function → escalate to CRITICAL.
 
-P13: all hits are `genuine-bug` (HIGH). Use the §5 migration table from
-`typed-error-prescription.md` for the `Prescribed:` field.
+P13: confirmed hits are `genuine-bug` (HIGH). After context reading (see over-matches note above), use the §5 migration table from
+`typed-error-prescription.md` for the `Prescribed:` field. When no matching legacy constant is present, use §3 litmus tests to select a leaf directly.
 
 #### Step 1.4 — Build Remediation Plan
 
@@ -247,8 +247,8 @@ TODO comment format for swallow/logging findings:
 
 TODO comment format for untyped/legacy raise findings — include the prescribed leaf:
 ```python
-# TODO(signal-over-noise): [P12] convert to typed AppError. Leaf: InternalError (wire code: INTERNAL_ENGINE_NOT_INITIALIZED). See references/typed-error-prescription.md#4
-# TODO(signal-over-noise): [P13] legacy AtlanError — migrate to DependencyUnavailableError. See references/typed-error-prescription.md#5
+# TODO(signal-over-noise): [P12] convert to typed AppError. Leaf: InternalError (wire code: INTERNAL_ENGINE_NOT_INITIALIZED). See typed-error-prescription.md §4
+# TODO(signal-over-noise): [P13] legacy AtlanError — migrate to DependencyUnavailableError. See typed-error-prescription.md §5
 ```
 
 #### After applying fixes:

--- a/.claude/skills/signal-over-noise/SKILL.md
+++ b/.claude/skills/signal-over-noise/SKILL.md
@@ -101,7 +101,7 @@ Pattern catalogue, severity criteria, fix templates, and linting rules are in:
 
 #### Step 1.2 — Pattern Detection
 
-Run all 10 grep searches in parallel against `TARGET_PATH` (`*.py` files only):
+Run all 13 grep searches in parallel against `TARGET_PATH` (`*.py` files only):
 
 | # | Pattern ID | Grep |
 |---|------------|------|
@@ -163,7 +163,7 @@ Pattern:  P12
 Current:
     raise ValueError("Engine is not initialized. Call load() first.")
 Prescribed:
-    InternalError(code="INTERNAL_ENGINE_NOT_INITIALIZED")
+    InternalError  (wire code: INTERNAL_ENGINE_NOT_INITIALIZED — ClassVar, not a constructor arg)
     audience=APP_OWNER  retryable=False
 Fix (FT-8):
     raise InternalError(
@@ -250,7 +250,7 @@ TODO comment format for swallow/logging findings:
 
 TODO comment format for untyped/legacy raise findings — include the prescribed leaf:
 ```python
-# TODO(signal-over-noise): [P12] convert to typed AppError. Suggested: InternalError(code="INTERNAL_ENGINE_NOT_INITIALIZED"). See references/typed-error-prescription.md#4
+# TODO(signal-over-noise): [P12] convert to typed AppError. Leaf: InternalError (wire code: INTERNAL_ENGINE_NOT_INITIALIZED). See references/typed-error-prescription.md#4
 # TODO(signal-over-noise): [P13] legacy AtlanError — migrate to DependencyUnavailableError. See references/typed-error-prescription.md#5
 ```
 

--- a/.claude/skills/signal-over-noise/SKILL.md
+++ b/.claude/skills/signal-over-noise/SKILL.md
@@ -237,7 +237,7 @@ Apply the remediation plan that was approved. Only fix what was listed in the ap
 - **FT-5b** (typed re-raise for non-best-effort suppress): leaf choice is contextual
 - **FT-6** (narrow broad catch): `# TODO(signal-over-noise): [P4] narrow this catch`
 - **FT-7** (Filter exception safety): `# TODO(signal-over-noise): [P11] wrap filter body in try/except`
-- **FT-8** (convert untyped builtin raise to typed `AppError`): leaf from `typed-error-prescription.md` §4. If the same leaf+message+evidence recurs across ≥2 raise sites, define a subclass that bakes the defaults in a sibling `_<area>_errors.py` and reduce raise sites to the minimal form (`raise XError()`).
+- **FT-8** (convert untyped builtin raise to typed `AppError`): leaf from `typed-error-prescription.md` §4. Define a subclass for each distinct failure mode in a sibling errors module (SDK: `application_sdk/<area>/errors.py` or `_<area>_errors.py`; app: `app/failures.py`). Bake `message` and evidence-field defaults when they're stable across raise sites; for one-off sites, the subclass may just override `code` and let the raise site pass `message`.
 - **FT-9** (convert legacy `AtlanError` raise to typed `AppError`): leaf from `typed-error-prescription.md` §5. Same subclassing rule applies when the same error recurs.
 
 TODO comment format for swallow/logging findings:

--- a/.claude/skills/signal-over-noise/SKILL.md
+++ b/.claude/skills/signal-over-noise/SKILL.md
@@ -95,8 +95,9 @@ Pattern catalogue, severity criteria, fix templates, and linting rules are in:
 #### Step 1.1 — Setup
 
 1. Read `.claude/skills/signal-over-noise/references/error-recovery-patterns.md` in full.
-2. Resolve `TARGET_PATH` from arguments (default: current directory). Confirm it exists.
-3. Set `SEVERITY_FILTER` from `--severity` (default: `all`).
+2. Read `.claude/skills/signal-over-noise/references/typed-error-prescription.md` in full.
+3. Resolve `TARGET_PATH` from arguments (default: current directory). Confirm it exists.
+4. Set `SEVERITY_FILTER` from `--severity` (default: `all`).
 
 #### Step 1.2 — Pattern Detection
 
@@ -115,8 +116,11 @@ Run all 10 grep searches in parallel against `TARGET_PATH` (`*.py` files only):
 | 9 | P9 | except block with only an assignment — collect hits for Step 1.3 |
 | 10 | P10 | `return_exceptions=True` |
 | 11 | P11 | `class\s+\w+.*logging\.Filter` or `def filter\(self` inside a Filter subclass |
+| 12 | P12 | `raise\s+(ValueError\|RuntimeError\|Exception\|TypeError\|NotImplementedError\|OSError\|KeyError\|LookupError)\b` |
+| 13 | P13 | `raise\s+(ClientError\|ApiError\|OrchestratorError\|WorkflowError\|IOError\|CommonError\|DocGenError\|ActivityError\|AtlanError)\b` |
 
-For P5, P7, P9, P11: raw grep over-matches. Collect `file:line` hits and read context in Step 1.3.
+For P5, P7, P9, P11, P12: raw grep over-matches. Collect `file:line` hits and read context in Step 1.3.
+P13 is mechanical — every hit is a finding (no context reading needed).
 
 Collect all hits as a flat list: `(file, line_number, pattern_id, raw_snippet)`.
 
@@ -128,27 +132,51 @@ Classify each finding:
 - **Severity:** CRITICAL, HIGH, MEDIUM, or LOW (from §Severity Classification in reference)
 - **Legitimacy:** `genuine-bug` or `acceptable` (from §Legitimacy in reference)
 - **Category:** `silent-swallow`, `missing-traceback`, `overly-broad-catch`,
-  `error-to-return-value`, `suppress-operational`, `optional-import`, `asyncio-unexamined`
+  `error-to-return-value`, `suppress-operational`, `optional-import`,
+  `asyncio-unexamined`, `untyped-raise`, `legacy-raise`
+- **Typed-error prescription:** for every `genuine-bug` finding whose fix involves
+  a `raise` (FT-1b, FT-3b, FT-5b, FT-8, FT-9), look up the prescribed leaf and
+  code from `references/typed-error-prescription.md`. Record as `Prescribed:` on
+  the remediation entry so the user sees the target class in the plan.
 
 Apply `SEVERITY_FILTER`: discard findings below the threshold before proceeding.
 
+P12 classification notes:
+- Inside `__post_init__` / stdlib dataclass validators: check for a comment
+  explaining the stdlib-interop need. If present → `acceptable`. If absent →
+  flag as `genuine-bug` (MEDIUM — add the comment).
+- Inside an `@task`-decorated activity body → escalate to CRITICAL.
+
+P13: all hits are `genuine-bug` (HIGH). Use the §5 migration table from
+`typed-error-prescription.md` for the `Prescribed:` field.
+
 #### Step 1.4 — Build Remediation Plan
 
-For each `genuine-bug` finding, produce a remediation entry:
+For each `genuine-bug` finding, produce a remediation entry. Include `Prescribed:`
+whenever the fix involves raising an exception:
 
 ```
-File:     src/foo/bar.py:42
+File:     application_sdk/clients/sql.py:142
 Severity: HIGH
-Category: missing-traceback
+Category: untyped-raise
+Pattern:  P12
 Current:
-    except ValueError as e:
-        logger.warning(f"Parse failed: {e}")
-Fix (FT-2):
-    except ValueError:
-        logger.warning("Parse failed", exc_info=True)
-Auto-fixable: yes
+    raise ValueError("Engine is not initialized. Call load() first.")
+Prescribed:
+    InternalError(code="INTERNAL_ENGINE_NOT_INITIALIZED")
+    audience=APP_OWNER  retryable=False
+Fix (FT-8):
+    raise InternalError(
+        message="Engine is not initialized. Call load() first.",
+        component="sql_client",
+        invariant="load_before_use",
+    )
+Auto-fixable: no  (leaf choice needs context — manual review)
 Priority: P1
 ```
+
+For existing-pattern (P1–P11) findings whose fix re-raises, also include
+`Prescribed:` with the leaf selected from `typed-error-prescription.md` §4.
 
 Priority mapping:
 - **P0** — CRITICAL: fix immediately, block merges
@@ -200,19 +228,30 @@ Call `ExitPlanMode` to request user approval. Wait for approval before proceedin
 Apply the remediation plan that was approved. Only fix what was listed in the approved plan.
 
 #### Auto-fixable patterns — apply directly:
-- **FT-1:** Add logging to silent-swallow (`except X: pass` → add `logger.warning`)
+- **FT-1a:** Add logging to silent-swallow (log-and-continue, best-effort paths)
 - **FT-2:** Add `exc_info=True` to existing log call in except block
-- **FT-3:** Add logging before error-to-return-value (`except X: return Y`)
+- **FT-3a:** Add logging before error-to-return-value (when caller treats default as valid)
 - **FT-4:** Add exception inspection after `asyncio.gather(..., return_exceptions=True)`
-- **FT-5:** Replace broad `contextlib.suppress(Exception)` with logged try/except
+- **FT-5a:** Replace broad `contextlib.suppress(Exception)` with logged try/except (best-effort)
 
 #### Manual review required — leave TODO comments:
+- **FT-1b** (log + typed re-raise): leaf choice is contextual
+- **FT-3b** (convert swallow to typed raise): default for error-to-return-value when caller trusts result
+- **FT-5b** (typed re-raise for non-best-effort suppress): leaf choice is contextual
 - **FT-6** (narrow broad catch): `# TODO(signal-over-noise): [P4] narrow this catch`
 - **FT-7** (Filter exception safety): `# TODO(signal-over-noise): [P11] wrap filter body in try/except`
+- **FT-8** (convert untyped builtin raise to typed `AppError`): leaf from `typed-error-prescription.md` §4
+- **FT-9** (convert legacy `AtlanError` raise to typed `AppError`): leaf from `typed-error-prescription.md` §5
 
-TODO comment format:
+TODO comment format for swallow/logging findings:
 ```python
 # TODO(signal-over-noise): [P2] silent swallow — add logging. See references/error-recovery-patterns.md#P2
+```
+
+TODO comment format for untyped/legacy raise findings — include the prescribed leaf:
+```python
+# TODO(signal-over-noise): [P12] convert to typed AppError. Suggested: InternalError(code="INTERNAL_ENGINE_NOT_INITIALIZED"). See references/typed-error-prescription.md#4
+# TODO(signal-over-noise): [P13] legacy AtlanError — migrate to DependencyUnavailableError. See references/typed-error-prescription.md#5
 ```
 
 #### After applying fixes:
@@ -518,3 +557,11 @@ Report a brief summary: N files changed, N auto-fixes applied, N TODO comments a
 7. **Phase ordering matters:** Run Surface before Tune. A silent-swallow in an except block (P1/P2)
    overlaps with a missing-exc_info finding (L4). Surface fixes the structural problem; Tune then
    verifies the logging quality of the fix. Avoid double-reporting the same line.
+
+8. **Typed-error prescription is mandatory.** Every fix that re-raises must name an `AppError`
+   leaf from `application_sdk.errors`. The skill never recommends raising a bare builtin or a
+   legacy `AtlanError`. The leaf catalogue (§2), litmus tests (§3), SDK-context cookbook (§4),
+   and exhaustive legacy-constant migration table (§5) all live in
+   `references/typed-error-prescription.md`. P12 (untyped builtin raises) and P13 (legacy
+   `AtlanError` raises) fold the BLDX-1261 audit into surface mode — every finding gets a
+   `Prescribed:` entry naming the target leaf and suggested code string.

--- a/.claude/skills/signal-over-noise/SKILL.md
+++ b/.claude/skills/signal-over-noise/SKILL.md
@@ -156,7 +156,7 @@ For each `genuine-bug` finding, produce a remediation entry. Include `Prescribed
 whenever the fix involves raising an exception:
 
 ```
-File:     application_sdk/clients/sql.py:142
+File:     application_sdk/clients/sql.py:352
 Severity: HIGH
 Category: untyped-raise
 Pattern:  P12

--- a/.claude/skills/signal-over-noise/SKILL.md
+++ b/.claude/skills/signal-over-noise/SKILL.md
@@ -163,15 +163,12 @@ Pattern:  P12
 Current:
     raise ValueError("Engine is not initialized. Call load() first.")
 Prescribed:
-    InternalError  (wire code: INTERNAL_ENGINE_NOT_INITIALIZED — ClassVar, not a constructor arg)
-    audience=APP_OWNER  retryable=False
+    EngineNotInitializedError(InternalError)  →  code=INTERNAL_ENGINE_NOT_INITIALIZED
+    Subclass bakes message + component + invariant. Place in a sibling
+    module (e.g. _<area>_errors.py); follow the WorkerEvictedError precedent.
 Fix (FT-8):
-    raise InternalError(
-        message="Engine is not initialized. Call load() first.",
-        component="sql_client",
-        invariant="load_before_use",
-    )
-Auto-fixable: no  (leaf choice needs context — manual review)
+    raise EngineNotInitializedError()
+Auto-fixable: no  (leaf + subclass choice needs context — manual review)
 Priority: P1
 ```
 
@@ -240,8 +237,8 @@ Apply the remediation plan that was approved. Only fix what was listed in the ap
 - **FT-5b** (typed re-raise for non-best-effort suppress): leaf choice is contextual
 - **FT-6** (narrow broad catch): `# TODO(signal-over-noise): [P4] narrow this catch`
 - **FT-7** (Filter exception safety): `# TODO(signal-over-noise): [P11] wrap filter body in try/except`
-- **FT-8** (convert untyped builtin raise to typed `AppError`): leaf from `typed-error-prescription.md` §4
-- **FT-9** (convert legacy `AtlanError` raise to typed `AppError`): leaf from `typed-error-prescription.md` §5
+- **FT-8** (convert untyped builtin raise to typed `AppError`): leaf from `typed-error-prescription.md` §4. If the same leaf+message+evidence recurs across ≥2 raise sites, define a subclass that bakes the defaults in a sibling `_<area>_errors.py` and reduce raise sites to the minimal form (`raise XError()`).
+- **FT-9** (convert legacy `AtlanError` raise to typed `AppError`): leaf from `typed-error-prescription.md` §5. Same subclassing rule applies when the same error recurs.
 
 TODO comment format for swallow/logging findings:
 ```python

--- a/.claude/skills/signal-over-noise/SKILL.md
+++ b/.claude/skills/signal-over-noise/SKILL.md
@@ -165,7 +165,7 @@ Current:
 Prescribed:
     EngineNotInitializedError(InternalError)  →  code=INTERNAL_ENGINE_NOT_INITIALIZED
     Subclass bakes message + component + invariant. Place in a sibling
-    module (e.g. _<area>_errors.py); follow the WorkerEvictedError precedent.
+    module (e.g. _<area>_errors.py); see typed-error-prescription.md §4.
 Fix (FT-8):
     raise EngineNotInitializedError()
 Auto-fixable: no  (leaf + subclass choice needs context — manual review)

--- a/.claude/skills/signal-over-noise/references/error-recovery-patterns.md
+++ b/.claude/skills/signal-over-noise/references/error-recovery-patterns.md
@@ -260,7 +260,7 @@ results are not subsequently checked for exception instances.
 ### P12 — Untyped builtin raise where a typed `AppError` code applies
 
 **Grep:** `raise\s+(ValueError|RuntimeError|Exception|TypeError|NotImplementedError|OSError|KeyError|LookupError)\b`
-**Severity:** HIGH (CRITICAL when inside an `@task`-decorated activity body)
+**Severity:** HIGH (CRITICAL when inside an `@task`-decorated activity body or `@activity.defn`-decorated function)
 **What it is:** SDK code raises a bare Python builtin. The Automation Engine
 receives an opaque string — no `category`, no `code`, no `audience`, no
 `retryable`. Dashboards are blind; on-call routing is impossible. Direct
@@ -302,20 +302,29 @@ envelope.
 # BAD
 raise IOError("Object store download failed")
 
-# GOOD
+# GOOD (standalone raise — no enclosing exception to chain)
 from application_sdk.errors import DependencyUnavailableError
 raise DependencyUnavailableError(
     message="Object store download failed",
     service="object_store",
-    cause=exc,
-) from exc
+)
+
+# GOOD (inside except block — chain the cause)
+except SomeError as exc:
+    raise DependencyUnavailableError(
+        message="Object store download failed",
+        service="object_store",
+        cause=exc,
+    ) from exc
 ```
 
-**Acceptable?** Never. Every legacy raise has a deterministic target in the
-`typed-error-prescription.md` §5 migration table.
+**Acceptable?** Never, except `IOError` hits — confirm the name refers to the `AtlanError`
+subclass (imported from `application_sdk.common.error_codes`) rather than the Python builtin
+alias for `OSError`.
 
-**Fix:** FT-9. Look up the legacy constant in the §5 migration table — the
-mapping is exhaustive and deterministic.
+**Fix:** FT-9. If the raise site uses a legacy constant, look it up in the §5 migration table
+in `typed-error-prescription.md`. If there is no constant (bare `raise AtlanError(msg)`), use
+the §3 litmus tests to select a leaf directly.
 
 ---
 
@@ -634,13 +643,20 @@ raise InternalError(
 # Before
 raise IOError("Object store download failed")
 
-# After
+# After (standalone — no enclosing exception)
 from application_sdk.errors import DependencyUnavailableError
 raise DependencyUnavailableError(
     message="Object store download failed",
     service="object_store",
-    cause=exc,
-) from exc
+)
+
+# After (inside except block — chain the cause)
+except SomeError as exc:
+    raise DependencyUnavailableError(
+        message="Object store download failed",
+        service="object_store",
+        cause=exc,
+    ) from exc
 ```
 
 ---
@@ -680,8 +696,10 @@ a CI-level grep is more practical than a ruff rule (false-positive rate is high
 without a per-file allowlist). A targeted check:
 
 ```bash
-# Fail if any bare builtin raise survives in application_sdk/ (outside __post_init__ / validators)
-grep -rnP "raise\s+(ValueError|RuntimeError|Exception)\b" application_sdk/ \
+# Fail if any bare builtin raise survives in application_sdk/ (outside interop sites).
+# Note: these -v filters are line-level — they won't exclude a raise on a separate line from
+# its interop comment. Put the "# stdlib-interop" marker on the raise line itself.
+grep -rnP "raise\s+(ValueError|RuntimeError|Exception|TypeError|NotImplementedError|OSError|KeyError|LookupError)\b" application_sdk/ \
   | grep -v "__post_init__" | grep -v "# stdlib-interop"
 ```
 

--- a/.claude/skills/signal-over-noise/references/error-recovery-patterns.md
+++ b/.claude/skills/signal-over-noise/references/error-recovery-patterns.md
@@ -257,6 +257,68 @@ results are not subsequently checked for exception instances.
 
 ---
 
+### P12 — Untyped builtin raise where a typed `AppError` code applies
+
+**Grep:** `raise\s+(ValueError|RuntimeError|Exception|TypeError|NotImplementedError|OSError|KeyError|LookupError)\b`
+**Severity:** HIGH (CRITICAL when inside an `@task`-decorated activity body)
+**What it is:** SDK code raises a bare Python builtin. The Automation Engine
+receives an opaque string — no `category`, no `code`, no `audience`, no
+`retryable`. Dashboards are blind; on-call routing is impossible. Direct
+expression of the BLDX-1261 audit scope.
+
+```python
+# BAD — unattributable on the wire
+raise ValueError("Engine is not initialized. Call load() first.")
+
+# GOOD — typed, attributable
+from application_sdk.errors import InternalError
+raise InternalError(
+    message="Engine is not initialized. Call load() first.",
+    component="sql_client",
+    invariant="load_before_use",
+)
+```
+
+**Acceptable?** Only inside dataclass `__post_init__` / stdlib validator methods
+where Python semantics require `TypeError` / `ValueError` for stdlib
+interoperability (e.g. Pydantic validators, `__init__` argument checks at the
+Python level). Must have a comment explaining why the builtin is required.
+
+**Fix:** FT-8. Use `typed-error-prescription.md` §4 (cookbook) or §3 (litmus
+tests) to select the leaf.
+
+---
+
+### P13 — Legacy `AtlanError` subclass raise (deprecated stack)
+
+**Grep:** `raise\s+(ClientError|ApiError|OrchestratorError|WorkflowError|IOError|CommonError|DocGenError|ActivityError|AtlanError)\b`
+**Severity:** HIGH (deprecated; scheduled for removal in v4.0 per
+`application_sdk/common/error_codes.py:51-63`)
+**What it is:** `AtlanError` and its subclasses emit a `DeprecationWarning` at
+construction time and reach AE as opaque strings. They produce no typed wire
+envelope.
+
+```python
+# BAD
+raise IOError("Object store download failed")
+
+# GOOD
+from application_sdk.errors import DependencyUnavailableError
+raise DependencyUnavailableError(
+    message="Object store download failed",
+    service="object_store",
+    cause=exc,
+) from exc
+```
+
+**Acceptable?** Never. Every legacy raise has a deterministic target in the
+`typed-error-prescription.md` §5 migration table.
+
+**Fix:** FT-9. Look up the legacy constant in the §5 migration table — the
+mapping is exhaustive and deterministic.
+
+---
+
 ### P11 — `logging.Filter` Exceptions Propagate to Caller (CRASH)
 
 **Grep:** `class\s+\w+.*logging\.Filter` or `def filter\(self` inside a class that inherits `logging.Filter`
@@ -335,16 +397,51 @@ When a finding is acceptable, note the justification and skip it from the remedi
 
 Mechanical fixes per category. Apply exactly — don't over-engineer.
 
-### FT-1: Add logging to silent-swallow
+**Typed-error requirement.** Whenever a fix surfaces or re-raises an exception,
+the replacement **must** use a typed `AppError` subclass from
+`application_sdk.errors`. See
+[`typed-error-prescription.md`](typed-error-prescription.md) for the full
+catalogue (14 SDK leaves), litmus tests, SDK-context cookbook (§4), the
+exhaustive legacy `AtlanError` → `AppError` migration table (§5), and the
+mandatory `cause`/`from` rules (§6). **Never** propose raising bare
+`Exception` / `ValueError` / `RuntimeError`; **never** propose raising legacy
+`AtlanError` subclasses (`ClientError`, `IOError`, `CommonError`, etc.).
+Use the §8 surface-or-swallow decision tree to choose between FT-1a and FT-1b.
+
+### FT-1a: Add logging to silent-swallow (log-and-continue — best-effort paths)
+
+Use when the §8 decision tree confirms "best-effort / caller does not depend
+on success". Log at WARNING if the failure is unexpected; DEBUG if it is
+fully anticipated.
 
 ```python
 # Before
 except SomeError:
     pass
 
-# After
+# After (log-and-continue)
 except SomeError:
     logger.warning("<context: what was being attempted>", exc_info=True)
+```
+
+### FT-1b: Log and re-raise as typed `AppError` (surfacing paths)
+
+Use when the §8 decision tree says the caller depends on the operation or this
+is inside an activity body. Pick the leaf from `typed-error-prescription.md` §4.
+
+```python
+# Before
+except SomeError:
+    pass
+
+# After (log + typed re-raise)
+except SomeError as exc:
+    logger.warning("<context: what was being attempted>", exc_info=True)
+    raise <TypedLeaf>(
+        message="<context: what was being attempted>",
+        cause=exc,
+        # evidence fields from leaves.py
+    ) from exc
 ```
 
 ### FT-2: Add `exc_info=True` to existing log
@@ -359,17 +456,39 @@ except SomeError:
     logger.warning("Failed: <static description>", exc_info=True)
 ```
 
-### FT-3: Add logging before error-to-return-value
+### FT-3a: Add logging before error-to-return-value (log-and-continue — caller treats default as valid)
+
+Use when the caller genuinely treats the fallback return value as a valid
+outcome. Log at WARNING.
 
 ```python
 # Before
 except Exception:
     return {}
 
-# After
+# After (log-and-continue)
 except Exception:
     logger.warning("<context>", exc_info=True)
     return {}
+```
+
+### FT-3b: Convert error-to-return-value to typed re-raise (dominant fix)
+
+The default fix — use unless FT-3a's condition is clearly met. Convert the
+swallow into a typed raise so callers see a real failure rather than a silently
+wrong result.
+
+```python
+# Before
+except Exception:
+    return {}
+
+# After (typed re-raise — caller must handle or propagate)
+except Exception as exc:
+    raise <TypedLeaf>(
+        message="<context: what was being attempted>",
+        cause=exc,
+    ) from exc
 ```
 
 ### FT-4: Add exception inspection to `asyncio.gather` results
@@ -381,18 +500,39 @@ for _r in _results:
         logger.warning("Async task failed", exc_info=_r)
 ```
 
-### FT-5: Replace broad `contextlib.suppress(Exception)` with logged try/except
+### FT-5a: Replace broad `contextlib.suppress(Exception)` with logged try/except (best-effort)
+
+Use when §8 confirms best-effort / caller does not depend on success.
 
 ```python
 # Before
 with contextlib.suppress(Exception):
     do_thing()
 
-# After
+# After (log-and-continue)
 try:
     do_thing()
 except Exception:
     logger.warning("<context>", exc_info=True)
+```
+
+### FT-5b: Replace broad `contextlib.suppress(Exception)` with typed re-raise (surfacing)
+
+Use when the call is not genuinely best-effort.
+
+```python
+# Before
+with contextlib.suppress(Exception):
+    do_thing()
+
+# After (typed re-raise)
+try:
+    do_thing()
+except Exception as exc:
+    raise <TypedLeaf>(
+        message="<context: what failed>",
+        cause=exc,
+    ) from exc
 ```
 
 ### FT-6: Narrow overly-broad catch (manual — requires knowing the right exception types)
@@ -438,6 +578,71 @@ class EnvFilter(logging.Filter):
         return getattr(record, "environment", None) == "production"
 ```
 
+### FT-8: Convert untyped builtin raise to typed `AppError` (manual — leaf choice needs context)
+
+Look up the right leaf in `typed-error-prescription.md` §4 (SDK-context cookbook)
+or §3 (litmus tests). Preserve the original message verbatim.
+
+```python
+# Before
+raise ValueError("aws_role_arn is required")
+
+# After
+from application_sdk.errors import InvalidInputError
+raise InvalidInputError(
+    message="aws_role_arn is required",
+    field="aws_role_arn",
+)
+```
+
+```python
+# Before
+raise RuntimeError("Engine is not initialized. Call load() first.")
+
+# After
+from application_sdk.errors import InternalError
+raise InternalError(
+    message="Engine is not initialized. Call load() first.",
+    component="sql_client",
+    invariant="load_before_use",
+)
+```
+
+When wrapping an upstream exception, always use both `cause=exc` **and**
+`raise ... from exc` (see `typed-error-prescription.md` §6).
+
+### FT-9: Convert legacy `AtlanError` raise to typed `AppError` (manual — use migration table)
+
+Look up the legacy constant in `typed-error-prescription.md` §5. The table
+is exhaustive and covers every constant in
+`application_sdk/common/error_codes.py`.
+
+```python
+# Before
+raise ClientError("Engine not initialized. Call load() first.")
+
+# After
+from application_sdk.errors import InternalError
+raise InternalError(
+    message="Engine not initialized. Call load() first.",
+    component="sql_client",
+    invariant="load_before_use",
+)
+```
+
+```python
+# Before
+raise IOError("Object store download failed")
+
+# After
+from application_sdk.errors import DependencyUnavailableError
+raise DependencyUnavailableError(
+    message="Object store download failed",
+    service="object_store",
+    cause=exc,
+) from exc
+```
+
 ---
 
 ## Linting Rules to Enable
@@ -469,3 +674,17 @@ select = [
 
 Note: `TRY300` and `TRY302` can be noisy on existing codebases — introduce separately after
 fixing the higher-severity issues.
+
+To prevent regressions on P12 (untyped builtin raises inside `application_sdk/`),
+a CI-level grep is more practical than a ruff rule (false-positive rate is high
+without a per-file allowlist). A targeted check:
+
+```bash
+# Fail if any bare builtin raise survives in application_sdk/ (outside __post_init__ / validators)
+grep -rnE "raise\s+(ValueError|RuntimeError|Exception)\b" application_sdk/ \
+  | grep -v "__post_init__" | grep -v "# stdlib-interop"
+```
+
+This is tracked under BLDX-1261; enforcement is out of scope for this skill.
+P13 (legacy `AtlanError`) will disappear once BLDX-1261 lands and can be
+enforced by deleting `application_sdk/common/error_codes.py` in v4.0.

--- a/.claude/skills/signal-over-noise/references/error-recovery-patterns.md
+++ b/.claude/skills/signal-over-noise/references/error-recovery-patterns.md
@@ -681,7 +681,7 @@ without a per-file allowlist). A targeted check:
 
 ```bash
 # Fail if any bare builtin raise survives in application_sdk/ (outside __post_init__ / validators)
-grep -rnE "raise\s+(ValueError|RuntimeError|Exception)\b" application_sdk/ \
+grep -rnP "raise\s+(ValueError|RuntimeError|Exception)\b" application_sdk/ \
   | grep -v "__post_init__" | grep -v "# stdlib-interop"
 ```
 

--- a/.claude/skills/signal-over-noise/references/error-recovery-patterns.md
+++ b/.claude/skills/signal-over-noise/references/error-recovery-patterns.md
@@ -692,15 +692,73 @@ Note: `TRY300` and `TRY302` can be noisy on existing codebases — introduce sep
 fixing the higher-severity issues.
 
 To prevent regressions on P12 (untyped builtin raises inside `application_sdk/`),
-a CI-level grep is more practical than a ruff rule (false-positive rate is high
-without a per-file allowlist). A targeted check:
+a CI-level AST check is more practical than a ruff rule (false-positive rate is high
+without a per-file allowlist). A grep-based approach can't correctly exclude raises
+inside `__post_init__` or validator bodies because those raises appear on a different
+line from the function definition. Use this AST-based check instead:
 
 ```bash
-# Fail if any bare builtin raise survives in application_sdk/ (outside interop sites).
-# Note: these -v filters are line-level — they won't exclude a raise on a separate line from
-# its interop comment. Put the "# stdlib-interop" marker on the raise line itself.
-grep -rnP "raise\s+(ValueError|RuntimeError|Exception|TypeError|NotImplementedError|OSError|KeyError|LookupError)\b" application_sdk/ \
-  | grep -v "__post_init__" | grep -v "# stdlib-interop"
+python - <<'PY'
+import ast, pathlib, sys
+
+BUILTIN_RAISES = {
+    "ValueError", "RuntimeError", "Exception", "TypeError",
+    "NotImplementedError", "OSError", "KeyError", "LookupError",
+}
+# Raises inside these methods / decorator names are acceptable stdlib-interop
+INTEROP_METHOD_NAMES = {"__post_init__", "__init__"}
+INTEROP_DECORATOR_NAMES = {"field_validator", "validator"}
+
+class Checker(ast.NodeVisitor):
+    def __init__(self, path: pathlib.Path):
+        self._path = path
+        self._interop_depth = 0
+        self.findings: list[str] = []
+
+    def _is_interop(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+        if node.name in INTEROP_METHOD_NAMES:
+            return True
+        for dec in node.decorator_list:
+            name = (dec.id if isinstance(dec, ast.Name)
+                    else dec.func.id if isinstance(dec, ast.Call) and isinstance(dec.func, ast.Name)
+                    else None)
+            if name in INTEROP_DECORATOR_NAMES:
+                return True
+        return False
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        in_interop = self._is_interop(node)
+        if in_interop:
+            self._interop_depth += 1
+        self.generic_visit(node)
+        if in_interop:
+            self._interop_depth -= 1
+
+    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+
+    def visit_Raise(self, node: ast.Raise) -> None:
+        if self._interop_depth > 0 or node.exc is None:
+            return
+        exc = node.exc
+        name = (exc.id if isinstance(exc, ast.Name)
+                else exc.func.id if isinstance(exc, ast.Call) and isinstance(exc.func, ast.Name)
+                else None)
+        if name in BUILTIN_RAISES:
+            self.findings.append(f"{self._path}:{node.lineno}: raise {name}")
+
+findings: list[str] = []
+for path in pathlib.Path("application_sdk").rglob("*.py"):
+    try:
+        checker = Checker(path)
+        checker.visit(ast.parse(path.read_text(), filename=str(path)))
+        findings.extend(checker.findings)
+    except SyntaxError:
+        pass
+
+if findings:
+    print("\n".join(findings), file=sys.stderr)
+    sys.exit(1)
+PY
 ```
 
 This is tracked under BLDX-1261; enforcement is out of scope for this skill.

--- a/.claude/skills/signal-over-noise/references/typed-error-prescription.md
+++ b/.claude/skills/signal-over-noise/references/typed-error-prescription.md
@@ -122,11 +122,12 @@ principal lacks permission for the resource or action → `AppPermissionDeniedEr
 
 Common situations in `application_sdk/`. Each entry gives a worked example.
 
-Each entry includes a **Subclass code:** annotation — the wire code you get if you
-subclass the leaf and override the `ClassVar`. The inline raise examples in each entry
-emit the leaf's own default code instead (e.g. `InvalidInputError` emits `INVALID_INPUT`,
-not `INVALID_INPUT_MISSING_FIELD`). `code` cannot be passed to the constructor. To emit
-the scenario-specific code, subclass the leaf and override it:
+Each entry includes a **Subclass code:** annotation — the wire code you get
+when you subclass the leaf and override the `ClassVar`. The inline raise
+examples show which leaf to use and which evidence fields to populate; they
+emit the leaf's generic default code (e.g. `INVALID_INPUT`) as shorthand.
+In practice, always wrap them in a subclass that overrides `code` — `code`
+cannot be passed to the constructor. Example:
 
 ```python
 @dataclass(kw_only=True)
@@ -134,15 +135,27 @@ class EngineNotInitializedError(InternalError):
     code: ClassVar[str] = "INTERNAL_ENGINE_NOT_INITIALIZED"
 ```
 
-If the leaf's default code is adequate for triage, use the leaf directly without
-subclassing. Subclass only when a stable, recognisable wire code is required for
-cross-process routing or dashboard attribution.
+**Always subclass.** Cookbook entries below model both subclassed and inline
+forms; treat the subclass form as the default. Sharing a generic code
+(`INTERNAL`, `INVALID_INPUT`, `UNIMPLEMENTED`) collapses unrelated failure modes
+into a single dashboard bucket and makes post-incident triage harder. The one
+exception: use bare `InternalError(classification_pending=True)` at catch-and-
+rewrap sites where the failure mode is genuinely unknown — ADR-0013 §2 documents
+this as the auditable-backlog mechanism.
 
 **Code naming rule**: always start with the category prefix
 (`AUTH_`, `INTERNAL_`, `DEPENDENCY_UNAVAILABLE_`, etc.) so the code is
-self-describing without joining against the category column. No vendor name in
-the code (vendor identity lives in `evidence`). Generic subtypes reused across
-callers are better than hyper-specific ones.
+self-describing without joining against the category column. When all subclasses
+share a sibling module, use that module's domain as a uniform infix in every
+subclass code (`_SQL_`, `_AWS_`, `_REDIS_`, connector name, etc.). Examples:
+every subclass in `application_sdk/clients/_sql_errors.py` uses `_SQL_` —
+`INTERNAL_SQL_ENGINE_NOT_INITIALIZED`, `AUTH_SQL_CLIENT_FAILED`,
+`UNIMPLEMENTED_SQL_CURSOR_TYPE`. Same rule applies to a connector app's
+`app/failures.py` — use the source name as the infix
+(`INTERNAL_REDSHIFT_*`, `AUTH_REDSHIFT_*`). This matches the existing
+migration-table conventions in §5 (e.g. `INTERNAL_SQL_PANDAS`,
+`AUTH_AWS_CREDENTIALS`). No vendor name or free-form label that isn't the
+stable domain token.
 
 ### When to bake defaults into a subclass
 
@@ -166,8 +179,53 @@ class EngineNotInitializedError(InternalError):
 raise EngineNotInitializedError()
 ```
 
-Raise inline (no subclass) only when the leaf's default code is adequate and
-the site appears once; the cookbook entries below show the inline form.
+The raise-site form is always minimal. The subclass absorbs all static defaults;
+the raise site passes only what is genuinely dynamic (typically `cause=` on
+wrapped-exception paths, or a per-site field value like a specific param name).
+
+**Worked end-to-end example** — a sibling errors module with three subclasses
+covering three distinct failure modes (same pattern applies to an SDK sibling
+`_<area>_errors.py` and to a connector app's `app/failures.py`):
+
+```python
+# application_sdk/clients/_sql_errors.py (or app/failures.py for an app)
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import ClassVar
+from application_sdk.errors import AuthError, InternalError, InvalidInputError
+
+# 1. Recurring pattern (4 raise sites) — bake message + evidence
+@dataclass(kw_only=True)
+class EngineNotInitializedError(InternalError):
+    code: ClassVar[str] = "INTERNAL_SQL_ENGINE_NOT_INITIALIZED"
+    message: str = "Engine is not initialized. Call load() first."
+    component: str | None = "sql_client"
+    invariant: str | None = "load_before_use"
+
+# 2. Auth failure — bake code + evidence defaults; raise site supplies cause
+@dataclass(kw_only=True)
+class SqlClientAuthFailedError(AuthError):
+    code: ClassVar[str] = "AUTH_SQL_CLIENT_FAILED"
+    message: str = "SQL client authentication failed"
+    auth_method: str | None = "sql"
+    failure_reason: str | None = "engine_load_failed"
+
+# 3. One-off — bake only code; raise site supplies message + evidence
+@dataclass(kw_only=True)
+class UnsupportedCursorError(UnimplementedError):
+    code: ClassVar[str] = "UNIMPLEMENTED_SQL_CURSOR_TYPE"
+```
+
+```python
+# Raise sites — always minimal
+raise EngineNotInitializedError()                      # no args needed
+raise SqlClientAuthFailedError(cause=exc) from exc     # only dynamic part
+raise UnsupportedCursorError(                          # one-off: per-site context
+    message="Cursor not supported by this driver",
+    operation="sql_run_query",
+    reason="dbapi_cursor_unavailable",
+) from exc
+```
 
 ---
 
@@ -248,13 +306,14 @@ Subclass code: `PERMISSION_DENIED`. Audience: USER (default — correct).
 ```python
 except SomeSourceError as exc:
     raise NotFoundError(
-        message=f"Resource not found: {resource_id}",
+        message="Resource not found",
         resource_type="table",
         resource_identifier=resource_id,
         cause=exc,
     ) from exc
 ```
-Subclass code: `NOT_FOUND_RESOURCE`. Evidence: `resource_type=` and `resource_identifier=`.
+Subclass code: `NOT_FOUND_RESOURCE`. Evidence: `resource_type=` and `resource_identifier=`
+carry the dynamic identity; `message` stays static so dashboard grouping is stable.
 
 ---
 
@@ -262,12 +321,12 @@ Subclass code: `NOT_FOUND_RESOURCE`. Evidence: `resource_type=` and `resource_id
 
 ```python
 raise AlreadyExistsError(
-    message=f"Entity already exists: {entity_id}",
+    message="Entity already exists",
     resource_type="connection",
     resource_identifier=entity_id,
 )
 ```
-Subclass code: `ALREADY_EXISTS_RESOURCE`.
+Subclass code: `ALREADY_EXISTS_RESOURCE`. `resource_identifier=` carries the dynamic ID.
 
 ---
 
@@ -293,11 +352,13 @@ raise DependencyUnavailableError(
     message="Source database unreachable",
     service="source_db",
     target=host,
-    network_error=str(exc),
     cause=exc,
 ) from exc
 ```
 Subclass code: `DEPENDENCY_UNAVAILABLE_NETWORK`. Audience: default PLATFORM.
+`cause=exc` routes the exception detail through `cause_repr` automatically — do
+not also set `network_error=str(exc)` as that duplicates what `cause_repr` already
+carries.
 **Override to USER** when the unreachable host is the customer's own source
 (their firewall / VPC). Add `audience: ClassVar[Audience] = Audience.USER`
 on a minimal subclass if doing this consistently.
@@ -310,12 +371,12 @@ on a minimal subclass if doing this consistently.
 raise DependencyUnavailableError(
     message="Dapr state store unavailable",
     service="dapr_state_store",
-    network_error=str(exc),
     cause=exc,
 ) from exc
 ```
 Subclass code: `DEPENDENCY_UNAVAILABLE_DAPR` / `DEPENDENCY_UNAVAILABLE_TEMPORAL` /
 `DEPENDENCY_UNAVAILABLE_OBJECT_STORE`. Audience: PLATFORM (default — correct).
+Exception detail flows through `cause_repr`; do not also set `network_error=str(exc)`.
 
 ---
 
@@ -355,11 +416,11 @@ raise ResourceExhaustedError(
     message="Worker ran out of memory processing batch",
     resource="heap_memory",
     limit="container_limit",
-    observed=str(exc),
     cause=exc,
 ) from exc
 ```
 Subclass code: `RESOURCE_EXHAUSTED_MEMORY`. Audience: PLATFORM (default — correct).
+Drop `observed=str(exc)` — `cause_repr` already carries the exception text.
 
 ---
 
@@ -580,9 +641,25 @@ Columns: `legacy constant` | `target leaf` | `suggested code` |
 These rules apply to every raise site in `application_sdk/` and in connector
 apps. Enforce them whenever creating or reviewing a raise.
 
-**`message=` is always required.** Set it to the same human-readable text the
-legacy raise used. Don't re-engineer the message during a migration — preserve
-it verbatim. The message is visible in logs, AE, and Temporal history.
+**`message=` is a static summary of what failed.** Bake it on the subclass
+(`message: str = "..."` default) whenever the description is stable across
+raise sites. Per-site override is allowed only when the site has genuinely
+distinct context (e.g. a field name that differs by call site) — but even then,
+see the evidence-fields rule below.
+
+**Never interpolate exception text into `message`.** No `{exc!s}`, `{exc!r}`,
+`str(exc)`, or any `f"...: {exc}"` form. The wrapped exception travels through
+`cause=exc` → `FailureDetails.cause_repr` automatically (sanitised, length-
+capped, secret-redacted). Duplicating it into `message` confuses log grouping,
+breaks dashboard string-matching, and may leak secret detail that `cause_repr`
+would have redacted.
+
+**Domain identifiers go in evidence fields, not the message.** Table names,
+hostnames, field names, and resource IDs belong in `field=`, `service=`,
+`resource_identifier=`, or a subclass-specific evidence field — not embedded in
+the message string. If the identifier is also useful in the message for human
+readability, it must already appear in an evidence field; the message must not
+be the sole carrier.
 
 **`cause=exc` AND `raise typed from exc` when wrapping.** Always apply both.
 They serve different consumers:
@@ -622,25 +699,38 @@ blocks any evidence key matching the exact denylist or the suffix denylist
 
 ---
 
-## §7 — SDK vs app subclassing rule
+## §7 — Subclassing rule (SDK and apps)
 
-**Connector apps** build `app/failures.py` with their own subclasses using
-the `/typed-failures` skill. Every connector app's typed classes live there,
-not in the SDK.
+**Default everywhere**: every distinct failure mode gets its own leaf subclass
+with a stable `code: ClassVar[str]`. This rule applies equally to SDK code and
+connector app code.
 
-**The SDK** raises leaves directly in most cases. There are currently no
-`AppError` subclasses in the SDK itself. (`WORKER_EVICTED_TYPE` is a
-platform-internal special case for k8s pod eviction detection — not a model
-to follow; see §2.)
+- Subclass files in the SDK live in `application_sdk/<area>/errors.py` (domain
+  umbrellas shared across that area) or a sibling `_<area>_errors.py` (narrow
+  internal-only sets, not re-exported from `application_sdk.errors`).
+- Subclass files in connector apps live in `app/failures.py`.
 
-If you are tempted to subclass a leaf in the SDK:
-1. Is there a cross-process recognition need? If not, raise the leaf directly
-   using the leaf's default `code`. If a specific `code` string is needed,
-   subclass and override the `ClassVar` — `code` cannot be set at the raise site.
-2. Does the new subclass bake repeated message+evidence defaults (≥2 call sites)?
-   If yes, that also justifies a subclass (see §4 "When to bake defaults").
-3. Does the new subclass add evidence fields? If yes, that justifies a subclass.
-4. Otherwise: raise the existing leaf directly.
+The subclass may bake `message` and evidence-field defaults when the site is
+recurring; for one-off sites, the subclass may just override `code` and let
+the raise site pass `message`.
+
+**The only acceptable "raise parent leaf directly" pattern** is
+`InternalError(classification_pending=True)` at catch-and-rewrap sites where
+the failure mode is genuinely unknown — ADR-0013 §2 documents this as the
+auditable-backlog mechanism.
+
+**Live precedents in the SDK:**
+- `application_sdk/storage/errors.py` — `StorageError`, `StorageNotFoundError`,
+  `StoragePermissionError`, `StorageConfigError` (domain umbrella + shape subclasses)
+- `application_sdk/credentials/errors.py` — `CredentialError`,
+  `CredentialNotFoundError`, `CredentialParseError`, `CredentialValidationError`
+- `application_sdk/infrastructure/secrets.py` — `SecretStoreError`,
+  `SecretNotFoundError`
+- `application_sdk/app/` — inline single-purpose subclasses:
+  `AppNotFoundError`, `TaskNotFoundError`, `EntrypointContractError`, etc.
+
+(`WORKER_EVICTED_TYPE` is a platform-internal special case for k8s pod eviction
+detection — not a model to follow; see §2.)
 
 ---
 

--- a/.claude/skills/signal-over-noise/references/typed-error-prescription.md
+++ b/.claude/skills/signal-over-noise/references/typed-error-prescription.md
@@ -122,11 +122,11 @@ principal lacks permission for the resource or action → `AppPermissionDeniedEr
 
 Common situations in `application_sdk/`. Each entry gives a worked example.
 
-Each entry includes a **Code:** annotation showing the suggested wire code for that
-scenario. `code` is a `ClassVar[str]` on the leaf class — it cannot be passed to the
-constructor, and inline raise examples emit the leaf's own default code (e.g.
-`InvalidInputError` emits `INVALID_INPUT`). To use the scenario-specific code shown in
-the annotation, subclass the leaf and override the `ClassVar`:
+Each entry includes a **Subclass code:** annotation — the wire code you get if you
+subclass the leaf and override the `ClassVar`. The inline raise examples in each entry
+emit the leaf's own default code instead (e.g. `InvalidInputError` emits `INVALID_INPUT`,
+not `INVALID_INPUT_MISSING_FIELD`). `code` cannot be passed to the constructor. To emit
+the scenario-specific code, subclass the leaf and override it:
 
 ```python
 @dataclass(kw_only=True)
@@ -180,7 +180,7 @@ raise InvalidInputError(
     field="aws_role_arn",
 )
 ```
-Code: `INVALID_INPUT_MISSING_FIELD`. Use `field=` evidence to name the param.
+Subclass code: `INVALID_INPUT_MISSING_FIELD`. Use `field=` evidence to name the param.
 
 ---
 
@@ -194,7 +194,7 @@ raise InternalError(
     invariant="load_before_use",
 )
 ```
-Code: `INTERNAL_ENGINE_NOT_INITIALIZED`. Audience: APP_OWNER.
+Subclass code: `INTERNAL_ENGINE_NOT_INITIALIZED`. Audience: APP_OWNER.
 `component=` names the SDK layer; `invariant=` is a short stable key suitable
 for runbook lookup.
 
@@ -209,7 +209,7 @@ raise AuthError(
     failure_reason="credentials_absent",
 )
 ```
-Code: `AUTH_MISSING_CREDENTIALS`. Audience: USER (default — correct).
+Subclass code: `AUTH_MISSING_CREDENTIALS`. Audience: USER (default — correct).
 
 ---
 
@@ -224,7 +224,7 @@ except HTTPError as exc:
         cause=exc,
     ) from exc
 ```
-Code: `AUTH_REJECTED`. Set `cause=exc` + `from exc` (see §6).
+Subclass code: `AUTH_REJECTED`. Set `cause=exc` + `from exc` (see §6).
 
 ---
 
@@ -239,7 +239,7 @@ except SomeSourceError as exc:
         cause=exc,
     ) from exc
 ```
-Code: `PERMISSION_DENIED`. Audience: USER (default — correct).
+Subclass code: `PERMISSION_DENIED`. Audience: USER (default — correct).
 
 ---
 
@@ -254,7 +254,7 @@ except SomeSourceError as exc:
         cause=exc,
     ) from exc
 ```
-Code: `NOT_FOUND_RESOURCE`. Evidence: `resource_type=` and `resource_identifier=`.
+Subclass code: `NOT_FOUND_RESOURCE`. Evidence: `resource_type=` and `resource_identifier=`.
 
 ---
 
@@ -267,7 +267,7 @@ raise AlreadyExistsError(
     resource_identifier=entity_id,
 )
 ```
-Code: `ALREADY_EXISTS_RESOURCE`.
+Subclass code: `ALREADY_EXISTS_RESOURCE`.
 
 ---
 
@@ -281,7 +281,7 @@ raise RateLimitedError(
     cause=exc,
 ) from exc
 ```
-Code: `RATE_LIMITED_API`. Set `retry_after_seconds=` from response header when
+Subclass code: `RATE_LIMITED_API`. Set `retry_after_seconds=` from response header when
 available.
 
 ---
@@ -297,7 +297,7 @@ raise DependencyUnavailableError(
     cause=exc,
 ) from exc
 ```
-Code: `DEPENDENCY_UNAVAILABLE_NETWORK`. Audience: default PLATFORM.
+Subclass code: `DEPENDENCY_UNAVAILABLE_NETWORK`. Audience: default PLATFORM.
 **Override to USER** when the unreachable host is the customer's own source
 (their firewall / VPC). Add `audience: ClassVar[Audience] = Audience.USER`
 on a minimal subclass if doing this consistently.
@@ -314,7 +314,7 @@ raise DependencyUnavailableError(
     cause=exc,
 ) from exc
 ```
-Code: `DEPENDENCY_UNAVAILABLE_DAPR` / `DEPENDENCY_UNAVAILABLE_TEMPORAL` /
+Subclass code: `DEPENDENCY_UNAVAILABLE_DAPR` / `DEPENDENCY_UNAVAILABLE_TEMPORAL` /
 `DEPENDENCY_UNAVAILABLE_OBJECT_STORE`. Audience: PLATFORM (default — correct).
 
 ---
@@ -329,7 +329,7 @@ raise PreconditionError(
     actual_state="v1",
 )
 ```
-Code: `PRECONDITION_SCHEMA_MISMATCH`.
+Subclass code: `PRECONDITION_SCHEMA_MISMATCH`.
 
 ---
 
@@ -343,7 +343,7 @@ raise AppTimeoutError(
     cause=exc,
 ) from exc
 ```
-Code: `TIMEOUT_QUERY`. Set `operation=` and `timeout_seconds=` from the
+Subclass code: `TIMEOUT_QUERY`. Set `operation=` and `timeout_seconds=` from the
 configured limit.
 
 ---
@@ -359,7 +359,7 @@ raise ResourceExhaustedError(
     cause=exc,
 ) from exc
 ```
-Code: `RESOURCE_EXHAUSTED_MEMORY`. Audience: PLATFORM (default — correct).
+Subclass code: `RESOURCE_EXHAUSTED_MEMORY`. Audience: PLATFORM (default — correct).
 
 ---
 
@@ -373,7 +373,7 @@ raise DataIntegrityError(
     location="transformer:finalize",
 )
 ```
-Code: `DATA_INTEGRITY_ROW_COUNT_MISMATCH`. Audience: APP_OWNER (default).
+Subclass code: `DATA_INTEGRITY_ROW_COUNT_MISMATCH`. Audience: APP_OWNER (default).
 
 ---
 
@@ -386,7 +386,7 @@ raise UnimplementedError(
     reason="server_side_cursor_not_implemented",
 )
 ```
-Code: `UNIMPLEMENTED_CURSOR_TYPE`. Audience: APP_OWNER. Use this — **not**
+Subclass code: `UNIMPLEMENTED_CURSOR_TYPE`. Audience: APP_OWNER. Use this — **not**
 `InternalError` — for known feature gaps so on-call is not paged for an
 expected absence.
 
@@ -403,7 +403,7 @@ raise CancelledError(
     reason="graceful_shutdown",
 )
 ```
-Code: `CANCELLED`.
+Subclass code: `CANCELLED`.
 
 ---
 

--- a/.claude/skills/signal-over-noise/references/typed-error-prescription.md
+++ b/.claude/skills/signal-over-noise/references/typed-error-prescription.md
@@ -1,0 +1,631 @@
+# Typed Error Prescription Reference
+
+Authoritative reference for "which `AppError` should I raise here?" — used by
+the signal-over-noise skill when producing prescriptive fix entries for raise
+sites and silent-swallow → re-raise conversions.
+
+Source of truth: `application_sdk/errors/{base,categories,leaves,wire}.py`.
+Companion for connector apps (not the SDK itself): `.claude/skills/typed-failures/SKILL.md`.
+
+---
+
+## §1 — Why typed errors
+
+Every `AppError` subclass produces a `FailureDetails` wire envelope via
+`AppError.to_failure_details()` (`application_sdk/errors/base.py:78-108`).
+Temporal serialises that envelope into `ApplicationError.details=[…]`. The
+Automation Engine reads `category`, `code`, `audience`, and `retryable` as
+typed, queryable fields — it **never** parses exception strings.
+
+Bare builtin raises (`ValueError`, `RuntimeError`, `Exception`) and legacy
+`AtlanError` subclasses (`ClientError`, `IOError`, etc.) reach AE as opaque
+strings. Dashboard cuts, SLA attribution, and on-call routing are all blind to
+them. Typed errors are not a style preference — they are the failure-attribution
+contract between the SDK and the Automation Engine.
+
+The `FailureDetails` envelope:
+
+```python
+FailureDetails(
+    category: FailureCategory,   # what happened (closed enum)
+    code: str,                   # fine-grained app-owned identifier
+    retryable: bool,             # should the orchestrator retry?
+    audience: Audience,          # who must act: USER / PLATFORM / APP_OWNER
+    message: str,
+    suggested_action: str | None,
+    evidence: dict[str, Any],    # leaf's dataclass fields (auto-populated)
+    cause_repr: str | None,      # sanitised upstream exception string
+)
+```
+
+---
+
+## §2 — The 14 SDK leaves
+
+All defined in `application_sdk/errors/leaves.py`. Import path:
+`from application_sdk.errors import <Leaf>`.
+
+**You may not invent new categories.** The `FailureCategory` enum is closed
+(`application_sdk/errors/categories.py`). If you need a sharper distinction,
+subclass a leaf and override `code` — never add a new category value.
+
+| Leaf class | Category | Default `audience` | Default `retryable` | Raise this when… |
+|---|---|---|---|---|
+| `CancelledError` | CANCELLED | APP_OWNER | False | Caller / workflow signalled cancellation; not a failure |
+| `AppTimeoutError` | TIMEOUT | APP_OWNER | **True** | A bounded wait elapsed (network read, activity start-to-close, heartbeat) |
+| `RateLimitedError` | RATE_LIMITED | USER | **True** | Source or dependency returned 429 or per-key quota signal |
+| `AuthError` | AUTH | USER | False | Credentials missing, expired, or rejected |
+| `AppPermissionDeniedError` | PERMISSION | USER | False | Authenticated but not authorised for the resource or action |
+| `NotFoundError` | NOT_FOUND | USER | False | Targeted entity does not exist |
+| `AlreadyExistsError` | ALREADY_EXISTS | USER | False | Entity the caller tried to create already exists (idempotent-create path) |
+| `InvalidInputError` | INVALID_INPUT | USER | False | Argument or payload malformed irrespective of system state |
+| `PreconditionError` | PRECONDITION | USER | False | Inputs syntactically valid but system state forbids the action |
+| `DependencyUnavailableError` | DEPENDENCY_UNAVAILABLE | **PLATFORM** | **True** | Required platform service down or degraded (Dapr, Temporal, object store, source DB) |
+| `ResourceExhaustedError` | RESOURCE_EXHAUSTED | **PLATFORM** | **True** | Local resource limit hit (OOM, disk full, file handles, worker slots) |
+| `DataIntegrityError` | DATA_INTEGRITY | APP_OWNER | False | Returned data is corrupt or violates expected invariants |
+| `InternalError` | INTERNAL | APP_OWNER | False | SDK or app bug; invariant broken in our code |
+| `UnimplementedError` | UNIMPLEMENTED | APP_OWNER | False | Operation not supported or capability not yet built (known gap, not a bug) |
+
+**Special SDK subclass** — `WorkerEvictedError` (`leaves.py:175-195`) subclasses
+`DependencyUnavailableError` with `code = "WORKER_EVICTED"`. This is the
+precedent for when the SDK itself should subclass a leaf: when a stable wire
+`code` string is needed for cross-process recognition (Temporal serialises only
+the type string, not the Python class). Do not add further SDK subclasses without
+this specific need.
+
+**`audience` override pattern** — when an SDK base default doesn't fit the locus,
+override `audience` on a minimal subclass. Example from the SDK itself:
+`WorkerEvictedError` inherits PLATFORM from `DependencyUnavailableError` and
+keeps it (correct — the pod is platform infrastructure). For connector apps that
+source-side network is `audience=USER` (the customer controls it), so they
+override in their `failures.py`. The SDK's own code should follow the same logic.
+
+---
+
+## §3 — Litmus tests for ambiguous categories
+
+Use these in order. Pick the first rule that applies.
+
+**`DEPENDENCY_UNAVAILABLE` vs `PRECONDITION`**
+If retrying *the same call* without any state change is expected to succeed →
+`DependencyUnavailableError`. If explicit state must change before the call can
+succeed (schema must be updated, version must match, entity must be in a
+different state) → `PreconditionError`.
+
+**`RATE_LIMITED` vs `RESOURCE_EXHAUSTED`**
+429 from a remote endpoint (per-key quota signal) → `RateLimitedError`.
+Local resource limit (OOM, disk full, file handles, worker-slot exhaustion) →
+`ResourceExhaustedError`.
+
+**`ALREADY_EXISTS` vs `PRECONDITION`**
+Entity already exists on an idempotent-create path → `AlreadyExistsError`.
+Resource exists but is in the wrong *state* for the operation →
+`PreconditionError`.
+
+**`UNIMPLEMENTED` vs `INTERNAL`**
+Known capability gap (feature not yet built, dialect not yet supported) →
+`UnimplementedError`. Unexpected invariant violation (our code has a bug) →
+`InternalError`.
+
+**`INVALID_INPUT` vs `PRECONDITION`**
+Payload itself is malformed irrespective of system state (missing required
+field, wrong type, out-of-range value) → `InvalidInputError`. Payload
+syntactically valid but system state blocks the operation → `PreconditionError`.
+
+**`AUTH` vs `PERMISSION`**
+Identity cannot be established (credentials missing, expired, or invalid;
+authentication handshake failed) → `AuthError`. Identity established but the
+principal lacks permission for the resource or action → `AppPermissionDeniedError`.
+
+---
+
+## §4 — SDK raise-context → leaf cookbook
+
+Common situations in `application_sdk/`. Each entry gives a worked example.
+Use the `code` suggestion as-is or append a more specific suffix.
+
+**Code naming rule**: always start with the category prefix
+(`AUTH_`, `INTERNAL_`, `DEPENDENCY_UNAVAILABLE_`, etc.) so the code is
+self-describing without joining against the category column. No vendor name in
+the code (vendor identity lives in `evidence`). Generic subtypes reused across
+callers are better than hyper-specific ones.
+
+---
+
+### Required field / config missing
+
+```python
+# Situation: raise ValueError("X is required")
+raise InvalidInputError(
+    message="aws_role_arn is required",
+    field="aws_role_arn",
+)
+```
+Code: `INVALID_INPUT_MISSING_FIELD`. Use `field=` evidence to name the param.
+
+---
+
+### SDK invariant violated (caller misused the API)
+
+```python
+# Situation: "Engine is not initialized. Call load() first."
+raise InternalError(
+    message="Engine is not initialized. Call load() first.",
+    component="sql_client",
+    invariant="load_before_use",
+)
+```
+Code: `INTERNAL_ENGINE_NOT_INITIALIZED`. Audience: APP_OWNER.
+`component=` names the SDK layer; `invariant=` is a short stable key suitable
+for runbook lookup.
+
+---
+
+### Credentials missing or invalid (no HTTP response)
+
+```python
+raise AuthError(
+    message="No credentials found for connection",
+    auth_method="connection_config",
+    failure_reason="credentials_absent",
+)
+```
+Code: `AUTH_MISSING_CREDENTIALS`. Audience: USER (default — correct).
+
+---
+
+### 401 from source (rejected by remote)
+
+```python
+except HTTPError as exc:
+    raise AuthError(
+        message="Source rejected credentials",
+        auth_method="api_key",
+        failure_reason="http_401",
+        cause=exc,
+    ) from exc
+```
+Code: `AUTH_REJECTED`. Set `cause=exc` + `from exc` (see §6).
+
+---
+
+### 403 from source
+
+```python
+raise AppPermissionDeniedError(
+    message="Permission denied by source",
+    resource=endpoint,
+    required_action="read",
+    cause=exc,
+) from exc
+```
+Code: `PERMISSION_DENIED`. Audience: USER (default — correct).
+
+---
+
+### 404 from source
+
+```python
+raise NotFoundError(
+    message=f"Resource not found: {resource_id}",
+    resource_type="table",
+    resource_identifier=resource_id,
+    cause=exc,
+) from exc
+```
+Code: `NOT_FOUND_RESOURCE`. Evidence: `resource_type=` and `resource_identifier=`.
+
+---
+
+### 409 / idempotent-create conflict
+
+```python
+raise AlreadyExistsError(
+    message=f"Entity already exists: {entity_id}",
+    resource_type="connection",
+    resource_identifier=entity_id,
+)
+```
+Code: `ALREADY_EXISTS_RESOURCE`.
+
+---
+
+### 429 / quota exceeded
+
+```python
+raise RateLimitedError(
+    message="API quota exceeded",
+    limit_type="requests_per_minute",
+    retry_after_seconds=float(retry_after) if retry_after else None,
+    cause=exc,
+) from exc
+```
+Code: `RATE_LIMITED_API`. Set `retry_after_seconds=` from response header when
+available.
+
+---
+
+### Network unreachable / 5xx from source
+
+```python
+raise DependencyUnavailableError(
+    message="Source database unreachable",
+    service="source_db",
+    target=host,
+    network_error=str(exc),
+    cause=exc,
+) from exc
+```
+Code: `DEPENDENCY_UNAVAILABLE_NETWORK`. Audience: default PLATFORM.
+**Override to USER** when the unreachable host is the customer's own source
+(their firewall / VPC). Add `audience: ClassVar[Audience] = Audience.USER`
+on a minimal subclass if doing this consistently.
+
+---
+
+### Dapr / Temporal / object-store outage
+
+```python
+raise DependencyUnavailableError(
+    message="Dapr state store unavailable",
+    service="dapr_state_store",
+    network_error=str(exc),
+    cause=exc,
+) from exc
+```
+Code: `DEPENDENCY_UNAVAILABLE_DAPR` / `DEPENDENCY_UNAVAILABLE_TEMPORAL` /
+`DEPENDENCY_UNAVAILABLE_OBJECT_STORE`. Audience: PLATFORM (default — correct).
+
+---
+
+### Schema mismatch / version conflict
+
+```python
+raise PreconditionError(
+    message="Schema version mismatch; re-run migration",
+    resource="output_schema",
+    expected_state="v2",
+    actual_state="v1",
+)
+```
+Code: `PRECONDITION_SCHEMA_MISMATCH`.
+
+---
+
+### Bounded-wait elapsed (timeout)
+
+```python
+raise AppTimeoutError(
+    message="Query execution exceeded timeout",
+    operation="sql_query",
+    timeout_seconds=30.0,
+    cause=exc,
+) from exc
+```
+Code: `TIMEOUT_QUERY`. Set `operation=` and `timeout_seconds=` from the
+configured limit.
+
+---
+
+### Local OOM / disk full / handle exhaustion
+
+```python
+raise ResourceExhaustedError(
+    message="Worker ran out of memory processing batch",
+    resource="heap_memory",
+    limit="container_limit",
+    observed=str(exc),
+    cause=exc,
+) from exc
+```
+Code: `RESOURCE_EXHAUSTED_MEMORY`. Audience: PLATFORM (default — correct).
+
+---
+
+### Returned data corrupt / invariant violated
+
+```python
+raise DataIntegrityError(
+    message="Row count mismatch after transform",
+    expectation="row_count == source_count",
+    observed=f"{actual} rows vs {expected} expected",
+    location="transformer:finalize",
+)
+```
+Code: `DATA_INTEGRITY_ROW_COUNT_MISMATCH`. Audience: APP_OWNER (default).
+
+---
+
+### Known capability gap
+
+```python
+raise UnimplementedError(
+    message="Cursor type 'server-side' not yet supported",
+    operation="sql_fetch_cursor",
+    reason="server_side_cursor_not_implemented",
+)
+```
+Code: `UNIMPLEMENTED_CURSOR_TYPE`. Audience: APP_OWNER. Use this — **not**
+`InternalError` — for known feature gaps so on-call is not paged for an
+expected absence.
+
+---
+
+### Workflow / caller cancellation
+
+Rarely raised manually — usually propagated from Temporal. If the SDK raises it:
+
+```python
+raise CancelledError(
+    message="Activity cancelled by workflow signal",
+    cancelled_by="workflow",
+    reason="graceful_shutdown",
+)
+```
+Code: `CANCELLED`.
+
+---
+
+## §5 — Exhaustive legacy `AtlanError` → `AppError` migration table
+
+Full mapping of every constant in
+`application_sdk/common/error_codes.py`. Use this as a deterministic lookup
+when converting P13 (legacy `AtlanError`) raise sites.
+
+Columns: `legacy constant` | `target leaf` | `suggested code` |
+`audience override?` | `notes`
+
+### `ClientError` → (`application_sdk/common/error_codes.py:66-105`)
+
+| Legacy constant | Target leaf | Suggested code | Audience override? | Notes |
+|---|---|---|---|---|
+| `REQUEST_VALIDATION_ERROR` | `InvalidInputError` | `INVALID_INPUT_REQUEST_VALIDATION` | — | set `constraint=` with validation details |
+| `INPUT_VALIDATION_ERROR` | `InvalidInputError` | `INVALID_INPUT_VALIDATION` | — | set `field=` if field-level |
+| `CLIENT_AUTH_ERROR` | `AuthError` | `AUTH_CLIENT_FAILED` | — | set `auth_method=` |
+| `HANDLER_AUTH_ERROR` | `AuthError` | `AUTH_HANDLER_FAILED` | — | HTTP handler auth failure |
+| `SQL_CLIENT_AUTH_ERROR` | `AuthError` | `AUTH_SQL_CLIENT_FAILED` | — | set `auth_method="sql"` |
+| `AUTH_TOKEN_REFRESH_ERROR` | `AuthError` | `AUTH_TOKEN_REFRESH_FAILED` | — | set `failure_reason="token_refresh"` |
+| `AUTH_CREDENTIALS_ERROR` | `AuthError` | `AUTH_CREDENTIALS_NOT_FOUND` | — | set `failure_reason="credentials_absent"` |
+| `AUTH_CONFIG_ERROR` | `InvalidInputError` | `INVALID_INPUT_AUTH_CONFIG` | — | configuration error, not a credentials error |
+| `REDIS_CONNECTION_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_REDIS` | — | set `service="redis"` |
+| `REDIS_TIMEOUT_ERROR` | `AppTimeoutError` | `TIMEOUT_REDIS` | — | set `operation="redis_op"` |
+| `REDIS_AUTH_ERROR` | `AuthError` | `AUTH_REDIS_FAILED` | — | set `auth_method="redis_auth"` |
+| `REDIS_PROTOCOL_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_REDIS_PROTOCOL` | — | set `service="redis"`, `network_error=` |
+
+### `ApiError` → (`application_sdk/common/error_codes.py:107-144`)
+
+| Legacy constant | Target leaf | Suggested code | Audience override? | Notes |
+|---|---|---|---|---|
+| `SERVER_START_ERROR` | `InternalError` | `INTERNAL_SERVER_START` | — | server startup invariant |
+| `SERVER_SHUTDOWN_ERROR` | `InternalError` | `INTERNAL_SERVER_SHUTDOWN` | — | |
+| `SERVER_CONFIG_ERROR` | `InvalidInputError` | `INVALID_INPUT_SERVER_CONFIG` | — | bad configuration supplied |
+| `CONFIGURATION_ERROR` | `InvalidInputError` | `INVALID_INPUT_CONFIG` | — | general config error |
+| `LOGGER_SETUP_ERROR` | `InternalError` | `INTERNAL_LOGGER_SETUP` | — | observability setup invariant |
+| `LOGGER_PROCESSING_ERROR` | `InternalError` | `INTERNAL_LOGGER_PROCESSING` | — | |
+| `LOGGER_OTLP_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_OTLP` | — | OTLP collector unreachable |
+| `LOGGER_RESOURCE_ERROR` | `ResourceExhaustedError` | `RESOURCE_EXHAUSTED_LOGGER` | — | |
+| `UNKNOWN_ERROR` | `InternalError` | `INTERNAL_UNKNOWN` | — | set `classification_pending=True` pending triage |
+| `SQL_FILE_ERROR` | `InternalError` | `INTERNAL_SQL_FILE` | — | SQL template / file read failure |
+| `ENDPOINT_ERROR` | `InternalError` | `INTERNAL_ENDPOINT` | — | HTTP endpoint setup/dispatch |
+| `EVENT_TRIGGER_ERROR` | `InternalError` | `INTERNAL_EVENT_TRIGGER` | — | |
+| `MIDDLEWARE_ERROR` | `InternalError` | `INTERNAL_MIDDLEWARE` | — | |
+| `ROUTE_HANDLER_ERROR` | `InternalError` | `INTERNAL_ROUTE_HANDLER` | — | |
+| `LOG_MIDDLEWARE_ERROR` | `InternalError` | `INTERNAL_LOG_MIDDLEWARE` | — | |
+
+### `OrchestratorError` → (`application_sdk/common/error_codes.py:147-159`)
+
+| Legacy constant | Target leaf | Suggested code | Audience override? | Notes |
+|---|---|---|---|---|
+| `ORCHESTRATOR_CLIENT_CONNECTION_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_TEMPORAL` | — | set `service="temporal"` |
+| `ORCHESTRATOR_CLIENT_ACTIVITY_ERROR` | `InternalError` | `INTERNAL_ORCHESTRATOR_ACTIVITY` | — | activity dispatch failure |
+| `ORCHESTRATOR_CLIENT_WORKER_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_TEMPORAL_WORKER` | — | set `service="temporal_worker"` |
+
+### `WorkflowError` → (`application_sdk/common/error_codes.py:161-188`)
+
+| Legacy constant | Target leaf | Suggested code | Audience override? | Notes |
+|---|---|---|---|---|
+| `WORKFLOW_EXECUTION_ERROR` | `InternalError` | `INTERNAL_WORKFLOW_EXECUTION` | — | unexpected workflow failure |
+| `WORKFLOW_CONFIG_ERROR` | `InvalidInputError` | `INVALID_INPUT_WORKFLOW_CONFIG` | — | bad workflow configuration |
+| `WORKFLOW_VALIDATION_ERROR` | `InvalidInputError` | `INVALID_INPUT_WORKFLOW_VALIDATION` | — | set `constraint=` with validation detail |
+| `WORKFLOW_CLIENT_START_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_TEMPORAL_START` | — | set `service="temporal"` |
+| `WORKFLOW_CLIENT_STOP_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_TEMPORAL_STOP` | — | set `service="temporal"` |
+| `WORKFLOW_CLIENT_STATUS_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_TEMPORAL_STATUS` | — | set `service="temporal"` |
+| `WORKFLOW_CLIENT_WORKER_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_TEMPORAL_WORKER` | — | set `service="temporal_worker"` |
+| `WORKFLOW_CLIENT_NOT_FOUND_ERROR` | `NotFoundError` | `NOT_FOUND_WORKFLOW` | — | set `resource_type="workflow"` |
+
+### `IOError` → (`application_sdk/common/error_codes.py:190-277`)
+
+| Legacy constant | Target leaf | Suggested code | Audience override? | Notes |
+|---|---|---|---|---|
+| `INPUT_ERROR` | `InvalidInputError` | `INVALID_INPUT_IO` | — | generic IO input error |
+| `INPUT_LOAD_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_INPUT_LOAD` | — | source load failure (retryable) |
+| `INPUT_PROCESSING_ERROR` | `InternalError` | `INTERNAL_INPUT_PROCESSING` | — | processing invariant |
+| `SQL_QUERY_ERROR` | `InvalidInputError` | `INVALID_INPUT_SQL_QUERY` | USER | bad query from caller |
+| `SQL_QUERY_BATCH_ERROR` | `InternalError` | `INTERNAL_SQL_BATCH` | — | SDK batch execution bug |
+| `SQL_QUERY_PANDAS_ERROR` | `InternalError` | `INTERNAL_SQL_PANDAS` | — | |
+| `SQL_QUERY_DAFT_ERROR` | `InternalError` | `INTERNAL_SQL_DAFT` | — | Daft engine invariant |
+| `JSON_READ_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_JSON_READ` | — | malformed JSON on read |
+| `JSON_BATCH_ERROR` | `InternalError` | `INTERNAL_JSON_BATCH` | — | |
+| `JSON_DAFT_ERROR` | `InternalError` | `INTERNAL_JSON_DAFT` | — | |
+| `JSON_DOWNLOAD_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_JSON_DOWNLOAD` | — | download from object store |
+| `PARQUET_READ_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_PARQUET_READ` | — | corrupt/malformed Parquet |
+| `PARQUET_BATCH_ERROR` | `InternalError` | `INTERNAL_PARQUET_BATCH` | — | |
+| `PARQUET_DAFT_ERROR` | `InternalError` | `INTERNAL_PARQUET_DAFT` | — | |
+| `PARQUET_VALIDATION_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_PARQUET_VALIDATION` | — | schema / row validation |
+| `ICEBERG_READ_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_ICEBERG_READ` | — | |
+| `ICEBERG_DAFT_ERROR` | `InternalError` | `INTERNAL_ICEBERG_DAFT` | — | |
+| `ICEBERG_TABLE_ERROR` | `PreconditionError` | `PRECONDITION_ICEBERG_TABLE` | — | table state blocks operation |
+| `OBJECT_STORE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_OBJECT_STORE` | — | set `service="object_store"` |
+| `OBJECT_STORE_DOWNLOAD_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_OBJECT_STORE_DOWNLOAD` | — | set `service="object_store"` |
+| `OBJECT_STORE_READ_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_OBJECT_STORE_READ` | — | set `service="object_store"` |
+| `STATE_STORE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_STATE_STORE` | — | set `service="dapr_state_store"` |
+| `STATE_STORE_EXTRACT_ERROR` | `InternalError` | `INTERNAL_STATE_STORE_EXTRACT` | — | extraction-phase invariant |
+| `STATE_STORE_VALIDATION_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_STATE_STORE` | — | state data corrupt |
+| `OUTPUT_ERROR` | `InternalError` | `INTERNAL_OUTPUT` | — | generic output failure |
+| `OUTPUT_WRITE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_OUTPUT_WRITE` | — | write destination unavailable |
+| `OUTPUT_STATISTICS_ERROR` | `InternalError` | `INTERNAL_OUTPUT_STATISTICS` | — | stats computation |
+| `OUTPUT_VALIDATION_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_OUTPUT_VALIDATION` | — | output data fails validation |
+| `JSON_WRITE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_JSON_WRITE` | — | write destination |
+| `JSON_BATCH_WRITE_ERROR` | `InternalError` | `INTERNAL_JSON_BATCH_WRITE` | — | |
+| `JSON_DAFT_WRITE_ERROR` | `InternalError` | `INTERNAL_JSON_DAFT_WRITE` | — | |
+| `PARQUET_WRITE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_PARQUET_WRITE` | — | |
+| `PARQUET_DAFT_WRITE_ERROR` | `InternalError` | `INTERNAL_PARQUET_DAFT_WRITE` | — | |
+| `ICEBERG_WRITE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_ICEBERG_WRITE` | — | |
+| `ICEBERG_DAFT_WRITE_ERROR` | `InternalError` | `INTERNAL_ICEBERG_DAFT_WRITE` | — | |
+| `ICEBERG_TABLE_ERROR_OUT` | `PreconditionError` | `PRECONDITION_ICEBERG_TABLE_OUT` | — | table state blocks write |
+| `OBJECT_STORE_WRITE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_OBJECT_STORE_WRITE` | — | set `service="object_store"` |
+| `STATE_STORE_WRITE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_STATE_STORE_WRITE` | — | set `service="dapr_state_store"` |
+
+### `CommonError` → (`application_sdk/common/error_codes.py:279-307`)
+
+| Legacy constant | Target leaf | Suggested code | Audience override? | Notes |
+|---|---|---|---|---|
+| `AWS_REGION_ERROR` | `InvalidInputError` | `INVALID_INPUT_AWS_REGION` | — | bad or missing region config |
+| `AWS_ROLE_ERROR` | `AppPermissionDeniedError` | `PERMISSION_AWS_ROLE` | — | IAM assume-role denied |
+| `AWS_CREDENTIALS_ERROR` | `AuthError` | `AUTH_AWS_CREDENTIALS` | — | set `auth_method="aws_iam"` |
+| `AWS_TOKEN_ERROR` | `AuthError` | `AUTH_AWS_TOKEN` | — | STS token error |
+| `QUERY_PREPARATION_ERROR` | `InternalError` | `INTERNAL_QUERY_PREP` | — | query templating / preparation |
+| `FILTER_PREPARATION_ERROR` | `InternalError` | `INTERNAL_FILTER_PREP` | — | filter expression build |
+| `CREDENTIALS_PARSE_ERROR` | `InvalidInputError` | `INVALID_INPUT_CREDENTIALS_PARSE` | — | malformed credentials config |
+| `CREDENTIALS_RESOLUTION_ERROR` | `AuthError` | `AUTH_CREDENTIALS_RESOLUTION` | — | Dapr secret store / vault |
+| `AZURE_CREDENTIAL_ERROR` | `AuthError` | `AUTH_AZURE_CREDENTIAL` | — | set `auth_method="azure"` |
+| `AZURE_CONNECTION_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_AZURE` | — | set `service="azure"` |
+| `AZURE_SERVICE_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_AZURE_SERVICE` | — | Azure API failure |
+
+### `DocGenError` → (`application_sdk/common/error_codes.py:311-358`)
+
+| Legacy constant | Target leaf | Suggested code | Audience override? | Notes |
+|---|---|---|---|---|
+| `DOCGEN_ERROR` | `InternalError` | `INTERNAL_DOCGEN` | — | generic docgen failure |
+| `DOCGEN_EXPORT_ERROR` | `InternalError` | `INTERNAL_DOCGEN_EXPORT` | — | |
+| `DOCGEN_BUILD_ERROR` | `InternalError` | `INTERNAL_DOCGEN_BUILD` | — | |
+| `MANIFEST_NOT_FOUND_ERROR` | `NotFoundError` | `NOT_FOUND_MANIFEST` | — | set `resource_type="manifest"` |
+| `MANIFEST_PARSE_ERROR` | `InvalidInputError` | `INVALID_INPUT_MANIFEST_PARSE` | — | malformed manifest YAML/JSON |
+| `MANIFEST_VALIDATION_ERROR` | `InvalidInputError` | `INVALID_INPUT_MANIFEST_VALIDATION` | — | set `constraint=` |
+| `MANIFEST_YAML_ERROR` | `InvalidInputError` | `INVALID_INPUT_MANIFEST_YAML` | — | YAML parse error |
+| `DIRECTORY_VALIDATION_ERROR` | `InvalidInputError` | `INVALID_INPUT_DIRECTORY_VALIDATION` | — | |
+| `DIRECTORY_CONTENT_ERROR` | `InvalidInputError` | `INVALID_INPUT_DIRECTORY_CONTENT` | — | |
+| `DIRECTORY_STRUCTURE_ERROR` | `InvalidInputError` | `INVALID_INPUT_DIRECTORY_STRUCTURE` | — | |
+| `DIRECTORY_FILE_ERROR` | `InvalidInputError` | `INVALID_INPUT_DIRECTORY_FILE` | — | missing / malformed file |
+| `MKDOCS_CONFIG_ERROR` | `InvalidInputError` | `INVALID_INPUT_MKDOCS_CONFIG` | — | |
+| `MKDOCS_EXPORT_ERROR` | `InternalError` | `INTERNAL_MKDOCS_EXPORT` | — | MkDocs export subprocess |
+| `MKDOCS_NAV_ERROR` | `InternalError` | `INTERNAL_MKDOCS_NAV` | — | navigation generation |
+| `MKDOCS_BUILD_ERROR` | `InternalError` | `INTERNAL_MKDOCS_BUILD` | — | |
+
+### `ActivityError` → (`application_sdk/common/error_codes.py:361-409`)
+
+| Legacy constant | Target leaf | Suggested code | Audience override? | Notes |
+|---|---|---|---|---|
+| `ACTIVITY_START_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_ACTIVITY_START` | — | Temporal activity start failure |
+| `ACTIVITY_END_ERROR` | `InternalError` | `INTERNAL_ACTIVITY_END` | — | activity teardown invariant |
+| `QUERY_EXTRACTION_ERROR` | `InternalError` | `INTERNAL_QUERY_EXTRACTION` | — | query extraction activity |
+| `QUERY_EXTRACTION_SQL_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_QUERY_SQL` | — | SQL source unreachable during extraction |
+| `QUERY_EXTRACTION_PARSE_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_QUERY_EXTRACTION_PARSE` | — | returned data unparseable |
+| `QUERY_EXTRACTION_VALIDATION_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_QUERY_EXTRACTION_VALIDATION` | — | extracted data fails schema check |
+| `METADATA_EXTRACTION_ERROR` | `InternalError` | `INTERNAL_METADATA_EXTRACTION` | — | generic extraction failure |
+| `METADATA_EXTRACTION_SQL_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_METADATA_SQL` | — | SQL source unreachable |
+| `METADATA_EXTRACTION_REST_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_METADATA_REST` | — | REST source unreachable |
+| `METADATA_EXTRACTION_PARSE_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_METADATA_EXTRACTION_PARSE` | — | |
+| `METADATA_EXTRACTION_VALIDATION_ERROR` | `DataIntegrityError` | `DATA_INTEGRITY_METADATA_EXTRACTION_VALIDATION` | — | |
+| `ATLAN_UPLOAD_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_ATLAN_UPLOAD` | — | set `service="atlan_api"` |
+| `LOCK_ACQUISITION_ERROR` | `DependencyUnavailableError` | `DEPENDENCY_UNAVAILABLE_LOCK_ACQUISITION` | — | set `service="dapr_lock"` |
+| `LOCK_RELEASE_ERROR` | `InternalError` | `INTERNAL_LOCK_RELEASE` | — | lock release invariant |
+| `LOCK_TIMEOUT_ERROR` | `AppTimeoutError` | `TIMEOUT_LOCK_ACQUISITION` | — | set `operation="lock_acquire"` |
+
+---
+
+## §6 — Mandatory raise-site rules
+
+These rules apply to every raise site in `application_sdk/` and in connector
+apps. Enforce them whenever creating or reviewing a raise.
+
+**`message=` is always required.** Set it to the same human-readable text the
+legacy raise used. Don't re-engineer the message during a migration — preserve
+it verbatim. The message is visible in logs, AE, and Temporal history.
+
+**`cause=exc` AND `raise typed from exc` when wrapping.** Always apply both.
+They serve different consumers:
+- `cause=exc` → populates `FailureDetails.cause_repr` (sanitised, length-capped
+  string in the wire envelope; visible to AE dashboards).
+- `from exc` → sets Python's `__cause__` (preserves the in-process traceback
+  for `exc_info=True` in logs and local debugging).
+
+```python
+# Correct — both bindings
+except SomeSourceError as exc:
+    raise DependencyUnavailableError(
+        message="Source unreachable",
+        service="source_db",
+        cause=exc,
+    ) from exc
+```
+
+**Never set `app_name`, `run_id`, or `suggested_action` from inside the SDK.**
+- `app_name` — AE provides via DAG node label (single source of truth).
+- `run_id` — AE attaches from Temporal context at ingest time.
+- `suggested_action` — only set at a *raise site* when the call site has specific
+  user-facing guidance ("regrant Glue read access on the IAM role"). Never
+  default it on the class definition.
+
+**Evidence fields.** Add dataclass fields when the call site has obvious context
+that aids debugging. Use the leaf's existing fields first (`field` on
+`InvalidInputError`, `service`/`target` on `DependencyUnavailableError`, etc.).
+Add a subclass field only when the leaf's existing fields are insufficient.
+Match the restraint in the Athena reference.
+
+**Secret-named evidence keys are rejected by the wire layer.** `wire.py:67-84`
+blocks any evidence key matching the exact denylist or the suffix denylist
+(`_secret`, `_password`, `_token`). Use a safe proxy name (e.g.
+`credential_name` instead of `credential_token`) or omit.
+
+---
+
+## §7 — SDK vs app subclassing rule
+
+**Connector apps** build `app/failures.py` with their own subclasses using
+the `/typed-failures` skill. Every connector app's typed classes live there,
+not in the SDK.
+
+**The SDK** raises leaves directly in most cases. The exception: when a stable
+wire `code` string is needed for *cross-process* recognition across the
+activity/workflow boundary — `WorkerEvictedError` is the only current example
+(`leaves.py:172`, `code = "WORKER_EVICTED"`). The wire type string lets
+workflow code identify the failure without depending on the Python class name.
+
+If you are tempted to subclass a leaf in the SDK:
+1. Is there a cross-process recognition need? If not, raise the leaf directly
+   and set `code` via a keyword arg at the raise site (not supported on the
+   current `ClassVar` design — so if `code` truly needs to vary, subclass).
+2. Does the new subclass add evidence fields? If yes, that justifies a subclass.
+3. Otherwise: raise the existing leaf directly.
+
+---
+
+## §8 — Surface or swallow? Decision tree
+
+When surface mode identifies a silent-swallow pattern and the right fix might
+involve re-raising (FT-1b, FT-3b, FT-5b), use this decision tree:
+
+```
+Does the caller depend on the operation succeeding?
+  YES → typed re-raise (FT-1b / FT-3b / FT-5b)
+  NO  ↓
+Is the exception from an activity body that reaches AE?
+  YES → typed re-raise — failure attribution depends on it
+  NO  ↓
+Does the surrounding code produce a visibly wrong result
+on failure (returns empty/None/False that callers trust)?
+  YES → typed re-raise
+  NO  ↓
+Is this a module-load / __init__ site?
+  YES → typed re-raise (deferred crashes are worse)
+  NO  ↓
+Is this genuinely best-effort cleanup (cache invalidation,
+stats flush, optional side-effect)?
+  YES → log-and-continue (FT-1a / FT-3a / FT-5a)
+        log at DEBUG if failure is expected; WARNING if unexpected
+  NO  → typed re-raise (default — lean toward surfacing)
+```
+
+When uncertain, lean toward typing and surfacing. A `classification_pending=True`
+`InternalError` is better than a silent swallow.

--- a/.claude/skills/signal-over-noise/references/typed-error-prescription.md
+++ b/.claude/skills/signal-over-noise/references/typed-error-prescription.md
@@ -143,6 +143,31 @@ self-describing without joining against the category column. No vendor name in
 the code (vendor identity lives in `evidence`). Generic subtypes reused across
 callers are better than hyper-specific ones.
 
+### When to bake defaults into a subclass
+
+If the same leaf will be raised with the same message and evidence at ≥2 call
+sites, encode those defaults on the subclass itself so each raise site collapses
+to one line. Raise sites pass only what is genuinely dynamic (typically
+`cause=` or a per-site message that names a specific field). Use
+`@dataclass(kw_only=True)` so the subclass can provide defaults for parent
+default-less fields like `message: str` (Python 3.10+).
+
+```python
+# Subclass — typically in a sibling module (see WorkerEvictedError precedent).
+@dataclass(kw_only=True)
+class EngineNotInitializedError(InternalError):
+    code: ClassVar[str] = "INTERNAL_ENGINE_NOT_INITIALIZED"
+    message: str = "Engine is not initialized. Call load() first."
+    component: str | None = "sql_client"
+    invariant: str | None = "load_before_use"
+
+# Raise sites — minimal.
+raise EngineNotInitializedError()
+```
+
+Raise inline (no subclass) only when the leaf's default code is adequate and
+the site appears once; the cookbook entries below show the inline form.
+
 ---
 
 ### Required field / config missing

--- a/.claude/skills/signal-over-noise/references/typed-error-prescription.md
+++ b/.claude/skills/signal-over-noise/references/typed-error-prescription.md
@@ -192,7 +192,7 @@ covering three distinct failure modes (same pattern applies to an SDK sibling
 from __future__ import annotations
 from dataclasses import dataclass
 from typing import ClassVar
-from application_sdk.errors import AuthError, InternalError, InvalidInputError
+from application_sdk.errors import AuthError, InternalError, UnimplementedError
 
 # 1. Recurring pattern (4 raise sites) — bake message + evidence
 @dataclass(kw_only=True)

--- a/.claude/skills/signal-over-noise/references/typed-error-prescription.md
+++ b/.claude/skills/signal-over-noise/references/typed-error-prescription.md
@@ -76,7 +76,7 @@ this specific need.
 **`audience` override pattern** — when an SDK base default doesn't fit the locus,
 override `audience` on a minimal subclass. Example from the SDK itself:
 `WorkerEvictedError` inherits PLATFORM from `DependencyUnavailableError` and
-keeps it (correct — the pod is platform infrastructure). For connector apps that
+keeps it (correct — the pod is platform infrastructure). For connector apps, the
 source-side network is `audience=USER` (the customer controls it), so they
 override in their `failures.py`. The SDK's own code should follow the same logic.
 
@@ -123,9 +123,11 @@ principal lacks permission for the resource or action → `AppPermissionDeniedEr
 
 Common situations in `application_sdk/`. Each entry gives a worked example.
 
-Each entry includes a **Code:** annotation. `code` is a `ClassVar[str]` on the leaf
-class — it cannot be passed to the constructor. To use a specific code, subclass the
-leaf and override it:
+Each entry includes a **Code:** annotation showing the suggested wire code for that
+scenario. `code` is a `ClassVar[str]` on the leaf class — it cannot be passed to the
+constructor, and inline raise examples emit the leaf's own default code (e.g.
+`InvalidInputError` emits `INVALID_INPUT`). To use the scenario-specific code shown in
+the annotation, subclass the leaf and override the `ClassVar`:
 
 ```python
 @dataclass(kw_only=True)
@@ -230,12 +232,13 @@ Code: `AUTH_REJECTED`. Set `cause=exc` + `from exc` (see §6).
 ### 403 from source
 
 ```python
-raise AppPermissionDeniedError(
-    message="Permission denied by source",
-    resource=endpoint,
-    required_action="read",
-    cause=exc,
-) from exc
+except SomeSourceError as exc:
+    raise AppPermissionDeniedError(
+        message="Permission denied by source",
+        resource=endpoint,
+        required_action="read",
+        cause=exc,
+    ) from exc
 ```
 Code: `PERMISSION_DENIED`. Audience: USER (default — correct).
 
@@ -244,12 +247,13 @@ Code: `PERMISSION_DENIED`. Audience: USER (default — correct).
 ### 404 from source
 
 ```python
-raise NotFoundError(
-    message=f"Resource not found: {resource_id}",
-    resource_type="table",
-    resource_identifier=resource_id,
-    cause=exc,
-) from exc
+except SomeSourceError as exc:
+    raise NotFoundError(
+        message=f"Resource not found: {resource_id}",
+        resource_type="table",
+        resource_identifier=resource_id,
+        cause=exc,
+    ) from exc
 ```
 Code: `NOT_FOUND_RESOURCE`. Evidence: `resource_type=` and `resource_identifier=`.
 
@@ -598,12 +602,13 @@ except SomeSourceError as exc:
     ) from exc
 ```
 
-**Never set `app_name`, `run_id`, or `suggested_action` from inside the SDK.**
+**Never set `app_name` or `run_id` from inside the SDK.**
 - `app_name` — AE provides via DAG node label (single source of truth).
 - `run_id` — AE attaches from Temporal context at ingest time.
-- `suggested_action` — only set at a *raise site* when the call site has specific
-  user-facing guidance ("regrant Glue read access on the IAM role"). Never
-  default it on the class definition.
+
+**`suggested_action`** — may be set at a raise site when the call site has specific
+user-facing guidance (e.g. "regrant Glue read access on the IAM role"). Omit when no
+specific action can be prescribed. Never default it on the class definition.
 
 **Evidence fields.** Add dataclass fields when the call site has obvious context
 that aids debugging. Use the leaf's existing fields first (`field` on
@@ -632,10 +637,12 @@ workflow code identify the failure without depending on the Python class name.
 
 If you are tempted to subclass a leaf in the SDK:
 1. Is there a cross-process recognition need? If not, raise the leaf directly
-   and set `code` via a keyword arg at the raise site (not supported on the
-   current `ClassVar` design — so if `code` truly needs to vary, subclass).
-2. Does the new subclass add evidence fields? If yes, that justifies a subclass.
-3. Otherwise: raise the existing leaf directly.
+   using the leaf's default `code`. If a specific `code` string is needed,
+   subclass and override the `ClassVar` — `code` cannot be set at the raise site.
+2. Does the new subclass bake repeated message+evidence defaults (≥2 call sites)?
+   If yes, that also justifies a subclass (see §4 "When to bake defaults").
+3. Does the new subclass add evidence fields? If yes, that justifies a subclass.
+4. Otherwise: raise the existing leaf directly.
 
 ---
 

--- a/.claude/skills/signal-over-noise/references/typed-error-prescription.md
+++ b/.claude/skills/signal-over-noise/references/typed-error-prescription.md
@@ -66,19 +66,19 @@ subclass a leaf and override `code` — never add a new category value.
 | `InternalError` | INTERNAL | APP_OWNER | False | SDK or app bug; invariant broken in our code |
 | `UnimplementedError` | UNIMPLEMENTED | APP_OWNER | False | Operation not supported or capability not yet built (known gap, not a bug) |
 
-**Special SDK subclass** — `WorkerEvictedError` (`leaves.py:175-195`) subclasses
-`DependencyUnavailableError` with `code = "WORKER_EVICTED"`. This is the
-precedent for when the SDK itself should subclass a leaf: when a stable wire
-`code` string is needed for cross-process recognition (Temporal serialises only
-the type string, not the Python class). Do not add further SDK subclasses without
-this specific need.
+**Cross-process type identification** — for failures that must be recognised by
+*string match* across the Temporal activity/workflow boundary, the SDK uses
+`WORKER_EVICTED_TYPE = "WorkerEvicted"` (`leaves.py:172`), a plain string
+constant. The activity wrapper raises Temporal's own
+`ApplicationError(type=WORKER_EVICTED_TYPE)` — **not** an `AppError` subclass.
+Workflow code matches `cause.type == WORKER_EVICTED_TYPE`. This is the
+existing SDK mechanism for cross-process recognition; it does not involve
+subclassing `AppError`.
 
 **`audience` override pattern** — when an SDK base default doesn't fit the locus,
-override `audience` on a minimal subclass. Example from the SDK itself:
-`WorkerEvictedError` inherits PLATFORM from `DependencyUnavailableError` and
-keeps it (correct — the pod is platform infrastructure). For connector apps, the
-source-side network is `audience=USER` (the customer controls it), so they
-override in their `failures.py`. The SDK's own code should follow the same logic.
+override `audience` on a minimal subclass. For connector apps, the source-side
+network is `audience=USER` (the customer controls it), so they override in their
+`failures.py`. The SDK's own code should follow the same logic.
 
 ---
 
@@ -155,7 +155,7 @@ to one line. Raise sites pass only what is genuinely dynamic (typically
 default-less fields like `message: str` (Python 3.10+).
 
 ```python
-# Subclass — typically in a sibling module (see WorkerEvictedError precedent).
+# Subclass — typically in a sibling module (e.g. application_sdk/clients/_sql_errors.py).
 @dataclass(kw_only=True)
 class EngineNotInitializedError(InternalError):
     code: ClassVar[str] = "INTERNAL_ENGINE_NOT_INITIALIZED"
@@ -629,11 +629,11 @@ blocks any evidence key matching the exact denylist or the suffix denylist
 the `/typed-failures` skill. Every connector app's typed classes live there,
 not in the SDK.
 
-**The SDK** raises leaves directly in most cases. The exception: when a stable
-wire `code` string is needed for *cross-process* recognition across the
-activity/workflow boundary — `WorkerEvictedError` is the only current example
-(`leaves.py:172`, `code = "WORKER_EVICTED"`). The wire type string lets
-workflow code identify the failure without depending on the Python class name.
+**The SDK** raises leaves directly in most cases. For *cross-process* type
+recognition across the activity/workflow boundary, the SDK uses a string
+constant (`WORKER_EVICTED_TYPE = "WorkerEvicted"`, `leaves.py:172`) passed to
+Temporal's own `ApplicationError(type=…)` — not an `AppError` subclass. There
+are currently no `AppError` subclasses in the SDK itself.
 
 If you are tempted to subclass a leaf in the SDK:
 1. Is there a cross-process recognition need? If not, raise the leaf directly

--- a/.claude/skills/signal-over-noise/references/typed-error-prescription.md
+++ b/.claude/skills/signal-over-noise/references/typed-error-prescription.md
@@ -66,14 +66,13 @@ subclass a leaf and override `code` — never add a new category value.
 | `InternalError` | INTERNAL | APP_OWNER | False | SDK or app bug; invariant broken in our code |
 | `UnimplementedError` | UNIMPLEMENTED | APP_OWNER | False | Operation not supported or capability not yet built (known gap, not a bug) |
 
-**Cross-process type identification** — for failures that must be recognised by
-*string match* across the Temporal activity/workflow boundary, the SDK uses
-`WORKER_EVICTED_TYPE = "WorkerEvicted"` (`leaves.py:172`), a plain string
-constant. The activity wrapper raises Temporal's own
-`ApplicationError(type=WORKER_EVICTED_TYPE)` — **not** an `AppError` subclass.
-Workflow code matches `cause.type == WORKER_EVICTED_TYPE`. This is the
-existing SDK mechanism for cross-process recognition; it does not involve
-subclassing `AppError`.
+**Platform-internal special case** — `WORKER_EVICTED_TYPE = "WorkerEvicted"`
+(`leaves.py:172`) is a narrow internal mechanism used exclusively to detect
+when Kubernetes has terminated a worker pod mid-activity. The activity wrapper
+raises Temporal's own `ApplicationError(type=WORKER_EVICTED_TYPE)` so the
+workflow retry loop can identify the eviction by string match. This is **not**
+a general pattern: do not use string-typed `ApplicationError` for anything else,
+and do not model new failure types on this approach.
 
 **`audience` override pattern** — when an SDK base default doesn't fit the locus,
 override `audience` on a minimal subclass. For connector apps, the source-side
@@ -629,11 +628,10 @@ blocks any evidence key matching the exact denylist or the suffix denylist
 the `/typed-failures` skill. Every connector app's typed classes live there,
 not in the SDK.
 
-**The SDK** raises leaves directly in most cases. For *cross-process* type
-recognition across the activity/workflow boundary, the SDK uses a string
-constant (`WORKER_EVICTED_TYPE = "WorkerEvicted"`, `leaves.py:172`) passed to
-Temporal's own `ApplicationError(type=…)` — not an `AppError` subclass. There
-are currently no `AppError` subclasses in the SDK itself.
+**The SDK** raises leaves directly in most cases. There are currently no
+`AppError` subclasses in the SDK itself. (`WORKER_EVICTED_TYPE` is a
+platform-internal special case for k8s pod eviction detection — not a model
+to follow; see §2.)
 
 If you are tempted to subclass a leaf in the SDK:
 1. Is there a cross-process recognition need? If not, raise the leaf directly

--- a/.claude/skills/signal-over-noise/references/typed-error-prescription.md
+++ b/.claude/skills/signal-over-noise/references/typed-error-prescription.md
@@ -122,7 +122,20 @@ principal lacks permission for the resource or action → `AppPermissionDeniedEr
 ## §4 — SDK raise-context → leaf cookbook
 
 Common situations in `application_sdk/`. Each entry gives a worked example.
-Use the `code` suggestion as-is or append a more specific suffix.
+
+Each entry includes a **Code:** annotation. `code` is a `ClassVar[str]` on the leaf
+class — it cannot be passed to the constructor. To use a specific code, subclass the
+leaf and override it:
+
+```python
+@dataclass(kw_only=True)
+class EngineNotInitializedError(InternalError):
+    code: ClassVar[str] = "INTERNAL_ENGINE_NOT_INITIALIZED"
+```
+
+If the leaf's default code is adequate for triage, use the leaf directly without
+subclassing. Subclass only when a stable, recognisable wire code is required for
+cross-process routing or dashboard attribution.
 
 **Code naming rule**: always start with the category prefix
 (`AUTH_`, `INTERNAL_`, `DEPENDENCY_UNAVAILABLE_`, etc.) so the code is


### PR DESCRIPTION
## Summary

- **Every distinct failure mode gets its own subclass** — drops the "≥2 sites" threshold; the universal default (SDK and app code alike) is now "distinct failure mode → leaf subclass with stable `code: ClassVar[str]`". §7's SDK-vs-app split collapsed into a single rule.
- **Domain-infix requirement for wire codes** — when subclasses share a sibling module, every code gets a uniform domain infix (e.g. `INTERNAL_SQL_*`, `AUTH_SQL_*`, `UNIMPLEMENTED_SQL_*`), matching the existing §5 migration-table conventions.
- **Static `message=` rule** — §6 rewritten: message is a static summary baked on the subclass; never interpolate `{exc!s}` / `str(exc)` into it (routes through `cause_repr` instead); domain identifiers go in evidence fields.
- **Four cookbook examples fixed** — `NotFoundError`, `AlreadyExistsError`, network-unreachable, and OOM entries had f-string / `str(exc)` anti-patterns; updated to model the new rule.
- **End-to-end worked example** added in §4 showing the three subclass shapes (recurring/baked-defaults, auth/cause-only, one-off/code-only).
- **§7 refreshed** with live SDK precedents (`Storage*`, `Credential*`, `Secret*`, `App*`) replacing the stale "no SDK subclasses" claim.

## Context

Produced by comparing PR #1724 and PR #1737, both generated by successive versions of `/signal-over-noise` against the same target file. #1724 was generated by an earlier version of the skill; #1737 by the version on this branch. The comparison identified two behavioural gaps in the current prescription that caused the two PRs to differ:

1. The "≥2 sites" threshold in the old §7/§4 caused one-off failure modes to fall through to bare parent-leaf raises with generic codes (`INTERNAL`, `INVALID_INPUT`, `UNIMPLEMENTED`).
2. The "preserve message verbatim from legacy raise" framing in the old §6 encouraged embedding `{exc!s}` into `message` when the legacy raise contained it.

## Test plan

- [ ] Read §4, §6, §7 of `typed-error-prescription.md` + SKILL.md FT-8 line as a single document — every example satisfies: (a) each subclass has `code: ClassVar[str]`; (b) no `message=` contains `{exc...}` or `str(exc)`; (c) all subclass codes in a worked module share a domain infix
- [ ] Mentally re-apply to `application_sdk/clients/sql.py`: confirm 8 typed subclasses, `<CATEGORY>_SQL_*` codes, `SqlClientAuthFailedError` with static message + `cause=e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)