### PR TITLE
chore(security): renew CVE-2024-35515 (sqlitedict) allowlist entry

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -94,5 +94,16 @@
     "compensating_controls": null,
     "re_evaluation_trigger": "expiry",
     "exposure_assessment": null
+  },
+  "CVE-2024-35515": {
+    "package": "sqlitedict==2.1.0",
+    "severity": "HIGH",
+    "reason": "Python dependency - no upstream fix available.",
+    "expires": "2026-07-05",
+    "added_by": "chaitanyaatlan",
+    "fix_available_date": null,
+    "compensating_controls": null,
+    "re_evaluation_trigger": "expiry",
+    "exposure_assessment": null
   }
 }


### PR DESCRIPTION
## Summary

- Renews expired CVE-2024-35515 (sqlitedict@2.1.0) entry in `.security/base-allowlist.json`
- Previous entry expired 2026-05-23; no upstream fix is available
- New expiry: 2026-07-05 (30-day HIGH policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)