### PR TITLE
fix(conformance): grant security-events: write to conformance-ci.yaml

### DIFF
--- a/.github/workflows/conformance-ci.yaml
+++ b/.github/workflows/conformance-ci.yaml
@@ -34,6 +34,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   conformance-ci:


### PR DESCRIPTION
## Summary

One-line fix missed from #2110: `conformance-ci.yaml` needs `security-events: write` so the `Upload SARIF to Security tab` step can write to the Security tab.

The outer callers (`conformance-reusable.yaml` and `conformance.yaml`) already declare it — this makes it explicit at every level of the reusable call chain.

## Why it was missed

The fix commit was pushed to the `ci/conformance-reusable-workflows` branch after the squash merge had already happened, so it was not included in the merge.

## Test plan
- [ ] `conformance / CI series (C) / C-series checks` passes and `Upload SARIF to Security tab` step succeeds
- [ ] `conformance / Full suite` passes
- [ ] Post-merge push-to-main: SARIF upload succeeds (no more "Resource not accessible by integration" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)