### PR TITLE
fix(ci): tighten release_tag bypass and add release_model opt-in for versioned releases

### DIFF
--- a/.github/scripts/parse_atlan_yaml.py
+++ b/.github/scripts/parse_atlan_yaml.py
@@ -15,6 +15,7 @@ Outputs (single-line, append-safe):
     build_tag          ``build_tag`` (only ``v1`` supported today)
     dockerfile         ``dockerfile`` (default ``./Dockerfile``)
     enable_sdr         ``true``/``false`` from ``self_deployed_runtime``
+    release_model      ``cd`` (default) or ``versioned`` — controls publish-to-all gating
     sdk_version        atlan-application-sdk version pinned in uv.lock (or empty)
     entrypoints  JSON-encoded list (single line) or empty string
     deploy_config      YAML-dumped ``deploy:`` block (multiline; heredoc'd by caller)
@@ -41,6 +42,9 @@ _KEBAB_RE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
 
 # Closed type set. Mirrors core.version.model.EntrypointPackageType in GM.
 _ALLOWED_TYPES = {"connector", "miner", "orchestrator", "utility", "custom"}
+
+# Allowed values for the release_model field.
+_ALLOWED_RELEASE_MODELS = {"cd", "versioned"}
 
 # Channel keys that GM's catalog read interprets as channel-tier overrides.
 # Any other key is interpreted as a tenant-name-tier override (matched against
@@ -215,6 +219,7 @@ def parse(
     build_tag = d.get("build_tag", "v1")
     dockerfile = d.get("dockerfile", "./Dockerfile")
     enable_sdr = "true" if d.get("self_deployed_runtime", False) else "false"
+    release_model = d.get("release_model", "cd")
 
     if not app_name:
         _err('atlan.yaml is missing required "name" field')
@@ -222,6 +227,12 @@ def parse(
     if build_tag != "v1":
         _err(
             f"Unsupported build_tag {build_tag!r}. Only 'v1' is supported by this template version."
+        )
+
+    if release_model not in _ALLOWED_RELEASE_MODELS:
+        _err(
+            f"Unsupported release_model {release_model!r}. "
+            f"Must be one of: {sorted(_ALLOWED_RELEASE_MODELS)}."
         )
 
     deploy_val = d.get("deploy")
@@ -241,6 +252,7 @@ def parse(
         "build_tag": build_tag,
         "dockerfile": dockerfile,
         "enable_sdr": enable_sdr,
+        "release_model": release_model,
         "sdk_version": sdk_version,
         "entrypoints": entrypoints,
         "deploy_config": deploy_config,
@@ -281,6 +293,7 @@ def main() -> None:
     print(f"App ID: {outputs['app_id']}")
     print(f"Dockerfile: {outputs['dockerfile']}")
     print(f"SDR: {outputs['enable_sdr']}")
+    print(f"Release model: {outputs['release_model']}")
     print(f"SDK version: {outputs['sdk_version'] or '(not pinned)'}")
     print(
         "Entrypoint packages: "

--- a/.github/scripts/tests/test_parse_atlan_yaml.py
+++ b/.github/scripts/tests/test_parse_atlan_yaml.py
@@ -253,3 +253,27 @@ class TestParse:
         yaml_file = _write(tmp_path, "atlan.yaml", MINIMAL_YAML)
         result = parse(str(yaml_file), str(tmp_path / "missing.lock"))
         assert result["deploy_config"] == ""
+
+    def test_release_model_defaults_to_cd(self, tmp_path: Path) -> None:
+        yaml_file = _write(tmp_path, "atlan.yaml", MINIMAL_YAML)
+        result = parse(str(yaml_file), str(tmp_path / "missing.lock"))
+        assert result["release_model"] == "cd"
+
+    def test_release_model_versioned(self, tmp_path: Path) -> None:
+        yaml_file = _write(
+            tmp_path, "atlan.yaml", MINIMAL_YAML + "release_model: versioned\n"
+        )
+        result = parse(str(yaml_file), str(tmp_path / "missing.lock"))
+        assert result["release_model"] == "versioned"
+
+    def test_release_model_cd_explicit(self, tmp_path: Path) -> None:
+        yaml_file = _write(tmp_path, "atlan.yaml", MINIMAL_YAML + "release_model: cd\n")
+        result = parse(str(yaml_file), str(tmp_path / "missing.lock"))
+        assert result["release_model"] == "cd"
+
+    def test_release_model_invalid_raises(self, tmp_path: Path) -> None:
+        yaml_file = _write(
+            tmp_path, "atlan.yaml", MINIMAL_YAML + "release_model: rolling\n"
+        )
+        with pytest.raises(AtlanYamlError, match="Unsupported release_model"):
+            parse(str(yaml_file), str(tmp_path / "missing.lock"))

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -103,8 +103,18 @@ jobs:
           REF: ${{ inputs.ref || github.ref }}
           CHANNEL: ${{ inputs.channel }}
           TENANTS: ${{ inputs.tenants }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
+
+          # A non-empty release_tag means the caller is the SDK's own
+          # tag-and-release.yaml, which only fires after a release-labelled
+          # PR merges to main. The ref will be refs/tags/v* but the build
+          # is legitimately from main — skip the gate.
+          if [ -n "${RELEASE_TAG}" ]; then
+            echo "Tagged release (${RELEASE_TAG}) — main-branch gate skipped."
+            exit 0
+          fi
 
           # Mirror the channel-resolution rules used at publish time:
           #   tenants  -> specific  (skip gate)
@@ -128,9 +138,8 @@ jobs:
           # Accept both the short ('main') and qualified ('refs/heads/main')
           # forms. Anything else falls through to the reject arm, including:
           #   - feature branches (refs/heads/feat-foo, feat/foo, …)
-          #   - tag refs (refs/tags/v1.2.3) — by design: tag-triggered builds
-          #     should not auto-publish to all tenants; cut a release from
-          #     main and let the push-trigger run instead.
+          #   - bare tag refs without release_tag (release_tag is handled above;
+          #     bare tags without it are rejected)
           case "${REF}" in
             main|refs/heads/main)
               echo "Channel 'all' on main — proceeding."

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -186,6 +186,7 @@ jobs:
       app_id:           ${{ steps.manifest.outputs.app_id }}
       dockerfile:       ${{ steps.manifest.outputs.dockerfile }}
       enable_sdr:       ${{ steps.manifest.outputs.enable_sdr }}
+      release_model:    ${{ steps.manifest.outputs.release_model }}
       deploy_config:    ${{ steps.manifest.outputs.deploy_config }}
       sdk_version:      ${{ steps.manifest.outputs.sdk_version }}
       entrypoints: ${{ steps.manifest.outputs.entrypoints }}
@@ -520,10 +521,42 @@ jobs:
           CHANNEL: ${{ inputs.channel }}
           TENANTS: ${{ inputs.tenants }}
           RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_MODEL: ${{ needs.prepare.outputs.release_model }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
           GITHUB_ACTOR: ${{ github.triggering_actor }}
         run: |
           set -euo pipefail
+
+          # Strip CR/LF that GitHub expression evaluation can inject.
+          RELEASE_TAG="${RELEASE_TAG//$'\r'/}"
+          RELEASE_TAG="${RELEASE_TAG//$'\n'/}"
+          RELEASE_MODEL="${RELEASE_MODEL//$'\r'/}"
+          RELEASE_MODEL="${RELEASE_MODEL//$'\n'/}"
+
+          # Versioned-release gate: apps that opt in via release_model=versioned
+          # must supply an explicit release_tag for any channel='all' publish.
+          # Merge-to-main builds the image (already in GHCR) but does not publish
+          # to all tenants — only a GitHub Release (which sets release_tag) does.
+          # Tenant-targeted and non-all-channel publishes are unrestricted.
+          EFFECTIVE_CHANNEL="${CHANNEL:-all}"
+          EFFECTIVE_CHANNEL="${EFFECTIVE_CHANNEL,,}"
+          if [ "${RELEASE_MODEL}" = "versioned" ] && [ -z "${RELEASE_TAG}" ] && [ -z "${TENANTS}" ] && [ "${EFFECTIVE_CHANNEL}" = "all" ]; then
+            echo "::error title=Publish blocked::App declares release_model=versioned — publishing to channel='all' requires an explicit release tag. The image is already in GHCR; cut a GitHub Release from main to publish to all tenants."
+            {
+              echo "### Publish blocked — versioned release required"
+              echo ""
+              echo "This app has \`release_model: versioned\` in \`atlan.yaml\`."
+              echo "Publishing to the **all** channel requires an explicit GitHub Release."
+              echo ""
+              echo "| Field | Value |"
+              echo "|-------|-------|"
+              echo "| Built image | \`${GHCR_IMAGE}\` |"
+              echo "| Channel | \`${EFFECTIVE_CHANNEL}\` |"
+              echo ""
+              echo "**Next step:** create a GitHub Release from \`main\` — the image above is already built and ready."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 1
+          fi
 
           # Resolve triggering actor to email; fall back to GitHub username
           GH_EMAIL=$(gh api "users/${GITHUB_ACTOR}" --jq '.email // empty' 2>/dev/null || true)

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -107,11 +107,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          # A non-empty release_tag means the caller is the SDK's own
-          # tag-and-release.yaml, which only fires after a release-labelled
-          # PR merges to main. The ref will be refs/tags/v* but the build
-          # is legitimately from main — skip the gate.
-          if [ -n "${RELEASE_TAG}" ]; then
+          # Strip any trailing CR/LF that GitHub expression evaluation can inject.
+          RELEASE_TAG="${RELEASE_TAG//$'\r'/}"
+          RELEASE_TAG="${RELEASE_TAG//$'\n'/}"
+
+          # Bypass the main-branch gate only when the ref is actually the
+          # matching tag ref. Checking release_tag alone is insufficient:
+          # a caller could pass any non-empty value from a feature branch
+          # to skip the channel='all' protection.
+          if [ -n "${RELEASE_TAG}" ] && [ "${REF}" = "refs/tags/${RELEASE_TAG}" ]; then
             echo "Tagged release (${RELEASE_TAG}) — main-branch gate skipped."
             exit 0
           fi

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.9.0
-source-sha:    8e034cef779d05f5e7a00c73ccf8daf4cda120db
-source-date:   2026-05-13T19:24:34+01:00
+sdk-version:   3.10.0
+source-sha:    07a69d6a62821adc7169cac97c73d9bf042f75ea
+source-date:   2026-05-14T18:35:34+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 


### PR DESCRIPTION
## Summary

Three related changes to \`build-and-publish-app.yaml\` and its supporting scripts:

### 1. Fix: tighten the release_tag gate bypass (security)

PR #1709 blocked \`channel=all\` publishes from non-main refs, but the original bypass — skipping the gate whenever \`release_tag\` is non-empty — was too loose. Any caller could pass a non-empty \`release_tag\` from a feature branch to bypass the \`channel=all\` protection.

The bypass now also requires \`REF == refs/tags/${RELEASE_TAG}\`, so it only fires when the workflow is genuinely triggered by a matching GitHub Release event.

### 2. Fix: CR/LF normalisation in validate-channel

\`RELEASE_TAG\` is stripped of trailing CR/LF before comparison in \`validate-channel\`, matching the same defensive pattern already applied in the \`prepare\` job.

### 3. Feat: opt-in \`release_model: versioned\` for apps that want explicit release gating

Apps that merge frequently to \`main\` but want to control _when_ those changes reach all tenants can now add one line to \`atlan.yaml\`:

\`\`\`yaml
release_model: versioned
\`\`\`

**Effect:** on a plain merge to \`main\`, the image is built and pushed to GHCR as normal, but the \`publish\` job is blocked before the GM API call. Publishing to \`channel=all\` only proceeds when a GitHub Release supplies \`release_tag\`. Tenant-targeted and non-all-channel publishes are unrestricted.

**Default:** \`release_model: cd\` (continuous delivery). Every existing app repo is completely unaffected — no \`atlan.yaml\` changes, no workflow changes, no behaviour change.

## Decision matrix after this PR

| Invocation | CD app (default) | Versioned app |
|---|---|---|
| Push to \`main\` (auto-trigger) | ✅ publishes draft to all | ✅ builds image, ❌ publish blocked |
| GitHub Release (\`release_tag\` set, \`ref=refs/tags/v*\`) | ✅ | ✅ |
| \`workflow_dispatch\` from \`main\`, default channel | ✅ | ✅ builds image, ❌ publish blocked |
| \`workflow_dispatch\`, \`channel: staging\` | ✅ | ✅ |
| \`workflow_dispatch\`, \`tenants: <id>\` | ✅ | ✅ |
| \`workflow_dispatch\` from feature branch, \`channel: all\` | ❌ validate-channel | ❌ validate-channel |
| Non-empty \`release_tag\` from a feature branch | ❌ validate-channel | ❌ validate-channel |

## Files changed

- \`.github/workflows/build-and-publish-app.yaml\` — validate-channel tightening; publish job gate
- \`.github/scripts/parse_atlan_yaml.py\` — parse and validate \`release_model\` field
- \`.github/scripts/tests/test_parse_atlan_yaml.py\` — 4 new tests covering default, explicit cd, versioned, and invalid values

🤖 Generated with [Claude Code](https://claude.com/claude-code)