### PR TITLE
chore(docs): add minimal cloud permissions reference

### DIFF
--- a/docs/concepts/storage.md
+++ b/docs/concepts/storage.md
@@ -227,3 +227,83 @@ Use `azureEnvironment` to target sovereign clouds (`AzurePublicCloud`, `AzureChi
 |------|----------------|
 | Inline service-account key | Any SA JSON field that includes `private_key` or `private_key_id` |
 | ADC / Workload Identity / metadata server | `bucket` + `project_id` only (no `private_key`) |
+
+---
+
+## Required Cloud Permissions
+
+The SDK uses a fixed set of object-level operations — no bucket creation, versioning, lifecycle, or presigned-URL generation. The tables below list the minimum permissions the access identity must hold on the target bucket or container.
+
+### S3
+
+Apply object-level actions to `arn:aws:s3:::BUCKET/*` and the list action to `arn:aws:s3:::BUCKET` in separate IAM statement entries.
+
+| IAM action | Operations covered |
+|---|---|
+| `s3:GetObject` | GetObject (full and byte-range), HeadObject |
+| `s3:PutObject` | PutObject, CreateMultipartUpload, UploadPart, CompleteMultipartUpload |
+| `s3:AbortMultipartUpload` | Abort in-flight multipart upload on error (required for streaming write error paths) |
+| `s3:DeleteObject` | DeleteObject and DeleteObjects (bulk batch — same IAM action) |
+| `s3:ListBucket` | ListObjectsV2 — bucket-level permission, not object-level |
+
+Minimal policy skeleton:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:AbortMultipartUpload",
+        "s3:DeleteObject"
+      ],
+      "Resource": "arn:aws:s3:::YOUR-BUCKET/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::YOUR-BUCKET"
+    }
+  ]
+}
+```
+
+**AssumeRole**: when using `assumeRoleArn`, the caller identity additionally needs `sts:AssumeRole` on the target role ARN. The role itself holds the bucket policy above.
+
+### GCS
+
+| IAM permission | Operations covered |
+|---|---|
+| `storage.objects.get` | GetObject (full and byte-range), object metadata / HeadObject equivalent |
+| `storage.objects.create` | PutObject, resumable / streaming write |
+| `storage.objects.delete` | DeleteObject (GCS has no native bulk-delete API — `delete_prefix` issues parallel single-object deletes) |
+| `storage.objects.list` | ListObjects |
+
+No `storage.buckets.*` permissions are needed. The smallest predefined role that covers all four is **`roles/storage.objectAdmin`** scoped to the bucket. Alternatively, create a custom role with exactly these four permissions.
+
+### Azure Blob Storage / ADLS Gen2
+
+**RBAC** — assign at container or storage-account scope:
+
+| RBAC action | Operations covered |
+|---|---|
+| `Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read` | GetBlob, GetBlobProperties (HEAD), ListBlobs, byte-range GET |
+| `Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write` | PutBlob, PutBlock + PutBlockList (streaming / block write) |
+| `Microsoft.Storage/storageAccounts/blobServices/containers/blobs/delete` | DeleteBlob, BlobBatch delete (bulk — up to 256 keys per request) |
+
+The smallest predefined role covering all three is **`Storage Blob Data Contributor`**. `Storage Blob Data Owner` is a superset and is only needed if you additionally require POSIX ACL management on ADLS Gen2.
+
+**SAS token** — minimum permissions at container scope: `r` (read) + `w` (write) + `d` (delete) + `l` (list), i.e. a container-scoped SAS with **`rwdl`**.
+
+**ADLS Gen2 with POSIX ACLs**: if the storage account has hierarchical namespace enabled and you use ACL-based access control instead of RBAC, the principal needs Execute (`X`) on every parent directory and Read / Write / Delete on the objects in scope. RBAC (`Storage Blob Data Contributor`) is simpler and is recommended unless you have a specific ACL requirement.
+
+### What you do not need
+
+These are commonly over-provisioned by accident:
+
+- S3: any `s3:*Bucket*` action beyond `s3:ListBucket` (no lifecycle, versioning, ACL, tagging, or CORS operations)
+- GCS: any `storage.buckets.*` permission
+- Azure: `Microsoft.Storage/storageAccounts/blobServices/containers/write` (container creation)


### PR DESCRIPTION
## Summary

- Adds a **Required Cloud Permissions** section to `docs/concepts/storage.md`, directly after the existing Supported Auth Modes section
- Documents the minimum IAM/RBAC permissions for S3, GCS, and Azure Blob Storage / ADLS Gen2, derived from the exact `obstore` operations the SDK performs
- Includes an IAM policy skeleton for S3, predefined-role guidance for GCS and Azure, SAS token shorthand (`rwdl`) for Azure, and an explicit "what you don't need" list to prevent over-provisioning

## Test plan

- [ ] Verify the new section renders correctly in MkDocs (`uv run poe generate-apidocs`)
- [ ] Confirm IAM actions against AWS, GCS, and Azure documentation for accuracy