### PR TITLE
ci(capability-manifest): trigger on label changes to unstick release PRs

### DIFF
--- a/.github/workflows/capability-manifest-check.yaml
+++ b/.github/workflows/capability-manifest-check.yaml
@@ -32,7 +32,7 @@ name: Capability Manifest Check
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
 
 # Cancel in-flight runs when the PR receives a new push, so we don't


### PR DESCRIPTION
## Summary

Add `labeled` and `unlabeled` to the `pull_request` trigger types on the Capability Manifest Check workflow so the required check actually fires on release PRs.

## Why

GitHub's recursion guard suppresses `pull_request.synchronize` events when a branch is force-pushed using `GITHUB_TOKEN`. The release flow force-pushes `bump-version-*` branches this way, so the workflow never re-runs against the new head SHA — leaving the required "Capability Manifest Drift" check stuck on "Expected — waiting for status to be reported" and blocking merge (e.g. PR #1861).

Labels are always toggled on release PRs (`atlan-ci` adds `release`; humans add e2e selectors), and `labeled` events fire normally regardless of the push token. Listening to them gives a reliable re-trigger on the current head SHA.

## Notes

- Workflow already no-ops on `bump-version-*` branches, so this is effectively a "report green" path for release PRs (~10s run).
- For normal PRs label toggles are rare; concurrency `cancel-in-progress` prevents churn.
- Sticky comment is deduped by header, so no comment spam.

## Test plan

- [ ] PR opens successfully, workflow runs on `opened`
- [ ] Toggle a label on this PR; verify the workflow re-runs on `labeled`
- [ ] After merge, next release PR's "Capability Manifest Drift" check reports green within ~10s of the `release` label being added