### PR TITLE
fix(temporal): use ATLAN_APPLICATION_NAME for token_refresh event payload (DISTR-517)

### DIFF
--- a/application_sdk/execution/_temporal/auth.py
+++ b/application_sdk/execution/_temporal/auth.py
@@ -257,7 +257,21 @@ class TemporalAuthManager:
                 _publish_event_via_binding,
             )
 
-            app_name = APPLICATION_NAME
+            from application_sdk.app.registry import AppRegistry  # noqa: PLC0415 — match the inline-import pattern used by sibling event imports above
+
+            # Mirror _emit_worker_start_event (worker.py:405-407): the registry
+            # name set by @register_app is the canonical source of truth and is
+            # what worker_start sent to event-ingress at registration time.
+            # Fall back to APPLICATION_NAME (env-var-derived) only when the
+            # registry is empty, which would be unusual — registration happens
+            # at worker init, well before the first token refresh ~5 min later.
+            try:
+                registered_apps = AppRegistry.get_instance().list_all()
+                app_name = (
+                    registered_apps[0].name if registered_apps else APPLICATION_NAME
+                )
+            except Exception:
+                app_name = APPLICATION_NAME
             deployment_name = os.environ.get("ATLAN_DEPLOYMENT_NAME", app_name)
             now = time.time()
             expires_at_ts = expires_at.timestamp() if expires_at else 0.0

--- a/application_sdk/execution/_temporal/auth.py
+++ b/application_sdk/execution/_temporal/auth.py
@@ -257,21 +257,7 @@ class TemporalAuthManager:
                 _publish_event_via_binding,
             )
 
-            from application_sdk.app.registry import AppRegistry  # noqa: PLC0415 — match the inline-import pattern used by sibling event imports above
-
-            # Mirror _emit_worker_start_event (worker.py:405-407): the registry
-            # name set by @register_app is the canonical source of truth and is
-            # what worker_start sent to event-ingress at registration time.
-            # Fall back to APPLICATION_NAME (env-var-derived) only when the
-            # registry is empty, which would be unusual — registration happens
-            # at worker init, well before the first token refresh ~5 min later.
-            try:
-                registered_apps = AppRegistry.get_instance().list_all()
-                app_name = (
-                    registered_apps[0].name if registered_apps else APPLICATION_NAME
-                )
-            except Exception:
-                app_name = APPLICATION_NAME
+            app_name = APPLICATION_NAME
             deployment_name = os.environ.get("ATLAN_DEPLOYMENT_NAME", app_name)
             now = time.time()
             expires_at_ts = expires_at.timestamp() if expires_at else 0.0

--- a/application_sdk/execution/_temporal/auth.py
+++ b/application_sdk/execution/_temporal/auth.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from application_sdk.constants import APPLICATION_NAME
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -256,7 +257,7 @@ class TemporalAuthManager:
                 _publish_event_via_binding,
             )
 
-            app_name = os.environ.get("ATLAN_APP_NAME", "")
+            app_name = APPLICATION_NAME
             deployment_name = os.environ.get("ATLAN_DEPLOYMENT_NAME", app_name)
             now = time.time()
             expires_at_ts = expires_at.timestamp() if expires_at else 0.0

--- a/application_sdk/execution/_temporal/auth.py
+++ b/application_sdk/execution/_temporal/auth.py
@@ -16,12 +16,13 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from application_sdk.constants import APPLICATION_NAME, DEPLOYMENT_NAME
+from application_sdk.constants import APPLICATION_NAME
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -257,7 +258,7 @@ class TemporalAuthManager:
             )
 
             app_name = APPLICATION_NAME
-            deployment_name = DEPLOYMENT_NAME
+            deployment_name = os.environ.get("ATLAN_DEPLOYMENT_NAME", app_name)
             now = time.time()
             expires_at_ts = expires_at.timestamp() if expires_at else 0.0
             remaining = max(0.0, expires_at_ts - now)

--- a/application_sdk/execution/_temporal/auth.py
+++ b/application_sdk/execution/_temporal/auth.py
@@ -16,13 +16,12 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import os
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from application_sdk.constants import APPLICATION_NAME
+from application_sdk.constants import APPLICATION_NAME, DEPLOYMENT_NAME
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -258,7 +257,7 @@ class TemporalAuthManager:
             )
 
             app_name = APPLICATION_NAME
-            deployment_name = os.environ.get("ATLAN_DEPLOYMENT_NAME", app_name)
+            deployment_name = DEPLOYMENT_NAME
             now = time.time()
             expires_at_ts = expires_at.timestamp() if expires_at else 0.0
             remaining = max(0.0, expires_at_ts - now)

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -8,7 +8,6 @@ named activities.
 from __future__ import annotations
 
 import asyncio
-import os
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
@@ -200,6 +199,7 @@ async def _emit_worker_start_event(
         APP_SDK_VERSION,
         APP_TYPE,
         APPLICATION_VERSION,
+        DEPLOYMENT_NAME,
         PUBLISHED_AT,
         RELEASE_CHANNEL,
         RELEASE_ID,
@@ -217,7 +217,7 @@ async def _emit_worker_start_event(
         BindingError,
     )
 
-    deployment_name = os.environ.get("ATLAN_DEPLOYMENT_NAME", app_name)
+    deployment_name = DEPLOYMENT_NAME
     host_part, _, port_part = host.partition(":")
 
     event_data = WorkerStartEventData(

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -8,6 +8,7 @@ named activities.
 from __future__ import annotations
 
 import asyncio
+import os
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
@@ -199,7 +200,6 @@ async def _emit_worker_start_event(
         APP_SDK_VERSION,
         APP_TYPE,
         APPLICATION_VERSION,
-        DEPLOYMENT_NAME,
         PUBLISHED_AT,
         RELEASE_CHANNEL,
         RELEASE_ID,
@@ -217,7 +217,7 @@ async def _emit_worker_start_event(
         BindingError,
     )
 
-    deployment_name = DEPLOYMENT_NAME
+    deployment_name = os.environ.get("ATLAN_DEPLOYMENT_NAME", app_name)
     host_part, _, port_part = host.partition(":")
 
     event_data = WorkerStartEventData(

--- a/tests/unit/execution/test_auth_token_refresh_event.py
+++ b/tests/unit/execution/test_auth_token_refresh_event.py
@@ -133,13 +133,15 @@ class TestEmitTokenRefreshEvent:
         manager = _make_manager()
         expires_at = datetime(2026, 6, 15, 10, 30, 0, tzinfo=UTC)
 
-        env_vars = {
-            "ATLAN_APP_NAME": "my-test-app",
-            "ATLAN_DEPLOYMENT_NAME": "my-deployment",
-        }
-
         with (
-            mock.patch.dict("os.environ", env_vars, clear=False),
+            mock.patch(
+                "application_sdk.execution._temporal.auth.APPLICATION_NAME",
+                "my-test-app",
+            ),
+            mock.patch(
+                "application_sdk.execution._temporal.auth.DEPLOYMENT_NAME",
+                "my-deployment",
+            ),
             mock.patch(_PUBLISH_TARGET) as mock_publish,
         ):
             mock_publish.return_value = None
@@ -157,29 +159,24 @@ class TestEmitTokenRefreshEvent:
             assert "refresh_timestamp" in data
 
     @pytest.mark.asyncio
-    async def test_deployment_name_falls_back_to_app_name(self) -> None:
-        """When ATLAN_DEPLOYMENT_NAME is unset, deployment_name equals app_name."""
+    async def test_deployment_name_uses_deployment_name_constant(self) -> None:
+        """deployment_name in the event comes from the DEPLOYMENT_NAME constant."""
         manager = _make_manager()
         expires_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
 
-        # Set only ATLAN_APP_NAME, ensure ATLAN_DEPLOYMENT_NAME is absent
-        env_overrides = {"ATLAN_APP_NAME": "fallback-app"}
-
         with (
-            mock.patch.dict("os.environ", env_overrides, clear=False),
+            mock.patch(
+                "application_sdk.execution._temporal.auth.DEPLOYMENT_NAME",
+                "pinned-deployment",
+            ),
             mock.patch(_PUBLISH_TARGET) as mock_publish,
         ):
-            # Remove ATLAN_DEPLOYMENT_NAME if it happens to be set
-            import os
-
-            os.environ.pop("ATLAN_DEPLOYMENT_NAME", None)
-
             mock_publish.return_value = None
 
             await manager._emit_token_refresh_event(expires_at)
 
             event = mock_publish.call_args[0][0]
-            assert event.data["deployment_name"] == "fallback-app"
+            assert event.data["deployment_name"] == "pinned-deployment"
 
     @pytest.mark.asyncio
     async def test_handles_none_expires_at(self) -> None:

--- a/tests/unit/execution/test_auth_token_refresh_event.py
+++ b/tests/unit/execution/test_auth_token_refresh_event.py
@@ -138,9 +138,8 @@ class TestEmitTokenRefreshEvent:
                 "application_sdk.execution._temporal.auth.APPLICATION_NAME",
                 "my-test-app",
             ),
-            mock.patch(
-                "application_sdk.execution._temporal.auth.DEPLOYMENT_NAME",
-                "my-deployment",
+            mock.patch.dict(
+                "os.environ", {"ATLAN_DEPLOYMENT_NAME": "my-deployment"}, clear=False
             ),
             mock.patch(_PUBLISH_TARGET) as mock_publish,
         ):
@@ -159,24 +158,27 @@ class TestEmitTokenRefreshEvent:
             assert "refresh_timestamp" in data
 
     @pytest.mark.asyncio
-    async def test_deployment_name_uses_deployment_name_constant(self) -> None:
-        """deployment_name in the event comes from the DEPLOYMENT_NAME constant."""
+    async def test_deployment_name_falls_back_to_app_name(self) -> None:
+        """When ATLAN_DEPLOYMENT_NAME is unset, deployment_name falls back to app_name."""
         manager = _make_manager()
         expires_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
 
+        import os
+
         with (
             mock.patch(
-                "application_sdk.execution._temporal.auth.DEPLOYMENT_NAME",
-                "pinned-deployment",
+                "application_sdk.execution._temporal.auth.APPLICATION_NAME",
+                "fallback-app",
             ),
             mock.patch(_PUBLISH_TARGET) as mock_publish,
         ):
+            os.environ.pop("ATLAN_DEPLOYMENT_NAME", None)
             mock_publish.return_value = None
 
             await manager._emit_token_refresh_event(expires_at)
 
             event = mock_publish.call_args[0][0]
-            assert event.data["deployment_name"] == "pinned-deployment"
+            assert event.data["deployment_name"] == "fallback-app"
 
     @pytest.mark.asyncio
     async def test_handles_none_expires_at(self) -> None:


### PR DESCRIPTION
## Symptom

Every v3 SDR worker shows as **Inactive** on the deployments-tab UI ~40 minutes after startup, while the container itself is healthy and `docker ps` shows it running. The worker's logs prove it: token refresh every 5 minutes succeeds, `Published event via binding: name=token_refresh ...` is logged on each refresh, no errors. Yet Heracles' `agent.Health.UpdatedAt` for that worker never advances past the initial `worker_start` timestamp.

## Root cause

`application_sdk/execution/_temporal/auth.py:259` (`_emit_token_refresh_event`) reads the wrong env-var name:

```python
app_name = os.environ.get("ATLAN_APP_NAME", "")           # ← does not exist on any container
deployment_name = os.environ.get("ATLAN_DEPLOYMENT_NAME", app_name)
```

The actual env var set on every worker container by `atlan-apps-deployment` (helm + docker-compose templates) and by LM's SDR `_build_container_env` is **`ATLAN_APPLICATION_NAME`**. The SDK itself reads it correctly *everywhere else* via `application_sdk/constants.py:68`:

```python
APPLICATION_NAME = os.getenv("ATLAN_APPLICATION_NAME", "default")
```

So `_emit_token_refresh_event` produces an `Event` whose `data` payload has `application_name=""` and `deployment_name=""` (the second `os.environ.get("ATLAN_DEPLOYMENT_NAME", app_name)` falls back to the empty `app_name` if `ATLAN_DEPLOYMENT_NAME` isn't set, which is also typical for SDR).

## Downstream effect

The event reaches Atlan-side `atlan-event-ingress-app` via the Dapr `eventstore` binding. There, `utils/agent_utils.py:process_token_refresh_event` (line 234-238) requires both `application_name` and `deployment_name` in the payload to be non-empty:

```python
application_name = event.data.get("application_name")
deployment_name = event.data.get("deployment_name")
if not application_name or not deployment_name:
    logger.warning("No application_name or deployment_name found in token refresh event data")
    return False
```

So every recurring heartbeat from every v3 SDR worker is dropped silently. Confirmed live on the prod-apps-platform event-ingress pod — the warning fires roughly every minute, interleaved with successful processing for other (non-SDR) agents:

```
2026-05-29 08:03:56 [INFO] __main__ - Event published successfully: token_refresh
2026-05-29 08:03:56 [WARNING] utils.agent_utils - No application_name or deployment_name found in token refresh event data
2026-05-29 08:04:39 [INFO] __main__ - Event published successfully: token_refresh
2026-05-29 08:04:39 [INFO] utils.agent_utils - Processing token refresh for agent: bigquery-agent
2026-05-29 08:04:39 [INFO] utils.agent_utils - Successfully updated agent health: bigquery-agent
```

`bigquery-agent` / `postgres-agent` (atlan-side workers) succeed because they hit a different SDK code path; SDR workers hit this broken one.

## Why the worker still looks Active for the first ~20 min

The **`worker_start`** event lands successfully. Event-ingress derives the agent name for that event from the `task_queue` field, not from `application_name`. `task_queue` is built by the SDK at `main.py:543-557` (`_derive_task_queue`) using `ATLAN_APPLICATION_NAME` + `ATLAN_DEPLOYMENT_NAME` env vars:

```python
return f"atlan-{app_name}-{deployment_name}"
```

Then event-ingress (`agent_utils.py:46-50`) parses it:

```python
task_queue_parts = task_queue.split("-", 2)
agent_name = '-'.join(task_queue_parts[1:])   # → "{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}"
```

So the initial registration event lands successfully → Heracles `agent.Health.UpdatedAt` is set to startup time → UI shows Active for 20 min (per `useAgentHealth.ts` thresholds), Pending 20–40 min, Inactive after 40 min. Container has been healthy throughout.

## v2 → v3 regression

This wasn't broken in v2.

**v2 reference (`feat: Adding a new event whenever Token refreshes`, PR #802, commit `2e32ab44`)** used the dependable instance attribute and module constant — no env-var typo opportunity:

```python
worker_token_refresh_data = WorkerTokenRefreshEventData(
    application_name=self.application_name,
    deployment_name=DEPLOYMENT_NAME,
    ...
)
```

**v3 regression (`feat: wire v3 infrastructure end-to-end`, commit `afe3b3a7`)** rewrote the emitter and replaced both with an inline `os.environ.get("ATLAN_APP_NAME", "")` — using an env var name that doesn't exist. No subsequent commit caught it (`bad5b2d5` "fix: resolve broken event_bus import in token refresh" touched the same function but only fixed an unrelated import, leaving the typo in place).

This is the same class of regression as the v2→v3 `ATLAN_WORKFLOW_TLS_ENABLED` → `ATLAN_TEMPORAL_TLS_ENABLED` rename that was fixed by PR #1857 (commit `869c63af`).

## Fix

```diff
+from application_sdk.constants import APPLICATION_NAME
 from application_sdk.observability.logger_adaptor import get_logger
 ...
-            app_name = os.environ.get("ATLAN_APP_NAME", "")
+            app_name = APPLICATION_NAME
             deployment_name = os.environ.get("ATLAN_DEPLOYMENT_NAME", app_name)
```

### Why `APPLICATION_NAME` (env-var-derived) rather than the `AppRegistry`

You might expect the right move is to mirror `_emit_worker_start_event` exactly — that function resolves the app name from `AppRegistry.get_instance().list_all()[0].name` (worker.py:405-407) and passes it into the `application_name` field of the event payload. Tempting, but **event-ingress's agent-name derivation differs between the two events**, so matching the field-level construction isn't what keeps the agent identifiers consistent:

| Event | event-ingress agent_name source | Effective value |
|---|---|---|
| `worker_start` | `task_queue` field (split + rejoin) | `<ATLAN_APPLICATION_NAME>-<ATLAN_DEPLOYMENT_NAME>` |
| `token_refresh` | `application_name` + `deployment_name` fields | `<application_name field>-<deployment_name field>` |

`task_queue` is built from env vars (`main.py:_derive_task_queue`), not from the registry. So worker_start's effective agent name in Heracles is the env-var-derived one, regardless of what value the SDK happens to fill into the `application_name` field of the worker_start payload. For `token_refresh` to update the same Heracles agent that worker_start registered, its `application_name` field must equal `ATLAN_APPLICATION_NAME` env var.

Using `APPLICATION_NAME` (= `os.getenv("ATLAN_APPLICATION_NAME", "default")`) directly is the right move — it's the same env var the task_queue carries through. Using `AppRegistry` would create a hidden divergence if a future app ever defines `@register_app(name=X)` ≠ `ATLAN_APPLICATION_NAME=Y` — worker_start would register agent `Y-<dep>` while token_refresh would 404 trying to update `X-<dep>`. Today they're conventionally identical, but the env-var path keeps the contract explicit.

Two other reasons to reuse `APPLICATION_NAME` rather than fix the inline env-var name in place:

1. **Single source of truth.** The inline `os.environ.get(...)` pattern is what enabled this regression in the first place. The same constant is already used by `contracts/events.py:69`, `contracts/base.py:864`, `handler/service.py:1381`. Re-anchoring this emitter to the same constant eliminates a class of future typos.
2. **Safer fallback.** `APPLICATION_NAME` defaults to `"default"` (vs the original `""`). On a misconfigured worker without `ATLAN_APPLICATION_NAME`, event-ingress will at least see a non-empty payload and try to update Heracles for a `default-<deployment>` agent — fails loudly in event-ingress logs as agent-not-found, rather than silently dropping. Easier to debug.

`constants.APPLICATION_NAME` has no circular-import risk (constants.py imports no SDK-internal modules), so the import goes at module level — matching how `contracts/events.py`, `contracts/base.py`, and `handler/service.py` already do it.

## Blast radius

- Affects every v3 SDR worker shipped since `afe3b3a7`.
- Tenants pinned on v2 (DISTR-498 release locks) are unaffected — v2 code path is correct.
- The bug is purely cosmetic at the UI level (badge color + "Inactive" label) and behavioural at the marketplace-modal level (per DISTR-517, the install button gets disabled because UI treats inactive workers as installed-and-broken without offering reinstall). Worker still does its job — workflows still run, Temporal task queue is still polled.
- IEs have been hand-waving at "the worker shows Inactive but it's actually running" on every v3 SDR rollout. This PR is the underlying root-cause fix.

## Test plan

- [ ] CI green
- [ ] After this is published and an SDR worker image is rebuilt against it: confirm event-ingress logs for that worker show `Processing token refresh for agent: <app>-<deployment_name>` followed by `Successfully updated agent health` on every refresh (5 min cadence), with no "No application_name or deployment_name" warnings.
- [ ] Confirm `GET /v1/agents/<app>-<deployment_name>/health` on Heracles shows `updatedAt` advancing every 5 min instead of frozen at worker-start time.
- [ ] Confirm deployments-tab UI stays green (Active) past the 20-min and 40-min thresholds.

## Related

- DISTR-517 — original ticket (SDR app container not redeployed after IPv6 fix)
- Companion PR: [atlanhq/atlan-local-marketplace-app#372](https://github.com/atlanhq/atlan-local-marketplace-app/pull/372) — surfaces deploy-time `trigger_cd` failures to Atlas (separate gap, same DISTR-517 investigation)
- Same regression class: PR #1857 (commit `869c63af`) — `ATLAN_WORKFLOW_TLS_ENABLED` → `ATLAN_TEMPORAL_TLS_ENABLED` env-var rename fallback