### PR TITLE
feat(storage): opt-in explicit_files path for deterministic uploads (PART-1148)

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -934,6 +934,7 @@ class App(ABC):
             storage_subdir=input.storage_subdir,
             skip_if_exists=input.skip_if_exists,
             raise_on_empty=input.raise_on_empty,
+            explicit_files=input.explicit_files,
             store=store,
             _source_ref=source_ref,
             _source_store=self.context.storage,

--- a/application_sdk/contracts/storage.py
+++ b/application_sdk/contracts/storage.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from pathlib import PurePosixPath
+from typing import Annotated
 
 from pydantic import Field, field_validator
 
 from application_sdk.contracts.base import Input, Output
-from application_sdk.contracts.types import FileReference, StorageTier
+from application_sdk.contracts.types import FileReference, MaxItems, StorageTier
 
 
 class UploadInput(Input):
@@ -64,6 +65,16 @@ class UploadInput(Input):
             patterns in dbt / databricks / coalesce connectors. Will flip
             to ``True`` default in v4.0 alongside ``BaseMetadataExtractor``
             removal.
+        explicit_files: Optional pre-enumerated list of files to upload.
+            When supplied, the directory branch skips ``rglob`` discovery
+            entirely and uses this list as the authoritative file set —
+            closes the filesystem-listing-transient race deterministically
+            (PART-1148). The canonical producer is
+            ``pyarrow.dataset.write_dataset(file_visitor=lambda f:
+            out.append(Path(f.path)))``, which captures every written file
+            synchronously at write time. When ``None`` (default),
+            discovery falls back to ``rglob`` — byte-identical to existing
+            behavior. All paths must be under ``local_path``.
     """
 
     local_path: str = ""
@@ -73,6 +84,7 @@ class UploadInput(Input):
     tier: StorageTier = StorageTier.RETAINED
     skip_if_exists: bool = False
     raise_on_empty: bool = False
+    explicit_files: Annotated[list[str], MaxItems(10000)] | None = None
 
     @field_validator("storage_subdir")
     @classmethod

--- a/application_sdk/storage/transfer.py
+++ b/application_sdk/storage/transfer.py
@@ -492,22 +492,40 @@ async def upload(
             append_leaf=False,
         )
         files = [p for p in src.rglob("*") if p.is_file()]
-        if raise_on_empty and not files:
-            from application_sdk.storage.errors import (  # noqa: PLC0415
-                StorageEmptyUploadError,
-            )
+        # rglob/iterdir listing transients settle within ~350ms — absorb
+        # internally so callers never see file_count=0 for a populated dir.
+        for backoff_s in (0.05, 0.1, 0.2):
+            if files or not any(p.is_file() for p in src.iterdir()):
+                break
+            await asyncio.sleep(backoff_s)
+            files = [p for p in src.rglob("*") if p.is_file()]
+        if not files:
+            if any(p.is_file() for p in src.iterdir()):
+                from application_sdk.storage.errors import StorageError  # noqa: PLC0415
 
-            raise StorageEmptyUploadError(
-                f"upload(local_path={local_path!r}): directory contains "
-                "zero files. Either the extract step produced no output, "
-                "or files were written to a different path than the one "
-                "passed here. If quiet-day empty uploads are expected "
-                "(e.g. incremental extracts with no new data), drop "
-                "``raise_on_empty=True``. Otherwise verify the extract "
-                "wrote files to the expected ``local_path``. See the "
-                "dbt / databricks / coalesce connectors for the "
-                "stream-uploaded-per-file workaround pattern.",
-                local_path=local_path,
+                raise StorageError(
+                    f"upload(local_path={local_path!r}): rglob persistently "
+                    f"inconsistent with iterdir after retries."
+                )
+            if raise_on_empty:
+                from application_sdk.storage.errors import (  # noqa: PLC0415
+                    StorageEmptyUploadError,
+                )
+
+                raise StorageEmptyUploadError(
+                    f"upload(local_path={local_path!r}): directory contains "
+                    "zero files. Either the extract step produced no output, "
+                    "or files were written to a different path than the one "
+                    "passed here. If quiet-day empty uploads are expected "
+                    "(e.g. incremental extracts with no new data), drop "
+                    "``raise_on_empty=True``. Otherwise verify the extract "
+                    "wrote files to the expected ``local_path``. See the "
+                    "dbt / databricks / coalesce connectors for the "
+                    "stream-uploaded-per-file workaround pattern.",
+                    local_path=local_path,
+                )
+            return _make_upload_output(
+                str(src), prefix, 0, _tier, 0, "empty", is_dir=True
             )
         sem = asyncio.Semaphore(max_concurrency)
         keys = [

--- a/application_sdk/storage/transfer.py
+++ b/application_sdk/storage/transfer.py
@@ -355,6 +355,7 @@ async def upload(
     storage_subdir: str | None = None,
     skip_if_exists: bool = False,
     raise_on_empty: bool = False,
+    explicit_files: list[Path] | list[str] | None = None,
     store: ObjectStore | None = None,
     _source_ref: FileReference | None = None,
     _source_store: ObjectStore | None = None,
@@ -404,6 +405,17 @@ async def upload(
             *local_path* is a directory that contains zero files. Opt-in
             fail-loud for connectors where empty output indicates a bug
             (see BLDX-1255). Applies to the local-directory branch only.
+        explicit_files: Optional pre-enumerated list of files to upload.
+            When supplied, the directory branch skips ``src.rglob("*")``
+            discovery entirely and uses this list as the authoritative file
+            set — fully deterministic, no filesystem-listing race surface.
+            The canonical producer is
+            ``pyarrow.dataset.write_dataset(file_visitor=lambda f: out.append(Path(f.path)))``,
+            which captures every written file synchronously at write time
+            (see PART-1148 for the bug this closes). When ``None``
+            (default), discovery falls back to ``rglob`` — byte-identical
+            to pre-PART-1148 behavior, no change for existing callers.
+            All paths must be under *local_path*.
         store: Target object store (upstream in SDR, deployment otherwise), or
             ``None`` to resolve from infrastructure.
         _source_ref: Internal — pre-computed ``FileReference`` carrying both
@@ -491,48 +503,40 @@ async def upload(
             normalize_key,
             append_leaf=False,
         )
-        files = [p for p in src.rglob("*") if p.is_file()]
-        # rglob/iterdir listing transients settle within ~350ms — absorb
-        # internally so callers never see file_count=0 for a populated dir.
-        for backoff_s in (0.05, 0.1, 0.2):
-            if files or not any(p.is_file() for p in src.iterdir()):
-                break
-            await asyncio.sleep(backoff_s)
-            files = [p for p in src.rglob("*") if p.is_file()]
-        if not files:
-            if any(p.is_file() for p in src.iterdir()):
-                from application_sdk.storage.errors import StorageError  # noqa: PLC0415
+        # ``files`` (when supplied by the caller) bypasses rglob entirely —
+        # closes the listing-transient race deterministically for callers
+        # that already know the exact file set (typically captured via
+        # ``pyarrow.dataset.write_dataset(file_visitor=...)``). When the
+        # caller doesn't supply one, fall back to rglob discovery —
+        # byte-identical to pre-PART-1148 behavior so existing callers see
+        # no change.
+        if explicit_files is not None:
+            discovered = [Path(f) for f in explicit_files]
+        else:
+            discovered = [p for p in src.rglob("*") if p.is_file()]
+        if raise_on_empty and not discovered:
+            from application_sdk.storage.errors import (  # noqa: PLC0415
+                StorageEmptyUploadError,
+            )
 
-                raise StorageError(
-                    f"upload(local_path={local_path!r}): rglob persistently "
-                    f"inconsistent with iterdir after retries."
-                )
-            if raise_on_empty:
-                from application_sdk.storage.errors import (  # noqa: PLC0415
-                    StorageEmptyUploadError,
-                )
-
-                raise StorageEmptyUploadError(
-                    f"upload(local_path={local_path!r}): directory contains "
-                    "zero files. Either the extract step produced no output, "
-                    "or files were written to a different path than the one "
-                    "passed here. If quiet-day empty uploads are expected "
-                    "(e.g. incremental extracts with no new data), drop "
-                    "``raise_on_empty=True``. Otherwise verify the extract "
-                    "wrote files to the expected ``local_path``. See the "
-                    "dbt / databricks / coalesce connectors for the "
-                    "stream-uploaded-per-file workaround pattern.",
-                    local_path=local_path,
-                )
-            return _make_upload_output(
-                str(src), prefix, 0, _tier, 0, "empty", is_dir=True
+            raise StorageEmptyUploadError(
+                f"upload(local_path={local_path!r}): directory contains "
+                "zero files. Either the extract step produced no output, "
+                "or files were written to a different path than the one "
+                "passed here. If quiet-day empty uploads are expected "
+                "(e.g. incremental extracts with no new data), drop "
+                "``raise_on_empty=True``. Otherwise verify the extract "
+                "wrote files to the expected ``local_path``. See the "
+                "dbt / databricks / coalesce connectors for the "
+                "stream-uploaded-per-file workaround pattern.",
+                local_path=local_path,
             )
         sem = asyncio.Semaphore(max_concurrency)
         keys = [
             f"{prefix}/{str(fp.relative_to(src)).replace(os.sep, '/')}"
             if prefix
             else str(fp.relative_to(src)).replace(os.sep, "/")
-            for fp in files
+            for fp in discovered
         ]
 
         async def _bounded_upload(file_path: Path, fkey: str) -> bool:
@@ -543,7 +547,7 @@ async def upload(
                 return ok
 
         results = await asyncio.gather(
-            *[_bounded_upload(fp, k) for fp, k in zip(files, keys)],
+            *[_bounded_upload(fp, k) for fp, k in zip(discovered, keys)],
             return_exceptions=True,
         )
         errs = [r for r in results if isinstance(r, BaseException)]
@@ -554,7 +558,7 @@ async def upload(
         n = sum(1 for ok in results if ok)
         reason = "uploaded" if n > 0 else "skipped:hash_match"
         return _make_upload_output(
-            str(src), prefix, len(files), _tier, n, reason, is_dir=True
+            str(src), prefix, len(discovered), _tier, n, reason, is_dir=True
         )
 
     elif (

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.16.0
-source-sha:    8d1f0a5dfc5ccd4c5356e86d5157d120a3ca68b0
-source-date:   2026-06-10T17:45:19+05:30
+source-sha:    19c8f8ef92b2161e52e6c7f20b70a46f8d26d90a
+source-date:   2026-06-11T17:36:49+05:30
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -2360,6 +2360,7 @@ Strongly-typed Pydantic models for SDK methods. Contracts in `application_sdk.co
   - `tier: StorageTier` `= StorageTier.RETAINED`
   - `skip_if_exists: bool` `= False`
   - `raise_on_empty: bool` `= False`
+  - `explicit_files: Annotated[list[str], MaxItems(10000)] | None`
 - **Defined in:** `application_sdk/contracts/storage.py`
 
 #### `UploadOutput`

--- a/tests/integration/test_storage_io.py
+++ b/tests/integration/test_storage_io.py
@@ -340,3 +340,94 @@ async def test_transfer_upload_directory_max_concurrency(store, tmp_path):
 
     assert out.ref.file_count == 8
     assert out.synced is True
+
+
+# ------------------------------------------------------------------
+# PART-1148: explicit_files (deterministic file enumeration via
+# pyarrow.dataset.write_dataset(file_visitor=...))
+# ------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_explicit_files_end_to_end_with_pyarrow_file_visitor(store, tmp_path):
+    """Canonical PART-1148 flow exercised against a real store.
+
+    Demonstrates the full pattern the SDK contract documents:
+
+      1. ``pa_ds.write_dataset(file_visitor=lambda f: written.append(Path(f.path)))``
+         writes parquet chunks AND captures the authoritative file list
+         synchronously at write time.
+      2. The captured list is passed as ``explicit_files`` to ``upload``.
+      3. ``upload`` skips ``rglob`` discovery entirely, uploads every
+         captured file via the real local store backend.
+      4. ``download_prefix`` returns the same bytes the parquet writer
+         produced — closing the read-after-write loop deterministically.
+
+    This is the canonical bug-closure scenario from PART-1148: when the
+    rglob-side race could have returned an empty list under load, the
+    explicit-files path is unaffected because no listing happens.
+    """
+    import pyarrow as pa  # noqa: PLC0415 — integration-only; not a runtime dep of the SDK
+    import pyarrow.dataset as pa_ds  # noqa: PLC0415
+    import pyarrow.parquet as pq  # noqa: PLC0415
+
+    from application_sdk.storage.transfer import upload
+
+    src_dir = tmp_path / "parquet_out"
+
+    # Build a small but multi-chunk dataset so write_dataset produces
+    # multiple files (exercises the per-file file_visitor callback).
+    table = pa.table(
+        {
+            "id": list(range(1200)),
+            "name": [f"row-{i}" for i in range(1200)],
+        }
+    )
+
+    written: list[str] = []
+    pa_ds.write_dataset(
+        table,
+        base_dir=str(src_dir),
+        format="parquet",
+        basename_template="chunk_{i}.parquet",
+        max_rows_per_file=500,
+        min_rows_per_group=500,
+        max_rows_per_group=500,
+        file_visitor=lambda f: written.append(f.path),
+    )
+
+    # write_dataset wrote three chunks (500 + 500 + 200). file_visitor
+    # captured the authoritative paths synchronously.
+    assert len(written) == 3, f"expected 3 chunks from write_dataset, got {written}"
+    assert all(p.endswith(".parquet") for p in written)
+
+    # Pass the captured list directly. rglob is not called.
+    out = await upload(
+        str(src_dir),
+        "deterministic/",
+        store=store,
+        explicit_files=written,
+    )
+
+    assert out.ref.file_count == 3
+    assert out.synced is True
+    assert out.reason == "uploaded"
+
+    # Read back through the store — the bytes survived the round trip,
+    # proving the explicit_files path uploaded the same files
+    # write_dataset produced.
+    keys = await list_keys("deterministic/", store)
+    parquet_keys = [k for k in keys if k.endswith(".parquet")]
+    assert len(parquet_keys) == 3
+    # Each parquet has a sibling .sha256 sidecar written by the store.
+    sidecar_keys = [k for k in keys if k.endswith(".sha256")]
+    assert len(sidecar_keys) == 3
+
+    dest_dir = tmp_path / "downloaded"
+    paths = await download_prefix("deterministic/", dest_dir, store)
+    parquet_paths = [p for p in paths if str(p).endswith(".parquet")]
+    assert len(parquet_paths) == 3
+    # Each downloaded parquet is a valid file with the expected schema.
+    for downloaded in parquet_paths:
+        rt = pq.read_table(downloaded)
+        assert rt.schema.names == ["id", "name"]

--- a/tests/unit/storage/test_transfer.py
+++ b/tests/unit/storage/test_transfer.py
@@ -182,6 +182,234 @@ class TestUploadRaiseOnEmpty:
         assert out.synced is True
 
 
+class TestUploadDirectoryListingTransient:
+    """PART-1148: absorb the rglob/iterdir listing transient inside the SDK.
+
+    Before the fix, the directory branch of :func:`upload` enumerated the
+    local tree with a single ``src.rglob("*")`` walk and trusted the
+    result. When that walk returned empty for a directory that DID
+    contain files (filesystem-listing transient, observed on macOS APFS
+    under concurrent activity load), the SDK silently completed with
+    ``ref.file_count=0, reason="skipped:hash_match"``. Downstream
+    consumers branching on ``ref.file_count == 0`` then dropped the
+    whole stage — invisible to telemetry.
+
+    The fix has two parts:
+
+    1. Internal retry-with-backoff (50/100/200 ms) when ``rglob`` and
+       ``iterdir`` disagree on whether the directory has top-level
+       files. Caller code never sees the transient; the library
+       absorbs it. Standard pattern across cloud SDKs for transient
+       I/O.
+    2. Observability: emit ``reason="empty"`` (not the misleading
+       ``"skipped:hash_match"``) for genuinely empty input.
+
+    Tests below pin every branch of the new behaviour:
+    happy-path / quiet-day-empty / one-retry recovery / two-retry
+    recovery / persistent disagreement raises / race-takes-precedence
+    over raise_on_empty / no false positive on subdir-only / explicit
+    top-level-only scope.
+    """
+
+    @pytest.fixture
+    def captured_sleeps(self, monkeypatch):
+        """Mock ``asyncio.sleep`` inside transfer.py — capture durations, skip waits."""
+        sleeps: list[float] = []
+
+        async def _fake_sleep(seconds):
+            sleeps.append(seconds)
+
+        monkeypatch.setattr(
+            "application_sdk.storage.transfer.asyncio.sleep", _fake_sleep
+        )
+        return sleeps
+
+    async def test_genuinely_empty_dir_default_returns_empty_reason(
+        self, store, tmp_path, captured_sleeps
+    ) -> None:
+        """Empty input + default ``raise_on_empty=False`` → silent quiet-day path.
+
+        Pins both BLDX-1255 contract (silent ``file_count=0``) AND the
+        observability correction (no more misleading ``skipped:hash_match``
+        reason on empty input).
+        """
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        out = await upload(str(empty), "myprefix", store=store)
+        assert out.ref.file_count == 0
+        assert out.synced is False
+        assert out.reason == "empty", (
+            f"reason={out.reason!r}: empty input must report a distinct "
+            f"reason. 'skipped:hash_match' falsely implies hash-match "
+            f"skipping happened."
+        )
+        assert captured_sleeps == []
+
+    async def test_genuinely_empty_dir_with_raise_on_empty_still_raises(
+        self, store, tmp_path, captured_sleeps
+    ) -> None:
+        """Existing BLDX-1255 opt-in path preserved unchanged."""
+        from application_sdk.storage.errors import StorageEmptyUploadError
+
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        with pytest.raises(StorageEmptyUploadError, match="contains zero files"):
+            await upload(str(empty), "myprefix", store=store, raise_on_empty=True)
+        assert captured_sleeps == []
+
+    async def test_happy_path_no_sleeps(self, store, tmp_path, captured_sleeps) -> None:
+        """When rglob succeeds first try, retries never fire — zero latency cost."""
+        (tmp_path / "data.txt").write_bytes(b"hello")
+        out = await upload(str(tmp_path), "myprefix", store=store)
+        assert out.ref.file_count == 1
+        assert out.reason == "uploaded"
+        assert captured_sleeps == []
+
+    async def test_transient_recovers_on_first_retry(
+        self, store, tmp_path, captured_sleeps, monkeypatch
+    ) -> None:
+        """One empty rglob → 50ms backoff → next call returns the file → uploads normally.
+
+        Models the macOS APFS readdir-after-write window. Caller observes
+        a normal ``reason="uploaded"`` result — no surfacing of the
+        transient.
+        """
+        from pathlib import Path
+
+        local_dir = tmp_path / "raced"
+        local_dir.mkdir()
+        (local_dir / "file.txt").write_bytes(b"data")
+
+        original_rglob = Path.rglob
+        n = {"calls": 0}
+
+        def _flaky_rglob(self, pattern):
+            n["calls"] += 1
+            return iter([]) if n["calls"] == 1 else original_rglob(self, pattern)
+
+        monkeypatch.setattr(Path, "rglob", _flaky_rglob)
+
+        out = await upload(str(local_dir), "raced", store=store)
+        assert out.ref.file_count == 1
+        assert out.reason == "uploaded"
+        assert captured_sleeps == [0.05]
+
+    async def test_transient_recovers_on_second_retry(
+        self, store, tmp_path, captured_sleeps, monkeypatch
+    ) -> None:
+        """Two empty rglobs (50, 100ms backoffs) → third call recovers → succeeds."""
+        from pathlib import Path
+
+        local_dir = tmp_path / "raced"
+        local_dir.mkdir()
+        (local_dir / "file.txt").write_bytes(b"data")
+
+        original_rglob = Path.rglob
+        n = {"calls": 0}
+
+        def _flaky_rglob(self, pattern):
+            n["calls"] += 1
+            return iter([]) if n["calls"] <= 2 else original_rglob(self, pattern)
+
+        monkeypatch.setattr(Path, "rglob", _flaky_rglob)
+
+        out = await upload(str(local_dir), "raced", store=store)
+        assert out.ref.file_count == 1
+        assert out.reason == "uploaded"
+        assert captured_sleeps == [0.05, 0.1]
+
+    async def test_persistent_disagreement_raises_after_retries(
+        self, store, tmp_path, captured_sleeps, monkeypatch
+    ) -> None:
+        """rglob STAYS empty across all three backoffs → ``StorageError``.
+
+        Three retries (50/100/200 ms) fire before the raise. Caller
+        knows it's not a transient — either truly broken filesystem or
+        an external observer that keeps removing files.
+        """
+        from pathlib import Path
+
+        from application_sdk.storage.errors import StorageError
+
+        local_dir = tmp_path / "broken"
+        local_dir.mkdir()
+        (local_dir / "file.txt").write_bytes(b"data")
+
+        monkeypatch.setattr(Path, "rglob", lambda self, pattern: iter([]))
+
+        with pytest.raises(StorageError, match="persistently inconsistent"):
+            await upload(str(local_dir), "broken", store=store)
+        assert captured_sleeps == [0.05, 0.1, 0.2]
+
+    async def test_persistent_disagreement_precedes_raise_on_empty(
+        self, store, tmp_path, captured_sleeps, monkeypatch
+    ) -> None:
+        """Race raise takes precedence over BLDX-1255's empty-upload raise.
+
+        Without this ordering, a caller opting in to ``raise_on_empty=True``
+        would see ``StorageEmptyUploadError("extract produced no output")``
+        when the actual cause is the SDK's inability to list the
+        already-present file — sending them looking in the wrong place.
+        """
+        from pathlib import Path
+
+        from application_sdk.storage.errors import StorageError
+
+        local_dir = tmp_path / "raced"
+        local_dir.mkdir()
+        (local_dir / "file.txt").write_bytes(b"x")
+
+        monkeypatch.setattr(Path, "rglob", lambda self, pattern: iter([]))
+
+        with pytest.raises(StorageError, match="persistently inconsistent"):
+            await upload(str(local_dir), "raced", store=store, raise_on_empty=True)
+
+    async def test_no_false_positive_on_only_empty_subdir(
+        self, store, tmp_path, captured_sleeps
+    ) -> None:
+        """A directory whose only child is an empty subdir is genuinely empty.
+
+        The iterdir disagreement check scopes to top-level FILES
+        (matching ``rglob``'s ``is_file()`` filter). A subdir at top
+        level isn't a file → no false retry → correct genuine-empty
+        report.
+        """
+        outer = tmp_path / "outer"
+        outer.mkdir()
+        (outer / "empty_sub").mkdir()
+        out = await upload(str(outer), "outer", store=store)
+        assert out.ref.file_count == 0
+        assert out.reason == "empty"
+        assert captured_sleeps == []
+
+    async def test_iterdir_check_is_top_level_only(
+        self, store, tmp_path, captured_sleeps, monkeypatch
+    ) -> None:
+        """The cheap iterdir check is scoped to top level (documented limit).
+
+        When rglob returns empty AND the only top-level entry is a
+        subdir (even if that subdir contains a deeply-nested file), the
+        check correctly returns "no race" — matching the rglob
+        ``is_file()`` filter. Deep-tree transients are out of scope; if
+        they ever surface in the wild we'd add a recursive secondary
+        check. This test pins the current scope as intentional.
+        """
+        from pathlib import Path
+
+        outer = tmp_path / "outer"
+        outer.mkdir()
+        inner = outer / "subdir"
+        inner.mkdir()
+        (inner / "deep.txt").write_bytes(b"nested")
+
+        monkeypatch.setattr(Path, "rglob", lambda self, pattern: iter([]))
+
+        out = await upload(str(outer), "outer", store=store)
+        assert out.ref.file_count == 0
+        assert out.reason == "empty"
+        assert captured_sleeps == []
+
+
 class TestUploadStorageSubdir:
     """Tests for the storage_subdir parameter on upload."""
 

--- a/tests/unit/storage/test_transfer.py
+++ b/tests/unit/storage/test_transfer.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -182,232 +184,128 @@ class TestUploadRaiseOnEmpty:
         assert out.synced is True
 
 
-class TestUploadDirectoryListingTransient:
-    """PART-1148: absorb the rglob/iterdir listing transient inside the SDK.
+class TestUploadExplicitFiles:
+    """PART-1148: ``explicit_files`` bypasses ``rglob`` discovery deterministically.
 
-    Before the fix, the directory branch of :func:`upload` enumerated the
-    local tree with a single ``src.rglob("*")`` walk and trusted the
-    result. When that walk returned empty for a directory that DID
-    contain files (filesystem-listing transient, observed on macOS APFS
-    under concurrent activity load), the SDK silently completed with
-    ``ref.file_count=0, reason="skipped:hash_match"``. Downstream
-    consumers branching on ``ref.file_count == 0`` then dropped the
-    whole stage — invisible to telemetry.
-
-    The fix has two parts:
-
-    1. Internal retry-with-backoff (50/100/200 ms) when ``rglob`` and
-       ``iterdir`` disagree on whether the directory has top-level
-       files. Caller code never sees the transient; the library
-       absorbs it. Standard pattern across cloud SDKs for transient
-       I/O.
-    2. Observability: emit ``reason="empty"`` (not the misleading
-       ``"skipped:hash_match"``) for genuinely empty input.
-
-    Tests below pin every branch of the new behaviour:
-    happy-path / quiet-day-empty / one-retry recovery / two-retry
-    recovery / persistent disagreement raises / race-takes-precedence
-    over raise_on_empty / no false positive on subdir-only / explicit
-    top-level-only scope.
+    The directory branch of :func:`upload` accepts an optional pre-enumerated
+    file list. When supplied, ``rglob`` is not called — closes the
+    filesystem-listing-transient race for callers that already know the
+    exact written file set (canonical producer is
+    ``pyarrow.dataset.write_dataset(file_visitor=...)``). When ``None``,
+    discovery falls back to ``rglob``, byte-identical to pre-PART-1148.
     """
 
-    @pytest.fixture
-    def captured_sleeps(self, monkeypatch):
-        """Mock ``asyncio.sleep`` inside transfer.py — capture durations, skip waits."""
-        sleeps: list[float] = []
+    async def test_explicit_files_bypasses_rglob(self, store, tmp_path) -> None:
+        """rglob is never called when explicit_files is supplied."""
+        (tmp_path / "a.txt").write_bytes(b"alpha")
+        (tmp_path / "b.txt").write_bytes(b"beta")
+        rglob_calls = 0
 
-        async def _fake_sleep(seconds):
-            sleeps.append(seconds)
+        def patched_rglob(self, pattern):  # noqa: ARG001
+            nonlocal rglob_calls
+            rglob_calls += 1
+            return iter([])
 
-        monkeypatch.setattr(
-            "application_sdk.storage.transfer.asyncio.sleep", _fake_sleep
+        with patch.object(Path, "rglob", patched_rglob):
+            out = await upload(
+                str(tmp_path),
+                "myprefix",
+                store=store,
+                explicit_files=[
+                    str(tmp_path / "a.txt"),
+                    str(tmp_path / "b.txt"),
+                ],
+            )
+
+        assert rglob_calls == 0
+        assert out.ref.file_count == 2
+        assert out.synced is True
+        assert out.reason == "uploaded"
+
+    async def test_explicit_files_single_file(self, store, tmp_path) -> None:
+        """Single-file list works — same path as the rglob branch."""
+        (tmp_path / "x.parquet").write_bytes(b"data")
+
+        out = await upload(
+            str(tmp_path),
+            "p",
+            store=store,
+            explicit_files=[str(tmp_path / "x.parquet")],
         )
-        return sleeps
 
-    async def test_genuinely_empty_dir_default_returns_empty_reason(
-        self, store, tmp_path, captured_sleeps
-    ) -> None:
-        """Empty input + default ``raise_on_empty=False`` → silent quiet-day path.
+        assert out.ref.file_count == 1
+        assert out.synced is True
 
-        Pins both BLDX-1255 contract (silent ``file_count=0``) AND the
-        observability correction (no more misleading ``skipped:hash_match``
-        reason on empty input).
-        """
-        empty = tmp_path / "empty"
-        empty.mkdir()
-        out = await upload(str(empty), "myprefix", store=store)
+    async def test_explicit_empty_list_is_empty_directory(self, store, tmp_path) -> None:
+        """``explicit_files=[]`` produces the same result as a genuinely empty
+        directory — preserves backwards-compat ``skipped:hash_match`` reason."""
+        (tmp_path / "ignored.txt").write_bytes(b"would-be-uploaded")
+
+        out = await upload(
+            str(tmp_path), "p", store=store, explicit_files=[]
+        )
+
         assert out.ref.file_count == 0
         assert out.synced is False
-        assert out.reason == "empty", (
-            f"reason={out.reason!r}: empty input must report a distinct "
-            f"reason. 'skipped:hash_match' falsely implies hash-match "
-            f"skipping happened."
-        )
-        assert captured_sleeps == []
 
-    async def test_genuinely_empty_dir_with_raise_on_empty_still_raises(
-        self, store, tmp_path, captured_sleeps
+    async def test_explicit_empty_list_raises_when_raise_on_empty_true(
+        self, store, tmp_path
     ) -> None:
-        """Existing BLDX-1255 opt-in path preserved unchanged."""
+        """``raise_on_empty`` applies to ``explicit_files=[]`` the same way it
+        applies to a discovered-empty directory."""
         from application_sdk.storage.errors import StorageEmptyUploadError
 
-        empty = tmp_path / "empty"
-        empty.mkdir()
-        with pytest.raises(StorageEmptyUploadError, match="contains zero files"):
-            await upload(str(empty), "myprefix", store=store, raise_on_empty=True)
-        assert captured_sleeps == []
+        with pytest.raises(StorageEmptyUploadError):
+            await upload(
+                str(tmp_path),
+                "p",
+                store=store,
+                explicit_files=[],
+                raise_on_empty=True,
+            )
 
-    async def test_happy_path_no_sleeps(self, store, tmp_path, captured_sleeps) -> None:
-        """When rglob succeeds first try, retries never fire — zero latency cost."""
-        (tmp_path / "data.txt").write_bytes(b"hello")
-        out = await upload(str(tmp_path), "myprefix", store=store)
-        assert out.ref.file_count == 1
+    async def test_explicit_files_with_listing_transient_still_succeeds(
+        self, store, tmp_path
+    ) -> None:
+        """Even when rglob would return empty (the PART-1148 listing-transient
+        condition), an opt-in caller using explicit_files succeeds
+        deterministically. This is the canonical bug-closure scenario."""
+        (tmp_path / "chunk_0.parquet").write_bytes(b"data" * 100)
+        (tmp_path / "chunk_1.parquet").write_bytes(b"data" * 100)
+
+        # Inject the APFS-style transient: rglob returns empty even though
+        # the directory has two files.
+        with patch.object(Path, "rglob", lambda self, pat: iter([])):
+            out = await upload(
+                str(tmp_path),
+                "transient-resistant",
+                store=store,
+                explicit_files=[
+                    str(tmp_path / "chunk_0.parquet"),
+                    str(tmp_path / "chunk_1.parquet"),
+                ],
+            )
+
+        # Without explicit_files this would have been file_count=0,
+        # reason="skipped:hash_match" (the bug). With it: deterministic.
+        assert out.ref.file_count == 2
         assert out.reason == "uploaded"
-        assert captured_sleeps == []
+        assert out.synced is True
 
-    async def test_transient_recovers_on_first_retry(
-        self, store, tmp_path, captured_sleeps, monkeypatch
+    async def test_rglob_fallback_unchanged_when_explicit_files_none(
+        self, store, tmp_path
     ) -> None:
-        """One empty rglob → 50ms backoff → next call returns the file → uploads normally.
+        """Non-opt-in callers (no explicit_files) hit the rglob path —
+        byte-identical to pre-PART-1148 behavior. Guards against accidental
+        coupling between the two paths."""
+        (tmp_path / "a.txt").write_bytes(b"x")
+        (tmp_path / "b.txt").write_bytes(b"y")
 
-        Models the macOS APFS readdir-after-write window. Caller observes
-        a normal ``reason="uploaded"`` result — no surfacing of the
-        transient.
-        """
-        from pathlib import Path
+        out = await upload(str(tmp_path), "p", store=store)
 
-        local_dir = tmp_path / "raced"
-        local_dir.mkdir()
-        (local_dir / "file.txt").write_bytes(b"data")
-
-        original_rglob = Path.rglob
-        n = {"calls": 0}
-
-        def _flaky_rglob(self, pattern):
-            n["calls"] += 1
-            return iter([]) if n["calls"] == 1 else original_rglob(self, pattern)
-
-        monkeypatch.setattr(Path, "rglob", _flaky_rglob)
-
-        out = await upload(str(local_dir), "raced", store=store)
-        assert out.ref.file_count == 1
+        assert out.ref.file_count == 2
+        assert out.synced is True
         assert out.reason == "uploaded"
-        assert captured_sleeps == [0.05]
-
-    async def test_transient_recovers_on_second_retry(
-        self, store, tmp_path, captured_sleeps, monkeypatch
-    ) -> None:
-        """Two empty rglobs (50, 100ms backoffs) → third call recovers → succeeds."""
-        from pathlib import Path
-
-        local_dir = tmp_path / "raced"
-        local_dir.mkdir()
-        (local_dir / "file.txt").write_bytes(b"data")
-
-        original_rglob = Path.rglob
-        n = {"calls": 0}
-
-        def _flaky_rglob(self, pattern):
-            n["calls"] += 1
-            return iter([]) if n["calls"] <= 2 else original_rglob(self, pattern)
-
-        monkeypatch.setattr(Path, "rglob", _flaky_rglob)
-
-        out = await upload(str(local_dir), "raced", store=store)
-        assert out.ref.file_count == 1
-        assert out.reason == "uploaded"
-        assert captured_sleeps == [0.05, 0.1]
-
-    async def test_persistent_disagreement_raises_after_retries(
-        self, store, tmp_path, captured_sleeps, monkeypatch
-    ) -> None:
-        """rglob STAYS empty across all three backoffs → ``StorageError``.
-
-        Three retries (50/100/200 ms) fire before the raise. Caller
-        knows it's not a transient — either truly broken filesystem or
-        an external observer that keeps removing files.
-        """
-        from pathlib import Path
-
-        from application_sdk.storage.errors import StorageError
-
-        local_dir = tmp_path / "broken"
-        local_dir.mkdir()
-        (local_dir / "file.txt").write_bytes(b"data")
-
-        monkeypatch.setattr(Path, "rglob", lambda self, pattern: iter([]))
-
-        with pytest.raises(StorageError, match="persistently inconsistent"):
-            await upload(str(local_dir), "broken", store=store)
-        assert captured_sleeps == [0.05, 0.1, 0.2]
-
-    async def test_persistent_disagreement_precedes_raise_on_empty(
-        self, store, tmp_path, captured_sleeps, monkeypatch
-    ) -> None:
-        """Race raise takes precedence over BLDX-1255's empty-upload raise.
-
-        Without this ordering, a caller opting in to ``raise_on_empty=True``
-        would see ``StorageEmptyUploadError("extract produced no output")``
-        when the actual cause is the SDK's inability to list the
-        already-present file — sending them looking in the wrong place.
-        """
-        from pathlib import Path
-
-        from application_sdk.storage.errors import StorageError
-
-        local_dir = tmp_path / "raced"
-        local_dir.mkdir()
-        (local_dir / "file.txt").write_bytes(b"x")
-
-        monkeypatch.setattr(Path, "rglob", lambda self, pattern: iter([]))
-
-        with pytest.raises(StorageError, match="persistently inconsistent"):
-            await upload(str(local_dir), "raced", store=store, raise_on_empty=True)
-
-    async def test_no_false_positive_on_only_empty_subdir(
-        self, store, tmp_path, captured_sleeps
-    ) -> None:
-        """A directory whose only child is an empty subdir is genuinely empty.
-
-        The iterdir disagreement check scopes to top-level FILES
-        (matching ``rglob``'s ``is_file()`` filter). A subdir at top
-        level isn't a file → no false retry → correct genuine-empty
-        report.
-        """
-        outer = tmp_path / "outer"
-        outer.mkdir()
-        (outer / "empty_sub").mkdir()
-        out = await upload(str(outer), "outer", store=store)
-        assert out.ref.file_count == 0
-        assert out.reason == "empty"
-        assert captured_sleeps == []
-
-    async def test_iterdir_check_is_top_level_only(
-        self, store, tmp_path, captured_sleeps, monkeypatch
-    ) -> None:
-        """The cheap iterdir check is scoped to top level (documented limit).
-
-        When rglob returns empty AND the only top-level entry is a
-        subdir (even if that subdir contains a deeply-nested file), the
-        check correctly returns "no race" — matching the rglob
-        ``is_file()`` filter. Deep-tree transients are out of scope; if
-        they ever surface in the wild we'd add a recursive secondary
-        check. This test pins the current scope as intentional.
-        """
-        from pathlib import Path
-
-        outer = tmp_path / "outer"
-        outer.mkdir()
-        inner = outer / "subdir"
-        inner.mkdir()
-        (inner / "deep.txt").write_bytes(b"nested")
-
-        monkeypatch.setattr(Path, "rglob", lambda self, pattern: iter([]))
-
-        out = await upload(str(outer), "outer", store=store)
-        assert out.ref.file_count == 0
-        assert out.reason == "empty"
-        assert captured_sleeps == []
 
 
 class TestUploadStorageSubdir:

--- a/tests/unit/storage/test_transfer.py
+++ b/tests/unit/storage/test_transfer.py
@@ -236,14 +236,14 @@ class TestUploadExplicitFiles:
         assert out.ref.file_count == 1
         assert out.synced is True
 
-    async def test_explicit_empty_list_is_empty_directory(self, store, tmp_path) -> None:
+    async def test_explicit_empty_list_is_empty_directory(
+        self, store, tmp_path
+    ) -> None:
         """``explicit_files=[]`` produces the same result as a genuinely empty
         directory — preserves backwards-compat ``skipped:hash_match`` reason."""
         (tmp_path / "ignored.txt").write_bytes(b"would-be-uploaded")
 
-        out = await upload(
-            str(tmp_path), "p", store=store, explicit_files=[]
-        )
+        out = await upload(str(tmp_path), "p", store=store, explicit_files=[])
 
         assert out.ref.file_count == 0
         assert out.synced is False


### PR DESCRIPTION
## What

Adds an opt-in deterministic file-list path to `UploadInput` + `transfer.upload()` that lets callers bypass `rglob` discovery entirely. Closes the filesystem-listing-transient race ([PART-1148](https://linear.app/atlan-epd/issue/PART-1148)) for callers that already have the authoritative file list from `pyarrow.dataset.write_dataset(file_visitor=...)`.

The original retry-with-backoff approach on this branch was reverted per [@cmgrote's review](https://github.com/atlanhq/application-sdk/pull/2048#issuecomment-2964820107): retries reduce failure probability but don't close the race. The deterministic primitive does.

## Fix

| Layer | Change |
|---|---|
| Contract | `UploadInput.explicit_files: Annotated[list[str], MaxItems(10000)] \| None = None` |
| Function | `transfer.upload(..., explicit_files=list[str] \| list[Path] \| None = None, ...)` |
| Wrapper | `App.upload()` threads `input.explicit_files` through to `_upload(...)`. |

When supplied, the directory branch skips `src.rglob("*")` and uses the list directly. When `None`, behavior is **byte-identical to `main`** — no retry, no new error surface, no reason rename. Non-opt-in callers see zero change.

Total prod-code diff: +93 / -78 (`application_sdk/{app/base.py, contracts/storage.py, storage/transfer.py}`).

## Canonical usage pattern (callers)

```python
import pyarrow.dataset as pa_ds
from application_sdk.contracts.storage import UploadInput

written: list[str] = []
pa_ds.write_dataset(
    table,
    base_dir=out_dir,
    format="parquet",
    basename_template="chunk_{i}.parquet",
    file_visitor=lambda f: written.append(f.path),
)

# write_dataset captured every written file synchronously via file_visitor.
# Passing the list to upload skips rglob entirely — no race surface.
await self.upload(UploadInput(
    local_path=str(out_dir),
    explicit_files=written,
))
```

## Empty-dataset note for callers

`pa_ds.write_dataset` with zero rows writes zero files **and fires zero `file_visitor` callbacks**. Callers passing `explicit_files=[]` get the same behavior as a genuinely empty directory (`file_count=0`, `reason="skipped:hash_match"`, or `StorageEmptyUploadError` if `raise_on_empty=True`). No special-case to wire.

## Tests

**Unit tests** — `tests/unit/storage/test_transfer.py::TestUploadExplicitFiles` (6 tests):

* `test_explicit_files_bypasses_rglob` — patches `Path.rglob` to count calls; verifies it's never invoked when `explicit_files` is supplied
* `test_explicit_files_single_file` — single-file list works through the same path
* `test_explicit_empty_list_is_empty_directory` — `explicit_files=[]` reproduces empty-directory semantics
* `test_explicit_empty_list_raises_when_raise_on_empty_true` — `raise_on_empty` applies to caller-supplied empty list too
* `test_explicit_files_with_listing_transient_still_succeeds` — the canonical PART-1148 bug closure: `rglob` mocked to return empty, but caller passes the real list and upload succeeds deterministically
* `test_rglob_fallback_unchanged_when_explicit_files_none` — guards against accidental coupling between the two paths

All 40 unit tests in `test_transfer.py` pass. Broader sweep (`tests/unit/storage` + `tests/unit/contracts`): **767 passed, 3 skipped, 0 failures**.

**Integration test** — `tests/integration/test_storage_io.py::test_explicit_files_end_to_end_with_pyarrow_file_visitor`:

Exercises the full canonical flow against a real `LocalStore`:
1. `pa_ds.write_dataset(file_visitor=...)` writes 3 parquet chunks AND captures the file list synchronously
2. `upload(explicit_files=...)` uploads via the deterministic path
3. `download_prefix(...)` round-trips the bytes
4. Each downloaded parquet is re-read and verified against the original schema

All 17 integration tests in `test_storage_io.py` pass.

## Reproduce the bug closure scenario

```python
from unittest.mock import patch
from pathlib import Path
from application_sdk.storage.factory import create_memory_store
from application_sdk.storage.transfer import upload

store = create_memory_store()
import tempfile
with tempfile.TemporaryDirectory() as d:
    (Path(d) / "chunk_0.parquet").write_bytes(b"x" * 400)
    (Path(d) / "chunk_1.parquet").write_bytes(b"y" * 400)

    # On main / on this PR without explicit_files: silent file_count=0
    with patch.object(Path, "rglob", lambda self, pat: iter([])):
        out_buggy = await upload(d, "buggy", store=store)
        # out_buggy.ref.file_count == 0  ← the bug
        # out_buggy.reason == "skipped:hash_match"  ← misleading

    # With explicit_files: deterministic, no rglob involvement
    with patch.object(Path, "rglob", lambda self, pat: iter([])):
        out_fixed = await upload(
            d, "fixed", store=store,
            explicit_files=[str(Path(d) / "chunk_0.parquet"), str(Path(d) / "chunk_1.parquet")],
        )
        assert out_fixed.ref.file_count == 2  ← bug closed
        assert out_fixed.reason == "uploaded"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
