### PR TITLE
fix(storage): deterministic cross-worker local FileReference GC (BLDX-1337)

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -13,6 +13,7 @@ from abc import ABC
 from collections.abc import Callable
 from dataclasses import replace
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any, ClassVar, Literal, Never, TypeVar, cast, get_type_hints
 from uuid import UUID
 
@@ -702,6 +703,41 @@ class App(ABC):
         """Get the correlation ID."""
         return self.context.correlation_id
 
+    def local_run_dir(self) -> Path:
+        """Return the run-scoped local scratch root, creating it if needed.
+
+        Layout: ``{LOCAL_FILE_REF_ROOT}/{sanitized_workflow_id}/{run_id}/``.
+
+        Write per-run scratch here (then wrap it in
+        :meth:`FileReference.from_local`) so it is reachable by the deterministic
+        cross-worker GC sweep — see :mod:`application_sdk.storage.local_gc`. The
+        directory path encodes both keys the sweep needs (``workflow_id`` and
+        ``run_id``), so no separate registry has to be kept consistent.
+
+        Must be called from within a ``@task`` (activity) context, where the
+        current workflow/run ids are available via ``activity.info()``.
+
+        Returns:
+            Path to the run-scoped directory (created with ``parents=True``).
+
+        Raises:
+            AppContextError: If called outside an activity context, where the
+                workflow/run ids are unavailable.
+        """
+        from application_sdk.storage.local_gc import (  # noqa: PLC0415 — lazy: avoids importing the storage GC module at app-class import time
+            run_scoped_dir,
+        )
+
+        info = activity.info()
+        workflow_id = info.workflow_id
+        run_id = info.workflow_run_id
+        if not workflow_id or not run_id:
+            raise AppContextError(
+                "local_run_dir() requires an activity context with a "
+                "workflow_id and run_id"
+            )
+        return run_scoped_dir(workflow_id, run_id, create=True)
+
     def is_cancelled(self) -> bool:
         """Check if execution has been cancelled."""
         return self.context.is_cancelled()
@@ -1130,6 +1166,15 @@ class App(ABC):
                     exc_info=True,
                 )
                 path_results[base_path] = False
+
+        # 3. Belt-and-braces end-of-run sweep: reclaim *other* finished runs'
+        # run-scoped local scratch too. Gated + best-effort inside the helper
+        # (no-op when the kill-switch is off or no Temporal client is stashed).
+        from application_sdk.execution._temporal.activities import (  # noqa: PLC0415 — lazy: execution/__init__.py imports app.base, so import at call time
+            _maybe_sweep_local_file_refs,
+        )
+
+        await _maybe_sweep_local_file_refs()
 
         return CleanupOutput(path_results=path_results)
 

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -118,6 +118,24 @@ CLEANUP_BASE_PATHS = [
 # Key used to store tracked FileReference objects in _app_state during a workflow run
 TRACKED_FILE_REFS_KEY = "_tracked_file_refs"
 
+# Run-scoped local root for FileReference scratch. The directory layout under this
+# root — {workflow_id}/{run_id}/ — IS the GC registry: a sweep walks it and asks
+# Temporal whether each run is over (see storage/local_gc.py). Apps write run-scoped
+# scratch under App.local_run_dir() so SDK-chosen paths are GC-discoverable too.
+LOCAL_FILE_REF_ROOT = os.getenv(
+    "ATLAN_LOCAL_FILE_REF_ROOT", os.path.join(TEMPORARY_PATH, "file_refs_local")
+)
+
+# Kill-switch for deterministic cross-worker local FileReference GC. Default on;
+# set ATLAN_ENABLE_LOCAL_GC=false to disable the sweep instantly.
+ENABLE_LOCAL_GC = os.getenv("ATLAN_ENABLE_LOCAL_GC", "true").lower() == "true"
+
+# Upper bound on Temporal describe() RPCs issued per local-GC sweep, to bound
+# frontend load. Run dirs not examined this sweep are handled by the next one.
+LOCAL_GC_MAX_DESCRIBES_PER_SWEEP = int(
+    os.getenv("ATLAN_LOCAL_GC_MAX_DESCRIBES_PER_SWEEP", "50")
+)
+
 # Object-store prefixes that must never be deleted by cleanup_storage.
 # These store cross-run persistent state (connection configs, incremental markers, etc.)
 PROTECTED_STORAGE_PREFIXES = ("persistent-artifacts/",)

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -71,6 +71,64 @@ def _track_file_refs(workflow_id: str, *refs: FileReference) -> None:
         tracked.update(refs)
 
 
+def _local_gc_dir_for_activity() -> str | None:
+    """Run-scoped local dir for the current activity, or ``None``.
+
+    Returned as the ``local_dir`` for auto-materialised FileReferences so the
+    SDK's downloaded copies land under the GC-discoverable run-scoped root (see
+    :mod:`application_sdk.storage.local_gc`). ``None`` when the local-GC
+    kill-switch is off or the workflow/run ids are unavailable — callers then
+    fall back to a bare temp file (unchanged legacy behaviour).
+    """
+    from application_sdk.constants import ENABLE_LOCAL_GC  # noqa: PLC0415
+
+    if not ENABLE_LOCAL_GC:
+        return None
+    info = activity.info()
+    if not info.workflow_id or not info.workflow_run_id:
+        return None
+    from application_sdk.storage.local_gc import run_scoped_dir  # noqa: PLC0415
+
+    return str(run_scoped_dir(info.workflow_id, info.workflow_run_id))
+
+
+async def _maybe_sweep_local_file_refs() -> None:
+    """Best-effort: GC this worker's finished-run local scratch. Never raises.
+
+    Each worker self-GCs its own filesystem by asking Temporal which runs are
+    over — coordination-free and bounded (``LOCAL_GC_MAX_DESCRIBES_PER_SWEEP``)
+    per activity. Skips silently when the kill-switch is off or no Temporal
+    client was stashed on the infra context (e.g. non-Temporal / dev contexts).
+    A sweep failure must never fail the activity, so all errors are swallowed.
+    """
+    try:
+        from application_sdk.constants import (  # noqa: PLC0415
+            ENABLE_LOCAL_GC,
+            LOCAL_GC_MAX_DESCRIBES_PER_SWEEP,
+        )
+
+        if not ENABLE_LOCAL_GC:
+            return
+        from application_sdk.infrastructure.context import (  # noqa: PLC0415
+            get_temporal_client,
+        )
+
+        client = get_temporal_client()
+        if client is None:
+            return
+        from application_sdk.storage.local_gc import (  # noqa: PLC0415
+            sweep_local_file_refs,
+        )
+
+        await sweep_local_file_refs(
+            client,
+            current_run_id=activity.info().workflow_run_id or "",
+            max_describes=LOCAL_GC_MAX_DESCRIBES_PER_SWEEP,
+        )
+    except Exception:
+        logger.warning("local_gc: sweep failed (non-fatal)", exc_info=True)
+
+
 def create_activity_from_task(
     task_metadata: TaskMetadata,
 ) -> Callable[..., Any]:
@@ -177,8 +235,12 @@ def create_activity_from_task(
             store = infra.storage if infra is not None else None
 
             # Materialise any durable FileReferences in the input before the task runs.
+            # Auto-materialised copies land under the run-scoped GC root so they
+            # are reclaimable by the cross-worker sweep.
             if store is not None and has_refs_to_materialize(input_data):
-                input_data = await materialize_file_refs(store, input_data)
+                input_data = await materialize_file_refs(
+                    store, input_data, local_dir=_local_gc_dir_for_activity()
+                )
 
             result = await task_method(input_data)
 
@@ -206,6 +268,10 @@ def create_activity_from_task(
             all_refs = _find_file_refs(input_data) + _find_file_refs(result)
             if all_refs:
                 _track_file_refs(activity.info().workflow_id, *all_refs)
+
+            # Self-GC this worker's finished-run local scratch as it works —
+            # deterministic, bounded, coordination-free (no-op when disabled).
+            await _maybe_sweep_local_file_refs()
 
             return cast("Output", result)
 

--- a/application_sdk/infrastructure/context.py
+++ b/application_sdk/infrastructure/context.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from obstore.store import ObjectStore
+    from temporalio.client import Client
 
     from application_sdk.infrastructure.bindings import Binding
     from application_sdk.infrastructure.secrets import SecretStore
@@ -35,6 +36,12 @@ class InfrastructureContext:
 
     The optional ``_dapr_client`` field holds the shared ``AsyncDaprClient``
     so it can be closed on shutdown via :func:`close_infrastructure`.
+
+    The optional ``_temporal_client`` field holds the worker's connected Temporal
+    client, stashed at startup so activity-side code (e.g. the local-file GC
+    sweep) can reach it via :func:`get_temporal_client` without threading a
+    client through every call. Its lifecycle is owned by the worker bootstrap,
+    not by :func:`close_infrastructure`.
     """
 
     state_store: StateStore | None = field(default=None)
@@ -42,6 +49,7 @@ class InfrastructureContext:
     storage: ObjectStore | None = field(default=None)
     event_binding: Binding | None = field(default=None)
     _dapr_client: Any = field(default=None, repr=False)
+    _temporal_client: Any = field(default=None, repr=False)
 
 
 _infrastructure: InfrastructureContext | None = None
@@ -54,6 +62,19 @@ def get_infrastructure() -> InfrastructureContext | None:
         Current InfrastructureContext, or None if not set.
     """
     return _infrastructure
+
+
+def get_temporal_client() -> Client | None:
+    """Return the Temporal client stashed on the current infrastructure context.
+
+    Populated at worker startup (see ``main.py``) so activity-side code can reach
+    the connected client without it being threaded through every call. Returns
+    ``None`` when no context is set, or when no client was stashed (e.g.
+    server-only or non-Temporal contexts) — callers should treat ``None`` as
+    "no client available" and fall back accordingly.
+    """
+    ctx = _infrastructure
+    return ctx._temporal_client if ctx is not None else None
 
 
 def set_infrastructure(ctx: InfrastructureContext) -> None:

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -30,7 +30,7 @@ import faulthandler
 import os
 import signal
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, NoReturn
 
 from application_sdk.common._env import env_int as _env_int
@@ -816,6 +816,11 @@ async def run_worker_mode(config: AppConfig) -> None:
         auth_manager.start_background_refresh(client)
         logger.info("Background token refresh started")
 
+    # Stash the connected Temporal client on the infra context so activity-side
+    # code (the local-file GC sweep) can reach it. The client doesn't exist when
+    # the context is first built, and the context is frozen — so re-set a copy.
+    set_infrastructure(replace(infra, _temporal_client=client))
+
     # Discover the app's Handler so SDR workflows can be registered on the
     # worker.  When no Handler is found, create_worker silently skips SDR.
     handler_class_for_sdr = load_handler_class(
@@ -1073,6 +1078,11 @@ async def run_combined_mode(config: AppConfig) -> None:
     if auth_manager is not None:
         auth_manager.start_background_refresh(client)
         logger.info("Background token refresh started")
+
+    # Stash the connected Temporal client on the infra context so activity-side
+    # code (the local-file GC sweep) can reach it. The client doesn't exist when
+    # the context is first built, and the context is frozen — so re-set a copy.
+    set_infrastructure(replace(infra, _temporal_client=client))
 
     # Discover the handler before building the worker so the same instance
     # serves both the HTTP service and the SDR Temporal workflows.

--- a/application_sdk/storage/file_ref_sync.py
+++ b/application_sdk/storage/file_ref_sync.py
@@ -136,7 +136,11 @@ def has_refs_to_materialize(data: Any) -> bool:
 
 
 async def _replace_refs(
-    data: Any, store: ObjectStore, mode: str, output_path: str | None = None
+    data: Any,
+    store: ObjectStore,
+    mode: str,
+    output_path: str | None = None,
+    local_dir: str | None = None,
 ) -> Any:
     """Replace FileReference instances in a data tree using concurrent execution.
 
@@ -203,7 +207,7 @@ async def _replace_refs(
                 if key not in _factories:
                     _ref = node
                     _factories[key] = lambda r=_ref: materialize_file_reference(
-                        store, r
+                        store, r, local_dir=local_dir
                     )
                     _winners[key] = node
             return
@@ -321,7 +325,9 @@ async def persist_file_refs(
     return await _replace_refs(data, store, "persist", output_path=output_path)
 
 
-async def materialize_file_refs(store: ObjectStore, data: Any) -> Any:
+async def materialize_file_refs(
+    store: ObjectStore, data: Any, *, local_dir: str | None = None
+) -> Any:
     """Download all durable FileReferences in *data* to local temp files.
 
     Handles:
@@ -336,4 +342,4 @@ async def materialize_file_refs(store: ObjectStore, data: Any) -> Any:
         New object tree with all durable FileReferences replaced by local
         ones (``local_path`` set, ``.sha256`` sidecar written).
     """
-    return await _replace_refs(data, store, "materialize")
+    return await _replace_refs(data, store, "materialize", local_dir=local_dir)

--- a/application_sdk/storage/local_gc.py
+++ b/application_sdk/storage/local_gc.py
@@ -1,0 +1,212 @@
+"""Deterministic, cross-worker GC for run-scoped local ``FileReference`` scratch.
+
+The local directory layout *is* the registry: every run's scratch lives under
+``{LOCAL_FILE_REF_ROOT}/{workflow_id}/{run_id}/``. :func:`sweep_local_file_refs`
+walks that tree and, for each run dir, asks Temporal for the run's status via
+``describe()`` to decide whether the run is over and its scratch can be removed.
+
+No separate index and no cross-worker coordination: each worker GCs its *own*
+filesystem at its next activity by querying the authoritative source (Temporal).
+A worker that held orphaned copies cleans them the next time it runs anything.
+
+Decision table (per run dir):
+
+* COMPLETED / FAILED / CANCELED / TERMINATED / TIMED_OUT / CONTINUED_AS_NEW
+  → delete
+* RUNNING → keep
+* ``RPCError(NOT_FOUND)`` (history GC'd / never ran) → delete
+* connection / transient error → keep (retry next sweep)
+* dir == current run → skip (never described)
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from temporalio.client import WorkflowExecutionStatus
+from temporalio.service import RPCError, RPCStatusCode
+
+from application_sdk.observability.logger_adaptor import get_logger
+
+if TYPE_CHECKING:
+    from temporalio.client import Client
+
+logger = get_logger(__name__)
+
+#: Statuses that mean the run is over and its local scratch is safe to delete.
+_TERMINAL_STATUSES = frozenset(
+    {
+        WorkflowExecutionStatus.COMPLETED,
+        WorkflowExecutionStatus.FAILED,
+        WorkflowExecutionStatus.CANCELED,
+        WorkflowExecutionStatus.TERMINATED,
+        WorkflowExecutionStatus.TIMED_OUT,
+        WorkflowExecutionStatus.CONTINUED_AS_NEW,
+    }
+)
+
+
+def run_scoped_dir(
+    workflow_id: str,
+    run_id: str,
+    *,
+    root: str | None = None,
+    create: bool = False,
+) -> Path:
+    """Return ``{root}/{sanitize(workflow_id)}/{run_id}/`` — the GC path scheme.
+
+    This is the single definition of the run-scoped local layout. ``App.local_run_dir()``
+    (where apps write scratch), the activity auto-materialize directory, and
+    :func:`sweep_local_file_refs` (which walks the tree) all derive from it, so
+    the layout can never drift between writer and collector.
+
+    Args:
+        workflow_id: Current workflow id. Path separators are collapsed to a
+            single safe segment so the run dir never nests unexpectedly.
+        run_id: Current run id (used verbatim as the leaf segment).
+        root: Local root. Defaults to ``LOCAL_FILE_REF_ROOT`` (read at call time
+            so the env-driven default stays patchable in tests).
+        create: When True, create the directory (``parents=True, exist_ok=True``).
+
+    Returns:
+        The run-scoped :class:`~pathlib.Path`.
+    """
+    if root is None:
+        from application_sdk.constants import (  # noqa: PLC0415 — read at call time so the env-driven default stays patchable
+            LOCAL_FILE_REF_ROOT,
+        )
+
+        root = LOCAL_FILE_REF_ROOT
+    safe_workflow_id = re.sub(r"[/\\]+", "_", workflow_id)
+    path = Path(root) / safe_workflow_id / run_id
+    if create:
+        path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@dataclass
+class SweepResult:
+    """Outcome of a single :func:`sweep_local_file_refs` pass.
+
+    Attributes:
+        deleted: Run-dir paths removed (terminal status or NOT_FOUND).
+        kept: Run-dir paths left in place (RUNNING, a transient describe error,
+            or a delete that failed and will be retried next sweep).
+        describes: Number of ``describe()`` RPCs issued — bounded by ``max_describes``.
+    """
+
+    deleted: list[str] = field(default_factory=list)
+    kept: list[str] = field(default_factory=list)
+    describes: int = 0
+
+
+async def _describe_status(
+    client: Client, workflow_id: str, run_id: str
+) -> WorkflowExecutionStatus | None:
+    """Return the run's ``WorkflowExecutionStatus``, or ``None`` for NOT_FOUND.
+
+    ``None`` means Temporal has no record of the run (history GC'd or it never
+    existed) — the caller treats that as "safe to delete". Any non-NOT_FOUND
+    ``RPCError`` (and any other exception) propagates so the caller can keep the
+    dir and retry on the next sweep.
+    """
+    handle = client.get_workflow_handle(workflow_id, run_id=run_id)
+    try:
+        desc = await handle.describe()
+    except RPCError as e:
+        if e.status == RPCStatusCode.NOT_FOUND:
+            return None
+        raise
+    return desc.status
+
+
+def _rmtree(run_dir: Path) -> bool:
+    """Best-effort recursive delete. Returns True on success.
+
+    A failed delete is swallowed (logged) so one undeletable dir never aborts
+    the sweep; the dir is kept and retried on the next pass.
+    """
+    try:
+        shutil.rmtree(run_dir)
+        return True
+    except OSError:
+        logger.warning(
+            "local_gc: failed to delete run dir, will retry next sweep",
+            run_dir=str(run_dir),
+            exc_info=True,
+        )
+        return False
+
+
+async def sweep_local_file_refs(
+    client: Client,
+    *,
+    current_run_id: str,
+    max_describes: int,
+    root: str | None = None,
+) -> SweepResult:
+    """Walk the run-scoped local root and delete scratch for finished runs.
+
+    Args:
+        client: Connected Temporal client used to ``describe()`` each run.
+        current_run_id: Run id of the sweeping activity. Its own dir is always
+            skipped (and never described) so a live run never deletes itself.
+        max_describes: Upper bound on ``describe()`` RPCs this sweep issues.
+            Run dirs beyond the cap are left for the next sweep.
+        root: Local root to walk. Defaults to ``LOCAL_FILE_REF_ROOT`` (read at
+            call time so tests can point it at a temp dir).
+
+    Returns:
+        A :class:`SweepResult` summarising deletes, keeps, and describes issued.
+    """
+    if root is None:
+        from application_sdk.constants import (  # noqa: PLC0415 — read at call time so the env-driven default is patchable in tests
+            LOCAL_FILE_REF_ROOT,
+        )
+
+        root = LOCAL_FILE_REF_ROOT
+
+    result = SweepResult()
+    base = Path(root)
+    if not base.is_dir():
+        return result
+
+    for wf_dir in sorted(base.iterdir()):
+        if not wf_dir.is_dir():
+            continue
+        for run_dir in sorted(wf_dir.iterdir()):
+            if not run_dir.is_dir():
+                continue
+            # The live run's own scratch is off-limits — never describe or delete it.
+            if run_dir.name == current_run_id:
+                continue
+            # Budget spent: leave the rest for a later sweep (self-healing).
+            if result.describes >= max_describes:
+                return result
+
+            result.describes += 1
+            try:
+                status = await _describe_status(client, wf_dir.name, run_dir.name)
+            except Exception:
+                # Transient / connection error — keep the dir, retry next sweep.
+                logger.warning(
+                    "local_gc: describe failed, keeping run dir for next sweep",
+                    run_dir=str(run_dir),
+                    exc_info=True,
+                )
+                result.kept.append(str(run_dir))
+                continue
+
+            if status is None or status in _TERMINAL_STATUSES:
+                if _rmtree(run_dir):
+                    result.deleted.append(str(run_dir))
+                else:
+                    result.kept.append(str(run_dir))
+            else:
+                result.kept.append(str(run_dir))
+
+    return result

--- a/docs/concepts/file-reference.md
+++ b/docs/concepts/file-reference.md
@@ -288,6 +288,75 @@ Both fields end up with the same `local_path` after materialization. A
 `file_ref.materialize.dedup_hit` DEBUG event is emitted for the second ref. You
 do not need to deduplicate manually.
 
+### Run-Scoped Local Scratch and Automatic Cleanup
+
+`FileReference` covers files you pass between tasks. Apps sometimes also write
+their *own* scratch files on local disk — intermediate working files the app
+manages directly. Two things make cleaning these up reliably hard:
+
+- A workflow fans its activities across several workers (scale-out, or a retry
+  on a different pod). Each worker that wrote or downloaded a file holds a
+  *local* copy. `cleanup_files` runs as a single activity on a single worker and
+  reads in-process tracking — it cannot reach copies on the other workers, so
+  they are orphaned.
+- The implicit safety net is ephemeral pod storage (a restart reclaims the temp
+  dir). That assumption breaks when the temp dir is backed by a persistent
+  volume — orphans then accumulate across restarts.
+
+#### `App.local_run_dir()`
+
+Write run-scoped scratch under the directory returned by `local_run_dir()`:
+
+```python
+@task
+async def parse(self, input: ParseInput) -> ParseOutput:
+    scratch = self.local_run_dir() / "working_set.json"
+    scratch.write_text(build_working_set())
+    return ParseOutput(working_set=FileReference.from_local(scratch))
+```
+
+`local_run_dir()` returns (and creates) a directory of the form:
+
+```
+{LOCAL_FILE_REF_ROOT}/{workflow_id}/{run_id}/
+```
+
+Encoding the workflow and run ids in the path is what makes automatic cleanup
+possible — the directory layout *is* the cleanup registry. It must be called
+from inside a `@task` (activity) context, where those ids are available.
+
+#### Automatic Cross-Worker Cleanup
+
+When enabled (the default), each worker reclaims finished runs' local scratch as
+it works: it walks `LOCAL_FILE_REF_ROOT`, and for each `{workflow_id}/{run_id}`
+directory asks Temporal whether that run is over. Terminal runs (completed,
+failed, cancelled, terminated, timed-out, continued-as-new — or no longer known
+to Temporal) have their directory removed; `RUNNING` runs are left untouched.
+
+This is coordination-free and self-healing: every worker cleans its *own* disk
+by querying the authoritative run status, so a worker that holds an orphaned
+copy reclaims it the next time it runs any activity. The sweep is bounded per
+activity and never fails the activity.
+
+SDK auto-materialised `FileReference` downloads also land under this root, so
+they are covered by the same cleanup, in addition to the existing per-run
+`cleanup_files` behaviour.
+
+#### Migration
+
+If your app maintains its own scratch directory and a manual cleanup step (for
+example, an `rmtree` of a fixed path at the end of every run), switch the writes
+to `local_run_dir()` and drop the manual cleanup — the SDK then reclaims that
+scratch deterministically across workers.
+
+#### Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `ATLAN_ENABLE_LOCAL_GC` | `true` | Kill-switch for the automatic sweep. Set `false` to disable it instantly. |
+| `ATLAN_LOCAL_FILE_REF_ROOT` | `{ATLAN_TEMPORARY_PATH}/file_refs_local` | Root directory for run-scoped local scratch. |
+| `ATLAN_LOCAL_GC_MAX_DESCRIBES_PER_SWEEP` | `50` | Upper bound on Temporal status checks per sweep (bounds frontend load). |
+
 ---
 
 ## Part 2 — App.upload()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,9 @@ Set variables in your shell environment, a `.env` file at the project root, or D
 | `ATLAN_DOMAIN_NAME` | `atlan.com` | Tenant domain name. |
 | `ATLAN_TEMPORARY_PATH` | `./local/tmp/` | Path for intermediate files during processing. |
 | `ATLAN_CLEANUP_BASE_PATHS` | _(empty)_ | Comma-separated object-store prefixes cleaned up by `cleanup_files()`. Defaults to the workflow-scoped run path when unset. |
+| `ATLAN_LOCAL_FILE_REF_ROOT` | `{ATLAN_TEMPORARY_PATH}/file_refs_local` | Root for run-scoped local scratch written via `App.local_run_dir()`. Its `{workflow_id}/{run_id}/` layout drives automatic cross-worker cleanup. |
+| `ATLAN_ENABLE_LOCAL_GC` | `true` | Kill-switch for the deterministic cross-worker cleanup of finished runs' local scratch. Set `false` to disable the sweep. |
+| `ATLAN_LOCAL_GC_MAX_DESCRIBES_PER_SWEEP` | `50` | Upper bound on Temporal status checks issued per cleanup sweep (bounds frontend load; remaining run dirs are handled by the next sweep). |
 | `ATLAN_CONTRACT_GENERATED_DIR` | `app/generated` | Directory for generated contract JSON (configmaps, manifest). In Docker (`WORKDIR=/app`) this resolves to `/app/app/generated`. |
 | `ATLAN_FRONTEND_ASSETS_PATH` | `app/generated/frontend/static` | Path to static frontend assets served by the handler. |
 

--- a/tests/integration/test_sql_app_file_reference.py
+++ b/tests/integration/test_sql_app_file_reference.py
@@ -420,3 +420,84 @@ async def test_zero_row_extract_emits_no_raw_file(store, tmp_path):
 
     assert result.total_record_count == 0
     assert result.raw_file is None
+
+
+# ---------------------------------------------------------------------------
+# Cross-worker local GC: materialize into run-scoped scratch, then reclaim it
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_local_gc_reclaims_finished_run_scratch(store, tmp_path):
+    """A worker materialises a durable ref into its run-scoped scratch; a later
+    sweep reclaims that scratch once Temporal reports the run terminal, while a
+    still-RUNNING run's scratch survives.
+
+    Exercises the real chain end-to-end against a local obstore — ``run_scoped_dir``
+    → ``materialize_file_reference(local_dir=...)`` → ``sweep_local_file_refs`` —
+    with only the Temporal client faked (consistent with this module's no-Temporal
+    approach). This is the cross-worker GC contract: a worker reclaims *another*
+    run's local copy by querying the authoritative run status.
+    """
+    from temporalio.client import WorkflowExecutionStatus
+
+    from application_sdk.storage.local_gc import run_scoped_dir, sweep_local_file_refs
+
+    # Upload a local file so we have a durable ref to materialise.
+    src = tmp_path / "io_pairs.json"
+    src.write_text(json.dumps([{"q": "select 1"}]))
+    durable = await persist_file_reference(
+        store, FileReference(local_path=str(src), is_durable=False)
+    )
+    assert durable.storage_path is not None
+
+    # "Worker B" materialises it into the run-scoped scratch for a finished run.
+    root = tmp_path / "file_refs_local"
+    done_dir = run_scoped_dir("wf-gc", "run-done", root=str(root))
+    materialised = await materialize_file_reference(
+        store,
+        FileReference(
+            is_durable=True, storage_path=durable.storage_path, local_path=None
+        ),
+        local_dir=str(done_dir),
+    )
+    assert materialised.local_path is not None
+    assert materialised.local_path.startswith(str(done_dir))
+    assert done_dir.exists()
+
+    # A second run is still RUNNING and has its own scratch.
+    live_dir = run_scoped_dir("wf-gc", "run-live", root=str(root))
+    live_dir.mkdir(parents=True)
+    (live_dir / "io_pairs.json").write_text("[]")
+
+    # A third worker sweeps: describe() drives delete (terminal) vs keep (running).
+    class _FakeHandle:
+        def __init__(self, status: WorkflowExecutionStatus) -> None:
+            self._status = status
+
+        async def describe(self) -> Any:
+            return type("Desc", (), {"status": self._status})()
+
+    class _FakeClient:
+        def __init__(self, by_run: dict[str, WorkflowExecutionStatus]) -> None:
+            self._by_run = by_run
+
+        def get_workflow_handle(
+            self, workflow_id: str, *, run_id: str | None = None
+        ) -> _FakeHandle:
+            return _FakeHandle(self._by_run[run_id])
+
+    client = _FakeClient(
+        {
+            "run-done": WorkflowExecutionStatus.COMPLETED,
+            "run-live": WorkflowExecutionStatus.RUNNING,
+        }
+    )
+    result = await sweep_local_file_refs(
+        client, current_run_id="run-other", max_describes=50, root=str(root)
+    )
+
+    assert not done_dir.exists()  # terminal run's scratch reclaimed
+    assert live_dir.exists()  # running run's scratch preserved
+    assert str(done_dir) in result.deleted
+    assert str(live_dir) in result.kept

--- a/tests/unit/app/test_cleanup_files.py
+++ b/tests/unit/app/test_cleanup_files.py
@@ -91,13 +91,13 @@ class TestCleanupFiles:
         (test_dir / "some-file.txt").write_text("data")
 
         app = _CleanupApp()
-        with mock.patch(
-            "application_sdk.app.base.TaskStateAccessor.get", return_value=None
+        with (
+            mock.patch(
+                "application_sdk.app.base.TaskStateAccessor.get", return_value=None
+            ),
+            mock.patch("application_sdk.constants.CLEANUP_BASE_PATHS", [str(test_dir)]),
         ):
-            with mock.patch(
-                "application_sdk.constants.CLEANUP_BASE_PATHS", [str(test_dir)]
-            ):
-                result = await app.cleanup_files(CleanupInput())
+            result = await app.cleanup_files(CleanupInput())
 
         assert not test_dir.exists()
         assert result.path_results[str(test_dir)] is True
@@ -107,11 +107,13 @@ class TestCleanupFiles:
         missing = str(tmp_path / "nonexistent")
 
         app = _CleanupApp()
-        with mock.patch(
-            "application_sdk.app.base.TaskStateAccessor.get", return_value=None
+        with (
+            mock.patch(
+                "application_sdk.app.base.TaskStateAccessor.get", return_value=None
+            ),
+            mock.patch("application_sdk.constants.CLEANUP_BASE_PATHS", [missing]),
         ):
-            with mock.patch("application_sdk.constants.CLEANUP_BASE_PATHS", [missing]):
-                result = await app.cleanup_files(CleanupInput())
+            result = await app.cleanup_files(CleanupInput())
 
         assert result.path_results[missing] is True
 
@@ -153,14 +155,60 @@ class TestCleanupFiles:
         ref = FileReference(local_path=str(f), storage_path="artifacts/locked")
 
         app = _CleanupApp()
-        with mock.patch(
-            "application_sdk.app.base.TaskStateAccessor.get",
-            return_value={ref},
+        with (
+            mock.patch(
+                "application_sdk.app.base.TaskStateAccessor.get",
+                return_value={ref},
+            ),
+            mock.patch("os.remove", side_effect=OSError("permission denied")),
         ):
-            with mock.patch("os.remove", side_effect=OSError("permission denied")):
-                result = await app.cleanup_files(
-                    CleanupInput(extra_paths=["nonexistent-dir"])
-                )
+            result = await app.cleanup_files(
+                CleanupInput(extra_paths=["nonexistent-dir"])
+            )
 
         # Error is captured — task does not raise
         assert result.path_results[str(f)] is False
+
+    @pytest.mark.asyncio
+    async def test_invokes_local_gc_sweep(self, monkeypatch: Any) -> None:
+        """cleanup_files runs the belt-and-braces cross-worker GC sweep."""
+        app = _CleanupApp()
+        called: list[bool] = []
+
+        async def _fake_sweep() -> None:
+            called.append(True)
+
+        monkeypatch.setattr(
+            "application_sdk.execution._temporal.activities._maybe_sweep_local_file_refs",
+            _fake_sweep,
+        )
+        with mock.patch(
+            "application_sdk.app.base.TaskStateAccessor.get", return_value=None
+        ):
+            await app.cleanup_files(CleanupInput(extra_paths=["nonexistent-dir"]))
+
+        assert called == [True]
+
+    @pytest.mark.asyncio
+    async def test_sweep_respects_kill_switch(self, monkeypatch: Any) -> None:
+        """With the kill-switch off, no real sweep runs even via cleanup_files."""
+        app = _CleanupApp()
+        monkeypatch.setattr("application_sdk.constants.ENABLE_LOCAL_GC", False)
+        monkeypatch.setattr(
+            "application_sdk.infrastructure.context.get_temporal_client",
+            lambda: object(),
+        )
+        swept: list[bool] = []
+
+        async def _fake_sweep(*a: Any, **k: Any) -> None:
+            swept.append(True)
+
+        monkeypatch.setattr(
+            "application_sdk.storage.local_gc.sweep_local_file_refs", _fake_sweep
+        )
+        with mock.patch(
+            "application_sdk.app.base.TaskStateAccessor.get", return_value=None
+        ):
+            await app.cleanup_files(CleanupInput(extra_paths=["nonexistent-dir"]))
+
+        assert swept == []

--- a/tests/unit/app/test_local_run_dir.py
+++ b/tests/unit/app/test_local_run_dir.py
@@ -1,0 +1,119 @@
+"""Tests for App.local_run_dir() — run-scoped local scratch root."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from application_sdk.app.base import App, AppContextError, _app_state, _app_state_lock
+from application_sdk.app.registry import AppRegistry, TaskRegistry
+from application_sdk.contracts.base import Input, Output
+
+
+@dataclass
+class _LRInput(Input, allow_unbounded_fields=True):
+    value: str = ""
+
+
+@dataclass
+class _LROutput(Output, allow_unbounded_fields=True):
+    result: str = ""
+
+
+class _LRApp(App):
+    async def run(self, input: _LRInput) -> _LROutput:
+        return _LROutput()
+
+
+def _info(workflow_id: str, run_id: str) -> Any:
+    return mock.Mock(workflow_id=workflow_id, workflow_run_id=run_id)
+
+
+class TestLocalRunDir:
+    def setup_method(self) -> None:
+        AppRegistry.reset()
+        TaskRegistry.reset()
+        with _app_state_lock:
+            _app_state.clear()
+
+    def teardown_method(self) -> None:
+        AppRegistry.reset()
+        TaskRegistry.reset()
+        with _app_state_lock:
+            _app_state.clear()
+
+    def test_returns_run_scoped_path_and_creates_it(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "application_sdk.constants.LOCAL_FILE_REF_ROOT", str(tmp_path)
+        )
+        app = _LRApp()
+        with mock.patch(
+            "application_sdk.app.base.activity.info",
+            return_value=_info("wf1", "run1"),
+        ):
+            path = app.local_run_dir()
+
+        assert path == tmp_path / "wf1" / "run1"
+        assert path.is_dir()
+
+    def test_sanitizes_slashes_in_workflow_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "application_sdk.constants.LOCAL_FILE_REF_ROOT", str(tmp_path)
+        )
+        app = _LRApp()
+        with mock.patch(
+            "application_sdk.app.base.activity.info",
+            return_value=_info("ns/team/wf-7", "run-1"),
+        ):
+            path = app.local_run_dir()
+
+        # The slash-bearing workflow_id collapses to a single safe segment —
+        # no accidental nested directories.
+        assert path == tmp_path / "ns_team_wf-7" / "run-1"
+        assert path.is_dir()
+        assert not (tmp_path / "ns").exists()
+
+    def test_raises_app_context_error_when_ids_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "application_sdk.constants.LOCAL_FILE_REF_ROOT", str(tmp_path)
+        )
+        app = _LRApp()
+        # Outside a real activity context Temporal's Info ids are None — surface a
+        # clear AppContextError rather than a raw TypeError from path building.
+        with (
+            mock.patch(
+                "application_sdk.app.base.activity.info",
+                return_value=_info(None, "run1"),
+            ),
+            pytest.raises(AppContextError),
+        ):
+            app.local_run_dir()
+
+    def test_is_idempotent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "application_sdk.constants.LOCAL_FILE_REF_ROOT", str(tmp_path)
+        )
+        app = _LRApp()
+        with mock.patch(
+            "application_sdk.app.base.activity.info",
+            return_value=_info("wf1", "run1"),
+        ):
+            first = app.local_run_dir()
+            (first / "scratch.json").write_text("{}")
+            second = app.local_run_dir()
+
+        assert first == second
+        # Re-creating must not wipe existing scratch.
+        assert (second / "scratch.json").exists()

--- a/tests/unit/execution/test_activities.py
+++ b/tests/unit/execution/test_activities.py
@@ -578,9 +578,9 @@ class TestActivityFnExecution:
                 "application_sdk.infrastructure.context.get_infrastructure",
                 return_value=None,
             ),
+            pytest.raises(ApplicationError) as exc_info,
         ):
-            with pytest.raises(ApplicationError) as exc_info:
-                await activity_fn(ctx, _AfnIn(name="x"))
+            await activity_fn(ctx, _AfnIn(name="x"))
         # ApplicationError should be flagged non-retryable.
         assert exc_info.value.non_retryable is True
 
@@ -617,9 +617,9 @@ class TestActivityFnExecution:
                 "application_sdk.infrastructure.context.get_infrastructure",
                 return_value=None,
             ),
+            pytest.raises(ValueError, match="ordinary failure"),
         ):
-            with pytest.raises(ValueError, match="ordinary failure"):
-                await activity_fn(ctx, _AfnIn(name="x"))
+            await activity_fn(ctx, _AfnIn(name="x"))
 
     @pytest.mark.asyncio
     async def test_starts_and_stops_auto_heartbeat_loop(self) -> None:
@@ -690,3 +690,140 @@ class TestActivityFnExecution:
         ):
             result = await activity_fn(ctx, _AfnIn(name="i"))
         assert result.greeting == "hi i"
+
+
+# --------------------------------------------------------------------------- #
+# Local-file GC wiring (interceptor helpers)                                  #
+# --------------------------------------------------------------------------- #
+
+
+class TestLocalGcDirForActivity:
+    """_local_gc_dir_for_activity(): the local_dir for auto-materialised refs."""
+
+    def test_returns_none_when_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("application_sdk.constants.ENABLE_LOCAL_GC", False)
+        with mock.patch.object(
+            activities_module.activity,
+            "info",
+            return_value=mock.MagicMock(workflow_id="wf", workflow_run_id="run"),
+        ):
+            assert activities_module._local_gc_dir_for_activity() is None
+
+    def test_returns_none_when_ids_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("application_sdk.constants.ENABLE_LOCAL_GC", True)
+        with mock.patch.object(
+            activities_module.activity,
+            "info",
+            return_value=mock.MagicMock(workflow_id=None, workflow_run_id="run"),
+        ):
+            assert activities_module._local_gc_dir_for_activity() is None
+
+    def test_returns_run_scoped_dir_when_enabled(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("application_sdk.constants.ENABLE_LOCAL_GC", True)
+        monkeypatch.setattr(
+            "application_sdk.constants.LOCAL_FILE_REF_ROOT", str(tmp_path)
+        )
+        with mock.patch.object(
+            activities_module.activity,
+            "info",
+            return_value=mock.MagicMock(workflow_id="wf", workflow_run_id="run"),
+        ):
+            result = activities_module._local_gc_dir_for_activity()
+        assert result == str(tmp_path / "wf" / "run")
+
+
+class TestMaybeSweepLocalFileRefs:
+    """_maybe_sweep_local_file_refs(): best-effort, gated, never raises."""
+
+    @pytest.mark.asyncio
+    async def test_noop_when_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("application_sdk.constants.ENABLE_LOCAL_GC", False)
+        swept = []
+
+        async def _fake_sweep(*a, **k):
+            swept.append(True)
+
+        monkeypatch.setattr(
+            "application_sdk.storage.local_gc.sweep_local_file_refs", _fake_sweep
+        )
+        await activities_module._maybe_sweep_local_file_refs()
+        assert swept == []
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("application_sdk.constants.ENABLE_LOCAL_GC", True)
+        monkeypatch.setattr(
+            "application_sdk.infrastructure.context.get_temporal_client",
+            lambda: None,
+        )
+        swept = []
+
+        async def _fake_sweep(*a, **k):
+            swept.append(True)
+
+        monkeypatch.setattr(
+            "application_sdk.storage.local_gc.sweep_local_file_refs", _fake_sweep
+        )
+        await activities_module._maybe_sweep_local_file_refs()
+        assert swept == []
+
+    @pytest.mark.asyncio
+    async def test_sweeps_with_stashed_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("application_sdk.constants.ENABLE_LOCAL_GC", True)
+        monkeypatch.setattr(
+            "application_sdk.constants.LOCAL_GC_MAX_DESCRIBES_PER_SWEEP", 7
+        )
+        client = object()
+        monkeypatch.setattr(
+            "application_sdk.infrastructure.context.get_temporal_client",
+            lambda: client,
+        )
+        captured: dict = {}
+
+        async def _fake_sweep(c, *, current_run_id, max_describes):
+            captured.update(
+                client=c, current_run_id=current_run_id, max_describes=max_describes
+            )
+
+        monkeypatch.setattr(
+            "application_sdk.storage.local_gc.sweep_local_file_refs", _fake_sweep
+        )
+        with mock.patch.object(
+            activities_module.activity,
+            "info",
+            return_value=mock.MagicMock(workflow_run_id="run-9"),
+        ):
+            await activities_module._maybe_sweep_local_file_refs()
+        assert captured == {
+            "client": client,
+            "current_run_id": "run-9",
+            "max_describes": 7,
+        }
+
+    @pytest.mark.asyncio
+    async def test_swallows_sweep_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("application_sdk.constants.ENABLE_LOCAL_GC", True)
+        monkeypatch.setattr(
+            "application_sdk.infrastructure.context.get_temporal_client",
+            lambda: object(),
+        )
+
+        async def _boom(*a, **k):
+            raise RuntimeError("temporal unreachable")
+
+        monkeypatch.setattr(
+            "application_sdk.storage.local_gc.sweep_local_file_refs", _boom
+        )
+        with mock.patch.object(
+            activities_module.activity,
+            "info",
+            return_value=mock.MagicMock(workflow_run_id="run-9"),
+        ):
+            # Must not raise — a sweep failure can never fail the activity.
+            await activities_module._maybe_sweep_local_file_refs()

--- a/tests/unit/infrastructure/test_context.py
+++ b/tests/unit/infrastructure/test_context.py
@@ -1,0 +1,48 @@
+"""Tests for InfrastructureContext._temporal_client and get_temporal_client()."""
+
+from __future__ import annotations
+
+import dataclasses
+
+from application_sdk.infrastructure.context import (
+    InfrastructureContext,
+    clear_infrastructure,
+    get_temporal_client,
+    set_infrastructure,
+)
+
+
+class TestTemporalClientOnContext:
+    def teardown_method(self) -> None:
+        clear_infrastructure()
+
+    def test_field_defaults_to_none(self) -> None:
+        ctx = InfrastructureContext()
+        assert ctx._temporal_client is None
+
+    def test_get_returns_none_when_no_context(self) -> None:
+        clear_infrastructure()
+        assert get_temporal_client() is None
+
+    def test_get_returns_none_when_client_not_stashed(self) -> None:
+        set_infrastructure(InfrastructureContext())
+        assert get_temporal_client() is None
+
+    def test_get_returns_stashed_client(self) -> None:
+        sentinel = object()
+        set_infrastructure(InfrastructureContext(_temporal_client=sentinel))
+        assert get_temporal_client() is sentinel
+
+    def test_replace_sets_client_and_preserves_other_fields(self) -> None:
+        # Mirrors the main.py stash: replace() on the frozen context adds the
+        # client without disturbing the already-built infra services, and leaves
+        # the original instance untouched.
+        storage = object()
+        base = InfrastructureContext(storage=storage)
+        client = object()
+
+        updated = dataclasses.replace(base, _temporal_client=client)
+
+        assert updated._temporal_client is client
+        assert updated.storage is storage
+        assert base._temporal_client is None

--- a/tests/unit/storage/test_file_ref_sync.py
+++ b/tests/unit/storage/test_file_ref_sync.py
@@ -172,6 +172,33 @@ class TestPersistAndMaterialize:
         assert open(materialised.ref.local_path, "rb").read() == content
         os.unlink(materialised.ref.local_path)
 
+    async def test_materialize_writes_under_local_dir(self, tmp_path: Path) -> None:
+        """local_dir threads through to the download so auto-materialised refs
+        land under the run-scoped GC root."""
+        store = create_memory_store()
+        content = b"scoped content"
+        path = _make_local_file(content)
+        try:
+            output = _TaskOutput(ref=FileReference(local_path=path, is_durable=False))
+            persisted = await persist_file_refs(store, output)
+            storage_path = persisted.ref.storage_path
+        finally:
+            os.unlink(path)
+
+        remote_input = _TaskInput(
+            ref=FileReference(
+                is_durable=True, storage_path=storage_path, local_path=None
+            )
+        )
+        local_dir = str(tmp_path / "wf" / "run")
+        materialised = await materialize_file_refs(
+            store, remote_input, local_dir=local_dir
+        )
+        assert materialised.ref.local_path is not None
+        assert materialised.ref.local_path.startswith(local_dir)
+        assert os.path.exists(materialised.ref.local_path)
+        os.unlink(materialised.ref.local_path)
+
     async def test_persist_noop_for_durable_ref(self) -> None:
         store = create_memory_store()
         ref = FileReference(is_durable=True, storage_path="file_refs/existing")

--- a/tests/unit/storage/test_local_gc.py
+++ b/tests/unit/storage/test_local_gc.py
@@ -1,0 +1,297 @@
+"""Tests for the deterministic cross-worker local FileReference GC sweep."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from temporalio.client import WorkflowExecutionStatus
+from temporalio.service import RPCError, RPCStatusCode
+
+from application_sdk.storage.local_gc import (
+    SweepResult,
+    _describe_status,
+    run_scoped_dir,
+    sweep_local_file_refs,
+)
+
+# --- WorkflowExecutionStatus partitioning -----------------------------------
+
+TERMINAL_STATUSES = [
+    WorkflowExecutionStatus.COMPLETED,
+    WorkflowExecutionStatus.FAILED,
+    WorkflowExecutionStatus.CANCELED,
+    WorkflowExecutionStatus.TERMINATED,
+    WorkflowExecutionStatus.TIMED_OUT,
+    WorkflowExecutionStatus.CONTINUED_AS_NEW,
+]
+
+
+# --- Fake Temporal client ----------------------------------------------------
+
+
+class _FakeHandle:
+    def __init__(self, behavior: tuple[Any, ...]) -> None:
+        self._behavior = behavior
+
+    async def describe(self) -> Any:
+        kind = self._behavior[0]
+        if kind == "status":
+            return type("Desc", (), {"status": self._behavior[1]})()
+        if kind == "not_found":
+            raise RPCError("workflow not found", RPCStatusCode.NOT_FOUND, b"")
+        if kind == "raise":
+            raise self._behavior[1]
+        raise AssertionError(f"unknown behavior {kind!r}")
+
+
+class _FakeClient:
+    """Returns a handle whose ``describe()`` is keyed by ``run_id``.
+
+    ``behaviors`` maps run_id -> ("status", WorkflowExecutionStatus)
+    | ("not_found",) | ("raise", Exception).
+    """
+
+    def __init__(self, behaviors: dict[str, tuple[Any, ...]]) -> None:
+        self._behaviors = behaviors
+        self.handle_calls: list[tuple[str, str | None]] = []
+
+    def get_workflow_handle(
+        self, workflow_id: str, *, run_id: str | None = None
+    ) -> _FakeHandle:
+        self.handle_calls.append((workflow_id, run_id))
+        return _FakeHandle(self._behaviors[run_id])
+
+
+# --- Helpers -----------------------------------------------------------------
+
+
+def _make_run_dir(root: Path, workflow_id: str, run_id: str) -> Path:
+    """Create ``{root}/{workflow_id}/{run_id}/`` with a scratch file inside."""
+    run_dir = root / workflow_id / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "io_pairs.json").write_text("[]")
+    return run_dir
+
+
+# --- sweep_local_file_refs ---------------------------------------------------
+
+
+class TestSweep:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", TERMINAL_STATUSES)
+    async def test_terminal_status_dir_is_deleted(
+        self, tmp_path: Path, status: WorkflowExecutionStatus
+    ) -> None:
+        run_dir = _make_run_dir(tmp_path, "wf", "run-1")
+        client = _FakeClient({"run-1": ("status", status)})
+
+        result = await sweep_local_file_refs(
+            client, current_run_id="other", max_describes=50, root=str(tmp_path)
+        )
+
+        assert not run_dir.exists()
+        assert str(run_dir) in result.deleted
+        assert str(run_dir) not in result.kept
+        assert result.describes == 1
+
+    @pytest.mark.asyncio
+    async def test_running_status_dir_is_kept(self, tmp_path: Path) -> None:
+        run_dir = _make_run_dir(tmp_path, "wf", "run-1")
+        client = _FakeClient({"run-1": ("status", WorkflowExecutionStatus.RUNNING)})
+
+        result = await sweep_local_file_refs(
+            client, current_run_id="other", max_describes=50, root=str(tmp_path)
+        )
+
+        assert run_dir.exists()
+        assert str(run_dir) in result.kept
+        assert str(run_dir) not in result.deleted
+
+    @pytest.mark.asyncio
+    async def test_not_found_dir_is_deleted(self, tmp_path: Path) -> None:
+        run_dir = _make_run_dir(tmp_path, "wf", "run-1")
+        client = _FakeClient({"run-1": ("not_found",)})
+
+        result = await sweep_local_file_refs(
+            client, current_run_id="other", max_describes=50, root=str(tmp_path)
+        )
+
+        assert not run_dir.exists()
+        assert str(run_dir) in result.deleted
+
+    @pytest.mark.asyncio
+    async def test_transient_error_dir_is_kept(self, tmp_path: Path) -> None:
+        run_dir = _make_run_dir(tmp_path, "wf", "run-1")
+        transient = RPCError("unavailable", RPCStatusCode.UNAVAILABLE, b"")
+        client = _FakeClient({"run-1": ("raise", transient)})
+
+        result = await sweep_local_file_refs(
+            client, current_run_id="other", max_describes=50, root=str(tmp_path)
+        )
+
+        assert run_dir.exists()
+        assert str(run_dir) in result.kept
+        assert str(run_dir) not in result.deleted
+
+    @pytest.mark.asyncio
+    async def test_current_run_dir_is_skipped_and_never_described(
+        self, tmp_path: Path
+    ) -> None:
+        current = _make_run_dir(tmp_path, "wf", "current-run")
+        # Even if Temporal would report it COMPLETED, the current run is never touched.
+        client = _FakeClient(
+            {"current-run": ("status", WorkflowExecutionStatus.COMPLETED)}
+        )
+
+        result = await sweep_local_file_refs(
+            client,
+            current_run_id="current-run",
+            max_describes=50,
+            root=str(tmp_path),
+        )
+
+        assert current.exists()
+        assert result.describes == 0
+        assert client.handle_calls == []  # never even asked Temporal
+        assert str(current) not in result.deleted
+
+    @pytest.mark.asyncio
+    async def test_max_describes_cap_honored(self, tmp_path: Path) -> None:
+        run_dirs = [_make_run_dir(tmp_path, "wf", f"run-{i}") for i in range(5)]
+        client = _FakeClient(
+            {
+                f"run-{i}": ("status", WorkflowExecutionStatus.COMPLETED)
+                for i in range(5)
+            }
+        )
+
+        result = await sweep_local_file_refs(
+            client, current_run_id="other", max_describes=2, root=str(tmp_path)
+        )
+
+        # Only two describes issued this sweep; the rest are deferred.
+        assert result.describes == 2
+        assert len(client.handle_calls) == 2
+        assert len(result.deleted) == 2
+        surviving = [d for d in run_dirs if d.exists()]
+        assert len(surviving) == 3
+
+    @pytest.mark.asyncio
+    async def test_delete_failure_keeps_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        run_dir = _make_run_dir(tmp_path, "wf", "run-1")
+        client = _FakeClient({"run-1": ("status", WorkflowExecutionStatus.COMPLETED)})
+
+        def _boom(_path: Any) -> None:
+            raise OSError("device busy")
+
+        monkeypatch.setattr("application_sdk.storage.local_gc.shutil.rmtree", _boom)
+
+        result = await sweep_local_file_refs(
+            client, current_run_id="other", max_describes=50, root=str(tmp_path)
+        )
+
+        # Undeletable dir is kept (retried next sweep), never reported as deleted.
+        assert run_dir.exists()
+        assert str(run_dir) in result.kept
+        assert str(run_dir) not in result.deleted
+
+    @pytest.mark.asyncio
+    async def test_missing_root_returns_empty_result(self, tmp_path: Path) -> None:
+        client = _FakeClient({})
+
+        result = await sweep_local_file_refs(
+            client,
+            current_run_id="other",
+            max_describes=50,
+            root=str(tmp_path / "does-not-exist"),
+        )
+
+        assert result == SweepResult()
+        assert client.handle_calls == []
+
+    @pytest.mark.asyncio
+    async def test_mixed_runs_partition_correctly(self, tmp_path: Path) -> None:
+        done = _make_run_dir(tmp_path, "wf-a", "done")
+        live = _make_run_dir(tmp_path, "wf-b", "live")
+        gone = _make_run_dir(tmp_path, "wf-c", "gone")
+        client = _FakeClient(
+            {
+                "done": ("status", WorkflowExecutionStatus.COMPLETED),
+                "live": ("status", WorkflowExecutionStatus.RUNNING),
+                "gone": ("not_found",),
+            }
+        )
+
+        result = await sweep_local_file_refs(
+            client, current_run_id="other", max_describes=50, root=str(tmp_path)
+        )
+
+        assert not done.exists()
+        assert live.exists()
+        assert not gone.exists()
+        assert sorted(result.deleted) == sorted([str(done), str(gone)])
+        assert result.kept == [str(live)]
+
+
+# --- _describe_status --------------------------------------------------------
+
+
+class TestDescribeStatus:
+    @pytest.mark.asyncio
+    async def test_returns_status_for_known_run(self) -> None:
+        client = _FakeClient({"r": ("status", WorkflowExecutionStatus.FAILED)})
+        assert (
+            await _describe_status(client, "wf", "r") == WorkflowExecutionStatus.FAILED
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_not_found(self) -> None:
+        client = _FakeClient({"r": ("not_found",)})
+        assert await _describe_status(client, "wf", "r") is None
+
+    @pytest.mark.asyncio
+    async def test_reraises_non_not_found_rpc_error(self) -> None:
+        transient = RPCError("unavailable", RPCStatusCode.UNAVAILABLE, b"")
+        client = _FakeClient({"r": ("raise", transient)})
+        with pytest.raises(RPCError):
+            await _describe_status(client, "wf", "r")
+
+
+# --- run_scoped_dir ----------------------------------------------------------
+
+
+class TestRunScopedDir:
+    """The single source of the GC path scheme: {root}/{sanitize(wf)}/{run}/.
+
+    local_run_dir(), the activity auto-materialize dir, and the sweep walk must
+    all agree on this layout, so it lives in one place.
+    """
+
+    def test_builds_run_scoped_path(self, tmp_path: Path) -> None:
+        path = run_scoped_dir("wf1", "run1", root=str(tmp_path))
+        assert path == tmp_path / "wf1" / "run1"
+
+    def test_sanitizes_slashes_in_workflow_id(self, tmp_path: Path) -> None:
+        path = run_scoped_dir("ns/team/wf-7", "run-1", root=str(tmp_path))
+        assert path == tmp_path / "ns_team_wf-7" / "run-1"
+
+    def test_does_not_create_by_default(self, tmp_path: Path) -> None:
+        path = run_scoped_dir("wf1", "run1", root=str(tmp_path))
+        assert not path.exists()
+
+    def test_create_true_makes_the_directory(self, tmp_path: Path) -> None:
+        path = run_scoped_dir("wf1", "run1", root=str(tmp_path), create=True)
+        assert path.is_dir()
+
+    def test_defaults_root_to_constant(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "application_sdk.constants.LOCAL_FILE_REF_ROOT", str(tmp_path)
+        )
+        path = run_scoped_dir("wf1", "run1")
+        assert path == tmp_path / "wf1" / "run1"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from application_sdk.infrastructure.context import InfrastructureContext
 from application_sdk.main import (
     AppConfig,
     _create_infrastructure,
@@ -987,9 +988,8 @@ class TestRunWorkerMode:
     @pytest.fixture
     def worker_patches(self):
         """Patch the worker-mode collaborators."""
-        infra = MagicMock()
-        infra.secret_store = MagicMock()
-        infra.storage = MagicMock()
+        # A real (frozen) context so main.py's dataclasses.replace() stash works.
+        infra = InfrastructureContext(secret_store=MagicMock(), storage=MagicMock())
 
         with (
             patch(
@@ -1064,7 +1064,11 @@ class TestRunWorkerMode:
         with patch.object(asyncio.Event, "wait", new=AsyncMock(return_value=None)):
             await run_worker_mode(cfg)
 
-        worker_patches["set_infra"].assert_called_once()
+        # set_infrastructure is called twice: once with the base context, then
+        # again to stash the connected Temporal client for activity-side GC.
+        assert worker_patches["set_infra"].call_count == 2
+        stashed = worker_patches["set_infra"].call_args_list[1].args[0]
+        assert stashed._temporal_client is worker_patches["create_client"].return_value
         worker_patches["create_client"].assert_awaited_once()
         worker_patches["close_infra"].assert_awaited_once()
         worker_patches["health"].assert_called_once()
@@ -1260,9 +1264,8 @@ class TestRunCombinedMode:
 
     @pytest.fixture
     def combined_patches(self):
-        infra = MagicMock()
-        infra.secret_store = MagicMock()
-        infra.storage = MagicMock()
+        # A real (frozen) context so main.py's dataclasses.replace() stash works.
+        infra = InfrastructureContext(secret_store=MagicMock(), storage=MagicMock())
 
         # uvicorn: serve() is awaitable and returns immediately
         uvicorn_server = MagicMock()
@@ -1342,9 +1345,7 @@ class TestRunCombinedMode:
 
     async def test_reuses_existing_infrastructure(self, combined_patches) -> None:
         """If infra is already set, _create_infrastructure must NOT be called."""
-        existing = MagicMock()
-        existing.secret_store = MagicMock()
-        existing.storage = MagicMock()
+        existing = InfrastructureContext(secret_store=MagicMock(), storage=MagicMock())
         cfg = AppConfig(mode="combined", app_module="pkg:FakeApp")
         with (
             patch(
@@ -1769,9 +1770,8 @@ class TestRunCombinedAuth:
 
     async def test_auth_enabled_acquires_token_and_shuts_down(self) -> None:
         """When auth_enabled, TemporalAuthManager is acquired + shutdown."""
-        infra = MagicMock()
-        infra.secret_store = MagicMock()
-        infra.storage = MagicMock()
+        # A real (frozen) context so main.py's dataclasses.replace() stash works.
+        infra = InfrastructureContext(secret_store=MagicMock(), storage=MagicMock())
 
         uvicorn_server = MagicMock()
         uvicorn_server.serve = AsyncMock(return_value=None)


### PR DESCRIPTION
## Problem

`FileReference` local files materialized on a worker are only reclaimed by `cleanup_files`, which runs as a **single Temporal activity on one worker** and reads **in-process, per-process tracking**. Any `FileReference` materialized on a *different* worker (fan-out across worker replicas, or a retry on another pod) orphans its local copy.

- `cleanup_storage` (object store) is fine — remote deletes are global, so one delete from any worker reclaims the remote copy.
- `cleanup_files` (local FS) is the gap — it can only reach the filesystem of the one worker it runs on.

Ephemeral pod storage masks this (a restart reclaims the temp dir). With **persistent-volume-backed** temp directories the orphans persist across restarts and grow unbounded.

## Design — the directory layout *is* the registry

Encode the GC key in the local path instead of maintaining a separate index:

```
{LOCAL_FILE_REF_ROOT}/{workflow_id}/{run_id}/
```

Each worker self-GCs its own filesystem as it works: it walks the root and, for each `{workflow_id}/{run_id}` directory, asks Temporal whether that run is over via `describe()`.

| Temporal status | Action |
|---|---|
| COMPLETED / FAILED / CANCELED / TERMINATED / TIMED_OUT / CONTINUED_AS_NEW | delete |
| RUNNING | keep |
| `RPCError(NOT_FOUND)` (history GC'd / never existed) | delete |
| transient / connection error | keep (retry next sweep) |
| dir == current run | skip (never described) |

Coordination-free, bounded per activity (`ATLAN_LOCAL_GC_MAX_DESCRIBES_PER_SWEEP`), and self-healing — a worker holding orphaned copies cleans them the next time it runs any activity. Chosen over a TTL because describe-based GC never deletes a live run's scratch and promptly catches `TERMINATED` / `TIMED_OUT` that end-of-run cleanup never sees.

## What changed

- **`App.local_run_dir()`** — run-scoped local scratch root for apps to write into (then wrap in `FileReference.from_local`).
- **`storage/local_gc.py`** *(new)* — `run_scoped_dir()` (the single definition of the path scheme) + describe-based `sweep_local_file_refs()`.
- **Infra context** — the worker's connected Temporal client is exposed via `get_temporal_client()` so the activity-side sweep can reach it (stashed at worker bootstrap; reuses the existing client, so TLS/mTLS is unchanged).
- **Triggers** — the activity interceptor materializes auto-downloads under the run-scoped root and runs the bounded sweep as it works; `cleanup_files` runs a belt-and-braces sweep at end of run.
- All behind **`ATLAN_ENABLE_LOCAL_GC`** (default on; instant kill-switch).

## Backward compatibility

Additive. The existing in-process tracked-ref cleanup and current `cleanup_files` / `cleanup_storage` behaviour are unchanged. Apps that manage their own scratch opt in by writing under `local_run_dir()`; the `mkstemp` fallback is retained when workflow/run ids are unavailable (local dev / non-Temporal).

## Testing

- **Unit:** `tests/unit/storage/test_local_gc.py` (sweep decision table per `WorkflowExecutionStatus`, NOT_FOUND → delete, transient → keep, current-run skip, `max_describes` cap, delete-failure → keep, `run_scoped_dir`), `test_local_run_dir.py`, `test_context.py`, plus extensions to `test_main.py` (client stash), `test_file_ref_sync.py` (`local_dir` threading), `test_activities.py` (interceptor wiring), and `test_cleanup_files.py` (sweep + kill-switch).
- **Integration:** `tests/integration/test_sql_app_file_reference.py` — materialize into a run-scoped scratch dir against a real local store, then a sweep reclaims a terminal run while a RUNNING run survives.
- **Docs:** `docs/concepts/file-reference.md` (usage + migration note) and `docs/configuration.md` (new env vars).

All unit + integration tests pass locally; pre-commit (ruff, ruff-format, isort, pyright) clean.

## Config

| Env var | Default | Purpose |
|---|---|---|
| `ATLAN_ENABLE_LOCAL_GC` | `true` | Kill-switch for the sweep. |
| `ATLAN_LOCAL_FILE_REF_ROOT` | `{ATLAN_TEMPORARY_PATH}/file_refs_local` | Root for run-scoped local scratch. |
| `ATLAN_LOCAL_GC_MAX_DESCRIBES_PER_SWEEP` | `50` | Upper bound on Temporal status checks per sweep. |
