### PR TITLE
ci(parse-atlan-yaml): relax env_overrides validator for tenant-name keys

### DIFF
--- a/.github/scripts/parse_atlan_yaml.py
+++ b/.github/scripts/parse_atlan_yaml.py
@@ -158,9 +158,7 @@ def _validate_env_overrides(deploy_val: Any) -> None:
         _err("deploy.env_overrides must be a mapping of channel-or-tenant → env vars")
     for key, env in overrides.items():
         if not isinstance(key, str) or not key:
-            _err(
-                f"deploy.env_overrides keys must be non-empty strings; " f"got {key!r}"
-            )
+            _err(f"deploy.env_overrides keys must be non-empty strings; got {key!r}")
         if not isinstance(env, dict):
             _err(
                 f"deploy.env_overrides.{key} must be a mapping of env vars; "

--- a/.github/scripts/parse_atlan_yaml.py
+++ b/.github/scripts/parse_atlan_yaml.py
@@ -42,10 +42,11 @@ _KEBAB_RE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
 # Closed type set. Mirrors core.version.model.EntrypointPackageType in GM.
 _ALLOWED_TYPES = {"connector", "miner", "orchestrator", "utility", "custom"}
 
-# Channels for which ``deploy.env_overrides.<channel>`` actually takes
-# effect at GM's catalog read. Mirrors ``_OVERRIDABLE_CHANNELS`` in
-# ``core/release/config_resolver.py`` in global-marketplace. Bumping this
-# set is a coordinated change with GM.
+# Channel keys that GM's catalog read interprets as channel-tier overrides.
+# Any other key is interpreted as a tenant-name-tier override (matched against
+# horizon_tenants.name at runtime). We keep this constant for diagnostics —
+# the validator no longer rejects non-channel keys, since tenant-name entries
+# are a supported atlan.yaml shape.
 _OVERRIDABLE_CHANNELS = {"beta", "staging"}
 
 # Required keys for each entrypoints entry. description and icon_url
@@ -133,19 +134,20 @@ def _validate_entrypoints(wp_val: Any) -> str:
 def _validate_env_overrides(deploy_val: Any) -> None:
     """Validate ``deploy.env_overrides`` shape, if present.
 
-    GM's resolver is intentionally lenient (silent no-op on malformed input)
-    so a typo'd channel name would ship the base config to that channel with
-    no signal to the developer. We fail CI fast instead.
+    GM's resolver interprets ``env_overrides`` keys in two tiers: ``beta`` /
+    ``staging`` are channel-tier; anything else is a tenant-name match
+    against ``horizon_tenants.name``. We can only validate the shape here —
+    the SDK doesn't know the live tenant list, so we don't reject unknown
+    keys (a typo'd ``staing`` is silently a tenant name as far as the SDK
+    is concerned, and falls through to the channel tier on GM at runtime).
 
     Allowed shape::
 
         deploy:
           env_overrides:
-            beta:    {KEY: value, ...}
-            staging: {KEY: value, ...}
-
-    Only channels in ``_OVERRIDABLE_CHANNELS`` are accepted; bumping that set
-    is a coordinated change with GM's ``config_resolver._OVERRIDABLE_CHANNELS``.
+            beta:        {KEY: value, ...}
+            staging:     {KEY: value, ...}
+            tenant-xyz:  {KEY: value, ...}     # any string key = tenant name
     """
     if not isinstance(deploy_val, dict):
         return
@@ -153,17 +155,15 @@ def _validate_env_overrides(deploy_val: Any) -> None:
     if overrides is None:
         return
     if not isinstance(overrides, dict):
-        _err("deploy.env_overrides must be a mapping of channel → env vars")
-    unknown = set(overrides.keys()) - _OVERRIDABLE_CHANNELS
-    if unknown:
-        _err(
-            f"deploy.env_overrides has unknown channel(s) {sorted(unknown)}; "
-            f"allowed: {sorted(_OVERRIDABLE_CHANNELS)}"
-        )
-    for channel, env in overrides.items():
+        _err("deploy.env_overrides must be a mapping of channel-or-tenant → env vars")
+    for key, env in overrides.items():
+        if not isinstance(key, str) or not key:
+            _err(
+                f"deploy.env_overrides keys must be non-empty strings; " f"got {key!r}"
+            )
         if not isinstance(env, dict):
             _err(
-                f"deploy.env_overrides.{channel} must be a mapping of env vars; "
+                f"deploy.env_overrides.{key} must be a mapping of env vars; "
                 f"got {type(env).__name__}"
             )
 

--- a/tests/unit/test_parse_atlan_yaml.py
+++ b/tests/unit/test_parse_atlan_yaml.py
@@ -261,10 +261,13 @@ def test_invalid_yaml_rejected(tmp_path, monkeypatch):
 
 # ── deploy.env_overrides validation ─────────────────────────────────────────
 #
-# GM resolves ``env_overrides`` at catalog-read time (global-marketplace's
-# core/release/config_resolver.py) and is intentionally lenient — a typo'd
-# channel name silently no-ops. CI is the only place that catches it, so
-# these tests pin the rules.
+# GM interprets ``env_overrides`` keys in two tiers: ``beta`` / ``staging``
+# are channel-tier, anything else is a tenant-name match against
+# ``horizon_tenants.name``. The SDK validator can only enforce the shape of
+# the block (mapping of non-empty-string → mapping); it can't enforce the
+# allowlist of channel names because non-channel keys are valid tenant
+# entries. A typo'd ``staing`` is treated as a tenant name here and falls
+# through to the channel tier at runtime in GM.
 
 
 def _with_overrides(overrides):
@@ -288,28 +291,33 @@ def test_env_overrides_with_valid_channels_accepted(tmp_path, monkeypatch):
     assert "env_overrides" in out["deploy_config"]
 
 
-def test_env_overrides_unknown_channel_rejected(tmp_path, monkeypatch):
+def test_env_overrides_with_tenant_name_accepted(tmp_path, monkeypatch):
+    # Tenant names are valid keys — checked by tenant_name match at GM
+    # runtime, not at SDK validation time.
     monkeypatch.chdir(tmp_path)
-    # Common typo — 'staing' instead of 'staging'.
+    _write(
+        tmp_path,
+        _with_overrides(
+            {
+                "beta": {"OTEL_ENVIRONMENT": "beta"},
+                "tenant-xyz": {"OTEL_ENVIRONMENT": "xyz-only"},
+            }
+        ),
+    )
+    out = parse_atlan_yaml.parse()
+    assert "env_overrides" in out["deploy_config"]
+    assert "tenant-xyz" in out["deploy_config"]
+
+
+def test_env_overrides_unknown_key_accepted_as_tenant_name(tmp_path, monkeypatch):
+    # A typo'd 'staing' is now treated as a tenant name and accepted by
+    # SDK validation. It will silently no-op at GM runtime since no live
+    # tenant matches it. Trade-off vs the previous strict allowlist: lost
+    # typo detection, gained tenant-name support.
+    monkeypatch.chdir(tmp_path)
     _write(tmp_path, _with_overrides({"staing": {"OTEL_ENVIRONMENT": "staging"}}))
-    with pytest.raises(AtlanYamlError, match="unknown channel"):
-        parse_atlan_yaml.parse()
-
-
-def test_env_overrides_all_channel_rejected(tmp_path, monkeypatch):
-    # 'all' is GA — base config IS the GA config — an entry here would
-    # never take effect at runtime, so fail fast.
-    monkeypatch.chdir(tmp_path)
-    _write(tmp_path, _with_overrides({"all": {"OTEL_ENVIRONMENT": "production"}}))
-    with pytest.raises(AtlanYamlError, match="unknown channel"):
-        parse_atlan_yaml.parse()
-
-
-def test_env_overrides_specific_channel_rejected(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    _write(tmp_path, _with_overrides({"specific": {"X": "y"}}))
-    with pytest.raises(AtlanYamlError, match="unknown channel"):
-        parse_atlan_yaml.parse()
+    out = parse_atlan_yaml.parse()
+    assert "env_overrides" in out["deploy_config"]
 
 
 def test_env_overrides_not_a_mapping_rejected(tmp_path, monkeypatch):
@@ -326,8 +334,16 @@ def test_env_overrides_channel_value_not_a_mapping_rejected(tmp_path, monkeypatc
         parse_atlan_yaml.parse()
 
 
+def test_env_overrides_tenant_value_not_a_mapping_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, _with_overrides({"tenant-xyz": ["not", "a", "mapping"]}))
+    with pytest.raises(
+        AtlanYamlError, match="env_overrides.tenant-xyz must be a mapping"
+    ):
+        parse_atlan_yaml.parse()
+
+
 def test_env_overrides_absent_is_fine(tmp_path, monkeypatch):
-    # Backwards compat: apps without env_overrides parse cleanly.
     monkeypatch.chdir(tmp_path)
     _write(
         tmp_path,
@@ -338,7 +354,6 @@ def test_env_overrides_absent_is_fine(tmp_path, monkeypatch):
 
 
 def test_env_overrides_with_no_deploy_block_is_fine(tmp_path, monkeypatch):
-    # No deploy block at all — _validate_env_overrides is a no-op.
     monkeypatch.chdir(tmp_path)
     _write(tmp_path, {"name": "x", "app_id": "1"})
     out = parse_atlan_yaml.parse()


### PR DESCRIPTION
Linear: [DISTR-473](https://linear.app/atlan-epd/issue/DISTR-473)
Companion to: [atlanhq/global-marketplace#183](https://github.com/atlanhq/global-marketplace/pull/183) — tenant-tier override extension

## Why

PR #1725 (already merged) added a CI-time allowlist that rejected `env_overrides` keys outside `{beta, staging}` to catch typos. GM PR #183 now extends the feature so that tenant names are also valid keys (per-tenant overrides win over channel overrides). The previous strict validator would reject perfectly valid `env_overrides.tenant-xyz` entries.

## What

Relax `_validate_env_overrides` to accept any non-empty string key while still enforcing the rest of the shape:

```yaml
deploy:
  env_overrides:
    beta:        {KEY: val}    # channel-tier — still works
    staging:     {KEY: val}    # channel-tier — still works
    tenant-xyz:  {KEY: val}    # tenant-name-tier — now accepted (NEW)
```

Validator still enforces:
- `env_overrides` must be a mapping.
- Each key is a non-empty string.
- Each value is a mapping of env vars.

**Trade-off acknowledged in the docstring:** the SDK doesn't know the live tenant list, so a typo'd `staing` is now treated as a tenant name and accepted. It silently falls through to the channel tier at GM runtime.

## Files

- `.github/scripts/parse_atlan_yaml.py` — drops the `{beta, staging}` allowlist; docstring updated.
- `tests/unit/test_parse_atlan_yaml.py` — drops three reject-key tests; adds two new accept-key tests; repurposes the typo test.

## Test plan

- [x] `python3 -m pytest tests/unit/test_parse_atlan_yaml.py` — 35 pass
- [x] Pre-commit hooks (ruff/isort/pyright) pass