### PR TITLE
ci(certify): seed pkl CA bundle from system trust store

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -434,6 +434,27 @@ jobs:
           sudo mv /tmp/pkl /usr/local/bin/pkl
           pkl --version
 
+      # Most app `poe generate` tasks invoke `pkl eval --ca-certificates
+      # ~/.pkl-ca-bundle.pem ...` — that path is Atlan's local-dev convention
+      # (per atlan-cli's defaultCert and ~20 connector pyproject.toml files)
+      # for honoring the corporate proxy/VPN CA. GitHub runners have no such
+      # file, so pkl fails with "Cannot find CA certificate file" BEFORE it
+      # can resolve `@app-contract-toolkit/NativeApp.pkl` over HTTPS. Seed
+      # ~/.pkl-ca-bundle.pem from the runner's system trust store so every
+      # app's `--ca-certificates ~/.pkl-ca-bundle.pem` resolves to a valid
+      # bundle in CI without app-side changes.
+      - name: Seed pkl CA bundle from system trust store
+        if: steps.app_install.outcome == 'success'
+        run: |
+          set -euo pipefail
+          SYSTEM_CA="/etc/ssl/certs/ca-certificates.crt"
+          if [ ! -f "$SYSTEM_CA" ]; then
+            echo "::warning::System CA bundle $SYSTEM_CA not found; skipping pkl CA seed."
+            exit 0
+          fi
+          cp "$SYSTEM_CA" "$HOME/.pkl-ca-bundle.pem"
+          echo "Seeded $HOME/.pkl-ca-bundle.pem from $SYSTEM_CA"
+
       # ── 3. Contract drift (enforced) ─────────────────────────────────────────
       # Failure here exits non-zero and (via the standard step-fail cascade)
       # also fails the job. Unit tests + coverage below use `always() &&` so


### PR DESCRIPTION
## Summary

- Unblocks the **Contract-drift (enforced)** step in `build-and-publish-app.yaml` for apps that use the conventional `pkl eval --ca-certificates ~/.pkl-ca-bundle.pem ...` in their `poe generate` task.
- Right after Install PKL, copies the runner's system trust store (`/etc/ssl/certs/ca-certificates.crt`) → `~/.pkl-ca-bundle.pem` so the flag every app already passes resolves to a valid CA bundle in CI.
- Zero app-side changes required.

## Context

The path `~/.pkl-ca-bundle.pem` is Atlan's local-dev convention: `atlan-cli` reads it as `defaultCert`, and ~20 connector `pyproject.toml` files hard-code it (so devs behind the Atlan corporate proxy/VPN can fetch `@app-contract-toolkit/NativeApp.pkl` over MITM-intercepted HTTPS). On a GitHub-hosted runner the file doesn't exist, so `pkl` errors out with:

```
–– Pkl Error ––
Cannot find CA certificate file `/home/runner/.pkl-ca-bundle.pem`.
```

…before it can resolve the toolkit package. With PR #1987 making Contract-drift **enforced**, that error now blocks build + publish for every pkl-based app — e.g. [atlan-saphana-app run 26955616072](https://github.com/atlanhq/atlan-saphana-app/actions/runs/26955616072/job/79531924955).

Seeding `~/.pkl-ca-bundle.pem` from the runner's system CAs is semantically the same as what dev Macs put in that file (system roots), minus the proxy cert (none needed on a GitHub runner). It's CI environment setup, same category as the Install PKL step right above it.

## Test plan

- [ ] After merge, re-run the saphana certify job and confirm `poe generate` resolves `@app-contract-toolkit/NativeApp.pkl` and Contract-drift turns ✅ (or fails on a real diff, not on the missing CA bundle).
- [ ] Smoke-check on another pkl-based app (athena / mode / dynamodb) that the seed step runs and `pkl eval` succeeds.