### PR TITLE
fix: extend args-reading to typed Input objects (Pydantic / dataclass)

### DIFF
--- a/application_sdk/execution/_temporal/interceptors/log.py
+++ b/application_sdk/execution/_temporal/interceptors/log.py
@@ -223,17 +223,42 @@ class _LogWorkflowInboundInterceptor(WorkflowInboundInterceptor):
         # (notably the automation-engine on SDK 2.8.7) still rely on this
         # convention and have no way to inject memo / header on workflow
         # start. Reading args here keeps those callers' correlation chains
-        # intact without forcing each one to migrate immediately. Falls
-        # through silently for typed-arg workflows (Pydantic models,
-        # dataclasses, primitives) — those callers should use memo / header
-        # at start time, which are the preferred channels.
+        # intact without forcing each one to migrate immediately.
+        #
+        # Three shapes covered, in order:
+        #   1. ``args[0]`` is a ``dict`` → ``correlation_id`` key. Plain
+        #      dict-shaped configs (AE 2.8.7, scripted starts, tests).
+        #   2. ``args[0]`` is a typed object (Pydantic model, dataclass,
+        #      namespace) with a ``correlation_id`` attribute. Catches v3
+        #      SDK-generated workflow wrappers whose ``run(input: Input)``
+        #      converted the caller's dict into a typed Input before the
+        #      interceptor was called.
+        #   3. ``args[0]`` is a Pydantic v2 model with ``extra='allow'`` and
+        #      ``correlation_id`` ended up in ``__pydantic_extra__`` because
+        #      the field wasn't declared on the model. Pydantic still
+        #      preserves it on the instance even though it's not a typed
+        #      attribute.
+        #
+        # Falls through silently for any other shape — primitives, models
+        # without the field and ``extra='ignore'`` (default), etc. Those
+        # callers should use memo / header at start time, which are the
+        # preferred OTel-aligned channels.
         try:
             if input.args:
                 first = input.args[0]
+                cid: str | None = None
                 if isinstance(first, dict):
                     cid = first.get("correlation_id")
-                    if cid:
-                        return str(cid)
+                else:
+                    raw = getattr(first, "correlation_id", None)
+                    if not raw:
+                        extras = getattr(first, "__pydantic_extra__", None)
+                        if isinstance(extras, dict):
+                            raw = extras.get("correlation_id")
+                    if raw:
+                        cid = str(raw)
+                if cid:
+                    return str(cid)
         except Exception:
             logger.warning(
                 "Failed to read correlation_id from workflow args", exc_info=True

--- a/tests/unit/interceptors/test_log_interceptor.py
+++ b/tests/unit/interceptors/test_log_interceptor.py
@@ -546,6 +546,74 @@ class TestLogWorkflowInboundInterceptor:
 
         assert len(interceptor._correlation_id) == 36
 
+    async def test_reads_correlation_id_from_typed_object_with_attr(self, interceptor):
+        # Real-world v3 case: the SDK-generated workflow wrapper takes a
+        # typed ``Input`` instance (Pydantic model / dataclass / namespace).
+        # args[0] reaches the interceptor as that typed object, not a dict.
+        # We must still find correlation_id via attribute access.
+        @dataclass
+        class TypedInput:
+            workflow_id: str = "wf-1"
+            correlation_id: str = "from-typed-input"
+
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = False
+            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.memo.return_value = {}
+            await interceptor.execute_workflow(
+                MockExecuteWorkflowInput(headers={}, args=[TypedInput()])
+            )
+
+        assert interceptor._correlation_id == "from-typed-input"
+
+    async def test_reads_correlation_id_from_pydantic_extra_bag(self, interceptor):
+        # Pydantic v2 models with ``model_config = ConfigDict(extra='allow')``
+        # stash undeclared fields on ``__pydantic_extra__``. The caller-supplied
+        # ``correlation_id`` lives there when the model doesn't declare it as
+        # a field. Cover that bag too.
+        class FakeExtraBagModel:
+            def __init__(self):
+                # No declared correlation_id attribute — only on the extras
+                # dict. ``getattr(self, 'correlation_id', None)`` returns None.
+                self.__pydantic_extra__ = {"correlation_id": "from-extras-bag"}
+
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = False
+            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.memo.return_value = {}
+            await interceptor.execute_workflow(
+                MockExecuteWorkflowInput(headers={}, args=[FakeExtraBagModel()])
+            )
+
+        assert interceptor._correlation_id == "from-extras-bag"
+
+    async def test_falls_through_typed_object_without_correlation_id(self, interceptor):
+        # Typed object that genuinely has no correlation_id (no attribute
+        # declared, no pydantic extras bag) falls through to priority 4.
+        # Common case: v3 workflows whose Input contract doesn't carry the
+        # correlation field at all — those callers should use memo / header.
+        @dataclass
+        class TypedInputWithoutCorrId:
+            workflow_id: str = "wf-1"
+            some_other_field: int = 42
+
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = False
+            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.memo.return_value = {}
+            await interceptor.execute_workflow(
+                MockExecuteWorkflowInput(headers={}, args=[TypedInputWithoutCorrId()])
+            )
+
+        # uuid4 fallback — 36 chars with hyphens.
+        assert len(interceptor._correlation_id) == 36
+
     async def test_reads_correlation_id_from_header(self, interceptor):
         payload = _encode_header("header-corr-id")
         headers = {"x-correlation-id": payload}


### PR DESCRIPTION
## Summary

Follow-up to #1802 (merged). Live trace on a tenant running the post-#1802 SDK showed the args-reading path still fell through to priority-4 \`uuid4()\` for automation-engine-launched connector workflows: child \`correlation_id\` became a fresh uuid4 instead of the parent's \`workflow_run_guid\`.

## Root cause

The SDK-generated workflow wrapper (one per app/entrypoint pair, registered as \`<app>:<entrypoint>\` — e.g. \`teradata-app:crawler\`) is the workflow that actually receives caller args. Its \`run()\` signature is:

\`\`\`python
async def _run(self, input_data: Input) -> Output:
\`\`\`

where \`Input\` is the entrypoint's declared typed contract. By the time \`LogInterceptor.execute_workflow\` receives \`ExecuteWorkflowInput\`, \`input.args[0]\` is the deserialized typed object, **not** the dict the caller (AE) sent on the wire. #1802's \`isinstance(first, dict)\` check silently skips that shape.

End-to-end mismatch observed on tenant \`cusucwap04\`:

| Stage | correlation_id |
|---|---|
| AE workflow body (\`workflow_run_guid\`) | \`c384e46a-9de9-4425-809d-b833ceb80ab6\` |
| Wire payload (\`child_args[\"correlation_id\"]\`) | \`c384e46a-9de9-4425-809d-b833ceb80ab6\` |
| Connector \`workflow.started\` (deserialized) | **\`aad97b84-889a-4964-afd1-84f11d67f7c5\`** (fresh uuid4) |

## Fix

Extend the priority-3 reader to cover three input shapes, in order:

1. \`dict\` — existing behaviour. AE 2.8.7 callers, scripted starts, tests.
2. **Typed object with declared \`correlation_id\` field** — read via \`getattr\`. Pydantic models, dataclasses, namespaces, any object the converter built from the caller's dict that preserved the field.
3. **Pydantic v2 \`__pydantic_extra__\` bag** — for models configured with \`extra='allow'\` whose Input contract doesn't declare \`correlation_id\` but Pydantic preserved it on the extras bag.

Genuinely-typeless inputs (primitives, models with \`extra='ignore'\` and no declared field) still fall through to priority 4. Memo / header remain the explicit, OTel-aligned channels for those cases.

## Test plan

- [x] \`uv run pytest tests/unit/interceptors/test_log_interceptor.py\` — 50 passed (3 new)
- [x] \`uv run pre-commit run --files <both files>\` — ruff / ruff-format / isort / pyright clean
- [x] **Three new tests** in \`tests/unit/interceptors/test_log_interceptor.py\`:
  - \`test_reads_correlation_id_from_typed_object_with_attr\` — dataclass with declared \`correlation_id\` field is read via getattr
  - \`test_reads_correlation_id_from_pydantic_extra_bag\` — \`__pydantic_extra__\` bag fallback works when no declared attribute
  - \`test_falls_through_typed_object_without_correlation_id\` — typed object without the field cleanly falls through to uuid4

## Related

- #1802 (merged) — initial priority-3 args-reading for dict args
- #1791 (merged) — preserved correlation state on workflow replay