### PR TITLE
ci(monitoring): publish conformance SARIF summaries to S3 fleet dashboard (BLDX-1461)

### DIFF
--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -345,3 +345,229 @@ jobs:
           aws s3 cp /tmp/merged_history.jsonl "s3://kryptonite-store/${{ inputs.dashboard_path }}/${HISTORY_FILE}"
 
           echo "Dashboard updated at https://k.atlan.dev/${{ inputs.dashboard_path }}/"
+
+  conformance:
+    name: Update Conformance Dashboard
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.head_branch == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Discover latest Conformance run
+        id: discover
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # The workflow_run trigger fires on "Vulnerability Scan", not
+          # "Conformance". Conformance artifacts live in a separate run —
+          # discover the latest completed one on the default branch.
+          RUN_ID=$(gh run list \
+            --workflow="Conformance" \
+            --status=completed \
+            --branch="${{ github.event.repository.default_branch || 'main' }}" \
+            --limit=5 \
+            --json databaseId,conclusion \
+            --jq '[.[] | select(.conclusion=="success" or .conclusion=="failure")] | .[0].databaseId')
+
+          if [ -z "${RUN_ID:-}" ] || [ "$RUN_ID" = "null" ]; then
+            echo "::warning::No completed Conformance run found — skipping conformance dashboard update"
+            echo "has_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          COMMIT_SHA=$(gh run view "$RUN_ID" --json headSha  --jq '.headSha')
+          BRANCH=$(gh run view "$RUN_ID"     --json headBranch --jq '.headBranch')
+          echo "Conformance run: $RUN_ID  sha=$COMMIT_SHA  branch=$BRANCH"
+          echo "run_id=$RUN_ID"         >> "$GITHUB_OUTPUT"
+          echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH"         >> "$GITHUB_OUTPUT"
+          echo "has_run=true"           >> "$GITHUB_OUTPUT"
+
+      - name: Download SARIF artifacts
+        id: download
+        if: steps.discover.outputs.has_run == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ steps.discover.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/sarif
+          found=0
+          # All 7 series — download each separately so a missing slug
+          # (e.g. a repo scoped to sdk-only) doesn't fail the whole step.
+          for slug in ci error-handling prescriptions optimizations dependency logging tests; do
+            gh run download "$RUN_ID" \
+              --name "conformance-${slug}-sarif" \
+              --dir /tmp/sarif 2>/dev/null \
+              && found=$((found + 1)) || true
+          done
+          echo "Downloaded $found / 7 series SARIF artifacts"
+          if [ "$found" -eq 0 ]; then
+            echo "::warning::No SARIF artifacts found for run $RUN_ID (expired?) — skipping"
+            echo "has_artifacts=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_artifacts=true"  >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Parse SARIF and generate per-repo summary
+        if: steps.download.outputs.has_artifacts == 'true'
+        env:
+          CONFORMANCE_SHA: ${{ steps.discover.outputs.commit_sha }}
+          CONFORMANCE_BRANCH: ${{ steps.discover.outputs.branch }}
+        run: |
+          python3 - <<'PYEOF'
+          import glob, json, os
+          from datetime import datetime, timezone
+
+          repo_name   = os.environ.get("GITHUB_REPOSITORY", "unknown")
+          commit_sha  = os.environ.get("CONFORMANCE_SHA", "")
+          branch      = os.environ.get("CONFORMANCE_BRANCH", "")
+
+          tool_version   = "unknown"
+          profile_version = "v1"
+          rule_catalog: dict = {}
+          summary        = {"failing": 0, "warning": 0, "suppressing": 0}
+          by_rule: dict  = {}
+          excluded_paths: set  = set()
+          suppressions_list: list = []
+
+          for sarif_path in sorted(glob.glob("/tmp/sarif/*.sarif")):
+              try:
+                  with open(sarif_path) as f:
+                      sarif = json.load(f)
+              except (FileNotFoundError, json.JSONDecodeError) as e:
+                  print(f"Warning: skipping {sarif_path}: {e}")
+                  continue
+
+              for run in sarif.get("runs", []):
+                  driver = run.get("tool", {}).get("driver", {})
+                  if driver.get("version") and tool_version == "unknown":
+                      tool_version = driver["version"]
+
+                  # Build rule catalog from the embedded descriptors — carry
+                  # tier/category/series/since so connector-pulse never needs
+                  # to re-fetch the rule metadata separately.
+                  for rule in driver.get("rules", []):
+                      rid = rule.get("id")
+                      if rid and rid not in rule_catalog:
+                          props = rule.get("properties", {})
+                          rule_catalog[rid] = {
+                              "name":     rule.get("name", ""),
+                              "tier":     props.get("atlan/tier", ""),
+                              "category": props.get("atlan/category", ""),
+                              "series":   props.get("atlan/series", ""),
+                              "since":    props.get("atlan/since", ""),
+                              "helpUri":  rule.get("helpUri", ""),
+                          }
+
+                  # Run-level pre-computed summary (accurate counts from the suite).
+                  run_props = run.get("properties", {})
+                  run_sum   = run_props.get("atlan/summary", {})
+                  summary["failing"]    += run_sum.get("failing", 0)
+                  summary["warning"]    += run_sum.get("warning", 0)
+                  summary["suppressing"] += run_sum.get("suppressing", 0)
+                  excluded_paths.update(run_props.get("atlan/excludedPaths", []))
+                  if run_props.get("atlan/profileVersion"):
+                      profile_version = run_props["atlan/profileVersion"]
+
+                  # Per-result pass for byRule breakdown + suppression justifications.
+                  for result in run.get("results", []):
+                      rule_id = result.get("ruleId", "")
+                      if not rule_id or result.get("kind") == "pass":
+                          continue
+                      supps = result.get("suppressions") or []
+                      entry = by_rule.setdefault(rule_id, {"failing": 0, "suppressing": 0})
+                      if supps:
+                          entry["suppressing"] += 1
+                          for s in supps:
+                              just = s.get("justification", "").strip()
+                              if just:
+                                  suppressions_list.append({"ruleId": rule_id, "justification": just})
+                      else:
+                          entry["failing"] += 1
+
+          repo_slug = repo_name.replace("/", "_")
+          repo_data = {
+              "repo":          repo_name,
+              "collectedAt":   datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+              "commit":        commit_sha,
+              "branch":        branch,
+              "toolVersion":   tool_version,
+              "profileVersion": profile_version,
+              "summary":       summary,
+              "byRule":        by_rule,
+              "excludedPaths": sorted(excluded_paths),
+              "suppressions":  suppressions_list,
+              # Rule metadata carried so connector-pulse can build the fleet
+              # catalog without re-fetching any source; one authoritative copy
+              # per repo, consistent across all series SARIF files.
+              "ruleCatalog":   rule_catalog,
+          }
+
+          os.makedirs("/tmp/conformance-deploy/repos", exist_ok=True)
+          with open(f"/tmp/conformance-deploy/repos/{repo_slug}.json", "w") as f:
+              json.dump(repo_data, f, indent=2)
+
+          # Append-only history for trend tracking.
+          history_entry = {
+              "date":        datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+              "repo":        repo_name,
+              "toolVersion": tool_version,
+              "failing":     summary["failing"],
+              "warning":     summary["warning"],
+              "suppressing": summary["suppressing"],
+          }
+          with open(f"/tmp/conformance-deploy/history_{repo_slug}.jsonl", "a") as f:
+              f.write(json.dumps(history_entry) + "\n")
+
+          print(f"Conformance data for {repo_name}:")
+          print(f"  toolVersion:  {tool_version}")
+          print(f"  failing:      {summary['failing']}")
+          print(f"  warning:      {summary['warning']}")
+          print(f"  suppressing:  {summary['suppressing']}")
+          print(f"  rules active: {len(by_rule)}")
+          print(f"  suppressions: {len(suppressions_list)}")
+          PYEOF
+
+      - name: Setup AWS Credentials
+        if: steps.download.outputs.has_artifacts == 'true'
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6
+        with:
+          aws-region: ap-south-1
+          role-to-assume: arn:aws:iam::733936409301:role/kryptonite-store_FullAccess
+
+      - name: Deploy to Kryptonite (conformance)
+        if: steps.download.outputs.has_artifacts == 'true'
+        env:
+          REPO_SLUG: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          SLUG=$(echo "$REPO_SLUG" | tr '/' '_')
+          PREFIX="conformance-dashboard"
+
+          # Per-repo summary
+          aws s3 cp "/tmp/conformance-deploy/repos/${SLUG}.json" \
+            "s3://kryptonite-store/${PREFIX}/repos/${SLUG}.json"
+
+          # Regenerate manifest of all repo files present in S3
+          aws s3 ls "s3://kryptonite-store/${PREFIX}/repos/" \
+            | grep '\.json$' | awk '{print $4}' \
+            | python3 -c "import json,sys; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))" \
+            > /tmp/conformance-deploy/repos.json
+          aws s3 cp /tmp/conformance-deploy/repos.json \
+            "s3://kryptonite-store/${PREFIX}/repos.json"
+
+          # Append history (download existing → merge → re-upload, same as
+          # the Trivy history path above; sort -u deduplicates same-day reruns).
+          HISTORY_FILE="history/${SLUG}.jsonl"
+          aws s3 cp \
+            "s3://kryptonite-store/${PREFIX}/${HISTORY_FILE}" \
+            /tmp/existing_conformance_history.jsonl 2>/dev/null || true
+          cat /tmp/existing_conformance_history.jsonl \
+            "/tmp/conformance-deploy/history_${SLUG}.jsonl" 2>/dev/null \
+            | sort -u \
+            > /tmp/merged_conformance_history.jsonl
+          aws s3 cp /tmp/merged_conformance_history.jsonl \
+            "s3://kryptonite-store/${PREFIX}/${HISTORY_FILE}"
+
+          echo "Conformance dashboard updated: https://k.atlan.dev/${PREFIX}/"

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -362,15 +362,15 @@ jobs:
           # "Conformance". Conformance artifacts live in a separate run —
           # discover the latest completed one on the default branch.
           RUN_ID=$(gh run list \
-            --workflow="Conformance" \
+            --workflow=conformance.yaml \
             --status=completed \
             --branch="${{ github.event.repository.default_branch || 'main' }}" \
-            --limit=5 \
+            --limit=20 \
             --json databaseId,conclusion \
             --jq '[.[] | select(.conclusion=="success" or .conclusion=="failure")] | .[0].databaseId')
 
           if [ -z "${RUN_ID:-}" ] || [ "$RUN_ID" = "null" ]; then
-            echo "::warning::No completed Conformance run found — skipping conformance dashboard update"
+            echo "::warning::No completed (success/failure) Conformance run found in the last 20 runs — all recent runs may be cancelled; skipping conformance dashboard update"
             echo "has_run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -423,7 +423,7 @@ jobs:
           commit_sha  = os.environ.get("CONFORMANCE_SHA", "")
           branch      = os.environ.get("CONFORMANCE_BRANCH", "")
 
-          tool_version   = "unknown"
+          tool_versions: set  = set()
           profile_version = "v1"
           rule_catalog: dict = {}
           summary        = {"failing": 0, "warning": 0, "suppressing": 0}
@@ -441,8 +441,8 @@ jobs:
 
               for run in sarif.get("runs", []):
                   driver = run.get("tool", {}).get("driver", {})
-                  if driver.get("version") and tool_version == "unknown":
-                      tool_version = driver["version"]
+                  if driver.get("version"):
+                      tool_versions.add(driver["version"])
 
                   # Build rule catalog from the embedded descriptors — carry
                   # tier/category/series/since so connector-pulse never needs
@@ -485,6 +485,16 @@ jobs:
                                   suppressions_list.append({"ruleId": rule_id, "justification": just})
                       else:
                           entry["failing"] += 1
+
+          # Emit a single toolVersion when all series agree; surface the
+          # disagreement explicitly when they don't (partial publish, two
+          # artifacts from different runs) so connector-pulse can flag it.
+          if len(tool_versions) == 1:
+              tool_version = next(iter(tool_versions))
+          elif len(tool_versions) > 1:
+              tool_version = "skew:" + ",".join(sorted(tool_versions))
+          else:
+              tool_version = "unknown"
 
           repo_slug = repo_name.replace("/", "_")
           repo_data = {


### PR DESCRIPTION
## Summary

- Adds a `conformance` job to `.github/workflows/update-dashboard.yaml` alongside the existing Trivy job
- Self-discovers the latest Conformance CI run (separate from the Vulnerability Scan trigger), downloads all 7 SARIF series, parses them into a per-repo summary, and publishes to `s3://kryptonite-store/conformance-dashboard/`
- No new shim or bootstrap change — the `update-dashboard.yml` shim already deployed across all consumer repos calls this reusable workflow `@main`, so the new job propagates automatically

## What gets published per repo

Each push writes:
- `conformance-dashboard/repos/<owner>_<repo>.json` — per-repo summary (failing/warning/suppressing totals, per-rule breakdown, suppression justifications with text, excluded paths, embedded rule catalog)
- `conformance-dashboard/repos.json` — fleet manifest
- `conformance-dashboard/history/<owner>_<repo>.jsonl` — append-only daily history for trend tracking

The suppression justifications and per-rule counts survive here **intact** — unlike the GitHub Security tab upload (which strips suppressed results), this path preserves the full SARIF signal needed for fleet-wide mass-suppression detection.

## Downstream

The connector-pulse side (separate PR) reads this data via `k.atlan.dev/conformance-dashboard`, assembles a fleet rollup (per-rule prevalence, suppression rates, top justifications, tool-version distribution), and renders it as a dashboard alongside the existing Vulnerabilities page.

## Test plan

- [ ] `workflow_dispatch` `update-dashboard.yml` on one consumer repo; confirm `s3://kryptonite-store/conformance-dashboard/repos/<slug>.json` appears with expected shape and suppressions intact
- [ ] Confirm `repos.json` manifest is updated and `history/<slug>.jsonl` entry is appended
- [ ] Confirm the existing `update` (Trivy) job is unaffected — runs independently in parallel
- [ ] Confirm graceful skip when no completed Conformance run exists (`has_run=false` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)