### PR TITLE
fix: derive root correlation_id from workflow_id for replay determinism

### DIFF
--- a/application_sdk/execution/_temporal/interceptors/log.py
+++ b/application_sdk/execution/_temporal/interceptors/log.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import dataclasses
 import time
 from typing import TYPE_CHECKING, Any
-from uuid import uuid4
 
 from temporalio import activity, workflow
 from temporalio.converter import default as default_converter
@@ -217,8 +216,13 @@ class _LogWorkflowInboundInterceptor(WorkflowInboundInterceptor):
                 "Failed to read correlation header in workflow", exc_info=True
             )
 
-        # Priority 3: top-level workflow — generate a fresh correlation ID.
-        return str(uuid4())
+        # Priority 3: top-level workflow — derive correlation_id from the
+        # workflow_id. workflow.info().workflow_id is recorded in the
+        # workflow-execution-started history event and is therefore stable
+        # across replays of the same execution, unlike uuid4() which would
+        # mint a fresh value each replay and desync logs / outbound headers
+        # from the values recorded on the first run.
+        return workflow.info().workflow_id or ""
 
     async def execute_workflow(self, input: ExecuteWorkflowInput) -> Any:
         # State setup (ContextVars + interceptor-instance attrs) must run on

--- a/tests/unit/interceptors/test_log_interceptor.py
+++ b/tests/unit/interceptors/test_log_interceptor.py
@@ -425,20 +425,44 @@ class TestLogWorkflowInboundInterceptor:
         assert kwargs["failure.audience"] == "USER"
         assert kwargs["failure.code"] == "INVALID_INPUT"
 
-    async def test_generates_new_correlation_id_when_no_headers_no_memo(
+    async def test_derives_correlation_id_from_workflow_id_when_no_headers_no_memo(
         self, interceptor
     ):
+        # Priority 3 (top-level workflow, no memo, no header) must derive the
+        # correlation_id from workflow.info().workflow_id so it stays stable
+        # across replays — uuid4() would mint a fresh value on every replay
+        # and desync logs / outbound headers from the values recorded on the
+        # first run.
         with patch(
             "application_sdk.execution._temporal.interceptors.log.workflow"
         ) as mock_wf:
             mock_wf.unsafe.is_replaying.return_value = False
-            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.info.return_value = MockWorkflowInfo(workflow_id="wf-stable-42")
             mock_wf.memo.return_value = {}
             await interceptor.execute_workflow(MockExecuteWorkflowInput(headers={}))
 
-        assert interceptor._correlation_id != ""
-        # Should look like a UUID (36 chars with hyphens)
-        assert len(interceptor._correlation_id) == 36
+        assert interceptor._correlation_id == "wf-stable-42"
+
+    async def test_priority_3_is_stable_across_replays(self, mock_next):
+        # Two fresh interceptor instances simulating two worker pickups of
+        # the same execution (same workflow_id from history) must agree on
+        # the priority-3 correlation_id — once on first run, once on replay.
+        first = _LogWorkflowInboundInterceptor(mock_next)
+        second = _LogWorkflowInboundInterceptor(mock_next)
+
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.workflow"
+        ) as mock_wf:
+            mock_wf.info.return_value = MockWorkflowInfo(workflow_id="wf-stable-99")
+            mock_wf.memo.return_value = {}
+
+            mock_wf.unsafe.is_replaying.return_value = False
+            await first.execute_workflow(MockExecuteWorkflowInput(headers={}))
+
+            mock_wf.unsafe.is_replaying.return_value = True
+            await second.execute_workflow(MockExecuteWorkflowInput(headers={}))
+
+        assert first._correlation_id == second._correlation_id == "wf-stable-99"
 
     async def test_restores_correlation_id_from_memo(self, interceptor):
         with patch(


### PR DESCRIPTION
## Summary

Follow-up to #1791. `_resolve_correlation_id` priority 3 (top-level workflow with no memo and no inbound header) returned `str(uuid4())`. `uuid4()` is non-deterministic, so a root that hit priority 3 minted a *fresh* correlation_id every time the workflow was replayed (worker restart, sticky-cache eviction, rehydration). Effects:

- In-workflow `logger.info(...)` calls during replay tagged with the new id instead of the id recorded on the first run.
- New `start_child_workflow` / `start_activity` commands issued after replay injected the new id, so siblings of the same parent ended up with different correlation_ids depending on which run scheduled them.

Use `workflow.info().workflow_id` as the priority-3 fallback. The workflow_id is recorded in the workflow-execution-started history event at start time, so it's:

- **Stable across every replay** of the same execution.
- **Globally unique enough** to serve as a correlation id (Temporal scopes workflow_id within a namespace; collisions with another running workflow's id imply the user reused the id intentionally).
- **Free** — no extra entropy, no Temporal sandbox concern, no import.

Priority 1 (memo) and priority 2 (inherited header) are unchanged. In practice this path is mostly exercised by local-dev / ad-hoc starts — the automation-engine pins `x-correlation-id` on outbound, so connector roots inherit at priority 2.

## Test plan

- [x] `uv run pytest tests/unit/interceptors/test_log_interceptor.py` — 43 passed
- [x] `uv run pre-commit run --files <both files>` — ruff / ruff-format / isort / pyright clean
- [x] **Renamed existing test** `test_derives_correlation_id_from_workflow_id_when_no_headers_no_memo` (formerly `test_generates_new_correlation_id_when_no_headers_no_memo`) — asserts `interceptor._correlation_id == workflow.info().workflow_id` instead of the old 36-char UUID-shape assertion.
- [x] **New test** `test_priority_3_is_stable_across_replays` — two fresh interceptor instances simulating two worker pickups of the same execution (same `workflow_id` from history, one with `is_replaying=False`, one with `is_replaying=True`) agree on the priority-3 correlation_id.