### PR TITLE
fix(renovate): throttle lockFileMaintenance to at most twice per hour

### DIFF
--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -14,9 +14,9 @@
   ],
   "gitIgnoredAuthors": ["github-actions[bot]@users.noreply.github.com"],
   "lockFileMaintenance": {
-    "description": "Python in-range deps: refresh uv.lock without touching pyproject.toml; auto-merge on green.",
+    "description": "Python in-range deps: refresh uv.lock without touching pyproject.toml; auto-merge on green. Runs at most twice per hour (at :00 and :30) to avoid a continuous-merge feedback loop.",
     "enabled": true,
-    "schedule": ["at any time"],
+    "schedule": ["every 30 minutes"],
     "automerge": true,
     "automergeType": "pr",
     "platformAutomerge": true


### PR DESCRIPTION
## Summary

- Changes `lockFileMaintenance.schedule` from `"at any time"` to `"every 30 minutes"` in the shared Renovate fleet config
- `"every 30 minutes"` is valid [later.js](https://bunkat.github.io/later/parsers.html#text) syntax — fires at `:00` and `:30` each hour
- Mend Renovate runs on webhook events, so the `schedule` field gates *when it's allowed to act*: a PR that merges at `:07` will cause Renovate to defer until `:30` before opening the next one

## Why

`"at any time"` + `prHourlyLimit: 0` + auto-merge created a continuous feedback loop across all `atlan-*-app` repos: each lock file maintenance PR merged in ~7 minutes and immediately triggered the next one, cycling indefinitely. This was generating 8–10 PRs/hour per repo with no end in sight.

## Test plan

- [ ] Confirm Renovate accepts the schedule (no config error in Dependency Dashboard)
- [ ] Observe that lock file maintenance PRs in `atlan-*-app` repos no longer fire back-to-back; gap between consecutive PRs should be ~30 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)