### PR TITLE
fix(temporal): gate IPv4 pre-resolution to SDR only (ENABLE_ATLAN_UPLOAD)

### DIFF
--- a/application_sdk/execution/_temporal/backend.py
+++ b/application_sdk/execution/_temporal/backend.py
@@ -14,7 +14,10 @@ from temporalio.client import Client
 from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
 
-from application_sdk.constants import TEMPORAL_PROMETHEUS_BIND_ADDRESS
+from application_sdk.constants import (
+    ENABLE_ATLAN_UPLOAD,
+    TEMPORAL_PROMETHEUS_BIND_ADDRESS,
+)
 from application_sdk.execution.retry import RetryPolicy, _to_temporal_retry_policy
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.observability.utils import get_metric_enrichment_labels
@@ -505,14 +508,16 @@ async def create_temporal_client(
             "Connecting to Temporal (plaintext): host=%s namespace=%s", host, namespace
         )
 
-    # Pre-resolve the target hostname and prefer IPv4 when the OS
-    # resolver returns both A and AAAA. The Rust Temporal bridge picks
-    # one address from the resolver and fails the whole connect if that
-    # address is unreachable — on hosts with half-broken IPv6 (link-
-    # local only, or v6 enabled without a global route) this manifests
-    # as ``Status { code: Unavailable, ... AddrNotAvailable ... }`` on
-    # an AAAA record. See ``_prefer_v4_target`` for the full rationale.
-    resolved_host, sni_host = await _prefer_v4_target(host)
+    # IPv4 pre-resolution (#1857) is an SDR-only workaround: it pins the
+    # target to a literal v4 IP so the Rust bridge can't pick an unreachable
+    # AAAA on half-broken-IPv6 customer hosts. SDR-gated because for internal
+    # cluster URLs (headless Temporal frontend) a pinned pod IP goes stale on
+    # restart and can't re-resolve, hanging every call ~130s. Non-SDR connects
+    # by hostname and lets gRPC re-resolve. See ``_prefer_v4_target``.
+    if ENABLE_ATLAN_UPLOAD:
+        resolved_host, sni_host = await _prefer_v4_target(host)
+    else:
+        resolved_host, sni_host = host, None
     if sni_host is not None:
         # We substituted an IP for the hostname — preserve TLS SNI so
         # the handshake still validates against the original DNS name's

--- a/tests/unit/execution/test_backend.py
+++ b/tests/unit/execution/test_backend.py
@@ -644,6 +644,12 @@ class TestApplySniDomain:
 
 
 class TestCreateTemporalClientPrefersV4:
+    @pytest.fixture(autouse=True)
+    def _sdr_mode(self):
+        # v4 pre-resolution is SDR-gated; these tests assert the SDR path.
+        with mock.patch.object(backend_module, "ENABLE_ATLAN_UPLOAD", True):
+            yield
+
     @pytest.mark.asyncio
     async def test_substitutes_v4_ip_and_preserves_sni_for_tls(self) -> None:
         """End-to-end: when the resolver returns both v4 and v6 and TLS
@@ -732,4 +738,31 @@ class TestCreateTemporalClientPrefersV4:
             )
         kwargs = connect.await_args.kwargs
         assert kwargs["target_host"] == "203.0.113.10:443"
+        assert kwargs["tls"] is False
+
+
+class TestCreateTemporalClientNonSdrSkipsV4:
+    @pytest.mark.asyncio
+    async def test_non_sdr_connects_by_hostname(self) -> None:
+        # Non-SDR (in-cluster): skip v4 pre-resolution so gRPC can re-resolve
+        # the headless service on pod restart. target_host stays the hostname.
+        host = "temporal-cluster-internal-frontend-headless.temporal.svc.cluster.local:7236"
+        with (
+            mock.patch.object(backend_module, "ENABLE_ATLAN_UPLOAD", False),
+            mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(
+                backend_module,
+                "_prefer_v4_target",
+                new=mock.AsyncMock(),
+            ) as prefer_v4,
+            mock.patch.object(
+                backend_module.Client,
+                "connect",
+                new=mock.AsyncMock(return_value=mock.MagicMock()),
+            ) as connect,
+        ):
+            await create_temporal_client(host=host, connect_max_attempts=1)
+        prefer_v4.assert_not_called()
+        kwargs = connect.await_args.kwargs
+        assert kwargs["target_host"] == host
         assert kwargs["tls"] is False


### PR DESCRIPTION
## What

Gate the `_prefer_v4_target` IPv4 pre-resolution (#1857) behind `ENABLE_ATLAN_UPLOAD` (the SDR-mode flag): keep it for SDR, disable it for in-cluster apps.

## Why

#1857 pins the Temporal target to a literal v4 IP — safe for SDR's stable external DNS, but broken for internal cluster URLs. The headless `temporal-cluster-internal-frontend` resolves to per-pod IPs; the pinned IP can't re-resolve, so when a frontend pod is replaced every call fails `tcp connect error` for ~130s until the process restarts.

Reproduced in-cluster (cycle the frontend pods → new IPs):
```
Visibility lookup by RunId failed … : tcp connect error
GET /api/v1/runs status_code=200 duration_ms=135955.52
```

## Fix

- SDR (`ENABLE_ATLAN_UPLOAD=true`) → keep pre-resolution.
- Non-SDR (default) → connect by hostname, let gRPC re-resolve.

## Tests
Existing v4 tests run under an autouse SDR fixture; new test asserts non-SDR connects by hostname. 41 passed.

## Follow-up
For SDR, re-resolve on connection failure instead of pinning for the process lifetime (separate PR).