### PR TITLE
fix: normalize APITree filters in extraction inputs

### DIFF
--- a/application_sdk/common/sql_filters.py
+++ b/application_sdk/common/sql_filters.py
@@ -127,6 +127,18 @@ def validate_filter_no_sql_injection(v: Any) -> Any:
                     f"SQL-unsafe sequence {seq!r} not allowed in filter {label}: {value!r}"
                 )
 
+    def _check_value(label: str, value: Any) -> None:
+        if isinstance(value, str):
+            _check_str(label, value)
+        elif isinstance(value, list):
+            for item in value:
+                _check_value("value", item)
+        elif isinstance(value, dict):
+            for nested_key, nested_value in value.items():
+                if isinstance(nested_key, str):
+                    _check_str("key", nested_key)
+                _check_value("value", nested_value)
+
     if isinstance(v, str):
         # Legacy AE callers pass the filter as a JSON-encoded string. The
         # JSON syntax itself carries double-quotes that would trip the
@@ -149,13 +161,9 @@ def validate_filter_no_sql_injection(v: Any) -> Any:
         _check_str("value", v)
     elif isinstance(v, dict):
         for key, values in v.items():
-            _check_str("key", key)
-            if isinstance(values, list):
-                for item in values:
-                    if isinstance(item, str):
-                        _check_str("value", item)
-            elif isinstance(values, str):
-                _check_str("value", values)
+            if isinstance(key, str):
+                _check_str("key", key)
+            _check_value("value", values)
     return v
 
 
@@ -571,9 +579,7 @@ def prepare_filters(
     return normalized_include_regex, normalized_exclude_regex
 
 
-def normalize_filters(
-    filter_dict: dict[str, list[str] | str], is_include: bool
-) -> list[str]:
+def normalize_filters(filter_dict: dict[str, Any], is_include: bool) -> list[str]:
     """Normalize filter dict to fully-anchored ``db.schema`` regex patterns.
 
     Each emitted pattern is anchored with ``^`` and ``$`` so that callers
@@ -583,6 +589,7 @@ def normalize_filters(
     Mapping:
         - ``{"^db$": []}`` or ``{"^db$": "*"}`` → ``^db\\..*$`` (every schema in db)
         - ``{"^db$": ["^sch$"]}`` → ``^db\\.sch$`` (exactly that schema)
+        - ``{"^db$": {"^sch$": {}}}`` → ``^db\\.sch$`` (APITree object shape)
 
     The previous implementation emitted unanchored ``db\\.*`` (literal dot,
     zero-or-more), which substring-matched targets like ``something.atlan_dev``
@@ -604,6 +611,9 @@ def normalize_filters(
         if filtered_schemas == "*" or not filtered_schemas:
             normalized_filter_list.append(f"^{db}\\..*$")
             continue
+
+        if isinstance(filtered_schemas, dict):
+            filtered_schemas = list(filtered_schemas.keys())
 
         if isinstance(filtered_schemas, list):
             for schema in filtered_schemas:

--- a/application_sdk/common/sql_filters.py
+++ b/application_sdk/common/sql_filters.py
@@ -9,7 +9,7 @@ import glob
 import json
 import os
 import re
-from typing import Any
+from typing import Any, TypeAlias
 
 from application_sdk.common.sql_filters_errors import InvalidSqlFilterError
 from application_sdk.errors import AppError
@@ -89,6 +89,11 @@ _FORBIDDEN_FILTER_SEQUENCES: tuple[str, ...] = (
 SAFE_FILTER_PATTERN: str = r"^[^'\";\x00]*$"
 _SAFE_FILTER_PATTERN = SAFE_FILTER_PATTERN  # backward-compat alias
 
+FilterTreeNode: TypeAlias = dict[str, "FilterTreeNode"]
+FilterValue: TypeAlias = list[str] | str | FilterTreeNode
+
+_MAX_FILTER_NESTING_DEPTH = 4
+
 
 def validate_filter_no_sql_injection(v: Any) -> Any:
     """Reject filter values containing SQL-meaningful character sequences.
@@ -127,17 +132,21 @@ def validate_filter_no_sql_injection(v: Any) -> Any:
                     f"SQL-unsafe sequence {seq!r} not allowed in filter {label}: {value!r}"
                 )
 
-    def _check_value(label: str, value: Any) -> None:
+    def _check_value(label: str, value: Any, depth: int = 0) -> None:
+        if depth > _MAX_FILTER_NESTING_DEPTH:
+            raise ValueError(
+                f"Filter nesting exceeds maximum depth {_MAX_FILTER_NESTING_DEPTH}"
+            )
         if isinstance(value, str):
             _check_str(label, value)
         elif isinstance(value, list):
             for item in value:
-                _check_value("value", item)
+                _check_value("value", item, depth + 1)
         elif isinstance(value, dict):
             for nested_key, nested_value in value.items():
                 if isinstance(nested_key, str):
                     _check_str("key", nested_key)
-                _check_value("value", nested_value)
+                _check_value("value", nested_value, depth + 1)
 
     if isinstance(v, str):
         # Legacy AE callers pass the filter as a JSON-encoded string. The
@@ -579,7 +588,9 @@ def prepare_filters(
     return normalized_include_regex, normalized_exclude_regex
 
 
-def normalize_filters(filter_dict: dict[str, Any], is_include: bool) -> list[str]:
+def normalize_filters(
+    filter_dict: dict[str, FilterValue], is_include: bool
+) -> list[str]:
     """Normalize filter dict to fully-anchored ``db.schema`` regex patterns.
 
     Each emitted pattern is anchored with ``^`` and ``$`` so that callers

--- a/application_sdk/common/sql_filters.py
+++ b/application_sdk/common/sql_filters.py
@@ -89,8 +89,7 @@ _FORBIDDEN_FILTER_SEQUENCES: tuple[str, ...] = (
 SAFE_FILTER_PATTERN: str = r"^[^'\";\x00]*$"
 _SAFE_FILTER_PATTERN = SAFE_FILTER_PATTERN  # backward-compat alias
 
-FilterTreeNode: TypeAlias = dict[str, "FilterTreeNode"]
-FilterValue: TypeAlias = list[str] | str | FilterTreeNode
+FilterValue: TypeAlias = list[str] | str | dict[str, dict[str, Any]]
 
 _MAX_FILTER_NESTING_DEPTH = 4
 

--- a/application_sdk/templates/contracts/sql_metadata.py
+++ b/application_sdk/templates/contracts/sql_metadata.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Annotated, Any
 
 import orjson
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, JsonValue, field_validator, model_validator
 
 from application_sdk.common.sql_filters import (
     SAFE_FILTER_PATTERN,
@@ -37,13 +37,25 @@ FilterMap = Annotated[
 # any in-tree import path remains valid.
 _validate_filter_no_sql_injection = validate_filter_no_sql_injection
 
+_FILTER_FIELD_JSON_SCHEMA_EXTRA: dict[str, JsonValue] = {
+    "x-accepted-before-validation": [
+        "dict[str, list[str]]",
+        "APITree-style dict[str, dict]",
+        "list[str]",
+        "str",
+        "None",
+    ]
+}
+
 
 def _normalize_tree_filter_value(v: dict[str, Any]) -> dict[str, Any]:
     """Normalize APITree-style selections to the existing FilterMap shape.
 
     APITree widgets can emit ``{"catalog": {"db": {}}}`` while the SDK
     filter contract is ``{"catalog": ["db"]}``. Preserve existing list and
-    string values; only collapse object children to their selected keys.
+    string values; only collapse immediate object children to their selected
+    keys. Deeper descendants are validated before flattening, but are not
+    represented because the SDK filter contract is catalog/schema-level.
     """
     normalized: dict[str, Any] = {}
     changed = False
@@ -77,6 +89,8 @@ def _coerce_filter_value(v: Any) -> Any:
     if isinstance(v, str):
         return normalize_legacy_filter_value(v)
     if isinstance(v, dict):
+        # Validate before flattening so deeper APITree descendants that are not
+        # represented in FilterMap cannot hide unsafe strings.
         validate_filter_no_sql_injection(v)
         return _normalize_tree_filter_value(v)
     return v
@@ -174,7 +188,9 @@ class ExtractionInput(Input):
     output_path: str = ""
     """Local or object store path for output files."""
 
-    exclude_filter: FilterMap | str = Field(default="")
+    exclude_filter: FilterMap | str = Field(
+        default="", json_schema_extra=_FILTER_FIELD_JSON_SCHEMA_EXTRA
+    )
     """Filter for excluding schemas/tables.
 
     Accepts:
@@ -182,9 +198,14 @@ class ExtractionInput(Input):
     - APITree-style ``dict[str, dict]`` — normalized to ``dict[str, list[str]]``
     - ``str`` — JSON string or raw regex (backward compat)
     - ``None`` → empty string
+
+    APITree inputs are accepted in the before-validator and stored as the
+    normalized ``dict[str, list[str]]`` shape.
     """
 
-    include_filter: FilterMap | str = Field(default="")
+    include_filter: FilterMap | str = Field(
+        default="", json_schema_extra=_FILTER_FIELD_JSON_SCHEMA_EXTRA
+    )
     """Filter for including schemas/tables.
 
     Accepts:
@@ -192,6 +213,9 @@ class ExtractionInput(Input):
     - APITree-style ``dict[str, dict]`` — normalized to ``dict[str, list[str]]``
     - ``str`` — JSON string or raw regex (backward compat)
     - ``None`` → empty string
+
+    APITree inputs are accepted in the before-validator and stored as the
+    normalized ``dict[str, list[str]]`` shape.
     """
 
     temp_table_regex: Annotated[str, Field(pattern=SAFE_FILTER_PATTERN)] = ""
@@ -260,8 +284,12 @@ class ExtractionTaskInput(Input):
     credential_ref: CredentialRef | None = None
     output_prefix: str = ""
     output_path: str = ""
-    exclude_filter: FilterMap | str = Field(default="")
-    include_filter: FilterMap | str = Field(default="")
+    exclude_filter: FilterMap | str = Field(
+        default="", json_schema_extra=_FILTER_FIELD_JSON_SCHEMA_EXTRA
+    )
+    include_filter: FilterMap | str = Field(
+        default="", json_schema_extra=_FILTER_FIELD_JSON_SCHEMA_EXTRA
+    )
     temp_table_regex: Annotated[str, Field(pattern=SAFE_FILTER_PATTERN)] = ""
     source_tag_prefix: str = ""
 

--- a/application_sdk/templates/contracts/sql_metadata.py
+++ b/application_sdk/templates/contracts/sql_metadata.py
@@ -54,8 +54,9 @@ def _normalize_tree_filter_value(v: dict[str, Any]) -> dict[str, Any]:
     APITree widgets can emit ``{"catalog": {"db": {}}}`` while the SDK
     filter contract is ``{"catalog": ["db"]}``. Preserve existing list and
     string values; only collapse immediate object children to their selected
-    keys. Deeper descendants are validated before flattening, but are not
-    represented because the SDK filter contract is catalog/schema-level.
+    keys. Callers must validate ``v`` before invoking; this helper does not
+    re-check deeper descendants because they are dropped during normalization
+    and the SDK filter contract is catalog/schema-level.
     """
     normalized: dict[str, Any] = {}
     changed = False

--- a/application_sdk/templates/contracts/sql_metadata.py
+++ b/application_sdk/templates/contracts/sql_metadata.py
@@ -38,10 +38,30 @@ FilterMap = Annotated[
 _validate_filter_no_sql_injection = validate_filter_no_sql_injection
 
 
-def _coerce_filter_value(v: Any) -> FilterMap | str:
+def _normalize_tree_filter_value(v: dict[str, Any]) -> dict[str, Any]:
+    """Normalize APITree-style selections to the existing FilterMap shape.
+
+    APITree widgets can emit ``{"catalog": {"db": {}}}`` while the SDK
+    filter contract is ``{"catalog": ["db"]}``. Preserve existing list and
+    string values; only collapse object children to their selected keys.
+    """
+    normalized: dict[str, Any] = {}
+    changed = False
+    for key, value in v.items():
+        if isinstance(value, dict):
+            normalized[key] = list(value.keys())
+            changed = True
+        else:
+            normalized[key] = value
+    return normalized if changed else v
+
+
+def _coerce_filter_value(v: Any) -> Any:
     """Coerce filter input to FilterMap | str.
 
     - ``dict`` → pass through (structured filter map from AE)
+    - ``dict[str, dict]`` → normalize APITree selections to
+      ``dict[str, list[str]]``
     - ``list`` → wrap as ``{".*": <list>}``
     - ``str`` → normalise the legacy quoted-CSV shape (``'"A","B"'`` →
       ``'A|B'``) so migrated workflow specs from the pre-v3 SaaS-agent
@@ -56,6 +76,9 @@ def _coerce_filter_value(v: Any) -> FilterMap | str:
         return {".*": v}
     if isinstance(v, str):
         return normalize_legacy_filter_value(v)
+    if isinstance(v, dict):
+        validate_filter_no_sql_injection(v)
+        return _normalize_tree_filter_value(v)
     return v
 
 
@@ -156,6 +179,7 @@ class ExtractionInput(Input):
 
     Accepts:
     - ``dict[str, list[str]]`` — structured filter map from AE
+    - APITree-style ``dict[str, dict]`` — normalized to ``dict[str, list[str]]``
     - ``str`` — JSON string or raw regex (backward compat)
     - ``None`` → empty string
     """
@@ -165,6 +189,7 @@ class ExtractionInput(Input):
 
     Accepts:
     - ``dict[str, list[str]]`` — structured filter map from AE
+    - APITree-style ``dict[str, dict]`` — normalized to ``dict[str, list[str]]``
     - ``str`` — JSON string or raw regex (backward compat)
     - ``None`` → empty string
     """
@@ -177,7 +202,7 @@ class ExtractionInput(Input):
 
     @field_validator("include_filter", "exclude_filter", mode="before")
     @classmethod
-    def _coerce_filter(cls, v: Any) -> FilterMap | str:
+    def _coerce_filter(cls, v: Any) -> Any:
         return _coerce_filter_value(v)
 
     @field_validator("temp_table_regex", mode="before")
@@ -242,7 +267,7 @@ class ExtractionTaskInput(Input):
 
     @field_validator("include_filter", "exclude_filter", mode="before")
     @classmethod
-    def _coerce_filter(cls, v: Any) -> FilterMap | str:
+    def _coerce_filter(cls, v: Any) -> Any:
         return _coerce_filter_value(v)
 
     @field_validator("temp_table_regex", mode="before")

--- a/application_sdk/templates/contracts/sql_metadata.py
+++ b/application_sdk/templates/contracts/sql_metadata.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Annotated, Any
 
 import orjson
-from pydantic import Field, JsonValue, field_validator, model_validator
+from pydantic import Field, JsonValue, ValidationInfo, field_validator, model_validator
 
 from application_sdk.common.sql_filters import (
     SAFE_FILTER_PATTERN,
@@ -95,6 +95,16 @@ def _coerce_filter_value(v: Any) -> Any:
         validate_filter_no_sql_injection(v)
         return _normalize_tree_filter_value(v)
     return v
+
+
+def _is_sdk_sql_filter_field(cls: type, field_name: str | None) -> bool:
+    """Return True when a subclass still uses the SDK-owned SQL filter field."""
+    if field_name is None:
+        return False
+    field = cls.model_fields.get(field_name)
+    return (
+        field is not None and field.json_schema_extra == _FILTER_FIELD_JSON_SCHEMA_EXTRA
+    )
 
 
 class ExtractionInput(Input):
@@ -227,7 +237,9 @@ class ExtractionInput(Input):
 
     @field_validator("include_filter", "exclude_filter", mode="before")
     @classmethod
-    def _coerce_filter(cls, v: Any) -> Any:
+    def _coerce_filter(cls, v: Any, info: ValidationInfo) -> Any:
+        if not _is_sdk_sql_filter_field(cls, info.field_name):
+            return v
         return _coerce_filter_value(v)
 
     @field_validator("temp_table_regex", mode="before")
@@ -296,7 +308,9 @@ class ExtractionTaskInput(Input):
 
     @field_validator("include_filter", "exclude_filter", mode="before")
     @classmethod
-    def _coerce_filter(cls, v: Any) -> Any:
+    def _coerce_filter(cls, v: Any, info: ValidationInfo) -> Any:
+        if not _is_sdk_sql_filter_field(cls, info.field_name):
+            return v
         return _coerce_filter_value(v)
 
     @field_validator("temp_table_regex", mode="before")

--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -151,7 +151,7 @@ A run-level **failure-notification node** (`notify-on-failure`) is appended when
 
 ### `_input.py` (`app/generated/_input.py`)
 
-Typed Python `AppInputContract` dataclass. SDK-owned fields inherited from `ExtractionInput`; app-specific fields generated from `uiConfig.properties`.
+Typed Python `AppInputContract` dataclass. SDK-owned fields inherited from `ExtractionInput`; app-specific fields generated from `uiConfig.properties`. Inherited `include_filter` and `exclude_filter` fields accept APITree object selections by normalizing them to the SDK filter-map shape before validation.
 
 ## Modules
 

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -2539,7 +2539,10 @@ class AppInputContract(ExtractionInput):
   into generated connector contracts.
 - SDK-owned fields are skipped in the generated subclass so parent validators
   continue to apply. This includes `include_filter`, `exclude_filter`, and
-  `temp_table_regex`.
+  `temp_table_regex`. When `include-filter` or `exclude-filter` are object
+  widgets such as `APITree`, the SDK normalizes tree selections like
+  `{"catalog": {"db": {}}}` to the existing filter map shape
+  `{"catalog": ["db"]}` before validation.
 - Publish fields simplified: `publish_dry_run` replaces the loader-specific fields
 
 ---

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.15.1
-source-sha:    0a490e9128563a2e1d1d688134bcc352ac800a87
-source-date:   2026-06-09T22:04:25+01:00
+sdk-version:   3.16.0
+source-sha:    8d1f0a5dfc5ccd4c5356e86d5157d120a3ca68b0
+source-date:   2026-06-10T17:45:19+05:30
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -359,7 +359,7 @@ Shared utilities — SQL filters, concurrency helpers, TaskStatistics, Dataframe
 #### `normalize_filters`
 
 - **Import:** `from application_sdk.common import normalize_filters`
-- **Signature:** `normalize_filters(filter_dict: dict[str, list[str] | str], is_include: bool)`
+- **Signature:** `normalize_filters(filter_dict: dict[str, FilterValue], is_include: bool)`
 - **Summary:** Normalize filter dict to fully-anchored ``db.schema`` regex patterns.
 - **Defined in:** `application_sdk/common/sql_filters.py`
 
@@ -2610,8 +2610,8 @@ Strongly-typed Pydantic models for SDK methods. Contracts in `application_sdk.co
   - `agent_json: AgentCredentialSpec | None` — Typed agent credential spec. Non-None when extraction_method is agent.
   - `output_prefix: str` `= ''` — Object store prefix for all output artifacts.
   - `output_path: str` `= ''` — Local or object store path for output files.
-  - `exclude_filter: FilterMap | str` `= Field(default='')` — Filter for excluding schemas/tables.
-  - `include_filter: FilterMap | str` `= Field(default='')` — Filter for including schemas/tables.
+  - `exclude_filter: FilterMap | str` `= Field(default='', json_schema_extra=_FILTER_FIELD_JSON_SCHEMA_EXTRA)` — Filter for excluding schemas/tables.
+  - `include_filter: FilterMap | str` `= Field(default='', json_schema_extra=_FILTER_FIELD_JSON_SCHEMA_EXTRA)` — Filter for including schemas/tables.
   - `temp_table_regex: Annotated[str, Field(pattern=SAFE_FILTER_PATTERN)]` `= ''` — Regex pattern identifying temporary tables.
   - `source_tag_prefix: str` `= ''` — Tag prefix for source-level metadata.
 - **Defined in:** `application_sdk/templates/contracts/sql_metadata.py`
@@ -2646,8 +2646,8 @@ Strongly-typed Pydantic models for SDK methods. Contracts in `application_sdk.co
   - `credential_ref: CredentialRef | None`
   - `output_prefix: str` `= ''`
   - `output_path: str` `= ''`
-  - `exclude_filter: FilterMap | str` `= Field(default='')`
-  - `include_filter: FilterMap | str` `= Field(default='')`
+  - `exclude_filter: FilterMap | str` `= Field(default='', json_schema_extra=_FILTER_FIELD_JSON_SCHEMA_EXTRA)`
+  - `include_filter: FilterMap | str` `= Field(default='', json_schema_extra=_FILTER_FIELD_JSON_SCHEMA_EXTRA)`
   - `temp_table_regex: Annotated[str, Field(pattern=SAFE_FILTER_PATTERN)]` `= ''`
   - `source_tag_prefix: str` `= ''`
 - **Defined in:** `application_sdk/templates/contracts/sql_metadata.py`

--- a/tests/unit/common/test_sql_filters_injection.py
+++ b/tests/unit/common/test_sql_filters_injection.py
@@ -96,6 +96,11 @@ class TestValidateFilterNoSqlInjection:
         with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
             validate_filter_no_sql_injection("{ not really json ' }")
 
+    def test_excessive_nested_filter_depth_raises(self) -> None:
+        deeply_nested = {"a": {"b": {"c": {"d": {"e": {"f": {}}}}}}}
+        with pytest.raises(ValueError, match=r"Filter nesting exceeds maximum depth"):
+            validate_filter_no_sql_injection(deeply_nested)
+
 
 # ---------------------------------------------------------------------------
 # prepare_filters — string/dict inputs are gated before normalization

--- a/tests/unit/common/test_sql_filters_injection.py
+++ b/tests/unit/common/test_sql_filters_injection.py
@@ -101,6 +101,10 @@ class TestValidateFilterNoSqlInjection:
         with pytest.raises(ValueError, match=r"Filter nesting exceeds maximum depth"):
             validate_filter_no_sql_injection(deeply_nested)
 
+    def test_max_nested_filter_depth_passes(self) -> None:
+        at_limit = {"a": {"b": {"c": {"d": {}}}}}
+        assert validate_filter_no_sql_injection(at_limit) == at_limit
+
 
 # ---------------------------------------------------------------------------
 # prepare_filters — string/dict inputs are gated before normalization

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -127,6 +127,18 @@ class TestPrepareFilters:
         assert "^db1\\..*$" == include_regex
         assert "^$" == exclude_regex
 
+    def test_prepare_filters_with_apitree_object_shape(self) -> None:
+        """APITree JSON strings normalize through the SQL helper path too."""
+        include_filter = '{"AwsDataCatalog": {"mswtest_2": {}, "mswtest_3": {}}}'
+        exclude_filter = "{}"
+
+        include_regex, exclude_regex = prepare_filters(include_filter, exclude_filter)
+
+        assert (
+            "^AwsDataCatalog\\.mswtest_2$|^AwsDataCatalog\\.mswtest_3$" == include_regex
+        )
+        assert "^$" == exclude_regex
+
     def test_prepare_filters_with_empty_include_and_filled_exclude(self) -> None:
         """Test prepare_filters with empty include filter but filled exclude filter"""
         include_filter = "{}"
@@ -173,6 +185,15 @@ class TestNormalizeFilters:
         # ``^``/``$`` are stripped from both the db key and each schema entry,
         # then re-anchored on the assembled segment.
         assert result == ["^db1\\.schema1$"]
+
+    def test_normalize_filters_with_apitree_object_shape(self) -> None:
+        filter_dict = {"AwsDataCatalog": {"mswtest_2": {}, "mswtest_3": {}}}
+        result = normalize_filters(filter_dict, True)
+
+        assert result == [
+            "^AwsDataCatalog\\.mswtest_2$",
+            "^AwsDataCatalog\\.mswtest_3$",
+        ]
 
     def test_normalize_filters_wildcard_and_empty_list_equivalent(self) -> None:
         """``"*"`` and an empty list both mean "every schema in this db"."""

--- a/tests/unit/templates/test_extraction_input_filters.py
+++ b/tests/unit/templates/test_extraction_input_filters.py
@@ -118,6 +118,19 @@ class TestAPITreeFilterCoercion:
         result = ExtractionTaskInput.model_validate(payload)
         assert result.exclude_filter == {"AwsDataCatalog": ["mswtest_2"]}
 
+    def test_deeper_apitree_filter_truncated_to_catalog_schema_level(self):
+        payload = {
+            "include_filter": {
+                "AwsDataCatalog": {
+                    "mswtest_2": {
+                        "nested_schema": {},
+                    },
+                }
+            }
+        }
+        result = ExtractionInput.model_validate(payload)
+        assert result.include_filter == {"AwsDataCatalog": ["mswtest_2"]}
+
 
 class TestFilterSQLInjectionGuard:
     """SQL-unsafe sequences blocked in filter values (BLDX-518 deny-list)."""

--- a/tests/unit/templates/test_extraction_input_filters.py
+++ b/tests/unit/templates/test_extraction_input_filters.py
@@ -4,8 +4,12 @@ Filters accept dict (structured from AE), JSON string, raw regex string,
 list, and None. SQL injection is guarded by rejecting single quotes.
 """
 
-import pytest
+from typing import Annotated
 
+import pytest
+from pydantic import Field
+
+from application_sdk.contracts.types import MaxItems
 from application_sdk.templates.contracts.sql_metadata import (
     ExtractionInput,
     ExtractionTaskInput,
@@ -130,6 +134,37 @@ class TestAPITreeFilterCoercion:
         }
         result = ExtractionInput.model_validate(payload)
         assert result.include_filter == {"AwsDataCatalog": ["mswtest_2"]}
+
+    def test_overridden_filter_fields_keep_app_specific_tree_shape(self):
+        class AppSpecificInput(ExtractionInput, allow_unbounded_fields=True):
+            include_filter: Annotated[dict[str, object], MaxItems(1000)] = Field(  # type: ignore[assignment]
+                default_factory=dict
+            )
+            exclude_filter: Annotated[dict[str, object], MaxItems(1000)] = Field(  # type: ignore[assignment]
+                default_factory=dict
+            )
+
+        payload = {
+            "include_filter": {
+                "warehouse_1": {
+                    "project_1": {
+                        "dataset_1": {},
+                    },
+                }
+            },
+            "exclude_filter": {
+                "warehouse_2": {},
+            },
+        }
+        result = AppSpecificInput.model_validate(payload)
+        assert result.include_filter == {
+            "warehouse_1": {
+                "project_1": {
+                    "dataset_1": {},
+                },
+            }
+        }
+        assert result.exclude_filter == {"warehouse_2": {}}
 
 
 class TestFilterSQLInjectionGuard:

--- a/tests/unit/templates/test_extraction_input_filters.py
+++ b/tests/unit/templates/test_extraction_input_filters.py
@@ -58,6 +58,67 @@ class TestFilterCoercion:
         assert result.exclude_filter == ""
 
 
+class TestAPITreeFilterCoercion:
+    """APITree include/exclude filters decode before app workflow code starts."""
+
+    def test_apitree_exclude_filter_normalized_to_filter_map(self):
+        payload = {
+            "exclude_filter": {
+                "AwsDataCatalog": {
+                    "mswtest_2": {},
+                    "mswtest_3": {},
+                    "redshift_sample_testing": {},
+                }
+            }
+        }
+        result = ExtractionInput.model_validate(payload)
+        assert result.exclude_filter == {
+            "AwsDataCatalog": [
+                "mswtest_2",
+                "mswtest_3",
+                "redshift_sample_testing",
+            ]
+        }
+
+    def test_apitree_include_filter_lifted_from_ae_metadata(self):
+        payload = {
+            "metadata": {
+                "include-filter": {
+                    "AwsDataCatalog": {
+                        "mswtest_2": {},
+                    }
+                }
+            }
+        }
+        result = ExtractionInput.model_validate(payload)
+        assert result.include_filter == {"AwsDataCatalog": ["mswtest_2"]}
+
+    def test_apitree_filter_works_for_generated_contract_subclasses(self):
+        class AppInputContract(ExtractionInput):
+            pass
+
+        payload = {
+            "include_filter": {
+                "AwsDataCatalog": {
+                    "mswtest_2": {},
+                }
+            }
+        }
+        result = AppInputContract.model_validate(payload)
+        assert result.include_filter == {"AwsDataCatalog": ["mswtest_2"]}
+
+    def test_apitree_filter_works_for_task_inputs(self):
+        payload = {
+            "exclude_filter": {
+                "AwsDataCatalog": {
+                    "mswtest_2": {},
+                }
+            }
+        }
+        result = ExtractionTaskInput.model_validate(payload)
+        assert result.exclude_filter == {"AwsDataCatalog": ["mswtest_2"]}
+
+
 class TestFilterSQLInjectionGuard:
     """SQL-unsafe sequences blocked in filter values (BLDX-518 deny-list)."""
 
@@ -73,6 +134,11 @@ class TestFilterSQLInjectionGuard:
 
     def test_single_quote_in_dict_value_rejected(self):
         payload = {"include_filter": {"^db$": ["schema'; DROP TABLE--"]}}
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            ExtractionInput.model_validate(payload)
+
+    def test_single_quote_in_nested_apitree_value_rejected(self):
+        payload = {"include_filter": {"AwsDataCatalog": {"db'; DROP TABLE--": {}}}}
         with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
             ExtractionInput.model_validate(payload)
 

--- a/tests/unit/templates/test_extraction_input_filters.py
+++ b/tests/unit/templates/test_extraction_input_filters.py
@@ -142,6 +142,19 @@ class TestFilterSQLInjectionGuard:
         with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
             ExtractionInput.model_validate(payload)
 
+    def test_single_quote_in_deeper_apitree_descendant_rejected(self):
+        payload = {
+            "include_filter": {
+                "AwsDataCatalog": {
+                    "mswtest_2": {
+                        "schema'; DROP TABLE--": {},
+                    }
+                }
+            }
+        }
+        with pytest.raises(ValueError, match=r"SQL-unsafe sequence"):
+            ExtractionInput.model_validate(payload)
+
     def test_semicolon_rejected(self):
         # Statement separator — would let an attacker stack a second
         # statement after the filter substitution.


### PR DESCRIPTION
## Root Cause

Toolkit-generated `AppInputContract` subclasses intentionally inherit SDK-owned `include_filter` and `exclude_filter` fields from `ExtractionInput`. APITree-backed `include-filter` / `exclude-filter` widgets can emit nested object selections such as:

```json
{"AwsDataCatalog": {"mswtest_2": {}}}
```

The SDK field contract only accepted `dict[str, list[str]] | str`, so Temporal/Pydantic rejected workflow args before connector code could normalize them.

## Existing Behavior

- Configmap/widget: APITree object widgets are valid toolkit fields.
- Manifest: `include-filter` / `exclude-filter` are substituted as `include_filter` / `exclude_filter`.
- `_input.py`: generated subclasses skip those fields because they are SDK-owned parent fields.
- Runtime: inherited SDK fields reject APITree nested object selections.

## New Behavior

- SDK `ExtractionInput` and `ExtractionTaskInput` accept APITree-style nested filter objects at the decode boundary.
- Nested APITree selections are normalized to the existing filter-map shape before Pydantic validates the field.
- SQL helper normalization also understands APITree object-shaped dicts and JSON strings.
- Nested dict/list filter values are recursively checked for SQL-unsafe sequences with a bounded depth guard.
- Public helper and stored contract annotations stay payload-safe and precise; pre-validation APITree input shapes are documented via field schema metadata.

## API Design Decision

This is an SDK input-boundary fix, not a toolkit generated-field override.

We keep the stored field contract as `FilterMap | str` and normalize APITree payloads into that contract. This avoids mutable Pydantic field overrides in generated subclasses, preserves Pyright compatibility, and keeps the toolkit invariant that SDK-owned fields are inherited from `ExtractionInput`.

The pre-validator intentionally accepts a wider APITree input shape than the stored field annotation. The field schema metadata documents that accepted pre-validation shape without adding an unbounded `dict[str, Any]` contract field.

## Backward Compatibility

Existing payloads keep their behavior:

- `dict[str, list[str]]`
- JSON string filters
- raw regex strings
- legacy quoted-CSV strings
- `list[str]`
- `None`

No generated JSON, manifest placeholders, DAG shape, widget config, or generated `_input.py` files changed.

## Affected Apps / Examples

- Representative affected pattern: APITree-backed `include-filter` / `exclude-filter` fields that collide with SDK-owned `include_filter` / `exclude_filter`.
- Existing toolkit examples continue to import without regeneration changes.

## Cross-Repo Validation

- Frontend UI rendering compatibility: not applicable, no configmap/widget JSON changed.
- Backend manifest substitution compatibility: not applicable, no manifest placeholder shape changed.
- Playground UI compatibility: not applicable, no generated UI surface changed.
- Workflow backend contract: validated at SDK decode boundary with APITree object payload regression tests.
- Generated SDK input contract: validated with toolkit generated `_input.py` import checks.
- Representative app pattern: validated with generated subclass regression test and original nested APITree payload.

Consumer remotes were refreshed for the configured frontend UI, backend manifest, playground UI, and workflow backend validation surfaces. No consumer-specific source paths, repository names, or SHAs are included here because the PR only changes SDK decode behavior and generated-input compatibility.

## Value Flow

- Configmap field: `include-filter` / `exclude-filter`
- Widget/schema: APITree / object-valued conditional widget
- Manifest arg: `include_filter` / `exclude_filter`
- Placeholder/static value: `{{include-filter}}` / `{{exclude-filter}}`
- `_input.py` field/type: inherited `ExtractionInput.include_filter` / `exclude_filter`, stored as `FilterMap | str`
- Runtime consumer: SDK normalizes APITree object selections before Pydantic validation, then connector code sees the existing filter-map shape
- Docs: toolkit README and reference note the inherited-field APITree normalization behavior; SDK capability manifest refreshed
- Example: no generated example changes; existing generated subclass import validation covers unchanged outputs
- Tests: APITree decode, AE metadata lifting, generated subclass decode, task input parity, nested SQL-safety validation, bounded recursion, SQL helper normalization

## Validation Commands

```bash
uv run pytest tests/unit/templates/test_extraction_input_filters.py tests/unit/common/test_sql_filters_injection.py tests/unit/common/test_utils.py -q
uv run pre-commit run --files application_sdk/common/sql_filters.py application_sdk/templates/contracts/sql_metadata.py tests/unit/templates/test_extraction_input_filters.py tests/unit/common/test_sql_filters_injection.py tests/unit/common/test_utils.py contract-toolkit/README.md contract-toolkit/docs/reference.md
contract-toolkit/scripts/check-invariants.sh
(cd contract-toolkit && pkl test tests/*.pkl)
uv run --extra workflows python contract-toolkit/scripts/test-sdk-import.py
uv run poe regen-capabilities
git diff --check
```
