### PR TITLE
ci(renovate): allow workspace-relative lock files in Renovate auto-approve

### DIFF
--- a/.github/workflows/renovate-auto-approve-reusable.yml
+++ b/.github/workflows/renovate-auto-approve-reusable.yml
@@ -143,8 +143,11 @@ jobs:
             fi
 
             # d. All changed files must be dependency-related.
-            #    Allowed: anything under .github/, or the file roots uv.lock,
-            #    requirements.txt, pyproject.toml.
+            #    Allowed: anything under .github/, or lock/manifest files at
+            #    any depth: uv.lock, package-lock.json, requirements.txt,
+            #    pyproject.toml.  The (.*/)?  prefix in each pattern makes
+            #    -x (full-line) matching work for both root-level and
+            #    workspace-relative paths (e.g. packages/conformance/uv.lock).
             FILENAMES=$(gh api "repos/${REPO}/pulls/${PR_NUM}/files" \
               --paginate --jq '.[].filename')
             if [ -z "$FILENAMES" ]; then
@@ -154,7 +157,7 @@ jobs:
 
             NON_DEP_FILES=$(echo "$FILENAMES" \
               | grep -v '^\.github/' \
-              | grep -vxE 'uv\.lock|requirements\.txt|pyproject\.toml' \
+              | grep -vxE '(.*/)?uv\.lock|(.*/)?package-lock\.json|(.*/)?requirements\.txt|(.*/)?pyproject\.toml' \
               || true)
             if [ -n "$NON_DEP_FILES" ]; then
               echo "PR #${PR_NUM}: contains non-dependency files:"


### PR DESCRIPTION
## Summary

- The dependency-file allowlist used exact-match grep (`-x`) with bare filenames, so `packages/conformance/uv.lock` and `packages/conformance/conformance/package-lock.json` were rejected as non-dependency files on every lock-file-maintenance PR (see PR #2199).
- Prefix each pattern with `(.*/)?` so the full-line match works for both root-level paths (`uv.lock`) and any workspace-relative path (`packages/*/uv.lock`).
- Also adds `package-lock.json` coverage, which was missing entirely.

## Test plan

- [ ] Trigger `workflow_dispatch` on `renovate-auto-approve.yml` with `pr_number=2199` after this lands to verify PR #2199 gets auto-approved
- [ ] Confirm future lock-file-maintenance Renovate PRs auto-approve without manual intervention