### PR TITLE
fix: read correlation_id from workflow args as back-compat priority

### DIFF
--- a/application_sdk/execution/_temporal/interceptors/log.py
+++ b/application_sdk/execution/_temporal/interceptors/log.py
@@ -217,7 +217,29 @@ class _LogWorkflowInboundInterceptor(WorkflowInboundInterceptor):
                 "Failed to read correlation header in workflow", exc_info=True
             )
 
-        # Priority 3: top-level workflow — generate a fresh correlation ID.
+        # Priority 3: legacy args-based propagation. The pre-v3
+        # CorrelationContextInterceptor read ``correlation_id`` from the
+        # first workflow argument when it was a dict; many existing callers
+        # (notably the automation-engine on SDK 2.8.7) still rely on this
+        # convention and have no way to inject memo / header on workflow
+        # start. Reading args here keeps those callers' correlation chains
+        # intact without forcing each one to migrate immediately. Falls
+        # through silently for typed-arg workflows (Pydantic models,
+        # dataclasses, primitives) — those callers should use memo / header
+        # at start time, which are the preferred channels.
+        try:
+            if input.args:
+                first = input.args[0]
+                if isinstance(first, dict):
+                    cid = first.get("correlation_id")
+                    if cid:
+                        return str(cid)
+        except Exception:
+            logger.warning(
+                "Failed to read correlation_id from workflow args", exc_info=True
+            )
+
+        # Priority 4: top-level workflow — generate a fresh correlation ID.
         return str(uuid4())
 
     async def execute_workflow(self, input: ExecuteWorkflowInput) -> Any:

--- a/tests/unit/interceptors/test_log_interceptor.py
+++ b/tests/unit/interceptors/test_log_interceptor.py
@@ -451,6 +451,101 @@ class TestLogWorkflowInboundInterceptor:
 
         assert interceptor._correlation_id == "memo-id-123"
 
+    async def test_reads_correlation_id_from_args_when_no_memo_no_headers(
+        self, interceptor
+    ):
+        # Legacy args-based propagation: pre-v3 CorrelationContextInterceptor
+        # (still in use on SDK 2.8.7 callers like the automation-engine) puts
+        # correlation_id in the first arg dict. Priority 3 must surface it so
+        # the chain stays intact without forcing every caller to migrate to
+        # memo / header on start_workflow.
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = False
+            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.memo.return_value = {}
+            await interceptor.execute_workflow(
+                MockExecuteWorkflowInput(
+                    headers={}, args=[{"correlation_id": "from-args-id"}]
+                )
+            )
+
+        assert interceptor._correlation_id == "from-args-id"
+
+    async def test_args_correlation_id_is_lower_priority_than_memo(self, interceptor):
+        # Memo wins over args — memo is the explicit / preferred channel.
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = False
+            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.memo.return_value = {"correlation_id": "memo-wins"}
+            await interceptor.execute_workflow(
+                MockExecuteWorkflowInput(
+                    headers={}, args=[{"correlation_id": "args-loses"}]
+                )
+            )
+
+        assert interceptor._correlation_id == "memo-wins"
+
+    async def test_args_correlation_id_is_lower_priority_than_header(self, interceptor):
+        # Header wins over args — header is the explicit / preferred channel
+        # for child-workflow inheritance.
+        payload = _encode_header("header-wins")
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = False
+            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.memo.return_value = {}
+            await interceptor.execute_workflow(
+                MockExecuteWorkflowInput(
+                    headers={"x-correlation-id": payload},
+                    args=[{"correlation_id": "args-loses"}],
+                )
+            )
+
+        assert interceptor._correlation_id == "header-wins"
+
+    async def test_falls_through_args_when_first_arg_is_not_a_dict(self, interceptor):
+        # Typed args (Pydantic model, dataclass, primitive) are skipped
+        # silently — those callers should use memo / header. Verifies we
+        # fall through to the uuid4 fallback instead of crashing.
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = False
+            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.memo.return_value = {}
+            await interceptor.execute_workflow(
+                MockExecuteWorkflowInput(headers={}, args=["just-a-string"])
+            )
+
+        assert interceptor._correlation_id != ""
+        assert interceptor._correlation_id != "just-a-string"
+        # Falls back to the priority-4 uuid4 path.
+        assert len(interceptor._correlation_id) == 36
+
+    async def test_falls_through_args_when_dict_lacks_correlation_id_key(
+        self, interceptor
+    ):
+        # Dict args without the magic key fall through cleanly to uuid4
+        # rather than raising or returning an empty string.
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = False
+            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.memo.return_value = {}
+            await interceptor.execute_workflow(
+                MockExecuteWorkflowInput(
+                    headers={}, args=[{"workflow_id": "wf-1", "other": "field"}]
+                )
+            )
+
+        assert len(interceptor._correlation_id) == 36
+
     async def test_reads_correlation_id_from_header(self, interceptor):
         payload = _encode_header("header-corr-id")
         headers = {"x-correlation-id": payload}


### PR DESCRIPTION
## Summary

`_resolve_correlation_id` in the v3 `LogInterceptor` only checks memo (priority 1) and Temporal headers (priority 2) before falling through to `uuid4()`. Pre-v3 callers — notably the **automation-engine on SDK 2.8.7** — propagate `correlation_id` by putting it in the workflow's first arg dict, the convention enforced by the legacy `CorrelationContextInterceptor`. Those callers have no easy way to migrate every workflow-start site to memo / header overnight, so AE-launched v3 connector workflows hit the `uuid4()` fallback and end up with a fresh `correlation_id`, breaking the end-to-end chain from AE's `workflow_run_guid` through to connector logs.

This PR adds a priority-3 args-reading step. The new priority order is:

| Priority | Source | Notes |
|---|---|---|
| 1 | `workflow.memo()["correlation_id"]` | continue-as-new restoration |
| 2 | `input.headers["x-correlation-id"]` (or `correlation_id` legacy) | child-workflow inheritance, OTel-aligned |
| **3 (NEW)** | `input.args[0]["correlation_id"]` if `args[0]` is a dict | back-compat with the SDK 2.8.7 args convention |
| 4 | `uuid4()` | top-level fallback (becomes deterministic per #1793 when merged) |

Falls through silently for typed arg shapes (Pydantic models, dataclasses, primitives) and for dicts lacking the key, so it cannot regress typed-contract workflows.

## Why both memo *and* args

Memo and header remain the preferred, explicit, OTel-aligned propagation channels and outrank args. Args at priority 3 is the safety net for the existing ecosystem of callers that follow the 2.8.7 convention — closes the AE → SDK-v3-connector gap today without requiring a coordinated patch across every consumer's workflow-start sites. New code on v3 should still use memo / header.

The companion AE-side PR (in `atlan-automation-engine-app`) will add `memo={"correlation_id": ...}` on every workflow-start site so AE eventually uses the preferred channel. Once that lands, this priority-3 args path becomes a quiet safety net rather than the load-bearing route.

## Test plan

- [x] `uv run pytest tests/unit/interceptors/test_log_interceptor.py` — 47 passed
- [x] `uv run pre-commit run --files <both files>` — ruff / ruff-format / isort / pyright clean
- [x] **Five new tests** in `tests/unit/interceptors/test_log_interceptor.py`:
  - `test_reads_correlation_id_from_args_when_no_memo_no_headers` — happy path
  - `test_args_correlation_id_is_lower_priority_than_memo` — memo wins
  - `test_args_correlation_id_is_lower_priority_than_header` — header wins
  - `test_falls_through_args_when_first_arg_is_not_a_dict` — string arg → uuid4 fallback
  - `test_falls_through_args_when_dict_lacks_correlation_id_key` — dict without key → uuid4 fallback

## Related

- #1791 (merged) — preserved correlation state on replay
- #1793 (open) — derives root correlation_id from `workflow_id` instead of `uuid4()`; complements this PR (this fixes priority 3, that fixes the final fallback)
- Companion PR in `atlan-automation-engine-app` to follow: AE-side `memo={"correlation_id": ...}` on workflow starts