### PR TITLE
feat(execution): make worker default_versioning_behavior configurable (default PINNED)

### DIFF
--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -13,7 +13,6 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from temporalio.client import Client
-from temporalio.common import VersioningBehavior
 from temporalio.worker import Interceptor as TemporalInterceptor
 from temporalio.worker import Worker, WorkerDeploymentConfig, WorkerDeploymentVersion
 from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
@@ -448,6 +447,9 @@ def create_worker(
     # Worker Deployment versioning — set by TWD controller via Kubernetes Downward API.
     # ATLAN_APP_BUILD_ID alone: legacy build-ID mode (build ID doubles as deployment name).
     # ATLAN_APP_BUILD_ID + ATLAN_APP_DEPLOYMENT_NAME: full Worker Deployment versioning.
+    # default_versioning_behavior defaults to PINNED; an app may opt into
+    # AUTO_UPGRADE via TEMPORAL_DEFAULT_VERSIONING_BEHAVIOR in its own deployment.
+    versioning_behavior = load_execution_settings().default_versioning_behavior
     deployment_config: WorkerDeploymentConfig | None = None
     if APP_BUILD_ID and APP_DEPLOYMENT_NAME:
         deployment_config = WorkerDeploymentConfig(
@@ -456,12 +458,13 @@ def create_worker(
                 build_id=APP_BUILD_ID,
             ),
             use_worker_versioning=True,
-            default_versioning_behavior=VersioningBehavior.PINNED,
+            default_versioning_behavior=versioning_behavior,
         )
         logger.info(
-            "Worker Deployment versioning enabled: deployment=%s build_id=%s",
+            "Worker Deployment versioning enabled: deployment=%s build_id=%s behavior=%s",
             APP_DEPLOYMENT_NAME,
             APP_BUILD_ID,
+            versioning_behavior.name,
         )
     elif APP_BUILD_ID:
         deployment_config = WorkerDeploymentConfig(
@@ -470,9 +473,13 @@ def create_worker(
                 build_id=APP_BUILD_ID,
             ),
             use_worker_versioning=True,
-            default_versioning_behavior=VersioningBehavior.PINNED,
+            default_versioning_behavior=versioning_behavior,
         )
-        logger.info("Worker versioning enabled: build_id=%s", APP_BUILD_ID)
+        logger.info(
+            "Worker versioning enabled: build_id=%s behavior=%s",
+            APP_BUILD_ID,
+            versioning_behavior.name,
+        )
 
     worker_kwargs: dict = dict(
         task_queue=task_queue,

--- a/application_sdk/execution/settings.py
+++ b/application_sdk/execution/settings.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
+from temporalio.common import VersioningBehavior
+
 
 @dataclass(frozen=True)
 class ExecutionSettings:
@@ -27,6 +29,24 @@ class ExecutionSettings:
 
     graceful_shutdown_timeout_seconds: int = 3600
     """Seconds to wait for in-flight activities to complete during worker shutdown."""
+
+    default_versioning_behavior: VersioningBehavior = VersioningBehavior.PINNED
+    """Default Worker Deployment versioning behavior for workflows that do not
+    set one explicitly on ``@workflow.defn``.
+
+    ``PINNED`` (the default) keeps an in-flight workflow on the build it started
+    on until it finishes, so an incompatible release can never break a running
+    workflow mid-execution — the safe choice for the broad connector fleet.
+    ``AUTO_UPGRADE`` migrates in-flight workflows to the new ``CURRENT`` build at
+    their next workflow task, letting old builds drain and scale down sooner.
+
+    Opt into ``AUTO_UPGRADE`` per-app (set the env var in the app's own
+    deployment), and only when the app owner guarantees replay-determinism
+    across builds — reordering steps, parallelizing previously-sequential work,
+    or renaming activities is a *breaking change* for Temporal replay even when
+    the observable behavior is identical, and would fail in-flight workflows at
+    the migration boundary.
+    """
 
 
 @dataclass(frozen=True)
@@ -55,6 +75,18 @@ class InterceptorSettings:
     """
 
 
+def _load_versioning_behavior(env_var: str) -> VersioningBehavior:
+    """Parse a worker versioning behavior from ``env_var``.
+
+    Accepts ``PINNED`` / ``AUTO_UPGRADE`` (case-insensitive). Any unset, empty,
+    or unrecognized value falls back to the safe default, ``PINNED``.
+    """
+    val = os.environ.get(env_var, "").strip().upper()
+    if val == "AUTO_UPGRADE":
+        return VersioningBehavior.AUTO_UPGRADE
+    return VersioningBehavior.PINNED
+
+
 def load_execution_settings() -> ExecutionSettings:
     """Load execution settings from environment variables."""
     # v2-compat: remove ATLAN_WORKFLOW_HOST/PORT fallbacks when all deployments use TEMPORAL_HOST.
@@ -71,6 +103,9 @@ def load_execution_settings() -> ExecutionSettings:
         ),
         graceful_shutdown_timeout_seconds=int(
             os.environ.get("TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT", "3600")
+        ),
+        default_versioning_behavior=_load_versioning_behavior(
+            "TEMPORAL_DEFAULT_VERSIONING_BEHAVIOR"
         ),
     )
 

--- a/application_sdk/execution/settings.py
+++ b/application_sdk/execution/settings.py
@@ -8,7 +8,15 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
+# VersioningBehavior is a temporalio type. Importing it directly here leaks the
+# execution-backend dependency, but temporalio is a hard core dependency so the
+# coupling is acceptable. Re-exporting via _temporal/ would invert the layer
+# direction without providing any real isolation.
 from temporalio.common import VersioningBehavior
+
+from application_sdk.observability.logger_adaptor import get_logger
+
+logger = get_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -84,6 +92,8 @@ def _load_versioning_behavior(env_var: str) -> VersioningBehavior:
     val = os.environ.get(env_var, "").strip().upper()
     if val == "AUTO_UPGRADE":
         return VersioningBehavior.AUTO_UPGRADE
+    if val and val != "PINNED":
+        logger.warning("%s=%r not recognized; falling back to PINNED", env_var, val)
     return VersioningBehavior.PINNED
 
 

--- a/tests/unit/execution/test_settings.py
+++ b/tests/unit/execution/test_settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from temporalio.common import VersioningBehavior
 
 from application_sdk.execution.settings import (
     ExecutionSettings,
@@ -34,6 +35,10 @@ class TestExecutionSettingsDefaults:
     def test_default_graceful_shutdown_timeout(self) -> None:
         settings = ExecutionSettings()
         assert settings.graceful_shutdown_timeout_seconds == 3600
+
+    def test_default_versioning_behavior_is_pinned(self) -> None:
+        settings = ExecutionSettings()
+        assert settings.default_versioning_behavior == VersioningBehavior.PINNED
 
     def test_is_frozen(self) -> None:
         settings = ExecutionSettings()
@@ -85,6 +90,41 @@ class TestLoadExecutionSettingsFromEnv:
         settings = load_execution_settings()
         assert settings.host == "localhost:7233"
         assert settings.namespace == "default"
+
+    def test_versioning_behavior_auto_upgrade_from_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TEMPORAL_DEFAULT_VERSIONING_BEHAVIOR", "AUTO_UPGRADE")
+        settings = load_execution_settings()
+        assert settings.default_versioning_behavior == VersioningBehavior.AUTO_UPGRADE
+
+    def test_versioning_behavior_is_case_insensitive(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TEMPORAL_DEFAULT_VERSIONING_BEHAVIOR", "auto_upgrade")
+        settings = load_execution_settings()
+        assert settings.default_versioning_behavior == VersioningBehavior.AUTO_UPGRADE
+
+    def test_versioning_behavior_pinned_from_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TEMPORAL_DEFAULT_VERSIONING_BEHAVIOR", "PINNED")
+        settings = load_execution_settings()
+        assert settings.default_versioning_behavior == VersioningBehavior.PINNED
+
+    def test_versioning_behavior_unknown_falls_back_to_pinned(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TEMPORAL_DEFAULT_VERSIONING_BEHAVIOR", "bogus")
+        settings = load_execution_settings()
+        assert settings.default_versioning_behavior == VersioningBehavior.PINNED
+
+    def test_versioning_behavior_unset_defaults_to_pinned(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("TEMPORAL_DEFAULT_VERSIONING_BEHAVIOR", raising=False)
+        settings = load_execution_settings()
+        assert settings.default_versioning_behavior == VersioningBehavior.PINNED
 
 
 class TestInterceptorSettingsDefaults:


### PR DESCRIPTION
## What

Makes the Temporal worker's `default_versioning_behavior` configurable via env, instead of being hardcoded to `PINNED`. **Default is unchanged (`PINNED`).**

- `ExecutionSettings.default_versioning_behavior` — new field, defaults to `VersioningBehavior.PINNED`
- `load_execution_settings()` reads `TEMPORAL_DEFAULT_VERSIONING_BEHAVIOR` (`PINNED` | `AUTO_UPGRADE`, case-insensitive; unknown/empty/unset → `PINNED`)
- `execution/_temporal/worker.py` uses the setting at the two `WorkerDeploymentConfig` sites instead of the literal `VersioningBehavior.PINNED`

Same env-driven pattern as `max_concurrent_activities` / `graceful_shutdown_timeout`.

## Why

Per the [#publish-app discussion](https://atlanhq.slack.com/archives/C0A831V57JM/p1781005637077669):

- `PINNED` is the correct default for the broad connector fleet — an incompatible release can't break an in-flight workflow mid-execution.
- But system apps with long-running, frequently-deployed workflows (publish, AE) accumulate several pinned worker versions that stay warm until their in-flight runs drain — real cost (observed 4 live versions each of publish/AE, ~10 idle 32GB workers).
- Conclusion: keep `PINNED` as the safe default, but let an app **opt into `AUTO_UPGRADE` per-app** (set the env in its own deployment), and only when that app owner guarantees Temporal replay-determinism across builds (reordering/parallelizing steps or renaming activities is "breaking" for replay even if behavior is identical).

Ownership is per-app (the app sets the env in its deploy config), **not** per-tenant — so determinism responsibility sits with the app owner, not with whoever deploys connectors to a tenant.

## Tests

Added to `tests/unit/execution/test_settings.py`: default is `PINNED`; env `AUTO_UPGRADE` (+ case-insensitive); explicit `PINNED`; unknown value → `PINNED`; unset → `PINNED`. Full file: 29 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)