### PR TITLE
ci(publish): add credential-leak gate to block publish on any leak

### DIFF
--- a/.github/scripts/credential-leak-gate/credential-leak-rules.md
+++ b/.github/scripts/credential-leak-gate/credential-leak-rules.md
@@ -1,0 +1,149 @@
+# Credential Leak Rules (publish-gate copy)
+
+Reference ruleset for the **publish-time** credential-leak gate. The patterns
+below are implemented deterministically (no LLM) by `scan.py` in this
+directory, driven by the `leak-scan` job in
+`.github/workflows/build-and-publish-app.yaml`.
+
+> **Provenance / sync.** This ruleset is vendored from
+> `atlanhq/connector-pulse` →
+> `skills/credential-leak-scan/references/credential-leak-rules.md`,
+> the canonical source maintained by the nightly credential-leak scan.
+> The nightly scan is detection + tracking (Linear tickets, ClickHouse) and
+> uses an LLM to triage candidates; this copy is the **blocking publish gate**
+> — same sink pattern set and severity rubric, but **deterministic**: the LLM
+> triage/adversarial stages are replaced by static heuristics (see "Deterministic
+> gate notes" below). **Keep the pattern set + severity rubric in sync** when
+> either side changes. The pattern IDs are stable — do not rename them.
+
+> **Deterministic gate notes (how `scan.py` diverges from the nightly):**
+> - **`fstring-interp` is folded into the sinks, not standalone.** An f-string
+>   interpolating a credential is only a leak when it reaches a log/print/CLI
+>   sink; the `logger-call`/`print-call`/`console-call`/`go-fmt-call` patterns
+>   already match the interpolated form via `.*{cred}`. A standalone f-string
+>   pattern flags benign value construction (e.g. building a basic-auth header).
+> - **Static triage replaces the LLM.** A candidate is dropped when: the line
+>   routes the value through a masking helper (`mask`/`redact`/`***`/…); the
+>   matched token is a metadata identifier (`credential_name`, `secret_id`,
+>   `credential_guid`, …); or the credential identifier appears only inside a
+>   message string literal, never referenced as code.
+> - **Severity gating.** CRITICAL/HIGH block the publish; MEDIUM/LOW are
+>   reported only. `helm-set` and findings in test/fixture paths cap at MEDIUM.
+> - **Allowlist.** An app-level `.credential-leak-allow` file suppresses
+>   confirmed false positives (`path` to ignore a file, `path:lineno` for a
+>   single line).
+
+---
+
+## File-extension allowlist (Stage 1)
+
+Source files that commonly carry log/print/format/CLI-arg calls:
+
+```
+.py .go .ts .tsx .js .jsx .java .kt .rs .sh .yaml .yml
+```
+
+Extensions intentionally excluded (high false-positive rate, low value):
+`.md`, `.rst`, `.txt`, `.json`, `.lock`, `.sum`, `.mod`, `.toml` (except
+CI/workflow YAML which we keep).
+
+---
+
+## Credential identifier tokens
+
+A candidate line must contain one of these identifiers (case-insensitive),
+captured as the `variable_name` regex group for later triage:
+
+```
+password | passwd | pwd
+secret   | client_secret | api_key | access_key | secret_key | private_key
+token    | atlan_token  | atlan_api_token | bearer
+authorization | credential | connection_string
+```
+
+Regex class (exact form used in both the nightly skill and this gate):
+
+```regex
+(password|passwd|pwd|secret|api[_-]?key|access[_-]?key|secret[_-]?key|client[_-]?secret|atlan[_-]?token|atlan[_-]?api[_-]?token|bearer|authorization|credential|connection[_-]?string|private[_-]?key)
+```
+
+---
+
+## Sink patterns (Stage 1)
+
+Each pattern ID routes a credential identifier into an output / log / CLI-arg
+sink. The IDs are stable — keep them unchanged so dedup across the nightly
+scan and this gate stays aligned.
+
+| Pattern ID | Language / Sink | Regex |
+|------------|-----------------|-------|
+| `logger-call` | Python/Java loggers: `logger.info(...)`, `logging.warning(...)` | `(log(ger)?\|logging)\.(debug\|info\|warn(ing)?\|error\|critical\|fatal\|trace)\s*\(.*{cred}` |
+| `print-call` | Bare `print(...)` with credential | `(^\|[^A-Za-z0-9_.])print\s*\(.*{cred}` |
+| `console-call` | JS/TS: `console.log`, `console.error`, etc. | `console\.(log\|info\|debug\|warn\|error)\s*\(.*{cred}` |
+| `go-fmt-call` | Go: `fmt.Printf`, `log.Errorf`, etc. | `(fmt\|log)\.(Print\|Println\|Printf\|Errorf\|Fatalf\|Panicf)\s*\(.*{cred}` |
+| `rust-println` | Rust: `println!`, `eprintln!`, `log::info!` | `(println!\|eprintln!\|log::(debug\|info\|warn\|error)!)\s*\(.*{cred}` |
+| `fstring-interp` | Python f-string / JS template literal interpolating a credential var | `f["\'][^"\']*\{[^}]*{cred}[^}]*\}` |
+| `shell-echo` | Shell `echo`/`printf` with credential env var | `(echo\|printf)\s.*\$\{?[A-Z_]*{cred}[A-Z_]*\}?` |
+| `helm-set` | Helm/argo/kubectl CLI args: `--set password=...`, `--from-literal=password=...` | `(--set[= ]\|--from-literal[= ])\S*{cred}\S*=` |
+
+`{cred}` above is the credential identifier regex class.
+
+---
+
+## Comment stripping
+
+Before pattern matching, strip trailing inline comments so a literal word in a
+comment doesn't fire:
+
+- `#` — Python, shell, YAML, Ruby
+- `//` — Go, JS, TS, Java, Kotlin, Rust
+
+Block comments (`/* ... */`, `"""..."""`) are out of scope — rare in practice
+and not worth the parser complexity.
+
+---
+
+## Severity rubric (Stage 2 — triage)
+
+Applied only when the triage verdict is `LEAK`.
+
+| Severity | Definition |
+|----------|------------|
+| CRITICAL | Full credential (password, secret_key, client_secret, atlan_token, atlan_api_token) reaches a sink in production code paths. |
+| HIGH | Plaintext credential in TLS/URI config logged at non-production code paths (test scripts, dev-mode), OR partial credential (first N chars of token) logged anywhere. |
+| MEDIUM | Credential passed as CLI `--set` arg in test/e2e scripts, OR credential logged behind a feature flag / debug log. |
+| LOW | Credential-adjacent identifier reaches a sink but the value is structurally non-sensitive (e.g., a redacted URI format template where the credential is always masked). |
+
+**Publish-gate blocking threshold:** `CRITICAL` and `HIGH` surviving the gate
+block the publish. `MEDIUM`/`LOW` are reported in the verdict and the job
+summary but do **not** block (they are tracked by the nightly scan).
+
+---
+
+## Known false-positive classes
+
+Triage (Stage 2) and gate (Stage 3) should recognise these and classify as
+`FALSE_POSITIVE`:
+
+1. **Test fixtures** — `password = "dummy"`, `atlan_token = "test-token"`. Fixture files (`tests/`, `fixtures/`, `*_test.go`) passed to a logger are low value; classify LOW at most unless the fixture value itself is a real credential committed to the repo (in which case raise to HIGH as a separate secret-in-code finding — gitleaks should already catch that).
+2. **Type annotations / signatures** — `def send(password: str)` does not route the value to a sink. Match only if the identifier appears inside a sink call, which the regex patterns above ensure.
+3. **Docstrings / block comments** — out of scope per comment-stripping note.
+4. **Already-redacted values** — a variable reassigned to `***` or passed through a `redact()` / `mask()` helper before reaching the sink. Triage must inspect the ±10-line context to spot this.
+5. **Format template literals without interpolation** — `logger.info("password=%s", mask(p))` where the sink receives a masked arg. The triage prompt should favour the mask wrapper over the identifier name.
+
+---
+
+## Previously-confirmed leak patterns (APP-1602 audit)
+
+Concrete patterns confirmed in the Apr 16, 2026 audit. Use them as ground-truth
+examples in prompt engineering and as regression checks for this gate.
+
+| Pattern | Sink |
+|---------|------|
+| `logger.info(f"credentials={credentials}")` — dict with password + atlan_token | `logger-call`, `fstring-interp` |
+| Full cloud credentials (`client_secret`, `tenant_id`) passed to logger in activities/handlers | `logger-call` |
+| `logger.info(f"access_key={aws_access_key} secret_key={...} token={atlan_api_token}")` | `fstring-interp`, `logger-call` |
+| Broken URI redaction leaks plaintext password; TLS cert key password logged | `logger-call` |
+| First N chars of an OAuth token logged (`logger.info("token: " + token[:20])`) | `logger-call` |
+| Passwords passed as plaintext Helm `--set` CLI args in e2e tests | `helm-set` |
+| Connection string with password logged in a test script | `logger-call` |

--- a/.github/scripts/credential-leak-gate/credential-leak-rules.md
+++ b/.github/scripts/credential-leak-gate/credential-leak-rules.md
@@ -10,11 +10,13 @@ directory, driven by the `leak-scan` job in
 > `skills/credential-leak-scan/references/credential-leak-rules.md`,
 > the canonical source maintained by the nightly credential-leak scan.
 > The nightly scan is detection + tracking (Linear tickets, ClickHouse) and
-> uses an LLM to triage candidates; this copy is the **blocking publish gate**
-> — same sink pattern set and severity rubric, but **deterministic**: the LLM
-> triage/adversarial stages are replaced by static heuristics (see "Deterministic
-> gate notes" below). **Keep the pattern set + severity rubric in sync** when
-> either side changes. The pattern IDs are stable — do not rename them.
+> uses an LLM to triage candidates; this copy drives the **publish-time gate**
+> — same sink pattern set and severity rubric, but **deterministic** (the LLM
+> triage/adversarial stages are replaced by static heuristics, see below) and
+> **warn-only** (creds-into-logs findings annotate the run + ping Slack; they do
+> not block — only the gitleaks hardcoded-secret layer blocks). **Keep the
+> pattern set + severity rubric in sync** when either side changes. The pattern
+> IDs are stable — do not rename them.
 
 > **Deterministic gate notes (how `scan.py` diverges from the nightly):**
 > - **`fstring-interp` is folded into the sinks, not standalone.** An f-string
@@ -27,8 +29,11 @@ directory, driven by the `leak-scan` job in
 >   matched token is a metadata identifier (`credential_name`, `secret_id`,
 >   `credential_guid`, …); or the credential identifier appears only inside a
 >   message string literal, never referenced as code.
-> - **Severity gating.** CRITICAL/HIGH block the publish; MEDIUM/LOW are
->   reported only. `helm-set` and findings in test/fixture paths cap at MEDIUM.
+> - **Non-secret field access.** Logging `creds['host']` / `creds.get('authType')`
+>   / `creds.account` reveals connection metadata, not the secret value.
+> - **Severity (warn-only).** CRITICAL/HIGH raise a warning + Slack ping;
+>   MEDIUM/LOW are counted only. `helm-set` and test/fixture paths cap at MEDIUM.
+>   Nothing here blocks the publish — only the gitleaks layer does.
 > - **Allowlist.** An app-level `.credential-leak-allow` file suppresses
 >   confirmed false positives (`path` to ignore a file, `path:lineno` for a
 >   single line).
@@ -114,9 +119,10 @@ Applied only when the triage verdict is `LEAK`.
 | MEDIUM | Credential passed as CLI `--set` arg in test/e2e scripts, OR credential logged behind a feature flag / debug log. |
 | LOW | Credential-adjacent identifier reaches a sink but the value is structurally non-sensitive (e.g., a redacted URI format template where the credential is always masked). |
 
-**Publish-gate blocking threshold:** `CRITICAL` and `HIGH` surviving the gate
-block the publish. `MEDIUM`/`LOW` are reported in the verdict and the job
-summary but do **not** block (they are tracked by the nightly scan).
+**Publish-gate warning threshold:** `CRITICAL` and `HIGH` raise a non-blocking
+warning (run summary + Slack). `MEDIUM`/`LOW` are counted in the verdict only.
+The creds-into-logs layer never blocks the publish — only the gitleaks
+hardcoded-secret layer does.
 
 ---
 

--- a/.github/scripts/credential-leak-gate/scan.py
+++ b/.github/scripts/credential-leak-gate/scan.py
@@ -22,10 +22,12 @@ Detection model
 
 Output
 ------
-Writes a verdict JSON (same shape the publish gate consumes) and exits:
-  - 0  -> no blocking (CRITICAL/HIGH) findings  (decision="pass")
-  - 1  -> one or more blocking findings         (decision="fail")
-Any uncaught exception propagates as a non-zero exit, so the gate fails closed.
+Writes a verdict JSON (the source of truth the workflow reads) and exits:
+  - 0  -> no CRITICAL/HIGH findings  (decision="pass")
+  - 1  -> one or more CRITICAL/HIGH  (decision="fail")
+The exit code is advisory: in the publish gate this scan is WARN-ONLY (the
+workflow annotates the run + pings Slack on findings but does not block — only
+the companion gitleaks hardcoded-secret scan blocks the publish).
 
 Secret values are NEVER recorded or printed — only file, line, pattern id,
 matched identifier, and severity.
@@ -196,6 +198,54 @@ def _strip_comment(line: str, ext: str) -> str:
 # `len(creds)` / `list(creds.keys())` reveals shape/presence, not the value.
 _META_BUILTIN = re.compile(r"(bool|type|len|dir|id|isinstance|repr|hasattr)\s*\([^)]*$")
 
+# Fields of a credential object that are NOT the secret. Logging these reveals
+# connection metadata, not a credential value. Normalized (no separators).
+# Deliberately excludes password/secret/token/key/clientsecret/etc.
+NON_SECRET_FIELDS = {
+    "host",
+    "hostname",
+    "port",
+    "account",
+    "accountid",
+    "user",
+    "username",
+    "userid",
+    "project",
+    "projectid",
+    "region",
+    "zone",
+    "type",
+    "authtype",
+    "scheme",
+    "url",
+    "uri",
+    "endpoint",
+    "server",
+    "database",
+    "db",
+    "schema",
+    "warehouse",
+    "role",
+    "catalog",
+    "namespace",
+    "driver",
+    "dialect",
+    "name",
+    "id",
+    "email",
+    "tenant",
+    "tenantid",
+    "clientid",
+    "impersonateuser",
+    "path",
+    "method",
+    "protocol",
+    "format",
+    "version",
+    "status",
+    "kind",
+}
+
 
 _BRACE = re.compile(r"\{[^{}]*\}")
 _IS_NONE = re.compile(r"[\w\[\]'\".]*\s+is\s+(not\s+)?none\b", re.IGNORECASE)
@@ -250,6 +300,23 @@ def _is_metadata_access(code: str, var_start: int, var_end: int) -> bool:
     # Wrapped in a metadata builtin: bool(creds), type(creds), len(creds), ...
     if _META_BUILTIN.search(before):
         return True
+    # Boolean negation `not creds` — a presence check, not the value.
+    if re.search(r"\bnot\s+$", before):
+        return True
+    # Accessing a known NON-secret field of a credential object logs that
+    # field, not the secret: creds['host'], creds.get("authType"),
+    # creds.account, ... Unknown / secret-named fields (password, token,
+    # secret_key, ...) are NOT in the set, so they still flag.
+    # `\w*` first absorbs the rest of the identifier (the regex group may match
+    # only a prefix, e.g. `credential` of `credentials`).
+    fld = re.match(
+        r"""\w*\s*(?:\[\s*['"]([\w-]+)['"]\s*\]|\.\s*get\s*\(\s*['"]([\w-]+)['"]|\.\s*([A-Za-z_]\w*))""",
+        after,
+    )
+    if fld:
+        field = _norm(fld.group(1) or fld.group(2) or fld.group(3) or "")
+        if field in NON_SECRET_FIELDS:
+            return True
     # The identifier is itself a quoted string literal (e.g. a dict key in a
     # membership/`.get()` test: `'credentials' in cfg`), not a value reference.
     # Allow trailing word chars (the matched token may be a prefix, e.g.
@@ -300,6 +367,13 @@ def _iter_source_files(root: str):
     for dirpath, dirnames, filenames in os.walk(root):
         dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
         for name in filenames:
+            # Skip security rule-definition files: they legitimately contain
+            # sink-pattern strings like `print(... credentials ...)` that are
+            # rules, not leaks (e.g. an app's own .semgrep.yml).
+            if name in (".semgrep.yml", ".semgrep.yaml") or name.endswith(
+                (".semgrep.yml", ".semgrep.yaml")
+            ):
+                continue
             if os.path.splitext(name)[1].lower() in EXTS:
                 full = os.path.join(dirpath, name)
                 yield full, os.path.relpath(full, root)

--- a/.github/scripts/credential-leak-gate/scan.py
+++ b/.github/scripts/credential-leak-gate/scan.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Deterministic credential-leak gate (no LLM).
+
+Scans a local working tree for credentials reaching log / print / format /
+CLI-arg sinks — the APP-1602 audit class. This is the deterministic mirror of
+the nightly `credential-leak-scan` (atlanhq/connector-pulse): same sink pattern
+set and severity rubric (see credential-leak-rules.md in this directory), but
+the LLM triage/adversarial stages are replaced by static heuristics so the gate
+runs synchronously in the publish path with no token and no network.
+
+Detection model
+---------------
+1. Regex sweep: each line of each source file (extension allowlist) is matched
+   against the documented sink patterns after inline-comment stripping.
+2. Static triage (replaces the LLM): a hit is only treated as a real leak when
+   the credential identifier is referenced *as code* — interpolated, passed as
+   a variable, or concatenated — rather than appearing only inside a log
+   message string literal. Lines that route the value through a masking helper
+   (mask()/redact()/*** etc.) are dropped. Findings in test/fixture paths are
+   capped at MEDIUM. An optional `.credential-leak-allow` file suppresses
+   confirmed false positives.
+
+Output
+------
+Writes a verdict JSON (same shape the publish gate consumes) and exits:
+  - 0  -> no blocking (CRITICAL/HIGH) findings  (decision="pass")
+  - 1  -> one or more blocking findings         (decision="fail")
+Any uncaught exception propagates as a non-zero exit, so the gate fails closed.
+
+Secret values are NEVER recorded or printed — only file, line, pattern id,
+matched identifier, and severity.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass
+
+# ── Ruleset (mirrors credential-leak-rules.md — keep in sync) ──────────────────
+
+# Credential identifier class. The named group `var` is the matched identifier.
+CRED = (
+    r"(?P<var>password|passwd|pwd|secret|api[_-]?key|access[_-]?key|"
+    r"secret[_-]?key|client[_-]?secret|atlan[_-]?token|atlan[_-]?api[_-]?token|"
+    r"bearer|authorization|credential|connection[_-]?string|private[_-]?key)"
+)
+
+# (pattern_id, sink_type, regex template). `{cred}` expands to CRED.
+_SINKS: list[tuple[str, str, str]] = [
+    (
+        "logger-call",
+        "logger",
+        r"(log(ger)?|logging)\.(debug|info|warn(ing)?|error|critical|fatal|trace)\s*\(.*{cred}",
+    ),
+    ("print-call", "print", r"(^|[^A-Za-z0-9_.])print\s*\(.*{cred}"),
+    ("console-call", "console", r"console\.(log|info|debug|warn|error)\s*\(.*{cred}"),
+    (
+        "go-fmt-call",
+        "go-fmt",
+        r"(fmt|log)\.(Print|Println|Printf|Errorf|Fatalf|Panicf)\s*\(.*{cred}",
+    ),
+    (
+        "rust-println",
+        "rust-macro",
+        r"(println!|eprintln!|log::(debug|info|warn|error)!)\s*\(.*{cred}",
+    ),
+    # NOTE: the nightly scan keeps a standalone `fstring-interp` sink and lets
+    # the LLM confirm it reaches a real sink. This deterministic gate omits it:
+    # an f-string interpolating a credential is only a leak when it reaches a
+    # log/print/CLI sink, and those interpolations are already caught inside the
+    # logger-call / print-call / console-call / go-fmt-call patterns above
+    # (whose `.*{cred}` matches the interpolated form). Keeping it standalone
+    # flags benign value construction (e.g. building a basic-auth header).
+    ("shell-echo", "shell", r"(echo|printf)\s.*\$\{?[A-Z_]*{cred}[A-Z_]*\}?"),
+    ("helm-set", "cli-arg", r"(--set[= ]|--from-literal[= ])\S*{cred}\S*="),
+]
+SINKS = [
+    (pid, stype, re.compile(tmpl.replace("{cred}", CRED), re.IGNORECASE))
+    for pid, stype, tmpl in _SINKS
+]
+
+CRED_BARE = re.compile(CRED, re.IGNORECASE)
+
+# When the matched credential token is part of a larger identifier denoting
+# metadata (a name / id / guid / reference / etc.), the value is not the secret
+# itself — e.g. `credential_name`, `secret_id`, `credential_guid`. Tested
+# against the characters immediately following the matched token.
+META_SUFFIX = re.compile(
+    r"^(s|es)?[_-]?(name|names|id|ids|guid|uuid|ref|refs|reference|arn|type|types|"
+    r"prefix|suffix|count|len|length|url|uri|urls|path|paths|file|files|field|fields|"
+    r"list|map|store|stores|provider|providers|source|sources|kind|key_name|"
+    r"expiry|expires|expiration|created|updated|at|hash|fingerprint|format|"
+    r"template|var|vars|env|enabled|present|exists|status|state)\b",
+    re.IGNORECASE,
+)
+
+# Identifiers that, when leaked, are a full credential -> CRITICAL.
+FULL_CRED = {
+    "password",
+    "passwd",
+    "pwd",
+    "secret",
+    "secretkey",
+    "clientsecret",
+    "atlantoken",
+    "atlanapitoken",
+    "privatekey",
+    "credential",
+    "connectionstring",
+}
+
+EXTS = {
+    ".py",
+    ".go",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".java",
+    ".kt",
+    ".rs",
+    ".sh",
+    ".yaml",
+    ".yml",
+}
+HASH_COMMENT = {".py", ".sh", ".yaml", ".yml"}
+SLASH_COMMENT = {".go", ".ts", ".tsx", ".js", ".jsx", ".java", ".kt", ".rs"}
+
+# Directories never worth scanning.
+SKIP_DIRS = {
+    ".git",
+    "node_modules",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+    "vendor",
+    ".mypy_cache",
+    ".pytest_cache",
+    "__pycache__",
+    ".ruff_cache",
+    "site-packages",
+    ".tox",
+}
+
+TEST_PATH = re.compile(
+    r"(^|/)(tests?|fixtures?|testdata|e2e)(/|$)|"
+    r"(^|/)(test_[^/]*|[^/]*_test|conftest)\.[^/]+$|"
+    r"\.(spec|test)\.[^/]+$",
+    re.IGNORECASE,
+)
+
+# Masking/redaction helpers — if present in the line, the value is already
+# protected before it reaches the sink (FP classes #4 / #5).
+REDACT = re.compile(
+    r"(mask|redact|obfuscat|scrub|sanitiz|hidden|\*\*\*|\[redacted\]|<redacted>|x{4,})",
+    re.IGNORECASE,
+)
+
+# String literals (single/double quoted, non-greedy). Used to decide whether a
+# credential identifier is referenced as code vs only inside a message string.
+STRING_LIT = re.compile(r"""(['"]).*?\1""")
+# f-string / template-literal interpolation of a credential identifier.
+INTERP = re.compile(r"""[{$]\s*[^{}]*""" + CRED + r"""[^{}]*[}]?""", re.IGNORECASE)
+
+
+@dataclass
+class Finding:
+    id: str
+    file: str
+    line: int
+    pattern_id: str
+    variable_name: str
+    sink_type: str
+    severity: str
+    verdict_triage: str
+    verdict_gate: str
+    reason: str
+
+
+def _strip_comment(line: str, ext: str) -> str:
+    """Remove a trailing inline comment so words in comments don't fire."""
+    if ext in HASH_COMMENT:
+        idx = line.find("#")
+        return line[:idx] if idx != -1 else line
+    if ext in SLASH_COMMENT:
+        # Avoid eating the `//` in scheme://host.
+        m = re.search(r"(?<!:)//", line)
+        return line[: m.start()] if m else line
+    return line
+
+
+def _referenced_as_code(line: str, var_norm: str) -> bool:
+    """True when the credential identifier is used as a value/variable, not just
+    as a word inside a log-message string literal."""
+    if INTERP.search(line):
+        return True
+    # Strip quoted string literals; if the identifier still appears, it is being
+    # referenced as code (a variable, kwarg, concatenation, CLI arg, ...).
+    stripped = STRING_LIT.sub("", line)
+    return CRED_BARE.search(stripped) is not None
+
+
+def _norm(var: str) -> str:
+    return re.sub(r"[_-]", "", var).lower()
+
+
+def _severity(var_norm: str, pattern_id: str, is_test: bool) -> str:
+    if pattern_id == "helm-set":
+        return "MEDIUM"
+    if is_test:
+        return "MEDIUM"
+    if var_norm in FULL_CRED:
+        return "CRITICAL"
+    return "HIGH"
+
+
+def _load_allowlist(root: str) -> tuple[set[str], set[str]]:
+    """Return (ignored_files, ignored_file_lines) from `.credential-leak-allow`.
+
+    Entries: `path` ignores a whole file; `path:lineno` ignores one line;
+    blank lines and `#` comments are skipped.
+    """
+    files: set[str] = set()
+    lines: set[str] = set()
+    path = os.path.join(root, ".credential-leak-allow")
+    if not os.path.isfile(path):
+        return files, lines
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        for raw in fh:
+            entry = raw.strip()
+            if not entry or entry.startswith("#"):
+                continue
+            if re.search(r":\d+$", entry):
+                lines.add(entry)
+            else:
+                files.add(entry)
+    return files, lines
+
+
+def _iter_source_files(root: str):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for name in filenames:
+            if os.path.splitext(name)[1].lower() in EXTS:
+                full = os.path.join(dirpath, name)
+                yield full, os.path.relpath(full, root)
+
+
+def scan(root: str) -> dict:
+    ignored_files, ignored_lines = _load_allowlist(root)
+    findings: list[Finding] = []
+    files_scanned = 0
+    candidates = 0
+    counter = 0
+
+    for full, rel in _iter_source_files(root):
+        if rel in ignored_files:
+            continue
+        ext = os.path.splitext(rel)[1].lower()
+        is_test = bool(TEST_PATH.search(rel))
+        try:
+            with open(full, encoding="utf-8", errors="replace") as fh:
+                lines = fh.readlines()
+        except (OSError, UnicodeError):
+            continue
+        files_scanned += 1
+        for lineno, raw in enumerate(lines, start=1):
+            code = _strip_comment(raw.rstrip("\n"), ext)
+            if not CRED_BARE.search(code):
+                continue
+            for pattern_id, sink_type, rx in SINKS:
+                m = rx.search(code)
+                if not m:
+                    continue
+                candidates += 1
+                if f"{rel}:{lineno}" in ignored_lines:
+                    break
+                if REDACT.search(code):
+                    break  # value masked before the sink — not a leak
+                var = m.groupdict().get("var") or ""
+                var_norm = _norm(var)
+                # Metadata, not a secret value: `credential_name`, `secret_id`,
+                # `credential_guid`, ... (suffix immediately after the token).
+                if META_SUFFIX.search(code[m.end("var") :]):
+                    break
+                # Static triage: only a real leak if referenced as code.
+                if pattern_id not in (
+                    "shell-echo",
+                    "helm-set",
+                ) and not _referenced_as_code(code, var_norm):
+                    break
+                counter += 1
+                sev = _severity(var_norm, pattern_id, is_test)
+                findings.append(
+                    Finding(
+                        id=f"CL-{counter:04d}",
+                        file=rel,
+                        line=lineno,
+                        pattern_id=pattern_id,
+                        variable_name=var,
+                        sink_type=sink_type,
+                        severity=sev,
+                        verdict_triage="LEAK",
+                        verdict_gate="survived",
+                        reason=(
+                            f"credential identifier '{var}' reaches a {sink_type} "
+                            f"sink ({pattern_id})"
+                            + (" in a test/fixture path" if is_test else "")
+                        ),
+                    )
+                )
+                break  # one finding per line is enough
+
+    sev_count = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0}
+    for f in findings:
+        sev_count[f.severity] = sev_count.get(f.severity, 0) + 1
+    blocking = sev_count["CRITICAL"] + sev_count["HIGH"]
+
+    return {
+        "scan_root": root,
+        "stages": {
+            "regex_scan": {"files_scanned": files_scanned, "candidates": candidates},
+            "triage": {"leaks": len(findings)},
+        },
+        "findings": [asdict(f) for f in findings],
+        "summary": {
+            "total_findings": len(findings),
+            "critical": sev_count["CRITICAL"],
+            "high": sev_count["HIGH"],
+            "medium": sev_count["MEDIUM"],
+            "low": sev_count["LOW"],
+            "blocking": blocking,
+        },
+        "decision": "fail" if blocking > 0 else "pass",
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Deterministic credential-leak gate")
+    ap.add_argument("--root", required=True, help="Directory to scan")
+    ap.add_argument("--report", required=True, help="Verdict JSON output path")
+    args = ap.parse_args()
+
+    verdict = scan(args.root)
+    with open(args.report, "w", encoding="utf-8") as fh:
+        json.dump(verdict, fh, indent=2)
+
+    s = verdict["summary"]
+    print(
+        f"Scanned {verdict['stages']['regex_scan']['files_scanned']} files, "
+        f"{verdict['stages']['regex_scan']['candidates']} candidate lines."
+    )
+    print(
+        f"Findings: {s['total_findings']} "
+        f"({s['critical']} critical, {s['high']} high, "
+        f"{s['medium']} medium, {s['low']} low) — "
+        f"{s['blocking']} blocking. Decision: {verdict['decision']}."
+    )
+    for f in verdict["findings"]:
+        if f["severity"] in ("CRITICAL", "HIGH"):
+            print(
+                f"  [{f['severity']}] {f['file']}:{f['line']} "
+                f"({f['pattern_id']}, var={f['variable_name']})"
+            )
+    return 1 if verdict["decision"] == "fail" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/credential-leak-gate/scan.py
+++ b/.github/scripts/credential-leak-gate/scan.py
@@ -194,7 +194,7 @@ def _strip_comment(line: str, ext: str) -> str:
     return line
 
 
-def _referenced_as_code(line: str, var_norm: str) -> bool:
+def _referenced_as_code(line: str) -> bool:
     """True when the credential identifier is used as a value/variable, not just
     as a word inside a log-message string literal."""
     if INTERP.search(line):
@@ -292,7 +292,7 @@ def scan(root: str) -> dict:
                 if pattern_id not in (
                     "shell-echo",
                     "helm-set",
-                ) and not _referenced_as_code(code, var_norm):
+                ) and not _referenced_as_code(code):
                     break
                 counter += 1
                 sev = _severity(var_norm, pattern_id, is_test)

--- a/.github/scripts/credential-leak-gate/scan.py
+++ b/.github/scripts/credential-leak-gate/scan.py
@@ -164,8 +164,6 @@ REDACT = re.compile(
 # String literals (single/double quoted, non-greedy). Used to decide whether a
 # credential identifier is referenced as code vs only inside a message string.
 STRING_LIT = re.compile(r"""(['"]).*?\1""")
-# f-string / template-literal interpolation of a credential identifier.
-INTERP = re.compile(r"""[{$]\s*[^{}]*""" + CRED + r"""[^{}]*[}]?""", re.IGNORECASE)
 
 
 @dataclass
@@ -194,15 +192,71 @@ def _strip_comment(line: str, ext: str) -> str:
     return line
 
 
-def _referenced_as_code(line: str) -> bool:
-    """True when the credential identifier is used as a value/variable, not just
-    as a word inside a log-message string literal."""
-    if INTERP.search(line):
+# Metadata-accessor builtins: logging `bool(creds)` / `type(creds)` /
+# `len(creds)` / `list(creds.keys())` reveals shape/presence, not the value.
+_META_BUILTIN = re.compile(r"(bool|type|len|dir|id|isinstance|repr|hasattr)\s*\([^)]*$")
+
+
+_BRACE = re.compile(r"\{[^{}]*\}")
+_IS_NONE = re.compile(r"[\w\[\]'\".]*\s+is\s+(not\s+)?none\b", re.IGNORECASE)
+LOGGING_SINKS = (
+    "logger-call",
+    "print-call",
+    "console-call",
+    "go-fmt-call",
+    "rust-println",
+)
+
+
+def _logging_leak_var(code: str) -> str | None:
+    """For a logging-style sink line, return the credential identifier that
+    actually reaches the sink *as a value*, or None when every occurrence is
+    derived metadata (keys()/bool()/type()/membership/`_name` suffix/presence
+    check) or appears only inside a plain message string.
+
+    Evaluating every occurrence — not just the greedy regex capture — avoids
+    misreading lines like `f"{list(creds.keys())} {creds_else}"`.
+    """
+    str_spans = [(m.start(), m.end()) for m in STRING_LIT.finditer(code)]
+    interp_spans = [(m.start(), m.end()) for m in _BRACE.finditer(code)]
+    for m in CRED_BARE.finditer(code):
+        s, e = m.start(), m.end()
+        if META_SUFFIX.match(code[e:]):
+            continue
+        if _is_metadata_access(code, s, e):
+            continue
+        if _IS_NONE.match(code[e:]):  # `creds is None` / `is not None`
+            continue
+        in_interp = any(a <= s < b for a, b in interp_spans)
+        in_string = any(a <= s < b for a, b in str_spans)
+        # A value reference is interpolated, or sits outside any string literal
+        # (bare variable / kwarg / concatenation). A bare word inside a message
+        # string is not a leak.
+        if in_interp or not in_string:
+            return m.group("var")
+    return None
+
+
+def _is_metadata_access(code: str, var_start: int, var_end: int) -> bool:
+    """True when the credential identifier reaches the sink only as derived
+    metadata (key names, a bool/type/len, or a string-literal dict key) rather
+    than as the secret value itself. These are the dominant false positives on
+    real connector apps (`logger.info(f"keys: {list(creds.keys())}")`)."""
+    before = code[:var_start]
+    after = code[var_end:]
+    # `creds.keys()` / `creds['x'].keys()` — logging key NAMES, not values.
+    if re.match(r"[\w\[\]'\"]*\.\s*keys\s*\(", after):
         return True
-    # Strip quoted string literals; if the identifier still appears, it is being
-    # referenced as code (a variable, kwarg, concatenation, CLI arg, ...).
-    stripped = STRING_LIT.sub("", line)
-    return CRED_BARE.search(stripped) is not None
+    # Wrapped in a metadata builtin: bool(creds), type(creds), len(creds), ...
+    if _META_BUILTIN.search(before):
+        return True
+    # The identifier is itself a quoted string literal (e.g. a dict key in a
+    # membership/`.get()` test: `'credentials' in cfg`), not a value reference.
+    # Allow trailing word chars (the matched token may be a prefix, e.g.
+    # `credential` of `credentials`) before the closing quote.
+    if before[-1:] in ("'", '"') and re.match(r"\w*['\"]", after):
+        return True
+    return False
 
 
 def _norm(var: str) -> str:
@@ -282,18 +336,30 @@ def scan(root: str) -> dict:
                     break
                 if REDACT.search(code):
                     break  # value masked before the sink — not a leak
-                var = m.groupdict().get("var") or ""
+                if pattern_id in LOGGING_SINKS:
+                    # Evaluate every credential occurrence: a leak requires one
+                    # that reaches the sink as a value, not derived metadata
+                    # (keys()/bool()/type()/membership/presence/`_name` suffix)
+                    # or a bare word in a message string.
+                    var = _logging_leak_var(code) or ""
+                    if not var:
+                        break
+                else:
+                    var = m.groupdict().get("var") or ""
+                    # Metadata, not a secret value: `credential_name`,
+                    # `secret_id`, ... (suffix immediately after the token).
+                    if META_SUFFIX.search(code[m.end("var") :]):
+                        break
+                    # Secure shell idiom, not a leak: piping a secret into a
+                    # command's stdin (`echo "$PASSWORD" | docker login
+                    # --password-stdin`) feeds the value to stdin, not a
+                    # log/console sink — the *recommended* way to pass a secret.
+                    # Skip when the echo/printf is piped on, or `--*-stdin` used.
+                    if pattern_id == "shell-echo" and (
+                        "-stdin" in code or re.search(r"(?<!\|)\|(?!\|)", code)
+                    ):
+                        break
                 var_norm = _norm(var)
-                # Metadata, not a secret value: `credential_name`, `secret_id`,
-                # `credential_guid`, ... (suffix immediately after the token).
-                if META_SUFFIX.search(code[m.end("var") :]):
-                    break
-                # Static triage: only a real leak if referenced as code.
-                if pattern_id not in (
-                    "shell-echo",
-                    "helm-set",
-                ) and not _referenced_as_code(code):
-                    break
                 counter += 1
                 sev = _severity(var_norm, pattern_id, is_test)
                 findings.append(

--- a/.github/scripts/tests/test_credential_leak_scan.py
+++ b/.github/scripts/tests/test_credential_leak_scan.py
@@ -55,6 +55,33 @@ def test_metadata_identifier_is_not_a_leak(tmp_path: Path) -> None:
     assert result["findings"] == []
 
 
+def test_logging_credential_keys_is_not_a_leak(tmp_path: Path) -> None:
+    # Logging key NAMES / shape, not the value — the dominant FP on real apps.
+    _write(
+        tmp_path,
+        "h.py",
+        'logger.info(f"keys: {list(credentials.keys())}")\n'
+        'logger.debug(f"has pwd: {bool(password)}")\n'
+        'logger.error(f"type: {type(credentials)}")\n'
+        "logger.info(f\"present: {'credentials' in cfg}\")\n",
+    )
+    result = scan.scan(str(tmp_path))
+    assert result["findings"] == []
+    assert result["decision"] == "pass"
+
+
+def test_logging_raw_credential_object_still_blocks(tmp_path: Path) -> None:
+    # The genuine April-audit leak class: the raw object reaches the sink.
+    _write(
+        tmp_path,
+        "h.js",
+        'console.log("returning credentials:", credentials)\n',
+    )
+    result = scan.scan(str(tmp_path))
+    assert _by_file(result)["h.js"]["severity"] in ("CRITICAL", "HIGH")
+    assert result["decision"] == "fail"
+
+
 def test_helm_set_is_medium_non_blocking(tmp_path: Path) -> None:
     _write(tmp_path, "deploy.sh", "helm upgrade app --set password=$DB_PASSWORD\n")
     result = scan.scan(str(tmp_path))
@@ -62,6 +89,26 @@ def test_helm_set_is_medium_non_blocking(tmp_path: Path) -> None:
     assert finding["severity"] == "MEDIUM"
     assert result["summary"]["blocking"] == 0
     assert result["decision"] == "pass"
+
+
+def test_password_stdin_pipe_is_not_a_leak(tmp_path: Path) -> None:
+    # The recommended secure docker-login idiom: secret piped to stdin, never
+    # a log/console sink. Present in most app repos' CI scaffold.
+    _write(
+        tmp_path,
+        "ci/registry-login.sh",
+        'echo "$PASSWORD" | docker login "$REG" -u "$USER" --password-stdin\n',
+    )
+    result = scan.scan(str(tmp_path))
+    assert result["findings"] == []
+    assert result["decision"] == "pass"
+
+
+def test_bare_echo_of_secret_still_flagged(tmp_path: Path) -> None:
+    # No pipe / stdin — echoes the secret to stdout (CI log). Still a leak.
+    _write(tmp_path, "run.sh", 'echo "password=$DB_PASSWORD"\n')
+    result = scan.scan(str(tmp_path))
+    assert _by_file(result)["run.sh"]["pattern_id"] == "shell-echo"
 
 
 def test_test_path_is_capped_at_medium(tmp_path: Path) -> None:

--- a/.github/scripts/tests/test_credential_leak_scan.py
+++ b/.github/scripts/tests/test_credential_leak_scan.py
@@ -1,0 +1,106 @@
+"""Tests for .github/scripts/credential-leak-gate/scan.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "credential-leak-gate"))
+
+import scan  # noqa: E402
+
+
+def _write(root: Path, rel: str, body: str) -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body)
+
+
+def _by_file(result: dict) -> dict[str, dict]:
+    return {f["file"]: f for f in result["findings"]}
+
+
+def test_real_credential_in_logger_is_critical_and_blocks(tmp_path: Path) -> None:
+    _write(tmp_path, "handler.py", 'logger.info(f"credentials={credentials}")\n')
+    result = scan.scan(str(tmp_path))
+    assert result["decision"] == "fail"
+    assert result["summary"]["blocking"] == 1
+    finding = _by_file(result)["handler.py"]
+    assert finding["severity"] == "CRITICAL"
+    assert finding["pattern_id"] == "logger-call"
+
+
+def test_prose_log_message_is_not_flagged(tmp_path: Path) -> None:
+    # The word "password" appears only inside the message string, never as code.
+    _write(tmp_path, "h.py", 'logger.info("password reset email sent to user")\n')
+    result = scan.scan(str(tmp_path))
+    assert result["findings"] == []
+    assert result["decision"] == "pass"
+
+
+def test_masked_value_is_skipped(tmp_path: Path) -> None:
+    _write(tmp_path, "h.py", 'logger.info("auth %s", mask(password))\n')
+    result = scan.scan(str(tmp_path))
+    assert result["findings"] == []
+
+
+def test_metadata_identifier_is_not_a_leak(tmp_path: Path) -> None:
+    # credential_name / secret_id are names/ids, not the secret value.
+    _write(
+        tmp_path,
+        "h.py",
+        'logger.info(f"credential={cred.credential_name} id={cred.secret_id}")\n',
+    )
+    result = scan.scan(str(tmp_path))
+    assert result["findings"] == []
+
+
+def test_helm_set_is_medium_non_blocking(tmp_path: Path) -> None:
+    _write(tmp_path, "deploy.sh", "helm upgrade app --set password=$DB_PASSWORD\n")
+    result = scan.scan(str(tmp_path))
+    finding = _by_file(result)["deploy.sh"]
+    assert finding["severity"] == "MEDIUM"
+    assert result["summary"]["blocking"] == 0
+    assert result["decision"] == "pass"
+
+
+def test_test_path_is_capped_at_medium(tmp_path: Path) -> None:
+    _write(tmp_path, "tests/test_conn.py", 'logger.info(f"password={password}")\n')
+    result = scan.scan(str(tmp_path))
+    finding = _by_file(result)["tests/test_conn.py"]
+    assert finding["severity"] == "MEDIUM"
+    assert result["summary"]["blocking"] == 0
+
+
+def test_inline_comment_does_not_fire(tmp_path: Path) -> None:
+    _write(tmp_path, "h.py", 'print("hello")  # remember the password=secret\n')
+    result = scan.scan(str(tmp_path))
+    assert result["findings"] == []
+
+
+def test_allowlist_line_suppresses_finding(tmp_path: Path) -> None:
+    _write(tmp_path, "h.py", 'logger.info(f"secret={secret}")\n')
+    _write(tmp_path, ".credential-leak-allow", "h.py:1\n")
+    result = scan.scan(str(tmp_path))
+    assert result["findings"] == []
+    assert result["decision"] == "pass"
+
+
+def test_allowlist_file_suppresses_whole_file(tmp_path: Path) -> None:
+    _write(tmp_path, "h.py", 'logger.info(f"secret={secret}")\n')
+    _write(tmp_path, ".credential-leak-allow", "# ignore vault helper\nh.py\n")
+    result = scan.scan(str(tmp_path))
+    assert result["findings"] == []
+
+
+def test_skips_vendored_dirs(tmp_path: Path) -> None:
+    _write(tmp_path, "node_modules/x.js", "console.log(`secret=${secret}`)\n")
+    result = scan.scan(str(tmp_path))
+    assert result["findings"] == []
+
+
+def test_clean_tree_passes(tmp_path: Path) -> None:
+    _write(tmp_path, "h.py", 'logger.info("started worker")\n')
+    result = scan.scan(str(tmp_path))
+    assert result["decision"] == "pass"
+    assert result["summary"]["total_findings"] == 0

--- a/.github/scripts/tests/test_credential_leak_scan.py
+++ b/.github/scripts/tests/test_credential_leak_scan.py
@@ -82,6 +82,38 @@ def test_logging_raw_credential_object_still_blocks(tmp_path: Path) -> None:
     assert result["decision"] == "fail"
 
 
+def test_logging_non_secret_field_is_not_a_leak(tmp_path: Path) -> None:
+    # Accessing a non-secret field of a credential object logs that field,
+    # not the secret value.
+    _write(
+        tmp_path,
+        "h.py",
+        "logger.info(f\"host: {credentials['host']}\")\n"
+        "logger.info(f\"authType={credentials.get('authType')}\")\n"
+        'logger.debug(f"user: {self._credentials.impersonate_user}")\n'
+        'logger.info(f"empty: {not credentials if isinstance(credentials, dict) else 0}")\n',
+    )
+    result = scan.scan(str(tmp_path))
+    assert result["findings"] == []
+
+
+def test_logging_secret_field_still_blocks(tmp_path: Path) -> None:
+    # Accessing a secret-named field MUST still flag.
+    _write(
+        tmp_path,
+        "h.py",
+        "logger.info(f\"pw: {credentials['password']}\")\n",
+    )
+    result = scan.scan(str(tmp_path))
+    assert result["decision"] == "fail"
+
+
+def test_semgrep_rule_file_is_skipped(tmp_path: Path) -> None:
+    _write(tmp_path, ".semgrep.yml", "    - pattern: print(... , credentials, ...)\n")
+    result = scan.scan(str(tmp_path))
+    assert result["findings"] == []
+
+
 def test_helm_set_is_medium_non_blocking(tmp_path: Path) -> None:
     _write(tmp_path, "deploy.sh", "helm upgrade app --set password=$DB_PASSWORD\n")
     result = scan.scan(str(tmp_path))

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -75,9 +75,9 @@ on:
       APP_PUBLISH_TOKEN:
         required: false
         description: "API token for marketplace publish — required when publish=true"
-      LEAK_SCAN_SLACK_WEBHOOK:
+      SLACK_LEAK_SCAN_WEBHOOK:
         required: false
-        description: "Slack incoming-webhook URL for credential-leak (creds-into-logs) WARNINGS. Warnings are non-blocking; when this is unset the Slack ping is skipped. Never receives secret values — only file:line locations."
+        description: "Slack incoming-webhook URL (hooks.slack.com) for credential-leak (creds-into-logs) WARNINGS. Org-level secret, passed via `secrets: inherit` — same convention as SLACK_DEP_COOLDOWN_WEBHOOK. Warnings are non-blocking; when unset the Slack ping is skipped. Never receives secret values — only file:line locations."
 
 permissions:
   contents: read
@@ -687,30 +687,37 @@ jobs:
           fi
 
       - name: Notify Slack on warnings
-        # Warn-only signal → Slack. Skipped silently when the webhook secret is
-        # not configured, so apps that haven't set it still publish cleanly.
+        # Warn-only signal → Slack. Gated on the step OUTPUT (not the secret):
+        # secrets are unavailable in `if:`, so the secret presence is checked
+        # inside the step instead. Mirrors reusable-dep-cooldown.yml.
         if: always() && steps.gitleaks.outcome == 'success' && (steps.credscan.outputs.blocking || '0') != '0'
         env:
-          SLACK_WEBHOOK: ${{ secrets.LEAK_SCAN_SLACK_WEBHOOK }}
-          WARN: ${{ steps.credscan.outputs.blocking }}
+          WEBHOOK: ${{ secrets.SLACK_LEAK_SCAN_WEBHOOK }}
           CRIT: ${{ steps.credscan.outputs.critical }}
           HIGH: ${{ steps.credscan.outputs.high }}
           REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          if [ -z "${SLACK_WEBHOOK:-}" ]; then
-            echo "::notice::LEAK_SCAN_SLACK_WEBHOOK not set — skipping Slack notification."
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "::notice::SLACK_LEAK_SCAN_WEBHOOK not set — skipping Slack notification."
             exit 0
           fi
+          # Host allowlist: refuse to send if the secret is ever tampered to
+          # point somewhere other than Slack.
+          case "$WEBHOOK" in
+            https://hooks.slack.com/*) ;;
+            *) echo "::warning::SLACK_LEAK_SCAN_WEBHOOK is not a hooks.slack.com URL — refusing to send."; exit 0 ;;
+          esac
           V=/tmp/leak-gate-verdict.json
           # Top 10 locations only — never secret values.
           LOCS=$(jq -r '.findings[]? | select(.severity=="CRITICAL" or .severity=="HIGH") | "• `\(.file):\(.line)` (\(.pattern_id), \(.severity))"' "$V" | head -10)
           TEXT=$(printf ':warning: *Credential-leak warnings* in *%s* (publish NOT blocked)\n%s critical, %s high reaching log/CLI sinks.\n%s\n<%s|View run>' \
             "$REPO" "$CRIT" "$HIGH" "$LOCS" "$RUN_URL")
-          # jq builds the JSON so the message is safely escaped.
+          # jq builds the JSON so the message is safely escaped. --fail/--max-time
+          # so a hung Slack endpoint can't stall or fail the job (warn-only).
           jq -n --arg t "$TEXT" '{text: $t}' \
-            | curl -sS -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK" \
+            | curl -sS --fail --max-time 10 -X POST -H 'Content-type: application/json' --data @- "$WEBHOOK" \
             || echo "::warning::Slack notification failed (non-blocking)."
 
   # ── Job 1: Read atlan.yaml, validate secrets, compute all image tags ──────────

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -576,14 +576,17 @@ jobs:
 
       # ── Layer 1: deterministic hardcoded-secret scan (gitleaks) ───────────────
       - name: Install gitleaks
-        env:
-          GITHUB_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
         run: |
           set -euo pipefail
           GITLEAKS_VERSION=8.21.2
+          # Pin the artifact by SHA-256 (not just version): the checksum is
+          # hardcoded here, so a tampered release asset fails verification
+          # rather than being trusted because it sits at the right URL.
+          GITLEAKS_SHA256=5bc41815076e6ed6ef8fbecc9d9b75bcae31f39029ceb55da08086315316e3ba
           curl -sSL \
             "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
             -o /tmp/gitleaks.tar.gz
+          echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum -c -
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
           sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
           gitleaks version

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -528,19 +528,165 @@ jobs:
           fi
           exit 0
 
+  # ── Job 0d: Credential-leak gate — block publish on any leak ──────────────────
+  # Two deterministic layers, both blocking, run before any build minutes are
+  # spent so a leak surfaces at minute 0. No LLM, no token, no network beyond
+  # checkout + the pinned gitleaks download.
+  #   1. Hardcoded secrets: gitleaks over the checked-out source for committed
+  #      secrets (API keys, tokens, private keys). Honors an app-level
+  #      .gitleaks.toml allowlist.
+  #   2. Creds-into-logs: a regex scanner (scan.py) for credentials reaching
+  #      log/print/format/CLI-arg sinks (the APP-1602 audit class). Mirrors the
+  #      nightly credential-leak-scan's sink pattern set + severity rubric, with
+  #      the LLM triage replaced by static heuristics (masking-helper skip,
+  #      metadata-identifier exclusion, code-vs-message-string check, test-path
+  #      downgrade) plus an app-level .credential-leak-allow allowlist.
+  #      CRITICAL/HIGH findings block; MEDIUM/LOW are reported only.
+  # Only runs when publish=true (matches validate-channel / certify). A failure
+  # here trips prepare's `!failure()` and skips build + publish.
+  # See docs/standards/credential-leak-gate.md.
+  leak-scan:
+    name: Credential leak gate
+    if: inputs.publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          path: app
+          fetch-depth: 1
+
+      - name: Checkout SDK gate assets
+        # Pull only the vendored scanner + ruleset from the SDK at main, so the
+        # gate is self-contained at publish time (no private cross-repo fetch of
+        # the connector-pulse nightly skill). ORG_PAT_GITHUB grants the
+        # cross-repo read a consumer app's scoped GITHUB_TOKEN cannot.
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          repository: atlanhq/application-sdk
+          ref: main
+          path: sdk
+          sparse-checkout: .github/scripts/credential-leak-gate
+          sparse-checkout-cone-mode: false
+          token: ${{ secrets.ORG_PAT_GITHUB }}
+
+      # ── Layer 1: deterministic hardcoded-secret scan (gitleaks) ───────────────
+      - name: Install gitleaks
+        env:
+          GITHUB_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+        run: |
+          set -euo pipefail
+          GITLEAKS_VERSION=8.21.2
+          curl -sSL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            -o /tmp/gitleaks.tar.gz
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: gitleaks — hardcoded secrets
+        id: gitleaks
+        working-directory: app
+        run: |
+          set -euo pipefail
+          # Scan the working tree, not git history: a publish checkout is a
+          # single shallow commit. Drop .git so gitleaks doesn't walk internals.
+          rm -rf .git
+          CONFIG_ARGS=()
+          if [ -f .gitleaks.toml ]; then
+            echo "Using app-level .gitleaks.toml allowlist"
+            CONFIG_ARGS=(--config .gitleaks.toml)
+          fi
+          set +e
+          gitleaks dir \
+            --report-format json \
+            --report-path /tmp/gitleaks-report.json \
+            "${CONFIG_ARGS[@]}" \
+            .
+          RC=$?
+          set -e
+          COUNT=$(jq 'length' /tmp/gitleaks-report.json 2>/dev/null || echo 0)
+          if [ "$RC" -ne 0 ] || [ "$COUNT" -gt 0 ]; then
+            # Emit redacted finding LOCATIONS only — never the secret value
+            # (the report's Secret/Match fields are not printed or uploaded).
+            {
+              echo "### ❌ Publish blocked — hardcoded secret(s) detected"
+              echo ""
+              echo "gitleaks found ${COUNT} hardcoded secret(s) in the source. Locations only (values withheld):"
+              echo ""
+              jq -r '.[] | "- `\(.File):\(.StartLine)` — rule: \(.RuleID)"' /tmp/gitleaks-report.json 2>/dev/null || true
+              echo ""
+              echo "Remove the secret(s), **rotate** any that were committed, and re-run. Allowlist confirmed false positives in \`.gitleaks.toml\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error title=Publish blocked::gitleaks found ${COUNT} hardcoded secret(s). See workflow summary."
+            exit 1
+          fi
+          echo "gitleaks: no hardcoded secrets found."
+
+      # ── Layer 2: deterministic creds-into-logs scan (regex, no LLM) ───────────
+      - name: Creds-into-logs scan
+        id: credscan
+        run: |
+          set -euo pipefail
+          python3 sdk/.github/scripts/credential-leak-gate/scan.py \
+            --root app \
+            --report /tmp/leak-gate-verdict.json
+
+      - name: Enforce creds-into-logs verdict
+        # always() so a non-zero scan exit (blocking findings) still renders the
+        # summary instead of being swallowed by the failed previous step.
+        if: always() && steps.gitleaks.outcome == 'success'
+        run: |
+          set -euo pipefail
+          VERDICT=/tmp/leak-gate-verdict.json
+          # Fail closed: a missing or malformed verdict blocks the publish.
+          if [ ! -f "$VERDICT" ] || ! jq empty "$VERDICT" 2>/dev/null; then
+            echo "::error title=Publish blocked::creds-into-logs scan produced no valid verdict JSON. Gate fails closed."
+            exit 1
+          fi
+          DECISION=$(jq -r '.decision // "fail"' "$VERDICT")
+          BLOCKING=$(jq -r '.summary.blocking // 0' "$VERDICT")
+          CRIT=$(jq -r '.summary.critical // 0' "$VERDICT")
+          HIGH=$(jq -r '.summary.high // 0' "$VERDICT")
+          MED=$(jq -r '.summary.medium // 0' "$VERDICT")
+          if [ "$DECISION" != "pass" ] || [ "$BLOCKING" -gt 0 ]; then
+            {
+              echo "### ❌ Publish blocked — credential(s) reaching log/CLI sinks"
+              echo ""
+              echo "${BLOCKING} blocking finding(s) (${CRIT} critical, ${HIGH} high). Locations only (values never recorded):"
+              echo ""
+              jq -r '.findings[]? | select(.severity=="CRITICAL" or .severity=="HIGH") | "- `\(.file):\(.line)` — \(.pattern_id) (var: \(.variable_name), \(.severity))"' "$VERDICT"
+              echo ""
+              echo "Route the credential through the SDK redaction helper before the sink, or drop the log line. Confirmed false positives go in \`.credential-leak-allow\`. See docs/standards/credential-leak-gate.md."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error title=Publish blocked::${BLOCKING} credential-leak finding(s) reach a log/CLI sink."
+            exit 1
+          fi
+          {
+            echo "### ✅ Credential leak gate passed"
+            echo ""
+            echo "gitleaks: 0 hardcoded secrets. Creds-into-logs: 0 blocking findings (${MED} medium reported, non-blocking)."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   # ── Job 1: Read atlan.yaml, validate secrets, compute all image tags ──────────
   prepare:
-    needs: [validate-channel, unit-tests-gate, certify]
-    # `needs: [validate-channel, unit-tests-gate, certify]` only enforces
-    # ordering when those jobs run. When publish=false, all three are skipped
-    # via their `if:` — which by default would propagate "skipped" to
-    # dependents. The condition below explicitly allows prepare to run when
-    # those jobs are skipped OR successful, but NOT when one failed. `certify`
-    # enforces its unit + coverage check: a failing run exits non-zero, which
-    # trips `failure()` here and correctly skips prepare → build → publish. Its
-    # other layers (v3 shape, contract drift) stay warn-only (always exit 0) so
-    # they never trip this yet. `unit-tests-gate` is currently warn-only;
-    # its enforcement-flip is tracked separately.
+    needs: [validate-channel, unit-tests-gate, certify, leak-scan]
+    # `needs: [...]` only enforces ordering when those jobs run. When
+    # publish=false, all of them are skipped via their `if:` — which by default
+    # would propagate "skipped" to dependents. The condition below explicitly
+    # allows prepare to run when those jobs are skipped OR successful, but NOT
+    # when one failed. `certify` enforces its unit + coverage check: a failing
+    # run exits non-zero, which trips `failure()` here and correctly skips
+    # prepare → build → publish. Its other layers (v3 shape, contract drift)
+    # stay warn-only (always exit 0) so they never trip this yet.
+    # `leak-scan` enforces: a confirmed hardcoded secret (gitleaks) or a
+    # surviving CRITICAL/HIGH creds-into-logs finding exits non-zero, tripping
+    # `failure()` here and blocking the publish. `unit-tests-gate` is currently
+    # warn-only; its enforcement-flip is tracked separately.
     if: ${{ !failure() && !cancelled() }}
     name: Prepare
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -604,7 +604,11 @@ jobs:
             CONFIG_ARGS=(--config .gitleaks.toml)
           fi
           set +e
+          # --redact: replace secret values with "REDACTED" in the report, so
+          # the raw secret never lands on disk. The summary/Slack steps read only
+          # File/StartLine/RuleID anyway, but this is defense-in-depth.
           gitleaks dir \
+            --redact \
             --report-format json \
             --report-path /tmp/gitleaks-report.json \
             "${CONFIG_ARGS[@]}" \

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -75,6 +75,9 @@ on:
       APP_PUBLISH_TOKEN:
         required: false
         description: "API token for marketplace publish — required when publish=true"
+      LEAK_SCAN_SLACK_WEBHOOK:
+        required: false
+        description: "Slack incoming-webhook URL for credential-leak (creds-into-logs) WARNINGS. Warnings are non-blocking; when this is unset the Slack ping is skipped. Never receives secret values — only file:line locations."
 
 permissions:
   contents: read
@@ -528,22 +531,18 @@ jobs:
           fi
           exit 0
 
-  # ── Job 0d: Credential-leak gate — block publish on any leak ──────────────────
-  # Two deterministic layers, both blocking, run before any build minutes are
-  # spent so a leak surfaces at minute 0. No LLM, no token, no network beyond
-  # checkout + the pinned gitleaks download.
-  #   1. Hardcoded secrets: gitleaks over the checked-out source for committed
-  #      secrets (API keys, tokens, private keys). Honors an app-level
-  #      .gitleaks.toml allowlist.
-  #   2. Creds-into-logs: a regex scanner (scan.py) for credentials reaching
-  #      log/print/format/CLI-arg sinks (the APP-1602 audit class). Mirrors the
-  #      nightly credential-leak-scan's sink pattern set + severity rubric, with
-  #      the LLM triage replaced by static heuristics (masking-helper skip,
-  #      metadata-identifier exclusion, code-vs-message-string check, test-path
-  #      downgrade) plus an app-level .credential-leak-allow allowlist.
-  #      CRITICAL/HIGH findings block; MEDIUM/LOW are reported only.
-  # Only runs when publish=true (matches validate-channel / certify). A failure
-  # here trips prepare's `!failure()` and skips build + publish.
+  # ── Job 0d: Credential-leak gate ──────────────────────────────────────────────
+  # Two deterministic layers (no LLM, no token), run before any build minutes:
+  #   1. Hardcoded secrets (gitleaks) — BLOCKING. A committed secret (API key,
+  #      token, private key) fails the job, which trips prepare's `!failure()`
+  #      and skips build + publish. High precision; honors .gitleaks.toml.
+  #   2. Creds-into-logs (scan.py) — WARN-ONLY. Flags credentials reaching
+  #      log/print/format/CLI sinks (the APP-1602 audit class). Pure-regex
+  #      detection has an irreducible false-positive rate (it cannot always tell
+  #      a logged secret value from a logged non-secret field), so it does NOT
+  #      block: it annotates the run summary and pings Slack when there are
+  #      warnings. Honors an app-level .credential-leak-allow allowlist.
+  # Only runs when publish=true (matches validate-channel / certify).
   # See docs/standards/credential-leak-gate.md.
   leak-scan:
     name: Credential leak gate
@@ -630,50 +629,89 @@ jobs:
           fi
           echo "gitleaks: no hardcoded secrets found."
 
-      # ── Layer 2: deterministic creds-into-logs scan (regex, no LLM) ───────────
-      - name: Creds-into-logs scan
+      # ── Layer 2: creds-into-logs scan (regex, no LLM) — WARN-ONLY ─────────────
+      - name: Creds-into-logs scan (warn-only)
         id: credscan
+        # `|| true`: this layer never fails the job. scan.py exits non-zero when
+        # it finds CRITICAL/HIGH, but here that is advisory — only gitleaks
+        # (Layer 1) blocks the publish. The verdict JSON is the source of truth.
         run: |
-          set -euo pipefail
+          set -uo pipefail
           python3 sdk/.github/scripts/credential-leak-gate/scan.py \
             --root app \
-            --report /tmp/leak-gate-verdict.json
+            --report /tmp/leak-gate-verdict.json || true
+          # Surface counts for the summary + Slack steps. Defaults are safe if
+          # the scan errored (warn-only — an operational failure must not block).
+          V=/tmp/leak-gate-verdict.json
+          if [ -f "$V" ] && jq empty "$V" 2>/dev/null; then
+            echo "findings=$(jq -r '.summary.total_findings // 0' "$V")" >> "$GITHUB_OUTPUT"
+            echo "blocking=$(jq -r '.summary.blocking // 0' "$V")" >> "$GITHUB_OUTPUT"
+            echo "critical=$(jq -r '.summary.critical // 0' "$V")" >> "$GITHUB_OUTPUT"
+            echo "high=$(jq -r '.summary.high // 0' "$V")" >> "$GITHUB_OUTPUT"
+            echo "medium=$(jq -r '.summary.medium // 0' "$V")" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning title=Creds-into-logs scan incomplete::No valid verdict produced; reporting 0 (warn-only, publish not blocked)."
+            echo "findings=0" >> "$GITHUB_OUTPUT"
+            echo "blocking=0" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Enforce creds-into-logs verdict
-        # always() so a non-zero scan exit (blocking findings) still renders the
-        # summary instead of being swallowed by the failed previous step.
+      - name: Creds-into-logs report (run summary)
         if: always() && steps.gitleaks.outcome == 'success'
+        env:
+          WARN: ${{ steps.credscan.outputs.blocking || '0' }}
+          CRIT: ${{ steps.credscan.outputs.critical || '0' }}
+          HIGH: ${{ steps.credscan.outputs.high || '0' }}
+          MED: ${{ steps.credscan.outputs.medium || '0' }}
         run: |
           set -euo pipefail
-          VERDICT=/tmp/leak-gate-verdict.json
-          # Fail closed: a missing or malformed verdict blocks the publish.
-          if [ ! -f "$VERDICT" ] || ! jq empty "$VERDICT" 2>/dev/null; then
-            echo "::error title=Publish blocked::creds-into-logs scan produced no valid verdict JSON. Gate fails closed."
-            exit 1
-          fi
-          DECISION=$(jq -r '.decision // "fail"' "$VERDICT")
-          BLOCKING=$(jq -r '.summary.blocking // 0' "$VERDICT")
-          CRIT=$(jq -r '.summary.critical // 0' "$VERDICT")
-          HIGH=$(jq -r '.summary.high // 0' "$VERDICT")
-          MED=$(jq -r '.summary.medium // 0' "$VERDICT")
-          if [ "$DECISION" != "pass" ] || [ "$BLOCKING" -gt 0 ]; then
+          V=/tmp/leak-gate-verdict.json
+          if [ "${WARN}" -gt 0 ]; then
             {
-              echo "### ❌ Publish blocked — credential(s) reaching log/CLI sinks"
+              echo "### ⚠️ Credential leak warnings (non-blocking)"
               echo ""
-              echo "${BLOCKING} blocking finding(s) (${CRIT} critical, ${HIGH} high). Locations only (values never recorded):"
+              echo "gitleaks: ✅ no hardcoded secrets (blocking layer passed)."
               echo ""
-              jq -r '.findings[]? | select(.severity=="CRITICAL" or .severity=="HIGH") | "- `\(.file):\(.line)` — \(.pattern_id) (var: \(.variable_name), \(.severity))"' "$VERDICT"
+              echo "Creds-into-logs found ${WARN} likely finding(s) (${CRIT} critical, ${HIGH} high). **This does not block the publish** — review and fix, or allowlist confirmed false positives in \`.credential-leak-allow\`. Locations only (values never recorded):"
               echo ""
-              echo "Route the credential through the SDK redaction helper before the sink, or drop the log line. Confirmed false positives go in \`.credential-leak-allow\`. See docs/standards/credential-leak-gate.md."
+              jq -r '.findings[]? | select(.severity=="CRITICAL" or .severity=="HIGH") | "- `\(.file):\(.line)` — \(.pattern_id) (var: \(.variable_name), \(.severity))"' "$V"
+              echo ""
+              echo "See docs/standards/credential-leak-gate.md."
             } >> "$GITHUB_STEP_SUMMARY"
-            echo "::error title=Publish blocked::${BLOCKING} credential-leak finding(s) reach a log/CLI sink."
-            exit 1
+            echo "::warning title=Credential-leak warnings::${WARN} credential(s) may reach a log/CLI sink (non-blocking). See run summary."
+          else
+            {
+              echo "### ✅ Credential leak gate"
+              echo ""
+              echo "gitleaks: ✅ no hardcoded secrets (blocking). Creds-into-logs: ✅ no warnings (${MED} medium, non-blocking)."
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
-          {
-            echo "### ✅ Credential leak gate passed"
-            echo ""
-            echo "gitleaks: 0 hardcoded secrets. Creds-into-logs: 0 blocking findings (${MED} medium reported, non-blocking)."
-          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Notify Slack on warnings
+        # Warn-only signal → Slack. Skipped silently when the webhook secret is
+        # not configured, so apps that haven't set it still publish cleanly.
+        if: always() && steps.gitleaks.outcome == 'success' && (steps.credscan.outputs.blocking || '0') != '0'
+        env:
+          SLACK_WEBHOOK: ${{ secrets.LEAK_SCAN_SLACK_WEBHOOK }}
+          WARN: ${{ steps.credscan.outputs.blocking }}
+          CRIT: ${{ steps.credscan.outputs.critical }}
+          HIGH: ${{ steps.credscan.outputs.high }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_WEBHOOK:-}" ]; then
+            echo "::notice::LEAK_SCAN_SLACK_WEBHOOK not set — skipping Slack notification."
+            exit 0
+          fi
+          V=/tmp/leak-gate-verdict.json
+          # Top 10 locations only — never secret values.
+          LOCS=$(jq -r '.findings[]? | select(.severity=="CRITICAL" or .severity=="HIGH") | "• `\(.file):\(.line)` (\(.pattern_id), \(.severity))"' "$V" | head -10)
+          TEXT=$(printf ':warning: *Credential-leak warnings* in *%s* (publish NOT blocked)\n%s critical, %s high reaching log/CLI sinks.\n%s\n<%s|View run>' \
+            "$REPO" "$CRIT" "$HIGH" "$LOCS" "$RUN_URL")
+          # jq builds the JSON so the message is safely escaped.
+          jq -n --arg t "$TEXT" '{text: $t}' \
+            | curl -sS -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK" \
+            || echo "::warning::Slack notification failed (non-blocking)."
 
   # ── Job 1: Read atlan.yaml, validate secrets, compute all image tags ──────────
   prepare:
@@ -686,10 +724,11 @@ jobs:
     # run exits non-zero, which trips `failure()` here and correctly skips
     # prepare → build → publish. Its other layers (v3 shape, contract drift)
     # stay warn-only (always exit 0) so they never trip this yet.
-    # `leak-scan` enforces: a confirmed hardcoded secret (gitleaks) or a
-    # surviving CRITICAL/HIGH creds-into-logs finding exits non-zero, tripping
-    # `failure()` here and blocking the publish. `unit-tests-gate` is currently
-    # warn-only; its enforcement-flip is tracked separately.
+    # `leak-scan` blocks ONLY on its gitleaks (hardcoded-secret) layer: that
+    # step exits non-zero, fails the job, and trips `failure()` here to skip the
+    # publish. Its creds-into-logs layer is warn-only (annotates + pings Slack,
+    # never fails the job), so warnings do not block. `unit-tests-gate` is
+    # currently warn-only; its enforcement-flip is tracked separately.
     if: ${{ !failure() && !cancelled() }}
     name: Prepare
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -629,6 +629,36 @@ jobs:
           fi
           echo "gitleaks: no hardcoded secrets found."
 
+      - name: Notify Slack on hardcoded-secret block
+        # The gitleaks layer hard-blocks the publish — alert Slack too. Runs only
+        # when the gitleaks step failed. Same webhook + host allowlist + hardened
+        # curl as the warn-only creds-into-logs notifier. Posts finding LOCATIONS
+        # only (never the secret value). Exits 0 so it can't mask the block.
+        if: always() && steps.gitleaks.outcome == 'failure'
+        env:
+          WEBHOOK: ${{ secrets.SLACK_LEAK_SCAN_WEBHOOK }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "::notice::SLACK_LEAK_SCAN_WEBHOOK not set — skipping Slack notification."
+            exit 0
+          fi
+          case "$WEBHOOK" in
+            https://hooks.slack.com/*) ;;
+            *) echo "::warning::SLACK_LEAK_SCAN_WEBHOOK is not a hooks.slack.com URL — refusing to send."; exit 0 ;;
+          esac
+          R=/tmp/gitleaks-report.json
+          COUNT=$(jq 'length' "$R" 2>/dev/null || echo "?")
+          # Top 10 locations only — the report's Secret/Match fields are never read.
+          LOCS=$(jq -r '.[] | "• `\(.File):\(.StartLine)` (rule: \(.RuleID))"' "$R" 2>/dev/null | head -10)
+          TEXT=$(printf ':no_entry: *Publish BLOCKED — hardcoded secret(s)* in *%s*\ngitleaks found %s secret(s) in source. Remove and *rotate* them. Locations only (values withheld):\n%s\n<%s|View run>' \
+            "$REPO" "$COUNT" "$LOCS" "$RUN_URL")
+          jq -n --arg t "$TEXT" '{text: $t}' \
+            | curl -sS --fail --max-time 10 -X POST -H 'Content-type: application/json' --data @- "$WEBHOOK" \
+            || echo "::warning::Slack notification failed (non-blocking)."
+
       # ── Layer 2: creds-into-logs scan (regex, no LLM) — WARN-ONLY ─────────────
       - name: Creds-into-logs scan (warn-only)
         id: credscan

--- a/docs/standards/credential-leak-gate.md
+++ b/docs/standards/credential-leak-gate.md
@@ -47,6 +47,18 @@ job, which trips `failure()` and skips the whole `prepare → build → merge �
 publish` chain. The creds-into-logs layer is warn-only — it never fails the
 job, so its findings (and any scanner error) do not block the publish.
 
+## Slack alerts
+
+If the optional `SLACK_LEAK_SCAN_WEBHOOK` secret is set, the job pings Slack in
+**two** cases (locations only — never secret values):
+
+| Trigger | Message | Publish |
+|---------|---------|---------|
+| gitleaks finds a hardcoded secret | `:no_entry: Publish BLOCKED — hardcoded secret(s)` | **blocked** |
+| creds-into-logs finds CRITICAL/HIGH | `:warning: Credential-leak warnings (publish NOT blocked)` | proceeds |
+
+When the secret is unset, both Slack steps skip silently.
+
 ## Warnings: run summary + Slack
 
 When the creds-into-logs scan produces CRITICAL/HIGH findings:

--- a/docs/standards/credential-leak-gate.md
+++ b/docs/standards/credential-leak-gate.md
@@ -1,10 +1,19 @@
 # Credential Leak Gate (centralized)
 
 The `build-and-publish-app.yaml` reusable workflow runs a **`leak-scan`** job
-before it publishes a version. The job **blocks the publish** when the app
-contains a credential leak. Like the `certify` job, it needs **no per-app
+before it publishes a version. Like the `certify` job, it needs **no per-app
 wiring** — every app is scanned at publish time without editing its own
 workflows.
+
+It has **two layers with different postures**, chosen from a measured dry run
+against all 152 `atlan-*-app` repos:
+
+- **Hardcoded secrets (gitleaks) — BLOCKS the publish.** High precision.
+- **Creds-into-logs (regex scanner) — WARN-ONLY.** Pure-regex detection has an
+  irreducible false-positive rate (it cannot always tell a logged *secret
+  value* from a logged *non-secret field* of a credential object), so it never
+  blocks: it annotates the run summary and pings a Slack channel when there are
+  warnings. Blocking it outright would freeze ~7 repos on false positives.
 
 It is the publish-time counterpart of the nightly **credential-leak-scan**
 in `atlanhq/connector-pulse` (the APP-1602 audit pipeline). The nightly scan
@@ -15,33 +24,46 @@ publish path.
 
 ## What it checks
 
-The job checks out the app source and runs two layers, both blocking, before
-any build minutes are spent:
+The job checks out the app source and runs two layers before any build minutes
+are spent:
 
-| Layer | Tool | Blocks on |
-|-------|------|-----------|
-| **Hardcoded secrets** | [`gitleaks`](https://github.com/gitleaks/gitleaks) over the working tree | any committed secret (API key, token, private key, …) |
-| **Creds-into-logs** | `scan.py` regex scanner (`.github/scripts/credential-leak-gate/`) | any **CRITICAL/HIGH** credential reaching a log / print / format / CLI-arg sink |
+| Layer | Tool | Posture | On finding |
+|-------|------|---------|------------|
+| **Hardcoded secrets** | [`gitleaks`](https://github.com/gitleaks/gitleaks) over the working tree | **Blocking** | any committed secret (API key, token, private key, …) **fails the publish** |
+| **Creds-into-logs** | `scan.py` regex scanner (`.github/scripts/credential-leak-gate/`) | **Warn-only** | CRITICAL/HIGH findings annotate the run summary + ping Slack; publish proceeds |
 
 `MEDIUM`/`LOW` creds-into-logs findings (e.g. `helm --set password=` in an e2e
-script, or any finding under a `tests/` path) are reported in the job summary
-but do **not** block.
+script, or anything under a `tests/` path) are counted but not surfaced as
+warnings.
 
 ## How blocking works
 
 `leak-scan` runs only when `publish: true` (the same condition as
 `validate-channel` and `certify`). It is in `prepare`'s `needs`, and `prepare`
-gates on `!failure()` — so a finding in either layer trips `failure()` and the
-whole `prepare → build → merge → publish` chain is skipped. The gate **fails
-closed**: a missing or malformed scanner verdict also blocks.
+gates on `!failure()`.
+
+**Only the gitleaks layer blocks.** A committed secret fails the `leak-scan`
+job, which trips `failure()` and skips the whole `prepare → build → merge →
+publish` chain. The creds-into-logs layer is warn-only — it never fails the
+job, so its findings (and any scanner error) do not block the publish.
+
+## Warnings: run summary + Slack
+
+When the creds-into-logs scan produces CRITICAL/HIGH findings:
+
+- A **run-summary** section lists the finding **locations** (`file:line`,
+  pattern id, identifier, severity) — never secret values.
+- If the caller sets the optional **`LEAK_SCAN_SLACK_WEBHOOK`** secret (a Slack
+  incoming-webhook URL), the job posts the same location-only summary to that
+  channel with a link to the run. When the secret is unset, the Slack step is
+  skipped silently.
 
 ## The creds-into-logs scanner
 
 `scan.py` mirrors the canonical ruleset in
 `.github/scripts/credential-leak-gate/credential-leak-rules.md` (vendored from
 the connector-pulse nightly skill — keep the two in sync). It replaces the
-nightly's LLM triage with static heuristics that keep the false-positive rate
-low enough for a blocking gate:
+nightly's LLM triage with static heuristics that keep the warning signal clean:
 
 - A candidate is dropped when the line routes the value through a masking
   helper (`mask`/`redact`/`***`/…).
@@ -50,21 +72,26 @@ low enough for a blocking gate:
 - A candidate must be referenced **as code** (interpolated, passed as a
   variable, concatenated) — a credential word appearing only inside a log
   *message string* is not a leak.
-- Findings under test/fixture paths and `helm --set` args cap at `MEDIUM`
-  (non-blocking).
+- A credential accessed by a known **non-secret field** (`creds['host']`,
+  `creds.get('authType')`, `creds.account`, …) logs that field, not the secret.
+- Findings under test/fixture paths and `helm --set` args cap at `MEDIUM`.
+- Security rule-definition files (`*.semgrep.yml`) are skipped — they contain
+  sink patterns as *rules*, not leaks.
 
-Secret values are never recorded or printed — the verdict and job summary
-report only `file:line`, the pattern id, the matched identifier, and severity.
+Secret values are never recorded or printed — the verdict, run summary, and
+Slack message report only `file:line`, the pattern id, the matched identifier,
+and severity.
 
-## Fixing a blocked publish
+## Acting on a finding
 
-**Hardcoded secret (gitleaks):** remove the secret, **rotate** any value that
-was committed, and re-run. Genuine false positives go in an app-level
+**Hardcoded secret (gitleaks) — blocks:** remove the secret, **rotate** any
+value that was committed, and re-run. Genuine false positives go in an app-level
 `.gitleaks.toml` config (the gate passes `--config .gitleaks.toml` when present).
 
-**Creds-into-logs (`scan.py`):** route the credential through the SDK redaction
-helper before the sink, or drop the log line. Confirmed false positives go in
-an app-level `.credential-leak-allow` file at the repo root:
+**Creds-into-logs (`scan.py`) — warning, does not block:** route the credential
+through the SDK redaction helper before the sink, or drop the log line.
+Confirmed false positives go in an app-level `.credential-leak-allow` file at
+the repo root (this keeps the warning + Slack noise down):
 
 ```
 # .credential-leak-allow — one entry per line

--- a/docs/standards/credential-leak-gate.md
+++ b/docs/standards/credential-leak-gate.md
@@ -1,0 +1,82 @@
+# Credential Leak Gate (centralized)
+
+The `build-and-publish-app.yaml` reusable workflow runs a **`leak-scan`** job
+before it publishes a version. The job **blocks the publish** when the app
+contains a credential leak. Like the `certify` job, it needs **no per-app
+wiring** — every app is scanned at publish time without editing its own
+workflows.
+
+It is the publish-time counterpart of the nightly **credential-leak-scan**
+in `atlanhq/connector-pulse` (the APP-1602 audit pipeline). The nightly scan
+is detection + tracking (Linear tickets, ClickHouse) and uses an LLM to triage
+candidates. This gate is **deterministic** (no LLM, no token): same sink
+pattern set and severity rubric, but it just renders a pass/fail verdict in the
+publish path.
+
+## What it checks
+
+The job checks out the app source and runs two layers, both blocking, before
+any build minutes are spent:
+
+| Layer | Tool | Blocks on |
+|-------|------|-----------|
+| **Hardcoded secrets** | [`gitleaks`](https://github.com/gitleaks/gitleaks) over the working tree | any committed secret (API key, token, private key, …) |
+| **Creds-into-logs** | `scan.py` regex scanner (`.github/scripts/credential-leak-gate/`) | any **CRITICAL/HIGH** credential reaching a log / print / format / CLI-arg sink |
+
+`MEDIUM`/`LOW` creds-into-logs findings (e.g. `helm --set password=` in an e2e
+script, or any finding under a `tests/` path) are reported in the job summary
+but do **not** block.
+
+## How blocking works
+
+`leak-scan` runs only when `publish: true` (the same condition as
+`validate-channel` and `certify`). It is in `prepare`'s `needs`, and `prepare`
+gates on `!failure()` — so a finding in either layer trips `failure()` and the
+whole `prepare → build → merge → publish` chain is skipped. The gate **fails
+closed**: a missing or malformed scanner verdict also blocks.
+
+## The creds-into-logs scanner
+
+`scan.py` mirrors the canonical ruleset in
+`.github/scripts/credential-leak-gate/credential-leak-rules.md` (vendored from
+the connector-pulse nightly skill — keep the two in sync). It replaces the
+nightly's LLM triage with static heuristics that keep the false-positive rate
+low enough for a blocking gate:
+
+- A candidate is dropped when the line routes the value through a masking
+  helper (`mask`/`redact`/`***`/…).
+- A candidate is dropped when the matched token is a **metadata identifier**
+  (`credential_name`, `secret_id`, `credential_guid`, …) rather than the value.
+- A candidate must be referenced **as code** (interpolated, passed as a
+  variable, concatenated) — a credential word appearing only inside a log
+  *message string* is not a leak.
+- Findings under test/fixture paths and `helm --set` args cap at `MEDIUM`
+  (non-blocking).
+
+Secret values are never recorded or printed — the verdict and job summary
+report only `file:line`, the pattern id, the matched identifier, and severity.
+
+## Fixing a blocked publish
+
+**Hardcoded secret (gitleaks):** remove the secret, **rotate** any value that
+was committed, and re-run. Genuine false positives go in an app-level
+`.gitleaks.toml` config (the gate passes `--config .gitleaks.toml` when present).
+
+**Creds-into-logs (`scan.py`):** route the credential through the SDK redaction
+helper before the sink, or drop the log line. Confirmed false positives go in
+an app-level `.credential-leak-allow` file at the repo root:
+
+```
+# .credential-leak-allow — one entry per line
+path/to/file.py            # ignore the whole file
+path/to/other.py:123       # ignore a single line
+```
+
+## Relationship to the other security jobs
+
+- **`security-scan`** (`build-and-scan.yaml`, Trivy) scans the built **image**
+  for CVEs. It is about vulnerable dependencies, not leaked credentials.
+- **`leak-scan`** scans the **source** for leaked/hardcoded credentials.
+- **Nightly credential-leak-scan** (connector-pulse) is the wider,
+  LLM-assisted detection + Linear-tracking pipeline. This gate is the
+  synchronous, deterministic enforcement point at publish time.

--- a/docs/standards/credential-leak-gate.md
+++ b/docs/standards/credential-leak-gate.md
@@ -53,10 +53,17 @@ When the creds-into-logs scan produces CRITICAL/HIGH findings:
 
 - A **run-summary** section lists the finding **locations** (`file:line`,
   pattern id, identifier, severity) — never secret values.
-- If the caller sets the optional **`LEAK_SCAN_SLACK_WEBHOOK`** secret (a Slack
-  incoming-webhook URL), the job posts the same location-only summary to that
-  channel with a link to the run. When the secret is unset, the Slack step is
+- If the optional **`SLACK_LEAK_SCAN_WEBHOOK`** secret is set (a
+  `hooks.slack.com` incoming-webhook URL), the job posts the same location-only
+  summary to that channel with a link to the run. When unset, the Slack step is
   skipped silently.
+
+  Set it **once at the org level** and let apps pick it up via `secrets:
+  inherit` — the same convention as `SLACK_DEP_COOLDOWN_WEBHOOK`
+  (`atlanhq/.github` → `reusable-dep-cooldown.yml`). There is no shared generic
+  Slack secret in the org; each pipeline uses its own `SLACK_<purpose>_WEBHOOK`.
+  The webhook URL itself encodes the destination channel. The step refuses to
+  POST anywhere other than `hooks.slack.com`.
 
 ## The creds-into-logs scanner
 

--- a/docs/standards/credential-leak-gate.md
+++ b/docs/standards/credential-leak-gate.md
@@ -65,6 +65,11 @@ When the creds-into-logs scan produces CRITICAL/HIGH findings:
   The webhook URL itself encodes the destination channel. The step refuses to
   POST anywhere other than `hooks.slack.com`.
 
+  **Destination channel:** `#temp-int-studio-test` (`C0ALP5HSTCG`) — create the
+  incoming webhook against this channel and store its URL as the org secret.
+  (A test channel suits the current warn-only rollout; repoint the webhook to a
+  permanent channel later without any workflow change.)
+
 ## The creds-into-logs scanner
 
 `scan.py` mirrors the canonical ruleset in


### PR DESCRIPTION
## What

Adds a new **`leak-scan`** gate job to the `build-and-publish-app.yaml` reusable workflow that **blocks the publish** when the app being published contains a credential leak. Motivated by wanting the same protection as the connector-pulse [Nightly Credential Leak Scan](https://github.com/atlanhq/connector-pulse/actions/runs/26863900052) — but synchronous, in the publish path, and **deterministic (no LLM, no token, no VPN)**.

## How it works

The job runs **only when `publish: true`** (same condition as `validate-channel` / `certify`) and is in `prepare`'s `needs`, so a finding trips the existing `!failure()` chain and skips **build → merge → publish**. Two layers, both blocking, run before any build minutes are spent:

| Layer | Tool | Blocks on |
|-------|------|-----------|
| **Hardcoded secrets** | `gitleaks` (pinned v8.21.2) over the working tree | any committed secret (API key, token, private key, …) |
| **Creds-into-logs** | `scan.py` regex scanner | any **CRITICAL/HIGH** credential reaching a log / print / format / CLI-arg sink |

`MEDIUM`/`LOW` creds-into-logs findings (`helm --set password=`, anything under `tests/`) are reported in the job summary but **don't block**. The gate **fails closed** on a missing/invalid verdict. Secret values are never recorded or printed — only `file:line`, pattern id, matched identifier, and severity.

## Why deterministic (no LLM)

The nightly scan uses an LLM to triage candidates. The detection itself is a regex ruleset, so the gate reuses the nightly's exact sink patterns + severity rubric and replaces the LLM triage with static heuristics:

- skip values routed through a masking helper (`mask`/`redact`/`***`/…)
- exclude metadata identifiers (`credential_name`, `secret_id`, `credential_guid`, …)
- require the credential to be referenced **as code**, not just a word in a log message string
- cap test/fixture paths and `helm --set` at `MEDIUM`
- app-level `.credential-leak-allow` allowlist for confirmed false positives

**FP control:** on the SDK's own 297-file source the naive ruleset flagged **18**; after these heuristics it's down to **1** (a `secret_key` used as a lookup *key name* — exactly what the allowlist is for).

## Files

- `.github/workflows/build-and-publish-app.yaml` — new `leak-scan` job, wired into `prepare`'s `needs`
- `.github/scripts/credential-leak-gate/scan.py` — deterministic scanner
- `.github/scripts/credential-leak-gate/credential-leak-rules.md` — ruleset vendored from connector-pulse (with sync note)
- `.github/scripts/tests/test_credential_leak_scan.py` — 11 tests, all passing
- `docs/standards/credential-leak-gate.md` — standards doc

## Test plan

- [x] `pytest .github/scripts/tests/test_credential_leak_scan.py` — 11 passed
- [x] pre-commit (ruff / ruff-format / isort / pyright) green
- [x] workflow YAML parses
- [ ] **gitleaks layer is unverified locally** (CI-only binary); `gitleaks dir` is correct for v8.21.2 and the step is fail-closed, but first real exercise is the initial CI run

## Notes

- Diverges from the nightly on one pattern: the standalone `fstring-interp` sink is dropped (an f-string isn't a leak unless it reaches a real sink, and the log/print patterns already catch interpolation). Documented in the rules file; it's the single biggest FP reducer.