### PR TITLE
fix: handle empty parquet (0 MicroPartitions) in batched daft reader

### DIFF
--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -462,9 +462,7 @@ class ParquetFileReader(Reader):
                 total_rows = lazy_df.count_rows()
             except DaftCoreException as exc:
                 if "MicroPartition" in str(exc):
-                    logger.info(
-                        "Parquet file(s) contain no data; yielding no batches"
-                    )
+                    logger.info("Parquet file(s) contain no data; yielding no batches")
                     return
                 raise
 

--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -751,7 +751,14 @@ class ParquetFileWriter(Writer):
             if isinstance(write_mode, str):
                 write_mode = WriteMode(write_mode)
 
-            row_count = dataframe.count_rows()
+            from daft.exceptions import DaftCoreException  # noqa: PLC0415
+
+            try:
+                row_count = dataframe.count_rows()
+            except DaftCoreException as exc:
+                if "MicroPartition" in str(exc):
+                    return
+                raise
             if row_count == 0:
                 return
 

--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -450,7 +450,23 @@ class ParquetFileReader(Reader):
             # and _build_unified_daft_schema for the failure modes guarded.
             daft_schema = _build_unified_daft_schema(parquet_files, daft)
             lazy_df = daft.read_parquet(parquet_files, schema=daft_schema)
-            total_rows = lazy_df.count_rows()
+
+            # An empty/degenerate parquet set produces zero MicroPartitions, and
+            # count_rows() then raises DaftCoreException ("Need at least 1
+            # MicroPartition to perform concat"). An empty input is not an
+            # error (a fetch may legitimately return no rows) — emit no batches
+            # instead of crashing the caller.
+            from daft.exceptions import DaftCoreException  # noqa: PLC0415
+
+            try:
+                total_rows = lazy_df.count_rows()
+            except DaftCoreException as exc:
+                if "MicroPartition" in str(exc):
+                    logger.info(
+                        "Parquet file(s) contain no data; yielding no batches"
+                    )
+                    return
+                raise
 
             for offset in range(0, total_rows, self.buffer_size):
                 chunk = lazy_df.offset(offset).limit(self.buffer_size)

--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -757,6 +757,7 @@ class ParquetFileWriter(Writer):
                 row_count = dataframe.count_rows()
             except DaftCoreException as exc:
                 if "MicroPartition" in str(exc):
+                    logger.info("daft DataFrame contains no rows; skipping write")
                     return
                 raise
             if row_count == 0:

--- a/tests/unit/storage/formats/readers/test_parquet_reader.py
+++ b/tests/unit/storage/formats/readers/test_parquet_reader.py
@@ -1006,3 +1006,50 @@ async def test_read_batches_empty_micropartition_yields_no_batches(monkeypatch) 
     reader = ParquetFileReader(path="/tmp/empty", dataframe_type=DataframeType.daft)
     batches = [batch async for batch in reader._get_batched_daft_dataframe()]
     assert batches == []
+
+
+@pytest.mark.asyncio
+async def test_read_batches_non_micropartition_daft_exception_propagates(
+    monkeypatch,
+) -> None:
+    """A DaftCoreException whose message does NOT contain "MicroPartition" must
+    propagate unchanged — the reader only swallows the empty-concat variant."""
+    import sys
+    import types
+
+    dummy_daft = types.ModuleType("daft")
+    dummy_exceptions = types.ModuleType("daft.exceptions")
+
+    class DaftCoreException(Exception):
+        pass
+
+    dummy_exceptions.DaftCoreException = DaftCoreException  # type: ignore[attr-defined]
+    dummy_daft.exceptions = dummy_exceptions  # type: ignore[attr-defined]
+
+    class FailingDaftDataFrame:
+        def count_rows(self):
+            raise DaftCoreException("some other daft failure")
+
+    dummy_daft.read_parquet = lambda path, **kwargs: FailingDaftDataFrame()  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "daft", dummy_daft)
+    monkeypatch.setitem(sys.modules, "daft.exceptions", dummy_exceptions)
+
+    async def dummy_download(path, file_extension, file_names=None):
+        return [f"{path}/some.parquet"]
+
+    monkeypatch.setattr(
+        "application_sdk.storage.formats.parquet._download_files",
+        dummy_download,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "application_sdk.storage.formats.parquet._build_unified_daft_schema",
+        lambda files, daft: None,
+        raising=False,
+    )
+
+    reader = ParquetFileReader(path="/tmp/fail", dataframe_type=DataframeType.daft)
+    with pytest.raises(DaftCoreException, match="some other daft failure"):
+        async for _ in reader._get_batched_daft_dataframe():
+            pass

--- a/tests/unit/storage/formats/readers/test_parquet_reader.py
+++ b/tests/unit/storage/formats/readers/test_parquet_reader.py
@@ -956,3 +956,53 @@ class TestReadNonBatchedSchemaUnification:
             "bar",
             "foo",
         ]
+
+
+@pytest.mark.asyncio
+async def test_read_batches_empty_micropartition_yields_no_batches(monkeypatch) -> None:
+    """Empty parquet input => zero MicroPartitions => count_rows() raises
+    DaftCoreException ("Need at least 1 MicroPartition to perform concat").
+
+    The batched daft reader should treat that as an empty result and yield no
+    batches, instead of propagating the error and crashing the activity.
+    """
+    import sys
+    import types
+
+    dummy_daft = types.ModuleType("daft")
+    dummy_exceptions = types.ModuleType("daft.exceptions")
+
+    class DaftCoreException(Exception):
+        pass
+
+    dummy_exceptions.DaftCoreException = DaftCoreException  # type: ignore[attr-defined]
+    dummy_daft.exceptions = dummy_exceptions  # type: ignore[attr-defined]
+
+    class EmptyDaftDataFrame:
+        def count_rows(self):
+            raise DaftCoreException(
+                "DaftError::ValueError Need at least 1 MicroPartition to perform concat"
+            )
+
+    dummy_daft.read_parquet = lambda path, **kwargs: EmptyDaftDataFrame()  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "daft", dummy_daft)
+    monkeypatch.setitem(sys.modules, "daft.exceptions", dummy_exceptions)
+
+    async def dummy_download(path, file_extension, file_names=None):
+        return [f"{path}/empty.parquet"]
+
+    monkeypatch.setattr(
+        "application_sdk.storage.formats.parquet._download_files",
+        dummy_download,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "application_sdk.storage.formats.parquet._build_unified_daft_schema",
+        lambda files, daft: None,
+        raising=False,
+    )
+
+    reader = ParquetFileReader(path="/tmp/empty", dataframe_type=DataframeType.daft)
+    batches = [batch async for batch in reader._get_batched_daft_dataframe()]
+    assert batches == []

--- a/tests/unit/storage/formats/writers/test_parquet_writer.py
+++ b/tests/unit/storage/formats/writers/test_parquet_writer.py
@@ -748,6 +748,49 @@ class TestParquetFileWriterWriteDaftDataframe:
         with pytest.raises(Exception, match="Count rows error"):
             await parquet_output._write_daft_dataframe(mock_df)
 
+    @pytest.mark.asyncio
+    async def test_write_empty_micropartition_swallowed(
+        self, base_output_path: str
+    ) -> None:
+        """count_rows() raising DaftCoreException with "MicroPartition" in the
+        message must be treated as an empty DataFrame — early return, no write."""
+        from daft.exceptions import DaftCoreException
+
+        mock_df = MagicMock()
+        mock_df.count_rows.side_effect = DaftCoreException(
+            "DaftError::ValueError Need at least 1 MicroPartition to perform concat"
+        )
+
+        parquet_output = ParquetFileWriter(
+            path=base_output_path,
+            dataframe_type=DataframeType.daft,
+        )
+
+        await parquet_output._write_daft_dataframe(mock_df)
+
+        mock_df.write_parquet.assert_not_called()
+        assert parquet_output.chunk_count == 0
+        assert parquet_output.total_record_count == 0
+
+    @pytest.mark.asyncio
+    async def test_write_non_micropartition_daft_exception_propagates(
+        self, base_output_path: str
+    ) -> None:
+        """A DaftCoreException whose message does NOT contain "MicroPartition"
+        must propagate — the writer only swallows the empty-concat variant."""
+        from daft.exceptions import DaftCoreException
+
+        mock_df = MagicMock()
+        mock_df.count_rows.side_effect = DaftCoreException("some other daft failure")
+
+        parquet_output = ParquetFileWriter(
+            path=base_output_path,
+            dataframe_type=DataframeType.daft,
+        )
+
+        with pytest.raises(DaftCoreException, match="some other daft failure"):
+            await parquet_output._write_daft_dataframe(mock_df)
+
 
 class TestParquetFileWriterMetrics:
     """Test ParquetFileWriter metrics recording."""


### PR DESCRIPTION
## Problem

`ParquetFileReader._get_batched_daft_dataframe()` calls `lazy_df.count_rows()` directly (`storage/formats/parquet.py`). When the parquet input is **empty** (a fetch that returned no rows), daft produces **zero MicroPartitions** and `count_rows()` raises:

```
daft.exceptions.DaftCoreException: DaftError::ValueError Need at least 1 MicroPartition to perform concat
  File ".../application_sdk/storage/formats/parquet.py", line 453, in _get_batched_daft_dataframe
    total_rows = lazy_df.count_rows()
```

This crashes the calling activity. It's been recurring across multiple Atlan tenants (docusign-context, gitlab, gc/ice/rga) in the sql-intelligence / readme pipelines — ~28 hits on one tenant since Jun 5 — and is the single most frequent variant in that failure cluster. An empty fetch is a legitimate outcome, not an error.

## Fix

Guard `count_rows()`: treat the empty-MicroPartition case as an empty result and **yield no batches** (the async generator simply returns). Any other `DaftCoreException` is re-raised unchanged so real failures still surface.

```python
try:
    total_rows = lazy_df.count_rows()
except DaftCoreException as exc:
    if "MicroPartition" in str(exc):
        logger.info("Parquet file(s) contain no data; yielding no batches")
        return
    raise
```

## Test

`test_read_batches_empty_micropartition_yields_no_batches` — drives the batched reader with a stubbed daft whose `count_rows()` raises the MicroPartition error; asserts zero batches are yielded. Passes locally (`uv run --all-extras pytest ... -k empty_micropartition` → 1 passed).

## Notes

- `ParquetFileReader` is marked deprecated (v4.0), but it's still the active path for current callers (e.g. automation-engine), so this prevents live crashes today.
- Companion hardening in automation-engine's own reader call sites: atlanhq/atlan-automation-engine-app#898.

🤖 Generated with [Claude Code](https://claude.com/claude-code)