### PR TITLE
fix(handler): align preflight response shape with SageV2 widget (BLDX-901 follow-up, DBBI-665)

### DIFF
--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -633,14 +633,30 @@ def create_app_handler_service(
                 )
                 # Build v2-compatible response: each check becomes a top-level
                 # key in data so the frontend can iterate check names directly.
-                # v2 format: {"authenticationCheck": {"success": true, "message": "..."}, ...}
+                # v2 format: {"authenticationCheck": {"success": true,
+                # "successMessage": "...", "failureMessage": "..."}, ...}.
+                #
+                # The SageV2 widget at
+                # atlan-frontend/src/workflowsv2/components/dynamicForm2/widget/SageV2.vue:271-273
+                # renders ``checkResult.success ? successMessage :
+                # failureMessage`` with no fallback to ``message``, so omitting
+                # those fields leaves the detail panel blank on a failed check
+                # (DBBI-665, WARE-1250). ``message`` is retained so any
+                # consumer already reading the v3 field keeps working.
+                #
+                # This finishes the third sub-mismatch from BLDX-901; PR #1228
+                # converted ``checks`` → camelCase keys and ``passed`` →
+                # ``success`` but left the message-field rename.
                 v2_data: dict[str, Any] = {}
                 for check in result.checks:
                     # Convert check name to camelCase key (e.g. "AuthCheck" -> "authCheck")
                     key = check.name[0].lower() + check.name[1:]
+                    msg = check.message or ""
                     v2_data[key] = {
                         "success": check.passed,
-                        "message": check.message or "",
+                        "message": msg,
+                        "successMessage": msg if check.passed else "",
+                        "failureMessage": "" if check.passed else msg,
                     }
                 return JSONResponse(
                     content=_wrap_response(

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -63,7 +63,6 @@ from application_sdk.handler.contracts import (
     HandlerCredential,
     MetadataInput,
     PreflightInput,
-    PreflightStatus,
     SubscriptionConfig,
 )
 from application_sdk.handler.manifest import AppManifest
@@ -658,12 +657,24 @@ def create_app_handler_service(
                         "successMessage": msg if check.passed else "",
                         "failureMessage": "" if check.passed else msg,
                     }
+                # Envelope ``success`` reports whether preflight executed at
+                # all, not whether every check passed — per-check pass/fail
+                # belongs in ``data.<check>.success``. The SageV2 widget at
+                # SageV2.vue:249 short-circuits on ``!response.success`` and
+                # skips the per-check render loop entirely, so collapsing
+                # envelope success to ``status == READY`` (the previous
+                # behaviour) made every PARTIAL/NOT_READY response surface
+                # as "Check failed" with a blank "Hide details" panel
+                # (DBBI-665). Tying envelope success to "any check ran"
+                # keeps it false when the handler produced no checks (a
+                # genuine preflight-system failure) and lets the widget
+                # render per-check rows otherwise.
                 return JSONResponse(
                     content=_wrap_response(
                         v2_data,
                         message=result.message
                         or f"Preflight check {result.status.value}",
-                        success=result.status == PreflightStatus.READY,
+                        success=len(result.checks) > 0,
                     )
                 )
             except HandlerError as e:

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -354,9 +354,12 @@ class TestPreflightEndpoint:
         )
         assert response.status_code == 200
         body = response.json()
-        assert body["success"] is True
+        # _TestHandler returns no checks, so envelope success is false
+        # (envelope success now means "preflight produced checks" — a handler
+        # that returns zero checks is treated as a preflight-system failure
+        # so the widget falls back to the top-level "Check failed" path).
+        assert body["success"] is False
         # v2 format: data is a dict of check results keyed by camelCase name.
-        # _TestHandler returns no checks, so data is empty.
         assert body["data"] == {}
         assert body["message"] == "ready"
 
@@ -556,6 +559,131 @@ class TestPreflightEndpoint:
         assert entry["message"] == ""
         assert entry["successMessage"] == ""
         assert entry["failureMessage"] == ""
+
+    # ------------------------------------------------------------------
+    # Envelope ``success`` reports preflight execution, not per-check pass
+    # (DBBI-665 root cause).
+    # ------------------------------------------------------------------
+    #
+    # The previous behaviour ``success = (status == READY)`` made every
+    # PARTIAL/NOT_READY response surface as a blank "Check failed" panel
+    # because SageV2.vue:249 short-circuits on ``!response.success`` and
+    # never iterates the per-check data. These tests pin the new contract:
+    # envelope success is true as long as preflight produced any checks.
+
+    def test_preflight_envelope_success_true_when_all_checks_pass(self) -> None:
+        """Status READY → envelope success true (regression guard)."""
+
+        class _OneCheck(_TestHandler):
+            async def preflight_check(self, input: PreflightInput) -> PreflightOutput:
+                from application_sdk.handler.contracts import PreflightCheck
+
+                return PreflightOutput(
+                    status=PreflightStatus.READY,
+                    checks=[
+                        PreflightCheck(name="apiVersion", passed=True, message="ok")
+                    ],
+                )
+
+        body = (
+            _make_client(handler=_OneCheck())
+            .post("/workflows/v1/check", json={"credentials": []})
+            .json()
+        )
+        assert body["success"] is True
+
+    def test_preflight_envelope_success_true_when_a_check_fails(self) -> None:
+        """Status NOT_READY → envelope success TRUE so SageV2 still renders per-check rows.
+
+        This is the DBBI-665 case: previously a failed check forced envelope
+        success=false, which made the widget skip the per-check loop entirely
+        and show a blank "Hide details" panel. Pinning envelope success=true
+        whenever checks ran lets the per-check rows render.
+        """
+
+        class _OneCheck(_TestHandler):
+            async def preflight_check(self, input: PreflightInput) -> PreflightOutput:
+                from application_sdk.handler.contracts import PreflightCheck
+
+                return PreflightOutput(
+                    status=PreflightStatus.NOT_READY,
+                    checks=[
+                        PreflightCheck(
+                            name="apiVersion",
+                            passed=False,
+                            message="Could not connect to Tableau",
+                        )
+                    ],
+                )
+
+        body = (
+            _make_client(handler=_OneCheck())
+            .post("/workflows/v1/check", json={"credentials": []})
+            .json()
+        )
+        assert body["success"] is True
+        # Per-check detail is still on the wire so the widget can render it.
+        assert body["data"]["apiVersion"]["success"] is False
+        assert body["data"]["apiVersion"]["failureMessage"] == (
+            "Could not connect to Tableau"
+        )
+
+    def test_preflight_envelope_success_true_on_partial_status(self) -> None:
+        """Status PARTIAL → envelope success TRUE.
+
+        Mixed pass/fail must surface to the UI; a single failing check
+        cannot collapse the entire response.
+        """
+
+        class _Mixed(_TestHandler):
+            async def preflight_check(self, input: PreflightInput) -> PreflightOutput:
+                from application_sdk.handler.contracts import PreflightCheck
+
+                return PreflightOutput(
+                    status=PreflightStatus.PARTIAL,
+                    checks=[
+                        PreflightCheck(name="apiVersion", passed=True, message="ok"),
+                        PreflightCheck(
+                            name="metadataAPI",
+                            passed=False,
+                            message="GraphQL 404",
+                        ),
+                    ],
+                )
+
+        body = (
+            _make_client(handler=_Mixed())
+            .post("/workflows/v1/check", json={"credentials": []})
+            .json()
+        )
+        assert body["success"] is True
+        assert body["data"]["apiVersion"]["success"] is True
+        assert body["data"]["metadataAPI"]["failureMessage"] == "GraphQL 404"
+
+    def test_preflight_envelope_success_false_when_no_checks_run(self) -> None:
+        """No checks emitted → envelope success FALSE — preflight-system failure.
+
+        A handler that returns zero checks signals that preflight itself
+        couldn't execute (e.g. the client failed to construct). The widget
+        falls back to the top-level "Check failed" branch — same UX as a
+        thrown exception, just without the 500.
+        """
+
+        class _ZeroChecks(_TestHandler):
+            async def preflight_check(self, input: PreflightInput) -> PreflightOutput:
+                return PreflightOutput(
+                    status=PreflightStatus.NOT_READY,
+                    checks=[],
+                    message="couldn't build client",
+                )
+
+        body = (
+            _make_client(handler=_ZeroChecks())
+            .post("/workflows/v1/check", json={"credentials": []})
+            .json()
+        )
+        assert body["success"] is False
+        assert body["data"] == {}
 
 
 class TestMetadataEndpoint:

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -423,6 +423,140 @@ class TestPreflightEndpoint:
         assert response.status_code == 200
         assert received == [{}]
 
+    # ------------------------------------------------------------------
+    # Per-check v2-shape fields (DBBI-665 / WARE-1250 / finishes BLDX-901)
+    # ------------------------------------------------------------------
+    #
+    # The SageV2 widget at
+    # atlan-frontend/src/workflowsv2/components/dynamicForm2/widget/SageV2.vue:271-273
+    # renders ``checkResult.success ? successMessage : failureMessage`` with
+    # no fallback to ``message``. PR #1228 (BLDX-901) finished two of the
+    # three sub-mismatches but dropped this rename; these tests pin the
+    # finished shape so it does not regress again.
+
+    def test_preflight_check_emits_v2_success_fields(self) -> None:
+        """A passing check carries the message in successMessage; failureMessage is empty."""
+
+        class _OneCheck(_TestHandler):
+            async def preflight_check(self, input: PreflightInput) -> PreflightOutput:
+                from application_sdk.handler.contracts import PreflightCheck
+
+                return PreflightOutput(
+                    status=PreflightStatus.READY,
+                    checks=[
+                        PreflightCheck(
+                            name="apiVersion",
+                            passed=True,
+                            message="API version 3.17 is supported",
+                        )
+                    ],
+                )
+
+        client = _make_client(handler=_OneCheck())
+        body = client.post("/workflows/v1/check", json={"credentials": []}).json()
+        entry = body["data"]["apiVersion"]
+        assert entry["success"] is True
+        assert entry["message"] == "API version 3.17 is supported"
+        assert entry["successMessage"] == "API version 3.17 is supported"
+        assert entry["failureMessage"] == ""
+
+    def test_preflight_check_emits_v2_failure_fields(self) -> None:
+        """A failing check carries the message in failureMessage; successMessage is empty.
+
+        This is the DBBI-665 / IEEE case — without ``failureMessage`` the
+        SageV2 widget renders an empty "Hide details" panel even though the
+        handler set a real message on the check.
+        """
+
+        class _OneCheck(_TestHandler):
+            async def preflight_check(self, input: PreflightInput) -> PreflightOutput:
+                from application_sdk.handler.contracts import PreflightCheck
+
+                return PreflightOutput(
+                    status=PreflightStatus.NOT_READY,
+                    checks=[
+                        PreflightCheck(
+                            name="metadataAPI",
+                            passed=False,
+                            message="Metadata GraphQL API returned no sites",
+                        )
+                    ],
+                )
+
+        client = _make_client(handler=_OneCheck())
+        body = client.post("/workflows/v1/check", json={"credentials": []}).json()
+        entry = body["data"]["metadataAPI"]
+        assert entry["success"] is False
+        assert entry["message"] == "Metadata GraphQL API returned no sites"
+        assert entry["failureMessage"] == "Metadata GraphQL API returned no sites"
+        assert entry["successMessage"] == ""
+
+    def test_preflight_check_multiple_checks_v2_fields_per_check(self) -> None:
+        """Mixed pass/fail set — each check entry carries its own v2 fields."""
+
+        class _ThreeChecks(_TestHandler):
+            async def preflight_check(self, input: PreflightInput) -> PreflightOutput:
+                from application_sdk.handler.contracts import PreflightCheck
+
+                return PreflightOutput(
+                    status=PreflightStatus.PARTIAL,
+                    checks=[
+                        PreflightCheck(
+                            name="apiVersion",
+                            passed=True,
+                            message="API version 3.17 is supported",
+                        ),
+                        PreflightCheck(
+                            name="viewCapability",
+                            passed=True,
+                            message="Projects accessible — 5 project(s) found",
+                        ),
+                        PreflightCheck(
+                            name="metadataAPI",
+                            passed=False,
+                            message="Metadata GraphQL API returned 404",
+                        ),
+                    ],
+                )
+
+        client = _make_client(handler=_ThreeChecks())
+        data = client.post("/workflows/v1/check", json={"credentials": []}).json()[
+            "data"
+        ]
+
+        assert data["apiVersion"]["successMessage"].startswith("API version")
+        assert data["apiVersion"]["failureMessage"] == ""
+        assert data["viewCapability"]["successMessage"].startswith("Projects")
+        assert data["viewCapability"]["failureMessage"] == ""
+        assert data["metadataAPI"]["failureMessage"] == (
+            "Metadata GraphQL API returned 404"
+        )
+        assert data["metadataAPI"]["successMessage"] == ""
+        # ``message`` is preserved on every entry for any v3-shape consumer.
+        for name in ("apiVersion", "viewCapability", "metadataAPI"):
+            assert data[name]["message"]
+
+    def test_preflight_check_empty_message_yields_empty_v2_fields(self) -> None:
+        """A check with no message yields empty strings in all message fields."""
+
+        class _OneCheck(_TestHandler):
+            async def preflight_check(self, input: PreflightInput) -> PreflightOutput:
+                from application_sdk.handler.contracts import PreflightCheck
+
+                return PreflightOutput(
+                    status=PreflightStatus.NOT_READY,
+                    checks=[PreflightCheck(name="connectivity", passed=False)],
+                )
+
+        client = _make_client(handler=_OneCheck())
+        entry = client.post("/workflows/v1/check", json={"credentials": []}).json()[
+            "data"
+        ]["connectivity"]
+        assert entry["success"] is False
+        assert entry["message"] == ""
+        assert entry["successMessage"] == ""
+        assert entry["failureMessage"] == ""
+
 
 class TestMetadataEndpoint:
     """Tests for POST /workflows/v1/metadata."""


### PR DESCRIPTION
## Summary

Two related SDK serialization bugs in `application_sdk/handler/service.py` make every customer-facing preflight failure on a v3 native app surface as **"Check failed"** with an empty "Hide details" panel — verified against IEEE's Tableau preflight ([DBBI-665](https://linear.app/atlan-epd/issue/DBBI-665)) and the SageV2 widget source (`atlan-frontend/src/workflowsv2/components/dynamicForm2/widget/SageV2.vue`).

### Bug 1 — Per-check field rename was dropped from BLDX-901

[BLDX-901](https://linear.app/atlan-epd/issue/BLDX-901) flagged three sub-mismatches between SDK `/workflows/v1/check` responses and the SageV2 widget. PR #1228 closed two of them (camelCase keys, `passed → success`) but silently dropped the third — the `message → successMessage / failureMessage` rename. [WARE-1250](https://linear.app/atlan-epd/issue/WARE-1250) re-flagged the gap on 2026-05-02 as a "separate SDK-side issue."

SageV2.vue:271-273 reads `checkResult.success ? successMessage : failureMessage`, with no fallback to `message`. The detail line under each check row is `<div v-if="step.message">` — `undefined` skips the entire render. Per-check messages never display.

### Bug 2 — Envelope `success` short-circuits SageV2 rendering

Before this PR:
```python
success = result.status == PreflightStatus.READY
```

Any failing check flips status to `NOT_READY` (or `PARTIAL`) → envelope `success: false`. SageV2.vue:249-254:

```js
if (!response.success || !response.data) {
    currentStepStatus.value = AuthCheckStatus.ERROR
    currentStepMessage.value = t('Check failed')
    return   // ← never reaches the per-check for-loop
}
```

The widget bails before populating `allStepResponse`. No per-check rows. No detail lines. Just "Check failed" + blank "Hide details" — the exact DBBI-665 symptom.

### Empirical verification

Two live production responses confirmed the diagnosis end-to-end:

| App | Outer `success` | Per-check `data` | UI |
|---|---|---|---|
| **Sigma** (all passed) | `true` | `{connectionAccessPermission: {success:true, message:"..."}, ...}` | "Connection Access Permission check passed" rows render (title+suffix from key) |
| **Tableau** (apiVersion failed) | `false` | `{apiVersion: {success:false, message:"Could not connect to Tableau: ..."}}` | "Check failed", blank "Hide details" — widget short-circuits |

Sigma "works" only because all its checks pass — the moment one fails it hits the same blank panel. Every v3 native app is one failing preflight away from the same UI bug.

## What changed

`application_sdk/handler/service.py` preflight response builder:

```python
v2_data[key] = {
    "success": check.passed,
    "message": msg,                                    # preserved for v3 consumers
    "successMessage": msg if check.passed else "",     # SageV2 reads this on success
    "failureMessage": "" if check.passed else msg,     # SageV2 reads this on failure
}
...
return JSONResponse(
    content=_wrap_response(
        v2_data,
        message=...,
        success=len(result.checks) > 0,   # envelope success = preflight executed
    )
)
```

`message` is retained so any v3-shape consumer keeps working. Envelope `success` now reports whether preflight executed at all; per-check pass/fail is on `data.<check>.success`. Zero-check responses (handler couldn't build a client, etc.) still surface as `success: false` so the widget falls through to its top-level "Check failed" branch.

## Test plan

- [x] `uv run pytest tests/unit/handler/test_service.py -q` — 193/193 pass
- [x] 8 new tests covering: pass/fail/multi-check/empty-message per-check shape + envelope success across READY / NOT_READY / PARTIAL / zero-checks
- [x] `uv run pre-commit run` — ruff, ruff-format, pyright, isort all clean
- [ ] After release: bump SDK pin on `atlan-tableau-app` v3-ae and re-run IEEE's `atlan-tableau-1758212129` preflight. The "Hide details" panel should expand to show "API Version check failed" with the underlying message ("Could not connect to Tableau: Tableau signin failed (no response)") rendered below it.

## Related

- Linear: [BLDX-901](https://linear.app/atlan-epd/issue/BLDX-901) (this finishes it), [WARE-1250](https://linear.app/atlan-epd/issue/WARE-1250), [DBBI-665](https://linear.app/atlan-epd/issue/DBBI-665) (customer impact — IEEE Tableau)
- Prior SDK PR: #1228 (BLDX-901 partial fix)
- Frontend widget: `atlan-frontend/src/workflowsv2/components/dynamicForm2/widget/SageV2.vue:249,271-273`

🤖 Generated with [Claude Code](https://claude.com/claude-code)