### PR TITLE
docs: align docs and skills with two-store storage architecture (ADR-0014)

### DIFF
--- a/.claude/skills/add-entrypoint/SKILL.md
+++ b/.claude/skills/add-entrypoint/SKILL.md
@@ -85,7 +85,7 @@ class MyConnector(App):
         # Omitting this call is a silent failure: the DAG succeeds but Atlan's
         # publish app finds nothing in its bucket. See docs/concepts/file-reference.md.
         #
-        # await self.upload(UploadInput(local_path=out.output_path, tier=StorageTier.RETAINED))
+        # await self.upload(UploadInput(local_path=out.output_path))  # RETAINED is the default tier
         return {EntrypointName}Output(record_count=out.count)
 
     @task(timeout_seconds=3600, auto_heartbeat_seconds=30)

--- a/.claude/skills/add-entrypoint/SKILL.md
+++ b/.claude/skills/add-entrypoint/SKILL.md
@@ -78,6 +78,14 @@ class MyConnector(App):
         out = await self.{fetch_task_name}(
             {FetchTask}Input(connection_id=input.connection_id, ...)
         )
+        # If this entrypoint hands artifacts to a downstream Atlan system app
+        # (publish, lineage, quality), call App.upload() here — not from inside @task.
+        # The @task FileReference interceptor writes only to the customer-owned
+        # objectstore; App.upload() routes to atlan-objectstore in SDR deployments.
+        # Omitting this call is a silent failure: the DAG succeeds but Atlan's
+        # publish app finds nothing in its bucket. See docs/concepts/file-reference.md.
+        #
+        # await self.upload(UploadInput(local_path=out.output_path, tier=StorageTier.RETAINED))
         return {EntrypointName}Output(record_count=out.count)
 
     @task(timeout_seconds=3600, auto_heartbeat_seconds=30)

--- a/.claude/skills/capability-manifest/references/format-spec.md
+++ b/.claude/skills/capability-manifest/references/format-spec.md
@@ -122,11 +122,14 @@ Strongly-typed Inputs/Outputs for SDK methods. All inherit from
 #### `UploadInput`
 
 - **Import:** `from application_sdk.contracts import UploadInput`
-- **Summary:** Input contract for ObjectStore.upload.
+- **Summary:** Input contract for `App.upload()` — explicit app-to-app hand-off to Atlan's upstream store.
 - **Fields:**
-  - `source: str` — local path
-  - `key: str` — destination object-store key
-  - `tier: StorageTier` `= StorageTier.HOT` — storage tier
+  - `local_path: str` — local filesystem path to the file to upload
+  - `tier: StorageTier` `= StorageTier.RETAINED` — controls destination prefix and cleanup policy
+  - `storage_path: str | None` `= None` — override the auto-generated destination key
+  - `storage_subdir: str | None` `= None` — subdirectory appended under the run prefix
+  - `skip_if_exists: bool` `= False` — skip when remote SHA-256 already matches
+  - `raise_on_empty: bool` `= False` — raise if the local path has no files to upload
 - **Defined in:** `application_sdk/contracts/storage.py`
 ```
 

--- a/.claude/skills/make-contract/SKILL.md
+++ b/.claude/skills/make-contract/SKILL.md
@@ -180,6 +180,12 @@ Rules for stable contracts:
 
 ## Authoring Rules
 
+> **FileReference and App.upload():** If your contract carries a `FileReference` that must
+> reach a downstream Atlan system app (publish, lineage, quality), the connector must call
+> `App.upload()` explicitly from `run()` — the task-to-task activity interceptor only writes
+> to the customer-owned `objectstore`. See
+> [ADR-0014](../../docs/adr/0014-two-store-storage-architecture.md).
+
 Prefer typed toolkit APIs over raw JSON:
 
 - `NativeApp.pkl` for standard single-entrypoint contracts.

--- a/.claude/skills/scaffold-app/SKILL.md
+++ b/.claude/skills/scaffold-app/SKILL.md
@@ -157,7 +157,36 @@ class {Name}App(SqlMetadataExtractor):
         return FetchDatabasesOutput(chunk_count=1, total_record_count=10)
 ```
 
-For REST connectors, subclass `App` directly with custom `@task` methods.
+The `SqlMetadataExtractor` base `run()` already calls `App.upload()` to hand off artifacts to Atlan. Do not override `run()` without also calling `super().run(input)` or explicitly calling `await self.upload(...)` — omitting the upload is a silent failure in SDR deployments.
+
+For REST connectors, subclass `App` directly with custom `@task` methods and an explicit `App.upload()` call in `run()`:
+
+```python
+from application_sdk.app import App, task
+from application_sdk.contracts import UploadInput, StorageTier
+
+class {Name}App(App):
+    @task(timeout_seconds=3600)
+    async def fetch_entities(self, input: {Name}Input) -> {Name}Output:
+        # ... fetch and write results to input.output_path ...
+        return {Name}Output(output_path=input.output_path, record_count=count)
+
+    async def run(self, input: {Name}Input) -> {Name}Output:
+        fetch_out = await self.fetch_entities(input)
+
+        # Required: push output to Atlan's upstream store (atlan-objectstore in SDR)
+        # so the publish app can index it. The activity interceptor only writes
+        # FileReferences to the customer-owned objectstore. Omitting this call
+        # produces a silent failure in SDR — the DAG succeeds but nothing is published.
+        # See docs/concepts/file-reference.md and ADR-0014.
+        await self.upload(
+            UploadInput(
+                local_path=fetch_out.output_path,
+                tier=StorageTier.RETAINED,
+            )
+        )
+        return fetch_out
+```
 
 ### 8. Generate `app/clients.py` (SQL only)
 

--- a/.claude/skills/scaffold-app/SKILL.md
+++ b/.claude/skills/scaffold-app/SKILL.md
@@ -163,7 +163,7 @@ For REST connectors, subclass `App` directly with custom `@task` methods and an 
 
 ```python
 from application_sdk.app import App, task
-from application_sdk.contracts import UploadInput, StorageTier
+from application_sdk.contracts import UploadInput
 
 class {Name}App(App):
     @task(timeout_seconds=3600)
@@ -179,12 +179,7 @@ class {Name}App(App):
         # FileReferences to the customer-owned objectstore. Omitting this call
         # produces a silent failure in SDR — the DAG succeeds but nothing is published.
         # See docs/concepts/file-reference.md and ADR-0014.
-        await self.upload(
-            UploadInput(
-                local_path=fetch_out.output_path,
-                tier=StorageTier.RETAINED,
-            )
-        )
+        await self.upload(UploadInput(local_path=fetch_out.output_path))
         return fetch_out
 ```
 

--- a/.claude/skills/upgrade-v3/SKILL.md
+++ b/.claude/skills/upgrade-v3/SKILL.md
@@ -905,7 +905,7 @@ async def fetch_tables(self, input: FetchTablesInput) -> FetchTablesOutput:
 The task names, input/output contracts, and write helper differ per connector type; the `FileReference` shape is the same for all. Downstream tasks accept `FileReference` on their typed input and read via `input.tables_file.local_path`. As the final app step prior to handing off to the Publish (or other) system app, explicitly call `self.upload()` from `run()`:
 
 ```python
-await self.upload(UploadInput(local_path=output_file_path, tier=StorageTier.RETAINED))
+await self.upload(UploadInput(local_path=output_file_path))  # RETAINED is the default tier
 ```
 
 **StorageTier choices** for `UploadInput`:

--- a/.claude/skills/upgrade-v3/SKILL.md
+++ b/.claude/skills/upgrade-v3/SKILL.md
@@ -883,6 +883,13 @@ If you find yourself reaching for threads in a hot loop, reconsider — fully-as
 
 ### `self.upload()` + `FileReference` — never hand-roll uploads
 
+**Two-store architecture.** The SDK has two distinct object stores:
+
+- **`objectstore`** (Dapr component, customer-owned) — the **deployment store** (`infra.storage`). The `FileReference` activity interceptor auto-uploads task outputs here. Task-to-task only.
+- **`atlan-objectstore`** (Dapr component, Atlan-owned) — the **upstream store** (`infra.upstream_storage`). Only present in SDR deployments. This is where Atlan system apps (publish, lineage, quality) look for artifacts. `App.upload()` routes here automatically when the component is bound; falls back to `objectstore` in local dev.
+
+**Silent-failure rule.** If a connector returns a `FileReference` from a `@task` but never calls `App.upload()` from `run()`, the DAG completes successfully but the publish app finds nothing in Atlan's bucket. The Temporal UI shows no error. Always call `App.upload()` from `run()` as the final publish step.
+
 Each fetch task writes to a local file and returns a typed `FileReference` on its output. For example, in a SQL connector:
 
 ```python
@@ -895,13 +902,21 @@ async def fetch_tables(self, input: FetchTablesInput) -> FetchTablesOutput:
     )
 ```
 
-The task names, input/output contracts, and write helper differ per connector type; the `FileReference` shape is the same for all. Downstream tasks accept `FileReference` on their typed input and read via `input.tables_file.local_path`. As the final app step prior to handing off to the Publish (or other) system app, explicitly call `self.upload()` on the final output:
+The task names, input/output contracts, and write helper differ per connector type; the `FileReference` shape is the same for all. Downstream tasks accept `FileReference` on their typed input and read via `input.tables_file.local_path`. As the final app step prior to handing off to the Publish (or other) system app, explicitly call `self.upload()` from `run()`:
 
 ```python
-await self.upload(UploadInput(local_path=output_file_path, storage_path=storage_path))
+await self.upload(UploadInput(local_path=output_file_path, tier=StorageTier.RETAINED))
 ```
 
-Note that this is NOT necessary inside each task — task-to-task uploading/downloading of files within the same app is handled _automatically_ purely by virtue of a `FileReference` being included in the Output of a task (automatically uploaded, if not already in the object store) or the Input of a task (automatically downloaded, if not already present in the worker).
+**StorageTier choices** for `UploadInput`:
+
+| Tier | Prefix | Cleanup |
+|------|--------|---------|
+| `StorageTier.TRANSIENT` | `file_refs/{uuid}/` | Auto-deleted after run |
+| `StorageTier.RETAINED` | `artifacts/apps/{app}/workflows/{wf}/{run}/` | Kept; default for published artifacts |
+| `StorageTier.PERSISTENT` | `persistent-artifacts/apps/{app}/` | Never deleted; use for long-term state |
+
+Note that `App.upload()` is NOT necessary inside each `@task` — task-to-task uploading/downloading of files within the same app is handled _automatically_ purely by virtue of a `FileReference` being included in the Output of a task (automatically uploaded to `objectstore`, if not already there) or the Input of a task (automatically downloaded, if not already present on the worker).
 
 **Selective materialization with `Lazy()`:** If a task declares a `FileReference` input field it doesn't always need (e.g. a heavy artifact only read under certain conditions), mark it `Lazy` to skip the automatic pre-download:
 
@@ -921,7 +936,7 @@ Call `await fetch(ref)` from `application_sdk.storage.reference` inside the task
 Reasons every connector must use this shape:
 
 - `self.upload()` is an SDK `@task` with a dedicated retry policy and activity-level recording. A worker swap mid-run will not re-upload; a hand-rolled `obstore.put` will.
-- The "shared `output_path` directory" + `upload_to_atlan()` scan-the-directory pattern from v2 is gone. Each task owns its file.
+- The "shared `output_path` directory" + `upload_to_atlan()` (v2 deprecated) scan-the-directory pattern is gone. Each task owns its file.
 - AE downstream nodes (`qi`, `lineage-app`, `publish`) JSONPath against `FileReference` outputs, not directory prefixes.
 
 **Forbidden:** `obstore.*` calls in app code, custom `JsonFileWriter` / `ParquetFileWriter` instantiation, calling `application_sdk.execution._temporal.activity_utils.get_object_store_prefix` (or anything else from a `_`-prefixed SDK module).

--- a/.claude/skills/upgrade-v3/SKILL.md
+++ b/.claude/skills/upgrade-v3/SKILL.md
@@ -910,11 +910,13 @@ await self.upload(UploadInput(local_path=output_file_path))  # RETAINED is the d
 
 **StorageTier choices** for `UploadInput`:
 
-| Tier | Prefix | Cleanup |
-|------|--------|---------|
-| `StorageTier.TRANSIENT` | `file_refs/{uuid}/` | Auto-deleted after run |
-| `StorageTier.RETAINED` | `artifacts/apps/{app}/workflows/{wf}/{run}/` | Kept; default for published artifacts |
-| `StorageTier.PERSISTENT` | `persistent-artifacts/apps/{app}/` | Never deleted; use for long-term state |
+| Tier | Key pattern (App.upload) | Cleanup |
+|------|--------------------------|---------|
+| `StorageTier.TRANSIENT` | `file_refs/{filename}` | Auto-deleted after run |
+| `StorageTier.RETAINED` | `artifacts/apps/{app}/workflows/{run_id}/{filename}` | Kept; default for published artifacts |
+| `StorageTier.PERSISTENT` | `persistent-artifacts/apps/{app}/{filename}` | Never deleted; use for long-term state |
+
+Note: the `{uuid}` key format (e.g. `file_refs/{uuid}`) is used by the automatic FileReference interceptor when persisting `@task` outputs — `App.upload()` uses `{filename}` directly.
 
 Note that `App.upload()` is NOT necessary inside each `@task` — task-to-task uploading/downloading of files within the same app is handled _automatically_ purely by virtue of a `FileReference` being included in the Output of a task (automatically uploaded to `objectstore`, if not already there) or the Input of a task (automatically downloaded, if not already present on the worker).
 

--- a/application_sdk/common/incremental/skills/implement-incremental-extraction/SKILL.md
+++ b/application_sdk/common/incremental/skills/implement-incremental-extraction/SKILL.md
@@ -82,7 +82,7 @@ Phase 1: Setup
 
 Phase 2: Base Extraction (inherited from BaseSQLMetadataExtractionWorkflow)
   fetch_databases → fetch_schemas → fetch_tables → fetch_columns (skipped if incremental)
-  → fetch_procedures → transform_data → upload_to_atlan
+  → fetch_procedures → transform_data → App.upload()
 
 Phase 3: Incremental Column Extraction (if prerequisites met)
   prepare_column_extraction_queries → execute_single_column_batch (parallel) → transform_data

--- a/application_sdk/common/incremental/skills/implement-incremental-extraction/references/activities-implementation.md
+++ b/application_sdk/common/incremental/skills/implement-incremental-extraction/references/activities-implementation.md
@@ -245,7 +245,7 @@ def get_activities(activities):
         activities.prepare_column_extraction_queries,
         activities.execute_single_column_batch,
         activities.write_current_state,
-        activities.upload_to_atlan,
+        activities.upload_to_atlan,  # v2-native activity; v3 equivalent: self.upload(UploadInput(...))
         activities.update_incremental_marker,
         activities.save_workflow_state,
     ]

--- a/application_sdk/common/incremental/skills/implement-incremental-extraction/references/workflow-implementation.md
+++ b/application_sdk/common/incremental/skills/implement-incremental-extraction/references/workflow-implementation.md
@@ -53,7 +53,7 @@ class ClickHouseWorkflow(IncrementalSQLMetadataExtractionWorkflow):
             activities.prepare_column_extraction_queries,
             activities.execute_single_column_batch,
             activities.write_current_state,
-            activities.upload_to_atlan,
+            activities.upload_to_atlan,  # v2-native activity; v3 equivalent: self.upload(UploadInput(...))
             activities.update_incremental_marker,
             activities.save_workflow_state,
         ]
@@ -89,7 +89,7 @@ The `run()` method in `IncrementalSQLMetadataExtractionWorkflow` executes:
 │  super().run(workflow_config)                             │
 │  → fetch_databases → fetch_schemas → fetch_tables        │
 │  → fetch_columns (SKIPPED if incremental)                │
-│  → fetch_procedures → transform_data → upload_to_atlan   │
+│  → fetch_procedures → transform_data → App.upload()       │
 ├─────────────────────────────────────────────────────────┤
 │ Phase 3: Incremental Column Extraction                   │
 │          (only if is_incremental_ready() == True)        │

--- a/application_sdk/common/incremental/skills/incremental-migrate/SKILL.md
+++ b/application_sdk/common/incremental/skills/incremental-migrate/SKILL.md
@@ -289,7 +289,7 @@ Execute each brick fully before starting the next. Halt on failure and report.
    - `read_marker` -- calls SDK `fetch_marker_from_storage` with configurable prepone
    - `read_previous_<entity>_list` -- downloads previous scope from S3 via ObjectStore
    - `persist_incremental_state` -- writes marker + entity lists + cache to S3
-     (GUARD-IMPL-01: this MUST be the last activity, after upload_to_atlan)
+     (GUARD-IMPL-01: this MUST be the last activity, after App.upload())
 
    **Modified** `<app_path>/app/models.py`:
    - `incremental_enabled: bool = False`
@@ -329,7 +329,7 @@ Execute each brick fully before starting the next. Halt on failure and report.
      - Modify expensive extraction to use only changed entity IDs
      - `backfill_unchanged_<entities>` after fresh extraction
    - Add short-circuit: if 0 entities changed, skip expensive extraction entirely
-   - Add `persist_incremental_state` AFTER `upload_to_atlan` (GUARD-IMPL-01)
+   - Add `persist_incremental_state` AFTER `App.upload()` (GUARD-IMPL-01)
    - Register all new activities in `get_activities()`
    - Update `<app_path>/app/templates/workflow.json` to add incremental UI toggles
 5. Verify the workflow modifications.

--- a/application_sdk/common/incremental/skills/incremental-migrate/references/rest-incremental-pattern.md
+++ b/application_sdk/common/incremental/skills/incremental-migrate/references/rest-incremental-pattern.md
@@ -144,7 +144,7 @@ READ (with prepone)        EXTRACT                   PERSIST (after publish)
        |                       |                            |
        v                       v                            v
   fetch_marker()        run extraction            persist_marker(now_iso)
-  prepone by N min      using cutoff              only after upload_to_atlan
+  prepone by N min      using cutoff              only after App.upload()
   to handle clock       from marker               succeeds
   skew / overlap
 ```
@@ -152,7 +152,7 @@ READ (with prepone)        EXTRACT                   PERSIST (after publish)
 - **Prepone**: Subtract a safety window (e.g., 5 minutes) from the stored marker
   to handle clock skew between your system and the upstream API.
 - **First run**: If no marker exists, treat as full extraction (all entities changed).
-- **Persist timing**: ALWAYS persist the new marker AFTER `upload_to_atlan` succeeds.
+- **Persist timing**: ALWAYS persist the new marker AFTER `App.upload()` succeeds (formerly `upload_to_atlan` in v2).
   If upload fails, the next run re-extracts the same window — idempotent and safe.
 
 ### 2.3 Entity List (Filter-Change & Delete Detection)
@@ -294,7 +294,7 @@ persistent-artifacts/apps/{app_name}/connection/{connection_id}/
 |
 |-- marker.txt
 |   # ISO timestamp of last successful extraction completion.
-|   # Written ONLY after upload_to_atlan succeeds.
+|   # Written ONLY after App.upload() succeeds.
 |   # Read at start of next run, preponed by safety window.
 |   # Lifecycle: created on first run, overwritten every run.
 |
@@ -302,7 +302,7 @@ persistent-artifacts/apps/{app_name}/connection/{connection_id}/
 |   # Array of workbook IDs that passed the project/site filter
 |   # on the previous run. Used for delete detection and
 |   # filter-change detection on the next run.
-|   # Lifecycle: overwritten every run after upload_to_atlan.
+|   # Lifecycle: overwritten every run after App.upload().
 |
 |-- filtered-datasources.json
 |   # Same pattern for datasources (one file per entity type).
@@ -316,7 +316,7 @@ persistent-artifacts/apps/{app_name}/connection/{connection_id}/
 |   |-- _index.json
 |   |   # v2 index: maps each datasource ID to its chunk file,
 |   |   # start line, and line count. Small file (~1KB per entity).
-|   |   # Lifecycle: overwritten every run after upload_to_atlan.
+|   |   # Lifecycle: overwritten every run after App.upload().
 |   |
 |   |-- datasource/
 |   |   |-- result-0.json    # NDJSON chunk (~50MB max)
@@ -336,7 +336,7 @@ persistent-artifacts/apps/{app_name}/connection/{connection_id}/
 ```
 
 All files under this tree are **overwritten** on every successful run. There is no
-append-only log. If a run fails before `upload_to_atlan`, the old state is preserved
+append-only log. If a run fails before `App.upload()`, the old state is preserved
 and the next run retries cleanly.
 
 ---
@@ -366,7 +366,7 @@ STEP  ACTIVITY                             INCREMENTAL?   NOTES
 8a.   backfill_unchanged_datasources       << NEW >>      From S3 extracts via index
 9.    filter_data                          existing       Apply project/site filters
 10.   transform                            existing       YAML transformers (unchanged)
-11.   upload_to_atlan                      existing       Publish to Atlan (unchanged)
+11.   App.upload()                         existing       Publish to Atlan (in v3; v2: upload_to_atlan)
 11a.  persist_incremental_state            << NEW >>      Marker + entity lists + cache + extracts
 ```
 
@@ -380,7 +380,7 @@ STEP  ACTIVITY                             INCREMENTAL?   NOTES
    (sheets, dashboards, fields) and datasource details (columns, connections)
    are the expensive calls. These are the ones we skip for unchanged entities.
 
-3. **State persistence is ALWAYS after `upload_to_atlan`.** If upload fails,
+3. **State persistence is ALWAYS after `App.upload()`.** If upload fails,
    the marker is not advanced and entity lists are not updated. The next run
    retries the exact same window. This guarantees no data loss.
 
@@ -429,8 +429,9 @@ class ExtractionWorkflow:
         )
 
         # Phase 5: Transform + Upload (existing, unchanged)
+        # v3: self.upload(UploadInput(...)) in App.run(); v2-native: upload_to_atlan activity
         await workflow.execute_activity(transform, ...)
-        await workflow.execute_activity(upload_to_atlan, ...)
+        await workflow.execute_activity(upload_to_atlan, ...)  # v2-native; in v3 use self.upload()
 
         # Phase 6: State persistence (new, MUST be after upload)
         await workflow.execute_activity(

--- a/docs/adr/0008-payload-safe-bounded-types.md
+++ b/docs/adr/0008-payload-safe-bounded-types.md
@@ -116,4 +116,4 @@ Automatically split large payloads into chunks, reassemble transparently.
 
 **`MaxItems`** (`application_sdk/contracts/types.py`): `@dataclass(frozen=True)` constraint marker used with `Annotated`.
 
-**`FileReference`** (`application_sdk/contracts/types.py`): frozen Pydantic `BaseModel` with fields `local_path`, `storage_path`, `is_durable`, `file_count`, and `tier (StorageTier)`. Store large data via `application_sdk.storage.upload_file()` and pass only the reference through Temporal.
+**`FileReference`** (`application_sdk/contracts/types.py`): frozen Pydantic `BaseModel` with fields `local_path`, `storage_path`, `is_durable`, `file_count`, and `tier (StorageTier)`. Store large data via `application_sdk.storage.upload_file()` and pass only the reference through Temporal. For the two-store routing of `FileReference` (task-to-task, customer-owned `objectstore`) and `App.upload()` (app-to-app, Atlan-owned `atlan-objectstore`), see [ADR-0014](0014-two-store-storage-architecture.md).

--- a/docs/adr/0014-two-store-storage-architecture.md
+++ b/docs/adr/0014-two-store-storage-architecture.md
@@ -135,6 +135,16 @@ async def run(self, input: ExtractionInput) -> ExtractionOutput:
   S3 and publishes nothing. SQL connectors built on `SqlApp` should include the
   explicit upload in their `run()` override; the `SqlApp` base class will add
   this call in a future SDK release.
+- **`App.upload()` misuse.** Calling `App.upload()` for task-to-task data —
+  instead of `FileReference` — has three distinct harms: (1) in SDR it routes to
+  Atlan's `atlan-objectstore`, polluting it with intermediate pipeline artifacts
+  that the publish app treats as connector output; (2) it bypasses SHA-256 dedup —
+  every call uploads the full file even if an identical file already exists in the
+  store; (3) it does not wire into the SDK's cross-worker auto-materialization —
+  the resulting `FileReference` will not be automatically re-downloaded if a
+  downstream task lands on a different worker. The correct tool for task-to-task
+  data is `FileReference` on the contract; the interceptor handles persistence and
+  materialization automatically.
 - **Two stores to configure.** SDR deployments need both components provisioned.
   The atlan-configurator handles this automatically; custom deployments must
   ensure `atlan-objectstore` is present if the connector hands off to Atlan

--- a/docs/adr/0014-two-store-storage-architecture.md
+++ b/docs/adr/0014-two-store-storage-architecture.md
@@ -1,0 +1,151 @@
+# ADR-0014: Two-Store Storage Architecture
+
+## Status
+**Accepted**
+
+## Context
+
+When a connector runs in Self-Deployed Runtime (SDR) mode it operates inside
+the customer's own infrastructure — on their Kubernetes cluster, behind their
+firewall, potentially writing to their own object store. Atlan's system apps
+(publish, query-intelligence, lineage-app, lineage-publish) run in Atlan's
+managed cloud and can only read artifacts from Atlan's own S3-compatible
+blobstorage proxy (`/api/blobstorage`).
+
+Before this architecture existed there was a single Dapr component named
+`objectstore`. When a connector needed to hand extracted artifacts to the
+publish app it had to write to a path that Atlan's infrastructure could reach.
+This created a coupling problem: either the customer had to open their internal
+object store to Atlan's publish workers, or every SDR deployment had to be
+pre-configured to write directly to Atlan's S3. Both options are security and
+operational antipatterns, and neither composably supports customers who want to
+keep all intermediate pipeline data inside their own perimeter.
+
+Within a single connector run there is also a durability requirement that is
+entirely local to the customer's deployment: a `@task` on worker pod A may
+produce a large file that another `@task` on pod B needs as input. This
+transfer has nothing to do with Atlan's infrastructure — it is intra-deployment
+inter-task communication. Forcing it through Atlan's S3 would add latency,
+incur unnecessary cross-boundary transfer costs, and unnecessarily expose
+customer data to Atlan's storage.
+
+These are two fundamentally different data flows:
+
+1. **Task-to-task**: within a single run, between activities on the same or
+   different pods of *the same deployment*. The storage is deployment-owned
+   and can be any backend the customer controls.
+
+2. **App-to-app**: from the connector's extract activity to Atlan's system apps
+   (publish, QI, lineage). The storage must be Atlan-owned because only Atlan's
+   infrastructure can access it.
+
+## Decision
+
+Introduce two distinct Dapr objectstore components and two matching store
+references in `InfrastructureContext`:
+
+| Component name | SDK reference | Owner | Purpose |
+|----------------|--------------|-------|---------|
+| `objectstore` | `infra.storage` (`DEPLOYMENT_OBJECT_STORE_NAME`) | Customer / deployment | Task-to-task `FileReference` durability within a run |
+| `atlan-objectstore` | `infra.upstream_storage` (`UPSTREAM_OBJECT_STORE_NAME`) | Atlan | Final artifact hand-off to Atlan system apps |
+
+The `atlan-objectstore` component is provisioned by the atlan-configurator at
+SDR deploy time and points to `{tenant}/api/blobstorage` with the deployment's
+OAuth client credentials for SigV4 signing. In non-SDR deployments (local dev,
+Atlan-hosted) the component is absent and `upstream_storage` is `None`.
+
+### Activity interceptor — always uses `infra.storage`
+
+The activity interceptor's persist step automatically uploads every ephemeral
+`FileReference` returned from a `@task` to `infra.storage`. This is intentional
+and must not change:
+
+- `infra.storage` is the SDR-controlled deployment store. Using it for intra-run
+  transfers keeps all intermediate data inside the customer's perimeter.
+- In Atlan-hosted deployments there is no `atlan-objectstore`; the interceptor
+  must work with a single store.
+- The interceptor upload is fire-and-forget plumbing, not a semantic hand-off.
+  Routing it through Atlan's S3 would couple every task output to Atlan's
+  availability and access model, even for data that never needs to leave the
+  deployment.
+
+### App.upload() — routes through upstream_storage when present
+
+`App.upload()` uses `upstream_storage or storage`:
+
+```python
+store = self.context.upstream_storage or self.context.storage
+```
+
+In SDR deployments `upstream_storage` is the `atlan-objectstore` S3 binding, so
+`App.upload()` routes to Atlan's bucket. In local dev and Atlan-hosted
+deployments `upstream_storage` is `None` and `App.upload()` falls back to the
+deployment store.
+
+### Connector responsibility
+
+Connectors that hand artifacts to Atlan system apps **must** call `App.upload()`
+explicitly. Relying on the activity interceptor is not sufficient — the
+interceptor writes to `infra.storage` (deployment-owned), which the publish app
+cannot access in SDR deployments.
+
+The typical pattern in a SQL connector's `run()`:
+
+```python
+async def run(self, input: ExtractionInput) -> ExtractionOutput:
+    base = await super().run(input)  # extract + transform → local files
+
+    # Explicit hand-off to Atlan: upload transformed/ to atlan-objectstore (S3).
+    # The activity interceptor already persisted FileReferences to infra.storage
+    # for task-to-task durability; this separate upload routes through
+    # upstream_storage so the publish app can read the artifacts.
+    await self.upload(
+        UploadInput(
+            local_path=os.path.join(base.output_path, "transformed"),
+            storage_path=base.transformed_data_prefix,
+            raise_on_empty=True,
+        )
+    )
+    return ExtractionOutput(transformed_data_prefix=base.transformed_data_prefix, ...)
+```
+
+## Consequences
+
+### Positive
+
+- **Perimeter isolation.** Intermediate pipeline data (raw SQL results, partial
+  transform outputs) never leaves the customer's deployment unless the connector
+  explicitly decides to hand it off.
+- **Backend flexibility.** Customers can configure `objectstore` to any backend
+  they already operate (their own S3 bucket, Azure Blob, GCS, even local disk in
+  dev). Only the final artifact upload cares about Atlan's specific S3 endpoint.
+- **Clear semantic boundary.** The two-store split makes the task-to-task vs
+  app-to-app distinction visible in the code: `FileReference` + interceptor =
+  intra-run, `App.upload()` = cross-system hand-off.
+- **Graceful local-dev fallback.** When `atlan-objectstore` is absent
+  `upstream_storage` is `None` and `App.upload()` silently falls back to the
+  deployment store. Local dev and integration tests work without any special
+  configuration.
+
+### Negative / Tradeoffs
+
+- **Connector authors must know the rule.** Forgetting the explicit `App.upload()`
+  call produces a silent failure: all DAG nodes succeed (the interceptor
+  uploaded to localstorage), but the publish app finds 0 artifacts in Atlan's
+  S3 and publishes nothing. SQL connectors built on `SqlApp` should include the
+  explicit upload in their `run()` override; the `SqlApp` base class will add
+  this call in a future SDK release.
+- **Two stores to configure.** SDR deployments need both components provisioned.
+  The atlan-configurator handles this automatically; custom deployments must
+  ensure `atlan-objectstore` is present if the connector hands off to Atlan
+  system apps.
+
+## Related
+
+- `application_sdk.constants.DEPLOYMENT_OBJECT_STORE_NAME` — `"objectstore"`
+- `application_sdk.constants.UPSTREAM_OBJECT_STORE_NAME` — `"atlan-objectstore"`
+- `application_sdk.app.base.App.upload()` — routes through `upstream_storage or storage`
+- `application_sdk.execution._temporal.activities` — interceptor persist step uses `infra.storage`
+- [ADR-0007: Apps as the Unit of Inter-App Coordination](0007-apps-as-coordination-unit.md)
+- [docs/concepts/file-reference.md](../concepts/file-reference.md)
+- [docs/concepts/storage.md](../concepts/storage.md)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -17,3 +17,4 @@ ADRs capture the architectural decisions behind the Application SDK — what was
 | [ADR-0011](0011-logging-level-guidelines.md) | Logging Level Guidelines |
 | [ADR-0012](0012-observability-consolidation.md) | Observability Consolidation |
 | [ADR-0013](0013-error-hierarchy-and-failure-taxonomy.md) | Error Hierarchy and Failure Taxonomy |
+| [ADR-0014](0014-two-store-storage-architecture.md) | Two-Store Storage Architecture (task-to-task vs app-to-app) |

--- a/docs/agents/coding-standards.md
+++ b/docs/agents/coding-standards.md
@@ -87,16 +87,22 @@ To hand off artifacts to Atlan system apps (publish, lineage, quality), call
 `atlan-objectstore` (`infra.upstream_storage`) in SDR deployments:
 
 ```python
-from application_sdk.contracts import UploadInput, StorageTier
+from application_sdk.contracts import UploadInput
 
 async def run(self, input: MyInput) -> MyOutput:
     fetch_out = await self.fetch_data(input)
     # Required: push artifact to Atlan's upstream store
-    await self.upload(
-        UploadInput(local_path=fetch_out.output_path, tier=StorageTier.RETAINED)
-    )
+    await self.upload(UploadInput(local_path=fetch_out.output_path))  # RETAINED is the default tier
     return fetch_out
 ```
+
+**Anti-pattern: calling `App.upload()` for task-to-task data.** `App.upload()` routes
+to `atlan-objectstore` in SDR — using it for intermediate pipeline data (instead of
+`FileReference`) has three harms: pollutes Atlan's bucket with internal artifacts;
+bypasses SHA-256 dedup (every call is a full re-upload, even for identical files);
+and does not wire into cross-worker auto-materialization. Declare `FileReference` on
+task `Input`/`Output` contracts instead — the interceptor handles persistence and
+re-download automatically.
 
 See [file-reference.md § App-to-app hand-off](../concepts/file-reference.md) and
 [ADR-0014](../adr/0014-two-store-storage-architecture.md) for the full rationale.

--- a/docs/agents/coding-standards.md
+++ b/docs/agents/coding-standards.md
@@ -72,6 +72,35 @@ Use `FileReference` for any data that cannot fit in Temporal's 2 MB payload limi
 See `docs/concepts/file-reference.md` for the full guide: decision matrix, lifecycle,
 the `Lazy()` marker for selective materialization, dedup behaviour, and observability events.
 
+### App-to-app hand-off (required for SDR deployments)
+
+`FileReference` auto-durability writes to the **customer-owned `objectstore`**
+(`infra.storage`) — it is designed for task-to-task data passing within a single run.
+
+**Silent-failure rule:** if a connector returns a `FileReference` from a `@task` but
+never calls `App.upload()` from `run()`, the DAG completes successfully but the publish
+app finds nothing in Atlan's bucket. This produces no error — the failure is invisible
+in the Temporal UI.
+
+To hand off artifacts to Atlan system apps (publish, lineage, quality), call
+`App.upload()` explicitly from `run()` — it routes to the Atlan-owned
+`atlan-objectstore` (`infra.upstream_storage`) in SDR deployments:
+
+```python
+from application_sdk.contracts import UploadInput, StorageTier
+
+async def run(self, input: MyInput) -> MyOutput:
+    fetch_out = await self.fetch_data(input)
+    # Required: push artifact to Atlan's upstream store
+    await self.upload(
+        UploadInput(local_path=fetch_out.output_path, tier=StorageTier.RETAINED)
+    )
+    return fetch_out
+```
+
+See [file-reference.md § App-to-app hand-off](../concepts/file-reference.md) and
+[ADR-0014](../adr/0014-two-store-storage-architecture.md) for the full rationale.
+
 ## Replacing `ParquetFileWriter` / `JsonFileWriter` (v4.0 removal path)
 
 `ParquetFileWriter`, `JsonFileWriter`, `ParquetFileReader`, and `JsonFileReader`

--- a/docs/concepts/apps.md
+++ b/docs/concepts/apps.md
@@ -187,8 +187,10 @@ class MyConnector(App):
 
 ### Built-in Cleanup Tasks
 
-Two cleanup tasks are available on every `App`:
+Two cleanup tasks and two transfer tasks are available on every `App`:
 
+- `upload(UploadInput(...))` — pushes a local file or directory to object storage. Routes to the Atlan-owned `atlan-objectstore` (`infra.upstream_storage`) in SDR deployments; falls back to the customer-owned `objectstore` (`infra.storage`) in local dev. This is the explicit hand-off step that downstream Atlan system apps (publish, lineage, quality) consume. See [file-reference.md](file-reference.md) and [ADR-0014](../adr/0014-two-store-storage-architecture.md).
+- `download(DownloadInput(...))` — pulls a file or directory from object storage to a local path.
 - `cleanup_files()` — removes tracked `FileReference` local paths from task outputs, **then** convention-based temp directories (using `input.extra_paths` if provided, otherwise `ATLAN_CLEANUP_BASE_PATHS`, otherwise the default temp path).
 - `cleanup_storage()` — removes object store artifacts by tier:
   - `StorageTier.TRANSIENT` refs are always removed.

--- a/docs/concepts/contracts.md
+++ b/docs/concepts/contracts.md
@@ -131,12 +131,17 @@ class MyConnector(App):
         fetch = await self.fetch_data(FetchInput(...))
         # FileReference passes through the contract automatically — no manual upload between tasks.
         transformed = await self.transform(TransformInput(data_file=fetch.data_file))
-        # Upload the final result at the end of run(), after all processing is complete.
+        # This explicit App.upload() call is required for any data Atlan system apps
+        # (publish, lineage, QI) must consume; the activity interceptor's auto-upload
+        # only writes to the customer-owned objectstore. See ADR-0014.
         up = await self.upload(UploadInput(local_path=transformed.output_path))
         return ExtractionOutput(output_file=up.ref, record_count=transformed.record_count)
 ```
 
 See [Storage](storage.md) for full `FileReference` and `StorageTier` documentation.
+`FileReference` handles task-to-task data passing; for hand-off to Atlan system apps,
+call `App.upload()` from `run()`. See [file-reference.md](file-reference.md) and
+[ADR-0014](../adr/0014-two-store-storage-architecture.md).
 
 ---
 

--- a/docs/concepts/file-reference.md
+++ b/docs/concepts/file-reference.md
@@ -36,12 +36,32 @@ failures.
 | Task B always needs what task A produced, and the file is always present | `FileReference` field (eager, default) | SDK downloads it before task B runs. |
 | Task B only sometimes needs the file (e.g. only when `mode == "full"`) | `Annotated[FileReference \| None, Lazy()]` | SDK skips the download; task B fetches on demand with `fetch()`. |
 | Multiple tasks all share the same large manifest file | Single `FileReference` passed through the chain | SDK downloads it exactly once per task via dedup. |
-| Push a completed artifact so it appears in the Atlan UI after the run | `await self.upload(UploadInput(..., tier=StorageTier.RETAINED))` | Writes to a stable run-scoped prefix that the platform indexes. |
+| Push a completed artifact so it appears in the Atlan UI after the run | `await self.upload(UploadInput(local_path=...))` | `RETAINED` is the default tier — writes to a stable run-scoped prefix that the platform indexes. |
 | Write a file that must persist across multiple runs (e.g. incremental bookmark) | `await self.upload(UploadInput(..., tier=StorageTier.PERSISTENT))` | Writes to a fixed path not cleaned up between runs. |
 | Directory of output files (e.g. partitioned Parquet) from task A to task B | `FileReference(local_path=str(dir_path))` — same API, directory-aware | SDK uploads all files in the directory and re-creates the structure on download. |
+| Pass intermediate data between tasks using `App.upload()` | **Don't — use `FileReference`** | `App.upload()` routes to Atlan's `atlan-objectstore` in SDR, polluting it with internal artifacts; bypasses SHA-256 dedup; and doesn't wire into cross-worker auto-materialization. |
 
 **Key rule:** `FileReference` is for *within-run* transfer. `App.upload()` is
 for *durable outbound* delivery.
+
+> **Anti-pattern: `App.upload()` for task-to-task data.** Using `App.upload()` to
+> move data between tasks — instead of `FileReference` — causes three distinct harms:
+>
+> 1. **Wrong bucket.** In SDR, `App.upload()` routes to the Atlan-owned
+>    `atlan-objectstore`. Intermediate pipeline data (raw SQL rows, partial
+>    transforms) pollutes Atlan's bucket with artifacts that the publish app treats
+>    as connector output.
+> 2. **Bypasses SHA-256 dedup.** The `FileReference` interceptor maintains a
+>    `.sha256` sidecar so re-transfers across workers are skipped automatically.
+>    `App.upload()` performs a full upload on every call — no dedup, no sidecar,
+>    no skip.
+> 3. **No cross-worker auto-materialization.** `FileReference` input fields are
+>    automatically re-downloaded before a task runs when the local file is absent
+>    (cross-worker fault tolerance). `App.upload()` produces a bare `FileReference`
+>    without wiring it into the SDK's materialization machinery.
+>
+> For task-to-task data: declare `FileReference` on your `Output` and `Input`
+> contracts — the interceptor handles persistence and materialization automatically.
 
 ### Which store does each API write to?
 
@@ -401,10 +421,7 @@ from application_sdk.contracts.types import StorageTier
 
 # Inside run() or a @task method:
 upload_result = await self.upload(
-    UploadInput(
-        local_path="/tmp/output/tables.parquet",
-        tier=StorageTier.RETAINED,
-    )
+    UploadInput(local_path="/tmp/output/tables.parquet")  # RETAINED is the default tier
 )
 # upload_result.ref is now a durable FileReference
 # storage_path will be something like:
@@ -439,9 +456,7 @@ upload_result = await self.upload(
 
 ```python
 # In the extract task:
-upload_result = await self.upload(
-    UploadInput(local_path=extract_output.db_path, tier=StorageTier.RETAINED)
-)
+upload_result = await self.upload(UploadInput(local_path=extract_output.db_path))
 
 # Pass the durable ref to the transform task:
 transform_input = TransformInput(source_db=upload_result.ref)
@@ -484,8 +499,7 @@ async def transform(self, input: TransformInput) -> TransformOutput:
 
 # In the run() method — push result for the platform to index:
 result = await self.upload(
-    UploadInput(local_path=transform_output.result_parquet.local_path,
-                tier=StorageTier.RETAINED)
+    UploadInput(local_path=transform_output.result_parquet.local_path)  # RETAINED is the default
 )
 # result.ref.storage_path is stable and survives workflow completion
 ```
@@ -537,7 +551,6 @@ class MyConnector(App):
         upload = await self.upload(
             UploadInput(
                 local_path=transform_out.result_parquet.local_path,
-                tier=StorageTier.RETAINED,
                 storage_subdir="argo-artifacts",
             )
         )
@@ -648,7 +661,7 @@ return Output(ref=FileReference(local_path=str(result), tier=StorageTier.RETAINE
 # The Atlan platform cannot index this on its own
 
 # CORRECT — use App.upload() to push to a stable, platform-visible path:
-await self.upload(UploadInput(local_path=str(result), tier=StorageTier.RETAINED))
+await self.upload(UploadInput(local_path=str(result)))  # RETAINED is the default tier
 ```
 
 ---
@@ -705,12 +718,7 @@ await self.upload_to_atlan(UploadInput(output_path=input.output_path))
 **Replacement:**
 
 ```python
-up = await self.upload(
-    UploadInput(
-        local_path=input.output_path,
-        tier=StorageTier.RETAINED,
-    )
-)
+up = await self.upload(UploadInput(local_path=input.output_path))
 records_uploaded = up.ref.file_count or 0
 ```
 

--- a/docs/concepts/file-reference.md
+++ b/docs/concepts/file-reference.md
@@ -43,6 +43,32 @@ failures.
 **Key rule:** `FileReference` is for *within-run* transfer. `App.upload()` is
 for *durable outbound* delivery.
 
+### Which store does each API write to?
+
+These two APIs route to **different object stores**:
+
+| API | Store | Who can read it |
+|-----|-------|-----------------|
+| `FileReference` (via interceptor) | `objectstore` — `infra.storage`, customer-owned | Other tasks in the same deployment |
+| `App.upload()` | `atlan-objectstore` — `infra.upstream_storage`, Atlan-owned (in SDR); falls back to `infra.storage` in local dev | Atlan system apps (publish, QI, lineage) and the Atlan UI |
+
+The activity interceptor's persist step always writes `FileReference` objects to
+`infra.storage` (`objectstore`). This is intentional: intermediate task outputs
+stay inside the customer's deployment perimeter and never cross into Atlan's
+infrastructure unless the connector explicitly decides to hand them off.
+
+`App.upload()` uses `upstream_storage or storage`. In SDR deployments
+`upstream_storage` is the `atlan-objectstore` Dapr binding (pointing to
+`{tenant}/api/blobstorage`), so `App.upload()` routes to Atlan's S3.
+
+**Consequence for connector authors:** if your connector produces artifacts that
+Atlan's publish app must consume, you must call `App.upload()` explicitly from
+`run()` — the interceptor alone is not sufficient. Omitting the explicit call
+produces a silent failure: the DAG runs to completion but the publish app finds
+nothing in Atlan's S3 and publishes zero assets. See
+[ADR-0014](../adr/0014-two-store-storage-architecture.md) for the full
+rationale.
+
 ---
 
 ## Part 1 — FileReference
@@ -173,7 +199,8 @@ return BookmarkOutput(
 #### Persist (output side)
 
 After your `@task` returns an Output containing an ephemeral `FileReference`
-(one with `local_path` set but `is_durable=False`), the SDK automatically:
+(one with `local_path` set but `is_durable=False`), the SDK automatically
+uploads it to **`infra.storage`** (`objectstore` — the deployment store):
 
 1. Computes the storage path from the tier prefix.
 2. Uploads the local file (or all files in a local directory) to the store.

--- a/docs/concepts/file-reference.md
+++ b/docs/concepts/file-reference.md
@@ -104,7 +104,7 @@ class FileReference(BaseModel, frozen=True):
     storage_path: str | None = None    # object-store key (set after persist)
     is_durable: bool = False           # True once uploaded to the store
     tier: StorageTier = StorageTier.TRANSIENT
-    file_count: int | None = None      # set for directories; number of files
+    file_count: int = 1                # number of files; >1 for directory uploads
     auto_materialize: bool = True      # False = SDK never touches this ref
 ```
 
@@ -359,57 +359,65 @@ await self.upload(input: UploadInput) -> UploadOutput
 
 ```python
 class UploadInput(BaseModel):
-    local_path: str                            # required: path to the file on disk
+    local_path: str = ""                       # path to the file or directory on disk
     tier: StorageTier = StorageTier.RETAINED   # where to store it
     storage_path: str | None = None            # override the full destination key
     storage_subdir: str | None = None          # append a subdir under the run prefix
     skip_if_exists: bool = False               # skip upload when remote SHA-256 matches
+    raise_on_empty: bool = False               # raise if the upload produces 0 files
 ```
 
 | Field | Required | Description |
 |---|---|---|
-| `local_path` | Yes | Absolute path to the file to upload. |
+| `local_path` | Yes | Path to the file or directory to upload. Defaults to `""` (must be set before calling `App.upload()`). |
 | `tier` | No (default `RETAINED`) | Tier that controls the destination prefix and cleanup policy. |
 | `storage_path` | No | Fully-qualified destination key. Overrides the auto-generated path. Use this when you need an exact fixed path (e.g. `argo-artifacts/spec.json`). |
 | `storage_subdir` | No | Subdirectory appended under the run prefix. Useful for grouping related uploads without spelling out the full path. |
 | `skip_if_exists` | No (default `False`) | When `True`, skip uploading files whose SHA-256 already matches the stored `{key}.sha256` sidecar. Useful for retried tasks and idempotent re-uploads. |
+| `raise_on_empty` | No (default `False`) | When `True`, raise `StorageEmptyUploadError` if the upload completes with zero files (e.g. `local_path` pointed at an empty directory). Leave `False` for incremental extractors where a quiet run legitimately produces no output; set `True` when zero files indicates a bug. |
 
 ### Path Computation
 
 When `storage_path` is **not** set, the destination key is computed as:
 
 ```
-{run_prefix}/{tier_subdir}/{filename}
+{app_prefix}/{filename}
 ```
 
-Where `run_prefix` is:
+Where `app_prefix` depends on the tier:
 
-```
-artifacts/apps/{app_name}/workflows/{workflow_id}/{run_id}
-```
-
-And `tier_subdir` depends on the tier:
-
-| Tier | tier_subdir |
+| Tier | `app_prefix` (= destination key without filename) |
 |---|---|
-| `RETAINED` | `file_refs/` |
-| `PERSISTENT` | (uses `persistent-artifacts/` as the base, ignores run_prefix) |
+| `RETAINED` (default) | `artifacts/apps/{app_name}/workflows/{run_id}` |
+| `TRANSIENT` | `file_refs` |
+| `PERSISTENT` | `persistent-artifacts/apps/{app_name}` |
 
-When `storage_subdir` is set:
+> **Note:** the `{uuid}` segment (e.g. `file_refs/{uuid}/tables.parquet`) only appears when the **FileReference activity interceptor** auto-persists a ref returned from a `@task` — that path is computed by `StorageTier.auto_persist_key()`, not by `App.upload()`. `App.upload()` uses `StorageTier.upload_prefix()`, which puts the file directly under `{app_prefix}/{filename}`.
+
+When `storage_subdir` is set, it is appended between the run prefix and the filename:
 
 ```
-{run_prefix}/{storage_subdir}/{filename}
+artifacts/apps/{app_name}/workflows/{run_id}/{storage_subdir}/{filename}
 ```
+
+TRANSIENT and PERSISTENT tiers ignore `storage_subdir`.
 
 ### UploadOutput
 
 ```python
 class UploadOutput(BaseModel):
     ref: FileReference    # durable ref pointing at the uploaded file
+    synced: bool = False  # True if at least one file was actually transferred
+    reason: str = ""      # human-readable outcome, e.g. "uploaded" or "skipped:hash_match"
 ```
 
-The returned `ref` is already durable (`is_durable=True`, `storage_path` set).
-You can pass it as a `FileReference` field on a subsequent task's Input.
+| Field | Description |
+|---|---|
+| `ref` | Durable `FileReference` with `is_durable=True` and `storage_path` set. `file_count` reflects the number of files uploaded (1 for a single file, N for a directory). |
+| `synced` | `True` if at least one file was transferred to the store. `False` when all files were skipped (e.g. `skip_if_exists=True` and every file already matched its SHA-256 sidecar). |
+| `reason` | Short string describing the transfer outcome. Typical values: `"uploaded"`, `"skipped:hash_match"`, `"empty"`. Useful for logging. |
+
+The returned `ref` is already durable — you can pass it as a `FileReference` field on a subsequent task's Input.
 
 ### Usage Patterns
 

--- a/docs/concepts/file-reference.md
+++ b/docs/concepts/file-reference.md
@@ -425,7 +425,7 @@ upload_result = await self.upload(
 )
 # upload_result.ref is now a durable FileReference
 # storage_path will be something like:
-# artifacts/apps/myapp/workflows/wf-123/run-456/file_refs/tables.parquet
+# artifacts/apps/myapp/workflows/run-abc123/tables.parquet
 ```
 
 #### Pattern 2 — Upload to a known subdir (e.g. argo-artifacts pattern)

--- a/docs/concepts/infrastructure.md
+++ b/docs/concepts/infrastructure.md
@@ -24,9 +24,12 @@ from application_sdk.infrastructure import (
 | `secret_store` | `SecretStore` | `DaprSecretStore` | `MockSecretStore` |
 | `state_store` | `StateStore` | `DaprStateStore` | `MockStateStore` |
 | `storage` | `ObjectStore` | obstore S3/GCS/Azure | local filesystem |
+| `upstream_storage` | `ObjectStore \| None` | `atlan-objectstore` (SDR only) | `None` |
 | `event_binding` | `Binding` | `DaprBinding` | `MockBinding` |
 
 All fields are optional (`None` by default). Accessing a `None` field raises a configuration error at runtime.
+
+**Two-store architecture:** `storage` and `upstream_storage` serve distinct purposes. `storage` is the customer-owned deployment store used by the activity interceptor for task-to-task `FileReference` durability — intermediate data stays inside the customer's perimeter. `upstream_storage` is an Atlan-owned store provisioned by the atlan-configurator in SDR deployments; `App.upload()` routes through it so Atlan system apps (publish, QI, lineage) can read connector artifacts. When `upstream_storage` is `None` (local dev, Atlan-hosted), `App.upload()` falls back to `storage`. See [ADR-0014](../adr/0014-two-store-storage-architecture.md) and [Storage](storage.md) for full details.
 
 `PubSub` and `CapacityPool` are separate infrastructure capabilities managed by their own module-level singletons — see [State, Secrets, Pub/Sub & Bindings](state-secrets-pubsub.md) for usage.
 

--- a/docs/concepts/storage.md
+++ b/docs/concepts/storage.md
@@ -4,6 +4,50 @@ The SDK uses `obstore` for all object storage operations, bypassing the Dapr sid
 
 ---
 
+## Two-Store Architecture
+
+The SDK maintains two distinct object-store references, each serving a different
+purpose:
+
+| Dapr component | SDK reference | Owner | Purpose |
+|----------------|--------------|-------|---------|
+| `objectstore` | `infra.storage` | Customer / deployment | Task-to-task `FileReference` durability within a run |
+| `atlan-objectstore` | `infra.upstream_storage` | Atlan | Final artifact hand-off to Atlan system apps (publish, QI, lineage) |
+
+**Task-to-task transfers** use `infra.storage`. The activity interceptor
+automatically uploads every `FileReference` returned from a `@task` to this
+store, keeping all intermediate data inside the customer's deployment perimeter.
+`objectstore` can be any backend the customer controls (S3, Azure Blob, GCS,
+local disk) — Atlan's infrastructure never reads from it.
+
+**App-to-app hand-off** uses `infra.upstream_storage`. When a connector's
+extract activity produces artifacts that Atlan's publish or lineage apps must
+consume, the connector calls `App.upload()` explicitly. In SDR deployments
+`upstream_storage` points to `atlan-objectstore` (Atlan's S3-compatible
+blobstorage proxy); in local dev it is `None` and `App.upload()` falls back to
+the deployment store.
+
+```
+Connector run (customer's cluster)
+  @task extract  ──► FileReference ──► objectstore (infra.storage, customer-owned)
+  @task transform ──► FileReference ──► objectstore
+  run()          ──► App.upload()  ──► atlan-objectstore (infra.upstream_storage, Atlan-owned)
+                                         │
+                                         ▼
+                                  Atlan publish app reads → Atlas
+```
+
+**The key rule:** rely on the interceptor for intra-run durability; call
+`App.upload()` explicitly for any data that must cross into Atlan's
+infrastructure. Relying on the interceptor alone for the app-to-app
+hand-off produces a silent failure — all DAG nodes succeed but the publish
+app finds nothing to publish.
+
+See [ADR-0014](../adr/0014-two-store-storage-architecture.md) for the full
+rationale, fallback behaviour, and consequences.
+
+---
+
 ## Basic Operations
 
 ```python

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -168,6 +168,11 @@ class MyConnector(App):
         return await self.process(ProcessInput(results=fetch_out.results))
 ```
 
+`FileReference` handles task-to-task data passing within a run (automatic via the activity
+interceptor). For hand-off to Atlan system apps (publish, lineage, quality), call
+`App.upload()` explicitly from `run()` — see [storage.md](storage.md) and
+[file-reference.md](file-reference.md) for the two-store routing details.
+
 ## Auto-Discovery
 
 You do not register tasks manually. When your `App` subclass is defined, `App.__init_subclass__` scans it for `@task` methods and registers them in the `TaskRegistry`. The worker discovers all registered tasks at startup via `create_worker()`.

--- a/docs/concepts/transformers.md
+++ b/docs/concepts/transformers.md
@@ -16,7 +16,7 @@ Raw SQL query results (daft.DataFrame)
   Atlas entity JSONL
         │
         ▼
-  upload_to_atlan() → Atlan ingestion API
+  App.upload() → atlan-objectstore (Atlan-owned)
 ```
 
 This pipeline is used internally by `SqlMetadataExtractor.transform_data()`. If you subclass `SqlMetadataExtractor` today without overriding `transform_data()`, you are running through this legacy path.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,7 +105,7 @@ Dapr component names are read at module-import time (not at runtime) because the
 | `STATE_STORE_NAME` | `statestore` | Dapr state store component name. |
 | `SECRET_STORE_NAME` | `secretstore` | Dapr secret store component name. |
 | `DEPLOYMENT_OBJECT_STORE_NAME` | `objectstore` | Dapr object store for workflow outputs and artifacts. |
-| `UPSTREAM_OBJECT_STORE_NAME` | `atlan-objectstore` | Dapr object store for uploading data to the Atlan platform (SDR deployments only). If the named component is absent, `upstream_storage` is `None` and `App.upload()`/`App.download()` fall back to the deployment store. |
+| `UPSTREAM_OBJECT_STORE_NAME` | `atlan-objectstore` | Dapr object store for uploading data to the Atlan platform (SDR deployments only). If the named component is absent, `upstream_storage` is `None` and `App.upload()`/`App.download()` fall back to the deployment store. See [ADR-0014](adr/0014-two-store-storage-architecture.md). |
 | `EVENT_STORE_NAME` | `eventstore` | Dapr pub/sub component name. |
 | `DEPLOYMENT_SECRET_STORE_NAME` | `deployment-secret-store` | Dapr secret store holding deployment-scoped secrets (auth credentials, etc.). |
 | `DAPR_MAX_GRPC_MESSAGE_LENGTH` | `104857600` (100 MB) | Maximum gRPC message size in bytes for Dapr client calls. Increase for apps that move large payloads through Dapr state or bindings. |

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -194,7 +194,7 @@ await upload_file("artifacts/output.json", local_path="/tmp/output.json")
 await download_file("artifacts/output.json", local_path="/tmp/output.json")
 ```
 
-Higher-level: `App` provides `self.upload()` and `self.download()` framework tasks for directory-level transfer with automatic `FileReference` tracking for cleanup. See [ADR-0005](../adr/0005-infrastructure-abstraction.md).
+Higher-level: `App` provides `self.upload()` and `self.download()` framework tasks for directory-level transfer with automatic `FileReference` tracking for cleanup. `self.upload()` routes to the Atlan-owned `atlan-objectstore` in SDR deployments (the hand-off to Atlan system apps like publish and lineage) and falls back to `objectstore` in local dev — the two-store split is handled automatically. See [ADR-0005](../adr/0005-infrastructure-abstraction.md) and [ADR-0014](../adr/0014-two-store-storage-architecture.md).
 
 ---
 

--- a/docs/guides/multi-app-coordination.md
+++ b/docs/guides/multi-app-coordination.md
@@ -118,7 +118,7 @@ class MyExtractor(App):
     async def transform(self, input: TransformInput) -> ExtractionOutput:
         path = "/tmp/output.parquet"
         write_parquet(path, records)
-        up = await self.upload(UploadInput(local_path=path, tier=StorageTier.RETAINED))
+        up = await self.upload(UploadInput(local_path=path))
         return ExtractionOutput(parquet_file=up.ref)
 ```
 

--- a/docs/guides/multi-app-coordination.md
+++ b/docs/guides/multi-app-coordination.md
@@ -124,6 +124,8 @@ class MyExtractor(App):
 
 The downstream app receives the `FileReference.storage_path` (object-store path) via the AE args substitution and downloads it before processing.
 
+When `atlan-objectstore` is bound, `App.upload()` writes to Atlan's S3 so downstream AE nodes (publish, lineage) can read it. Without the explicit `self.upload()` call, downstream nodes see nothing — the DAG succeeds but the publish app finds no artifact in its bucket. See [ADR-0014](../adr/0014-two-store-storage-architecture.md).
+
 ---
 
 ## Observability Across Apps

--- a/docs/guides/rest-api-application-guide.md
+++ b/docs/guides/rest-api-application-guide.md
@@ -167,12 +167,7 @@ class MyConnectorApp(App):
         # only writes FileReferences to the customer-owned objectstore (infra.storage).
         # Omitting this call produces a silent failure in SDR — the DAG succeeds but
         # the publish app finds nothing. See ADR-0014.
-        await self.upload(
-            UploadInput(
-                local_path=fetch_out.output_path,
-                tier=StorageTier.RETAINED,
-            )
-        )
+        await self.upload(UploadInput(local_path=fetch_out.output_path))
         return ExtractionOutput(
             output_path=fetch_out.output_path,
             record_count=fetch_out.record_count,

--- a/docs/guides/rest-api-application-guide.md
+++ b/docs/guides/rest-api-application-guide.md
@@ -11,7 +11,7 @@ A connector that:
 1. Authenticates with an API using an API key
 2. Fetches entities (e.g. tables, pipelines, dashboards)
 3. Writes JSONL output to object storage
-4. Uploads the output to Atlan via `upload_to_atlan`
+4. Uploads the output to Atlan via `App.upload()`
 
 ## Project Setup
 
@@ -137,12 +137,11 @@ from __future__ import annotations
 
 import json
 import os
-import tempfile
 
 from application_sdk.app import App, task
+from application_sdk.contracts import UploadInput, StorageTier
 from application_sdk.credentials import CredentialResolver, api_key_ref
 from application_sdk.infrastructure import get_infrastructure
-from application_sdk.storage import upload_file
 
 from app.clients import MyApiClient
 from app.contracts import (
@@ -163,6 +162,17 @@ class MyConnectorApp(App):
                 days_back=input.days_back,
             )
         )
+        # Explicit hand-off to Atlan: routes through atlan-objectstore (Atlan-owned)
+        # in SDR deployments so the publish app can read it. The activity interceptor
+        # only writes FileReferences to the customer-owned objectstore (infra.storage).
+        # Omitting this call produces a silent failure in SDR — the DAG succeeds but
+        # the publish app finds nothing. See ADR-0014.
+        await self.upload(
+            UploadInput(
+                local_path=fetch_out.output_path,
+                tier=StorageTier.RETAINED,
+            )
+        )
         return ExtractionOutput(
             output_path=fetch_out.output_path,
             record_count=fetch_out.record_count,
@@ -181,32 +191,24 @@ class MyConnectorApp(App):
             base_url=raw.get("base_url", "https://api.example.com"),
         )
 
+        os.makedirs(input.output_path, exist_ok=True)
         output_file = os.path.join(input.output_path, "entities.jsonl")
         record_count = 0
 
         try:
-            with tempfile.NamedTemporaryFile(
-                mode="w", suffix=".jsonl", delete=False
-            ) as tmp:
+            with open(output_file, "w") as f:
                 page = 1
                 while True:
                     entities = await client.get_entities(page=page)
                     if not entities:
                         break
                     for entity in entities:
-                        # Transform to Atlan entity format
                         atlan_entity = _transform_entity(entity)
-                        tmp.write(json.dumps(atlan_entity) + "\n")
+                        f.write(json.dumps(atlan_entity) + "\n")
                         record_count += 1
-                    page += 1
-
-                tmp_path = tmp.name
-
-            await upload_file(output_file, tmp_path)
+                page += 1
         finally:
             await client.close()
-            if os.path.exists(tmp_path):
-                os.unlink(tmp_path)
 
         return FetchEntitiesOutput(
             output_path=input.output_path,
@@ -215,7 +217,6 @@ class MyConnectorApp(App):
 
 
 def _transform_entity(raw: dict) -> dict:
-    """Transform a raw API entity to Atlan entity format."""
     return {
         "typeName": "Table",
         "attributes": {
@@ -226,7 +227,12 @@ def _transform_entity(raw: dict) -> dict:
     }
 ```
 
-The connector above inherits directly from `App`. For connectors that need to push output to Atlan's upstream store, `BaseMetadataExtractor` (a subclass of `App`) provides a built-in `upload_to_atlan` task that handles the transfer. Both patterns are supported; the direct `App` approach shown here gives more explicit control.
+> **Silent-failure rule:** `App.upload()` in `run()` is required for any data that Atlan system apps
+> (publish, QI, lineage) must consume. The activity interceptor only writes `FileReference` objects
+> to the **customer-owned** `objectstore` (`infra.storage`). In SDR deployments, `App.upload()`
+> routes through `atlan-objectstore` (`infra.upstream_storage`, Atlan-owned). Connectors that omit
+> this call produce a silent failure — the DAG completes normally but the publish app finds nothing
+> in Atlan's bucket. See [ADR-0014](../adr/0014-two-store-storage-architecture.md).
 
 ## Local Development
 

--- a/docs/guides/rest-api-application-guide.md
+++ b/docs/guides/rest-api-application-guide.md
@@ -201,7 +201,7 @@ class MyConnectorApp(App):
                         atlan_entity = _transform_entity(entity)
                         f.write(json.dumps(atlan_entity) + "\n")
                         record_count += 1
-                page += 1
+                    page += 1
         finally:
             await client.close()
 

--- a/docs/guides/sql-application-guide.md
+++ b/docs/guides/sql-application-guide.md
@@ -263,7 +263,7 @@ The core of your connector is a `SqlMetadataExtractor` subclass. Override `@task
 ```python
 # app/connector.py
 import asyncio
-from application_sdk.contracts import UploadInput, StorageTier
+from application_sdk.contracts import UploadInput
 from application_sdk.templates import SqlMetadataExtractor
 from application_sdk.templates.contracts import (
     ExtractionInput,
@@ -394,12 +394,7 @@ class PostgresApp(SqlMetadataExtractor):
         # Explicit hand-off to Atlan: routes through atlan-objectstore in SDR so
         # the publish app can read it. The interceptor only writes to infra.storage
         # (customer-owned). Omitting this call is a silent failure. See ADR-0014.
-        await self.upload(
-            UploadInput(
-                local_path=input.output_path,
-                tier=StorageTier.RETAINED,
-            )
-        )
+        await self.upload(UploadInput(local_path=input.output_path))
 
         return ExtractionOutput(
             databases_extracted=db_result.total_record_count,

--- a/docs/guides/sql-application-guide.md
+++ b/docs/guides/sql-application-guide.md
@@ -263,6 +263,7 @@ The core of your connector is a `SqlMetadataExtractor` subclass. Override `@task
 ```python
 # app/connector.py
 import asyncio
+from application_sdk.contracts import UploadInput, StorageTier
 from application_sdk.templates import SqlMetadataExtractor
 from application_sdk.templates.contracts import (
     ExtractionInput,
@@ -390,6 +391,16 @@ class PostgresApp(SqlMetadataExtractor):
             self.fetch_columns(task_input),
         )
 
+        # Explicit hand-off to Atlan: routes through atlan-objectstore in SDR so
+        # the publish app can read it. The interceptor only writes to infra.storage
+        # (customer-owned). Omitting this call is a silent failure. See ADR-0014.
+        await self.upload(
+            UploadInput(
+                local_path=input.output_path,
+                tier=StorageTier.RETAINED,
+            )
+        )
+
         return ExtractionOutput(
             databases_extracted=db_result.total_record_count,
             schemas_extracted=schema_result.total_record_count,
@@ -404,7 +415,8 @@ Each `@task` method becomes a Temporal activity. The `run()` method orchestrates
 
 1. **Fetch phase** --- fetch databases, schemas, tables, and columns **in parallel** via `asyncio.gather`
 2. **Transform phase** --- map raw results to pyatlan entities using the asset mapper
-3. **Return** --- aggregate counts into an `ExtractionOutput`
+3. **Upload** --- `App.upload()` pushes the final output to `atlan-objectstore` (Atlan-owned) so the publish app can index it. This explicit call is required — the activity interceptor only writes `FileReference` objects to the customer-owned `objectstore`. See [ADR-0014](../adr/0014-two-store-storage-architecture.md).
+4. **Return** --- aggregate counts into an `ExtractionOutput`
 
 ### Available task methods
 
@@ -492,17 +504,19 @@ class FetchDatabasesOutput(Output):
 
 ### FileReference for large data
 
-When a task produces data too large for a Temporal payload, use `FileReference`. The SDK uploads it to object storage automatically:
+When a task produces data too large for a Temporal payload, use `FileReference`. The SDK uploads it to the **customer-owned deployment store** (`objectstore`) automatically when the task returns:
 
 ```python
 from application_sdk.contracts import FileReference
 
 class FetchOutput(Output):
-    results: FileReference  # automatically uploaded on task output
+    results: FileReference  # automatically uploaded on task output (to infra.storage)
 
 class ProcessInput(Input):
     results: FileReference  # automatically downloaded on task input
 ```
+
+`FileReference` is for **task-to-task** transfer within a run. To hand off artifacts to Atlan system apps (publish, QI, lineage), call `App.upload()` explicitly from `run()` — the interceptor's auto-upload only writes to the customer-owned store and is not visible to Atlan. See [file-reference.md](../concepts/file-reference.md) and [ADR-0014](../adr/0014-two-store-storage-architecture.md).
 
 ## Entry Point
 

--- a/docs/upgrade-guide-v3.md
+++ b/docs/upgrade-guide-v3.md
@@ -285,7 +285,7 @@ Wire them into extract/transform tasks on your `App` subclass:
 ```python
 # app/app.py
 from application_sdk.app import App, task
-from application_sdk.contracts import Input, Output, FileReference
+from application_sdk.contracts import Input, Output, FileReference, UploadInput, StorageTier
 from app.api_types import TopicRecord
 from app.asset_mapper import map_topic
 
@@ -314,7 +314,30 @@ class MyConnector(App):
         local_path = "/tmp/topics_assets.jsonl"
         write_jsonl(local_path, assets)  # your serialisation helper
         return TransformOutput(file=FileReference.from_local(local_path))  # framework auto-uploads
+
+    async def run(self, input: MyInput) -> MyOutput:
+        fetch_out = await self.extract_topics(input)
+        transform_out = await self.transform_topics(TransformInput(file=fetch_out.file))
+
+        # Required explicit hand-off: routes through atlan-objectstore (Atlan-owned) in SDR
+        # so the publish app can read it. The activity interceptor only writes FileReferences
+        # to the customer-owned objectstore (infra.storage). Omitting this call produces a
+        # silent failure in SDR — the DAG succeeds but nothing is published. See ADR-0014.
+        await self.upload(
+            UploadInput(
+                local_path=transform_out.file.local_path,
+                tier=StorageTier.RETAINED,
+            )
+        )
+        return MyOutput(...)
 ```
+
+> **Two-store rule:** `FileReference` + the activity interceptor = **task-to-task** durability,
+> customer-owned `objectstore`. `App.upload()` = **app-to-app** hand-off, Atlan-owned
+> `atlan-objectstore` in SDR. These are two distinct stores. Forgetting `App.upload()` is a
+> silent failure — all activities succeed but Atlan's publish app sees nothing. See
+> [ADR-0014](../adr/0014-two-store-storage-architecture.md) and
+> [file-reference.md](../concepts/file-reference.md).
 
 ### Rules for mapper functions
 

--- a/docs/upgrade-guide-v3.md
+++ b/docs/upgrade-guide-v3.md
@@ -285,7 +285,7 @@ Wire them into extract/transform tasks on your `App` subclass:
 ```python
 # app/app.py
 from application_sdk.app import App, task
-from application_sdk.contracts import Input, Output, FileReference, UploadInput, StorageTier
+from application_sdk.contracts import Input, Output, FileReference, UploadInput
 from app.api_types import TopicRecord
 from app.asset_mapper import map_topic
 
@@ -323,12 +323,7 @@ class MyConnector(App):
         # so the publish app can read it. The activity interceptor only writes FileReferences
         # to the customer-owned objectstore (infra.storage). Omitting this call produces a
         # silent failure in SDR — the DAG succeeds but nothing is published. See ADR-0014.
-        await self.upload(
-            UploadInput(
-                local_path=transform_out.file.local_path,
-                tier=StorageTier.RETAINED,
-            )
-        )
+        await self.upload(UploadInput(local_path=transform_out.file.local_path))
         return MyOutput(...)
 ```
 

--- a/docs/whats-new-v3.md
+++ b/docs/whats-new-v3.md
@@ -270,6 +270,16 @@ class MyConnector(App):
         return await self.process(ProcessInput(results=fetch_out.results))
 ```
 
+> **Two-store routing.** `FileReference` auto-durability writes to the customer-owned
+> `objectstore` (`infra.storage`) — intended for task-to-task data passing within a run.
+> To hand off artifacts to Atlan system apps (publish, lineage, quality), call
+> `App.upload()` explicitly from `run()` — it routes to the Atlan-owned
+> `atlan-objectstore` (`infra.upstream_storage`) in SDR deployments. Relying on the
+> `FileReference` interceptor alone for the Atlan hand-off is a silent failure in SDR:
+> the DAG succeeds but the publish app finds nothing in its bucket.
+> See [ADR-0014](adr/0014-two-store-storage-architecture.md) and
+> [File Reference guide](concepts/file-reference.md).
+
 #### Contract evolution rules
 
 Because Temporal may replay a workflow with a payload serialised before you deployed a new
@@ -314,13 +324,17 @@ class MyConnector(App):
 
         # Secret store
         api_key = await self.context.get_secret("my-api-key")
-
-        # Object storage (upload/download via built-in App tasks)
-        result = await self.upload(UploadInput(
-            local_path="/tmp/data.parquet",
-            storage_path="output/data.parquet",
-        ))
         ...
+
+    async def run(self, input: FetchInput) -> FetchOutput:
+        fetch_out = await self.fetch(input)
+        # App.upload() routes to Atlan's upstream store (atlan-objectstore in SDR).
+        # Call it from run(), not from within a @task.
+        await self.upload(UploadInput(
+            local_path="/tmp/data.parquet",
+            tier=StorageTier.RETAINED,
+        ))
+        return fetch_out
 ```
 
 **The key improvements:**
@@ -554,7 +568,7 @@ from application_sdk.credentials import AtlanClientMixin, atlan_api_token_ref
 
 class MyConnector(AtlanClientMixin, App):
     @task
-    async def upload_to_atlan(self, input: UploadInput) -> UploadOutput:
+    async def call_atlan_api(self, input: MyInput) -> MyOutput:
         ref = atlan_api_token_ref("atlan-token")
         client = await self.get_or_create_async_atlan_client(ref)
         # client is an AsyncAtlanClient, cached per run

--- a/docs/whats-new-v3.md
+++ b/docs/whats-new-v3.md
@@ -330,10 +330,7 @@ class MyConnector(App):
         fetch_out = await self.fetch(input)
         # App.upload() routes to Atlan's upstream store (atlan-objectstore in SDR).
         # Call it from run(), not from within a @task.
-        await self.upload(UploadInput(
-            local_path="/tmp/data.parquet",
-            tier=StorageTier.RETAINED,
-        ))
+        await self.upload(UploadInput(local_path="/tmp/data.parquet"))
         return fetch_out
 ```
 

--- a/tests/integration/test_app_upload_routing.py
+++ b/tests/integration/test_app_upload_routing.py
@@ -93,9 +93,12 @@ async def test_app_upload_routes_to_upstream_when_present(tmp_path):
     storage_path = result.ref.storage_path
     assert storage_path is not None
 
-    # The file must be findable in upstream
+    # The file must be findable in upstream (excluding .sha256 sidecars)
     upstream_keys = await list_keys("", store=upstream_store)
-    assert any(storage_path in key or key in storage_path for key in upstream_keys), (
+    non_sidecar_upstream = [k for k in upstream_keys if not k.endswith(".sha256")]
+    assert any(
+        storage_path in key or key in storage_path for key in non_sidecar_upstream
+    ), (
         f"App.upload() did not route to upstream_storage. "
         f"Expected key containing '{storage_path}' in upstream, found: {upstream_keys}"
     )
@@ -139,9 +142,12 @@ async def test_app_upload_falls_back_when_upstream_none(tmp_path):
     storage_path = result.ref.storage_path
     assert storage_path is not None
 
-    # The file must be in the deployment store (fallback)
+    # The file must be in the deployment store (fallback, excluding .sha256 sidecars)
     deployment_keys = await list_keys("", store=deployment_store)
-    assert any(storage_path in key or key in storage_path for key in deployment_keys), (
+    non_sidecar_deployment = [k for k in deployment_keys if not k.endswith(".sha256")]
+    assert any(
+        storage_path in key or key in storage_path for key in non_sidecar_deployment
+    ), (
         f"App.upload() did not fall back to deployment store when upstream is None. "
         f"Expected key containing '{storage_path}' in deployment, found: {deployment_keys}"
     )

--- a/tests/integration/test_app_upload_routing.py
+++ b/tests/integration/test_app_upload_routing.py
@@ -1,0 +1,208 @@
+"""Integration tests pinning two-store routing for App.upload() (ADR-0014).
+
+Three invariants verified:
+
+(a) App.upload() routes to upstream_storage when an upstream store is wired —
+    the file lands in the Atlan-owned bucket, NOT the customer deployment store.
+
+(b) App.upload() falls back to storage when upstream_storage is None —
+    the file lands in the deployment store (standard / non-SDR deployments).
+
+(c) The activity interceptor (persist_file_reference) always writes FileReferences
+    to the deployment store, never to upstream_storage — even when upstream is
+    wired alongside it.
+
+Invariant (c) is the inverse of (a): it proves that returning a FileReference from
+a @task is NOT a substitute for an explicit App.upload() hand-off. A connector
+that relies on the interceptor alone will produce a silent failure in SDR
+deployments — the DAG succeeds but Atlan's publish app finds nothing in its bucket.
+
+See:
+  docs/concepts/file-reference.md   (decision matrix and lifecycle)
+  docs/adr/0014-two-store-storage-architecture.md   (full rationale)
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import pytest
+
+from application_sdk.app import App
+from application_sdk.app.context import AppContext
+from application_sdk.contracts.storage import UploadInput
+from application_sdk.contracts.types import FileReference, StorageTier
+from application_sdk.storage.batch import list_keys
+from application_sdk.storage.factory import create_local_store
+from application_sdk.storage.reference import persist_file_reference
+
+
+class _UploadApp(App):
+    """Minimal App subclass for upload routing tests."""
+
+    _app_registered: ClassVar[bool] = True
+    _app_name: ClassVar[str] = "upload-routing-test"
+
+    async def run(self, input):  # type: ignore[override]
+        pass  # not exercised by these tests
+
+
+def _make_app(
+    deployment_store,
+    upstream_store=None,
+    run_id: str = "run-routing-test",
+) -> _UploadApp:
+    """Build an _UploadApp with the given stores wired into its context."""
+    app = _UploadApp()
+    app._context = AppContext(
+        app_name=app._app_name,
+        app_version="1",
+        run_id=run_id,
+        _storage=deployment_store,
+        _upstream_storage=upstream_store,
+    )
+    return app
+
+
+# ---------------------------------------------------------------------------
+# (a) App.upload() routes to upstream_storage when present
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_app_upload_routes_to_upstream_when_present(tmp_path):
+    """App.upload() must land the file in upstream_storage, not in storage.
+
+    This is the SDR case: upstream_storage is the Atlan-owned atlan-objectstore,
+    storage is the customer-owned objectstore. Published artifacts must reach
+    Atlan's bucket so the publish app can index them.
+    """
+    deployment_root = tmp_path / "deployment"
+    upstream_root = tmp_path / "upstream"
+    deployment_store = create_local_store(deployment_root)
+    upstream_store = create_local_store(upstream_root)
+
+    src = tmp_path / "artifact.jsonl"
+    src.write_text('{"name": "test-entity"}\n')
+
+    app = _make_app(deployment_store, upstream_store=upstream_store)
+    result = await app.upload(
+        UploadInput(local_path=str(src), tier=StorageTier.RETAINED)
+    )
+
+    storage_path = result.ref.storage_path
+    assert storage_path is not None
+
+    # The file must be findable in upstream
+    upstream_keys = await list_keys("", store=upstream_store)
+    assert any(storage_path in key or key in storage_path for key in upstream_keys), (
+        f"App.upload() did not route to upstream_storage. "
+        f"Expected key containing '{storage_path}' in upstream, found: {upstream_keys}"
+    )
+
+    # The same key must NOT be in the deployment store
+    deployment_keys = await list_keys("", store=deployment_store)
+    assert not any(
+        storage_path in key or key in storage_path
+        for key in deployment_keys
+        if not key.endswith(".sha256")
+    ), (
+        f"App.upload() incorrectly wrote to deployment store when upstream was present. "
+        f"deployment_keys: {deployment_keys}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (b) App.upload() falls back to storage when upstream_storage is None
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_app_upload_falls_back_when_upstream_none(tmp_path):
+    """App.upload() must use storage when upstream_storage is None.
+
+    This is the standard (non-SDR) case: no atlan-objectstore is configured,
+    so App.upload() falls back to the deployment store. The file must land
+    in storage so the run produces usable artifacts in local dev / Atlan-hosted.
+    """
+    deployment_root = tmp_path / "deployment"
+    deployment_store = create_local_store(deployment_root)
+
+    src = tmp_path / "artifact.jsonl"
+    src.write_text('{"name": "test-entity"}\n')
+
+    app = _make_app(deployment_store, upstream_store=None)
+    result = await app.upload(
+        UploadInput(local_path=str(src), tier=StorageTier.RETAINED)
+    )
+
+    storage_path = result.ref.storage_path
+    assert storage_path is not None
+
+    # The file must be in the deployment store (fallback)
+    deployment_keys = await list_keys("", store=deployment_store)
+    assert any(storage_path in key or key in storage_path for key in deployment_keys), (
+        f"App.upload() did not fall back to deployment store when upstream is None. "
+        f"Expected key containing '{storage_path}' in deployment, found: {deployment_keys}"
+    )
+
+    assert result.ref.is_durable
+    assert result.ref.file_count is not None and result.ref.file_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# (c) persist_file_reference (interceptor) writes to deployment, never upstream
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_filereference_persist_uses_deployment_store_not_upstream(tmp_path):
+    """The activity interceptor (persist_file_reference) must write to the
+    customer-owned deployment store, never to upstream_storage.
+
+    This test pins the inverse of test (a): returning a FileReference from a
+    @task does NOT hand the artifact off to Atlan's bucket. Connectors that rely
+    on the interceptor alone for the publish hand-off produce a silent failure in
+    SDR — the DAG succeeds but the publish app finds nothing in its bucket.
+
+    Proof: after persist_file_reference, the file exists in the deployment store
+    but NOT in the upstream store.
+    """
+    deployment_root = tmp_path / "deployment"
+    upstream_root = tmp_path / "upstream"
+    deployment_store = create_local_store(deployment_root)
+    upstream_store = create_local_store(upstream_root)
+
+    raw = tmp_path / "raw.jsonl"
+    raw.write_text('{"database_name": "prod"}\n')
+
+    # Simulate what the activity interceptor does after a @task returns a
+    # FileReference: calls persist_file_reference with the deployment store.
+    ephemeral = FileReference(local_path=str(raw))
+    durable = await persist_file_reference(deployment_store, ephemeral)
+
+    assert durable.is_durable
+    storage_path = durable.storage_path
+    assert storage_path is not None
+
+    # File must be in deployment store (interceptor wrote here)
+    deployment_keys = await list_keys("", store=deployment_store)
+    assert any(storage_path in key or key in storage_path for key in deployment_keys), (
+        f"persist_file_reference did not write to deployment store. "
+        f"storage_path={storage_path}, deployment_keys={deployment_keys}"
+    )
+
+    # File must NOT be in upstream store — the interceptor never touches it.
+    # If this assertion fails, the two-store boundary has been violated and the
+    # "silent failure" scenario can no longer be reproduced.
+    upstream_keys = await list_keys("", store=upstream_store)
+    non_sidecar_upstream = [k for k in upstream_keys if not k.endswith(".sha256")]
+    assert non_sidecar_upstream == [], (
+        f"persist_file_reference incorrectly wrote to upstream_storage. "
+        f"This means FileReference durability is now crossing into Atlan's bucket "
+        f"without an explicit App.upload() call. upstream_keys: {upstream_keys}"
+    )
+
+    # Sanity check: the upstream store is not the same object as deployment store
+    assert upstream_store is not deployment_store
+    assert str(upstream_root.resolve()) != str(deployment_root.resolve())


### PR DESCRIPTION
## Summary

- **New ADR-0014** formalising the two-store split: `objectstore` (customer-owned, task-to-task via `FileReference` interceptor) vs `atlan-objectstore` (Atlan-owned, app-to-app via `App.upload()`). Documents the silent-failure mode in SDR.
- **New `file-reference.md`** canonical reference covering the decision matrix, lifecycle, storage tiers, lazy materialisation, dedup, observability, and migration from `upload_to_atlan`.
- **New `storage.md`** two-store ASCII diagram and silent-failure warning.
- **REST + SQL guides** rewritten to show explicit `App.upload()` in `run()`; remove `upload_file` antipattern; add silent-failure callout.
- **`upgrade-guide-v3`, `whats-new-v3`**: Kafka/examples extended with `App.upload()`; fixed `self.upload()` shown inside `@task`; renamed `AtlanClientMixin` example method to avoid `upload_to_atlan` confusion.
- **`infrastructure.md`**: added `upstream_storage` row to `InfrastructureContext` fields table.
- **`capability-manifest` format-spec**: fixed `UploadInput` example (all fields were wrong — `source`, `key`, `StorageTier.HOT` don't exist).
- **`coding-standards`**: new "App-to-app hand-off" subsection naming the silent-failure rule verbatim with a code example.
- **`upgrade-v3` skill**: two-store Dapr component names, silent-failure rule, `StorageTier` table.
- **`scaffold-app`, `add-entrypoint` skills**: upload hand-off guidance in templates.
- **Incremental skills**: all `upload_to_atlan` in guards, diagrams, and prose rewritten to `App.upload()`; first occurrence keeps `(formerly upload_to_atlan in v2)` for migrators.
- **Cross-links** in `contracts.md`, `tasks.md`, `apps.md`, `architecture.md`, `multi-app-coordination.md`, `configuration.md`, `ADR-0008`, `make-contract` skill.
- **New integration test** `tests/integration/test_app_upload_routing.py` pinning all three two-store invariants:
  - (a) `App.upload()` routes to `upstream_storage` when present (SDR case)
  - (b) `App.upload()` falls back to `storage` when `upstream_storage` is `None`
  - (c) `persist_file_reference` writes to deployment store only — proves `FileReference` alone is not a substitute for `App.upload()` (the silent-failure proof)
- **Anti-pattern callout** (3 locations): using `App.upload()` for task-to-task data — instead of `FileReference` — causes three distinct harms: (1) in SDR it routes to `atlan-objectstore`, polluting it with intermediate pipeline artifacts; (2) it bypasses SHA-256 dedup, so every call is a full re-upload even for identical files; (3) it does not wire into cross-worker auto-materialization. Added to the `file-reference.md` decision matrix + callout block, `ADR-0014` consequences, and `coding-standards` App-to-app section.
- **Simplified `UploadInput` examples**: `StorageTier.RETAINED` is already the default for `UploadInput` — removed the redundant `tier=` argument from all doc/skill examples and cleaned up now-unused `StorageTier` imports. `FileReference` constructor examples keep explicit tiers intact (`FileReference` defaults to `TRANSIENT`).

## Test plan

- [x] `uv run pre-commit run --all-files` — clean
- [x] `uv run python -m pytest tests/unit -x -q` — 4805 passed
- [x] `uv run pytest tests/integration/test_app_upload_routing.py -m integration -v` — 3 passed
- [x] `uv run pytest tests/integration/test_sql_app_file_reference.py tests/integration/test_storage_writers.py -m integration -v` — 8 passed (no regression)
- [x] `rg -n 'upload_to_atlan' docs/ .claude/skills/ application_sdk/common/incremental/skills/` — only migration/deprecated context hits remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)