### PR TITLE
fix(observability): preserve correlation state on workflow replay

### DIFF
--- a/application_sdk/execution/_temporal/interceptors/log.py
+++ b/application_sdk/execution/_temporal/interceptors/log.py
@@ -221,11 +221,17 @@ class _LogWorkflowInboundInterceptor(WorkflowInboundInterceptor):
         return str(uuid4())
 
     async def execute_workflow(self, input: ExecuteWorkflowInput) -> Any:
-        # During Temporal replay the workflow code re-executes for determinism;
-        # observability events would double-count, so we skip everything.
-        if workflow.unsafe.is_replaying():
-            return await self.next.execute_workflow(input)
-
+        # State setup (ContextVars + interceptor-instance attrs) must run on
+        # every replay, not just the first execution: the outbound interceptor
+        # reads ``self._correlation_id`` / ``self._parent_*`` to inject
+        # ``x-correlation-id`` and ``atlan-parent-*`` headers on workflow-issued
+        # commands. A fresh worker that picks up an in-flight workflow rebuilds
+        # state by replaying history with ``is_replaying() == True``; if we
+        # short-circuit here, those instance attrs stay at their ``__init__``
+        # defaults and outbound commands issued post-replay lose the headers,
+        # breaking the correlation chain at child-workflow / activity calls.
+        # Only the side-effectful log emission (workflow.started /
+        # workflow.ended) is gated on ``is_replaying()`` to avoid double-count.
         info = workflow.info()
         parent = getattr(info, "parent", None)
         self._parent_workflow_id = (parent.workflow_id if parent else "") or ""
@@ -248,6 +254,9 @@ class _LogWorkflowInboundInterceptor(WorkflowInboundInterceptor):
         correlation_id = self._resolve_correlation_id(input)
         self._correlation_id = correlation_id
         set_correlation_context(CorrelationContext(correlation_id=correlation_id))
+
+        if workflow.unsafe.is_replaying():
+            return await self.next.execute_workflow(input)
 
         identity: dict[str, str | int | float] = {
             "temporal.workflow.id": info.workflow_id or "",

--- a/tests/unit/interceptors/test_log_interceptor.py
+++ b/tests/unit/interceptors/test_log_interceptor.py
@@ -181,11 +181,15 @@ class TestLogWorkflowInboundInterceptor:
     def interceptor(self, mock_next):
         return _LogWorkflowInboundInterceptor(mock_next)
 
-    async def test_skips_on_replay(self, interceptor, mock_next):
+    async def test_skips_log_emission_on_replay(self, interceptor, mock_next):
+        # On replay the lifecycle log lines must NOT be emitted (they would
+        # double-count workflow.started / workflow.ended across attempts).
         with patch(
             "application_sdk.execution._temporal.interceptors.log.workflow"
         ) as mock_wf:
             mock_wf.unsafe.is_replaying.return_value = True
+            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.memo.return_value = {}
             with patch(
                 "application_sdk.execution._temporal.interceptors.log.logger"
             ) as mock_logger:
@@ -193,6 +197,95 @@ class TestLogWorkflowInboundInterceptor:
 
         mock_logger.info.assert_not_called()
         mock_logger.error.assert_not_called()
+        # …but ``next.execute_workflow`` must still run so the wrapped workflow
+        # can replay its commands.
+        mock_next.execute_workflow.assert_awaited_once()
+
+    async def test_sets_correlation_id_on_replay_from_header(
+        self, interceptor, mock_next
+    ):
+        # Regression: a worker that picks up an in-flight workflow rebuilds
+        # state under is_replaying() == True. The interceptor must still
+        # resolve correlation_id (here from the header injected by the parent)
+        # and stash it on self so the outbound interceptor can re-inject it
+        # on workflow-issued commands during/after replay.
+        payload = _encode_header("inherited-corr-id")
+        headers = {"x-correlation-id": payload}
+
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = True
+            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.memo.return_value = {}
+            await interceptor.execute_workflow(
+                MockExecuteWorkflowInput(headers=headers)
+            )
+
+        assert interceptor._correlation_id == "inherited-corr-id"
+        ctx = get_correlation_context()
+        assert ctx is not None
+        assert ctx.correlation_id == "inherited-corr-id"
+
+    async def test_sets_correlation_id_on_replay_from_memo(
+        self, interceptor, mock_next
+    ):
+        # Continue-as-new path under replay: correlation_id comes from the
+        # workflow memo and must still land on self / the ContextVar.
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = True
+            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.memo.return_value = {"correlation_id": "memo-corr-id"}
+            await interceptor.execute_workflow(MockExecuteWorkflowInput())
+
+        assert interceptor._correlation_id == "memo-corr-id"
+
+    async def test_sets_parent_identity_on_replay(self, interceptor, mock_next):
+        # Outbound activity-header injection relies on self._parent_*; these
+        # must be populated on replay too.
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = True
+            mock_wf.info.return_value = MockWorkflowInfo(
+                parent=MockParentInfo(
+                    workflow_id="parent-wf-42", run_id="parent-run-42"
+                )
+            )
+            mock_wf.memo.return_value = {}
+            await interceptor.execute_workflow(MockExecuteWorkflowInput())
+
+        assert interceptor._parent_workflow_id == "parent-wf-42"
+        assert interceptor._parent_run_id == "parent-run-42"
+
+    async def test_outbound_injects_header_after_replay_setup(
+        self, interceptor, mock_next
+    ):
+        # End-to-end shape of the bug: after the inbound runs under replay,
+        # the outbound interceptor must still be able to inject the
+        # ``x-correlation-id`` header on a workflow-issued command.
+        payload = _encode_header("inherited-corr-id")
+        headers = {"x-correlation-id": payload}
+
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = True
+            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.memo.return_value = {}
+            await interceptor.execute_workflow(
+                MockExecuteWorkflowInput(headers=headers)
+            )
+
+        outbound = _LogWorkflowOutboundInterceptor(MagicMock(), interceptor)
+        injected = outbound._inject({})
+        assert "x-correlation-id" in injected
+        decoded = default_converter().payload_converter.from_payload(
+            injected["x-correlation-id"], type_hint=str
+        )
+        assert decoded == "inherited-corr-id"
 
     async def test_emits_workflow_started_log(self, interceptor):
         with patch(


### PR DESCRIPTION
## Summary

`_LogWorkflowInboundInterceptor.execute_workflow` had a single `is_replaying()` early-return at the top that skipped both side-effectful log emission **and** the deterministic state setup needed for outbound header injection.

A worker that picks up an in-flight workflow (sticky-cache miss, worker restart, rehydration) rebuilds state by replaying history with `is_replaying() == True`. With the early-return in place:

- `self._correlation_id` stayed at its `__init__` default (`""`)
- `self._parent_workflow_id` / `self._parent_run_id` stayed at `""`
- `set_correlation_context(...)` / `set_execution_context(...)` were never called

`_LogWorkflowOutboundInterceptor._inject` reads those instance attrs to decide whether to inject `x-correlation-id` / `atlan-parent-*` headers on workflow-issued commands. With all three empty, the guard returned headers unchanged — so any child workflow or activity issued during or after the replay went out un-tagged, fell through to `uuid4()` at priority 3 inside the child's inbound, and the correlation chain broke.

The legacy `CorrelationContextInterceptor` (deleted in #1573 / `2ccf34ec`) handled this correctly by virtue of not having a replay short-circuit at all — its only job was correlation propagation, which is deterministic and replay-safe.

## Fix

Move the `is_replaying()` gate down inside `execute_workflow` so it covers only the side-effectful log emission (`workflow.started` + the `try/finally` `workflow.ended` block with `time.monotonic_ns()` timing). All state setup above the gate now runs on every replay:

- `workflow.info()` read and parent-ID stashing
- `set_execution_context(ExecutionContext(...))`
- `_resolve_correlation_id(input)` → `self._correlation_id` assignment
- `set_correlation_context(CorrelationContext(...))`

These are all replay-safe (`workflow.info()`, `workflow.memo()`, `input.headers` reads + ContextVar sets + interceptor-instance attr assignments). The log emission stays gated because re-emitting `workflow.started` / `workflow.ended` per replay would double-count.

## Test plan

- [x] `uv run pytest tests/unit/interceptors/test_log_interceptor.py` — 42 passed
- [x] `uv run pytest tests/unit/interceptors/ tests/unit/observability/` — 395 passed, 1 skipped
- [x] `uv run pre-commit run --files <both files>` — ruff / ruff-format / isort / pyright clean
- [x] **New regression tests** — `tests/unit/interceptors/test_log_interceptor.py`:
  - `test_skips_log_emission_on_replay` (renamed from `test_skips_on_replay`) — preserves "no logs emitted on replay" assertion and additionally asserts `next.execute_workflow` is still awaited
  - `test_sets_correlation_id_on_replay_from_header` — header-inheritance path under replay
  - `test_sets_correlation_id_on_replay_from_memo` — continue-as-new memo path under replay
  - `test_sets_parent_identity_on_replay` — `self._parent_workflow_id` / `self._parent_run_id` populated under replay
  - `test_outbound_injects_header_after_replay_setup` — end-to-end: outbound `_inject` produces a non-empty `x-correlation-id` after an inbound pass under `is_replaying() == True`