### PR TITLE
ci(conformance): add workflow_dispatch trigger for manual publish retry

### DIFF
--- a/.github/workflows/conformance-publish.yml
+++ b/.github/workflows/conformance-publish.yml
@@ -13,6 +13,7 @@ on:
     types: [closed]
     branches:
       - main
+  workflow_dispatch: {}
 
 permissions:
   contents: write
@@ -24,9 +25,11 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     if: >-
-      github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'release:conformance') &&
-      startsWith(github.event.pull_request.head.ref, 'bump-version-conformance')
+      github.event_name == 'workflow_dispatch' || (
+        github.event.pull_request.merged == true &&
+        contains(github.event.pull_request.labels.*.name, 'release:conformance') &&
+        startsWith(github.event.pull_request.head.ref, 'bump-version-conformance')
+      )
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch: {}` trigger so the publish job can be manually fired from the Actions tab without needing a new release PR
- Updates the job `if:` condition to bypass the PR-label checks on manual dispatch

**Motivation:** After a failed publish run (e.g. the OIDC fix in #2148), GitHub re-runs replay the old workflow file. A `workflow_dispatch` trigger lets us fire the current workflow on main directly — reading the version from `packages/conformance/pyproject.toml` as-is — without creating a dummy release PR.

## Test plan

- [ ] Merge this PR
- [ ] Go to Actions → "Publish Conformance Package" → "Run workflow" → branch: `main`
- [ ] Confirm `atlan-application-sdk-conformance 0.2.0` publishes to PyPI and the `conformance-v0.2.0` tag is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)