### PR TITLE
fix(ci): make unit-tests gate poll tolerant of transient API errors

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -312,8 +312,26 @@ jobs:
           # Loop bound covers the 30-min job timeout. The job-level
           # timeout-minutes already enforces an outer cap; this inner cap
           # avoids tight infinite loops if `gh run view` ever returns junk.
+          #
+          # Tolerate transient API errors (401/5xx/network blips) — a single
+          # failed `gh run view` should not fail the whole gate. Retry within
+          # the iteration with short backoff; on exhausted retries, log and
+          # continue to the next outer tick rather than killing publish.
           for i in $(seq 1 70); do
-            RESULT=$(gh run view "${RUN_ID}" --repo "${REPO}" --json status,conclusion,url)
+            RESULT=""
+            for attempt in 1 2 3; do
+              if RESULT=$(gh run view "${RUN_ID}" --repo "${REPO}" --json status,conclusion,url 2>&1); then
+                break
+              fi
+              echo "  iteration ${i} attempt ${attempt}/3: gh run view failed: ${RESULT}"
+              RESULT=""
+              sleep 5
+            done
+            if [ -z "${RESULT}" ]; then
+              echo "  iteration ${i}: API unreachable after 3 retries — will retry next tick"
+              sleep 25
+              continue
+            fi
             STATUS=$(echo "${RESULT}" | jq -r '.status')
             CONCLUSION=$(echo "${RESULT}" | jq -r '.conclusion // ""')
             URL=$(echo "${RESULT}" | jq -r '.url')


### PR DESCRIPTION
## Summary

Make the \`unit-tests-gate\` poller resilient to transient GitHub API errors so a single \`gh run view\` hiccup doesn't kill publish on a passing test.

## Problem

The poller has \`set -euo pipefail\` and runs \`gh run view\` once per 25s iteration. Any non-zero exit — 401 \"Bad credentials\", 5xx, transient network blip — kills the whole step. Worse, the warn-only safety net at the next step (\`if: steps.wait.outputs.conclusion != 'success'\`) doesn't fire when the wait step itself errors out, so all downstream publish jobs cascade-skip via their \`!failure()\` guards. Result: warn-only mode silently becomes fail-closed on infra blips.

### Real incident

Run [\`atlanhq/atlan-databricks-app/actions/runs/26329578246\`](https://github.com/atlanhq/atlan-databricks-app/actions/runs/26329578246):

| Time (UTC) | Event |
|---|---|
| 09:45:35 | gate starts |
| 09:45:37 | dispatches \`unit-tests.yml\` → \`RUN_ID=26329580954\` |
| 09:45:43 | poll iter 1 — \`in_progress\` |
| 09:46:08 | poll iter 2 — \`in_progress\` |
| 09:46:34 | poll iter 3 — \`in_progress\` |
| 09:46:59 | **poll iter 4 — HTTP 401 Bad credentials on \`actions/workflows/239199404\`** → step exits 1 → all publish jobs skipped |
| ~09:46:50 | meanwhile, the dispatched unit-tests run [\`26329580954\`](https://github.com/atlanhq/atlan-databricks-app/actions/runs/26329580954) **succeeded** ✓ in 1m7s |

Tests passed; the gate blocked publish on a one-off API blip.

## Fix

Wrap \`gh run view\` in a 3-attempt retry with 5s backoff inside each polling iteration. If all retries fail in one iteration, log and \`continue\` to the next 25s tick rather than failing the step. The 30-minute outer cap (\`for i in \$(seq 1 70)\`) is unchanged, so eternal API outages still time out cleanly.

## Test plan

- [ ] Existing gate runs (no transient) still complete in roughly the same wall-clock time
- [ ] Inject a transient by temporarily exporting an invalid \`GH_TOKEN\` for one iteration locally; confirm the poller logs the retry exhaustion, sleeps 25s, and recovers on the next tick instead of failing
- [ ] Run [\`atlan-databricks-app\` build-and-publish](https://github.com/atlanhq/atlan-databricks-app/actions/workflows/build-and-publish.yaml) against this branch (pin caller \`uses:\` to this PR's SHA) and confirm gate behavior unchanged on the happy path

## Follow-ups (not in this PR)

The broader warn-only semantic issue still stands: even with this retry, an exhausted-retry exit \`1\` would still cascade-skip publish. Worth a separate change to either (a) write \`conclusion=unknown\` on retry exhaustion and \`exit 0\`, letting the warn-only annotate step decide, or (b) change the warn-only step's \`if:\` to \`always()\` and tighten downstream \`needs:\` conditions. Punting that to a follow-up so this fix is small and focused.