### PR TITLE
chore(security): allowlist additional golang.org/x/crypto/ssh SSH CVEs (Dapr base)

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -578,5 +578,27 @@
     "compensating_controls": null,
     "re_evaluation_trigger": "expiry",
     "exposure_assessment": null
+  },
+  "SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796326": {
+    "package": "golang.org/x/crypto/ssh",
+    "severity": "HIGH",
+    "reason": "Base image — Go dependency in Dapr runtime. Fix available in golang.org/x/crypto 0.52.0; awaiting upstream Dapr bump and subsequent Wolfi base image rebuild.",
+    "expires": "2026-06-21",
+    "added_by": "vaibhavatlan",
+    "fix_available_date": null,
+    "compensating_controls": null,
+    "re_evaluation_trigger": "expiry",
+    "exposure_assessment": null
+  },
+  "SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796332": {
+    "package": "golang.org/x/crypto/ssh",
+    "severity": "HIGH",
+    "reason": "Base image — Go dependency in Dapr runtime. Fix available in golang.org/x/crypto 0.52.0; awaiting upstream Dapr bump and subsequent Wolfi base image rebuild.",
+    "expires": "2026-06-21",
+    "added_by": "vaibhavatlan",
+    "fix_available_date": null,
+    "compensating_controls": null,
+    "re_evaluation_trigger": "expiry",
+    "exposure_assessment": null
   }
 }


### PR DESCRIPTION
## Summary

- Adds `SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796326` and `SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796332` (HIGH) to `.security/base-allowlist.json`.
- Both report against `golang.org/x/crypto/ssh@v0.50.0` pulled in transitively via Dapr in the SDK base image. Fix is in `golang.org/x/crypto 0.52.0`, awaiting upstream Dapr bump and a Wolfi base image rebuild.
- Follow-up to #1841, which allowlisted `-16795342` and `-16795344` against the same package. Snyk has published two additional advisory IDs that the gate is now flagging as `New: 2`.

## Why two more IDs?

Same package, same fix version — but Snyk publishes one record per CVE. The original allowlist entries match the older IDs, while these two newer IDs are unrecognized by the gate. Surfaced by the Trivy/Snyk gate on a downstream consumer build.

## Expiry

`2026-06-21` (30-day HIGH window from 2026-05-22), matching the prior entries so all four expire together.

## Test plan

- [ ] CI: `validate_allowlist.py` passes (expiry + schema)
- [ ] Trivy/Snyk gate on downstream consumer reports `New: 0` for these two IDs after SDK base image republishes