### PR TITLE
fix(ci): publish skipped when unit-tests-gate is skipped

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -690,7 +690,7 @@ jobs:
   publish:
     name: Publish to Marketplace
     needs: [prepare, merge, security-scan]
-    if: inputs.publish
+    if: ${{ !failure() && !cancelled() && needs.prepare.result == 'success' && needs.merge.result == 'success' && needs.security-scan.result == 'success' && inputs.publish }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
## Summary

After DISTR-456 (#1774) landed on `main`, consumer apps that **haven't opted into the gate yet** (no `unit_tests_workflow_file` set) started seeing **`Publish to Marketplace` silently skipped** even though all upstream jobs (`prepare`, `build`, `merge`, `security-scan`) succeeded.

Real example: [atlan-bigquery-app run 26094894124](https://github.com/atlanhq/atlan-bigquery-app/actions/runs/26094894124) — every job green, but publish skipped and the version never reached the marketplace.

## Root cause

GitHub Actions' **implicit skip-propagation**. When a job's `if:` does not contain a status function (`success()`, `failure()`, `cancelled()`, `always()`, `!failure()`, etc.), GH applies the implicit `success()` check against the **entire transitive `needs:` chain** — not just direct needs. Any upstream `skipped` job (including transitive ancestors) causes the dependent job to skip too.

In the post-#1774 state:

| Job | `if:` | Handles skipped chain? |
|---|---|---|
| `prepare` | `!failure() && !cancelled()` | ✅ |
| `build` | `!failure() && !cancelled() && needs.prepare.result == 'success'` | ✅ |
| `merge` | `!failure() && !cancelled() && needs.build.result == 'success'` | ✅ |
| `security-scan` | `!failure() && !cancelled() && needs.merge.result == 'success'` | ✅ |
| `app-deployment-dispatcher` | `!failure() && !cancelled() && … && needs.security-scan.result == 'success' && …` | ✅ |
| **`publish`** | **`inputs.publish`** | ❌ — bare boolean, no status functions |

`publish` was the only downstream job using a bare `if:`. When `unit-tests-gate` skipped (its `if:` now includes `&& inputs.unit_tests_workflow_file != ''`), GH treated `publish`'s implicit success-of-chain check as failing and skipped it.

## Fix

Bring `publish`'s `if:` into the same shape as `app-deployment-dispatcher` — direct needs results checked explicitly, plus the `!failure() && !cancelled()` prefix that bypasses implicit cascade:

```diff
   publish:
     name: Publish to Marketplace
     needs: [prepare, merge, security-scan]
-    if: inputs.publish
+    if: ${{ !failure() && !cancelled() && needs.prepare.result == 'success' && needs.merge.result == 'success' && needs.security-scan.result == 'success' && inputs.publish }}
```

One-line change. Semantically equivalent in the happy path (all upstream success + publish=true → run). Only difference: explicit handling of skipped/failed chain ancestors.

## What this restores

For every consumer app that has *not yet* set `unit_tests_workflow_file`:
- `unit-tests-gate` is skipped (as designed — gate is opt-in)
- `publish` runs again (previously broken)
- Behaviour reverts to pre-#1774 publish flow until the consumer opts into the gate

For consumers that *have* set `unit_tests_workflow_file`:
- `unit-tests-gate` runs as designed
- On success → publish runs
- On failure → upstream chain fails → publish skipped via the explicit `success()` requirement (correct behaviour)

## Test plan

- [ ] Trigger build-and-publish on any consumer that doesn't set `unit_tests_workflow_file` (e.g. atlan-bigquery-app on a small no-op commit) → confirm `Publish to Marketplace` runs and the version registers in GM
- [ ] Trigger build-and-publish on atlan-clickhouse-app's `test/distr-456-gate-pilot` branch (which has `unit_tests_workflow_file` set) → confirm gate still runs and publish still gated on it