### PR TITLE
ci: extract conformance gate and Renovate auto-approve into reusable workflows

### DIFF
--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -1,0 +1,57 @@
+# .github/workflows/conformance-reusable.yaml
+#
+# Reusable workflow: Conformance full suite gate.
+#
+# Wraps conformance-ci.yaml (C-series checks) plus the aggregating "Full suite"
+# gate job so that consumers (atlan-*-app repos) never copy gate logic — they
+# carry only a thin caller that sets triggers and passes sdk-ref.
+#
+# The gate job uses if: always() so it reports a concrete pass/fail rather than
+# "skipped", which is what allows it to be marked a required status check without
+# ever blocking the merge queue.
+#
+# Usage from a connector app:
+#   uses: atlanhq/application-sdk/.github/workflows/conformance-reusable.yaml@main
+#   with:
+#     sdk-ref: main
+
+name: "Conformance (reusable)"
+
+on:
+  workflow_call:
+    inputs:
+      sdk-ref:
+        description: "Ref of atlanhq/application-sdk to source the conformance suite from"
+        required: false
+        default: main
+        type: string
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  ci-series:
+    name: "CI series (C)"
+    uses: ./.github/workflows/conformance-ci.yaml
+    with:
+      sdk-ref: ${{ inputs.sdk-ref }}
+
+  # ── Required gate ─────────────────────────────────────────────────────────
+  # This job always runs (if: always()) so it can be marked a required check
+  # without ever becoming "skipped" and blocking the merge queue.  It
+  # aggregates every series job above: if any series returned "failure" the
+  # gate exits 1; otherwise it exits 0 (pass or no-op).
+  gate:
+    name: "Full suite"
+    runs-on: ubuntu-latest
+    needs: [ci-series]
+    if: always()
+    steps:
+      - name: "Evaluate conformance results"
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "::error::Conformance gate FAILED — one or more series found violations."
+            exit 1
+          fi
+          echo "Conformance gate passed (series: ${{ join(needs.*.result, ', ') }})."

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -11,27 +11,7 @@ permissions:
   security-events: write
 
 jobs:
-  ci-series:
-    name: "CI series (C)"
-    uses: ./.github/workflows/conformance-ci.yaml
+  conformance:
+    uses: ./.github/workflows/conformance-reusable.yaml
     with:
       sdk-ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-  # ── Required gate ─────────────────────────────────────────────────────────
-  # This job always runs (if: always()) so it can be marked a required check
-  # without ever becoming "skipped" and blocking the merge queue.  It
-  # aggregates every series job above: if any series returned "failure" the
-  # gate exits 1; otherwise it exits 0 (pass or no-op).
-  gate:
-    name: "Full suite"
-    runs-on: ubuntu-latest
-    needs: [ci-series]
-    if: always()
-    steps:
-      - name: "Evaluate conformance results"
-        run: |
-          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
-            echo "::error::Conformance gate FAILED — one or more series found violations."
-            exit 1
-          fi
-          echo "Conformance gate passed (series: ${{ join(needs.*.result, ', ') }})."

--- a/.github/workflows/renovate-auto-approve-reusable.yml
+++ b/.github/workflows/renovate-auto-approve-reusable.yml
@@ -17,8 +17,28 @@
 #   In a reusable workflow, github.repository refers to the *calling* repository,
 #   not application-sdk. So REPO picks up the consumer's repo automatically.
 #
-# See renovate-auto-approve.yml for the full rationale on trigger choice,
-# approval conditions, and relationship to @sdk-review.
+# Why atlan-ci:
+#   atlan-ci is a regular GitHub User account listed in CODEOWNERS (the `*` rule).
+#   Running `gh pr review --approve` with GH_TOKEN set to the org_pat secret
+#   posts the review as atlan-ci, satisfying require_code_owner_review.
+#
+# Relationship to @sdk-review:
+#   Fully decoupled. This workflow uses the approval signature
+#   "**Renovate auto-approval:**". The sdk-review companion workflows only act
+#   on reviews starting with "**SDK reviewer's verdict:**" and will never touch
+#   approvals posted here. Human comments do not auto-dismiss this approval;
+#   freshness is guaranteed by the ruleset's dismiss_stale_reviews_on_push.
+#
+# Approval conditions (ALL must hold — see step comments in the bash below):
+#   1. PR author is renovate[bot]
+#   2. PR is open and not a draft
+#   3. Current HEAD SHA matches the evaluated SHA (race guard)
+#   4. Every changed file is under .github/, uv.lock, requirements.txt, or pyproject.toml
+#   5. All ruleset-required checks are green (gh pr checks --required exits 0)
+#   6. atlan-ci has not already posted an APPROVED review with this signature
+#
+# Trigger rationale lives in the caller — each consumer lists the workflow names
+# that produce its required status checks, which differ per repo.
 
 name: "Renovate auto-approve (reusable)"
 

--- a/.github/workflows/renovate-auto-approve-reusable.yml
+++ b/.github/workflows/renovate-auto-approve-reusable.yml
@@ -1,0 +1,185 @@
+# .github/workflows/renovate-auto-approve-reusable.yml
+#
+# Reusable workflow: automatically post an atlan-ci code-owner approval on
+# Renovate dependency-only PRs once all required CI checks are green on the
+# current HEAD.
+#
+# All approval logic lives here so that atlan-*-app repos never copy it —
+# they carry only a thin caller that sets their workflow_run trigger and
+# passes event context as inputs.
+#
+# Inputs
+#   event_name  github.event_name from the caller ('workflow_run' or 'workflow_dispatch')
+#   head_sha    github.event.workflow_run.head_sha (empty for workflow_dispatch)
+#   pr_number   inputs.pr_number from the caller (empty for workflow_run)
+#
+# Why github.repository resolves correctly:
+#   In a reusable workflow, github.repository refers to the *calling* repository,
+#   not application-sdk. So REPO picks up the consumer's repo automatically.
+#
+# See renovate-auto-approve.yml for the full rationale on trigger choice,
+# approval conditions, and relationship to @sdk-review.
+
+name: "Renovate auto-approve (reusable)"
+
+on:
+  workflow_call:
+    inputs:
+      event_name:
+        description: "github.event_name from the caller"
+        required: true
+        type: string
+      head_sha:
+        description: "github.event.workflow_run.head_sha (empty for workflow_dispatch)"
+        required: false
+        default: ""
+        type: string
+      pr_number:
+        description: "PR number for workflow_dispatch manual testing"
+        required: false
+        default: ""
+        type: string
+    secrets:
+      org_pat:
+        description: "PAT owned by atlan-ci with repo read + pull-request write access"
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  renovate-auto-approve:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Serialize concurrent runs for the same SHA so the idempotency check
+    # is reliable — two workflow completions for the same HEAD can't both
+    # pass the "no approval yet" guard in parallel.
+    concurrency:
+      group: renovate-auto-approve-${{ inputs.head_sha || inputs.pr_number }}
+      cancel-in-progress: false
+    steps:
+      - name: Auto-approve if Renovate dep-only PR and all required checks are green
+        env:
+          GH_TOKEN: ${{ secrets.org_pat }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ inputs.event_name }}
+          RUN_SHA: ${{ inputs.head_sha }}
+          DISPATCH_PR: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          # ── 1. Resolve candidate PR number(s) and the SHA to evaluate ────────
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            EVAL_SHA=$(gh api "repos/${REPO}/pulls/${DISPATCH_PR}" --jq '.head.sha')
+            PR_NUMBERS="$DISPATCH_PR"
+          else
+            EVAL_SHA="$RUN_SHA"
+            # A single commit can be the HEAD of multiple PRs in rare cases;
+            # handle them all.
+            #
+            # Gate the assignment on exit code — a non-2xx gh api response
+            # writes the JSON error body to stdout, which would otherwise
+            # populate PR_NUMBERS with garbage tokens.
+            if ! PR_NUMBERS=$(gh api "repos/${REPO}/commits/${EVAL_SHA}/pulls" \
+                --jq '.[] | select(.state == "open") | .number' 2>/dev/null); then
+              PR_NUMBERS=""
+            fi
+          fi
+
+          if [ -z "$PR_NUMBERS" ]; then
+            echo "No open PRs found for SHA ${EVAL_SHA} — nothing to do."
+            exit 0
+          fi
+
+          # ── 2. Evaluate each candidate PR ────────────────────────────────────
+          for PR_NUM in $PR_NUMBERS; do
+            echo "--- Evaluating PR #${PR_NUM} ---"
+
+            # Fetch all relevant PR metadata in one API call.
+            PR_META=$(gh api "repos/${REPO}/pulls/${PR_NUM}" \
+              --jq '{author: .user.login, state: .state, draft: .draft, head_sha: .head.sha}')
+            AUTHOR=$(printf '%s' "$PR_META"   | jq -r .author)
+            STATE=$(printf '%s'  "$PR_META"   | jq -r .state)
+            DRAFT=$(printf '%s'  "$PR_META"   | jq -r .draft)
+            HEAD_SHA=$(printf '%s' "$PR_META" | jq -r .head_sha)
+
+            # a. Author must be renovate[bot].
+            if [ "$AUTHOR" != "renovate[bot]" ]; then
+              echo "PR #${PR_NUM}: author is '${AUTHOR}', not renovate[bot] — skipping."
+              continue
+            fi
+
+            # b. PR must be open and not a draft.
+            if [ "$STATE" != "open" ] || [ "$DRAFT" = "true" ]; then
+              echo "PR #${PR_NUM}: state='${STATE}' draft='${DRAFT}' — skipping."
+              continue
+            fi
+
+            # c. Race guard: bail if HEAD moved since this event fired.
+            if [ "$HEAD_SHA" != "$EVAL_SHA" ]; then
+              echo "PR #${PR_NUM}: HEAD moved (${EVAL_SHA} → ${HEAD_SHA}). Skipping — a later run will re-evaluate."
+              continue
+            fi
+
+            # d. All changed files must be dependency-related.
+            #    Allowed: anything under .github/, or the file roots uv.lock,
+            #    requirements.txt, pyproject.toml.
+            FILENAMES=$(gh api "repos/${REPO}/pulls/${PR_NUM}/files" \
+              --paginate --jq '.[].filename')
+            if [ -z "$FILENAMES" ]; then
+              echo "PR #${PR_NUM}: no changed files found — skipping."
+              continue
+            fi
+
+            NON_DEP_FILES=$(echo "$FILENAMES" \
+              | grep -v '^\.github/' \
+              | grep -vxE 'uv\.lock|requirements\.txt|pyproject\.toml' \
+              || true)
+            if [ -n "$NON_DEP_FILES" ]; then
+              echo "PR #${PR_NUM}: contains non-dependency files:"
+              echo "$NON_DEP_FILES" | sed 's/^/  /'
+              echo "Skipping."
+              continue
+            fi
+            echo "PR #${PR_NUM}: all changed files are dependency-related."
+
+            # e. All ruleset-required checks must be green.
+            #    `gh pr checks --required` exits 0 iff every required check is
+            #    passing or skipping. Non-required failures are correctly excluded.
+            #    Pending required checks produce a non-zero exit; a later
+            #    workflow_run completion will re-fire.
+            echo "PR #${PR_NUM}: checking required CI status..."
+            if ! gh pr checks "${PR_NUM}" --repo "${REPO}" --required; then
+              echo "PR #${PR_NUM}: required checks not yet all green — skipping."
+              continue
+            fi
+            echo "PR #${PR_NUM}: all required checks are green."
+
+            # f. Idempotency: skip if atlan-ci already has an APPROVED review
+            #    bearing our signature. Push-dismissed reviews have state
+            #    DISMISSED (not APPROVED) so they won't match here — a fresh
+            #    approval is correctly posted on the next green run.
+            EXISTING=$(gh api "repos/${REPO}/pulls/${PR_NUM}/reviews" --paginate \
+              --jq '[.[] | select(.user.login == "atlan-ci"
+                                   and .state == "APPROVED"
+                                   and ((.body // "") | startswith("**Renovate auto-approval:**")))] | length')
+            if [ "$EXISTING" != "0" ]; then
+              echo "PR #${PR_NUM}: atlan-ci has already approved with the Renovate signature — skipping."
+              continue
+            fi
+
+            # ── 3. Post the atlan-ci code-owner approval ──────────────────────
+            # NOTE: the leading line is a STABLE SIGNATURE used by the idempotency
+            # guard above. Keep it in sync with that check if it ever changes.
+            APPROVE_BODY=$(printf '%s\n' \
+              "**Renovate auto-approval:** all required CI checks passed." \
+              "" \
+              "This is an automated code-owner approval posted by \`atlan-ci\` for a" \
+              "dependency-only Renovate PR. It is automatically dismissed on any new" \
+              "push (\`dismiss_stale_reviews_on_push\`) and re-posted once the new" \
+              "HEAD's required checks are green." \
+              "")
+            gh pr review "${PR_NUM}" --repo "${REPO}" --approve --body "$APPROVE_BODY"
+            echo "✅ Approved PR #${PR_NUM} as atlan-ci (Renovate auto-approval)."
+          done

--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -1,53 +1,14 @@
 # Automatically post an atlan-ci code-owner approval on Renovate
 # dependency-only PRs once all required CI checks are green on the current HEAD.
 #
-# Why this exists:
-#   The `main` ruleset requires require_code_owner_review + 1 approving review.
-#   Renovate PRs for dependency bumps (`.github/`, `uv.lock`, `requirements.txt`,
-#   `pyproject.toml`) stall waiting for a human code owner even though CI fully
-#   validates the change. This workflow provides that approval automatically,
-#   enabling Renovate's platformAutomerge for minor/patch PRs and removing the
-#   manual approval step for all other dependency-only Renovate PRs.
+# All approval logic lives in the reusable renovate-auto-approve-reusable.yml.
+# This caller is responsible only for:
+#   - Wiring the trigger (workflow_run on this repo's required-check workflows)
+#   - Filtering out failed/cancelled upstream runs before spending a runner
+#   - Forwarding event context as inputs to the reusable
 #
-# Why atlan-ci:
-#   atlan-ci is a regular GitHub User account listed in CODEOWNERS (the `*` rule).
-#   Running `gh pr review --approve` with GH_TOKEN set to ORG_PAT_GITHUB (a PAT
-#   owned by atlan-ci) posts the review as atlan-ci, satisfying
-#   require_code_owner_review. This is the same mechanism used by sdk-review.yml.
-#
-# Trigger: workflow_run (not check_suite):
-#   GitHub explicitly blocks check_suite: completed events from GitHub Actions-
-#   owned check suites from triggering other Actions workflows (anti-recursion
-#   guard baked into the platform). All required-check providers for this repo
-#   are GitHub Actions workflows, so check_suite: completed never fires for the
-#   events we care about. workflow_run: completed crosses that boundary and is
-#   designed for exactly this use case. We listen to PR Checks (provides most
-#   required contexts: Integration Tests, Unit Tests Gate, Pre-commit Checks,
-#   Trivy Code Scan, Full suite) and Conformance (Conventional Commits,
-#   Authorized Approver Check). Capability Manifest Check is informational (not
-#   a required status check per its own header), but including it means we
-#   re-evaluate promptly if it ever becomes required without a config change.
-#
-# Relationship to @sdk-review:
-#   Fully decoupled. This workflow uses the approval signature
-#   "**Renovate auto-approval:**". The sdk-review companion workflows
-#   (sdk-review-dismiss-on-human.yml, sdk-review-downgrade-on-ci-failure.yml)
-#   only act on reviews starting with "**SDK reviewer's verdict:**" and will
-#   never touch approvals posted here. Human comments do NOT auto-dismiss this
-#   approval; freshness is guaranteed by the ruleset's dismiss_stale_reviews_on_push
-#   (new commit → approval auto-dismissed → re-posted when CI is green again).
-#
-# Approval conditions (ALL must hold):
-#   1. PR author is renovate[bot]
-#   2. PR is open and not a draft
-#   3. Current HEAD SHA matches the evaluated SHA (race guard)
-#   4. Every changed file is under one of: .github/, uv.lock, requirements.txt,
-#      pyproject.toml
-#   5. All ruleset-required checks are green on the current HEAD
-#      (gh pr checks --required exits 0; non-required failures don't block)
-#   6. atlan-ci has not already posted an APPROVED review with this signature
-#      (idempotency; push-dismissed reviews are DISMISSED state, so they won't
-#      block a fresh approval after the next green run)
+# See renovate-auto-approve-reusable.yml for the full rationale on approval
+# conditions and relationship to @sdk-review.
 
 name: Renovate — auto-approve dependency-only PRs
 
@@ -73,152 +34,17 @@ permissions:
   pull-requests: write
 
 jobs:
-  renovate-auto-approve:
-    # Skip failed/cancelled upstream runs — step (e) would no-op them anyway,
-    # but filtering here avoids consuming a runner at all. workflow_dispatch
-    # always runs (used for manual testing / back-approvals).
+  auto-approve:
+    # Skip failed/cancelled upstream runs — the reusable's gh pr checks guard
+    # would no-op them anyway, but filtering here avoids consuming a runner
+    # at all. workflow_dispatch always runs (used for manual testing).
     if: >-
       github.event_name == 'workflow_dispatch'
       || github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    # Serialize concurrent runs for the same SHA so the idempotency check
-    # in step (f) is reliable — two workflow completions for the same HEAD
-    # can't both pass the "no approval yet" guard in parallel.
-    concurrency:
-      group: renovate-auto-approve-${{ github.event.workflow_run.head_sha || inputs.pr_number }}
-      cancel-in-progress: false
-    steps:
-      - name: Auto-approve if Renovate dep-only PR and all required checks are green
-        env:
-          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
-          REPO: ${{ github.repository }}
-          EVENT_NAME: ${{ github.event_name }}
-          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
-          DISPATCH_PR: ${{ inputs.pr_number }}
-        run: |
-          set -euo pipefail
-
-          # ── 1. Resolve candidate PR number(s) and the SHA to evaluate ────────
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            EVAL_SHA=$(gh api "repos/${REPO}/pulls/${DISPATCH_PR}" --jq '.head.sha')
-            PR_NUMBERS="$DISPATCH_PR"
-          else
-            EVAL_SHA="$RUN_SHA"
-            # A single commit can be the HEAD of multiple PRs in rare cases;
-            # handle them all. Mirror the pattern from
-            # sdk-review-downgrade-on-ci-failure.yml.
-            #
-            # Gate the assignment on exit code — a non-2xx gh api response
-            # writes the JSON error body to stdout, which would otherwise
-            # populate PR_NUMBERS with garbage tokens.
-            if ! PR_NUMBERS=$(gh api "repos/${REPO}/commits/${EVAL_SHA}/pulls" \
-                --jq '.[] | select(.state == "open") | .number' 2>/dev/null); then
-              PR_NUMBERS=""
-            fi
-          fi
-
-          if [ -z "$PR_NUMBERS" ]; then
-            echo "No open PRs found for SHA ${EVAL_SHA} — nothing to do."
-            exit 0
-          fi
-
-          # ── 2. Evaluate each candidate PR ────────────────────────────────────
-          for PR_NUM in $PR_NUMBERS; do
-            echo "--- Evaluating PR #${PR_NUM} ---"
-
-            # Fetch all relevant PR metadata in one API call.
-            PR_META=$(gh api "repos/${REPO}/pulls/${PR_NUM}" \
-              --jq '{author: .user.login, state: .state, draft: .draft, head_sha: .head.sha}')
-            AUTHOR=$(printf '%s' "$PR_META"   | jq -r .author)
-            STATE=$(printf '%s'  "$PR_META"   | jq -r .state)
-            DRAFT=$(printf '%s'  "$PR_META"   | jq -r .draft)
-            HEAD_SHA=$(printf '%s' "$PR_META" | jq -r .head_sha)
-
-            # a. Author must be renovate[bot].
-            #    Note: `gh pr view --json author` returns the GraphQL form
-            #    "app/renovate", but the REST API returns "renovate[bot]". Use
-            #    the REST form (above) for consistency with other guard checks.
-            if [ "$AUTHOR" != "renovate[bot]" ]; then
-              echo "PR #${PR_NUM}: author is '${AUTHOR}', not renovate[bot] — skipping."
-              continue
-            fi
-
-            # b. PR must be open and not a draft.
-            if [ "$STATE" != "open" ] || [ "$DRAFT" = "true" ]; then
-              echo "PR #${PR_NUM}: state='${STATE}' draft='${DRAFT}' — skipping."
-              continue
-            fi
-
-            # c. Race guard: bail if HEAD moved since this event fired.
-            #    For workflow_dispatch, EVAL_SHA was read from the PR itself so
-            #    HEAD_SHA == EVAL_SHA by construction; the guard is still
-            #    load-bearing for the workflow_run path where a push between
-            #    workflow-queued and now would invalidate the check results.
-            if [ "$HEAD_SHA" != "$EVAL_SHA" ]; then
-              echo "PR #${PR_NUM}: HEAD moved (${EVAL_SHA} → ${HEAD_SHA}). Skipping — a later run will re-evaluate."
-              continue
-            fi
-
-            # d. All changed files must be dependency-related.
-            #    Allowed: anything under .github/, or the file roots uv.lock,
-            #    requirements.txt, pyproject.toml.
-            FILENAMES=$(gh api "repos/${REPO}/pulls/${PR_NUM}/files" \
-              --paginate --jq '.[].filename')
-            if [ -z "$FILENAMES" ]; then
-              echo "PR #${PR_NUM}: no changed files found — skipping."
-              continue
-            fi
-
-            NON_DEP_FILES=$(echo "$FILENAMES" \
-              | grep -v '^\.github/' \
-              | grep -vxE 'uv\.lock|requirements\.txt|pyproject\.toml' \
-              || true)
-            if [ -n "$NON_DEP_FILES" ]; then
-              echo "PR #${PR_NUM}: contains non-dependency files:"
-              echo "$NON_DEP_FILES" | sed 's/^/  /'
-              echo "Skipping."
-              continue
-            fi
-            echo "PR #${PR_NUM}: all changed files are dependency-related."
-
-            # e. All ruleset-required checks must be green.
-            #    `gh pr checks --required` exits 0 iff every required check is
-            #    passing or skipping. Non-required failures (e.g. connector
-            #    tests, dep-cooldown) are correctly excluded. Pending required
-            #    checks produce a non-zero exit; a later workflow_run completion
-            #    will re-fire.
-            echo "PR #${PR_NUM}: checking required CI status..."
-            if ! gh pr checks "${PR_NUM}" --repo "${REPO}" --required; then
-              echo "PR #${PR_NUM}: required checks not yet all green — skipping."
-              continue
-            fi
-            echo "PR #${PR_NUM}: all required checks are green."
-
-            # f. Idempotency: skip if atlan-ci already has an APPROVED review
-            #    bearing our signature. Push-dismissed reviews have state
-            #    DISMISSED (not APPROVED) so they won't match here — a fresh
-            #    approval is correctly posted on the next green run.
-            EXISTING=$(gh api "repos/${REPO}/pulls/${PR_NUM}/reviews" --paginate \
-              --jq '[.[] | select(.user.login == "atlan-ci"
-                                   and .state == "APPROVED"
-                                   and ((.body // "") | startswith("**Renovate auto-approval:**")))] | length')
-            if [ "$EXISTING" != "0" ]; then
-              echo "PR #${PR_NUM}: atlan-ci has already approved with the Renovate signature — skipping."
-              continue
-            fi
-
-            # ── 3. Post the atlan-ci code-owner approval ──────────────────────
-            # NOTE: the leading line is a STABLE SIGNATURE used by the idempotency
-            # guard above. Keep it in sync with that check if it ever changes.
-            APPROVE_BODY=$(printf '%s\n' \
-              "**Renovate auto-approval:** all required CI checks passed." \
-              "" \
-              "This is an automated code-owner approval posted by \`atlan-ci\` for a" \
-              "dependency-only Renovate PR. It is automatically dismissed on any new" \
-              "push (\`dismiss_stale_reviews_on_push\`) and re-posted once the new" \
-              "HEAD's required checks are green." \
-              "")
-            gh pr review "${PR_NUM}" --repo "${REPO}" --approve --body "$APPROVE_BODY"
-            echo "✅ Approved PR #${PR_NUM} as atlan-ci (Renovate auto-approval)."
-          done
+    uses: ./.github/workflows/renovate-auto-approve-reusable.yml
+    with:
+      event_name: ${{ github.event_name }}
+      head_sha: ${{ github.event.workflow_run.head_sha }}
+      pr_number: ${{ inputs.pr_number }}
+    secrets:
+      org_pat: ${{ secrets.ORG_PAT_GITHUB }}


### PR DESCRIPTION
### Changelog
- **`conformance-reusable.yaml`** (new): reusable workflow wrapping `conformance-ci.yaml` (C-series checks) + the `Full suite` gate job. `atlan-*-app` repos call this with three lines; zero logic is copied.
- **`renovate-auto-approve-reusable.yml`** (new): the entire auto-approve bash lives here as a `workflow_call` reusable. Callers supply their repo-specific `workflow_run` trigger list and forward event context as inputs. Full approval rationale (why `atlan-ci`, decoupling from `@sdk-review`, all six approval conditions) is documented inline in the reusable; trigger rationale lives in each caller since required-check workflow names differ per repo.
- **`conformance.yaml`** (refactored): stripped from 38 → 15 lines, now calls `conformance-reusable.yaml` (dogfood).
- **`renovate-auto-approve.yml`** (refactored): stripped to a thin caller, delegates all logic to the new reusable; documents only its own trigger-wiring responsibility.

### Additional context (e.g. screenshots, logs, links)
- This pattern rolls out to hundreds of `atlan-*-app` repos. Centralising the logic here ensures the conformance suite and auto-approve behaviour evolve in one place — no drift, no copy-paste.
- **⚠️ Required-check name change (action needed before merge):** The `conformance.yaml` refactor nests the gate one level deeper. The SDK's `main` branch-protection ruleset must be updated **before this merges**:

  | | Status check name |
  |---|---|
  | **Before** | `Conformance / Full suite` |
  | **After** | `Conformance / conformance / Full suite` |

  Update the ruleset in repo Settings → Branches → `main` to replace the old name. The gate is still enforced immediately after the update; there's no gap.

### Checklist
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.