### PR TITLE
ci(fix): replace manual git-cliff install with orhun/git-cliff-action

### DIFF
--- a/.github/workflows/contract-toolkit-release.yml
+++ b/.github/workflows/contract-toolkit-release.yml
@@ -27,7 +27,6 @@ permissions:
 env:
   PKG_NAME: app-contract-toolkit
   PKL_VERSION: "0.27.2"
-  GIT_CLIFF_VERSION: "2.7.0"
   RELEASE_LABEL: "release:contract-toolkit"
   BUMP_BRANCH: "bump-version-contract-toolkit"
 
@@ -55,19 +54,9 @@ jobs:
           sudo mv /tmp/pkl /usr/local/bin/pkl
 
       - name: Install git-cliff
-        run: |
-          set -euo pipefail
-          base="https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}"
-          archive="git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-          curl -fsSL -o "/tmp/${archive}" "${base}/${archive}"
-          expected="$(curl -fsSL "${base}/${archive}.sha256" | awk '{print $1}')"
-          actual="$(sha256sum "/tmp/${archive}" | awk '{print $1}')"
-          if [ "$expected" != "$actual" ]; then
-            echo "::error::SHA256 mismatch for ${archive}: expected ${expected}, got ${actual}"
-            exit 1
-          fi
-          tar -xz -f "/tmp/${archive}" -C /tmp
-          sudo mv "/tmp/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu/git-cliff" /usr/local/bin/git-cliff
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
+        with:
+          args: --version
 
       - name: Compute next version
         id: versions


### PR DESCRIPTION
## Problem

The Release Contract Toolkit workflow has been failing since PR #1778 introduced it. Every merge to `main` that touches `contract-toolkit/**` triggers the workflow, which immediately 404s during `Install git-cliff`:

```
curl: (22) The requested URL returned error: 404
```

Root cause: `GIT_CLIFF_VERSION: "2.7.0"` refers to a version that does not exist in the git-cliff release history. Additionally, the checksum verification used `.sha256` — which git-cliff releases dropped in favour of `.sha512` in recent versions.

## Why it happened

The manual install approach requires tracking three things independently:
- a version string that must exactly match a release tag
- a checksum file extension (`.sha256` vs `.sha512`) that can change across git-cliff releases
- a tarball/directory naming convention that must stay in sync

Any one of these drifting silently breaks the workflow. There is no mechanism that enforces consistency between the version we write here and what actually exists upstream.

## Fix

Replace the manual `Install git-cliff` step with `orhun/git-cliff-action`, SHA-pinned like every other action in this repo:

```yaml
- name: Install git-cliff
  uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
  with:
    args: --version
```

The action adds the `git-cliff` binary to PATH, so all subsequent `run:` steps that call `git cliff` work unchanged. Updating git-cliff in future now means bumping one action SHA — the same pattern we already use for every other tool in CI.

## Verification

After this merges, the next PR touching `contract-toolkit/**` should produce a `bump-version-contract-toolkit` PR automatically. The two runs that failed after PRs #1778 and #1803 can also be re-run manually via `workflow_dispatch`.