### PR TITLE
fix(sdr): route App.upload() to upstream store when configured

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -963,10 +963,11 @@ class App(ABC):
         the upstream store is Atlan's bucket — the correct destination for
         extracted artifacts handed off to the publish app.
 
-        This routing applies **only** to ``App.upload()``.  The automatic
-        file-reference materialisation that transfers ``FileReference`` objects
-        between ``@task`` methods always uses the deployment store; use that
-        mechanism (not ``App.upload()``) for intermediate task-to-task data.
+        This routing applies to ``App.upload()`` and ``App.download()``.  The
+        automatic file-reference materialisation that transfers ``FileReference``
+        objects between ``@task`` methods always uses the deployment store; use
+        that mechanism (not ``App.upload()`` / ``App.download()``) for
+        intermediate task-to-task data.
 
         For direct use inside an existing ``@task``, import and call
         :func:`application_sdk.storage.transfer.upload` directly.
@@ -1029,6 +1030,11 @@ class App(ABC):
         If ``input.ref`` is provided and ``input.storage_path`` is empty, the
         ref's ``storage_path`` is used as the source.
 
+        **Store routing (SDR vs non-SDR):** mirrors ``App.upload()`` — reads
+        from the upstream store when one is configured, falling back to the
+        deployment store otherwise.  In SDR deployments the publish app uses
+        this to pull artifacts written by the extract app.
+
         For direct use inside an existing ``@task``, import and call
         :func:`application_sdk.storage.transfer.download` directly.
 
@@ -1040,14 +1046,12 @@ class App(ABC):
             ``DownloadOutput`` with a fully materialised ``FileReference``
             containing both ``storage_path`` and ``local_path``.
 
-        Example — download a file reference from a previous upload::
+        Example — SDR publish app consuming artifacts from the extract app::
 
-            async def run(self, input: InferInput) -> InferOutput:
-                dl = await self.download(
-                    DownloadInput(storage_path=input.model_ref.storage_path)
-                )
-                result = await self.run_inference(
-                    InferenceInput(model_path=dl.ref.local_path, data=input.data)
+            async def run(self, input: PublishInput) -> PublishOutput:
+                dl = await self.download(DownloadInput(ref=input.artifacts_ref))
+                return await self.publish_data(
+                    PublishInput(local_path=dl.ref.local_path)
                 )
 
         Example — re-materialise an existing FileReference::
@@ -1058,7 +1062,7 @@ class App(ABC):
             download as _download,
         )
 
-        store = self.context.storage
+        store = self.context.upstream_storage or self.context.storage
         if store is None:
             raise ObjectStoreNotConfiguredError()
 

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -144,16 +144,6 @@ def _safe_log(level: str, message: str, **attrs: Any) -> None:
             log_method(message)
 
 
-def _log_upstream_storage_fallback(context: "AppContext", operation: str) -> None:
-    """Log when upload/download falls back from upstream_storage to storage."""
-    context.logger.warning(
-        "upstream_storage is not configured; %s will use the deployment store. "
-        "Set UPSTREAM_OBJECT_STORE_NAME and provide the matching Dapr component "
-        "to route to the upstream bucket.",
-        operation,
-    )
-
-
 # =============================================================================
 # Error Classes
 # =============================================================================
@@ -1015,8 +1005,6 @@ class App(ABC):
         store = self.context.upstream_storage or self.context.storage
         if store is None:
             raise ObjectStoreNotConfiguredError()
-        if self.context.upstream_storage is None:
-            _log_upstream_storage_fallback(self.context, "upload")
         run_prefix = f"artifacts/apps/{self._app_name}/workflows/{self.context.run_id}"
         app_prefix = input.tier.upload_prefix(
             run_prefix=run_prefix, app_name=self._app_name
@@ -1081,9 +1069,6 @@ class App(ABC):
         store = self.context.upstream_storage or self.context.storage
         if store is None:
             raise ObjectStoreNotConfiguredError()
-        if self.context.upstream_storage is None:
-            _log_upstream_storage_fallback(self.context, "download")
-
         # Resolve storage_path: explicit field takes precedence over ref.storage_path
         storage_path = input.storage_path
         if not storage_path and input.ref is not None:

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -955,6 +955,19 @@ class App(ABC):
         is never re-executed on workflow replay even if the worker is replaced
         mid-run (e.g. a KEDA scale-down event).
 
+        **Store routing (SDR vs non-SDR):** this method targets the upstream
+        object store when one is configured (``UPSTREAM_OBJECT_STORE_NAME``
+        points to a distinct Dapr component), and falls back to the deployment
+        store otherwise.  In standard (non-SDR) deployments the two env vars
+        share the same default so routing is transparent.  In SDR deployments
+        the upstream store is Atlan's bucket — the correct destination for
+        extracted artifacts handed off to the publish app.
+
+        This routing applies **only** to ``App.upload()``.  The automatic
+        file-reference materialisation that transfers ``FileReference`` objects
+        between ``@task`` methods always uses the deployment store; use that
+        mechanism (not ``App.upload()``) for intermediate task-to-task data.
+
         For direct use inside an existing ``@task``, import and call
         :func:`application_sdk.storage.transfer.upload` directly.
 
@@ -984,7 +997,9 @@ class App(ABC):
             upload as _upload,
         )
 
-        store = self.context.storage
+        # Prefer the upstream store (SDR: Atlan's bucket for the extract→publish
+        # handoff); fall back to the deployment store (standard deployments).
+        store = self.context.upstream_storage or self.context.storage
         if store is None:
             raise ObjectStoreNotConfiguredError()
         run_prefix = f"artifacts/apps/{self._app_name}/workflows/{self.context.run_id}"

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -144,6 +144,16 @@ def _safe_log(level: str, message: str, **attrs: Any) -> None:
             log_method(message)
 
 
+def _log_upstream_storage_fallback(context: "AppContext", operation: str) -> None:
+    """Log when upload/download falls back from upstream_storage to storage."""
+    context.logger.warning(
+        "upstream_storage is not configured; %s will use the deployment store. "
+        "Set UPSTREAM_OBJECT_STORE_NAME and provide the matching Dapr component "
+        "to route to the upstream bucket.",
+        operation,
+    )
+
+
 # =============================================================================
 # Error Classes
 # =============================================================================
@@ -994,6 +1004,7 @@ class App(ABC):
             up = await self.upload(UploadInput(local_path="/tmp/output/"))
             # up.ref.file_count == number of files in the directory
         """
+
         from application_sdk.storage.transfer import (  # noqa: PLC0415 — patched at module path in tests; lifting would break mock.patch sites
             upload as _upload,
         )
@@ -1003,6 +1014,8 @@ class App(ABC):
         store = self.context.upstream_storage or self.context.storage
         if store is None:
             raise ObjectStoreNotConfiguredError()
+        if self.context.upstream_storage is None:
+            _log_upstream_storage_fallback(self.context, "upload")
         run_prefix = f"artifacts/apps/{self._app_name}/workflows/{self.context.run_id}"
         app_prefix = input.tier.upload_prefix(
             run_prefix=run_prefix, app_name=self._app_name
@@ -1065,6 +1078,8 @@ class App(ABC):
         store = self.context.upstream_storage or self.context.storage
         if store is None:
             raise ObjectStoreNotConfiguredError()
+        if self.context.upstream_storage is None:
+            _log_upstream_storage_fallback(self.context, "download")
 
         # Resolve storage_path: explicit field takes precedence over ref.storage_path
         storage_path = input.storage_path

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -980,13 +980,13 @@ class App(ABC):
             containing both ``local_path`` and ``storage_path``, plus ``file_count``
             indicating the number of files uploaded.
 
-        Example — upload a single file produced by an extraction task::
+        Example — SDR extract app handing off artifacts to the publish app::
 
-            async def run(self, input: PipelineInput) -> PipelineOutput:
-                extract = await self.extract_data(ExtractInput(source=input.source))
-                up = await self.upload(UploadInput(local_path=extract.output_file))
-                # up.ref is durable — safe to pass to a task on a different worker
-                await self.load_data(LoadInput(ref=up.ref))
+            async def run(self, input: ExtractInput) -> ExtractOutput:
+                result = await self.extract_data(ExtractInput(source=input.source))
+                up = await self.upload(UploadInput(local_path=result.output_file))
+                # Return the ref so the publish app can consume it as input
+                return ExtractOutput(artifacts_ref=up.ref)
 
         Example — upload an entire output directory::
 

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -968,10 +968,11 @@ class App(ABC):
         **Store routing (SDR vs non-SDR):** this method targets the upstream
         object store when one is configured (``UPSTREAM_OBJECT_STORE_NAME``
         points to a distinct Dapr component), and falls back to the deployment
-        store otherwise.  In standard (non-SDR) deployments the two env vars
-        share the same default so routing is transparent.  In SDR deployments
-        the upstream store is Atlan's bucket — the correct destination for
-        extracted artifacts handed off to the publish app.
+        store otherwise.  In standard (non-SDR) deployments only the deployment
+        binding is present, so ``upstream_storage`` is ``None`` and routing
+        falls back to the deployment store.  In SDR deployments the upstream
+        store is Atlan's bucket — the correct destination for extracted
+        artifacts handed off to the publish app.
 
         This routing applies to ``App.upload()`` and ``App.download()``.  The
         automatic file-reference materialisation that transfers ``FileReference``
@@ -1045,8 +1046,10 @@ class App(ABC):
 
         **Store routing (SDR vs non-SDR):** mirrors ``App.upload()`` — reads
         from the upstream store when one is configured, falling back to the
-        deployment store otherwise.  In SDR deployments the publish app uses
-        this to pull artifacts written by the extract app.
+        deployment store otherwise.  In standard (non-SDR) deployments only
+        the deployment binding is present, so ``upstream_storage`` is ``None``
+        and routing falls back to the deployment store.  In SDR deployments
+        the publish app uses this to pull artifacts written by the extract app.
 
         For direct use inside an existing ``@task``, import and call
         :func:`application_sdk.storage.transfer.download` directly.

--- a/application_sdk/app/context.py
+++ b/application_sdk/app/context.py
@@ -213,6 +213,7 @@ class AppContext:
     _state_store: "StateStore | None" = field(default=None, repr=False)
     _secret_store: "SecretStore | None" = field(default=None, repr=False)
     _storage: "ObjectStore | None" = field(default=None, repr=False)
+    _upstream_storage: "ObjectStore | None" = field(default=None, repr=False)
     _logger: Any = field(default=None, repr=False)
     _cancelled: bool = field(default=False, repr=False)
 
@@ -329,6 +330,17 @@ class AppContext:
             await download_file("input/data.parquet", local_path, self.context.storage)
         """
         return self._storage
+
+    @property
+    def upstream_storage(self) -> "ObjectStore | None":
+        """Upstream object store, or ``None`` if not configured.
+
+        Present only in SDR deployments where ``UPSTREAM_OBJECT_STORE_NAME`` is
+        bound to a separate Dapr component pointing at Atlan's bucket.  In
+        standard (non-SDR) deployments this is ``None`` and ``App.upload()``
+        falls back to ``storage`` (the deployment store).
+        """
+        return self._upstream_storage
 
     def log_debug(self, message: str, **kwargs: Any) -> None:
         """Log a debug message."""

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -322,7 +322,9 @@ SECRET_STORE_NAME = os.getenv("SECRET_STORE_NAME", "secretstore")
 #: Name of the deployment object store component in DAPR
 DEPLOYMENT_OBJECT_STORE_NAME = os.getenv("DEPLOYMENT_OBJECT_STORE_NAME", "objectstore")
 #: Name of the upstream object store component in DAPR
-UPSTREAM_OBJECT_STORE_NAME = os.getenv("UPSTREAM_OBJECT_STORE_NAME", "objectstore")
+UPSTREAM_OBJECT_STORE_NAME = os.getenv(
+    "UPSTREAM_OBJECT_STORE_NAME", "atlan-objectstore"
+)
 #: Name of the pubsub component in DAPR
 EVENT_STORE_NAME = os.getenv("EVENT_STORE_NAME", "eventstore")
 #: DAPR binding operation for creating resources

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -321,7 +321,10 @@ STATE_STORE_NAME = os.getenv("STATE_STORE_NAME", "statestore")
 SECRET_STORE_NAME = os.getenv("SECRET_STORE_NAME", "secretstore")
 #: Name of the deployment object store component in DAPR
 DEPLOYMENT_OBJECT_STORE_NAME = os.getenv("DEPLOYMENT_OBJECT_STORE_NAME", "objectstore")
-#: Name of the upstream object store component in DAPR
+#: Name of the upstream object store component in DAPR.
+#: Default differs from DEPLOYMENT_OBJECT_STORE_NAME so that non-SDR deployments
+#: — which only ship the deployment binding — cause create_store_from_binding_optional
+#: to return None, leaving upstream_storage unset and routing to fall back to storage.
 UPSTREAM_OBJECT_STORE_NAME = os.getenv(
     "UPSTREAM_OBJECT_STORE_NAME", "atlan-objectstore"
 )

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -128,6 +128,7 @@ def create_activity_from_task(
             app_context._state_store = infra.state_store
             app_context._secret_store = infra.secret_store
             app_context._storage = infra.storage
+            app_context._upstream_storage = infra.upstream_storage
 
         app_instance._context = app_context
 

--- a/application_sdk/infrastructure/context.py
+++ b/application_sdk/infrastructure/context.py
@@ -40,6 +40,7 @@ class InfrastructureContext:
     state_store: StateStore | None = field(default=None)
     secret_store: SecretStore | None = field(default=None)
     storage: ObjectStore | None = field(default=None)
+    upstream_storage: ObjectStore | None = field(default=None)
     event_binding: Binding | None = field(default=None)
     _dapr_client: Any = field(default=None, repr=False)
 

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -505,6 +505,7 @@ async def _create_infrastructure(
         )
         from application_sdk.storage import (  # noqa: PLC0415 — cold path: storage init only when binding YAML present
             create_store_from_binding,
+            create_store_from_binding_optional,
         )
 
         await wait_for_dapr_sidecar()
@@ -520,7 +521,7 @@ async def _create_infrastructure(
                 DEPLOYMENT_OBJECT_STORE_NAME,
                 components_dir=components_dir,
             ),
-            upstream_storage=create_store_from_binding(
+            upstream_storage=create_store_from_binding_optional(
                 UPSTREAM_OBJECT_STORE_NAME,
                 components_dir=components_dir,
             ),

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -513,21 +513,6 @@ async def _create_infrastructure(
         registered_components = await _log_dapr_components(dapr_client, components_dir)
         logger.info("Dapr sidecar detected — using Dapr infrastructure")
 
-        # Upstream store is only distinct from the deployment store in SDR
-        # deployments where UPSTREAM_OBJECT_STORE_NAME is bound to a separate
-        # Dapr component.  When both env vars point at the same component name
-        # (the default), create_store_from_binding returns an equivalent store
-        # and App.upload() routing is transparent — non-SDR callers see no
-        # behavioral change.
-        upstream_store = (
-            create_store_from_binding(
-                UPSTREAM_OBJECT_STORE_NAME,
-                components_dir=components_dir,
-            )
-            if UPSTREAM_OBJECT_STORE_NAME != DEPLOYMENT_OBJECT_STORE_NAME
-            else None
-        )
-
         return InfrastructureContext(
             state_store=DaprStateStore(dapr_client, store_name=STATE_STORE_NAME),
             secret_store=DaprSecretStore(dapr_client, store_name=SECRET_STORE_NAME),
@@ -535,7 +520,10 @@ async def _create_infrastructure(
                 DEPLOYMENT_OBJECT_STORE_NAME,
                 components_dir=components_dir,
             ),
-            upstream_storage=upstream_store,
+            upstream_storage=create_store_from_binding(
+                UPSTREAM_OBJECT_STORE_NAME,
+                components_dir=components_dir,
+            ),
             event_binding=(
                 DaprBinding(dapr_client, EVENT_STORE_NAME)
                 if EVENT_STORE_NAME in registered_components

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -492,6 +492,7 @@ async def _create_infrastructure(
             EVENT_STORE_NAME,
             SECRET_STORE_NAME,
             STATE_STORE_NAME,
+            UPSTREAM_OBJECT_STORE_NAME,
         )
         from application_sdk.infrastructure._dapr.client import (  # noqa: PLC0415 — cold path: only when infrastructure init is needed
             DaprBinding,
@@ -511,6 +512,22 @@ async def _create_infrastructure(
         components_dir = Path(os.environ.get("DAPR_COMPONENTS_PATH", "./components"))
         registered_components = await _log_dapr_components(dapr_client, components_dir)
         logger.info("Dapr sidecar detected — using Dapr infrastructure")
+
+        # Upstream store is only distinct from the deployment store in SDR
+        # deployments where UPSTREAM_OBJECT_STORE_NAME is bound to a separate
+        # Dapr component.  When both env vars point at the same component name
+        # (the default), create_store_from_binding returns an equivalent store
+        # and App.upload() routing is transparent — non-SDR callers see no
+        # behavioral change.
+        upstream_store = (
+            create_store_from_binding(
+                UPSTREAM_OBJECT_STORE_NAME,
+                components_dir=components_dir,
+            )
+            if UPSTREAM_OBJECT_STORE_NAME != DEPLOYMENT_OBJECT_STORE_NAME
+            else None
+        )
+
         return InfrastructureContext(
             state_store=DaprStateStore(dapr_client, store_name=STATE_STORE_NAME),
             secret_store=DaprSecretStore(dapr_client, store_name=SECRET_STORE_NAME),
@@ -518,6 +535,7 @@ async def _create_infrastructure(
                 DEPLOYMENT_OBJECT_STORE_NAME,
                 components_dir=components_dir,
             ),
+            upstream_storage=upstream_store,
             event_binding=(
                 DaprBinding(dapr_client, EVENT_STORE_NAME)
                 if EVENT_STORE_NAME in registered_components

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -514,6 +514,18 @@ async def _create_infrastructure(
         registered_components = await _log_dapr_components(dapr_client, components_dir)
         logger.info("Dapr sidecar detected — using Dapr infrastructure")
 
+        upstream_storage = create_store_from_binding_optional(
+            UPSTREAM_OBJECT_STORE_NAME,
+            components_dir=components_dir,
+        )
+        if upstream_storage is None:
+            logger.warning(
+                "No Dapr component named '%s' found; App.upload/download will use "
+                "the deployment store. Configure this binding in SDR deployments to "
+                "route to the upstream bucket.",
+                UPSTREAM_OBJECT_STORE_NAME,
+            )
+
         return InfrastructureContext(
             state_store=DaprStateStore(dapr_client, store_name=STATE_STORE_NAME),
             secret_store=DaprSecretStore(dapr_client, store_name=SECRET_STORE_NAME),
@@ -521,10 +533,7 @@ async def _create_infrastructure(
                 DEPLOYMENT_OBJECT_STORE_NAME,
                 components_dir=components_dir,
             ),
-            upstream_storage=create_store_from_binding_optional(
-                UPSTREAM_OBJECT_STORE_NAME,
-                components_dir=components_dir,
-            ),
+            upstream_storage=upstream_storage,
             event_binding=(
                 DaprBinding(dapr_client, EVENT_STORE_NAME)
                 if EVENT_STORE_NAME in registered_components

--- a/application_sdk/storage/__init__.py
+++ b/application_sdk/storage/__init__.py
@@ -1,10 +1,11 @@
 """Object storage module — direct obstore-backed I/O, no Dapr sidecar needed.
 
 Public API:
-    create_local_store(root_path)     → LocalStore (for local dev / testing)
-    create_memory_store()             → MemoryStore (for unit tests)
-    create_store_from_binding(...)    → ObjectStore parsed from Dapr component YAML
-    normalize_key(key)                → str  (path normalisation)
+    create_local_store(root_path)              → LocalStore (for local dev / testing)
+    create_memory_store()                      → MemoryStore (for unit tests)
+    create_store_from_binding(...)             → ObjectStore parsed from Dapr component YAML
+    create_store_from_binding_optional(...)    → ObjectStore | None (None if component absent)
+    normalize_key(key)                         → str  (path normalisation)
     upload_file(key, local_path)      → str  (streaming upload, returns sha256)
     download_file(key, local_path)    → str | None  (streaming download)
     delete(key, store=None)           → bool
@@ -32,7 +33,10 @@ from application_sdk.storage.batch import (
     upload_file_from_bytes,
     upload_prefix,
 )
-from application_sdk.storage.binding import create_store_from_binding
+from application_sdk.storage.binding import (
+    create_store_from_binding,
+    create_store_from_binding_optional,
+)
 from application_sdk.storage.cloud import CloudStore
 from application_sdk.storage.errors import (
     StorageConfigError,
@@ -55,6 +59,7 @@ __all__ = [
     "CloudStore",
     # Store factories
     "create_store_from_binding",
+    "create_store_from_binding_optional",
     "create_local_store",
     "create_memory_store",
     # Core ops

--- a/application_sdk/storage/__init__.py
+++ b/application_sdk/storage/__init__.py
@@ -39,6 +39,7 @@ from application_sdk.storage.binding import (
 )
 from application_sdk.storage.cloud import CloudStore
 from application_sdk.storage.errors import (
+    StorageBindingNotFoundError,
     StorageConfigError,
     StorageError,
     StorageNotFoundError,
@@ -79,4 +80,5 @@ __all__ = [
     "StorageNotFoundError",
     "StoragePermissionError",
     "StorageConfigError",
+    "StorageBindingNotFoundError",
 ]

--- a/application_sdk/storage/binding.py
+++ b/application_sdk/storage/binding.py
@@ -477,3 +477,39 @@ def create_store_from_binding(
         )
 
     raise StorageConfigError(f"Store kind not implemented: {store_kind!r}")
+
+
+def create_store_from_binding_optional(
+    name: str,
+    *,
+    components_dir: Path | str = Path("./components"),
+) -> ObjectStore | None:
+    """Create an obstore store from a Dapr component binding, or ``None`` if absent.
+
+    Identical to :func:`create_store_from_binding` except that a missing
+    component returns ``None`` instead of raising ``StorageConfigError``.
+    Use this for optional bindings (e.g. ``UPSTREAM_OBJECT_STORE_NAME``) that
+    are only present in certain deployment configurations.
+
+    Args:
+        name: The Dapr component name (e.g. ``"atlan-objectstore"``).
+        components_dir: Directory containing Dapr component YAML files.
+
+    Returns:
+        A configured obstore store instance, or ``None`` if no component
+        named *name* exists in *components_dir*.
+
+    Raises:
+        StorageConfigError: If the component exists but is misconfigured
+            (unsupported binding type, missing required options, etc.).
+    """
+    from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
+        StorageConfigError,
+    )
+
+    try:
+        return create_store_from_binding(name, components_dir=components_dir)
+    except StorageConfigError as exc:
+        if f"No Dapr component named '{name}'" in str(exc):
+            return None
+        raise

--- a/application_sdk/storage/binding.py
+++ b/application_sdk/storage/binding.py
@@ -391,6 +391,7 @@ def create_store_from_binding(
     import yaml  # noqa: PLC0415 — defensive: keep inline
 
     from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
+        StorageBindingNotFoundError,
         StorageConfigError,
     )
 
@@ -409,8 +410,9 @@ def create_store_from_binding(
             break
 
     if component is None:
-        raise StorageConfigError(
-            f"No Dapr component named '{name}' found in {components_path}"
+        raise StorageBindingNotFoundError(
+            f"No Dapr component named '{name}' found in {components_path}",
+            binding_name=name,
         )
 
     spec = component.get("spec", {})
@@ -504,12 +506,10 @@ def create_store_from_binding_optional(
             (unsupported binding type, missing required options, etc.).
     """
     from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
-        StorageConfigError,
+        StorageBindingNotFoundError,
     )
 
     try:
         return create_store_from_binding(name, components_dir=components_dir)
-    except StorageConfigError as exc:
-        if f"No Dapr component named '{name}'" in str(exc):
-            return None
-        raise
+    except StorageBindingNotFoundError:
+        return None

--- a/application_sdk/storage/errors.py
+++ b/application_sdk/storage/errors.py
@@ -203,6 +203,8 @@ class StorageConfigError(InvalidInputError, StorageError):
         return " | ".join(parts)
 
 
+# code is the new structured identifier; legacy DEFAULT_ERROR_CODE inherited from
+# StorageConfigError (AAF-STR-003, deprecated, kept for back-compat — do not override).
 @dataclass(kw_only=True)
 class StorageBindingNotFoundError(StorageConfigError):
     """No Dapr component with the given name exists in the components directory.

--- a/application_sdk/storage/errors.py
+++ b/application_sdk/storage/errors.py
@@ -204,6 +204,40 @@ class StorageConfigError(InvalidInputError, StorageError):
 
 
 @dataclass(kw_only=True)
+class StorageBindingNotFoundError(StorageConfigError):
+    """No Dapr component with the given name exists in the components directory.
+
+    Subclass of ``StorageConfigError`` so existing ``except StorageConfigError:``
+    catch blocks keep working.  Use this type specifically to distinguish
+    "component absent" from other configuration errors (e.g. wrong binding type).
+    """
+
+    code: ClassVar[str] = "STORAGE_BINDING_NOT_FOUND"
+    binding_name: str | None = None
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        binding_name: str | None = None,
+        cause: Exception | None = None,
+        error_code: ErrorCode | None = None,
+    ) -> None:
+        StorageConfigError.__init__(
+            self, message=message, cause=cause, error_code=error_code
+        )
+        self.binding_name = binding_name
+
+    def __str__(self) -> str:
+        parts = [f"[{self.error_code.code}] {self.message}"]
+        if self.binding_name:
+            parts.append(f"binding_name={self.binding_name}")
+        if self.cause:
+            parts.append(f"caused_by={type(self.cause).__name__}: {self.cause}")
+        return " | ".join(parts)
+
+
+@dataclass(kw_only=True)
 class UnsafeUploadPathError(InvalidInputError):
     """Upload path is blocked — sensitive path, traversal, or user-defined block list."""
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.13.4
-source-sha:    d5871bc67ef9924be442ea57e13a9f8b714d4e41
-source-date:   2026-05-27T01:59:56+01:00
+source-sha:    68f00c067a5b6d1137f83df5362c7c9570cdf88c
+source-date:   2026-05-29T17:49:01+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -30,7 +30,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.main` | Dev entry point — run_dev_combined() and AppConfig for local execution and container startup | 2 |
 | `application_sdk.observability` | Logging context — ExecutionContext, CorrelationContext, request/correlation helpers | 11 |
 | `application_sdk.outputs` | Output collectors and record models for Automation Engine | 4 |
-| `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 19 |
+| `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 21 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 5 |
 | `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 15 |
 
@@ -1888,6 +1888,13 @@ Object-store abstraction — factory, formats, batch, transfer, cloud bindings
 - **Summary:** Async client for external customer-provided cloud object stores.
 - **Defined in:** `application_sdk/storage/cloud.py`
 
+#### `StorageBindingNotFoundError`
+
+- **Import:** `from application_sdk.storage import StorageBindingNotFoundError`
+- **Signature:** `class StorageBindingNotFoundError(message: str, ...)`
+- **Summary:** No Dapr component with the given name exists in the components directory.
+- **Defined in:** `application_sdk/storage/errors.py`
+
 #### `StorageConfigError`
 
 - **Import:** `from application_sdk.storage import StorageConfigError`
@@ -1937,6 +1944,13 @@ Object-store abstraction — factory, formats, batch, transfer, cloud bindings
 - **Import:** `from application_sdk.storage import create_store_from_binding`
 - **Signature:** `create_store_from_binding(name: str, *, components_dir: Path | str = Path('./components'))`
 - **Summary:** Create an obstore store from a Dapr component binding YAML file.
+- **Defined in:** `application_sdk/storage/binding.py`
+
+#### `create_store_from_binding_optional`
+
+- **Import:** `from application_sdk.storage import create_store_from_binding_optional`
+- **Signature:** `create_store_from_binding_optional(name: str, *, components_dir: Path | str = Path('./components'))`
+- **Summary:** Create an obstore store from a Dapr component binding, or ``None`` if absent.
 - **Defined in:** `application_sdk/storage/binding.py`
 
 #### `delete`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,7 +105,7 @@ Dapr component names are read at module-import time (not at runtime) because the
 | `STATE_STORE_NAME` | `statestore` | Dapr state store component name. |
 | `SECRET_STORE_NAME` | `secretstore` | Dapr secret store component name. |
 | `DEPLOYMENT_OBJECT_STORE_NAME` | `objectstore` | Dapr object store for workflow outputs and artifacts. |
-| `UPSTREAM_OBJECT_STORE_NAME` | `objectstore` | Dapr object store for uploading data to the Atlan platform. |
+| `UPSTREAM_OBJECT_STORE_NAME` | `atlan-objectstore` | Dapr object store for uploading data to the Atlan platform (SDR deployments only). If the named component is absent, `upstream_storage` is `None` and `App.upload()`/`App.download()` fall back to the deployment store. |
 | `EVENT_STORE_NAME` | `eventstore` | Dapr pub/sub component name. |
 | `DEPLOYMENT_SECRET_STORE_NAME` | `deployment-secret-store` | Dapr secret store holding deployment-scoped secrets (auth credentials, etc.). |
 | `DAPR_MAX_GRPC_MESSAGE_LENGTH` | `104857600` (100 MB) | Maximum gRPC message size in bytes for Dapr client calls. Increase for apps that move large payloads through Dapr state or bindings. |

--- a/tests/unit/app/test_base.py
+++ b/tests/unit/app/test_base.py
@@ -1580,6 +1580,85 @@ class TestWorkflowInteractionRelay:
 
 
 # =============================================================================
+# App.upload() — store routing
+# =============================================================================
+
+
+class TestUploadStoreRouting:
+    """App.upload() routes to upstream_storage when configured, else storage."""
+
+    def setup_method(self) -> None:
+        from application_sdk.app.registry import TaskRegistry
+
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    def teardown_method(self) -> None:
+        from application_sdk.app.registry import TaskRegistry
+
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    async def test_upload_uses_upstream_when_configured(self) -> None:
+        from application_sdk.app.context import AppContext
+        from application_sdk.contracts.storage import UploadInput, UploadOutput
+
+        upstream_sentinel = object()
+        deployment_sentinel = object()
+
+        class _UpApp(App):
+            async def run(self, input: _BLDXInput) -> _BLDXOutput:
+                return _BLDXOutput()
+
+        app = _UpApp()
+        app._context = AppContext(
+            app_name=app._app_name,
+            app_version="1",
+            run_id="run-1",
+            _storage=deployment_sentinel,  # type: ignore[arg-type]
+            _upstream_storage=upstream_sentinel,  # type: ignore[arg-type]
+        )
+
+        mock_result = UploadOutput()
+        with mock.patch(
+            "application_sdk.storage.transfer.upload",
+            new_callable=mock.AsyncMock,
+            return_value=mock_result,
+        ) as mock_upload:
+            await app.upload(UploadInput(local_path="/tmp/out"))
+
+        assert mock_upload.call_args.kwargs["store"] is upstream_sentinel
+
+    async def test_upload_falls_back_to_deployment_when_no_upstream(self) -> None:
+        from application_sdk.app.context import AppContext
+        from application_sdk.contracts.storage import UploadInput, UploadOutput
+
+        deployment_sentinel = object()
+
+        class _UpApp2(App):
+            async def run(self, input: _BLDXInput) -> _BLDXOutput:
+                return _BLDXOutput()
+
+        app = _UpApp2()
+        app._context = AppContext(
+            app_name=app._app_name,
+            app_version="1",
+            run_id="run-1",
+            _storage=deployment_sentinel,  # type: ignore[arg-type]
+        )
+
+        mock_result = UploadOutput()
+        with mock.patch(
+            "application_sdk.storage.transfer.upload",
+            new_callable=mock.AsyncMock,
+            return_value=mock_result,
+        ) as mock_upload:
+            await app.upload(UploadInput(local_path="/tmp/out"))
+
+        assert mock_upload.call_args.kwargs["store"] is deployment_sentinel
+
+
+# =============================================================================
 # Inline-import smoke checks
 # =============================================================================
 

--- a/tests/unit/app/test_base.py
+++ b/tests/unit/app/test_base.py
@@ -1657,6 +1657,64 @@ class TestUploadStoreRouting:
 
         assert mock_upload.call_args.kwargs["store"] is deployment_sentinel
 
+    async def test_download_uses_upstream_when_configured(self) -> None:
+        from application_sdk.app.context import AppContext
+        from application_sdk.contracts.storage import DownloadInput, DownloadOutput
+
+        upstream_sentinel = object()
+        deployment_sentinel = object()
+
+        class _DlApp(App):
+            async def run(self, input: _BLDXInput) -> _BLDXOutput:
+                return _BLDXOutput()
+
+        app = _DlApp()
+        app._context = AppContext(
+            app_name=app._app_name,
+            app_version="1",
+            run_id="run-1",
+            _storage=deployment_sentinel,  # type: ignore[arg-type]
+            _upstream_storage=upstream_sentinel,  # type: ignore[arg-type]
+        )
+
+        mock_result = DownloadOutput()
+        with mock.patch(
+            "application_sdk.storage.transfer.download",
+            new_callable=mock.AsyncMock,
+            return_value=mock_result,
+        ) as mock_download:
+            await app.download(DownloadInput(storage_path="artifacts/out"))
+
+        assert mock_download.call_args.kwargs["store"] is upstream_sentinel
+
+    async def test_download_falls_back_to_deployment_when_no_upstream(self) -> None:
+        from application_sdk.app.context import AppContext
+        from application_sdk.contracts.storage import DownloadInput, DownloadOutput
+
+        deployment_sentinel = object()
+
+        class _DlApp2(App):
+            async def run(self, input: _BLDXInput) -> _BLDXOutput:
+                return _BLDXOutput()
+
+        app = _DlApp2()
+        app._context = AppContext(
+            app_name=app._app_name,
+            app_version="1",
+            run_id="run-1",
+            _storage=deployment_sentinel,  # type: ignore[arg-type]
+        )
+
+        mock_result = DownloadOutput()
+        with mock.patch(
+            "application_sdk.storage.transfer.download",
+            new_callable=mock.AsyncMock,
+            return_value=mock_result,
+        ) as mock_download:
+            await app.download(DownloadInput(storage_path="artifacts/out"))
+
+        assert mock_download.call_args.kwargs["store"] is deployment_sentinel
+
 
 # =============================================================================
 # Inline-import smoke checks

--- a/tests/unit/app/test_context.py
+++ b/tests/unit/app/test_context.py
@@ -119,6 +119,15 @@ class TestAppContextIdentity:
         ctx = AppContext(app_name="a", app_version="1")
         assert ctx.storage is None
 
+    def test_upstream_storage_returns_configured_store(self) -> None:
+        sentinel = object()
+        ctx = AppContext(app_name="a", app_version="1", _upstream_storage=sentinel)  # type: ignore[arg-type]
+        assert ctx.upstream_storage is sentinel
+
+    def test_upstream_storage_returns_none_by_default(self) -> None:
+        ctx = AppContext(app_name="a", app_version="1")
+        assert ctx.upstream_storage is None
+
 
 # ---------------------------------------------------------------------------
 # AppContext: state store contract

--- a/tests/unit/storage/test_binding.py
+++ b/tests/unit/storage/test_binding.py
@@ -16,8 +16,12 @@ from application_sdk.storage.binding import (
     _nonempty,
     _resolve_metadata_value,
     create_store_from_binding,
+    create_store_from_binding_optional,
 )
-from application_sdk.storage.errors import StorageConfigError
+from application_sdk.storage.errors import (
+    StorageBindingNotFoundError,
+    StorageConfigError,
+)
 
 
 def _write_component(
@@ -1077,3 +1081,26 @@ class TestGCSServiceAccountFieldsConstant:
             "universe_domain",
         }
         assert required == set(GCS_SERVICE_ACCOUNT_FIELDS)
+
+
+class TestCreateStoreFromBindingOptional:
+    def test_returns_none_when_component_absent(self, tmp_path: Path) -> None:
+        """Returns None when no component with the given name exists."""
+        result = create_store_from_binding_optional(
+            "nonexistent", components_dir=tmp_path
+        )
+        assert result is None
+
+    def test_reraises_for_misconfigured_component(self, tmp_path: Path) -> None:
+        """Propagates StorageConfigError when the component exists but is misconfigured."""
+        (tmp_path / "bad.yaml").write_text(
+            "kind: Component\n"
+            "metadata:\n"
+            "  name: my-store\n"
+            "spec:\n"
+            "  type: bindings.unsupported.type\n"
+            "  metadata: []\n"
+        )
+        with pytest.raises(StorageConfigError) as exc_info:
+            create_store_from_binding_optional("my-store", components_dir=tmp_path)
+        assert not isinstance(exc_info.value, StorageBindingNotFoundError)

--- a/tests/unit/storage/test_binding.py
+++ b/tests/unit/storage/test_binding.py
@@ -1104,3 +1104,9 @@ class TestCreateStoreFromBindingOptional:
         with pytest.raises(StorageConfigError) as exc_info:
             create_store_from_binding_optional("my-store", components_dir=tmp_path)
         assert not isinstance(exc_info.value, StorageBindingNotFoundError)
+
+    def test_binding_not_found_error_carries_binding_name(self, tmp_path: Path) -> None:
+        """StorageBindingNotFoundError exposes the queried component name."""
+        with pytest.raises(StorageBindingNotFoundError) as exc_info:
+            create_store_from_binding("atlan-objectstore", components_dir=tmp_path)
+        assert exc_info.value.binding_name == "atlan-objectstore"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -584,6 +584,75 @@ class TestCreateInfrastructureEventBinding:
         assert infra.event_binding is None
 
 
+class TestCreateInfrastructureUpstreamStore:
+    """Tests for _create_infrastructure() upstream_storage selection."""
+
+    _DAPR_CLIENT_MOD = "application_sdk.infrastructure._dapr.client"
+    _STORAGE_MOD = "application_sdk.storage"
+
+    def _make_dapr_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DAPR_HTTP_PORT", "3500")
+
+    async def test_upstream_storage_is_none_when_names_match(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When UPSTREAM and DEPLOYMENT names are equal, upstream_storage is None."""
+        self._make_dapr_env(monkeypatch)
+
+        with (
+            patch(
+                "application_sdk.main._log_dapr_components",
+                new_callable=AsyncMock,
+                return_value=set(),
+            ),
+            patch(f"{self._DAPR_CLIENT_MOD}.AsyncDaprClient"),
+            patch(f"{self._DAPR_CLIENT_MOD}.DaprStateStore"),
+            patch(f"{self._DAPR_CLIENT_MOD}.DaprSecretStore"),
+            patch(f"{self._STORAGE_MOD}.create_store_from_binding") as mock_store,
+            patch(
+                "application_sdk.constants.DEPLOYMENT_OBJECT_STORE_NAME", "objectstore"
+            ),
+            patch(
+                "application_sdk.constants.UPSTREAM_OBJECT_STORE_NAME", "objectstore"
+            ),
+        ):
+            infra = await _create_infrastructure()
+
+        assert infra.upstream_storage is None
+        mock_store.assert_called_once()
+
+    async def test_upstream_storage_created_when_names_differ(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When UPSTREAM != DEPLOYMENT, upstream_storage is a distinct store."""
+        self._make_dapr_env(monkeypatch)
+
+        with (
+            patch(
+                "application_sdk.main._log_dapr_components",
+                new_callable=AsyncMock,
+                return_value=set(),
+            ),
+            patch(f"{self._DAPR_CLIENT_MOD}.AsyncDaprClient"),
+            patch(f"{self._DAPR_CLIENT_MOD}.DaprStateStore"),
+            patch(f"{self._DAPR_CLIENT_MOD}.DaprSecretStore"),
+            patch(f"{self._STORAGE_MOD}.create_store_from_binding") as mock_store,
+            patch(
+                "application_sdk.constants.DEPLOYMENT_OBJECT_STORE_NAME",
+                "deployment-store",
+            ),
+            patch(
+                "application_sdk.constants.UPSTREAM_OBJECT_STORE_NAME", "upstream-store"
+            ),
+        ):
+            infra = await _create_infrastructure()
+
+        assert infra.upstream_storage is not None
+        assert mock_store.call_count == 2
+
+
 class TestInstallGracefulSignalHandlers:
     """Tests for _install_graceful_signal_handlers()."""
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -8,7 +8,7 @@ import signal
 import sys
 from pathlib import Path
 from unittest import mock
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -593,11 +593,11 @@ class TestCreateInfrastructureUpstreamStore:
     def _make_dapr_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DAPR_HTTP_PORT", "3500")
 
-    async def test_upstream_storage_always_created(
+    async def test_upstream_storage_none_when_component_absent(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """upstream_storage is always created, even when names are equal (non-SDR)."""
+        """upstream_storage is None in non-SDR deployments (no atlan-objectstore component)."""
         self._make_dapr_env(monkeypatch)
 
         with (
@@ -609,25 +609,24 @@ class TestCreateInfrastructureUpstreamStore:
             patch(f"{self._DAPR_CLIENT_MOD}.AsyncDaprClient"),
             patch(f"{self._DAPR_CLIENT_MOD}.DaprStateStore"),
             patch(f"{self._DAPR_CLIENT_MOD}.DaprSecretStore"),
-            patch(f"{self._STORAGE_MOD}.create_store_from_binding") as mock_store,
+            patch(f"{self._STORAGE_MOD}.create_store_from_binding"),
             patch(
-                "application_sdk.constants.DEPLOYMENT_OBJECT_STORE_NAME", "objectstore"
-            ),
-            patch(
-                "application_sdk.constants.UPSTREAM_OBJECT_STORE_NAME", "objectstore"
-            ),
+                f"{self._STORAGE_MOD}.create_store_from_binding_optional",
+                return_value=None,
+            ) as mock_optional,
         ):
             infra = await _create_infrastructure()
 
-        assert infra.upstream_storage is not None
-        assert mock_store.call_count == 2
+        assert infra.upstream_storage is None
+        mock_optional.assert_called_once()
 
-    async def test_upstream_storage_created_when_names_differ(
+    async def test_upstream_storage_set_when_component_present(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """When UPSTREAM != DEPLOYMENT, upstream_storage is a distinct store."""
+        """upstream_storage is a live store in SDR deployments (component present)."""
         self._make_dapr_env(monkeypatch)
+        upstream_store = MagicMock()
 
         with (
             patch(
@@ -638,19 +637,25 @@ class TestCreateInfrastructureUpstreamStore:
             patch(f"{self._DAPR_CLIENT_MOD}.AsyncDaprClient"),
             patch(f"{self._DAPR_CLIENT_MOD}.DaprStateStore"),
             patch(f"{self._DAPR_CLIENT_MOD}.DaprSecretStore"),
-            patch(f"{self._STORAGE_MOD}.create_store_from_binding") as mock_store,
+            patch(f"{self._STORAGE_MOD}.create_store_from_binding") as mock_required,
+            patch(
+                f"{self._STORAGE_MOD}.create_store_from_binding_optional",
+                return_value=upstream_store,
+            ) as mock_optional,
             patch(
                 "application_sdk.constants.DEPLOYMENT_OBJECT_STORE_NAME",
-                "deployment-store",
+                "objectstore",
             ),
             patch(
-                "application_sdk.constants.UPSTREAM_OBJECT_STORE_NAME", "upstream-store"
+                "application_sdk.constants.UPSTREAM_OBJECT_STORE_NAME",
+                "atlan-objectstore",
             ),
         ):
             infra = await _create_infrastructure()
 
-        assert infra.upstream_storage is not None
-        assert mock_store.call_count == 2
+        assert infra.upstream_storage is upstream_store
+        mock_required.assert_called_once_with("objectstore", components_dir=ANY)
+        mock_optional.assert_called_once_with("atlan-objectstore", components_dir=ANY)
 
 
 class TestInstallGracefulSignalHandlers:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -593,11 +593,11 @@ class TestCreateInfrastructureUpstreamStore:
     def _make_dapr_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DAPR_HTTP_PORT", "3500")
 
-    async def test_upstream_storage_is_none_when_names_match(
+    async def test_upstream_storage_always_created(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """When UPSTREAM and DEPLOYMENT names are equal, upstream_storage is None."""
+        """upstream_storage is always created, even when names are equal (non-SDR)."""
         self._make_dapr_env(monkeypatch)
 
         with (
@@ -619,8 +619,8 @@ class TestCreateInfrastructureUpstreamStore:
         ):
             infra = await _create_infrastructure()
 
-        assert infra.upstream_storage is None
-        mock_store.assert_called_once()
+        assert infra.upstream_storage is not None
+        assert mock_store.call_count == 2
 
     async def test_upstream_storage_created_when_names_differ(
         self,


### PR DESCRIPTION
## Summary

- Adds `upstream_storage` field to `InfrastructureContext` and `AppContext`, populated from `UPSTREAM_OBJECT_STORE_NAME` when it resolves to a distinct Dapr component from `DEPLOYMENT_OBJECT_STORE_NAME`
- `App.upload()` now selects `upstream_storage` when present, falling back to `storage` (deployment store) — enabling the extract→publish artifact handoff in SDR deployments without any callsite changes
- Documents in `App.upload()`'s docstring that this routing is intentional and distinct from auto-materialisation (which always uses the deployment store)

## Motivation

In SDR deployments the extract app runs locally but must hand off its final artifacts to Atlan's upstream bucket so the publish app can consume them. Previously `App.upload()` hardwired to the deployment store — there was no path to the upstream store at all.

The fix uses precedence-based routing rather than an explicit `store=` parameter because `App.upload()` has one documented purpose (durable artifact handoff, not intermediate task-to-task transfers), so all callers should route to upstream when available. Adding a parameter would require all existing callsites to be updated for no benefit.

**Non-SDR deployments are unaffected:** `UPSTREAM_OBJECT_STORE_NAME` and `DEPLOYMENT_OBJECT_STORE_NAME` both default to `"objectstore"`, so `upstream_storage` is `None` and routing falls through to the deployment store as before.

## Test plan

- [ ] Verify non-SDR: both env vars at default (`objectstore`) → `upstream_storage` is `None` → `App.upload()` routes to deployment store (no behaviour change)
- [ ] Verify SDR: `UPSTREAM_OBJECT_STORE_NAME` set to a distinct component → `upstream_storage` is populated → `App.upload()` routes to upstream store
- [ ] Confirm auto-materialisation (`FileReference` task-to-task transfers) is unaffected — it uses `infra.storage` directly, not `App.upload()`