### PR TITLE
ci(e2e): trigger base-image build on container-only changes too

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -335,8 +335,11 @@ jobs:
   build-sdk-base-image:
     name: Build SDK base image (e2e)
     needs: changes
+    # code OR container: a Dockerfile-only PR (the prime base-image use case,
+    # e.g. a daprd / base bump) is container==true / code==false — it must
+    # still rebuild the base so the connector e2e exercises the new image.
     if: |
-      needs.changes.outputs.code == 'true' &&
+      (needs.changes.outputs.code == 'true' || needs.changes.outputs.container == 'true') &&
       github.event_name == 'pull_request' &&
       contains(github.event.pull_request.labels.*.name, 'e2e') &&
       github.event.pull_request.head.repo.fork != true &&
@@ -409,7 +412,7 @@ jobs:
     # back to the released base.
     if: |
       always() &&
-      needs.changes.outputs.code == 'true' &&
+      (needs.changes.outputs.code == 'true' || needs.changes.outputs.container == 'true') &&
       needs.matrix-builder.result == 'success' &&
       (needs.build-sdk-base-image.result == 'success' || needs.build-sdk-base-image.result == 'skipped') && (
         github.event_name == 'merge_group' ||


### PR DESCRIPTION
## What

Widen the gate on `build-sdk-base-image` and the `connector-tests` guard from `code == 'true'` to **`code == 'true' || container == 'true'`**. Single-file change to `.github/workflows/pull_request.yaml` (+5/−2).

## Why

The image-level connector e2e (from #2116 + #2134) only fired when a PR touched a `code`-filter path. But `Dockerfile` / `entrypoint.sh` live in the **`container`** filter, not `code` — so a **Dockerfile-only PR** (the prime use case, e.g. a `dapr-daprd` / base bump) was `container=true / code=false` and the base-image rebuild **silently skipped** even with the `e2e` label, leaving connectors on the released `:3` base.

Surfaced while validating the flow (#2141): a Dockerfile-only marker didn't trigger the build until a `code`-path file was added.

## merge_group note

Also lets a *container-only* `merge_group` entry run `connector-tests` (against the released base — no base image is built on `merge_group`, no `base_image_ref` sent). Benign added coverage.

---
_Replaces #2142, which accidentally included unrelated `examples/` + `e2e-examples` deletions from a stale local base._

🤖 Generated with [Claude Code](https://claude.com/claude-code)