### PR TITLE
chore(ci): use GITHUB_TOKEN for security-gate PR comment

### DIFF
--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -49,6 +49,10 @@ on:
 permissions:
   contents: read
   packages: read
+  # Needed for the Security Gate's "Comment on PR" step to post the gate
+  # result summary using GITHUB_TOKEN. Adds capability only — no other
+  # behaviour changes.
+  pull-requests: write
 
 jobs:
   # ── Build Docker image (single-arch, no push) ──────────────────────────────
@@ -294,7 +298,10 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
-          github-token: ${{ secrets.ORG_PAT_GITHUB }}
+          # Same-repo PR comment — use the workflow's built-in token instead
+          # of the fine-grained PAT (which has to be manually granted to each
+          # repo and 404s on any repo not on its allowlist).
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             let body;


### PR DESCRIPTION
## Summary
The Security Gate job's `Comment on PR` step posts via `ORG_PAT_GITHUB`. That PAT has a manually-curated repo allowlist, so when a connector repo onboards to the reusable scan workflow without being added to the PAT's allowed-repos list, the comment 404s and the job is marked failed — even when the underlying gate logic passed.

Switch to `GITHUB_TOKEN`, which is auto-scoped to the calling repo and works natively for same-repo PR comments.

## Reproduction
Latest example: [atlanhq/atlan-alloydb-postgres-app#39, run 26157543758, job 76949093445](https://github.com/atlanhq/atlan-alloydb-postgres-app/actions/runs/26157543758/job/76949093445)

```
✓ Check against allowlist           ← gate logic: PASS (1 CVE, all allowlisted)
✓ Report Snyk findings
X Comment on PR                     ← 404 from POST /repos/.../issues/39/comments
```

## Changes

**1) Top-level permissions** — add `pull-requests: write` so `GITHUB_TOKEN` can post the comment. Capability addition only; no other behaviour changes.

**2) `Comment on PR` step** — swap `secrets.ORG_PAT_GITHUB` → `secrets.GITHUB_TOKEN`.

`ORG_PAT_GITHUB` is still used by the `Checkout base allowlist from SDK` step at line 248 — that one genuinely needs cross-repo read access to fetch `.security/base-allowlist.json` from this repo. Unchanged.

## Blast radius
- Affects every connector repo that calls `build-and-scan.yaml@main`. Behaviour change: the gate-result PR comment is now authored by `github-actions[bot]` instead of the `ORG_PAT_GITHUB` identity. Cosmetic only.
- No effect on:
  - Trivy / Snyk scan steps
  - Allowlist check logic
  - The actual gate pass/fail outcome
  - Dashboard update workflow (separate file)
  - `auto-fix-vulnerabilities.yaml` (separate file)

## Test plan
- [ ] Re-run the failed job on atlan-alloydb-postgres-app#39 → Security Gate goes green
- [ ] Confirm PR comment lands with the same body as before (author will now be `github-actions[bot]`)
- [ ] On a new connector PR, confirm comment posts without the PAT-allowlist hop