### PR TITLE
ci: add Renovate fleet upgrade PoC (BLDX-1386)

### DIFF
--- a/.github/workflows/dependabot-requirements-sync.yaml
+++ b/.github/workflows/dependabot-requirements-sync.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'dependabot/**'
+      - 'renovate/**'
     paths:
       - 'uv.lock'
 

--- a/.github/workflows/renovate-pkl-sync.yaml
+++ b/.github/workflows/renovate-pkl-sync.yaml
@@ -1,0 +1,64 @@
+name: Sync PklProject.deps.json for Renovate (Reusable)
+
+# Reusable merge gate for Renovate (and Dependabot) upgrade PRs.
+# When Renovate bumps the @<version> URI in contract/PklProject, the committed
+# PklProject.deps.json lock file is stale. This workflow re-resolves it so the
+# PR is self-contained and CI passes without a manual `pkl project resolve` step.
+#
+# Consumer repos call this from their own .github/workflows/renovate-pkl-sync.yaml:
+#
+#   on:
+#     push:
+#       branches: ['renovate/**']
+#       paths: ['contract/PklProject']
+#   permissions:
+#     contents: write
+#   jobs:
+#     sync:
+#       uses: atlanhq/application-sdk/.github/workflows/renovate-pkl-sync.yaml@main
+#
+# The GITHUB_TOKEN in the called workflow inherits the caller's contents:write
+# permission, which is enough to commit and push to the renovate/** branch.
+
+on:
+  workflow_call:
+    inputs:
+      pkl-version:
+        description: Pkl toolchain version to use.
+        required: false
+        default: "0.27.2"
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  sync-pkl-deps:
+    name: Re-resolve PklProject.deps.json
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.ref }}
+
+      - name: Install pkl
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/pkl \
+            "https://github.com/apple/pkl/releases/download/${{ inputs.pkl-version }}/pkl-linux-amd64"
+          chmod +x /tmp/pkl
+          sudo mv /tmp/pkl /usr/local/bin/pkl
+
+      - name: Re-resolve PklProject.deps.json
+        run: pkl project resolve contract/
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet contract/PklProject.deps.json; then
+            git add contract/PklProject.deps.json
+            git commit -m "chore: sync PklProject.deps.json with updated app-contract-toolkit"
+            git push
+          fi

--- a/.github/workflows/reusable-renovate-dispatch.yaml
+++ b/.github/workflows/reusable-renovate-dispatch.yaml
@@ -1,0 +1,109 @@
+name: Renovate Fan-out Dispatch (Reusable)
+
+# Triggers Renovate runs on all consumer app repos immediately after an SDK or
+# contract-toolkit release. Consumer repos pick up the new version within
+# minutes rather than waiting for the next scheduled Renovate run.
+#
+# Usage — add a fan-out job to tag-and-publish.yaml (after the publish step):
+#
+#   fan-out:
+#     name: Fan out Renovate to consumers
+#     needs: [publish]          # run after PyPI/gh-pages publish completes
+#     uses: atlanhq/application-sdk/.github/workflows/reusable-renovate-dispatch.yaml@main
+#     secrets:
+#       fleet-dispatch-token: ${{ secrets.FLEET_DISPATCH_TOKEN }}
+#
+# Usage — same pattern in contract-toolkit-publish.yml (after Pages publish):
+#
+#   fan-out:
+#     name: Fan out Renovate to consumers
+#     needs: [publish]
+#     uses: atlanhq/application-sdk/.github/workflows/reusable-renovate-dispatch.yaml@main
+#     secrets:
+#       fleet-dispatch-token: ${{ secrets.FLEET_DISPATCH_TOKEN }}
+#
+# FLEET_DISPATCH_TOKEN: store as a repo/org secret. Requires:
+#   - Personal Access Token (classic) with repo + workflow scope, OR
+#   - GitHub App installation token with contents:write + actions:write on each
+#     consumer repo.
+#   The token must have write access to every atlan-*-app repo you want to reach.
+#
+# Each consumer repo must have a .github/workflows/renovate.yaml that accepts
+# workflow_dispatch (see renovate-config/README.md for the template). If a
+# consumer has not yet adopted the preset the dispatch is skipped with a warning.
+
+on:
+  workflow_call:
+    inputs:
+      workflow-file:
+        description: Workflow filename to trigger in each consumer repo.
+        required: false
+        default: "renovate.yaml"
+        type: string
+      ref:
+        description: Branch/ref to run the workflow on in consumer repos.
+        required: false
+        default: "main"
+        type: string
+    secrets:
+      fleet-dispatch-token:
+        description: PAT or GitHub App token with actions:write on consumer repos.
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    name: Discover consumer repos
+    runs-on: ubuntu-latest
+    outputs:
+      repos: ${{ steps.discover.outputs.repos }}
+    steps:
+      - name: Discover atlan-application-sdk consumers
+        id: discover
+        env:
+          GH_TOKEN: ${{ secrets.fleet-dispatch-token }}
+        run: |
+          set -euo pipefail
+          # Search for repos in the atlanhq org that list atlan-application-sdk
+          # as a dependency. gh search code returns up to 100 results per query;
+          # for a fleet > 100 repos, page through with --limit / --page.
+          repos=$(gh search code \
+            --owner atlanhq \
+            "atlan-application-sdk filename:pyproject.toml" \
+            --json repository \
+            --jq '[.[].repository.nameWithOwner] | unique | @json' \
+            --limit 100 2>/dev/null || echo "[]")
+
+          if [ "$repos" = "[]" ] || [ -z "$repos" ]; then
+            echo "::warning::No consumer repos discovered. Check FLEET_DISPATCH_TOKEN permissions."
+          else
+            echo "Discovered $(echo "$repos" | jq '. | length') consumer repos"
+          fi
+          echo "repos=${repos}" >> "$GITHUB_OUTPUT"
+
+  dispatch:
+    name: Trigger ${{ matrix.repo }}
+    needs: [discover]
+    if: needs.discover.outputs.repos != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ${{ fromJson(needs.discover.outputs.repos) }}
+      fail-fast: false   # attempt all consumers even if some fail
+      max-parallel: 10   # avoid GitHub API rate limits
+    steps:
+      - name: Trigger workflow_dispatch
+        env:
+          GH_TOKEN: ${{ secrets.fleet-dispatch-token }}
+        run: |
+          set -euo pipefail
+          if gh workflow run "${{ inputs.workflow-file }}" \
+              --repo "${{ matrix.repo }}" \
+              --ref "${{ inputs.ref }}"; then
+            echo "Triggered Renovate in ${{ matrix.repo }}"
+          else
+            echo "::warning::Could not trigger ${{ inputs.workflow-file }} in ${{ matrix.repo }}" \
+              "(workflow may not exist yet or token lacks permissions)"
+          fi

--- a/.github/workflows/reusable-renovate-dispatch.yaml
+++ b/.github/workflows/reusable-renovate-dispatch.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Discover atlan-application-sdk consumers
         id: discover
         env:
-          GH_TOKEN: ${{ secrets.fleet-dispatch-token }}
+          GH_TOKEN: ${{ secrets['fleet-dispatch-token'] }}
         run: |
           set -euo pipefail
           # Search for repos in the atlanhq org that list atlan-application-sdk
@@ -73,7 +73,7 @@ jobs:
             --owner atlanhq \
             "atlan-application-sdk filename:pyproject.toml" \
             --json repository \
-            --jq '[.[].repository.nameWithOwner] | unique | @json' \
+            --jq '[.[].repository.nameWithOwner] | unique' \
             --limit 100 2>/dev/null || echo "[]")
 
           if [ "$repos" = "[]" ] || [ -z "$repos" ]; then
@@ -96,7 +96,7 @@ jobs:
     steps:
       - name: Trigger workflow_dispatch
         env:
-          GH_TOKEN: ${{ secrets.fleet-dispatch-token }}
+          GH_TOKEN: ${{ secrets['fleet-dispatch-token'] }}
         run: |
           set -euo pipefail
           if gh workflow run "${{ inputs.workflow-file }}" \

--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Atlan fleet upgrade policy for atlan-*-app repos. Extend via: {\"extends\": [\"github>atlanhq/application-sdk//renovate-config/default.json\"]}",
+  "extends": ["config:recommended"],
+  "schedule": ["at any time"],
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 10,
+  "labels": ["dependencies"],
+  "dependencyDashboard": true,
+  "postUpdateOptions": ["uvLock"],
+  "packageRules": [
+    {
+      "description": "SDK: minor+patch in one PR; auto-merge on green gate. Major bumps are manual (consumers pin >=3.0.0,<4.0.0; DeprecationWarnings precede removal by one major).",
+      "matchPackageNames": ["atlan-application-sdk"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "atlan-application-sdk",
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
+      "addLabels": ["sdk-update"]
+    },
+    {
+      "description": "SDK: disable major bumps — these are opt-in manual migrations.",
+      "matchPackageNames": ["atlan-application-sdk"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "app-contract-toolkit (Pkl): minor+patch in one PR; auto-merge on green. Matched by the regex customManager below.",
+      "matchManagers": ["regex"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "app-contract-toolkit",
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
+      "addLabels": ["contract-toolkit-update"]
+    },
+    {
+      "description": "app-contract-toolkit: disable major bumps.",
+      "matchManagers": ["regex"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Python transitive deps (all except atlan-application-sdk): group minor+patch; auto-merge on green.",
+      "matchManagers": ["uv"],
+      "matchPackageNames": ["!atlan-application-sdk"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "python-transitive-deps",
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
+      "description": "GitHub Actions: group minor+patch; auto-merge on green.",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "github-actions",
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    }
+  ],
+  "customManagers": [
+    {
+      "description": "Pkl app-contract-toolkit: track the @<version> URI pinned in contract/PklProject. Uses github-tags datasource against atlanhq/application-sdk, filtering to contract-toolkit-v* tags.",
+      "customType": "regex",
+      "managerFilePatterns": ["(^|/)contract/PklProject$"],
+      "matchStrings": [
+        "uri\\s*=\\s*\"package://atlanhq\\.github\\.io/application-sdk/contracts/app-contract-toolkit@(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "app-contract-toolkit",
+      "packageNameTemplate": "atlanhq/application-sdk",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^contract-toolkit-v(?<version>.+)$"
+    }
+  ],
+  "postUpgradeTasks": {
+    "commands": [
+      "uv lock",
+      "uv export --no-hashes --frozen > requirements.txt",
+      "if [ -d contract ] && [ -f contract/PklProject ] && command -v pkl >/dev/null 2>&1; then pkl project resolve contract/; fi"
+    ],
+    "fileFilters": [
+      "uv.lock",
+      "requirements.txt",
+      "contract/PklProject.deps.json"
+    ],
+    "executionMode": "branch"
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "application-sdk dogfood config — extends its own fleet preset (renovate-config/default.json).",
+  "extends": [
+    "local>renovate-config/default.json"
+  ],
+  "ignorePaths": [
+    ".venv/**",
+    "**/node_modules/**",
+    "contract-toolkit/examples/**"
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `renovate-config/default.json` — a shareable Renovate preset that consumer `atlan-*-app` repos extend with one line to get the full fleet upgrade policy (SDK, Pkl contract-toolkit, transitive deps, GitHub Actions; auto-merge on green CI)
- Adds `renovate.json` — this repo dogfoods its own preset
- Adds `reusable-renovate-dispatch.yaml` — fan-out dispatcher for self-hosted path; SDK/toolkit release workflows call this to immediately trigger Renovate across all consumers after a publish
- Adds `renovate-pkl-sync.yaml` — reusable `workflow_call` that re-resolves `PklProject.deps.json` after Renovate bumps the `@<version>` URI in `contract/PklProject` (hosted-app path, since `postUpgradeTasks` requires self-hosted)
- Updates `dependabot-requirements-sync.yaml` to also cover `renovate/**` branches

## Consumer adoption (2 files per repo)

```json
// renovate.json
{ "extends": ["github>atlanhq/application-sdk//renovate-config/default.json"] }
```

```yaml
# .github/workflows/renovate-pkl-sync.yaml
on:
  push:
    branches: ['renovate/**']
    paths: ['contract/PklProject']
permissions:
  contents: write
jobs:
  sync:
    uses: atlanhq/application-sdk/.github/workflows/renovate-pkl-sync.yaml@main
```

Auto-merge gates on the repo's existing `tests-passed` required check via `platformAutomerge: true` — no new CI workflow needed in consumers.

Canary wiring for `atlan-hello-world-app` and `atlan-openapi-app` is ready locally, pending Renovate GitHub App admin approval.

## Investigation

Full tool comparison, language support matrix, Pkl propagation options A/B, and rollout sequencing posted as comment on [BLDX-1386](https://linear.app/atlan-epd/issue/BLDX-1386/investigate-bot-options-for-update-propagation).

## Test plan

- [ ] `renovate-config/default.json` passes `renovate-config-validator` (add to CI as follow-up)
- [ ] After merge to `main`, install Renovate GitHub App on `atlan-hello-world-app` + `atlan-openapi-app` canaries
- [ ] Confirm Renovate opens toolkit bump PRs (`0.10.2 → 0.11.1` / `0.10.4 → 0.11.1`) and SDK bump PRs if behind
- [ ] Confirm `tests-passed` gates auto-merge correctly (green → merged, red → stays open)
- [ ] Confirm `renovate-pkl-sync.yaml` commits updated `PklProject.deps.json` on toolkit bump branches