### PR TITLE
docs(dev-commands): full dev deps in Step 1 (sandbox for @test-sdk-review loop)

### DIFF
--- a/docs/agents/dev-commands.md
+++ b/docs/agents/dev-commands.md
@@ -38,8 +38,10 @@ uv run pre-commit install
 ### Step 1: Install dependencies
 
 ```bash
-uv sync
+uv sync --all-extras --all-groups
 ```
+
+This installs the full dev/test dependency set used by pre-commit, pyright, and pytest. Plain `uv sync` only resolves runtime deps and will leave tooling missing.
 
 ### Step 2: Verify Dapr components are present
 


### PR DESCRIPTION
## Summary

- Step 1 of `docs/agents/dev-commands.md` previously said `uv sync`, but the canonical full dev/test install (per `CLAUDE.md` and AGENTS guidelines) is `uv sync --all-extras --all-groups`. Plain `uv sync` leaves pre-commit / pyright / pytest tooling missing, which breaks later steps for new contributors.
- This PR ships that one-line fix plus a clarifying sentence.

## Why this PR exists

This is also a **sandbox PR** intended to exercise the `@test-sdk-review` auto-complete loop end-to-end. The change is intentionally small and low-risk so the loop's behaviour (review → suggest → re-review → approve) is easy to observe in isolation.

Comment `@test-sdk-review` on this PR to trigger the bot.

## Test plan

- [ ] `uv run pre-commit run --files docs/agents/dev-commands.md` passes (already verified locally)
- [ ] `@test-sdk-review` runs to completion on this PR
- [ ] Auto-fix loop (if any issues are surfaced) iterates and lands a clean state