### PR TITLE
fix(observability): suppress health/ready/metrics logs across mounts (BLDX-1292)

### DIFF
--- a/application_sdk/server/middleware/log.py
+++ b/application_sdk/server/middleware/log.py
@@ -30,7 +30,9 @@ class LogMiddleware(BaseHTTPMiddleware):
         token = request_context.set({"request_id": request_id})
         start_time = time.time()
 
-        should_log = request.url.path not in EXCLUDED_LOG_PATHS
+        # Suffix match so excluded paths are suppressed regardless of mount
+        # prefix (e.g. `/automation/server/health` still matches `/server/health`).
+        should_log = not any(request.url.path.endswith(p) for p in EXCLUDED_LOG_PATHS)
 
         if should_log:
             client_host = request.client.host if request.client else None

--- a/tests/unit/server/middleware/test_log.py
+++ b/tests/unit/server/middleware/test_log.py
@@ -1,0 +1,89 @@
+"""Unit tests for LogMiddleware path-exclusion behavior."""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from application_sdk.server.middleware import EXCLUDED_LOG_PATHS, LogMiddleware
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(LogMiddleware)
+
+    @app.get("/server/health")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/server/ready")
+    def ready() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/metrics")
+    def metrics() -> str:
+        return "metrics"
+
+    @app.get("/automation/server/health")
+    def prefixed_health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/automation/server/ready")
+    def prefixed_ready() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/automation/metrics")
+    def prefixed_metrics() -> str:
+        return "metrics"
+
+    @app.get("/workflows/start")
+    def workflows() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(_build_app())
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/server/health",
+        "/server/ready",
+        "/metrics",
+        "/automation/server/health",
+        "/automation/server/ready",
+        "/automation/metrics",
+    ],
+)
+def test_excluded_paths_are_not_logged(client: TestClient, path: str) -> None:
+    """Excluded paths must not produce request-started or request-completed logs,
+    regardless of whether the app is mounted under a prefix."""
+    with patch("application_sdk.server.middleware.log.logger.info") as mock_info:
+        response = client.get(path)
+    assert response.status_code == 200
+    assert (
+        mock_info.call_count == 0
+    ), f"path {path} unexpectedly produced log entries: {mock_info.call_args_list}"
+
+
+def test_non_excluded_path_is_logged(client: TestClient) -> None:
+    """Non-excluded paths emit both a started and a completed log entry."""
+    with patch("application_sdk.server.middleware.log.logger.info") as mock_info:
+        response = client.get("/workflows/start")
+    assert response.status_code == 200
+    # one "Request started", one "Request completed"
+    assert mock_info.call_count == 2
+
+
+def test_excluded_log_paths_set_contents() -> None:
+    """Regression: ensure the canonical exclusion set hasn't drifted."""
+    assert "/server/health" in EXCLUDED_LOG_PATHS
+    assert "/server/ready" in EXCLUDED_LOG_PATHS
+    assert "/metrics" in EXCLUDED_LOG_PATHS
+    assert "/health" in EXCLUDED_LOG_PATHS
+    assert "/ready" in EXCLUDED_LOG_PATHS


### PR DESCRIPTION
## Summary

- `LogMiddleware` exclusion was an exact-match set membership check, so paths under a FastAPI mount prefix (e.g. `/automation/server/health`) slipped through and spammed central LH `app_logs` with one log per health/ready probe per tenant.
- Switch the check from `path not in EXCLUDED_LOG_PATHS` to a **suffix match** (`any(path.endswith(p) for p in ...)`) so excluded paths are skipped regardless of mount prefix.
- Add unit tests covering both bare and prefixed forms of `/server/health`, `/server/ready`, and `/metrics`, plus a positive case for a non-excluded path.

## Why

From production logs in the App Logs - Central Lakehouse v2 dashboard:

```
Request started for GET /automation/server/health
Request completed for GET /automation/server/health 200
Request started for GET /automation/server/ready
Request completed for GET /automation/server/ready 200
Request started for GET /automation/metrics
Request completed for GET /automation/metrics 200
```

Every tenant, every few seconds. The automation engine mounts the SDK FastAPI app under `/automation`, so the exact-match set lookup never matches.

## Risk

Suffix matching could in theory swallow a legitimate endpoint that ends with `/health`, `/ready`, `/metrics`, `/server/health`, `/server/ready`, or `/api/eventingress[/]`. None exist today, and any future endpoint with one of these suffixes would almost certainly be a probe we want suppressed anyway.

## Test plan

- [x] `pytest tests/unit/server/middleware/test_log.py` — 8 passed
- [x] `pre-commit run --files application_sdk/server/middleware/log.py tests/unit/server/middleware/test_log.py` — passed
- [ ] Verify in a tenant via App Logs - Central Lakehouse v2 dashboard once shipped: `/server/health`, `/server/ready`, `/metrics` lines disappear

Linear: [BLDX-1292](https://linear.app/atlan-epd/issue/BLDX-1292)