### PR TITLE
fix(contract-toolkit): allow 10-day timeout cap

### DIFF
--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -1407,7 +1407,7 @@ class ErrorHandlingConfig {
   maximumInterval: Int(this >= 1)?                  // Retry max interval (seconds)
   maximumAttempts: Int?                             // Retry cap
   nonRetryableErrorTypes: Listing<String>?          // Exact error types to skip retry on
-  startToCloseTimeoutSeconds: Int(isBetween(1, 259200))?  // Total node time budget
+  startToCloseTimeoutSeconds: Int(isBetween(1, 864000))?  // Total node time budget, up to 10 days
   heartbeatTimeoutSeconds: Int(isBetween(1, 3600))?       // Activity-only
 }
 ```

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -619,7 +619,7 @@ class ErrorHandlingConfig {
 
   nonRetryableErrorTypes: Listing<String>?
 
-  startToCloseTimeoutSeconds: Int(isBetween(1, 259200))?
+  startToCloseTimeoutSeconds: Int(isBetween(1, 864000))?
 
   heartbeatTimeoutSeconds: Int(isBetween(1, 3600))?
 

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -874,10 +874,10 @@ class ErrorHandlingConfig {
   /// Error types that should not be retried (exact type/class names).
   nonRetryableErrorTypes: Listing<String>?
 
-  /// Maximum time from start to completion in seconds (1-259200).
+  /// Maximum time from start to completion in seconds (1-864000).
   /// AE remaps to `execution_timeout` for workflow nodes (default 2 hours)
   /// or `start_to_close_timeout` for activity nodes (default 30 minutes).
-  startToCloseTimeoutSeconds: Int(isBetween(1, 259200))?
+  startToCloseTimeoutSeconds: Int(isBetween(1, 864000))?
 
   /// Maximum time between heartbeats in seconds (1-3600). Activity nodes only —
   /// AE rejects this on workflow nodes (see DAGNode.nodeType).

--- a/contract-toolkit/tests/timeout_cap_test.pkl
+++ b/contract-toolkit/tests/timeout_cap_test.pkl
@@ -1,0 +1,70 @@
+// Tests for the maximum supported start-to-close timeout in toolkit error handling.
+//
+// The toolkit should allow publish workflows to opt into a 10-day timeout
+// budget while preserving the existing 72h publish default.
+
+amends "pkl:test"
+
+import "pkl:json"
+import "../src/App.pkl" as App
+import "../src/NativeApp.pkl" as NativeApp
+
+local tenDaysSeconds = 864000
+local seventyTwoHoursSeconds = 259200
+
+local appWithTenDayPublishTimeout = (App) {
+  name = "ten-day-timeout"
+  displayName = "Ten Day Timeout"
+  icon = "https://example.com/icon.svg"
+  hasCredentialConfig = false
+
+  pipeline {
+    publish {
+      errorHandling {
+        startToCloseTimeoutSeconds = tenDaysSeconds
+      }
+    }
+  }
+
+  uiConfig = new App.UIConfig {
+    tasks {
+      ["Configuration"] {
+        inputs {
+          ["connection"] = new App.ConnectionCreator {
+            placeholderText = "Connection Name"
+          }
+        }
+      }
+    }
+  }
+}
+
+local publishNode = new json.Parser { useMapping = true }.parse(
+  appWithTenDayPublishTimeout.output.files["app/generated/manifest.json"].text
+)["dag"]["publish"]
+
+facts {
+  ["App.ErrorHandlingConfig accepts the 10-day timeout cap"] {
+    new App.ErrorHandlingConfig {
+      startToCloseTimeoutSeconds = tenDaysSeconds
+    }.startToCloseTimeoutSeconds == tenDaysSeconds
+  }
+
+  ["NativeApp.ErrorHandlingConfig accepts the 10-day timeout cap"] {
+    new NativeApp.ErrorHandlingConfig {
+      startToCloseTimeoutSeconds = tenDaysSeconds
+    }.startToCloseTimeoutSeconds == tenDaysSeconds
+  }
+
+  ["App publish node keeps the existing 72h default timeout"] {
+    new App.PublishNode {}.errorHandling.startToCloseTimeoutSeconds == seventyTwoHoursSeconds
+  }
+
+  ["App publish pipeline can render a 10-day timeout override"] {
+    publishNode["error_handling"]["start_to_close_timeout_seconds"] == tenDaysSeconds
+  }
+
+  ["NativeApp publish node keeps the existing 72h default timeout"] {
+    new NativeApp.PublishNode {}.errorHandling.startToCloseTimeoutSeconds == seventyTwoHoursSeconds
+  }
+}


### PR DESCRIPTION
## Summary

Raise the contract toolkit `startToCloseTimeoutSeconds` validation ceiling from 72h (`259200`) to 10 days (`864000`) in both toolkit entrypoints:

- `contract-toolkit/src/App.pkl`
- `contract-toolkit/src/NativeApp.pkl`

The existing publish-node default stays at 72h. This only allows apps to opt into longer publish workflow timeouts when needed.

## Root cause

The toolkit Pkl schema capped `ErrorHandlingConfig.startToCloseTimeoutSeconds` at `259200`, so a connector contract could not render a publish node with a 10-day timeout even though Automation Engine already accepts `864000`.

## Validation

- `pkl test tests/timeout_cap_test.pkl`
- `pkl test tests/*.pkl`
- `./scripts/check-invariants.sh`
- `uv run pre-commit run --files contract-toolkit/src/App.pkl contract-toolkit/src/NativeApp.pkl contract-toolkit/docs/reference.md contract-toolkit/tests/timeout_cap_test.pkl`

## Consumer check

Checked required downstream repos:

- `atlan-automation-engine-app@main`: `automation_engine/registry/workflows/models.py` already allows `start_to_close_timeout_seconds <= 864000`.
- `heracles@beta`: no relevant `start_to_close_timeout` / 72h cap references found.
- `atlan-frontend@beta`: no relevant workflow timeout cap references found; hits were unrelated time constants/assets.
- `blaze@main`: no relevant timeout cap references found.

## Compatibility

Backward-compatible. Existing generated manifests remain unchanged unless an app explicitly overrides `startToCloseTimeoutSeconds` above 72h.

Linear: HYP-1807
