### PR TITLE
ci(revert): use GITHUB_TOKEN for requirements.txt sync push on Renovate branches

### DIFF
--- a/.github/workflows/dependabot-requirements-sync.yaml
+++ b/.github/workflows/dependabot-requirements-sync.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ORG_PAT_GITHUB }}
           ref: ${{ github.ref }}
 
       - name: Install uv


### PR DESCRIPTION
Reverts atlanhq/application-sdk#2218