### PR TITLE
ci(conformance): only upload SARIF to Security tab on push to main

### DIFF
--- a/.github/workflows/conformance-ci.yaml
+++ b/.github/workflows/conformance-ci.yaml
@@ -52,15 +52,8 @@ jobs:
             relevant:
               - '${{ inputs.scan-path }}/**'
 
-      - name: "No relevant changes — emit empty SARIF"
-        if: steps.changes.outputs.relevant == 'false'
-        run: |
-          printf '{"$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","version":"2.1.0","runs":[{"tool":{"driver":{"name":"atlan-conformance","version":"0.0.0"}},"results":[]}]}\n' \
-            > ci-upload.sarif
-          echo "No .github changes; C-series gate passes."
-
       - name: "Sparse-checkout conformance suite"
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: atlanhq/application-sdk
@@ -69,11 +62,11 @@ jobs:
           path: _sdk
 
       - name: "Set up uv"
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: "Run C-series checks"
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
         env:
           PYTHONPATH: _sdk/conformance
         run: |
@@ -83,20 +76,20 @@ jobs:
             --output ci.sarif
 
       - name: "Upload SARIF artifact"
-        if: steps.changes.outputs.relevant == 'true' && !cancelled()
+        if: (steps.changes.outputs.relevant == 'true' || github.event_name == 'push') && !cancelled()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: conformance-ci-sarif
           path: ci.sarif
 
       - name: "Strip suppressed results for Security tab"
-        if: ${{ inputs.upload-sarif && steps.changes.outputs.relevant == 'true' && github.event_name != 'merge_group' }}
+        if: ${{ inputs.upload-sarif && github.event_name == 'push' }}
         run: |
           jq '.runs[] |= (.results |= map(select(.suppressions == null or (.suppressions | length == 0))))' \
             ci.sarif > ci-upload.sarif
 
       - name: "Upload SARIF to Security tab"
-        if: ${{ inputs.upload-sarif && github.event_name != 'merge_group' }}
+        if: ${{ inputs.upload-sarif && github.event_name == 'push' }}
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: ci-upload.sarif

--- a/.github/workflows/conformance-ci.yaml
+++ b/.github/workflows/conformance-ci.yaml
@@ -31,6 +31,11 @@ on:
         required: false
         default: true
         type: boolean
+      event_name:
+        description: "Caller's github.event_name (push / pull_request / merge_group); reusable workflows always see 'workflow_call' internally"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -53,7 +58,7 @@ jobs:
               - '${{ inputs.scan-path }}/**'
 
       - name: "Sparse-checkout conformance suite"
-        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
+        if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: atlanhq/application-sdk
@@ -62,11 +67,11 @@ jobs:
           path: _sdk
 
       - name: "Set up uv"
-        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
+        if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push'
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: "Run C-series checks"
-        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
+        if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push'
         env:
           PYTHONPATH: _sdk/conformance
         run: |
@@ -76,20 +81,20 @@ jobs:
             --output ci.sarif
 
       - name: "Upload SARIF artifact"
-        if: (steps.changes.outputs.relevant == 'true' || github.event_name == 'push') && !cancelled()
+        if: (steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push') && !cancelled()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: conformance-ci-sarif
           path: ci.sarif
 
       - name: "Strip suppressed results for Security tab"
-        if: ${{ inputs.upload-sarif && github.event_name == 'push' }}
+        if: ${{ inputs.upload-sarif && inputs.event_name == 'push' }}
         run: |
           jq '.runs[] |= (.results |= map(select(.suppressions == null or (.suppressions | length == 0))))' \
             ci.sarif > ci-upload.sarif
 
       - name: "Upload SARIF to Security tab"
-        if: ${{ inputs.upload-sarif && github.event_name == 'push' }}
+        if: ${{ inputs.upload-sarif && inputs.event_name == 'push' }}
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: ci-upload.sarif

--- a/.github/workflows/conformance-error-handling.yaml
+++ b/.github/workflows/conformance-error-handling.yaml
@@ -52,15 +52,8 @@ jobs:
             relevant:
               - '**/*.py'
 
-      - name: "No relevant changes — emit empty SARIF"
-        if: steps.changes.outputs.relevant == 'false'
-        run: |
-          printf '{"$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","version":"2.1.0","runs":[{"tool":{"driver":{"name":"atlan-conformance","version":"0.0.0"}},"results":[]}]}\n' \
-            > error-handling-upload.sarif
-          echo "No .py changes; E-series gate passes."
-
       - name: "Sparse-checkout conformance suite"
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: atlanhq/application-sdk
@@ -69,11 +62,11 @@ jobs:
           path: _sdk
 
       - name: "Set up uv"
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: "Run E-series checks"
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
         env:
           PYTHONPATH: _sdk/conformance
         run: |
@@ -83,20 +76,20 @@ jobs:
             --output error-handling.sarif
 
       - name: "Upload SARIF artifact"
-        if: steps.changes.outputs.relevant == 'true' && !cancelled()
+        if: (steps.changes.outputs.relevant == 'true' || github.event_name == 'push') && !cancelled()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: conformance-error-handling-sarif
           path: error-handling.sarif
 
       - name: "Strip suppressed results for Security tab"
-        if: ${{ inputs.upload-sarif && steps.changes.outputs.relevant == 'true' && github.event_name != 'merge_group' }}
+        if: ${{ inputs.upload-sarif && github.event_name == 'push' }}
         run: |
           jq '.runs[] |= (.results |= map(select(.suppressions == null or (.suppressions | length == 0))))' \
             error-handling.sarif > error-handling-upload.sarif
 
       - name: "Upload SARIF to Security tab"
-        if: ${{ inputs.upload-sarif && github.event_name != 'merge_group' }}
+        if: ${{ inputs.upload-sarif && github.event_name == 'push' }}
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: error-handling-upload.sarif

--- a/.github/workflows/conformance-error-handling.yaml
+++ b/.github/workflows/conformance-error-handling.yaml
@@ -31,6 +31,11 @@ on:
         required: false
         default: true
         type: boolean
+      event_name:
+        description: "Caller's github.event_name (push / pull_request / merge_group); reusable workflows always see 'workflow_call' internally"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -53,7 +58,7 @@ jobs:
               - '**/*.py'
 
       - name: "Sparse-checkout conformance suite"
-        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
+        if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: atlanhq/application-sdk
@@ -62,11 +67,11 @@ jobs:
           path: _sdk
 
       - name: "Set up uv"
-        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
+        if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push'
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: "Run E-series checks"
-        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
+        if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push'
         env:
           PYTHONPATH: _sdk/conformance
         run: |
@@ -76,20 +81,20 @@ jobs:
             --output error-handling.sarif
 
       - name: "Upload SARIF artifact"
-        if: (steps.changes.outputs.relevant == 'true' || github.event_name == 'push') && !cancelled()
+        if: (steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push') && !cancelled()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: conformance-error-handling-sarif
           path: error-handling.sarif
 
       - name: "Strip suppressed results for Security tab"
-        if: ${{ inputs.upload-sarif && github.event_name == 'push' }}
+        if: ${{ inputs.upload-sarif && inputs.event_name == 'push' }}
         run: |
           jq '.runs[] |= (.results |= map(select(.suppressions == null or (.suppressions | length == 0))))' \
             error-handling.sarif > error-handling-upload.sarif
 
       - name: "Upload SARIF to Security tab"
-        if: ${{ inputs.upload-sarif && github.event_name == 'push' }}
+        if: ${{ inputs.upload-sarif && inputs.event_name == 'push' }}
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: error-handling-upload.sarif

--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -55,6 +55,11 @@ on:
         required: false
         default: true
         type: boolean
+      event_name:
+        description: "Caller's github.event_name (push / pull_request / merge_group); reusable workflows always see 'workflow_call' internally"
+        required: false
+        default: ""
+        type: string
       exclude-paths-c:
         description: >
           Comma-separated repo-root-relative path prefixes to exclude from C-series
@@ -92,7 +97,7 @@ jobs:
               - '.github/**'
 
       - name: "Sparse-checkout conformance suite"
-        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
+        if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: atlanhq/application-sdk
@@ -101,11 +106,11 @@ jobs:
           path: _sdk
 
       - name: "Set up uv"
-        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
+        if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push'
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: "Run C-series checks"
-        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
+        if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push'
         env:
           PYTHONPATH: _sdk/conformance
         run: |
@@ -116,20 +121,20 @@ jobs:
             ${{ inputs.exclude-paths-c != '' && format('--exclude "{0}"', inputs.exclude-paths-c) || '' }}
 
       - name: "Upload SARIF artifact"
-        if: (steps.changes.outputs.relevant == 'true' || github.event_name == 'push') && !cancelled()
+        if: (steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push') && !cancelled()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: conformance-ci-sarif
           path: ci.sarif
 
       - name: "Strip suppressed results for Security tab"
-        if: ${{ inputs.upload-sarif && github.event_name == 'push' }}
+        if: ${{ inputs.upload-sarif && inputs.event_name == 'push' }}
         run: |
           jq '.runs[] |= (.results |= map(select(.suppressions == null or (.suppressions | length == 0))))' \
             ci.sarif > ci-upload.sarif
 
       - name: "Upload SARIF to Security tab"
-        if: ${{ inputs.upload-sarif && github.event_name == 'push' }}
+        if: ${{ inputs.upload-sarif && inputs.event_name == 'push' }}
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: ci-upload.sarif
@@ -151,7 +156,7 @@ jobs:
               - '**/*.py'
 
       - name: "Sparse-checkout conformance suite"
-        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
+        if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: atlanhq/application-sdk
@@ -160,11 +165,11 @@ jobs:
           path: _sdk
 
       - name: "Set up uv"
-        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
+        if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push'
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: "Run E-series checks"
-        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
+        if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push'
         env:
           PYTHONPATH: _sdk/conformance
         run: |
@@ -175,20 +180,20 @@ jobs:
             ${{ inputs.exclude-paths-e != '' && format('--exclude "{0}"', inputs.exclude-paths-e) || '' }}
 
       - name: "Upload SARIF artifact"
-        if: (steps.changes.outputs.relevant == 'true' || github.event_name == 'push') && !cancelled()
+        if: (steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push') && !cancelled()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: conformance-error-handling-sarif
           path: error-handling.sarif
 
       - name: "Strip suppressed results for Security tab"
-        if: ${{ inputs.upload-sarif && github.event_name == 'push' }}
+        if: ${{ inputs.upload-sarif && inputs.event_name == 'push' }}
         run: |
           jq '.runs[] |= (.results |= map(select(.suppressions == null or (.suppressions | length == 0))))' \
             error-handling.sarif > error-handling-upload.sarif
 
       - name: "Upload SARIF to Security tab"
-        if: ${{ inputs.upload-sarif && github.event_name == 'push' }}
+        if: ${{ inputs.upload-sarif && inputs.event_name == 'push' }}
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: error-handling-upload.sarif

--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -91,15 +91,8 @@ jobs:
             relevant:
               - '.github/**'
 
-      - name: "No relevant changes — emit empty SARIF"
-        if: steps.changes.outputs.relevant == 'false'
-        run: |
-          printf '{"$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","version":"2.1.0","runs":[{"tool":{"driver":{"name":"atlan-conformance","version":"0.0.0"}},"results":[]}]}\n' \
-            > ci-upload.sarif
-          echo "No .github changes; C-series gate passes."
-
       - name: "Sparse-checkout conformance suite"
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: atlanhq/application-sdk
@@ -108,11 +101,11 @@ jobs:
           path: _sdk
 
       - name: "Set up uv"
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: "Run C-series checks"
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
         env:
           PYTHONPATH: _sdk/conformance
         run: |
@@ -123,20 +116,20 @@ jobs:
             ${{ inputs.exclude-paths-c != '' && format('--exclude "{0}"', inputs.exclude-paths-c) || '' }}
 
       - name: "Upload SARIF artifact"
-        if: steps.changes.outputs.relevant == 'true' && !cancelled()
+        if: (steps.changes.outputs.relevant == 'true' || github.event_name == 'push') && !cancelled()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: conformance-ci-sarif
           path: ci.sarif
 
       - name: "Strip suppressed results for Security tab"
-        if: ${{ inputs.upload-sarif && steps.changes.outputs.relevant == 'true' && github.event_name != 'merge_group' }}
+        if: ${{ inputs.upload-sarif && github.event_name == 'push' }}
         run: |
           jq '.runs[] |= (.results |= map(select(.suppressions == null or (.suppressions | length == 0))))' \
             ci.sarif > ci-upload.sarif
 
       - name: "Upload SARIF to Security tab"
-        if: ${{ inputs.upload-sarif && github.event_name != 'merge_group' }}
+        if: ${{ inputs.upload-sarif && github.event_name == 'push' }}
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: ci-upload.sarif
@@ -157,15 +150,8 @@ jobs:
             relevant:
               - '**/*.py'
 
-      - name: "No relevant changes — emit empty SARIF"
-        if: steps.changes.outputs.relevant == 'false'
-        run: |
-          printf '{"$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","version":"2.1.0","runs":[{"tool":{"driver":{"name":"atlan-conformance","version":"0.0.0"}},"results":[]}]}\n' \
-            > error-handling-upload.sarif
-          echo "No .py changes; E-series gate passes."
-
       - name: "Sparse-checkout conformance suite"
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: atlanhq/application-sdk
@@ -174,11 +160,11 @@ jobs:
           path: _sdk
 
       - name: "Set up uv"
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: "Run E-series checks"
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'push'
         env:
           PYTHONPATH: _sdk/conformance
         run: |
@@ -189,20 +175,20 @@ jobs:
             ${{ inputs.exclude-paths-e != '' && format('--exclude "{0}"', inputs.exclude-paths-e) || '' }}
 
       - name: "Upload SARIF artifact"
-        if: steps.changes.outputs.relevant == 'true' && !cancelled()
+        if: (steps.changes.outputs.relevant == 'true' || github.event_name == 'push') && !cancelled()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: conformance-error-handling-sarif
           path: error-handling.sarif
 
       - name: "Strip suppressed results for Security tab"
-        if: ${{ inputs.upload-sarif && steps.changes.outputs.relevant == 'true' && github.event_name != 'merge_group' }}
+        if: ${{ inputs.upload-sarif && github.event_name == 'push' }}
         run: |
           jq '.runs[] |= (.results |= map(select(.suppressions == null or (.suppressions | length == 0))))' \
             error-handling.sarif > error-handling-upload.sarif
 
       - name: "Upload SARIF to Security tab"
-        if: ${{ inputs.upload-sarif && github.event_name != 'merge_group' }}
+        if: ${{ inputs.upload-sarif && github.event_name == 'push' }}
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: error-handling-upload.sarif

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -16,3 +16,4 @@ jobs:
     with:
       sdk-ref: ${{ github.event.pull_request.head.sha || github.sha }}
       exclude-paths-e: "tools/,contract-toolkit/,examples/"
+      event_name: ${{ github.event_name }}


### PR DESCRIPTION
### Changelog
- Remove the "emit empty SARIF" fallback that caused GHAS findings to flicker when a PR did not touch the relevant file types for a given series
- Restrict Security tab SARIF uploads to `push` events so GitHub receives one authoritative scan per merge instead of updating on every PR run
- Bypass the file-change guard on `push` events so the full conformance suite always runs after merge, providing a stable baseline on `main`
- Pass the caller's `github.event_name` into the reusable conformance workflows and gate push-only behavior on `inputs.event_name`, since `github.event_name` is always `workflow_call` inside a called workflow
- Keep gate behavior unchanged for PRs and merge-queue checks, and continue producing SARIF artifacts for download when a series runs

### Additional context (e.g. screenshots, logs, links)
- This PR updates `.github/workflows/conformance.yaml`, `.github/workflows/conformance-reusable.yaml`, `.github/workflows/conformance-ci.yaml`, and `.github/workflows/conformance-error-handling.yaml`
- Follow-up validation to perform after merge:
  - confirm the conformance workflow runs the full suite on the resulting push to `main` and uploads to the Security tab
  - confirm a PR touching only non-`.github`/non-`.py` files does not update the Security tab and does not emit a configuration warning
  - confirm a PR touching `.github/**` still produces a SARIF artifact in the run, but does not update the Security tab until merge

### Checklist
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.