### PR TITLE
ci: remove labeled/unlabeled triggers from capability manifest check

### DIFF
--- a/.github/workflows/capability-manifest-check.yaml
+++ b/.github/workflows/capability-manifest-check.yaml
@@ -26,17 +26,33 @@
 # status checks — leaving the check permanently pending and blocking the merge.
 # Running the job unconditionally ensures the conclusion is always "success" or
 # "failure", never the ambiguous "skipped".
+#
+# WHY labeled/unlabeled are NOT in the trigger types:
+# On bot PRs (Renovate, Dependabot), the auto-approve workflow adds labels
+# within milliseconds of the synchronize event from the commit push.  That
+# fires two pull_request events for the same SHA simultaneously, creating two
+# check runs with the same name.  cancel-in-progress then cancels one of them,
+# leaving a CANCELLED check run on the commit.  GitHub branch protection treats
+# ALL check runs for the required check name as part of the gate — a single
+# CANCELLED run blocks the merge permanently even though a SUCCESS run for the
+# same SHA also exists.  Labels have no bearing on whether the manifest has
+# drifted, so there is no value in re-running on label changes.
 
 name: Capability Manifest Check
 
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
   merge_group:
 
 # Cancel in-flight runs when the PR receives a new push, so we don't
 # post duplicate sticky comments or waste runner time on stale SHAs.
+# IMPORTANT: because GitHub branch protection evaluates ALL check runs for a
+# required check name on a given SHA (not just the latest), cancel-in-progress
+# must only fire when there is exactly one in-flight run (i.e. only one event
+# can trigger a run at a time).  The labeled/unlabeled types are excluded above
+# precisely to guarantee this — each push creates exactly one pull_request event.
 concurrency:
   group: capability-manifest-check-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- Removes `labeled` and `unlabeled` from the `capability-manifest-check.yaml` pull_request trigger types
- Documents the concurrency invariant to prevent the same mistake in the future

## Root cause

GitHub branch protection evaluates **all** check runs for a required check name on a given SHA — not just the most recently completed one. On Renovate/bot PRs, two events fire within milliseconds of each other for the same commit:

1. `synchronize` — from the commit push
2. `labeled` — from the auto-approve workflow adding a label at the same time

Both trigger the manifest check workflow for the same SHA, creating two check runs in the same concurrency group. `cancel-in-progress: true` cancels one, leaving a `CANCELLED` check run on the commit. The `CANCELLED` run poisons the required status check permanently — GitHub sees it alongside the `SUCCESS` run and fails the gate — stalling auto-merge and requiring a human to intervene.

Confirmed via `gh api` inspection of PR #2263: two check runs (`82427592863` = `cancelled`, `82427594442` = `success`) both present for SHA `490db80`. The `cancelled` one blocks the merge even though the `success` one completed afterwards.

## Fix

Labels have no bearing on whether the manifest has drifted. Removing `labeled` and `unlabeled` from the triggers ensures exactly one `pull_request` event fires per push, so the concurrency group can never contain more than one run — the race condition that produces the poisoned `CANCELLED` check run cannot occur.

## Test plan

- [ ] Merge this PR and observe that the next Renovate lock-file-maintenance PR auto-merges without a human needing to click anything
- [ ] Confirm that the "Capability Manifest Drift" check no longer appears as `cancelled` in the status check rollup on bot PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)