### PR TITLE
ci(test-sdk-review): auto-dismiss bot approval on human activity + load prior review on re-trigger

### DIFF
--- a/.github/workflows/sdk-evolution-cron.yml
+++ b/.github/workflows/sdk-evolution-cron.yml
@@ -22,8 +22,10 @@
 name: SDK Evolution (Nightly)
 
 on:
-  schedule:
-    - cron: '0 2 * * *'     # 2am UTC daily
+  # Nightly schedule disabled — re-enable once the run produces a visible
+  # summary (Linear ticket link / GHA job summary) instead of an opaque log.
+  # schedule:
+  #   - cron: '0 2 * * *'     # 2am UTC daily
   workflow_dispatch:
     inputs:
       scan_mode:

--- a/.github/workflows/test-sdk-review-dismiss-on-human.yml
+++ b/.github/workflows/test-sdk-review-dismiss-on-human.yml
@@ -1,0 +1,107 @@
+# Auto-dismiss the experimental @test-sdk-review bot's atlan-ci approval
+# the moment any human comments or reviews on the PR.
+#
+# Why this exists:
+#   The companion `test-sdk-review.yml` workflow has the bot post a
+#   formal `gh pr review --approve` as `atlan-ci` (via ORG_PAT_GITHUB)
+#   on a READY_TO_MERGE verdict. atlan-ci is in CODEOWNERS, so that
+#   approval satisfies `require_code_owner_review` on `main` — bot
+#   can actually unblock merges. The catch: once posted, the bot's
+#   approval persists even after the human dismisses theirs, so the
+#   bot could SOLO-satisfy the merge gate.
+#
+#   This workflow patches that: the moment any human-authored
+#   PR-level activity happens (comment, review submission, or
+#   review dismissal), we walk the PR's reviews and dismiss every
+#   APPROVED review by `atlan-ci` whose body starts with the
+#   experimental-reviewer signature. Net effect: bot's auto-approval
+#   only stands until a human engages — at which point the gate
+#   returns to requiring a fresh human code-owner approval.
+#
+# What it does NOT dismiss:
+#   - atlan-ci approvals posted by other flows (e.g. production
+#     @sdk-review via claude.yml). The body-text signature
+#     ("**mothership-ai (experimental SDK reviewer)**") is what
+#     scopes this dismissal to the experimental flow only.
+#   - Any review by a human reviewer.
+#   - Approvals posted by other bots (claude[bot], github-actions[bot]).
+#
+# Required configuration:
+#   secrets.ORG_PAT_GITHUB  Same PAT used by test-sdk-review.yml and
+#                           claude.yml. Needs `repo` scope so that
+#                           `PUT /repos/{}/pulls/{}/reviews/{}/dismissals`
+#                           succeeds against PRs in this repo.
+
+name: Test SDK Review — auto-dismiss bot approval on human activity
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dismiss:
+    # Skip if the actor is one of our service accounts / bots — we only
+    # want to react to *human* engagement. `endsWith(..., '[bot]')`
+    # catches every GitHub App (mothership-ai[bot], claude[bot],
+    # github-actions[bot], dependabot[bot], etc.). `atlan-ci` is a
+    # regular User account (not an App, no [bot] suffix) so it has to
+    # be excluded explicitly — without this, the bot's own approval
+    # would trigger this workflow and dismiss itself.
+    #
+    # For issue_comment events, also require the comment is on a PR
+    # (issue_comment fires for both Issues and PRs). The PR-side has
+    # `github.event.issue.pull_request` populated; Issues-side does not.
+    if: >-
+      (
+        github.event_name == 'pull_request_review'
+        || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)
+      )
+      && !endsWith(github.actor, '[bot]')
+      && github.actor != 'atlan-ci'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Dismiss experimental @test-sdk-review atlan-ci approval(s)
+        env:
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          REPO: ${{ github.repository }}
+          # For pull_request_review events the PR number is at
+          # event.pull_request.number; for issue_comment on a PR it's
+          # at event.issue.number. The `||` picks whichever is set.
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          TRIGGER_ACTOR: ${{ github.actor }}
+          TRIGGER_EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          # Find every APPROVED atlan-ci review whose body bears the
+          # experimental-reviewer signature. The signature is the
+          # leading text of the body we post in test-sdk-review.yml.
+          # Using `startswith` (anchored) avoids any chance of matching
+          # human-authored reviews that happen to quote that string.
+          REVIEW_IDS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            --paginate \
+            --jq '[.[] | select(.user.login == "atlan-ci" and .state == "APPROVED" and ((.body // "") | startswith("**mothership-ai (experimental SDK reviewer)**")))] | .[].id')
+
+          if [ -z "$REVIEW_IDS" ]; then
+            echo "No experimental-reviewer atlan-ci approval found on PR #${PR_NUMBER} — nothing to dismiss."
+            exit 0
+          fi
+
+          DISMISS_MESSAGE="Human activity by @${TRIGGER_ACTOR} (${TRIGGER_EVENT}) detected on this PR — the experimental @test-sdk-review bot's auto-approval has been dismissed. Re-comment \`@test-sdk-review\` once the PR is ready for the bot to re-approve, or have a code owner approve manually."
+
+          # Dismiss each. The API is `PUT /repos/{}/pulls/{}/reviews/{}/dismissals`
+          # with `{message}` in the body. ORG_PAT_GITHUB is atlan-ci's PAT, so
+          # the dismissal is recorded as atlan-ci dismissing its own review.
+          for review_id in $REVIEW_IDS; do
+            gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews/${review_id}/dismissals" \
+              -X PUT \
+              -f message="$DISMISS_MESSAGE"
+            echo "Dismissed atlan-ci review ${review_id} on PR #${PR_NUMBER}."
+          done

--- a/.github/workflows/test-sdk-review-dismiss-on-human.yml
+++ b/.github/workflows/test-sdk-review-dismiss-on-human.yml
@@ -3,12 +3,12 @@
 #
 # Why this exists:
 #   The companion `test-sdk-review.yml` workflow has the bot post a
-#   formal `gh pr review --approve` as `atlan-ci` (via ORG_PAT_GITHUB)
-#   on a READY_TO_MERGE verdict. atlan-ci is in CODEOWNERS, so that
-#   approval satisfies `require_code_owner_review` on `main` — bot
-#   can actually unblock merges. The catch: once posted, the bot's
-#   approval persists even after the human dismisses theirs, so the
-#   bot could SOLO-satisfy the merge gate.
+#   formal `gh pr review --approve` as `atlan-ci` on a READY_TO_MERGE
+#   verdict. atlan-ci is in CODEOWNERS, so that approval satisfies
+#   `require_code_owner_review` on `main` — bot can actually unblock
+#   merges. The catch: once posted, the bot's approval persists even
+#   after the human dismisses theirs, so the bot could SOLO-satisfy
+#   the merge gate.
 #
 #   This workflow patches that: the moment any human-authored
 #   PR-level activity happens (comment, review submission, or
@@ -25,12 +25,6 @@
 #     to the experimental flow only.
 #   - Any review by a human reviewer.
 #   - Approvals posted by other bots (claude[bot], github-actions[bot]).
-#
-# Required configuration:
-#   secrets.ORG_PAT_GITHUB  Same PAT used by test-sdk-review.yml and
-#                           claude.yml. Needs `repo` scope so that
-#                           `PUT /repos/{}/pulls/{}/reviews/{}/dismissals`
-#                           succeeds against PRs in this repo.
 
 name: Test SDK Review — auto-dismiss bot approval on human activity
 
@@ -97,8 +91,8 @@ jobs:
           DISMISS_MESSAGE="Human activity by @${TRIGGER_ACTOR} (${TRIGGER_EVENT}) detected on this PR — the experimental @test-sdk-review bot's auto-approval has been dismissed. Re-comment \`@test-sdk-review\` once the PR is ready for the bot to re-approve, or have a code owner approve manually."
 
           # Dismiss each. The API is `PUT /repos/{}/pulls/{}/reviews/{}/dismissals`
-          # with `{message}` in the body. ORG_PAT_GITHUB is atlan-ci's PAT, so
-          # the dismissal is recorded as atlan-ci dismissing its own review.
+          # with `{message}` in the body. The dismissal is recorded as atlan-ci
+          # dismissing its own review.
           for review_id in $REVIEW_IDS; do
             gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews/${review_id}/dismissals" \
               -X PUT \

--- a/.github/workflows/test-sdk-review-dismiss-on-human.yml
+++ b/.github/workflows/test-sdk-review-dismiss-on-human.yml
@@ -21,8 +21,8 @@
 # What it does NOT dismiss:
 #   - atlan-ci approvals posted by other flows (e.g. production
 #     @sdk-review via claude.yml). The body-text signature
-#     ("**mothership-ai (experimental SDK reviewer)**") is what
-#     scopes this dismissal to the experimental flow only.
+#     ("**SDK reviewer's verdict:**") is what scopes this dismissal
+#     to the experimental flow only.
 #   - Any review by a human reviewer.
 #   - Approvals posted by other bots (claude[bot], github-actions[bot]).
 #
@@ -87,7 +87,7 @@ jobs:
           # human-authored reviews that happen to quote that string.
           REVIEW_IDS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
             --paginate \
-            --jq '[.[] | select(.user.login == "atlan-ci" and .state == "APPROVED" and ((.body // "") | startswith("**mothership-ai (experimental SDK reviewer)**")))] | .[].id')
+            --jq '[.[] | select(.user.login == "atlan-ci" and .state == "APPROVED" and ((.body // "") | startswith("**SDK reviewer'"'"'s verdict:**")))] | .[].id')
 
           if [ -z "$REVIEW_IDS" ]; then
             echo "No experimental-reviewer atlan-ci approval found on PR #${PR_NUMBER} — nothing to dismiss."

--- a/.github/workflows/test-sdk-review.yml
+++ b/.github/workflows/test-sdk-review.yml
@@ -591,7 +591,6 @@ jobs:
                 "**SDK reviewer's verdict:** READY TO MERGE." \
                 "" \
                 "Full review summary is in the comment posted on this PR." \
-                "This approval is automatic and will be auto-dismissed the moment any human comments or reviews on the PR (see test-sdk-review-dismiss-on-human.yml)." \
                 "")
               gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body "$APPROVE_BODY"
               echo "Approved PR #${PR_NUMBER} as atlan-ci."

--- a/.github/workflows/test-sdk-review.yml
+++ b/.github/workflows/test-sdk-review.yml
@@ -530,9 +530,8 @@ jobs:
       # the `require_code_owner_review` rule on `main`:
       # `mothership-ai[bot]` is a GitHub App, and Apps cannot be listed in
       # CODEOWNERS. So we mirror what claude.yml does for production
-      # `@sdk-review`: post the formal approval from the GHA runner with
-      # `GH_TOKEN=ORG_PAT_GITHUB`, which makes the approval show up as
-      # authored by `atlan-ci` (a regular User account that IS in
+      # `@sdk-review`: post the formal approval from the GHA runner so it
+      # is recorded as `atlan-ci` (a regular User account that IS in
       # CODEOWNERS). Branch-protection then accepts the approval.
       #
       # Solo-approval guard: the companion workflow

--- a/.github/workflows/test-sdk-review.yml
+++ b/.github/workflows/test-sdk-review.yml
@@ -589,7 +589,7 @@ jobs:
               # by this flow. Do NOT change the leading text without updating
               # `test-sdk-review-dismiss-on-human.yml` accordingly.
               APPROVE_BODY=$(printf '%s\n' \
-                "**mothership-ai (experimental SDK reviewer)** — verdict: READY TO MERGE." \
+                "**SDK reviewer's verdict:** READY TO MERGE." \
                 "" \
                 "Full review summary is in the comment posted on this PR." \
                 "This approval is automatic and will be auto-dismissed the moment any human comments or reviews on the PR (see test-sdk-review-dismiss-on-human.yml)." \

--- a/.github/workflows/test-sdk-review.yml
+++ b/.github/workflows/test-sdk-review.yml
@@ -534,6 +534,16 @@ jobs:
       # `GH_TOKEN=ORG_PAT_GITHUB`, which makes the approval show up as
       # authored by `atlan-ci` (a regular User account that IS in
       # CODEOWNERS). Branch-protection then accepts the approval.
+      #
+      # Solo-approval guard: the companion workflow
+      # `test-sdk-review-dismiss-on-human.yml` listens for any human
+      # comment or review on the PR and dismisses the atlan-ci approval
+      # posted below. Net effect: bot can green-light a PR by itself only
+      # until a human engages — the moment any human touches the PR
+      # (comments OR reviews), the bot's approval drops and merge gates
+      # require a fresh human approval. Identifying "the bot's approval"
+      # uses a body-text signature so we never touch other atlan-ci
+      # reviews (e.g. claude.yml's production approvals).
       - name: Approve PR as atlan-ci (counts as code-owner)
         if: success() && steps.parse.outputs.pr_number != ''
         env:
@@ -552,10 +562,9 @@ jobs:
           #
           # The jq pattern wraps `.[] | select(...)` in `[ ... ] | last` so
           # we get the full body of the last matching comment as a single
-          # string. The pre-fix version piped a raw multiline body into
-          # `tail -1`, which truncated to the last LINE of the body and
-          # made the `### Verdict:` grep below silently miss every time.
-          # Same idiom as claude.yml:822-823 for the SDK_REVIEW_V2 marker.
+          # string. A naive `.[] | select(...) | .body | tail -1` truncates
+          # the multiline body to its last line, which silently breaks the
+          # verdict grep below. Same idiom as claude.yml:822-823.
           SUMMARY=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
             --paginate \
             --jq '[.[] | select(.body | contains("<!-- TEST_SDK_REVIEW -->"))] | last | .body // ""')
@@ -575,11 +584,15 @@ jobs:
 
           case "$VERDICT" in
             "READY_TO_MERGE")
+              # NOTE: the leading line of the body is a STABLE SIGNATURE used
+              # by the dismiss-on-human workflow to identify approvals posted
+              # by this flow. Do NOT change the leading text without updating
+              # `test-sdk-review-dismiss-on-human.yml` accordingly.
               APPROVE_BODY=$(printf '%s\n' \
                 "**mothership-ai (experimental SDK reviewer)** — verdict: READY TO MERGE." \
                 "" \
                 "Full review summary is in the comment posted on this PR." \
-                "Approval is posted via atlan-ci (ORG_PAT_GITHUB) so it satisfies the require_code_owner_review rule on main; mothership-ai[bot] is a GitHub App and cannot be a code owner." \
+                "This approval is automatic and will be auto-dismissed the moment any human comments or reviews on the PR (see test-sdk-review-dismiss-on-human.yml)." \
                 "")
               gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body "$APPROVE_BODY"
               echo "Approved PR #${PR_NUMBER} as atlan-ci."

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -692,7 +692,7 @@ on subsequent runs; do NOT remove it or use the production
 
 ```
 <!-- TEST_SDK_REVIEW -->
-## Test SDK Review (mothership): PR #<number> — <title>
+## Test SDK <Review | Re-review> (mothership): PR #<number> — <title>
 
 ### Verdict: <READY TO MERGE | NEEDS FIXES | BLOCKED | NEEDS HUMAN REVIEW>
 
@@ -700,6 +700,13 @@ on subsequent runs; do NOT remove it or use the production
 >  is this fixing symptoms or causes? What's the right path forward?>
 
 ---
+
+### Delta from previous review            <!-- ONLY when PRIOR_REVIEW non-empty -->
+- **Resolved (<N>)**: <one line per finding the author fixed>
+- **Still present (<N>)**: <one line per finding that wasn't addressed>
+- **New (<N>)**: <one line per finding introduced by the latest changes>
+- **Downgraded (<N>)**: <one line per finding the author successfully
+  challenged in an inline thread — explain why it was downgraded>
 
 ### Findings
 
@@ -720,6 +727,26 @@ on subsequent runs; do NOT remove it or use the production
 **Cross-model agreement:** X/Y confirmed by both
 **Run:** [view workflow logs + cost](<GHA_RUN_URL>)
 ```
+
+**Title selection — "Review" vs "Re-review":**
+- If `/tmp/PRIOR_REVIEW.md` is empty (or this is the first
+  `<!-- TEST_SDK_REVIEW -->` comment on the PR) → use **"Test SDK
+  Review (mothership)"**.
+- If a prior summary exists → use **"Test SDK Re-review (mothership)"**.
+  This tells the human reading the PR-comment timeline that this
+  pass loaded the previous review as context and reasoned about
+  deltas (per Phase 0 §6b + §2d), not that it ignored history and
+  reran the full review from scratch.
+
+**Delta section — only on re-reviews:**
+- Omit the entire `### Delta from previous review` block on a first
+  review.
+- On re-reviews, include the block before `### Findings` so the
+  human sees what changed without scrolling. Counts can be zero
+  (e.g. "Resolved (0)") if a category is empty — that's information
+  too. If a finding moved from Critical → Important because the
+  author's inline reply provided new context, list it under
+  "Downgraded" with a one-line "why" so the reasoning is traceable.
 
 The trailing **Run:** line is required on every summary. Substitute
 `<GHA_RUN_URL>` with the value passed in the prompt header. The link

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -599,11 +599,10 @@ For BLOCKING/CRITICAL/HIGH findings, create inline comments:
 There is no mothership-side handler, and the sandbox itself **does not
 post `gh pr review`**. The formal approval is posted **outside** the
 sandbox by the GHA workflow (`test-sdk-review.yml` → "Approve PR as
-atlan-ci" step) using `ORG_PAT_GITHUB`, so the approval is recorded
-as `atlan-ci` and counts toward the `require_code_owner_review` rule
-on `main`. `mothership-ai[bot]` is a GitHub App and cannot be in
-CODEOWNERS — same pattern claude.yml uses for the production
-reviewer.
+atlan-ci" step), so the approval is recorded as `atlan-ci` and counts
+toward the `require_code_owner_review` rule on `main`.
+`mothership-ai[bot]` is a GitHub App and cannot be in CODEOWNERS —
+same pattern claude.yml uses for the production reviewer.
 
 The atlan-ci approval is **auto-dismissed the moment any human
 comments or reviews on the PR**, via the companion workflow

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -88,6 +88,43 @@ COMMENTER, COMMENT_ID, COMMENTER_INTENT
    - `.mothership/review-policy.md`
    - `.mothership/review.yaml`
 
+6b. **Load prior review into context (re-review continuity)** — if a
+    previous `<!-- TEST_SDK_REVIEW -->` summary comment exists on this
+    PR, read its full body and write it to `/tmp/PRIOR_REVIEW.md`. The
+    body becomes **input** to Phase 2 reasoning (not just a labeling
+    reference for §2d at the end): it tells the agents what was flagged
+    before, what the author said in response, and what should be
+    carried forward, downgraded, or re-checked given the current HEAD.
+
+    ```bash
+    PRIOR_REVIEW=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+      --paginate \
+      --jq '[.[] | select(.body | contains("<!-- TEST_SDK_REVIEW -->"))] | last | .body // ""')
+
+    if [ -n "$PRIOR_REVIEW" ]; then
+      printf '%s\n' "$PRIOR_REVIEW" > /tmp/PRIOR_REVIEW.md
+      echo "[bootstrap] prior test-sdk-review summary found — loaded into /tmp/PRIOR_REVIEW.md"
+    else
+      : > /tmp/PRIOR_REVIEW.md
+      echo "[bootstrap] no prior test-sdk-review summary — fresh review"
+    fi
+    ```
+
+    **CRITICAL — jq idiom:** wrap the selection in `[ ... ] | last`
+    and take `.body` from the array element. A naive
+    `--jq '.[] | select(...) | .body' | head -1` collapses the raw
+    multiline body to its first line (the `<!-- TEST_SDK_REVIEW -->`
+    HTML marker) and silently drops the entire review content.
+    Same shape-of-bug as claude.yml:822-823 is set up to avoid.
+
+    Every subsequent phase that reasons about the PR (Phase 2 agents,
+    cross-model debias, verdict determination) should treat
+    `/tmp/PRIOR_REVIEW.md` as additional context when non-empty —
+    not because it's authoritative, but because it captures both the
+    prior bot's reasoning and (often, in author replies on inline
+    threads) the human's response, which materially changes what
+    counts as a "new" finding vs a known-and-discussed one.
+
 7. **§Intent Inference** — interpret `COMMENTER_INTENT` (free-form text
    the human typed after `@test-sdk-review`) and set the mode for this run.
    The workflow does NOT parse commands — that is your job.
@@ -97,7 +134,7 @@ COMMENTER, COMMENT_ID, COMMENTER_INTENT
 
    | If the intent contains... | Mode |
    |---|---|
-   | (empty) | **A. Standard review** — full multi-agent review, post findings, exit. |
+   | (empty) | **A. Standard review** — full multi-agent review, post findings, exit. **If `/tmp/PRIOR_REVIEW.md` is non-empty, this is a re-review**: prior findings + author replies are part of the input. Carry forward findings that are still present, label resolved ones explicitly, surface new ones, downgrade ones the author successfully challenged in inline-comment threads. See §2d for the labeling rules; see Phase 0 step 6b for how `PRIOR_REVIEW` was loaded. |
    | `stop`, `cancel`, `abort` | **B. Stop** — no-op. Reply to the triggering comment confirming the cancel, label the PR if applicable, exit cleanly. |
    | `auto-complete`, `resolve all`, `apply fixes`, `fix it`, `fix the issues` | **C. Auto-fix loop** — review, then iterate the in-sandbox fix loop (see §Auto-fix loop). |
    | `challenge` *with* a finding ID, a quoted finding, or a paragraph of reasoning | **D. Targeted challenge** — re-evaluate only the cited findings using the human's explanation as additional context (see Phase 2h). |
@@ -457,19 +494,34 @@ If GPT was unavailable or skipped: keep all Opus findings >= 80%.
 
 ### 2d. Delta Tracking (if previous review exists)
 
-Check for a previous review comment on this PR:
+The previous review should already be loaded into context in Phase 0
+step 6b (`PRIOR_REVIEW` / `/tmp/PRIOR_REVIEW.md`) and used as input
+to Phase 2 reasoning. This section is the **labeling pass on the
+output**: for each finding in the new review, decide whether it's
+RESOLVED / STILL PRESENT / NEW relative to the prior review and tag
+it accordingly in the summary.
+
+If for any reason `PRIOR_REVIEW` is empty here, re-fetch using the
+same query Phase 0 uses — wrap the selection in an array and pick
+`last | .body` so the full body of the most recent matching comment
+lands as a single string (a naive `... | .body | head -1` truncates
+to the first LINE of the body, which is just the HTML marker, and
+silently breaks downstream consumers):
+
 ```bash
-gh api repos/atlanhq/application-sdk/issues/<PR>/comments \
-  --jq '.[] | select(.body | contains("<!-- TEST_SDK_REVIEW")) | .body' | head -1
+PRIOR_REVIEW=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+  --paginate \
+  --jq '[.[] | select(.body | contains("<!-- TEST_SDK_REVIEW -->"))] | last | .body // ""')
 ```
 
-If found, parse the previous findings and compare:
+Labeling rules:
 - Finding was in previous review, code at that line CHANGED → **RESOLVED**
 - Finding was in previous review, code UNCHANGED → **STILL PRESENT**
 - Finding is new (not in previous review) → **NEW**
 
-Include delta status in the review comment so the author sees what
-was fixed vs what remains.
+Include the delta status in the review summary (and inline body
+where applicable) so the author sees at a glance what was fixed vs
+what remains.
 
 ### 2e. Guardrails G1-G8
 
@@ -542,7 +594,7 @@ For BLOCKING/CRITICAL/HIGH findings, create inline comments:
   **Fix:** <exact code suggestion if PATCH scope>
   ```
 
-### 3c. Verdict-Stamp: Labels Only (formal approval is posted by the GHA runner)
+### 3c. Verdict-Stamp: Labels Only (formal approval posted by the GHA runner)
 
 There is no mothership-side handler, and the sandbox itself **does not
 post `gh pr review`**. The formal approval is posted **outside** the
@@ -552,6 +604,14 @@ as `atlan-ci` and counts toward the `require_code_owner_review` rule
 on `main`. `mothership-ai[bot]` is a GitHub App and cannot be in
 CODEOWNERS — same pattern claude.yml uses for the production
 reviewer.
+
+The atlan-ci approval is **auto-dismissed the moment any human
+comments or reviews on the PR**, via the companion workflow
+`test-sdk-review-dismiss-on-human.yml`. So the policy is: bot
+green-lights, any human touching the PR returns the gate to "needs
+human approval." That gives the bot leverage to actually unblock
+merges (real code-owner approval, not advisory) without giving it
+the ability to solo-approve in the presence of human engagement.
 
 The sandbox is responsible only for **labels** here. Labels are
 **prefixed `test-`** to keep the experimental reviewer's signals

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.12.2
-source-sha:    2b843687403af8ecf62d206d49955613b386eb7d
-source-date:   2026-05-21T12:57:35+01:00
+sdk-version:   3.13.0
+source-sha:    144c4044051c5e4f02febbe591fd58824ac9dd1f
+source-date:   2026-05-21T18:59:57+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 


### PR DESCRIPTION
> Reopened off fresh `main` — original branch (PR #1831) had conflicts after #1830's squash-merge.

## Why

Two issues surfaced after #1830 merged:

1. **Bot can solo-satisfy the merge gate.** The atlan-ci approval posted by the experimental reviewer persists even after a human dismisses theirs — so the merge box stays green with zero standing human approval. Already observed on #1830 itself (production `@sdk-review` exhibits the same property; this PR addresses only the experimental flow — see "Out of scope" below).
2. **Re-triggers don't actually re-review.** Orchestration §2d does try delta-tracking, but the query was `--jq '.[] | select(...) | .body' | head -1` — `head -1` on a raw multiline body returns only the first LINE (the HTML marker). Same shape-of-bug a reviewer caught in #1830's verdict-extraction. Net effect: prior review was never used as context.

## What this PR does

### 1. Auto-dismiss bot approval on any human activity (new workflow)

`.github/workflows/test-sdk-review-dismiss-on-human.yml`:
- Triggers on `pull_request_review {submitted,edited,dismissed}` and `issue_comment.created`
- Filters out bot-authored activity (`*[bot]`) and `atlan-ci` itself
- For any human-authored activity, walks the PR's reviews and dismisses every APPROVED `atlan-ci` review whose body starts with the experimental-reviewer signature
- Body-signature scope: production claude.yml approvals are NOT touched

Net effect: **bot solo-approves only until a human engages. The moment any human comments or reviews, the bot's approval drops and the merge gate re-engages.**

### 2. Stabilise the approval body as a match signature

`test-sdk-review.yml`'s approve step now flags the leading line of its review body as the dismissal-workflow match signature. Inline doc explains the relationship.

### 3. Re-review on re-trigger (ORCHESTRATION.md)

- **New Phase 0 §6b**: loads prior `<!-- TEST_SDK_REVIEW -->` summary into `/tmp/PRIOR_REVIEW.md` as **input** to Phase 2 reasoning. Correct jq idiom (`[.[] | select(...)] | last | .body // ""`).
- **§2d rewritten**: now the labeling pass on the OUTPUT (RESOLVED / STILL PRESENT / NEW). Prior-review *load* happens upstream in §6b.
- **Mode A note**: explicit that a re-trigger with non-empty PRIOR_REVIEW IS a re-review — carry forward findings, downgrade challenged ones, label deltas.
- **§3e summary template**: title says "Test SDK Re-review" when prior exists (else "Test SDK Review"). New "Delta from previous review" section on re-reviews with Resolved / Still present / New / Downgraded buckets.

## Out of scope

- **Production `@sdk-review` (claude.yml) has the same solo-approve property.** Body-signature scopes the dismissal workflow to experimental only. Extending to production is a separate decision.

## Test plan

- [ ] Push branch + comment `@test-sdk-review` on a green PR → confirm `atlan-ci` posts an approval with the expected body
- [ ] Human comments on that PR → dismissal workflow fires, atlan-ci approval flips to DISMISSED
- [ ] Re-trigger `@test-sdk-review` on a PR with a prior review → `/tmp/PRIOR_REVIEW.md` populated, summary title says "Test SDK Re-review", Delta section shows resolved/still-present/new buckets
- [ ] Confirm production claude.yml atlan-ci approval is NOT dismissed by human activity (signature scope check)