### PR TITLE
ci(publish): inject self_deployed_runtime into the publish config

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -1160,6 +1160,7 @@ jobs:
           APP_ID: ${{ needs.prepare.outputs.app_id }}
           APP_NAME: ${{ needs.prepare.outputs.app_name }}
           DEPLOY_CONFIG: ${{ needs.prepare.outputs.deploy_config }}
+          ENABLE_SDR: ${{ needs.prepare.outputs.enable_sdr }}
           SDK_VERSION: ${{ needs.prepare.outputs.sdk_version }}
           ENTRYPOINTS: ${{ needs.prepare.outputs.entrypoints }}
           CHANNEL: ${{ inputs.channel }}
@@ -1268,6 +1269,13 @@ jobs:
           }
 
           config = os.environ.get("DEPLOY_CONFIG", "").strip()
+          # SDR capability rides inside the opaque config YAML — GM stores
+          # versions.config as raw TEXT and echoes it back in the tenant
+          # catalog, so LM can gate "Install on more environments" per app
+          # without a GM schema change. Only injected when true: absence
+          # means not SDR-capable (keeps non-SDR configs byte-identical).
+          if os.environ.get("ENABLE_SDR", "").strip() == "true":
+              config = f"self_deployed_runtime: true\n{config}".strip()
           if config:
               body["config"] = config
 


### PR DESCRIPTION
## Summary
- The publish step now prepends `self_deployed_runtime: true` to the version config it sends to the marketplace, reusing the existing `enable_sdr` output from `parse_atlan_yaml.py` (the same flag that gates the shared-registry image push)
- Only injected when true — non-SDR apps produce a publish payload byte-identical to today
- `deploy_config` itself is untouched: the guardrail validator step keeps seeing a pure `deploy:` block

## Context
The marketplace sidebar shows the SDR **Install on more environments** option for every installed app, but SDR installs only work when the image was pushed to the shared registry (`self_deployed_runtime: true` in atlan.yaml). The flag currently dies in CI — this change rides it inside the opaque `versions.config` TEXT that GM stores and echoes back in the tenant catalog, so no GM schema change is needed.

Part 1 of 3:
1. **this PR**: CI injects the key into the publish config
2. atlanhq/atlan-local-marketplace-app#388: LM parses it onto catalog cards
3. `atlan-frontend` (follow-up): gates the multi-env install option on the field

Heracles needs no changes — its publish proxy binds the body as `map[string]interface{}` and the field rides inside the existing `config` string anyway.

## Why prepend instead of yaml.dump
The publish heredoc only has stdlib; `deploy_config` is flat `yaml.dump` output with no document markers, so prepending one `key: value` line is valid YAML. The `.strip()` covers SDR apps with no `deploy:` block (config becomes just the flag line).

## Test plan
- [x] `yaml.safe_load` on the edited workflow passes
- [ ] Dry-run a publish from an SDR app repo (e.g. atlan-mssql-app) on a beta channel and confirm the version config in GM starts with `self_deployed_runtime: true`
- [ ] Publish from a non-SDR app and confirm the config is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)