### PR TITLE
ci(fix): correct git-cliff extraction path in release workflow

### DIFF
--- a/.github/workflows/contract-toolkit-release.yml
+++ b/.github/workflows/contract-toolkit-release.yml
@@ -66,7 +66,7 @@ jobs:
           echo "${expected}  ${tmpdir}/git-cliff.tar.gz" | sha512sum --check
           tar -xzf "${tmpdir}/git-cliff.tar.gz" -C "${tmpdir}/"
           sudo install -m755 \
-            "${tmpdir}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu/git-cliff" \
+            "${tmpdir}/git-cliff-${GIT_CLIFF_VERSION}/git-cliff" \
             /usr/local/bin/git-cliff
           git-cliff --version
         env:


### PR DESCRIPTION
One-line fix: the tarball `git-cliff-2.13.1-x86_64-unknown-linux-gnu.tar.gz` extracts to `git-cliff-2.13.1/` (version only), not `git-cliff-2.13.1-x86_64-unknown-linux-gnu/` (version + arch). The explicit path added in #1844 used the wrong directory name, causing `install: cannot stat ... No such file or directory`.

Verified locally with `tar -tzf` against the release asset.