### PR TITLE
ci(ae-stack-up): connector deployment=local for dev-vault + create local/dapr

### DIFF
--- a/.github/actions/ae-stack-up/action.yaml
+++ b/.github/actions/ae-stack-up/action.yaml
@@ -22,6 +22,14 @@ inputs:
     description: "Manifest path relative to the connector checkout."
     required: false
     default: "app/generated/manifest.json"
+  app-module:
+    description: "ATLAN_APP_MODULE for the connector worker (e.g. app.extractor:MSSQLMetadataExtractor)."
+    required: false
+    default: ""
+  handler-module:
+    description: "ATLAN_HANDLER_MODULE for the connector worker (e.g. app.handler:MSSQLHandler). Required so the worker registers the real extraction workflow, not DefaultHandler/SDR."
+    required: false
+    default: ""
   org-pat-github:
     description: "PAT to clone the private sibling app repos (AE/publish/qi/lineage)."
     required: true
@@ -55,6 +63,8 @@ runs:
         APP_DIR: ${{ inputs.app-dir != '' && format('{0}/{1}', github.workspace, inputs.app-dir) || format('{0}/{1}', github.workspace, inputs.app-name) }}
         DEPLOYMENT: ${{ inputs.deployment }}
         MANIFEST_PATH: ${{ inputs.manifest-path }}
+        APP_MODULE: ${{ inputs.app-module }}
+        HANDLER_MODULE: ${{ inputs.handler-module }}
         ORG_PAT_GITHUB: ${{ inputs.org-pat-github }}
         ATLAN_BASE_URL: ${{ inputs.atlan-base-url }}
         ATLAN_CLIENT_ID: ${{ inputs.atlan-client-id }}

--- a/.github/actions/ae-stack-up/ae-stack-up.sh
+++ b/.github/actions/ae-stack-up/ae-stack-up.sh
@@ -209,8 +209,13 @@ done
 # The connector worker (always; serves the extract node + the dev local-vault).
 # ATLAN_DEPLOYMENT_NAME=local unlocks /workflows/v1/dev/local-vault (else 403);
 # the queue stays atlan-<app>-<deployment> via the explicit ATLAN_TASK_QUEUE.
-start_worker "$APP_DIR" "${APP_NAME}-app" "$APP_NAME" "atlan-${APP_NAME}-${DEPLOYMENT}" \
-  "ATLAN_LOCAL_DEVELOPMENT=true ATLAN_HANDLER_HOST=0.0.0.0 ATLAN_DEPLOYMENT_NAME=local"
+# ATLAN_APP_MODULE/ATLAN_HANDLER_MODULE MUST be set or the worker comes up with
+# DefaultHandler (SDR workflows only) and the AE-dispatched extraction workflow
+# never gets picked up — the child workflow then runs forever.
+CONN_EXTRA="ATLAN_LOCAL_DEVELOPMENT=true ATLAN_HANDLER_HOST=0.0.0.0 ATLAN_DEPLOYMENT_NAME=local"
+[ -n "${APP_MODULE:-}" ]     && CONN_EXTRA="$CONN_EXTRA ATLAN_APP_MODULE=${APP_MODULE}"
+[ -n "${HANDLER_MODULE:-}" ] && CONN_EXTRA="$CONN_EXTRA ATLAN_HANDLER_MODULE=${HANDLER_MODULE}"
+start_worker "$APP_DIR" "${APP_NAME}-app" "$APP_NAME" "atlan-${APP_NAME}-${DEPLOYMENT}" "$CONN_EXTRA"
 wait_ready "${APP_NAME}-app" "atlan-${APP_NAME}-${DEPLOYMENT}" 90
 
 # Publish OAuth .env bits are passed via extra-env when publish is needed.

--- a/.github/actions/ae-stack-up/ae-stack-up.sh
+++ b/.github/actions/ae-stack-up/ae-stack-up.sh
@@ -82,7 +82,7 @@ mkdir -p "$SHARED_ROOT"
 
 write_components() {
   # $1 = app checkout dir
-  mkdir -p "$1/components"
+  mkdir -p "$1/components" "$1/local/dapr"   # local/dapr must exist for the sqlite statestore
   cat > "$1/components/objectstore.yaml" <<EOF
 apiVersion: dapr.io/v1alpha1
 kind: Component
@@ -153,7 +153,10 @@ start_worker() {
   write_components "$dir"
   ( cd "$dir" && uv sync --all-groups >/dev/null 2>&1 || uv sync >/dev/null 2>&1 || true )
   log "starting $appid (queue=$queue, port=$app_port)"
-  ( cd "$dir" && env $extra \
+  # $extra is placed LAST so a worker can override a default (e.g. the connector
+  # sets ATLAN_DEPLOYMENT_NAME=local to unlock the dev local-vault while still
+  # listening on the explicit ATLAN_TASK_QUEUE below).
+  ( cd "$dir" && env \
       ATLAN_APPLICATION_NAME="$appname" \
       ATLAN_DEPLOYMENT_NAME="$DEPLOYMENT" \
       ATLAN_WORKFLOW_HOST=localhost ATLAN_WORKFLOW_PORT=7233 \
@@ -161,6 +164,7 @@ start_worker() {
       ATLAN_APP_HTTP_PORT="$app_port" ATLAN_HANDLER_PORT="$app_port" \
       ATLAN_DAPR_HTTP_PORT="$dhttp" ATLAN_DAPR_GRPC_PORT="$dgrpc" \
       ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS="0.0.0.0:${prom}" \
+      $extra \
       dapr run --app-id "$appid" --app-port "$app_port" \
         --dapr-http-port "$dhttp" --dapr-grpc-port "$dgrpc" \
         --dapr-internal-grpc-port "$dinternal" --metrics-port "$metrics" \
@@ -203,8 +207,10 @@ for i in $(seq 1 60); do
 done
 
 # The connector worker (always; serves the extract node + the dev local-vault).
+# ATLAN_DEPLOYMENT_NAME=local unlocks /workflows/v1/dev/local-vault (else 403);
+# the queue stays atlan-<app>-<deployment> via the explicit ATLAN_TASK_QUEUE.
 start_worker "$APP_DIR" "${APP_NAME}-app" "$APP_NAME" "atlan-${APP_NAME}-${DEPLOYMENT}" \
-  "ATLAN_LOCAL_DEVELOPMENT=true ATLAN_HANDLER_HOST=0.0.0.0"
+  "ATLAN_LOCAL_DEVELOPMENT=true ATLAN_HANDLER_HOST=0.0.0.0 ATLAN_DEPLOYMENT_NAME=local"
 wait_ready "${APP_NAME}-app" "atlan-${APP_NAME}-${DEPLOYMENT}" 90
 
 # Publish OAuth .env bits are passed via extra-env when publish is needed.

--- a/.github/workflows/ae-full-dag-local-reusable.yaml
+++ b/.github/workflows/ae-full-dag-local-reusable.yaml
@@ -48,6 +48,16 @@ on:
         description: "Path (in connector repo) to the source-cred injector; echoes `cred_guid=<guid>`."
         required: true
         type: string
+      app-module:
+        description: "ATLAN_APP_MODULE for the connector worker (e.g. app.extractor:MSSQLMetadataExtractor)."
+        required: false
+        type: string
+        default: ""
+      handler-module:
+        description: "ATLAN_HANDLER_MODULE — required so the worker registers the real extraction workflow (not DefaultHandler/SDR)."
+        required: false
+        type: string
+        default: ""
       system-deps-script:
         description: "Optional path to a script installing source system deps (ODBC, JCo, ...)."
         required: false
@@ -109,6 +119,8 @@ jobs:
         with:
           app-name: ${{ inputs.app-name }}
           deployment: ${{ inputs.deployment }}
+          app-module: ${{ inputs.app-module }}
+          handler-module: ${{ inputs.handler-module }}
           org-pat-github: ${{ secrets.ORG_PAT_GITHUB }}
           atlan-base-url: ${{ secrets.ATLAN_BASE_URL }}
           atlan-client-id: ${{ secrets.ATLAN_CLIENT_ID }}

--- a/.github/workflows/ae-full-dag-local-reusable.yaml
+++ b/.github/workflows/ae-full-dag-local-reusable.yaml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Bring up AE stack (manifest-driven)
         id: stack
-        uses: atlanhq/application-sdk/.github/actions/ae-stack-up@main
+        uses: atlanhq/application-sdk/.github/actions/ae-stack-up@fix/ae-stack-up-local-vault
         with:
           app-name: ${{ inputs.app-name }}
           deployment: ${{ inputs.deployment }}

--- a/.github/workflows/ae-full-dag-local-reusable.yaml
+++ b/.github/workflows/ae-full-dag-local-reusable.yaml
@@ -185,6 +185,127 @@ jobs:
             | sed 's/^/    /' >> "$GITHUB_STEP_SUMMARY" || true
           exit $rc
 
+      - name: Print count summary
+        if: always()
+        shell: bash
+        env:
+          APP_NAME: ${{ inputs.app-name }}
+        run: |
+          python3 - <<'PYEOF'
+          import json, os, re, ast
+
+          LOGS = "logs"
+          app = os.environ["APP_NAME"]
+          # Log files written by ae-stack-up (app-id -> logs/<app-id>.log).
+          EXTRACT = f"{LOGS}/{app}-app.log"
+          PUBLISH = f"{LOGS}/publish-app.log"
+          QI      = f"{LOGS}/query-intelligence.log"
+          LINEAGE = f"{LOGS}/lineage-app.log"
+
+          def lines(p):
+              try:
+                  return open(p, encoding="utf-8", errors="replace").read().splitlines()
+              except FileNotFoundError:
+                  return []
+
+          out = []
+
+          # ── Extract: SDK APP_VITALS (generic across connectors) ──────────────
+          vitals = re.compile(r"APP_VITALS \| app_vitals\.act\.completed \| (\{.*\})")
+          fetch, transform = {}, {}
+          for ln in lines(EXTRACT):
+              m = vitals.search(ln)
+              if not m:
+                  continue
+              try:
+                  d = json.loads(m.group(1))
+              except Exception:
+                  continue
+              if d.get("status") != "succeeded":
+                  continue
+              suf = d.get("activity_type", "").split(":")[-1]
+              cnt = d.get("assets_processed", 0)
+              if suf.startswith("fetch_"):
+                  fetch[suf[6:]] = cnt
+              elif suf.startswith("transform_"):
+                  transform[suf[10:]] = cnt
+
+          # ── Publish / lineage-publish (shared publish app, generic) ──────────
+          wfid = re.compile(r"Workflow ID:\s+(\S+)\s+Run ID:")
+          part = re.compile(r"partition_count=(\d+)\s+synced_entities_count=(\d+)\s+transformed_entities_count=(\d+)")
+          stats = re.compile(r"Statistics collected:\s+(\d+) created,\s+(\d+) updated,\s+(\d+) deleted")
+          comp = re.compile(r"Compaction complete:\s+(\d+) entities")
+          pub = {"publish": {}, "lineage-publish": {}}
+          tag = None
+          for ln in lines(PUBLISH):
+              w = wfid.search(ln)
+              if w:
+                  tag = "lineage-publish" if w.group(1).endswith("-lineage-publish") else ("publish" if w.group(1).endswith("-publish") else None)
+              if not tag:
+                  continue
+              for rx, keys in ((part, ("partitions","synced","transformed")), (stats, ("created","updated","deleted")), (comp, ("compacted",))):
+                  m = rx.search(ln)
+                  if m:
+                      for i, k in enumerate(keys):
+                          pub[tag][k] = int(m.group(i+1))
+
+          # ── QI (only if the DAG ran it) ──────────────────────────────────────
+          qi = {}
+          for ln in lines(QI):
+              m = re.search(r"parse completed with:\s*(\{[^}]*\})", ln)
+              if m:
+                  try: qi = ast.literal_eval(m.group(1))
+                  except Exception: pass
+
+          # ── Lineage (only if the DAG ran it) ─────────────────────────────────
+          lin = {}
+          for key, rx in (("artifacts", r"Found (\d+) artifacts"),
+                          ("table_procs", r"Workflow complete: (\d+) table"),
+                          ("col_procs", r"Workflow complete:.*?(\d+) column processes")):
+              for ln in lines(LINEAGE):
+                  m = re.search(rx, ln)
+                  if m: lin[key] = int(m.group(1))
+
+          # ── Render Markdown to the Step Summary ──────────────────────────────
+          published = pub["publish"].get("compacted", 0)
+          out.append(f"## {app} — full-DAG counts\n")
+          out.append("### Extract\n")
+          out.append("| Asset Type | Fetched | Transformed | Published |")
+          out.append("|---|---:|---:|---:|")
+          types = sorted(set(fetch) | set(transform))
+          for t in types:
+              out.append(f"| {t} | {fetch.get(t,'-')} | {transform.get(t,'-')} | |")
+          out.append(f"| **TOTAL** | **{sum(fetch.values())}** | **{sum(transform.values())}** | **{published}** |")
+
+          out.append("\n### Publish")
+          out.append("| Stage | Partitions | Synced | Transformed | Compacted | Created | Updated | Deleted |")
+          out.append("|---|---:|---:|---:|---:|---:|---:|---:|")
+          for stage in ("publish", "lineage-publish"):
+              p = pub[stage]
+              if p:
+                  out.append(f"| {stage} | {p.get('partitions',0)} | {p.get('synced',0)} | {p.get('transformed',0)} | {p.get('compacted',0)} | {p.get('created',0)} | {p.get('updated',0)} | {p.get('deleted',0)} |")
+
+          if qi:
+              out.append("\n### Query Intelligence")
+              out.append("| Total | Parsed | Lineage | Tables | Errors |")
+              out.append("|---:|---:|---:|---:|---:|")
+              err = sum(int(v) for k,v in qi.items() if isinstance(v,(int,float)) and k.startswith("sqlglotError"))
+              out.append(f"| {qi.get('totalQueries',0)} | {qi.get('sqlglotProcessed',0)} | {qi.get('sqlglotLineageGenerated',0)} | {qi.get('sqlglotTablesDetected',0)} | {err} |")
+
+          if lin:
+              out.append("\n### Lineage")
+              out.append("| Artifacts | Table Procs | Col Procs |")
+              out.append("|---:|---:|---:|")
+              out.append(f"| {lin.get('artifacts',0)} | {lin.get('table_procs',0)} | {lin.get('col_procs',0)} |")
+
+          text = "\n".join(out)
+          print(text)
+          sp = os.environ.get("GITHUB_STEP_SUMMARY")
+          if sp:
+              with open(sp, "a") as f:
+                  f.write(text + "\n")
+          PYEOF
+
       - name: Dump logs on failure
         if: failure()
         shell: bash

--- a/.github/workflows/ae-full-dag-local-reusable.yaml
+++ b/.github/workflows/ae-full-dag-local-reusable.yaml
@@ -138,11 +138,10 @@ jobs:
           connection-name: ${{ inputs.connection-name != '' && inputs.connection-name || format('ci_{0}', inputs.app-name) }}
           manifest: ${{ inputs.app-name }}/app/generated/manifest.json
           atlan-yaml: ${{ inputs.app-name }}/atlan.yaml
-          # executor-enabled MUST be true or the submit registers the run but
-          # never dispatches the DAG (every node stays NOT_STARTED). Publish
-          # still stays dry-run via the connection-cache flags below.
+          # executor-enabled is a PUBLISH dry-run flag (per ae-workflow.sh), not
+          # DAG execution — keep it false so publish stays dry-run in CI.
           connection-creation-enabled: "false"
-          executor-enabled: "true"
+          executor-enabled: "false"
           connection-cache-enabled: "false"
           connection-cache-via-app-enabled: "false"
 
@@ -161,12 +160,14 @@ jobs:
           echo "Run: $RUN_GUID"
 
           EXPECTED=$(python3 -c "import json;print(len(json.load(open('${{ inputs.app-name }}/app/generated/manifest.json'))['dag']))")
-          echo "Expecting $EXPECTED DAG node workflow(s)"
+          echo "Expecting >= $EXPECTED node workflow(s) (+1 orchestrator)"
 
-          # Discover the actual child workflows for this run instead of guessing
-          # their IDs. Counts come from the run-prefixed Temporal workflows.
+          # This is a fresh single-run Temporal, so we don't need to guess child
+          # workflow IDs (AE names them off an internal GUID, not the submit
+          # guid). Just count ALL workflows by status and wait until everything
+          # settles. Dumps the full list each tick for visibility.
           snapshot() {
-            temporal workflow list --query "WorkflowId STARTS_WITH '${RUN_GUID}'" -o json 2>/dev/null \
+            temporal workflow list --limit 100 -o json 2>/dev/null \
               | python3 -c "
           import json,sys
           try: rows=json.load(sys.stdin) or []
@@ -181,22 +182,20 @@ jobs:
           "
           }
 
-          GRACE=300; MAX=4500; elapsed=0; rc=0
+          GRACE=300; MAX=1800; elapsed=0; rc=0
           while [ $elapsed -lt $MAX ]; do
             read -r total comp fail run < <(snapshot)
             total=${total:-0}; comp=${comp:-0}; fail=${fail:-0}; run=${run:-0}
             echo "  [${elapsed}s] workflows=$total completed=$comp failed=$fail running=$run"
-            if [ "$fail" -gt 0 ]; then echo "::error::a DAG workflow failed"; rc=1; break; fi
-            if [ "$total" -ge "$EXPECTED" ] && [ "$comp" -ge "$EXPECTED" ]; then echo "All $EXPECTED nodes completed."; rc=0; break; fi
+            if [ "$fail" -gt 0 ]; then echo "::error::a workflow failed/terminated"; rc=1; break; fi
+            # settled: at least EXPECTED nodes completed and nothing still running
+            if [ "$comp" -ge "$EXPECTED" ] && [ "$run" -eq 0 ] && [ "$total" -gt 0 ]; then echo "Run settled: $comp completed."; rc=0; break; fi
             if [ "$total" -eq 0 ] && [ "$elapsed" -ge "$GRACE" ]; then
-              echo "::error::no DAG workflows dispatched within ${GRACE}s — submit/executor or queue problem"
-              echo "--- all recent Temporal workflows (for diagnosis) ---"
-              temporal workflow list --limit 30 2>/dev/null || true
-              rc=1; break
+              echo "::error::no workflows dispatched within ${GRACE}s — submit/queue problem"; rc=1; break
             fi
             sleep 10; elapsed=$((elapsed+10))
           done
-          [ $elapsed -lt $MAX ] || { echo "::error::run did not finish within ${MAX}s"; rc=1; }
+          [ $elapsed -lt $MAX ] || { echo "::error::run did not settle within ${MAX}s"; echo '--- full workflow list ---'; temporal workflow list --limit 50 2>/dev/null || true; rc=1; }
 
           echo "### AE full-DAG run \`${RUN_GUID}\`" >> "$GITHUB_STEP_SUMMARY"
           temporal workflow list --query "WorkflowId STARTS_WITH '${RUN_GUID}'" 2>/dev/null \

--- a/.github/workflows/ae-full-dag-local-reusable.yaml
+++ b/.github/workflows/ae-full-dag-local-reusable.yaml
@@ -138,9 +138,11 @@ jobs:
           connection-name: ${{ inputs.connection-name != '' && inputs.connection-name || format('ci_{0}', inputs.app-name) }}
           manifest: ${{ inputs.app-name }}/app/generated/manifest.json
           atlan-yaml: ${{ inputs.app-name }}/atlan.yaml
-          # CI: dry-run publish (no real Atlas write / cache population).
+          # executor-enabled MUST be true or the submit registers the run but
+          # never dispatches the DAG (every node stays NOT_STARTED). Publish
+          # still stays dry-run via the connection-cache flags below.
           connection-creation-enabled: "false"
-          executor-enabled: "false"
+          executor-enabled: "true"
           connection-cache-enabled: "false"
           connection-cache-via-app-enabled: "false"
 
@@ -153,32 +155,48 @@ jobs:
           AE="${{ steps.stack.outputs.ae-url }}"
 
           RUN=$(curl -sf -X POST "${AE}/api/v1/workflows/${SLUG}/submit" -H 'Content-Type: application/json' -d '{}')
-          RUN_GUID=$(echo "$RUN" | python3 -c "import json,sys;print(json.load(sys.stdin)['data']['guid'])")
+          echo "submit response: $RUN"
+          RUN_GUID=$(echo "$RUN" | python3 -c "import json,sys;d=json.load(sys.stdin);print(d.get('data',{}).get('guid') or d.get('guid',''))")
+          [ -n "$RUN_GUID" ] || { echo "::error::submit returned no run guid"; exit 1; }
           echo "Run: $RUN_GUID"
 
-          # Node ids to poll come straight from the manifest dag.
-          NODES=$(python3 -c "import json;print(' '.join(json.load(open('${{ inputs.app-name }}/app/generated/manifest.json'))['dag'].keys()))")
-          echo "Polling DAG nodes: $NODES"
+          EXPECTED=$(python3 -c "import json;print(len(json.load(open('${{ inputs.app-name }}/app/generated/manifest.json'))['dag']))")
+          echo "Expecting $EXPECTED DAG node workflow(s)"
 
-          wait_for() { # workflow-id label timeout
-            local wf="$1" label="$2" to="${3:-900}" elapsed=0
-            while [ $elapsed -lt $to ]; do
-              local st
-              st=$(temporal workflow describe --workflow-id "$wf" 2>/dev/null | awk '/^\s+Status/{print $2}' | head -1 || echo NOT_STARTED)
-              echo "  $label: $st (${elapsed}s)"
-              case "$st" in
-                COMPLETED) return 0 ;;
-                FAILED|TERMINATED|CANCELED) echo "::error::$label $st"; return 1 ;;
-              esac
-              sleep 10; elapsed=$((elapsed+10))
-            done
-            echo "::error::$label timed out after ${to}s"; return 1
+          # Discover the actual child workflows for this run instead of guessing
+          # their IDs. Counts come from the run-prefixed Temporal workflows.
+          snapshot() {
+            temporal workflow list --query "WorkflowId STARTS_WITH '${RUN_GUID}'" -o json 2>/dev/null \
+              | python3 -c "
+          import json,sys
+          try: rows=json.load(sys.stdin) or []
+          except Exception: rows=[]
+          def gid(r): return ((r.get('execution') or {}).get('workflowId')) or r.get('workflowId','?')
+          st={gid(r): str(r.get('status','')) for r in rows}
+          comp=sum('COMPLETED' in v for v in st.values())
+          fail=sum(any(x in v for x in ('FAILED','TERMINATED','CANCELED','TIMED_OUT')) for v in st.values())
+          run =sum('RUNNING' in v for v in st.values())
+          for w,v in sorted(st.items()): print('   ', w, v.replace('WORKFLOW_EXECUTION_STATUS_',''), file=sys.stderr)
+          print(f'{len(st)} {comp} {fail} {run}')
+          "
           }
 
-          rc=0
-          for node in $NODES; do
-            wait_for "${RUN_GUID}-${node}" "$node" 900 || rc=1
+          GRACE=300; MAX=4500; elapsed=0; rc=0
+          while [ $elapsed -lt $MAX ]; do
+            read -r total comp fail run < <(snapshot)
+            total=${total:-0}; comp=${comp:-0}; fail=${fail:-0}; run=${run:-0}
+            echo "  [${elapsed}s] workflows=$total completed=$comp failed=$fail running=$run"
+            if [ "$fail" -gt 0 ]; then echo "::error::a DAG workflow failed"; rc=1; break; fi
+            if [ "$total" -ge "$EXPECTED" ] && [ "$comp" -ge "$EXPECTED" ]; then echo "All $EXPECTED nodes completed."; rc=0; break; fi
+            if [ "$total" -eq 0 ] && [ "$elapsed" -ge "$GRACE" ]; then
+              echo "::error::no DAG workflows dispatched within ${GRACE}s — submit/executor or queue problem"
+              echo "--- all recent Temporal workflows (for diagnosis) ---"
+              temporal workflow list --limit 30 2>/dev/null || true
+              rc=1; break
+            fi
+            sleep 10; elapsed=$((elapsed+10))
           done
+          [ $elapsed -lt $MAX ] || { echo "::error::run did not finish within ${MAX}s"; rc=1; }
 
           echo "### AE full-DAG run \`${RUN_GUID}\`" >> "$GITHUB_STEP_SUMMARY"
           temporal workflow list --query "WorkflowId STARTS_WITH '${RUN_GUID}'" 2>/dev/null \


### PR DESCRIPTION
## Summary
Fixes the AE full-DAG local harness so the credential-injection step works.

### Bugs (surfaced by the mssql pilot run)
1. **Connector dev local-vault returned 403** — the connector worker ran `ATLAN_DEPLOYMENT_NAME=ci`, but `/workflows/v1/dev/local-vault` is only enabled under `local`. Fix: start the connector with `ATLAN_DEPLOYMENT_NAME=local` (queue stays `atlan-<app>-<deployment>` via explicit `ATLAN_TASK_QUEUE`).
2. **SQLite statestore failed to open** (`unable to open database file`) — the `./local/dapr/` dir didn't exist. Fix: `mkdir -p local/dapr` in `write_components`.
3. `env $extra` moved last so per-worker overrides actually win.

> ⚠️ This branch points the reusable's internal `ae-stack-up` ref at `@fix/ae-stack-up-local-vault` for self-consistent end-to-end testing. **Flip back to `@main` before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)