### PR TITLE
feat: report dapr binding types on worker_start

### DIFF
--- a/application_sdk/contracts/events.py
+++ b/application_sdk/contracts/events.py
@@ -182,6 +182,12 @@ class WorkerStartEventData(BaseModel):
         sdk_version: SDK version used to build the app image (ATLAN_SDK_VERSION).
         app_type: App type from Global Marketplace (ATLAN_APP_TYPE).
         published_at: Release publication timestamp (ATLAN_PUBLISHED_AT).
+        objectstore_binding_type: Dapr component type of the deployment object
+            store (e.g. "bindings.aws.s3", "bindings.localstorage"), discovered
+            at runtime from the Dapr sidecar metadata. Empty if undiscoverable.
+        secretstore_binding_type: Dapr component type of the secret store (e.g.
+            "secretstores.hashicorp.vault", "secretstores.kubernetes"),
+            discovered at runtime from the Dapr sidecar metadata.
     """
 
     version: str = WORKER_START_EVENT_VERSION
@@ -204,6 +210,8 @@ class WorkerStartEventData(BaseModel):
     sdk_version: str = ""
     app_type: str = ""
     published_at: str = ""
+    objectstore_binding_type: str = ""
+    secretstore_binding_type: str = ""
 
 
 class WorkerTokenRefreshEventData(BaseModel):

--- a/application_sdk/contracts/events.py
+++ b/application_sdk/contracts/events.py
@@ -185,6 +185,10 @@ class WorkerStartEventData(BaseModel):
         objectstore_binding_type: Dapr component type of the deployment object
             store (e.g. "bindings.aws.s3", "bindings.localstorage"), discovered
             at runtime from the Dapr sidecar metadata. Empty if undiscoverable.
+        upstream_objectstore_binding_type: Dapr component type of the upstream
+            (Atlan) object store the app uploads artifacts to, discovered the
+            same way. Reported alongside the deployment store so a mis-wired
+            upstream binding is visible. Empty if undiscoverable.
         secretstore_binding_type: Dapr component type of the secret store (e.g.
             "secretstores.hashicorp.vault", "secretstores.kubernetes"),
             discovered at runtime from the Dapr sidecar metadata.
@@ -211,6 +215,7 @@ class WorkerStartEventData(BaseModel):
     app_type: str = ""
     published_at: str = ""
     objectstore_binding_type: str = ""
+    upstream_objectstore_binding_type: str = ""
     secretstore_binding_type: str = ""
 
 

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -199,9 +199,11 @@ async def _emit_worker_start_event(
         APP_SDK_VERSION,
         APP_TYPE,
         APPLICATION_VERSION,
+        DEPLOYMENT_OBJECT_STORE_NAME,
         PUBLISHED_AT,
         RELEASE_CHANNEL,
         RELEASE_ID,
+        SECRET_STORE_NAME,
     )
     from application_sdk.contracts.events import (  # noqa: PLC0415 — circular: contracts.events imports execution.errors
         ApplicationEventNames,
@@ -212,12 +214,19 @@ async def _emit_worker_start_event(
     from application_sdk.execution._temporal.interceptors.events import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
         _publish_event_via_binding,
     )
+    from application_sdk.infrastructure._dapr.http import (  # noqa: PLC0415 — circular: infrastructure imports execution transitively
+        get_dapr_component_types,
+    )
     from application_sdk.infrastructure.bindings import (  # noqa: PLC0415 — circular: infrastructure imports execution transitively
         BindingError,
     )
 
     deployment_name = os.environ.get("ATLAN_DEPLOYMENT_NAME", app_name)
     host_part, _, port_part = host.partition(":")
+
+    # Discover which Dapr binding types back the object/secret stores. Best-effort
+    # and deploy-path-agnostic: read from the live sidecar rather than env.
+    component_types = await get_dapr_component_types()
 
     event_data = WorkerStartEventData(
         application_name=app_name,
@@ -239,6 +248,8 @@ async def _emit_worker_start_event(
         sdk_version=APP_SDK_VERSION,
         app_type=APP_TYPE,
         published_at=PUBLISHED_AT,
+        objectstore_binding_type=component_types.get(DEPLOYMENT_OBJECT_STORE_NAME, ""),
+        secretstore_binding_type=component_types.get(SECRET_STORE_NAME, ""),
     )
     event = Event(
         event_type=EventTypes.APPLICATION_EVENT.value,

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -204,6 +204,7 @@ async def _emit_worker_start_event(
         RELEASE_CHANNEL,
         RELEASE_ID,
         SECRET_STORE_NAME,
+        UPSTREAM_OBJECT_STORE_NAME,
     )
     from application_sdk.contracts.events import (  # noqa: PLC0415 — circular: contracts.events imports execution.errors
         ApplicationEventNames,
@@ -249,6 +250,9 @@ async def _emit_worker_start_event(
         app_type=APP_TYPE,
         published_at=PUBLISHED_AT,
         objectstore_binding_type=component_types.get(DEPLOYMENT_OBJECT_STORE_NAME, ""),
+        upstream_objectstore_binding_type=component_types.get(
+            UPSTREAM_OBJECT_STORE_NAME, ""
+        ),
         secretstore_binding_type=component_types.get(SECRET_STORE_NAME, ""),
     )
     event = Event(

--- a/application_sdk/infrastructure/_dapr/http.py
+++ b/application_sdk/infrastructure/_dapr/http.py
@@ -293,14 +293,19 @@ async def get_dapr_component_types() -> dict[str, str]:
     is malformed. Never raises — callers treat a missing entry as unknown.
     """
     try:
-        async with AsyncDaprClient() as client:
+        # Tight bound: this runs inline at worker startup and is pure
+        # observability — never let a slow/flaky sidecar gate the worker.
+        # Degrade to {} rather than stall on the default 30s x retries.
+        async with AsyncDaprClient(timeout=2.0, retries=0) as client:
             meta = await client.get_metadata()
     except Exception:
         logger.debug("Could not read Dapr component metadata", exc_info=True)
         return {}
 
     types: dict[str, str] = {}
-    for component in meta.get("components") or []:
+    # Dapr versions differ on the key: newer sidecars return "components",
+    # older ones "registeredComponents" (mirrors is_dapr_component_registered).
+    for component in meta.get("components") or meta.get("registeredComponents") or []:
         name = component.get("name")
         if name:
             types[name] = component.get("type", "")

--- a/application_sdk/infrastructure/_dapr/http.py
+++ b/application_sdk/infrastructure/_dapr/http.py
@@ -278,3 +278,30 @@ class AsyncDaprClient:
         resp = await self._client.get(METADATA_PATH)
         resp.raise_for_status()
         return resp.json()
+
+
+async def get_dapr_component_types() -> dict[str, str]:
+    """Return a ``{component_name: component_type}`` map from the Dapr sidecar.
+
+    Reads ``/v1.0/metadata`` and projects each registered component to its
+    type, e.g. ``{"objectstore": "bindings.aws.s3", "secretstore":
+    "secretstores.hashicorp.vault"}``. This lets a worker self-report which
+    object/secret store binding it is actually wired to, independent of how it
+    was deployed.
+
+    Best-effort: returns ``{}`` if the sidecar is unreachable or the response
+    is malformed. Never raises — callers treat a missing entry as unknown.
+    """
+    try:
+        async with AsyncDaprClient() as client:
+            meta = await client.get_metadata()
+    except Exception:
+        logger.debug("Could not read Dapr component metadata", exc_info=True)
+        return {}
+
+    types: dict[str, str] = {}
+    for component in meta.get("components") or []:
+        name = component.get("name")
+        if name:
+            types[name] = component.get("type", "")
+    return types

--- a/tests/unit/infrastructure/test_dapr_http.py
+++ b/tests/unit/infrastructure/test_dapr_http.py
@@ -16,6 +16,7 @@ from application_sdk.infrastructure._dapr.http import (
     STATE_PATH,
     AsyncDaprClient,
     BindingResult,
+    get_dapr_component_types,
     wait_for_dapr_sidecar,
 )
 
@@ -440,3 +441,62 @@ class TestWaitForDaprSidecar:
             )
             mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
             await wait_for_dapr_sidecar(timeout=0.05, interval=0.01)
+
+
+class TestGetDaprComponentTypes:
+    """Tests for get_dapr_component_types() — the worker_start binding-type reader."""
+
+    @staticmethod
+    def _patch_metadata(meta):
+        """Patch AsyncDaprClient so `async with` yields a client returning `meta`."""
+        fake = AsyncMock()
+        fake.get_metadata = AsyncMock(return_value=meta)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=fake)
+        cm.__aexit__ = AsyncMock(return_value=None)
+        return patch(
+            "application_sdk.infrastructure._dapr.http.AsyncDaprClient",
+            return_value=cm,
+        )
+
+    async def test_projects_components_to_types(self):
+        meta = {
+            "components": [
+                {"name": "objectstore", "type": "bindings.aws.s3"},
+                {"name": "secretstore", "type": "secretstores.kubernetes"},
+            ]
+        }
+        with self._patch_metadata(meta):
+            result = await get_dapr_component_types()
+        assert result == {
+            "objectstore": "bindings.aws.s3",
+            "secretstore": "secretstores.kubernetes",
+        }
+
+    async def test_reads_registered_components_key(self):
+        # Older Dapr sidecars emit "registeredComponents" rather than "components".
+        meta = {
+            "registeredComponents": [
+                {"name": "objectstore", "type": "bindings.localstorage"},
+            ]
+        }
+        with self._patch_metadata(meta):
+            result = await get_dapr_component_types()
+        assert result == {"objectstore": "bindings.localstorage"}
+
+    async def test_skips_unnamed_components(self):
+        meta = {"components": [{"type": "bindings.aws.s3"}]}
+        with self._patch_metadata(meta):
+            result = await get_dapr_component_types()
+        assert result == {}
+
+    async def test_returns_empty_on_sidecar_error(self):
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(side_effect=RuntimeError("sidecar unreachable"))
+        cm.__aexit__ = AsyncMock(return_value=None)
+        with patch(
+            "application_sdk.infrastructure._dapr.http.AsyncDaprClient",
+            return_value=cm,
+        ):
+            result = await get_dapr_component_types()
+        assert result == {}


### PR DESCRIPTION
## What

The `worker_start` event now reports the Dapr component **types** backing the deployment object store and secret store:

- New `get_dapr_component_types()` helper (`infrastructure/_dapr/http.py`) reads the Dapr sidecar metadata and returns a `{component_name: component_type}` map.
- `_emit_worker_start_event` populates `objectstore_binding_type` / `secretstore_binding_type` on `WorkerStartEventData` from that map.

## Why

Gives downstream consumers (event-ingress → Heracles agent specs) visibility into *how* each agent is wired at runtime — e.g. `bindings.aws.s3` vs `bindings.localstorage`, `secretstores.kubernetes` vs `secretstores.hashicorp.vault` — without the worker having to be told its own deployment topology.

## Notes

- Both fields default to `""` when the sidecar metadata is unavailable, so nothing breaks if discovery fails or Dapr isn't present.
- The discovery call is best-effort and does not block worker startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)