### PR TITLE
chore(publish): restore GHCR org-PAT auth after setup-crane clobbers it

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -1156,6 +1156,18 @@ jobs:
         if: needs.prepare.outputs.enable_sdr == 'true'
         uses: imjasonh/setup-crane@59c71e96a00b28651f10369ba3359a6d730740a0 # v0.6
 
+      # setup-crane's final step runs `crane auth login ghcr.io` with the
+      # calling repo's GITHUB_TOKEN, overwriting the ghcr.io credential the
+      # "Log in to GHCR" step wrote. GITHUB_TOKEN has no access to
+      # PAT-published GHCR packages, so `crane copy` would fail with DENIED.
+      # Log back in with the org PAT before copying.
+      - name: Restore GHCR auth (setup-crane clobbers it with GITHUB_TOKEN)
+        if: needs.prepare.outputs.enable_sdr == 'true'
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_PAT:  ${{ secrets.ORG_PAT_GITHUB }}
+        run: crane auth login ghcr.io --username "${GHCR_USER}" --password-stdin <<< "${GHCR_PAT}"
+
       - name: Push to Docker Hub (re-tag, no rebuild)
         id: dockerhub_push
         if: needs.prepare.outputs.enable_sdr == 'true'


### PR DESCRIPTION
## Problem

Since #2020, the `Push to Docker Hub (re-tag, no rebuild)` step in `build-and-publish-app.yaml` fails deterministically for consuming apps:

```
Error: fetching "ghcr.io/atlanhq/<app>:<tag>": GET https://ghcr.io/v2/atlanhq/<app>/manifests/<tag>: DENIED: requested access to the resource is denied
```

Example failing runs (atlan-redshift-app, 3-of-3 at the same step): [27262328989](https://github.com/atlanhq/atlan-redshift-app/actions/runs/27262328989), [27263083668](https://github.com/atlanhq/atlan-redshift-app/actions/runs/27263083668), [27266230481](https://github.com/atlanhq/atlan-redshift-app/actions/runs/27266230481).

## Root cause

`imjasonh/setup-crane` unconditionally runs the following as its **final step** ([action source](https://github.com/imjasonh/setup-crane/blob/59c71e96a00b28651f10369ba3359a6d730740a0/action.yml)):

```bash
echo "${GITHUB_TOKEN}" | crane auth login ghcr.io --username "dummy" --password-stdin
```

with `GITHUB_TOKEN: ${{ github.token }}` hardcoded in its env. Because `Install crane` runs **after** the `docker/login-action` GHCR login, it overwrites the `ghcr.io` entry in `~/.docker/config.json`, replacing `ORG_PAT_GITHUB` with the calling repo's default `GITHUB_TOKEN`.

That token has no access to the GHCR package when the package was published with the org PAT (GHCR only auto-grants a repo's Actions access when the package is first published from that repo's workflow using `GITHUB_TOKEN`) — so `crane copy` gets `DENIED` on the first manifest GET. Apps whose package happens to grant the repo Actions access pass, which is why the breakage looked inconsistent across the fleet while being 100% reproducible per repo.

## Fix

Add a 1-line `Restore GHCR auth` step between `Install crane` and the copy: `crane auth login ghcr.io` with `ORG_PAT_GITHUB` (via env + `--password-stdin`, so the secret never appears in argv). This re-establishes the credential the copy step was always documented to use, and is order-robust — it states the invariant explicitly instead of relying on step ordering.

## Verification

- `uv run pre-commit run --files .github/workflows/build-and-publish-app.yaml` — passed
- YAML parse check — passed
- **End-to-end verified**: dispatched atlan-redshift-app `Build & Publish` (`publish=false`) from a branch off the originally-failing branch, with the reusable workflow pointed at this PR branch — [run 27271172987](https://github.com/atlanhq/atlan-redshift-app/actions/runs/27271172987) ✅. The previously-failing `Push to Docker Hub (re-tag, no rebuild)` step succeeded: crane copied the multi-arch image GHCR → Docker Hub and the image was cosign-signed by digest.

## Follow-up

atlan-redshift-app (and any other app that pinned `build-and-publish-app.yaml@0424b8e6` as a workaround) should re-point to `@main` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
