### PR TITLE
feat(conformance): rule scope (sdk/app/both) + wire D-series CI

### DIFF
--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -22,8 +22,8 @@
 #
 # Scope: the runner auto-detects whether the caller repo is the SDK or a consumer
 # app (from its `[project].name`) and runs only the rules in scope.  D-series and
-# the bootstrap-shim C-rules are app-scoped, so they no-op on the SDK itself with
-# no per-caller configuration.
+# the bootstrap-workflow-drift rule (C002) are app-scoped, so they no-op on the
+# SDK itself with no per-caller configuration.
 #
 # The matrix job is intentionally inline (not delegating to sub-workflows) so
 # GitHub reports the legs at the correct depth — one level of workflow_call from

--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -2,21 +2,28 @@
 #
 # Reusable workflow: full conformance suite gate.
 #
-# Runs each rule series (C, E, P, O) as a separate leg of one matrix job so each
-# appears as its own status check:
+# Runs each rule series (C, E, P, O, D) as a separate leg of one matrix job so
+# each appears as its own status check:
 #   Conformance / suite / CI
 #   Conformance / suite / Error-handling
 #   Conformance / suite / Prescriptions
 #   Conformance / suite / Optimizations
+#   Conformance / suite / Dependency
 #   Conformance / suite / Conformance Gate  (required gate)
 #
 # The series share an identical job body (checkout → changed-files filter → uv →
 # run → upload → Security-tab upload), so they are expressed as a single
-# `strategy.matrix` rather than four copy-pasted jobs.  The only per-series
+# `strategy.matrix` rather than copy-pasted jobs.  The only per-series
 # values are the matrix entries (series letter, display name, sarif slug,
 # changed-files path glob, and the caller's exclude-paths input).  Note C-series
-# watches `.github/**` while the AST series (E/P/O) watch `**/*.py`; that
-# asymmetry is just a matrix field, not a separate job.
+# watches `.github/**`, D-series watches `**/pyproject.toml`, and the AST series
+# (E/P/O) watch `**/*.py`; that asymmetry is just a matrix field, not a separate
+# job.
+#
+# Scope: the runner auto-detects whether the caller repo is the SDK or a consumer
+# app (from its `[project].name`) and runs only the rules in scope.  D-series and
+# the bootstrap-shim C-rules are app-scoped, so they no-op on the SDK itself with
+# no per-caller configuration.
 #
 # The matrix job is intentionally inline (not delegating to sub-workflows) so
 # GitHub reports the legs at the correct depth — one level of workflow_call from
@@ -114,6 +121,13 @@ on:
         required: false
         default: ""
         type: string
+      exclude-paths-d:
+        description: >
+          Comma-separated repo-root-relative path prefixes to exclude from D-series
+          (dependency) checks only, e.g. 'tools/,contract-toolkit/'.  Default: nothing excluded.
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -153,6 +167,11 @@ jobs:
             slug: optimizations
             paths: "**/*.py"
             exclude_paths: ${{ inputs.exclude-paths-o }}
+          - series: D
+            name: "Dependency"
+            slug: dependency
+            paths: "**/pyproject.toml"
+            exclude_paths: ${{ inputs.exclude-paths-d }}
     steps:
       - name: "Checkout caller repo"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/packages/conformance/conformance/docs/rules/ci.md
+++ b/packages/conformance/conformance/docs/rules/ci.md
@@ -13,17 +13,17 @@ Suppress a finding on the violating line or the line directly above it:
 # conformance: ignore[C001] intentional: org-internal action
 ```
 
-| ID | Name | Tier | Category | Autofixable | Since |
-|---|---|---|---|---|---|
-| [C001](#c001) | `UnpinnedActionReference` | `block` | `supply-chain` | yes | 3.16.0 |
-| [C002](#c002) | `BootstrapWorkflowDrift` | `warn` | `ci-consistency` | yes | 0.3.0 |
-| [C003](#c003) | `GitignoreMissingEntry` | `warn` | `ci-consistency` | — | 0.4.0 |
+| ID | Name | Tier | Scope | Category | Autofixable | Since |
+|---|---|---|---|---|---|---|
+| [C001](#c001) | `UnpinnedActionReference` | `block` | `both` | `supply-chain` | yes | 3.16.0 |
+| [C002](#c002) | `BootstrapWorkflowDrift` | `warn` | `app` | `ci-consistency` | yes | 0.3.0 |
+| [C003](#c003) | `GitignoreMissingEntry` | `warn` | `app` | `ci-consistency` | — | 0.4.0 |
 
 ---
 
 ## C001 — `UnpinnedActionReference` {#c001}
 
-**Tier:** `block` · **Category:** `supply-chain` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `block` · **Scope:** `both` · **Category:** `supply-chain` · **Autofixable:** yes · **Since:** 3.16.0
 
 > External GitHub Action not pinned to a full commit digest
 
@@ -40,7 +40,7 @@ local `./` composite-action refs are exempt (no version to pin).
 
 ## C002 — `BootstrapWorkflowDrift` {#c002}
 
-**Tier:** `warn` · **Category:** `ci-consistency` · **Autofixable:** yes · **Since:** 0.3.0
+**Tier:** `warn` · **Scope:** `app` · **Category:** `ci-consistency` · **Autofixable:** yes · **Since:** 0.3.0
 
 > Managed CI workflow is absent or has drifted from the bootstrap canonical
 
@@ -59,7 +59,7 @@ choices (e.g. `package_name`, `unit_tests_workflow_file`) are preserved.
 
 ## C003 — `GitignoreMissingEntry` {#c003}
 
-**Tier:** `warn` · **Category:** `ci-consistency` · **Autofixable:** — · **Since:** 0.4.0
+**Tier:** `warn` · **Scope:** `app` · **Category:** `ci-consistency` · **Autofixable:** — · **Since:** 0.4.0
 
 > .gitignore is absent or missing a standard required entry
 

--- a/packages/conformance/conformance/docs/rules/ci.md
+++ b/packages/conformance/conformance/docs/rules/ci.md
@@ -17,7 +17,7 @@ Suppress a finding on the violating line or the line directly above it:
 |---|---|---|---|---|---|---|
 | [C001](#c001) | `UnpinnedActionReference` | `block` | `both` | `supply-chain` | yes | 0.2.0 |
 | [C002](#c002) | `BootstrapWorkflowDrift` | `warn` | `app` | `ci-consistency` | yes | 0.3.0 |
-| [C003](#c003) | `GitignoreMissingEntry` | `warn` | `app` | `ci-consistency` | — | 0.4.0 |
+| [C003](#c003) | `GitignoreMissingEntry` | `warn` | `both` | `ci-consistency` | — | 0.4.0 |
 
 ---
 
@@ -59,7 +59,7 @@ choices (e.g. `package_name`, `unit_tests_workflow_file`) are preserved.
 
 ## C003 — `GitignoreMissingEntry` {#c003}
 
-**Tier:** `warn` · **Scope:** `app` · **Category:** `ci-consistency` · **Autofixable:** — · **Since:** 0.4.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `ci-consistency` · **Autofixable:** — · **Since:** 0.4.0
 
 > .gitignore is absent or missing a standard required entry
 

--- a/packages/conformance/conformance/docs/rules/dependency.md
+++ b/packages/conformance/conformance/docs/rules/dependency.md
@@ -13,16 +13,16 @@ Suppress a finding on the violating line or the line directly above it:
 # conformance: ignore[D002] intentional: pinned to pre-release for hotfix
 ```
 
-| ID | Name | Tier | Category | Autofixable | Since |
-|---|---|---|---|---|---|
-| [D001](#d001) | `UnpinnedSdkDependency` | `block` | `dependency-pinning` | yes | 0.4.0 |
-| [D002](#d002) | `RedeclaredSdkManagedDependency` | `warn` | `dependency-pinning` | yes | 0.4.0 |
+| ID | Name | Tier | Scope | Category | Autofixable | Since |
+|---|---|---|---|---|---|---|
+| [D001](#d001) | `UnpinnedSdkDependency` | `block` | `app` | `dependency-pinning` | yes | 0.4.0 |
+| [D002](#d002) | `RedeclaredSdkManagedDependency` | `warn` | `app` | `dependency-pinning` | yes | 0.4.0 |
 
 ---
 
 ## D001 — `UnpinnedSdkDependency` {#d001}
 
-**Tier:** `block` · **Category:** `dependency-pinning` · **Autofixable:** yes · **Since:** 0.4.0
+**Tier:** `block` · **Scope:** `app` · **Category:** `dependency-pinning` · **Autofixable:** yes · **Since:** 0.4.0
 
 > Application SDK dependency is missing or its version specifier is not bounded on both ends
 
@@ -41,7 +41,7 @@ the SDK are also exempt — packages whose `[project].name` starts with
 
 ## D002 — `RedeclaredSdkManagedDependency` {#d002}
 
-**Tier:** `warn` · **Category:** `dependency-pinning` · **Autofixable:** yes · **Since:** 0.4.0
+**Tier:** `warn` · **Scope:** `app` · **Category:** `dependency-pinning` · **Autofixable:** yes · **Since:** 0.4.0
 
 > Dependency redeclared in the app's pyproject.toml is already managed by the SDK
 

--- a/packages/conformance/conformance/docs/rules/error-handling.md
+++ b/packages/conformance/conformance/docs/rules/error-handling.md
@@ -13,32 +13,32 @@ Suppress a finding on the violating line or the line directly above it:
 # conformance: ignore[E012] intentional: stdlib interop
 ```
 
-| ID | Name | Tier | Category | Autofixable | Since |
-|---|---|---|---|---|---|
-| [E001](#e001) | `BareExceptPass` | `block` | `silent-swallow` | — | 3.16.0 |
-| [E002](#e002) | `TypedExceptPass` | `block` | `silent-swallow` | — | 3.16.0 |
-| [E003](#e003) | `BroadContextlibSuppress` | `warn` | `silent-swallow` | — | 3.16.0 |
-| [E004](#e004) | `BroadExceptClause` | `warn` | `overly-broad-catch` | — | 3.16.0 |
-| [E005](#e005) | `ExceptBlockMissingExcInfo` | `warn` | `missing-traceback` | yes | 3.16.0 |
-| [E006](#e006) | `BareExceptWithBody` | `block` | `silent-swallow` | — | 3.16.0 |
-| [E007](#e007) | `ErrorToReturnValue` | `warn` | `error-to-return-value` | — | 3.16.0 |
-| [E008](#e008) | `ImportErrorWithoutLogging` | `warn` | `optional-import` | — | 3.16.0 |
-| [E009](#e009) | `ExceptBlockOnlyAssigns` | `warn` | `error-to-return-value` | — | 3.16.0 |
-| [E010](#e010) | `AsyncioGatherExceptionsUnexamined` | `warn` | `asyncio-unexamined` | — | 3.16.0 |
-| [E011](#e011) | `LoggingFilterUnsafeBody` | `warn` | `filter-safety` | — | 3.17.0 |
-| [E012](#e012) | `UntypedBuiltinRaise` | `warn` | `untyped-raise` | — | 3.16.0 |
-| [E013](#e013) | `LegacyAtlanErrorRaise` | `block` | `legacy-raise` | — | 3.16.0 |
-| [E014](#e014) | `ExceptLoopControlSwallow` | `warn` | `silent-swallow` | — | 3.17.0 |
-| [E015](#e015) | `ExceptionTextInErrorMessage` | `warn` | `error-message-hygiene` | — | 3.17.0 |
-| [E016](#e016) | `MissingExceptionChaining` | `warn` | `exception-chaining` | yes | 3.17.0 |
-| [E017](#e017) | `SecretNamedEvidenceKey` | `block` | `security` | — | 3.17.0 |
-| [E018](#e018) | `BareParentLeafRaise` | `warn` | `untyped-raise` | — | 3.17.0 |
+| ID | Name | Tier | Scope | Category | Autofixable | Since |
+|---|---|---|---|---|---|---|
+| [E001](#e001) | `BareExceptPass` | `block` | `both` | `silent-swallow` | — | 3.16.0 |
+| [E002](#e002) | `TypedExceptPass` | `block` | `both` | `silent-swallow` | — | 3.16.0 |
+| [E003](#e003) | `BroadContextlibSuppress` | `warn` | `both` | `silent-swallow` | — | 3.16.0 |
+| [E004](#e004) | `BroadExceptClause` | `warn` | `both` | `overly-broad-catch` | — | 3.16.0 |
+| [E005](#e005) | `ExceptBlockMissingExcInfo` | `warn` | `both` | `missing-traceback` | yes | 3.16.0 |
+| [E006](#e006) | `BareExceptWithBody` | `block` | `both` | `silent-swallow` | — | 3.16.0 |
+| [E007](#e007) | `ErrorToReturnValue` | `warn` | `both` | `error-to-return-value` | — | 3.16.0 |
+| [E008](#e008) | `ImportErrorWithoutLogging` | `warn` | `both` | `optional-import` | — | 3.16.0 |
+| [E009](#e009) | `ExceptBlockOnlyAssigns` | `warn` | `both` | `error-to-return-value` | — | 3.16.0 |
+| [E010](#e010) | `AsyncioGatherExceptionsUnexamined` | `warn` | `both` | `asyncio-unexamined` | — | 3.16.0 |
+| [E011](#e011) | `LoggingFilterUnsafeBody` | `warn` | `both` | `filter-safety` | — | 3.17.0 |
+| [E012](#e012) | `UntypedBuiltinRaise` | `warn` | `both` | `untyped-raise` | — | 3.16.0 |
+| [E013](#e013) | `LegacyAtlanErrorRaise` | `block` | `both` | `legacy-raise` | — | 3.16.0 |
+| [E014](#e014) | `ExceptLoopControlSwallow` | `warn` | `both` | `silent-swallow` | — | 3.17.0 |
+| [E015](#e015) | `ExceptionTextInErrorMessage` | `warn` | `both` | `error-message-hygiene` | — | 3.17.0 |
+| [E016](#e016) | `MissingExceptionChaining` | `warn` | `both` | `exception-chaining` | yes | 3.17.0 |
+| [E017](#e017) | `SecretNamedEvidenceKey` | `block` | `both` | `security` | — | 3.17.0 |
+| [E018](#e018) | `BareParentLeafRaise` | `warn` | `both` | `untyped-raise` | — | 3.17.0 |
 
 ---
 
 ## E001 — `BareExceptPass` {#e001}
 
-**Tier:** `block` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `block` · **Scope:** `both` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 3.16.0
 
 > Bare 'except: pass' silently discards every exception
 
@@ -55,7 +55,7 @@ even cleanup paths should log at DEBUG.
 
 ## E002 — `TypedExceptPass` {#e002}
 
-**Tier:** `block` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `block` · **Scope:** `both` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 3.16.0
 
 > Typed 'except SomeError: pass' discards exception silently
 
@@ -72,7 +72,7 @@ reasoning.
 
 ## E003 — `BroadContextlibSuppress` {#e003}
 
-**Tier:** `warn` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 3.16.0
 
 > contextlib.suppress() — check whether scope is too broad
 
@@ -88,7 +88,7 @@ the suppressed exception type before classifying.
 
 ## E004 — `BroadExceptClause` {#e004}
 
-**Tier:** `warn` · **Category:** `overly-broad-catch` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `overly-broad-catch` · **Autofixable:** — · **Since:** 3.16.0
 
 > Overly broad 'except Exception/BaseException' without exc_info
 
@@ -104,7 +104,7 @@ MEDIUM when logged but missing `exc_info=True`.  Acceptable only at top-level ha
 
 ## E005 — `ExceptBlockMissingExcInfo` {#e005}
 
-**Tier:** `warn` · **Category:** `missing-traceback` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `missing-traceback` · **Autofixable:** yes · **Since:** 3.16.0
 
 > except block logs without exc_info=True — stack trace discarded
 
@@ -120,7 +120,7 @@ is exempt (it implies `exc_info=True`).
 
 ## E006 — `BareExceptWithBody` {#e006}
 
-**Tier:** `block` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `block` · **Scope:** `both` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 3.16.0
 
 > Bare 'except:' (no type) — catches SystemExit and KeyboardInterrupt
 
@@ -135,7 +135,7 @@ SystemExit.  Always specify at least `except Exception:`.
 
 ## E007 — `ErrorToReturnValue` {#e007}
 
-**Tier:** `warn` · **Category:** `error-to-return-value` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `error-to-return-value` · **Autofixable:** — · **Since:** 3.16.0
 
 > except block returns a value without logging — error hidden
 
@@ -151,7 +151,7 @@ domain-specific exception instead.
 
 ## E008 — `ImportErrorWithoutLogging` {#e008}
 
-**Tier:** `warn` · **Category:** `optional-import` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `optional-import` · **Autofixable:** — · **Since:** 3.16.0
 
 > except ImportError without logging — environment issues hidden
 
@@ -168,7 +168,7 @@ later with a confusing AttributeError).
 
 ## E009 — `ExceptBlockOnlyAssigns` {#e009}
 
-**Tier:** `warn` · **Category:** `error-to-return-value` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `error-to-return-value` · **Autofixable:** — · **Since:** 3.16.0
 
 > except block only assigns a variable — error hidden with no log
 
@@ -183,7 +183,7 @@ no logging.  Add a `logger.warning(..., exc_info=True)` before the assignment.
 
 ## E010 — `AsyncioGatherExceptionsUnexamined` {#e010}
 
-**Tier:** `warn` · **Category:** `asyncio-unexamined` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `asyncio-unexamined` · **Autofixable:** — · **Since:** 3.16.0
 
 > asyncio.gather(return_exceptions=True) results not checked for exceptions
 
@@ -200,7 +200,7 @@ silently.  The pattern is only a bug when results are not checked;
 
 ## E011 — `LoggingFilterUnsafeBody` {#e011}
 
-**Tier:** `warn` · **Category:** `filter-safety` · **Autofixable:** — · **Since:** 3.17.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `filter-safety` · **Autofixable:** — · **Since:** 3.17.0
 
 > logging.Filter.filter() body not wrapped in try/except — can crash caller
 
@@ -221,7 +221,7 @@ propagate.
 
 ## E012 — `UntypedBuiltinRaise` {#e012}
 
-**Tier:** `warn` · **Category:** `untyped-raise` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `untyped-raise` · **Autofixable:** — · **Since:** 3.16.0
 
 > raise ValueError/RuntimeError/... where a typed AppError applies
 
@@ -239,7 +239,7 @@ require `TypeError`/`ValueError` for stdlib interoperability.
 
 ## E013 — `LegacyAtlanErrorRaise` {#e013}
 
-**Tier:** `block` · **Category:** `legacy-raise` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `block` · **Scope:** `both` · **Category:** `legacy-raise` · **Autofixable:** — · **Since:** 3.16.0
 
 > raise ClientError/ApiError/... (deprecated AtlanError stack)
 
@@ -255,7 +255,7 @@ in v4.0.  Replace with the appropriate leaf from `application_sdk.errors`.
 
 ## E014 — `ExceptLoopControlSwallow` {#e014}
 
-**Tier:** `warn` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 3.17.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `silent-swallow` · **Autofixable:** — · **Since:** 3.17.0
 
 > except block exits loop silently (continue/break) without logging
 
@@ -273,7 +273,7 @@ log at WARNING/ERROR with `exc_info=True`.
 
 ## E015 — `ExceptionTextInErrorMessage` {#e015}
 
-**Tier:** `warn` · **Category:** `error-message-hygiene` · **Autofixable:** — · **Since:** 3.17.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `error-message-hygiene` · **Autofixable:** — · **Since:** 3.17.0
 
 > Caught exception text interpolated into typed error message= — leaks unsanitised text
 
@@ -294,7 +294,7 @@ and keep `message=` a stable human summary.
 
 ## E016 — `MissingExceptionChaining` {#e016}
 
-**Tier:** `warn` · **Category:** `exception-chaining` · **Autofixable:** yes · **Since:** 3.17.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `exception-chaining` · **Autofixable:** yes · **Since:** 3.17.0
 
 > raise inside except block missing 'from exc' cause — breaks exception chain
 
@@ -317,7 +317,7 @@ None` (intentional suppression).
 
 ## E017 — `SecretNamedEvidenceKey` {#e017}
 
-**Tier:** `block` · **Category:** `security` · **Autofixable:** — · **Since:** 3.17.0
+**Tier:** `block` · **Scope:** `both` · **Category:** `security` · **Autofixable:** — · **Since:** 3.17.0
 
 > Error evidence kwarg ending in _secret/_password/_token — rejected by wire layer at runtime
 
@@ -337,7 +337,7 @@ before any code runs.  Rename the evidence field to a safe key (e.g. `credential
 
 ## E018 — `BareParentLeafRaise` {#e018}
 
-**Tier:** `warn` · **Category:** `untyped-raise` · **Autofixable:** — · **Since:** 3.17.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `untyped-raise` · **Autofixable:** — · **Since:** 3.17.0
 
 > Raising a bare AppError leaf class without a domain subclass overriding code
 

--- a/packages/conformance/conformance/docs/rules/logging.md
+++ b/packages/conformance/conformance/docs/rules/logging.md
@@ -13,32 +13,32 @@ Suppress a finding on the violating line or the line directly above it:
 # conformance: ignore[L001] intentional: dynamic message
 ```
 
-| ID | Name | Tier | Category | Autofixable | Since |
-|---|---|---|---|---|---|
-| [L001](#l001) | `FStringInLogMessage` | `block` | `log-format` | yes | 3.16.0 |
-| [L002](#l002) | `InconsistentLoggerFactory` | `warn` | `log-format` | yes | 3.16.0 |
-| [L003](#l003) | `ExtraKwargsWrongFramework` | `warn` | `log-format` | — | 3.16.0 |
-| [L004](#l004) | `ExceptBlockMissingExcInfoLog` | `block` | `missing-traceback` | yes | 3.16.0 |
-| [L005](#l005) | `PrintInProductionCode` | `warn` | `log-format` | yes | 3.16.0 |
-| [L006](#l006) | `InfoInTightLoop` | `warn` | `log-level` | — | 3.16.0 |
-| [L007](#l007) | `LoggerCriticalUsage` | `warn` | `log-level` | yes | 3.16.0 |
-| [L008](#l008) | `UnguardedExpensiveDebug` | `warn` | `log-performance` | — | 3.16.0 |
-| [L009](#l009) | `WarnThenRaiseDuplication` | `warn` | `log-noise` | — | 3.16.0 |
-| [L010](#l010) | `CredentialInLogOutput` | `block` | `security` | — | 3.16.0 |
-| [L011](#l011) | `StringConcatenationInLog` | `block` | `log-format` | yes | 3.16.0 |
-| [L012](#l012) | `StdlibExtraReservedKeyCollision` | `block` | `log-crash` | — | 3.16.0 |
-| [L013](#l013) | `StdlibArbitraryKwargs` | `block` | `log-crash` | yes | 3.16.0 |
-| [L014](#l014) | `StructlogEventKwargOverwrite` | `warn` | `log-format` | — | 3.16.0 |
-| [L015](#l015) | `DictConfigDisableExistingLoggers` | `warn` | `log-config` | yes | 3.16.0 |
-| [L016](#l016) | `BasicConfigNoopAfterFirstCall` | `warn` | `log-config` | — | 3.16.0 |
-| [L017](#l017) | `LoggerExceptionUsage` | `warn` | `log-level` | yes | 3.16.0 |
-| [L018](#l018) | `KwargsInApplicationLogCalls` | `warn` | `log-format` | — | 3.16.0 |
+| ID | Name | Tier | Scope | Category | Autofixable | Since |
+|---|---|---|---|---|---|---|
+| [L001](#l001) | `FStringInLogMessage` | `block` | `both` | `log-format` | yes | 3.16.0 |
+| [L002](#l002) | `InconsistentLoggerFactory` | `warn` | `both` | `log-format` | yes | 3.16.0 |
+| [L003](#l003) | `ExtraKwargsWrongFramework` | `warn` | `both` | `log-format` | — | 3.16.0 |
+| [L004](#l004) | `ExceptBlockMissingExcInfoLog` | `block` | `both` | `missing-traceback` | yes | 3.16.0 |
+| [L005](#l005) | `PrintInProductionCode` | `warn` | `both` | `log-format` | yes | 3.16.0 |
+| [L006](#l006) | `InfoInTightLoop` | `warn` | `both` | `log-level` | — | 3.16.0 |
+| [L007](#l007) | `LoggerCriticalUsage` | `warn` | `both` | `log-level` | yes | 3.16.0 |
+| [L008](#l008) | `UnguardedExpensiveDebug` | `warn` | `both` | `log-performance` | — | 3.16.0 |
+| [L009](#l009) | `WarnThenRaiseDuplication` | `warn` | `both` | `log-noise` | — | 3.16.0 |
+| [L010](#l010) | `CredentialInLogOutput` | `block` | `both` | `security` | — | 3.16.0 |
+| [L011](#l011) | `StringConcatenationInLog` | `block` | `both` | `log-format` | yes | 3.16.0 |
+| [L012](#l012) | `StdlibExtraReservedKeyCollision` | `block` | `both` | `log-crash` | — | 3.16.0 |
+| [L013](#l013) | `StdlibArbitraryKwargs` | `block` | `both` | `log-crash` | yes | 3.16.0 |
+| [L014](#l014) | `StructlogEventKwargOverwrite` | `warn` | `both` | `log-format` | — | 3.16.0 |
+| [L015](#l015) | `DictConfigDisableExistingLoggers` | `warn` | `both` | `log-config` | yes | 3.16.0 |
+| [L016](#l016) | `BasicConfigNoopAfterFirstCall` | `warn` | `both` | `log-config` | — | 3.16.0 |
+| [L017](#l017) | `LoggerExceptionUsage` | `warn` | `both` | `log-level` | yes | 3.16.0 |
+| [L018](#l018) | `KwargsInApplicationLogCalls` | `warn` | `both` | `log-format` | — | 3.16.0 |
 
 ---
 
 ## L001 — `FStringInLogMessage` {#l001}
 
-**Tier:** `block` · **Category:** `log-format` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `block` · **Scope:** `both` · **Category:** `log-format` · **Autofixable:** yes · **Since:** 3.16.0
 
 > f-string in log message — breaks log grouping and aggregation
 
@@ -57,7 +57,7 @@ kwargs.
 
 ## L002 — `InconsistentLoggerFactory` {#l002}
 
-**Tier:** `warn` · **Category:** `log-format` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `log-format` · **Autofixable:** yes · **Since:** 3.16.0
 
 > Logger factory inconsistent with project canonical factory
 
@@ -73,7 +73,7 @@ occurrence count) in Phase 1 and flags deviations.
 
 ## L003 — `ExtraKwargsWrongFramework` {#l003}
 
-**Tier:** `warn` · **Category:** `log-format` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `log-format` · **Autofixable:** — · **Since:** 3.16.0
 
 > extra={} used where framework expects direct kwargs (or vice versa)
 
@@ -90,7 +90,7 @@ detect the active framework first.
 
 ## L004 — `ExceptBlockMissingExcInfoLog` {#l004}
 
-**Tier:** `block` · **Category:** `missing-traceback` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `block` · **Scope:** `both` · **Category:** `missing-traceback` · **Autofixable:** yes · **Since:** 3.16.0
 
 > logger.warning/error in except block without exc_info=True
 
@@ -106,7 +106,7 @@ the root cause is invisible.  Add `exc_info=True` to all `logger.warning()` /
 
 ## L005 — `PrintInProductionCode` {#l005}
 
-**Tier:** `warn` · **Category:** `log-format` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `log-format` · **Autofixable:** yes · **Since:** 3.16.0
 
 > print() in production code — bypasses logging framework
 
@@ -123,7 +123,7 @@ log lines.  Acceptable in CLI scripts, test/debug scripts, and `if __name__ ==
 
 ## L006 — `InfoInTightLoop` {#l006}
 
-**Tier:** `warn` · **Category:** `log-level` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `log-level` · **Autofixable:** — · **Since:** 3.16.0
 
 > logger.info() inside a tight loop — generates excessive log volume
 
@@ -140,7 +140,7 @@ bounded (≤10 items) before flagging.
 
 ## L007 — `LoggerCriticalUsage` {#l007}
 
-**Tier:** `warn` · **Category:** `log-level` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `log-level` · **Autofixable:** yes · **Since:** 3.16.0
 
 > logger.critical() — CRITICAL is not a meaningful level here
 
@@ -157,7 +157,7 @@ on the observability platform.
 
 ## L008 — `UnguardedExpensiveDebug` {#l008}
 
-**Tier:** `warn` · **Category:** `log-performance` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `log-performance` · **Autofixable:** — · **Since:** 3.16.0
 
 > Expensive computation in logger.debug() argument — evaluates eagerly
 
@@ -173,7 +173,7 @@ logger.isEnabledFor(logging.DEBUG):`.
 
 ## L009 — `WarnThenRaiseDuplication` {#l009}
 
-**Tier:** `warn` · **Category:** `log-noise` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `log-noise` · **Autofixable:** — · **Since:** 3.16.0
 
 > logger.warning/error immediately before raise — duplicate log records
 
@@ -189,7 +189,7 @@ available to the caller.  Otherwise: just re-raise.
 
 ## L010 — `CredentialInLogOutput` {#l010}
 
-**Tier:** `block` · **Category:** `security` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `block` · **Scope:** `both` · **Category:** `security` · **Autofixable:** — · **Since:** 3.16.0
 
 > Credential/secret value in log output — security vulnerability
 
@@ -206,7 +206,7 @@ store.  Requires human security review before marking acceptable.  Logging a cre
 
 ## L011 — `StringConcatenationInLog` {#l011}
 
-**Tier:** `block` · **Category:** `log-format` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `block` · **Scope:** `both` · **Category:** `log-format` · **Autofixable:** yes · **Since:** 3.16.0
 
 > String concatenation in log message — breaks log grouping
 
@@ -221,7 +221,7 @@ way that breaks log grouping.  Rewrite as %-style message body.
 
 ## L012 — `StdlibExtraReservedKeyCollision` {#l012}
 
-**Tier:** `block` · **Category:** `log-crash` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `block` · **Scope:** `both` · **Category:** `log-crash` · **Autofixable:** — · **Since:** 3.16.0
 
 > extra={} key collides with stdlib LogRecord attribute — crashes caller
 
@@ -238,7 +238,7 @@ stdlib's `Logger.makeRecord()` raises `KeyError` if any key in `extra={}` matche
 
 ## L013 — `StdlibArbitraryKwargs` {#l013}
 
-**Tier:** `block` · **Category:** `log-crash` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `block` · **Scope:** `both` · **Category:** `log-crash` · **Autofixable:** yes · **Since:** 3.16.0
 
 > Arbitrary kwargs in stdlib logger — raises TypeError immediately
 
@@ -254,7 +254,7 @@ from structlog/loguru. Applies to stdlib only.
 
 ## L014 — `StructlogEventKwargOverwrite` {#l014}
 
-**Tier:** `warn` · **Category:** `log-format` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `log-format` · **Autofixable:** — · **Since:** 3.16.0
 
 > event= kwarg in structlog silently overwrites the log message
 
@@ -271,7 +271,7 @@ only.
 
 ## L015 — `DictConfigDisableExistingLoggers` {#l015}
 
-**Tier:** `warn` · **Category:** `log-config` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `log-config` · **Autofixable:** yes · **Since:** 3.16.0
 
 > dictConfig without disable_existing_loggers=False silently kills loggers
 
@@ -288,7 +288,7 @@ Applies to stdlib only.
 
 ## L016 — `BasicConfigNoopAfterFirstCall` {#l016}
 
-**Tier:** `warn` · **Category:** `log-config` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `log-config` · **Autofixable:** — · **Since:** 3.16.0
 
 > Multiple basicConfig() calls — second+ are silent no-ops
 
@@ -304,7 +304,7 @@ __name__ == "__main__":` blocks. Applies to stdlib only.
 
 ## L017 — `LoggerExceptionUsage` {#l017}
 
-**Tier:** `warn` · **Category:** `log-level` · **Autofixable:** yes · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `log-level` · **Autofixable:** yes · **Since:** 3.16.0
 
 > logger.exception() used — use logger.error(..., exc_info=True) instead
 
@@ -329,7 +329,7 @@ only to satisfy third-party Temporal callers and immediately delegates to
 
 ## L018 — `KwargsInApplicationLogCalls` {#l018}
 
-**Tier:** `warn` · **Category:** `log-format` · **Autofixable:** — · **Since:** 3.16.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `log-format` · **Autofixable:** — · **Since:** 3.16.0
 
 > kwargs in application log calls — use %-style message body instead
 

--- a/packages/conformance/conformance/docs/rules/optimizations.md
+++ b/packages/conformance/conformance/docs/rules/optimizations.md
@@ -21,15 +21,15 @@ the same topic.  When a domain series takes over an area, the rule is retired in
 (kept documented, no longer firing) and the new rule gets a fresh id — the original id
 is never reused or reassigned.
 
-| ID | Name | Tier | Category | Autofixable | Since |
-|---|---|---|---|---|---|
-| [O001](#o001) | `OrjsonOverStdlibJson` | `warn` | `canonical-dependency` | — | 0.3.0 |
+| ID | Name | Tier | Scope | Category | Autofixable | Since |
+|---|---|---|---|---|---|---|
+| [O001](#o001) | `OrjsonOverStdlibJson` | `warn` | `both` | `canonical-dependency` | — | 0.3.0 |
 
 ---
 
 ## O001 — `OrjsonOverStdlibJson` {#o001}
 
-**Tier:** `warn` · **Category:** `canonical-dependency` · **Autofixable:** — · **Since:** 0.3.0
+**Tier:** `warn` · **Scope:** `both` · **Category:** `canonical-dependency` · **Autofixable:** — · **Since:** 0.3.0
 
 > json.dumps()/json.loads() — prefer orjson (a core SDK dependency, ~10x faster)
 

--- a/packages/conformance/conformance/docs/rules/prescriptions.md
+++ b/packages/conformance/conformance/docs/rules/prescriptions.md
@@ -21,17 +21,17 @@ the same topic.  When a domain series takes over an area, the rule is retired in
 (kept documented, no longer firing) and the new rule gets a fresh id — the original id
 is never reused or reassigned.
 
-| ID | Name | Tier | Category | Autofixable | Since |
-|---|---|---|---|---|---|
-| [P001](#p001) | `UnboundedContractFields` | `block` | `contract-payload-safety` | — | 0.3.0 |
-| [P002](#p002) | `CategoryFieldOverride` | `block` | `category-immutability` | — | 0.3.0 |
-| [P003](#p003) | `ErrorCodePrefixMismatch` | `block` | `error-code-shape` | — | 0.3.0 |
+| ID | Name | Tier | Scope | Category | Autofixable | Since |
+|---|---|---|---|---|---|---|
+| [P001](#p001) | `UnboundedContractFields` | `block` | `both` | `contract-payload-safety` | — | 0.3.0 |
+| [P002](#p002) | `CategoryFieldOverride` | `block` | `both` | `category-immutability` | — | 0.3.0 |
+| [P003](#p003) | `ErrorCodePrefixMismatch` | `block` | `both` | `error-code-shape` | — | 0.3.0 |
 
 ---
 
 ## P001 — `UnboundedContractFields` {#p001}
 
-**Tier:** `block` · **Category:** `contract-payload-safety` · **Autofixable:** — · **Since:** 0.3.0
+**Tier:** `block` · **Scope:** `both` · **Category:** `contract-payload-safety` · **Autofixable:** — · **Since:** 0.3.0
 
 > Input/Output contract declared with allow_unbounded_fields=True — opts out of payload safety
 
@@ -56,7 +56,7 @@ sanctioned use is the justified inline suppression above — see BLDX-1428.
 
 ## P002 — `CategoryFieldOverride` {#p002}
 
-**Tier:** `block` · **Category:** `category-immutability` · **Autofixable:** — · **Since:** 0.3.0
+**Tier:** `block` · **Scope:** `both` · **Category:** `category-immutability` · **Autofixable:** — · **Since:** 0.3.0
 
 > AppError subclass redeclares the `category` ClassVar — drifts the canonical taxonomy
 
@@ -87,7 +87,7 @@ sanctioned use is the justified inline suppression `# conformance: ignore[P002]
 
 ## P003 — `ErrorCodePrefixMismatch` {#p003}
 
-**Tier:** `block` · **Category:** `error-code-shape` · **Autofixable:** — · **Since:** 0.3.0
+**Tier:** `block` · **Scope:** `both` · **Category:** `error-code-shape` · **Autofixable:** — · **Since:** 0.3.0
 
 > AppError subclass code missing or doesn't start with the parent leaf's category prefix
 

--- a/packages/conformance/conformance/suite/checks/_ast_common/__init__.py
+++ b/packages/conformance/conformance/suite/checks/_ast_common/__init__.py
@@ -13,12 +13,15 @@ from ._cli import TOOL_VERSION, make_cli_main
 from ._directives import _IgnoreDirective, _parse_directives, parse_ignore_directive
 from ._discovery import EXCLUDE_DIRS, discover
 from ._findings import make_finding
+from ._scope import SDK_PACKAGE_PREFIX, detect_scope
 
 __all__ = [
     "EXCLUDE_DIRS",
+    "SDK_PACKAGE_PREFIX",
     "TOOL_VERSION",
     "_IgnoreDirective",
     "_parse_directives",
+    "detect_scope",
     "discover",
     "make_cli_main",
     "make_finding",

--- a/packages/conformance/conformance/suite/checks/_ast_common/__init__.py
+++ b/packages/conformance/conformance/suite/checks/_ast_common/__init__.py
@@ -13,7 +13,7 @@ from ._cli import TOOL_VERSION, make_cli_main
 from ._directives import _IgnoreDirective, _parse_directives, parse_ignore_directive
 from ._discovery import EXCLUDE_DIRS, discover
 from ._findings import make_finding
-from ._scope import SDK_PACKAGE_PREFIX, detect_scope
+from ._scope import SDK_PACKAGE_PREFIX, detect_scope, is_sdk_package_name
 
 __all__ = [
     "EXCLUDE_DIRS",
@@ -23,6 +23,7 @@ __all__ = [
     "_parse_directives",
     "detect_scope",
     "discover",
+    "is_sdk_package_name",
     "make_cli_main",
     "make_finding",
     "parse_ignore_directive",

--- a/packages/conformance/conformance/suite/checks/_ast_common/_scope.py
+++ b/packages/conformance/conformance/suite/checks/_ast_common/_scope.py
@@ -69,6 +69,11 @@ def detect_scope(root: Path) -> RuleScope | None:
     name = _project_name(text)
     if name is None:
         return None
-    if _normalise_name(name).startswith(_normalise_name(SDK_PACKAGE_PREFIX)):
+    norm = _normalise_name(name)
+    prefix = _normalise_name(SDK_PACKAGE_PREFIX)
+    # Hyphen-anchored so the prefix matches the SDK itself and its sibling
+    # packages (``atlan-application-sdk-conformance``) but not an unrelated name
+    # that merely shares the prefix as a substring (``atlan-application-sdk2``).
+    if norm == prefix or norm.startswith(prefix + "-"):
         return RuleScope.SDK
     return RuleScope.APP

--- a/packages/conformance/conformance/suite/checks/_ast_common/_scope.py
+++ b/packages/conformance/conformance/suite/checks/_ast_common/_scope.py
@@ -49,14 +49,32 @@ def _project_name(pyproject_text: str) -> str | None:
     return str(name) if isinstance(name, str) else None
 
 
+def is_sdk_package_name(name: str) -> bool:
+    """True if *name* is the SDK distribution or a hyphen-extended sibling.
+
+    Hyphen-anchored (after PEP 503 normalisation): matches
+    ``atlan-application-sdk`` exactly and siblings like
+    ``atlan-application-sdk-conformance``, but **not** a substring lookalike such
+    as ``atlan-application-sdk2``.
+
+    This is the single source of truth for "is this the SDK?" — both
+    ``detect_scope`` (runner-side scope detection) and
+    ``dependency_conformance._is_self_check`` (the D-series self-exemption) call
+    it, so the two cannot drift apart on matching semantics.
+    """
+    norm = _normalise_name(name)
+    prefix = _normalise_name(SDK_PACKAGE_PREFIX)
+    return norm == prefix or norm.startswith(prefix + "-")
+
+
 def detect_scope(root: Path) -> RuleScope | None:
     """Resolve the active :class:`RuleScope` for the repo rooted at *root*.
 
     Reads ``<root>/pyproject.toml`` and classifies by ``[project].name``:
 
-    * name starts with ``atlan-application-sdk`` → :attr:`RuleScope.SDK`
-    * any other name                            → :attr:`RuleScope.APP`
-    * no/unparseable pyproject, or no name      → ``None`` (scope unknown)
+    * SDK / sibling package (see :func:`is_sdk_package_name`) → :attr:`RuleScope.SDK`
+    * any other name                                          → :attr:`RuleScope.APP`
+    * no/unparseable pyproject, or no name                    → ``None`` (scope unknown)
 
     ``None`` means "do not filter" — the runner runs every rule, preserving the
     behaviour from before scope existed.
@@ -69,11 +87,4 @@ def detect_scope(root: Path) -> RuleScope | None:
     name = _project_name(text)
     if name is None:
         return None
-    norm = _normalise_name(name)
-    prefix = _normalise_name(SDK_PACKAGE_PREFIX)
-    # Hyphen-anchored so the prefix matches the SDK itself and its sibling
-    # packages (``atlan-application-sdk-conformance``) but not an unrelated name
-    # that merely shares the prefix as a substring (``atlan-application-sdk2``).
-    if norm == prefix or norm.startswith(prefix + "-"):
-        return RuleScope.SDK
-    return RuleScope.APP
+    return RuleScope.SDK if is_sdk_package_name(name) else RuleScope.APP

--- a/packages/conformance/conformance/suite/checks/_ast_common/_scope.py
+++ b/packages/conformance/conformance/suite/checks/_ast_common/_scope.py
@@ -1,0 +1,74 @@
+"""Runtime scope detection — is this repo the SDK or a consumer app?
+
+The conformance suite runs against two kinds of repo, and some rules only apply
+to one of them (see :class:`~conformance.suite.schema.disposition.RuleScope`).
+This module answers "which kind am I scanning?" so the runner can filter rules
+to the surface they govern *without* the fleet having to configure anything: the
+signal is the repo's own ``[project].name``.
+
+This generalises into one mechanism what the D-series detector did inline (its
+``_is_self_check`` package-name skip): the SDK and its sibling packages publish
+the contracts that the APP-scoped rules enforce, so they are never subject to
+them.
+
+Detection is deliberately best-effort: a repo with no parseable
+``pyproject.toml`` / no ``[project].name`` yields ``None``, which the runner
+treats as "scope unknown — run every rule" (the pre-feature behaviour).  An
+explicit ``--scope`` flag always overrides detection.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+from conformance.suite.schema.disposition import RuleScope
+
+# Distribution-name prefix that identifies the SDK and its sibling packages
+# (``atlan-application-sdk``, ``atlan-application-sdk-conformance``, …).  Kept in
+# sync with ``checks.dependency_conformance.SDK_PACKAGE``.
+SDK_PACKAGE_PREFIX = "atlan-application-sdk"
+
+
+def _normalise_name(name: str) -> str:
+    """PEP 503 normalisation: lowercase + ``-``/``_``/``.`` collapsed to ``-``."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _project_name(pyproject_text: str) -> str | None:
+    """Return ``[project].name`` from a pyproject.toml string, else ``None``."""
+    try:
+        data = tomllib.loads(pyproject_text)
+    except tomllib.TOMLDecodeError:
+        return None
+    project = data.get("project") if isinstance(data, dict) else None
+    if not isinstance(project, dict):
+        return None
+    name = project.get("name")
+    return str(name) if isinstance(name, str) else None
+
+
+def detect_scope(root: Path) -> RuleScope | None:
+    """Resolve the active :class:`RuleScope` for the repo rooted at *root*.
+
+    Reads ``<root>/pyproject.toml`` and classifies by ``[project].name``:
+
+    * name starts with ``atlan-application-sdk`` → :attr:`RuleScope.SDK`
+    * any other name                            → :attr:`RuleScope.APP`
+    * no/unparseable pyproject, or no name      → ``None`` (scope unknown)
+
+    ``None`` means "do not filter" — the runner runs every rule, preserving the
+    behaviour from before scope existed.
+    """
+    pyproject = root / "pyproject.toml"
+    try:
+        text = pyproject.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    name = _project_name(text)
+    if name is None:
+        return None
+    if _normalise_name(name).startswith(_normalise_name(SDK_PACKAGE_PREFIX)):
+        return RuleScope.SDK
+    return RuleScope.APP

--- a/packages/conformance/conformance/suite/checks/dependency_conformance.py
+++ b/packages/conformance/conformance/suite/checks/dependency_conformance.py
@@ -26,7 +26,7 @@ from importlib import metadata as importlib_metadata
 from pathlib import Path
 from typing import Any
 
-from conformance.suite.checks._ast_common import make_cli_main
+from conformance.suite.checks._ast_common import is_sdk_package_name, make_cli_main
 from conformance.suite.schema.findings import Finding
 
 SERIES = "D"
@@ -423,10 +423,13 @@ def _project_name(text: str) -> str | None:
 
 
 def _is_self_check(name: str | None) -> bool:
-    """Return True for the SDK and its sibling packages (exempt from D-series)."""
-    if name is None:
-        return False
-    return _normalise_name(name).startswith(_normalise_name(SDK_PACKAGE))
+    """Return True for the SDK and its sibling packages (exempt from D-series).
+
+    Delegates to the shared ``is_sdk_package_name`` so this self-exemption and the
+    runner-side ``detect_scope`` answer "is this the SDK?" with identical
+    (hyphen-anchored) semantics — see ``_ast_common._scope``.
+    """
+    return name is not None and is_sdk_package_name(name)
 
 
 def scan_text(

--- a/packages/conformance/conformance/suite/rules/ci.py
+++ b/packages/conformance/conformance/suite/rules/ci.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 from conformance.suite.schema.catalog import RuleDefinition
-from conformance.suite.schema.disposition import EnforcementTier, RuleMechanism
+from conformance.suite.schema.disposition import (
+    EnforcementTier,
+    RuleMechanism,
+    RuleScope,
+)
 
 RULES: tuple[RuleDefinition, ...] = (
     RuleDefinition(
         id="C001",
+        scope=RuleScope.BOTH,
         name="UnpinnedActionReference",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,
@@ -32,6 +37,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="C002",
+        scope=RuleScope.APP,
         name="BootstrapWorkflowDrift",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -57,6 +63,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="C003",
+        scope=RuleScope.APP,
         name="GitignoreMissingEntry",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,

--- a/packages/conformance/conformance/suite/rules/ci.py
+++ b/packages/conformance/conformance/suite/rules/ci.py
@@ -63,7 +63,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="C003",
-        scope=RuleScope.APP,
+        scope=RuleScope.BOTH,
         name="GitignoreMissingEntry",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,

--- a/packages/conformance/conformance/suite/rules/dependency.py
+++ b/packages/conformance/conformance/suite/rules/dependency.py
@@ -15,11 +15,16 @@ SDK upgrades.  These rules enforce two invariants:
 from __future__ import annotations
 
 from conformance.suite.schema.catalog import RuleDefinition
-from conformance.suite.schema.disposition import EnforcementTier, RuleMechanism
+from conformance.suite.schema.disposition import (
+    EnforcementTier,
+    RuleMechanism,
+    RuleScope,
+)
 
 RULES: tuple[RuleDefinition, ...] = (
     RuleDefinition(
         id="D001",
+        scope=RuleScope.APP,
         name="UnpinnedSdkDependency",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,
@@ -53,6 +58,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="D002",
+        scope=RuleScope.APP,
         name="RedeclaredSdkManagedDependency",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,

--- a/packages/conformance/conformance/suite/rules/error_handling.py
+++ b/packages/conformance/conformance/suite/rules/error_handling.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 from conformance.suite.schema.catalog import RuleDefinition
-from conformance.suite.schema.disposition import EnforcementTier, RuleMechanism
+from conformance.suite.schema.disposition import (
+    EnforcementTier,
+    RuleMechanism,
+    RuleScope,
+)
 
 RULES: tuple[RuleDefinition, ...] = (
     RuleDefinition(
         id="E001",
+        scope=RuleScope.BOTH,
         name="BareExceptPass",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,
@@ -32,6 +37,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="E002",
+        scope=RuleScope.BOTH,
         name="TypedExceptPass",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,
@@ -55,6 +61,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="E003",
+        scope=RuleScope.BOTH,
         name="BroadContextlibSuppress",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -78,6 +85,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="E004",
+        scope=RuleScope.BOTH,
         name="BroadExceptClause",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -101,6 +109,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="E005",
+        scope=RuleScope.BOTH,
         name="ExceptBlockMissingExcInfo",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -123,6 +132,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="E006",
+        scope=RuleScope.BOTH,
         name="BareExceptWithBody",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,
@@ -144,6 +154,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="E007",
+        scope=RuleScope.BOTH,
         name="ErrorToReturnValue",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -166,6 +177,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="E008",
+        scope=RuleScope.BOTH,
         name="ImportErrorWithoutLogging",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -189,6 +201,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="E009",
+        scope=RuleScope.BOTH,
         name="ExceptBlockOnlyAssigns",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -212,6 +225,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="E010",
+        scope=RuleScope.BOTH,
         name="AsyncioGatherExceptionsUnexamined",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -236,6 +250,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="E011",
+        scope=RuleScope.BOTH,
         name="LoggingFilterUnsafeBody",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -264,6 +279,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="E012",
+        scope=RuleScope.BOTH,
         name="UntypedBuiltinRaise",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -290,6 +306,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="E013",
+        scope=RuleScope.BOTH,
         name="LegacyAtlanErrorRaise",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,
@@ -313,6 +330,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="E014",
+        scope=RuleScope.BOTH,
         name="ExceptLoopControlSwallow",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -339,6 +357,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="E015",
+        scope=RuleScope.BOTH,
         name="ExceptionTextInErrorMessage",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -368,6 +387,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="E016",
+        scope=RuleScope.BOTH,
         name="MissingExceptionChaining",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -398,6 +418,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="E017",
+        scope=RuleScope.BOTH,
         name="SecretNamedEvidenceKey",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,
@@ -425,6 +446,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="E018",
+        scope=RuleScope.BOTH,
         name="BareParentLeafRaise",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,

--- a/packages/conformance/conformance/suite/rules/logging.py
+++ b/packages/conformance/conformance/suite/rules/logging.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 from conformance.suite.schema.catalog import RuleDefinition
-from conformance.suite.schema.disposition import EnforcementTier, RuleMechanism
+from conformance.suite.schema.disposition import (
+    EnforcementTier,
+    RuleMechanism,
+    RuleScope,
+)
 
 RULES: tuple[RuleDefinition, ...] = (
     RuleDefinition(
         id="L001",
+        scope=RuleScope.BOTH,
         name="FStringInLogMessage",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,
@@ -34,6 +39,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="L002",
+        scope=RuleScope.BOTH,
         name="InconsistentLoggerFactory",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -55,6 +61,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="L003",
+        scope=RuleScope.BOTH,
         name="ExtraKwargsWrongFramework",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -77,6 +84,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="L004",
+        scope=RuleScope.BOTH,
         name="ExceptBlockMissingExcInfoLog",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,
@@ -100,6 +108,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="L005",
+        scope=RuleScope.BOTH,
         name="PrintInProductionCode",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -122,6 +131,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="L006",
+        scope=RuleScope.BOTH,
         name="InfoInTightLoop",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -145,6 +155,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="L007",
+        scope=RuleScope.BOTH,
         name="LoggerCriticalUsage",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -168,6 +179,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="L008",
+        scope=RuleScope.BOTH,
         name="UnguardedExpensiveDebug",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -189,6 +201,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="L009",
+        scope=RuleScope.BOTH,
         name="WarnThenRaiseDuplication",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -210,6 +223,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="L010",
+        scope=RuleScope.BOTH,
         name="CredentialInLogOutput",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,
@@ -234,6 +248,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="L011",
+        scope=RuleScope.BOTH,
         name="StringConcatenationInLog",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,
@@ -254,6 +269,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="L012",
+        scope=RuleScope.BOTH,
         name="StdlibExtraReservedKeyCollision",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,
@@ -278,6 +294,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="L013",
+        scope=RuleScope.BOTH,
         name="StdlibArbitraryKwargs",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,
@@ -300,6 +317,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="L014",
+        scope=RuleScope.BOTH,
         name="StructlogEventKwargOverwrite",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -322,6 +340,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="L015",
+        scope=RuleScope.BOTH,
         name="DictConfigDisableExistingLoggers",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -345,6 +364,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="L016",
+        scope=RuleScope.BOTH,
         name="BasicConfigNoopAfterFirstCall",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -368,6 +388,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="L017",
+        scope=RuleScope.BOTH,
         name="LoggerExceptionUsage",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
@@ -398,6 +419,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="L018",
+        scope=RuleScope.BOTH,
         name="KwargsInApplicationLogCalls",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,

--- a/packages/conformance/conformance/suite/rules/optimizations.py
+++ b/packages/conformance/conformance/suite/rules/optimizations.py
@@ -9,11 +9,16 @@ earns mandatory status graduates into a category series or the P-series.
 from __future__ import annotations
 
 from conformance.suite.schema.catalog import RuleDefinition
-from conformance.suite.schema.disposition import EnforcementTier, RuleMechanism
+from conformance.suite.schema.disposition import (
+    EnforcementTier,
+    RuleMechanism,
+    RuleScope,
+)
 
 RULES: tuple[RuleDefinition, ...] = (
     RuleDefinition(
         id="O001",
+        scope=RuleScope.BOTH,
         name="OrjsonOverStdlibJson",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,

--- a/packages/conformance/conformance/suite/rules/prescriptions.py
+++ b/packages/conformance/conformance/suite/rules/prescriptions.py
@@ -19,11 +19,16 @@ reassigned.  The same policy applies to O-ids.
 from __future__ import annotations
 
 from conformance.suite.schema.catalog import RuleDefinition
-from conformance.suite.schema.disposition import EnforcementTier, RuleMechanism
+from conformance.suite.schema.disposition import (
+    EnforcementTier,
+    RuleMechanism,
+    RuleScope,
+)
 
 RULES: tuple[RuleDefinition, ...] = (
     RuleDefinition(
         id="P001",
+        scope=RuleScope.BOTH,
         name="UnboundedContractFields",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,
@@ -57,6 +62,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="P002",
+        scope=RuleScope.BOTH,
         name="CategoryFieldOverride",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,
@@ -98,6 +104,7 @@ RULES: tuple[RuleDefinition, ...] = (
     ),
     RuleDefinition(
         id="P003",
+        scope=RuleScope.BOTH,
         name="ErrorCodePrefixMismatch",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,

--- a/packages/conformance/conformance/suite/runner.py
+++ b/packages/conformance/conformance/suite/runner.py
@@ -118,7 +118,7 @@ def _series_in_scope(series: str, active: RuleScope | None) -> bool:
 
     Used to skip a whole check's discovery+scan when none of its series' rules
     could ever produce an in-scope finding (e.g. the all-APP D-series on the SDK).
-    Series that mix scopes (C001 is ``both`` while C002/C003 are ``app``) stay
+    Series that mix scopes (C001/C003 are ``both`` while C002 is ``app``) stay
     active and rely on the post-scan finding filter for correctness.
     """
     return any(

--- a/packages/conformance/conformance/suite/runner.py
+++ b/packages/conformance/conformance/suite/runner.py
@@ -31,9 +31,9 @@ from conformance.suite.checks import (
     optimizations,
     prescriptions,
 )
-from conformance.suite.checks._ast_common import TOOL_VERSION
-from conformance.suite.rules import assert_registry_consistent, get_rule
-from conformance.suite.schema.disposition import EnforcementTier
+from conformance.suite.checks._ast_common import TOOL_VERSION, detect_scope
+from conformance.suite.rules import CATALOG, assert_registry_consistent, get_rule
+from conformance.suite.schema.disposition import EnforcementTier, RuleScope
 from conformance.suite.schema.findings import Finding, findings_to_report
 
 
@@ -101,6 +101,31 @@ assert_registry_consistent(check_series=frozenset(c.series for c in _CHECKS))
 
 def _tier(f: Finding) -> EnforcementTier:
     return get_rule(f.rule_id).tier
+
+
+def _rule_in_scope(rule_scope: RuleScope, active: RuleScope | None) -> bool:
+    """True if a rule with ``rule_scope`` applies under the ``active`` scope.
+
+    ``active`` is ``None`` when the scope could not be determined and ``--scope``
+    was not given — in that case every rule is in scope (the pre-feature
+    behaviour).  Otherwise a rule applies iff its scope is ``BOTH`` or matches.
+    """
+    return active is None or rule_scope == RuleScope.BOTH or rule_scope == active
+
+
+def _series_in_scope(series: str, active: RuleScope | None) -> bool:
+    """True if *any* rule in ``series`` is in scope under ``active``.
+
+    Used to skip a whole check's discovery+scan when none of its series' rules
+    could ever produce an in-scope finding (e.g. the all-APP D-series on the SDK).
+    Series that mix scopes (C001 is ``both`` while C002/C003 are ``app``) stay
+    active and rely on the post-scan finding filter for correctness.
+    """
+    return any(
+        _rule_in_scope(rule.scope, active)
+        for rule in CATALOG.values()
+        if rule.id[0] == series
+    )
 
 
 def _print_human_summary(
@@ -240,6 +265,17 @@ def main(argv: list[str] | None = None) -> int:
             "it works uniformly across every registered series."
         ),
     )
+    parser.add_argument(
+        "--scope",
+        choices=[RuleScope.SDK.value, RuleScope.APP.value],
+        default=None,
+        help=(
+            "Restrict to rules that apply to this consumer surface ('sdk' or "
+            "'app'); 'both'-scoped rules always run.  Default: auto-detected from "
+            "the repo's [project].name (atlan-application-sdk* -> sdk, else app); "
+            "if undetectable, every rule runs."
+        ),
+    )
     args = parser.parse_args(argv)
 
     if args.series:
@@ -257,8 +293,17 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     root = Path(args.repo).resolve()
+
+    # Resolve the active scope: an explicit --scope wins; otherwise auto-detect
+    # from the repo under scan.  ``None`` means "scope unknown — run everything".
+    active_scope = RuleScope(args.scope) if args.scope else detect_scope(root)
+
     all_findings: list[Finding] = []
     for check in active:
+        # Skip a whole check when none of its series' rules could be in scope
+        # (e.g. the all-APP D-series when scanning the SDK itself).
+        if not _series_in_scope(check.series, active_scope):
+            continue
         paths: list[Path] = []
         for p in check.discover(root):
             if excluded_prefixes:
@@ -274,6 +319,16 @@ def main(argv: list[str] | None = None) -> int:
         else:
             for p in paths:
                 all_findings.extend(check.scan_path(p, root))
+
+    # Drop findings for rules outside the active scope.  This is the
+    # finding-level counterpart to the series-level skip above: it covers
+    # mixed-scope series (e.g. C, where C001 is 'both' but C002/C003 are 'app')
+    # so the SARIF report, counts, and exit code reflect only in-scope rules.
+    all_findings = [
+        f
+        for f in all_findings
+        if _rule_in_scope(get_rule(f.rule_id).scope, active_scope)
+    ]
 
     # Always surface violations in a human-readable form so CI logs are actionable.
     _print_human_summary(all_findings, args.series, excluded_prefixes)

--- a/packages/conformance/conformance/suite/schema/catalog.py
+++ b/packages/conformance/conformance/suite/schema/catalog.py
@@ -18,7 +18,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from conformance.suite.schema.disposition import EnforcementTier, RuleMechanism
+from conformance.suite.schema.disposition import (
+    EnforcementTier,
+    RuleMechanism,
+    RuleScope,
+)
 from pydantic import BaseModel, Field, model_validator
 
 # ---------------------------------------------------------------------------
@@ -44,6 +48,11 @@ class RuleDefinition(BaseModel):
 
     mechanism: RuleMechanism
     """``static`` or ``test``."""
+
+    scope: RuleScope
+    """Where the rule applies — ``sdk``, ``app``, or ``both``.  Required (no
+    default) so every rule must declare its surface explicitly; the meta-test
+    ``test_catalog_all_have_scope`` enforces this for present and future rules."""
 
     category: str
     """Rule family, e.g. ``"silent-swallow"``."""
@@ -71,6 +80,8 @@ class RuleDefinition(BaseModel):
                 data["tier"] = EnforcementTier(data["tier"].lower())
             if "mechanism" in data and isinstance(data["mechanism"], str):
                 data["mechanism"] = RuleMechanism(data["mechanism"].lower())
+            if "scope" in data and isinstance(data["scope"], str):
+                data["scope"] = RuleScope(data["scope"].lower())
         return data
 
     def to_reporting_descriptor(self) -> ReportingDescriptor:  # type: ignore[name-defined]  # noqa: F821
@@ -84,6 +95,7 @@ class RuleDefinition(BaseModel):
         rule_props = AtlanRuleProperties(
             tier=self.tier,
             mechanism=self.mechanism,
+            scope=self.scope,
             category=self.category,
             autofixable=self.autofixable,
             orthogonal_gate=self.orthogonal_gate,

--- a/packages/conformance/conformance/suite/schema/disposition.py
+++ b/packages/conformance/conformance/suite/schema/disposition.py
@@ -68,6 +68,31 @@ class RuleMechanism(str, Enum):
     TEST = "test"
 
 
+class RuleScope(str, Enum):
+    """Where a rule applies — the consumer surface it governs.
+
+    The conformance suite runs against two kinds of repo: the SDK itself and the
+    consumer apps built on it.  Most rules apply to any Python in the fleet, but
+    some are inherently one-sided:
+
+    * ``SDK``  — only meaningful inside ``atlan-application-sdk`` (and its sibling
+      packages); skipped on consumer apps.
+    * ``APP``  — only meaningful on a consumer app; skipped on the SDK itself.
+      Example: dependency-pinning (D001/D002) and bootstrap-shim drift (C002/C003),
+      where the SDK is the *publisher* of the contract, not a subject of it.
+    * ``BOTH`` — applies everywhere (the default posture for code-quality rules
+      like error-handling, logging, prescriptions, optimisations).
+
+    The active scope is resolved at runtime from the repo under scan (see
+    ``checks._ast_common.detect_scope``) or set explicitly via ``--scope``; a rule
+    is in scope iff its scope is ``BOTH`` or equals the active scope.
+    """
+
+    SDK = "sdk"
+    APP = "app"
+    BOTH = "both"
+
+
 # ---------------------------------------------------------------------------
 # Disposition
 # ---------------------------------------------------------------------------

--- a/packages/conformance/conformance/suite/schema/disposition.py
+++ b/packages/conformance/conformance/suite/schema/disposition.py
@@ -78,7 +78,7 @@ class RuleScope(str, Enum):
     * ``SDK``  — only meaningful inside ``atlan-application-sdk`` (and its sibling
       packages); skipped on consumer apps.
     * ``APP``  — only meaningful on a consumer app; skipped on the SDK itself.
-      Example: dependency-pinning (D001/D002) and bootstrap-shim drift (C002/C003),
+      Example: dependency-pinning (D001/D002) and bootstrap-workflow drift (C002),
       where the SDK is the *publisher* of the contract, not a subject of it.
     * ``BOTH`` — applies everywhere (the default posture for code-quality rules
       like error-handling, logging, prescriptions, optimisations).

--- a/packages/conformance/conformance/suite/schema/extensions.py
+++ b/packages/conformance/conformance/suite/schema/extensions.py
@@ -20,7 +20,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from conformance.suite.schema.disposition import EnforcementTier, RuleMechanism
+from conformance.suite.schema.disposition import (
+    EnforcementTier,
+    RuleMechanism,
+    RuleScope,
+)
 from pydantic import BaseModel
 
 # ---------------------------------------------------------------------------
@@ -40,6 +44,13 @@ class AtlanRuleProperties(BaseModel):
     mechanism: RuleMechanism
     """``static`` (AST/regex, fast) or ``test`` (execution-required, slow).
     Lets the remediation loop re-run only the narrowest gate covering a fix.
+    """
+
+    scope: RuleScope = RuleScope.BOTH
+    """``sdk``, ``app``, or ``both`` — the consumer surface the rule governs.
+    Defaulted at the SARIF-projection layer so reading an older or hand-authored
+    report that predates the field is tolerant; the authoring layer
+    (``catalog.RuleDefinition.scope``) is where the field is required.
     """
 
     category: str
@@ -69,6 +80,7 @@ class AtlanRuleProperties(BaseModel):
         out: dict[str, Any] = {
             "atlan/tier": self.tier.value,
             "atlan/mechanism": self.mechanism.value,
+            "atlan/scope": self.scope.value,
             "atlan/category": self.category,
             "atlan/autofixable": self.autofixable,
         }
@@ -86,6 +98,7 @@ class AtlanRuleProperties(BaseModel):
         return cls(
             tier=EnforcementTier(props["atlan/tier"]),
             mechanism=RuleMechanism(props["atlan/mechanism"]),
+            scope=RuleScope(props.get("atlan/scope", RuleScope.BOTH.value)),
             category=props["atlan/category"],
             autofixable=bool(props.get("atlan/autofixable", False)),
             orthogonal_gate=props.get("atlan/orthogonalGate"),

--- a/packages/conformance/conformance/tools/generate_rule_docs.py
+++ b/packages/conformance/conformance/tools/generate_rule_docs.py
@@ -198,14 +198,15 @@ def _render_series(meta: SeriesMeta, rules: list[RuleDefinition]) -> str:
         lines.append("")
 
     # Summary table
-    lines.append("| ID | Name | Tier | Category | Autofixable | Since |")
-    lines.append("|---|---|---|---|---|---|")
+    lines.append("| ID | Name | Tier | Scope | Category | Autofixable | Since |")
+    lines.append("|---|---|---|---|---|---|---|")
     for rule in rules:
         anchor = _rule_anchor(rule)
         since = rule.since or "—"
         lines.append(
             f"| [{rule.id}](#{anchor}) | `{rule.name}` | {_tier_badge(rule.tier)}"
-            f" | `{rule.category}` | {_bool_icon(rule.autofixable)} | {since} |"
+            f" | `{rule.scope.value}` | `{rule.category}`"
+            f" | {_bool_icon(rule.autofixable)} | {since} |"
         )
     lines.append("")
     lines.append("---")
@@ -223,6 +224,7 @@ def _render_series(meta: SeriesMeta, rules: list[RuleDefinition]) -> str:
         # Metadata row
         lines.append(
             f"**Tier:** {_tier_badge(rule.tier)} · "
+            f"**Scope:** `{rule.scope.value}` · "
             f"**Category:** `{rule.category}` · "
             f"**Autofixable:** {autofixable} · "
             f"**Since:** {since}"

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -8,7 +8,11 @@ import pytest
 from conformance.suite.rules import CATALOG, _combine_rules, get_rule
 from conformance.suite.schema import load_catalog
 from conformance.suite.schema.catalog import RuleDefinition, validate_catalog
-from conformance.suite.schema.disposition import EnforcementTier, RuleMechanism
+from conformance.suite.schema.disposition import (
+    EnforcementTier,
+    RuleMechanism,
+    RuleScope,
+)
 from pydantic import ValidationError
 
 
@@ -57,6 +61,53 @@ def test_catalog_all_have_rationale() -> None:
     assert (
         not missing
     ), f"Rules missing rationale (add a rationale= to each RuleDefinition): {missing}"
+
+
+def test_catalog_all_have_scope() -> None:
+    """Every rule must declare a valid RuleScope (sdk / app / both)."""
+    rules = load_catalog()
+    bad = [rule.id for rule in rules if not isinstance(rule.scope, RuleScope)]
+    assert not bad, f"Rules with invalid/missing scope: {bad}"
+
+
+def test_scope_is_required_field() -> None:
+    """``scope`` has no default: constructing a rule without it must fail.
+
+    This is what makes ``test_catalog_all_have_scope`` an enforceable guarantee
+    — a new rule that forgets ``scope=`` cannot even be constructed.
+    """
+    with pytest.raises(ValidationError):
+        RuleDefinition(  # pyright: ignore[reportCallIssue]  # scope deliberately omitted
+            id="E999",
+            name="NoScope",
+            tier=EnforcementTier.WARN,
+            mechanism=RuleMechanism.STATIC,
+            category="test",
+        )
+
+
+def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
+    """The publisher-side rules are app-scoped; everything else is 'both'.
+
+    APP-scoped rules (dependency pinning, bootstrap-shim drift) must never fire
+    on the SDK itself, which publishes the contract.  Pin the exact set so a new
+    rule has to make a deliberate scope decision rather than silently inheriting.
+    """
+    rules = load_catalog()
+    app_scoped = {r.id for r in rules if r.scope == RuleScope.APP}
+    assert app_scoped == {"C002", "C003", "D001", "D002"}, app_scoped
+    # No rule is currently SDK-only; the rest are 'both'.
+    assert not {r.id for r in rules if r.scope == RuleScope.SDK}
+    both = {r.id for r in rules if r.scope == RuleScope.BOTH}
+    assert both == {r.id for r in rules} - app_scoped
+
+
+def test_scope_emitted_in_sarif_properties() -> None:
+    """The rule's scope is surfaced as ``atlan/scope`` in SARIF properties."""
+    descriptor = get_rule("D001").to_reporting_descriptor()
+    assert descriptor.properties["atlan/scope"] == "app"
+    descriptor = get_rule("E001").to_reporting_descriptor()
+    assert descriptor.properties["atlan/scope"] == "both"
 
 
 def test_catalog_e_series_present() -> None:
@@ -216,6 +267,7 @@ def test_duplicate_id_raises() -> None:
         name="R1",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,
+        scope=RuleScope.BOTH,
         category="test",
     )
     r2 = RuleDefinition(
@@ -223,6 +275,7 @@ def test_duplicate_id_raises() -> None:
         name="R2",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
+        scope=RuleScope.BOTH,
         category="test",
     )
     with pytest.raises(ValueError, match="duplicate rule ID"):
@@ -237,6 +290,7 @@ def test_invalid_rule_id_raises() -> None:
             name="BadRule",
             tier=EnforcementTier.BLOCK,
             mechanism=RuleMechanism.STATIC,
+            scope=RuleScope.BOTH,
             category="test",
         )
 
@@ -248,6 +302,7 @@ def test_validate_catalog_raises_on_duplicate() -> None:
         name="R1",
         tier=EnforcementTier.BLOCK,
         mechanism=RuleMechanism.STATIC,
+        scope=RuleScope.BOTH,
         category="test",
     )
     r2 = RuleDefinition(
@@ -255,6 +310,7 @@ def test_validate_catalog_raises_on_duplicate() -> None:
         name="R2",
         tier=EnforcementTier.WARN,
         mechanism=RuleMechanism.STATIC,
+        scope=RuleScope.BOTH,
         category="test",
     )
     with pytest.raises(ValueError, match="duplicate rule ID"):

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -89,13 +89,17 @@ def test_scope_is_required_field() -> None:
 def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
     """The publisher-side rules are app-scoped; everything else is 'both'.
 
-    APP-scoped rules (dependency pinning, bootstrap-shim drift) must never fire
+    APP-scoped rules (dependency pinning, managed-workflow drift) must never fire
     on the SDK itself, which publishes the contract.  Pin the exact set so a new
     rule has to make a deliberate scope decision rather than silently inheriting.
+
+    Note C003 (.gitignore entries) is *both*, not app: the SDK has its own
+    .gitignore sharing the standard baseline, so the rule is useful there too —
+    only C002 (bootstrap workflow drift) is genuinely 0%-applicable to the SDK.
     """
     rules = load_catalog()
     app_scoped = {r.id for r in rules if r.scope == RuleScope.APP}
-    assert app_scoped == {"C002", "C003", "D001", "D002"}, app_scoped
+    assert app_scoped == {"C002", "D001", "D002"}, app_scoped
     # No rule is currently SDK-only; the rest are 'both'.
     assert not {r.id for r in rules if r.scope == RuleScope.SDK}
     both = {r.id for r in rules if r.scope == RuleScope.BOTH}

--- a/packages/conformance/tests/test_scope.py
+++ b/packages/conformance/tests/test_scope.py
@@ -1,0 +1,153 @@
+"""Tests for rule scope: runtime detection + runner filtering.
+
+Covers:
+- ``detect_scope`` classifying a repo as SDK / app / unknown from pyproject.
+- The runner skipping an all-APP series (D) when scope is SDK.
+- The runner honouring an explicit ``--scope`` over auto-detection.
+- ``--scope app`` surfacing app-scoped findings (D001) on a consumer app.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from conformance.suite.checks._ast_common import detect_scope
+from conformance.suite.runner import _rule_in_scope, _series_in_scope, main
+from conformance.suite.schema.disposition import RuleScope
+
+# ---------------------------------------------------------------------------
+# detect_scope
+# ---------------------------------------------------------------------------
+
+
+def _write_pyproject(root: Path, name: str | None) -> None:
+    if name is None:
+        (root / "pyproject.toml").write_text("[build-system]\n", encoding="utf-8")
+    else:
+        (root / "pyproject.toml").write_text(
+            f'[project]\nname = "{name}"\nversion = "0.1.0"\n', encoding="utf-8"
+        )
+
+
+def test_detect_scope_sdk(tmp_path: Path) -> None:
+    _write_pyproject(tmp_path, "atlan-application-sdk")
+    assert detect_scope(tmp_path) == RuleScope.SDK
+
+
+def test_detect_scope_sdk_sibling(tmp_path: Path) -> None:
+    _write_pyproject(tmp_path, "atlan-application-sdk-conformance")
+    assert detect_scope(tmp_path) == RuleScope.SDK
+
+
+def test_detect_scope_app(tmp_path: Path) -> None:
+    _write_pyproject(tmp_path, "my-connector")
+    assert detect_scope(tmp_path) == RuleScope.APP
+
+
+def test_detect_scope_no_pyproject(tmp_path: Path) -> None:
+    assert detect_scope(tmp_path) is None
+
+
+def test_detect_scope_no_project_name(tmp_path: Path) -> None:
+    _write_pyproject(tmp_path, None)
+    assert detect_scope(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# Scope predicates
+# ---------------------------------------------------------------------------
+
+
+def test_rule_in_scope_predicate() -> None:
+    assert _rule_in_scope(RuleScope.BOTH, RuleScope.SDK)
+    assert _rule_in_scope(RuleScope.APP, RuleScope.APP)
+    assert not _rule_in_scope(RuleScope.APP, RuleScope.SDK)
+    # Unknown active scope -> everything is in scope.
+    assert _rule_in_scope(RuleScope.APP, None)
+
+
+def test_series_in_scope_predicate() -> None:
+    # D-series is all-APP: out of scope on the SDK, in scope on an app.
+    assert not _series_in_scope("D", RuleScope.SDK)
+    assert _series_in_scope("D", RuleScope.APP)
+    # C-series is mixed (C001 both, C002/C003 app) -> stays active on the SDK.
+    assert _series_in_scope("C", RuleScope.SDK)
+
+
+# ---------------------------------------------------------------------------
+# Runner end-to-end (D-series: app-scoped)
+# ---------------------------------------------------------------------------
+
+
+def _make_app_repo(root: Path) -> None:
+    """An app pyproject with no atlan-application-sdk dependency -> triggers D001."""
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "my-connector"\nversion = "0.1.0"\n'
+        'dependencies = ["requests>=2,<3"]\n',
+        encoding="utf-8",
+    )
+
+
+def _rule_ids(sarif_path: Path) -> set[str]:
+    data = json.loads(sarif_path.read_text(encoding="utf-8"))
+    return {r["ruleId"] for r in data["runs"][0]["results"]}
+
+
+def test_runner_app_scope_surfaces_d001(tmp_path: Path) -> None:
+    _make_app_repo(tmp_path)
+    out = tmp_path / "report.sarif"
+    exit_code = main(
+        [
+            "--repo",
+            str(tmp_path),
+            "--series",
+            "D",
+            "--scope",
+            "app",
+            "--output",
+            str(out),
+        ]
+    )
+    assert "D001" in _rule_ids(out)
+    assert exit_code == 1  # D001 is block-tier
+
+
+def test_runner_sdk_scope_skips_d_series(tmp_path: Path) -> None:
+    _make_app_repo(tmp_path)  # same repo, but force SDK scope
+    out = tmp_path / "report.sarif"
+    exit_code = main(
+        [
+            "--repo",
+            str(tmp_path),
+            "--series",
+            "D",
+            "--scope",
+            "sdk",
+            "--output",
+            str(out),
+        ]
+    )
+    assert _rule_ids(out) == set()
+    assert exit_code == 0
+
+
+def test_runner_autodetects_app_scope(tmp_path: Path) -> None:
+    """No --scope: the app's pyproject name auto-detects to app, so D001 fires."""
+    _make_app_repo(tmp_path)
+    out = tmp_path / "report.sarif"
+    main(["--repo", str(tmp_path), "--series", "D", "--output", str(out)])
+    assert "D001" in _rule_ids(out)
+
+
+def test_runner_autodetects_sdk_scope_skips_d(tmp_path: Path) -> None:
+    """An SDK-named repo auto-detects to sdk, so the app-scoped D-series is skipped."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "atlan-application-sdk"\nversion = "0.1.0"\n'
+        'dependencies = ["requests>=2,<3"]\n',
+        encoding="utf-8",
+    )
+    out = tmp_path / "report.sarif"
+    exit_code = main(["--repo", str(tmp_path), "--series", "D", "--output", str(out)])
+    assert _rule_ids(out) == set()
+    assert exit_code == 0

--- a/packages/conformance/tests/test_scope.py
+++ b/packages/conformance/tests/test_scope.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from conformance.suite.checks._ast_common import detect_scope
 from conformance.suite.runner import _rule_in_scope, _series_in_scope, main
 from conformance.suite.schema.disposition import RuleScope
@@ -52,6 +53,40 @@ def test_detect_scope_no_pyproject(tmp_path: Path) -> None:
 def test_detect_scope_no_project_name(tmp_path: Path) -> None:
     _write_pyproject(tmp_path, None)
     assert detect_scope(tmp_path) is None
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        # SDK: exact name and hyphen-extended sibling packages.
+        ("atlan-application-sdk", RuleScope.SDK),
+        ("atlan-application-sdk-conformance", RuleScope.SDK),
+        ("atlan_application_sdk", RuleScope.SDK),  # PEP 503 underscore form
+        # APP: names that merely share the prefix as a substring must NOT match.
+        ("atlan-application-sdk2", RuleScope.APP),
+        ("atlan-application-sdkk", RuleScope.APP),
+        ("my-connector", RuleScope.APP),
+    ],
+)
+def test_detect_scope_prefix_boundary(
+    tmp_path: Path, name: str, expected: RuleScope
+) -> None:
+    """The SDK prefix is hyphen-anchored, not a loose substring match."""
+    _write_pyproject(tmp_path, name)
+    assert detect_scope(tmp_path) == expected
+
+
+def test_sdk_prefix_matches_dependency_checker() -> None:
+    """Guard the comment-synced duplication of the SDK package name.
+
+    ``_scope.SDK_PACKAGE_PREFIX`` and ``dependency_conformance.SDK_PACKAGE`` encode
+    the same Atlan distribution name in two places (kept in sync by comment rather
+    than a shared module).  This catches drift without taking on that layering cost.
+    """
+    from conformance.suite.checks import dependency_conformance
+    from conformance.suite.checks._ast_common import SDK_PACKAGE_PREFIX
+
+    assert SDK_PACKAGE_PREFIX == dependency_conformance.SDK_PACKAGE
 
 
 # ---------------------------------------------------------------------------

--- a/packages/conformance/tests/test_scope.py
+++ b/packages/conformance/tests/test_scope.py
@@ -71,7 +71,7 @@ def test_series_in_scope_predicate() -> None:
     # D-series is all-APP: out of scope on the SDK, in scope on an app.
     assert not _series_in_scope("D", RuleScope.SDK)
     assert _series_in_scope("D", RuleScope.APP)
-    # C-series is mixed (C001 both, C002/C003 app) -> stays active on the SDK.
+    # C-series is mixed (C001/C003 both, C002 app) -> stays active on the SDK.
     assert _series_in_scope("C", RuleScope.SDK)
 
 

--- a/packages/conformance/tests/test_scope.py
+++ b/packages/conformance/tests/test_scope.py
@@ -89,6 +89,38 @@ def test_sdk_prefix_matches_dependency_checker() -> None:
     assert SDK_PACKAGE_PREFIX == dependency_conformance.SDK_PACKAGE
 
 
+@pytest.mark.parametrize(
+    ("name", "is_sdk"),
+    [
+        ("atlan-application-sdk", True),
+        ("atlan-application-sdk-conformance", True),
+        ("atlan_application_sdk", True),  # PEP 503 underscore form
+        ("atlan-application-sdk2", False),  # substring lookalike
+        ("atlan-application-sdkk", False),
+        ("my-connector", False),
+    ],
+)
+def test_is_self_check_matches_shared_helper(name: str, is_sdk: bool) -> None:
+    """`_is_self_check` and the shared `is_sdk_package_name` must agree.
+
+    Both now route through `is_sdk_package_name`, so the matching *semantics*
+    (hyphen-anchored, not just the constant) cannot drift between the D-series
+    self-exemption and the runner-side scope detection.
+    """
+    from conformance.suite.checks import dependency_conformance
+    from conformance.suite.checks._ast_common import is_sdk_package_name
+
+    assert is_sdk_package_name(name) is is_sdk
+    assert dependency_conformance._is_self_check(name) is is_sdk
+
+
+def test_is_self_check_handles_none() -> None:
+    """`_is_self_check(None)` stays False (the original None-guard is preserved)."""
+    from conformance.suite.checks import dependency_conformance
+
+    assert dependency_conformance._is_self_check(None) is False
+
+
 # ---------------------------------------------------------------------------
 # Scope predicates
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

Conformance rules previously ran identically against every repo — the SDK itself and every consumer app — with no way to say *where* a rule applies. Some rules are inherently one-sided (dependency pinning, bootstrap-shim drift), and their app-only-ness was either hacked inside a detector or simply never wired into CI.

This makes **scope** a first-class, **required** rule attribute (`sdk` / `app` / `both`), resolved at runtime from the repo under scan — with **zero fleet churn** (no app needs to change its `conformance.yaml`).

## How it works

- **Required `scope` field** on `RuleDefinition` (no default) + new `RuleScope` enum. Emitted as `atlan/scope` in SARIF and shown in the generated rule docs.
- **Runtime detection** — `detect_scope(root)` reads the repo's `[project].name`: `atlan-application-sdk*` → `sdk`, else → `app`, no/unparseable pyproject → run everything. Generalises the D-series `_is_self_check` hack into one shared helper. Explicit `--scope` overrides.
- **Runner** skips an all-out-of-scope series wholesale (e.g. D on the SDK) and post-filters findings for mixed-scope series (C keeps C001, drops C002/C003 on the SDK), so counts and exit code stay correct. A rule is in scope iff its scope is `both` or equals the active scope.

## Scope classification (backfilled on all 45 rules)

| Rules | Scope | Reason |
|---|---|---|
| `D001`, `D002`, `C002`, `C003` | `app` | Publisher-side: the SDK *authors* these contracts (dependency pins, bootstrap shims) and can't be a subject of them |
| `C001`, all E/L/O/P | `both` | Universal — apply to any repo, SDK included |

No rule is `sdk`-only today; the enum supports it for future SDK-internal invariants.

## CI

- **D-series wired into `conformance-reusable.yaml`** (`**/pyproject.toml` leg) — it was previously in **zero** workflows. Auto-scopes to `app`, no-ops on the SDK.
- `D001` ships at **BLOCK** (reviewed rollout decision). Canonical consumer `atlan-openapi-app` is clean on D001 (only a non-blocking D002 WARN).

## Guarantees

- `scope` required → a rule without it can't be constructed (catalog import fails).
- Meta-tests: `test_catalog_all_have_scope`, `test_scope_is_required_field`, and `test_catalog_app_scoped_rules_are_the_expected_set` (pins the app-scoped set).
- The in-detector `_is_self_check` is **kept** as defense-in-depth for the `--scope app` on an SDK-repo edge the runner skip doesn't cover.

## Verification

- 514 tests pass (1 xfail); new `test_scope.py` covers detection + runner skip/filter end-to-end.
- pre-commit clean (ruff, ruff-format, pyright, isort); rule docs regenerated (`gen-rule-docs --check` clean).
- Detection verified: SDK root & conformance pkg → `sdk`; openapi-app → `app`. D auto-skips on the SDK; D001 fires on a synthetic app.

## Remediation

No new prescription needed — scope is a filtering concern; `detect-violations` shells out to the runner and inherits scoping for free.
