### PR TITLE
fix(contract-toolkit): hide JDBC merge-target auth panes

### DIFF
--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -134,6 +134,9 @@ selected upload widget plus `ui.accept`, `ui.fileMetadata`, and opt-in
 `ui.removeBeforeUpload` when the widget is emitted. When
 `credentialAuthOptions` has a single entry, the auth-type radio is auto-hidden —
 the generated default is still emitted, so no form input is required.
+For `credentialUrlGroup` forms, the visible auth panes live inside
+`jdbcUrl.properties`; root-level auth panes are hidden merge targets for agent
+credential overrides.
 
 ### Manifest (`app/generated/manifest.json`)
 

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -951,6 +951,11 @@ When `credentialUrlGroup != null`, the credential JSON emits:
      at `credential-guid.connectBy` / `credential-guid.extra.compiled_url`.
    - **`anyOf`** — enforces the selected auth-option pane is present.
 
+The renderer also emits each auth pane at the credential root as a hidden merge
+target for agent credential overrides. These root-level panes are not the
+visible credential UI; the visible JDBC auth panes live under
+`jdbcUrl.properties.<authKey>`.
+
 ### Classes
 
 ```pkl

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -1587,6 +1587,11 @@ local function renderJdbcAuthOption(opt: AuthOption): Mapping<String, Any> = new
   }
 }
 
+local function renderJdbcAuthMergeTargetOption(opt: AuthOption): Mapping<String, Any> =
+  let (auth = renderJdbcAuthOption(opt).toMap())
+  let (ui = (auth["ui"] as Mapping<String, Any>).toMap())
+  auth.put("ui", ui.put("hidden", true).toMapping()).toMapping()
+
 local extractionNamespaces: Map<String, String> = Map(
   "direct", "credential-guid",
   "agent", "agent-json"
@@ -1959,8 +1964,10 @@ local function generateCredentialConfig(): Mapping<String, Any> =
       when (credentialUrlGroup != null && credentialAuthOptions != null) {
         ["connectBy"] = renderConnectByRadio(credentialUrlGroup!!)
         ["jdbcUrl"] = renderJdbcUrlField(credentialUrlGroup!!, credentialAuthOptions!!)
+        // Top-level copies are agent merge targets only. The visible JDBC auth
+        // panes live inside jdbcUrl.properties.
         for (k, opt in credentialAuthOptions!!) {
-          [k] = renderJdbcAuthOption(opt)
+          [k] = renderJdbcAuthMergeTargetOption(opt)
         }
       }
       when (credentialUrlGroup == null && credentialAuthOptions != null) {

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -1865,6 +1865,11 @@ local function renderJdbcAuthOption(opt: AuthOption): Mapping<String, Any> = new
   }
 }
 
+local function renderJdbcAuthMergeTargetOption(opt: AuthOption): Mapping<String, Any> =
+  let (auth = renderJdbcAuthOption(opt).toMap())
+  let (ui = (auth["ui"] as Mapping<String, Any>).toMap())
+  auth.put("ui", ui.put("hidden", true).toMapping()).toMapping()
+
 /// Namespace prefix per extraction-method. `credential-guid` is the form-field
 /// path for the direct credential input; `agent-json` is the path used when the
 /// agent extraction mode layers an override schema on the same form.
@@ -2308,7 +2313,7 @@ local function generateCredentialConfig(): Mapping<String, Any> =
         // the merge creates orphaned entries with no ui metadata → empty boxes.
         // These hidden copies ensure the merge inherits correct ui (HYP-1251).
         for (k, opt in credentialAuthOptions!!) {
-          [k] = renderJdbcAuthOption(opt)
+          [k] = renderJdbcAuthMergeTargetOption(opt)
         }
       }
       // Plain auth-type flow (non-JDBC): auth-type radio + nested panes

--- a/contract-toolkit/tests/jdbc_auth_pane_test.pkl
+++ b/contract-toolkit/tests/jdbc_auth_pane_test.pkl
@@ -8,8 +8,11 @@
 /// creates orphaned top-level entries with no ui metadata.
 amends "pkl:test"
 
+import "pkl:json"
 import "../src/App.pkl" as App
+import "../src/Config.pkl"
 import "../src/Connectors.pkl"
+import "../src/NativeApp.pkl"
 
 /// Minimal JDBC-URL app with two auth types — exercises the exact
 /// code path in `generateCredentialConfig()` that emits top-level
@@ -84,7 +87,135 @@ local jdbcApp = (App) {
   }
 }
 
+/// Single-auth JDBC-URL app that intentionally reveals the real auth pane.
+/// The top-level copy must remain hidden because it is only an agent merge target.
+local singleAuthJdbcApp = (App) {
+  name = "jdbc-single-auth-test"
+  displayName = "JDBC Single Auth Test"
+  connector = Connectors.TERADATA
+  icon = "https://example.com/icon.svg"
+
+  credentialUrlGroup = new App.AdvancedJDBCUrlGroup {
+    protocol = ""
+    urlAddonBefore = "driver://"
+    hostField = new App.FieldSpec {
+      name = "host"
+      displayName = "Host"
+      placeholder = "host.example.com"
+      feedback = true
+    }
+    portField = new App.FieldSpec {
+      name = "port"
+      fieldType = "number"
+      displayName = "Port"
+      placeholder = "1025"
+      defaultValue = "1025"
+      required = false
+    }
+  }
+
+  credentialAuthOptions {
+    ["basic"] = new App.JDBCUrlAuthOption {
+      label = "Basic"
+      nestedLabel = "Basic"
+      nestedHidden = false
+      urlPartMapping = new App.UrlPartMapping {
+        hostname = "host"
+        searchParams {
+          ["PORT"] = new App.UrlRef { field = "port" }
+        }
+      }
+      fields {
+        new App.FieldSpec { name = "username"; displayName = "Username" }
+        new App.FieldSpec { name = "password"; sensitive = true; displayName = "Password" }
+      }
+    }
+  }
+
+  uiConfig = new App.UIConfig {
+    tasks {
+      ["Credential"] {
+        inputs {
+          ["credential-guid"] = new App.CredentialInput {
+            credType = "atlan-connectors-jdbc-single-auth-test"
+          }
+        }
+      }
+    }
+  }
+}
+
+local nativeSingleAuthJdbcApp = (NativeApp) {
+  name = "native-jdbc-single-auth-test"
+  displayName = "Native JDBC Single Auth Test"
+  connector = Connectors.TERADATA
+  workflowType = "NativeJdbcSingleAuthTestWorkflow"
+  icon = "https://example.com/icon.svg"
+
+  credentialUrlGroup = new NativeApp.AdvancedJDBCUrlGroup {
+    protocol = ""
+    urlAddonBefore = "driver://"
+    hostField = new NativeApp.FieldSpec {
+      name = "host"
+      displayName = "Host"
+      placeholder = "host.example.com"
+      feedback = true
+    }
+    portField = new NativeApp.FieldSpec {
+      name = "port"
+      fieldType = "number"
+      displayName = "Port"
+      placeholder = "1025"
+      defaultValue = "1025"
+      required = false
+    }
+  }
+
+  credentialAuthOptions {
+    ["basic"] = new NativeApp.JDBCUrlAuthOption {
+      label = "Basic"
+      nestedLabel = "Basic"
+      nestedHidden = false
+      urlPartMapping = new NativeApp.UrlPartMapping {
+        hostname = "host"
+        searchParams {
+          ["PORT"] = new NativeApp.UrlRef { field = "port" }
+        }
+      }
+      fields {
+        new NativeApp.FieldSpec { name = "username"; displayName = "Username" }
+        new NativeApp.FieldSpec { name = "password"; sensitive = true; displayName = "Password" }
+      }
+    }
+  }
+
+  uiConfig = new Config.UIConfig {
+    tasks {
+      ["Credential"] {
+        inputs {
+          ["credential-guid"] = new Config.CredentialInput {
+            credType = "atlan-connectors-native-jdbc-single-auth-test"
+          }
+        }
+      }
+    }
+  }
+}
+
 local credentialJson: String = jdbcApp.output.files["app/generated/atlan-connectors-jdbc-auth-test.json"].text
+local credential = new json.Parser { useMapping = true }.parse(credentialJson)
+
+local singleAuthCredentialJson: String =
+  singleAuthJdbcApp.output.files["app/generated/atlan-connectors-jdbc-single-auth-test.json"].text
+local singleAuthCredential = new json.Parser { useMapping = true }.parse(singleAuthCredentialJson)
+
+local nativeSingleAuthCredentialJson: String =
+  nativeSingleAuthJdbcApp.output.files["atlan-connectors-native-jdbc-single-auth-test.json"].text
+local nativeSingleAuthCredential = new json.Parser { useMapping = true }.parse(nativeSingleAuthCredentialJson)
+
+local credentialProperties = credential["config"]["properties"]
+local singleAuthProperties = singleAuthCredential["config"]["properties"]
+local nativeSingleAuthProperties = nativeSingleAuthCredential["config"]["properties"]
 
 facts {
   ["JDBC-URL credential configmap contains AdvancedJDBCUrlGroup and connectBy"] {
@@ -94,19 +225,28 @@ facts {
   }
 
   ["Top-level auth panes emitted as hidden merge targets (HYP-1251)"] {
-    // Both auth panes must exist at the top level for agent widget merges
-    credentialJson.contains("\"basic\"")
-    credentialJson.contains("\"ldap\"")
-    // They must be hidden (visible versions live inside jdbcUrl.properties)
-    credentialJson.contains("\"hidden\": true")
-    credentialJson.contains("\"widget\": \"nested\"")
-    credentialJson.contains("\"nestedValue\": false")
+    credentialProperties["basic"]["ui"]["hidden"] == true
+    credentialProperties["ldap"]["ui"]["hidden"] == true
+    credentialProperties["basic"]["ui"]["widget"] == "nested"
+    credentialProperties["basic"]["ui"]["nestedValue"] == false
   }
 
   ["Auth panes also exist inside jdbcUrl.properties"] {
-    // The AdvancedJDBCUrlGroup widget renders from these nested versions
-    credentialJson.contains("\"auth-type\"")
-    credentialJson.contains("\"Username\"")
-    credentialJson.contains("\"Password\"")
+    credentialProperties["jdbcUrl"]["properties"]["basic"]["ui"]["hidden"] == true
+    credentialProperties["jdbcUrl"]["properties"]["ldap"]["ui"]["hidden"] == true
+    credentialProperties["jdbcUrl"]["properties"]["basic"]["properties"]["username"]["ui"]["label"] == "Username"
+    credentialProperties["jdbcUrl"]["properties"]["basic"]["properties"]["password"]["ui"]["label"] == "Password"
+  }
+
+  ["App.pkl single-auth JDBC exposes only the in-card auth pane"] {
+    singleAuthProperties["basic"]["ui"]["hidden"] == true
+    singleAuthProperties["jdbcUrl"]["properties"]["basic"]["ui"]["hidden"] == false
+    singleAuthProperties["jdbcUrl"]["properties"]["auth-type"]["ui"]["hidden"] == true
+  }
+
+  ["NativeApp.pkl single-auth JDBC exposes only the in-card auth pane"] {
+    nativeSingleAuthProperties["basic"]["ui"]["hidden"] == true
+    nativeSingleAuthProperties["jdbcUrl"]["properties"]["basic"]["ui"]["hidden"] == false
+    nativeSingleAuthProperties["jdbcUrl"]["properties"]["auth-type"]["ui"]["hidden"] == true
   }
 }


### PR DESCRIPTION
## Summary
- Fixes single-auth AdvancedJDBCUrlGroup credential forms that rendered the auth pane twice.
- Keeps HYP-1251 top-level JDBC auth panes as hidden agent merge targets.
- Preserves visible auth-pane rendering under jdbcUrl.properties for the AdvancedJDBCUrlGroup UI.
- Adds App.pkl and NativeApp.pkl regression coverage for the single-auth nestedHidden=false case.

## Root Cause
JDBC URL credentials render auth panes in two places: inside jdbcUrl.properties for the visible AdvancedJDBCUrlGroup card, and at credential root as agent merge targets. When single-auth connectors hide the auth-type radio, they need nestedHidden=false so the only auth pane is enterable. The same nestedHidden value also controlled the root merge target, making both copies visible.

## Affected Toolkit Surfaces
- Credential config output: App.pkl and NativeApp.pkl JDBC URL auth pane rendering.
- UI rendering compatibility: single-auth AdvancedJDBCUrlGroup forms now expose only the in-card auth pane.
- Examples/docs: docs clarify that root-level JDBC auth panes are hidden merge targets.

## Cross-Repo Validation
- UI rendering compatibility: validated
- Manifest substitution compatibility: not applicable
- Workflow execution contract: not applicable
- Generated SDK input contract: validated
- Representative app pattern: validated

## Validation
- contract-toolkit/scripts/regenerate-all.sh
- contract-toolkit/scripts/check-invariants.sh
- cd contract-toolkit && pkl test tests/*.pkl
- uv run --extra workflows python contract-toolkit/scripts/test-sdk-import.py
- git diff --check
- uv run pre-commit run --files contract-toolkit/src/App.pkl contract-toolkit/src/NativeApp.pkl contract-toolkit/tests/jdbc_auth_pane_test.pkl contract-toolkit/README.md contract-toolkit/docs/reference.md

## Notes
- Representative single-auth AdvancedJDBCUrlGroup behavior was validated through toolkit regression coverage and read-only downstream artifact inspection.
- No consuming app repository was changed.