### PR TITLE
ci(conformance): add merge_group trigger so Full suite runs in merge queue

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -2,6 +2,7 @@ name: "Conformance"
 
 on:
   pull_request: {}
+  merge_group: {}
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary

- Adds `merge_group:` to the `on:` triggers in `conformance.yaml`
- Without it, the merge queue creates a temporary commit that neither `pull_request` nor `push` fires for — GitHub waits forever for a status that never arrives, blocking the queue

## Test plan
- [ ] Merge queue unblocks and `Full suite` reports a result (pass or fail) for queued PRs