### PR TITLE
ci: sign Docker Hub images with cosign keyless

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -1032,10 +1032,21 @@ jobs:
     if: ${{ !failure() && !cancelled() && needs.build.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # A job-level `permissions` block REPLACES the workflow-level default, so we
+    # re-declare what merge needs. `id-token: write` is required for cosign
+    # keyless signing of the Docker Hub image (OIDC token exchange with Fulcio).
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
 
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Install Cosign
+        if: needs.prepare.outputs.enable_sdr == 'true'
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Log in to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -1084,15 +1095,34 @@ jobs:
           fi
 
       - name: Push to Docker Hub (re-tag, no rebuild)
+        id: dockerhub_push
         if: needs.prepare.outputs.enable_sdr == 'true'
         env:
           GHCR_IMAGE:      ${{ needs.prepare.outputs.ghcr_image }}
           DOCKERHUB_IMAGE: ${{ needs.prepare.outputs.dockerhub_image }}
         run: |
+          set -euo pipefail
           docker buildx imagetools create \
             --tag "${DOCKERHUB_IMAGE}" \
             "${GHCR_IMAGE}"
           echo "Pushed to DockerHub: ${DOCKERHUB_IMAGE}"
+
+          # Resolve the pushed manifest digest so we can sign by digest (immutable)
+          # rather than by tag (mutable). `${DOCKERHUB_IMAGE%%:*}` strips the tag.
+          DIGEST="$(docker buildx imagetools inspect "${DOCKERHUB_IMAGE}" --format '{{.Manifest.Digest}}')"
+          echo "digest_ref=${DOCKERHUB_IMAGE%%:*}@${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign Docker Hub image (cosign keyless)
+        if: needs.prepare.outputs.enable_sdr == 'true'
+        env:
+          # Keyless signing — no long-lived key. Cosign uses the job's ambient
+          # GitHub OIDC token (id-token: write) to obtain a short-lived Fulcio
+          # cert and records the signature in the Rekor transparency log.
+          DIGEST_REF: ${{ steps.dockerhub_push.outputs.digest_ref }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes "${DIGEST_REF}"
+          echo "Signed (keyless): ${DIGEST_REF}"
 
       - name: Summary
         run: |
@@ -1103,6 +1133,7 @@ jobs:
           echo "| Immutable image | \`${{ needs.prepare.outputs.ghcr_image }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Branch tag (mutable) | \`${{ needs.prepare.outputs.ghcr_branch_tag }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| DockerHub image | \`${{ needs.prepare.outputs.dockerhub_image }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Signed digest (cosign) | \`${{ steps.dockerhub_push.outputs.digest_ref }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Tag | \`${{ needs.prepare.outputs.image_tag }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Branch | \`${{ needs.prepare.outputs.branch }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Dockerfile | \`${{ needs.prepare.outputs.dockerfile }}\` |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## What

Signs the Self-Deployed Runtime (SDR) Docker Hub image in the `merge` job, immediately after the existing re-tag push, using **cosign keyless** signing (GitHub OIDC → Fulcio cert → signature recorded in Rekor).

Signing is gated on `enable_sdr == 'true'`, so **GHCR-only builds are completely unaffected** — only images that get pushed to Docker Hub get signed.

## Why

The customer-facing docs ([Verify container images](https://docs.atlan.com/product/connections/self-deployed-runtime/how-tos/verify-container-images)) instruct SDR customers to verify our images with `cosign verify`, but **no signing ever happened** in the build pipeline. Any customer following the docs today gets `no matching signatures`. This closes that gap for the Docker Hub (SDR) images.

## Changes

`.github/workflows/build-and-publish-app.yaml` — `merge` job only:
- Add `id-token: write` to the job (a job-level `permissions` block replaces the workflow default, so `contents: read` / `packages: write` are re-declared).
- Install pinned `sigstore/cosign-installer@v4.1.2`.
- Resolve the pushed **manifest digest** and `cosign sign --yes <repo>@<digest>` — sign by digest (immutable, correctly signs the multi-arch manifest list), not by mutable tag.
- Surface the signed digest in the job summary.

The signature artifact is pushed using the existing `DOCKER_HUB_PAT_RW` login (write scope covers it) — no new secret required.

## Verification identity for consumers

Because signing runs inside this **reusable** workflow, cosign's keyless certificate identity is:

\`\`\`
--certificate-identity      https://github.com/atlanhq/application-sdk/.github/workflows/build-and-publish-app.yaml@refs/heads/main
--certificate-oidc-issuer   https://token.actions.githubusercontent.com
\`\`\`

> ⚠️ This identity carries an `@refs/heads/main` suffix. If the reusable workflow is ever invoked from a non-`main` ref, the identity changes and customer-side verification with the documented value will fail. We should treat `main` as the only signing ref.

A companion **atlan-docs** PR (draft) corrects the published `--certificate-identity`, workflow name/branch, and registry (the page currently shows `public.ecr.aws/...` and a non-existent `test-image-sign.yaml@image-signing-test`).

## Testing

See the dry-run + on-tenant verification steps in the linked discussion; in short — push to a branch on an SDR-enabled connector, then `cosign verify` the resulting `atlanhq/<app>` digest against the identity above.

---

## ✅ Tested end-to-end (atlan-oracle-app)

Validated this branch against a real SDR connector before merge:

1. Cut a throwaway branch on `atlan-oracle-app` pointing its `build-and-publish.yaml` at `application-sdk@feat/sign-dockerhub-images`. `atlan.yaml` has `self_deployed_runtime: true`, so signing was in scope.
2. Dispatched the build with `publish=false` ([run 26941901818](https://github.com/atlanhq/atlan-oracle-app/actions/runs/26941901818)) — all jobs success/skipped.
   - `Prepare` resolved `enable_sdr=true`.
   - `Install Cosign` → cosign v3.0.6 (pinned SHA).
   - `Push to Docker Hub` → `atlanhq/atlan-oracle-app:cosign-sign-dockerhub-test-66bba94`.
   - `Sign Docker Hub image (cosign keyless)` → exit 0, signed `atlanhq/atlan-oracle-app@sha256:20c2131…f453`.
3. Independently verified the pushed image from a laptop — **passes by digest and by tag**:

   ```bash
   cosign verify \
     --certificate-identity="https://github.com/atlanhq/application-sdk/.github/workflows/build-and-publish-app.yaml@refs/heads/feat/sign-dockerhub-images" \
     --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
     atlanhq/atlan-oracle-app:cosign-sign-dockerhub-test-66bba94
   ```

   All three checks pass (cosign claims, Rekor transparency-log entry, Fulcio cert chain) and the cert identity matches the asserted workflow identity.

> The test identity carries `@refs/heads/feat/sign-dockerhub-images` only because the connector pointed at this branch. After merge, production images sign under `@refs/heads/main` — the value the docs publish. Verifying by **tag** works (cosign resolves tag → digest), so customers can verify the `atlanhq/<app>:main-<sha>` images they already receive without needing a digest.

Companion docs fix: atlanhq/atlan-docs#1221.
