### PR TITLE
ci: manifest-driven AE full-DAG local harness (ae-stack-up + reusable)

### DIFF
--- a/.github/actions/ae-stack-up/action.yaml
+++ b/.github/actions/ae-stack-up/action.yaml
@@ -1,0 +1,62 @@
+name: "AE stack up (manifest-driven)"
+description: >
+  Boot the local Automation Engine stack for a connector full-DAG test.
+  Reads app/generated/manifest.json and starts ONLY the apps the DAG
+  references — always the Automation Engine + the connector; publish /
+  query-intelligence / lineage workers are started conditionally based on
+  the manifest's task queues. No hand-listed app set, no per-connector DAG.
+
+inputs:
+  app-name:
+    description: "Connector short name (matches atlan.yaml `name`, e.g. monte-carlo)."
+    required: true
+  app-dir:
+    description: "Connector checkout dir (relative to workspace). Default: <app-name>."
+    required: false
+    default: ""
+  deployment:
+    description: "Deployment tier; fills {deployment_name} in manifest task queues."
+    required: false
+    default: "ci"
+  manifest-path:
+    description: "Manifest path relative to the connector checkout."
+    required: false
+    default: "app/generated/manifest.json"
+  org-pat-github:
+    description: "PAT to clone the private sibling app repos (AE/publish/qi/lineage)."
+    required: true
+  atlan-base-url:
+    description: "Tenant base URL for the publish app's OAuth (only used if the DAG publishes)."
+    required: false
+    default: ""
+  atlan-client-id:
+    required: false
+    default: ""
+  atlan-client-secret:
+    required: false
+    default: ""
+
+outputs:
+  ae-url:
+    description: "Local Automation Engine base URL."
+    value: ${{ steps.up.outputs.ae-url }}
+  started-apps:
+    description: "Space-separated list of started app ids."
+    value: ${{ steps.up.outputs.started-apps }}
+
+runs:
+  using: composite
+  steps:
+    - id: up
+      shell: bash
+      env:
+        WORKSPACE: ${{ github.workspace }}
+        APP_NAME: ${{ inputs.app-name }}
+        APP_DIR: ${{ inputs.app-dir != '' && format('{0}/{1}', github.workspace, inputs.app-dir) || format('{0}/{1}', github.workspace, inputs.app-name) }}
+        DEPLOYMENT: ${{ inputs.deployment }}
+        MANIFEST_PATH: ${{ inputs.manifest-path }}
+        ORG_PAT_GITHUB: ${{ inputs.org-pat-github }}
+        ATLAN_BASE_URL: ${{ inputs.atlan-base-url }}
+        ATLAN_CLIENT_ID: ${{ inputs.atlan-client-id }}
+        ATLAN_CLIENT_SECRET: ${{ inputs.atlan-client-secret }}
+      run: bash "${{ github.action_path }}/ae-stack-up.sh"

--- a/.github/actions/ae-stack-up/ae-stack-up.sh
+++ b/.github/actions/ae-stack-up/ae-stack-up.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# ae-stack-up.sh — Boot the local Automation Engine stack for a connector's
+# full-DAG test, deciding which sibling apps to start *from the manifest*.
+#
+# The connector never hand-lists "I need publish + qi + lineage". Instead this
+# reads app/generated/manifest.json -> dag, maps each node's task_queue to the
+# owning app, and starts exactly those workers (always AE + the connector;
+# publish / query-intelligence / lineage only when the DAG references them).
+#
+# Everything runs in-runner: Temporal dev server + Dapr (slim) + one `dapr run`
+# per app. No live tenant is contacted for orchestration — only the source
+# (via injected creds) and, for the publish app, OAuth to fetch a token.
+#
+# Inputs come from env (set by action.yaml):
+#   WORKSPACE         — $GITHUB_WORKSPACE (parent of all checkouts)
+#   APP_NAME          — connector short name (e.g. monte-carlo); also atlan.yaml name
+#   APP_DIR           — connector checkout dir (default: $WORKSPACE/<repo>)
+#   DEPLOYMENT        — deployment tier; fills {deployment_name} (default: ci)
+#   MANIFEST_PATH     — manifest, relative to APP_DIR (default app/generated/manifest.json)
+#   ORG_PAT_GITHUB    — PAT to clone the private sibling app repos
+#   ATLAN_BASE_URL / ATLAN_CLIENT_ID / ATLAN_CLIENT_SECRET — publish OAuth (only
+#                       needed when the DAG has a publish node)
+#
+# Emits to $GITHUB_OUTPUT (when run under Actions):
+#   ae-url=http://localhost:8000
+#   started-apps=<space-separated app ids>
+set -euo pipefail
+
+WORKSPACE="${WORKSPACE:-$PWD}"
+DEPLOYMENT="${DEPLOYMENT:-ci}"
+MANIFEST_PATH="${MANIFEST_PATH:-app/generated/manifest.json}"
+APP_DIR="${APP_DIR:-$WORKSPACE/$APP_NAME}"
+LOG_DIR="$WORKSPACE/logs"; mkdir -p "$LOG_DIR"
+
+log() { echo "[ae-stack-up] $*"; }
+err() { echo "::error::[ae-stack-up] $*" >&2; exit 1; }
+
+MANIFEST="$APP_DIR/$MANIFEST_PATH"
+[ -f "$MANIFEST" ] || err "manifest not found at $MANIFEST"
+
+# ── 1. Decide which apps the DAG needs (manifest-driven) ─────────────────────
+# Maps each dag node's task_queue prefix to the owning sibling app. The
+# connector + AE are implicit. Output: newline list of "app_key|repo|queue".
+NEEDS=$(APP_NAME="$APP_NAME" DEPLOYMENT="$DEPLOYMENT" python3 - "$MANIFEST" <<'PYEOF'
+import json, os, sys
+m = json.load(open(sys.argv[1]))
+dep = os.environ["DEPLOYMENT"]
+dag = m.get("dag", {})
+# queue-prefix -> (app_key, repo). The connector itself is handled separately.
+KNOWN = {
+    "atlan-publish":             ("publish",           "atlan-publish-app"),
+    "atlan-query-intelligence":  ("query-intelligence","atlan-query-intelligence-app"),
+    "atlan-lineage":             ("lineage",           "atlan-lineage-app"),
+}
+seen = {}
+for node in dag.values():
+    q = (node.get("inputs", {}) or {}).get("task_queue", "") or ""
+    q = q.replace("{deployment_name}", dep)
+    for prefix, (key, repo) in KNOWN.items():
+        if q.startswith(prefix + "-") and key not in seen:
+            seen[key] = (repo, q)
+for key, (repo, q) in seen.items():
+    print(f"{key}|{repo}|{q}")
+PYEOF
+)
+log "DAG needs sibling apps: $(echo "$NEEDS" | cut -d'|' -f1 | tr '\n' ' ' )"
+
+# ── 2. Toolchain: Dapr (slim) + Temporal CLI + uv ────────────────────────────
+DAPR_VERSION="1.16.2"
+if ! command -v dapr >/dev/null 2>&1; then
+  wget -q "https://github.com/dapr/cli/releases/download/v${DAPR_VERSION}/dapr_linux_amd64.tar.gz" -O /tmp/dapr.tar.gz
+  tar -xzf /tmp/dapr.tar.gz -C /tmp && sudo mv /tmp/dapr /usr/local/bin/
+  dapr init --runtime-version "${DAPR_VERSION}" --slim
+fi
+command -v temporal >/dev/null 2>&1 || curl -sSf https://temporal.download/cli.sh | sh
+export PATH="$HOME/.dapr/bin:$HOME/.temporalio/bin:$PATH"
+
+# Shared object-store bucket so every app's localstorage binding resolves the
+# same files on disk (extract writes, publish/qi/lineage read).
+SHARED_ROOT="$WORKSPACE/_ae-bucket/atlan-bucket"
+mkdir -p "$SHARED_ROOT"
+
+write_components() {
+  # $1 = app checkout dir
+  mkdir -p "$1/components"
+  cat > "$1/components/objectstore.yaml" <<EOF
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata: { name: objectstore }
+spec:
+  version: v1
+  type: bindings.localstorage
+  ignoreErrors: true
+  metadata:
+    - name: rootPath
+      value: "${SHARED_ROOT}"
+EOF
+  cat > "$1/components/statestore.yaml" <<'EOF'
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata: { name: statestore }
+spec:
+  version: v1
+  type: state.sqlite
+  ignoreErrors: true
+  metadata:
+    - name: connectionString
+      value: "./local/dapr/statestore.db"
+EOF
+}
+
+clone_app() {
+  # $1 = repo name under atlanhq
+  local repo="$1"
+  [ -d "$WORKSPACE/$repo" ] && return 0
+  git clone --depth 1 \
+    "https://x-access-token:${ORG_PAT_GITHUB}@github.com/atlanhq/${repo}.git" \
+    "$WORKSPACE/$repo" >/dev/null 2>&1 || err "clone failed: $repo"
+}
+
+# Always need the Automation Engine.
+clone_app atlan-automation-engine-app
+AE_DIR="$WORKSPACE/atlan-automation-engine-app"
+
+# uv
+command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+
+# ── 3. Start Temporal dev server ─────────────────────────────────────────────
+log "starting Temporal dev server"
+temporal server start-dev --db-filename /tmp/temporal.db > "$LOG_DIR/temporal.log" 2>&1 &
+for i in $(seq 1 30); do
+  temporal workflow list >/dev/null 2>&1 && { log "Temporal ready (${i}s)"; break; }
+  [ "$i" -eq 30 ] && err "Temporal failed to start"
+  sleep 1
+done
+
+# ── 4. Generic worker launcher ───────────────────────────────────────────────
+# Every app starts the same way: uv sync, dapr-run its main.py with a unique
+# port block + its task queue. Ports are derived from a per-app index so they
+# never collide.
+PORT_IDX=0
+STARTED=""
+start_worker() {
+  # $1 dir  $2 app-id  $3 ATLAN_APPLICATION_NAME  $4 task_queue  $5 extra_env(optional)
+  local dir="$1" appid="$2" appname="$3" queue="$4" extra="${5:-}"
+  local app_port=$((3001 + PORT_IDX * 10))
+  local dhttp=$((3511 + PORT_IDX * 10))
+  local dgrpc=$((50012 + PORT_IDX * 10))
+  local dinternal=$((50013 + PORT_IDX * 10))
+  local metrics=$((3112 + PORT_IDX * 10))
+  local prom=$((9466 + PORT_IDX))
+  write_components "$dir"
+  ( cd "$dir" && uv sync --all-groups >/dev/null 2>&1 || uv sync >/dev/null 2>&1 || true )
+  log "starting $appid (queue=$queue, port=$app_port)"
+  ( cd "$dir" && env $extra \
+      ATLAN_APPLICATION_NAME="$appname" \
+      ATLAN_DEPLOYMENT_NAME="$DEPLOYMENT" \
+      ATLAN_WORKFLOW_HOST=localhost ATLAN_WORKFLOW_PORT=7233 \
+      ATLAN_TASK_QUEUE="$queue" \
+      ATLAN_APP_HTTP_PORT="$app_port" ATLAN_HANDLER_PORT="$app_port" \
+      ATLAN_DAPR_HTTP_PORT="$dhttp" ATLAN_DAPR_GRPC_PORT="$dgrpc" \
+      ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS="0.0.0.0:${prom}" \
+      dapr run --app-id "$appid" --app-port "$app_port" \
+        --dapr-http-port "$dhttp" --dapr-grpc-port "$dgrpc" \
+        --dapr-internal-grpc-port "$dinternal" --metrics-port "$metrics" \
+        --scheduler-host-address '' --placement-host-address '' \
+        --max-body-size 100Mi --resources-path components --log-level warn \
+        -- uv run python main.py > "$LOG_DIR/${appid}.log" 2>&1 & )
+  STARTED="$STARTED $appid"
+  PORT_IDX=$((PORT_IDX + 1))
+}
+
+wait_ready() { # $1 app-id  $2 grep-marker  $3 timeout
+  local appid="$1" marker="$2" to="${3:-120}"
+  for i in $(seq 1 "$to"); do
+    grep -q "$marker" "$LOG_DIR/${appid}.log" 2>/dev/null && { log "$appid ready (${i}s)"; return 0; }
+    [ "$i" -eq "$to" ] && { tail -30 "$LOG_DIR/${appid}.log" 2>/dev/null; err "$appid not ready in ${to}s"; }
+    sleep 1
+  done
+}
+
+# AE first (port idx 0 = http 8000-ish; AE serves the workflow API).
+# AE is special: it exposes the workflow API the reusable POSTs to, on :8000.
+write_components "$AE_DIR"
+( cd "$AE_DIR" && uv sync --all-groups >/dev/null 2>&1 || true )
+log "starting automation-engine on :8000"
+( cd "$AE_DIR" && env \
+    ATLAN_APPLICATION_NAME=automation-engine ATLAN_DEPLOYMENT_NAME="$DEPLOYMENT" \
+    ATLAN_REGISTRY_TYPE=sql ATLAN_WORKFLOW_HOST=localhost ATLAN_WORKFLOW_PORT=7233 \
+    ATLAN_APP_HTTP_PORT=8000 ATLAN_HANDLER_PORT=8000 \
+    ATLAN_DAPR_HTTP_PORT=3500 ATLAN_DAPR_GRPC_PORT=50001 \
+    ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS=0.0.0.0:9465 \
+    dapr run --app-id automation-engine --app-port 8000 \
+      --dapr-http-port 3500 --dapr-grpc-port 50001 --dapr-internal-grpc-port 50002 \
+      --metrics-port 3100 --scheduler-host-address '' --placement-host-address '' \
+      --resources-path components --log-level warn \
+      -- uv run automation_engine/main.py > "$LOG_DIR/automation-engine.log" 2>&1 & )
+for i in $(seq 1 60); do
+  curl -sf "http://localhost:8000/api/v1/workflows" >/dev/null 2>&1 && { log "AE ready (${i}s)"; break; }
+  [ "$i" -eq 60 ] && { tail -30 "$LOG_DIR/automation-engine.log"; err "AE failed to start"; }
+  sleep 2
+done
+
+# The connector worker (always; serves the extract node + the dev local-vault).
+start_worker "$APP_DIR" "${APP_NAME}-app" "$APP_NAME" "atlan-${APP_NAME}-${DEPLOYMENT}" \
+  "ATLAN_LOCAL_DEVELOPMENT=true ATLAN_HANDLER_HOST=0.0.0.0"
+wait_ready "${APP_NAME}-app" "atlan-${APP_NAME}-${DEPLOYMENT}" 90
+
+# Publish OAuth .env bits are passed via extra-env when publish is needed.
+PUBLISH_ENV=""
+if [ -n "${ATLAN_BASE_URL:-}" ]; then
+  TOKEN_URL=$(curl -sf "${ATLAN_BASE_URL}/auth/realms/default/.well-known/openid-configuration" \
+    | python3 -c "import json,sys;print(json.load(sys.stdin)['token_endpoint'])" 2>/dev/null \
+    || echo "${ATLAN_BASE_URL}/auth/realms/default/protocol/openid-connect/token")
+  PUBLISH_ENV="ATLAN_OAUTH2_CLIENT_ID=${ATLAN_CLIENT_ID:-} ATLAN_OAUTH2_CLIENT_SECRET=${ATLAN_CLIENT_SECRET:-} ATLAN_CLIENT_ID=${ATLAN_CLIENT_ID:-} ATLAN_CLIENT_SECRET=${ATLAN_CLIENT_SECRET:-} ATLAN_BASE_URL=${ATLAN_BASE_URL} ATLAN_TOKEN_URL=${TOKEN_URL}"
+fi
+
+# Now the manifest-selected siblings.
+while IFS='|' read -r key repo queue; do
+  [ -z "$key" ] && continue
+  clone_app "$repo"
+  case "$key" in
+    publish)            start_worker "$WORKSPACE/$repo" publish-app          publish            "$queue" "$PUBLISH_ENV"
+                        wait_ready publish-app "task queue: $queue" 180 ;;
+    query-intelligence) start_worker "$WORKSPACE/$repo" query-intelligence   query-intelligence "$queue"
+                        wait_ready query-intelligence "task queue: $queue" 180 ;;
+    lineage)            start_worker "$WORKSPACE/$repo" lineage-app          lineage            "$queue"
+                        wait_ready lineage-app "task queue: $queue" 180 ;;
+  esac
+done <<< "$NEEDS"
+
+log "stack up. started:$STARTED automation-engine"
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "ae-url=http://localhost:8000" >> "$GITHUB_OUTPUT"
+  echo "started-apps=automation-engine ${APP_NAME}-app${STARTED}" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/ae-full-dag-local-reusable.yaml
+++ b/.github/workflows/ae-full-dag-local-reusable.yaml
@@ -1,0 +1,191 @@
+name: ae-full-dag-local-reusable
+
+# Reusable: run a connector's FULL Automation Engine DAG entirely inside the
+# GitHub runner (local Temporal + Dapr + every worker the manifest references),
+# register the workflow straight from app/generated/manifest.json, submit it,
+# and assert every DAG node reaches COMPLETED.
+#
+# Manifest-driven end to end:
+#   • which apps boot           ← .github/actions/ae-stack-up (reads dag queues)
+#   • the registered DAG/queues  ← .github/actions/ae-workflow (reads manifest)
+#   • which nodes are polled     ← manifest dag keys (this workflow)
+#
+# A connector's per-repo file collapses to ~10 lines:
+#
+#     name: AE Full-DAG Local
+#     on:
+#       workflow_dispatch:
+#       pull_request:
+#         types: [labeled]
+#     jobs:
+#       ae:
+#         if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'ae-full-dag'
+#         uses: atlanhq/application-sdk/.github/workflows/ae-full-dag-local-reusable.yaml@main
+#         with:
+#           app-name: monte-carlo
+#           creds-script: .github/e2e/inject-creds.sh
+#         secrets: inherit
+#
+# The ONLY connector-specific input is `creds-script` — the source credential
+# shape can't come from the manifest. It POSTs the source creds to the connector
+# worker's dev local-vault (http://localhost:3001/workflows/v1/dev/local-vault)
+# and echoes `cred_guid=<guid>` on its last line. Plus, for sources needing
+# system packages (ODBC etc.), an optional `system-deps-script`.
+
+on:
+  workflow_call:
+    inputs:
+      app-name:
+        description: 'Connector short name (matches atlan.yaml `name`).'
+        required: true
+        type: string
+      deployment:
+        description: "Deployment tier; fills {deployment_name} in queues."
+        required: false
+        type: string
+        default: ci
+      creds-script:
+        description: "Path (in connector repo) to the source-cred injector; echoes `cred_guid=<guid>`."
+        required: true
+        type: string
+      system-deps-script:
+        description: "Optional path to a script installing source system deps (ODBC, JCo, ...)."
+        required: false
+        type: string
+        default: ""
+      connection-qn:
+        description: "Connection qualified name. Default default/<app-name>/<deployment>."
+        required: false
+        type: string
+        default: ""
+      connection-name:
+        description: "Connection display name. Default ci_<app-name>."
+        required: false
+        type: string
+        default: ""
+      timeout-minutes:
+        required: false
+        type: number
+        default: 120
+    secrets:
+      ORG_PAT_GITHUB:
+        description: "PAT to clone the private sibling app repos."
+        required: true
+      ATLAN_BASE_URL:
+        description: "Tenant URL for the publish app's OAuth (only if the DAG publishes)."
+        required: false
+      ATLAN_CLIENT_ID:
+        required: false
+      ATLAN_CLIENT_SECRET:
+        required: false
+
+jobs:
+  ae-full-dag:
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    concurrency:
+      group: ae-full-dag-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
+    steps:
+      - name: Checkout connector
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          path: ${{ inputs.app-name }}
+
+      - name: Install source system deps
+        if: inputs.system-deps-script != ''
+        shell: bash
+        working-directory: ${{ inputs.app-name }}
+        run: bash "${{ inputs.system-deps-script }}"
+
+      - name: Bring up AE stack (manifest-driven)
+        id: stack
+        uses: atlanhq/application-sdk/.github/actions/ae-stack-up@main
+        with:
+          app-name: ${{ inputs.app-name }}
+          deployment: ${{ inputs.deployment }}
+          org-pat-github: ${{ secrets.ORG_PAT_GITHUB }}
+          atlan-base-url: ${{ secrets.ATLAN_BASE_URL }}
+          atlan-client-id: ${{ secrets.ATLAN_CLIENT_ID }}
+          atlan-client-secret: ${{ secrets.ATLAN_CLIENT_SECRET }}
+
+      - name: Inject source credentials
+        id: creds
+        shell: bash
+        working-directory: ${{ inputs.app-name }}
+        run: |
+          set -euo pipefail
+          GUID=$(bash "${{ inputs.creds-script }}" | sed -n 's/^cred_guid=//p' | tail -1)
+          [ -n "$GUID" ] || { echo "::error::creds-script did not echo cred_guid="; exit 1; }
+          echo "cred_guid=$GUID" >> "$GITHUB_OUTPUT"
+          echo "Provisioned credential: $GUID"
+
+      - name: Register AE workflow from manifest
+        id: register
+        uses: atlanhq/application-sdk/.github/actions/ae-workflow@main
+        with:
+          ae-url: ${{ steps.stack.outputs.ae-url }}
+          token: "local"                       # local AE has no auth gate in dev mode
+          name: "${{ inputs.app-name }} full-DAG CI - ${{ github.run_id }}"
+          deployment: ${{ inputs.deployment }}
+          cred-guid: ${{ steps.creds.outputs.cred_guid }}
+          connection-qn: ${{ inputs.connection-qn != '' && inputs.connection-qn || format('default/{0}/{1}', inputs.app-name, inputs.deployment) }}
+          connection-name: ${{ inputs.connection-name != '' && inputs.connection-name || format('ci_{0}', inputs.app-name) }}
+          manifest: ${{ inputs.app-name }}/app/generated/manifest.json
+          atlan-yaml: ${{ inputs.app-name }}/atlan.yaml
+          # CI: dry-run publish (no real Atlas write / cache population).
+          connection-creation-enabled: "false"
+          executor-enabled: "false"
+          connection-cache-enabled: "false"
+          connection-cache-via-app-enabled: "false"
+
+      - name: Submit run and assert every DAG node completes
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PATH="$HOME/.temporalio/bin:$PATH"
+          SLUG="${{ steps.register.outputs.slug }}"
+          AE="${{ steps.stack.outputs.ae-url }}"
+
+          RUN=$(curl -sf -X POST "${AE}/api/v1/workflows/${SLUG}/submit" -H 'Content-Type: application/json' -d '{}')
+          RUN_GUID=$(echo "$RUN" | python3 -c "import json,sys;print(json.load(sys.stdin)['data']['guid'])")
+          echo "Run: $RUN_GUID"
+
+          # Node ids to poll come straight from the manifest dag.
+          NODES=$(python3 -c "import json;print(' '.join(json.load(open('${{ inputs.app-name }}/app/generated/manifest.json'))['dag'].keys()))")
+          echo "Polling DAG nodes: $NODES"
+
+          wait_for() { # workflow-id label timeout
+            local wf="$1" label="$2" to="${3:-900}" elapsed=0
+            while [ $elapsed -lt $to ]; do
+              local st
+              st=$(temporal workflow describe --workflow-id "$wf" 2>/dev/null | awk '/^\s+Status/{print $2}' | head -1 || echo NOT_STARTED)
+              echo "  $label: $st (${elapsed}s)"
+              case "$st" in
+                COMPLETED) return 0 ;;
+                FAILED|TERMINATED|CANCELED) echo "::error::$label $st"; return 1 ;;
+              esac
+              sleep 10; elapsed=$((elapsed+10))
+            done
+            echo "::error::$label timed out after ${to}s"; return 1
+          }
+
+          rc=0
+          for node in $NODES; do
+            wait_for "${RUN_GUID}-${node}" "$node" 900 || rc=1
+          done
+
+          echo "### AE full-DAG run \`${RUN_GUID}\`" >> "$GITHUB_STEP_SUMMARY"
+          temporal workflow list --query "WorkflowId STARTS_WITH '${RUN_GUID}'" 2>/dev/null \
+            | sed 's/^/    /' >> "$GITHUB_STEP_SUMMARY" || true
+          exit $rc
+
+      - name: Dump logs on failure
+        if: failure()
+        shell: bash
+        run: for f in logs/*.log; do echo "===== $f ====="; tail -60 "$f"; done 2>/dev/null || true


### PR DESCRIPTION
## Summary
Adds a **manifest-driven, generic** harness to run a connector's full Automation Engine DAG entirely inside the GitHub runner — replacing the bespoke ~1100-line per-connector `ae-publish-test.yaml` (e.g. in `atlan-mssql-app`) with a reusable that connectors call in ~10 lines.

### New files
- **`.github/actions/ae-stack-up`** — composite action that reads `app/generated/manifest.json` → `dag` and boots **only** the apps the DAG references: always the Automation Engine + the connector; `publish` / `query-intelligence` / `lineage` workers **conditionally**, decided from each node's `task_queue`. No hand-listed app set, no per-connector DAG.
- **`.github/workflows/ae-full-dag-local-reusable.yaml`** — reusable workflow: `ae-stack-up` → inject source creds (connector script) → register from manifest (existing `.github/actions/ae-workflow`) → submit → poll **every DAG node** (node list also read from the manifest) and assert `COMPLETED`.

### Why
The registration/DAG-build is already manifest-driven (`ae-workflow` action). The missing piece was the **local multi-app spin-up**, which today only exists as bespoke per-connector code that hard-codes which apps to start. This makes that manifest-driven too.

### Per-connector residue (irreducible — can't come from the manifest)
- `creds-script` — POSTs source creds to the connector worker's dev local-vault (`:3001`) and echoes `cred_guid=`.
- optional `system-deps-script` — for sources needing OS packages (ODBC/JCo).

### Status
⚠️ **Draft.** Generalized from the proven `atlan-mssql-app/ae-publish-test.yaml` but not yet run end-to-end against a connector here — opening for review of the approach + manifest→app mapping. Pilot caller: `atlan-monte-carlo-app` (extract→publish, simplest DAG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)