### PR TITLE
fix(handler): resolve per-entrypoint output_type for /result from desc.workflow_type

### DIFF
--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -362,7 +362,7 @@ class WorkflowClientConfig:
     prometheus_bind_address: str = ""
 
     def is_configured(self) -> bool:
-        return bool(self.host and self.app_class)
+        return bool(self.host and self.app_class and self.app_name)
 
 
 _temporal_client: Client | None = None
@@ -1122,7 +1122,7 @@ def create_app_handler_service(
                     desc = await handle.describe()
                     output_type = _resolve_output_type_for_workflow(desc.workflow_type)
                     if output_type is None:
-                        logger.debug(
+                        logger.warning(
                             "No output_type resolved for workflow_id=%s workflow_type=%s; using untyped deserialization",
                             workflow_id,
                             desc.workflow_type,
@@ -1195,7 +1195,7 @@ def create_app_handler_service(
                 try:
                     output_type = _resolve_output_type_for_workflow(desc.workflow_type)
                     if output_type is None:
-                        logger.debug(
+                        logger.warning(
                             "No output_type resolved for workflow_id=%s workflow_type=%s; using untyped deserialization",
                             workflow_id,
                             desc.workflow_type,
@@ -1639,7 +1639,7 @@ def create_app_handler_service(
             input_data.workflow_id = workflow_id
 
             handle = await client.start_workflow(
-                app_cls._app_name,  # type: ignore[attr-defined]
+                _workflow_config.app_name,
                 args=[input_data],
                 id=workflow_id,
                 task_queue=_workflow_config.task_queue,

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -291,7 +291,7 @@ def _resolve_output_type_for_workflow(workflow_type_name: str) -> type | None:
     """
     if _workflow_config.app_class is None:
         return None
-    app_cls_name: str | None = getattr(_workflow_config.app_class, "_app_name", None)
+    app_cls_name = _workflow_config.app_name
     if not app_cls_name:
         return None
 
@@ -317,6 +317,11 @@ def _resolve_output_type_for_workflow(workflow_type_name: str) -> type | None:
         ep = next((e for e in app_meta.entry_points.values() if e.implicit), None)
         if ep is None and len(app_meta.entry_points) == 1:
             ep = next(iter(app_meta.entry_points.values()))
+            logger.debug(
+                "Resolved output_type via single-entrypoint fallback for workflow_type=%s ep=%s",
+                workflow_type_name,
+                ep.name,
+            )
 
     return ep.output_type if ep else None
 
@@ -333,6 +338,7 @@ class WorkflowClientConfig:
     host: str = ""
     namespace: str = "default"
     task_queue: str = ""
+    app_name: str = ""
     app_class: type[App] | None = dataclasses.field(default=None, repr=False)
     data_converter: DataConverter | None = dataclasses.field(default=None, repr=False)
 
@@ -541,6 +547,7 @@ def create_app_handler_service(
         host=temporal_host,
         namespace=temporal_namespace,
         task_queue=task_queue or f"{app_name}-queue",
+        app_name=getattr(app_class, "_app_name", "") if app_class is not None else "",
         app_class=app_class,
         data_converter=data_converter,
         tls_enabled=tls_enabled,
@@ -928,7 +935,7 @@ def create_app_handler_service(
             # Deferred to avoid a circular import at module load time.
             from application_sdk.app.registry import AppRegistry  # noqa: PLC0415
 
-            app_meta = AppRegistry.get_instance().get(app_cls._app_name)  # type: ignore[attr-defined]
+            app_meta = AppRegistry.get_instance().get(_workflow_config.app_name)
             entry_points = app_meta.entry_points
 
             if selected_entrypoint:
@@ -964,9 +971,9 @@ def create_app_handler_service(
 
             input_type = ep.input_type
             workflow_name = (
-                app_cls._app_name  # type: ignore[attr-defined]
+                _workflow_config.app_name
                 if ep.implicit
-                else f"{app_cls._app_name}:{ep.name}"  # type: ignore[attr-defined]
+                else f"{_workflow_config.app_name}:{ep.name}"
             )
 
             if input_type is None:
@@ -1114,6 +1121,12 @@ def create_app_handler_service(
                 try:
                     desc = await handle.describe()
                     output_type = _resolve_output_type_for_workflow(desc.workflow_type)
+                    if output_type is None:
+                        logger.debug(
+                            "No output_type resolved for workflow_id=%s workflow_type=%s; using untyped deserialization",
+                            workflow_id,
+                            desc.workflow_type,
+                        )
                     result_data = await _get_workflow_result(
                         client, workflow_id=workflow_id, output_type=output_type
                     )
@@ -1181,6 +1194,12 @@ def create_app_handler_service(
             elif status == "COMPLETED":
                 try:
                     output_type = _resolve_output_type_for_workflow(desc.workflow_type)
+                    if output_type is None:
+                        logger.debug(
+                            "No output_type resolved for workflow_id=%s workflow_type=%s; using untyped deserialization",
+                            workflow_id,
+                            desc.workflow_type,
+                        )
                     result_data = await _get_workflow_result(
                         client, workflow_id=workflow_id, output_type=output_type
                     )

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -295,16 +295,24 @@ def _resolve_output_type_for_workflow(workflow_type_name: str) -> type | None:
     if not app_cls_name:
         return None
 
-    from application_sdk.app.registry import AppRegistry  # noqa: PLC0415
+    from application_sdk.app.registry import (  # noqa: PLC0415
+        AppNotFoundError,
+        AppRegistry,
+    )
 
-    app_meta = AppRegistry.get_instance().get(app_cls_name)
-    if not app_meta:
+    try:
+        app_meta = AppRegistry.get_instance().get(app_cls_name)
+    except AppNotFoundError:
         return None
 
     if ":" in workflow_type_name:
-        _, ep_name = workflow_type_name.split(":", 1)
+        prefix, ep_name = workflow_type_name.split(":", 1)
+        if prefix != app_cls_name:
+            return None  # workflow belongs to a different app
         ep = app_meta.entry_points.get(ep_name)
     else:
+        if workflow_type_name != app_cls_name:
+            return None  # workflow belongs to a different app
         # Implicit single-entrypoint (backward-compat run() path)
         ep = next((e for e in app_meta.entry_points.values() if e.implicit), None)
         if ep is None and len(app_meta.entry_points) == 1:

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -276,6 +276,43 @@ async def _get_workflow_result(
     return {}
 
 
+def _resolve_output_type_for_workflow(workflow_type_name: str) -> type | None:
+    """Resolve the correct Output type for a workflow from its Temporal type name.
+
+    Temporal workflow type names are ``"app-name"`` for the implicit (single)
+    entry point and ``"app-name:entrypoint-name"`` for explicit named entry
+    points.  We parse the entry-point suffix, look it up in AppRegistry, and
+    return its declared ``output_type`` so the caller can pass it to
+    ``get_workflow_handle(result_type=…)`` for typed deserialisation.
+
+    Returns ``None`` when the entry point cannot be resolved (e.g. missing
+    registry entry, external workflow); the caller falls back to untyped
+    deserialisation via ``_get_workflow_result``'s own fallback path.
+    """
+    if _workflow_config.app_class is None:
+        return None
+    app_cls_name: str | None = getattr(_workflow_config.app_class, "_app_name", None)
+    if not app_cls_name:
+        return None
+
+    from application_sdk.app.registry import AppRegistry  # noqa: PLC0415
+
+    app_meta = AppRegistry.get_instance().get(app_cls_name)
+    if not app_meta:
+        return None
+
+    if ":" in workflow_type_name:
+        _, ep_name = workflow_type_name.split(":", 1)
+        ep = app_meta.entry_points.get(ep_name)
+    else:
+        # Implicit single-entrypoint (backward-compat run() path)
+        ep = next((e for e in app_meta.entry_points.values() if e.implicit), None)
+        if ep is None and len(app_meta.entry_points) == 1:
+            ep = next(iter(app_meta.entry_points.values()))
+
+    return ep.output_type if ep else None
+
+
 # ---------------------------------------------------------------------------
 # Workflow client config and singleton
 # ---------------------------------------------------------------------------
@@ -1067,9 +1104,8 @@ def create_app_handler_service(
 
             if wait:
                 try:
-                    output_type = getattr(
-                        _workflow_config.app_class, "_output_type", None
-                    )
+                    desc = await handle.describe()
+                    output_type = _resolve_output_type_for_workflow(desc.workflow_type)
                     result_data = await _get_workflow_result(
                         client, workflow_id=workflow_id, output_type=output_type
                     )
@@ -1136,9 +1172,7 @@ def create_app_handler_service(
                 )
             elif status == "COMPLETED":
                 try:
-                    output_type = getattr(
-                        _workflow_config.app_class, "_output_type", None
-                    )
+                    output_type = _resolve_output_type_for_workflow(desc.workflow_type)
                     result_data = await _get_workflow_result(
                         client, workflow_id=workflow_id, output_type=output_type
                     )

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -3265,6 +3265,8 @@ class TestGetResultMultiEntrypointOutputType:
         TaskRegistry.reset()
 
         class _MultiEpApp(App):
+            name = "multi-ep-test"
+
             @entrypoint
             async def alpha(self, input: _AlphaInput) -> _AlphaOutput:
                 return _AlphaOutput()

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -155,6 +155,25 @@ class _RoutingOutput(Output, allow_unbounded_fields=True):  # type: ignore[call-
     result: str = ""
 
 
+# Contracts for TestGetResultMultiEntrypointOutputType — must be at module
+# level because get_type_hints() resolves annotation strings against module
+# globals when 'from __future__ import annotations' is active.
+class _AlphaInput(Input, allow_unbounded_fields=True):  # type: ignore[call-arg]
+    pass
+
+
+class _AlphaOutput(Output, allow_unbounded_fields=True):  # type: ignore[call-arg]
+    alpha_field: str = ""
+
+
+class _BetaInput(Input, allow_unbounded_fields=True):  # type: ignore[call-arg]
+    pass
+
+
+class _BetaOutput(Output, allow_unbounded_fields=True):  # type: ignore[call-arg]
+    beta_field: str = ""
+
+
 # ---------------------------------------------------------------------------
 # Helper: create test client
 # ---------------------------------------------------------------------------
@@ -3123,7 +3142,10 @@ class TestGetResultEndpoint:
 
         try:
             svc = self._setup()
+            desc = MagicMock()
+            desc.workflow_type = "res-test"  # single implicit entrypoint
             mock_handle = MagicMock()
+            mock_handle.describe = AsyncMock(return_value=desc)
             mock_client = MagicMock()
             mock_client.get_workflow_handle = MagicMock(return_value=mock_handle)
             with (
@@ -3155,7 +3177,10 @@ class TestGetResultEndpoint:
 
         try:
             svc = self._setup()
+            desc = MagicMock()
+            desc.workflow_type = "res-test"
             mock_handle = MagicMock()
+            mock_handle.describe = AsyncMock(return_value=desc)
             mock_client = MagicMock()
             mock_client.get_workflow_handle = MagicMock(return_value=mock_handle)
             with (
@@ -3217,6 +3242,153 @@ class TestGetResultEndpoint:
         client = _make_client()
         response = client.get("/workflows/v1/status/wf-1/run-1")
         assert response.status_code == 503
+
+
+class TestGetResultMultiEntrypointOutputType:
+    """Regression: /result must resolve per-entrypoint output_type from
+    desc.workflow_type, not use the app's first-registered type or None.
+
+    Original bug: _output_type on the App class was set to the first entry
+    point's Output type (alphabetically via dir()), so any workflow that ran
+    a different entry point would be deserialised with the wrong schema.
+
+    The fix uses desc.workflow_type (e.g. "app-name:beta") to look up the
+    correct EntryPointMetadata and pass its output_type to _get_workflow_result.
+    """
+
+    def _setup(self):
+        from application_sdk.app.base import App
+        from application_sdk.app.entrypoint import entrypoint
+        from application_sdk.app.registry import AppRegistry, TaskRegistry
+
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+        class _MultiEpApp(App):
+            @entrypoint
+            async def alpha(self, input: _AlphaInput) -> _AlphaOutput:
+                return _AlphaOutput()
+
+            @entrypoint
+            async def beta(self, input: _BetaInput) -> _BetaOutput:
+                return _BetaOutput()
+
+        return create_app_handler_service(
+            _TestHandler(),
+            app_name="multi-ep-test",
+            app_class=_MultiEpApp,
+            temporal_host="temporal:7233",
+        )
+
+    def _teardown(self) -> None:
+        from application_sdk.app.registry import AppRegistry, TaskRegistry
+
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    @pytest.mark.parametrize(
+        "ep_name,expected_output_type",
+        [
+            ("alpha", _AlphaOutput),
+            ("beta", _BetaOutput),
+        ],
+    )
+    def test_result_completed_resolves_per_entrypoint_output_type(
+        self, ep_name: str, expected_output_type: type
+    ) -> None:
+        """Polling path: output_type passed to _get_workflow_result must match
+        the entrypoint encoded in desc.workflow_type, not the app's
+        first-registered type (_AlphaOutput) and not None."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        try:
+            svc = self._setup()
+
+            desc = MagicMock()
+            desc.status.name = "COMPLETED"
+            desc.workflow_type = f"multi-ep-test:{ep_name}"
+
+            mock_handle = MagicMock()
+            mock_handle.describe = AsyncMock(return_value=desc)
+            mock_client = MagicMock()
+            mock_client.get_workflow_handle = MagicMock(return_value=mock_handle)
+
+            captured: list[type | None] = []
+
+            async def _spy(client, *, workflow_id, output_type):
+                captured.append(output_type)
+                return {"result_field": "ok"}
+
+            with (
+                patch(
+                    "application_sdk.handler.service._get_temporal_client",
+                    new=AsyncMock(return_value=mock_client),
+                ),
+                patch(
+                    "application_sdk.handler.service._get_workflow_result",
+                    side_effect=_spy,
+                ),
+            ):
+                client = TestClient(svc)
+                response = client.get(f"/workflows/v1/result/wf-{ep_name}")
+
+            assert response.status_code == 200
+            assert len(captured) == 1
+            assert captured[0] is expected_output_type, (
+                f"For entrypoint {ep_name!r} expected output_type="
+                f"{expected_output_type.__name__!r}, got {captured[0]!r}. "
+                "The /result endpoint must resolve per-entrypoint output_type "
+                "from desc.workflow_type, not use the app-level first-registered "
+                "type or None."
+            )
+        finally:
+            self._teardown()
+
+    def test_result_wait_resolves_per_entrypoint_output_type(self) -> None:
+        """wait=True path: describe() must be called to obtain workflow_type
+        so the correct output_type can be resolved before waiting."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        try:
+            svc = self._setup()
+
+            desc = MagicMock()
+            desc.workflow_type = "multi-ep-test:beta"
+
+            mock_handle = MagicMock()
+            mock_handle.describe = AsyncMock(return_value=desc)
+            mock_client = MagicMock()
+            mock_client.get_workflow_handle = MagicMock(return_value=mock_handle)
+
+            captured: list[type | None] = []
+
+            async def _spy(client, *, workflow_id, output_type):
+                captured.append(output_type)
+                return {"result_field": "ok"}
+
+            with (
+                patch(
+                    "application_sdk.handler.service._get_temporal_client",
+                    new=AsyncMock(return_value=mock_client),
+                ),
+                patch(
+                    "application_sdk.handler.service._get_workflow_result",
+                    side_effect=_spy,
+                ),
+            ):
+                client = TestClient(svc)
+                response = client.get("/workflows/v1/result/wf-beta-wait?wait=true")
+
+            assert response.status_code == 200
+            assert len(captured) == 1
+            assert captured[0] is _BetaOutput, (
+                f"For wait=True + 'beta' entrypoint expected output_type=_BetaOutput, "
+                f"got {captured[0]!r}. "
+                "The wait=True path must call describe() and resolve output_type "
+                "from desc.workflow_type."
+            )
+        finally:
+            self._teardown()
 
 
 class TestStartWorkflowExtras:

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -3958,7 +3958,7 @@ class TestWorkflowClientConfig:
         class _Cls:
             pass
 
-        cfg = WorkflowClientConfig(host="t:7233", app_class=_Cls)  # type: ignore[arg-type]
+        cfg = WorkflowClientConfig(host="t:7233", app_class=_Cls, app_name="test-app")  # type: ignore[arg-type]
         assert cfg.is_configured() is True
 
 


### PR DESCRIPTION
## Summary

- `/result` endpoint was deserialising completed workflows using `_output_type` from the App class, which is always bound to the **first** entry point's Output type (alphabetical, via `dir()`). For multi-entrypoint apps this silently dropped fields from any workflow that ran a different entry point.
- A prior workaround switched to `output_type=None` (untyped) for all multi-entrypoint apps — preserving fields but losing typed deserialisation entirely.
- This fix adds `_resolve_output_type_for_workflow()`, which reads `desc.workflow_type` (e.g. `"app-name:entrypoint-name"`), looks up the matching `EntryPointMetadata` in `AppRegistry`, and returns its declared `output_type`. Both the polling (`COMPLETED`) and `wait=True` paths now use this helper. The `wait=True` path gains a `describe()` call to retrieve the workflow type before waiting for the result.

## Test plan

- [ ] `TestGetResultMultiEntrypointOutputType` — three new regression tests assert the exact `output_type` passed to `_get_workflow_result` matches the entry point that ran, for both alpha/beta entry points and both the polling and `wait=True` paths. These tests failed against the prior code (got `None`) and pass with this fix.
- [ ] All existing `TestGetResultEndpoint` and `TestGetWorkflowResultHelper` tests continue to pass (two existing `wait=True` tests updated to supply `desc.workflow_type` on their mock handle, which the new code requires).
- [ ] Full unit suite: 4513 passed, 8 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)