### PR TITLE
fix(proxy): honor HTTP(S)_PROXY for Temporal gRPC and obstore object storage

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -562,15 +562,6 @@ If set and points to a directory, all .pem/.crt/.cer/.ca-bundle files
 in that directory are trusted in addition to system CAs.
 """
 
-# Proxy Configuration
-#: Outbound HTTP CONNECT proxy for Temporal gRPC connections. Temporal's client
-#: does not read proxy environment variables on its own, so the SDK forwards
-#: them explicitly, mirroring how HTTP clients select a proxy by target scheme:
-#: HTTPS_PROXY is used for TLS-enabled connections and HTTP_PROXY for plaintext.
-#: Lowercase variants are honored as a fallback.
-HTTPS_PROXY = os.getenv("HTTPS_PROXY") or os.getenv("https_proxy") or ""
-HTTP_PROXY = os.getenv("HTTP_PROXY") or os.getenv("http_proxy") or ""
-
 # Daft analytics are disabled via ENV vars in the Dockerfile (DO_NOT_TRACK,
 # SCARF_NO_ANALYTICS, DAFT_ANALYTICS_ENABLED). They must NOT be set here at
 # module level — os.environ assignments call os.putenv(), which Temporal's

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -562,6 +562,15 @@ If set and points to a directory, all .pem/.crt/.cer/.ca-bundle files
 in that directory are trusted in addition to system CAs.
 """
 
+# Proxy Configuration
+#: Outbound HTTP CONNECT proxy for Temporal gRPC connections. Temporal's client
+#: does not read proxy environment variables on its own, so the SDK forwards
+#: them explicitly, mirroring how HTTP clients select a proxy by target scheme:
+#: HTTPS_PROXY is used for TLS-enabled connections and HTTP_PROXY for plaintext.
+#: Lowercase variants are honored as a fallback.
+HTTPS_PROXY = os.getenv("HTTPS_PROXY") or os.getenv("https_proxy") or ""
+HTTP_PROXY = os.getenv("HTTP_PROXY") or os.getenv("http_proxy") or ""
+
 # Daft analytics are disabled via ENV vars in the Dockerfile (DO_NOT_TRACK,
 # SCARF_NO_ANALYTICS, DAFT_ANALYTICS_ENABLED). They must NOT be set here at
 # module level — os.environ assignments call os.putenv(), which Temporal's

--- a/application_sdk/execution/_temporal/backend.py
+++ b/application_sdk/execution/_temporal/backend.py
@@ -446,30 +446,25 @@ def _build_temporal_proxy_config(
 ) -> HttpConnectProxyConfig | None:
     """Build an HTTP CONNECT proxy config for the Temporal gRPC connection.
 
-    Temporal's client does not read proxy environment variables on its own, so
-    the SDK forwards them explicitly, resolving them through the stdlib
-    (:func:`urllib.request.getproxies`) exactly like ``httpx`` does:
-
-    * the proxy is selected by target scheme — ``HTTPS_PROXY`` for TLS-enabled
-      connections, ``HTTP_PROXY`` for plaintext;
-    * ``NO_PROXY`` is honored (so in-cluster Temporal reached via Service DNS is
-      never tunneled);
-    * upper/lowercase env variants and the httpoxy CGI mitigation come for free.
+    Temporal doesn't read proxy env vars itself, so we resolve them via the
+    stdlib (``urllib.request.getproxies``) like httpx: HTTPS_PROXY for TLS,
+    HTTP_PROXY for plaintext, honoring NO_PROXY.
 
     Args:
-        host: Temporal target ``host[:port]`` (used for NO_PROXY matching and to
-            keep the proxy CONNECT keyed by hostname).
+        host: Temporal target ``host[:port]`` (used for NO_PROXY matching).
         tls_enabled: Whether the Temporal connection uses TLS.
 
     Returns:
-        An ``HttpConnectProxyConfig`` when a proxy applies, else ``None`` (direct).
+        An ``HttpConnectProxyConfig``, or ``None`` for a direct connection.
     """
     proxies = urllib.request.getproxies()
     proxy = proxies.get("https" if tls_enabled else "http")
     if not proxy:
         return None
 
-    hostname = host.rsplit(":", 1)[0]  # drop :port before NO_PROXY matching
+    # bare host:port needs // so urlsplit reads it as an authority
+    normalised = host if "//" in host else f"//{host}"
+    hostname = urlsplit(normalised).hostname
     if urllib.request.proxy_bypass_environment(hostname, proxies):
         logger.info("Temporal host %s matches NO_PROXY; connecting directly", host)
         return None

--- a/application_sdk/execution/_temporal/backend.py
+++ b/application_sdk/execution/_temporal/backend.py
@@ -7,8 +7,10 @@ import ipaddress
 import random
 import socket
 import threading
+import urllib.request
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
 
 from temporalio.client import Client
 from temporalio.contrib.pydantic import pydantic_data_converter
@@ -16,8 +18,6 @@ from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
 
 from application_sdk.constants import (
     ENABLE_ATLAN_UPLOAD,
-    HTTP_PROXY,
-    HTTPS_PROXY,
     TEMPORAL_PROMETHEUS_BIND_ADDRESS,
 )
 from application_sdk.execution.retry import RetryPolicy, _to_temporal_retry_policy
@@ -441,29 +441,66 @@ def _apply_sni_domain(tls: TLSConfig | bool, sni: str) -> TLSConfig | bool:
     return tls
 
 
-def _build_temporal_proxy_config(*, tls_enabled: bool) -> HttpConnectProxyConfig | None:
+def _build_temporal_proxy_config(
+    host: str, *, tls_enabled: bool
+) -> HttpConnectProxyConfig | None:
     """Build an HTTP CONNECT proxy config for the Temporal gRPC connection.
 
     Temporal's client does not read proxy environment variables on its own, so
-    the SDK forwards them explicitly — mirroring how HTTP clients select a proxy
-    by target scheme: ``HTTPS_PROXY`` for TLS-enabled connections and
-    ``HTTP_PROXY`` for plaintext. Returns ``None`` when no proxy is configured.
+    the SDK forwards them explicitly, resolving them through the stdlib
+    (:func:`urllib.request.getproxies`) exactly like ``httpx`` does:
+
+    * the proxy is selected by target scheme — ``HTTPS_PROXY`` for TLS-enabled
+      connections, ``HTTP_PROXY`` for plaintext;
+    * ``NO_PROXY`` is honored (so in-cluster Temporal reached via Service DNS is
+      never tunneled);
+    * upper/lowercase env variants and the httpoxy CGI mitigation come for free.
+
+    Args:
+        host: Temporal target ``host[:port]`` (used for NO_PROXY matching and to
+            keep the proxy CONNECT keyed by hostname).
+        tls_enabled: Whether the Temporal connection uses TLS.
+
+    Returns:
+        An ``HttpConnectProxyConfig`` when a proxy applies, else ``None`` (direct).
     """
-    proxy = HTTPS_PROXY if tls_enabled else HTTP_PROXY
+    proxies = urllib.request.getproxies()
+    proxy = proxies.get("https" if tls_enabled else "http")
     if not proxy:
         return None
+
+    hostname = host.rsplit(":", 1)[0]  # drop :port before NO_PROXY matching
+    if urllib.request.proxy_bypass_environment(hostname, proxies):
+        logger.info("Temporal host %s matches NO_PROXY; connecting directly", host)
+        return None
+
+    parsed = urlsplit(proxy)  # RFC 3986 proxy URL, e.g. http://host:port
+    if parsed.scheme == "https":
+        logger.warning(
+            "Proxy URL uses an https:// scheme, but Temporal's HTTP CONNECT "
+            "tunnel reaches the proxy over plaintext (no TLS-to-proxy)."
+        )
+
+    # hostname[:port] only — keep any userinfo out of target_host and the logs.
+    target_host = (
+        f"{parsed.hostname}:{parsed.port}" if parsed.port else (parsed.hostname or "")
+    )
+    basic_auth = (
+        (parsed.username, parsed.password)
+        if parsed.username and parsed.password
+        else None
+    )
 
     from temporalio.service import (  # noqa: PLC0415 — cold path: only when a proxy is configured
         HttpConnectProxyConfig,
     )
 
-    target_host = proxy.split("://", 1)[-1].rstrip("/")  # strip scheme/trailing slash
     logger.info(
         "Routing Temporal gRPC via HTTP CONNECT proxy %s (tls=%s)",
         target_host,
         tls_enabled,
     )
-    return HttpConnectProxyConfig(target_host=target_host)
+    return HttpConnectProxyConfig(target_host=target_host, basic_auth=basic_auth)
 
 
 async def create_temporal_client(
@@ -549,6 +586,10 @@ async def create_temporal_client(
             "Connecting to Temporal (plaintext): host=%s namespace=%s", host, namespace
         )
 
+    # Temporal's client ignores proxy env vars, so forward an HTTP CONNECT proxy
+    # explicitly when HTTPS_PROXY/HTTP_PROXY is set (selected by TLS state).
+    proxy_config = _build_temporal_proxy_config(host, tls_enabled=tls_enabled)
+
     # SDR-only: pre-resolve the target hostname and prefer IPv4 when the OS
     # resolver returns both A and AAAA. Solves the half-broken-IPv6 case on
     # customer SDR hosts (link-local-only v6, or v6 enabled without a global
@@ -566,8 +607,11 @@ async def create_temporal_client(
     # stay healthy through Service IP churn. Only SDR — where DNS goes
     # through Cloudflare anycast and there's no in-cluster Service to track
     # — benefits from the literal-IP substitution.
+    #
+    # Skipped when a proxy is in use: the proxy does DNS, so we keep the hostname
+    # (CONNECT <hostname>, preserving allowlists) instead of sending a bare IP.
     resolved_host, sni_host = host, None
-    if ENABLE_ATLAN_UPLOAD:
+    if ENABLE_ATLAN_UPLOAD and proxy_config is None:
         resolved_host, sni_host = await _prefer_v4_target(host)
         if sni_host is not None:
             # We substituted an IP for the hostname — preserve TLS SNI so
@@ -591,10 +635,6 @@ async def create_temporal_client(
     }
     if api_key:
         kwargs["api_key"] = api_key
-
-    # Temporal's client ignores proxy env vars, so forward an HTTP CONNECT proxy
-    # explicitly when HTTPS_PROXY/HTTP_PROXY is set (selected by TLS state).
-    proxy_config = _build_temporal_proxy_config(tls_enabled=tls_enabled)
     if proxy_config is not None:
         kwargs["http_connect_proxy_config"] = proxy_config
 

--- a/application_sdk/execution/_temporal/backend.py
+++ b/application_sdk/execution/_temporal/backend.py
@@ -470,6 +470,16 @@ def _build_temporal_proxy_config(
         return None
 
     parsed = urlsplit(proxy)  # RFC 3986 proxy URL, e.g. http://host:port
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        # e.g. a schemeless "proxy.corp:8080" — fail loudly instead of handing
+        # Temporal an empty target_host. Log scheme/host only (no userinfo).
+        logger.error(
+            "Malformed proxy URL — expected http://host[:port], got scheme=%r "
+            "host=%r; connecting Temporal directly.",
+            parsed.scheme,
+            parsed.hostname,
+        )
+        return None
     if parsed.scheme == "https":
         logger.warning(
             "Proxy URL uses an https:// scheme, but Temporal's HTTP CONNECT "
@@ -477,14 +487,10 @@ def _build_temporal_proxy_config(
         )
 
     # hostname[:port] only — keep any userinfo out of target_host and the logs.
-    target_host = (
-        f"{parsed.hostname}:{parsed.port}" if parsed.port else (parsed.hostname or "")
-    )
-    basic_auth = (
-        (parsed.username, parsed.password)
-        if parsed.username and parsed.password
-        else None
-    )
+    target_host = f"{parsed.hostname}:{parsed.port}" if parsed.port else parsed.hostname
+    # Keep auth when only a username is present (token-as-username proxies,
+    # e.g. http://TOKEN@proxy/) — password defaults to empty rather than dropping.
+    basic_auth = (parsed.username, parsed.password or "") if parsed.username else None
 
     from temporalio.service import (  # noqa: PLC0415 — cold path: only when a proxy is configured
         HttpConnectProxyConfig,

--- a/application_sdk/execution/_temporal/backend.py
+++ b/application_sdk/execution/_temporal/backend.py
@@ -16,6 +16,8 @@ from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
 
 from application_sdk.constants import (
     ENABLE_ATLAN_UPLOAD,
+    HTTP_PROXY,
+    HTTPS_PROXY,
     TEMPORAL_PROMETHEUS_BIND_ADDRESS,
 )
 from application_sdk.execution.retry import RetryPolicy, _to_temporal_retry_policy
@@ -82,7 +84,7 @@ if TYPE_CHECKING:
     from datetime import timedelta
 
     from temporalio.converter import DataConverter
-    from temporalio.service import TLSConfig
+    from temporalio.service import HttpConnectProxyConfig, TLSConfig
 
     from application_sdk.app.base import App
     from application_sdk.app.context import AppContext
@@ -439,6 +441,31 @@ def _apply_sni_domain(tls: TLSConfig | bool, sni: str) -> TLSConfig | bool:
     return tls
 
 
+def _build_temporal_proxy_config(*, tls_enabled: bool) -> HttpConnectProxyConfig | None:
+    """Build an HTTP CONNECT proxy config for the Temporal gRPC connection.
+
+    Temporal's client does not read proxy environment variables on its own, so
+    the SDK forwards them explicitly — mirroring how HTTP clients select a proxy
+    by target scheme: ``HTTPS_PROXY`` for TLS-enabled connections and
+    ``HTTP_PROXY`` for plaintext. Returns ``None`` when no proxy is configured.
+    """
+    proxy = HTTPS_PROXY if tls_enabled else HTTP_PROXY
+    if not proxy:
+        return None
+
+    from temporalio.service import (  # noqa: PLC0415 — cold path: only when a proxy is configured
+        HttpConnectProxyConfig,
+    )
+
+    target_host = proxy.split("://", 1)[-1].rstrip("/")  # strip scheme/trailing slash
+    logger.info(
+        "Routing Temporal gRPC via HTTP CONNECT proxy %s (tls=%s)",
+        target_host,
+        tls_enabled,
+    )
+    return HttpConnectProxyConfig(target_host=target_host)
+
+
 async def create_temporal_client(
     host: str = "localhost:7233",
     namespace: str = "default",
@@ -459,6 +486,10 @@ async def create_temporal_client(
 
     Supports plain TCP, TLS, mTLS, and API key auth. Retries the connection
     up to ``connect_max_attempts`` times with exponential backoff.
+
+    When ``HTTPS_PROXY`` (TLS) or ``HTTP_PROXY`` (plaintext) is set, the gRPC
+    connection is routed through that HTTP CONNECT proxy. Temporal does not read
+    these env vars itself, so the SDK forwards them.
 
     Args:
         host: Temporal server address.
@@ -560,6 +591,12 @@ async def create_temporal_client(
     }
     if api_key:
         kwargs["api_key"] = api_key
+
+    # Temporal's client ignores proxy env vars, so forward an HTTP CONNECT proxy
+    # explicitly when HTTPS_PROXY/HTTP_PROXY is set (selected by TLS state).
+    proxy_config = _build_temporal_proxy_config(tls_enabled=tls_enabled)
+    if proxy_config is not None:
+        kwargs["http_connect_proxy_config"] = proxy_config
 
     # Configure Temporal runtime (with or without Prometheus metrics)
     kwargs["runtime"] = _get_or_create_runtime(

--- a/application_sdk/storage/_obstore_config.py
+++ b/application_sdk/storage/_obstore_config.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 import os
 import urllib.request
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit, urlunsplit
 
 if TYPE_CHECKING:
     # obstore TypedDicts — not importable at runtime.
@@ -246,8 +247,26 @@ def log_obstore_config(
     logger.info(
         "obstore configured for %s: client=%s retry=%s",
         provider,
-        dict(client_options) if client_options else {},
+        _redact_proxy_userinfo(client_options) if client_options else {},
         dict(retry_config)
         if retry_config
         else "default(max_retries=10, retry_timeout=3m)",
     )
+
+
+def _redact_proxy_userinfo(client_options: ClientConfig) -> dict:
+    """Return a copy of *client_options* with any proxy_url credentials masked.
+
+    The real config keeps the userinfo (obstore needs it); only the log copy is
+    redacted so a `user:pass@` proxy never lands in logs.
+    """
+    opts = dict(client_options)
+    proxy = opts.get("proxy_url")
+    if not isinstance(proxy, str):
+        return opts
+    p = urlsplit(proxy)
+    if p.username or p.password:
+        host = p.hostname or ""
+        netloc = f"***@{host}:{p.port}" if p.port else f"***@{host}"
+        opts["proxy_url"] = urlunsplit((p.scheme, netloc, p.path, p.query, p.fragment))
+    return opts

--- a/application_sdk/storage/_obstore_config.py
+++ b/application_sdk/storage/_obstore_config.py
@@ -43,6 +43,7 @@ without changing the outcome (see BLDX-1155 review thread).
 from __future__ import annotations
 
 import os
+import urllib.request
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -78,6 +79,16 @@ def _default_user_agent() -> str:
         return "atlan-application-sdk"
 
 
+def _obstore_proxy_url() -> str | None:
+    """Return the proxy URL from HTTPS_PROXY/HTTP_PROXY, or None.
+
+    obstore doesn't read proxy env vars itself, so we pass ``proxy_url``
+    explicitly. NO_PROXY isn't honored — the binding has no per-host excludes.
+    """
+    proxies = urllib.request.getproxies()
+    return proxies.get("https") or proxies.get("http") or None
+
+
 def obstore_client_options() -> ClientConfig:
     """Build an obstore ``ClientConfig`` from environment variables.
 
@@ -103,6 +114,9 @@ def obstore_client_options() -> ClientConfig:
     pool_max = os.getenv("ATLAN_OBSTORE_POOL_MAX_IDLE_PER_HOST")
     if pool_max:
         opts["pool_max_idle_per_host"] = pool_max
+    proxy_url = _obstore_proxy_url()
+    if proxy_url:
+        opts["proxy_url"] = proxy_url
     return opts
 
 

--- a/tests/unit/execution/test_backend.py
+++ b/tests/unit/execution/test_backend.py
@@ -485,21 +485,34 @@ class TestCreateTemporalClient:
 
 
 # ---------------------------------------------------------------------------
-# HTTP CONNECT proxy support (HTTPS_PROXY / HTTP_PROXY)
+# HTTP CONNECT proxy support (HTTPS_PROXY / HTTP_PROXY / NO_PROXY via stdlib)
 # ---------------------------------------------------------------------------
 
 
 class TestTemporalProxyConfig:
+    """Proxy resolution goes through urllib.request.getproxies /
+    proxy_bypass_environment, so tests patch those to stay platform-independent
+    (plain proxy_bypass reads system config on macOS)."""
+
     @staticmethod
     def _connect_mock():
         return mock.AsyncMock(return_value=mock.MagicMock())
 
+    @staticmethod
+    def _proxy_env(proxies: dict, bypass: bool = False):
+        """Patch the stdlib proxy resolver to return *proxies* and *bypass*."""
+        return (
+            mock.patch("urllib.request.getproxies", return_value=proxies),
+            mock.patch("urllib.request.proxy_bypass_environment", return_value=bypass),
+        )
+
     @pytest.mark.asyncio
     async def test_no_proxy_config_when_env_unset(self) -> None:
-        """No HTTPS_PROXY/HTTP_PROXY set -> connect directly (no proxy kwarg)."""
+        """No proxy in the environment -> connect directly (no proxy kwarg)."""
+        getproxies, bypass = self._proxy_env({})
         with (
-            mock.patch.object(backend_module, "HTTPS_PROXY", ""),
-            mock.patch.object(backend_module, "HTTP_PROXY", ""),
+            getproxies,
+            bypass,
             mock.patch.object(backend_module, "_get_or_create_runtime"),
             mock.patch.object(
                 backend_module.Client, "connect", new=self._connect_mock()
@@ -510,10 +523,11 @@ class TestTemporalProxyConfig:
 
     @pytest.mark.asyncio
     async def test_https_proxy_used_when_tls_enabled(self) -> None:
-        """HTTPS_PROXY is used (scheme stripped) when TLS is enabled."""
+        """The 'https' proxy is used (scheme stripped) when TLS is enabled."""
+        getproxies, bypass = self._proxy_env({"https": "http://proxy.corp:8080"})
         with (
-            mock.patch.object(backend_module, "HTTPS_PROXY", "http://proxy.corp:8080"),
-            mock.patch.object(backend_module, "HTTP_PROXY", ""),
+            getproxies,
+            bypass,
             mock.patch.object(backend_module, "_get_or_create_runtime"),
             mock.patch.object(
                 backend_module.Client, "connect", new=self._connect_mock()
@@ -522,12 +536,14 @@ class TestTemporalProxyConfig:
             await create_temporal_client(tls_enabled=True, connect_max_attempts=1)
         proxy = connect.await_args.kwargs["http_connect_proxy_config"]
         assert proxy.target_host == "proxy.corp:8080"
+        assert proxy.basic_auth is None
 
     @pytest.mark.asyncio
     async def test_http_proxy_used_when_plaintext(self) -> None:
+        getproxies, bypass = self._proxy_env({"http": "http://plainproxy:3128"})
         with (
-            mock.patch.object(backend_module, "HTTPS_PROXY", ""),
-            mock.patch.object(backend_module, "HTTP_PROXY", "plainproxy:3128"),
+            getproxies,
+            bypass,
             mock.patch.object(backend_module, "_get_or_create_runtime"),
             mock.patch.object(
                 backend_module.Client, "connect", new=self._connect_mock()
@@ -539,17 +555,93 @@ class TestTemporalProxyConfig:
 
     @pytest.mark.asyncio
     async def test_proxy_selected_by_tls_state(self) -> None:
-        """HTTPS_PROXY must not be used for a plaintext connection."""
+        """Only an 'http' proxy set -> a TLS connection picks nothing (direct)."""
+        getproxies, bypass = self._proxy_env({"http": "http://proxy.corp:3128"})
         with (
-            mock.patch.object(backend_module, "HTTPS_PROXY", "http://proxy.corp:8080"),
-            mock.patch.object(backend_module, "HTTP_PROXY", ""),
+            getproxies,
+            bypass,
             mock.patch.object(backend_module, "_get_or_create_runtime"),
             mock.patch.object(
                 backend_module.Client, "connect", new=self._connect_mock()
             ) as connect,
         ):
-            await create_temporal_client(tls_enabled=False, connect_max_attempts=1)
+            await create_temporal_client(tls_enabled=True, connect_max_attempts=1)
         assert "http_connect_proxy_config" not in connect.await_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_no_proxy_bypass(self) -> None:
+        """NO_PROXY match -> connect directly even with a proxy configured."""
+        getproxies, bypass = self._proxy_env(
+            {"https": "http://proxy.corp:8080", "no": "internal.corp"}, bypass=True
+        )
+        with (
+            getproxies,
+            bypass,
+            mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(
+                backend_module.Client, "connect", new=self._connect_mock()
+            ) as connect,
+        ):
+            await create_temporal_client(
+                host="temporal.internal.corp:7233",
+                tls_enabled=True,
+                connect_max_attempts=1,
+            )
+        assert "http_connect_proxy_config" not in connect.await_args.kwargs
+
+    def test_build_proxy_config_extracts_credentials_without_leaking(self) -> None:
+        """Credentials become basic_auth and never appear in target_host."""
+        getproxies, bypass = self._proxy_env(
+            {"https": "http://user:pass@proxy.corp:8080"}
+        )
+        with getproxies, bypass:
+            cfg = backend_module._build_temporal_proxy_config(
+                "tmprl:443", tls_enabled=True
+            )
+        assert cfg is not None
+        assert cfg.target_host == "proxy.corp:8080"
+        assert cfg.basic_auth == ("user", "pass")
+
+    def test_build_proxy_config_warns_on_https_scheme(self) -> None:
+        getproxies, bypass = self._proxy_env({"https": "https://proxy.corp:443"})
+        with (
+            getproxies,
+            bypass,
+            mock.patch.object(backend_module.logger, "warning") as warn,
+        ):
+            cfg = backend_module._build_temporal_proxy_config(
+                "tmprl:443", tls_enabled=True
+            )
+        assert cfg is not None
+        assert cfg.target_host == "proxy.corp:443"
+        warn.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_proxy_skips_sdr_ipv4_substitution(self) -> None:
+        """With a proxy set, _prefer_v4_target is skipped so the proxy sees the
+        hostname (not a bare IP) and does DNS itself."""
+        getproxies, bypass = self._proxy_env({"https": "http://proxy.corp:8080"})
+        with (
+            getproxies,
+            bypass,
+            mock.patch.object(backend_module, "ENABLE_ATLAN_UPLOAD", True),
+            mock.patch.object(
+                backend_module, "_prefer_v4_target", new=mock.AsyncMock()
+            ) as prefer_v4,
+            mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(
+                backend_module.Client, "connect", new=self._connect_mock()
+            ) as connect,
+        ):
+            await create_temporal_client(
+                host="tenant-temporal.atlan.com:443",
+                tls_enabled=True,
+                connect_max_attempts=1,
+            )
+        prefer_v4.assert_not_awaited()
+        assert (
+            connect.await_args.kwargs["target_host"] == "tenant-temporal.atlan.com:443"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/execution/test_backend.py
+++ b/tests/unit/execution/test_backend.py
@@ -607,6 +607,22 @@ class TestTemporalProxyConfig:
             cfg = backend_module._build_temporal_proxy_config(host, tls_enabled=True)
         assert cfg is None
 
+    def test_malformed_schemeless_proxy_rejected(self) -> None:
+        """A schemeless proxy value (ops typo) is rejected with an error log and
+        a direct connection, not a silent empty target_host."""
+        with (
+            mock.patch(
+                "urllib.request.getproxies", return_value={"https": "proxy.corp:8080"}
+            ),
+            mock.patch("urllib.request.proxy_bypass_environment", return_value=False),
+            mock.patch.object(backend_module.logger, "error") as err,
+        ):
+            cfg = backend_module._build_temporal_proxy_config(
+                "tmprl:443", tls_enabled=True
+            )
+        assert cfg is None
+        err.assert_called_once()
+
     def test_build_proxy_config_extracts_credentials_without_leaking(self) -> None:
         """Credentials become basic_auth and never appear in target_host."""
         getproxies, bypass = self._proxy_env(
@@ -619,6 +635,16 @@ class TestTemporalProxyConfig:
         assert cfg is not None
         assert cfg.target_host == "proxy.corp:8080"
         assert cfg.basic_auth == ("user", "pass")
+
+    def test_build_proxy_config_keeps_token_username_without_password(self) -> None:
+        """Token-as-username proxy (http://TOKEN@proxy/) keeps auth, empty pass."""
+        getproxies, bypass = self._proxy_env({"https": "http://TOKEN@proxy.corp:8080"})
+        with getproxies, bypass:
+            cfg = backend_module._build_temporal_proxy_config(
+                "tmprl:443", tls_enabled=True
+            )
+        assert cfg is not None
+        assert cfg.basic_auth == ("TOKEN", "")
 
     def test_build_proxy_config_warns_on_https_scheme(self) -> None:
         getproxies, bypass = self._proxy_env({"https": "https://proxy.corp:443"})

--- a/tests/unit/execution/test_backend.py
+++ b/tests/unit/execution/test_backend.py
@@ -589,6 +589,24 @@ class TestTemporalProxyConfig:
             )
         assert "http_connect_proxy_config" not in connect.await_args.kwargs
 
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "svc.internal.corp:7233",  # bare host:port
+            "https://svc.internal.corp:443",  # scheme-prefixed (customer form)
+            "user:pass@svc.internal.corp:7233",  # with userinfo
+        ],
+    )
+    def test_no_proxy_matches_on_bare_hostname(self, host: str) -> None:
+        """NO_PROXY matches on the hostname regardless of scheme/userinfo/port."""
+        # Real proxy_bypass_environment runs against the extracted hostname.
+        with mock.patch(
+            "urllib.request.getproxies",
+            return_value={"https": "http://proxy.corp:8080", "no": "internal.corp"},
+        ):
+            cfg = backend_module._build_temporal_proxy_config(host, tls_enabled=True)
+        assert cfg is None
+
     def test_build_proxy_config_extracts_credentials_without_leaking(self) -> None:
         """Credentials become basic_auth and never appear in target_host."""
         getproxies, bypass = self._proxy_env(

--- a/tests/unit/execution/test_backend.py
+++ b/tests/unit/execution/test_backend.py
@@ -485,6 +485,74 @@ class TestCreateTemporalClient:
 
 
 # ---------------------------------------------------------------------------
+# HTTP CONNECT proxy support (HTTPS_PROXY / HTTP_PROXY)
+# ---------------------------------------------------------------------------
+
+
+class TestTemporalProxyConfig:
+    @staticmethod
+    def _connect_mock():
+        return mock.AsyncMock(return_value=mock.MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_no_proxy_config_when_env_unset(self) -> None:
+        """No HTTPS_PROXY/HTTP_PROXY set -> connect directly (no proxy kwarg)."""
+        with (
+            mock.patch.object(backend_module, "HTTPS_PROXY", ""),
+            mock.patch.object(backend_module, "HTTP_PROXY", ""),
+            mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(
+                backend_module.Client, "connect", new=self._connect_mock()
+            ) as connect,
+        ):
+            await create_temporal_client(tls_enabled=True, connect_max_attempts=1)
+        assert "http_connect_proxy_config" not in connect.await_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_https_proxy_used_when_tls_enabled(self) -> None:
+        """HTTPS_PROXY is used (scheme stripped) when TLS is enabled."""
+        with (
+            mock.patch.object(backend_module, "HTTPS_PROXY", "http://proxy.corp:8080"),
+            mock.patch.object(backend_module, "HTTP_PROXY", ""),
+            mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(
+                backend_module.Client, "connect", new=self._connect_mock()
+            ) as connect,
+        ):
+            await create_temporal_client(tls_enabled=True, connect_max_attempts=1)
+        proxy = connect.await_args.kwargs["http_connect_proxy_config"]
+        assert proxy.target_host == "proxy.corp:8080"
+
+    @pytest.mark.asyncio
+    async def test_http_proxy_used_when_plaintext(self) -> None:
+        with (
+            mock.patch.object(backend_module, "HTTPS_PROXY", ""),
+            mock.patch.object(backend_module, "HTTP_PROXY", "plainproxy:3128"),
+            mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(
+                backend_module.Client, "connect", new=self._connect_mock()
+            ) as connect,
+        ):
+            await create_temporal_client(tls_enabled=False, connect_max_attempts=1)
+        proxy = connect.await_args.kwargs["http_connect_proxy_config"]
+        assert proxy.target_host == "plainproxy:3128"
+
+    @pytest.mark.asyncio
+    async def test_proxy_selected_by_tls_state(self) -> None:
+        """HTTPS_PROXY must not be used for a plaintext connection."""
+        with (
+            mock.patch.object(backend_module, "HTTPS_PROXY", "http://proxy.corp:8080"),
+            mock.patch.object(backend_module, "HTTP_PROXY", ""),
+            mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(
+                backend_module.Client, "connect", new=self._connect_mock()
+            ) as connect,
+        ):
+            await create_temporal_client(tls_enabled=False, connect_max_attempts=1)
+        assert "http_connect_proxy_config" not in connect.await_args.kwargs
+
+
+# ---------------------------------------------------------------------------
 # _prefer_v4_target / _apply_sni_domain (IPv6-fallback safety net)
 #
 # These guard against a v3-vs-v2 regression seen on two SDR customer VMs:

--- a/tests/unit/storage/test_obstore_config.py
+++ b/tests/unit/storage/test_obstore_config.py
@@ -59,7 +59,10 @@ class TestClientOptionsOverrides:
         monkeypatch.setenv("ATLAN_OBSTORE_USER_AGENT", "custom-agent/1.0")
         monkeypatch.setenv("ATLAN_OBSTORE_POOL_MAX_IDLE_PER_HOST", "32")
 
-        opts = obstore_client_options()
+        # Pin no proxy so the exact-dict assertion is deterministic regardless
+        # of the host's proxy env / system settings.
+        with patch("urllib.request.getproxies", return_value={}):
+            opts = obstore_client_options()
         assert opts == {
             "timeout": "1h",
             "connect_timeout": "10s",
@@ -68,6 +71,49 @@ class TestClientOptionsOverrides:
             "user_agent": "custom-agent/1.0",
             "pool_max_idle_per_host": "32",
         }
+
+
+# ---------------------------------------------------------------------------
+# proxy_url plumbing (obstore does not read proxy env vars itself)
+# ---------------------------------------------------------------------------
+
+
+class TestClientOptionsProxy:
+    """proxy_url is forwarded from the standard proxy env vars; getproxies is
+    patched so the result is platform-independent (it reads system config on
+    macOS)."""
+
+    def test_no_proxy_url_when_env_unset(self) -> None:
+        with patch("urllib.request.getproxies", return_value={}):
+            opts = obstore_client_options()
+        assert "proxy_url" not in opts
+
+    def test_https_proxy_is_used(self) -> None:
+        with patch(
+            "urllib.request.getproxies",
+            return_value={"https": "http://proxy.corp:8080"},
+        ):
+            opts = obstore_client_options()
+        assert opts["proxy_url"] == "http://proxy.corp:8080"
+
+    def test_http_proxy_used_as_fallback(self) -> None:
+        with patch(
+            "urllib.request.getproxies",
+            return_value={"http": "http://proxy.corp:3128"},
+        ):
+            opts = obstore_client_options()
+        assert opts["proxy_url"] == "http://proxy.corp:3128"
+
+    def test_https_preferred_over_http(self) -> None:
+        with patch(
+            "urllib.request.getproxies",
+            return_value={
+                "https": "http://secure.corp:8080",
+                "http": "http://plain.corp:3128",
+            },
+        ):
+            opts = obstore_client_options()
+        assert opts["proxy_url"] == "http://secure.corp:8080"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/storage/test_obstore_config.py
+++ b/tests/unit/storage/test_obstore_config.py
@@ -183,6 +183,19 @@ class TestLogObstoreConfig:
         formatted = fmt % tuple(args)
         assert "default(max_retries=10" in formatted
 
+    def test_redacts_proxy_userinfo(self) -> None:
+        """A proxy_url with credentials must not log the password."""
+        with patch("application_sdk.storage._obstore_config.logger") as mock_logger:
+            log_obstore_config(
+                "s3",
+                client_options={"proxy_url": "http://user:secretpass@proxy.corp:8080"},
+                retry_config=None,
+            )
+        fmt, *args = mock_logger.info.call_args.args
+        formatted = fmt % tuple(args)
+        assert "secretpass" not in formatted
+        assert "***@proxy.corp:8080" in formatted
+
 
 # ---------------------------------------------------------------------------
 # binding.py / cloud.py plumbing — the actual fix


### PR DESCRIPTION
- Temporal's Rust client and obstore (object storage) don't read proxy env vars themselves, so in a proxy-locked network the Temporal gRPC connection failed at the TLS handshake (`tls handshake eof`).
- httpx (OAuth token exchange) already honors `HTTPS_PROXY`/`HTTP_PROXY`/`NO_PROXY` natively — no change needed there.
- **Temporal** (`_temporal/backend.py`): resolve the proxy via `urllib.request.getproxies()` — `HTTPS_PROXY` for TLS, `HTTP_PROXY` for plaintext — honor `NO_PROXY`, and pass `HttpConnectProxyConfig` to `Client.connect`.
- Skip the SDR IPv4-substitution when proxied so the proxy receives `CONNECT <hostname>` (preserves hostname allowlists).
- **obstore** (`storage/_obstore_config.py`): set `client_options["proxy_url"]` from the same env vars.
- Object storage goes through obstore
- Validated end-to-end against a live tenant through a real HTTP `CONNECT` proxy.
- Tests: `test_backend.py` (TLS selection, scheme/userinfo/port stripping, `NO_PROXY`, credentials, https-warning, IPv4-skip) and `test_obstore_config.py` (`proxy_url` resolution).