### PR TITLE
feat(contracts): add standard `status` to Output base (BLDX-1244)

### DIFF
--- a/application_sdk/app/__init__.py
+++ b/application_sdk/app/__init__.py
@@ -26,7 +26,7 @@ from application_sdk.app.context import AppContext
 from application_sdk.app.entrypoint import EntryPointMetadata, entrypoint
 from application_sdk.app.registry import AppRegistry, TaskRegistry
 from application_sdk.app.task import TaskMetadata, task
-from application_sdk.contracts.base import Input, Output
+from application_sdk.contracts.base import Input, Output, OutputStatus
 from application_sdk.credentials.atlan_client import AtlanClientMixin
 from application_sdk.execution.retry import RetryPolicy
 from application_sdk.server.mcp.decorators import mcp_tool
@@ -41,6 +41,7 @@ __all__ = [
     "Input",
     "NonRetryableError",
     "Output",
+    "OutputStatus",
     "RetryPolicy",
     "RetryableError",
     "TaskMetadata",

--- a/application_sdk/contracts/base.py
+++ b/application_sdk/contracts/base.py
@@ -132,6 +132,42 @@ T = TypeVar("T")
 
 
 # =============================================================================
+# Output status enum
+# =============================================================================
+
+
+class OutputStatus(SerializableEnum):
+    """Standard run-result status used on :class:`Output`.
+
+    Set on every Output by default to :data:`OutputStatus.SUCCESS` so the
+    field is non-breaking for existing connectors — subclasses can leave
+    it alone if their run is unambiguously a pass, or set it to
+    ``PARTIAL_SUCCESS`` / ``FAILURE`` when they want to surface a
+    coarser-grained outcome alongside whatever domain-specific result
+    fields they already return.
+
+    Why an enum (vs. a free string): downstream consumers
+    (notifications, retries, billing, post-run wiring) all need a
+    closed vocabulary to switch on. A free string would let connectors
+    invent ad-hoc states (``"ok"``, ``"warn"``, ``"degraded"``) that
+    nothing else can interpret reliably. Additive evolution stays
+    available — new statuses get added to this enum, the default
+    stays ``SUCCESS``, so existing returners stay correct.
+
+    Members:
+        SUCCESS:          The run completed successfully.
+        PARTIAL_SUCCESS:  The run completed with some non-fatal issues
+                          (e.g. some entities were skipped due to
+                          permissions, but the rest succeeded).
+        FAILURE:          The run failed.
+    """
+
+    SUCCESS = "success"
+    PARTIAL_SUCCESS = "partial_success"
+    FAILURE = "failure"
+
+
+# =============================================================================
 # Base Contract Classes
 # =============================================================================
 
@@ -390,7 +426,8 @@ class Output(BaseModel):
         class ExtractOutput(Output):
             records_extracted: int
             checkpoint_path: str
-            status: str = "completed"
+            # ``status`` is inherited from Output and defaults to SUCCESS;
+            # set it explicitly only to signal partial-success / failure.
 
     Structured outputs:
         The SDK's OutputInterceptor automatically populates ``metrics`` and
@@ -400,6 +437,13 @@ class Output(BaseModel):
     """
 
     model_config = ConfigDict()
+
+    status: OutputStatus = OutputStatus.SUCCESS
+    """Coarse-grained run outcome — see :class:`OutputStatus`. Defaults to
+    ``SUCCESS`` so the field is additive-only for connectors that don't
+    override it. Set to ``PARTIAL_SUCCESS`` when some entities were
+    skipped or degraded but the run produced usable output; set to
+    ``FAILURE`` when the run did not produce usable output."""
 
     metrics: dict[str, Any] | None = None
     """Metrics collected by the OutputInterceptor (e.g. assets-extracted).

--- a/application_sdk/templates/contracts/incremental_sql.py
+++ b/application_sdk/templates/contracts/incremental_sql.py
@@ -304,7 +304,11 @@ class ExecuteColumnBatchOutput(Output):
 
     batch_index: int = 0
     records: int = 0
-    status: str = ""
+    # Pre-dates BLDX-1244's standard Output.status (``OutputStatus`` enum)
+    # and uses domain-specific values ("not_found", "success") that aren't
+    # part of the enum vocabulary. Keep the str override for backward-compat;
+    # the misc ignore acknowledges the deliberate field-type narrowing.
+    status: str = ""  # type: ignore[assignment]
 
 
 # =============================================================================

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.11.0
-source-sha:    11a8c861924c0b6d68a6e4ca9d76e9c477824af4
-source-date:   2026-05-15T20:54:14+01:00
+source-sha:    a382f2f56b8eb6f9b1059f43f1425783e4e29ba3
+source-date:   2026-05-18T12:38:31+05:30
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -18,7 +18,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 
 | Subpackage | Purpose | Exports |
 |---|---|---|
-| `application_sdk.app` | Core developer abstractions — App, @task, @entrypoint, Input, Output, RetryPolicy, mcp_tool | 16 |
+| `application_sdk.app` | Core developer abstractions — App, @task, @entrypoint, Input, Output, RetryPolicy, mcp_tool | 17 |
 | `application_sdk.clients` | Connection clients (SQL, Redis, Azure) and ClientInterface ABC | 11 |
 | `application_sdk.common` | Shared utilities — SQL filters, concurrency helpers, TaskStatistics, DataframeType | 9 |
 | `application_sdk.contracts` | Typed Pydantic Input/Output base classes, payload safety, storage and type helpers | 28 |
@@ -103,6 +103,13 @@ Core developer abstractions — App, @task, @entrypoint, Input, Output, RetryPol
 - **Import:** `from application_sdk.app import Output`
 - **Signature:** `class Output`
 - **Summary:** Base class for all output contracts (Apps and tasks).
+- **Defined in:** `application_sdk/contracts/base.py`
+
+#### `OutputStatus`
+
+- **Import:** `from application_sdk.app import OutputStatus`
+- **Signature:** `class OutputStatus`
+- **Summary:** Standard run-result status used on :class:`Output`.
 - **Defined in:** `application_sdk/contracts/base.py`
 
 #### `RetryableError`
@@ -2204,6 +2211,7 @@ Strongly-typed Pydantic models for SDK methods. Contracts in `application_sdk.co
 - **Import:** `from application_sdk.contracts import Output`
 - **Summary:** Base class for all output contracts (Apps and tasks).
 - **Fields:**
+  - `status: OutputStatus` `= OutputStatus.SUCCESS` — Coarse-grained run outcome — see :class:`OutputStatus`. Defaults to
   - `metrics: dict[str, Any] | None` — Metrics collected by the OutputInterceptor (e.g. assets-extracted).
   - `artifacts: dict[str, Any] | None` — Artifact references collected by the OutputInterceptor.
 - **Defined in:** `application_sdk/contracts/base.py`

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.11.0
-source-sha:    a382f2f56b8eb6f9b1059f43f1425783e4e29ba3
-source-date:   2026-05-18T12:38:31+05:30
+source-sha:    430c1611fe13c2a7e7535b3634a0eb3712bd0476
+source-date:   2026-05-18T13:33:16+05:30
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/examples/application_custom_fastapi.py
+++ b/examples/application_custom_fastapi.py
@@ -42,7 +42,10 @@ class SampleInput(Input):
 class SampleOutput(Output):
     """Output from the sample workflow."""
 
-    status: str = "completed"
+    # The example pre-dates BLDX-1244's standard Output.status (OutputStatus
+    # enum). New connectors should rely on the inherited enum default; this
+    # example keeps the str override for illustrative continuity.
+    status: str = "completed"  # type: ignore[assignment]
 
 
 class CustomHandler(Handler):

--- a/examples/application_fastapi.py
+++ b/examples/application_fastapi.py
@@ -36,7 +36,10 @@ class SampleInput(Input):
 class SampleOutput(Output):
     """Output contract for the sample workflow."""
 
-    status: str = "completed"
+    # The example pre-dates BLDX-1244's standard Output.status (OutputStatus
+    # enum). New connectors should rely on the inherited enum default; this
+    # example keeps the str override for illustrative continuity.
+    status: str = "completed"  # type: ignore[assignment]
 
 
 class SampleHandler(Handler):

--- a/tests/unit/contracts/test_base.py
+++ b/tests/unit/contracts/test_base.py
@@ -12,6 +12,7 @@ from application_sdk.contracts.base import (
     HeartbeatDetails,
     Input,
     Output,
+    OutputStatus,
     PayloadSafetyError,
     Record,
     SerializableEnum,
@@ -45,6 +46,88 @@ class TestInputSubclassing:
         obj = MyOutput(result="done")
         assert obj.result == "done"
         assert obj.success is True
+
+
+class TestOutputStatus:
+    """Standard status field on Output, BLDX-1244."""
+
+    def test_default_is_success(self) -> None:
+        # Additive-only requirement: existing connectors that don't set
+        # `status` must get `SUCCESS`, so nothing breaks.
+        class MyOutput(Output):
+            result: str
+
+        obj = MyOutput(result="done")
+        assert obj.status is OutputStatus.SUCCESS
+        assert obj.status == "success"  # StrEnum equality with raw string
+
+    def test_all_three_values_round_trip(self) -> None:
+        # Vocabulary defined in BLDX-1244 — success / partial_success / failure.
+        for value in (
+            OutputStatus.SUCCESS,
+            OutputStatus.PARTIAL_SUCCESS,
+            OutputStatus.FAILURE,
+        ):
+
+            class MyOutput(Output):
+                result: str
+
+            obj = MyOutput(result="x", status=value)
+            assert obj.status is value
+
+    def test_string_value_is_accepted(self) -> None:
+        # Temporal serialisation hands us back the enum as a string. Pydantic
+        # must coerce that back to the enum on deserialization.
+        class MyOutput(Output):
+            result: str
+
+        obj = MyOutput(result="x", status="partial_success")  # type: ignore[arg-type]
+        assert obj.status is OutputStatus.PARTIAL_SUCCESS
+
+    def test_invalid_value_rejected(self) -> None:
+        class MyOutput(Output):
+            result: str
+
+        with pytest.raises(ValidationError):
+            MyOutput(result="x", status="degraded")  # type: ignore[arg-type]
+
+    def test_json_serialises_as_lowercase_string(self) -> None:
+        # Consumers (notifications, retries) need a stable string token.
+        class MyOutput(Output):
+            result: str
+
+        obj = MyOutput(result="x", status=OutputStatus.PARTIAL_SUCCESS)
+        dumped = obj.model_dump_json()
+        assert '"status":"partial_success"' in dumped
+
+    def test_subclass_can_override_default_value(self) -> None:
+        # Connectors with always-partial semantics (rare, but valid) can pin
+        # a different default at the subclass level — Pydantic supports
+        # overriding a field's default without changing its type.
+        class AlwaysPartialOutput(Output):
+            result: str
+            status: OutputStatus = OutputStatus.PARTIAL_SUCCESS
+
+        assert AlwaysPartialOutput(result="x").status is OutputStatus.PARTIAL_SUCCESS
+
+    def test_subclass_overrides_status_type_to_str(self) -> None:
+        # Backward-compat: an existing subclass (e.g. ExecuteColumnBatchOutput
+        # in templates/contracts/incremental_sql.py) declared
+        # ``status: str = ""`` before this base field existed and uses
+        # domain-specific values like ``"not_found"`` that aren't part of
+        # the new enum vocabulary. Adding the typed base field must not
+        # break those callers — Pydantic resolves field type in
+        # most-derived-wins order, so the subclass declaration shadows
+        # the base and free-form strings keep working.
+        class DomainSpecificOutput(Output):
+            status: str = ""
+
+        # Empty default still works
+        obj = DomainSpecificOutput()
+        assert obj.status == ""
+        # Non-enum string value still works
+        obj = DomainSpecificOutput(status="not_found")  # type: ignore[arg-type]
+        assert obj.status == "not_found"
 
     def test_input_safe_primitive_types(self) -> None:
         class SafeInput(Input):


### PR DESCRIPTION
## Summary
Adds a coarse-grained run-outcome field to every `Output`, per [BLDX-1244](https://linear.app/atlan-epd/issue/BLDX-1244/add-standard-status-as-part-of-base-output-contract):

```python
class OutputStatus(SerializableEnum):
    SUCCESS = "success"           # default
    PARTIAL_SUCCESS = "partial_success"
    FAILURE = "failure"
```

```python
class Output(BaseModel):
    status: OutputStatus = OutputStatus.SUCCESS
    metrics: dict | None = None
    artifacts: dict | None = None
```

Downstream consumers (notifications, retries, billing, post-run wiring) need a closed vocabulary to switch on. A free string would let connectors invent ad-hoc states (`"ok"`, `"warn"`, `"degraded"`) that nothing else can interpret reliably. Additive evolution stays available — new statuses get added to this enum, the default stays `SUCCESS`, so existing returners stay correct.

## Backward-compat

Default is `SUCCESS` → connectors that don't set the field continue to return SUCCESS, exactly as the issue requires.

Enum extends `SerializableEnum` (which is a `StrEnum`), so:
- Serialises through Temporal payloads as its lowercase string value (`"success"`, `"partial_success"`, `"failure"`).
- Pydantic round-trips strings → enums on deserialization.
- Subclasses that already declared `status: str = ...` (e.g. `ExecuteColumnBatchOutput` in `templates/contracts/incremental_sql.py`, which uses values like `"not_found"`) keep working — Pydantic resolves field type in most-derived-wins order, so the subclass declaration shadows the base.

`OutputStatus` re-exported from `application_sdk.app` alongside `Output` so connectors can `from application_sdk.app import OutputStatus`.

## Test plan
- [x] `tests/unit/contracts/test_base.py` — 7 new tests under `TestOutputStatus`:
  - `test_default_is_success` (additive-only requirement)
  - `test_all_three_values_round_trip`
  - `test_string_value_is_accepted` (Temporal round-trip)
  - `test_invalid_value_rejected`
  - `test_json_serialises_as_lowercase_string`
  - `test_subclass_can_override_default_value`
  - `test_subclass_overrides_status_type_to_str` (regression for existing `ExecuteColumnBatchOutput`-style overrides)
- [x] Full `test_base.py` (56 tests) + `test_incremental_sql_metadata_extractor.py` (63 tests) — 119/119 passing locally.
- [x] Pre-commit (ruff, ruff-format, isort, pyright) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)