### PR TITLE
fix(observability): resolve objectstore bindings once at exporter init

### DIFF
--- a/application_sdk/observability/_objectstore_metric_exporter.py
+++ b/application_sdk/observability/_objectstore_metric_exporter.py
@@ -12,12 +12,12 @@ collection.
 
 from __future__ import annotations
 
-import asyncio
 import gzip
 import os
 import posixpath
 from collections.abc import Sequence
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import orjson
@@ -51,6 +51,7 @@ from application_sdk.observability.observability import OBSERVABILITY_S3_PREFIX_
 from application_sdk.observability.utils import get_observability_dir
 
 if TYPE_CHECKING:
+    from obstore.store import ObjectStore
     from opentelemetry.sdk.metrics.export import HistogramDataPoint, NumberDataPoint
     from opentelemetry.sdk.resources import Resource
 
@@ -195,48 +196,6 @@ def _write_ndjson_gz(records: Sequence[dict[str, Any]], path: str) -> None:
             f.write(orjson.dumps(record) + b"\n")
 
 
-def _upload_sync(local_path: str, remote_key: str, timeout_s: float) -> None:
-    """Upload *local_path* to object stores, bridging async→sync.
-
-    Called from the ``PeriodicExportingMetricReader`` background thread,
-    which is not an asyncio thread.  We use ``asyncio.run()`` to drive
-    the async ``upload_file`` from a synchronous context.  The upload is
-    bounded by ``timeout_s`` so a hanging store never blocks the reader.
-    """
-
-    async def _upload() -> None:
-        from application_sdk.storage import (  # noqa: PLC0415 — deferred to break the observability→storage circular import
-            upload_file,
-        )
-        from application_sdk.storage.binding import (  # noqa: PLC0415 — deferred to break the observability→storage circular import
-            create_store_from_binding,
-        )
-
-        try:
-            store = create_store_from_binding(DEPLOYMENT_OBJECT_STORE_NAME)
-            await upload_file(remote_key, local_path, store=store)
-        except Exception:
-            logger.warning(
-                "ObjectStore metric upload to deployment store failed", exc_info=True
-            )
-
-        if ENABLE_ATLAN_UPLOAD:
-            try:
-                store = create_store_from_binding(UPSTREAM_OBJECT_STORE_NAME)
-                await upload_file(remote_key, local_path, store=store)
-            except Exception:
-                logger.warning(
-                    "ObjectStore metric upload to upstream store failed", exc_info=True
-                )
-
-    try:
-        asyncio.run(asyncio.wait_for(_upload(), timeout=timeout_s))
-    except TimeoutError:
-        logger.warning(
-            "ObjectStore metric upload timed out after %.1fs", timeout_s, exc_info=True
-        )
-
-
 class ObjectStoreMetricExporter(MetricExporter):
     """Exports OTel metrics as NDJSON.gz files to ObjectStore.
 
@@ -256,6 +215,32 @@ class ObjectStoreMetricExporter(MetricExporter):
             },
         )
         self._data_dir = data_dir or get_observability_dir()
+        self._deployment_store: ObjectStore | None = self._resolve_store(
+            DEPLOYMENT_OBJECT_STORE_NAME, "deployment"
+        )
+        self._upstream_store: ObjectStore | None = (
+            self._resolve_store(UPSTREAM_OBJECT_STORE_NAME, "upstream")
+            if ENABLE_ATLAN_UPLOAD
+            else None
+        )
+
+    def _resolve_store(self, name: str, label: str) -> ObjectStore | None:
+        from application_sdk.storage.binding import (  # noqa: PLC0415 — deferred to break the observability→storage circular import
+            create_store_from_binding,
+        )
+        from application_sdk.storage.errors import (  # noqa: PLC0415 — deferred to break the observability→storage circular import
+            StorageConfigError,
+        )
+
+        try:
+            return create_store_from_binding(name)
+        except StorageConfigError:
+            logger.warning(
+                "Object store '%s' not configured; %s metric upload disabled",
+                name,
+                label,
+            )
+            return None
 
     def export(
         self,
@@ -298,9 +283,23 @@ class ObjectStoreMetricExporter(MetricExporter):
             _write_ndjson_gz(records, local_path)
 
             try:
-                _upload_sync(local_path, remote_key, timeout_millis / 1000.0)
+                if self._deployment_store is not None:
+                    try:
+                        self._deployment_store.put(remote_key, Path(local_path))
+                    except Exception:
+                        logger.warning(
+                            "ObjectStore metric upload to deployment store failed",
+                            exc_info=True,
+                        )
+                if self._upstream_store is not None:
+                    try:
+                        self._upstream_store.put(remote_key, Path(local_path))
+                    except Exception:
+                        logger.warning(
+                            "ObjectStore metric upload to upstream store failed",
+                            exc_info=True,
+                        )
             finally:
-                # Always clean up local file
                 try:
                     os.unlink(local_path)
                 except OSError:

--- a/application_sdk/observability/_objectstore_metric_exporter.py
+++ b/application_sdk/observability/_objectstore_metric_exporter.py
@@ -216,17 +216,17 @@ class ObjectStoreMetricExporter(MetricExporter):
         )
         self._data_dir = data_dir or get_observability_dir()
         self._deployment_store: ObjectStore | None = (
-            self._resolve_store(DEPLOYMENT_OBJECT_STORE_NAME, "deployment")
+            self._resolve_store(DEPLOYMENT_OBJECT_STORE_NAME)
             if ENABLE_OBSERVABILITY_STORE_SINK
             else None
         )
         self._upstream_store: ObjectStore | None = (
-            self._resolve_store(UPSTREAM_OBJECT_STORE_NAME, "upstream")
+            self._resolve_store(UPSTREAM_OBJECT_STORE_NAME)
             if ENABLE_OBSERVABILITY_STORE_SINK and ENABLE_ATLAN_UPLOAD
             else None
         )
 
-    def _resolve_store(self, name: str, label: str) -> ObjectStore | None:
+    def _resolve_store(self, name: str) -> ObjectStore | None:
         from application_sdk.storage.binding import (  # noqa: PLC0415 — deferred to break the observability→storage circular import
             create_store_from_binding,
         )
@@ -238,16 +238,14 @@ class ObjectStoreMetricExporter(MetricExporter):
             return create_store_from_binding(name)
         except StorageConfigError:
             logger.warning(
-                "Object store '%s' not configured; %s metric upload disabled",
+                "Object store '%s' not configured; metric upload disabled",
                 name,
-                label,
             )
             return None
         except Exception:
             logger.warning(
-                "Object store '%s' setup failed; %s metric upload disabled",
+                "Object store '%s' setup failed; metric upload disabled",
                 name,
-                label,
                 exc_info=True,
             )
             return None

--- a/application_sdk/observability/_objectstore_metric_exporter.py
+++ b/application_sdk/observability/_objectstore_metric_exporter.py
@@ -215,12 +215,14 @@ class ObjectStoreMetricExporter(MetricExporter):
             },
         )
         self._data_dir = data_dir or get_observability_dir()
-        self._deployment_store: ObjectStore | None = self._resolve_store(
-            DEPLOYMENT_OBJECT_STORE_NAME, "deployment"
+        self._deployment_store: ObjectStore | None = (
+            self._resolve_store(DEPLOYMENT_OBJECT_STORE_NAME, "deployment")
+            if ENABLE_OBSERVABILITY_STORE_SINK
+            else None
         )
         self._upstream_store: ObjectStore | None = (
             self._resolve_store(UPSTREAM_OBJECT_STORE_NAME, "upstream")
-            if ENABLE_ATLAN_UPLOAD
+            if ENABLE_OBSERVABILITY_STORE_SINK and ENABLE_ATLAN_UPLOAD
             else None
         )
 
@@ -239,6 +241,14 @@ class ObjectStoreMetricExporter(MetricExporter):
                 "Object store '%s' not configured; %s metric upload disabled",
                 name,
                 label,
+            )
+            return None
+        except Exception:
+            logger.warning(
+                "Object store '%s' setup failed; %s metric upload disabled",
+                name,
+                label,
+                exc_info=True,
             )
             return None
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.12.0
-source-sha:    f6d8aa081514133f73996cac57711d10c8451325
-source-date:   2026-05-19T22:50:57+05:30
+sdk-version:   3.12.1
+source-sha:    eb24effade0c5ed17743ad1fa7a22385e5a0c7bf
+source-date:   2026-05-20T00:20:24+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/tests/unit/observability/test_objectstore_metric_exporter.py
+++ b/tests/unit/observability/test_objectstore_metric_exporter.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from unittest.mock import AsyncMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from opentelemetry.sdk.metrics import (
@@ -140,16 +140,15 @@ class TestExport:
         "application_sdk.observability._objectstore_metric_exporter.ENABLE_OBSERVABILITY_STORE_SINK",
         True,
     )
-    @patch(
-        "application_sdk.observability._objectstore_metric_exporter._upload_sync",
-    )
     def test_export_writes_ndjson_gz(
         self,
-        mock_upload: AsyncMock,
         provider: MeterProvider,
         in_memory_reader: InMemoryMetricReader,
         exporter: ObjectStoreMetricExporter,
     ) -> None:
+        mock_store = MagicMock()
+        exporter._deployment_store = mock_store
+
         meter = provider.get_meter("test")
         counter = meter.create_counter("export.test")
         counter.add(1, {"k": "v"})
@@ -160,10 +159,10 @@ class TestExport:
         from opentelemetry.sdk.metrics.export import MetricExportResult
 
         assert result == MetricExportResult.SUCCESS
-        assert mock_upload.called
+        assert mock_store.put.called
         # Verify the local file was cleaned up
-        local_path = mock_upload.call_args[0][0]
-        assert not os.path.exists(local_path)
+        uploaded_path = mock_store.put.call_args[0][1]
+        assert not os.path.exists(uploaded_path)
 
     @patch(
         "application_sdk.observability._objectstore_metric_exporter.ENABLE_OBSERVABILITY_STORE_SINK",
@@ -189,17 +188,16 @@ class TestExport:
         "application_sdk.observability._objectstore_metric_exporter.ENABLE_OBSERVABILITY_STORE_SINK",
         True,
     )
-    @patch(
-        "application_sdk.observability._objectstore_metric_exporter._upload_sync",
-        side_effect=Exception("upload boom"),
-    )
     def test_export_swallows_upload_failure(
         self,
-        mock_upload: AsyncMock,
         provider: MeterProvider,
         in_memory_reader: InMemoryMetricReader,
         exporter: ObjectStoreMetricExporter,
     ) -> None:
+        mock_store = MagicMock()
+        mock_store.put.side_effect = Exception("upload boom")
+        exporter._deployment_store = mock_store
+
         meter = provider.get_meter("test")
         counter = meter.create_counter("fail.test")
         counter.add(1)


### PR DESCRIPTION
## Summary

- `create_store_from_binding` was called on every export cycle (every 60s), scanning component YAML files from disk on each call. Stores are now resolved once in `ObjectStoreMetricExporter.__init__` via `_resolve_store`; a WARNING is logged once if a binding is missing, then the store is cached as `None` for the lifetime of the exporter.
- The async→sync bridge (`asyncio.run` wrapping `upload_file` inside `_upload_sync`) is removed entirely. `PeriodicExportingMetricReader` is a standard OTel component that calls `export()` from its own synchronous background thread — `store.put(key, Path(path))` (obstore's native sync API) is the correct fit and requires no event-loop machinery.
- Metric files are kilobytes in size (delta temporality + gzip compression), well below any multipart threshold, so `store.put` is safe.

## Background

This was surfaced by a repeating `WARNING … ObjectStore metric upload to deployment store failed [AAF-STR-003]` log in local dev (no `objectstore` Dapr component configured). The root cause was `f76098c9` fixing the reader temporality, which unmasked a pre-existing issue: the store binding was re-probed on every 60s export tick rather than at startup. Confirmed safe via kubectl: component YAMLs are written by an initContainer (`atlan-env-seeder`) that must complete before the main container starts, so bindings are always present at Python startup in deployed environments.

## Test plan

- [ ] All existing unit tests pass (`uv run python -m pytest tests/unit -x -q`)
- [ ] `uv run pre-commit run --all-files` clean
- [ ] Run hello-world app locally — confirm the repeating WARNING no longer appears