### PR TITLE
feat(observability): emit per-activity cpu and memory cost metrics

### DIFF
--- a/application_sdk/execution/_temporal/interceptors/metrics.py
+++ b/application_sdk/execution/_temporal/interceptors/metrics.py
@@ -26,6 +26,7 @@ from temporalio.worker import (
 
 from application_sdk.errors.categories import Audience, FailureCategory
 from application_sdk.execution._temporal.interceptors.log import _extract_failure_attrs
+from application_sdk.observability import resource_sampler
 
 _METER_NAME = "application_sdk.temporal"
 
@@ -105,6 +106,35 @@ def _activity_errors():
     return _INSTRUMENTS["act_err"]
 
 
+def _activity_cpu_seconds():
+    if "act_cpu" not in _INSTRUMENTS:
+        _INSTRUMENTS["act_cpu"] = _meter().create_histogram(
+            "temporal.activity.cpu_seconds",
+            unit="s",
+            description=(
+                "CPU time (user + system) consumed per activity execution. "
+                "Process-level delta between activity start and end — accurate "
+                "for workers running one activity at a time; over-attributes "
+                "per activity when activities run concurrently (sum is always correct)."
+            ),
+        )
+    return _INSTRUMENTS["act_cpu"]
+
+
+def _activity_mem_gib_seconds():
+    if "act_mem" not in _INSTRUMENTS:
+        _INSTRUMENTS["act_mem"] = _meter().create_histogram(
+            "temporal.activity.mem_gib_seconds",
+            unit="GiBy.s",
+            description=(
+                "Memory-time integral per activity execution: average RSS in GiB "
+                "multiplied by wall-clock duration in seconds. Same process-level "
+                "scope caveat as temporal.activity.cpu_seconds."
+            ),
+        )
+    return _INSTRUMENTS["act_mem"]
+
+
 def _classify_failure(exc: BaseException | None) -> dict[str, str]:
     """Extract bounded {category, audience} labels for the classified counter.
 
@@ -168,6 +198,7 @@ class _MetricsActivityInboundInterceptor(ActivityInboundInterceptor):
             "temporal.task_queue": info.task_queue or "",
         }
         start_ns = time.monotonic_ns()
+        start_sample = resource_sampler.sample()
         status = "OK"
         exception_class = ""
         try:
@@ -178,6 +209,7 @@ class _MetricsActivityInboundInterceptor(ActivityInboundInterceptor):
             raise
         finally:
             duration_s = (time.monotonic_ns() - start_ns) / 1_000_000_000
+            end_sample = resource_sampler.sample()
             tagged = {**attrs, "otel.status_code": status}
             try:
                 _activity_executions().add(1, tagged)
@@ -190,6 +222,12 @@ class _MetricsActivityInboundInterceptor(ActivityInboundInterceptor):
                             "exception.type": exception_class or "Unknown",
                         },
                     )
+                cpu_s, mem_gib_s = resource_sampler.compute_deltas(
+                    start_sample, end_sample, duration_s
+                )
+                if cpu_s > 0 or mem_gib_s > 0:
+                    _activity_cpu_seconds().record(cpu_s, attrs)
+                    _activity_mem_gib_seconds().record(mem_gib_s, attrs)
             except Exception:  # noqa: S110 — best-effort observability; never block the activity on metric emission
                 pass
 
@@ -207,6 +245,8 @@ class MetricsInterceptor(Interceptor):
       * ``temporal.activity.executions`` (counter)
       * ``temporal.activity.duration`` (histogram, seconds)
       * ``temporal.activity.errors`` (counter, partitioned by ``exception.type``)
+      * ``temporal.activity.cpu_seconds`` (histogram) — CPU time consumed per activity
+      * ``temporal.activity.mem_gib_seconds`` (histogram) — memory-time integral per activity
 
     Independent of, and complementary to, Temporal's Rust-core metrics —
     those measure scheduling / cache / poll latencies; these measure business

--- a/application_sdk/execution/_temporal/interceptors/metrics.py
+++ b/application_sdk/execution/_temporal/interceptors/metrics.py
@@ -222,10 +222,10 @@ class _MetricsActivityInboundInterceptor(ActivityInboundInterceptor):
                             "exception.type": exception_class or "Unknown",
                         },
                     )
-                cpu_s, mem_gib_s = resource_sampler.compute_deltas(
-                    start_sample, end_sample, duration_s
-                )
-                if cpu_s > 0 or mem_gib_s > 0:
+                if start_sample is not None and end_sample is not None:
+                    cpu_s, mem_gib_s = resource_sampler.compute_deltas(
+                        start_sample, end_sample, duration_s
+                    )
                     _activity_cpu_seconds().record(cpu_s, attrs)
                     _activity_mem_gib_seconds().record(mem_gib_s, attrs)
             except Exception:  # noqa: S110 — best-effort observability; never block the activity on metric emission

--- a/application_sdk/execution/_temporal/interceptors/metrics.py
+++ b/application_sdk/execution/_temporal/interceptors/metrics.py
@@ -226,8 +226,8 @@ class _MetricsActivityInboundInterceptor(ActivityInboundInterceptor):
                     cpu_s, mem_gib_s = resource_sampler.compute_deltas(
                         start_sample, end_sample, duration_s
                     )
-                    _activity_cpu_seconds().record(cpu_s, attrs)
-                    _activity_mem_gib_seconds().record(mem_gib_s, attrs)
+                    _activity_cpu_seconds().record(cpu_s, tagged)
+                    _activity_mem_gib_seconds().record(mem_gib_s, tagged)
             except Exception:  # noqa: S110 — best-effort observability; never block the activity on metric emission
                 pass
 

--- a/tests/unit/interceptors/test_metrics_interceptor.py
+++ b/tests/unit/interceptors/test_metrics_interceptor.py
@@ -384,13 +384,50 @@ class TestMetricsActivityInboundInterceptor:
         histogram = mock_meter.create_histogram.return_value
         # Three histograms recorded: duration, cpu_seconds, mem_gib_seconds.
         assert histogram.record.call_count == 3
-        recorded_values = [call[0][0] for call in histogram.record.call_args_list]
+        calls = histogram.record.call_args_list
+        recorded_values = [c[0][0] for c in calls]
+        recorded_tags = [c[0][1] for c in calls]
         # duration = 1.0s (pinned)
         assert recorded_values[0] == 1.0
         # cpu_seconds: 1.5 - 1.0 = 0.5
         assert recorded_values[1] == pytest.approx(0.5)
         # mem_gib_seconds: avg RSS = 150 MiB = 150/1024 GiB ≈ 0.14648; × 1.0s
         assert recorded_values[2] == pytest.approx(150 / 1024, rel=1e-4)
+        # cost metrics carry the same tags as duration (including otel.status_code)
+        for tags in recorded_tags[1:]:
+            assert tags["temporal.activity.type"] == "TestActivity"
+            assert tags["temporal.task_queue"] == "default"
+            assert tags["otel.status_code"] == "OK"
+
+    async def test_error_path_records_cost_metrics(self, mock_next, mock_meter):
+        fake_start = ResourceSample(cpu_time_s=1.0, rss_bytes=100 * 1024 * 1024)
+        fake_end = ResourceSample(cpu_time_s=1.5, rss_bytes=200 * 1024 * 1024)
+        mock_next.execute_activity = AsyncMock(side_effect=ValueError("bad"))
+        interceptor = _MetricsActivityInboundInterceptor(mock_next)
+
+        with (
+            patch(
+                "application_sdk.execution._temporal.interceptors.metrics.activity"
+            ) as mock_act,
+            patch(
+                "application_sdk.execution._temporal.interceptors.metrics.resource_sampler.sample",
+                side_effect=[fake_start, fake_end],
+            ),
+            patch(
+                "application_sdk.execution._temporal.interceptors.metrics.time.monotonic_ns",
+                side_effect=[0, 1_000_000_000],
+            ),
+        ):
+            mock_act.info.return_value = MockActivityInfo()
+            with pytest.raises(ValueError):
+                await interceptor.execute_activity(MockExecuteActivityInput())
+
+        histogram = mock_meter.create_histogram.return_value
+        # duration + cpu + mem all recorded even on error
+        assert histogram.record.call_count == 3
+        cost_tags = histogram.record.call_args_list[1][0][1]
+        assert cost_tags["otel.status_code"] == "ERROR"
+        assert cost_tags["temporal.activity.type"] == "TestActivity"
 
     async def test_no_cost_metrics_when_sampling_unavailable(
         self, interceptor, mock_meter

--- a/tests/unit/interceptors/test_metrics_interceptor.py
+++ b/tests/unit/interceptors/test_metrics_interceptor.py
@@ -364,6 +364,7 @@ class TestMetricsActivityInboundInterceptor:
     ):
         fake_start = ResourceSample(cpu_time_s=1.0, rss_bytes=100 * 1024 * 1024)
         fake_end = ResourceSample(cpu_time_s=1.5, rss_bytes=200 * 1024 * 1024)
+        # Pin monotonic clock: start=0ns, end=1_000_000_000ns → duration_s=1.0
         with (
             patch(
                 "application_sdk.execution._temporal.interceptors.metrics.activity"
@@ -371,6 +372,10 @@ class TestMetricsActivityInboundInterceptor:
             patch(
                 "application_sdk.execution._temporal.interceptors.metrics.resource_sampler.sample",
                 side_effect=[fake_start, fake_end],
+            ),
+            patch(
+                "application_sdk.execution._temporal.interceptors.metrics.time.monotonic_ns",
+                side_effect=[0, 1_000_000_000],
             ),
         ):
             mock_act.info.return_value = MockActivityInfo()
@@ -380,12 +385,12 @@ class TestMetricsActivityInboundInterceptor:
         # Three histograms recorded: duration, cpu_seconds, mem_gib_seconds.
         assert histogram.record.call_count == 3
         recorded_values = [call[0][0] for call in histogram.record.call_args_list]
-        # cpu_seconds delta should be ~0.5s
-        cpu_val = recorded_values[1]
-        assert 0.4 < cpu_val < 0.6
-        # mem_gib_seconds: avg RSS = 150 MiB = ~0.146 GiB; value depends on duration
-        mem_val = recorded_values[2]
-        assert mem_val >= 0
+        # duration = 1.0s (pinned)
+        assert recorded_values[0] == 1.0
+        # cpu_seconds: 1.5 - 1.0 = 0.5
+        assert recorded_values[1] == pytest.approx(0.5)
+        # mem_gib_seconds: avg RSS = 150 MiB = 150/1024 GiB ≈ 0.14648; × 1.0s
+        assert recorded_values[2] == pytest.approx(150 / 1024, rel=1e-4)
 
     async def test_no_cost_metrics_when_sampling_unavailable(
         self, interceptor, mock_meter

--- a/tests/unit/interceptors/test_metrics_interceptor.py
+++ b/tests/unit/interceptors/test_metrics_interceptor.py
@@ -19,6 +19,7 @@ from application_sdk.execution._temporal.interceptors.metrics import (
     _workflow_executions,
     _workflow_failures_classified,
 )
+from application_sdk.observability.resource_sampler import ResourceSample
 
 _METER_TARGET = (
     "application_sdk.execution._temporal.interceptors.metrics._otel_metrics.get_meter"
@@ -339,9 +340,16 @@ class TestMetricsActivityInboundInterceptor:
         assert tags["temporal.task_queue"] == "default"
 
     async def test_success_records_activity_duration(self, interceptor, mock_meter):
-        with patch(
-            "application_sdk.execution._temporal.interceptors.metrics.activity"
-        ) as mock_act:
+        # Suppress cost metrics so only the duration histogram call is emitted.
+        with (
+            patch(
+                "application_sdk.execution._temporal.interceptors.metrics.activity"
+            ) as mock_act,
+            patch(
+                "application_sdk.execution._temporal.interceptors.metrics.resource_sampler.sample",
+                return_value=None,
+            ),
+        ):
             mock_act.info.return_value = MockActivityInfo()
             await interceptor.execute_activity(MockExecuteActivityInput())
 
@@ -350,6 +358,53 @@ class TestMetricsActivityInboundInterceptor:
         duration_arg = histogram.record.call_args[0][0]
         assert isinstance(duration_arg, float)
         assert duration_arg >= 0
+
+    async def test_success_records_cpu_and_mem_cost_metrics(
+        self, interceptor, mock_meter
+    ):
+        fake_start = ResourceSample(cpu_time_s=1.0, rss_bytes=100 * 1024 * 1024)
+        fake_end = ResourceSample(cpu_time_s=1.5, rss_bytes=200 * 1024 * 1024)
+        with (
+            patch(
+                "application_sdk.execution._temporal.interceptors.metrics.activity"
+            ) as mock_act,
+            patch(
+                "application_sdk.execution._temporal.interceptors.metrics.resource_sampler.sample",
+                side_effect=[fake_start, fake_end],
+            ),
+        ):
+            mock_act.info.return_value = MockActivityInfo()
+            await interceptor.execute_activity(MockExecuteActivityInput())
+
+        histogram = mock_meter.create_histogram.return_value
+        # Three histograms recorded: duration, cpu_seconds, mem_gib_seconds.
+        assert histogram.record.call_count == 3
+        recorded_values = [call[0][0] for call in histogram.record.call_args_list]
+        # cpu_seconds delta should be ~0.5s
+        cpu_val = recorded_values[1]
+        assert 0.4 < cpu_val < 0.6
+        # mem_gib_seconds: avg RSS = 150 MiB = ~0.146 GiB; value depends on duration
+        mem_val = recorded_values[2]
+        assert mem_val >= 0
+
+    async def test_no_cost_metrics_when_sampling_unavailable(
+        self, interceptor, mock_meter
+    ):
+        with (
+            patch(
+                "application_sdk.execution._temporal.interceptors.metrics.activity"
+            ) as mock_act,
+            patch(
+                "application_sdk.execution._temporal.interceptors.metrics.resource_sampler.sample",
+                return_value=None,
+            ),
+        ):
+            mock_act.info.return_value = MockActivityInfo()
+            await interceptor.execute_activity(MockExecuteActivityInput())
+
+        histogram = mock_meter.create_histogram.return_value
+        # Only duration — cpu/mem skipped when sample() returns None.
+        histogram.record.assert_called_once()
 
     async def test_error_increments_counter_error_tag_and_reraises(
         self, mock_next, mock_meter


### PR DESCRIPTION
## Summary

- Wires the existing (but orphaned) `resource_sampler` module into `MetricsInterceptor` so two new OTel histograms are emitted on every activity execution:
  - `temporal.activity.cpu_seconds` — CPU time (user + system) delta between activity start and end
  - `temporal.activity.mem_gib_seconds` — memory-time integral: average RSS in GiB × wall-clock seconds
- Both histograms carry `temporal.activity.type` and `temporal.task_queue` labels, matching the existing activity instruments
- Sampling is best-effort: if `resource_sampler.sample()` returns `None` (e.g. on Windows or if `/proc` is unavailable), cost histograms are silently skipped with no effect on existing metrics

## Context

Raised as part of the Publish App monitoring & RCA consolidation (BLDX-1407). Anbarasan's cost war-room workstream (spot migration, VPA right-sizing, task-queue splitting) needs per-activity cost attribution in Victoria Metrics to make informed decisions. The `resource_sampler` module was already fully implemented — this PR makes the connection to the interceptor.

## Victoria Metrics queries this enables

CPU cost by activity type:
```promql
sum by (temporal_activity_type, app_name) (
  rate(temporal_activity_cpu_seconds_sum[1h])
)
```

Memory-time by activity type:
```promql
sum by (temporal_activity_type, app_name) (
  rate(temporal_activity_mem_gib_seconds_sum[1h])
)
```

**Scope caveat:** metrics are process-level samples. Accurate for workers running one activity at a time; over-attributes per activity when activities run concurrently, but the per-task-queue sum is always correct.

## Test plan

- [x] `test_success_records_cpu_and_mem_cost_metrics` — verifies all three histograms (duration, cpu, mem) fire with correct delta values from fake `ResourceSample` fixtures
- [x] `test_no_cost_metrics_when_sampling_unavailable` — verifies only duration is recorded when `sample()` returns `None`
- [x] `test_success_records_activity_duration` — updated to suppress cost metrics so the single-call assertion still holds
- [x] All 24 unit tests pass; all pre-commit checks pass

Closes BLDX-1407