### PR TITLE
[ARUN-615] : fix(observability): allow workflow_run.* prefix through loguru attri…

### DIFF
--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -131,6 +131,10 @@ _PREFIXES_PASSTHROUGH = (
     "otel.",  # OTel semconv: otel.status_code
     "temporal.",  # SDK convention: temporal.workflow.id, etc.
     "tenant.",
+    "workflow_run.",  # AE convention: workflow_run.terminated / workflow_run.node
+    # events emitted from AutomationEngineWorkflow's finally block,
+    # carrying typed FailureDetails (category, code, audience,
+    # retryable, evidence) projected from the cause chain.
 )
 
 


### PR DESCRIPTION
Lets the Automation Engine emit its workflow_run.terminated and workflow_run.node lifecycle log lines directly from workflow code via the SDK's loguru adapter, without bypassing the sink to call the OTel logs API directly.

Background: AE walks the Temporal cause chain to find the deepest typed FailureDetails on a failed workflow, then emits two structured log lines per terminated workflow run:
  - workflow_run.terminated: one per run, carrying the typed FailureDetails on workflow_run.failure.* keys.
  - workflow_run.node: one per DAG node, with per-node typed failure on workflow_run.node.failure.* keys.

Before this change, _build_extra_dict's allowlist dropped every workflow_run.* key on the floor, so AE bypassed loguru entirely and called the OTel logs SDK directly. That bypass had to run in an activity rather than workflow code (the OTel SDK is non-deterministic and Temporal replay-violates calls from inside a workflow).

Adding workflow_run. to _PREFIXES_PASSTHROUGH lets AE call logger.info("workflow_run.terminated", **attrs) from AutomationEngineWorkflow's finally block directly, collapsing the extra activity into a single log line — matching how workflow.started/ended already work in the SDK's interceptor.

No change to keys outside the workflow_run.* prefix.

Tested: existing 273 observability tests pass. Synthetic loguru record_extra with workflow_run.guid / workflow_run.failure.category / workflow_run.node.app_name flows through _build_extra_dict end-to-end and lands as OTLP attributes.

### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- _to be added_

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.