### PR TITLE
ci: disable unit-tests-gate in favor of certify job

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -204,7 +204,12 @@ jobs:
   # `unit_tests_workflow_file` — apps that have not onboarded skip the gate.
   unit-tests-gate:
     name: Unit-tests gate
-    if: inputs.publish && inputs.unit_tests_workflow_file != ''
+    # Permanently disabled (#1943): unit-test enforcement now lives in the
+    # `certify` job, which runs the app's tests directly. The job body and the
+    # `unit_tests_workflow_file` input are retained for backward compatibility
+    # — callers that still pass the input validate fine and the value is simply
+    # ignored, so nothing fails hard. Revert this line to re-enable the gate.
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## What

Neutralizes the `unit-tests-gate` job in `build-and-publish-app.yaml` by setting `if: false`, so it is always skipped.

```yaml
  unit-tests-gate:
    name: Unit-tests gate
    if: false        # was: inputs.publish && inputs.unit_tests_workflow_file != ''
```

## Why

The `unit-tests-gate` (DISTR-456, #1774) is superseded by the `certify` job added in #1943, which runs the app's unit tests directly. Running both is redundant.

## Backward compatibility — no hard failures

This is deliberately a one-line, soft disable rather than a removal:

- The **`unit_tests_workflow_file` input stays defined**. Removing it would cause any caller still passing it via `with:` to fail reusable-workflow input validation at startup (a hard config error). Keeping it means callers that pass it validate fine and the value is simply ignored.
- The **job body is retained** for easy revert — flip the single `if:` line back to re-enable.
- **`prepare` already tolerates a skipped dependency** via `if: ${{ !failure() && !cancelled() }}`, so `build` / `publish` proceed normally.

## Behavior change to flag

Any app that today sets `unit_tests_workflow_file` expecting it to *block* publish will no longer be gated by this job. That enforcement now lives in `certify`. Intended consolidation, called out for reviewers.