### PR TITLE
feat(conformance): smarter bootstrap with auto-detection and renovate.json scaffold

### DIFF
--- a/packages/conformance/conformance/bootstrap/templates/renovate.json
+++ b/packages/conformance/conformance/bootstrap/templates/renovate.json
@@ -1,4 +1,6 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["github>atlanhq/application-sdk//renovate-config/default.json"],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>atlanhq/application-sdk//renovate-config/default.json"
+  ]
 }

--- a/packages/conformance/conformance/bootstrap/templates/renovate.json
+++ b/packages/conformance/conformance/bootstrap/templates/renovate.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["github>atlanhq/application-sdk//renovate-config/default.json"],
+}

--- a/packages/conformance/conformance/bootstrap/templates/tests.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/tests.yaml
@@ -74,7 +74,9 @@ jobs:
     with:
       app-name: "<< app_name >>"
       app-image-name: "<< app_image_name >>"
+<% if enable_e2e != 'true' %>
       enable-e2e: << enable_e2e >>
+<% endif %>
 <% if services_script %>
       services-script: "<< services_script >>"
 <% else %>

--- a/packages/conformance/conformance/cli.py
+++ b/packages/conformance/conformance/cli.py
@@ -83,6 +83,38 @@ def _ensure_gitignore_entry(root: pathlib.Path, entry: str) -> None:
     print(f"appended:  {gitignore}  ({entry!r})")
 
 
+def _read_atlan_yaml_name(root: pathlib.Path) -> str:
+    """Return the ``name:`` value from ``atlan.yaml`` in *root*, or ``""``."""
+    import re
+
+    atlan_yaml = root / "atlan.yaml"
+    if not atlan_yaml.exists():
+        return ""
+    try:
+        for line in atlan_yaml.read_text(encoding="utf-8").splitlines():
+            m = re.match(r"^name:\s+(\S+)", line)
+            if m:
+                return m.group(1)
+    except OSError:
+        pass
+    return ""
+
+
+def _derive_app_name_from_dir(root: pathlib.Path) -> str:
+    """Derive app name from the repo directory name.
+
+    Strips a leading ``atlan-`` prefix and a trailing ``-app`` suffix so that
+    e.g. ``atlan-openapi-app`` → ``openapi``.  Falls back to ``"app"`` if the
+    result would be empty.
+    """
+    name = root.name
+    if name.startswith("atlan-"):
+        name = name[len("atlan-") :]
+    if name.endswith("-app"):
+        name = name[: -len("-app")]
+    return name or "app"
+
+
 def _parse_bootstrap_args(argv: list[str]) -> dict[str, str]:
     """Parse bootstrap flags from argv.
 
@@ -92,16 +124,20 @@ def _parse_bootstrap_args(argv: list[str]) -> dict[str, str]:
     -----
     --package-name NAME          docstring-coverage package (default: app)
     --unit-tests-workflow FILE   build-and-publish test workflow (default: tests.yaml)
-    --app-name NAME              connector app name for tests.yaml scaffold (default: app)
+    --app-name NAME              connector app name for tests.yaml scaffold
+                                 (default: auto-detected from atlan.yaml, else "app")
     --app-image-name NAME        GHCR image name for tests.yaml scaffold (default: atlan-<app-name>-app)
     --enable-e2e BOOL            enable e2e job in tests.yaml scaffold (default: true)
+    --services-script PATH       path to services setup script for tests.yaml scaffold
+                                 (default: auto-detected from .github/test/setup-services.sh)
     """
     result: dict[str, str] = {
         "package_name": "app",
         "unit_tests_workflow": "tests.yaml",
-        "app_name": "app",
+        "app_name": "",
         "app_image_name": "",
         "enable_e2e": "true",
+        "services_script": "",
     }
     _flags = {
         "--package-name": "package_name",
@@ -109,6 +145,7 @@ def _parse_bootstrap_args(argv: list[str]) -> dict[str, str]:
         "--app-name": "app_name",
         "--app-image-name": "app_image_name",
         "--enable-e2e": "enable_e2e",
+        "--services-script": "services_script",
     }
     i = 0
     while i < len(argv):
@@ -139,6 +176,17 @@ def _cmd_bootstrap(argv: list[str]) -> int:
 
     kwargs = _parse_bootstrap_args(argv)
     root = pathlib.Path.cwd()
+    # Auto-detect app name when --app-name was not supplied:
+    # 1. atlan.yaml `name:` field, 2. repo directory name, 3. "app".
+    if not kwargs["app_name"]:
+        kwargs["app_name"] = _read_atlan_yaml_name(root) or _derive_app_name_from_dir(
+            root
+        )
+    # Auto-detect services-script when --services-script was not supplied.
+    if not kwargs["services_script"]:
+        candidate = root / ".github" / "test" / "setup-services.sh"
+        if candidate.exists():
+            kwargs["services_script"] = ".github/test/setup-services.sh"
 
     _bootstrap_file(
         root / ".claude" / "skills" / "remediate" / "SKILL.md",
@@ -187,9 +235,10 @@ commands:
                  (scaffolded once; delete it and re-run to regenerate from canonical).
                    --package-name NAME         docstring-coverage package (default: app)
                    --unit-tests-workflow FILE   build-and-publish test workflow (default: tests.yaml)
-                   --app-name NAME             connector app name for tests.yaml (default: app)
+                   --app-name NAME             connector app name for tests.yaml (default: from atlan.yaml, else "app")
                    --app-image-name NAME       GHCR image name for tests.yaml (default: atlan-<app-name>-app)
-                   --enable-e2e true|false     enable e2e in tests.yaml (default: true)
+                   --enable-e2e true|false     enable e2e in tests.yaml (default: true, line omitted)
+                   --services-script PATH      services setup script (default: auto-detected from .github/test/setup-services.sh)
 """
 
 

--- a/packages/conformance/conformance/cli.py
+++ b/packages/conformance/conformance/cli.py
@@ -198,16 +198,20 @@ def _cmd_bootstrap(argv: list[str]) -> int:
             render(name, **kwargs),
         )
 
-    # tests.yaml is write-if-absent (not always-overwrite) — bootstrap creates
-    # it once as a starting point; apps customise it freely.  C002 tracks drift
-    # at WARN only.  To force-regenerate: delete the file and re-run bootstrap.
-    tests_dest = root / ".github" / "workflows" / "tests.yaml"
-    if not tests_dest.exists():
-        tests_dest.parent.mkdir(parents=True, exist_ok=True)
-        tests_dest.write_text(render("tests.yaml", **kwargs), encoding="utf-8")
-        print(f"scaffolded: {tests_dest}")
-    else:
-        print(f"ok (exists): {tests_dest}  (edit freely; C002 tracks drift at WARN)")
+    # Write-if-absent scaffolds — created once; apps customise freely.
+    # C002 tracks drift at WARN only.  Delete + re-run to force-regenerate.
+    for scaffold_dest, scaffold_name in [
+        (root / ".github" / "workflows" / "tests.yaml", "tests.yaml"),
+        (root / "renovate.json", "renovate.json"),
+    ]:
+        if not scaffold_dest.exists():
+            scaffold_dest.parent.mkdir(parents=True, exist_ok=True)
+            scaffold_dest.write_text(render(scaffold_name, **kwargs), encoding="utf-8")
+            print(f"scaffolded: {scaffold_dest}")
+        else:
+            print(
+                f"ok (exists): {scaffold_dest}  (edit freely; C002 tracks drift at WARN)"
+            )
 
     _ensure_gitignore_entry(root, "remediation/")
     return 0

--- a/packages/conformance/conformance/cli.py
+++ b/packages/conformance/conformance/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pathlib
+import re
 import sys
 
 
@@ -85,7 +86,6 @@ def _ensure_gitignore_entry(root: pathlib.Path, entry: str) -> None:
 
 def _read_atlan_yaml_name(root: pathlib.Path) -> str:
     """Return the ``name:`` value from ``atlan.yaml`` in *root*, or ``""``."""
-    import re
 
     atlan_yaml = root / "atlan.yaml"
     if not atlan_yaml.exists():
@@ -94,7 +94,7 @@ def _read_atlan_yaml_name(root: pathlib.Path) -> str:
         for line in atlan_yaml.read_text(encoding="utf-8").splitlines():
             m = re.match(r"^name:\s+(\S+)", line)
             if m:
-                return m.group(1)
+                return m.group(1).strip("\"'")
     except OSError:
         pass
     return ""

--- a/packages/conformance/conformance/suite/checks/bootstrap_drift.py
+++ b/packages/conformance/conformance/suite/checks/bootstrap_drift.py
@@ -36,8 +36,9 @@ RULE_ID = "C002"
 
 _CLI_CMD = "atlan-application-sdk-conformance bootstrap"
 
-# Filename of the write-if-absent scaffold (tracked separately from MANAGED_WORKFLOWS).
+# Write-if-absent scaffolds tracked alongside managed shims (WARN-only drift).
 _TESTS_WORKFLOW = "tests.yaml"
+_RENOVATE_JSON = "renovate.json"
 
 # ---------------------------------------------------------------------------
 # Managed-shim param extractors
@@ -98,15 +99,16 @@ def _extract_tests_yaml_params(text: str) -> dict[str, str]:
 
 
 def discover(root: Path) -> list[Path]:
-    """Return expected managed + scaffold workflow paths under root/.github/workflows/.
+    """Return expected managed + scaffold paths for this repo.
 
     Paths are returned whether or not they exist; ``scan_path`` handles the
     missing-file case so absent shims are reported as findings.
     """
     wf_dir = root / ".github" / "workflows"
     paths = [wf_dir / name for name in MANAGED_WORKFLOWS]
-    # Also track the write-if-absent tests.yaml scaffold.
+    # Write-if-absent scaffolds (WARN-only drift tracking).
     paths.append(wf_dir / _TESTS_WORKFLOW)
+    paths.append(root / _RENOVATE_JSON)
     return paths
 
 
@@ -114,6 +116,8 @@ def scan_path(path: Path, root: Path) -> list[Finding]:
     """Return C002 findings for *path* (may or may not exist on disk)."""
     if path.name == _TESTS_WORKFLOW:
         return _scan_tests_yaml(path, root)
+    if path.name == _RENOVATE_JSON:
+        return _scan_renovate_json(path, root)
     return _scan_managed_shim(path, root)
 
 
@@ -164,6 +168,52 @@ def _scan_managed_shim(path: Path, root: Path) -> list[Finding]:
             message=(
                 f"CI workflow '{name}' has drifted from the bootstrap canonical. "
                 f"Run `{_CLI_CMD}` to re-sync."
+            ),
+        )
+    ]
+
+
+def _scan_renovate_json(path: Path, root: Path) -> list[Finding]:
+    """Scan the write-if-absent renovate.json scaffold — WARN-only, never BLOCK."""
+    try:
+        rel = path.relative_to(root).as_posix()
+    except ValueError:
+        rel = str(path)
+
+    _remediate = (
+        f"To regenerate, delete renovate.json and re-run `{_CLI_CMD}` "
+        f"(drift is informational — WARN only, never blocks CI)."
+    )
+
+    if not path.exists():
+        return [
+            Finding(
+                rule_id=RULE_ID,
+                file=rel,
+                line=1,
+                column=1,
+                message=(
+                    f"Scaffolded renovate.json is absent. "
+                    f"Run `{_CLI_CMD}` to regenerate it. " + _remediate
+                ),
+            )
+        ]
+
+    on_disk = path.read_text(encoding="utf-8")
+    canonical = render(_RENOVATE_JSON)
+
+    if on_disk == canonical:
+        return []
+
+    return [
+        Finding(
+            rule_id=RULE_ID,
+            file=rel,
+            line=1,
+            column=1,
+            message=(
+                "Scaffolded renovate.json has drifted from the bootstrap canonical. "
+                + _remediate
             ),
         )
     ]

--- a/packages/conformance/pyproject.toml
+++ b/packages/conformance/pyproject.toml
@@ -47,6 +47,9 @@ packages = ["conformance"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
 
+[tool.ruff.format]
+exclude = ["conformance/bootstrap/templates/renovate.json"]
+
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["G004", "PLC0415", "F841", "T201"]
 "conformance/tools/generate_rule_docs.py" = ["E402"]

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -14,6 +14,7 @@ from conformance.bootstrap.render import MANAGED_WORKFLOWS, render
 from conformance.cli import (
     _bootstrap_file,
     _cmd_bootstrap,
+    _derive_app_name_from_dir,
     _ensure_gitignore_entry,
     _parse_bootstrap_args,
 )
@@ -127,9 +128,10 @@ def test_parse_bootstrap_args_defaults() -> None:
     assert result == {
         "package_name": "app",
         "unit_tests_workflow": "tests.yaml",
-        "app_name": "app",
+        "app_name": "",
         "app_image_name": "",
         "enable_e2e": "true",
+        "services_script": "",
     }
 
 
@@ -357,13 +359,15 @@ def test_cmd_bootstrap_tests_yaml_recreated_when_deleted(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Delete tests.yaml → re-run bootstrap → file regenerated from canonical."""
-    monkeypatch.chdir(tmp_path)
+    app_dir = tmp_path / "atlan-myapp-app"
+    app_dir.mkdir()
+    monkeypatch.chdir(app_dir)
     _cmd_bootstrap([])
-    wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+    wf = app_dir / ".github" / "workflows" / "tests.yaml"
     wf.unlink()
     _cmd_bootstrap([])
     assert wf.exists()
-    assert wf.read_text() == render("tests.yaml")
+    assert wf.read_text() == render("tests.yaml", app_name="myapp")
 
 
 # ---------------------------------------------------------------------------
@@ -403,7 +407,7 @@ def test_tests_yaml_default_app_name() -> None:
     content = render("tests.yaml")
     assert 'app-name: "app"' in content
     assert 'app-image-name: "atlan-app-app"' in content
-    assert "enable-e2e: true" in content
+    assert "enable-e2e:" not in content
 
 
 def test_tests_yaml_custom_app_name_and_image() -> None:
@@ -453,3 +457,149 @@ def test_cmd_bootstrap_custom_app_args_propagate(
     assert 'app-name: "mysql"' in tests
     assert 'app-image-name: "custom-image-name"' in tests
     assert "enable-e2e: false" in tests
+
+
+# ---------------------------------------------------------------------------
+# Auto-detection: app name from atlan.yaml
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_bootstrap_reads_app_name_from_atlan_yaml(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """bootstrap reads `name:` from atlan.yaml when --app-name is not supplied."""
+    (tmp_path / "atlan.yaml").write_text("name: openapi\ndisplay_name: OpenAPI\n")
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    tests = (tmp_path / ".github" / "workflows" / "tests.yaml").read_text()
+    assert 'app-name: "openapi"' in tests
+    assert 'app-image-name: "atlan-openapi-app"' in tests
+
+
+def test_cmd_bootstrap_explicit_app_name_overrides_atlan_yaml(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Explicit --app-name takes priority over atlan.yaml."""
+    (tmp_path / "atlan.yaml").write_text("name: openapi\n")
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap(["--app-name", "mysql"])
+    tests = (tmp_path / ".github" / "workflows" / "tests.yaml").read_text()
+    assert 'app-name: "mysql"' in tests
+
+
+def test_cmd_bootstrap_falls_back_to_dir_name(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without atlan.yaml, app name is derived from the repo directory name."""
+    app_dir = tmp_path / "atlan-postgres-app"
+    app_dir.mkdir()
+    monkeypatch.chdir(app_dir)
+    _cmd_bootstrap([])
+    tests = (app_dir / ".github" / "workflows" / "tests.yaml").read_text()
+    assert 'app-name: "postgres"' in tests
+    assert 'app-image-name: "atlan-postgres-app"' in tests
+
+
+def test_cmd_bootstrap_atlan_yaml_takes_priority_over_dir_name(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """atlan.yaml name: takes priority over the directory name."""
+    app_dir = tmp_path / "atlan-wrong-app"
+    app_dir.mkdir()
+    (app_dir / "atlan.yaml").write_text("name: openapi\n")
+    monkeypatch.chdir(app_dir)
+    _cmd_bootstrap([])
+    tests = (app_dir / ".github" / "workflows" / "tests.yaml").read_text()
+    assert 'app-name: "openapi"' in tests
+
+
+# ---------------------------------------------------------------------------
+# Auto-detection: services-script from .github/test/setup-services.sh
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_bootstrap_detects_services_script(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """bootstrap activates services-script when .github/test/setup-services.sh exists."""
+    script = tmp_path / ".github" / "test" / "setup-services.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text("#!/bin/bash\n")
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    tests = (tmp_path / ".github" / "workflows" / "tests.yaml").read_text()
+    assert 'services-script: ".github/test/setup-services.sh"' in tests
+    assert "# services-script:" not in tests
+
+
+def test_cmd_bootstrap_no_services_script_when_absent(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without setup-services.sh the services-script line stays commented out."""
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    tests = (tmp_path / ".github" / "workflows" / "tests.yaml").read_text()
+    assert "# services-script:" in tests
+    assert 'services-script: ".github/test/setup-services.sh"' not in tests
+
+
+def test_cmd_bootstrap_explicit_services_script_overrides_autodetect(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Explicit --services-script takes priority over auto-detected path."""
+    script = tmp_path / ".github" / "test" / "setup-services.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text("#!/bin/bash\n")
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap(["--services-script", ".github/test/custom-setup.sh"])
+    tests = (tmp_path / ".github" / "workflows" / "tests.yaml").read_text()
+    assert 'services-script: ".github/test/custom-setup.sh"' in tests
+
+
+# ---------------------------------------------------------------------------
+# enable-e2e: omitted when default (true)
+# ---------------------------------------------------------------------------
+
+
+def test_tests_yaml_enable_e2e_omitted_when_default() -> None:
+    """enable-e2e: true is the reusable workflow default — don't emit it."""
+    content = render("tests.yaml")
+    assert "enable-e2e:" not in content
+
+
+def test_tests_yaml_enable_e2e_present_when_false() -> None:
+    """enable-e2e: false must appear explicitly to opt out of e2e."""
+    content = render("tests.yaml", enable_e2e="false")
+    assert "enable-e2e: false" in content
+
+
+# ---------------------------------------------------------------------------
+# _derive_app_name_from_dir unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_derive_strips_atlan_prefix_and_app_suffix(tmp_path: pathlib.Path) -> None:
+    assert _derive_app_name_from_dir(tmp_path / "atlan-openapi-app") == "openapi"
+
+
+def test_derive_strips_only_prefix(tmp_path: pathlib.Path) -> None:
+    assert _derive_app_name_from_dir(tmp_path / "atlan-openapi") == "openapi"
+
+
+def test_derive_strips_only_suffix(tmp_path: pathlib.Path) -> None:
+    assert _derive_app_name_from_dir(tmp_path / "my-connector-app") == "my-connector"
+
+
+def test_derive_no_affixes(tmp_path: pathlib.Path) -> None:
+    assert _derive_app_name_from_dir(tmp_path / "postgres") == "postgres"
+
+
+def test_derive_hello_world(tmp_path: pathlib.Path) -> None:
+    assert (
+        _derive_app_name_from_dir(tmp_path / "atlan-hello-world-app") == "hello-world"
+    )
+
+
+def test_derive_falls_back_to_app_for_bare_atlan(tmp_path: pathlib.Path) -> None:
+    # "atlan-app" → strip prefix → "app" → strip suffix ("app" doesn't end with "-app") → "app"
+    assert _derive_app_name_from_dir(tmp_path / "atlan-app") == "app"

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -327,6 +327,58 @@ def test_cmd_bootstrap_custom_args_propagate(
 
 
 # ---------------------------------------------------------------------------
+# renovate.json scaffold — write-if-absent semantics
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_bootstrap_writes_renovate_json(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    assert (tmp_path / "renovate.json").exists()
+
+
+def test_cmd_bootstrap_renovate_json_not_in_managed_workflows() -> None:
+    assert "renovate.json" not in MANAGED_WORKFLOWS
+
+
+def test_cmd_bootstrap_renovate_json_is_write_if_absent(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second bootstrap run must NOT overwrite an already-customised renovate.json."""
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    rj = tmp_path / "renovate.json"
+    rj.write_text('{"customised": true}\n')
+    _cmd_bootstrap([])
+    assert rj.read_text() == '{"customised": true}\n'
+
+
+def test_cmd_bootstrap_renovate_json_recreated_when_deleted(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Delete renovate.json → re-run bootstrap → file regenerated from canonical."""
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    rj = tmp_path / "renovate.json"
+    rj.unlink()
+    _cmd_bootstrap([])
+    assert rj.exists()
+    assert rj.read_text() == render("renovate.json")
+
+
+def test_renovate_json_contains_fleet_preset() -> None:
+    content = render("renovate.json")
+    assert "atlanhq/application-sdk//renovate-config/default.json" in content
+
+
+def test_renovate_json_contains_schema() -> None:
+    content = render("renovate.json")
+    assert "renovate-schema.json" in content
+
+
+# ---------------------------------------------------------------------------
 # tests.yaml scaffold — write-if-absent semantics
 # ---------------------------------------------------------------------------
 

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -528,6 +528,17 @@ def test_cmd_bootstrap_reads_app_name_from_atlan_yaml(
     assert 'app-image-name: "atlan-openapi-app"' in tests
 
 
+def test_cmd_bootstrap_strips_quotes_from_atlan_yaml_name(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Quoted name: \"openapi\" in atlan.yaml should still resolve to openapi."""
+    (tmp_path / "atlan.yaml").write_text('name: "openapi"\n')
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    tests = (tmp_path / ".github" / "workflows" / "tests.yaml").read_text()
+    assert 'app-name: "openapi"' in tests
+
+
 def test_cmd_bootstrap_explicit_app_name_overrides_atlan_yaml(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/packages/conformance/tests/test_bootstrap_drift.py
+++ b/packages/conformance/tests/test_bootstrap_drift.py
@@ -63,16 +63,17 @@ def test_c002_is_autofixable() -> None:
 def test_discover_returns_all_managed_paths(tmp_path: pathlib.Path) -> None:
     paths = discover(tmp_path)
     names = {p.name for p in paths}
-    # Must include all managed shims plus the tests.yaml scaffold.
+    # Must include all managed shims plus the write-if-absent scaffolds.
     assert set(MANAGED_WORKFLOWS).issubset(names)
     assert "tests.yaml" in names
+    assert "renovate.json" in names
 
 
 def test_discover_returns_paths_even_when_absent(tmp_path: pathlib.Path) -> None:
     """discover() must not filter out non-existent files."""
     paths = discover(tmp_path)
-    # managed shims + tests.yaml scaffold.
-    assert len(paths) == len(MANAGED_WORKFLOWS) + 1
+    # managed shims + tests.yaml + renovate.json scaffolds.
+    assert len(paths) == len(MANAGED_WORKFLOWS) + 2
     # None of them exist yet.
     assert all(not p.exists() for p in paths)
 
@@ -316,3 +317,68 @@ def test_tests_yaml_finding_message_mentions_delete_and_bootstrap(
     msg = findings[0].message
     assert "delete" in msg.lower() or "regenerate" in msg.lower()
     assert "bootstrap" in msg
+
+
+# ---------------------------------------------------------------------------
+# renovate.json scaffold — write-if-absent, WARN-only drift tracking
+# ---------------------------------------------------------------------------
+
+
+def test_renovate_json_clean_after_bootstrap(tmp_path: pathlib.Path) -> None:
+    """A freshly-bootstrapped renovate.json yields no C002 finding."""
+    _bootstrap(tmp_path)
+    rj = tmp_path / "renovate.json"
+    assert rj.exists()
+    findings = scan_path(rj, tmp_path)
+    assert findings == [], [f.message for f in findings]
+
+
+def test_renovate_json_missing_produces_finding(tmp_path: pathlib.Path) -> None:
+    """Absent renovate.json → one C002 finding."""
+    rj = tmp_path / "renovate.json"
+    findings = scan_path(rj, tmp_path)
+    assert len(findings) == 1
+    assert findings[0].rule_id == "C002"
+    assert "absent" in findings[0].message
+
+
+def test_renovate_json_drifted_produces_finding(tmp_path: pathlib.Path) -> None:
+    """Structurally modified renovate.json → one C002 WARN finding."""
+    _bootstrap(tmp_path)
+    rj = tmp_path / "renovate.json"
+    rj.write_text('{"completely": "wrong"}\n')
+    findings = scan_path(rj, tmp_path)
+    assert len(findings) == 1
+    assert findings[0].rule_id == "C002"
+    assert "drifted" in findings[0].message
+
+
+def test_renovate_json_finding_is_warn_never_block(tmp_path: pathlib.Path) -> None:
+    """renovate.json drift is WARN, not BLOCK."""
+    rj = tmp_path / "renovate.json"
+    rj.write_text("{}\n")
+    findings = scan_path(rj, tmp_path)
+    assert len(findings) == 1
+    assert get_rule("C002").tier == EnforcementTier.WARN
+
+
+def test_renovate_json_finding_mentions_delete_and_bootstrap(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Drift message tells users to delete + re-run bootstrap to remediate."""
+    rj = tmp_path / "renovate.json"
+    rj.write_text("{}\n")
+    findings = scan_path(rj, tmp_path)
+    assert len(findings) == 1
+    msg = findings[0].message
+    assert "delete" in msg.lower() or "regenerate" in msg.lower()
+    assert "bootstrap" in msg
+
+
+def test_all_scaffolds_clean_after_bootstrap(tmp_path: pathlib.Path) -> None:
+    """Every discovered path — managed shims + both scaffolds — is clean after bootstrap."""
+    _bootstrap(tmp_path)
+    findings = []
+    for path in discover(tmp_path):
+        findings.extend(scan_path(path, tmp_path))
+    assert findings == [], [f.message for f in findings]

--- a/packages/conformance/uv.lock
+++ b/packages/conformance/uv.lock
@@ -218,7 +218,7 @@ wheels = [
 
 [[package]]
 name = "atlan-application-sdk-conformance"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

- **`tests.yaml` auto-detection**: bootstrap now infers `app-name` / `app-image-name` without flags — reads `atlan.yaml` `name:` first, falls back to repo directory name (stripping `atlan-` prefix and `-app` suffix, e.g. `atlan-openapi-app` → `openapi`), then `"app"`. Also auto-activates `services-script` when `.github/test/setup-services.sh` exists.
- **`enable-e2e` omission**: `enable-e2e: true` is no longer emitted in the scaffold since the reusable workflow already defaults to it; only `false` appears explicitly.
- **`renovate.json` scaffold**: bootstrap now creates `renovate.json` as a write-if-absent file (same semantics as `tests.yaml` — never clobbered, C002 drift tracked at WARN only). Canonical template extends the fleet preset (`github>atlanhq/application-sdk//renovate-config/default.json`).
- **New flags**: `--services-script` for explicit override of the auto-detected path.
- **Review fixes**: strict JSON in `renovate.json` template (no trailing comma, ruff format excluded via `pyproject.toml`); `import re` at module level; quote-stripping on `atlan.yaml` `name:` values.

## Test plan

- [ ] All bootstrap + drift tests pass (`uv run pytest tests/test_bootstrap.py tests/test_bootstrap_drift.py`) — 117 tests
- [ ] Pre-commit clean
- [ ] Manually run `atlan-application-sdk-conformance bootstrap` in `atlan-openapi-app` to verify `openapi` is auto-detected and `renovate.json` is scaffolded