### PR TITLE
ci: label-gate SDR integration tests behind `sdr-e2e-test`

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -315,14 +315,18 @@ jobs:
   # not openapi-app). Keeping them separate so the SDR path can grow
   # connectors independently of the legacy e2e path.
   #
-  # No label gate — the SDR connector suite (~3 min per app) auto-runs
-  # on every PR push so SDK changes are validated end-to-end against
-  # the connector fleet by default. Custom <repo>:<branch> labels
-  # still override the default matrix when a contributor wants to pin
-  # an alternate target branch for a specific connector.
+  # Label-gated on `sdr-e2e-test`. The SDR connector suite (~3 min per
+  # app) was previously auto-on, but the dispatched-from-SDK code path
+  # consistently red-failed inside atlan-configurator due to a CI
+  # secret gap (`atlan.client_secret: Client secret is required`) in
+  # downstream connector repos, blocking SDK PRs on environment state
+  # that's not part of any single PR's diff. Gating opt-in via the
+  # `sdr-e2e-test` label keeps the capability available while
+  # decoupling normal SDK PR signal from downstream secret health.
+  # Custom <repo>:<branch> labels still override the default matrix.
   sdr-matrix-builder:
     name: Build SDR Test Matrix
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'sdr-e2e-test')
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -388,10 +392,11 @@ jobs:
   sdr-e2e-apps:
     name: SDR Integration Tests (testcontainer) — ${{ matrix.repo_name }}
     needs: [changes, sdr-matrix-builder]
-    # No label gate — runs on every push to a non-fork, non-dependabot
-    # PR. ~3 min per connector and validates the SDR contract end-to-
-    # end, which is worth the spend on every SDK PR.
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true && github.event.pull_request.user.login != 'dependabot[bot]' && needs.changes.outputs.code == 'true'
+    # Label-gated on `sdr-e2e-test`. See the comment block on
+    # `sdr-matrix-builder` above for the rationale (downstream CI
+    # secret gap was making this red on every SDK PR). Add the label
+    # to opt a PR back in to end-to-end SDR validation.
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'sdr-e2e-test') && github.event.pull_request.head.repo.fork != true && github.event.pull_request.user.login != 'dependabot[bot]' && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.13.4
-source-sha:    0c04cac72bf1a000f31295f7f4818385c3ce530d
-source-date:   2026-05-29T23:38:58+01:00
+sdk-version:   3.14.0
+source-sha:    400e0a6a04a3f29708cde7cd5c64ee2158e85f0d
+source-date:   2026-05-30T00:33:05+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 


### PR DESCRIPTION
## Summary

Stop auto-running `SDR Integration Tests (testcontainer) — atlan-mysql-app` on every SDK PR. Gate both `sdr-matrix-builder` and `sdr-e2e-apps` behind the `sdr-e2e-test` label so the default SDK PR signal is decoupled from downstream secret health. The capability is preserved — adding the label opts a PR back into end-to-end SDR validation.

## Why

The dispatched-from-SDK code path of the SDR test has been consistently red-failing inside `atlan-configurator` on the downstream connector repo:

```
❌ Configuration validation failed:
   - atlan.client_secret: Client secret is required
##[error]Process completed with exit code 1.
```

Root cause: a CI secret gap in downstream connector repos. In `atlan-mysql-app`, `SDR_CLIENT_SECRET` has a repo-level override (set ~3 weeks ago) that shadows the org-level secret. When the workflow runs in the dispatched-from-SDK code path, `${{ secrets.SDR_CLIENT_SECRET }}` resolves to that empty/wrong override, the configurator validation rejects it, and the whole step fails. This is environment state — not anything in the SDK PR's diff.

The team has been merging through this red across multiple SDK PRs (e.g. #1941, #1939, #1938). Gating it makes the default state clean and the opt-in explicit.

## Behaviour change

| Before | After |
|---|---|
| Runs on every SDK PR push to a non-fork, non-dependabot PR. | Runs only when the PR has the `sdr-e2e-test` label. |
| `Custom <repo>:<branch>` labels override the default matrix (atlan-mysql-app). | Same — `sdr-e2e-test` flips the gate, `<repo>:<branch>` labels still customize the matrix. |
| Failures block merge for environment reasons. | No-op by default; explicit opt-in to validate. |

## Follow-up (not in this PR)

The underlying secret-gap fix lives in `atlan-mysql-app` repo settings — either:

- Update `SDR_CLIENT_SECRET` (and probably `SDR_CLIENT_ID`, `SDR_TEST_TENANT`) repo-level overrides with the current configurator OAuth values, or
- Delete the repo-level overrides so the org-level secrets take effect.

Both are admin actions, no code changes needed. Once the secret gap is closed and a few SDK PRs confirm the SDR path is green when opted in, we can flip the default back to "on" — restoring the original "auto-validate on every SDK PR" design intent if desired.

## Test plan

- [x] `uv run pre-commit run --files .github/workflows/pull_request.yaml` — all hooks pass
- [ ] After merge, verify `SDR Integration Tests (testcontainer) — atlan-mysql-app` does **not** appear on the next SDK PR's check list.
- [ ] On a PR with the `sdr-e2e-test` label applied, verify the check appears and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)