### PR TITLE
ci(renovate): auto-approve workflow runs via pull_request_target

### DIFF
--- a/.github/workflows/renovate-auto-run-approve.yml
+++ b/.github/workflows/renovate-auto-run-approve.yml
@@ -1,0 +1,90 @@
+# Automatically approve GitHub Actions workflow runs from renovate[bot].
+#
+# The problem this solves:
+#   GitHub requires manual "Approve workflows to run" clicks before CI can
+#   start for PRs from outside collaborators (like renovate[bot]). Without
+#   this, all required checks stay in "Waiting for status to be reported"
+#   forever until a maintainer manually clicks the button.
+#
+# Why pull_request_target (not pull_request):
+#   pull_request_target always runs the workflow code from the BASE branch
+#   (main), not the PR branch. GitHub never blocks it behind the "Approve
+#   workflows to run" gate, and the GITHUB_TOKEN carries full repo permissions
+#   including actions:write. pull_request workflows from external contributors
+#   DO get blocked — that's the gate we're unblocking.
+#
+# Safety:
+#   - Only acts on PRs authored by renovate[bot] (line-level guard)
+#   - Never checks out or executes code from the PR branch
+#   - Only approves workflow runs (does not merge, comment, or modify code)
+#
+# Timing:
+#   When this job picks up a runner (typically 10-30s after the PR event),
+#   the pull_request workflow runs are already in action_required state.
+#   The poll loop is a safety net for slow queue processing under GitHub load.
+
+name: Renovate — auto-approve workflow runs
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  actions: write
+
+jobs:
+  approve-runs:
+    name: Approve pending workflow runs
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    if: github.event.pull_request.user.login == 'renovate[bot]'
+    steps:
+      - name: Approve all action_required runs for this HEAD SHA
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const sha = context.payload.pull_request.head.sha;
+            const { owner, repo } = context.repo;
+
+            // Poll until we find action_required runs or give up.
+            // In practice the runs exist before our runner picks up, so the
+            // first iteration usually succeeds. The loop is a safety net for
+            // GitHub-side delays under load.
+            const maxAttempts = 8;
+            const intervalMs = 5_000;
+            let approved = 0;
+
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                owner,
+                repo,
+                head_sha: sha,
+                status: 'action_required',
+                per_page: 100,
+              });
+
+              if (data.workflow_runs.length === 0) {
+                if (attempt < maxAttempts) {
+                  console.log(`Attempt ${attempt}: no action_required runs yet — retrying in ${intervalMs / 1000}s`);
+                  await new Promise(r => setTimeout(r, intervalMs));
+                  continue;
+                }
+                console.log(`No action_required runs found after ${maxAttempts} attempts — nothing to approve.`);
+                break;
+              }
+
+              for (const run of data.workflow_runs) {
+                try {
+                  await github.rest.actions.approveWorkflowRun({ owner, repo, run_id: run.id });
+                  console.log(`✅ Approved run #${run.id}: ${run.name}`);
+                  approved++;
+                } catch (err) {
+                  // Already approved or transient error — not fatal.
+                  console.log(`⚠️  Run #${run.id} (${run.name}): ${err.message}`);
+                }
+              }
+              break;
+            }
+
+            console.log(`Done — approved ${approved} workflow run(s) for ${sha.slice(0, 7)}.`);


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/renovate-auto-run-approve.yml` — a `pull_request_target` workflow that automatically approves pending GitHub Actions workflow runs from `renovate[bot]`
- Fixes the recurring need to manually click the "Approve workflows to run" button on Renovate PRs
- Distinct from `renovate-auto-approve.yml` (which approves the PR *review* after CI is green) — this unblocks CI from *starting* at all

## Root cause

GitHub blocks `pull_request` workflow runs from outside collaborators (including `renovate[bot]`) behind a manual approval gate. Without approval, all required checks stay stuck in "Waiting for status to be reported" indefinitely.

## How the fix works

`pull_request_target` always runs from the **base branch** — GitHub never subjects it to the workflow approval gate, and the `GITHUB_TOKEN` has full `actions: write` permission. When a Renovate PR is opened or updated, this workflow calls `actions.approveWorkflowRun` for every `action_required` run on that HEAD SHA.

**Security**: only acts on PRs from `renovate[bot]`, never checks out PR code, only approves workflow runs (no merge/comment/code changes).

## Test plan

- [ ] Open a fresh Renovate lock-file-maintenance PR and verify CI starts without any manual "Approve workflows to run" click
- [ ] Verify the workflow skips on non-Renovate PRs (`if: github.event.pull_request.user.login == 'renovate[bot]'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)