### PR TITLE
ci: use GITHUB_TOKEN for requirements.txt sync push on Renovate branches

### DIFF
--- a/.github/workflows/dependabot-requirements-sync.yaml
+++ b/.github/workflows/dependabot-requirements-sync.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          token: ${{ secrets.ORG_PAT_GITHUB }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.ref }}
 
       - name: Install uv


### PR DESCRIPTION
## Summary

- Reverts the `dependabot-requirements-sync.yaml` checkout token from `ORG_PAT_GITHUB` back to `GITHUB_TOKEN`
- Fixes lock-file-maintenance Renovate PRs getting stuck: `atlan-ci` was the last pusher (via the requirements.txt sync commit) and therefore could not satisfy its own auto-approval
- The outside-collaborator workflow re-approval concern that motivated d7418bf only applies to fork PRs; Renovate creates same-repo branches, so the gate never fires here

## Root cause

d7418bf switched the checkout token to `ORG_PAT_GITHUB` (atlan-ci's PAT) so that bot-pushed commits to Renovate branches would not trigger GitHub's outside-collaborator workflow re-approval gate on public repos. That guard is only relevant for **fork** pull requests. Renovate always opens PRs from branches within the same repository (`renovate/lock-file-maintenance` etc.), so `github-actions[bot]` pushes to those branches are treated as normal same-repo pushes — no re-approval gate.

With `ORG_PAT_GITHUB` the sync commit was attributed to `atlan-ci`. GitHub then blocked the auto-merge: *"New changes require approval from someone other than atlan-ci because they were the last pusher."*

## Fix

One-line revert to `GITHUB_TOKEN`. The sync commit now pushes as `github-actions[bot]`, `atlan-ci` is not the last pusher, and the Renovate auto-approval clears normally.

## Test plan

- [ ] Merge this PR
- [ ] Confirm the next `chore(deps): lock file maintenance` Renovate PR auto-approves and merges without the "last pusher" block