### PR TITLE
ci(build-scan): add opt-in lfs input for the image-build checkout

### DIFF
--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -32,6 +32,11 @@ on:
         required: false
         type: boolean
         default: true
+      lfs:
+        description: "Check out git-LFS objects before building the image (default false). Set true for apps that vendor LFS-tracked assets (e.g. large parser jars) into the Docker build context — without it the build copies the LFS pointer, not the real file. Mirrors the same input on build-and-publish-app.yaml; only applied to the image-build checkout."
+        required: false
+        type: boolean
+        default: false
     secrets:
       ORG_PAT_GITHUB:
         required: true
@@ -58,6 +63,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.ref || github.ref }}
+          lfs: ${{ inputs.lfs }}
 
       - name: Read Dockerfile path
         id: meta


### PR DESCRIPTION
## Problem

`build-and-scan.yaml` builds the caller's Dockerfile (to produce an image for Trivy), but its **Build Image** checkout does not fetch git-LFS objects:

```yaml
# .github/workflows/build-and-scan.yaml — job: build
- name: Checkout
  uses: actions/checkout@…  # v6
  with:
    ref: ${{ inputs.ref || github.ref }}
    # no lfs:
```

For an app that vendors **LFS-tracked assets into the Docker build context** (e.g. the SAP ERP connector's `sapjco3.jar` SAP JCo binaries, `*.jar filter=lfs`), the build context contains the **LFS pointer file (~132 bytes), not the real artifact**, so the image build fails.

## Why it surfaced now

It was latent until #2065 bumped `actions/checkout` **v4 → v6**:

- **v4** persisted the auth token as `http.extraheader` **inside `.git/config`**. An app Dockerfile could `COPY .git ./.git` + `RUN git lfs pull` to self-serve LFS during the build — the token rode along in the copied `.git` and authenticated. This is how LFS apps built under both `build-and-publish-app.yaml` and `build-and-scan.yaml` despite neither checkout setting `lfs: true`.
- **v6** stores the token in an **external credentials file** under the runner's `_temp` dir, **outside the Docker build context**. The copied `.git` no longer has usable credentials, so the in-build `git lfs pull` fails (`could not read Username for github.com / credentials not found`) and the image build exits non-zero.

Net effect after #2065: every LFS-vendoring app's PR security gate (and merge-path reconfirm scan) is broken, with no per-caller knob to fix it — `build-and-scan.yaml` exposes only `ref`, `image`, `fail_on_findings`.

## Change

Add an opt-in `lfs` input (boolean, default `false`) and wire it into the Build Image checkout:

```yaml
inputs:
  lfs:
    type: boolean
    default: false
…
- name: Checkout
  with:
    ref: ${{ inputs.ref || github.ref }}
    lfs: ${{ inputs.lfs }}
```

This is the **exact mirror** of the `lfs` input added to `build-and-publish-app.yaml` in #2018, so the two image builds (publish + scan) have parity. LFS-vendoring apps set `lfs: true` in their caller and stop relying on the removed-credential, ship-`.git`-into-the-build pattern.

## Blast radius

- **Default `false`** → no behaviour change for existing callers.
- Only the `build` (Build Image) job's checkout is affected; `trivy-scan` downloads the built artifact and needs no source/LFS.
- Companion app-side change (sets `lfs: true` on its scan caller + drops the in-build `git lfs pull`): atlanhq/atlan-saperp-app#102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)