### PR TITLE
fix(dev): fix Windows example CI and Capability Manifest Drift on release PRs

### DIFF
--- a/.github/actions/e2e-examples/action.yaml
+++ b/.github/actions/e2e-examples/action.yaml
@@ -66,8 +66,16 @@ runs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        $script=iwr -useb https://raw.githubusercontent.com/dapr/cli/master/install/install.ps1; $block=[ScriptBlock]::Create($script); invoke-command -ScriptBlock $block -ArgumentList 1.17.1, "$env:USERPROFILE\.dapr\bin\"
-        $env:Path += ";$env:USERPROFILE\.dapr\bin\"
+        # Direct download — avoids install.ps1's GitHub API lookup, which hits the
+        # 60 req/hr unauthenticated rate limit on shared runner IPs.
+        $CliVersion = "1.17.1"
+        $CliZip = "$env:TEMP\dapr_cli.zip"
+        Invoke-WebRequest -Uri "https://github.com/dapr/cli/releases/download/v$CliVersion/dapr_windows_amd64.zip" -OutFile $CliZip
+        $InstallDir = "$env:USERPROFILE\.dapr\bin"
+        New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+        Expand-Archive -Path $CliZip -DestinationPath $InstallDir -Force
+        Remove-Item $CliZip
+        $env:Path += ";$InstallDir"
         dapr init --runtime-version ${{ steps.dapr-version.outputs.version }} --slim
 
     - name: Install Temporal CLI

--- a/.github/workflows/capability-manifest-check.yaml
+++ b/.github/workflows/capability-manifest-check.yaml
@@ -17,8 +17,15 @@
 # squash-merge-incompatible during a PR (the final squash SHA doesn't exist yet).
 # They are updated whenever the manifest is regenerated post-merge.
 #
-# Skipped for: bump-version-* branches (they only touch version/lockfile artefacts).
+# Noop for: bump-version-* branches (they only touch version/lockfile artefacts).
 # No comment posted for: fork PRs (no ORG_PAT_GITHUB access anyway).
+#
+# NOTE: the job has NO job-level `if` condition even though release PRs skip all
+# the real work.  A job-level skip is reported as "skipped" by GitHub Actions,
+# and GitHub branch protection does NOT treat "skipped" as "success" for required
+# status checks — leaving the check permanently pending and blocking the merge.
+# Running the job unconditionally ensures the conclusion is always "success" or
+# "failure", never the ambiguous "skipped".
 
 name: Capability Manifest Check
 
@@ -40,13 +47,24 @@ permissions:
 jobs:
   drift-check:
     name: Capability Manifest Drift
-    # Skip bot-owned version-bump PRs (mirrors the skip in release.yaml:12).
-    if: ${{ !startsWith(github.event.pull_request.head.ref, 'bump-version') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
+      # Detect release PRs up-front so subsequent steps can gate on this flag.
+      # Release PRs only touch version/lockfile artefacts — no manifest check needed.
+      - name: Detect release PR
+        id: ctx
+        run: |
+          if [[ "${{ github.event.pull_request.head.ref }}" == bump-version* ]]; then
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "Release PR — capability manifest check is a noop."
+          else
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        if: steps.ctx.outputs.release == 'false'
         with:
           # Check out the PR branch HEAD, not the synthetic merge commit.
           # The default pull_request checkout is the GitHub-created test merge of
@@ -61,12 +79,15 @@ jobs:
           fetch-depth: 0
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        if: steps.ctx.outputs.release == 'false'
 
       - name: Regenerate capability manifest
+        if: steps.ctx.outputs.release == 'false'
         run: uv run poe regen-capabilities
 
       - name: Check for drift
         id: drift
+        if: steps.ctx.outputs.release == 'false'
         run: |
           # source-sha / source-date are excluded: with squash merges the final
           # SHA doesn't exist during the PR, so these fields are always stale
@@ -106,7 +127,7 @@ jobs:
             current before approval so the SDK-surface diff is visible in **Files changed**.
 
       - name: Clear sticky comment when manifest is current
-        if: success() && github.event.pull_request.head.repo.fork == false
+        if: success() && steps.ctx.outputs.release == 'false' && github.event.pull_request.head.repo.fork == false
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: capability-manifest-drift

--- a/.github/workflows/capability-manifest-check.yaml
+++ b/.github/workflows/capability-manifest-check.yaml
@@ -55,8 +55,10 @@ jobs:
       # Release PRs only touch version/lockfile artefacts — no manifest check needed.
       - name: Detect release PR
         id: ctx
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          if [[ "${{ github.event.pull_request.head.ref }}" == bump-version* ]]; then
+          if [[ "$HEAD_REF" == bump-version* ]]; then
             echo "release=true" >> "$GITHUB_OUTPUT"
             echo "Release PR — capability manifest check is a noop."
           else

--- a/application_sdk/dev/_dapr.py
+++ b/application_sdk/dev/_dapr.py
@@ -32,11 +32,19 @@ from pathlib import Path
 from application_sdk.version import __dapr_version as _DAPRD_VERSION
 
 logger = logging.getLogger(__name__)
-_DAPRD_RELEASE_URL = (
-    "https://github.com/dapr/dapr/releases/download/v{version}/daprd_{os}_{arch}.tar.gz"
+_DAPRD_RELEASE_BASE = (
+    "https://github.com/dapr/dapr/releases/download/v{version}/daprd_{os}_{arch}"
 )
-_DAPRD_BINARY_NAME = "daprd"
 _CACHE_DIR = Path.home() / ".cache" / "atlan-sdk" / "dapr" / _DAPRD_VERSION
+
+
+def _daprd_binary_name() -> str:
+    return "daprd.exe" if platform.system().lower() == "windows" else "daprd"
+
+
+def _daprd_archive_ext() -> str:
+    # Windows releases use .zip; Linux/macOS use .tar.gz
+    return ".zip" if platform.system().lower() == "windows" else ".tar.gz"
 
 
 @dataclass(frozen=True)
@@ -68,34 +76,51 @@ def _platform_tuple() -> tuple[str, str]:
 def _download_daprd(target: Path) -> None:
     """Download + extract the ``daprd`` binary into *target*."""
     os_name, arch = _platform_tuple()
-    url = _DAPRD_RELEASE_URL.format(version=_DAPRD_VERSION, os=os_name, arch=arch)
+    ext = _daprd_archive_ext()
+    binary_name = _daprd_binary_name()
+    url = (
+        _DAPRD_RELEASE_BASE.format(version=_DAPRD_VERSION, os=os_name, arch=arch) + ext
+    )
     logger.info("Downloading daprd v%s for %s/%s …", _DAPRD_VERSION, os_name, arch)
     target.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
-        try:
-            urllib.request.urlretrieve(url, tmp.name)
-            with tarfile.open(tmp.name, "r:gz") as tar:
+    # Use mkstemp + immediate close so the file handle is released before
+    # urlretrieve opens it — NamedTemporaryFile on Windows keeps an exclusive
+    # lock that prevents urlretrieve from opening the same path ([WinError 32]).
+    tmp_fd, tmp_name = tempfile.mkstemp(suffix=ext)
+    os.close(tmp_fd)
+    try:
+        urllib.request.urlretrieve(url, tmp_name)
+        if ext == ".zip":
+            import zipfile  # noqa: PLC0415 — Windows-only cold path
+
+            with zipfile.ZipFile(tmp_name) as zf:
                 member = next(
-                    (
-                        m
-                        for m in tar.getmembers()
-                        if m.name.endswith(_DAPRD_BINARY_NAME)
-                    ),
+                    (m for m in zf.namelist() if m.endswith(binary_name)),
+                    None,
+                )
+                if member is None:
+                    raise RuntimeError(f"daprd binary not found in archive at {url}")
+                with zf.open(member) as src, target.open("wb") as dst:
+                    shutil.copyfileobj(src, dst)
+        else:
+            with tarfile.open(tmp_name, "r:gz") as tar:
+                member = next(
+                    (m for m in tar.getmembers() if m.name.endswith(binary_name)),
                     None,
                 )
                 if member is None:
                     raise RuntimeError(f"daprd binary not found in archive at {url}")
                 with tar.extractfile(member) as src, target.open("wb") as dst:  # type: ignore[arg-type]
                     shutil.copyfileobj(src, dst)
-        finally:
-            Path(tmp.name).unlink(missing_ok=True)
+    finally:
+        Path(tmp_name).unlink(missing_ok=True)
     target.chmod(target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     logger.info("daprd cached at %s", target)
 
 
 def _ensure_daprd_binary() -> Path:
     """Return path to the daprd binary, downloading if absent."""
-    binary = _CACHE_DIR / _DAPRD_BINARY_NAME
+    binary = _CACHE_DIR / _daprd_binary_name()
     if not binary.exists():
         _download_daprd(binary)
     return binary

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -247,17 +247,21 @@ def run_example(example: ExampleConfig) -> tuple[str, float]:
     # alongside a running Temporal worker.  WindowsSelectorEventLoopPolicy
     # switches to the select()-based SelectorEventLoop, matching the
     # epoll/kqueue behaviour on Linux/macOS and letting uvicorn start cleanly.
+    #
+    # When DAPR_HTTP_PORT is already set (CI: external daprd + Temporal already
+    # running), skip embedded startup and connect to those directly via
+    # run_combined_mode.  Otherwise use run_dev_combined which auto-downloads
+    # and boots its own embedded daprd + Temporal dev server.
     launcher = (
-        "import sys, importlib.util, asyncio\n"
+        "import sys, importlib.util, asyncio, os\n"
         "if sys.platform == 'win32':\n"
         "    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())\n"
         "sys.path.insert(0, '.')\n"
         f"sys.path.insert(0, {_examples_dir!r})\n"
         f"spec = importlib.util.spec_from_file_location({example.module!r}, {_module_path!r})\n"
-        f"mod = importlib.util.module_from_spec(spec)\n"
+        "mod = importlib.util.module_from_spec(spec)\n"
         f"sys.modules[{example.module!r}] = mod\n"
         "spec.loader.exec_module(mod)\n"
-        "from application_sdk.main import run_dev_combined\n"
         "from application_sdk.app import App as _App\n"
         "_app_cls = next(\n"
         "    (v for v in vars(mod).values()\n"
@@ -267,7 +271,13 @@ def run_example(example: ExampleConfig) -> tuple[str, float]:
         ")\n"
         "if _app_cls is None:\n"
         f"    raise RuntimeError('No App subclass found in {example.module}')\n"
-        "asyncio.run(run_dev_combined(_app_cls))\n"
+        "if os.environ.get('DAPR_HTTP_PORT'):\n"
+        "    from application_sdk.main import _build_dev_config, run_combined_mode\n"
+        "    _m = f'{_app_cls.__module__}:{_app_cls.__name__}'\n"
+        "    asyncio.run(run_combined_mode(_build_dev_config(_m)))\n"
+        "else:\n"
+        "    from application_sdk.main import run_dev_combined\n"
+        "    asyncio.run(run_dev_combined(_app_cls))\n"
     )
     proc = subprocess.Popen(
         [sys.executable, "-u", "-c", launcher],


### PR DESCRIPTION
## Summary

- **Windows example CI failures**: the embedded Dapr downloader always used a `.tar.gz` URL, but Windows releases are `.zip` only → HTTP 404. `NamedTemporaryFile` also held an exclusive lock on Windows, causing `[WinError 32]` when the cleanup `unlink` ran. Additionally, the CI example runner always called `run_dev_combined` (which tries to download and boot embedded Dapr + Temporal) even though the `e2e-examples` action already starts both externally — fix bypasses the embedded startup when `DAPR_HTTP_PORT` is already set.
- **Capability Manifest Drift blocking release PRs**: a job-level `if: false` is reported as `"skipped"` by GitHub Actions, which branch protection does not treat as `"success"` — leaving the required check permanently pending on `bump-version-*` PRs. Fix removes the job-level condition and uses a step-level flag instead so the job always exits with `"success"`.

## Changes

**`application_sdk/dev/_dapr.py`**
- `_daprd_archive_ext()`: returns `.zip` on Windows, `.tar.gz` elsewhere
- `_daprd_binary_name()`: returns `daprd.exe` on Windows, `daprd` elsewhere
- `_download_daprd()`: `tempfile.mkstemp()` + immediate `os.close()` releases the handle before `urlretrieve` opens it (fixes `[WinError 32]`); branches on `.zip` vs `.tar.gz` for extraction

**`examples/run_examples.py`**
- When `DAPR_HTTP_PORT` is already set (CI has external Dapr running), the launcher calls `run_combined_mode(_build_dev_config(app_module))` directly instead of `run_dev_combined` — no binary downloads, no port conflicts

**`.github/workflows/capability-manifest-check.yaml`**
- Removed job-level `if` condition; added a "Detect release PR" step that sets a `release` flag
- All substantive steps gated on `steps.ctx.outputs.release == 'false'`
- Job always produces a `"success"` conclusion, satisfying the required status check on `bump-version-*` PRs

## Test plan

- [ ] Windows `Run Examples` CI passes on this PR
- [ ] `Capability Manifest Drift` check reports green on `bump-version-*` PRs after merge
- [ ] `Capability Manifest Drift` check still runs and fails correctly on a PR with stale manifest
- [ ] Local dev `run_dev_combined` (no `DAPR_HTTP_PORT` set) still works on Linux/macOS