### PR TITLE
chore(observability): logging-hygiene fixes from signal-over-noise audit

### DIFF
--- a/application_sdk/execution/_temporal/backend.py
+++ b/application_sdk/execution/_temporal/backend.py
@@ -349,7 +349,7 @@ async def _prefer_v4_target(target_host: str) -> tuple[str, str | None]:
     try:
         ipaddress.ip_address(host_stripped)
     except ValueError:
-        pass
+        pass  # not a literal IP — fall through to DNS resolution below
     else:
         # Already a literal IP — no resolution to do, no SNI to preserve.
         return target_host, None

--- a/application_sdk/execution/_temporal/interceptors/log.py
+++ b/application_sdk/execution/_temporal/interceptors/log.py
@@ -122,6 +122,9 @@ def _failure_details_from_detail(detail: Any) -> dict[str, str]:
             "failure.code": fd.code,
         }
     except Exception:
+        logger.debug(
+            "Failed to extract failure details for log enrichment", exc_info=True
+        )
         return {}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -289,6 +289,7 @@ extend-select = [
     "PLC0415", # imports must be at top of module — prevents broken-import-at-runtime bugs (e.g. PR #1543)
     "S110",    # try-except-pass detected
     "S112",    # try-except-continue detected
+    "LOG009",  # logger.warn() is deprecated — use .warning()
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
## Summary

Three minor logging-hygiene improvements surfaced by running `/signal-over-noise` (both `--mode surface` and `--mode tune`) against `main`.

- **`interceptors/log.py`** — `_failure_details_from_detail()` previously caught any model-validation error and silently returned `{}`. Added a single `logger.debug("Failed to extract failure details for log enrichment", exc_info=True)` before the return so the failure is observable without flooding the log stream (this is on the log-enrichment path, so DEBUG is intentional).
- **`backend.py`** — `_resolve_host_to_ip()` uses the classic `try / except ValueError: pass / else: return` idiom around `ipaddress.ip_address()` to detect literal-IP targets. Added a single inline comment on the `pass` so future readers immediately recognize the pattern as control-flow-by-exception rather than a silent error swallow.
- **`pyproject.toml`** — added `LOG009` (`logger.warn()` is deprecated, use `.warning()`) to the existing ruff `extend-select` list. Zero current violations — this is a regression guard alongside the already-enabled `G001`, `G003`, `G004`, `T201`, `S110`, `S112`.

The audit otherwise found zero CRITICAL/HIGH issues. The codebase's `# noqa: S110 / BLE001 — <reason>` discipline, the `_safe_log()` Temporal-workflow helper, the `_handle_redis_error()` re-raising helper, and the `_format_printf_args` %-style bridge in `logger_adaptor.py` already handle the patterns this skill looks for.

## Test plan

- [ ] `uv run pre-commit run --files application_sdk/execution/_temporal/interceptors/log.py application_sdk/execution/_temporal/backend.py pyproject.toml` passes locally (ruff, ruff-format, isort, pyright all green)
- [ ] CI green on the new branch
- [ ] No runtime behavior change in the IP-literal detection path (comment-only)
- [ ] DEBUG log in `_failure_details_from_detail` only fires when an `ApplicationError.details` payload fails Pydantic validation — verify it's quiet on normal Temporal workflow execution