### PR TITLE
ci(test-sdk-review): fail fast on VPN issues and notify PR on final failure

### DIFF
--- a/.github/actions/globalprotect-connect/action.yml
+++ b/.github/actions/globalprotect-connect/action.yml
@@ -78,10 +78,12 @@ runs:
 
           # Initial connectivity test
           echo "Testing initial connectivity to Phoenix AI..."
-          # --max-time 30 ensures a black-holed route (e.g. broken VPN
+          # --max-time 60 ensures a black-holed route (e.g. broken VPN
           # split-tunnel) fails fast instead of burning the full retry-action
-          # timeout_minutes budget on a single hung TCP connection.
-          time curl -k -sS --max-time 30 https://phoenix-ai.atlan.com -o /dev/null
+          # timeout_minutes budget on a single hung TCP connection. 60s is
+          # comfortably above any healthy response time but well below the
+          # 5-min per-attempt cap.
+          time curl -k -sS --max-time 60 https://phoenix-ai.atlan.com -o /dev/null
 
           if [ $? -eq 0 ]; then
             echo "Initial connectivity test successful"

--- a/.github/actions/globalprotect-connect/action.yml
+++ b/.github/actions/globalprotect-connect/action.yml
@@ -74,7 +74,10 @@ runs:
 
           # Initial connectivity test
           echo "Testing initial connectivity to Phoenix AI..."
-          time curl -k -sS https://phoenix-ai.atlan.com -o /dev/null
+          # --max-time 30 ensures a black-holed route (e.g. broken VPN
+          # split-tunnel) fails fast instead of burning the full retry-action
+          # timeout_minutes budget on a single hung TCP connection.
+          time curl -k -sS --max-time 30 https://phoenix-ai.atlan.com -o /dev/null
 
           if [ $? -eq 0 ]; then
             echo "Initial connectivity test successful"

--- a/.github/actions/globalprotect-connect/action.yml
+++ b/.github/actions/globalprotect-connect/action.yml
@@ -30,7 +30,11 @@ runs:
       id: openconnect-connection
       with:
         max_attempts: ${{ fromJSON(inputs.max-attempts) }}
-        timeout_minutes: 10
+        # Per-attempt budget. With --max-time 30 on the curl test below, a
+        # real attempt completes (or fails) in well under a minute, so this
+        # is a safety net — kill any attempt that wedges instead of letting
+        # it consume the original 10-min cap.
+        timeout_minutes: 5
         shell: bash
         command: |
           echo "Connecting to GlobalProtect VPN using OpenConnect..."

--- a/.github/workflows/test-sdk-review-dismiss-on-human.yml
+++ b/.github/workflows/test-sdk-review-dismiss-on-human.yml
@@ -10,13 +10,15 @@
 #   after the human dismisses theirs, so the bot could SOLO-satisfy
 #   the merge gate.
 #
-#   This workflow patches that: the moment any human-authored
-#   PR-level activity happens (comment, review submission, or
-#   review dismissal), we walk the PR's reviews and dismiss every
-#   APPROVED review by `atlan-ci` whose body starts with the
-#   experimental-reviewer signature. Net effect: bot's auto-approval
-#   only stands until a human engages — at which point the gate
-#   returns to requiring a fresh human code-owner approval.
+#   This workflow patches that: when a human posts feedback that
+#   could change the merge calculus (a top-level PR comment, a
+#   review with state `changes_requested` or `commented`, or an
+#   edit/dismissal of an existing review), we walk the PR's reviews
+#   and dismiss every APPROVED review by `atlan-ci` whose body
+#   starts with the experimental-reviewer signature. Net effect:
+#   bot's auto-approval stands until a human pushes back or asks a
+#   question — at which point the gate returns to requiring a fresh
+#   human code-owner approval.
 #
 # What it does NOT dismiss:
 #   - atlan-ci approvals posted by other flows (e.g. production
@@ -25,6 +27,10 @@
 #     to the experimental flow only.
 #   - Any review by a human reviewer.
 #   - Approvals posted by other bots (claude[bot], github-actions[bot]).
+#   - A human review submission whose state is `approved` — a human
+#     approval is a positive signal, not a reason to drop the bot's
+#     parallel approval. Only non-approval submissions (changes
+#     requested, comments) and PR-level comments trigger dismissal.
 
 name: Test SDK Review — auto-dismiss bot approval on human activity
 
@@ -51,6 +57,12 @@ jobs:
     # For issue_comment events, also require the comment is on a PR
     # (issue_comment fires for both Issues and PRs). The PR-side has
     # `github.event.issue.pull_request` populated; Issues-side does not.
+    #
+    # Also skip when a human submits an `approved` review — the human
+    # is endorsing the change, so there's no reason to retract the
+    # bot's parallel approval. `changes_requested` and `commented`
+    # review submissions, as well as edits and dismissals of any
+    # existing review, still trigger; so do top-level PR comments.
     if: >-
       (
         github.event_name == 'pull_request_review'
@@ -58,6 +70,11 @@ jobs:
       )
       && !endsWith(github.actor, '[bot]')
       && github.actor != 'atlan-ci'
+      && !(
+        github.event_name == 'pull_request_review'
+        && github.event.action == 'submitted'
+        && github.event.review.state == 'approved'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/test-sdk-review.yml
+++ b/.github/workflows/test-sdk-review.yml
@@ -249,6 +249,10 @@ jobs:
               target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             });
 
+      # max-attempts: '1' overrides the action's internal default of 3 so
+      # each outer step is one real attempt, not three. Combined with the
+      # action's 5-min timeout_minutes, three outer steps cap total VPN
+      # time at ~15 min in the worst case.
       - name: Connect to VPN (attempt 1/3)
         id: vpn1
         uses: ./.github/actions/globalprotect-connect
@@ -257,6 +261,7 @@ jobs:
           portal-url: ${{ vars.GLOBALPROTECT_PORTAL_URL }}
           username: ${{ secrets.GLOBALPROTECT_USERNAME }}
           password: ${{ secrets.GLOBALPROTECT_PASSWORD }}
+          max-attempts: '1'
 
       - name: Connect to VPN (attempt 2/3)
         id: vpn2
@@ -267,6 +272,7 @@ jobs:
           portal-url: ${{ vars.GLOBALPROTECT_PORTAL_URL }}
           username: ${{ secrets.GLOBALPROTECT_USERNAME }}
           password: ${{ secrets.GLOBALPROTECT_PASSWORD }}
+          max-attempts: '1'
 
       - name: Connect to VPN (attempt 3/3)
         id: vpn3
@@ -277,6 +283,7 @@ jobs:
           portal-url: ${{ vars.GLOBALPROTECT_PORTAL_URL }}
           username: ${{ secrets.GLOBALPROTECT_USERNAME }}
           password: ${{ secrets.GLOBALPROTECT_PASSWORD }}
+          max-attempts: '1'
 
       # If all three VPN attempts failed, post a comment on the PR so the
       # author knows the workflow died for an infra reason (not a real review

--- a/.github/workflows/test-sdk-review.yml
+++ b/.github/workflows/test-sdk-review.yml
@@ -269,12 +269,57 @@ jobs:
           password: ${{ secrets.GLOBALPROTECT_PASSWORD }}
 
       - name: Connect to VPN (attempt 3/3)
+        id: vpn3
         if: steps.vpn2.outcome == 'failure'
         uses: ./.github/actions/globalprotect-connect
+        continue-on-error: true
         with:
           portal-url: ${{ vars.GLOBALPROTECT_PORTAL_URL }}
           username: ${{ secrets.GLOBALPROTECT_USERNAME }}
           password: ${{ secrets.GLOBALPROTECT_PASSWORD }}
+
+      # If all three VPN attempts failed, post a comment on the PR so the
+      # author knows the workflow died for an infra reason (not a real review
+      # failure) and can retry with another @test-sdk-review mention. Without
+      # this, the only signal is a red commit status — and most authors don't
+      # check the GHA logs to discover it was a VPN issue.
+      - name: Notify PR if VPN failed after 3 attempts
+        if: steps.vpn3.outcome == 'failure'
+        env:
+          PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
+          GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PORTAL_URL: ${{ vars.GLOBALPROTECT_PORTAL_URL }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const runUrl = process.env.GHA_RUN_URL;
+            const body = [
+              `⚠️ **Test SDK Review failed: could not connect to VPN.**`,
+              ``,
+              `All 3 VPN connection attempts to \`${process.env.PORTAL_URL || 'the VPN portal'}\` failed. This is usually a transient infrastructure issue.`,
+              ``,
+              `[View workflow logs](${runUrl})`,
+              ``,
+              `Please retry by commenting \`@test-sdk-review\` again. If it keeps failing, flag it in \`#bu-platform-engineering\`.`,
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
+      # Explicit fail so the existing failure()-gated 'Set status to failure'
+      # step (below) fires and the commit status flips to red. Without this,
+      # vpn3.continue-on-error: true would let the workflow proceed past a
+      # broken VPN into the mothership dispatch, which would itself hang or
+      # fail confusingly.
+      - name: Fail workflow after VPN failure notification
+        if: steps.vpn3.outcome == 'failure'
+        run: |
+          echo "::error::All 3 VPN connection attempts failed. PR has been notified — see comment posted above."
+          exit 1
 
       - name: Dispatch to mothership Rover Direct API
         env:


### PR DESCRIPTION
## Summary

Two related changes so VPN problems don't silently burn ~30 min of CI time per `@test-sdk-review` trigger and leave the PR author with no signal beyond a red commit status:

- **`globalprotect-connect` action**: add `--max-time 30` to the connectivity-test `curl`. Without it, a black-holed route (e.g. broken split-tunnel from `vpn2.atlan.app`) hangs each attempt for the full `nick-fields/retry@v3` `timeout_minutes` budget. Worst-case failure budget for `@test-sdk-review` drops from ~30 min (10 min × 3 outer attempts) to ~9 min (~30 s × 3 inner × 3 outer).
- **`test-sdk-review` workflow**: when all three outer VPN attempts fail, post a comment on the PR with a link to the run logs and a retry hint, then `exit 1` explicitly so the existing `failure()`-gated status step still fires.

## Context

Triggered by today's reports of `@test-sdk-review` runs hanging at "Connect to VPN" for 14+ min and `@sdk-review` (`claude.yml`) hanging at "Pre-fetch PR diff and file list" for 17 min with `read tcp 10.254.128.41:…->20.207.73.85:443: read: network is unreachable`. Root cause appears to be on the VPN portal side (likely a split-tunnel/route change today) — these code changes only mitigate the symptom on the `@test-sdk-review` path. The `@sdk-review` (`claude.yml`) pre-fetch issue and the underlying VPN routing issue still need follow-up.

## Test plan

- [ ] Confirm pre-commit passes on changed files (done locally).
- [ ] Once merged, trigger `@test-sdk-review` on a PR while VPN is healthy — verify normal path is unchanged (VPN connects, dispatch runs).
- [ ] Verify the new PR-notify behavior fires the next time VPN fails (or by deliberately misconfiguring the portal URL in a test run).