### PR TITLE
chore(ci): auto-mark tests/integration as integration so they skip the unit job

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,6 +22,22 @@ import pytest
 import pytest_asyncio
 
 
+def pytest_collection_modifyitems(items):
+    """Auto-apply the ``integration`` marker to every test under ``tests/integration/``.
+
+    The unit-test job runs the whole tree (``pytest tests/``) and relies on the
+    default ``addopts`` deselection (``-m 'not integration ...'``) to skip these
+    heavyweight, Temporal-backed tests; the dedicated integration job selects
+    them with ``-m integration``. Marking by directory here makes that the single
+    source of truth, so a file that forgets an explicit ``@pytest.mark.integration``
+    can no longer leak into the unit job and blow its time budget.
+    """
+    integration_root = Path(__file__).parent
+    for item in items:
+        if integration_root in item.path.parents:
+            item.add_marker("integration")
+
+
 @pytest.fixture(autouse=True)
 def _integration_env_vars():
     """Disable interceptors and Dapr sinks for the duration of each integration test.


### PR DESCRIPTION
## Relationship to #2208

#2208 (merged) fixed one instance of this exact bug class — a `WorkflowEnvironment.start_local()` test (`StorageTier` round-trip) that was missing `@pytest.mark.integration`, leaked into the unit suite, and timed out the job. That fix moved the file into `tests/integration/` and added an explicit marker.

This PR generalizes that one-file fix into a **guardrail**: rather than relying on each contributor remembering to add the marker, every test under `tests/integration/` is auto-marked. The fact that the four files below slipped through *after* #2208 is the evidence that a per-file manual fix isn't sufficient on its own.

---

## Problem

The **Unit Tests** matrix job runs the whole tree (`pytest tests/`) and relies on the default `addopts` deselection (`-m 'not integration and not e2e ...'`, see `pyproject.toml`) to skip the heavyweight, Temporal-backed integration suite.

Four files under `tests/integration/` were **missing** the `@pytest.mark.integration` marker:

- `test_workflow_interaction_cookbook.py`
- `test_workflow_interaction_relay.py`
- `test_dapr_http.py`
- `test_sql_app_prime_auth.py`

Because they were unmarked, they were **not** deselected and ran inside *every* unit matrix cell (4 Python versions × 3 OSes) — while being **excluded** from the dedicated Integration job (which selects with `-m integration`). So these tests ran in the wrong job, 12× over, and not in the right one at all.

The workflow-interaction tests spin up a local Temporal dev server (`WorkflowEnvironment.start_local()`, binary fetched from `temporal.download`). When that download is slow, each test takes minutes, pushing the slowest unit matrix cells past the **10-minute** job timeout → the job is cancelled and CI fails.

Observed in a recent merge-queue run: `Unit Tests (3.12, windows-latest)` and `Unit Tests (3.13, ubuntu-22.04)` both hit `exceeded the maximum execution time of 10m0s` while running `test_workflow_interaction_cookbook.py` (2–3.5 min/test). The dedicated Integration job passed in the same run — because it never ran these unmarked tests.

## Fix

Add a `pytest_collection_modifyitems` hook in `tests/integration/conftest.py` that auto-applies the `integration` marker to every test collected under `tests/integration/`.

This makes **"lives in `tests/integration/` ⇒ `integration`"** the single source of truth: a file that forgets an explicit `@pytest.mark.integration` can no longer leak into the unit job and blow its time budget.

## Verification

- **Unit job (default addopts):** the 21 previously-leaking tests are now deselected; full unit suite green, **coverage 90.96%** (≥ 85% gate). Suite runs in ~95s without the slow integration tests.
- **Integration job (`-m integration --timeout=120`):** all 25 relocated tests pass in ~16s with a warm Temporal binary — comfortably under the 120s per-test cap. No failure relocated.
- `pre-commit run --files tests/integration/conftest.py` passes (ruff, ruff-format, isort, pyright).

## Notes / out of scope

- This stops integration tests from polluting the unit job; it does **not** harden CI against a `temporal.download` outage itself. Pre-fetching/caching the `start_local` Temporal binary (the existing cache step only covers the `embedded_runtime` helper path, not temporalio's own downloader) would be a good follow-up to remove that single point of network flakiness.