### PR TITLE
ci(fix): unit-tests gate fails on same-second race when polling for dispatched run

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -247,7 +247,11 @@ jobs:
           # `gh workflow run` doesn't return the new run's ID, so capture
           # it by listing recent dispatches after the trigger.
           echo "No existing run of '${WORKFLOW_FILE}' on ${SHA}. Dispatching on '${DISPATCH_REF}'..."
-          BEFORE=$(date -u +%FT%TZ)
+          # 5s buffer: `gh run list --created '>X'` uses strict-greater-than at
+          # second granularity, so a same-second dispatch silently excludes the
+          # newly-created run from polling results and the gate fails the 60s
+          # window even though the run actually got created.
+          BEFORE=$(date -u -d '5 seconds ago' +%FT%TZ)
           if ! gh workflow run "${WORKFLOW_FILE}" --repo "${REPO}" --ref "${DISPATCH_REF}"; then
             {
               echo "### Publish blocked: failed to dispatch '${WORKFLOW_FILE}'"


### PR DESCRIPTION
## Symptom

Build-and-publish on consumer apps **fails on the first attempt** and succeeds on retry. The failing step is `Resolve SHA, find or dispatch tests run`, with logs:

```
Dispatched. Polling for the new run to appear...
Attempt 1/12 — run not yet visible, retrying...
...
Attempt 12/12 — run not yet visible, retrying...
##[error]Dispatched 'tests.yml' but the new run never registered within 60s.
```

…but a manual check shows the dispatched run **was created on time** and ran fine. Reproduced on [atlan-popularity-app run 26159196700](https://github.com/atlanhq/atlan-popularity-app/actions/runs/26159196700/job/76946385161).

## Root cause

```bash
BEFORE=$(date -u +%FT%TZ)                # captured RIGHT BEFORE the dispatch
gh workflow run "${WORKFLOW_FILE}" ...    # dispatch — usually finishes within the same second
# ...
gh run list --created ">${BEFORE}" ...    # STRICT greater-than at second granularity
```

`gh run list --created ">X"` excludes runs whose `created_at == X`. In the failing case:

| | Value |
|---|---|
| `BEFORE` | `2026-05-20T11:20:35Z` |
| Dispatched run's `created_at` | `2026-05-20T11:20:35Z` |
| Filter `>2026-05-20T11:20:35Z` | excludes the run |

The gate then polls for 60 s looking for "newer" runs, finds none, fails. On retry, the timing diverges by a millisecond and the filter lands on a different second → run is included → gate passes.

## Fix

Buffer `BEFORE` by 5 seconds. The polling filter already constrains by repo + workflow + branch + event, so picking up a neighbouring run is virtually impossible — the buffer just absorbs sub-second clock skew.

```diff
-BEFORE=$(date -u +%FT%TZ)
+# 5s buffer: `gh run list --created '>X'` uses strict-greater-than at
+# second granularity, so a same-second dispatch silently excludes the
+# newly-created run from polling results and the gate fails the 60s
+# window even though the run actually got created.
+BEFORE=$(date -u -d '5 seconds ago' +%FT%TZ)
```

## Test plan

- [ ] Trigger build-and-publish on any consumer with `unit_tests_workflow_file` set (e.g. atlan-popularity-app or atlan-clickhouse-app)
- [ ] Confirm the polling step finds the dispatched run on attempt 1 (was attempt-2-onwards before the fix because the first iteration starts with `sleep 5`, but the run is now visible in the filter from the start)