### PR TITLE
ci(connector-integration-tests): add application-sdk-ref input to pin SDK for cross-repo dispatch

### DIFF
--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -116,6 +116,13 @@ inputs:
       connector's main.py has NOT been migrated to the embedded runtime path yet
       and still expects external daprd at localhost:3500 + temporal at localhost:7233.
     default: "false"
+  application-sdk-ref:
+    required: false
+    description: |
+      Branch/SHA of atlanhq/application-sdk to pin before running tests.
+      Empty = use the lockfile version. Used by cross-repo dispatch from
+      application-sdk PRs to exercise the SDK branch under review.
+    default: ""
 
 runs:
   using: "composite"
@@ -124,6 +131,11 @@ runs:
       uses: atlanhq/application-sdk/.github/actions/setup-deps@main
       with:
         python-version: ${{ inputs.python-version }}
+
+    - name: Pin application-sdk to dispatched ref
+      if: inputs.application-sdk-ref != ''
+      shell: bash
+      run: uv add git+https://github.com/atlanhq/application-sdk --rev "${{ inputs.application-sdk-ref }}"
 
     # SDK 3.13+ boots an embedded daprd + Temporal directly from
     # `python main.py` (application_sdk/dev/_dapr.py + _embedded.py), each

--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -135,7 +135,12 @@ runs:
     - name: Pin application-sdk to dispatched ref
       if: inputs.application-sdk-ref != ''
       shell: bash
-      run: uv add git+https://github.com/atlanhq/application-sdk --rev "${{ inputs.application-sdk-ref }}"
+      env:
+        SDK_REF: ${{ inputs.application-sdk-ref }}
+      run: |
+        chmod +x "${{ github.action_path }}/repin-application-sdk.sh"
+        "${{ github.action_path }}/repin-application-sdk.sh"
+        uv sync --all-extras --all-groups
 
     # SDK 3.13+ boots an embedded daprd + Temporal directly from
     # `python main.py` (application_sdk/dev/_dapr.py + _embedded.py), each

--- a/.github/actions/connector-integration-tests/repin-application-sdk.sh
+++ b/.github/actions/connector-integration-tests/repin-application-sdk.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Rewrite the [tool.uv.sources] atlan-application-sdk entry in the caller
+# repo's pyproject.toml to point at a specific git ref. Invoked from
+# action.yaml when `application-sdk-ref` is supplied — i.e. on apps-sdk
+# cross-repo dispatches.
+#
+# Reads:  $SDK_REF (the commit / branch / tag to pin to)
+# Writes: pyproject.toml in CWD (the caller workspace)
+#
+# Idempotent: re-running with the same SDK_REF is a no-op diff.
+
+set -euo pipefail
+
+if [ -z "${SDK_REF:-}" ]; then
+  echo "::error::SDK_REF env var not set"
+  exit 1
+fi
+
+if [ ! -f pyproject.toml ]; then
+  echo "::error::pyproject.toml not found in $(pwd)"
+  exit 1
+fi
+
+python3 - <<PYEOF
+import os
+import pathlib
+import re
+
+ref = os.environ["SDK_REF"]
+path = pathlib.Path("pyproject.toml")
+src = path.read_text()
+
+new_line = (
+    'atlan-application-sdk = { git = '
+    f'"https://github.com/atlanhq/application-sdk", rev = "{ref}" }}'
+)
+
+# Match the entire atlan-application-sdk source pin (single-line, any
+# combination of branch/rev/tag/path inside the braces). Anchored to a
+# line start and runs to a closing brace + EOL.
+pattern = re.compile(
+    r'^atlan-application-sdk\s*=\s*\{[^}]*\}\s*$',
+    flags=re.MULTILINE,
+)
+replaced, n = pattern.subn(new_line, src)
+
+if n == 0:
+    # No existing [tool.uv.sources] entry — consumer repo uses PyPI.
+    # Insert the git override under [tool.uv.sources], creating the
+    # section if it doesn't exist.
+    if "[tool.uv.sources]" in src:
+        replaced = src.replace(
+            "[tool.uv.sources]",
+            f"[tool.uv.sources]\n{new_line}",
+            1,
+        )
+    else:
+        replaced = src + f"\n[tool.uv.sources]\n{new_line}\n"
+    print(f"No existing source pin found; inserted new entry for {ref}")
+
+if n > 1:
+    # More than one pin is ambiguous — fail loudly rather than rewriting
+    # something the user did not intend.
+    raise SystemExit(
+        f"Multiple atlan-application-sdk source pins matched ({n}); "
+        "expected exactly one."
+    )
+
+path.write_text(replaced)
+print(f"Re-pinned application-sdk to {ref}")
+PYEOF


### PR DESCRIPTION
## Summary

- Adds an `application-sdk-ref` input to the `connector-integration-tests` composite action
- When set, pins `atlan-application-sdk` to the specified branch/SHA immediately after `setup-deps` completes
- This ensures unit/integration tests in connector repos exercise the SDK branch under review when dispatched from an application-sdk PR

## Problem

Previously, connector workflows tried to pin the SDK with a manual `uv add --rev` step before calling `connector-integration-tests`. This was silently broken: the action's own internal `setup-deps` call re-checks out the connector repo (resetting `uv.lock` to the committed version), so the pin was always reverted before tests ran.

The fix moves the pin inside the action itself, after `setup-deps` completes, where it can't be clobbered.

## Test plan

- [ ] Trigger a cross-repo dispatch from an application-sdk PR against a connector repo and confirm the tests run with the dispatched SDK ref
- [ ] Confirm normal (non-dispatch) runs continue to use the lockfile version

🤖 Generated with [Claude Code](https://claude.com/claude-code)