### PR TITLE
fix(storage): guard prefix downloads against path-traversal keys (BLDX-1270)

### DIFF
--- a/application_sdk/storage/batch.py
+++ b/application_sdk/storage/batch.py
@@ -29,6 +29,7 @@ from application_sdk.storage.ops import (
     _list_items,
     _normalize_listing_prefix,
     _resolve_store,
+    _safe_join_under,
     download_file,
     normalize_key,
     upload_file,
@@ -230,8 +231,8 @@ async def download_prefix(
 
     keys = await list_keys(prefix, store, suffix=suffix, normalize=normalize)
     local = Path(local_dir)
-    # S3 keys use forward slashes; convert to OS-native path for local filesystem
-    destinations = [str(local / Path(*PurePosixPath(key).parts)) for key in keys]
+    # Reject keys whose resolved path escapes local_dir (e.g. via ".." segments).
+    destinations = [str(_safe_join_under(local, key)) for key in keys]
 
     sem = asyncio.Semaphore(max_concurrency)
 

--- a/application_sdk/storage/cloud.py
+++ b/application_sdk/storage/cloud.py
@@ -55,7 +55,12 @@ from application_sdk.storage.errors import (
     StorageError,
     StorageNotFoundError,
 )
-from application_sdk.storage.ops import _list_items, download_file, upload_file
+from application_sdk.storage.ops import (
+    _list_items,
+    _safe_join_under,
+    download_file,
+    upload_file,
+)
 
 # Lazy import: direct get_logger() at module load would create a circular
 # dependency (observability -> storage -> cloud -> observability).
@@ -249,7 +254,6 @@ class CloudStore:
                 + (f" (filter: {suffix_filter})" if suffix_filter else "")
             )
 
-        resolved_output = output.resolve()
         sem = asyncio.Semaphore(max_concurrency)
 
         async def _dl(obj_key: str) -> Path:
@@ -259,10 +263,8 @@ class CloudStore:
                     if list_prefix and obj_key.startswith(list_prefix)
                     else Path(obj_key).name
                 )
-                local_path = (output / rel).resolve()
-                # Prevent path traversal from malicious remote keys
-                if not local_path.is_relative_to(resolved_output):
-                    raise StorageError(f"Path traversal detected in key: {obj_key!r}")
+                # Reject keys whose resolved path escapes output (e.g. via ".." segments).
+                local_path = _safe_join_under(output, rel)
                 await download_file(
                     obj_key, local_path, store=self._store, normalize=False
                 )

--- a/application_sdk/storage/ops.py
+++ b/application_sdk/storage/ops.py
@@ -42,7 +42,7 @@ import logging
 import math
 import os
 import time
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
 import obstore
@@ -114,6 +114,36 @@ def normalize_key(key: str) -> str:
     normalized = normalized.replace("\\", "/").replace(os.sep, "/").strip("/")
     # os.path.relpath resolves the staging root itself to "."; treat as store root.
     return "" if normalized == "." else normalized
+
+
+def _safe_join_under(root: Path | str, rel: str) -> Path:
+    """Join *rel* under *root* and reject path-traversal escapes.
+
+    S3-style keys use POSIX separators, so *rel* is split with
+    :class:`~pathlib.PurePosixPath` before being joined to *root*. The
+    candidate path is then resolved and compared against the resolved
+    *root*; anything that escapes (``..`` segments, symlinks pointing
+    outside, etc.) is rejected before the caller writes to disk.
+
+    Args:
+        root: Local destination directory.
+        rel: Relative path derived from an object-store key.
+
+    Returns:
+        Resolved absolute :class:`~pathlib.Path` guaranteed to be inside
+        *root*.
+
+    Raises:
+        StorageError: If *rel* resolves outside *root*.
+    """
+    from application_sdk.storage.errors import StorageError  # noqa: PLC0415
+
+    resolved_root = Path(root).resolve()
+    parts = PurePosixPath(rel.lstrip("/")).parts
+    candidate = (resolved_root / Path(*parts)).resolve() if parts else resolved_root
+    if not candidate.is_relative_to(resolved_root):
+        raise StorageError(f"Path traversal detected in key: {rel!r}")
+    return candidate
 
 
 def _normalize_listing_prefix(prefix: str, normalize: bool) -> str:

--- a/application_sdk/storage/reference.py
+++ b/application_sdk/storage/reference.py
@@ -353,6 +353,7 @@ async def materialize_file_reference(
         StorageNotFoundError,
     )
     from application_sdk.storage.ops import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
+        _safe_join_under,
         download_file,
         download_file_chunked,
         get_file_size,
@@ -529,8 +530,9 @@ async def materialize_file_reference(
         async def _download_one(key: str) -> bool:
             """Download one file from the prefix. Returns True if skipped (cache hit)."""
             rel = key.removeprefix(prefix)
-            dest = os.path.join(local_directory, rel)
-            dest_path = Path(dest)
+            # Reject keys whose resolved path escapes local_directory.
+            dest_path = _safe_join_under(local_directory, rel)
+            dest = str(dest_path)
             dest_sidecar = Path(dest + ".sha256")
             dest_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/application_sdk/storage/transfer.py
+++ b/application_sdk/storage/transfer.py
@@ -21,7 +21,7 @@ import asyncio
 import hashlib
 import os
 import tempfile
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from application_sdk.constants import MAX_CONCURRENT_STORAGE_TRANSFERS
@@ -345,6 +345,7 @@ async def download(
     )
     from application_sdk.storage.ops import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
         _resolve_store,
+        _safe_join_under,
         normalize_key,
     )
 
@@ -415,8 +416,8 @@ async def download(
         transferred_count = 0
         for key in data_keys:
             rel = key.removeprefix(strip)
-            # S3 keys use forward slashes; convert to OS-native path for local filesystem
-            local_file = dest_dir / Path(*PurePosixPath(rel.lstrip("/")).parts)
+            # Reject keys whose resolved path escapes dest_dir (e.g. via ".." segments).
+            local_file = _safe_join_under(dest_dir, rel)
             ok, _ = await _download_one(
                 resolved, key, local_file, skip_if_exists=skip_if_exists
             )

--- a/tests/unit/storage/test_batch.py
+++ b/tests/unit/storage/test_batch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -160,6 +160,25 @@ class TestDownloadPrefix:
     async def test_empty_prefix_returns_no_files(self, store, tmp_path) -> None:
         dests = await download_prefix("nothing/", tmp_path, store, normalize=False)
         assert dests == []
+
+    async def test_path_traversal_in_key_rejected(self, store, tmp_path) -> None:
+        """A listed key containing ``..`` must not write outside *local_dir*.
+
+        obstore rejects ``..`` keys on put, so we plant a hostile listing via
+        a patched ``list_keys`` and assert the containment guard fires before
+        any local write happens (issue #1694).
+        """
+        dest = tmp_path / "dest"
+        canary = tmp_path / "canary.txt"
+        with (
+            patch(
+                "application_sdk.storage.batch.list_keys",
+                new=AsyncMock(return_value=["safe/../../canary.txt"]),
+            ),
+            pytest.raises(StorageError, match="Path traversal"),
+        ):
+            await download_prefix("p/", dest, store, normalize=False)
+        assert not canary.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/storage/test_ops.py
+++ b/tests/unit/storage/test_ops.py
@@ -793,3 +793,41 @@ async def test_upload_file_does_not_delete_when_retain_local_copy_true(
         )
     assert isinstance(digest, str)
     assert f.exists()
+
+
+# ---------------------------------------------------------------------------
+# _safe_join_under — containment guard for prefix downloads (issue #1694)
+# ---------------------------------------------------------------------------
+
+
+class TestSafeJoinUnder:
+    def test_simple_key_resolves_inside_root(self, tmp_path) -> None:
+        from application_sdk.storage.ops import _safe_join_under
+
+        result = _safe_join_under(tmp_path, "sub/file.txt")
+        assert result == (tmp_path / "sub" / "file.txt").resolve()
+        assert result.is_relative_to(tmp_path.resolve())
+
+    def test_leading_slash_stripped(self, tmp_path) -> None:
+        from application_sdk.storage.ops import _safe_join_under
+
+        result = _safe_join_under(tmp_path, "/a/b.txt")
+        assert result == (tmp_path / "a" / "b.txt").resolve()
+
+    def test_parent_traversal_rejected(self, tmp_path) -> None:
+        from application_sdk.storage.ops import _safe_join_under
+
+        with pytest.raises(StorageError, match="Path traversal"):
+            _safe_join_under(tmp_path, "../escape.txt")
+
+    def test_mixed_traversal_rejected(self, tmp_path) -> None:
+        from application_sdk.storage.ops import _safe_join_under
+
+        with pytest.raises(StorageError, match="Path traversal"):
+            _safe_join_under(tmp_path, "safe/../../escape.txt")
+
+    def test_empty_rel_returns_root(self, tmp_path) -> None:
+        from application_sdk.storage.ops import _safe_join_under
+
+        result = _safe_join_under(tmp_path, "")
+        assert result == tmp_path.resolve()

--- a/tests/unit/storage/test_reference.py
+++ b/tests/unit/storage/test_reference.py
@@ -363,6 +363,34 @@ class TestMaterializeFileReference:
         # Cleanup
         Path(result.local_path).joinpath("x.txt").unlink(missing_ok=True)
 
+    async def test_directory_materialize_path_traversal_rejected(
+        self, store, tmp_path
+    ) -> None:
+        """A listed key containing ``..`` must not write outside *local_path*.
+
+        obstore rejects ``..`` keys on put, so we patch ``list_keys`` to plant
+        a hostile listing and assert the containment guard fires before any
+        write happens (issue #1694).
+        """
+        from unittest.mock import AsyncMock
+
+        local_dir = tmp_path / "out"
+        canary = tmp_path / "canary.txt"
+        ref = FileReference(
+            local_path=str(local_dir),
+            is_durable=True,
+            storage_path="dirkey",
+        )
+        with (
+            patch(
+                "application_sdk.storage.batch.list_keys",
+                new=AsyncMock(return_value=["dirkey/../../canary.txt"]),
+            ),
+            pytest.raises(StorageError, match="Path traversal"),
+        ):
+            await materialize_file_reference(store, ref)
+        assert not canary.exists()
+
 
 # ---------------------------------------------------------------------------
 # Sidecar fetch error handling (best-effort)

--- a/tests/unit/storage/test_transfer.py
+++ b/tests/unit/storage/test_transfer.py
@@ -325,3 +325,28 @@ class TestDownloadDirectory:
         # Only 1 real file — sidecar should not appear in file_count or on disk
         assert dl.ref.file_count == 1
         assert not (dest / "data.txt.sha256").exists()
+
+    async def test_path_traversal_in_listed_key_rejected(self, store, tmp_path) -> None:
+        """A listed key containing ``..`` must not write outside dest_dir.
+
+        obstore rejects ``..`` keys on put, so we patch ``list_keys`` to plant
+        a hostile listing and assert the containment guard fires before any
+        write happens (issue #1694).
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from application_sdk.storage.errors import StorageError
+
+        dest = tmp_path / "dest"
+        canary = tmp_path / "canary.txt"
+        # Trailing slash in storage_path puts download() straight into prefix
+        # mode, so only the prefix listing is consulted.
+        with (
+            patch(
+                "application_sdk.storage.batch.list_keys",
+                new=AsyncMock(return_value=["p/safe/../../canary.txt"]),
+            ),
+            pytest.raises(StorageError, match="Path traversal"),
+        ):
+            await download("p/", str(dest), store=store)
+        assert not canary.exists()


### PR DESCRIPTION
## Summary

Closes #1694.

`CloudStore._download_prefix` already resolves each candidate local path
and rejects keys whose resolved path escapes the caller-provided
destination directory. Three other prefix-download paths in the SDK did
not — they built local paths directly from object-store keys and wrote
them without a containment check:

- `application_sdk/storage/transfer.py` — `download()` prefix branch
- `application_sdk/storage/batch.py` — `download_prefix()`
- `application_sdk/storage/reference.py` — `materialize_file_reference()` directory branch

A malformed or unexpected key (e.g. one containing `..` segments) could
therefore land outside the caller's intended destination and overwrite
adjacent files in the app workspace.

## What changed

- Added `_safe_join_under(root, rel) -> Path` helper to
  `application_sdk/storage/ops.py`. It resolves `rel` under `root` using
  `PurePosixPath` (S3 keys are POSIX), then resolves and checks the
  candidate against the resolved root and raises `StorageError` on
  escape.
- Applied the helper in `transfer.download()`, `batch.download_prefix()`,
  and `materialize_file_reference()` (directory branch).
- Refactored `CloudStore._download_prefix` to use the same helper for a
  single source of truth.

## Test plan

- [x] New unit tests for `_safe_join_under` covering simple keys, leading
  slash, parent traversal, mixed `..` segments, and empty `rel`.
- [x] Regression tests for `transfer.download`, `batch.download_prefix`,
  and `materialize_file_reference` that patch `list_keys` to return a
  hostile key (obstore rejects `..` keys on put, so the listing has to
  be planted via mock) and assert `StorageError` is raised with
  `Path traversal` in the message **and** no canary file is written
  outside the destination.
- [x] Full `tests/unit/storage` suite passes (443 passed, 3 skipped).
- [x] `pre-commit run` clean on touched files.