### PR TITLE
chore(ci): hard step timeout + stdio detach on sdk-review VPN connect

### DIFF
--- a/.github/actions/globalprotect-connect/action.yml
+++ b/.github/actions/globalprotect-connect/action.yml
@@ -30,11 +30,16 @@ runs:
       id: openconnect-connection
       with:
         max_attempts: ${{ fromJSON(inputs.max-attempts) }}
-        # Per-attempt budget. With --max-time 30 on the curl test below, a
+        # Per-attempt budget. With --max-time 60 on the curl test below, a
         # real attempt completes (or fails) in well under a minute, so this
         # is a safety net — kill any attempt that wedges instead of letting
-        # it consume the original 10-min cap.
-        timeout_minutes: 5
+        # it consume the outer step's runner-enforced cap.
+        #
+        # Set below the outer step's timeout-minutes (5) so this inner
+        # best-effort timeout fires first when it can; the outer
+        # runner-enforced cap is the guarantee that the step terminates even
+        # if sudo/openconnect children ignore the inner SIGTERM.
+        timeout_minutes: 4
         shell: bash
         command: |
           echo "Connecting to GlobalProtect VPN using OpenConnect..."
@@ -62,14 +67,26 @@ runs:
 
           echo "Attempting OpenConnect to: ${{ inputs.portal-url }}"
 
-          # Create credentials file for OpenConnect
+          # Connect with openconnect in the background.
+          #
+          # >/tmp/openconnect.log 2>&1 is required: without it, the
+          # daemonized openconnect process inherits the step's stdout/stderr
+          # file descriptors and keeps them open for the lifetime of the VPN
+          # session. GitHub's log streamer treats the step as "in progress"
+          # until those FDs close, so the step badge in the UI never turns
+          # green even after the script exits and the next step starts
+          # running. Redirecting here detaches the daemon's stdio so the
+          # step closes cleanly. (stdin stays on the pipe so --passwd-on-stdin
+          # still reads the password; the pipe closes after echo and the
+          # daemon ends up with stdin at EOF, which is fine.)
           echo "${{ inputs.password }}" | sudo openconnect \
             --protocol=gp \
             --user="${{ inputs.username }}" \
             --passwd-on-stdin \
             --background \
-            "${{ inputs.portal-url }}" || {
+            "${{ inputs.portal-url }}" >/tmp/openconnect.log 2>&1 || {
             echo "OpenConnect connection failed"
+            cat /tmp/openconnect.log 2>/dev/null || true
             exit 1
           }
 

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -246,13 +246,20 @@ jobs:
             });
 
       # max-attempts: '1' overrides the action's internal default of 3 so
-      # each outer step is one real attempt, not three. Combined with the
-      # action's 5-min timeout_minutes, three outer steps cap total VPN
-      # time at ~15 min in the worst case.
+      # each outer step is one real attempt, not three. Three outer steps
+      # cap total VPN time at ~15 min in the worst case.
+      #
+      # timeout-minutes: 5 is a runner-enforced hard cap on each step. The
+      # inner nick-fields/retry timeout_minutes is best-effort — it SIGTERMs
+      # the bash subshell, but sudo/openconnect children survive parent
+      # signals, so a wedged attempt can hang indefinitely. The outer
+      # timeout-minutes is enforced by the runner itself and is the only
+      # guarantee the step terminates and the next attempt fires.
       - name: Connect to VPN (attempt 1/3)
         id: vpn1
         uses: ./.github/actions/globalprotect-connect
         continue-on-error: true
+        timeout-minutes: 5
         with:
           portal-url: ${{ vars.GLOBALPROTECT_PORTAL_URL }}
           username: ${{ secrets.GLOBALPROTECT_USERNAME }}
@@ -264,6 +271,7 @@ jobs:
         if: steps.vpn1.outcome == 'failure'
         uses: ./.github/actions/globalprotect-connect
         continue-on-error: true
+        timeout-minutes: 5
         with:
           portal-url: ${{ vars.GLOBALPROTECT_PORTAL_URL }}
           username: ${{ secrets.GLOBALPROTECT_USERNAME }}
@@ -275,6 +283,7 @@ jobs:
         if: steps.vpn2.outcome == 'failure'
         uses: ./.github/actions/globalprotect-connect
         continue-on-error: true
+        timeout-minutes: 5
         with:
           portal-url: ${{ vars.GLOBALPROTECT_PORTAL_URL }}
           username: ${{ secrets.GLOBALPROTECT_USERNAME }}


### PR DESCRIPTION
## Summary

Two issues with the sdk-review VPN connect step, both observed on a hung run (~30 min stuck on attempt 1/3, ladder never advanced):

- **Hung attempts didn't time out.** The 3-attempt retry ladder relied on `nick-fields/retry`'s `timeout_minutes` (5 min) to cap each attempt. That timeout is best-effort — it SIGTERMs the bash subshell, but `sudo` and `openconnect`'s daemonized child survive parent signals, so a wedged attempt hangs indefinitely. The ladder never reached attempts 2/3 or the PR-notify-and-fail step.
- **GitHub UI showed the step "in progress" forever.** Even after the script exited, the daemonized `openconnect` inherited the step's stdout/stderr FDs and held them open for the VPN session's lifetime. GitHub's log streamer keeps a step marked in-progress until those FDs close.

## Fix

- Add `timeout-minutes: 5` on each of the three outer VPN attempt steps. This is runner-enforced — the runner kills the entire step process tree at the cap, guaranteeing `outcome == 'failure'` so the ladder advances.
- Drop the inner `nick-fields/retry` `timeout_minutes` to 4 so it still fires first when it can, with the outer step as the guarantee.
- Redirect `openconnect`'s stdout/stderr to `/tmp/openconnect.log` (kept stdin on the pipe so `--passwd-on-stdin` still works) so the daemon detaches cleanly and the step badge closes.

## Test plan

- [ ] Merge, then trigger `@sdk-review` on a test PR
- [ ] Confirm step completes and badge closes promptly even on successful VPN connect
- [ ] If/when VPN flakes again, confirm attempt 1 caps at ~5 min and attempt 2 fires automatically