### PR TITLE
fix(storage): preserve ObjectStoreReadError classification in _download_files

### DIFF
--- a/application_sdk/storage/formats/format_errors.py
+++ b/application_sdk/storage/formats/format_errors.py
@@ -88,11 +88,20 @@ class UnsupportedFileExtensionError(InvalidInputError):
 
 @dataclass(kw_only=True)
 class ObjectStoreReadError(DependencyUnavailableError):
-    """Files were downloaded from the object store but no matching files were found."""
+    """Object store listing returned no files matching the expected extension.
+
+    Surfaces the prefix that was searched so operators can immediately tell
+    whether the upstream task wrote to the wrong path, was skipped entirely,
+    or if the configured prefix on this read side is wrong.
+    """
 
     code: ClassVar[str] = "DEPENDENCY_UNAVAILABLE_OBJECT_STORE_READ"
-    message: str = "Downloaded from object store but no matching files found"
+    message: str = (
+        "No matching files found in object store — verify the upstream task "
+        "wrote to this prefix and that the configured prefix is correct"
+    )
     service: str | None = "object_store"
+    path: str | None = None
     file_extension: str | None = None
 
 

--- a/application_sdk/storage/formats/format_errors.py
+++ b/application_sdk/storage/formats/format_errors.py
@@ -96,9 +96,10 @@ class ObjectStoreReadError(DependencyUnavailableError):
     """
 
     code: ClassVar[str] = "DEPENDENCY_UNAVAILABLE_OBJECT_STORE_READ"
-    message: str = (
-        "No matching files found in object store — verify the upstream task "
-        "wrote to this prefix and that the configured prefix is correct"
+    message: str = "No matching files found in object store."
+    suggested_action: str | None = (
+        "Verify the upstream task wrote to this prefix and that the "
+        "configured prefix is correct."
     )
     service: str | None = "object_store"
     path: str | None = None

--- a/application_sdk/storage/formats/utils.py
+++ b/application_sdk/storage/formats/utils.py
@@ -183,6 +183,7 @@ async def _download_files(
             return downloaded_paths
 
         raise ObjectStoreReadError(
+            path=path,
             file_extension=file_extension,
         )
 

--- a/application_sdk/storage/formats/utils.py
+++ b/application_sdk/storage/formats/utils.py
@@ -7,6 +7,10 @@ from typing import TYPE_CHECKING, Any, Union
 from application_sdk.constants import TEMPORARY_PATH
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.storage.batch import list_keys as _list_keys
+from application_sdk.storage.formats.format_errors import (
+    ObjectStoreDownloadError,
+    ObjectStoreReadError,
+)
 from application_sdk.storage.ops import _resolve_store, normalize_key
 from application_sdk.storage.transfer import _download_one
 
@@ -177,20 +181,17 @@ async def _download_files(
                 file_extension,
             )
             return downloaded_paths
-        else:
-            from application_sdk.storage.formats.format_errors import (  # noqa: PLC0415
-                ObjectStoreReadError,
-            )
 
-            raise ObjectStoreReadError(
-                file_extension=file_extension,
-            )
-
-    except Exception as e:
-        from application_sdk.storage.formats.format_errors import (  # noqa: PLC0415
-            ObjectStoreDownloadError,
+        raise ObjectStoreReadError(
+            file_extension=file_extension,
         )
 
+    except ObjectStoreReadError:
+        # READ error means files were downloaded but none matched the expected
+        # extension — preserve the READ classification instead of letting the
+        # broad ``except Exception`` below re-wrap it as a DOWNLOAD failure.
+        raise
+    except Exception as e:
         raise ObjectStoreDownloadError(
             path=path,
             file_extension=file_extension,

--- a/tests/unit/storage/formats/readers/test_json_reader.py
+++ b/tests/unit/storage/formats/readers/test_json_reader.py
@@ -209,6 +209,10 @@ async def test_no_matching_files_surfaces_read_error_not_download_error() -> Non
             await _download_files(path, ".json", None)
         assert exc_info.value.code == "DEPENDENCY_UNAVAILABLE_OBJECT_STORE_READ"
         assert not isinstance(exc_info.value, ObjectStoreDownloadError)
+        # Operator-visible fields: prefix + extension must round-trip so the
+        # alert tells you exactly what was searched.
+        assert exc_info.value.path == path
+        assert exc_info.value.file_extension == ".json"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/storage/formats/readers/test_json_reader.py
+++ b/tests/unit/storage/formats/readers/test_json_reader.py
@@ -174,6 +174,43 @@ async def test_download_file_error_propagation() -> None:
         assert exc_info.value.code == "DEPENDENCY_UNAVAILABLE_OBJECT_STORE_DOWNLOAD"
 
 
+@pytest.mark.asyncio
+async def test_no_matching_files_surfaces_read_error_not_download_error() -> None:
+    """Empty prefix listing must raise ObjectStoreReadError, not ObjectStoreDownloadError.
+
+    Regression guard for the classification bug where the broad ``except Exception``
+    around the prefix-listing path swallowed the typed ``ObjectStoreReadError`` and
+    re-wrapped it as ``ObjectStoreDownloadError`` — producing the mismatched
+    ``DEPENDENCY_UNAVAILABLE_OBJECT_STORE_DOWNLOAD`` code + "Downloaded but no
+    matching files found" message seen in production.
+    """
+    from application_sdk.storage.formats.format_errors import (
+        ObjectStoreDownloadError,
+        ObjectStoreReadError,
+    )
+
+    path = "/local"
+
+    with (
+        patch("os.path.isfile", return_value=False),
+        patch("os.path.isdir", return_value=True),
+        patch("glob.glob", return_value=[]),
+        patch(
+            "application_sdk.storage.formats.utils._resolve_store",
+            return_value=_MOCK_STORE,
+        ),
+        patch(
+            "application_sdk.storage.formats.utils._list_keys",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        with pytest.raises(ObjectStoreReadError) as exc_info:
+            await _download_files(path, ".json", None)
+        assert exc_info.value.code == "DEPENDENCY_UNAVAILABLE_OBJECT_STORE_READ"
+        assert not isinstance(exc_info.value, ObjectStoreDownloadError)
+
+
 # ---------------------------------------------------------------------------
 # Pandas-related helpers & tests
 # ---------------------------------------------------------------------------

--- a/tests/unit/storage/formats/readers/test_json_reader.py
+++ b/tests/unit/storage/formats/readers/test_json_reader.py
@@ -213,6 +213,10 @@ async def test_no_matching_files_surfaces_read_error_not_download_error() -> Non
         # alert tells you exactly what was searched.
         assert exc_info.value.path == path
         assert exc_info.value.file_extension == ".json"
+        # `message` states what happened; `suggested_action` states what to
+        # do — kept separate per the AppError contract.
+        assert exc_info.value.suggested_action is not None
+        assert "upstream" in exc_info.value.suggested_action.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the mismatched `DEPENDENCY_UNAVAILABLE_OBJECT_STORE_DOWNLOAD` code paired with `"Downloaded from object store but no matching files found"` message observed in production on the sap-hana connector.

### Root cause

`application_sdk/storage/formats/utils.py:_download_files` had:

```python
try:
    # ... list_keys + download_one loop ...
    if downloaded_paths:
        return downloaded_paths
    raise ObjectStoreReadError(file_extension=file_extension)   # READ code
except Exception as e:
    raise ObjectStoreDownloadError(cause=e, ...) from e          # DOWNLOAD code
```

The `else:` branch raised `ObjectStoreReadError` (`..._READ` / "Downloaded but no matching files found"), but the outer `except Exception` caught it and re-wrapped it as `ObjectStoreDownloadError` (`..._DOWNLOAD` / "No files found locally and failed to download…"). The wire-rendering pipeline then surfaced the **cause's** message but the **outer error's** code — exactly the production mismatch.

Operationally this matters because `DEPENDENCY_UNAVAILABLE` implies infra/SRE attention (object store down, auth broken), whereas the actual condition was "files downloaded but none had the expected extension" — a data-shape / empty-result condition, not an infra failure.

## Fix

- Add `except ObjectStoreReadError: raise` ahead of the broad `except Exception` so the typed READ classification is preserved.
- Hoist both `ObjectStoreReadError` / `ObjectStoreDownloadError` imports from lazy `# noqa: PLC0415` to module-level, since the catch clause now references the name outside the try body.

## Test

Adds `test_no_matching_files_surfaces_read_error_not_download_error` as a regression guard: mocks `_list_keys` returning `[]` and asserts the result is `ObjectStoreReadError` (code `DEPENDENCY_UNAVAILABLE_OBJECT_STORE_READ`), not `ObjectStoreDownloadError`.

## Test plan

- [x] `uv run pytest tests/unit/storage/formats/readers/test_json_reader.py` — 20 passed
- [x] `uv run pytest tests/unit/storage/formats/` — 147 passed, 3 skipped
- [x] pre-commit clean on changed files (ruff, ruff-format, isort, pyright)
- [ ] CI green
- [ ] Verify post-merge: sap-hana production alert now reports `DEPENDENCY_UNAVAILABLE_OBJECT_STORE_READ` (or, if the underlying condition was genuine, `..._DOWNLOAD` with a download-failure message — no longer mixed)

## Caller impact

All callers (`storage/formats/json.py`, `storage/formats/parquet.py`) catch via the parent `DependencyUnavailableError` hierarchy or via `Exception`. No call site explicitly catches `ObjectStoreDownloadError` only, so no downstream changes are required.