### PR TITLE
fix(certify): install all dependency groups when running app unit tests

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -453,7 +453,12 @@ jobs:
             echo "No tests/unit/ — skipping."
             exit 0
           fi
-          uv run --with pytest-cov pytest tests/unit --cov=app --cov-report=term
+          # --all-groups so the app's test dependency group (pytest plugins like
+          # pytest-asyncio, etc.) is installed. `uv run` otherwise re-syncs to only
+          # the default groups, pruning any test deps an app keeps in a non-default
+          # group — which silently breaks async/plugin-dependent suites and trips
+          # this gate on a packaging gap rather than a real failure.
+          uv run --all-groups --with pytest-cov pytest tests/unit --cov=app --cov-report=term
 
       - name: "Coverage threshold (>=85%)"
         id: coverage_threshold


### PR DESCRIPTION
## Problem

The certify **Unit tests** step (added in #1945) runs:

```
uv run --with pytest-cov pytest tests/unit --cov=app --cov-report=term
```

`uv run` re-syncs the environment to only uv's **default** dependency groups before running. So any test dependency an app keeps in a *non-default* group (commonly a `test` group with `pytest-asyncio`, `pytest-xdist`, `coverage`, …) gets **pruned right before pytest runs**.

`pytest` itself usually survives (pulled transitively via the app's main deps), so the suite *executes* — but every plugin-dependent test fails. Concretely, with `asyncio_mode = "auto"` and no `pytest-asyncio` loaded, **all `async def` tests fail**. That trips this (correct, valuable) gate on a *packaging gap* rather than a real regression.

This blocked releases for `atlan-publish-app`: hundreds of "failures" that were entirely a missing `pytest-asyncio` plugin — confirmed by the `plugins:` line in the run output listing `cov, anyio, order, typeguard` but **no `asyncio`**. The suite is fully green once the plugin is present.

## Fix

Add `--all-groups` to the `uv run` invocation so all dependency groups (including whatever group holds an app's test deps) are installed before the suite runs:

```
uv run --all-groups --with pytest-cov pytest tests/unit --cov=app --cov-report=term
```

- **Group-name-agnostic** — doesn't assume apps name the group `test`.
- Certify runs on a native runner, so the heavier install is fine.
- The app-side workaround (marking the test group as a uv `default-group`) keeps working; this just makes the gate robust by default so other apps don't hit the same trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)