### PR TITLE
feat(storage): dual-write App.upload artifacts to deployment + upstream stores (BLDX-1464)

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -897,8 +897,8 @@ class App(ABC):
         """
 
         from application_sdk.constants import (  # noqa: PLC0415 — import here to avoid module-level circular import (same pattern as normalize_key)
-            DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED,
-            ENABLE_DEPLOYMENT_ARTIFACT_MIRROR,
+            DEPLOYMENT_ARTIFACT_DUAL_WRITE_ENABLED,
+            DEPLOYMENT_ARTIFACT_DUAL_WRITE_REQUIRED,
         )
         from application_sdk.storage.ops import (  # noqa: PLC0415 — circular: app.base is imported by execution which imports storage
             normalize_key,
@@ -910,26 +910,16 @@ class App(ABC):
         deployment = self.context.storage
         upstream = self.context.upstream_storage
 
-        # Build the ordered list of upload targets.
-        #
-        # SDR (both stores distinct + mirror enabled): write deployment store
-        # (customer bucket) first, then upstream (Atlan) — matching the
-        # documented flow "object store → Atlan SaaS" (BLDX-1464).
-        # Non-SDR / mirror disabled: single target (upstream or deployment),
-        # preserving pre-BLDX-1464 behaviour.
-        #
-        # Each entry is (store, label, fatal) where fatal controls whether a
-        # failure defers-and-re-raises (True) or logs a WARNING and continues
-        # (False = best-effort).  A fatal failure is always deferred until all
-        # remaining targets have run so a copy lands somewhere.
+        # Build the ordered list of (store, label, fatal) upload targets.
+        # See ADR-0014 §"BLDX-1464 dual-write" for the full routing decision.
         if (
-            ENABLE_DEPLOYMENT_ARTIFACT_MIRROR
+            DEPLOYMENT_ARTIFACT_DUAL_WRITE_ENABLED
             and upstream is not None
             and deployment is not None
             and upstream is not deployment
         ):
             targets = [
-                (deployment, "deployment", DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED),
+                (deployment, "deployment", DEPLOYMENT_ARTIFACT_DUAL_WRITE_REQUIRED),
                 (upstream, "upstream", True),
             ]
         else:
@@ -945,15 +935,9 @@ class App(ABC):
             run_prefix=run_prefix, app_name=self._app_name
         )
 
-        # Derive the internal FileReference used for cross-store dedup and the
-        # deployment-store fallback (step 3).  When input.ref is set explicitly
-        # the caller already has a durable FileReference (e.g. from a @task
-        # output); otherwise derive it from local_path.
-        # normalize_key strips TEMPORARY_PATH to yield the canonical
-        # deployment-store key — the same key written by extract tasks.
-        # Guard: if normalize_key returns "" (local_path resolved to the store
-        # root), skip creating source_ref so we don't inadvertently query the
-        # entire store.
+        # Derive the FileReference for cross-store dedup / deployment-store fallback.
+        # normalize_key strips TEMPORARY_PATH → canonical deployment-store key.
+        # Guard: "" means local_path resolved to the store root — skip source_ref.
         _store_key = normalize_key(input.local_path) if input.local_path else ""
         source_ref = input.ref or (
             FileReference(local_path=input.local_path, storage_path=_store_key)
@@ -961,12 +945,17 @@ class App(ABC):
             else None
         )
 
-        # Fan-out upload: iterate targets in order, deferring required failures
-        # until all targets have been attempted so the last target (upstream)
-        # always runs and a copy lands somewhere even when a required write fails.
+        # Fan-out: iterate targets in order. Fatal failures are deferred until all
+        # remaining targets complete so the upstream write always runs and a copy
+        # lands somewhere. If both writes fail the deployment error is chained as
+        # __cause__ of the upstream error so neither traceback is lost.
         result: UploadOutput | None = None
         deferred_required_error: Exception | None = None
         for target_store, label, fatal in targets:
+            # When writing to the deployment store, it is already the source for the
+            # cross-store fallback — passing it as _source_store would add a redundant
+            # SHA-256 sidecar lookup against itself. Skip it in that case.
+            source_store = None if target_store is deployment else self.context.storage
             try:
                 out = await _upload(
                     input.local_path,
@@ -976,29 +965,43 @@ class App(ABC):
                     raise_on_empty=input.raise_on_empty,
                     store=target_store,
                     _source_ref=source_ref,
-                    _source_store=self.context.storage,
+                    _source_store=source_store,
                     _app_prefix=app_prefix,
                     _tier=input.tier,
                 )
             except Exception as exc:
-                _task_logger.warning(
-                    "Object-store upload to %s store failed for prefix %s%s",
-                    label,
-                    app_prefix,
-                    "; will fail run after remaining targets complete"
-                    if fatal
-                    else " (non-fatal); continuing to next target",
-                    exc_info=True,
-                )
                 if fatal:
+                    _task_logger.error(
+                        "Object-store upload to %s store failed for prefix %s; "
+                        "will fail run after remaining targets complete",
+                        label,
+                        app_prefix,
+                        exc_info=True,
+                    )
+                    if deferred_required_error is not None:
+                        # Both writes failed: chain the earlier error as __cause__ so
+                        # neither traceback is lost when the exception is surfaced.
+                        exc.__cause__ = deferred_required_error
                     deferred_required_error = exc
+                else:
+                    _task_logger.warning(
+                        "Object-store upload to %s store failed for prefix %s "
+                        "(non-fatal); continuing to next target",
+                        label,
+                        app_prefix,
+                        exc_info=True,
+                    )
                 continue
             result = out  # last successful write is authoritative (upstream in SDR)
 
         if deferred_required_error is not None:
             raise deferred_required_error
         if result is None:
-            raise ObjectStoreNotConfiguredError()
+            # Unreachable under current target-construction logic (the single-target
+            # branch is always fatal=True), but guards against future changes.
+            raise RuntimeError(
+                "App.upload fan-out captured no result — this is a programming error"
+            )
         return result
 
     @task(timeout_seconds=600, retry_max_attempts=3)

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -896,6 +896,10 @@ class App(ABC):
             # up.ref.file_count == number of files in the directory
         """
 
+        from application_sdk.constants import (  # noqa: PLC0415 — import here to avoid module-level circular import (same pattern as normalize_key)
+            DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED,
+            ENABLE_DEPLOYMENT_ARTIFACT_MIRROR,
+        )
         from application_sdk.storage.ops import (  # noqa: PLC0415 — circular: app.base is imported by execution which imports storage
             normalize_key,
         )
@@ -903,11 +907,39 @@ class App(ABC):
             upload as _upload,
         )
 
-        # Prefer the upstream store (SDR: Atlan's bucket for the extract→publish
-        # handoff); fall back to the deployment store (standard deployments).
-        store = self.context.upstream_storage or self.context.storage
-        if store is None:
-            raise ObjectStoreNotConfiguredError()
+        deployment = self.context.storage
+        upstream = self.context.upstream_storage
+
+        # Build the ordered list of upload targets.
+        #
+        # SDR (both stores distinct + mirror enabled): write deployment store
+        # (customer bucket) first, then upstream (Atlan) — matching the
+        # documented flow "object store → Atlan SaaS" (BLDX-1464).
+        # Non-SDR / mirror disabled: single target (upstream or deployment),
+        # preserving pre-BLDX-1464 behaviour.
+        #
+        # Each entry is (store, label, fatal) where fatal controls whether a
+        # failure defers-and-re-raises (True) or logs a WARNING and continues
+        # (False = best-effort).  A fatal failure is always deferred until all
+        # remaining targets have run so a copy lands somewhere.
+        if (
+            ENABLE_DEPLOYMENT_ARTIFACT_MIRROR
+            and upstream is not None
+            and deployment is not None
+            and upstream is not deployment
+        ):
+            targets = [
+                (deployment, "deployment", DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED),
+                (upstream, "upstream", True),
+            ]
+        else:
+            single = upstream or deployment
+            if single is None:
+                raise ObjectStoreNotConfiguredError()
+            targets = [
+                (single, "upstream" if single is upstream else "deployment", True)
+            ]
+
         run_prefix = f"artifacts/apps/{self._app_name}/workflows/{self.context.run_id}"
         app_prefix = input.tier.upload_prefix(
             run_prefix=run_prefix, app_name=self._app_name
@@ -929,18 +961,45 @@ class App(ABC):
             else None
         )
 
-        return await _upload(
-            input.local_path,
-            input.storage_path,
-            storage_subdir=input.storage_subdir,
-            skip_if_exists=input.skip_if_exists,
-            raise_on_empty=input.raise_on_empty,
-            store=store,
-            _source_ref=source_ref,
-            _source_store=self.context.storage,
-            _app_prefix=app_prefix,
-            _tier=input.tier,
-        )
+        # Fan-out upload: iterate targets in order, deferring required failures
+        # until all targets have been attempted so the last target (upstream)
+        # always runs and a copy lands somewhere even when a required write fails.
+        result: UploadOutput | None = None
+        deferred_required_error: Exception | None = None
+        for target_store, label, fatal in targets:
+            try:
+                out = await _upload(
+                    input.local_path,
+                    input.storage_path,
+                    storage_subdir=input.storage_subdir,
+                    skip_if_exists=input.skip_if_exists,
+                    raise_on_empty=input.raise_on_empty,
+                    store=target_store,
+                    _source_ref=source_ref,
+                    _source_store=self.context.storage,
+                    _app_prefix=app_prefix,
+                    _tier=input.tier,
+                )
+            except Exception as exc:
+                _task_logger.warning(
+                    "Object-store upload to %s store failed for prefix %s%s",
+                    label,
+                    app_prefix,
+                    "; will fail run after remaining targets complete"
+                    if fatal
+                    else " (non-fatal); continuing to next target",
+                    exc_info=True,
+                )
+                if fatal:
+                    deferred_required_error = exc
+                continue
+            result = out  # last successful write is authoritative (upstream in SDR)
+
+        if deferred_required_error is not None:
+            raise deferred_required_error
+        if result is None:
+            raise ObjectStoreNotConfiguredError()
+        return result
 
     @task(timeout_seconds=600, retry_max_attempts=3)
     async def download(

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -350,24 +350,34 @@ _HTTP_POOL_TIMEOUT_SECONDS = 30.0
 #: Whether to enable Atlan storage upload
 ENABLE_ATLAN_UPLOAD = os.getenv("ENABLE_ATLAN_UPLOAD", "false").lower() == "true"
 
-# Artifact mirror — BLDX-1464: retain a copy of every App.upload artifact in the
-# deployment (customer) object store as well as the upstream (Atlan) store when
-# both are configured (SDR deployments only; ignored when only one store exists).
+# Dual-write — BLDX-1464: when both stores are configured (SDR), App.upload writes
+# to the deployment (customer) store first, then to upstream (Atlan), at the same
+# run-scoped key.  See ADR-0014 §"BLDX-1464 rollout" for the write-count delta.
 #
-#: Write App.upload artifacts to the deployment (customer) bucket first, then to
-#: the upstream (Atlan) bucket, when both stores are configured.  Default: True.
-#: Set ``ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR=false`` to disable (upstream-only,
-#: pre-BLDX-1464 behaviour).
-ENABLE_DEPLOYMENT_ARTIFACT_MIRROR: bool = (
-    os.getenv("ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR", "true").lower() == "true"
+# ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE accepts three values:
+#   disabled    — upstream only; pre-BLDX-1464 behaviour.
+#   best_effort — dual-write; deployment failure logs ERROR and run succeeds.
+#   required    — dual-write; deployment failure logs ERROR, upstream still runs,
+#                 then the run fails (customer copy missing is surfaced).
+_DEPLOYMENT_ARTIFACT_DUAL_WRITE: str = os.getenv(
+    "ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE", "best_effort"
+).lower()
+#: True when dual-write is active (best_effort or required).
+DEPLOYMENT_ARTIFACT_DUAL_WRITE_ENABLED: bool = (
+    _DEPLOYMENT_ARTIFACT_DUAL_WRITE != "disabled"
 )
-#: When True, a failed deployment-bucket mirror write causes the run to fail
-#: (after the upstream write still completes, so a copy always lands somewhere).
-#: Default: False — deployment write is best-effort; a WARNING is logged and the
-#: run succeeds even if the customer-bucket copy could not be written.
-DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED: bool = (
-    os.getenv("ATLAN_DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED", "false").lower() == "true"
+#: True only when dual-write is required (a failed deployment write fails the run).
+DEPLOYMENT_ARTIFACT_DUAL_WRITE_REQUIRED: bool = (
+    _DEPLOYMENT_ARTIFACT_DUAL_WRITE == "required"
 )
+if DEPLOYMENT_ARTIFACT_DUAL_WRITE_ENABLED:
+    import logging as _logging  # stdlib: constants.py cannot import from observability
+
+    _logging.getLogger(__name__).info(
+        "BLDX-1464 dual-write active (ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE=%s): "
+        "App.upload writes to both deployment and upstream stores per run.",
+        _DEPLOYMENT_ARTIFACT_DUAL_WRITE,
+    )
 # Dapr Client Configuration
 #: Maximum gRPC message length in bytes for Dapr client.
 #:

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -352,11 +352,12 @@ ENABLE_ATLAN_UPLOAD = os.getenv("ENABLE_ATLAN_UPLOAD", "false").lower() == "true
 
 # Dual-write — BLDX-1464: when both stores are configured (SDR), App.upload writes
 # to the deployment (customer) store first, then to upstream (Atlan), at the same
-# run-scoped key.  See ADR-0014 §"BLDX-1464 rollout" for the write-count delta.
+# run-scoped key.  See ADR-0014 §"App.upload() — dual-write when both stores are
+# configured (BLDX-1464)" for the full rationale.
 #
 # ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE accepts three values:
 #   disabled    — upstream only; pre-BLDX-1464 behaviour.
-#   best_effort — dual-write; deployment failure logs ERROR and run succeeds.
+#   best_effort — dual-write; deployment failure logs WARNING and run succeeds.
 #   required    — dual-write; deployment failure logs ERROR, upstream still runs,
 #                 then the run fails (customer copy missing is surfaced).
 _DEPLOYMENT_ARTIFACT_DUAL_WRITE: str = os.getenv(

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -349,6 +349,25 @@ _HTTP_POOL_TIMEOUT_SECONDS = 30.0
 
 #: Whether to enable Atlan storage upload
 ENABLE_ATLAN_UPLOAD = os.getenv("ENABLE_ATLAN_UPLOAD", "false").lower() == "true"
+
+# Artifact mirror — BLDX-1464: retain a copy of every App.upload artifact in the
+# deployment (customer) object store as well as the upstream (Atlan) store when
+# both are configured (SDR deployments only; ignored when only one store exists).
+#
+#: Write App.upload artifacts to the deployment (customer) bucket first, then to
+#: the upstream (Atlan) bucket, when both stores are configured.  Default: True.
+#: Set ``ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR=false`` to disable (upstream-only,
+#: pre-BLDX-1464 behaviour).
+ENABLE_DEPLOYMENT_ARTIFACT_MIRROR: bool = (
+    os.getenv("ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR", "true").lower() == "true"
+)
+#: When True, a failed deployment-bucket mirror write causes the run to fail
+#: (after the upstream write still completes, so a copy always lands somewhere).
+#: Default: False — deployment write is best-effort; a WARNING is logged and the
+#: run succeeds even if the customer-bucket copy could not be written.
+DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED: bool = (
+    os.getenv("ATLAN_DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED", "false").lower() == "true"
+)
 # Dapr Client Configuration
 #: Maximum gRPC message length in bytes for Dapr client.
 #:

--- a/docs/adr/0014-two-store-storage-architecture.md
+++ b/docs/adr/0014-two-store-storage-architecture.md
@@ -69,18 +69,37 @@ and must not change:
   availability and access model, even for data that never needs to leave the
   deployment.
 
-### App.upload() — routes through upstream_storage when present
+### App.upload() — dual-write when both stores are configured (BLDX-1464)
 
-`App.upload()` uses `upstream_storage or storage`:
+In SDR deployments, `App.upload()` writes artifacts to **both** stores at the
+identical key/prefix — deployment (customer) store first, then upstream (Atlan) —
+matching the documented flow "extracted metadata is first written to configured
+storage … then transferred to Atlan SaaS":
 
-```python
-store = self.context.upstream_storage or self.context.storage
+```
+deployment store (objectstore)   ← written first; retained audit copy
+upstream store (atlan-objectstore) ← written second; authoritative handoff to publish app
 ```
 
-In SDR deployments `upstream_storage` is the `atlan-objectstore` S3 binding, so
-`App.upload()` routes to Atlan's bucket. In local dev and Atlan-hosted
-deployments `upstream_storage` is `None` and `App.upload()` falls back to the
-deployment store.
+The destination key is **identical** in both stores because it is derived purely
+from the tier, run prefix, and app name — not from the store itself (see
+`StorageTier.upload_prefix`, `storage/transfer._derive_target_key`). The
+returned `UploadOutput` reflects the upstream write; because keys are identical,
+the `FileReference` it carries is valid for reading from either store.
+
+Two flags control the behaviour (see `docs/configuration.md`, `## Storage`):
+
+| Flag (`ATLAN_*`) | Default | Meaning |
+|---|---|---|
+| `ENABLE_DEPLOYMENT_ARTIFACT_MIRROR` | `true` | Enable dual-write when both stores are configured. |
+| `DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED` | `false` | Make a failed deployment write fatal (after upstream still completes). |
+
+When `ENABLE_DEPLOYMENT_ARTIFACT_MIRROR=false`, or in non-SDR deployments where
+`upstream_storage` is `None`, `App.upload()` writes to a single store as before.
+
+The deployment-write failure is **never** allowed to suppress the upstream
+write — the upstream write (Atlan handoff) always runs even if the customer-bucket
+mirror failed, so a copy lands somewhere regardless.
 
 ### Connector responsibility
 
@@ -126,6 +145,10 @@ async def run(self, input: ExtractionInput) -> ExtractionOutput:
   `upstream_storage` is `None` and `App.upload()` silently falls back to the
   deployment store. Local dev and integration tests work without any special
   configuration.
+- **Retained audit copy (BLDX-1464).** In SDR deployments the customer's bucket
+  receives a mirror copy of every metadata artifact at the identical run-scoped
+  key (`artifacts/apps/{app}/workflows/{run_id}/…`). Customers can apply their
+  own lifecycle/rollover policies on this prefix to manage retention.
 
 ### Negative / Tradeoffs
 
@@ -154,8 +177,11 @@ async def run(self, input: ExtractionInput) -> ExtractionOutput:
 
 - `application_sdk.constants.DEPLOYMENT_OBJECT_STORE_NAME` — `"objectstore"`
 - `application_sdk.constants.UPSTREAM_OBJECT_STORE_NAME` — `"atlan-objectstore"`
-- `application_sdk.app.base.App.upload()` — routes through `upstream_storage or storage`
+- `application_sdk.constants.ENABLE_DEPLOYMENT_ARTIFACT_MIRROR` — dual-write flag (default `True`)
+- `application_sdk.constants.DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED` — fatal-mirror flag (default `False`)
+- `application_sdk.app.base.App.upload()` — dual-write fan-out (deployment first, upstream second)
 - `application_sdk.execution._temporal.activities` — interceptor persist step uses `infra.storage`
 - [ADR-0007: Apps as the Unit of Inter-App Coordination](0007-apps-as-coordination-unit.md)
 - [docs/concepts/file-reference.md](../concepts/file-reference.md)
 - [docs/concepts/storage.md](../concepts/storage.md)
+- [docs/configuration.md](../configuration.md) — `## Storage` table for env-var reference

--- a/docs/adr/0014-two-store-storage-architecture.md
+++ b/docs/adr/0014-two-store-storage-architecture.md
@@ -87,14 +87,15 @@ from the tier, run prefix, and app name — not from the store itself (see
 returned `UploadOutput` reflects the upstream write; because keys are identical,
 the `FileReference` it carries is valid for reading from either store.
 
-Two flags control the behaviour (see `docs/configuration.md`, `## Storage`):
+One tri-state flag controls the behaviour (see `docs/configuration.md`, `## Storage`):
 
-| Flag (`ATLAN_*`) | Default | Meaning |
-|---|---|---|
-| `ENABLE_DEPLOYMENT_ARTIFACT_MIRROR` | `true` | Enable dual-write when both stores are configured. |
-| `DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED` | `false` | Make a failed deployment write fatal (after upstream still completes). |
+| `ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE` | Meaning |
+|---|---|
+| `best_effort` (default) | Dual-write enabled; deployment failure logs `WARNING`, run succeeds. |
+| `required` | Dual-write enabled; deployment failure fails the run after upstream completes. |
+| `disabled` | Upstream-only write (pre-BLDX-1464 behaviour). |
 
-When `ENABLE_DEPLOYMENT_ARTIFACT_MIRROR=false`, or in non-SDR deployments where
+When `ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE=disabled`, or in non-SDR deployments where
 `upstream_storage` is `None`, `App.upload()` writes to a single store as before.
 
 The deployment-write failure is **never** allowed to suppress the upstream
@@ -177,8 +178,8 @@ async def run(self, input: ExtractionInput) -> ExtractionOutput:
 
 - `application_sdk.constants.DEPLOYMENT_OBJECT_STORE_NAME` — `"objectstore"`
 - `application_sdk.constants.UPSTREAM_OBJECT_STORE_NAME` — `"atlan-objectstore"`
-- `application_sdk.constants.ENABLE_DEPLOYMENT_ARTIFACT_MIRROR` — dual-write flag (default `True`)
-- `application_sdk.constants.DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED` — fatal-mirror flag (default `False`)
+- `application_sdk.constants.DEPLOYMENT_ARTIFACT_DUAL_WRITE_ENABLED` — `True` when dual-write is active
+- `application_sdk.constants.DEPLOYMENT_ARTIFACT_DUAL_WRITE_REQUIRED` — `True` when a deployment failure is fatal
 - `application_sdk.app.base.App.upload()` — dual-write fan-out (deployment first, upstream second)
 - `application_sdk.execution._temporal.activities` — interceptor persist step uses `infra.storage`
 - [ADR-0007: Apps as the Unit of Inter-App Coordination](0007-apps-as-coordination-unit.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,6 +150,8 @@ Used by `RedisCapacityPool` for distributed slot locking. Leave empty if you use
 |----------|---------|-------------|
 | `ATLAN_MAX_CONCURRENT_STORAGE_TRANSFERS` | `4` | Maximum concurrent object-store uploads/downloads. |
 | `ENABLE_ATLAN_UPLOAD` | `false` | Enable uploading processed artifacts to the Atlan platform object store. |
+| `ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR` | `true` | Mirror every `App.upload` artifact to the deployment (customer) object store in addition to the upstream (Atlan) store, when both stores are configured (SDR only). Set to `false` to restore single-target (upstream-only) behaviour. |
+| `ATLAN_DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED` | `false` | When `true`, a failed deployment-bucket mirror write causes the run to fail after the upstream write completes (a copy is guaranteed somewhere). When `false` (default) the deployment write is best-effort: failures are logged as `WARNING` and the run succeeds. Only meaningful when `ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR=true`. |
 | `SSL_CERT_DIR` | _(empty)_ | Directory of custom CA certificates (`.pem`, `.crt`, `.cer`, `.ca-bundle`). Used by `httpx` and `aiohttp` clients when set. |
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,8 +150,7 @@ Used by `RedisCapacityPool` for distributed slot locking. Leave empty if you use
 |----------|---------|-------------|
 | `ATLAN_MAX_CONCURRENT_STORAGE_TRANSFERS` | `4` | Maximum concurrent object-store uploads/downloads. |
 | `ENABLE_ATLAN_UPLOAD` | `false` | Enable uploading processed artifacts to the Atlan platform object store. |
-| `ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR` | `true` | Mirror every `App.upload` artifact to the deployment (customer) object store in addition to the upstream (Atlan) store, when both stores are configured (SDR only). Set to `false` to restore single-target (upstream-only) behaviour. |
-| `ATLAN_DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED` | `false` | When `true`, a failed deployment-bucket mirror write causes the run to fail after the upstream write completes (a copy is guaranteed somewhere). When `false` (default) the deployment write is best-effort: failures are logged as `WARNING` and the run succeeds. Only meaningful when `ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR=true`. |
+| `ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE` | `best_effort` | Controls dual-write behaviour when both stores are configured (SDR only). `best_effort` (default): artifact is written to the deployment (customer) store and the upstream (Atlan) store; a deployment-write failure logs a `WARNING` and the run continues. `required`: same dual-write, but a deployment-write failure causes the run to fail after the upstream write completes (a copy is guaranteed somewhere). `disabled`: upstream-only write (pre-BLDX-1464 behaviour). |
 | `SSL_CERT_DIR` | _(empty)_ | Directory of custom CA certificates (`.pem`, `.crt`, `.cer`, `.ca-bundle`). Used by `httpx` and `aiohttp` clients when set. |
 
 ---

--- a/tests/integration/test_app_upload_routing.py
+++ b/tests/integration/test_app_upload_routing.py
@@ -2,14 +2,15 @@
 
 Invariants:
 
-(a) App.upload() dual-writes to BOTH stores when both are configured and mirror
+(a) App.upload() dual-writes to BOTH stores when both are configured and dual-write
     is enabled (BLDX-1464 default).  The file lands in deployment first, then in
     upstream, at the **identical key**.  The returned ref reflects the upstream
     (authoritative) write.
-(a2) Mirror disabled (ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR=false) → upstream
+(a2) Dual-write disabled (ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE=disabled) → upstream
     only (pre-BLDX-1464 behaviour).
 (a3) Same-store guard (upstream is deployment object) → single write, no double.
 (b) App.upload() falls back to storage when upstream_storage is None.
+(b2) Both stores None → ObjectStoreNotConfiguredError raised immediately.
 (c) persist_file_reference always writes to the deployment store, never upstream.
 
 New invariants added for BLDX-1377 (FileReference / cross-pod safety):
@@ -24,12 +25,12 @@ New invariants added for BLDX-1377 (FileReference / cross-pod safety):
     StorageError raised (prevents accidental full-store queries).
 (h) UploadInput.ref is symmetric with DownloadInput.ref.
 
-New invariants added for BLDX-1464 (artifact mirror):
+New invariants added for BLDX-1464 (artifact dual-write):
 
-(i_fail_soft) Deployment write fails + best-effort (default) → WARNING logged,
+(i_fail_soft) Deployment write fails + best_effort mode → ERROR logged,
     upstream still written, run succeeds.
-(i_fail_hard) Deployment write fails + DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED=true
-    → upstream still written first, then run fails.
+(i_fail_hard) Deployment write fails + required mode → upstream still written
+    first, then run fails with the deployment exception.
 
 See:
   docs/concepts/file-reference.md   (decision matrix and lifecycle)
@@ -38,10 +39,12 @@ See:
 
 from __future__ import annotations
 
+import hashlib
 from typing import ClassVar
 
 import pytest
 
+import application_sdk.constants as _constants
 from application_sdk.app import App
 from application_sdk.app.context import AppContext
 from application_sdk.contracts.storage import UploadInput
@@ -79,26 +82,73 @@ def _make_app(
 
 
 # ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def dual_write_enabled(monkeypatch):
+    """Enable dual-write in best_effort mode (the default)."""
+    monkeypatch.setattr(_constants, "DEPLOYMENT_ARTIFACT_DUAL_WRITE_ENABLED", True)
+    monkeypatch.setattr(_constants, "DEPLOYMENT_ARTIFACT_DUAL_WRITE_REQUIRED", False)
+
+
+@pytest.fixture()
+def dual_write_disabled(monkeypatch):
+    """Disable dual-write (upstream-only, pre-BLDX-1464 behaviour)."""
+    monkeypatch.setattr(_constants, "DEPLOYMENT_ARTIFACT_DUAL_WRITE_ENABLED", False)
+    monkeypatch.setattr(_constants, "DEPLOYMENT_ARTIFACT_DUAL_WRITE_REQUIRED", False)
+
+
+@pytest.fixture()
+def dual_write_required(monkeypatch):
+    """Enable dual-write in required mode (a deployment failure fails the run)."""
+    monkeypatch.setattr(_constants, "DEPLOYMENT_ARTIFACT_DUAL_WRITE_ENABLED", True)
+    monkeypatch.setattr(_constants, "DEPLOYMENT_ARTIFACT_DUAL_WRITE_REQUIRED", True)
+
+
+class _DeploymentWriteError(RuntimeError):
+    """Sentinel: injected to simulate a deployment-store write failure.
+
+    Using a distinct type lets tests pin pytest.raises() precisely and avoids
+    masking unrelated errors (ObjectStoreNotConfiguredError, AttributeError, etc.).
+    """
+
+
+def _inject_deployment_failure(deployment_store, monkeypatch):
+    """Monkeypatch storage.transfer.upload so the deployment-store call raises
+    _DeploymentWriteError while the upstream call runs the real implementation.
+
+    Works regardless of the process UID (unlike chmod 0o555 which is ignored
+    by root and in most CI container runtimes).
+    """
+    import application_sdk.storage.transfer as _transfer_mod
+
+    _real_upload = _transfer_mod.upload  # capture before patching
+
+    async def _patched(*args, store, **kwargs):
+        if store is deployment_store:
+            raise _DeploymentWriteError("injected deployment write failure")
+        return await _real_upload(*args, store=store, **kwargs)
+
+    monkeypatch.setattr(_transfer_mod, "upload", _patched)
+
+
+# ---------------------------------------------------------------------------
 # (a) App.upload() dual-writes to BOTH stores when both are configured (BLDX-1464)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
-async def test_app_upload_dual_writes_when_both_stores_present(tmp_path, monkeypatch):
+async def test_app_upload_dual_writes_when_both_stores_present(
+    tmp_path, dual_write_enabled
+):
     """App.upload() must write to BOTH stores at the identical key when both are configured.
 
-    BLDX-1464: the deployment (customer) bucket receives a mirror copy alongside
+    BLDX-1464: the deployment (customer) bucket receives a copy alongside
     the upstream (Atlan) bucket.  The returned ref reflects the upstream write;
     because keys are identical the ref is valid for reading from either store.
     """
-    monkeypatch.setenv("ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR", "true")
-    # Re-read the constant so the env-var is picked up for this process.
-    import importlib
-
-    import application_sdk.constants as _c
-
-    importlib.reload(_c)
-
     deployment_root = tmp_path / "deployment"
     upstream_root = tmp_path / "upstream"
     deployment_store = create_local_store(deployment_root)
@@ -129,7 +179,7 @@ async def test_app_upload_dual_writes_when_both_stores_present(tmp_path, monkeyp
     # IDENTICAL key — this is the BLDX-1464 guarantee.
     deployment_keys = _non_sidecar(await list_keys("", store=deployment_store))
     assert any(storage_path in key or key in storage_path for key in deployment_keys), (
-        f"App.upload() did not write the mirror copy to deployment store. "
+        f"App.upload() did not write the dual-write copy to deployment store. "
         f"Expected key containing '{storage_path}' in deployment, found: {deployment_keys}"
     )
 
@@ -147,23 +197,18 @@ async def test_app_upload_dual_writes_when_both_stores_present(tmp_path, monkeyp
 
 
 # ---------------------------------------------------------------------------
-# (a2) Mirror disabled → upstream only
+# (a2) Dual-write disabled → upstream only
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
-async def test_app_upload_mirror_disabled_writes_upstream_only(tmp_path, monkeypatch):
-    """When ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR=false, upload goes to upstream only.
+async def test_app_upload_dual_write_disabled_writes_upstream_only(
+    tmp_path, dual_write_disabled
+):
+    """When ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE=disabled, upload goes to upstream only.
 
     This preserves pre-BLDX-1464 behaviour for operators who opt out.
     """
-    monkeypatch.setenv("ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR", "false")
-    import importlib
-
-    import application_sdk.constants as _c
-
-    importlib.reload(_c)
-
     deployment_root = tmp_path / "deployment"
     upstream_root = tmp_path / "upstream"
     deployment_store = create_local_store(deployment_root)
@@ -188,9 +233,9 @@ async def test_app_upload_mirror_disabled_writes_upstream_only(tmp_path, monkeyp
     ]
     assert any(
         storage_path in key or key in storage_path for key in upstream_keys
-    ), f"File not in upstream when mirror disabled. upstream_keys={upstream_keys}"
+    ), f"File not in upstream when dual-write disabled. upstream_keys={upstream_keys}"
 
-    # File must NOT be in deployment store when mirror is disabled.
+    # File must NOT be in deployment store when dual-write is disabled.
     deployment_keys = [
         k
         for k in await list_keys("", store=deployment_store)
@@ -199,7 +244,7 @@ async def test_app_upload_mirror_disabled_writes_upstream_only(tmp_path, monkeyp
     assert not any(
         storage_path in key or key in storage_path for key in deployment_keys
     ), (
-        f"App.upload() wrote to deployment store when mirror was disabled. "
+        f"App.upload() wrote to deployment store when dual-write was disabled. "
         f"deployment_keys={deployment_keys}"
     )
 
@@ -210,19 +255,14 @@ async def test_app_upload_mirror_disabled_writes_upstream_only(tmp_path, monkeyp
 
 
 @pytest.mark.integration
-async def test_app_upload_same_store_guard_prevents_double_write(tmp_path, monkeypatch):
+async def test_app_upload_same_store_guard_prevents_double_write(
+    tmp_path, dual_write_enabled
+):
     """When upstream_storage is the same object as storage, only one write occurs.
 
     The identity guard (``upstream is not deployment``) prevents the SDK from
     uploading the file twice to the same store.
     """
-    monkeypatch.setenv("ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR", "true")
-    import importlib
-
-    import application_sdk.constants as _c
-
-    importlib.reload(_c)
-
     store = create_local_store(tmp_path / "store")
 
     src = tmp_path / "artifact.jsonl"
@@ -284,6 +324,24 @@ async def test_app_upload_falls_back_when_upstream_none(tmp_path):
 
     assert result.ref.is_durable
     assert result.ref.file_count is not None and result.ref.file_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# (b2) Both stores None → ObjectStoreNotConfiguredError raised immediately
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_upload_raises_when_no_stores_configured(tmp_path):
+    """When both storage and upstream_storage are None, ObjectStoreNotConfiguredError
+    must be raised at target-list construction time, before any upload is attempted.
+    """
+    from application_sdk.app.base_errors import ObjectStoreNotConfiguredError
+
+    app = _make_app(None, upstream_store=None)  # type: ignore[arg-type]
+
+    with pytest.raises(ObjectStoreNotConfiguredError):
+        await app.upload(UploadInput(local_path=str(tmp_path / "x.jsonl")))
 
 
 # ---------------------------------------------------------------------------
@@ -362,6 +420,7 @@ async def test_app_upload_falls_back_to_deployment_store_when_local_absent(tmp_p
     so existing call sites get the fallback for free on the next SDK bump.
     """
     from application_sdk.storage.ops import normalize_key, upload_file
+    from application_sdk.storage.transfer import _put_remote_sha256
 
     deployment_root = tmp_path / "deployment"
     upstream_root = tmp_path / "upstream"
@@ -376,11 +435,6 @@ async def test_app_upload_falls_back_to_deployment_store_when_local_absent(tmp_p
     # (mirrors what the task interceptor / upload_file writes under the hood).
     deploy_key = normalize_key(str(local_src))
     await upload_file(deploy_key, local_src, deployment_store, normalize=False)
-
-    # Write the SHA-256 sidecar that the interceptor would have created.
-    import hashlib
-
-    from application_sdk.storage.transfer import _put_remote_sha256
 
     digest = hashlib.sha256(content).hexdigest()
     await _put_remote_sha256(deployment_store, deploy_key, digest)
@@ -422,13 +476,14 @@ async def test_app_upload_ref_uses_storage_path_as_source_key(tmp_path):
     Verifies that passing an explicit FileReference (e.g. from a task output)
     correctly routes the fallback to ref.storage_path in the deployment store.
     """
+    from application_sdk.storage.ops import upload_file
+
     deployment_root = tmp_path / "deployment"
     upstream_root = tmp_path / "upstream"
     deployment_store = create_local_store(deployment_root)
     upstream_store = create_local_store(upstream_root)
 
     content = b'{"schema": "public"}\n'
-    from application_sdk.storage.ops import upload_file
 
     deploy_key = "artifacts/apps/test-app/workflows/run-ref/schema.jsonl"
     src_file = tmp_path / "schema.jsonl"
@@ -465,21 +520,20 @@ async def test_app_upload_cross_store_sha256_match_causes_skip(tmp_path):
     deployment-store sidecar already matches the upstream sidecar the SDK
     must return synced=False without transferring any bytes.
     """
+    from application_sdk.storage.ops import upload_file
+    from application_sdk.storage.transfer import _put_remote_sha256
+
     deployment_root = tmp_path / "deployment"
     upstream_root = tmp_path / "upstream"
     deployment_store = create_local_store(deployment_root)
     upstream_store = create_local_store(upstream_root)
 
     content = b'{"table": "orders"}\n'
-    from application_sdk.storage.ops import upload_file
 
     deploy_key = "artifacts/apps/test-app/workflows/run-dedup/tables.jsonl"
     src_file = tmp_path / "tables.jsonl"
     src_file.write_bytes(content)
     await upload_file(deploy_key, src_file, deployment_store, normalize=False)
-    import hashlib
-
-    from application_sdk.storage.transfer import _put_remote_sha256
 
     digest = hashlib.sha256(content).hexdigest()
     await _put_remote_sha256(deployment_store, deploy_key, digest)
@@ -565,53 +619,39 @@ async def test_app_upload_blocks_sensitive_path_when_local_absent(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# (i_fail_soft) Deployment mirror fails + best-effort → WARNING, upstream succeeds
+# (i_fail_soft) Deployment write fails + best_effort → ERROR logged, upstream ok
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
-async def test_app_upload_mirror_failure_best_effort(tmp_path, monkeypatch):
-    """When the deployment-bucket mirror write fails, a WARNING is logged and the
-    run continues.  The upstream write must still succeed and the returned
+async def test_app_upload_dual_write_failure_best_effort(
+    tmp_path, monkeypatch, dual_write_enabled
+):
+    """When the deployment-bucket write fails in best_effort mode, an ERROR is logged
+    and the run continues.  The upstream write must still succeed and the returned
     UploadOutput must reflect the upstream copy.
 
-    Invariant: ATLAN_DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED=false (default)
-    → a failed deployment write is non-fatal.
+    Failure is injected deterministically via monkeypatch — avoids the chmod 0o555
+    approach which silently degenerates to a pass when running as root.
     """
-    import importlib
-
-    import application_sdk.constants as _c
-
-    monkeypatch.setenv("ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR", "true")
-    monkeypatch.setenv("ATLAN_DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED", "false")
-    importlib.reload(_c)
-
     upstream_root = tmp_path / "upstream"
     upstream_store = create_local_store(upstream_root)
+    deployment_store = create_local_store(tmp_path / "deployment")
 
-    # Use a read-only deployment store path to force a write failure.
-    import os
-
-    readonly_root = tmp_path / "readonly"
-    readonly_root.mkdir(mode=0o555)
-    deployment_store = create_local_store(readonly_root)
+    _inject_deployment_failure(deployment_store, monkeypatch)
 
     src = tmp_path / "artifact.jsonl"
     src.write_text('{"name": "test-entity"}\n')
 
     app = _make_app(deployment_store, upstream_store=upstream_store)
 
-    # The upload must succeed (non-fatal deployment failure).
+    # Upload must succeed (non-fatal deployment failure in best_effort mode).
     result = await app.upload(
         UploadInput(local_path=str(src), tier=StorageTier.RETAINED)
     )
 
-    # Restore permissions so tmp_path cleanup can remove the directory.
-    readonly_root.chmod(0o755)
-
     assert result.ref.storage_path is not None
 
-    # The upstream copy must exist.
     upstream_keys = [
         k
         for k in await list_keys("", store=upstream_store)
@@ -622,48 +662,33 @@ async def test_app_upload_mirror_failure_best_effort(tmp_path, monkeypatch):
         f"upstream_keys={upstream_keys}"
     )
 
-    # Restore so cleanup can proceed.
-    os.chmod(readonly_root, 0o755)
-
 
 # ---------------------------------------------------------------------------
-# (i_fail_hard) Deployment mirror fails + required → upstream writes, then raises
+# (i_fail_hard) Deployment write fails + required → upstream writes, then raises
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
-async def test_app_upload_mirror_failure_required_raises_after_upstream(
-    tmp_path, monkeypatch
+async def test_app_upload_dual_write_failure_required_raises_after_upstream(
+    tmp_path, monkeypatch, dual_write_required
 ):
-    """When ATLAN_DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED=true and the deployment
+    """When ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE=required and the deployment
     write fails, the upstream write must still complete before the exception is
     raised — ensuring a copy always lands somewhere.
     """
-    import importlib
-
-    import application_sdk.constants as _c
-
-    monkeypatch.setenv("ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR", "true")
-    monkeypatch.setenv("ATLAN_DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED", "true")
-    importlib.reload(_c)
-
     upstream_root = tmp_path / "upstream"
     upstream_store = create_local_store(upstream_root)
+    deployment_store = create_local_store(tmp_path / "deployment")
 
-    readonly_root = tmp_path / "readonly"
-    readonly_root.mkdir(mode=0o555)
-    deployment_store = create_local_store(readonly_root)
+    _inject_deployment_failure(deployment_store, monkeypatch)
 
     src = tmp_path / "artifact.jsonl"
     src.write_text('{"name": "test-entity"}\n')
 
     app = _make_app(deployment_store, upstream_store=upstream_store)
 
-    with pytest.raises(Exception):
+    with pytest.raises(_DeploymentWriteError):
         await app.upload(UploadInput(local_path=str(src), tier=StorageTier.RETAINED))
-
-    # Restore permissions before asserting so cleanup works even on failure.
-    readonly_root.chmod(0o755)
 
     # The upstream write must have completed before the raise — a copy exists.
     upstream_keys = [
@@ -672,6 +697,6 @@ async def test_app_upload_mirror_failure_required_raises_after_upstream(
         if not k.endswith(".sha256")
     ]
     assert upstream_keys, (
-        f"Upstream write did not complete before the required-mirror exception. "
+        f"Upstream write did not complete before the required-mode exception. "
         f"upstream_keys={upstream_keys}"
     )

--- a/tests/integration/test_app_upload_routing.py
+++ b/tests/integration/test_app_upload_routing.py
@@ -1,8 +1,14 @@
 """Integration tests pinning two-store routing for App.upload() (ADR-0014).
 
-Three existing invariants:
+Invariants:
 
-(a) App.upload() routes to upstream_storage when an upstream store is wired.
+(a) App.upload() dual-writes to BOTH stores when both are configured and mirror
+    is enabled (BLDX-1464 default).  The file lands in deployment first, then in
+    upstream, at the **identical key**.  The returned ref reflects the upstream
+    (authoritative) write.
+(a2) Mirror disabled (ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR=false) → upstream
+    only (pre-BLDX-1464 behaviour).
+(a3) Same-store guard (upstream is deployment object) → single write, no double.
 (b) App.upload() falls back to storage when upstream_storage is None.
 (c) persist_file_reference always writes to the deployment store, never upstream.
 
@@ -17,6 +23,13 @@ New invariants added for BLDX-1377 (FileReference / cross-pod safety):
 (g) normalize_key(local_path) == "" guard: no fallback attempted, existing
     StorageError raised (prevents accidental full-store queries).
 (h) UploadInput.ref is symmetric with DownloadInput.ref.
+
+New invariants added for BLDX-1464 (artifact mirror):
+
+(i_fail_soft) Deployment write fails + best-effort (default) → WARNING logged,
+    upstream still written, run succeeds.
+(i_fail_hard) Deployment write fails + DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED=true
+    → upstream still written first, then run fails.
 
 See:
   docs/concepts/file-reference.md   (decision matrix and lifecycle)
@@ -66,18 +79,26 @@ def _make_app(
 
 
 # ---------------------------------------------------------------------------
-# (a) App.upload() routes to upstream_storage when present
+# (a) App.upload() dual-writes to BOTH stores when both are configured (BLDX-1464)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
-async def test_app_upload_routes_to_upstream_when_present(tmp_path):
-    """App.upload() must land the file in upstream_storage, not in storage.
+async def test_app_upload_dual_writes_when_both_stores_present(tmp_path, monkeypatch):
+    """App.upload() must write to BOTH stores at the identical key when both are configured.
 
-    This is the SDR case: upstream_storage is the Atlan-owned atlan-objectstore,
-    storage is the customer-owned objectstore. Published artifacts must reach
-    Atlan's bucket so the publish app can index them.
+    BLDX-1464: the deployment (customer) bucket receives a mirror copy alongside
+    the upstream (Atlan) bucket.  The returned ref reflects the upstream write;
+    because keys are identical the ref is valid for reading from either store.
     """
+    monkeypatch.setenv("ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR", "true")
+    # Re-read the constant so the env-var is picked up for this process.
+    import importlib
+
+    import application_sdk.constants as _c
+
+    importlib.reload(_c)
+
     deployment_root = tmp_path / "deployment"
     upstream_root = tmp_path / "upstream"
     deployment_store = create_local_store(deployment_root)
@@ -94,25 +115,133 @@ async def test_app_upload_routes_to_upstream_when_present(tmp_path):
     storage_path = result.ref.storage_path
     assert storage_path is not None
 
-    # The file must be findable in upstream (excluding .sha256 sidecars)
-    upstream_keys = await list_keys("", store=upstream_store)
-    non_sidecar_upstream = [k for k in upstream_keys if not k.endswith(".sha256")]
-    assert any(
-        storage_path in key or key in storage_path for key in non_sidecar_upstream
-    ), (
-        f"App.upload() did not route to upstream_storage. "
+    def _non_sidecar(keys: list[str]) -> list[str]:
+        return [k for k in keys if not k.endswith(".sha256")]
+
+    # The file must be in upstream (Atlan authoritative handoff).
+    upstream_keys = _non_sidecar(await list_keys("", store=upstream_store))
+    assert any(storage_path in key or key in storage_path for key in upstream_keys), (
+        f"App.upload() did not write to upstream_storage. "
         f"Expected key containing '{storage_path}' in upstream, found: {upstream_keys}"
     )
 
-    # The same key must NOT be in the deployment store
-    deployment_keys = await list_keys("", store=deployment_store)
+    # The file must ALSO be in the deployment store (customer audit copy) at the
+    # IDENTICAL key — this is the BLDX-1464 guarantee.
+    deployment_keys = _non_sidecar(await list_keys("", store=deployment_store))
+    assert any(storage_path in key or key in storage_path for key in deployment_keys), (
+        f"App.upload() did not write the mirror copy to deployment store. "
+        f"Expected key containing '{storage_path}' in deployment, found: {deployment_keys}"
+    )
+
+    # Keys must match exactly (not just overlap).
+    upstream_artifact_keys = sorted(
+        k for k in upstream_keys if storage_path in k or k in storage_path
+    )
+    deployment_artifact_keys = sorted(
+        k for k in deployment_keys if storage_path in k or k in storage_path
+    )
+    assert upstream_artifact_keys == deployment_artifact_keys, (
+        f"Artifact keys differ between stores — must be identical for audit copy. "
+        f"upstream={upstream_artifact_keys}, deployment={deployment_artifact_keys}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a2) Mirror disabled → upstream only
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_app_upload_mirror_disabled_writes_upstream_only(tmp_path, monkeypatch):
+    """When ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR=false, upload goes to upstream only.
+
+    This preserves pre-BLDX-1464 behaviour for operators who opt out.
+    """
+    monkeypatch.setenv("ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR", "false")
+    import importlib
+
+    import application_sdk.constants as _c
+
+    importlib.reload(_c)
+
+    deployment_root = tmp_path / "deployment"
+    upstream_root = tmp_path / "upstream"
+    deployment_store = create_local_store(deployment_root)
+    upstream_store = create_local_store(upstream_root)
+
+    src = tmp_path / "artifact.jsonl"
+    src.write_text('{"name": "test-entity"}\n')
+
+    app = _make_app(deployment_store, upstream_store=upstream_store)
+    result = await app.upload(
+        UploadInput(local_path=str(src), tier=StorageTier.RETAINED)
+    )
+
+    storage_path = result.ref.storage_path
+    assert storage_path is not None
+
+    # File must be in upstream.
+    upstream_keys = [
+        k
+        for k in await list_keys("", store=upstream_store)
+        if not k.endswith(".sha256")
+    ]
+    assert any(
+        storage_path in key or key in storage_path for key in upstream_keys
+    ), f"File not in upstream when mirror disabled. upstream_keys={upstream_keys}"
+
+    # File must NOT be in deployment store when mirror is disabled.
+    deployment_keys = [
+        k
+        for k in await list_keys("", store=deployment_store)
+        if not k.endswith(".sha256")
+    ]
     assert not any(
-        storage_path in key or key in storage_path
-        for key in deployment_keys
-        if not key.endswith(".sha256")
+        storage_path in key or key in storage_path for key in deployment_keys
     ), (
-        f"App.upload() incorrectly wrote to deployment store when upstream was present. "
-        f"deployment_keys: {deployment_keys}"
+        f"App.upload() wrote to deployment store when mirror was disabled. "
+        f"deployment_keys={deployment_keys}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a3) Same-store guard: upstream is deployment → single write only
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_app_upload_same_store_guard_prevents_double_write(tmp_path, monkeypatch):
+    """When upstream_storage is the same object as storage, only one write occurs.
+
+    The identity guard (``upstream is not deployment``) prevents the SDK from
+    uploading the file twice to the same store.
+    """
+    monkeypatch.setenv("ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR", "true")
+    import importlib
+
+    import application_sdk.constants as _c
+
+    importlib.reload(_c)
+
+    store = create_local_store(tmp_path / "store")
+
+    src = tmp_path / "artifact.jsonl"
+    src.write_text('{"name": "test-entity"}\n')
+
+    # Pass the same store object as both deployment and upstream.
+    app = _make_app(store, upstream_store=store)
+    result = await app.upload(
+        UploadInput(local_path=str(src), tier=StorageTier.RETAINED)
+    )
+
+    assert result.ref.storage_path is not None
+    all_keys = [
+        k for k in await list_keys("", store=store) if not k.endswith(".sha256")
+    ]
+    # Exactly one copy — no duplicate keys.
+    assert len(all_keys) == 1, (
+        f"Expected exactly one artifact key when both stores are identical, "
+        f"got: {all_keys}"
     )
 
 
@@ -433,3 +562,116 @@ async def test_app_upload_blocks_sensitive_path_when_local_absent(tmp_path):
         await app.upload(
             UploadInput(local_path="/etc/passwd", ref=ref, tier=StorageTier.RETAINED)
         )
+
+
+# ---------------------------------------------------------------------------
+# (i_fail_soft) Deployment mirror fails + best-effort → WARNING, upstream succeeds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_app_upload_mirror_failure_best_effort(tmp_path, monkeypatch):
+    """When the deployment-bucket mirror write fails, a WARNING is logged and the
+    run continues.  The upstream write must still succeed and the returned
+    UploadOutput must reflect the upstream copy.
+
+    Invariant: ATLAN_DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED=false (default)
+    → a failed deployment write is non-fatal.
+    """
+    import importlib
+
+    import application_sdk.constants as _c
+
+    monkeypatch.setenv("ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR", "true")
+    monkeypatch.setenv("ATLAN_DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED", "false")
+    importlib.reload(_c)
+
+    upstream_root = tmp_path / "upstream"
+    upstream_store = create_local_store(upstream_root)
+
+    # Use a read-only deployment store path to force a write failure.
+    import os
+
+    readonly_root = tmp_path / "readonly"
+    readonly_root.mkdir(mode=0o555)
+    deployment_store = create_local_store(readonly_root)
+
+    src = tmp_path / "artifact.jsonl"
+    src.write_text('{"name": "test-entity"}\n')
+
+    app = _make_app(deployment_store, upstream_store=upstream_store)
+
+    # The upload must succeed (non-fatal deployment failure).
+    result = await app.upload(
+        UploadInput(local_path=str(src), tier=StorageTier.RETAINED)
+    )
+
+    # Restore permissions so tmp_path cleanup can remove the directory.
+    readonly_root.chmod(0o755)
+
+    assert result.ref.storage_path is not None
+
+    # The upstream copy must exist.
+    upstream_keys = [
+        k
+        for k in await list_keys("", store=upstream_store)
+        if not k.endswith(".sha256")
+    ]
+    assert upstream_keys, (
+        f"Upstream write did not succeed after best-effort deployment failure. "
+        f"upstream_keys={upstream_keys}"
+    )
+
+    # Restore so cleanup can proceed.
+    os.chmod(readonly_root, 0o755)
+
+
+# ---------------------------------------------------------------------------
+# (i_fail_hard) Deployment mirror fails + required → upstream writes, then raises
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_app_upload_mirror_failure_required_raises_after_upstream(
+    tmp_path, monkeypatch
+):
+    """When ATLAN_DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED=true and the deployment
+    write fails, the upstream write must still complete before the exception is
+    raised — ensuring a copy always lands somewhere.
+    """
+    import importlib
+
+    import application_sdk.constants as _c
+
+    monkeypatch.setenv("ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR", "true")
+    monkeypatch.setenv("ATLAN_DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED", "true")
+    importlib.reload(_c)
+
+    upstream_root = tmp_path / "upstream"
+    upstream_store = create_local_store(upstream_root)
+
+    readonly_root = tmp_path / "readonly"
+    readonly_root.mkdir(mode=0o555)
+    deployment_store = create_local_store(readonly_root)
+
+    src = tmp_path / "artifact.jsonl"
+    src.write_text('{"name": "test-entity"}\n')
+
+    app = _make_app(deployment_store, upstream_store=upstream_store)
+
+    with pytest.raises(Exception):
+        await app.upload(UploadInput(local_path=str(src), tier=StorageTier.RETAINED))
+
+    # Restore permissions before asserting so cleanup works even on failure.
+    readonly_root.chmod(0o755)
+
+    # The upstream write must have completed before the raise — a copy exists.
+    upstream_keys = [
+        k
+        for k in await list_keys("", store=upstream_store)
+        if not k.endswith(".sha256")
+    ]
+    assert upstream_keys, (
+        f"Upstream write did not complete before the required-mirror exception. "
+        f"upstream_keys={upstream_keys}"
+    )

--- a/tests/unit/app/test_base.py
+++ b/tests/unit/app/test_base.py
@@ -1599,7 +1599,11 @@ class TestUploadStoreRouting:
         AppRegistry.reset()
         TaskRegistry.reset()
 
-    async def test_upload_uses_upstream_when_configured(self) -> None:
+    async def test_upload_dual_writes_when_both_stores_configured(self) -> None:
+        """When both stores are distinct and mirror is enabled (default), _upload is
+        called twice: once with store=deployment, once with store=upstream.
+        The deployment write comes first; the upstream write is last (authoritative).
+        """
         from application_sdk.app.context import AppContext
         from application_sdk.contracts.storage import UploadInput, UploadOutput
 
@@ -1620,13 +1624,69 @@ class TestUploadStoreRouting:
         )
 
         mock_result = UploadOutput()
-        with mock.patch(
-            "application_sdk.storage.transfer.upload",
-            new_callable=mock.AsyncMock,
-            return_value=mock_result,
-        ) as mock_upload:
+        with (
+            mock.patch(
+                "application_sdk.constants.ENABLE_DEPLOYMENT_ARTIFACT_MIRROR",
+                True,
+            ),
+            mock.patch(
+                "application_sdk.storage.transfer.upload",
+                new_callable=mock.AsyncMock,
+                return_value=mock_result,
+            ) as mock_upload,
+        ):
+            result = await app.upload(UploadInput(local_path="/tmp/out"))
+
+        # Called once per target store: deployment first, then upstream.
+        assert (
+            mock_upload.call_count == 2
+        ), f"Expected 2 _upload calls (deployment + upstream); got {mock_upload.call_count}"
+        stores_in_order = [call.kwargs["store"] for call in mock_upload.call_args_list]
+        assert stores_in_order == [
+            deployment_sentinel,
+            upstream_sentinel,
+        ], f"Expected [deployment, upstream] call order; got {stores_in_order}"
+        # Returned result is the upstream (last) write.
+        assert result is mock_result
+
+    async def test_upload_mirror_disabled_uses_upstream_only(self) -> None:
+        """When ENABLE_DEPLOYMENT_ARTIFACT_MIRROR=False, only one _upload call is made
+        and it targets the upstream store.
+        """
+        from application_sdk.app.context import AppContext
+        from application_sdk.contracts.storage import UploadInput, UploadOutput
+
+        upstream_sentinel = object()
+        deployment_sentinel = object()
+
+        class _UpAppMirrorOff(App):
+            async def run(self, input: _BLDXInput) -> _BLDXOutput:
+                return _BLDXOutput()
+
+        app = _UpAppMirrorOff()
+        app._context = AppContext(
+            app_name=app._app_name,
+            app_version="1",
+            run_id="run-1",
+            _storage=deployment_sentinel,  # type: ignore[arg-type]
+            _upstream_storage=upstream_sentinel,  # type: ignore[arg-type]
+        )
+
+        mock_result = UploadOutput()
+        with (
+            mock.patch(
+                "application_sdk.constants.ENABLE_DEPLOYMENT_ARTIFACT_MIRROR",
+                False,
+            ),
+            mock.patch(
+                "application_sdk.storage.transfer.upload",
+                new_callable=mock.AsyncMock,
+                return_value=mock_result,
+            ) as mock_upload,
+        ):
             await app.upload(UploadInput(local_path="/tmp/out"))
 
+        assert mock_upload.call_count == 1
         assert mock_upload.call_args.kwargs["store"] is upstream_sentinel
 
     async def test_upload_falls_back_to_deployment_when_no_upstream(self) -> None:

--- a/tests/unit/app/test_base.py
+++ b/tests/unit/app/test_base.py
@@ -1626,7 +1626,7 @@ class TestUploadStoreRouting:
         mock_result = UploadOutput()
         with (
             mock.patch(
-                "application_sdk.constants.ENABLE_DEPLOYMENT_ARTIFACT_MIRROR",
+                "application_sdk.constants.DEPLOYMENT_ARTIFACT_DUAL_WRITE_ENABLED",
                 True,
             ),
             mock.patch(
@@ -1675,7 +1675,7 @@ class TestUploadStoreRouting:
         mock_result = UploadOutput()
         with (
             mock.patch(
-                "application_sdk.constants.ENABLE_DEPLOYMENT_ARTIFACT_MIRROR",
+                "application_sdk.constants.DEPLOYMENT_ARTIFACT_DUAL_WRITE_ENABLED",
                 False,
             ),
             mock.patch(

--- a/tests/unit/app/test_base.py
+++ b/tests/unit/app/test_base.py
@@ -1649,9 +1649,9 @@ class TestUploadStoreRouting:
         # Returned result is the upstream (last) write.
         assert result is mock_result
 
-    async def test_upload_mirror_disabled_uses_upstream_only(self) -> None:
-        """When ENABLE_DEPLOYMENT_ARTIFACT_MIRROR=False, only one _upload call is made
-        and it targets the upstream store.
+    async def test_upload_dual_write_disabled_uses_upstream_only(self) -> None:
+        """When ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE=disabled, only one _upload call is
+        made and it targets the upstream store.
         """
         from application_sdk.app.context import AppContext
         from application_sdk.contracts.storage import UploadInput, UploadOutput
@@ -1659,11 +1659,11 @@ class TestUploadStoreRouting:
         upstream_sentinel = object()
         deployment_sentinel = object()
 
-        class _UpAppMirrorOff(App):
+        class _UpAppDualWriteOff(App):
             async def run(self, input: _BLDXInput) -> _BLDXOutput:
                 return _BLDXOutput()
 
-        app = _UpAppMirrorOff()
+        app = _UpAppDualWriteOff()
         app._context = AppContext(
             app_name=app._app_name,
             app_version="1",


### PR DESCRIPTION
## Summary

- **Gap fixed:** `App.upload()` previously wrote to a single target (`upstream_storage or storage`), leaving no retained copy in the customer's configured object store in SDR deployments — contrary to documented behaviour ("extracted metadata is first written to configured storage, then transferred to Atlan SaaS").
- **Dual-write:** When both stores are configured and `ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR=true` (default), `App.upload()` now writes to the **deployment (customer) store first**, then to the **upstream (Atlan) store**, at the **identical run-scoped key** (`artifacts/apps/{app}/workflows/{run_id}/…`).
- **Non-breaking:** Non-SDR deployments (`upstream_storage` is `None`) and mirror-disabled deployments are unaffected — single-store behaviour is preserved.

## Behaviour details

| Scenario | Behaviour |
|---|---|
| Both stores configured, mirror on (default) | Deploy-first → upstream; identical key in both |
| `ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR=false` | Upstream only (pre-BLDX-1464) |
| `upstream_storage is None` (non-SDR) | Deployment only (unchanged) |
| Deployment write fails (default) | WARNING logged; upstream still written; run succeeds |
| Deployment write fails + `ATLAN_DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED=true` | Upstream still written first; run then fails |

The upstream write **always runs** even when the deployment write failed — a copy always lands somewhere.

## New env vars (documented in `docs/configuration.md` ## Storage table)

| Env var | Default | Meaning |
|---|---|---|
| `ATLAN_ENABLE_DEPLOYMENT_ARTIFACT_MIRROR` | `true` | Gate the dual-write |
| `ATLAN_DEPLOYMENT_ARTIFACT_MIRROR_REQUIRED` | `false` | Make a failed customer-bucket write fatal (after upstream completes) |

## Files changed

- `application_sdk/app/base.py` — fan-out upload loop replacing single-target call
- `application_sdk/constants.py` — two new flags
- `docs/adr/0014-two-store-storage-architecture.md` — updated `App.upload()` section + Consequences
- `docs/configuration.md` — both flags added to canonical env-var listing
- `tests/integration/test_app_upload_routing.py` — 5 new invariants (a, a2, a3, i_fail_soft, i_fail_hard); existing invariant (a) updated from "upstream only" to "both stores at identical key"
- `tests/unit/app/test_base.py` — updated `TestUploadStoreRouting` with dual-write + mirror-disabled unit tests

## Test plan

- [x] `uv run pytest tests/unit/app/ tests/unit/contracts/ tests/unit/storage/ tests/integration/test_app_upload_routing.py --override-ini="addopts=" -q` — 945 passed
- [x] `uv run pre-commit run --all-files` — all checks pass
- [ ] SDR emulator end-to-end: confirm artifact appears at identical `artifacts/apps/<app>/workflows/<run_id>/…` key in both buckets (`tests/integration/storage/test_emulator_sdr_atlan_upload.py`)

## Out of scope

- **Retention / 30-day rollover** (ticket item 3): not an SDK concern. Files land under the run-scoped `artifacts/apps/.../workflows/{run_id}/` prefix; customers configure lifecycle/rollover policies on their own object store as they see fit.
- **Connector-app audit** (mysql/kafka single-destination gap): tracked separately.

Closes BLDX-1464