### PR TITLE
fix(ci): trailing dot after URL in unit-tests-gate annotation breaks the link

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -344,7 +344,7 @@ jobs:
             echo ""
             echo "**Currently warn-only — publish will proceed.** Once the enforcement-flip PR lands, this state will block publish. Fix the failing tests before then."
           } >> "${GITHUB_STEP_SUMMARY}"
-          echo "::warning title=Tests failed (warn-only)::${WORKFLOW_FILE} concluded as ${CONCLUSION}. See ${URL}. Publish proceeded; will block once enforcement lands."
+          echo "::warning title=Tests failed (warn-only)::${WORKFLOW_FILE} concluded as ${CONCLUSION}. Publish proceeded; will block once enforcement lands. See: ${URL}"
 
   # ── Job 1: Read atlan.yaml, validate secrets, compute all image tags ──────────
   prepare:


### PR DESCRIPTION
## Issue

The warn-only annotation in `unit-tests-gate` ends with:

```
::warning::… concluded as ${CONCLUSION}. See ${URL}. Publish proceeded; will block once enforcement lands.
```

The `.` immediately after `${URL}` is captured by most auto-linkers (Slack, terminals, browsers, GH Actions log viewer) and becomes part of the URL — every click 404s.

## Fix

Move `${URL}` to the end of the message after a `See:` label so there's no trailing punctuation.

```diff
-echo "::warning title=Tests failed (warn-only)::${WORKFLOW_FILE} concluded as ${CONCLUSION}. See ${URL}. Publish proceeded; will block once enforcement lands."
+echo "::warning title=Tests failed (warn-only)::${WORKFLOW_FILE} concluded as ${CONCLUSION}. Publish proceeded; will block once enforcement lands. See: ${URL}"
```

The step summary's `Failing run: ${URL}` line already has URL at end-of-line and isn't affected.

## Test plan

- [ ] Trigger a gate-fail run (e.g. atlan-clickhouse-app's existing test-failure pilot branch with the deliberate `assert False` test) → click the URL in the annotation → confirms the link resolves instead of 404