### PR TITLE
fix(observability): promote app_name to top-level log record field

### DIFF
--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -166,6 +166,13 @@ def _make_log_record_dict(message: Any) -> dict[str, Any]:
         "timestamp": message.record["time"].timestamp(),
         "level": message.record["level"].name,
         "logger_name": message.record["extra"].get("logger_name", ""),
+        # Promote app_name to a top-level key (like logger_name) so the
+        # objectstore json.gz sink carries it as a top-level field. The OTLP
+        # path flattens it via the resource attribute / extra map, but the
+        # objectstore-sink ingestion only lifts top-level keys — so without
+        # this, app_name (nested only under ``extra``) lands null on records
+        # ingested from the store sink (e.g. SDR worker logs).
+        "app_name": message.record["extra"].get("app_name", APPLICATION_NAME),
         "message": message.record["message"],
         "file": str(message.record["file"].path),
         "line": message.record["line"],

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -827,6 +827,56 @@ def test_log_record_model_extracts_nested_exception_type():
     )
 
 
+def test_log_record_promotes_app_name_to_top_level():
+    """``app_name`` must be a top-level key, not only nested under ``extra``.
+
+    The objectstore (json.gz) log sink serializes the record verbatim and its
+    ingestion lifts only top-level keys into columns. Without top-level
+    ``app_name`` it lands null for store-sink-ingested records (e.g. SDR worker
+    logs on customer infra, which have no remote OTLP collector). ``logger_name``
+    is promoted the same way."""
+    test_message = mock.MagicMock()
+    level_mock = mock.MagicMock()
+    level_mock.name = "INFO"
+    test_message.record = {
+        "time": datetime.now(),
+        "level": level_mock,
+        "extra": {"logger_name": "test_logger", "app_name": "oracle-app"},
+        "message": "extract",
+        "file": mock.MagicMock(path="worker.py"),
+        "line": 10,
+        "function": "run",
+        "exception": None,
+    }
+
+    model = _make_log_record_dict(test_message)
+    assert model["app_name"] == "oracle-app"
+
+
+def test_log_record_app_name_falls_back_to_application_name():
+    """When ``extra`` carries no ``app_name`` (e.g. a raw loguru record), the
+    top-level field falls back to the configured ``APPLICATION_NAME`` rather
+    than an empty string."""
+    from application_sdk.constants import APPLICATION_NAME
+
+    test_message = mock.MagicMock()
+    level_mock = mock.MagicMock()
+    level_mock.name = "INFO"
+    test_message.record = {
+        "time": datetime.now(),
+        "level": level_mock,
+        "extra": {"logger_name": "test_logger"},
+        "message": "no app_name in extra",
+        "file": mock.MagicMock(path="worker.py"),
+        "line": 10,
+        "function": "run",
+        "exception": None,
+    }
+
+    model = _make_log_record_dict(test_message)
+    assert model["app_name"] == APPLICATION_NAME
+
+
 def test_otel_stacktrace_in_attributes_not_body_from_loguru_record(
     logger_adapter: AtlanLoggerAdapter,
 ):


### PR DESCRIPTION
## Problem

`app_name` is `null` on `is_sdr=true` rows in the central lakehouse `observability.app_logs`, even though the worker records it.

Root cause is on the **store-sink path**, not log emission. `_make_log_record_dict` promotes only `logger_name` to a top-level key; `app_name` (and the other context fields) live nested under `extra{}`. The two sinks then diverge:

- **OTLP path** (atlan-infra apps): `_create_log_record` flattens `extra` into the OTel attribute map and the `LoggerProvider` resource carries `app.name`, so the collector → lakehouse maps it to a top-level column. ✅
- **Objectstore json.gz path** (SDR workers on customer infra, which have no reachable remote OTLP collector — `_has_remote_otlp_endpoint()` is false): the record is written verbatim with `orjson.dumps`, so `extra` stays nested, and the json.gz ingestion lifts only top-level keys → `app_name` is dropped. ❌

Confirmed against raw `sdr-logs/*.json.gz`: each record carries `extra.app_name` but no top-level `app_name`. Related to the OTLP-side fix in BLDX-1297 (`app_name=None` from the stdlib bridge); this is the store-sink counterpart.

## Change

Promote `app_name` to a top-level key in `_make_log_record_dict`, the same way `logger_name` already is, falling back to `APPLICATION_NAME` when absent from `extra`.

- The OTLP path is unaffected — it builds attributes from `extra`/resource and ignores unknown top-level keys.
- No backfill of already-ingested logs; this fixes records going forward.

## Tests

- `test_log_record_promotes_app_name_to_top_level` — top-level `app_name` reflects `extra.app_name`.
- `test_log_record_app_name_falls_back_to_application_name` — falls back to `APPLICATION_NAME` when `extra` has none.
- Full `tests/unit/observability/test_logger_adaptor.py` green (126 passed); pre-commit (ruff, ruff-format, isort, pyright) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)