### PR TITLE
feat(transformers): add set-last-sync-details primitive (BLDX-1229)

### DIFF
--- a/application_sdk/transformers/atlas/__init__.py
+++ b/application_sdk/transformers/atlas/__init__.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
 
 from pyatlan.model.enums import AtlanConnectorType, EntityStatus
 
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.transformers import TransformerInterface
+from application_sdk.transformers.common.last_sync import resolve_last_sync_details
 from application_sdk.transformers.common.utils import process_text
 
 logger = get_logger(__name__)
@@ -66,7 +67,7 @@ class AtlasTransformer(TransformerInterface):
         self.current_epoch = kwargs.get("current_epoch", "0")
         self.connector_name = connector_name
         self.tenant_id = tenant_id
-        self.entity_class_definitions: Dict[str, Type[Any]] = {
+        self.entity_class_definitions: dict[str, type[Any]] = {
             "DATABASE": Database,
             "SCHEMA": Schema,
             "TABLE": Table,
@@ -81,12 +82,12 @@ class AtlasTransformer(TransformerInterface):
     def transform_metadata(
         self,
         typename: str,
-        dataframe: "daft.DataFrame",
+        dataframe: daft.DataFrame,
         workflow_id: str,
         workflow_run_id: str,
-        entity_class_definitions: Dict[str, Type[Any]] | None = None,
-        **kwargs: Dict[str, Any],
-    ) -> "daft.DataFrame":
+        entity_class_definitions: dict[str, type[Any]] | None = None,
+        **kwargs: dict[str, Any],
+    ) -> daft.DataFrame:
         self.entity_class_definitions = (
             entity_class_definitions or self.entity_class_definitions
         )
@@ -128,12 +129,12 @@ class AtlasTransformer(TransformerInterface):
     def transform_row(
         self,
         typename: str,
-        data: Dict[str, Any],
+        data: dict[str, Any],
         workflow_id: str,
         workflow_run_id: str,
-        entity_class_definitions: Dict[str, Type[Any]] | None = None,
+        entity_class_definitions: dict[str, type[Any]] | None = None,
         **kwargs: Any,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """Transform metadata into an Atlas entity.
 
         This method transforms the provided metadata into an Atlas entity based on
@@ -202,8 +203,8 @@ class AtlasTransformer(TransformerInterface):
         self,
         workflow_id: str,
         workflow_run_id: str,
-        data: Dict[str, Any],
-    ) -> Dict[str, Any]:
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         """Enrich an entity with additional metadata.
 
         This method adds workflow metadata and other attributes to the entity.
@@ -223,11 +224,27 @@ class AtlasTransformer(TransformerInterface):
 
         attributes["status"] = EntityStatus.ACTIVE
         attributes["tenant_id"] = self.tenant_id
-        attributes["last_sync_workflow_name"] = workflow_id
-        attributes["last_sync_run"] = workflow_run_id
-        attributes["last_sync_run_at"] = int(
-            datetime.now(timezone.utc).timestamp() * 1000
-        )
+        # In production the Temporal interceptor populates execution +
+        # correlation context, so the resolver returns the AE-assigned
+        # workflow id slug and end-to-end correlation id — the values
+        # operators actually see in the UI.  The ``workflow_id`` /
+        # ``workflow_run_id`` args carry the *current* (often child)
+        # workflow's Temporal ids, which is what older v2 connectors and
+        # test fixtures pass; treat them as fallbacks only — used when the
+        # context isn't set (CLI tools, unit tests without Temporal).
+        # See BLDX-1229.
+        last_sync = resolve_last_sync_details()
+        if not last_sync.workflow_name and not last_sync.run:
+            # Pure-fallback path.  Expected in tests; in a Temporal worker
+            # this means the interceptor is bypassed and we're about to
+            # stamp the buggy child-wf id again — surface it so the drift
+            # is visible.
+            logger.debug(
+                "Last-sync enrichment using legacy args (execution context empty)"
+            )
+        attributes["last_sync_workflow_name"] = last_sync.workflow_name or workflow_id
+        attributes["last_sync_run"] = last_sync.run or workflow_run_id
+        attributes["last_sync_run_at"] = last_sync.run_at_ms
         attributes["connection_name"] = data.get("connection_name", "")
         attributes["connector_name"] = AtlanConnectorType.get_connector_name(
             data.get("connection_qualified_name", "")

--- a/application_sdk/transformers/common/last_sync.py
+++ b/application_sdk/transformers/common/last_sync.py
@@ -1,0 +1,179 @@
+"""Last-sync details primitive.
+
+Stamps the three asset attributes that identify *which* run last touched an
+asset (``lastSyncRun``, ``lastSyncWorkflowName``, ``lastSyncRunAt``).  Before
+this primitive, every connector hand-rolled these values, usually from
+``input.workflow_id`` and ``ctx.workflow_run_id`` — both of which resolve to
+the *current* (often child) workflow's Temporal id, not the AE-assigned
+workflow that owns the end-to-end run.  The result on assets looked like::
+
+    "lastSyncWorkflowName": "<uuid>-process",   # child wf id, not clickable
+    "lastSyncRun":          "<temporal-run-uuid>"  # internal id, not in UI
+
+The fields are meant for operator debugging (jumping from an asset back to the
+run that produced it).  The right identifiers are the ones the Atlan UI shows
+on the workflow runs page — i.e. the AE-assigned workflow id slug
+(``<connector>-<short>``) plus the correlation id that ties the full
+end-to-end run (extract + publish) together.  Both are available in the
+SDK's execution / correlation context — the AE id is the *topmost* workflow
+id (``workflow.info().parent.workflow_id`` for child workflows the connector
+spawns internally, otherwise ``workflow.info().workflow_id``), and the
+correlation id is propagated through Temporal headers + memo by the
+correlation interceptor.
+
+The primitive resolves both automatically so callers don't need to know about
+workflow id de-referencing.  Explicit overrides are accepted for non-Temporal
+callers (tests, batch tools).
+
+Trade-offs to be aware of:
+
+* ``lastSyncRun`` defaults to the SDK correlation id, which spans the full
+  end-to-end run (extract + publish) but is *not* the same string the Atlan
+  UI uses in the runs-page URL (Temporal's ``run_id``).  Callers that want
+  UI-clickthrough semantics should pass ``run=<temporal_run_id>`` explicitly
+  — the default favours end-to-end correlation per the BLDX-1229 discussion.
+* ``workflow_name`` resolves to ``parent_workflow_id or workflow_id`` — i.e.
+  one level of parent walk-up.  This covers connectors that spawn a single
+  layer of child workflows (the common shape today).  For deeper nesting
+  the resolver would return an intermediate child's id, not the AE top.
+  If multi-level nesting becomes a thing, propagate the AE id via Temporal
+  memo (mirroring how the correlation interceptor handles ``correlation_id``
+  in ``execution/_temporal/interceptors/log.py``) and read it here.
+* ``workflow_name`` is the AE-assigned *slug* (e.g. ``dbt-AMBSvQPJ``), not a
+  human-readable connection name.  The slug is connection-stable (one slug
+  per Atlan connection, regardless of how many times the run fires) which
+  satisfies the operational use case raised on BLDX-1229.  If teams later
+  need the friendly connection name, AE would need to plumb it through as
+  a distinct input field; for now, callers can pass
+  ``workflow_name=<connection_name>`` explicitly to override.
+
+See BLDX-1229 for the design discussion.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from application_sdk.observability import get_correlation_context, get_execution_context
+
+LAST_SYNC_RUN: str = "lastSyncRun"
+LAST_SYNC_WORKFLOW_NAME: str = "lastSyncWorkflowName"
+LAST_SYNC_RUN_AT: str = "lastSyncRunAt"
+
+
+@dataclass(frozen=True)
+class LastSyncDetails:
+    """Resolved last-sync values for a single end-to-end run.
+
+    Attributes:
+        run: Correlation id tying the full run together (extract + publish).
+            Empty string when no correlation context is set.
+        workflow_name: AE-assigned workflow id slug (e.g. ``dbt-AMBSvQPJ``).
+            Resolves to the topmost workflow id — ``parent_workflow_id``
+            when running inside a child workflow, ``workflow_id`` when
+            running at the top.  Empty string outside Temporal.
+        run_at_ms: Epoch milliseconds at the moment the values were
+            resolved.  Always set.
+    """
+
+    run: str
+    workflow_name: str
+    run_at_ms: int
+
+
+def resolve_last_sync_details(
+    *,
+    run: str | None = None,
+    workflow_name: str | None = None,
+    run_at_ms: int | None = None,
+) -> LastSyncDetails:
+    """Resolve last-sync values from the current execution + correlation
+    contexts, with explicit overrides taking precedence.
+
+    Args:
+        run: Override for ``lastSyncRun``.  When ``None`` (default), the
+            correlation id from the current correlation context is used.
+        workflow_name: Override for ``lastSyncWorkflowName``.  When ``None``
+            (default), the topmost workflow id from the current execution
+            context is used (``parent_workflow_id or workflow_id``).
+        run_at_ms: Override for ``lastSyncRunAt``.  When ``None`` (default),
+            the current UTC epoch in milliseconds is used.
+    """
+    if run is None:
+        corr = get_correlation_context()
+        run = corr.correlation_id if corr else ""
+
+    if workflow_name is None:
+        ctx = get_execution_context()
+        workflow_name = ctx.parent_workflow_id or ctx.workflow_id
+
+    if run_at_ms is None:
+        run_at_ms = int(datetime.now(UTC).timestamp() * 1000)
+
+    return LastSyncDetails(run=run, workflow_name=workflow_name, run_at_ms=run_at_ms)
+
+
+def set_last_sync_details(
+    asset: dict[str, Any],
+    *,
+    details: LastSyncDetails | None = None,
+    run: str | None = None,
+    workflow_name: str | None = None,
+    run_at_ms: int | None = None,
+) -> dict[str, Any]:
+    """Stamp ``lastSyncRun`` / ``lastSyncWorkflowName`` / ``lastSyncRunAt``
+    onto an asset dict (mutating in place).
+
+    Asset shape follows the Atlas wire format: keys live under
+    ``asset["attributes"]`` (camelCase).  Missing ``attributes`` is created.
+
+    Args:
+        asset: Asset dict to stamp.  Mutated in place; also returned for
+            chaining.
+        details: Pre-resolved values.  When provided, ``run`` /
+            ``workflow_name`` / ``run_at_ms`` are ignored.  Use this with
+            :func:`set_last_sync_details_bulk` to apply the same values to a
+            batch consistently.
+        run: One-off override for ``lastSyncRun``.  Ignored when ``details``
+            is supplied.  ``None`` (default) auto-resolves from correlation
+            context.
+        workflow_name: One-off override for ``lastSyncWorkflowName``.
+            Ignored when ``details`` is supplied.  ``None`` (default)
+            auto-resolves from execution context.
+        run_at_ms: One-off override for ``lastSyncRunAt``.  Ignored when
+            ``details`` is supplied.  ``None`` (default) uses now.
+    """
+    d = details or resolve_last_sync_details(
+        run=run, workflow_name=workflow_name, run_at_ms=run_at_ms
+    )
+
+    attrs = asset.setdefault("attributes", {})
+    if d.run:
+        attrs[LAST_SYNC_RUN] = d.run
+    if d.workflow_name:
+        attrs[LAST_SYNC_WORKFLOW_NAME] = d.workflow_name
+    attrs[LAST_SYNC_RUN_AT] = d.run_at_ms
+    return asset
+
+
+def set_last_sync_details_bulk(
+    assets: Iterable[dict[str, Any]],
+    *,
+    run: str | None = None,
+    workflow_name: str | None = None,
+    run_at_ms: int | None = None,
+) -> list[dict[str, Any]]:
+    """Stamp last-sync details on every asset in ``assets``.
+
+    Resolves the values **once** so every asset in the batch carries the
+    same ``lastSyncRunAt`` (and the same resolved run / workflow_name when
+    auto-resolved).  Each asset is mutated in place and returned in a list
+    for caller convenience.
+    """
+    details = resolve_last_sync_details(
+        run=run, workflow_name=workflow_name, run_at_ms=run_at_ms
+    )
+    return [set_last_sync_details(a, details=details) for a in assets]

--- a/tests/unit/transformers/atlas/test_atlas_transformer.py
+++ b/tests/unit/transformers/atlas/test_atlas_transformer.py
@@ -17,7 +17,7 @@ only side effect is in-memory mutation of stub objects.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -32,7 +32,7 @@ from application_sdk.transformers.atlas import AtlasTransformer
 class _FakeDataFrame:
     """A minimal stand-in for `daft.DataFrame` exposing iter_rows()."""
 
-    def __init__(self, rows: List[Dict[str, Any]]):
+    def __init__(self, rows: list[dict[str, Any]]):
         self._rows = rows
 
     def iter_rows(self):  # pragma: no cover - generator protocol trivial
@@ -115,22 +115,47 @@ def test_transform_row_lowercase_typename_is_normalized(
     transformer: AtlasTransformer,
 ):
     # Ensures `typename.upper()` converts "database" to a known key.
-    result = transformer.transform_row(
-        "database",
-        {
-            "database_name": "DB",
-        },
-        "wf",
-        "run",
-        connection_name="conn",
-        connection_qualified_name="default/snowflake/1728518400",
+    # Enrichment pulls last-sync values from the SDK's execution +
+    # correlation contexts (BLDX-1229).  Set them explicitly so the
+    # assertions below don't depend on ambient process state.
+    from application_sdk.observability import (
+        CorrelationContext,
+        ExecutionContext,
+        set_correlation_context,
+        set_execution_context,
     )
+
+    set_execution_context(
+        ExecutionContext(
+            execution_type="workflow",
+            workflow_id="dbt-AMBSvQPJ",
+            workflow_run_id="3d4aa53e-f47a-4d2b-b120-79db652ff759",
+        )
+    )
+    set_correlation_context(CorrelationContext(correlation_id="corr-xyz"))
+
+    try:
+        result = transformer.transform_row(
+            "database",
+            {
+                "database_name": "DB",
+            },
+            "wf",
+            "run",
+            connection_name="conn",
+            connection_qualified_name="default/snowflake/1728518400",
+        )
+    finally:
+        set_execution_context(ExecutionContext())
+        set_correlation_context(CorrelationContext())
+
     assert result is not None
     assert result["typeName"] == "Database"
-    # Confirm enrichment metadata propagated.
+    # Confirm enrichment metadata propagated and now reads from context,
+    # not from the legacy ``workflow_id`` / ``workflow_run_id`` args.
     assert result["attributes"]["tenantId"] == "default"
-    assert result["attributes"]["lastSyncWorkflowName"] == "wf"
-    assert result["attributes"]["lastSyncRun"] == "run"
+    assert result["attributes"]["lastSyncWorkflowName"] == "dbt-AMBSvQPJ"
+    assert result["attributes"]["lastSyncRun"] == "corr-xyz"
 
 
 def test_transform_row_overrides_entity_class_definitions(

--- a/tests/unit/transformers/common/test_last_sync.py
+++ b/tests/unit/transformers/common/test_last_sync.py
@@ -1,0 +1,209 @@
+"""Unit tests for the last-sync details primitive (BLDX-1229).
+
+Covers the four interesting paths through ``resolve_last_sync_details`` —
+top-level workflow, child workflow (where the AE-assigned id is exposed via
+``parent_workflow_id``), no execution context (tests / CLI), and explicit
+overrides — plus the two dict-stamping wrappers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from application_sdk.observability import (
+    CorrelationContext,
+    ExecutionContext,
+    set_correlation_context,
+    set_execution_context,
+)
+from application_sdk.transformers.common.last_sync import (
+    LAST_SYNC_RUN,
+    LAST_SYNC_RUN_AT,
+    LAST_SYNC_WORKFLOW_NAME,
+    LastSyncDetails,
+    resolve_last_sync_details,
+    set_last_sync_details,
+    set_last_sync_details_bulk,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_contexts():
+    """Always start each test with empty contexts.
+
+    The SDK's execution / correlation context lives in ContextVars; without
+    a reset, leakage from prior tests would make these assertions flaky.
+    """
+    set_execution_context(ExecutionContext())
+    set_correlation_context(CorrelationContext())
+    yield
+    set_execution_context(ExecutionContext())
+    set_correlation_context(CorrelationContext())
+
+
+# ---------------------------------------------------------------------------
+# resolve_last_sync_details
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_empty_context_returns_empty_strings_and_current_epoch():
+    details = resolve_last_sync_details()
+    assert details.run == ""
+    assert details.workflow_name == ""
+    assert details.run_at_ms > 0  # always populated
+
+
+def test_resolve_top_level_workflow_uses_workflow_id():
+    """Top-level workflow → no parent → workflow_name == workflow_id."""
+    set_execution_context(
+        ExecutionContext(
+            execution_type="workflow",
+            workflow_id="dbt-AMBSvQPJ",
+            workflow_run_id="run-uuid-1",
+        )
+    )
+    set_correlation_context(CorrelationContext(correlation_id="corr-1"))
+
+    details = resolve_last_sync_details()
+    assert details.workflow_name == "dbt-AMBSvQPJ"
+    assert details.run == "corr-1"
+
+
+def test_resolve_child_workflow_prefers_parent_workflow_id():
+    """Child workflow → ``parent_workflow_id`` wins over ``workflow_id``.
+
+    This is the exact bug Chetan hit in the BLDX-1229 thread: from inside
+    a connector's child workflow, ``input.workflow_id`` (= the child's
+    Temporal id, ``<uuid>-process``) was being written to assets instead
+    of the AE-assigned slug.  The resolver picks the topmost id.
+    """
+    set_execution_context(
+        ExecutionContext(
+            execution_type="workflow",
+            workflow_id="64b1330d-4635-4d9d-99c1-1ee2c78105ea-process",
+            workflow_run_id="019dd951-76a9-7125-aa42-86f0bbe36f6a",
+            parent_workflow_id="dbt-AMBSvQPJ",
+            parent_run_id="3d4aa53e-f47a-4d2b-b120-79db652ff759",
+        )
+    )
+    set_correlation_context(CorrelationContext(correlation_id="corr-2"))
+
+    details = resolve_last_sync_details()
+    assert details.workflow_name == "dbt-AMBSvQPJ"
+    assert details.run == "corr-2"
+
+
+def test_resolve_explicit_overrides_beat_context():
+    set_execution_context(
+        ExecutionContext(execution_type="workflow", workflow_id="from-ctx")
+    )
+    set_correlation_context(CorrelationContext(correlation_id="from-ctx"))
+
+    details = resolve_last_sync_details(
+        run="explicit-run",
+        workflow_name="explicit-wf",
+        run_at_ms=1234567890,
+    )
+    assert details.run == "explicit-run"
+    assert details.workflow_name == "explicit-wf"
+    assert details.run_at_ms == 1234567890
+
+
+# ---------------------------------------------------------------------------
+# set_last_sync_details
+# ---------------------------------------------------------------------------
+
+
+def test_set_stamps_camelcase_keys_under_attributes():
+    asset: dict = {"typeName": "Table"}
+    out = set_last_sync_details(
+        asset,
+        run="r",
+        workflow_name="w",
+        run_at_ms=42,
+    )
+    assert out is asset  # mutates in place
+    assert out["attributes"][LAST_SYNC_RUN] == "r"
+    assert out["attributes"][LAST_SYNC_WORKFLOW_NAME] == "w"
+    assert out["attributes"][LAST_SYNC_RUN_AT] == 42
+
+
+def test_set_creates_missing_attributes_key():
+    asset: dict = {}
+    set_last_sync_details(asset, run="r", workflow_name="w", run_at_ms=42)
+    assert "attributes" in asset
+    assert asset["attributes"][LAST_SYNC_RUN] == "r"
+
+
+def test_set_preserves_existing_attributes():
+    asset = {"attributes": {"name": "Customers", "rowCount": 100}}
+    set_last_sync_details(asset, run="r", workflow_name="w", run_at_ms=42)
+    assert asset["attributes"]["name"] == "Customers"
+    assert asset["attributes"]["rowCount"] == 100
+    assert asset["attributes"][LAST_SYNC_RUN_AT] == 42
+
+
+def test_set_skips_empty_run_and_workflow_name_but_always_writes_run_at():
+    """Empty resolutions don't get written — operator dashboards filter on
+    presence, so writing ``""`` would be worse than omitting.  ``runAt`` is
+    always populated (clock is always available) so it's always written."""
+    asset: dict = {}
+    set_last_sync_details(asset, run="", workflow_name="", run_at_ms=42)
+    attrs = asset.get("attributes", {})
+    assert LAST_SYNC_RUN not in attrs
+    assert LAST_SYNC_WORKFLOW_NAME not in attrs
+    assert attrs[LAST_SYNC_RUN_AT] == 42
+
+
+def test_set_details_param_wins_over_individual_overrides():
+    asset: dict = {}
+    details = LastSyncDetails(run="from-details", workflow_name="wf", run_at_ms=1)
+    set_last_sync_details(
+        asset,
+        details=details,
+        run="ignored",
+        workflow_name="ignored",
+        run_at_ms=999,
+    )
+    assert asset["attributes"][LAST_SYNC_RUN] == "from-details"
+    assert asset["attributes"][LAST_SYNC_RUN_AT] == 1
+
+
+# ---------------------------------------------------------------------------
+# set_last_sync_details_bulk
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_applies_same_values_to_every_asset():
+    """Every asset in the batch carries identical lastSync* values — the
+    resolver runs once, not per asset, so the timestamp is stable across
+    the batch."""
+    set_execution_context(
+        ExecutionContext(execution_type="workflow", workflow_id="dbt-XYZ")
+    )
+    set_correlation_context(CorrelationContext(correlation_id="corr-batch"))
+
+    assets = [{"typeName": "Table"}, {"typeName": "Column"}, {"typeName": "Schema"}]
+    out = set_last_sync_details_bulk(assets)
+
+    assert len(out) == 3
+    first_run_at = out[0]["attributes"][LAST_SYNC_RUN_AT]
+    for asset in out:
+        assert asset["attributes"][LAST_SYNC_RUN] == "corr-batch"
+        assert asset["attributes"][LAST_SYNC_WORKFLOW_NAME] == "dbt-XYZ"
+        # Same timestamp across the whole batch — proves the resolver
+        # didn't fire per asset.
+        assert asset["attributes"][LAST_SYNC_RUN_AT] == first_run_at
+
+
+def test_bulk_accepts_explicit_overrides():
+    out = set_last_sync_details_bulk(
+        [{} for _ in range(3)],
+        run="explicit",
+        workflow_name="explicit-wf",
+        run_at_ms=7,
+    )
+    for asset in out:
+        assert asset["attributes"][LAST_SYNC_RUN] == "explicit"
+        assert asset["attributes"][LAST_SYNC_WORKFLOW_NAME] == "explicit-wf"
+        assert asset["attributes"][LAST_SYNC_RUN_AT] == 7


### PR DESCRIPTION
## Summary
- New shared primitive `application_sdk/transformers/common/last_sync.py` that stamps `lastSyncRun` / `lastSyncWorkflowName` / `lastSyncRunAt` on assets, auto-resolving from the SDK's execution + correlation context so connector authors no longer hand-roll wrong values from `input.workflow_id` (child wf id) and `ctx.workflow_run_id` (Temporal run UUID).
- `AtlasTransformer._enrich_entity_with_metadata` rewired to call the resolver. The legacy `workflow_id` / `workflow_run_id` method args become test-only fallbacks, used only when execution context is empty; a `logger.debug` line fires on that path so any production drift back to the old buggy ids is visible in logs.
- Unit tests cover the four resolution paths (top-level wf, child wf using Chetan's exact buggy ids from the thread, no-context, explicit overrides) plus the dict-stamping + bulk variants.

Linear: [BLDX-1229](https://linear.app/atlan-epd/issue/BLDX-1229/create-a-set-last-sync-details-primitive)

## Resolution rules
| Field | Default (auto-resolved) | Override knob |
|---|---|---|
| `lastSyncRun` | SDK correlation id (end-to-end span across extract + publish) | `run=<value>` — e.g. pass Temporal `run_id` if UI clickthrough is preferred |
| `lastSyncWorkflowName` | Topmost workflow id slug (`parent_workflow_id or workflow_id`) — connection-stable; e.g. `dbt-AMBSvQPJ` | `workflow_name=<value>` |
| `lastSyncRunAt` | Current UTC epoch milliseconds | `run_at_ms=<value>` |

## Alignment with the thread consensus

| Concern | Source | This PR |
|---|---|---|
| `input.workflow_id` returns child wf id, want AE id | Chetan | ✅ resolver returns topmost id via `parent_workflow_id or workflow_id` |
| Three fields are right, run = correlation id, workflow_name = initiating workflow, run_at_ms = epoch | Chris | ✅ default mapping |
| `lastSyncWorkflowName` must be connection-stable, not connector-type | Chetan nitpick | ✅ slug is per-connection, not per-type |
| Third-party app developers shouldn't have to know about workflow id de-referencing | Chetan / Prateek | ✅ zero-arg `set_last_sync_details(asset)` works in any Temporal context |
| AE / publish ownership debate | Chris vs Prateek | The primitive is location-neutral — AtlasTransformer-using connectors get the fix for free; publish or AE can call it later without re-deciding the values |

## Known trade-offs (documented in module docstring)
1. **`lastSyncRun` default is correlation_id, not Temporal `run_id`** — favours end-to-end correlation (Chris's call) over UI clickthrough (Chetan's original use case). Worth a confirmation with Chris that the default is right; trivial to flip if not. Callers can override via `run=`.
2. **One-level parent walk-up** — covers today's single-layer child-workflow shape. Deeper nesting would need AE-id propagation via Temporal memo (mirroring the existing correlation_id pattern in `execution/_temporal/interceptors/log.py`). Not in scope.
3. **Slug, not friendly connection name** — `dbt-AMBSvQPJ` style, since that's what the SDK has visibility into today. AE plumbing a separate `connection_name` field through would let the resolver pick that up; not in scope.

## Test plan
- [x] `uv run pytest tests/unit/transformers/atlas/ tests/unit/transformers/common/` — 111 passed
- [x] `uv run pre-commit run --files <touched files>` — clean
- [ ] Manual smoke test of an app that uses `AtlasTransformer` once merged + released, confirming `lastSyncWorkflowName` on a transformed asset matches the workflow slug in the runs-page URL