### PR TITLE
ci: strip refs/heads/ from DISPATCH_REF before gh run list --branch

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -247,6 +247,11 @@ jobs:
           # `gh workflow run` doesn't return the new run's ID, so capture
           # it by listing recent dispatches after the trigger.
           echo "No existing run of '${WORKFLOW_FILE}' on ${SHA}. Dispatching on '${DISPATCH_REF}'..."
+          # `gh run list --branch` compares against the short headBranch (e.g. 'main'),
+          # not the full ref ('refs/heads/main'). Strip the prefix so the filter actually
+          # matches the dispatched run.
+          DISPATCH_BRANCH="${DISPATCH_REF#refs/heads/}"
+          DISPATCH_BRANCH="${DISPATCH_BRANCH#refs/tags/}"
           BEFORE=$(date -u +%FT%TZ)
           if ! gh workflow run "${WORKFLOW_FILE}" --repo "${REPO}" --ref "${DISPATCH_REF}"; then
             {
@@ -275,7 +280,7 @@ jobs:
             RUN_ID=$(gh run list \
               --repo "${REPO}" \
               --workflow "${WORKFLOW_FILE}" \
-              --branch "${DISPATCH_REF}" \
+              --branch "${DISPATCH_BRANCH}" \
               --event workflow_dispatch \
               --created ">${BEFORE}" \
               --limit 1 \


### PR DESCRIPTION
## Symptom

Every **first attempt** of build-and-publish on a fresh SHA fails at the gate with:

```
Attempt 12/12 — run not yet visible, retrying...
##[error]Dispatched 'tests.yml' but the new run never registered within 60s.
```

…but a **second attempt** succeeds without any code change, on the same SHA.

Reproduced live on [atlan-popularity-app run 26171701824](https://github.com/atlanhq/atlan-popularity-app/actions/runs/26171701824) — attempt 1 failed, attempt 2 passed and published.

(Closing [#1808][1808] which misdiagnosed this as a same-second `--created` race.)

[1808]: https://github.com/atlanhq/application-sdk/pull/1808

## Root cause

The post-dispatch polling step calls:

```bash
gh run list \
  --repo "${REPO}" \
  --workflow "${WORKFLOW_FILE}" \
  --branch "${DISPATCH_REF}" \    # <— here
  --event workflow_dispatch \
  --created ">${BEFORE}" \
  --limit 1 ...
```

`DISPATCH_REF` is set from `inputs.ref || github.ref_name`. On the common push-to-main flow, the consumer's caller forwards `github.ref` (which is `refs/heads/main`), so `DISPATCH_REF` ends up as **`refs/heads/main`**.

But `gh run list --branch` filters against the run's **`headBranch`** field, which carries the **short branch name** (e.g. `main`). The full-ref-prefixed value never matches:

```
$ gh run list --branch 'refs/heads/main' --workflow tests.yml --event workflow_dispatch
[]    # empty

$ gh run list --branch 'main' --workflow tests.yml --event workflow_dispatch
[ matches the dispatched run ]
```

The dispatched run **was** created — the workflow ran to success — but the gate's polling never saw it because of the branch format mismatch. After 12 retries, the gate fails.

On attempt 2, the gate hits its existing-run lookup first:

```bash
EXISTING=$(gh run list \
  --repo "${REPO}" \
  --workflow "${WORKFLOW_FILE}" \
  --commit "${SHA}" \              # <— no --branch filter
  --limit 1 ...)
```

That uses `--commit` (not `--branch`), so it correctly finds the run that attempt 1's dispatch had created. Attempt 2 reuses it and the rest of the chain succeeds.

## Evidence

From popularity-app attempt 2's log verbatim:

```
Resolved 'refs/heads/main' → 58b6ea6226a3eee3b8db256fb5bd9d2086e5a223
Found existing run 26171711061 of 'tests.yml' on 58b6ea6226a3eee3b8db256fb5bd9d2086e5a223 — reusing.
Polling run 26171711061 every 30s (timeout 30m)...
```

Run `26171711061` was the run attempt 1 dispatched and lost track of.

## Fix

Derive `DISPATCH_BRANCH` from `DISPATCH_REF` by stripping `refs/heads/` or `refs/tags/`, and use that bare value in the `--branch` filter. `gh workflow run --ref` accepts both prefixed and bare forms, so the dispatch call is unaffected.

```diff
+ # `gh run list --branch` compares against the short headBranch (e.g. 'main'),
+ # not the full ref ('refs/heads/main'). Strip the prefix so the filter actually
+ # matches the dispatched run.
+ DISPATCH_BRANCH="${DISPATCH_REF#refs/heads/}"
+ DISPATCH_BRANCH="${DISPATCH_BRANCH#refs/tags/}"
  BEFORE=$(date -u +%FT%TZ)
  ...
-           --branch "${DISPATCH_REF}" \
+           --branch "${DISPATCH_BRANCH}" \
```

## Test plan

- [ ] Pick any consumer that has `unit_tests_workflow_file` set (e.g. atlan-popularity-app or atlan-clickhouse-app). Push an empty commit to main. Confirm the **first** build-and-publish attempt:
  - Resolves SHA
  - Dispatches `tests.yml` on the publish ref
  - Polling finds the new run within 1–2 attempts (was attempt-NEVER before)
  - Gate succeeds, publish proceeds