### PR TITLE
chore: disable Renovate dependency dashboard issue

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "extends": [
     "github>atlanhq/application-sdk//renovate-config/default.json"
   ],
+  "dependencyDashboard": false,
   "semanticCommitType": "chore",
   "ignorePaths": [
     ".venv/**",


### PR DESCRIPTION
## Summary

- Sets `dependencyDashboard: false` in `renovate.json` to override the fleet preset, which has it enabled by default
- Dependency tracking will be managed through the Renovate portal instead of a pinned GitHub Issue

## Test plan

- [ ] Confirm Renovate closes the existing Dependency Dashboard issue on its next run