### PR TITLE
fix(ci): stop certify unit-test gate failing on app coverage config

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -502,7 +502,17 @@ jobs:
           # the default groups, pruning any test deps an app keeps in a non-default
           # group — which silently breaks async/plugin-dependent suites and trips
           # this gate on a packaging gap rather than a real failure.
-          uv run --all-groups --with pytest-cov pytest tests/unit --cov=app --cov-report=term
+          #
+          # Bare --cov (no value) defers to the app's [tool.coverage.run] source
+          # config — an explicit --cov=app would override it and measure nothing
+          # for apps whose package isn't literally named `app` (e.g. the
+          # automation engine's `automation_engine`), reporting 0% coverage.
+          # --cov-fail-under=0 keeps this gate purely about test pass/fail: an
+          # app-level [tool.coverage.report] fail_under would otherwise fail
+          # pytest on a coverage shortfall and masquerade as failing unit tests,
+          # hard-blocking publish. The threshold check belongs to the dedicated
+          # warn-only step below.
+          uv run --all-groups --with pytest-cov pytest tests/unit --cov --cov-report=term --cov-fail-under=0
 
       - name: "Coverage threshold (>=85%)"
         id: coverage_threshold


### PR DESCRIPTION
## Problem

The `certify` job's **Unit tests** step in `build-and-publish-app.yaml` runs:

```bash
uv run --all-groups --with pytest-cov pytest tests/unit --cov=app --cov-report=term
```

Two bugs interact here:

1. **`--cov=app` hardcodes the package name.** An explicit `--cov=<name>` overrides the app's own `[tool.coverage.run] source` config. For apps whose package isn't literally named `app` — e.g. `atlan-automation-engine-app`, whose package is `automation_engine` — coverage instruments a nonexistent module (`CoverageWarning: Module app was never imported`) and collects **zero data**.
2. **App-level coverage config leaks into the tests-only gate.** pytest-cov also reads the app's `[tool.coverage.report] fail_under` (60 in that repo) and fails pytest on it. With 0% collected, pytest exits non-zero **even when every test passes**, the verdict records `UT: failure`, and publish is hard-blocked with *"Unit tests failed"* — contradicting the workflow's own contract that coverage is warn-only (the dedicated `Coverage threshold (>=85%)` step, `continue-on-error: true`).

Real-world hit: [atlan-automation-engine-app run 27287372211](https://github.com/atlanhq/atlan-automation-engine-app/actions/runs/27287372211/job/80598804939) — `2252 passed, 352 warnings`, yet publish blocked by `ERROR: Coverage failure: total of 0 is less than fail-under=60`.

## Fix

```diff
- uv run --all-groups --with pytest-cov pytest tests/unit --cov=app --cov-report=term
+ uv run --all-groups --with pytest-cov pytest tests/unit --cov --cov-report=term --cov-fail-under=0
```

- **Bare `--cov`** defers to the app's `[tool.coverage.run] source`, so the actual package gets measured. Apps whose package *is* named `app` behave identically.
- **`--cov-fail-under=0`** neutralizes any app-level `fail_under` inside this step, so the unit-test gate can only fail on genuinely failing tests.

The ≥85% threshold check is untouched — it stays in the dedicated warn-only step, which reads `.coverage` directly with its own explicit `--fail-under=85`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)