### PR TITLE
docs(storage): fix raise_on_empty arg docstring in transfer.py (BLDX-1255)

### DIFF
--- a/application_sdk/storage/transfer.py
+++ b/application_sdk/storage/transfer.py
@@ -202,7 +202,7 @@ async def upload(
         storage_subdir: Subdirectory name appended to the auto-generated run prefix.
             Ignored when *storage_path* is set.
         skip_if_exists: Skip files whose SHA-256 matches the stored sidecar.
-        raise_on_empty: When ``True``, raise ``StorageError`` if
+        raise_on_empty: When ``True``, raise ``StorageEmptyUploadError`` if
             *local_path* is a directory that contains zero files. Opt-in
             fail-loud for connectors where empty output indicates a bug
             (see BLDX-1255). Defaults to ``False`` to preserve historical


### PR DESCRIPTION
## Summary

- Fixes the `raise_on_empty` Args docstring in `application_sdk/storage/transfer.py` which incorrectly referenced ``StorageError`` — the implementation and the `Raises:` section both use `StorageEmptyUploadError`.

Caught by the SDK review bot on #1821 after that PR merged.

Linear: [BLDX-1255](https://linear.app/atlan-epd/issue/BLDX-1255)

🤖 Generated with [Claude Code](https://claude.com/claude-code)