### PR TITLE
chore(security): drop resolved pyo3 advisory from base allowlist

### DIFF
--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,20 +1,10 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Updated by SDK team. CODEOWNERS: SDK/security team only.",
   "_base_image": "application-sdk-main",
-  "_updated": "2026-06-13",
+  "_updated": "2026-06-19",
   "_renewal_note": "Expiry dates staggered by severity. CRITICAL: 15 days. HIGH: 30 days. Review before expiry. Enforced by .github/scripts/validate_allowlist.py via _expiry_policy below.",
   "_expiry_policy": {
     "CRITICAL": 15,
     "HIGH": 30
-  },
-  "GHSA-36hh-v3qg-5jq4": {
-    "package": "pyo3",
-    "severity": "HIGH",
-    "reason": "Transitive Rust CVE bundled inside temporalio's compiled bridge (temporalio/bridge/Cargo.lock -> pyo3 0.25.1); not a directly-pinnable Python dependency. No temporalio release ships the fix yet -- the latest, 1.28.0 (2026-06-04), still bundles pyo3 0.25.1, so no upgrade resolves it. The advisory is an out-of-bounds READ in PyO3's Iterator::nth / nth_back for PyList/PyTuple iterators, reachable only when Rust calls .nth(n) with an attacker-controlled large n on a Python list/tuple iterator -- a path internal to the Temporal SDK bridge that is not reachable from connector or workflow-input code. Re-evaluate and drop this entry when temporalio bumps pyo3 to >= 0.29.0.",
-    "expires": "2026-07-13",
-    "added_by": "hariharan.radhakrishnan@atlan.com",
-    "re_evaluation_trigger": "fix_released",
-    "fix_available_date": "",
-    "suppressed": false
   }
 }


### PR DESCRIPTION
## What

Removes the `GHSA-36hh-v3qg-5jq4` (pyo3, HIGH) suppression from `.security/base-allowlist.json`. This was the only entry in the allowlist; the file now retains just its metadata header.

## Why — the dependency upgrade resolves it

The entry's own documented exit criterion was: *"Re-evaluate and drop this entry when temporalio bumps pyo3 to >= 0.29.0"* (`re_evaluation_trigger: fix_released`). Every condition is now met:

- **Advisory is fixed in pyo3 0.29.0.** GHSA-36hh-v3qg-5jq4 (out-of-bounds read in PyO3's `Iterator::nth` / `nth_back`, introduced in 0.24.0, present through 0.28.x) is patched in **0.29.0**.
- **temporalio now ships the fix.** When the entry was written, the latest temporalio (1.28.0) still bundled the vulnerable pyo3 0.25.1. **temporalio 1.29.0** bumped its compiled bridge to pyo3 0.29.0 — confirmed from `temporalio/bridge/Cargo.lock` at tag 1.29.0, where `pyo3` and every `pyo3-*` crate are pinned to 0.29.0.
- **This repo already consumes it.** `uv.lock` resolves `temporalio==1.29.0`, so the vulnerable pyo3 is no longer present anywhere in the dependency tree.

The suppression is dead — the base image no longer contains the affected pyo3.

## Validation

- `python3 .github/scripts/validate_allowlist.py` → ✅ `Allowlist valid: 0 entries`
- `pre-commit run --files .security/base-allowlist.json` → passes
- Comments in `.github/workflows/daily-security-scan.yml` reference this GHSA id only as the motivating example for why the scan syncs `.venv` to surface vendored native lockfiles — that rationale remains valid and is intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)