### PR TITLE
test(e2e): validate image-level connector e2e [DO NOT MERGE]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,11 @@ ENV UV_NO_CACHE=1 \
     DAFT_ANALYTICS_ENABLED=0 \
     ATLAN_CONTRACT_GENERATED_DIR=/app/app/generated
 
+# TEMP — validation marker for the image-level connector e2e flow. Proves a
+# connector built on this PR's rebuilt base (not the released :3). Remove
+# before merge; this PR is a throwaway harness, not for merging.
+ENV APP_RUNTIME_BASE_E2E_MARKER=pr-validation
+
 # Copy entrypoint script for graceful shutdown handling
 COPY --chown=appuser:appuser entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/examples/_e2e_validation_marker.md
+++ b/examples/_e2e_validation_marker.md
@@ -1,0 +1,7 @@
+# e2e validation marker (throwaway)
+
+This file exists only so the validation PR touches a `code`-filter path,
+satisfying the `build-sdk-base-image` job gate (`changes.outputs.code == 'true'`)
+while the real change under test is the Dockerfile `APP_RUNTIME_BASE_E2E_MARKER`.
+
+Delete with the branch once the image-level e2e run is verified.


### PR DESCRIPTION
**Throwaway validation harness — DO NOT MERGE.** Verifies the image-level connector e2e flow that landed in #2116 + #2134 (+ connector PRs mysql#180 / metabase#70 / openapi#122).

Adds one marker to the SDK `Dockerfile`:
```dockerfile
ENV APP_RUNTIME_BASE_E2E_MARKER=pr-validation
```

## What to watch once the `e2e` label is on

1. **`Build SDK base image (e2e)`** job succeeds → pushes `registry.atlan.com/public/app-runtime-base:pr-<this PR#>-sha-<sha>`.
2. **`Connector Tests (…)`** dispatch to mysql/metabase/openapi with that `base_image_ref`.
3. In each connector run, the `sdr-e2e` build step logs `Building connector on dispatched base image: …pr-<#>-sha-<sha>` → confirms `--build-arg BASE_IMAGE` was used.
4. Full-DAG e2e runs on that image; sticky result posts back here.

## Decisive proof (marker present in the rebuilt base)
```bash
docker pull registry.atlan.com/public/app-runtime-base:pr-<this PR#>-sha-<sha>
docker inspect <ref> --format '{{json .Config.Env}}' | grep APP_RUNTIME_BASE_E2E_MARKER
```
Marker present = the connector ran on this PR's rebuilt base, not the released `:3`.

Close + delete branch after verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)