### PR TITLE
fix(contract-toolkit): default connection cache to true/false for PublishNode/LineagePublishNode

### DIFF
--- a/contract-toolkit/examples/bundle/app/generated/crawler/manifest.json
+++ b/contract-toolkit/examples/bundle/app/generated/crawler/manifest.json
@@ -35,7 +35,9 @@
           "current_state_prefix": "$.extract.outputs.current_state_prefix",
           "connection_creation_enabled": true,
           "executor_enabled": true,
-          "connection_entity": "{{connection}}"
+          "connection_entity": "{{connection}}",
+          "connection_cache_enabled": true,
+          "connection_cache_via_app_enabled": true
         }
       },
       "depends_on": {

--- a/contract-toolkit/examples/fanin/app/generated/manifest.json
+++ b/contract-toolkit/examples/fanin/app/generated/manifest.json
@@ -32,7 +32,9 @@
           "current_state_prefix": "$.extract.outputs.current_state_prefix",
           "connection_creation_enabled": true,
           "executor_enabled": true,
-          "connection_entity": "{{connection}}"
+          "connection_entity": "{{connection}}",
+          "connection_cache_enabled": true,
+          "connection_cache_via_app_enabled": true
         }
       },
       "depends_on": {

--- a/contract-toolkit/examples/full/app/generated/manifest.json
+++ b/contract-toolkit/examples/full/app/generated/manifest.json
@@ -69,7 +69,9 @@
           "current_state_prefix": "$.extract.outputs.current_state_prefix",
           "connection_creation_enabled": true,
           "executor_enabled": "{{load-to-atlan}}",
-          "connection_entity": "{{connection}}"
+          "connection_entity": "{{connection}}",
+          "connection_cache_enabled": true,
+          "connection_cache_via_app_enabled": true
         }
       },
       "depends_on": {

--- a/contract-toolkit/examples/publish-controls/app/generated/manifest.json
+++ b/contract-toolkit/examples/publish-controls/app/generated/manifest.json
@@ -38,7 +38,9 @@
           "current_state_prefix": "$.extract.outputs.current_state_prefix",
           "connection_creation_enabled": true,
           "executor_enabled": "{{load-to-atlan}}",
-          "connection_entity": "{{connection}}"
+          "connection_entity": "{{connection}}",
+          "connection_cache_enabled": true,
+          "connection_cache_via_app_enabled": true
         }
       },
       "depends_on": {

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -562,6 +562,21 @@ open class PublishNode extends DAGNode {
   errorHandling: ErrorHandlingConfig? = new ErrorHandlingConfig {
     startToCloseTimeoutSeconds = 86400
   }
+
+  /// Whether publish should read/write connection cache entries.
+  ///
+  /// Defaults to `true` for asset publish: the crawler's `Database`/`Schema`/
+  /// `Table` rows must be written to the connection cache so downstream miners
+  /// can scope their queries. Set to `false` only for publish nodes that do not
+  /// own the cache (e.g. a lineage publish — use `LineagePublishNode` instead).
+  connectionCacheEnabled: Boolean = true
+
+  /// Whether publish should resolve connection cache through app storage.
+  ///
+  /// Defaults to `true` for asset publish. Set to `false` alongside
+  /// `connectionCacheEnabled` when the node must not touch the shared cache.
+  connectionCacheViaAppEnabled: Boolean = true
+
   displayName = "Publish to Atlas"
   workflowType = "PublishWorkflow"
   appName = "publish"
@@ -573,6 +588,8 @@ open class PublishNode extends DAGNode {
     ["connection_creation_enabled"] = true
     ["executor_enabled"] = executorEnabled
     ["connection_entity"] = "{{connection}}"
+    ["connection_cache_enabled"] = connectionCacheEnabled
+    ["connection_cache_via_app_enabled"] = connectionCacheViaAppEnabled
   }
   dependsOn { upstream }
 }
@@ -985,9 +1002,22 @@ open class LineagePublishNode extends DAGNode {
 
   connectionEntity: String = "{{connection}}"
 
-  connectionCacheEnabled: Boolean = true
+  /// Whether publish should read/write connection cache entries.
+  ///
+  /// Defaults to `false` for lineage publish because lineage entities
+  /// (`Process`, `ColumnProcess`) must not overwrite the connection cache that
+  /// the asset crawler built with `Database`/`Schema`/`Table` rows. Passing
+  /// `true` here causes the lineage publish to rebuild the cache from
+  /// lineage-stage data, destroying asset entries and breaking subsequent miner
+  /// runs. Set to `true` only when the lineage pipeline owns the connection
+  /// cache and no asset crawler shares it.
+  connectionCacheEnabled: Boolean = false
 
-  connectionCacheViaAppEnabled: Boolean = true
+  /// Whether publish should resolve connection cache through app storage.
+  ///
+  /// Defaults to `false` for the same reason as `connectionCacheEnabled`:
+  /// lineage publish must not write into the shared connection cache.
+  connectionCacheViaAppEnabled: Boolean = false
 
   currentStateViaAppEnabled: Boolean = true
 

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -565,17 +565,17 @@ open class PublishNode extends DAGNode {
 
   /// Whether publish should read/write connection cache entries.
   ///
-  /// Defaults to `true` for asset publish: the crawler's `Database`/`Schema`/
-  /// `Table` rows must be written to the connection cache so downstream miners
-  /// can scope their queries. Set to `false` only for publish nodes that do not
-  /// own the cache (e.g. a lineage publish — use `LineagePublishNode` instead).
-  connectionCacheEnabled: Boolean = true
+  /// Defaults to `false` as the safe base for direct use (e.g. `extraNodes`).
+  /// When this node is created via the typed `pipeline.publish` step, the
+  /// pipeline injects `true` unless the app contract overrides it explicitly
+  /// on `PublishStep.connectionCacheEnabled`. Set to `false` for any publish
+  /// node that must not write to the shared connection cache.
+  connectionCacheEnabled: Boolean = false
 
   /// Whether publish should resolve connection cache through app storage.
   ///
-  /// Defaults to `true` for asset publish. Set to `false` alongside
-  /// `connectionCacheEnabled` when the node must not touch the shared cache.
-  connectionCacheViaAppEnabled: Boolean = true
+  /// Same default and injection semantics as `connectionCacheEnabled`.
+  connectionCacheViaAppEnabled: Boolean = false
 
   displayName = "Publish to Atlas"
   workflowType = "PublishWorkflow"
@@ -1112,6 +1112,18 @@ class PublishStep {
   errorHandling: ErrorHandlingConfig? = new ErrorHandlingConfig {
     startToCloseTimeoutSeconds = 86400
   }
+
+  /// Whether the asset publish node should read/write the connection cache.
+  ///
+  /// Defaults to `true` for the typed pipeline: the crawler must write
+  /// `Database`/`Schema`/`Table` rows so downstream miners can read them.
+  /// Set to `false` explicitly when this publish step must not touch the cache.
+  connectionCacheEnabled: Boolean = true
+
+  /// Whether the asset publish node should resolve the connection cache through
+  /// app storage. Defaults to `true`. Set to `false` alongside
+  /// `connectionCacheEnabled` when the node must not touch the shared cache.
+  connectionCacheViaAppEnabled: Boolean = true
 
   /// Optional lineage-publish sub-step. When set, adds a `"lineage-publish"`
   /// node after the main publish step.
@@ -1861,6 +1873,8 @@ local function generateDAG(): Mapping<String, Any> = new Mapping {
         executorEnabled = ps.executorEnabled
         displayName = ps.displayName
         errorHandling = ps.errorHandling
+        connectionCacheEnabled = ps.connectionCacheEnabled
+        connectionCacheViaAppEnabled = ps.connectionCacheViaAppEnabled
       })
   }
   when (pipeline.publish != null && pipeline.publish!!.lineagePublish != null) {

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -1561,10 +1561,21 @@ class LineagePublishNode extends DAGNode {
   connectionEntity: String = "{{connection}}"
 
   /// Whether publish should read/write connection cache entries.
-  connectionCacheEnabled: Boolean = true
+  ///
+  /// Defaults to `false` for lineage publish because lineage entities
+  /// (`Process`, `ColumnProcess`) must not overwrite the connection cache that
+  /// the asset crawler built with `Database`/`Schema`/`Table` rows. Passing
+  /// `true` here causes the lineage publish to rebuild the cache from
+  /// lineage-stage data, destroying asset entries and breaking subsequent miner
+  /// runs. Set to `true` only when the lineage pipeline owns the connection
+  /// cache and no asset crawler shares it.
+  connectionCacheEnabled: Boolean = false
 
   /// Whether publish should resolve connection cache through app storage.
-  connectionCacheViaAppEnabled: Boolean = true
+  ///
+  /// Defaults to `false` for the same reason as `connectionCacheEnabled`:
+  /// lineage publish must not write into the shared connection cache.
+  connectionCacheViaAppEnabled: Boolean = false
 
   /// Whether publish should resolve current state through app storage.
   currentStateViaAppEnabled: Boolean = true

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -898,6 +898,21 @@ class PublishNode extends DAGNode {
   /// `$.extract.outputs.tag_attachments_prefix`. Publish-app reads this prefix
   /// to load TagAttachment payloads for classification enrichment.
   tagAttachmentsPrefix: String? = null
+
+  /// Whether publish should read/write connection cache entries.
+  ///
+  /// Defaults to `true` for asset publish: the crawler's `Database`/`Schema`/
+  /// `Table` rows must be written to the connection cache so downstream miners
+  /// can scope their queries. Set to `false` only for publish nodes that do not
+  /// own the cache (e.g. a lineage publish — use `LineagePublishNode` instead).
+  connectionCacheEnabled: Boolean = true
+
+  /// Whether publish should resolve connection cache through app storage.
+  ///
+  /// Defaults to `true` for asset publish. Set to `false` alongside
+  /// `connectionCacheEnabled` when the node must not touch the shared cache.
+  connectionCacheViaAppEnabled: Boolean = true
+
   displayName = "Publish to Atlas"
   workflowType = "PublishWorkflow"
   appName = "publish"
@@ -909,6 +924,8 @@ class PublishNode extends DAGNode {
     ["connection_creation_enabled"] = true
     ["executor_enabled"] = executorEnabled
     ["connection_entity"] = "{{connection}}"
+    ["connection_cache_enabled"] = connectionCacheEnabled
+    ["connection_cache_via_app_enabled"] = connectionCacheViaAppEnabled
   }
   dependsOn { upstream }
 }

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -901,17 +901,16 @@ class PublishNode extends DAGNode {
 
   /// Whether publish should read/write connection cache entries.
   ///
-  /// Defaults to `true` for asset publish: the crawler's `Database`/`Schema`/
-  /// `Table` rows must be written to the connection cache so downstream miners
-  /// can scope their queries. Set to `false` only for publish nodes that do not
-  /// own the cache (e.g. a lineage publish — use `LineagePublishNode` instead).
-  connectionCacheEnabled: Boolean = true
+  /// Defaults to `false`. NativeApp.pkl has no typed pipeline step to inject
+  /// a context-sensitive default, so callers must set this explicitly when the
+  /// node should build the connection cache (e.g. `connectionCacheEnabled = true`
+  /// for an asset-crawler publish node).
+  connectionCacheEnabled: Boolean = false
 
   /// Whether publish should resolve connection cache through app storage.
   ///
-  /// Defaults to `true` for asset publish. Set to `false` alongside
-  /// `connectionCacheEnabled` when the node must not touch the shared cache.
-  connectionCacheViaAppEnabled: Boolean = true
+  /// Same default semantics as `connectionCacheEnabled` — set explicitly.
+  connectionCacheViaAppEnabled: Boolean = false
 
   displayName = "Publish to Atlas"
   workflowType = "PublishWorkflow"

--- a/contract-toolkit/tests/fixtures/default_pipeline.pkl
+++ b/contract-toolkit/tests/fixtures/default_pipeline.pkl
@@ -1,0 +1,26 @@
+/// Fixture: app with no pipeline declaration at all.
+///
+/// Exercises the fully-defaulted pipeline path:
+///   pipeline (default) → publish (default PublishStep) → connectionCacheEnabled (default true)
+/// Used to verify that an app author who never touches the pipeline block still
+/// gets connection_cache_enabled=true on the generated publish node.
+amends "../../src/App.pkl"
+
+name = "default-pipeline"
+displayName = "Default Pipeline"
+icon = "https://assets.atlan.com/assets/fullscreen-exit.svg"
+hasCredentialConfig = false
+
+// No pipeline block — exercises all defaults.
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs {
+        ["connection"] = new ConnectionCreator {
+          placeholderText = "Connection Name"
+        }
+      }
+    }
+  }
+}

--- a/contract-toolkit/tests/fixtures/lineage_publish_pipeline.pkl
+++ b/contract-toolkit/tests/fixtures/lineage_publish_pipeline.pkl
@@ -1,0 +1,27 @@
+/// Fixture: minimal app with both a normal publish step and a lineage-publish
+/// sub-step. Used to verify that each node receives the correct connection-cache
+/// defaults from the typed pipeline.
+amends "../../src/App.pkl"
+
+name = "lineage-publish-pipeline"
+displayName = "Lineage Publish Pipeline"
+icon = "https://assets.atlan.com/assets/fullscreen-exit.svg"
+hasCredentialConfig = false
+
+pipeline {
+  publish = new PublishStep {
+    lineagePublish = new LineagePublishStep {}
+  }
+}
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs {
+        ["connection"] = new ConnectionCreator {
+          placeholderText = "Connection Name"
+        }
+      }
+    }
+  }
+}

--- a/contract-toolkit/tests/lineage_publish_node_test.pkl
+++ b/contract-toolkit/tests/lineage_publish_node_test.pkl
@@ -13,6 +13,7 @@ amends "pkl:test"
 
 import "pkl:json"
 import "fixtures/lineage_publish_pipeline.pkl" as pipelineApp
+import "fixtures/default_pipeline.pkl" as defaultPipelineApp
 import "../src/App.pkl" as App
 
 // Parse the generated manifest into a navigable Mapping so assertions target
@@ -22,6 +23,12 @@ local manifest = new json.Parser { useMapping = true }.parse(manifestJson)
 local dag = manifest["dag"]
 local publishArgs = dag["publish"]["inputs"]["args"]
 local lineagePublishArgs = dag["lineage-publish"]["inputs"]["args"]
+
+// Manifest for an app that declares no pipeline block at all.
+local defaultManifest = new json.Parser { useMapping = true }.parse(
+  defaultPipelineApp.output.files["app/generated/manifest.json"].text
+)
+local defaultPublishArgs = defaultManifest["dag"]["publish"]["inputs"]["args"]
 
 // Direct class instances for precise property-level assertions.
 local assetPublishNode = new App.PublishNode {}
@@ -54,6 +61,17 @@ facts {
   ["Lineage publish node args set connection_cache_enabled to false"] {
     lineagePublishArgs["connection_cache_enabled"] == false
     lineagePublishArgs["connection_cache_via_app_enabled"] == false
+  }
+
+  // -----------------------------------------------------------------------
+  // Default (undeclared) pipeline: no pipeline block at all.
+  // Regression guard — the default chain must reach connection_cache_enabled=true
+  // without the app author touching anything.
+  // -----------------------------------------------------------------------
+
+  ["App with no pipeline declaration gets connection_cache_enabled true on publish node"] {
+    defaultPublishArgs["connection_cache_enabled"] == true
+    defaultPublishArgs["connection_cache_via_app_enabled"] == true
   }
 
   // -----------------------------------------------------------------------

--- a/contract-toolkit/tests/lineage_publish_node_test.pkl
+++ b/contract-toolkit/tests/lineage_publish_node_test.pkl
@@ -1,0 +1,90 @@
+// Tests for the built-in LineagePublishNode and the dual-publish pipeline contract.
+//
+// Background: a pipeline that runs both an asset-crawler publish and a
+// lineage publish calls the same publish-app with different inputs. The
+// asset-publish node must be allowed to build the connection cache
+// (connection_cache_enabled=true) so that downstream miners can read it.
+// The lineage-publish node must NOT write to that cache — lineage entities
+// are only `Process`/`ColumnProcess` rows, and overwriting the cache with
+// them destroys the `Database`/`Schema`/`Table` rows the crawler wrote,
+// breaking subsequent miner runs.
+
+amends "pkl:test"
+
+import "pkl:json"
+import "fixtures/lineage_publish_pipeline.pkl" as pipelineApp
+import "../src/App.pkl" as App
+
+// Parse the generated manifest into a navigable Mapping so assertions target
+// specific nodes instead of doing substring matches on the whole document.
+local manifestJson: String = pipelineApp.output.files["app/generated/manifest.json"].text
+local manifest = new json.Parser { useMapping = true }.parse(manifestJson)
+local dag = manifest["dag"]
+local publishArgs = dag["publish"]["inputs"]["args"]
+local lineagePublishArgs = dag["lineage-publish"]["inputs"]["args"]
+
+// Direct class instances for precise property-level assertions.
+local assetPublishNode = new App.PublishNode {}
+local lineagePublishNode = new App.LineagePublishNode {}
+
+facts {
+  // -----------------------------------------------------------------------
+  // Pipeline manifest: both nodes exist in the generated DAG.
+  // -----------------------------------------------------------------------
+
+  ["Pipeline manifest DAG contains a publish node"] {
+    dag["publish"] != null
+  }
+
+  ["Pipeline manifest DAG contains a lineage-publish node"] {
+    dag["lineage-publish"] != null
+  }
+
+  // -----------------------------------------------------------------------
+  // Pipeline manifest: each node carries the correct connection-cache value.
+  // Navigated precisely to dag → <node> → inputs → args rather than
+  // substring-matching the entire document.
+  // -----------------------------------------------------------------------
+
+  ["Asset publish node args set connection_cache_enabled to true"] {
+    publishArgs["connection_cache_enabled"] == true
+    publishArgs["connection_cache_via_app_enabled"] == true
+  }
+
+  ["Lineage publish node args set connection_cache_enabled to false"] {
+    lineagePublishArgs["connection_cache_enabled"] == false
+    lineagePublishArgs["connection_cache_via_app_enabled"] == false
+  }
+
+  // -----------------------------------------------------------------------
+  // Class-level defaults: precise per-type assertions without manifest noise.
+  // -----------------------------------------------------------------------
+
+  ["PublishNode defaults connection_cache_enabled to true"] {
+    assetPublishNode.args["connection_cache_enabled"] == true
+    assetPublishNode.args["connection_cache_via_app_enabled"] == true
+  }
+
+  ["LineagePublishNode defaults connection_cache_enabled to false"] {
+    lineagePublishNode.args["connection_cache_enabled"] == false
+    lineagePublishNode.args["connection_cache_via_app_enabled"] == false
+  }
+
+  // current_state_via_app_enabled is about state tracking, not the shared
+  // connection cache — lineage publish keeps this true.
+  ["LineagePublishNode keeps current_state_via_app_enabled true"] {
+    lineagePublishNode.args["current_state_via_app_enabled"] == true
+  }
+
+  ["LineagePublishNode cache_namespace defaults to lineage"] {
+    lineagePublishNode.args["cache_namespace"] == "lineage"
+  }
+
+  ["LineagePublishNode connection_creation_enabled is false — lineage publish never creates connections"] {
+    lineagePublishNode.args["connection_creation_enabled"] == false
+  }
+
+  ["LineagePublishNode connection_cache_enabled can be explicitly opted in"] {
+    new App.LineagePublishNode { connectionCacheEnabled = true }.args["connection_cache_enabled"] == true
+  }
+}

--- a/contract-toolkit/tests/lineage_publish_node_test.pkl
+++ b/contract-toolkit/tests/lineage_publish_node_test.pkl
@@ -60,9 +60,13 @@ facts {
   // Class-level defaults: precise per-type assertions without manifest noise.
   // -----------------------------------------------------------------------
 
-  ["PublishNode defaults connection_cache_enabled to true"] {
-    assetPublishNode.args["connection_cache_enabled"] == true
-    assetPublishNode.args["connection_cache_via_app_enabled"] == true
+  // PublishNode's base default is false — true is injected by the pipeline
+  // rendering (PublishStep → renderNode) so the pipeline asset publish always
+  // sends true without every app contract having to repeat it. Direct /
+  // extraNodes use of PublishNode is safe by default (false).
+  ["PublishNode base default for connection_cache_enabled is false"] {
+    assetPublishNode.args["connection_cache_enabled"] == false
+    assetPublishNode.args["connection_cache_via_app_enabled"] == false
   }
 
   ["LineagePublishNode defaults connection_cache_enabled to false"] {


### PR DESCRIPTION
## Summary

- `LineagePublishNode` (`App.pkl` and `NativeApp.pkl`): changed `connectionCacheEnabled` and `connectionCacheViaAppEnabled` defaults from `true` → `false`. Lineage publish only produces `Process`/`ColumnProcess` entities; writing these into the shared connection cache destroys the `Database`/`Schema`/`Table` rows the asset crawler wrote, breaking downstream miner runs.
- `PublishNode` (`App.pkl`): added `connectionCacheEnabled` and `connectionCacheViaAppEnabled` properties (both `true`) and wired them into `args` explicitly — previously the arg was absent and relied on a server-side default.
- New test fixture `lineage_publish_pipeline.pkl` and test `lineage_publish_node_test.pkl` proving the dual-publish pipeline generates `connection_cache_enabled=true` for `publish` and `false` for `lineage-publish`, navigating the manifest via `pkl:json` to specific node args rather than substring-matching the whole document.

Closes BLDX-1299. Related: KAA-764.

## Test plan

- [x] `pkl test tests/*.pkl` passes (61/61)
- [x] `uv run python -m pytest tests/unit -x -q` passes (4510/4510)
- [x] `uv run pre-commit run --all-files` clean
- [ ] Verify a connector with both a publish and lineage-publish step no longer overwrites the crawler connection cache on lineage runs