### PR TITLE
feat(task): add optional task_queue routing to @task

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -1741,6 +1741,7 @@ def _wrap_instance_tasks(app_instance: Any, context_data: dict[str, Any]) -> Non
                     task_meta.heartbeat_timeout_seconds,
                     task_meta.auto_heartbeat_seconds,
                     task_meta.retry_policy,
+                    task_meta.task_queue,
                 )
                 setattr(app_instance, attr_name, wrapper)
 
@@ -1756,6 +1757,7 @@ def _create_task_activity_wrapper(
     heartbeat_timeout_seconds: int | None = 60,
     auto_heartbeat_seconds: int | None = 10,
     retry_policy: Any = None,
+    task_queue: str | None = None,
 ) -> Any:
     """Create a wrapper that executes a task as a Temporal activity.
 
@@ -1770,6 +1772,9 @@ def _create_task_activity_wrapper(
         heartbeat_timeout_seconds: Heartbeat timeout. None disables.
         auto_heartbeat_seconds: Auto-heartbeat interval. None disables.
         retry_policy: Full retry policy (overrides max_attempts/interval if set).
+        task_queue: Target Temporal task queue. None inherits the workflow's
+            queue (default, unchanged behavior); a value routes the activity to
+            a dedicated worker pool polling that queue.
 
     Returns:
         Async function that executes the task as an activity.
@@ -1823,6 +1828,10 @@ def _create_task_activity_wrapper(
         # Execute as activity, routed through the SDK eviction-retry loop so
         # worker pod evictions (SIGTERM mid-activity) re-dispatch as fresh
         # attempts without burning the application-error retry budget.
+        # task_queue=None inherits the workflow's queue (Temporal default), so
+        # the kwarg is a no-op unless the task opted into a dedicated queue; the
+        # eviction-retry loop re-passes it on every re-dispatch, so a routed
+        # activity stays routed across evictions.
         result: Output = await execute_activity_with_eviction_retry(
             f"{app_name}:{task_name}",
             args=[task_context, input_data],
@@ -1831,6 +1840,7 @@ def _create_task_activity_wrapper(
             retry_policy=temporal_retry_policy,
             result_type=output_type,
             summary=summary,
+            task_queue=task_queue,
         )
 
         return result

--- a/application_sdk/app/task.py
+++ b/application_sdk/app/task.py
@@ -130,6 +130,13 @@ class TaskMetadata:
     Should be less than heartbeat_timeout_seconds (recommended: 1/6 of timeout).
     Default: 10 seconds."""
 
+    task_queue: str | None = None
+    """Route this task to a specific Temporal task queue. When set, the activity
+    is dispatched to this queue instead of the workflow's own queue, so a
+    dedicated worker deployment polling that queue can execute it (e.g. a
+    resource-isolated pool for a heavy or long-running task). Defaults to None,
+    which inherits the workflow's task queue — i.e. unchanged behavior."""
+
 
 def _validate_task_signature(
     fn: Callable[..., Any],
@@ -242,6 +249,7 @@ def task(
     retry_max_interval_seconds: int = 30,
     heartbeat_timeout_seconds: int | None | object = _USE_DEFAULT,
     auto_heartbeat_seconds: int | None | object = _USE_DEFAULT,
+    task_queue: str | None = None,
 ) -> Callable[[F], F]: ...
 
 
@@ -256,6 +264,7 @@ def task(
     retry_max_interval_seconds: int = 30,
     heartbeat_timeout_seconds: int | None | object = _USE_DEFAULT,
     auto_heartbeat_seconds: int | None | object = _USE_DEFAULT,
+    task_queue: str | None = None,
 ) -> F | Callable[[F], F]:
     """Decorator to mark a method as a task (Temporal activity).
 
@@ -333,6 +342,11 @@ def task(
         auto_heartbeat_seconds: Auto-heartbeat interval - framework sends
             heartbeats at this rate in a background task. Set to None to disable
             auto-heartbeating (manual only). Default: 10 seconds (~1/6 of timeout).
+        task_queue: Route this task to a specific Temporal task queue instead of
+            the workflow's own queue, so a dedicated worker deployment polling
+            that queue executes it (resource isolation for heavy/long-running
+            tasks). Defaults to None — inherits the workflow's queue (unchanged
+            behavior).
 
     Returns:
         The decorated function with task metadata attached.
@@ -379,6 +393,7 @@ def task(
             retry_max_interval_seconds=retry_max_interval_seconds,
             heartbeat_timeout_seconds=resolved_heartbeat_timeout,
             auto_heartbeat_seconds=resolved_auto_heartbeat,
+            task_queue=task_queue,
         )
 
         return fn

--- a/tests/unit/app/test_base.py
+++ b/tests/unit/app/test_base.py
@@ -948,6 +948,47 @@ class TestCreateTaskActivityWrapper:
         # Temporal RetryPolicy uses .maximum_attempts (not .max_attempts).
         assert passed.maximum_attempts == 7
 
+    @pytest.mark.asyncio
+    async def test_wrapper_defaults_task_queue_to_none(self) -> None:
+        """Without routing, task_queue=None is forwarded (inherits the queue)."""
+        wrapper = _create_task_activity_wrapper(
+            app_name="a",
+            task_name="t",
+            timeout_seconds=1,
+            retry_max_attempts=1,
+            retry_max_interval_seconds=1,
+            output_type=_BLDXOutput,
+            context_data={},
+        )
+        with mock.patch(
+            "application_sdk.app.base.workflow.execute_activity",
+            new_callable=mock.AsyncMock,
+            return_value=_BLDXOutput(),
+        ) as exec_act:
+            await wrapper(_BLDXInput())
+        assert exec_act.call_args.kwargs["task_queue"] is None
+
+    @pytest.mark.asyncio
+    async def test_wrapper_routes_to_explicit_task_queue(self) -> None:
+        """A task_queue value is forwarded to workflow.execute_activity."""
+        wrapper = _create_task_activity_wrapper(
+            app_name="a",
+            task_name="t",
+            timeout_seconds=1,
+            retry_max_attempts=1,
+            retry_max_interval_seconds=1,
+            output_type=_BLDXOutput,
+            context_data={},
+            task_queue="atlan-publish-publish",
+        )
+        with mock.patch(
+            "application_sdk.app.base.workflow.execute_activity",
+            new_callable=mock.AsyncMock,
+            return_value=_BLDXOutput(),
+        ) as exec_act:
+            await wrapper(_BLDXInput())
+        assert exec_act.call_args.kwargs["task_queue"] == "atlan-publish-publish"
+
 
 # =============================================================================
 # generate_workflow_class — exercises the whole _run lifecycle end to end

--- a/tests/unit/app/test_task.py
+++ b/tests/unit/app/test_task.py
@@ -178,6 +178,30 @@ class TestTaskMetadata:
         assert metadata.heartbeat_timeout_seconds == 120
         assert metadata.auto_heartbeat_seconds == 20
 
+    def test_task_default_task_queue_is_none(self) -> None:
+        """task_queue defaults to None (inherits the workflow's queue)."""
+
+        class MyApp:
+            @task
+            async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                return SimpleOutput()
+
+        metadata = get_task_metadata(MyApp.my_task)
+        assert metadata is not None
+        assert metadata.task_queue is None
+
+    def test_task_custom_task_queue(self) -> None:
+        """@task(task_queue=...) routes the activity to a dedicated queue."""
+
+        class MyApp:
+            @task(task_queue="atlan-publish-publish")
+            async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                return SimpleOutput()
+
+        metadata = get_task_metadata(MyApp.my_task)
+        assert metadata is not None
+        assert metadata.task_queue == "atlan-publish-publish"
+
     def test_task_disable_heartbeat(self) -> None:
         """Setting heartbeat_timeout_seconds=None disables heartbeating."""
 


### PR DESCRIPTION
## What

Adds an optional `task_queue` to the `@task` contract so an activity can be dispatched to a **specific Temporal task queue** instead of the workflow's own (derived) queue.

```python
@task(task_queue="atlan-publish-publish")
async def publish(self, args: PublishActivityArgs) -> PublishActivityResult:
    ...
```

- `TaskMetadata.task_queue` + `@task(task_queue=...)` parameter (`app/task.py`)
- threaded through `_wrap_instance_tasks` → `_create_task_activity_wrapper` (`app/base.py`)
- forwarded as `task_queue=` to `execute_activity_with_eviction_retry`, which already passes `**kwargs` to `workflow.execute_activity`

## Why

Today every activity runs on the worker's single derived queue (`atlan-{app}-{deployment}`) — the `@task` wrapper supplies no `task_queue`, and one SDK process = one worker = one queue. There is no way to route a single heavy/long-running activity to a **dedicated, independently-scaled worker pool**.

This is the enabling primitive for apps with heterogeneous activities that scale on opposite axes (e.g. a memory-heavy partitioning step that wants few beefy pods vs. a long-running, network-bound step that wants many frugal pods). The first consumer is the publish app (splitting its `publish` activity onto a frugal pool), but the capability is generic and reusable by any app.

## Backwards compatibility

**Fully backwards compatible.** `task_queue` defaults to `None`, which is exactly Temporal's own default for `workflow.execute_activity(task_queue=None)` — "use the workflow's queue." So:

- every existing `@task` is unchanged (no behavior difference, the kwarg is a no-op when `None`);
- the field is an additive dataclass field with a default, so all existing `TaskMetadata(...)` constructions remain valid;
- because the eviction-retry loop re-passes the same `**kwargs` on every re-dispatch, a *routed* activity stays routed across worker evictions (it is **not** silently dropped on retry — which would otherwise land on the churny pool most exposed to eviction).

> Note: this only adds **dispatch-side** routing. The worker side already supports polling an arbitrary queue via `ATLAN_TASK_QUEUE` / `--task-queue`, so no worker/registration change is needed — a dedicated worker deployment sets that env var and polls the routed queue.

## Tests

- `tests/unit/app/test_task.py`: default `task_queue is None`; explicit value preserved on `TaskMetadata`.
- `tests/unit/app/test_base.py`: wrapper forwards `task_queue=None` by default and the explicit value to `workflow.execute_activity`.
- Full `tests/unit/app/` + `tests/unit/execution/test_eviction.py` green (157 passed). ruff 0.6.4 clean, ruff-format clean, pyright 0 errors on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)