### PR TITLE
security: allowlist CVE-2026-25087 (pyarrow) pending <23 cap bump

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -83,5 +83,16 @@
     "compensating_controls": null,
     "re_evaluation_trigger": "expiry",
     "exposure_assessment": null
+  },
+  "CVE-2026-25087": {
+    "package": "pyarrow",
+    "severity": "HIGH",
+    "reason": "Python transitive dependency. Fix available in pyarrow 23.0.1, but the SDK's pandas/sql/incremental extras pin pyarrow<23.0.0 — adopting 23.x is a major-version bump that needs validation before the cap can be raised. Allowlisting downstream connector builds while the SDK bump is evaluated.",
+    "expires": "2026-07-08",
+    "added_by": "AngadSethi",
+    "fix_available_date": "2026-02-16",
+    "compensating_controls": null,
+    "re_evaluation_trigger": "fix_released",
+    "exposure_assessment": null
   }
 }


### PR DESCRIPTION
## What

Adds `CVE-2026-25087` (HIGH, `pyarrow`) to `.security/base-allowlist.json`.

## Why

The security gate is failing downstream connector builds (e.g. `atlan-cognos-app`) on this HIGH:

| Field | Value |
|-------|-------|
| CVE | `CVE-2026-25087` |
| Package | `pyarrow@22.0.0` |
| Fix version | `23.0.1` (released 2026-02-16) |

A fix exists, **but the SDK caps `pyarrow<23.0.0`** in its `pandas`, `sql`, and `incremental` extras (still true on the latest 3.15.0):

```
pyarrow<23.0.0,>=20.0.0; extra == "pandas"
```

So the resolver's allowed window is `>=20.0.0,<23.0.0` and the patched `23.0.1` sits just outside it. Downstream connectors can't reach the fix via a lockfile bump — the cap has to be raised here first. Adopting pyarrow 23.x is a **major-version bump** that needs validation against the SDK's own pyarrow usage before we change the constraint.

This entry allowlists the HIGH for **30 days** (HIGH policy max; expires `2026-07-08`) while the cap bump is evaluated.

- `re_evaluation_trigger`: `fix_released`
- `fix_available_date`: `2026-02-16`
- Validated by `.github/scripts/validate_allowlist.py` ✅

## Follow-up

Raise the `pandas`/`sql`/`incremental` extras to `pyarrow<24.0.0` (daft already supports `<24.0.0`) once 23.x is validated, then drop this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)