### PR TITLE
ci: add CodeQL Advanced to renovate-auto-approve trigger list

### DIFF
--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -19,8 +19,11 @@ on:
     # (Trivy, commits, docstring). Conformance is retained for the push-to-main
     # baseline run (it no longer fires on PRs). Capability Manifest Check is
     # informational (see its own header) but included so we re-evaluate promptly
-    # if it is later added to the ruleset.
-    workflows: [SDK Gate, PR Checks, Conformance, Capability Manifest Check]
+    # if it is later added to the ruleset. CodeQL Advanced hosts the
+    # Pre-commit Checks job (a required status check) — without it, the
+    # auto-approve workflow never re-fires after Pre-commit Checks completes,
+    # leaving the PR permanently waiting for approval.
+    workflows: [SDK Gate, PR Checks, Conformance, Capability Manifest Check, CodeQL Advanced]
     types: [completed]
     # Limit to Renovate branches at trigger level — avoids spending a runner on
     # every workflow completion across the repo.


### PR DESCRIPTION
## Summary

- `Pre-commit Checks` is a job inside the `CodeQL Advanced` workflow, not `PR Checks`
- `renovate-auto-approve.yml` only watched `[SDK Gate, PR Checks, Conformance, Capability Manifest Check]` — `CodeQL Advanced` was missing
- Result: the auto-approve workflow never re-fired after `Pre-commit Checks` completed, so all Renovate dep-only PRs (e.g. #2243) were left waiting for approval even with every required check green

## Test plan

- [ ] Merge this PR
- [ ] Verify next Renovate lock-file-maintenance PR gets an atlan-ci approval automatically once all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)