### PR TITLE
fix(allowlist): bump CVE-2026-31812 expires by 30 days

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -99,7 +99,7 @@
     "package": "quinn-proto",
     "severity": "HIGH",
     "reason": "Base image — Dapr Rust dependency",
-    "expires": "2026-05-23",
+    "expires": "2026-06-25",
     "added_by": "mananjain99",
     "fix_available_date": null,
     "compensating_controls": null,


### PR DESCRIPTION
## Summary

One-line bump on `.security/base-allowlist.json` for **CVE-2026-31812** (quinn-proto, HIGH):

```diff
-    "expires": "2026-05-23",
+    "expires": "2026-06-25",
```

That's exactly **30 days** from today (2026-05-26) — the HIGH cap per `_expiry_policy.HIGH = 30` in this same file, and what `.github/scripts/validate_allowlist.py` enforces.

## Why this PR exists

The Trivy Security Gate (`scan / Security Gate`) on every downstream connector PR that uses `atlanhq/application-sdk/.github/workflows/build-and-scan.yaml@main` is currently blocked when the docker image contains quinn-proto 0.11.12 — because the allowlist entry expired on 2026-05-23.

Immediate impact:
- **atlanhq/atlan-sigma-app#34** (Sigma badge → certificateStatus, REQ-1095) — blocked
- **atlanhq/atlan-sigma-app#35** (CI tenant-deploy workflow port) — blocked
- Any other atlan-*-app PR that builds an image with the same base layer

## Why scope is one entry

Per operator direction, **this PR deliberately does NOT touch the other 33 allowlist entries** that have already expired (most on 2026-05-23 or 2026-05-24). Those will block other connectors but each needs its own renew-vs-remove-vs-upgrade triage. Bundling them all into a single PR would be a rubber-stamp; they deserve individual review by @mananjain99 / the security team.

If you want them all renewed in one shot, say so on this PR and I can expand the scope. Otherwise this stays narrow.

## Verification

- `diff --stat`: 1 file, 1 insertion, 1 deletion
- `python3 .github/scripts/validate_allowlist.py` — CVE-2026-31812 now passes ✅
- All other validation failures the script reports on this branch are **pre-existing on main** (the 33 entries above); not introduced by this PR

## Reviewer notes

- `quinn-proto` is a transitive Rust dependency in the Dapr base image. Connector apps don't invoke it at runtime; the exposure is base-image surface, same as the other Dapr Rust deps in the allowlist.
- No SDK base-image rebuild has shipped a quinn-proto 0.11.14 upgrade yet. When it does, this entry's `re_evaluation_trigger` ("expiry") should flip to closing the entry rather than renewing.
- Original owner: @mananjain99 (per `added_by`).

🤖 Surfaced by the connector-feature-triage pipeline (REQ-1072 → PR #34 on atlan-sigma-app).