### PR TITLE
fix(observability): demote storage upload/download success logs to DEBUG

### DIFF
--- a/application_sdk/storage/ops.py
+++ b/application_sdk/storage/ops.py
@@ -413,7 +413,7 @@ async def upload_file(
 
     elapsed_ms = (time.monotonic() - started) * 1000.0
     _log_storage_event(
-        logging.INFO,
+        logging.DEBUG,
         "upload",
         key,
         outcome="success",
@@ -544,7 +544,7 @@ async def download_file(
 
     elapsed_ms = (time.monotonic() - started) * 1000.0
     _log_storage_event(
-        logging.INFO,
+        logging.DEBUG,
         "download",
         key,
         outcome="success",


### PR DESCRIPTION
## Summary

- `upload_file` and `download_file` success events were logged at `INFO`, generating constant noise in dev mode (and production) when apps flush artifacts on a tight loop
- Demoted both success paths to `DEBUG`; failure paths remain at `WARNING` (unchanged)

## Test plan

- [ ] Run app locally in dev mode — `storage.upload success` / `storage.download success` lines should no longer appear at default log level
- [ ] Confirm failure events still surface at `WARNING`
- [ ] Unit tests pass (`uv run python -m pytest tests/unit -x -q`)