### PR TITLE
ci(build-publish): add opt-in lfs input for the image-build checkout

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -65,6 +65,11 @@ on:
         required: false
         type: string
         default: ""
+      lfs:
+        description: "Check out git-LFS objects before building the image (default false). Set true for apps that vendor LFS-tracked assets (e.g. large parser jars) into the Docker build context — without it the build copies the LFS pointer, not the real file. Only applied to the image-build checkout; other jobs do not need LFS content."
+        required: false
+        type: boolean
+        default: false
     secrets:
       ORG_PAT_GITHUB:
         required: true
@@ -1048,6 +1053,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+          lfs: ${{ inputs.lfs }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3


### PR DESCRIPTION
## What

Adds an opt-in `lfs` boolean input (default `false`) to the reusable `build-and-publish-app.yaml` and threads it into the **image-build** checkout only.

## Why

Apps that vendor a **git-LFS-tracked asset** into their Docker build context get a silently-broken image from this workflow today. Concrete case: `atlan-query-intelligence-app` vendors the ~100MB Gudusoft parser jar at `app/pond/gudusoft/parser-1.0-SNAPSHOT-all.jar` (LFS-tracked via `*.jar filter=lfs`). The build job checks out with `actions/checkout`'s default `lfs: false`, so the ~130-byte **LFS pointer** — not the real jar — is copied in via the Dockerfile's `COPY . .`. The image builds and CI goes green (`docker build` never validates the copied bytes), but the parser fails to load at runtime.

The app's legacy `build-image.yaml` set `lfs: true` precisely to avoid this; the unified workflow had no equivalent, blocking those apps from migrating.

## Change

```yaml
      lfs:
        required: false
        type: boolean
        default: false
```
threaded only into the build job's checkout:
```yaml
        with:
          ref: ${{ inputs.ref || github.ref }}
          lfs: ${{ inputs.lfs }}
```

## Scope / safety

- **Backward compatible** — default `false` means the ~30 existing callers are unchanged.
- Applied **only** to the image-build checkout. `prepare`, `certify`, and `leak-scan` do not consume LFS content (e.g. QI has no `tests/unit/`, so the certify unit-test step is skipped; leak-scan over a pointer is harmless), so they keep the default and avoid pulling large objects unnecessarily.

## Follow-up

The companion caller change (`atlan-query-intelligence-app` passing `lfs: true`) depends on this merging first — until then, passing `lfs:` to `@main` would error as an unknown input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)