### PR TITLE
fix(conformance): use conformance suite version in rule since fields

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -31,7 +31,7 @@ uv add --dev atlan-application-sdk-conformance
 ```python
 from conformance.suite.schema import ReportBuilder, Disposition, derive_disposition
 
-builder = ReportBuilder(tool_name="atlan-conformance", tool_version="3.16.0")
+builder = ReportBuilder(tool_name="atlan-conformance", tool_version="0.4.0")
 builder.add_result("P001", "src/foo.py", 42)
 report = builder.build()
 

--- a/packages/conformance/conformance/docs/rules/ci.md
+++ b/packages/conformance/conformance/docs/rules/ci.md
@@ -15,14 +15,14 @@ Suppress a finding on the violating line or the line directly above it:
 
 | ID | Name | Tier | Category | Autofixable | Since |
 |---|---|---|---|---|---|
-| [C001](#c001) | `UnpinnedActionReference` | `block` | `supply-chain` | yes | 3.16.0 |
+| [C001](#c001) | `UnpinnedActionReference` | `block` | `supply-chain` | yes | 0.2.0 |
 | [C002](#c002) | `BootstrapWorkflowDrift` | `warn` | `ci-consistency` | yes | 0.3.0 |
 
 ---
 
 ## C001 — `UnpinnedActionReference` {#c001}
 
-**Tier:** `block` · **Category:** `supply-chain` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `block` · **Category:** `supply-chain` · **Autofixable:** yes · **Since:** 0.2.0
 
 > External GitHub Action not pinned to a full commit digest
 

--- a/packages/conformance/conformance/docs/rules/error-handling.md
+++ b/packages/conformance/conformance/docs/rules/error-handling.md
@@ -15,30 +15,30 @@ Suppress a finding on the violating line or the line directly above it:
 
 | ID | Name | Tier | Category | Autofixable | Since |
 |---|---|---|---|---|---|
-| [E001](#e001) | `BareExceptPass` | `block` | `silent-swallow` | — | 3.16.0 |
-| [E002](#e002) | `TypedExceptPass` | `block` | `silent-swallow` | — | 3.16.0 |
-| [E003](#e003) | `BroadContextlibSuppress` | `warn` | `silent-swallow` | — | 3.16.0 |
-| [E004](#e004) | `BroadExceptClause` | `warn` | `overly-broad-catch` | — | 3.16.0 |
-| [E005](#e005) | `ExceptBlockMissingExcInfo` | `warn` | `missing-traceback` | yes | 3.16.0 |
-| [E006](#e006) | `BareExceptWithBody` | `block` | `silent-swallow` | — | 3.16.0 |
-| [E007](#e007) | `ErrorToReturnValue` | `warn` | `error-to-return-value` | — | 3.16.0 |
-| [E008](#e008) | `ImportErrorWithoutLogging` | `warn` | `optional-import` | — | 3.16.0 |
-| [E009](#e009) | `ExceptBlockOnlyAssigns` | `warn` | `error-to-return-value` | — | 3.16.0 |
-| [E010](#e010) | `AsyncioGatherExceptionsUnexamined` | `warn` | `asyncio-unexamined` | — | 3.16.0 |
-| [E011](#e011) | `LoggingFilterUnsafeBody` | `warn` | `filter-safety` | — | 3.17.0 |
-| [E012](#e012) | `UntypedBuiltinRaise` | `warn` | `untyped-raise` | — | 3.16.0 |
-| [E013](#e013) | `LegacyAtlanErrorRaise` | `block` | `legacy-raise` | — | 3.16.0 |
-| [E014](#e014) | `ExceptLoopControlSwallow` | `warn` | `silent-swallow` | — | 3.17.0 |
-| [E015](#e015) | `ExceptionTextInErrorMessage` | `warn` | `error-message-hygiene` | — | 3.17.0 |
-| [E016](#e016) | `MissingExceptionChaining` | `warn` | `exception-chaining` | yes | 3.17.0 |
-| [E017](#e017) | `SecretNamedEvidenceKey` | `block` | `security` | — | 3.17.0 |
-| [E018](#e018) | `BareParentLeafRaise` | `warn` | `untyped-raise` | — | 3.17.0 |
+| [E001](#e001) | `BareExceptPass` | `block` | `silent-swallow` | — | 0.2.0 |
+| [E002](#e002) | `TypedExceptPass` | `block` | `silent-swallow` | — | 0.2.0 |
+| [E003](#e003) | `BroadContextlibSuppress` | `warn` | `silent-swallow` | — | 0.2.0 |
+| [E004](#e004) | `BroadExceptClause` | `warn` | `overly-broad-catch` | — | 0.2.0 |
+| [E005](#e005) | `ExceptBlockMissingExcInfo` | `warn` | `missing-traceback` | yes | 0.2.0 |
+| [E006](#e006) | `BareExceptWithBody` | `block` | `silent-swallow` | — | 0.2.0 |
+| [E007](#e007) | `ErrorToReturnValue` | `warn` | `error-to-return-value` | — | 0.2.0 |
+| [E008](#e008) | `ImportErrorWithoutLogging` | `warn` | `optional-import` | — | 0.2.0 |
+| [E009](#e009) | `ExceptBlockOnlyAssigns` | `warn` | `error-to-return-value` | — | 0.2.0 |
+| [E010](#e010) | `AsyncioGatherExceptionsUnexamined` | `warn` | `asyncio-unexamined` | — | 0.2.0 |
+| [E011](#e011) | `LoggingFilterUnsafeBody` | `warn` | `filter-safety` | — | 0.2.0 |
+| [E012](#e012) | `UntypedBuiltinRaise` | `warn` | `untyped-raise` | — | 0.2.0 |
+| [E013](#e013) | `LegacyAtlanErrorRaise` | `block` | `legacy-raise` | — | 0.2.0 |
+| [E014](#e014) | `ExceptLoopControlSwallow` | `warn` | `silent-swallow` | — | 0.2.0 |
+| [E015](#e015) | `ExceptionTextInErrorMessage` | `warn` | `error-message-hygiene` | — | 0.2.0 |
+| [E016](#e016) | `MissingExceptionChaining` | `warn` | `exception-chaining` | yes | 0.2.0 |
+| [E017](#e017) | `SecretNamedEvidenceKey` | `block` | `security` | — | 0.2.0 |
+| [E018](#e018) | `BareParentLeafRaise` | `warn` | `untyped-raise` | — | 0.2.0 |
 
 ---
 
 ## E001 — `BareExceptPass` {#e001}
 
-**Tier:** `block` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `block` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 0.2.0
 
 > Bare 'except: pass' silently discards every exception
 
@@ -55,7 +55,7 @@ even cleanup paths should log at DEBUG.
 
 ## E002 — `TypedExceptPass` {#e002}
 
-**Tier:** `block` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `block` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 0.2.0
 
 > Typed 'except SomeError: pass' discards exception silently
 
@@ -72,7 +72,7 @@ reasoning.
 
 ## E003 — `BroadContextlibSuppress` {#e003}
 
-**Tier:** `warn` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 0.2.0
 
 > contextlib.suppress() — check whether scope is too broad
 
@@ -88,7 +88,7 @@ the suppressed exception type before classifying.
 
 ## E004 — `BroadExceptClause` {#e004}
 
-**Tier:** `warn` · **Category:** `overly-broad-catch` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `overly-broad-catch` · **Autofixable:** — · **Since:** 0.2.0
 
 > Overly broad 'except Exception/BaseException' without exc_info
 
@@ -104,7 +104,7 @@ MEDIUM when logged but missing `exc_info=True`.  Acceptable only at top-level ha
 
 ## E005 — `ExceptBlockMissingExcInfo` {#e005}
 
-**Tier:** `warn` · **Category:** `missing-traceback` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `missing-traceback` · **Autofixable:** yes · **Since:** 0.2.0
 
 > except block logs without exc_info=True — stack trace discarded
 
@@ -120,7 +120,7 @@ is exempt (it implies `exc_info=True`).
 
 ## E006 — `BareExceptWithBody` {#e006}
 
-**Tier:** `block` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `block` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 0.2.0
 
 > Bare 'except:' (no type) — catches SystemExit and KeyboardInterrupt
 
@@ -135,7 +135,7 @@ SystemExit.  Always specify at least `except Exception:`.
 
 ## E007 — `ErrorToReturnValue` {#e007}
 
-**Tier:** `warn` · **Category:** `error-to-return-value` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `error-to-return-value` · **Autofixable:** — · **Since:** 0.2.0
 
 > except block returns a value without logging — error hidden
 
@@ -151,7 +151,7 @@ domain-specific exception instead.
 
 ## E008 — `ImportErrorWithoutLogging` {#e008}
 
-**Tier:** `warn` · **Category:** `optional-import` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `optional-import` · **Autofixable:** — · **Since:** 0.2.0
 
 > except ImportError without logging — environment issues hidden
 
@@ -168,7 +168,7 @@ later with a confusing AttributeError).
 
 ## E009 — `ExceptBlockOnlyAssigns` {#e009}
 
-**Tier:** `warn` · **Category:** `error-to-return-value` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `error-to-return-value` · **Autofixable:** — · **Since:** 0.2.0
 
 > except block only assigns a variable — error hidden with no log
 
@@ -183,7 +183,7 @@ no logging.  Add a `logger.warning(..., exc_info=True)` before the assignment.
 
 ## E010 — `AsyncioGatherExceptionsUnexamined` {#e010}
 
-**Tier:** `warn` · **Category:** `asyncio-unexamined` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `asyncio-unexamined` · **Autofixable:** — · **Since:** 0.2.0
 
 > asyncio.gather(return_exceptions=True) results not checked for exceptions
 
@@ -200,7 +200,7 @@ silently.  The pattern is only a bug when results are not checked;
 
 ## E011 — `LoggingFilterUnsafeBody` {#e011}
 
-**Tier:** `warn` · **Category:** `filter-safety` · **Autofixable:** — · **Since:** 3.17.0
+**Tier:** `warn` · **Category:** `filter-safety` · **Autofixable:** — · **Since:** 0.2.0
 
 > logging.Filter.filter() body not wrapped in try/except — can crash caller
 
@@ -221,7 +221,7 @@ propagate.
 
 ## E012 — `UntypedBuiltinRaise` {#e012}
 
-**Tier:** `warn` · **Category:** `untyped-raise` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `untyped-raise` · **Autofixable:** — · **Since:** 0.2.0
 
 > raise ValueError/RuntimeError/... where a typed AppError applies
 
@@ -239,7 +239,7 @@ require `TypeError`/`ValueError` for stdlib interoperability.
 
 ## E013 — `LegacyAtlanErrorRaise` {#e013}
 
-**Tier:** `block` · **Category:** `legacy-raise` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `block` · **Category:** `legacy-raise` · **Autofixable:** — · **Since:** 0.2.0
 
 > raise ClientError/ApiError/... (deprecated AtlanError stack)
 
@@ -255,7 +255,7 @@ in v4.0.  Replace with the appropriate leaf from `application_sdk.errors`.
 
 ## E014 — `ExceptLoopControlSwallow` {#e014}
 
-**Tier:** `warn` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 3.17.0
+**Tier:** `warn` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 0.2.0
 
 > except block exits loop silently (continue/break) without logging
 
@@ -273,7 +273,7 @@ log at WARNING/ERROR with `exc_info=True`.
 
 ## E015 — `ExceptionTextInErrorMessage` {#e015}
 
-**Tier:** `warn` · **Category:** `error-message-hygiene` · **Autofixable:** — · **Since:** 3.17.0
+**Tier:** `warn` · **Category:** `error-message-hygiene` · **Autofixable:** — · **Since:** 0.2.0
 
 > Caught exception text interpolated into typed error message= — leaks unsanitised text
 
@@ -294,7 +294,7 @@ and keep `message=` a stable human summary.
 
 ## E016 — `MissingExceptionChaining` {#e016}
 
-**Tier:** `warn` · **Category:** `exception-chaining` · **Autofixable:** yes · **Since:** 3.17.0
+**Tier:** `warn` · **Category:** `exception-chaining` · **Autofixable:** yes · **Since:** 0.2.0
 
 > raise inside except block missing 'from exc' cause — breaks exception chain
 
@@ -317,7 +317,7 @@ None` (intentional suppression).
 
 ## E017 — `SecretNamedEvidenceKey` {#e017}
 
-**Tier:** `block` · **Category:** `security` · **Autofixable:** — · **Since:** 3.17.0
+**Tier:** `block` · **Category:** `security` · **Autofixable:** — · **Since:** 0.2.0
 
 > Error evidence kwarg ending in _secret/_password/_token — rejected by wire layer at runtime
 
@@ -337,7 +337,7 @@ before any code runs.  Rename the evidence field to a safe key (e.g. `credential
 
 ## E018 — `BareParentLeafRaise` {#e018}
 
-**Tier:** `warn` · **Category:** `untyped-raise` · **Autofixable:** — · **Since:** 3.17.0
+**Tier:** `warn` · **Category:** `untyped-raise` · **Autofixable:** — · **Since:** 0.2.0
 
 > Raising a bare AppError leaf class without a domain subclass overriding code
 

--- a/packages/conformance/conformance/docs/rules/logging.md
+++ b/packages/conformance/conformance/docs/rules/logging.md
@@ -15,30 +15,30 @@ Suppress a finding on the violating line or the line directly above it:
 
 | ID | Name | Tier | Category | Autofixable | Since |
 |---|---|---|---|---|---|
-| [L001](#l001) | `FStringInLogMessage` | `block` | `log-format` | yes | 3.16.0 |
-| [L002](#l002) | `InconsistentLoggerFactory` | `warn` | `log-format` | yes | 3.16.0 |
-| [L003](#l003) | `ExtraKwargsWrongFramework` | `warn` | `log-format` | — | 3.16.0 |
-| [L004](#l004) | `ExceptBlockMissingExcInfoLog` | `block` | `missing-traceback` | yes | 3.16.0 |
-| [L005](#l005) | `PrintInProductionCode` | `warn` | `log-format` | yes | 3.16.0 |
-| [L006](#l006) | `InfoInTightLoop` | `warn` | `log-level` | — | 3.16.0 |
-| [L007](#l007) | `LoggerCriticalUsage` | `warn` | `log-level` | yes | 3.16.0 |
-| [L008](#l008) | `UnguardedExpensiveDebug` | `warn` | `log-performance` | — | 3.16.0 |
-| [L009](#l009) | `WarnThenRaiseDuplication` | `warn` | `log-noise` | — | 3.16.0 |
-| [L010](#l010) | `CredentialInLogOutput` | `block` | `security` | — | 3.16.0 |
-| [L011](#l011) | `StringConcatenationInLog` | `block` | `log-format` | yes | 3.16.0 |
-| [L012](#l012) | `StdlibExtraReservedKeyCollision` | `block` | `log-crash` | — | 3.16.0 |
-| [L013](#l013) | `StdlibArbitraryKwargs` | `block` | `log-crash` | yes | 3.16.0 |
-| [L014](#l014) | `StructlogEventKwargOverwrite` | `warn` | `log-format` | — | 3.16.0 |
-| [L015](#l015) | `DictConfigDisableExistingLoggers` | `warn` | `log-config` | yes | 3.16.0 |
-| [L016](#l016) | `BasicConfigNoopAfterFirstCall` | `warn` | `log-config` | — | 3.16.0 |
-| [L017](#l017) | `LoggerExceptionUsage` | `warn` | `log-level` | yes | 3.16.0 |
-| [L018](#l018) | `KwargsInApplicationLogCalls` | `warn` | `log-format` | — | 3.16.0 |
+| [L001](#l001) | `FStringInLogMessage` | `block` | `log-format` | yes | 0.2.0 |
+| [L002](#l002) | `InconsistentLoggerFactory` | `warn` | `log-format` | yes | 0.2.0 |
+| [L003](#l003) | `ExtraKwargsWrongFramework` | `warn` | `log-format` | — | 0.2.0 |
+| [L004](#l004) | `ExceptBlockMissingExcInfoLog` | `block` | `missing-traceback` | yes | 0.2.0 |
+| [L005](#l005) | `PrintInProductionCode` | `warn` | `log-format` | yes | 0.2.0 |
+| [L006](#l006) | `InfoInTightLoop` | `warn` | `log-level` | — | 0.2.0 |
+| [L007](#l007) | `LoggerCriticalUsage` | `warn` | `log-level` | yes | 0.2.0 |
+| [L008](#l008) | `UnguardedExpensiveDebug` | `warn` | `log-performance` | — | 0.2.0 |
+| [L009](#l009) | `WarnThenRaiseDuplication` | `warn` | `log-noise` | — | 0.2.0 |
+| [L010](#l010) | `CredentialInLogOutput` | `block` | `security` | — | 0.2.0 |
+| [L011](#l011) | `StringConcatenationInLog` | `block` | `log-format` | yes | 0.2.0 |
+| [L012](#l012) | `StdlibExtraReservedKeyCollision` | `block` | `log-crash` | — | 0.2.0 |
+| [L013](#l013) | `StdlibArbitraryKwargs` | `block` | `log-crash` | yes | 0.2.0 |
+| [L014](#l014) | `StructlogEventKwargOverwrite` | `warn` | `log-format` | — | 0.2.0 |
+| [L015](#l015) | `DictConfigDisableExistingLoggers` | `warn` | `log-config` | yes | 0.2.0 |
+| [L016](#l016) | `BasicConfigNoopAfterFirstCall` | `warn` | `log-config` | — | 0.2.0 |
+| [L017](#l017) | `LoggerExceptionUsage` | `warn` | `log-level` | yes | 0.2.0 |
+| [L018](#l018) | `KwargsInApplicationLogCalls` | `warn` | `log-format` | — | 0.2.0 |
 
 ---
 
 ## L001 — `FStringInLogMessage` {#l001}
 
-**Tier:** `block` · **Category:** `log-format` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `block` · **Category:** `log-format` · **Autofixable:** yes · **Since:** 0.2.0
 
 > f-string in log message — breaks log grouping and aggregation
 
@@ -57,7 +57,7 @@ kwargs.
 
 ## L002 — `InconsistentLoggerFactory` {#l002}
 
-**Tier:** `warn` · **Category:** `log-format` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `log-format` · **Autofixable:** yes · **Since:** 0.2.0
 
 > Logger factory inconsistent with project canonical factory
 
@@ -73,7 +73,7 @@ occurrence count) in Phase 1 and flags deviations.
 
 ## L003 — `ExtraKwargsWrongFramework` {#l003}
 
-**Tier:** `warn` · **Category:** `log-format` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `log-format` · **Autofixable:** — · **Since:** 0.2.0
 
 > extra={} used where framework expects direct kwargs (or vice versa)
 
@@ -90,7 +90,7 @@ detect the active framework first.
 
 ## L004 — `ExceptBlockMissingExcInfoLog` {#l004}
 
-**Tier:** `block` · **Category:** `missing-traceback` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `block` · **Category:** `missing-traceback` · **Autofixable:** yes · **Since:** 0.2.0
 
 > logger.warning/error in except block without exc_info=True
 
@@ -106,7 +106,7 @@ the root cause is invisible.  Add `exc_info=True` to all `logger.warning()` /
 
 ## L005 — `PrintInProductionCode` {#l005}
 
-**Tier:** `warn` · **Category:** `log-format` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `log-format` · **Autofixable:** yes · **Since:** 0.2.0
 
 > print() in production code — bypasses logging framework
 
@@ -123,7 +123,7 @@ log lines.  Acceptable in CLI scripts, test/debug scripts, and `if __name__ ==
 
 ## L006 — `InfoInTightLoop` {#l006}
 
-**Tier:** `warn` · **Category:** `log-level` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `log-level` · **Autofixable:** — · **Since:** 0.2.0
 
 > logger.info() inside a tight loop — generates excessive log volume
 
@@ -140,7 +140,7 @@ bounded (≤10 items) before flagging.
 
 ## L007 — `LoggerCriticalUsage` {#l007}
 
-**Tier:** `warn` · **Category:** `log-level` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `log-level` · **Autofixable:** yes · **Since:** 0.2.0
 
 > logger.critical() — CRITICAL is not a meaningful level here
 
@@ -157,7 +157,7 @@ on the observability platform.
 
 ## L008 — `UnguardedExpensiveDebug` {#l008}
 
-**Tier:** `warn` · **Category:** `log-performance` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `log-performance` · **Autofixable:** — · **Since:** 0.2.0
 
 > Expensive computation in logger.debug() argument — evaluates eagerly
 
@@ -173,7 +173,7 @@ logger.isEnabledFor(logging.DEBUG):`.
 
 ## L009 — `WarnThenRaiseDuplication` {#l009}
 
-**Tier:** `warn` · **Category:** `log-noise` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `log-noise` · **Autofixable:** — · **Since:** 0.2.0
 
 > logger.warning/error immediately before raise — duplicate log records
 
@@ -189,7 +189,7 @@ available to the caller.  Otherwise: just re-raise.
 
 ## L010 — `CredentialInLogOutput` {#l010}
 
-**Tier:** `block` · **Category:** `security` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `block` · **Category:** `security` · **Autofixable:** — · **Since:** 0.2.0
 
 > Credential/secret value in log output — security vulnerability
 
@@ -206,7 +206,7 @@ store.  Requires human security review before marking acceptable.  Logging a cre
 
 ## L011 — `StringConcatenationInLog` {#l011}
 
-**Tier:** `block` · **Category:** `log-format` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `block` · **Category:** `log-format` · **Autofixable:** yes · **Since:** 0.2.0
 
 > String concatenation in log message — breaks log grouping
 
@@ -221,7 +221,7 @@ way that breaks log grouping.  Rewrite as %-style message body.
 
 ## L012 — `StdlibExtraReservedKeyCollision` {#l012}
 
-**Tier:** `block` · **Category:** `log-crash` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `block` · **Category:** `log-crash` · **Autofixable:** — · **Since:** 0.2.0
 
 > extra={} key collides with stdlib LogRecord attribute — crashes caller
 
@@ -238,7 +238,7 @@ stdlib's `Logger.makeRecord()` raises `KeyError` if any key in `extra={}` matche
 
 ## L013 — `StdlibArbitraryKwargs` {#l013}
 
-**Tier:** `block` · **Category:** `log-crash` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `block` · **Category:** `log-crash` · **Autofixable:** yes · **Since:** 0.2.0
 
 > Arbitrary kwargs in stdlib logger — raises TypeError immediately
 
@@ -254,7 +254,7 @@ from structlog/loguru. Applies to stdlib only.
 
 ## L014 — `StructlogEventKwargOverwrite` {#l014}
 
-**Tier:** `warn` · **Category:** `log-format` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `log-format` · **Autofixable:** — · **Since:** 0.2.0
 
 > event= kwarg in structlog silently overwrites the log message
 
@@ -271,7 +271,7 @@ only.
 
 ## L015 — `DictConfigDisableExistingLoggers` {#l015}
 
-**Tier:** `warn` · **Category:** `log-config` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `log-config` · **Autofixable:** yes · **Since:** 0.2.0
 
 > dictConfig without disable_existing_loggers=False silently kills loggers
 
@@ -288,7 +288,7 @@ Applies to stdlib only.
 
 ## L016 — `BasicConfigNoopAfterFirstCall` {#l016}
 
-**Tier:** `warn` · **Category:** `log-config` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `log-config` · **Autofixable:** — · **Since:** 0.2.0
 
 > Multiple basicConfig() calls — second+ are silent no-ops
 
@@ -304,7 +304,7 @@ __name__ == "__main__":` blocks. Applies to stdlib only.
 
 ## L017 — `LoggerExceptionUsage` {#l017}
 
-**Tier:** `warn` · **Category:** `log-level` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `log-level` · **Autofixable:** yes · **Since:** 0.2.0
 
 > logger.exception() used — use logger.error(..., exc_info=True) instead
 
@@ -329,7 +329,7 @@ only to satisfy third-party Temporal callers and immediately delegates to
 
 ## L018 — `KwargsInApplicationLogCalls` {#l018}
 
-**Tier:** `warn` · **Category:** `log-format` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Category:** `log-format` · **Autofixable:** — · **Since:** 0.2.0
 
 > kwargs in application log calls — use %-style message body instead
 

--- a/packages/conformance/conformance/docs/schema-contract.md
+++ b/packages/conformance/conformance/docs/schema-contract.md
@@ -43,7 +43,7 @@ validation contract.  Every produced document must validate against it via
 | **Proposed fix** | `result.fixes[]` (`artifactChanges`) | populated by the remediation layer (BLDX-1388) |
 | **Rule mechanism** | `properties["atlan/mechanism"]` | `"static"` or `"test"` — lets the loop re-run the narrowest gate |
 | **Remediation hint** | `result.properties["atlan/hint"]` | machine-actionable hint for the model |
-| **Suite version** | `run.tool.driver.version` | = SDK release, e.g. `"3.16.0"` |
+| **Suite version** | `run.tool.driver.version` | = conformance package release, e.g. `"0.4.0"` |
 | **Repo / commit** | `run.versionControlProvenance[]` | `repositoryUri`, `revisionId` (SHA), `branch` |
 | **Gate decision** | `run.invocations[0].exitCode` | `0` = gate passed, `1` = gate failed |
 | **Disposition totals** | `run.properties["atlan/summary"]` | `{passing, failing, warning, suppressed}` counts |

--- a/packages/conformance/conformance/suite/rules/ci.py
+++ b/packages/conformance/conformance/suite/rules/ci.py
@@ -13,7 +13,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="supply-chain",
         autofixable=True,
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "A mutable tag (@v4) can be silently re-pointed to any commit after review — "
             "including malicious code — with no notification to the consumer. Pinning to a "

--- a/packages/conformance/conformance/suite/rules/error_handling.py
+++ b/packages/conformance/conformance/suite/rules/error_handling.py
@@ -14,7 +14,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="silent-swallow",
         autofixable=False,
         orthogonal_gate="tests",
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "The hardest class of production bug to debug: no stack trace, no log record, "
             "no indication anything failed. Every downstream anomaly (wrong results, missing "
@@ -38,7 +38,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="silent-swallow",
         autofixable=False,
         orthogonal_gate="tests",
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "A typed catch that discards silently still destroys the event record. Stack "
             "traces at the point of failure are often the only artifact that survives async "
@@ -61,7 +61,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="silent-swallow",
         autofixable=False,
         orthogonal_gate="tests",
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "suppress(Exception) is semantically identical to except Exception: pass — it "
             "absorbs every unexpected failure with no trace. A narrow suppress(FileNotFoundError) "
@@ -84,7 +84,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="overly-broad-catch",
         autofixable=False,
         orthogonal_gate="tests",
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "Without exc_info, the stack trace is gone at the point of capture. A broad "
             "catch without a traceback also masks completely unexpected exceptions from "
@@ -107,7 +107,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="missing-traceback",
         autofixable=True,
         orthogonal_gate="tests",
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "Tracebacks are the primary artifact of incident postmortems. A record that "
             "says something failed but carries no stack trace forces engineers to reproduce "
@@ -129,7 +129,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="silent-swallow",
         autofixable=False,
         orthogonal_gate="tests",
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "A bare except: absorbs KeyboardInterrupt and SystemExit even with a handler "
             "body. Process-termination signals are silently intercepted and the process may "
@@ -150,7 +150,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="error-to-return-value",
         autofixable=False,
         orthogonal_gate="tests",
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "Converting an exception to a falsy return value (None, [], False) shifts the "
             "failure point: the caller sees a plausible empty result and fails later, often "
@@ -172,7 +172,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="optional-import",
         autofixable=False,
         orthogonal_gate="tests",
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "Silent optional-import guards mask environment misconfigurations. If a "
             "preferred module is unexpectedly absent, the fallback runs and produces subtly "
@@ -195,7 +195,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="error-to-return-value",
         autofixable=False,
         orthogonal_gate="tests",
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "The exception sets a flag or default and the event record is destroyed. "
             "Callers see apparently-normal behaviour until they discover the silent fallback "
@@ -218,7 +218,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="asyncio-unexamined",
         autofixable=False,
         orthogonal_gate="tests",
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "gather(return_exceptions=True) turns exceptions into values, "
             "indistinguishable from normal results in the returned list. Every failed "
@@ -242,7 +242,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="filter-safety",
         autofixable=False,
         orthogonal_gate="tests",
-        since="3.17.0",
+        since="0.2.0",
         rationale=(
             "logging.Filter.filter() exceptions propagate to the code that called "
             "logger.info() — not to handleError() like handler exceptions. An unguarded "
@@ -270,7 +270,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="untyped-raise",
         autofixable=False,
         orthogonal_gate="tests",
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "The Automation Engine receives a typed error envelope (category, audience, "
             "retryable, code). A bare ValueError delivers an opaque string with none of "
@@ -296,7 +296,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="legacy-raise",
         autofixable=False,
         orthogonal_gate="tests",
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "AtlanError subclasses produce no typed wire envelope — they reach AE as opaque "
             "strings and emit DeprecationWarning at construction. Every new raise site "
@@ -319,7 +319,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="silent-swallow",
         autofixable=False,
         orthogonal_gate="tests",
-        since="3.17.0",
+        since="0.2.0",
         rationale=(
             "A loop that silently absorbs per-item exceptions can complete with a "
             "full-looking result set that silently omits items. Silent partial failure is "
@@ -345,7 +345,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="error-message-hygiene",
         autofixable=False,
         orthogonal_gate="tests",
-        since="3.17.0",
+        since="0.2.0",
         rationale=(
             "Embedding str(exc) in message= produces a unique string per failure instance — "
             "each path/value becomes a separate dashboard bucket instead of one countable "
@@ -374,7 +374,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="exception-chaining",
         autofixable=True,
         orthogonal_gate="tests",
-        since="3.17.0",
+        since="0.2.0",
         rationale=(
             "When the Automation Engine rebuilds the typed wire envelope it walks the "
             ".cause/__cause__ chain (set by 'raise X from e'); its reconstruction path does "
@@ -404,7 +404,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="security",
         autofixable=False,
         orthogonal_gate="tests",
-        since="3.17.0",
+        since="0.2.0",
         rationale=(
             "Evidence fields with secret-bearing suffixes are rejected by the wire layer at "
             "runtime. Static detection catches the pattern before any code runs, eliminating "
@@ -431,7 +431,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="untyped-raise",
         autofixable=False,
         orthogonal_gate="tests",
-        since="3.17.0",
+        since="0.2.0",
         rationale=(
             "Each categorical leaf is a dashboard bucket. Raising the parent directly "
             "collapses all domain failure modes into one bucket — impossible to count "

--- a/packages/conformance/conformance/suite/rules/logging.py
+++ b/packages/conformance/conformance/suite/rules/logging.py
@@ -14,7 +14,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="log-format",
         autofixable=True,
         orthogonal_gate="tests",
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "%-style message bodies are the fleet-wide logging convention: one consistent "
             "call-site style keeps log statements legible and reviewable, and the SDK's "
@@ -39,7 +39,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="log-format",
         autofixable=True,
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "Mixed logger factories produce incompatible record formats. The adapter that "
             "injects Temporal context only activates for the canonical factory; records from "
@@ -60,7 +60,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="log-format",
         autofixable=False,
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "Whether kwargs land in indexed top-level fields or an unindexed nested dict "
             "depends on the framework. The wrong form routes context where aggregation "
@@ -83,7 +83,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="missing-traceback",
         autofixable=True,
         orthogonal_gate="tests",
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "Same failure as E005 at the logging layer: the message appears in the stream "
             "but the stack trace is absent, so every postmortem hitting this pattern must "
@@ -105,7 +105,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="log-format",
         autofixable=True,
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "print() bypasses the logging adapter entirely: no level, no correlation ID, "
             "no structured fields, no OTel forwarding. In containers, stdout may route to a "
@@ -127,7 +127,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="log-level",
         autofixable=False,
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "Per-item INFO in a large loop emits O(N) records at the level operators "
             "monitor, drowning lifecycle signals in noise and inflating storage cost. INFO "
@@ -150,7 +150,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="log-level",
         autofixable=True,
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "ADR-0011 codifies exactly four levels (DEBUG/INFO/WARNING/ERROR) — there is no "
             "CRITICAL. Fatal conditions are communicated through process exit codes and "
@@ -173,7 +173,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="log-performance",
         autofixable=False,
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "Log-call arguments evaluate eagerly regardless of level. An unguarded expensive "
             "serialisation inside logger.debug() runs on every call in production — invisible "
@@ -194,7 +194,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="log-noise",
         autofixable=False,
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "Logging immediately before re-raising creates two records for one event (raise "
             "site + handler), inflating error counts and making 'how many times did this "
@@ -216,7 +216,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="security",
         autofixable=False,
         orthogonal_gate="tests",
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "Log aggregation stores records in plaintext accessible to more people and "
             "systems than the credential store. A credential value in a log is a persistent "
@@ -239,7 +239,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="log-format",
         autofixable=True,
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "Same convention as L001: string concatenation is an ad-hoc alternative to the "
             "standard %-style message body. It reads worse at the call site and breaks "
@@ -259,7 +259,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="log-crash",
         autofixable=False,
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "stdlib's Logger.makeRecord() raises KeyError when an extra={} key collides "
             "with a LogRecord attribute, propagating to the caller's logger.info() site and "
@@ -283,7 +283,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="log-crash",
         autofixable=True,
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "stdlib logger.info() raises TypeError immediately for any kwarg outside its "
             "short allowlist. The most common breakage when migrating from structlog (which "
@@ -305,7 +305,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="log-format",
         autofixable=False,
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "In structlog the first positional arg is the message (stored as 'event'). "
             "Passing event= as a keyword silently replaces the message with the domain "
@@ -327,7 +327,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="log-config",
         autofixable=True,
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "dictConfig() defaults disable_existing_loggers=True, silently disabling every "
             "logger created before the call. SDK components create loggers at import — before "
@@ -350,7 +350,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="log-config",
         autofixable=False,
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "basicConfig() is silently ignored if the root logger already has handlers. "
             "Multiple calls rely on import order to decide which wins; the rest are silently "
@@ -373,7 +373,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="log-level",
         autofixable=True,
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "logger.exception() is rejected outright. ADR-0011 restricts logging to four "
             "levels with exc_info=True as the sanctioned way to attach a traceback; "
@@ -403,7 +403,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="log-format",
         autofixable=False,
-        since="3.16.0",
+        since="0.2.0",
         rationale=(
             "The adapter auto-injects Temporal context (workflow/run/activity IDs) as the "
             "only top-level indexed columns in ClickHouse/Grafana. App kwargs land in an "

--- a/packages/conformance/conformance/suite/schema/catalog.py
+++ b/packages/conformance/conformance/suite/schema/catalog.py
@@ -54,10 +54,10 @@ class RuleDefinition(BaseModel):
     help_uri: str | None = None
     orthogonal_gate: str | None = None
     since: str | None = None
-    """SDK version when the behaviour behind this rule was first enforced.
+    """Conformance suite version when the behaviour behind this rule was first enforced.
     Tracks the behavioural appearance, not when a specific rule ID was assigned —
     so a renumbered rule retains the original ``since`` of the behaviour it
-    describes, e.g. ``"3.16.0"``."""
+    describes, e.g. ``"0.2.0"``."""
     rationale: str = ""
     """Why this rule exists — what risk it avoids, what loop it closes, or what
     value it adds. Surfaced as ``atlan/rationale`` in SARIF ``properties``."""

--- a/packages/conformance/conformance/suite/schema/extensions.py
+++ b/packages/conformance/conformance/suite/schema/extensions.py
@@ -58,7 +58,7 @@ class AtlanRuleProperties(BaseModel):
     """
 
     since: str | None = None
-    """Suite (SDK) version when this rule was introduced, e.g. ``"3.16.0"``."""
+    """Conformance suite version when this rule was introduced, e.g. ``"0.2.0"``."""
 
     rationale: str | None = None
     """Why this rule exists — what risk it avoids, what loop it closes, or what

--- a/packages/conformance/tests/fixtures/golden_four_dispositions.sarif.json
+++ b/packages/conformance/tests/fixtures/golden_four_dispositions.sarif.json
@@ -6,8 +6,8 @@
       "tool": {
         "driver": {
           "name": "atlan-conformance",
-          "version": "3.16.0",
-          "semanticVersion": "3.16.0",
+          "version": "0.4.0",
+          "semanticVersion": "0.4.0",
           "rules": [
             {
               "id": "P001",
@@ -26,7 +26,7 @@
                 "atlan/category": "silent-swallow",
                 "atlan/autofixable": false,
                 "atlan/orthogonalGate": "tests",
-                "atlan/since": "3.16.0"
+                "atlan/since": "0.2.0"
               }
             },
             {
@@ -45,7 +45,7 @@
                 "atlan/mechanism": "static",
                 "atlan/category": "log-format",
                 "atlan/autofixable": true,
-                "atlan/since": "3.16.0"
+                "atlan/since": "0.2.0"
               }
             }
           ]

--- a/packages/conformance/tests/test_schema_validation.py
+++ b/packages/conformance/tests/test_schema_validation.py
@@ -75,7 +75,7 @@ def test_golden_example_summary() -> None:
 
 def test_report_builder_empty_validates() -> None:
     """An empty report (no results) is still valid SARIF."""
-    builder = ReportBuilder(tool_name="atlan-conformance", tool_version="3.16.0")
+    builder = ReportBuilder(tool_name="atlan-conformance", tool_version="0.4.0")
     report = builder.build()
     validate_sarif(report)
 
@@ -86,7 +86,7 @@ def test_report_builder_with_results_validates() -> None:
     builder = ReportBuilder.from_catalog(
         catalog,
         tool_name="atlan-conformance",
-        tool_version="3.16.0",
+        tool_version="0.4.0",
         repo_uri="https://github.com/atlanhq/test-app",
         commit_sha="abc123",
         branch="main",
@@ -111,7 +111,7 @@ def test_report_builder_suppressed_result_validates() -> None:
     builder = ReportBuilder.from_catalog(
         catalog,
         tool_name="atlan-conformance",
-        tool_version="3.16.0",
+        tool_version="0.4.0",
     )
     suppression = Suppression(
         kind="inSource",
@@ -132,7 +132,7 @@ def test_report_builder_suppressed_result_validates() -> None:
 
 def test_report_builder_pass_only_validates() -> None:
     """A report with only a pass result validates and has exitCode=0."""
-    builder = ReportBuilder(tool_name="atlan-conformance", tool_version="3.16.0")
+    builder = ReportBuilder(tool_name="atlan-conformance", tool_version="0.4.0")
     builder.add_pass(rule_id="L001", file_uri="src/connector/loader.py")
     report = builder.build()
     validate_sarif(report)
@@ -147,7 +147,7 @@ def test_report_builder_warning_only_exit_code() -> None:
     builder = ReportBuilder.from_catalog(
         catalog,
         tool_name="atlan-conformance",
-        tool_version="3.16.0",
+        tool_version="0.4.0",
     )
     # L006 (InfoInTightLoop) is tier=warn → level=warning
     builder.add_result(

--- a/packages/conformance/uv.lock
+++ b/packages/conformance/uv.lock
@@ -218,7 +218,7 @@ wheels = [
 
 [[package]]
 name = "atlan-application-sdk-conformance"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

- All C/E/L-series rules that pre-dated the standalone package (C001, E001–E018, L001–L018) carried `since` values from the application-sdk version namespace (`3.16.0` / `3.17.0`). Since the conformance suite is released as its own package, these now reference the conformance package version at which they first appeared (`0.2.0`).
- Updates the `since` field docstrings in `catalog.py` and `extensions.py` to say "conformance suite version" rather than "SDK version".
- Fixes the self-referencing version in `packages/conformance/uv.lock` (`0.3.0` → `0.4.0`).

## Test plan

- [ ] Pre-commit checks pass (`ruff`, `pyright`, `isort`)
- [ ] Conformance catalog and rule tests pass (`test_catalog.py`, `test_error_handling.py`, `test_disposition.py`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)