### PR TITLE
ci(renovate): move ignoreDeps for private-org packages into fleet preset

### DIFF
--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -8,6 +8,10 @@
   "labels": ["dependencies"],
   "dependencyDashboard": true,
   "ignorePaths": ["requirements.txt"],
+  "ignoreDeps": [
+    "atlanhq/.github",
+    "atlanhq/mothership"
+  ],
   "gitIgnoredAuthors": ["github-actions[bot]@users.noreply.github.com"],
   "postUpdateOptions": ["uvLock"],
   "packageRules": [

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,6 @@
   ],
   "ignoreDeps": [
     "cgr.dev/atlan.com/app-framework-golden",
-    "atlanhq/.github",
     "daft"
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `atlanhq/.github` and `atlanhq/mothership` to `ignoreDeps` in `renovate-config/default.json` (the org-wide fleet preset) so that every consumer repo inherits the exclusion automatically.
- Removes `atlanhq/.github` from the application-sdk's own `renovate.json` overlay since it is now covered by the preset.

## Why

Renovate's hosted (Mend) runner was failing to look up `atlanhq/.github` and `atlanhq/mothership` as packages, recording them as \"Package lookup failures\" in the dashboard. When any dependency in a group fails to resolve, Renovate skips the **entire group PR** — so no `github-actions` or other update PRs were being raised in consumer repos.

`atlanhq/.github` was already excluded in the SDK's own `renovate.json` overlay, but that overlay is repo-specific and was never part of the shared preset. Consumer repos (e.g. `atlan-openapi-app`) were therefore not inheriting the exclusion and hitting the same lookup failures.

## Test plan

- [ ] Confirm Renovate dashboard no longer logs package-lookup failures for `atlanhq/.github` or `atlanhq/mothership` after next scheduled run
- [ ] Confirm Renovate raises `github-actions` and `python-transitive-deps` group PRs in `atlan-openapi-app` (or other consumer repos) once this preset change is live on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)