### PR TITLE
fix(observability): enrich stdlib-bridge logs with app_name & context (BLDX-1297)

### DIFF
--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -267,6 +267,68 @@ _LOGRECORD_RESERVED_ATTRS: frozenset[str] = frozenset(
 )
 
 
+def _apply_atlan_context(kwargs: dict[str, Any], *, prefer_caller: bool) -> None:
+    """Inject request / workflow / correlation context into log ``kwargs``.
+
+    Called by both :meth:`AtlanLoggerAdapter.process` (the SDK-adapter path)
+    and :meth:`InterceptHandler.emit` (the stdlib-bridge path) so that every
+    log record — SDK-emitted or stdlib / third-party — carries the same Atlan
+    context fields (``app_name``, ``request_id``, workflow / activity context,
+    ``trace_id`` / ``correlation_id``, ``atlan-`` / ``temporal.`` / ``tenant.``
+    prefixed headers).
+
+    Args:
+        kwargs: Mutable dict of log kwargs (these become loguru ``extra``).
+        prefer_caller: If ``True``, only fill keys that aren't already present —
+            caller-supplied ``extra={...}`` wins over auto-injection. Used by
+            the stdlib-bridge path. If ``False``, overwrite existing keys —
+            the legacy SDK-adapter behaviour.
+    """
+    assign = kwargs.setdefault if prefer_caller else kwargs.__setitem__
+
+    ctx = request_context.get()
+    if ctx and "request_id" in ctx:
+        assign("request_id", ctx["request_id"])
+
+    workflow_context = get_workflow_context()
+    if (
+        workflow_context.get("in_workflow") == "true"
+        or workflow_context.get("in_activity") == "true"
+    ):
+        if prefer_caller:
+            for k, v in workflow_context.items():
+                kwargs.setdefault(k, v)
+        else:
+            kwargs.update(workflow_context)
+
+    # Add correlation context (atlan-, temporal., tenant. prefixed keys,
+    # trace_id, correlation_id) to kwargs.
+    corr_ctx = correlation_context.get()
+    if corr_ctx:
+        if corr_ctx.get("trace_id"):
+            assign("trace_id", str(corr_ctx["trace_id"]))
+        if corr_ctx.get("correlation_id"):
+            assign("correlation_id", str(corr_ctx["correlation_id"]))
+        for key, value in corr_ctx.items():
+            if key.startswith(("atlan-", "temporal.", "tenant.")) and value:
+                if isinstance(value, (bool, int, float, str, bytes)):
+                    assign(key, value)
+                else:
+                    assign(key, str(value))
+
+    # Bridge: if legacy correlation_context dict didn't supply correlation_id,
+    # read from v3 CorrelationContext ContextVar (set by the v3
+    # CorrelationContextInterceptor).
+    if "correlation_id" not in kwargs:
+        from application_sdk.observability.correlation import (  # noqa: PLC0415 — circular: observability is imported transitively by many modules; lifting risks circles
+            get_correlation_context,
+        )
+
+        v3_ctx = get_correlation_context()
+        if v3_ctx and v3_ctx.correlation_id:
+            kwargs["correlation_id"] = v3_ctx.correlation_id
+
+
 class InterceptHandler(logging.Handler):
     """Bridge Python's stdlib logging into loguru, preserving ``extra={...}``.
 
@@ -298,7 +360,7 @@ class InterceptHandler(logging.Handler):
         # Forward caller-supplied ``extra={...}``. Python's stdlib spreads
         # ``extra`` directly into ``record.__dict__``; the delta vs. a blank
         # LogRecord is exactly what the caller passed.
-        logger_extras: dict[str, object] = {
+        logger_extras: dict[str, Any] = {
             k: v
             for k, v in record.__dict__.items()
             if k not in _LOGRECORD_RESERVED_ATTRS
@@ -306,6 +368,13 @@ class InterceptHandler(logging.Handler):
         # SDK convention: ``logger_name`` always tracks ``record.name``.
         # Set last so callers can't shadow it via ``extra``.
         logger_extras["logger_name"] = record.name
+        # Mirror :meth:`AtlanLoggerAdapter.process` enrichment so stdlib /
+        # third-party log records (httpx, boto3, ``logging.getLogger(__name__)``)
+        # carry the same Atlan context as SDK-adapter records. ``prefer_caller``
+        # / ``setdefault`` preserves any field the caller explicitly set via
+        # ``extra={"app_name": "X", ...}``.
+        logger_extras.setdefault("app_name", APPLICATION_NAME)
+        _apply_atlan_context(logger_extras, prefer_caller=True)
 
         logger.opt(depth=depth, exception=record.exc_info).bind(**logger_extras).log(
             level, record.getMessage()
@@ -719,52 +788,11 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
         """
         kwargs["logger_name"] = self.logger_name
         kwargs["app_name"] = APPLICATION_NAME
-
-        # Get request context
-        ctx = request_context.get()
-        if ctx and "request_id" in ctx:
-            kwargs["request_id"] = ctx["request_id"]
-
-        workflow_context = get_workflow_context()
-
-        if (
-            workflow_context.get("in_workflow") == "true"
-            or workflow_context.get("in_activity") == "true"
-        ):
-            kwargs.update(workflow_context)
-
-        # Add correlation context (atlan-, temporal., tenant. prefixed keys, trace_id, correlation_id) to kwargs
-        corr_ctx = correlation_context.get()
-        if corr_ctx:
-            # Add trace_id if present (for log format display)
-            if corr_ctx.get("trace_id"):
-                kwargs["trace_id"] = str(corr_ctx["trace_id"])
-            # Add correlation_id if present (AppWorkflowRun GUID for e2e correlation)
-            if corr_ctx.get("correlation_id"):
-                kwargs["correlation_id"] = str(corr_ctx["correlation_id"])
-            # Add atlan-* headers for OTEL
-            for key, value in corr_ctx.items():
-                if (
-                    key.startswith("atlan-")
-                    or key.startswith("temporal.")
-                    or key.startswith("tenant.")
-                ) and value:
-                    if isinstance(value, (bool, int, float, str, bytes)):
-                        kwargs[key] = value
-                    else:
-                        kwargs[key] = str(value)
-
-        # Bridge: if legacy correlation_context dict is empty, read from v3
-        # CorrelationContext ContextVar (set by the v3 CorrelationContextInterceptor).
-        if "correlation_id" not in kwargs:
-            from application_sdk.observability.correlation import (  # noqa: PLC0415 — circular: observability is imported transitively by many modules; lifting risks circles
-                get_correlation_context,
-            )
-
-            v3_ctx = get_correlation_context()
-            if v3_ctx and v3_ctx.correlation_id:
-                kwargs["correlation_id"] = v3_ctx.correlation_id
-
+        # Enrichment is shared with :class:`InterceptHandler` so stdlib-bridged
+        # records carry the same Atlan context; see :func:`_apply_atlan_context`.
+        # ``prefer_caller=False`` preserves the historic SDK-adapter behaviour
+        # of overwriting any caller-supplied value with the live context.
+        _apply_atlan_context(kwargs, prefer_caller=False)
         return msg, kwargs
 
     def debug(self, msg: str, *args: Any, **kwargs: Any):

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -3,6 +3,7 @@ import warnings
 from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import datetime
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -1814,12 +1815,19 @@ class TestInterceptHandlerStdlibBridge:
         bind_kwargs = mock_log.opt.return_value.bind.call_args.kwargs
         assert bind_kwargs["logger_name"] == "real_logger"
 
-    def test_record_with_no_extras_only_forwards_logger_name(self) -> None:
+    def test_record_with_no_extras_does_not_leak_builtin_record_fields(
+        self,
+    ) -> None:
         """A vanilla stdlib log call (no ``extra=``) shouldn't accidentally
-        forward built-in record attributes as caller fields."""
+        forward built-in ``LogRecord`` attributes (``name``, ``msg``,
+        ``levelname`` etc.) as caller fields. SDK-injected enrichment
+        (``logger_name``, ``app_name``, …) is expected to be present."""
         import logging
 
-        from application_sdk.observability.logger_adaptor import InterceptHandler
+        from application_sdk.observability.logger_adaptor import (
+            _LOGRECORD_RESERVED_ATTRS,
+            InterceptHandler,
+        )
 
         handler = InterceptHandler()
         record = logging.LogRecord(
@@ -1838,8 +1846,133 @@ class TestInterceptHandlerStdlibBridge:
             handler.emit(record)
 
         bind_kwargs = mock_log.opt.return_value.bind.call_args.kwargs
-        # Only the SDK-injected key, no spurious built-in record fields.
-        assert bind_kwargs == {"logger_name": "vanilla"}
+        # SDK-injected fields are present.
+        assert bind_kwargs["logger_name"] == "vanilla"
+        assert "app_name" in bind_kwargs
+        # No built-in LogRecord field leaked through as a caller extra.
+        leaked = set(bind_kwargs) & _LOGRECORD_RESERVED_ATTRS
+        assert leaked == set(), f"built-in record fields leaked to bind: {leaked}"
+
+    @staticmethod
+    def _emit(name: str = "third_party") -> dict[str, Any]:
+        """Emit a vanilla stdlib record through ``InterceptHandler`` and
+        return the kwargs that the bridge bound on the loguru record."""
+        import logging
+
+        from application_sdk.observability.logger_adaptor import InterceptHandler
+
+        handler = InterceptHandler()
+        record = logging.LogRecord(
+            name=name,
+            level=logging.WARNING,
+            pathname=__file__,
+            lineno=1,
+            msg="m",
+            args=(),
+            exc_info=None,
+        )
+        with mock.patch(
+            "application_sdk.observability.logger_adaptor.logger"
+        ) as mock_log:
+            handler.emit(record)
+        return mock_log.opt.return_value.bind.call_args.kwargs
+
+    def test_stdlib_emit_injects_app_name(self) -> None:
+        """Stdlib bridge must inject ``app_name`` so third-party / library
+        logs (httpx, boto3, …) are attributable in OTLP — this is the
+        :issue:`BLDX-1297` regression: 17.6M log rows landed in central LH
+        with ``app_name=None`` because the bridge skipped enrichment."""
+        from application_sdk.constants import APPLICATION_NAME
+
+        bind_kwargs = self._emit()
+
+        assert bind_kwargs["app_name"] == APPLICATION_NAME
+
+    def test_stdlib_emit_injects_workflow_context(self) -> None:
+        """Stdlib log inside a Temporal workflow must carry workflow_id,
+        workflow_run_id, etc. — matching the SDK adapter path."""
+        set_execution_context(
+            ExecutionContext(
+                execution_type="workflow",
+                workflow_id="wf-123",
+                workflow_run_id="run-abc",
+                workflow_type="t",
+                namespace="ns",
+                task_queue="q",
+                attempt=1,
+            )
+        )
+        try:
+            bind_kwargs = self._emit()
+
+            assert bind_kwargs["workflow_id"] == "wf-123"
+            assert bind_kwargs["workflow_run_id"] == "run-abc"
+            assert bind_kwargs["task_queue"] == "q"
+        finally:
+            set_execution_context(ExecutionContext())
+
+    def test_stdlib_emit_injects_correlation_and_trace_id(self) -> None:
+        """Stdlib log must pick up ``correlation_id`` / ``trace_id`` from the
+        correlation ContextVar — same as the SDK adapter."""
+        with mock.patch(
+            "application_sdk.observability.logger_adaptor.correlation_context"
+        ) as mock_corr_context:
+            mock_corr_context.get.return_value = {
+                "trace_id": "trace-xyz",
+                "correlation_id": "corr-abc",
+                "atlan-workflow-name": "publish",
+                "tenant.id": "cars-vc",
+                "temporal.task_queue": "q",
+                # Empty / falsy values must be filtered out.
+                "atlan-empty": "",
+            }
+            bind_kwargs = self._emit()
+
+        assert bind_kwargs["trace_id"] == "trace-xyz"
+        assert bind_kwargs["correlation_id"] == "corr-abc"
+        assert bind_kwargs["atlan-workflow-name"] == "publish"
+        assert bind_kwargs["tenant.id"] == "cars-vc"
+        assert bind_kwargs["temporal.task_queue"] == "q"
+        assert "atlan-empty" not in bind_kwargs
+
+    def test_caller_extra_app_name_wins_over_injection(self) -> None:
+        """A caller passing ``extra={"app_name": "custom"}`` must keep its
+        value — auto-injection only fills gaps (``setdefault``)."""
+        import logging
+
+        from application_sdk.observability.logger_adaptor import InterceptHandler
+
+        handler = InterceptHandler()
+        record = logging.LogRecord(
+            name="caller",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="m",
+            args=(),
+            exc_info=None,
+        )
+        record.app_name = "explicit-override"
+        record.correlation_id = "caller-corr"
+
+        with mock.patch(
+            "application_sdk.observability.logger_adaptor.correlation_context"
+        ) as mock_corr_context:
+            mock_corr_context.get.return_value = {
+                "correlation_id": "context-corr",
+                "trace_id": "context-trace",
+            }
+            with mock.patch(
+                "application_sdk.observability.logger_adaptor.logger"
+            ) as mock_log:
+                handler.emit(record)
+
+        bind_kwargs = mock_log.opt.return_value.bind.call_args.kwargs
+        # Caller wins.
+        assert bind_kwargs["app_name"] == "explicit-override"
+        assert bind_kwargs["correlation_id"] == "caller-corr"
+        # But the auto-fill still adds anything the caller didn't specify.
+        assert bind_kwargs["trace_id"] == "context-trace"
 
 
 class TestSecondaryWorkflowLogsExporter:


### PR DESCRIPTION
## Summary

`InterceptHandler.emit()` — the bridge that captures Python stdlib `logging` calls and forwards them to loguru → OTLP — was a pure passthrough. It set `logger_name` and forwarded caller `extra={...}` but did not inject the Atlan context that `AtlanLoggerAdapter.process()` adds on the SDK path (`app_name`, `request_id`, workflow/activity context, `trace_id`, `correlation_id`, `atlan-` / `temporal.` / `tenant.` prefixed headers).

Net result: any third-party library (httpx, boto3, temporalio, daft, …) or first-party code still on raw `logging.getLogger(__name__)` produced OTLP records missing every Atlan-specific field.

## Observed impact

Central LH `central_observability.app_logs`, 2026-05-22 04:00–05:30 UTC:

| | |
|---|---|
| Total rows today | 53.8M |
| cars-vc rows | **17.6M (33%)** |
| `app_name = None` | **17.60M of 17.64M (99.8%)** |
| `correlation_id = None` | **17.61M of 17.64M (99.96%)** |

All from `atlan-publish-worker` because `atlan-publish-app/app/lib/diff/calculator.py:14` uses raw `import logging; logger = logging.getLogger(__name__)`. The records reached OTLP correctly — but were unattributable when filtering.

Cross-checked in ClickHouse `otel_logs.service_logs` → ~15.7M matching rows in the same window with the same `app_name=None` symptom, confirming both sinks receive the same fan-out.

Ticket: [BLDX-1297](https://linear.app/atlan-epd/issue/BLDX-1297).

## Approach

Factor the enrichment logic out of `AtlanLoggerAdapter.process()` into a shared module-level helper:

```python
def _apply_atlan_context(kwargs: dict[str, Any], *, prefer_caller: bool) -> None
```

Both paths now call it:

- `process()` → `prefer_caller=False`: assigns directly, preserving the historic SDK-adapter behaviour (existing tests stay green).
- `emit()`   → `prefer_caller=True`: uses `setdefault`, so a caller passing `extra={"app_name": "X"}` keeps `X` while still getting auto-fill for everything else.

`emit()` also `setdefault`s `app_name = APPLICATION_NAME` before the call, matching `process()`.

The diff is small for what it covers — most of the line count is doc on the helper and the new tests.

## Behaviour matrix

| Field | SDK path (process) | stdlib path (emit) — before | stdlib path (emit) — after |
|---|---|---|---|
| `app_name` | ✅ | ❌ | ✅ |
| `request_id` (when request_context set) | ✅ | ❌ | ✅ |
| `workflow_id` / `workflow_run_id` / `activity_id` etc. | ✅ | ❌ | ✅ |
| `correlation_id` / `trace_id` | ✅ | ❌ | ✅ |
| `atlan-*` / `temporal.*` / `tenant.*` headers | ✅ | ❌ | ✅ |
| Caller-supplied `extra={...}` precedence | overwritten | preserved | preserved (setdefault) |

## Tests

- All existing `process()` tests pass unchanged — 1:1 behavioural compatibility verified via 107 cases (workflow, activity, correlation, generated-context hypothesis tests, …).
- Updated `test_record_with_no_extras_only_forwards_logger_name` → `test_record_with_no_extras_does_not_leak_builtin_record_fields`. The original assertion (`bind_kwargs == {"logger_name": "vanilla"}`) encoded the bug; the new assertion verifies the spirit of the original — no built-in `LogRecord` field leaks as a caller extra — while allowing the now-expected `app_name` injection.
- Added 4 new tests in `TestInterceptHandlerStdlibBridge`:
  - `test_stdlib_emit_injects_app_name` — vanilla stdlib emit carries `APPLICATION_NAME`.
  - `test_stdlib_emit_injects_workflow_context` — stdlib emit inside a workflow gets `workflow_id` / `workflow_run_id` / `task_queue`.
  - `test_stdlib_emit_injects_correlation_and_trace_id` — `correlation_id` / `trace_id` / `atlan-*` / `tenant.*` propagate; empty values filtered out.
  - `test_caller_extra_app_name_wins_over_injection` — caller `extra={"app_name": "X"}` is preserved; auto-fill only adds gaps.

Final suite: **115 passed** in `tests/unit/observability/test_logger_adaptor.py`; **292 passed, 1 skipped** in `tests/unit/observability/` overall.

## Test plan

- [x] All existing `tests/unit/observability/test_logger_adaptor.py` tests pass.
- [x] All existing `tests/unit/observability/` tests pass.
- [x] New tests cover: app_name injection, workflow context propagation, correlation context propagation, caller-extra precedence.
- [ ] Post-deploy validation in `central_observability.app_logs`: re-run scan on `tenant_id='cars-vc' AND logger_name='atlan-publish-worker'` for a 90 min window — `app_name=None` ratio should drop from ~99% to ~0%.
- [ ] Spot-check ClickHouse `otel_logs.service_logs` for the same window — `app_name` resource attribute should be populated on records that previously had it null.

## Related

- BLDX-1297 (this PR)
- BLDX-599: prior commit `feat(BLDX-599): add app_name to log attributes` (process() side, already on main).
- BLDX-1292: sibling — suppress health/ready/metrics noise; same App Observabilty workstream.
- Downstream consumer: MDLH `central_observability.app_logs` Jolt spec maps OTLP `extra.app_name` → `app_name` column (`ObservabilityDefs.java:241`). This PR unblocks accurate tenant/app filtering and the table's `tenant_id, app_name, timestamp` sort order.