### PR TITLE
ci: support private-org git dependencies (build secret mount + certify auth)

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -75,6 +75,11 @@ on:
         required: false
         type: string
         default: "app"
+      private_git_auth:
+        description: "Set true if the app has a private-org (atlanhq) git dependency that `uv sync` must clone in the certify gate. When true, certify authenticates atlanhq GitHub remotes with ORG_PAT_GITHUB before installing deps, so the install succeeds and unit tests actually run. Default false — apps with only PyPI deps are unaffected."
+        required: false
+        type: boolean
+        default: false
     secrets:
       ORG_PAT_GITHUB:
         required: true
@@ -423,6 +428,14 @@ jobs:
           fi
 
       # ── 2. App dependencies ───────────────────────────────────────────────────
+      - name: Configure git auth for private dependencies
+        if: ${{ inputs.private_git_auth }}
+        env:
+          GIT_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+        run: |
+          git config --global url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "https://github.com/atlanhq/"
+          git config --global --add url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "ssh://git@github.com/atlanhq/"
+
       - name: Install app dependencies
         id: app_install
         continue-on-error: true
@@ -1087,6 +1100,8 @@ jobs:
           build-args: |
             ACCESS_TOKEN_USR=${{ github.actor }}
             ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
+          secrets: |
+            git_token=${{ secrets.ORG_PAT_GITHUB }}
 
   # ── Job 3: Merge arch digests into a single multi-arch manifest ───────────────
   merge:


### PR DESCRIPTION
## What
Make the shared `build-and-publish-app.yaml` support apps that pull a **private-org git dependency** via `uv sync`. Two additive, default-off changes:

1. **build step** — add a `secrets:` input to `build-push-action` so app Dockerfiles can authenticate the private clone via a BuildKit secret mount (`--mount=type=secret,id=git_token`).
2. **certify gate** — add an opt-in `private_git_auth` input; when set, certify authenticates `atlanhq` GitHub remotes (org-scoped) before `uv sync`.

## Why
First consumer: the **query-redaction** library (in the QI app repo) pulled into extractor apps (BigQuery, Snowflake) to redact queries during extraction. Consumer Dockerfile already wired: https://github.com/atlanhq/atlan-bigquery-app/compare/main...test/qi-redaction-dep-build

**build:** today the token is passed only as a `build-arg` ([L1087-1089](https://github.com/atlanhq/application-sdk/blob/main/.github/workflows/build-and-publish-app.yaml#L1087-L1089)), so Dockerfiles must consume it via `ARG` — which leaks it into image history and the `cache-to: type=gha,mode=max` cache ([Docker anti-pattern](https://docs.docker.com/build/building/secrets/), SEC-628 / SEC-3988).

**certify:** the gate runs `uv sync` on the runner; with a private git dep it fails (no git auth), and because that step is `continue-on-error`, the unit tests **silently skip** while the gate still passes — an app can publish with its tests never run.

## Change
```yaml
# build step
secrets: |
  git_token=${{ secrets.ORG_PAT_GITHUB }}

# new workflow_call input
private_git_auth: { type: boolean, default: false }

# certify, before `uv sync`
- if: ${{ inputs.private_git_auth }}
  run: git config --global url."https://x-access-token:${TOKEN}@github.com/atlanhq/".insteadOf "https://github.com/atlanhq/"   # + ssh form
```
Both are **additive and default-off** — the ~120 apps on this workflow are unaffected until they opt in. A consumer turns on certify auth with `with: private_git_auth: true` in its caller workflow.

## Notes / possible follow-ups
- **Token scope:** reuses `ORG_PAT_GITHUB`. A read-only token scoped to the single private repo would be least-privilege — happy to follow up.
- **Placement:** kept on the inline `build-push-action`; can redirect through the `secure-build-push-apps` action if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
