### PR TITLE
fix(conformance): skip SARIF Security-tab upload in merge queue

### DIFF
--- a/.github/workflows/conformance-ci.yaml
+++ b/.github/workflows/conformance-ci.yaml
@@ -86,7 +86,7 @@ jobs:
           path: ci.sarif
 
       - name: "Upload SARIF to Security tab"
-        if: ${{ inputs.upload-sarif && steps.changes.outputs.workflow == 'true' }}
+        if: ${{ inputs.upload-sarif && steps.changes.outputs.workflow == 'true' && github.event_name != 'merge_group' }}
         uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: ci.sarif


### PR DESCRIPTION
## Summary

- The `codeql-action/upload-sarif` step in `conformance-ci.yaml` was failing in the merge queue (`gh-readonly-queue/...` branches) with _"Resource not accessible by integration"_ because those contexts don't have `security-events: write` access.
- Added `&& github.event_name != 'merge_group'` to the upload step's `if` condition.
- The artifact upload step directly above it is unaffected — the SARIF file is still uploaded as a workflow artifact in the merge queue, so it remains downloadable for debugging.

## Test plan

- [ ] Merge this PR via the merge queue and confirm the SARIF upload step is skipped (not failed) while the artifact upload step still runs
- [ ] Confirm the SARIF upload step still runs on normal push/PR triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)