### PR TITLE
chore(deps): bump idna 3.13 -> 3.15 (CVE-2026-45409)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -108,7 +108,7 @@ httpx-retries==0.4.6
 hypothesis==6.148.13
 identify==2.6.19
     # via pre-commit
-idna==3.13
+idna==3.15
     # via
     #   anyio
     #   email-validator

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -1961,11 +1961,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps transitive `idna` from `3.13` → `3.15` via `uv lock --upgrade-package idna`.
- Resolves the medium-severity findings from the daily security scan ([run 26206330267](https://github.com/atlanhq/application-sdk/actions/runs/26206330267)):
  - **CVE-2026-45409** (Trivy Python) — ReDoS / bypass of the CVE-2024-3651 fix in `idna.encode()`.
  - **SNYK-PYTHON-IDNA-16769942** (Snyk Python) — same root issue.
- Together these account for 3 of the 4 mediums in that scan. The remaining medium (`filippo.io/edwards25519` v1.1.0 inside `daprd`) requires a Dapr bump in the runtime base image and will be handled separately.

## Changes
- `uv.lock`: idna 3.13 → 3.15.
- `requirements.txt`: regenerated by the `Sync requirements.txt with uv.lock` pre-commit hook.

No source or API changes. idna is a transitive dep — not pinned in `pyproject.toml`.

## Test plan
- [x] `uv lock --upgrade-package idna` succeeds and only mutates idna lines.
- [x] `uv run pre-commit run --files uv.lock` passes (incl. `Sync requirements.txt with uv.lock`).
- [ ] CI green on this PR.
- [ ] Next daily security scan run after merge no longer reports CVE-2026-45409 / SNYK-PYTHON-IDNA-16769942.