### PR TITLE
ci(sdk-review): soft-success on stream break when verdict already posted

### DIFF
--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -650,26 +650,34 @@ jobs:
             fi
           fi
 
-          if [ "$ERRORED" = "1" ]; then
-            MSG="Sandbox error: code=${FINAL_ERR_CODE} message=${FINAL_ERR_MSG}"
+          # Soft-success rule: if the orchestration already posted a
+          # <!-- SDK_REVIEW --> verdict comment on this run, the review was
+          # delivered to the PR — any subsequent stream breakage (idle
+          # connection drop, missing `complete` event, non-`completed` final
+          # status, mid-stream `error` event) is a mothership-side
+          # finalize/cleanup glitch, not a real review failure. Surface as a
+          # warning so the CI check still passes.
+          fail_or_warn() {
+            local msg="$1"
             if [ "$VERDICT_POSTED" = "1" ]; then
-              echo "::warning::${MSG} — but a SDK_REVIEW summary comment was already posted on PR #${PR_NUMBER}. Treating as soft-success since the review was delivered."
+              echo "::warning::${msg} — but a SDK_REVIEW summary comment was already posted on PR #${PR_NUMBER}. Treating as soft-success since the review was delivered."
             else
-              echo "::error::${MSG}"
+              echo "::error::${msg}"
               exit 1
             fi
+          }
+
+          if [ "$ERRORED" = "1" ]; then
+            fail_or_warn "Sandbox error: code=${FINAL_ERR_CODE} message=${FINAL_ERR_MSG}"
           fi
           if [ "$STREAM_GOT_EVENT" = "0" ]; then
-            echo "::error::Stream ended without a single SSE event — likely VPN/network/proxy issue"
-            exit 1
+            fail_or_warn "Stream ended without a single SSE event — likely VPN/network/proxy issue"
           fi
           if [ "$COMPLETED" != "1" ] && [ "$ERRORED" != "1" ]; then
-            echo "::error::Stream ended without a 'complete' event"
-            exit 1
+            fail_or_warn "Stream ended without a 'complete' event"
           fi
           if [ "$FINAL_STATUS" != "completed" ] && [ "$ERRORED" != "1" ]; then
-            echo "::error::Sandbox final status=${FINAL_STATUS} (expected 'completed')"
-            exit 1
+            fail_or_warn "Sandbox final status=${FINAL_STATUS} (expected 'completed')"
           fi
 
           echo "SDK Review (mothership) completed successfully (cost=${FINAL_COST})."


### PR DESCRIPTION
## Summary

- The SDK Review workflow already had a soft-success path for one stream-failure branch (mid-stream `error` event) — if the orchestration had posted the `<!-- SDK_REVIEW -->` verdict comment, the stream breakage was downgraded to a warning. But three other branches still hard-failed even when the review had been delivered: `STREAM_GOT_EVENT=0`, missing `complete` event, and non-`completed` final status.
- This PR extracts a `fail_or_warn` bash helper and routes all four failure branches through it. The downstream `Approve PR as atlan-ci` step is gated on `if: success()`, so it now also runs on stream-broken-but-verdict-posted paths — matching the intent of "review delivered → CI green → atlan-ci approval recorded".

## Why

Recent runs (e.g. [run 26589623138](https://github.com/atlanhq/application-sdk/actions/runs/26589623138/job/78344660901)) hit `curl: (56) Recv failure: Connection timed out` after a long sandbox idle, then `Stream ended without a 'complete' event` — the verdict had already been posted to the PR but the CI check went red, blocking merge. The `VERDICT_POSTED` flag is computed unconditionally above; this just consults it from the other branches too.

The `created_at >= RUN_STARTED_AT` filter on the verdict-comment lookup (existing logic, untouched) prevents false soft-success on re-triggers — a verdict from a previous head won't be counted.

## Test plan

- [ ] Trigger `@sdk-review` on a PR and let it complete normally → workflow still passes; atlan-ci approval still fires.
- [ ] Confirm via job logs that on a clean run, none of the `fail_or_warn` branches are taken (no `::warning::` lines from this helper).
- [ ] (Opportunistic) On the next stream-break event in the wild, confirm the workflow now exits green with a `::warning::` annotation rather than red.