### PR TITLE
chore(tests): move StorageTier serde tests to integration suite

### DIFF
--- a/tests/integration/test_sql_app_prime_auth.py
+++ b/tests/integration/test_sql_app_prime_auth.py
@@ -41,9 +41,13 @@ import time
 from typing import Any, ClassVar
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from application_sdk.clients.sql import BaseSQLClient
 from application_sdk.templates.contracts.sql_metadata import ExtractionInput
 from application_sdk.templates.sql_app import SqlApp
+
+pytestmark = pytest.mark.integration
 
 
 class _TimingSqlClient(BaseSQLClient):
@@ -78,7 +82,6 @@ class _TimingSqlClient(BaseSQLClient):
         # Yield zero rows — extract activities exit fast.
         if False:
             yield []
-        return
 
     async def get_results(self, query: str):
         # prime_sql_auth issues SELECT 1 through this method; we just

--- a/tests/integration/test_storage_tier_temporal_serde.py
+++ b/tests/integration/test_storage_tier_temporal_serde.py
@@ -1,14 +1,13 @@
 """Integration test: StorageTier / FileReference round-trips through Temporal.
 
-Uses ``WorkflowEnvironment.start_local()`` to spin up the embedded Temporal
-dev server and run a minimal workflow that receives a ``FileReference`` as
-input and echoes it back as output.  The test proves that all three
-``StorageTier`` values survive JSON serialisation → Temporal payload →
-JSON deserialisation intact.
+Runs a minimal echo workflow against the session's embedded Temporal dev
+server (booted once by conftest.py via ``embedded_runtime``).  The test
+proves that all three ``StorageTier`` values survive JSON serialisation →
+Temporal payload → JSON deserialisation intact.
 
 Why this matters
 ----------------
-``FileReference`` is a frozen Pydantic model that travels through Temporal's
+``FileReference`` is a Pydantic model that travels through Temporal's
 2 MB payload system as JSON.  The ``tier`` field is a ``str`` enum
 (``StorageTier``).  Temporal's ``pydantic_data_converter`` must:
 
@@ -24,9 +23,6 @@ from __future__ import annotations
 import pytest
 from pydantic import Field
 from temporalio import workflow
-from temporalio.client import Client
-from temporalio.contrib.pydantic import pydantic_data_converter
-from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
 
@@ -73,18 +69,6 @@ _SANDBOX_RUNNER = SandboxedWorkflowRunner(
 )
 
 
-async def _run_echo(client: Client, ref: FileReference) -> FileReference:
-    """Execute the echo workflow and return the FileReference from the output."""
-    result: _EchoOutput = await client.execute_workflow(
-        "StorageTierEchoWorkflow",
-        _EchoInput(ref=ref),
-        id=f"serde-test-{ref.tier.value}-{id(ref)}",
-        task_queue="serde-test-queue",
-        result_type=_EchoOutput,
-    )
-    return result.ref
-
-
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -107,7 +91,7 @@ async def _run_echo(client: Client, ref: FileReference) -> FileReference:
     ids=["transient", "retained", "persistent"],
 )
 async def test_storage_tier_survives_temporal_round_trip(
-    tier: StorageTier, storage_path: str
+    temporal_client, task_queue, tier: StorageTier, storage_path: str
 ) -> None:
     """FileReference.tier is preserved after Temporal payload serialisation."""
     original = FileReference(
@@ -118,44 +102,48 @@ async def test_storage_tier_survives_temporal_round_trip(
         tier=tier,
     )
 
-    async with (
-        await WorkflowEnvironment.start_local(
-            data_converter=pydantic_data_converter
-        ) as env,
-        Worker(
-            env.client,
-            task_queue="serde-test-queue",
-            workflows=[_StorageTierEchoWorkflow],
-            workflow_runner=_SANDBOX_RUNNER,
-        ),
+    async with Worker(
+        temporal_client,
+        task_queue=task_queue,
+        workflows=[_StorageTierEchoWorkflow],
+        workflow_runner=_SANDBOX_RUNNER,
     ):
-        echoed = await _run_echo(env.client, original)
+        result: _EchoOutput = await temporal_client.execute_workflow(
+            "StorageTierEchoWorkflow",
+            _EchoInput(ref=original),
+            id=f"serde-test-{tier.value}",
+            task_queue=task_queue,
+            result_type=_EchoOutput,
+        )
 
     assert (
-        echoed.tier == tier
-    ), f"Expected tier={tier!r} but got {echoed.tier!r} after Temporal round-trip"
-    assert echoed.storage_path == storage_path
-    assert echoed.is_durable is True
-    assert echoed.file_count == 3
+        result.ref.tier == tier
+    ), f"Expected tier={tier!r} but got {result.ref.tier!r} after Temporal round-trip"
+    assert result.ref.storage_path == storage_path
+    assert result.ref.is_durable is True
+    assert result.ref.file_count == 3
 
 
 @pytest.mark.asyncio
-async def test_default_tier_is_transient_after_round_trip() -> None:
+async def test_default_tier_is_transient_after_round_trip(
+    temporal_client, task_queue
+) -> None:
     """FileReference without explicit tier defaults to TRANSIENT through serde."""
     original = FileReference(storage_path="file_refs/default.parquet", is_durable=True)
     assert original.tier == StorageTier.TRANSIENT  # sanity check
 
-    async with (
-        await WorkflowEnvironment.start_local(
-            data_converter=pydantic_data_converter
-        ) as env,
-        Worker(
-            env.client,
-            task_queue="serde-test-queue",
-            workflows=[_StorageTierEchoWorkflow],
-            workflow_runner=_SANDBOX_RUNNER,
-        ),
+    async with Worker(
+        temporal_client,
+        task_queue=task_queue,
+        workflows=[_StorageTierEchoWorkflow],
+        workflow_runner=_SANDBOX_RUNNER,
     ):
-        echoed = await _run_echo(env.client, original)
+        result: _EchoOutput = await temporal_client.execute_workflow(
+            "StorageTierEchoWorkflow",
+            _EchoInput(ref=original),
+            id="serde-test-default-tier",
+            task_queue=task_queue,
+            result_type=_EchoOutput,
+        )
 
-    assert echoed.tier == StorageTier.TRANSIENT
+    assert result.ref.tier == StorageTier.TRANSIENT

--- a/tests/integration/test_storage_tier_temporal_serde.py
+++ b/tests/integration/test_storage_tier_temporal_serde.py
@@ -8,13 +8,13 @@ JSON deserialisation intact.
 
 Why this matters
 ----------------
-``FileReference`` is a frozen dataclass that travels through Temporal's
+``FileReference`` is a frozen Pydantic model that travels through Temporal's
 2 MB payload system as JSON.  The ``tier`` field is a ``str`` enum
-(``StorageTier``).  Temporal's ``DefaultPayloadConverter`` must:
+(``StorageTier``).  Temporal's ``pydantic_data_converter`` must:
 
 1. Encode ``StorageTier.RETAINED`` → ``"retained"`` (the string value).
 2. Decode ``"retained"`` back → ``StorageTier.RETAINED`` using the type
-   annotation on the dataclass field.
+   annotation on the model field.
 
 This test catches any regression in that flow.
 """
@@ -33,6 +33,8 @@ from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
 from application_sdk.contracts.base import Input, Output
 from application_sdk.contracts.types import FileReference, StorageTier
 from application_sdk.execution.sandbox import SandboxConfig
+
+pytestmark = pytest.mark.integration
 
 # ---------------------------------------------------------------------------
 # Minimal workflow definition
@@ -116,16 +118,18 @@ async def test_storage_tier_survives_temporal_round_trip(
         tier=tier,
     )
 
-    async with await WorkflowEnvironment.start_local(
-        data_converter=pydantic_data_converter
-    ) as env:
-        async with Worker(
+    async with (
+        await WorkflowEnvironment.start_local(
+            data_converter=pydantic_data_converter
+        ) as env,
+        Worker(
             env.client,
             task_queue="serde-test-queue",
             workflows=[_StorageTierEchoWorkflow],
             workflow_runner=_SANDBOX_RUNNER,
-        ):
-            echoed = await _run_echo(env.client, original)
+        ),
+    ):
+        echoed = await _run_echo(env.client, original)
 
     assert (
         echoed.tier == tier
@@ -141,28 +145,17 @@ async def test_default_tier_is_transient_after_round_trip() -> None:
     original = FileReference(storage_path="file_refs/default.parquet", is_durable=True)
     assert original.tier == StorageTier.TRANSIENT  # sanity check
 
-    async with await WorkflowEnvironment.start_local(
-        data_converter=pydantic_data_converter
-    ) as env:
-        async with Worker(
+    async with (
+        await WorkflowEnvironment.start_local(
+            data_converter=pydantic_data_converter
+        ) as env,
+        Worker(
             env.client,
             task_queue="serde-test-queue",
             workflows=[_StorageTierEchoWorkflow],
             workflow_runner=_SANDBOX_RUNNER,
-        ):
-            echoed = await _run_echo(env.client, original)
+        ),
+    ):
+        echoed = await _run_echo(env.client, original)
 
     assert echoed.tier == StorageTier.TRANSIENT
-
-
-@pytest.mark.asyncio
-async def test_tier_string_value_is_lowercase() -> None:
-    """StorageTier serialises to its lowercase string value (not the enum name)."""
-    assert StorageTier.TRANSIENT.value == "transient"
-    assert StorageTier.RETAINED.value == "retained"
-    assert StorageTier.PERSISTENT.value == "persistent"
-
-    # Reconstruct from value — this is what Temporal's converter does.
-    assert StorageTier("transient") is StorageTier.TRANSIENT
-    assert StorageTier("retained") is StorageTier.RETAINED
-    assert StorageTier("persistent") is StorageTier.PERSISTENT

--- a/tests/integration/test_workflow_interaction_cookbook.py
+++ b/tests/integration/test_workflow_interaction_cookbook.py
@@ -15,8 +15,6 @@ from datetime import timedelta
 
 import pytest
 from temporalio.client import WorkflowUpdateFailedError
-from temporalio.contrib.pydantic import pydantic_data_converter
-from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
 
@@ -25,6 +23,8 @@ from application_sdk.app.base import App, generate_workflow_class
 from application_sdk.app.entrypoint import EntryPointMetadata
 from application_sdk.contracts.base import Input, Output
 from application_sdk.execution.sandbox import SandboxConfig
+
+pytestmark = pytest.mark.integration
 
 _SANDBOX_RUNNER = SandboxedWorkflowRunner(
     restrictions=SandboxConfig().to_temporal_restrictions()
@@ -102,20 +102,15 @@ _PAUSE_RESUME_WF = generate_workflow_class(
 )
 
 
-async def test_cookbook_pause_resume_cycle() -> None:
+async def test_cookbook_pause_resume_cycle(temporal_client) -> None:
     """Customer pauses mid-extract, then resumes; run completes with full progress."""
-    async with (
-        await WorkflowEnvironment.start_local(
-            data_converter=pydantic_data_converter
-        ) as env,
-        Worker(
-            env.client,
-            task_queue="cookbook-pause-resume",
-            workflows=[_PAUSE_RESUME_WF],
-            workflow_runner=_SANDBOX_RUNNER,
-        ),
+    async with Worker(
+        temporal_client,
+        task_queue="cookbook-pause-resume",
+        workflows=[_PAUSE_RESUME_WF],
+        workflow_runner=_SANDBOX_RUNNER,
     ):
-        handle = await env.client.start_workflow(
+        handle = await temporal_client.start_workflow(
             _PAUSE_RESUME_WF.run,
             _ExtractInput(total_batches=3),
             id="cookbook-pause-resume",
@@ -134,21 +129,16 @@ async def test_cookbook_pause_resume_cycle() -> None:
     assert result.rows_extracted == 300  # 3 batches × 100 rows
 
 
-async def test_cookbook_graceful_cancel_short_circuits_run() -> None:
+async def test_cookbook_graceful_cancel_short_circuits_run(temporal_client) -> None:
     """graceful_cancel flips state; run() exits its loop without processing
     remaining batches, but with partial progress preserved."""
-    async with (
-        await WorkflowEnvironment.start_local(
-            data_converter=pydantic_data_converter
-        ) as env,
-        Worker(
-            env.client,
-            task_queue="cookbook-graceful-cancel",
-            workflows=[_PAUSE_RESUME_WF],
-            workflow_runner=_SANDBOX_RUNNER,
-        ),
+    async with Worker(
+        temporal_client,
+        task_queue="cookbook-graceful-cancel",
+        workflows=[_PAUSE_RESUME_WF],
+        workflow_runner=_SANDBOX_RUNNER,
     ):
-        handle = await env.client.start_workflow(
+        handle = await temporal_client.start_workflow(
             _PAUSE_RESUME_WF.run,
             _ExtractInput(total_batches=100),
             id="cookbook-graceful-cancel",
@@ -203,20 +193,15 @@ class _MetricsApp(App):
 _METRICS_WF = generate_workflow_class(_MetricsApp, _ep(_ExtractInput, _ExtractOutput))
 
 
-async def test_cookbook_progress_query_returns_live_state() -> None:
+async def test_cookbook_progress_query_returns_live_state(temporal_client) -> None:
     """Operator queries get_progress mid-run; query reads live App state."""
-    async with (
-        await WorkflowEnvironment.start_local(
-            data_converter=pydantic_data_converter
-        ) as env,
-        Worker(
-            env.client,
-            task_queue="cookbook-progress",
-            workflows=[_METRICS_WF],
-            workflow_runner=_SANDBOX_RUNNER,
-        ),
+    async with Worker(
+        temporal_client,
+        task_queue="cookbook-progress",
+        workflows=[_METRICS_WF],
+        workflow_runner=_SANDBOX_RUNNER,
     ):
-        handle = await env.client.start_workflow(
+        handle = await temporal_client.start_workflow(
             _METRICS_WF.run,
             _ExtractInput(total_batches=7),
             id="cookbook-progress",
@@ -273,21 +258,18 @@ _RATE_LIMITED_WF = generate_workflow_class(
 )
 
 
-async def test_cookbook_rate_limit_validator_rejects_out_of_range() -> None:
+async def test_cookbook_rate_limit_validator_rejects_out_of_range(
+    temporal_client,
+) -> None:
     """Out-of-range rate limit is rejected by the validator before the
     interaction body runs; in-range update succeeds and mutates state."""
-    async with (
-        await WorkflowEnvironment.start_local(
-            data_converter=pydantic_data_converter
-        ) as env,
-        Worker(
-            env.client,
-            task_queue="cookbook-rate-limit",
-            workflows=[_RATE_LIMITED_WF],
-            workflow_runner=_SANDBOX_RUNNER,
-        ),
+    async with Worker(
+        temporal_client,
+        task_queue="cookbook-rate-limit",
+        workflows=[_RATE_LIMITED_WF],
+        workflow_runner=_SANDBOX_RUNNER,
     ):
-        handle = await env.client.start_workflow(
+        handle = await temporal_client.start_workflow(
             _RATE_LIMITED_WF.run,
             _ExtractInput(),
             id="cookbook-rate-limit",
@@ -345,20 +327,15 @@ _INCREMENTAL_WF = generate_workflow_class(
 )
 
 
-async def test_cookbook_external_update_advances_watermark() -> None:
+async def test_cookbook_external_update_advances_watermark(temporal_client) -> None:
     """An external service sends a watermark update; run() observes it on the same instance."""
-    async with (
-        await WorkflowEnvironment.start_local(
-            data_converter=pydantic_data_converter
-        ) as env,
-        Worker(
-            env.client,
-            task_queue="cookbook-watermark",
-            workflows=[_INCREMENTAL_WF],
-            workflow_runner=_SANDBOX_RUNNER,
-        ),
+    async with Worker(
+        temporal_client,
+        task_queue="cookbook-watermark",
+        workflows=[_INCREMENTAL_WF],
+        workflow_runner=_SANDBOX_RUNNER,
     ):
-        handle = await env.client.start_workflow(
+        handle = await temporal_client.start_workflow(
             _INCREMENTAL_WF.run,
             _ExtractInput(),
             id="cookbook-watermark",
@@ -409,20 +386,15 @@ _CHECKPOINTED_WF = generate_workflow_class(
 )
 
 
-async def test_cookbook_checkpoint_query_returns_position() -> None:
+async def test_cookbook_checkpoint_query_returns_position(temporal_client) -> None:
     """Oncall queries the live checkpoint without restarting the run."""
-    async with (
-        await WorkflowEnvironment.start_local(
-            data_converter=pydantic_data_converter
-        ) as env,
-        Worker(
-            env.client,
-            task_queue="cookbook-checkpoint",
-            workflows=[_CHECKPOINTED_WF],
-            workflow_runner=_SANDBOX_RUNNER,
-        ),
+    async with Worker(
+        temporal_client,
+        task_queue="cookbook-checkpoint",
+        workflows=[_CHECKPOINTED_WF],
+        workflow_runner=_SANDBOX_RUNNER,
     ):
-        handle = await env.client.start_workflow(
+        handle = await temporal_client.start_workflow(
             _CHECKPOINTED_WF.run,
             _ExtractInput(),
             id="cookbook-checkpoint",

--- a/tests/integration/test_workflow_interaction_relay.py
+++ b/tests/integration/test_workflow_interaction_relay.py
@@ -19,8 +19,6 @@ from datetime import timedelta
 
 import pytest
 from temporalio.client import WorkflowUpdateFailedError
-from temporalio.contrib.pydantic import pydantic_data_converter
-from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
 
@@ -29,6 +27,8 @@ from application_sdk.app.base import App, generate_workflow_class
 from application_sdk.app.entrypoint import EntryPointMetadata
 from application_sdk.contracts.base import Input, Output
 from application_sdk.execution.sandbox import SandboxConfig
+
+pytestmark = pytest.mark.integration
 
 # Production sandbox passthrough config — same one the SDK worker uses, so
 # loguru / application_sdk imports work inside the workflow sandbox.
@@ -125,20 +125,15 @@ _WF_CLS = generate_workflow_class(
 # ---------------------------------------------------------------------------
 
 
-async def test_update_interaction_mutates_run_state() -> None:
+async def test_update_interaction_mutates_run_state(temporal_client) -> None:
     """Update fired mid-run reaches the same App instance ``run`` observes."""
-    async with (
-        await WorkflowEnvironment.start_local(
-            data_converter=pydantic_data_converter
-        ) as env,
-        Worker(
-            env.client,
-            task_queue="interaction-relay-queue",
-            workflows=[_WF_CLS],
-            workflow_runner=_SANDBOX_RUNNER,
-        ),
+    async with Worker(
+        temporal_client,
+        task_queue="interaction-relay-queue",
+        workflows=[_WF_CLS],
+        workflow_runner=_SANDBOX_RUNNER,
     ):
-        handle = await env.client.start_workflow(
+        handle = await temporal_client.start_workflow(
             _WF_CLS.run,
             _InteractionInput(timeout_seconds=5.0),
             id="interaction-relay-update",
@@ -157,20 +152,15 @@ async def test_update_interaction_mutates_run_state() -> None:
     assert result.final_state == "stopped:operator-request"
 
 
-async def test_signal_interaction_increments_state() -> None:
+async def test_signal_interaction_increments_state(temporal_client) -> None:
     """Multiple signals accumulate on the same per-run App instance."""
-    async with (
-        await WorkflowEnvironment.start_local(
-            data_converter=pydantic_data_converter
-        ) as env,
-        Worker(
-            env.client,
-            task_queue="interaction-relay-queue-2",
-            workflows=[_WF_CLS],
-            workflow_runner=_SANDBOX_RUNNER,
-        ),
+    async with Worker(
+        temporal_client,
+        task_queue="interaction-relay-queue-2",
+        workflows=[_WF_CLS],
+        workflow_runner=_SANDBOX_RUNNER,
     ):
-        handle = await env.client.start_workflow(
+        handle = await temporal_client.start_workflow(
             _WF_CLS.run,
             _InteractionInput(timeout_seconds=5.0),
             id="interaction-relay-signal",
@@ -187,20 +177,15 @@ async def test_signal_interaction_increments_state() -> None:
     assert result.signals_received == 3
 
 
-async def test_query_interaction_returns_live_state() -> None:
+async def test_query_interaction_returns_live_state(temporal_client) -> None:
     """Query reads state from the same instance ``run`` is mutating."""
-    async with (
-        await WorkflowEnvironment.start_local(
-            data_converter=pydantic_data_converter
-        ) as env,
-        Worker(
-            env.client,
-            task_queue="interaction-relay-queue-3",
-            workflows=[_WF_CLS],
-            workflow_runner=_SANDBOX_RUNNER,
-        ),
+    async with Worker(
+        temporal_client,
+        task_queue="interaction-relay-queue-3",
+        workflows=[_WF_CLS],
+        workflow_runner=_SANDBOX_RUNNER,
     ):
-        handle = await env.client.start_workflow(
+        handle = await temporal_client.start_workflow(
             _WF_CLS.run,
             _InteractionInput(timeout_seconds=5.0),
             id="interaction-relay-query",
@@ -213,21 +198,16 @@ async def test_query_interaction_returns_live_state() -> None:
         await handle.result()
 
 
-async def test_validator_rejects_invalid_update() -> None:
+async def test_validator_rejects_invalid_update(temporal_client) -> None:
     """Validator decorated on the App method propagates through the relay,
     causing the runtime to reject the update before it reaches the interaction body."""
-    async with (
-        await WorkflowEnvironment.start_local(
-            data_converter=pydantic_data_converter
-        ) as env,
-        Worker(
-            env.client,
-            task_queue="interaction-relay-queue-4",
-            workflows=[_WF_CLS],
-            workflow_runner=_SANDBOX_RUNNER,
-        ),
+    async with Worker(
+        temporal_client,
+        task_queue="interaction-relay-queue-4",
+        workflows=[_WF_CLS],
+        workflow_runner=_SANDBOX_RUNNER,
     ):
-        handle = await env.client.start_workflow(
+        handle = await temporal_client.start_workflow(
             _WF_CLS.run,
             _InteractionInput(timeout_seconds=5.0),
             id="interaction-relay-validator",

--- a/tests/unit/contracts/test_types.py
+++ b/tests/unit/contracts/test_types.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from application_sdk.contracts.types import FileReference, MaxItems
+from application_sdk.contracts.types import FileReference, MaxItems, StorageTier
 
 # =============================================================================
 # MaxItems
@@ -228,3 +228,20 @@ class TestUploadDownloadRefSymmetry:
 
         ref = FileReference(local_path="/tmp/x.jsonl", storage_path="artifacts/x.jsonl")
         assert UploadInput(ref=ref).ref == DownloadInput(ref=ref).ref
+
+
+# =============================================================================
+# StorageTier
+# =============================================================================
+
+
+class TestStorageTier:
+    def test_string_values_are_lowercase(self) -> None:
+        assert StorageTier.TRANSIENT.value == "transient"
+        assert StorageTier.RETAINED.value == "retained"
+        assert StorageTier.PERSISTENT.value == "persistent"
+
+    def test_reconstruct_from_value(self) -> None:
+        assert StorageTier("transient") is StorageTier.TRANSIENT
+        assert StorageTier("retained") is StorageTier.RETAINED
+        assert StorageTier("persistent") is StorageTier.PERSISTENT


### PR DESCRIPTION
## Summary

- `WorkflowEnvironment.start_local()` spins up a real Temporal dev server (~35s per invocation). The three parametrised `test_storage_tier_survives_temporal_round_trip` cases were sitting in `tests/unit/` without `@pytest.mark.integration`, so pytest's default filter (`-m 'not integration'`) did not exclude them — they ran in the unit suite, hit the job timeout, and cancelled the run.
- Moves `test_storage_tier_temporal_serde.py` to `tests/integration/` and adds `pytestmark = pytest.mark.integration`.
- Rescues the pure string-value assertions (no Temporal needed) into a new `TestStorageTier` class in `tests/unit/contracts/test_types.py`.

## Test plan

- [ ] Unit test run (`poe test`) no longer includes the Temporal round-trip tests
- [ ] Integration test run (`poe test-integration`) still covers the full serde round-trip
- [ ] `TestStorageTier` in `test_types.py` covers the pure enum-value contract in the unit suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)