### PR TITLE
ci(merge-queue): gate merge on connector tests via single required check

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -362,6 +362,64 @@ jobs:
           workflow: tests.yaml
           workflow-inputs: ${{ github.event_name == 'merge_group' && format('{{"application_sdk_ref":"{0}"}}', github.sha) || format('{{"application_sdk_ref":"{0}","run_e2e":"true","base_image_ref":"{1}"}}', github.event.pull_request.head.sha, needs.build-sdk-base-image.outputs.image) }}
 
+  # ── The single required check for the connector e2e area ────────────────────
+  # Always runs and always concludes, so branch protection / the merge queue can
+  # require exactly this one stable context instead of the matrix legs
+  # (whose names are label-driven: "Connector Tests (<repo>)"). Without this,
+  # the matrix legs are not required, so the merge queue (ALLGREEN) merges as
+  # soon as the OTHER required contexts (SDK Gate, Trivy, …) conclude — even
+  # while the connector legs are still running. This gate closes that window.
+  #
+  # Fail-closed, mirroring SDK Gate: connector-tests is skipped both legitimately
+  # (docs-only PR: sdk==false && container==false) AND on upstream failure
+  # (matrix-builder failed, or the e2e-path base build failed). A naive
+  # "skipped → pass" would go green when ZERO connector tests ran because an
+  # upstream job died. So we require changes + matrix-builder to have SUCCEEDED
+  # and build-sdk-base-image to be success|skipped (never failure) before
+  # treating a skipped connector-tests as the genuine docs-only skip.
+  connector-gate:
+    name: Connector Tests Gate
+    needs: [changes, matrix-builder, build-sdk-base-image, connector-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate connector e2e area
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          MATRIX_RESULT: ${{ needs.matrix-builder.result }}
+          BASE_IMAGE_RESULT: ${{ needs.build-sdk-base-image.result }}
+          CONNECTOR_RESULT: ${{ needs.connector-tests.result }}
+        run: |
+          set -euo pipefail
+          # Detection / matrix build have no path-skip — anything other than
+          # success means we cannot trust whether the connector legs ran. A
+          # connector-tests skip downstream of these would then be an
+          # upstream-failure skip, not the docs-only skip. Fail closed.
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "::error::Detect Changes did not succeed ($CHANGES_RESULT) — failing the gate closed."
+            exit 1
+          fi
+          if [[ "$MATRIX_RESULT" != "success" ]]; then
+            echo "::error::Build Test Matrix did not succeed ($MATRIX_RESULT) — failing the gate closed."
+            exit 1
+          fi
+          # build-sdk-base-image is legitimately skipped on merge_group and on
+          # non-e2e PRs; only a genuine build FAILURE must block (a base that
+          # won't build is the signal, per the connector-tests if: comment).
+          if [[ "$BASE_IMAGE_RESULT" != "success" && "$BASE_IMAGE_RESULT" != "skipped" ]]; then
+            echo "::error::Build SDK base image did not succeed ($BASE_IMAGE_RESULT) — failing the gate closed."
+            exit 1
+          fi
+          # With upstream proven healthy, a skipped connector-tests is the
+          # genuine docs-only skip (sdk==false && container==false) → pass.
+          if [[ "$CONNECTOR_RESULT" == "success" || "$CONNECTOR_RESULT" == "skipped" ]]; then
+            echo "✓ Connector Tests: $CONNECTOR_RESULT"
+            echo "Connector gate passed."
+          else
+            echo "::error::Connector Tests did not pass ($CONNECTOR_RESULT) — failing the gate."
+            exit 1
+          fi
+
   # (sdr-matrix-builder, sdr-e2e-apps, and e2e-full-mysql removed —
   # superseded by connector-tests + the 'e2e' label on tests.yaml)
 


### PR DESCRIPTION
## Problem

The merge queue (`grouping_strategy: ALLGREEN`) merges as soon as the **required** status checks conclude. The connector e2e matrix legs — `Connector Tests (<repo>)` — are **not** on the required list, so the queue merges as soon as the *other* required contexts (`SDK Gate`, `Trivy Code Scan`, etc.) go green, **even while the connector legs are still running**.

This was observed on a recent `merge_group` run: it merged with 2 of 3 connector legs still in progress.

The matrix legs can't simply be marked required:
- their names are **label-driven** (`Connector Tests (<repo>)`), so they're unstable, and
- the job legitimately **skips** on docs-only PRs — a skipped *required* check leaves the context pending forever and deadlocks the queue.

## Fix (this PR)

Add a single always-concluding aggregator job, **`Connector Tests Gate`**, that `needs:` the connector matrix and concludes only after every leg finishes. This mirrors the existing `SDK Gate` pattern and gives one stable context that can be marked required.

It is **fail-closed**. `connector-tests` is skipped both legitimately (docs-only: `sdk==false && container==false`) *and* on upstream failure (`matrix-builder` died, or the e2e-path base build failed). A naïve `skipped → pass` would go green when **zero** connector tests ran. So the gate first proves `changes` + `matrix-builder` succeeded and `build-sdk-base-image` did not fail, and only *then* treats a skipped `connector-tests` as the genuine docs-only skip.

### Behavior summary

| Event | connector-tests | Gate |
|---|---|---|
| Merge queue, code change | 3 legs run (gate waits) | ✅ all pass · ❌ any fail |
| Merge queue, docs-only | skipped (legit) | ✅ pass |
| PR without `e2e` label | skipped | ✅ pass (won't block normal PRs) |
| PR with `e2e` label, code change | legs run on PR base image | ✅ pass · ❌ fail |
| matrix-builder / changes / base-build fails | skipped (upstream) | ❌ FAIL (fail-closed) |

The gate job itself never skips (`if: always()`, no path filter), so it's safe to mark required — it always reports.

## ⚠️ Follow-up required — repo admin, NOT in this PR

This PR is **inert until** `Connector Tests Gate` is added to the required status checks on the `main` ruleset (`16702782`). The new job runs and reports, but the merge queue won't *wait* on it until it's required.

**Ordering matters — do this only AFTER this PR merges.** If the required check is added while this (or any) PR is still open, the check doesn't exist on those branches yet, never reports, and **every open PR blocks forever**. Correct sequence:

1. Merge this PR → the `Connector Tests Gate` job now exists on `main`.
2. Admin adds `Connector Tests Gate` to the `main` ruleset's required status checks.

### Tradeoff
Making this required couples every SDK merge to connector-repo health and adds their e2e latency to the queue (the ruleset's `check_response_timeout_minutes: 60` is already sized for this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)