### PR TITLE
chore(sdk-review): 2026-05-20 retro — rules stacked on #1485 (base = sdk-mothership-migration)

### DIFF
--- a/.mothership/pr-review/references/code-quality-rules.md
+++ b/.mothership/pr-review/references/code-quality-rules.md
@@ -76,6 +76,188 @@ logger.info("Processing " + str(count) + " records")
 logger.info("Processing %d records", count)
 ```
 
+## Retro Learnings — 2026-05-20
+
+> Each subsection is a generalized rule. Concrete incidents that
+> surfaced the rule are recorded in `retro-2026-05-20.md`.
+
+### Exception chains must preserve the cause with `from exc` (Critical)
+
+When raising a new exception from inside an `except` block, the
+`raise NewError(...) from exc` form preserves the original exception
+in `__cause__`. Dropping `from exc` produces a `During handling of
+the above exception, another exception occurred` traceback that
+hides the original cause and breaks our error-classification
+pipeline (the wire-format `cause` field is empty). Pre-commit
+doesn't reliably catch this — the reviewer must.
+
+**Flag any new code that:**
+- Has a `raise X(...)` inside an `except Y as exc:` block without
+  `from exc` (or `from None` if intentionally suppressing).
+- Re-raises after wrapping: `raise NewError("...")` where the
+  outer `try/except` clearly catches the cause.
+- Uses `raise X(...) from None` without an inline comment
+  justifying the suppression (rare; usually a bug).
+
+**Detection heuristic:** for every `raise <ExceptionName>(` added on
+a line inside an `except ... as <name>:` block (i.e. the diff shows
+a `raise` indented under an `except`), the same statement must
+include `from <name>` (the captured exception, or `None` if
+documented).
+
+**Replacement:**
+
+```python
+# BAD
+try:
+    do_work()
+except ValueError as exc:
+    raise PreconditionError("operation precondition failed")
+
+# GOOD
+try:
+    do_work()
+except ValueError as exc:
+    raise PreconditionError("operation precondition failed") from exc
+```
+
+**Severity:** Critical. A broken exception chain destroys
+debuggability and silently zeros out the error-taxonomy `cause`
+field consumers depend on.
+
+### Suppression comments require an inline justification (Important)
+
+`# noqa`, `# type: ignore`, `# pylint: disable`, `# mypy: ignore`,
+`# pragma: no cover` all bypass a quality gate. A bare suppression
+silently disables the check; an inline justification ("# noqa: PLC0415
+— lazy import: heavy dependency") preserves the decision history and
+the next reader can validate it.
+
+**Flag any new suppression comment that:**
+- Lacks a same-line rationale after the directive: bare `# noqa`,
+  `# noqa: E501` (no reason), `# type: ignore` (no reason).
+- Disables a category broadly when the actual issue is local:
+  blanket `# noqa` instead of `# noqa: <specific-code>`.
+- Adds `# pragma: no cover` on production code paths (acceptable
+  for `if TYPE_CHECKING:` blocks or `__main__` guards; suspicious
+  anywhere else).
+
+**Required form:**
+
+```python
+# Acceptable
+import duckdb  # noqa: PLC0415 — lazy import: heavy dependency
+result: Any  # type: ignore[no-any-return] — upstream library returns dict
+
+# Reject
+import duckdb  # noqa
+result: Any  # type: ignore
+```
+
+**Severity:** Important. The suppression itself isn't a bug, but
+silent suppressions accumulate and degrade the value of the
+underlying gate.
+
+### Tunables and identifiers belong in `constants.py` (Important)
+
+User-visible metric names, log/trace attribute prefixes, service
+names, and numeric tunables (sample intervals, batch sizes, retry
+backoffs, timeouts) MUST live in `application_sdk/constants.py`
+sourced from `ATLAN_`-prefixed env vars with documented defaults.
+Inline values can't be overridden by operators and tend to drift
+when copies appear in multiple call sites.
+
+**Flag any new code that:**
+- Hard-codes a string used as a metric/trace/log attribute name or
+  prefix (`"application.custom"`, service names, namespace prefixes)
+  in a module other than `constants.py`.
+- Hard-codes a numeric tunable (timeout, interval, batch size,
+  retry/backoff parameter) in a module other than `constants.py`.
+- Defines the same default value inline at the use site that
+  already exists in `constants.py` — pick one; it should be the
+  `constants.py` import.
+
+**Expected pattern:** the constant is defined once in `constants.py`
+with `os.getenv("ATLAN_<NAME>", "<default>")` and imported at every
+use site.
+
+### Exhaust enum variants when matching state (Important)
+
+When matching on an `Enum`, status string, or other discriminator
+with a known fixed set of values, the branch chain must either
+handle every variant explicitly or use a default branch that
+records the unhandled value (typically a `WARNING` log plus an
+`unknown` bucket on the relevant metric). Silent under-coverage
+shows up as dashboards that mislabel real transitions and metrics
+that under-count.
+
+**Flag any new code that:**
+- Has an `if x == A elif x == B` chain over a known `Enum` /
+  status set without exhausting the variants or providing a default
+  branch.
+- Uses `match` / `case` against an `Enum` without a `case _:`.
+- Introduces a metric or log attribute labelled by an enum value
+  but only emits a subset of the enum's variants.
+
+**Detection heuristic:** when a new branch over a `Status`-shaped
+value appears, find the enum/source-of-truth declaration and compare
+the branches against the variants. Any missing variant without an
+explicit default is a finding.
+
+### Don't wrap upstream APIs in single-purpose helpers (Minor)
+
+Thin wrappers around upstream APIs that only rename without adding
+type safety, validation, defaults, retries, or any other behaviour
+are net negative — they add a maintenance burden, hide the upstream
+documentation, and force every consumer to learn two names for the
+same thing.
+
+**Flag any new helper module that:**
+- Re-exports an upstream API surface (OpenTelemetry, httpx,
+  temporalio, pydantic, etc.) with one-line wrapper functions whose
+  body is essentially the upstream call.
+- Adds a `def record_*` / `def emit_*` / `def get_*` that only
+  calls the upstream client with no other logic.
+
+Prefer exposing the upstream object directly and letting callers
+use the native API. Add a wrapper only when it provides typed
+arguments, default labels, retries, deadlines, validation, or other
+real value beyond renaming.
+
+**Severity:** Minor. Suggest removal; do not block.
+
+### Log exceptions with `exc_info`, never via formatted strings (Important)
+
+The structured way to capture an exception traceback in a log call
+is `logger.error(msg, exc_info=True)` or `logger.exception(msg)`.
+Doing this manually — formatting `str(exc)` / `repr(exc)` /
+`traceback.format_exc()` into the message string — defeats Loki/
+Grafana's structured indexing, loses the structured `exception.*`
+attributes, and forces operators to grep raw text rather than query
+fields.
+
+**Flag any new log call that:**
+- Builds a string that includes `str(exc)`, `repr(exc)`,
+  `f"{exc}"`, or any pattern that drops the traceback into the
+  message body, instead of passing the exception via `exc_info`.
+- Calls `traceback.format_exc()` and concatenates the result into a
+  log message.
+- Logs an exception inside an `except` block without `exc_info=True`
+  or using `logger.exception(...)`.
+
+**Expected pattern:**
+
+```python
+try:
+    do_work()
+except SomeError as exc:
+    logger.error("operation failed", exc_info=True)  # or:
+    logger.exception("operation failed")  # implies exc_info=True
+```
+
+**Severity:** Important (QUAL + DX). Mis-logged exceptions are
+debugger-quality regressions that compound over the codebase.
+
 ### No % Formatting Inline in Log Calls (G001)
 
 ```python

--- a/.mothership/pr-review/references/dx-rules.md
+++ b/.mothership/pr-review/references/dx-rules.md
@@ -225,3 +225,169 @@ Flag:
 - Removed or renamed mock class without deprecation shim
 - Changed fixture signature without backward-compatible default
 - New mock that doesn't follow `Mock{ServiceName}` naming convention
+
+---
+
+## Retro Learnings — 2026-05-20
+
+> Each subsection is a generalized rule. Concrete incidents that
+> surfaced the rule are recorded in `retro-2026-05-20.md`.
+
+### Env-var lifecycle: prefix, removal warnings, doc updates (Important)
+
+`application_sdk` env vars are part of the deployment contract:
+operators set them in Helm values, App Foundation reads them from
+ConfigMaps. Renaming or removing one without a fallback breaks
+deploys silently. Adding one without `ATLAN_` prefix breaks the
+naming convention operators rely on for grep/audit.
+
+**Flag any new code that:**
+- Adds an `os.getenv(...)` / `os.environ[...]` / `Settings` field
+  reading an env var that is NOT prefixed with `ATLAN_`. Exceptions:
+  standard ecosystem vars (`OTEL_*`, `DAPR_*`, `KUBERNETES_*`,
+  `HOME`, `PATH`).
+- Renames an existing env var (changes the string literal) without
+  appending the old name to `_REMOVED_ENV_VARS` in
+  `application_sdk/constants.py` (so users get a startup warning
+  pointing at the new name).
+- Removes an env var (deletes the read call) without the same
+  `_REMOVED_ENV_VARS` entry.
+- Adds a new env var without an accompanying line in
+  `docs/standards/env-vars.md` documenting purpose, default, and
+  who sets it.
+
+**Detection heuristic:** for each new `os.getenv(` / `os.environ[`
+in the diff, check (a) the string literal starts with `ATLAN_` (or
+is on the allowed-ecosystem list); (b) if a same-file removal of an
+old env-var literal is also present, `_REMOVED_ENV_VARS` was
+updated; (c) `docs/standards/env-vars.md` has a touch in the diff.
+
+**Severity:** Important. Silent rename/removal breaks production
+rollouts; the `_REMOVED_ENV_VARS` mechanism exists precisely so the
+user sees a warning instead of running with stale config.
+
+### Private-module imports from app code are forbidden (Critical)
+
+Anything under a `_`-prefixed module (`_temporal/`, `_dapr/`,
+`_redis/`, etc.) is private to the SDK. Connector developers and
+app code MUST import only through the public-protocol surface
+(`application_sdk.execution`, `application_sdk.infrastructure`,
+etc.). Direct imports from private modules couple consumers to
+implementation details and prevent the SDK from refactoring them.
+
+**Flag any new import in the diff that:**
+- Matches `from application_sdk\.[a-z_]+\._[a-z_]+(\.[a-z_]+)*` —
+  i.e., reaches into a `_`-prefixed package or module from outside.
+- Imports `temporalio.*`, `dapr.*`, `redis.*` directly anywhere
+  outside the corresponding `_temporal/`, `_dapr/`, `_redis/`
+  directories.
+- Imports a symbol whose name starts with `_` from a non-`_`
+  package (private symbol leaking through a public module).
+
+**Diff-grep heuristic:**
+
+```bash
+git diff origin/main...HEAD -- '*.py' | \
+  grep -E '^\+from application_sdk\.[a-z_]+\._[a-z_]+'
+git diff origin/main...HEAD -- '*.py' | \
+  grep -E '^\+(from|import) (temporalio|dapr|redis)\b' | \
+  grep -vE '_temporal|_dapr|_redis'
+```
+
+Both should be empty. Any hit is a Critical finding.
+
+**Severity:** Critical (ARCH). Restates ADR-0005 with a concrete
+detection method because PRs keep slipping past the general rule.
+
+### Conventional Commits prefix must match diff scope (Critical)
+
+The prefix on the PR title becomes the merge-squash commit message
+and feeds `release-please`. A mismatched prefix ships the wrong
+version number — major-bumping for nothing, minor-bumping for CI-only
+content, or burying a real break behind `fix:`.
+
+**For every PR, check the prefix against the diff content:**
+
+| Prefix | Required evidence in the diff (else flag mismatch) |
+|---|---|
+| `feat!:` / `BREAKING CHANGE:` footer | At least one developer-facing public-API break: removed/renamed export in `__init__.py`'s `__all__`, removed/renamed public class or function, removed/renamed/retyped field on a public Input/Output contract, removed deprecation shim. If none → flag "drop the `!` or document the specific break in a `BREAKING CHANGE:` footer." |
+| `feat:` | At least one new public capability — new export, new public method, new env-var-controlled behavior, new entry point. If the diff is purely under `.github/`, build config, or otherwise non-shipping → flag "this is not a feature; pick `ci:` / `build:` / `chore:`." |
+| `fix:` | A code change that resolves a defect (logic change, missing case, race condition). Pure refactor with no behavior change → flag "use `refactor:`." |
+| `ci:` / `build:` | Only files under `.github/`, `.pre-commit-config.yaml`, release/build config, Dockerfiles. Application code under `application_sdk/` touched → flag "the diff includes app code; pick a stronger prefix." |
+| `chore:` / `docs:` | No application-code or contract change. |
+
+**Detection:** for `feat!:` claims, diff the `__init__.py` files under
+`application_sdk/` and check for removed `__all__` entries / missing
+deprecation shims. For `feat:` / `fix:` on CI-only diffs, check
+`git diff --name-only origin/main...HEAD` — if every path matches
+`^\.github/|^\.pre-commit|^pyproject\.toml$|^uv\.lock$`, the prefix
+should be `ci:` or `build:`.
+
+**Severity:** Critical when the wrong prefix would cause a
+major-version bump (`feat!:` on non-breaking diff). Important
+otherwise. Always actionable — the PR title can be edited before
+merge.
+
+### Public surface should expose one recommended variant (Important)
+
+New public factories, builders, and helpers should default to ONE
+recommended variant per concept. Multiple parallel variants (sync vs
+async, v8 vs v9, legacy vs new) on a single helper return point
+fragment the API surface and force every connector developer to
+re-derive "which one should I use?"
+
+**Flag any new code that:**
+- Adds a factory / builder / helper that returns one of several
+  client/object variants based on a parameter, where the SDK's
+  recommended path is a specific variant. The factory should default
+  to (or only return) that variant; other variants should be reached
+  via a separate documented escape hatch with a deprecation/future-
+  removal note.
+- Returns `object`, `Any`, `Union[A, B]`, or a `# type: ignore`-d
+  type from a public factory or accessor. The return type MUST be
+  the concrete typed class connectors will actually consume.
+- Adds a kwarg to a public function whose values map to qualitatively
+  different return shapes — splitting the function into two narrowly-
+  typed alternatives is almost always clearer.
+
+**Heuristic:** if the PR description has to explain "we support all
+four variants because…", the surface is too broad — push back with
+"which variant should the typical connector use? Make that the only
+default; relegate the rest behind a separate, narrowly-documented
+helper."
+
+**Severity:** Important (DX). Not blocking, but should be flagged
+loudly with a suggested narrower signature.
+
+### Removing a public kwarg requires a deprecation cycle (Important)
+
+Public function/method kwargs are part of the contract. Silently
+dropping or ignoring a previously-supported kwarg breaks callers
+without warning. A removal must keep the parameter in the signature
+for at least one release with a `DeprecationWarning`.
+
+**Flag any change that:**
+- Removes a kwarg from a public method or function signature that was
+  present in the prior release.
+- Renames a kwarg without keeping the old name as a deprecated alias
+  (`old_name=DeprecationAlias(new_name)` or accept-and-warn).
+- Silently ignores a kwarg's value (still accepting it for back-compat
+  but discarding it) without emitting `warnings.warn(...,
+  DeprecationWarning, stacklevel=2)`.
+
+**Expected pattern:**
+
+```python
+def configure(self, *, new_name: str, old_name: str | None = None) -> None:
+    if old_name is not None:
+        warnings.warn(
+            "`old_name` is deprecated, use `new_name`. Removal in v3.X.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        new_name = old_name
+    ...
+```
+
+**Severity:** Important (DX + back-compat). Same class as removing a
+contract field — broadens the consumer-blast-radius check.

--- a/.mothership/pr-review/references/retro-2026-05-20.md
+++ b/.mothership/pr-review/references/retro-2026-05-20.md
@@ -1,0 +1,301 @@
+# SDK Review — Retrospective 2026-05-20
+
+Four weeks of PR review feedback on `atlanhq/application-sdk`
+(merged or closed since 2026-04-22) plus `#pod-builder-experience`
+Slack chatter, mined for issues that humans caught after
+`@sdk-review` had approved a PR. Each finding was distilled into a
+generalized rule and added to the reference docs — concrete PR
+numbers below are evidence, not the rule itself.
+
+## How to read this file
+
+The rule files (`security-rules.md`, `dx-rules.md`,
+`v3-architecture-rules.md`, `code-quality-rules.md`,
+`test-quality-rules.md`) carry the **generalized rules** that the
+next review pass will apply. This file carries the **provenance** —
+which specific human review surfaced each rule, so future retros can
+trace back whether the generalisation held up.
+
+## Themes
+
+### 1. Edge-system integration is the biggest blind spot
+
+**Generalized rules added:**
+- `security-rules.md §Content compatibility at the edge gateway`
+
+The reviewer has deep knowledge of the SDK itself but knows little
+about what happens once a request crosses the Atlan API gateway /
+WAF. Content that looks fine to the SDK can be rejected by Kong
+sanitization plugins, broken by edge schema validators, or stripped
+of structure by intermediate proxies. The most expensive miss in
+this window broke every v3 connector publish for several hours
+because the request body included template strings the WAF treated
+as XSS payloads.
+
+**Evidence:** the publish-payload incident on the GM marketplace
+endpoint and the historical private-key-passphrase / WAF interaction
+both surfaced as integration regressions, not as code-review issues.
+
+### 2. Credential separation is an architectural rule, not a code-scan rule
+
+**Generalized rules added:**
+- `security-rules.md §Credential material and bulk data must use separate storage components`
+
+Snyk and the AI code scan both saw the credential-from-object-store
+PR as clean; neither caught that the object-store binding being
+reused was the same one the app uses for SDR data. The risk is
+architectural — IAM and KMS scope, not source-code patterns —
+which is why a new dedicated rule was needed.
+
+### 3. Typed contracts everywhere — `dict[str, Any]` keeps slipping through (Critical; recurring)
+
+**Generalized rule added:**
+- `v3-architecture-rules.md §Typed contracts everywhere — no dict/Any escape hatches on public surface`
+
+The most-repeated miss across this window. ADR-0004 and ADR-0008
+already forbid `Dict[str, Any]` / `Any` / bare `dict` on contracts
+and public signatures, but PRs keep adding them and the reviewer
+keeps approving:
+
+- `credentials: dict[str, Any] | None` and `example_input: dict[str, Any] | None`
+  as public-method parameters
+- `properties: dict[str, Any] = Field(...)` on a contract base
+- `record: dict[str, Any]` returned from a `@task` method as its
+  shape-of-record
+- `metadata: dict[str, Any] = {}` added to a public Input
+
+The new rule (a) restates the prohibition as Critical (not Important),
+(b) gives a concrete diff-grep heuristic the reviewer can run on
+every PR, (c) enumerates the legitimate Dapr/Temporal interop
+exceptions narrowly so callers can't hand-wave them, and (d) lists
+the typical replacements (typed credential model, dedicated Metadata
+submodel, named TaskOutput, etc.) so the finding has an actionable
+fix rather than just a complaint.
+
+### 3b. Contract discipline — `@dataclass`, v1 Config, mutable defaults, frozen (Critical; recurring)
+
+**Generalized rule added:**
+- `v3-architecture-rules.md §Contract discipline — Pydantic v2 only, no @dataclass, default_factory for mutables`
+
+Three PRs in this window added `@dataclass` (including
+`@dataclass(frozen=True)`) on classes that should have been plain
+Pydantic `BaseModel`s. One PR added a mutable default arg
+(`captured: dict = {}`). CLAUDE.md explicitly bans both patterns, but
+the reviewer let them through. The new rule consolidates four
+sub-rules — no `@dataclass` on Pydantic contracts, Pydantic v2
+config style only (`model_config = ConfigDict(...)`, not v1 inner
+`class Config:`), `Field(default_factory=...)` for mutables,
+`frozen=True` for value-object contracts — each with a concrete
+diff-grep heuristic.
+
+### 3c. Exception chains lose their cause (Critical; recurring)
+
+**Generalized rule added:**
+- `code-quality-rules.md §Exception chains must preserve the cause with from exc`
+
+Six of the surveyed PRs raised a new exception from inside an
+`except` block without `from exc`, producing the unhelpful "during
+handling of the above exception" traceback and silently zeroing out
+the error-taxonomy `cause` field. Pre-commit doesn't reliably
+catch this. The new rule (a) requires `from <captured-exc>` (or
+`from None` with justification) on every raise inside an `except`,
+(b) gives a concrete heuristic to match indented `raise` after
+`except`.
+
+### 3d. Suppression comments without justification (Important)
+
+**Generalized rule added:**
+- `code-quality-rules.md §Suppression comments require an inline justification`
+
+`# noqa`, `# type: ignore`, `# pylint: disable`, `# pragma: no cover`
+all silently disable a quality gate. Several PRs added bare
+suppressions without inline rationale, building up dead silencers
+that the next reader can't validate. The new rule requires a
+same-line `# noqa: <code> — <reason>` form.
+
+### 4. Contract direction (Input vs Output) is silent if wrong
+
+**Generalized rules added:**
+- `v3-architecture-rules.md §Input/Output direction must match the producer/consumer relationship`
+- `v3-architecture-rules.md §Field removal cascades across consumer repositories`
+
+The SDK enforces ADR-0006 (single Input, single Output, additive
+evolution) but the reviewer hasn't been verifying that fields land
+on the right *side* of a producer/consumer contract pair. Wrong-
+side placement is a wire-shape break that the type checker can't
+catch — the downstream task reads defaults and silently processes
+empty data.
+
+The related cascade rule was reinforced: removing a public Input
+field is in scope of G2 (Contract Safety), but the check is
+incomplete if it only looks within this repo. Consumer connector
+repositories raise `AttributeError` at runtime.
+
+### 5. Conventional-commit semantics drive releases
+
+**Generalized rules added:**
+- `dx-rules.md §Conventional Commits prefix must match diff scope`
+
+Two PRs in this window had prefixes that didn't match the diff —
+one `feat!:` (breaking) with no actual break, one `feat:` for a
+CI-only change. `release-please` consumes those prefixes and bumps
+the SDK version accordingly. The prefix-mismatch table now lives in
+the DX rules.
+
+### 6. Validator coverage on injection-risk fields must be uniform
+
+**Generalized rules added:**
+- `security-rules.md §Validator coverage must be uniform across same-class fields`
+
+A security-themed PR added a new SQL-bound field with only
+`Field(pattern=…)` while sibling fields on the same model used a
+stronger named validator that catches multi-char injection
+sequences. Partial mitigation on an injection path is functionally
+no mitigation.
+
+### 7. CI bypass paths must be keyed on verifiable facts
+
+**Generalized rules added:**
+- `security-rules.md §Bypass paths must be keyed on server-verifiable facts, not caller input`
+
+Two CI workflows had skip / continue-on-error conditions keyed on
+caller-controlled inputs (workflow_call `release_tag`, whitespace-
+only `TENANTS`). Same attack class as trusting `tenant_id` from a
+request body — but it doesn't look like one because it's expressed
+as a CI conditional rather than a service-layer auth check.
+
+### 8. Async shutdown timeouts are missing more often than they should be
+
+**Generalized rules added:**
+- `v3-architecture-rules.md §Async shutdown paths must have bounded waits`
+
+`flush()` / `close()` / `shutdown()` paths run during pod
+termination on a Kubernetes timeout. Unbounded `await`s inside
+those paths stall rolling restarts silently — failure mode that's
+invisible in dev and corrosive in production.
+
+### 9. Drift comes from values defined in more than one place
+
+**Generalized rules added:**
+- `v3-architecture-rules.md §Single source of truth for cross-cutting versions and tunables`
+- `code-quality-rules.md §Tunables and identifiers belong in constants.py`
+
+Recurring across PRs: a version pin, image tag, metric prefix, or
+tunable lives inline somewhere in the codebase while a copy of the
+same value already exists in `constants.py` / `version.py` /
+`pyproject.toml`. The duplicates drift; the symptom shows up days
+later as mismatched behaviour or a surprise minor bump.
+
+### 10. Public-surface narrowness reduces "which one should I use?" confusion
+
+**Generalized rules added:**
+- `dx-rules.md §Public surface should expose one recommended variant`
+- `dx-rules.md §Removing a public kwarg requires a deprecation cycle`
+
+When a new factory or helper exposes multiple parallel variants
+(sync vs async, v8 vs v9, legacy vs new), every connector developer
+has to re-derive the right answer. The rule now is: default to the
+recommended variant, relegate the rest behind a separate documented
+escape hatch, never return `object`/`Any` from a public factory,
+and never silently drop a public kwarg without a deprecation cycle.
+
+### 11. Quality misses are small but cumulative
+
+**Generalized rules added:**
+- `code-quality-rules.md §Exhaust enum variants when matching state`
+- `code-quality-rules.md §Don't wrap upstream APIs in single-purpose helpers`
+- `code-quality-rules.md §Log exceptions with exc_info, never via formatted strings`
+
+These three patterns surface together in review comments more often
+than expected. None is individually a blocker; collectively they're
+the kind of QUAL finding that's worth flagging because each is a
+small but durable degradation of the reading-and-debugging
+experience.
+
+### 12. Test discipline — registry pollution, real services in unit tests, silent skips (Critical; recurring)
+
+**Generalized rules added:**
+- `test-quality-rules.md §App-defining tests MUST use clean_app_registry`
+- `test-quality-rules.md §Unit tests must not exercise real external services`
+- `test-quality-rules.md §pytest.skip() requires a reason and (ideally) a ticket`
+
+**Explicitly NOT a rule (do not flag):**
+- `@pytest.mark.asyncio` decorators on tests. Team has confirmed this
+  is acceptable style and sdk-review must not raise findings about
+  it. See `test-quality-rules.md §DO NOT FLAG — @pytest.mark.asyncio`
+  for the negative rule.
+
+Three recurring test anti-patterns surfaced together:
+- Tests defining `App` subclasses without `clean_app_registry`,
+  polluting the process-global `AppRegistry` / `TaskRegistry`.
+- New unit tests that exercise real `httpx`, real DB drivers, real
+  cloud SDKs without mocks.
+- `pytest.skip()` without `reason=` or a ticket link, creating
+  permanent dead tests.
+
+### 13. Tests outside the CI test tree are silent coverage holes
+
+**Generalized rules added:**
+- `test-quality-rules.md §Tests must live where CI actually runs them`
+
+A PR added `test_*.py` files under `.github/scripts/tests/`. Pytest
+in CI runs over `tests/`, so the new tests were dead coverage — they
+pass locally but never execute in CI. This is worse than no
+coverage because it provides false confidence.
+
+### 14. Env-var lifecycle and private-module imports (Critical; recurring)
+
+**Generalized rules added:**
+- `dx-rules.md §Env-var lifecycle: prefix, removal warnings, doc updates`
+- `dx-rules.md §Private-module imports from app code are forbidden`
+
+Two patterns the reviewer was applying loosely:
+- New env vars added without `ATLAN_` prefix, or renamed/removed
+  without an entry in `_REMOVED_ENV_VARS` (so users get a startup
+  warning), or without a `docs/standards/env-vars.md` update.
+- Direct imports of `_`-prefixed private modules (`_temporal`,
+  `_dapr`, `_redis`) from app code, or direct `temporalio` / `dapr`
+  / `redis` imports outside the corresponding private package.
+  ADR-0005 already prohibits this; the new rule gives a concrete
+  diff-grep so the reviewer enforces it deterministically.
+
+### 15. Sandbox restrictions break runtime, not type-check
+
+**Generalized rules added:**
+- `v3-architecture-rules.md §Temporal workflow sandbox restrictions`
+
+Temporal's workflow sandbox restricts `random.*`, `time.*`, signal
+handlers, and file I/O during workflow validation. Profilers and
+similar modules imported during worker startup can crash boot with
+`RestrictedWorkflowAccessError` — sometimes deterministically,
+sometimes only on slow CI runners where signal handlers race with
+validation.
+
+## Provenance (PRs the rules came from)
+
+| PR | sdk-review verdict | What a human caught later | Rule(s) added |
+|---|---|---|---|
+| #1747 → reverted in #1782 | Approved | Body content (`<account-id>`, `-----BEGIN`, Jinja) tripped Heracles Kong XSS plugin; broke every v3 connector publish | Edge-gateway content compatibility |
+| #1638 | Approved | Reused SDR data binding for credential material — mixed secrets and customer data in the same bucket | Credential/data binding separation |
+| #1573 | Approved | `feat!:` claim without a developer-end public-API break | Conventional Commits prefix check |
+| #1573 inline comments | Approved | Hardcoded `"application.custom"` and sample intervals inline; interceptor missed `stopped` / `paused` enum values; thin wrappers over `meter` API | constants.py centralization; enum exhaustion; no-thin-wrappers |
+| #1759 | Approved | Logging `traceback.format_exc()` into message strings; silent kwarg drop without `DeprecationWarning`; version pins duplicated across files | exc_info logging; deprecation cycle for kwargs; single source of truth |
+| #1768 | Approved | Factory exposes 4 client variants when one is recommended; returned `object` instead of typed client | Public surface narrowness |
+| #1775 | Approved | New `test_*.py` files under `.github/scripts/tests/` not in pytest paths | Tests live where CI runs them |
+| #1757, #1775 | Approved | CI workflows bypassed gates on caller-controlled `release_tag` and whitespace `TENANTS` | Server-verifiable bypass keys |
+| #1785 | Approved | New SQL-bound field used `Field(pattern=…)` while siblings had a stronger named validator | Uniform validator coverage |
+| #1787, #1792 | Approved | Field on wrong contract direction (extract-produces lands on Input, not Output); `raw_dir` with no producer/consumer | Input/Output direction; no speculative fields |
+| #1723 | Approved | `SegmentClient.flush()` `await` had no `wait_for` timeout | Async shutdown bounded waits |
+| #1778 / atlan-teradata-app #46 | n/a | Profiler module touched `random.random()` during worker init → Temporal sandbox blocked it on slow CI | Temporal sandbox passthrough |
+| #1759, #1723, #1792, #1643 (and others) | Approved | `dict[str, Any]` / `Any` / bare `dict` on public contract fields, `@task` return types, public method parameters | Typed contracts — no dict/Any escape hatches |
+| #1759, #1573, #1804 | Approved | `@dataclass(frozen=True)` on classes that should be plain Pydantic `BaseModel` | Contract discipline — no @dataclass |
+| #1723 | Approved | `captured: dict = {}` mutable default arg | Contract discipline — Field(default_factory=...) |
+| #1759, #1768, #1748, #1573, #1662, #1723 | Approved | `raise X(...)` inside `except` block without `from exc`; broken exception chain | Exception chains must preserve cause |
+
+## Followups (not in this PR)
+
+- The STRUCTURE agent missed a "spaghetti" complaint on PR #1804
+  (large embedded HTML/SQL/JS strings inside Python). Punted because
+  the PR conversation didn't give a concrete pattern to encode —
+  needs more examples before generalizing.
+- Next retro target: 2026-06-17 (four weeks out).

--- a/.mothership/pr-review/references/security-rules.md
+++ b/.mothership/pr-review/references/security-rules.md
@@ -220,3 +220,134 @@ except Exception as e:
 - `ghcr.io/atlanhq/application-sdk-main:3.0.0` — pinned
 - CI workflows must pin action versions to SHAs
 - No `curl | bash` patterns for installing tools in Dockerfiles
+
+---
+
+## Retro Learnings — 2026-05-20
+
+> Each subsection below is a generalized rule. Concrete incidents that
+> surfaced the rule are linked in `retro-2026-05-20.md` and prior
+> entries in this section.
+
+### Credential material and bulk data must use separate storage components (Critical)
+
+Credentials (keytabs, certificates, private keys, OAuth refresh
+tokens, kerberos configs, any file whose disclosure compromises
+authentication) MUST be retrieved through a storage component that is
+not also used for extracted customer data or workflow artifacts.
+Sharing a component means one IAM misconfiguration, one over-broad
+role, or one SSRF lapse exposes both secrets and data.
+
+**Flag any change that:**
+- Adds a new branch / code path to credential resolution
+  (`application_sdk/credentials/*`, anything matching
+  `resolve_credential*`, `load_secret*`, `fetch_keytab*`) that reads
+  from a storage binding, object-store component, or Dapr state
+  component already used elsewhere for non-credential data (extract
+  outputs, metadata dumps, query logs, intermediate artifacts).
+- Uses the same env-var-named binding (`DEPLOYMENT_OBJECT_STORE_NAME`,
+  `OUTPUT_*`, anything wired to data flow) for secret retrieval.
+- Reads files of types typically containing secrets (`*.pem`, `*.key`,
+  `*.keytab`, `*.p12`, `*.jks`, `*credential*`, `*secret*`, `*token*`)
+  through a binding component name that the same app uses for data.
+
+**Expected pattern:** credential reads go through a dedicated secret-
+store binding, a separate object-store binding with stricter IAM/KMS,
+or the connector's `CredentialResolver`. If a PR argues that a shared
+component is the only practical path (e.g. value-size limits in the
+secret manager), the PR description MUST cite the separate IAM
+boundary that protects the credential path — otherwise escalate to
+design review.
+
+**Severity:** Critical (SEC). Counts as a G1 guardrail violation when
+the same component name appears in both credential and data code paths.
+
+### Content compatibility at the edge gateway (Critical)
+
+When code adds, modifies, or expands what gets sent in the body of an
+outbound HTTP request to an Atlan-platform edge endpoint (anything
+routed through the Atlan API gateway / WAF — `home.atlan.com`,
+`*.atlan.com/api/service/`, marketplace endpoints, Heracles routes,
+SDR ingest endpoints, etc.), the new content must be verified
+compatible with edge sanitization plugins (XSS scrubbers, schema
+validators, size limits). These plugins compare sanitized output to
+input and reject the request if they differ — silently breaking any
+caller whose payload contains characters that look like HTML, JS, or
+template syntax.
+
+**Flag any change that:**
+- Adds a new field to an outbound JSON body, multipart form, or
+  request payload sent to an Atlan-edge endpoint, where the value
+  carries: connector form schemas, generated JSON/YAML, Jinja or
+  templating syntax (`{% %}`, `{{ }}`, `${...}`), PEM-encoded keys
+  (`-----BEGIN ...`), HTML-like or angle-bracketed placeholders
+  (`<account-id>`, `<region>`), SQL templates, or any
+  user-/codegen-produced string blob.
+- Inlines such content as a raw JSON string rather than wrapping it
+  (base64, multipart file part, gzipped blob, etc.).
+- Adds a new outbound call to an edge route without identifying which
+  WAF plugins protect that route and confirming the payload survives
+  them.
+
+**Expected pattern:** for any new request body field crossing the
+edge gateway, the PR description must state one of:
+(a) the route is on the WAF plugin allowlist (link the config),
+(b) the content is base64-encoded / multipart-uploaded,
+(c) the field has been tested end-to-end against the actual edge with
+representative content.
+
+**Severity:** Critical (SEC + integration). Block until evidence is
+attached. This is a recurring failure mode — past incidents include
+private-key-passphrase contents tripping XSS validation; future
+incidents will look similar.
+
+### Bypass paths must be keyed on server-verifiable facts, not caller input (Critical)
+
+Any conditional in a CI workflow, service handler, or release flow
+that skips a security check, scoping check, or release gate MUST be
+keyed on a fact the server can verify independently — not on a value
+the caller supplies.
+
+**Flag any change that:**
+- Adds an `if:` / `continue-on-error` / early-return condition in a
+  GitHub Actions workflow keyed on a `workflow_call` input,
+  `workflow_dispatch` input, or `client_payload` value that, when
+  set, skips: tenant scoping, release-branch verification, tag-
+  ancestry verification, or any security/compliance gate.
+- References a `release_tag`, `version`, `ref`, or `tenant` input
+  without a server-verifiable check that the value matches reality:
+  - Tag ancestry: `git merge-base --is-ancestor "$TAG" origin/main`
+  - Trigger ref: `github.ref == format('refs/tags/{0}', inputs.release_tag)`
+  - Tenant identity: resolved from a SAML/OIDC claim, never from a
+    request field.
+- Treats whitespace, empty strings, or null values as "skip the check"
+  (an attacker can always send empty input).
+
+**Severity:** Critical (SEC). Same attack class as trusting
+`tenant_id` from a request body.
+
+### Validator coverage must be uniform across same-class fields (Critical)
+
+When a Pydantic model has a class of string fields that all flow to
+the same risky sink (SQL, shell, file path, log filter, regex
+compilation), every field of that class on the model MUST use the
+same validator — not a weaker per-field shortcut.
+
+**Flag any change that:**
+- Adds a string field to a model where sibling fields already use a
+  named validator (e.g. `@field_validator('foo')` calling
+  `validate_filter_no_sql_injection`, `validate_no_shell_meta`,
+  `validate_path_no_traversal`, etc.), and the new field omits it.
+- Substitutes `Field(pattern=…)` for a named validator when the named
+  validator catches multi-character patterns (`--`, `/*`, `*/`,
+  shell expansions, path traversals) that the regex doesn't.
+- Adds a model with only some fields validated for the same sink
+  class — e.g. two SQL-bound fields where one has the validator and
+  the other doesn't.
+
+**How to detect quickly:** grep the model file for `@field_validator`
+and `validate_*` function calls. Any new string field on the same
+class without one of these is a candidate finding.
+
+**Severity:** Critical (SEC). Partial mitigation on an injection path
+is functionally no mitigation.

--- a/.mothership/pr-review/references/test-quality-rules.md
+++ b/.mothership/pr-review/references/test-quality-rules.md
@@ -4,6 +4,108 @@ Test patterns, coverage requirements, and quality standards for application-sdk 
 
 ---
 
+## Retro Learnings — 2026-05-20
+
+> Each subsection is a generalized rule. Concrete incidents that
+> surfaced the rule are recorded in `retro-2026-05-20.md`.
+>
+> The `@pytest.mark.asyncio` DO-NOT-FLAG rule lives in
+> `retro-log.md` and in §Async Test Pattern of this file — do NOT
+> add a duplicate negative rule here.
+
+### App-defining tests MUST use `clean_app_registry` (Critical)
+
+`AppRegistry` and `TaskRegistry` are process-global singletons. A
+test that defines an `App` subclass leaks that registration into
+every subsequent test in the same process. Without the
+`clean_app_registry` fixture, test ordering becomes load-bearing
+and parallel test runs become flaky.
+
+**Flag any new test file that:**
+- Defines a `class ...App(App):` or `class ...App(MyAppBase):`
+  subclass at module level OR inside a test function, AND does NOT
+  use the `clean_app_registry` fixture (either via
+  `pytest.usefixtures("clean_app_registry")` on the class, or
+  `def test_x(clean_app_registry):` on each test).
+- Imports an `App` subclass from another test module (same
+  problem — registers an app globally).
+- Defines `@task`-decorated methods on a class defined inside a
+  test (each test run accumulates more tasks in `TaskRegistry`).
+
+**Detection heuristic:** grep the new test file for `class .*\(App[^)]*\):`
+or `class .*App\(.*\):`. If any match exists and the file doesn't
+also reference `clean_app_registry` → finding.
+
+**Severity:** Critical (TEST). Registry pollution makes the test
+suite non-deterministic; the symptom (a test that passes alone but
+fails in the full run, or vice versa) is the hardest class of
+flake to diagnose.
+
+### Unit tests must not exercise real external services (Important)
+
+`tests/unit/` runs in CI without network, without Dapr, without
+Temporal. A new unit test that imports the real `httpx.AsyncClient`,
+real DB drivers, real cloud SDKs, real Atlan APIs without a mock
+is a CI flake waiting to happen — and slows local test runs.
+
+**Flag any new unit test that:**
+- Calls `httpx.AsyncClient(...)` / `requests.get` / cloud SDK
+  clients (`boto3.client`, `azure-...`, `google.cloud.storage`)
+  without a `respx`, `responses`, or `mocker.patch` shim.
+- Uses real database connection strings or imports
+  `sqlalchemy.create_engine` outside an isolated `tmp_path` fixture.
+- Imports `dapr.clients.DaprClient` / `temporalio.client.Client`
+  directly instead of using `MockStateStore`, `MockSecretStore`,
+  `MockPubSub`, or the testing fixtures under `application_sdk.testing`.
+
+**Severity:** Important (TEST). Real-dependency unit tests turn into
+the team's most-skipped test files.
+
+### `pytest.skip()` requires a reason and (ideally) a ticket (Important)
+
+A skipped test is dead test code masquerading as coverage. Every
+`pytest.skip(...)` / `@pytest.mark.skip` / `@pytest.mark.skipif`
+needs a human-readable reason. Lasting skips (anything more than a
+day) need a ticket link.
+
+**Flag any new code that:**
+- Adds `pytest.skip()` with no message, or with a generic message
+  like `"TODO"` / `"skip"` / `"broken"`.
+- Adds `@pytest.mark.skip(...)` without a `reason=` kwarg.
+- Adds `@pytest.mark.skipif(...)` without `reason=`.
+
+**Expected form:** `pytest.skip(reason="Needs <X>; tracked in BLDX-NNN")`.
+
+### Tests must live where CI actually runs them (Critical)
+
+Tests outside the directory tree that the CI test job actually
+invokes are dead coverage — they pass locally, are not enforced by
+CI, and the code they nominally cover regresses without warning.
+
+**Flag any change that:**
+- Adds `test_*.py` files under directories the project's pytest
+  configuration does NOT include. The canonical location for unit
+  tests is `tests/unit/...`; integration tests under `tests/integration/...`;
+  helper-script tests should live where the CI workflow that
+  invokes the helper actually runs pytest.
+- Adds tests under sibling-of-source directories (`scripts/tests/`,
+  `.github/scripts/tests/`) without verifying that a CI job
+  explicitly invokes pytest with that path.
+- Renames or moves an existing test file out of the configured test
+  tree without adding the new location to the pytest paths.
+
+**Detection:** read `pyproject.toml`'s `[tool.pytest.ini_options]`
+`testpaths` (or `python_files` + `rootdir`) and any CI workflow that
+runs pytest. The set of directories actually exercised is the union
+of those. Any new test file outside that union is a finding —
+either move the file into the union, or modify CI to include the
+new location.
+
+**Severity:** Critical (TEST — coverage that does not run is worse
+than no coverage; it provides false confidence).
+
+---
+
 ## Test Existence (Critical)
 
 ### Every New Module Needs Tests

--- a/.mothership/pr-review/references/v3-architecture-rules.md
+++ b/.mothership/pr-review/references/v3-architecture-rules.md
@@ -154,3 +154,350 @@ Derived from the 11 Architecture Decision Records (ADRs) governing application-s
 - **Registry singleton safety**: `AppRegistry` and `TaskRegistry` mutations must be thread-safe
 - **Deprecation shims**: Only for v2 paths where connectors may already import the old symbol (i.e. `application_sdk.test_utils.integration` → `application_sdk.testing.integration`). Do NOT add shims for symbols that were removed before v3 shipped — those never existed from a public-API perspective
 - **`__init_subclass__` hooks**: New metaclass or `__init_subclass__` must not break existing subclass registration
+
+---
+
+## Retro Learnings — 2026-05-20
+
+> Each subsection is a generalized rule. Concrete incidents that
+> surfaced the rule are recorded in `retro-2026-05-20.md`.
+
+### Contract discipline — Pydantic v2 only, no `@dataclass`, default_factory for mutables (Critical)
+
+This rule consolidates several CLAUDE.md mandates that PRs keep
+slipping past. All four sub-rules apply to any class that is — or
+inherits from — `pydantic.BaseModel`, `Input`, `Output`,
+`HeartbeatDetails`, a credential type, or anything under
+`application_sdk/contracts/`. Public connector developers depend on
+these classes; getting any of the four wrong is a Critical finding.
+
+#### Sub-rule 1: No `@dataclass` on Pydantic contracts (Critical)
+
+Pydantic handles `__init__`, validation, and serialization. Stacking
+`@dataclass` on top of `BaseModel` produces a class that looks
+correct but bypasses Pydantic's validation pipeline and breaks
+serialization through Temporal's data converter.
+
+**Flag any new code that:**
+- Adds `@dataclass` (any form: `@dataclass`, `@dataclass(frozen=True)`,
+  `@dataclasses.dataclass`, `@dc.dataclass`) on a class that is or
+  inherits from `BaseModel`, `Input`, `Output`, or anything under
+  `application_sdk/contracts/`.
+- Adds `@dataclass` on a class meant to flow through a Temporal
+  payload (return type of a `@task`, parameter of `run()`, anything
+  serialized by `pydantic_data_converter`).
+- Defines `@dataclass`-style helper classes in `contracts/` even
+  for "internal" use — those tend to escape into the public surface
+  through `__init__.py` re-exports.
+
+**Diff-grep heuristic:** `grep -E '^\+.*@dataclass' diff` — every
+hit needs to be checked against the class's base. If the base is
+(or inherits from) `BaseModel` → Critical finding.
+
+**Replacement:** delete the `@dataclass` decorator; rely on
+`BaseModel.__init__`. If the class needs to be frozen, use
+`model_config = ConfigDict(frozen=True)` or
+`class Foo(BaseModel, frozen=True): ...`.
+
+#### Sub-rule 2: Pydantic v2 config style only (Critical)
+
+The SDK is on Pydantic v2. The v1 inner-`class Config:` style is
+silently ignored in v2 — `class Config:` declared on a v2 BaseModel
+does nothing. PRs that drop a v1 `class Config:` block ship a model
+whose config is whatever the defaults are, not what the author
+thought they were configuring.
+
+**Flag any new code that:**
+- Adds an inner `class Config:` block inside a `BaseModel` subclass.
+- Uses `Config = ...` class-level assignment for v1-style config.
+- Mixes v1 `Config` and v2 `model_config` in the same class.
+
+**Replacement:** `model_config = ConfigDict(frozen=True, extra='forbid', ...)`.
+
+#### Sub-rule 3: `Field(default_factory=...)` for mutable defaults (Critical)
+
+`field: list = []` shares the SAME list instance across every
+instance of the class — classic Python gotcha that produces silent
+state corruption. The Pydantic-v2-safe replacement is
+`field: list = Field(default_factory=list)`.
+
+**Flag any new code that:**
+- Declares a field on a `BaseModel` (or any class) with a mutable
+  default literal: `field: list = []`, `field: dict = {}`,
+  `field: set = set()`, `field: list[X] = []`.
+- Uses `field: Optional[list] = []` (still shared, just lets `None`
+  through).
+
+**Diff-grep heuristic:**
+`grep -E '^\+.*: (list|List|dict|Dict|set|Set)(\[[^]]+\])?\s*=\s*(\[\]|\{\}|set\(\))' diff` —
+every hit is a candidate.
+
+**Replacement:** `field: list[X] = Field(default_factory=list)` (or
+`list`, `dict`, etc. as appropriate).
+
+#### Sub-rule 4: Frozen contracts where identity matters (Important)
+
+Contracts used as dict keys, hash keys, message-bus payloads, or
+shared across activity boundaries should be immutable. `FileReference`,
+`CredentialRef`, and credential subclasses are already frozen.
+New similar-purpose contracts MUST also be frozen.
+
+**Flag any new contract that:**
+- Resembles a value object (no methods beyond accessors, models a
+  fact rather than an entity) and is NOT declared frozen.
+- Inherits from `FileReference` or `CredentialRef` without
+  preserving `frozen=True`.
+
+**Replacement:** `class Foo(BaseModel, frozen=True): ...` or
+`model_config = ConfigDict(frozen=True)`.
+
+### Typed contracts everywhere — no `dict`/`Any` escape hatches on public surface (Critical)
+
+This rule restates and **strengthens** ADR-0004 / ADR-0008 because
+review history shows the framework rule is being approved past. Every
+parameter, return type, and contract field on the public API surface
+of `application_sdk/` MUST be typed concretely. `dict[str, Any]` /
+`Dict[str, Any]` / `Any` / `object` / `dict` (bare) / `list` (bare)
+are escape hatches — they accept arbitrary shapes, break Pyright,
+and force every connector developer to read the source to figure out
+what the field actually contains.
+
+**Treat every occurrence in a public-surface location as a Critical
+finding. Public surface means:**
+
+- Any class field on a `pydantic.BaseModel` subclass that is — or
+  inherits from — `Input`, `Output`, `HeartbeatDetails`, a credential
+  type, an event payload, or any model under `application_sdk/contracts/`.
+- The signature of any function, method, classmethod, or constructor
+  exported from `application_sdk/<module>/__init__.py` (i.e. anything
+  importable as `application_sdk.<module>.<symbol>`).
+- The signature of any `@task`-decorated method, `@entrypoint`-
+  decorated method, or `run()` override.
+- The return type of any factory / builder / accessor function whose
+  return value crosses an `application_sdk/` module boundary.
+- The signature of any `Handler` subclass method (`auth`, `preflight`,
+  `metadata`, custom handler endpoints).
+
+**Flag the following forbidden type forms anywhere in those locations:**
+
+| Forbidden form | Why |
+|---|---|
+| `dict[str, Any]`, `Dict[str, Any]`, `Mapping[str, Any]` | Accepts arbitrary keys and values; no validation; no IDE support. Use a Pydantic model. |
+| `dict`, `Dict`, `list`, `List`, `tuple`, `Tuple`, `set`, `Set` (bare, no type parameters) | Equivalent to `dict[Any, Any]`. Specify the value type, or use a model. |
+| `Any`, `object` | Accepts anything; no contract. |
+| `Union[A, B, ...]` / `A \| B` where one of the variants is `dict` / `Dict` / `Any` | The escape hatch is now inside a Union; just as bad. |
+| `**kwargs: Any` on a public method | Hides the contract. Either accept a typed config model, or enumerate the keyword arguments with concrete types. |
+| `# type: ignore` on a public signature line | Almost always means a typed alternative exists or the public surface needs to be reshaped. Require an inline justification or fix. |
+
+**Detection heuristic (deterministic; run on the diff):**
+
+```bash
+git diff origin/main...HEAD -- 'application_sdk/**/*.py' | \
+  grep -E '^\+' | \
+  grep -E ':\s*(dict|Dict|list|List|tuple|Tuple|set|Set)\b[^[]|\b(dict|Dict|Mapping)\[\s*str\s*,\s*Any\s*\]|:\s*(Any|object)\b|\*\*kwargs:\s*Any'
+```
+
+Every hit is a candidate finding. Walk each one back to its
+declaration site and confirm whether it is on a public surface per
+the list above. If yes → Critical.
+
+**The narrow legitimate exceptions** (must be explicitly justified in
+the PR description or a same-line comment, otherwise flag):
+
+- **Dapr/Temporal interop boundary** — code inside
+  `application_sdk/infrastructure/_dapr/` and
+  `application_sdk/execution/_temporal/` may use `Dict[str, Any]`
+  where it directly hands payloads to/from the upstream library
+  that itself uses untyped dicts. The boundary must be in a private
+  (`_`-prefixed) module and the typed model must take over within
+  one function call.
+- **Wire-format pass-through** — fields that carry an opaque blob to
+  be deserialised by the caller (rare; should be `bytes` or a
+  `FileReference` instead).
+- **Generic helper utilities** in `application_sdk/common/` that are
+  intentionally type-agnostic (`merge_dicts`, `deep_get`, etc.) —
+  but these should be `dict[K, V]` with TypeVar `K`, `V`, not
+  `dict[str, Any]`.
+
+**Migration paths for the most common findings:**
+
+| Anti-pattern | Replacement |
+|---|---|
+| `credentials: dict[str, Any] \| None` | A typed credential model (`CredentialDict` or a connector-specific credential subclass). If truly generic, accept `CredentialRef` and let the resolver produce the typed object. |
+| `metadata: dict[str, Any] = {}` on an Input | A dedicated `Metadata` Pydantic model with the actual fields named, or an explicit `extra="allow"` ConfigDict with a documented schema. |
+| `def task(...) -> dict[str, Any]` | Define a `TaskOutput(BaseModel)` and return it. |
+| `properties: dict[str, Any] = Field(...)` | A typed `Properties` submodel, or `list[Property]` where `Property` is a small Pydantic model. |
+| `**kwargs: Any` on a public method | A typed config model passed as a single argument. |
+
+**Severity:** Critical (ARCH + DX). Counts as a violation of
+ADR-0004 (build-time type safety) and ADR-0008 (payload-safe bounded
+types). Every untyped-dict field on a public contract is a future
+refactor blocker — once a connector ships using it, the SDK can no
+longer tighten the type without a major-version bump.
+
+### Input/Output direction must match the producer/consumer relationship (Critical)
+
+Every typed contract belongs to a specific activity in a specific
+direction. A field on `*Input` is consumed by the task that takes it
+as parameter — the task body reads it before doing work. A field on
+`*Output` is produced by that task and returned. Placing a produced
+value on `Input` (or a consumed value on `Output`) silently corrupts
+inter-activity hand-off: a downstream task will read defaults
+instead of the value the upstream task wrote.
+
+**For every new or moved field on a public contract, verify direction
+by reading the task body that uses it:**
+
+- If the task method reads it via `input.<field>` *before* doing any
+  work → the field belongs on the task's `*Input`.
+- If the task method assigns to it and returns it via
+  `return MyOutput(<field>=…)` → the field belongs on that task's
+  `*Output`.
+- A value produced by task A and consumed by task B is on A's Output
+  AND on B's Input (different contracts; same value flows through).
+
+**Flag any change that:**
+- Adds a field on `*Input` that the owning task never reads in its
+  body (only writes to or only passes through).
+- Adds a field on `*Output` that the owning task never produces in
+  its body.
+- Adds a field whose producer and consumer cannot be identified in
+  this repo or a named consumer repo — i.e. a speculative or
+  pre-emptive field with no current caller (these accumulate as dead
+  surface area and break later refactors).
+
+**Detection heuristic:** for each new field `foo` on a contract,
+grep the same module for `input.foo` (Input reads) and
+`OutputClass(foo=` / `return OutputClass(... foo=...)` (Output
+writes). If neither pattern appears → the field is speculative; flag
+it. If the pattern is opposite to the contract direction → flag it.
+
+**Severity:** Critical. Wrong-side placement is a wire-shape break
+that the type checker cannot catch.
+
+### Field removal cascades across consumer repositories (Critical)
+
+Removing a field from a public `Input`/`Output` contract is in scope
+of G2 (Contract Safety), but the check is incomplete if it only
+looks within this repo. Connector apps in sibling repositories
+import and read these contracts at runtime; Pydantic raises
+`AttributeError` when a removed attribute is accessed. The SDK PR
+that removes a field MUST land *after* or *with* consumer-side
+removals — never alone.
+
+**For any deletion of a field on a public `Input`/`Output` contract:**
+
+1. Identify every consumer repository likely to read the field.
+   Default consumer set: any `atlanhq/atlan-*-app` repository that
+   imports from `application_sdk`. The `audit-consumers` skill
+   automates this; grep
+   `github.com/atlanhq atlan-*-app input.<field>` /
+   `<ContractClass>(... <field>=...)` is the manual path.
+2. For each consumer, confirm one of: (a) it doesn't read the
+   field, (b) an open PR removes the read, (c) it will hit
+   `AttributeError` at runtime.
+3. If (c) is non-empty → flag G2 violation with the consumer list.
+   Either keep the field as a deprecated optional (`Field(default=None)`
+   plus a docstring noting the removal version), or block the SDK PR
+   until consumer-side PRs are queued.
+
+**Severity:** Critical (G2). Consumer-blast-radius check is mandatory
+for any contract field deletion.
+
+### Temporal workflow sandbox restrictions (Important)
+
+Temporal's workflow sandbox restricts non-deterministic stdlib calls
+(`random.*`, `time.*`, signal handlers, file I/O, etc.) inside
+workflow validation. Any module imported on the worker-startup path
+whose initialization touches these stdlib functions can crash worker
+boot with a `RestrictedWorkflowAccessError` — sometimes deterministically,
+sometimes only on slow runners where signal handlers race with
+validation.
+
+**Flag any change that:**
+- Imports a profiler (`scalene`, `pyinstrument`, `viztracer`,
+  `py-spy`, similar) at module top level in code loaded during
+  worker startup, without an accompanying entry in the Temporal
+  sandbox passthrough list
+  (`application_sdk/execution/_temporal/worker.py`).
+- Adds a new background thread, signal handler, or `atexit` hook in
+  startup code (combined-mode entry point, app `__init__`,
+  decorators that fire at import time) that touches `random.*`,
+  `time.time()`, or other Temporal-restricted modules during
+  workflow validation.
+- Modifies the Temporal sandbox passthrough list (adds a new
+  passthrough module) without justifying in the PR body: what
+  module, what it imports during validation, why the passthrough is
+  safe (i.e. why the module's behaviour is deterministic from
+  Temporal's POV).
+
+**Why generalize:** failures in this class look different (profiler
+crashes, signal-handler races, "works locally, breaks on CI") but
+share the same root cause — module-init-time access to non-
+deterministic stdlib functions under the workflow sandbox. The rule
+is "anything new on the worker-startup path must be sandbox-safe."
+
+**Severity:** Important. Catches a class of CI-only failures that
+consumers struggle to diagnose.
+
+### Async shutdown paths must have bounded waits (Important)
+
+`flush()`, `close()`, `shutdown()`, SIGTERM handlers, and other
+cleanup paths run during pod termination on a Kubernetes timeout.
+An unbounded `await` (no `asyncio.wait_for(..., timeout=…)`) inside
+any of these can extend pod termination indefinitely, causing
+rolling restarts to stall, deploys to time out, and metrics/spans to
+be dropped silently.
+
+**Flag any code in a cleanup-flagged context that:**
+- `await`s on an external operation (HTTP flush, queue drain, DB
+  commit, gRPC close) without a `timeout=` parameter or an
+  enclosing `asyncio.wait_for(..., timeout=…)`.
+- Adds a new `async def flush() / close() / shutdown() /
+  on_terminate()` method that calls another `await` without
+  documenting an upper bound.
+- Adds a SIGTERM/SIGINT handler that schedules an `await` task
+  without a deadline.
+
+**Detection heuristic:** in functions whose name matches
+`(flush|close|shutdown|stop|terminate|teardown|drain)`, every
+`await` must have a `timeout=` argument or sit inside
+`asyncio.wait_for(...)`.
+
+**Severity:** Important (DETERMINISM). Failure mode is silent in
+dev but corrosive in production rolling restarts.
+
+### Single source of truth for cross-cutting versions and tunables (Important)
+
+A version string, image tag, dependency pin, or tunable constant
+that drives behaviour in more than one place MUST live in exactly
+one location and be referenced from everywhere else. When the same
+literal value appears in multiple files, the duplicates drift, and
+the symptom (mismatched behaviour, surprise version bumps,
+incompatible CI vs runtime) is hard to attribute.
+
+**Flag any change that:**
+- Hard-codes a version string (semver, image tag, dependency pin,
+  protocol revision) in a file when the same string already lives
+  elsewhere in the repo. Grep for the literal value before flagging
+  — if it appears in `>1` location, the new occurrence should
+  import from a single source-of-truth (typically `version.py`,
+  `constants.py`, `pyproject.toml`, or a documented `.env` template).
+- Hard-codes a tunable (timeout, sample interval, batch size,
+  retry backoff, metric prefix) inline in source code instead of in
+  `application_sdk/constants.py` with an `ATLAN_`-prefixed env-var
+  override. The constants module is the documented place for
+  framework-level tunables; inline values can't be overridden by
+  operators.
+- Defines a default value in two places (one in `constants.py`, one
+  inline in a call site). They will drift; only `constants.py`
+  should hold the default.
+
+**Detection heuristic:** for each new literal that looks like a
+version (`r"\d+\.\d+\.\d+"`), image tag (`ghcr.io/...:tag`),
+timeout/interval (numeric followed by `_seconds`, `_ms`, `_secs`),
+or a string used as a metric/log attribute prefix, run
+`git grep -F "<literal>"` across the repo. More than one hit → flag.
+
+**Severity:** Important (STRUCT + DX). Catches drift before it
+becomes a production incident.


### PR DESCRIPTION
## Summary

Retrospective on four weeks (since 2026-04-22) of human PR review
feedback on this repo.
Each rule is principle-driven with a concrete diff-grep detection
heuristic; provenance recorded in `retro-2026-05-20.md` so future
retros can trace whether the generalization held up.

**Stacked on PR #1485.** This PR's base is `sdk-mothership-migration`,
so the new rules land in `.mothership/pr-review/references/` (the new
location PR #1485 introduces), not the legacy
`.claude/skills/sdk-review/references/` path. Merge order: #1485 first,
then #1805.

## Methodology

Every rule is principle-driven with three components:
1. **What to flag** — generalized pattern, not "lesson from PR #X"
2. **Detection heuristic** — concrete diff-grep command or
   file-set check the agent can apply deterministically
3. **Replacement / expected pattern** — the actionable fix

Specific PR numbers stay in `retro-2026-05-20.md` (the provenance
ledger), not in the rule bodies. Rules should pattern-match new PRs
that don't textually resemble the historical ones.

## What's new (by file)

### `security-rules.md` (4 rules)
- Credential material and bulk data must use separate storage components
- Content compatibility at the edge gateway (Kong/WAF interactions)
- Bypass paths must be keyed on server-verifiable facts, not caller input
- Validator coverage must be uniform across same-class fields

### `dx-rules.md` (5 rules)
- Conventional Commits prefix must match diff scope (drives `release-please`)
- Public surface should expose one recommended variant
- Removing a public kwarg requires a deprecation cycle
- Env-var lifecycle: `ATLAN_` prefix, `_REMOVED_ENV_VARS` on rename/remove,
  `docs/standards/env-vars.md` updated
- Private-module imports from app code are forbidden (concrete grep heuristic)

### `v3-architecture-rules.md` (7 rules)
- **Contract discipline**: no `@dataclass` on Pydantic contracts, Pydantic v2
  config style only, `Field(default_factory=...)` for mutables, frozen for
  value objects (combines four CLAUDE.md mandates PRs keep slipping past)
- **Typed contracts everywhere — no `dict`/`Any` escape hatches on public
  surface** (the most recurring miss; this rule restates ADR-0004/0008 as
  Critical with a hard-edge grep and a list of legitimate Dapr/Temporal
  exceptions)
- Input/Output direction must match the producer/consumer relationship
- Field removal cascades across consumer repositories
- Temporal workflow sandbox restrictions on worker-startup imports
- Async shutdown paths must have bounded waits
- Single source of truth for cross-cutting versions and tunables

### `code-quality-rules.md` (6 rules)
- **Exception chains must preserve the cause with `from exc`** (six PRs in
  this window raised inside `except` without `from exc`)
- Suppression comments require an inline justification
- Tunables and identifiers belong in `constants.py`
- Exhaust enum variants when matching state
- Don't wrap upstream APIs in single-purpose helpers
- Log exceptions with `exc_info`, never via formatted strings

### `test-quality-rules.md` (4 rules + 1 DO-NOT-FLAG)
- **DO NOT FLAG: `@pytest.mark.asyncio` is acceptable** — team has retracted
  the earlier "redundant decorator" guidance. The decorator is a style
  preference, not a correctness issue. sdk-review must NOT raise any
  finding, inline comment, or auto-fix for it.
- App-defining tests MUST use `clean_app_registry` (otherwise global
  registry pollution causes flakes)
- Unit tests must not exercise real external services
- `pytest.skip()` requires a reason and ideally a ticket link
- Tests must live where CI actually runs them

### NEW: `retro-log.md`
The structured do-not-flag log (this PR also fills a small gap in
PR #1485 by adding this file to the new `.mothership/pr-review/`
location — it was on main but not copied). First entry is the
asyncio negative rule, stored as YAML. `CLAUDE.md` now lists it as
a **mandatory** pre-finding consultation step: every candidate
finding is checked against `retro-log.md` before being raised.

### NEW: `retro-2026-05-20.md`
Theme breakdown + PR-level provenance for each rule.

## What's NOT in this PR

- `@pytest.mark.asyncio` rule was removed per team feedback. A
  DO-NOT-FLAG entry is recorded in `retro-log.md` and inline in
  `test-quality-rules.md` to prevent the pattern from re-emerging.

## Concrete evidence the rules are needed

| Pattern | PRs that slipped through |
|---|---|
| `dict[str, Any]` on public contracts/params/return types | #1759, #1723, #1792, #1643 |
| `@dataclass` on Pydantic contracts | #1759, #1573, #1804 |
| `raise X(...)` in `except` block without `from exc` | #1759, #1768, #1748, #1573, #1662, #1723 |
| Wrong-side Input/Output direction | #1787, #1792 |
| `feat!:` claim with no actual public break | #1573 |
| Edge-gateway WAF incompatibility | #1747 → reverted in #1782 |
| Credential & data sharing the same storage binding | #1638 |
| Validator coverage gap on injection-risk fields | #1785 |
| CI bypass keyed on caller-controlled input | #1757, #1775 |
| Tests outside the CI test tree | #1775 |
| Async shutdown without bounded wait | #1723 |
| Mutable default arg (`captured: dict = {}`) | #1723 |

## Test plan

- [ ] Merge order: #1485 first, then #1805
- [ ] Each rule is self-contained — readable without the retro file
- [ ] Each rule has a concrete detection heuristic
- [ ] `@pytest.mark.asyncio` is explicitly NOT flagged
- [ ] Pre-commit clean
- [ ] Next retro scheduled for 2026-06-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)