### PR TITLE
feat(temporal): expose extra_workflows in create_worker [BLDX-1281]

### DIFF
--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from collections.abc import Sequence
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
@@ -268,6 +269,7 @@ def create_worker(
     graceful_shutdown_timeout_seconds: int | None = None,
     interceptors: list[TemporalInterceptor] | None = None,
     enable_pushgateway: bool = False,
+    extra_workflows: Sequence[type] | None = None,
 ) -> AppWorker:
     """Create a Temporal worker for registered Apps.
 
@@ -303,6 +305,11 @@ def create_worker(
             performs a final push on exit. Combined deployments (server +
             worker in one process) should leave this False so /metrics
             doesn't double-count.
+        extra_workflows: Hand-rolled ``@workflow.defn`` classes to register
+            alongside the SDK-generated App workflows. Use when a caller has
+            a workflow whose shape doesn't fit the App entry-point pattern —
+            e.g. a generic single-activity dispatcher driven dynamically by
+            an LLM agent — and still needs it served by the same worker.
 
     Returns:
         AppWorker wrapping a configured Temporal Worker (not yet started).
@@ -317,6 +324,8 @@ def create_worker(
         await worker.run()
     """
     app_workflows = get_all_app_workflows()
+    if extra_workflows:
+        app_workflows = [*app_workflows, *extra_workflows]
     task_activities = get_all_task_activities()
 
     if enable_sdr and handler is not None:

--- a/tests/unit/execution/test_worker.py
+++ b/tests/unit/execution/test_worker.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from unittest import mock
 
 import pytest
+from temporalio import workflow
 
 from application_sdk.app.base import App
 from application_sdk.app.registry import AppRegistry, TaskRegistry
@@ -59,6 +60,19 @@ class _FilterIn2(Input, allow_unbounded_fields=True):
 @dataclass
 class _FilterOut2(Output, allow_unbounded_fields=True):
     y: str = ""
+
+
+@workflow.defn(name="_ExtraDispatchWorkflow")
+class _ExtraDispatchWorkflow:
+    """Test workflow class registered via ``extra_workflows=``.
+
+    Module-level definition is required: Temporal rejects ``@workflow.defn``
+    on locally-defined classes (it needs a globally-referenceable name).
+    """
+
+    @workflow.run
+    async def run(self, params: dict) -> dict:
+        return {}
 
 
 def _make_mock_client() -> mock.MagicMock:
@@ -371,6 +385,89 @@ class TestCreateWorker:
             create_worker(client, passthrough_modules={"my_custom_module"})
 
         assert len(sandbox_configs) == 1
+
+    def test_extra_workflows_appended_to_registration(self) -> None:
+        """Caller-supplied hand-rolled @workflow.defn classes are appended to
+        the SDK-generated App workflows passed to ``Worker(workflows=...)``."""
+
+        class _ExtraApp(App):
+            async def run(self, input: _WorkerInput) -> _WorkerOutput:
+                return _WorkerOutput()
+
+        client = _make_mock_client()
+        captured: dict = {}
+
+        def capture_worker(*args, **kwargs):
+            captured["workflows"] = list(kwargs.get("workflows", []))
+            return mock.MagicMock()
+
+        with mock.patch(
+            "application_sdk.execution._temporal.worker.Worker",
+            side_effect=capture_worker,
+        ):
+            create_worker(client, extra_workflows=[_ExtraDispatchWorkflow])
+
+        assert _ExtraDispatchWorkflow in captured["workflows"]
+
+    def test_extra_workflows_none_is_default(self) -> None:
+        """Omitting ``extra_workflows`` leaves the App-generated list unchanged."""
+
+        class _BaselineApp(App):
+            async def run(self, input: _WorkerInput) -> _WorkerOutput:
+                return _WorkerOutput()
+
+        client = _make_mock_client()
+        captured: dict = {}
+
+        def capture_worker(*args, **kwargs):
+            captured["workflows"] = list(kwargs.get("workflows", []))
+            return mock.MagicMock()
+
+        with mock.patch(
+            "application_sdk.execution._temporal.worker.Worker",
+            side_effect=capture_worker,
+        ):
+            create_worker(client)
+
+        baseline_count = len(captured["workflows"])
+
+        with mock.patch(
+            "application_sdk.execution._temporal.worker.Worker",
+            side_effect=capture_worker,
+        ):
+            create_worker(client, extra_workflows=None)
+
+        assert len(captured["workflows"]) == baseline_count
+
+    def test_extra_workflows_empty_sequence_is_noop(self) -> None:
+        """An empty ``extra_workflows`` sequence behaves like ``None``."""
+
+        class _EmptyExtraApp(App):
+            async def run(self, input: _WorkerInput) -> _WorkerOutput:
+                return _WorkerOutput()
+
+        client = _make_mock_client()
+        captured: dict = {}
+
+        def capture_worker(*args, **kwargs):
+            captured["workflows"] = list(kwargs.get("workflows", []))
+            return mock.MagicMock()
+
+        with mock.patch(
+            "application_sdk.execution._temporal.worker.Worker",
+            side_effect=capture_worker,
+        ):
+            create_worker(client, extra_workflows=[])
+
+        baseline_count = len(captured["workflows"])
+
+        with mock.patch(
+            "application_sdk.execution._temporal.worker.Worker",
+            side_effect=capture_worker,
+        ):
+            create_worker(client)
+
+        assert len(captured["workflows"]) == baseline_count
 
 
 class TestAppWorker:


### PR DESCRIPTION
## Discussion-first PR

This PR is opened **as a draft** to anchor the team discussion on the problem statement before locking in the implementation shape. The patch is intentionally minimal (3 LOC in `create_worker`) and is only meant to make the conversation concrete.

- Linear: [BLDX-1281](https://linear.app/atlan-epd/issue/BLDX-1281/create-worker-expose-extra-workflows-for-hand-rolled-workflowdefn)
- Related: [AUT-904](https://linear.app/atlan-epd/issue/AUT-904/upgrade-application-sdk-to-v3-for-automation-engine)

## Problem

`application_sdk.execution._temporal.create_worker` registers workflows by calling `get_all_app_workflows()`, which returns SDK-generated workflows per registered App entry point. Apps that need to register **hand-rolled `@workflow.defn` workflow classes** alongside the App-generated ones cannot do so without forking `create_worker` entirely.

Concrete consumer: Automation Engine (AUT-904) has a `SingleActivityWorkflow` — a generic one-activity dispatcher used by an LLM agent harness's `run_activity` tool. The LLM picks any registered activity by name; the workflow looks up the activity's task metadata, constructs the Pydantic `Input`, and invokes the activity. It is fundamentally not an App entry point (dynamic activity selection, not a typed input/output schema), but it must still be a real Temporal workflow because the Temporal SDK requires activities to be invoked from within workflow execution context.

Today AE maintains a copy of SDK's `create_worker` in ``automation_engine/clients/temporal.py`` just to inject this one extra workflow class. The fork has to track SDK upstream evolution (interceptor chain, sandbox config composition, deployment versioning) on every SDK release and is at risk of silent divergence.

## Open questions for the team

1. Is exposing ``extra_workflows=`` the right shape, or would the team prefer an alternative — e.g. a synthetic-App wrapper, a new SDK-side "generic dispatch workflow" primitive, or a different abstraction?
2. Are there security / correctness concerns about letting callers register arbitrary workflow classes outside the App registry's lifecycle metadata (no entry-point metadata, no input/output schema)?
3. Are there other consumers with similar needs we should design for at the same time?

## Summary of the proposed change

- Adds ``extra_workflows: Sequence[type] | None = None`` keyword-only param to ``create_worker``.
- When set, the workflows are appended to ``get_all_app_workflows()`` before being passed to ``Worker(workflows=...)``.
- When ``None`` (default), behavior is unchanged.

## Test plan

- [x] New unit tests in ``tests/unit/execution/test_worker.py``:
  - ``test_extra_workflows_appended_to_registration`` — extra workflow class lands in ``Worker(workflows=...)``.
  - ``test_extra_workflows_none_is_default`` — omitting the param matches passing ``None``.
  - ``test_extra_workflows_empty_sequence_is_noop`` — empty sequence behaves like ``None``.
- [x] All 22 existing tests in ``tests/unit/execution/test_worker.py`` still pass.
- [x] ``uv run pre-commit run --files application_sdk/execution/_temporal/worker.py tests/unit/execution/test_worker.py`` — ruff, ruff-format, isort, pyright all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)