### PR TITLE
ci(renovate): use full github> path for self-referencing preset

### DIFF
--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -64,7 +64,7 @@ _USER_AGENT = "atlan-sdk-full-dag-e2e/1.0 (+https://github.com/atlanhq/applicati
 # while-loops so the overall budget is driven by ``poll_native_status``
 # / ``poll_atlas_for_connection``; the per-request timeout just keeps
 # any one call from hanging the whole loop.
-_HTTP_TIMEOUT = 30
+_HTTP_TIMEOUT = 60
 
 # Cadence for "still polling" heartbeat log lines in
 # ``poll_native_status`` — lineage stages take 2-5 min on small

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "application-sdk dogfood config — extends its own fleet preset (renovate-config/default.json).",
   "extends": [
-    "local>renovate-config/default.json"
+    "github>atlanhq/application-sdk//renovate-config/default.json"
   ],
   "ignorePaths": [
     ".venv/**",


### PR DESCRIPTION
## Summary

`local>renovate-config/default.json` is invalid syntax for the hosted Mend app — `local>` requires a full `org/repo//path` reference. Renovate was bailing with "Cannot find preset's package" before running at all.

Switches to `github>atlanhq/application-sdk//renovate-config/default.json`, which is the same syntax consumer repos already use to extend this preset.

## Test plan

- [ ] Repository problems banner clears on developer.mend.io after next Renovate run