### PR TITLE
chore(ci): drop snyk_org/snyk_monitor from hotfix/bypass-scan-gate

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -50,11 +50,6 @@ on:
         required: false
         type: string
         default: "https://home.atlan.com"
-      snyk_monitor:
-        description: "Push scan results to Snyk UI dashboard via snyk container monitor (default: false)"
-        required: false
-        type: boolean
-        default: false
     secrets:
       ORG_PAT_GITHUB:
         required: true
@@ -365,8 +360,6 @@ jobs:
     uses: atlanhq/application-sdk/.github/workflows/build-and-scan.yaml@main
     with:
       image: ${{ needs.prepare.outputs.ghcr_image }}
-      snyk_org: partner-images
-      snyk_monitor: ${{ inputs.snyk_monitor }}
       fail_on_findings: false
     secrets: inherit
 


### PR DESCRIPTION
## Summary
- Drops the `snyk_org: partner-images` and `snyk_monitor: \${{ inputs.snyk_monitor }}` inputs from the `security-scan` job's call to `build-and-scan.yaml@main`.
- Also removes the now-unused `snyk_monitor` workflow input at the top of `build-and-publish-app.yaml`.

## Why
PR #1963 removed Snyk from `build-and-scan.yaml` on `main`. Because consumer workflows reference `@main` (floating), every caller still passing `snyk_org` / `snyk_monitor` now hard-errors:

```
Invalid input, snyk_org is not defined in the referenced workflow at
build-and-publish-app.yaml@hotfix/bypass-scan-gate line 368.
```

Reported by the context-studio-app team — their `build-and-publish` started failing today because they pin to `hotfix/bypass-scan-gate` (pending SDK v3 migration).

## Scope
Targets `hotfix/bypass-scan-gate` only — keeps the bypass branch alive for apps that haven't migrated to v3 yet, just realigns it with the current `build-and-scan` input contract.

## Test plan
- [ ] Re-run context-studio-app `build-and-publish` after merge — Vulnerability Scan job should now resolve inputs cleanly and run Trivy only.
- [ ] Confirm no other caller on `hotfix/bypass-scan-gate` regresses.