### PR TITLE
fix(sql_app): hydrate raw file from object store on cross-worker miss

### DIFF
--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -77,6 +77,8 @@ from application_sdk.credentials.ref import CredentialRef
 from application_sdk.execution import build_output_path, get_object_store_prefix
 from application_sdk.infrastructure.context import get_infrastructure
 from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.storage import StorageNotFoundError
+from application_sdk.storage.ops import download_file
 from application_sdk.storage.transfer import upload as transfer_upload
 from application_sdk.templates.contracts.base_metadata_extraction import (
     UploadInput,
@@ -712,8 +714,19 @@ class SqlApp(App):
 
         Reads ``raw/<entity>/records.json`` line by line, runs each
         record through ``mapper_fn``, and writes the resulting Atlan
-        asset to ``transformed/<entity>/entities.json``. If the raw file
-        is missing or empty (extract returned 0 rows), this is a no-op.
+        asset to ``transformed/<entity>/entities.json``.
+
+        Cross-worker fault tolerance: each ``extract_*`` and
+        ``transform_*`` is a separate Temporal activity and can land on
+        any worker pod. When this transform runs on a pod that didn't
+        run the matching extract, the raw file isn't on this pod's
+        local filesystem — but it IS in object storage (each pod
+        mirrors its raw writes up). Fall back to fetching from object
+        storage in that case rather than silently treating the entity
+        as empty (which previously caused all downstream assets of the
+        missing type to be archived by the publish step on every run
+        that hit a cross-pod schedule). If the raw file is genuinely
+        absent in both places (extract produced 0 rows), return 0.
         """
         output_path = self._resolve_output_path(input)
         if not output_path:
@@ -721,7 +734,50 @@ class SqlApp(App):
 
         raw_file = Path(output_path) / "raw" / entity_type / "records.json"
         if not raw_file.exists() or raw_file.stat().st_size == 0:
-            return TransformOutput(typename=entity_type, total_record_count=0)
+            # Local miss — try the object store before deciding the
+            # entity is empty. The key matches what ``_extract_entity``
+            # ultimately publishes via ``transfer_upload``.
+            object_key = get_object_store_prefix(str(raw_file))
+            try:
+                await download_file(key=object_key, local_path=str(raw_file))
+            except StorageNotFoundError:
+                # Not on this pod AND not in the store ⇒ extract really
+                # returned zero rows for this entity. Preserve the
+                # historical zero-count return so the publish step
+                # interprets the absence consistently.
+                logger.info(
+                    "Transform %s: raw file absent locally and in object "
+                    "store (%s); treating as zero-row extract.",
+                    entity_type,
+                    object_key,
+                )
+                return TransformOutput(typename=entity_type, total_record_count=0)
+            except Exception:
+                # Transient object-store error — let Temporal retry the
+                # activity rather than silently dropping the entity.
+                # Historically this code path returned 0 unconditionally,
+                # which is what caused asset archival across thousands
+                # of records when a download blip coincided with a
+                # cross-worker schedule.
+                logger.error(
+                    "Transform %s: failed to fetch raw file from object "
+                    "store (%s); raising to retry the activity.",
+                    entity_type,
+                    object_key,
+                    exc_info=True,
+                )
+                raise
+            logger.info(
+                "Transform %s: hydrated raw file from object store at %s "
+                "(cross-worker schedule).",
+                entity_type,
+                object_key,
+            )
+            # Re-check after download. A zero-byte object in the store is
+            # treated the same as a genuinely-missing file: no records to
+            # transform, return 0 cleanly.
+            if not raw_file.exists() or raw_file.stat().st_size == 0:
+                return TransformOutput(typename=entity_type, total_record_count=0)
 
         connection_qn = ""
         connection_name = ""

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.12.0
-source-sha:    2157426b76635450d766321dfc86f30110237398
-source-date:   2026-05-19T04:03:28+05:30
+source-sha:    f76098c9462870fe02bbb32aa53ed160fc529456
+source-date:   2026-05-18T23:50:49+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/tests/unit/templates/test_sql_app.py
+++ b/tests/unit/templates/test_sql_app.py
@@ -277,15 +277,216 @@ class TestTransformTasks:
         assert json.loads(out.split("\n")[0])["typeName"] == "Table"
 
     async def test_transform_no_raw_file_returns_zero(self, app, tmp_path):
-        """When extract didn't run (no raw file), transform is a no-op."""
+        """When extract didn't run (no raw file) AND nothing exists in the
+        object store either, transform is a no-op. With BLDX-1281 the
+        transform first attempts an object-store fetch on local miss;
+        ``StorageNotFoundError`` from that fetch is treated as a true
+        zero-row signal (matches historical behaviour).
+        """
+        from application_sdk.storage import StorageNotFoundError
+
         input_ = _make_task_input(output_path=str(tmp_path))
-        result = await app.transform_tables(input_)
+        with patch(
+            "application_sdk.templates.sql_app.download_file",
+            new=AsyncMock(side_effect=StorageNotFoundError("not in store")),
+        ):
+            result = await app.transform_tables(input_)
         assert result.total_record_count == 0
 
     async def test_transform_procedures_no_raw_file(self, app, tmp_path):
+        from application_sdk.storage import StorageNotFoundError
+
         input_ = _make_task_input(output_path=str(tmp_path))
-        result = await app.transform_procedures(input_)
+        with patch(
+            "application_sdk.templates.sql_app.download_file",
+            new=AsyncMock(side_effect=StorageNotFoundError("not in store")),
+        ):
+            result = await app.transform_procedures(input_)
         assert result.total_record_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Cross-worker fault tolerance (BLDX-1281)
+# ---------------------------------------------------------------------------
+#
+# Each extract_* and transform_* is a separate Temporal activity and may run
+# on a different worker pod. The raw file written by extract is on that
+# pod's local filesystem; if transform lands on a different pod, the local
+# file is missing. Historically ``_transform_entity`` would silently return
+# total_record_count=0 in that case — and the downstream publish step would
+# interpret the empty transformed/ directory as "this entity is gone" and
+# archive every previously-published asset of that type for the connection.
+#
+# The fix: on local miss, fetch the raw file from the object store. The
+# tests below pin the three branches of that contract:
+#   * local miss + object-store hit → transform succeeds against the
+#     hydrated file (no asset archival).
+#   * local miss + object-store miss → return count=0 cleanly
+#     (interpreted as "extract produced zero rows", matches historical
+#     behaviour).
+#   * local miss + transient object-store error → raise so Temporal
+#     retries the activity (the historical silent-0 here is what caused
+#     thousands of assets to be archived on a single S3 blip).
+
+
+class TestTransformCrossWorkerFallback:
+    """``_transform_entity`` falls back to the object store on local miss."""
+
+    async def test_local_hit_skips_object_store(self, app, tmp_path):
+        """Happy path: raw is local → no download_file call, no S3 traffic."""
+        _seed_raw(tmp_path, "table", [{"table_name": "t1"}])
+        input_ = _make_task_input(output_path=str(tmp_path))
+
+        with patch(
+            "application_sdk.templates.sql_app.download_file",
+            new=AsyncMock(),
+        ) as mock_download:
+            result = await app.transform_tables(input_)
+
+        assert result.total_record_count == 1
+        mock_download.assert_not_called()
+
+    async def test_local_miss_object_store_hit_hydrates(self, app, tmp_path):
+        """Cross-worker schedule: local raw is missing, but the matching
+        extract pod uploaded it to the object store. download_file
+        materialises the file locally; transform proceeds normally and
+        writes entities.json so the publish step has data to compare.
+        """
+        # raw/table/records.json starts absent — simulate the file landing
+        # only after a download_file call.
+        records = [
+            {"table_name": "users"},
+            {"table_name": "orders"},
+            {"table_name": "products"},
+        ]
+
+        async def fake_download(*, key: str, local_path: str):
+            # download_file creates parents itself; mirror that contract.
+            from pathlib import Path
+
+            target = Path(local_path)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+            return None
+
+        input_ = _make_task_input(output_path=str(tmp_path))
+
+        with patch(
+            "application_sdk.templates.sql_app.download_file",
+            new=AsyncMock(side_effect=fake_download),
+        ) as mock_download:
+            result = await app.transform_tables(input_)
+
+        assert result.total_record_count == 3
+        # Transform was hydrated from the object store, not skipped.
+        mock_download.assert_awaited_once()
+        # entities.json was written with one mapped row per raw record.
+        out_lines = (
+            (tmp_path / "transformed" / "table" / "entities.json")
+            .read_text()
+            .strip()
+            .split("\n")
+        )
+        assert len(out_lines) == 3
+        assert {
+            json.loads(line)["qualifiedName"].rsplit("/", 1)[-1] for line in out_lines
+        } == {"users", "orders", "products"}
+
+    async def test_local_miss_object_store_miss_returns_zero(self, app, tmp_path):
+        """Genuine zero-row extract: raw is absent locally AND in the store.
+        ``StorageNotFoundError`` from download_file is treated as the
+        "extract produced 0 rows" signal so the publish step downstream
+        sees consistent zero-count behaviour (matches the historical
+        contract — no spurious asset archival on first-time runs of
+        empty entity types like ``view`` or ``procedure``).
+        """
+        from application_sdk.storage import StorageNotFoundError
+
+        input_ = _make_task_input(output_path=str(tmp_path))
+
+        with patch(
+            "application_sdk.templates.sql_app.download_file",
+            new=AsyncMock(side_effect=StorageNotFoundError("absent")),
+        ):
+            result = await app.transform_tables(input_)
+
+        assert result.total_record_count == 0
+        # No entities.json should have been created.
+        assert not (tmp_path / "transformed" / "table" / "entities.json").exists()
+
+    async def test_local_miss_object_store_transient_error_raises(self, app, tmp_path):
+        """A transient object-store error (network blip, throttling, etc.)
+        must NOT be swallowed — Temporal needs to retry the activity.
+        Silently returning 0 here is what caused the thirdbridge incident
+        where a multi-pod schedule + a transient S3 hiccup archived
+        thousands of assets in a single publish round.
+        """
+        input_ = _make_task_input(output_path=str(tmp_path))
+
+        with patch(
+            "application_sdk.templates.sql_app.download_file",
+            new=AsyncMock(side_effect=ConnectionError("transient")),
+        ):
+            with pytest.raises(ConnectionError):
+                await app.transform_tables(input_)
+
+    async def test_object_store_returns_empty_file_returns_zero(self, app, tmp_path):
+        """Edge case: download_file succeeds but the object is zero bytes.
+        Treat the same as a missing raw — return 0 instead of attempting
+        to read an empty file (which would also yield 0 but burn an
+        extra activity stat-call). This keeps the contract symmetric
+        with the local-empty-file early return at the top of the helper.
+        """
+
+        async def fake_empty_download(*, key: str, local_path: str):
+            from pathlib import Path
+
+            target = Path(local_path)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(b"")
+            return None
+
+        input_ = _make_task_input(output_path=str(tmp_path))
+
+        with patch(
+            "application_sdk.templates.sql_app.download_file",
+            new=AsyncMock(side_effect=fake_empty_download),
+        ):
+            result = await app.transform_tables(input_)
+
+        assert result.total_record_count == 0
+        assert not (tmp_path / "transformed" / "table" / "entities.json").exists()
+
+    async def test_object_store_key_matches_extract_upload(self, app, tmp_path):
+        """Sanity: the object key passed to download_file is derived from
+        the same path extract uses. Concretely, it must be the
+        ``get_object_store_prefix(...)`` of the local raw path so the
+        upload (transfer_upload of TEMPORARY_PATH/.../raw/<entity>/
+        records.json) and the download line up on the same key.
+        """
+        input_ = _make_task_input(output_path=str(tmp_path))
+
+        captured_keys: list[str] = []
+
+        async def capture_key(*, key: str, local_path: str):
+            captured_keys.append(key)
+            from application_sdk.storage import StorageNotFoundError
+
+            raise StorageNotFoundError("simulated absence")
+
+        with patch(
+            "application_sdk.templates.sql_app.download_file",
+            new=AsyncMock(side_effect=capture_key),
+        ):
+            await app.transform_tables(input_)
+
+        assert len(captured_keys) == 1
+        # The key must reference the same ``raw/table/records.json`` path
+        # the extract step writes — any drift between the two would
+        # silently break the fallback in production. Don't pin the full
+        # prefix shape (it depends on TEMPORARY_PATH at runtime); just
+        # pin the suffix that uniquely identifies this entity.
+        assert captured_keys[0].endswith("raw/table/records.json")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes a data-correctness P0 in the standard SQL template: when extract and transform activities land on different Temporal worker pods, the transform silently returns 0 records, which the downstream publish step interprets as 'the entity is gone' and archives every previously-published asset of that type for the connection.

## Root cause (observed on thirdbridge prod, mysql-app v3.10.0)

Each `extract_*` / `transform_*` is a separate Temporal activity, dispatched independently. With multi-replica workers, Temporal scatters activities across pods. The raw file (`raw/<entity>/records.json`) is written to the extract-pod's local FS. The transform activity, on a different pod, opens that local path, doesn't find the file, and returns `TransformOutput(total_record_count=0)`. The publish step then sees an empty `transformed/<entity>/` directory and archives the corresponding assets.

The raw files do reach the object store (each pod mirrors its own raw writes), but transform never checked there.

Observed pattern in a single thirdbridge workflow run:

| Entity | Raw (S3) | Transformed (S3) |
|---|---|---|
| database | 58 B ✓ | 312 B ✓ |
| schema | 1.5 KB ✓ | **MISSING** ❌ |
| table | 319 KB ✓ | **MISSING** ❌ |
| column | 2.7 MB ✓ | 4.3 MB ✓ |
| extras-procedure | 30 KB ✓ | **MISSING** ❌ |

Which 2-of-5 transforms succeed varies per run (random pod placement), so the archival pattern looks intermittent in customer reports.

## The fix

On local miss, attempt `download_file(key=<object-store key>, local_path=<same local path>)` before treating the entity as empty. The object key is derived from `get_object_store_prefix(local_path)` — same mapping the upload side uses, so the two endpoints always agree on the key.

Four branches, all pinned by tests:

| Local raw | Object store | Result |
|---|---|---|
| present | n/a | Fast path, no S3 traffic |
| missing | hit | Download, transform proceeds normally |
| missing | StorageNotFoundError | Return 0 cleanly (matches historical 'extract had 0 rows' contract) |
| missing | other exception | **Raise** — Temporal retries |

The last row is the critical behaviour change: a transient store error now fails loud rather than silently returning 0. The historical silent-0 there is exactly what caused the thirdbridge incident.

## Test plan

- [x] `tests/unit/templates/test_sql_app.py::TestTransformCrossWorkerFallback` — 6 new tests
  - local hit → no download call
  - local miss + store hit → hydrates and transforms (3 rows in/out)
  - local miss + store miss → returns 0, no entities.json written
  - local miss + transient error → raises ConnectionError
  - empty file from store → returns 0
  - object key shape matches the extract upload path
- [x] 2 existing 'no raw file' tests updated to mock the new download path
- [x] Full unit suite: 4327 → 4333 passing, 0 regressions
- [x] Pre-commit clean (ruff, ruff-format, isort, pyright)
- [x] Capability manifest regenerated

## Operational notes

The bug affects any v3 SDK SqlApp running with >1 worker replica. After this lands and a 3.12.0 release is cut, downstream apps (mysql-app, postgres, redshift, mssql, …) need to bump their pin to pick up the fix. Until then, the only customer-side mitigation is `replicas: 1` on the worker — pinning everything to a single pod sidesteps the scheduling drift.