### PR TITLE
chore: add toolkit PR review mode

### DIFF
--- a/.agents/skills/toolkit-feature-workflow/SKILL.md
+++ b/.agents/skills/toolkit-feature-workflow/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: toolkit-feature-workflow
+description: Use when reviewing an application-sdk PR that changes contract-toolkit behavior, generated contract artifacts, toolkit examples, or toolkit docs. Runs toolkit-only PR review mode: classify affected generated surfaces, perform mandatory private downstream compatibility validation through Mothership/Rover, and post sanitized review findings without exposing internal consumer repo paths.
+---
+
+# Toolkit PR Review Workflow
+
+Use this skill only in PR review mode. It does not implement toolkit features.
+
+The contract toolkit lives under `contract-toolkit/` in the SDK repository. It
+renders app setup config, credential config, Automation Engine manifests, typed
+SDK input models, and bundle metadata. A PR can pass local Pkl checks while still
+breaking a downstream consumer, so every substantive review must validate the
+affected generated surface against the relevant consumer class.
+
+## Review Contract
+
+1. Read the PR, diff, changed files, and `contract-toolkit/AGENTS.md`.
+2. Classify the changed surface:
+   - workflow/setup UI: `Config.pkl`, `Widgets.pkl`, setup widgets/properties.
+   - credentials: `FieldSpec`, `AuthOption`, `ConditionalFieldSpec`, credential config output.
+   - manifest: node args, `{{params}}`, static values, output references.
+   - DAG/default nodes: typed nodes, node ids, dependencies, task queues, workflow/activity labels.
+   - generated SDK input: `_input.py` names, defaults, types, `ExtractionInput` collisions.
+   - bundle/root metadata: `NativeAppBundle.pkl`, generated `atlan.yaml`, shared credentials.
+   - examples/docs/release metadata: generated output, docs, changelog, PR title.
+3. Run only relevant validations, but treat them as mandatory once the surface is
+   affected. Do not approve over an unrun mandatory check.
+4. Distinguish compatibility from adoption:
+   - Optional new fields do not need every downstream app to already use them.
+   - Required generated values, changed placeholders, changed node args, or changed
+     runtime assumptions must be validated against the relevant consumer.
+   - If the PR claims compatibility with a specific app pattern, validate that
+     representative pattern.
+5. Keep private evidence private. Internal repo names, file paths, and clone
+   locations may be used in scratch notes, but public PR comments must use
+   capability names such as "UI rendering", "manifest substitution", "workflow
+   execution", and "representative app pattern".
+
+## Mandatory Local Checks
+
+Run these from the SDK repo root when the relevant files changed:
+
+```bash
+contract-toolkit/scripts/regenerate-all.sh
+contract-toolkit/scripts/check-invariants.sh
+(cd contract-toolkit && pkl test tests/*.pkl)
+uv run --extra workflows python contract-toolkit/scripts/test-sdk-import.py
+git diff --check
+```
+
+Inspect generated output whenever `contract-toolkit/src/` or examples changed:
+
+```bash
+git diff -- contract-toolkit/examples
+find contract-toolkit/examples -name "_input.py" -print
+```
+
+Do not hand-edit generated files to satisfy stale-output findings; require
+regeneration.
+
+## Mandatory Private Consumer Validation
+
+Use `.mothership/pr-review/references/toolkit-consumer-registry.md` as the
+private registry. Mothership/Rover should clone missing consumers into a scratch
+directory or use an existing checkout, fetch the configured branch, and record
+the checked SHA privately.
+
+Maintain `/tmp/TOOLKIT_VALIDATION.md` as the private validation ledger. Each
+mandatory capability must be recorded once with one of `validated`, `not
+applicable`, or `needs rerun`. Any `needs rerun` status prevents approval.
+
+Validation mapping:
+
+- UI/setup or credential shape changed -> validate UI rendering consumers.
+- Manifest placeholders, static args, or parameter names changed -> validate
+  manifest substitution consumers.
+- DAG/default typed node behavior changed -> validate workflow execution consumers.
+- Generated `_input.py` shape changed -> validate SDK runtime input import and
+  any representative app pattern the PR targets.
+- App-specific node/field changed -> validate the representative app pattern only
+  when the PR changes required behavior, generated output, or claims that app's
+  compatibility.
+
+If a mandatory private check cannot run because Rover/Mothership infrastructure
+failed, do not expose the internal failure details. Add a final public note:
+
+```text
+Review note: one required compatibility check could not be completed due to a Rover execution issue. Please re-run @sdk-review or request human review before merge.
+```
+
+## Public Review Format
+
+Post a concise review with these sections:
+
+```text
+### Affected Toolkit Surfaces
+- <surface>: <why it is affected>
+
+### Compatibility Checks
+- UI rendering compatibility: validated | not applicable | needs rerun
+- Manifest substitution compatibility: validated | not applicable | needs rerun
+- Workflow execution contract: validated | not applicable | needs rerun
+- Generated SDK input contract: validated | not applicable | needs rerun
+- Representative app pattern: validated | not applicable | needs rerun
+
+### Findings
+<file-grouped findings, sanitized>
+
+### Review Note
+<only if a mandatory private check could not complete due to Rover execution>
+```
+
+Public findings can mention generated artifact names such as `manifest.json`,
+`_input.py`, or workflow/credential config, but must not mention private consumer
+repo paths or internal app file paths.
+
+Before posting, run `.mothership/pr-review/scripts/redact-toolkit-public-review.sh`
+on the summary and inline comment bodies.
+
+## Verdict Rules
+
+- Compatibility break found -> `NEEDS_FIXES`.
+- Required generated output stale -> `NEEDS_FIXES`.
+- Missing tests/docs/examples for a public toolkit behavior change -> `NEEDS_FIXES`.
+- Mandatory consumer validation blocked by Rover/Mothership execution -> no
+  approval; request rerun or human review using the sanitized note.
+- Optional field not yet adopted by a downstream app -> not a finding.
+- Mixed `application_sdk/**` and `contract-toolkit/**` PR -> require both SDK
+  review and toolkit review tracks before approval.

--- a/.agents/skills/toolkit-feature-workflow/SKILL.md
+++ b/.agents/skills/toolkit-feature-workflow/SKILL.md
@@ -97,7 +97,7 @@ Post a concise review with these sections:
 ### Affected Toolkit Surfaces
 - <surface>: <why it is affected>
 
-### Compatibility Checks
+### Cross-Repo Validation
 - UI rendering compatibility: validated | not applicable | needs rerun
 - Manifest substitution compatibility: validated | not applicable | needs rerun
 - Workflow execution contract: validated | not applicable | needs rerun
@@ -114,6 +114,9 @@ Post a concise review with these sections:
 Public findings can mention generated artifact names such as `manifest.json`,
 `_input.py`, or workflow/credential config, but must not mention private consumer
 repo paths or internal app file paths.
+The cross-repo section must confirm capability-level validation only; it must
+not list consumer repository names, package names, branch names, SHAs, local
+paths, or system-app implementation details.
 
 Before posting, run `.mothership/pr-review/scripts/redact-toolkit-public-review.sh`
 on the summary and inline comment bodies.

--- a/.claude/skills/toolkit-feature-workflow/SKILL.md
+++ b/.claude/skills/toolkit-feature-workflow/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: toolkit-feature-workflow
+description: Use when reviewing an application-sdk PR that changes contract-toolkit behavior, generated contract artifacts, toolkit examples, or toolkit docs. Runs toolkit-only PR review mode: classify affected generated surfaces, perform mandatory private downstream compatibility validation through Mothership/Rover, and post sanitized review findings without exposing internal consumer repo paths.
+---
+
+# Toolkit PR Review Workflow
+
+Use this skill only in PR review mode. It does not implement toolkit features.
+
+The contract toolkit lives under `contract-toolkit/` in the SDK repository. It
+renders app setup config, credential config, Automation Engine manifests, typed
+SDK input models, and bundle metadata. A PR can pass local Pkl checks while still
+breaking a downstream consumer, so every substantive review must validate the
+affected generated surface against the relevant consumer class.
+
+## Review Contract
+
+1. Read the PR, diff, changed files, and `contract-toolkit/AGENTS.md`.
+2. Classify the changed surface:
+   - workflow/setup UI: `Config.pkl`, `Widgets.pkl`, setup widgets/properties.
+   - credentials: `FieldSpec`, `AuthOption`, `ConditionalFieldSpec`, credential config output.
+   - manifest: node args, `{{params}}`, static values, output references.
+   - DAG/default nodes: typed nodes, node ids, dependencies, task queues, workflow/activity labels.
+   - generated SDK input: `_input.py` names, defaults, types, `ExtractionInput` collisions.
+   - bundle/root metadata: `NativeAppBundle.pkl`, generated `atlan.yaml`, shared credentials.
+   - examples/docs/release metadata: generated output, docs, changelog, PR title.
+3. Run only relevant validations, but treat them as mandatory once the surface is
+   affected. Do not approve over an unrun mandatory check.
+4. Distinguish compatibility from adoption:
+   - Optional new fields do not need every downstream app to already use them.
+   - Required generated values, changed placeholders, changed node args, or changed
+     runtime assumptions must be validated against the relevant consumer.
+   - If the PR claims compatibility with a specific app pattern, validate that
+     representative pattern.
+5. Keep private evidence private. Internal repo names, file paths, and clone
+   locations may be used in scratch notes, but public PR comments must use
+   capability names such as "UI rendering", "manifest substitution", "workflow
+   execution", and "representative app pattern".
+
+## Mandatory Local Checks
+
+Run these from the SDK repo root when the relevant files changed:
+
+```bash
+contract-toolkit/scripts/regenerate-all.sh
+contract-toolkit/scripts/check-invariants.sh
+(cd contract-toolkit && pkl test tests/*.pkl)
+uv run --extra workflows python contract-toolkit/scripts/test-sdk-import.py
+git diff --check
+```
+
+Inspect generated output whenever `contract-toolkit/src/` or examples changed:
+
+```bash
+git diff -- contract-toolkit/examples
+find contract-toolkit/examples -name "_input.py" -print
+```
+
+Do not hand-edit generated files to satisfy stale-output findings; require
+regeneration.
+
+## Mandatory Private Consumer Validation
+
+Use `.mothership/pr-review/references/toolkit-consumer-registry.md` as the
+private registry. Mothership/Rover should clone missing consumers into a scratch
+directory or use an existing checkout, fetch the configured branch, and record
+the checked SHA privately.
+
+Maintain `/tmp/TOOLKIT_VALIDATION.md` as the private validation ledger. Each
+mandatory capability must be recorded once with one of `validated`, `not
+applicable`, or `needs rerun`. Any `needs rerun` status prevents approval.
+
+Validation mapping:
+
+- UI/setup or credential shape changed -> validate UI rendering consumers.
+- Manifest placeholders, static args, or parameter names changed -> validate
+  manifest substitution consumers.
+- DAG/default typed node behavior changed -> validate workflow execution consumers.
+- Generated `_input.py` shape changed -> validate SDK runtime input import and
+  any representative app pattern the PR targets.
+- App-specific node/field changed -> validate the representative app pattern only
+  when the PR changes required behavior, generated output, or claims that app's
+  compatibility.
+
+If a mandatory private check cannot run because Rover/Mothership infrastructure
+failed, do not expose the internal failure details. Add a final public note:
+
+```text
+Review note: one required compatibility check could not be completed due to a Rover execution issue. Please re-run @sdk-review or request human review before merge.
+```
+
+## Public Review Format
+
+Post a concise review with these sections:
+
+```text
+### Affected Toolkit Surfaces
+- <surface>: <why it is affected>
+
+### Compatibility Checks
+- UI rendering compatibility: validated | not applicable | needs rerun
+- Manifest substitution compatibility: validated | not applicable | needs rerun
+- Workflow execution contract: validated | not applicable | needs rerun
+- Generated SDK input contract: validated | not applicable | needs rerun
+- Representative app pattern: validated | not applicable | needs rerun
+
+### Findings
+<file-grouped findings, sanitized>
+
+### Review Note
+<only if a mandatory private check could not complete due to Rover execution>
+```
+
+Public findings can mention generated artifact names such as `manifest.json`,
+`_input.py`, or workflow/credential config, but must not mention private consumer
+repo paths or internal app file paths.
+
+Before posting, run `.mothership/pr-review/scripts/redact-toolkit-public-review.sh`
+on the summary and inline comment bodies.
+
+## Verdict Rules
+
+- Compatibility break found -> `NEEDS_FIXES`.
+- Required generated output stale -> `NEEDS_FIXES`.
+- Missing tests/docs/examples for a public toolkit behavior change -> `NEEDS_FIXES`.
+- Mandatory consumer validation blocked by Rover/Mothership execution -> no
+  approval; request rerun or human review using the sanitized note.
+- Optional field not yet adopted by a downstream app -> not a finding.
+- Mixed `application_sdk/**` and `contract-toolkit/**` PR -> require both SDK
+  review and toolkit review tracks before approval.

--- a/.claude/skills/toolkit-feature-workflow/SKILL.md
+++ b/.claude/skills/toolkit-feature-workflow/SKILL.md
@@ -97,7 +97,7 @@ Post a concise review with these sections:
 ### Affected Toolkit Surfaces
 - <surface>: <why it is affected>
 
-### Compatibility Checks
+### Cross-Repo Validation
 - UI rendering compatibility: validated | not applicable | needs rerun
 - Manifest substitution compatibility: validated | not applicable | needs rerun
 - Workflow execution contract: validated | not applicable | needs rerun
@@ -114,6 +114,9 @@ Post a concise review with these sections:
 Public findings can mention generated artifact names such as `manifest.json`,
 `_input.py`, or workflow/credential config, but must not mention private consumer
 repo paths or internal app file paths.
+The cross-repo section must confirm capability-level validation only; it must
+not list consumer repository names, package names, branch names, SHAs, local
+paths, or system-app implementation details.
 
 Before posting, run `.mothership/pr-review/scripts/redact-toolkit-public-review.sh`
 on the summary and inline comment bodies.

--- a/.mothership/pr-review/CLAUDE.md
+++ b/.mothership/pr-review/CLAUDE.md
@@ -14,6 +14,7 @@ COMMENTER_INTENT, etc.). Follow
 2. `.mothership/pr-review/severity-rubric.yaml` — pattern → severity map
 3. `.mothership/pr-review/references/retro-log.md` — **MANDATORY: do-not-flag list.** Every candidate finding MUST be checked against the patterns here; matches are withdrawn silently with no inline comment or auto-fix.
 4. `.mothership/pr-review/references/*.md` + `modes/*.md` + `agents/*.md`
+5. For `contract-toolkit/**` PRs: `contract-toolkit/AGENTS.md`, `.mothership/pr-review/agents/toolkit-review.md`, and `.mothership/pr-review/references/toolkit-consumer-registry.md`
 
 PR metadata and the authoritative diff are fetched in Phase 0 via
 `gh pr view` / `gh pr diff` and written to `/tmp/PR.json` and
@@ -29,6 +30,15 @@ PR metadata and the authoritative diff are fetched in Phase 0 via
 - **Dependency direction**: `app/` -> `execution/` -> `infrastructure/` (NEVER reverse)
 - **Credential pattern**: `CredentialRef` in contracts, `CredentialResolver` in `@task` only
 - **Blocking ops**: use `self.run_in_thread()` for blocking operations in `@task`
+
+## Contract Toolkit Review Context
+
+For PRs that touch `contract-toolkit/**`, review generated artifact contracts,
+toolkit API fit, and private downstream compatibility instead of applying
+SDK-only Temporal/Dapr assumptions. The reviewer must classify affected
+surfaces, run the relevant private consumer checks, and sanitize public output.
+Do not expose internal consumer repo names, internal file paths, or clone
+locations in PR comments.
 
 ### Determinism Rules (Temporal replay safety)
 

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -374,7 +374,7 @@ amend/import `/workspace/application-sdk/contract-toolkit/src/*.pkl`. If no
 PR-bound command or inspection is possible, mark that capability `needs rerun`
 and do not approve.
 
-Each mandatory capability must append exactly one sanitized status line to
+Each mandatory capability must append exactly one private status line to
 `/tmp/TOOLKIT_VALIDATION.md`:
 
 ```text
@@ -387,6 +387,10 @@ Each mandatory capability must append exactly one sanitized status line to
 
 Allowed statuses are `validated`, `not applicable`, and `needs rerun`. Any
 `needs rerun` status forces `NEEDS_HUMAN`.
+The public review must mirror these as a `### Cross-Repo Validation` section
+using only capability aliases and status values. Do not include private
+consumer repository names, package names, branch names, SHAs, local paths, or
+system-app implementation details in the public section.
 
 For representative app patterns, inspect PR title, body, and diff for trigger
 terms from the registry. Clone/fetch only the matching pattern repos. Optional
@@ -951,7 +955,7 @@ after `VERDICT:` MUST be one of: `READY_TO_MERGE`, `NEEDS_FIXES`,
 ### Affected Toolkit Surfaces             <!-- ONLY when review_scope=contract-toolkit or mixed-sdk-toolkit -->
 - `<surface>` — <why it is affected>
 
-### Compatibility Checks                  <!-- ONLY when review_scope=contract-toolkit or mixed-sdk-toolkit -->
+### Cross-Repo Validation                 <!-- ONLY when review_scope=contract-toolkit or mixed-sdk-toolkit -->
 - UI rendering compatibility: validated | not applicable | needs rerun
 - Manifest substitution compatibility: validated | not applicable | needs rerun
 - Workflow execution contract: validated | not applicable | needs rerun

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -66,6 +66,19 @@ COMMENTER, COMMENT_ID, COMMENTER_INTENT
    gh pr diff "$PR_NUMBER" --repo "$REPO" > /tmp/DIFF.patch
    ```
 
+4b. **Reset per-run review artifacts** — these files are load-bearing signals
+    across later phases, so never let a prior iteration in the same sandbox
+    affect the current verdict or public post:
+    ```bash
+    rm -f /tmp/TOOLKIT_ROVER_NOTE.md
+    : > /tmp/TOOLKIT_VALIDATION.md
+    : > /tmp/TOOLKIT_PR_ARTIFACTS.txt
+    : > /tmp/TOOLKIT_CHANGED_FILES.txt
+    : > /tmp/TOOLKIT_CONSUMERS.md
+    mkdir -p /tmp/inline-comments
+    find /tmp/inline-comments -type f \( -name '*.md' -o -name '*.json' \) -delete
+    ```
+
 5. **Stale SHA guard** — bail if the PR has moved since dispatch:
    ```bash
    CURRENT_SHA=$(jq -r '.headRefOid' /tmp/PR.json)
@@ -788,7 +801,7 @@ explicit confirmation rather than absence of a complaint.
 |---|---|---|
 | BLOCKED | G1/G2/G3/G5 violation | REJECT |
 | NEEDS_HUMAN | DESIGN_CHANGE scope | REQUEST_CHANGES |
-| NEEDS_HUMAN | `/tmp/TOOLKIT_ROVER_NOTE.md` exists or `/tmp/TOOLKIT_VALIDATION.md` has any mandatory toolkit compatibility check with status `needs rerun` | REQUEST_CHANGES |
+| NEEDS_HUMAN | `review_scope` is `contract-toolkit` or `mixed-sdk-toolkit`, and non-empty `/tmp/TOOLKIT_ROVER_NOTE.md` exists or `/tmp/TOOLKIT_VALIDATION.md` has any mandatory toolkit compatibility check with status `needs rerun` | REQUEST_CHANGES |
 | NEEDS_FIXES | Critical, G4/G6, **any Important**, CI failing, **OR §2f-bis title mismatch** | REQUEST_CHANGES |
 | READY_TO_MERGE | **0 Critical AND 0 Important**, CI passing, **AND §2f-bis title aligned** | APPROVE |
 
@@ -835,6 +848,11 @@ in the findings array — put those in the summary or inline comment body instea
 For BLOCKING/CRITICAL/HIGH findings, create inline comments:
 - `file` and `line` must be in DIFF.patch (added lines only)
 - Max 15 inline comments
+- Write each inline body to `/tmp/inline-comments/<n>.md` and the matching
+  path/line metadata to `/tmp/inline-comments/<n>.json` before Phase 3f. The
+  staged markdown file is the only source allowed for the posted `body`.
+  Do not post from an in-memory body string for toolkit reviews; that bypasses
+  the redaction gate.
 - Format:
   ```
   **[SEVERITY]** [TAG] — description
@@ -1065,6 +1083,10 @@ gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/review-summary.md
 # specific path + line in the diff. The formal verdict review
 # (--approve | --comment) is already submitted in §3c — do NOT submit
 # a second `gh pr review` here.
+#
+# For toolkit reviews, every inline body must already exist under
+# /tmp/inline-comments/*.md and must have passed the redaction gate above.
+# Post inline comments by reading the body from that staged file only.
 
 # Commit status — set the sdk-review check explicitly.
 gh api "repos/$REPO/statuses/$HEAD_SHA" \

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -229,12 +229,21 @@ COMMENTER, COMMENT_ID, COMMENTER_INTENT
 
 12. **Smart agent routing** — classify the PR:
     ```bash
-    TOTAL_FILES=$(grep -c '^+++ b/' /tmp/DIFF.patch || echo 0)
-    TEST_FILES=$(grep -c '^+++ b/tests/' /tmp/DIFF.patch || echo 0)
-    DOC_FILES=$(grep -c '^+++ b/docs/' /tmp/DIFF.patch || echo 0)
-    CONFIG_FILES=$(grep -cE '^\+\+\+ b/(pyproject\.toml|uv\.lock|\.pre-commit|\.github/|helm/)' /tmp/DIFF.patch || echo 0)
+    gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path' > /tmp/PR_FILES.txt
+    TOTAL_FILES=$(wc -l < /tmp/PR_FILES.txt)
+    CT_FILES=$(grep -cE '^contract-toolkit/' /tmp/PR_FILES.txt || true)
+    SDK_FILES=$(grep -cE '^application_sdk/' /tmp/PR_FILES.txt || true)
+    TEST_FILES=$(grep -cE '^(tests/|contract-toolkit/tests/)' /tmp/PR_FILES.txt || true)
+    DOC_FILES=$(grep -cE '^(docs/|contract-toolkit/docs/|.*README\.md$)' /tmp/PR_FILES.txt || true)
+    CONFIG_FILES=$(grep -cE '^(pyproject\.toml|uv\.lock|\.pre-commit|\.github/|helm/)' /tmp/PR_FILES.txt || true)
     SOURCE_FILES=$((TOTAL_FILES - TEST_FILES - DOC_FILES - CONFIG_FILES))
     ```
+   This file-list based classification includes deleted files; do not classify
+   only from `+++ b/` diff headers.
+   - If `CT_FILES > 0 && SDK_FILES == 0 && CONFIG_FILES == 0` → `review_scope=contract-toolkit`
+     (toolkit-review.md only; mandatory private consumer validation based on affected surface)
+   - If `CT_FILES > 0 && (SDK_FILES > 0 || CONFIG_FILES > 0)` → `review_scope=mixed-sdk-toolkit`
+     (standard SDK review agents + toolkit-review.md)
    - If `SOURCE_FILES == 0 && TEST_FILES > 0` → `review_scope=tests-only`
      (QUALITY agent only — focused on test patterns, coverage, assertions)
    - If `SOURCE_FILES == 0 && DOC_FILES > 0 && TEST_FILES == 0` → `review_scope=docs-only`
@@ -268,13 +277,172 @@ rg "warnings\.warn\|DeprecationWarning" <file>          # deprecated?
 
 Build annotations: lines, callers, DUMPING_GROUND/V3_REPLACEMENT/DEPRECATED flags.
 
-### 1b. Dispatch Reachability Agent (if review_scope=full)
+### 1b. Dispatch Reachability Agent (if review_scope=full or mixed-sdk-toolkit)
 
 Use Agent tool to dispatch `agents/reachability.md` — classifies each
 changed symbol as temporal-workflow, temporal-activity, public-http,
 internal, test, or dead.
 
-Skip if review_scope is tests-only, docs-only, or config-only.
+Skip if review_scope is contract-toolkit, tests-only, docs-only, or config-only.
+
+### 1b-toolkit. Private Toolkit Consumer Setup (if review_scope=contract-toolkit or mixed-sdk-toolkit)
+
+Read:
+
+- `contract-toolkit/AGENTS.md`
+- `.mothership/pr-review/agents/toolkit-review.md`
+- `.mothership/pr-review/references/toolkit-consumer-registry.md`
+
+Classify the affected toolkit surfaces from `/tmp/DIFF.patch`. Then clone or
+reuse every mandatory consumer target from the registry. This validation setup
+is mandatory for affected surfaces; do not approve if a required check cannot
+run.
+
+Create a private validation ledger. This is the source of truth for toolkit
+compatibility status and verdict gating:
+
+```bash
+: > /tmp/TOOLKIT_VALIDATION.md
+printf '## Toolkit Validation Ledger\n\n' >> /tmp/TOOLKIT_VALIDATION.md
+```
+
+First run local PR-bound toolkit checks when toolkit source, examples, or
+generated output changed:
+
+```bash
+contract-toolkit/scripts/regenerate-all.sh
+contract-toolkit/scripts/check-invariants.sh
+(cd contract-toolkit && pkl test tests/*.pkl)
+uv run --extra workflows python contract-toolkit/scripts/test-sdk-import.py
+git diff --check
+```
+
+If any command fails due to PR code or stale generated output, add a finding.
+If the command cannot run due to Rover environment/tooling failure, create
+`/tmp/TOOLKIT_ROVER_NOTE.md` with the sanitized note below.
+
+Record successful local checks privately:
+
+```bash
+printf -- '- Generated SDK input contract: validated (local generated imports and Pkl tests passed)\n' >> /tmp/TOOLKIT_VALIDATION.md
+```
+
+Capture PR-generated artifacts as the input to downstream checks. Do not use a
+consumer repository's released toolkit dependency as proof for this PR:
+
+```bash
+find contract-toolkit/examples -path '*/generated/*' -type f | sort > /tmp/TOOLKIT_PR_ARTIFACTS.txt
+git diff --name-only -- contract-toolkit/examples contract-toolkit/src > /tmp/TOOLKIT_CHANGED_FILES.txt
+```
+
+Use `/tmp/toolkit-review-consumers` for scratch clones:
+
+```bash
+mkdir -p /tmp/toolkit-review-consumers
+
+# Core consumers. Use existing /workspace checkout if present; otherwise clone.
+# Record branch and SHA privately in /tmp/TOOLKIT_CONSUMERS.md.
+for spec in \
+  "atlan-frontend beta" \
+  "blaze main" \
+  "heracles beta" \
+  "atlan-automation-engine-app main"
+do
+  repo="${spec% *}"
+  branch="${spec#* }"
+  if [ -d "/workspace/${repo}/.git" ]; then
+    target="/workspace/${repo}"
+  else
+    target="/tmp/toolkit-review-consumers/${repo}"
+    if [ ! -d "${target}/.git" ] && ! git clone "https://github.com/atlanhq/${repo}.git" "${target}"; then
+      printf '%s\n' "Review note: one required compatibility check could not be completed due to a Rover execution issue. Please re-run @sdk-review or request human review before merge." > /tmp/TOOLKIT_ROVER_NOTE.md
+      continue
+    fi
+  fi
+  if ! git -C "${target}" fetch origin "${branch}"; then
+    printf '%s\n' "Review note: one required compatibility check could not be completed due to a Rover execution issue. Please re-run @sdk-review or request human review before merge." > /tmp/TOOLKIT_ROVER_NOTE.md
+    continue
+  fi
+  printf '%s %s %s\n' "${repo}" "origin/${branch}" "$(git -C "${target}" rev-parse "origin/${branch}")" >> /tmp/TOOLKIT_CONSUMERS.md
+done
+```
+
+Cloning/fetching only establishes the validation target. It is not validation.
+For each affected capability, run the corresponding minimum actionable check in
+the registry using PR-generated artifacts or a scratch contract rewritten to
+amend/import `/workspace/application-sdk/contract-toolkit/src/*.pkl`. If no
+PR-bound command or inspection is possible, mark that capability `needs rerun`
+and do not approve.
+
+Each mandatory capability must append exactly one sanitized status line to
+`/tmp/TOOLKIT_VALIDATION.md`:
+
+```text
+- UI rendering compatibility: validated (<private evidence recorded>)
+- Manifest substitution compatibility: validated (<private evidence recorded>)
+- Workflow execution contract: validated (<private evidence recorded>)
+- Generated SDK input contract: validated (<private evidence recorded>)
+- Representative app pattern: not applicable (<why>)
+```
+
+Allowed statuses are `validated`, `not applicable`, and `needs rerun`. Any
+`needs rerun` status forces `NEEDS_HUMAN`.
+
+For representative app patterns, inspect PR title, body, and diff for trigger
+terms from the registry. Clone/fetch only the matching pattern repos. Optional
+field additions do not require adoption in the representative app unless the PR
+claims compatibility or changes required generated/runtime behavior.
+
+Use these pattern specs after a trigger match:
+
+```bash
+# Pattern specs: "<pattern> <repo> <branch>"
+# query-intelligence atlan-query-intelligence-app main
+# publish atlan-publish-app main
+# popularity atlan-popularity-app main
+# lineage atlan-lineage-app main
+```
+
+For each matched pattern, reuse `/workspace/<repo>` if present, otherwise clone
+to `/tmp/toolkit-review-consumers/<repo>`, fetch the listed branch, and append
+the private SHA to `/tmp/TOOLKIT_CONSUMERS.md`.
+
+When validating a representative app contract, work only in a scratch copy. If
+the contract imports `@app-contract-toolkit/...`, rewrite that scratch copy to
+import the PR checkout source under
+`/workspace/application-sdk/contract-toolkit/src/` before running `pkl eval`.
+
+Scratch rewrite pattern:
+
+```bash
+scratch="/tmp/toolkit-review-consumers/scratch/<pattern>"
+mkdir -p "$scratch"
+cp -R "<consumer-contract-dir>"/. "$scratch"/
+rg -l '@app-contract-toolkit/' "$scratch" \
+  | xargs perl -0pi -e 's#@app-contract-toolkit/#/workspace/application-sdk/contract-toolkit/src/#g'
+pkl eval -m "$scratch/generated" "$scratch/app.pkl"
+```
+
+If the representative app does not have a contract yet, do not fail adoption.
+Validate the generic PR-generated artifact shape and record the representative
+pattern as `not applicable` with the reason.
+
+All consumer repo names, local paths, and SHAs are private evidence. Public PR
+comments may only use capability aliases:
+
+- `UI rendering compatibility`
+- `Manifest substitution compatibility`
+- `Workflow execution contract`
+- `Generated SDK input contract`
+- `Representative app pattern`
+
+If clone/fetch/auth/network fails for a mandatory target, create
+`/tmp/TOOLKIT_ROVER_NOTE.md` with exactly this public note and continue to
+Phase 2 so the review can request a rerun or human review:
+
+```text
+Review note: one required compatibility check could not be completed due to a Rover execution issue. Please re-run @sdk-review or request human review before merge.
+```
 
 ### 1c. Prepare Context by Tier
 
@@ -432,6 +600,8 @@ Based on `review_scope`, dispatch agents via the Agent tool:
 | review_scope | Agents dispatched |
 |---|---|
 | `full` | correctness.md + quality.md + structure.md (all 3) |
+| `contract-toolkit` | toolkit-review.md only |
+| `mixed-sdk-toolkit` | correctness.md + quality.md + structure.md + toolkit-review.md |
 | `tests-only` | quality.md only |
 | `tests-focused` | quality.md + correctness.md (lightweight) |
 | `config-only` | correctness.md only |
@@ -439,6 +609,17 @@ Based on `review_scope`, dispatch agents via the Agent tool:
 
 Each agent receives: PR diff (or partition), full file contents,
 holistic annotations, their reference rules, reachability output.
+For `mixed-sdk-toolkit`, partition context by path: SDK agents receive only
+`application_sdk/**`, SDK tests, and config files relevant to SDK behavior;
+`toolkit-review.md` receives `contract-toolkit/**` and toolkit-related config.
+Do not send `contract-toolkit/**` content to SDK agents for Temporal/Dapr
+review.
+For `toolkit-review.md`, also pass `contract-toolkit/AGENTS.md`,
+`.mothership/pr-review/references/toolkit-consumer-registry.md`,
+`/tmp/TOOLKIT_CONSUMERS.md` when present, `/tmp/TOOLKIT_VALIDATION.md`,
+`/tmp/TOOLKIT_PR_ARTIFACTS.txt`, and `/tmp/TOOLKIT_ROVER_NOTE.md` when
+present. The toolkit agent must not include private consumer repo names, paths,
+or SHAs in public findings.
 
 **Degradation priority** (if running over time budget):
 1. Drop STRUCTURE agent first (holistic opinions, least urgent)
@@ -453,6 +634,7 @@ After Wave 1, call GPT to challenge your findings.
 
 **Skip conditions** (no adversarial):
 - `review_scope` is tests-only, config-only, or docs-only
+- `review_scope` is contract-toolkit and toolkit-review.md produced zero findings
 - `review_tier` is "staged" (massive PR — too much context for one GPT call)
 - Wave 1 produced zero findings (nothing to challenge)
 - Time budget already over 70% consumed
@@ -602,6 +784,7 @@ explicit confirmation rather than absence of a complaint.
 |---|---|---|
 | BLOCKED | G1/G2/G3/G5 violation | REJECT |
 | NEEDS_HUMAN | DESIGN_CHANGE scope | REQUEST_CHANGES |
+| NEEDS_HUMAN | `/tmp/TOOLKIT_ROVER_NOTE.md` exists or `/tmp/TOOLKIT_VALIDATION.md` has any mandatory toolkit compatibility check with status `needs rerun` | REQUEST_CHANGES |
 | NEEDS_FIXES | Critical, G4/G6, **any Important**, CI failing, **OR §2f-bis title mismatch** | REQUEST_CHANGES |
 | READY_TO_MERGE | **0 Critical AND 0 Important**, CI passing, **AND §2f-bis title aligned** | APPROVE |
 
@@ -750,6 +933,9 @@ after `VERDICT:` MUST be one of: `READY_TO_MERGE`, `NEEDS_FIXES`,
 <!-- SDK_REVIEW -->
 <!-- VERDICT: READY_TO_MERGE | NEEDS_FIXES | BLOCKED | NEEDS_HUMAN | NEEDS_REBASE -->
 ## SDK <Review | Re-review> (mothership): PR #<number> — <title>
+<!-- For review_scope=contract-toolkit, write this heading as:
+     "Contract Toolkit <Review | Re-review> (mothership)".
+     Keep the SDK_REVIEW marker above unchanged. -->
 
 ### Verdict: <READY TO MERGE | NEEDS FIXES | BLOCKED | NEEDS HUMAN REVIEW>
 
@@ -761,6 +947,16 @@ after `VERDICT:` MUST be one of: `READY_TO_MERGE`, `NEEDS_FIXES`,
 ### PR Title Check                         <!-- ALWAYS present, from §2f-bis -->
 - ✅ **Aligned** — title \`<title>\` matches the file scope (<which bucket and why>). <!-- when passed -->
 - 🟥 **Needs change** — title \`<title>\` doesn't match the file scope. Files touched: <SDK|CT|OTHER buckets>. Required: <expected title shape>. Suggested rewrite: \`<example>\`. <!-- when failed; forces verdict = NEEDS_FIXES per §2f-bis -->
+
+### Affected Toolkit Surfaces             <!-- ONLY when review_scope=contract-toolkit or mixed-sdk-toolkit -->
+- `<surface>` — <why it is affected>
+
+### Compatibility Checks                  <!-- ONLY when review_scope=contract-toolkit or mixed-sdk-toolkit -->
+- UI rendering compatibility: validated | not applicable | needs rerun
+- Manifest substitution compatibility: validated | not applicable | needs rerun
+- Workflow execution contract: validated | not applicable | needs rerun
+- Generated SDK input contract: validated | not applicable | needs rerun
+- Representative app pattern: validated | not applicable | needs rerun
 
 ### Delta from previous review            <!-- ONLY when PRIOR_REVIEW non-empty -->
 - **Resolved (<N>)**: <one line per finding the author fixed>
@@ -798,6 +994,9 @@ after `VERDICT:` MUST be one of: `READY_TO_MERGE`, `NEEDS_FIXES`,
 ### Strengths
 - <what the PR does well>
 
+### Review Note                           <!-- ONLY when /tmp/TOOLKIT_ROVER_NOTE.md exists -->
+<contents of /tmp/TOOLKIT_ROVER_NOTE.md>
+
 ---
 **CI:** all passing | N failing
 **Models:** Claude Opus 4.6 (review) + GPT-5.3-codex (adversarial)
@@ -814,6 +1013,9 @@ after `VERDICT:` MUST be one of: `READY_TO_MERGE`, `NEEDS_FIXES`,
   pass loaded the previous review as context and reasoned about
   deltas (per Phase 0 §6b + §2d), not that it ignored history and
   reran the full review from scratch.
+- If `review_scope=contract-toolkit`, replace `SDK` in the visible
+  heading with `Contract Toolkit`. Keep `<!-- SDK_REVIEW -->` unchanged
+  because the approval workflow parses that stable marker.
 
 **Delta section — only on re-reviews:**
 - Omit the entire `### Delta from previous review` block on a first
@@ -839,6 +1041,17 @@ There is no mothership-side `submit-review` endpoint. Use the
 comment and each finding as an inline review comment.
 
 ```bash
+# Redaction gate for toolkit reviews. Public review bodies must not include
+# private consumer repo names, scratch paths, or fetched SHAs. If this fires,
+# rewrite the public body using capability aliases before posting.
+if [ "$review_scope" = "contract-toolkit" ] || [ "$review_scope" = "mixed-sdk-toolkit" ]; then
+  .mothership/pr-review/scripts/redact-toolkit-public-review.sh /tmp/review-summary.md
+  for body in /tmp/inline-comments/*.md; do
+    [ -f "$body" ] || continue
+    .mothership/pr-review/scripts/redact-toolkit-public-review.sh "$body"
+  done
+fi
+
 # Summary comment (the body built in 3a, including the
 # <!-- SDK_REVIEW --> marker and the <!-- REVIEW_DATA --> JSON):
 gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/review-summary.md

--- a/.mothership/pr-review/agents/toolkit-review.md
+++ b/.mothership/pr-review/agents/toolkit-review.md
@@ -25,6 +25,8 @@ them for private validation only. Public findings must use sanitized capability
 aliases such as `UI rendering compatibility`, `Manifest substitution
 compatibility`, `Workflow execution contract`, `Generated SDK input contract`,
 and `Representative app pattern`.
+The public summary should expose these as `### Cross-Repo Validation`, not as
+consumer repository details.
 
 ## What To Check
 
@@ -84,7 +86,7 @@ Return valid JSON only:
       "reason": "Node args changed"
     }
   ],
-  "compatibility_checks": [
+  "cross_repo_validation": [
     {
       "alias": "Manifest substitution compatibility",
       "status": "validated",
@@ -119,3 +121,8 @@ Return valid JSON only:
 
 Severity must be one of `BLOCKING`, `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, or
 `INFO`. Only report findings with confidence >= 0.80.
+
+The `cross_repo_validation` array is private reasoning input for the summary.
+When writing the public summary, include only `alias` and `status`; do not
+include `evidence` if it names private consumers, branches, SHAs, package names,
+local paths, or system-app implementation details.

--- a/.mothership/pr-review/agents/toolkit-review.md
+++ b/.mothership/pr-review/agents/toolkit-review.md
@@ -1,0 +1,121 @@
+# Sub-agent — CONTRACT TOOLKIT Review
+
+## Role
+
+You are a senior reviewer for contract-toolkit PRs inside application-sdk.
+Review only toolkit correctness, generated artifact compatibility, downstream
+consumer compatibility, tests/docs/examples, and API design fit.
+
+Do not apply SDK Temporal/Dapr workflow determinism rules unless the PR also
+changes `application_sdk/**` and that context was explicitly included.
+
+## Private Context
+
+Read:
+
+- `contract-toolkit/AGENTS.md`
+- `.mothership/pr-review/references/toolkit-consumer-registry.md`
+- `/tmp/TOOLKIT_VALIDATION.md`
+- `/tmp/TOOLKIT_PR_ARTIFACTS.txt`
+- changed toolkit files and generated output
+- PR body and previous review summary, if any
+
+The consumer registry contains internal repo names and validation paths. Use
+them for private validation only. Public findings must use sanitized capability
+aliases such as `UI rendering compatibility`, `Manifest substitution
+compatibility`, `Workflow execution contract`, `Generated SDK input contract`,
+and `Representative app pattern`.
+
+## What To Check
+
+1. Affected generated surfaces:
+   - workflow/setup config JSON
+   - credential config JSON
+   - `manifest.json`
+   - generated `_input.py`
+   - bundle/root `atlan.yaml`
+   - docs/examples/release metadata
+2. Cross-surface value flow:
+   - config field -> manifest arg -> runtime input
+   - credential field -> credential config -> UI conditional behavior
+   - typed node property -> manifest node args -> execution consumer
+   - bundle metadata -> generated root/per-entrypoint artifacts
+3. Compatibility:
+   - old output remains unchanged by default unless this is a deliberate bug fix
+   - new behavior is opt-in where possible
+   - required generated values have a producer and consumer
+   - no unresolved placeholder or missing `_input.py` field is introduced
+4. Adoption distinction:
+   - optional new fields do not require every app to already use them
+   - PR claims or required runtime changes do require representative pattern validation
+5. Validation:
+   - generated output is committed and not stale
+   - Pkl tests cover new invariant or bug reproduction
+   - docs explain public properties and generated output impact
+   - private consumer checks ran for every mandatory affected capability
+   - each consumer check used PR-generated artifacts or a consumer contract
+     rewritten to import `/workspace/application-sdk/contract-toolkit/src/*.pkl`
+     rather than validating only the consumer's released toolkit dependency
+   - `/tmp/TOOLKIT_VALIDATION.md` has one status line for every mandatory
+     capability: `validated`, `not applicable`, or `needs rerun`
+
+## Failure Handling
+
+If private validation could not run due to Rover/Mothership execution issues,
+do not report internal details. Return a finding with:
+
+- title: `Required compatibility check needs rerun`
+- severity: `HIGH`
+- category: `bug`
+- file: the most relevant toolkit file or `contract-toolkit/AGENTS.md`
+- evidence: `A required compatibility check could not be completed by Rover.`
+- suggested_fix: `Re-run @sdk-review or request human review before merge.`
+- public_note: `Review note: one required compatibility check could not be completed due to a Rover execution issue. Please re-run @sdk-review or request human review before merge.`
+
+## Output Format
+
+Return valid JSON only:
+
+```json
+{
+  "affected_surfaces": [
+    {
+      "surface": "manifest",
+      "reason": "Node args changed"
+    }
+  ],
+  "compatibility_checks": [
+    {
+      "alias": "Manifest substitution compatibility",
+      "status": "validated",
+      "evidence": "PR-generated manifest was checked against substitution behavior"
+    }
+  ],
+  "findings": [
+    {
+      "title": "Manifest argument has no generated setup field",
+      "pattern_id": "toolkit-manifest-missing-config-field",
+      "severity": "HIGH",
+      "category": "bug",
+      "confidence": 0.91,
+      "file": "contract-toolkit/src/NativeApp.pkl",
+      "line": 120,
+      "evidence": "manifest.json renders {{params.newField}} but no workflow config field is generated",
+      "attack_path": null,
+      "reachable_from": "Manifest substitution compatibility",
+      "by_design_check": "No matching config field or documented external producer found",
+      "suggested_fix": "Generate the setup field, make the arg static, or document the external producer and validate it.",
+      "scope": "PATCH",
+      "domain_tag": "TOOLKIT",
+      "guardrail": null,
+      "public_note": null
+    }
+  ],
+  "strengths": [
+    "Generated output is committed and the default example remains backward-compatible"
+  ]
+}
+```
+
+Severity must be one of `BLOCKING`, `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, or
+`INFO`. Only report findings with confidence >= 0.80.

--- a/.mothership/pr-review/references/toolkit-consumer-registry.md
+++ b/.mothership/pr-review/references/toolkit-consumer-registry.md
@@ -1,0 +1,92 @@
+# Contract Toolkit Consumer Registry
+
+This file is private reviewer context. Use it to decide which downstream
+compatibility checks are mandatory for a contract-toolkit PR. Do not quote
+repository names, internal paths, clone locations, or file paths from this file
+in public PR comments. Public review text must use capability aliases only.
+
+## Public Aliases
+
+Use these aliases in review comments:
+
+- `UI rendering compatibility`
+- `Manifest substitution compatibility`
+- `Workflow execution contract`
+- `Generated SDK input contract`
+- `Representative app pattern`
+
+## Core Consumers
+
+Clone missing repos under `/tmp/toolkit-review-consumers/<repo>`. If a sibling
+checkout already exists under `/workspace`, use it. Always fetch the configured
+remote branch and record the SHA privately before validating.
+
+Every consumer check must be PR-bound. It is not enough to clone/fetch the
+consumer repository. The check must evaluate generated artifacts from the PR
+checkout or a scratch copy of a consumer contract rewritten to amend/import
+`/workspace/application-sdk/contract-toolkit/src/*.pkl`.
+
+| Capability alias | Repository | Branch | Purpose |
+|---|---|---|---|
+| UI rendering compatibility | `atlanhq/atlan-frontend` | `origin/beta` | Workflow and credential config rendering, widget support, conditional/default behavior. |
+| UI rendering compatibility | `atlanhq/blaze` | `origin/main` | Playground/schema rendering and manifest payload substitution previews. |
+| Manifest substitution compatibility | `atlanhq/heracles` | `origin/beta` | Manifest `{{param}}` substitution, unresolved placeholder behavior, credential/config propagation. |
+| Workflow execution contract | `atlanhq/atlan-automation-engine-app` | `origin/main` | DAG node ids, dependencies, labels, task queues, workflow types, args, and error semantics. |
+
+## Representative App Patterns
+
+Use app-pattern checks only when a PR changes a required generated value,
+changes runtime assumptions, or claims compatibility for that app pattern. An
+optional field that no app has adopted yet is not a failure by itself.
+
+| Pattern | Trigger terms | Repository | Branch | Public alias |
+|---|---|---|---|---|
+| query intelligence | `QueryIntelligenceNode`, `query intelligence`, `QI`, `query_intelligence` | `atlanhq/atlan-query-intelligence-app` | `origin/main` | Representative app pattern |
+| publish | `PublishNode`, `publish`, `publish controls`, `current state` | `atlanhq/atlan-publish-app` | `origin/main` | Representative app pattern |
+| popularity | `PopularityNode`, `popularity` | `atlanhq/atlan-popularity-app` | `origin/main` | Representative app pattern |
+| lineage | `LineageNode`, `LineagePublishNode`, `lineage` | `atlanhq/atlan-lineage-app` | `origin/main` | Representative app pattern |
+
+If a trigger term matches multiple patterns, validate each relevant pattern
+unless the diff or PR body clearly narrows the claim.
+
+## Surface Mapping
+
+| Changed surface | Mandatory validations |
+|---|---|
+| `contract-toolkit/src/Config.pkl` or `contract-toolkit/src/Widgets.pkl` | UI rendering compatibility |
+| Credential fields in `NativeApp.pkl`, `Credential.pkl`, or examples | UI rendering compatibility |
+| `manifest.json` rendering, node args, placeholders, static values, output refs | Manifest substitution compatibility |
+| Typed nodes, DAG defaults, dependencies, labels, task queues, workflow/activity names | Workflow execution contract |
+| Generated `_input.py`, field names, defaults, aliases, or SDK import behavior | Generated SDK input contract |
+| `NativeAppBundle.pkl`, generated root `atlan.yaml`, bundle shared credentials | Manifest substitution compatibility, workflow execution contract |
+| PR claims a system-app/default-node compatibility story | Representative app pattern |
+
+## Minimum Actionable Checks
+
+Do not mark a capability as `validated` unless at least one PR-bound command or
+inspection below completed and produced evidence.
+
+Write the result of every mandatory capability to `/tmp/TOOLKIT_VALIDATION.md`
+using the public alias and one of: `validated`, `not applicable`, `needs rerun`.
+The public PR summary may include these status names, but not the private
+repository, path, or SHA evidence.
+
+| Capability alias | PR-bound input | Minimum check | Failure means |
+|---|---|---|---|
+| UI rendering compatibility | Changed/generated workflow or credential JSON from this PR | Run the consumer's relevant schema/parser/unit test when available, or inspect the exact generated keys against widget/conditional/default handling in the fetched consumer SHA. | Generated config uses a widget, rule, default, or nesting shape the UI consumer does not handle. |
+| Manifest substitution compatibility | Changed/generated `manifest.json` from this PR | Inspect `{{params}}`, static args, and output refs against substitution behavior in the fetched consumer SHA; run targeted tests when present. | Placeholder cannot be produced, is stripped incorrectly, or changes required propagation semantics. |
+| Workflow execution contract | Changed/generated `manifest.json` from this PR | Inspect node ids, deps, workflow/activity labels, task queues, workflow types, and args against execution models in the fetched consumer SHA; run targeted tests when present. | Generated DAG cannot be accepted or executed with the current execution contract. |
+| Generated SDK input contract | Changed/generated `_input.py` from this PR | Run `uv run --extra workflows python contract-toolkit/scripts/test-sdk-import.py` and inspect field names/types/defaults for runtime collisions. | Generated Python cannot import or runtime input fields no longer match generated config/manifest expectations. |
+| Representative app pattern | Scratch copy of the representative app contract rewritten to use `/workspace/application-sdk/contract-toolkit/src/*.pkl`, or generated PR artifact that represents the pattern | Regenerate or inspect the app-pattern contract against the PR toolkit source. If no contract exists yet, validate only the generic generated shape and record adoption as not applicable. | PR claims or requires app-pattern compatibility that current representative contract/runtime cannot satisfy. |
+
+## Validation Failure Handling
+
+- Compatibility break found: public finding with sanitized capability alias,
+  verdict `NEEDS_FIXES`.
+- Mandatory validation cannot run because Rover/Mothership clone/auth/network
+  failed: do not disclose internal details. Add the public note:
+  `Review note: one required compatibility check could not be completed due to a Rover execution issue. Please re-run @sdk-review or request human review before merge.`
+- Mandatory validation cannot run because examples/generated artifacts are
+  missing from the PR: public finding, verdict `NEEDS_FIXES`.
+- Optional field not adopted by an app yet: not a finding unless the PR claims
+  adoption or changes required runtime behavior.

--- a/.mothership/pr-review/references/toolkit-consumer-registry.md
+++ b/.mothership/pr-review/references/toolkit-consumer-registry.md
@@ -7,7 +7,7 @@ in public PR comments. Public review text must use capability aliases only.
 
 ## Public Aliases
 
-Use these aliases in review comments:
+Use these aliases in review comments under `### Cross-Repo Validation`:
 
 - `UI rendering compatibility`
 - `Manifest substitution compatibility`
@@ -70,6 +70,21 @@ Write the result of every mandatory capability to `/tmp/TOOLKIT_VALIDATION.md`
 using the public alias and one of: `validated`, `not applicable`, `needs rerun`.
 The public PR summary may include these status names, but not the private
 repository, path, or SHA evidence.
+
+Public cross-repo validation wording should be confirmation-oriented:
+
+```text
+### Cross-Repo Validation
+- UI rendering compatibility: validated
+- Manifest substitution compatibility: validated
+- Workflow execution contract: not applicable
+- Generated SDK input contract: validated
+- Representative app pattern: not applicable
+```
+
+Do not include consumer repository names, package names, branch names, SHAs,
+local checkout paths, private app filenames, or system-app implementation
+details. Put that evidence only in `/tmp/TOOLKIT_VALIDATION.md` or sandbox logs.
 
 | Capability alias | PR-bound input | Minimum check | Failure means |
 |---|---|---|---|

--- a/.mothership/pr-review/scripts/redact-toolkit-public-review.sh
+++ b/.mothership/pr-review/scripts/redact-toolkit-public-review.sh
@@ -6,17 +6,17 @@ if [ "$#" -lt 1 ]; then
   exit 2
 fi
 
-PRIVATE_RE='(atlan-frontend|blaze|heracles|atlan-automation-engine-app|atlan-query-intelligence-app|atlan-publish-app|atlan-popularity-app|atlan-lineage-app|@atlanhq/[^ )`]+|/workspace/[^ )`]+|/tmp/toolkit-review-consumers[^ )`]*|[0-9a-f]{40})'
+PRIVATE_RE='(atlan-frontend|blaze|heracles|atlan-automation-engine-app|atlan-query-intelligence-app|atlan-publish-app|atlan-popularity-app|atlan-lineage-app|@atlanhq/[^[:space:])`,;!?]+|/workspace/[^[:space:])`,;!?]+|/tmp/toolkit-review-consumers[^[:space:])`,;!?]*|[0-9a-f]{40})'
 
 for file in "$@"; do
   [ -f "$file" ] || continue
 
   perl -0pi -e '
-    s#/workspace/[^ \n`)]+#[private path]#g;
-    s#/tmp/toolkit-review-consumers[^ \n`)]*#[private path]#g;
-    s#\@atlanhq/[^ \n`)]+#[private package]#g;
-    s/\b(atlan-frontend|blaze|heracles|atlan-automation-engine-app|atlan-query-intelligence-app|atlan-publish-app|atlan-popularity-app|atlan-lineage-app)\b/[private consumer]/g;
-    s/\b[0-9a-f]{40}\b/[private sha]/g;
+    s#/workspace/[^[:space:]`),;!?]+#[private path]#g;
+    s#/tmp/toolkit-review-consumers[^[:space:]`),;!?]*#[private path]#g;
+    s#\@atlanhq/[^[:space:]`),;!?]+#[private package]#g;
+    s/(atlan-frontend|blaze|heracles|atlan-automation-engine-app|atlan-query-intelligence-app|atlan-publish-app|atlan-popularity-app|atlan-lineage-app)/[private consumer]/g;
+    s/[0-9a-f]{40}/[private sha]/g;
   ' "$file"
 
   if grep -Eq "$PRIVATE_RE" "$file"; then

--- a/.mothership/pr-review/scripts/redact-toolkit-public-review.sh
+++ b/.mothership/pr-review/scripts/redact-toolkit-public-review.sh
@@ -6,7 +6,7 @@ if [ "$#" -lt 1 ]; then
   exit 2
 fi
 
-PRIVATE_RE='(atlan-frontend|blaze|heracles|atlan-automation-engine-app|atlan-query-intelligence-app|atlan-publish-app|atlan-popularity-app|atlan-lineage-app|/workspace/[^ )`]+|/tmp/toolkit-review-consumers[^ )`]*|[0-9a-f]{40})'
+PRIVATE_RE='(atlan-frontend|blaze|heracles|atlan-automation-engine-app|atlan-query-intelligence-app|atlan-publish-app|atlan-popularity-app|atlan-lineage-app|@atlanhq/[^ )`]+|/workspace/[^ )`]+|/tmp/toolkit-review-consumers[^ )`]*|[0-9a-f]{40})'
 
 for file in "$@"; do
   [ -f "$file" ] || continue
@@ -14,6 +14,7 @@ for file in "$@"; do
   perl -0pi -e '
     s#/workspace/[^ \n`)]+#[private path]#g;
     s#/tmp/toolkit-review-consumers[^ \n`)]*#[private path]#g;
+    s#\@atlanhq/[^ \n`)]+#[private package]#g;
     s/\b(atlan-frontend|blaze|heracles|atlan-automation-engine-app|atlan-query-intelligence-app|atlan-publish-app|atlan-popularity-app|atlan-lineage-app)\b/[private consumer]/g;
     s/\b[0-9a-f]{40}\b/[private sha]/g;
   ' "$file"

--- a/.mothership/pr-review/scripts/redact-toolkit-public-review.sh
+++ b/.mothership/pr-review/scripts/redact-toolkit-public-review.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <markdown-file> [<markdown-file> ...]" >&2
+  exit 2
+fi
+
+PRIVATE_RE='(atlan-frontend|blaze|heracles|atlan-automation-engine-app|atlan-query-intelligence-app|atlan-publish-app|atlan-popularity-app|atlan-lineage-app|/workspace/[^ )`]+|/tmp/toolkit-review-consumers[^ )`]*|[0-9a-f]{40})'
+
+for file in "$@"; do
+  [ -f "$file" ] || continue
+
+  perl -0pi -e '
+    s#/workspace/[^ \n`)]+#[private path]#g;
+    s#/tmp/toolkit-review-consumers[^ \n`)]*#[private path]#g;
+    s/\b(atlan-frontend|blaze|heracles|atlan-automation-engine-app|atlan-query-intelligence-app|atlan-publish-app|atlan-popularity-app|atlan-lineage-app)\b/[private consumer]/g;
+    s/\b[0-9a-f]{40}\b/[private sha]/g;
+  ' "$file"
+
+  if grep -Eq "$PRIVATE_RE" "$file"; then
+    echo "toolkit public review redaction failed for $file" >&2
+    exit 1
+  fi
+done

--- a/.mothership/pr-review/scripts/test-redact-toolkit-public-review.sh
+++ b/.mothership/pr-review/scripts/test-redact-toolkit-public-review.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REDACTOR="$SCRIPT_DIR/redact-toolkit-public-review.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+review="$TMP_DIR/review.md"
+
+{
+  printf '%s\n' 'atlan-frontends are pluralized references.'
+  printf '%s\n' 'blazes should not block posting.'
+  printf '%s\n' 'See /workspace/repo/foo.py, then continue.'
+  printf '%s\n' 'Package @atlanhq/internal-app, then continue.'
+  printf '%s\n' 'SHA cafe1234cafe1234cafe1234cafe1234cafe1234c'
+  printf '%s\n' 'Public summary is otherwise fine.'
+} > "$review"
+
+"$REDACTOR" "$review"
+
+if grep -Eq '(atlan-frontend|blaze|heracles|atlan-automation-engine-app|atlan-query-intelligence-app|atlan-publish-app|atlan-popularity-app|atlan-lineage-app|@atlanhq/[^[:space:])`,;!?]+|/workspace/[^[:space:])`,;!?]+|/tmp/toolkit-review-consumers[^[:space:])`,;!?]*|[0-9a-f]{40})' "$review"; then
+  echo "redaction test failed: private token remained" >&2
+  cat "$review" >&2
+  exit 1
+fi
+
+grep -Fq '[private consumer]s are pluralized references.' "$review"
+grep -Fq '[private consumer]s should not block posting.' "$review"
+grep -Fq 'See [private path], then continue.' "$review"
+grep -Fq 'Package [private package], then continue.' "$review"
+grep -Fq 'SHA [private sha]c' "$review"
+grep -Fq 'Public summary is otherwise fine.' "$review"


### PR DESCRIPTION
## Summary
- add a contract-toolkit-specific Mothership PR review mode with toolkit-only and mixed SDK/toolkit routing
- add a private consumer registry, toolkit review agent, and paired toolkit review skill copies
- require PR-bound cross-repo compatibility validation through a private ledger
- expose only capability-level Cross-Repo Validation statuses in public review output
- sanitize public review output with a deterministic redaction helper

## Why
Contract-toolkit PRs can pass local Pkl checks while still breaking generated artifact consumers. The reviewer now classifies affected toolkit surfaces, validates mandatory consumer classes using PR-generated artifacts or scratch contracts, and avoids applying SDK Temporal/Dapr review rules to toolkit files.

Public review comments confirm the right validation categories without exposing internal consumer repos, private package names, branch names, SHAs, local paths, or system-app implementation details.

## Validation
- uv run pre-commit run --files .agents/skills/toolkit-feature-workflow/SKILL.md .claude/skills/toolkit-feature-workflow/SKILL.md .mothership/pr-review/ORCHESTRATION.md .mothership/pr-review/agents/toolkit-review.md .mothership/pr-review/references/toolkit-consumer-registry.md .mothership/pr-review/scripts/redact-toolkit-public-review.sh
- bash -n .mothership/pr-review/scripts/redact-toolkit-public-review.sh
- redaction smoke test with consumer, package, path, and SHA tokens
- git diff --check
- trailing whitespace scan
- skill copy comparison