### PR TITLE
chore(security): allowlist SNYK-GOLANG-GOLANGORGXNETIDNA-17116876 (Dapr base)

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Updated by SDK team. CODEOWNERS: SDK/security team only.",
   "_base_image": "application-sdk-main",
-  "_updated": "2026-05-09",
+  "_updated": "2026-06-02",
   "_renewal_note": "Expiry dates staggered by severity. CRITICAL: 15 days. HIGH: 30 days. Review before expiry. Enforced by .github/scripts/validate_allowlist.py via _expiry_policy below.",
   "_expiry_policy": {
     "CRITICAL": 15,
@@ -618,6 +618,17 @@
     "reason": "Upstream fix available but need immediate unblock for v2.x.x releases for SDR locked app releases.",
     "expires": "2026-06-09",
     "added_by": "adityachoudhury-cloud",
+    "fix_available_date": null,
+    "compensating_controls": null,
+    "re_evaluation_trigger": "expiry",
+    "exposure_assessment": null
+  },
+  "SNYK-GOLANG-GOLANGORGXNETIDNA-17116876": {
+    "package": "golang.org/x/net/idna",
+    "severity": "CRITICAL",
+    "reason": "Base image - Dapr runtime dependency. Fix (v0.54.0) lands when Dapr's daprd is rebuilt with the upstream golang.org/x/net bump; until then no actionable change in the SDK or downstream connectors.",
+    "expires": "2026-06-17",
+    "added_by": "tejeshallampati-alt",
     "fix_available_date": null,
     "compensating_controls": null,
     "re_evaluation_trigger": "expiry",


### PR DESCRIPTION
CRITICAL Snyk finding in `golang.org/x/net/idna@v0.53.0`, bundled into the daprd binary inside `app-runtime-base`. Fix (v0.54.0) lands when Dapr's daprd is rebuilt with the upstream `golang.org/x/net` bump; no actionable change exists in the SDK or downstream connectors until then.

Currently failing the Security Gate across:
- atlanhq/atlan-looker-app#106
- atlanhq/atlan-publish-app#656 / #679 / #684 / #683
- atlanhq/atlan-fabric-app#102
- atlanhq/atlan-anomalo-app#35

15-day expiry per `_expiry_policy.CRITICAL`.

Approvers: @cmgrote @mananjain99 @gaurav-atlan @Aryamanz29 — could one of you take a look so we can unblock the fleet?
