### PR TITLE
feat: metrics - add classified workflow failure counter for actionable alerts

### DIFF
--- a/application_sdk/execution/_temporal/interceptors/metrics.py
+++ b/application_sdk/execution/_temporal/interceptors/metrics.py
@@ -40,8 +40,6 @@ def _meter():
     return _otel_metrics.get_meter(_METER_NAME)
 
 
-# Lazily created singletons — meters/instruments are cheap to look up but we
-# only want one of each per process.
 _INSTRUMENTS: dict[str, Any] = {}
 
 

--- a/application_sdk/execution/_temporal/interceptors/metrics.py
+++ b/application_sdk/execution/_temporal/interceptors/metrics.py
@@ -27,12 +27,6 @@ from temporalio.worker import (
 from application_sdk.errors.categories import Audience, FailureCategory
 from application_sdk.execution._temporal.interceptors.log import _extract_failure_attrs
 
-# Audiences that should drive alerts / Sherlock dispatch. USER-audience failures
-# (auth, permission, invalid input, not found) are customer-fixable config noise
-# and are intentionally excluded from the classified counter — they remain
-# counted in ``temporal.workflow.executions`` for general visibility.
-_ALERTABLE_AUDIENCES = frozenset({Audience.PLATFORM.value, Audience.APP_OWNER.value})
-
 _METER_NAME = "application_sdk.temporal"
 
 
@@ -71,10 +65,11 @@ def _workflow_failures_classified():
             "temporal.workflow.failures.classified",
             unit="1",
             description=(
-                "Workflow failures partitioned by failure.category + "
-                "failure.audience. Only audience in {PLATFORM, APP_OWNER} is "
-                "emitted — USER failures (customer-fixable config) are "
-                "excluded so alerts driven off this counter are actionable."
+                "Workflow failures partitioned by failure.category and "
+                "failure.audience. Emitted for every failure across all "
+                "audiences (USER, PLATFORM, APP_OWNER); consumers filter at "
+                "query time — e.g. drop USER for actionable alerts, or keep "
+                "USER for customer-failure dashboards."
             ),
         )
     return _INSTRUMENTS["wf_fail_cls"]
@@ -157,11 +152,10 @@ class _MetricsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
                 _workflow_duration().record(duration_s, tagged)
                 if status == "ERROR":
                     classified = _classify_failure(exc_caught)
-                    if classified["failure.audience"] in _ALERTABLE_AUDIENCES:
-                        _workflow_failures_classified().add(
-                            1,
-                            {**attrs, **classified},
-                        )
+                    _workflow_failures_classified().add(
+                        1,
+                        {**attrs, **classified},
+                    )
             except Exception:  # noqa: S110 — best-effort observability; never block the workflow on metric emission
                 pass
 
@@ -206,8 +200,10 @@ class MetricsInterceptor(Interceptor):
     Instruments:
       * ``temporal.workflow.executions`` (counter)
       * ``temporal.workflow.duration`` (histogram, seconds)
-      * ``temporal.workflow.failures.classified`` (counter, only emitted for
-        ``failure.audience in {PLATFORM, APP_OWNER}`` — drives alert routing)
+      * ``temporal.workflow.failures.classified`` (counter, partitioned by
+        ``failure.category`` and ``failure.audience`` — consumers filter at
+        query time, e.g. drop ``failure_audience="USER"`` for actionable
+        alerts)
       * ``temporal.activity.executions`` (counter)
       * ``temporal.activity.duration`` (histogram, seconds)
       * ``temporal.activity.errors`` (counter, partitioned by ``exception.type``)

--- a/application_sdk/execution/_temporal/interceptors/metrics.py
+++ b/application_sdk/execution/_temporal/interceptors/metrics.py
@@ -24,6 +24,15 @@ from temporalio.worker import (
     WorkflowInterceptorClassInput,
 )
 
+from application_sdk.errors.categories import Audience, FailureCategory
+from application_sdk.execution._temporal.interceptors.log import _extract_failure_attrs
+
+# Audiences that should drive alerts / Sherlock dispatch. USER-audience failures
+# (auth, permission, invalid input, not found) are customer-fixable config noise
+# and are intentionally excluded from the classified counter — they remain
+# counted in ``temporal.workflow.executions`` for general visibility.
+_ALERTABLE_AUDIENCES = frozenset({Audience.PLATFORM.value, Audience.APP_OWNER.value})
+
 _METER_NAME = "application_sdk.temporal"
 
 
@@ -56,6 +65,21 @@ def _workflow_duration():
     return _INSTRUMENTS["wf_dur"]
 
 
+def _workflow_failures_classified():
+    if "wf_fail_cls" not in _INSTRUMENTS:
+        _INSTRUMENTS["wf_fail_cls"] = _meter().create_counter(
+            "temporal.workflow.failures.classified",
+            unit="1",
+            description=(
+                "Workflow failures partitioned by failure.category + "
+                "failure.audience. Only audience in {PLATFORM, APP_OWNER} is "
+                "emitted — USER failures (customer-fixable config) are "
+                "excluded so alerts driven off this counter are actionable."
+            ),
+        )
+    return _INSTRUMENTS["wf_fail_cls"]
+
+
 def _activity_executions():
     if "act_exec" not in _INSTRUMENTS:
         _INSTRUMENTS["act_exec"] = _meter().create_counter(
@@ -86,6 +110,27 @@ def _activity_errors():
     return _INSTRUMENTS["act_err"]
 
 
+def _classify_failure(exc: BaseException | None) -> dict[str, str]:
+    """Extract bounded {category, audience} labels for the classified counter.
+
+    Reuses :func:`_extract_failure_attrs` from the log interceptor so log and
+    metric paths agree on classification. When extraction yields no SDK-typed
+    failure (raw ``ValueError`` / 3rd-party exception), falls back to
+    ``INTERNAL`` / ``APP_OWNER`` per the SDK doctrine that unowned failures
+    default to the app team (see :class:`Audience` docstring).
+    """
+    attrs = _extract_failure_attrs(exc)
+    if attrs:
+        return {
+            "failure.category": attrs["failure.category"],
+            "failure.audience": attrs["failure.audience"],
+        }
+    return {
+        "failure.category": FailureCategory.INTERNAL.value,
+        "failure.audience": Audience.APP_OWNER.value,
+    }
+
+
 class _MetricsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
     async def execute_workflow(self, input: ExecuteWorkflowInput) -> Any:
         if workflow.unsafe.is_replaying():
@@ -97,10 +142,12 @@ class _MetricsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
         }
         start_ns = time.monotonic_ns()
         status = "OK"
+        exc_caught: BaseException | None = None
         try:
             return await self.next.execute_workflow(input)
-        except BaseException:
+        except BaseException as exc:
             status = "ERROR"
+            exc_caught = exc
             raise
         finally:
             duration_s = (time.monotonic_ns() - start_ns) / 1_000_000_000
@@ -108,6 +155,13 @@ class _MetricsWorkflowInboundInterceptor(WorkflowInboundInterceptor):
             try:
                 _workflow_executions().add(1, tagged)
                 _workflow_duration().record(duration_s, tagged)
+                if status == "ERROR":
+                    classified = _classify_failure(exc_caught)
+                    if classified["failure.audience"] in _ALERTABLE_AUDIENCES:
+                        _workflow_failures_classified().add(
+                            1,
+                            {**attrs, **classified},
+                        )
             except Exception:  # noqa: S110 — best-effort observability; never block the workflow on metric emission
                 pass
 
@@ -152,6 +206,8 @@ class MetricsInterceptor(Interceptor):
     Instruments:
       * ``temporal.workflow.executions`` (counter)
       * ``temporal.workflow.duration`` (histogram, seconds)
+      * ``temporal.workflow.failures.classified`` (counter, only emitted for
+        ``failure.audience in {PLATFORM, APP_OWNER}`` — drives alert routing)
       * ``temporal.activity.executions`` (counter)
       * ``temporal.activity.duration`` (histogram, seconds)
       * ``temporal.activity.errors`` (counter, partitioned by ``exception.type``)

--- a/application_sdk/execution/_temporal/interceptors/metrics.py
+++ b/application_sdk/execution/_temporal/interceptors/metrics.py
@@ -40,6 +40,8 @@ def _meter():
     return _otel_metrics.get_meter(_METER_NAME)
 
 
+# Lazily created singletons — meters/instruments are cheap to look up but we
+# only want one of each per process.
 _INSTRUMENTS: dict[str, Any] = {}
 
 

--- a/tests/unit/interceptors/test_metrics_interceptor.py
+++ b/tests/unit/interceptors/test_metrics_interceptor.py
@@ -169,9 +169,6 @@ class TestMetricsWorkflowInboundInterceptor:
             with pytest.raises(RuntimeError, match="boom"):
                 await interceptor.execute_workflow(MockExecuteWorkflowInput())
 
-        # Executions counter still fires with ERROR; raw exc also routes
-        # through the classified counter with INTERNAL / APP_OWNER fallback,
-        # so create_counter is invoked twice (one per instrument).
         exec_calls = [
             c
             for c in mock_meter.create_counter.return_value.add.call_args_list
@@ -190,7 +187,6 @@ class TestWorkflowFailuresClassified:
 
     @pytest.fixture
     def split_counters(self, mock_meter):
-        """Return (exec, classified) counters so emits are distinguishable."""
         exec_counter = MagicMock()
         classified_counter = MagicMock()
         histogram = MagicMock()
@@ -218,7 +214,6 @@ class TestWorkflowFailuresClassified:
 
     async def test_app_owner_audience_fires_with_correct_labels(self, split_counters):
         _, classified = split_counters
-        # Raw RuntimeError → fallback INTERNAL / APP_OWNER.
         await self._run_failing_workflow(RuntimeError("boom"), split_counters)
 
         classified.add.assert_called_once()
@@ -269,8 +264,6 @@ class TestWorkflowFailuresClassified:
             "application_sdk.execution._temporal.interceptors.metrics.workflow"
         ) as mock_wf:
             mock_wf.unsafe.is_replaying.return_value = True
-            # Under replay the interceptor delegates straight through without
-            # touching counters; the underlying exc still propagates.
             with pytest.raises(RuntimeError, match="boom"):
                 await interceptor.execute_workflow(MockExecuteWorkflowInput())
 
@@ -286,7 +279,6 @@ class TestWorkflowFailuresClassified:
         assert tags["failure.audience"] == Audience.APP_OWNER.value
 
     async def test_classified_emit_failure_is_silent(self, mock_meter):
-        """Metric exceptions must not propagate into workflow execution."""
         exec_counter = MagicMock()
         classified_counter = MagicMock()
         classified_counter.add.side_effect = RuntimeError("metrics broken")

--- a/tests/unit/interceptors/test_metrics_interceptor.py
+++ b/tests/unit/interceptors/test_metrics_interceptor.py
@@ -25,8 +25,6 @@ _METER_TARGET = (
     "application_sdk.execution._temporal.interceptors.metrics._otel_metrics.get_meter"
 )
 
-assert _ALERTABLE_AUDIENCES == {Audience.PLATFORM.value, Audience.APP_OWNER.value}
-
 
 @dataclass
 class MockWorkflowInfo:
@@ -102,6 +100,12 @@ class TestInstrumentCaching:
         c2 = _workflow_failures_classified()
         assert c1 is c2
         mock_meter.create_counter.assert_called_once()
+
+    def test_alertable_audiences_constant(self):
+        assert _ALERTABLE_AUDIENCES == {
+            Audience.PLATFORM.value,
+            Audience.APP_OWNER.value,
+        }
 
 
 class TestMetricsWorkflowInboundInterceptor:
@@ -302,6 +306,12 @@ class TestWorkflowFailuresClassified:
             mock_wf.info.return_value = MockWorkflowInfo()
             with pytest.raises(RuntimeError, match="boom"):
                 await interceptor.execute_workflow(MockExecuteWorkflowInput())
+
+        # Classified emit was attempted (raw RuntimeError → APP_OWNER fallback)
+        # and the RuntimeError from `.add` was swallowed by the interceptor's
+        # outer try/except, leaving only the original workflow exception to
+        # propagate.
+        classified_counter.add.assert_called_once()
 
 
 class TestMetricsActivityInboundInterceptor:

--- a/tests/unit/interceptors/test_metrics_interceptor.py
+++ b/tests/unit/interceptors/test_metrics_interceptor.py
@@ -324,6 +324,7 @@ class TestMetricsActivityInboundInterceptor:
             mock_act.info.return_value = MockActivityInfo()
             await interceptor.execute_activity(MockExecuteActivityInput())
 
+        # create_counter is called for both executions and (not errors on success)
         counter = mock_meter.create_counter.return_value
         counter.add.assert_called_once()
         tags = counter.add.call_args[0][1]
@@ -357,6 +358,7 @@ class TestMetricsActivityInboundInterceptor:
             with pytest.raises(ValueError, match="bad"):
                 await interceptor.execute_activity(MockExecuteActivityInput())
 
+        # Both executions counter and errors counter should be called
         exec_counter_calls = [
             c
             for c in mock_meter.create_counter.return_value.add.call_args_list
@@ -367,11 +369,14 @@ class TestMetricsActivityInboundInterceptor:
     async def test_error_increments_errors_counter_with_exception_type(
         self, mock_next, mock_meter
     ):
+        # Use separate counters for executions vs errors
         exec_counter = MagicMock()
         errors_counter = MagicMock()
         histogram = MagicMock()
+        call_count = [0]
 
         def make_counter(name, **kwargs):
+            call_count[0] += 1
             if "errors" in name:
                 return errors_counter
             return exec_counter

--- a/tests/unit/interceptors/test_metrics_interceptor.py
+++ b/tests/unit/interceptors/test_metrics_interceptor.py
@@ -10,7 +10,6 @@ import pytest
 from application_sdk.errors.categories import Audience, FailureCategory
 from application_sdk.errors.leaves import AuthError, DependencyUnavailableError
 from application_sdk.execution._temporal.interceptors.metrics import (
-    _ALERTABLE_AUDIENCES,
     _INSTRUMENTS,
     MetricsInterceptor,
     _activity_errors,
@@ -101,12 +100,6 @@ class TestInstrumentCaching:
         assert c1 is c2
         mock_meter.create_counter.assert_called_once()
 
-    def test_alertable_audiences_constant(self):
-        assert _ALERTABLE_AUDIENCES == {
-            Audience.PLATFORM.value,
-            Audience.APP_OWNER.value,
-        }
-
 
 class TestMetricsWorkflowInboundInterceptor:
     @pytest.fixture
@@ -184,9 +177,9 @@ class TestMetricsWorkflowInboundInterceptor:
 class TestWorkflowFailuresClassified:
     """Behaviour of `temporal.workflow.failures.classified` counter.
 
-    The counter must fire only for APP_OWNER / PLATFORM audiences. USER
-    failures (auth, permission, invalid input) are intentionally excluded
-    so alerts driven off this counter stay actionable.
+    Fires on every workflow failure, partitioned by failure.category and
+    failure.audience. Consumers filter at query time (e.g. drop USER) when
+    driving alerts.
     """
 
     @pytest.fixture
@@ -238,12 +231,15 @@ class TestWorkflowFailuresClassified:
         assert tags["failure.category"] == FailureCategory.DEPENDENCY_UNAVAILABLE.value
         assert tags["failure.audience"] == Audience.PLATFORM.value
 
-    async def test_user_audience_does_not_fire(self, split_counters):
+    async def test_user_audience_fires_with_user_label(self, split_counters):
         _, classified = split_counters
         exc = AuthError(message="bad creds")
         await self._run_failing_workflow(exc, split_counters)
 
-        classified.add.assert_not_called()
+        classified.add.assert_called_once()
+        tags = classified.add.call_args[0][1]
+        assert tags["failure.category"] == FailureCategory.AUTH.value
+        assert tags["failure.audience"] == Audience.USER.value
 
     async def test_success_does_not_fire(self, split_counters):
         _, classified = split_counters

--- a/tests/unit/interceptors/test_metrics_interceptor.py
+++ b/tests/unit/interceptors/test_metrics_interceptor.py
@@ -7,7 +7,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from application_sdk.errors.categories import Audience, FailureCategory
+from application_sdk.errors.leaves import AuthError, DependencyUnavailableError
 from application_sdk.execution._temporal.interceptors.metrics import (
+    _ALERTABLE_AUDIENCES,
     _INSTRUMENTS,
     MetricsInterceptor,
     _activity_errors,
@@ -15,11 +18,14 @@ from application_sdk.execution._temporal.interceptors.metrics import (
     _MetricsActivityInboundInterceptor,
     _MetricsWorkflowInboundInterceptor,
     _workflow_executions,
+    _workflow_failures_classified,
 )
 
 _METER_TARGET = (
     "application_sdk.execution._temporal.interceptors.metrics._otel_metrics.get_meter"
 )
+
+assert _ALERTABLE_AUDIENCES == {Audience.PLATFORM.value, Audience.APP_OWNER.value}
 
 
 @dataclass
@@ -91,6 +97,12 @@ class TestInstrumentCaching:
         _activity_executions()
         assert mock_meter.create_counter.call_count == 2
 
+    def test_workflow_failures_classified_cached(self, mock_meter):
+        c1 = _workflow_failures_classified()
+        c2 = _workflow_failures_classified()
+        assert c1 is c2
+        mock_meter.create_counter.assert_called_once()
+
 
 class TestMetricsWorkflowInboundInterceptor:
     @pytest.fixture
@@ -157,10 +169,147 @@ class TestMetricsWorkflowInboundInterceptor:
             with pytest.raises(RuntimeError, match="boom"):
                 await interceptor.execute_workflow(MockExecuteWorkflowInput())
 
-        counter = mock_meter.create_counter.return_value
-        counter.add.assert_called_once()
-        tags = counter.add.call_args[0][1]
-        assert tags["otel.status_code"] == "ERROR"
+        # Executions counter still fires with ERROR; raw exc also routes
+        # through the classified counter with INTERNAL / APP_OWNER fallback,
+        # so create_counter is invoked twice (one per instrument).
+        exec_calls = [
+            c
+            for c in mock_meter.create_counter.return_value.add.call_args_list
+            if c[0][1].get("otel.status_code") == "ERROR"
+        ]
+        assert len(exec_calls) == 1
+
+
+class TestWorkflowFailuresClassified:
+    """Behaviour of `temporal.workflow.failures.classified` counter.
+
+    The counter must fire only for APP_OWNER / PLATFORM audiences. USER
+    failures (auth, permission, invalid input) are intentionally excluded
+    so alerts driven off this counter stay actionable.
+    """
+
+    @pytest.fixture
+    def split_counters(self, mock_meter):
+        """Return (exec, classified) counters so emits are distinguishable."""
+        exec_counter = MagicMock()
+        classified_counter = MagicMock()
+        histogram = MagicMock()
+
+        def make_counter(name, **kwargs):
+            if "failures.classified" in name:
+                return classified_counter
+            return exec_counter
+
+        mock_meter.create_counter.side_effect = make_counter
+        mock_meter.create_histogram.return_value = histogram
+        return exec_counter, classified_counter
+
+    async def _run_failing_workflow(self, exc: BaseException, split_counters):
+        mock_next = AsyncMock()
+        mock_next.execute_workflow = AsyncMock(side_effect=exc)
+        interceptor = _MetricsWorkflowInboundInterceptor(mock_next)
+        with patch(
+            "application_sdk.execution._temporal.interceptors.metrics.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = False
+            mock_wf.info.return_value = MockWorkflowInfo()
+            with pytest.raises(type(exc)):
+                await interceptor.execute_workflow(MockExecuteWorkflowInput())
+
+    async def test_app_owner_audience_fires_with_correct_labels(self, split_counters):
+        _, classified = split_counters
+        # Raw RuntimeError → fallback INTERNAL / APP_OWNER.
+        await self._run_failing_workflow(RuntimeError("boom"), split_counters)
+
+        classified.add.assert_called_once()
+        tags = classified.add.call_args[0][1]
+        assert tags["temporal.workflow.type"] == "TestWorkflow"
+        assert tags["failure.category"] == FailureCategory.INTERNAL.value
+        assert tags["failure.audience"] == Audience.APP_OWNER.value
+
+    async def test_platform_audience_fires_with_dependency_unavailable(
+        self, split_counters
+    ):
+        _, classified = split_counters
+        exc = DependencyUnavailableError(message="dapr down")
+        await self._run_failing_workflow(exc, split_counters)
+
+        classified.add.assert_called_once()
+        tags = classified.add.call_args[0][1]
+        assert tags["failure.category"] == FailureCategory.DEPENDENCY_UNAVAILABLE.value
+        assert tags["failure.audience"] == Audience.PLATFORM.value
+
+    async def test_user_audience_does_not_fire(self, split_counters):
+        _, classified = split_counters
+        exc = AuthError(message="bad creds")
+        await self._run_failing_workflow(exc, split_counters)
+
+        classified.add.assert_not_called()
+
+    async def test_success_does_not_fire(self, split_counters):
+        _, classified = split_counters
+        mock_next = AsyncMock()
+        mock_next.execute_workflow = AsyncMock(return_value="ok")
+        interceptor = _MetricsWorkflowInboundInterceptor(mock_next)
+        with patch(
+            "application_sdk.execution._temporal.interceptors.metrics.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = False
+            mock_wf.info.return_value = MockWorkflowInfo()
+            await interceptor.execute_workflow(MockExecuteWorkflowInput())
+
+        classified.add.assert_not_called()
+
+    async def test_replay_does_not_fire(self, split_counters):
+        _, classified = split_counters
+        mock_next = AsyncMock()
+        mock_next.execute_workflow = AsyncMock(side_effect=RuntimeError("boom"))
+        interceptor = _MetricsWorkflowInboundInterceptor(mock_next)
+        with patch(
+            "application_sdk.execution._temporal.interceptors.metrics.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = True
+            # Under replay the interceptor delegates straight through without
+            # touching counters; the underlying exc still propagates.
+            with pytest.raises(RuntimeError, match="boom"):
+                await interceptor.execute_workflow(MockExecuteWorkflowInput())
+
+        classified.add.assert_not_called()
+
+    async def test_raw_exception_falls_back_to_internal_app_owner(self, split_counters):
+        _, classified = split_counters
+        await self._run_failing_workflow(ValueError("oops"), split_counters)
+
+        classified.add.assert_called_once()
+        tags = classified.add.call_args[0][1]
+        assert tags["failure.category"] == FailureCategory.INTERNAL.value
+        assert tags["failure.audience"] == Audience.APP_OWNER.value
+
+    async def test_classified_emit_failure_is_silent(self, mock_meter):
+        """Metric exceptions must not propagate into workflow execution."""
+        exec_counter = MagicMock()
+        classified_counter = MagicMock()
+        classified_counter.add.side_effect = RuntimeError("metrics broken")
+        histogram = MagicMock()
+
+        def make_counter(name, **kwargs):
+            if "failures.classified" in name:
+                return classified_counter
+            return exec_counter
+
+        mock_meter.create_counter.side_effect = make_counter
+        mock_meter.create_histogram.return_value = histogram
+
+        mock_next = AsyncMock()
+        mock_next.execute_workflow = AsyncMock(side_effect=RuntimeError("boom"))
+        interceptor = _MetricsWorkflowInboundInterceptor(mock_next)
+        with patch(
+            "application_sdk.execution._temporal.interceptors.metrics.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = False
+            mock_wf.info.return_value = MockWorkflowInfo()
+            with pytest.raises(RuntimeError, match="boom"):
+                await interceptor.execute_workflow(MockExecuteWorkflowInput())
 
 
 class TestMetricsActivityInboundInterceptor:
@@ -183,7 +332,6 @@ class TestMetricsActivityInboundInterceptor:
             mock_act.info.return_value = MockActivityInfo()
             await interceptor.execute_activity(MockExecuteActivityInput())
 
-        # create_counter is called for both executions and (not errors on success)
         counter = mock_meter.create_counter.return_value
         counter.add.assert_called_once()
         tags = counter.add.call_args[0][1]
@@ -217,7 +365,6 @@ class TestMetricsActivityInboundInterceptor:
             with pytest.raises(ValueError, match="bad"):
                 await interceptor.execute_activity(MockExecuteActivityInput())
 
-        # Both executions counter and errors counter should be called
         exec_counter_calls = [
             c
             for c in mock_meter.create_counter.return_value.add.call_args_list
@@ -228,14 +375,11 @@ class TestMetricsActivityInboundInterceptor:
     async def test_error_increments_errors_counter_with_exception_type(
         self, mock_next, mock_meter
     ):
-        # Use separate counters for executions vs errors
         exec_counter = MagicMock()
         errors_counter = MagicMock()
         histogram = MagicMock()
-        call_count = [0]
 
         def make_counter(name, **kwargs):
-            call_count[0] += 1
             if "errors" in name:
                 return errors_counter
             return exec_counter


### PR DESCRIPTION
## Summary

Adds `temporal.workflow.failures.classified` counter on the workflow metrics interceptor. Surfaces the SDK's existing `FailureCategory` / `Audience` taxonomy as a Prom-safe alertable signal, so VMRules can route workflow-failure alerts by responsible team (USER vs PLATFORM vs APP_OWNER) instead of pageing on every `otel_status_code="ERROR"`.

- Fires on **every** workflow failure (replay-skipped). Labels: `temporal.workflow.type`, `failure.category`, `failure.audience`. All bounded — Prom-safe.
- Consumers filter at query time:
  - actionable alerts → `{failure_audience!="USER"}` (drops customer-fixable config noise)
  - product/UX dashboards → keep USER for customer-failure trends
- Classification reuses `_extract_failure_attrs` from the log interceptor (`interceptors/log.py:63`), so log and metric paths agree on `failure.category` / `failure.audience` values.
- Raw exceptions (`ValueError`, 3rd-party) without SDK classification fall back to `INTERNAL` / `APP_OWNER` per the `Audience` doctrine that unowned failures default to the app team. Creates pressure for typed-failure adoption via `/typed-failures`.
- `failure.code` and `workflow.id` / `run.id` are intentionally **not** on the metric — high cardinality, recoverable via correlated `otel_logs.service_logs` query on `workflow.ended` ERROR rows.

## Why

Today the only alertable workflow-failure signal is `temporal_workflow_executions_total{otel_status_code="ERROR"}` — binary outcome, no classification axis. Alerts driven off it can't distinguish:
- "bad creds in tenant config" (USER, customer-fixable, alert noise)
- "Dapr sidecar OOM" (PLATFORM, infra ops paging)
- "connector bug" (APP_OWNER, app team page)

Most failures observed in prod are USER-audience config issues, drowning out real APP_OWNER/PLATFORM signals. This counter exposes the same classification the SDK already attaches to `workflow.ended` logs, but on a metric so it can drive VMRule alerts + incident.io routing + Sherlock auto-triage.

## What changed

- `application_sdk/execution/_temporal/interceptors/metrics.py`
  - new `_workflow_failures_classified()` instrument (`temporal.workflow.failures.classified`)
  - new `_classify_failure(exc)` helper — wraps `_extract_failure_attrs` with `INTERNAL`/`APP_OWNER` fallback
  - workflow inbound interceptor captures `exc_caught` in `except`; emits classified counter in `finally` for every failure
  - replay-skip preserved; metric exceptions swallowed (`except Exception: pass`)
- `tests/unit/interceptors/test_metrics_interceptor.py`
  - new `TestWorkflowFailuresClassified` (7 cases): APP_OWNER fires for InternalError; PLATFORM fires for `DependencyUnavailableError`; USER fires for `AuthError`; success no-op; replay no-op; raw exception → INTERNAL/APP_OWNER fallback; metric-emit-failure swallowed (classified.add still attempted)
  - instrument-caching test extended for the new counter
  - one pre-existing workflow-error test adapted because shared mock `create_counter.return_value` now sees `.add` from both exec + classified counters

## Counter shape (per failure)

```
temporal_workflow_failures_classified_total{
  temporal_workflow_type="dynamodb-metadata-extractor",
  failure_category="DEPENDENCY_UNAVAILABLE",  # one of 15 FailureCategory enum values
  failure_audience="PLATFORM",                # one of {USER, PLATFORM, APP_OWNER}
  app_name="amazon-dynamodb-assets",          # free OTel resource attrs
  domainName="...", clusterName="...", deploymentType="Production",
} 1
```

Series cardinality bound: `~3 audiences × ~15 categories × workflow_types × tenant × cluster × deploymentType`. Trivial for VM/vmagent.

## Driving use case (follow-up PRs)

Future VMRule in `atlan-alerts` (App-Platform / App-Resiliency):

```yaml
# Warning — actionable failures
sum by (clusterName, domainName, app_name, temporal_workflow_type,
        failure_audience, failure_category) (
  increase(temporal_workflow_failures_classified_total{
    failure_audience!="USER",
    deploymentType=~"Production|Trial"
  }[15m])
) >= 3
```

Routes via Alertmanager → incident.io. Critical-severity rule (≥10/15m) escalates to Sherlock via incident webhook.

## Test plan

- [x] `pytest tests/unit/interceptors/test_metrics_interceptor.py` — 22/22 pass
- [x] `pre-commit run` — ruff, ruff-format, isort, pyright pass
- [ ] Deploy to a tenant; verify `temporal_workflow_failures_classified_total` series appears in Prom for a known failed workflow with all 3 audience values
- [ ] Confirm USER-audience series exists (e.g. trigger `AuthError`) — proves consumer can opt in to seeing it
- [ ] Confirm raw exception (e.g. uncaught `ValueError`) emits with `failure_category="INTERNAL"`, `failure_audience="APP_OWNER"`
- [ ] Follow-up PR in `atlan-alerts` adds VMRule querying this counter with `failure_audience!="USER"` filter