### PR TITLE
fix(sql_app): pre-warm SQL auth cache before parallel extract burst (BLDX-1295)

### DIFF
--- a/application_sdk/templates/contracts/__init__.py
+++ b/application_sdk/templates/contracts/__init__.py
@@ -41,6 +41,7 @@ from application_sdk.templates.contracts.sql_metadata import (
     FetchTablesOutput,
     FetchViewsInput,
     FetchViewsOutput,
+    PrimeAuthOutput,
     TransformInput,
     TransformOutput,
 )
@@ -74,6 +75,7 @@ __all__ = [
     "FetchTablesOutput",
     "FetchViewsInput",
     "FetchViewsOutput",
+    "PrimeAuthOutput",
     "TransformInput",
     "TransformOutput",
     # Incremental SQL

--- a/application_sdk/templates/contracts/sql_metadata.py
+++ b/application_sdk/templates/contracts/sql_metadata.py
@@ -316,16 +316,41 @@ class PrimeAuthOutput(Output):
     The task itself is a single serial probe — it issues one ``SELECT 1``
     to populate the SQL server's auth cache (notably MySQL 8's
     ``caching_sha2_password``) before the parallel ``_extract_entity``
-    burst. It returns no payload of interest; activity-level success /
-    failure on the Temporal side is the meaningful signal. The fields
-    below exist purely for observability — they surface in
-    ``worker_start`` / activity-complete events and make it easy to spot
-    primes that are unusually slow (which often correlate with an
-    impending connection-burst failure).
+    burst.
+
+    Failure-as-data contract:
+        ``prime_sql_auth`` deliberately catches probe exceptions and
+        reports them as ``success=False`` on this output rather than
+        raising. ``run()`` inspects ``success`` and short-circuits with
+        a structured ``AuthError`` before the parallel extract burst.
+
+        Why return-not-raise: the failure mode this task targets is
+        cache-cold auth rejection (``Access denied``). Retrying that
+        through Temporal's activity-level retry just stacks the source's
+        ``failed_login_attempts`` counter — i.e. accelerates the lockout
+        cycle the prime was added to prevent. Returning structured
+        failure to ``run()`` makes the short-circuit explicit, keeps
+        the contextual error visible in Temporal activity-complete
+        events, and removes the auto-retry that was actively harmful.
     """
 
     duration_ms: float = 0.0
     """Wall-clock time spent on the probe connection + ``SELECT 1`` + close."""
+
+    success: bool = True
+    """Whether the probe completed cleanly. ``False`` means the probe
+    raised; ``run()`` will short-circuit the workflow with an
+    ``AuthError`` carrying ``error_type`` / ``error_message``."""
+
+    error_type: str | None = None
+    """Exception class name (e.g. ``OperationalError``) when ``success``
+    is ``False``. ``None`` on success."""
+
+    error_message: str | None = None
+    """Truncated exception message when ``success`` is ``False``.
+    ``None`` on success. Secrets in the underlying driver message are
+    sanitised by the SDK error-wrapping layer; this field is the raw
+    short summary for observability."""
 
 
 class ExtractionTaskOutput(Output):

--- a/application_sdk/templates/contracts/sql_metadata.py
+++ b/application_sdk/templates/contracts/sql_metadata.py
@@ -310,6 +310,24 @@ class FetchViewsOutput(Output):
     total_record_count: int = 0
 
 
+class PrimeAuthOutput(Output):
+    """Output from the ``prime_sql_auth`` task (BLDX-1295).
+
+    The task itself is a single serial probe — it issues one ``SELECT 1``
+    to populate the SQL server's auth cache (notably MySQL 8's
+    ``caching_sha2_password``) before the parallel ``_extract_entity``
+    burst. It returns no payload of interest; activity-level success /
+    failure on the Temporal side is the meaningful signal. The fields
+    below exist purely for observability — they surface in
+    ``worker_start`` / activity-complete events and make it easy to spot
+    primes that are unusually slow (which often correlate with an
+    impending connection-burst failure).
+    """
+
+    duration_ms: float = 0.0
+    """Wall-clock time spent on the probe connection + ``SELECT 1`` + close."""
+
+
 class ExtractionTaskOutput(Output):
     """Output from a per-entity ``extract_*`` task.
 

--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -81,6 +81,7 @@ from application_sdk.constants import (
 from application_sdk.contracts.types import FileReference, StorageTier
 from application_sdk.credentials import CredentialResolver, legacy_credential_ref
 from application_sdk.credentials.ref import CredentialRef
+from application_sdk.errors.leaves import AuthError
 from application_sdk.execution import build_output_path, get_object_store_prefix
 from application_sdk.infrastructure.context import get_infrastructure
 from application_sdk.observability.logger_adaptor import get_logger
@@ -218,7 +219,7 @@ class SqlApp(App):
     # @task: SQL auth cache pre-warm — Argo parity (BLDX-1295)
     # =====================================================================
 
-    @task(timeout_seconds=60, retry_max_attempts=3)
+    @task(timeout_seconds=60)
     async def prime_sql_auth(self, input: ExtractionTaskInput) -> PrimeAuthOutput:
         """Single sequential probe that primes the SQL server's auth cache
         before the parallel ``_extract_entity`` burst.
@@ -265,33 +266,65 @@ class SqlApp(App):
             MSSQL, Snowflake on most setups), this is harmless overhead
             — a single ~100ms probe round-trip per workflow run.
 
-        Failure semantics:
+        Failure semantics (return-not-raise):
             If the probe fails (auth rejected, network unreachable,
-            wrong host, etc.), this activity raises and Temporal
-            short-circuits the entire workflow run. That's deliberate:
-            if the probe — a single non-parallel connection — fails,
-            the parallel extract burst would have failed N-fold and
-            would have flooded the source with ``Access denied``
-            attempts that could trip rate-limits / lockouts on the
-            customer side. Failing here surfaces a clean credential /
-            connectivity error before doing damage.
+            wrong host, etc.) this task catches the exception, populates
+            ``success=False`` + ``error_type`` + ``error_message`` on the
+            returned ``PrimeAuthOutput``, and lets ``run()`` short-circuit
+            the workflow with a structured ``AuthError``.
+
+            Why return failure instead of raising and letting Temporal
+            retry: the failure mode this task was added to prevent is
+            cache-cold auth rejection. Retrying it via Temporal's
+            activity-level retry stacks the source's
+            ``failed_login_attempts`` counter on each attempt — i.e. it
+            accelerates the very lockout cycle the prime exists to
+            avoid. Surfacing failure as structured data on the output
+            keeps the failure visible in Temporal activity-complete
+            events, gives ``run()`` an explicit decision point, and
+            removes an auto-retry that was actively harmful for this
+            specific code path. Workflow-level retry (re-running the
+            whole extraction after operator action) remains available
+            and is the correct retry layer for transient blips.
         """
         start = time.perf_counter()
-        client = await self._init_sql_client(input)
         try:
-            # ``SELECT 1`` is a no-op for query semantics; what we
-            # actually care about is that the client opened a
-            # connection + completed the auth handshake. The cache is
-            # populated as a side effect of that handshake.
-            await client.get_results("SELECT 1")
-        finally:
-            await client.close()
+            client = await self._init_sql_client(input)
+            try:
+                # ``SELECT 1`` is a no-op for query semantics; what we
+                # actually care about is that the client opened a
+                # connection + completed the auth handshake. The cache
+                # is populated as a side effect of that handshake.
+                await client.get_results("SELECT 1")
+            finally:
+                await client.close()
+        except Exception as exc:
+            duration_ms = (time.perf_counter() - start) * 1000.0
+            # Truncate driver messages so the contract field stays bounded;
+            # secret-sanitisation happens later when run() wraps this into
+            # an AuthError (errors.base._sanitize_cause_repr).
+            error_message = str(exc)
+            if len(error_message) > 500:
+                error_message = error_message[:500] + "…"
+            logger.error(
+                "SQL auth cache prime FAILED after %.1fms (%s) — short-circuiting "
+                "before parallel extract burst to avoid stacking failed_login_attempts "
+                "on the source.",
+                duration_ms,
+                type(exc).__name__,
+            )
+            return PrimeAuthOutput(
+                duration_ms=duration_ms,
+                success=False,
+                error_type=type(exc).__name__,
+                error_message=error_message,
+            )
         duration_ms = (time.perf_counter() - start) * 1000.0
         logger.info(
             "SQL auth cache primed in %.1fms before parallel extract fan-out",
             duration_ms,
         )
-        return PrimeAuthOutput(duration_ms=duration_ms)
+        return PrimeAuthOutput(duration_ms=duration_ms, success=True)
 
     # =====================================================================
     # @task: Metadata extraction — SQL stream → raw JSONL
@@ -552,12 +585,39 @@ class SqlApp(App):
         # parallel ``extract_*`` burst so MySQL 8's
         # ``caching_sha2_password`` server-side cache is populated. The
         # subsequent parallel connections then take the fast-auth path
-        # and never trip ``FAILED_LOGIN_ATTEMPTS`` lockouts. Failure
-        # here short-circuits the run with a clean credential /
-        # connectivity error instead of flooding the source with N
-        # parallel auth failures. See ``prime_sql_auth`` docstring for
-        # the full incident-rooted rationale.
-        await self.prime_sql_auth(task_input)
+        # and never trip ``FAILED_LOGIN_ATTEMPTS`` lockouts.
+        #
+        # Failure handling: prime_sql_auth catches probe exceptions and
+        # returns them as ``success=False`` on its output (see its
+        # docstring for why return-not-raise — short version: Temporal
+        # auto-retrying an auth-class failure stacks the lockout counter
+        # we're trying to avoid). We translate that structured failure
+        # into a typed AuthError here so the workflow short-circuits with
+        # an operator-actionable message that names the prime step, the
+        # underlying driver error, and the recommended fix path — and
+        # crucially, the parallel extract burst below never runs.
+        prime_result = await self.prime_sql_auth(task_input)
+        if not prime_result.success:
+            raise AuthError(
+                message=(
+                    "SQL auth-cache prime probe failed before parallel extract "
+                    f"burst ({prime_result.error_type}). Skipping extract "
+                    "fan-out to avoid stacking failed_login_attempts on the "
+                    "source's lockout counter."
+                ),
+                auth_method="sql_client",
+                failure_reason=prime_result.error_message,
+                suggested_action=(
+                    "Verify the SQL connection credentials and that the "
+                    "source is reachable from the worker. If the source is "
+                    "MySQL 8 and credentials are correct, also confirm the "
+                    "user is not currently locked out by "
+                    "FAILED_LOGIN_ATTEMPTS policy — wait for auto-unlock "
+                    "or have a DBA run ALTER USER … ACCOUNT UNLOCK before "
+                    "retrying the workflow."
+                ),
+                app_name=self._app_name,
+            )
 
         # ── Phase 1: Extract — SQL rows → raw JSONL ─────────────────────
         db_result, schema_result, table_result, column_result = await asyncio.gather(

--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -306,12 +306,18 @@ class SqlApp(App):
             error_message = str(exc)
             if len(error_message) > 500:
                 error_message = error_message[:500] + "…"
+            # exc_info=True preserves the traceback in worker logs even
+            # though the exception is being converted to structured return
+            # data. For most failures the class+message is sufficient, but
+            # the long-tail (TLS negotiation, driver bugs, version skew)
+            # is only diagnosable from the original frames.
             logger.error(
                 "SQL auth cache prime FAILED after %.1fms (%s) — short-circuiting "
                 "before parallel extract burst to avoid stacking failed_login_attempts "
                 "on the source.",
                 duration_ms,
                 type(exc).__name__,
+                exc_info=True,
             )
             return PrimeAuthOutput(
                 duration_ms=duration_ms,

--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -81,7 +81,12 @@ from application_sdk.constants import (
 from application_sdk.contracts.types import FileReference, StorageTier
 from application_sdk.credentials import CredentialResolver, legacy_credential_ref
 from application_sdk.credentials.ref import CredentialRef
-from application_sdk.errors.leaves import AuthError
+from application_sdk.errors.leaves import (
+    AppTimeoutError,
+    AuthError,
+    DependencyUnavailableError,
+    InternalError,
+)
 from application_sdk.execution import build_output_path, get_object_store_prefix
 from application_sdk.infrastructure.context import get_infrastructure
 from application_sdk.observability.logger_adaptor import get_logger
@@ -219,7 +224,17 @@ class SqlApp(App):
     # @task: SQL auth cache pre-warm — Argo parity (BLDX-1295)
     # =====================================================================
 
-    @task(timeout_seconds=60)
+    # retry_max_attempts=1 is load-bearing: the body's try/except only
+    # catches Python exceptions, NOT Temporal-level failures (start-to-close
+    # timeout, worker eviction, heartbeat timeout, OOM). Any of those
+    # triggers activity-level retry, which re-runs
+    # ``_init_sql_client → load → auth handshake`` — re-stacking
+    # ``failed_login_attempts`` on the source, i.e. the exact lockout-cycle
+    # this task exists to prevent. ``@task()`` defaults to
+    # ``retry_max_attempts=3`` (application_sdk/app/task.py), so we MUST
+    # override explicitly. See application-sdk#1835 mothership review
+    # comment-3287629972.
+    @task(timeout_seconds=60, retry_max_attempts=1)
     async def prime_sql_auth(self, input: ExtractionTaskInput) -> PrimeAuthOutput:
         """Single sequential probe that primes the SQL server's auth cache
         before the parallel ``_extract_entity`` burst.
@@ -266,12 +281,14 @@ class SqlApp(App):
             MSSQL, Snowflake on most setups), this is harmless overhead
             — a single ~100ms probe round-trip per workflow run.
 
-        Failure semantics (return-not-raise):
+        Failure semantics (return-not-raise + zero Temporal retries):
             If the probe fails (auth rejected, network unreachable,
             wrong host, etc.) this task catches the exception, populates
             ``success=False`` + ``error_type`` + ``error_message`` on the
             returned ``PrimeAuthOutput``, and lets ``run()`` short-circuit
-            the workflow with a structured ``AuthError``.
+            the workflow with a typed error (``AuthError``,
+            ``AppTimeoutError`` or ``DependencyUnavailableError``
+            depending on ``error_type``).
 
             Why return failure instead of raising and letting Temporal
             retry: the failure mode this task was added to prevent is
@@ -279,13 +296,15 @@ class SqlApp(App):
             activity-level retry stacks the source's
             ``failed_login_attempts`` counter on each attempt — i.e. it
             accelerates the very lockout cycle the prime exists to
-            avoid. Surfacing failure as structured data on the output
-            keeps the failure visible in Temporal activity-complete
-            events, gives ``run()`` an explicit decision point, and
-            removes an auto-retry that was actively harmful for this
-            specific code path. Workflow-level retry (re-running the
-            whole extraction after operator action) remains available
-            and is the correct retry layer for transient blips.
+            avoid. The ``retry_max_attempts=1`` override on the ``@task``
+            decorator above is load-bearing: the body try/except only
+            catches Python exceptions, not Temporal-level failures
+            (start-to-close timeout, worker eviction, heartbeat timeout,
+            OOM) — those would re-run the activity even with this body
+            structure, re-stacking the counter. Workflow-level retry
+            (re-running the whole extraction after operator action)
+            remains available and is the correct retry layer for
+            transient blips.
         """
         start = time.perf_counter()
         try:
@@ -331,6 +350,144 @@ class SqlApp(App):
             duration_ms,
         )
         return PrimeAuthOutput(duration_ms=duration_ms, success=True)
+
+    # =====================================================================
+    # prime_sql_auth failure classifier (BLDX-1295)
+    # =====================================================================
+
+    @staticmethod
+    def _classify_prime_failure(prime_result: PrimeAuthOutput) -> Exception:
+        """Map a failed ``PrimeAuthOutput`` to the right typed error.
+
+        Painting every probe failure as ``AuthError`` would mis-direct
+        on-call: a DBA who follows the lockout-specific
+        ``suggested_action`` for a DNS misconfiguration wastes time on
+        a non-existent account-lockout. We discriminate based on
+        ``error_type`` / ``error_message`` and raise:
+
+        - ``AuthError`` for actual credential rejections
+          (``Access denied``, MySQL code 1045,
+          ``AuthenticationError`` class names).
+        - ``AppTimeoutError`` for probe timeouts (``TimeoutError`` /
+          ``asyncio.TimeoutError`` / message contains ``timed out``).
+        - ``DependencyUnavailableError`` for network / DNS / TLS /
+          connection-refused failures — the source is presumed
+          reachable but didn't respond cleanly.
+        - ``InternalError`` as the last-resort fallback so we never
+          return ``None`` and never accidentally swallow an unknown
+          driver exception class.
+        """
+        error_type = prime_result.error_type or ""
+        error_message = prime_result.error_message or ""
+        msg_lower = error_message.lower()
+
+        is_timeout = "timeout" in error_type.lower() or "timed out" in msg_lower
+        if is_timeout:
+            return AppTimeoutError(
+                message=(
+                    "SQL auth-cache prime probe timed out before parallel "
+                    f"extract burst ({error_type}): {error_message}"
+                ),
+                operation="prime_sql_auth",
+                suggested_action=(
+                    "Check network reachability and source health: the probe "
+                    "did not get an auth response within the 60s task "
+                    "deadline. Verify the source listener is up and the "
+                    "worker → source network path is healthy before "
+                    "retrying the workflow."
+                ),
+            )
+
+        # Auth-class indicators: explicit class name OR driver-specific
+        # message tokens (MySQL "Access denied" / code 1045, generic
+        # "authentication failed"). Driver error_type for MySQL
+        # ``Access denied`` is ``OperationalError`` — that class is
+        # overloaded across both auth and network failures, so message
+        # content has to be the tiebreaker.
+        auth_class_hints = ("authentication", "accessdenied", "authfail")
+        auth_msg_hints = (
+            "access denied",
+            "1045",
+            "authentication failed",
+            "authentication error",
+            "login failed",
+            "password authentication failed",
+            "invalid credentials",
+        )
+        is_auth = any(h in error_type.lower() for h in auth_class_hints) or any(
+            h in msg_lower for h in auth_msg_hints
+        )
+        if is_auth:
+            return AuthError(
+                message=(
+                    "SQL auth-cache prime rejected by source before parallel "
+                    f"extract burst ({error_type}). Skipping extract fan-out "
+                    "to avoid stacking failed_login_attempts on the source's "
+                    "lockout counter."
+                ),
+                auth_method="sql_client",
+                failure_reason=error_message,
+                suggested_action=(
+                    "Verify the SQL connection credentials. If the source is "
+                    "MySQL 8 and credentials are correct, also confirm the "
+                    "user is not currently locked out by "
+                    "FAILED_LOGIN_ATTEMPTS policy — wait for auto-unlock or "
+                    "have a DBA run ALTER USER … ACCOUNT UNLOCK before "
+                    "retrying the workflow."
+                ),
+            )
+
+        # Network / DNS / TLS / connection-refused / generic
+        # OperationalError without an auth-keyword message. Default to
+        # DependencyUnavailableError — actionable guidance is "fix the
+        # network path, the source itself may be fine."
+        network_class_hints = (
+            "connectionerror",
+            "connectionrefused",
+            "gaierror",
+            "sslerror",
+            "oserror",
+            "operationalerror",
+            "interfaceerror",
+            "dependencyunavailable",
+            "socketerror",
+        )
+        if any(h in error_type.lower() for h in network_class_hints):
+            return DependencyUnavailableError(
+                message=(
+                    "SQL auth-cache prime could not reach the source before "
+                    f"parallel extract burst ({error_type})."
+                ),
+                service="sql_source",
+                network_error=error_message,
+                suggested_action=(
+                    "Check DNS resolution, NAT/firewall rules, TLS "
+                    "configuration, and that the source listener is "
+                    "accepting connections from the worker network. The "
+                    "credentials path was not exercised, so this is not a "
+                    "lockout situation — do not run ACCOUNT UNLOCK."
+                ),
+            )
+
+        # Last-resort: never swallow an unknown driver error class.
+        # ``classification_pending=True`` flags this to wire/log
+        # consumers that the on-call should help refine the classifier
+        # rather than treat the category at face value.
+        return InternalError(
+            message=(
+                "SQL auth-cache prime failed before parallel extract burst "
+                f"with an unclassified error ({error_type}): {error_message}"
+            ),
+            component="sql_app.prime_sql_auth",
+            classification_pending=True,
+            suggested_action=(
+                "Inspect the worker logs (the prime task logs the original "
+                "traceback via exc_info=True). The error type was not "
+                "recognised as auth / timeout / network — please file a "
+                "ticket so the classifier in SqlApp._classify_prime_failure "
+                "can be extended."
+            ),
+        )
 
     # =====================================================================
     # @task: Metadata extraction — SQL stream → raw JSONL
@@ -594,36 +751,16 @@ class SqlApp(App):
         # and never trip ``FAILED_LOGIN_ATTEMPTS`` lockouts.
         #
         # Failure handling: prime_sql_auth catches probe exceptions and
-        # returns them as ``success=False`` on its output (see its
-        # docstring for why return-not-raise — short version: Temporal
-        # auto-retrying an auth-class failure stacks the lockout counter
-        # we're trying to avoid). We translate that structured failure
-        # into a typed AuthError here so the workflow short-circuits with
-        # an operator-actionable message that names the prime step, the
-        # underlying driver error, and the recommended fix path — and
-        # crucially, the parallel extract burst below never runs.
+        # returns them as ``success=False`` on its output. We classify
+        # ``error_type`` / ``error_message`` and raise the matching typed
+        # error so operators get actionable guidance for the *actual*
+        # failure mode (not a one-size-fits-all auth-lockout message —
+        # which would mislead an on-call investigating a DNS or TLS
+        # misconfiguration). The parallel extract burst still never
+        # runs on prime failure regardless of which error type we raise.
         prime_result = await self.prime_sql_auth(task_input)
         if not prime_result.success:
-            raise AuthError(
-                message=(
-                    "SQL auth-cache prime probe failed before parallel extract "
-                    f"burst ({prime_result.error_type}). Skipping extract "
-                    "fan-out to avoid stacking failed_login_attempts on the "
-                    "source's lockout counter."
-                ),
-                auth_method="sql_client",
-                failure_reason=prime_result.error_message,
-                suggested_action=(
-                    "Verify the SQL connection credentials and that the "
-                    "source is reachable from the worker. If the source is "
-                    "MySQL 8 and credentials are correct, also confirm the "
-                    "user is not currently locked out by "
-                    "FAILED_LOGIN_ATTEMPTS policy — wait for auto-unlock "
-                    "or have a DBA run ALTER USER … ACCOUNT UNLOCK before "
-                    "retrying the workflow."
-                ),
-                app_name=self._app_name,
-            )
+            raise self._classify_prime_failure(prime_result)
 
         # ── Phase 1: Extract — SQL rows → raw JSONL ─────────────────────
         db_result, schema_result, table_result, column_result = await asyncio.gather(

--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -61,6 +61,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import time
 from collections.abc import Callable
 from decimal import Decimal
 from pathlib import Path
@@ -88,6 +89,7 @@ from application_sdk.templates.contracts.sql_metadata import (
     ExtractionOutput,
     ExtractionTaskInput,
     ExtractionTaskOutput,
+    PrimeAuthOutput,
     TransformInput,
     TransformOutput,
 )
@@ -211,6 +213,85 @@ class SqlApp(App):
             temp_table_regex=src.temp_table_regex,
             source_tag_prefix=getattr(src, "source_tag_prefix", ""),
         )
+
+    # =====================================================================
+    # @task: SQL auth cache pre-warm — Argo parity (BLDX-1295)
+    # =====================================================================
+
+    @task(timeout_seconds=60, retry_max_attempts=3)
+    async def prime_sql_auth(self, input: ExtractionTaskInput) -> PrimeAuthOutput:
+        """Single sequential probe that primes the SQL server's auth cache
+        before the parallel ``_extract_entity`` burst.
+
+        Background — why this exists (BLDX-1295):
+            v3's parallel-activity execution model fans out
+            ``extract_databases / extract_schemas / extract_tables /
+            extract_columns`` (and on subclasses, ``extract_procedures``)
+            as concurrent Temporal activities. Each one creates its own
+            ``SQLClient`` instance and opens its own connections to the
+            source — roughly simultaneously when the workflow first
+            starts.
+
+            MySQL 8's default auth plugin ``caching_sha2_password`` has a
+            server-side cache keyed by ``(user, password_hash)``. The
+            *first* auth for a given user is cache-cold and requires
+            either (a) a TLS-encrypted connection or (b) an RSA key
+            exchange between client and server. Without either — which
+            is the default for ``aiomysql`` against a typical customer
+            MySQL — a cache-cold auth attempt fails with
+            ``Access denied (1045)``. When N parallel activities all hit
+            cold-cache simultaneously, each independently tries full
+            auth, each fails, and those failures stack on the server's
+            ``failed_login_attempts`` counter — tripping the
+            ``FAILED_LOGIN_ATTEMPTS`` lockout policy if the customer has
+            one set (most do). The lockout then poisons every subsequent
+            scheduled run until it auto-expires, at which point a manual
+            "Test Authentication" works briefly, the next cron burst
+            re-trips it, repeat.
+
+            The Argo-era extract ran phases serially — only one
+            connection at a time — so the cache had time to prime
+            between phases and the race never occurred. v3's parallel
+            model exposes it.
+
+            This task is the Argo-parity fix: ``run()`` awaits it
+            *once*, sequentially, before the ``asyncio.gather(...)`` of
+            extract activities. It opens one connection, runs
+            ``SELECT 1``, closes. That populates MySQL's
+            ``caching_sha2_password`` cache; subsequent parallel
+            connections take the fast path and never need full auth.
+
+            For SQL servers without this auth-cache concept (Postgres,
+            MSSQL, Snowflake on most setups), this is harmless overhead
+            — a single ~100ms probe round-trip per workflow run.
+
+        Failure semantics:
+            If the probe fails (auth rejected, network unreachable,
+            wrong host, etc.), this activity raises and Temporal
+            short-circuits the entire workflow run. That's deliberate:
+            if the probe — a single non-parallel connection — fails,
+            the parallel extract burst would have failed N-fold and
+            would have flooded the source with ``Access denied``
+            attempts that could trip rate-limits / lockouts on the
+            customer side. Failing here surfaces a clean credential /
+            connectivity error before doing damage.
+        """
+        start = time.perf_counter()
+        client = await self._init_sql_client(input)
+        try:
+            # ``SELECT 1`` is a no-op for query semantics; what we
+            # actually care about is that the client opened a
+            # connection + completed the auth handshake. The cache is
+            # populated as a side effect of that handshake.
+            await client.get_results("SELECT 1")
+        finally:
+            await client.close()
+        duration_ms = (time.perf_counter() - start) * 1000.0
+        logger.info(
+            "SQL auth cache primed in %.1fms before parallel extract fan-out",
+            duration_ms,
+        )
+        return PrimeAuthOutput(duration_ms=duration_ms)
 
     # =====================================================================
     # @task: Metadata extraction — SQL stream → raw JSONL
@@ -465,6 +546,18 @@ class SqlApp(App):
         task_input = self.build_task_input(
             ExtractionTaskInput, input, cred_ref=cred_ref
         )
+
+        # ── Phase 0: Pre-warm SQL auth cache (BLDX-1295) ────────────────
+        # Argo parity fix. One serial probe connection BEFORE the
+        # parallel ``extract_*`` burst so MySQL 8's
+        # ``caching_sha2_password`` server-side cache is populated. The
+        # subsequent parallel connections then take the fast-auth path
+        # and never trip ``FAILED_LOGIN_ATTEMPTS`` lockouts. Failure
+        # here short-circuits the run with a clean credential /
+        # connectivity error instead of flooding the source with N
+        # parallel auth failures. See ``prime_sql_auth`` docstring for
+        # the full incident-rooted rationale.
+        await self.prime_sql_auth(task_input)
 
         # ── Phase 1: Extract — SQL rows → raw JSONL ─────────────────────
         db_result, schema_result, table_result, column_result = await asyncio.gather(

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.13.0
-source-sha:    144c4044051c5e4f02febbe591fd58824ac9dd1f
-source-date:   2026-05-21T18:59:57+01:00
+source-sha:    2620401691856f2595deb93eec003b0fd1ed14df
+source-date:   2026-05-22T14:59:16+05:30
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -2805,9 +2805,9 @@ Strongly-typed Pydantic models for SDK methods. Contracts in `application_sdk.co
 - **Summary:** Output from the ``prime_sql_auth`` task (BLDX-1295).
 - **Fields:**
   - `duration_ms: float` `= 0.0` — Wall-clock time spent on the probe connection + ``SELECT 1`` + close.
-  - `success: bool` `= True` — Whether the probe completed cleanly. ``False`` means ``run()`` short-circuits with a typed ``AuthError`` carrying ``error_type`` / ``error_message``.
-  - `error_type: str | None` `= None` — Exception class name when ``success`` is ``False``.
-  - `error_message: str | None` `= None` — Truncated exception message when ``success`` is ``False``.
+  - `success: bool` `= True` — Whether the probe completed cleanly. ``False`` means the probe
+  - `error_type: str | None` — Exception class name (e.g. ``OperationalError``) when ``success``
+  - `error_message: str | None` — Truncated exception message when ``success`` is ``False``.
 - **Defined in:** `application_sdk/templates/contracts/sql_metadata.py`
 
 #### `QueryBatchInput`

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -2799,6 +2799,14 @@ Strongly-typed Pydantic models for SDK methods. Contracts in `application_sdk.co
   - `batches_local_dir: str` `= ''`
 - **Defined in:** `application_sdk/templates/contracts/incremental_sql.py`
 
+#### `PrimeAuthOutput`
+
+- **Import:** `from application_sdk.templates.contracts import PrimeAuthOutput`
+- **Summary:** Output from the ``prime_sql_auth`` task (BLDX-1295).
+- **Fields:**
+  - `duration_ms: float` `= 0.0` — Wall-clock time spent on the probe connection + ``SELECT 1`` + close.
+- **Defined in:** `application_sdk/templates/contracts/sql_metadata.py`
+
 #### `QueryBatchInput`
 
 - **Import:** `from application_sdk.templates.contracts import QueryBatchInput`

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.13.0
-source-sha:    2620401691856f2595deb93eec003b0fd1ed14df
-source-date:   2026-05-22T14:59:16+05:30
+source-sha:    085256727df025f7d1acd7fd65efac9463bee9f7
+source-date:   2026-05-22T15:53:09+05:30
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -2805,6 +2805,9 @@ Strongly-typed Pydantic models for SDK methods. Contracts in `application_sdk.co
 - **Summary:** Output from the ``prime_sql_auth`` task (BLDX-1295).
 - **Fields:**
   - `duration_ms: float` `= 0.0` — Wall-clock time spent on the probe connection + ``SELECT 1`` + close.
+  - `success: bool` `= True` — Whether the probe completed cleanly. ``False`` means ``run()`` short-circuits with a typed ``AuthError`` carrying ``error_type`` / ``error_message``.
+  - `error_type: str | None` `= None` — Exception class name when ``success`` is ``False``.
+  - `error_message: str | None` `= None` — Truncated exception message when ``success`` is ``False``.
 - **Defined in:** `application_sdk/templates/contracts/sql_metadata.py`
 
 #### `QueryBatchInput`

--- a/tests/integration/test_sql_app_prime_auth.py
+++ b/tests/integration/test_sql_app_prime_auth.py
@@ -1,0 +1,232 @@
+"""Integration test: SqlApp pre-warms SQL auth cache before parallel extract burst
+(BLDX-1295 — Argo parity for v3's parallel-activity execution model).
+
+Bug context:
+    v3's ``SqlApp.run()`` fans out ``extract_databases / extract_schemas
+    / extract_tables / extract_columns`` as parallel Temporal activities.
+    Each activity opens its own SQL client and authenticates against
+    the source — concurrently. For sources whose first-auth handshake
+    is cache-cold (MySQL 8's ``caching_sha2_password`` is the canonical
+    example), N parallel cold-cache auth attempts can each fail and
+    stack on the per-user ``failed_login_attempts`` counter — tripping
+    the customer's ``FAILED_LOGIN_ATTEMPTS`` lockout policy. The
+    customer then sees scheduled runs failing with ``Access denied``
+    until the lockout auto-expires, at which point a manual ``Test
+    Authentication`` works briefly, the next cron run re-trips it,
+    repeat.
+
+What this test asserts:
+    Running through ``app.run()`` end-to-end (with the prime fix in
+    place) produces a timeline where:
+    1. The serial ``prime_sql_auth`` connection completes BEFORE any
+       ``extract_*`` connection starts.
+    2. The four ``extract_*`` connections then run concurrently
+       (overlapping wall-clock windows) — we don't want to give up
+       v3's parallel-extract speed; we just want the *first*
+       connection to be serial.
+
+What this test would fail at if the prime is removed:
+    The bug-repro test in ``tests/unit/templates/test_sql_app.py::
+    TestPrimeSqlAuth::test_reproduces_parallel_auth_burst_when_prime_skipped``
+    pins the call-order assertion. This integration test pins the
+    wall-clock-time assertion against a live ``app.run()``, so a
+    regression where the prime is dropped from ``run()`` is caught
+    both in unit (call order) and integration (timeline overlap).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, ClassVar
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from application_sdk.clients.sql import BaseSQLClient
+from application_sdk.templates.contracts.sql_metadata import ExtractionInput
+from application_sdk.templates.sql_app import SqlApp
+
+
+class _TimingSqlClient(BaseSQLClient):
+    """In-process SQL client that records the wall-clock window of each
+    connection it serves. Lets the test assert ordering and overlap
+    without needing a real MySQL server.
+    """
+
+    # Each entry: (label, connect_started_at, connect_ended_at)
+    _CONNECTION_LOG: ClassVar[list[tuple[str, float, float]]] = []
+
+    # Per-connection label injected by the caller; lets us correlate
+    # connection windows back to which orchestration phase opened them
+    # (prime_sql_auth vs each extract_*).
+    label: str = ""
+
+    def __init__(self) -> None:
+        pass  # skip BaseSQLClient.__init__
+
+    async def load(self, credentials: dict[str, Any] | None = None) -> None:
+        start = time.perf_counter()
+        # Simulate a real connection + auth handshake taking some time so
+        # parallel attempts can plausibly overlap on the wall clock.
+        await asyncio.sleep(0.05)
+        end = time.perf_counter()
+        self._CONNECTION_LOG.append((self.label, start, end))
+
+    async def close(self) -> None:
+        return None
+
+    async def run_query(self, query: str, batch_size: int = 100_000):
+        # Yield zero rows — extract activities exit fast.
+        if False:
+            yield []
+        return
+
+    async def get_results(self, query: str):
+        # prime_sql_auth issues SELECT 1 through this method; we just
+        # need to return something truthy-ish — no real query execution.
+        return []
+
+
+class _PrimeAuthIntegrationApp(SqlApp):
+    """SqlApp subclass that injects a labelled ``_TimingSqlClient`` so
+    each orchestration phase's connection window is identifiable in
+    the timeline.
+    """
+
+    _app_registered: ClassVar[bool] = True
+
+    sql_client_class: ClassVar[type[BaseSQLClient] | None] = _TimingSqlClient
+
+    fetch_database_sql: ClassVar[str] = "SELECT 1"
+    fetch_schema_sql: ClassVar[str] = "SELECT 1"
+    fetch_table_sql: ClassVar[str] = "SELECT 1"
+    fetch_column_sql: ClassVar[str] = "SELECT 1"
+
+    # Track which phase is calling _init_sql_client so we can label
+    # the resulting connection. _init_sql_client is the single
+    # choke-point through which every SQL connection in SqlApp is
+    # created — see prime_sql_auth, extract_*, etc.
+    def __init__(self) -> None:
+        super().__init__()
+        self._label_seq = iter(
+            [
+                "prime_sql_auth",
+                "extract_databases",
+                "extract_schemas",
+                "extract_tables",
+                "extract_columns",
+            ]
+        )
+
+    async def _init_sql_client(self, input):  # type: ignore[override]
+        client = self.sql_client_class()  # type: ignore[misc]
+        client.label = next(self._label_seq, "unknown")
+        await client.load(credentials={})
+        return client
+
+    def map_database(self, record, connection_qn):
+        return {"typeName": "Database"}
+
+    def map_schema(self, record, connection_qn):
+        return {"typeName": "Schema"}
+
+    def map_table(self, record, connection_qn):
+        return {"typeName": "Table"}
+
+    def map_column(self, record, connection_qn):
+        return {"typeName": "Column"}
+
+
+@pytest.mark.asyncio
+async def test_prime_completes_before_extracts_start(tmp_path) -> None:
+    """End-to-end: drive ``SqlApp.run()`` with a real timing-instrumented
+    SQL client. The prime connection must complete strictly before any
+    extract connection starts."""
+    _TimingSqlClient._CONNECTION_LOG.clear()
+
+    app = _PrimeAuthIntegrationApp()
+    mock_wf_info = MagicMock(workflow_id="wf-prime-1", run_id="run-prime-1")
+
+    with (
+        patch.object(SqlApp, "_resolve_credential_ref", return_value=None),
+        patch(
+            "application_sdk.templates.sql_app._temporal_workflow.info",
+            return_value=mock_wf_info,
+        ),
+    ):
+        await app.run(ExtractionInput(output_path=str(tmp_path)))
+
+    log = _TimingSqlClient._CONNECTION_LOG
+    by_label = {label: (start, end) for label, start, end in log}
+
+    # Assertion 1: prime ran first
+    assert (
+        "prime_sql_auth" in by_label
+    ), f"prime_sql_auth connection was never recorded; got {list(by_label)}"
+
+    prime_start, prime_end = by_label["prime_sql_auth"]
+
+    extract_labels = (
+        "extract_databases",
+        "extract_schemas",
+        "extract_tables",
+        "extract_columns",
+    )
+
+    # Assertion 2: every extract connection started AFTER prime ended.
+    # This is the core BLDX-1295 invariant — prevents the parallel
+    # cold-auth burst from hitting the source before the cache is primed.
+    for label in extract_labels:
+        assert label in by_label, f"missing connection log for {label}"
+        ext_start, _ = by_label[label]
+        assert ext_start >= prime_end, (
+            f"{label} started at {ext_start:.4f}s but prime ended at "
+            f"{prime_end:.4f}s — extract connection overlapped or preceded "
+            f"the prime, defeating the BLDX-1295 fix"
+        )
+
+
+@pytest.mark.asyncio
+async def test_extracts_still_run_concurrently_after_prime(tmp_path) -> None:
+    """End-to-end: the prime serializes only the FIRST connection.
+    Subsequent extracts must still overlap on the wall clock —
+    otherwise we've regressed v3's parallel-extract performance."""
+    _TimingSqlClient._CONNECTION_LOG.clear()
+
+    app = _PrimeAuthIntegrationApp()
+    mock_wf_info = MagicMock(workflow_id="wf-concurrent-1", run_id="run-concurrent-1")
+
+    with (
+        patch.object(SqlApp, "_resolve_credential_ref", return_value=None),
+        patch(
+            "application_sdk.templates.sql_app._temporal_workflow.info",
+            return_value=mock_wf_info,
+        ),
+    ):
+        await app.run(ExtractionInput(output_path=str(tmp_path)))
+
+    log = _TimingSqlClient._CONNECTION_LOG
+
+    extract_windows = [
+        (label, start, end) for label, start, end in log if label.startswith("extract_")
+    ]
+    assert len(extract_windows) == 4, (
+        f"Expected 4 extract connections; got {len(extract_windows)}: "
+        f"{[lbl for lbl, _, _ in extract_windows]}"
+    )
+
+    # Compute pairwise overlap. With ``asyncio.gather`` + 50ms sleeps,
+    # extract connections must have at least one overlapping pair.
+    overlapping_pairs = 0
+    for i, (a_label, a_start, a_end) in enumerate(extract_windows):
+        for b_label, b_start, b_end in extract_windows[i + 1 :]:
+            if a_start < b_end and b_start < a_end:
+                overlapping_pairs += 1
+
+    assert overlapping_pairs > 0, (
+        "Expected at least one pair of extract connections to overlap "
+        "on the wall clock — they're supposed to run in parallel via "
+        f"asyncio.gather. Connection windows: "
+        f"{[(lbl, end - start) for lbl, start, end in extract_windows]}"
+    )

--- a/tests/integration/test_sql_app_prime_auth.py
+++ b/tests/integration/test_sql_app_prime_auth.py
@@ -41,8 +41,6 @@ import time
 from typing import Any, ClassVar
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from application_sdk.clients.sql import BaseSQLClient
 from application_sdk.templates.contracts.sql_metadata import ExtractionInput
 from application_sdk.templates.sql_app import SqlApp
@@ -138,7 +136,6 @@ class _PrimeAuthIntegrationApp(SqlApp):
         return {"typeName": "Column"}
 
 
-@pytest.mark.asyncio
 async def test_prime_completes_before_extracts_start(tmp_path) -> None:
     """End-to-end: drive ``SqlApp.run()`` with a real timing-instrumented
     SQL client. The prime connection must complete strictly before any
@@ -187,7 +184,6 @@ async def test_prime_completes_before_extracts_start(tmp_path) -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_extracts_still_run_concurrently_after_prime(tmp_path) -> None:
     """End-to-end: the prime serializes only the FIRST connection.
     Subsequent extracts must still overlap on the wall clock —

--- a/tests/unit/templates/test_sql_app.py
+++ b/tests/unit/templates/test_sql_app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1672,80 +1673,84 @@ class TestPrimeSqlAuth:
 
     # ── Bug-reproduction via call ordering ──────────────────────────────
 
-    async def test_reproduces_parallel_auth_burst_when_prime_skipped(self, app):
-        """BUG REPRO (pre-fix shape): without a serial prime, the four
-        extract activities each independently initialise a SQL client,
-        concurrently. Capture each ``_init_sql_client`` call and assert
-        the calls overlap in time — this is precisely what triggers the
-        cold-cache lockout cycle described in BLDX-1295.
-
-        This test patches out ``prime_sql_auth`` to simulate the
-        pre-fix code path; with ``prime_sql_auth`` skipped, all four
-        extract clients init concurrently. The complementary test
-        below pins the fix.
+    async def test_reproduces_parallel_auth_burst_when_prime_skipped(self):
+        """BUG REPRO (pre-fix shape): drive the real ``SqlApp.run()`` with
+        ``prime_sql_auth`` patched to a no-op, and observe ``_init_sql_client``
+        being entered concurrently by the four real ``extract_*``
+        activities. ``max_active >= 2`` here is meaningful — it proves
+        the *SDK's* extract fan-out actually overlaps on init, which is
+        exactly the cold-auth-burst race BLDX-1295 was filed for. (An
+        earlier version of this test was vacuous: it awaited four bare
+        helpers via ``asyncio.gather`` and never went through ``run()``.
+        Pinned by application-sdk#1835 mothership comment-3287630369.)
         """
-        import asyncio as _asyncio
+        from unittest.mock import MagicMock
 
         active = 0
         max_active = 0
-        ready = _asyncio.Event()
 
-        async def _slow_client_init(self_, input_):
+        async def _counting_init(self_, input_):
             nonlocal active, max_active
             active += 1
             max_active = max(max_active, active)
-            # Hold open briefly so concurrent inits overlap in real time
             try:
-                await _asyncio.sleep(0.02)
+                # Hold the client init open briefly so concurrent enters
+                # are observable on the wall clock.
+                await asyncio.sleep(0.02)
+                return FakeSQLClient(rows=[{"x": 1}])
             finally:
                 active -= 1
-                ready.set()
-            return FakeSQLClient(rows=[{"x": 1}])
 
-        # Simulate the pre-fix path: prime_sql_auth is a no-op, extract
-        # activities each open their own client in parallel.
-        input_ = ExtractionInput(output_path="/tmp/test")
+        async def _fake_extract(_self, input_):
+            # Each real extract_* path normally goes through
+            # _init_sql_client. Reproduce that here so the counter
+            # observes the parallel burst — and return a minimal
+            # ExtractionTaskOutput so run()'s downstream wiring
+            # (transform threading) doesn't blow up.
+            await _counting_init(_self, input_)
+            return ExtractionTaskOutput(
+                typename="x", total_record_count=0, raw_file=None
+            )
+
+        app = SqlApp.__new__(SqlApp)
+        app._app_name = "test-app"
+
+        mock_wf_info = MagicMock(workflow_id="wf-burst", run_id="run-burst")
+
         with (
             patch.object(SqlApp, "_resolve_credential_ref", return_value=None),
+            patch(
+                "application_sdk.templates.sql_app._temporal_workflow.info",
+                return_value=mock_wf_info,
+            ),
+            # Simulate the pre-fix path: prime is a no-op so it does
+            # NOT serialise the first connection.
             patch.object(
                 SqlApp,
                 "prime_sql_auth",
                 new=AsyncMock(return_value=PrimeAuthOutput(duration_ms=0.0)),
             ),
-            patch.object(SqlApp, "_init_sql_client", new=_slow_client_init),
-            patch.object(
-                SqlApp,
-                "_extract_entity",
-                new=AsyncMock(
-                    side_effect=lambda **_kw: _asyncio.sleep(0).__await__().send(None)
-                    if False
-                    else _asyncio.create_task(_slow_client_init(None, None))
-                    and ExtractionTaskOutput(
-                        typename="x", total_record_count=1, raw_file=None
-                    ),
-                ),
-            ),
+            # Real extract_* tasks each enter _counting_init — that's
+            # the parallel burst we want to expose.
+            patch.object(SqlApp, "extract_databases", new=_fake_extract),
+            patch.object(SqlApp, "extract_schemas", new=_fake_extract),
+            patch.object(SqlApp, "extract_tables", new=_fake_extract),
+            patch.object(SqlApp, "extract_columns", new=_fake_extract),
             patch.object(SqlApp, "transform_databases", new=AsyncMock()),
             patch.object(SqlApp, "transform_schemas", new=AsyncMock()),
             patch.object(SqlApp, "transform_tables", new=AsyncMock()),
             patch.object(SqlApp, "transform_columns", new=AsyncMock()),
         ):
-            # Drive a minimal run via the extract_* tasks directly so the
-            # gather() in run() reproduces the parallel burst.
-            task_input = SqlApp.build_task_input(ExtractionTaskInput, input_)
-            await _asyncio.gather(
-                _slow_client_init(None, task_input),
-                _slow_client_init(None, task_input),
-                _slow_client_init(None, task_input),
-                _slow_client_init(None, task_input),
-            )
+            await app.run(ExtractionInput(output_path="/tmp/test"))
 
-        # Pre-fix shape: 4 concurrent inits overlapped. max_active > 1
-        # is the diagnostic — it's exactly what we want the prime task
-        # to prevent in real-world execution.
+        # Genuine evidence: with the prime stubbed out, the four
+        # extract_* activities all entered _init_sql_client at the
+        # same time. That is precisely the BLDX-1295 cold-auth burst
+        # the prime_sql_auth task exists to prevent.
         assert max_active >= 2, (
-            f"Expected concurrent client inits to reproduce the BLDX-1295 "
-            f"cold-auth burst, but only saw max_active={max_active}"
+            f"Expected the pre-fix shape (no real prime) to produce "
+            f"overlapping _init_sql_client entries, but only saw "
+            f"max_active={max_active}"
         )
 
     async def test_run_invokes_prime_sql_auth_before_extracts(self):
@@ -1882,7 +1887,7 @@ class TestPrimeSqlAuth:
         # failure_reason, and the suggestion mentions FAILED_LOGIN_ATTEMPTS
         # so an operator knows what to check before retrying.
         err = exc_info.value
-        assert "auth-cache prime probe failed" in err.message.lower()
+        assert "rejected by source" in err.message.lower()
         assert "OperationalError" in err.message
         assert err.failure_reason and "Access denied" in err.failure_reason
         assert err.auth_method == "sql_client"
@@ -1926,3 +1931,158 @@ class TestPrimeSqlAuth:
                 await app.run(ExtractionInput(output_path="/tmp/test"))
 
         assert exc_info.value.effective_retryable is False
+
+    @pytest.mark.parametrize(
+        "error_type,error_message",
+        [
+            ("TimeoutError", "operation timed out after 60s"),
+            ("AsyncioTimeoutError", "deadline exceeded"),
+            ("OperationalError", "(2013) Lost connection during query — timed out"),
+        ],
+    )
+    async def test_prime_timeout_raises_app_timeout_error(
+        self, error_type, error_message
+    ):
+        """Probe failures classified as timeouts must surface as
+        ``AppTimeoutError`` — NOT ``AuthError`` — so the on-call's
+        ``suggested_action`` is "check network reachability" rather
+        than "run ACCOUNT UNLOCK". Pinned by application-sdk#1835
+        mothership comment-3287630230 (HIGH).
+        """
+        from application_sdk.errors.leaves import AppTimeoutError
+
+        app = SqlApp.__new__(SqlApp)
+        app._app_name = "test-app"
+
+        with (
+            patch.object(SqlApp, "_resolve_credential_ref", return_value=None),
+            patch.object(
+                SqlApp,
+                "prime_sql_auth",
+                new=AsyncMock(
+                    return_value=PrimeAuthOutput(
+                        duration_ms=60_000.0,
+                        success=False,
+                        error_type=error_type,
+                        error_message=error_message,
+                    ),
+                ),
+            ),
+            patch.object(SqlApp, "extract_databases", new=AsyncMock()),
+            patch.object(SqlApp, "extract_schemas", new=AsyncMock()),
+            patch.object(SqlApp, "extract_tables", new=AsyncMock()),
+            patch.object(SqlApp, "extract_columns", new=AsyncMock()),
+        ):
+            with pytest.raises(AppTimeoutError) as exc_info:
+                await app.run(ExtractionInput(output_path="/tmp/test"))
+
+        err = exc_info.value
+        assert err.operation == "prime_sql_auth"
+        # AppTimeoutError doesn't define a structured ``failure_reason``
+        # field — driver message is inlined into ``message`` instead.
+        assert error_message in err.message
+        assert err.suggested_action and "network reachability" in err.suggested_action
+
+    @pytest.mark.parametrize(
+        "error_type,error_message",
+        [
+            ("ConnectionRefusedError", "[Errno 111] Connection refused"),
+            ("gaierror", "[Errno -2] Name or service not known"),
+            ("SSLError", "[SSL: CERTIFICATE_VERIFY_FAILED]"),
+            (
+                "OperationalError",
+                "(2003) Can't connect to MySQL server on 'db.example.com'",
+            ),
+        ],
+    )
+    async def test_prime_network_failure_raises_dependency_unavailable(
+        self, error_type, error_message
+    ):
+        """Probe failures that look like network / DNS / TLS /
+        connection-refused must surface as
+        ``DependencyUnavailableError``. The on-call guidance must NOT
+        suggest a credentials check (the credentials path was never
+        exercised) and must NOT suggest ACCOUNT UNLOCK (no failed
+        login attempts were made). Pinned by application-sdk#1835
+        mothership comment-3287630230 (HIGH).
+        """
+        from application_sdk.errors.leaves import DependencyUnavailableError
+
+        app = SqlApp.__new__(SqlApp)
+        app._app_name = "test-app"
+
+        with (
+            patch.object(SqlApp, "_resolve_credential_ref", return_value=None),
+            patch.object(
+                SqlApp,
+                "prime_sql_auth",
+                new=AsyncMock(
+                    return_value=PrimeAuthOutput(
+                        duration_ms=50.0,
+                        success=False,
+                        error_type=error_type,
+                        error_message=error_message,
+                    ),
+                ),
+            ),
+            patch.object(SqlApp, "extract_databases", new=AsyncMock()),
+            patch.object(SqlApp, "extract_schemas", new=AsyncMock()),
+            patch.object(SqlApp, "extract_tables", new=AsyncMock()),
+            patch.object(SqlApp, "extract_columns", new=AsyncMock()),
+        ):
+            with pytest.raises(DependencyUnavailableError) as exc_info:
+                await app.run(ExtractionInput(output_path="/tmp/test"))
+
+        err = exc_info.value
+        assert err.service == "sql_source"
+        assert err.network_error == error_message
+        # Must steer the operator toward network/DNS investigation, and
+        # explicitly NOT toward auth-lockout work. The classifier's
+        # actual phrasing is "this is not a lockout situation — do not
+        # run ACCOUNT UNLOCK" (a helpful disclaimer), so check the
+        # positive guidance is network-shaped.
+        assert err.suggested_action and "DNS" in err.suggested_action
+        assert (
+            err.suggested_action and "FAILED_LOGIN_ATTEMPTS" not in err.suggested_action
+        )
+
+    async def test_prime_unknown_error_class_falls_back_to_internal(self):
+        """Last-resort: a driver throws an unrecognised exception class.
+        The classifier must NOT swallow it as auth — it returns
+        ``InternalError`` so the on-call sees "unclassified" and knows
+        to inspect worker logs (where ``exc_info=True`` preserves the
+        full traceback). Pinned by application-sdk#1835 mothership
+        comment-3287630230 (HIGH).
+        """
+        from application_sdk.errors.leaves import InternalError
+
+        app = SqlApp.__new__(SqlApp)
+        app._app_name = "test-app"
+
+        with (
+            patch.object(SqlApp, "_resolve_credential_ref", return_value=None),
+            patch.object(
+                SqlApp,
+                "prime_sql_auth",
+                new=AsyncMock(
+                    return_value=PrimeAuthOutput(
+                        duration_ms=10.0,
+                        success=False,
+                        error_type="WeirdVendorSpecificError",
+                        error_message="something we have never seen before",
+                    ),
+                ),
+            ),
+            patch.object(SqlApp, "extract_databases", new=AsyncMock()),
+            patch.object(SqlApp, "extract_schemas", new=AsyncMock()),
+            patch.object(SqlApp, "extract_tables", new=AsyncMock()),
+            patch.object(SqlApp, "extract_columns", new=AsyncMock()),
+        ):
+            with pytest.raises(InternalError) as exc_info:
+                await app.run(ExtractionInput(output_path="/tmp/test"))
+
+        err = exc_info.value
+        assert "unclassified" in err.message.lower()
+        assert (
+            err.suggested_action and "_classify_prime_failure" in err.suggested_action
+        )

--- a/tests/unit/templates/test_sql_app.py
+++ b/tests/unit/templates/test_sql_app.py
@@ -14,6 +14,7 @@ from application_sdk.templates.contracts.sql_metadata import (
     ExtractionInput,
     ExtractionTaskInput,
     ExtractionTaskOutput,
+    PrimeAuthOutput,
     TransformInput,
     TransformOutput,
 )
@@ -54,6 +55,13 @@ class FakeSQLClient:
         self.last_batch_size = batch_size
         if self._rows:
             yield self._rows
+
+    async def get_results(self, query: str):
+        """Single-query result. Used by ``prime_sql_auth`` (BLDX-1295)
+        to issue a ``SELECT 1`` probe — we don't care about the value,
+        only that the connection + auth completed."""
+        self.last_query = query
+        return self._rows
 
 
 def _mock_init_client(rows: list[dict[str, Any]]) -> AsyncMock:
@@ -1425,6 +1433,15 @@ class TestRunOutputPrefixes:
                 "transform_columns",
                 new=AsyncMock(return_value=MagicMock(total_record_count=10)),
             ),
+            # Mock prime_sql_auth (BLDX-1295) — the real one opens an
+            # actual SQL client. These run() tests are about output
+            # plumbing, not the prime mechanism itself; the prime task
+            # has its own dedicated test class below.
+            patch.object(
+                SqlApp,
+                "prime_sql_auth",
+                new=AsyncMock(return_value=PrimeAuthOutput(duration_ms=5.0)),
+            ),
             patch.object(SqlApp, "_resolve_credential_ref", return_value=None),
         ]
 
@@ -1509,3 +1526,285 @@ class TestRunOutputPrefixes:
 
         # build_output_path must NOT be called from run() — it would crash in workflow context
         mock_bop.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# prime_sql_auth (BLDX-1295) — Argo parity: serial probe before parallel burst
+# ---------------------------------------------------------------------------
+
+
+class TestPrimeSqlAuth:
+    """BLDX-1295 — pre-warm SQL auth cache before parallel extract burst.
+
+    Background:
+        v3's parallel-activity execution model fans out
+        ``extract_databases / extract_schemas / extract_tables /
+        extract_columns`` simultaneously. Each opens its own SQL client
+        and authenticates against the source — concurrently. For sources
+        whose first-auth handshake is expensive or race-prone (MySQL 8's
+        ``caching_sha2_password`` is the canonical example: requires
+        TLS or RSA exchange when the server-side cache is cold), N
+        parallel cold-cache auth attempts can each fail and stack on
+        the per-user ``failed_login_attempts`` counter — tripping
+        ``FAILED_LOGIN_ATTEMPTS`` lockouts on the customer's source.
+
+        The fix is one serial probe activity, ``prime_sql_auth``,
+        invoked by ``run()`` before the ``asyncio.gather(...)`` of
+        extracts. One connection, one ``SELECT 1``, primes the
+        server's auth cache, then parallel extracts take the fast path.
+
+        Argo's serial extract pipeline never exposed this — only v3's
+        parallel model does.
+    """
+
+    @staticmethod
+    def _build_input() -> ExtractionTaskInput:
+        return ExtractionTaskInput(
+            workflow_id="wf-test",
+            output_path="/tmp/test",
+            output_prefix="/tmp",
+            exclude_filter="",
+            include_filter="",
+            temp_table_regex="",
+        )
+
+    # ── Direct task behaviour ────────────────────────────────────────────
+
+    async def test_prime_sql_auth_issues_select_1(self, app):
+        """The probe must execute a single ``SELECT 1`` query — that's the
+        whole point: a no-op query that nonetheless forces the connection
+        + auth handshake, populating the server-side cache."""
+        fake = FakeSQLClient(rows=[{"1": 1}])
+        with patch.object(SqlApp, "_init_sql_client", new=AsyncMock(return_value=fake)):
+            result = await app.prime_sql_auth(self._build_input())
+
+        assert fake.last_query == "SELECT 1"
+        assert isinstance(result, PrimeAuthOutput)
+        assert result.duration_ms >= 0.0  # observability field populated
+
+    async def test_prime_sql_auth_closes_client(self, app):
+        """The probe must close its client. A leaked connection would
+        defeat the priming intent — the cache is primed by *completed*
+        connections, not held-open ones."""
+        fake = FakeSQLClient(rows=[{"1": 1}])
+        close_mock = AsyncMock(wraps=fake.close)
+        fake.close = close_mock  # type: ignore[method-assign]
+
+        with patch.object(SqlApp, "_init_sql_client", new=AsyncMock(return_value=fake)):
+            await app.prime_sql_auth(self._build_input())
+
+        close_mock.assert_awaited_once()
+
+    async def test_prime_sql_auth_closes_client_even_on_failure(self, app):
+        """When the probe query itself raises (network blip, intermittent
+        auth fail), the client must still be closed so the connection
+        doesn't leak — otherwise repeated failures pile up sockets."""
+
+        class _ExplodingClient(FakeSQLClient):
+            async def run_query(self, query, batch_size=100000):
+                raise RuntimeError("boom")  # simulate auth/network failure
+
+            async def get_results(self, query):
+                raise RuntimeError("boom")
+
+        fake = _ExplodingClient()
+        close_mock = AsyncMock(wraps=fake.close)
+        fake.close = close_mock  # type: ignore[method-assign]
+
+        with patch.object(SqlApp, "_init_sql_client", new=AsyncMock(return_value=fake)):
+            with pytest.raises(RuntimeError, match="boom"):
+                await app.prime_sql_auth(self._build_input())
+
+        close_mock.assert_awaited_once()
+
+    # ── Bug-reproduction via call ordering ──────────────────────────────
+
+    async def test_reproduces_parallel_auth_burst_when_prime_skipped(self, app):
+        """BUG REPRO (pre-fix shape): without a serial prime, the four
+        extract activities each independently initialise a SQL client,
+        concurrently. Capture each ``_init_sql_client`` call and assert
+        the calls overlap in time — this is precisely what triggers the
+        cold-cache lockout cycle described in BLDX-1295.
+
+        This test patches out ``prime_sql_auth`` to simulate the
+        pre-fix code path; with ``prime_sql_auth`` skipped, all four
+        extract clients init concurrently. The complementary test
+        below pins the fix.
+        """
+        import asyncio as _asyncio
+
+        active = 0
+        max_active = 0
+        ready = _asyncio.Event()
+
+        async def _slow_client_init(self_, input_):
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            # Hold open briefly so concurrent inits overlap in real time
+            try:
+                await _asyncio.sleep(0.02)
+            finally:
+                active -= 1
+                ready.set()
+            return FakeSQLClient(rows=[{"x": 1}])
+
+        # Simulate the pre-fix path: prime_sql_auth is a no-op, extract
+        # activities each open their own client in parallel.
+        input_ = ExtractionInput(output_path="/tmp/test")
+        with (
+            patch.object(SqlApp, "_resolve_credential_ref", return_value=None),
+            patch.object(
+                SqlApp,
+                "prime_sql_auth",
+                new=AsyncMock(return_value=PrimeAuthOutput(duration_ms=0.0)),
+            ),
+            patch.object(SqlApp, "_init_sql_client", new=_slow_client_init),
+            patch.object(
+                SqlApp,
+                "_extract_entity",
+                new=AsyncMock(
+                    side_effect=lambda **_kw: _asyncio.sleep(0).__await__().send(None)
+                    if False
+                    else _asyncio.create_task(_slow_client_init(None, None))
+                    and ExtractionTaskOutput(
+                        typename="x", total_record_count=1, raw_file=None
+                    ),
+                ),
+            ),
+            patch.object(SqlApp, "transform_databases", new=AsyncMock()),
+            patch.object(SqlApp, "transform_schemas", new=AsyncMock()),
+            patch.object(SqlApp, "transform_tables", new=AsyncMock()),
+            patch.object(SqlApp, "transform_columns", new=AsyncMock()),
+        ):
+            # Drive a minimal run via the extract_* tasks directly so the
+            # gather() in run() reproduces the parallel burst.
+            task_input = SqlApp.build_task_input(ExtractionTaskInput, input_)
+            await _asyncio.gather(
+                _slow_client_init(None, task_input),
+                _slow_client_init(None, task_input),
+                _slow_client_init(None, task_input),
+                _slow_client_init(None, task_input),
+            )
+
+        # Pre-fix shape: 4 concurrent inits overlapped. max_active > 1
+        # is the diagnostic — it's exactly what we want the prime task
+        # to prevent in real-world execution.
+        assert max_active >= 2, (
+            f"Expected concurrent client inits to reproduce the BLDX-1295 "
+            f"cold-auth burst, but only saw max_active={max_active}"
+        )
+
+    async def test_run_invokes_prime_sql_auth_before_extracts(self):
+        """FIX PIN: ``SqlApp.run()`` must call ``prime_sql_auth`` exactly
+        once, before any ``extract_*`` activity fires. Without this
+        ordering, the parallel extract burst hits cold-cache and can
+        trigger the lockout cycle. With it, the cache is primed once
+        and parallel extracts take the fast path."""
+        app = SqlApp.__new__(SqlApp)
+        app._app_name = "test-app"
+
+        call_order: list[str] = []
+
+        def _record_prime(_inp):
+            call_order.append("prime_sql_auth")
+            return PrimeAuthOutput(duration_ms=1.0)
+
+        def _make_extract_recorder(name: str):
+            def _record(_inp):
+                call_order.append(name)
+                return ExtractionTaskOutput(
+                    typename=name.removeprefix("extract_"),
+                    total_record_count=1,
+                    raw_file=None,
+                )
+
+            return _record
+
+        mock_wf_info = MagicMock(workflow_id="wf-1", run_id="run-1")
+
+        with (
+            patch.object(SqlApp, "_resolve_credential_ref", return_value=None),
+            patch(
+                "application_sdk.templates.sql_app._temporal_workflow.info",
+                return_value=mock_wf_info,
+            ),
+            patch.object(
+                SqlApp,
+                "prime_sql_auth",
+                new=AsyncMock(side_effect=_record_prime),
+            ),
+            patch.object(
+                SqlApp,
+                "extract_databases",
+                new=AsyncMock(side_effect=_make_extract_recorder("extract_databases")),
+            ),
+            patch.object(
+                SqlApp,
+                "extract_schemas",
+                new=AsyncMock(side_effect=_make_extract_recorder("extract_schemas")),
+            ),
+            patch.object(
+                SqlApp,
+                "extract_tables",
+                new=AsyncMock(side_effect=_make_extract_recorder("extract_tables")),
+            ),
+            patch.object(
+                SqlApp,
+                "extract_columns",
+                new=AsyncMock(side_effect=_make_extract_recorder("extract_columns")),
+            ),
+            patch.object(SqlApp, "transform_databases", new=AsyncMock()),
+            patch.object(SqlApp, "transform_schemas", new=AsyncMock()),
+            patch.object(SqlApp, "transform_tables", new=AsyncMock()),
+            patch.object(SqlApp, "transform_columns", new=AsyncMock()),
+        ):
+            await app.run(ExtractionInput(output_path="/tmp/test"))
+
+        assert (
+            call_order[0] == "prime_sql_auth"
+        ), f"prime_sql_auth must run first; got order: {call_order}"
+        assert (
+            call_order.count("prime_sql_auth") == 1
+        ), f"prime_sql_auth must run exactly once; got order: {call_order}"
+        for ext in (
+            "extract_databases",
+            "extract_schemas",
+            "extract_tables",
+            "extract_columns",
+        ):
+            assert (
+                call_order.index(ext) > 0
+            ), f"{ext} must run after prime_sql_auth; got order: {call_order}"
+
+    async def test_prime_failure_short_circuits_run(self):
+        """When ``prime_sql_auth`` raises (credential failure, network
+        unreachable), ``run()`` must abort BEFORE the parallel extract
+        burst. Otherwise we'd flood the source with N parallel
+        auth-failure attempts — the exact behaviour the prime is meant
+        to prevent."""
+        app = SqlApp.__new__(SqlApp)
+        app._app_name = "test-app"
+
+        extract_called = AsyncMock(
+            return_value=ExtractionTaskOutput(
+                typename="db", total_record_count=0, raw_file=None
+            )
+        )
+
+        with (
+            patch.object(SqlApp, "_resolve_credential_ref", return_value=None),
+            patch.object(
+                SqlApp,
+                "prime_sql_auth",
+                new=AsyncMock(side_effect=ConnectionError("auth refused")),
+            ),
+            patch.object(SqlApp, "extract_databases", new=extract_called),
+            patch.object(SqlApp, "extract_schemas", new=extract_called),
+            patch.object(SqlApp, "extract_tables", new=extract_called),
+            patch.object(SqlApp, "extract_columns", new=extract_called),
+        ):
+            with pytest.raises(ConnectionError, match="auth refused"):
+                await app.run(ExtractionInput(output_path="/tmp/test"))
+
+        extract_called.assert_not_called()

--- a/tests/unit/templates/test_sql_app.py
+++ b/tests/unit/templates/test_sql_app.py
@@ -1598,7 +1598,14 @@ class TestPrimeSqlAuth:
     async def test_prime_sql_auth_closes_client_even_on_failure(self, app):
         """When the probe query itself raises (network blip, intermittent
         auth fail), the client must still be closed so the connection
-        doesn't leak — otherwise repeated failures pile up sockets."""
+        doesn't leak — otherwise repeated failures pile up sockets.
+
+        Note: post-review (PR #1835), prime_sql_auth catches the probe
+        exception and returns ``PrimeAuthOutput(success=False, ...)``
+        rather than re-raising. We still assert the inner ``client.close()``
+        was awaited so the connection is released cleanly before the
+        structured failure is reported upward.
+        """
 
         class _ExplodingClient(FakeSQLClient):
             async def run_query(self, query, batch_size=100000):
@@ -1612,10 +1619,56 @@ class TestPrimeSqlAuth:
         fake.close = close_mock  # type: ignore[method-assign]
 
         with patch.object(SqlApp, "_init_sql_client", new=AsyncMock(return_value=fake)):
-            with pytest.raises(RuntimeError, match="boom"):
-                await app.prime_sql_auth(self._build_input())
+            result = await app.prime_sql_auth(self._build_input())
 
         close_mock.assert_awaited_once()
+        # Failure is now returned as data, not raised.
+        assert isinstance(result, PrimeAuthOutput)
+        assert result.success is False
+        assert result.error_type == "RuntimeError"
+        assert result.error_message is not None and "boom" in result.error_message
+
+    async def test_prime_sql_auth_returns_failure_when_init_raises(self, app):
+        """If client construction itself raises (e.g. credential resolution
+        failed, host unresolvable), ``prime_sql_auth`` still reports the
+        failure as structured data rather than letting Temporal retry —
+        retrying that on the auth-cache probe path stacks the source's
+        ``failed_login_attempts`` counter and is the exact behaviour the
+        prime exists to avoid. Pinned by the PR #1835 reviewer's request."""
+
+        async def _exploding_init(_self, _input):
+            raise ConnectionError("could not resolve host 'mysql.bad'")
+
+        with patch.object(SqlApp, "_init_sql_client", new=_exploding_init):
+            result = await app.prime_sql_auth(self._build_input())
+
+        assert result.success is False
+        assert result.error_type == "ConnectionError"
+        assert (
+            result.error_message is not None
+            and "could not resolve host" in result.error_message
+        )
+
+    async def test_prime_sql_auth_truncates_long_error_message(self, app):
+        """Driver error strings can be huge (full server response dumps).
+        The contract field caps at 500 chars + ellipsis so the
+        ``PrimeAuthOutput`` envelope stays bounded in activity-event
+        payloads."""
+
+        long_message = "x" * 2000
+
+        class _ExplodingClient(FakeSQLClient):
+            async def get_results(self, query):
+                raise RuntimeError(long_message)
+
+        fake = _ExplodingClient()
+        with patch.object(SqlApp, "_init_sql_client", new=AsyncMock(return_value=fake)):
+            result = await app.prime_sql_auth(self._build_input())
+
+        assert result.success is False
+        assert result.error_message is not None
+        assert len(result.error_message) == 501  # 500 chars + ellipsis
+        assert result.error_message.endswith("…")
 
     # ── Bug-reproduction via call ordering ──────────────────────────────
 
@@ -1778,11 +1831,19 @@ class TestPrimeSqlAuth:
             ), f"{ext} must run after prime_sql_auth; got order: {call_order}"
 
     async def test_prime_failure_short_circuits_run(self):
-        """When ``prime_sql_auth`` raises (credential failure, network
-        unreachable), ``run()`` must abort BEFORE the parallel extract
-        burst. Otherwise we'd flood the source with N parallel
-        auth-failure attempts — the exact behaviour the prime is meant
-        to prevent."""
+        """When ``prime_sql_auth`` reports ``success=False`` (credential
+        failure, network unreachable), ``run()`` must abort BEFORE the
+        parallel extract burst. Otherwise we'd flood the source with N
+        parallel auth-failure attempts — the exact behaviour the prime
+        is meant to prevent.
+
+        Post-review (PR #1835): prime returns structured failure
+        instead of raising. ``run()`` translates it into a typed
+        ``AuthError`` that names the prime step + the underlying
+        driver error + a recommended fix path.
+        """
+        from application_sdk.errors.leaves import AuthError
+
         app = SqlApp.__new__(SqlApp)
         app._app_name = "test-app"
 
@@ -1797,14 +1858,71 @@ class TestPrimeSqlAuth:
             patch.object(
                 SqlApp,
                 "prime_sql_auth",
-                new=AsyncMock(side_effect=ConnectionError("auth refused")),
+                new=AsyncMock(
+                    return_value=PrimeAuthOutput(
+                        duration_ms=12.3,
+                        success=False,
+                        error_type="OperationalError",
+                        error_message="(1045, \"Access denied for user 'foo'@'1.2.3.4'\")",
+                    ),
+                ),
             ),
             patch.object(SqlApp, "extract_databases", new=extract_called),
             patch.object(SqlApp, "extract_schemas", new=extract_called),
             patch.object(SqlApp, "extract_tables", new=extract_called),
             patch.object(SqlApp, "extract_columns", new=extract_called),
         ):
-            with pytest.raises(ConnectionError, match="auth refused"):
+            with pytest.raises(AuthError) as exc_info:
                 await app.run(ExtractionInput(output_path="/tmp/test"))
 
         extract_called.assert_not_called()
+
+        # The raised AuthError must carry actionable context — the prime
+        # step is named, the underlying driver error is surfaced as
+        # failure_reason, and the suggestion mentions FAILED_LOGIN_ATTEMPTS
+        # so an operator knows what to check before retrying.
+        err = exc_info.value
+        assert "auth-cache prime probe failed" in err.message.lower()
+        assert "OperationalError" in err.message
+        assert err.failure_reason and "Access denied" in err.failure_reason
+        assert err.auth_method == "sql_client"
+        assert err.suggested_action and "FAILED_LOGIN_ATTEMPTS" in err.suggested_action
+
+    async def test_prime_failure_yields_auth_error_with_no_temporal_retry(self):
+        """Pin the BLDX-1295 retry-semantics decision: the structured
+        AuthError raised by ``run()`` on prime failure is
+        ``effective_retryable=False``. This is what stops Temporal from
+        auto-retrying the run-level activity and stacking the source's
+        ``failed_login_attempts`` counter on each retry — the original
+        ``@task(retry_max_attempts=3)`` on the prime itself was the
+        bug; this test pins that we don't reintroduce auto-retry on the
+        failure path.
+        """
+        from application_sdk.errors.leaves import AuthError
+
+        app = SqlApp.__new__(SqlApp)
+        app._app_name = "test-app"
+
+        with (
+            patch.object(SqlApp, "_resolve_credential_ref", return_value=None),
+            patch.object(
+                SqlApp,
+                "prime_sql_auth",
+                new=AsyncMock(
+                    return_value=PrimeAuthOutput(
+                        duration_ms=10.0,
+                        success=False,
+                        error_type="OperationalError",
+                        error_message="Access denied",
+                    ),
+                ),
+            ),
+            patch.object(SqlApp, "extract_databases", new=AsyncMock()),
+            patch.object(SqlApp, "extract_schemas", new=AsyncMock()),
+            patch.object(SqlApp, "extract_tables", new=AsyncMock()),
+            patch.object(SqlApp, "extract_columns", new=AsyncMock()),
+        ):
+            with pytest.raises(AuthError) as exc_info:
+                await app.run(ExtractionInput(output_path="/tmp/test"))
+
+        assert exc_info.value.effective_retryable is False


### PR DESCRIPTION
## Summary

Adds a serial `prime_sql_auth` `@task` to `SqlApp` and wires it into `run()` before the parallel `extract_*` fan-out. Argo-parity fix for a v3-only regression that recently surfaced as a customer-tenant lockout cycle on a MySQL 8 source.

Linear: [BLDX-1295](https://linear.app/atlan-epd/issue/BLDX-1295)

## Why

v3's `SqlApp.run()` fans out `extract_databases / extract_schemas / extract_tables / extract_columns` as parallel Temporal activities. Each activity instantiates its own `SQLClient`, opens its own connections, and authenticates — **all roughly simultaneously**.

For sources whose first-auth handshake is cache-cold, that simultaneous-N burst is a problem. MySQL 8's default `caching_sha2_password` plugin is the canonical example: the first auth for a given `(user, password_hash)` requires either TLS or an RSA exchange. Without either (default for `aiomysql` against a stock MySQL), the cold-cache auth fails. When **N parallel** activities all hit cold cache at once, each independently tries full auth, each fails, and those failures stack on the per-user `failed_login_attempts` counter — tripping `FAILED_LOGIN_ATTEMPTS` lockouts.

Argo's extract pipeline ran serially as separate steps — one connection at a time — so the cache had time to prime between connections and the race never appeared. v3's parallel model exposes it.

## What this PR does

- New `prime_sql_auth` `@task` on `SqlApp`. Opens one connection, runs `SELECT 1`, closes. Populates the server's auth cache.
- `SqlApp.run()` awaits it **once, sequentially**, before the `asyncio.gather()` of extract activities.
- Failure of `prime_sql_auth` short-circuits the run. Credential / network issues surface as a clean error instead of flooding the source with N parallel auth failures (which itself can trigger source-side rate-limit / lockout).
- New `PrimeAuthOutput` contract (just `duration_ms` for observability).

The prime is a no-op overhead on sources without this auth-cache concept (Postgres, MSSQL, most Snowflake setups) — ~100ms per run, negligible vs. the multi-minute extract.

## Why at the SDK template level

Every SqlApp-based connector (mysql, mssql, postgres, …) benefits without per-connector code. Lives in `application_sdk/templates/sql_app.py` rather than in any single connector app.

## Test plan

### Unit — `tests/unit/templates/test_sql_app.py::TestPrimeSqlAuth` (6 tests)

- `prime_sql_auth` issues `SELECT 1` and populates `duration_ms`
- Client closes on success AND on failure (no socket leak)
- **Call-order assertion**: `prime_sql_auth` runs first, then extracts
- **Bug-repro**: documents the parallel-burst failure mode this PR prevents (multiple `_init_sql_client` calls overlapping on the wall clock when prime is skipped)
- **Fix pin**: `run()` invokes `prime_sql_auth` exactly once before any extract
- **Short-circuit on failure**: a failing prime raises before extracts fire — no parallel-auth-flood

### Integration — `tests/integration/test_sql_app_prime_auth.py` (2 tests)

Drive `app.run()` end-to-end with a timing-instrumented SQL client that records wall-clock windows for each connection:

- Every extract connection starts **after** the prime connection ends — the BLDX-1295 invariant
- Extract connections still **overlap** on the wall clock post-prime — proves we only serialize the *first* connection, not the whole flow (i.e., we don't regress v3's parallel-extract throughput)

### Regression

- 310 tests pass across `tests/unit/templates/`, `tests/integration/test_sql_app_prime_auth.py`, `tests/integration/test_sql_app_file_reference.py`.
- Pre-commit green (ruff / ruff-format / pyright / isort).
- Capability manifest regenerated for the new `PrimeAuthOutput` contract.

## Out of scope (separate tickets if needed)

- TLS-by-default for SQL connectors (credential schema + UI + per-driver SSL context — bigger change).
- Per-connector connection-pool sizing (`pool_size` / `max_overflow` tuning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)