### PR TITLE
fix(contract-toolkit): preserve in-pipeline position for extraNodes publish override

### DIFF
--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -1957,25 +1957,39 @@ local function generateDAG(): Mapping<String, Any> = new Mapping {
   when (pipeline.lineage != null) {
     ["lineage-app"] = renderNode(pipeline.lineage!!)
   }
-  when (pipeline.publish != null && !extraNodes.toMap().containsKey("publish")) {
+  when (pipeline.publish != null || extraNodes.toMap().containsKey("publish")) {
+    // If the app overrides the publish node via `extraNodes["publish"]`, emit
+    // the override here so it keeps the typed publish node's position in the
+    // generated DAG (between `lineage-app` and `lineage-publish`). Without
+    // this in-place emit, the override would only be appended by the trailing
+    // `for` loop and end up after `lineage-publish` — a cosmetic but noisy
+    // diff that hurts reviewability of override PRs.
     ["publish"] =
-      let (ps = pipeline.publish!!)
-      let (_publishEhCheck = validateWorkflowNodeErrorHandling(ps.errorHandling, "pipeline.publish.errorHandling"))
-      renderNode(new PublishNode {
-        executorEnabled = ps.executorEnabled
-        displayName = ps.displayName
-        errorHandling = ps.errorHandling
-        connectionCacheEnabled = ps.connectionCacheEnabled
-        connectionCacheViaAppEnabled = ps.connectionCacheViaAppEnabled
-        currentStateEnabled = ps.currentStateEnabled
-        currentStateViaAppEnabled = ps.currentStateViaAppEnabled
-      })
+      if (extraNodes.toMap().containsKey("publish"))
+        renderNode(extraNodes["publish"])
+      else
+        let (ps = pipeline.publish!!)
+        let (_publishEhCheck = validateWorkflowNodeErrorHandling(ps.errorHandling, "pipeline.publish.errorHandling"))
+        renderNode(new PublishNode {
+          executorEnabled = ps.executorEnabled
+          displayName = ps.displayName
+          errorHandling = ps.errorHandling
+          connectionCacheEnabled = ps.connectionCacheEnabled
+          connectionCacheViaAppEnabled = ps.connectionCacheViaAppEnabled
+          currentStateEnabled = ps.currentStateEnabled
+          currentStateViaAppEnabled = ps.currentStateViaAppEnabled
+        })
   }
   when (pipeline.publish != null && pipeline.publish!!.lineagePublish != null) {
     ["lineage-publish"] = renderNode(pipeline.publish!!.lineagePublish!!)
   }
   for (nodeId, node in extraNodes) {
-    [nodeId] = renderNode(node)
+    // `publish` is already emitted above (at its in-pipeline position) when
+    // overridden via `extraNodes["publish"]`; skip it here to avoid emitting
+    // a duplicate trailing entry.
+    when (nodeId != "publish") {
+      [nodeId] = renderNode(node)
+    }
   }
 }
 

--- a/contract-toolkit/tests/extra_nodes_publish_override_test.pkl
+++ b/contract-toolkit/tests/extra_nodes_publish_override_test.pkl
@@ -1,0 +1,52 @@
+// Tests that an app overriding the typed publish node via `extraNodes["publish"]`
+// keeps the override at the same position the typed publish node would have
+// occupied (between `lineage-app` and `lineage-publish`), and that the
+// override's args are emitted intact.
+//
+// Background: `extraNodes` was implemented as an append-at-end mechanism.
+// When the same key as a typed pipeline node ("publish") was used to inject
+// extra args (e.g. `delete_percentage_circuit_breaker`), the override ended
+// up after `lineage-publish` in the JSON. AE doesn't care about JSON key
+// order, but it produced a noisy diff that made override PRs hard to review.
+
+amends "pkl:test"
+
+import "pkl:json"
+import "fixtures/extra_nodes_publish_override.pkl" as overrideApp
+
+local manifest = new json.Parser { useMapping = true }.parse(
+  overrideApp.output.files["app/generated/manifest.json"].text
+)
+local dag = manifest["dag"]
+local nodeIds: List<String> = dag.keys.toList()
+local publishArgs = dag["publish"]["inputs"]["args"]
+
+facts {
+  ["DAG contains both publish and lineage-publish nodes"] {
+    dag["publish"] != null
+    dag["lineage-publish"] != null
+  }
+
+  ["publish node is emitted before lineage-publish"] {
+    nodeIds.indexOf("publish") < nodeIds.indexOf("lineage-publish")
+  }
+
+  ["publish override carries the additive arg from extraNodes"] {
+    publishArgs["delete_percentage_circuit_breaker"] == 90.0
+  }
+
+  ["publish override preserves the standard publish args"] {
+    publishArgs["connection_cache_enabled"] == true
+    publishArgs["connection_cache_via_app_enabled"] == true
+    publishArgs["current_state_enabled"] == true
+    publishArgs["current_state_via_app_enabled"] == true
+    publishArgs["connection_qualified_name"] != null
+    publishArgs["transformed_data_prefix"] != null
+    publishArgs["publish_state_prefix"] != null
+    publishArgs["current_state_prefix"] != null
+  }
+
+  ["publish override is emitted exactly once in the DAG"] {
+    nodeIds.filter((id) -> id == "publish").length == 1
+  }
+}

--- a/contract-toolkit/tests/fixtures/extra_nodes_publish_override.pkl
+++ b/contract-toolkit/tests/fixtures/extra_nodes_publish_override.pkl
@@ -1,0 +1,40 @@
+/// Fixture: app that declares both `pipeline.publish` (with `lineagePublish`)
+/// AND an `extraNodes["publish"]` override. Used to verify that the override
+/// keeps the typed publish node's position in the emitted DAG (between
+/// `lineage-app` and `lineage-publish`) instead of being appended at the end.
+amends "../../src/App.pkl"
+
+name = "extra-nodes-publish-override"
+displayName = "Extra Nodes Publish Override"
+icon = "https://assets.atlan.com/assets/fullscreen-exit.svg"
+hasCredentialConfig = false
+
+pipeline {
+  publish = new PublishStep {
+    lineagePublish = new LineagePublishStep {}
+  }
+}
+
+extraNodes {
+  ["publish"] = new PublishNode {
+    connectionCacheEnabled = true
+    connectionCacheViaAppEnabled = true
+    currentStateEnabled = true
+    currentStateViaAppEnabled = true
+    args {
+      ["delete_percentage_circuit_breaker"] = 90.0
+    }
+  }
+}
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs {
+        ["connection"] = new ConnectionCreator {
+          placeholderText = "Connection Name"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- When an app overrides the publish node via `extraNodes[\"publish\"]`, emit it at the typed publish node's position (between `lineage-app` and `lineage-publish`) instead of appending after `lineage-publish`.
- Adds a regression test (`tests/extra_nodes_publish_override_test.pkl`) — 5 facts, 13 asserts — and a small fixture.
- Full toolkit suite: **83/83 pass** (was 78 before, +5 new asserts modules → 297 asserts total).

## Why

The `extraNodes[\"publish\"]` mechanism (documented inline at `App.pkl:238`) is the only path apps have to inject args the typed `PublishStep` doesn't expose — e.g. `delete_percentage_circuit_breaker`, which we currently need for the connection-cache-pollution unblock (see [atlan-mysql-app#169](https://github.com/atlanhq/atlan-mysql-app/pull/169)).

Before this change, the override landed at the end of the DAG:

```
extract → qi → lineage-app → lineage-publish → publish    ❌ (before)
extract → qi → lineage-app → publish → lineage-publish    ✅ (after)
```

AE doesn't care about JSON key order — the DAG is a map and execution is driven by `depends_on` — but the noisy diff actively hurts reviewability of override PRs. Reviewers see large blocks moving around and have to manually verify nothing semantic was lost. Fixing this in the toolkit removes that friction for every app that needs the pattern.

## Mechanism

Two changes in `generateDAG()` (App.pkl ~line 1960):

1. The publish emit clause is now gated on `pipeline.publish != null || extraNodes.toMap().containsKey(\"publish\")`. Body: if `extraNodes[\"publish\"]` is set, render the override; otherwise fall back to building a `PublishNode` from `PublishStep`.
2. The trailing `for (nodeId, node in extraNodes)` loop skips `\"publish\"` to avoid emitting a duplicate trailing entry.

No change to `PublishStep`, `PublishNode`, or the `pipeline.publish.lineagePublish` emit path — `lineage-publish` continues to come from the typed pipeline.

## Test plan

- [x] `pkl test tests/*.pkl` — 83/83 tests pass
- [x] New `tests/extra_nodes_publish_override_test.pkl` covers:
  - both `publish` and `lineage-publish` exist in the DAG
  - `publish` appears before `lineage-publish` in node order
  - override carries the additive arg (`delete_percentage_circuit_breaker: 90.0`)
  - override preserves standard publish args (cache flags, current-state flags, prefixes)
  - `publish` is emitted exactly once (no duplicate trailing entry)
- [ ] Validated end-to-end against [atlan-mysql-app#169](https://github.com/atlanhq/atlan-mysql-app/pull/169) (local toolkit pin → regenerate → confirm clean single-line diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)