### PR TITLE
feat(conformance): add C003 GitignoreMissingEntry check (BLDX-1452)

### DIFF
--- a/packages/conformance/conformance/bootstrap/render.py
+++ b/packages/conformance/conformance/bootstrap/render.py
@@ -84,6 +84,7 @@ def render(
       (default derived as ``"atlan-<app_name>-app"``), ``enable_e2e``
       (default ``"true"``), ``services_script`` (default ``""`` — renders the
       services-script line commented out; supply a path to render it active).
+    - ``.gitignore``: static template, no substitution.
 
     All other keyword arguments are accepted but unused, so callers can pass
     the full variable set without knowing which template is parametric.

--- a/packages/conformance/conformance/bootstrap/templates/.gitignore
+++ b/packages/conformance/conformance/bootstrap/templates/.gitignore
@@ -1,0 +1,57 @@
+# ─── OS Files ───────────────────────────────────────────────────────────────
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Thumbs.db
+ehthumbs.db
+desktop.ini
+
+# ─── IDE & Editor Settings ──────────────────────────────────────────────────
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.*.sw?
+
+# ─── Environment & Secrets ──────────────────────────────────────────────────
+.env
+.env.*
+!.env.example
+secrets/
+
+# ─── Python ─────────────────────────────────────────────────────────────────
+__pycache__/
+*.py[cod]
+*.pyo
+.venv/
+venv/
+env/
+*.egg-info/
+dist/
+build/
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+.coverage*
+htmlcov/
+
+# ─── Node.js ────────────────────────────────────────────────────────────────
+node_modules/
+npm-debug.log*
+yarn-error.log*
+
+# ─── Logs & Temp Files ──────────────────────────────────────────────────────
+*.log
+logs/
+*.tmp
+*.bak
+*.cache
+*.pid
+
+# ─── Atlan Tooling ──────────────────────────────────────────────────────────
+.atlan/
+.claude/worktrees/
+remediation/

--- a/packages/conformance/conformance/cli.py
+++ b/packages/conformance/conformance/cli.py
@@ -213,7 +213,16 @@ def _cmd_bootstrap(argv: list[str]) -> int:
                 f"ok (exists): {scaffold_dest}  (edit freely; C002 tracks drift at WARN)"
             )
 
-    _ensure_gitignore_entry(root, "remediation/")
+    # .gitignore — write-if-absent scaffold.  C003 warns about missing entries.
+    gitignore_dest = root / ".gitignore"
+    if not gitignore_dest.exists():
+        gitignore_dest.write_text(render(".gitignore"), encoding="utf-8")
+        print(f"scaffolded: {gitignore_dest}")
+    else:
+        print(
+            f"ok (exists): {gitignore_dest}  (edit freely; C003 warns on missing entries)"
+        )
+
     return 0
 
 

--- a/packages/conformance/conformance/cli.py
+++ b/packages/conformance/conformance/cli.py
@@ -68,22 +68,6 @@ def _bootstrap_file(dest: pathlib.Path, content: str) -> None:
     print(f"{'updated' if existed else 'installed'}: {dest}")
 
 
-def _ensure_gitignore_entry(root: pathlib.Path, entry: str) -> None:
-    """Append *entry* to .gitignore if not already present; never overwrites."""
-    gitignore = root / ".gitignore"
-    if gitignore.exists():
-        lines = gitignore.read_text(encoding="utf-8").splitlines()
-        if any(line.strip() == entry for line in lines):
-            print(f"ok:        {gitignore}  ({entry!r} already present)")
-            return
-        # Append with a preceding blank line for readability.
-        with gitignore.open("a", encoding="utf-8") as fh:
-            fh.write(f"\n{entry}\n")
-    else:
-        gitignore.write_text(f"{entry}\n", encoding="utf-8")
-    print(f"appended:  {gitignore}  ({entry!r})")
-
-
 def _read_atlan_yaml_name(root: pathlib.Path) -> str:
     """Return the ``name:`` value from ``atlan.yaml`` in *root*, or ``""``."""
 

--- a/packages/conformance/conformance/docs/rules/ci.md
+++ b/packages/conformance/conformance/docs/rules/ci.md
@@ -5,7 +5,7 @@
 
 # CI/Workflow Supply-Chain Rules (C-series)
 
-**2 rules** · Checker: `suite.checks.actions_pinning` and related workflow checks (static)
+**3 rules** · Checker: `suite.checks.actions_pinning` and related workflow checks (static)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -17,6 +17,7 @@ Suppress a finding on the violating line or the line directly above it:
 |---|---|---|---|---|---|
 | [C001](#c001) | `UnpinnedActionReference` | `block` | `supply-chain` | yes | 3.16.0 |
 | [C002](#c002) | `BootstrapWorkflowDrift` | `warn` | `ci-consistency` | yes | 0.3.0 |
+| [C003](#c003) | `GitignoreMissingEntry` | `warn` | `ci-consistency` | — | 0.4.0 |
 
 ---
 
@@ -53,5 +54,25 @@ workflow shims into `.github/workflows/`. This rule flags any managed file that 
 missing or whose content has diverged from what `bootstrap` would write. Re-run
 `bootstrap` to re-sync; structural drift is flagged while intentional per-repo value
 choices (e.g. `package_name`, `unit_tests_workflow_file`) are preserved.
+
+---
+
+## C003 — `GitignoreMissingEntry` {#c003}
+
+**Tier:** `warn` · **Category:** `ci-consistency` · **Autofixable:** — · **Since:** 0.4.0
+
+> .gitignore is absent or missing a standard required entry
+
+**Rationale:** A .gitignore that is missing standard entries risks accidentally committing secrets,
+virtual environments, build artefacts, or IDE noise — each of which has caused incidents
+or review friction. The standard set is the minimal baseline every app repo should
+carry.
+
+The `atlan-application-sdk-conformance bootstrap` command scaffolds a standard
+.gitignore when the file is absent. This rule flags any required entry that is missing
+from the file. One finding is emitted per missing entry so each can be triaged or
+suppressed independently. Equivalences are respected: `.venv` covers `.venv/`, and
+`**/node_modules/**` covers `node_modules/`. Both absent-file and missing-entry findings
+are WARN only — the file is app-editable and must never block CI.
 
 ---

--- a/packages/conformance/conformance/suite/checks/gitignore_entries.py
+++ b/packages/conformance/conformance/suite/checks/gitignore_entries.py
@@ -69,7 +69,7 @@ def _is_covered(required: str, present: frozenset[str]) -> bool:
 def _present_lines(path: Path) -> frozenset[str]:
     """Return the set of non-blank, non-comment, stripped lines in *path*."""
     lines: set[str] = set()
-    for raw in path.read_text(encoding="utf-8").splitlines():
+    for raw in path.read_text(encoding="utf-8-sig").splitlines():
         stripped = raw.strip()
         if stripped and not stripped.startswith("#"):
             lines.add(stripped)

--- a/packages/conformance/conformance/suite/checks/gitignore_entries.py
+++ b/packages/conformance/conformance/suite/checks/gitignore_entries.py
@@ -1,0 +1,127 @@
+"""C003 GitignoreMissingEntry — detect absent or incomplete .gitignore.
+
+Bootstrap writes a standard .gitignore when the file is absent.  This check
+flags any required entry that is missing from the file.
+
+Two cases:
+- ``.gitignore`` absent → one WARN finding; run ``bootstrap`` to create it.
+- ``.gitignore`` exists but missing an entry → one WARN finding per entry.
+
+Both cases are WARN only (never BLOCK); the file is app-editable.
+
+Covered entries
+---------------
+An entry in *required* is considered "covered" when the file contains:
+
+- An exact-match line (``__pycache__/`` covers ``__pycache__/``).
+- A no-trailing-slash variant for directory patterns
+  (``.venv`` covers ``.venv/``).
+- The glob ``**/node_modules/**`` as an equivalent for ``node_modules/``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from conformance.suite.schema.findings import Finding
+
+SERIES = "C"
+RULE_ID = "C003"
+
+_CLI_CMD = "atlan-application-sdk-conformance bootstrap"
+
+# Canonical required entries in the order they appear in the bootstrap template.
+# ``_is_covered`` accepts exact matches and the equivalences documented above.
+REQUIRED_ENTRIES: tuple[str, ...] = (
+    ".DS_Store",
+    ".vscode/",
+    ".idea/",
+    "*~",
+    ".env",
+    "__pycache__/",
+    ".venv/",
+    ".pytest_cache/",
+    ".mypy_cache/",
+    ".ruff_cache/",
+    ".coverage*",
+    "htmlcov/",
+    "dist/",
+    "node_modules/",
+    ".atlan/",
+    ".claude/worktrees/",
+    "remediation/",
+)
+
+
+def _is_covered(required: str, present: frozenset[str]) -> bool:
+    """Return True if *present* contains a line that effectively covers *required*."""
+    if required in present:
+        return True
+    # .venv/ is also covered by .venv (gitignore matches both interpretations)
+    if required.endswith("/") and required[:-1] in present:
+        return True
+    # node_modules/ is also covered by the recursive glob form
+    if required == "node_modules/" and "**/node_modules/**" in present:
+        return True
+    return False
+
+
+def _present_lines(path: Path) -> frozenset[str]:
+    """Return the set of non-blank, non-comment, stripped lines in *path*."""
+    lines: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        stripped = raw.strip()
+        if stripped and not stripped.startswith("#"):
+            lines.add(stripped)
+    return frozenset(lines)
+
+
+# ---------------------------------------------------------------------------
+# Discovery + scanning
+# ---------------------------------------------------------------------------
+
+
+def discover(root: Path) -> list[Path]:
+    """Return the single .gitignore path (whether or not it exists)."""
+    return [root / ".gitignore"]
+
+
+def scan_path(path: Path, root: Path) -> list[Finding]:
+    """Return C003 findings for the repo .gitignore."""
+    try:
+        rel = path.relative_to(root).as_posix()
+    except ValueError:
+        rel = str(path)
+
+    if not path.exists():
+        return [
+            Finding(
+                rule_id=RULE_ID,
+                file=rel,
+                line=1,
+                column=1,
+                message=(
+                    ".gitignore is absent. "
+                    f"Run `{_CLI_CMD}` to create it with the standard entries."
+                ),
+            )
+        ]
+
+    present = _present_lines(path)
+    findings: list[Finding] = []
+    for entry in REQUIRED_ENTRIES:
+        if not _is_covered(entry, present):
+            findings.append(
+                Finding(
+                    rule_id=RULE_ID,
+                    file=rel,
+                    line=1,
+                    column=1,
+                    message=(
+                        f".gitignore is missing the standard entry {entry!r}. "
+                        f"Add it manually or run `{_CLI_CMD}` on a new repo to "
+                        f"scaffold a .gitignore that includes it."
+                    ),
+                )
+            )
+    return findings

--- a/packages/conformance/conformance/suite/rules/ci.py
+++ b/packages/conformance/conformance/suite/rules/ci.py
@@ -62,7 +62,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="ci-consistency",
         autofixable=False,
-        since="0.4.1",
+        since="0.4.0",
         rationale=(
             "A .gitignore that is missing standard entries risks accidentally committing "
             "secrets, virtual environments, build artefacts, or IDE noise — each of which "

--- a/packages/conformance/conformance/suite/rules/ci.py
+++ b/packages/conformance/conformance/suite/rules/ci.py
@@ -55,4 +55,31 @@ RULES: tuple[RuleDefinition, ...] = (
         ),
         help_uri="https://github.com/atlanhq/application-sdk/blob/main/conformance/docs/rules/ci.md#c002",
     ),
+    RuleDefinition(
+        id="C003",
+        name="GitignoreMissingEntry",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="ci-consistency",
+        autofixable=False,
+        since="0.4.1",
+        rationale=(
+            "A .gitignore that is missing standard entries risks accidentally committing "
+            "secrets, virtual environments, build artefacts, or IDE noise — each of which "
+            "has caused incidents or review friction. The standard set is the minimal "
+            "baseline every app repo should carry."
+        ),
+        short_description=".gitignore is absent or missing a standard required entry",
+        full_description=(
+            "The `atlan-application-sdk-conformance bootstrap` command scaffolds a "
+            "standard .gitignore when the file is absent. This rule flags any required "
+            "entry that is missing from the file. One finding is emitted per missing "
+            "entry so each can be triaged or suppressed independently. "
+            "Equivalences are respected: `.venv` covers `.venv/`, and "
+            "`**/node_modules/**` covers `node_modules/`. "
+            "Both absent-file and missing-entry findings are WARN only — the file is "
+            "app-editable and must never block CI."
+        ),
+        help_uri="https://github.com/atlanhq/application-sdk/blob/main/conformance/docs/rules/ci.md#c003",
+    ),
 )

--- a/packages/conformance/conformance/suite/runner.py
+++ b/packages/conformance/conformance/suite/runner.py
@@ -27,6 +27,7 @@ from conformance.suite.checks import (
     bootstrap_drift,
     dependency_conformance,
     error_handling,
+    gitignore_entries,
     optimizations,
     prescriptions,
 )
@@ -84,6 +85,11 @@ _CHECKS: list[CheckRegistration] = [
         discover=prescriptions.discover,
         scan_path=prescriptions.scan_path,
         scan_all=prescriptions.scan_all,
+    ),
+    CheckRegistration(
+        series=gitignore_entries.SERIES,
+        discover=gitignore_entries.discover,
+        scan_path=gitignore_entries.scan_path,
     ),
 ]
 

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -1,8 +1,8 @@
 """Tests for the bootstrap command and its helpers.
 
-Covers _bootstrap_file and _ensure_gitignore_entry in isolation, and the full
-_cmd_bootstrap dispatch (SKILL.md + CI workflow shims + .gitignore) via the
-CLI entrypoint so the tests exercise the same code path a caller would use.
+Covers _bootstrap_file in isolation, and the full _cmd_bootstrap dispatch
+(SKILL.md + CI workflow shims + .gitignore) via the CLI entrypoint so the
+tests exercise the same code path a caller would use.
 """
 
 from __future__ import annotations
@@ -15,7 +15,6 @@ from conformance.cli import (
     _bootstrap_file,
     _cmd_bootstrap,
     _derive_app_name_from_dir,
-    _ensure_gitignore_entry,
     _parse_bootstrap_args,
 )
 
@@ -58,64 +57,6 @@ def test_bootstrap_file_prints_updated_for_overwrite(
     dest.write_text("old")
     _bootstrap_file(dest, "new")
     assert "updated" in capsys.readouterr().out
-
-
-# ---------------------------------------------------------------------------
-# _ensure_gitignore_entry
-# ---------------------------------------------------------------------------
-
-
-def test_gitignore_appends_entry_to_existing_file(tmp_path: pathlib.Path) -> None:
-    gi = tmp_path / ".gitignore"
-    gi.write_text("# existing\n*.pyc\n")
-    _ensure_gitignore_entry(tmp_path, "remediation/")
-    assert "remediation/" in gi.read_text()
-
-
-def test_gitignore_creates_file_if_absent(tmp_path: pathlib.Path) -> None:
-    _ensure_gitignore_entry(tmp_path, "remediation/")
-    assert (tmp_path / ".gitignore").read_text().strip() == "remediation/"
-
-
-def test_gitignore_does_not_duplicate_existing_entry(tmp_path: pathlib.Path) -> None:
-    gi = tmp_path / ".gitignore"
-    gi.write_text("remediation/\n")
-    _ensure_gitignore_entry(tmp_path, "remediation/")
-    assert gi.read_text().count("remediation/") == 1
-
-
-def test_gitignore_does_not_clobber_existing_content(tmp_path: pathlib.Path) -> None:
-    gi = tmp_path / ".gitignore"
-    original = "# my rules\n*.log\n.env\n"
-    gi.write_text(original)
-    _ensure_gitignore_entry(tmp_path, "remediation/")
-    result = gi.read_text()
-    assert result.startswith(original)
-    assert "remediation/" in result
-
-
-def test_gitignore_no_op_prints_ok(
-    tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    (tmp_path / ".gitignore").write_text("remediation/\n")
-    _ensure_gitignore_entry(tmp_path, "remediation/")
-    assert "ok" in capsys.readouterr().out
-
-
-def test_gitignore_append_prints_appended(
-    tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    (tmp_path / ".gitignore").write_text("*.pyc\n")
-    _ensure_gitignore_entry(tmp_path, "remediation/")
-    assert "appended" in capsys.readouterr().out
-
-
-def test_gitignore_entry_match_is_exact_line(tmp_path: pathlib.Path) -> None:
-    """'remediation/' must not be considered present just because 'remediation/runs/' exists."""
-    gi = tmp_path / ".gitignore"
-    gi.write_text("remediation/runs/\n")
-    _ensure_gitignore_entry(tmp_path, "remediation/")
-    assert gi.read_text().count("remediation/") == 2
 
 
 # ---------------------------------------------------------------------------

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -234,17 +234,16 @@ def test_cmd_bootstrap_gitignore_not_duplicated_on_rerun(
     assert (tmp_path / ".gitignore").read_text().count("remediation/") == 1
 
 
-def test_cmd_bootstrap_preserves_existing_gitignore_content(
+def test_cmd_bootstrap_does_not_modify_existing_gitignore(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Bootstrap is write-if-absent for .gitignore; it never modifies an existing file."""
     monkeypatch.chdir(tmp_path)
     gi = tmp_path / ".gitignore"
-    gi.write_text("*.pyc\n.env\n")
+    original = "*.pyc\n.env\n"
+    gi.write_text(original)
     _cmd_bootstrap([])
-    content = gi.read_text()
-    assert "*.pyc" in content
-    assert ".env" in content
-    assert "remediation/" in content
+    assert gi.read_text() == original
 
 
 def test_cmd_bootstrap_returns_zero(

--- a/packages/conformance/tests/test_gitignore_entries.py
+++ b/packages/conformance/tests/test_gitignore_entries.py
@@ -1,0 +1,220 @@
+"""Tests for C003 GitignoreMissingEntry check.
+
+Covers:
+- Rule metadata (exists, tier=WARN, not autofixable)
+- discover() always returns the .gitignore path
+- Absent .gitignore → one C003 finding
+- Complete .gitignore (from bootstrap) → no findings
+- Missing a single required entry → one finding per missing entry
+- Directory entry equivalences (.venv covers .venv/, **/node_modules/** covers node_modules/)
+- Bootstrap writes .gitignore when absent; is no-op when present
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+from conformance.suite.checks.gitignore_entries import (
+    REQUIRED_ENTRIES,
+    _is_covered,
+    discover,
+    scan_path,
+)
+from conformance.suite.rules import get_rule
+from conformance.suite.schema.disposition import EnforcementTier
+
+# ---------------------------------------------------------------------------
+# Rule metadata
+# ---------------------------------------------------------------------------
+
+
+def test_c003_rule_exists() -> None:
+    rule = get_rule("C003")
+    assert rule.name == "GitignoreMissingEntry"
+
+
+def test_c003_tier_is_warn() -> None:
+    assert get_rule("C003").tier == EnforcementTier.WARN
+
+
+def test_c003_is_not_autofixable() -> None:
+    assert get_rule("C003").autofixable is False
+
+
+# ---------------------------------------------------------------------------
+# discover()
+# ---------------------------------------------------------------------------
+
+
+def test_discover_returns_gitignore_path(tmp_path: pathlib.Path) -> None:
+    paths = discover(tmp_path)
+    assert len(paths) == 1
+    assert paths[0] == tmp_path / ".gitignore"
+
+
+def test_discover_returns_path_even_when_absent(tmp_path: pathlib.Path) -> None:
+    paths = discover(tmp_path)
+    assert not paths[0].exists()
+
+
+# ---------------------------------------------------------------------------
+# Absent .gitignore → one finding
+# ---------------------------------------------------------------------------
+
+
+def test_absent_gitignore_produces_one_finding(tmp_path: pathlib.Path) -> None:
+    findings = scan_path(tmp_path / ".gitignore", tmp_path)
+    assert len(findings) == 1
+    assert findings[0].rule_id == "C003"
+
+
+def test_absent_gitignore_finding_mentions_absent(tmp_path: pathlib.Path) -> None:
+    findings = scan_path(tmp_path / ".gitignore", tmp_path)
+    assert "absent" in findings[0].message.lower()
+
+
+def test_absent_gitignore_finding_mentions_bootstrap(tmp_path: pathlib.Path) -> None:
+    findings = scan_path(tmp_path / ".gitignore", tmp_path)
+    assert "bootstrap" in findings[0].message
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap scaffold → no findings
+# ---------------------------------------------------------------------------
+
+
+def _bootstrap(root: pathlib.Path) -> None:
+    import os
+
+    from conformance.cli import _cmd_bootstrap
+
+    old = os.getcwd()
+    os.chdir(root)
+    try:
+        _cmd_bootstrap([])
+    finally:
+        os.chdir(old)
+
+
+def test_bootstrapped_gitignore_has_no_findings(tmp_path: pathlib.Path) -> None:
+    _bootstrap(tmp_path)
+    gi = tmp_path / ".gitignore"
+    assert gi.exists()
+    findings = scan_path(gi, tmp_path)
+    assert findings == [], [f.message for f in findings]
+
+
+def test_bootstrap_does_not_overwrite_existing_gitignore(
+    tmp_path: pathlib.Path,
+) -> None:
+    gi = tmp_path / ".gitignore"
+    gi.write_text("# custom\n.my-custom-entry/\n", encoding="utf-8")
+    _bootstrap(tmp_path)
+    assert ".my-custom-entry/" in gi.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Present but missing entries → one finding per missing entry
+# ---------------------------------------------------------------------------
+
+
+def test_empty_gitignore_produces_finding_per_required_entry(
+    tmp_path: pathlib.Path,
+) -> None:
+    gi = tmp_path / ".gitignore"
+    gi.write_text("# empty\n", encoding="utf-8")
+    findings = scan_path(gi, tmp_path)
+    assert len(findings) == len(REQUIRED_ENTRIES)
+    assert all(f.rule_id == "C003" for f in findings)
+
+
+def test_finding_per_missing_entry_names_the_entry(tmp_path: pathlib.Path) -> None:
+    gi = tmp_path / ".gitignore"
+    gi.write_text("# nothing useful\n", encoding="utf-8")
+    findings = scan_path(gi, tmp_path)
+    messages = [f.message for f in findings]
+    for entry in REQUIRED_ENTRIES:
+        assert any(entry in m for m in messages), f"no finding for {entry!r}"
+
+
+def test_single_missing_entry_produces_one_finding(tmp_path: pathlib.Path) -> None:
+    gi = tmp_path / ".gitignore"
+    # Write all required entries except .claude/worktrees/
+    content = "\n".join(e for e in REQUIRED_ENTRIES if e != ".claude/worktrees/")
+    gi.write_text(content + "\n", encoding="utf-8")
+    findings = scan_path(gi, tmp_path)
+    assert len(findings) == 1
+    assert ".claude/worktrees/" in findings[0].message
+
+
+def test_no_findings_when_all_required_entries_present(tmp_path: pathlib.Path) -> None:
+    gi = tmp_path / ".gitignore"
+    gi.write_text("\n".join(REQUIRED_ENTRIES) + "\n", encoding="utf-8")
+    findings = scan_path(gi, tmp_path)
+    assert findings == []
+
+
+def test_comments_and_blank_lines_are_ignored(tmp_path: pathlib.Path) -> None:
+    gi = tmp_path / ".gitignore"
+    # All required entries plus noise lines
+    lines = list(REQUIRED_ENTRIES) + ["# a comment", "", "   "]
+    gi.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    findings = scan_path(gi, tmp_path)
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Equivalence rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "required,equivalent",
+    [
+        (".venv/", ".venv"),
+        (".vscode/", ".vscode"),
+        (".idea/", ".idea"),
+        ("__pycache__/", "__pycache__"),
+        (".pytest_cache/", ".pytest_cache"),
+        (".mypy_cache/", ".mypy_cache"),
+        (".ruff_cache/", ".ruff_cache"),
+        ("htmlcov/", "htmlcov"),
+        ("dist/", "dist"),
+        ("node_modules/", "**/node_modules/**"),
+        (".atlan/", ".atlan"),
+        (".claude/worktrees/", ".claude/worktrees"),
+        ("remediation/", "remediation"),
+    ],
+)
+def test_equivalent_form_is_accepted(required: str, equivalent: str) -> None:
+    assert _is_covered(required, frozenset({equivalent}))
+
+
+def test_exact_form_always_accepted() -> None:
+    for entry in REQUIRED_ENTRIES:
+        assert _is_covered(
+            entry, frozenset({entry})
+        ), f"exact match failed for {entry!r}"
+
+
+def test_unrelated_entry_does_not_cover() -> None:
+    assert not _is_covered(".venv/", frozenset({"venv/", ".venv2"}))
+
+
+def test_venv_no_slash_covers_venv_slash(tmp_path: pathlib.Path) -> None:
+    gi = tmp_path / ".gitignore"
+    content = "\n".join(e if e != ".venv/" else ".venv" for e in REQUIRED_ENTRIES)
+    gi.write_text(content + "\n", encoding="utf-8")
+    findings = scan_path(gi, tmp_path)
+    assert findings == [], [f.message for f in findings]
+
+
+def test_node_modules_recursive_glob_covers_slash_form(tmp_path: pathlib.Path) -> None:
+    gi = tmp_path / ".gitignore"
+    content = "\n".join(
+        e if e != "node_modules/" else "**/node_modules/**" for e in REQUIRED_ENTRIES
+    )
+    gi.write_text(content + "\n", encoding="utf-8")
+    findings = scan_path(gi, tmp_path)
+    assert findings == [], [f.message for f in findings]

--- a/packages/conformance/uv.lock
+++ b/packages/conformance/uv.lock
@@ -218,7 +218,7 @@ wheels = [
 
 [[package]]
 name = "atlan-application-sdk-conformance"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

- Adds **C003 `GitignoreMissingEntry`** (WARN-only) — flags `.gitignore` files that are absent or missing any of the 17 standard required entries derived from the canonical app repos (openapi, metabase, mysql) plus the `.claude/worktrees/` entry suggested in BLDX-1452.
- Bootstrap gains a **write-if-absent** `.gitignore` scaffold (replacing the old single-entry `_ensure_gitignore_entry` call); existing files are never modified.
- Equivalences respected at check time: `.venv` covers `.venv/`; `**/node_modules/**` covers `node_modules/`.

## Required entries (17)

| Category | Entries |
|---|---|
| OS files | `.DS_Store`, `.DS_Store?`, `._*`, `.Spotlight-V100`, `.Trashes`, `Thumbs.db`, `ehthumbs.db`, `desktop.ini` |
| IDE | `.vscode/`, `.idea/`, `*.swp`, `*.swo`, `*~`, `.*.sw?` |
| Env / secrets | `.env`, `.env.*`, `!.env.example`, `secrets/` |
| Python | `__pycache__/`, `*.py[cod]`, `*.pyo`, `.venv/`, `venv/`, `env/`, `*.egg-info/`, `dist/`, `build/`, `.mypy_cache/`, `.pytest_cache/`, `.ruff_cache/`, `.coverage*`, `htmlcov/` |
| Node.js | `node_modules/`, `npm-debug.log*`, `yarn-error.log*` |
| Logs / temp | `*.log`, `logs/`, `*.tmp`, `*.bak`, `*.cache`, `*.pid` |
| Atlan tooling | `.atlan/`, `.claude/worktrees/`, `remediation/` |

The **check** requires the 17 entries marked as canonical in `REQUIRED_ENTRIES`; the template contains the full set above.

## Test plan

- [x] 32 new tests in `test_gitignore_entries.py` — rule metadata, `discover()`, absent/missing-entry findings, per-entry naming, all equivalence rules, bootstrap scaffold round-trip
- [x] `test_bootstrap.py` updated: `test_cmd_bootstrap_preserves_existing_gitignore_content` → `test_cmd_bootstrap_does_not_modify_existing_gitignore` (write-if-absent, no appending)
- [x] Full conformance package suite: **506 passed, 1 xfailed**
- [x] Pre-commit clean (ruff, ruff-format, isort, pyright)

Closes BLDX-1452

🤖 Generated with [Claude Code](https://claude.com/claude-code)