### PR TITLE
fix(conformance): decouple SARIF upload from gate to fix Security tab errors

### DIFF
--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -76,11 +76,6 @@ on:
         required: false
         default: ""
         type: string
-      upload-sarif:
-        description: "Upload SARIF report to GitHub Security tab (requires security-events: write)"
-        required: false
-        default: true
-        type: boolean
       event_name:
         description: "Caller's github.event_name (push / pull_request / merge_group); reusable workflows always see 'workflow_call' internally"
         required: false
@@ -117,7 +112,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   # ── Per-series checks (one matrix leg per rule series) ──────────────────────
@@ -199,20 +193,6 @@ jobs:
         with:
           name: conformance-${{ matrix.slug }}-sarif
           path: ${{ matrix.slug }}.sarif
-
-      - name: "Strip suppressed results for Security tab"
-        if: ${{ inputs.upload-sarif && inputs.event_name == 'push' }}
-        env:
-          SARIF_SLUG: ${{ matrix.slug }}
-        run: |
-          jq '.runs[] |= (.results |= map(select(.suppressions == null or (.suppressions | length == 0))))' \
-            "$SARIF_SLUG.sarif" > "$SARIF_SLUG-upload.sarif"
-
-      - name: "Upload SARIF to Security tab"
-        if: ${{ inputs.upload-sarif && inputs.event_name == 'push' }}
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
-        with:
-          sarif_file: ${{ matrix.slug }}-upload.sarif
 
   # ── Required gate ─────────────────────────────────────────────────────────
   # Always runs so it can be marked a required check without ever becoming

--- a/.github/workflows/conformance-upload-sarif.yaml
+++ b/.github/workflows/conformance-upload-sarif.yaml
@@ -1,0 +1,59 @@
+name: "Conformance SARIF Upload"
+# Uploads SARIF results from the Conformance workflow to the GitHub Security
+# tab.  Runs as a separate workflow triggered by workflow_run so that it always
+# exits 0 — GitHub Code Scanning marks a tool as "reporting errors" whenever
+# the workflow that uploads SARIF fails, so the upload must be decoupled from
+# the gate (which intentionally exits 1 on blocking violations).
+
+on:
+  workflow_run:
+    workflows: ["Conformance"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  security-events: write
+  actions: read  # required to download artifacts from the triggering run
+
+jobs:
+  upload:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'cancelled'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - slug: ci
+            name: "Upload CI SARIF"
+          - slug: error-handling
+            name: "Upload Error-handling SARIF"
+          - slug: prescriptions
+            name: "Upload Prescriptions SARIF"
+          - slug: optimizations
+            name: "Upload Optimizations SARIF"
+    steps:
+      - name: "Download SARIF artifact"
+        id: download
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: conformance-${{ matrix.slug }}-sarif
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+        continue-on-error: true  # absent when series had no relevant changes
+
+      - name: "Strip suppressed results"
+        if: steps.download.outcome == 'success'
+        env:
+          SARIF_SLUG: ${{ matrix.slug }}
+        run: |
+          jq '.runs[] |= (.results |= map(select(.suppressions == null or (.suppressions | length == 0))))' \
+            "$SARIF_SLUG.sarif" > "$SARIF_SLUG-upload.sarif"
+
+      - name: "Upload SARIF to Security tab"
+        if: steps.download.outcome == 'success'
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          sarif_file: ${{ matrix.slug }}-upload.sarif
+          ref: ${{ github.event.workflow_run.head_branch }}
+          sha: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   suite:

--- a/packages/conformance/conformance/bootstrap/render.py
+++ b/packages/conformance/conformance/bootstrap/render.py
@@ -41,6 +41,7 @@ _ENV = jinja2.Environment(
 # ``.github/workflows/``).  The C002 drift check iterates this registry.
 MANAGED_WORKFLOWS: tuple[str, ...] = (
     "conformance.yaml",
+    "conformance-upload-sarif.yaml",
     "checks.yml",
     "commits.yaml",
     "release-gate.yaml",

--- a/packages/conformance/conformance/bootstrap/templates/conformance-upload-sarif.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/conformance-upload-sarif.yaml
@@ -1,0 +1,59 @@
+name: "Conformance SARIF Upload"
+# Uploads SARIF results from the Conformance workflow to the GitHub Security
+# tab.  Runs as a separate workflow triggered by workflow_run so that it always
+# exits 0 — GitHub Code Scanning marks a tool as "reporting errors" whenever
+# the workflow that uploads SARIF fails, so the upload must be decoupled from
+# the gate (which intentionally exits 1 on blocking violations).
+
+on:
+  workflow_run:
+    workflows: ["Conformance"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  security-events: write
+  actions: read  # required to download artifacts from the triggering run
+
+jobs:
+  upload:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'cancelled'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - slug: ci
+            name: "Upload CI SARIF"
+          - slug: error-handling
+            name: "Upload Error-handling SARIF"
+          - slug: prescriptions
+            name: "Upload Prescriptions SARIF"
+          - slug: optimizations
+            name: "Upload Optimizations SARIF"
+    steps:
+      - name: "Download SARIF artifact"
+        id: download
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: conformance-${{ matrix.slug }}-sarif
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+        continue-on-error: true  # absent when series had no relevant changes
+
+      - name: "Strip suppressed results"
+        if: steps.download.outcome == 'success'
+        env:
+          SARIF_SLUG: ${{ matrix.slug }}
+        run: |
+          jq '.runs[] |= (.results |= map(select(.suppressions == null or (.suppressions | length == 0))))' \
+            "$SARIF_SLUG.sarif" > "$SARIF_SLUG-upload.sarif"
+
+      - name: "Upload SARIF to Security tab"
+        if: steps.download.outcome == 'success'
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          sarif_file: ${{ matrix.slug }}-upload.sarif
+          ref: ${{ github.event.workflow_run.head_branch }}
+          sha: ${{ github.event.workflow_run.head_sha }}

--- a/packages/conformance/conformance/bootstrap/templates/conformance.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/conformance.yaml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   suite:

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -266,10 +266,44 @@ def test_conformance_workflow_contains_event_name() -> None:
     assert "sdk-ref" not in content
 
 
+def test_conformance_upload_sarif_workflow_run_trigger() -> None:
+    """Upload workflow is triggered by the Conformance workflow_run on main."""
+    content = render("conformance-upload-sarif.yaml")
+    assert 'workflows: ["Conformance"]' in content
+    assert "workflow_run" in content
+    assert "branches: [main]" in content
+
+
+def test_conformance_upload_sarif_decoupled_from_gate() -> None:
+    """Upload workflow uses continue-on-error on download so it always exits 0."""
+    content = render("conformance-upload-sarif.yaml")
+    assert "continue-on-error: true" in content
+
+
+def test_conformance_upload_sarif_passes_ref_and_sha() -> None:
+    """Upload workflow passes head_branch and head_sha so SARIF is anchored to the triggering commit."""
+    content = render("conformance-upload-sarif.yaml")
+    assert "workflow_run.head_branch" in content
+    assert "workflow_run.head_sha" in content
+
+
+def test_conformance_upload_sarif_has_actions_read_permission() -> None:
+    """actions: read is required to download artifacts from the triggering run."""
+    content = render("conformance-upload-sarif.yaml")
+    assert "actions: read" in content
+
+
+def test_conformance_upload_sarif_covers_all_series() -> None:
+    """Upload workflow covers all four conformance series slugs."""
+    content = render("conformance-upload-sarif.yaml")
+    for slug in ("ci", "error-handling", "prescriptions", "optimizations"):
+        assert slug in content, f"Missing series slug: {slug}"
+
+
 def test_all_shims_have_atlanhq_uses_reference() -> None:
     """Every managed workflow delegates to atlanhq/* (or a known inline file)."""
     # These files contain inline logic (no `uses: atlanhq/...`) but are still standard.
-    inline_ok = {"release-gate.yaml"}
+    inline_ok = {"release-gate.yaml", "conformance-upload-sarif.yaml"}
     for name in MANAGED_WORKFLOWS:
         content = render(name)
         if name in inline_ok:

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -287,9 +287,10 @@ def test_conformance_upload_sarif_passes_ref_and_sha() -> None:
     assert "workflow_run.head_sha" in content
 
 
-def test_conformance_upload_sarif_has_actions_read_permission() -> None:
-    """actions: read is required to download artifacts from the triggering run."""
+def test_conformance_upload_sarif_has_required_permissions() -> None:
+    """security-events: write uploads SARIF; actions: read downloads artifacts from the triggering run."""
     content = render("conformance-upload-sarif.yaml")
+    assert "security-events: write" in content
     assert "actions: read" in content
 
 

--- a/packages/conformance/uv.lock
+++ b/packages/conformance/uv.lock
@@ -218,7 +218,7 @@ wheels = [
 
 [[package]]
 name = "atlan-application-sdk-conformance"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

- **Root cause**: GitHub Code Scanning marks a tool as \"reporting errors\" whenever the workflow that uploads SARIF exits non-zero. The Conformance gate intentionally exits 1 on blocking violations, which caused all series configurations to show as errored — even for CI/E/O series that individually succeeded and uploaded SARIF cleanly.
- **Fix**: Move SARIF upload into a new `conformance-upload-sarif.yaml` workflow triggered via `workflow_run` on the Conformance workflow completing on `main`. This workflow always exits 0, so the Code Scanning tool status stays clean regardless of gate outcome.
- **Gate unchanged**: The gate still exits 1 on blocking violations — PR blocking is unaffected.

## Changes

| File | Change |
|---|---|
| `.github/workflows/conformance-reusable.yaml` | Remove `upload-sarif` input, `security-events: write`, and the two SARIF upload steps |
| `.github/workflows/conformance-upload-sarif.yaml` | New — SDK's deployed copy of the upload workflow |
| `packages/conformance/conformance/bootstrap/templates/conformance-upload-sarif.yaml` | New — bootstrap template deployed to consumer repos |
| `packages/conformance/conformance/bootstrap/render.py` | Add `conformance-upload-sarif.yaml` to `MANAGED_WORKFLOWS` |
| `packages/conformance/tests/test_bootstrap.py` | 6 new fidelity tests + `inline_ok` exception for the new template |

## Consumer repo migration

The reusable workflow change takes effect immediately for all consumers (`@main`). Consumer repos need to run `atlan-application-sdk-conformance bootstrap` to deploy the new upload workflow. C002 will flag the absence of `conformance-upload-sarif.yaml` automatically, surfacing the migration without manual tracking.

## Test plan

- [ ] Conformance test suite passes (480 tests + 1 xfailed)
- [ ] Pre-commit clean on all changed files
- [ ] After merge: verify Security and quality tab in a consumer repo shows the tool as healthy after next push to main
- [ ] Confirm gate still fails (and blocks PRs) when violations are present