### PR TITLE
feat(build-and-publish-app): add optional image_name override for renamed repos

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -65,6 +65,11 @@ on:
         required: false
         type: string
         default: ""
+      image_name:
+        description: "Override the image name used for GHCR + DockerHub repos. Defaults to the caller's repository name. Use this when the repo has been renamed but the existing GHCR package was created under the previous name (GitHub does not auto-rename packages on repo rename, and org policies typically block ORG_PAT_GITHUB from auto-creating new container packages — so without this override, the first push after rename 403s)."
+        required: false
+        type: string
+        default: ""
     secrets:
       ORG_PAT_GITHUB:
         required: true
@@ -946,7 +951,9 @@ jobs:
       - name: Compute image tags
         id: tags
         env:
-          REPO: ${{ github.event.repository.name }}
+          # image_name override (when set) lets renamed repos keep pushing to
+          # their pre-rename GHCR package. See input docs above.
+          REPO: ${{ inputs.image_name != '' && inputs.image_name || github.event.repository.name }}
           REF: ${{ inputs.ref || github.ref }}
         run: |
           # Resolve SHA from the checked-out HEAD rather than github.sha.


### PR DESCRIPTION
## Summary

Adds an optional `image_name` input to the `build-and-publish-app.yaml` reusable workflow. When a repo is renamed but its linked GHCR container package stays under the old name, callers can pass the pre-rename name to keep the CI pipeline working.

## Why

When a GitHub repo is renamed, the linked GHCR container package is **not** auto-renamed. The reusable workflow derives the image name from `github.event.repository.name`, so the first push after a rename targets a non-existent GHCR package. Most orgs block `ORG_PAT_GITHUB` from auto-creating new container packages, so the push 403s — and the entire pipeline (including the downstream Docker Hub re-tag, which depends on a successful GHCR push) breaks.

**Concrete case driving this:** `atlanhq/atlan-alloydb-postgres-app` was renamed from `atlan-alloydb-app`. Every `build-and-publish` run on that repo has 403'd at the GHCR push step since 2026-05-22, blocking a CRITICAL-severity-patched image (CVE-2026-39821 in bundled daprd) from reaching CME Group via Docker Hub.

## Change

One input + one expression. Fully backward-compatible:

```yaml
inputs:
  image_name:
    description: "Override the image name used for GHCR + DockerHub repos. ..."
    required: false
    type: string
    default: ""
```

```yaml
env:
  REPO: ${{ inputs.image_name != '' && inputs.image_name || github.event.repository.name }}
```

When unset (the default for every existing caller), `REPO` falls through to `github.event.repository.name` exactly as today. Both `GHCR_BASE` and `DOCKERHUB_BASE` are derived from `REPO` in the same step, so the override flows through both pushes consistently — no additional plumbing needed.

## Usage

In a renamed repo's `build-and-publish.yaml`:

```yaml
jobs:
  build-and-publish:
    uses: atlanhq/application-sdk/.github/workflows/build-and-publish-app.yaml@main
    with:
      image_name: atlan-alloydb-app   # pre-rename package name
    secrets: inherit
```

## Test plan

- [x] Default behaviour unchanged when `image_name` is unset (verified by reading the conditional — empty string false-branch resolves to `github.event.repository.name`).
- [ ] Consumer PR on `atlanhq/atlan-alloydb-postgres-app` passes `image_name: atlan-alloydb-app` and lands the long-blocked image on Docker Hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)