### PR TITLE
fix(toolkit): emit top-level hidden auth panes for JDBC-URL agent merge (HYP-1251)

### DIFF
--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -2250,6 +2250,14 @@ local function generateCredentialConfig(): Mapping<String, Any> =
       when (credentialUrlGroup != null && credentialAuthOptions != null) {
         ["connectBy"] = renderConnectByRadio(credentialUrlGroup!!)
         ["jdbcUrl"] = renderJdbcUrlField(credentialUrlGroup!!, credentialAuthOptions!!)
+        // Agent merge targets: the agent widget's agentConfigEntries overrides
+        // target top-level auth panes (basic, ldap, etc.). In JDBC-URL mode
+        // these live inside jdbcUrl.properties, so without top-level copies
+        // the merge creates orphaned entries with no ui metadata → empty boxes.
+        // These hidden copies ensure the merge inherits correct ui (HYP-1251).
+        for (k, opt in credentialAuthOptions!!) {
+          [k] = renderJdbcAuthOption(opt)
+        }
       }
       // Plain auth-type flow (non-JDBC): auth-type radio + nested panes
       when (credentialUrlGroup == null && credentialAuthOptions != null) {

--- a/contract-toolkit/tests/jdbc_auth_pane_test.pkl
+++ b/contract-toolkit/tests/jdbc_auth_pane_test.pkl
@@ -1,0 +1,116 @@
+/// Unit test: AdvancedJDBCUrlGroup emits top-level auth panes (HYP-1251).
+///
+/// When `credentialUrlGroup` (AdvancedJDBCUrlGroup) is used with
+/// `credentialAuthOptions`, the credential configmap must emit auth
+/// panes (basic, ldap, etc.) at the top level with `hidden: true`.
+/// These serve as merge targets for the frontend agent widget's
+/// `agentConfigEntries` overrides. Without them, the deep merge
+/// creates orphaned top-level entries with no ui metadata.
+amends "pkl:test"
+
+import "../src/NativeApp.pkl"
+import "../src/Config.pkl"
+import "../src/Connectors.pkl"
+
+/// Minimal JDBC-URL app with two auth types — exercises the exact
+/// code path in `generateCredentialConfig()` that emits top-level
+/// auth panes alongside `connectBy` + `jdbcUrl`.
+local jdbcApp = (NativeApp) {
+  name = "jdbc-auth-test"
+  displayName = "JDBC Auth Pane Test"
+  connector = Connectors.TERADATA
+  workflowType = "JDBCAuthTestWorkflow"
+  icon = "https://example.com/icon.svg"
+
+  credentialUrlGroup = new NativeApp.AdvancedJDBCUrlGroup {
+    protocol = ""
+    urlAddonBefore = "driver://"
+    hostField = new NativeApp.FieldSpec {
+      name = "host"
+      displayName = "Host"
+      placeholder = "host.example.com"
+      feedback = true
+    }
+    portField = new NativeApp.FieldSpec {
+      name = "port"
+      fieldType = "number"
+      displayName = "Port"
+      placeholder = "1025"
+      defaultValue = "1025"
+      required = false
+    }
+  }
+
+  credentialAuthOptions {
+    ["basic"] = new NativeApp.JDBCUrlAuthOption {
+      label = "Basic"
+      nestedLabel = "Basic"
+      urlPartMapping = new NativeApp.UrlPartMapping {
+        hostname = "host"
+        searchParams {
+          ["PORT"] = new NativeApp.UrlRef { field = "port" }
+        }
+      }
+      fields {
+        new NativeApp.FieldSpec { name = "username"; displayName = "Username" }
+        new NativeApp.FieldSpec { name = "password"; sensitive = true; displayName = "Password" }
+      }
+    }
+    ["ldap"] = new NativeApp.JDBCUrlAuthOption {
+      label = "LDAP"
+      nestedLabel = "LDAP"
+      urlPartMapping = new NativeApp.UrlPartMapping {
+        hostname = "host"
+        searchParams {
+          ["PORT"] = new NativeApp.UrlRef { field = "port" }
+          ["LOGMECH"] = new NativeApp.UrlLiteral { value = "LDAP" }
+        }
+      }
+      fields {
+        new NativeApp.FieldSpec { name = "username"; displayName = "Username" }
+        new NativeApp.FieldSpec { name = "password"; sensitive = true; displayName = "Password" }
+      }
+    }
+  }
+
+  uiConfig {
+    tasks {
+      ["Credential"] {
+        inputs {
+          ["credential-guid"] = new Config.CredentialInput {
+            title = ""
+            credType = "atlan-connectors-jdbc-auth-test"
+            placeholderText = "Credential Guid"
+          }
+        }
+      }
+    }
+  }
+}
+
+local credentialJson: String = jdbcApp.output.files["atlan-connectors-jdbc-auth-test.json"].text
+
+facts {
+  ["JDBC-URL credential configmap contains AdvancedJDBCUrlGroup and connectBy"] {
+    credentialJson.contains("\"AdvancedJDBCUrlGroup\"")
+    credentialJson.contains("\"connectBy\"")
+    credentialJson.contains("\"jdbcUrl\"")
+  }
+
+  ["Top-level auth panes emitted as hidden merge targets (HYP-1251)"] {
+    // Both auth panes must exist at the top level for agent widget merges
+    credentialJson.contains("\"basic\"")
+    credentialJson.contains("\"ldap\"")
+    // They must be hidden (visible versions live inside jdbcUrl.properties)
+    credentialJson.contains("\"hidden\": true")
+    credentialJson.contains("\"widget\": \"nested\"")
+    credentialJson.contains("\"nestedValue\": false")
+  }
+
+  ["Auth panes also exist inside jdbcUrl.properties"] {
+    // The AdvancedJDBCUrlGroup widget renders from these nested versions
+    credentialJson.contains("\"auth-type\"")
+    credentialJson.contains("\"Username\"")
+    credentialJson.contains("\"Password\"")
+  }
+}

--- a/contract-toolkit/tests/open_source_examples_test.pkl
+++ b/contract-toolkit/tests/open_source_examples_test.pkl
@@ -90,4 +90,5 @@ facts {
     publishControlsInputPy.contains("load_to_atlan: bool = True")
     !publishControlsInputPy.contains("publish_dry_run")
   }
+
 }


### PR DESCRIPTION
## Summary

When `credentialUrlGroup` (AdvancedJDBCUrlGroup) is used with `credentialAuthOptions`, emit auth panes (`basic`, `ldap`, etc.) at the top level with `hidden: true` alongside `jdbcUrl`. These serve as merge targets for the frontend agent widget's `agentConfigEntries` overrides.

## Problem

The agent widget deep-merges `agentConfigEntries` overrides onto the connector configmap at the **top level**. All 7 legacy marketplace connectors with JDBCUrlGroup (teradata, mssql, postgres, alloydb, cloudsql, hive, cratedb) had auth panes at both the top level AND inside `jdbcUrl`. The toolkit-generated configmap only put them inside `jdbcUrl.properties`.

When agent overrides target top-level `basic`/`ldap`, the deep merge creates orphaned entries with no `type`, no `ui.hidden`, no `ui.widget` → two empty input boxes on the credential page.

**Affected**: Any connector using `AdvancedJDBCUrlGroup` + `AgentSelector`. Currently Teradata and Hive. AlloyDB Postgres and CloudSQL Postgres will hit this when they add SDR support.

## Fix

6-line addition in `generateCredentialConfig()` — when JDBC-URL mode is active, also emit each auth option via `renderJdbcAuthOption()` at the top level. This function produces `{type: "object", ui: {widget: "nested", hidden: true, nestedValue: false}, properties: {...}}` — exactly what the old marketplace configmaps had.

Connectors using the plain auth flow (no `credentialUrlGroup`) are completely unaffected.

## Test plan

- [x] New source-agnostic unit test (`jdbc_auth_pane_test.pkl`) — exercises JDBC + multi-auth-type condition, verifies top-level hidden panes
- [x] All 39 existing toolkit tests pass (172 assertions, 0 regressions)
- [x] Verified generated output with real Teradata app contract — `basic`/`ldap` at top level with `hidden: true`
- [x] Verified parity with old marketplace configmap structure
- [x] Tested on kill-argo tenant — no empty boxes in agent mode

Linear: [HYP-1251](https://linear.app/atlan-epd/issue/HYP-1251)

🤖 Generated with [Claude Code](https://claude.com/claude-code)