### PR TITLE
chore(dashboard): surface exact SDK lib version from uv.lock

### DIFF
--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -224,12 +224,63 @@ jobs:
           if chosen and ":" in chosen:
               sdk_version = chosen.split(":")[-1]
 
+          # Extract the Atlan SDK Python library version (the actual code
+          # running inside the connector — separate from the base image tag
+          # read above). Two repos pinning the same base tag (e.g. ":3") can
+          # still ship different SDK library versions, which is exactly the
+          # confusion this resolves on the dashboard.
+          #
+          # Source preference: uv.lock (resolved/pinned) > pyproject.toml
+          # (may be a range) > requirements.txt (legacy).
+          sdk_lib_version = "unknown"
+          # uv.lock — TOML, but parsed via regex to avoid the Python 3.11+
+          # tomllib dependency on the runner.
+          try:
+              with open("uv.lock") as f:
+                  lock_content = f.read()
+              for block in lock_content.split("[[package]]")[1:]:
+                  section = block.split("\n[")[0]
+                  name_m = _re.search(r'^\s*name\s*=\s*"([^"]+)"', section, _re.MULTILINE)
+                  ver_m = _re.search(r'^\s*version\s*=\s*"([^"]+)"', section, _re.MULTILINE)
+                  if name_m and ver_m:
+                      n = name_m.group(1).lower().replace("_", "-")
+                      if n in ("atlan-application-sdk", "application-sdk"):
+                          sdk_lib_version = ver_m.group(1)
+                          break
+          except FileNotFoundError:
+              pass
+          if sdk_lib_version == "unknown":
+              try:
+                  with open("pyproject.toml") as f:
+                      m = _re.search(
+                          r'(?:atlan-)?application[-_]sdk(?:\[[^\]]*\])?\s*==\s*([^\s"\',]+)',
+                          f.read(),
+                      )
+                  if m:
+                      sdk_lib_version = m.group(1)
+              except FileNotFoundError:
+                  pass
+          if sdk_lib_version == "unknown":
+              try:
+                  with open("requirements.txt") as f:
+                      for line in f:
+                          m = _re.match(
+                              r'\s*(?:atlan-)?application[-_]sdk(?:\[[^\]]*\])?\s*==\s*([^\s;#]+)',
+                              line,
+                          )
+                          if m:
+                              sdk_lib_version = m.group(1)
+                              break
+              except FileNotFoundError:
+                  pass
+
           repo_slug = repo_name.replace("/", "_")
           app_count = sum(1 for v in unique if v["source_type"] == "app")
           base_count = sum(1 for v in unique if v["source_type"] == "base_image")
           repo_data = {
               "repo": repo_name,
               "sdk_version": sdk_version,
+              "sdk_lib_version": sdk_lib_version,
               "vulnerabilities": unique,
               "scanned_at": datetime.now().isoformat() + "Z",
               "total": len(unique),
@@ -256,7 +307,8 @@ jobs:
           app_count = sum(1 for v in unique if v['source_type'] == 'app')
           base_count = sum(1 for v in unique if v['source_type'] == 'base_image')
           print(f"Dashboard data generated: {len(unique)} vulnerabilities for {repo_name}")
-          print(f"  SDK version: {sdk_version}")
+          print(f"  Base image:  {sdk_version}")
+          print(f"  SDK lib:     {sdk_lib_version}")
           print(f"  CRITICAL: {repo_data['critical']}")
           print(f"  HIGH: {repo_data['high']}")
           print(f"  Base image: {base_count}")
@@ -271,6 +323,7 @@ jobs:
               "date": datetime.now().strftime("%Y-%m-%d"),
               "repo": repo_name,
               "sdk_version": sdk_version,
+              "sdk_lib_version": sdk_lib_version,
               "total": len(unique),
               "critical": repo_data["critical"],
               "high": repo_data["high"],

--- a/.security/dashboard/index.html
+++ b/.security/dashboard/index.html
@@ -232,7 +232,7 @@
             </div>
             <div style="overflow-x:auto">
                 <table id="trendTable"><thead><tr>
-                    <th style="width:40px">#</th><th data-ts="repo">Repo</th><th data-ts="sdk">SDK Version</th><th data-ts="scanned">Last Scan</th><th data-ts="app">App CVEs</th><th data-ts="base">Base CVEs</th><th data-ts="now">Total CVEs</th><th data-ts="old" id="thCompare">7d ago</th><th data-ts="delta">Change</th><th>Status</th>
+                    <th style="width:40px">#</th><th data-ts="repo">Repo</th><th data-ts="sdk">Base Image</th><th data-ts="sdk_lib">SDK Version</th><th data-ts="scanned">Last Scan</th><th data-ts="app">App CVEs</th><th data-ts="base">Base CVEs</th><th data-ts="now">Total CVEs</th><th data-ts="old" id="thCompare">7d ago</th><th data-ts="delta">Change</th><th>Status</th>
                 </tr></thead><tbody id="trendTableBody"></tbody></table>
             </div>
         </div>
@@ -786,7 +786,7 @@ async function loadHistory(){
     if(!Object.keys(historyData).length){
         visibleRepoKeys().forEach(r=>{
             const d=D.repos[r];
-            historyData[r]=[{date:new Date().toISOString().slice(0,10),repo:r,sdk_version:d.sdk_version||'unknown',total:d.total,critical:d.critical,high:d.high,base_image:d.base_image_count||0,app:d.app_count||0,allowlisted:d.allowlisted,new:d.new||0}];
+            historyData[r]=[{date:new Date().toISOString().slice(0,10),repo:r,sdk_version:d.sdk_version||'unknown',sdk_lib_version:d.sdk_lib_version||'unknown',total:d.total,critical:d.critical,high:d.high,base_image:d.base_image_count||0,app:d.app_count||0,allowlisted:d.allowlisted,new:d.new||0}];
         });
     }
 }
@@ -1085,7 +1085,7 @@ function renderTrends(){
         const oldStart=getOldTotal(r);
         const peak=getMaxInWindow(r);
         const now=D.repos[r].total||0;
-        return{repo:r,sdk:D.repos[r].sdk_version||'?',now,
+        return{repo:r,sdk:D.repos[r].sdk_version||'?',sdk_lib:D.repos[r].sdk_lib_version||'?',now,
             old:oldStart,delta:now-oldStart,                 // window-start basis (used by table & regressions)
             peak,improvementDelta:now-peak,                  // peak basis (used by improvements)
             app:D.repos[r].app_count||0,base:D.repos[r].base_image_count||0,
@@ -1146,7 +1146,7 @@ function renderTrends(){
     document.querySelectorAll('#trendTable th[data-ts]').forEach(th=>{
         const isActive=th.dataset.ts===ts.col;
         const arrow=isActive?(ts.dir==='asc'?' ▲':' ▼'):'';
-        const baseLabels={repo:'Repo',sdk:'SDK Version',scanned:'Last Scan',app:'App CVEs',base:'Base CVEs',now:'Total CVEs',delta:'Change'};
+        const baseLabels={repo:'Repo',sdk:'Base Image',sdk_lib:'SDK Version',scanned:'Last Scan',app:'App CVEs',base:'Base CVEs',now:'Total CVEs',delta:'Change'};
         if(th.id==='thCompare')return; // compare label is dynamic, handled separately
         if(baseLabels[th.dataset.ts]!==undefined)th.innerHTML=baseLabels[th.dataset.ts]+arrow;
         th.style.cursor='pointer';th.style.userSelect='none';
@@ -1183,6 +1183,7 @@ function renderTrends(){
             <td style="color:#b0b3c6;font-weight:600">${i+1}</td>
             <td><span class="repo-tag">${esc(r.repo.split('/').pop())}</span></td>
             <td><span class="badge" style="${isV3?'background:#dafbe1;color:#16a34a':'background:#fff7ed;color:#ea580c'}">${esc(r.sdk)}</span></td>
+            <td><span class="badge" style="background:#eef2ff;color:#4f46e5">${esc(r.sdk_lib||'?')}</span></td>
             <td title="${esc(scan.title)}" style="color:${scan.color};font-size:11px">${scan.label}</td>
             <td>${r.app}</td>
             <td>${r.base}</td>
@@ -1303,7 +1304,7 @@ function exportTrendCSV(){
     const repos=sdkFilter==='all'?allRepos:allRepos.filter(r=>(D.repos[r].sdk_version||'')==sdkFilter);
     const days=parseInt(document.getElementById('fTrendDays').value);
     const cutoff=new Date();cutoff.setDate(cutoff.getDate()-days);const cutoffStr=cutoff.toISOString().slice(0,10);
-    let csv='Repo,SDK,Last Scan,Total Today,App CVEs,Base CVEs,Compare Period,Change,Status\n';
+    let csv='Repo,Base Image,SDK Version,Last Scan,Total Today,App CVEs,Base CVEs,Compare Period,Change,Status\n';
     repos.forEach(r=>{
         const d=D.repos[r];
         const all=(historyData[r]||[]).slice().sort((a,b)=>a.date.localeCompare(b.date));
@@ -1312,7 +1313,7 @@ function exportTrendCSV(){
         const delta=(d.total||0)-old;
         const status=(d.total||0)===0?'Clean':delta<0?'Improving':delta>0?'Degraded':'Stable';
         const scanDate=(d.scanned_at||'').slice(0,10);
-        csv+=`${r.split('/').pop()},${d.sdk_version||'?'},${scanDate},${d.total||0},${d.app_count||0},${d.base_image_count||0},${old},${delta},${status}\n`;
+        csv+=`${r.split('/').pop()},${d.sdk_version||'?'},${d.sdk_lib_version||'?'},${scanDate},${d.total||0},${d.app_count||0},${d.base_image_count||0},${old},${delta},${status}\n`;
     });
     const blob=new Blob([csv],{type:'text/csv'});const url=URL.createObjectURL(blob);
     const a=document.createElement('a');a.href=url;a.download='vulnerability-trends.csv';a.click();URL.revokeObjectURL(url);
@@ -1404,7 +1405,7 @@ function renderCategoryView(category){
     };
     const rows=repos.map(r=>{
         const d=D.repos[r];
-        return {repo:r,sdk:d.sdk_version||'?',total:d.total||0,crit:d.critical||0,high:d.high||0,app:d.app_count||0,base:d.base_image_count||0,scanned:d.scanned_at||''};
+        return {repo:r,sdk:d.sdk_version||'?',sdk_lib:d.sdk_lib_version||'?',total:d.total||0,crit:d.critical||0,high:d.high||0,app:d.app_count||0,base:d.base_image_count||0,scanned:d.scanned_at||''};
     }).sort((a,b)=>b.total-a.total);
 
     const catLabel=category==='system'?'System Apps':'Connector Apps';
@@ -1454,7 +1455,7 @@ function renderCategoryView(category){
             <div class="card-title">Per Repo — ${catLabel} <span style="color:#b0b3c6;font-weight:500">(${rows.length})</span></div>
             <div style="overflow-x:auto">
                 <table style="width:100%"><thead><tr>
-                    <th style="width:40px">#</th><th>Repo</th><th>SDK</th><th>Last Scan</th><th>App CVEs</th><th>Base CVEs</th><th>Critical</th><th>High</th><th>Total</th>
+                    <th style="width:40px">#</th><th>Repo</th><th>Base Image</th><th>SDK Version</th><th>Last Scan</th><th>App CVEs</th><th>Base CVEs</th><th>Critical</th><th>High</th><th>Total</th>
                 </tr></thead><tbody>
                 ${rows.map((r,i)=>{
                     const isV3=r.sdk.startsWith('3')||r.sdk.includes('v3')||r.sdk.includes('refactor-v3');
@@ -1463,6 +1464,7 @@ function renderCategoryView(category){
                         <td style="color:#b0b3c6;font-weight:600">${i+1}</td>
                         <td><span class="repo-tag">${esc(r.repo.split('/').pop())}</span></td>
                         <td><span class="badge" style="${isV3?'background:#dafbe1;color:#16a34a':'background:#fff7ed;color:#ea580c'}">${esc(r.sdk)}</span></td>
+                        <td><span class="badge" style="background:#eef2ff;color:#4f46e5">${esc(r.sdk_lib||'?')}</span></td>
                         <td title="${esc(scan.title)}" style="color:${scan.color};font-size:11px">${scan.label}</td>
                         <td>${r.app}</td>
                         <td>${r.base}</td>


### PR DESCRIPTION
## Summary
Adds a second version column to the dashboard's per-repo tables (**Trends** + per-category **Snapshot**) showing the resolved `atlan-application-sdk` Python library version pinned by each repo.

## Why
The existing single SDK column reads the **Dockerfile `FROM` tag**, which is the *base image* — many repos pin to the rolling major tag (`:3`), so the dashboard shows `3` for all of them and we can't tell two `3`-labelled repos apart. That base tag also doesn't represent what the connector is actually executing — that's the `atlan-application-sdk` Python lib version, pinned in each repo's `uv.lock`.

This change surfaces both, side-by-side.

## How
Workflow side (`update-dashboard.yaml`): after the existing Dockerfile-`FROM` extractor, parse the SDK Python library version from one of:
1. `uv.lock` (resolved/pinned — preferred)
2. `pyproject.toml` (`==X.Y.Z` match)
3. `requirements.txt` (legacy)

The new field `sdk_lib_version` lands in both the per-repo JSON and the history entry.

Dashboard side (`index.html`): rename existing column from "SDK Version" → "Base Image" and add a new "SDK Version" column rendering `sdk_lib_version`. CSV export and history seeding also include the new field.

## Verified against real data

Extractor tested against 8 production connector `uv.lock` files:

| Repo | Base Image (today) | SDK Version (NEW) |
|---|---|---|
| atlan-cloudsql-postgres-app | `3` | `3.12.1` |
| atlan-snowflake-app | `3` | `3.15.1` |
| atlan-sagemaker-app | `3.0.0` | `3.5.0` |
| atlan-glue-app | `3.5.0` | `3.14.0` |
| atlan-monte-carlo-app | `3` | `3.15.1` |
| atlan-lineage-app | `2.7.3` | `2.8.7` |
| atlan-bigquery-app | (3.x) | `3.13.4` |
| atlan-dbt-app | `3` | `3.13.4` |

Two repos showing the same `Base Image` now surface their distinct `SDK Version` — that's the confusion this is designed to eliminate.

## Test plan
- [ ] After merge, next scheduled scan refreshes a few repos' dashboard JSON files with `sdk_lib_version` populated.
- [ ] Verify Trends → Per Repo table has both columns rendering.
- [ ] Verify Connector Apps → Snapshot table has both columns rendering.
- [ ] Verify CSV export contains both columns.
- [ ] Repos without `uv.lock`/`pyproject.toml` show `?` (graceful fallback, not a crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)