### PR TITLE
fix(dev): align embedded Dapr store roots with static components

### DIFF
--- a/application_sdk/dev/_dapr.py
+++ b/application_sdk/dev/_dapr.py
@@ -138,6 +138,9 @@ def _pick_free_port() -> int:
         return sock.getsockname()[1]
 
 
+DEFAULT_OBJECTSTORE_ROOT = "./local/dapr/objectstore"
+DEFAULT_EVENTSTORE_ROOT = "./local/dapr/eventstore"
+
 _COMPONENTS_YAML = {
     "statestore.yaml": """\
 apiVersion: dapr.io/v1alpha1
@@ -179,7 +182,7 @@ spec:
   version: v1
   metadata:
     - name: rootPath
-      value: {rootPath}
+      value: {objectstore_root}
 """,
     "eventstore.yaml": """\
 apiVersion: dapr.io/v1alpha1
@@ -191,18 +194,24 @@ spec:
   version: v1
   metadata:
     - name: rootPath
-      value: {rootPath}
+      value: {eventstore_root}
 """,
 }
 
 
-def _write_components(components_dir: Path, objectstore_root: Path) -> None:
+def _write_components(
+    components_dir: Path, objectstore_root: Path, eventstore_root: Path
+) -> None:
     """Write the auto-generated Dapr component YAMLs into *components_dir*."""
     components_dir.mkdir(parents=True, exist_ok=True)
     objectstore_root.mkdir(parents=True, exist_ok=True)
+    eventstore_root.mkdir(parents=True, exist_ok=True)
     for filename, template in _COMPONENTS_YAML.items():
         (components_dir / filename).write_text(
-            template.format(rootPath=str(objectstore_root.resolve()))
+            template.format(
+                objectstore_root=str(objectstore_root.resolve()),
+                eventstore_root=str(eventstore_root.resolve()),
+            )
         )
 
 
@@ -229,7 +238,8 @@ async def _wait_for_dapr_ready(http_port: int, timeout_s: float = 30.0) -> None:
 async def embedded_dapr(
     *,
     app_id: str = "atlan-app",
-    objectstore_root: str = "./local/objectstore",
+    objectstore_root: str = DEFAULT_OBJECTSTORE_ROOT,
+    eventstore_root: str = DEFAULT_EVENTSTORE_ROOT,
     log_level: str = "warn",
 ) -> AsyncIterator[EmbeddedDapr]:
     """Boot an embedded ``daprd`` for local app development.
@@ -238,8 +248,8 @@ async def embedded_dapr(
 
     * ``statestore`` — ``state.in-memory``
     * ``secretstore`` / ``deployment-secret-store`` — ``secretstores.local.env``
-    * ``objectstore`` / ``eventstore`` — ``bindings.localstorage`` rooted at
-      *objectstore_root*
+    * ``objectstore`` — ``bindings.localstorage`` rooted at *objectstore_root*
+    * ``eventstore`` — ``bindings.localstorage`` rooted at *eventstore_root*
 
     On entry the context manager sets ``DAPR_HTTP_PORT``, ``DAPR_GRPC_PORT``,
     and ``DAPR_COMPONENTS_PATH`` so callers (and any background observability
@@ -250,7 +260,7 @@ async def embedded_dapr(
     http_port = _pick_free_port()
     grpc_port = _pick_free_port()
     components_dir = Path(tempfile.mkdtemp(prefix="atlan-dapr-"))
-    _write_components(components_dir, Path(objectstore_root))
+    _write_components(components_dir, Path(objectstore_root), Path(eventstore_root))
 
     # Set env BEFORE spawning the subprocess so the observability sink's
     # flush cycle (which may fire during the ~3s daprd startup window) finds

--- a/application_sdk/dev/_dapr.py
+++ b/application_sdk/dev/_dapr.py
@@ -200,7 +200,9 @@ spec:
 
 
 def _write_components(
-    components_dir: Path, objectstore_root: Path, eventstore_root: Path
+    components_dir: Path,
+    objectstore_root: Path = Path(DEFAULT_OBJECTSTORE_ROOT),
+    eventstore_root: Path = Path(DEFAULT_EVENTSTORE_ROOT),
 ) -> None:
     """Write the auto-generated Dapr component YAMLs into *components_dir*."""
     components_dir.mkdir(parents=True, exist_ok=True)

--- a/components/eventstore.yaml
+++ b/components/eventstore.yaml
@@ -7,6 +7,7 @@ spec:
   type: bindings.localstorage
   ignoreErrors: true
   metadata:
+  # Must match DEFAULT_EVENTSTORE_ROOT in application_sdk/dev/_dapr.py
   - name: rootPath
     value: "./local/dapr/eventstore"
 

--- a/components/eventstore.yaml
+++ b/components/eventstore.yaml
@@ -7,9 +7,9 @@ spec:
   type: bindings.localstorage
   ignoreErrors: true
   metadata:
-  # Must match DEFAULT_EVENTSTORE_ROOT in application_sdk/dev/_dapr.py
-  - name: rootPath
-    value: "./local/dapr/eventstore"
+    # Must match DEFAULT_EVENTSTORE_ROOT in application_sdk/dev/_dapr.py
+    - name: rootPath
+      value: "./local/dapr/eventstore"
 
 # to test this with http binding - use this
 # apiVersion: dapr.io/v1alpha1

--- a/components/objectstore.yaml
+++ b/components/objectstore.yaml
@@ -7,5 +7,6 @@ spec:
   type: bindings.localstorage
   ignoreErrors: true
   metadata:
+    # Must match DEFAULT_OBJECTSTORE_ROOT in application_sdk/dev/_dapr.py
     - name: rootPath
       value: "./local/dapr/objectstore"

--- a/tests/unit/dev/test_dapr.py
+++ b/tests/unit/dev/test_dapr.py
@@ -122,10 +122,12 @@ class TestWriteComponents:
         objectstore_root = tmp_path / "objects" / "nested"
         eventstore_root = tmp_path / "events" / "nested"
         assert not objectstore_root.exists()
+        assert not eventstore_root.exists()
 
         _write_components(components_dir, objectstore_root, eventstore_root)
 
         assert objectstore_root.is_dir()
+        assert eventstore_root.is_dir()
 
 
 class TestPickFreePort:

--- a/tests/unit/dev/test_dapr.py
+++ b/tests/unit/dev/test_dapr.py
@@ -74,8 +74,9 @@ class TestWriteComponents:
     def test_writes_all_five_components(self, tmp_path: Path) -> None:
         components_dir = tmp_path / "components"
         objectstore_root = tmp_path / "objects"
+        eventstore_root = tmp_path / "events"
 
-        _write_components(components_dir, objectstore_root)
+        _write_components(components_dir, objectstore_root, eventstore_root)
 
         expected = sorted(_COMPONENTS_YAML.keys())
         actual = sorted(p.name for p in components_dir.iterdir())
@@ -84,21 +85,33 @@ class TestWriteComponents:
     def test_objectstore_root_substituted(self, tmp_path: Path) -> None:
         components_dir = tmp_path / "components"
         objectstore_root = tmp_path / "objects"
+        eventstore_root = tmp_path / "events"
 
-        _write_components(components_dir, objectstore_root)
+        _write_components(components_dir, objectstore_root, eventstore_root)
 
         content = (components_dir / "objectstore.yaml").read_text()
         assert str(objectstore_root.resolve()) in content
         assert "bindings.localstorage" in content
 
+    def test_eventstore_root_substituted(self, tmp_path: Path) -> None:
+        components_dir = tmp_path / "components"
+        objectstore_root = tmp_path / "objects"
+        eventstore_root = tmp_path / "events"
+
+        _write_components(components_dir, objectstore_root, eventstore_root)
+
+        content = (components_dir / "eventstore.yaml").read_text()
+        assert str(eventstore_root.resolve()) in content
+        assert "bindings.localstorage" in content
+
     def test_statestore_uses_in_memory(self, tmp_path: Path) -> None:
         components_dir = tmp_path / "components"
-        _write_components(components_dir, tmp_path / "objects")
+        _write_components(components_dir, tmp_path / "objects", tmp_path / "events")
         assert "state.in-memory" in (components_dir / "statestore.yaml").read_text()
 
     def test_secretstore_uses_local_env(self, tmp_path: Path) -> None:
         components_dir = tmp_path / "components"
-        _write_components(components_dir, tmp_path / "objects")
+        _write_components(components_dir, tmp_path / "objects", tmp_path / "events")
         assert (
             "secretstores.local.env"
             in (components_dir / "secretstore.yaml").read_text()
@@ -107,9 +120,10 @@ class TestWriteComponents:
     def test_objectstore_root_created(self, tmp_path: Path) -> None:
         components_dir = tmp_path / "components"
         objectstore_root = tmp_path / "objects" / "nested"
+        eventstore_root = tmp_path / "events" / "nested"
         assert not objectstore_root.exists()
 
-        _write_components(components_dir, objectstore_root)
+        _write_components(components_dir, objectstore_root, eventstore_root)
 
         assert objectstore_root.is_dir()
 


### PR DESCRIPTION
## Summary

- Defines `DEFAULT_OBJECTSTORE_ROOT` and `DEFAULT_EVENTSTORE_ROOT` as module-level constants in `application_sdk/dev/_dapr.py`, eliminating the path divergence between the embedded runtime (`./local/objectstore`) and the static component YAMLs (`./local/dapr/{objectstore,eventstore}`)
- Gives the two `bindings.localstorage` templates separate format keys (`{objectstore_root}` / `{eventstore_root}`) so eventstore gets its own dedicated directory rather than sharing objectstore's root
- Annotates `components/*.yaml` with cross-references to the constants so the coupling is visible to anyone editing either side

## Context

The embedded runtime (SDK 3.13+, `run_dev_combined`) was rooting both objectstore and eventstore at `./local/objectstore`, while the static Dapr component YAMLs used by `poe start-deps` used `./local/dapr/objectstore` and `./local/dapr/eventstore`. This caused `FileNotFoundError` in connectors running both runtimes simultaneously (e.g. in CI). The root fix is to align the paths at source rather than work around it with version-detection logic in CI.

## Test plan

- [ ] `uv run pre-commit run --files application_sdk/dev/_dapr.py` passes
- [ ] Local `run_dev_combined()` writes artifacts to `./local/dapr/objectstore` (matching `poe start-deps` path)
- [ ] Connector integration tests no longer produce `FileNotFoundError` on SDK 3.13+