### PR TITLE
feat(transformers): add set-last-sync-details primitive (BLDX-1229)

### DIFF
--- a/application_sdk/transformers/atlas/__init__.py
+++ b/application_sdk/transformers/atlas/__init__.py
@@ -23,6 +23,12 @@ from application_sdk.transformers.common.utils import process_text
 
 logger = get_logger(__name__)
 
+# Module-level sentinel so the legacy-args fallback warning fires once per
+# process (not once per asset).  In production this surfaces a missing
+# Temporal interceptor or a non-Temporal entry path; in tests the legacy
+# fixtures fire it once, which keeps the test log readable.
+_LEGACY_LAST_SYNC_WARNED: bool = False
+
 
 class AtlasTransformer(TransformerInterface):
     """Transformer for converting metadata into Atlas entities.
@@ -225,9 +231,8 @@ class AtlasTransformer(TransformerInterface):
         attributes["status"] = EntityStatus.ACTIVE
         attributes["tenant_id"] = self.tenant_id
         # In production the Temporal interceptor populates execution +
-        # correlation context, so the resolver returns the AE-assigned
-        # workflow id slug and end-to-end correlation id — the values
-        # operators actually see in the UI.  The ``workflow_id`` /
+        # correlation context, so the resolver returns the AE Temporal
+        # workflow id and end-to-end correlation id.  The ``workflow_id`` /
         # ``workflow_run_id`` args carry the *current* (often child)
         # workflow's Temporal ids, which is what older v2 connectors and
         # test fixtures pass; treat them as fallbacks only — used when the
@@ -235,13 +240,23 @@ class AtlasTransformer(TransformerInterface):
         # See BLDX-1229.
         last_sync = resolve_last_sync_details()
         if not last_sync.workflow_name and not last_sync.run:
-            # Pure-fallback path.  Expected in tests; in a Temporal worker
-            # this means the interceptor is bypassed and we're about to
-            # stamp the buggy child-wf id again — surface it so the drift
-            # is visible.
-            logger.debug(
-                "Last-sync enrichment using legacy args (execution context empty)"
-            )
+            # Pure-fallback path: about to write whatever the caller passed
+            # in the legacy args.  In a Temporal worker this means the
+            # interceptor never ran (regression or non-Temporal entry path)
+            # and we're about to stamp the v2 child-wf id again.  Warn once
+            # per process so the drift is visible; the sentinel keeps test
+            # logs sane even though tests exercise this path many times.
+            global _LEGACY_LAST_SYNC_WARNED
+            if not _LEGACY_LAST_SYNC_WARNED:
+                _LEGACY_LAST_SYNC_WARNED = True
+                logger.warning(
+                    "AtlasTransformer falling back to legacy workflow_id / "
+                    "workflow_run_id args for last-sync enrichment because the "
+                    "SDK execution / correlation context is empty. In a Temporal "
+                    "worker this indicates the SDK's interceptors are not "
+                    "registered; assets will carry the child workflow's Temporal "
+                    "id instead of the AE workflow id (BLDX-1229)."
+                )
         attributes["last_sync_workflow_name"] = last_sync.workflow_name or workflow_id
         attributes["last_sync_run"] = last_sync.run or workflow_run_id
         attributes["last_sync_run_at"] = last_sync.run_at_ms

--- a/application_sdk/transformers/atlas/__init__.py
+++ b/application_sdk/transformers/atlas/__init__.py
@@ -18,7 +18,11 @@ if TYPE_CHECKING:
 
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.transformers import TransformerInterface
-from application_sdk.transformers.common.last_sync import resolve_last_sync_details
+from application_sdk.transformers.common.last_sync import (
+    LastSyncDetails,
+    resolve_last_sync_details,
+    set_last_sync_details_on_asset,
+)
 from application_sdk.transformers.common.utils import process_text
 
 logger = get_logger(__name__)
@@ -182,9 +186,7 @@ class AtlasTransformer(TransformerInterface):
             try:
                 entity_attributes = creator.get_attributes(data)
                 # enrich the entity with workflow metadata
-                enriched_data = self._enrich_entity_with_metadata(
-                    workflow_id, workflow_run_id, data
-                )
+                enriched_data = self._enrich_entity_with_metadata(data)
 
                 entity_attributes["attributes"].update(enriched_data["attributes"])
                 entity_attributes["custom_attributes"].update(
@@ -197,6 +199,39 @@ class AtlasTransformer(TransformerInterface):
                     status=EntityStatus.ACTIVE,
                 )
 
+                # Stamp last-sync details on the typed pyatlan ``Asset``
+                # *before* serialisation — the dict round-trip path is
+                # intentionally not used so all transformations converge on
+                # the single Asset-based primitive (BLDX-1229).  The legacy
+                # ``workflow_id`` / ``workflow_run_id`` method args are
+                # passed only as fallbacks: the resolver reads execution +
+                # correlation context first (set by the Temporal
+                # interceptor in production), and the explicit args are
+                # used only when the context is empty (CLI tools, unit
+                # tests without Temporal).
+                resolved = resolve_last_sync_details()
+                if not resolved.workflow_name and not resolved.run:
+                    global _LEGACY_LAST_SYNC_WARNED
+                    if not _LEGACY_LAST_SYNC_WARNED:
+                        _LEGACY_LAST_SYNC_WARNED = True
+                        logger.warning(
+                            "AtlasTransformer falling back to legacy "
+                            "workflow_id / workflow_run_id args for last-sync "
+                            "enrichment because the SDK execution / correlation "
+                            "context is empty. In a Temporal worker this "
+                            "indicates the SDK's interceptors are not registered; "
+                            "assets will carry the child workflow's Temporal id "
+                            "instead of the AE workflow id (BLDX-1229)."
+                        )
+                set_last_sync_details_on_asset(
+                    entity,
+                    details=LastSyncDetails(
+                        run=resolved.run or workflow_run_id,
+                        workflow_name=resolved.workflow_name or workflow_id,
+                        run_at_ms=resolved.run_at_ms,
+                    ),
+                )
+
                 return entity.dict(by_alias=True, exclude_none=True, exclude_unset=True)
             except Exception:
                 logger.error("Error transforming entity: %s", typename, exc_info=True)
@@ -207,59 +242,23 @@ class AtlasTransformer(TransformerInterface):
 
     def _enrich_entity_with_metadata(
         self,
-        workflow_id: str,
-        workflow_run_id: str,
         data: dict[str, Any],
     ) -> dict[str, Any]:
-        """Enrich an entity with additional metadata.
+        """Enrich an entity with non-last-sync metadata from the source row.
 
-        This method adds workflow metadata and other attributes to the entity.
-
-        Args:
-            entity (Asset): The entity to enrich.
-            workflow_id (str): ID of the workflow.
-            workflow_run_id (str): ID of the workflow run.
-            data (Dict[str, Any]): Additional data for enrichment.
-
-        Returns:
-            Any: The enriched entity.
+        Returns the attributes that get merged into the pyatlan asset
+        construction kwargs.  Last-sync stamping is intentionally *not*
+        done here — it happens after entity construction via
+        :func:`set_last_sync_details_on_asset` on the typed Asset, so the
+        single Asset-based primitive is the only path that writes those
+        fields (BLDX-1229).
         """
 
-        attributes = {}
-        custom_attributes = {}
+        attributes: dict[str, Any] = {}
+        custom_attributes: dict[str, Any] = {}
 
         attributes["status"] = EntityStatus.ACTIVE
         attributes["tenant_id"] = self.tenant_id
-        # In production the Temporal interceptor populates execution +
-        # correlation context, so the resolver returns the AE Temporal
-        # workflow id and end-to-end correlation id.  The ``workflow_id`` /
-        # ``workflow_run_id`` args carry the *current* (often child)
-        # workflow's Temporal ids, which is what older v2 connectors and
-        # test fixtures pass; treat them as fallbacks only — used when the
-        # context isn't set (CLI tools, unit tests without Temporal).
-        # See BLDX-1229.
-        last_sync = resolve_last_sync_details()
-        if not last_sync.workflow_name and not last_sync.run:
-            # Pure-fallback path: about to write whatever the caller passed
-            # in the legacy args.  In a Temporal worker this means the
-            # interceptor never ran (regression or non-Temporal entry path)
-            # and we're about to stamp the v2 child-wf id again.  Warn once
-            # per process so the drift is visible; the sentinel keeps test
-            # logs sane even though tests exercise this path many times.
-            global _LEGACY_LAST_SYNC_WARNED
-            if not _LEGACY_LAST_SYNC_WARNED:
-                _LEGACY_LAST_SYNC_WARNED = True
-                logger.warning(
-                    "AtlasTransformer falling back to legacy workflow_id / "
-                    "workflow_run_id args for last-sync enrichment because the "
-                    "SDK execution / correlation context is empty. In a Temporal "
-                    "worker this indicates the SDK's interceptors are not "
-                    "registered; assets will carry the child workflow's Temporal "
-                    "id instead of the AE workflow id (BLDX-1229)."
-                )
-        attributes["last_sync_workflow_name"] = last_sync.workflow_name or workflow_id
-        attributes["last_sync_run"] = last_sync.run or workflow_run_id
-        attributes["last_sync_run_at"] = last_sync.run_at_ms
         attributes["connection_name"] = data.get("connection_name", "")
         attributes["connector_name"] = AtlanConnectorType.get_connector_name(
             data.get("connection_qualified_name", "")

--- a/application_sdk/transformers/atlas/__init__.py
+++ b/application_sdk/transformers/atlas/__init__.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
 
 from pyatlan.model.enums import AtlanConnectorType, EntityStatus
 
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.transformers import TransformerInterface
+from application_sdk.transformers.common.last_sync import resolve_last_sync_details
 from application_sdk.transformers.common.utils import process_text
 
 logger = get_logger(__name__)
@@ -66,7 +67,7 @@ class AtlasTransformer(TransformerInterface):
         self.current_epoch = kwargs.get("current_epoch", "0")
         self.connector_name = connector_name
         self.tenant_id = tenant_id
-        self.entity_class_definitions: Dict[str, Type[Any]] = {
+        self.entity_class_definitions: dict[str, type[Any]] = {
             "DATABASE": Database,
             "SCHEMA": Schema,
             "TABLE": Table,
@@ -81,12 +82,12 @@ class AtlasTransformer(TransformerInterface):
     def transform_metadata(
         self,
         typename: str,
-        dataframe: "daft.DataFrame",
+        dataframe: daft.DataFrame,
         workflow_id: str,
         workflow_run_id: str,
-        entity_class_definitions: Dict[str, Type[Any]] | None = None,
-        **kwargs: Dict[str, Any],
-    ) -> "daft.DataFrame":
+        entity_class_definitions: dict[str, type[Any]] | None = None,
+        **kwargs: dict[str, Any],
+    ) -> daft.DataFrame:
         self.entity_class_definitions = (
             entity_class_definitions or self.entity_class_definitions
         )
@@ -128,12 +129,12 @@ class AtlasTransformer(TransformerInterface):
     def transform_row(
         self,
         typename: str,
-        data: Dict[str, Any],
+        data: dict[str, Any],
         workflow_id: str,
         workflow_run_id: str,
-        entity_class_definitions: Dict[str, Type[Any]] | None = None,
+        entity_class_definitions: dict[str, type[Any]] | None = None,
         **kwargs: Any,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """Transform metadata into an Atlas entity.
 
         This method transforms the provided metadata into an Atlas entity based on
@@ -202,8 +203,8 @@ class AtlasTransformer(TransformerInterface):
         self,
         workflow_id: str,
         workflow_run_id: str,
-        data: Dict[str, Any],
-    ) -> Dict[str, Any]:
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         """Enrich an entity with additional metadata.
 
         This method adds workflow metadata and other attributes to the entity.
@@ -223,11 +224,27 @@ class AtlasTransformer(TransformerInterface):
 
         attributes["status"] = EntityStatus.ACTIVE
         attributes["tenant_id"] = self.tenant_id
-        attributes["last_sync_workflow_name"] = workflow_id
-        attributes["last_sync_run"] = workflow_run_id
-        attributes["last_sync_run_at"] = int(
-            datetime.now(timezone.utc).timestamp() * 1000
-        )
+        # In production the Temporal interceptor populates execution +
+        # correlation context, so the resolver returns the AE-assigned
+        # workflow id slug and end-to-end correlation id — the values
+        # operators actually see in the UI.  The ``workflow_id`` /
+        # ``workflow_run_id`` args carry the *current* (often child)
+        # workflow's Temporal ids, which is what older v2 connectors and
+        # test fixtures pass; treat them as fallbacks only — used when the
+        # context isn't set (CLI tools, unit tests without Temporal).
+        # See BLDX-1229.
+        last_sync = resolve_last_sync_details()
+        if not last_sync.workflow_name and not last_sync.run:
+            # Pure-fallback path.  Expected in tests; in a Temporal worker
+            # this means the interceptor is bypassed and we're about to
+            # stamp the buggy child-wf id again — surface it so the drift
+            # is visible.
+            logger.debug(
+                "Last-sync enrichment using legacy args (execution context empty)"
+            )
+        attributes["last_sync_workflow_name"] = last_sync.workflow_name or workflow_id
+        attributes["last_sync_run"] = last_sync.run or workflow_run_id
+        attributes["last_sync_run_at"] = last_sync.run_at_ms
         attributes["connection_name"] = data.get("connection_name", "")
         attributes["connector_name"] = AtlanConnectorType.get_connector_name(
             data.get("connection_qualified_name", "")

--- a/application_sdk/transformers/common/last_sync.py
+++ b/application_sdk/transformers/common/last_sync.py
@@ -4,48 +4,50 @@ Stamps the three asset attributes that identify *which* run last touched an
 asset (``lastSyncRun``, ``lastSyncWorkflowName``, ``lastSyncRunAt``).  Before
 this primitive, every connector hand-rolled these values, usually from
 ``input.workflow_id`` and ``ctx.workflow_run_id`` — both of which resolve to
-the *current* (often child) workflow's Temporal id, not the AE-assigned
+the *current* (often child) workflow's Temporal id, not the AE-dispatched
 workflow that owns the end-to-end run.  The result on assets looked like::
 
-    "lastSyncWorkflowName": "<uuid>-process",   # child wf id, not clickable
-    "lastSyncRun":          "<temporal-run-uuid>"  # internal id, not in UI
+    "lastSyncWorkflowName": "<uuid>-extract",   # child wf id, not clickable to AE
+    "lastSyncRun":          "<temporal-run-uuid>"  # internal id, not propagated
 
-The fields are meant for operator debugging (jumping from an asset back to the
-run that produced it).  The right identifiers are the ones the Atlan UI shows
-on the workflow runs page — i.e. the AE-assigned workflow id slug
-(``<connector>-<short>``) plus the correlation id that ties the full
-end-to-end run (extract + publish) together.  Both are available in the
-SDK's execution / correlation context — the AE id is the *topmost* workflow
-id (``workflow.info().parent.workflow_id`` for child workflows the connector
-spawns internally, otherwise ``workflow.info().workflow_id``), and the
-correlation id is propagated through Temporal headers + memo by the
-correlation interceptor.
+The primitive resolves the values from the SDK's execution + correlation
+context, which the Temporal interceptor already populates:
 
-The primitive resolves both automatically so callers don't need to know about
-workflow id de-referencing.  Explicit overrides are accepted for non-Temporal
-callers (tests, batch tools).
+* ``lastSyncWorkflowName`` ← the **AE-dispatched workflow's Temporal id**,
+  picked up via ``parent_workflow_id`` when a connector workflow is running
+  inside an AE-spawned child (``workflow.info().parent``); otherwise the
+  top-level ``workflow_id``.  This is a run-unique UUID (e.g.
+  ``4b9eade4-de53-4b69-9010-2446e0a8f85c``) — clickable from an asset back
+  to that exact AE run's history in Temporal UI for debugging.
+* ``lastSyncRun`` ← the correlation id that ties the full end-to-end run
+  (extract + publish) together; propagated through Temporal headers + memo
+  by the correlation interceptor.
+* ``lastSyncRunAt`` ← the current UTC epoch in milliseconds.
+
+The primitive resolves these automatically so callers don't need to know
+about workflow id de-referencing.  Explicit overrides are accepted for
+non-Temporal callers (tests, batch tools).
 
 Trade-offs to be aware of:
 
-* ``lastSyncRun`` defaults to the SDK correlation id, which spans the full
-  end-to-end run (extract + publish) but is *not* the same string the Atlan
-  UI uses in the runs-page URL (Temporal's ``run_id``).  Callers that want
-  UI-clickthrough semantics should pass ``run=<temporal_run_id>`` explicitly
-  — the default favours end-to-end correlation per the BLDX-1229 discussion.
-* ``workflow_name`` resolves to ``parent_workflow_id or workflow_id`` — i.e.
-  one level of parent walk-up.  This covers connectors that spawn a single
-  layer of child workflows (the common shape today).  For deeper nesting
-  the resolver would return an intermediate child's id, not the AE top.
-  If multi-level nesting becomes a thing, propagate the AE id via Temporal
-  memo (mirroring how the correlation interceptor handles ``correlation_id``
-  in ``execution/_temporal/interceptors/log.py``) and read it here.
-* ``workflow_name`` is the AE-assigned *slug* (e.g. ``dbt-AMBSvQPJ``), not a
-  human-readable connection name.  The slug is connection-stable (one slug
-  per Atlan connection, regardless of how many times the run fires) which
-  satisfies the operational use case raised on BLDX-1229.  If teams later
-  need the friendly connection name, AE would need to plumb it through as
-  a distinct input field; for now, callers can pass
-  ``workflow_name=<connection_name>`` explicitly to override.
+* ``lastSyncRun`` defaults to the SDK correlation id (end-to-end span across
+  extract + publish) rather than the Temporal ``run_id`` that appears in the
+  Atlan UI's runs-page URL.  Callers that want UI-clickthrough semantics
+  should pass ``run=<temporal_run_id>`` explicitly.
+* ``workflow_name`` returns the **AE Temporal workflow_id** — a run-unique
+  UUID — *not* the Atlan UI's workflow slug (the ``<connector>-<short>``
+  string in URLs like ``…/workflows/profile/dbt-AMBSvQPJ/…``).  The UI slug
+  isn't plumbed through to the SDK today.  Connection identity is already
+  carried on assets via ``connectionName`` / ``connectionQualifiedName``
+  (separate fields, not ``lastSyncWorkflowName``).  Callers who want the UI
+  slug or a friendly connection name in this field can pass
+  ``workflow_name=<value>`` explicitly.
+* The resolver walks **one level** of ``info.parent``.  This covers
+  connectors that spawn a single layer of child workflows below the AE
+  parent (the common shape today).  Deeper nesting would need the AE id
+  propagated via Temporal memo (mirroring how the correlation interceptor
+  handles ``correlation_id`` in
+  ``execution/_temporal/interceptors/log.py``).
 
 See BLDX-1229 for the design discussion.
 """

--- a/application_sdk/transformers/common/last_sync.py
+++ b/application_sdk/transformers/common/last_sync.py
@@ -1,11 +1,12 @@
 """Last-sync details primitive.
 
 Stamps the three asset attributes that identify *which* run last touched an
-asset (``lastSyncRun``, ``lastSyncWorkflowName``, ``lastSyncRunAt``).  Before
-this primitive, every connector hand-rolled these values, usually from
-``input.workflow_id`` and ``ctx.workflow_run_id`` — both of which resolve to
-the *current* (often child) workflow's Temporal id, not the AE-dispatched
-workflow that owns the end-to-end run.  The result on assets looked like::
+asset (``last_sync_run``, ``last_sync_workflow_name``, ``last_sync_run_at``).
+Before this primitive, every connector hand-rolled these values, usually
+from ``input.workflow_id`` and ``ctx.workflow_run_id`` — both of which
+resolve to the *current* (often child) workflow's Temporal id, not the
+AE-dispatched workflow that owns the end-to-end run.  The result on assets
+looked like::
 
     "lastSyncWorkflowName": "<uuid>-extract",   # child wf id, not clickable to AE
     "lastSyncRun":          "<temporal-run-uuid>"  # internal id, not propagated
@@ -13,40 +14,56 @@ workflow that owns the end-to-end run.  The result on assets looked like::
 The primitive resolves the values from the SDK's execution + correlation
 context, which the Temporal interceptor already populates:
 
-* ``lastSyncWorkflowName`` ← the **AE-dispatched workflow's Temporal id**,
-  picked up via ``parent_workflow_id`` when a connector workflow is running
-  inside an AE-spawned child (``workflow.info().parent``); otherwise the
-  top-level ``workflow_id``.  This is a run-unique UUID (e.g.
-  ``4b9eade4-de53-4b69-9010-2446e0a8f85c``) — clickable from an asset back
-  to that exact AE run's history in Temporal UI for debugging.
-* ``lastSyncRun`` ← the correlation id that ties the full end-to-end run
-  (extract + publish) together; propagated through Temporal headers + memo
-  by the correlation interceptor.
-* ``lastSyncRunAt`` ← the current UTC epoch in milliseconds.
+* ``last_sync_workflow_name`` ← the **AE-dispatched workflow's Temporal
+  id**, picked up via ``parent_workflow_id`` when a connector workflow is
+  running inside an AE-spawned child (``workflow.info().parent``);
+  otherwise the top-level ``workflow_id``.  This is a run-unique UUID
+  (e.g. ``4b9eade4-de53-4b69-9010-2446e0a8f85c``) — clickable from an
+  asset back to that exact AE run's history in Temporal UI for debugging.
+* ``last_sync_run`` ← the correlation id that ties the full end-to-end
+  run (extract + publish) together; propagated through Temporal headers
+  + memo by the correlation interceptor.
+* ``last_sync_run_at`` ← the current UTC epoch in milliseconds (pyatlan
+  / pydantic auto-converts to a ``datetime`` internally).
 
 The primitive resolves these automatically so callers don't need to know
 about workflow id de-referencing.  Explicit overrides are accepted for
 non-Temporal callers (tests, batch tools).
 
+API surface — single recommended path:
+
+* :func:`set_last_sync_details_on_asset` /
+  :func:`set_last_sync_details_on_assets_bulk` — operate on pyatlan
+  ``Asset`` (or any subclass: ``Database``, ``Table``, ``Column``, …).
+  Transformation should stay on the typed pyatlan object end-to-end so
+  callers don't hand-roll camelCase keys or know the wire format.
+
+Earlier iterations of this primitive also exposed dict-shaped helpers
+(``set_last_sync_details`` / ``set_last_sync_details_bulk``) for callers
+that produced ``dict[str, Any]`` assets.  Those were removed deliberately
+to close the aperture for new code adopting non-Asset transformation
+patterns — pyatlan ``Asset`` is the recommended transformation target,
+and a single API enforces that.  See BLDX-1229.
+
 Trade-offs to be aware of:
 
-* ``lastSyncRun`` defaults to the SDK correlation id (end-to-end span across
-  extract + publish) rather than the Temporal ``run_id`` that appears in the
-  Atlan UI's runs-page URL.  Callers that want UI-clickthrough semantics
-  should pass ``run=<temporal_run_id>`` explicitly.
-* ``workflow_name`` returns the **AE Temporal workflow_id** — a run-unique
-  UUID — *not* the Atlan UI's workflow slug (the ``<connector>-<short>``
-  string in URLs like ``…/workflows/profile/dbt-AMBSvQPJ/…``).  The UI slug
-  isn't plumbed through to the SDK today.  Connection identity is already
-  carried on assets via ``connectionName`` / ``connectionQualifiedName``
-  (separate fields, not ``lastSyncWorkflowName``).  Callers who want the UI
-  slug or a friendly connection name in this field can pass
-  ``workflow_name=<value>`` explicitly.
-* The resolver walks **one level** of ``info.parent``.  This covers
-  connectors that spawn a single layer of child workflows below the AE
-  parent (the common shape today).  Deeper nesting would need the AE id
-  propagated via Temporal memo (mirroring how the correlation interceptor
-  handles ``correlation_id`` in
+* ``last_sync_run`` defaults to the SDK correlation id (end-to-end span
+  across extract + publish) rather than the Temporal ``run_id`` that
+  appears in the Atlan UI's runs-page URL.  Callers that want UI
+  clickthrough semantics should pass ``run=<temporal_run_id>``
+  explicitly.
+* ``workflow_name`` returns the **AE Temporal workflow_id** — a
+  run-unique UUID — *not* the Atlan UI's workflow slug (the
+  ``<connector>-<short>`` string in URLs like
+  ``…/workflows/profile/dbt-AMBSvQPJ/…``).  The UI slug isn't plumbed
+  through to the SDK today.  Connection identity is already carried on
+  assets via ``connection_name`` / ``connection_qualified_name``
+  (separate fields).  Callers who want the UI slug or a friendly
+  connection name in this field can pass ``workflow_name=<value>``
+  explicitly.
+* The resolver walks **one level** of ``info.parent``.  Deeper nesting
+  would need the AE id propagated via Temporal memo (mirroring how the
+  correlation interceptor handles ``correlation_id`` in
   ``execution/_temporal/interceptors/log.py``).
 
 See BLDX-1229 for the design discussion.
@@ -57,13 +74,12 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING
 
 from application_sdk.observability import get_correlation_context, get_execution_context
 
-LAST_SYNC_RUN: str = "lastSyncRun"
-LAST_SYNC_WORKFLOW_NAME: str = "lastSyncWorkflowName"
-LAST_SYNC_RUN_AT: str = "lastSyncRunAt"
+if TYPE_CHECKING:
+    from pyatlan.model.assets import Asset
 
 
 @dataclass(frozen=True)
@@ -73,7 +89,7 @@ class LastSyncDetails:
     Attributes:
         run: Correlation id tying the full run together (extract + publish).
             Empty string when no correlation context is set.
-        workflow_name: AE-assigned workflow id slug (e.g. ``dbt-AMBSvQPJ``).
+        workflow_name: AE-assigned workflow id (UUID, run-unique).
             Resolves to the topmost workflow id — ``parent_workflow_id``
             when running inside a child workflow, ``workflow_id`` when
             running at the top.  Empty string outside Temporal.
@@ -96,13 +112,13 @@ def resolve_last_sync_details(
     contexts, with explicit overrides taking precedence.
 
     Args:
-        run: Override for ``lastSyncRun``.  When ``None`` (default), the
+        run: Override for ``last_sync_run``.  When ``None`` (default), the
             correlation id from the current correlation context is used.
-        workflow_name: Override for ``lastSyncWorkflowName``.  When ``None``
-            (default), the topmost workflow id from the current execution
-            context is used (``parent_workflow_id or workflow_id``).
-        run_at_ms: Override for ``lastSyncRunAt``.  When ``None`` (default),
-            the current UTC epoch in milliseconds is used.
+        workflow_name: Override for ``last_sync_workflow_name``.  When
+            ``None`` (default), the topmost workflow id from the current
+            execution context is used (``parent_workflow_id or workflow_id``).
+        run_at_ms: Override for ``last_sync_run_at``.  When ``None``
+            (default), the current UTC epoch in milliseconds is used.
     """
     if run is None:
         corr = get_correlation_context()
@@ -118,64 +134,64 @@ def resolve_last_sync_details(
     return LastSyncDetails(run=run, workflow_name=workflow_name, run_at_ms=run_at_ms)
 
 
-def set_last_sync_details(
-    asset: dict[str, Any],
+def set_last_sync_details_on_asset(
+    asset: Asset,
     *,
     details: LastSyncDetails | None = None,
     run: str | None = None,
     workflow_name: str | None = None,
     run_at_ms: int | None = None,
-) -> dict[str, Any]:
-    """Stamp ``lastSyncRun`` / ``lastSyncWorkflowName`` / ``lastSyncRunAt``
-    onto an asset dict (mutating in place).
+) -> Asset:
+    """Stamp last-sync details onto a pyatlan ``Asset`` (mutating in place).
 
-    Asset shape follows the Atlas wire format: keys live under
-    ``asset["attributes"]`` (camelCase).  Missing ``attributes`` is created.
+    pyatlan accepts ``run_at_ms`` as an int (epoch milliseconds) and stores
+    it internally as a ``datetime``; no conversion is needed on the caller.
 
     Args:
-        asset: Asset dict to stamp.  Mutated in place; also returned for
+        asset: pyatlan ``Asset`` (or subclass — ``Database``, ``Table``,
+            ``Column``, …) to stamp.  Mutated in place; also returned for
             chaining.
         details: Pre-resolved values.  When provided, ``run`` /
             ``workflow_name`` / ``run_at_ms`` are ignored.  Use this with
-            :func:`set_last_sync_details_bulk` to apply the same values to a
-            batch consistently.
-        run: One-off override for ``lastSyncRun``.  Ignored when ``details``
-            is supplied.  ``None`` (default) auto-resolves from correlation
-            context.
-        workflow_name: One-off override for ``lastSyncWorkflowName``.
+            :func:`set_last_sync_details_on_assets_bulk` to apply the same
+            values to a batch consistently.
+        run: One-off override for ``last_sync_run``.  Ignored when
+            ``details`` is supplied.  ``None`` (default) auto-resolves from
+            correlation context.
+        workflow_name: One-off override for ``last_sync_workflow_name``.
             Ignored when ``details`` is supplied.  ``None`` (default)
             auto-resolves from execution context.
-        run_at_ms: One-off override for ``lastSyncRunAt``.  Ignored when
-            ``details`` is supplied.  ``None`` (default) uses now.
+        run_at_ms: One-off override for ``last_sync_run_at`` (epoch ms).
+            Ignored when ``details`` is supplied.  ``None`` (default) uses
+            now.
     """
     d = details or resolve_last_sync_details(
         run=run, workflow_name=workflow_name, run_at_ms=run_at_ms
     )
 
-    attrs = asset.setdefault("attributes", {})
     if d.run:
-        attrs[LAST_SYNC_RUN] = d.run
+        asset.last_sync_run = d.run
     if d.workflow_name:
-        attrs[LAST_SYNC_WORKFLOW_NAME] = d.workflow_name
-    attrs[LAST_SYNC_RUN_AT] = d.run_at_ms
+        asset.last_sync_workflow_name = d.workflow_name
+    asset.last_sync_run_at = d.run_at_ms
     return asset
 
 
-def set_last_sync_details_bulk(
-    assets: Iterable[dict[str, Any]],
+def set_last_sync_details_on_assets_bulk(
+    assets: Iterable[Asset],
     *,
     run: str | None = None,
     workflow_name: str | None = None,
     run_at_ms: int | None = None,
-) -> list[dict[str, Any]]:
-    """Stamp last-sync details on every asset in ``assets``.
+) -> list[Asset]:
+    """Stamp last-sync details on every pyatlan ``Asset`` in ``assets``.
 
     Resolves the values **once** so every asset in the batch carries the
-    same ``lastSyncRunAt`` (and the same resolved run / workflow_name when
-    auto-resolved).  Each asset is mutated in place and returned in a list
-    for caller convenience.
+    same ``last_sync_run_at`` (and the same resolved run / workflow_name
+    when auto-resolved).  Each asset is mutated in place and returned in a
+    list for caller convenience.
     """
     details = resolve_last_sync_details(
         run=run, workflow_name=workflow_name, run_at_ms=run_at_ms
     )
-    return [set_last_sync_details(a, details=details) for a in assets]
+    return [set_last_sync_details_on_asset(a, details=details) for a in assets]

--- a/application_sdk/transformers/common/last_sync.py
+++ b/application_sdk/transformers/common/last_sync.py
@@ -1,0 +1,179 @@
+"""Last-sync details primitive.
+
+Stamps the three asset attributes that identify *which* run last touched an
+asset (``lastSyncRun``, ``lastSyncWorkflowName``, ``lastSyncRunAt``).  Before
+this primitive, every connector hand-rolled these values, usually from
+``input.workflow_id`` and ``ctx.workflow_run_id`` — both of which resolve to
+the *current* (often child) workflow's Temporal id, not the AE-assigned
+workflow that owns the end-to-end run.  The result on assets looked like::
+
+    "lastSyncWorkflowName": "<uuid>-process",   # child wf id, not clickable
+    "lastSyncRun":          "<temporal-run-uuid>"  # internal id, not in UI
+
+The fields are meant for operator debugging (jumping from an asset back to the
+run that produced it).  The right identifiers are the ones the Atlan UI shows
+on the workflow runs page — i.e. the AE-assigned workflow id slug
+(``<connector>-<short>``) plus the correlation id that ties the full
+end-to-end run (extract + publish) together.  Both are available in the
+SDK's execution / correlation context — the AE id is the *topmost* workflow
+id (``workflow.info().parent.workflow_id`` for child workflows the connector
+spawns internally, otherwise ``workflow.info().workflow_id``), and the
+correlation id is propagated through Temporal headers + memo by the
+correlation interceptor.
+
+The primitive resolves both automatically so callers don't need to know about
+workflow id de-referencing.  Explicit overrides are accepted for non-Temporal
+callers (tests, batch tools).
+
+Trade-offs to be aware of:
+
+* ``lastSyncRun`` defaults to the SDK correlation id, which spans the full
+  end-to-end run (extract + publish) but is *not* the same string the Atlan
+  UI uses in the runs-page URL (Temporal's ``run_id``).  Callers that want
+  UI-clickthrough semantics should pass ``run=<temporal_run_id>`` explicitly
+  — the default favours end-to-end correlation per the BLDX-1229 discussion.
+* ``workflow_name`` resolves to ``parent_workflow_id or workflow_id`` — i.e.
+  one level of parent walk-up.  This covers connectors that spawn a single
+  layer of child workflows (the common shape today).  For deeper nesting
+  the resolver would return an intermediate child's id, not the AE top.
+  If multi-level nesting becomes a thing, propagate the AE id via Temporal
+  memo (mirroring how the correlation interceptor handles ``correlation_id``
+  in ``execution/_temporal/interceptors/log.py``) and read it here.
+* ``workflow_name`` is the AE-assigned *slug* (e.g. ``dbt-AMBSvQPJ``), not a
+  human-readable connection name.  The slug is connection-stable (one slug
+  per Atlan connection, regardless of how many times the run fires) which
+  satisfies the operational use case raised on BLDX-1229.  If teams later
+  need the friendly connection name, AE would need to plumb it through as
+  a distinct input field; for now, callers can pass
+  ``workflow_name=<connection_name>`` explicitly to override.
+
+See BLDX-1229 for the design discussion.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from application_sdk.observability import get_correlation_context, get_execution_context
+
+LAST_SYNC_RUN: str = "lastSyncRun"
+LAST_SYNC_WORKFLOW_NAME: str = "lastSyncWorkflowName"
+LAST_SYNC_RUN_AT: str = "lastSyncRunAt"
+
+
+@dataclass(frozen=True)
+class LastSyncDetails:
+    """Resolved last-sync values for a single end-to-end run.
+
+    Attributes:
+        run: Correlation id tying the full run together (extract + publish).
+            Empty string when no correlation context is set.
+        workflow_name: AE-assigned workflow id slug (e.g. ``dbt-AMBSvQPJ``).
+            Resolves to the topmost workflow id — ``parent_workflow_id``
+            when running inside a child workflow, ``workflow_id`` when
+            running at the top.  Empty string outside Temporal.
+        run_at_ms: Epoch milliseconds at the moment the values were
+            resolved.  Always set.
+    """
+
+    run: str
+    workflow_name: str
+    run_at_ms: int
+
+
+def resolve_last_sync_details(
+    *,
+    run: str | None = None,
+    workflow_name: str | None = None,
+    run_at_ms: int | None = None,
+) -> LastSyncDetails:
+    """Resolve last-sync values from the current execution + correlation
+    contexts, with explicit overrides taking precedence.
+
+    Args:
+        run: Override for ``lastSyncRun``.  When ``None`` (default), the
+            correlation id from the current correlation context is used.
+        workflow_name: Override for ``lastSyncWorkflowName``.  When ``None``
+            (default), the topmost workflow id from the current execution
+            context is used (``parent_workflow_id or workflow_id``).
+        run_at_ms: Override for ``lastSyncRunAt``.  When ``None`` (default),
+            the current UTC epoch in milliseconds is used.
+    """
+    if run is None:
+        corr = get_correlation_context()
+        run = corr.correlation_id if corr else ""
+
+    if workflow_name is None:
+        ctx = get_execution_context()
+        workflow_name = ctx.parent_workflow_id or ctx.workflow_id
+
+    if run_at_ms is None:
+        run_at_ms = int(datetime.now(UTC).timestamp() * 1000)
+
+    return LastSyncDetails(run=run, workflow_name=workflow_name, run_at_ms=run_at_ms)
+
+
+def set_last_sync_details(
+    asset: dict[str, Any],
+    *,
+    details: LastSyncDetails | None = None,
+    run: str | None = None,
+    workflow_name: str | None = None,
+    run_at_ms: int | None = None,
+) -> dict[str, Any]:
+    """Stamp ``lastSyncRun`` / ``lastSyncWorkflowName`` / ``lastSyncRunAt``
+    onto an asset dict (mutating in place).
+
+    Asset shape follows the Atlas wire format: keys live under
+    ``asset["attributes"]`` (camelCase).  Missing ``attributes`` is created.
+
+    Args:
+        asset: Asset dict to stamp.  Mutated in place; also returned for
+            chaining.
+        details: Pre-resolved values.  When provided, ``run`` /
+            ``workflow_name`` / ``run_at_ms`` are ignored.  Use this with
+            :func:`set_last_sync_details_bulk` to apply the same values to a
+            batch consistently.
+        run: One-off override for ``lastSyncRun``.  Ignored when ``details``
+            is supplied.  ``None`` (default) auto-resolves from correlation
+            context.
+        workflow_name: One-off override for ``lastSyncWorkflowName``.
+            Ignored when ``details`` is supplied.  ``None`` (default)
+            auto-resolves from execution context.
+        run_at_ms: One-off override for ``lastSyncRunAt``.  Ignored when
+            ``details`` is supplied.  ``None`` (default) uses now.
+    """
+    d = details or resolve_last_sync_details(
+        run=run, workflow_name=workflow_name, run_at_ms=run_at_ms
+    )
+
+    attrs = asset.setdefault("attributes", {})
+    if d.run:
+        attrs[LAST_SYNC_RUN] = d.run
+    if d.workflow_name:
+        attrs[LAST_SYNC_WORKFLOW_NAME] = d.workflow_name
+    attrs[LAST_SYNC_RUN_AT] = d.run_at_ms
+    return asset
+
+
+def set_last_sync_details_bulk(
+    assets: Iterable[dict[str, Any]],
+    *,
+    run: str | None = None,
+    workflow_name: str | None = None,
+    run_at_ms: int | None = None,
+) -> list[dict[str, Any]]:
+    """Stamp last-sync details on every asset in ``assets``.
+
+    Resolves the values **once** so every asset in the batch carries the
+    same ``lastSyncRunAt`` (and the same resolved run / workflow_name when
+    auto-resolved).  Each asset is mutated in place and returned in a list
+    for caller convenience.
+    """
+    details = resolve_last_sync_details(
+        run=run, workflow_name=workflow_name, run_at_ms=run_at_ms
+    )
+    return [set_last_sync_details(a, details=details) for a in assets]

--- a/tests/unit/transformers/atlas/test_atlas_transformer.py
+++ b/tests/unit/transformers/atlas/test_atlas_transformer.py
@@ -17,7 +17,7 @@ only side effect is in-memory mutation of stub objects.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -32,7 +32,7 @@ from application_sdk.transformers.atlas import AtlasTransformer
 class _FakeDataFrame:
     """A minimal stand-in for `daft.DataFrame` exposing iter_rows()."""
 
-    def __init__(self, rows: List[Dict[str, Any]]):
+    def __init__(self, rows: list[dict[str, Any]]):
         self._rows = rows
 
     def iter_rows(self):  # pragma: no cover - generator protocol trivial
@@ -115,22 +115,47 @@ def test_transform_row_lowercase_typename_is_normalized(
     transformer: AtlasTransformer,
 ):
     # Ensures `typename.upper()` converts "database" to a known key.
-    result = transformer.transform_row(
-        "database",
-        {
-            "database_name": "DB",
-        },
-        "wf",
-        "run",
-        connection_name="conn",
-        connection_qualified_name="default/snowflake/1728518400",
+    # Enrichment pulls last-sync values from the SDK's execution +
+    # correlation contexts (BLDX-1229).  Set them explicitly so the
+    # assertions below don't depend on ambient process state.
+    from application_sdk.observability import (
+        CorrelationContext,
+        ExecutionContext,
+        set_correlation_context,
+        set_execution_context,
     )
+
+    set_execution_context(
+        ExecutionContext(
+            execution_type="workflow",
+            workflow_id="dbt-AMBSvQPJ",
+            workflow_run_id="3d4aa53e-f47a-4d2b-b120-79db652ff759",
+        )
+    )
+    set_correlation_context(CorrelationContext(correlation_id="corr-xyz"))
+
+    try:
+        result = transformer.transform_row(
+            "database",
+            {
+                "database_name": "DB",
+            },
+            "wf",
+            "run",
+            connection_name="conn",
+            connection_qualified_name="default/snowflake/1728518400",
+        )
+    finally:
+        set_execution_context(ExecutionContext())
+        set_correlation_context(CorrelationContext())
+
     assert result is not None
     assert result["typeName"] == "Database"
-    # Confirm enrichment metadata propagated.
+    # Confirm enrichment metadata propagated and now reads from context,
+    # not from the legacy ``workflow_id`` / ``workflow_run_id`` args.
     assert result["attributes"]["tenantId"] == "default"
-    assert result["attributes"]["lastSyncWorkflowName"] == "wf"
-    assert result["attributes"]["lastSyncRun"] == "run"
+    assert result["attributes"]["lastSyncWorkflowName"] == "dbt-AMBSvQPJ"
+    assert result["attributes"]["lastSyncRun"] == "corr-xyz"
 
 
 def test_transform_row_overrides_entity_class_definitions(

--- a/tests/unit/transformers/atlas/test_atlas_transformer.py
+++ b/tests/unit/transformers/atlas/test_atlas_transformer.py
@@ -492,8 +492,6 @@ CONN_QN = "default/snowflake/1728518400"
 
 def test_enrich_uses_remarks_first_for_description(transformer: AtlasTransformer):
     enriched = transformer._enrich_entity_with_metadata(
-        "wf",
-        "run",
         {
             "remarks": "<p>hello</p>",
             "comment": "ignored",
@@ -508,8 +506,6 @@ def test_enrich_falls_back_to_comment_when_remarks_absent(
     transformer: AtlasTransformer,
 ):
     enriched = transformer._enrich_entity_with_metadata(
-        "wf",
-        "run",
         {"comment": "  hi  there  ", "connection_qualified_name": CONN_QN},
     )
     # process_text collapses whitespace
@@ -520,7 +516,7 @@ def test_enrich_no_remarks_no_comment_no_description_key(
     transformer: AtlasTransformer,
 ):
     enriched = transformer._enrich_entity_with_metadata(
-        "wf", "run", {"connection_qualified_name": CONN_QN}
+        {"connection_qualified_name": CONN_QN}
     )
     assert "description" not in enriched["attributes"]
 
@@ -529,8 +525,6 @@ def test_enrich_propagates_source_owner_and_source_id(
     transformer: AtlasTransformer,
 ):
     enriched = transformer._enrich_entity_with_metadata(
-        "wf",
-        "run",
         {
             "source_owner": "alice",
             "source_id": "abc-123",
@@ -545,8 +539,6 @@ def test_enrich_converts_created_and_last_altered_timestamps(
     transformer: AtlasTransformer,
 ):
     enriched = transformer._enrich_entity_with_metadata(
-        "wf",
-        "run",
         {
             "created": 1_700_000_000_000,
             "last_altered": 1_700_000_500_000,
@@ -557,17 +549,19 @@ def test_enrich_converts_created_and_last_altered_timestamps(
     assert isinstance(enriched["attributes"]["source_updated_at"], datetime)
 
 
-def test_enrich_sets_workflow_metadata(transformer: AtlasTransformer):
+def test_enrich_does_not_stamp_last_sync_fields(transformer: AtlasTransformer):
+    """After BLDX-1229 the enrichment step intentionally no longer touches
+    ``last_sync_*``.  Stamping happens after entity construction on the
+    typed pyatlan ``Asset`` via :func:`set_last_sync_details_on_asset`, so
+    the single Asset-based primitive owns those fields end-to-end.
+    """
     enriched = transformer._enrich_entity_with_metadata(
-        "wf-id",
-        "run-id",
         {"connection_name": "myconn", "connection_qualified_name": CONN_QN},
     )
     attrs = enriched["attributes"]
-    assert attrs["last_sync_workflow_name"] == "wf-id"
-    assert attrs["last_sync_run"] == "run-id"
+    assert "last_sync_workflow_name" not in attrs
+    assert "last_sync_run" not in attrs
+    assert "last_sync_run_at" not in attrs
+    # Other enrichment still works.
     assert attrs["connection_name"] == "myconn"
     assert attrs["tenant_id"] == "default"
-    # last_sync_run_at should be epoch ms (int, > 0)
-    assert isinstance(attrs["last_sync_run_at"], int)
-    assert attrs["last_sync_run_at"] > 0

--- a/tests/unit/transformers/atlas/test_atlas_transformer.py
+++ b/tests/unit/transformers/atlas/test_atlas_transformer.py
@@ -111,13 +111,25 @@ def test_transform_row_creator_failure_returns_none(transformer: AtlasTransforme
     assert result is None
 
 
-def test_transform_row_lowercase_typename_is_normalized(
-    transformer: AtlasTransformer,
-):
-    # Ensures `typename.upper()` converts "database" to a known key.
-    # Enrichment pulls last-sync values from the SDK's execution +
-    # correlation contexts (BLDX-1229).  Set them explicitly so the
-    # assertions below don't depend on ambient process state.
+# Realistic identifiers captured from an AE-dispatched BigQuery extract run
+# on a dev tenant — used by the context-driven last-sync tests below to
+# anchor assertions to real Temporal id shapes (UUIDs), not invented strings.
+_AE_WORKFLOW_ID = "4b9eade4-de53-4b69-9010-2446e0a8f85c"
+_AE_RUN_ID = "019e2498-87d6-7d99-b345-e00a6dfa8fe2"
+_CHILD_WORKFLOW_ID = "d637c39c-81a0-48b5-bf36-312108e4615c-extract"
+_CHILD_RUN_ID = "019e2499-c758-7869-9e37-8a50f1d2315c"
+_CORRELATION_ID = "d637c39c-81a0-48b5-bf36-312108e4615c"
+
+
+@pytest.fixture
+def ae_child_context():
+    """Populate execution + correlation context as if running inside an
+    AE-spawned child workflow (the production shape per BLDX-1229).
+
+    Mirrors a real run captured against a BigQuery extract: the connector
+    activity sees ``workflow_id = <correlation>-extract`` (child wf id) and
+    ``parent_workflow_id = <AE uuid>`` (the AE-dispatched workflow's id).
+    """
     from application_sdk.observability import (
         CorrelationContext,
         ExecutionContext,
@@ -128,34 +140,129 @@ def test_transform_row_lowercase_typename_is_normalized(
     set_execution_context(
         ExecutionContext(
             execution_type="workflow",
-            workflow_id="dbt-AMBSvQPJ",
-            workflow_run_id="3d4aa53e-f47a-4d2b-b120-79db652ff759",
+            workflow_id=_CHILD_WORKFLOW_ID,
+            workflow_run_id=_CHILD_RUN_ID,
+            parent_workflow_id=_AE_WORKFLOW_ID,
+            parent_run_id=_AE_RUN_ID,
         )
     )
-    set_correlation_context(CorrelationContext(correlation_id="corr-xyz"))
-
+    set_correlation_context(CorrelationContext(correlation_id=_CORRELATION_ID))
     try:
-        result = transformer.transform_row(
-            "database",
-            {
-                "database_name": "DB",
-            },
-            "wf",
-            "run",
-            connection_name="conn",
-            connection_qualified_name="default/snowflake/1728518400",
-        )
+        yield
     finally:
         set_execution_context(ExecutionContext())
         set_correlation_context(CorrelationContext())
 
+
+def test_transform_row_lowercase_typename_is_normalized(
+    transformer: AtlasTransformer,
+    ae_child_context,
+):
+    # Ensures `typename.upper()` converts "database" to a known key, and
+    # confirms that last-sync enrichment reads from the AE-child execution
+    # context populated by the ``ae_child_context`` fixture — not from the
+    # legacy ``workflow_id`` / ``workflow_run_id`` args (which are ignored
+    # whenever the context is populated; BLDX-1229).
+    result = transformer.transform_row(
+        "database",
+        {
+            "database_name": "DB",
+        },
+        "ignored-legacy-wf-id",
+        "ignored-legacy-run-id",
+        connection_name="conn",
+        connection_qualified_name="default/snowflake/1728518400",
+    )
+
     assert result is not None
     assert result["typeName"] == "Database"
-    # Confirm enrichment metadata propagated and now reads from context,
-    # not from the legacy ``workflow_id`` / ``workflow_run_id`` args.
     assert result["attributes"]["tenantId"] == "default"
-    assert result["attributes"]["lastSyncWorkflowName"] == "dbt-AMBSvQPJ"
-    assert result["attributes"]["lastSyncRun"] == "corr-xyz"
+    assert result["attributes"]["lastSyncWorkflowName"] == _AE_WORKFLOW_ID
+    assert result["attributes"]["lastSyncRun"] == _CORRELATION_ID
+
+
+# ---------------------------------------------------------------------------
+# Last-sync context propagation across entity types (BLDX-1229)
+#
+# Anchors the new production behavior at the AtlasTransformer level for the
+# three most common SQL entity types.  Before BLDX-1229, AtlasTransformer
+# stamped the explicit ``workflow_id`` / ``workflow_run_id`` args directly
+# onto assets — which in production resolved to the child workflow's
+# Temporal id and run id (the buggy values described in the ticket).  The
+# tests below set realistic AE-parent context and confirm the AE workflow
+# id + correlation id reach the asset, regardless of what the caller passes
+# as the legacy args.
+# ---------------------------------------------------------------------------
+
+
+def test_transform_row_table_uses_ae_workflow_id_from_context(
+    transformer: AtlasTransformer,
+    ae_child_context,
+):
+    result = transformer.transform_row(
+        "TABLE",
+        {
+            "table_name": "CUSTOMERS",
+            "table_schema": "PUBLIC",
+            "table_catalog": "DB",
+            "table_kind": "BASE TABLE",
+        },
+        "ignored-legacy-wf-id",
+        "ignored-legacy-run-id",
+        connection_name="conn",
+        connection_qualified_name="default/snowflake/1728518400",
+    )
+
+    assert result is not None
+    assert result["attributes"]["lastSyncWorkflowName"] == _AE_WORKFLOW_ID
+    assert result["attributes"]["lastSyncRun"] == _CORRELATION_ID
+
+
+def test_transform_row_column_uses_ae_workflow_id_from_context(
+    transformer: AtlasTransformer,
+    ae_child_context,
+):
+    result = transformer.transform_row(
+        "COLUMN",
+        {
+            "column_name": "CUSTOMER_ID",
+            "table_name": "CUSTOMERS",
+            "table_schema": "PUBLIC",
+            "table_catalog": "DB",
+            "table_kind": "BASE TABLE",
+            "data_type": "NUMBER",
+            "ordinal_position": 1,
+        },
+        "ignored-legacy-wf-id",
+        "ignored-legacy-run-id",
+        connection_name="conn",
+        connection_qualified_name="default/snowflake/1728518400",
+    )
+
+    assert result is not None
+    assert result["attributes"]["lastSyncWorkflowName"] == _AE_WORKFLOW_ID
+    assert result["attributes"]["lastSyncRun"] == _CORRELATION_ID
+
+
+def test_transform_row_schema_uses_ae_workflow_id_from_context(
+    transformer: AtlasTransformer,
+    ae_child_context,
+):
+    result = transformer.transform_row(
+        "SCHEMA",
+        {
+            "schema_name": "PUBLIC",
+            "catalog_name": "DB",
+        },
+        "ignored-legacy-wf-id",
+        "ignored-legacy-run-id",
+        connection_name="conn",
+        connection_qualified_name="default/snowflake/1728518400",
+    )
+
+    assert result is not None
+    assert result["attributes"]["lastSyncWorkflowName"] == _AE_WORKFLOW_ID
+    assert result["attributes"]["lastSyncRun"] == _CORRELATION_ID
 
 
 def test_transform_row_overrides_entity_class_definitions(

--- a/tests/unit/transformers/common/test_last_sync.py
+++ b/tests/unit/transformers/common/test_last_sync.py
@@ -54,43 +54,53 @@ def test_resolve_empty_context_returns_empty_strings_and_current_epoch():
 
 
 def test_resolve_top_level_workflow_uses_workflow_id():
-    """Top-level workflow → no parent → workflow_name == workflow_id."""
+    """Top-level workflow → no parent → workflow_name == workflow_id.
+
+    Fixture uses a realistic AE Temporal workflow_id (a UUID, run-unique).
+    """
     set_execution_context(
         ExecutionContext(
             execution_type="workflow",
-            workflow_id="dbt-AMBSvQPJ",
-            workflow_run_id="run-uuid-1",
+            workflow_id="4b9eade4-de53-4b69-9010-2446e0a8f85c",
+            workflow_run_id="019e2498-87d6-7d99-b345-e00a6dfa8fe2",
         )
     )
-    set_correlation_context(CorrelationContext(correlation_id="corr-1"))
+    set_correlation_context(
+        CorrelationContext(correlation_id="d637c39c-81a0-48b5-bf36-312108e4615c")
+    )
 
     details = resolve_last_sync_details()
-    assert details.workflow_name == "dbt-AMBSvQPJ"
-    assert details.run == "corr-1"
+    assert details.workflow_name == "4b9eade4-de53-4b69-9010-2446e0a8f85c"
+    assert details.run == "d637c39c-81a0-48b5-bf36-312108e4615c"
 
 
 def test_resolve_child_workflow_prefers_parent_workflow_id():
     """Child workflow → ``parent_workflow_id`` wins over ``workflow_id``.
 
-    This is the exact bug Chetan hit in the BLDX-1229 thread: from inside
-    a connector's child workflow, ``input.workflow_id`` (= the child's
-    Temporal id, ``<uuid>-process``) was being written to assets instead
-    of the AE-assigned slug.  The resolver picks the topmost id.
+    Fixture mirrors the BLDX-1229 scenario observed against a real BigQuery
+    extract run on a dev tenant: the connector activity runs inside an
+    AE-spawned child workflow whose Temporal id is ``<correlation>-extract``;
+    the parent is the AE workflow whose id is a fresh UUID per AE run.  The
+    v2 pattern (stamp ``input.workflow_id``) produced the child id on assets,
+    so operators could not click back to the AE run from an asset.  The
+    resolver instead reads ``parent_workflow_id`` and stamps the AE id.
     """
     set_execution_context(
         ExecutionContext(
             execution_type="workflow",
-            workflow_id="64b1330d-4635-4d9d-99c1-1ee2c78105ea-process",
-            workflow_run_id="019dd951-76a9-7125-aa42-86f0bbe36f6a",
-            parent_workflow_id="dbt-AMBSvQPJ",
-            parent_run_id="3d4aa53e-f47a-4d2b-b120-79db652ff759",
+            workflow_id="d637c39c-81a0-48b5-bf36-312108e4615c-extract",
+            workflow_run_id="019e2499-c758-7869-9e37-8a50f1d2315c",
+            parent_workflow_id="4b9eade4-de53-4b69-9010-2446e0a8f85c",
+            parent_run_id="019e2498-87d6-7d99-b345-e00a6dfa8fe2",
         )
     )
-    set_correlation_context(CorrelationContext(correlation_id="corr-2"))
+    set_correlation_context(
+        CorrelationContext(correlation_id="d637c39c-81a0-48b5-bf36-312108e4615c")
+    )
 
     details = resolve_last_sync_details()
-    assert details.workflow_name == "dbt-AMBSvQPJ"
-    assert details.run == "corr-2"
+    assert details.workflow_name == "4b9eade4-de53-4b69-9010-2446e0a8f85c"
+    assert details.run == "d637c39c-81a0-48b5-bf36-312108e4615c"
 
 
 def test_resolve_explicit_overrides_beat_context():
@@ -178,10 +188,12 @@ def test_bulk_applies_same_values_to_every_asset():
     """Every asset in the batch carries identical lastSync* values — the
     resolver runs once, not per asset, so the timestamp is stable across
     the batch."""
+    ae_wf_id = "4b9eade4-de53-4b69-9010-2446e0a8f85c"
+    corr_id = "d637c39c-81a0-48b5-bf36-312108e4615c"
     set_execution_context(
-        ExecutionContext(execution_type="workflow", workflow_id="dbt-XYZ")
+        ExecutionContext(execution_type="workflow", workflow_id=ae_wf_id)
     )
-    set_correlation_context(CorrelationContext(correlation_id="corr-batch"))
+    set_correlation_context(CorrelationContext(correlation_id=corr_id))
 
     assets = [{"typeName": "Table"}, {"typeName": "Column"}, {"typeName": "Schema"}]
     out = set_last_sync_details_bulk(assets)
@@ -189,8 +201,8 @@ def test_bulk_applies_same_values_to_every_asset():
     assert len(out) == 3
     first_run_at = out[0]["attributes"][LAST_SYNC_RUN_AT]
     for asset in out:
-        assert asset["attributes"][LAST_SYNC_RUN] == "corr-batch"
-        assert asset["attributes"][LAST_SYNC_WORKFLOW_NAME] == "dbt-XYZ"
+        assert asset["attributes"][LAST_SYNC_RUN] == corr_id
+        assert asset["attributes"][LAST_SYNC_WORKFLOW_NAME] == ae_wf_id
         # Same timestamp across the whole batch — proves the resolver
         # didn't fire per asset.
         assert asset["attributes"][LAST_SYNC_RUN_AT] == first_run_at

--- a/tests/unit/transformers/common/test_last_sync.py
+++ b/tests/unit/transformers/common/test_last_sync.py
@@ -1,0 +1,209 @@
+"""Unit tests for the last-sync details primitive (BLDX-1229).
+
+Covers the four interesting paths through ``resolve_last_sync_details`` —
+top-level workflow, child workflow (where the AE-assigned id is exposed via
+``parent_workflow_id``), no execution context (tests / CLI), and explicit
+overrides — plus the two dict-stamping wrappers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from application_sdk.observability import (
+    CorrelationContext,
+    ExecutionContext,
+    set_correlation_context,
+    set_execution_context,
+)
+from application_sdk.transformers.common.last_sync import (
+    LAST_SYNC_RUN,
+    LAST_SYNC_RUN_AT,
+    LAST_SYNC_WORKFLOW_NAME,
+    LastSyncDetails,
+    resolve_last_sync_details,
+    set_last_sync_details,
+    set_last_sync_details_bulk,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_contexts():
+    """Always start each test with empty contexts.
+
+    The SDK's execution / correlation context lives in ContextVars; without
+    a reset, leakage from prior tests would make these assertions flaky.
+    """
+    set_execution_context(ExecutionContext())
+    set_correlation_context(CorrelationContext())
+    yield
+    set_execution_context(ExecutionContext())
+    set_correlation_context(CorrelationContext())
+
+
+# ---------------------------------------------------------------------------
+# resolve_last_sync_details
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_empty_context_returns_empty_strings_and_current_epoch():
+    details = resolve_last_sync_details()
+    assert details.run == ""
+    assert details.workflow_name == ""
+    assert details.run_at_ms > 0  # always populated
+
+
+def test_resolve_top_level_workflow_uses_workflow_id():
+    """Top-level workflow → no parent → workflow_name == workflow_id."""
+    set_execution_context(
+        ExecutionContext(
+            execution_type="workflow",
+            workflow_id="dbt-AMBSvQPJ",
+            workflow_run_id="run-uuid-1",
+        )
+    )
+    set_correlation_context(CorrelationContext(correlation_id="corr-1"))
+
+    details = resolve_last_sync_details()
+    assert details.workflow_name == "dbt-AMBSvQPJ"
+    assert details.run == "corr-1"
+
+
+def test_resolve_child_workflow_prefers_parent_workflow_id():
+    """Child workflow → ``parent_workflow_id`` wins over ``workflow_id``.
+
+    This is the exact bug Chetan hit in the BLDX-1229 thread: from inside
+    a connector's child workflow, ``input.workflow_id`` (= the child's
+    Temporal id, ``<uuid>-process``) was being written to assets instead
+    of the AE-assigned slug.  The resolver picks the topmost id.
+    """
+    set_execution_context(
+        ExecutionContext(
+            execution_type="workflow",
+            workflow_id="64b1330d-4635-4d9d-99c1-1ee2c78105ea-process",
+            workflow_run_id="019dd951-76a9-7125-aa42-86f0bbe36f6a",
+            parent_workflow_id="dbt-AMBSvQPJ",
+            parent_run_id="3d4aa53e-f47a-4d2b-b120-79db652ff759",
+        )
+    )
+    set_correlation_context(CorrelationContext(correlation_id="corr-2"))
+
+    details = resolve_last_sync_details()
+    assert details.workflow_name == "dbt-AMBSvQPJ"
+    assert details.run == "corr-2"
+
+
+def test_resolve_explicit_overrides_beat_context():
+    set_execution_context(
+        ExecutionContext(execution_type="workflow", workflow_id="from-ctx")
+    )
+    set_correlation_context(CorrelationContext(correlation_id="from-ctx"))
+
+    details = resolve_last_sync_details(
+        run="explicit-run",
+        workflow_name="explicit-wf",
+        run_at_ms=1234567890,
+    )
+    assert details.run == "explicit-run"
+    assert details.workflow_name == "explicit-wf"
+    assert details.run_at_ms == 1234567890
+
+
+# ---------------------------------------------------------------------------
+# set_last_sync_details
+# ---------------------------------------------------------------------------
+
+
+def test_set_stamps_camelcase_keys_under_attributes():
+    asset: dict = {"typeName": "Table"}
+    out = set_last_sync_details(
+        asset,
+        run="r",
+        workflow_name="w",
+        run_at_ms=42,
+    )
+    assert out is asset  # mutates in place
+    assert out["attributes"][LAST_SYNC_RUN] == "r"
+    assert out["attributes"][LAST_SYNC_WORKFLOW_NAME] == "w"
+    assert out["attributes"][LAST_SYNC_RUN_AT] == 42
+
+
+def test_set_creates_missing_attributes_key():
+    asset: dict = {}
+    set_last_sync_details(asset, run="r", workflow_name="w", run_at_ms=42)
+    assert "attributes" in asset
+    assert asset["attributes"][LAST_SYNC_RUN] == "r"
+
+
+def test_set_preserves_existing_attributes():
+    asset = {"attributes": {"name": "Customers", "rowCount": 100}}
+    set_last_sync_details(asset, run="r", workflow_name="w", run_at_ms=42)
+    assert asset["attributes"]["name"] == "Customers"
+    assert asset["attributes"]["rowCount"] == 100
+    assert asset["attributes"][LAST_SYNC_RUN_AT] == 42
+
+
+def test_set_skips_empty_run_and_workflow_name_but_always_writes_run_at():
+    """Empty resolutions don't get written — operator dashboards filter on
+    presence, so writing ``""`` would be worse than omitting.  ``runAt`` is
+    always populated (clock is always available) so it's always written."""
+    asset: dict = {}
+    set_last_sync_details(asset, run="", workflow_name="", run_at_ms=42)
+    attrs = asset.get("attributes", {})
+    assert LAST_SYNC_RUN not in attrs
+    assert LAST_SYNC_WORKFLOW_NAME not in attrs
+    assert attrs[LAST_SYNC_RUN_AT] == 42
+
+
+def test_set_details_param_wins_over_individual_overrides():
+    asset: dict = {}
+    details = LastSyncDetails(run="from-details", workflow_name="wf", run_at_ms=1)
+    set_last_sync_details(
+        asset,
+        details=details,
+        run="ignored",
+        workflow_name="ignored",
+        run_at_ms=999,
+    )
+    assert asset["attributes"][LAST_SYNC_RUN] == "from-details"
+    assert asset["attributes"][LAST_SYNC_RUN_AT] == 1
+
+
+# ---------------------------------------------------------------------------
+# set_last_sync_details_bulk
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_applies_same_values_to_every_asset():
+    """Every asset in the batch carries identical lastSync* values — the
+    resolver runs once, not per asset, so the timestamp is stable across
+    the batch."""
+    set_execution_context(
+        ExecutionContext(execution_type="workflow", workflow_id="dbt-XYZ")
+    )
+    set_correlation_context(CorrelationContext(correlation_id="corr-batch"))
+
+    assets = [{"typeName": "Table"}, {"typeName": "Column"}, {"typeName": "Schema"}]
+    out = set_last_sync_details_bulk(assets)
+
+    assert len(out) == 3
+    first_run_at = out[0]["attributes"][LAST_SYNC_RUN_AT]
+    for asset in out:
+        assert asset["attributes"][LAST_SYNC_RUN] == "corr-batch"
+        assert asset["attributes"][LAST_SYNC_WORKFLOW_NAME] == "dbt-XYZ"
+        # Same timestamp across the whole batch — proves the resolver
+        # didn't fire per asset.
+        assert asset["attributes"][LAST_SYNC_RUN_AT] == first_run_at
+
+
+def test_bulk_accepts_explicit_overrides():
+    out = set_last_sync_details_bulk(
+        [{} for _ in range(3)],
+        run="explicit",
+        workflow_name="explicit-wf",
+        run_at_ms=7,
+    )
+    for asset in out:
+        assert asset["attributes"][LAST_SYNC_RUN] == "explicit"
+        assert asset["attributes"][LAST_SYNC_WORKFLOW_NAME] == "explicit-wf"
+        assert asset["attributes"][LAST_SYNC_RUN_AT] == 7

--- a/tests/unit/transformers/common/test_last_sync.py
+++ b/tests/unit/transformers/common/test_last_sync.py
@@ -3,10 +3,13 @@
 Covers the four interesting paths through ``resolve_last_sync_details`` —
 top-level workflow, child workflow (where the AE-assigned id is exposed via
 ``parent_workflow_id``), no execution context (tests / CLI), and explicit
-overrides — plus the two dict-stamping wrappers.
+overrides — plus the Asset-based stamping helpers (the single recommended
+API surface; earlier dict-shaped helpers were removed in BLDX-1229).
 """
 
 from __future__ import annotations
+
+from datetime import UTC
 
 import pytest
 
@@ -17,13 +20,10 @@ from application_sdk.observability import (
     set_execution_context,
 )
 from application_sdk.transformers.common.last_sync import (
-    LAST_SYNC_RUN,
-    LAST_SYNC_RUN_AT,
-    LAST_SYNC_WORKFLOW_NAME,
     LastSyncDetails,
     resolve_last_sync_details,
-    set_last_sync_details,
-    set_last_sync_details_bulk,
+    set_last_sync_details_on_asset,
+    set_last_sync_details_on_assets_bulk,
 )
 
 
@@ -120,74 +120,54 @@ def test_resolve_explicit_overrides_beat_context():
 
 
 # ---------------------------------------------------------------------------
-# set_last_sync_details
+# set_last_sync_details_on_asset (pyatlan Asset — the only stamping path)
 # ---------------------------------------------------------------------------
 
 
-def test_set_stamps_camelcase_keys_under_attributes():
-    asset: dict = {"typeName": "Table"}
-    out = set_last_sync_details(
+def _epoch_ms_to_datetime(epoch_ms: int):
+    """pyatlan stores ``last_sync_run_at`` internally as a ``datetime``.
+
+    pydantic v2 (which pyatlan uses) auto-detects seconds vs milliseconds
+    by magnitude: ``|value| <= 2e10`` → seconds, else milliseconds.  All
+    fixtures below use realistic recent-epoch values (>2e10) so the unit
+    is unambiguous.
+    """
+    from datetime import datetime as _dt
+
+    return _dt.fromtimestamp(epoch_ms / 1000, tz=UTC)
+
+
+# Use values > 2e10 so pydantic parses as ms (not seconds).
+_TEST_RUN_AT_MS = 1700000000000  # 2023-11-14T22:13:20Z
+_TEST_RUN_AT_MS_ALT = 1700000123000
+_TEST_RUN_AT_MS_BULK = 1700000456000
+
+
+def test_set_on_asset_stamps_typed_attributes():
+    """Direct attribute assignment on a pyatlan Asset subclass.
+
+    Uses ``Database`` (any subclass works — covariance via the base
+    ``Asset`` type).  pyatlan accepts an int (epoch ms) for
+    ``last_sync_run_at`` and stores it as a ``datetime`` internally.
+    """
+    from pyatlan.model.assets import Database
+
+    asset = Database()
+    out = set_last_sync_details_on_asset(
         asset,
         run="r",
         workflow_name="w",
-        run_at_ms=42,
+        run_at_ms=_TEST_RUN_AT_MS,
     )
     assert out is asset  # mutates in place
-    assert out["attributes"][LAST_SYNC_RUN] == "r"
-    assert out["attributes"][LAST_SYNC_WORKFLOW_NAME] == "w"
-    assert out["attributes"][LAST_SYNC_RUN_AT] == 42
+    assert asset.last_sync_run == "r"
+    assert asset.last_sync_workflow_name == "w"
+    assert asset.last_sync_run_at == _epoch_ms_to_datetime(_TEST_RUN_AT_MS)
 
 
-def test_set_creates_missing_attributes_key():
-    asset: dict = {}
-    set_last_sync_details(asset, run="r", workflow_name="w", run_at_ms=42)
-    assert "attributes" in asset
-    assert asset["attributes"][LAST_SYNC_RUN] == "r"
+def test_set_on_asset_resolves_from_context_when_no_overrides():
+    from pyatlan.model.assets import Table
 
-
-def test_set_preserves_existing_attributes():
-    asset = {"attributes": {"name": "Customers", "rowCount": 100}}
-    set_last_sync_details(asset, run="r", workflow_name="w", run_at_ms=42)
-    assert asset["attributes"]["name"] == "Customers"
-    assert asset["attributes"]["rowCount"] == 100
-    assert asset["attributes"][LAST_SYNC_RUN_AT] == 42
-
-
-def test_set_skips_empty_run_and_workflow_name_but_always_writes_run_at():
-    """Empty resolutions don't get written — operator dashboards filter on
-    presence, so writing ``""`` would be worse than omitting.  ``runAt`` is
-    always populated (clock is always available) so it's always written."""
-    asset: dict = {}
-    set_last_sync_details(asset, run="", workflow_name="", run_at_ms=42)
-    attrs = asset.get("attributes", {})
-    assert LAST_SYNC_RUN not in attrs
-    assert LAST_SYNC_WORKFLOW_NAME not in attrs
-    assert attrs[LAST_SYNC_RUN_AT] == 42
-
-
-def test_set_details_param_wins_over_individual_overrides():
-    asset: dict = {}
-    details = LastSyncDetails(run="from-details", workflow_name="wf", run_at_ms=1)
-    set_last_sync_details(
-        asset,
-        details=details,
-        run="ignored",
-        workflow_name="ignored",
-        run_at_ms=999,
-    )
-    assert asset["attributes"][LAST_SYNC_RUN] == "from-details"
-    assert asset["attributes"][LAST_SYNC_RUN_AT] == 1
-
-
-# ---------------------------------------------------------------------------
-# set_last_sync_details_bulk
-# ---------------------------------------------------------------------------
-
-
-def test_bulk_applies_same_values_to_every_asset():
-    """Every asset in the batch carries identical lastSync* values — the
-    resolver runs once, not per asset, so the timestamp is stable across
-    the batch."""
     ae_wf_id = "4b9eade4-de53-4b69-9010-2446e0a8f85c"
     corr_id = "d637c39c-81a0-48b5-bf36-312108e4615c"
     set_execution_context(
@@ -195,27 +175,87 @@ def test_bulk_applies_same_values_to_every_asset():
     )
     set_correlation_context(CorrelationContext(correlation_id=corr_id))
 
-    assets = [{"typeName": "Table"}, {"typeName": "Column"}, {"typeName": "Schema"}]
-    out = set_last_sync_details_bulk(assets)
+    asset = Table()
+    set_last_sync_details_on_asset(asset)
+
+    assert asset.last_sync_run == corr_id
+    assert asset.last_sync_workflow_name == ae_wf_id
+    assert asset.last_sync_run_at is not None
+
+
+def test_set_on_asset_skips_empty_run_and_workflow_name_but_always_writes_run_at():
+    """Empty resolutions don't get written — operator dashboards filter on
+    presence, so writing ``""`` would be worse than omitting.  ``run_at`` is
+    always populated (clock is always available) so it's always written."""
+    from pyatlan.model.assets import Database
+
+    asset = Database()
+    set_last_sync_details_on_asset(
+        asset, run="", workflow_name="", run_at_ms=_TEST_RUN_AT_MS
+    )
+
+    assert asset.last_sync_run is None
+    assert asset.last_sync_workflow_name is None
+    assert asset.last_sync_run_at == _epoch_ms_to_datetime(_TEST_RUN_AT_MS)
+
+
+def test_set_on_asset_details_param_wins_over_individual_overrides():
+    from pyatlan.model.assets import Column
+
+    asset = Column()
+    details = LastSyncDetails(
+        run="from-details", workflow_name="wf", run_at_ms=_TEST_RUN_AT_MS_ALT
+    )
+    set_last_sync_details_on_asset(
+        asset,
+        details=details,
+        run="ignored",
+        workflow_name="ignored",
+        run_at_ms=_TEST_RUN_AT_MS,
+    )
+    assert asset.last_sync_run == "from-details"
+    assert asset.last_sync_workflow_name == "wf"
+    assert asset.last_sync_run_at == _epoch_ms_to_datetime(_TEST_RUN_AT_MS_ALT)
+
+
+# ---------------------------------------------------------------------------
+# set_last_sync_details_on_assets_bulk
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_on_assets_applies_same_values_to_every_asset():
+    from pyatlan.model.assets import Column, Schema, Table
+
+    ae_wf_id = "4b9eade4-de53-4b69-9010-2446e0a8f85c"
+    corr_id = "d637c39c-81a0-48b5-bf36-312108e4615c"
+    set_execution_context(
+        ExecutionContext(execution_type="workflow", workflow_id=ae_wf_id)
+    )
+    set_correlation_context(CorrelationContext(correlation_id=corr_id))
+
+    assets = [Table(), Column(), Schema()]
+    out = set_last_sync_details_on_assets_bulk(assets)
 
     assert len(out) == 3
-    first_run_at = out[0]["attributes"][LAST_SYNC_RUN_AT]
+    first_run_at = out[0].last_sync_run_at
     for asset in out:
-        assert asset["attributes"][LAST_SYNC_RUN] == corr_id
-        assert asset["attributes"][LAST_SYNC_WORKFLOW_NAME] == ae_wf_id
+        assert asset.last_sync_run == corr_id
+        assert asset.last_sync_workflow_name == ae_wf_id
         # Same timestamp across the whole batch — proves the resolver
         # didn't fire per asset.
-        assert asset["attributes"][LAST_SYNC_RUN_AT] == first_run_at
+        assert asset.last_sync_run_at == first_run_at
 
 
-def test_bulk_accepts_explicit_overrides():
-    out = set_last_sync_details_bulk(
-        [{} for _ in range(3)],
+def test_bulk_on_assets_accepts_explicit_overrides():
+    from pyatlan.model.assets import Database
+
+    out = set_last_sync_details_on_assets_bulk(
+        [Database() for _ in range(3)],
         run="explicit",
         workflow_name="explicit-wf",
-        run_at_ms=7,
+        run_at_ms=_TEST_RUN_AT_MS_BULK,
     )
     for asset in out:
-        assert asset["attributes"][LAST_SYNC_RUN] == "explicit"
-        assert asset["attributes"][LAST_SYNC_WORKFLOW_NAME] == "explicit-wf"
-        assert asset["attributes"][LAST_SYNC_RUN_AT] == 7
+        assert asset.last_sync_run == "explicit"
+        assert asset.last_sync_workflow_name == "explicit-wf"
+        assert asset.last_sync_run_at == _epoch_ms_to_datetime(_TEST_RUN_AT_MS_BULK)


### PR DESCRIPTION
## Summary
- New shared primitive `application_sdk/transformers/common/last_sync.py` that stamps `last_sync_run` / `last_sync_workflow_name` / `last_sync_run_at` on pyatlan `Asset` objects, auto-resolving from the SDK's execution + correlation context so connector authors no longer hand-roll wrong values from `input.workflow_id` (child wf id) and `ctx.workflow_run_id` (Temporal run UUID).
- Single API surface: `set_last_sync_details_on_asset(asset, …)` + `set_last_sync_details_on_assets_bulk(assets, …)`. The earlier dict-shaped helpers and the AtlasTransformer's internal dict-merge stamping have been removed so the typed pyatlan `Asset` is the only path that writes these fields.
- `AtlasTransformer.transform_row` rewired to call the Asset helper on the constructed entity *before* `.dict()` serialisation. `_enrich_entity_with_metadata` no longer touches `last_sync_*`; the legacy `workflow_id` / `workflow_run_id` method args remain as test-only fallbacks, used only when execution context is empty (warned once-per-process so any production drift is visible).
- Unit tests cover the four resolution paths through `resolve_last_sync_details` (top-level wf, child wf using real AE-dispatched UUIDs from a dev tenant, no-context, explicit overrides) plus the Asset-stamping and bulk variants. AtlasTransformer-level anchor tests for Table / Column / Schema / Database pin the new behaviour end-to-end.

Linear: [BLDX-1229](https://linear.app/atlan-epd/issue/BLDX-1229/create-a-set-last-sync-details-primitive)

## API surface
Single recommended path — pyatlan `Asset` (or any subclass):

```python
from application_sdk.transformers.common.last_sync import (
    set_last_sync_details_on_asset,
    set_last_sync_details_on_assets_bulk,
)

set_last_sync_details_on_asset(asset)                    # auto-resolve from Temporal context
set_last_sync_details_on_asset(asset, run="…")           # explicit override
set_last_sync_details_on_assets_bulk(assets)             # one resolution shared across the batch
```

Earlier iterations also exposed `set_last_sync_details(asset: dict)` and `set_last_sync_details_bulk(assets: Iterable[dict])`. Those were removed in review: transformation should target pyatlan `Asset` (or subclass), so a single API enforces that and avoids developers / agents reaching for non-recommended dict-shaped transformation paths.

## Resolution rules
| Field | Default (auto-resolved) | Override knob |
|---|---|---|
| `last_sync_run` | SDK correlation id (end-to-end span across extract + publish) | `run=<value>` — e.g. pass Temporal `run_id` if UI clickthrough is preferred |
| `last_sync_workflow_name` | AE Temporal `workflow_id` (run-unique UUID, e.g. `4b9eade4-de53-4b69-9010-2446e0a8f85c`) via `parent_workflow_id or workflow_id` | `workflow_name=<value>` |
| `last_sync_run_at` | Current UTC epoch milliseconds (pyatlan stores as `datetime` internally) | `run_at_ms=<value>` |

## Alignment with the thread consensus

| Concern | This PR |
|---|---|
| `input.workflow_id` returns child wf id (e.g. `<correlation>-extract`), want AE id | resolver returns the AE Temporal workflow_id via `parent_workflow_id or workflow_id` |
| `lastSyncRun` = correlation id, `lastSyncWorkflowName` = initiating workflow, `lastSyncRunAt` = epoch | default mapping matches |
| `lastSyncWorkflowName` must be connection-stable, not connector-type | **Not met by default** — the AE Temporal id is run-unique (a fresh UUID per AE invocation), not connection-stable. Verified against a real AE-dispatched BigQuery extract on a dev tenant. Connection identity is already carried on assets via `connectionName` / `connectionQualifiedName` (separate fields); the Atlan UI's connection-stable slug (`<connector>-<short>` like `dbt-AMBSvQPJ`) isn't plumbed through to the SDK today. Callers that want a stable identifier in this specific field can pass `workflow_name=<value>` via the override knob. |
| Third-party app developers shouldn't have to know about workflow id de-referencing | zero-arg `set_last_sync_details_on_asset(asset)` works in any Temporal context |
| Transformation should target pyatlan `Asset`, not dicts or daft.DataFrames | Single Asset-based API; dict helpers removed; AtlasTransformer routes through the Asset helper internally |
| AE / publish ownership debate | The primitive is location-neutral — AtlasTransformer-using connectors get the fix for free; publish or AE can call it later without re-deciding the values |

## Known trade-offs (documented in module docstring)
1. **`last_sync_run` default is correlation_id, not Temporal `run_id`** — favours end-to-end correlation across extract + publish over UI clickthrough. Callers can override via `run=`.
2. **`last_sync_workflow_name` is the AE Temporal workflow_id (run-unique UUID), not the Atlan UI's workflow slug.** The UI slug isn't plumbed to the SDK; connection identity is on `connection_name` / `connection_qualified_name`. Callers can override via `workflow_name=`.
3. **One-level parent walk-up** — covers today's single-layer child-workflow shape. Deeper nesting would need the AE id propagated via Temporal memo (mirroring the existing `correlation_id` pattern in `execution/_temporal/interceptors/log.py`). Not in scope.

## Test plan
- [x] `uv run pytest tests/unit/transformers/atlas/ tests/unit/transformers/common/` — 113 passed
- [x] `uv run pre-commit run --files <touched files>` — clean
- [x] Validated `parent_workflow_id` and child `workflow_id` shapes against a real AE-dispatched BigQuery extract run (UUIDs in test fixtures are the actual observed values)
- [ ] Manual smoke test of an app that uses `AtlasTransformer` once merged + released, confirming `lastSyncWorkflowName` on a transformed asset matches the AE workflow id visible in Temporal UI
- [ ] Follow-up in `atlan-dbt-app`: replace hand-rolled stamping in `app/dbt_logic/dbt_asset_processors/base_transformer.py` + `tag_processor.py` + `lineage/process_transformer.py` with `set_last_sync_details_on_asset()` (this PR only fixes AtlasTransformer-based connectors automatically; dbt-app has its own transformer and is the canonical proof of the bug in production source)