### PR TITLE
chore(ci): add force-external-runtime opt-in to connector-integration-tests action

### DIFF
--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -104,6 +104,14 @@ inputs:
     required: false
     description: Dapr runtime version to install.
     default: "1.16.2"
+  force-external-runtime:
+    required: false
+    description: >
+      Force the external Dapr CLI + Temporal CLI install steps to run even when the
+      installed SDK reports embedded runtime support (SDK >= 3.13). Use when the
+      connector's main.py has NOT been migrated to the embedded runtime path yet
+      and still expects external daprd at localhost:3500 + temporal at localhost:7233.
+    default: "false"
 
 runs:
   using: "composite"
@@ -132,7 +140,7 @@ runs:
         echo "SDK ${VER} -> embedded runtime: ${EMBEDDED}"
 
     - name: Install Dapr CLI
-      if: steps.runtime.outputs.embedded != 'true'
+      if: steps.runtime.outputs.embedded != 'true' || inputs.force-external-runtime == 'true'
       shell: bash
       run: |
         DAPR_VERSION="${{ inputs.dapr-version }}"
@@ -143,24 +151,24 @@ runs:
         dapr init --runtime-version "${DAPR_VERSION}" --slim
 
     - name: Install Temporal CLI
-      if: steps.runtime.outputs.embedded != 'true'
+      if: steps.runtime.outputs.embedded != 'true' || inputs.force-external-runtime == 'true'
       shell: bash
       run: curl -sSf https://temporal.download/cli.sh | sh
 
     - name: Add Dapr and Temporal to PATH
-      if: steps.runtime.outputs.embedded != 'true'
+      if: steps.runtime.outputs.embedded != 'true' || inputs.force-external-runtime == 'true'
       shell: bash
       run: |
         echo "$HOME/.dapr/bin" >> "$GITHUB_PATH"
         echo "$HOME/.temporalio/bin" >> "$GITHUB_PATH"
 
     - name: Download Dapr components
-      if: steps.runtime.outputs.embedded != 'true'
+      if: steps.runtime.outputs.embedded != 'true' || inputs.force-external-runtime == 'true'
       shell: bash
       run: uv run poe download-components
 
     - name: Start Dapr + Temporal
-      if: steps.runtime.outputs.embedded != 'true'
+      if: steps.runtime.outputs.embedded != 'true' || inputs.force-external-runtime == 'true'
       shell: bash
       run: |
         uv run poe start-deps


### PR DESCRIPTION
## Summary

Add a per-invocation opt-in to the `connector-integration-tests` composite action so connectors pinned to SDK >= 3.13 that haven't yet migrated to the embedded runtime path can still get the external Dapr + Temporal install they need.

## Context

Today the action detects SDK >= 3.13 and skips:
- Install Dapr CLI
- Install Temporal CLI
- Add Dapr/Temporal to PATH
- Download Dapr components
- Start Dapr + Temporal

The assumption is the SDK boots embedded daprd + temporal in-process. But several connectors are pinned to SDK 3.13.1+ while their `main.py` still calls out to `localhost:3500` (Dapr) and `localhost:7233` (Temporal). Those connectors hit:
- `StorageConfigError: [AAF-STR-003] No Dapr component named 'objectstore' found in components`
- `RuntimeError: Failed client connect: tcp connect error, 127.0.0.1:7233, ConnectionRefused`

## Fix

Add input `force-external-runtime` (default `'false'`). When `'true'`, the 5 install/start steps run regardless of detected SDK version.

Caller usage:
```yaml
- uses: atlanhq/application-sdk/.github/actions/connector-integration-tests@main
  with:
    app-name: databricks
    force-external-runtime: 'true'
```

## Safety

Pure additive change. Default `'false'` preserves all current behavior. No existing caller breaks. Affected only when a connector explicitly opts in.

## Test plan
- [x] Existing connectors (looker, mysql, athena) — unchanged behavior, no flag set
- [ ] `atlan-databricks-app` PR will set the flag and validate end-to-end