### PR TITLE
fix(contract-toolkit): default splitDeployment and keda.enabled to true

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -97,6 +97,8 @@ jobs:
   # Testing
   unit:
     name: Unit Tests
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
@@ -373,7 +375,7 @@ jobs:
     # No label gate — runs on every push to a non-fork, non-dependabot
     # PR. ~3 min per connector and validates the SDR contract end-to-
     # end, which is worth the spend on every SDK PR.
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true && github.event.pull_request.user.login != 'dependabot[bot]' && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -249,7 +249,8 @@ The typed `deploy` block replaces the legacy free-form mapping. The common 80% i
 ```pkl
 deploy {
   keda {
-    enabled = true
+    // enabled = true and minReplicaCount = 0 (scale-to-zero) by default.
+    // Set minReplicaCount = 1 to keep at least one replica running at all times.
     minReplicaCount = 1
     temporal { targetQueueSize = 10 }  // Note: must be set here, NOT on keda.targetQueueSize
   }

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -218,7 +218,7 @@ The typed `deploy` block replaces the legacy free-form mapping.
 | Property | Type | Default | Description |
 |---|---|---|---|
 | `deploy.executionMode` | String | `"native"` | Execution mode. |
-| `deploy.splitDeployment` | Boolean | `false` | Emitted as `splitDeploymentEnabled`. |
+| `deploy.splitDeployment` | Boolean | `true` | Emitted as `splitDeploymentEnabled`. |
 | `deploy.replicaCount` | Int? | null | Honoured only when `keda.enabled = false`. |
 | `deploy.dapr` | DaprComponents | `new DaprComponents {}` | Dapr sidecar toggles. |
 | `deploy.keda` | KedaConfig | `new KedaConfig {}` | KEDA autoscaling config. |
@@ -244,8 +244,8 @@ class DaprComponents {
 
 ```pkl
 class KedaConfig {
-  enabled: Boolean = false
-  minReplicaCount: Int = 1
+  enabled: Boolean = true
+  minReplicaCount: Int = 0
   temporal: KedaTemporalConfig = new { targetQueueSize = 5 }
 }
 class KedaTemporalConfig { targetQueueSize: Int }

--- a/contract-toolkit/examples/bundle/atlan.yaml
+++ b/contract-toolkit/examples/bundle/atlan.yaml
@@ -34,6 +34,6 @@ deploy:
     lock: false
   keda:
     enabled: true
-    minReplicaCount: 1
+    minReplicaCount: 0
     temporal:
       targetQueueSize: 5

--- a/contract-toolkit/examples/bundle/atlan.yaml
+++ b/contract-toolkit/examples/bundle/atlan.yaml
@@ -23,7 +23,7 @@ entrypoints:
   source_category: database
 deploy:
   execution_mode: native
-  splitDeploymentEnabled: false
+  splitDeploymentEnabled: true
   dapr:
     objectstore: false
     secretstore: false
@@ -33,4 +33,7 @@ deploy:
     configurationstore: false
     lock: false
   keda:
-    enabled: false
+    enabled: true
+    minReplicaCount: 1
+    temporal:
+      targetQueueSize: 5

--- a/contract-toolkit/examples/connection-ref/atlan.yaml
+++ b/contract-toolkit/examples/connection-ref/atlan.yaml
@@ -26,6 +26,6 @@ deploy:
     lock: false
   keda:
     enabled: true
-    minReplicaCount: 1
+    minReplicaCount: 0
     temporal:
       targetQueueSize: 5

--- a/contract-toolkit/examples/connection-ref/atlan.yaml
+++ b/contract-toolkit/examples/connection-ref/atlan.yaml
@@ -15,7 +15,7 @@ entrypoints:
   type: connector
 deploy:
   execution_mode: native
-  splitDeploymentEnabled: false
+  splitDeploymentEnabled: true
   dapr:
     objectstore: false
     secretstore: false
@@ -25,4 +25,7 @@ deploy:
     configurationstore: false
     lock: false
   keda:
-    enabled: false
+    enabled: true
+    minReplicaCount: 1
+    temporal:
+      targetQueueSize: 5

--- a/contract-toolkit/examples/deploy/atlan.yaml
+++ b/contract-toolkit/examples/deploy/atlan.yaml
@@ -15,7 +15,7 @@ entrypoints:
   type: connector
 deploy:
   execution_mode: native
-  splitDeploymentEnabled: false
+  splitDeploymentEnabled: true
   dapr:
     objectstore: true
     secretstore: true

--- a/contract-toolkit/examples/fanin/atlan.yaml
+++ b/contract-toolkit/examples/fanin/atlan.yaml
@@ -26,6 +26,6 @@ deploy:
     lock: false
   keda:
     enabled: true
-    minReplicaCount: 1
+    minReplicaCount: 0
     temporal:
       targetQueueSize: 5

--- a/contract-toolkit/examples/fanin/atlan.yaml
+++ b/contract-toolkit/examples/fanin/atlan.yaml
@@ -15,7 +15,7 @@ entrypoints:
   type: connector
 deploy:
   execution_mode: native
-  splitDeploymentEnabled: false
+  splitDeploymentEnabled: true
   dapr:
     objectstore: false
     secretstore: false
@@ -25,4 +25,7 @@ deploy:
     configurationstore: false
     lock: false
   keda:
-    enabled: false
+    enabled: true
+    minReplicaCount: 1
+    temporal:
+      targetQueueSize: 5

--- a/contract-toolkit/examples/full/atlan.yaml
+++ b/contract-toolkit/examples/full/atlan.yaml
@@ -26,6 +26,6 @@ deploy:
     lock: false
   keda:
     enabled: true
-    minReplicaCount: 1
+    minReplicaCount: 0
     temporal:
       targetQueueSize: 5

--- a/contract-toolkit/examples/full/atlan.yaml
+++ b/contract-toolkit/examples/full/atlan.yaml
@@ -15,7 +15,7 @@ entrypoints:
   type: connector
 deploy:
   execution_mode: native
-  splitDeploymentEnabled: false
+  splitDeploymentEnabled: true
   dapr:
     objectstore: false
     secretstore: false
@@ -25,4 +25,7 @@ deploy:
     configurationstore: false
     lock: false
   keda:
-    enabled: false
+    enabled: true
+    minReplicaCount: 1
+    temporal:
+      targetQueueSize: 5

--- a/contract-toolkit/examples/minimal/atlan.yaml
+++ b/contract-toolkit/examples/minimal/atlan.yaml
@@ -26,6 +26,6 @@ deploy:
     lock: false
   keda:
     enabled: true
-    minReplicaCount: 1
+    minReplicaCount: 0
     temporal:
       targetQueueSize: 5

--- a/contract-toolkit/examples/minimal/atlan.yaml
+++ b/contract-toolkit/examples/minimal/atlan.yaml
@@ -15,7 +15,7 @@ entrypoints:
   type: connector
 deploy:
   execution_mode: native
-  splitDeploymentEnabled: false
+  splitDeploymentEnabled: true
   dapr:
     objectstore: false
     secretstore: false
@@ -25,4 +25,7 @@ deploy:
     configurationstore: false
     lock: false
   keda:
-    enabled: false
+    enabled: true
+    minReplicaCount: 1
+    temporal:
+      targetQueueSize: 5

--- a/contract-toolkit/examples/publish-controls/atlan.yaml
+++ b/contract-toolkit/examples/publish-controls/atlan.yaml
@@ -26,6 +26,6 @@ deploy:
     lock: false
   keda:
     enabled: true
-    minReplicaCount: 1
+    minReplicaCount: 0
     temporal:
       targetQueueSize: 5

--- a/contract-toolkit/examples/publish-controls/atlan.yaml
+++ b/contract-toolkit/examples/publish-controls/atlan.yaml
@@ -15,7 +15,7 @@ entrypoints:
   type: connector
 deploy:
   execution_mode: native
-  splitDeploymentEnabled: false
+  splitDeploymentEnabled: true
   dapr:
     objectstore: false
     secretstore: false
@@ -25,4 +25,7 @@ deploy:
     configurationstore: false
     lock: false
   keda:
-    enabled: false
+    enabled: true
+    minReplicaCount: 1
+    temporal:
+      targetQueueSize: 5

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -1132,7 +1132,7 @@ class KedaTemporalConfig {
 
 class KedaConfig {
   enabled: Boolean = true
-  minReplicaCount: Int = 1
+  minReplicaCount: Int = 0
   temporal: KedaTemporalConfig = new KedaTemporalConfig {}
 }
 

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -1131,7 +1131,7 @@ class KedaTemporalConfig {
 }
 
 class KedaConfig {
-  enabled: Boolean = false
+  enabled: Boolean = true
   minReplicaCount: Int = 1
   temporal: KedaTemporalConfig = new KedaTemporalConfig {}
 }
@@ -1144,7 +1144,7 @@ class ResourceConfig {
 /// Typed deployment configuration rendered into `atlan.yaml`'s `deploy:` block.
 class DeployConfig {
   executionMode: String = "native"
-  splitDeployment: Boolean = false
+  splitDeployment: Boolean = true
   /// Ignored when keda.enabled = true (KEDA manages replica count).
   replicaCount: Int? = null
   dapr: DaprComponents = new DaprComponents {}


### PR DESCRIPTION
## Summary

- `DeployConfig.splitDeployment` default changed from `false` → `true`
- `KedaConfig.enabled` default changed from `false` → `true`
- `KedaConfig.minReplicaCount` default changed from `1` → `0` (scale-to-zero)
- All example `atlan.yaml` outputs regenerated to reflect the new defaults

Apps that need the previous behaviour must explicitly opt out in their `deploy` block:

```pkl
deploy {
  splitDeployment = false
  keda {
    enabled = false
    minReplicaCount = 1
  }
}
```

## Test plan

- [x] `./scripts/regenerate-all.sh` — all examples regenerate cleanly
- [x] `./scripts/check-invariants.sh` — invariants pass
- [x] `pkl test tests/*.pkl` — all tests pass
- [x] Verify `minimal/atlan.yaml` emits `splitDeploymentEnabled: true`, `keda.enabled: true`, and `keda.minReplicaCount: 0`