### PR TITLE
ci: skip external Dapr/Temporal in connector-integration-tests on SDK >= 3.13

### DIFF
--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -113,7 +113,26 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
+    # SDK 3.13+ boots an embedded daprd + Temporal directly from
+    # `python main.py` (application_sdk/dev/_dapr.py + _embedded.py), each
+    # downloading its own runtime. On those versions the external Dapr CLI /
+    # Temporal CLI / `poe download-components` / `poe start-deps` below are
+    # redundant — worse, the embedded daprd roots its objectstore at
+    # ./local/objectstore while the external one roots at
+    # ./local/dapr/objectstore, so running both is a source of confusion.
+    # Detect the installed SDK version and skip the external infra when the
+    # embedded runtime is available. Pre-3.13 connectors still need it.
+    - name: Detect embedded runtime (SDK >= 3.13)
+      id: runtime
+      shell: bash
+      run: |
+        VER=$(uv run python -c "from importlib.metadata import version; print(version('atlan-application-sdk'))")
+        EMBEDDED=$(uv run python -c "import re; from importlib.metadata import version; m = re.match(r'(\d+)\.(\d+)', version('atlan-application-sdk')); print('true' if (int(m.group(1)), int(m.group(2))) >= (3, 13) else 'false')")
+        echo "embedded=${EMBEDDED}" >> "$GITHUB_OUTPUT"
+        echo "SDK ${VER} -> embedded runtime: ${EMBEDDED}"
+
     - name: Install Dapr CLI
+      if: steps.runtime.outputs.embedded != 'true'
       shell: bash
       run: |
         DAPR_VERSION="${{ inputs.dapr-version }}"
@@ -124,20 +143,24 @@ runs:
         dapr init --runtime-version "${DAPR_VERSION}" --slim
 
     - name: Install Temporal CLI
+      if: steps.runtime.outputs.embedded != 'true'
       shell: bash
       run: curl -sSf https://temporal.download/cli.sh | sh
 
     - name: Add Dapr and Temporal to PATH
+      if: steps.runtime.outputs.embedded != 'true'
       shell: bash
       run: |
         echo "$HOME/.dapr/bin" >> "$GITHUB_PATH"
         echo "$HOME/.temporalio/bin" >> "$GITHUB_PATH"
 
     - name: Download Dapr components
+      if: steps.runtime.outputs.embedded != 'true'
       shell: bash
       run: uv run poe download-components
 
     - name: Start Dapr + Temporal
+      if: steps.runtime.outputs.embedded != 'true'
       shell: bash
       run: |
         uv run poe start-deps

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.13.4
-source-sha:    0c04cac72bf1a000f31295f7f4818385c3ce530d
-source-date:   2026-05-29T23:38:58+01:00
+sdk-version:   3.14.0
+source-sha:    400e0a6a04a3f29708cde7cd5c64ee2158e85f0d
+source-date:   2026-05-30T00:33:05+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 


### PR DESCRIPTION
## Summary

The `connector-integration-tests` composite action (landed in #1862) sets up an **external** Dapr + Temporal (`poe download-components` → `poe start-deps`) and then starts the app with `python main.py`. On **SDK 3.13+**, `main.py` boots its **own embedded** daprd + Temporal (`application_sdk/dev/_dapr.py` + `_embedded.py`), each downloading its own runtime — so the external infra is redundant.

Worse, the two disagree on the objectstore root:

| Runtime | objectstore rootPath |
|---|---|
| External (`poe start-deps`, downloaded components) | `./local/dapr/objectstore` |
| Embedded daprd (3.13+, `embedded_dapr` default) | `./local/objectstore` |

Running both leaves two objectstores. A connector that bumps to 3.13 and whose integration tests still read `./local/dapr/objectstore` then fails with `FileNotFoundError: No data found in extracted directory …` even though extraction succeeded — the data went to `./local/objectstore`. (Observed and root-caused on `atlan-mssql-app` after its 3.13 bump.)

## Change

- Add a **Detect embedded runtime (SDK >= 3.13)** step that reads the installed `atlan-application-sdk` version.
- Gate the five external-infra steps (Install Dapr CLI, Install Temporal CLI, Add to PATH, Download components, Start deps) behind `steps.runtime.outputs.embedded != 'true'`.
- Pre-3.13 connectors are unaffected (external infra still runs); 3.13+ connectors rely on the embedded runtime only.

## Scope / non-goals

- This removes the **redundant/conflicting external Dapr**; it does **not** change *where* 3.13 connectors must read artifacts. Connector integration tests on 3.13+ should read `./local/objectstore` (as `atlan-mssql-app` now does). That path lives in connector test code, not in this action.
- `connector-unit-tests` is unchanged (no Dapr).

## Validation

- [ ] YAML lints; logic is `if:`-gated only — needs a real run to confirm. Best validated against a 3.13 connector (e.g. an `atlan-mssql-app` PR that adopts this action) **and** a pre-3.13 connector to confirm the external path still runs.
- [ ] Confirm `poe stop-deps || true` in Cleanup is a harmless no-op when deps were never started (it is — guarded by `|| true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)