### PR TITLE
fix(timeouts): restore atlan.yaml timeout env vars as SDK fallbacks

### DIFF
--- a/.claude/skills/capability-manifest/SKILL.md
+++ b/.claude/skills/capability-manifest/SKILL.md
@@ -15,7 +15,7 @@ optional_triggers:
   - "what does the SDK expose"
   - "list public methods of the SDK"
 owner: connector-platform-team
-last_updated: "2026-05-04"
+last_updated: "2026-05-27"
 staleness_days: 30
 inputs:
   - mode: "create | refresh | verify (auto-detected from existing state)"

--- a/application_sdk/app/task.py
+++ b/application_sdk/app/task.py
@@ -16,13 +16,12 @@ Tasks support heartbeating for long-running operations:
 """
 
 import inspect
-import logging
-import os
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, cast, get_type_hints, overload
 
+from application_sdk.common._env import env_int
 from application_sdk.contracts.base import Input, Output
 from application_sdk.errors import CONTRACT_VALIDATION, ErrorCode
 from application_sdk.errors.leaves import InvalidInputError
@@ -32,36 +31,14 @@ if TYPE_CHECKING:
 
 F = TypeVar("F", bound=Callable[..., Any])
 
-logger = logging.getLogger(__name__)
-
 # Sentinel for "use default" - allows None to mean "disable"
 _USE_DEFAULT = object()
-
-
-def _env_int(key: str, default: int) -> int:
-    """Read an int env var, returning ``default`` when unset, empty, or unparsable."""
-    val = os.environ.get(key)
-    if not val:
-        return default
-    try:
-        return int(val)
-    except ValueError:
-        logger.warning(
-            "Ignoring non-integer env var %s=%r; falling back to default %d",
-            key,
-            val,
-            default,
-        )
-        return default
-
 
 # Env-var-driven defaults for @task timeouts. Read once at import time so the
 # value is stable for the process lifetime (same pattern as constants.py).
 # Apps that need a different per-task value pass it explicitly to @task().
-_DEFAULT_HEARTBEAT_TIMEOUT_SECONDS: int = _env_int(
-    "ATLAN_HEARTBEAT_TIMEOUT_SECONDS", 60
-)
-_DEFAULT_TIMEOUT_SECONDS: int = _env_int("ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS", 600)
+_DEFAULT_HEARTBEAT_TIMEOUT_SECONDS: int = env_int("ATLAN_HEARTBEAT_TIMEOUT_SECONDS", 60)
+_DEFAULT_TIMEOUT_SECONDS: int = env_int("ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS", 600)
 
 # Type alias for methods with single Input param returning Output
 TaskMethod = Callable[..., Any]
@@ -363,9 +340,9 @@ def task(
     Raises:
         TaskContractError: If the method doesn't follow the contract pattern.
     """
-    # Resolve sentinel values to defaults — evaluated at decoration time so that
-    # process-level env-var overrides (e.g. ATLAN_HEARTBEAT_TIMEOUT_SECONDS) are
-    # picked up even when the module-level constants were patched after import.
+    # Resolve sentinels at decoration time so test-side monkeypatching of
+    # _DEFAULT_* constants takes effect on subsequent @task uses; env-var values
+    # themselves are read once at module import via env_int().
     resolved_timeout: int = (
         _DEFAULT_TIMEOUT_SECONDS
         if timeout_seconds is _USE_DEFAULT

--- a/application_sdk/app/task.py
+++ b/application_sdk/app/task.py
@@ -16,6 +16,7 @@ Tasks support heartbeating for long-running operations:
 """
 
 import inspect
+import logging
 import os
 import warnings
 from collections.abc import Callable
@@ -31,18 +32,36 @@ if TYPE_CHECKING:
 
 F = TypeVar("F", bound=Callable[..., Any])
 
+logger = logging.getLogger(__name__)
+
 # Sentinel for "use default" - allows None to mean "disable"
 _USE_DEFAULT = object()
+
+
+def _env_int(key: str, default: int) -> int:
+    """Read an int env var, returning ``default`` when unset, empty, or unparsable."""
+    val = os.environ.get(key)
+    if not val:
+        return default
+    try:
+        return int(val)
+    except ValueError:
+        logger.warning(
+            "Ignoring non-integer env var %s=%r; falling back to default %d",
+            key,
+            val,
+            default,
+        )
+        return default
+
 
 # Env-var-driven defaults for @task timeouts. Read once at import time so the
 # value is stable for the process lifetime (same pattern as constants.py).
 # Apps that need a different per-task value pass it explicitly to @task().
-_DEFAULT_HEARTBEAT_TIMEOUT_SECONDS: int = int(
-    os.getenv("ATLAN_HEARTBEAT_TIMEOUT_SECONDS", "60")
+_DEFAULT_HEARTBEAT_TIMEOUT_SECONDS: int = _env_int(
+    "ATLAN_HEARTBEAT_TIMEOUT_SECONDS", 60
 )
-_DEFAULT_TIMEOUT_SECONDS: int = int(
-    os.getenv("ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS", "600")
-)
+_DEFAULT_TIMEOUT_SECONDS: int = _env_int("ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS", 600)
 
 # Type alias for methods with single Input param returning Output
 TaskMethod = Callable[..., Any]
@@ -254,7 +273,7 @@ def task(
     *,
     name: str | None = None,
     description: str = "",
-    timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
+    timeout_seconds: int | object = _USE_DEFAULT,
     retry_policy: "RetryPolicy | None" = None,
     retry_max_attempts: int = 3,
     retry_max_interval_seconds: int = 30,
@@ -340,7 +359,14 @@ def task(
     Raises:
         TaskContractError: If the method doesn't follow the contract pattern.
     """
-    # Resolve sentinel values to defaults
+    # Resolve sentinel values to defaults — evaluated at decoration time so that
+    # process-level env-var overrides (e.g. ATLAN_HEARTBEAT_TIMEOUT_SECONDS) are
+    # picked up even when the module-level constants were patched after import.
+    resolved_timeout: int = (
+        _DEFAULT_TIMEOUT_SECONDS
+        if timeout_seconds is _USE_DEFAULT
+        else cast("int", timeout_seconds)
+    )
     resolved_heartbeat_timeout: int | None = (
         _DEFAULT_HEARTBEAT_TIMEOUT_SECONDS
         if heartbeat_timeout_seconds is _USE_DEFAULT
@@ -366,7 +392,7 @@ def task(
             output_type=output_type,
             app_name="",  # Will be set by App registration
             description=description or fn.__doc__ or "",
-            timeout_seconds=timeout_seconds,
+            timeout_seconds=resolved_timeout,
             retry_policy=retry_policy,
             retry_max_attempts=retry_max_attempts,
             retry_max_interval_seconds=retry_max_interval_seconds,

--- a/application_sdk/app/task.py
+++ b/application_sdk/app/task.py
@@ -16,6 +16,7 @@ Tasks support heartbeating for long-running operations:
 """
 
 import inspect
+import os
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -33,6 +34,15 @@ F = TypeVar("F", bound=Callable[..., Any])
 # Sentinel for "use default" - allows None to mean "disable"
 _USE_DEFAULT = object()
 
+# Env-var-driven defaults for @task timeouts. Read once at import time so the
+# value is stable for the process lifetime (same pattern as constants.py).
+# Apps that need a different per-task value pass it explicitly to @task().
+_DEFAULT_HEARTBEAT_TIMEOUT_SECONDS: int = int(
+    os.getenv("ATLAN_HEARTBEAT_TIMEOUT_SECONDS", "60")
+)
+_DEFAULT_TIMEOUT_SECONDS: int = int(
+    os.getenv("ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS", "600")
+)
 
 # Type alias for methods with single Input param returning Output
 TaskMethod = Callable[..., Any]
@@ -95,8 +105,9 @@ class TaskMetadata:
     description: str = ""
     """Human-readable description."""
 
-    timeout_seconds: int = 600
-    """Default timeout for this task (10 minutes)."""
+    timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS
+    """Default timeout for this task. Defaults to ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS
+    env var, or 600s (10 minutes) if unset."""
 
     retry_policy: "RetryPolicy | None" = field(default=None, compare=False)
     """Full retry policy for this task. When provided, takes precedence over
@@ -110,11 +121,11 @@ class TaskMetadata:
     to prevent very long waits between retries. Default: 30 seconds.
     Ignored when retry_policy is set."""
 
-    heartbeat_timeout_seconds: int | None = 60
+    heartbeat_timeout_seconds: int | None = _DEFAULT_HEARTBEAT_TIMEOUT_SECONDS
     """Heartbeat timeout in seconds. If no heartbeat is received within this
     window, Temporal will consider the activity dead and restart it.
     Set to None to disable heartbeating entirely (legacy behavior).
-    Default: 60 seconds."""
+    Defaults to ATLAN_HEARTBEAT_TIMEOUT_SECONDS env var, or 60 seconds if unset."""
 
     auto_heartbeat_seconds: int | None = 10
     """Auto-heartbeat interval in seconds. The framework will automatically
@@ -229,7 +240,7 @@ def task(
     *,
     name: str | None = None,
     description: str = "",
-    timeout_seconds: int = 600,
+    timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
     retry_policy: "RetryPolicy | None" = None,
     retry_max_attempts: int = 3,
     retry_max_interval_seconds: int = 30,
@@ -243,7 +254,7 @@ def task(
     *,
     name: str | None = None,
     description: str = "",
-    timeout_seconds: int = 600,
+    timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
     retry_policy: "RetryPolicy | None" = None,
     retry_max_attempts: int = 3,
     retry_max_interval_seconds: int = 30,
@@ -331,7 +342,7 @@ def task(
     """
     # Resolve sentinel values to defaults
     resolved_heartbeat_timeout: int | None = (
-        60
+        _DEFAULT_HEARTBEAT_TIMEOUT_SECONDS
         if heartbeat_timeout_seconds is _USE_DEFAULT
         else cast("int | None", heartbeat_timeout_seconds)
     )

--- a/application_sdk/app/task.py
+++ b/application_sdk/app/task.py
@@ -338,7 +338,9 @@ def task(
         func: The function to decorate (when used without parentheses).
         name: Override the task name (defaults to function name).
         description: Human-readable description.
-        timeout_seconds: Activity timeout (default 10 minutes).
+        timeout_seconds: Activity timeout in seconds. Defaults to
+            ``ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS`` env var, or 600 s (10 min)
+            if unset. Explicit values take precedence over the env var.
         retry_policy: Full retry policy. When provided, takes precedence over
             retry_max_attempts and retry_max_interval_seconds.
         retry_max_attempts: Maximum retry attempts (default 3). Ignored when
@@ -346,9 +348,11 @@ def task(
         retry_max_interval_seconds: Maximum interval between retries in seconds.
             Caps exponential backoff to prevent very long waits. Default: 30 seconds.
             Ignored when retry_policy is provided.
-        heartbeat_timeout_seconds: Heartbeat timeout - if no heartbeat is received
-            within this window, Temporal restarts the activity. Set to None to
-            disable heartbeating entirely. Default: 60 seconds.
+        heartbeat_timeout_seconds: Heartbeat timeout in seconds — if no heartbeat
+            is received within this window, Temporal restarts the activity. Set to
+            None to disable heartbeating entirely. Defaults to
+            ``ATLAN_HEARTBEAT_TIMEOUT_SECONDS`` env var, or 60 s if unset.
+            Explicit values take precedence over the env var.
         auto_heartbeat_seconds: Auto-heartbeat interval - framework sends
             heartbeats at this rate in a background task. Set to None to disable
             auto-heartbeating (manual only). Default: 10 seconds (~1/6 of timeout).

--- a/application_sdk/common/_env.py
+++ b/application_sdk/common/_env.py
@@ -6,7 +6,7 @@ import os
 logger = logging.getLogger(__name__)
 
 
-def env_int(key: str, default: int) -> int:
+def env_int(key: str, default: int = 0) -> int:
     """Read an int env var, returning ``default`` when unset, empty, or unparsable.
 
     A malformed value like ``ATLAN_HANDLER_PORT="not-a-number"`` falls through

--- a/application_sdk/common/_env.py
+++ b/application_sdk/common/_env.py
@@ -1,0 +1,27 @@
+"""Internal env-var parsing helpers shared across SDK modules."""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def env_int(key: str, default: int) -> int:
+    """Read an int env var, returning ``default`` when unset, empty, or unparsable.
+
+    A malformed value like ``ATLAN_HANDLER_PORT="not-a-number"`` falls through
+    to the default instead of crashing startup.
+    """
+    val = os.environ.get(key)
+    if not val:
+        return default
+    try:
+        return int(val)
+    except ValueError:
+        logger.warning(
+            "Ignoring non-integer env var %s=%r; falling back to default %d",
+            key,
+            val,
+            default,
+        )
+        return default

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -269,9 +269,14 @@ WORKFLOW_AUTH_CLIENT_SECRET_KEY = os.getenv(
 )
 
 # REMOVED: HEARTBEAT_TIMEOUT, START_TO_CLOSE_TIMEOUT, GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS
-# These were never used. See ExecutionSettings for the actual runtime values:
+# The env-var fallbacks for heartbeat and start-to-close timeouts are now read in
+# application_sdk/app/task.py (_DEFAULT_HEARTBEAT_TIMEOUT_SECONDS,
+# _DEFAULT_TIMEOUT_SECONDS) and used as the defaults for TaskMetadata fields and
+# the @task decorator. Per-task overrides still take precedence.
+#   ATLAN_HEARTBEAT_TIMEOUT_SECONDS → default heartbeat_timeout_seconds for @task
+#   ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS → default timeout_seconds for @task
+# ExecutionSettings owns the graceful shutdown timeout:
 #   - ExecutionSettings.graceful_shutdown_timeout_seconds (TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT)
-#   - @task(timeout_seconds=..., heartbeat_timeout_seconds=...) for per-task timeouts
 
 #: Delay before initiating worker shutdown after receiving a termination signal.
 #: This gives the event loop time to flush in-flight activity completions

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -1653,6 +1653,11 @@ def create_app_handler_service(
                 args=[input_data],
                 id=workflow_id,
                 task_queue=_workflow_config.task_queue,
+                execution_timeout=(
+                    timedelta(hours=_workflow_config.workflow_max_timeout_hours)
+                    if _workflow_config.workflow_max_timeout_hours
+                    else None
+                ),
             )
             return JSONResponse(
                 content={

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -530,6 +530,13 @@ def create_app_handler_service(
             Temporal Rust-core metrics from ``prometheus_bind_address``.
         prometheus_bind_address: Loopback bind address for the Temporal
             Rust-core metrics endpoint. Defaults to the SDK constant.
+        workflow_max_timeout_hours: Optional ceiling on workflow execution time in
+            hours. When set, passed as ``execution_timeout`` to Temporal on every
+            ``/workflows/v1/start`` and ``/events/v1/{event_id}`` call. ``None``
+            (the default) means no SDK-level ceiling — the Temporal namespace
+            default applies. Reads ``ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS`` env var
+            when constructed via :class:`AppConfig`; non-positive values are
+            treated as ``None`` with a boot-time warning.
 
     Returns:
         Configured FastAPI application.

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -37,7 +37,7 @@ import re
 import shutil
 import tempfile
 import warnings
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Annotated, Any, cast
 from uuid import uuid4
@@ -361,6 +361,9 @@ class WorkflowClientConfig:
     enable_temporal_core_metrics: bool = True
     prometheus_bind_address: str = ""
 
+    # Workflow execution timeout
+    workflow_max_timeout_hours: int | None = None
+
     def is_configured(self) -> bool:
         return bool(self.host and self.app_class and self.app_name)
 
@@ -499,6 +502,7 @@ def create_app_handler_service(
     frontend_assets_path: str = "app/generated/frontend/static",
     enable_temporal_core_metrics: bool = True,
     prometheus_bind_address: str = "",
+    workflow_max_timeout_hours: int | None = None,
     # Deprecated: state_store is no longer used. Credential resolution now
     # goes through DaprCredentialVault exclusively. Passing this parameter
     # emits a DeprecationWarning. Will be removed in v3.2.0.
@@ -563,6 +567,7 @@ def create_app_handler_service(
         auth_scopes=auth_scopes,
         enable_temporal_core_metrics=enable_temporal_core_metrics,
         prometheus_bind_address=prometheus_bind_address,
+        workflow_max_timeout_hours=workflow_max_timeout_hours,
     )
 
     from application_sdk.constants import (  # noqa: PLC0415 — cold path: only at handler service startup
@@ -1035,6 +1040,11 @@ def create_app_handler_service(
                 id=workflow_id,
                 task_queue=_workflow_config.task_queue,
                 memo=corr_ctx.to_temporal_memo(),
+                execution_timeout=(
+                    timedelta(hours=_workflow_config.workflow_max_timeout_hours)
+                    if _workflow_config.workflow_max_timeout_hours
+                    else None
+                ),
             )
 
             logger.info(

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -972,6 +972,7 @@ def run_handler_mode(config: AppConfig) -> None:
         secret_store=infra.secret_store,
         storage=infra.storage,
         frontend_assets_path=config.frontend_assets_path,
+        workflow_max_timeout_hours=config.workflow_max_timeout_hours,
     )
 
     from application_sdk.infrastructure.context import (  # noqa: PLC0415 — cold path: only when infrastructure init is needed

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -33,6 +33,7 @@ import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NoReturn
 
+from application_sdk.common._env import env_int as _env_int
 from application_sdk.discovery import (
     load_app_class,
     load_handler_class,
@@ -554,28 +555,6 @@ def _derive_task_queue(app_module: str) -> str:
     if app_name:
         return app_name
     return f"{_derive_service_name(app_module)}-queue"
-
-
-def _env_int(key: str, default: int = 0) -> int:
-    """Read an int env var, returning ``default`` when unset, empty, or unparsable.
-
-    A malformed value like ``ATLAN_HANDLER_PORT="not-a-number"`` falls through
-    to the next key instead of crashing startup.
-    """
-    val = os.environ.get(key)
-    if not val:
-        return default
-    try:
-        return int(val)
-    except ValueError:
-        logger.warning(
-            "Ignoring non-integer env var %s=%r; falling back to default %d",
-            key,
-            val,
-            default,
-            exc_info=True,
-        )
-        return default
 
 
 def _parse_workflow_max_timeout_hours() -> int | None:

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -319,8 +319,7 @@ class AppConfig:
             max_concurrent_storage_transfers=_env_int(
                 "ATLAN_MAX_CONCURRENT_STORAGE_TRANSFERS", 4
             ),
-            workflow_max_timeout_hours=_env_int("ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS", 0)
-            or None,
+            workflow_max_timeout_hours=_parse_workflow_max_timeout_hours(),
         )
 
 
@@ -577,6 +576,19 @@ def _env_int(key: str, default: int = 0) -> int:
             exc_info=True,
         )
         return default
+
+
+def _parse_workflow_max_timeout_hours() -> int | None:
+    """Parse ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS, returning None for unset or non-positive values."""
+    hours = _env_int("ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS", 0)
+    if hours <= 0:
+        if hours < 0:
+            logger.warning(
+                "ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS=%d is non-positive; ignoring.",
+                hours,
+            )
+        return None
+    return hours
 
 
 def _build_dev_config(

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -181,6 +181,12 @@ class AppConfig:
     """Maximum concurrent object-store uploads/downloads.
     Reads same env var as constants.MAX_CONCURRENT_STORAGE_TRANSFERS."""
 
+    workflow_max_timeout_hours: int | None = None
+    """Maximum workflow execution timeout in hours. When set, passed as
+    execution_timeout to Temporal on every /workflows/v1/start call.
+    Reads env var ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS. None means no SDK-level
+    ceiling (Temporal namespace default applies)."""
+
     def __post_init__(self) -> None:
         """Derive task_queue from app_module when not explicitly set."""
         if not self.task_queue and self.app_module:
@@ -313,6 +319,8 @@ class AppConfig:
             max_concurrent_storage_transfers=_env_int(
                 "ATLAN_MAX_CONCURRENT_STORAGE_TRANSFERS", 4
             ),
+            workflow_max_timeout_hours=_env_int("ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS", 0)
+            or None,
         )
 
 
@@ -1125,6 +1133,7 @@ async def run_combined_mode(config: AppConfig) -> None:
         auth_scopes=config.auth_scopes,
         enable_temporal_core_metrics=config.enable_temporal_core_metrics,
         prometheus_bind_address=config.prometheus_bind_address,
+        workflow_max_timeout_hours=config.workflow_max_timeout_hours,
         secret_store=infra.secret_store,
         storage=infra.storage,
         frontend_assets_path=config.frontend_assets_path,

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.13.2
-source-sha:    802c1284630b7045881ed7eb1b1dd884168214fd
-source-date:   2026-05-25T22:48:09+05:30
+sdk-version:   3.13.3
+source-sha:    43a08735157173a4ac04a119cb10f96ff2812b65
+source-date:   2026-05-27T11:23:14+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.13.3
-source-sha:    43a08735157173a4ac04a119cb10f96ff2812b65
-source-date:   2026-05-27T11:23:14+01:00
+source-sha:    782d06bcee6f4c643d341e6001b7096dc4a83d53
+source-date:   2026-05-27T12:59:26+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/docs/concepts/handlers.md
+++ b/docs/concepts/handlers.md
@@ -212,6 +212,23 @@ class MySQLHandler(Handler):
             ])
 ```
 
+## Workflow Execution Timeout
+
+By default the Temporal namespace ceiling applies to workflows started by the handler service. To cap execution time at the SDK level, set `ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS` in your deployment environment:
+
+| Env var | Default | Effect |
+|---|---|---|
+| `ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS` | unset (no SDK cap) | Maximum wall-clock hours a workflow may run before Temporal terminates it. Applies to every workflow started via `/workflows/v1/start` and `/events/v1/event/{event_id}`. |
+
+Non-positive values (`0`, negative numbers) are treated as unset and emit a boot-time warning. Set in `atlan.yaml`:
+
+```yaml
+# atlan.yaml
+env:
+  - name: ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS
+    value: "4"   # workflows are capped at 4 hours
+```
+
 ## Testing Handlers
 
 Test handlers by injecting mock infrastructure:

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -69,6 +69,30 @@ class MyConnector(App):
 
 There is no `@auto_heartbeater` decorator in v3. Heartbeating is declarative.
 
+### Process-wide timeout defaults via env vars
+
+When no explicit value is passed to `@task`, the framework reads two env vars at
+process startup:
+
+| Env var | Default | Controls |
+|---|---|---|
+| `ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS` | `600` (10 min) | `timeout_seconds` — Temporal kills the activity after this many seconds |
+| `ATLAN_HEARTBEAT_TIMEOUT_SECONDS` | `60` | `heartbeat_timeout_seconds` — Temporal restarts the activity if no heartbeat is received within this window |
+
+Set these in `atlan.yaml` (or your deployment env) to apply a fleet-wide default
+without touching every `@task` decorator:
+
+```yaml
+# atlan.yaml
+env:
+  - name: ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS
+    value: "1800"   # 30 min default for all tasks in this app
+  - name: ATLAN_HEARTBEAT_TIMEOUT_SECONDS
+    value: "120"    # 2 min heartbeat window
+```
+
+Explicit `@task(timeout_seconds=...)` values always take precedence over the env vars.
+
 ## Manual Heartbeats with Progress
 
 For tasks that should resume from where they left off after a retry, send typed heartbeat details:

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,7 @@ coverage==7.13.5
 cryptography==48.0.0
     # via
     #   authlib
+    #   pyjwt
     #   trustme
 distlib==0.4.0
     # via virtualenv
@@ -253,6 +254,7 @@ pygments==2.20.0
     # via
     #   pytest
     #   rich
+pyjwt==2.12.1
 pytest==9.0.3
     # via
     #   pytest-asyncio

--- a/tests/unit/app/test_task.py
+++ b/tests/unit/app/test_task.py
@@ -408,6 +408,8 @@ class TestTaskEnvVarDefaults:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A non-integer env var value falls back to the hardcoded default."""
+        from application_sdk.common._env import env_int
+
         monkeypatch.setenv("ATLAN_HEARTBEAT_TIMEOUT_SECONDS", "not-a-number")
-        result = self._task_module()._env_int("ATLAN_HEARTBEAT_TIMEOUT_SECONDS", 60)
+        result = env_int("ATLAN_HEARTBEAT_TIMEOUT_SECONDS", 60)
         assert result == 60

--- a/tests/unit/app/test_task.py
+++ b/tests/unit/app/test_task.py
@@ -336,3 +336,78 @@ class TestTaskRetryPolicy:
         metadata = get_task_metadata(MyApp.my_task)
         assert metadata is not None
         assert metadata.retry_policy is None
+
+
+# =============================================================================
+# Env-var-driven defaults
+# =============================================================================
+
+
+class TestTaskEnvVarDefaults:
+    """Tests for env-var-driven timeout defaults."""
+
+    @staticmethod
+    def _task_module():
+        import sys
+
+        # application_sdk/app/__init__.py re-exports `task` as an attribute,
+        # so `import application_sdk.app.task as m` gives the function, not the
+        # module. sys.modules always holds the real module object.
+        return sys.modules["application_sdk.app.task"]
+
+    def test_heartbeat_timeout_from_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ATLAN_HEARTBEAT_TIMEOUT_SECONDS overrides heartbeat_timeout_seconds default."""
+        monkeypatch.setattr(
+            self._task_module(), "_DEFAULT_HEARTBEAT_TIMEOUT_SECONDS", 300
+        )
+
+        class MyApp:
+            @task
+            async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                return SimpleOutput()
+
+        metadata = get_task_metadata(MyApp.my_task)
+        assert metadata is not None
+        assert metadata.heartbeat_timeout_seconds == 300
+
+    def test_start_to_close_timeout_from_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS overrides timeout_seconds default."""
+        monkeypatch.setattr(self._task_module(), "_DEFAULT_TIMEOUT_SECONDS", 1800)
+
+        class MyApp:
+            @task
+            async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                return SimpleOutput()
+
+        metadata = get_task_metadata(MyApp.my_task)
+        assert metadata is not None
+        assert metadata.timeout_seconds == 1800
+
+    def test_explicit_task_param_overrides_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit @task parameter takes precedence over env-var default."""
+        monkeypatch.setattr(
+            self._task_module(), "_DEFAULT_HEARTBEAT_TIMEOUT_SECONDS", 300
+        )
+
+        class MyApp:
+            @task(heartbeat_timeout_seconds=120)
+            async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                return SimpleOutput()
+
+        metadata = get_task_metadata(MyApp.my_task)
+        assert metadata is not None
+        assert metadata.heartbeat_timeout_seconds == 120
+
+    def test_invalid_env_var_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-integer env var value falls back to the hardcoded default."""
+        monkeypatch.setenv("ATLAN_HEARTBEAT_TIMEOUT_SECONDS", "not-a-number")
+        result = self._task_module()._env_int("ATLAN_HEARTBEAT_TIMEOUT_SECONDS", 60)
+        assert result == 60

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -3519,6 +3519,80 @@ class TestStartWorkflowExtras:
             patcher.stop()
 
 
+class TestStartWorkflowExecutionTimeout:
+    """Tests for execution_timeout wiring in /workflows/v1/start."""
+
+    def setup_method(self) -> None:
+        from application_sdk.app.registry import AppRegistry, TaskRegistry
+
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    def teardown_method(self) -> None:
+        from application_sdk.app.registry import AppRegistry, TaskRegistry
+
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    def _wire(self, app_cls, workflow_max_timeout_hours=None):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        svc = create_app_handler_service(
+            _TestHandler(),
+            app_name="timeout-test",
+            app_class=app_cls,
+            temporal_host="temporal:7233",
+            workflow_max_timeout_hours=workflow_max_timeout_hours,
+        )
+        mock_client = MagicMock()
+        mock_handle = MagicMock()
+        mock_handle.id = "wf-id"
+        mock_handle.result_run_id = "run-id"
+        mock_client.start_workflow = AsyncMock(return_value=mock_handle)
+        patcher = patch(
+            "application_sdk.handler.service._get_temporal_client",
+            new=AsyncMock(return_value=mock_client),
+        )
+        patcher.start()
+        return TestClient(svc, raise_server_exceptions=False), mock_client, patcher
+
+    def test_execution_timeout_set_when_configured(self) -> None:
+        """execution_timeout is passed to start_workflow when workflow_max_timeout_hours is set."""
+        from datetime import timedelta
+
+        from application_sdk.app.base import App
+
+        class _TApp(App):
+            async def run(self, input: _RoutingInput) -> _RoutingOutput:
+                return _RoutingOutput()
+
+        client, mock_client, patcher = self._wire(_TApp, workflow_max_timeout_hours=48)
+        try:
+            response = client.post("/workflows/v1/start", json={"name": "x"})
+            assert response.status_code == 200
+            kwargs = mock_client.start_workflow.call_args.kwargs
+            assert kwargs["execution_timeout"] == timedelta(hours=48)
+        finally:
+            patcher.stop()
+
+    def test_execution_timeout_none_when_not_configured(self) -> None:
+        """execution_timeout is None when workflow_max_timeout_hours is not set."""
+        from application_sdk.app.base import App
+
+        class _TApp2(App):
+            async def run(self, input: _RoutingInput) -> _RoutingOutput:
+                return _RoutingOutput()
+
+        client, mock_client, patcher = self._wire(_TApp2)
+        try:
+            response = client.post("/workflows/v1/start", json={"name": "x"})
+            assert response.status_code == 200
+            kwargs = mock_client.start_workflow.call_args.kwargs
+            assert kwargs["execution_timeout"] is None
+        finally:
+            patcher.stop()
+
+
 class TestUploadFileEndpoint:
     """Tests for POST /workflows/v1/file."""
 

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -3854,6 +3854,78 @@ class TestEventTriggerEndpoint:
         finally:
             self._teardown()
 
+    def test_event_execution_timeout_set_when_configured(self) -> None:
+        """execution_timeout is passed to start_workflow on the event route when configured."""
+        from datetime import timedelta
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from application_sdk.handler.contracts import EventTriggerConfig
+
+        try:
+            app_cls = self._make_event_app()
+            trigger = EventTriggerConfig(
+                event_id="t1", event_type="topic", event_name="ev"
+            )
+            app = create_app_handler_service(
+                _TestHandler(),
+                app_name="ev-test",
+                app_class=app_cls,
+                temporal_host="t:7233",
+                event_triggers=[trigger],
+                workflow_max_timeout_hours=48,
+            )
+            mock_client = MagicMock()
+            mock_handle = MagicMock()
+            mock_handle.id = "wf-id"
+            mock_handle.result_run_id = "run-id"
+            mock_client.start_workflow = AsyncMock(return_value=mock_handle)
+            with patch(
+                "application_sdk.handler.service._get_temporal_client",
+                new=AsyncMock(return_value=mock_client),
+            ):
+                client = TestClient(app)
+                response = client.post("/events/v1/event/t1", json={})
+            assert response.status_code == 200
+            kwargs = mock_client.start_workflow.call_args.kwargs
+            assert kwargs["execution_timeout"] == timedelta(hours=48)
+        finally:
+            self._teardown()
+
+    def test_event_execution_timeout_none_when_not_configured(self) -> None:
+        """execution_timeout is None on the event route when workflow_max_timeout_hours is unset."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from application_sdk.handler.contracts import EventTriggerConfig
+
+        try:
+            app_cls = self._make_event_app()
+            trigger = EventTriggerConfig(
+                event_id="t1", event_type="topic", event_name="ev"
+            )
+            app = create_app_handler_service(
+                _TestHandler(),
+                app_name="ev-test",
+                app_class=app_cls,
+                temporal_host="t:7233",
+                event_triggers=[trigger],
+            )
+            mock_client = MagicMock()
+            mock_handle = MagicMock()
+            mock_handle.id = "wf-id"
+            mock_handle.result_run_id = "run-id"
+            mock_client.start_workflow = AsyncMock(return_value=mock_handle)
+            with patch(
+                "application_sdk.handler.service._get_temporal_client",
+                new=AsyncMock(return_value=mock_client),
+            ):
+                client = TestClient(app)
+                response = client.post("/events/v1/event/t1", json={})
+            assert response.status_code == 200
+            kwargs = mock_client.start_workflow.call_args.kwargs
+            assert kwargs["execution_timeout"] is None
+        finally:
+            self._teardown()
+
 
 class TestFrontendHomeEndpoint:
     """Tests for GET / (frontend index.html)."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -22,6 +22,7 @@ from application_sdk.main import (
     _log_dapr_components,
     _loop_exception_handler,
     _parse_all_component_yamls,
+    _parse_workflow_max_timeout_hours,
     main,
     parse_args,
     run_combined_mode,
@@ -370,6 +371,39 @@ class TestAppConfigFromArgsAndEnv:
         args = self._make_args()
         config = AppConfig.from_args_and_env(args)
         assert config.task_queue == "custom-queue"
+
+
+class TestParseWorkflowMaxTimeoutHours:
+    """Tests for _parse_workflow_max_timeout_hours()."""
+
+    def test_positive_value_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A positive env var value is returned as-is."""
+        monkeypatch.setenv("ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS", "4")
+        assert _parse_workflow_max_timeout_hours() == 4
+
+    def test_zero_returns_none_silently(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Zero is treated as unset — returns None without a warning."""
+        monkeypatch.setenv("ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS", "0")
+        with patch("application_sdk.main.logger") as mock_log:
+            result = _parse_workflow_max_timeout_hours()
+        assert result is None
+        mock_log.warning.assert_not_called()
+
+    def test_negative_returns_none_and_warns(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A negative value returns None and emits a warning."""
+        monkeypatch.setenv("ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS", "-5")
+        with patch("application_sdk.main.logger") as mock_log:
+            result = _parse_workflow_max_timeout_hours()
+        assert result is None
+        mock_log.warning.assert_called_once()
+        assert "ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS" in mock_log.warning.call_args[0][0]
+
+    def test_unset_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unset env var returns None."""
+        monkeypatch.delenv("ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS", raising=False)
+        assert _parse_workflow_max_timeout_hours() is None
 
 
 class TestRunMain:


### PR DESCRIPTION
## Summary

- Restores `ATLAN_HEARTBEAT_TIMEOUT_SECONDS` and `ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS` as env-var-driven defaults for `@task` timeouts (`TaskMetadata.heartbeat_timeout_seconds` and `timeout_seconds`). Explicit `@task()` params still take precedence.
- Restores `ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS` — read by `AppConfig.from_args_and_env`, threaded through `create_app_handler_service` → `WorkflowClientConfig`, and passed as `execution_timeout` to `client.start_workflow()` on the `/workflows/v1/start` path.

## Context

Closes BLDX-1339. These three env vars were removed during the v2→v3 migration and their removal was noted in `constants.py` as `# REMOVED`. As a result, `atlan.yaml` declarations like `ATLAN_HEARTBEAT_TIMEOUT_SECONDS: '600'` were silently ignored at runtime — activities defaulted to 60s heartbeat regardless of manifest config (confirmed via Temporal event histories showing `heartbeatTimeout: 60s` on a connector declaring 600).

## Test plan

- [x] Unit tests pass (`tests/unit` — 4548 pass)
- [x] Pre-commit clean (ruff, ruff-format, isort, pyright all pass)
- [ ] Verify on a connector with `ATLAN_HEARTBEAT_TIMEOUT_SECONDS` set in `atlan.yaml` that activities show the configured heartbeat timeout in Temporal event history
- [ ] Verify `ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS` is respected on the `/workflows/v1/start` path (dev/manual invocation)

## Notes

The AE orchestrated path (child workflows started directly by the AE orchestrator) is **not** affected by the `ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS` change here — that path sets `execution_timeout` from the contract manifest's `errorHandling.startToCloseTimeoutSeconds` on each DAG node. The heartbeat and start-to-close fixes apply to all paths since they govern activity-level timeouts on the worker.