### PR TITLE
fix(testing): bump e2e HTTP per-request timeout from 30s to 60s

### DIFF
--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -64,7 +64,7 @@ _USER_AGENT = "atlan-sdk-full-dag-e2e/1.0 (+https://github.com/atlanhq/applicati
 # while-loops so the overall budget is driven by ``poll_native_status``
 # / ``poll_atlas_for_connection``; the per-request timeout just keeps
 # any one call from hanging the whole loop.
-_HTTP_TIMEOUT = 30
+_HTTP_TIMEOUT = 60
 
 # Cadence for "still polling" heartbeat log lines in
 # ``poll_native_status`` — lineage stages take 2-5 min on small


### PR DESCRIPTION
## Summary

- Bumps `_HTTP_TIMEOUT` in `application_sdk/testing/e2e/client.py` from 30 s to 60 s
- AE API calls during workflow submission can connect and complete TLS but be slow to return a response on a loaded test tenant, causing the 30 s socket read guard to fire before the workflow even starts
- The outer `ae_poll_timeout_seconds` / `atlas_poll_timeout_seconds` budgets remain the correctness guard; this change only widens the per-request hang-prevention window

## Test plan

- [ ] Re-run the `atlan-openapi-app` e2e workflow that surfaced the original `TimeoutError: The read operation timed out` failure
- [ ] Confirm no regression on other connectors using the same e2e harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)