### PR TITLE
fix(storage): allow GCS binding to use ADC / Workload Identity

### DIFF
--- a/application_sdk/storage/binding.py
+++ b/application_sdk/storage/binding.py
@@ -212,10 +212,16 @@ def create_store_from_binding(
         bucket = meta.get("bucket", "")
         gcs_config: dict[str, str] = {}
 
-        # Build service account JSON from Dapr component metadata fields
-        # (injected from gcp-service-account-creds secret via Helm).
-        sa_data = {k: meta[k] for k in GCS_SERVICE_ACCOUNT_FIELDS if k in meta}
-        if sa_data:
+        # Build service-account JSON only when actual credential material is
+        # supplied.  ``project_id`` alone is not credential material — daprd's
+        # gcp-bucket binding schema requires ``project_id`` in component
+        # metadata even on the ADC path (Workload Identity / GKE metadata
+        # server / GOOGLE_APPLICATION_CREDENTIALS), so a config containing
+        # only ``bucket`` + ``project_id`` must fall through to ADC rather
+        # than be synthesised into a partial SA JSON that obstore would
+        # reject for missing ``private_key``.
+        if any(meta.get(f) for f in ("private_key", "private_key_id")):
+            sa_data = {k: meta[k] for k in GCS_SERVICE_ACCOUNT_FIELDS if k in meta}
             # Normalize escaped newlines in private_key PEM blocks — Helm
             # templating from K8s secrets can produce literal two-char "\n".
             if "private_key" in sa_data:
@@ -227,7 +233,9 @@ def create_store_from_binding(
         )
         return GCSStore(
             bucket=bucket,
-            config=gcs_config,
+            # Pass ``None`` (not {}) when no key was supplied so obstore uses
+            # Application Default Credentials.  Mirrors storage/cloud.py.
+            config=gcs_config if gcs_config else None,
             client_options=sdk_client_options,
             retry_config=sdk_retry_config,
         )

--- a/tests/unit/storage/test_binding.py
+++ b/tests/unit/storage/test_binding.py
@@ -80,10 +80,14 @@ class TestGCSStoreCredentials:
         assert sa_json["universe_domain"] == "googleapis.com"
 
     @patch("obstore.store.GCSStore")
-    def test_no_sa_fields_passes_empty_config(
+    def test_no_sa_fields_passes_none_config(
         self, mock_gcs_cls: MagicMock, tmp_path: Path
     ) -> None:
-        """When no SA fields are present (local dev / ADC), config should be empty."""
+        """When no SA fields are present (local dev / ADC), config must be None.
+
+        Passing an empty dict prevents obstore from following its ADC chain,
+        so the bucket-only case must collapse to ``config=None``.
+        """
         components_dir = _write_component(
             tmp_path, "objectstore", "bindings.gcs", {"bucket": "dev-bucket"}
         )
@@ -93,14 +97,47 @@ class TestGCSStoreCredentials:
 
         call_kwargs = mock_gcs_cls.call_args
         assert call_kwargs.kwargs["bucket"] == "dev-bucket"
-        config = call_kwargs.kwargs["config"]
-        assert config == {} or config is None or "service_account_key" not in config
+        assert call_kwargs.kwargs["config"] is None
 
     @patch("obstore.store.GCSStore")
-    def test_partial_sa_fields_only_includes_present(
+    def test_project_id_only_uses_adc(
         self, mock_gcs_cls: MagicMock, tmp_path: Path
     ) -> None:
-        partial_meta = {"bucket": "b", "project_id": "proj", "client_email": "e@x.com"}
+        """bucket + project_id (the WIF / ADC config) must NOT synthesise a SA JSON.
+
+        daprd's gcp-bucket binding requires ``project_id`` in component
+        metadata even on the ADC path.  The previous behaviour treated any
+        SA-field presence — including ``project_id`` alone — as a trigger
+        to build a partial SA JSON, which obstore then rejected with
+        ``missing field 'private_key'``.  After the fix, only credential
+        fields trigger key construction; this config falls through to ADC.
+        """
+        components_dir = _write_component(
+            tmp_path,
+            "objectstore",
+            "bindings.gcp.bucket",
+            {"bucket": "wif-bucket", "project_id": "wif-project"},
+        )
+        mock_gcs_cls.return_value = MagicMock()
+
+        create_store_from_binding("objectstore", components_dir=components_dir)
+
+        call_kwargs = mock_gcs_cls.call_args
+        assert call_kwargs.kwargs["bucket"] == "wif-bucket"
+        assert call_kwargs.kwargs["config"] is None
+
+    @patch("obstore.store.GCSStore")
+    def test_partial_metadata_without_credentials_uses_adc(
+        self, mock_gcs_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """Any non-credential SA fields (project_id, client_email, type) must
+        still fall through to ADC unless private_key / private_key_id is set."""
+        partial_meta = {
+            "bucket": "b",
+            "type": "service_account",
+            "project_id": "proj",
+            "client_email": "e@x.com",
+        }
         components_dir = _write_component(
             tmp_path, "objectstore", "bindings.gcs", partial_meta
         )
@@ -108,10 +145,28 @@ class TestGCSStoreCredentials:
 
         create_store_from_binding("objectstore", components_dir=components_dir)
 
+        assert mock_gcs_cls.call_args.kwargs["config"] is None
+
+    @patch("obstore.store.GCSStore")
+    def test_private_key_id_alone_triggers_sa_json(
+        self, mock_gcs_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """Either credential field is sufficient to trigger SA-JSON construction."""
+        meta = {
+            "bucket": "b",
+            "project_id": "proj",
+            "private_key_id": "kid-1",
+            "client_email": "e@x.com",
+        }
+        components_dir = _write_component(tmp_path, "objectstore", "bindings.gcs", meta)
+        mock_gcs_cls.return_value = MagicMock()
+
+        create_store_from_binding("objectstore", components_dir=components_dir)
+
         sa_json = orjson.loads(
             mock_gcs_cls.call_args.kwargs["config"]["service_account_key"]
         )
-        assert set(sa_json.keys()) == {"project_id", "client_email"}
+        assert set(sa_json.keys()) == {"project_id", "private_key_id", "client_email"}
 
     @patch("obstore.store.GCSStore")
     def test_private_key_newlines_normalized(


### PR DESCRIPTION
## Summary

- The Dapr GCP bucket binding requires `project_id` in component metadata even on the ADC path (GKE Workload Identity, `GOOGLE_APPLICATION_CREDENTIALS`, metadata server). Today, `create_store_from_binding` treats the presence of *any* field in `GCS_SERVICE_ACCOUNT_FIELDS` — including `project_id` alone — as a trigger to synthesize a partial service-account JSON, which obstore then rejects with `missing field 'private_key'`. Result: GCS on V3 SDR is only usable with a full inline SA key in `values.yaml`; the documented `bucket` + `project_id` config doesn't come up.
- Fix: only build the SA JSON when credential material is present (`private_key` or `private_key_id`), and pass `config=None` to `GCSStore` when no JSON was built. Mirrors the pattern already in `application_sdk/storage/cloud.py:498-503`. obstore then follows its ADC chain and transparently picks up Workload Identity on GKE.

This is the SDK-side change needed to unblock the V3 BigQuery SDR objectstore on kaa-main without inline long-lived SA keys (Slack: [`#bu-application-sdk` thread, 2026-05-27](https://atlanhq.slack.com/archives/C0AHHBDBP9Q/p1779891384632439)).

## Why this is a V3-only regression

This bug does not exist in v2.x. The auth path changed twice:

| Version | Storage I/O path | Who authenticates to GCS | `bucket` + `project_id` only |
|---|---|---|---|
| v2.x (≤ v2.8.7) | `DaprClient().invoke_binding()` over HTTP to the sidecar | daprd alone | ✅ works — daprd's binary `if private_key_id then explicit else storage.NewClient(ctx)` decision falls through to ADC → WIF |
| v3.0.0 (commit `77b264fa`, 2026-03-18) | In-process `obstore.GCSStore` — Dapr data plane bypassed for streaming | Both daprd (still required for schema) and obstore (in-process) | ✅ would still work — initial v3 GCS branch was `GCSStore(bucket=bucket)` with no credentials |
| v3.0.1+ (commit `b130fee9` / PR #1216, 2026-04-06) | Same as v3.0.0 | obstore gets a synthesised SA JSON whenever any SA field is present | ❌ **regression** — `project_id` alone triggers a partial JSON; obstore rejects with `missing field 'private_key'` |

PR #1216 added the inline-SA-key path so operators could supply credentials via component metadata, but conflated identifier fields (`project_id`) with credential fields (`private_key` / `private_key_id`). This PR restores the v2.x and v3.0.0 behaviour for the no-key case while preserving the inline-key path that #1216 enabled.

## Behaviour matrix

| Component metadata | Before | After |
|---|---|---|
| `bucket` only | daprd refuses (`missing property project_id`) | daprd refuses (unchanged — this is daprd's schema, not us) |
| `bucket` + `project_id` | obstore rejects (`missing field 'private_key'`) | **config=None → obstore uses ADC → WIF works** |
| `bucket` + `project_id` + non-credential SA fields (`client_email`, `type`, ...) | obstore rejects | **config=None → ADC** |
| `bucket` + full SA key (all credential fields) | works | works (no change) |

## What this does *not* change

- The inline-SA-key path (current production config on kaa-main) is preserved bit-for-bit — verified by the existing `test_full_sa_metadata_passed_as_service_account_key` test.
- The obstore config key remains `service_account_key` (note: `cloud.py` uses `google_service_account_key`; that inconsistency exists but is out of scope here — the inline path is known to work today and I didn't want to broaden the diff).

## Test plan

- [x] `uv run pytest tests/unit/storage/test_binding.py` — 20/20 pass (existing + 4 new assertions)
- [x] `uv run pytest tests/unit/storage/ --ignore=tests/unit/storage/formats` — 306/306 pass
- [x] `uvx ruff check` + `uvx ruff format --check` on the modified files — clean
- [ ] Deploy to kaa-main BigQuery SDR with `bucket` + `project_id` only (no inline key) and confirm uploads succeed under WIF — **needs reviewer to validate on the live SDR**

## Slack context

Thread: `#bu-application-sdk` 2026-05-27 — Hariharan asked whether anyone has run the V3 GCS objectstore without an inline SA key. The hypothesis posted in that thread (`binding.py` builds a partial SA JSON whenever any field is present) was correct; this PR implements the fix it pointed to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)