### PR TITLE
fix(common): only pass ExternalId to sts.assume_role when non-empty [HYP-1445]

### DIFF
--- a/application_sdk/common/aws_utils.py
+++ b/application_sdk/common/aws_utils.py
@@ -76,9 +76,16 @@ def generate_aws_rds_token_with_iam_role(
         sts_client = client(
             "sts", region_name=region or get_region_name_from_hostname(host)
         )
-        assumed_role = sts_client.assume_role(
-            RoleArn=role_arn, RoleSessionName=session_name, ExternalId=external_id or ""
-        )
+        # Only include ExternalId when set — AWS STS rejects an empty
+        # ExternalId (min length 2). Trust policies without an external-id
+        # requirement are valid and must not be forced to send one.
+        assume_role_kwargs: dict[str, Any] = {
+            "RoleArn": role_arn,
+            "RoleSessionName": session_name,
+        }
+        if external_id:
+            assume_role_kwargs["ExternalId"] = external_id
+        assumed_role = sts_client.assume_role(**assume_role_kwargs)
 
         credentials = assumed_role["Credentials"]
         aws_client = create_aws_client(

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.13.0
-source-sha:    085256727df025f7d1acd7fd65efac9463bee9f7
-source-date:   2026-05-22T15:53:09+05:30
+sdk-version:   3.13.1
+source-sha:    2aa149e95d91de953842cccab0400bdee6e63bc4
+source-date:   2026-05-25T14:30:23+05:30
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/tests/unit/common/test_aws_utils.py
+++ b/tests/unit/common/test_aws_utils.py
@@ -124,6 +124,70 @@ class TestAWSUtils:
         assert result == "test_token"
 
     @patch("boto3.client")
+    def test_generate_aws_rds_token_with_iam_role_omits_external_id_when_blank(
+        self, mock_client
+    ):
+        """ExternalId must NOT be sent to STS when external_id is None or empty.
+
+        AWS STS rejects ExternalId shorter than 2 characters with
+        ParamValidationError. Trust policies that don't require an external
+        ID are valid; the SDK must not force one. Regression test for HYP-1445.
+        """
+        for blank in (None, ""):
+            mock_client.reset_mock()
+            mock_sts = MagicMock()
+            mock_rds = MagicMock()
+            mock_client.side_effect = [mock_sts, mock_rds]
+            mock_sts.assume_role.return_value = {
+                "Credentials": {
+                    "AccessKeyId": "test_key",
+                    "SecretAccessKey": "test_secret",
+                    "SessionToken": "test_token",
+                }
+            }
+            mock_rds.generate_db_auth_token.return_value = "test_token"
+
+            generate_aws_rds_token_with_iam_role(
+                role_arn="arn:aws:iam::123456789012:role/test-role",
+                host="database-1.abc123xyz.us-east-1.rds.amazonaws.com",
+                user="test_user",
+                external_id=blank,
+            )
+
+            kwargs = mock_sts.assume_role.call_args.kwargs
+            assert "ExternalId" not in kwargs, (
+                f"ExternalId must not be passed when external_id={blank!r}; "
+                f"got {kwargs!r}"
+            )
+
+    @patch("boto3.client")
+    def test_generate_aws_rds_token_with_iam_role_passes_external_id_when_set(
+        self, mock_client
+    ):
+        """ExternalId must be forwarded verbatim to STS when provided."""
+        mock_sts = MagicMock()
+        mock_rds = MagicMock()
+        mock_client.side_effect = [mock_sts, mock_rds]
+        mock_sts.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "test_key",
+                "SecretAccessKey": "test_secret",
+                "SessionToken": "test_token",
+            }
+        }
+        mock_rds.generate_db_auth_token.return_value = "test_token"
+
+        generate_aws_rds_token_with_iam_role(
+            role_arn="arn:aws:iam::123456789012:role/test-role",
+            host="database-1.abc123xyz.us-east-1.rds.amazonaws.com",
+            user="test_user",
+            external_id="my-external-id",
+        )
+
+        kwargs = mock_sts.assume_role.call_args.kwargs
+        assert kwargs.get("ExternalId") == "my-external-id"
+
+    @patch("boto3.client")
     def test_generate_aws_rds_token_with_iam_role_error(self, mock_client):
         """Test error handling in RDS token generation with IAM role."""
         from botocore.exceptions import ClientError


### PR DESCRIPTION
### Changelog
- `generate_aws_rds_token_with_iam_role` no longer forces `ExternalId=""` into `sts.assume_role`. The kwarg is now included only when `external_id` is non-empty, matching the docstring's `external_id (str, optional)` contract.
- Adds two regression tests: one asserts `ExternalId` is omitted when `external_id` is `None` or `""`; the other asserts it is forwarded verbatim when set.

### Additional context (e.g. screenshots, logs, links)
- Linear: [HYP-1445](https://linear.app/atlan-epd/issue/HYP-1445)
- **Customer impact:** Tenant `gamecgup01` (GameChanger, AWS us-east-1, MAIN-BASE, segment STRATEGIC, ARR $164K) is currently failing every `postgres:fetch_*` activity. Pod identity `postgres-worker-twd-v3-dd4d043` confirms the v3 connector image.
- **Symptom:**
  ```
  ATLAN-CLIENT-401-02: SQL client authentication failed:
  Parameter validation failed:
  Invalid length for parameter ExternalId, value: 0, valid min length: 2
  ```
- **Root cause:** `aws_utils.py:80` (pre-fix) ran `sts_client.assume_role(... ExternalId=external_id or "")`. When `external_id` is `None` or `""` — perfectly valid when the AWS trust policy does not require an external ID — `external_id or ""` evaluates to `""` (length 0). AWS STS validates `ExternalId` against `min length: 2` and rejects with `ParamValidationError`.
- **Call chain that surfaced this:** `postgres:fetch_procedures` activity → `app/connector.py:_fetch_metadata` → `SQLClient.load` → `BaseSQLClient.get_sqlalchemy_connection_string` → `get_auth_token` → `get_iam_role_token` → this function.
- **Pre-existing test failures:** `test_create_engine_url_success` / `test_create_engine_url_without_port` fail on `main` (unrelated optional-dep gap); not introduced by this PR. All four `generate_aws_rds_token_with_iam_role_*` tests pass.

### Checklist
- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated (no docstring change needed — `external_id (str, optional)` already described the intended behaviour; this PR makes the code match it)

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [x] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [x] If yes, have you modified the code in the context of this project? please share additional details.

No copyleft-licensed code is introduced or modified by this PR.