### PR TITLE
fix(sql_app): align prime_sql_auth with SDK error model

### DIFF
--- a/application_sdk/templates/contracts/sql_metadata.py
+++ b/application_sdk/templates/contracts/sql_metadata.py
@@ -339,39 +339,27 @@ class PrimeAuthOutput(Output):
     ``caching_sha2_password``) before the parallel ``_extract_entity``
     burst.
 
-    Failure-as-data contract:
-        ``prime_sql_auth`` deliberately catches probe exceptions and
-        reports them as ``success=False`` on this output rather than
-        raising. ``run()`` inspects ``success`` and short-circuits with
-        a structured ``AuthError`` before the parallel extract burst.
+    Failure semantics — *raise, do not return*:
+        ``prime_sql_auth`` raises a typed :class:`AppError` on failure
+        (either propagating one the connector raised, or classifying a
+        raw driver exception at the catch site).  The standard ``@task``
+        wrapper translates the raised ``AppError`` into a Temporal
+        ``ApplicationError`` carrying the full ``to_failure_details()``
+        envelope, preserving audience / category / code on the wire and
+        setting ``non_retryable`` from the leaf's effective retryability.
+        Retry stacking is bounded by ``retry_max_attempts=1`` on the
+        ``@task`` decorator — the only failure mode that can re-run the
+        activity is a Temporal-level event (start-to-close timeout,
+        worker eviction, OOM), and those re-run regardless of whether
+        the body raises or returns failure data, so there is no
+        observability or safety benefit to a bespoke failure envelope.
 
-        Why return-not-raise: the failure mode this task targets is
-        cache-cold auth rejection (``Access denied``). Retrying that
-        through Temporal's activity-level retry just stacks the source's
-        ``failed_login_attempts`` counter — i.e. accelerates the lockout
-        cycle the prime was added to prevent. Returning structured
-        failure to ``run()`` makes the short-circuit explicit, keeps
-        the contextual error visible in Temporal activity-complete
-        events, and removes the auto-retry that was actively harmful.
+    This output only carries success-path observability; on failure the
+    workflow never receives it because the activity has already raised.
     """
 
     duration_ms: float = 0.0
     """Wall-clock time spent on the probe connection + ``SELECT 1`` + close."""
-
-    success: bool = True
-    """Whether the probe completed cleanly. ``False`` means the probe
-    raised; ``run()`` will short-circuit the workflow with an
-    ``AuthError`` carrying ``error_type`` / ``error_message``."""
-
-    error_type: str | None = None
-    """Exception class name (e.g. ``OperationalError``) when ``success``
-    is ``False``. ``None`` on success."""
-
-    error_message: str | None = None
-    """Truncated exception message when ``success`` is ``False``.
-    ``None`` on success. Secrets in the underlying driver message are
-    sanitised by the SDK error-wrapping layer; this field is the raw
-    short summary for observability."""
 
 
 class ExtractionTaskOutput(Output):

--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -84,6 +84,7 @@ from application_sdk.constants import (
 from application_sdk.contracts.types import FileReference, StorageTier
 from application_sdk.credentials import CredentialResolver, legacy_credential_ref
 from application_sdk.credentials.ref import CredentialRef
+from application_sdk.errors.base import AppError
 from application_sdk.errors.leaves import (
     AppTimeoutError,
     AuthError,
@@ -284,30 +285,33 @@ class SqlApp(App):
             MSSQL, Snowflake on most setups), this is harmless overhead
             — a single ~100ms probe round-trip per workflow run.
 
-        Failure semantics (return-not-raise + zero Temporal retries):
-            If the probe fails (auth rejected, network unreachable,
-            wrong host, etc.) this task catches the exception, populates
-            ``success=False`` + ``error_type`` + ``error_message`` on the
-            returned ``PrimeAuthOutput``, and lets ``run()`` short-circuit
-            the workflow with a typed error (``AuthError``,
-            ``AppTimeoutError`` or ``DependencyUnavailableError``
-            depending on ``error_type``).
+        Failure semantics — raise typed AppError on failure:
+            Two cases:
 
-            Why return failure instead of raising and letting Temporal
-            retry: the failure mode this task was added to prevent is
-            cache-cold auth rejection. Retrying it via Temporal's
-            activity-level retry stacks the source's
-            ``failed_login_attempts`` counter on each attempt — i.e. it
-            accelerates the very lockout cycle the prime exists to
-            avoid. The ``retry_max_attempts=1`` override on the ``@task``
-            decorator above is load-bearing: the body try/except only
-            catches Python exceptions, not Temporal-level failures
-            (start-to-close timeout, worker eviction, heartbeat timeout,
-            OOM) — those would re-run the activity even with this body
-            structure, re-stacking the counter. Workflow-level retry
-            (re-running the whole extraction after operator action)
-            remains available and is the correct retry layer for
-            transient blips.
+            - **Connector-raised typed leaf** (e.g. ``IamTokenGenerationError``,
+              ``MysqlSourceUnreachableError``, ``AwsAssumeRoleError``):
+              the ``except AppError: raise`` clause propagates it
+              unchanged.  The ``@task`` wrapper translates raised
+              ``AppError`` into a Temporal ``ApplicationError`` whose
+              payload is ``e.to_failure_details()`` and whose
+              ``non_retryable`` flag mirrors ``e.effective_retryable``,
+              so audience / category / code reach the wire intact.
+            - **Raw driver exception** (``OperationalError``,
+              ``TimeoutError``, …): the ``except Exception`` clause
+              classifies into a typed leaf via
+              :py:meth:`_classify_driver_exception` and raises that —
+              the same wire-envelope path applies.
+
+            Retry safety:
+            ``retry_max_attempts=1`` on the ``@task`` decorator is the
+            load-bearing guard against retry stacking on the source's
+            ``failed_login_attempts`` counter.  The body's try/except
+            cannot catch Temporal-level events (start-to-close timeout,
+            worker eviction, OOM) — those re-run the activity regardless
+            of whether the body raises or returns failure data, so a
+            return-not-raise envelope buys nothing here.  Workflow-level
+            retry (re-running the whole extraction after operator
+            action) remains the correct layer for transient blips.
         """
         start = time.perf_counter()
         try:
@@ -320,68 +324,96 @@ class SqlApp(App):
                 await client.get_results("SELECT 1")
             finally:
                 await client.close()
-        except Exception as exc:
-            duration_ms = (time.perf_counter() - start) * 1000.0
-            # Truncate driver messages so the contract field stays bounded;
-            # secret-sanitisation happens later when run() wraps this into
-            # an AuthError (errors.base._sanitize_cause_repr).
-            error_message = str(exc)
-            if len(error_message) > 500:
-                error_message = error_message[:500] + "…"
-            # exc_info=True preserves the traceback in worker logs even
-            # though the exception is being converted to structured return
-            # data. For most failures the class+message is sufficient, but
-            # the long-tail (TLS negotiation, driver bugs, version skew)
-            # is only diagnosable from the original frames.
+        except AppError:
+            # Already typed by the connector (e.g. ``IamTokenGenerationError``,
+            # ``MysqlSourceUnreachableError``, ``AwsAssumeRoleError``).
+            # The ``@task`` wrapper translates this into a Temporal
+            # ``ApplicationError`` carrying the full
+            # ``to_failure_details()`` envelope (audience, category,
+            # code) and sets ``non_retryable`` from the leaf's
+            # ``effective_retryable``.  ``retry_max_attempts=1`` on the
+            # decorator is the load-bearing guard against retry
+            # stacking — Python-level try/except cannot catch
+            # Temporal-level failures (start-to-close timeout, worker
+            # eviction, OOM) regardless of return-vs-raise, so there is
+            # no observability win to converting this into a
+            # return-failure envelope.
             logger.error(
-                "SQL auth cache prime FAILED after %.1fms (%s) — short-circuiting "
-                "before parallel extract burst to avoid stacking failed_login_attempts "
-                "on the source.",
-                duration_ms,
+                "SQL auth cache prime FAILED after %.1fms (typed AppError) — "
+                "propagating to short-circuit before parallel extract burst.",
+                (time.perf_counter() - start) * 1000.0,
+                exc_info=True,
+            )
+            raise
+        except Exception as exc:
+            # Untyped driver exception (raw ``OperationalError``,
+            # ``TimeoutError``, …).  Classify into a typed ``AppError``
+            # at the catch site — this is the connector-of-last-resort
+            # path for connectors that have not yet wrapped driver
+            # errors into their own typed leaves.  Raise so the
+            # standard ``@task`` wrapper handles the wire envelope
+            # uniformly.
+            logger.error(
+                "SQL auth cache prime FAILED after %.1fms (%s) — classifying "
+                "into typed AppError before propagating to short-circuit.",
+                (time.perf_counter() - start) * 1000.0,
                 type(exc).__name__,
                 exc_info=True,
             )
-            return PrimeAuthOutput(
-                duration_ms=duration_ms,
-                success=False,
-                error_type=type(exc).__name__,
-                error_message=error_message,
-            )
+            raise SqlApp._classify_driver_exception(exc) from exc
         duration_ms = (time.perf_counter() - start) * 1000.0
         logger.info(
             "SQL auth cache primed in %.1fms before parallel extract fan-out",
             duration_ms,
         )
-        return PrimeAuthOutput(duration_ms=duration_ms, success=True)
+        return PrimeAuthOutput(duration_ms=duration_ms)
 
     # =====================================================================
-    # prime_sql_auth failure classifier (BLDX-1295)
+    # prime_sql_auth driver-exception classifier (BLDX-1295)
     # =====================================================================
 
     @staticmethod
-    def _classify_prime_failure(prime_result: PrimeAuthOutput) -> Exception:
-        """Map a failed ``PrimeAuthOutput`` to the right typed error.
+    def _classify_driver_exception(exc: Exception) -> Exception:
+        """Map a raw (non-``AppError``) driver exception to a typed leaf.
 
-        Painting every probe failure as ``AuthError`` would mis-direct
-        on-call: a DBA who follows the lockout-specific
+        Only invoked for exceptions that are NOT already :class:`AppError`
+        subclasses.  Connectors that raise typed leaves directly (e.g.
+        ``IamTokenGenerationError``, ``MysqlSourceUnreachableError``)
+        bypass this method entirely — their typing flows through the
+        ``@task`` wrapper unchanged, preserving the connector's chosen
+        audience / category / code on the wire envelope.
+
+        This classifier exists for the "last-mile" cases where a
+        connector has not (yet) wrapped its driver exceptions into typed
+        leaves.  Painting every probe failure as ``AuthError`` would
+        mis-direct on-call: a DBA who follows the lockout-specific
         ``suggested_action`` for a DNS misconfiguration wastes time on
-        a non-existent account-lockout. We discriminate based on
-        ``error_type`` / ``error_message`` and raise:
+        a non-existent account-lockout.  We discriminate as:
 
-        - ``AuthError`` for actual credential rejections
-          (``Access denied``, MySQL code 1045,
-          ``AuthenticationError`` class names).
+        - ``AuthError`` for credential rejections
+          (``Access denied``, MySQL code 1045, ``AuthenticationError``
+          class names).
         - ``AppTimeoutError`` for probe timeouts (``TimeoutError`` /
           ``asyncio.TimeoutError`` / message contains ``timed out``).
-        - ``DependencyUnavailableError`` for network / DNS / TLS /
-          connection-refused failures — the source is presumed
-          reachable but didn't respond cleanly.
+        - ``DependencyUnavailableError`` (PLATFORM-audienced) for
+          network / DNS / TLS / connection-refused failures.  Note the
+          audience is PLATFORM because the SDK cannot know whether the
+          unreachable target is Atlan infra or a customer source —
+          connectors that *do* know (every SQL connector) should raise
+          their own USER-audienced typed leaf at the connect call site
+          and bypass this fallback entirely.
         - ``InternalError`` as the last-resort fallback so we never
           return ``None`` and never accidentally swallow an unknown
           driver exception class.
         """
-        error_type = prime_result.error_type or ""
-        error_message = prime_result.error_message or ""
+        error_type = type(exc).__name__
+        error_message = str(exc)
+        # Truncate driver messages so the resulting AppError's payload
+        # stays bounded in Temporal event history.  Secret sanitisation
+        # happens later in ``AppError.to_failure_details`` via
+        # ``_sanitize_cause_repr``.
+        if len(error_message) > 500:
+            error_message = error_message[:500] + "…"
         msg_lower = error_message.lower()
 
         is_timeout = "timeout" in error_type.lower() or "timed out" in msg_lower
@@ -441,9 +473,11 @@ class SqlApp(App):
             )
 
         # Network / DNS / TLS / connection-refused / generic
-        # OperationalError without an auth-keyword message. Default to
-        # DependencyUnavailableError — actionable guidance is "fix the
-        # network path, the source itself may be fine."
+        # OperationalError without an auth-keyword message.  Falls back
+        # to PLATFORM-audienced DependencyUnavailableError — connectors
+        # that know the target is customer-owned should raise their own
+        # USER-audienced leaf at the connect site and bypass this branch
+        # (see classmethod docstring).
         network_class_hints = (
             "connectionerror",
             "connectionrefused",
@@ -487,7 +521,7 @@ class SqlApp(App):
                 "Inspect the worker logs (the prime task logs the original "
                 "traceback via exc_info=True). The error type was not "
                 "recognised as auth / timeout / network — please file a "
-                "ticket so the classifier in SqlApp._classify_prime_failure "
+                "ticket so the classifier in SqlApp._classify_driver_exception "
                 "can be extended."
             ),
         )
@@ -753,17 +787,14 @@ class SqlApp(App):
         # subsequent parallel connections then take the fast-auth path
         # and never trip ``FAILED_LOGIN_ATTEMPTS`` lockouts.
         #
-        # Failure handling: prime_sql_auth catches probe exceptions and
-        # returns them as ``success=False`` on its output. We classify
-        # ``error_type`` / ``error_message`` and raise the matching typed
-        # error so operators get actionable guidance for the *actual*
-        # failure mode (not a one-size-fits-all auth-lockout message —
-        # which would mislead an on-call investigating a DNS or TLS
-        # misconfiguration). The parallel extract burst still never
-        # runs on prime failure regardless of which error type we raise.
-        prime_result = await self.prime_sql_auth(task_input)
-        if not prime_result.success:
-            raise self._classify_prime_failure(prime_result)
+        # Failure handling: prime_sql_auth raises a typed AppError
+        # directly on failure — connector-raised leaves propagate as-is
+        # via the @task wrapper (preserving audience/category/code on
+        # the wire); raw driver exceptions are classified into typed
+        # leaves at the activity's catch site by
+        # ``_classify_driver_exception`` before being raised.  Either
+        # way, the parallel extract burst never runs on prime failure.
+        await self.prime_sql_auth(task_input)
 
         # ── Phase 1: Extract — SQL rows → raw JSONL ─────────────────────
         db_result, schema_result, table_result, column_result = await asyncio.gather(

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.14.0
-source-sha:    0ef594aefde221c861d45a54d896d314ca1d906b
-source-date:   2026-06-01T18:50:15+05:30
+source-sha:    20086c1483e19616448e5a9f3199d426275731dc
+source-date:   2026-06-03T18:07:09+05:30
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -2826,9 +2826,6 @@ Strongly-typed Pydantic models for SDK methods. Contracts in `application_sdk.co
 - **Summary:** Output from the ``prime_sql_auth`` task (BLDX-1295).
 - **Fields:**
   - `duration_ms: float` `= 0.0` — Wall-clock time spent on the probe connection + ``SELECT 1`` + close.
-  - `success: bool` `= True` — Whether the probe completed cleanly. ``False`` means the probe
-  - `error_type: str | None` — Exception class name (e.g. ``OperationalError``) when ``success``
-  - `error_message: str | None` — Truncated exception message when ``success`` is ``False``.
 - **Defined in:** `application_sdk/templates/contracts/sql_metadata.py`
 
 #### `QueryBatchInput`

--- a/tests/unit/templates/test_sql_app.py
+++ b/tests/unit/templates/test_sql_app.py
@@ -1698,17 +1698,15 @@ class TestPrimeSqlAuth:
         """When the probe query itself raises (network blip, intermittent
         auth fail), the client must still be closed so the connection
         doesn't leak — otherwise repeated failures pile up sockets.
-
-        Note: post-review (PR #1835), prime_sql_auth catches the probe
-        exception and returns ``PrimeAuthOutput(success=False, ...)``
-        rather than re-raising. We still assert the inner ``client.close()``
-        was awaited so the connection is released cleanly before the
-        structured failure is reported upward.
+        Closing happens via the inner ``finally`` block, so it must
+        complete before the activity's catch site classifies and
+        re-raises the failure as a typed ``AppError``.
         """
+        from application_sdk.errors.leaves import InternalError
 
         class _ExplodingClient(FakeSQLClient):
             async def run_query(self, query, batch_size=100000):
-                raise RuntimeError("boom")  # simulate auth/network failure
+                raise RuntimeError("boom")
 
             async def get_results(self, query):
                 raise RuntimeError("boom")
@@ -1718,56 +1716,100 @@ class TestPrimeSqlAuth:
         fake.close = close_mock  # type: ignore[method-assign]
 
         with patch.object(SqlApp, "_init_sql_client", new=AsyncMock(return_value=fake)):
-            result = await app.prime_sql_auth(self._build_input())
+            # Raw ``RuntimeError`` is unrecognised by the driver-exception
+            # classifier and falls into the InternalError last-resort
+            # branch.  Closing the client is the real point of this test.
+            with pytest.raises(InternalError):
+                await app.prime_sql_auth(self._build_input())
 
         close_mock.assert_awaited_once()
-        # Failure is now returned as data, not raised.
-        assert isinstance(result, PrimeAuthOutput)
-        assert result.success is False
-        assert result.error_type == "RuntimeError"
-        assert result.error_message is not None and "boom" in result.error_message
 
-    async def test_prime_sql_auth_returns_failure_when_init_raises(self, app):
-        """If client construction itself raises (e.g. credential resolution
-        failed, host unresolvable), ``prime_sql_auth`` still reports the
-        failure as structured data rather than letting Temporal retry —
-        retrying that on the auth-cache probe path stacks the source's
-        ``failed_login_attempts`` counter and is the exact behaviour the
-        prime exists to avoid. Pinned by the PR #1835 reviewer's request."""
+    async def test_prime_sql_auth_raises_typed_error_when_init_raises(self, app):
+        """If client construction itself raises (e.g. credential
+        resolution failed, host unresolvable), ``prime_sql_auth``
+        classifies the driver exception and raises a typed leaf — the
+        ``@task`` wrapper translates that into ``ApplicationError``
+        with the wire envelope intact.  ``retry_max_attempts=1`` on
+        the task decorator prevents Temporal from retrying and
+        stacking the source's ``failed_login_attempts`` counter.
+        """
+        from application_sdk.errors.leaves import DependencyUnavailableError
 
         async def _exploding_init(_self, _input):
             raise ConnectionError("could not resolve host 'mysql.bad'")
 
         with patch.object(SqlApp, "_init_sql_client", new=_exploding_init):
-            result = await app.prime_sql_auth(self._build_input())
+            # ``ConnectionError`` matches the network-class hints in the
+            # classifier so it routes to ``DependencyUnavailableError``
+            # carrying the original message as ``network_error``.
+            with pytest.raises(DependencyUnavailableError) as exc_info:
+                await app.prime_sql_auth(self._build_input())
 
-        assert result.success is False
-        assert result.error_type == "ConnectionError"
-        assert (
-            result.error_message is not None
-            and "could not resolve host" in result.error_message
-        )
+        err = exc_info.value
+        assert err.service == "sql_source"
+        assert err.network_error and "could not resolve host" in err.network_error
 
-    async def test_prime_sql_auth_truncates_long_error_message(self, app):
+    async def test_prime_sql_auth_propagates_typed_apperror_unchanged(self, app):
+        """When the probe catches an exception that is already a typed
+        :class:`AppError` subclass — connector raised it from the
+        client's connect path — the activity must re-raise it
+        unchanged so the connector's audience / category / code reach
+        the wire envelope via the ``@task`` wrapper.  This is the
+        load-bearing path that lets connectors do their own
+        classification (e.g. ``IamTokenGenerationError``,
+        ``MysqlSourceUnreachableError``) without the SDK re-deriving
+        anything via string match.
+        """
+        from application_sdk.common.aws_utils_errors import AwsAssumeRoleError
+        from application_sdk.errors.categories import Audience
+
+        class _StsDeniedClient(FakeSQLClient):
+            async def get_results(self, query):
+                raise AwsAssumeRoleError(cause=RuntimeError("STS denied"))
+
+        fake = _StsDeniedClient()
+        with patch.object(SqlApp, "_init_sql_client", new=AsyncMock(return_value=fake)):
+            with pytest.raises(AwsAssumeRoleError) as exc_info:
+                await app.prime_sql_auth(self._build_input())
+
+        err = exc_info.value
+        # Class identity preserved — no reconstruction, no string-match
+        # re-classification.  The ``@task`` wrapper handles
+        # serialisation via ``to_failure_details()``.
+        assert type(err) is AwsAssumeRoleError
+        # Wire envelope: USER / PERMISSION_AWS_ROLE, exactly as the
+        # leaf's ClassVars declare.
+        envelope = err.to_failure_details()
+        assert envelope.audience is Audience.USER
+        assert envelope.code == "PERMISSION_AWS_ROLE"
+
+    async def test_prime_sql_auth_truncates_long_classified_message(self, app):
         """Driver error strings can be huge (full server response dumps).
-        The contract field caps at 500 chars + ellipsis so the
-        ``PrimeAuthOutput`` envelope stays bounded in activity-event
-        payloads."""
+        ``_classify_driver_exception`` truncates at 500 chars + ellipsis
+        so the resulting typed ``AppError``'s payload stays bounded in
+        Temporal event history.
+        """
 
         long_message = "x" * 2000
 
         class _ExplodingClient(FakeSQLClient):
             async def get_results(self, query):
-                raise RuntimeError(long_message)
+                # OperationalError lookalike — routes through the
+                # network branch which embeds the message into
+                # ``network_error``.
+                raise type("OperationalError", (Exception,), {})(long_message)
 
         fake = _ExplodingClient()
         with patch.object(SqlApp, "_init_sql_client", new=AsyncMock(return_value=fake)):
-            result = await app.prime_sql_auth(self._build_input())
+            with pytest.raises(Exception) as exc_info:
+                await app.prime_sql_auth(self._build_input())
 
-        assert result.success is False
-        assert result.error_message is not None
-        assert len(result.error_message) == 501  # 500 chars + ellipsis
-        assert result.error_message.endswith("…")
+        # The classifier truncates ``str(exc)`` to 500 chars + ellipsis
+        # before embedding it into the typed leaf.
+        err = exc_info.value
+        truncated = getattr(err, "network_error", None) or err.message
+        assert truncated.endswith("…")
+        assert len(truncated) <= 600  # 500 chars + ellipsis + small framing
 
     # ── Bug-reproduction via call ordering ──────────────────────────────
 
@@ -1934,16 +1976,16 @@ class TestPrimeSqlAuth:
             ), f"{ext} must run after prime_sql_auth; got order: {call_order}"
 
     async def test_prime_failure_short_circuits_run(self):
-        """When ``prime_sql_auth`` reports ``success=False`` (credential
-        failure, network unreachable), ``run()`` must abort BEFORE the
+        """When ``prime_sql_auth`` raises a typed ``AppError`` (e.g.
+        ``AuthError`` from the driver-exception classifier on an
+        ``Access denied`` from MySQL), ``run()`` must abort BEFORE the
         parallel extract burst. Otherwise we'd flood the source with N
         parallel auth-failure attempts — the exact behaviour the prime
         is meant to prevent.
 
-        Post-review (PR #1835): prime returns structured failure
-        instead of raising. ``run()`` translates it into a typed
-        ``AuthError`` that names the prime step + the underlying
-        driver error + a recommended fix path.
+        The activity now raises the typed leaf directly (via the
+        ``@task`` wrapper's AppError → ApplicationError translation),
+        so ``run()`` doesn't need any classification logic of its own.
         """
         from application_sdk.errors.leaves import AuthError
 
@@ -1956,19 +1998,23 @@ class TestPrimeSqlAuth:
             )
         )
 
+        # prime_sql_auth raises AuthError (as it would after
+        # _classify_driver_exception sees an ``Access denied`` message).
+        auth_err = AuthError(
+            message="SQL auth-cache prime rejected by source (OperationalError)",
+            auth_method="sql_client",
+            failure_reason="(1045, \"Access denied for user 'foo'@'1.2.3.4'\")",
+            suggested_action=(
+                "Verify credentials; check FAILED_LOGIN_ATTEMPTS lockout."
+            ),
+        )
+
         with (
             patch.object(SqlApp, "_resolve_credential_ref", return_value=None),
             patch.object(
                 SqlApp,
                 "prime_sql_auth",
-                new=AsyncMock(
-                    return_value=PrimeAuthOutput(
-                        duration_ms=12.3,
-                        success=False,
-                        error_type="OperationalError",
-                        error_message="(1045, \"Access denied for user 'foo'@'1.2.3.4'\")",
-                    ),
-                ),
+                new=AsyncMock(side_effect=auth_err),
             ),
             patch.object(SqlApp, "extract_databases", new=extract_called),
             patch.object(SqlApp, "extract_schemas", new=extract_called),
@@ -1979,46 +2025,36 @@ class TestPrimeSqlAuth:
                 await app.run(ExtractionInput(output_path="/tmp/test"))
 
         extract_called.assert_not_called()
+        # The raised AuthError must propagate unchanged — no
+        # re-classification on the run() side.
+        assert exc_info.value is auth_err
 
-        # The raised AuthError must carry actionable context — the prime
-        # step is named, the underlying driver error is surfaced as
-        # failure_reason, and the suggestion mentions FAILED_LOGIN_ATTEMPTS
-        # so an operator knows what to check before retrying.
-        err = exc_info.value
-        assert "rejected by source" in err.message.lower()
-        assert "OperationalError" in err.message
-        assert err.failure_reason and "Access denied" in err.failure_reason
-        assert err.auth_method == "sql_client"
-        assert err.suggested_action and "FAILED_LOGIN_ATTEMPTS" in err.suggested_action
-
-    async def test_prime_failure_yields_auth_error_with_no_temporal_retry(self):
-        """Pin the BLDX-1295 retry-semantics decision: the structured
-        AuthError raised by ``run()`` on prime failure is
-        ``effective_retryable=False``. This is what stops Temporal from
-        auto-retrying the run-level activity and stacking the source's
-        ``failed_login_attempts`` counter on each retry — the original
-        ``@task(retry_max_attempts=3)`` on the prime itself was the
-        bug; this test pins that we don't reintroduce auto-retry on the
-        failure path.
+    async def test_prime_failure_yields_app_error_non_retryable(self):
+        """Pin the BLDX-1295 retry-semantics decision: AppError leaves
+        raised on the prime failure path have ``effective_retryable``
+        controlled by the leaf, not by the prime probe itself.  For
+        ``AuthError`` (non-retryable by default) this means the
+        ``@task`` wrapper sets ``non_retryable=True`` on the resulting
+        Temporal ``ApplicationError`` — Temporal will not auto-retry
+        and stack the source's ``failed_login_attempts`` counter.
         """
         from application_sdk.errors.leaves import AuthError
 
         app = SqlApp.__new__(SqlApp)
         app._app_name = "test-app"
 
+        auth_err = AuthError(
+            message="prime rejected by source",
+            auth_method="sql_client",
+            failure_reason="Access denied",
+        )
+
         with (
             patch.object(SqlApp, "_resolve_credential_ref", return_value=None),
             patch.object(
                 SqlApp,
                 "prime_sql_auth",
-                new=AsyncMock(
-                    return_value=PrimeAuthOutput(
-                        duration_ms=10.0,
-                        success=False,
-                        error_type="OperationalError",
-                        error_message="Access denied",
-                    ),
-                ),
+                new=AsyncMock(side_effect=auth_err),
             ),
             patch.object(SqlApp, "extract_databases", new=AsyncMock()),
             patch.object(SqlApp, "extract_schemas", new=AsyncMock()),
@@ -2028,20 +2064,28 @@ class TestPrimeSqlAuth:
             with pytest.raises(AuthError) as exc_info:
                 await app.run(ExtractionInput(output_path="/tmp/test"))
 
+        # AuthError defaults to non-retryable; the @task wrapper reads
+        # this to set ApplicationError.non_retryable.
         assert exc_info.value.effective_retryable is False
 
     @pytest.mark.parametrize(
-        "error_type,error_message",
+        "exc_type,exc_message",
         [
-            ("TimeoutError", "operation timed out after 60s"),
-            ("AsyncioTimeoutError", "deadline exceeded"),
-            ("OperationalError", "(2013) Lost connection during query — timed out"),
+            (type("TimeoutError", (Exception,), {}), "operation timed out after 60s"),
+            (
+                type("AsyncioTimeoutError", (Exception,), {}),
+                "deadline exceeded",
+            ),
+            (
+                type("OperationalError", (Exception,), {}),
+                "(2013) Lost connection during query — timed out",
+            ),
         ],
     )
-    async def test_prime_timeout_raises_app_timeout_error(
-        self, error_type, error_message
+    async def test_classify_driver_exception_routes_timeouts(
+        self, exc_type, exc_message
     ):
-        """Probe failures classified as timeouts must surface as
+        """Raw driver exceptions classified as timeouts route to
         ``AppTimeoutError`` — NOT ``AuthError`` — so the on-call's
         ``suggested_action`` is "check network reachability" rather
         than "run ACCOUNT UNLOCK". Pinned by application-sdk#1835
@@ -2049,111 +2093,107 @@ class TestPrimeSqlAuth:
         """
         from application_sdk.errors.leaves import AppTimeoutError
 
-        app = SqlApp.__new__(SqlApp)
-        app._app_name = "test-app"
+        result = SqlApp._classify_driver_exception(exc_type(exc_message))
 
-        with (
-            patch.object(SqlApp, "_resolve_credential_ref", return_value=None),
-            patch.object(
-                SqlApp,
-                "prime_sql_auth",
-                new=AsyncMock(
-                    return_value=PrimeAuthOutput(
-                        duration_ms=60_000.0,
-                        success=False,
-                        error_type=error_type,
-                        error_message=error_message,
-                    ),
-                ),
-            ),
-            patch.object(SqlApp, "extract_databases", new=AsyncMock()),
-            patch.object(SqlApp, "extract_schemas", new=AsyncMock()),
-            patch.object(SqlApp, "extract_tables", new=AsyncMock()),
-            patch.object(SqlApp, "extract_columns", new=AsyncMock()),
-        ):
-            with pytest.raises(AppTimeoutError) as exc_info:
-                await app.run(ExtractionInput(output_path="/tmp/test"))
-
-        err = exc_info.value
-        assert err.operation == "prime_sql_auth"
-        # AppTimeoutError doesn't define a structured ``failure_reason``
-        # field — driver message is inlined into ``message`` instead.
-        assert error_message in err.message
-        assert err.suggested_action and "network reachability" in err.suggested_action
+        assert isinstance(result, AppTimeoutError)
+        assert result.operation == "prime_sql_auth"
+        assert exc_message in result.message
+        assert (
+            result.suggested_action
+            and "network reachability" in result.suggested_action
+        )
 
     @pytest.mark.parametrize(
-        "error_type,error_message",
+        "exc_type,exc_message",
         [
-            ("ConnectionRefusedError", "[Errno 111] Connection refused"),
-            ("gaierror", "[Errno -2] Name or service not known"),
-            ("SSLError", "[SSL: CERTIFICATE_VERIFY_FAILED]"),
             (
-                "OperationalError",
+                type("ConnectionRefusedError", (Exception,), {}),
+                "[Errno 111] Connection refused",
+            ),
+            (
+                type("gaierror", (Exception,), {}),
+                "[Errno -2] Name or service not known",
+            ),
+            (
+                type("SSLError", (Exception,), {}),
+                "[SSL: CERTIFICATE_VERIFY_FAILED]",
+            ),
+            (
+                type("OperationalError", (Exception,), {}),
                 "(2003) Can't connect to MySQL server on 'db.example.com'",
             ),
         ],
     )
-    async def test_prime_network_failure_raises_dependency_unavailable(
-        self, error_type, error_message
+    async def test_classify_driver_exception_routes_network_failures(
+        self, exc_type, exc_message
     ):
-        """Probe failures that look like network / DNS / TLS /
-        connection-refused must surface as
-        ``DependencyUnavailableError``. The on-call guidance must NOT
-        suggest a credentials check (the credentials path was never
-        exercised) and must NOT suggest ACCOUNT UNLOCK (no failed
-        login attempts were made). Pinned by application-sdk#1835
-        mothership comment-3287630230 (HIGH).
+        """Network / DNS / TLS / connection-refused failures (no auth
+        keywords in message) route to ``DependencyUnavailableError``.
+        PLATFORM-audienced by default — connectors that know the
+        target is a customer-owned source should raise their own
+        USER-audienced leaf at the connect site and bypass this
+        branch entirely (see ``MysqlSourceUnreachableError`` in
+        atlan-mysql-app).
         """
         from application_sdk.errors.leaves import DependencyUnavailableError
 
-        app = SqlApp.__new__(SqlApp)
-        app._app_name = "test-app"
+        result = SqlApp._classify_driver_exception(exc_type(exc_message))
 
-        with (
-            patch.object(SqlApp, "_resolve_credential_ref", return_value=None),
-            patch.object(
-                SqlApp,
-                "prime_sql_auth",
-                new=AsyncMock(
-                    return_value=PrimeAuthOutput(
-                        duration_ms=50.0,
-                        success=False,
-                        error_type=error_type,
-                        error_message=error_message,
-                    ),
-                ),
-            ),
-            patch.object(SqlApp, "extract_databases", new=AsyncMock()),
-            patch.object(SqlApp, "extract_schemas", new=AsyncMock()),
-            patch.object(SqlApp, "extract_tables", new=AsyncMock()),
-            patch.object(SqlApp, "extract_columns", new=AsyncMock()),
-        ):
-            with pytest.raises(DependencyUnavailableError) as exc_info:
-                await app.run(ExtractionInput(output_path="/tmp/test"))
-
-        err = exc_info.value
-        assert err.service == "sql_source"
-        assert err.network_error == error_message
-        # Must steer the operator toward network/DNS investigation, and
-        # explicitly NOT toward auth-lockout work. The classifier's
-        # actual phrasing is "this is not a lockout situation — do not
-        # run ACCOUNT UNLOCK" (a helpful disclaimer), so check the
-        # positive guidance is network-shaped.
-        assert err.suggested_action and "DNS" in err.suggested_action
+        assert isinstance(result, DependencyUnavailableError)
+        assert result.service == "sql_source"
+        assert result.network_error == exc_message
+        # Steer toward network/DNS investigation, NOT toward
+        # auth-lockout work.
+        assert result.suggested_action and "DNS" in result.suggested_action
         assert (
-            err.suggested_action and "FAILED_LOGIN_ATTEMPTS" not in err.suggested_action
+            result.suggested_action
+            and "FAILED_LOGIN_ATTEMPTS" not in result.suggested_action
         )
 
-    async def test_prime_unknown_error_class_falls_back_to_internal(self):
-        """Last-resort: a driver throws an unrecognised exception class.
-        The classifier must NOT swallow it as auth — it returns
-        ``InternalError`` so the on-call sees "unclassified" and knows
-        to inspect worker logs (where ``exc_info=True`` preserves the
-        full traceback). Pinned by application-sdk#1835 mothership
-        comment-3287630230 (HIGH).
+    async def test_classify_driver_exception_falls_back_to_internal(self):
+        """Last-resort: an unrecognised driver exception class routes to
+        ``InternalError`` with ``classification_pending=True`` so
+        on-call sees ``unclassified`` and knows to inspect worker
+        logs (where ``exc_info=True`` preserves the full traceback).
         """
         from application_sdk.errors.leaves import InternalError
 
+        unknown = type("WeirdVendorSpecificError", (Exception,), {})(
+            "something we have never seen before"
+        )
+        result = SqlApp._classify_driver_exception(unknown)
+
+        assert isinstance(result, InternalError)
+        assert "unclassified" in result.message.lower()
+        assert (
+            result.suggested_action
+            and "_classify_driver_exception" in result.suggested_action
+        )
+
+    async def test_prime_propagates_typed_apperror_unchanged_through_run(self):
+        """When ``prime_sql_auth`` raises a typed ``AppError`` subclass
+        the connector defined (e.g. ``AwsAssumeRoleError`` carrying
+        ``USER / PERMISSION_AWS_ROLE``), ``run()`` lets it propagate
+        unchanged.  No re-classification, no reconstruction —
+        the ``@task`` wrapper preserves audience/category/code via
+        ``to_failure_details()``.
+
+        Pre-fix: the prime probe caught the AppError, stuffed it into
+        ``PrimeAuthOutput.success=False`` with a bare class name, and
+        a workflow-side string-match classifier re-derived the type —
+        landing on ``InternalError`` for any class name the matcher
+        didn't recognise (``AwsAssumeRoleError`` was the production
+        case for rocketcompanies' nightly SLA bleed).
+
+        Post-fix: ``prime_sql_auth`` re-raises typed AppErrors and the
+        wrapper handles serialisation.  This test pins the end-to-end
+        wire shape so we don't regress.
+        """
+        from application_sdk.common.aws_utils_errors import AwsAssumeRoleError
+        from application_sdk.errors.categories import Audience
+
+        sts_err = AwsAssumeRoleError(cause=RuntimeError("STS denied"))
+
         app = SqlApp.__new__(SqlApp)
         app._app_name = "test-app"
 
@@ -2162,25 +2202,21 @@ class TestPrimeSqlAuth:
             patch.object(
                 SqlApp,
                 "prime_sql_auth",
-                new=AsyncMock(
-                    return_value=PrimeAuthOutput(
-                        duration_ms=10.0,
-                        success=False,
-                        error_type="WeirdVendorSpecificError",
-                        error_message="something we have never seen before",
-                    ),
-                ),
+                new=AsyncMock(side_effect=sts_err),
             ),
             patch.object(SqlApp, "extract_databases", new=AsyncMock()),
             patch.object(SqlApp, "extract_schemas", new=AsyncMock()),
             patch.object(SqlApp, "extract_tables", new=AsyncMock()),
             patch.object(SqlApp, "extract_columns", new=AsyncMock()),
         ):
-            with pytest.raises(InternalError) as exc_info:
+            with pytest.raises(AwsAssumeRoleError) as exc_info:
                 await app.run(ExtractionInput(output_path="/tmp/test"))
 
         err = exc_info.value
-        assert "unclassified" in err.message.lower()
-        assert (
-            err.suggested_action and "_classify_prime_failure" in err.suggested_action
-        )
+        # Same identity — no reconstruction.
+        assert err is sts_err
+        # Wire envelope carries USER / PERMISSION_AWS_ROLE from the
+        # leaf's ClassVars via to_failure_details().
+        envelope = err.to_failure_details()
+        assert envelope.audience is Audience.USER
+        assert envelope.code == "PERMISSION_AWS_ROLE"


### PR DESCRIPTION
## Summary

`prime_sql_auth` was the only typed-error-aware `@task` in the SDK that caught typed `AppError` subclasses, stuffed them into a bespoke failure envelope (`PrimeAuthOutput.success=False` + bare class-name strings), and re-classified them workflow-side via string matching. This was both a duplicate classification layer and the root cause of the production misclassification that bled Atlan SLA budget for customer-side AWS IAM failures (`AwsAssumeRoleError` surfaced as `APP_OWNER/INTERNAL` because the workflow-side string match didn't recognise the connector's class name).

This PR aligns `prime_sql_auth` with the SDK's standard pattern: **just raise**.

### How the SDK already preserves typing across the activity boundary

The `@task` wrapper at `application_sdk/execution/_temporal/activities.py:255-265` translates raised `AppError` into Temporal `ApplicationError` carrying the full `to_failure_details()` envelope (audience / category / code) and sets `non_retryable` from the leaf's `effective_retryable`. Every other typed-error-aware activity in the SDK already uses this. The retry-stacking concern that motivated `prime_sql_auth`'s return-not-raise pattern is handled by `retry_max_attempts=1` on the `@task` decorator — the body's try/except can't catch Temporal-level failures (start-to-close timeout, worker eviction, OOM) regardless of return-vs-raise, so a bespoke envelope buys nothing.

### Changes

- **`prime_sql_auth`**: `except AppError: raise` (typed leaves propagate unchanged through the wrapper) + `except Exception: raise _classify_driver_exception(exc)` (raw driver exceptions classified at the catch site, raised as the typed leaf).
- **Rename `_classify_prime_failure(PrimeAuthOutput)` → `_classify_driver_exception(Exception)`**. Same string-match logic; smaller signature; only invoked for non-`AppError` exceptions.
- **Trim `PrimeAuthOutput` to `duration_ms` only**. The `success` / `error_type` / `error_message` failure envelope is gone — the activity raises on failure, so the workflow never sees `PrimeAuthOutput` in that case.
- **Simplify `run()`**: `await self.prime_sql_auth(task_input)` — exception propagates if the prime fails, no success-flag check.

### Net effect for connectors

| Connector pattern | Behaviour |
|---|---|
| Raises a typed `AppError` from its connect path (e.g. `IamTokenGenerationError`, `MysqlSourceUnreachableError`, `AwsAssumeRoleError`) | Flows through `prime_sql_auth` → `@task` wrapper → wire envelope with audience / category / code intact. No SDK changes per-connector. |
| Lets raw driver exceptions propagate (no app-side typed wrapping yet) | Lands in `_classify_driver_exception` fallback — same string-match logic as before, now at the activity's catch site. |

### Production motivation

`rocketcompanies` MySQL workflows nightly at ~04:00 UTC fix:

| Failure | Before | After |
|---|---|---|
| `AwsAssumeRoleError` (already typed `AppPermissionDeniedError`, USER) | `APP_OWNER / INTERNAL` ❌ | `USER / PERMISSION_AWS_ROLE` ✅ |
| `OperationalError` against customer source (no auth keywords) | `PLATFORM / DEPENDENCY_UNAVAILABLE` (unchanged for raw driver exceptions) | App-side wrap (e.g. `MysqlSourceUnreachableError`) → `USER / DEPENDENCY_UNAVAILABLE_MYSQL_SOURCE` via [atlan-mysql-app#160](https://github.com/atlanhq/atlan-mysql-app/pull/160) |

### Breaking change

SDK subclassers that override `prime_sql_auth` and rely on the return-not-raise contract must switch to raising typed `AppError`s. The new shape is what every other typed-error-aware `@task` in the SDK already does. CHANGELOG updated by CI.

## Test plan

- [x] `pytest tests/unit/templates/test_sql_app.py -k "prime or classify"` — 19/19 pass:
  - `test_prime_sql_auth_propagates_typed_apperror_unchanged` — `AwsAssumeRoleError` raised by client propagates through prime probe with USER / PERMISSION_AWS_ROLE intact on the envelope
  - `test_prime_sql_auth_raises_typed_error_when_init_raises` — `ConnectionError` classifies into `DependencyUnavailableError` at the catch site and raises
  - `test_prime_sql_auth_closes_client_even_on_failure` — inner `finally: client.close()` still runs before the raise propagates
  - `test_prime_sql_auth_truncates_long_classified_message` — classifier truncates driver messages to bound the wire payload
  - `test_classify_driver_exception_routes_{timeouts,network_failures}` — parametrised cases for the string-match fallback
  - `test_classify_driver_exception_falls_back_to_internal` — unknown driver exceptions get `InternalError` with `classification_pending=True`
  - `test_prime_failure_short_circuits_run` — `run()` aborts on raised AppError before the extract burst
  - `test_prime_failure_yields_app_error_non_retryable` — `AuthError` raised by prime has `effective_retryable=False`, so the `@task` wrapper sets `non_retryable=True` on the Temporal `ApplicationError`
  - `test_prime_propagates_typed_apperror_unchanged_through_run` — end-to-end: connector-raised `AwsAssumeRoleError` reaches `run()` unchanged, wire envelope intact
- [x] `pytest tests/unit/errors/ tests/unit/templates/ tests/integration/test_sql_app_prime_auth.py` — 295/295 pass
- [x] `pre-commit run --files <changed>` — clean (ruff / ruff-format / pyright)