### PR TITLE
chore(pr-review): teach mothership to flag conceptual doc drift

### DIFF
--- a/.mothership/pr-review/agents/quality.md
+++ b/.mothership/pr-review/agents/quality.md
@@ -46,6 +46,14 @@ better, worse, or the same?"
 - Error messages actionable? (include entity type, GUID, what went wrong)
 - Migration path clear? (deprecation warnings before removal)
 - Import depth logical? (`from application_sdk.app import App` not 5 levels deep)
+- **Docs sync?** For each `application_sdk/<area>/` prefix with
+  substantive changes in the diff, check whether the mapped
+  `docs/concepts/*.md` (per `references/dx-rules.md` §5
+  "Conceptual Doc Sync") was also touched. If not, raise a
+  `[DX] docs-drift` finding scoped PATCH unless one of the escape
+  hatches in §5 applies (internal-only change, `docs-not-needed`
+  label, deprecated module, `chore:`/`test:`/`ci:`/`build:`
+  commit scope).
 
 ### [QUAL] findings — focus on:
 - Imports inside functions (should be top-level unless lazy with justification)

--- a/.mothership/pr-review/references/dx-rules.md
+++ b/.mothership/pr-review/references/dx-rules.md
@@ -300,6 +300,77 @@ Flag:
 - Missing `Raises` section when the method raises documented exceptions
 - Missing `Example` on core APIs that developers subclass/call directly
 
+### Conceptual Doc Sync (Important)
+
+Connector developers read `docs/concepts/*.md` to learn how the SDK
+fits together. When SDK source code changes, the matching conceptual
+doc has to move with it — otherwise the docs become a lie that
+silently misleads every new connector author. The mapping below is
+the canonical source (`docs/standards/documentation.md`); update
+both in lockstep.
+
+| When the PR touches... | The matching doc must be reviewed |
+|---|---|
+| `application_sdk/app/**` | `docs/concepts/apps.md` |
+| `application_sdk/execution/**` | `docs/concepts/apps.md` |
+| `application_sdk/infrastructure/**` | `docs/concepts/apps.md` (infrastructure abstraction section) |
+| `application_sdk/storage/**` | `docs/concepts/apps.md` (built-in storage tasks section) |
+| `application_sdk/templates/**` | `docs/concepts/tasks.md` |
+| `application_sdk/handler/**` | `docs/concepts/handlers.md` |
+| `application_sdk/credentials/**` | `docs/concepts/handlers.md` (credential resolution section) |
+| `application_sdk/server/**` | `docs/concepts/server.md` |
+| `application_sdk/clients/**` | `docs/concepts/clients.md` |
+| `application_sdk/contracts/**` | `docs/concepts/entry-points.md` (contract types section) |
+| `application_sdk/observability/**` | `docs/concepts/monitoring.md` |
+| `application_sdk/errors/**` | `docs/concepts/common.md` (Error Handling) AND `docs/standards/exceptions.md` |
+| `application_sdk/common/**` or `application_sdk/constants.py` | `docs/concepts/common.md` |
+| `application_sdk/transformers/**` | `docs/concepts/common.md` |
+
+**Detection heuristic** (run per PR):
+1. From the diff, collect the set of `application_sdk/<area>/` prefixes
+   that have non-test, non-`__init__.py` additions or substantive changes
+   (renames, signature changes, new public symbols, removed public
+   symbols, behavioural changes — NOT pure formatting, NOT type-only
+   edits, NOT internal helper renames invisible to consumers).
+2. For each prefix, look up the mapped doc(s) in the table.
+3. Check the diff for any touch on any mapped doc. If at least one is
+   touched → satisfied for that prefix (the agent should still skim
+   to confirm the touch is substantive, not just a typo fix).
+4. If a prefix has substantive source changes and zero touches on any
+   of its mapped docs → flag `[DX] docs-drift` for that prefix.
+
+**Escape hatches — do NOT flag when:**
+- The source change is provably internal (private helper rename, log
+  string tweak, inline comment edit, type-annotation-only diff).
+- The PR description explicitly invokes a docs-not-needed rationale
+  AND that rationale matches the code: e.g. "this is a bugfix that
+  preserves documented behaviour, no doc surface change."
+- The PR has the `docs-not-needed` label (reviewer-applied escape
+  hatch — record it in the finding's `by_design_check` field).
+- The change is in a deprecated module already documented as
+  going away — patching it does not need fresh prose.
+- The PR is `chore:`/`test:`/`ci:`/`build:` per Conventional Commits
+  (those scopes are doc-exempt by §7 of this file).
+
+**Finding shape:**
+
+```
+[DX] docs-drift: application_sdk/handler/ changed without touch on docs/concepts/handlers.md
+File: application_sdk/handler/base.py (or representative file)
+Why it matters: connector authors learn the handler API from
+  docs/concepts/handlers.md. If the surface changed but the doc
+  didn't, the next author will write to the old contract and waste
+  half a day debugging.
+Path forward: PATCH — update docs/concepts/handlers.md to reflect
+  <specific changes>. Reviewer can downgrade if the change is purely
+  internal and confirms in a comment.
+Severity: Important.
+```
+
+**Severity:** Important. Doc drift is corrosive but not blocking — the
+code works; only future-readers pay. Reviewer downgrades to LOW when
+the PR description plausibly argues "no consumer-visible change."
+
 ---
 
 ## 6. Backwards Compatibility


### PR DESCRIPTION
## Why

`docs/standards/documentation.md` already defines a module→doc mapping (e.g. `application_sdk/handler/**` → `docs/concepts/handlers.md`), but nothing enforces it. `capability-manifest-check.yaml` only covers the auto-generated `docs/agents/sdk-capabilities.md` (and is explicitly informational — see its header). Prose docs under `docs/concepts/` therefore rot silently until a reader trips over them.

The lowest-friction lever is the existing `@test-sdk-review` (mothership) reviewer: it already reads the diff holistically, so adding "did the matched conceptual docs move with the code?" to its `[DX]` checklist costs no new CI surface, no new label, no new workflow.

## What changed

- **`references/dx-rules.md` §5** — add **Conceptual Doc Sync (Important)**. Contains the full module→doc mapping copied from `docs/standards/documentation.md`, a four-step detection heuristic the LLM agent runs against the diff, five explicit escape hatches (internal-only changes, `docs-not-needed` label, deprecated modules, `chore:`/`test:`/`ci:`/`build:` scopes), the finding shape, and the severity rationale.
- **`agents/quality.md`** — add one bullet to the existing `[DX] findings — ask:` checklist pointing the reviewer at §5. The QUALITY agent already owns `[DX]` tags and fires in `full`, `tests-only`, and `tests-focused` review scopes, so the check has the right coverage without dispatching a new agent.

The env-vars rule (`§8` of `dx-rules.md`) is the existing template — same shape: state the rule, give the detection heuristic, list escape hatches, fix severity. This change just generalises that pattern to conceptual docs.

## Why an LLM rule and not a path-pair GHA workflow

A naive mechanical "if you touched `application_sdk/X/`, you must touch `docs/concepts/Y.md`" check would fire on every typo fix, internal helper rename, type-annotation-only edit, and test-only change. The team would route around it with a skip-label within a week and stop trusting it. An LLM check distinguishes consumer-visible changes from internal ones, so the false-positive rate stays low without a noisy label dance.

## Severity & enforcement

- **Important**, not blocking. Doc drift corrodes onboarding but the code still works.
- Reviewer can downgrade to LOW when the PR description plausibly argues "no consumer-visible change."
- A `docs-not-needed` label (reviewer-applied) is an explicit escape hatch — the finding's `by_design_check` field captures the rationale.

## Test plan

- [ ] Trigger `@test-sdk-review` on a PR that touches `application_sdk/handler/**` but not `docs/concepts/handlers.md` → expect a `[DX] docs-drift` finding in the review summary.
- [ ] Trigger `@test-sdk-review` on a PR that touches both `application_sdk/handler/**` and `docs/concepts/handlers.md` → expect no docs-drift finding.
- [ ] Trigger `@test-sdk-review` on a `test:`-scoped or `chore:`-scoped PR that touches source → expect no docs-drift finding (commit scope is an escape hatch).
- [ ] If drift is consistently over-reported on internal-only refactors, tighten step 1 of the detection heuristic to require a `__init__.py` re-export change or a public-API signature change before flagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)