### PR TITLE
ci(renovate): use regex delimiters in managerFilePatterns for Pkl custom manager

### DIFF
--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -103,7 +103,7 @@
       "description": "Pkl app-contract-toolkit: track the @<version> URI pinned in contract/PklProject. Uses github-tags datasource against atlanhq/application-sdk, filtering to contract-toolkit-v* tags.",
       "customType": "regex",
       "managerFilePatterns": [
-        "(^|/)contract/PklProject$"
+        "/(^|\\/)contract\\/PklProject$/"
       ],
       "matchStrings": [
         "uri\\s*=\\s*\"package://atlanhq\\.github\\.io/application-sdk/contracts/app-contract-toolkit@(?<currentValue>[^\"]+)\""


### PR DESCRIPTION
## Summary

- `managerFilePatterns` in Renovate treats patterns as **globs** unless they start with `/`
- The existing pattern `(^|/)contract/PklProject$` was silently matched as a literal glob (matching nothing), so no consumer's `contract/PklProject` was ever detected
- Wrapping it as `/(^|\\/)contract\\/PklProject$/` makes Renovate treat it as a JS regex, which correctly matches the file

This is why `atlan-openapi-app` (and all other consumers) are still on `app-contract-toolkit@0.10.4` despite Renovate running regularly — the dep was never discovered.

## Test plan

- [ ] Merge to `main`
- [ ] Trigger a Renovate run on `atlan-openapi-app` (tick the checkbox on its Dependency Dashboard issue)
- [ ] Verify `app-contract-toolkit` appears under "Detected Dependencies" → `custom.regex`
- [ ] Verify a PR is opened to bump `contract/PklProject` from `0.10.4` → `0.13.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)