### PR TITLE
fix(temporal): use rpc_metadata setter for token refresh on running worker (DISTR-508) [v2]

### DIFF
--- a/application_sdk/clients/temporal.py
+++ b/application_sdk/clients/temporal.py
@@ -247,10 +247,14 @@ class TemporalWorkflowClient(WorkflowClient):
 
                 await asyncio.sleep(refresh_interval)
 
-                # Get fresh token
+                # Get fresh token. Use rpc_metadata setter rather than
+                # client.api_key: rpc_metadata is the path Temporal documents
+                # for rotating auth headers on a running client and worker.
+                # The "authorization" key set here takes precedence over any
+                # value passed via api_key at connect time.
                 token = await self.auth_manager.get_access_token(force_refresh=True)
-                if self.client:
-                    self.client.api_key = token
+                if self.client and token:
+                    self.client.rpc_metadata = {"authorization": f"Bearer {token}"}
                 logger.info("Updated client RPC metadata with fresh token")
 
                 # Update our stored refresh interval for next iteration


### PR DESCRIPTION
## Summary

v2 mirror of [#1865](https://github.com/atlanhq/application-sdk/pull/1865) (v3 fix on main).

Switches the token-refresh path in `application_sdk/clients/temporal.py:_token_refresh_loop` from `self.client.api_key = token` to `self.client.rpc_metadata = {"authorization": f"Bearer {token}"}` — the path Temporal maintainers document as *"built to update the underlying client on set"* for live runtime header rotation.

The `authorization` key set via `rpc_metadata` takes precedence over `api_key` at connect time (per temporalio's `api_key` setter docstring), so the initial connect path remains unchanged.

## Linear

DISTR-508

## Why v2 also needs it

Hive pins a feat branch off `release/v2`. The same buggy code path (`self.client.api_key = token`) exists in v2's `clients/temporal.py:253`. Bumping temporalio cap on v2 (commit `0d28d911`, May 2026) pulled in the same 1.27.x line that ships sdk-core PR #1101's refactored client architecture — the version line where `client.api_key` mutation appears to stop propagating to running workers.

## Affected downstream

- `atlan-hive` (pins feat branch off `release/v2`) — primary motivator.
- Any other v2-pinned connector using Atlan-issued OAuth tokens for Temporal.

## Test plan

- [ ] Pre-commit clean (ruff / ruff-format / pyright).
- [ ] No public API changes — the `_token_refresh_loop` is internal.
- [ ] Verify on Hive (or any v2-pinned connector) that the worker survives past T+10min token expiry under active workflow load.

## Caveat

Local reproduction in a non-prod setup (against `developer-experience.atlan.com`) **did not** reproduce the PermissionDenied crash in idle-polling or short-workflow mode. The bug fires under active workflow execution conditions we haven't fully recreated outside prod. See PR #1865 discussion for the full evidence chain (Hive logs + DocumentDB KNOWN_ISSUES.md #2 + temporalio maintainer recommendation + sdk-core PR #1101 timing).

This PR sticks to the maintainer-documented runtime-rotation primitive; even if Hive's crash had a different root cause (e.g., transient Cloudflare flakiness), `rpc_metadata` is still the documented setter and the change is one line.