### PR TITLE
test(sdr): Docker full output validation — count parity vs direct run (DISTR-758)

### DIFF
--- a/application_sdk/testing/integration/models.py
+++ b/application_sdk/testing/integration/models.py
@@ -137,6 +137,12 @@ class Scenario:
             present in the extracted output (e.g. {"Database", "Schema",
             "Table", "Column"}). The run fails if any are missing. Workflow
             scenarios only.
+        expected_counts: Exact per-type asset counts the run must produce, e.g.
+            {"Database": 1, "Schema": 3, "Table": 42}. The run fails if any
+            listed type's count differs (asset-count parity vs. a direct,
+            non-SDR baseline run — generate the baseline once via a direct
+            extraction / the parity-extract action and commit the counts).
+            Workflow scenarios only.
     """
 
     name: str
@@ -166,6 +172,7 @@ class Scenario:
     preflight_timeout: int = 60
     assert_min_total_assets: int | None = None
     expected_asset_types: set[str] | None = None
+    expected_counts: dict[str, int] | None = None
 
     def __post_init__(self):
         """Validate the scenario after initialization."""
@@ -203,6 +210,7 @@ class Scenario:
         for _field, _value in (
             ("assert_min_total_assets", self.assert_min_total_assets),
             ("expected_asset_types", self.expected_asset_types),
+            ("expected_counts", self.expected_counts),
         ):
             if _value is not None and self.api.lower() != "workflow":
                 raise ValueError(
@@ -212,6 +220,11 @@ class Scenario:
 
         if self.assert_min_total_assets is not None and self.assert_min_total_assets < 0:
             raise ValueError("assert_min_total_assets must be >= 0")
+
+        if self.expected_counts is not None and any(
+            v < 0 for v in self.expected_counts.values()
+        ):
+            raise ValueError("expected_counts values must be >= 0")
 
         if self.api.lower() == "config":
             if self.config_action not in ("get", "update"):

--- a/application_sdk/testing/integration/runner.py
+++ b/application_sdk/testing/integration/runner.py
@@ -576,6 +576,7 @@ class BaseIntegrationTest:
             needs_output_check = scenario.api_type == APIType.WORKFLOW and (
                 scenario.assert_min_total_assets is not None
                 or scenario.expected_asset_types is not None
+                or scenario.expected_counts is not None
             )
 
             if needs_metadata or needs_pandera or needs_output_check:
@@ -596,6 +597,7 @@ class BaseIntegrationTest:
                     response,
                     min_total=scenario.assert_min_total_assets,
                     required_types=scenario.expected_asset_types,
+                    expected_counts=scenario.expected_counts,
                 )
 
             logger.info("Scenario %s passed", scenario.name)
@@ -785,15 +787,19 @@ class BaseIntegrationTest:
         *,
         min_total: int | None = None,
         required_types: set[str] | None = None,
+        expected_counts: dict[str, int] | None = None,
         soft_if_no_base_path: bool = False,
     ) -> None:
         """Assert the extracted output meets a minimum bar.
 
-        Two complementary checks (either or both):
+        Three complementary checks (any combination):
           * ``min_total`` — the run must produce at least this many assets.
             Catches "workflow succeeded but extracted nothing" regressions that
             status-only validation is blind to.
           * ``required_types`` — every listed asset ``typeName`` must be present.
+          * ``expected_counts`` — exact per-type asset-count parity vs. a
+            (committed) direct-run baseline; fails if any listed type's count
+            differs.
 
         Operates on the **local** extracted output (the same ``transformed/``
         JSONL the metadata-baseline comparison reads), so it runs hermetically
@@ -869,11 +875,34 @@ class BaseIntegrationTest:
                     f"{sorted(present_types)} (total assets: {total})."
                 )
 
+        if expected_counts:
+            actual_counts: dict[str, int] = {}
+            for record in actual:
+                type_name = record.get("typeName")
+                if type_name:
+                    actual_counts[type_name] = actual_counts.get(type_name, 0) + 1
+            mismatches = {
+                type_name: (want, actual_counts.get(type_name, 0))
+                for type_name, want in expected_counts.items()
+                if actual_counts.get(type_name, 0) != want
+            }
+            if mismatches:
+                detail = ", ".join(
+                    f"{t}: expected {want}, got {got}"
+                    for t, (want, got) in sorted(mismatches.items())
+                )
+                raise AssertionError(
+                    f"Asset count parity failed for scenario '{scenario.name}' "
+                    f"(SDR run vs. direct-run baseline): {detail}. "
+                    f"Full actual counts: {dict(sorted(actual_counts.items()))}."
+                )
+
         logger.info(
-            "Output floor passed for scenario '%s': %d asset(s)%s",
+            "Output floor passed for scenario '%s': %d asset(s)%s%s",
             scenario.name,
             total,
             f", types present: {sorted(required_types)}" if required_types else "",
+            ", counts match baseline" if expected_counts else "",
         )
 
     def _validate_pandera_schemas(

--- a/application_sdk/testing/sdr/base.py
+++ b/application_sdk/testing/sdr/base.py
@@ -109,6 +109,7 @@ class BaseSDRIntegrationTest(BaseIntegrationTest):
             # already polled + validated them — don't double-poll here.
             and scenario.assert_min_total_assets is None
             and not scenario.expected_asset_types
+            and not scenario.expected_counts
             and result.success
             and result.response
         ):

--- a/tests/unit/testing/integration/test_output_floor.py
+++ b/tests/unit/testing/integration/test_output_floor.py
@@ -149,3 +149,60 @@ def test_missing_workflow_ids_fails() -> None:
     runner = _Runner()
     with pytest.raises(AssertionError, match="workflow_id or run_id"):
         runner._validate_output_floor(_scenario(), {"data": {}}, min_total=1)
+
+
+# --------------------------------------------------------------------------
+# _validate_output_floor — count parity (M3)
+# --------------------------------------------------------------------------
+
+
+def test_expected_counts_match_passes() -> None:
+    runner = _Runner()
+    actual = [
+        {"typeName": "Database"},
+        {"typeName": "Schema"},
+        {"typeName": "Schema"},
+    ]
+    with patch(_LOAD, return_value=actual):
+        runner._validate_output_floor(
+            _scenario(), _wf_response(), expected_counts={"Database": 1, "Schema": 2}
+        )
+
+
+def test_expected_counts_mismatch_fails() -> None:
+    runner = _Runner()
+    actual = [{"typeName": "Database"}, {"typeName": "Schema"}]
+    with patch(_LOAD, return_value=actual):
+        with pytest.raises(AssertionError, match="Schema: expected 5, got 1"):
+            runner._validate_output_floor(
+                _scenario(), _wf_response(), expected_counts={"Database": 1, "Schema": 5}
+            )
+
+
+def test_expected_counts_missing_type_counts_as_zero() -> None:
+    runner = _Runner()
+    with patch(_LOAD, return_value=[{"typeName": "Database"}]):
+        with pytest.raises(AssertionError, match="Table: expected 1, got 0"):
+            runner._validate_output_floor(
+                _scenario(), _wf_response(), expected_counts={"Table": 1}
+            )
+
+
+# --------------------------------------------------------------------------
+# Scenario model validation — M3
+# --------------------------------------------------------------------------
+
+
+def test_expected_counts_only_for_workflow() -> None:
+    with pytest.raises(ValueError, match="workflow"):
+        Scenario(
+            name="x",
+            api="auth",
+            assert_that={"success": lambda v: True},
+            expected_counts={"Table": 1},
+        )
+
+
+def test_expected_counts_negative_value_raises() -> None:
+    with pytest.raises(ValueError, match=">= 0"):
+        _scenario(expected_counts={"Table": -1})


### PR DESCRIPTION
## What
Second slice of the SDR test-automation pipeline (DISTR-752) — the **Docker-tier full output validation** to start with (per Avinash). Adds **M3: asset-count parity vs a direct-run baseline**, completing M1 (≥1 asset) + M2 (expected types) + M3 (exact counts).

**Stacked on #2145** (M1/M2). Closes DISTR-758.

## Why
"Output validation must go beyond workflow status: ≥1 asset → all expected types → correct counts vs direct run." This adds the last milestone.

- `Scenario.expected_counts: dict[str, int]` — exact per-type counts the run must produce (the committed **direct-run baseline**; generate once via a direct extraction / the `parity-extract` action and commit).
- `_validate_output_floor(..., expected_counts=...)` — per-type exact-count parity; on failure lists expected-vs-actual per type.
- Wired through `_execute_scenario` (Step 7) + the SDR no-double-poll guard.

## Verified
- **29 unit tests** (`test_output_floor.py` + `test_base.py`).
- **Against real Hive SDR extract output** (Docker combo, objectstore mounted host-readable): `{Database:1, Schema:1}` passes; injected count drift fails as intended.

## Docker combo note
The Docker leg is where the hermetic local-output check works cleanly because we control the objectstore mount (host-readable `transformed/`). For the shared CI `sdr-e2e` flow, the objectstore must be mounted out of the container (or use the Atlas-tier count) — tracked separately. The cloud legs (AWS/GCP/Azure) follow this.

## Status — DRAFT
Ready-for-review after full end-to-end pipeline validation, per plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)