### PR TITLE
fix(renovate): switch pep621 rules from update-lockfile to bump

### DIFF
--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -16,10 +16,11 @@
   "postUpdateOptions": ["uvLock"],
   "packageRules": [
     {
-      "description": "SDK: minor+patch in one PR; auto-merge on green gate. Major bumps are manual (consumers pin >=3.0.0,<4.0.0; DeprecationWarnings precede removal by one major).",
+      "description": "SDK: minor+patch in one PR; auto-merge on green gate. Major bumps are manual (consumers pin >=3.0.0,<4.0.0; DeprecationWarnings precede removal by one major). rangeStrategy update-lockfile bumps uv.lock without touching the pyproject.toml range constraint (which already covers the new version).",
       "matchPackageNames": ["atlan-application-sdk"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "atlan-application-sdk",
+      "rangeStrategy": "update-lockfile",
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true,
@@ -48,8 +49,8 @@
       "enabled": false
     },
     {
-      "description": "Python transitive deps (all except atlan-application-sdk): group minor+patch; auto-merge on green. rangeStrategy update-lockfile keeps pyproject.toml untouched when the new version satisfies the existing constraint.",
-      "matchManagers": ["uv"],
+      "description": "Python transitive deps (all except atlan-application-sdk): group minor+patch; auto-merge on green. rangeStrategy update-lockfile keeps pyproject.toml untouched when the new version satisfies the existing constraint. Both pep621 and uv managers are listed: pep621 extracts pyproject.toml constraints + locked versions in Renovate v43+; uv is kept for forward-compatibility.",
+      "matchManagers": ["pep621", "uv"],
       "matchPackageNames": ["!atlan-application-sdk"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "python-transitive-deps",

--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -16,11 +16,11 @@
   "postUpdateOptions": ["uvLock"],
   "packageRules": [
     {
-      "description": "SDK: minor+patch in one PR; auto-merge on green gate. Major bumps are manual (consumers pin >=3.0.0,<4.0.0; DeprecationWarnings precede removal by one major). rangeStrategy update-lockfile bumps uv.lock without touching the pyproject.toml range constraint (which already covers the new version).",
+      "description": "SDK: minor+patch in one PR; auto-merge on green gate. Major bumps are manual (consumers pin >=3.0.0,<4.0.0; DeprecationWarnings precede removal by one major). rangeStrategy bump updates pyproject.toml lower bound (e.g. >=3.16.0,<4.0.0 → >=3.17.0,<4.0.0); postUpdateOptions uvLock then regenerates uv.lock. update-lockfile is not supported by pep621 in Renovate v43.",
       "matchPackageNames": ["atlan-application-sdk"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "atlan-application-sdk",
-      "rangeStrategy": "update-lockfile",
+      "rangeStrategy": "bump",
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true,
@@ -49,12 +49,12 @@
       "enabled": false
     },
     {
-      "description": "Python transitive deps (all except atlan-application-sdk): group minor+patch; auto-merge on green. rangeStrategy update-lockfile keeps pyproject.toml untouched when the new version satisfies the existing constraint. Both pep621 and uv managers are listed: pep621 extracts pyproject.toml constraints + locked versions in Renovate v43+; uv is kept for forward-compatibility.",
+      "description": "Python transitive deps (all except atlan-application-sdk): group minor+patch; auto-merge on green. rangeStrategy bump updates pyproject.toml lower bound; postUpdateOptions uvLock then regenerates uv.lock. update-lockfile is not supported by pep621 in Renovate v43. Both pep621 and uv managers are listed for forward-compatibility.",
       "matchManagers": ["pep621", "uv"],
       "matchPackageNames": ["!atlan-application-sdk"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "python-transitive-deps",
-      "rangeStrategy": "update-lockfile",
+      "rangeStrategy": "bump",
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true

--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -8,6 +8,10 @@
   "labels": ["dependencies"],
   "dependencyDashboard": true,
   "ignorePaths": ["requirements.txt"],
+  "ignoreDeps": [
+    "atlanhq/.github",
+    "atlanhq/mothership"
+  ],
   "gitIgnoredAuthors": ["github-actions[bot]@users.noreply.github.com"],
   "postUpdateOptions": ["uvLock"],
   "packageRules": [

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,6 @@
   ],
   "ignoreDeps": [
     "cgr.dev/atlan.com/app-framework-golden",
-    "atlanhq/.github",
     "daft"
   ]
 }


### PR DESCRIPTION
## What

Changes both Python dep package rules from `rangeStrategy: "update-lockfile"` to `rangeStrategy: "bump"`:
- `atlan-application-sdk` rule
- `python-transitive-deps` rule

## Why

`rangeStrategy: "update-lockfile"` is not implemented for the `pep621` manager in Renovate v43. The Renovate docs note this strategy "requires Renovate to execute the package manager to update the lockfile" — `pep621` with `uv.lock` has no such mechanism wired up. The result: silently produces `updates: []` even when newer versions exist.

Confirmed by reading the Renovate debug log: `atlan-application-sdk 3.17.0` is on PyPI (`mostRecentTimestamp: "2026-06-12T07:02:38"` differs from `currentVersionTimestamp: "2026-06-10T11:56:41"`), the fleet preset rules are loading correctly, but `branchifyUpgrades` still reports `"0 flattened updates found"`.

Same issue affects `httpx` and other transitive deps with range constraints.

With `rangeStrategy: "bump"`, Renovate updates the lower bound in `pyproject.toml` (e.g. `>=3.6.0,<4.0.0` → `>=3.17.0,<4.0.0`) and `postUpdateOptions: ["uvLock"]` regenerates `uv.lock`. This is the supported path for `pep621` in v43.

## Test plan

- [ ] Trigger a Renovate scan on `atlan-openapi-app` after this merges; expect a `renovate/atlan-application-sdk` PR bumping the lower bound from `>=3.6.0,<4.0.0` to `>=3.17.0,<4.0.0` and `uv.lock` updated to `3.17.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)