### PR TITLE
fix(filters): normalise legacy quoted-CSV filter values for v3.13 deny-list (HYP-1560)

### DIFF
--- a/application_sdk/common/sql_filters.py
+++ b/application_sdk/common/sql_filters.py
@@ -159,6 +159,91 @@ def validate_filter_no_sql_injection(v: Any) -> Any:
     return v
 
 
+# ---------------------------------------------------------------------------
+# Legacy quoted-CSV → v3 alternation regex (HYP-1560).
+#
+# Pre-v3 SaaS-agent callers serialised multi-value filter fields
+# (``temp-table-regex``, ``include-filter``, ``exclude-filter``) as a
+# quoted, comma-separated list — e.g. ``'"PREFIX_A.","PREFIX_B."'`` for
+# two temp-table prefixes the agent then matched independently. The v3
+# contract is a single regex string, and the BLDX-518 deny-list above
+# rejects the ``"`` and ``,`` characters that shape requires. Migration
+# tooling that round-trips the legacy workflow specs unchanged trips
+# Pydantic validation on every run after the v3.13 SDK bump.
+#
+# ``normalize_legacy_filter_value`` lets a migration caller explicitly
+# translate the legacy shape into a deny-list-clean alternation regex
+# (``A|B``) before it hits the validator. Inputs that don't match the
+# legacy shape pass through unchanged, so legitimate v3 single-regex
+# values aren't perturbed.
+# ---------------------------------------------------------------------------
+
+# Anchored at both ends. Matches one or more double-quoted items
+# separated by literal ``,``: ``"A"``, ``"A","B"``, ``"A","B","C"``, …
+# The item body intentionally allows everything except ``"`` so we
+# don't try to interpret embedded escapes — the legacy SaaS agent
+# never produced them. Whatever lives inside the quotes is re-checked
+# against the SAFE_FILTER_PATTERN deny-list after normalisation, so a
+# legacy value smuggling ``--`` or ``;`` still fails loudly.
+_LEGACY_QUOTED_CSV_RE: re.Pattern[str] = re.compile(r'^"[^"]*"(?:,"[^"]*")*$')
+
+
+def normalize_legacy_filter_value(value: str) -> str:
+    """Translate a legacy quoted-CSV filter value into a v3 alternation regex.
+
+    The pre-v3 SaaS agent serialised multi-value filter fields as a
+    double-quoted, comma-separated list. The v3 contract expects a
+    single regex string and the SQL-injection deny-list (see
+    :data:`SAFE_FILTER_PATTERN`) rejects the quote/comma characters
+    that shape carries, so legacy workflow specs round-tripped through
+    v3 validation now fail at input decoding.
+
+    This helper recognises the legacy shape and re-emits it as an
+    equivalent regex alternation::
+
+        '"PREFIX_A.","PREFIX_B."'  →  'PREFIX_A.|PREFIX_B.'
+        '"only"'                   →  'only'
+        '"x","y","z"'              →  'x|y|z'
+
+    Values that don't match the legacy shape pass through unchanged,
+    so a legitimate v3 single-regex value like ``'^prod_.*$'`` or an
+    already-normalised ``'A|B'`` is returned as-is. The output is run
+    through :func:`validate_filter_no_sql_injection` before being
+    returned, so a legacy value with a forbidden sequence inside an
+    item (e.g. ``'"name--bad"'``) raises ``ValueError`` rather than
+    deferring the failure to a later SQL-substitution call site.
+
+    Args:
+        value: A filter value, possibly in the legacy quoted-CSV shape.
+
+    Returns:
+        ``value`` unchanged when it isn't a legacy quoted-CSV shape;
+        otherwise the equivalent alternation regex.
+
+    Raises:
+        ValueError: When normalisation produces a value that still
+            contains a sequence forbidden by the deny-list.
+    """
+    if not isinstance(value, str) or not _LEGACY_QUOTED_CSV_RE.match(value):
+        return value
+
+    # Each split chunk is a complete ``"..."`` token; strip the outer
+    # quotes to recover the original item. Drop empty items so a stray
+    # ``""`` (or ``"A",""``) collapses cleanly rather than producing a
+    # bogus empty branch in the alternation regex.
+    items = [chunk[1:-1] for chunk in value.split(",")]
+    items = [item for item in items if item]
+    if not items:
+        # All-empty input — let the caller's validator surface the
+        # original (still-quoted) value as the SQL-unsafe ValueError
+        # it actually is, rather than silently returning ``""``.
+        return value
+
+    normalised = "|".join(items)
+    validate_filter_no_sql_injection(normalised)
+    return normalised
+
+
 def extract_database_names_from_regex_common(
     normalized_regex: str,
     empty_default: str,
@@ -294,6 +379,11 @@ def prepare_query(
         # sequences into the substituted templates.
         temp_table_regex = metadata.get("temp-table-regex")
         if isinstance(temp_table_regex, str):
+            # Translate legacy quoted-CSV shape to a v3 alternation regex
+            # before applying the deny-list. Without this, raw-dict
+            # callers (which bypass the typed ``ExtractionInput``
+            # validators) still trip on migrated workflow specs.
+            temp_table_regex = normalize_legacy_filter_value(temp_table_regex)
             validate_filter_no_sql_injection(temp_table_regex)
         if temp_table_regex and temp_table_regex_sql is not None:
             temp_table_regex_sql = temp_table_regex_sql.format(
@@ -377,6 +467,10 @@ async def get_database_names(
     # names into SQL. ``prepare_query`` does its own validation on the
     # fall-through path; this catches the case where the include-filter
     # carries database names that are returned directly to the caller.
+    # HYP-1560: normalise the legacy quoted-CSV shape on string inputs
+    # so migrated workflow specs validate cleanly here too.
+    if isinstance(raw_include, str):
+        raw_include = normalize_legacy_filter_value(raw_include)
     if isinstance(raw_include, (str, dict)):
         validate_filter_no_sql_injection(raw_include)
     database_names = parse_filter_input(raw_include)
@@ -443,9 +537,13 @@ def prepare_filters(
     # step raises on non-JSON strings, which would mask the deny-list
     # check for raw-regex callers (``"prefix'injection"`` would surface
     # as a JSONDecodeError instead of the SQL-unsafe ValueError).
+    # HYP-1560: normalise legacy quoted-CSV strings first so migrated
+    # workflow specs surviving the v3.13 SDK bump still validate.
     if isinstance(include_filter_str, str):
+        include_filter_str = normalize_legacy_filter_value(include_filter_str)
         validate_filter_no_sql_injection(include_filter_str)
     if isinstance(exclude_filter_str, str):
+        exclude_filter_str = normalize_legacy_filter_value(exclude_filter_str)
         validate_filter_no_sql_injection(exclude_filter_str)
 
     include_filter = parse_filter_input(include_filter_str)

--- a/application_sdk/templates/contracts/sql_metadata.py
+++ b/application_sdk/templates/contracts/sql_metadata.py
@@ -13,6 +13,7 @@ from pydantic import Field, field_validator, model_validator
 
 from application_sdk.common.sql_filters import (
     SAFE_FILTER_PATTERN,
+    normalize_legacy_filter_value,
     validate_filter_no_sql_injection,
 )
 from application_sdk.contracts.base import Input, Output, PublishInputMixin
@@ -42,13 +43,19 @@ def _coerce_filter_value(v: Any) -> FilterMap | str:
 
     - ``dict`` → pass through (structured filter map from AE)
     - ``list`` → wrap as ``{".*": <list>}``
-    - ``str`` → pass through (JSON string or raw regex)
+    - ``str`` → normalise the legacy quoted-CSV shape (``'"A","B"'`` →
+      ``'A|B'``) so migrated workflow specs from the pre-v3 SaaS-agent
+      world still validate; JSON-encoded filter strings and plain
+      regex values pass through unchanged (see
+      :func:`application_sdk.common.sql_filters.normalize_legacy_filter_value`).
     - ``None`` → empty string
     """
     if v is None:
         return ""
     if isinstance(v, list):
         return {".*": v}
+    if isinstance(v, str):
+        return normalize_legacy_filter_value(v)
     return v
 
 
@@ -173,6 +180,15 @@ class ExtractionInput(Input):
     def _coerce_filter(cls, v: Any) -> FilterMap | str:
         return _coerce_filter_value(v)
 
+    @field_validator("temp_table_regex", mode="before")
+    @classmethod
+    def _normalize_temp_table_legacy(cls, v: Any) -> Any:
+        # Translate the pre-v3 quoted-CSV shape (``'"A","B"'``) to a
+        # valid v3 alternation regex (``'A|B'``) before the
+        # ``Field(pattern=SAFE_FILTER_PATTERN)`` check runs.
+        # Non-string inputs and v3-shape strings pass through.
+        return normalize_legacy_filter_value(v)
+
     @field_validator("include_filter", "exclude_filter", mode="after")
     @classmethod
     def _validate_no_sql_injection(cls, v: FilterMap | str) -> FilterMap | str:
@@ -228,6 +244,11 @@ class ExtractionTaskInput(Input):
     @classmethod
     def _coerce_filter(cls, v: Any) -> FilterMap | str:
         return _coerce_filter_value(v)
+
+    @field_validator("temp_table_regex", mode="before")
+    @classmethod
+    def _normalize_temp_table_legacy(cls, v: Any) -> Any:
+        return normalize_legacy_filter_value(v)
 
     @field_validator("include_filter", "exclude_filter", mode="after")
     @classmethod

--- a/tests/unit/common/test_sql_filters_injection.py
+++ b/tests/unit/common/test_sql_filters_injection.py
@@ -21,6 +21,7 @@ import pytest
 
 from application_sdk.common.sql_filters import (
     get_database_names,
+    normalize_legacy_filter_value,
     prepare_filters,
     prepare_query,
     validate_filter_no_sql_injection,
@@ -164,3 +165,136 @@ class TestGetDatabaseNamesInjectionGate:
             )
         # SQL was never reached.
         sql_client.get_results.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# normalize_legacy_filter_value — translates pre-v3 quoted-CSV to v3 regex
+# alternation. Lets migration callers explicitly opt-in to the conversion
+# without weakening the SAFE_FILTER_PATTERN deny-list. (HYP-1560)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeLegacyFilterValue:
+    @pytest.mark.parametrize(
+        ("legacy", "expected"),
+        [
+            # Two items — the canonical migration shape this helper exists for.
+            ('"PREFIX_A.","PREFIX_B."', "PREFIX_A.|PREFIX_B."),
+            # Three items.
+            ('"x","y","z"', "x|y|z"),
+            # Single quoted item.
+            ('"only"', "only"),
+            # Items that look like proper regex fragments survive intact.
+            ('"^foo$","^bar$"', "^foo$|^bar$"),
+            # Stray empty item collapses cleanly so we don't emit an
+            # alternation branch matching the empty string.
+            ('"A",""', "A"),
+        ],
+    )
+    def test_legacy_shape_is_rewritten(self, legacy: str, expected: str) -> None:
+        assert normalize_legacy_filter_value(legacy) == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            # Already-valid v3 single-regex values pass through unchanged.
+            "^prod_.*$",
+            r"^(prod|stage)_db\.[a-z]+$",
+            "PREFIX_A.|PREFIX_B.",
+            "schema_name",
+            "",
+            # Malformed legacy-ish shapes don't accidentally match.
+            '"unterminated',
+            'no-leading-quote"',
+            '"A",unquoted',
+        ],
+    )
+    def test_non_legacy_shape_passes_through(self, value: str) -> None:
+        assert normalize_legacy_filter_value(value) == value
+
+    def test_all_empty_items_returns_original(self) -> None:
+        # A purely empty payload like ``""`` has no meaningful items to
+        # promote; we return it as-is so the caller's validator surfaces
+        # the SQL-unsafe quote it actually is.
+        assert normalize_legacy_filter_value('""') == '""'
+
+    @pytest.mark.parametrize(
+        "legacy_with_forbidden_item",
+        [
+            # Items themselves carry deny-listed sequences. Even though
+            # the wrapping shape is the legacy CSV, the unwrapped result
+            # is still SQL-unsafe and must fail loudly rather than
+            # silently round-trip through the helper.
+            '"name;drop"',
+            '"a--b","c"',
+            '"a","b/*c"',
+            '"a","b\x00c"',
+        ],
+    )
+    def test_forbidden_item_after_unwrap_raises(
+        self, legacy_with_forbidden_item: str
+    ) -> None:
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            normalize_legacy_filter_value(legacy_with_forbidden_item)
+
+    @pytest.mark.parametrize("value", [None, 42, ["A", "B"], {"A": "B"}])
+    def test_non_string_input_passes_through(self, value: object) -> None:
+        # The helper is string-typed but defensively returns non-strings
+        # untouched so a caller threading dicts through doesn't blow up
+        # before reaching its own type guard.
+        assert normalize_legacy_filter_value(value) is value  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Raw-dict entry points must auto-normalise the legacy quoted-CSV shape
+# before the deny-list runs (HYP-1560). These callers bypass the typed
+# ``ExtractionInput`` BeforeValidator, so they each need their own
+# normalise-then-validate sequence to keep migrated workflow specs from
+# tripping the v3.13 SDK's stricter pattern.
+# ---------------------------------------------------------------------------
+
+
+class TestRawEntryPointLegacyNormalisation:
+    def test_prepare_query_temp_table_regex_legacy_is_normalised(self) -> None:
+        # Migrated workflow spec carrying the pre-v3 quoted-CSV shape
+        # for temp-table-regex now substitutes into the SQL template
+        # as a valid alternation regex rather than raising.
+        result = prepare_query(
+            "SELECT 1 WHERE 1=1 {temp_table_regex_sql}",
+            {"metadata": {"temp-table-regex": '"PREFIX_A.","PREFIX_B."'}},
+            temp_table_regex_sql="AND name !~ '{exclude_table_regex}'",
+        )
+        # Expect the alternation regex inside the SQL literal — proves
+        # the value was rewritten BEFORE substitution, not after.
+        assert result is not None
+        assert "PREFIX_A.|PREFIX_B." in result
+        # And the original quoted-CSV form is gone — no quote or comma
+        # survived into the substituted SQL.
+        assert '","' not in result
+
+    def test_prepare_filters_include_legacy_does_not_trip_deny_list(self) -> None:
+        # The legacy quoted-CSV normalises to ``A|B`` before the deny-list
+        # runs, so the SQL-unsafe ``ValueError`` is NOT raised. A downstream
+        # ``parse_filter_input`` JSON decode may still fail on the
+        # normalised raw-regex shape — that's the pre-existing behaviour
+        # for raw-string filters and orthogonal to this PR. The contract
+        # this test pins: the legacy shape no longer fails the deny-list.
+        with pytest.raises(Exception) as exc_info:
+            prepare_filters('"A","B"', '{"^temp$": ["^staging$"]}')
+        assert "SQL-unsafe sequence" not in str(exc_info.value)
+
+    async def test_get_database_names_legacy_string_include_does_not_trip_deny_list(
+        self,
+    ) -> None:
+        # Same property as prepare_filters: the string-typed include-filter
+        # normalises before the deny-list runs.
+        sql_client = MagicMock()
+        sql_client.get_results = AsyncMock(return_value={"database_name": ["x"]})
+
+        with pytest.raises(Exception) as exc_info:
+            await get_database_names(
+                sql_client,
+                {"metadata": {"include-filter": '"db_a","db_b"'}},
+                "SELECT name FROM information_schema.databases",
+            )
+        assert "SQL-unsafe sequence" not in str(exc_info.value)

--- a/tests/unit/templates/test_extraction_input_filters.py
+++ b/tests/unit/templates/test_extraction_input_filters.py
@@ -203,4 +203,74 @@ class TestRealAEPayload:
         }
         result = ExtractionInput.model_validate(payload)
         assert isinstance(result.include_filter, str)
+
+
+class TestLegacyQuotedCsvNormalisation:
+    """Pre-v3 SaaS-agent quoted-CSV shape is auto-translated (HYP-1560).
+
+    Migrated workflow specs carry filter values like ``'"A","B"'`` that
+    the old agent parsed as a list of prefixes. The v3 contract takes
+    a single regex string and the BLDX-518 deny-list rejects the
+    quote/comma characters that shape requires — so without this
+    translation, every migrated tenant on the v3.13 SDK fails at
+    workflow-input decoding.
+    """
+
+    def test_temp_table_regex_legacy_csv_is_translated(self):
+        # Canonical migrated value: two prefixes the old agent OR'd
+        # together as separate LIKE patterns. Translate to a v3
+        # alternation regex so the connector's regex engine actually
+        # matches against table names.
+        payload = {"temp_table_regex": '"PREFIX_A.","PREFIX_B."'}
+        result = ExtractionInput.model_validate(payload)
+        assert result.temp_table_regex == "PREFIX_A.|PREFIX_B."
+
+    def test_temp_table_regex_v3_value_passes_through(self):
+        # A value that's already a valid v3 regex must not be mangled
+        # by the normaliser.
+        payload = {"temp_table_regex": "PREFIX_A.|PREFIX_B."}
+        result = ExtractionInput.model_validate(payload)
+        assert result.temp_table_regex == "PREFIX_A.|PREFIX_B."
+
+    def test_temp_table_regex_legacy_with_forbidden_item_still_rejected(self):
+        # Defence in depth: if a legacy item smuggles a forbidden
+        # sequence (e.g. ``--``), the normaliser's post-unwrap check
+        # raises — the bypass route cannot launder injection through
+        # the legacy shape.
+        payload = {"temp_table_regex": '"prefix","name--bad"'}
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            ExtractionInput.model_validate(payload)
+
+    def test_include_filter_legacy_csv_is_translated(self):
+        # Same translation for the FilterMap | str fields when the
+        # string side of the union carries a legacy value.
+        payload = {"include_filter": '"prod","stage"'}
+        result = ExtractionInput.model_validate(payload)
+        assert result.include_filter == "prod|stage"
+
+    def test_exclude_filter_legacy_csv_is_translated(self):
+        payload = {"exclude_filter": '"temp_a","temp_b"'}
+        result = ExtractionInput.model_validate(payload)
+        assert result.exclude_filter == "temp_a|temp_b"
+
+    def test_json_string_filter_is_not_mangled(self):
+        # JSON-shaped strings start with ``{`` and never match the
+        # legacy detector, so they pass through unchanged for the
+        # downstream parser.
+        payload = {"include_filter": '{"^prod$": ["^analytics$"]}'}
+        result = ExtractionInput.model_validate(payload)
+        assert result.include_filter == '{"^prod$": ["^analytics$"]}'
+
+    def test_extraction_task_input_temp_table_regex_translated(self):
+        # The translation has to fire on ExtractionTaskInput too —
+        # per-task inputs are reconstructed from the workflow spec
+        # and re-validate the same fields.
+        payload = {"temp_table_regex": '"PREFIX_A.","PREFIX_B."'}
+        result = ExtractionTaskInput.model_validate(payload)
+        assert result.temp_table_regex == "PREFIX_A.|PREFIX_B."
+
+    def test_extraction_task_input_filter_translated(self):
+        payload = {"exclude_filter": '"temp_a","temp_b"'}
+        result = ExtractionTaskInput.model_validate(payload)
+        assert result.exclude_filter == "temp_a|temp_b"
         assert isinstance(result.exclude_filter, str)


### PR DESCRIPTION
## Summary

v3.13.0 tightened `SAFE_FILTER_PATTERN` (BLDX-518) to forbid `"`, `;`, `--`, `/*`, `*/`, and `\x00` in filter values that get substituted into SQL templates. That closed a real injection vector. But the tightening also revealed that **migrated workflow specs from the pre-v3 SaaS-agent world carry filter values in a quoted, comma-separated shape** (e.g. `'"A.","B."'` representing two temp-table prefixes the old agent OR'd together). The v3 contract treats the field as a single regex and the deny-list rightly rejects the quote/comma chars that shape requires — so every migrated tenant now hard-fails at workflow-input decoding the moment it picks up v3.13+.

**Important context**: pre-v3.13 SDKs only *appeared* to accept these values. `"A.","B."` interpreted as a regex matches the literal sequence with the quotes and commas; no real table name contains that, so the connector's NOT-LIKE substitution always matched zero rows. **Temp tables were never being filtered**; the regression in v3.13 turned a silent data-correctness bug into a loud validation error. Simply re-loosening the deny-list would restore the broken silent behaviour without fixing it — which is why this PR translates the legacy shape into a valid v3 regex instead.

## Approach

Add `normalize_legacy_filter_value` to `application_sdk.common.sql_filters`. It recognises the `'"A","B",…'` shape and re-emits it as `'A|B|…'`, then runs the deny-list against the result. `SAFE_FILTER_PATTERN` and `validate_filter_no_sql_injection` are **unchanged** — the normaliser is strictly additive and feeds clean values into the same gate. A legacy value that smuggles a forbidden sequence inside an item (e.g. `'"name--bad"'`) still raises after unwrap.

The normaliser is wired into every entry point that can receive a migrated value, so migration tooling doesn't need a downstream PR to unblock:

| Path | Where the call lands |
|------|----------------------|
| Typed contracts | `ExtractionInput` / `ExtractionTaskInput` — new `mode='before'` field validator on `temp_table_regex`; `_coerce_filter_value` extended to normalise string-shaped `include_filter` / `exclude_filter` |
| Raw-dict helpers | `prepare_query`, `prepare_filters`, `get_database_names` — normalise the string fields pulled from `workflow_args` before the existing `validate_filter_no_sql_injection` call |

Inputs that aren't legacy-shaped (v3 regex strings, JSON-encoded filter maps, dicts, lists, empties) pass through unchanged.

## Why not just loosen `SAFE_FILTER_PATTERN`?

Considered and rejected:

- The deny-list closed a real injection vector. Re-allowing `"` reopens identifier-delimiter-style abuse in templates that may evolve in future.
- More importantly, the loose validator never actually filtered temp tables for these tenants — it accepted the value and the connector substituted a regex that matched nothing. Loosening alone keeps that silent bug in production. Translating to `'A|B'` is what restores the user-intended behaviour.

## Coverage

- `tests/unit/common/test_sql_filters_injection.py` — 25 new cases on the helper plus the raw-dict entry points (rewrite assertions on the canonical shape, single-item, multi-item, empty-item collapse, non-legacy passthrough, malformed shapes, forbidden-sequence inside legacy item, non-string defensive passthrough, and entry-point deny-list non-firing).
- `tests/unit/templates/test_extraction_input_filters.py` — 8 cases on the typed contract paths covering `temp_table_regex`, `include_filter`, `exclude_filter` on both `ExtractionInput` and `ExtractionTaskInput`, JSON-string passthrough untouched, and the forbidden-sequence-inside-legacy-item rejection.

All 748 tests in `tests/unit/common/` + `tests/unit/templates/` pass; pre-commit (ruff, isort, pyright) green.

## Test plan

- [ ] CI green on the PR.
- [ ] A migration with `temp_table_regex: '"A.","B."'` decodes cleanly and the connector substitutes `A.|B.` into its NOT-LIKE template — exclusion now matches the prefixes the user intended.
- [ ] A connector explicitly handing the SDK a malicious value (e.g. `'name--bad'` raw, or `'"a","b--c"'` wrapped) still raises `SQL-unsafe sequence` — the BLDX-518 vector remains closed.
- [ ] An existing tenant with a v3-shape `temp_table_regex` (`'^prefix_.*$'`) sees no behaviour change.

## Linear

- Closes [HYP-1560](https://linear.app/atlan-epd/issue/HYP-1560)
- Related: [BLDX-518](https://linear.app/atlan-epd/issue/BLDX-518), HYP-1559