### PR TITLE
fix(conformance): correct detect and test commands in remediate prose

### DIFF
--- a/packages/conformance/conformance/programs/functions/orthogonal-gate.prose.md
+++ b/packages/conformance/conformance/programs/functions/orthogonal-gate.prose.md
@@ -23,7 +23,7 @@ description: >
 Run the repository's standard test command from `scope`:
 
 ```sh
-uv run poe test 2>&1
+uv run coverage run -m pytest --import-mode=importlib --capture=no --log-cli-level=INFO tests/ -v 2>&1
 ```
 
 Capture exit code and the last 20 lines of combined output.  Return `passed =

--- a/packages/conformance/conformance/programs/functions/recheck-narrowest.prose.md
+++ b/packages/conformance/conformance/programs/functions/recheck-narrowest.prose.md
@@ -34,10 +34,10 @@ Derive the series letter from the first character of `rule_id`.
 uv run atlan-application-sdk-conformance detect \
   --repo <scope> \
   --series <series_letter> \
-  --output - 2>/dev/null
+  --output remediation/runs/recheck.sarif
 ```
 
-Parse the SARIF output.  Filter results to those whose
+Parse `remediation/runs/recheck.sarif`.  Filter results to those whose
 `locations[0].physicalLocation.artifactLocation.uri` matches `file`.
 
 `clear` is true when no result with `partialFingerprints["atlanConformance/v1"]


### PR DESCRIPTION
## Summary

- **`recheck-narrowest.prose.md`**: Replace `--output -` (stdout) with `--output remediation/runs/recheck.sarif`. The tool writes a human-readable summary line (`conformance (L-series): N findings found.`) to stdout alongside the SARIF JSON, making piped JSON parsing fail with a decode error on the first try.
- **`orthogonal-gate.prose.md`**: Replace `uv run poe test` (task doesn't exist) with the command CI actually uses: `uv run coverage run -m pytest --import-mode=importlib --capture=no --log-cli-level=INFO tests/ -v`. Source of truth: `.github/actions/unit-tests/action.yaml`.

## Test plan

- [ ] Run `/remediate` in a connector repo and confirm the recheck command runs without JSON parse errors on the first attempt
- [ ] Confirm the orthogonal gate invokes pytest directly rather than failing with a `poe` task-not-found error