### PR TITLE
fix(contract-toolkit): emit lint-clean generated input contracts

### DIFF
--- a/contract-toolkit/examples/bundle/app/generated/crawler/_input.py
+++ b/contract-toolkit/examples/bundle/app/generated/crawler/_input.py
@@ -1,7 +1,9 @@
 # AUTO-GENERATED from contract/app.pkl — DO NOT EDIT MANUALLY.
 # To regenerate: pkl eval -m . contract/app.pkl
 from __future__ import annotations
+
 from typing import ClassVar
+
 from application_sdk.credentials.ref import CredentialRef
 from application_sdk.templates.contracts import ExtractionInput
 

--- a/contract-toolkit/examples/bundle/app/generated/miner/_input.py
+++ b/contract-toolkit/examples/bundle/app/generated/miner/_input.py
@@ -1,6 +1,7 @@
 # AUTO-GENERATED from contract/app.pkl — DO NOT EDIT MANUALLY.
 # To regenerate: pkl eval -m . contract/app.pkl
 from __future__ import annotations
+
 from application_sdk.templates.contracts import ExtractionInput
 
 

--- a/contract-toolkit/examples/connection-ref/app/generated/_input.py
+++ b/contract-toolkit/examples/connection-ref/app/generated/_input.py
@@ -1,10 +1,12 @@
 # AUTO-GENERATED from contract/app.pkl — DO NOT EDIT MANUALLY.
 # To regenerate: pkl eval -m . contract/app.pkl
 from __future__ import annotations
-from typing import Annotated, Any, ClassVar
+
+from typing import Annotated
+
 from pydantic import Field
-from application_sdk.contracts.types import ConnectionRef, FileReference, MaxItems
-from application_sdk.credentials.ref import CredentialRef
+
+from application_sdk.contracts.types import ConnectionRef, MaxItems
 from application_sdk.templates.contracts import ExtractionInput
 
 

--- a/contract-toolkit/examples/deploy/app/generated/_input.py
+++ b/contract-toolkit/examples/deploy/app/generated/_input.py
@@ -1,10 +1,7 @@
 # AUTO-GENERATED from contract/app.pkl — DO NOT EDIT MANUALLY.
 # To regenerate: pkl eval -m . contract/app.pkl
 from __future__ import annotations
-from typing import Annotated, Any, ClassVar
-from pydantic import Field
-from application_sdk.contracts.types import ConnectionRef, FileReference, MaxItems
-from application_sdk.credentials.ref import CredentialRef
+
 from application_sdk.templates.contracts import ExtractionInput
 
 

--- a/contract-toolkit/examples/fanin/app/generated/_input.py
+++ b/contract-toolkit/examples/fanin/app/generated/_input.py
@@ -1,9 +1,9 @@
 # AUTO-GENERATED from contract/app.pkl — DO NOT EDIT MANUALLY.
 # To regenerate: pkl eval -m . contract/app.pkl
 from __future__ import annotations
-from typing import Annotated, Any, ClassVar
-from pydantic import Field
-from application_sdk.contracts.types import ConnectionRef, FileReference, MaxItems
+
+from typing import ClassVar
+
 from application_sdk.credentials.ref import CredentialRef
 from application_sdk.templates.contracts import ExtractionInput
 

--- a/contract-toolkit/examples/full/app/generated/_input.py
+++ b/contract-toolkit/examples/full/app/generated/_input.py
@@ -1,10 +1,13 @@
 # AUTO-GENERATED from contract/app.pkl — DO NOT EDIT MANUALLY.
 # To regenerate: pkl eval -m . contract/app.pkl
 from __future__ import annotations
+
 import json
 from typing import Annotated, Any, ClassVar
+
 from pydantic import Field, field_validator
-from application_sdk.contracts.types import ConnectionRef, FileReference, MaxItems
+
+from application_sdk.contracts.types import MaxItems
 from application_sdk.credentials.ref import CredentialRef
 from application_sdk.templates.contracts import ExtractionInput
 

--- a/contract-toolkit/examples/minimal/app/generated/_input.py
+++ b/contract-toolkit/examples/minimal/app/generated/_input.py
@@ -1,10 +1,7 @@
 # AUTO-GENERATED from contract/app.pkl — DO NOT EDIT MANUALLY.
 # To regenerate: pkl eval -m . contract/app.pkl
 from __future__ import annotations
-from typing import Annotated, Any, ClassVar
-from pydantic import Field
-from application_sdk.contracts.types import ConnectionRef, FileReference, MaxItems
-from application_sdk.credentials.ref import CredentialRef
+
 from application_sdk.templates.contracts import ExtractionInput
 
 

--- a/contract-toolkit/examples/publish-controls/app/generated/_input.py
+++ b/contract-toolkit/examples/publish-controls/app/generated/_input.py
@@ -1,9 +1,7 @@
 # AUTO-GENERATED from contract/app.pkl — DO NOT EDIT MANUALLY.
 # To regenerate: pkl eval -m . contract/app.pkl
 from __future__ import annotations
-from typing import Annotated, Any, ClassVar
-from pydantic import Field
-from application_sdk.contracts.types import ConnectionRef, FileReference, MaxItems
+
 from application_sdk.credentials.ref import CredentialRef
 from application_sdk.templates.contracts import ExtractionInput
 

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -2209,6 +2209,13 @@ local credentialConfigOutput: FileOutput = new FileOutput {
 
 local function toPyName(k: String): String = k.replaceAll("-", "_")
 
+local function getPyDefaultFactoryField(k: String, fieldType: String, factory: String): String =
+  let (line = "\(k): \(fieldType) = Field(default_factory=\(factory))")
+  if (line.length <= 84)
+    line
+  else
+    "\(k): \(fieldType) = Field(\n        default_factory=\(factory)\n    )"
+
 local function getInputPyField(k: String, u: Widgets.UIElement): String =
   let (k = toPyName(k))
   if (u is Widgets.BooleanInput)
@@ -2225,7 +2232,7 @@ local function getInputPyField(k: String, u: Widgets.UIElement): String =
     "\(k): ConnectionRef | None = None"
   else if (u is Widgets.ConnectionRefInput)
     (if ((u as Widgets.ConnectionRefInput).multiSelect)
-      "\(k): Annotated[list[ConnectionRef], MaxItems(1000)] = Field(default_factory=list)"
+      getPyDefaultFactoryField(k, "Annotated[list[ConnectionRef], MaxItems(1000)]", "list")
     else
       "\(k): ConnectionRef | None = None")
   else if (u is Widgets.ConnectionSelector)
@@ -2235,12 +2242,12 @@ local function getInputPyField(k: String, u: Widgets.UIElement): String =
   else if (u is Widgets.PasswordInput)
     "\(k): str = \"\""
   else if (u is Widgets.TagsInput)
-    "\(k): Annotated[list[str], MaxItems(1000)] = Field(default_factory=list)"
+    getPyDefaultFactoryField(k, "Annotated[list[str], MaxItems(1000)]", "list")
   else if (u is Widgets.InputRepeater)
-    "\(k): Annotated[list[str], MaxItems(1000)] = Field(default_factory=list)"
+    getPyDefaultFactoryField(k, "Annotated[list[str], MaxItems(1000)]", "list")
   else if (u is Widgets.DropDown)
     (if ((u as Widgets.DropDown).multiSelect)
-      "\(k): Annotated[list[str], MaxItems(1000)] = Field(default_factory=list)"
+      getPyDefaultFactoryField(k, "Annotated[list[str], MaxItems(1000)]", "list")
     else
       "\(k): str = \"\(if ((u as Widgets.DropDown).default != null) (u as Widgets.DropDown).default!! else "")\"")
   else if (u is Widgets.Radio)
@@ -2260,16 +2267,16 @@ local function getInputPyField(k: String, u: Widgets.UIElement): String =
   else if (u is Widgets.ConditionalInput)
     (let (ci = u as Widgets.ConditionalInput)
       if (ci.outputValueType == "object")
-        "\(k): Annotated[dict[str, Any], MaxItems(1000)] = Field(default_factory=dict)"
+        getPyDefaultFactoryField(k, "Annotated[dict[str, Any], MaxItems(1000)]", "dict")
       else
         "\(k): str = \"\(if (ci.default != null) ci.default!!.toString() else "")\"")
   else if (u is Widgets.SqlTree)
     // Values are bounded strings (schema names / JSON-encoded selections); `str` avoids
     // the SDK's AAF-CTR-002 rejection of `Any`.  Pydantic's lax mode coerces non-string
     // leaf values (e.g. booleans) to str during model construction.
-    "\(k): Annotated[dict[str, str], MaxItems(1000)] = Field(default_factory=dict)"
+    getPyDefaultFactoryField(k, "Annotated[dict[str, str], MaxItems(1000)]", "dict")
   else if (u is Widgets.NestedInput || u is Widgets.APITree || u is Widgets.ApiTreeSelect || u is Widgets.DsnTreeMap || u is Widgets.AgentSelector)
-    "\(k): Annotated[dict[str, Any], MaxItems(1000)] = Field(default_factory=dict)"
+    getPyDefaultFactoryField(k, "Annotated[dict[str, Any], MaxItems(1000)]", "dict")
   else
     "\(k): str = \"\""
 
@@ -2339,6 +2346,8 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
     "                return parsed\n" +
     "        return value\n\n"
   else ""
+  local objectStringCoercionSeparator: String =
+    if (!uiFieldLines.isEmpty && !objectStringCoercionBlock.isEmpty) "\n" else ""
   local credFieldLine: String = if (credentialFieldName != null && !skipFields.contains(credentialFieldName!!))
     "    \(credentialFieldName!!): CredentialRef | None = None\n"
   else ""
@@ -2382,20 +2391,64 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
   local classBody: String =
     publishHashExcludeBlock +
     uiFieldLines +
+    objectStringCoercionSeparator +
     objectStringCoercionBlock +
     credFieldLine +
     publishFieldBlock
+  local usesAnnotated: Boolean = uiFieldLines.contains("Annotated[")
+  local usesAny: Boolean = uiFieldLines.contains("Any") || !objectStringCoercionFields.isEmpty
+  local usesClassVar: Boolean = includePublishInputFields
+  local typingImports: List<String> = (new Listing {
+    when (usesAnnotated) {
+      "Annotated"
+    }
+    when (usesAny) {
+      "Any"
+    }
+    when (usesClassVar) {
+      "ClassVar"
+    }
+  }).toList()
+  local stdlibImportLines: String =
+    (if (!objectStringCoercionFields.isEmpty) "import json\n" else "") +
+    (if (!typingImports.isEmpty) "from typing import \(typingImports.join(", "))\n" else "")
+  local pydanticImports: List<String> = (new Listing {
+    when (uiFieldLines.contains("Field(")) {
+      "Field"
+    }
+    when (!objectStringCoercionFields.isEmpty) {
+      "field_validator"
+    }
+  }).toList()
+  local pydanticImportLines: String =
+    if (!pydanticImports.isEmpty) "from pydantic import \(pydanticImports.join(", "))\n" else ""
+  local sdkTypeImports: List<String> = (new Listing {
+    when (uiFieldLines.contains("ConnectionRef")) {
+      "ConnectionRef"
+    }
+    when (uiFieldLines.contains("FileReference")) {
+      "FileReference"
+    }
+    when (uiFieldLines.contains("MaxItems")) {
+      "MaxItems"
+    }
+  }).toList()
+  local firstPartyImportLines: String =
+    (if (!sdkTypeImports.isEmpty)
+      "from application_sdk.contracts.types import \(sdkTypeImports.join(", "))\n"
+    else "") +
+    (if (!credFieldLine.isEmpty) "from application_sdk.credentials.ref import CredentialRef\n" else "") +
+    "from application_sdk.templates.contracts import ExtractionInput\n"
+  local inputImportBlock: String =
+    "from __future__ import annotations\n\n" +
+    (if (!stdlibImportLines.isEmpty) stdlibImportLines + "\n" else "") +
+    (if (!pydanticImportLines.isEmpty) pydanticImportLines + "\n" else "") +
+    firstPartyImportLines +
+    "\n\n"
   text =
     "# AUTO-GENERATED from contract/app.pkl — DO NOT EDIT MANUALLY.\n" +
     "# To regenerate: pkl eval -m . contract/app.pkl\n" +
-    "from __future__ import annotations\n" +
-    (if (!objectStringCoercionFields.isEmpty) "import json\n" else "") +
-    "from typing import Annotated, Any, ClassVar\n" +
-    "from pydantic import Field\(if (!objectStringCoercionFields.isEmpty) ", field_validator" else "")\n" +
-    "from application_sdk.contracts.types import ConnectionRef, FileReference, MaxItems\n" +
-    "from application_sdk.credentials.ref import CredentialRef\n" +
-    "from application_sdk.templates.contracts import ExtractionInput\n" +
-    "\n\n" +
+    inputImportBlock +
     "class AppInputContract(ExtractionInput):\n" +
     (if (classBody.isEmpty) "    pass\n" else classBody)
 }

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -2396,7 +2396,7 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
     credFieldLine +
     publishFieldBlock
   local usesAnnotated: Boolean = uiFieldLines.contains("Annotated[")
-  local usesAny: Boolean = uiFieldLines.contains("Any") || !objectStringCoercionFields.isEmpty
+  local usesAny: Boolean = uiFieldLines.contains("dict[str, Any]") || !objectStringCoercionFields.isEmpty
   local usesClassVar: Boolean = includePublishInputFields
   local typingImports: List<String> = (new Listing {
     when (usesAnnotated) {
@@ -2413,7 +2413,7 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
     (if (!objectStringCoercionFields.isEmpty) "import json\n" else "") +
     (if (!typingImports.isEmpty) "from typing import \(typingImports.join(", "))\n" else "")
   local pydanticImports: List<String> = (new Listing {
-    when (uiFieldLines.contains("Field(")) {
+    when (uiFieldLines.contains(" = Field(")) {
       "Field"
     }
     when (!objectStringCoercionFields.isEmpty) {
@@ -2423,13 +2423,13 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
   local pydanticImportLines: String =
     if (!pydanticImports.isEmpty) "from pydantic import \(pydanticImports.join(", "))\n" else ""
   local sdkTypeImports: List<String> = (new Listing {
-    when (uiFieldLines.contains("ConnectionRef")) {
+    when (uiFieldLines.contains(": ConnectionRef") || uiFieldLines.contains("list[ConnectionRef]")) {
       "ConnectionRef"
     }
-    when (uiFieldLines.contains("FileReference")) {
+    when (uiFieldLines.contains(": FileReference")) {
       "FileReference"
     }
-    when (uiFieldLines.contains("MaxItems")) {
+    when (uiFieldLines.contains("MaxItems(")) {
       "MaxItems"
     }
   }).toList()

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -2656,6 +2656,13 @@ local credentialConfigOutput: FileOutput = new FileOutput {
 /// consumers (Pydantic models, Go structs) receive valid identifiers.
 local function toPyName(k: String): String = k.replaceAll("-", "_")
 
+local function getPyDefaultFactoryField(k: String, fieldType: String, factory: String): String =
+  let (line = "\(k): \(fieldType) = Field(default_factory=\(factory))")
+  if (line.length <= 84)
+    line
+  else
+    "\(k): \(fieldType) = Field(\n        default_factory=\(factory)\n    )"
+
 /// Map a single UI widget to its Python field declaration (name: type = default).
 /// Does not include the trailing docstring — see generateInputClassPy for that.
 local function getInputPyField(k: String, u: Config.UIElement): String =
@@ -2674,7 +2681,7 @@ local function getInputPyField(k: String, u: Config.UIElement): String =
     "\(k): ConnectionRef | None = None"
   else if (u is Config.ConnectionRefInput)
     (if ((u as Config.ConnectionRefInput).multiSelect)
-      "\(k): Annotated[list[ConnectionRef], MaxItems(1000)] = Field(default_factory=list)"
+      getPyDefaultFactoryField(k, "Annotated[list[ConnectionRef], MaxItems(1000)]", "list")
     else
       "\(k): ConnectionRef | None = None")
   else if (u is Config.ConnectionSelector)
@@ -2684,12 +2691,12 @@ local function getInputPyField(k: String, u: Config.UIElement): String =
   else if (u is Config.PasswordInput)
     "\(k): str = \"\""
   else if (u is Config.TagsInput)
-    "\(k): Annotated[list[str], MaxItems(1000)] = Field(default_factory=list)"
+    getPyDefaultFactoryField(k, "Annotated[list[str], MaxItems(1000)]", "list")
   else if (u is Config.InputRepeater)
-    "\(k): Annotated[list[str], MaxItems(1000)] = Field(default_factory=list)"
+    getPyDefaultFactoryField(k, "Annotated[list[str], MaxItems(1000)]", "list")
   else if (u is Config.DropDown)
     (if ((u as Config.DropDown).multiSelect)
-      "\(k): Annotated[list[str], MaxItems(1000)] = Field(default_factory=list)"
+      getPyDefaultFactoryField(k, "Annotated[list[str], MaxItems(1000)]", "list")
     else
       "\(k): str = \"\(if ((u as Config.DropDown).default != null) (u as Config.DropDown).default!! else "")\"")
   else if (u is Config.Radio)
@@ -2709,11 +2716,11 @@ local function getInputPyField(k: String, u: Config.UIElement): String =
   else if (u is Config.ConditionalInput)
     (let (ci = u as Config.ConditionalInput)
       if (ci.outputValueType == "object")
-        "\(k): Annotated[dict[str, Any], MaxItems(1000)] = Field(default_factory=dict)"
+        getPyDefaultFactoryField(k, "Annotated[dict[str, Any], MaxItems(1000)]", "dict")
       else
         "\(k): str = \"\(if (ci.default != null) ci.default!!.toString() else "")\"")
   else if (u is Config.NestedInput || u is Config.APITree || u is Config.ApiTreeSelect || u is Config.DsnTreeMap || u is Config.SqlTree || u is Config.AgentSelector)
-    "\(k): Annotated[dict[str, Any], MaxItems(1000)] = Field(default_factory=dict)"
+    getPyDefaultFactoryField(k, "Annotated[dict[str, Any], MaxItems(1000)]", "dict")
   else
     "\(k): str = \"\""
 
@@ -2795,6 +2802,8 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
     "                return parsed\n" +
     "        return value\n\n"
   else ""
+  local objectStringCoercionSeparator: String =
+    if (!uiFieldLines.isEmpty && !objectStringCoercionBlock.isEmpty) "\n" else ""
   local credFieldLine: String = if (credentialFieldName != null && !skipFields.contains(credentialFieldName!!))
     "    \(credentialFieldName!!): CredentialRef | None = None\n"
   else ""
@@ -2817,20 +2826,64 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
     "    publish_dry_run: bool = False\n" +
     "    \"\"\"When True, skip the Atlas publish step (executor_enabled=False).\"\"\"\n"
   else ""
+  local usesAnnotated: Boolean = uiFieldLines.contains("Annotated[")
+  local usesAny: Boolean = uiFieldLines.contains("Any") || !objectStringCoercionFields.isEmpty
+  local usesClassVar: Boolean = hasPublishStep && hasPublishInputFields
+  local typingImports: List<String> = (new Listing {
+    when (usesAnnotated) {
+      "Annotated"
+    }
+    when (usesAny) {
+      "Any"
+    }
+    when (usesClassVar) {
+      "ClassVar"
+    }
+  }).toList()
+  local stdlibImportLines: String =
+    (if (!objectStringCoercionFields.isEmpty) "import json\n" else "") +
+    (if (!typingImports.isEmpty) "from typing import \(typingImports.join(", "))\n" else "")
+  local pydanticImports: List<String> = (new Listing {
+    when (uiFieldLines.contains("Field(")) {
+      "Field"
+    }
+    when (!objectStringCoercionFields.isEmpty) {
+      "field_validator"
+    }
+  }).toList()
+  local pydanticImportLines: String =
+    if (!pydanticImports.isEmpty) "from pydantic import \(pydanticImports.join(", "))\n" else ""
+  local sdkTypeImports: List<String> = (new Listing {
+    when (uiFieldLines.contains("ConnectionRef")) {
+      "ConnectionRef"
+    }
+    when (uiFieldLines.contains("FileReference")) {
+      "FileReference"
+    }
+    when (uiFieldLines.contains("MaxItems")) {
+      "MaxItems"
+    }
+  }).toList()
+  local firstPartyImportLines: String =
+    (if (!sdkTypeImports.isEmpty)
+      "from application_sdk.contracts.types import \(sdkTypeImports.join(", "))\n"
+    else "") +
+    (if (!credFieldLine.isEmpty) "from application_sdk.credentials.ref import CredentialRef\n" else "") +
+    "from application_sdk.templates.contracts import ExtractionInput\n"
+  local inputImportBlock: String =
+    "from __future__ import annotations\n\n" +
+    (if (!stdlibImportLines.isEmpty) stdlibImportLines + "\n" else "") +
+    (if (!pydanticImportLines.isEmpty) pydanticImportLines + "\n" else "") +
+    firstPartyImportLines +
+    "\n\n"
   text =
     "# AUTO-GENERATED from app.pkl — DO NOT EDIT MANUALLY.\n" +
     "# To regenerate: make generate\n" +
-    "from __future__ import annotations\n" +
-    (if (!objectStringCoercionFields.isEmpty) "import json\n" else "") +
-    "from typing import Annotated, Any, ClassVar\n" +
-    "from pydantic import Field\(if (!objectStringCoercionFields.isEmpty) ", field_validator" else "")\n" +
-    "from application_sdk.contracts.types import ConnectionRef, FileReference, MaxItems\n" +
-    "from application_sdk.credentials.ref import CredentialRef\n" +
-    "from application_sdk.templates.contracts import ExtractionInput\n" +
-    "\n\n" +
+    inputImportBlock +
     "class AppInputContract(ExtractionInput):\n" +
     publishHashExcludeBlock +
     uiFieldLines +
+    objectStringCoercionSeparator +
     objectStringCoercionBlock +
     credFieldLine +
     publishFieldBlock

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -2827,7 +2827,7 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
     "    \"\"\"When True, skip the Atlas publish step (executor_enabled=False).\"\"\"\n"
   else ""
   local usesAnnotated: Boolean = uiFieldLines.contains("Annotated[")
-  local usesAny: Boolean = uiFieldLines.contains("Any") || !objectStringCoercionFields.isEmpty
+  local usesAny: Boolean = uiFieldLines.contains("dict[str, Any]") || !objectStringCoercionFields.isEmpty
   local usesClassVar: Boolean = hasPublishStep && hasPublishInputFields
   local typingImports: List<String> = (new Listing {
     when (usesAnnotated) {
@@ -2844,7 +2844,7 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
     (if (!objectStringCoercionFields.isEmpty) "import json\n" else "") +
     (if (!typingImports.isEmpty) "from typing import \(typingImports.join(", "))\n" else "")
   local pydanticImports: List<String> = (new Listing {
-    when (uiFieldLines.contains("Field(")) {
+    when (uiFieldLines.contains(" = Field(")) {
       "Field"
     }
     when (!objectStringCoercionFields.isEmpty) {
@@ -2854,13 +2854,13 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
   local pydanticImportLines: String =
     if (!pydanticImports.isEmpty) "from pydantic import \(pydanticImports.join(", "))\n" else ""
   local sdkTypeImports: List<String> = (new Listing {
-    when (uiFieldLines.contains("ConnectionRef")) {
+    when (uiFieldLines.contains(": ConnectionRef") || uiFieldLines.contains("list[ConnectionRef]")) {
       "ConnectionRef"
     }
-    when (uiFieldLines.contains("FileReference")) {
+    when (uiFieldLines.contains(": FileReference")) {
       "FileReference"
     }
-    when (uiFieldLines.contains("MaxItems")) {
+    when (uiFieldLines.contains("MaxItems(")) {
       "MaxItems"
     }
   }).toList()

--- a/contract-toolkit/tests/open_source_examples_test.pkl
+++ b/contract-toolkit/tests/open_source_examples_test.pkl
@@ -23,6 +23,8 @@ local minimalInputPy: String = minimalApp.output.files["app/generated/_input.py"
 
 local publishControlsManifestJson: String = publishControlsApp.output.files["app/generated/manifest.json"].text
 local publishControlsInputPy: String = publishControlsApp.output.files["app/generated/_input.py"].text
+local bundleCrawlerInputPy: String = bundleApp.output.files["app/generated/crawler/_input.py"].text
+local bundleMinerInputPy: String = bundleApp.output.files["app/generated/miner/_input.py"].text
 
 facts {
   ["Minimal example generates all standard output files"] {
@@ -48,6 +50,18 @@ facts {
   ["Minimal example omits publish input fields"] {
     !minimalInputPy.contains("output_dir:")
     !minimalInputPy.contains("load_to_atlan:")
+  }
+
+  ["Minimal example emits only used SDK input imports"] {
+    minimalInputPy.contains(
+      "from __future__ import annotations\n\n" +
+      "from application_sdk.templates.contracts import ExtractionInput\n\n\n" +
+      "class AppInputContract(ExtractionInput):"
+    )
+    !minimalInputPy.contains("from typing import")
+    !minimalInputPy.contains("from pydantic import")
+    !minimalInputPy.contains("from application_sdk.contracts.types import")
+    !minimalInputPy.contains("from application_sdk.credentials.ref import")
   }
 
   ["Full example demonstrates JDBC URL auth with two auth options"] {
@@ -98,6 +112,21 @@ facts {
     !fullInputPy.contains("dict[str, Any]")
   }
 
+  ["Full example emits isort-compatible SDK input imports"] {
+    fullInputPy.contains(
+      "from __future__ import annotations\n\n" +
+      "import json\n" +
+      "from typing import Annotated, Any, ClassVar\n\n" +
+      "from pydantic import Field, field_validator\n\n" +
+      "from application_sdk.contracts.types import MaxItems\n" +
+      "from application_sdk.credentials.ref import CredentialRef\n" +
+      "from application_sdk.templates.contracts import ExtractionInput\n\n\n" +
+      "class AppInputContract(ExtractionInput):"
+    )
+    !fullInputPy.contains("ConnectionRef")
+    !fullInputPy.contains("FileReference")
+  }
+
   ["Full example UIRules wire conditional field requirements"] {
     fullWorkflowJson.contains("\"anyOf\"")
     fullWorkflowJson.contains("\"enable_lineage\"")
@@ -146,6 +175,23 @@ facts {
     bundleApp.output.files.containsKey("app/generated/miner/miner.json")
     bundleApp.output.files.containsKey("app/generated/miner/manifest.json")
     bundleApp.output.files.containsKey("app/generated/miner/_input.py")
+  }
+
+  ["Bundle example emits isort-compatible per-entrypoint SDK input imports"] {
+    bundleCrawlerInputPy.contains(
+      "from __future__ import annotations\n\n" +
+      "from typing import ClassVar\n\n" +
+      "from application_sdk.credentials.ref import CredentialRef\n" +
+      "from application_sdk.templates.contracts import ExtractionInput\n\n\n" +
+      "class AppInputContract(ExtractionInput):"
+    )
+    bundleMinerInputPy.contains(
+      "from __future__ import annotations\n\n" +
+      "from application_sdk.templates.contracts import ExtractionInput\n\n\n" +
+      "class AppInputContract(ExtractionInput):"
+    )
+    !bundleMinerInputPy.contains("from typing import")
+    !bundleMinerInputPy.contains("from pydantic import")
   }
 
   ["Bundle example hoists shared credential configmap to app/generated root"] {

--- a/contract-toolkit/tests/open_source_examples_test.pkl
+++ b/contract-toolkit/tests/open_source_examples_test.pkl
@@ -7,6 +7,9 @@ import "../examples/fanin/app.pkl" as faninApp
 import "../examples/full/app.pkl" as fullApp
 import "../examples/minimal/app.pkl" as minimalApp
 import "../examples/publish-controls/app.pkl" as publishControlsApp
+import "../src/App.pkl" as App
+import "../src/Config.pkl"
+import "../src/NativeApp.pkl"
 
 local connectionRefWorkflowJson: String = connectionRefApp.output.files["app/generated/connection-ref.json"].text
 local connectionRefManifestJson: String = connectionRefApp.output.files["app/generated/manifest.json"].text
@@ -25,6 +28,54 @@ local publishControlsManifestJson: String = publishControlsApp.output.files["app
 local publishControlsInputPy: String = publishControlsApp.output.files["app/generated/_input.py"].text
 local bundleCrawlerInputPy: String = bundleApp.output.files["app/generated/crawler/_input.py"].text
 local bundleMinerInputPy: String = bundleApp.output.files["app/generated/miner/_input.py"].text
+local importTokenHelpText: String =
+  "Any prose mentioning ConnectionRef FileReference MaxItems Field( must not affect imports."
+local helpTextOnlyApp = (App) {
+  name = "helptext-import-token-test"
+  displayName = "HelpText Import Token Test"
+  icon = "https://assets.atlan.com/assets/fullscreen-exit.svg"
+  hasCredentialConfig = false
+
+  pipeline {
+    publish = null
+  }
+
+  uiConfig = new App.UIConfig {
+    tasks {
+      ["Configuration"] {
+        inputs {
+          ["target"] = new App.TextInput {
+            title = "Target"
+            helpText = importTokenHelpText
+          }
+        }
+      }
+    }
+  }
+}
+local nativeHelpTextOnlyApp = (NativeApp) {
+  name = "native-helptext-import-token-test"
+  displayName = "Native HelpText Import Token Test"
+  icon = "https://assets.atlan.com/assets/fullscreen-exit.svg"
+  workflowTypeOverride = "NativeHelpTextImportTokenTestWorkflow"
+  hasCredentialConfig = false
+  hasPublishStep = false
+
+  uiConfig = new Config.UIConfig {
+    tasks {
+      ["Configuration"] {
+        inputs {
+          ["target"] = new Config.TextInput {
+            title = "Target"
+            helpText = importTokenHelpText
+          }
+        }
+      }
+    }
+  }
+}
+local helpTextOnlyInputPy: String = helpTextOnlyApp.output.files["app/generated/_input.py"].text
+local nativeHelpTextOnlyInputPy: String = nativeHelpTextOnlyApp.output.files["_input.py"].text
 
 facts {
   ["Minimal example generates all standard output files"] {
@@ -192,6 +243,30 @@ facts {
     )
     !bundleMinerInputPy.contains("from typing import")
     !bundleMinerInputPy.contains("from pydantic import")
+  }
+
+  ["Help text import tokens do not affect App.pkl SDK input imports"] {
+    helpTextOnlyInputPy.contains(importTokenHelpText)
+    helpTextOnlyInputPy.contains(
+      "from __future__ import annotations\n\n" +
+      "from application_sdk.templates.contracts import ExtractionInput\n\n\n" +
+      "class AppInputContract(ExtractionInput):"
+    )
+    !helpTextOnlyInputPy.contains("from typing import")
+    !helpTextOnlyInputPy.contains("from pydantic import")
+    !helpTextOnlyInputPy.contains("from application_sdk.contracts.types import")
+  }
+
+  ["Help text import tokens do not affect NativeApp.pkl SDK input imports"] {
+    nativeHelpTextOnlyInputPy.contains(importTokenHelpText)
+    nativeHelpTextOnlyInputPy.contains(
+      "from __future__ import annotations\n\n" +
+      "from application_sdk.templates.contracts import ExtractionInput\n\n\n" +
+      "class AppInputContract(ExtractionInput):"
+    )
+    !nativeHelpTextOnlyInputPy.contains("from typing import")
+    !nativeHelpTextOnlyInputPy.contains("from pydantic import")
+    !nativeHelpTextOnlyInputPy.contains("from application_sdk.contracts.types import")
   }
 
   ["Bundle example hoists shared credential configmap to app/generated root"] {


### PR DESCRIPTION
## Root Cause

`app-contract-toolkit` generated `_input.py` with a fixed import block and some raw field lines that did not match `isort --profile black` or `ruff format` output. Consuming connector repos commit raw `pkl eval` output, so lint hooks and byte-stable generation checks could fight each other unless repos excluded `app/generated/`.

## Existing Behavior

Generated `_input.py` always included broad imports such as `Annotated, Any, ClassVar`, `Field`, SDK contract types, and `CredentialRef`, even when the generated class did not use them. Import groups were also emitted without the blank-line structure expected by isort.

## New Behavior

The `_input.py` renderer now:

- emits only imports used by the generated class
- groups imports in isort-compatible stdlib / third-party / first-party blocks
- preserves ruff-format spacing before generated validators/classes
- renders `Field(default_factory=...)` in the same shape ruff format expects

Generated example `_input.py` files were regenerated.

## API Design Decision

This is a codegen-formatting fix, not a new toolkit API. The right layer is the `_input.py` renderer in both `App.pkl` and the `NativeApp.pkl` compatibility path, so consuming apps do not need post-render patches or lint exclusions.

## Backward Compatibility

Generated model fields, types, defaults, and runtime semantics are unchanged. The generated Python source now becomes lint-clean as raw `pkl eval` output.

## Affected Apps / Examples

Updated generated `_input.py` examples:

- `bundle`
- `connection-ref`
- `deploy`
- `fanin`
- `full`
- `minimal`
- `publish-controls`

## Cross-Repo Validation

Frontend, Heracles, Blaze, and Automation Engine contracts are not affected: generated workflow JSON, credential JSON, and manifest JSON are unchanged. The affected consumer surface is SDK/app runtime import of `_input.py`, validated with `scripts/test-sdk-import.py`.

## Value Flow

- Configmap field: unchanged
- Widget/schema: unchanged
- Manifest arg: unchanged
- Placeholder/static value: unchanged
- `_input.py` field/type: unchanged
- `_input.py` formatting/imports: now raw-generation lint-clean
- Runtime consumer: SDK import path validated

## Validation Commands

```bash
./scripts/regenerate-all.sh
./scripts/check-invariants.sh
pkl test tests/*.pkl
uv run isort --profile black --check-only contract-toolkit/examples/*/app/generated/_input.py contract-toolkit/examples/bundle/app/generated/*/_input.py
uvx ruff format --check contract-toolkit/examples/*/app/generated/_input.py contract-toolkit/examples/bundle/app/generated/*/_input.py
uvx ruff check --isolated contract-toolkit/examples/*/app/generated/_input.py contract-toolkit/examples/bundle/app/generated/*/_input.py
uv run python scripts/test-sdk-import.py
uv run pre-commit run --files <changed files>
git diff --check
```

Also validated raw `pkl eval` output in `/private/tmp` before the repo's regenerate post-processing:

```bash
uv run isort --profile black --check-only /private/tmp/app-contract-raw-check-37739/*/app/generated/_input.py /private/tmp/app-contract-raw-check-37739/bundle/app/generated/*/_input.py
uvx ruff format --check /private/tmp/app-contract-raw-check-37739/*/app/generated/_input.py /private/tmp/app-contract-raw-check-37739/bundle/app/generated/*/_input.py
uvx ruff check --isolated /private/tmp/app-contract-raw-check-37739/*/app/generated/_input.py /private/tmp/app-contract-raw-check-37739/bundle/app/generated/*/_input.py
```

Fixes HYP-1611.
