### PR TITLE
ci(deps): disable Dependabot, raise Renovate prConcurrentLimit to 5

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,2 +1,0 @@
-version: 2
-updates: []

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,20 +1,2 @@
 version: 2
-updates:
-  - package-ecosystem: uv
-    directory: "/"
-    schedule:
-      interval: daily
-    versioning-strategy: lockfile-only
-    open-pull-requests-limit: 5
-    groups:
-      python-deps:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: weekly
+updates: []

--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -8,7 +8,7 @@
     "at any time"
   ],
   "prHourlyLimit": 0,
-  "prConcurrentLimit": 3,
+  "prConcurrentLimit": 5,
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
## Summary

- Disables Dependabot entirely (`updates: []`) — Renovate already covers both the `uv` and `github-actions` ecosystems, making Dependabot redundant. Having both active caused duplicate dependency PRs (e.g. #2193).
- Raises Renovate's `prConcurrentLimit` from 3 → 5 so it can drain its patch-update queue faster now that it is the sole dependency bot.

## Follow-up

Close Dependabot PR #2193 — Renovate will pick up `duckdb` and `snowflake-sqlalchemy` once a queue slot is free (immediately, since only 3 of the new limit of 5 are occupied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)