### PR TITLE
fix(deps): hard-pin daft to 0.7.3 to prevent concurrency regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ sql = [
 ]
 # Daft transformer engine
 daft = [
-    "daft>=0.7.1,<0.8.0",
+    "daft==0.7.3",
 ]
 # Incremental extraction: sql + daft + RocksDB state store
 incremental = [
@@ -73,7 +73,7 @@ incremental = [
     "sqlalchemy[asyncio]>=2.0.36,<3.0.0",
     "duckdb>=1.1.3,<1.6.0",
     "duckdb-engine>=0.17.0,<0.18.0",
-    "daft>=0.7.1,<0.8.0",
+    "daft==0.7.3",
     "rocksdict>=0.3.0",
 ]
 # AWS IAM authentication for RDS/Redshift

--- a/uv.lock
+++ b/uv.lock
@@ -327,8 +327,8 @@ requires-dist = [
     { name = "azure-storage-blob", marker = "extra == 'azure'", specifier = ">=12.19.0" },
     { name = "azure-storage-file-datalake", marker = "extra == 'azure'", specifier = ">=12.19.0" },
     { name = "boto3", marker = "extra == 'iam-auth'", specifier = ">=1.38.6,<2.0.0" },
-    { name = "daft", marker = "extra == 'daft'", specifier = ">=0.7.1,<0.8.0" },
-    { name = "daft", marker = "extra == 'incremental'", specifier = ">=0.7.1,<0.8.0" },
+    { name = "daft", marker = "extra == 'daft'", specifier = "==0.7.3" },
+    { name = "daft", marker = "extra == 'incremental'", specifier = "==0.7.3" },
     { name = "duckdb", marker = "extra == 'incremental'", specifier = ">=1.1.3,<1.6.0" },
     { name = "duckdb", marker = "extra == 'sql'", specifier = ">=1.1.3,<1.6.0" },
     { name = "duckdb-engine", marker = "extra == 'incremental'", specifier = ">=0.17.0,<0.18.0" },
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "daft"
-version = "0.7.14"
+version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fsspec" },
@@ -1107,13 +1107,13 @@ dependencies = [
     { name = "pyarrow" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/43/897f27f2cdcd8a93276fbc64fbde15d0c2131c8e656bb93be657efe85b66/daft-0.7.14.tar.gz", hash = "sha256:23b8ae24537817d40f300f71d60550fdca50a9000ddf37deffc0e303b3e6923e", size = 3224465, upload-time = "2026-05-20T03:41:05.088Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/db/32cf6cffa3f9e99a6c0d666fbe32883a1abfa7f1e013ac686c785196a7e2/daft-0.7.3.tar.gz", hash = "sha256:1adfb4301f4417de33b6ffbcfc07c8e8414655141556065d1bf1ab9ae988b90d", size = 2820158, upload-time = "2026-02-13T22:57:25.031Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/ca/02f43d207e29383a3743ad2738aa3726419e376a3c4574e31c9399b2b011/daft-0.7.14-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dd2328961835797cc3b1f721bea910518b8e1a090560e19088db82ec2ef8ff44", size = 61509612, upload-time = "2026-05-20T03:40:16.485Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/40/f7437c120cd9c78e8bd258d9047403ffb8371ac9b21587e8ca5c28b9e52e/daft-0.7.14-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d372ac76beb2cd1cd8d7cb617b5c5936ddd2ade8f6d61f8b32a9b2bb14747685", size = 57069703, upload-time = "2026-05-20T03:40:22.526Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/16/b442a439004934de1140e04025e0d1ba07dd17c5fc6e6dda89bc6746723f/daft-0.7.14-cp310-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:de296328d19f3ecd5ad409583979f89b01f1d8a913d0360b4b4d3f20f5e56a09", size = 59651829, upload-time = "2026-05-20T03:40:27.904Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/19/df6465dee01e2557801d8e323a7d1ad5bae1ec11883440afebe21f6be67a/daft-0.7.14-cp310-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:5808823c3ef21dfe278d21af2540e11bc675642f617d2b51434bf2fdd827d0fa", size = 61946262, upload-time = "2026-05-20T03:40:33.309Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/13/e0efefb2cfac2b2b33d01143aaa16f832009a7516969eb42efaac723d36c/daft-0.7.14-cp310-abi3-win_amd64.whl", hash = "sha256:f7a7ae3088b234d75fa10242b181d90326eea3f7b6a9c331ec02ce07f404c706", size = 62767597, upload-time = "2026-05-20T03:40:40.416Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b6/4b988cab87923c66e211afc04e1282e49ed90e6f06573215536477cbdaac/daft-0.7.3-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c02feff1989ffc0cf3c3d202c90516b14256b0b4a07352c2b86482891434a413", size = 51422467, upload-time = "2026-02-13T22:56:59.119Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9f/87e4b23780cfac48f807103c7edac8175506a550d6556205c5f65d51afb7/daft-0.7.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8287ff3167fd2d00839c5d35c1b361bd98b186b5ed53c4213e8beb21ae32281e", size = 47291018, upload-time = "2026-02-13T22:57:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/08/73/93190221d291d31d4d52367fc2aaf2d616ed9e7b7b1508d322d9731f8a01/daft-0.7.3-cp310-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:48b142326dcff2a21f313951d07cac7d4eccef51bf40478ac50a974958577d57", size = 49246103, upload-time = "2026-02-13T22:57:05.839Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ae/300a77c40a65eb87fb683561ad67a4e1d9c1a186c83d445a28a8ff059c08/daft-0.7.3-cp310-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:2d05f28fec9b758d9e1e69539933d48978ab17a7dc04fe012b1bc668f3024741", size = 51698861, upload-time = "2026-02-13T22:57:08.924Z" },
+    { url = "https://files.pythonhosted.org/packages/63/91/7fb7d4f3781ec2583d0351539723a077d87fd7ce056fd88890b01e307342/daft-0.7.3-cp310-abi3-win_amd64.whl", hash = "sha256:c77a0bfc2ade63e2cf24eb6d0ca7b094b00049eddf752fe65972041fb8140a0a", size = 50368377, upload-time = "2026-02-13T22:57:12.443Z" },
 ]
 
 [[package]]
@@ -1611,11 +1611,11 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2026.2.0"
+version = "2025.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/7f/2747c0d332b9acfa75dc84447a066fdf812b5a6b8d30472b74d309bfe8cb/fsspec-2025.10.0.tar.gz", hash = "sha256:b6789427626f068f9a83ca4e8a3cc050850b6c0f71f99ddb4f542b8266a26a59", size = 309285, upload-time = "2025-10-30T14:58:44.036Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/02/a6b21098b1d5d6249b7c5ab69dde30108a71e4e819d4a9778f1de1d5b70d/fsspec-2025.10.0-py3-none-any.whl", hash = "sha256:7c7712353ae7d875407f97715f0e1ffcc21e33d5b24556cb1e090ae9409ec61d", size = 200966, upload-time = "2025-10-30T14:58:42.53Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Daft was transitively bumped from **0.7.3 → 0.7.14** by a recent lockfile re-resolve (our pin was a loose `>=0.7.1,<0.8.0`). The upgrade introduced a catastrophic concurrency regression that caused production failures across multiple tenants.

**Root cause (confirmed by RCA):** In daft 0.7.14, two parallel `iter_rows()` calls on *different* DataFrames share a single underlying iterator — each concurrent task receives a partial, mutually-exclusive slice of rows. On 0.7.3 the execution plans are properly independent. Serial runs pass cleanly on both versions; the regression only manifests under concurrent load (matching the SDK's parallel `transform_entity_type` activities).

The likely upstream source is the `arrow2 → arrow-rs` migration introduced in daft 0.7.4.

**Observed symptoms:**
- `not implemented: List casting not implemented for dtype: Int32`
- `index out of bounds: the len is N but the index is N`
- `index out of bounds: the len is 0 but the index is 0`
- Silent data corruption: concurrent runs completing without panic but producing fewer rows than expected

## What

- Pins both the `daft` and `incremental` extras in `pyproject.toml` to `daft==0.7.3` (exact version, immune to `uv sync --upgrade`)
- Regenerates `uv.lock` — also downgrades `fsspec` 2026.2.0 → 2025.10.0, which is expected (daft 0.7.3 has a narrower fsspec bound)

**Do not bump this pin** until the upstream concurrency bug is confirmed fixed and validated under concurrent load.

## Test plan

- [x] Pre-commit clean (`ruff`, `pyright`, `isort`, lockfile sync)
- [x] All 4466 unit tests pass
- [ ] Verify no daft-touching integration tests regress on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)