### PR TITLE
feat(e2e): cross-cloud object-store matrix (AWS/Azure/GCS) for the SDR end-to-end suite

### DIFF
--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -121,6 +121,16 @@ inputs:
       agent-name so the worker registers on its own Temporal queue).
     required: false
     default: ""
+  storage-profile:
+    description: |
+      Optional cross-cloud storage matrix profile: `aws` | `azure` | `gcp`.
+      When set, the profile under `profiles/<name>/` overrides the customer
+      object store with an emulator-backed variant (LocalStack S3 / Azurite /
+      fake-gcs-server) and its compose snippet adds the matching emulator
+      sidecar + bucket/container init. Empty (default) keeps the SDK default
+      `localstorage` — existing behaviour unchanged, so this is purely opt-in.
+    required: false
+    default: ""
 outputs:
   test-outcome:
     description: pytest exit outcome (success/failure)
@@ -376,6 +386,8 @@ runs:
       env:
         SDK_COMPONENTS: ${{ steps.action_root.outputs.path }}/components
         APP_COMPONENTS: ${{ inputs.components-dir }}
+        STORAGE_PROFILE: ${{ inputs.storage-profile }}
+        PROFILES_ROOT: ${{ steps.action_root.outputs.path }}/profiles
       run: |
         cp "${SDK_COMPONENTS}"/*.yaml ci-deploy/components/
         # Resolve effective overrides directory: explicit input wins,
@@ -389,6 +401,18 @@ runs:
           echo "Applying app-level component overrides from ${OVERRIDE_DIR}"
           cp "${OVERRIDE_DIR}"/*.yaml ci-deploy/components/
         fi
+        # Cross-cloud storage matrix (opt-in): the profile's components win last,
+        # so the customer object store becomes the emulator-backed variant.
+        if [ -n "${STORAGE_PROFILE}" ]; then
+          PROFILE_COMPONENTS="${PROFILES_ROOT}/${STORAGE_PROFILE}/components"
+          if [ -d "${PROFILE_COMPONENTS}" ]; then
+            echo "Applying storage-profile '${STORAGE_PROFILE}' components from ${PROFILE_COMPONENTS}"
+            cp "${PROFILE_COMPONENTS}"/*.yaml ci-deploy/components/
+          else
+            echo "::error::Unknown storage-profile '${STORAGE_PROFILE}' (no ${PROFILE_COMPONENTS})"
+            exit 1
+          fi
+        fi
 
     - name: Build compose -f chain
       id: compose_files
@@ -396,6 +420,8 @@ runs:
       env:
         SDK_COMPOSE: ${{ steps.action_root.outputs.path }}/docker-compose.ci.yml
         APP_COMPOSE: ${{ inputs.compose-overlay }}
+        STORAGE_PROFILE: ${{ inputs.storage-profile }}
+        PROFILES_ROOT: ${{ steps.action_root.outputs.path }}/profiles
       run: |
         # Order: configurator-generated base → SDK CI overrides → optional app layer.
         FILES=("-f" "ci-deploy/docker-compose.yaml" "-f" "${SDK_COMPOSE}")
@@ -409,6 +435,15 @@ runs:
         if [ -f "${OVERLAY}" ]; then
           echo "Adding app-level compose layer from ${OVERLAY}"
           FILES+=("-f" "${OVERLAY}")
+        fi
+        # Cross-cloud storage matrix (opt-in): add the emulator sidecar + init
+        # last so atlan-app gains a depends_on the emulator's bucket/container.
+        if [ -n "${STORAGE_PROFILE}" ]; then
+          PROFILE_COMPOSE="${PROFILES_ROOT}/${STORAGE_PROFILE}/docker-compose.ci.yml"
+          if [ -f "${PROFILE_COMPOSE}" ]; then
+            echo "Adding storage-profile '${STORAGE_PROFILE}' compose layer from ${PROFILE_COMPOSE}"
+            FILES+=("-f" "${PROFILE_COMPOSE}")
+          fi
         fi
         # Persist the array as a single space-joined string (compose -f flags
         # are simple paths, no whitespace issues).

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -443,6 +443,12 @@ runs:
           if [ -f "${PROFILE_COMPOSE}" ]; then
             echo "Adding storage-profile '${STORAGE_PROFILE}' compose layer from ${PROFILE_COMPOSE}"
             FILES+=("-f" "${PROFILE_COMPOSE}")
+          else
+            # Symmetric with the component-override step: a profile with
+            # components but no compose would silently start no emulator
+            # sidecar and fail confusingly later. Fail loudly instead.
+            echo "::error::storage-profile '${STORAGE_PROFILE}' has no ${PROFILE_COMPOSE}"
+            exit 1
           fi
         fi
         # Persist the array as a single space-joined string (compose -f flags

--- a/.github/actions/sdr-e2e/profiles/aws/components/objectstore.yaml
+++ b/.github/actions/sdr-e2e/profiles/aws/components/objectstore.yaml
@@ -1,0 +1,25 @@
+# Cross-cloud matrix — AWS profile: customer object store on S3 (LocalStack).
+# Overrides the SDK-default `objectstore` (bindings.localstorage). Upstream
+# `atlan-objectstore` (Atlan blobstorage proxy) is untouched.
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: objectstore
+spec:
+  type: bindings.aws.s3
+  version: v1
+  metadata:
+    - name: bucket
+      value: atlan-customer-e2e
+    - name: region
+      value: us-east-1
+    - name: endpoint
+      value: http://localstack:4566
+    - name: forcePathStyle
+      value: "true"
+    - name: disableSSL
+      value: "true"
+    - name: accessKey
+      value: test
+    - name: secretKey
+      value: test

--- a/.github/actions/sdr-e2e/profiles/aws/docker-compose.ci.yml
+++ b/.github/actions/sdr-e2e/profiles/aws/docker-compose.ci.yml
@@ -23,11 +23,13 @@ services:
     command:
       - |
         for i in $(seq 1 60); do
-          aws --endpoint-url=http://localstack:4566 s3 ls >/dev/null 2>&1 && break
+          aws --endpoint-url=http://localstack:4566 s3 mb s3://atlan-customer-e2e >/dev/null 2>&1
+          if aws --endpoint-url=http://localstack:4566 s3api head-bucket --bucket atlan-customer-e2e >/dev/null 2>&1; then
+            echo "localstack-init done"; exit 0
+          fi
           echo "waiting for localstack s3..."; sleep 2
         done
-        aws --endpoint-url=http://localstack:4566 s3 mb s3://atlan-customer-e2e || true
-        echo "localstack-init done"
+        echo "localstack-init: giving up after retries"; exit 1
     restart: "no"
 
   atlan-app:

--- a/.github/actions/sdr-e2e/profiles/aws/docker-compose.ci.yml
+++ b/.github/actions/sdr-e2e/profiles/aws/docker-compose.ci.yml
@@ -1,0 +1,36 @@
+# Cross-cloud matrix — AWS profile sidecars (LocalStack S3).
+# The init container self-retries until S3 is up, then creates the customer
+# bucket; atlan-app waits for it to complete. No emulator healthcheck needed
+# (avoids depending on the image shipping curl/nc).
+services:
+  localstack:
+    image: localstack/localstack:3
+    environment:
+      - SERVICES=s3
+      - DEBUG=0
+    expose:
+      - "4566"
+
+  localstack-init:
+    image: amazon/aws-cli:2.15.0
+    depends_on:
+      - localstack
+    environment:
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_DEFAULT_REGION: us-east-1
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        for i in $(seq 1 60); do
+          aws --endpoint-url=http://localstack:4566 s3 ls >/dev/null 2>&1 && break
+          echo "waiting for localstack s3..."; sleep 2
+        done
+        aws --endpoint-url=http://localstack:4566 s3 mb s3://atlan-customer-e2e || true
+        echo "localstack-init done"
+    restart: "no"
+
+  atlan-app:
+    depends_on:
+      localstack-init:
+        condition: service_completed_successfully

--- a/.github/actions/sdr-e2e/profiles/azure/components/objectstore.yaml
+++ b/.github/actions/sdr-e2e/profiles/azure/components/objectstore.yaml
@@ -1,0 +1,19 @@
+# Cross-cloud matrix — Azure profile: customer object store on Azure Blob
+# (Azurite). Uses the well-known Azurite account + an http endpoint (→ SDK
+# infers allow_http). Overrides the SDK-default `objectstore`.
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: objectstore
+spec:
+  type: bindings.azure.blobstorage
+  version: v1
+  metadata:
+    - name: accountName
+      value: devstoreaccount1
+    - name: accountKey
+      value: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMA==
+    - name: containerName
+      value: atlan-customer-e2e
+    - name: endpoint
+      value: http://azurite:10000/devstoreaccount1

--- a/.github/actions/sdr-e2e/profiles/azure/components/objectstore.yaml
+++ b/.github/actions/sdr-e2e/profiles/azure/components/objectstore.yaml
@@ -12,7 +12,7 @@ spec:
     - name: accountName
       value: devstoreaccount1
     - name: accountKey
-      value: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMA==
+      value: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
     - name: containerName
       value: atlan-customer-e2e
     - name: endpoint

--- a/.github/actions/sdr-e2e/profiles/azure/components/objectstore.yaml
+++ b/.github/actions/sdr-e2e/profiles/azure/components/objectstore.yaml
@@ -17,3 +17,10 @@ spec:
       value: atlan-customer-e2e
     - name: endpoint
       value: http://azurite:10000/devstoreaccount1
+    # The azurite-init sidecar already creates the container. Stop daprd's
+    # azure binding from trying to create it again at init — with the account
+    # already in `endpoint`, daprd doubles the path
+    # (.../devstoreaccount1/devstoreaccount1/...) → 400. The SDK does its real
+    # I/O via obstore, so daprd's binding only needs to load, not manage state.
+    - name: disableEntityManagement
+      value: "true"

--- a/.github/actions/sdr-e2e/profiles/azure/docker-compose.ci.yml
+++ b/.github/actions/sdr-e2e/profiles/azure/docker-compose.ci.yml
@@ -17,11 +17,14 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
-        for i in $(seq 1 60); do
-          az storage container create --name atlan-customer-e2e >/dev/null 2>&1 && break
-          echo "waiting for azurite..."; sleep 2
+        for i in $(seq 1 40); do
+          if az storage container create --name atlan-customer-e2e \
+               --connection-string "$AZURE_STORAGE_CONNECTION_STRING"; then
+            echo "azurite-init: container created"; exit 0
+          fi
+          echo "waiting for azurite (attempt $i)..."; sleep 3
         done
-        echo "azurite-init done"
+        echo "azurite-init: giving up after retries"; exit 1
     restart: "no"
 
   atlan-app:

--- a/.github/actions/sdr-e2e/profiles/azure/docker-compose.ci.yml
+++ b/.github/actions/sdr-e2e/profiles/azure/docker-compose.ci.yml
@@ -13,7 +13,7 @@ services:
     depends_on:
       - azurite
     environment:
-      AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMA==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
+      AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |

--- a/.github/actions/sdr-e2e/profiles/azure/docker-compose.ci.yml
+++ b/.github/actions/sdr-e2e/profiles/azure/docker-compose.ci.yml
@@ -1,0 +1,30 @@
+# Cross-cloud matrix — Azure profile sidecars (Azurite blob).
+# The init container self-retries until the blob endpoint is up, then creates
+# the customer container; atlan-app waits for it to complete.
+services:
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite:3.31.0
+    command: ["azurite-blob", "--blobHost", "0.0.0.0", "--blobPort", "10000", "--skipApiVersionCheck"]
+    expose:
+      - "10000"
+
+  azurite-init:
+    image: mcr.microsoft.com/azure-cli:2.62.0
+    depends_on:
+      - azurite
+    environment:
+      AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMA==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        for i in $(seq 1 60); do
+          az storage container create --name atlan-customer-e2e >/dev/null 2>&1 && break
+          echo "waiting for azurite..."; sleep 2
+        done
+        echo "azurite-init done"
+    restart: "no"
+
+  atlan-app:
+    depends_on:
+      azurite-init:
+        condition: service_completed_successfully

--- a/.github/actions/sdr-e2e/profiles/gcp/components/objectstore.yaml
+++ b/.github/actions/sdr-e2e/profiles/gcp/components/objectstore.yaml
@@ -1,7 +1,9 @@
 # Cross-cloud matrix — GCP profile: customer object store on GCS
-# (fake-gcs-server). endpoint → obstore base_url (DISTR-774); skipSignature
-# sends unsigned/anonymous requests since the emulator has no auth.
-# Overrides the SDK-default `objectstore`.
+# (Google storage-testbench). endpoint → obstore base_url (DISTR-774);
+# skipSignature sends unsigned/anonymous requests since the emulator has no
+# auth. fake-gcs-server rejected obstore uploads ("invalid uploadType"); the
+# official storage-testbench implements the full upload API. Overrides the
+# SDK-default `objectstore`.
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
@@ -18,6 +20,6 @@ spec:
     - name: project_id
       value: test
     - name: endpoint
-      value: http://fake-gcs:4443
+      value: http://gcs-testbench:9000
     - name: skipSignature
       value: "true"

--- a/.github/actions/sdr-e2e/profiles/gcp/components/objectstore.yaml
+++ b/.github/actions/sdr-e2e/profiles/gcp/components/objectstore.yaml
@@ -1,0 +1,20 @@
+# Cross-cloud matrix — GCP profile: customer object store on GCS
+# (fake-gcs-server). endpoint → obstore base_url (DISTR-774); skipSignature
+# sends unsigned/anonymous requests since the emulator has no auth.
+# Overrides the SDK-default `objectstore`.
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: objectstore
+spec:
+  type: bindings.gcs
+  version: v1
+  metadata:
+    - name: bucket
+      value: atlan-customer-e2e
+    - name: project_id
+      value: test
+    - name: endpoint
+      value: http://fake-gcs:4443
+    - name: skipSignature
+      value: "true"

--- a/.github/actions/sdr-e2e/profiles/gcp/components/objectstore.yaml
+++ b/.github/actions/sdr-e2e/profiles/gcp/components/objectstore.yaml
@@ -20,6 +20,6 @@ spec:
     - name: project_id
       value: test
     - name: endpoint
-      value: http://gcs-testbench:9000
+      value: http://gcs:9000
     - name: skipSignature
       value: "true"

--- a/.github/actions/sdr-e2e/profiles/gcp/components/objectstore.yaml
+++ b/.github/actions/sdr-e2e/profiles/gcp/components/objectstore.yaml
@@ -7,7 +7,10 @@ kind: Component
 metadata:
   name: objectstore
 spec:
-  type: bindings.gcs
+  # bindings.gcp.bucket is the canonical Dapr type daprd recognises (the SDK
+  # maps both gcp.bucket and the .gcs alias to obstore GCS; daprd only knows
+  # gcp.bucket, so the alias makes the sidecar fail at load).
+  type: bindings.gcp.bucket
   version: v1
   metadata:
     - name: bucket

--- a/.github/actions/sdr-e2e/profiles/gcp/docker-compose.ci.yml
+++ b/.github/actions/sdr-e2e/profiles/gcp/docker-compose.ci.yml
@@ -25,6 +25,12 @@ services:
     restart: "no"
 
   atlan-app:
+    # STORAGE_EMULATOR_HOST makes Google's Go client (used by daprd's gcp.bucket
+    # binding) talk to fake-gcs with NO credentials, so daprd inits cleanly
+    # instead of failing ADC lookup. obstore (the SDK's actual I/O path) is
+    # pointed at the same emulator via the component's endpoint→base_url.
+    environment:
+      - STORAGE_EMULATOR_HOST=fake-gcs:4443
     depends_on:
       fake-gcs-init:
         condition: service_completed_successfully

--- a/.github/actions/sdr-e2e/profiles/gcp/docker-compose.ci.yml
+++ b/.github/actions/sdr-e2e/profiles/gcp/docker-compose.ci.yml
@@ -25,6 +25,10 @@ services:
           listen 9000;
           client_max_body_size 0;
           location / {
+            # testbench's XML API doesn't implement object DELETE (405); the
+            # worker's post-upload cleanup is best-effort, so ack DELETEs with
+            # 204 to keep the run log clean (object lifetime = container).
+            if ($request_method = DELETE) { return 204; }
             proxy_pass http://storage-testbench:9000;
             proxy_hide_header ETag;
             add_header ETag '"d41d8cd98f00b204e9800998ecf8427e"' always;

--- a/.github/actions/sdr-e2e/profiles/gcp/docker-compose.ci.yml
+++ b/.github/actions/sdr-e2e/profiles/gcp/docker-compose.ci.yml
@@ -27,6 +27,10 @@ services:
           location / {
             proxy_pass http://storage-testbench:9000;
             proxy_hide_header ETag;
+            # A single constant ETag — fine for this suite's small single-PUT
+            # objects, but it will NOT survive multipart completion (needs
+            # per-part ETags) or any If-Match/conditional logic. Revisit if this
+            # profile is ever used for large-object E2E.
             add_header ETag '"d41d8cd98f00b204e9800998ecf8427e"' always;
           }
           # NB: the worker's best-effort post-upload cleanup DELETEs log a
@@ -48,12 +52,14 @@ services:
     command:
       - |
         for i in $(seq 1 60); do
-          curl -sf -X POST "http://gcs:9000/storage/v1/b?project=test" \
-            -H "Content-Type: application/json" \
-            -d '{"name":"atlan-customer-e2e"}' >/dev/null 2>&1 && break
+          if curl -sf -X POST "http://gcs:9000/storage/v1/b?project=test" \
+               -H "Content-Type: application/json" \
+               -d '{"name":"atlan-customer-e2e"}' >/dev/null 2>&1; then
+            echo "gcs-init done"; exit 0
+          fi
           echo "waiting for gcs proxy + testbench..."; sleep 2
         done
-        echo "gcs-init done"
+        echo "gcs-init: giving up after retries"; exit 1
     restart: "no"
 
   atlan-app:

--- a/.github/actions/sdr-e2e/profiles/gcp/docker-compose.ci.yml
+++ b/.github/actions/sdr-e2e/profiles/gcp/docker-compose.ci.yml
@@ -1,40 +1,62 @@
-# Cross-cloud matrix — GCP profile sidecars (Google storage-testbench).
-# fake-gcs-server rejected object_store's uploads with "invalid uploadType"
-# (a documented fake-gcs limitation); Google's official storage-testbench
-# implements the full upload API surface that obstore exercises. The init
-# self-retries until the JSON API is up, then creates the customer bucket;
-# atlan-app waits for it to complete.
+# Cross-cloud matrix — GCP profile sidecars (storage-testbench + ETag shim).
+# Google's storage-testbench stores objects correctly (HTTP 200 on obstore's
+# XML-API PUT) but omits the ETag response header that obstore requires
+# ("ETag Header missing from response"). A tiny nginx proxy in front injects a
+# stable ETag on every response, patching that one emulator gap — fully
+# hermetic, no real GCS bucket needed. atlan-app + the bucket-init talk to the
+# proxy (gcs:9000); the proxy forwards to storage-testbench:9000.
 services:
-  gcs-testbench:
+  storage-testbench:
     image: gcr.io/cloud-devrel-public-resources/storage-testbench:latest
     environment:
       - PORT=9000
     expose:
       - "9000"
 
-  gcs-testbench-init:
+  gcs:
+    image: nginx:1.27-alpine
+    depends_on:
+      - storage-testbench
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        cat > /etc/nginx/conf.d/default.conf <<'NGINX'
+        server {
+          listen 9000;
+          client_max_body_size 0;
+          location / {
+            proxy_pass http://storage-testbench:9000;
+            proxy_hide_header ETag;
+            add_header ETag '"d41d8cd98f00b204e9800998ecf8427e"' always;
+          }
+        }
+        NGINX
+        exec nginx -g 'daemon off;'
+    expose:
+      - "9000"
+
+  gcs-init:
     image: curlimages/curl:8.10.1
     depends_on:
-      - gcs-testbench
+      - gcs
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
         for i in $(seq 1 60); do
-          curl -sf -X POST "http://gcs-testbench:9000/storage/v1/b?project=test" \
+          curl -sf -X POST "http://gcs:9000/storage/v1/b?project=test" \
             -H "Content-Type: application/json" \
             -d '{"name":"atlan-customer-e2e"}' >/dev/null 2>&1 && break
-          echo "waiting for storage-testbench..."; sleep 2
+          echo "waiting for gcs proxy + testbench..."; sleep 2
         done
-        echo "gcs-testbench-init done"
+        echo "gcs-init done"
     restart: "no"
 
   atlan-app:
-    # STORAGE_EMULATOR_HOST makes Google's Go client (used by daprd's gcp.bucket
-    # binding) talk to the emulator with NO credentials, so daprd inits cleanly
-    # instead of failing ADC lookup. obstore (the SDK's actual I/O path) is
-    # pointed at the same emulator via the component's endpoint→base_url.
+    # STORAGE_EMULATOR_HOST makes daprd's gcp.bucket binding talk to the emulator
+    # credential-free; obstore uses the component endpoint (base_url). Both point
+    # at the nginx proxy so the injected ETag reaches obstore.
     environment:
-      - STORAGE_EMULATOR_HOST=gcs-testbench:9000
+      - STORAGE_EMULATOR_HOST=gcs:9000
     depends_on:
-      gcs-testbench-init:
+      gcs-init:
         condition: service_completed_successfully

--- a/.github/actions/sdr-e2e/profiles/gcp/docker-compose.ci.yml
+++ b/.github/actions/sdr-e2e/profiles/gcp/docker-compose.ci.yml
@@ -25,14 +25,15 @@ services:
           listen 9000;
           client_max_body_size 0;
           location / {
-            # testbench's XML API doesn't implement object DELETE (405); the
-            # worker's post-upload cleanup is best-effort, so ack DELETEs with
-            # 204 to keep the run log clean (object lifetime = container).
-            if ($request_method = DELETE) { return 204; }
             proxy_pass http://storage-testbench:9000;
             proxy_hide_header ETag;
             add_header ETag '"d41d8cd98f00b204e9800998ecf8427e"' always;
           }
+          # NB: the worker's best-effort post-upload cleanup DELETEs log a
+          # benign 405 (testbench's XML API has no object DELETE); the run still
+          # passes. Not silenced via nginx `if` — it's evil + compose eats the
+          # `$request_method` var; the noise is harmless (objects die with the
+          # container).
         }
         NGINX
         exec nginx -g 'daemon off;'

--- a/.github/actions/sdr-e2e/profiles/gcp/docker-compose.ci.yml
+++ b/.github/actions/sdr-e2e/profiles/gcp/docker-compose.ci.yml
@@ -1,36 +1,40 @@
-# Cross-cloud matrix — GCP profile sidecars (fake-gcs-server).
-# The init container self-retries until the JSON API is up, then creates the
-# customer bucket; atlan-app waits for it to complete.
+# Cross-cloud matrix — GCP profile sidecars (Google storage-testbench).
+# fake-gcs-server rejected object_store's uploads with "invalid uploadType"
+# (a documented fake-gcs limitation); Google's official storage-testbench
+# implements the full upload API surface that obstore exercises. The init
+# self-retries until the JSON API is up, then creates the customer bucket;
+# atlan-app waits for it to complete.
 services:
-  fake-gcs:
-    image: fsouza/fake-gcs-server:1.49.2
-    command: ["-scheme", "http", "-port", "4443", "-host", "0.0.0.0", "-public-host", "fake-gcs:4443"]
+  gcs-testbench:
+    image: gcr.io/cloud-devrel-public-resources/storage-testbench:latest
+    environment:
+      - PORT=9000
     expose:
-      - "4443"
+      - "9000"
 
-  fake-gcs-init:
+  gcs-testbench-init:
     image: curlimages/curl:8.10.1
     depends_on:
-      - fake-gcs
+      - gcs-testbench
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
         for i in $(seq 1 60); do
-          curl -sf -X POST "http://fake-gcs:4443/storage/v1/b?project=test" \
+          curl -sf -X POST "http://gcs-testbench:9000/storage/v1/b?project=test" \
             -H "Content-Type: application/json" \
             -d '{"name":"atlan-customer-e2e"}' >/dev/null 2>&1 && break
-          echo "waiting for fake-gcs..."; sleep 2
+          echo "waiting for storage-testbench..."; sleep 2
         done
-        echo "fake-gcs-init done"
+        echo "gcs-testbench-init done"
     restart: "no"
 
   atlan-app:
     # STORAGE_EMULATOR_HOST makes Google's Go client (used by daprd's gcp.bucket
-    # binding) talk to fake-gcs with NO credentials, so daprd inits cleanly
+    # binding) talk to the emulator with NO credentials, so daprd inits cleanly
     # instead of failing ADC lookup. obstore (the SDK's actual I/O path) is
     # pointed at the same emulator via the component's endpoint→base_url.
     environment:
-      - STORAGE_EMULATOR_HOST=fake-gcs:4443
+      - STORAGE_EMULATOR_HOST=gcs-testbench:9000
     depends_on:
-      fake-gcs-init:
+      gcs-testbench-init:
         condition: service_completed_successfully

--- a/.github/actions/sdr-e2e/profiles/gcp/docker-compose.ci.yml
+++ b/.github/actions/sdr-e2e/profiles/gcp/docker-compose.ci.yml
@@ -1,0 +1,30 @@
+# Cross-cloud matrix — GCP profile sidecars (fake-gcs-server).
+# The init container self-retries until the JSON API is up, then creates the
+# customer bucket; atlan-app waits for it to complete.
+services:
+  fake-gcs:
+    image: fsouza/fake-gcs-server:1.49.2
+    command: ["-scheme", "http", "-port", "4443", "-host", "0.0.0.0", "-public-host", "fake-gcs:4443"]
+    expose:
+      - "4443"
+
+  fake-gcs-init:
+    image: curlimages/curl:8.10.1
+    depends_on:
+      - fake-gcs
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        for i in $(seq 1 60); do
+          curl -sf -X POST "http://fake-gcs:4443/storage/v1/b?project=test" \
+            -H "Content-Type: application/json" \
+            -d '{"name":"atlan-customer-e2e"}' >/dev/null 2>&1 && break
+          echo "waiting for fake-gcs..."; sleep 2
+        done
+        echo "fake-gcs-init done"
+    restart: "no"
+
+  atlan-app:
+    depends_on:
+      fake-gcs-init:
+        condition: service_completed_successfully

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -196,9 +196,7 @@ jobs:
           fi
           echo "Using agent-name=$(grep '^name=' "$GITHUB_OUTPUT" | cut -d= -f2)"
 
-      # TEMP(DISTR-767): pinned to the matrix branch to exercise the new
-      # storage-profile support before merge. REVERT to @main before ready.
-      - uses: atlanhq/application-sdk/.github/actions/sdr-e2e@adityachoudhury/gcs-emulator-base-url
+      - uses: atlanhq/application-sdk/.github/actions/sdr-e2e@main
         with:
           app-name: ${{ inputs.app-name }}
           app-image-name: ${{ inputs.app-image-name }}

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -196,7 +196,7 @@ jobs:
           fi
           echo "Using agent-name=$(grep '^name=' "$GITHUB_OUTPUT" | cut -d= -f2)"
 
-      - uses: atlanhq/application-sdk/.github/actions/sdr-e2e@main
+      - uses: atlanhq/application-sdk/.github/actions/sdr-e2e@adityachoudhury/gcs-emulator-base-url
         with:
           app-name: ${{ inputs.app-name }}
           app-image-name: ${{ inputs.app-image-name }}

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -196,7 +196,7 @@ jobs:
           fi
           echo "Using agent-name=$(grep '^name=' "$GITHUB_OUTPUT" | cut -d= -f2)"
 
-      - uses: atlanhq/application-sdk/.github/actions/sdr-e2e@adityachoudhury/gcs-emulator-base-url
+      - uses: atlanhq/application-sdk/.github/actions/sdr-e2e@main
         with:
           app-name: ${{ inputs.app-name }}
           app-image-name: ${{ inputs.app-image-name }}

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -86,6 +86,15 @@ on:
         required: false
         type: string
         default: .github/e2e/e2e-full-docker-compose.yaml
+      storage-profile:
+        description: |
+          Optional cross-cloud storage matrix profile (aws|azure|gcp).
+          Forwarded to the sdr-e2e action, which swaps the customer object
+          store for an emulator (LocalStack/Azurite/fake-gcs). Empty = the
+          SDK default (localstorage), behaviour unchanged.
+        required: false
+        type: string
+        default: ""
       timeout-minutes:
         description: |
           GH job timeout. Must always be > ae_poll_timeout_seconds +
@@ -187,7 +196,9 @@ jobs:
           fi
           echo "Using agent-name=$(grep '^name=' "$GITHUB_OUTPUT" | cut -d= -f2)"
 
-      - uses: atlanhq/application-sdk/.github/actions/sdr-e2e@main
+      # TEMP(DISTR-767): pinned to the matrix branch to exercise the new
+      # storage-profile support before merge. REVERT to @main before ready.
+      - uses: atlanhq/application-sdk/.github/actions/sdr-e2e@adityachoudhury/gcs-emulator-base-url
         with:
           app-name: ${{ inputs.app-name }}
           app-image-name: ${{ inputs.app-image-name }}
@@ -195,6 +206,7 @@ jobs:
           secrets-script: ${{ inputs.secrets-script }}
           components-dir: ${{ inputs.components-dir }}
           compose-overlay: ${{ inputs.compose-overlay }}
+          storage-profile: ${{ inputs.storage-profile }}
           # Bump the container-health wait because the worker has to
           # establish the Temporal connection with TLS + auth before
           # /server/health turns green.

--- a/application_sdk/storage/_obstore_config.py
+++ b/application_sdk/storage/_obstore_config.py
@@ -201,19 +201,27 @@ def make_gcs_store(
     *,
     label: str = "gcs",
     client_options: ClientConfig | None = None,
+    credential_provider: object | None = None,
 ) -> ObjectStore:
     """Create a GCSStore with SDK-default client/retry config.
 
     See :func:`make_s3_store` for rationale.
+
+    *credential_provider* is an optional obstore credential callback, used only
+    for unauthenticated emulators (fake-gcs-server) so obstore skips the
+    metadata-server / OAuth token dance. Real GCS leaves it None.
     """
     from obstore.store import GCSStore  # noqa: PLC0415
 
     opts = client_options if client_options is not None else obstore_client_options()
     retry = obstore_retry_config()
     log_obstore_config(label, client_options=opts, retry_config=retry)
-    return GCSStore(
+    kwargs: dict[str, object] = dict(
         bucket=bucket, config=config, client_options=opts, retry_config=retry
-    )  # type: ignore[arg-type]
+    )
+    if credential_provider is not None:
+        kwargs["credential_provider"] = credential_provider
+    return GCSStore(**kwargs)  # type: ignore[arg-type]
 
 
 def log_obstore_config(

--- a/application_sdk/storage/_obstore_config.py
+++ b/application_sdk/storage/_obstore_config.py
@@ -216,13 +216,12 @@ def make_gcs_store(
     opts = client_options if client_options is not None else obstore_client_options()
     retry = obstore_retry_config()
     log_obstore_config(label, client_options=opts, retry_config=retry)
-    return GCSStore(
-        bucket=bucket,
-        config=config,
-        client_options=opts,
-        retry_config=retry,
-        credential_provider=credential_provider,
-    )  # type: ignore[arg-type]
+    kw: dict[str, object] = dict(
+        bucket=bucket, config=config, client_options=opts, retry_config=retry
+    )
+    if credential_provider is not None:
+        kw["credential_provider"] = credential_provider
+    return GCSStore(**kw)  # type: ignore[arg-type]
 
 
 def log_obstore_config(

--- a/application_sdk/storage/_obstore_config.py
+++ b/application_sdk/storage/_obstore_config.py
@@ -216,12 +216,13 @@ def make_gcs_store(
     opts = client_options if client_options is not None else obstore_client_options()
     retry = obstore_retry_config()
     log_obstore_config(label, client_options=opts, retry_config=retry)
-    kwargs: dict[str, object] = dict(
-        bucket=bucket, config=config, client_options=opts, retry_config=retry
-    )
-    if credential_provider is not None:
-        kwargs["credential_provider"] = credential_provider
-    return GCSStore(**kwargs)  # type: ignore[arg-type]
+    return GCSStore(
+        bucket=bucket,
+        config=config,
+        client_options=opts,
+        retry_config=retry,
+        credential_provider=credential_provider,
+    )  # type: ignore[arg-type]
 
 
 def log_obstore_config(

--- a/application_sdk/storage/binding.py
+++ b/application_sdk/storage/binding.py
@@ -544,19 +544,15 @@ def _build_gcs_config(
             sa_data["private_key"] = sa_data["private_key"].replace("\\n", "\n")
         gcs_config["google_service_account_key"] = orjson.dumps(sa_data).decode()
 
-    # --- Custom endpoint (emulators: fake-gcs-server) -------------------------
+    # --- Custom endpoint (emulators) ------------------------------------------
     # obstore's GCS config key is ``base_url`` (env GOOGLE_BASE_URL); an http://
-    # endpoint means plaintext, so infer allow_http from the scheme — mirrors the
-    # S3 / Azure branches above. Real GCS leaves both unset (default endpoint).
+    # endpoint means plaintext, so infer allow_http from the scheme. Real GCS
+    # leaves the endpoint unset (default).
     endpoint = _nonempty(meta, "endpoint")
     if endpoint:
         gcs_config["base_url"] = endpoint
         if endpoint.lower().startswith("http://"):
             client_options["allow_http"] = True
-    if _coerce_bool(meta.get("disableSSL", "")):
-        client_options["allow_http"] = True
-    if _coerce_bool(meta.get("insecureSSL", "")):
-        client_options["allow_invalid_certificates"] = True
     # NB: ``skipSignature`` (unauthenticated emulators) is NOT a GCS config key —
     # obstore silently ignores it for GCS. It is handled by the caller, which
     # attaches a static anonymous credential_provider instead (see

--- a/application_sdk/storage/binding.py
+++ b/application_sdk/storage/binding.py
@@ -493,10 +493,11 @@ def _build_azure_config(
 
 def _build_gcs_config(
     meta: dict[str, str],
-) -> tuple[str, dict[str, str], dict[str, str] | None]:
+    sdk_client_options: dict[str, object],
+) -> tuple[str, dict[str, str], dict[str, object], dict[str, str] | None]:
     """Translate GCS Dapr binding metadata into obstore GCSStore constructor args.
 
-    Returns *(bucket, config, put_attributes)*.
+    Returns *(bucket, config, client_options, put_attributes)*.
 
     *put_attributes* is ``{"X-Goog-Storage-Class": "<class>"}`` when ``storageClass``
     is set in the binding metadata, or ``None`` otherwise.
@@ -505,6 +506,7 @@ def _build_gcs_config(
 
     bucket = meta.get("bucket", "")
     gcs_config: dict[str, str] = {}
+    client_options = dict(sdk_client_options)
 
     # Build service-account JSON only when actual credential material is
     # supplied.  ``project_id`` alone is not credential material — daprd's
@@ -522,13 +524,27 @@ def _build_gcs_config(
             sa_data["private_key"] = sa_data["private_key"].replace("\\n", "\n")
         gcs_config["google_service_account_key"] = orjson.dumps(sa_data).decode()
 
+    # --- Custom endpoint (emulators: fake-gcs-server) -------------------------
+    # obstore's GCS config key is ``base_url`` (env GOOGLE_BASE_URL); an http://
+    # endpoint means plaintext, so infer allow_http from the scheme — mirrors the
+    # S3 / Azure branches above. Real GCS leaves both unset (default endpoint).
+    endpoint = _nonempty(meta, "endpoint")
+    if endpoint:
+        gcs_config["base_url"] = endpoint
+        if endpoint.lower().startswith("http://"):
+            client_options["allow_http"] = True
+    if _coerce_bool(meta.get("disableSSL", "")):
+        client_options["allow_http"] = True
+    if _coerce_bool(meta.get("insecureSSL", "")):
+        client_options["allow_invalid_certificates"] = True
+
     # --- Storage class --------------------------------------------------------
     storage_class = _nonempty(meta, "storageClass")
     put_attributes: dict[str, str] | None = (
         {"X-Goog-Storage-Class": storage_class} if storage_class else None
     )
 
-    return bucket, gcs_config, put_attributes
+    return bucket, gcs_config, client_options, put_attributes
 
 
 def create_store_from_binding_with_put_attrs(
@@ -668,12 +684,14 @@ def _create_store_core(
         return store, put_attrs
 
     if store_kind == "gcs":
-        bucket, gcs_config, put_attrs = _build_gcs_config(meta)
+        bucket, gcs_config, gcs_client_options, put_attrs = _build_gcs_config(
+            meta, sdk_client_options
+        )
         store = make_gcs_store(
             bucket,
             # Pass ``None`` (not {}) so obstore uses Application Default Credentials.
             gcs_config if gcs_config else None,
-            client_options=sdk_client_options,
+            client_options=gcs_client_options,
         )
         return store, put_attrs
 

--- a/application_sdk/storage/binding.py
+++ b/application_sdk/storage/binding.py
@@ -537,6 +537,11 @@ def _build_gcs_config(
         client_options["allow_http"] = True
     if _coerce_bool(meta.get("insecureSSL", "")):
         client_options["allow_invalid_certificates"] = True
+    # Unauthenticated emulators (fake-gcs-server) reject signed requests; send
+    # anonymous, unsigned requests when the binding opts in. Real GCS never sets
+    # this, so production signing is unaffected.
+    if _coerce_bool(meta.get("skipSignature", "")):
+        gcs_config["skip_signature"] = "true"
 
     # --- Storage class --------------------------------------------------------
     storage_class = _nonempty(meta, "storageClass")

--- a/application_sdk/storage/binding.py
+++ b/application_sdk/storage/binding.py
@@ -491,6 +491,26 @@ def _build_azure_config(
     )
 
 
+def _anonymous_gcs_credential_provider():
+    """Static no-op GCS credential for unauthenticated emulators (fake-gcs-server).
+
+    obstore calls this instead of probing the GCE metadata server / OAuth token
+    endpoint; the emulator ignores the bearer token. Returns obstore's
+    ``GcpCredential`` shape ``{"token", "expires_at"}`` with a far-future expiry so
+    it is never refreshed. Test-only — gated on the binding's ``skipSignature``
+    flag, which real GCS never sets.
+    """
+    from datetime import datetime, timezone  # noqa: PLC0415
+
+    def _provider() -> dict[str, object]:
+        return {
+            "token": "anonymous-emulator",
+            "expires_at": datetime(2999, 1, 1, tzinfo=timezone.utc),
+        }
+
+    return _provider
+
+
 def _build_gcs_config(
     meta: dict[str, str],
     sdk_client_options: dict[str, object],
@@ -537,11 +557,10 @@ def _build_gcs_config(
         client_options["allow_http"] = True
     if _coerce_bool(meta.get("insecureSSL", "")):
         client_options["allow_invalid_certificates"] = True
-    # Unauthenticated emulators (fake-gcs-server) reject signed requests; send
-    # anonymous, unsigned requests when the binding opts in. Real GCS never sets
-    # this, so production signing is unaffected.
-    if _coerce_bool(meta.get("skipSignature", "")):
-        gcs_config["skip_signature"] = "true"
+    # NB: ``skipSignature`` (unauthenticated emulators) is NOT a GCS config key —
+    # obstore silently ignores it for GCS. It is handled by the caller, which
+    # attaches a static anonymous credential_provider instead (see
+    # create_store_from_binding's gcs branch).
 
     # --- Storage class --------------------------------------------------------
     storage_class = _nonempty(meta, "storageClass")
@@ -692,11 +711,22 @@ def _create_store_core(
         bucket, gcs_config, gcs_client_options, put_attrs = _build_gcs_config(
             meta, sdk_client_options
         )
+        # Unauthenticated emulators (fake-gcs-server): obstore's GCS client would
+        # otherwise hit the metadata server / OAuth for a token and fail. A static
+        # no-op credential makes obstore send a (token-bearing) request the emulator
+        # ignores. Gated on skipSignature — real GCS never sets it, so prod auth
+        # (SA key / ADC) is untouched.
+        gcs_credential_provider = (
+            _anonymous_gcs_credential_provider()
+            if _coerce_bool(meta.get("skipSignature", ""))
+            else None
+        )
         store = make_gcs_store(
             bucket,
             # Pass ``None`` (not {}) so obstore uses Application Default Credentials.
             gcs_config if gcs_config else None,
             client_options=gcs_client_options,
+            credential_provider=gcs_credential_provider,
         )
         return store, put_attrs
 

--- a/tests/unit/storage/test_binding.py
+++ b/tests/unit/storage/test_binding.py
@@ -1244,7 +1244,10 @@ class TestGCSStoreCredentials:
 
         config = mock_gcs_cls.call_args.kwargs["config"]
         assert config["base_url"] == "https://fake-gcs:4443"
-        assert mock_gcs_cls.call_args.kwargs["client_options"].get("allow_http") is not True
+        assert (
+            mock_gcs_cls.call_args.kwargs["client_options"].get("allow_http")
+            is not True
+        )
 
     @patch("obstore.store.GCSStore")
     def test_skip_signature_attaches_anonymous_credential_provider(

--- a/tests/unit/storage/test_binding.py
+++ b/tests/unit/storage/test_binding.py
@@ -1247,6 +1247,26 @@ class TestGCSStoreCredentials:
         assert mock_gcs_cls.call_args.kwargs["client_options"].get("allow_http") is not True
 
     @patch("obstore.store.GCSStore")
+    def test_skip_signature_for_unauthenticated_emulator(
+        self, mock_gcs_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """skipSignature → config skip_signature (anonymous requests to fake-gcs)."""
+        components_dir = _write_component(
+            tmp_path,
+            "objectstore",
+            "bindings.gcs",
+            {
+                "bucket": "dev-bucket",
+                "endpoint": "http://fake-gcs:4443",
+                "skipSignature": "true",
+            },
+        )
+        mock_gcs_cls.return_value = MagicMock()
+        create_store_from_binding("objectstore", components_dir=components_dir)
+
+        assert mock_gcs_cls.call_args.kwargs["config"]["skip_signature"] == "true"
+
+    @patch("obstore.store.GCSStore")
     def test_private_key_newlines_normalized(
         self, mock_gcs_cls: MagicMock, tmp_path: Path
     ) -> None:

--- a/tests/unit/storage/test_binding.py
+++ b/tests/unit/storage/test_binding.py
@@ -1247,10 +1247,10 @@ class TestGCSStoreCredentials:
         assert mock_gcs_cls.call_args.kwargs["client_options"].get("allow_http") is not True
 
     @patch("obstore.store.GCSStore")
-    def test_skip_signature_for_unauthenticated_emulator(
+    def test_skip_signature_attaches_anonymous_credential_provider(
         self, mock_gcs_cls: MagicMock, tmp_path: Path
     ) -> None:
-        """skipSignature → config skip_signature (anonymous requests to fake-gcs)."""
+        """skipSignature → a static credential_provider (anonymous fake-gcs auth)."""
         components_dir = _write_component(
             tmp_path,
             "objectstore",
@@ -1264,7 +1264,26 @@ class TestGCSStoreCredentials:
         mock_gcs_cls.return_value = MagicMock()
         create_store_from_binding("objectstore", components_dir=components_dir)
 
-        assert mock_gcs_cls.call_args.kwargs["config"]["skip_signature"] == "true"
+        provider = mock_gcs_cls.call_args.kwargs.get("credential_provider")
+        assert provider is not None
+        cred = provider()
+        assert cred["token"] and cred["expires_at"] is not None
+
+    @patch("obstore.store.GCSStore")
+    def test_no_skip_signature_leaves_credentials_default(
+        self, mock_gcs_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """Without skipSignature, no credential_provider is injected (real GCS path)."""
+        components_dir = _write_component(
+            tmp_path,
+            "objectstore",
+            "bindings.gcs",
+            {"bucket": "prod-bucket", "endpoint": "https://storage.googleapis.com"},
+        )
+        mock_gcs_cls.return_value = MagicMock()
+        create_store_from_binding("objectstore", components_dir=components_dir)
+
+        assert mock_gcs_cls.call_args.kwargs.get("credential_provider") is None
 
     @patch("obstore.store.GCSStore")
     def test_private_key_newlines_normalized(

--- a/tests/unit/storage/test_binding.py
+++ b/tests/unit/storage/test_binding.py
@@ -1211,6 +1211,42 @@ class TestGCSStoreCredentials:
         assert mock_gcs_cls.call_args.kwargs["config"] is None
 
     @patch("obstore.store.GCSStore")
+    def test_http_endpoint_sets_base_url_and_allow_http(
+        self, mock_gcs_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """Emulator (fake-gcs-server): endpoint → config base_url + allow_http."""
+        components_dir = _write_component(
+            tmp_path,
+            "objectstore",
+            "bindings.gcs",
+            {"bucket": "dev-bucket", "endpoint": "http://localhost:4443"},
+        )
+        mock_gcs_cls.return_value = MagicMock()
+        create_store_from_binding("objectstore", components_dir=components_dir)
+
+        config = mock_gcs_cls.call_args.kwargs["config"]
+        assert config["base_url"] == "http://localhost:4443"
+        assert mock_gcs_cls.call_args.kwargs["client_options"]["allow_http"] is True
+
+    @patch("obstore.store.GCSStore")
+    def test_https_endpoint_sets_base_url_without_forcing_allow_http(
+        self, mock_gcs_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """An https endpoint sets base_url but must not flip allow_http on."""
+        components_dir = _write_component(
+            tmp_path,
+            "objectstore",
+            "bindings.gcs",
+            {"bucket": "dev-bucket", "endpoint": "https://fake-gcs:4443"},
+        )
+        mock_gcs_cls.return_value = MagicMock()
+        create_store_from_binding("objectstore", components_dir=components_dir)
+
+        config = mock_gcs_cls.call_args.kwargs["config"]
+        assert config["base_url"] == "https://fake-gcs:4443"
+        assert mock_gcs_cls.call_args.kwargs["client_options"].get("allow_http") is not True
+
+    @patch("obstore.store.GCSStore")
     def test_private_key_newlines_normalized(
         self, mock_gcs_cls: MagicMock, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## What

Adds an opt-in **cross-cloud object-store matrix** to the SDR end-to-end suite: the *same* `BaseE2ETest` full-DAG run, executed with the customer object store backed by each cloud's emulator. **No new test classes or tiers** (per Chris) — it's a `storage-profile` knob on the existing `sdr-e2e` action.

### CI matrix mechanism (DISTR-767)
- `sdr-e2e` action: new opt-in **`storage-profile`** input (`aws` | `azure` | `gcp`). When set, it copies the profile's Dapr component over the customer `objectstore` (last, so it wins) and appends the profile's compose layer (emulator sidecar + bucket/container init). Empty (default) = SDK default `localstorage` — existing behaviour unchanged.
- Profiles under `.github/actions/sdr-e2e/profiles/<cloud>/`:
  - **aws** — LocalStack S3 (`bindings.aws.s3`)
  - **azure** — Azurite (`bindings.azure.blobstorage`; `disableEntityManagement` so daprd doesn't double-create the container)
  - **gcp** — Google **storage-testbench** fronted by a tiny nginx proxy that injects the `ETag` header obstore requires (testbench stores the object but omits ETag on the XML-API PUT)
- `e2e-full-reusable.yaml` forwards the new `storage-profile` input.

### SDK storage support (DISTR-774)
- `application_sdk/storage/binding.py`: map a GCS binding `endpoint` → obstore `base_url` (+ infer `allow_http` for `http://`), and attach a **gated anonymous `credential_provider`** (via `skipSignature`) so obstore can talk to an unauthenticated GCS emulator. Real GCS/Azure are unchanged (Azure already honoured `endpoint`/`useEmulator`).
- `_obstore_config.make_gcs_store` threads the optional `credential_provider`.
- New unit tests in `tests/unit/storage/test_binding.py`.

## Validation (mysql e2e against the CI test tenant)
All three profiles green end-to-end — the worker loads the right store kind and the full asset set lands in Atlas (`{Database:1, Schema:1, Table:2, View:1, Column:11}`):
- **AWS** — run 27603926616 ✅ (`bindings.aws.s3` → LocalStack)
- **Azure** — run 27611511051 ✅ (`bindings.azure.blobstorage` → Azurite)
- **GCS** — run 27613643264 ✅ (`bindings.gcp.bucket` → storage-testbench + ETag proxy)

> The GCS profile logs a benign `405` on the worker's best-effort cleanup `DELETE`s (testbench's XML API has no object DELETE); the run still passes — emulator objects live only for the container.

## Closes
DISTR-762 (AWS), DISTR-763 (GCS), DISTR-764 (Azure), DISTR-767 (matrix runner — object-store axis), DISTR-774 (GCS endpoint override).

## Out of scope (follow-ups)
- **Secret-store matrix** (DISTR-766): AWS Secrets Manager is emulatable (LocalStack); GCP Secret Manager + Azure Key Vault have no emulators (need real creds).
- **Docker/MinIO** object-store variant (DISTR-765).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
