### PR TITLE
fix(sdr-e2e): insert [tool.uv.sources] entry when absent instead of erroring

### DIFF
--- a/.github/actions/sdr-e2e/repin-application-sdk.sh
+++ b/.github/actions/sdr-e2e/repin-application-sdk.sh
@@ -46,12 +46,18 @@ pattern = re.compile(
 replaced, n = pattern.subn(new_line, src)
 
 if n == 0:
-    raise SystemExit(
-        "atlan-application-sdk source pin not found in pyproject.toml; "
-        "expected a line like:\n"
-        "  atlan-application-sdk = { git = \"...\", branch = \"...\" }\n"
-        "under [tool.uv.sources]."
-    )
+    # No existing [tool.uv.sources] entry — consumer repo uses PyPI.
+    # Insert the git override under [tool.uv.sources], creating the
+    # section if it doesn't exist.
+    if "[tool.uv.sources]" in src:
+        replaced = src.replace(
+            "[tool.uv.sources]",
+            f"[tool.uv.sources]\n{new_line}",
+            1,
+        )
+    else:
+        replaced = src + f"\n[tool.uv.sources]\n{new_line}\n"
+    print(f"No existing source pin found; inserted new entry for {ref}")
 
 if n > 1:
     # More than one pin is ambiguous — fail loudly rather than rewriting

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.13.0
-source-sha:    085256727df025f7d1acd7fd65efac9463bee9f7
-source-date:   2026-05-22T15:53:09+05:30
+sdk-version:   3.13.1
+source-sha:    565e2a004fa3a1a095b0eba0ab336dbdd5e1737c
+source-date:   2026-05-22T22:04:23+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 


### PR DESCRIPTION
## Problem

`repin-application-sdk.sh` required an existing `atlan-application-sdk` entry in `[tool.uv.sources]` and exited with **"source pin not found"** when the connector repo pinned the SDK via PyPI only (`>=X.Y.Z,<N` in `[project.dependencies]`, no `[tool.uv.sources]` override). This broke SDR cross-repo dispatch from SDK PRs on connectors that had promoted from a git-hash pin to a PyPI range constraint.

Example failure: https://github.com/atlanhq/atlan-mysql-app/actions/runs/26393378010/job/77688165392

## Fix

When the regex finds no existing `[tool.uv.sources]` entry for `atlan-application-sdk`, insert the git override under the existing `[tool.uv.sources]` section (or create that section if absent) instead of failing. Connector repos using PyPI for normal installs no longer need a placeholder git entry just to satisfy the repin script.

## Test plan

- [x] `uv run pre-commit run --files .github/actions/sdr-e2e/repin-application-sdk.sh` clean.
- [ ] Re-trigger the failing mysql-app SDR dispatch run to confirm the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)