### PR TITLE
feat: enable Temporal UI in embedded dev runtime

### DIFF
--- a/application_sdk/dev/_embedded.py
+++ b/application_sdk/dev/_embedded.py
@@ -31,7 +31,7 @@ async def embedded_runtime(
     namespace: str = "default",
     log_level: str = "warn",
     temporal_ui: bool = False,
-    temporal_ui_port: int | None = None,
+    temporal_ui_port: int = 8233,
 ) -> AsyncIterator[EmbeddedRuntime]:
     """Boot an in-process workflow runtime for local development.
 
@@ -42,11 +42,10 @@ async def embedded_runtime(
     from temporalio.testing import WorkflowEnvironment  # noqa: PLC0415
 
     logger.info("Starting embedded workflow runtime")
-    resolved_ui_port = temporal_ui_port if temporal_ui_port is not None else 8233
     env = await WorkflowEnvironment.start_local(
         namespace=namespace,
         ui=temporal_ui,
-        ui_port=resolved_ui_port if temporal_ui else None,
+        ui_port=temporal_ui_port if temporal_ui else None,
         dev_server_log_level=log_level,
         dev_server_extra_args=[
             "--dynamic-config-value",
@@ -56,7 +55,7 @@ async def embedded_runtime(
     try:
         host = env.client.service_client.config.target_host
         logger.info("Embedded workflow runtime ready at %s", host)
-        ui_url = f"http://127.0.0.1:{resolved_ui_port}" if temporal_ui else None
+        ui_url = f"http://127.0.0.1:{temporal_ui_port}" if temporal_ui else None
         yield EmbeddedRuntime(host=host, namespace=namespace, ui_url=ui_url)
     finally:
         logger.info("Shutting down embedded workflow runtime")

--- a/application_sdk/dev/_embedded.py
+++ b/application_sdk/dev/_embedded.py
@@ -21,12 +21,17 @@ class EmbeddedRuntime:
     namespace: str = "default"
     """Workflow namespace served by the embedded runtime."""
 
+    ui_url: str | None = None
+    """Temporal Web UI URL when enabled for local development."""
+
 
 @asynccontextmanager
 async def embedded_runtime(
     *,
     namespace: str = "default",
     log_level: str = "warn",
+    temporal_ui: bool = False,
+    temporal_ui_port: int | None = None,
 ) -> AsyncIterator[EmbeddedRuntime]:
     """Boot an in-process workflow runtime for local development.
 
@@ -37,8 +42,11 @@ async def embedded_runtime(
     from temporalio.testing import WorkflowEnvironment  # noqa: PLC0415
 
     logger.info("Starting embedded workflow runtime")
+    resolved_ui_port = temporal_ui_port if temporal_ui_port is not None else 8233
     env = await WorkflowEnvironment.start_local(
         namespace=namespace,
+        ui=temporal_ui,
+        ui_port=resolved_ui_port if temporal_ui else None,
         dev_server_log_level=log_level,
         dev_server_extra_args=[
             "--dynamic-config-value",
@@ -48,7 +56,8 @@ async def embedded_runtime(
     try:
         host = env.client.service_client.config.target_host
         logger.info("Embedded workflow runtime ready at %s", host)
-        yield EmbeddedRuntime(host=host, namespace=namespace)
+        ui_url = f"http://127.0.0.1:{resolved_ui_port}" if temporal_ui else None
+        yield EmbeddedRuntime(host=host, namespace=namespace, ui_url=ui_url)
     finally:
         logger.info("Shutting down embedded workflow runtime")
         await env.shutdown()

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -1188,7 +1188,7 @@ async def run_dev_combined(
     temporal_host: str | None = None,  # deprecated — ignored, kept for back-compat
     temporal_namespace: str | None = None,
     temporal_ui: bool = False,
-    temporal_ui_port: int | None = None,
+    temporal_ui_port: int = 8233,
     task_queue: str | None = None,
 ) -> None:
     """Run worker + handler in a single process for local development.
@@ -1234,8 +1234,7 @@ async def run_dev_combined(
             ``"default"``.
         temporal_ui: Enable the embedded Temporal Web UI for local debugging.
             Default ``False`` keeps the dev server headless.
-        temporal_ui_port: Optional Temporal Web UI port. Defaults to ``8233``
-            when ``temporal_ui`` is enabled.
+        temporal_ui_port: Temporal Web UI port. Defaults to ``8233``.
         task_queue: Task queue name. Default precedence: kwarg →
             ``ATLAN_TASK_QUEUE`` → ``"{app_name}-queue"``.
 

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -1187,6 +1187,8 @@ async def run_dev_combined(
     port: int | None = None,
     temporal_host: str | None = None,  # deprecated — ignored, kept for back-compat
     temporal_namespace: str | None = None,
+    temporal_ui: bool = False,
+    temporal_ui_port: int | None = None,
     task_queue: str | None = None,
 ) -> None:
     """Run worker + handler in a single process for local development.
@@ -1230,6 +1232,10 @@ async def run_dev_combined(
         temporal_namespace: Temporal namespace. Default precedence: kwarg →
             ``ATLAN_TEMPORAL_NAMESPACE`` → ``ATLAN_WORKFLOW_NAMESPACE`` →
             ``"default"``.
+        temporal_ui: Enable the embedded Temporal Web UI for local debugging.
+            Default ``False`` keeps the dev server headless.
+        temporal_ui_port: Optional Temporal Web UI port. Defaults to ``8233``
+            when ``temporal_ui`` is enabled.
         task_queue: Task queue name. Default precedence: kwarg →
             ``ATLAN_TASK_QUEUE`` → ``"{app_name}-queue"``.
 
@@ -1275,9 +1281,15 @@ async def run_dev_combined(
     # startup and log spurious "objectstore upload failed" warnings.
     async with (
         embedded_dapr(app_id=app_name) as _dapr,
-        embedded_runtime(namespace=temporal_namespace or "default") as _rt,
+        embedded_runtime(
+            namespace=temporal_namespace or "default",
+            temporal_ui=temporal_ui,
+            temporal_ui_port=temporal_ui_port,
+        ) as _rt,
     ):
         del _dapr  # env-side-effect is sufficient; the dataclass is just for tests
+        if _rt.ui_url:
+            print(f"\nTemporal UI running at {_rt.ui_url}")
         await _run_dev_combined_inner(
             app_class=app_class,
             credential_stores=credential_stores,

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.12.1
-source-sha:    eb24effade0c5ed17743ad1fa7a22385e5a0c7bf
-source-date:   2026-05-20T00:20:24+01:00
+sdk-version:   3.12.2
+source-sha:    7f86b2b2e8b38b25a18e5545f05aa0b3ebd12c5d
+source-date:   2026-05-20T23:24:07+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/docs/concepts/entry-points.md
+++ b/docs/concepts/entry-points.md
@@ -73,6 +73,13 @@ asyncio.run(run_dev_combined(MyExtractor))
 
 This starts both the Temporal worker and the HTTP handler service in a single process. It derives the module path automatically from the class.
 
+To inspect local workflows in Temporal Web UI, enable it explicitly. The UI
+uses port `8233` by default:
+
+```python
+asyncio.run(run_dev_combined(MyExtractor, temporal_ui=True))
+```
+
 ### Custom Secrets for Local Dev
 
 Pass credentials directly for local development — `run_dev_combined` auto-provisions them

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -132,8 +132,13 @@ asyncio.run(
         PostgresApp,
         credentials={"host": "localhost", "port": "5432", ...},
         example_input={"connection": {"connection_name": "test", ...}},
+        temporal_ui=True,
+        temporal_ui_port=8233,
     )
 )
 ```
+
+`temporal_ui` is local-dev only. When enabled, the embedded Temporal Web UI
+binds to `http://127.0.0.1:8233` unless `temporal_ui_port` is set.
 
 See [Getting Started](../guides/getting-started.md#step-7-optional-use-run_dev_combined) for details.

--- a/tests/unit/dev/test_embedded.py
+++ b/tests/unit/dev/test_embedded.py
@@ -21,16 +21,56 @@ class TestEmbeddedRuntimeLifecycle:
         fake_env.client.service_client.config.target_host = "127.0.0.1:54321"
         fake_env.shutdown = AsyncMock(return_value=None)
 
+        start_local = AsyncMock(return_value=fake_env)
         with patch(
             "temporalio.testing.WorkflowEnvironment.start_local",
-            AsyncMock(return_value=fake_env),
+            start_local,
         ):
             async with embedded_runtime(namespace="ns1") as rt:
                 assert isinstance(rt, EmbeddedRuntime)
                 assert rt.host == "127.0.0.1:54321"
                 assert rt.namespace == "ns1"
+                assert rt.ui_url is None
 
         fake_env.shutdown.assert_awaited_once()
+        assert start_local.await_args.kwargs["ui"] is False
+        assert start_local.await_args.kwargs["ui_port"] is None
+
+    async def test_can_enable_temporal_ui(self) -> None:
+        """Temporal Web UI can be enabled with the default SDK port."""
+        fake_env = MagicMock()
+        fake_env.client.service_client.config.target_host = "127.0.0.1:54321"
+        fake_env.shutdown = AsyncMock(return_value=None)
+
+        start_local = AsyncMock(return_value=fake_env)
+        with patch(
+            "temporalio.testing.WorkflowEnvironment.start_local",
+            start_local,
+        ):
+            async with embedded_runtime(temporal_ui=True) as rt:
+                assert rt.ui_url == "http://127.0.0.1:8233"
+
+        fake_env.shutdown.assert_awaited_once()
+        assert start_local.await_args.kwargs["ui"] is True
+        assert start_local.await_args.kwargs["ui_port"] == 8233
+
+    async def test_can_override_temporal_ui_port(self) -> None:
+        """Temporal Web UI can bind to an explicit port when requested."""
+        fake_env = MagicMock()
+        fake_env.client.service_client.config.target_host = "127.0.0.1:54321"
+        fake_env.shutdown = AsyncMock(return_value=None)
+
+        start_local = AsyncMock(return_value=fake_env)
+        with patch(
+            "temporalio.testing.WorkflowEnvironment.start_local",
+            start_local,
+        ):
+            async with embedded_runtime(temporal_ui=True, temporal_ui_port=9233) as rt:
+                assert rt.ui_url == "http://127.0.0.1:9233"
+
+        fake_env.shutdown.assert_awaited_once()
+        assert start_local.await_args.kwargs["ui"] is True
+        assert start_local.await_args.kwargs["ui_port"] == 9233
 
     async def test_shutdown_runs_even_when_body_raises(self) -> None:
         """The runtime is torn down even if the caller raises inside the context."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1311,6 +1311,8 @@ def _stub_embedded_daemons():
     from application_sdk.dev._dapr import EmbeddedDapr
     from application_sdk.dev._embedded import EmbeddedRuntime
 
+    captured_runtime_kwargs: list[dict[str, object]] = []
+
     @asynccontextmanager
     async def _fake_dapr(**_kwargs):
         yield EmbeddedDapr(
@@ -1319,7 +1321,12 @@ def _stub_embedded_daemons():
 
     @asynccontextmanager
     async def _fake_runtime(**_kwargs):
-        yield EmbeddedRuntime(host="127.0.0.1:7233", namespace="default")
+        captured_runtime_kwargs.append(_kwargs)
+        temporal_ui = bool(_kwargs.get("temporal_ui", False))
+        temporal_ui_port = _kwargs.get("temporal_ui_port")
+        resolved_ui_port = temporal_ui_port if temporal_ui_port is not None else 8233
+        ui_url = f"http://127.0.0.1:{resolved_ui_port}" if temporal_ui else None
+        yield EmbeddedRuntime(host="127.0.0.1:7233", namespace="default", ui_url=ui_url)
 
     # ``run_dev_combined`` does ``from application_sdk.dev import embedded_dapr,
     # embedded_runtime`` lazily inside the function body, so patch them on the
@@ -1328,7 +1335,7 @@ def _stub_embedded_daemons():
         patch("application_sdk.dev.embedded_dapr", _fake_dapr),
         patch("application_sdk.dev.embedded_runtime", _fake_runtime),
     ):
-        yield
+        yield captured_runtime_kwargs
 
 
 class TestRunDevCombined:
@@ -1417,6 +1424,36 @@ class TestRunDevCombined:
             )
         out = capsys.readouterr().out
         assert "abc" in out
+
+    async def test_temporal_ui_options_are_passed_to_embedded_runtime(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        _stub_embedded_daemons: list[dict[str, object]],
+    ) -> None:
+        """Temporal UI options are forwarded and the UI URL is printed."""
+        monkeypatch.setenv("DAPR_HTTP_PORT", "3500")
+        with (
+            patch(
+                "application_sdk.main._create_infrastructure",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+            patch("application_sdk.infrastructure.context.set_infrastructure"),
+            patch(
+                "application_sdk.main.run_combined_mode",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await run_dev_combined(
+                _fake_app_class(),
+                temporal_ui=True,
+                temporal_ui_port=8233,
+            )
+
+        assert _stub_embedded_daemons[-1]["temporal_ui"] is True
+        assert _stub_embedded_daemons[-1]["temporal_ui_port"] == 8233
+        assert "Temporal UI running at http://127.0.0.1:8233" in capsys.readouterr().out
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- add opt-in Temporal Web UI support to the embedded local dev runtime
- expose `temporal_ui` and `temporal_ui_port` on `run_dev_combined`
- default the UI to port `8233` when enabled and print the local UI URL at startup
- keep embedded runtime headless by default

## App Opt-In
Apps that want the local Temporal UI need to opt in from their local dev script:

```python
asyncio.run(
    run_dev_combined(
        MyApp,
        temporal_ui=True,
    )
)
```

This starts the UI at `http://127.0.0.1:8233`. Apps can override the port when needed:

```python
asyncio.run(
    run_dev_combined(
        MyApp,
        temporal_ui=True,
        temporal_ui_port=9233,
    )
)
```

No app changes are required unless the app wants the UI; the embedded runtime remains headless by default.

## Tests
- `uv run pytest tests/unit/dev/test_embedded.py tests/unit/test_main.py::TestRunDevCombined -q`
- `uv run pre-commit run --files application_sdk/dev/_embedded.py application_sdk/main.py tests/unit/dev/test_embedded.py tests/unit/test_main.py docs/concepts/entry-points.md docs/reference/cli.md`
