### PR TITLE
feat(temporal): expose max_concurrent_workflow_tasks in create_worker [BLDX-1282]

### DIFF
--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -265,6 +265,7 @@ def create_worker(
     passthrough_modules: set[str] | None = None,
     service_name: str | None = None,
     max_concurrent_activities: int | None = None,
+    max_concurrent_workflow_tasks: int | None = None,
     graceful_shutdown_timeout_seconds: int | None = None,
     interceptors: list[TemporalInterceptor] | None = None,
     enable_pushgateway: bool = False,
@@ -293,6 +294,14 @@ def create_worker(
         passthrough_modules: Additional modules to pass through the sandbox.
         service_name: Service name for observability (traces/metrics).
         max_concurrent_activities: Maximum number of concurrent activity executions.
+        max_concurrent_workflow_tasks: Maximum number of in-flight workflow tasks
+            the worker will poll for at once. Each in-flight workflow task spins
+            up a workflow sandbox, so this also caps concurrent sandbox
+            initializations. Leave ``None`` to use Temporal's default. Set
+            explicitly when many short workflows trigger simultaneously (e.g. a
+            cron burst): excess sandboxes that can't reach activity-execution
+            progress trip Temporal's TMPRL1101 deadlock detector and bloat memory
+            via sandbox churn. The conservative pin is ``max_concurrent_activities``.
         graceful_shutdown_timeout_seconds: Seconds to allow in-flight activities to
             complete after SIGTERM before cancelling them.
         interceptors: Additional Temporal interceptors to register. Log /
@@ -474,6 +483,8 @@ def create_worker(
         max_heartbeat_throttle_interval=timedelta(seconds=10),
         graceful_shutdown_timeout=timedelta(seconds=graceful_shutdown_timeout_seconds),
     )
+    if max_concurrent_workflow_tasks is not None:
+        worker_kwargs["max_concurrent_workflow_tasks"] = max_concurrent_workflow_tasks
     if deployment_config is not None:
         worker_kwargs["deployment_config"] = deployment_config
 

--- a/tests/unit/execution/test_worker.py
+++ b/tests/unit/execution/test_worker.py
@@ -372,6 +372,50 @@ class TestCreateWorker:
 
         assert len(sandbox_configs) == 1
 
+    def test_max_concurrent_workflow_tasks_forwarded_when_set(self) -> None:
+        """When set, ``max_concurrent_workflow_tasks`` is forwarded to ``Worker(...)``."""
+
+        class _WFTaskCapApp(App):
+            async def run(self, input: _WorkerInput) -> _WorkerOutput:
+                return _WorkerOutput()
+
+        client = _make_mock_client()
+        captured: dict = {}
+
+        def capture_worker(*args, **kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        with mock.patch(
+            "application_sdk.execution._temporal.worker.Worker",
+            side_effect=capture_worker,
+        ):
+            create_worker(client, max_concurrent_workflow_tasks=1)
+
+        assert captured.get("max_concurrent_workflow_tasks") == 1
+
+    def test_max_concurrent_workflow_tasks_default_is_omitted(self) -> None:
+        """When ``None`` (default), the kwarg is not passed so Temporal's default applies."""
+
+        class _WFTaskDefaultApp(App):
+            async def run(self, input: _WorkerInput) -> _WorkerOutput:
+                return _WorkerOutput()
+
+        client = _make_mock_client()
+        captured: dict = {}
+
+        def capture_worker(*args, **kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        with mock.patch(
+            "application_sdk.execution._temporal.worker.Worker",
+            side_effect=capture_worker,
+        ):
+            create_worker(client)
+
+        assert "max_concurrent_workflow_tasks" not in captured
+
 
 class TestAppWorker:
     """Tests for AppWorker wrapper."""


### PR DESCRIPTION
## Discussion-first PR

This PR is opened **as a draft** to anchor the team discussion on the problem statement before locking in the implementation shape. The patch is intentionally minimal (2 LOC in ``create_worker``) and is only meant to make the conversation concrete.

- Linear: [BLDX-1282](https://linear.app/atlan-epd/issue/BLDX-1282/create-worker-expose-max-concurrent-workflow-tasks-for-sandbox)
- Related: [AUT-904](https://linear.app/atlan-epd/issue/AUT-904/upgrade-application-sdk-to-v3-for-automation-engine)

## Problem

Temporal's ``Worker(...)`` constructor accepts ``max_concurrent_workflow_tasks``, which caps the number of in-flight workflow tasks the worker will poll for at once. Each in-flight workflow task initializes a workflow sandbox, so this also caps concurrent sandbox initializations. SDK's ``create_worker`` does not forward this parameter, leaving callers stuck with Temporal's default.

Concrete consumer: Automation Engine (AUT-904) hit TMPRL1101 sandbox-deadlock-detection issues in production. When many cron workflows fire simultaneously, Temporal's default workflow-task concurrency initializes far more sandboxes than the worker has activity capacity to drain. Excess sandboxes sit idle, trip the deadlock detector after the configured timeout, and bloat resident memory via sandbox churn.

AE's empirically-determined fix: pin ``max_concurrent_workflow_tasks`` to match ``max_concurrent_activities`` (default 1 in production). This keeps the active sandbox count bounded by what the worker can actually drain. Today AE maintains a copy of SDK's ``create_worker`` (in ``automation_engine/clients/temporal.py``) just for this knob and one other (``extra_workflows`` — see [BLDX-1281](https://linear.app/atlan-epd/issue/BLDX-1281/create-worker-expose-extra-workflows-for-hand-rolled-workflowdefn)).

## Open questions for the team

1. Should this stay an opt-in caller knob (current shape) or should the SDK set a sensible default that matches ``max_concurrent_activities`` automatically?
2. Are there other deployments hitting TMPRL1101 in similar cron-burst scenarios that would benefit from the same control?
3. Any other Temporal ``Worker(...)`` kwargs the team thinks we should expose at the same time, while we're touching the signature?

## Summary of the proposed change

- Adds ``max_concurrent_workflow_tasks: int | None = None`` keyword-only param to ``create_worker``.
- When set, forwarded to ``Worker(...)``; when ``None`` (default), the kwarg is not passed and Temporal's default applies. Behavior unchanged for existing callers.

## Test plan

- [x] New unit tests in ``tests/unit/execution/test_worker.py``:
  - ``test_max_concurrent_workflow_tasks_forwarded_when_set`` — verifies the kwarg lands on ``Worker(...)``.
  - ``test_max_concurrent_workflow_tasks_default_is_omitted`` — verifies omission keeps Temporal's default.
- [x] All existing tests in ``tests/unit/execution/test_worker.py`` still pass (21 total).
- [x] ``uv run pre-commit run --files application_sdk/execution/_temporal/worker.py tests/unit/execution/test_worker.py`` — ruff, ruff-format, isort, pyright all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)