### PR TITLE
ci: fix sdk paths-filter false positives from !**/*.md picomatch catch-all

### DIFF
--- a/.github/scripts/sdk_changes_non_md.py
+++ b/.github/scripts/sdk_changes_non_md.py
@@ -1,0 +1,24 @@
+"""
+Reads the JSON file list emitted by dorny/paths-filter (list-files: json) from
+the SDK_FILES environment variable and exits 0 (sdk=true) when at least one
+matched file is not a Markdown file, or exits 1 (sdk=false) when every matched
+file is Markdown.
+
+Called by the 'Refine sdk — suppress markdown-only matches' step in
+pull_request.yaml and sdk-gate.yaml.
+"""
+
+import json
+import os
+
+files = json.loads(os.environ.get("SDK_FILES", "[]"))
+has_non_md = any(not f.endswith(".md") for f in files)
+
+github_output = os.environ.get("GITHUB_OUTPUT", "")
+line = "sdk=" + ("true" if has_non_md else "false")
+
+if github_output:
+    with open(github_output, "a") as fh:
+        fh.write(line + "\n")
+else:
+    print(line)

--- a/.github/scripts/sdk_changes_non_md.py
+++ b/.github/scripts/sdk_changes_non_md.py
@@ -1,11 +1,12 @@
 """
 Reads the JSON file list emitted by dorny/paths-filter (list-files: json) from
-the SDK_FILES environment variable and exits 0 (sdk=true) when at least one
-matched file is not a Markdown file, or exits 1 (sdk=false) when every matched
-file is Markdown.
+the SDK_FILES environment variable and writes sdk=true|false to $GITHUB_OUTPUT.
 
-Called by the 'Refine sdk — suppress markdown-only matches' step in
-pull_request.yaml and sdk-gate.yaml.
+sdk=true  when at least one matched file is not a Markdown file.
+sdk=false when every matched file is Markdown (or the list is empty).
+
+Always exits 0. Called by the 'Refine sdk — suppress markdown-only matches'
+step in pull_request.yaml and sdk-gate.yaml.
 """
 
 import json

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -26,7 +26,7 @@ jobs:
       #          test matrix. The .github/actions/* entries are the test
       #          harness itself (the unit/integration deps + docstring-coverage
       #          wrappers), so changing *how* those checks run still re-runs them.
-      sdk: ${{ steps.filter.outputs.sdk }}
+      sdk: ${{ steps.sdk-refine.outputs.sdk }}
       # 'scan' — wider net for the Trivy filesystem scan: every first-party
       #          source tree + the dependency lockfiles. Still short-circuits on
       #          pure docs/, .github-meta, and .security-only PRs.
@@ -39,6 +39,9 @@ jobs:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
+          # list-files: json is required so the sdk-refine step below can inspect
+          # which files actually matched and suppress markdown-only false positives.
+          list-files: json
           filters: |
             container:
               - 'Dockerfile'
@@ -51,10 +54,11 @@ jobs:
               - '.github/actions/unit-tests/**'
               - '.github/actions/setup-deps/**'
               - '.github/actions/docstring-coverage/**'
-              # Markdown-only changes never affect SDK behaviour. Listed LAST so
-              # paths-filter's gitignore-style last-match-wins excludes e.g.
-              # application_sdk/README.md while application_sdk/foo.py still runs.
-              - '!**/*.md'
+              # NOTE: do NOT add '!**/*.md' here. dorny/paths-filter passes '!'
+              # patterns straight to picomatch, which interprets '!**/*.md' as
+              # "match any file that is not a .md file" — a near-catch-all that
+              # makes sdk=true for every non-markdown change in the repo. Markdown
+              # exclusion is handled in the sdk-refine step below instead.
             scan:
               - 'application_sdk/**'
               - 'contract-toolkit/**'
@@ -62,6 +66,24 @@ jobs:
               - 'pyproject.toml'
               - 'uv.lock'
               - '.github/actions/trivy/**'
+
+      # paths-filter sdk=true is necessary but not sufficient: the broad
+      # application_sdk/** pattern also matches .md files, so a PR that only
+      # touches e.g. application_sdk/README.md would incorrectly trigger the
+      # docstring-coverage check and the SDK test matrix. Check whether ANY
+      # matched file is non-.md; if all matched files are .md, suppress sdk=false.
+      - name: Refine sdk — suppress markdown-only matches
+        id: sdk-refine
+        env:
+          SDK_RESULT: ${{ steps.filter.outputs.sdk }}
+          SDK_FILES: ${{ steps.filter.outputs.sdk_files }}
+        run: |
+          set -euo pipefail
+          if [[ "$SDK_RESULT" != "true" ]]; then
+            echo "sdk=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python3 .github/scripts/sdk_changes_non_md.py
 
   # Required status check — the JOB has no `if:` so it always runs and always
   # concludes. The real validation step is gated to PR (non-fork) events: the

--- a/.github/workflows/sdk-gate.yaml
+++ b/.github/workflows/sdk-gate.yaml
@@ -53,7 +53,7 @@ jobs:
     name: Detect Changes (SDK Gate)
     runs-on: ubuntu-latest
     outputs:
-      sdk: ${{ steps.filter.outputs.sdk }}
+      sdk: ${{ steps.sdk-refine.outputs.sdk }}
       toolkit: ${{ steps.filter.outputs.toolkit }}
       conformance: ${{ steps.filter.outputs.conformance }}
       conformance_pkg: ${{ steps.filter.outputs.conformance_pkg }}
@@ -93,6 +93,9 @@ jobs:
         id: filter
         if: steps.force.outputs.force_all != 'true'
         with:
+          # list-files: json is required so the sdk-refine step below can inspect
+          # which files actually matched and suppress markdown-only false positives.
+          list-files: json
           filters: |
             # Dependency routing (Renovate auto-bumps these lockfiles within
             # range pins): ROOT pyproject.toml / uv.lock are the SDK's own deps,
@@ -114,10 +117,12 @@ jobs:
               # gate would stay green because the area it governs never ran.
               - '.github/workflows/sdk-tests-reusable.yaml'
               - '.github/workflows/sdk-gate.yaml'
-              # Markdown-only changes never affect SDK behaviour. Listed LAST so
-              # paths-filter's last-match-wins excludes e.g.
-              # application_sdk/README.md while application_sdk/foo.py still runs.
-              - '!**/*.md'
+              # NOTE: do NOT add '!**/*.md' here. dorny/paths-filter passes '!'
+              # patterns straight to picomatch, which interprets '!**/*.md' as
+              # "match any file that is not a .md file" — a near-catch-all that
+              # makes sdk=true for every non-markdown change in the repo (e.g. all
+              # packages/conformance/**/*.py files). Markdown exclusion is handled
+              # in the sdk-refine step below instead.
             toolkit:
               - 'contract-toolkit/**'
               - 'application_sdk/contracts/**'
@@ -132,7 +137,9 @@ jobs:
             conformance:
               - '**/*.py'
               - '.github/**'
-              - '!**/*.md'
+              # NOTE: '!**/*.md' intentionally omitted — same picomatch catch-all
+              # issue as sdk above; neither **/*.py nor .github/** match .md files,
+              # so the exclusion is not needed and the pattern would be harmful.
             # The conformance PACKAGE itself (its source, pyproject.toml, uv.lock,
             # and own pytest tests). A Renovate bump to packages/conformance/uv.lock
             # re-runs the package's unit tests here — conformance-only, never SDK.
@@ -148,6 +155,29 @@ jobs:
             container:
               - 'Dockerfile'
               - 'entrypoint.sh'
+
+      # paths-filter sdk=true is necessary but not sufficient: the broad
+      # application_sdk/** pattern also matches .md files, so a PR that only
+      # touches e.g. application_sdk/README.md would incorrectly trigger the
+      # full SDK test matrix. Check whether ANY matched file is non-.md; if all
+      # matched files are .md, suppress sdk to false.
+      - name: Refine sdk — suppress markdown-only matches
+        id: sdk-refine
+        env:
+          SDK_RESULT: ${{ steps.filter.outputs.sdk }}
+          SDK_FILES: ${{ steps.filter.outputs.sdk_files }}
+          FORCE_ALL: ${{ steps.force.outputs.force_all }}
+        run: |
+          set -euo pipefail
+          if [[ "$FORCE_ALL" == "true" ]]; then
+            echo "sdk=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$SDK_RESULT" != "true" ]]; then
+            echo "sdk=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python3 .github/scripts/sdk_changes_non_md.py
 
   sdk-tests:
     name: SDK Tests


### PR DESCRIPTION
## Summary

- `dorny/paths-filter` passes `!` patterns directly to picomatch, which interprets `!**/*.md` as "match any file that is NOT a `.md` file" — a near-catch-all that made `sdk=true` for every non-markdown change in the repo, including all `packages/conformance/**/*.py` files (triggering the full SDK unit test matrix on every conformance PR)
- Replaces the broken negation with a post-filter step that reads the matched file list (`list-files: json`) and sets `sdk=false` when every matched file ends in `.md`
- Extracts the check into `.github/scripts/sdk_changes_non_md.py` rather than embedding it inline
- Also removes `!**/*.md` from the `conformance` filter in `sdk-gate.yaml` for the same reason (harmless there since `**/*.py` already covers the relevant files, but the pattern was an unintended catch-all)

## Behaviour

| PR touches | Before | After |
|---|---|---|
| `packages/conformance/**/*.py` only | `sdk=true` → full SDK test matrix runs ❌ | `sdk=false` → SDK tests skip ✅ |
| `application_sdk/README.md` only | `sdk=true` → full SDK test matrix runs ❌ | `sdk=false` → SDK tests skip ✅ |
| `application_sdk/foo.py` | `sdk=true` → SDK tests run ✅ | `sdk=true` → SDK tests run ✅ |

## Test plan

- [ ] Verify CI on this PR: only conformance + conformance-suite-tests should run (no SDK Tests jobs)
- [ ] After merge, verify a real SDK code PR still triggers `SDK Tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)