### PR TITLE
ci(renovate): auto-approve and automerge dependency-only Renovate PRs as atlan-ci

### DIFF
--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -64,6 +64,12 @@ jobs:
       || startsWith(github.event.check_suite.head_branch, 'renovate/')
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Serialize concurrent runs for the same SHA so the idempotency check
+    # in step (f) is reliable — two check_suite completions for the same HEAD
+    # can't both pass the "no approval yet" guard in parallel.
+    concurrency:
+      group: renovate-auto-approve-${{ github.event.check_suite.head_sha || inputs.pr_number }}
+      cancel-in-progress: false
     steps:
       - name: Auto-approve if Renovate dep-only PR and all required checks are green
         env:
@@ -71,9 +77,26 @@ jobs:
           REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
           SUITE_SHA: ${{ github.event.check_suite.head_sha }}
+          SUITE_ID: ${{ github.event.check_suite.id }}
           DISPATCH_PR: ${{ inputs.pr_number }}
         run: |
           set -euo pipefail
+
+          # ── 0. Recursion guard (check_suite path only) ────────────────────────
+          # When this workflow run completes, it emits its own check_suite:
+          # completed event on the same SHA, which would re-trigger this workflow
+          # indefinitely (each no-op run fires the next). Short-circuit if the
+          # completing suite's check runs are exclusively from this workflow's own
+          # job. Mirror the guard in sdk-review-downgrade-on-ci-failure.yml.
+          if [ "$EVENT_NAME" != "workflow_dispatch" ] && [ -n "$SUITE_ID" ]; then
+            NON_OWN_RUNS=$(gh api "repos/${REPO}/check-suites/${SUITE_ID}/check-runs" \
+              --jq '[.check_runs[] | select(.name != "renovate-auto-approve")] | length' \
+              2>/dev/null || echo "0")
+            if [ "$NON_OWN_RUNS" = "0" ]; then
+              echo "Completing suite ${SUITE_ID} contains only self-owned check runs — exiting to prevent recursion."
+              exit 0
+            fi
+          fi
 
           # ── 1. Resolve candidate PR number(s) and the SHA to evaluate ────────
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
@@ -84,8 +107,14 @@ jobs:
             # A single commit can be the HEAD of multiple PRs in rare cases;
             # handle them all. Mirror the pattern from
             # sdk-review-downgrade-on-ci-failure.yml.
-            PR_NUMBERS=$(gh api "repos/${REPO}/commits/${EVAL_SHA}/pulls" \
-              --jq '.[] | select(.state == "open") | .number' 2>/dev/null || echo "")
+            #
+            # Gate the assignment on exit code — a non-2xx gh api response
+            # writes the JSON error body to stdout, which would otherwise
+            # populate PR_NUMBERS with garbage tokens.
+            if ! PR_NUMBERS=$(gh api "repos/${REPO}/commits/${EVAL_SHA}/pulls" \
+                --jq '.[] | select(.state == "open") | .number' 2>/dev/null); then
+              PR_NUMBERS=""
+            fi
           fi
 
           if [ -z "$PR_NUMBERS" ]; then

--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -1,0 +1,193 @@
+# Automatically post an atlan-ci code-owner approval on Renovate
+# dependency-only PRs once all required CI checks are green on the current HEAD.
+#
+# Why this exists:
+#   The `main` ruleset requires require_code_owner_review + 1 approving review.
+#   Renovate PRs for dependency bumps (`.github/`, `uv.lock`, `requirements.txt`,
+#   `pyproject.toml`) stall waiting for a human code owner even though CI fully
+#   validates the change. This workflow provides that approval automatically,
+#   enabling Renovate's platformAutomerge for minor/patch PRs and removing the
+#   manual approval step for all other dependency-only Renovate PRs.
+#
+# Why atlan-ci:
+#   atlan-ci is a regular GitHub User account listed in CODEOWNERS (the `*` rule).
+#   Running `gh pr review --approve` with GH_TOKEN set to ORG_PAT_GITHUB (a PAT
+#   owned by atlan-ci) posts the review as atlan-ci, satisfying
+#   require_code_owner_review. This is the same mechanism used by sdk-review.yml.
+#
+# Relationship to @sdk-review:
+#   Fully decoupled. This workflow uses the approval signature
+#   "**Renovate auto-approval:**". The sdk-review companion workflows
+#   (sdk-review-dismiss-on-human.yml, sdk-review-downgrade-on-ci-failure.yml)
+#   only act on reviews starting with "**SDK reviewer's verdict:**" and will
+#   never touch approvals posted here. Human comments do NOT auto-dismiss this
+#   approval; freshness is guaranteed by the ruleset's dismiss_stale_reviews_on_push
+#   (new commit → approval auto-dismissed → re-posted when CI is green again).
+#
+# Approval conditions (ALL must hold):
+#   1. PR author is renovate[bot]
+#   2. PR is open and not a draft
+#   3. Current HEAD SHA matches the evaluated SHA (race guard)
+#   4. Every changed file is under one of: .github/, uv.lock, requirements.txt,
+#      pyproject.toml
+#   5. All ruleset-required checks are green on the current HEAD
+#      (gh pr checks --required exits 0; non-required failures don't block)
+#   6. atlan-ci has not already posted an APPROVED review with this signature
+#      (idempotency; push-dismissed reviews are DISMISSED state, so they won't
+#      block a fresh approval after the next green suite)
+
+name: Renovate — auto-approve dependency-only PRs
+
+on:
+  check_suite:
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to evaluate (for manual testing / re-approval)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  renovate-auto-approve:
+    # For check_suite events, only fire on branches that Renovate creates.
+    # This avoids spinning up a runner for every completed suite across the
+    # entire repo — most are irrelevant to Renovate PRs. workflow_dispatch
+    # always runs (used for manual testing before this lands on main, since
+    # check_suite events only use the workflow version on the default branch).
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || startsWith(github.event.check_suite.head_branch, 'renovate/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Auto-approve if Renovate dep-only PR and all required checks are green
+        env:
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          SUITE_SHA: ${{ github.event.check_suite.head_sha }}
+          DISPATCH_PR: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          # ── 1. Resolve candidate PR number(s) and the SHA to evaluate ────────
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            EVAL_SHA=$(gh api "repos/${REPO}/pulls/${DISPATCH_PR}" --jq '.head.sha')
+            PR_NUMBERS="$DISPATCH_PR"
+          else
+            EVAL_SHA="$SUITE_SHA"
+            # A single commit can be the HEAD of multiple PRs in rare cases;
+            # handle them all. Mirror the pattern from
+            # sdk-review-downgrade-on-ci-failure.yml.
+            PR_NUMBERS=$(gh api "repos/${REPO}/commits/${EVAL_SHA}/pulls" \
+              --jq '.[] | select(.state == "open") | .number' 2>/dev/null || echo "")
+          fi
+
+          if [ -z "$PR_NUMBERS" ]; then
+            echo "No open PRs found for SHA ${EVAL_SHA} — nothing to do."
+            exit 0
+          fi
+
+          # ── 2. Evaluate each candidate PR ────────────────────────────────────
+          for PR_NUM in $PR_NUMBERS; do
+            echo "--- Evaluating PR #${PR_NUM} ---"
+
+            # Fetch all relevant PR metadata in one API call.
+            PR_META=$(gh api "repos/${REPO}/pulls/${PR_NUM}" \
+              --jq '{author: .user.login, state: .state, draft: .draft, head_sha: .head.sha}')
+            AUTHOR=$(printf '%s' "$PR_META"   | jq -r .author)
+            STATE=$(printf '%s'  "$PR_META"   | jq -r .state)
+            DRAFT=$(printf '%s'  "$PR_META"   | jq -r .draft)
+            HEAD_SHA=$(printf '%s' "$PR_META" | jq -r .head_sha)
+
+            # a. Author must be renovate[bot].
+            #    Note: `gh pr view --json author` returns the GraphQL form
+            #    "app/renovate", but the REST API returns "renovate[bot]". Use
+            #    the REST form (above) for consistency with other guard checks.
+            if [ "$AUTHOR" != "renovate[bot]" ]; then
+              echo "PR #${PR_NUM}: author is '${AUTHOR}', not renovate[bot] — skipping."
+              continue
+            fi
+
+            # b. PR must be open and not a draft.
+            if [ "$STATE" != "open" ] || [ "$DRAFT" = "true" ]; then
+              echo "PR #${PR_NUM}: state='${STATE}' draft='${DRAFT}' — skipping."
+              continue
+            fi
+
+            # c. Race guard: bail if HEAD moved since this event fired.
+            #    For workflow_dispatch, EVAL_SHA was read from the PR itself so
+            #    HEAD_SHA == EVAL_SHA by construction; the guard is still
+            #    load-bearing for the check_suite path where a push between
+            #    suite-queued and now would invalidate the check results.
+            if [ "$HEAD_SHA" != "$EVAL_SHA" ]; then
+              echo "PR #${PR_NUM}: HEAD moved (${EVAL_SHA} → ${HEAD_SHA}). Skipping — a later suite will re-evaluate."
+              continue
+            fi
+
+            # d. All changed files must be dependency-related.
+            #    Allowed: anything under .github/, or the file roots uv.lock,
+            #    requirements.txt, pyproject.toml.
+            FILENAMES=$(gh api "repos/${REPO}/pulls/${PR_NUM}/files" \
+              --paginate --jq '.[].filename')
+            if [ -z "$FILENAMES" ]; then
+              echo "PR #${PR_NUM}: no changed files found — skipping."
+              continue
+            fi
+
+            NON_DEP_FILES=$(echo "$FILENAMES" \
+              | grep -v '^\.github/' \
+              | grep -vxE 'uv\.lock|requirements\.txt|pyproject\.toml' \
+              || true)
+            if [ -n "$NON_DEP_FILES" ]; then
+              echo "PR #${PR_NUM}: contains non-dependency files:"
+              echo "$NON_DEP_FILES" | sed 's/^/  /'
+              echo "Skipping."
+              continue
+            fi
+            echo "PR #${PR_NUM}: all changed files are dependency-related."
+
+            # e. All ruleset-required checks must be green.
+            #    `gh pr checks --required` exits 0 iff every required check is
+            #    passing or skipping. Non-required failures (e.g. connector
+            #    tests) are correctly excluded. Pending required checks produce
+            #    a non-zero exit; a later check_suite completion will re-fire.
+            echo "PR #${PR_NUM}: checking required CI status..."
+            if ! gh pr checks "${PR_NUM}" --repo "${REPO}" --required; then
+              echo "PR #${PR_NUM}: required checks not yet all green — skipping."
+              continue
+            fi
+            echo "PR #${PR_NUM}: all required checks are green."
+
+            # f. Idempotency: skip if atlan-ci already has an APPROVED review
+            #    bearing our signature. Push-dismissed reviews have state
+            #    DISMISSED (not APPROVED) so they won't match here — a fresh
+            #    approval is correctly posted on the next green suite.
+            EXISTING=$(gh api "repos/${REPO}/pulls/${PR_NUM}/reviews" --paginate \
+              --jq '[.[] | select(.user.login == "atlan-ci"
+                                   and .state == "APPROVED"
+                                   and ((.body // "") | startswith("**Renovate auto-approval:**")))] | length')
+            if [ "$EXISTING" != "0" ]; then
+              echo "PR #${PR_NUM}: atlan-ci has already approved with the Renovate signature — skipping."
+              continue
+            fi
+
+            # ── 3. Post the atlan-ci code-owner approval ──────────────────────
+            # NOTE: the leading line is a STABLE SIGNATURE used by the idempotency
+            # guard above. Keep it in sync with that check if it ever changes.
+            APPROVE_BODY=$(printf '%s\n' \
+              "**Renovate auto-approval:** all required CI checks passed." \
+              "" \
+              "This is an automated code-owner approval posted by \`atlan-ci\` for a" \
+              "dependency-only Renovate PR. It is automatically dismissed on any new" \
+              "push (\`dismiss_stale_reviews_on_push\`) and re-posted once the new" \
+              "HEAD's required checks are green." \
+              "")
+            gh pr review "${PR_NUM}" --repo "${REPO}" --approve --body "$APPROVE_BODY"
+            echo "✅ Approved PR #${PR_NUM} as atlan-ci (Renovate auto-approval)."
+          done

--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -90,8 +90,8 @@ jobs:
           # job. Mirror the guard in sdk-review-downgrade-on-ci-failure.yml.
           if [ "$EVENT_NAME" != "workflow_dispatch" ] && [ -n "$SUITE_ID" ]; then
             NON_OWN_RUNS=$(gh api "repos/${REPO}/check-suites/${SUITE_ID}/check-runs" \
-              --jq '[.check_runs[] | select(.name != "renovate-auto-approve")] | length' \
-              2>/dev/null || echo "0")
+              --paginate \
+              --jq '[.check_runs[] | select(.name != "renovate-auto-approve")] | length')
             if [ "$NON_OWN_RUNS" = "0" ]; then
               echo "Completing suite ${SUITE_ID} contains only self-owned check runs — exiting to prevent recursion."
               exit 0

--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -55,9 +55,9 @@
       "platformAutomerge": true
     },
     {
-      "description": "GitHub Actions: group minor+patch; auto-merge on green.",
+      "description": "GitHub Actions: group all update types (including major) in one PR; auto-merge on green. Major action bumps are safe to auto-merge because the auto-approval workflow gates on green CI, which validates behaviour. Unlike Python deps, action majors are frequent and low-risk compared to library API changes.",
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "matchUpdateTypes": ["major", "minor", "patch", "digest"],
       "groupName": "github-actions",
       "automerge": true,
       "automergeType": "pr",


### PR DESCRIPTION
### Changelog
- Adds `.github/workflows/renovate-auto-approve.yml` — a fully automatic workflow that posts an `atlan-ci` code-owner approval on Renovate PRs when all of the following hold:
  1. PR is authored by `renovate[bot]`
  2. Every changed file is under one of `.github/`, `uv.lock`, `requirements.txt`, `pyproject.toml`
  3. All **ruleset-required** CI checks are green on the current HEAD (`gh pr checks --required` exits 0 — non-required failures don't block)
- Workflow includes a **concurrency group** keyed on `head_sha` to serialise concurrent `check_suite: completed` events and make the idempotency guard race-free
- Workflow includes a **recursion guard** that exits early if the completing suite's check runs are exclusively from this workflow's own job, preventing an infinite self-trigger loop; the guard uses `--paginate` for correctness on large CI suites and lets API failures propagate loudly via `set -euo pipefail` rather than silently no-oping
- `PR_NUMBERS` assignment is gated on the `gh api` exit code so a non-2xx response never populates the variable with garbage tokens
- Triggered by `check_suite: completed` filtered to `renovate/` branches; a `workflow_dispatch` input is provided for manual testing
- Fully decoupled from `@sdk-review`: uses the distinct approval signature `**Renovate auto-approval:**` — the sdk-review dismiss/downgrade companions never touch it
- Updates `renovate-config/default.json` to include `major` in the GitHub Actions package rule's `matchUpdateTypes` and enables `automerge`/`platformAutomerge`, so major action bumps (e.g. `actions/checkout` v4→v5) also self-merge on green CI

### Additional context (e.g. screenshots, logs, links)
- **End-to-end flow for a minor/patch Renovate PR:**
  1. Renovate opens PR → CI runs
  2. Each `check_suite: completed` event fires this workflow (job `if:` skips non-`renovate/` branches); concurrent firings queue via the concurrency group
  3. Workflow checks: recursion guard → author → file allowlist → required CI green → idempotency guard
  4. Posts `atlan-ci` approval — code-owner gate satisfied
  5. Renovate's `platformAutomerge` + the merge queue ALLGREEN policy squash-merges the PR
- Push-dismissed reviews have state `DISMISSED` (not `APPROVED`), so the idempotency guard correctly allows a fresh approval after a new commit's CI goes green
- The GitHub Actions automerge rule now covers all update types including `major`; Python and other dependency rules are unchanged

### Checklist
- [ ] Additional tests added
- [x] All CI checks passed
- [ ] Relevant documentation updated

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.