### PR TITLE
fix(storage): match Dapr S3 defaults — infer allow_http from http scheme + AWS_REGION fallback

### DIFF
--- a/application_sdk/storage/binding.py
+++ b/application_sdk/storage/binding.py
@@ -243,12 +243,30 @@ def _build_s3_config(
     client_options: dict[str, object] = dict(sdk_client_options)
     credential_provider = None
 
-    if _nonempty(meta, "region"):
-        config["aws_region"] = meta["region"]
+    # Region: explicit metadata wins; otherwise fall back to the standard AWS
+    # env vars. Dapr's Go binding leaves region resolution to the AWS SDK
+    # (LoadDefaultConfig → AWS_REGION / AWS_DEFAULT_REGION / shared config /
+    # instance metadata), so ambient region (IRSA / EKS injection) worked in v2.
+    # obstore reads neither env var with an explicit config and silently defaults
+    # to us-east-1 → 301 PermanentRedirect for buckets in other regions.
+    resolved_region = (
+        _nonempty(meta, "region")
+        or os.environ.get("AWS_REGION", "")
+        or os.environ.get("AWS_DEFAULT_REGION", "")
+    )
+    if resolved_region:
+        config["aws_region"] = resolved_region
     endpoint = _nonempty(meta, "endpoint")
     if endpoint:
         config["aws_endpoint"] = endpoint
         client_options["user_agent"] = "aws-sdk-go-v2 atlan-application-sdk"
+        # Match Dapr (and the Azure branch below): an http:// endpoint means
+        # plaintext, so infer allow_http from the scheme. obstore's reqwest
+        # client is https-only by default and rejects http at request-build time
+        # ("HTTP error: builder error") otherwise. An explicit disableSSL below
+        # still works and is now redundant for http endpoints.
+        if endpoint.startswith("http://"):
+            client_options["allow_http"] = True
     if _coerce_bool(meta.get("forcePathStyle", "")):
         config["aws_virtual_hosted_style_request"] = "false"
     if _coerce_bool(meta.get("disableSSL", "")):
@@ -319,7 +337,7 @@ def _build_s3_config(
         credential_provider = make_s3_assume_role_provider(
             role_arn=meta["assumeRoleArn"],
             session_name=_nonempty(meta, "sessionName") or "atlan-application-sdk",
-            region=_nonempty(meta, "region") or None,
+            region=resolved_region or None,
             base_access_key=base_access_key,
             base_secret_key=base_secret_key,
             base_session_token=base_session_token,

--- a/application_sdk/storage/binding.py
+++ b/application_sdk/storage/binding.py
@@ -265,7 +265,7 @@ def _build_s3_config(
         # client is https-only by default and rejects http at request-build time
         # ("HTTP error: builder error") otherwise. An explicit disableSSL below
         # still works and is now redundant for http endpoints.
-        if endpoint.startswith("http://"):
+        if endpoint.lower().startswith("http://"):
             client_options["allow_http"] = True
     if _coerce_bool(meta.get("forcePathStyle", "")):
         config["aws_virtual_hosted_style_request"] = "false"

--- a/application_sdk/storage/binding.py
+++ b/application_sdk/storage/binding.py
@@ -383,7 +383,7 @@ def _build_azure_config(
         az_config["azure_storage_account_name"] = account
     if _nonempty(meta, "endpoint"):
         az_config["azure_storage_endpoint"] = meta["endpoint"]
-        if meta["endpoint"].startswith("http://"):
+        if meta["endpoint"].lower().startswith("http://"):
             az_client_options["allow_http"] = True
     if _coerce_bool(meta.get("useEmulator", "")):
         az_config["azure_storage_use_emulator"] = "true"

--- a/tests/unit/storage/test_binding.py
+++ b/tests/unit/storage/test_binding.py
@@ -224,6 +224,11 @@ class TestS3StaticCredentials:
 
 
 class TestS3EmptyConfigHardening:
+    @pytest.fixture(autouse=True)
+    def _isolate_aws_region_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+
     @patch("obstore.store.S3Store")
     def test_bucket_only_passes_config_none(
         self, mock_s3_cls: MagicMock, tmp_path: Path
@@ -261,6 +266,11 @@ class TestS3EmptyConfigHardening:
 
 
 class TestS3BehaviorKnobs:
+    @pytest.fixture(autouse=True)
+    def _isolate_aws_region_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+
     @patch("obstore.store.S3Store")
     def test_endpoint_and_force_path_style(
         self, mock_s3_cls: MagicMock, tmp_path: Path
@@ -397,6 +407,24 @@ class TestS3BehaviorKnobs:
     ) -> None:
         # No region in metadata → use AWS_REGION (as Dapr's LoadDefaultConfig
         # would) instead of letting obstore silently default to us-east-1.
+        components_dir = _write_component(
+            tmp_path,
+            "objectstore",
+            "bindings.aws.s3",
+            {"bucket": "b"},
+        )
+        mock_s3_cls.return_value = MagicMock()
+        create_store_from_binding("objectstore", components_dir=components_dir)
+
+        config = mock_s3_cls.call_args.kwargs["config"]
+        assert config["aws_region"] == "ap-south-1"
+
+    @patch.dict(os.environ, {"AWS_DEFAULT_REGION": "ap-south-1"}, clear=False)
+    @patch("obstore.store.S3Store")
+    def test_region_falls_back_to_aws_default_region_env(
+        self, mock_s3_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        # AWS_REGION absent; AWS_DEFAULT_REGION is the second fallback arm.
         components_dir = _write_component(
             tmp_path,
             "objectstore",

--- a/tests/unit/storage/test_binding.py
+++ b/tests/unit/storage/test_binding.py
@@ -51,6 +51,24 @@ def _write_component(
 
 
 # ---------------------------------------------------------------------------
+# Module-level env isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_aws_region_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear AWS_REGION / AWS_DEFAULT_REGION before every test in this module.
+
+    _build_s3_config now reads these env vars as a fallback, so any test that
+    asserts on the absence of aws_region would fail on machines (or CI pods)
+    that have either var exported.  Per-test @patch.dict decorators still work
+    because they run after this fixture clears the slate.
+    """
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+
+
+# ---------------------------------------------------------------------------
 # Helper unit tests
 # ---------------------------------------------------------------------------
 
@@ -224,11 +242,6 @@ class TestS3StaticCredentials:
 
 
 class TestS3EmptyConfigHardening:
-    @pytest.fixture(autouse=True)
-    def _isolate_aws_region_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("AWS_REGION", raising=False)
-        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
-
     @patch("obstore.store.S3Store")
     def test_bucket_only_passes_config_none(
         self, mock_s3_cls: MagicMock, tmp_path: Path
@@ -266,11 +279,6 @@ class TestS3EmptyConfigHardening:
 
 
 class TestS3BehaviorKnobs:
-    @pytest.fixture(autouse=True)
-    def _isolate_aws_region_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("AWS_REGION", raising=False)
-        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
-
     @patch("obstore.store.S3Store")
     def test_endpoint_and_force_path_style(
         self, mock_s3_cls: MagicMock, tmp_path: Path
@@ -366,17 +374,20 @@ class TestS3BehaviorKnobs:
         assert client_options.get("timeout") == "90s"
         assert client_options.get("user_agent", "").startswith("atlan-application-sdk")
 
+    @pytest.mark.parametrize(
+        "endpoint", ["http://minio:9000", "HTTP://minio:9000", "Http://minio:9000"]
+    )
     @patch("obstore.store.S3Store")
     def test_http_endpoint_infers_allow_http_without_disable_ssl(
-        self, mock_s3_cls: MagicMock, tmp_path: Path
+        self, mock_s3_cls: MagicMock, tmp_path: Path, endpoint: str
     ) -> None:
-        # Dapr derives plaintext from the http:// endpoint scheme; mirror that
-        # (and the Azure branch) so an http endpoint works without disableSSL.
+        # endpoint.lower().startswith("http://") — RFC 3986 schemes are
+        # case-insensitive; test all three casing variants.
         components_dir = _write_component(
-            tmp_path,
+            tmp_path / endpoint[:4],
             "objectstore",
             "bindings.aws.s3",
-            {"bucket": "b", "endpoint": "http://minio:9000"},
+            {"bucket": "b", "endpoint": endpoint},
         )
         mock_s3_cls.return_value = MagicMock()
         create_store_from_binding("objectstore", components_dir=components_dir)
@@ -544,6 +555,35 @@ class TestS3AssumeRole:
         assert "aws_access_key_id" not in session_kwargs
         assert "aws_secret_access_key" not in session_kwargs
         assert "aws_session_token" not in session_kwargs
+
+    @patch.dict(os.environ, {"AWS_REGION": "ap-south-1"}, clear=False)
+    @patch("application_sdk.storage._credential_providers.StsCredentialProvider")
+    @patch("boto3.Session")
+    @patch("obstore.store.S3Store")
+    def test_assume_role_region_falls_back_to_env(
+        self,
+        mock_s3_cls: MagicMock,
+        mock_session_cls: MagicMock,
+        mock_sts_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        # resolved_region (binding.py L340) must flow into boto3.Session so
+        # the STS call targets the correct regional endpoint when metadata.region
+        # is absent but AWS_REGION is set (IRSA / EKS injection).
+        mock_s3_cls.return_value = MagicMock()
+        mock_sts_cls.return_value = MagicMock()
+        mock_session_cls.return_value = MagicMock()
+
+        components_dir = _write_component(
+            tmp_path,
+            "objectstore",
+            "bindings.aws.s3",
+            {"bucket": "b", "assumeRoleArn": "arn:aws:iam::123:role/MyRole"},
+        )
+        create_store_from_binding("objectstore", components_dir=components_dir)
+
+        session_kwargs = mock_session_cls.call_args.kwargs
+        assert session_kwargs.get("region_name") == "ap-south-1"
 
 
 class TestS3SecretKeyRef:
@@ -856,6 +896,72 @@ class TestAzureEndpointAndEmulator:
 
         config = mock_az_cls.call_args.kwargs["config"]
         assert config["azure_storage_endpoint"] == "http://127.0.0.1:10000"
+
+    @patch("obstore.store.AzureStore")
+    def test_http_endpoint_infers_allow_http(
+        self, mock_az_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        components_dir = _write_component(
+            tmp_path,
+            "objectstore",
+            "bindings.azure.blobstorage",
+            {
+                "accountName": "devstoreaccount1",
+                "containerName": "ctr",
+                "accountKey": "KEY==",
+                "endpoint": "http://127.0.0.1:10000",
+            },
+        )
+        mock_az_cls.return_value = MagicMock()
+        create_store_from_binding("objectstore", components_dir=components_dir)
+
+        client_options = mock_az_cls.call_args.kwargs["client_options"]
+        assert client_options["allow_http"] is True
+
+    @pytest.mark.parametrize(
+        "endpoint", ["HTTP://127.0.0.1:10000", "Http://127.0.0.1:10000"]
+    )
+    @patch("obstore.store.AzureStore")
+    def test_http_endpoint_infers_allow_http_case_insensitive(
+        self, mock_az_cls: MagicMock, tmp_path: Path, endpoint: str
+    ) -> None:
+        components_dir = _write_component(
+            tmp_path / endpoint[:4],
+            "objectstore",
+            "bindings.azure.blobstorage",
+            {
+                "accountName": "devstoreaccount1",
+                "containerName": "ctr",
+                "accountKey": "KEY==",
+                "endpoint": endpoint,
+            },
+        )
+        mock_az_cls.return_value = MagicMock()
+        create_store_from_binding("objectstore", components_dir=components_dir)
+
+        client_options = mock_az_cls.call_args.kwargs["client_options"]
+        assert client_options["allow_http"] is True
+
+    @patch("obstore.store.AzureStore")
+    def test_https_endpoint_does_not_set_allow_http(
+        self, mock_az_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        components_dir = _write_component(
+            tmp_path,
+            "objectstore",
+            "bindings.azure.blobstorage",
+            {
+                "accountName": "acct",
+                "containerName": "ctr",
+                "accountKey": "KEY==",
+                "endpoint": "https://acct.blob.core.windows.net",
+            },
+        )
+        mock_az_cls.return_value = MagicMock()
+        create_store_from_binding("objectstore", components_dir=components_dir)
+
+        client_options = mock_az_cls.call_args.kwargs["client_options"]
+        assert "allow_http" not in client_options
 
     @patch("obstore.store.AzureStore")
     def test_use_emulator_flag(self, mock_az_cls: MagicMock, tmp_path: Path) -> None:

--- a/tests/unit/storage/test_binding.py
+++ b/tests/unit/storage/test_binding.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -354,6 +355,76 @@ class TestS3BehaviorKnobs:
         client_options = mock_s3_cls.call_args.kwargs["client_options"]
         assert client_options.get("timeout") == "90s"
         assert client_options.get("user_agent", "").startswith("atlan-application-sdk")
+
+    @patch("obstore.store.S3Store")
+    def test_http_endpoint_infers_allow_http_without_disable_ssl(
+        self, mock_s3_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        # Dapr derives plaintext from the http:// endpoint scheme; mirror that
+        # (and the Azure branch) so an http endpoint works without disableSSL.
+        components_dir = _write_component(
+            tmp_path,
+            "objectstore",
+            "bindings.aws.s3",
+            {"bucket": "b", "endpoint": "http://minio:9000"},
+        )
+        mock_s3_cls.return_value = MagicMock()
+        create_store_from_binding("objectstore", components_dir=components_dir)
+
+        client_options = mock_s3_cls.call_args.kwargs["client_options"]
+        assert client_options["allow_http"] is True
+
+    @patch("obstore.store.S3Store")
+    def test_https_endpoint_does_not_set_allow_http(
+        self, mock_s3_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        components_dir = _write_component(
+            tmp_path,
+            "objectstore",
+            "bindings.aws.s3",
+            {"bucket": "b", "endpoint": "https://s3.example.com"},
+        )
+        mock_s3_cls.return_value = MagicMock()
+        create_store_from_binding("objectstore", components_dir=components_dir)
+
+        client_options = mock_s3_cls.call_args.kwargs["client_options"]
+        assert "allow_http" not in client_options
+
+    @patch.dict(os.environ, {"AWS_REGION": "ap-south-1"}, clear=False)
+    @patch("obstore.store.S3Store")
+    def test_region_falls_back_to_aws_region_env(
+        self, mock_s3_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        # No region in metadata → use AWS_REGION (as Dapr's LoadDefaultConfig
+        # would) instead of letting obstore silently default to us-east-1.
+        components_dir = _write_component(
+            tmp_path,
+            "objectstore",
+            "bindings.aws.s3",
+            {"bucket": "b"},
+        )
+        mock_s3_cls.return_value = MagicMock()
+        create_store_from_binding("objectstore", components_dir=components_dir)
+
+        config = mock_s3_cls.call_args.kwargs["config"]
+        assert config["aws_region"] == "ap-south-1"
+
+    @patch.dict(os.environ, {"AWS_REGION": "ap-south-1"}, clear=False)
+    @patch("obstore.store.S3Store")
+    def test_metadata_region_takes_precedence_over_env(
+        self, mock_s3_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        components_dir = _write_component(
+            tmp_path,
+            "objectstore",
+            "bindings.aws.s3",
+            {"bucket": "b", "region": "eu-west-1"},
+        )
+        mock_s3_cls.return_value = MagicMock()
+        create_store_from_binding("objectstore", components_dir=components_dir)
+
+        config = mock_s3_cls.call_args.kwargs["config"]
+        assert config["aws_region"] == "eu-west-1"
 
 
 class TestS3AssumeRole:


### PR DESCRIPTION
## Context

Follow-up to the v2→v3 objectstore-settings audit (DISTR-652). PR #1912 + #2025 closed the bulk of the Dapr→obstore translation gaps. This closes two remaining cases in `_build_s3_config` where **v2 (Dapr's Go binding) inferred behaviour that v3 (obstore) does not**, so the same component YAML that worked in v2 fails in v3 unless the customer adds an explicit field.

Principle: keep our defaults equal to Dapr's, while explicit overrides take precedence.

## Changes (`_build_s3_config`)

### 1. Infer `allow_http` from an `http://` endpoint
obstore's reqwest client is **https-only by default** and rejects an `http://` endpoint at request-build time (`OSError: Generic S3 error: … HTTP error: builder error`, fails in microseconds before any network I/O). Dapr derived plaintext from the endpoint URL scheme, so `disableSSL` was effectively redundant in v2.

Notably, the **Azure branch in this same file already infers `allow_http` from `http://`** — S3 was the inconsistent one. Now S3 matches:

```python
if endpoint.startswith("http://"):
    client_options["allow_http"] = True
```
Explicit `disableSSL: "true"` still works (now redundant for http). `insecureSSL` (cert *validation*) intentionally stays explicit.

### 2. Fall back to `AWS_REGION` / `AWS_DEFAULT_REGION` when `region` is absent
Dapr's S3 binding doesn't require `region`; when empty it defers to the AWS SDK's `LoadDefaultConfig` (env vars → shared config → EC2/ECS instance metadata). obstore, constructed with an explicit `config=` dict, reads **neither** env var and silently defaults to **`us-east-1`** → `301 PermanentRedirect` for buckets in any other region. Common trigger: IRSA/EKS where `AWS_REGION` is injected but no `region` is set in the component.

```python
resolved_region = (
    _nonempty(meta, "region")
    or os.environ.get("AWS_REGION", "")
    or os.environ.get("AWS_DEFAULT_REGION", "")
)
```
Explicit metadata `region` still wins, and the resolved value is reused for the assume-role STS provider.

## Safety
Both changes are **purely permissive** — `https://` endpoints and any explicitly-set fields are unaffected; this only enables what would otherwise hard-fail, matching v2/Dapr behaviour. No regression path.

## Tests
Added to `TestS3BehaviorKnobs`:
- `http://` endpoint → `allow_http` set without `disableSSL`
- `https://` endpoint → `allow_http` not set
- no metadata region + `AWS_REGION` env → `aws_region` resolved from env
- metadata region takes precedence over env

`uv run pytest tests/unit/storage/test_binding.py -k S3` → 53 passed. pre-commit clean (ruff, ruff-format, pyright, isort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)