### PR TITLE
chore(security): allowlist validator recognizes F-cross.2 compliance fields

### DIFF
--- a/.github/scripts/validate_allowlist.py
+++ b/.github/scripts/validate_allowlist.py
@@ -27,6 +27,10 @@ ALLOWLIST_PATH = ".security/base-allowlist.json"
 DEFAULT_POLICY = {"CRITICAL": 15, "HIGH": 30}
 REQUIRED_FIELDS = ["package", "severity", "reason", "expires", "added_by"]
 
+# F-cross.2 compliance fields. Optional during the migration window; promoted
+# to required once all entries are filled in.
+VALID_TRIGGERS = ("fix_released", "quarterly", "expiry", "kev_listed")
+
 
 def main() -> int:
     try:
@@ -91,6 +95,23 @@ def main() -> int:
                 f"{cve_id} ({severity}): expires {expires_str} is {days_from_now} days away "
                 f"— max allowed for {severity} is {max_days} days (by {max_date})"
             )
+
+        # 5. Compliance fields — type-check when present, not required yet.
+        trig = entry.get("re_evaluation_trigger")
+        if trig is not None and trig not in VALID_TRIGGERS:
+            errors.append(
+                f"{cve_id}: re_evaluation_trigger '{trig}' must be one of "
+                f"{VALID_TRIGGERS}"
+            )
+
+        fad = entry.get("fix_available_date")
+        if fad:  # None / empty string allowed during migration
+            try:
+                datetime.strptime(fad, "%Y-%m-%d")
+            except ValueError:
+                errors.append(
+                    f"{cve_id}: fix_available_date '{fad}' must be YYYY-MM-DD"
+                )
 
     if errors:
         print(f"❌ Allowlist validation failed ({len(errors)} error(s)):\n")


### PR DESCRIPTION
## Summary

F-cross.2 step 1 — validator awareness of the 4 compliance fields from [PR atlanhq/global-marketplace#149](https://github.com/atlanhq/global-marketplace/pull/149) PRD §F4.

The validator now type-checks `re_evaluation_trigger` and `fix_available_date` when present on an allowlist entry. The fields are **not required yet** — the existing 41 entries are being migrated in a follow-up PR; once filled in, a third PR promotes them to REQUIRED.

| Field | Check |
|---|---|
| `re_evaluation_trigger` | Must be one of `fix_released` / `quarterly` / `expiry` / `kev_listed` |
| `fix_available_date` | Must be `YYYY-MM-DD` (or absent / null / empty during migration) |
| `compensating_controls` | No check yet (free-text string per PRD) |
| `exposure_assessment` | No check yet (free-text string per PRD) |

## Test plan

- [x] Ran the validator against current `.security/base-allowlist.json` — all 50 entries pass.
- [ ] Manually craft a PR adding `re_evaluation_trigger: "bogus"` on a new entry, confirm validator rejects.

## Follow-ups

1. Migration script populates the 4 fields on the 41 existing entries.
2. Once migration is complete, a third PR adds the 4 fields to `REQUIRED_FIELDS` so new entries must specify them (PRD F4 acceptance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)