### PR TITLE
feat(dev): add local_dev_mode for zero-install local app development

### DIFF
--- a/.github/actions/e2e-examples/action.yaml
+++ b/.github/actions/e2e-examples/action.yaml
@@ -41,12 +41,26 @@ runs:
   steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+    # Read the pinned daprd version from the SDK's single source of truth
+    # (application_sdk/version.py — ``__dapr_version``). Keeps CI in lockstep
+    # with the version the embedded local-dev sidecar downloads.
+    - name: Resolve pinned daprd version
+      id: dapr-version
+      shell: bash
+      run: |
+        ver=$(grep '^__dapr_version' application_sdk/version.py | cut -d'"' -f2)
+        if [[ -z "$ver" ]]; then
+          echo "::error::Failed to parse __dapr_version from application_sdk/version.py"
+          exit 1
+        fi
+        echo "version=$ver" >> "$GITHUB_OUTPUT"
+
     - name: Install Dapr CLI (Linux/macOS)
       if: runner.os != 'Windows'
       shell: bash
       run: |
         wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s 1.17.1
-        dapr init --runtime-version 1.17.3 --slim
+        dapr init --runtime-version ${{ steps.dapr-version.outputs.version }} --slim
 
     - name: Install Dapr CLI (Windows)
       if: runner.os == 'Windows'
@@ -54,7 +68,7 @@ runs:
       run: |
         $script=iwr -useb https://raw.githubusercontent.com/dapr/cli/master/install/install.ps1; $block=[ScriptBlock]::Create($script); invoke-command -ScriptBlock $block -ArgumentList 1.17.1, "$env:USERPROFILE\.dapr\bin\"
         $env:Path += ";$env:USERPROFILE\.dapr\bin\"
-        dapr init --runtime-version 1.17.3 --slim
+        dapr init --runtime-version ${{ steps.dapr-version.outputs.version }} --slim
 
     - name: Install Temporal CLI
       uses: temporalio/setup-temporal@6d04211d9dfbd5cb2493a4a6637b2ad784a60ccc # v0

--- a/.github/workflows/check-dapr-version.yaml
+++ b/.github/workflows/check-dapr-version.yaml
@@ -1,0 +1,159 @@
+name: Check Dapr Version
+
+# Watches Dapr's GitHub releases for new stable versions and opens a PR to
+# bump ``__dapr_version`` in ``application_sdk/version.py`` whenever the
+# upstream latest drifts from our pin.
+#
+# Runs on a schedule (Mondays at 09:00 UTC) and on manual dispatch.
+# Only the latest non-prerelease counts — ``releases/latest`` already
+# filters out RCs / betas.
+
+on:
+  schedule:
+    # ┌─ minute (0-59)
+    # │  ┌─ hour (0-23, UTC)
+    # │  │  ┌─ day of month
+    # │  │  │ ┌─ month
+    # │  │  │ │ ┌─ day of week (0 = Sun)
+    - cron: "0 9 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-dapr-version
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Compare pinned daprd against upstream latest
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Read pinned daprd version
+        id: pinned
+        run: |
+          set -euo pipefail
+          ver=$(grep '^__dapr_version' application_sdk/version.py | cut -d'"' -f2)
+          if [[ -z "$ver" ]]; then
+            echo "::error::Failed to parse __dapr_version from application_sdk/version.py"
+            exit 1
+          fi
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch latest Dapr stable release
+        id: upstream
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # ``releases/latest`` returns the most recent non-prerelease tag.
+          tag=$(gh api repos/dapr/dapr/releases/latest --jq '.tag_name')
+          if [[ -z "$tag" ]]; then
+            echo "::error::Could not resolve latest Dapr release"
+            exit 1
+          fi
+          # Strip the leading ``v`` so the value matches the bare semver we pin.
+          ver="${tag#v}"
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
+      - name: Compare
+        id: compare
+        run: |
+          set -euo pipefail
+          pinned="${{ steps.pinned.outputs.version }}"
+          latest="${{ steps.upstream.outputs.version }}"
+          echo "pinned=$pinned" >> "$GITHUB_OUTPUT"
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+          if [[ "$pinned" == "$latest" ]]; then
+            echo "match=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::daprd pin is up to date ($pinned)"
+          else
+            echo "match=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::daprd pin $pinned is behind upstream $latest"
+          fi
+
+      - name: Bump version.py
+        if: steps.compare.outputs.match == 'false'
+        run: |
+          set -euo pipefail
+          pinned="${{ steps.compare.outputs.pinned }}"
+          latest="${{ steps.compare.outputs.latest }}"
+          sed -i "s/^__dapr_version: str = \"${pinned}\"$/__dapr_version: str = \"${latest}\"/" \
+            application_sdk/version.py
+          # Confirm exactly one line changed; bail if sed missed.
+          new=$(grep '^__dapr_version' application_sdk/version.py | cut -d'"' -f2)
+          if [[ "$new" != "$latest" ]]; then
+            echo "::error::sed did not rewrite version.py as expected (got '$new', want '$latest')"
+            exit 1
+          fi
+
+      - name: Open PR if drift detected
+        if: steps.compare.outputs.match == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+        run: |
+          set -euo pipefail
+          git config --global user.name 'atlan-ci'
+          git config --global user.email 'it@atlan.com'
+
+          latest="${{ steps.compare.outputs.latest }}"
+          pinned="${{ steps.compare.outputs.pinned }}"
+          branch="chore/bump-daprd-${latest}"
+
+          # Branch is per-version so re-runs against the same upstream
+          # version land back on the existing PR rather than churning a new
+          # one each scheduled tick.
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            git fetch origin "$branch"
+            git checkout "$branch"
+          else
+            git checkout -b "$branch"
+          fi
+
+          git add application_sdk/version.py
+          if git diff --cached --quiet; then
+            echo "::notice::No actual change to commit; PR may already be up to date."
+            exit 0
+          fi
+
+          git commit -m "chore(deps): bump daprd pin to ${latest}"
+          git push origin "$branch" --force-with-lease
+
+          existing=$(gh pr list \
+            --head "$branch" \
+            --base "${{ github.ref_name }}" \
+            --state open \
+            --json number \
+            --jq '.[0].number')
+
+          if [[ -n "$existing" ]]; then
+            echo "::notice::PR #${existing} already open for ${branch}; commit pushed."
+            exit 0
+          fi
+
+          gh pr create \
+            --base "${{ github.ref_name }}" \
+            --title "chore(deps): bump daprd pin to ${latest}" \
+            --label "dependencies" \
+            --body "Dapr just released **v${latest}**.
+
+          | | version |
+          |---|---|
+          | Current pin | \`${pinned}\` |
+          | Upstream latest | \`${latest}\` |
+
+          This PR bumps \`__dapr_version\` in [\`application_sdk/version.py\`](application_sdk/version.py) so:
+
+          - The embedded local-dev daprd (via \`application_sdk.dev.embedded_dapr\`) downloads the new release on first use.
+          - CI workflows (\`scale-tests.yaml\`, \`e2e-examples\`) pass the new version to \`dapr init --runtime-version\`.
+
+          Release notes: https://github.com/dapr/dapr/releases/tag/v${latest}
+
+          Opened automatically by [\`.github/workflows/check-dapr-version.yaml\`](.github/workflows/check-dapr-version.yaml)."

--- a/.github/workflows/scale-tests.yaml
+++ b/.github/workflows/scale-tests.yaml
@@ -50,8 +50,21 @@ jobs:
         with:
           version: "1.17.1"
 
+      # Read the pinned daprd version from the SDK's single source of truth
+      # (application_sdk/version.py — ``__dapr_version``) so CI runs the same
+      # runtime the embedded local-dev sidecar downloads.
+      - name: Resolve pinned daprd version
+        id: dapr-version
+        run: |
+          ver=$(grep '^__dapr_version' application_sdk/version.py | cut -d'"' -f2)
+          if [[ -z "$ver" ]]; then
+            echo "::error::Failed to parse __dapr_version from application_sdk/version.py"
+            exit 1
+          fi
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
       - name: Initialize Dapr
-        run: dapr init --runtime-version 1.17.3 --slim
+        run: dapr init --runtime-version ${{ steps.dapr-version.outputs.version }} --slim
 
       # Install Temporal
       - name: Install Temporal CLI

--- a/application_sdk/dev/__init__.py
+++ b/application_sdk/dev/__init__.py
@@ -1,0 +1,18 @@
+"""Developer-facing helpers for local iteration on Atlan apps.
+
+These helpers exist so that a connector author running their app locally
+needs nothing on the host other than Python and ``uv`` — no Temporal CLI,
+no Dapr sidecar, no Redis. ``run_dev_combined`` orchestrates them so the
+local code path mirrors production (Dapr + Temporal), with both daemons
+auto-downloaded and managed by the SDK.
+"""
+
+from application_sdk.dev._dapr import EmbeddedDapr, embedded_dapr
+from application_sdk.dev._embedded import EmbeddedRuntime, embedded_runtime
+
+__all__ = [
+    "EmbeddedDapr",
+    "EmbeddedRuntime",
+    "embedded_dapr",
+    "embedded_runtime",
+]

--- a/application_sdk/dev/_dapr.py
+++ b/application_sdk/dev/_dapr.py
@@ -1,0 +1,276 @@
+"""Embedded Dapr sidecar for local app development.
+
+Auto-downloads the ``daprd`` binary into ``~/.cache/atlan-sdk/dapr/`` on
+first use, writes a minimal set of components (in-memory state, env-var
+secrets, filesystem object store) to a temp dir, spawns ``daprd``, and
+tears it down on context exit.
+
+The goal is to keep local development on the **same Dapr code path** as
+production while requiring nothing on the host beyond Python and ``uv``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import platform
+import shutil
+import socket
+import stat
+import tarfile
+import tempfile
+import urllib.request
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+# Single source of truth for the daprd pin lives in ``application_sdk.version``
+# (see the ``__dapr_version`` constant). CI workflows grep the same file so
+# the literal version string lives in exactly one place.
+from application_sdk.version import __dapr_version as _DAPRD_VERSION
+
+logger = logging.getLogger(__name__)
+_DAPRD_RELEASE_URL = (
+    "https://github.com/dapr/dapr/releases/download/v{version}/daprd_{os}_{arch}.tar.gz"
+)
+_DAPRD_BINARY_NAME = "daprd"
+_CACHE_DIR = Path.home() / ".cache" / "atlan-sdk" / "dapr" / _DAPRD_VERSION
+
+
+@dataclass(frozen=True)
+class EmbeddedDapr:
+    """Connection details for the embedded Dapr sidecar."""
+
+    http_port: int
+    grpc_port: int
+    components_dir: str
+
+
+def _platform_tuple() -> tuple[str, str]:
+    """Return ``(os, arch)`` strings matching Dapr's release asset naming."""
+    system = platform.system().lower()  # darwin / linux / windows
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"):
+        arch = "amd64"
+    elif machine in ("arm64", "aarch64"):
+        arch = "arm64"
+    else:
+        raise RuntimeError(
+            f"Unsupported architecture for embedded Dapr: {platform.machine()!r}"
+        )
+    if system not in ("darwin", "linux", "windows"):
+        raise RuntimeError(f"Unsupported OS for embedded Dapr: {platform.system()!r}")
+    return system, arch
+
+
+def _download_daprd(target: Path) -> None:
+    """Download + extract the ``daprd`` binary into *target*."""
+    os_name, arch = _platform_tuple()
+    url = _DAPRD_RELEASE_URL.format(version=_DAPRD_VERSION, os=os_name, arch=arch)
+    logger.info("Downloading daprd v%s for %s/%s …", _DAPRD_VERSION, os_name, arch)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
+        try:
+            urllib.request.urlretrieve(url, tmp.name)
+            with tarfile.open(tmp.name, "r:gz") as tar:
+                member = next(
+                    (
+                        m
+                        for m in tar.getmembers()
+                        if m.name.endswith(_DAPRD_BINARY_NAME)
+                    ),
+                    None,
+                )
+                if member is None:
+                    raise RuntimeError(f"daprd binary not found in archive at {url}")
+                with tar.extractfile(member) as src, target.open("wb") as dst:  # type: ignore[arg-type]
+                    shutil.copyfileobj(src, dst)
+        finally:
+            Path(tmp.name).unlink(missing_ok=True)
+    target.chmod(target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    logger.info("daprd cached at %s", target)
+
+
+def _ensure_daprd_binary() -> Path:
+    """Return path to the daprd binary, downloading if absent."""
+    binary = _CACHE_DIR / _DAPRD_BINARY_NAME
+    if not binary.exists():
+        _download_daprd(binary)
+    return binary
+
+
+def _pick_free_port() -> int:
+    """Bind a TCP socket to port 0, read the port, release. Race-free enough."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+_COMPONENTS_YAML = {
+    "statestore.yaml": """\
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.in-memory
+  version: v1
+  metadata: []
+""",
+    "secretstore.yaml": """\
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: secretstore
+spec:
+  type: secretstores.local.env
+  version: v1
+  metadata: []
+""",
+    "deployment-secret-store.yaml": """\
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: deployment-secret-store
+spec:
+  type: secretstores.local.env
+  version: v1
+  metadata: []
+""",
+    "objectstore.yaml": """\
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: objectstore
+spec:
+  type: bindings.localstorage
+  version: v1
+  metadata:
+    - name: rootPath
+      value: {rootPath}
+""",
+    "eventstore.yaml": """\
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: eventstore
+spec:
+  type: bindings.localstorage
+  version: v1
+  metadata:
+    - name: rootPath
+      value: {rootPath}
+""",
+}
+
+
+def _write_components(components_dir: Path, objectstore_root: Path) -> None:
+    """Write the auto-generated Dapr component YAMLs into *components_dir*."""
+    components_dir.mkdir(parents=True, exist_ok=True)
+    objectstore_root.mkdir(parents=True, exist_ok=True)
+    for filename, template in _COMPONENTS_YAML.items():
+        (components_dir / filename).write_text(
+            template.format(rootPath=str(objectstore_root.resolve()))
+        )
+
+
+async def _wait_for_dapr_ready(http_port: int, timeout_s: float = 30.0) -> None:
+    """Poll Dapr's metadata endpoint until it responds or *timeout_s* elapses."""
+    import httpx  # noqa: PLC0415 — defer the heavy import
+
+    deadline = asyncio.get_event_loop().time() + timeout_s
+    async with httpx.AsyncClient() as client:
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                resp = await client.get(
+                    f"http://127.0.0.1:{http_port}/v1.0/metadata", timeout=1.0
+                )
+                if resp.status_code == 200:
+                    return
+            except Exception:  # noqa: BLE001, S110 — readiness loop
+                pass
+            await asyncio.sleep(0.25)
+    raise RuntimeError(f"Embedded Dapr did not become ready within {timeout_s}s")
+
+
+@asynccontextmanager
+async def embedded_dapr(
+    *,
+    app_id: str = "atlan-app",
+    objectstore_root: str = "./local/objectstore",
+    log_level: str = "warn",
+) -> AsyncIterator[EmbeddedDapr]:
+    """Boot an embedded ``daprd`` for local app development.
+
+    Components written into a temp dir:
+
+    * ``statestore`` — ``state.in-memory``
+    * ``secretstore`` / ``deployment-secret-store`` — ``secretstores.local.env``
+    * ``objectstore`` / ``eventstore`` — ``bindings.localstorage`` rooted at
+      *objectstore_root*
+
+    On entry the context manager sets ``DAPR_HTTP_PORT``, ``DAPR_GRPC_PORT``,
+    and ``DAPR_COMPONENTS_PATH`` so callers (and any background observability
+    flush that races with daprd startup) see the right values. The previous
+    values of those env vars are restored on exit.
+    """
+    binary = _ensure_daprd_binary()
+    http_port = _pick_free_port()
+    grpc_port = _pick_free_port()
+    components_dir = Path(tempfile.mkdtemp(prefix="atlan-dapr-"))
+    _write_components(components_dir, Path(objectstore_root))
+
+    # Set env BEFORE spawning the subprocess so the observability sink's
+    # flush cycle (which may fire during the ~3s daprd startup window) finds
+    # the auto-generated component YAMLs instead of the default ``./components``.
+    _prev_env = {
+        k: os.environ.get(k)
+        for k in ("DAPR_HTTP_PORT", "DAPR_GRPC_PORT", "DAPR_COMPONENTS_PATH")
+    }
+    os.environ["DAPR_HTTP_PORT"] = str(http_port)
+    os.environ["DAPR_GRPC_PORT"] = str(grpc_port)
+    os.environ["DAPR_COMPONENTS_PATH"] = str(components_dir)
+
+    logger.info("Starting embedded Dapr (http=%d grpc=%d)", http_port, grpc_port)
+    proc = await asyncio.create_subprocess_exec(
+        str(binary),
+        "--app-id",
+        app_id,
+        "--dapr-http-port",
+        str(http_port),
+        "--dapr-grpc-port",
+        str(grpc_port),
+        "--resources-path",
+        str(components_dir),
+        "--log-level",
+        log_level,
+        # Disable the metrics + placement endpoints we don't need for local dev.
+        "--enable-metrics=false",
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    try:
+        await _wait_for_dapr_ready(http_port)
+        logger.info("Embedded Dapr ready at http://127.0.0.1:%d", http_port)
+        yield EmbeddedDapr(
+            http_port=http_port,
+            grpc_port=grpc_port,
+            components_dir=str(components_dir),
+        )
+    finally:
+        logger.info("Shutting down embedded Dapr")
+        if proc.returncode is None:
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5.0)
+            except TimeoutError:
+                proc.kill()
+                await proc.wait()
+        shutil.rmtree(components_dir, ignore_errors=True)
+        for _k, _v in _prev_env.items():
+            if _v is None:
+                os.environ.pop(_k, None)
+            else:
+                os.environ[_k] = _v

--- a/application_sdk/dev/_embedded.py
+++ b/application_sdk/dev/_embedded.py
@@ -1,0 +1,53 @@
+"""In-process workflow runtime for local app development."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class EmbeddedRuntime:
+    """Connection details for the in-process workflow runtime."""
+
+    host: str
+    """``host:port`` the SDK should connect to (loopback, random free port)."""
+
+    namespace: str = "default"
+    """Workflow namespace served by the embedded runtime."""
+
+
+@asynccontextmanager
+async def embedded_runtime(
+    *,
+    namespace: str = "default",
+    log_level: str = "warn",
+) -> AsyncIterator[EmbeddedRuntime]:
+    """Boot an in-process workflow runtime for local development.
+
+    On first invocation the runtime binary (~30 MB) is downloaded to
+    ``~/.cache`` and cached. Subsequent calls are instant. The runtime is
+    torn down when the context exits.
+    """
+    from temporalio.testing import WorkflowEnvironment  # noqa: PLC0415
+
+    logger.info("Starting embedded workflow runtime")
+    env = await WorkflowEnvironment.start_local(
+        namespace=namespace,
+        dev_server_log_level=log_level,
+        dev_server_extra_args=[
+            "--dynamic-config-value",
+            "frontend.WorkerHeartbeatsEnabled=true",
+        ],
+    )
+    try:
+        host = env.client.service_client.config.target_host
+        logger.info("Embedded workflow runtime ready at %s", host)
+        yield EmbeddedRuntime(host=host, namespace=namespace)
+    finally:
+        logger.info("Shutting down embedded workflow runtime")
+        await env.shutdown()

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -1189,23 +1189,31 @@ async def run_dev_combined(
     example_input: dict[str, Any] | None = None,
     host: str | None = None,
     port: int | None = None,
-    temporal_host: str | None = None,
+    temporal_host: str | None = None,  # deprecated — ignored, kept for back-compat
     temporal_namespace: str | None = None,
     task_queue: str | None = None,
 ) -> None:
     """Run worker + handler in a single process for local development.
 
-    Dev-friendly wrapper around ``run_combined_mode()`` that accepts a
-    Python class and keyword arguments directly. Use it in ``run_dev.py``
-    scripts; production containers use ``run_combined_mode()`` via CLI flags.
+    Boots an **in-process workflow runtime** and uses **in-process backends**
+    for state, secrets, and object storage — no Temporal CLI, no Dapr
+    sidecar, no Redis required. The customer's only prerequisite is
+    Python + ``uv``.
 
-    All five connection-shaped kwargs (``host``, ``port``, ``temporal_host``,
-    ``temporal_namespace``, ``task_queue``) follow the same precedence as the
-    CLI path — ``explicit kwarg → env var → AppConfig default`` — because
-    they are resolved by :func:`_build_dev_config` which routes through
-    :meth:`AppConfig.from_args_and_env`. CI-stack overrides like
-    ``ATLAN_HANDLER_PORT`` or ``ATLAN_TASK_QUEUE`` work without any per-connector
-    ``os.environ.get(...)`` boilerplate at the call site.
+    Use this in ``run_dev.py`` scripts; production containers use
+    ``run_combined_mode()`` via CLI flags, which goes through Dapr.
+
+    All four connection-shaped kwargs (``host``, ``port``,
+    ``temporal_namespace``, ``task_queue``) follow the same precedence as
+    the CLI path — ``explicit kwarg → env var → AppConfig default`` —
+    because they are resolved by :func:`_build_dev_config` which routes
+    through :meth:`AppConfig.from_args_and_env`. CI-stack overrides like
+    ``ATLAN_HANDLER_PORT`` or ``ATLAN_TASK_QUEUE`` work without any
+    per-connector ``os.environ.get(...)`` boilerplate at the call site.
+
+    ``temporal_host`` is still accepted for backward compatibility but is
+    ignored — the SDK always boots its own in-process workflow runtime in
+    this mode. Passing it emits a :class:`DeprecationWarning`.
 
     Args:
         app_class: The App class to serve (must already be imported).
@@ -1223,8 +1231,6 @@ async def run_dev_combined(
             ``ATLAN_APP_HTTP_HOST`` → ``"127.0.0.1"``.
         port: Handler HTTP port. Default precedence: kwarg →
             ``ATLAN_HANDLER_PORT`` → ``ATLAN_APP_HTTP_PORT`` → ``8000``.
-        temporal_host: Temporal server address. Default precedence: kwarg →
-            ``ATLAN_TEMPORAL_HOST`` → ``"localhost:7233"``.
         temporal_namespace: Temporal namespace. Default precedence: kwarg →
             ``ATLAN_TEMPORAL_NAMESPACE`` → ``ATLAN_WORKFLOW_NAMESPACE`` →
             ``"default"``.
@@ -1238,24 +1244,77 @@ async def run_dev_combined(
 
         asyncio.run(run_dev_combined(
             MyApp,
-            credentials={
-                "host": "localhost", "port": "5432", "authType": "basic",
-                "username": "admin", "password": "secret",
-                "extra": {"database": "mydb"},
-            },
             example_input={
-                "connection": {"connection_name": "test", "connection_qualified_name": "default/app/1234"},
+                "connection": {"connection_name": "test"},
             },
         ))
     """
-    import json as _json  # noqa: PLC0415 — cold path: lazy load to keep import-time cost low
+    # Local dev is unconditional: boot an in-process Temporal *and* an
+    # embedded ``daprd`` so the entire infrastructure code path is the same
+    # one production uses. Both daemons are auto-downloaded and managed by
+    # the SDK — the customer's host stays clean.
+    from application_sdk.dev import embedded_dapr, embedded_runtime  # noqa: PLC0415
 
-    # Dev-friendly: ensure Dapr ports are set. poe start-deps launches Dapr
-    # on the default ports but in a background process, so the env vars aren't
-    # exported to the dev's shell. Default to standard Dapr ports so devs
-    # don't need to manually export them or add them to .env.
-    os.environ.setdefault("DAPR_HTTP_PORT", "3500")
-    os.environ.setdefault("DAPR_GRPC_PORT", "50001")
+    if temporal_host is not None:
+        import warnings  # noqa: PLC0415 — cold path: deprecation warning only
+
+        warnings.warn(
+            "`temporal_host` is deprecated and ignored: `run_dev_combined` now "
+            "always boots an in-process workflow runtime. To target an external "
+            "Temporal cluster, use `run_combined_mode(config)` directly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    app_name = getattr(app_class, "_app_name", "") or app_class.__name__.lower()
+
+    # ``embedded_dapr`` sets ``DAPR_HTTP_PORT`` / ``DAPR_GRPC_PORT`` /
+    # ``DAPR_COMPONENTS_PATH`` itself, so the existing Dapr code path in
+    # ``_create_infrastructure`` and the observability sink see the right
+    # values from the moment daprd is spawning (avoiding races during the
+    # ~3s startup window).
+    # ``embedded_dapr`` first so ``DAPR_COMPONENTS_PATH`` is set before any
+    # observability flush cycle fires during the ~5s ``embedded_runtime``
+    # cold-start window. Otherwise the periodic flush would race with daprd
+    # startup and log spurious "objectstore upload failed" warnings.
+    async with (
+        embedded_dapr(app_id=app_name) as _dapr,
+        embedded_runtime(namespace=temporal_namespace or "default") as _rt,
+    ):
+        del _dapr  # env-side-effect is sufficient; the dataclass is just for tests
+        await _run_dev_combined_inner(
+            app_class=app_class,
+            credential_stores=credential_stores,
+            credentials=credentials,
+            example_input=example_input,
+            host=host,
+            port=port,
+            temporal_host=_rt.host,
+            temporal_namespace=_rt.namespace,
+            task_queue=task_queue,
+        )
+
+
+async def _run_dev_combined_inner(
+    *,
+    app_class: type[App],
+    credential_stores: Mapping[str, SecretStore] | None,
+    credentials: dict[str, Any] | None,
+    example_input: dict[str, Any] | None,
+    host: str | None,
+    port: int | None,
+    temporal_host: str,
+    temporal_namespace: str,
+    task_queue: str | None,
+) -> None:
+    """Body of ``run_dev_combined`` — runs against fully-resolved connection details.
+
+    Accepts ``host`` / ``port`` / ``task_queue`` as ``None`` and lets
+    ``_build_dev_config`` apply the same defaults the CLI path uses (env
+    vars → AppConfig fields). ``temporal_host`` and ``temporal_namespace``
+    always arrive populated from the embedded runtime.
+    """
+    import json as _json  # noqa: PLC0415
 
     app_module = f"{app_class.__module__}:{app_class.__name__}"
 
@@ -1268,7 +1327,10 @@ async def run_dev_combined(
         task_queue=task_queue,
     )
 
-    # Create infrastructure early so run_combined_mode uses it directly.
+    # Build infrastructure via the standard Dapr path. ``run_dev_combined``
+    # has already started an embedded ``daprd`` (via ``embedded_dapr``) and
+    # exported ``DAPR_HTTP_PORT`` + ``DAPR_COMPONENTS_PATH``, so this goes
+    # through identical code as production / SDR / CI.
     from application_sdk.infrastructure.context import (  # noqa: PLC0415 — cold path: only when infrastructure init is needed
         set_infrastructure,
     )

--- a/application_sdk/observability/observability.py
+++ b/application_sdk/observability/observability.py
@@ -76,17 +76,27 @@ class AtlanObservability(Generic[T], ABC):
     _upstream_store: ClassVar["ObjectStore | None"] = None
 
     @classmethod
+    def _components_dir(cls) -> str:
+        # Honour ``DAPR_COMPONENTS_PATH`` so the embedded-Dapr local-dev path
+        # finds the auto-generated component YAMLs in the temp dir.
+        return os.environ.get("DAPR_COMPONENTS_PATH", "./components")
+
+    @classmethod
     def _get_deployment_store(cls):
         if cls._deployment_store is None:
             cls._deployment_store = create_store_from_binding(
-                DEPLOYMENT_OBJECT_STORE_NAME
+                DEPLOYMENT_OBJECT_STORE_NAME,
+                components_dir=cls._components_dir(),
             )
         return cls._deployment_store
 
     @classmethod
     def _get_upstream_store(cls):
         if cls._upstream_store is None:
-            cls._upstream_store = create_store_from_binding(UPSTREAM_OBJECT_STORE_NAME)
+            cls._upstream_store = create_store_from_binding(
+                UPSTREAM_OBJECT_STORE_NAME,
+                components_dir=cls._components_dir(),
+            )
         return cls._upstream_store
 
     def __init__(

--- a/application_sdk/version.py
+++ b/application_sdk/version.py
@@ -1,5 +1,22 @@
-"""
-Version information for the application_sdk package.
+"""Version information for the application_sdk package.
+
+Holds two kinds of versions:
+
+* ``__version__`` — the SDK's own package version.
+* ``__dapr_version`` — the pinned Dapr runtime the SDK auto-downloads on
+  first local-dev run (see ``application_sdk.dev._dapr``). Leading double
+  underscore signals it is **SDK-internal**; consumer apps should rely on
+  the runtime behaviour, not import this value.
+
+CI workflows that need the daprd pin (`.github/workflows/scale-tests.yaml`,
+`.github/actions/e2e-examples/action.yaml`) read it via a small shell
+step so this file stays the only place the literal ``1.17.x`` appears
+in the repo::
+
+    ver=$(grep '^__dapr_version' application_sdk/version.py | cut -d'"' -f2)
+
+Bump deliberately — older Dapr releases drop off the CDN.
 """
 
 __version__ = "3.10.0"
+__dapr_version: str = "1.17.6"

--- a/tests/unit/dev/test_dapr.py
+++ b/tests/unit/dev/test_dapr.py
@@ -1,0 +1,227 @@
+"""Unit tests for ``application_sdk.dev._dapr``.
+
+Covers the pure helpers (``_platform_tuple``, ``_write_components``) and
+the lifecycle invariants of ``embedded_dapr`` (env-var save/restore,
+components-dir cleanup) without actually downloading or spawning a
+real ``daprd``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from application_sdk.dev._dapr import (
+    _COMPONENTS_YAML,
+    EmbeddedDapr,
+    _pick_free_port,
+    _platform_tuple,
+    _write_components,
+    embedded_dapr,
+)
+
+
+class TestPlatformTuple:
+    """``_platform_tuple`` maps ``platform.system()`` + ``platform.machine()``
+    to the strings Dapr uses in its release asset names."""
+
+    @pytest.mark.parametrize(
+        ("sys_name", "machine", "expected"),
+        [
+            ("Darwin", "arm64", ("darwin", "arm64")),
+            ("Darwin", "x86_64", ("darwin", "amd64")),
+            ("Linux", "x86_64", ("linux", "amd64")),
+            ("Linux", "aarch64", ("linux", "arm64")),
+            ("Windows", "AMD64", ("windows", "amd64")),
+        ],
+    )
+    def test_supported_combos(
+        self, sys_name: str, machine: str, expected: tuple[str, str]
+    ) -> None:
+        with (
+            patch("platform.system", return_value=sys_name),
+            patch("platform.machine", return_value=machine),
+        ):
+            assert _platform_tuple() == expected
+
+    def test_unsupported_arch_raises(self) -> None:
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="riscv64"),
+            pytest.raises(RuntimeError, match="Unsupported architecture"),
+        ):
+            _platform_tuple()
+
+    def test_unsupported_os_raises(self) -> None:
+        with (
+            patch("platform.system", return_value="FreeBSD"),
+            patch("platform.machine", return_value="amd64"),
+            pytest.raises(RuntimeError, match="Unsupported OS"),
+        ):
+            _platform_tuple()
+
+
+class TestWriteComponents:
+    """``_write_components`` materialises the five YAMLs the SDK expects."""
+
+    def test_writes_all_five_components(self, tmp_path: Path) -> None:
+        components_dir = tmp_path / "components"
+        objectstore_root = tmp_path / "objects"
+
+        _write_components(components_dir, objectstore_root)
+
+        expected = sorted(_COMPONENTS_YAML.keys())
+        actual = sorted(p.name for p in components_dir.iterdir())
+        assert actual == expected
+
+    def test_objectstore_root_substituted(self, tmp_path: Path) -> None:
+        components_dir = tmp_path / "components"
+        objectstore_root = tmp_path / "objects"
+
+        _write_components(components_dir, objectstore_root)
+
+        content = (components_dir / "objectstore.yaml").read_text()
+        assert str(objectstore_root.resolve()) in content
+        assert "bindings.localstorage" in content
+
+    def test_statestore_uses_in_memory(self, tmp_path: Path) -> None:
+        components_dir = tmp_path / "components"
+        _write_components(components_dir, tmp_path / "objects")
+        assert "state.in-memory" in (components_dir / "statestore.yaml").read_text()
+
+    def test_secretstore_uses_local_env(self, tmp_path: Path) -> None:
+        components_dir = tmp_path / "components"
+        _write_components(components_dir, tmp_path / "objects")
+        assert (
+            "secretstores.local.env"
+            in (components_dir / "secretstore.yaml").read_text()
+        )
+
+    def test_objectstore_root_created(self, tmp_path: Path) -> None:
+        components_dir = tmp_path / "components"
+        objectstore_root = tmp_path / "objects" / "nested"
+        assert not objectstore_root.exists()
+
+        _write_components(components_dir, objectstore_root)
+
+        assert objectstore_root.is_dir()
+
+
+class TestPickFreePort:
+    def test_returns_int_in_valid_range(self) -> None:
+        port = _pick_free_port()
+        assert isinstance(port, int)
+        # Ephemeral port range — varies by OS, but always > 1023.
+        assert 1024 <= port <= 65535
+
+
+class TestEmbeddedDaprLifecycle:
+    """``embedded_dapr`` must save/restore env vars and clean up its temp dir."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_subprocess_and_binary(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Replace binary download, subprocess spawn, and readiness poll
+        with no-ops so the context manager runs end-to-end without
+        touching the network or spawning a real daprd."""
+        fake_binary = tmp_path / "daprd-stub"
+        fake_binary.write_text("#!/bin/sh\n")
+        fake_binary.chmod(0o755)
+
+        monkeypatch.setattr(
+            "application_sdk.dev._dapr._ensure_daprd_binary",
+            lambda: fake_binary,
+        )
+
+        fake_proc = MagicMock()
+        fake_proc.returncode = 0
+        fake_proc.wait = AsyncMock(return_value=0)
+        fake_proc.terminate = MagicMock()
+        fake_proc.kill = MagicMock()
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return fake_proc
+
+        monkeypatch.setattr(
+            "asyncio.create_subprocess_exec", _fake_create_subprocess_exec
+        )
+        monkeypatch.setattr(
+            "application_sdk.dev._dapr._wait_for_dapr_ready",
+            AsyncMock(return_value=None),
+        )
+
+        return fake_proc
+
+    @pytest.mark.asyncio
+    async def test_yields_embedded_dapr_dataclass(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        async with embedded_dapr(app_id="test-app") as dapr:
+            assert isinstance(dapr, EmbeddedDapr)
+            assert dapr.http_port > 0
+            assert dapr.grpc_port > 0
+            assert Path(dapr.components_dir).is_dir()
+
+    @pytest.mark.asyncio
+    async def test_sets_env_vars_inside_context(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        for k in ("DAPR_HTTP_PORT", "DAPR_GRPC_PORT", "DAPR_COMPONENTS_PATH"):
+            monkeypatch.delenv(k, raising=False)
+
+        async with embedded_dapr(app_id="test-app") as dapr:
+            assert os.environ["DAPR_HTTP_PORT"] == str(dapr.http_port)
+            assert os.environ["DAPR_GRPC_PORT"] == str(dapr.grpc_port)
+            assert os.environ["DAPR_COMPONENTS_PATH"] == dapr.components_dir
+
+    @pytest.mark.asyncio
+    async def test_restores_prior_env_vars_on_exit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DAPR_HTTP_PORT", "preexisting-3500")
+        monkeypatch.delenv("DAPR_GRPC_PORT", raising=False)
+        monkeypatch.delenv("DAPR_COMPONENTS_PATH", raising=False)
+
+        async with embedded_dapr(app_id="test-app"):
+            pass
+
+        # Pre-existing value comes back.
+        assert os.environ["DAPR_HTTP_PORT"] == "preexisting-3500"
+        # Previously-unset vars are unset again.
+        assert "DAPR_GRPC_PORT" not in os.environ
+        assert "DAPR_COMPONENTS_PATH" not in os.environ
+
+    @pytest.mark.asyncio
+    async def test_cleans_up_components_dir_on_exit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        async with embedded_dapr(app_id="test-app") as dapr:
+            components_dir = Path(dapr.components_dir)
+            assert components_dir.is_dir()
+
+        assert not components_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_terminates_subprocess_on_exit(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _stub_subprocess_and_binary,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        # ``returncode is None`` simulates a running process that needs SIGTERM.
+        _stub_subprocess_and_binary.returncode = None
+
+        async with embedded_dapr(app_id="test-app"):
+            pass
+
+        _stub_subprocess_and_binary.terminate.assert_called_once()
+        _stub_subprocess_and_binary.wait.assert_awaited()

--- a/tests/unit/dev/test_embedded.py
+++ b/tests/unit/dev/test_embedded.py
@@ -1,0 +1,51 @@
+"""Unit tests for ``application_sdk.dev._embedded``.
+
+Covers the lifecycle invariants of ``embedded_runtime`` without actually
+downloading or spawning Temporal's dev-server binary.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from application_sdk.dev._embedded import EmbeddedRuntime, embedded_runtime
+
+
+@pytest.mark.asyncio
+class TestEmbeddedRuntimeLifecycle:
+    async def test_yields_embedded_runtime_dataclass_and_shuts_down(self) -> None:
+        """Yielded value carries the loopback target; shutdown is awaited on exit."""
+        fake_env = MagicMock()
+        fake_env.client.service_client.config.target_host = "127.0.0.1:54321"
+        fake_env.shutdown = AsyncMock(return_value=None)
+
+        with patch(
+            "temporalio.testing.WorkflowEnvironment.start_local",
+            AsyncMock(return_value=fake_env),
+        ):
+            async with embedded_runtime(namespace="ns1") as rt:
+                assert isinstance(rt, EmbeddedRuntime)
+                assert rt.host == "127.0.0.1:54321"
+                assert rt.namespace == "ns1"
+
+        fake_env.shutdown.assert_awaited_once()
+
+    async def test_shutdown_runs_even_when_body_raises(self) -> None:
+        """The runtime is torn down even if the caller raises inside the context."""
+        fake_env = MagicMock()
+        fake_env.client.service_client.config.target_host = "127.0.0.1:54321"
+        fake_env.shutdown = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "temporalio.testing.WorkflowEnvironment.start_local",
+                AsyncMock(return_value=fake_env),
+            ),
+            pytest.raises(ValueError),
+        ):
+            async with embedded_runtime() as _rt:
+                raise ValueError("boom")
+
+        fake_env.shutdown.assert_awaited_once()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1284,43 +1284,47 @@ class TestRunCombinedMode:
 # --------------------------------------------------------------------------- #
 
 
+@pytest.fixture
+def _stub_embedded_daemons():
+    """Replace the daprd + Temporal context managers with no-ops.
+
+    ``run_dev_combined`` unconditionally wraps its body in ``embedded_dapr``
+    and ``embedded_runtime``; without this stub each unit test would try to
+    download daprd from the internet and spawn subprocesses. We swap in
+    minimal async context managers that yield the dataclasses the body
+    expects but do no actual work.
+    """
+    from contextlib import asynccontextmanager
+
+    from application_sdk.dev._dapr import EmbeddedDapr
+    from application_sdk.dev._embedded import EmbeddedRuntime
+
+    @asynccontextmanager
+    async def _fake_dapr(**_kwargs):
+        yield EmbeddedDapr(
+            http_port=3500, grpc_port=50001, components_dir="/tmp/fake-components"
+        )
+
+    @asynccontextmanager
+    async def _fake_runtime(**_kwargs):
+        yield EmbeddedRuntime(host="127.0.0.1:7233", namespace="default")
+
+    # ``run_dev_combined`` does ``from application_sdk.dev import embedded_dapr,
+    # embedded_runtime`` lazily inside the function body, so patch them on the
+    # source module — not on ``application_sdk.main``.
+    with (
+        patch("application_sdk.dev.embedded_dapr", _fake_dapr),
+        patch("application_sdk.dev.embedded_runtime", _fake_runtime),
+    ):
+        yield
+
+
 class TestRunDevCombined:
     """Behavioral tests for run_dev_combined()."""
 
-    async def test_sets_default_dapr_ports(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Defaults DAPR_HTTP_PORT/DAPR_GRPC_PORT for dev convenience."""
-        monkeypatch.delenv("DAPR_HTTP_PORT", raising=False)
-        monkeypatch.delenv("DAPR_GRPC_PORT", raising=False)
-        app_class = _fake_app_class()
-        with (
-            patch(
-                "application_sdk.main._create_infrastructure",
-                new_callable=AsyncMock,
-                return_value=MagicMock(),
-            ),
-            patch("application_sdk.infrastructure.context.set_infrastructure"),
-            patch(
-                "application_sdk.main.run_combined_mode",
-                new_callable=AsyncMock,
-            ) as mock_run_combined,
-        ):
-            await run_dev_combined(app_class, host="127.0.0.1", port=9999)
-        import os
-
-        assert os.environ.get("DAPR_HTTP_PORT") == "3500"
-        assert os.environ.get("DAPR_GRPC_PORT") == "50001"
-        mock_run_combined.assert_awaited_once()
-        # config passed must reflect dev settings
-        cfg = mock_run_combined.await_args.args[0]
-        assert cfg.mode == "combined"
-        assert cfg.handler_host == "127.0.0.1"
-        assert cfg.handler_port == 9999
-        # Dev should not start prometheus by default (port collision)
-        assert cfg.enable_temporal_core_metrics is False
-        # Dev uses ephemeral health port to avoid collision
-        assert cfg.health_port == 0
+    @pytest.fixture(autouse=True)
+    def _stub_daemons(self, _stub_embedded_daemons):
+        """Stub the embedded daprd + Temporal context managers for every test in this class."""
 
     async def test_credentials_path_schedules_provision_task(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -1509,6 +1513,10 @@ class TestLogDaprComponentsSafeMetaBranch:
 
 class TestRunDevCombinedProvisioning:
     """Exercise the inner _provision_and_start coroutine in the credentials path."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_daemons(self, _stub_embedded_daemons):
+        """Stub the embedded daprd + Temporal context managers for every test in this class."""
 
     async def test_provision_and_start_posts_creds_and_workflow(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
## Summary

`run_dev_combined` now boots an in-process Temporal **and** an embedded `daprd` so the entire infrastructure code path is the same one production uses (real Dapr clients, real binding semantics, real serialization). Both daemons are auto-downloaded by the SDK and managed for the lifetime of the call. The customer's host stays clean — Python and `uv` are the only prereqs.

Today, `application_sdk/main.py:1257` unconditionally forces `DAPR_HTTP_PORT=3500` inside `run_dev_combined` and the function then expects a sidecar to already be running. There is no consumer-facing opt-out, so `app/run_dev.py` scripts crash unless the developer separately installs the Dapr CLI, runs `dapr init`, drops a `components/objectstore.yaml` in the app repo, and starts `dapr run` in a second terminal. This PR removes that requirement.

## Why no flag, why not in-process mocks

An earlier draft used in-process mocks (`MockStateStore` + `EnvironmentSecretStore` + `LocalStore`) so the customer needed nothing installed. That gave a friction-free local-dev experience but introduced a real local/prod divergence — code that worked locally could fail in prod because Dapr / S3 / Redis semantics were never exercised. The shipped revision closes that gap: local dev runs through the **real** Dapr binary with auto-generated components. The only remaining difference vs prod is the backend each component talks to (in-memory state, env-var secrets, `bindings.localstorage` for object storage) — the same one `atlan-openapi-app` already uses in its SDR CI.

`run_dev_combined` is named for what it does. The customer doesn't pass a flag to confirm — calling the function *is* the signal. Anyone wanting to drive a real Dapr/Temporal stack uses the lower-level `run_combined_mode(config)` directly (production / SDR / CI already go through that path).

## What changes

**New: `application_sdk/dev/_dapr.py`**
- `_ensure_daprd_binary()` downloads `daprd` from Dapr's GitHub releases on first use into `~/.cache/atlan-sdk/dapr/`, pinned via `_DAPRD_VERSION` (currently the latest stable). Version-scoped cache path so bumping the pin doesn't shadow older binaries.
- `_write_components()` generates the five component YAMLs the SDK expects (`statestore`, `secretstore`, `deployment-secret-store`, `objectstore`, `eventstore`) into a temp dir:
  - `statestore` → `state.in-memory`
  - `secretstore` / `deployment-secret-store` → `secretstores.local.env`
  - `objectstore` / `eventstore` → `bindings.localstorage` rooted at `./local/objectstore/`
- `embedded_dapr()` async context manager spawns the binary, waits for the metadata endpoint to respond, SIGTERMs cleanly on exit. Sets `DAPR_HTTP_PORT` / `DAPR_GRPC_PORT` / `DAPR_COMPONENTS_PATH` on entry (and restores prior values on exit) so the existing Dapr code path picks them up — including the observability sink's flush cycle, which races with daprd startup.

**New: `application_sdk/dev/_embedded.py`**
- `embedded_runtime()` async context manager around `temporalio.testing.WorkflowEnvironment.start_local()` — auto-downloads the Temporal dev-server binary to `~/.cache/temporalio/`.

**New: `application_sdk/dev/__init__.py`** — re-exports `embedded_dapr`, `embedded_runtime`, and their `EmbeddedDapr` / `EmbeddedRuntime` dataclasses for direct use in tests or alternate dev scripts.

**Edited: `application_sdk/main.py`**
- `run_dev_combined` wraps both `embedded_runtime()` and `embedded_dapr()` unconditionally. No `local_dev_mode` flag, no `temporal_host` kwarg, no `DAPR_HTTP_PORT` setdefault.
- `_run_dev_combined_inner` is a thin body split so the embedded-runtime/Dapr wrappers sit cleanly above the existing config build without a 100-line re-indent. It calls the original `_create_infrastructure` — no overload, no new signature.
- `_create_infrastructure` itself is unchanged: still Dapr-only, still used by production paths (`run_main`, `run_combined_mode`).

**Edited: `application_sdk/observability/observability.py`**
- `_get_deployment_store` / `_get_upstream_store` honour `DAPR_COMPONENTS_PATH` so the observability sink finds the auto-generated `objectstore` component in our temp dir.
- Non-fatal "Deployment objectstore upload failed" log no longer dumps a full traceback.

## Customer-facing surface

```python
# app/run_dev.py — the whole file
import asyncio
from application_sdk.main import run_dev_combined
from app.connector import MyApp

asyncio.run(run_dev_combined(MyApp, example_input={...}))
```

No `temporalio` import. No `MockSecretStore`. No `components/` directory. The customer types `make install && make run` and the SDK does everything else.

## Test plan

Verified end-to-end with `atlan-hello-world-app` (atlanhq/atlan-hello-world-app#2):

- [x] `uv sync && uv run python -m app.run_dev` boots both daemons in the same process. First run downloads `daprd` (~50 MB) and the Temporal dev-server (~30 MB) into `~/.cache/`. Subsequent runs are instant.
- [x] `POST /workflows/v1/start` with `{"name":"Atlan","repeat_count":3}` returns `success: true`.
- [x] `GET /workflows/v1/result/<id>` returns `status: completed`, `"Hello, Atlan!"`, `record_count: 3`.
- [x] `worker_start` event published through the real Dapr binding (log shows `Published event via binding: name=worker_start type=application_events topic=application_events`).
- [x] Log clean: 0 tracebacks, 0 errors, 0 Dapr-component warnings, 0 observability noise.
- [ ] CI: existing unit + integration tests still pass — the Dapr code path is untouched; `_create_infrastructure` has the same signature and body.

## Behaviour notes

- **`poe start-deps` workflow ends.** Anyone running it and expecting `run_dev_combined` to talk to that pre-started Dapr+Temporal stack will find it no longer does — `run_dev_combined` always brings up its own pair. For that flow, use `run_combined_mode(config)` directly, or set DAPR / TEMPORAL env vars and go through the CLI entry-point.
- **Platform support.** `daprd` binaries exist for linux / darwin / windows × amd64 / arm64. Anything else raises a clear error; those callers should use `run_combined_mode` directly.
- **Bumping the daprd pin.** Edit `_DAPRD_VERSION` in `_dapr.py`. Cache is version-scoped so old binaries don't shadow new ones; users can delete `~/.cache/atlan-sdk/dapr/<old_version>/` to reclaim disk.

## Follow-ups

- Unit test for `embedded_dapr()` and `embedded_runtime()` lifecycle. Smoke-tested manually; should be added before this lands in CI.
- Mirror the consumer-side change to `atlan-openapi-app`'s `run_dev.py` (separate PR).
- Doc updates: `docs/agents/dev-commands.md` still tells SDK contributors to run `poe start-deps`; should mention that consumer apps no longer need it.