### PR TITLE
docs(upgrade-v3): rewrite heartbeat guidance (ARUN-764)

### DIFF
--- a/.claude/skills/upgrade-v3/SKILL.md
+++ b/.claude/skills/upgrade-v3/SKILL.md
@@ -1384,14 +1384,13 @@ output_prefix = str(Path(tempfile.gettempdir()))
 ```
 The interim-apps framework handles S3 mapping in production.
 
-### auto_heartbeat_seconds triggers Dapr health check
+### Heartbeat - keep the defaults
 
-The auto-heartbeater creates a `DaprClient` which blocks on Dapr health check (60s timeout). For tasks that don't need fine-grained heartbeating, omit `auto_heartbeat_seconds`:
-```python
-@task(timeout_seconds=3600)  # no auto_heartbeat_seconds
-async def my_long_task(self, input: MyInput) -> MyOutput:
-    ...
-```
+The `@task` defaults (`heartbeat_timeout_seconds=60`, `auto_heartbeat_seconds=10`) are correct. Don't disable `auto_heartbeat_seconds` to "work around" missed beats - auto-heartbeat runs as a coroutine on the same event loop as your task body, so anything that blocks the loop blocks the beats. Fix it with `self.run_in_thread(...)`, async-native libraries, or `await asyncio.sleep(0)` chunking. If you see `Event loop blocked for X seconds during task ...` in worker logs, that's this failure mode.
+
+For long tasks, raise `timeout_seconds` (the overall activity budget), not `heartbeat_timeout_seconds` (the failure-detection knob - a higher value just delays retry on a dead worker). SQL templates set `timeout_seconds=1800, heartbeat_timeout_seconds=120, auto_heartbeat_seconds=30` (`application_sdk/templates/sql_app.py:508`) for long extracts - precedent if your work matches.
+
+For resume-on-retry, call `self.heartbeat(HeartbeatDetails(records_done=N))` at checkpoints - auto-heartbeat is keepalive only.
 
 ### Template base classes auto-register but do not leak workflows
 

--- a/.claude/skills/upgrade-v3/SKILL.md
+++ b/.claude/skills/upgrade-v3/SKILL.md
@@ -1386,7 +1386,7 @@ The interim-apps framework handles S3 mapping in production.
 
 ### Heartbeat - keep the defaults
 
-The `@task` defaults (`heartbeat_timeout_seconds=60`, `auto_heartbeat_seconds=10`) are correct. Don't disable `auto_heartbeat_seconds` to "work around" missed beats - auto-heartbeat runs as a coroutine on the same event loop as your task body, so anything that blocks the loop blocks the beats. Fix it with `self.run_in_thread(...)`, async-native libraries, or `await asyncio.sleep(0)` chunking. If you see `Event loop blocked for X seconds during task ...` in worker logs, that's this failure mode.
+The `@task` defaults (`heartbeat_timeout_seconds=60`, `auto_heartbeat_seconds=10`) are correct. Don't disable `auto_heartbeat_seconds` to "work around" missed beats - auto-heartbeat runs as a coroutine on the same event loop as your task body, so anything that blocks the loop blocks the beats. Fix it with async-native libraries (preferred), `self.run_in_thread(...)` (if async-native is impossible), or `await asyncio.sleep(0)` chunking. If you see `Event loop blocked for X seconds during task ...` in worker logs, that's this failure mode.
 
 For long tasks, raise `timeout_seconds` (the overall activity budget), not `heartbeat_timeout_seconds` (the failure-detection knob - a higher value just delays retry on a dead worker). SQL templates set `timeout_seconds=1800, heartbeat_timeout_seconds=120, auto_heartbeat_seconds=30` (`application_sdk/templates/sql_app.py:508`) for long extracts - precedent if your work matches.
 


### PR DESCRIPTION
## Summary

Replace the `### auto_heartbeat_seconds triggers Dapr health check` section in the `upgrade-v3` skill with accurate guidance. The original note misdiagnosed the symptom and prescribed the wrong fix; new guidance reflects what the code actually does.

## What was wrong

> The auto-heartbeater creates a `DaprClient` which blocks on Dapr health check (60s timeout). For tasks that don't need fine-grained heartbeating, omit `auto_heartbeat_seconds`.

Neither v2 nor v3 ever constructs a `DaprClient` in the heartbeat code path:

- **v3 main**: `application_sdk/execution/heartbeat.py:64-93` - `TemporalHeartbeatController.heartbeat()` / `heartbeat_keepalive()` call `activity.heartbeat()` only. `auto_heartbeat_loop` (line 117) is asyncio + that call.
- **v2.5.0**: `application_sdk/activities/common/utils.py:228-231` - `send_periodic_heartbeat` is `await asyncio.sleep(delay); activity.heartbeat(*details)`. No Dapr.

The 60s stall observers saw came from unrelated paths (observability metric sink, `is_component_registered()` gates on SecretStore/EventStore). Those were removed from the activity hot path in commit `afe3b3a7` (`feat: wire v3 infrastructure end-to-end and fix unit test hangs`), which explicitly: _"remove `is_component_registered` Dapr health-check calls from the hot path"_ and _"set `ATLAN_ENABLE_OBSERVABILITY_DAPR_SINK=false` in conftest.py to prevent metrics flush from connecting to Dapr sidecar"_.

So the symptom is also gone in v3.

## What the new guidance says

- Keep the `@task` defaults (`heartbeat_timeout_seconds=60`, `auto_heartbeat_seconds=10`); they are correct for almost every task.
- The real failure mode is **blocking the event loop**. Auto-heartbeat is a coroutine on the same loop as the task body; if the body blocks, the beats stop. Fix with `self.run_in_thread(...)`, async-native libraries, or `await asyncio.sleep(0)` chunking. The `Event loop blocked for X seconds during task ...` log line is this failure mode.
- For long tasks, raise `timeout_seconds` (overall activity budget), **not** `heartbeat_timeout_seconds` (failure-detection latency - raising it just delays retry on a dead worker). SQL templates' `1800/120/30` (`application_sdk/templates/sql_app.py:508`) is cited as precedent.
- For resume-on-retry, manual `self.heartbeat(HeartbeatDetails(records_done=N))` at checkpoints is still required; auto-heartbeat is keepalive only.

## Why this matters

Authors hit the failure mode (missed heartbeats under blocking work) and reach for the SKILL.md prescription. Disabling auto-heartbeat doesn't fix the underlying event-loop block - it just removes one signal that something is wrong. The skill is reference material for an interactive `/upgrade-v3` flow, so wrong guidance compounds across every connector migrated.

## Test plan

- [x] Tested via reupgrade thoughtspot app from v2 to v3, the heartbeat is now applied correctly

## Risk

Low. Skill file under `.claude/`, no production code touched.