### PR TITLE
ci(release): preserve non-`__version__` content in version.py

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,12 +56,22 @@ jobs:
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
 
       - name: Update version.py
+        # In-place edit the ``__version__`` line only. The previous block
+        # truncated the file and re-emitted a fixed 5-line template, which
+        # wiped out anything else living alongside ``__version__`` (the
+        # ``__dapr_version`` pin, its docstring, and any future SDK-internal
+        # constants). A targeted ``sed`` keeps the bump working while
+        # preserving everything around it.
         run: |
-          echo '"""' > application_sdk/version.py
-          echo 'Version information for the application_sdk package.' >> application_sdk/version.py
-          echo '"""' >> application_sdk/version.py
-          echo '' >> application_sdk/version.py
-          echo '__version__ = "${{ env.NEW_VERSION }}"' >> application_sdk/version.py
+          set -euo pipefail
+          sed -i 's/^__version__ = .*/__version__ = "${{ env.NEW_VERSION }}"/' application_sdk/version.py
+          # Confirm exactly one line changed; bail if the constant moved or
+          # was renamed, so a silent miss doesn't ship a broken bump.
+          new=$(grep '^__version__' application_sdk/version.py | cut -d'"' -f2)
+          if [[ "$new" != "${{ env.NEW_VERSION }}" ]]; then
+            echo "::error::sed did not rewrite __version__ as expected (got '$new', want '${{ env.NEW_VERSION }}')"
+            exit 1
+          fi
 
       - name: Generate changelog
         id: changelog


### PR DESCRIPTION
## Summary

The bump workflow's `Update version.py` step was rewriting `application_sdk/version.py` from scratch using five hardcoded `echo` lines:

```yaml
- name: Update version.py
  run: |
    echo '"""' > application_sdk/version.py
    echo 'Version information for the application_sdk package.' >> application_sdk/version.py
    echo '"""' >> application_sdk/version.py
    echo '' >> application_sdk/version.py
    echo '__version__ = "${{ env.NEW_VERSION }}"' >> application_sdk/version.py
```

The first `>` truncates the file, so anything else living alongside `__version__` gets silently nuked on every bump. Most recently the auto-generated PR #1758 erased the `__dapr_version` pin (and its docstring) that `application_sdk/dev/_dapr.py` and the CI workflows depend on.

This PR replaces the truncate-and-rewrite with a targeted `sed` that touches only the `__version__` line. Everything else — `__dapr_version`, docstrings, any future SDK-internal constants — stays put.

## What changes

`.github/workflows/release.yaml`:

```yaml
- name: Update version.py
  run: |
    set -euo pipefail
    sed -i 's/^__version__ = .*/__version__ = "${{ env.NEW_VERSION }}"/' application_sdk/version.py
    new=$(grep '^__version__' application_sdk/version.py | cut -d'"' -f2)
    if [[ "$new" != "${{ env.NEW_VERSION }}" ]]; then
      echo "::error::sed did not rewrite __version__ as expected (got '$new', want '${{ env.NEW_VERSION }}')"
      exit 1
    fi
```

The post-sed verification step fails the job loudly if the constant is missing, renamed, or otherwise unreachable — so a silent miss can't ship a broken bump.

## Verified locally

Ran the new `sed` against the current `application_sdk/version.py` with `NEW_VERSION=3.11.0`:

- Exactly one line changed (`__version__ = "3.10.0"` → `__version__ = "3.11.0"`).
- `__dapr_version: str = "1.17.6"` preserved.
- Top-of-file docstring preserved.

## Follow-up

PR #1758 still carries the broken overwrite from before this fix and should be closed. The next merge to `main` will trigger the bump workflow again and regenerate a fresh PR using the corrected step, which will leave `__dapr_version` intact.

## Why not the longer-term fix (deriving `__version__` from `pyproject.toml` via `importlib.metadata`)?

Scoping. The point of this PR is to stop the bleeding — keep the existing bump flow working, just stop it from clobbering neighbouring content. The cleaner refactor (single source of truth in `pyproject.toml`, `version.py` reads it at import time, delete the `Update version.py` step entirely) is a separate, larger change that touches the wheel build and the release pipeline's mental model. Worth doing later as its own PR.