### PR TITLE
ci(security): stop filtering no-fix CVEs in report-only Trivy scans

### DIFF
--- a/.github/scripts/security_scan_create_linear.py
+++ b/.github/scripts/security_scan_create_linear.py
@@ -52,14 +52,16 @@ LINEAR_URL = "https://api.linear.app/graphql"
 
 TRIVY_FILES = ["trivy-image-results.json", "trivy-fs-results.json"]
 
-# All severities are ticketed. The hourly scan runs with --ignore-unfixed, so
-# every finding that reaches here has an upstream fix available. "Fix available"
-# is NOT the same as "we fix it by bumping uv.lock": the fix is delivered either
-# as a dependency bump (Case 1, our dep) OR a base-image rebuild (Case 4, a
-# package baked into app-runtime-base, e.g. Dapr). --ignore-unfixed filters out
-# our-dep-no-fix CVEs, so the rover's allowlist/alternative branches (Cases 2/3)
-# don't fire today, but Case 4 is fully reachable. The rover classifies each
-# finding from the ticket — see .mothership/vuln-triage/ORCHESTRATION.md.
+# All severities are ticketed. The hourly scan no longer runs with
+# --ignore-unfixed, so findings that reach here may OR may not have an upstream
+# fix available. A fix, when one exists, is delivered either as a dependency
+# bump (Case 1, our dep) OR a base-image rebuild (Case 4, a package baked into
+# app-runtime-base, e.g. Dapr). No-fix CVEs (our-dep-no-fix and disputed/
+# won't-fix) now reach the rover too, so its allowlist/alternative branches
+# (Cases 2/3) are fully reachable — those are exactly the findings that need an
+# operational mitigation or an explicit allowlist decision rather than a bump.
+# The rover classifies each finding from the ticket — see
+# .mothership/vuln-triage/ORCHESTRATION.md.
 ACTIONABLE_SEVERITIES_TRIVY = {"CRITICAL", "HIGH", "MEDIUM", "LOW"}
 
 # Lower rank sorts first.

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -45,9 +45,13 @@ jobs:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
         run: |
+          # NOTE: intentionally NO --ignore-unfixed. This is a report-only /
+          # ticket-filing scan, so we want visibility into no-fix ("won't fix",
+          # disputed, awaiting-patch) CVEs too — they still need tracking and an
+          # operational mitigation. Keep --ignore-unfixed only on build/CI
+          # gating steps, where un-actionable findings would just wedge the build.
           trivy image \
             --scanners vuln \
-            --ignore-unfixed \
             --severity CRITICAL,HIGH,MEDIUM,LOW \
             --format json \
             --output trivy-image-results.json \
@@ -60,9 +64,10 @@ jobs:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
         run: |
+          # See note on the image scan above: report-only pass, so no
+          # --ignore-unfixed — no-fix CVEs are surfaced and ticketed.
           trivy fs \
             --scanners vuln \
-            --ignore-unfixed \
             --severity CRITICAL,HIGH,MEDIUM,LOW \
             --format json \
             --output trivy-fs-results.json \

--- a/.github/workflows/scheduled-trivy-scan.yml
+++ b/.github/workflows/scheduled-trivy-scan.yml
@@ -56,7 +56,6 @@ jobs:
         run: |
           trivy image \
             --scanners vuln \
-            --ignore-unfixed \
             --format json \
             --output trivy-image.json \
             --severity CRITICAL,HIGH \
@@ -70,7 +69,6 @@ jobs:
         run: |
           trivy image \
             --scanners vuln \
-            --ignore-unfixed \
             --format table \
             --output trivy-image.txt \
             --severity CRITICAL,HIGH \
@@ -85,7 +83,6 @@ jobs:
         run: |
           trivy fs \
             --scanners vuln \
-            --ignore-unfixed \
             --format json \
             --output trivy-deps.json \
             --severity CRITICAL,HIGH \
@@ -98,7 +95,6 @@ jobs:
         run: |
           trivy fs \
             --scanners vuln \
-            --ignore-unfixed \
             --format table \
             --output trivy-deps.txt \
             --severity CRITICAL,HIGH \

--- a/.mothership/vuln-triage/ORCHESTRATION.md
+++ b/.mothership/vuln-triage/ORCHESTRATION.md
@@ -129,11 +129,11 @@ Is the package one of OUR dependencies (in uv.lock / pyproject.toml)?
 > `app-runtime-base:3`, not `uv.lock`, so a fixed Dapr CVE is Case 4 (rebuild),
 > never Case 1 (bump).
 >
-> The scan runs with `--ignore-unfixed` (daily-security-scan.yml), so today
-> **Cases 2/3 (our dep, no fix) do not fire** — those CVEs are filtered at scan
-> time. **Case 4 is fully reachable** and is the dominant non-Case-1 path. Keep
-> Cases 2/3 documented (they revive the moment `--ignore-unfixed` is dropped),
-> but do not mistake Case 4 for a dead branch and prune it.
+> The scan runs **without** `--ignore-unfixed` (daily-security-scan.yml), so
+> **Cases 2/3 (our dep, no fix) are reachable today** — no-fix CVEs are surfaced
+> and ticketed, not filtered at scan time. **Case 4 is also fully reachable** and
+> remains the dominant non-Case-1 path. Do not mistake Case 4 for a dead branch
+> and prune it.
 
 Print: `[Stage 3/6 complete] <c1> draft-PR, <c2> allowlist, <c3> alternative, <c4> base-image, <k> killed`
 
@@ -171,14 +171,14 @@ git checkout -b fix/bump-<pkg>-<version>-<cve-id> origin/main
 5. Link the draft PR on the ticket and tag Vaibhav/Chris to review + finalize.
    Do **not** comment `@sdk-review`, do **not** mark ready, do **not** merge.
 
-### 4b. Case 2 — recommend temporary allowlist (our dep, no fix, upstream alive) — _not reached while `--ignore-unfixed` is set_
+### 4b. Case 2 — recommend temporary allowlist (our dep, no fix, upstream alive)
 
 1. **Exposure analysis:** does the SDK actually exercise the vulnerable path?
    State the conclusion explicitly.
 2. Detail on the ticket: the proposed allowlist entry + the exposure analysis.
    **Do not commit it.** Tag Vaibhav/Chris for approval.
 
-### 4c. Case 3 — recommend an alternative (our dep, no fix, upstream dead) — _not reached while `--ignore-unfixed` is set_
+### 4c. Case 3 — recommend an alternative (our dep, no fix, upstream dead)
 
 Detail on the ticket: the package, why no bump is possible (upstream
 archived/unmaintained — link the evidence), and a proposed alternative


### PR DESCRIPTION
## Why

Our hourly scan (`daily-security-scan.yml`) reported **0 findings** while real CVEs were live in our images/deps. One root cause is `--ignore-unfixed`: it silently drops every CVE that has **no upstream fix** (won't-fix, disputed, or awaiting-patch). Example: **CVE-2018-20225** (pip dependency-confusion, disputed/won't-fix) is in scope of the filesystem scan but was filtered out before it could ever be counted or ticketed.

For a **report-only / ticket-filing** scan, that's the wrong default — its job is *visibility*. No-fix CVEs still need tracking and an operational mitigation (e.g. pin `--index-url`, claim package names), even when there's no version to bump to.

> Note: `--ignore-unfixed` is only one of three reasons that scan misses CVEs. The other two (it scans the **base** image + Python lockfile, not the built **app** images; and Go binaries shipped as apk packages like `daprd` are matched only against the Chainguard feed, not the Go vuln DB) are **not** addressed here — they're separate, larger changes.

## What

Removes `--ignore-unfixed` from the two **report-only** scans:
- `.github/workflows/daily-security-scan.yml` (hourly image + fs scan)
- `.github/workflows/scheduled-trivy-scan.yml` (twice-weekly image + deps scan; already `--exit-code 0`)

Leaves the flag **in place** on all **build/CI gating** steps, where un-actionable findings would just wedge the pipeline with no path forward:
- `.github/actions/trivy/action.yaml`
- `.github/actions/trivy-container/action.yaml`
- `.github/actions/secure-build-push-apps/action.yaml`
- `.github/workflows/build-apps-image.yaml`

Also updates the rover comment in `security_scan_create_linear.py`: no-fix CVEs now reach triage, so its allowlist / alternative-mitigation branches (Cases 2/3) become reachable.

## Expected impact

Ticket volume from the report-only scans will rise — the new tickets include CVEs with no version bump available. The vuln-triage rover already has branches to classify these (allowlist / operational mitigation); if volume is noisy, follow-up by tuning the rover's triage states rather than re-adding the filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)