### PR TITLE
fix(ci): set GH_TOKEN on publish step so PR-author lookup actually authenticates (AUT-975)

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -718,6 +718,9 @@ jobs:
           RELEASE_MODEL: ${{ needs.prepare.outputs.release_model }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
           GITHUB_ACTOR: ${{ github.triggering_actor }}
+          # Required by `gh api` calls below; without it the PR-author
+          # lookup silently falls back to triggering_actor.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary

Follow-up to #1772. The PR-author resolver added in that change calls `gh api /commits/{sha}/pulls`, but the Publish step's `env:` block at `.github/workflows/build-and-publish-app.yaml` doesn't define `GH_TOKEN`. Without it, `gh` CLI in GitHub Actions can't authenticate, the call exits non-zero, stderr is `2>/dev/null`'d, and the resolver silently falls back to `triggering_actor` — i.e. whoever clicked "Merge". That's the exact regression [AUT-975](https://linear.app/atlan-epd/issue/AUT-975/use-last-commit-author-as-release-creator) was meant to fix.

Observed in [atlan-netsuite-app run 26140415112](https://github.com/atlanhq/atlan-netsuite-app/actions/runs/26140415112): release `019e438e-694a-…` was attributed to the merger, not the PR author.

The two other `gh api` callers in this file (`Resolve SHA, find or dispatch tests run` line 214, `Wait for tests run to complete` line 301) already set `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` — this step was missed.

## Why `GITHUB_TOKEN`, not `ORG_PAT_GITHUB`

Same-repo lookup (`repos/${GITHUB_REPOSITORY}/commits/${SHA}/pulls`) → `GITHUB_TOKEN` is sufficient. Least privilege, auto-revoked at job end, no rotation. Matches the pattern the tests-gate steps already use.

## Safety

Pure env-block addition; no script changes. Every existing failure path (PR not yet indexed, missing `pull-requests: read` on a downstream caller, API outage) still falls back to `triggering_actor` — i.e. current behavior. No new code paths.

## Test plan

- [ ] Merge to main and trigger a netsuite-app (or any consumer) merge-to-main publish
- [ ] Confirm GM Slack notification shows the PR author in `Created by:`, not the merger
- [ ] If a downstream caller doesn't grant `pull-requests: read`, behavior remains the (broken) fallback — no regression

## Follow-ups (not in this PR)

- Add `echo "PR_AUTHOR='${PR_AUTHOR}' ACTOR='${ACTOR}' CREATED_BY='${CREATED_BY}'"` so the next regression is diagnosable from logs without re-instrumenting.
- Consider declaring `permissions: pull-requests: read` on the reusable workflow's publish job to make the required scope explicit for callers.