### PR TITLE
chore(test-sdk-review): post a 'review starting' notice with run URL on PR

### DIFF
--- a/.github/workflows/test-sdk-review.yml
+++ b/.github/workflows/test-sdk-review.yml
@@ -177,6 +177,62 @@ jobs:
             core.setOutput('base_ref', pr.base.ref);
             core.setOutput('html_url', pr.html_url);
 
+      - name: Post 'review starting' notice to PR
+        env:
+          PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
+          COMMENTER: ${{ steps.parse.outputs.commenter }}
+          GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Post / update a single "starting" notice per PR so the user
+            // gets an immediate clickable link to the workflow run and can
+            // watch the SSE event stream live. The final review summary
+            // lands as a separate comment from mothership-ai[bot] when the
+            // sandbox completes.
+            //
+            // The HTML comment marker lets repeat invocations update the
+            // existing notice in place instead of accumulating one comment
+            // per @test-sdk-review trigger.
+            const marker = '<!-- TEST_SDK_REVIEW_STARTED -->';
+            const commenter = process.env.COMMENTER || 'unknown';
+            const runUrl = process.env.GHA_RUN_URL;
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const startedAt = new Date().toISOString();
+
+            const body = [
+              marker,
+              `🔍 **Test SDK Review (mothership)** triggered by @${commenter} at ${startedAt}.`,
+              ``,
+              `[Watch the workflow run live](${runUrl}) — the review summary will appear as a separate comment when complete (typical: 5–30 min, hard cap 2h).`,
+            ].join('\n');
+
+            const existing = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const prior = existing.data.find(c => c.body && c.body.startsWith(marker));
+
+            if (prior) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: prior.id,
+                body,
+              });
+              console.log(`Updated existing 'starting' comment ${prior.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+              console.log(`Posted new 'starting' comment`);
+            }
+
       - name: Set test-sdk-review status to pending
         env:
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}


### PR DESCRIPTION
## Summary

When a user posts `@test-sdk-review` on a PR, the only immediate signal today is a 👀 reaction on the triggering comment. No link to the workflow run, no estimated wait time. The user sits blind for 5-30 min until the final review comment appears.

This adds a small step before the dispatch that posts (or updates in place) a single PR comment like:

> 🔍 **Test SDK Review (mothership)** triggered by @user at 2026-05-21T15:07:15Z.
>
> [Watch the workflow run live](https://github.com/atlanhq/application-sdk/actions/runs/...) — the review summary will appear as a separate comment when complete (typical: 5–30 min, hard cap 2h).

## What this gives the user

- **Immediate clickable link** to the workflow run — they can watch the SSE event stream live (`[started]`, `[action]`, `[response]`, `[complete]`)
- **Wall-clock baseline** (the ISO timestamp) for how long the run has been going
- **Expected duration** so they don't refresh every 30 seconds
- **No mystery** about whether the dispatch even fired

## How the marker-based update works

The notice carries a `<!-- TEST_SDK_REVIEW_STARTED -->` HTML comment marker. On every `@test-sdk-review` trigger, the workflow:

1. Lists the PR's comments
2. Finds any comment that starts with the marker
3. If found → `updateComment` to refresh the trigger timestamp + run URL (one notice per PR, latest run only)
4. If not found → `createComment` to post a fresh one

Net result: repeat invocations don't accumulate "starting" comments. The PR sees one current notice + however many final review comments mothership has posted historically.

## What this does NOT change

- `sdk-evolution-cron.yml` — no triggering PR to comment on. Run URL is already in the Stage 4b parent Linear ticket + Stage 8 summary table (shipped in #1827).
- The final review comment from `mothership-ai[bot]` — still posted separately when the sandbox completes, still carries `<!-- TEST_SDK_REVIEW -->` marker, still includes the run URL in its footer (shipped in #1827).
- The 👀 reaction on the triggering comment — still happens as the first signal.
- Status check `test-sdk-review` — still set to pending/failure/success at workflow + orchestration boundaries.

## Test plan

- [ ] Merge this PR
- [ ] Comment `@test-sdk-review` on PR #1826 — confirm a 🔍 notice appears within ~30 sec with a clickable run URL
- [ ] Click the link — confirm it lands on the workflow run page
- [ ] Comment `@test-sdk-review` AGAIN on the same PR — confirm the existing notice updates in place (timestamp + run URL refreshed) rather than a duplicate appearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)