### PR TITLE
refactor(contracts): make cleanup contracts payload-safe without the unbounded-fields opt-out

### DIFF
--- a/application_sdk/contracts/cleanup.py
+++ b/application_sdk/contracts/cleanup.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from pydantic import Field
 
 from application_sdk.contracts.base import Input, Output
+from application_sdk.contracts.types import MaxItems
 
 
-class CleanupInput(Input, allow_unbounded_fields=True):
+class CleanupInput(Input):
     """Input for ``App.cleanup_files``.
 
     Args:
@@ -18,10 +21,10 @@ class CleanupInput(Input, allow_unbounded_fields=True):
             always cleaned up regardless of this field.
     """
 
-    extra_paths: list[str] = Field(default_factory=list)
+    extra_paths: Annotated[list[str], MaxItems(10000)] = Field(default_factory=list)
 
 
-class CleanupOutput(Output, allow_unbounded_fields=True):
+class CleanupOutput(Output):
     """Output from ``App.cleanup_files``.
 
     Args:
@@ -29,10 +32,12 @@ class CleanupOutput(Output, allow_unbounded_fields=True):
             already absent, ``False`` = error during deletion).
     """
 
-    path_results: dict[str, bool] = Field(default_factory=dict)
+    path_results: Annotated[dict[str, bool], MaxItems(10000)] = Field(
+        default_factory=dict
+    )
 
 
-class StorageCleanupInput(Input, allow_unbounded_fields=True):
+class StorageCleanupInput(Input):
     """Input for ``App.cleanup_storage``.
 
     Args:
@@ -46,7 +51,7 @@ class StorageCleanupInput(Input, allow_unbounded_fields=True):
     include_prefix_cleanup: bool = False
 
 
-class StorageCleanupOutput(Output, allow_unbounded_fields=True):
+class StorageCleanupOutput(Output):
     """Output from ``App.cleanup_storage``.
 
     Args:


### PR DESCRIPTION
## Summary

The four `App.cleanup_files` / `App.cleanup_storage` contracts each declared `allow_unbounded_fields=True`, opting out of the SDK's import-time payload-safety validation. This removes all four opt-outs — the SDK no longer needs them at all.

| Contract | Was | Now |
|---|---|---|
| `StorageCleanupInput` (`bool`) | `allow_unbounded_fields=True` | plain `Input` — already payload-safe, opt-out was **vestigial** |
| `StorageCleanupOutput` (3× `int`) | `allow_unbounded_fields=True` | plain `Output` — already payload-safe, opt-out was **vestigial** |
| `CleanupInput.extra_paths` (`list[str]`) | `allow_unbounded_fields=True` | `Annotated[list[str], MaxItems(10000)]` — bounded |
| `CleanupOutput.path_results` (`dict[str, bool]`) | `allow_unbounded_fields=True` | `Annotated[dict[str, bool], MaxItems(10000)]` — bounded |

### Why this is safe
- `allow_unbounded_fields` only suppresses an **import-time field-*type* check**; it has nothing to do with runtime extra-field acceptance.
- Two contracts (`Storage*`) have only scalar fields and were already payload-safe — the opt-out did nothing.
- The other two use the SDK's own bounded-collection pattern. **`MaxItems` is a declarative marker for the payload scanner — verified *not* Pydantic-runtime-enforced** — so this adds no runtime validation and cannot crash large cleanups.
- **Both collections are bounded symmetrically at `MaxItems(10000)`**: with reasonable per-entry assumptions that covers ~1MB of JSON payload, leaving headroom for "extreme" path counts counterbalanced by simpler paths, and staying well under Temporal's 2MB limit.

### Relationship to #2162
[#2162](https://github.com/atlanhq/application-sdk/pull/2162) adds the conformance **P001 `UnboundedContractFields`** check (BLOCK). This PR removes the only real `allow_unbounded_fields=True` declarations in `application_sdk/`, so P001 passes **with zero opt-outs and zero suppressions** — no inline `# conformance: ignore[P001]` needed anywhere. Whichever of the two PRs merges second should rebase; once both are in, the SDK's `Conformance / Prescriptions` dogfood job is green.

### Downstream consumer audit
Ran a version-agnostic `/audit-consumers` clean sweep across all 145 `atlanhq/` consumers of `application_sdk`. **No consumer is affected — not even slightly.** The only break vector (subclassing an SDK cleanup contract) has zero instances org-wide; the one real user (`atlan-mongodbatlas-app`) constructs the contracts with zero args (unchanged); the other name matches are unrelated same-named contracts in `oracle`/`policy-manager`/`tableau`.

## Test plan

- [x] All 4 contracts import & instantiate with no opt-out (payload-safety validation passes).
- [x] 17 cleanup unit tests pass (`test_cleanup_files`, `test_cleanup_storage`).
- [x] `ruff` / `ruff-format` / `isort` / `pyright` clean.
- [x] No real `allow_unbounded_fields=True` ClassDef remains in `application_sdk/` (only docstring examples).
- [x] Downstream consumer audit: 0 affected.

Part of BLDX-1428.