### PR TITLE
ci: enforce unit-tests gate — block build & publish on failure

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -328,12 +328,11 @@ jobs:
           echo "::error title=Publish blocked::Tests run ${RUN_ID} did not complete within the gate timeout."
           exit 1
 
-      # TEMPORARY warn-only mode for the rollout window. The follow-up PR
-      # (DISTR-456 enforcement flip) restores `exit 1` so gate failure
-      # blocks publish. While in warn-only mode, the gate runs, the
-      # verdict is annotated on the workflow summary, but publish
-      # proceeds even on test failure.
-      - name: Annotate warning if tests did not succeed (warn-only)
+      # Enforcement (DISTR-456 flip): a non-success conclusion exits non-zero,
+      # so `prepare`'s `if: !failure()` skips the whole build + publish chain.
+      # The gate runs before any build minutes are spent, so a failing unit
+      # test surfaces at minute 0 rather than after the multi-arch build.
+      - name: Block publish if tests did not succeed
         if: steps.wait.outputs.conclusion != 'success'
         env:
           CONCLUSION: ${{ steps.wait.outputs.conclusion }}
@@ -341,15 +340,16 @@ jobs:
           WORKFLOW_FILE: ${{ inputs.unit_tests_workflow_file }}
         run: |
           {
-            echo "### ⚠️ Publish would be blocked once enforcement lands"
+            echo "### ❌ Publish blocked — unit tests did not pass"
             echo ""
             echo "Run of \`${WORKFLOW_FILE}\` concluded as \`${CONCLUSION}\`."
             echo ""
             echo "Failing run: ${URL}"
             echo ""
-            echo "**Currently warn-only — publish will proceed.** Once the enforcement-flip PR lands, this state will block publish. Fix the failing tests before then."
+            echo "Build and publish will not proceed until the unit-tests gate passes. Fix the failing tests and re-run."
           } >> "${GITHUB_STEP_SUMMARY}"
-          echo "::warning title=Tests failed (warn-only)::${WORKFLOW_FILE} concluded as ${CONCLUSION}. Publish proceeded; will block once enforcement lands. See: ${URL}"
+          echo "::error title=Publish blocked::${WORKFLOW_FILE} concluded as ${CONCLUSION}. Build and publish blocked. See: ${URL}"
+          exit 1
 
   # ── Job 1: Read atlan.yaml, validate secrets, compute all image tags ──────────
   prepare:


### PR DESCRIPTION
## What

Flips the **unit-tests gate** in `build-and-publish-app.yaml` from temporary **warn-only** mode to **enforcing** — a failing unit-tests run now **blocks build and publish**.

This is the DISTR-456 enforcement-flip that the gate's own comments and `docs/standards/unit-tests-gate.md` already anticipate.

## Why

The gate has been running in warn-only mode during rollout: it ran the app's `unit_tests_workflow_file`, annotated the verdict on the workflow summary, but exited `0` so publish proceeded **even on a failing test run**. An app could ship to production with broken unit tests.

## How

The gate's final step (`Block publish if tests did not succeed`) now `exit 1`s when the tests run concludes as anything other than `success`. That trips `prepare`'s `if: ${{ !failure() && !cancelled() }}` guard, which cascades through the `needs` chain so `prepare → build → merge → publish` all skip. The failure surfaces at minute 0, before any multi-arch build minutes are spent.

## Scope / blast radius

- **Opt-in, unchanged for non-onboarded apps.** The gate only runs when the caller sets `unit_tests_workflow_file` (and `publish: true`). Apps that haven't onboarded leave it unset → the gate stays skipped → no behaviour change.
- Matches the behaviour already documented in `docs/standards/unit-tests-gate.md` (which describes the gate as blocking), so no doc change is needed here.

## Note

A parallel change flips the centralized **`certify`** job's unit + coverage check to blocking too. That job is introduced by #1943 and doesn't exist on `main` yet, so it can't ride in this PR — it lands with/after #1943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)