### PR TITLE
ci(security): scan installed deps so the hourly scan catches Rust-in-wheel CVEs

### DIFF
--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -57,15 +57,41 @@ jobs:
             --output trivy-image-results.json \
             "$TARGET_IMAGE"
 
-      # ── Trivy filesystem scan (uv.lock / pyproject.toml) ─────────────────
+      # ── Install SDK dependencies so vendored native lockfiles materialize ──
+      #
+      # Rust/Go/native crates bundled inside Python wheels only exist on disk
+      # once the wheel is INSTALLED. e.g. temporalio ships a compiled bridge
+      # whose temporalio/bridge/Cargo.lock pins pyo3 — a transitive Rust CVE
+      # (GHSA-36hh-v3qg-5jq4). The source tree names `temporalio` as a Python
+      # dep in uv.lock but never contains that Cargo.lock, so a source-only
+      # `trivy fs` cannot see it — which is why pyo3 first surfaced on a
+      # downstream connector image, not in this SDK scan. Syncing into .venv
+      # lays those vendored manifests on disk so the filesystem scan below
+      # reaches them. Verified locally with Trivy v0.70.0: `trivy fs .` reports
+      # pyo3/GHSA-36hh-v3qg-5jq4 from .venv/.../temporalio/bridge/Cargo.lock.
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+      - name: Sync SDK dependencies into .venv
+        run: uv sync --all-extras --all-groups
 
-      - name: Trivy filesystem scan (uv.lock / pyproject.toml)
+      # ── Trivy filesystem scan (source lockfiles + installed .venv wheels) ──
+
+      - name: Trivy filesystem scan (lockfiles + installed wheel artifacts)
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
         run: |
           # See note on the image scan above: report-only pass, so no
           # --ignore-unfixed — no-fix CVEs are surfaced and ticketed.
+          #
+          # Scans the repo root, which now includes the synced .venv — so
+          # native lockfiles vendored inside installed wheels (Rust Cargo.lock,
+          # etc.) are covered, not just the Python uv.lock. This is what lets
+          # the SDK scan catch transitive Rust CVEs like pyo3
+          # (GHSA-36hh-v3qg-5jq4) at the source instead of only in downstream
+          # connector images.
           trivy fs \
             --scanners vuln \
             --severity CRITICAL,HIGH,MEDIUM,LOW \
@@ -148,7 +174,7 @@ jobs:
               fi
 
               if [ "$((TF_CRIT + TF_HIGH + TF_MED + TF_LOW))" -gt 0 ]; then
-                echo "### Trivy — Python Deps (uv.lock / pyproject.toml)"
+                echo "### Trivy — SDK Deps (lockfiles + installed wheel artifacts)"
                 echo ""
                 echo "| Severity | Package | Installed | Fixed | CVE |"
                 echo "|----------|---------|-----------|-------|-----|"
@@ -176,7 +202,7 @@ jobs:
             echo ""
             echo "### Vulnerability Summary"
             echo ""
-            echo "| Severity | Trivy (Image) | Trivy (Python) | Total |"
+            echo "| Severity | Trivy (Image) | Trivy (Deps) | Total |"
             echo "|----------|:-------------:|:--------------:|------:|"
             echo "| 🔴 Critical | ${{ steps.parse.outputs.ti_crit || 0 }} | ${{ steps.parse.outputs.tf_crit || 0 }} | **${{ steps.parse.outputs.total_crit || 0 }}** |"
             echo "| 🟠 High     | ${{ steps.parse.outputs.ti_high || 0 }} | ${{ steps.parse.outputs.tf_high || 0 }} | **${{ steps.parse.outputs.total_high || 0 }}** |"


### PR DESCRIPTION
## Problem

The hourly security scan (`daily-security-scan.yml`) has a **blind spot for native crates bundled inside Python wheels** — exactly the class of the recent pyo3 finding (`GHSA-36hh-v3qg-5jq4`, HIGH).

It scans two things, and pyo3 lives in neither:
- `trivy image` on `app-runtime-base:3` — the **base image**, which has **no SDK deps installed**, so temporalio's compiled bridge isn't present.
- `trivy fs .` on the **source tree** — `uv.lock` names `temporalio` as a Python dependency but **never contains** the Rust crate. pyo3 only exists inside the *installed* temporalio wheel, at `…/temporalio/bridge/Cargo.lock`.

Net result: pyo3 first surfaced on a **downstream connector image** (`atlan-bigquery-app`) and failed *its* security gate — but the SDK's own hourly scan reported **0**, even though the SDK is the source of the dependency. Same Trivy, same DB — the SDK scan just never pointed Trivy at a place where the vendored `Cargo.lock` exists.

## Fix

Install the SDK's dependencies into `.venv` **before** the filesystem scan, so vendored native lockfiles land on disk:

```yaml
- uses: astral-sh/setup-uv@…  # v8.2.0
- run: uv sync --all-extras --all-groups
```

`trivy fs .` already recurses into `.venv`, so the vendored `Cargo.lock` flows into the existing `trivy-fs-results.json` — **no change** to the parse / summary / Linear-ticket pipeline (it reads that same file). Only cosmetic relabels: "Python Deps" → "SDK Deps (lockfiles + installed wheel artifacts)".

## Verification

⚠️ **The real gate is this PR's own scan run** — it must now **show `pyo3` / `GHSA-36hh-v3qg-5jq4` appearing**. A green run reporting 0 would mean the fix didn't take; don't read "workflow passed" as "coverage added."

Verified locally with the **pinned Trivy v0.70.0**:

```
uv venv && uv pip install temporalio==1.27.2
trivy fs --scanners vuln --severity HIGH,CRITICAL .
# → pyo3  GHSA-36hh-v3qg-5jq4  HIGH  0.25.1 → 0.29.0
#   from .venv/lib/python3.13/site-packages/temporalio/bridge/Cargo.lock
```

Both `trivy fs .` and `trivy fs .venv` detect it; keeping `.` since it also retains the source-lockfile coverage.

## Expected side effects / follow-ups

- **First-run ticket may be larger.** Scanning the full synced `.venv` surfaces every installed package's CVEs at once. Dedup-by-`VulnerabilityID` in `security_scan_create_linear.py` collapses repeats against open issues, so it won't refile each run — but the first ticket after merge will be bigger than usual. Expected, not alarming.
- **Known gap — rover routing (separate PR).** Surfacing pyo3 is only half the loop. `.mothership/vuln-triage/ORCHESTRATION.md` routes on "is the package in `uv.lock` / `pyproject.toml`?" — pyo3 is in **neither** (it's inside the temporalio wheel), so the rover would route it to **Case 4 (base-image rebuild)**, which is wrong; the human allowlist correctly treated it as **Case 2 (our dep, no fix, upstream alive)**. This change makes that path newly reachable, so the routing heuristic should learn "transitive native crate inside one of our wheels → Case 2." Flagging for a follow-up; out of scope here.
- **Bi-weekly scan.** `scheduled-trivy-scan.yml` likely has the same blind spot — can apply the same install-then-scan there in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)