### PR TITLE
chore(security): allowlist golang.org/x/crypto/ssh SSH CVEs (Dapr base)

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -556,5 +556,27 @@
     "compensating_controls": null,
     "re_evaluation_trigger": "expiry",
     "exposure_assessment": null
+  },
+  "SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16795342": {
+    "package": "golang.org/x/crypto/ssh",
+    "severity": "HIGH",
+    "reason": "Base image — Go dependency in Dapr runtime. Fix available in golang.org/x/crypto 0.52.0; awaiting upstream Dapr bump and subsequent Wolfi base image rebuild.",
+    "expires": "2026-06-21",
+    "added_by": "vaibhavatlan",
+    "fix_available_date": null,
+    "compensating_controls": null,
+    "re_evaluation_trigger": "expiry",
+    "exposure_assessment": null
+  },
+  "SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16795344": {
+    "package": "golang.org/x/crypto/ssh",
+    "severity": "HIGH",
+    "reason": "Base image — Go dependency in Dapr runtime. Fix available in golang.org/x/crypto 0.52.0; awaiting upstream Dapr bump and subsequent Wolfi base image rebuild.",
+    "expires": "2026-06-21",
+    "added_by": "vaibhavatlan",
+    "fix_available_date": null,
+    "compensating_controls": null,
+    "re_evaluation_trigger": "expiry",
+    "exposure_assessment": null
   }
 }


### PR DESCRIPTION
Add SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16795342 and -16795344 (HIGH) to .security/base-allowlist.json. Both report against golang.org/x/crypto/ssh@v0.50.0 pulled in transitively via Dapr in the SDK base image. Fix is in golang.org/x/crypto 0.52.0; awaiting upstream Dapr bump and a Wolfi base image rebuild.

Expiry set to 2026-06-21 (30-day HIGH window from 2026-05-22). Surfaced by Trivy/Snyk gate on atlanhq/atlan-databricks-app#119.

### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- _to be added_

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.