### PR TITLE
fix(observability): derive Segment userId per-tenant from labels

### DIFF
--- a/application_sdk/observability/segment_client.py
+++ b/application_sdk/observability/segment_client.py
@@ -371,9 +371,26 @@ class SegmentClient:
         if metric_record.unit:
             event_properties["unit"] = metric_record.unit
 
+        # Per-tenant identity. Without this, every event across every customer
+        # tenant shares one Mixpanel distinct_id and per-customer analytics
+        # collapse to a single synthetic user. The default user id is kept as
+        # a namespace prefix so events across services remain easy to group;
+        # the tenant identifier is appended when present in labels. Candidates
+        # are checked in increasing-genericity order.
+        tenant_suffix = (
+            metric_record.labels.get("tenant_name")
+            or metric_record.labels.get("atlan_base_url")
+            or metric_record.labels.get("tenant_id")
+        )
+        user_id = (
+            f"{self._default_user_id}:{tenant_suffix}"
+            if tenant_suffix
+            else self._default_user_id
+        )
+
         # Create and return Pydantic model
         return SegmentTrackEvent(
-            userId=self._default_user_id,
+            userId=user_id,
             event=metric_record.name,
             properties=event_properties,
             timestamp=datetime.fromtimestamp(metric_record.timestamp).isoformat(),

--- a/tests/unit/observability/test_segment_client.py
+++ b/tests/unit/observability/test_segment_client.py
@@ -297,6 +297,58 @@ class TestBuildTrackEvent:
         # ISO 8601 format from datetime.fromtimestamp(...).isoformat().
         assert "T" in event.timestamp
 
+    def test_userid_uses_tenant_name_label_when_present(self):
+        """tenant_name takes precedence over other tenant identifiers and is
+        appended to the default namespace prefix."""
+        client = _disabled_client()
+        record = _make_record(
+            labels={
+                "tenant_name": "workivap01",
+                "atlan_base_url": "https://workiva.atlan.com",
+                "tenant_id": "default",
+            }
+        )
+        event = client._build_track_event(record)
+        assert event.userId == f"{client._default_user_id}:workivap01"
+
+    def test_userid_falls_back_to_atlan_base_url(self):
+        """When tenant_name is absent, atlan_base_url is appended."""
+        client = _disabled_client()
+        record = _make_record(
+            labels={
+                "atlan_base_url": "https://workiva.atlan.com",
+                "tenant_id": "default",
+            }
+        )
+        event = client._build_track_event(record)
+        assert event.userId == f"{client._default_user_id}:https://workiva.atlan.com"
+
+    def test_userid_falls_back_to_tenant_id(self):
+        """When tenant_name and atlan_base_url absent, tenant_id is appended."""
+        client = _disabled_client()
+        record = _make_record(labels={"tenant_id": "some-tenant"})
+        event = client._build_track_event(record)
+        assert event.userId == f"{client._default_user_id}:some-tenant"
+
+    def test_userid_falls_back_to_default_when_no_tenant_labels(self):
+        """With no tenant labels, the bare default user id is used (no suffix)."""
+        client = _disabled_client()
+        record = _make_record(labels={"unrelated": "x"})
+        event = client._build_track_event(record)
+        assert event.userId == client._default_user_id
+
+    def test_userid_ignores_empty_string_tenant_labels(self):
+        """Empty string tenant labels fall through to the next candidate."""
+        client = _disabled_client()
+        record = _make_record(
+            labels={
+                "tenant_name": "",
+                "atlan_base_url": "https://workiva.atlan.com",
+            }
+        )
+        event = client._build_track_event(record)
+        assert event.userId == f"{client._default_user_id}:https://workiva.atlan.com"
+
 
 # ---------------------------------------------------------------------------
 # send_metric — sync interface, no real thread

--- a/tests/unit/observability/test_segment_client.py
+++ b/tests/unit/observability/test_segment_client.py
@@ -303,25 +303,25 @@ class TestBuildTrackEvent:
         client = _disabled_client()
         record = _make_record(
             labels={
-                "tenant_name": "workivap01",
-                "atlan_base_url": "https://workiva.atlan.com",
+                "tenant_name": "acme-tenant-01",
+                "atlan_base_url": "https://acme.example.com",
                 "tenant_id": "default",
             }
         )
         event = client._build_track_event(record)
-        assert event.userId == f"{client._default_user_id}:workivap01"
+        assert event.userId == f"{client._default_user_id}:acme-tenant-01"
 
     def test_userid_falls_back_to_atlan_base_url(self):
         """When tenant_name is absent, atlan_base_url is appended."""
         client = _disabled_client()
         record = _make_record(
             labels={
-                "atlan_base_url": "https://workiva.atlan.com",
+                "atlan_base_url": "https://acme.example.com",
                 "tenant_id": "default",
             }
         )
         event = client._build_track_event(record)
-        assert event.userId == f"{client._default_user_id}:https://workiva.atlan.com"
+        assert event.userId == f"{client._default_user_id}:https://acme.example.com"
 
     def test_userid_falls_back_to_tenant_id(self):
         """When tenant_name and atlan_base_url absent, tenant_id is appended."""
@@ -343,11 +343,11 @@ class TestBuildTrackEvent:
         record = _make_record(
             labels={
                 "tenant_name": "",
-                "atlan_base_url": "https://workiva.atlan.com",
+                "atlan_base_url": "https://acme.example.com",
             }
         )
         event = client._build_track_event(record)
-        assert event.userId == f"{client._default_user_id}:https://workiva.atlan.com"
+        assert event.userId == f"{client._default_user_id}:https://acme.example.com"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Every event sent through `SegmentClient` was using the hardcoded `SEGMENT_DEFAULT_USER_ID = "atlan.automation"` as its Segment `userId`. With all of Atlan's app-sdk-based services (automation-engine, marketplace-app, lineage, …) sharing a single distinct_id in Mixpanel, the per-distinct_id ingestion path hits Mixpanel's hot-shard threshold and Mixpanel routes the excess to `$hotshard_events` — same properties, different event name. Dashboards filtering on the original event name miss them.

This change composes `userId` per-event as `{default_user_id}:{tenant_suffix}`, where `tenant_suffix` is taken from labels in order of decreasing specificity:

1. `tenant_name` (internal tenant identifier, when present)
2. `atlan_base_url` (customer URL, e.g. `https://workiva.atlan.com`)
3. `tenant_id`
4. fall back to bare default if no tenant labels

Result: ~300 distinct user buckets in Mixpanel (one per tenant) instead of one. Each tenant's volume sits comfortably under any per-distinct_id rate limit; events land under their proper event names.

## Why this matters (incident context — AUT-977)

Symptom: customer-success and the team noticed AE failure events missing in Mixpanel for many tenants (e.g. `workiva.atlan.com`: 1,061 Succeeded, 0 Failed over 7 days — statistically impossible).

Root cause confirmed against production Mixpanel data:

| Day | `automation_workflow_run_completed` | `$hotshard_events` | hotshard ratio |
|-----|-------------------------------------|--------------------|---------------:|
| May 14 | 37,228 | 174,829 | 4.7× |
| May 19 | 18,697 | **427,431** | **22.9×** |
| May 20 | 25,295 | 302,221 | 11.9× |

`$hotshard_events` broken down by `status` property (7 days):
- `Failed`: **1,666** (vs 1,435 correctly named — more than 50% of failures were hot-sharded)
- `Succeeded`: 130,966
- `undefined`: 1.75M (non-AE services also affected)

The hot-sharding is keyed on distinct_id. Splitting one global distinct_id into ~300 per-tenant ones eliminates the trigger.

## Test plan

- [x] 5 new unit tests in `TestBuildTrackEvent` covering each fallback level + empty-string handling
- [x] Full `test_segment_client.py` suite: 45 passed
- [x] `test_metrics_adaptor.py` (downstream consumer): 22 passed
- [x] `pre-commit run --files <changed>`: all hooks pass (ruff, ruff-format, isort, pyright)

## Verification post-rollout

After release + downstream version bumps, expect to see in Mixpanel:
- `$distinct_id` breakdown on `automation_workflow_run_completed` → hundreds of distinct values (one per `atlan_base_url`), not just `atlan.automation`
- `$hotshard_events` daily count drop substantially as per-distinct_id load is spread across tenants
- Failure event counts for previously empty tenants (workiva, sailpoint, syngenta-sandbox, …) become non-zero, matching their real failure rates

## Linear

[AUT-977](https://linear.app/atlan-epd/issue/AUT-977/ae-failure-events-missing-for-some-tenants)