### PR TITLE
fix(observability): suppress Cloudflare 504 long-poll noise from Temporal gRPC bridge

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -414,6 +414,12 @@ AWS_SESSION_NAME = os.getenv("AWS_SESSION_NAME", "temp-session")
 # Log batching configuration
 LOG_BATCH_SIZE = int(os.environ.get("ATLAN_LOG_BATCH_SIZE", 100))
 LOG_FLUSH_INTERVAL_SECONDS = int(os.environ.get("ATLAN_LOG_FLUSH_INTERVAL_SECONDS", 10))
+#: Minimum seconds between repeated INFO summaries for the Cloudflare 504
+#: long-poll suppression filter (TFKB ERROR-NET-001).  Increase for very
+#: chatty multi-worker deployments; decrease to see summaries more frequently.
+LOG_CLOUDFLARE_504_SUMMARY_INTERVAL_SECONDS = float(
+    os.environ.get("ATLAN_LOG_CLOUDFLARE_504_SUMMARY_INTERVAL_SECONDS", "60")
+)
 
 # Log Retention configuration
 LOG_RETENTION_DAYS = int(os.environ.get("ATLAN_LOG_RETENTION_DAYS", 30))

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -20,6 +20,7 @@ from application_sdk.constants import (
     ENABLE_OTLP_WORKFLOW_LOGS,
     LOG_BATCH_SIZE,
     LOG_CLEANUP_ENABLED,
+    LOG_CLOUDFLARE_504_SUMMARY_INTERVAL_SECONDS,
     LOG_FILE_NAME,
     LOG_FLUSH_INTERVAL_SECONDS,
     LOG_LEVEL,
@@ -394,7 +395,7 @@ class _CloudflareTimeoutFilter(logging.Filter):
     minute thereafter, so the pattern stays visible without flooding logs.
     """
 
-    _WARN_INTERVAL: ClassVar[float] = 60.0  # seconds between summary messages
+    _WARN_INTERVAL: ClassVar[float] = LOG_CLOUDFLARE_504_SUMMARY_INTERVAL_SECONDS
     _last_emitted: ClassVar[dict[str, float]] = {}
     _counts: ClassVar[dict[str, int]] = {}
     _lock: ClassVar[threading.Lock] = threading.Lock()
@@ -418,7 +419,7 @@ class _CloudflareTimeoutFilter(logging.Filter):
                 if should_emit:
                     self._last_emitted[record.name] = now
             if should_emit:
-                logger.info(
+                get_logger(__name__).info(
                     f"Cloudflare 504 timeout on poll_workflow_task_queue"
                     f" (occurrence {count} — expected, worker retrying normally,"
                     " TFKB ERROR-NET-001)"

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import sys
 import threading
+import time
 import traceback as tb_module
 from typing import Any, ClassVar
 
@@ -381,8 +382,56 @@ class InterceptHandler(logging.Handler):
         )
 
 
+class _CloudflareTimeoutFilter(logging.Filter):
+    """Suppress Cloudflare 504 long-poll noise from the Temporal gRPC bridge.
+
+    Cloudflare closes idle long-poll connections with an HTTP 504 whose HTML body
+    the Rust Temporal SDK misreads as an invalid gRPC compression flag (ASCII
+    '<' = 60).  The SDK logs this at ERROR and immediately retries — the worker
+    is unaffected.  See TFKB ERROR-NET-001.
+
+    An INFO summary is emitted on the first occurrence and at most once per
+    minute thereafter, so the pattern stays visible without flooding logs.
+    """
+
+    _WARN_INTERVAL: ClassVar[float] = 60.0  # seconds between summary messages
+    _last_emitted: ClassVar[dict[str, float]] = {}
+    _counts: ClassVar[dict[str, int]] = {}
+    _lock: ClassVar[threading.Lock] = threading.Lock()
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno != logging.ERROR or not record.name.startswith("temporalio"):
+            return True
+        msg = record.getMessage()
+        if (
+            "invalid compression flag: 60" in msg  # ASCII '<' = first byte of HTML 504
+            and "504 Gateway Timeout" in msg
+            and "poll_workflow_task_queue" in msg
+        ):
+            with self._lock:
+                self._counts[record.name] = self._counts.get(record.name, 0) + 1
+                count = self._counts[record.name]
+                now = time.monotonic()
+                # Seed with now - interval so the very first occurrence always fires
+                last = self._last_emitted.get(record.name, now - self._WARN_INTERVAL)
+                should_emit = (now - last) >= self._WARN_INTERVAL
+                if should_emit:
+                    self._last_emitted[record.name] = now
+            if should_emit:
+                logger.info(
+                    "Cloudflare 504 timeout on poll_workflow_task_queue"
+                    " (occurrence %d — expected, worker retrying normally,"
+                    " TFKB ERROR-NET-001)",
+                    count,
+                )
+            return False
+        return True
+
+
+_intercept_handler = InterceptHandler()
+_intercept_handler.addFilter(_CloudflareTimeoutFilter())
 logging.basicConfig(
-    level=logging.getLevelNamesMapping()[LOG_LEVEL], handlers=[InterceptHandler()]
+    level=logging.getLevelNamesMapping()[LOG_LEVEL], handlers=[_intercept_handler]
 )
 
 DEPENDENCY_LOGGERS = ["daft_io.stats", "tracing.span", "httpx"]

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -419,10 +419,9 @@ class _CloudflareTimeoutFilter(logging.Filter):
                     self._last_emitted[record.name] = now
             if should_emit:
                 logger.info(
-                    "Cloudflare 504 timeout on poll_workflow_task_queue"
-                    " (occurrence %d — expected, worker retrying normally,"
-                    " TFKB ERROR-NET-001)",
-                    count,
+                    f"Cloudflare 504 timeout on poll_workflow_task_queue"
+                    f" (occurrence {count} — expected, worker retrying normally,"
+                    " TFKB ERROR-NET-001)"
                 )
             return False
         return True

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 import warnings
 from collections.abc import Generator
@@ -2074,3 +2075,164 @@ class TestSecondaryWorkflowLogsExporter:
         )
         endpoints = self._endpoints_passed_to_exporter(mock_exporter)
         assert "" not in endpoints
+
+
+# ---------------------------------------------------------------------------
+# _CloudflareTimeoutFilter
+# ---------------------------------------------------------------------------
+
+_CF504_MSG = (
+    "gRPC call poll_workflow_task_queue retried 60 times\n"
+    'error=Status { code: Internal, message: "protocol error: received message with '
+    "invalid compression flag: 60 (valid flags are 0 and 1) while receiving response "
+    'with status: 504 Gateway Timeout", metadata: ... }'
+)
+
+
+def _make_temporalio_record(
+    msg: str = _CF504_MSG,
+    level: int = logging.ERROR,
+    name: str = "temporalio.client.retry",
+) -> logging.LogRecord:
+    import logging
+
+    return logging.LogRecord(
+        name=name,
+        level=level,
+        pathname=__file__,
+        lineno=1,
+        msg=msg,
+        args=(),
+        exc_info=None,
+    )
+
+
+class TestCloudflareTimeoutFilter:
+    @pytest.fixture(autouse=True)
+    def _reset_state(self):
+        from application_sdk.observability.logger_adaptor import (
+            _CloudflareTimeoutFilter,
+        )
+
+        _CloudflareTimeoutFilter._counts.clear()
+        _CloudflareTimeoutFilter._last_emitted.clear()
+        yield
+        _CloudflareTimeoutFilter._counts.clear()
+        _CloudflareTimeoutFilter._last_emitted.clear()
+
+    def test_matching_record_suppressed(self):
+        from application_sdk.observability.logger_adaptor import (
+            _CloudflareTimeoutFilter,
+        )
+
+        f = _CloudflareTimeoutFilter()
+        with mock.patch("application_sdk.observability.logger_adaptor.logger"):
+            assert f.filter(_make_temporalio_record()) is False
+
+    def test_non_temporalio_record_passes_through(self):
+        from application_sdk.observability.logger_adaptor import (
+            _CloudflareTimeoutFilter,
+        )
+
+        f = _CloudflareTimeoutFilter()
+        assert f.filter(_make_temporalio_record(name="some.other.logger")) is True
+
+    def test_non_error_level_passes_through(self):
+        from application_sdk.observability.logger_adaptor import (
+            _CloudflareTimeoutFilter,
+        )
+
+        f = _CloudflareTimeoutFilter()
+        assert f.filter(_make_temporalio_record(level=logging.WARNING)) is True
+
+    def test_different_temporalio_error_passes_through(self):
+        from application_sdk.observability.logger_adaptor import (
+            _CloudflareTimeoutFilter,
+        )
+
+        f = _CloudflareTimeoutFilter()
+        assert (
+            f.filter(_make_temporalio_record(msg="auth failure: credentials rejected"))
+            is True
+        )
+
+    def test_partial_match_passes_through(self):
+        """All three anchors must be present — two out of three still passes through."""
+        from application_sdk.observability.logger_adaptor import (
+            _CloudflareTimeoutFilter,
+        )
+
+        f = _CloudflareTimeoutFilter()
+        partial = "poll_workflow_task_queue retried\ninvalid compression flag: 60"
+        assert f.filter(_make_temporalio_record(msg=partial)) is True
+
+    def test_info_emitted_on_first_occurrence(self):
+        from application_sdk.observability.logger_adaptor import (
+            _CloudflareTimeoutFilter,
+        )
+
+        f = _CloudflareTimeoutFilter()
+        with mock.patch(
+            "application_sdk.observability.logger_adaptor.logger"
+        ) as mock_log:
+            f.filter(_make_temporalio_record())
+        mock_log.info.assert_called_once()
+
+    def test_info_suppressed_within_interval(self):
+        from application_sdk.observability.logger_adaptor import (
+            _CloudflareTimeoutFilter,
+        )
+
+        f = _CloudflareTimeoutFilter()
+        with mock.patch(
+            "application_sdk.observability.logger_adaptor.time"
+        ) as mock_time:
+            mock_time.monotonic.return_value = 1000.0
+            with mock.patch(
+                "application_sdk.observability.logger_adaptor.logger"
+            ) as mock_log:
+                f.filter(_make_temporalio_record())  # first — emits
+                f.filter(_make_temporalio_record())  # within interval — suppressed
+                assert mock_log.info.call_count == 1
+
+    def test_info_emitted_again_after_interval(self):
+        from application_sdk.observability.logger_adaptor import (
+            _CloudflareTimeoutFilter,
+        )
+
+        f = _CloudflareTimeoutFilter()
+        with (
+            mock.patch(
+                "application_sdk.observability.logger_adaptor.time"
+            ) as mock_time,
+            mock.patch(
+                "application_sdk.observability.logger_adaptor.logger"
+            ) as mock_log,
+        ):
+            mock_time.monotonic.return_value = 1000.0
+            f.filter(_make_temporalio_record())
+            mock_time.monotonic.return_value = 1060.1  # past 60 s interval
+            f.filter(_make_temporalio_record())
+            assert mock_log.info.call_count == 2
+
+    def test_count_in_summary_message(self):
+        """Cumulative occurrence count must appear in the INFO message."""
+        from application_sdk.observability.logger_adaptor import (
+            _CloudflareTimeoutFilter,
+        )
+
+        f = _CloudflareTimeoutFilter()
+        with (
+            mock.patch(
+                "application_sdk.observability.logger_adaptor.time"
+            ) as mock_time,
+            mock.patch(
+                "application_sdk.observability.logger_adaptor.logger"
+            ) as mock_log,
+        ):
+            mock_time.monotonic.return_value = 1000.0
+            f.filter(_make_temporalio_record())
+            mock_time.monotonic.return_value = 1060.1
+            f.filter(_make_temporalio_record())
+            second_msg = mock_log.info.call_args_list[1][0][0]
+            assert "2" in second_msg

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -2094,8 +2094,6 @@ def _make_temporalio_record(
     level: int = logging.ERROR,
     name: str = "temporalio.client.retry",
 ) -> logging.LogRecord:
-    import logging
-
     return logging.LogRecord(
         name=name,
         level=level,

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -2126,7 +2126,7 @@ class TestCloudflareTimeoutFilter:
         )
 
         f = _CloudflareTimeoutFilter()
-        with mock.patch("application_sdk.observability.logger_adaptor.logger"):
+        with mock.patch("application_sdk.observability.logger_adaptor.get_logger"):
             assert f.filter(_make_temporalio_record()) is False
 
     def test_non_temporalio_record_passes_through(self):
@@ -2172,11 +2172,13 @@ class TestCloudflareTimeoutFilter:
         )
 
         f = _CloudflareTimeoutFilter()
+        mock_adapter = mock.MagicMock()
         with mock.patch(
-            "application_sdk.observability.logger_adaptor.logger"
-        ) as mock_log:
+            "application_sdk.observability.logger_adaptor.get_logger",
+            return_value=mock_adapter,
+        ):
             f.filter(_make_temporalio_record())
-        mock_log.info.assert_called_once()
+        mock_adapter.info.assert_called_once()
 
     def test_info_suppressed_within_interval(self):
         from application_sdk.observability.logger_adaptor import (
@@ -2184,16 +2186,20 @@ class TestCloudflareTimeoutFilter:
         )
 
         f = _CloudflareTimeoutFilter()
-        with mock.patch(
-            "application_sdk.observability.logger_adaptor.time"
-        ) as mock_time:
+        mock_adapter = mock.MagicMock()
+        with (
+            mock.patch(
+                "application_sdk.observability.logger_adaptor.time"
+            ) as mock_time,
+            mock.patch(
+                "application_sdk.observability.logger_adaptor.get_logger",
+                return_value=mock_adapter,
+            ),
+        ):
             mock_time.monotonic.return_value = 1000.0
-            with mock.patch(
-                "application_sdk.observability.logger_adaptor.logger"
-            ) as mock_log:
-                f.filter(_make_temporalio_record())  # first — emits
-                f.filter(_make_temporalio_record())  # within interval — suppressed
-                assert mock_log.info.call_count == 1
+            f.filter(_make_temporalio_record())  # first — emits
+            f.filter(_make_temporalio_record())  # within interval — suppressed
+            assert mock_adapter.info.call_count == 1
 
     def test_info_emitted_again_after_interval(self):
         from application_sdk.observability.logger_adaptor import (
@@ -2201,19 +2207,21 @@ class TestCloudflareTimeoutFilter:
         )
 
         f = _CloudflareTimeoutFilter()
+        mock_adapter = mock.MagicMock()
         with (
             mock.patch(
                 "application_sdk.observability.logger_adaptor.time"
             ) as mock_time,
             mock.patch(
-                "application_sdk.observability.logger_adaptor.logger"
-            ) as mock_log,
+                "application_sdk.observability.logger_adaptor.get_logger",
+                return_value=mock_adapter,
+            ),
         ):
             mock_time.monotonic.return_value = 1000.0
             f.filter(_make_temporalio_record())
             mock_time.monotonic.return_value = 1060.1  # past 60 s interval
             f.filter(_make_temporalio_record())
-            assert mock_log.info.call_count == 2
+            assert mock_adapter.info.call_count == 2
 
     def test_count_in_summary_message(self):
         """Cumulative occurrence count must appear in the INFO message."""
@@ -2222,17 +2230,19 @@ class TestCloudflareTimeoutFilter:
         )
 
         f = _CloudflareTimeoutFilter()
+        mock_adapter = mock.MagicMock()
         with (
             mock.patch(
                 "application_sdk.observability.logger_adaptor.time"
             ) as mock_time,
             mock.patch(
-                "application_sdk.observability.logger_adaptor.logger"
-            ) as mock_log,
+                "application_sdk.observability.logger_adaptor.get_logger",
+                return_value=mock_adapter,
+            ),
         ):
             mock_time.monotonic.return_value = 1000.0
             f.filter(_make_temporalio_record())
             mock_time.monotonic.return_value = 1060.1
             f.filter(_make_temporalio_record())
-            second_msg = mock_log.info.call_args_list[1][0][0]
+            second_msg = mock_adapter.info.call_args_list[1][0][0]
             assert "2" in second_msg


### PR DESCRIPTION
## Summary

- The Rust Temporal SDK logs `poll_workflow_task_queue` 504 timeouts at `ERROR` level on every retry — an expected, harmless side-effect of Cloudflare closing idle long-poll connections. This generates hundreds of false-alarm `ERROR` lines per workflow and buries genuine failures.
- Adds `_CloudflareTimeoutFilter` to `InterceptHandler`, which suppresses log records matching all three anchors (`"invalid compression flag: 60"`, `"504 Gateway Timeout"`, `"poll_workflow_task_queue"`) and emits a single `INFO` summary on first occurrence, then at most once per minute.
- Filter is attached to the handler (not the logger) so suppressed records never reach `emit()` — zero frame-walk or loguru dispatch cost for the noisy path.

Closes BLDX-1277. See also TFKB ERROR-NET-001.

## Design notes

**Why three `in` checks instead of a regex?** The match needs all three substrings to be present — substring `in` is O(n) with no backtracking, strictly cheaper than a compiled regex with `[\s\S]*` connectors. Ordered most-to-least discriminating so the first check short-circuits on any non-matching record.

**Why `return False` (not level downgrade)?** Returning `False` from a handler filter causes `Handler.handle()` to skip `emit()` entirely. Downgrading `record.levelno` to `DEBUG` still runs the full `InterceptHandler.emit()` frame walk before loguru drops it at the sink level.

**Why time-based (60 s) not count-based?** The ticket notes ~one ERROR every few seconds per worker — count-based at 100 would mean a summary every 3–8 minutes. Time-based gives predictable cadence regardless of emit rate.

## Test plan

- [ ] Deploy an SDR Oracle worker against a Cloudflare-fronted Temporal endpoint and confirm `ERROR temporalio_client::retry: gRPC call poll_workflow_task_queue` no longer appears in logs
- [ ] Confirm a single `INFO` line referencing `TFKB ERROR-NET-001` appears within the first minute of idle polling
- [ ] Confirm genuine `temporalio.*` `ERROR` logs (auth failure, quota exceeded, etc.) are unaffected
- [ ] Unit tests pass (`4987 passed`)