### PR TITLE
ci: reusable workflow to register AE workflow from manifest

### DIFF
--- a/.github/workflows/ae-workflow-register.yaml
+++ b/.github/workflows/ae-workflow-register.yaml
@@ -1,0 +1,138 @@
+name: Register AE workflow (reusable)
+
+# Reusable workflow that registers (create + publish) a connector app's AE
+# workflow straight from its app/generated/manifest.json. Every connector
+# adds a small ``workflow_dispatch`` wrapper that ``uses:`` this — no job
+# boilerplate per connector.
+#
+# Composes the ``ae-workflow`` composite action; structural config (DAG
+# topology, parsing_mode, timeouts, workflow_type, $. output wiring) flows
+# from the caller's manifest, so a manifest change can't leave any connector
+# behind.
+#
+# Required secret:
+#   atlan-api-key — Bearer token for the target tenant's AE
+#
+# Output:
+#   slug — the AE workflow slug that was created/updated and published
+
+on:
+  workflow_call:
+    inputs:
+      tenant:
+        description: "Tenant hostname (no scheme), e.g. apps-typedef.atlan.com"
+        required: true
+        type: string
+      name:
+        description: "Workflow display name (reused-or-created by name)"
+        required: true
+        type: string
+      credential-guid:
+        description: "Credential GUID (must be fully provisioned in Vault + object store)"
+        required: true
+        type: string
+      connection-qn:
+        description: "Connection qualified name (pre-existing Atlas connection)"
+        required: true
+        type: string
+      connection-name:
+        description: "Connection display name"
+        required: true
+        type: string
+      deployment:
+        description: "Deployment tier; fills {deployment_name} in manifest task_queues"
+        required: false
+        type: string
+        default: production
+      ref:
+        description: "Caller repo ref to check out (default: the triggering ref)"
+        required: false
+        type: string
+        default: ""
+      extraction-method:
+        required: false
+        type: string
+        default: direct
+      values-file:
+        description: "Path (in caller repo) to a JSON file extending the {{token}} map"
+        required: false
+        type: string
+        default: ""
+      manifest:
+        required: false
+        type: string
+        default: app/generated/manifest.json
+      atlan-yaml:
+        required: false
+        type: string
+        default: atlan.yaml
+      connection-creation-enabled:
+        required: false
+        type: string
+        default: "false"
+      executor-enabled:
+        required: false
+        type: string
+        default: "true"
+      connection-cache-enabled:
+        required: false
+        type: string
+        default: "true"
+      connection-cache-via-app-enabled:
+        required: false
+        type: string
+        default: "true"
+    secrets:
+      atlan-api-key:
+        description: "Bearer token for the target tenant's AE"
+        required: true
+    outputs:
+      slug:
+        description: "Registered/updated AE workflow slug"
+        value: ${{ jobs.register.outputs.slug }}
+
+jobs:
+  register:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      slug: ${{ steps.ae.outputs.slug }}
+    steps:
+      # Caller repo (the connector) — its manifest + atlan.yaml are what
+      # the composite action reads from $GITHUB_WORKSPACE.
+      - name: Checkout caller
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.0.0
+        with:
+          ref: ${{ inputs.ref }}
+
+      # Pinned to the composite action's commit SHA (#1891 squash) per the
+      # actions-pinning rule. Bump to a release tag once application-sdk
+      # cuts one that includes the action.
+      - name: Register AE workflow
+        id: ae
+        uses: atlanhq/application-sdk/.github/actions/ae-workflow@38d38ec37741abe811c760c2345500297361b35a
+        with:
+          ae-url:                          "https://${{ inputs.tenant }}/automation"
+          token:                           ${{ secrets.atlan-api-key }}
+          name:                            ${{ inputs.name }}
+          deployment:                      ${{ inputs.deployment }}
+          cred-guid:                       ${{ inputs.credential-guid }}
+          connection-qn:                   ${{ inputs.connection-qn }}
+          connection-name:                 ${{ inputs.connection-name }}
+          extraction-method:               ${{ inputs.extraction-method }}
+          values:                          ${{ inputs.values-file }}
+          manifest:                        ${{ inputs.manifest }}
+          atlan-yaml:                      ${{ inputs.atlan-yaml }}
+          connection-creation-enabled:     ${{ inputs.connection-creation-enabled }}
+          executor-enabled:                ${{ inputs.executor-enabled }}
+          connection-cache-enabled:        ${{ inputs.connection-cache-enabled }}
+          connection-cache-via-app-enabled: ${{ inputs.connection-cache-via-app-enabled }}
+
+      - name: Summary
+        run: |
+          echo "### Registered AE workflow" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Tenant:** \`${{ inputs.tenant }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Workflow name:** ${{ inputs.name }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Slug:** \`${{ steps.ae.outputs.slug }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Connection:** \`${{ inputs.connection-qn }}\` (${{ inputs.connection-name }})" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why

Following the [composite action](https://github.com/atlanhq/application-sdk/pull/1891), each connector still has to add ~25 lines of GitHub Actions job boilerplate to call it (job, runner, checkout, step). A **reusable workflow** (`workflow_call`) collapses that to ~10 lines of `with:` inputs on the connector side.

## What

`.github/workflows/ae-workflow-register.yaml` — `workflow_call`-able. Takes the per-deploy inputs (tenant, credential-guid, connection-qn, connection-name, deployment, optional publish flags and `values-file`), the `atlan-api-key` secret, checks out the caller repo, runs the composite action, exposes the `slug` output, and writes a step summary.

Composite action is pinned to its full commit SHA (`38d38ec3…`, the #1891 squash), per the actions-pinning rule.

## How connectors use it

Each connector adds a single small workflow:

```yaml
# .github/workflows/register-ae.yaml in (e.g.) atlan-sigma-app
name: Register AE workflow
on:
  workflow_dispatch:
    inputs:
      tenant:          { required: true, type: string }
      credential_guid: { required: true, type: string }
      connection_qn:   { required: true, type: string }
      connection_name: { required: true, type: string }
      deployment:      { required: false, type: string, default: production }

jobs:
  register:
    uses: atlanhq/application-sdk/.github/workflows/ae-workflow-register.yaml@<sha>
    with:
      tenant:          ${{ inputs.tenant }}
      name:            "Sigma Extract - ${{ inputs.connection_name }}"
      deployment:      ${{ inputs.deployment }}
      credential-guid: ${{ inputs.credential_guid }}
      connection-qn:   ${{ inputs.connection_qn }}
      connection-name: ${{ inputs.connection_name }}
    secrets:
      atlan-api-key: ${{ secrets.ATLAN_API_KEY }}
```

That's it — Sigma (and every other connector) gets a "Register AE workflow" GitHub Actions button with no script, no DAG, no token logic in its own repo.

## Validation

YAML parses; composite action pinned by SHA; references `actions/checkout` pinned by SHA.

## Follow-ups

- Add the dispatch wrapper to atlan-sigma-app once this merges (pin to its merge SHA).
- mssql/mysql/saphana: same one-file wrapper, no per-app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)