### PR TITLE
fix: repair objectstore metric reader temporality

### DIFF
--- a/application_sdk/observability/_objectstore_metric_exporter.py
+++ b/application_sdk/observability/_objectstore_metric_exporter.py
@@ -21,15 +21,22 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 import orjson
-from opentelemetry.sdk.metrics.export import (
-    AggregationTemporality,
-    Gauge,
+from opentelemetry.sdk.metrics import (
+    Counter,
     Histogram,
+    ObservableCounter,
+    ObservableUpDownCounter,
+    UpDownCounter,
+)
+from opentelemetry.sdk.metrics.export import AggregationTemporality
+from opentelemetry.sdk.metrics.export import Gauge as GaugeData
+from opentelemetry.sdk.metrics.export import Histogram as HistogramData
+from opentelemetry.sdk.metrics.export import (
     MetricExporter,
     MetricExportResult,
     MetricsData,
-    Sum,
 )
+from opentelemetry.sdk.metrics.export import Sum as SumData
 
 from application_sdk.constants import (
     APPLICATION_NAME,
@@ -137,7 +144,7 @@ def _serialize_metrics_data(metrics_data: MetricsData | None) -> list[dict[str, 
         for sm in rm.scope_metrics:
             for metric in sm.metrics:
                 data = metric.data
-                if isinstance(data, Sum):
+                if isinstance(data, SumData):
                     temp = _temporality_name(data.aggregation_temporality)
                     for dp in data.data_points:
                         records.append(
@@ -152,7 +159,7 @@ def _serialize_metrics_data(metrics_data: MetricsData | None) -> list[dict[str, 
                                 aggregation_temporality=temp,
                             )
                         )
-                elif isinstance(data, Gauge):
+                elif isinstance(data, GaugeData):
                     for dp in data.data_points:
                         records.append(
                             _number_record(
@@ -164,7 +171,7 @@ def _serialize_metrics_data(metrics_data: MetricsData | None) -> list[dict[str, 
                                 res_attrs,
                             )
                         )
-                elif isinstance(data, Histogram):
+                elif isinstance(data, HistogramData):
                     temp = _temporality_name(data.aggregation_temporality)
                     for dp in data.data_points:
                         records.append(
@@ -241,9 +248,11 @@ class ObjectStoreMetricExporter(MetricExporter):
     def __init__(self, *, data_dir: str | None = None) -> None:
         super().__init__(
             preferred_temporality={
-                Sum: AggregationTemporality.DELTA,
+                Counter: AggregationTemporality.DELTA,
+                UpDownCounter: AggregationTemporality.DELTA,
+                ObservableCounter: AggregationTemporality.DELTA,
+                ObservableUpDownCounter: AggregationTemporality.DELTA,
                 Histogram: AggregationTemporality.DELTA,
-                Gauge: AggregationTemporality.CUMULATIVE,
             },
         )
         self._data_dir = data_dir or get_observability_dir()

--- a/application_sdk/observability/metrics_adaptor.py
+++ b/application_sdk/observability/metrics_adaptor.py
@@ -52,11 +52,13 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
     """
 
     _flush_task_started: ClassVar[bool] = False
+    _otel_setup_failed_logged: ClassVar[bool] = False
 
     @classmethod
     def _reset_for_testing(cls) -> None:
         """Reset initialization state for test isolation."""
         cls._flush_task_started = False
+        cls._otel_setup_failed_logged = False
 
     def __init__(self):
         """Initialize the metrics adapter with configuration and setup.
@@ -78,6 +80,7 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
         )
 
         # Prometheus is the canonical metrics surface and is always on.
+        self._otel_metrics_enabled = False
         self._setup_otel_metrics()
 
         # Initialize Segment client (enabled automatically if write key is present)
@@ -144,9 +147,14 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
             )
             metrics.set_meter_provider(self.meter_provider)
             self.meter = self.meter_provider.get_meter(SERVICE_NAME)
+            self._otel_metrics_enabled = True
+            AtlanMetricsAdapter._otel_setup_failed_logged = False
             logging.info("Prometheus metrics reader enabled")
         except Exception:
-            logging.error("Failed to setup OTel meter provider", exc_info=True)
+            self._otel_metrics_enabled = False
+            if not AtlanMetricsAdapter._otel_setup_failed_logged:
+                logging.error("Failed to setup OTel meter provider", exc_info=True)
+                AtlanMetricsAdapter._otel_setup_failed_logged = True
 
     async def _flush_buffer(self, force=False):
         await super()._flush_buffer(force=force)
@@ -224,6 +232,9 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
         Raises:
             Exception: If sending fails, logs error and continues
         """
+        if not self._otel_metrics_enabled:
+            return
+
         try:
             otel_attrs: dict[str, str | int | float | bool] = {}
             dropped: list[str] = []

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.11.0
-source-sha:    62c758aef4585dd2ebaa8587d9d5c25464001e41
-source-date:   2026-05-18T10:26:02+01:00
+sdk-version:   3.12.0
+source-sha:    2157426b76635450d766321dfc86f30110237398
+source-date:   2026-05-19T04:03:28+05:30
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/tests/unit/observability/test_metrics_adaptor.py
+++ b/tests/unit/observability/test_metrics_adaptor.py
@@ -610,6 +610,35 @@ class TestPrometheusMetrics:
                 call_kwargs = mock_provider.call_args[1]
                 assert len(call_kwargs["metric_readers"]) == 1
 
+    def test_otel_setup_failure_disables_metric_send_spam(self):
+        AtlanMetricsAdapter._reset_for_testing()
+        AtlanMetricsAdapter._flush_task_started = True
+        with (
+            mock.patch(
+                "application_sdk.observability.metrics_adaptor.ENABLE_OBSERVABILITY_STORE_SINK",
+                True,
+            ),
+            mock.patch(
+                "application_sdk.observability._objectstore_metric_reader.create_objectstore_metric_reader",
+                side_effect=RuntimeError("reader boom"),
+            ),
+            mock.patch(
+                "application_sdk.observability.metrics_adaptor.logging.error"
+            ) as mock_error,
+        ):
+            adapter = AtlanMetricsAdapter()
+            assert adapter._otel_metrics_enabled is False
+
+            adapter.record_metric(
+                name="setup_failure_metric",
+                value=1.0,
+                metric_type=MetricType.COUNTER,
+                labels={},
+            )
+
+        assert mock_error.call_count == 1
+        assert mock_error.call_args.args[0] == "Failed to setup OTel meter provider"
+
 
 # ---------------------------------------------------------------------------
 # METRIC_ENRICHMENT_KEYS — pin the inline label set. The minimum-viable inline

--- a/tests/unit/observability/test_objectstore_metric_exporter.py
+++ b/tests/unit/observability/test_objectstore_metric_exporter.py
@@ -6,7 +6,14 @@ import os
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics import (
+    Counter,
+    Histogram,
+    MeterProvider,
+    ObservableCounter,
+    ObservableUpDownCounter,
+    UpDownCounter,
+)
 from opentelemetry.sdk.metrics.export import (
     AggregationTemporality,
     InMemoryMetricReader,
@@ -16,6 +23,9 @@ from opentelemetry.sdk.resources import Resource
 from application_sdk.observability._objectstore_metric_exporter import (
     ObjectStoreMetricExporter,
     _serialize_metrics_data,
+)
+from application_sdk.observability._objectstore_metric_reader import (
+    create_objectstore_metric_reader,
 )
 
 
@@ -204,8 +214,24 @@ class TestExport:
 class TestExporterTemporality:
     """Verify delta temporality preference."""
 
-    def test_preferred_temporality_is_delta_for_sum(self) -> None:
-        from opentelemetry.sdk.metrics.export import Sum
-
+    def test_preferred_temporality_uses_otel_instrument_classes(self) -> None:
         e = ObjectStoreMetricExporter()
-        assert e._preferred_temporality.get(Sum) == AggregationTemporality.DELTA
+        assert e._preferred_temporality.get(Counter) == AggregationTemporality.DELTA
+        assert e._preferred_temporality.get(UpDownCounter) == (
+            AggregationTemporality.DELTA
+        )
+        assert e._preferred_temporality.get(ObservableCounter) == (
+            AggregationTemporality.DELTA
+        )
+        assert e._preferred_temporality.get(ObservableUpDownCounter) == (
+            AggregationTemporality.DELTA
+        )
+        assert e._preferred_temporality.get(Histogram) == AggregationTemporality.DELTA
+
+    def test_reader_registers_with_real_meter_provider(self) -> None:
+        reader = create_objectstore_metric_reader(export_interval_millis=3_600_000)
+        provider = MeterProvider(metric_readers=[reader])
+        try:
+            assert provider.get_meter("test")
+        finally:
+            provider.shutdown()


### PR DESCRIPTION
## Summary
- fix ObjectStoreMetricExporter preferred temporality to use OTel instrument classes instead of export data classes
- keep serialization checks on export data classes via explicit aliases
- guard AtlanMetricsAdapter so OTel setup failures disable OTel sends instead of spamming per-metric stack traces

## Before: noisy HYP-1285 repro
With the default objectstore observability sink enabled and OpenTelemetry 1.41.1, SDK metric setup failed during reader creation:

```text
ERROR:root:Failed to setup OTel meter provider
Traceback (most recent call last):
  File "application_sdk/observability/metrics_adaptor.py", line 138, in _setup_otel_metrics
    self._objectstore_reader = create_objectstore_metric_reader()
  File "application_sdk/observability/_objectstore_metric_reader.py", line 28, in create_objectstore_metric_reader
    return PeriodicExportingMetricReader(
  File ".venv/lib/python3.11/site-packages/opentelemetry/sdk/metrics/_internal/export/__init__.py", line 477, in __init__
    super().__init__(
  File ".venv/lib/python3.11/site-packages/opentelemetry/sdk/metrics/_internal/export/__init__.py", line 287, in __init__
    raise Exception(f"Invalid instrument class found {typ}")
Exception: Invalid instrument class found <class 'opentelemetry.sdk.metrics._internal.point.Sum'>
```

After that first setup failure, later metric writes kept logging another stack trace because the adapter never created `self.meter`:

```text
ERROR:root:Error sending metric to OpenTelemetry
Traceback (most recent call last):
  File "application_sdk/observability/metrics_adaptor.py", line 243, in _send_to_otel
    counter = self.meter.create_counter(
AttributeError: 'AtlanMetricsAdapter' object has no attribute 'meter'
```

## After fix
The same sink-enabled repro initializes the meter/provider and records a metric without the original stack traces:

```text
INFO:root:Prometheus metrics reader enabled
WARNING:root:Segment write key not configured - Segment metrics will be disabled
has_meter True
has_provider True
buffer_len 1
```

## Validation
- reproduced HYP-1285 before the fix with OpenTelemetry 1.41.1: objectstore reader setup failed with `Invalid instrument class found ... Sum`, then metric writes hit missing `self.meter`
- verified the default sink-enabled repro after the fix initializes meter/provider without the original stack traces
- `uv run pytest tests/unit/observability/test_objectstore_metric_exporter.py tests/unit/observability/test_metrics_adaptor.py -q`
- `uv run pre-commit run --files application_sdk/observability/_objectstore_metric_exporter.py application_sdk/observability/metrics_adaptor.py tests/unit/observability/test_objectstore_metric_exporter.py tests/unit/observability/test_metrics_adaptor.py`

Fixes HYP-1285