### PR TITLE
fix(ci): include test dependency group when running pytest

### DIFF
--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -275,7 +275,7 @@ runs:
         # pytest-cov added transiently so callers can opt in to coverage
         # via pytest-args (e.g., `--cov=app --cov-report=xml ...`). No
         # effect when coverage flags aren't passed.
-        uv run --with pytest-xdist --with pytest-cov pytest ${{ inputs.test-paths }} -v \
+        uv run --group test --with pytest-xdist --with pytest-cov pytest ${{ inputs.test-paths }} -v \
           ${{ inputs.pytest-args }} \
           --junit-xml=results/test-results.xml \
           2>&1 | tee results/test-output.txt


### PR DESCRIPTION
## Summary
- Add `--group test` to the `uv run` command in `connector-integration-tests` action
- Without this, test-only dependencies like `pytest-asyncio` (declared in `[dependency-groups] test`) are not installed, causing async unit tests to fail with `"async def functions are not natively supported"` when run under pytest-xdist

## Context
Discovered while upgrading `atlan-cloudsql-postgres-app` to SDK 3.17.3. The app's async unit tests all failed in CI because `pytest-asyncio` was only in the `test` dependency group, which `uv run --with pytest-xdist --with pytest-cov` doesn't resolve.

## Change
```diff
- uv run --with pytest-xdist --with pytest-cov pytest ...
+ uv run --group test --with pytest-xdist --with pytest-cov pytest ...
```

## Test plan
- [ ] Verify cloudsql-postgres async unit tests pass in CI after this merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)