### PR TITLE
fix(temporal): gate IPv4-resolver substitution on SDR mode only (DISTR-507 follow-up)

### DIFF
--- a/application_sdk/execution/_temporal/backend.py
+++ b/application_sdk/execution/_temporal/backend.py
@@ -14,7 +14,10 @@ from temporalio.client import Client
 from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
 
-from application_sdk.constants import TEMPORAL_PROMETHEUS_BIND_ADDRESS
+from application_sdk.constants import (
+    ENABLE_ATLAN_UPLOAD,
+    TEMPORAL_PROMETHEUS_BIND_ADDRESS,
+)
 from application_sdk.execution.retry import RetryPolicy, _to_temporal_retry_policy
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.observability.utils import get_metric_enrichment_labels
@@ -291,6 +294,11 @@ def _build_tls_config(
 async def _prefer_v4_target(target_host: str) -> tuple[str, str | None]:
     """Pre-resolve ``target_host`` and prefer an IPv4 address when AAAA is present.
 
+    Caller-gated: ``create_temporal_client`` only invokes this when
+    ``ENABLE_ATLAN_UPLOAD`` is set (SDR mode). Internal Atlan services that
+    connect via in-cluster Service DNS keep the hostname intact so the
+    Rust bridge re-resolves on reconnect and survives Service IP changes.
+
     Returns ``(resolved_target, sni_hostname)``:
 
     * ``resolved_target`` — the literal ``<ip>:<port>`` to hand to the Rust
@@ -505,25 +513,37 @@ async def create_temporal_client(
             "Connecting to Temporal (plaintext): host=%s namespace=%s", host, namespace
         )
 
-    # Pre-resolve the target hostname and prefer IPv4 when the OS
-    # resolver returns both A and AAAA. The Rust Temporal bridge picks
-    # one address from the resolver and fails the whole connect if that
-    # address is unreachable — on hosts with half-broken IPv6 (link-
-    # local only, or v6 enabled without a global route) this manifests
-    # as ``Status { code: Unavailable, ... AddrNotAvailable ... }`` on
-    # an AAAA record. See ``_prefer_v4_target`` for the full rationale.
-    resolved_host, sni_host = await _prefer_v4_target(host)
-    if sni_host is not None:
-        # We substituted an IP for the hostname — preserve TLS SNI so
-        # the handshake still validates against the original DNS name's
-        # cert, not the literal IP.
-        tls_config = _apply_sni_domain(tls_config, sni_host)
-        logger.info(
-            "Pre-resolved Temporal target %s -> %s (SNI preserved as %s)",
-            host,
-            resolved_host,
-            sni_host,
-        )
+    # SDR-only: pre-resolve the target hostname and prefer IPv4 when the OS
+    # resolver returns both A and AAAA. Solves the half-broken-IPv6 case on
+    # customer SDR hosts (link-local-only v6, or v6 enabled without a global
+    # route) where the Rust Temporal bridge picks the AAAA address and fails
+    # the whole connect with ``EADDRNOTAVAIL``. See ``_prefer_v4_target`` for
+    # the full rationale.
+    #
+    # Gated on ``ENABLE_ATLAN_UPLOAD`` (the SDR-mode flag) because internal
+    # Atlan services connect to Temporal via in-cluster Service DNS
+    # (``temporal-frontend.temporal.svc.cluster.local``) where the ClusterIP
+    # can change if the Service object is recreated (Helm reapply, namespace
+    # rebuild, etc.). On reconnect the Rust bridge keeps using the literal
+    # IP it was given at connect time, so a pinned-IP target goes stale and
+    # connect fails. Hostname-based connects re-resolve each reconnect and
+    # stay healthy through Service IP churn. Only SDR — where DNS goes
+    # through Cloudflare anycast and there's no in-cluster Service to track
+    # — benefits from the literal-IP substitution.
+    resolved_host, sni_host = host, None
+    if ENABLE_ATLAN_UPLOAD:
+        resolved_host, sni_host = await _prefer_v4_target(host)
+        if sni_host is not None:
+            # We substituted an IP for the hostname — preserve TLS SNI so
+            # the handshake still validates against the original DNS name's
+            # cert, not the literal IP.
+            tls_config = _apply_sni_domain(tls_config, sni_host)
+            logger.info(
+                "Pre-resolved Temporal target %s -> %s (SNI preserved as %s)",
+                host,
+                resolved_host,
+                sni_host,
+            )
 
     kwargs: dict[str, Any] = {
         "target_host": resolved_host,

--- a/tests/unit/execution/test_backend.py
+++ b/tests/unit/execution/test_backend.py
@@ -644,6 +644,13 @@ class TestApplySniDomain:
 
 
 class TestCreateTemporalClientPrefersV4:
+    # All three end-to-end tests below explicitly patch
+    # ``backend_module.ENABLE_ATLAN_UPLOAD`` to True because the
+    # resolver substitution is now gated on SDR mode (the env-driven
+    # flag). Internal-Atlan-service flows leave it False and keep the
+    # hostname intact for re-resolution on reconnect — covered by the
+    # ``TestCreateTemporalClientNonSdrMode`` class below.
+
     @pytest.mark.asyncio
     async def test_substitutes_v4_ip_and_preserves_sni_for_tls(self) -> None:
         """End-to-end: when the resolver returns both v4 and v6 and TLS
@@ -653,6 +660,7 @@ class TestCreateTemporalClientPrefersV4:
 
         with (
             mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(backend_module, "ENABLE_ATLAN_UPLOAD", True),
             mock.patch.object(
                 backend_module.socket,
                 "getaddrinfo",
@@ -688,6 +696,7 @@ class TestCreateTemporalClientPrefersV4:
         # attempts on netns-with-no-v6 hosts.
         with (
             mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(backend_module, "ENABLE_ATLAN_UPLOAD", True),
             mock.patch.object(
                 backend_module.socket,
                 "getaddrinfo",
@@ -714,6 +723,7 @@ class TestCreateTemporalClientPrefersV4:
         # stays False because there's no handshake to preserve SNI for.
         with (
             mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(backend_module, "ENABLE_ATLAN_UPLOAD", True),
             mock.patch.object(
                 backend_module.socket,
                 "getaddrinfo",
@@ -733,3 +743,108 @@ class TestCreateTemporalClientPrefersV4:
         kwargs = connect.await_args.kwargs
         assert kwargs["target_host"] == "203.0.113.10:443"
         assert kwargs["tls"] is False
+
+
+class TestCreateTemporalClientNonSdrMode:
+    # Internal Atlan services connect to Temporal via in-cluster Service
+    # DNS (e.g. ``temporal-frontend.temporal.svc.cluster.local``). The
+    # ClusterIP can change if the Service object is recreated (Helm
+    # reapply, namespace rebuild), and the Rust bridge holds a literal-IP
+    # target across reconnects — so pinning the IP at connect time would
+    # cause stale-IP connect failures later. These tests pin
+    # ``ENABLE_ATLAN_UPLOAD`` to False and confirm the SDK keeps the
+    # hostname intact so the bridge re-resolves DNS on each reconnect.
+
+    @pytest.mark.asyncio
+    async def test_hostname_preserved_when_not_sdr_dual_stack(self) -> None:
+        with (
+            mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(backend_module, "ENABLE_ATLAN_UPLOAD", False),
+            # Resolver still returns both families — this should NOT
+            # trigger any swap because we're not in SDR mode.
+            mock.patch.object(
+                backend_module.socket,
+                "getaddrinfo",
+                return_value=_fake_addrinfo(_socket.AF_INET6, _socket.AF_INET),
+            ),
+            mock.patch.object(
+                backend_module.Client,
+                "connect",
+                new=mock.AsyncMock(return_value=mock.MagicMock()),
+            ) as connect,
+        ):
+            await create_temporal_client(
+                host="temporal-frontend.temporal.svc.cluster.local:7233",
+                connect_max_attempts=1,
+            )
+        kwargs = connect.await_args.kwargs
+        # Hostname preserved end-to-end so the Rust bridge re-resolves
+        # on every reconnect.
+        assert (
+            kwargs["target_host"] == "temporal-frontend.temporal.svc.cluster.local:7233"
+        )
+        assert kwargs["tls"] is False
+
+    @pytest.mark.asyncio
+    async def test_tls_unchanged_when_not_sdr(self) -> None:
+        """When not in SDR mode, ``tls=True`` is NOT upgraded to a
+        TLSConfig with a SNI domain — because we never substituted an
+        IP, the original hostname continues to drive SNI on each
+        Rust-bridge reconnect."""
+        with (
+            mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(backend_module, "ENABLE_ATLAN_UPLOAD", False),
+            mock.patch.object(
+                backend_module.socket,
+                "getaddrinfo",
+                return_value=_fake_addrinfo(_socket.AF_INET6, _socket.AF_INET),
+            ),
+            mock.patch(
+                "application_sdk.clients.ssl_utils.get_custom_ca_cert_bytes",
+                return_value=None,
+            ),
+            mock.patch.object(
+                backend_module.Client,
+                "connect",
+                new=mock.AsyncMock(return_value=mock.MagicMock()),
+            ) as connect,
+        ):
+            await create_temporal_client(
+                host="temporal-frontend.temporal.svc.cluster.local:7233",
+                tls_enabled=True,
+                connect_max_attempts=1,
+            )
+        kwargs = connect.await_args.kwargs
+        assert (
+            kwargs["target_host"] == "temporal-frontend.temporal.svc.cluster.local:7233"
+        )
+        # ``tls=True`` stays as-is — no TLSConfig upgrade because we
+        # didn't substitute an IP, so SNI naturally tracks the hostname.
+        assert kwargs["tls"] is True
+
+    @pytest.mark.asyncio
+    async def test_resolver_helper_is_not_called_when_not_sdr(self) -> None:
+        # Direct evidence the resolver short-circuits before
+        # ``getaddrinfo`` runs at all when we're not in SDR mode. Catches
+        # accidental regressions where someone moves the gate the wrong
+        # side of the call.
+        getaddrinfo_mock = mock.MagicMock(
+            return_value=_fake_addrinfo(_socket.AF_INET6, _socket.AF_INET)
+        )
+        with (
+            mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(backend_module, "ENABLE_ATLAN_UPLOAD", False),
+            mock.patch.object(
+                backend_module.socket, "getaddrinfo", new=getaddrinfo_mock
+            ),
+            mock.patch.object(
+                backend_module.Client,
+                "connect",
+                new=mock.AsyncMock(return_value=mock.MagicMock()),
+            ),
+        ):
+            await create_temporal_client(
+                host="internal-temporal.svc.cluster.local:7233",
+                connect_max_attempts=1,
+            )
+        assert getaddrinfo_mock.call_count == 0


### PR DESCRIPTION
## Summary

Hot-fix follow-up to merged PR #1857. That change added a pre-resolve step that substitutes a literal v4 IP for the Temporal hostname at \`Client.connect\` time to dodge the half-broken-IPv6 failure mode on SDR customer hosts. **Reviewer post-merge flagged a gap on Slack:** the substitution is correct for SDR (Cloudflare anycast, customer DNS) but breaks internal Atlan services connecting via in-cluster Service DNS.

Linear: [DISTR-507](https://linear.app/atlan-epd/issue/DISTR-507/sdr-worker-fails-to-connect-to-temporal-on-hosts-with-partial-ipv6)

## Why the fix-of-fix is needed

In-cluster, internal services reach the Temporal frontend at \`temporal-frontend.temporal.svc.cluster.local\`. The ClusterIP behind that hostname *can* change if the Service object is recreated (Helm reapply, namespace rebuild). The Rust Temporal bridge keeps the literal-IP target across reconnects — so once we substitute the hostname for an IP, every subsequent reconnect after a Service-IP change fails because the bridge still tries the stale IP.

Keeping the hostname intact for internal services means the bridge re-resolves DNS on each reconnect and naturally tracks Service-IP churn.

## The fix

Gate the \`_prefer_v4_target\` substitution on \`ENABLE_ATLAN_UPLOAD\` (already exists in \`application_sdk/constants.py:341\` and is the SDR-mode flag used throughout \`application_sdk/observability/\`):

\`\`\`python
resolved_host, sni_host = host, None
if ENABLE_ATLAN_UPLOAD:
    resolved_host, sni_host = await _prefer_v4_target(host)
    if sni_host is not None:
        tls_config = _apply_sni_domain(tls_config, sni_host)
        logger.info(...)
\`\`\`

When \`ENABLE_ATLAN_UPLOAD\` is False (the default; internal services don't set it), \`host\` and \`tls_config\` flow through to \`Client.connect\` exactly as the caller passed them — same behaviour as SDK v3.4 and earlier. \`_prefer_v4_target\` and \`_apply_sni_domain\` are unchanged; they're pure helpers, the gate just decides whether to call them.

### What's unchanged

The TLS env fallback (\`ATLAN_WORKFLOW_TLS_ENABLED\` -> \`ATLAN_TEMPORAL_TLS_ENABLED\`) also shipped in #1857 stays enabled for all modes — it's universally safe and doesn't share this failure mode.

## Behaviour matrix

| Caller environment | \`ENABLE_ATLAN_UPLOAD\` | Resolver substitution | \`target_host\` to bridge |
| --- | --- | --- | --- |
| SDR customer host (saperp, etc.) | \`true\` | Yes (v4 IP, SNI preserved) | \`<v4-ip>:<port>\` |
| Internal Atlan service (in-cluster) | unset / \`false\` | **No** (this PR) | hostname unchanged |
| Local dev (\`localhost:7233\`) | unset | **No** | \`localhost:7233\` |

## Tests

- The three existing end-to-end tests in \`TestCreateTemporalClientPrefersV4\` now explicitly patch \`backend_module.ENABLE_ATLAN_UPLOAD\` to True so they continue exercising the SDR substitution path.
- New \`TestCreateTemporalClientNonSdrMode\` class with 3 tests:
  - dual-stack resolver result + flag False → hostname preserved end-to-end
  - \`tls=True\` + flag False → \`tls\` stays as the bare \`True\` (no TLSConfig SNI upgrade — because we didn't substitute, the hostname continues to drive SNI naturally on each Rust-bridge reconnect)
  - flag False → \`socket.getaddrinfo\` provably never called (catches accidental regressions where the gate moves to the wrong side of the call)
- All 43 tests in \`test_backend.py\` pass; 561 across the broader related surface pass; pre-commit clean (ruff, ruff-format, pyright, isort).

## Backwards-compatibility notes

- Customer-facing impact for SDR: **none**. The substitution still happens for them.
- Customer-facing impact for internal services: **restores SDK v3.4-era behaviour** of passing the hostname through to the Rust bridge unchanged. The regression from #1857 that prompted this PR goes away.

## Follow-up (separate ticket worth considering)

Worth a long-term think: should this gating live in the SDK at all, or should it be a knob the caller flips? Today the implicit coupling is \"SDR mode = pre-resolve target\". If we ever ship a non-SDR setup that *also* hits the IPv6 issue (unlikely but not impossible), they'd have to set \`ENABLE_ATLAN_UPLOAD\` just to get the resolver behaviour — semantically wrong. A dedicated \`ATLAN_TEMPORAL_PREFER_IPV4\` env var would be cleaner. Not blocking this hot-fix; raising for the SDR project review.