### PR TITLE
fix(toolkit): default emitEntrypoints to !entrypoints.isEmpty

### DIFF
--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -270,7 +270,7 @@ Set `entrypoints` to serve multiple marketplace tiles from one deployment. Per-e
 |---|---|---|---|
 | `entrypoints` | Listing<Entrypoint> | `[]` | Marketplace card / SDK entrypoint definitions. When non-empty, enables bundle mode. |
 | `emitAtlanYaml` | Boolean | `true` | Emit `atlan.yaml`. |
-| `emitEntrypoints` | Boolean | `true` | Emit the `entrypoints:` block. |
+| `emitEntrypoints` | Boolean | `!entrypoints.isEmpty` | Emit the `entrypoints:` block in `atlan.yaml`. Defaults to `true` when the consumer declared `entrypoints { ... }` (multi-entrypoint mode), `false` otherwise. Single-entrypoint apps suppress the block so downstream tooling (marketplace, frontend, Heracles) routes configmap fetches as `/configmaps/{name}` instead of `/configmaps/{display_name}-{name}?entrypoint={name}` — the latter 404s because the SDK only serves `app/generated/{name}.json`. |
 | `emitGeneratedArtifacts` | Boolean | `true` | Re-export entrypoint contract files. |
 
 **Entrypoint class:**
@@ -423,7 +423,7 @@ contract/app.pkl
 | `atlanYamlOverrides` | Mapping<String, Any> | `{}` | Deep overrides applied after typed fields and `metadata`. Use for exact rendered yaml control, including nested `deploy` overrides. |
 | `entrypoints` | Listing<Entrypoint> | `[]` | Marketplace card / SDK entrypoint definitions. |
 | `emitAtlanYaml` | Boolean | `true` | Emit `atlan.yaml`. Set `false` when using the bundle only for generated artifact layout / credential hoisting. |
-| `emitEntrypoints` | Boolean | `true` | Emit the `entrypoints:` block. Set `false` for marketplace paths that do not support entrypoint passthrough. |
+| `emitEntrypoints` | Boolean | `!entrypoints.isEmpty` | Emit the `entrypoints:` block. Defaults to `true` when the consumer declared `entrypoints { ... }` (multi-entrypoint mode), `false` when not. Set to `true` explicitly to force emission for the synthesized single-entrypoint case (rarely needed; primarily for backwards compatibility with consumers that still rely on the phantom block). |
 | `emitGeneratedArtifacts` | Boolean | `true` | Re-export entrypoint contract files. Credential configmaps are hoisted to the bundle root and deduped by filename; other files are emitted under `{entrypoint.name}/`. |
 | `additionalOutputFiles` | Mapping<String, FileOutput> | `{}` | Explicit root-level files to emit with the bundle, for example a customized `AgentConfig.pkl` output. |
 | `deploy` | Mapping<String, Any> | `{}` | Current flat deployment config. Unknown keys are passed through by local marketplace. |

--- a/contract-toolkit/examples/connection-ref/atlan.yaml
+++ b/contract-toolkit/examples/connection-ref/atlan.yaml
@@ -8,11 +8,6 @@ icon_url: https://assets.atlan.com/assets/trino.svg
 visibility: public
 build_tag: v1
 self_deployed_runtime: false
-entrypoints:
-- name: connection-ref
-  display_name: ConnectionRef Example
-  icon_url: https://assets.atlan.com/assets/trino.svg
-  type: connector
 deploy:
   execution_mode: native
   splitDeploymentEnabled: true

--- a/contract-toolkit/examples/deploy/atlan.yaml
+++ b/contract-toolkit/examples/deploy/atlan.yaml
@@ -8,11 +8,6 @@ icon_url: https://assets.atlan.com/assets/fullscreen-open.svg
 visibility: public
 build_tag: v1
 self_deployed_runtime: false
-entrypoints:
-- name: deploy
-  display_name: Deploy Config Example
-  icon_url: https://assets.atlan.com/assets/fullscreen-open.svg
-  type: connector
 deploy:
   execution_mode: native
   splitDeploymentEnabled: true

--- a/contract-toolkit/examples/fanin/atlan.yaml
+++ b/contract-toolkit/examples/fanin/atlan.yaml
@@ -8,11 +8,6 @@ icon_url: https://assets.atlan.com/assets/trino.svg
 visibility: public
 build_tag: v1
 self_deployed_runtime: false
-entrypoints:
-- name: fanin
-  display_name: Fan-in Example
-  icon_url: https://assets.atlan.com/assets/trino.svg
-  type: connector
 deploy:
   execution_mode: native
   splitDeploymentEnabled: true

--- a/contract-toolkit/examples/full/atlan.yaml
+++ b/contract-toolkit/examples/full/atlan.yaml
@@ -8,11 +8,6 @@ icon_url: https://assets.atlan.com/assets/fullscreen-open.svg
 visibility: public
 build_tag: v1
 self_deployed_runtime: false
-entrypoints:
-- name: full-featured
-  display_name: Full-Featured Example
-  icon_url: https://assets.atlan.com/assets/fullscreen-open.svg
-  type: connector
 deploy:
   execution_mode: native
   splitDeploymentEnabled: true

--- a/contract-toolkit/examples/minimal/atlan.yaml
+++ b/contract-toolkit/examples/minimal/atlan.yaml
@@ -8,11 +8,6 @@ icon_url: https://assets.atlan.com/assets/fullscreen-exit.svg
 visibility: public
 build_tag: v1
 self_deployed_runtime: false
-entrypoints:
-- name: minimal
-  display_name: Minimal Example
-  icon_url: https://assets.atlan.com/assets/fullscreen-exit.svg
-  type: connector
 deploy:
   execution_mode: native
   splitDeploymentEnabled: true

--- a/contract-toolkit/examples/publish-controls/atlan.yaml
+++ b/contract-toolkit/examples/publish-controls/atlan.yaml
@@ -8,11 +8,6 @@ icon_url: https://assets.atlan.com/assets/trino.svg
 visibility: public
 build_tag: v1
 self_deployed_runtime: false
-entrypoints:
-- name: publish-controls
-  display_name: Publish Controls Example
-  icon_url: https://assets.atlan.com/assets/trino.svg
-  type: connector
 deploy:
   execution_mode: native
   splitDeploymentEnabled: true

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -150,7 +150,32 @@ atlanYamlOverrides: Mapping<String, Any> = new Mapping {}
 emitAtlanYaml: Boolean = true
 
 /// Whether to emit the `entrypoints:` block into `atlan.yaml`.
-emitEntrypoints: Boolean = true
+///
+/// Default: `!entrypoints.isEmpty` — emit only when the consumer explicitly
+/// declared `entrypoints { ... }`. For apps that don't (the common
+/// single-entrypoint case), the block is omitted.
+///
+/// Why the default is opt-in:
+///
+/// When `entrypoints` is empty, the toolkit synthesizes a single-element
+/// list from the app's own identity (see `effectiveEntrypoints` below) and
+/// — until this default flipped — emitted it as an `entrypoints:` block in
+/// `atlan.yaml`. Downstream consumers (local-marketplace, frontend, Heracles)
+/// read the presence of `entrypoints:` as the signal that the app is in
+/// multi-entrypoint mode and build URLs of the shape
+/// `/configmaps/{display_name}-{entrypoint.name}?entrypoint={name}`. The
+/// SDK only serves `app/generated/{name}.json`, not
+/// `{display_name}-{name}.json`, so the configmap fetch 404s.
+///
+/// Single-entrypoint apps should therefore not emit the block. Apps that
+/// genuinely declare multiple entrypoints (`entrypoints { ... }`) continue
+/// to emit it as before — the existing `bundle` example exercises this
+/// path and its generated `atlan.yaml` is unchanged.
+///
+/// Set this to `true` explicitly to force emission for the synthesized
+/// single-entrypoint case (rarely needed; primarily for backwards
+/// compatibility with consumers that still rely on the phantom block).
+emitEntrypoints: Boolean = !entrypoints.isEmpty
 
 /// Whether to emit `app.yaml` in the output.
 emitAppYaml: Boolean = true

--- a/contract-toolkit/tests/open_source_examples_test.pkl
+++ b/contract-toolkit/tests/open_source_examples_test.pkl
@@ -151,6 +151,25 @@ facts {
     bundleApp.output.files.containsKey("atlan.yaml")
     bundleApp.output.files["atlan.yaml"].text.contains("name: crawler")
     bundleApp.output.files["atlan.yaml"].text.contains("name: miner")
+    // Multi-entrypoint apps explicitly declare `entrypoints { ... }`, so the
+    // `entrypoints:` block is emitted by default.
+    bundleApp.output.files["atlan.yaml"].text.contains("\nentrypoints:")
+  }
+
+  ["Single-entrypoint apps omit the synthesized entrypoints: block by default"] {
+    // Default `emitEntrypoints = !entrypoints.isEmpty`: when the consumer
+    // does not declare entrypoints, the toolkit synthesizes one internally
+    // for routing, but does NOT emit it to atlan.yaml. Downstream tooling
+    // (local-marketplace, frontend, Heracles) reads the absence of
+    // `entrypoints:` as the single-entrypoint signal and builds configmap
+    // URLs as `/configmaps/{name}` (not `/configmaps/{display_name}-{name}`),
+    // which is what the SDK actually serves at `app/generated/{name}.json`.
+    !minimalApp.output.files["atlan.yaml"].text.contains("\nentrypoints:")
+    !fullApp.output.files["atlan.yaml"].text.contains("\nentrypoints:")
+    !deployApp.output.files["atlan.yaml"].text.contains("\nentrypoints:")
+    !faninApp.output.files["atlan.yaml"].text.contains("\nentrypoints:")
+    !connectionRefApp.output.files["atlan.yaml"].text.contains("\nentrypoints:")
+    !publishControlsApp.output.files["atlan.yaml"].text.contains("\nentrypoints:")
   }
 
   ["Deploy example atlan.yaml includes typed KEDA, Dapr, resources, env, and deployOverrides"] {


### PR DESCRIPTION
## Why

`contract-toolkit/src/App.pkl` defaulted `emitEntrypoints = true`, which made **every single-entrypoint app** (any consumer that doesn't explicitly declare `entrypoints { ... }`) render a synthesized one-element `entrypoints:` block into its `atlan.yaml`.

That synthesized block trips a chain reaction downstream:

```
toolkit App.pkl  : emitEntrypoints: Boolean = true        ← always emits
       ↓
atlan.yaml       : entrypoints:
                   - name: <app-name>
                     display_name: <Display>
       ↓
local-marketplace: "this app has an entrypoints[] → multi-entrypoint card"
       ↓
frontend         : builds URL /configmaps/{display_name}-{entrypoint.name}?entrypoint={name}
       ↓
heracles         : sees ?entrypoint=, takes the multi-entrypoint branch
                   forwards name AS-IS to <app>/workflows/v1/configmap/{display_name}-{name}
       ↓
SDK              : looks for app/generated/{display_name}-{name}.json → NOT FOUND → 404
```

I hit this on `atlan-metabase-app`: hitting `GET /api/service/configmaps/Metabase-metabase?entrypoint=metabase` returned `ConfigMap 'Metabase-metabase' not found`. The SDK only serves `app/generated/metabase.json`, so the dashed configmap key never resolves.

I had to flip it manually in atlan-metabase-app's PKL (atlanhq/atlan-metabase-app#24, commit 3eae5b8) to ship around it — calling that out here so future apps don't trip over the same trap.

## What changed

Flipped the default:

```pkl
- emitEntrypoints: Boolean = true
+ emitEntrypoints: Boolean = !entrypoints.isEmpty
```

Plus an extended doc comment on the field explaining the chain and when to override.

The effect:

| App type | `entrypoints { ... }` declared? | `emitEntrypoints` default | Block emitted? |
|---|---|---|---|
| Single-entrypoint (minimal, full, deploy, etc.) | No | `false` | **No** (was: yes — phantom) |
| Multi-entrypoint (`bundle` example, future bundles) | Yes | `true` | Yes (unchanged) |

Apps that genuinely need to force emission for the synthesized case can still set `emitEntrypoints = true` explicitly. (Rarely needed; documented in the field comment.)

## Regenerated outputs

Six single-entrypoint example `atlan.yaml` files lose the phantom block:

- `examples/connection-ref/atlan.yaml`
- `examples/deploy/atlan.yaml`
- `examples/fanin/atlan.yaml`
- `examples/full/atlan.yaml`
- `examples/minimal/atlan.yaml`
- `examples/publish-controls/atlan.yaml`

`examples/bundle/atlan.yaml` is byte-identical (it explicitly declares two entrypoints).

## Tests

Added a targeted pkl assertion to `tests/open_source_examples_test.pkl`:

- New: `"Single-entrypoint apps omit the synthesized entrypoints: block by default"` — verifies all six single-entrypoint examples have no `entrypoints:` line.
- Strengthened: `"Bundle atlan.yaml lists both entrypoints"` — also asserts the block IS emitted (regression guard for the multi-entrypoint path).

```
100.0% tests pass [63 passed], 100.0% asserts pass [235 passed]
./scripts/check-invariants.sh  → All invariant checks passed.
```

## Cross-repo consumer impact

Per CLAUDE.md guidance, the consumers to think about:

- **atlan-frontend** / **heracles**: This fix *removes* the phantom multi-entrypoint signal. Heracles' single-entrypoint branch (`handler/configmap.go` URL-derivation path) is what we want all single-entrypoint apps to land in. No frontend/Heracles change needed.
- **blaze** / **atlan-automation-engine-app**: These read the generated `manifest.json` (DAG), not the `entrypoints:` block in `atlan.yaml`. Unaffected.
- **local-marketplace**: Single-entrypoint registration is the goal — without the phantom block it registers cards as `{argo_package_scope}-{name}` (e.g. `atlan-metabase`, matching `csa-hightouch`) instead of `{display_name}-{entrypoint.name}` (e.g. `Metabase-metabase`).
- **Existing app repos with toolkit-generated `atlan.yaml`**: On their next regeneration their `atlan.yaml` will drop the phantom block. This is the *desired* behavior — the block was causing the 404. If any specific consumer is somehow depending on the phantom block being present, they can opt back in with `emitEntrypoints = true`.

## Reference

- Originally surfaced in: atlanhq/atlan-metabase-app#24 (workaround applied via per-app `emitEntrypoints = false`).
- This PR fixes it at the source so the workaround is no longer needed.