### PR TITLE
ci(conformance): switch PyPI publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/conformance-publish.yml
+++ b/.github/workflows/conformance-publish.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   pull-requests: read
 
 jobs:
@@ -57,12 +58,10 @@ jobs:
           echo "Publishing conformance ${tag} from $(git rev-parse HEAD)"
 
       - name: Build and publish to PyPI
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           cd packages/conformance
           uv build
-          uv publish
+          uv publish --trusted-publishing automatic
 
       - name: Create source tag
         run: |


### PR DESCRIPTION
## Summary

- Removes `UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}` from the conformance publish step — the existing project-scoped token is bound to `atlan-application-sdk` and cannot publish to `atlan-application-sdk-conformance`
- Adds `id-token: write` permission so GitHub Actions can mint an OIDC token
- Switches `uv publish` to `uv publish --trusted-publishing automatic`, which exchanges the OIDC token for a short-lived PyPI credential via the Trusted Publisher configured on the PyPI project

The PyPI Trusted Publisher for `atlan-application-sdk-conformance` has already been configured to trust this repository and the `conformance-publish.yml` workflow.

## Test plan

- [ ] Merge this PR into main
- [ ] Manually re-run the failed "Publish Conformance Package" run from PR #2147 (or cycle the `release:conformance` label on the next release PR) to trigger a fresh publish attempt with OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)