### PR TITLE
fix(publish): use crane to copy large images GHCR → Docker Hub

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -1152,6 +1152,10 @@ jobs:
             while IFS= read -r tag; do [ -n "$tag" ] && echo "    ${tag}"; done <<< "${RELEASE_TAGS}"
           fi
 
+      - name: Install crane
+        if: needs.prepare.outputs.enable_sdr == 'true'
+        uses: imjasonh/setup-crane@59c71e96a00b28651f10369ba3359a6d730740a0 # v0.6
+
       - name: Push to Docker Hub (re-tag, no rebuild)
         id: dockerhub_push
         if: needs.prepare.outputs.enable_sdr == 'true'
@@ -1160,14 +1164,20 @@ jobs:
           DOCKERHUB_IMAGE: ${{ needs.prepare.outputs.dockerhub_image }}
         run: |
           set -euo pipefail
-          docker buildx imagetools create \
-            --tag "${DOCKERHUB_IMAGE}" \
-            "${GHCR_IMAGE}"
+          # Use `crane copy`, not `docker buildx imagetools create`, for the
+          # cross-registry GHCR -> Docker Hub copy. imagetools uploads each blob
+          # to Docker Hub with a monolithic PUT, which Docker Hub rejects with
+          # HTTP 400 once a layer is large (e.g. apps that vendor a ~100MB jar).
+          # crane does chunked uploads + cross-repo blob mounts, so it handles
+          # large layers and copies the full multi-arch index byte-identically.
+          # Auth comes from ~/.docker/config.json written by the GHCR + Docker Hub
+          # login steps above.
+          crane copy "${GHCR_IMAGE}" "${DOCKERHUB_IMAGE}"
           echo "Pushed to DockerHub: ${DOCKERHUB_IMAGE}"
 
           # Resolve the pushed manifest digest so we can sign by digest (immutable)
           # rather than by tag (mutable). `${DOCKERHUB_IMAGE%%:*}` strips the tag.
-          DIGEST="$(docker buildx imagetools inspect "${DOCKERHUB_IMAGE}" --format '{{.Manifest.Digest}}')"
+          DIGEST="$(crane digest "${DOCKERHUB_IMAGE}")"
           echo "digest_ref=${DOCKERHUB_IMAGE%%:*}@${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: Sign Docker Hub image (cosign keyless)


### PR DESCRIPTION
## What

In the `Merge & Push Manifest` job, replace the GHCR → Docker Hub re-tag from `docker buildx imagetools create` to **`crane copy`** (with `crane digest` for the cosign digest). Adds a pinned `imjasonh/setup-crane` step. The GHCR-side multi-arch manifest step is unchanged.

## Why

`docker buildx imagetools create` copies each blob cross-registry with a **monolithic PUT**. Docker Hub rejects that with **HTTP 400** once a layer is large, so any `self_deployed_runtime: true` app that vendors a big asset can build + push to GHCR but **fails to publish to Docker Hub**.

First hit by `atlan-query-intelligence-app` once it started shipping its real ~100MB Gudusoft jar — run [27200164418](https://github.com/atlanhq/atlan-query-intelligence-app/actions/runs/27200164418):

- ✅ Build (amd64), Build (arm64), GHCR multi-arch manifest
- ❌ `Push to Docker Hub (re-tag, no rebuild)`:
  ```
  failed to copy: unexpected status from PUT .../blobs/uploads/...
  &digest=sha256:f05c970b...: 400 Bad Request
  ```
  (32s of upload, no retry; the jar layer blob.)

Docker Hub was healthy at the time — snowflake and bigquery (same self-deployed path, smaller layers) published green hours earlier. The differentiator is the large layer.

## The fix

`crane copy` uses **chunked blob uploads + cross-repo blob mounts**, the standard robust path for cross-registry copies of large images. It copies the full multi-arch index byte-identically. No new secrets — crane reads the same `~/.docker/config.json` the existing GHCR + Docker Hub `docker/login-action` steps write.

```diff
- docker buildx imagetools create --tag "${DOCKERHUB_IMAGE}" "${GHCR_IMAGE}"
- DIGEST="$(docker buildx imagetools inspect "${DOCKERHUB_IMAGE}" --format '{{.Manifest.Digest}}')"
+ crane copy "${GHCR_IMAGE}" "${DOCKERHUB_IMAGE}"
+ DIGEST="$(crane digest "${DOCKERHUB_IMAGE}")"
```

## Blast radius / validation

This step runs for **every** `self_deployed_runtime: true` app's Docker Hub publish. crane produces an identical copy, so regression risk is low — but please validate by watching the first post-merge publish on **QI** (the large-layer case this fixes) and **one already-working self-deployed app** (e.g. snowflake/bigquery) to confirm no regression on the normal path.

## Secondary hypothesis (if this somehow doesn't fix it)

If Docker Hub is enforcing a hard per-layer size cap on the `atlanhq` plan rather than rejecting the monolithic transport, no copier helps and we'd need to split/shrink the jar layer. The 400-on-monolithic-PUT signature points firmly at the transport, but flagging it for completeness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)