### PR TITLE
chore(renovate): disable dependency dashboard and clean up ignorePaths

### DIFF
--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -12,7 +12,7 @@
   "labels": [
     "dependencies"
   ],
-  "dependencyDashboard": true,
+  "dependencyDashboard": false,
   "ignorePaths": [
     "requirements.txt"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -4,11 +4,8 @@
   "extends": [
     "github>atlanhq/application-sdk//renovate-config/default.json"
   ],
-  "dependencyDashboard": false,
   "semanticCommitType": "chore",
   "ignorePaths": [
-    ".venv/**",
-    "**/node_modules/**",
     "contract-toolkit/examples/**",
     "requirements.txt"
   ],


### PR DESCRIPTION
## Summary

- Disables the Renovate dependency dashboard in the fleet default config (`renovate-config/default.json`)
- Removes the redundant `dependencyDashboard: false` override from the dogfood `renovate.json` (now inherited from default)
- Removes `.venv/**` and `**/node_modules/**` from dogfood `ignorePaths` — these are always `.gitignored` so Renovate never sees them anyway

## Test plan

- [ ] Confirm no dependency dashboard issue is created after next Renovate run