### PR TITLE
chore(ci): land connector-unit-tests + connector-integration-tests composite actions

### DIFF
--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -26,6 +26,32 @@ description: |
   pytest-xdist is installed transiently via `uv run --with pytest-xdist` so the
   caller does not need to declare it as a dependency.
 
+  ## Connectors with native dependencies
+
+  Some connectors require OS-level native libs (ODBC drivers for MSSQL/Oracle,
+  SAP JCo for SAP ERP, Kafka native clients, etc.). Install them as a
+  PRE-STEP in the caller's workflow BEFORE invoking this action — they
+  survive the action's internal re-checkout because they're installed at
+  the system level, not in the repo tree. `uv sync` (inside this action's
+  `setup-deps` call) will then find the headers/libraries when compiling
+  Python wrappers like `pyodbc`.
+
+  Example — MSSQL with ODBC 18 + FreeTDS:
+
+  ```yaml
+  steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/actions/mssql-native-deps   # connector-local action
+    - uses: atlanhq/application-sdk/.github/actions/connector-integration-tests@v3.14.0
+      with:
+        app-name: mssql
+  ```
+
+  Where `./.github/actions/mssql-native-deps/action.yml` is a tiny ~15-line
+  composite action that does ONLY the apt-install steps (no Python, no Dapr,
+  no app server — this action handles those). The connector ships its own
+  native-deps action; this action handles all the connector-agnostic setup.
+
 inputs:
   app-name:
     required: true

--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -73,12 +73,14 @@ inputs:
   test-paths:
     required: false
     description: |
-      Space-separated pytest target paths. Default is `tests/integration/`
-      (run integration scenarios only). To run unit + integration in a
-      single pytest invocation (xdist parallelism across both layers),
-      pass `tests/unit tests/integration`. Coverage flags can be added
-      via `pytest-args`; pytest-cov is installed transiently.
-    default: "tests/integration/"
+      Optional space-separated pytest target paths. Default is empty,
+      which means pytest auto-discovers tests from the rootdir (honors
+      `[tool.pytest.ini_options].testpaths` in `pyproject.toml` if set).
+      Override only when you need to scope to a subset of test files
+      (e.g., `tests/integration/` for integration-only runs).
+      Coverage flags can be added via `pytest-args`; pytest-cov is
+      installed transiently.
+    default: ""
   python-version:
     required: false
     description: Python version to use.

--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -1,0 +1,151 @@
+name: Integration Tests for Atlan Connector Apps
+
+description: |
+  Runs integration tests for an Atlan connector app (atlan-*-app repository).
+
+  Reusable across every connector built on atlan-application-sdk v3+. The
+  connector's workflow `uses:` this action; per-app variation is limited to:
+  - `app-name` input — the connector's ATLAN_APPLICATION_NAME (e.g., athena, postgres)
+  - The caller's job-level `env:` block — where TEST_<CONNECTOR>_* env vars
+    are wired from `secrets.*`. These are inherited by the action's steps.
+
+  The integration framework itself lives at
+  `application_sdk.testing.integration` (merged in PR #1233; forward-ported
+  to v3). Connectors pin a tagged SDK release (e.g., v3.7.0) and this action
+  just runs pytest against the installed package.
+
+  Steps:
+  - Sets up Python + uv via `setup-deps` (which also checks out the caller repo).
+  - Installs Dapr CLI + Temporal CLI.
+  - Starts Dapr + Temporal (`poe start-deps`).
+  - Starts the connector app server (`python main.py`) and waits for health.
+  - Runs `pytest tests/integration/` with pytest-xdist for in-process parallelism.
+  - Uploads junit XML + raw test output as artifacts.
+  - Cleans up app server + Dapr/Temporal.
+
+  pytest-xdist is installed transiently via `uv run --with pytest-xdist` so the
+  caller does not need to declare it as a dependency.
+
+inputs:
+  app-name:
+    required: true
+    description: |
+      The connector app name. Used as ATLAN_APPLICATION_NAME for the
+      running app server. Must match the connector's pyproject.toml
+      `tool.poe.tasks.start-app` ATLAN_APPLICATION_NAME (e.g., athena, postgres).
+  python-version:
+    required: false
+    description: Python version to use.
+    default: "3.11"
+  pytest-args:
+    required: false
+    description: |
+      Extra arguments passed to pytest after the integration-tests path.
+      Default parallelises tests across xdist workers; override to dial worker
+      count or change distribution strategy.
+    default: "-n auto --dist=load --tb=short"
+  app-port:
+    required: false
+    description: HTTP port the connector app server listens on.
+    default: "8000"
+  health-check-timeout-seconds:
+    required: false
+    description: How long to wait for the app server to become healthy.
+    default: "60"
+  dapr-version:
+    required: false
+    description: Dapr runtime version to install.
+    default: "1.16.2"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Python, uv, and dependencies
+      uses: atlanhq/application-sdk/.github/actions/setup-deps@main
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install Dapr CLI
+      shell: bash
+      run: |
+        DAPR_VERSION="${{ inputs.dapr-version }}"
+        wget -q "https://github.com/dapr/cli/releases/download/v${DAPR_VERSION}/dapr_linux_amd64.tar.gz" -O /tmp/dapr.tar.gz
+        tar -xzf /tmp/dapr.tar.gz -C /tmp
+        sudo mv /tmp/dapr /usr/local/bin/
+        chmod +x /usr/local/bin/dapr
+        dapr init --runtime-version "${DAPR_VERSION}" --slim
+
+    - name: Install Temporal CLI
+      shell: bash
+      run: curl -sSf https://temporal.download/cli.sh | sh
+
+    - name: Add Dapr and Temporal to PATH
+      shell: bash
+      run: |
+        echo "$HOME/.dapr/bin" >> "$GITHUB_PATH"
+        echo "$HOME/.temporalio/bin" >> "$GITHUB_PATH"
+
+    - name: Download Dapr components
+      shell: bash
+      run: uv run poe download-components
+
+    - name: Start Dapr + Temporal
+      shell: bash
+      run: |
+        uv run poe start-deps
+        sleep 5
+
+    - name: Start app server
+      shell: bash
+      env:
+        ATLAN_LOCAL_DEVELOPMENT: "true"
+        ATLAN_APPLICATION_NAME: ${{ inputs.app-name }}
+      run: |
+        uv run python main.py &
+        for i in $(seq 1 ${{ inputs.health-check-timeout-seconds }}); do
+          if curl -sf "http://localhost:${{ inputs.app-port }}/server/health" > /dev/null 2>&1; then
+            echo "App server ready after ${i}s"
+            break
+          fi
+          if [ "$i" -eq ${{ inputs.health-check-timeout-seconds }} ]; then
+            echo "::error::App server failed to start within ${{ inputs.health-check-timeout-seconds }}s"
+            exit 1
+          fi
+          sleep 1
+        done
+
+    - name: Run integration tests (parallel via pytest-xdist)
+      id: tests
+      shell: bash
+      env:
+        ATLAN_LOCAL_DEVELOPMENT: "true"
+        ATLAN_APPLICATION_NAME: ${{ inputs.app-name }}
+      # NOTE: TEST_<CONNECTOR>_* env vars are NOT declared here. They're
+      # provided by the caller's job-level env block (which has access to
+      # `secrets.*`) and inherited by this composite-action step.
+      run: |
+        mkdir -p results
+        set +e
+        uv run --with pytest-xdist pytest tests/integration/ -v \
+          ${{ inputs.pytest-args }} \
+          --junit-xml=results/test-results.xml \
+          2>&1 | tee results/test-output.txt
+        TEST_EXIT_CODE=${PIPESTATUS[0]}
+        set -e
+        echo "exit_code=$TEST_EXIT_CODE" >> "$GITHUB_OUTPUT"
+        exit "$TEST_EXIT_CODE"
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: integration-test-results
+        path: results/
+        retention-days: 14
+
+    - name: Cleanup
+      if: always()
+      shell: bash
+      run: |
+        kill $(lsof -t -i :${{ inputs.app-port }}) 2>/dev/null || true
+        uv run poe stop-deps || true

--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -52,6 +52,17 @@ description: |
   no app server — this action handles those). The connector ships its own
   native-deps action; this action handles all the connector-agnostic setup.
 
+outputs:
+  summary:
+    description: |
+      One-line pytest summary parsed from the test-output's final
+      `=== ... ===` line (e.g. "248 passed, 8 skipped in 159.91s").
+      Caller workflows can surface this in PR comments.
+    value: ${{ steps.tests.outputs.summary }}
+  exit_code:
+    description: pytest exit code from the test run.
+    value: ${{ steps.tests.outputs.exit_code }}
+
 inputs:
   app-name:
     required: true
@@ -158,6 +169,9 @@ runs:
           2>&1 | tee results/test-output.txt
         TEST_EXIT_CODE=${PIPESTATUS[0]}
         set -e
+        # Extract the pytest summary line for caller PR comments.
+        SUMMARY=$(grep -E "^=+ .* =+$" results/test-output.txt | tail -1 | sed -E 's/^=+ *//; s/ *=+$//')
+        echo "summary=${SUMMARY:-no summary parsed}" >> "$GITHUB_OUTPUT"
         echo "exit_code=$TEST_EXIT_CODE" >> "$GITHUB_OUTPUT"
         exit "$TEST_EXIT_CODE"
 

--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -70,6 +70,15 @@ inputs:
       The connector app name. Used as ATLAN_APPLICATION_NAME for the
       running app server. Must match the connector's pyproject.toml
       `tool.poe.tasks.start-app` ATLAN_APPLICATION_NAME (e.g., athena, postgres).
+  test-paths:
+    required: false
+    description: |
+      Space-separated pytest target paths. Default is `tests/integration/`
+      (run integration scenarios only). To run unit + integration in a
+      single pytest invocation (xdist parallelism across both layers),
+      pass `tests/unit tests/integration`. Coverage flags can be added
+      via `pytest-args`; pytest-cov is installed transiently.
+    default: "tests/integration/"
   python-version:
     required: false
     description: Python version to use.
@@ -163,7 +172,10 @@ runs:
       run: |
         mkdir -p results
         set +e
-        uv run --with pytest-xdist pytest tests/integration/ -v \
+        # pytest-cov added transiently so callers can opt in to coverage
+        # via pytest-args (e.g., `--cov=app --cov-report=xml ...`). No
+        # effect when coverage flags aren't passed.
+        uv run --with pytest-xdist --with pytest-cov pytest ${{ inputs.test-paths }} -v \
           ${{ inputs.pytest-args }} \
           --junit-xml=results/test-results.xml \
           2>&1 | tee results/test-output.txt

--- a/.github/actions/connector-unit-tests/action.yaml
+++ b/.github/actions/connector-unit-tests/action.yaml
@@ -1,0 +1,71 @@
+name: Unit Tests for Atlan Connector Apps
+
+description: |
+  Runs unit tests for an Atlan connector app (atlan-*-app repository).
+
+  Reusable across every connector built on atlan-application-sdk v3+. The
+  connector repo's workflow `uses:` this action; per-app variation is limited
+  to the `python-version` and `fail-under` inputs.
+
+  Steps:
+  - Sets up Python + uv via `setup-deps` (which also checks out the caller repo).
+  - Runs `pytest tests/unit/` with coverage.
+  - Enforces a minimum coverage threshold (`fail-under`) via `coverage report`.
+  - Comments the coverage delta on the PR.
+
+  Does NOT upload coverage to S3 — that wiring is per-app and stays in the
+  caller's workflow if desired.
+
+inputs:
+  github-token:
+    required: true
+    description: GitHub token used to comment coverage results on the PR.
+  python-version:
+    required: false
+    description: Python version to use.
+    default: "3.11"
+  fail-under:
+    required: false
+    description: |
+      Minimum coverage percentage to enforce on the final `coverage report`
+      step. CLI flag overrides `[tool.coverage.report].fail_under` in the
+      consumer's pyproject.toml.
+    default: "60"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Python, uv, and dependencies
+      uses: atlanhq/application-sdk/.github/actions/setup-deps@main
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Run unit tests with coverage
+      shell: bash
+      # xml/html subcommands ALSO honor pyproject.toml's
+      # [tool.coverage.report].fail_under. Pin them to --fail-under=0 so
+      # artifact generation never short-circuits the run. The actual
+      # threshold gate is the final `coverage report` step — its CLI flag
+      # overrides pyproject.toml on that step.
+      run: |
+        uv run coverage run -m pytest tests/unit -v
+        uv run coverage xml --fail-under=0
+        uv run coverage html --fail-under=0
+        uv run coverage report --fail-under=${{ inputs.fail-under }}
+
+    - name: Comment coverage on PR
+      if: github.event_name == 'pull_request'
+      uses: orgoro/coverage@3f13a558c5af7376496aa4848bf0224aead366ac # v3.2
+      with:
+        coverageFile: coverage.xml
+        token: ${{ inputs.github-token }}
+
+    - name: Upload coverage artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: unit-test-coverage
+        path: |
+          coverage.xml
+          htmlcov/
+        retention-days: 14

--- a/.github/actions/connector-unit-tests/action.yaml
+++ b/.github/actions/connector-unit-tests/action.yaml
@@ -16,6 +16,14 @@ description: |
   Does NOT upload coverage to S3 — that wiring is per-app and stays in the
   caller's workflow if desired.
 
+outputs:
+  summary:
+    description: |
+      One-line pytest summary parsed from the test-output's final
+      `=== ... ===` line (e.g. "227 passed, 15 warnings in 4.01s").
+      Caller workflows can surface this in PR comments.
+    value: ${{ steps.tests.outputs.summary }}
+
 inputs:
   github-token:
     required: true
@@ -41,6 +49,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Run unit tests with coverage
+      id: tests
       shell: bash
       # xml/html subcommands ALSO honor pyproject.toml's
       # [tool.coverage.report].fail_under. Pin them to --fail-under=0 so
@@ -48,9 +57,18 @@ runs:
       # threshold gate is the final `coverage report` step — its CLI flag
       # overrides pyproject.toml on that step.
       run: |
-        uv run coverage run -m pytest tests/unit -v
-        uv run coverage xml --fail-under=0
-        uv run coverage html --fail-under=0
+        set +e
+        uv run coverage run -m pytest tests/unit -v 2>&1 | tee /tmp/unit-test-output.txt
+        TEST_EXIT_CODE=${PIPESTATUS[0]}
+        set -e
+        # Extract pytest summary line for caller PR comments.
+        SUMMARY=$(grep -E "^=+ .* =+$" /tmp/unit-test-output.txt | tail -1 | sed -E 's/^=+ *//; s/ *=+$//')
+        echo "summary=${SUMMARY:-no summary parsed}" >> "$GITHUB_OUTPUT"
+        # Always emit coverage artifacts, even if pytest failed.
+        uv run coverage xml --fail-under=0 || true
+        uv run coverage html --fail-under=0 || true
+        # Propagate pytest failure first; otherwise check coverage threshold.
+        if [ $TEST_EXIT_CODE -ne 0 ]; then exit $TEST_EXIT_CODE; fi
         uv run coverage report --fail-under=${{ inputs.fail-under }}
 
     - name: Comment coverage on PR


### PR DESCRIPTION
## Summary

Lands two reusable composite actions on `main` so connector repos (atlan-*-app) can adopt them via stable refs (today they pin a moving feature branch — that doesn't scale to 60+ repos).

| Action | Purpose |
|---|---|
| `.github/actions/connector-unit-tests/` | Runs `pytest tests/unit/` with coverage. Pins `coverage xml/html` to `--fail-under=0` so artifact generation never short-circuits; final `coverage report` step owns the threshold gate. |
| `.github/actions/connector-integration-tests/` | Installs Dapr + Temporal, starts the connector app server (`python main.py`), runs `pytest tests/integration/` with pytest-xdist installed transiently. |

These are the load-bearing pieces for the test-framework rollout across connectors.

## Architecture: critical fix #1 — stable version refs

Currently the actions live on `ci/connector-tests-composite-actions` (feature branch). Every consumer pins `@ci/connector-tests-composite-actions` — a **moving target**. Any commit to that branch affects all 60+ future consumers immediately.

After this lands:
1. Tag a release: `git tag v3.14.0 && git push --tags`
2. Connectors pin the tag: `@v3.14.0`
3. Subsequent updates → tag new releases; connectors bump intentionally

Standard SemVer-for-actions pattern.

## Architecture: critical fix #2 — pre-setup pattern for native deps

Connectors like `atlan-mssql-app` need OS-level libraries (ODBC 18, FreeTDS). Today mssql duplicates the entire setup in its own `mssql-test-stack/action.yml` — a DRY violation. This PR documents the **pre-step pattern**:

```yaml
steps:
  - uses: actions/checkout@v4
  - uses: ./.github/actions/<connector>-native-deps  # ~15 lines, OS install only
  - uses: atlanhq/application-sdk/.github/actions/connector-integration-tests@v3.14.0
    with: { app-name: <connector> }
```

No generic-action code change — `setup-deps`' internal re-checkout doesn't wipe system packages.

## Validation

In use end-to-end on:
- `atlan-athena-app#80` (unit + integration)
- `atlan-mssql-app#146` (unit + integration + sdr, all green)
- `atlan-mssql-app#148` (combined unit+integration via xdist + sdr + aggregator gate, all green)

## After merge

1. Tag `v3.14.0`
2. Update consumer pins on athena PR #80 + mssql PR #146/#148 from `@ci/...` → `@v3.14.0`
3. Close stale `ci/connector-tests-composite-actions` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)