### PR TITLE
ci(fix): install git-cliff to PATH via curl so release workflow can use it

### DIFF
--- a/.github/workflows/contract-toolkit-release.yml
+++ b/.github/workflows/contract-toolkit-release.yml
@@ -64,29 +64,46 @@ jobs:
           set -euo pipefail
           current="$(grep -oP 'version\s*=\s*"\K[^"]+' contract-toolkit/src/PklProject)"
 
-          # Find commit subjects since the last contract-toolkit-v* tag that
-          # touched contract-toolkit/** paths. We use plain git log rather than
-          # git-cliff --bumped-version because the latter has been silently
-          # returning empty output with --include-path across git-cliff 2.x
-          # releases, causing every release PR to be skipped.
-          unreleased="$(git log \
+          # Verify the expected tag exists before using it as a revision anchor.
+          # A missing tag (e.g. failed publish, or very first release) would
+          # cause git log to exit non-zero and fail the workflow under set -e.
+          if ! git rev-parse --verify "contract-toolkit-v${current}" >/dev/null 2>&1; then
+            echo "::error::Tag contract-toolkit-v${current} not found. Publish the current version first, or create the tag manually."
+            exit 1
+          fi
+
+          # Find commit messages (full body) since the last contract-toolkit-v*
+          # tag that touched contract-toolkit/** paths. We use plain git log
+          # rather than git-cliff --bumped-version because the latter silently
+          # returns empty output with --include-path across git-cliff 2.x,
+          # causing every release PR to be skipped.
+          #
+          # Full message (%B) is used so BREAKING CHANGE trailers in commit
+          # bodies are detected; subject-only (%s) would miss them.
+          unreleased_body="$(git log \
+            "contract-toolkit-v${current}..HEAD" \
+            --format='%B' \
+            -- 'contract-toolkit/**')"
+
+          unreleased_subjects="$(git log \
             "contract-toolkit-v${current}..HEAD" \
             --format='%s' \
             -- 'contract-toolkit/**')"
 
-          if [ -z "$unreleased" ]; then
+          if [ -z "$unreleased_subjects" ]; then
             echo "No unreleased contract-toolkit commits (current: ${current})."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           # Conventional-commits bump rules:
-          #   BREAKING CHANGE trailer or ! suffix → major
+          #   BREAKING CHANGE trailer (body) or ! suffix (subject) → major
           #   feat → minor
           #   anything else → patch
-          if echo "$unreleased" | grep -qP 'BREAKING[ _-]CHANGE|^[a-z]+(\([^)]+\))?!:'; then
+          if echo "$unreleased_subjects" | grep -qP '^[a-z]+(\([^)]+\))?!:' || \
+             echo "$unreleased_body"     | grep -qP '^BREAKING[ _-]CHANGE:'; then
             bump="major"
-          elif echo "$unreleased" | grep -qP '^feat'; then
+          elif echo "$unreleased_subjects" | grep -qP '^feat'; then
             bump="minor"
           else
             bump="patch"

--- a/.github/workflows/contract-toolkit-release.yml
+++ b/.github/workflows/contract-toolkit-release.yml
@@ -60,39 +60,50 @@ jobs:
 
       - name: Compute next version
         id: versions
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           current="$(grep -oP 'version\s*=\s*"\K[^"]+' contract-toolkit/src/PklProject)"
 
-          # Only commits touching contract-toolkit/** paths (since the last
-          # contract-toolkit-v* tag) determine the semver bump type.
-          next_tag="$(git cliff \
-            --config contract-toolkit/cliff.toml \
-            --bumped-version \
-            --tag-pattern '^contract-toolkit-v[0-9].*' \
-            --include-path 'contract-toolkit/**' \
-            2>/dev/null || true)"
+          # Find commit subjects since the last contract-toolkit-v* tag that
+          # touched contract-toolkit/** paths. We use plain git log rather than
+          # git-cliff --bumped-version because the latter has been silently
+          # returning empty output with --include-path across git-cliff 2.x
+          # releases, causing every release PR to be skipped.
+          unreleased="$(git log \
+            "contract-toolkit-v${current}..HEAD" \
+            --format='%s' \
+            -- 'contract-toolkit/**')"
 
-          # Strip tag prefix — handles contract-toolkit-vX.Y.Z and bare vX.Y.Z
-          new_version="${next_tag#contract-toolkit-v}"
-          new_version="${new_version#v}"
-
-          # Skip when there is nothing to release or the computed version is not
-          # an advancement over what is already in PklProject.
-          higher="$(printf '%s\n%s\n' "$current" "$new_version" | sort -V | tail -1)"
-          if [ -z "$new_version" ] || [ "$higher" != "$new_version" ] || [ "$current" = "$new_version" ]; then
-            echo "No unreleased contract-toolkit changes require a version bump (current: ${current}, computed: ${new_version:-none})."
+          if [ -z "$unreleased" ]; then
+            echo "No unreleased contract-toolkit commits (current: ${current})."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          # Conventional-commits bump rules:
+          #   BREAKING CHANGE trailer or ! suffix → major
+          #   feat → minor
+          #   anything else → patch
+          if echo "$unreleased" | grep -qP 'BREAKING[ _-]CHANGE|^[a-z]+(\([^)]+\))?!:'; then
+            bump="major"
+          elif echo "$unreleased" | grep -qP '^feat'; then
+            bump="minor"
+          else
+            bump="patch"
+          fi
+
+          IFS='.' read -r ver_major ver_minor ver_patch <<< "$current"
+          case "$bump" in
+            major) new_version="$((ver_major + 1)).0.0" ;;
+            minor) new_version="${ver_major}.$((ver_minor + 1)).0" ;;
+            patch) new_version="${ver_major}.${ver_minor}.$((ver_patch + 1))" ;;
+          esac
 
           echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "old=${current}" >> "$GITHUB_OUTPUT"
           echo "new=${new_version}" >> "$GITHUB_OUTPUT"
           echo "tag=contract-toolkit-v${new_version}" >> "$GITHUB_OUTPUT"
-          echo "Version: ${current} -> ${new_version}"
+          echo "Version: ${current} -> ${new_version} (${bump} bump)"
 
       - name: Apply version bump to PklProject
         if: steps.versions.outputs.skip != 'true'

--- a/.github/workflows/contract-toolkit-release.yml
+++ b/.github/workflows/contract-toolkit-release.yml
@@ -54,9 +54,15 @@ jobs:
           sudo mv /tmp/pkl /usr/local/bin/pkl
 
       - name: Install git-cliff
-        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
-        with:
-          args: --version
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/git-cliff.tar.gz \
+            "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          tar -xzf /tmp/git-cliff.tar.gz -C /tmp/
+          sudo install -m755 "$(find /tmp -name 'git-cliff' -type f | head -1)" /usr/local/bin/git-cliff
+          git-cliff --version
+        env:
+          GIT_CLIFF_VERSION: "2.13.1"
 
       - name: Compute next version
         id: versions

--- a/.github/workflows/contract-toolkit-release.yml
+++ b/.github/workflows/contract-toolkit-release.yml
@@ -56,10 +56,18 @@ jobs:
       - name: Install git-cliff
         run: |
           set -euo pipefail
-          curl -fsSL -o /tmp/git-cliff.tar.gz \
+          tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
+          curl -fsSL -o "${tmpdir}/git-cliff.tar.gz" \
             "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-          tar -xzf /tmp/git-cliff.tar.gz -C /tmp/
-          sudo install -m755 "$(find /tmp -name 'git-cliff' -type f | head -1)" /usr/local/bin/git-cliff
+          curl -fsSL -o "${tmpdir}/git-cliff.tar.gz.sha512" \
+            "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz.sha512"
+          expected="$(awk '{print $1}' "${tmpdir}/git-cliff.tar.gz.sha512")"
+          echo "${expected}  ${tmpdir}/git-cliff.tar.gz" | sha512sum --check
+          tar -xzf "${tmpdir}/git-cliff.tar.gz" -C "${tmpdir}/"
+          sudo install -m755 \
+            "${tmpdir}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu/git-cliff" \
+            /usr/local/bin/git-cliff
           git-cliff --version
         env:
           GIT_CLIFF_VERSION: "2.13.1"
@@ -109,7 +117,7 @@ jobs:
           if echo "$unreleased_subjects" | grep -qP '^[a-z]+(\([^)]+\))?!:' || \
              echo "$unreleased_body"     | grep -qP '^BREAKING[ _-]CHANGE:'; then
             bump="major"
-          elif echo "$unreleased_subjects" | grep -qP '^feat'; then
+          elif echo "$unreleased_subjects" | grep -qP '^feat[(!:]'; then
             bump="minor"
           else
             bump="patch"


### PR DESCRIPTION
## Root cause

`orhun/git-cliff-action` runs git-cliff internally but never adds the binary to `PATH` for subsequent steps. Every prior run of `contract-toolkit-release.yml` happened to skip before reaching the changelog-rendering steps (because version computation always returned empty), so this was silently broken since the workflow was written.

With the version-computation fix from #1840 now on main, the workflow advances past the skip check and calls `git cliff` — which immediately fails with `git: 'cliff' is not a git command`.

## Fix

Replace the `orhun/git-cliff-action` install step with a direct `curl` download to `/usr/local/bin/git-cliff`, identical to how PKL is installed. This ensures `git-cliff` (and therefore `git cliff`) is available for all subsequent steps.

## Test

Trigger `workflow_dispatch` on main after merging — this run should complete fully and open the `bump-version-contract-toolkit` PR for v0.10.1.