### PR TITLE
fix(storage): use artifacts/apps/ prefix for SDR preflight probe key

### DIFF
--- a/application_sdk/storage/preflight.py
+++ b/application_sdk/storage/preflight.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-_PREFLIGHT_PREFIX = "artifacts/.atlan-preflight"
+_PREFLIGHT_PREFIX = "artifacts/apps/.atlan-sdk-preflight"
 _PREFLIGHT_PAYLOAD = b"atlan-preflight"
 
 # Per-store probe timeout.  Keeps a blackholed endpoint from stalling boot
@@ -63,7 +63,9 @@ del _raw_timeout
 
 # Stable probe key reused across boots on the same host so that a principal
 # with put+head but no delete permission doesn't accumulate one orphaned
-# object per boot.
+# object per boot.  Must stay under ``artifacts/apps/`` (or another allowed
+# prefix) — the Kong s3proxy plugin enforces an upstream_path_prefixes
+# allowlist and rejects anything outside it with 403 code 1009.
 _PROBE_KEY = f"{_PREFLIGHT_PREFIX}/probe-{socket.gethostname()}"
 
 # Pre-compiled patterns for HTTP status codes.  Word-boundary anchors prevent


### PR DESCRIPTION
## Summary

- The SDR boot-time preflight probe was writing to `artifacts/.atlan-preflight/<hostname>`, which sits outside the Kong `s3proxy-signature-verification` plugin's `upstream_path_prefixes` allowlist (`artifacts/apps/`, `persistent-artifacts/`, `workflow_file_upload/`).
- Every SDR deployment (e2e and production) got a `403 code 1009 "Invalid Path"` on the probe PUT and aborted startup — a regression introduced in #2217.
- Fix: change `_PREFLIGHT_PREFIX` to `artifacts/apps/.atlan-sdk-preflight` so the probe key lands under the gateway-permitted subtree.

## Root cause

`atlanhq/kong-plugins` `s3proxy-signature-verification` enforces a fixed allowlist on `PUT /api/blobstorage/<bucket>/<key>`. The original prefix (`artifacts/.atlan-preflight/`) doesn't start with `artifacts/apps/`, so the proxy rejects it before the AWS signature check even runs.

## Test plan

- [ ] e2e full-DAG run passes (preflight probe completes, Temporal worker starts)
- [ ] Local SDR run with `ENABLE_ATLAN_UPLOAD=true` no longer fails at startup
- [ ] Existing preflight unit tests still pass (`uv run pytest tests/ -k preflight`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)