### PR TITLE
chore(ci): smarter Dockerfile-based SDK version extractor

### DIFF
--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -252,20 +252,40 @@ jobs:
                   unique.append(v)
 
           # Write per-repo data file (not shared data.json)
-          # Extract SDK version from Dockerfile
+          # Extract SDK version from the repo's Dockerfile. Compared to the
+          # previous "open ./Dockerfile, take first FROM, stop", this:
+          #   1. Searches common Dockerfile locations (./Dockerfile, deploy/,
+          #      docker/) — many repos put their Dockerfile in a subdir.
+          #   2. Reads ALL FROM lines, then prefers one whose image matches a
+          #      known SDK base registry — so multi-stage builds whose first
+          #      FROM is a builder layer (node:20-alpine etc.) no longer leak
+          #      that builder tag into the SDK version column.
+          #   3. Falls back to the LAST FROM (final runtime stage) when no
+          #      SDK-base FROM is found. Same "no :tag → unknown" behaviour.
           import re as _re
           sdk_version = "unknown"
-          try:
-              with open("Dockerfile") as f:
-                  for line in f:
-                      if line.strip().startswith("FROM "):
-                          image = line.strip().split()[1]
-                          # Extract tag after ':'
-                          if ":" in image:
-                              sdk_version = image.split(":")[-1]
-                          break
-          except FileNotFoundError:
-              pass
+          SDK_BASE_PATTERNS = (
+              "registry.atlan.com/public/app-runtime-base",
+              "registry.atlan.com/public/application-sdk",
+              "ghcr.io/atlanhq/application-sdk-main",
+          )
+          dockerfile_candidates = ["Dockerfile", "deploy/Dockerfile", "docker/Dockerfile"]
+          froms = []
+          for path in dockerfile_candidates:
+              try:
+                  with open(path) as f:
+                      for line in f:
+                          s = line.strip()
+                          if s.startswith("FROM "):
+                              froms.append(s.split()[1])
+                  break  # use the first existing Dockerfile
+              except FileNotFoundError:
+                  continue
+          chosen = next((i for i in froms if any(p in i for p in SDK_BASE_PATTERNS)), None)
+          if not chosen and froms:
+              chosen = froms[-1]
+          if chosen and ":" in chosen:
+              sdk_version = chosen.split(":")[-1]
 
           repo_slug = repo_name.replace("/", "_")
           app_count = sum(1 for v in unique if v["source_type"] == "app")


### PR DESCRIPTION
## Summary

Improves the SDK version extractor in \`update-dashboard.yaml\` so the dashboard's SDK column reflects reality for several repos that currently show \`unknown\` or misleading values.

## What it changes

Compared to the previous "open \`./Dockerfile\`, take first FROM line, stop", the new logic:
1. **Searches multiple Dockerfile paths**: \`Dockerfile\`, \`deploy/Dockerfile\`, \`docker/Dockerfile\` — uses the first that exists.
2. **Reads ALL FROM lines**, then **prefers** one whose image matches a known SDK base registry (\`app-runtime-base\`, \`application-sdk\`, \`application-sdk-main\`).
3. **Falls back** to the LAST FROM (final runtime stage) if no SDK base match is found. Same \`no :tag → unknown\` behaviour as before.

## Verified output (simulated against the 17 repos currently showing 'unknown'-ish SDK)

| Repo | Before | After |
|---|---|---|
| atlan-hightouch-app | \`unknown\` | **\`3\`** ✓ (Dockerfile is in \`deploy/\`) |
| atlan-metabase-app | \`unknown\` | **\`3\`** ✓ (same) |
| atlan-powerquery-parser-app | \`20-alpine\` | **\`3\`** ✓ (skips node frontend-builder FROM, picks SDK base on line 31) |
| atlan-aws-glue-enrichment-app | \`unknown\` | \`3.11-slim\` (it's actually on python-slim — honest off-SDK signal) |
| atlan-metadata-propagator-app | \`unknown\` | \`3.11-slim\` (same) |
| lineage-builder-app | \`unknown\` | \`3.11-slim\` (same) |
| atlan-context-studio-app | \`20-alpine\` | \`unknown\` (today's value is the misleading node builder stage; runtime is wolfi-base untagged → \`unknown\` is more accurate) |
| 10 other floating-tag repos | \`main-latest\` / \`refactor-v3-latest\` / \`latest\` / \`main-3.0.0\` | unchanged (dashboard already accurate; fix is repo-side) |

## Blast radius

- ✅ Repos already showing a clean SDK tag: unchanged
- ✅ All other workflows (scan, allowlist, gate, S3 upload): untouched
- ✅ Dashboard JS / HTML: untouched
- ✅ Same \`no :tag → unknown\` behaviour preserved
- Single file change, ~30 LOC in one Python heredoc

If anything regresses, revert PR. No state changes elsewhere.

## Test plan
- [ ] After merge, trigger the next Build & Publish on \`atlan-metabase-app\` and \`atlan-hightouch-app\` — confirm dashboard SDK column flips from \`unknown\` to \`3\`
- [ ] Confirm \`atlan-powerquery-parser-app\` flips from \`20-alpine\` to \`3\` on its next refresh
- [ ] Spot-check 2-3 already-clean repos (e.g., athena, mssql) — values should be unchanged