### PR TITLE
fix(ci): replace git-cliff --bumped-version with native git log in release workflow

### DIFF
--- a/.github/workflows/contract-toolkit-release.yml
+++ b/.github/workflows/contract-toolkit-release.yml
@@ -64,29 +64,46 @@ jobs:
           set -euo pipefail
           current="$(grep -oP 'version\s*=\s*"\K[^"]+' contract-toolkit/src/PklProject)"
 
-          # Find commit subjects since the last contract-toolkit-v* tag that
-          # touched contract-toolkit/** paths. We use plain git log rather than
-          # git-cliff --bumped-version because the latter has been silently
-          # returning empty output with --include-path across git-cliff 2.x
-          # releases, causing every release PR to be skipped.
-          unreleased="$(git log \
+          # Verify the expected tag exists before using it as a revision anchor.
+          # A missing tag (e.g. failed publish, or very first release) would
+          # cause git log to exit non-zero and fail the workflow under set -e.
+          if ! git rev-parse --verify "contract-toolkit-v${current}" >/dev/null 2>&1; then
+            echo "::error::Tag contract-toolkit-v${current} not found. Publish the current version first, or create the tag manually."
+            exit 1
+          fi
+
+          # Find commit messages (full body) since the last contract-toolkit-v*
+          # tag that touched contract-toolkit/** paths. We use plain git log
+          # rather than git-cliff --bumped-version because the latter silently
+          # returns empty output with --include-path across git-cliff 2.x,
+          # causing every release PR to be skipped.
+          #
+          # Full message (%B) is used so BREAKING CHANGE trailers in commit
+          # bodies are detected; subject-only (%s) would miss them.
+          unreleased_body="$(git log \
+            "contract-toolkit-v${current}..HEAD" \
+            --format='%B' \
+            -- 'contract-toolkit/**')"
+
+          unreleased_subjects="$(git log \
             "contract-toolkit-v${current}..HEAD" \
             --format='%s' \
             -- 'contract-toolkit/**')"
 
-          if [ -z "$unreleased" ]; then
+          if [ -z "$unreleased_subjects" ]; then
             echo "No unreleased contract-toolkit commits (current: ${current})."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           # Conventional-commits bump rules:
-          #   BREAKING CHANGE trailer or ! suffix → major
+          #   BREAKING CHANGE trailer (body) or ! suffix (subject) → major
           #   feat → minor
           #   anything else → patch
-          if echo "$unreleased" | grep -qP 'BREAKING[ _-]CHANGE|^[a-z]+(\([^)]+\))?!:'; then
+          if echo "$unreleased_subjects" | grep -qP '^[a-z]+(\([^)]+\))?!:' || \
+             echo "$unreleased_body"     | grep -qP '^BREAKING[ _-]CHANGE:'; then
             bump="major"
-          elif echo "$unreleased" | grep -qP '^feat'; then
+          elif echo "$unreleased_subjects" | grep -qP '^feat'; then
             bump="minor"
           else
             bump="patch"

--- a/.github/workflows/contract-toolkit-release.yml
+++ b/.github/workflows/contract-toolkit-release.yml
@@ -60,39 +60,50 @@ jobs:
 
       - name: Compute next version
         id: versions
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           current="$(grep -oP 'version\s*=\s*"\K[^"]+' contract-toolkit/src/PklProject)"
 
-          # Only commits touching contract-toolkit/** paths (since the last
-          # contract-toolkit-v* tag) determine the semver bump type.
-          next_tag="$(git cliff \
-            --config contract-toolkit/cliff.toml \
-            --bumped-version \
-            --tag-pattern '^contract-toolkit-v[0-9].*' \
-            --include-path 'contract-toolkit/**' \
-            2>/dev/null || true)"
+          # Find commit subjects since the last contract-toolkit-v* tag that
+          # touched contract-toolkit/** paths. We use plain git log rather than
+          # git-cliff --bumped-version because the latter has been silently
+          # returning empty output with --include-path across git-cliff 2.x
+          # releases, causing every release PR to be skipped.
+          unreleased="$(git log \
+            "contract-toolkit-v${current}..HEAD" \
+            --format='%s' \
+            -- 'contract-toolkit/**')"
 
-          # Strip tag prefix — handles contract-toolkit-vX.Y.Z and bare vX.Y.Z
-          new_version="${next_tag#contract-toolkit-v}"
-          new_version="${new_version#v}"
-
-          # Skip when there is nothing to release or the computed version is not
-          # an advancement over what is already in PklProject.
-          higher="$(printf '%s\n%s\n' "$current" "$new_version" | sort -V | tail -1)"
-          if [ -z "$new_version" ] || [ "$higher" != "$new_version" ] || [ "$current" = "$new_version" ]; then
-            echo "No unreleased contract-toolkit changes require a version bump (current: ${current}, computed: ${new_version:-none})."
+          if [ -z "$unreleased" ]; then
+            echo "No unreleased contract-toolkit commits (current: ${current})."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          # Conventional-commits bump rules:
+          #   BREAKING CHANGE trailer or ! suffix → major
+          #   feat → minor
+          #   anything else → patch
+          if echo "$unreleased" | grep -qP 'BREAKING[ _-]CHANGE|^[a-z]+(\([^)]+\))?!:'; then
+            bump="major"
+          elif echo "$unreleased" | grep -qP '^feat'; then
+            bump="minor"
+          else
+            bump="patch"
+          fi
+
+          IFS='.' read -r ver_major ver_minor ver_patch <<< "$current"
+          case "$bump" in
+            major) new_version="$((ver_major + 1)).0.0" ;;
+            minor) new_version="${ver_major}.$((ver_minor + 1)).0" ;;
+            patch) new_version="${ver_major}.${ver_minor}.$((ver_patch + 1))" ;;
+          esac
 
           echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "old=${current}" >> "$GITHUB_OUTPUT"
           echo "new=${new_version}" >> "$GITHUB_OUTPUT"
           echo "tag=contract-toolkit-v${new_version}" >> "$GITHUB_OUTPUT"
-          echo "Version: ${current} -> ${new_version}"
+          echo "Version: ${current} -> ${new_version} (${bump} bump)"
 
       - name: Apply version bump to PklProject
         if: steps.versions.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

`git-cliff --bumped-version --include-path` has been silently returning empty output on **every single run** of the release workflow across multiple git-cliff 2.x releases. The `2>/dev/null || true` in the previous implementation masked the failure completely, causing every toolkit release PR to be skipped without any visible error.

Root cause identified by checking CI logs: all runs of `contract-toolkit-release.yml` showed `computed: none` regardless of what commits were present, including the earlier "successful" run for the `feat(contract-toolkit)` commit.

## Fix

Replaced `git cliff --bumped-version` with native `git log + bash` semver computation:
- `git log contract-toolkit-v{current}..HEAD --format='%s' -- 'contract-toolkit/**'` to find unreleased commits touching toolkit files
- Conventional commits bump rules (breaking → major, feat → minor, anything else → patch) applied via `grep -P` on subject lines

`git-cliff` is kept for CHANGELOG and release-notes generation (the `--unreleased` calls), where it works correctly. Only the version-computation step is replaced.

## Test plan

- [ ] Merge this PR → release workflow fires → should compute `0.10.1` and open the bump-version PR