### PR TITLE
chore(ci): tolerate missing <!-- VERDICT --> marker in verdict extraction

### DIFF
--- a/.github/workflows/sdk-review-approve-on-verdict.yml
+++ b/.github/workflows/sdk-review-approve-on-verdict.yml
@@ -77,9 +77,15 @@ jobs:
           # `<!-- VERDICT: READY_TO_MERGE -->` (deterministic, formatting-
           # invariant). Fall back to the `### Verdict:` grep for legacy
           # comments that pre-date the structured marker.
-          VERDICT=$(printf '%s' "$COMMENT_BODY" | grep -oP '<!--\s*VERDICT:\s*\K[A-Z_]+' | head -1)
+          #
+          # `|| true` is load-bearing here: under `set -euo pipefail`,
+          # grep returning 1 on a no-match (the structured marker isn't
+          # present yet in the verdict comment we're parsing) would kill
+          # the script BEFORE the prose-grep fallback below got a chance
+          # to run. Tolerate the no-match so we fall through cleanly.
+          VERDICT=$(printf '%s' "$COMMENT_BODY" | grep -oP '<!--\s*VERDICT:\s*\K[A-Z_]+' | head -1 || true)
           if [ -z "$VERDICT" ]; then
-            RAW=$(printf '%s' "$COMMENT_BODY" | grep -oiP '###\s*Verdict:\s*\K[A-Z][A-Z _]+' | head -1 | tr '[:lower:]' '[:upper:]')
+            RAW=$(printf '%s' "$COMMENT_BODY" | grep -oiP '###\s*Verdict:\s*\K[A-Z][A-Z _]+' | head -1 | tr '[:lower:]' '[:upper:]' || true)
             VERDICT=$(printf '%s' "$RAW" | tr -s ' ' '_' | sed 's/_*$//')
           fi
           if [ -z "$VERDICT" ]; then

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -814,9 +814,15 @@ jobs:
           # invariant). Fall back to the `### Verdict:` grep for legacy
           # comments from orchestration versions that pre-date the
           # structured marker.
-          VERDICT=$(printf '%s' "$SUMMARY" | grep -oP '<!--\s*VERDICT:\s*\K[A-Z_]+' | head -1)
+          #
+          # `|| true` is load-bearing here: under `set -euo pipefail`,
+          # grep returning 1 on a no-match (the structured marker isn't
+          # present yet in the verdict comment we're parsing) would kill
+          # the script BEFORE the prose-grep fallback below got a chance
+          # to run. Tolerate the no-match so we fall through cleanly.
+          VERDICT=$(printf '%s' "$SUMMARY" | grep -oP '<!--\s*VERDICT:\s*\K[A-Z_]+' | head -1 || true)
           if [ -z "$VERDICT" ]; then
-            RAW=$(printf '%s' "$SUMMARY" | grep -oiP '###\s*Verdict:\s*\K[A-Z][A-Z _]+' | head -1 | tr '[:lower:]' '[:upper:]')
+            RAW=$(printf '%s' "$SUMMARY" | grep -oiP '###\s*Verdict:\s*\K[A-Z][A-Z _]+' | head -1 | tr '[:lower:]' '[:upper:]' || true)
             VERDICT=$(printf '%s' "$RAW" | tr -s ' ' '_' | sed 's/_*$//')
           fi
           echo "Detected verdict: '${VERDICT}'"


### PR DESCRIPTION
## Why

Follow-up to #1926 — the structured-marker grep is killing the approve step on PRs whose verdict comments don't (yet) carry `<!-- VERDICT: X -->`.

PR #1873 hit this on every `@sdk-review` after #1926 merged:

- `sdk-review.yml` slow-path approve step → `Process completed with exit code 1` with **no echoed output** between the env block and the error.
- `sdk-review-approve-on-verdict.yml` fast-path → same failure.
- Net effect on PR: mothership applied `sdk-review-approved` from the PR-head orchestration, but the `sdk-review` commit status was stuck on failure because both approve paths crashed before reading the verdict.

## Root cause

The structured-marker grep ran without `|| true`. Under `set -euo pipefail`, `grep -oP '<!-- VERDICT: …'` returning 1 on a no-match killed the entire script before the prose-grep fallback (`### Verdict:`) got a chance to run. Mothership-ai's verdict comment on PR #1873 uses the prose verdict line only — the new orchestration template that emits `<!-- VERDICT: X -->` is on `main` but PR #1873's branch head doesn't have it.

## Fix

Append `|| true` to both grep pipelines (structured + prose fallback) so a no-match falls through cleanly:

```bash
VERDICT=$(printf '%s' "$SUMMARY" | grep -oP '<!-- VERDICT: …' | head -1 || true)
if [ -z "$VERDICT" ]; then
  RAW=$(printf '%s' "$SUMMARY" | grep -oiP '### Verdict: …' | head -1 | tr … || true)
  VERDICT=$(printf '%s' "$RAW" | tr -s ' ' '_' | sed 's/_*$//')
fi
```

Verified against the live verdict comment on PR #1873 — now extracts `READY_TO_MERGE` correctly.

## Test plan

- [ ] Comment `@sdk-review` on PR #1873 (or any open PR whose orchestration head pre-dates #1926). Confirm both the fast-path and slow-path approve steps complete; `sdk-review` commit status goes green; atlan-ci approval is posted.
- [ ] On a PR whose orchestration head DOES have the new `<!-- VERDICT: X -->` marker, confirm the structured marker still wins (the fallback only runs if the structured one is empty).