### PR TITLE
fix: bump dependencies and exclude sdk-version from capability manifest drift check

### DIFF
--- a/.github/workflows/capability-manifest-check.yaml
+++ b/.github/workflows/capability-manifest-check.yaml
@@ -92,15 +92,22 @@ jobs:
         id: drift
         if: steps.ctx.outputs.release == 'false'
         run: |
-          # source-sha / source-date are excluded: with squash merges the final
-          # SHA doesn't exist during the PR, so these fields are always stale
-          # until the manifest is regenerated post-merge.
+          # source-sha / source-date / sdk-version are excluded: with squash
+          # merges the final SHA doesn't exist during the PR, so source-sha/
+          # source-date are always stale until post-merge regeneration.
+          # sdk-version is excluded for the same reason: release PRs (bump-
+          # version-* branches) bump application_sdk/version.py, which the
+          # extractor reads to produce this header. In the merge queue the
+          # synthetic commit already has the new version, so the header would
+          # differ from the committed manifest even though no API surface changed.
+          # Excluding these three metadata-only header fields avoids false drift
+          # failures without hiding real API-surface changes.
           # || true: grep exits 1 on no matches; with pipefail that would kill the
           # script before the [ -z ] check, producing a false drift failure.
           SEMANTIC=$(git diff -- docs/agents/sdk-capabilities.md \
             | grep '^[+-]' \
             | grep -v '^+++\|^---' \
-            | grep -v '^[+-]source-sha:\|^[+-]source-date:' \
+            | grep -v '^[+-]source-sha:\|^[+-]source-date:\|^[+-]sdk-version:' \
             || true)
           if [ -z "$SEMANTIC" ]; then
             echo "status=clean" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- The capability manifest drift check was failing in the merge queue for release PRs (`bump-version-*` branches), forcing a bypass instead of using \"Merge when ready\"
- Root cause: release PRs bump `application_sdk/version.py`, which the extractor reads to generate the `sdk-version:` header in the manifest. In the merge queue the synthetic commit already has the new version, so the drift check found a diff even though no API surface changed
- Fix: exclude `sdk-version:` from the semantic diff, alongside the already-excluded `source-sha:` and `source-date:` — all three are metadata-only header fields that cannot hide real API-surface drift

## Test plan

- [ ] Merge a future release PR (`bump-version-main`) via \"Merge when ready\" — the capability manifest check should pass in the merge queue without a bypass
- [ ] Verify a PR that genuinely changes SDK surface still triggers the drift check (the exclusion only covers the three metadata header lines)