### PR TITLE
chore(ci): scan artifact retention 7d + dashboard reads from triggering run

### DIFF
--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -111,7 +111,7 @@ jobs:
         with:
           name: docker-image
           path: /tmp/image.tar
-          retention-days: 1
+          retention-days: 7
 
   # ── Trivy scan (parallel with Snyk) ─────────────────────────────────────────
   trivy-scan:
@@ -171,7 +171,7 @@ jobs:
         with:
           name: trivy-results
           path: /tmp/trivy_results.json
-          retention-days: 1
+          retention-days: 7
 
   # ── Snyk scan (parallel with Trivy) ─────────────────────────────────────────
   snyk-scan:
@@ -230,7 +230,7 @@ jobs:
         with:
           name: snyk-results
           path: /tmp/snyk_results.json
-          retention-days: 1
+          retention-days: 7
 
   # ── Security Gate — merge results, check allowlist ──────────────────────────
   security-gate:

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -65,15 +65,29 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SCAN_WORKFLOW: ${{ inputs.scan_workflow }}
+          # When invoked via workflow_run (the normal path), this is the run
+          # that just completed and uploaded the artifacts we want. Reading
+          # it directly avoids the prior "gh run list latest" race where
+          # an older run could be picked if API listing lagged behind.
+          TRIGGER_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           mkdir -p /tmp/scan-artifacts
 
-          RUN_ID=$(gh run list \
-            --workflow="${SCAN_WORKFLOW}" \
-            --status=completed \
-            --limit=5 \
-            --json databaseId,conclusion \
-            --jq '[.[] | select(.conclusion=="success" or .conclusion=="failure")] | .[0].databaseId')
+          # Prefer the triggering workflow_run's ID. Fall back to "latest
+          # completed run of SCAN_WORKFLOW" only for manual workflow_dispatch
+          # invocations (where TRIGGER_RUN_ID is empty).
+          if [ -n "$TRIGGER_RUN_ID" ]; then
+            RUN_ID="$TRIGGER_RUN_ID"
+            echo "Using triggering run: $RUN_ID"
+          else
+            RUN_ID=$(gh run list \
+              --workflow="${SCAN_WORKFLOW}" \
+              --status=completed \
+              --limit=5 \
+              --json databaseId,conclusion \
+              --jq '[.[] | select(.conclusion=="success" or .conclusion=="failure")] | .[0].databaseId')
+            echo "Manual dispatch fallback — latest completed run: $RUN_ID"
+          fi
 
           if [ -z "$RUN_ID" ]; then
             echo "::warning::No completed runs found for workflow ${SCAN_WORKFLOW}"


### PR DESCRIPTION
## Summary
Per-repo \`Last Scan\` date on the security dashboard was going stale even after PR merges to main. Root cause is two compounding issues in the CI pipeline; both fixed here.

## Reproducer

atlan-saphana-app#74 merged 2026-05-26 13:07:
- Post-merge \`Build & Publish\` ran; embedded Security Scan succeeded; \`trivy-results\` + \`snyk-results\` uploaded to run 26449800311
- Dashboard update fired at 13:14:19; queried \`gh run list --workflow=build-and-publish.yaml --limit=5\` and picked **run 26116788156** (5/19), not 26449800311 (5/26)
- 26116788156's artifacts had been auto-deleted on 5/20 (retention=1)
- Dashboard logged \"No scan artifacts found\" and bailed; \`scanned_at\` stayed at 2026-05-19
- Today (5/28) saphana still shows \"8d ago\"

## Bug 1 — \`retention-days: 1\` is too short

\`build-and-scan.yaml\` uploads scan results with a 24-hour retention. Any dashboard-refresh attempt against a run older than a day finds nothing.

Fix: bump retention from 1 → 7 days for the three artifacts:
- \`docker-image\`
- \`trivy-results\`
- \`snyk-results\`

Cost: a few MB of extra org-wide Actions storage. No behaviour change.

## Bug 2 — Dashboard picks the wrong run via \`gh run list\`

\`update-dashboard.yaml\` resolves the source run via:
\`\`\`bash
RUN_ID=\$(gh run list --workflow=X --status=completed --limit=5 ... | jq '.[0]')
\`\`\`
Under workflow_run timing (the new run completes just before the dashboard update fires), the listing API can lag by a few seconds, so \`[0]\` resolves to a stale older run.

Fix: when \`github.event.workflow_run.id\` is present, use it directly — the dashboard then reads from the *exact* run that triggered it. Manual \`workflow_dispatch\` paths still use the old \`gh run list\` fallback.

## Blast radius
- ✅ PR-based scan flow unchanged
- ✅ Allowlist / Security Gate logic untouched
- ✅ Dashboard JS / HTML untouched
- ✅ ORG_PAT_GITHUB usage untouched
- ✅ S3 upload step untouched
- ✅ Manual \`workflow_dispatch\` of update-dashboard still works via the fallback
- Storage: tiny — KB-level files, retained 7d instead of 1d

## Test plan
- [ ] After merge: re-merge a no-op PR on saphana (or trigger Build & Publish via workflow_dispatch) and confirm the post-merge dashboard update writes a fresh \`scanned_at\`
- [ ] On any other connector repo: open + merge a PR, watch the dashboard \"Last Scan\" date flip to \"today\" within ~3 minutes
- [ ] Manually dispatch update-dashboard to verify the fallback lookup still works