### PR TITLE
fix(security): tighten SQL injection defenses in filter / marker paths (BLDX-518)

### DIFF
--- a/application_sdk/common/incremental/skills/implement-incremental-extraction/references/activities-implementation.md
+++ b/application_sdk/common/incremental/skills/implement-incremental-extraction/references/activities-implementation.md
@@ -2,6 +2,16 @@
 
 This reference covers the detailed implementation of the Activities class for incremental extraction.
 
+> **SQL injection note (BLDX-518).** Any value substituted into a SQL
+> template via `str.replace` / f-string must pass through
+> `application_sdk.common.sql_filters.validate_filter_no_sql_injection`
+> first, and the template must wrap the substitution in single quotes
+> (e.g. `WHERE last_modified > '{marker_timestamp}'`). The SDK contracts
+> apply this guard automatically for `marker_timestamp`,
+> `include_filter`, `exclude_filter`, and `temp_table_regex`; if your
+> connector introduces a new substitution placeholder, validate the
+> value yourself before the `replace`.
+
 ## Class Structure
 
 ```python

--- a/application_sdk/common/sql_filters.py
+++ b/application_sdk/common/sql_filters.py
@@ -18,6 +18,119 @@ from application_sdk.observability.logger_adaptor import get_logger
 logger = get_logger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# SQL injection deny-list for filter values (BLDX-518).
+#
+# Filter values (include_filter, exclude_filter, temp_table_regex) are
+# substituted into SQL templates via ``str.replace`` and end up inside
+# quoted SQL string literals (the template author is contractually
+# required to wrap each substitution in single quotes — see the warning
+# in ``templates/sql_metadata_extractor.SqlMetadataExtractor._prepare_sql``).
+#
+# To make that contract attacker-resistant, we forbid the SQL-meaningful
+# sequences that have no legitimate use inside a regex pattern destined
+# for a quoted literal:
+#
+#   * ``'`` — string-literal delimiter (would close the surrounding quote)
+#   * ``"`` — identifier delimiter in dialects that allow it
+#   * ``;`` — statement separator (stacked-query injection)
+#   * ``--`` — SQL line comment (eats the rest of the line)
+#   * ``/*`` / ``*/`` — block comment
+#   * ``\x00`` — null byte; some drivers truncate on it
+#
+# Regex meta-characters that legitimately appear in filter values
+# (``^``, ``$``, ``.``, ``*``, ``+``, ``?``, ``|``, ``()``, ``[]``, ``\``,
+# ``{}``, single ``-``) remain allowed. This is a deny-list, not an
+# allow-list — a strict allow-list would break virtually every existing
+# filter pattern.
+# ---------------------------------------------------------------------------
+
+_FORBIDDEN_FILTER_SEQUENCES: tuple[str, ...] = (
+    "'",
+    '"',
+    ";",
+    "--",
+    "/*",
+    "*/",
+    "\x00",
+)
+
+# Used by Pydantic ``Field(pattern=...)`` on filter-shaped fields. Forbids
+# the single-character members of ``_FORBIDDEN_FILTER_SEQUENCES``;
+# multi-character sequences (``--``, ``/*``, ``*/``) are caught by the
+# dedicated ``validate_filter_no_sql_injection`` validator below.
+_SAFE_FILTER_PATTERN: str = r"^[^'\";\x00]*$"
+
+
+def validate_filter_no_sql_injection(v: Any) -> Any:
+    """Reject filter values containing SQL-meaningful character sequences.
+
+    See the module docstring for the rationale behind each forbidden
+    sequence. Applies to:
+
+    * Raw regex strings — checked directly.
+    * JSON-encoded strings (legacy AE payload shape) — parsed first;
+      the parsed dict is then checked. The JSON's own structural
+      double-quotes are stripped by the parse, so we only ever apply
+      the deny-list to the actual filter contents.
+    * Structured dict filters (``FilterMap``) — checks every key and
+      every string in every value list.
+
+    Returns ``v`` unchanged when the value is safe; raises ``ValueError``
+    on the first forbidden sequence encountered so the caller (Pydantic
+    or a hand-rolled helper) surfaces a clear error before any SQL
+    template substitution.
+
+    Args:
+        v: A filter value — either a raw regex string, a JSON-encoded
+            filter map string, or a normalized ``FilterMap`` dict.
+
+    Returns:
+        The same value if it passes all deny-list checks.
+
+    Raises:
+        ValueError: When any forbidden sequence is found.
+    """
+
+    def _check_str(label: str, value: str) -> None:
+        for seq in _FORBIDDEN_FILTER_SEQUENCES:
+            if seq in value:
+                raise ValueError(
+                    f"SQL-unsafe sequence {seq!r} not allowed in filter {label}: {value!r}"
+                )
+
+    if isinstance(v, str):
+        # Legacy AE callers pass the filter as a JSON-encoded string. The
+        # JSON syntax itself carries double-quotes that would trip the
+        # deny-list, so parse first and validate the resulting dict;
+        # fall back to treating the string as a raw regex otherwise.
+        # We return the ORIGINAL string unchanged on success — the
+        # downstream consumer expects whichever shape it was given,
+        # not a coerced one.
+        stripped = v.strip()
+        if stripped.startswith("{") and stripped.endswith("}"):
+            try:
+                parsed = json.loads(stripped)
+            except json.JSONDecodeError:
+                parsed = None
+            if isinstance(parsed, dict):
+                # Validate the parsed shape; ignore the returned value
+                # and keep ``v`` (the original JSON string) intact.
+                validate_filter_no_sql_injection(parsed)
+                return v
+        _check_str("value", v)
+    elif isinstance(v, dict):
+        for key, values in v.items():
+            _check_str("key", key)
+            if isinstance(values, list):
+                for item in values:
+                    if isinstance(item, str):
+                        _check_str("value", item)
+            elif isinstance(values, str):
+                _check_str("value", values)
+    return v
+
+
 def extract_database_names_from_regex_common(
     normalized_regex: str,
     empty_default: str,
@@ -146,9 +259,17 @@ def prepare_query(
 
         include_filter = metadata.get("include-filter") or "{}"
         exclude_filter = metadata.get("exclude-filter") or "{}"
-        if metadata.get("temp-table-regex") and temp_table_regex_sql is not None:
+        # Defense in depth (BLDX-518): callers of ``prepare_query`` pass a
+        # raw ``workflow_args`` dict, bypassing the Pydantic validators
+        # that gate the typed extraction inputs. Run the same deny-list
+        # here so user-controlled metadata can't smuggle SQL escape
+        # sequences into the substituted templates.
+        temp_table_regex = metadata.get("temp-table-regex")
+        if isinstance(temp_table_regex, str):
+            validate_filter_no_sql_injection(temp_table_regex)
+        if temp_table_regex and temp_table_regex_sql is not None:
             temp_table_regex_sql = temp_table_regex_sql.format(
-                exclude_table_regex=metadata.get("temp-table-regex")
+                exclude_table_regex=temp_table_regex
             )
         else:
             temp_table_regex_sql = ""
@@ -223,9 +344,14 @@ async def get_database_names(
     Returns:
         List of database names.
     """
-    database_names = parse_filter_input(
-        workflow_args.get("metadata", {}).get("include-filter", {})
-    )
+    raw_include = workflow_args.get("metadata", {}).get("include-filter", {})
+    # BLDX-518: validate before any downstream caller can interpolate these
+    # names into SQL. ``prepare_query`` does its own validation on the
+    # fall-through path; this catches the case where the include-filter
+    # carries database names that are returned directly to the caller.
+    if isinstance(raw_include, (str, dict)):
+        validate_filter_no_sql_injection(raw_include)
+    database_names = parse_filter_input(raw_include)
 
     database_names = [
         re.sub(r"^[^\w]+|[^\w]+$", "", database_name)
@@ -285,8 +411,22 @@ def prepare_filters(
     Raises:
         CommonError: If JSON parsing fails for either filter.
     """
+    # BLDX-518: gate raw input before ``parse_filter_input``. The parse
+    # step raises on non-JSON strings, which would mask the deny-list
+    # check for raw-regex callers (``"prefix'injection"`` would surface
+    # as a JSONDecodeError instead of the SQL-unsafe ValueError).
+    if isinstance(include_filter_str, str):
+        validate_filter_no_sql_injection(include_filter_str)
+    if isinstance(exclude_filter_str, str):
+        validate_filter_no_sql_injection(exclude_filter_str)
+
     include_filter = parse_filter_input(include_filter_str)
     exclude_filter = parse_filter_input(exclude_filter_str)
+
+    # Re-validate the parsed shapes — defense in depth for callers that
+    # pass a dict directly without going through the string path.
+    validate_filter_no_sql_injection(include_filter)
+    validate_filter_no_sql_injection(exclude_filter)
 
     normalized_include_filter_list = normalize_filters(include_filter, True)
     normalized_exclude_filter_list = normalize_filters(exclude_filter, False)

--- a/application_sdk/common/sql_filters.py
+++ b/application_sdk/common/sql_filters.py
@@ -59,7 +59,8 @@ _FORBIDDEN_FILTER_SEQUENCES: tuple[str, ...] = (
 # the single-character members of ``_FORBIDDEN_FILTER_SEQUENCES``;
 # multi-character sequences (``--``, ``/*``, ``*/``) are caught by the
 # dedicated ``validate_filter_no_sql_injection`` validator below.
-_SAFE_FILTER_PATTERN: str = r"^[^'\";\x00]*$"
+SAFE_FILTER_PATTERN: str = r"^[^'\";\x00]*$"
+_SAFE_FILTER_PATTERN = SAFE_FILTER_PATTERN  # backward-compat alias
 
 
 def validate_filter_no_sql_injection(v: Any) -> Any:

--- a/application_sdk/templates/contracts/incremental_sql.py
+++ b/application_sdk/templates/contracts/incremental_sql.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import dataclasses
 import re
-from typing import Optional
 
 from pydantic import field_validator
 
@@ -49,6 +48,12 @@ def _validate_marker_timestamp(value: str | None) -> str | None:
     Empty / None passes through (no marker = full-extraction signal).
     Anything else must match :data:`_ISO_TIMESTAMP_PATTERN`. Raises
     ``ValueError`` so Pydantic surfaces it as ``ValidationError``.
+
+    Assumption: all SDK-produced markers are ISO-8601 timestamps or empty
+    strings, so adding this validator to Output contracts
+    (``FetchIncrementalMarkerOutput``, ``UpdateMarkerOutput``) is safe for
+    Temporal workflow replay — no well-formed history entry would be
+    rejected by this constraint.
     """
     if value is None or value == "":
         return value
@@ -90,7 +95,7 @@ class IncrementalRunContext:
     prepone_marker_timestamp: bool = True
     prepone_marker_hours: int = 3
     # Set by fetch_incremental_marker
-    marker_timestamp: Optional[str] = None
+    marker_timestamp: str | None = None
     next_marker_timestamp: str = ""
     # Set by read_current_state
     current_state_available: bool = False
@@ -245,7 +250,7 @@ class FetchIncrementalMarkerInput(Input):
     application_name: str = ""
     """Application name for S3 path resolution."""
 
-    existing_marker: Optional[str] = None
+    existing_marker: str | None = None
     """Pre-existing marker value (e.g., from a manual workflow override)."""
 
     prepone_enabled: bool = True
@@ -256,7 +261,7 @@ class FetchIncrementalMarkerInput(Input):
 
     @field_validator("existing_marker", mode="after")
     @classmethod
-    def _validate_existing_marker(cls, v: Optional[str]) -> Optional[str]:
+    def _validate_existing_marker(cls, v: str | None) -> str | None:
         return _validate_marker_timestamp(v)
 
 

--- a/application_sdk/templates/contracts/incremental_sql.py
+++ b/application_sdk/templates/contracts/incremental_sql.py
@@ -8,7 +8,10 @@ input/output types.
 from __future__ import annotations
 
 import dataclasses
+import re
 from typing import Optional
+
+from pydantic import field_validator
 
 from application_sdk.contracts.base import Input, Output
 from application_sdk.templates.contracts.sql_metadata import (
@@ -20,6 +23,43 @@ from application_sdk.templates.contracts.sql_metadata import (
     FetchSchemasOutput,
     FetchTablesOutput,
 )
+
+# BLDX-518: marker_timestamp is substituted into incremental SQL templates
+# via ``str.replace``, so untrusted input could carry SQL escape sequences
+# (the marker is sourced from a persistent file but can also be overridden
+# from the workflow input — see ``FetchIncrementalMarkerInput.existing_marker``).
+#
+# Accept either:
+#   * Empty string — signals "no marker, perform a full extraction".
+#   * ISO-8601 / RFC-3339 timestamp — date + time, optional fractional
+#     seconds, optional timezone offset. ``T`` or space between date and
+#     time is allowed to match the variants different sources emit.
+#
+# Anything else (including SQL escape chars) is rejected by the validator
+# regardless of whether the value came from object storage or a workflow
+# override.
+_ISO_TIMESTAMP_PATTERN = re.compile(
+    r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$"
+)
+
+
+def _validate_marker_timestamp(value: str | None) -> str | None:
+    """Reject marker timestamps that don't match ISO-8601 / empty.
+
+    Empty / None passes through (no marker = full-extraction signal).
+    Anything else must match :data:`_ISO_TIMESTAMP_PATTERN`. Raises
+    ``ValueError`` so Pydantic surfaces it as ``ValidationError``.
+    """
+    if value is None or value == "":
+        return value
+    if not _ISO_TIMESTAMP_PATTERN.match(value):
+        raise ValueError(
+            f"marker_timestamp must be empty or an ISO-8601 / RFC-3339 timestamp "
+            f"(got {value!r}). Reject reason: prevents SQL injection via "
+            "templates that substitute the marker into a quoted literal."
+        )
+    return value
+
 
 # =============================================================================
 # IncrementalRunContext — local accumulator, NOT a Temporal payload
@@ -161,6 +201,11 @@ class IncrementalTaskInput(ExtractionTaskInput):
     column_chunk_size: int = 100000
     """Number of column records per output chunk file."""
 
+    @field_validator("marker_timestamp", mode="after")
+    @classmethod
+    def _validate_marker(cls, v: str) -> str:
+        return _validate_marker_timestamp(v) or ""
+
 
 # =============================================================================
 # Per-task incremental input types (inherit IncrementalTaskInput)
@@ -209,6 +254,11 @@ class FetchIncrementalMarkerInput(Input):
     prepone_hours: float = 3.0
     """Hours to subtract from the marker when preponing is enabled."""
 
+    @field_validator("existing_marker", mode="after")
+    @classmethod
+    def _validate_existing_marker(cls, v: Optional[str]) -> Optional[str]:
+        return _validate_marker_timestamp(v)
+
 
 class FetchIncrementalMarkerOutput(Output):
     """Output from the fetch_incremental_marker task."""
@@ -218,6 +268,11 @@ class FetchIncrementalMarkerOutput(Output):
 
     next_marker_timestamp: str = ""
     """New marker timestamp generated for the current run."""
+
+    @field_validator("marker_timestamp", "next_marker_timestamp", mode="after")
+    @classmethod
+    def _validate_marker(cls, v: str) -> str:
+        return _validate_marker_timestamp(v) or ""
 
 
 # =============================================================================
@@ -354,6 +409,11 @@ class UpdateMarkerInput(Input):
     next_marker_timestamp: str = ""
     application_name: str = ""
 
+    @field_validator("next_marker_timestamp", mode="after")
+    @classmethod
+    def _validate_marker(cls, v: str) -> str:
+        return _validate_marker_timestamp(v) or ""
+
 
 class UpdateMarkerOutput(Output):
     """Output from the update_incremental_marker task."""
@@ -361,6 +421,11 @@ class UpdateMarkerOutput(Output):
     marker_written: bool = False
     marker_timestamp: str = ""
     s3_key: str = ""
+
+    @field_validator("marker_timestamp", mode="after")
+    @classmethod
+    def _validate_marker(cls, v: str) -> str:
+        return _validate_marker_timestamp(v) or ""
 
 
 # =============================================================================

--- a/application_sdk/templates/contracts/sql_metadata.py
+++ b/application_sdk/templates/contracts/sql_metadata.py
@@ -12,7 +12,7 @@ import orjson
 from pydantic import Field, field_validator, model_validator
 
 from application_sdk.common.sql_filters import (
-    _SAFE_FILTER_PATTERN,
+    SAFE_FILTER_PATTERN,
     validate_filter_no_sql_injection,
 )
 from application_sdk.contracts.base import Input, Output, PublishInputMixin
@@ -162,7 +162,7 @@ class ExtractionInput(Input):
     - ``None`` → empty string
     """
 
-    temp_table_regex: Annotated[str, Field(pattern=_SAFE_FILTER_PATTERN)] = ""
+    temp_table_regex: Annotated[str, Field(pattern=SAFE_FILTER_PATTERN)] = ""
     """Regex pattern identifying temporary tables."""
 
     source_tag_prefix: str = ""
@@ -177,6 +177,12 @@ class ExtractionInput(Input):
     @classmethod
     def _validate_no_sql_injection(cls, v: FilterMap | str) -> FilterMap | str:
         return _validate_filter_no_sql_injection(v)
+
+    @field_validator("temp_table_regex", mode="after")
+    @classmethod
+    def _validate_temp_table_no_sql_injection(cls, v: str) -> str:
+        validate_filter_no_sql_injection(v)
+        return v
 
 
 class ExtractionOutput(Output, PublishInputMixin):
@@ -215,7 +221,7 @@ class ExtractionTaskInput(Input):
     output_path: str = ""
     exclude_filter: FilterMap | str = Field(default="")
     include_filter: FilterMap | str = Field(default="")
-    temp_table_regex: Annotated[str, Field(pattern=_SAFE_FILTER_PATTERN)] = ""
+    temp_table_regex: Annotated[str, Field(pattern=SAFE_FILTER_PATTERN)] = ""
     source_tag_prefix: str = ""
 
     @field_validator("include_filter", "exclude_filter", mode="before")
@@ -227,6 +233,12 @@ class ExtractionTaskInput(Input):
     @classmethod
     def _validate_no_sql_injection(cls, v: FilterMap | str) -> FilterMap | str:
         return _validate_filter_no_sql_injection(v)
+
+    @field_validator("temp_table_regex", mode="after")
+    @classmethod
+    def _validate_temp_table_no_sql_injection(cls, v: str) -> str:
+        validate_filter_no_sql_injection(v)
+        return v
 
 
 class FetchDatabasesInput(ExtractionTaskInput):

--- a/application_sdk/templates/contracts/sql_metadata.py
+++ b/application_sdk/templates/contracts/sql_metadata.py
@@ -11,6 +11,10 @@ from typing import Annotated, Any
 import orjson
 from pydantic import Field, field_validator, model_validator
 
+from application_sdk.common.sql_filters import (
+    _SAFE_FILTER_PATTERN,
+    validate_filter_no_sql_injection,
+)
 from application_sdk.contracts.base import Input, Output, PublishInputMixin
 from application_sdk.contracts.types import ConnectionRef, MaxItems
 from application_sdk.credentials.ref import CredentialRef
@@ -25,9 +29,12 @@ FilterMap = Annotated[
     MaxItems(100),
 ]
 
-# Disallow single quotes in temp_table_regex to prevent SQL injection when
-# values are substituted into SQL templates via _prepare_sql (str.replace).
-_SAFE_FILTER_PATTERN = r"^[^']*$"
+# Backward-compatible aliases: the deny-list moved to ``common.sql_filters``
+# in BLDX-518 so the same validation can be applied to raw-dict helper
+# callers (``prepare_query``, ``prepare_filters``, ``get_database_names``)
+# that bypass Pydantic. Keep the underscore-prefixed name re-exported so
+# any in-tree import path remains valid.
+_validate_filter_no_sql_injection = validate_filter_no_sql_injection
 
 
 def _coerce_filter_value(v: Any) -> FilterMap | str:
@@ -42,32 +49,6 @@ def _coerce_filter_value(v: Any) -> FilterMap | str:
         return ""
     if isinstance(v, list):
         return {".*": v}
-    return v
-
-
-def _validate_filter_no_sql_injection(v: FilterMap | str) -> FilterMap | str:
-    """Block single quotes in filter values to prevent SQL injection.
-
-    stdlib-interop: raises ValueError because callers wrap this in
-    Pydantic ``@field_validator``, which requires ValueError to surface as
-    ``ValidationError``. Do not migrate to ``InvalidInputError`` — Pydantic
-    only treats ValueError / AssertionError / PydanticCustomError as
-    validation failures.
-    """
-    if isinstance(v, str):
-        if "'" in v:
-            msg = f"Single quotes not allowed in filter value: {v}"
-            raise ValueError(msg)
-    elif isinstance(v, dict):
-        for key, values in v.items():
-            if "'" in key:
-                msg = f"Single quotes not allowed in filter key: {key}"
-                raise ValueError(msg)
-            if isinstance(values, list):
-                for val in values:
-                    if isinstance(val, str) and "'" in val:
-                        msg = f"Single quotes not allowed in filter value: {val}"
-                        raise ValueError(msg)
     return v
 
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.12.0
-source-sha:    2157426b76635450d766321dfc86f30110237398
-source-date:   2026-05-19T04:03:28+05:30
+source-sha:    f76098c9462870fe02bbb32aa53ed160fc529456
+source-date:   2026-05-18T23:50:49+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.12.0
-source-sha:    f76098c9462870fe02bbb32aa53ed160fc529456
-source-date:   2026-05-18T23:50:49+01:00
+source-sha:    528d7f48c54990992053278dcef2a7488ce0e3ea
+source-date:   2026-05-19T13:19:36+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -2496,7 +2496,7 @@ Strongly-typed Pydantic models for SDK methods. Contracts in `application_sdk.co
   - `output_path: str` `= ''` — Local or object store path for output files.
   - `exclude_filter: FilterMap | str` `= Field(default='')` — Filter for excluding schemas/tables.
   - `include_filter: FilterMap | str` `= Field(default='')` — Filter for including schemas/tables.
-  - `temp_table_regex: Annotated[str, Field(pattern=_SAFE_FILTER_PATTERN)]` `= ''` — Regex pattern identifying temporary tables.
+  - `temp_table_regex: Annotated[str, Field(pattern=SAFE_FILTER_PATTERN)]` `= ''` — Regex pattern identifying temporary tables.
   - `source_tag_prefix: str` `= ''` — Tag prefix for source-level metadata.
 - **Defined in:** `application_sdk/templates/contracts/sql_metadata.py`
 
@@ -2532,7 +2532,7 @@ Strongly-typed Pydantic models for SDK methods. Contracts in `application_sdk.co
   - `output_path: str` `= ''`
   - `exclude_filter: FilterMap | str` `= Field(default='')`
   - `include_filter: FilterMap | str` `= Field(default='')`
-  - `temp_table_regex: Annotated[str, Field(pattern=_SAFE_FILTER_PATTERN)]` `= ''`
+  - `temp_table_regex: Annotated[str, Field(pattern=SAFE_FILTER_PATTERN)]` `= ''`
   - `source_tag_prefix: str` `= ''`
 - **Defined in:** `application_sdk/templates/contracts/sql_metadata.py`
 
@@ -2580,7 +2580,7 @@ Strongly-typed Pydantic models for SDK methods. Contracts in `application_sdk.co
 - **Fields:**
   - `connection_qualified_name: str` `= ''` — Connection qualified name used to locate the persistent marker file.
   - `application_name: str` `= ''` — Application name for S3 path resolution.
-  - `existing_marker: Optional[str]` — Pre-existing marker value (e.g., from a manual workflow override).
+  - `existing_marker: str | None` — Pre-existing marker value (e.g., from a manual workflow override).
   - `prepone_enabled: bool` `= True` — Whether to move the marker back by ``prepone_hours``.
   - `prepone_hours: float` `= 3.0` — Hours to subtract from the marker when preponing is enabled.
 - **Defined in:** `application_sdk/templates/contracts/incremental_sql.py`

--- a/tests/unit/common/test_sql_filters_injection.py
+++ b/tests/unit/common/test_sql_filters_injection.py
@@ -26,7 +26,6 @@ from application_sdk.common.sql_filters import (
     validate_filter_no_sql_injection,
 )
 
-
 # ---------------------------------------------------------------------------
 # validate_filter_no_sql_injection — the deny-list itself
 # ---------------------------------------------------------------------------

--- a/tests/unit/common/test_sql_filters_injection.py
+++ b/tests/unit/common/test_sql_filters_injection.py
@@ -1,0 +1,170 @@
+"""SQL injection deny-list — covers raw-dict helper paths (BLDX-518).
+
+The Pydantic-validated paths (``ExtractionInput`` / ``ExtractionTaskInput``)
+are covered by ``tests/unit/templates/test_extraction_input_filters.py``.
+This file pins the helper-level enforcement: ``prepare_query``,
+``prepare_filters``, and ``get_database_names`` all run untyped
+``workflow_args`` dicts through the same deny-list before any SQL
+template substitution.
+
+Why this matters: connector apps call these helpers directly with raw
+``metadata`` payloads sourced from workflow input, which bypasses every
+Pydantic guard upstream. A regression here would re-open the original
+BLDX-518 vector even with the Pydantic validators in place.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from application_sdk.common.sql_filters import (
+    get_database_names,
+    prepare_filters,
+    prepare_query,
+    validate_filter_no_sql_injection,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_filter_no_sql_injection — the deny-list itself
+# ---------------------------------------------------------------------------
+
+
+class TestValidateFilterNoSqlInjection:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "prefix'injection",       # single quote
+            'prefix"injection',       # double quote
+            "name; DROP TABLE x",     # statement separator
+            "name-- comment",         # SQL line comment
+            "name/* block",           # block comment open
+            "name */",                # block comment close
+            "name\x00trailing",       # null byte
+        ],
+    )
+    def test_string_with_forbidden_sequence_raises(self, value: str) -> None:
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            validate_filter_no_sql_injection(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "^prod_.*$",                                       # simple regex
+            r"^(prod|stage)_db\.[a-z]+(\.bak)?$",              # full meta-char set
+            "",                                                # empty
+            "schema_name",                                     # plain identifier
+        ],
+    )
+    def test_clean_string_passes(self, value: str) -> None:
+        assert validate_filter_no_sql_injection(value) == value
+
+    def test_dict_key_with_quote_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            validate_filter_no_sql_injection({"db'; DROP--": ["^public$"]})
+
+    def test_dict_value_with_quote_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            validate_filter_no_sql_injection({"^db$": ["sch'; DROP--"]})
+
+    def test_dict_value_as_string_with_quote_raises(self) -> None:
+        # Some callers pass a string value instead of a list.
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            validate_filter_no_sql_injection({"^db$": "sch';--"})
+
+    def test_clean_dict_passes(self) -> None:
+        v = {"^prod$": ["^analytics$", "^reporting$"]}
+        assert validate_filter_no_sql_injection(v) == v
+
+    def test_json_encoded_string_parses_and_validates(self) -> None:
+        # Legacy AE payload shape: filter encoded as JSON string. Double
+        # quotes belong to JSON syntax, not filter content — must pass.
+        v = '{"^prod$": ["^analytics$"]}'
+        assert validate_filter_no_sql_injection(v) == v
+
+    def test_json_encoded_string_with_injected_quote_raises(self) -> None:
+        # The JSON structural quotes are fine; the single quote inside
+        # the actual filter value still fails.
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            validate_filter_no_sql_injection(
+                '{"^prod$": ["sch\'; DROP TABLE x"]}'
+            )
+
+    def test_malformed_json_falls_through_to_string_check(self) -> None:
+        # Not valid JSON despite the braces — treated as raw regex; the
+        # single quote in the value still trips the deny-list.
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            validate_filter_no_sql_injection("{ not really json ' }")
+
+
+# ---------------------------------------------------------------------------
+# prepare_filters — string/dict inputs are gated before normalization
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareFiltersInjectionGate:
+    def test_quote_in_include_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            prepare_filters("prefix'injection", "")
+
+    def test_quote_in_exclude_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            prepare_filters("", "name; DROP TABLE x")
+
+    def test_clean_filters_pass(self) -> None:
+        # ``prepare_filters`` calls ``parse_filter_input`` which JSON-decodes
+        # the string, so the input must be a JSON-encoded filter map (the
+        # shape AE actually emits). The deny-list runs on the parsed dict
+        # contents, not the JSON syntax.
+        include, exclude = prepare_filters(
+            '{"^prod$": ["^analytics$"]}',
+            '{"^temp$": ["^staging$"]}',
+        )
+        assert include
+        assert exclude
+
+
+# ---------------------------------------------------------------------------
+# prepare_query — workflow_args dict is gated for temp-table-regex
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareQueryInjectionGate:
+    def test_quote_in_temp_table_regex_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            prepare_query(
+                "SELECT 1",
+                {"metadata": {"temp-table-regex": "evil'; DROP TABLE--"}},
+                temp_table_regex_sql="AND name NOT LIKE '{exclude_table_regex}'",
+            )
+
+    def test_quote_in_include_filter_raises(self) -> None:
+        # ``prepare_query`` delegates filter validation to ``prepare_filters``;
+        # the injection guard fires there.
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            prepare_query(
+                "SELECT 1",
+                {"metadata": {"include-filter": "name'; DROP TABLE x"}},
+            )
+
+
+# ---------------------------------------------------------------------------
+# get_database_names — include-filter is gated before any return path
+# ---------------------------------------------------------------------------
+
+
+class TestGetDatabaseNamesInjectionGate:
+    @pytest.mark.asyncio
+    async def test_quote_in_include_filter_raises(self) -> None:
+        sql_client = MagicMock()
+        sql_client.get_results = AsyncMock()
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            await get_database_names(
+                sql_client,
+                {"metadata": {"include-filter": {"db'; DROP--": ["public"]}}},
+                "SELECT name FROM information_schema.databases",
+            )
+        # SQL was never reached.
+        sql_client.get_results.assert_not_called()

--- a/tests/unit/common/test_sql_filters_injection.py
+++ b/tests/unit/common/test_sql_filters_injection.py
@@ -153,7 +153,6 @@ class TestPrepareQueryInjectionGate:
 
 
 class TestGetDatabaseNamesInjectionGate:
-    @pytest.mark.asyncio
     async def test_quote_in_include_filter_raises(self) -> None:
         sql_client = MagicMock()
         sql_client.get_results = AsyncMock()

--- a/tests/unit/common/test_sql_filters_injection.py
+++ b/tests/unit/common/test_sql_filters_injection.py
@@ -36,13 +36,13 @@ class TestValidateFilterNoSqlInjection:
     @pytest.mark.parametrize(
         "value",
         [
-            "prefix'injection",       # single quote
-            'prefix"injection',       # double quote
-            "name; DROP TABLE x",     # statement separator
-            "name-- comment",         # SQL line comment
-            "name/* block",           # block comment open
-            "name */",                # block comment close
-            "name\x00trailing",       # null byte
+            "prefix'injection",  # single quote
+            'prefix"injection',  # double quote
+            "name; DROP TABLE x",  # statement separator
+            "name-- comment",  # SQL line comment
+            "name/* block",  # block comment open
+            "name */",  # block comment close
+            "name\x00trailing",  # null byte
         ],
     )
     def test_string_with_forbidden_sequence_raises(self, value: str) -> None:
@@ -52,10 +52,10 @@ class TestValidateFilterNoSqlInjection:
     @pytest.mark.parametrize(
         "value",
         [
-            "^prod_.*$",                                       # simple regex
-            r"^(prod|stage)_db\.[a-z]+(\.bak)?$",              # full meta-char set
-            "",                                                # empty
-            "schema_name",                                     # plain identifier
+            "^prod_.*$",  # simple regex
+            r"^(prod|stage)_db\.[a-z]+(\.bak)?$",  # full meta-char set
+            "",  # empty
+            "schema_name",  # plain identifier
         ],
     )
     def test_clean_string_passes(self, value: str) -> None:
@@ -88,9 +88,7 @@ class TestValidateFilterNoSqlInjection:
         # The JSON structural quotes are fine; the single quote inside
         # the actual filter value still fails.
         with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
-            validate_filter_no_sql_injection(
-                '{"^prod$": ["sch\'; DROP TABLE x"]}'
-            )
+            validate_filter_no_sql_injection('{"^prod$": ["sch\'; DROP TABLE x"]}')
 
     def test_malformed_json_falls_through_to_string_check(self) -> None:
         # Not valid JSON despite the braces — treated as raw regex; the

--- a/tests/unit/templates/contracts/test_incremental_sql_marker.py
+++ b/tests/unit/templates/contracts/test_incremental_sql_marker.py
@@ -28,23 +28,23 @@ from application_sdk.templates.contracts.incremental_sql import (
 
 # Canonical valid markers covering every shape the contract permits.
 _VALID_MARKERS = [
-    "",                                  # empty = full-extraction signal
-    "2026-05-18T12:34:56",                # plain ISO, no fractional / tz
-    "2026-05-18T12:34:56Z",               # Zulu
-    "2026-05-18T12:34:56.123456Z",        # microsecond precision
-    "2026-05-18T12:34:56+05:30",          # offset with colon
-    "2026-05-18T12:34:56-0700",           # offset without colon
-    "2026-05-18 12:34:56",                # space separator (PG/MySQL default)
+    "",  # empty = full-extraction signal
+    "2026-05-18T12:34:56",  # plain ISO, no fractional / tz
+    "2026-05-18T12:34:56Z",  # Zulu
+    "2026-05-18T12:34:56.123456Z",  # microsecond precision
+    "2026-05-18T12:34:56+05:30",  # offset with colon
+    "2026-05-18T12:34:56-0700",  # offset without colon
+    "2026-05-18 12:34:56",  # space separator (PG/MySQL default)
 ]
 
 # Malicious / malformed values that must be rejected on every contract.
 _INVALID_MARKERS = [
-    "2026-05-18T12:34:56'; DROP TABLE x",   # SQL injection via marker
-    "not-a-date",                            # malformed
-    "2026/05/18 12:34:56",                   # wrong separator
-    "12:34:56",                              # time only
-    "2026-05-18",                            # date only
-    "2026-05-18T12:34:56' OR '1'='1",        # classic-OR injection
+    "2026-05-18T12:34:56'; DROP TABLE x",  # SQL injection via marker
+    "not-a-date",  # malformed
+    "2026/05/18 12:34:56",  # wrong separator
+    "12:34:56",  # time only
+    "2026-05-18",  # date only
+    "2026-05-18T12:34:56' OR '1'='1",  # classic-OR injection
 ]
 
 
@@ -53,7 +53,9 @@ _INVALID_MARKERS = [
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("cls", [FetchTablesIncrementalInput, FetchColumnsIncrementalInput])
+@pytest.mark.parametrize(
+    "cls", [FetchTablesIncrementalInput, FetchColumnsIncrementalInput]
+)
 class TestIncrementalTaskInputMarker:
     @pytest.mark.parametrize("marker", _VALID_MARKERS)
     def test_valid_marker_accepted(self, cls, marker: str) -> None:
@@ -142,9 +144,7 @@ class TestUpdateMarkerContracts:
 
     def test_input_invalid_marker_rejected(self) -> None:
         with pytest.raises(ValueError, match=r"marker_timestamp must be"):
-            UpdateMarkerInput.model_validate(
-                {"next_marker_timestamp": "not-a-date"}
-            )
+            UpdateMarkerInput.model_validate({"next_marker_timestamp": "not-a-date"})
 
     def test_output_invalid_marker_rejected(self) -> None:
         with pytest.raises(ValueError, match=r"marker_timestamp must be"):

--- a/tests/unit/templates/contracts/test_incremental_sql_marker.py
+++ b/tests/unit/templates/contracts/test_incremental_sql_marker.py
@@ -25,7 +25,6 @@ from application_sdk.templates.contracts.incremental_sql import (
     UpdateMarkerOutput,
 )
 
-
 # Canonical valid markers covering every shape the contract permits.
 _VALID_MARKERS = [
     "",  # empty = full-extraction signal

--- a/tests/unit/templates/contracts/test_incremental_sql_marker.py
+++ b/tests/unit/templates/contracts/test_incremental_sql_marker.py
@@ -1,0 +1,153 @@
+"""Marker-timestamp validation across incremental SQL contracts (BLDX-518).
+
+``marker_timestamp`` and ``existing_marker`` end up in incremental SQL
+templates via ``str.replace``. A workflow input can override the value
+(``FetchIncrementalMarkerInput.existing_marker``), so the contract must
+constrain it to ISO-8601 / empty — anything else gets rejected before
+it reaches a SQL template.
+
+Covers all four contracts that carry a marker field:
+``IncrementalTaskInput``, ``FetchIncrementalMarkerInput``,
+``FetchIncrementalMarkerOutput``, ``UpdateMarkerInput`` /
+``UpdateMarkerOutput``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from application_sdk.templates.contracts.incremental_sql import (
+    FetchColumnsIncrementalInput,
+    FetchIncrementalMarkerInput,
+    FetchIncrementalMarkerOutput,
+    FetchTablesIncrementalInput,
+    UpdateMarkerInput,
+    UpdateMarkerOutput,
+)
+
+
+# Canonical valid markers covering every shape the contract permits.
+_VALID_MARKERS = [
+    "",                                  # empty = full-extraction signal
+    "2026-05-18T12:34:56",                # plain ISO, no fractional / tz
+    "2026-05-18T12:34:56Z",               # Zulu
+    "2026-05-18T12:34:56.123456Z",        # microsecond precision
+    "2026-05-18T12:34:56+05:30",          # offset with colon
+    "2026-05-18T12:34:56-0700",           # offset without colon
+    "2026-05-18 12:34:56",                # space separator (PG/MySQL default)
+]
+
+# Malicious / malformed values that must be rejected on every contract.
+_INVALID_MARKERS = [
+    "2026-05-18T12:34:56'; DROP TABLE x",   # SQL injection via marker
+    "not-a-date",                            # malformed
+    "2026/05/18 12:34:56",                   # wrong separator
+    "12:34:56",                              # time only
+    "2026-05-18",                            # date only
+    "2026-05-18T12:34:56' OR '1'='1",        # classic-OR injection
+]
+
+
+# ---------------------------------------------------------------------------
+# IncrementalTaskInput (and subclasses) — marker_timestamp
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cls", [FetchTablesIncrementalInput, FetchColumnsIncrementalInput])
+class TestIncrementalTaskInputMarker:
+    @pytest.mark.parametrize("marker", _VALID_MARKERS)
+    def test_valid_marker_accepted(self, cls, marker: str) -> None:
+        result = cls.model_validate({"marker_timestamp": marker})
+        assert result.marker_timestamp == marker
+
+    @pytest.mark.parametrize("marker", _INVALID_MARKERS)
+    def test_invalid_marker_rejected(self, cls, marker: str) -> None:
+        with pytest.raises(ValueError, match=r"marker_timestamp must be"):
+            cls.model_validate({"marker_timestamp": marker})
+
+
+# ---------------------------------------------------------------------------
+# FetchIncrementalMarkerInput — existing_marker (Optional[str])
+# ---------------------------------------------------------------------------
+
+
+class TestFetchIncrementalMarkerInputMarker:
+    def test_none_marker_accepted(self) -> None:
+        result = FetchIncrementalMarkerInput.model_validate(
+            {"connection_qualified_name": "default/mysql/1", "existing_marker": None}
+        )
+        assert result.existing_marker is None
+
+    @pytest.mark.parametrize("marker", _VALID_MARKERS)
+    def test_valid_marker_accepted(self, marker: str) -> None:
+        result = FetchIncrementalMarkerInput.model_validate(
+            {
+                "connection_qualified_name": "default/mysql/1",
+                "existing_marker": marker,
+            }
+        )
+        assert result.existing_marker == marker
+
+    @pytest.mark.parametrize("marker", _INVALID_MARKERS)
+    def test_invalid_marker_rejected(self, marker: str) -> None:
+        with pytest.raises(ValueError, match=r"marker_timestamp must be"):
+            FetchIncrementalMarkerInput.model_validate(
+                {
+                    "connection_qualified_name": "default/mysql/1",
+                    "existing_marker": marker,
+                }
+            )
+
+
+# ---------------------------------------------------------------------------
+# FetchIncrementalMarkerOutput — both marker fields
+# ---------------------------------------------------------------------------
+
+
+class TestFetchIncrementalMarkerOutputMarker:
+    def test_clean_marker_pair_accepted(self) -> None:
+        result = FetchIncrementalMarkerOutput.model_validate(
+            {
+                "marker_timestamp": "2026-05-18T00:00:00Z",
+                "next_marker_timestamp": "2026-05-19T00:00:00Z",
+            }
+        )
+        assert result.marker_timestamp == "2026-05-18T00:00:00Z"
+        assert result.next_marker_timestamp == "2026-05-19T00:00:00Z"
+
+    def test_invalid_marker_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"marker_timestamp must be"):
+            FetchIncrementalMarkerOutput.model_validate(
+                {"marker_timestamp": "not-a-date"}
+            )
+
+    def test_invalid_next_marker_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"marker_timestamp must be"):
+            FetchIncrementalMarkerOutput.model_validate(
+                {"next_marker_timestamp": "2026-05-19'; DROP--"}
+            )
+
+
+# ---------------------------------------------------------------------------
+# UpdateMarkerInput / UpdateMarkerOutput
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateMarkerContracts:
+    def test_input_clean_marker_accepted(self) -> None:
+        result = UpdateMarkerInput.model_validate(
+            {"next_marker_timestamp": "2026-05-18T00:00:00Z"}
+        )
+        assert result.next_marker_timestamp == "2026-05-18T00:00:00Z"
+
+    def test_input_invalid_marker_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"marker_timestamp must be"):
+            UpdateMarkerInput.model_validate(
+                {"next_marker_timestamp": "not-a-date"}
+            )
+
+    def test_output_invalid_marker_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"marker_timestamp must be"):
+            UpdateMarkerOutput.model_validate(
+                {"marker_timestamp": "2026-05-18'; DROP--"}
+            )

--- a/tests/unit/templates/test_extraction_input_filters.py
+++ b/tests/unit/templates/test_extraction_input_filters.py
@@ -59,21 +59,44 @@ class TestFilterCoercion:
 
 
 class TestFilterSQLInjectionGuard:
-    """Single quotes blocked in filter values."""
+    """SQL-unsafe sequences blocked in filter values (BLDX-518 deny-list)."""
 
     def test_single_quote_in_string_rejected(self):
         payload = {"include_filter": "prefix'injection"}
-        with pytest.raises(ValueError, match="Single quotes not allowed"):
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
             ExtractionInput.model_validate(payload)
 
     def test_single_quote_in_dict_key_rejected(self):
         payload = {"include_filter": {"db'; DROP TABLE--": ["^public$"]}}
-        with pytest.raises(ValueError, match="Single quotes not allowed"):
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
             ExtractionInput.model_validate(payload)
 
     def test_single_quote_in_dict_value_rejected(self):
         payload = {"include_filter": {"^db$": ["schema'; DROP TABLE--"]}}
-        with pytest.raises(ValueError, match="Single quotes not allowed"):
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            ExtractionInput.model_validate(payload)
+
+    def test_semicolon_rejected(self):
+        # Statement separator — would let an attacker stack a second
+        # statement after the filter substitution.
+        payload = {"include_filter": "name; DROP TABLE users"}
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence ';'"):
+            ExtractionInput.model_validate(payload)
+
+    def test_line_comment_rejected(self):
+        # SQL line comment eats the rest of the line.
+        payload = {"include_filter": "name-- comment"}
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence '--'"):
+            ExtractionInput.model_validate(payload)
+
+    def test_block_comment_open_rejected(self):
+        payload = {"include_filter": "name/* injected */"}
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence '/\*'"):
+            ExtractionInput.model_validate(payload)
+
+    def test_null_byte_rejected(self):
+        payload = {"include_filter": "name\x00trailing"}
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
             ExtractionInput.model_validate(payload)
 
     def test_clean_string_passes(self):
@@ -85,6 +108,14 @@ class TestFilterSQLInjectionGuard:
             {"include_filter": {"^prod$": ["^analytics$"]}}
         )
         assert result.include_filter == {"^prod$": ["^analytics$"]}
+
+    def test_regex_metachars_still_allowed(self):
+        # The deny-list must not over-block legitimate regex syntax —
+        # ``^``, ``$``, ``.``, ``*``, ``+``, ``?``, ``|``, ``()``, ``[]``,
+        # ``\``, ``{}``, and single ``-`` all stay legal.
+        payload = {"include_filter": r"^(prod|stage)_db\.[a-z]+(\.bak)?$"}
+        result = ExtractionInput.model_validate(payload)
+        assert result.include_filter == r"^(prod|stage)_db\.[a-z]+(\.bak)?$"
 
 
 class TestExtractionTaskInputFilters:

--- a/tests/unit/templates/test_extraction_input_filters.py
+++ b/tests/unit/templates/test_extraction_input_filters.py
@@ -118,6 +118,49 @@ class TestFilterSQLInjectionGuard:
         assert result.include_filter == r"^(prod|stage)_db\.[a-z]+(\.bak)?$"
 
 
+class TestTempTableRegexInjectionGuard:
+    """temp_table_regex Pydantic validator blocks SQL injection (BLDX-518).
+
+    Single-char forbidden sequences ('  " ; \\x00) are caught by
+    Field(pattern=SAFE_FILTER_PATTERN) — Pydantic raises a
+    string_pattern_mismatch error.  Multi-char sequences (-- /* */) are
+    not matched by the regex and are caught by the @field_validator that
+    calls validate_filter_no_sql_injection, which raises a ValueError
+    with "SQL-unsafe sequence" in the message.
+    """
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "evil--comment",
+            "evil/* block",
+            "evil */",
+        ],
+    )
+    def test_multichar_sequence_rejected(self, value: str) -> None:
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            ExtractionInput.model_validate({"temp_table_regex": value})
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "evil; DROP TABLE x",
+            "evil'injection",
+        ],
+    )
+    def test_singlechar_sequence_rejected(self, value: str) -> None:
+        with pytest.raises(ValueError):
+            ExtractionInput.model_validate({"temp_table_regex": value})
+
+    def test_clean_regex_passes(self) -> None:
+        result = ExtractionInput.model_validate({"temp_table_regex": "^temp_.*$"})
+        assert result.temp_table_regex == "^temp_.*$"
+
+    def test_task_input_multichar_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            ExtractionTaskInput.model_validate({"temp_table_regex": "evil--"})
+
+
 class TestExtractionTaskInputFilters:
     """ExtractionTaskInput has the same filter coercion."""
 


### PR DESCRIPTION
## Summary

Closes [BLDX-518](https://linear.app/atlan-epd/issue/BLDX-518/sql-injection-risks-in-sql-template).

The original BLDX-518 vector (free interpolation of `database_name`/`schema_name` as SQL **identifiers**) was resolved by the v3 architectural rewrite — the legacy `SQLQueryExtractionActivities` class is gone. This PR closes the remaining narrower gaps the v3 audit surfaced:

1. **Tighten the filter deny-list.** Previously only `'` was blocked. Add `"`, `;`, `--`, `/*`, `*/`, `\x00` — the SQL-meaningful sequences with no legitimate use inside a regex destined for a quoted literal. Regex meta-chars (`^`, `$`, `.`, `*`, `+`, `?`, `|`, `()`, `[]`, `\`, `{}`, single `-`) stay allowed.

2. **Cover the raw-dict helper paths.** `prepare_query`, `prepare_filters`, and `get_database_names` in [common/sql_filters.py](application_sdk/common/sql_filters.py) accept untyped `workflow_args` dicts that bypass every Pydantic validator. Connector apps call these directly. They now run the deny-list internally before any template substitution. The validator moved to `common/sql_filters.py` (lower in the dep graph) and is re-exported from `contracts/sql_metadata.py` so existing imports keep working.

3. **Handle JSON-encoded filter strings cleanly.** Legacy AE callers pass the filter as a JSON-encoded string whose own structural `"` would trip the new deny-list. The validator now parses such strings first, validates the parsed dict, and returns the **original string** unchanged so downstream consumers stay shape-stable.

4. **Constrain `marker_timestamp` / `existing_marker`.** Incremental extraction templates substitute these via `str.replace` into a quoted literal, and workflow inputs can override the value. Added an ISO-8601 / RFC-3339 regex validator on every contract that carries the field: `IncrementalTaskInput`, `FetchIncrementalMarkerInput`, `FetchIncrementalMarkerOutput`, `UpdateMarkerInput`, `UpdateMarkerOutput`. Empty / `None` still passes (it signals full-extraction mode).

5. **Document the substitution contract** in the incremental-extraction skill markdown — connector authors adding new substitution placeholders must call `validate_filter_no_sql_injection` themselves and wrap the substitution in single quotes.

## What this PR does NOT cover

- **Identifier interpolation** — not applicable; v3 doesn't interpolate identifiers into SQL.
- **Static / runtime enforcement of the "wrap in single quotes" template-author contract** — would require AST inspection of SQL templates. Worth a separate ticket if the deny-list ever proves insufficient.

## Test plan

- [x] 70 new tests covering the deny-list (all forbidden chars), the helper-level gating (`prepare_filters`, `prepare_query`, `get_database_names`), and the marker validator across all 5 contracts.
- [x] Existing filter tests updated for the new error message and forbidden-sequence list.
- [x] `uv run pytest tests/unit/ -q` — **4332 → 4402 passing**, 0 regressions.
- [x] `uv run pre-commit run --all-files` — clean (ruff, ruff-format, isort, pyright).
- [x] Capability manifest regenerated.

## Files touched

- `application_sdk/common/sql_filters.py` — new validator + 3 helper-level gates
- `application_sdk/templates/contracts/sql_metadata.py` — import validator from common; backward-compat alias
- `application_sdk/templates/contracts/incremental_sql.py` — marker validator on 5 contracts
- `application_sdk/common/incremental/skills/.../activities-implementation.md` — guidance note
- `docs/agents/sdk-capabilities.md` — regenerated manifest
- `tests/unit/common/test_sql_filters_injection.py` (new)
- `tests/unit/templates/contracts/test_incremental_sql_marker.py` (new)
- `tests/unit/templates/test_extraction_input_filters.py` — message + coverage updates