### PR TITLE
fix(security): supply-chain hardening — action pins, build secrets, integrity checks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,8 +22,17 @@ htmlcov/
 .venv/
 venv/
 env/
-.env
-.env.local
+
+# Credentials — Dockerfiles must never COPY env files or key material.
+# These patterns keep credential-shaped files out of the build context
+# entirely so a stray `COPY . .` cannot bake them into a layer.
+.env*
+*.pem
+*.key
+credentials*
+secrets*
+.aws/
+.gcp/
 
 # IDE files
 .vscode/

--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -40,7 +40,7 @@ description: |
 
   ```yaml
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - uses: ./.github/actions/mssql-native-deps   # connector-local action
     - uses: atlanhq/application-sdk/.github/actions/connector-integration-tests@v3.14.0
       with:
@@ -227,7 +227,7 @@ runs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: integration-test-results
         path: results/

--- a/.github/actions/connector-unit-tests/action.yaml
+++ b/.github/actions/connector-unit-tests/action.yaml
@@ -80,7 +80,7 @@ runs:
 
     - name: Upload coverage artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: unit-test-coverage
         path: |

--- a/.github/actions/doclint/action.yaml
+++ b/.github/actions/doclint/action.yaml
@@ -22,12 +22,12 @@ runs:
   using: "composite"
   steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 2
 
     - name: Run Vale Linter
-      uses: errata-ai/vale-action@v2.1.1
+      uses: errata-ai/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
       with:
         files: ${{ inputs.files }}
         filter_mode: ${{ inputs.filter_mode }}

--- a/.github/actions/docstring-coverage/action.yaml
+++ b/.github/actions/docstring-coverage/action.yaml
@@ -18,13 +18,13 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
 
     - name: Set up Python 3.11
       id: setup-python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: "3.11"
 
@@ -64,7 +64,7 @@ runs:
         echo "</details>" >> docstring-cov.md
 
     - name: Comment Docstring Coverage on PR
-      uses: mshick/add-pr-comment@v2
+      uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2
       with:
         message-id: "docstring-coverage"
         message-path: docstring-cov.md

--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -43,7 +43,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.ref }}
 
@@ -63,7 +63,7 @@ runs:
         fi
 
     - name: Trigger E2E Integrations Tests
-      uses: codex-/return-dispatch@v3
+      uses: codex-/return-dispatch@16fa9d14771c4d56ae0196bbda1d3c17f7f3650f # v3
       id: return_dispatch
       with:
         token: "${{ inputs.github-token }}"
@@ -197,7 +197,7 @@ runs:
     # exists so re-pushes don't spam the PR thread.
     - name: Post dispatched-run status to SDK PR
       if: always() && github.event_name == 'pull_request'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       env:
         REPO_NAME: ${{ inputs.repo-name }}
         WORKFLOW: ${{ inputs.workflow }}

--- a/.github/actions/e2e-examples/action.yaml
+++ b/.github/actions/e2e-examples/action.yaml
@@ -84,12 +84,12 @@ runs:
         version: "v1.3.0"
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: "3.11"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       with:
         version: "0.7.3"
 
@@ -173,7 +173,7 @@ runs:
 
     - name: Comment test results on Pull Request
       if: ${{ !cancelled() && github.event_name == 'pull_request' }}
-      uses: mshick/add-pr-comment@v2
+      uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2
       with:
         message-id: "workflow_status_${{ inputs.operating-system }}"
         message-path: "examples/workflow_status.md"

--- a/.github/actions/globalprotect-connect/action.yml
+++ b/.github/actions/globalprotect-connect/action.yml
@@ -26,7 +26,7 @@ runs:
   using: "composite"
   steps:
     - name: Connect via OpenConnect
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       id: openconnect-connection
       with:
         max_attempts: ${{ fromJSON(inputs.max-attempts) }}

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -873,7 +873,7 @@ runs:
     # mutating an old one, which makes "what's the latest run" obvious.
     - name: Render PR comment + post (when on a PR)
       if: always()
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       env:
         APP_NAME: ${{ inputs.app-name }}
         OUTCOME: ${{ steps.tests.outcome }}
@@ -1033,7 +1033,7 @@ runs:
     # the same rendered report.
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: sdr-integration-tests-${{ inputs.app-name }}-results
         path: results/

--- a/.github/actions/secure-build-push-apps/action.yaml
+++ b/.github/actions/secure-build-push-apps/action.yaml
@@ -96,6 +96,9 @@ inputs:
   secret-envs:
     description: 'List of secret environment variables to expose to the build (e.g., MY_SECRET=MY_SECRET_VAR).'
     required: false
+  secret-files:
+    description: 'List of secret files to expose to the build (e.g., MY_SECRET=./secret.txt).'
+    required: false
   shm-size:
     description: 'Size of /dev/shm (e.g., 2g).'
     required: false

--- a/.github/actions/secure-build-push-apps/action.yaml
+++ b/.github/actions/secure-build-push-apps/action.yaml
@@ -161,11 +161,11 @@ runs:
         echo "SEVERITY_THRESHOLD=$SEVERITY_THRESHOLD" >> $GITHUB_OUTPUT
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Build single-platform image for scanning
       id: build_for_scan
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         # Pass all inputs from the caller to the build action
         add-hosts: ${{ inputs.add-hosts }}
@@ -214,7 +214,7 @@ runs:
 
     - name: Run Trivy Scan
       id: trivy_scan
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       with:
         image-ref: ${{ steps.extract_tag.outputs.primary_tag }}
         format: 'json'
@@ -291,7 +291,7 @@ runs:
     - name: Build and Push multi-platform image
       id: docker_push
       if: ${{ steps.decision.outputs.result == 'true' }}
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         # Pass all relevant inputs again for the final push
         add-hosts: ${{ inputs.add-hosts }}

--- a/.github/actions/setup-deps/action.yaml
+++ b/.github/actions/setup-deps/action.yaml
@@ -18,18 +18,18 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
 
     - name: Set up Python
       id: setup-python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       with:
         version: "0.7.3"
 

--- a/.github/actions/sync-branches/action.yaml
+++ b/.github/actions/sync-branches/action.yaml
@@ -19,7 +19,7 @@ runs:
   using: 'composite'
   steps:
     - name: "Auto-merge ${{ inputs.source-branch }} -> ${{ inputs.target-branch }}"
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         github-token: ${{ inputs.github-token }}
         script: |

--- a/.github/actions/trivy-container/action.yaml
+++ b/.github/actions/trivy-container/action.yaml
@@ -32,17 +32,17 @@ runs:
   using: "composite"
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Log in to Chainguard Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: cgr.dev
         username: ${{ inputs.chainguard-username }}
         password: ${{ inputs.chainguard-password }}
 
     - name: Build Docker image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: .
         file: ./Dockerfile
@@ -56,7 +56,7 @@ runs:
 
     - name: Run Trivy scan (JSON)
       id: scan
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       with:
         image-ref: 'trivy-scan-target:latest'
         format: 'json'
@@ -72,7 +72,7 @@ runs:
       run: echo "results-file=trivy-container-results.json" >> $GITHUB_OUTPUT
 
     - name: Run Trivy scan (SARIF)
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       with:
         image-ref: 'trivy-scan-target:latest'
         format: 'sarif'
@@ -85,7 +85,7 @@ runs:
         TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
 
     - name: Upload scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
       if: always()
       continue-on-error: true
       with:
@@ -94,7 +94,7 @@ runs:
 
     - name: Fail on HIGH/CRITICAL vulnerabilities (with fix available)
       if: inputs.fail-on-vulns == 'true'
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       with:
         image-ref: 'trivy-scan-target:latest'
         format: 'table'

--- a/.github/actions/trivy/action.yaml
+++ b/.github/actions/trivy/action.yaml
@@ -14,11 +14,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
 
     - name: Trivy Vulnerability Scan (SARIF)
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       with:
         scan-type: 'fs'
         format: 'sarif'
@@ -31,7 +31,7 @@ runs:
         TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
 
     - name: Trivy Vulnerability Scan (JSON)
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       with:
         scan-type: 'fs'
         format: 'json'
@@ -44,7 +44,7 @@ runs:
         TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
 
     - name: Trivy Secret Scan (SARIF)
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       with:
         scan-type: 'fs'
         format: 'sarif'
@@ -57,7 +57,7 @@ runs:
         TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
 
     - name: Trivy Secret Scan (JSON)
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       with:
         scan-type: 'fs'
         format: 'json'
@@ -70,20 +70,20 @@ runs:
         TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
 
     - name: Upload Vulnerability Scan Results
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
       with:
         sarif_file: 'trivy-vuln-results.sarif'
         category: 'trivy-vulnerability'
 
     - name: Upload Secret Scan Results
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
       with:
         sarif_file: 'trivy-secret-results.sarif'
         category: 'trivy-secret'
 
     - name: Set up Python
       if: inputs.add-report-comment-to-pr == 'true'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.11'
 
@@ -107,21 +107,21 @@ runs:
 
     - name: Comment on PR with Vulnerability Scan Results
       if: inputs.add-report-comment-to-pr == 'true'
-      uses: mshick/add-pr-comment@v2
+      uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2
       with:
         message-id: trivy-vuln
         message-path: trivy-vuln-results.md
 
     - name: Comment on PR with Secret Scan Results
       if: inputs.add-report-comment-to-pr == 'true'
-      uses: mshick/add-pr-comment@v2
+      uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2
       with:
         message-id: trivy-secret
         message-path: trivy-secret-results.md
 
     - name: Fail on High/Critical Vulnerabilities (with fix available)
       if: inputs.add-report-comment-to-pr == 'true'
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       with:
         scan-type: 'fs'
         format: 'table'
@@ -135,7 +135,7 @@ runs:
 
     - name: Fail on Any Secrets Found
       if: inputs.add-report-comment-to-pr == 'true'
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       with:
         scan-type: 'fs'
         format: 'table'

--- a/.github/actions/unit-tests/action.yaml
+++ b/.github/actions/unit-tests/action.yaml
@@ -28,7 +28,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - uses: "./.github/actions/setup-deps"
       with:
@@ -59,14 +59,14 @@ runs:
         $UV_RUN coverage report --fail-under=${{ inputs.fail-under }}
 
     - name: Comment Coverage Report on PR
-      uses: orgoro/coverage@v3.2
+      uses: orgoro/coverage@3f13a558c5af7376496aa4848bf0224aead366ac # v3.2
       continue-on-error: true
       with:
         coverageFile: coverage.xml
         token: ${{ inputs.github-token }}
 
     - name: Setup AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
       continue-on-error: true
       id: aws-creds
       with:
@@ -81,7 +81,7 @@ runs:
         aws s3 sync ./htmlcov s3://kryptonite-store/coverage/application-sdk/pr/${{ github.event.number }} --delete
 
     - name: Comment Coverage Report URL on PR
-      uses: mshick/add-pr-comment@v2
+      uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2
       if: ${{ github.event_name == 'pull_request' }}
       with:
         message-id: "coverage"

--- a/.github/workflow-templates/checks.yaml
+++ b/.github/workflow-templates/checks.yaml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.11'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       with:
         version: "0.7.3"
 
@@ -27,4 +27,4 @@ jobs:
       shell: bash
       run: uv sync --all-extras --all-groups
 
-    - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflow-templates/codeql.yaml
+++ b/.github/workflow-templates/codeql.yaml
@@ -23,18 +23,18 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflow-templates/dependency-review.yml
+++ b/.github/workflow-templates/dependency-review.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
         with:
           comment-summary-in-pr: always

--- a/.github/workflow-templates/stale.yml
+++ b/.github/workflow-templates/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
       with:
         repo-token: ${{ secrets.ORG_PAT_GITHUB }}
         stale-issue-message: 'Stale issue'

--- a/.github/workflow-templates/trivy-container.yaml
+++ b/.github/workflow-templates/trivy-container.yaml
@@ -41,10 +41,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build and push docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./Dockerfile
@@ -54,7 +54,7 @@ jobs:
           tags: "docker-trivy-tag"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: 'docker-trivy-tag:latest'
           format: 'table'
@@ -65,7 +65,7 @@ jobs:
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
 
       - name: Generate trivy results for GitHub Security tab
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: 'docker-trivy-tag:latest'
           format: 'sarif'
@@ -77,6 +77,6 @@ jobs:
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflow-templates/trivy.yaml
+++ b/.github/workflow-templates/trivy.yaml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: 'fs'
           format: 'sarif'
@@ -45,6 +45,6 @@ jobs:
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/allowlist-approval.yaml
+++ b/.github/workflows/allowlist-approval.yaml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Check if PR modifies .security/
         id: check-files
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const prNumber = context.payload.pull_request?.number || context.issue?.number;
@@ -60,13 +60,13 @@ jobs:
 
       - name: Checkout base branch (to read current approvers, not PR's version)
         if: steps.check-files.outputs.touches_security == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Verify authorized approver
         if: steps.check-files.outputs.touches_security == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/auto-fix-vulnerabilities.yaml
+++ b/.github/workflows/auto-fix-vulnerabilities.yaml
@@ -1,12 +1,21 @@
 # Auto-fix Vulnerabilities — reusable workflow triggered by PR comment.
 #
 # When a developer comments "/fix-vulnerabilities" on a PR, this workflow:
+#   0. Verifies the commenter is an org member/collaborator (authorize job —
+#      this workflow pushes commits with ORG_PAT_GITHUB, so it must never be
+#      triggerable by an arbitrary commenter)
 #   1. Downloads the latest scan results from the Vulnerability Scan workflow
 #   2. Identifies fixable Python app dependencies (skips base image CVEs)
 #   3. Pins minimum version in pyproject.toml (prevents regression on future uv lock)
 #   4. Runs `uv lock --upgrade-package` for each
 #   5. Commits updated pyproject.toml + uv.lock to the PR branch
 #   5. Scan re-runs automatically on the new commit
+#
+# Authorization: a reusable workflow runs with the caller's event payload, so
+# `github.event.comment.author_association` is available here when triggered
+# from an `issue_comment` event. The authorize job fails closed — including
+# when no comment payload is present (e.g. someone wires this up to a
+# different trigger) — unless the author is OWNER / MEMBER / COLLABORATOR.
 #
 # Usage in each app repo (.github/workflows/auto-fix.yml):
 #
@@ -33,8 +42,37 @@ permissions:
   actions: read
 
 jobs:
+  # Gate: only org members/collaborators may trigger a workflow that pushes
+  # commits to the PR branch with ORG_PAT_GITHUB. Fails closed when the
+  # comment payload is absent (non-issue_comment trigger).
+  authorize:
+    name: Authorize Commenter
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Verify comment author association
+        env:
+          AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
+          AUTHOR_LOGIN: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+          case "${AUTHOR_ASSOCIATION}" in
+            OWNER|MEMBER|COLLABORATOR)
+              echo "Comment author '${AUTHOR_LOGIN}' (${AUTHOR_ASSOCIATION}) is authorized."
+              ;;
+            "")
+              echo "::error::No comment payload available — this workflow must be triggered from an issue_comment event so the commenter can be validated. Refusing to run."
+              exit 1
+              ;;
+            *)
+              echo "::error::Comment author '${AUTHOR_LOGIN}' has association '${AUTHOR_ASSOCIATION}' — only OWNER, MEMBER, or COLLABORATOR may trigger /fix-vulnerabilities."
+              exit 1
+              ;;
+          esac
+
   auto-fix:
     name: Auto-fix Vulnerabilities
+    needs: authorize
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/auto-fix-vulnerabilities.yaml
+++ b/.github/workflows/auto-fix-vulnerabilities.yaml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Get PR branch
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -52,7 +52,7 @@ jobs:
             core.setOutput('number', context.issue.number);
 
       - name: React to comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -63,7 +63,7 @@ jobs:
             });
 
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ steps.pr.outputs.branch }}
           token: ${{ secrets.ORG_PAT_GITHUB }}
@@ -161,7 +161,7 @@ jobs:
 
       - name: Install uv
         if: steps.identify.outputs.count > 0
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
       - name: Fix vulnerable packages
         if: steps.identify.outputs.count > 0
@@ -303,7 +303,7 @@ jobs:
 
       - name: Comment on PR
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -26,6 +26,18 @@
 #         tenants: ${{ inputs.tenants || '' }}
 #       secrets: inherit
 #
+# Private-dependency credentials are exposed as BuildKit secrets (NOT
+# build-args), so the PAT never lands in build logs, image history, or
+# cache metadata. Dockerfiles that need them must mount them per-RUN:
+#
+#   RUN --mount=type=secret,id=ACCESS_TOKEN_USR \
+#       --mount=type=secret,id=ACCESS_TOKEN_PWD \
+#       git config --global url."https://$(cat /run/secrets/ACCESS_TOKEN_USR):$(cat /run/secrets/ACCESS_TOKEN_PWD)@github.com/".insteadOf "https://github.com/" && \
+#       uv sync --locked && \
+#       rm -f "$HOME/.gitconfig"
+#
+# (ARG ACCESS_TOKEN_USR / ACCESS_TOKEN_PWD build-args are no longer passed.)
+#
 name: Build & Publish Atlan App
 
 on:
@@ -1079,9 +1091,12 @@ jobs:
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-          build-args: |
-            ACCESS_TOKEN_USR=${{ github.actor }}
-            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
+          # BuildKit secret mounts — never build-args, which leak into build
+          # logs and image/cache metadata. See the header comment for the
+          # Dockerfile-side RUN --mount=type=secret pattern.
+          secrets: |
+            "ACCESS_TOKEN_USR=${{ github.actor }}"
+            "ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}"
 
   # ── Job 3: Merge arch digests into a single multi-arch manifest ───────────────
   merge:

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -14,6 +14,18 @@
 #       uses: atlanhq/application-sdk/.github/workflows/build-and-scan.yaml@main
 #       secrets: inherit
 #
+# Private-dependency credentials are exposed as BuildKit secrets (NOT
+# build-args), so the PAT never lands in build logs, image history, or
+# cache metadata. Dockerfiles that need them must mount them per-RUN:
+#
+#   RUN --mount=type=secret,id=ACCESS_TOKEN_USR \
+#       --mount=type=secret,id=ACCESS_TOKEN_PWD \
+#       git config --global url."https://$(cat /run/secrets/ACCESS_TOKEN_USR):$(cat /run/secrets/ACCESS_TOKEN_PWD)@github.com/".insteadOf "https://github.com/" && \
+#       uv sync --locked && \
+#       rm -f "$HOME/.gitconfig"
+#
+# (ARG ACCESS_TOKEN_USR / ACCESS_TOKEN_PWD build-args are no longer passed.)
+#
 name: Build & Scan
 
 on:
@@ -92,9 +104,12 @@ jobs:
           cache-from: type=gha,scope=scan
           cache-to: type=gha,mode=max,scope=scan
           provenance: false
-          build-args: |
-            ACCESS_TOKEN_USR=${{ github.actor }}
-            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
+          # BuildKit secret mounts — never build-args, which leak into build
+          # logs and image/cache metadata. See the header comment for the
+          # Dockerfile-side RUN --mount=type=secret pattern.
+          secrets: |
+            "ACCESS_TOKEN_USR=${{ github.actor }}"
+            "ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}"
 
       - name: Upload image artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/build-apps-image.yaml
+++ b/.github/workflows/build-apps-image.yaml
@@ -19,6 +19,18 @@
 #       secrets: inherit   # template only reads: ORG_PAT_GITHUB, DOCKER_HUB_PAT_RW
 #                          # permissions are declared in this workflow — callers don't need to repeat them
 #
+# Private-dependency credentials are exposed as BuildKit secrets (NOT
+# build-args), so the PAT never lands in build logs, image history, or
+# cache metadata. Dockerfiles that need them must mount them per-RUN:
+#
+#   RUN --mount=type=secret,id=ACCESS_TOKEN_USR \
+#       --mount=type=secret,id=ACCESS_TOKEN_PWD \
+#       git config --global url."https://$(cat /run/secrets/ACCESS_TOKEN_USR):$(cat /run/secrets/ACCESS_TOKEN_PWD)@github.com/".insteadOf "https://github.com/" && \
+#       uv sync --locked && \
+#       rm -f "$HOME/.gitconfig"
+#
+# (ARG ACCESS_TOKEN_USR / ACCESS_TOKEN_PWD build-args are no longer passed.)
+#
 name: Build Atlan App Image
 
 on:
@@ -207,9 +219,12 @@ jobs:
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-          build-args: |
-            ACCESS_TOKEN_USR=${{ github.actor }}
-            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
+          # BuildKit secret mounts — never build-args, which leak into build
+          # logs and image/cache metadata. See the header comment for the
+          # Dockerfile-side RUN --mount=type=secret pattern.
+          secrets: |
+            "ACCESS_TOKEN_USR=${{ github.actor }}"
+            "ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}"
 
   # ── Job 3: Merge arch digests into a single multi-arch manifest ───────────────
   merge:

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -80,9 +80,13 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/atlanhq/app-runtime-base-${{ needs.prepare.outputs.lowercase_branch }}:sha-${{ needs.prepare.outputs.sha }}
-          build-args: |
-            ACCESS_TOKEN_USR=$GITHUB_ACTOR
-            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
+          # BuildKit secret mounts — never build-args, which leak into build
+          # logs and image/cache metadata. Consume in the Dockerfile via
+          # RUN --mount=type=secret,id=ACCESS_TOKEN_PWD ... (the SDK's own
+          # Dockerfile does not need them; passed for parity with app builds).
+          secrets: |
+            "ACCESS_TOKEN_USR=${{ github.actor }}"
+            "ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}"
           github-token: ${{ secrets.ORG_PAT_GITHUB }}
         env:
           DOCKER_CLIENT_TIMEOUT: 600

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -22,7 +22,7 @@ jobs:
       lowercase_branch: ${{ steps.get_lowercase_branch.outputs.lowercase_branch }}
       sha: ${{ steps.get_sha.outputs.sha }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -47,7 +47,7 @@ jobs:
       cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/check-dapr-version.yaml
+++ b/.github/workflows/check-dapr-version.yaml
@@ -1,8 +1,9 @@
 name: Check Dapr Version
 
 # Watches Dapr's GitHub releases for new stable versions and opens a PR to
-# bump ``__dapr_version`` in ``application_sdk/version.py`` whenever the
-# upstream latest drifts from our pin.
+# bump ``__dapr_version`` in ``application_sdk/version.py`` — and the
+# matching ``DAPR_RUNTIME_VERSION`` ARG in the ``Dockerfile`` — whenever
+# either pin drifts from the upstream latest.
 #
 # Runs on a schedule (Mondays at 09:00 UTC) and on manual dispatch.
 # Only the latest non-prerelease counts — ``releases/latest`` already
@@ -47,6 +48,17 @@ jobs:
           fi
           echo "version=$ver" >> "$GITHUB_OUTPUT"
 
+      - name: Read Dockerfile daprd pin
+        id: dockerfile
+        run: |
+          set -euo pipefail
+          ver=$(grep '^ARG DAPR_RUNTIME_VERSION=' Dockerfile | cut -d'=' -f2)
+          if [[ -z "$ver" ]]; then
+            echo "::error::Failed to parse ARG DAPR_RUNTIME_VERSION from Dockerfile"
+            exit 1
+          fi
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
       - name: Fetch latest Dapr stable release
         id: upstream
         env:
@@ -68,18 +80,21 @@ jobs:
         run: |
           set -euo pipefail
           pinned="${{ steps.pinned.outputs.version }}"
+          dockerfile="${{ steps.dockerfile.outputs.version }}"
           latest="${{ steps.upstream.outputs.version }}"
           echo "pinned=$pinned" >> "$GITHUB_OUTPUT"
           echo "latest=$latest" >> "$GITHUB_OUTPUT"
-          if [[ "$pinned" == "$latest" ]]; then
+          # Drift in EITHER pin (version.py or Dockerfile ARG) triggers a
+          # bump PR — both must track the upstream latest in lockstep.
+          if [[ "$pinned" == "$latest" && "$dockerfile" == "$latest" ]]; then
             echo "match=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::daprd pin is up to date ($pinned)"
+            echo "::notice::daprd pins are up to date ($pinned)"
           else
             echo "match=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::daprd pin $pinned is behind upstream $latest"
+            echo "::notice::daprd pins (version.py=$pinned, Dockerfile=$dockerfile) drift from upstream $latest"
           fi
 
-      - name: Bump version.py
+      - name: Bump version.py and Dockerfile
         if: steps.compare.outputs.match == 'false'
         run: |
           set -euo pipefail
@@ -87,10 +102,17 @@ jobs:
           latest="${{ steps.compare.outputs.latest }}"
           sed -i "s/^__dapr_version: str = \"${pinned}\"$/__dapr_version: str = \"${latest}\"/" \
             application_sdk/version.py
-          # Confirm exactly one line changed; bail if sed missed.
+          sed -i "s/^ARG DAPR_RUNTIME_VERSION=.*$/ARG DAPR_RUNTIME_VERSION=${latest}/" \
+            Dockerfile
+          # Confirm both rewrites landed; bail if either sed missed.
           new=$(grep '^__dapr_version' application_sdk/version.py | cut -d'"' -f2)
           if [[ "$new" != "$latest" ]]; then
             echo "::error::sed did not rewrite version.py as expected (got '$new', want '$latest')"
+            exit 1
+          fi
+          new_docker=$(grep '^ARG DAPR_RUNTIME_VERSION=' Dockerfile | cut -d'=' -f2)
+          if [[ "$new_docker" != "$latest" ]]; then
+            echo "::error::sed did not rewrite Dockerfile as expected (got '$new_docker', want '$latest')"
             exit 1
           fi
 
@@ -117,7 +139,7 @@ jobs:
             git checkout -b "$branch"
           fi
 
-          git add application_sdk/version.py
+          git add application_sdk/version.py Dockerfile
           if git diff --cached --quiet; then
             echo "::notice::No actual change to commit; PR may already be up to date."
             exit 0
@@ -149,10 +171,11 @@ jobs:
           | Current pin | \`${pinned}\` |
           | Upstream latest | \`${latest}\` |
 
-          This PR bumps \`__dapr_version\` in [\`application_sdk/version.py\`](application_sdk/version.py) so:
+          This PR bumps \`__dapr_version\` in [\`application_sdk/version.py\`](application_sdk/version.py) and \`ARG DAPR_RUNTIME_VERSION\` in the [\`Dockerfile\`](Dockerfile) so:
 
           - The embedded local-dev daprd (via \`application_sdk.dev.embedded_dapr\`) downloads the new release on first use.
           - CI workflows (\`scale-tests.yaml\`, \`e2e-examples\`) pass the new version to \`dapr init --runtime-version\`.
+          - The base image installs the matching Chainguard APK patch release.
 
           Release notes: https://github.com/dapr/dapr/releases/tag/v${latest}
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -28,25 +28,25 @@ jobs:
         language: ["python"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: "/language:${{matrix.language}}"
           upload: never
           output: codeql-results
 
       - name: Upload to Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         continue-on-error: true
         with:
           sarif_file: codeql-results/python.sarif
@@ -102,7 +102,7 @@ jobs:
           fi
 
       - name: Upload SARIF as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: codeql-sarif
@@ -114,6 +114,6 @@ jobs:
     name: Pre-commit Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: "./.github/actions/setup-deps"
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/harbor-release.yaml
+++ b/.github/workflows/harbor-release.yaml
@@ -21,7 +21,7 @@ jobs:
       cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/harbor-release.yaml
+++ b/.github/workflows/harbor-release.yaml
@@ -116,9 +116,13 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.image_tags.outputs.value }}
-          build-args: |
-            ACCESS_TOKEN_USR=$GITHUB_ACTOR
-            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
+          # BuildKit secret mounts — never build-args, which leak into build
+          # logs and image/cache metadata. Consume in the Dockerfile via
+          # RUN --mount=type=secret,id=ACCESS_TOKEN_PWD ... (the SDK's own
+          # Dockerfile does not need them; passed for parity with app builds).
+          secrets: |
+            "ACCESS_TOKEN_USR=${{ github.actor }}"
+            "ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}"
           github-token: ${{ secrets.ORG_PAT_GITHUB }}
         env:
           DOCKER_CLIENT_TIMEOUT: 600

--- a/.github/workflows/prune-dashboard-repo.yaml
+++ b/.github/workflows/prune-dashboard-repo.yaml
@@ -53,7 +53,7 @@ jobs:
           echo "Pruning slug: $SLUG"
 
       - name: Setup AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-region: ap-south-1
           role-to-assume: arn:aws:iam::733936409301:role/kryptonite-store_FullAccess

--- a/.github/workflows/publish-app.yaml
+++ b/.github/workflows/publish-app.yaml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref || github.ref }}
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       container: ${{ steps.filter.outputs.container }}
       code: ${{ steps.filter.outputs.code }}
+      deps: ${{ steps.filter.outputs.deps }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
@@ -40,6 +41,9 @@ jobs:
               - 'examples/**'
               - '.github/**'
               - '.security/**'
+            deps:
+              - 'pyproject.toml'
+              - 'uv.lock'
 
   # Conventional Commits (skipped on fork PRs — no org PAT available)
   commits:
@@ -79,6 +83,32 @@ jobs:
       - uses: "./.github/actions/trivy"
         with:
           add-report-comment-to-pr: "true"
+
+  # PR-time CVE gate for dependency changes. Post-merge/scheduled Trivy gates
+  # can miss a CVE published after Renovate's cooldown but before automerge —
+  # this scans the lockfile in fs mode (no image build, fast) and blocks the
+  # PR on CRITICAL/HIGH findings with an available fix.
+  deps-cve:
+    name: Dependency CVE Scan
+    needs: changes
+    if: needs.changes.outputs.deps == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Trivy filesystem scan (lockfile)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          format: table
+          exit-code: '1'
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
 
   trivy-container:
     name: Trivy Container Scan

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,17 +18,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Need full history for changelog
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "0.7.3"
 

--- a/.github/workflows/reusable-claude-review.yml
+++ b/.github/workflows/reusable-claude-review.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close Stale PRs
-        uses: actions/stale@v10
+        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
         with:
           repo-token: ${{ secrets.ORG_PAT_GITHUB }}
           stale-issue-message: 'Stale Issue'
@@ -27,5 +27,5 @@ jobs:
     name: Trivy Code Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: "./.github/actions/trivy"

--- a/.github/workflows/scheduled-trivy-scan.yml
+++ b/.github/workflows/scheduled-trivy-scan.yml
@@ -17,20 +17,20 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: cgr.dev
           username: ${{ secrets.CHAINGUARD_USERNAME }}
           password: ${{ secrets.CHAINGUARD_PASSWORD }}
 
       - name: Build image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: '.'
           file: './Dockerfile'
@@ -41,7 +41,7 @@ jobs:
       # ── Image scan ──
 
       - name: Trivy image scan (JSON)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: 'application-sdk:trivy-scan'
           scanners: 'vuln'
@@ -56,7 +56,7 @@ jobs:
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
 
       - name: Trivy image scan (table)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: 'application-sdk:trivy-scan'
           scanners: 'vuln'
@@ -73,7 +73,7 @@ jobs:
       # ── Dependency scan ──
 
       - name: Trivy dependency scan (JSON)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: fs
           input: 'uv.lock'
@@ -88,7 +88,7 @@ jobs:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
 
       - name: Trivy dependency scan (table)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: fs
           input: 'uv.lock'

--- a/.github/workflows/sdk-evolution-cron.yml
+++ b/.github/workflows/sdk-evolution-cron.yml
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 130
     steps:
       - name: Checkout repo (for local globalprotect-connect action)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Connect to VPN (attempt 1/3)
         id: vpn1

--- a/.github/workflows/sdk-review-reset-on-push.yml
+++ b/.github/workflows/sdk-review-reset-on-push.yml
@@ -58,7 +58,7 @@ jobs:
           echo "Stripped stale sdk-review-* labels from PR #${PR_NUMBER} (if present)."
 
       - name: Reset sdk-review commit status on new HEAD
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             // The `sdk-review` context lives on a specific SHA. When a new

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -98,11 +98,11 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout repo (for local globalprotect-connect action)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Parse comment intent
         id: parse
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const isDispatch = context.eventName === 'workflow_dispatch';
@@ -132,7 +132,7 @@ jobs:
             core.setOutput('commenter_intent', intent);
 
       - name: React to comment + ensure labels exist
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             // Only react when triggered by a real comment (workflow_dispatch
@@ -165,7 +165,7 @@ jobs:
         id: pr
         env:
           PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const { data: pr } = await github.rest.pulls.get({
@@ -185,7 +185,7 @@ jobs:
           PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
           COMMENTER: ${{ steps.parse.outputs.commenter }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             // Post a fresh "starting" notice per @sdk-review trigger so the
@@ -262,7 +262,7 @@ jobs:
       - name: Set sdk-review status to pending
         env:
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -331,7 +331,7 @@ jobs:
           PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PORTAL_URL: ${{ vars.GLOBALPROTECT_PORTAL_URL }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
@@ -730,7 +730,7 @@ jobs:
       # because the latter has shaky multi-line handling.
       - name: Stamp cost + status onto starter comment
         if: always() && steps.starter.outputs.comment_id != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           STARTER_COMMENT_ID: ${{ steps.starter.outputs.comment_id }}
           STARTER_STARTED_AT: ${{ steps.starter.outputs.started_at }}
@@ -954,7 +954,7 @@ jobs:
         if: failure() && steps.pr.outputs.head_sha != ''
         env:
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             // Only fires when an earlier step failed AND the orchestration

--- a/.github/workflows/tag-and-publish.yaml
+++ b/.github/workflows/tag-and-publish.yaml
@@ -18,17 +18,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Need full history for release notes
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "0.7.3"
 
@@ -65,7 +65,7 @@ jobs:
 
       - name: Create GitHub Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: "v${{ env.VERSION }}"
           name: "v${{ env.VERSION }}"

--- a/.github/workflows/trivy-container.yaml
+++ b/.github/workflows/trivy-container.yaml
@@ -38,10 +38,10 @@ jobs:
     runs-on: "ubuntu-24.04"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Checkout base allowlist from SDK
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: atlanhq/application-sdk
           ref: main

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -50,10 +50,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Checkout dashboard assets from SDK
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: atlanhq/application-sdk
           path: _sdk
@@ -293,7 +293,7 @@ jobs:
 
       - name: Setup AWS Credentials
         if: steps.download.outputs.has_artifacts == 'true'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-region: ap-south-1
           role-to-assume: arn:aws:iam::733936409301:role/kryptonite-store_FullAccess

--- a/.github/workflows/v3-readiness-check.yaml
+++ b/.github/workflows/v3-readiness-check.yaml
@@ -100,12 +100,12 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install application-sdk
         working-directory: sdk

--- a/.github/workflows/validate-allowlist.yaml
+++ b/.github/workflows/validate-allowlist.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Check if PR modifies base-allowlist.json
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({
@@ -46,7 +46,7 @@ jobs:
 
       - name: Checkout
         if: steps.check.outputs.modified == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Validate allowlist expiry policy
         if: steps.check.outputs.modified == 'true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
 FROM cgr.dev/atlan.com/app-framework-golden:3.13
 
-# Dapr version argument
+# Dapr runtime package (Chainguard APK). The package stream tracks the
+# minor release (1.17); DAPR_RUNTIME_VERSION pins the exact patch release
+# and must match __dapr_version in application_sdk/version.py.
+# .github/workflows/check-dapr-version.yaml keeps both pins in sync.
 ARG DAPR_RUNTIME_PACKAGE=dapr-daprd-1.17
+ARG DAPR_RUNTIME_VERSION=1.17.9
 
 # Switch to root for installation
 USER root
 
-# Install Dapr runtime from Chainguard APK
-RUN apk add --no-cache ${DAPR_RUNTIME_PACKAGE}
+# Install Dapr runtime from Chainguard APK, pinned to the exact patch
+# release (=~ matches the version prefix, tolerating apk -rN revisions).
+RUN apk add --no-cache "${DAPR_RUNTIME_PACKAGE}=~${DAPR_RUNTIME_VERSION}"
 
 # Create appuser (standardized user for all apps)
 RUN addgroup -g 1000 appuser && adduser -D -u 1000 -G appuser appuser

--- a/application_sdk/dev/_dapr.py
+++ b/application_sdk/dev/_dapr.py
@@ -12,6 +12,7 @@ production while requiring nothing on the host beyond Python and ``uv``.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import os
 import platform
 import shutil
@@ -27,6 +28,7 @@ from pathlib import Path
 
 from application_sdk.dev._dapr_errors import (
     DaprdBinaryMissingError,
+    DaprdChecksumMismatchError,
     DaprReadinessTimeoutError,
     UnsupportedArchitectureError,
     UnsupportedOsError,
@@ -43,6 +45,45 @@ _DAPRD_RELEASE_BASE = (
     "https://github.com/dapr/dapr/releases/download/v{version}/daprd_{os}_{arch}"
 )
 _CACHE_DIR = Path.home() / ".cache" / "atlan-sdk" / "dapr" / _DAPRD_VERSION
+
+
+def _fetch_expected_sha256(checksum_url: str) -> str:
+    """Fetch the published ``.sha256`` asset and return the hex digest.
+
+    Dapr release checksum files contain ``<hex-digest> *<asset-name>`` —
+    the first whitespace-separated token is the digest.
+    """
+    with urllib.request.urlopen(checksum_url) as resp:
+        text = resp.read().decode("utf-8")
+    tokens = text.split()
+    digest = tokens[0].lower() if tokens else ""
+    if len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest):
+        raise DaprdChecksumMismatchError(
+            archive_url=checksum_url,
+            expected_sha256=digest or None,
+            actual_sha256=None,
+        )
+    return digest
+
+
+def _verify_archive_checksum(archive_path: str, archive_url: str) -> None:
+    """Verify *archive_path* against the release's published SHA256.
+
+    Raises :class:`DaprdChecksumMismatchError` on any mismatch so a
+    corrupted or tampered archive is never extracted or executed.
+    """
+    expected = _fetch_expected_sha256(archive_url + ".sha256")
+    sha = hashlib.sha256()
+    with open(archive_path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            sha.update(chunk)
+    actual = sha.hexdigest()
+    if actual != expected:
+        raise DaprdChecksumMismatchError(
+            archive_url=archive_url,
+            expected_sha256=expected,
+            actual_sha256=actual,
+        )
 
 
 def _daprd_binary_name() -> str:
@@ -95,6 +136,9 @@ def _download_daprd(target: Path) -> None:
     os.close(tmp_fd)
     try:
         urllib.request.urlretrieve(url, tmp_name)
+        # Verify against the release's published checksum BEFORE extracting —
+        # never extract or execute an archive that fails integrity checks.
+        _verify_archive_checksum(tmp_name, url)
         if ext == ".zip":
             import zipfile  # noqa: PLC0415 — Windows-only cold path
 

--- a/application_sdk/dev/_dapr_errors.py
+++ b/application_sdk/dev/_dapr_errors.py
@@ -34,6 +34,20 @@ class DaprdBinaryMissingError(InternalError):
 
 
 @dataclass(kw_only=True)
+class DaprdChecksumMismatchError(InternalError):
+    code: ClassVar[str] = "INTERNAL_DAPR_CHECKSUM_MISMATCH"
+    message: str = (
+        "daprd archive failed SHA256 verification — refusing to extract. "
+        "The download may be corrupted or tampered with; delete any partial "
+        "cache under ~/.cache/atlan-sdk/dapr/ and retry."
+    )
+    component: str | None = "embedded_dapr"
+    archive_url: str | None = None
+    expected_sha256: str | None = None
+    actual_sha256: str | None = None
+
+
+@dataclass(kw_only=True)
 class DaprReadinessTimeoutError(AppTimeoutError):
     code: ClassVar[str] = "TIMEOUT_DAPR_READINESS"
     message: str = "Embedded Dapr did not become ready within deadline"

--- a/docs/adr/0016-supply-chain-pinning-policy.md
+++ b/docs/adr/0016-supply-chain-pinning-policy.md
@@ -1,0 +1,95 @@
+# ADR-0016: Supply-Chain Pinning Policy
+
+## Status
+**Accepted**
+
+## Context
+
+The SDK is both a library and a build platform: its reusable workflows, composite actions, base image, and Renovate preset are consumed by every first-party app repo. A compromise anywhere in that chain — a repointed action tag, a mutated registry tag, an unpinned runtime package, or a poisoned dependency release — propagates to the whole fleet.
+
+The concrete gaps this policy closes:
+
+- **Mutable action references.** Third-party GitHub Actions referenced by tag (`@v4`) can be silently repointed by the action maintainer. Several of our workflows run with `ORG_PAT_GITHUB` or publish credentials in scope, making a repointed tag a remote-code-execution vector in the publish path.
+- **Mutable image tags.** `FROM cgr.dev/atlan.com/app-framework-golden:3.13` resolves to whatever the registry serves for that tag at build time. Two builds of the same commit can produce different images.
+- **Loose runtime package pins.** `apk add dapr-daprd-1.17` installs whatever patch release the APK stream currently carries, so the daprd inside the image can drift from the `__dapr_version` pin the SDK and CI use everywhere else.
+- **Secrets in build-args.** `--build-arg ACCESS_TOKEN_PWD=...` leaks the PAT into build logs, image history, and BuildKit cache metadata.
+- **Unverified binary downloads.** The local-dev daprd download executed whatever bytes the network returned, with no integrity check.
+- **Post-merge-only CVE scanning.** Renovate automerges grouped minor/patch dependency bumps after a green gate, but the container/Trivy gates run post-merge or on a schedule — a CVE published between the dependency-cooldown window and automerge could land on `main` unscanned.
+
+## Decision
+
+Adopt a single supply-chain pinning policy across the repo:
+
+1. **Third-party GitHub Actions are pinned to full commit SHAs**, with the original tag preserved as a trailing comment (`uses: owner/action@<sha> # v4`). Internal same-repo `atlanhq/*` reusable references stay branch-pinned (that is the reusable-workflow distribution model).
+2. **Base images are digest-pinned via Renovate** (`pinDigests: true` for the Dockerfile manager in `renovate-config/default.json`). Renovate resolves `tag@sha256:...` and keeps the digest current alongside tag updates, so humans never hand-maintain digests.
+3. **Runtime packages are pinned to full semver.** The Dockerfile installs `dapr-daprd-1.17=~<patch>` where the patch version is an ARG kept in lockstep with `__dapr_version` in `application_sdk/version.py` by `.github/workflows/check-dapr-version.yaml`.
+4. **Secrets never travel as build-args.** Build credentials are passed as BuildKit secret mounts (`secrets:` on `docker/build-push-action`, `RUN --mount=type=secret,id=...` in Dockerfiles), keeping them out of logs, layers, and cache metadata.
+5. **Downloaded binaries are checksum-verified.** The embedded daprd download verifies the archive against the release's published SHA256 before extraction and refuses to run on mismatch.
+6. **Dependency changes get a PR-time CVE scan.** Any PR touching `uv.lock` or `pyproject.toml` runs a Trivy filesystem scan (no image build) that fails on fixable CRITICAL/HIGH findings — closing the cooldown-to-automerge window.
+7. **Cooldown + automerge stays.** Grouped minor/patch automerge behind a green gate (with the org-level dependency cooldown delaying fresh releases) remains the fleet upgrade mechanism; the PR-time scan makes it safe rather than replacing it.
+
+## Options Considered
+
+### Option 1: Pin everything, automate the churn (Chosen)
+
+SHA-pin actions, digest-pin images, semver-pin runtime packages — and delegate the resulting update churn to Renovate (digests, action SHAs via the `github-actions` manager) and a scheduled drift-check workflow (daprd).
+
+**Pros:**
+- Builds are reproducible: the same commit always resolves the same actions, base image, and runtime packages
+- Tag-repointing attacks (actions or registry tags) become inert
+- Update fatigue is handled by bots, not humans; the tag comment keeps SHAs reviewable
+- PR-time scan blocks bad releases before merge instead of detecting them after
+
+**Cons:**
+- More Renovate PRs (digest bumps ride along with tag updates, mitigating this)
+- A stale pin can linger if the bots are down — drift is silent until the scheduled checks run
+- SHA pins are unreadable without the tag comment; reviewers must check the comment matches the SHA
+
+### Option 2: Tag pinning + trust upstream (Not Chosen)
+
+Keep `@vN` action tags, `:3.13`-style image tags, and minor-stream packages; rely on registry/marketplace trust and post-merge scanning.
+
+**Pros:**
+- Minimal maintenance; updates arrive implicitly
+- Human-readable references
+
+**Cons:**
+- Every reference is mutable: a compromised maintainer account repoints a tag and our publish workflows execute it with org credentials
+- Non-reproducible builds make incident forensics ("what exactly did we ship?") unanswerable
+- Post-merge scanning means a vulnerable dependency is already on `main` (and possibly published) when detected
+
+### Option 3: Vendor everything (Not Chosen)
+
+Fork third-party actions into the org, mirror base images into our registry, vendor binaries.
+
+**Pros:**
+- Strongest isolation from upstream compromise
+
+**Cons:**
+- Permanent maintenance burden for dozens of actions and images
+- Forks rot; security fixes must be manually pulled
+- Digest/SHA pinning achieves the same immutability guarantee at a fraction of the cost
+
+## Consequences
+
+**Positive:**
+- A repointed upstream tag (action or image) can no longer change what we build or execute
+- Secrets are absent from build logs, image history, and cache — a leaked build log no longer leaks the org PAT
+- The daprd a developer runs locally is byte-verified against the official release
+- Dependency CVEs are caught at PR time for lockfile changes, before automerge can land them
+- One documented policy to point to in reviews: "pin it like ADR-0016 says"
+
+**Negative:**
+- Renovate digest/SHA-bump PRs add review traffic (grouped + automerged to compensate)
+- New third-party action references must be SHA-pinned by hand at introduction time
+- App Dockerfiles consuming `ACCESS_TOKEN_USR`/`ACCESS_TOKEN_PWD` as build-args must migrate to `RUN --mount=type=secret` (the snippet is documented in the reusable workflow headers)
+- If Chainguard ships a daprd patch ahead of the upstream GitHub release (or vice versa), the lockstep pin can briefly block image builds until the drift PR merges
+
+## Implementation
+
+- Action SHA pins: all `.github/workflows/`, `.github/actions/`, `.github/workflow-templates/`
+- Digest pinning: `renovate-config/default.json` (`pinDigests` rule, Dockerfile manager)
+- Runtime pin + sync: `Dockerfile` (`DAPR_RUNTIME_VERSION` ARG), `.github/workflows/check-dapr-version.yaml`, `application_sdk/version.py`
+- BuildKit secrets: `build-and-scan.yaml`, `build-image.yaml`, `harbor-release.yaml`, `build-apps-image.yaml`, `build-and-publish-app.yaml`, `secure-build-push-apps` action
+- Checksum verification: `application_sdk/dev/_dapr.py`
+- PR-time CVE scan: `deps-cve` job in `.github/workflows/pull_request.yaml`

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -18,3 +18,4 @@ ADRs capture the architectural decisions behind the Application SDK — what was
 | [ADR-0012](0012-observability-consolidation.md) | Observability Consolidation |
 | [ADR-0013](0013-error-hierarchy-and-failure-taxonomy.md) | Error Hierarchy and Failure Taxonomy |
 | [ADR-0014](0014-two-store-storage-architecture.md) | Two-Store Storage Architecture (task-to-task vs app-to-app) |
+| [ADR-0016](0016-supply-chain-pinning-policy.md) | Supply-Chain Pinning Policy (action SHAs, image digests, runtime semver, BuildKit secrets, PR-time CVE scan) |

--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -59,6 +59,11 @@
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true
+    },
+    {
+      "description": "Docker base images: pin FROM lines to digests (tag@sha256:...) so builds are immutable even if a registry tag is repointed. Renovate resolves and refreshes the digest; registries that need auth (e.g. cgr.dev) must have hostRules credentials configured on the Renovate runner.",
+      "matchManagers": ["dockerfile"],
+      "pinDigests": true
     }
   ],
   "customManagers": [

--- a/tests/unit/dev/test_dapr.py
+++ b/tests/unit/dev/test_dapr.py
@@ -8,7 +8,10 @@ real ``daprd``.
 
 from __future__ import annotations
 
+import hashlib
 import os
+import shutil as _shutil
+import tarfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -17,12 +20,16 @@ import pytest
 from application_sdk.dev._dapr import (
     _COMPONENTS_YAML,
     EmbeddedDapr,
+    _download_daprd,
+    _fetch_expected_sha256,
     _pick_free_port,
     _platform_tuple,
+    _verify_archive_checksum,
     _write_components,
     embedded_dapr,
 )
 from application_sdk.dev._dapr_errors import (
+    DaprdChecksumMismatchError,
     UnsupportedArchitectureError,
     UnsupportedOsError,
 )
@@ -245,3 +252,137 @@ class TestEmbeddedDaprLifecycle:
 
         _stub_subprocess_and_binary.terminate.assert_called_once()
         _stub_subprocess_and_binary.wait.assert_awaited()
+
+
+class TestDownloadDaprdIntegrity:
+    """The daprd archive must pass SHA256 verification against the release's
+    published ``.sha256`` asset before it is ever extracted or executed."""
+
+    BINARY_PAYLOAD = b"#!/bin/sh\necho daprd\n"
+
+    @pytest.fixture
+    def _linux_platform(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Force a deterministic os/arch + archive ext regardless of host."""
+        monkeypatch.setattr("platform.system", lambda: "Linux")
+        monkeypatch.setattr("platform.machine", lambda: "x86_64")
+
+    def _make_archive(self, tmp_path: Path) -> Path:
+        """Build a tiny tar.gz containing a fake ``daprd`` binary."""
+        binary = tmp_path / "daprd"
+        binary.write_bytes(self.BINARY_PAYLOAD)
+        archive = tmp_path / "daprd_linux_amd64.tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            tar.add(binary, arcname="daprd")
+        return archive
+
+    @staticmethod
+    def _sha256(path: Path) -> str:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+
+    def test_extracts_when_checksum_matches(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _linux_platform: None,
+    ) -> None:
+        archive = self._make_archive(tmp_path)
+        digest = self._sha256(archive)
+
+        def fake_urlretrieve(url: str, filename: str) -> None:
+            _shutil.copyfile(archive, filename)
+
+        monkeypatch.setattr("urllib.request.urlretrieve", fake_urlretrieve)
+        monkeypatch.setattr(
+            "application_sdk.dev._dapr._fetch_expected_sha256",
+            lambda _url: digest,
+        )
+
+        target = tmp_path / "cache" / "daprd"
+        _download_daprd(target)
+
+        assert target.read_bytes() == self.BINARY_PAYLOAD
+        assert os.access(target, os.X_OK)
+
+    def test_mismatch_raises_and_nothing_is_extracted(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _linux_platform: None,
+    ) -> None:
+        archive = self._make_archive(tmp_path)
+        real_digest = self._sha256(archive)
+        wrong_digest = "0" * 64
+        assert wrong_digest != real_digest
+
+        def fake_urlretrieve(url: str, filename: str) -> None:
+            _shutil.copyfile(archive, filename)
+
+        monkeypatch.setattr("urllib.request.urlretrieve", fake_urlretrieve)
+        monkeypatch.setattr(
+            "application_sdk.dev._dapr._fetch_expected_sha256",
+            lambda _url: wrong_digest,
+        )
+
+        target = tmp_path / "cache" / "daprd"
+        with pytest.raises(DaprdChecksumMismatchError) as exc_info:
+            _download_daprd(target)
+
+        # The tampered archive must never be extracted.
+        assert not target.exists()
+        # The error carries both digests for diagnosis.
+        assert exc_info.value.expected_sha256 == wrong_digest
+        assert exc_info.value.actual_sha256 == real_digest
+
+    def test_verify_archive_checksum_passes_on_match(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        archive = self._make_archive(tmp_path)
+        monkeypatch.setattr(
+            "application_sdk.dev._dapr._fetch_expected_sha256",
+            lambda _url: self._sha256(archive),
+        )
+        # Must not raise.
+        _verify_archive_checksum(str(archive), "https://example.invalid/a.tar.gz")
+
+    def test_fetch_expected_sha256_parses_release_format(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        digest = "d5" * 32
+        resp = MagicMock()
+        resp.read.return_value = f"{digest} *daprd_linux_amd64.tar.gz\n".encode()
+        resp.__enter__.return_value = resp
+        monkeypatch.setattr("urllib.request.urlopen", lambda _url: resp)
+
+        result = _fetch_expected_sha256("https://example.invalid/a.tar.gz.sha256")
+
+        assert result == digest
+
+    def test_fetch_expected_sha256_normalises_uppercase(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        digest = "AB" * 32
+        resp = MagicMock()
+        resp.read.return_value = f"{digest} *daprd_linux_amd64.tar.gz\n".encode()
+        resp.__enter__.return_value = resp
+        monkeypatch.setattr("urllib.request.urlopen", lambda _url: resp)
+
+        assert _fetch_expected_sha256("https://example.invalid/x.sha256") == "ab" * 32
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            b"",  # empty checksum file
+            b"not-a-digest *daprd_linux_amd64.tar.gz\n",  # non-hex token
+            b"abc123 *daprd_linux_amd64.tar.gz\n",  # too short
+        ],
+    )
+    def test_fetch_expected_sha256_rejects_malformed(
+        self, monkeypatch: pytest.MonkeyPatch, payload: bytes
+    ) -> None:
+        resp = MagicMock()
+        resp.read.return_value = payload
+        resp.__enter__.return_value = resp
+        monkeypatch.setattr("urllib.request.urlopen", lambda _url: resp)
+
+        with pytest.raises(DaprdChecksumMismatchError):
+            _fetch_expected_sha256("https://example.invalid/x.sha256")


### PR DESCRIPTION
## Summary

Supply-chain half of the SDK security audit (this repo is Tier-1 supply-chain risk: every connector builds on it). Three commits:

1. **SHA-pin all third-party GitHub Actions** — 126 references across 39 files (workflows, composite actions, workflow-templates) moved from mutable tags to commit SHAs with the tag preserved as a comment. Internal `atlanhq/*` same-repo refs unchanged.
2. **Build-pipeline hardening**:
   - `auto-fix-vulnerabilities.yaml`: new `authorize` job — fails closed unless the `/fix-vulnerabilities` commenter is OWNER/MEMBER/COLLABORATOR (this workflow pushes commits with `ORG_PAT_GITHUB`; previously any commenter could trigger it)
   - Dockerfile: `DAPR_RUNTIME_PACKAGE` split into package + pinned `DAPR_RUNTIME_VERSION=1.17.9` installed via `apk add "pkg=~version"`; `check-dapr-version.yaml` now detects and auto-bumps drift in both pins
   - Base-image digest pinning: Chainguard registry requires auth so no digest was hand-pinned; instead Renovate `pinDigests: true` added for the `dockerfile` manager (cgr.dev needs hostRules creds on the Renovate runner — noted in config)
   - **BuildKit secret mounts replace `ACCESS_TOKEN_*` build-args** in all five build workflows (build-args leak into logs and cache metadata; secrets don't). ⚠️ App-repo Dockerfiles still consuming these as `ARG`s must migrate to `RUN --mount=type=secret` — snippet documented in the reusable-workflow headers, flagged in ADR consequences
   - `.dockerignore`: credential-shaped patterns (`.env*`, `*.pem`, `*.key`, `credentials*`, `secrets*`, `.aws/`, `.gcp/`)
   - New `deps-cve` PR-time job in `pull_request.yaml`: Trivy fs scan on `uv.lock`/`pyproject.toml` changes, fails on fixable CRITICAL/HIGH — closes the window where a transitive-dep auto-merge lands after a CVE publishes post-cooldown
3. **daprd dev-download integrity** — `dev/_dapr.py` fetches the GitHub-release `.sha256` and verifies before extraction; typed `DaprdChecksumMismatchError`; 7 unit tests with real tar.gz fixtures

Plus **ADR-0016: Supply-Chain Pinning Policy** documenting all six planks + the cooldown/automerge rationale.

## Test plan

- `pre-commit run --all-files` green; unit suite green (5004 passed, 8 skipped); all edited YAML/JSON parse-validated; local `trivy fs` on current `uv.lock` is clean so the new gate starts green

🤖 Generated with [Claude Code](https://claude.com/claude-code)