### PR TITLE
ci: make certify coverage source configurable (default: app)

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -70,6 +70,11 @@ on:
         required: false
         type: boolean
         default: false
+      coverage_source:
+        description: "Python package (or path) measured for unit-test coverage — passed to `pytest --cov=<value>` in the certify gate. Defaults to 'app', the standard SDK app package name, so existing callers are unaffected. Apps whose importable package differs override this (e.g. automation-engine sets 'automation_engine'); otherwise coverage measures a non-existent module, records 0%, and trips the app's coverage fail_under gate."
+        required: false
+        type: string
+        default: "app"
     secrets:
       ORG_PAT_GITHUB:
         required: true
@@ -502,7 +507,7 @@ jobs:
           # the default groups, pruning any test deps an app keeps in a non-default
           # group — which silently breaks async/plugin-dependent suites and trips
           # this gate on a packaging gap rather than a real failure.
-          uv run --all-groups --with pytest-cov pytest tests/unit --cov=app --cov-report=term
+          uv run --all-groups --with pytest-cov pytest tests/unit --cov=${{ inputs.coverage_source }} --cov-report=term
 
       - name: "Coverage threshold (>=85%)"
         id: coverage_threshold


### PR DESCRIPTION
## Problem
The Certify job's "Unit tests" gate runs:
```
uv run --all-groups --with pytest-cov pytest tests/unit --cov=app --cov-report=term
```
The `--cov=app` hardcodes the app's importable package as `app`. Apps that use a different package name (e.g. **automation-engine** → `automation_engine`) measure a **non-existent module**, so coverage reports:
```
CoverageWarning: Module app was never imported. (module-not-imported)
FAIL Required test coverage of 60.0% not reached. Total coverage: 0.00%
```
That 0% trips the app's `[tool.coverage.report] fail_under` gate → the "Unit tests" step exits non-zero → **build + publish is blocked even though every unit test passed**.

It's been latent/intermittent: the gate only runs when the prior `app_install` step succeeds, so on runs where app-install failed, unit tests were skipped and the broken `--cov=app` never executed. When app-install succeeds, it fails — for any app whose package name ≠ `app`.

## Fix
- New `workflow_call` input **`coverage_source`** (default `"app"`).
- Certify "Unit tests" step uses `--cov=${{ inputs.coverage_source }}`.

```yaml
coverage_source:
  description: "Python package (or path) measured for unit-test coverage — passed to `pytest --cov=<value>`. Defaults to 'app' ..."
  required: false
  type: string
  default: "app"
```

## Backward compatibility
- Default `"app"` → **every existing caller is unaffected** (no caller changes required).
- Apps with a divergent package override it, e.g. automation-engine's caller passes `coverage_source: automation_engine`.

## Blast radius
One input + one substitution. The warn-only `coverage report --fail-under=85` step is package-agnostic (reads the `.coverage` data file) and is untouched.

## Rollout
1. Merge this PR (safe — default preserves current behavior).
2. `atlan-automation-engine-app` caller adds `coverage_source: automation_engine` (separate PR; lands after this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)