### PR TITLE
fix(redis): bump redis pin to <9.0.0 and pin socket_timeout=5

### DIFF
--- a/application_sdk/clients/redis.py
+++ b/application_sdk/clients/redis.py
@@ -201,7 +201,7 @@ class RedisClient(BaseRedisClient):
             self.redis_client = sentinel.master_for(
                 REDIS_SENTINEL_SERVICE_NAME,
                 password=REDIS_PASSWORD,
-                socket_timeout=None,
+                socket_timeout=5,
             )
 
         except (ConnectionError, TimeoutError, RedisError) as e:
@@ -220,7 +220,7 @@ class RedisClient(BaseRedisClient):
                 host=REDIS_HOST,
                 port=int(REDIS_PORT),
                 password=REDIS_PASSWORD,
-                socket_timeout=None,
+                socket_timeout=5,
             )
 
         except (ConnectionError, TimeoutError, RedisError) as e:
@@ -356,7 +356,7 @@ class RedisClientAsync(BaseRedisClient):
             self.redis_client = sentinel.master_for(
                 REDIS_SENTINEL_SERVICE_NAME,
                 password=REDIS_PASSWORD,
-                socket_timeout=None,
+                socket_timeout=5,
             )
 
         except (ConnectionError, TimeoutError, RedisError) as e:
@@ -375,7 +375,7 @@ class RedisClientAsync(BaseRedisClient):
                 host=REDIS_HOST,
                 port=int(REDIS_PORT),
                 password=REDIS_PASSWORD,
-                socket_timeout=None,
+                socket_timeout=5,
             )
 
         except (ConnectionError, TimeoutError, RedisError) as e:

--- a/application_sdk/clients/redis.py
+++ b/application_sdk/clients/redis.py
@@ -5,8 +5,6 @@ from typing import NoReturn
 
 import redis
 import redis.asyncio as async_redis
-from redis.exceptions import ConnectionError, RedisError, TimeoutError
-
 from application_sdk.clients.redis_errors import (
     RedisConfigError,
     RedisConnectionError,
@@ -23,6 +21,7 @@ from application_sdk.constants import (
 )
 from application_sdk.errors import AppError
 from application_sdk.observability.logger_adaptor import get_logger
+from redis.exceptions import ConnectionError, RedisError, TimeoutError
 
 logger = get_logger(__name__)
 
@@ -199,7 +198,9 @@ class RedisClient(BaseRedisClient):
 
             # Create master client with password
             self.redis_client = sentinel.master_for(
-                REDIS_SENTINEL_SERVICE_NAME, password=REDIS_PASSWORD
+                REDIS_SENTINEL_SERVICE_NAME,
+                password=REDIS_PASSWORD,
+                socket_timeout=None,
             )
 
         except (ConnectionError, TimeoutError, RedisError) as e:
@@ -215,7 +216,10 @@ class RedisClient(BaseRedisClient):
 
         try:
             self.redis_client = redis.Redis(
-                host=REDIS_HOST, port=int(REDIS_PORT), password=REDIS_PASSWORD
+                host=REDIS_HOST,
+                port=int(REDIS_PORT),
+                password=REDIS_PASSWORD,
+                socket_timeout=None,
             )
 
         except (ConnectionError, TimeoutError, RedisError) as e:
@@ -349,7 +353,9 @@ class RedisClientAsync(BaseRedisClient):
 
             # Create master client with password
             self.redis_client = sentinel.master_for(
-                REDIS_SENTINEL_SERVICE_NAME, password=REDIS_PASSWORD
+                REDIS_SENTINEL_SERVICE_NAME,
+                password=REDIS_PASSWORD,
+                socket_timeout=None,
             )
 
         except (ConnectionError, TimeoutError, RedisError) as e:
@@ -365,7 +371,10 @@ class RedisClientAsync(BaseRedisClient):
 
         try:
             self.redis_client = async_redis.Redis(
-                host=REDIS_HOST, port=int(REDIS_PORT), password=REDIS_PASSWORD
+                host=REDIS_HOST,
+                port=int(REDIS_PORT),
+                password=REDIS_PASSWORD,
+                socket_timeout=None,
             )
 
         except (ConnectionError, TimeoutError, RedisError) as e:

--- a/application_sdk/clients/redis.py
+++ b/application_sdk/clients/redis.py
@@ -5,6 +5,8 @@ from typing import NoReturn
 
 import redis
 import redis.asyncio as async_redis
+from redis.exceptions import ConnectionError, RedisError, TimeoutError
+
 from application_sdk.clients.redis_errors import (
     RedisConfigError,
     RedisConnectionError,
@@ -21,7 +23,6 @@ from application_sdk.constants import (
 )
 from application_sdk.errors import AppError
 from application_sdk.observability.logger_adaptor import get_logger
-from redis.exceptions import ConnectionError, RedisError, TimeoutError
 
 logger = get_logger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ azure = [
     "azure-storage-file-datalake>=12.19.0",
 ]
 distributed_lock = [
-    "redis[hiredis]>=5.2.0,<8.0.0",
+    "redis[hiredis]>=5.2.0,<9.0.0",
 ]
 mcp = [
     "fastmcp>=3.2.0,<4.0.0",

--- a/tests/unit/clients/test_redis_client_contracts.py
+++ b/tests/unit/clients/test_redis_client_contracts.py
@@ -231,7 +231,7 @@ class TestSyncConnect:
         ):
             standalone_client._connect()
         redis_ctor.assert_called_once_with(
-            host="localhost", port=6379, password="secret"
+            host="localhost", port=6379, password="secret", socket_timeout=None
         )
         fake_redis.ping.assert_called_once()
         assert standalone_client.redis_client is fake_redis
@@ -258,7 +258,9 @@ class TestSyncConnect:
         ):
             sentinel_client._connect()
         sentinel_ctor.assert_called_once()
-        sentinel.master_for.assert_called_once_with("mymaster", password="secret")
+        sentinel.master_for.assert_called_once_with(
+            "mymaster", password="secret", socket_timeout=None
+        )
         master.ping.assert_called_once()
         assert sentinel_client.redis_client is master
 
@@ -438,7 +440,7 @@ class TestAsyncConnect:
         ):
             await standalone_client._connect()
         redis_ctor.assert_called_once_with(
-            host="localhost", port=6379, password="secret"
+            host="localhost", port=6379, password="secret", socket_timeout=None
         )
         fake_redis.ping.assert_awaited_once()
         assert standalone_client.redis_client is fake_redis
@@ -460,7 +462,9 @@ class TestAsyncConnect:
             ),
         ):
             await sentinel_client._connect()
-        sentinel.master_for.assert_called_once_with("mymaster", password="secret")
+        sentinel.master_for.assert_called_once_with(
+            "mymaster", password="secret", socket_timeout=None
+        )
         master.ping.assert_awaited_once()
         assert sentinel_client.redis_client is master
 

--- a/tests/unit/clients/test_redis_client_contracts.py
+++ b/tests/unit/clients/test_redis_client_contracts.py
@@ -231,7 +231,7 @@ class TestSyncConnect:
         ):
             standalone_client._connect()
         redis_ctor.assert_called_once_with(
-            host="localhost", port=6379, password="secret", socket_timeout=None
+            host="localhost", port=6379, password="secret", socket_timeout=5
         )
         fake_redis.ping.assert_called_once()
         assert standalone_client.redis_client is fake_redis
@@ -259,7 +259,7 @@ class TestSyncConnect:
             sentinel_client._connect()
         sentinel_ctor.assert_called_once()
         sentinel.master_for.assert_called_once_with(
-            "mymaster", password="secret", socket_timeout=None
+            "mymaster", password="secret", socket_timeout=5
         )
         master.ping.assert_called_once()
         assert sentinel_client.redis_client is master
@@ -298,6 +298,28 @@ class TestSyncConnect:
             with pytest.raises(AppRedisProtocolError) as ei:
                 standalone_client._connect()
         assert ei.value.code == "DEPENDENCY_UNAVAILABLE_REDIS_PROTOCOL"
+
+    def test_socket_timeout_on_acquire_raises_redis_timeout_error(
+        self, standalone_client
+    ):
+        """A socket timeout during lock-acquire must surface as RedisTimeoutError.
+
+        Validates the finite socket_timeout wiring: a Redis hang raises
+        redis.exceptions.TimeoutError which _handle_redis_error maps to
+        AppRedisTimeoutError — the caller can handle it instead of blocking
+        indefinitely.
+        """
+        fake_redis = MagicMock()
+        fake_redis.ping.return_value = True
+        fake_redis.set.side_effect = RedisTimeoutError("socket timed out")
+        with (
+            patch("application_sdk.clients.redis.REDIS_SENTINEL_HOSTS", ""),
+            patch("application_sdk.clients.redis.redis.Redis", return_value=fake_redis),
+        ):
+            standalone_client._connect()
+        with pytest.raises(AppRedisTimeoutError) as ei:
+            standalone_client._acquire_lock("resource-id", "owner-id")
+        assert ei.value.code == "TIMEOUT_REDIS"
 
     def test_connect_standalone_ctor_failure_wrapped(self, standalone_client):
         with (
@@ -440,7 +462,7 @@ class TestAsyncConnect:
         ):
             await standalone_client._connect()
         redis_ctor.assert_called_once_with(
-            host="localhost", port=6379, password="secret", socket_timeout=None
+            host="localhost", port=6379, password="secret", socket_timeout=5
         )
         fake_redis.ping.assert_awaited_once()
         assert standalone_client.redis_client is fake_redis
@@ -463,7 +485,7 @@ class TestAsyncConnect:
         ):
             await sentinel_client._connect()
         sentinel.master_for.assert_called_once_with(
-            "mymaster", password="secret", socket_timeout=None
+            "mymaster", password="secret", socket_timeout=5
         )
         master.ping.assert_awaited_once()
         assert sentinel_client.redis_client is master
@@ -483,6 +505,25 @@ class TestAsyncConnect:
         ):
             await standalone_client._connect()
         assert ei.value.code == "DEPENDENCY_UNAVAILABLE_REDIS"
+
+    async def test_socket_timeout_on_acquire_raises_redis_timeout_error(
+        self, standalone_client
+    ):
+        """A socket timeout during async lock-acquire must surface as RedisTimeoutError."""
+        fake_redis = AsyncMock()
+        fake_redis.ping.return_value = True
+        fake_redis.set.side_effect = RedisTimeoutError("socket timed out")
+        with (
+            patch("application_sdk.clients.redis.REDIS_SENTINEL_HOSTS", ""),
+            patch(
+                "application_sdk.clients.redis.async_redis.Redis",
+                return_value=fake_redis,
+            ),
+        ):
+            await standalone_client._connect()
+        with pytest.raises(AppRedisTimeoutError) as ei:
+            await standalone_client._acquire_lock("resource-id", "owner-id")
+        assert ei.value.code == "TIMEOUT_REDIS"
 
 
 class TestAsyncClose:

--- a/uv.lock
+++ b/uv.lock
@@ -385,7 +385,7 @@ requires-dist = [
     { name = "pytest-order", marker = "extra == 'tests'", specifier = ">=1.3.0,<2.0.0" },
     { name = "python-dotenv", specifier = ">=1.1.0,<2.0.0" },
     { name = "pyyaml", specifier = ">=6.0.2,<7.0.0" },
-    { name = "redis", extras = ["hiredis"], marker = "extra == 'distributed-lock'", specifier = ">=5.2.0,<8.0.0" },
+    { name = "redis", extras = ["hiredis"], marker = "extra == 'distributed-lock'", specifier = ">=5.2.0,<9.0.0" },
     { name = "rocksdict", marker = "extra == 'storage'", specifier = ">=0.3.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'incremental'", specifier = ">=2.0.36,<3.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'sql'", specifier = ">=2.0.36,<3.0.0" },


### PR DESCRIPTION
## Summary

- Lifts the \`redis[hiredis]\` upper bound from \`<8.0.0\` to \`<9.0.0\`, allowing redis-py v8.x (released 2026-05-28)
- Replaces \`socket_timeout=None\` with an explicit \`socket_timeout=5\` on all four Redis connection paths (\`RedisClient\` standalone + sentinel, \`RedisClientAsync\` standalone + sentinel), so a Redis hang surfaces as \`RedisTimeoutError\` after 5 s rather than blocking the worker indefinitely

## redis-py v8 default changes reviewed

The following defaults changed in v8; none require code changes in this SDK but connector authors should be aware:

| Setting | v7 default | v8 default | Impact on this SDK |
|---|---|---|---|
| \`socket_timeout\` / \`socket_connect_timeout\` | \`None\` (no timeout) | 5 s | **Handled explicitly** — we now pin \`socket_timeout=5\` |
| Wire protocol | RESP2 | RESP3 (legacy Python response shapes preserved) | None — \`set\`/\`eval\`/\`ping\` return types unchanged |
| TCP keepalive | off | on | Benign improvement |
| \`max_connections\` (pool) | 50 | 100 | Benign; not pool-managed here |
| Retry policy | none | 10 attempts, exponential-jitter backoff | Safe by construction — \`set nx=True\` is idempotent; release Lua is owner-checked so stale retries return 0 |

## Test plan

- [ ] Unit tests pass, including two new tests that inject \`redis.exceptions.TimeoutError\` on \`set\` and confirm it maps to \`AppRedisTimeoutError\` (sync + async)
- [ ] Pre-commit clean (ruff, pyright, isort all pass)
- [ ] Verify Redis connection smoke-test with redis-py v8 installed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)