### PR TITLE
fix(temporal): use rpc_metadata setter for token refresh on running worker (DISTR-508)

### DIFF
--- a/application_sdk/execution/_temporal/auth.py
+++ b/application_sdk/execution/_temporal/auth.py
@@ -224,11 +224,18 @@ class TemporalAuthManager:
         logger.info("Token refresh loop exiting")
 
     async def _do_refresh(self, client: Client) -> None:
-        """Perform a single token refresh and update the Temporal client."""
+        """Perform a single token refresh and update the Temporal client.
+
+        Sets ``rpc_metadata`` rather than ``client.api_key``: the
+        ``rpc_metadata`` setter is the documented path for rotating auth
+        headers on a running client and worker. The ``authorization`` key
+        set here takes precedence over any value passed via ``api_key`` at
+        connect time.
+        """
         access_token = await self._get_token_service().get_token(force_refresh=True)
         expires_at = self._get_token_service().current_expires_at
 
-        client.api_key = access_token
+        client.rpc_metadata = {"authorization": f"Bearer {access_token}"}
 
         logger.info(
             "Temporal auth token refreshed (expires_at=%s)", expires_at or "unknown"


### PR DESCRIPTION
## Summary

- Switch the worker token-refresh path from `client.api_key = token` to `client.rpc_metadata = {"authorization": f"Bearer {token}"}` in `TemporalAuthManager._do_refresh`.
- The `api_key` setter does not propagate to a running worker's polling RPCs on the temporalio version we pin (≥1.27). The refresh loop logs success but the worker keeps using the original token and dies with `PermissionDenied` once the server expires it (~10 min in practice).
- The `rpc_metadata` setter is the path Temporal maintainers explicitly recommend for live header rotation — described in [thread #7622](https://community.temporal.io/t/refreshing-authorization-token-in-worker/7622) as *"built to update the underlying client on set"* and independently validated by another user in [thread #17883](https://community.temporal.io/t/how-to-refresh-jwt-token-without-restarting-worker-python-sdk-1-12-0/17883). It goes through `update_metadata` in the bridge client — a distinct path in Core from `update_api_key`.
- `authorization` set via `rpc_metadata` takes precedence over any value passed via `api_key` at connect time (per the temporalio `api_key` setter docstring), so the initial connect path is unchanged and the rotated header simply overrides on the next poll.
- No TLS renegotiation, no worker restart, no new `Client.connect`. Single-line behavioral change.

## Linear

DISTR-508

## Repro

Hive worker running in Docker against a real Atlan tenant:

```
07:58:38  Worker starts. Refresh interval = 479s.
08:06:37  "Refreshing OAuth2 token"
08:06:38  "Updated client RPC metadata with fresh token"   <- api_key setter fires
08:09:40  PermissionDenied on poll_workflow_task            <- worker dies 3 min after refresh
```

The refresh task ran, OAuth exchange succeeded, `client.api_key = new_token` was called — and the worker still crashed 3 minutes later. Primary evidence that the `api_key` mutation isn't reaching the worker's polling RPCs.

## Test plan

- [ ] Rebuild Hive image off this branch, run locally in Docker for at least 15 minutes (longer than the 10-minute token TTL).
- [ ] Confirm `Temporal auth token refreshed (expires_at=…)` fires at ~T+479s.
- [ ] Confirm worker is still polling successfully at T+722s and beyond (i.e. no `PermissionDenied` after the first refresh).
- [ ] Verify across at least two consecutive refresh cycles (~16+ minutes total).
- [ ] Spot-check that handler-mode HTTP endpoints (start_workflow etc.) still work — unary RPC path should be unaffected.
- [ ] No regression in non-auth runs (`auth_enabled=false`).

## Affected downstream

- `atlan-hive` (pins feat branch off `release/v2`) — same bug surface on v2; v2 fix is a separate PR.
- `atlan-documentdb-app` (pins `>=3.13.0`) — will pick up this fix on next SDK bump.
- All other v3 connector apps using Atlan-issued OAuth tokens for Temporal.

## Open questions for review

- Whether to file an upstream issue with `temporalio/sdk-python` documenting the `api_key`-setter-doesn't-propagate-to-workers behavior on 1.27. Possibly a regression from 1.12 (where a maintainer explicitly claimed `api_key` setter works "including internally by the worker"). Worth filing regardless so a future SDK release fixes the broken path and we can simplify.
- Whether to apply the same one-line change to v2's `clients/temporal.py:253` in a follow-up PR (separate branch).

## Notes

- Tested locally: pre-commit passes (`ruff`, `ruff-format`, `pyright`, `isort`).
- No changes to public API, no migration steps.