### PR TITLE
feat(task): support schedule_to_start_timeout on @task

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -1732,6 +1732,7 @@ def _wrap_instance_tasks(app_instance: Any, context_data: dict[str, Any]) -> Non
                     task_meta.heartbeat_timeout_seconds,
                     task_meta.auto_heartbeat_seconds,
                     task_meta.retry_policy,
+                    schedule_to_start_timeout_seconds=task_meta.schedule_to_start_timeout_seconds,
                 )
                 setattr(app_instance, attr_name, wrapper)
 
@@ -1747,6 +1748,7 @@ def _create_task_activity_wrapper(
     heartbeat_timeout_seconds: int | None = 60,
     auto_heartbeat_seconds: int | None = 10,
     retry_policy: Any = None,
+    schedule_to_start_timeout_seconds: int | None = None,
 ) -> Any:
     """Create a wrapper that executes a task as a Temporal activity.
 
@@ -1761,6 +1763,8 @@ def _create_task_activity_wrapper(
         heartbeat_timeout_seconds: Heartbeat timeout. None disables.
         auto_heartbeat_seconds: Auto-heartbeat interval. None disables.
         retry_policy: Full retry policy (overrides max_attempts/interval if set).
+        schedule_to_start_timeout_seconds: Max queue-wait before a worker picks
+            the task up; fails fast on dead/non-polling workers. None disables.
 
     Returns:
         Async function that executes the task as an activity.
@@ -1808,6 +1812,14 @@ def _create_task_activity_wrapper(
             else None
         )
 
+        # Build schedule-to-start timeout if enabled (fail fast when no worker
+        # is polling the queue instead of waiting out the workflow timeout)
+        schedule_to_start_timeout = (
+            timedelta(seconds=schedule_to_start_timeout_seconds)
+            if schedule_to_start_timeout_seconds is not None
+            else None
+        )
+
         # Extract summary from input for Temporal UI display
         summary = input_data.summary() if hasattr(input_data, "summary") else None
 
@@ -1818,6 +1830,7 @@ def _create_task_activity_wrapper(
             f"{app_name}:{task_name}",
             args=[task_context, input_data],
             start_to_close_timeout=timedelta(seconds=timeout_seconds),
+            schedule_to_start_timeout=schedule_to_start_timeout,
             heartbeat_timeout=heartbeat_timeout,
             retry_policy=temporal_retry_policy,
             result_type=output_type,

--- a/application_sdk/app/task.py
+++ b/application_sdk/app/task.py
@@ -39,6 +39,11 @@ _USE_DEFAULT = object()
 # Apps that need a different per-task value pass it explicitly to @task().
 _DEFAULT_HEARTBEAT_TIMEOUT_SECONDS: int = env_int("ATLAN_HEARTBEAT_TIMEOUT_SECONDS", 60)
 _DEFAULT_TIMEOUT_SECONDS: int = env_int("ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS", 600)
+# 0 / unset means disabled (None) — schedule-to-start stays opt-in because it is
+# non-retryable by Temporal semantics: when it fires the activity fails outright.
+_DEFAULT_SCHEDULE_TO_START_TIMEOUT_SECONDS: int | None = (
+    env_int("ATLAN_SCHEDULE_TO_START_TIMEOUT_SECONDS", 0) or None
+)
 
 # Type alias for methods with single Input param returning Output
 TaskMethod = Callable[..., Any]
@@ -129,6 +134,17 @@ class TaskMetadata:
     Set to None to disable auto-heartbeating (use manual heartbeats only).
     Should be less than heartbeat_timeout_seconds (recommended: 1/6 of timeout).
     Default: 10 seconds."""
+
+    schedule_to_start_timeout_seconds: int | None = (
+        _DEFAULT_SCHEDULE_TO_START_TIMEOUT_SECONDS
+    )
+    """Maximum time in seconds an activity task may wait in the task queue
+    before a worker picks it up. When it fires, the activity fails immediately
+    (Temporal does not retry schedule-to-start timeouts — re-queuing would land
+    in the same unpolled queue), surfacing a dead/scaled-down/non-polling worker
+    in minutes instead of stalling silently until the workflow execution
+    timeout. None (the default) disables it. Defaults to the
+    ATLAN_SCHEDULE_TO_START_TIMEOUT_SECONDS env var; 0/unset means disabled."""
 
 
 def _validate_task_signature(
@@ -242,6 +258,7 @@ def task(
     retry_max_interval_seconds: int = 30,
     heartbeat_timeout_seconds: int | None | object = _USE_DEFAULT,
     auto_heartbeat_seconds: int | None | object = _USE_DEFAULT,
+    schedule_to_start_timeout_seconds: int | None | object = _USE_DEFAULT,
 ) -> Callable[[F], F]: ...
 
 
@@ -256,6 +273,7 @@ def task(
     retry_max_interval_seconds: int = 30,
     heartbeat_timeout_seconds: int | None | object = _USE_DEFAULT,
     auto_heartbeat_seconds: int | None | object = _USE_DEFAULT,
+    schedule_to_start_timeout_seconds: int | None | object = _USE_DEFAULT,
 ) -> F | Callable[[F], F]:
     """Decorator to mark a method as a task (Temporal activity).
 
@@ -333,6 +351,14 @@ def task(
         auto_heartbeat_seconds: Auto-heartbeat interval - framework sends
             heartbeats at this rate in a background task. Set to None to disable
             auto-heartbeating (manual only). Default: 10 seconds (~1/6 of timeout).
+        schedule_to_start_timeout_seconds: Maximum time in seconds the activity
+            task may sit in the task queue before a worker picks it up. When it
+            fires the activity fails immediately (schedule-to-start timeouts are
+            not retryable by Temporal design), so a dead, scaled-down, or
+            non-polling worker surfaces in minutes instead of stalling the
+            workflow until its execution timeout. None disables it. Defaults to
+            the ``ATLAN_SCHEDULE_TO_START_TIMEOUT_SECONDS`` env var; 0/unset
+            means disabled.
 
     Returns:
         The decorated function with task metadata attached.
@@ -358,6 +384,11 @@ def task(
         if auto_heartbeat_seconds is _USE_DEFAULT
         else cast("int | None", auto_heartbeat_seconds)
     )
+    resolved_schedule_to_start: int | None = (
+        _DEFAULT_SCHEDULE_TO_START_TIMEOUT_SECONDS
+        if schedule_to_start_timeout_seconds is _USE_DEFAULT
+        else cast("int | None", schedule_to_start_timeout_seconds)
+    )
 
     def decorator(fn: F) -> F:
         task_name = name or getattr(fn, "__name__", repr(fn))
@@ -379,6 +410,7 @@ def task(
             retry_max_interval_seconds=retry_max_interval_seconds,
             heartbeat_timeout_seconds=resolved_heartbeat_timeout,
             auto_heartbeat_seconds=resolved_auto_heartbeat,
+            schedule_to_start_timeout_seconds=resolved_schedule_to_start,
         )
 
         return fn

--- a/application_sdk/app/task.py
+++ b/application_sdk/app/task.py
@@ -39,10 +39,15 @@ _USE_DEFAULT = object()
 # Apps that need a different per-task value pass it explicitly to @task().
 _DEFAULT_HEARTBEAT_TIMEOUT_SECONDS: int = env_int("ATLAN_HEARTBEAT_TIMEOUT_SECONDS", 60)
 _DEFAULT_TIMEOUT_SECONDS: int = env_int("ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS", 600)
-# 0 / unset means disabled (None) — schedule-to-start stays opt-in because it is
-# non-retryable by Temporal semantics: when it fires the activity fails outright.
+# Default 5 minutes: a task sitting unpolled in the queue that long means the
+# worker is dead, scaled to zero, or saturated — fail fast instead of stalling
+# until the workflow execution timeout. Explicit 0 disables (None). Note this
+# timeout is non-retryable by Temporal semantics: when it fires the activity
+# fails outright. Tasks that fan out wider than the worker's concurrent-slot
+# capacity should raise or disable it per @task, since queued-behind-busy-slots
+# waits also count against it.
 _DEFAULT_SCHEDULE_TO_START_TIMEOUT_SECONDS: int | None = (
-    env_int("ATLAN_SCHEDULE_TO_START_TIMEOUT_SECONDS", 0) or None
+    env_int("ATLAN_SCHEDULE_TO_START_TIMEOUT_SECONDS", 300) or None
 )
 
 # Type alias for methods with single Input param returning Output
@@ -143,8 +148,11 @@ class TaskMetadata:
     (Temporal does not retry schedule-to-start timeouts — re-queuing would land
     in the same unpolled queue), surfacing a dead/scaled-down/non-polling worker
     in minutes instead of stalling silently until the workflow execution
-    timeout. None (the default) disables it. Defaults to the
-    ATLAN_SCHEDULE_TO_START_TIMEOUT_SECONDS env var; 0/unset means disabled."""
+    timeout. Defaults to the ATLAN_SCHEDULE_TO_START_TIMEOUT_SECONDS env var,
+    or 300 s (5 minutes) if unset; set the env var to 0 or pass None to
+    disable. Queue waits behind a saturated worker also count — tasks that fan
+    out wider than the worker's concurrent-slot capacity should set a larger
+    value or None."""
 
 
 def _validate_task_signature(
@@ -356,9 +364,12 @@ def task(
             fires the activity fails immediately (schedule-to-start timeouts are
             not retryable by Temporal design), so a dead, scaled-down, or
             non-polling worker surfaces in minutes instead of stalling the
-            workflow until its execution timeout. None disables it. Defaults to
-            the ``ATLAN_SCHEDULE_TO_START_TIMEOUT_SECONDS`` env var; 0/unset
-            means disabled.
+            workflow until its execution timeout. Defaults to the
+            ``ATLAN_SCHEDULE_TO_START_TIMEOUT_SECONDS`` env var, or 300 s
+            (5 minutes) if unset. Set to None (or the env var to 0) to disable.
+            Queue waits behind a saturated worker also count against it — tasks
+            that fan out wider than the worker's concurrent-slot capacity
+            should set a larger value or None.
 
     Returns:
         The decorated function with task metadata attached.

--- a/tests/unit/app/test_base.py
+++ b/tests/unit/app/test_base.py
@@ -922,6 +922,32 @@ class TestCreateTaskActivityWrapper:
             await wrapper(_BLDXInput())
         # When heartbeat is disabled the kwarg is None.
         assert exec_act.call_args.kwargs["heartbeat_timeout"] is None
+        # schedule_to_start is disabled by default.
+        assert exec_act.call_args.kwargs["schedule_to_start_timeout"] is None
+
+    @pytest.mark.asyncio
+    async def test_wrapper_passes_schedule_to_start_timeout(self) -> None:
+        from datetime import timedelta
+
+        wrapper = _create_task_activity_wrapper(
+            app_name="a",
+            task_name="t",
+            timeout_seconds=10,
+            retry_max_attempts=1,
+            retry_max_interval_seconds=1,
+            output_type=_BLDXOutput,
+            context_data={},
+            schedule_to_start_timeout_seconds=600,
+        )
+        with mock.patch(
+            "application_sdk.app.base.workflow.execute_activity",
+            new_callable=mock.AsyncMock,
+            return_value=_BLDXOutput(),
+        ) as exec_act:
+            await wrapper(_BLDXInput())
+        assert exec_act.call_args.kwargs["schedule_to_start_timeout"] == timedelta(
+            seconds=600
+        )
 
     @pytest.mark.asyncio
     async def test_wrapper_passes_explicit_retry_policy_through(self) -> None:

--- a/tests/unit/app/test_task.py
+++ b/tests/unit/app/test_task.py
@@ -190,6 +190,30 @@ class TestTaskMetadata:
         assert metadata is not None
         assert metadata.heartbeat_timeout_seconds is None
 
+    def test_task_schedule_to_start_disabled_by_default(self) -> None:
+        """schedule_to_start_timeout_seconds defaults to None (disabled)."""
+
+        class MyApp:
+            @task
+            async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                return SimpleOutput()
+
+        metadata = get_task_metadata(MyApp.my_task)
+        assert metadata is not None
+        assert metadata.schedule_to_start_timeout_seconds is None
+
+    def test_task_custom_schedule_to_start(self) -> None:
+        """Explicit schedule_to_start_timeout_seconds is preserved."""
+
+        class MyApp:
+            @task(schedule_to_start_timeout_seconds=600)
+            async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                return SimpleOutput()
+
+        metadata = get_task_metadata(MyApp.my_task)
+        assert metadata is not None
+        assert metadata.schedule_to_start_timeout_seconds == 600
+
 
 # =============================================================================
 # @task decorator - contract validation
@@ -413,3 +437,37 @@ class TestTaskEnvVarDefaults:
         monkeypatch.setenv("ATLAN_HEARTBEAT_TIMEOUT_SECONDS", "not-a-number")
         result = env_int("ATLAN_HEARTBEAT_TIMEOUT_SECONDS", 60)
         assert result == 60
+
+    def test_schedule_to_start_timeout_from_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ATLAN_SCHEDULE_TO_START_TIMEOUT_SECONDS sets the schedule-to-start default."""
+        monkeypatch.setattr(
+            self._task_module(), "_DEFAULT_SCHEDULE_TO_START_TIMEOUT_SECONDS", 600
+        )
+
+        class MyApp:
+            @task
+            async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                return SimpleOutput()
+
+        metadata = get_task_metadata(MyApp.my_task)
+        assert metadata is not None
+        assert metadata.schedule_to_start_timeout_seconds == 600
+
+    def test_explicit_schedule_to_start_overrides_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit schedule_to_start_timeout_seconds (incl. None) beats the env default."""
+        monkeypatch.setattr(
+            self._task_module(), "_DEFAULT_SCHEDULE_TO_START_TIMEOUT_SECONDS", 600
+        )
+
+        class MyApp:
+            @task(schedule_to_start_timeout_seconds=None)
+            async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                return SimpleOutput()
+
+        metadata = get_task_metadata(MyApp.my_task)
+        assert metadata is not None
+        assert metadata.schedule_to_start_timeout_seconds is None

--- a/tests/unit/app/test_task.py
+++ b/tests/unit/app/test_task.py
@@ -190,11 +190,23 @@ class TestTaskMetadata:
         assert metadata is not None
         assert metadata.heartbeat_timeout_seconds is None
 
-    def test_task_schedule_to_start_disabled_by_default(self) -> None:
-        """schedule_to_start_timeout_seconds defaults to None (disabled)."""
+    def test_task_default_schedule_to_start_is_five_minutes(self) -> None:
+        """schedule_to_start_timeout_seconds defaults to 300 s (5 minutes)."""
 
         class MyApp:
             @task
+            async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                return SimpleOutput()
+
+        metadata = get_task_metadata(MyApp.my_task)
+        assert metadata is not None
+        assert metadata.schedule_to_start_timeout_seconds == 300
+
+    def test_task_disable_schedule_to_start(self) -> None:
+        """Setting schedule_to_start_timeout_seconds=None disables it."""
+
+        class MyApp:
+            @task(schedule_to_start_timeout_seconds=None)
             async def my_task(self, input: SimpleInput) -> SimpleOutput:
                 return SimpleOutput()
 


### PR DESCRIPTION
## Problem

The v3 `@task` decorator exposes `timeout_seconds` (start-to-close) and `heartbeat_timeout_seconds`, but **no schedule-to-start timeout** — and there is no way to set one. When a worker pod dies, scales to zero, or stops polling (KEDA scale-down, spot reclaim, node drain), scheduled activity tasks sit in the task queue **silently** until the workflow's execution timeout fires.

This is not theoretical: in the SHA-1186 publish "Timed out" triage (Jun 2026), **8 of 15 failing connections burned 2–23 hours** with publish activities scheduled-but-never-started (`scheduleToStartTimeout=86400s` in their histories) before being killed at the 24–72h AE ceiling — e.g. workiva sat idle 23.4h, prgam7zp01 21.9h, pmi 13.1h. Worker-down detection that used to take ~10 minutes on v2 now takes hours.

## Solution

- New `schedule_to_start_timeout_seconds: int | None` param on `@task` (+ `TaskMetadata` field), threaded through `_create_task_activity_wrapper` → `workflow.execute_activity` (via the existing eviction-retry wrapper, which forwards kwargs unchanged).
- **Default: 300 s (5 minutes)** — a KEDA spin-up from zero lands a polling worker within ~1 min, so 5 min is a generous buffer while still surfacing a dead/non-polling worker in minutes instead of hours. (v2 publish-app used 10 min on its checkpoint activities, set activity-by-activity.)
- Env override `ATLAN_SCHEDULE_TO_START_TIMEOUT_SECONDS` (same pattern as `ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS` / `ATLAN_HEARTBEAT_TIMEOUT_SECONDS`); set to `0` to disable fleet-wide, or pass `None` per task.

## ⚠️ Behavior-change caveat for reviewers

Temporal does **not** retry schedule-to-start timeouts (re-queuing would land in the same unpolled queue), so when it fires the activity — and typically the workflow — fails. Queue waits **behind a saturated-but-alive worker count against it too**: a task that fans out wider than the worker's `max_concurrent_activities` can legitimately queue for >5 min while slots are busy and would now fail (and KEDA may not scale up if the backlog stays under its activation threshold). Such fan-out tasks (e.g. publish batches) **must override with a larger value or `None`**.

If we'd rather not fail healthy-but-busy runs at all, a follow-up could catch `TimeoutType.SCHEDULE_TO_START` in the eviction-retry loop and re-dispatch with a log line — turning this into worker-down *detection with visibility* rather than a hard failure. Happy to do that in this PR if preferred.

## Usage

```python
@task  # inherits the 5-minute default
async def setup(self, input: SetupInput) -> SetupOutput: ...

@task(schedule_to_start_timeout_seconds=3600)  # wide fan-out: batches queue behind busy slots
async def publish(self, input: PublishInput) -> PublishOutput: ...

@task(schedule_to_start_timeout_seconds=None)  # disable for this task
async def compact(self, input: CompactInput) -> CompactOutput: ...
```

## Testing

- `tests/unit/app/test_task.py`: default is 300 s, explicit value, explicit `None` disables, env-var default, explicit-None-overrides-env (mirrors existing heartbeat tests).
- `tests/unit/app/test_base.py`: wrapper forwards `schedule_to_start_timeout=timedelta(...)` to `workflow.execute_activity`; `None` when disabled.
- Full `tests/unit` run: failure set identical to clean main (pre-existing local-env failures only); ruff + pyright clean on changed files.

## Notes for reviewers

- The `tools/migrate_v3` codemod still strips `schedule_to_start_timeout` from v2 call sites (it's in `_KWARGS_TO_STRIP`); happy to follow up mapping it to the new param if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)