### PR TITLE
chore(security): allowlist GHSA-36hh-v3qg-5jq4 (pyo3 0.25.1, transitive via temporalio)

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,10 +1,20 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Updated by SDK team. CODEOWNERS: SDK/security team only.",
   "_base_image": "application-sdk-main",
-  "_updated": "2026-06-09",
+  "_updated": "2026-06-13",
   "_renewal_note": "Expiry dates staggered by severity. CRITICAL: 15 days. HIGH: 30 days. Review before expiry. Enforced by .github/scripts/validate_allowlist.py via _expiry_policy below.",
   "_expiry_policy": {
     "CRITICAL": 15,
     "HIGH": 30
+  },
+  "GHSA-36hh-v3qg-5jq4": {
+    "package": "pyo3",
+    "severity": "HIGH",
+    "reason": "Transitive Rust CVE bundled inside temporalio's compiled bridge (temporalio/bridge/Cargo.lock -> pyo3 0.25.1); not a directly-pinnable Python dependency. No temporalio release ships the fix yet -- the latest, 1.28.0 (2026-06-04), still bundles pyo3 0.25.1, so no upgrade resolves it. The advisory is an out-of-bounds READ in PyO3's Iterator::nth / nth_back for PyList/PyTuple iterators, reachable only when Rust calls .nth(n) with an attacker-controlled large n on a Python list/tuple iterator -- a path internal to the Temporal SDK bridge that is not reachable from connector or workflow-input code. Re-evaluate and drop this entry when temporalio bumps pyo3 to >= 0.29.0.",
+    "expires": "2026-07-13",
+    "added_by": "hariharan.radhakrishnan@atlan.com",
+    "re_evaluation_trigger": "fix_released",
+    "fix_available_date": "",
+    "suppressed": false
   }
 }


### PR DESCRIPTION
## Summary

Allowlists `GHSA-36hh-v3qg-5jq4` (HIGH) — **`pyo3 0.25.1`**, a transitive Rust dependency bundled inside **temporalio's compiled bridge** (`temporalio/bridge/Cargo.lock`). It is not a directly-pinnable Python package, and **no temporalio release ships the fix yet** — the latest, `1.28.0` (2026-06-04), still bundles `pyo3 0.25.1`, so no version bump resolves it.

This currently fails the security gate on **every** connector PR that builds on the SDK base image (first surfaced on `atlanhq/atlan-bigquery-app#152`, but unrelated to that change).

## Risk assessment

The advisory is an **out-of-bounds read** in PyO3's `Iterator::nth` / `nth_back` for `PyList`/`PyTuple` iterators (integer overflow in `index + n` before the bounds check). It is reachable **only** when Rust calls `.nth(n)` with an attacker-controlled large `n` on a Python list/tuple iterator — a code path internal to the Temporal SDK bridge, **not reachable from connector code or workflow input**. No write primitive; read-only.

## Entry

```json
"GHSA-36hh-v3qg-5jq4": {
  "package": "pyo3",
  "severity": "HIGH",
  "expires": "2026-07-13",
  "re_evaluation_trigger": "fix_released",
  "fix_available_date": "",
  "added_by": "hariharan.radhakrishnan@atlan.com"
}
```

- **HIGH**, expires **2026-07-13** (30-day window per `_expiry_policy`).
- **Drop trigger:** remove when `temporalio` bumps `pyo3 ≥ 0.29.0`.

## Validation

- `python3 .github/scripts/validate_allowlist.py` → ✅ `Allowlist valid: 1 entry, all within policy`
- Simulated `check_allowlist.py` against the real bigquery-app Trivy report → only CRITICAL/HIGH finding is now **ALLOWED**, gate **PASS**.

> Requires SDK/security CODEOWNERS approval (allowlist is owned by the SDK/security team).

🤖 Generated with [Claude Code](https://claude.com/claude-code)