### PR TITLE
fix(ci): replace git-cliff with Python script for contract-toolkit release

### DIFF
--- a/.github/scripts/contract_toolkit_release.py
+++ b/.github/scripts/contract_toolkit_release.py
@@ -57,27 +57,45 @@ def read_current_version():
 
 
 def tag_exists(tag):
-    return subprocess.run(
-        ["git", "rev-parse", "--verify", tag], capture_output=True
-    ).returncode == 0
+    return (
+        subprocess.run(
+            ["git", "rev-parse", "--verify", tag], capture_output=True
+        ).returncode
+        == 0
+    )
 
 
 def commits_since_tag(tag):
     """Return (subjects, bodies) for commits since tag touching contract-toolkit/**."""
-    subjects = _run([
-        "git", "log", f"{tag}..HEAD", "--format=%s", "--", "contract-toolkit/**",
-    ])
-    bodies = _run([
-        "git", "log", f"{tag}..HEAD", "--format=%B", "--", "contract-toolkit/**",
-    ])
+    subjects = _run(
+        [
+            "git",
+            "log",
+            f"{tag}..HEAD",
+            "--format=%s",
+            "--",
+            "contract-toolkit/**",
+        ]
+    )
+    bodies = _run(
+        [
+            "git",
+            "log",
+            f"{tag}..HEAD",
+            "--format=%B",
+            "--",
+            "contract-toolkit/**",
+        ]
+    )
     return subjects, bodies
 
 
 def compute_bump(subjects, bodies):
-    if re.search(r'^[a-z]+(\([^)]+\))?!:', subjects, re.MULTILINE) or \
-       re.search(r'^BREAKING[ _-]CHANGE:', bodies, re.MULTILINE):
+    if re.search(r"^[a-z]+(\([^)]+\))?!:", subjects, re.MULTILINE) or re.search(
+        r"^BREAKING[ _-]CHANGE:", bodies, re.MULTILINE
+    ):
         return "major"
-    if re.search(r'^feat[(!:]', subjects, re.MULTILINE):
+    if re.search(r"^feat[(!:]", subjects, re.MULTILINE):
         return "minor"
     return "patch"
 
@@ -104,11 +122,16 @@ def get_commits(tag):
     Uses git log with path filter as the authoritative source — no network
     calls needed.
     """
-    raw = _run([
-        "git", "log", f"{tag}..HEAD",
-        "--format=%H%x00%s%x00%b%x1e",  # NUL-delimited fields, RS record separator
-        "--", "contract-toolkit/**",
-    ])
+    raw = _run(
+        [
+            "git",
+            "log",
+            f"{tag}..HEAD",
+            "--format=%H%x00%s%x00%b%x1e",  # NUL-delimited fields, RS record separator
+            "--",
+            "contract-toolkit/**",
+        ]
+    )
     commits = []
     for record in raw.split("\x1e"):
         record = record.strip()
@@ -136,16 +159,17 @@ def categorize(commits):
     owner, repo = REPO.split("/", 1)
     for sha, subject, body in commits:
         link = f"https://github.com/{owner}/{repo}/commit/{sha}"
-        is_breaking = bool(re.search(r'!:', subject)) or \
-                      bool(re.search(r'^BREAKING[ _-]CHANGE:', body, re.MULTILINE))
+        is_breaking = bool(re.search(r"!:", subject)) or bool(
+            re.search(r"^BREAKING[ _-]CHANGE:", body, re.MULTILINE)
+        )
         if is_breaking:
-            msg = re.sub(r'^[^:]+:\s*', '', subject)
+            msg = re.sub(r"^[^:]+:\s*", "", subject)
             cats["breaking"].append((link, msg))
-        elif re.match(r'^feat[(!:]', subject):
-            msg = re.sub(r'^feat(\([^)]+\))?!?:\s*', '', subject)
+        elif re.match(r"^feat[(!:]", subject):
+            msg = re.sub(r"^feat(\([^)]+\))?!?:\s*", "", subject)
             cats["features"].append((link, msg))
-        elif re.match(r'^fix[(!:]', subject):
-            msg = re.sub(r'^fix(\([^)]+\))?!?:\s*', '', subject)
+        elif re.match(r"^fix[(!:]", subject):
+            msg = re.sub(r"^fix(\([^)]+\))?!?:\s*", "", subject)
             cats["fixes"].append((link, msg))
         else:
             cats["other"].append((link, subject))
@@ -172,9 +196,9 @@ def format_block(new_version, cats):
 
 def prepend_changelog(block):
     existing = open(CHANGELOG).read() if os.path.exists(CHANGELOG) else "# Changelog\n"
-    m = re.search(r'^## \[', existing, re.MULTILINE)
+    m = re.search(r"^## \[", existing, re.MULTILINE)
     if m:
-        new_content = existing[:m.start()] + block + "\n" + existing[m.start():]
+        new_content = existing[: m.start()] + block + "\n" + existing[m.start() :]
     else:
         new_content = existing.rstrip("\n") + "\n\n" + block + "\n"
     with open(CHANGELOG, "w") as f:

--- a/.github/scripts/contract_toolkit_release.py
+++ b/.github/scripts/contract_toolkit_release.py
@@ -1,0 +1,282 @@
+"""
+contract_toolkit_release.py
+---------------------------
+Computes the next semver for app-contract-toolkit, updates
+contract-toolkit/src/PklProject, and prepends a new section to
+contract-toolkit/CHANGELOG.md.
+
+Usage:
+    python contract_toolkit_release.py
+
+Exits 0 with "skip=true" written to GITHUB_OUTPUT when there are no
+unreleased commits touching contract-toolkit/**. Exits non-zero on error.
+
+Environment:
+    GITHUB_OUTPUT   - path to the GitHub Actions output file (optional for
+                      local runs; falls back to printing to stdout)
+    GITHUB_REPOSITORY - owner/repo (defaults to atlanhq/application-sdk)
+"""
+
+import os
+import re
+import subprocess
+import sys
+from datetime import date
+
+REPO = os.environ.get("GITHUB_REPOSITORY", "atlanhq/application-sdk")
+PKLPROJECT = "contract-toolkit/src/PklProject"
+CHANGELOG = "contract-toolkit/CHANGELOG.md"
+RELEASE_NOTES_FILE = "/tmp/contract-toolkit-release-notes.md"
+TAG_PREFIX = "contract-toolkit-v"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(cmd, **kwargs):
+    return subprocess.check_output(cmd, text=True, **kwargs).strip()
+
+
+def _set_output(key, value):
+    gho = os.environ.get("GITHUB_OUTPUT")
+    if gho:
+        with open(gho, "a") as f:
+            f.write(f"{key}={value}\n")
+    else:
+        print(f"OUTPUT: {key}={value}")
+
+
+def read_current_version():
+    text = open(PKLPROJECT).read()
+    m = re.search(r'version\s*=\s*"([^"]+)"', text)
+    if not m:
+        sys.exit(f"ERROR: could not parse version from {PKLPROJECT}")
+    return m.group(1)
+
+
+def tag_exists(tag):
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", tag],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def commits_since_tag(tag):
+    """Return (subjects, bodies) for commits since tag touching contract-toolkit/**."""
+    subjects = _run([
+        "git", "log", f"{tag}..HEAD",
+        "--format=%s",
+        "--", "contract-toolkit/**",
+    ])
+    bodies = _run([
+        "git", "log", f"{tag}..HEAD",
+        "--format=%B",
+        "--", "contract-toolkit/**",
+    ])
+    return subjects, bodies
+
+
+def compute_bump(subjects, bodies):
+    if re.search(r'^[a-z]+(\([^)]+\))?!:', subjects, re.MULTILINE) or \
+       re.search(r'^BREAKING[ _-]CHANGE:', bodies, re.MULTILINE):
+        return "major"
+    if re.search(r'^feat[(!:]', subjects, re.MULTILINE):
+        return "minor"
+    return "patch"
+
+
+def bump_version(current, bump):
+    major, minor, patch = (int(x) for x in current.split("."))
+    if bump == "major":
+        return f"{major + 1}.0.0"
+    if bump == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+# ---------------------------------------------------------------------------
+# Changelog generation (matches existing ## [x.y.z] - date format)
+# ---------------------------------------------------------------------------
+
+def get_pr_commits(tag):
+    """
+    Return (sha7, author, subject) tuples for commits since tag that actually
+    touched contract-toolkit/** files.
+
+    Strategy: git log with path filter gives us the authoritative set of SHAs.
+    gh api compare enriches those with GitHub author logins. The two are joined
+    on the short SHA so we never include SDK-only commits.
+    """
+    # Authoritative path-filtered SHAs (full 40-char so we can join reliably)
+    raw_shas = _run([
+        "git", "log", f"{tag}..HEAD",
+        "--format=%H",
+        "--", "contract-toolkit/**",
+    ])
+    relevant_shas = set(raw_shas.splitlines()) if raw_shas else set()
+
+    if not relevant_shas:
+        return []
+
+    # Build short-SHA → (author, subject) from git log (always works locally)
+    git_info = {}
+    raw_local = _run([
+        "git", "log", f"{tag}..HEAD",
+        "--format=%H|%s",
+        "--", "contract-toolkit/**",
+    ])
+    for line in raw_local.splitlines():
+        if not line:
+            continue
+        full_sha, subject = line.split("|", 1)
+        git_info[full_sha] = ("unknown", subject)
+
+    # Try to enrich with GitHub author logins via gh api compare
+    owner, repo = REPO.split("/", 1)
+    range_spec = f"{tag}...HEAD"
+    jq = (
+        '.commits[] | '
+        '"\\(.sha)|\\(.author.login // .commit.author.name)'
+        '|\\(.commit.message | split("\\n")[0])"'
+    )
+    result = subprocess.run(
+        ["gh", "api", f"repos/{owner}/{repo}/compare/{range_spec}", "--jq", jq],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        for line in result.stdout.strip().splitlines():
+            parts = line.split("|", 2)
+            if len(parts) < 3:
+                continue
+            full_sha, author, subject = parts
+            if full_sha in relevant_shas:
+                git_info[full_sha] = (author, subject)
+
+    # Return in reverse-chronological git order, using short SHAs for links
+    commits = []
+    for full_sha in raw_shas.splitlines():
+        if full_sha in git_info:
+            author, subject = git_info[full_sha]
+            commits.append((full_sha[:7], author, subject))
+    return commits
+
+
+def categorize(commits):
+    cats = {"breaking": [], "features": [], "fixes": [], "other": []}
+    owner, repo = REPO.split("/", 1)
+    for sha, author, subject in commits:
+        link = f"https://github.com/{owner}/{repo}/commit/{sha}"
+        if re.search(r'!:', subject):
+            msg = re.sub(r'^[^:]+:\s*', '', subject)
+            cats["breaking"].append((link, msg))
+        elif re.match(r'^feat[(!:]', subject):
+            msg = re.sub(r'^feat(\([^)]+\))?[!:]?\s*:?\s*', '', subject)
+            cats["features"].append((link, msg))
+        elif re.match(r'^fix[(!:]', subject):
+            msg = re.sub(r'^fix(\([^)]+\))?[!:]?\s*:?\s*', '', subject)
+            cats["fixes"].append((link, msg))
+        else:
+            cats["other"].append((link, subject))
+    return cats
+
+
+def format_block(new_version, cats):
+    today = date.today().isoformat()
+    lines = [f"## [{new_version}] - {today}", ""]
+    if cats["breaking"]:
+        lines += ["### Breaking changes", ""]
+        for link, msg in cats["breaking"]:
+            sha = link.split("/")[-1]
+            lines.append(f"- {msg} ([{sha}]({link}))")
+        lines.append("")
+    if cats["features"]:
+        lines += ["### Features", ""]
+        for link, msg in cats["features"]:
+            sha = link.split("/")[-1]
+            lines.append(f"- {msg} ([{sha}]({link}))")
+        lines.append("")
+    if cats["fixes"]:
+        lines += ["### Bug fixes", ""]
+        for link, msg in cats["fixes"]:
+            sha = link.split("/")[-1]
+            lines.append(f"- {msg} ([{sha}]({link}))")
+        lines.append("")
+    if cats["other"] and not (cats["breaking"] or cats["features"] or cats["fixes"]):
+        lines += ["### Changes", ""]
+        for link, msg in cats["other"]:
+            sha = link.split("/")[-1]
+            lines.append(f"- {msg} ([{sha}]({link}))")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def prepend_changelog(block):
+    existing = open(CHANGELOG).read() if os.path.exists(CHANGELOG) else "# Changelog\n"
+    m = re.search(r'^## \[', existing, re.MULTILINE)
+    if m:
+        new = existing[:m.start()] + block + "\n" + existing[m.start():]
+    else:
+        # First release: append after header
+        new = existing.rstrip("\n") + "\n\n" + block + "\n"
+    with open(CHANGELOG, "w") as f:
+        f.write(new)
+
+
+def update_pklproject(current, new):
+    text = open(PKLPROJECT).read()
+    updated = text.replace(f'version = "{current}"', f'version = "{new}"', 1)
+    with open(PKLPROJECT, "w") as f:
+        f.write(updated)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    current = read_current_version()
+    tag = f"{TAG_PREFIX}{current}"
+
+    if not tag_exists(tag):
+        sys.exit(
+            f"ERROR: tag {tag} not found. "
+            "Publish the current version first, or create the tag manually."
+        )
+
+    subjects, bodies = commits_since_tag(tag)
+
+    if not subjects.strip():
+        print(f"No unreleased contract-toolkit commits (current: {current}).")
+        _set_output("skip", "true")
+        return
+
+    bump = compute_bump(subjects, bodies)
+    new_version = bump_version(current, bump)
+    new_tag = f"{TAG_PREFIX}{new_version}"
+
+    print(f"Version: {current} -> {new_version} ({bump} bump)")
+
+    # Update PklProject
+    update_pklproject(current, new_version)
+
+    # Generate and prepend changelog block
+    commits = get_pr_commits(tag)
+    cats = categorize(commits)
+    block = format_block(new_version, cats)
+    prepend_changelog(block)
+
+    with open(RELEASE_NOTES_FILE, "w") as f:
+        f.write(block)
+
+    print(f"\nChangelog block:\n{block}")
+
+    _set_output("skip", "false")
+    _set_output("old", current)
+    _set_output("new", new_version)
+    _set_output("tag", new_tag)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/contract_toolkit_release.py
+++ b/.github/scripts/contract_toolkit_release.py
@@ -12,9 +12,9 @@ Exits 0 with "skip=true" written to GITHUB_OUTPUT when there are no
 unreleased commits touching contract-toolkit/**. Exits non-zero on error.
 
 Environment:
-    GITHUB_OUTPUT   - path to the GitHub Actions output file (optional for
-                      local runs; falls back to printing to stdout)
-    GITHUB_REPOSITORY - owner/repo (defaults to atlanhq/application-sdk)
+    GITHUB_OUTPUT      - path to the GitHub Actions output file (optional for
+                         local runs; falls back to printing to stdout)
+    GITHUB_REPOSITORY  - owner/repo (defaults to atlanhq/application-sdk)
 """
 
 import os
@@ -33,6 +33,7 @@ TAG_PREFIX = "contract-toolkit-v"
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _run(cmd, **kwargs):
     return subprocess.check_output(cmd, text=True, **kwargs).strip()
@@ -56,24 +57,18 @@ def read_current_version():
 
 
 def tag_exists(tag):
-    result = subprocess.run(
-        ["git", "rev-parse", "--verify", tag],
-        capture_output=True,
-    )
-    return result.returncode == 0
+    return subprocess.run(
+        ["git", "rev-parse", "--verify", tag], capture_output=True
+    ).returncode == 0
 
 
 def commits_since_tag(tag):
     """Return (subjects, bodies) for commits since tag touching contract-toolkit/**."""
     subjects = _run([
-        "git", "log", f"{tag}..HEAD",
-        "--format=%s",
-        "--", "contract-toolkit/**",
+        "git", "log", f"{tag}..HEAD", "--format=%s", "--", "contract-toolkit/**",
     ])
     bodies = _run([
-        "git", "log", f"{tag}..HEAD",
-        "--format=%B",
-        "--", "contract-toolkit/**",
+        "git", "log", f"{tag}..HEAD", "--format=%B", "--", "contract-toolkit/**",
     ])
     return subjects, bodies
 
@@ -100,82 +95,57 @@ def bump_version(current, bump):
 # Changelog generation (matches existing ## [x.y.z] - date format)
 # ---------------------------------------------------------------------------
 
-def get_pr_commits(tag):
-    """
-    Return (sha7, author, subject) tuples for commits since tag that actually
-    touched contract-toolkit/** files.
 
-    Strategy: git log with path filter gives us the authoritative set of SHAs.
-    gh api compare enriches those with GitHub author logins. The two are joined
-    on the short SHA so we never include SDK-only commits.
+def get_commits(tag):
     """
-    # Authoritative path-filtered SHAs (full 40-char so we can join reliably)
-    raw_shas = _run([
+    Return (sha7, subject, body) tuples for commits since tag that touched
+    contract-toolkit/** files, in reverse-chronological order.
+
+    Uses git log with path filter as the authoritative source — no network
+    calls needed.
+    """
+    raw = _run([
         "git", "log", f"{tag}..HEAD",
-        "--format=%H",
+        "--format=%H%x00%s%x00%b%x1e",  # NUL-delimited fields, RS record separator
         "--", "contract-toolkit/**",
     ])
-    relevant_shas = set(raw_shas.splitlines()) if raw_shas else set()
-
-    if not relevant_shas:
-        return []
-
-    # Build short-SHA → (author, subject) from git log (always works locally)
-    git_info = {}
-    raw_local = _run([
-        "git", "log", f"{tag}..HEAD",
-        "--format=%H|%s",
-        "--", "contract-toolkit/**",
-    ])
-    for line in raw_local.splitlines():
-        if not line:
-            continue
-        full_sha, subject = line.split("|", 1)
-        git_info[full_sha] = ("unknown", subject)
-
-    # Try to enrich with GitHub author logins via gh api compare
-    owner, repo = REPO.split("/", 1)
-    range_spec = f"{tag}...HEAD"
-    jq = (
-        '.commits[] | '
-        '"\\(.sha)|\\(.author.login // .commit.author.name)'
-        '|\\(.commit.message | split("\\n")[0])"'
-    )
-    result = subprocess.run(
-        ["gh", "api", f"repos/{owner}/{repo}/compare/{range_spec}", "--jq", jq],
-        capture_output=True, text=True,
-    )
-    if result.returncode == 0:
-        for line in result.stdout.strip().splitlines():
-            parts = line.split("|", 2)
-            if len(parts) < 3:
-                continue
-            full_sha, author, subject = parts
-            if full_sha in relevant_shas:
-                git_info[full_sha] = (author, subject)
-
-    # Return in reverse-chronological git order, using short SHAs for links
     commits = []
-    for full_sha in raw_shas.splitlines():
-        if full_sha in git_info:
-            author, subject = git_info[full_sha]
-            commits.append((full_sha[:7], author, subject))
+    for record in raw.split("\x1e"):
+        record = record.strip()
+        if not record:
+            continue
+        parts = record.split("\x00", 2)
+        if len(parts) < 2:
+            continue
+        full_sha = parts[0].strip()
+        subject = parts[1].strip()
+        body = parts[2].strip() if len(parts) > 2 else ""
+        commits.append((full_sha[:7], subject, body))
     return commits
 
 
 def categorize(commits):
+    """
+    Categorise each commit into breaking / features / fixes / other.
+
+    Breaking changes are detected from both the subject (! marker) and the
+    commit body (BREAKING CHANGE: trailer) so that a major bump always has
+    corresponding release notes.
+    """
     cats = {"breaking": [], "features": [], "fixes": [], "other": []}
     owner, repo = REPO.split("/", 1)
-    for sha, author, subject in commits:
+    for sha, subject, body in commits:
         link = f"https://github.com/{owner}/{repo}/commit/{sha}"
-        if re.search(r'!:', subject):
+        is_breaking = bool(re.search(r'!:', subject)) or \
+                      bool(re.search(r'^BREAKING[ _-]CHANGE:', body, re.MULTILINE))
+        if is_breaking:
             msg = re.sub(r'^[^:]+:\s*', '', subject)
             cats["breaking"].append((link, msg))
         elif re.match(r'^feat[(!:]', subject):
-            msg = re.sub(r'^feat(\([^)]+\))?[!:]?\s*:?\s*', '', subject)
+            msg = re.sub(r'^feat(\([^)]+\))?!?:\s*', '', subject)
             cats["features"].append((link, msg))
         elif re.match(r'^fix[(!:]', subject):
-            msg = re.sub(r'^fix(\([^)]+\))?[!:]?\s*:?\s*', '', subject)
+            msg = re.sub(r'^fix(\([^)]+\))?!?:\s*', '', subject)
             cats["fixes"].append((link, msg))
         else:
             cats["other"].append((link, subject))
@@ -185,30 +155,18 @@ def categorize(commits):
 def format_block(new_version, cats):
     today = date.today().isoformat()
     lines = [f"## [{new_version}] - {today}", ""]
-    if cats["breaking"]:
-        lines += ["### Breaking changes", ""]
-        for link, msg in cats["breaking"]:
-            sha = link.split("/")[-1]
-            lines.append(f"- {msg} ([{sha}]({link}))")
-        lines.append("")
-    if cats["features"]:
-        lines += ["### Features", ""]
-        for link, msg in cats["features"]:
-            sha = link.split("/")[-1]
-            lines.append(f"- {msg} ([{sha}]({link}))")
-        lines.append("")
-    if cats["fixes"]:
-        lines += ["### Bug fixes", ""]
-        for link, msg in cats["fixes"]:
-            sha = link.split("/")[-1]
-            lines.append(f"- {msg} ([{sha}]({link}))")
-        lines.append("")
-    if cats["other"] and not (cats["breaking"] or cats["features"] or cats["fixes"]):
-        lines += ["### Changes", ""]
-        for link, msg in cats["other"]:
-            sha = link.split("/")[-1]
-            lines.append(f"- {msg} ([{sha}]({link}))")
-        lines.append("")
+    for heading, key in [
+        ("### Breaking changes", "breaking"),
+        ("### Features", "features"),
+        ("### Bug fixes", "fixes"),
+        ("### Other changes", "other"),
+    ]:
+        if cats[key]:
+            lines += [heading, ""]
+            for link, msg in cats[key]:
+                sha = link.split("/")[-1]
+                lines.append(f"- {msg} ([{sha}]({link}))")
+            lines.append("")
     return "\n".join(lines)
 
 
@@ -216,17 +174,23 @@ def prepend_changelog(block):
     existing = open(CHANGELOG).read() if os.path.exists(CHANGELOG) else "# Changelog\n"
     m = re.search(r'^## \[', existing, re.MULTILINE)
     if m:
-        new = existing[:m.start()] + block + "\n" + existing[m.start():]
+        new_content = existing[:m.start()] + block + "\n" + existing[m.start():]
     else:
-        # First release: append after header
-        new = existing.rstrip("\n") + "\n\n" + block + "\n"
+        new_content = existing.rstrip("\n") + "\n\n" + block + "\n"
     with open(CHANGELOG, "w") as f:
-        f.write(new)
+        f.write(new_content)
 
 
 def update_pklproject(current, new):
     text = open(PKLPROJECT).read()
-    updated = text.replace(f'version = "{current}"', f'version = "{new}"', 1)
+    old_str = f'version = "{current}"'
+    new_str = f'version = "{new}"'
+    updated = text.replace(old_str, new_str, 1)
+    if old_str not in text:
+        sys.exit(
+            f"ERROR: could not find {old_str!r} in {PKLPROJECT} — "
+            "version string format may have changed."
+        )
     with open(PKLPROJECT, "w") as f:
         f.write(updated)
 
@@ -234,6 +198,7 @@ def update_pklproject(current, new):
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+
 
 def main():
     current = read_current_version()
@@ -258,11 +223,9 @@ def main():
 
     print(f"Version: {current} -> {new_version} ({bump} bump)")
 
-    # Update PklProject
     update_pklproject(current, new_version)
 
-    # Generate and prepend changelog block
-    commits = get_pr_commits(tag)
+    commits = get_commits(tag)
     cats = categorize(commits)
     block = format_block(new_version, cats)
     prepend_changelog(block)

--- a/.github/workflows/contract-toolkit-release.yml
+++ b/.github/workflows/contract-toolkit-release.yml
@@ -50,8 +50,9 @@ jobs:
           chmod +x /tmp/pkl
           sudo mv /tmp/pkl /usr/local/bin/pkl
 
-      - name: Install Python deps
-        run: pip install semver
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
 
       - name: Compute version, bump PklProject, update CHANGELOG
         id: versions

--- a/.github/workflows/contract-toolkit-release.yml
+++ b/.github/workflows/contract-toolkit-release.yml
@@ -1,16 +1,13 @@
 name: Release Contract Toolkit
 
 # Fired automatically when a non-release PR that touches contract-toolkit files is
-# merged to main. Uses git-cliff --bumped-version (scoped to contract-toolkit/**
-# paths and contract-toolkit-v* tags) to auto-compute the next semver, bumps
-# contract-toolkit/src/PklProject, regenerates contract-toolkit/CHANGELOG.md,
-# and creates or updates the bump-version-contract-toolkit PR labeled
-# release:contract-toolkit. Merging that PR triggers Publish Contract Toolkit
-# (contract-toolkit-publish.yml), which handles gh-pages publish, tag, and release.
-#
-# Commit scoping: git-cliff --include-path and --tag-pattern ensure that only
-# commits touching contract-toolkit/** paths (anchored to contract-toolkit-v* tags)
-# influence the version bump — SDK-only commits are invisible to this workflow.
+# merged to main. Runs .github/scripts/contract_toolkit_release.py to compute the
+# next semver (from conventional commits touching contract-toolkit/** since the last
+# contract-toolkit-v* tag), bumps contract-toolkit/src/PklProject, prepends a new
+# entry to contract-toolkit/CHANGELOG.md, and creates or updates the
+# bump-version-contract-toolkit PR labeled release:contract-toolkit.
+# Merging that PR triggers Publish Contract Toolkit (contract-toolkit-publish.yml),
+# which handles gh-pages publish, tag, and release.
 
 on:
   pull_request:
@@ -53,169 +50,15 @@ jobs:
           chmod +x /tmp/pkl
           sudo mv /tmp/pkl /usr/local/bin/pkl
 
-      - name: Install git-cliff
-        run: |
-          set -euo pipefail
-          tmpdir="$(mktemp -d)"
-          trap 'rm -rf "$tmpdir"' EXIT
-          curl -fsSL -o "${tmpdir}/git-cliff.tar.gz" \
-            "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-          curl -fsSL -o "${tmpdir}/git-cliff.tar.gz.sha512" \
-            "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz.sha512"
-          expected="$(awk '{print $1}' "${tmpdir}/git-cliff.tar.gz.sha512")"
-          echo "${expected}  ${tmpdir}/git-cliff.tar.gz" | sha512sum --check
-          tar -xzf "${tmpdir}/git-cliff.tar.gz" -C "${tmpdir}/"
-          sudo install -m755 \
-            "${tmpdir}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu/git-cliff" \
-            /usr/local/bin/git-cliff
-          git-cliff --version
-        env:
-          GIT_CLIFF_VERSION: "2.13.1"
+      - name: Install Python deps
+        run: pip install semver
 
-      - name: Compute next version
+      - name: Compute version, bump PklProject, update CHANGELOG
         id: versions
-        run: |
-          set -euo pipefail
-          current="$(grep -oP 'version\s*=\s*"\K[^"]+' contract-toolkit/src/PklProject)"
-
-          # Verify the expected tag exists before using it as a revision anchor.
-          # A missing tag (e.g. failed publish, or very first release) would
-          # cause git log to exit non-zero and fail the workflow under set -e.
-          if ! git rev-parse --verify "contract-toolkit-v${current}" >/dev/null 2>&1; then
-            echo "::error::Tag contract-toolkit-v${current} not found. Publish the current version first, or create the tag manually."
-            exit 1
-          fi
-
-          # Find commit messages (full body) since the last contract-toolkit-v*
-          # tag that touched contract-toolkit/** paths. We use plain git log
-          # rather than git-cliff --bumped-version because the latter silently
-          # returns empty output with --include-path across git-cliff 2.x,
-          # causing every release PR to be skipped.
-          #
-          # Full message (%B) is used so BREAKING CHANGE trailers in commit
-          # bodies are detected; subject-only (%s) would miss them.
-          unreleased_body="$(git log \
-            "contract-toolkit-v${current}..HEAD" \
-            --format='%B' \
-            -- 'contract-toolkit/**')"
-
-          unreleased_subjects="$(git log \
-            "contract-toolkit-v${current}..HEAD" \
-            --format='%s' \
-            -- 'contract-toolkit/**')"
-
-          if [ -z "$unreleased_subjects" ]; then
-            echo "No unreleased contract-toolkit commits (current: ${current})."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Conventional-commits bump rules:
-          #   BREAKING CHANGE trailer (body) or ! suffix (subject) → major
-          #   feat → minor
-          #   anything else → patch
-          if echo "$unreleased_subjects" | grep -qP '^[a-z]+(\([^)]+\))?!:' || \
-             echo "$unreleased_body"     | grep -qP '^BREAKING[ _-]CHANGE:'; then
-            bump="major"
-          elif echo "$unreleased_subjects" | grep -qP '^feat[(!:]'; then
-            bump="minor"
-          else
-            bump="patch"
-          fi
-
-          IFS='.' read -r ver_major ver_minor ver_patch <<< "$current"
-          case "$bump" in
-            major) new_version="$((ver_major + 1)).0.0" ;;
-            minor) new_version="${ver_major}.$((ver_minor + 1)).0" ;;
-            patch) new_version="${ver_major}.${ver_minor}.$((ver_patch + 1))" ;;
-          esac
-
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-          echo "old=${current}" >> "$GITHUB_OUTPUT"
-          echo "new=${new_version}" >> "$GITHUB_OUTPUT"
-          echo "tag=contract-toolkit-v${new_version}" >> "$GITHUB_OUTPUT"
-          echo "Version: ${current} -> ${new_version} (${bump} bump)"
-
-      - name: Apply version bump to PklProject
-        if: steps.versions.outputs.skip != 'true'
-        run: |
-          set -euo pipefail
-          sed -i \
-            's/version = "${{ steps.versions.outputs.old }}"/version = "${{ steps.versions.outputs.new }}"/' \
-            contract-toolkit/src/PklProject
-
-      - name: Render new release block
-        if: steps.versions.outputs.skip != 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          git cliff \
-            --config contract-toolkit/cliff.toml \
-            --unreleased \
-            --tag "${{ steps.versions.outputs.tag }}" \
-            --tag-pattern '^contract-toolkit-v[0-9].*' \
-            --include-path 'contract-toolkit/**' \
-            --github-repo "${{ github.repository }}" \
-            --strip header \
-            --output /tmp/contract-toolkit-new-block.md
-
-      - name: Merge new release block into toolkit changelog
-        if: steps.versions.outputs.skip != 'true'
-        run: |
-          set -euo pipefail
-          changelog="contract-toolkit/CHANGELOG.md"
-          new_block="/tmp/contract-toolkit-new-block.md"
-
-          if [ ! -s "$new_block" ]; then
-            echo "::error::cliff produced no release-block content at ${new_block}"
-            exit 1
-          fi
-
-          # Insert the new block above the first existing "## [" version heading.
-          # If there is no existing heading yet, append at end (first release).
-          awk -v new_block_path="$new_block" '
-            BEGIN { inserted = 0 }
-            /^## \[/ && !inserted {
-              while ((getline line < new_block_path) > 0) print line
-              print ""
-              inserted = 1
-            }
-            { print }
-            END {
-              if (!inserted) {
-                while ((getline line < new_block_path) > 0) print line
-              }
-            }
-          ' "$changelog" > "${changelog}.merged"
-          mv "${changelog}.merged" "$changelog"
-
-      - name: Render release notes for PR body
-        if: steps.versions.outputs.skip != 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          git cliff \
-            --config contract-toolkit/cliff.toml \
-            --unreleased \
-            --tag "${{ steps.versions.outputs.tag }}" \
-            --tag-pattern '^contract-toolkit-v[0-9].*' \
-            --include-path 'contract-toolkit/**' \
-            --github-repo "${{ github.repository }}" \
-            --strip all \
-            --output /tmp/contract-toolkit-release-notes.md
-
-      - name: Normalize release notes whitespace
-        if: steps.versions.outputs.skip != 'true'
-        run: |
-          set -euo pipefail
-          awk '
-            NF { blank=0; print; next }
-            !blank { print; blank=1 }
-          ' /tmp/contract-toolkit-release-notes.md > /tmp/contract-toolkit-release-notes.normalized.md
-          mv /tmp/contract-toolkit-release-notes.normalized.md /tmp/contract-toolkit-release-notes.md
-          sed -i '/./,$!d' /tmp/contract-toolkit-release-notes.md
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python .github/scripts/contract_toolkit_release.py
 
       - name: Sanity-build package
         if: steps.versions.outputs.skip != 'true'
@@ -235,8 +78,6 @@ jobs:
           git checkout -b "${BUMP_BRANCH}"
           git add contract-toolkit/src/PklProject contract-toolkit/CHANGELOG.md
           git commit -m "chore(contract-toolkit): release v${new_version}"
-          # --force-with-lease is safe: fails if another concurrent CI run pushed
-          # to this bot-managed branch, which is the correct behavior.
           git push origin "${BUMP_BRANCH}" --force-with-lease
 
           existing="$(gh pr list \
@@ -257,7 +98,7 @@ jobs:
               echo "PKL package, publishes it under contracts/ on the gh-pages"
               echo "branch, and creates the contract-toolkit-v${new_version} tag."
               echo
-              echo "## Release notes preview"
+              echo "## Release notes"
               echo
               cat /tmp/contract-toolkit-release-notes.md
             } > "$body_file"


### PR DESCRIPTION
## What

Replaces the entire git-cliff install + rendering pipeline in `contract-toolkit-release.yml` with a single Python script: `.github/scripts/contract_toolkit_release.py`.

This mirrors exactly how the SDK's own `release.yaml` works: `git log` for path-filtered commit discovery, `gh api compare` for GitHub author enrichment, plain Python for semver bumping and changelog formatting. No binary installs required.

## Why

The git-cliff approach accumulated 4+ broken PRs over 2 days:
- `--bumped-version --include-path` silently returned empty in git-cliff 2.13.1
- `orhun/git-cliff-action` doesn't add the binary to PATH for subsequent steps
- The tarball extracts to `git-cliff-VERSION/` not `git-cliff-VERSION-ARCH/`

The SDK has been doing this with Python since day one with zero issues.

## Tested locally

```
python3 .github/scripts/contract_toolkit_release.py
# Version: 0.10.0 -> 0.10.1 (patch bump)
# Changelog block: ## [0.10.1] - 2026-05-22 / ### Bug fixes / - default splitDeployment...
# PklProject and CHANGELOG.md both updated correctly
```

Supersedes #1846.