### PR TITLE
ci: centralize app certification in build-and-publish gate

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -351,14 +351,164 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
           echo "::warning title=Tests failed (warn-only)::${WORKFLOW_FILE} concluded as ${CONCLUSION}. Publish proceeded; will block once enforcement lands. See: ${URL}"
 
+  # ── Job 0c: App certification — generic readiness checks (warn-only) ──────────
+  # Centralizes the certification layers that need NO per-app wiring, so every
+  # app is certified at publish time without editing its own workflows:
+  #   1. v3 shape         — tools.migrate_v3.check_migration (no deprecated
+  #                         imports, @task-only, typed Input/Output, …)
+  #   2. Contract drift   — `poe generate` must be a no-op vs the committed
+  #                         app/generated/ artifacts
+  #   3. Unit + coverage  — pytest tests/unit at the >=85% SDK coverage bar
+  #
+  # App-specific layers (integration, SDR, e2e/Playwright) are NOT run here —
+  # they need the app's own live stack + secrets and stay in the app's CI.
+  #
+  # WARN-ONLY during rollout (mirrors the unit-tests-gate DISTR-456 pattern):
+  # each check runs and annotates a verdict on the workflow summary, but the
+  # job exits 0 so publish proceeds even on ❌. The enforcement-flip PR
+  # restores blocking — see the "Certification verdict" step. Checks that
+  # don't apply to an app (no contract/app.pkl, no tests/unit, no poe) skip
+  # cleanly so non-conforming apps aren't hard-failed before they onboard.
+  #
+  # Only runs when `publish: true`. See docs/standards/app-certification.md.
+  certify:
+    name: Certify app (warn-only)
+    if: inputs.publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          path: app
+          # Full history so the contract-drift `git diff` compares against the
+          # committed tree rather than a shallow snapshot.
+          fetch-depth: 0
+
+      - name: Checkout application-sdk (migration tooling)
+        # tools.migrate_v3 ships in the SDK repo, not the published package —
+        # pinned to main so the check tracks the latest released rules.
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          repository: atlanhq/application-sdk
+          ref: main
+          path: sdk
+          token: ${{ secrets.ORG_PAT_GITHUB }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.7.3"
+
+      # ── 1. v3 shape ─────────────────────────────────────────────────────────
+      - name: Install SDK (migration tooling)
+        id: sdk_install
+        continue-on-error: true
+        working-directory: sdk
+        run: uv sync --all-extras --all-groups
+
+      - name: "v3 shape — check_migration"
+        id: check_migration
+        if: steps.sdk_install.outcome == 'success'
+        continue-on-error: true
+        working-directory: sdk
+        run: |
+          set -euo pipefail
+          if uv run python -m tools.migrate_v3.check_migration --no-color ../app; then
+            echo "check_migration: no FAILs"
+          else
+            echo "::warning::check_migration reported FAILs — see output above"
+            exit 1
+          fi
+
+      # ── 2. Contract drift ─────────────────────────────────────────────────────
+      - name: "Contract drift — poe generate must be a no-op"
+        id: contract_drift
+        continue-on-error: true
+        working-directory: app
+        run: |
+          set -euo pipefail
+          if [ ! -f contract/app.pkl ]; then
+            echo "No contract/app.pkl — skipping contract-drift check."
+            exit 0
+          fi
+          uv sync --all-extras
+          if ! uv run poe --help >/dev/null 2>&1; then
+            echo "::warning::'poe' task runner not available — cannot run drift check."
+            exit 0
+          fi
+          uv run poe generate || { echo "::warning::'poe generate' failed"; exit 1; }
+          if ! git diff --exit-code -- app/generated/; then
+            echo "::warning::app/generated/ is stale — run 'poe generate' locally and commit."
+            exit 1
+          fi
+
+      # ── 3. Unit tests + coverage ──────────────────────────────────────────────
+      - name: "Unit tests + coverage (>=85%)"
+        id: unit
+        continue-on-error: true
+        working-directory: app
+        run: |
+          set -euo pipefail
+          if [ ! -d tests/unit ]; then
+            echo "No tests/unit/ — skipping unit-coverage check."
+            exit 0
+          fi
+          uv sync --all-extras
+          uv run --with pytest-cov pytest tests/unit \
+            --cov=app --cov-report=term --cov-fail-under=85
+
+      # ── Verdict (warn-only) ───────────────────────────────────────────────────
+      - name: Certification verdict (warn-only)
+        if: always()
+        env:
+          CM: ${{ steps.check_migration.outcome }}
+          CD: ${{ steps.contract_drift.outcome }}
+          UT: ${{ steps.unit.outcome }}
+          SDK_INSTALL: ${{ steps.sdk_install.outcome }}
+        run: |
+          set -euo pipefail
+          render() {
+            case "$2" in
+              success) icon="✅" ;;
+              failure) icon="❌" ;;
+              skipped) icon="➖" ;;
+              *)       icon="❓" ;;
+            esac
+            echo "- $icon **$1** — $2"
+          }
+          {
+            echo "### App certification (warn-only)"
+            echo ""
+            render "v3 shape (check_migration)" "$CM"
+            render "Contract drift (poe generate)" "$CD"
+            render "Unit tests + coverage (>=85%)" "$UT"
+            echo ""
+            echo "**Warn-only during rollout — publish proceeds even on ❌.** Once the enforcement-flip PR lands, a ❌ here will block publish. See [docs/standards/app-certification.md](https://github.com/atlanhq/application-sdk/blob/main/docs/standards/app-certification.md)."
+          } >> "${GITHUB_STEP_SUMMARY}"
+          if [ "$SDK_INSTALL" != "success" ]; then
+            echo "::warning title=Certification incomplete::SDK install failed, so check_migration did not run."
+          fi
+          if [ "$CM" = "failure" ] || [ "$CD" = "failure" ] || [ "$UT" = "failure" ]; then
+            echo "::warning title=Certification failed (warn-only)::One or more certification checks failed; publish proceeded. Will block once enforcement lands."
+          fi
+          # WARN-ONLY: always succeed during rollout. The enforcement-flip PR
+          # replaces the line below with a non-zero exit when any check failed:
+          #   [ "$CM" != failure ] && [ "$CD" != failure ] && [ "$UT" != failure ]
+          exit 0
+
   # ── Job 1: Read atlan.yaml, validate secrets, compute all image tags ──────────
   prepare:
-    needs: [validate-channel, unit-tests-gate]
-    # `needs: [validate-channel, unit-tests-gate]` only enforces ordering when
-    # those jobs run. When publish=false, both are skipped via their `if:` —
-    # which by default would propagate "skipped" to dependents. The condition
-    # below explicitly allows prepare to run when those jobs are skipped OR
-    # successful, but NOT when it failed.
+    needs: [validate-channel, unit-tests-gate, certify]
+    # `needs: [validate-channel, unit-tests-gate, certify]` only enforces
+    # ordering when those jobs run. When publish=false, all three are skipped
+    # via their `if:` — which by default would propagate "skipped" to
+    # dependents. The condition below explicitly allows prepare to run when
+    # those jobs are skipped OR successful, but NOT when one failed. `certify`
+    # is warn-only today (always exits 0), so it never trips this; once the
+    # enforcement-flip lands, a failing certify will correctly skip prepare →
+    # build → publish.
     if: ${{ !failure() && !cancelled() }}
     name: Prepare
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -351,7 +351,7 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
           echo "::warning title=Tests failed (warn-only)::${WORKFLOW_FILE} concluded as ${CONCLUSION}. Publish proceeded; will block once enforcement lands. See: ${URL}"
 
-  # ── Job 0c: App certification — generic readiness checks (warn-only) ──────────
+  # ── Job 0c: App certification — generic readiness checks ──────────────────────
   # Centralizes the certification layers that need NO per-app wiring, so every
   # app is certified at publish time without editing its own workflows:
   #   1. v3 shape         — tools.migrate_v3.check_migration (no deprecated
@@ -363,16 +363,18 @@ jobs:
   # App-specific layers (integration, SDR, e2e/Playwright) are NOT run here —
   # they need the app's own live stack + secrets and stay in the app's CI.
   #
-  # WARN-ONLY during rollout (mirrors the unit-tests-gate DISTR-456 pattern):
-  # each check runs and annotates a verdict on the workflow summary, but the
-  # job exits 0 so publish proceeds even on ❌. The enforcement-flip PR
-  # restores blocking — see the "Certification verdict" step. Checks that
-  # don't apply to an app (no contract/app.pkl, no tests/unit, no poe) skip
-  # cleanly so non-conforming apps aren't hard-failed before they onboard.
+  # Enforcement: layer 3 (unit tests + coverage) BLOCKS publish on ❌ — the
+  # verdict step exits non-zero, which trips `prepare`'s `if: !failure()` and
+  # skips build + publish. Layers 1 and 2 (v3 shape, contract drift) remain
+  # WARN-ONLY during rollout: each runs and annotates a verdict, but does not
+  # block (contract drift still needs the pkl toolchain on the runner before it
+  # can flip). See the "Certification verdict" step. Checks that don't apply to
+  # an app (no contract/app.pkl, no tests/unit, no poe) skip cleanly so
+  # non-conforming apps aren't hard-failed before they onboard.
   #
   # Only runs when `publish: true`. See docs/standards/app-certification.md.
   certify:
-    name: Certify app (warn-only)
+    name: Certify app
     if: inputs.publish
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -459,8 +461,13 @@ jobs:
           uv run --with pytest-cov pytest tests/unit \
             --cov=app --cov-report=term --cov-fail-under=85
 
-      # ── Verdict (warn-only) ───────────────────────────────────────────────────
-      - name: Certification verdict (warn-only)
+      # ── Verdict ───────────────────────────────────────────────────────────────
+      # Unit tests + coverage now ENFORCE: a ❌ there exits non-zero, which trips
+      # `prepare`'s `if: !failure()` and skips build + publish. v3 shape and
+      # contract drift remain warn-only during rollout — they annotate but do
+      # not block (their enforcement-flip is tracked separately; contract drift
+      # still needs the pkl toolchain on the runner first).
+      - name: Certification verdict
         if: always()
         env:
           CM: ${{ steps.check_migration.outcome }}
@@ -479,23 +486,34 @@ jobs:
             echo "- $icon **$1** — $2"
           }
           {
-            echo "### App certification (warn-only)"
+            echo "### App certification"
             echo ""
-            render "v3 shape (check_migration)" "$CM"
-            render "Contract drift (poe generate)" "$CD"
-            render "Unit tests + coverage (>=85%)" "$UT"
+            render "v3 shape (check_migration) — warn-only" "$CM"
+            render "Contract drift (poe generate) — warn-only" "$CD"
+            render "Unit tests + coverage (>=85%) — enforced" "$UT"
             echo ""
-            echo "**Warn-only during rollout — publish proceeds even on ❌.** Once the enforcement-flip PR lands, a ❌ here will block publish. See [docs/standards/app-certification.md](https://github.com/atlanhq/application-sdk/blob/main/docs/standards/app-certification.md)."
+            echo "**Unit tests + coverage block publish on ❌.** v3 shape and contract drift remain warn-only during rollout — a ❌ there annotates but does not block. See [docs/standards/app-certification.md](https://github.com/atlanhq/application-sdk/blob/main/docs/standards/app-certification.md)."
           } >> "${GITHUB_STEP_SUMMARY}"
           if [ "$SDK_INSTALL" != "success" ]; then
             echo "::warning title=Certification incomplete::SDK install failed, so check_migration did not run."
           fi
-          if [ "$CM" = "failure" ] || [ "$CD" = "failure" ] || [ "$UT" = "failure" ]; then
-            echo "::warning title=Certification failed (warn-only)::One or more certification checks failed; publish proceeded. Will block once enforcement lands."
+          if [ "$CM" = "failure" ] || [ "$CD" = "failure" ]; then
+            echo "::warning title=Certification warning (warn-only)::v3 shape and/or contract drift failed; publish proceeded (warn-only)."
           fi
-          # WARN-ONLY: always succeed during rollout. The enforcement-flip PR
-          # replaces the line below with a non-zero exit when any check failed:
-          #   [ "$CM" != failure ] && [ "$CD" != failure ] && [ "$UT" != failure ]
+          # Unit tests + coverage enforce: block publish when they fail. The
+          # `unit` step keeps `continue-on-error` so this verdict can render the
+          # full summary first, then exit non-zero here. v3 shape (CM) and
+          # contract drift (CD) stay warn-only — only UT blocks.
+          if [ "$UT" = "failure" ]; then
+            {
+              echo ""
+              echo "### ❌ Publish blocked — unit tests + coverage"
+              echo ""
+              echo "The centralized \`tests/unit\` + coverage (>=85%) check failed. Build and publish will not proceed until it passes. Fix the failing tests and re-run."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            echo "::error title=Publish blocked::Unit tests + coverage check failed. Build and publish blocked."
+            exit 1
+          fi
           exit 0
 
   # ── Job 1: Read atlan.yaml, validate secrets, compute all image tags ──────────
@@ -506,9 +524,11 @@ jobs:
     # via their `if:` — which by default would propagate "skipped" to
     # dependents. The condition below explicitly allows prepare to run when
     # those jobs are skipped OR successful, but NOT when one failed. `certify`
-    # is warn-only today (always exits 0), so it never trips this; once the
-    # enforcement-flip lands, a failing certify will correctly skip prepare →
-    # build → publish.
+    # enforces its unit + coverage check: a failing run exits non-zero, which
+    # trips `failure()` here and correctly skips prepare → build → publish. Its
+    # other layers (v3 shape, contract drift) stay warn-only (always exit 0) so
+    # they never trip this yet. `unit-tests-gate` is warn-only on this branch;
+    # its enforcement-flip is tracked separately.
     if: ${{ !failure() && !cancelled() }}
     name: Prepare
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -370,14 +370,16 @@ jobs:
   # block (contract drift still needs the pkl toolchain on the runner before it
   # can flip). See the "Certification verdict" step. Checks that don't apply to
   # an app (no contract/app.pkl, no tests/unit, no poe) skip cleanly so
-  # non-conforming apps aren't hard-failed before they onboard.
+  # non-conforming apps aren't hard-failed before they onboard. A single
+  # `app_install` step (id: app_install) runs `uv sync --all-extras` once;
+  # contract-drift and unit tests both depend on it and are skipped if it fails.
   #
   # Only runs when `publish: true`. See docs/standards/app-certification.md.
   certify:
     name: Certify app
     if: inputs.publish
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
     steps:
       - name: Checkout app
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -399,7 +401,7 @@ jobs:
           token: ${{ secrets.ORG_PAT_GITHUB }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: "0.7.3"
 
@@ -424,9 +426,17 @@ jobs:
             exit 1
           fi
 
-      # ── 2. Contract drift ─────────────────────────────────────────────────────
+      # ── 2. App dependencies ───────────────────────────────────────────────────
+      - name: Install app dependencies
+        id: app_install
+        continue-on-error: true
+        working-directory: app
+        run: uv sync --all-extras
+
+      # ── 3. Contract drift ─────────────────────────────────────────────────────
       - name: "Contract drift — poe generate must be a no-op"
         id: contract_drift
+        if: steps.app_install.outcome == 'success'
         continue-on-error: true
         working-directory: app
         run: |
@@ -435,7 +445,6 @@ jobs:
             echo "No contract/app.pkl — skipping contract-drift check."
             exit 0
           fi
-          uv sync --all-extras
           if ! uv run poe --help >/dev/null 2>&1; then
             echo "::warning::'poe' task runner not available — cannot run drift check."
             exit 0
@@ -446,9 +455,10 @@ jobs:
             exit 1
           fi
 
-      # ── 3. Unit tests (enforced) + coverage threshold (warn-only) ───────────────
+      # ── 4. Unit tests (enforced) + coverage threshold (warn-only) ───────────────
       - name: "Unit tests"
         id: unit
+        if: steps.app_install.outcome == 'success'
         continue-on-error: true
         working-directory: app
         run: |
@@ -457,8 +467,8 @@ jobs:
             echo "No tests/unit/ — skipping."
             exit 0
           fi
-          uv sync --all-extras
-          uv run --with pytest-cov pytest tests/unit --cov=app --cov-report=term
+          uv run --with pytest-cov pytest tests/unit --cov=app --cov-report=term --data-file=.coverage
+
       - name: "Coverage threshold (>=85%)"
         id: coverage_threshold
         if: steps.unit.outcome == 'success'
@@ -466,7 +476,7 @@ jobs:
         working-directory: app
         run: |
           set -euo pipefail
-          uv run coverage report --fail-under=85
+          uv run coverage report --data-file=.coverage --fail-under=85
 
       # ── Verdict ───────────────────────────────────────────────────────────────
       # Unit test pass/fail (UT) ENFORCES: a ❌ exits non-zero, trips
@@ -481,6 +491,7 @@ jobs:
           UT: ${{ steps.unit.outcome }}
           COV: ${{ steps.coverage_threshold.outcome }}
           SDK_INSTALL: ${{ steps.sdk_install.outcome }}
+          APP_INSTALL: ${{ steps.app_install.outcome }}
         run: |
           set -euo pipefail
           render() {
@@ -492,18 +503,25 @@ jobs:
             esac
             echo "- $icon **$1** — $2"
           }
+          cm_label="v3 shape (check_migration) — warn-only"
+          [ "$SDK_INSTALL" != "success" ] && cm_label="$cm_label (sdk install failed)"
+          app_label=""
+          [ "$APP_INSTALL" != "success" ] && app_label=" (app install failed)"
           {
             echo "### App certification"
             echo ""
-            render "v3 shape (check_migration) — warn-only" "$CM"
-            render "Contract drift (poe generate) — warn-only" "$CD"
-            render "Unit tests — enforced" "$UT"
+            render "$cm_label" "$CM"
+            render "Contract drift (poe generate) — warn-only${app_label}" "$CD"
+            render "Unit tests — enforced${app_label}" "$UT"
             render "Coverage (>=85%) — warn-only" "$COV"
             echo ""
             echo "**Unit test pass/fail blocks publish on ❌.** Coverage threshold, v3 shape, and contract drift are warn-only during rollout. See [docs/standards/app-certification.md](https://github.com/atlanhq/application-sdk/blob/main/docs/standards/app-certification.md)."
           } >> "${GITHUB_STEP_SUMMARY}"
           if [ "$SDK_INSTALL" != "success" ]; then
             echo "::warning title=Certification incomplete::SDK install failed, so check_migration did not run."
+          fi
+          if [ "$APP_INSTALL" != "success" ]; then
+            echo "::warning title=Certification incomplete::App install failed; contract drift and unit tests did not run."
           fi
           if [ "$CM" = "failure" ] || [ "$CD" = "failure" ]; then
             echo "::warning title=Certification warning (warn-only)::v3 shape and/or contract drift failed; publish proceeded (warn-only)."

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -393,6 +393,10 @@ jobs:
       - name: Checkout application-sdk (migration tooling)
         # tools.migrate_v3 ships in the SDK repo, not the published package —
         # pinned to main so the check tracks the latest released rules.
+        # ORG_PAT_GITHUB is required because this workflow runs in the context
+        # of a consumer app repo whose GITHUB_TOKEN is scoped to that repo and
+        # cannot read other org repos (even public ones via cross-repo reusable
+        # workflow invocations). An org PAT grants the necessary read access.
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           repository: atlanhq/application-sdk
@@ -410,7 +414,7 @@ jobs:
         id: sdk_install
         continue-on-error: true
         working-directory: sdk
-        run: uv sync --all-extras --all-groups
+        run: uv sync --all-extras
 
       - name: "v3 shape — check_migration"
         id: check_migration
@@ -450,8 +454,8 @@ jobs:
             exit 0
           fi
           uv run poe generate || { echo "::warning::'poe generate' failed"; exit 1; }
-          if ! git diff --exit-code -- app/generated/; then
-            echo "::warning::app/generated/ is stale — run 'poe generate' locally and commit."
+          if ! git diff --exit-code -- generated/; then
+            echo "::warning::generated/ is stale — run 'poe generate' locally and commit."
             exit 1
           fi
 
@@ -467,7 +471,7 @@ jobs:
             echo "No tests/unit/ — skipping."
             exit 0
           fi
-          uv run --with pytest-cov pytest tests/unit --cov=app --cov-report=term --data-file=.coverage
+          uv run --with pytest-cov pytest tests/unit --cov=app --cov-report=term
 
       - name: "Coverage threshold (>=85%)"
         id: coverage_threshold

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -446,33 +446,40 @@ jobs:
             exit 1
           fi
 
-      # ── 3. Unit tests + coverage ──────────────────────────────────────────────
-      - name: "Unit tests + coverage (>=85%)"
+      # ── 3. Unit tests (enforced) + coverage threshold (warn-only) ───────────────
+      - name: "Unit tests"
         id: unit
         continue-on-error: true
         working-directory: app
         run: |
           set -euo pipefail
           if [ ! -d tests/unit ]; then
-            echo "No tests/unit/ — skipping unit-coverage check."
+            echo "No tests/unit/ — skipping."
             exit 0
           fi
           uv sync --all-extras
-          uv run --with pytest-cov pytest tests/unit \
-            --cov=app --cov-report=term --cov-fail-under=85
+          uv run --with pytest-cov pytest tests/unit --cov=app --cov-report=term
+      - name: "Coverage threshold (>=85%)"
+        id: coverage_threshold
+        if: steps.unit.outcome == 'success'
+        continue-on-error: true
+        working-directory: app
+        run: |
+          set -euo pipefail
+          uv run coverage report --fail-under=85
 
       # ── Verdict ───────────────────────────────────────────────────────────────
-      # Unit tests + coverage now ENFORCE: a ❌ there exits non-zero, which trips
-      # `prepare`'s `if: !failure()` and skips build + publish. v3 shape and
-      # contract drift remain warn-only during rollout — they annotate but do
-      # not block (their enforcement-flip is tracked separately; contract drift
-      # still needs the pkl toolchain on the runner first).
+      # Unit test pass/fail (UT) ENFORCES: a ❌ exits non-zero, trips
+      # `prepare`'s `if: !failure()`, and skips build + publish.
+      # Coverage threshold (COV), v3 shape (CM), and contract drift (CD)
+      # are warn-only — they annotate but do not block.
       - name: Certification verdict
         if: always()
         env:
           CM: ${{ steps.check_migration.outcome }}
           CD: ${{ steps.contract_drift.outcome }}
           UT: ${{ steps.unit.outcome }}
+          COV: ${{ steps.coverage_threshold.outcome }}
           SDK_INSTALL: ${{ steps.sdk_install.outcome }}
         run: |
           set -euo pipefail
@@ -490,9 +497,10 @@ jobs:
             echo ""
             render "v3 shape (check_migration) — warn-only" "$CM"
             render "Contract drift (poe generate) — warn-only" "$CD"
-            render "Unit tests + coverage (>=85%) — warn-only" "$UT"
+            render "Unit tests — enforced" "$UT"
+            render "Coverage (>=85%) — warn-only" "$COV"
             echo ""
-            echo "All three checks are warn-only during rollout — a ❌ annotates but does not block. See [docs/standards/app-certification.md](https://github.com/atlanhq/application-sdk/blob/main/docs/standards/app-certification.md)."
+            echo "**Unit test pass/fail blocks publish on ❌.** Coverage threshold, v3 shape, and contract drift are warn-only during rollout. See [docs/standards/app-certification.md](https://github.com/atlanhq/application-sdk/blob/main/docs/standards/app-certification.md)."
           } >> "${GITHUB_STEP_SUMMARY}"
           if [ "$SDK_INSTALL" != "success" ]; then
             echo "::warning title=Certification incomplete::SDK install failed, so check_migration did not run."
@@ -500,8 +508,18 @@ jobs:
           if [ "$CM" = "failure" ] || [ "$CD" = "failure" ]; then
             echo "::warning title=Certification warning (warn-only)::v3 shape and/or contract drift failed; publish proceeded (warn-only)."
           fi
+          if [ "$COV" = "failure" ]; then
+            echo "::warning title=Certification warning (warn-only)::Coverage below 85%; publish proceeded (warn-only)."
+          fi
           if [ "$UT" = "failure" ]; then
-            echo "::warning title=Certification warning (warn-only)::Unit tests + coverage check failed; publish proceeded (warn-only)."
+            {
+              echo ""
+              echo "### ❌ Publish blocked — unit tests failed"
+              echo ""
+              echo "Fix the failing tests and re-run."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            echo "::error title=Publish blocked::Unit tests failed. Build and publish blocked."
+            exit 1
           fi
           exit 0
 

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -352,29 +352,10 @@ jobs:
           exit 1
 
   # ── Job 0c: App certification — generic readiness checks ──────────────────────
-  # Centralizes the certification layers that need NO per-app wiring, so every
-  # app is certified at publish time without editing its own workflows:
-  #   1. v3 shape         — tools.migrate_v3.check_migration (no deprecated
-  #                         imports, @task-only, typed Input/Output, …)
-  #   2. Contract drift   — `poe generate` must be a no-op vs the committed
-  #                         app/generated/ artifacts
-  #   3. Unit + coverage  — pytest tests/unit at the >=85% SDK coverage bar
-  #
-  # App-specific layers (integration, SDR, e2e/Playwright) are NOT run here —
-  # they need the app's own live stack + secrets and stay in the app's CI.
-  #
-  # Enforcement: layer 3 (unit tests + coverage) BLOCKS publish on ❌ — the
-  # verdict step exits non-zero, which trips `prepare`'s `if: !failure()` and
-  # skips build + publish. Layers 1 and 2 (v3 shape, contract drift) remain
-  # WARN-ONLY during rollout: each runs and annotates a verdict, but does not
-  # block (contract drift still needs the pkl toolchain on the runner before it
-  # can flip). See the "Certification verdict" step. Checks that don't apply to
-  # an app (no contract/app.pkl, no tests/unit, no poe) skip cleanly so
-  # non-conforming apps aren't hard-failed before they onboard. A single
-  # `app_install` step (id: app_install) runs `uv sync --all-extras` once;
-  # contract-drift and unit tests both depend on it and are skipped if it fails.
-  #
-  # Only runs when `publish: true`. See docs/standards/app-certification.md.
+  # Runs v3-shape, contract-drift, unit tests, and coverage against the checked-
+  # out app source before publish — no per-app wiring needed. Unit test pass/fail
+  # blocks publish; other layers annotate warn-only. Only when `publish: true`.
+  # See docs/standards/app-certification.md.
   certify:
     name: Certify app
     if: inputs.publish
@@ -386,9 +367,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
           path: app
-          # Full history so the contract-drift `git diff` compares against the
-          # committed tree rather than a shallow snapshot.
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Checkout application-sdk (migration tooling)
         # tools.migrate_v3 ships in the SDK repo, not the published package —
@@ -435,7 +414,7 @@ jobs:
         id: app_install
         continue-on-error: true
         working-directory: app
-        run: uv sync --all-extras
+        run: uv sync --all-extras --frozen
 
       # ── 3. Contract drift ─────────────────────────────────────────────────────
       - name: "Contract drift — poe generate must be a no-op"
@@ -480,6 +459,10 @@ jobs:
         working-directory: app
         run: |
           set -euo pipefail
+          if [ ! -f .coverage ]; then
+            echo "No .coverage data (unit tests skipped) — skipping threshold check."
+            exit 0
+          fi
           uv run coverage report --data-file=.coverage --fail-under=85
 
       # ── Verdict ───────────────────────────────────────────────────────────────
@@ -556,7 +539,7 @@ jobs:
     # enforces its unit + coverage check: a failing run exits non-zero, which
     # trips `failure()` here and correctly skips prepare → build → publish. Its
     # other layers (v3 shape, contract drift) stay warn-only (always exit 0) so
-    # they never trip this yet. `unit-tests-gate` is warn-only on this branch;
+    # they never trip this yet. `unit-tests-gate` is currently warn-only;
     # its enforcement-flip is tracked separately.
     if: ${{ !failure() && !cancelled() }}
     name: Prepare

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -490,9 +490,9 @@ jobs:
             echo ""
             render "v3 shape (check_migration) — warn-only" "$CM"
             render "Contract drift (poe generate) — warn-only" "$CD"
-            render "Unit tests + coverage (>=85%) — enforced" "$UT"
+            render "Unit tests + coverage (>=85%) — warn-only" "$UT"
             echo ""
-            echo "**Unit tests + coverage block publish on ❌.** v3 shape and contract drift remain warn-only during rollout — a ❌ there annotates but does not block. See [docs/standards/app-certification.md](https://github.com/atlanhq/application-sdk/blob/main/docs/standards/app-certification.md)."
+            echo "All three checks are warn-only during rollout — a ❌ annotates but does not block. See [docs/standards/app-certification.md](https://github.com/atlanhq/application-sdk/blob/main/docs/standards/app-certification.md)."
           } >> "${GITHUB_STEP_SUMMARY}"
           if [ "$SDK_INSTALL" != "success" ]; then
             echo "::warning title=Certification incomplete::SDK install failed, so check_migration did not run."
@@ -500,19 +500,8 @@ jobs:
           if [ "$CM" = "failure" ] || [ "$CD" = "failure" ]; then
             echo "::warning title=Certification warning (warn-only)::v3 shape and/or contract drift failed; publish proceeded (warn-only)."
           fi
-          # Unit tests + coverage enforce: block publish when they fail. The
-          # `unit` step keeps `continue-on-error` so this verdict can render the
-          # full summary first, then exit non-zero here. v3 shape (CM) and
-          # contract drift (CD) stay warn-only — only UT blocks.
           if [ "$UT" = "failure" ]; then
-            {
-              echo ""
-              echo "### ❌ Publish blocked — unit tests + coverage"
-              echo ""
-              echo "The centralized \`tests/unit\` + coverage (>=85%) check failed. Build and publish will not proceed until it passes. Fix the failing tests and re-run."
-            } >> "${GITHUB_STEP_SUMMARY}"
-            echo "::error title=Publish blocked::Unit tests + coverage check failed. Build and publish blocked."
-            exit 1
+            echo "::warning title=Certification warning (warn-only)::Unit tests + coverage check failed; publish proceeded (warn-only)."
           fi
           exit 0
 

--- a/docs/standards/app-certification.md
+++ b/docs/standards/app-certification.md
@@ -37,20 +37,27 @@ The generic layers above don't need to know anything about the app's workflows
 them means an app gets v3-shape, contract-drift, and unit-coverage certification
 for free, with zero changes to its repo.
 
-## Rollout — warn-only
+## Enforcement
 
-The `certify` job is **warn-only** during rollout, mirroring the unit-tests-gate
-convention:
+| Layer | Mode |
+|-------|------|
+| **Unit + coverage** | **Enforced** — a ❌ exits the verdict step non-zero and blocks publish. |
+| **v3 shape** | Warn-only — annotated, does not block. |
+| **Contract drift** | Warn-only — annotated, does not block. |
 
-- Every check runs and the verdict is annotated on the workflow summary.
-- The job **always exits 0**, so publish proceeds even on a ❌.
-- The enforcement-flip PR replaces the final `exit 0` in the
-  "Certification verdict" step with a non-zero exit when any check failed.
-  Because `prepare` already lists `certify` in its `needs:`, a failing
-  certify will then skip `prepare → build → publish` automatically.
+How blocking works: the "Certification verdict" step exits non-zero when the
+unit + coverage check fails. Because `prepare` already lists `certify` in its
+`needs:` (with `if: !failure()`), a failing certify skips `prepare → build →
+publish` automatically — at minute 0, before any build minutes are spent.
+
+v3 shape and contract drift stay warn-only during rollout: every check runs and
+the verdict is annotated on the workflow summary, but only the unit check exits
+non-zero. Flipping the remaining two is tracked separately (contract drift needs
+the pkl toolchain on the runner first — see the rollout gaps below).
 
 Checks that don't apply to an app skip cleanly (➖) so non-conforming apps are
-never hard-failed before they onboard.
+never hard-failed before they onboard. In particular, an app with no
+`tests/unit/` directory skips the unit check (➖) and is **not** blocked.
 
 ## Known rollout gaps (before enforcement)
 

--- a/docs/standards/app-certification.md
+++ b/docs/standards/app-certification.md
@@ -18,7 +18,8 @@ and runs:
 |-------|---------|------------|
 | **v3 shape** | `tools.migrate_v3.check_migration` — no deprecated imports, `@task`-only, typed `Input`/`Output`, async clients, … | SDK install fails (annotated as incomplete) |
 | **Contract drift** | `poe generate` must produce no diff vs the committed `app/generated/` artifacts | no `contract/app.pkl`, or `poe` unavailable |
-| **Unit + coverage** | `pytest tests/unit --cov=app --cov-fail-under=85` | no `tests/unit/` directory |
+| **Unit tests** | `pytest tests/unit --cov=app --cov-report=term` | no `tests/unit/` directory |
+| **Coverage threshold** | `coverage report --fail-under=85` | unit tests skipped or failed |
 
 These are the layers that are **identical for every app**. App-specific layers
 — integration, SDR, and e2e/Playwright — are **not** run here: they need the
@@ -39,25 +40,28 @@ for free, with zero changes to its repo.
 
 ## Enforcement
 
-All three layers are **warn-only** during the initial rollout — every check runs
-and the verdict is annotated on the workflow summary, but none exit non-zero or
-block publish.
-
 | Layer | Mode |
 |-------|------|
-| **Unit + coverage** | Warn-only — annotated, does not block. |
+| **Unit tests** | **Enforced** — a ❌ exits the verdict step non-zero and blocks publish. |
+| **Coverage threshold** | Warn-only — annotated, does not block. |
 | **v3 shape** | Warn-only — annotated, does not block. |
 | **Contract drift** | Warn-only — annotated, does not block. |
 
+Unit test pass/fail is enforced: consistent with the `unit-tests-gate` job
+(PR #1945), a failing test run blocks publish. Coverage threshold, v3 shape,
+and contract drift remain warn-only during rollout — every check runs and the
+verdict is annotated on the workflow summary, but only a test failure exits
+non-zero.
+
 Checks that don't apply to an app skip cleanly (➖) so non-conforming apps are
 never hard-failed before they onboard. In particular, an app with no
-`tests/unit/` directory skips the unit check (➖).
+`tests/unit/` directory skips both the unit and coverage checks (➖).
 
 ## Known rollout gaps (before enforcement)
 
-- **Coverage threshold fixed at 85%.** Before flipping unit + coverage to
-  enforcing, verify active connector repos meet this bar. Raise the enforcement
-  question in `#pod-app-distribution`.
+- **Coverage threshold fixed at 85%.** Before flipping to enforcing, verify
+  active connector repos meet this bar. Raise the enforcement question in
+  `#pod-app-distribution`.
 - **Contract drift needs the pkl toolchain.** If `poe generate` requires pkl
   and it isn't installed on the runner, the check is recorded as a failure.
   Installing pkl in the `certify` job is a prerequisite for flipping

--- a/docs/standards/app-certification.md
+++ b/docs/standards/app-certification.md
@@ -1,0 +1,76 @@
+# App Certification (centralized)
+
+The `build-and-publish-app.yaml` reusable workflow runs a **`certify`** job
+before it publishes a version. The job centralizes every certification layer
+that needs **no per-app wiring**, so every app is certified at publish time
+without editing its own workflows.
+
+Tracked under [DISTR-456 — App Certification Framework][distr-456].
+
+[distr-456]: https://linear.app/atlan-epd/issue/DISTR-456/app-certification-framework
+
+## What it checks
+
+The job checks out the app source (plus the SDK, for the migration tooling)
+and runs:
+
+| Layer | Command | Skips when |
+|-------|---------|------------|
+| **v3 shape** | `tools.migrate_v3.check_migration` — no deprecated imports, `@task`-only, typed `Input`/`Output`, async clients, … | SDK install fails (annotated as incomplete) |
+| **Contract drift** | `poe generate` must produce no diff vs the committed `app/generated/` artifacts | no `contract/app.pkl`, or `poe` unavailable |
+| **Unit + coverage** | `pytest tests/unit --cov=app --cov-fail-under=85` | no `tests/unit/` directory |
+
+These are the layers that are **identical for every app**. App-specific layers
+— integration, SDR, and e2e/Playwright — are **not** run here: they need the
+app's own live stack (databases, Dapr, Temporal) and secrets, so they stay in
+the app's own CI (`tests.yaml`, the marketplace-releases e2e reusables, …).
+
+## Why centralized (no per-app wiring)
+
+The earlier model required each app to opt in by passing
+`unit_tests_workflow_file` and adding a `workflow_dispatch:` trigger to its
+test workflow (see [`unit-tests-gate.md`](./unit-tests-gate.md)). That gate
+dispatches the app's **own** workflow, so it could only ever be opt-in.
+
+The generic layers above don't need to know anything about the app's workflows
+— the SDK can run them directly against the checked-out source. Centralizing
+them means an app gets v3-shape, contract-drift, and unit-coverage certification
+for free, with zero changes to its repo.
+
+## Rollout — warn-only
+
+The `certify` job is **warn-only** during rollout, mirroring the unit-tests-gate
+convention:
+
+- Every check runs and the verdict is annotated on the workflow summary.
+- The job **always exits 0**, so publish proceeds even on a ❌.
+- The enforcement-flip PR replaces the final `exit 0` in the
+  "Certification verdict" step with a non-zero exit when any check failed.
+  Because `prepare` already lists `certify` in its `needs:`, a failing
+  certify will then skip `prepare → build → publish` automatically.
+
+Checks that don't apply to an app skip cleanly (➖) so non-conforming apps are
+never hard-failed before they onboard.
+
+## Known rollout gaps (before enforcement)
+
+- **Contract drift needs the pkl toolchain.** If `poe generate` requires pkl
+  and it isn't installed on the runner, the check is recorded as a failure and
+  (while warn-only) annotated. Installing pkl in the `certify` job is a
+  prerequisite for flipping contract-drift to blocking.
+- **Coverage threshold is fixed at 85%.** Matches the SDK tooling threshold; if
+  an app legitimately needs a different bar, raise it in `#pod-app-distribution`
+  rather than weakening the gate.
+
+## Relationship to the other layers
+
+`certify` is one of the pre-build gates in `build-and-publish-app.yaml`:
+
+```
+validate-channel ─┐
+unit-tests-gate ──┤
+certify ──────────┴─> prepare ─> build ─> merge ─> security-scan ─> publish
+```
+
+It complements — does not replace — the image security scan
+(`build-and-scan.yaml`, Trivy + Snyk + allowlist), which runs after the build.

--- a/docs/standards/app-certification.md
+++ b/docs/standards/app-certification.md
@@ -39,35 +39,29 @@ for free, with zero changes to its repo.
 
 ## Enforcement
 
+All three layers are **warn-only** during the initial rollout — every check runs
+and the verdict is annotated on the workflow summary, but none exit non-zero or
+block publish.
+
 | Layer | Mode |
 |-------|------|
-| **Unit + coverage** | **Enforced** — a ❌ exits the verdict step non-zero and blocks publish. |
+| **Unit + coverage** | Warn-only — annotated, does not block. |
 | **v3 shape** | Warn-only — annotated, does not block. |
 | **Contract drift** | Warn-only — annotated, does not block. |
 
-How blocking works: the "Certification verdict" step exits non-zero when the
-unit + coverage check fails. Because `prepare` already lists `certify` in its
-`needs:` (with `if: !failure()`), a failing certify skips `prepare → build →
-publish` automatically — at minute 0, before any build minutes are spent.
-
-v3 shape and contract drift stay warn-only during rollout: every check runs and
-the verdict is annotated on the workflow summary, but only the unit check exits
-non-zero. Flipping the remaining two is tracked separately (contract drift needs
-the pkl toolchain on the runner first — see the rollout gaps below).
-
 Checks that don't apply to an app skip cleanly (➖) so non-conforming apps are
 never hard-failed before they onboard. In particular, an app with no
-`tests/unit/` directory skips the unit check (➖) and is **not** blocked.
+`tests/unit/` directory skips the unit check (➖).
 
 ## Known rollout gaps (before enforcement)
 
+- **Coverage threshold fixed at 85%.** Before flipping unit + coverage to
+  enforcing, verify active connector repos meet this bar. Raise the enforcement
+  question in `#pod-app-distribution`.
 - **Contract drift needs the pkl toolchain.** If `poe generate` requires pkl
-  and it isn't installed on the runner, the check is recorded as a failure and
-  (while warn-only) annotated. Installing pkl in the `certify` job is a
-  prerequisite for flipping contract-drift to blocking.
-- **Coverage threshold is fixed at 85%.** Matches the SDK tooling threshold; if
-  an app legitimately needs a different bar, raise it in `#pod-app-distribution`
-  rather than weakening the gate.
+  and it isn't installed on the runner, the check is recorded as a failure.
+  Installing pkl in the `certify` job is a prerequisite for flipping
+  contract-drift to blocking.
 
 ## Relationship to the other layers
 

--- a/docs/standards/unit-tests-gate.md
+++ b/docs/standards/unit-tests-gate.md
@@ -1,11 +1,19 @@
 # Unit-Tests Gate Contract
 
-The `build-and-publish-app.yaml` reusable workflow refuses to publish a version
-unless the app's `unit_tests_workflow_file` has completed successfully for the
+> **Most apps no longer need this.** The generic certification layers — v3
+> shape, contract drift, and **unit tests + coverage** — now run centrally in
+> the `certify` job with no per-app wiring. See
+> [`app-certification.md`](./app-certification.md). This gate remains for apps
+> that want the publish step to additionally block on their **own** test
+> workflow (e.g. integration/e2e jobs that the centralized job can't run).
+
+The `build-and-publish-app.yaml` reusable workflow can block a publish until
+the app's `unit_tests_workflow_file` has completed successfully for the
 publish SHA. The gate tracks runs by ID (not by check name), so apps don't
 need any particular naming convention on their test jobs.
 
-This document defines the contract every consumer repo must satisfy.
+This document defines the contract a consumer repo must satisfy **if it opts
+into this gate**.
 
 ## Why this exists
 
@@ -41,8 +49,8 @@ Tracked under [DISTR-456 — App Certification Framework][distr-456].
 
 ## Caller setup
 
-Every consumer of the SDK's `build-and-publish-app.yaml` MUST set
-`unit_tests_workflow_file`:
+To opt into this gate, a consumer of the SDK's `build-and-publish-app.yaml`
+sets `unit_tests_workflow_file`:
 
 ```yaml
 jobs:
@@ -50,12 +58,14 @@ jobs:
     uses: atlanhq/application-sdk/.github/workflows/build-and-publish-app.yaml@main
     with:
       publish: ${{ github.event.inputs.publish != 'false' }}
-      unit_tests_workflow_file: "unit-tests.yml"   # required
+      unit_tests_workflow_file: "unit-tests.yml"   # opt-in
     secrets: inherit
 ```
 
-Omitting this input is a startup-time error — `workflow_call` rejects the call
-because `unit_tests_workflow_file` has no default.
+The input is **optional** and defaults to `""`. When unset, this gate is
+**skipped entirely** — apps onboard at their own pace and existing callers are
+unaffected. (The generic unit-coverage check still runs in the centralized
+`certify` job regardless; see [`app-certification.md`](./app-certification.md).)
 
 ## Reference template — `.github/workflows/unit-tests.yml`
 
@@ -109,7 +119,7 @@ jobs:
 | Tests workflow already ran on this commit, still `in_progress` | Gate polls the existing run until completion |
 | Tests workflow has not run on this commit | Gate dispatches `unit_tests_workflow_file` on the publish ref and waits |
 | `unit_tests_workflow_file` doesn't exist / lacks `workflow_dispatch:` | Gate fails at dispatch with onboarding instructions |
-| `unit_tests_workflow_file` not set by caller | `workflow_call` fails immediately (no default) |
+| `unit_tests_workflow_file` not set by caller | Gate is skipped entirely (input defaults to `""`) |
 
 ## Branch publishes (`workflow_dispatch` from a feature branch)
 


### PR DESCRIPTION
## What

Adds a **`certify`** job to the `build-and-publish-app.yaml` reusable workflow that runs certification layers needing **no per-app wiring** against the checked-out app source, before publish:

| Layer | Command | Enforcement |
|-------|---------|-------------|
| **Unit tests** | `pytest tests/unit --cov=app --cov-report=term` | **Enforced** — blocks publish on ❌ |
| **Coverage threshold** | `coverage report --fail-under=85` | Warn-only — annotates, does not block |
| **v3 shape** | `tools.migrate_v3.check_migration` | Warn-only — annotates, does not block |
| **Contract drift** | `poe generate` must be a no-op vs committed `app/generated/` | Warn-only — annotates, does not block |

App-specific layers (integration, SDR, e2e/Playwright) are **not** run here — they need the app's own live stack + secrets and stay in the app's CI.

## Why

Previously the only test-at-publish mechanism was the opt-in `unit-tests-gate`, which dispatches the app's **own** workflow and therefore requires each app to pass `unit_tests_workflow_file` and add a `workflow_dispatch:` trigger. The generic layers don't need to know anything about an app's workflows, so the SDK can run them directly — every app gets certified with zero repo changes.

## Enforcement model

Unit test pass/fail is enforced, consistent with the `unit-tests-gate` already enforced by #1945. The two mechanisms are complementary: `unit-tests-gate` dispatches the app's own full test workflow; `certify` runs the unit tier directly without any per-app config.

Coverage threshold (>=85%), v3 shape, and contract drift remain warn-only during rollout — each check runs and annotates a verdict on the workflow summary, but only a test failure trips `prepare`'s `if: !failure()` guard and skips build + publish.

Checks skip cleanly (➖) when not applicable (no `tests/unit/`, no `contract/app.pkl`, no `poe`).

### Known gaps before further enforcement
- **Coverage threshold (85%):** verify active connector repos meet this bar before flipping to enforcing.
- **Contract drift:** needs the pkl toolchain on the runner first.

## Docs
- New `docs/standards/app-certification.md`.
- Fixes the stale claim in `unit-tests-gate.md` that omitting `unit_tests_workflow_file` is a startup error — it defaults to `""` and the gate skips cleanly.

## Test plan
- `pre-commit run --files` on all changed files → pass
- Functional validation on first warn-only run against a consuming app (no blocking risk by design)