### PR TITLE
fix(temporal): unblock SDR Temporal connect — prefer IPv4 + fall back to v2 TLS env (DISTR-507)

### DIFF
--- a/application_sdk/execution/_temporal/backend.py
+++ b/application_sdk/execution/_temporal/backend.py
@@ -315,13 +315,13 @@ def _prefer_v4_target(target_host: str) -> tuple[str, str | None]:
     fell back to v4, which is why the same hosts worked on v2 and
     break on v3.
 
-    Pre-resolving in Python with ``AI_ADDRCONFIG`` mirrors what glibc
-    does for v4-fallback-friendly clients: it returns only the address
-    families the host actually has configured. We then sort A first so
-    we always pick v4 when both are available, and fall back to v6 only
-    when v4 isn't returned. On a v4-only host we return the hostname
-    unchanged (no benefit to swapping) so existing tests and callers
-    aren't perturbed.
+    Pre-resolving in Python with ``AI_ADDRCONFIG`` returns only the
+    address families the host actually has configured. We then always
+    pick a v4 IP when one is in the result and substitute it for the
+    hostname, falling back to v6 only when no v4 is returned. The key
+    invariant: as long as ``getaddrinfo`` returns at least one v4
+    result, we hand the Rust bridge a literal v4 IP — which guarantees
+    it can't re-resolve and pick a v6 address on its own.
 
     No-op cases (return ``(target_host, None)`` unchanged):
 
@@ -330,8 +330,7 @@ def _prefer_v4_target(target_host: str) -> tuple[str, str | None]:
     * Port is missing or non-numeric (malformed input; let the caller
       fail with a real connect error rather than a parse error here).
     * ``getaddrinfo`` raises (DNS down, unknown host, etc).
-    * Only one address family is returned and it's IPv4 — no
-      ambiguity for the Rust resolver to get wrong.
+    * The resolver returns zero usable address-family entries.
     """
     host, _, port = target_host.rpartition(":")
     if not host or not port.isdigit():
@@ -360,25 +359,33 @@ def _prefer_v4_target(target_host: str) -> tuple[str, str | None]:
     if not results:
         return target_host, None
 
-    has_v6 = any(r[0] == socket.AF_INET6 for r in results)
-    if not has_v6:
-        # v4-only host — Rust bridge will resolve the same single family
-        # and there's no v6-vs-v4 ambiguity to disambiguate. Leave the
-        # hostname alone so callers and tests that don't expect IP
-        # substitution keep working.
-        return target_host, None
+    # Prefer v4 whenever a v4 address is in the resolver result.
+    #
+    # Earlier versions of this helper only swapped when the result
+    # contained BOTH A and AAAA — the assumption being that on a
+    # v4-only host (where AI_ADDRCONFIG filters out AAAA), the Rust
+    # bridge would also see only A and there's nothing to fix. That
+    # assumption was wrong in production: the Rust connector does NOT
+    # use AI_ADDRCONFIG, so it queries DNS directly and still gets
+    # AAAA even when Python's filtered result drops it. On a Docker
+    # bridge netns with no v6 stack, Python returns "A only", Rust
+    # returns "A + AAAA from DNS", tries the AAAA, and fails with
+    # EADDRNOTAVAIL. The only way to keep the Rust client off v6 in
+    # that case is to feed it a literal v4 IP from the start.
+    v4_results = [r for r in results if r[0] == socket.AF_INET]
+    if v4_results:
+        ip = v4_results[0][4][0]
+        return f"{ip}:{port}", host
 
-    # Sort A before AAAA, then pick the first. This makes us prefer v4
-    # whenever the OS returned both, which is the safe choice on any
-    # host where v6 might be half-configured.
-    results.sort(key=lambda r: 0 if r[0] == socket.AF_INET else 1)
-    family, _, _, _, sockaddr = results[0]
-    ip = sockaddr[0]
-    if family == socket.AF_INET6:
-        resolved = f"[{ip}]:{port}"
-    else:
-        resolved = f"{ip}:{port}"
-    return resolved, host
+    # No v4 available — fall back to v6. This is the legitimate
+    # v6-only host case (e.g. some k8s clusters); the Rust client
+    # would have used v6 anyway and there's no v4 to prefer.
+    v6_results = [r for r in results if r[0] == socket.AF_INET6]
+    if v6_results:
+        ip = v6_results[0][4][0]
+        return f"[{ip}]:{port}", host
+
+    return target_host, None
 
 
 def _apply_sni_domain(tls: TLSConfig | bool, sni: str) -> TLSConfig | bool:

--- a/application_sdk/execution/_temporal/backend.py
+++ b/application_sdk/execution/_temporal/backend.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import random
+import socket
 import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -286,6 +288,128 @@ def _build_tls_config(
     )
 
 
+def _prefer_v4_target(target_host: str) -> tuple[str, str | None]:
+    """Pre-resolve ``target_host`` and prefer an IPv4 address when AAAA is present.
+
+    Returns ``(resolved_target, sni_hostname)``:
+
+    * ``resolved_target`` — the literal ``<ip>:<port>`` to hand to the Rust
+      Temporal bridge (IPv6 results are wrapped in brackets).
+    * ``sni_hostname`` — the original DNS name when we substituted an IP,
+      else ``None``. Callers must propagate this into ``TLSConfig.domain``
+      so the TLS handshake still validates against the right cert.
+
+    Why this exists
+    ---------------
+
+    The Temporal Rust bridge resolves the target via Tokio's connector,
+    which does not iterate every address returned by the OS resolver:
+    on a host where DNS returns both A and AAAA, the bridge picks one
+    address (often AAAA first), and if that connect fails the whole
+    ``Client.connect`` raises. Two production incidents on customer
+    SDR VMs hit this — both had partial IPv6 enablement (only
+    link-local v6 configured, no global v6 route) so ``connect()`` to
+    a global IPv6 destination fast-fails with ``EADDRNOTAVAIL`` before
+    the bridge falls back to v4. The pure-Python Temporal client used
+    by the earlier SDK line iterated the full address list and silently
+    fell back to v4, which is why the same hosts worked on v2 and
+    break on v3.
+
+    Pre-resolving in Python with ``AI_ADDRCONFIG`` mirrors what glibc
+    does for v4-fallback-friendly clients: it returns only the address
+    families the host actually has configured. We then sort A first so
+    we always pick v4 when both are available, and fall back to v6 only
+    when v4 isn't returned. On a v4-only host we return the hostname
+    unchanged (no benefit to swapping) so existing tests and callers
+    aren't perturbed.
+
+    No-op cases (return ``(target_host, None)`` unchanged):
+
+    * ``target_host`` is already a literal IP (``1.2.3.4:7233`` or
+      ``[::1]:7233``).
+    * Port is missing or non-numeric (malformed input; let the caller
+      fail with a real connect error rather than a parse error here).
+    * ``getaddrinfo`` raises (DNS down, unknown host, etc).
+    * Only one address family is returned and it's IPv4 — no
+      ambiguity for the Rust resolver to get wrong.
+    """
+    host, _, port = target_host.rpartition(":")
+    if not host or not port.isdigit():
+        return target_host, None
+    # IPv6 literal targets come bracketed (``[::1]:7233``); strip for the
+    # ipaddress check, leave the original ``target_host`` to return.
+    host_stripped = host[1:-1] if host.startswith("[") and host.endswith("]") else host
+    try:
+        ipaddress.ip_address(host_stripped)
+    except ValueError:
+        pass
+    else:
+        # Already a literal IP — no resolution to do, no SNI to preserve.
+        return target_host, None
+
+    try:
+        results = socket.getaddrinfo(
+            host,
+            int(port),
+            family=socket.AF_UNSPEC,
+            type=socket.SOCK_STREAM,
+            flags=socket.AI_ADDRCONFIG,
+        )
+    except (socket.gaierror, ValueError):
+        return target_host, None
+    if not results:
+        return target_host, None
+
+    has_v6 = any(r[0] == socket.AF_INET6 for r in results)
+    if not has_v6:
+        # v4-only host — Rust bridge will resolve the same single family
+        # and there's no v6-vs-v4 ambiguity to disambiguate. Leave the
+        # hostname alone so callers and tests that don't expect IP
+        # substitution keep working.
+        return target_host, None
+
+    # Sort A before AAAA, then pick the first. This makes us prefer v4
+    # whenever the OS returned both, which is the safe choice on any
+    # host where v6 might be half-configured.
+    results.sort(key=lambda r: 0 if r[0] == socket.AF_INET else 1)
+    family, _, _, _, sockaddr = results[0]
+    ip = sockaddr[0]
+    if family == socket.AF_INET6:
+        resolved = f"[{ip}]:{port}"
+    else:
+        resolved = f"{ip}:{port}"
+    return resolved, host
+
+
+def _apply_sni_domain(tls: TLSConfig | bool, sni: str) -> TLSConfig | bool:
+    """Return a TLSConfig with ``domain`` set to ``sni`` for SNI validation.
+
+    Needed when we've substituted a literal IP for the original
+    hostname: without an explicit ``domain``, the Rust bridge defaults
+    SNI to the literal IP and the TLS handshake fails because the
+    server cert's SAN list doesn't include the IP. Preserves any other
+    fields already configured on the caller's TLSConfig and respects a
+    caller-supplied ``domain`` if one is already set.
+    """
+    from temporalio.service import TLSConfig  # noqa: PLC0415 — cold path
+
+    if tls is False:
+        return tls
+    if tls is True:
+        return TLSConfig(domain=sni)
+    if isinstance(tls, TLSConfig):
+        if tls.domain:
+            # Caller explicitly set SNI; respect that.
+            return tls
+        return TLSConfig(
+            server_root_ca_cert=tls.server_root_ca_cert,
+            client_cert=tls.client_cert,
+            client_private_key=tls.client_private_key,
+            domain=sni,
+        )
+    return tls
+
+
 async def create_temporal_client(
     host: str = "localhost:7233",
     namespace: str = "default",
@@ -365,8 +489,28 @@ async def create_temporal_client(
             "Connecting to Temporal (plaintext): host=%s namespace=%s", host, namespace
         )
 
+    # Pre-resolve the target hostname and prefer IPv4 when the OS
+    # resolver returns both A and AAAA. The Rust Temporal bridge picks
+    # one address from the resolver and fails the whole connect if that
+    # address is unreachable — on hosts with half-broken IPv6 (link-
+    # local only, or v6 enabled without a global route) this manifests
+    # as ``Status { code: Unavailable, ... AddrNotAvailable ... }`` on
+    # an AAAA record. See ``_prefer_v4_target`` for the full rationale.
+    resolved_host, sni_host = _prefer_v4_target(host)
+    if sni_host is not None:
+        # We substituted an IP for the hostname — preserve TLS SNI so
+        # the handshake still validates against the original DNS name's
+        # cert, not the literal IP.
+        tls_config = _apply_sni_domain(tls_config, sni_host)
+        logger.info(
+            "Pre-resolved Temporal target %s -> %s (SNI preserved as %s)",
+            host,
+            resolved_host,
+            sni_host,
+        )
+
     kwargs: dict[str, Any] = {
-        "target_host": host,
+        "target_host": resolved_host,
         "namespace": namespace,
         "tls": tls_config,
         "data_converter": data_converter

--- a/application_sdk/execution/_temporal/backend.py
+++ b/application_sdk/execution/_temporal/backend.py
@@ -288,7 +288,7 @@ def _build_tls_config(
     )
 
 
-def _prefer_v4_target(target_host: str) -> tuple[str, str | None]:
+async def _prefer_v4_target(target_host: str) -> tuple[str, str | None]:
     """Pre-resolve ``target_host`` and prefer an IPv4 address when AAAA is present.
 
     Returns ``(resolved_target, sni_hostname)``:
@@ -346,8 +346,17 @@ def _prefer_v4_target(target_host: str) -> tuple[str, str | None]:
         # Already a literal IP — no resolution to do, no SNI to preserve.
         return target_host, None
 
+    # Use ``loop.getaddrinfo`` instead of the blocking ``socket.getaddrinfo``
+    # so the resolver runs off the event loop's thread. ``create_temporal_client``
+    # is on a hot startup path that overlaps with health-probe handlers,
+    # lifespan startup hooks, and other ``create_temporal_client`` calls
+    # (worker + executor backend) — a slow DNS server blocking the loop here
+    # would stall readiness probes and any other request handlers waiting
+    # for their turn. ``loop.getaddrinfo`` delegates to a thread executor
+    # so the resolution is concurrent with the rest of startup.
+    loop = asyncio.get_running_loop()
     try:
-        results = socket.getaddrinfo(
+        results = await loop.getaddrinfo(
             host,
             int(port),
             family=socket.AF_UNSPEC,
@@ -503,7 +512,7 @@ async def create_temporal_client(
     # local only, or v6 enabled without a global route) this manifests
     # as ``Status { code: Unavailable, ... AddrNotAvailable ... }`` on
     # an AAAA record. See ``_prefer_v4_target`` for the full rationale.
-    resolved_host, sni_host = _prefer_v4_target(host)
+    resolved_host, sni_host = await _prefer_v4_target(host)
     if sni_host is not None:
         # We substituted an IP for the hostname — preserve TLS SNI so
         # the handshake still validates against the original DNS name's

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -275,7 +275,17 @@ class AppConfig:
             else _env_int("ATLAN_HEALTH_PORT", 8081),
             service_name=service_name,
             # TLS
-            tls_enabled=_env_bool("ATLAN_TEMPORAL_TLS_ENABLED"),
+            # v2 compat: ATLAN_WORKFLOW_TLS_ENABLED is the legacy name; charts
+            # predating the v3 rename still set it. Fall back to the v2 name
+            # only when ATLAN_TEMPORAL_TLS_ENABLED is absent from the
+            # environment — an explicit ATLAN_TEMPORAL_TLS_ENABLED=false must
+            # still disable TLS even if a stale v2 value is left in place, so
+            # use a presence check rather than truthiness for the precedence.
+            tls_enabled=(
+                _env_bool("ATLAN_TEMPORAL_TLS_ENABLED")
+                if "ATLAN_TEMPORAL_TLS_ENABLED" in os.environ
+                else _env_bool("ATLAN_WORKFLOW_TLS_ENABLED")
+            ),
             tls_server_root_ca_cert_path=_env("ATLAN_TEMPORAL_TLS_CA_CERT_PATH"),
             tls_client_cert_path=_env("ATLAN_TEMPORAL_TLS_CLIENT_CERT_PATH"),
             tls_client_private_key_path=_env("ATLAN_TEMPORAL_TLS_CLIENT_KEY_PATH"),

--- a/tests/unit/execution/test_backend.py
+++ b/tests/unit/execution/test_backend.py
@@ -517,17 +517,29 @@ def _fake_addrinfo(*families: int) -> list[tuple[int, int, int, str, tuple]]:
 
 
 class TestPreferV4Target:
-    def test_returns_v4_ip_when_both_families_present(self) -> None:
+    # The helper now uses ``loop.getaddrinfo`` (which delegates to a thread
+    # executor) rather than the blocking ``socket.getaddrinfo``, so the
+    # tests are async. ``mock.patch.object(backend_module.socket,
+    # "getaddrinfo", ...)`` still works because asyncio's
+    # ``loop.getaddrinfo`` resolves ``socket.getaddrinfo`` from the global
+    # ``socket`` module attribute at call time — the patch is on that same
+    # module attribute so the thread executor picks it up.
+
+    @pytest.mark.asyncio
+    async def test_returns_v4_ip_when_both_families_present(self) -> None:
         with mock.patch.object(
             backend_module.socket,
             "getaddrinfo",
             return_value=_fake_addrinfo(_socket.AF_INET6, _socket.AF_INET),
         ):
-            target, sni = backend_module._prefer_v4_target("temporal.example.com:443")
+            target, sni = await backend_module._prefer_v4_target(
+                "temporal.example.com:443"
+            )
         assert target == "203.0.113.10:443"
         assert sni == "temporal.example.com"
 
-    def test_returns_v6_bracketed_when_no_v4_available(self) -> None:
+    @pytest.mark.asyncio
+    async def test_returns_v6_bracketed_when_no_v4_available(self) -> None:
         # Hosts genuinely v6-only (some k8s clusters) — pass v6 through
         # so the connect can still succeed via the only family available.
         # NB: this is also the no-swap-no-SNI path being unreachable here
@@ -538,11 +550,14 @@ class TestPreferV4Target:
             "getaddrinfo",
             return_value=_fake_addrinfo(_socket.AF_INET6),
         ):
-            target, sni = backend_module._prefer_v4_target("temporal.example.com:443")
+            target, sni = await backend_module._prefer_v4_target(
+                "temporal.example.com:443"
+            )
         assert target == "[2001:db8::abcd]:443"
         assert sni == "temporal.example.com"
 
-    def test_swaps_when_only_v4_returned(self) -> None:
+    @pytest.mark.asyncio
+    async def test_swaps_when_only_v4_returned(self) -> None:
         # Even when Python's AI_ADDRCONFIG-filtered result has no AAAA
         # (e.g. inside a Docker bridge netns with no v6 stack), the
         # Rust connector — which doesn't use AI_ADDRCONFIG — can still
@@ -555,36 +570,42 @@ class TestPreferV4Target:
             "getaddrinfo",
             return_value=_fake_addrinfo(_socket.AF_INET),
         ):
-            target, sni = backend_module._prefer_v4_target("temporal.example.com:443")
+            target, sni = await backend_module._prefer_v4_target(
+                "temporal.example.com:443"
+            )
         assert target == "203.0.113.10:443"
         assert sni == "temporal.example.com"
 
-    def test_noop_on_literal_ipv4(self) -> None:
-        target, sni = backend_module._prefer_v4_target("203.0.113.10:443")
+    @pytest.mark.asyncio
+    async def test_noop_on_literal_ipv4(self) -> None:
+        target, sni = await backend_module._prefer_v4_target("203.0.113.10:443")
         assert target == "203.0.113.10:443"
         assert sni is None
 
-    def test_noop_on_literal_ipv6_bracketed(self) -> None:
-        target, sni = backend_module._prefer_v4_target("[::1]:7233")
+    @pytest.mark.asyncio
+    async def test_noop_on_literal_ipv6_bracketed(self) -> None:
+        target, sni = await backend_module._prefer_v4_target("[::1]:7233")
         assert target == "[::1]:7233"
         assert sni is None
 
-    def test_noop_on_gaierror(self) -> None:
+    @pytest.mark.asyncio
+    async def test_noop_on_gaierror(self) -> None:
         with mock.patch.object(
             backend_module.socket,
             "getaddrinfo",
             side_effect=_socket.gaierror("name or service not known"),
         ):
-            target, sni = backend_module._prefer_v4_target("nx.example.com:443")
+            target, sni = await backend_module._prefer_v4_target("nx.example.com:443")
         assert target == "nx.example.com:443"
         assert sni is None
 
-    def test_noop_on_malformed_target(self) -> None:
+    @pytest.mark.asyncio
+    async def test_noop_on_malformed_target(self) -> None:
         # No port, port is non-numeric, or empty host — caller's input
         # contract violation, let the real connect raise rather than
         # masking it with a parse error here.
         for bad in ("just-a-host", ":443", "host:notaport", ""):
-            target, sni = backend_module._prefer_v4_target(bad)
+            target, sni = await backend_module._prefer_v4_target(bad)
             assert target == bad
             assert sni is None
 

--- a/tests/unit/execution/test_backend.py
+++ b/tests/unit/execution/test_backend.py
@@ -542,18 +542,22 @@ class TestPreferV4Target:
         assert target == "[2001:db8::abcd]:443"
         assert sni == "temporal.example.com"
 
-    def test_noop_when_only_v4_returned(self) -> None:
-        # No ambiguity for the Rust resolver to get wrong — keep the
-        # hostname so downstream callers / TLS SNI behave exactly as
-        # they did before this patch was introduced.
+    def test_swaps_when_only_v4_returned(self) -> None:
+        # Even when Python's AI_ADDRCONFIG-filtered result has no AAAA
+        # (e.g. inside a Docker bridge netns with no v6 stack), the
+        # Rust connector — which doesn't use AI_ADDRCONFIG — can still
+        # get AAAA back from DNS and try it, failing with
+        # EADDRNOTAVAIL. So we always substitute the literal v4 IP
+        # when one is available; that's the only way to keep the Rust
+        # client off v6 in that case.
         with mock.patch.object(
             backend_module.socket,
             "getaddrinfo",
             return_value=_fake_addrinfo(_socket.AF_INET),
         ):
             target, sni = backend_module._prefer_v4_target("temporal.example.com:443")
-        assert target == "temporal.example.com:443"
-        assert sni is None
+        assert target == "203.0.113.10:443"
+        assert sni == "temporal.example.com"
 
     def test_noop_on_literal_ipv4(self) -> None:
         target, sni = backend_module._prefer_v4_target("203.0.113.10:443")
@@ -654,7 +658,13 @@ class TestCreateTemporalClientPrefersV4:
         assert kwargs["tls"].domain == "temporal.example.com"
 
     @pytest.mark.asyncio
-    async def test_does_not_swap_when_resolver_returns_only_v4(self) -> None:
+    async def test_swaps_even_when_resolver_returns_only_v4(self) -> None:
+        # Plaintext path: Python's AI_ADDRCONFIG-filtered result has
+        # only A, but the substitution still happens — the Rust
+        # connector doesn't apply AI_ADDRCONFIG and may still query
+        # DNS for AAAA on its own. Substituting a literal v4 IP from
+        # the start is the only thing that consistently prevents v6
+        # attempts on netns-with-no-v6 hosts.
         with (
             mock.patch.object(backend_module, "_get_or_create_runtime"),
             mock.patch.object(
@@ -673,8 +683,8 @@ class TestCreateTemporalClientPrefersV4:
                 connect_max_attempts=1,
             )
         kwargs = connect.await_args.kwargs
-        # Hostname preserved end-to-end on v4-only resolution.
-        assert kwargs["target_host"] == "temporal.example.com:443"
+        assert kwargs["target_host"] == "203.0.113.10:443"
+        # Plaintext — no TLS to upgrade for SNI; tls stays False.
         assert kwargs["tls"] is False
 
     @pytest.mark.asyncio

--- a/tests/unit/execution/test_backend.py
+++ b/tests/unit/execution/test_backend.py
@@ -12,6 +12,7 @@ paths so a renamed symbol fails the test.
 
 from __future__ import annotations
 
+import socket as _socket
 from datetime import timedelta
 from typing import Any
 from unittest import mock
@@ -386,12 +387,25 @@ class TestCreateTemporalClient:
         assert tls_arg is not False
 
     @pytest.mark.asyncio
-    async def test_tls_with_no_paths_and_no_custom_ca_uses_true(self) -> None:
+    async def test_tls_with_no_paths_and_no_custom_ca_enables_tls(self) -> None:
+        """tls=True is the historical no-config TLS shape; the v4-preferring
+        pre-resolver may upgrade it to TLSConfig(domain=<original>) to
+        preserve SNI when it substitutes an IP for the hostname, so the
+        assertion is permissive about the exact representation."""
+        from temporalio.service import TLSConfig
+
         with (
             mock.patch.object(backend_module, "_get_or_create_runtime"),
             mock.patch(
                 "application_sdk.clients.ssl_utils.get_custom_ca_cert_bytes",
                 return_value=None,
+            ),
+            # Force the no-op resolver path so the assertion isn't sensitive
+            # to whether the test host actually has working IPv6.
+            mock.patch.object(
+                backend_module,
+                "_prefer_v4_target",
+                side_effect=lambda h: (h, None),
             ),
             mock.patch.object(
                 backend_module.Client,
@@ -400,7 +414,8 @@ class TestCreateTemporalClient:
             ) as connect,
         ):
             await create_temporal_client(tls_enabled=True, connect_max_attempts=1)
-        assert connect.await_args.kwargs["tls"] is True
+        tls_arg = connect.await_args.kwargs["tls"]
+        assert tls_arg is True or isinstance(tls_arg, TLSConfig)
 
     @pytest.mark.asyncio
     async def test_tls_with_explicit_cert_path_calls_build_tls_config(
@@ -467,3 +482,223 @@ class TestCreateTemporalClient:
                     connect_retry_delay_seconds=0.0,
                 )
         assert connect_mock.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# _prefer_v4_target / _apply_sni_domain (IPv6-fallback safety net)
+#
+# These guard against a v3-vs-v2 regression seen on two SDR customer VMs:
+# both hosts had half-broken IPv6 (link-local only, no global v6 route).
+# v2 SDK's pure-Python client iterated every getaddrinfo result and
+# silently fell back to v4; the v3 Rust bridge picks one address from
+# the resolver and fails the whole connect if that address is v6 on
+# such a host. Pre-resolving in Python lets us prefer v4 when both
+# families are returned, while preserving TLS SNI via TLSConfig.domain.
+# ---------------------------------------------------------------------------
+
+
+def _fake_addrinfo(*families: int) -> list[tuple[int, int, int, str, tuple]]:
+    """Build a getaddrinfo-shaped result with the given AF_INET / AF_INET6 entries."""
+    out: list[tuple[int, int, int, str, tuple]] = []
+    for fam in families:
+        if fam == _socket.AF_INET:
+            out.append((fam, _socket.SOCK_STREAM, 6, "", ("203.0.113.10", 443)))
+        else:
+            out.append(
+                (
+                    fam,
+                    _socket.SOCK_STREAM,
+                    6,
+                    "",
+                    ("2001:db8::abcd", 443, 0, 0),
+                )
+            )
+    return out
+
+
+class TestPreferV4Target:
+    def test_returns_v4_ip_when_both_families_present(self) -> None:
+        with mock.patch.object(
+            backend_module.socket,
+            "getaddrinfo",
+            return_value=_fake_addrinfo(_socket.AF_INET6, _socket.AF_INET),
+        ):
+            target, sni = backend_module._prefer_v4_target("temporal.example.com:443")
+        assert target == "203.0.113.10:443"
+        assert sni == "temporal.example.com"
+
+    def test_returns_v6_bracketed_when_no_v4_available(self) -> None:
+        # Hosts genuinely v6-only (some k8s clusters) — pass v6 through
+        # so the connect can still succeed via the only family available.
+        # NB: this is also the no-swap-no-SNI path being unreachable here
+        # because has_v6 is True and v4 is absent — we explicitly fall
+        # through to "pick v6" because there's no v4 to prefer.
+        with mock.patch.object(
+            backend_module.socket,
+            "getaddrinfo",
+            return_value=_fake_addrinfo(_socket.AF_INET6),
+        ):
+            target, sni = backend_module._prefer_v4_target("temporal.example.com:443")
+        assert target == "[2001:db8::abcd]:443"
+        assert sni == "temporal.example.com"
+
+    def test_noop_when_only_v4_returned(self) -> None:
+        # No ambiguity for the Rust resolver to get wrong — keep the
+        # hostname so downstream callers / TLS SNI behave exactly as
+        # they did before this patch was introduced.
+        with mock.patch.object(
+            backend_module.socket,
+            "getaddrinfo",
+            return_value=_fake_addrinfo(_socket.AF_INET),
+        ):
+            target, sni = backend_module._prefer_v4_target("temporal.example.com:443")
+        assert target == "temporal.example.com:443"
+        assert sni is None
+
+    def test_noop_on_literal_ipv4(self) -> None:
+        target, sni = backend_module._prefer_v4_target("203.0.113.10:443")
+        assert target == "203.0.113.10:443"
+        assert sni is None
+
+    def test_noop_on_literal_ipv6_bracketed(self) -> None:
+        target, sni = backend_module._prefer_v4_target("[::1]:7233")
+        assert target == "[::1]:7233"
+        assert sni is None
+
+    def test_noop_on_gaierror(self) -> None:
+        with mock.patch.object(
+            backend_module.socket,
+            "getaddrinfo",
+            side_effect=_socket.gaierror("name or service not known"),
+        ):
+            target, sni = backend_module._prefer_v4_target("nx.example.com:443")
+        assert target == "nx.example.com:443"
+        assert sni is None
+
+    def test_noop_on_malformed_target(self) -> None:
+        # No port, port is non-numeric, or empty host — caller's input
+        # contract violation, let the real connect raise rather than
+        # masking it with a parse error here.
+        for bad in ("just-a-host", ":443", "host:notaport", ""):
+            target, sni = backend_module._prefer_v4_target(bad)
+            assert target == bad
+            assert sni is None
+
+
+class TestApplySniDomain:
+    def test_returns_false_unchanged(self) -> None:
+        # Plaintext connections don't have a TLS handshake to validate,
+        # so SNI is irrelevant — propagate False through unchanged.
+        assert backend_module._apply_sni_domain(False, "temporal.example.com") is False
+
+    def test_upgrades_true_to_tlsconfig_with_domain(self) -> None:
+        from temporalio.service import TLSConfig
+
+        result = backend_module._apply_sni_domain(True, "temporal.example.com")
+        assert isinstance(result, TLSConfig)
+        assert result.domain == "temporal.example.com"
+
+    def test_preserves_existing_tlsconfig_fields_and_sets_domain(self) -> None:
+        from temporalio.service import TLSConfig
+
+        existing = TLSConfig(server_root_ca_cert=b"--CA--")
+        result = backend_module._apply_sni_domain(existing, "temporal.example.com")
+        assert isinstance(result, TLSConfig)
+        assert result.server_root_ca_cert == b"--CA--"
+        assert result.domain == "temporal.example.com"
+
+    def test_respects_caller_supplied_domain(self) -> None:
+        # When the caller passed --tls-domain (or otherwise built a
+        # TLSConfig with an explicit SNI), we must not silently
+        # overwrite their choice with the auto-derived hostname.
+        from temporalio.service import TLSConfig
+
+        existing = TLSConfig(domain="explicit.override.example")
+        result = backend_module._apply_sni_domain(existing, "temporal.example.com")
+        assert result is existing
+
+
+class TestCreateTemporalClientPrefersV4:
+    @pytest.mark.asyncio
+    async def test_substitutes_v4_ip_and_preserves_sni_for_tls(self) -> None:
+        """End-to-end: when the resolver returns both v4 and v6 and TLS
+        is enabled, Client.connect receives the v4 IP as target_host and
+        a TLSConfig whose domain matches the original hostname."""
+        from temporalio.service import TLSConfig
+
+        with (
+            mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(
+                backend_module.socket,
+                "getaddrinfo",
+                return_value=_fake_addrinfo(_socket.AF_INET6, _socket.AF_INET),
+            ),
+            mock.patch(
+                "application_sdk.clients.ssl_utils.get_custom_ca_cert_bytes",
+                return_value=None,
+            ),
+            mock.patch.object(
+                backend_module.Client,
+                "connect",
+                new=mock.AsyncMock(return_value=mock.MagicMock()),
+            ) as connect,
+        ):
+            await create_temporal_client(
+                host="temporal.example.com:443",
+                tls_enabled=True,
+                connect_max_attempts=1,
+            )
+        kwargs = connect.await_args.kwargs
+        assert kwargs["target_host"] == "203.0.113.10:443"
+        assert isinstance(kwargs["tls"], TLSConfig)
+        assert kwargs["tls"].domain == "temporal.example.com"
+
+    @pytest.mark.asyncio
+    async def test_does_not_swap_when_resolver_returns_only_v4(self) -> None:
+        with (
+            mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(
+                backend_module.socket,
+                "getaddrinfo",
+                return_value=_fake_addrinfo(_socket.AF_INET),
+            ),
+            mock.patch.object(
+                backend_module.Client,
+                "connect",
+                new=mock.AsyncMock(return_value=mock.MagicMock()),
+            ) as connect,
+        ):
+            await create_temporal_client(
+                host="temporal.example.com:443",
+                connect_max_attempts=1,
+            )
+        kwargs = connect.await_args.kwargs
+        # Hostname preserved end-to-end on v4-only resolution.
+        assert kwargs["target_host"] == "temporal.example.com:443"
+        assert kwargs["tls"] is False
+
+    @pytest.mark.asyncio
+    async def test_plaintext_target_swap_does_not_touch_tls(self) -> None:
+        # Plaintext connect with both v4 and v6 — target swaps, but tls
+        # stays False because there's no handshake to preserve SNI for.
+        with (
+            mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(
+                backend_module.socket,
+                "getaddrinfo",
+                return_value=_fake_addrinfo(_socket.AF_INET6, _socket.AF_INET),
+            ),
+            mock.patch.object(
+                backend_module.Client,
+                "connect",
+                new=mock.AsyncMock(return_value=mock.MagicMock()),
+            ) as connect,
+        ):
+            await create_temporal_client(
+                host="temporal.example.com:443",
+                tls_enabled=False,
+                connect_max_attempts=1,
+            )
+        kwargs = connect.await_args.kwargs
+        assert kwargs["target_host"] == "203.0.113.10:443"
+        assert kwargs["tls"] is False

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -294,6 +294,41 @@ class TestAppConfigFromArgsAndEnv:
         config = AppConfig.from_args_and_env(args)
         assert config.log_level == "WARNING"
 
+    def test_v2_temporal_tls_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Customer chart predating the v3 rename still sets the v2 name —
+        # the SDK should pick it up so the deployment doesn't have to be
+        # hand-edited on SDK upgrade.
+        monkeypatch.setenv("ATLAN_APP_MODULE", "pkg:App")
+        monkeypatch.delenv("ATLAN_TEMPORAL_TLS_ENABLED", raising=False)
+        monkeypatch.setenv("ATLAN_WORKFLOW_TLS_ENABLED", "true")
+        args = self._make_args()
+        config = AppConfig.from_args_and_env(args)
+        assert config.tls_enabled is True
+
+    def test_v3_temporal_tls_enabled_takes_precedence_over_v2(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Explicit v3 setting wins even when a stale v2 value is left in the
+        # environment — crucially including the v3=false case, so a customer
+        # migrating TLS-on → TLS-off can flip without first scrubbing the v2
+        # var from their chart.
+        monkeypatch.setenv("ATLAN_APP_MODULE", "pkg:App")
+        monkeypatch.setenv("ATLAN_TEMPORAL_TLS_ENABLED", "false")
+        monkeypatch.setenv("ATLAN_WORKFLOW_TLS_ENABLED", "true")
+        args = self._make_args()
+        config = AppConfig.from_args_and_env(args)
+        assert config.tls_enabled is False
+
+    def test_temporal_tls_defaults_to_false_when_neither_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATLAN_APP_MODULE", "pkg:App")
+        monkeypatch.delenv("ATLAN_TEMPORAL_TLS_ENABLED", raising=False)
+        monkeypatch.delenv("ATLAN_WORKFLOW_TLS_ENABLED", raising=False)
+        args = self._make_args()
+        config = AppConfig.from_args_and_env(args)
+        assert config.tls_enabled is False
+
     def test_task_queue_derived_from_app_module(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

Bundles two fixes that together let an SDR customer deploy a v3-SDK-built worker to a half-broken-IPv6 host with a v2-shaped Helm chart and have it connect to Temporal on first try — no `docker-compose.yaml` edits, no `network_mode: host`, no manual env var additions.

Both fixes target the same customer-side friction symptom — *"SDR deployment fails to connect to Temporal until customer hand-edits config"* — and the SDR rollout team needs both shipped together to actually retire the workaround docs.

**Linear:** [DISTR-507](https://linear.app/atlan-epd/issue/DISTR-507/sdr-worker-fails-to-connect-to-temporal-on-hosts-with-partial-ipv6)

## Commit 1 — Prefer IPv4 when the OS resolver returns both A and AAAA

`1cf5df79` (initial) + `cd2cf41a` (fix-of-fix, see below)

### Symptom

Two production SDR incidents on customer VMs (one EC2-hosted, one on-prem) both crashed on first `Client.connect`:

```
Status { code: Unavailable, message: \"tcp connect error\", source:
ConnectError(\"tcp connect error\", [2606:4700::6812:32c]:443,
Os { code: 99, kind: AddrNotAvailable, message: \"Cannot assign requested address\" }) }
```

Both hosts had partial IPv6 enablement (link-local only, no global v6 route). DNS for the Atlan-tenant Temporal frontend (Cloudflare-hosted) returns both A and AAAA. The kernel can't pick an IPv6 source address for the global v6 destination, so `connect()` fast-fails with `EADDRNOTAVAIL`. The Rust Temporal bridge picks one address from the resolver and surfaces that failure as the entire `Client.connect` raising — it doesn't iterate every result on failure.

### Why v2 worked and v3 didn't

The Python `temporalio` SDK has always wrapped the Rust core SDK via the bridge — nothing changed in **our** SDK's connect path. The regression is transitive: SDK v3.5.0 (commit `6de53dc7`, PR #1640, a CVE-driven security bump) bumped `temporalio` from `>=1.7.1,<1.24.0` to `>=1.25.0,<1.27.0`. The newer `temporalio` ships an updated Rust core with newer `tonic` / `hyper-util` versions; the modern HTTP connector no longer iterates address-family fallback on `EADDRNOTAVAIL`. Earlier `temporalio` versions did, which is why every v2.8.x SDK and every v3.0.0 – v3.4.0 SDK silently worked on the same hosts.

### First broken release

| SDK version | `temporalio` pin | Status |
| --- | --- | --- |
| v2.8.x (all) | `>=1.7.1,<1.24.0` | works |
| v3.0.0 – v3.4.0 | `>=1.7.1,<1.24.0` | works (same old `temporalio`) |
| **v3.5.0** (2026-05-01) | `>=1.25.0,<1.27.0` | **first broken release** |
| v3.6.0 – v3.13.1 | progressively `<1.28.0`, then `<2.0.0` | broken |

### Customer-side workarounds we've been telling them to apply

All friction we should not be putting on customers:

* Edit auto-generated `docker-compose.yaml` to add `extra_hosts:` pinning the Temporal hostname to a v4 IP.
* Switch to `network_mode: host`.
* Disable IPv6 system-wide on the VM via `/etc/sysctl.d/99-disable-ipv6.conf`.

Each fails on at least one of: customer can't edit (configurator overwrites), security team rejects (host networking), or requires root/sysadmin involvement.

### The fix

In `application_sdk/execution/_temporal/backend.py::create_temporal_client`, before constructing the `Client.connect(**kwargs)` call:

1. Pre-resolve the target via Python's `socket.getaddrinfo(..., AF_UNSPEC, SOCK_STREAM, AI_ADDRCONFIG)`.
2. If the result contains any A entry, substitute `<v4-ip>:<port>` into `target_host`.
3. Preserve TLS SNI by upgrading the `tls` arg: `True` becomes `TLSConfig(domain=<original-hostname>)`; an existing `TLSConfig` without an explicit `domain` gets one added; an existing `TLSConfig` with a caller-supplied `domain` is respected unchanged.

The key invariant: as long as `getaddrinfo` returns at least one v4 result, we hand the Rust bridge a literal v4 IP — which guarantees it can't re-resolve and pick a v6 address on its own.

### Fix-of-fix (`cd2cf41a`)

The initial cut (`1cf5df79`) gated the swap on `has_v6` being True (\"only swap when AAAA is also in the resolver result\"). Reasoning: \"if Python's `AI_ADDRCONFIG` returned only A, Rust will too, no swap needed.\"

That assumption was wrong in production. The Rust connector does **not** apply `AI_ADDRCONFIG` when it calls `getaddrinfo`. So on a Docker bridge netns that has no IPv6 stack at all:

* Python with `AI_ADDRCONFIG` correctly returns only A.
* Our `has_v6` gate said \"no swap needed.\"
* The hostname passed through to the Rust client.
* The Rust client called `getaddrinfo` without `AI_ADDRCONFIG`, got AAAA back from DNS, tried it, kernel `EADDRNOTAVAIL`.

`cd2cf41a` drops the `has_v6` gate. Always substitute a v4 IP when one is in the resolver result, regardless of whether AAAA is also returned. The point of the swap isn't \"disambiguate A vs AAAA\" — it's \"remove the hostname so the Rust connector can't pick AAAA on its own.\" Verified end-to-end on a real EC2 SDR customer host after the swap.

### Behaviour matrix

| Host shape | OS returns | Action |
| --- | --- | --- |
| dual-stack, healthy v6 | A + AAAA | swap to v4 IP, preserve SNI |
| dual-stack, broken v6 (the bug) | A + AAAA | swap to v4 IP, preserve SNI |
| bridge netns, no v6 | A only | swap to v4 IP, preserve SNI |
| v4-only host | A only | swap to v4 IP, preserve SNI |
| v6-only host (e.g. some k8s clusters) | AAAA only | use `[v6]:port`, preserve SNI |
| literal IP input (`1.2.3.4:7233`, `[::1]:7233`) | (skipped) | no-op |
| `gaierror` / malformed input | (skipped) | no-op, let real connect raise |

## Commit 2 — Fall back to `ATLAN_WORKFLOW_TLS_ENABLED` when `ATLAN_TEMPORAL_TLS_ENABLED` is absent

`869c63af`

### Symptom

Customer charts predating the v3 env rename still set the legacy `ATLAN_WORKFLOW_TLS_ENABLED=true`. Today the SDK silently ignores it — `tls_enabled` defaults to `False`, the worker tries plaintext gRPC against a TLS-fronted Temporal frontend, and `Client.connect` fails with a TLS error.

The only fix we've had was telling every SDR customer to manually add `ATLAN_TEMPORAL_TLS_ENABLED=true` to their deployment env. That doesn't scale and breaks the auto-generated docker-compose flow where customers shouldn't be editing config at all.

### The fix

In `application_sdk/main.py::AppConfig.from_args_and_env`, fall back to the v2 env name only when the v3 name is **absent from the environment** — use a presence check (`\"ATLAN_TEMPORAL_TLS_ENABLED\" in os.environ`) rather than truthiness, so an explicit `ATLAN_TEMPORAL_TLS_ENABLED=false` still disables TLS even with a stale v2 value left in the chart. That's the migration path for a customer flipping TLS-on → TLS-off without first scrubbing the v2 var.

Matches the existing v2-fallback pattern documented in `docs/standards/env-vars.md` (\"renamed-but-still-read-with-fallback\" case — no `_REMOVED_ENV_VARS` entry needed because the old name is still functional). Same shape as the `ATLAN_WORKFLOW_HOST → ATLAN_TEMPORAL_HOST` and `ATLAN_WORKFLOW_NAMESPACE → ATLAN_TEMPORAL_NAMESPACE` fallbacks already in place.

### Fallback semantics

| Customer env | `tls_enabled` |
| --- | --- |
| Neither var set | `False` (default) |
| Only `ATLAN_WORKFLOW_TLS_ENABLED=true` (v2 chart, untouched) | **`True`** ← this is the fix |
| Only `ATLAN_TEMPORAL_TLS_ENABLED=true` (clean v3 deployment) | `True` |
| Both `=true` | `True` |
| `ATLAN_TEMPORAL_TLS_ENABLED=false`, `ATLAN_WORKFLOW_TLS_ENABLED=true` | **`False`** — v3 explicit setting wins, even to disable |
| Only `ATLAN_TEMPORAL_TLS_ENABLED=false`, no v2 var | `False` |

## Test plan

- [x] 11 unit tests for `_prefer_v4_target` + `_apply_sni_domain` + `create_temporal_client` covering every row of the v4-resolver behaviour matrix above. Includes the bridge-netns regression case that broke the first cut.
- [x] 3 unit tests for the TLS env fallback (v2 picked up; v3-false beats v2-true; neither-set defaults to False).
- [x] All existing tests pass: 40/40 in `tests/unit/execution/test_backend.py`, 117/117 in `tests/unit/test_main.py`, 546/546 across the broader related surface.
- [x] `uv run pre-commit run` clean on all changed files (ruff, ruff-format, pyright, isort).
- [x] **End-to-end verification on a real EC2 SDR customer:** test-pinned saperp image built against this branch, pulled by the customer with **all workarounds removed** (no `extra_hosts:`, no `sysctls:`, no `network_mode: host`, and no manual `ATLAN_TEMPORAL_TLS_ENABLED` env addition — chart still sets the v2 name only) → worker connected to Temporal successfully on first attempt. Confirmed working.

## Backwards-compatibility notes

* One existing test (`test_tls_with_no_paths_and_no_custom_ca_uses_true`) was asserting the precise kwarg shape `tls is True`. Updated to permit either `True` or `TLSConfig` since the helper may upgrade the former to the latter; mock-patched the resolver to a no-op in that one test so it's independent of the CI host's IPv6 state.
* Callers passing `tls_domain=...` explicitly are respected — we only fill in SNI when the caller didn't.
* The TLS env fallback is purely additive — customers already on `ATLAN_TEMPORAL_TLS_ENABLED` keep their existing behaviour exactly.
* No `_REMOVED_ENV_VARS` entry — `ATLAN_WORKFLOW_TLS_ENABLED` remains a supported alias.

## Commit history (kept un-squashed intentionally)

Three commits on this PR, kept unsquashed because the fix-of-fix tells the story:

1. `1cf5df79` — *fix(temporal): prefer IPv4 when OS resolver returns both A and AAAA*
2. `cd2cf41a` — *fix(temporal): always prefer v4 — don't gate on AAAA being in the Python result* (drops the `has_v6` gate that the first cut got wrong)
3. `869c63af` — *feat(env): fall back to ATLAN_WORKFLOW_TLS_ENABLED when ATLAN_TEMPORAL_TLS_ENABLED is absent*

Let me know if you'd prefer this squashed before merge.

## Follow-ups (separate tickets, not blocking)

* `atlan-configurator` could probe for v6 brokenness at customer-VM bootstrap and warn so customers see the issue at install time. Not blocking — this SDK fix is enough.
* Update SDR onboarding docs to remove the `extra_hosts:` / `network_mode: host` / manual TLS env workarounds once this ships.
* Bump SDK pin in every other connector app currently on `>=3.5.0` so they pick up both fixes on next rebuild.