### PR TITLE
fix(logging): remediate blocking L004 violations

### DIFF
--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -142,7 +142,7 @@ class BaseSQLClient(ClientInterface):
             # No exc_info here: SQLAlchemy errors embed the full connection
             # string (including the password) in their message, and the
             # traceback would print it verbatim into logs.
-            logger.error(  # conformance: ignore[E005] exc_info would expose SQLAlchemy password in traceback; cause sanitized above
+            logger.error(  # conformance: ignore[E005,L004] exc_info would expose SQLAlchemy password in traceback; cause sanitized above
                 "Error loading SQL client: %s", sanitize_cause_repr(e)
             )
             if self.engine:
@@ -641,7 +641,7 @@ class AsyncBaseSQLClient(BaseSQLClient):
             # No exc_info here: SQLAlchemy errors embed the full connection
             # string (including the password) in their message, and the
             # traceback would print it verbatim into logs.
-            logger.error(  # conformance: ignore[E005] exc_info would expose SQLAlchemy password in traceback; cause sanitized above
+            logger.error(  # conformance: ignore[E005,L004] exc_info would expose SQLAlchemy password in traceback; cause sanitized above
                 "Error establishing database connection: %s", sanitize_cause_repr(e)
             )
             if self.engine:

--- a/application_sdk/credentials/agent.py
+++ b/application_sdk/credentials/agent.py
@@ -248,7 +248,7 @@ async def _fetch_per_key_bundle(
                 f"sha256:{value_hash}",
                 redact_secrets("".join(traceback.format_exception(exc))),
             )
-            logger.warning(  # conformance: ignore[E005] exc_info would bypass the secret-redacted traceback built above; safe_traceback included inline
+            logger.warning(  # conformance: ignore[E005,L004] exc_info would bypass the secret-redacted traceback built above; safe_traceback included inline
                 "single-key probe failed for ref-key sha256:%s — store error, "
                 "treating as non-secret. If this was a real credential "
                 "key, the auth attempt will fail with the ref-key as the "

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -1677,7 +1677,11 @@ def main() -> NoReturn:
         )
 
         if isinstance(exc, ObjectStorePreflightError):
-            logger.error("SDR object-store preflight failed — cannot start:\n%s", exc)
+            logger.error(
+                "SDR object-store preflight failed — cannot start:\n%s",
+                exc,
+                exc_info=True,
+            )
             try:
                 asyncio.run(_flush_observability())
             # conformance: ignore[E002,E004] best-effort flush on fatal exit; fatal error already logged above

--- a/application_sdk/storage/preflight.py
+++ b/application_sdk/storage/preflight.py
@@ -58,6 +58,7 @@ if _raw_timeout is not None:
             "ATLAN_SDR_PREFLIGHT_TIMEOUT_SECS=%r is not a valid number; using default %.0f s",
             _raw_timeout,
             _PROBE_TIMEOUT_SECS,
+            exc_info=True,
         )
 del _raw_timeout
 
@@ -194,6 +195,7 @@ async def _probe_store(store: object, label: str, binding_name: str) -> str | No
             binding_name,
             probe_key,
             exc,
+            exc_info=True,
         )
 
     return read_failure

--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -340,7 +340,7 @@ class SqlApp(App):
             # ourselves and redact secrets before logging — frames preserved,
             # credentials stripped.
             safe_traceback = redact_secrets("".join(traceback.format_exception(exc)))
-            logger.error(  # conformance: ignore[E005] exc_info would expose SQLAlchemy password in traceback; safe_traceback built above with secrets redacted
+            logger.error(  # conformance: ignore[E005,L004] exc_info would expose SQLAlchemy password in traceback; safe_traceback built above with secrets redacted
                 "SQL auth cache prime FAILED after %.1fms (%s) — short-circuiting "
                 "before parallel extract burst to avoid stacking failed_login_attempts "
                 "on the source.\n%s",

--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -322,6 +322,7 @@ class AEWorkflowClient:
                         total_attempts,
                         exc,
                         sleep_seconds,
+                        exc_info=True,
                     )
                     time.sleep(sleep_seconds)
                     continue


### PR DESCRIPTION
## Summary

- **8 blocking L004 violations** from the conformance gate cleared — all were `except` blocks logging without `exc_info=True`, causing stack traces to be silently discarded
- 4 sites intentionally omit `exc_info` for security (SQLAlchemy embeds connection-string passwords / redacted tracebacks already built manually) — added `L004` to their existing `ignore[E005]` suppressions
- 4 sites received `exc_info=True`: ObjectStorePreflightError fatal path in `main.py`, config parse `ValueError` and probe-object cleanup in `storage/preflight.py`, and timeout in submit retry loop in `testing/e2e/client.py`

## Test plan

- [ ] Pre-commit passes clean (`ruff`, `pyright`, `ruff-format`)
- [ ] All 5165 unit tests pass
- [ ] Conformance gate L004 blocking violations: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)