### PR TITLE
revert(renovate): undo pep621 manager changes from #2114

### DIFF
--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -16,11 +16,10 @@
   "postUpdateOptions": ["uvLock"],
   "packageRules": [
     {
-      "description": "SDK: minor+patch in one PR; auto-merge on green gate. Major bumps are manual (consumers pin >=3.0.0,<4.0.0; DeprecationWarnings precede removal by one major). rangeStrategy update-lockfile bumps uv.lock without touching the pyproject.toml range constraint (which already covers the new version).",
+      "description": "SDK: minor+patch in one PR; auto-merge on green gate. Major bumps are manual (consumers pin >=3.0.0,<4.0.0; DeprecationWarnings precede removal by one major).",
       "matchPackageNames": ["atlan-application-sdk"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "atlan-application-sdk",
-      "rangeStrategy": "update-lockfile",
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true,
@@ -49,8 +48,8 @@
       "enabled": false
     },
     {
-      "description": "Python transitive deps (all except atlan-application-sdk): group minor+patch; auto-merge on green. rangeStrategy update-lockfile keeps pyproject.toml untouched when the new version satisfies the existing constraint. Both pep621 and uv managers are listed: pep621 extracts pyproject.toml constraints + locked versions in Renovate v43+; uv is kept for forward-compatibility.",
-      "matchManagers": ["pep621", "uv"],
+      "description": "Python transitive deps (all except atlan-application-sdk): group minor+patch; auto-merge on green. rangeStrategy update-lockfile keeps pyproject.toml untouched when the new version satisfies the existing constraint.",
+      "matchManagers": ["uv"],
       "matchPackageNames": ["!atlan-application-sdk"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "python-transitive-deps",


### PR DESCRIPTION
Reverts the two changes introduced in #2114:
- removes `rangeStrategy: "update-lockfile"` from the `atlan-application-sdk` rule (not in the original)
- reverts `matchManagers` back to `["uv"]` (removes `"pep621"`)

The original config was working correctly for application-sdk; these changes were unnecessary and didn't produce the intended result in `atlan-openapi-app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)