### PR TITLE
chore(certify): install PKL before the app Contract-drift step

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -419,6 +419,21 @@ jobs:
         working-directory: app
         run: uv sync --all-extras --frozen
 
+      # PKL is required by pkl-based apps' `poe generate` (run in the Contract
+      # drift step below, which does `rm -rf app/generated && pkl eval ...`).
+      # The contract-toolkit-* workflows install it but this Certify job did
+      # not, so for pkl apps `poe generate` failed with `pkl: not found` AFTER
+      # wiping app/generated — breaking the enforced unit-test step.
+      - name: Install PKL
+        if: steps.app_install.outcome == 'success'
+        run: |
+          set -euo pipefail
+          PKL_VERSION="0.27.2"
+          curl -fsSL -o /tmp/pkl "https://github.com/apple/pkl/releases/download/${PKL_VERSION}/pkl-linux-amd64"
+          chmod +x /tmp/pkl
+          sudo mv /tmp/pkl /usr/local/bin/pkl
+          pkl --version
+
       # ── 3. Contract drift ─────────────────────────────────────────────────────
       - name: "Contract drift — poe generate must be a no-op"
         id: contract_drift


### PR DESCRIPTION
## Problem
The Certify job in `build-and-publish-app.yaml` runs `poe generate` in the **Contract drift** step. For pkl-based apps (teradata, sap-hana, bigquery, …) that task does:

```
rm -rf app/generated && mkdir -p app/generated && cd contract && pkl eval ...
```

But the Certify job never installs **`pkl`**, so `poe generate` fails with `pkl: not found` **after** it has already wiped `app/generated/`. The enforced **Unit tests** step then fails to import the now-deleted generated modules (`ModuleNotFoundError: No module named 'app.generated.crawler'`) and **publish is blocked**.

`pkl` is installed in the `contract-toolkit-*` workflows but was missing from this app-build Certify job (the gate added in #1964). Apps whose last green build predates the gate (e.g. teradata's Jun 1 build) only start failing now.

## Fix
Add an **Install PKL** step (pinned `0.27.2`, matching `contract-toolkit-validate.yml` / `contract-toolkit-publish.yml`) after "Install app dependencies" and before the Contract-drift step, gated on a successful app install.

## Effect
Unblocks pkl-based app builds (teradata/sap-hana/bigquery/…) on the new certify gate. No change for non-pkl apps (the drift step already early-exits when `contract/app.pkl` is absent; the install is cheap and harmless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)