### PR TITLE
chore(security): clear base-image allowlist (all entries resolved)

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Updated by SDK team. CODEOWNERS: SDK/security team only.",
   "_base_image": "application-sdk-main",
-  "_updated": "2026-06-08",
+  "_updated": "2026-06-09",
   "_renewal_note": "Expiry dates staggered by severity. CRITICAL: 15 days. HIGH: 30 days. Review before expiry. Enforced by .github/scripts/validate_allowlist.py via _expiry_policy below.",
   "_expiry_policy": {
     "CRITICAL": 15,
@@ -13,72 +13,6 @@
     "reason": "Base image - Dapr runtime dependency (Go stdlib used by daprd binary)",
     "expires": "2026-06-13",
     "added_by": "mananjain99",
-    "fix_available_date": null,
-    "compensating_controls": null,
-    "re_evaluation_trigger": "expiry",
-    "exposure_assessment": null
-  },
-  "CVE-2025-66418": {
-    "package": "py3-pip-wheel (Alpine/Wolfi)",
-    "severity": "HIGH",
-    "reason": "Base image - Chainguard Wolfi py3-pip-wheel@26.0.1-r2. Fix available in 26.1.1-r0; awaiting SDK base image rebuild.",
-    "expires": "2026-06-08",
-    "added_by": "TechyMT",
-    "fix_available_date": null,
-    "compensating_controls": null,
-    "re_evaluation_trigger": "expiry",
-    "exposure_assessment": null
-  },
-  "CVE-2025-66471": {
-    "package": "py3-pip-wheel (Alpine/Wolfi)",
-    "severity": "HIGH",
-    "reason": "Base image - Chainguard Wolfi py3-pip-wheel@26.0.1-r2. Fix available in 26.1.1-r0; awaiting SDK base image rebuild.",
-    "expires": "2026-06-08",
-    "added_by": "TechyMT",
-    "fix_available_date": null,
-    "compensating_controls": null,
-    "re_evaluation_trigger": "expiry",
-    "exposure_assessment": null
-  },
-  "CVE-2026-21441": {
-    "package": "py3-pip-wheel (Alpine/Wolfi)",
-    "severity": "HIGH",
-    "reason": "Base image - Chainguard Wolfi py3-pip-wheel@26.0.1-r2. Fix available in 26.1.1-r0; awaiting SDK base image rebuild.",
-    "expires": "2026-06-08",
-    "added_by": "TechyMT",
-    "fix_available_date": null,
-    "compensating_controls": null,
-    "re_evaluation_trigger": "expiry",
-    "exposure_assessment": null
-  },
-  "CVE-2026-42304": {
-    "package": "Twisted",
-    "severity": "HIGH",
-    "reason": "Python transitive dependency. Fix available only in Twisted 26.4.0rc2 (pre-release); no stable fix yet. Review at expiry for stable release.",
-    "expires": "2026-06-08",
-    "added_by": "TechyMT",
-    "fix_available_date": null,
-    "compensating_controls": null,
-    "re_evaluation_trigger": "expiry",
-    "exposure_assessment": null
-  },
-  "GHSA-82j2-j2ch-gfr8": {
-    "package": "rustls-webpki",
-    "severity": "HIGH",
-    "reason": "Base image - Rust dependency in Dapr runtime. Fix available in 0.103.13; awaiting SDK base image rebuild with updated Dapr.",
-    "expires": "2026-06-08",
-    "added_by": "TechyMT",
-    "fix_available_date": null,
-    "compensating_controls": null,
-    "re_evaluation_trigger": "expiry",
-    "exposure_assessment": null
-  },
-  "CVE-2026-41889": {
-    "package": "github.com/jackc/pgx/v5",
-    "severity": "CRITICAL",
-    "reason": "Upstream fix available but need immediate unblock for v2.x.x releases for SDR locked app releases.",
-    "expires": "2026-06-09",
-    "added_by": "adityachoudhury-cloud",
     "fix_available_date": null,
     "compensating_controls": null,
     "re_evaluation_trigger": "expiry",

--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -6,16 +6,5 @@
   "_expiry_policy": {
     "CRITICAL": 15,
     "HIGH": 30
-  },
-  "CVE-2026-33814": {
-    "package": "stdlib / dapr-daprd-1.17",
-    "severity": "HIGH",
-    "reason": "Base image - Dapr runtime dependency (Go stdlib used by daprd binary)",
-    "expires": "2026-06-13",
-    "added_by": "mananjain99",
-    "fix_available_date": null,
-    "compensating_controls": null,
-    "re_evaluation_trigger": "expiry",
-    "exposure_assessment": null
   }
 }


### PR DESCRIPTION
## Summary
Empties `.security/base-allowlist.json` — every suppression is now either expired or resolved upstream. The file retains only its metadata/policy header; 0 CVE entries remain.

### Expired entries removed (lapsed 2026-06-08 / 09)
| CVE / ID | Package | Severity | Expired |
|---|---|---|---|
| CVE-2025-66418 | py3-pip-wheel (Wolfi) | HIGH | 2026-06-08 |
| CVE-2025-66471 | py3-pip-wheel (Wolfi) | HIGH | 2026-06-08 |
| CVE-2026-21441 | py3-pip-wheel (Wolfi) | HIGH | 2026-06-08 |
| CVE-2026-42304 | Twisted | HIGH | 2026-06-08 |
| GHSA-82j2-j2ch-gfr8 | rustls-webpki | HIGH | 2026-06-08 |
| CVE-2026-41889 | jackc/pgx/v5 | CRITICAL | 2026-06-09 |

### Resolved entry removed
| CVE | Package | Severity | Resolution |
|---|---|---|---|
| CVE-2026-33814 | stdlib / dapr-daprd-1.17 | HIGH | Fixed by SDK base image rebuild onto Go 1.25.10+ / daprd 1.17.6-r3 (orig PR #1745) |

## Notes
- The 3 py3-pip-wheel CVEs had a fix available (`26.1.1-r0`) pending base image rebuild — removing the suppression means the scanner surfaces them again until the rebuild lands.
- **CVE-2026-41889** (CRITICAL, pgx/v5) was gating v2.x.x SDR-locked app releases per its reason field. Confirm with the release owner that the upstream fix is in before merge.

## Test plan
- [x] `python3 .github/scripts/validate_allowlist.py` → `✅ Allowlist valid: 0 entries`