### PR TITLE
fix(handler): preserve metadata template routing key in MetadataInput

### DIFF
--- a/application_sdk/handler/contracts.py
+++ b/application_sdk/handler/contracts.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
 from application_sdk.contracts.base import SerializableEnum
@@ -362,18 +362,8 @@ class MetadataInput(BaseModel):
     credentials: list[HandlerCredential] = []
     """Credentials to use for metadata discovery."""
 
-    metadata_template_key: str = Field(
-        default="",
-        validation_alias=AliasChoices(
-            "metadata_template_key",
-            "metadataTemplateKey",
-            "type",
-        ),
-    )
-    """Metadata source routing key for multi-source metadata widgets.
-
-    The ``type`` alias is accepted for legacy platform metadata requests.
-    """
+    metadata_template_key: str = ""
+    """Metadata source routing key for multi-source metadata widgets."""
 
     connection_config: BaseConnectionConfig = Field(
         default_factory=BaseConnectionConfig

--- a/application_sdk/handler/contracts.py
+++ b/application_sdk/handler/contracts.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
 from application_sdk.contracts.base import SerializableEnum
@@ -361,6 +361,16 @@ class MetadataInput(BaseModel):
 
     credentials: list[HandlerCredential] = []
     """Credentials to use for metadata discovery."""
+
+    metadata_template_key: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "metadata_template_key",
+            "metadataTemplateKey",
+            "type",
+        ),
+    )
+    """Metadata source routing key for multi-source metadata widgets."""
 
     connection_config: BaseConnectionConfig = Field(
         default_factory=BaseConnectionConfig

--- a/application_sdk/handler/contracts.py
+++ b/application_sdk/handler/contracts.py
@@ -370,7 +370,10 @@ class MetadataInput(BaseModel):
             "type",
         ),
     )
-    """Metadata source routing key for multi-source metadata widgets."""
+    """Metadata source routing key for multi-source metadata widgets.
+
+    The ``type`` alias is accepted for legacy platform metadata requests.
+    """
 
     connection_config: BaseConnectionConfig = Field(
         default_factory=BaseConnectionConfig

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -2464,7 +2464,7 @@ Strongly-typed Pydantic models for SDK methods. Contracts in `application_sdk.co
 - **Summary:** Input for the fetch_metadata handler operation.
 - **Fields:**
   - `credentials: list[HandlerCredential]` `= []` — Credentials to use for metadata discovery.
-  - `metadata_template_key: str` `= Field(default='', validation_alias=(AliasChoices('metadata_template_key', 'metadataTemplateKey', 'type')))` — Metadata source routing key for multi-source metadata widgets.
+  - `metadata_template_key: str` `= ''` — Metadata source routing key for multi-source metadata widgets.
   - `connection_config: BaseConnectionConfig` `= Field(default_factory=BaseConnectionConfig)` — Connection configuration.
   - `object_filter: str` `= ''` — Filter pattern (e.g., 'public.*', 'mydb.myschema.*').
   - `include_fields: bool` `= True` — Whether to include field/column details.

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.14.0
-source-sha:    0ef594aefde221c861d45a54d896d314ca1d906b
-source-date:   2026-06-01T18:50:15+05:30
+source-sha:    e84e1f49890c498a8419f7af5737cb62b15ff29f
+source-date:   2026-06-03T12:16:55+05:30
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -2464,6 +2464,7 @@ Strongly-typed Pydantic models for SDK methods. Contracts in `application_sdk.co
 - **Summary:** Input for the fetch_metadata handler operation.
 - **Fields:**
   - `credentials: list[HandlerCredential]` `= []` — Credentials to use for metadata discovery.
+  - `metadata_template_key: str` `= Field(default='', validation_alias=(AliasChoices('metadata_template_key', 'metadataTemplateKey', 'type')))` — Metadata source routing key for multi-source metadata widgets.
   - `connection_config: BaseConnectionConfig` `= Field(default_factory=BaseConnectionConfig)` — Connection configuration.
   - `object_filter: str` `= ''` — Filter pattern (e.g., 'public.*', 'mydb.myschema.*').
   - `include_fields: bool` `= True` — Whether to include field/column details.

--- a/tests/unit/handler/test_contracts.py
+++ b/tests/unit/handler/test_contracts.py
@@ -460,3 +460,8 @@ class TestMetadataInputFieldTypes:
         )
         assert isinstance(inp.connection_config, BaseConnectionConfig)
         assert inp.connection_config.model_extra == {"host": "db"}
+
+    def test_metadata_template_key_aliases(self):
+        for key in ("metadata_template_key", "metadataTemplateKey", "type"):
+            inp = MetadataInput.model_validate({"credentials": [], key: "feedbacks"})
+            assert inp.metadata_template_key == "feedbacks"

--- a/tests/unit/handler/test_contracts.py
+++ b/tests/unit/handler/test_contracts.py
@@ -461,7 +461,13 @@ class TestMetadataInputFieldTypes:
         assert isinstance(inp.connection_config, BaseConnectionConfig)
         assert inp.connection_config.model_extra == {"host": "db"}
 
-    def test_metadata_template_key_aliases(self):
-        for key in ("metadata_template_key", "metadataTemplateKey", "type"):
+    def test_metadata_template_key_accepts_canonical_field(self):
+        inp = MetadataInput.model_validate(
+            {"credentials": [], "metadata_template_key": "feedbacks"}
+        )
+        assert inp.metadata_template_key == "feedbacks"
+
+    def test_metadata_template_key_does_not_accept_non_canonical_fields(self):
+        for key in ("metadataTemplateKey", "type"):
             inp = MetadataInput.model_validate({"credentials": [], key: "feedbacks"})
-            assert inp.metadata_template_key == "feedbacks"
+            assert inp.metadata_template_key == ""

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -823,13 +823,34 @@ class TestMetadataEndpoint:
             "/workflows/v1/metadata",
             json={
                 "credentials": {"host": "db.example.com"},
-                "metadataTemplateKey": "feedbacks",
-                "type": "accounts",
+                "metadata_template_key": "feedbacks",
             },
         )
 
         assert response.status_code == 200
         assert received == ["feedbacks"]
+
+    def test_metadata_non_canonical_keys_do_not_populate_template_key(self) -> None:
+        received: list[str] = []
+
+        class _MetadataTemplateCapture(_TestHandler):
+            async def fetch_metadata(self, input: MetadataInput) -> MetadataOutput:
+                received.append(input.metadata_template_key)
+                return ApiMetadataOutput(objects=[])
+
+        client = _make_client(handler=_MetadataTemplateCapture())
+        for key in ("metadataTemplateKey", "type"):
+            response = client.post(
+                "/workflows/v1/metadata",
+                json={
+                    "credentials": {"host": "db.example.com"},
+                    key: "feedbacks",
+                },
+            )
+
+            assert response.status_code == 200
+
+        assert received == ["", ""]
 
     def test_metadata_handler_error_returns_500(self) -> None:
         client = _make_client(handler=_FailingHandler())

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -810,6 +810,27 @@ class TestMetadataEndpoint:
         assert data[0]["children"][0]["value"] == "ws-1"
         assert data[0]["children"][1]["node_type"] == "workspace"
 
+    def test_metadata_template_key_forwarded_to_handler(self) -> None:
+        received: list[str] = []
+
+        class _MetadataTemplateCapture(_TestHandler):
+            async def fetch_metadata(self, input: MetadataInput) -> MetadataOutput:
+                received.append(input.metadata_template_key)
+                return ApiMetadataOutput(objects=[])
+
+        client = _make_client(handler=_MetadataTemplateCapture())
+        response = client.post(
+            "/workflows/v1/metadata",
+            json={
+                "credentials": {"host": "db.example.com"},
+                "metadataTemplateKey": "feedbacks",
+                "type": "accounts",
+            },
+        )
+
+        assert response.status_code == 200
+        assert received == ["feedbacks"]
+
     def test_metadata_handler_error_returns_500(self) -> None:
         client = _make_client(handler=_FailingHandler())
         response = client.post(


### PR DESCRIPTION
## Summary
- add a typed `MetadataInput.metadata_template_key` field for metadata source routing
- enforce one canonical SDK request key: `metadata_template_key`
- add contract and endpoint regression coverage proving non-canonical keys do not populate the field
- refresh the generated SDK capability manifest

## Why this is needed
APITree widgets generated from app contracts can define multiple metadata sources. Native apps with more than one metadata source need a routing key to decide which tree to return from `/workflows/v1/metadata`.

The SDK contract should expose one consistent way to do this, not absorb every platform or app-specific spelling. Heracles owns the native/platform normalization layer and now maps incoming `metadataTemplateKey` into the SDK-canonical `metadata_template_key` before calling app handlers.

This keeps the SDK boundary typed and strict: apps read `input.metadata_template_key`; callers that send `metadataTemplateKey` or `type` directly to the SDK do not populate this field. That avoids making legacy/proxy payload names part of the SDK contract.

## Validation
- `uv run pytest tests/unit/handler/test_contracts.py::TestMetadataInputFieldTypes tests/unit/handler/test_service.py::TestMetadataEndpoint` -> 10 passed, 1 warning
- `uv run pre-commit run --files application_sdk/handler/contracts.py tests/unit/handler/test_contracts.py tests/unit/handler/test_service.py docs/agents/sdk-capabilities.md` -> passed
- `uv run poe regen-capabilities` -> passed
- `uv run pytest` -> 4821 passed, 8 skipped, 119 deselected