### PR TITLE
fix(conformance): use full ref format for SARIF upload

### DIFF
--- a/.github/workflows/conformance-upload-sarif.yaml
+++ b/.github/workflows/conformance-upload-sarif.yaml
@@ -57,5 +57,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: ${{ matrix.slug }}-upload.sarif
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: refs/heads/${{ github.event.workflow_run.head_branch }}
           sha: ${{ github.event.workflow_run.head_sha }}

--- a/packages/conformance/conformance/bootstrap/templates/conformance-upload-sarif.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/conformance-upload-sarif.yaml
@@ -55,5 +55,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: ${{ matrix.slug }}-upload.sarif
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: refs/heads/${{ github.event.workflow_run.head_branch }}
           sha: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
## Summary

- `github.event.workflow_run.head_branch` returns a bare branch name (e.g. `main`), but the GitHub Code Scanning API requires refs in the format `refs/heads/<branch>` — validated by the pattern `/^refs\/(heads|pull|tags)\/.*/`.
- Fix: prefix with `refs/heads/` in both the deployed workflow and the bootstrap template.

## Root cause

The `github/codeql-action/upload-sarif` action passes the `ref` value directly to the Code Scanning API, which rejects bare branch names. This is not immediately obvious because the field is optional (when omitted, the action infers the ref from the git checkout), but in `workflow_run` contexts the repo isn't checked out so it must be provided explicitly — and when provided it must be fully-qualified.

## Test plan

- [ ] Verify the next Conformance run on `main` in an affected app repo uploads SARIF successfully (no `main does not match /^refs\/(heads|pull|tags)\/.*$/` error)
- [ ] Bootstrap: confirm newly scaffolded apps get the correct template

🤖 Generated with [Claude Code](https://claude.com/claude-code)