### PR TITLE
feat(contract-toolkit): make `connectionEntity` argument optional in `publish`

### DIFF
--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -240,11 +240,16 @@ pipeline {
     executorEnabled = "{{load-to-atlan}}"
     includeInputFields = true
     errorHandling = new ErrorHandlingConfig { startToCloseTimeoutSeconds = 14400 }
+    // connectionEntity: default "{{connection}}". Set null to omit
+    // connection_entity AND disable connection creation (see below).
+    connectionEntity = null
   }
 }
 ```
 
 Dependencies between pipeline steps are **auto-wired** based on position — you do not write `dependsOn` for pipeline steps. Use `extraNodes` for custom nodes outside the typed pipeline.
+
+`PublishStep.connectionEntity` (also settable directly on `PublishNode`) controls the publish node's `connection_entity` arg — the full connection entity JSON used for connection creation. It defaults to the `"{{connection}}"` form placeholder. Setting it to `null` omits `connection_entity` from the generated args entirely, and because the field is **linked** to `connection_creation_enabled` (which defaults to `connectionEntity != null`), a `null` entity also disables connection creation — publish then targets an already-existing connection and creates nothing. Override `connectionCreationEnabled` explicitly on the node to disable creation even when an entity is present.
 
 The toolkit can append a run-level notification node when an app opts in:
 

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -168,6 +168,7 @@ class LineageStep {                      // wraps LineageNode
 class PublishStep {
   executorEnabled: Boolean|String = true
   includeInputFields: Boolean = true     // generates output_dir/load_to_atlan/publish_dry_run in _input.py
+  connectionEntity: String? = "{{connection}}"  // args["connection_entity"]; null omits the arg entirely
   lineagePublish: LineagePublishStep?    // opt-in lineage publish (default-off)
   errorHandling: ErrorHandlingConfig? = new ErrorHandlingConfig {
     startToCloseTimeoutSeconds = 259200  // 72h default — AE's 2h is too tight for large tenants
@@ -1461,6 +1462,7 @@ class PublishNode extends DAGNode {
   executorEnabled: Boolean|String = true
   tagPipelineEnabled: Boolean|String? = null
   tagAttachmentsPrefix: String? = null
+  connectionEntity: String? = "{{connection}}"
   displayName = "Publish to Atlas"
   workflowType = "PublishWorkflow"
   appName = "publish"
@@ -1471,13 +1473,20 @@ class PublishNode extends DAGNode {
     ["current_state_prefix"] = "$.<upstream>.outputs.current_state_prefix"
     ["connection_creation_enabled"] = true
     ["executor_enabled"] = executorEnabled
-    ["connection_entity"] = "{{connection}}"
+    when (connectionEntity != null) { ["connection_entity"] = connectionEntity }
   }
   dependsOn { upstream }
 }
 ```
 
 `executorEnabled` can be a Boolean literal or an exact workflow placeholder string.
+
+`connectionEntity` is the full connection entity JSON (typeName + attributes);
+when provided, publish uses it for connection creation, and when omitted publish
+constructs a minimal entity from `connection_qualified_name`. It defaults to the
+`"{{connection}}"` form placeholder. Set it to `null` (on the node, or via
+`pipeline.publish.connectionEntity`) to omit `connection_entity` from the args
+entirely so publish falls back to building a minimal entity from the qualified name.
 For the auto-generated default publish node, set the app-level
 `publishExecutorEnabled`; for `extraNodes["publish"] = new PublishNode { ... }`,
 set `executorEnabled` on that node.

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -168,7 +168,7 @@ class LineageStep {                      // wraps LineageNode
 class PublishStep {
   executorEnabled: Boolean|String = true
   includeInputFields: Boolean = true     // generates output_dir/load_to_atlan/publish_dry_run in _input.py
-  connectionEntity: String? = "{{connection}}"  // args["connection_entity"]; null omits the arg entirely
+  connectionEntity: String? = "{{connection}}"  // args["connection_entity"]; null omits it AND sets connection_creation_enabled=false
   lineagePublish: LineagePublishStep?    // opt-in lineage publish (default-off)
   errorHandling: ErrorHandlingConfig? = new ErrorHandlingConfig {
     startToCloseTimeoutSeconds = 259200  // 72h default — AE's 2h is too tight for large tenants
@@ -1463,6 +1463,7 @@ class PublishNode extends DAGNode {
   tagPipelineEnabled: Boolean|String? = null
   tagAttachmentsPrefix: String? = null
   connectionEntity: String? = "{{connection}}"
+  connectionCreationEnabled: Boolean = connectionEntity != null
   displayName = "Publish to Atlas"
   workflowType = "PublishWorkflow"
   appName = "publish"
@@ -1471,7 +1472,7 @@ class PublishNode extends DAGNode {
     ["transformed_data_prefix"] = "$.<upstream>.outputs.transformed_data_prefix"
     ["publish_state_prefix"] = "$.<upstream>.outputs.publish_state_prefix"
     ["current_state_prefix"] = "$.<upstream>.outputs.current_state_prefix"
-    ["connection_creation_enabled"] = true
+    ["connection_creation_enabled"] = connectionCreationEnabled
     ["executor_enabled"] = executorEnabled
     when (connectionEntity != null) { ["connection_entity"] = connectionEntity }
   }
@@ -1481,13 +1482,15 @@ class PublishNode extends DAGNode {
 
 `executorEnabled` can be a Boolean literal or an exact workflow placeholder string.
 
-`connectionEntity` is the full connection entity JSON (typeName + attributes);
-when provided, publish uses it for connection creation, and when omitted publish
-constructs a minimal entity from `connection_qualified_name`. It defaults to the
-`"{{connection}}"` form placeholder. Set it to `null` (on the node, or via
-`pipeline.publish.connectionEntity`) to omit `connection_entity` from the args
-entirely so publish falls back to building a minimal entity from the qualified name.
-For the auto-generated default publish node, set the app-level
+`connectionEntity` is the full connection entity JSON (typeName + attributes) used
+for connection creation. It defaults to the `"{{connection}}"` form placeholder.
+Set it to `null` (on the node, or via `pipeline.publish.connectionEntity`) to omit
+`connection_entity` from the args entirely. `connectionEntity` is **linked** to
+`connectionCreationEnabled`, which defaults to `connectionEntity != null`: a `null`
+entity therefore also sets `connection_creation_enabled = false` (publish targets an
+existing connection and creates nothing), while a present entity sets it `true`.
+Override `connectionCreationEnabled` explicitly to disable creation even when an
+entity is present. For the auto-generated default publish node, set the app-level
 `publishExecutorEnabled`; for `extraNodes["publish"] = new PublishNode { ... }`,
 set `executorEnabled` on that node.
 

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -657,6 +657,15 @@ open class PublishNode extends DAGNode {
   /// or written to a dry-run path.
   currentStateViaAppEnabled: Boolean = false
 
+  /// Connection entity passed to the publish workflow as `args["connection_entity"]`.
+  ///
+  /// The full connection entity JSON (typeName + attributes). When provided, publish
+  /// uses it for connection creation; when omitted, publish constructs a minimal
+  /// entity from `connection_qualified_name`. Defaults to the `"{{connection}}"`
+  /// form placeholder. Set to `null` to omit the arg entirely so publish falls back
+  /// to building a minimal entity from the qualified name.
+  connectionEntity: String? = "{{connection}}"
+
   displayName = "Publish to Atlas"
   workflowType = "PublishWorkflow"
   appName = "publish"
@@ -667,7 +676,7 @@ open class PublishNode extends DAGNode {
     ["current_state_prefix"] = "$.\(upstream).outputs.current_state_prefix"
     ["connection_creation_enabled"] = true
     ["executor_enabled"] = executorEnabled
-    ["connection_entity"] = "{{connection}}"
+    when (connectionEntity != null) { ["connection_entity"] = connectionEntity }
     ["connection_cache_enabled"] = connectionCacheEnabled
     ["connection_cache_via_app_enabled"] = connectionCacheViaAppEnabled
     ["current_state_enabled"] = currentStateEnabled
@@ -1307,6 +1316,15 @@ class PublishStep {
   /// `false` alongside `currentStateEnabled` when the node must not write
   /// current-state at all.
   currentStateViaAppEnabled: Boolean = true
+
+  /// Connection entity passed to the publish workflow as `args["connection_entity"]`.
+  ///
+  /// The full connection entity JSON (typeName + attributes). When provided, publish
+  /// uses it for connection creation; when omitted, publish constructs a minimal
+  /// entity from `connection_qualified_name`. Defaults to the `"{{connection}}"`
+  /// form placeholder. Set to `null` to omit the arg entirely so publish falls back
+  /// to building a minimal entity from the qualified name.
+  connectionEntity: String? = "{{connection}}"
 
   /// Optional lineage-publish sub-step. When set, adds a `"lineage-publish"`
   /// node after the main publish step.
@@ -2090,6 +2108,7 @@ local function generateDAG(): Mapping<String, Any> = new Mapping {
           connectionCacheViaAppEnabled = ps.connectionCacheViaAppEnabled
           currentStateEnabled = ps.currentStateEnabled
           currentStateViaAppEnabled = ps.currentStateViaAppEnabled
+          connectionEntity = ps.connectionEntity
         })
   }
   when (pipeline.publish != null && pipeline.publish!!.lineagePublish != null) {

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -659,12 +659,19 @@ open class PublishNode extends DAGNode {
 
   /// Connection entity passed to the publish workflow as `args["connection_entity"]`.
   ///
-  /// The full connection entity JSON (typeName + attributes). When provided, publish
-  /// uses it for connection creation; when omitted, publish constructs a minimal
-  /// entity from `connection_qualified_name`. Defaults to the `"{{connection}}"`
-  /// form placeholder. Set to `null` to omit the arg entirely so publish falls back
-  /// to building a minimal entity from the qualified name.
+  /// The full connection entity JSON (typeName + attributes), used for connection
+  /// creation. Defaults to the `"{{connection}}"` form placeholder. Set to `null`
+  /// to omit the arg entirely — doing so also turns `connectionCreationEnabled`
+  /// off (see below), since there is no entity for publish to create from.
   connectionEntity: String? = "{{connection}}"
+
+  /// Whether publish should create the connection (`args["connection_creation_enabled"]`).
+  ///
+  /// Linked to `connectionEntity`: defaults to `connectionEntity != null`, so a
+  /// `null` entity yields `false` (publish targets an existing connection and
+  /// creates nothing) and a present entity yields `true`. Override explicitly to
+  /// disable creation even when an entity is present.
+  connectionCreationEnabled: Boolean = connectionEntity != null
 
   displayName = "Publish to Atlas"
   workflowType = "PublishWorkflow"
@@ -674,7 +681,7 @@ open class PublishNode extends DAGNode {
     ["transformed_data_prefix"] = "$.\(upstream).outputs.transformed_data_prefix"
     ["publish_state_prefix"] = "$.\(upstream).outputs.publish_state_prefix"
     ["current_state_prefix"] = "$.\(upstream).outputs.current_state_prefix"
-    ["connection_creation_enabled"] = true
+    ["connection_creation_enabled"] = connectionCreationEnabled
     ["executor_enabled"] = executorEnabled
     when (connectionEntity != null) { ["connection_entity"] = connectionEntity }
     ["connection_cache_enabled"] = connectionCacheEnabled
@@ -1319,11 +1326,11 @@ class PublishStep {
 
   /// Connection entity passed to the publish workflow as `args["connection_entity"]`.
   ///
-  /// The full connection entity JSON (typeName + attributes). When provided, publish
-  /// uses it for connection creation; when omitted, publish constructs a minimal
-  /// entity from `connection_qualified_name`. Defaults to the `"{{connection}}"`
-  /// form placeholder. Set to `null` to omit the arg entirely so publish falls back
-  /// to building a minimal entity from the qualified name.
+  /// The full connection entity JSON (typeName + attributes), used for connection
+  /// creation. Defaults to the `"{{connection}}"` form placeholder. Set to `null`
+  /// to omit the arg entirely; doing so also sets `connection_creation_enabled` to
+  /// `false` on the generated publish node (the node links the two), so publish
+  /// targets an existing connection and creates nothing.
   connectionEntity: String? = "{{connection}}"
 
   /// Optional lineage-publish sub-step. When set, adds a `"lineage-publish"`

--- a/contract-toolkit/tests/fixtures/publish_no_connection_entity.pkl
+++ b/contract-toolkit/tests/fixtures/publish_no_connection_entity.pkl
@@ -1,8 +1,9 @@
 /// Fixture: app whose typed publish step opts out of `connection_entity`.
 ///
 /// Exercises the pipeline path with `pipeline.publish.connectionEntity = null`,
-/// which must omit `connection_entity` from the generated publish node's args so
-/// publish builds a minimal entity from `connection_qualified_name` instead.
+/// which must omit `connection_entity` from the generated publish node's args and,
+/// because the two are linked, also set `connection_creation_enabled = false` so
+/// publish targets an existing connection and creates nothing.
 amends "../../src/App.pkl"
 
 name = "publish-no-connection-entity"

--- a/contract-toolkit/tests/fixtures/publish_no_connection_entity.pkl
+++ b/contract-toolkit/tests/fixtures/publish_no_connection_entity.pkl
@@ -1,0 +1,29 @@
+/// Fixture: app whose typed publish step opts out of `connection_entity`.
+///
+/// Exercises the pipeline path with `pipeline.publish.connectionEntity = null`,
+/// which must omit `connection_entity` from the generated publish node's args so
+/// publish builds a minimal entity from `connection_qualified_name` instead.
+amends "../../src/App.pkl"
+
+name = "publish-no-connection-entity"
+displayName = "Publish No Connection Entity"
+icon = "https://assets.atlan.com/assets/fullscreen-exit.svg"
+hasCredentialConfig = false
+
+pipeline = new Pipeline {
+  publish = new PublishStep {
+    connectionEntity = null
+  }
+}
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs {
+        ["connection"] = new ConnectionCreator {
+          placeholderText = "Connection Name"
+        }
+      }
+    }
+  }
+}

--- a/contract-toolkit/tests/publish_node_connection_entity_test.pkl
+++ b/contract-toolkit/tests/publish_node_connection_entity_test.pkl
@@ -39,20 +39,39 @@ facts {
     new App.PublishNode { connectionEntity = "{{custom}}" }.args["connection_entity"] == "{{custom}}"
   }
 
+  // ---- connectionEntity is linked to connection_creation_enabled --------------
+
+  // A present entity means publish creates the connection from it.
+  ["PublishNode with a connection entity enables connection creation"] {
+    new App.PublishNode {}.args["connection_creation_enabled"] == true
+  }
+
+  // A null entity means there is nothing to create from, so creation is off.
+  ["PublishNode with a null connection entity disables connection creation"] {
+    new App.PublishNode { connectionEntity = null }.args["connection_creation_enabled"] == false
+  }
+
+  // The link is a default, not a hard constraint: creation can be disabled even
+  // when an entity is present (publish against an existing connection).
+  ["PublishNode connectionCreationEnabled can be overridden off with an entity present"] {
+    new App.PublishNode { connectionCreationEnabled = false }.args["connection_creation_enabled"] == false
+  }
+
   // ---- Typed pipeline (PublishStep) -------------------------------------------
 
-  ["Default pipeline emits connection_entity on the publish node"] {
+  ["Default pipeline emits connection_entity and enables connection creation"] {
     defaultPublishArgs["connection_entity"] == "{{connection}}"
+    defaultPublishArgs["connection_creation_enabled"] == true
   }
 
-  ["PublishStep.connectionEntity = null omits connection_entity from the generated node"] {
+  ["PublishStep.connectionEntity = null omits connection_entity and disables connection creation"] {
     !omittedPublishArgs.toMap().containsKey("connection_entity")
+    omittedPublishArgs["connection_creation_enabled"] == false
   }
 
-  // Omitting connection_entity must not disturb the other standard publish args.
+  // Omitting connection_entity must not disturb the remaining publish args.
   ["Omitting connection_entity preserves the other publish args"] {
     omittedPublishArgs["connection_qualified_name"] != null
-    omittedPublishArgs["connection_creation_enabled"] == true
     omittedPublishArgs["connection_cache_enabled"] == true
   }
 }

--- a/contract-toolkit/tests/publish_node_connection_entity_test.pkl
+++ b/contract-toolkit/tests/publish_node_connection_entity_test.pkl
@@ -1,11 +1,13 @@
 // Tests that `connection_entity` is an optional arg on the built-in PublishNode.
 //
 // Background: `connection_entity` is the full connection entity JSON (typeName +
-// attributes). When provided, publish uses it for connection creation; when
-// omitted, publish constructs a minimal entity from `connection_qualified_name`.
-// PublishNode therefore exposes a nullable `connectionEntity` (default
-// "{{connection}}") and only emits the arg when it is non-null — both directly on
-// the node and via the typed `PublishStep.connectionEntity`.
+// attributes) that publish uses for connection creation. PublishNode exposes a
+// nullable `connectionEntity` (default "{{connection}}") and only emits the arg
+// when it is non-null — both directly on the node and via the typed
+// `PublishStep.connectionEntity`. The field is linked to `connectionCreationEnabled`
+// (default `connectionEntity != null`), so a null entity also sets
+// `connection_creation_enabled = false`: publish targets an existing connection
+// and creates nothing, rather than creating one from a partial entity.
 
 amends "pkl:test"
 

--- a/contract-toolkit/tests/publish_node_connection_entity_test.pkl
+++ b/contract-toolkit/tests/publish_node_connection_entity_test.pkl
@@ -1,0 +1,58 @@
+// Tests that `connection_entity` is an optional arg on the built-in PublishNode.
+//
+// Background: `connection_entity` is the full connection entity JSON (typeName +
+// attributes). When provided, publish uses it for connection creation; when
+// omitted, publish constructs a minimal entity from `connection_qualified_name`.
+// PublishNode therefore exposes a nullable `connectionEntity` (default
+// "{{connection}}") and only emits the arg when it is non-null — both directly on
+// the node and via the typed `PublishStep.connectionEntity`.
+
+amends "pkl:test"
+
+import "pkl:json"
+import "fixtures/default_pipeline.pkl" as defaultPipelineApp
+import "fixtures/publish_no_connection_entity.pkl" as noConnEntityApp
+import "../src/App.pkl" as App
+
+// Default (undeclared) pipeline: the publish node should carry connection_entity.
+local defaultPublishArgs = new json.Parser { useMapping = true }.parse(
+  defaultPipelineApp.output.files["app/generated/manifest.json"].text
+)["dag"]["publish"]["inputs"]["args"]
+
+// Pipeline with `pipeline.publish.connectionEntity = null`: arg must be absent.
+local omittedPublishArgs = new json.Parser { useMapping = true }.parse(
+  noConnEntityApp.output.files["app/generated/manifest.json"].text
+)["dag"]["publish"]["inputs"]["args"]
+
+facts {
+  // ---- Direct class instances -------------------------------------------------
+
+  ["PublishNode defaults connection_entity to the {{connection}} placeholder"] {
+    new App.PublishNode {}.args["connection_entity"] == "{{connection}}"
+  }
+
+  ["PublishNode omits connection_entity entirely when connectionEntity is null"] {
+    !new App.PublishNode { connectionEntity = null }.args.toMap().containsKey("connection_entity")
+  }
+
+  ["PublishNode passes through a custom connectionEntity value"] {
+    new App.PublishNode { connectionEntity = "{{custom}}" }.args["connection_entity"] == "{{custom}}"
+  }
+
+  // ---- Typed pipeline (PublishStep) -------------------------------------------
+
+  ["Default pipeline emits connection_entity on the publish node"] {
+    defaultPublishArgs["connection_entity"] == "{{connection}}"
+  }
+
+  ["PublishStep.connectionEntity = null omits connection_entity from the generated node"] {
+    !omittedPublishArgs.toMap().containsKey("connection_entity")
+  }
+
+  // Omitting connection_entity must not disturb the other standard publish args.
+  ["Omitting connection_entity preserves the other publish args"] {
+    omittedPublishArgs["connection_qualified_name"] != null
+    omittedPublishArgs["connection_creation_enabled"] == true
+    omittedPublishArgs["connection_cache_enabled"] == true
+  }
+}


### PR DESCRIPTION
### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- Updated the `publish` functionality to make the `connectionEntity` argument optional.

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
- _to be added_

### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.