### PR TITLE
feat(contract-toolkit): codegen _e2e_base.py, _e2e_credential.py, _e2e_substitutions.py

### DIFF
--- a/application_sdk/testing/e2e/credential.py
+++ b/application_sdk/testing/e2e/credential.py
@@ -1,8 +1,9 @@
 """Base class for codegen'd per-connector credential body models.
 
-Each connector's ``contract/app.pkl`` (via ``contract-toolkit/src/E2EOutput.pkl``)
-generates a ``<Connector>CredentialBody`` subclass in
-``app/generated/_e2e_credential.py``. Fields are derived from the pkl's
+Each connector's ``contract/app.pkl`` generates a ``<Connector>CredentialBody``
+subclass in ``app/generated/_e2e_credential.py`` via
+``generateE2ECredentialPy()`` in ``contract-toolkit/src/App.pkl``. Fields are
+derived from the pkl's
 ``credentialCommonFields + credentialAuthOptions[*].fields + extraFields``
 (aligned with ``application_sdk.credentials.types.FieldSpec``). Aliases
 use the AE-payload-body key names.

--- a/application_sdk/testing/e2e/credential.py
+++ b/application_sdk/testing/e2e/credential.py
@@ -3,10 +3,11 @@
 Each connector's ``contract/app.pkl`` generates a ``<Connector>CredentialBody``
 subclass in ``app/generated/_e2e_credential.py`` via
 ``generateE2ECredentialPy()`` in ``contract-toolkit/src/App.pkl``. Fields are
-derived from the pkl's
-``credentialCommonFields + credentialAuthOptions[*].fields + extraFields``
-(aligned with ``application_sdk.credentials.types.FieldSpec``). Aliases
-use the AE-payload-body key names.
+derived from the union of: ``credentialUrlGroup`` host/port/extraFields,
+``credentialSharedExtraFields``, ``credentialCommonFields``,
+``credentialAuthOptions[*].fields`` (auth-specific fields become Optional),
+and ``credentialAuthOptions[*].extraFields`` (emitted as a nested
+``<Connector>CredentialBodyExtra`` model). Aliases use the AE-payload-body key names.
 
 Connectors with ``hasCredentialConfig = false`` (e.g. openapi → public
 source) do not emit this file; their ``_credential_body()`` returns ``None``.

--- a/application_sdk/testing/e2e/credential.py
+++ b/application_sdk/testing/e2e/credential.py
@@ -5,9 +5,11 @@ subclass in ``app/generated/_e2e_credential.py`` via
 ``generateE2ECredentialPy()`` in ``contract-toolkit/src/App.pkl``. Fields are
 derived from the union of: ``credentialUrlGroup`` host/port/extraFields,
 ``credentialSharedExtraFields``, ``credentialCommonFields``,
-``credentialAuthOptions[*].fields`` (auth-specific fields become Optional),
-and ``credentialAuthOptions[*].extraFields`` (emitted as a nested
-``<Connector>CredentialBodyExtra`` model). Aliases use the AE-payload-body key names.
+``credentialAuthOptions[*].fields`` (auth-specific fields keep their type
+with a sentinel default — ``""`` for str, ``0`` for int; conditional common
+fields become ``Optional``), and ``credentialAuthOptions[*].extraFields``
+(emitted as a nested ``<Connector>CredentialBodyExtra`` model).
+Aliases use the AE-payload-body key names.
 
 Connectors with ``hasCredentialConfig = false`` (e.g. openapi → public
 source) do not emit this file; their ``_credential_body()`` returns ``None``.

--- a/application_sdk/testing/e2e/substitutions.py
+++ b/application_sdk/testing/e2e/substitutions.py
@@ -56,7 +56,8 @@ class SQLMustacheSubstitutions(MustacheSubstitutions):
     Used by :class:`~application_sdk.testing.e2e.sql_app.SQLAppE2ETest`;
     subclassable further for SQL connectors whose manifest declares
     additional mustache keys (driven by the connector's ``app.pkl`` via
-    codegen — see ``contract-toolkit/src/E2EOutput.pkl``).
+    codegen — see ``generateE2ESubstitutionsPy()`` in
+    ``contract-toolkit/src/App.pkl``).
     """
 
     extraction_method: str = Field(default="", alias="{{extraction-method}}")

--- a/application_sdk/testing/e2e/substitutions.py
+++ b/application_sdk/testing/e2e/substitutions.py
@@ -11,7 +11,8 @@ Hierarchy:
 * :class:`SQLMustacheSubstitutions` — SQL additions: extraction-method,
   agent-json, filters, preflight-check.
 * Per-connector subclasses live in ``app/generated/_e2e_substitutions.py``
-  (codegen'd from ``contract/app.pkl`` via ``contract-toolkit``).
+  (codegen'd from ``contract/app.pkl`` via ``generateE2ESubstitutionsPy()``
+  in ``contract-toolkit/src/App.pkl``).
 """
 
 from __future__ import annotations

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -106,6 +106,16 @@ The single entry point for all new native app contracts. Supersedes `NativeApp.p
 | `workflowTypeOverride` | String? | null | Explicit workflow type (used as-is, overrides `workflowType`). |
 | `taskQueuePrefix` | String | `"atlan-{name}"` | Task queue prefix. Override for multi-entrypoint apps sharing a deployment. |
 
+### E2E Test Harness
+
+These three fields are emitted into `app/generated/_e2e_base.py` and are required by `BaseE2ETest` / `SQLAppE2ETest`. The defaults are derived from `name`; 95% of connectors never need to override them.
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `argoPackageName` | String | `"@atlan/{name}"` | Argo WorkflowTemplate package name. Override when the app uses a scoped or non-standard Argo package. |
+| `argoTemplateName` | String | `"atlan-{name}"` | Argo WorkflowTemplate resource name as deployed in-cluster. Matches `taskQueuePrefix` by default. |
+| `appServiceUrl` | String | `"http://{name}.{name}-app.svc.cluster.local"` | In-cluster Dapr service URL forwarded to by the e2e harness. Override when the app's Kubernetes service name deviates from the standard `{name}-app` pattern. |
+
 ### Pipeline Block
 
 The typed `pipeline` block replaces per-flag properties. Each step is nullable to opt out.

--- a/contract-toolkit/examples/bundle/app/generated/crawler/_e2e_base.py
+++ b/contract-toolkit/examples/bundle/app/generated/crawler/_e2e_base.py
@@ -1,0 +1,11 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from application_sdk.testing.e2e import SQLAppE2ETest
+
+
+class CrawlerGeneratedE2EBase(SQLAppE2ETest):
+    connector_short_name = "crawler"
+    argo_package_name = "@atlan/crawler"
+    argo_template_name = "atlan-crawler"
+    app_service_url = "http://crawler.crawler-app.svc.cluster.local"
+    connection_type = "snowflake"

--- a/contract-toolkit/examples/bundle/app/generated/crawler/_e2e_credential.py
+++ b/contract-toolkit/examples/bundle/app/generated/crawler/_e2e_credential.py
@@ -1,0 +1,13 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from pydantic import Field
+
+from application_sdk.testing.e2e.credential import CredentialBody
+
+
+class CrawlerCredentialBody(CredentialBody):
+    name: str = Field(alias="name")
+    auth_type: str = Field(default="basic", alias="authType")
+    host: str = Field(alias="host")
+    username: str = Field(default="", alias="username")
+    password: str = Field(default="", alias="password")

--- a/contract-toolkit/examples/bundle/app/generated/miner/_e2e_base.py
+++ b/contract-toolkit/examples/bundle/app/generated/miner/_e2e_base.py
@@ -1,0 +1,10 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from application_sdk.testing.e2e import BaseE2ETest
+
+
+class MinerGeneratedE2EBase(BaseE2ETest):
+    connector_short_name = "miner"
+    argo_package_name = "@atlan/miner"
+    argo_template_name = "atlan-miner"
+    app_service_url = "http://miner.miner-app.svc.cluster.local"

--- a/contract-toolkit/examples/bundle/app/generated/miner/_e2e_substitutions.py
+++ b/contract-toolkit/examples/bundle/app/generated/miner/_e2e_substitutions.py
@@ -1,0 +1,12 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from __future__ import annotations
+
+from pydantic import Field
+
+from application_sdk.testing.e2e.substitutions import MustacheSubstitutions
+
+
+class MinerMustacheSubstitutions(MustacheSubstitutions):
+    lookback_days: int = Field(default=30, alias="{{lookback-days}}")
+    max_queries: int = Field(default=0, alias="{{max-queries}}")

--- a/contract-toolkit/examples/connection-ref/app/generated/_e2e_base.py
+++ b/contract-toolkit/examples/connection-ref/app/generated/_e2e_base.py
@@ -1,0 +1,12 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from application_sdk.testing.e2e import SQLAppE2ETest
+
+
+class ConnectionRefGeneratedE2EBase(SQLAppE2ETest):
+    connector_short_name = "connection-ref"
+    argo_package_name = "@atlan/connection-ref"
+    argo_template_name = "atlan-connection-ref"
+    app_service_url = "http://connection-ref.connection-ref-app.svc.cluster.local"
+    connection_type = "trino"
+    connection_category = "database"

--- a/contract-toolkit/examples/deploy/app/generated/_e2e_base.py
+++ b/contract-toolkit/examples/deploy/app/generated/_e2e_base.py
@@ -1,0 +1,10 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from application_sdk.testing.e2e import BaseE2ETest
+
+
+class DeployGeneratedE2EBase(BaseE2ETest):
+    connector_short_name = "deploy"
+    argo_package_name = "@atlan/deploy"
+    argo_template_name = "atlan-deploy"
+    app_service_url = "http://deploy.deploy-app.svc.cluster.local"

--- a/contract-toolkit/examples/deploy/app/generated/_e2e_substitutions.py
+++ b/contract-toolkit/examples/deploy/app/generated/_e2e_substitutions.py
@@ -1,0 +1,11 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from __future__ import annotations
+
+from pydantic import Field
+
+from application_sdk.testing.e2e.substitutions import MustacheSubstitutions
+
+
+class DeployMustacheSubstitutions(MustacheSubstitutions):
+    target: str = Field(default="", alias="{{target}}")

--- a/contract-toolkit/examples/fanin/app/generated/_e2e_base.py
+++ b/contract-toolkit/examples/fanin/app/generated/_e2e_base.py
@@ -1,0 +1,12 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from application_sdk.testing.e2e import SQLAppE2ETest
+
+
+class FaninGeneratedE2EBase(SQLAppE2ETest):
+    connector_short_name = "fanin"
+    argo_package_name = "@atlan/fanin"
+    argo_template_name = "atlan-fanin"
+    app_service_url = "http://fanin.fanin-app.svc.cluster.local"
+    connection_type = "trino"
+    connection_category = "database"

--- a/contract-toolkit/examples/fanin/app/generated/_e2e_credential.py
+++ b/contract-toolkit/examples/fanin/app/generated/_e2e_credential.py
@@ -1,0 +1,13 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from pydantic import Field
+
+from application_sdk.testing.e2e.credential import CredentialBody
+
+
+class FaninCredentialBody(CredentialBody):
+    name: str = Field(alias="name")
+    auth_type: str = Field(default="basic", alias="authType")
+    host: str = Field(alias="host")
+    username: str = Field(default="", alias="username")
+    password: str = Field(default="", alias="password")

--- a/contract-toolkit/examples/full/app/generated/_e2e_base.py
+++ b/contract-toolkit/examples/full/app/generated/_e2e_base.py
@@ -1,0 +1,12 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from application_sdk.testing.e2e import SQLAppE2ETest
+
+
+class FullFeaturedGeneratedE2EBase(SQLAppE2ETest):
+    connector_short_name = "full-featured"
+    argo_package_name = "@atlan/full-featured"
+    argo_template_name = "atlan-full-featured"
+    app_service_url = "http://full-featured.full-featured-app.svc.cluster.local"
+    connection_type = "postgres"
+    connection_category = "database"

--- a/contract-toolkit/examples/full/app/generated/_e2e_credential.py
+++ b/contract-toolkit/examples/full/app/generated/_e2e_credential.py
@@ -1,0 +1,19 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from __future__ import annotations
+
+from pydantic import Field
+
+from application_sdk.testing.e2e.credential import CredentialBody
+
+
+class FullFeaturedCredentialBody(CredentialBody):
+    name: str = Field(alias="name")
+    auth_type: str = Field(default="basic", alias="authType")
+    host: str = Field(alias="host")
+    port: int = Field(default=5432, alias="port")
+    database: str = Field(alias="database")
+    token_audience: str | None = Field(default=None, alias="token_audience")
+    username: str = Field(default="", alias="username")
+    password: str = Field(default="", alias="password")
+    token: str = Field(default="", alias="token")

--- a/contract-toolkit/examples/full/app/generated/_e2e_substitutions.py
+++ b/contract-toolkit/examples/full/app/generated/_e2e_substitutions.py
@@ -10,14 +10,10 @@ from application_sdk.testing.e2e.substitutions import SQLMustacheSubstitutions
 
 
 class FullFeaturedMustacheSubstitutions(SQLMustacheSubstitutions):
-    output_format: Literal["parquet", "json"] = Field(
-        default="parquet", alias="{{output_format}}"
-    )
+    output_format: Literal["parquet", "json"] = Field(default="parquet", alias="{{output_format}}")
     max_results: int = Field(default=500, alias="{{max_results}}")
     enable_lineage: bool = Field(default=False, alias="{{enable_lineage}}")
     load_to_atlan: bool = Field(default=True, alias="{{load-to-atlan}}")
-    log_level: Literal["INFO", "DEBUG", "WARNING"] = Field(
-        default="INFO", alias="{{log_level}}"
-    )
+    log_level: Literal["INFO", "DEBUG", "WARNING"] = Field(default="INFO", alias="{{log_level}}")
     lineage_depth: int = Field(default=3, alias="{{lineage_depth}}")
     schemas: dict[str, Any] | None = Field(default=None, alias="{{schemas}}")

--- a/contract-toolkit/examples/full/app/generated/_e2e_substitutions.py
+++ b/contract-toolkit/examples/full/app/generated/_e2e_substitutions.py
@@ -1,0 +1,23 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import Field
+
+from application_sdk.testing.e2e.substitutions import SQLMustacheSubstitutions
+
+
+class FullFeaturedMustacheSubstitutions(SQLMustacheSubstitutions):
+    output_format: Literal["parquet", "json"] = Field(
+        default="parquet", alias="{{output_format}}"
+    )
+    max_results: int = Field(default=500, alias="{{max_results}}")
+    enable_lineage: bool = Field(default=False, alias="{{enable_lineage}}")
+    load_to_atlan: bool = Field(default=True, alias="{{load-to-atlan}}")
+    log_level: Literal["INFO", "DEBUG", "WARNING"] = Field(
+        default="INFO", alias="{{log_level}}"
+    )
+    lineage_depth: int = Field(default=3, alias="{{lineage_depth}}")
+    schemas: dict[str, Any] | None = Field(default=None, alias="{{schemas}}")

--- a/contract-toolkit/examples/full/app/generated/_e2e_substitutions.py
+++ b/contract-toolkit/examples/full/app/generated/_e2e_substitutions.py
@@ -10,10 +10,16 @@ from application_sdk.testing.e2e.substitutions import SQLMustacheSubstitutions
 
 
 class FullFeaturedMustacheSubstitutions(SQLMustacheSubstitutions):
-    output_format: Literal["parquet", "json"] = Field(default="parquet", alias="{{output_format}}")
+    output_format: Literal["parquet", "json"] = Field(
+        default="parquet",
+        alias="{{output_format}}",
+    )
     max_results: int = Field(default=500, alias="{{max_results}}")
     enable_lineage: bool = Field(default=False, alias="{{enable_lineage}}")
     load_to_atlan: bool = Field(default=True, alias="{{load-to-atlan}}")
-    log_level: Literal["INFO", "DEBUG", "WARNING"] = Field(default="INFO", alias="{{log_level}}")
+    log_level: Literal["INFO", "DEBUG", "WARNING"] = Field(
+        default="INFO",
+        alias="{{log_level}}",
+    )
     lineage_depth: int = Field(default=3, alias="{{lineage_depth}}")
     schemas: dict[str, Any] | None = Field(default=None, alias="{{schemas}}")

--- a/contract-toolkit/examples/minimal/app/generated/_e2e_base.py
+++ b/contract-toolkit/examples/minimal/app/generated/_e2e_base.py
@@ -1,0 +1,10 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from application_sdk.testing.e2e import BaseE2ETest
+
+
+class MinimalGeneratedE2EBase(BaseE2ETest):
+    connector_short_name = "minimal"
+    argo_package_name = "@atlan/minimal"
+    argo_template_name = "atlan-minimal"
+    app_service_url = "http://minimal.minimal-app.svc.cluster.local"

--- a/contract-toolkit/examples/minimal/app/generated/_e2e_substitutions.py
+++ b/contract-toolkit/examples/minimal/app/generated/_e2e_substitutions.py
@@ -1,0 +1,11 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from __future__ import annotations
+
+from pydantic import Field
+
+from application_sdk.testing.e2e.substitutions import MustacheSubstitutions
+
+
+class MinimalMustacheSubstitutions(MustacheSubstitutions):
+    target: str = Field(default="", alias="{{target}}")

--- a/contract-toolkit/examples/publish-controls/app/generated/_e2e_base.py
+++ b/contract-toolkit/examples/publish-controls/app/generated/_e2e_base.py
@@ -1,0 +1,12 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from application_sdk.testing.e2e import SQLAppE2ETest
+
+
+class PublishControlsGeneratedE2EBase(SQLAppE2ETest):
+    connector_short_name = "publish-controls"
+    argo_package_name = "@atlan/publish-controls"
+    argo_template_name = "atlan-publish-controls"
+    app_service_url = "http://publish-controls.publish-controls-app.svc.cluster.local"
+    connection_type = "trino"
+    connection_category = "database"

--- a/contract-toolkit/examples/publish-controls/app/generated/_e2e_credential.py
+++ b/contract-toolkit/examples/publish-controls/app/generated/_e2e_credential.py
@@ -1,0 +1,14 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from pydantic import Field
+
+from application_sdk.testing.e2e.credential import CredentialBody
+
+
+class PublishControlsCredentialBody(CredentialBody):
+    name: str = Field(alias="name")
+    auth_type: str = Field(default="basic", alias="authType")
+    host: str = Field(alias="host")
+    enable_ssl: str = Field(default="true", alias="enable_ssl")
+    username: str = Field(default="", alias="username")
+    password: str = Field(default="", alias="password")

--- a/contract-toolkit/examples/publish-controls/app/generated/_e2e_substitutions.py
+++ b/contract-toolkit/examples/publish-controls/app/generated/_e2e_substitutions.py
@@ -1,0 +1,11 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from __future__ import annotations
+
+from pydantic import Field
+
+from application_sdk.testing.e2e.substitutions import SQLMustacheSubstitutions
+
+
+class PublishControlsMustacheSubstitutions(SQLMustacheSubstitutions):
+    load_to_atlan: bool = Field(default=True, alias="{{load-to-atlan}}")

--- a/contract-toolkit/scripts/test-sdk-import.py
+++ b/contract-toolkit/scripts/test-sdk-import.py
@@ -1,4 +1,4 @@
-"""Validate that every generated _input.py imports cleanly against the SDK.
+"""Validate that every generated _input.py and _e2e_*.py imports cleanly against the SDK.
 
 Requires: pip install git+https://github.com/atlanhq/application-sdk.git@main
 """
@@ -10,54 +10,82 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EXAMPLES_DIR = REPO_ROOT / "examples"
 
+# Expected class names by file stem.
+_E2E_CLASSES = {
+    "_e2e_base": None,  # class name varies; just check importability
+    "_e2e_credential": None,
+    "_e2e_substitutions": None,
+}
 
-def test_import(path: Path) -> bool:
-    """Load a _input.py file as a module and verify AppInputContract exists."""
+
+def _load_module(path: Path) -> tuple[object | None, str | None]:
+    """Return (module, error_msg) pair."""
     module_name = f"test_{path.parent.name}_{path.stem}"
     try:
         spec = importlib.util.spec_from_file_location(module_name, path)
         if spec is None or spec.loader is None:
-            print(f"FAIL: {path} — could not create module spec")
-            return False
+            return None, "could not create module spec"
         mod = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = mod
         spec.loader.exec_module(mod)
+        return mod, None
     except Exception as e:
-        print(f"FAIL: {path} — import error: {e}")
-        return False
+        return None, f"import error: {e}"
 
+
+def test_input(path: Path) -> bool:
+    """Verify _input.py imports and exposes AppInputContract."""
+    mod, err = _load_module(path)
+    if mod is None:
+        print(f"FAIL: {path} — {err}")
+        return False
     if not hasattr(mod, "AppInputContract"):
         print(f"FAIL: {path} — AppInputContract class not found")
         return False
-
-    # Verify it's a proper Pydantic model with model_fields
     cls = mod.AppInputContract
     if not hasattr(cls, "model_fields"):
         print(f"FAIL: {path} — AppInputContract is not a Pydantic model")
         return False
-
     print(f"  OK: {path} ({len(cls.model_fields)} fields)")
     return True
 
 
+def test_e2e(path: Path) -> bool:
+    """Verify an _e2e_*.py file imports without error."""
+    mod, err = _load_module(path)
+    if mod is None:
+        print(f"FAIL: {path} — {err}")
+        return False
+    print(f"  OK: {path}")
+    return True
+
+
 def main() -> int:
+    failed = 0
+
     input_files = sorted(EXAMPLES_DIR.rglob("_input.py"))
     if not input_files:
         print("ERROR: no _input.py files found")
         return 1
-
     print(f":: Testing {len(input_files)} _input.py files against SDK...")
-    failed = 0
     for path in input_files:
-        if not test_import(path):
+        if not test_input(path):
             failed += 1
 
+    e2e_files = sorted(p for p in EXAMPLES_DIR.rglob("_e2e_*.py"))
+    if e2e_files:
+        print(f"\n:: Testing {len(e2e_files)} _e2e_*.py files against SDK...")
+        for path in e2e_files:
+            if not test_e2e(path):
+                failed += 1
+
     print()
+    total = len(input_files) + len(e2e_files)
     if failed:
-        print(f"{failed}/{len(input_files)} files failed import test.")
+        print(f"{failed}/{total} files failed import test.")
         return 1
 
-    print(f"All {len(input_files)} files imported successfully.")
+    print(f"All {total} files imported successfully.")
     return 0
 
 

--- a/contract-toolkit/scripts/test-sdk-import.py
+++ b/contract-toolkit/scripts/test-sdk-import.py
@@ -43,13 +43,51 @@ def test_input(path: Path) -> bool:
     return True
 
 
+_E2E_CLASS_SUFFIX = {
+    "_e2e_base": "GeneratedE2EBase",
+    "_e2e_credential": "CredentialBody",
+    "_e2e_substitutions": "MustacheSubstitutions",
+}
+
+
 def test_e2e(path: Path) -> bool:
-    """Verify an _e2e_*.py file imports without error."""
+    """Verify an _e2e_*.py file imports and exposes the expected generated class."""
     mod, err = _load_module(path)
     if mod is None:
         print(f"FAIL: {path} — {err}")
         return False
-    print(f"  OK: {path}")
+
+    suffix = _E2E_CLASS_SUFFIX.get(path.stem)
+    if suffix:
+        # Prefer the longest name (most-specific subclass) so we don't accidentally
+        # pick up the imported base class (e.g. CredentialBody itself).
+        matches = sorted(
+            [n for n in dir(mod) if n.endswith(suffix) and not n.startswith("_")],
+            key=len,
+            reverse=True,
+        )
+        if not matches:
+            print(f"FAIL: {path} — no class ending in '{suffix}' found")
+            return False
+        cls = getattr(mod, matches[0])
+        if path.stem == "_e2e_base":
+            # BaseE2ETest subclasses are not Pydantic models; verify required harness attrs.
+            for attr in (
+                "connector_short_name",
+                "argo_package_name",
+                "argo_template_name",
+            ):
+                if not hasattr(cls, attr):
+                    print(f"FAIL: {path} — {matches[0]} missing required attr '{attr}'")
+                    return False
+            print(f"  OK: {path} ({matches[0]})")
+        else:
+            if not hasattr(cls, "model_fields"):
+                print(f"FAIL: {path} — {matches[0]} is not a Pydantic model")
+                return False
+            print(f"  OK: {path} ({matches[0]}, {len(cls.model_fields)} fields)")
+    else:
+        print(f"  OK: {path}")
     return True
 
 

--- a/contract-toolkit/scripts/test-sdk-import.py
+++ b/contract-toolkit/scripts/test-sdk-import.py
@@ -10,13 +10,6 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EXAMPLES_DIR = REPO_ROOT / "examples"
 
-# Expected class names by file stem.
-_E2E_CLASSES = {
-    "_e2e_base": None,  # class name varies; just check importability
-    "_e2e_credential": None,
-    "_e2e_substitutions": None,
-}
-
 
 def _load_module(path: Path) -> tuple[object | None, str | None]:
     """Return (module, error_msg) pair."""

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -170,6 +170,21 @@ workflowType: String = name
 /// Task queue prefix for the extract node in the AE manifest.
 taskQueuePrefix: String = "atlan-\(name)"
 
+// ── E2E TEST HARNESS ──────────────────────────────────────────────────────────
+
+/// Argo WorkflowTemplate package name used by the e2e test harness.
+/// Default: `"@atlan/<name>"`. Override for apps with scoped or non-standard package names.
+argoPackageName: String = "@atlan/\(name)"
+
+/// Argo WorkflowTemplate resource name as deployed in the cluster.
+/// Default: `"atlan-<name>"` — same pattern as `taskQueuePrefix`.
+argoTemplateName: String = "atlan-\(name)"
+
+/// In-cluster HTTP URL for the app's Dapr service; used by the e2e harness to
+/// forward AE workflow calls to the running app.
+/// Default: `"http://<name>.<name>-app.svc.cluster.local"`.
+appServiceUrl: String = "http://\(name).\(name)-app.svc.cluster.local"
+
 // ── CREDENTIAL CONFIG ─────────────────────────────────────────────────────────
 
 /// Whether this app has a credential config.
@@ -2470,6 +2485,318 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
     (if (classBody.isEmpty) "    pass\n" else classBody)
 }
 
+// ── e2e code generation ───────────────────────────────────────────────────────
+
+local function capitalizeFirst(s: String): String =
+  if (s.isEmpty) s else s.take(1).toUpperCase() + s.drop(1)
+
+local function pascalCase(s: String): String =
+  (new Listing {
+    for (seg in s.split(Regex("[\\-_]+"))) { capitalizeFirst(seg) }
+  }).toList().join("")
+
+// SQL-family categories drive SQLAppE2ETest / SQLMustacheSubstitutions selection.
+local function e2eBaseClass(): String =
+  let (cat = connector?.category)
+  if (cat == "warehouse" || cat == "database" || cat == "lake" || cat == "queryengine")
+    "SQLAppE2ETest"
+  else "BaseE2ETest"
+
+local function e2eSubsParent(): String =
+  let (cat = connector?.category)
+  if (cat == "warehouse" || cat == "database" || cat == "lake" || cat == "queryengine")
+    "SQLMustacheSubstitutions"
+  else "MustacheSubstitutions"
+
+// Fields already provided by MustacheSubstitutions (always skip).
+local e2eSubsBaseSkip: Set<String> =
+  (new Listing { "credential"; "credential_guid"; "connection" }).toList().toSet()
+
+// Fields added by SQLMustacheSubstitutions (skip when parent is SQL).
+local e2eSubsSqlSkip: Set<String> =
+  List("extraction_method", "agent_json", "include_filter", "exclude_filter", "exclude_table_regex", "preflight_check")
+    .fold(e2eSubsBaseSkip, (acc, elem) -> (acc as Set<String>).add(elem))
+
+local function e2eSubsSkip(): Set<String> =
+  if (e2eSubsParent() == "SQLMustacheSubstitutions") e2eSubsSqlSkip
+  else e2eSubsBaseSkip
+
+// Returns a typed pydantic Field line for a substitution field, or null to skip.
+local function getSubsFieldLine(k: String, u: Widgets.UIElement): String? =
+  let (pyName = toPyName(k))
+  if (u is Widgets.ConnectionCreator || u is Widgets.ConnectionSelector || u is Widgets.ConnectionRefInput)
+    null
+  else if (u is Widgets.BooleanInput)
+    "    \(pyName): bool = Field(default=\(if ((u as Widgets.BooleanInput).default) "True" else "False"), alias=\"{{\(k)}}\")"
+  else if (u is Widgets.Switcher)
+    "    \(pyName): bool = Field(default=\(if ((u as Widgets.Switcher).default) "True" else "False"), alias=\"{{\(k)}}\")"
+  else if (u is Widgets.NumericInput)
+    let (d = (u as Widgets.NumericInput).default)
+    "    \(pyName): int = Field(default=\(if (d != null) d!!.toInt() else 0), alias=\"{{\(k)}}\")"
+  else if (u is Widgets.Radio)
+    let (radio = u as Widgets.Radio)
+    let (vals = radio.possibleValues.keys.toList())
+    if (!vals.isEmpty)
+      let (litStr = (new Listing { for (v in vals) { "\"\(v)\"" } }).toList().join(", "))
+      let (defVal = if (radio.default != null) radio.default!! else vals.first)
+      "    \(pyName): Literal[\(litStr)] = Field(default=\"\(defVal)\", alias=\"{{\(k)}}\")"
+    else
+      "    \(pyName): str = Field(default=\"\(if (radio.default != null) radio.default!! else "")\", alias=\"{{\(k)}}\")"
+  else if (u is Widgets.DropDown)
+    let (dd = u as Widgets.DropDown)
+    let (vals = dd.possibleValues.keys.toList())
+    if (!vals.isEmpty && !dd.multiSelect)
+      let (litStr = (new Listing { for (v in vals) { "\"\(v)\"" } }).toList().join(", "))
+      let (defVal = if (dd.default != null) dd.default!! else vals.first)
+      "    \(pyName): Literal[\(litStr)] = Field(default=\"\(defVal)\", alias=\"{{\(k)}}\")"
+    else
+      "    \(pyName): str = Field(default=\"\(if (dd.default != null) dd.default!! else "")\", alias=\"{{\(k)}}\")"
+  else if (u is Widgets.ConditionalInput)
+    let (ci = u as Widgets.ConditionalInput)
+    if (ci.outputValueType == "object")
+      "    \(pyName): dict[str, Any] | None = Field(default=None, alias=\"{{\(k)}}\")"
+    else if (ci.baseWidgetType == "radio" && ci.baseEnum != null && !ci.baseEnum!!.isEmpty)
+      let (litStr = (new Listing { for (v in ci.baseEnum!!) { "\"\(v)\"" } }).toList().join(", "))
+      let (defVal = if (ci.default != null) ci.default!!.toString() else ci.baseEnum!!.toList().first)
+      "    \(pyName): Literal[\(litStr)] = Field(default=\"\(defVal)\", alias=\"{{\(k)}}\")"
+    else
+      "    \(pyName): str = Field(default=\"\(if (ci.default != null) ci.default!!.toString() else "")\", alias=\"{{\(k)}}\")"
+  else if (u is Widgets.SqlTree || u is Widgets.NestedInput || u is Widgets.APITree ||
+      u is Widgets.ApiTreeSelect || u is Widgets.DsnTreeMap || u is Widgets.AgentSelector)
+    "    \(pyName): dict[str, Any] | None = Field(default=None, alias=\"{{\(k)}}\")"
+  else
+    // TextInput, PasswordInput, CredentialInput, TextBoxInput, etc. → str
+    let (defVal =
+      if (u is Widgets.TextInput && (u as Widgets.TextInput).default != null)
+        (u as Widgets.TextInput).default!!
+      else "")
+    "    \(pyName): str = Field(default=\"\(defVal)\", alias=\"{{\(k)}}\")"
+
+local function generateE2EBasePy(): FileOutput = new FileOutput {
+  local baseClass = e2eBaseClass()
+  local cname = pascalCase(name)
+  local emitConnType = connector != null && connector!!.value != name
+  local emitConnCat = connector != null && connector!!.category != "warehouse"
+  text =
+    "# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.\n" +
+    "# Regenerate with: pkl eval -m . contract/app.pkl\n" +
+    "from application_sdk.testing.e2e import \(baseClass)\n\n\n" +
+    "class \(cname)GeneratedE2EBase(\(baseClass)):\n" +
+    "    connector_short_name = \"\(name)\"\n" +
+    "    argo_package_name = \"\(argoPackageName)\"\n" +
+    "    argo_template_name = \"\(argoTemplateName)\"\n" +
+    "    app_service_url = \"\(appServiceUrl)\"\n" +
+    (if (emitConnType) "    connection_type = \"\(connector!!.value)\"\n" else "") +
+    (if (emitConnCat) "    connection_category = \"\(connector!!.category)\"\n" else "")
+}
+
+local function generateE2ESubstitutionsPy(): FileOutput? =
+  let (props = uiConfig?.properties ?? Map())
+  let (skip = e2eSubsSkip())
+  let (fieldLines = (new Listing {
+    for (k, u in props) {
+      when (!skip.contains(toPyName(k)) && u.includeInInput && getSubsFieldLine(k, u) != null) {
+        getSubsFieldLine(k, u)!! + "\n"
+      }
+    }
+  }).toList().fold("", (acc: String, s: String) -> acc + s))
+  if (fieldLines.isEmpty) null
+  else new FileOutput {
+    local parentClass = e2eSubsParent()
+    local cname = pascalCase(name)
+    local usesLiteral = fieldLines.contains("Literal[")
+    local usesAny = fieldLines.contains("dict[str, Any]")
+    local typingLine =
+      if (usesLiteral && usesAny) "from typing import Any, Literal\n\n"
+      else if (usesLiteral) "from typing import Literal\n\n"
+      else if (usesAny) "from typing import Any\n\n"
+      else ""
+    local parentImport =
+      if (parentClass == "SQLMustacheSubstitutions")
+        "from application_sdk.testing.e2e.substitutions import SQLMustacheSubstitutions\n"
+      else
+        "from application_sdk.testing.e2e.substitutions import MustacheSubstitutions\n"
+    text =
+      "# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.\n" +
+      "# Regenerate with: pkl eval -m . contract/app.pkl\n" +
+      "from __future__ import annotations\n\n" +
+      typingLine +
+      "from pydantic import Field\n\n" +
+      parentImport +
+      "\n\nclass \(cname)MustacheSubstitutions(\(parentClass)):\n" +
+      fieldLines
+  }
+
+// Returns a typed Field line for a single FieldSpec in a CredentialBody class.
+// authSpecific=true means the field only appears in some auth options (always use a default).
+local function credFieldLine(f: FieldSpec, authSpecific: Boolean): String =
+  let (pyName = toPyName(f.name))
+  let (pyType = if (f.fieldType == "number") "int" else "str")
+  let (defExpr =
+    if (f.defaultValue != null)
+      if (f.fieldType == "number") f.defaultValue!! else "\"" + f.defaultValue!! + "\""
+    else if (authSpecific || !f.required)
+      if (f.fieldType == "number") "0" else "\"\""
+    else "")
+  if (defExpr.isEmpty)
+    "    \(pyName): \(pyType) = Field(alias=\"\(f.name)\")"
+  else
+    "    \(pyName): \(pyType) = Field(default=\(defExpr), alias=\"\(f.name)\")"
+
+local function generateE2ECredentialPy(): FileOutput? =
+  if (!(hasCredentialConfig && credentialAuthOptions != null && !credentialAuthOptions!!.isEmpty))
+    null
+  else new FileOutput {
+    local cname = pascalCase(name)
+
+    // First auth option key (for auth_type default value).
+    local firstAuthKey: String = (new Listing {
+      for (k, v in credentialAuthOptions!!) { k }
+    }).toList().first
+
+    // Common top-level FieldSpec entries from either credentialUrlGroup or credentialCommonFields.
+    local commonSpecs: List<FieldSpec> = (new Listing {
+      when (credentialUrlGroup != null) {
+        credentialUrlGroup!!.hostField
+        credentialUrlGroup!!.portField
+        for (f in credentialUrlGroup!!.extraFields) {
+          when (f is FieldSpec) { f }
+        }
+      }
+      when (credentialUrlGroup == null) {
+        for (f in credentialCommonFields) {
+          when (f is FieldSpec) { f }
+        }
+      }
+    }).toList()
+
+    local condCommonSpecs: List<ConditionalFieldSpec> = (new Listing {
+      when (credentialUrlGroup != null) {
+        for (f in credentialUrlGroup!!.extraFields) {
+          when (f is ConditionalFieldSpec) { f }
+        }
+      }
+      when (credentialUrlGroup == null) {
+        for (f in credentialCommonFields) {
+          when (f is ConditionalFieldSpec) { f }
+        }
+      }
+    }).toList()
+
+    // Set of field names already in the common group (used to exclude from auth-specific).
+    local commonNameSet: Set<String> =
+      (new Listing { for (f in commonSpecs) { f.name } }).toList().toSet()
+
+    // Deduplicated auth-specific top-level FieldSpecs (first occurrence per name, excluding common).
+    local allAuthTopRaw: List<FieldSpec> = (new Listing {
+      for (key, opt in credentialAuthOptions!!) {
+        for (f in opt.fields) {
+          when (f is FieldSpec) { f }
+        }
+      }
+    }).toList()
+
+    local authTopDeduped: List<FieldSpec> =
+      allAuthTopRaw
+        .filter((f: FieldSpec) -> !commonNameSet.contains(f.name))
+        .fold(
+          List(),
+          (acc: List<FieldSpec>, f: FieldSpec) ->
+            if ((new Listing { for (s in acc) { s.name } }).toList().contains(f.name)) acc
+            else acc.add(f)
+        )
+
+    // Collect all extra FieldSpecs from auth options (for the nested Extra model).
+    local sharedExtraSpecs: List<FieldSpec> = (new Listing {
+      for (f in credentialSharedExtraFields) {
+        when (f is FieldSpec) { f }
+      }
+    }).toList()
+
+    local sharedExtraNames: Set<String> =
+      (new Listing { for (f in sharedExtraSpecs) { f.name } }).toList().toSet()
+
+    local allAuthExtraRaw: List<FieldSpec> = (new Listing {
+      for (key, opt in credentialAuthOptions!!) {
+        for (f in opt.extraFields) {
+          when (f is FieldSpec) { f }
+        }
+      }
+    }).toList()
+
+    // Extra model: sharedExtraSpecs + auth-specific extras, deduped.
+    local allExtraSpecs: List<FieldSpec> =
+      allAuthExtraRaw.fold(
+        sharedExtraSpecs,
+        (acc: List<FieldSpec>, f: FieldSpec) ->
+          if (sharedExtraNames.contains(f.name) ||
+              (new Listing { for (s in acc) { s.name } }).toList().contains(f.name))
+            acc
+          else acc.add(f)
+      )
+
+    local hasExtraModel = !allExtraSpecs.isEmpty
+
+    // Build field line blocks.
+    local commonLines = (new Listing {
+      for (f in commonSpecs) { credFieldLine(f, false) + "\n" }
+    }).toList().fold("", (acc: String, s: String) -> acc + s)
+
+    local condCommonLines = (new Listing {
+      for (f in condCommonSpecs) {
+        "    " + toPyName(f.name) + ": str | None = Field(default=None, alias=\"" + f.name + "\")\n"
+      }
+    }).toList().fold("", (acc: String, s: String) -> acc + s)
+
+    local authTopLines = (new Listing {
+      for (f in authTopDeduped) { credFieldLine(f, true) + "\n" }
+    }).toList().fold("", (acc: String, s: String) -> acc + s)
+
+    local extraFieldProp: String =
+      if (hasExtraModel)
+        let (line = "    extra: \(cname)CredentialBodyExtra = Field(default_factory=\(cname)CredentialBodyExtra, alias=\"extra\")")
+        (if (line.length <= 88) line
+        else "    extra: \(cname)CredentialBodyExtra = Field(\n        default_factory=\(cname)CredentialBodyExtra, alias=\"extra\"\n    )") + "\n"
+      else ""
+
+    local extraModelLines = (new Listing {
+      for (f in allExtraSpecs) { credFieldLine(f, true) + "\n" }
+    }).toList().fold("", (acc: String, s: String) -> acc + s)
+
+    local mainClassBody =
+      "    name: str = Field(alias=\"name\")\n" +
+      "    auth_type: str = Field(default=\"\(firstAuthKey)\", alias=\"authType\")\n" +
+      commonLines +
+      condCommonLines +
+      authTopLines +
+      extraFieldProp
+
+    local extraModelBlock =
+      if (hasExtraModel)
+        "\n\nclass \(cname)CredentialBodyExtra(BaseModel):\n" +
+        "    model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)\n\n" +
+        extraModelLines
+      else ""
+
+    local hasPipeType =
+      mainClassBody.contains(" | None") || extraModelLines.contains(" | None")
+
+    local pydanticImports: List<String> = (new Listing {
+      "Field"
+      when (hasExtraModel) { "BaseModel"; "ConfigDict" }
+    }).toList()
+
+    text =
+      "# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.\n" +
+      "# Regenerate with: pkl eval -m . contract/app.pkl\n" +
+      (if (hasPipeType) "from __future__ import annotations\n\n" else "") +
+      "from pydantic import \(pydanticImports.join(", "))\n\n" +
+      "from application_sdk.testing.e2e.credential import CredentialBody\n" +
+      extraModelBlock +
+      "\n\nclass \(cname)CredentialBody(CredentialBody):\n" +
+      mainClassBody
+  }
+
 // ── atlan.yaml generation ─────────────────────────────────────────────────────
 
 local function asMapping(value: Any): Mapping<String, Any>? =
@@ -2673,6 +3000,8 @@ output =
   let (_jdbcCheck = jdbcInvariant)
   let (_connectorCheck = connectorInvariant)
   let (_credCheck = _credentialConflictCheck)
+  let (_e2eCredOutput = generateE2ECredentialPy())
+  let (_e2eSubsOutput = generateE2ESubstitutionsPy())
   new ModuleOutput {
     files = new Mapping {
 
@@ -2692,6 +3021,13 @@ output =
         }
         ["app/generated/manifest.json"] = manifestOutput
         ["app/generated/_input.py"] = generateInputClassPy()
+        ["app/generated/_e2e_base.py"] = generateE2EBasePy()
+        when (_e2eCredOutput != null) {
+          ["app/generated/_e2e_credential.py"] = _e2eCredOutput!!
+        }
+        when (_e2eSubsOutput != null) {
+          ["app/generated/_e2e_substitutions.py"] = _e2eSubsOutput!!
+        }
         ["app/generated/__init__.py"] = new FileOutput { text = "" }
       }
 

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -3023,14 +3023,19 @@ output =
         ["app.yaml"] = appYamlOutput
       }
 
-      // ── single-entrypoint mode (entrypoints is empty; uiConfig is set) ────
-      when (uiConfig != null && entrypoints.isEmpty) {
-        ["app/generated/\(workflowConfigName).json"] = workflowConfigOutput
-        when (hasCredentialConfig && credentialAuthOptions != null) {
-          ["app/generated/\(connectorConfigName).json"] = credentialConfigOutput
+      // ── single-entrypoint mode ────────────────────────────────────────────
+      when (entrypoints.isEmpty) {
+        // uiConfig-dependent runtime artifacts
+        when (uiConfig != null) {
+          ["app/generated/\(workflowConfigName).json"] = workflowConfigOutput
+          when (hasCredentialConfig && credentialAuthOptions != null) {
+            ["app/generated/\(connectorConfigName).json"] = credentialConfigOutput
+          }
+          ["app/generated/manifest.json"] = manifestOutput
+          ["app/generated/_input.py"] = generateInputClassPy()
+          ["app/generated/__init__.py"] = new FileOutput { text = "" }
         }
-        ["app/generated/manifest.json"] = manifestOutput
-        ["app/generated/_input.py"] = generateInputClassPy()
+        // e2e test-harness artifacts (independent of uiConfig)
         ["app/generated/_e2e_base.py"] = generateE2EBasePy()
         when (_e2eCredOutput != null) {
           ["app/generated/_e2e_credential.py"] = _e2eCredOutput!!
@@ -3038,7 +3043,6 @@ output =
         when (_e2eSubsOutput != null) {
           ["app/generated/_e2e_substitutions.py"] = _e2eSubsOutput!!
         }
-        ["app/generated/__init__.py"] = new FileOutput { text = "" }
       }
 
       // ── multi-entrypoint mode (entrypoints is non-empty) ──────────────────

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -2655,10 +2655,10 @@ local function generateE2ECredentialPy(): FileOutput? =
   else new FileOutput {
     local cname = pascalCase(name)
 
-    // First auth option key (for auth_type default value).
-    local firstAuthKey: String = (new Listing {
-      for (k, v in credentialAuthOptions!!) { k }
-    }).toList().first
+    // Default auth type: honour credentialAuthDefault when set, fall back to first key.
+    local firstAuthKey: String =
+      credentialAuthDefault ??
+      (new Listing { for (k, v in credentialAuthOptions!!) { k } }).toList().first
 
     // Common top-level FieldSpec entries from either credentialUrlGroup or credentialCommonFields.
     local commonSpecs: List<FieldSpec> = (new Listing {

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -2487,12 +2487,16 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
 
 // ── e2e code generation ───────────────────────────────────────────────────────
 
+// Escape a string for use inside a Python double-quoted literal.
+local function escapePyStr(s: String): String =
+  s.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"").replaceAll("\n", "\\n").replaceAll("\r", "\\r")
+
 local function capitalizeFirst(s: String): String =
   if (s.isEmpty) s else s.take(1).toUpperCase() + s.drop(1)
 
 local function pascalCase(s: String): String =
   (new Listing {
-    for (seg in s.split(Regex("[\\-_]+"))) { capitalizeFirst(seg) }
+    for (seg in s.split(Regex("[^A-Za-z0-9]+"))) { capitalizeFirst(seg) }
   }).toList().join("")
 
 // SQL-family categories drive SQLAppE2ETest / SQLMustacheSubstitutions selection.
@@ -2588,12 +2592,12 @@ local function generateE2EBasePy(): FileOutput = new FileOutput {
     "# Regenerate with: pkl eval -m . contract/app.pkl\n" +
     "from application_sdk.testing.e2e import \(baseClass)\n\n\n" +
     "class \(cname)GeneratedE2EBase(\(baseClass)):\n" +
-    "    connector_short_name = \"\(name)\"\n" +
-    "    argo_package_name = \"\(argoPackageName)\"\n" +
-    "    argo_template_name = \"\(argoTemplateName)\"\n" +
-    "    app_service_url = \"\(appServiceUrl)\"\n" +
-    (if (emitConnType) "    connection_type = \"\(connector!!.value)\"\n" else "") +
-    (if (emitConnCat) "    connection_category = \"\(connector!!.category)\"\n" else "")
+    "    connector_short_name = \"\(escapePyStr(name))\"\n" +
+    "    argo_package_name = \"\(escapePyStr(argoPackageName))\"\n" +
+    "    argo_template_name = \"\(escapePyStr(argoTemplateName))\"\n" +
+    "    app_service_url = \"\(escapePyStr(appServiceUrl))\"\n" +
+    (if (emitConnType) "    connection_type = \"\(escapePyStr(connector!!.value))\"\n" else "") +
+    (if (emitConnCat) "    connection_category = \"\(escapePyStr(connector!!.category))\"\n" else "")
 }
 
 local function generateE2ESubstitutionsPy(): FileOutput? =
@@ -2780,7 +2784,7 @@ local function generateE2ECredentialPy(): FileOutput? =
     local extraModelBlock =
       if (hasExtraModel)
         "\n\nclass \(cname)CredentialBodyExtra(BaseModel):\n" +
-        "    model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)\n\n" +
+        "    model_config = ConfigDict(frozen=True, populate_by_name=True, serialize_by_alias=True)\n\n" +
         extraModelLines
       else ""
 

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -2521,56 +2521,62 @@ local function e2eSubsSkip(): Set<String> =
   if (e2eSubsParent() == "SQLMustacheSubstitutions") e2eSubsSqlSkip
   else e2eSubsBaseSkip
 
+// Line-length-aware Field line: inlines if ≤ 88 chars, wraps otherwise.
+local function fmtSubsField(pyName: String, typeStr: String, defaultExpr: String, k: String): String =
+  let (inline = "    \(pyName): \(typeStr) = Field(\(defaultExpr), alias=\"{{\(k)}}\")")
+  if (inline.length <= 88) inline
+  else "    \(pyName): \(typeStr) = Field(\n        \(defaultExpr),\n        alias=\"{{\(k)}}\",\n    )"
+
 // Returns a typed pydantic Field line for a substitution field, or null to skip.
 local function getSubsFieldLine(k: String, u: Widgets.UIElement): String? =
   let (pyName = toPyName(k))
   if (u is Widgets.ConnectionCreator || u is Widgets.ConnectionSelector || u is Widgets.ConnectionRefInput)
     null
   else if (u is Widgets.BooleanInput)
-    "    \(pyName): bool = Field(default=\(if ((u as Widgets.BooleanInput).default) "True" else "False"), alias=\"{{\(k)}}\")"
+    fmtSubsField(pyName, "bool", "default=\(if ((u as Widgets.BooleanInput).default) "True" else "False")", k)
   else if (u is Widgets.Switcher)
-    "    \(pyName): bool = Field(default=\(if ((u as Widgets.Switcher).default) "True" else "False"), alias=\"{{\(k)}}\")"
+    fmtSubsField(pyName, "bool", "default=\(if ((u as Widgets.Switcher).default) "True" else "False")", k)
   else if (u is Widgets.NumericInput)
     let (d = (u as Widgets.NumericInput).default)
-    "    \(pyName): int = Field(default=\(if (d != null) d!!.toInt() else 0), alias=\"{{\(k)}}\")"
+    fmtSubsField(pyName, "int", "default=\(if (d != null) d!!.toInt() else 0)", k)
   else if (u is Widgets.Radio)
     let (radio = u as Widgets.Radio)
     let (vals = radio.possibleValues.keys.toList())
     if (!vals.isEmpty)
       let (litStr = (new Listing { for (v in vals) { "\"\(v)\"" } }).toList().join(", "))
       let (defVal = if (radio.default != null) radio.default!! else vals.first)
-      "    \(pyName): Literal[\(litStr)] = Field(default=\"\(defVal)\", alias=\"{{\(k)}}\")"
+      fmtSubsField(pyName, "Literal[\(litStr)]", "default=\"\(defVal)\"", k)
     else
-      "    \(pyName): str = Field(default=\"\(if (radio.default != null) radio.default!! else "")\", alias=\"{{\(k)}}\")"
+      fmtSubsField(pyName, "str", "default=\"\(if (radio.default != null) radio.default!! else "")\"", k)
   else if (u is Widgets.DropDown)
     let (dd = u as Widgets.DropDown)
     let (vals = dd.possibleValues.keys.toList())
     if (!vals.isEmpty && !dd.multiSelect)
       let (litStr = (new Listing { for (v in vals) { "\"\(v)\"" } }).toList().join(", "))
       let (defVal = if (dd.default != null) dd.default!! else vals.first)
-      "    \(pyName): Literal[\(litStr)] = Field(default=\"\(defVal)\", alias=\"{{\(k)}}\")"
+      fmtSubsField(pyName, "Literal[\(litStr)]", "default=\"\(defVal)\"", k)
     else
-      "    \(pyName): str = Field(default=\"\(if (dd.default != null) dd.default!! else "")\", alias=\"{{\(k)}}\")"
+      fmtSubsField(pyName, "str", "default=\"\(if (dd.default != null) dd.default!! else "")\"", k)
   else if (u is Widgets.ConditionalInput)
     let (ci = u as Widgets.ConditionalInput)
     if (ci.outputValueType == "object")
-      "    \(pyName): dict[str, Any] | None = Field(default=None, alias=\"{{\(k)}}\")"
+      fmtSubsField(pyName, "dict[str, Any] | None", "default=None", k)
     else if (ci.baseWidgetType == "radio" && ci.baseEnum != null && !ci.baseEnum!!.isEmpty)
       let (litStr = (new Listing { for (v in ci.baseEnum!!) { "\"\(v)\"" } }).toList().join(", "))
       let (defVal = if (ci.default != null) ci.default!!.toString() else ci.baseEnum!!.toList().first)
-      "    \(pyName): Literal[\(litStr)] = Field(default=\"\(defVal)\", alias=\"{{\(k)}}\")"
+      fmtSubsField(pyName, "Literal[\(litStr)]", "default=\"\(defVal)\"", k)
     else
-      "    \(pyName): str = Field(default=\"\(if (ci.default != null) ci.default!!.toString() else "")\", alias=\"{{\(k)}}\")"
+      fmtSubsField(pyName, "str", "default=\"\(if (ci.default != null) ci.default!!.toString() else "")\"", k)
   else if (u is Widgets.SqlTree || u is Widgets.NestedInput || u is Widgets.APITree ||
       u is Widgets.ApiTreeSelect || u is Widgets.DsnTreeMap || u is Widgets.AgentSelector)
-    "    \(pyName): dict[str, Any] | None = Field(default=None, alias=\"{{\(k)}}\")"
+    fmtSubsField(pyName, "dict[str, Any] | None", "default=None", k)
   else
     // TextInput, PasswordInput, CredentialInput, TextBoxInput, etc. → str
     let (defVal =
       if (u is Widgets.TextInput && (u as Widgets.TextInput).default != null)
         (u as Widgets.TextInput).default!!
       else "")
-    "    \(pyName): str = Field(default=\"\(defVal)\", alias=\"{{\(k)}}\")"
+    fmtSubsField(pyName, "str", "default=\"\(defVal)\"", k)
 
 local function generateE2EBasePy(): FileOutput = new FileOutput {
   local baseClass = e2eBaseClass()

--- a/contract-toolkit/tests/e2e_codegen_test.pkl
+++ b/contract-toolkit/tests/e2e_codegen_test.pkl
@@ -1,0 +1,572 @@
+amends "pkl:test"
+
+import "../src/App.pkl" as App
+import "../src/Connectors.pkl"
+import "../examples/full/app.pkl" as fullExampleApp
+
+// ── Fixture helpers ────────────────────────────────────────────────────────────
+
+// Minimal uiConfig used by fixtures that only need the base file (no custom subs).
+local minimalUiConfig = new App.UIConfig {
+  tasks {
+    ["Connection"] {
+      inputs {
+        ["connection"] = new App.ConnectionCreator { placeholderText = "Connection" }
+      }
+    }
+  }
+}
+
+// Non-SQL connector (API category) — uses BaseE2ETest / MustacheSubstitutions.
+local apiApp = (App) {
+  name = "my-api"
+  displayName = "My API App"
+  icon = "https://assets.atlan.com/assets/fullscreen-open.svg"
+  connector = Connectors.API
+  hasCredentialConfig = false
+  pipeline { publish = null }
+  uiConfig = minimalUiConfig
+}
+
+// SQL connector (database category) — uses SQLAppE2ETest / SQLMustacheSubstitutions.
+local postgresApp = (App) {
+  name = "pg-connector"
+  displayName = "Postgres Connector"
+  icon = "https://assets.atlan.com/assets/fullscreen-open.svg"
+  connector = Connectors.POSTGRES
+  hasCredentialConfig = false
+  pipeline { publish = null }
+  uiConfig = minimalUiConfig
+}
+
+// App with default connector (warehouse) — connection_category should be omitted.
+local warehouseApp = (App) {
+  name = "snowflake-connector"
+  displayName = "Snowflake Connector"
+  icon = "https://assets.atlan.com/assets/fullscreen-open.svg"
+  connector = Connectors.SNOWFLAKE
+  hasCredentialConfig = false
+  pipeline { publish = null }
+  uiConfig = minimalUiConfig
+}
+
+// App where connector.value == name — connection_type should be omitted.
+local selfNamedApp = (App) {
+  name = "snowflake"
+  displayName = "Snowflake"
+  icon = "https://assets.atlan.com/assets/fullscreen-open.svg"
+  connector = Connectors.SNOWFLAKE
+  hasCredentialConfig = false
+  pipeline { publish = null }
+  uiConfig = minimalUiConfig
+}
+
+// App with custom argo/service overrides.
+local overrideApp = (App) {
+  name = "my-connector"
+  displayName = "My Connector"
+  icon = "https://assets.atlan.com/assets/fullscreen-open.svg"
+  hasCredentialConfig = false
+  argoPackageName = "@custom/scope"
+  argoTemplateName = "custom-template"
+  appServiceUrl = "http://custom.svc.local"
+  pipeline { publish = null }
+  uiConfig = minimalUiConfig
+}
+
+// App with diverse widget types for getSubsFieldLine coverage.
+local widgetApp = (App) {
+  name = "widget-test"
+  displayName = "Widget Test"
+  icon = "https://assets.atlan.com/assets/fullscreen-open.svg"
+  connector = Connectors.POSTGRES
+  hasCredentialConfig = false
+  pipeline { publish = null }
+  uiConfig = new App.UIConfig {
+    tasks {
+      ["Configuration"] {
+        inputs {
+          ["bool_field"] = new App.BooleanInput { title = "Bool"; default = true }
+          ["num_field"] = new App.NumericInput { title = "Num"; default = 42 }
+          ["radio_field"] = new App.Radio {
+            title = "Radio"
+            possibleValues { ["alpha"] = "Alpha"; ["beta"] = "Beta" }
+            default = "alpha"
+          }
+          ["dropdown_field"] = new App.DropDown {
+            title = "DropDown"
+            possibleValues { ["x"] = "X"; ["y"] = "Y"; ["z"] = "Z" }
+            default = "x"
+          }
+          ["multi_field"] = new App.DropDown {
+            title = "Multi"
+            multiSelect = true
+            possibleValues { ["p"] = "P"; ["q"] = "Q" }
+          }
+          ["tree_field"] = new App.SqlTree {
+            title = "Tree"
+            sqlQuery = "show schemas"
+            credentialType = "test-cred"
+          }
+          ["text_field"] = new App.TextInput { title = "Text"; default = "hello" }
+          ["connection"] = new App.ConnectionCreator { placeholderText = "Conn" }
+        }
+      }
+    }
+  }
+}
+
+// App where all uiConfig fields are in the SQL skip-set → substitutions file omitted.
+local allSkippedApp = (App) {
+  name = "skipped-test"
+  displayName = "Skipped Test"
+  icon = "https://assets.atlan.com/assets/fullscreen-open.svg"
+  connector = Connectors.POSTGRES
+  hasCredentialConfig = false
+  pipeline { publish = null }
+  uiConfig = new App.UIConfig {
+    tasks {
+      ["Connection"] {
+        inputs {
+          ["connection"] = new App.ConnectionCreator { placeholderText = "Conn" }
+          ["credential-guid"] = new App.CredentialInput { credType = "cred" }
+          ["include_filter"] = new App.TextInput { title = "Include" }
+        }
+      }
+    }
+  }
+}
+
+// Credential app: single auth option.
+local singleAuthApp = (App) {
+  name = "single-auth"
+  displayName = "Single Auth"
+  icon = "https://assets.atlan.com/assets/fullscreen-open.svg"
+  connector = Connectors.POSTGRES
+  hasCredentialConfig = true
+  credentialConnectorType = "rest"
+  credentialCommonFields {
+    new App.FieldSpec { name = "host"; displayName = "Host" }
+    new App.FieldSpec { name = "port"; fieldType = "number"; displayName = "Port"; defaultValue = "5432" }
+  }
+  credentialAuthOptions {
+    ["basic"] = new App.AuthOption {
+      label = "Basic"
+      fields {
+        new App.FieldSpec { name = "username"; displayName = "Username" }
+        new App.FieldSpec { name = "password"; sensitive = true; displayName = "Password" }
+      }
+    }
+  }
+  pipeline { publish = null }
+  uiConfig = minimalUiConfig
+}
+
+// Credential app: two auth options — auth-specific fields get sentinel defaults.
+local multiAuthApp = (App) {
+  name = "multi-auth"
+  displayName = "Multi Auth"
+  icon = "https://assets.atlan.com/assets/fullscreen-open.svg"
+  connector = Connectors.POSTGRES
+  hasCredentialConfig = true
+  credentialConnectorType = "rest"
+  credentialCommonFields {
+    new App.FieldSpec { name = "host"; displayName = "Host" }
+  }
+  credentialAuthOptions {
+    ["basic"] = new App.AuthOption {
+      label = "Basic"
+      fields {
+        new App.FieldSpec { name = "username"; displayName = "Username" }
+        new App.FieldSpec { name = "password"; sensitive = true; displayName = "Password" }
+      }
+    }
+    ["token"] = new App.AuthOption {
+      label = "Token"
+      fields {
+        new App.FieldSpec { name = "token"; sensitive = true; displayName = "Token" }
+      }
+    }
+  }
+  pipeline { publish = null }
+  uiConfig = minimalUiConfig
+}
+
+// Credential app: uses credentialAuthDefault to override auth_type default.
+local authDefaultApp = (App) {
+  name = "auth-default-test"
+  displayName = "Auth Default Test"
+  icon = "https://assets.atlan.com/assets/fullscreen-open.svg"
+  connector = Connectors.POSTGRES
+  hasCredentialConfig = true
+  credentialConnectorType = "rest"
+  credentialAuthDefault = "token"
+  credentialCommonFields {
+    new App.FieldSpec { name = "host"; displayName = "Host" }
+  }
+  credentialAuthOptions {
+    ["basic"] = new App.AuthOption {
+      label = "Basic"
+      fields {
+        new App.FieldSpec { name = "username"; displayName = "Username" }
+      }
+    }
+    ["token"] = new App.AuthOption {
+      label = "Token"
+      fields {
+        new App.FieldSpec { name = "token"; sensitive = true; displayName = "Token" }
+      }
+    }
+  }
+  pipeline { publish = null }
+  uiConfig = minimalUiConfig
+}
+
+// App with no credential config — _e2e_credential.py should not be emitted.
+// noCredApp has no uiConfig to verify _e2e_base.py is emitted regardless.
+local noCredApp = (App) {
+  name = "no-cred"
+  displayName = "No Cred"
+  icon = "https://assets.atlan.com/assets/fullscreen-open.svg"
+  hasCredentialConfig = false
+  pipeline { publish = null }
+}
+
+// Credential app with extraFields in an auth option — triggers CredentialBodyExtra emission.
+local extraFieldsApp = (App) {
+  name = "extra-fields"
+  displayName = "Extra Fields"
+  icon = "https://assets.atlan.com/assets/fullscreen-open.svg"
+  connector = Connectors.POSTGRES
+  hasCredentialConfig = true
+  credentialConnectorType = "rest"
+  credentialCommonFields {
+    new App.FieldSpec { name = "host"; displayName = "Host" }
+  }
+  credentialAuthOptions {
+    ["basic"] = new App.AuthOption {
+      label = "Basic"
+      fields {
+        new App.FieldSpec { name = "username"; displayName = "Username" }
+        new App.FieldSpec { name = "password"; sensitive = true; displayName = "Password" }
+      }
+      extraFields {
+        new App.FieldSpec { name = "schema"; displayName = "Schema" }
+        new App.FieldSpec { name = "timeout"; fieldType = "number"; displayName = "Timeout"; defaultValue = "30" }
+      }
+    }
+  }
+  pipeline { publish = null }
+  uiConfig = minimalUiConfig
+}
+
+
+// ── Capture output text ────────────────────────────────────────────────────────
+
+local apiBase: String = apiApp.output.files["app/generated/_e2e_base.py"].text
+local postgresBase: String = postgresApp.output.files["app/generated/_e2e_base.py"].text
+local warehouseBase: String = warehouseApp.output.files["app/generated/_e2e_base.py"].text
+local selfNamedBase: String = selfNamedApp.output.files["app/generated/_e2e_base.py"].text
+local overrideBase: String = overrideApp.output.files["app/generated/_e2e_base.py"].text
+local widgetSubs: String = widgetApp.output.files["app/generated/_e2e_substitutions.py"].text
+local singleAuthCred: String = singleAuthApp.output.files["app/generated/_e2e_credential.py"].text
+local multiAuthCred: String = multiAuthApp.output.files["app/generated/_e2e_credential.py"].text
+local authDefaultCred: String = authDefaultApp.output.files["app/generated/_e2e_credential.py"].text
+local fullCredPy: String = fullExampleApp.output.files["app/generated/_e2e_credential.py"].text
+local fullSubsPy: String = fullExampleApp.output.files["app/generated/_e2e_substitutions.py"].text
+local extraFieldsCred: String = extraFieldsApp.output.files["app/generated/_e2e_credential.py"].text
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+facts {
+
+  // ── _e2e_base.py: banner and structure ──────────────────────────────────────
+
+  ["_e2e_base.py emits DO-NOT-EDIT banner"] {
+    apiBase.contains("# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.")
+    apiBase.contains("# Regenerate with: pkl eval -m . contract/app.pkl")
+  }
+
+  ["_e2e_base.py always emitted even without connector"] {
+    noCredApp.output.files.containsKey("app/generated/_e2e_base.py")
+  }
+
+  // ── _e2e_base.py: base class routing ────────────────────────────────────────
+
+  ["Non-SQL connector uses BaseE2ETest"] {
+    apiBase.contains("from application_sdk.testing.e2e import BaseE2ETest")
+    apiBase.contains("class MyApiGeneratedE2EBase(BaseE2ETest):")
+  }
+
+  ["SQL connector (database) uses SQLAppE2ETest"] {
+    postgresBase.contains("from application_sdk.testing.e2e import SQLAppE2ETest")
+    postgresBase.contains("class PgConnectorGeneratedE2EBase(SQLAppE2ETest):")
+  }
+
+  // ── _e2e_base.py: required harness attributes ────────────────────────────────
+
+  ["_e2e_base.py emits connector_short_name from name"] {
+    apiBase.contains("connector_short_name = \"my-api\"")
+    postgresBase.contains("connector_short_name = \"pg-connector\"")
+  }
+
+  ["_e2e_base.py emits default argo_package_name from name"] {
+    apiBase.contains("argo_package_name = \"@atlan/my-api\"")
+  }
+
+  ["_e2e_base.py emits default argo_template_name from name"] {
+    apiBase.contains("argo_template_name = \"atlan-my-api\"")
+  }
+
+  ["_e2e_base.py emits default app_service_url from name"] {
+    apiBase.contains("app_service_url = \"http://my-api.my-api-app.svc.cluster.local\"")
+  }
+
+  ["_e2e_base.py respects overridden argo/service fields"] {
+    overrideBase.contains("argo_package_name = \"@custom/scope\"")
+    overrideBase.contains("argo_template_name = \"custom-template\"")
+    overrideBase.contains("app_service_url = \"http://custom.svc.local\"")
+  }
+
+  // ── _e2e_base.py: connection_type and connection_category emission ────────────
+
+  ["connection_type emitted when connector.value != name"] {
+    postgresBase.contains("connection_type = \"postgres\"")
+  }
+
+  ["connection_type omitted when connector.value == name"] {
+    !selfNamedBase.contains("connection_type =")
+  }
+
+  ["connection_category emitted when category is not warehouse"] {
+    // API has category "API", postgres has "database" — both should emit
+    apiBase.contains("connection_category = \"API\"")
+    postgresBase.contains("connection_category = \"database\"")
+  }
+
+  ["connection_category omitted when category is warehouse (SDK default)"] {
+    !warehouseBase.contains("connection_category =")
+  }
+
+  // ── _e2e_base.py: pascalCase name → class name ───────────────────────────────
+
+  ["pascalCase converts hyphenated name to PascalCase class name"] {
+    postgresBase.contains("PgConnectorGeneratedE2EBase")
+  }
+
+  ["pascalCase handles names with dots and other non-alphanumeric chars"] {
+    // overrideApp name = "my-connector" → MyConnector
+    overrideBase.contains("MyConnectorGeneratedE2EBase")
+  }
+
+  // ── _e2e_substitutions.py: not emitted when no custom fields ─────────────────
+
+  ["_e2e_substitutions.py omitted when all uiConfig fields are in parent skip-set"] {
+    !allSkippedApp.output.files.containsKey("app/generated/_e2e_substitutions.py")
+  }
+
+  ["_e2e_substitutions.py omitted when uiConfig is null"] {
+    !noCredApp.output.files.containsKey("app/generated/_e2e_substitutions.py")
+  }
+
+  // ── _e2e_substitutions.py: parent class routing ──────────────────────────────
+
+  ["SQL connector substitutions extend SQLMustacheSubstitutions"] {
+    widgetSubs.contains("from application_sdk.testing.e2e.substitutions import SQLMustacheSubstitutions")
+    widgetSubs.contains("class WidgetTestMustacheSubstitutions(SQLMustacheSubstitutions):")
+  }
+
+  ["Non-SQL connector substitutions extend MustacheSubstitutions"] {
+    local apiWidgetApp = (App) {
+      name = "api-widget"
+      displayName = "API Widget"
+      icon = "https://assets.atlan.com/assets/fullscreen-open.svg"
+      connector = Connectors.API
+      hasCredentialConfig = false
+      pipeline { publish = null }
+      uiConfig = new App.UIConfig {
+        tasks {
+          ["Configuration"] {
+            inputs {
+              ["custom_field"] = new App.TextInput { title = "Custom" }
+            }
+          }
+        }
+      }
+    }
+    local subs = apiWidgetApp.output.files["app/generated/_e2e_substitutions.py"].text
+    subs.contains("from application_sdk.testing.e2e.substitutions import MustacheSubstitutions")
+    subs.contains("class ApiWidgetMustacheSubstitutions(MustacheSubstitutions):")
+  }
+
+  // ── _e2e_substitutions.py: widget-type dispatch ──────────────────────────────
+
+  ["BooleanInput with default=true emits bool field with True default"] {
+    widgetSubs.contains("bool_field: bool = Field(default=True, alias=\"{{bool_field}}\")")
+  }
+
+  ["NumericInput emits int field with numeric default"] {
+    widgetSubs.contains("num_field: int = Field(default=42, alias=\"{{num_field}}\")")
+  }
+
+  ["Radio with possibleValues emits Literal type"] {
+    // 90 chars → fmtSubsField wraps to multi-line form
+    widgetSubs.contains("radio_field: Literal[\"alpha\", \"beta\"] = Field(\n        default=\"alpha\",\n        alias=\"{{radio_field}}\",\n    )")
+  }
+
+  ["DropDown (single-select) with possibleValues emits Literal type"] {
+    // 90 chars → fmtSubsField wraps to multi-line form
+    widgetSubs.contains("dropdown_field: Literal[\"x\", \"y\", \"z\"] = Field(\n        default=\"x\",\n        alias=\"{{dropdown_field}}\",\n    )")
+  }
+
+  ["DropDown with multiSelect=true emits str (not Literal)"] {
+    widgetSubs.contains("multi_field: str = Field(default=\"\", alias=\"{{multi_field}}\")")
+    !widgetSubs.contains("Literal[\"p\",")
+  }
+
+  ["SqlTree emits dict[str, Any] | None"] {
+    widgetSubs.contains("tree_field: dict[str, Any] | None = Field(default=None, alias=\"{{tree_field}}\")")
+  }
+
+  ["TextInput with default emits str field with that default"] {
+    widgetSubs.contains("text_field: str = Field(default=\"hello\", alias=\"{{text_field}}\")")
+  }
+
+  ["ConnectionCreator is skipped in substitutions"] {
+    !widgetSubs.contains("connection:")
+    !widgetSubs.contains("alias=\"{{connection}}\"")
+  }
+
+  ["SQL parent-class fields (include_filter etc.) are skipped for SQL connector"] {
+    // allSkippedApp has include_filter but is SQL → should be skipped entirely
+    !allSkippedApp.output.files.containsKey("app/generated/_e2e_substitutions.py")
+  }
+
+  ["Substitutions imports Literal and Any only when used"] {
+    widgetSubs.contains("from typing import Any, Literal")
+  }
+
+  ["Substitutions omits typing import when no Literal/Any fields"] {
+    local strOnlyApp = (App) {
+      name = "str-only"
+      displayName = "Str Only"
+      icon = "https://assets.atlan.com/assets/fullscreen-open.svg"
+      connector = Connectors.API
+      hasCredentialConfig = false
+      pipeline { publish = null }
+      uiConfig = new App.UIConfig {
+        tasks {
+          ["Configuration"] {
+            inputs {
+              ["my_text"] = new App.TextInput { title = "Text" }
+            }
+          }
+        }
+      }
+    }
+    local subs = strOnlyApp.output.files["app/generated/_e2e_substitutions.py"].text
+    !subs.contains("from typing import")
+  }
+
+  // ── _e2e_substitutions.py: alias preserves original key casing ────────────────
+
+  ["Substitution alias preserves original kebab-case key"] {
+    // widgetApp has bool_field (underscore) — alias should reflect the original key
+    widgetSubs.contains("alias=\"{{bool_field}}\"")
+  }
+
+  // ── _e2e_credential.py: not emitted without credential config ─────────────────
+
+  ["_e2e_credential.py not emitted when hasCredentialConfig=false"] {
+    !noCredApp.output.files.containsKey("app/generated/_e2e_credential.py")
+  }
+
+  // ── _e2e_credential.py: banner, imports, class structure ─────────────────────
+
+  ["_e2e_credential.py emits banner and CredentialBody import"] {
+    singleAuthCred.contains("# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.")
+    singleAuthCred.contains("from application_sdk.testing.e2e.credential import CredentialBody")
+  }
+
+  ["_e2e_credential.py emits correct class name"] {
+    singleAuthCred.contains("class SingleAuthCredentialBody(CredentialBody):")
+  }
+
+  // ── _e2e_credential.py: synthetic fields ─────────────────────────────────────
+
+  ["Credential body emits synthetic name field"] {
+    singleAuthCred.contains("name: str = Field(alias=\"name\")")
+  }
+
+  ["Credential body emits auth_type with first auth key as default"] {
+    singleAuthCred.contains("auth_type: str = Field(default=\"basic\", alias=\"authType\")")
+  }
+
+  ["credentialAuthDefault overrides first-key default for auth_type"] {
+    authDefaultCred.contains("auth_type: str = Field(default=\"token\", alias=\"authType\")")
+  }
+
+  // ── _e2e_credential.py: common fields ────────────────────────────────────────
+
+  ["Common FieldSpec without default emits required field (no default=)"] {
+    singleAuthCred.contains("host: str = Field(alias=\"host\")")
+  }
+
+  ["Common numeric FieldSpec with defaultValue emits int field"] {
+    singleAuthCred.contains("port: int = Field(default=5432, alias=\"port\")")
+  }
+
+  // ── _e2e_credential.py: auth-specific fields get sentinel defaults ────────────
+
+  ["Single auth option: fields with no defaultValue get empty sentinel"] {
+    singleAuthCred.contains("username: str = Field(default=\"\", alias=\"username\")")
+    singleAuthCred.contains("password: str = Field(default=\"\", alias=\"password\")")
+  }
+
+  ["Multi-auth: fields present in only one option get empty sentinel"] {
+    // username/password only in basic, token only in token
+    multiAuthCred.contains("username: str = Field(default=\"\", alias=\"username\")")
+    multiAuthCred.contains("password: str = Field(default=\"\", alias=\"password\")")
+    multiAuthCred.contains("token: str = Field(default=\"\", alias=\"token\")")
+  }
+
+  ["Multi-auth: all auth-specific fields appear in single unified class body"] {
+    multiAuthCred.contains("class MultiAuthCredentialBody(CredentialBody):")
+    // All three auth fields in one class
+    multiAuthCred.contains("username:")
+    multiAuthCred.contains("password:")
+    multiAuthCred.contains("token:")
+  }
+
+  // ── _e2e_credential.py: Extra model frozen ───────────────────────────────────
+
+  ["CredentialBodyExtra uses frozen=True in ConfigDict"] {
+    // extraFieldsApp has extraFields → triggers nested Extra model generation
+    extraFieldsCred.contains("ConfigDict(frozen=True, populate_by_name=True, serialize_by_alias=True)")
+  }
+
+  ["CredentialBodyExtra contains extraFields as typed fields"] {
+    extraFieldsCred.contains("class ExtraFieldsCredentialBodyExtra(BaseModel):")
+    extraFieldsCred.contains("schema: str")
+    extraFieldsCred.contains("timeout: int = Field(default=30")
+  }
+
+  // ── _e2e_credential.py: ConditionalFieldSpec becomes str | None ───────────────
+
+  ["ConditionalFieldSpec in URL group emits str | None field"] {
+    fullCredPy.contains("token_audience: str | None = Field(default=None, alias=\"token_audience\")")
+  }
+
+  // ── fmtSubsField: line-length wrapping ───────────────────────────────────────
+
+  ["Long Literal field is wrapped to multi-line (>88 chars)"] {
+    // output_format: Literal["parquet", "json"] + alias exceeds 88 chars
+    fullSubsPy.contains("output_format: Literal[\"parquet\", \"json\"] = Field(\n        default=\"parquet\",\n        alias=\"{{output_format}}\",\n    )")
+  }
+
+  ["Short field stays single-line (≤88 chars)"] {
+    // max_results: int = Field(default=500, alias="{{max_results}}") fits in 88 chars
+    fullSubsPy.contains("max_results: int = Field(default=500, alias=\"{{max_results}}\")")
+  }
+
+}


### PR DESCRIPTION
## Summary

- Adds three generator functions to `App.pkl` so `pkl eval -m . contract/app.pkl` now produces the e2e test harness files that were previously hand-authored (with misleading "Generated from contract/app.pkl" banners that weren't true)
- Adds three overridable contract fields — `argoPackageName`, `argoTemplateName`, `appServiceUrl` — with defaults derived from `name`; 95% of connectors never override
- Extends `scripts/test-sdk-import.py` to import-test all generated `_e2e_*.py` files (was only testing `_input.py`)
- Updates docstrings in `testing/e2e/credential.py` and `testing/e2e/substitutions.py` to reference the actual codegen functions instead of the never-created `E2EOutput.pkl`

## What's generated

| File | Emitted when |
|---|---|
| `_e2e_base.py` | Always |
| `_e2e_credential.py` | `hasCredentialConfig = true` and at least one auth option defined |
| `_e2e_substitutions.py` | `uiConfig` has fields beyond what the parent class already provides |

**Base class routing:** warehouse/database/lake/queryengine connectors → `SQLAppE2ETest` / `SQLMustacheSubstitutions`; others → `BaseE2ETest` / `MustacheSubstitutions`.

**Widget-type-aware substitution typing:** `Literal[...]` for bounded Radio/DropDown, `bool` for BooleanInput, `int` for NumericInput, `dict[str, Any] | None` for SqlTree/NestedInput — so `import_type="HTTP"` against the OpenAPI connector (valid values: `"URL"`, `"CLOUD"`) fails at type-check time, not at runtime.

**Credential body:** all auth options unioned into one model; auth-specific-only fields get empty-string defaults; `ConditionalFieldSpec`s become `str | None`.

## Verification

```
bash scripts/regenerate-all.sh   # all 7 examples regenerate cleanly
bash scripts/check-invariants.sh # all invariant checks pass
pkl test tests/*.pkl             # 78/78 tests pass
uv run python scripts/test-sdk-import.py  # 25/25 files import (8 _input.py + 17 _e2e_*.py)
```

## Follow-up (separate PRs in consumer repos, after toolkit version bump)

- `atlan-openapi-app`: regenerate to replace `AtlanConnectorType.API.value` indirection with `connection_type = "api"`
- `atlan-mysql-app`: regenerate to gain `iam_user`/`iam_role` union'd fields and the missing banner header

🤖 Generated with [Claude Code](https://claude.com/claude-code)