### PR TITLE
ci: repair toolkit skill YAML frontmatter

### DIFF
--- a/.agents/skills/toolkit-feature-workflow/SKILL.md
+++ b/.agents/skills/toolkit-feature-workflow/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: toolkit-feature-workflow
-description: Use when reviewing an application-sdk PR that changes contract-toolkit behavior, generated contract artifacts, toolkit examples, or toolkit docs. Runs toolkit-only PR review mode: classify affected generated surfaces, perform mandatory private downstream compatibility validation through Mothership/Rover, and post sanitized review findings without exposing internal consumer repo paths.
+description: >-
+  Use when reviewing an application-sdk PR that changes contract-toolkit behavior,
+  generated contract artifacts, toolkit examples, or toolkit docs. Runs
+  toolkit-only PR review mode: classify affected generated surfaces, perform
+  mandatory private downstream compatibility validation through Mothership/Rover,
+  and post sanitized review findings without exposing internal consumer repo
+  paths.
 ---
 
 # Toolkit PR Review Workflow

--- a/.claude/skills/toolkit-feature-workflow/SKILL.md
+++ b/.claude/skills/toolkit-feature-workflow/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: toolkit-feature-workflow
-description: Use when reviewing an application-sdk PR that changes contract-toolkit behavior, generated contract artifacts, toolkit examples, or toolkit docs. Runs toolkit-only PR review mode: classify affected generated surfaces, perform mandatory private downstream compatibility validation through Mothership/Rover, and post sanitized review findings without exposing internal consumer repo paths.
+description: >-
+  Use when reviewing an application-sdk PR that changes contract-toolkit behavior,
+  generated contract artifacts, toolkit examples, or toolkit docs. Runs
+  toolkit-only PR review mode: classify affected generated surfaces, perform
+  mandatory private downstream compatibility validation through Mothership/Rover,
+  and post sanitized review findings without exposing internal consumer repo
+  paths.
 ---
 
 # Toolkit PR Review Workflow


### PR DESCRIPTION
## Summary
- convert toolkit-feature-workflow skill descriptions to folded YAML in both mirrored skill copies
- preserve the description text while avoiding the unquoted colon parse error

## Validation
- ruby YAML.safe_load frontmatter check for both files
- diff confirmed .agents and .claude copies match
- uv run pre-commit run --files .agents/skills/toolkit-feature-workflow/SKILL.md .claude/skills/toolkit-feature-workflow/SKILL.md