### PR TITLE
chore(security): allowlist CVE-2026-6846 (binutils HIGH)

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Updated by SDK team. CODEOWNERS: SDK/security team only.",
   "_base_image": "application-sdk-main",
-  "_updated": "2026-05-09",
+  "_updated": "2026-06-05",
   "_renewal_note": "Expiry dates staggered by severity. CRITICAL: 15 days. HIGH: 30 days. Review before expiry. Enforced by .github/scripts/validate_allowlist.py via _expiry_policy below.",
   "_expiry_policy": {
     "CRITICAL": 15,
@@ -12,6 +12,17 @@
     "severity": "HIGH",
     "reason": "Base image - Dapr runtime dependency (Go stdlib used by daprd binary)",
     "expires": "2026-06-13",
+    "added_by": "mananjain99",
+    "fix_available_date": null,
+    "compensating_controls": null,
+    "re_evaluation_trigger": "expiry",
+    "exposure_assessment": null
+  },
+  "CVE-2026-6846": {
+    "package": "binutils (Alpine/Wolfi)",
+    "severity": "HIGH",
+    "reason": "Base image - Chainguard Wolfi binutils@2.46-r1. Fix available in 2.46-r2; awaiting SDK base image rebuild.",
+    "expires": "2026-07-05",
     "added_by": "mananjain99",
     "fix_available_date": null,
     "compensating_controls": null,


### PR DESCRIPTION
## Summary
Adds **CVE-2026-6846** (HIGH, base image) to `.security/base-allowlist.json` so the central allowlist gate stops blocking dependent connector PRs.

## Why
Surfaced by the security gate on [atlanhq/atlan-bigquery-app#119](https://github.com/atlanhq/atlan-bigquery-app/pull/119#issuecomment-4628862106):

| Severity | Scanner | ID | Package | Fix Available |
|----------|---------|-----|---------|---------------|
| HIGH | trivy | `CVE-2026-6846` | `binutils@2.46-r1` | 2.46-r2 |

Source: Chainguard Wolfi `binutils@2.46-r1` shipped via the SDK base image. Upstream fix exists (`2.46-r2`) but base image rebuild is pending. Allowlisting unblocks consumer connector PRs in the interim.

## Allowlist policy compliance
- Severity **HIGH** → 30-day expiry per `_expiry_policy`.
- Expires **2026-07-05** (re-evaluate on/before that date — either the base image will have rebuilt with `2.46-r2`, or the entry needs renewed justification).
- `validate_allowlist.py` passes: `Allowlist valid: 8 entries, all within policy`.

## Test plan
- [x] `python3 .github/scripts/validate_allowlist.py` passes locally
- [ ] `atlan-bigquery-app#119` security gate goes green after this merges