### PR TITLE
feat(events): include sdk_version in EventMetadata

### DIFF
--- a/application_sdk/contracts/events.py
+++ b/application_sdk/contracts/events.py
@@ -5,7 +5,7 @@ This module contains the base classes and models for all events in the applicati
 
 from abc import ABC
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -14,6 +14,7 @@ from application_sdk.constants import (
     RELEASE_ID,
     WORKER_START_EVENT_VERSION,
 )
+from application_sdk.version import __version__ as _SDK_VERSION
 
 
 class EventTypes(Enum):
@@ -51,6 +52,9 @@ class EventMetadata(BaseModel):
     Attributes:
         application_name: Name of the application the event belongs to.
         release_id: Release UUID from Global Marketplace (empty if not injected).
+        sdk_version: Installed application-sdk version of the running process
+            (from ``application_sdk.__version__``). Always populated — does not
+            depend on any env var being injected at image build time.
         created_timestamp: Timestamp when the event was created.
         workflow_type: Type of the workflow.
         workflow_id: ID of the workflow.
@@ -64,6 +68,7 @@ class EventMetadata(BaseModel):
 
     application_name: str = Field(init=True, default=APPLICATION_NAME)
     release_id: str = Field(init=True, default=RELEASE_ID)
+    sdk_version: str = Field(init=True, default=_SDK_VERSION)
     created_timestamp: int = Field(init=True, default=0)
 
     # Workflow information
@@ -109,7 +114,7 @@ class Consumes(BaseModel):
     event_type: str = Field(alias="eventType")
     event_name: str = Field(alias="eventName")
     version: str = Field()
-    filters: List[EventFilter] = Field(init=True, default=[])
+    filters: list[EventFilter] = Field(init=True, default=[])
 
 
 class EventRegistration(BaseModel):
@@ -120,8 +125,8 @@ class EventRegistration(BaseModel):
         produces: List of events to produce.
     """
 
-    consumes: List[Consumes] = Field(init=True, default=[])
-    produces: List[Dict[str, Any]] = Field(init=True, default=[])
+    consumes: list[Consumes] = Field(init=True, default=[])
+    produces: list[dict[str, Any]] = Field(init=True, default=[])
 
 
 class Event(BaseModel, ABC):
@@ -139,7 +144,7 @@ class Event(BaseModel, ABC):
     event_type: str
     event_name: str
 
-    data: Dict[str, Any]
+    data: dict[str, Any]
 
     def get_topic_name(self):
         """Get the topic name for this event.
@@ -185,10 +190,10 @@ class WorkerStartEventData(BaseModel):
     host: str
     port: str
     connection_string: str
-    max_concurrent_activities: Optional[int]
+    max_concurrent_activities: int | None
     workflow_count: int
     activity_count: int
-    build_id: Optional[str] = None
+    build_id: str | None = None
     use_worker_versioning: bool = False
     app_version: str = ""
     release_id: str = ""

--- a/tests/unit/interceptors/test_events.py
+++ b/tests/unit/interceptors/test_events.py
@@ -335,6 +335,29 @@ class TestEnrichEventMetadata:
         assert enriched.metadata.attempt == 2
         assert enriched.metadata.workflow_state == WorkflowStates.RUNNING.value
 
+    def test_sdk_version_defaults_to_installed_version(self) -> None:
+        """EventMetadata.sdk_version must always be populated with the running
+        SDK version — independent of ATLAN_SDK_VERSION env injection."""
+        from application_sdk.contracts.events import EventMetadata
+        from application_sdk.version import __version__ as sdk_version
+
+        # Default constructor — no enrichment needed for this field.
+        assert EventMetadata().sdk_version == sdk_version
+        # Constructed via the base Event default_factory path.
+        event = self._make_event()
+        assert event.metadata.sdk_version == sdk_version
+        # Enrichment must not clobber it.
+        with (
+            mock.patch.object(
+                events_module.workflow, "info", side_effect=RuntimeError("no ctx")
+            ),
+            mock.patch.object(
+                events_module.activity, "info", side_effect=RuntimeError("no ctx")
+            ),
+        ):
+            enriched = _enrich_event_metadata(event)
+        assert enriched.metadata.sdk_version == sdk_version
+
 
 class TestSendLifecycleEventToSegment:
     """Tests for _send_lifecycle_event_to_segment."""
@@ -594,9 +617,9 @@ class TestEventWorkflowInboundInterceptor:
             mock.patch.object(
                 events_module.workflow, "execute_activity", new=execute_activity
             ),
+            pytest.raises(ValueError, match="boom"),
         ):
-            with pytest.raises(ValueError, match="boom"):
-                await interceptor.execute_workflow(mock.MagicMock())
+            await interceptor.execute_workflow(mock.MagicMock())
 
         # start + end emitted even on failure
         assert execute_activity.await_count == 2


### PR DESCRIPTION
## Summary

- Add `sdk_version` to `EventMetadata` (`application_sdk/contracts/events.py`), sourced from `application_sdk.__version__` at module load time.
- Every event published through the Dapr event binding (`worker_start`, `workflow_*`, `activity_*`, `token_refresh`, `application_*`) now carries the SDK version of the running process — no reliance on `ATLAN_SDK_VERSION` being injected at image build.
- `WorkerStartEventData.sdk_version` (set from the env var) is left untouched for backwards compatibility; consumers can prefer the metadata field going forward.

## Test plan

- [x] Unit test: `EventMetadata().sdk_version == application_sdk.__version__` (default constructor)
- [x] Unit test: `Event(...).metadata.sdk_version` matches via `default_factory` path
- [x] Unit test: `_enrich_event_metadata` does not clobber `sdk_version`
- [x] `uv run pre-commit run --files application_sdk/contracts/events.py tests/unit/interceptors/test_events.py` — passes (ruff, ruff-format, isort, pyright)
- [x] `uv run pytest tests/unit/interceptors/test_events.py` — all 30 tests pass