### PR TITLE
chore(certify): enforce contract-drift, drop continue-on-error

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -434,11 +434,14 @@ jobs:
           sudo mv /tmp/pkl /usr/local/bin/pkl
           pkl --version
 
-      # ── 3. Contract drift ─────────────────────────────────────────────────────
+      # ── 3. Contract drift (enforced) ─────────────────────────────────────────
+      # Failure here exits non-zero and (via the standard step-fail cascade)
+      # also fails the job. Unit tests + coverage below use `always() &&` so
+      # they still run and report — the user sees every signal in one pass —
+      # even though the job's final status is already failed.
       - name: "Contract drift — poe generate must be a no-op"
         id: contract_drift
         if: steps.app_install.outcome == 'success'
-        continue-on-error: true
         working-directory: app
         run: |
           set -euo pipefail
@@ -450,16 +453,16 @@ jobs:
             echo "::warning::'poe' task runner not available — cannot run drift check."
             exit 0
           fi
-          uv run poe generate || { echo "::warning::'poe generate' failed"; exit 1; }
+          uv run poe generate || { echo "::error::'poe generate' failed"; exit 1; }
           if ! git diff --exit-code -- generated/; then
-            echo "::warning::generated/ is stale — run 'poe generate' locally and commit."
+            echo "::error::generated/ is stale — run 'poe generate' locally and commit."
             exit 1
           fi
 
       # ── 4. Unit tests (enforced) + coverage threshold (warn-only) ───────────────
       - name: "Unit tests"
         id: unit
-        if: steps.app_install.outcome == 'success'
+        if: always() && steps.app_install.outcome == 'success'
         continue-on-error: true
         working-directory: app
         run: |
@@ -477,7 +480,7 @@ jobs:
 
       - name: "Coverage threshold (>=85%)"
         id: coverage_threshold
-        if: steps.unit.outcome == 'success'
+        if: always() && steps.unit.outcome == 'success'
         continue-on-error: true
         working-directory: app
         run: |
@@ -489,10 +492,12 @@ jobs:
           uv run coverage report --data-file=.coverage --fail-under=85
 
       # ── Verdict ───────────────────────────────────────────────────────────────
-      # Unit test pass/fail (UT) ENFORCES: a ❌ exits non-zero, trips
-      # `prepare`'s `if: !failure()`, and skips build + publish.
-      # Coverage threshold (COV), v3 shape (CM), and contract drift (CD)
-      # are warn-only — they annotate but do not block.
+      # Unit test pass/fail (UT) and contract drift (CD) ENFORCE: a ❌ exits
+      # non-zero, trips `prepare`'s `if: !failure()`, and skips build + publish.
+      # (CD's enforcement comes from the step itself — no continue-on-error.
+      # The verdict re-checks CD only to render the summary correctly.)
+      # Coverage threshold (COV) and v3 shape (CM) are warn-only — they
+      # annotate but do not block.
       - name: Certification verdict
         if: always()
         env:
@@ -521,11 +526,11 @@ jobs:
             echo "### App certification"
             echo ""
             render "$cm_label" "$CM"
-            render "Contract drift (poe generate) — warn-only${app_label}" "$CD"
+            render "Contract drift (poe generate) — enforced${app_label}" "$CD"
             render "Unit tests — enforced${app_label}" "$UT"
             render "Coverage (>=85%) — warn-only" "$COV"
             echo ""
-            echo "**Unit test pass/fail blocks publish on ❌.** Coverage threshold, v3 shape, and contract drift are warn-only during rollout. See [docs/standards/app-certification.md](https://github.com/atlanhq/application-sdk/blob/main/docs/standards/app-certification.md)."
+            echo "**Unit tests and contract drift block publish on ❌.** Coverage threshold and v3 shape are warn-only during rollout. See [docs/standards/app-certification.md](https://github.com/atlanhq/application-sdk/blob/main/docs/standards/app-certification.md)."
           } >> "${GITHUB_STEP_SUMMARY}"
           if [ "$SDK_INSTALL" != "success" ]; then
             echo "::warning title=Certification incomplete::SDK install failed, so check_migration did not run."
@@ -533,11 +538,20 @@ jobs:
           if [ "$APP_INSTALL" != "success" ]; then
             echo "::warning title=Certification incomplete::App install failed; contract drift and unit tests did not run."
           fi
-          if [ "$CM" = "failure" ] || [ "$CD" = "failure" ]; then
-            echo "::warning title=Certification warning (warn-only)::v3 shape and/or contract drift failed; publish proceeded (warn-only)."
+          if [ "$CM" = "failure" ]; then
+            echo "::warning title=Certification warning (warn-only)::v3 shape failed; publish proceeded (warn-only)."
           fi
           if [ "$COV" = "failure" ]; then
             echo "::warning title=Certification warning (warn-only)::Coverage below 85%; publish proceeded (warn-only)."
+          fi
+          if [ "$CD" = "failure" ]; then
+            {
+              echo ""
+              echo "### ❌ Publish blocked — contract drift"
+              echo ""
+              echo "\`poe generate\` either failed or produced changes in \`app/generated/\`. Run it locally and commit the diff."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            echo "::error title=Publish blocked::Contract drift detected. Build and publish blocked."
           fi
           if [ "$UT" = "failure" ]; then
             {
@@ -547,6 +561,8 @@ jobs:
               echo "Fix the failing tests and re-run."
             } >> "${GITHUB_STEP_SUMMARY}"
             echo "::error title=Publish blocked::Unit tests failed. Build and publish blocked."
+          fi
+          if [ "$CD" = "failure" ] || [ "$UT" = "failure" ]; then
             exit 1
           fi
           exit 0
@@ -781,10 +797,10 @@ jobs:
     # publish=false, all of them are skipped via their `if:` — which by default
     # would propagate "skipped" to dependents. The condition below explicitly
     # allows prepare to run when those jobs are skipped OR successful, but NOT
-    # when one failed. `certify` enforces its unit + coverage check: a failing
-    # run exits non-zero, which trips `failure()` here and correctly skips
-    # prepare → build → publish. Its other layers (v3 shape, contract drift)
-    # stay warn-only (always exit 0) so they never trip this yet.
+    # when one failed. `certify` enforces unit tests and contract drift: a
+    # failing run exits non-zero, which trips `failure()` here and correctly
+    # skips prepare → build → publish. Its other layers (v3 shape, coverage
+    # threshold) stay warn-only (always exit 0) so they never trip this yet.
     # `leak-scan` blocks ONLY on its gitleaks (hardcoded-secret) layer: that
     # step exits non-zero, fails the job, and trips `failure()` here to skip the
     # publish. Its creds-into-logs layer is warn-only (annotates + pings Slack,

--- a/docs/standards/app-certification.md
+++ b/docs/standards/app-certification.md
@@ -43,29 +43,25 @@ for free, with zero changes to its repo.
 | Layer | Mode |
 |-------|------|
 | **Unit tests** | **Enforced** — a ❌ exits the verdict step non-zero and blocks publish. |
+| **Contract drift** | **Enforced** — a ❌ on the step fails the job (no `continue-on-error`) and blocks publish. |
 | **Coverage threshold** | Warn-only — annotated, does not block. |
 | **v3 shape** | Warn-only — annotated, does not block. |
-| **Contract drift** | Warn-only — annotated, does not block. |
 
-Unit test pass/fail is enforced: consistent with the `unit-tests-gate` job
-(PR #1945), a failing test run blocks publish. Coverage threshold, v3 shape,
-and contract drift remain warn-only during rollout — every check runs and the
-verdict is annotated on the workflow summary, but only a test failure exits
-non-zero.
+Unit test pass/fail and contract drift are enforced: a failing run blocks
+publish. Coverage threshold and v3 shape remain warn-only during rollout —
+every check runs and the verdict is annotated on the workflow summary, but
+only a test or contract-drift failure exits non-zero.
 
 Checks that don't apply to an app skip cleanly (➖) so non-conforming apps are
 never hard-failed before they onboard. In particular, an app with no
-`tests/unit/` directory skips both the unit and coverage checks (➖).
+`tests/unit/` directory skips both the unit and coverage checks (➖), and an
+app with no `contract/app.pkl` skips the contract-drift check.
 
 ## Known rollout gaps (before enforcement)
 
 - **Coverage threshold fixed at 85%.** Before flipping to enforcing, verify
   active connector repos meet this bar. Raise the enforcement question in
   `#pod-app-distribution`.
-- **Contract drift needs the pkl toolchain.** If `poe generate` requires pkl
-  and it isn't installed on the runner, the check is recorded as a failure.
-  Installing pkl in the `certify` job is a prerequisite for flipping
-  contract-drift to blocking.
 
 ## Relationship to the other layers
 


### PR DESCRIPTION
## Summary

- Removes `continue-on-error: true` from the **Contract drift** step in the `certify` job so a drift failure (or `poe generate` failure) now fails the job and skips `prepare → build → publish`, matching the unit-test enforcement path.
- `unit` + `coverage_threshold` steps now use `if: always() && …` so they still run and annotate the verdict summary even when contract drift has already failed — without this, GHA's implicit `success()` would silently skip them and hide unit-test signals on a drift failure.
- Verdict step renders Contract drift as **enforced**, moves CD failure out of the warn-only branch into the publish-blocked branch alongside UT.
- `docs/standards/app-certification.md` updated to reflect the new enforcement and to drop the obsolete "pkl not installed on runner" rollout gap (PKL has been installed in the certify job since #1986).

## Context

[atlan-teradata-app run #26943117913](https://github.com/atlanhq/atlan-teradata-app/actions/runs/26943117913/job/79489271143) tripped this:

```
org.pkl.core.http.HttpClientInitException: Cannot find CA certificate file `/home/runner/.pkl-ca-bundle.pem`.
```

That failure happened **inside** `poe generate`, but the certify step was marked `continue-on-error: true`, so the certification verdict labeled it warn-only and the publish proceeded as if drift were clean. After this PR, the same failure would fail certify and block publish — a real bug surfaces as a real block.

## Out of scope (separate fix in the app repo)

The CA-bundle error itself is an app-side issue. Nothing in the SDK, contract-toolkit, or `make-contract` skill uses `--ca-certificates ~/.pkl-ca-bundle.pem` — the standard pkl invocations are just `pkl project resolve` + `pkl eval`, and the JVM truststore is sufficient for `pkg.pkl-lang.org` / Atlan's registry. The flag should be removed from `atlan-teradata-app`'s `[tool.poe.tasks.generate]` (both the `pkl project resolve` and `pkl eval` calls). Will raise that fix in the app repo separately.

## Audit of remaining `continue-on-error` usages

24 other occurrences across `.github/`. All reviewed; all legitimate (VPN 3-attempt retries with explicit fail steps, SARIF telemetry uploads where the scan itself is the gating signal, PR-comment posting followed by an explicit fail step, the `v3-readiness-check` aggregator pattern, and the remaining certify siblings — sdk_install / check_migration / app_install / unit / coverage_threshold — that are either warn-only audits or are downstream-gated by `outcome == 'success'`). No mass revert.

One soft flag worth noting separately: `build-and-scan.yaml:187` (`Download Trivy results` artifact). If the artifact is missing, `check_allowlist.py` runs against absent input. Not changed here but raised for awareness.

## Test plan

- [ ] Run the `Build & Publish Atlan App` workflow on an app with a known-clean contract → certify passes, publish proceeds.
- [ ] Run it on an app whose `app/generated/` is intentionally stale → certify's Contract drift step fails ❌, verdict renders "Publish blocked — contract drift", `prepare` job is skipped via `if: !failure()`, no build/publish runs.
- [ ] Run it on an app whose `poe generate` errors out (e.g. the current teradata CA-bundle case before the app-side fix lands) → same as above: certify fails, publish blocked.
- [ ] Run it on an app with no `contract/app.pkl` → Contract drift skips cleanly (➖), unit tests still run, publish proceeds if they pass.
- [ ] Run it on an app where unit tests fail but contract drift passes → publish blocked on UT only, drift renders ✅.