### PR TITLE
fix(sdr-e2e): re-add components-dir + compose-overlay overrides for multi-pipeline connectors

### DIFF
--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -89,6 +89,28 @@ inputs:
       ref) action.yaml itself.
     required: false
     default: ""
+  components-dir:
+    description: |
+      App-level directory holding additional Dapr component YAMLs to
+      stack on top of the SDK defaults. Defaults to `$SDR_CONFIG_DIR/components`
+      so single-pipeline apps need no override. Multi-pipeline apps
+      (e.g. mysql-app's separate SDR + full-DAG stacks living in one
+      .github/e2e/ dir) override this from their caller workflow to
+      point at the per-pipeline overrides directory (e.g.
+      `.github/e2e/e2e-full-components`).
+    required: false
+    default: ""
+  compose-overlay:
+    description: |
+      App-level docker-compose overlay to stack on top of the
+      configurator output + SDK CI defaults. Defaults to
+      `$SDR_CONFIG_DIR/docker-compose.ci.yml`. Override from a caller
+      workflow when the pipeline needs a different compose layer
+      (e.g. mysql-app's `.github/e2e/e2e-full-docker-compose.yaml`
+      which propagates AWS_* env vars to the worker and sets a unique
+      agent-name so the worker registers on its own Temporal queue).
+    required: false
+    default: ""
 outputs:
   test-outcome:
     description: pytest exit outcome (success/failure)
@@ -330,11 +352,19 @@ runs:
       shell: bash
       env:
         SDK_COMPONENTS: ${{ steps.action_root.outputs.path }}/components
+        APP_COMPONENTS: ${{ inputs.components-dir }}
       run: |
         cp "${SDK_COMPONENTS}"/*.yaml ci-deploy/components/
-        if [ -d "$SDR_CONFIG_DIR/components" ] && [ -n "$(ls -A "$SDR_CONFIG_DIR/components" 2>/dev/null)" ]; then
-          echo "Applying app-level component overrides"
-          cp "$SDR_CONFIG_DIR/components"/*.yaml ci-deploy/components/
+        # Resolve effective overrides directory: explicit input wins,
+        # otherwise fall back to $SDR_CONFIG_DIR/components convention.
+        if [ -n "${APP_COMPONENTS}" ]; then
+          OVERRIDE_DIR="${APP_COMPONENTS}"
+        else
+          OVERRIDE_DIR="$SDR_CONFIG_DIR/components"
+        fi
+        if [ -d "${OVERRIDE_DIR}" ] && [ -n "$(ls -A "${OVERRIDE_DIR}" 2>/dev/null)" ]; then
+          echo "Applying app-level component overrides from ${OVERRIDE_DIR}"
+          cp "${OVERRIDE_DIR}"/*.yaml ci-deploy/components/
         fi
 
     - name: Build compose -f chain
@@ -342,12 +372,20 @@ runs:
       shell: bash
       env:
         SDK_COMPOSE: ${{ steps.action_root.outputs.path }}/docker-compose.ci.yml
+        APP_COMPOSE: ${{ inputs.compose-overlay }}
       run: |
         # Order: configurator-generated base → SDK CI overrides → optional app layer.
         FILES=("-f" "ci-deploy/docker-compose.yaml" "-f" "${SDK_COMPOSE}")
-        if [ -f "$SDR_CONFIG_DIR/docker-compose.ci.yml" ]; then
-          echo "Adding app-level compose layer"
-          FILES+=("-f" "$SDR_CONFIG_DIR/docker-compose.ci.yml")
+        # Resolve effective compose overlay: explicit input wins,
+        # otherwise fall back to $SDR_CONFIG_DIR/docker-compose.ci.yml convention.
+        if [ -n "${APP_COMPOSE}" ]; then
+          OVERLAY="${APP_COMPOSE}"
+        else
+          OVERLAY="$SDR_CONFIG_DIR/docker-compose.ci.yml"
+        fi
+        if [ -f "${OVERLAY}" ]; then
+          echo "Adding app-level compose layer from ${OVERLAY}"
+          FILES+=("-f" "${OVERLAY}")
         fi
         # Persist the array as a single space-joined string (compose -f flags
         # are simple paths, no whitespace issues).

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -31,12 +31,16 @@ name: e2e-full-reusable
 #   - Tenant + OAuth + API-key env wiring.
 #   - The `Resolve agent-name` step that handles the run-id default.
 #   - The SDR composite action invocation with full-DAG defaults
-#     (test-path, secrets-script).
+#     (test-path, secrets-script, components-dir, compose-overlay).
 #
-# Connector-level Dapr component / compose overrides live under the
-# connector's $SDR_CONFIG_DIR (`.github/sdr-e2e/` or fallback
-# `.github/e2e/`); the SDR composite picks them up by convention,
-# no inputs to thread through.
+# `components-dir` + `compose-overlay` are explicit here because the
+# full-DAG pipeline lives alongside the SDR (testcontainer) pipeline
+# in connector repos — both share `$SDR_CONFIG_DIR` but need
+# different component sets + compose overlays (full-DAG uses an S3
+# OAuth objectstore + a worker container that registers under a
+# dynamic agent-name, SDR uses localstorage + a hermetic sibling DB).
+# Passing the per-pipeline paths through bypasses the convention
+# fallback that would otherwise pick up the SDR files.
 #
 # Caller overrides any of the input defaults when their layout differs.
 
@@ -63,6 +67,25 @@ on:
         required: false
         type: string
         default: .github/e2e/make-secrets-e2e-full.py
+      components-dir:
+        description: |
+          App-level Dapr component overrides for the full-DAG stack
+          (e.g. S3 binding via the tenant's blobstorage proxy).
+          Default matches the convention this repo's apps follow —
+          a sibling directory in `.github/e2e/` so SDR and full-DAG
+          don't share the same overrides set.
+        required: false
+        type: string
+        default: .github/e2e/e2e-full-components
+      compose-overlay:
+        description: |
+          docker-compose overlay for the full-DAG stack. Propagates
+          AWS_* env vars to the worker for the S3 binding and sets a
+          unique agent-name so the worker registers on the harness's
+          dynamic Temporal queue.
+        required: false
+        type: string
+        default: .github/e2e/e2e-full-docker-compose.yaml
       timeout-minutes:
         description: |
           GH job timeout. Must always be > ae_poll_timeout_seconds +
@@ -175,6 +198,8 @@ jobs:
           app-image-name: ${{ inputs.app-image-name }}
           test-path: ${{ inputs.test-path }}
           secrets-script: ${{ inputs.secrets-script }}
+          components-dir: ${{ inputs.components-dir }}
+          compose-overlay: ${{ inputs.compose-overlay }}
           # Bump the container-health wait because the worker has to
           # establish the Temporal connection with TLS + auth before
           # /server/health turns green.


### PR DESCRIPTION
## Summary
atlanhq/application-sdk#1746 collapsed both pipeline-level config paths to `\$SDR_CONFIG_DIR/components` and `\$SDR_CONFIG_DIR/docker-compose.ci.yml`. That works for connectors with one SDR pipeline per repo, but breaks repos like `atlan-mysql-app` where two pipelines (SDR testcontainer + full-DAG e2e) share one config directory and need **different** component sets / compose overlays.

Concretely: after #1746 merged, mysql-app's full-DAG e2e runs silently picked up the SDR compose + components instead of the full-DAG ones. The worker container started polling `atlan-mysql` (the SDR default queue baked into the SDR compose) instead of `atlan-mysql-e2e-full-ci-<run_id>` (the dynamic queue the harness creates a workflow on). Temporal UI showed:

```
No Workers Running
There are no Workers polling the atlan-mysql-e2e-full-ci-<run_id> Task Queue.
```

## Fix
- Re-add `components-dir` and `compose-overlay` as optional inputs to `sdr-e2e/action.yaml`. Default to empty; both steps fall back to the `\$SDR_CONFIG_DIR` convention introduced by #1746 when unset, so single-pipeline apps continue to need no override.
- Thread per-pipeline paths through `e2e-full-reusable.yaml` (`.github/e2e/e2e-full-components` + `.github/e2e/e2e-full-docker-compose.yaml`) so the e2e-full path picks up the right files.

## Test plan
- [ ] mysql-app e2e-full run dispatched from this branch: worker registers on the dynamic `atlan-mysql-e2e-full-ci-<run_id>` queue (visible on devex Temporal UI), AE workflow polls to `COMPLETED`.
- [ ] mysql-app SDR run on a connector PR: behaviour unchanged (uses `\$SDR_CONFIG_DIR/components` + `\$SDR_CONFIG_DIR/docker-compose.ci.yml` fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)