### PR TITLE
chore(security): allowlist SSH knownhosts subpackage CVE missed in #1842

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -600,5 +600,16 @@
     "compensating_controls": null,
     "re_evaluation_trigger": "expiry",
     "exposure_assessment": null
+  },
+  "SNYK-GOLANG-GOLANGORGXCRYPTOSSHKNOWNHOSTS-16796449": {
+    "package": "golang.org/x/crypto/ssh/knownhosts",
+    "severity": "HIGH",
+    "reason": "Base image — Go dependency in Dapr runtime (knownhosts subpackage of golang.org/x/crypto/ssh). Same root cause and fix as the four SSH CVEs allowlisted in #1842; missed in that batch because Snyk emits a separate ID for the knownhosts subpackage. Fix available in golang.org/x/crypto 0.52.0; awaiting upstream Dapr bump and subsequent Wolfi base image rebuild.",
+    "expires": "2026-06-21",
+    "added_by": "tejeshallampati-alt",
+    "fix_available_date": null,
+    "compensating_controls": null,
+    "re_evaluation_trigger": "expiry",
+    "exposure_assessment": null
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1842. That PR allowlisted four `SNYK-GOLANG-GOLANGORGXCRYPTOSSH-*` IDs from the Dapr base-image Go runtime but missed one sibling — Snyk emits a separate ID for the `knownhosts` subpackage of the same library:

| ID | Package | In #1842? |
| --- | --- | :-: |
| `SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16795342` | `golang.org/x/crypto/ssh` | ✅ |
| `SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16795344` | `golang.org/x/crypto/ssh` | ✅ |
| `SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796326` | `golang.org/x/crypto/ssh` | ✅ |
| `SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796332` | `golang.org/x/crypto/ssh` | ✅ |
| `SNYK-GOLANG-GOLANGORGXCRYPTOSSHKNOWNHOSTS-16796449` | `golang.org/x/crypto/ssh/knownhosts` | ❌ — this PR |

## Same family, same wait

- **Root cause:** Dapr base-image Go transitive dep — we install `dapr-daprd-1.17` via Wolfi apk, and its Go binary embeds the affected `golang.org/x/crypto` family.
- **Fix:** `golang.org/x/crypto 0.52.0`, blocked on Dapr upstream + subsequent Wolfi rebuild — same as the other four.
- **Severity:** HIGH.
- **Expiry:** `2026-06-21` — matches the family so they lapse together.

## Why now

Blocking [atlanhq/atlan-looker-app#93](https://github.com/atlanhq/atlan-looker-app/pull/93) — a one-line UI-placeholder fix to the Looker connector's SSH-private-key form field. The connector's security gate reads this allowlist at run time; an unrelated PR can't merge until this Snyk ID is covered here.

## Test plan

- [x] JSON parses (`python3 -c "import json; json.load(open('.security/base-allowlist.json'))"`).
- [x] Schema mirrors the four existing entries from #1842 exactly (same key set, same value shapes).
- [ ] CI's allowlist validator passes (`.github/scripts/validate_allowlist.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)