### PR TITLE
ci(conformance): add --repo to gh run download in SARIF download step

### DIFF
--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -398,6 +398,7 @@ jobs:
           # (e.g. a repo scoped to sdk-only) doesn't fail the whole step.
           for slug in ci error-handling prescriptions optimizations dependency logging tests; do
             gh run download "$RUN_ID" \
+              --repo "${{ github.repository }}" \
               --name "conformance-${slug}-sarif" \
               --dir /tmp/sarif 2>/dev/null \
               && found=$((found + 1)) || true


### PR DESCRIPTION
## Summary

- `gh run download` in the conformance job's *Download SARIF artifacts* step was missing `--repo`, same root cause as the `gh run list/view` fix already merged.
- Without `--repo`, `gh` tries to infer the target repo from git context. The conformance job has no checkout step, so the command fails silently (`2>/dev/null`) and reports 0 artifacts found even when all 9 SARIF artifacts are present and unexpired.

## Fix

Add `--repo "${{ github.repository }}"` to the `gh run download` call in the `for slug in ci error-handling ...` loop.

## Test plan

- [ ] Re-dispatch `update-dashboard.yml` on a connector repo with a completed conformance CI run; confirm "Downloaded N / 7 series SARIF artifacts" shows N > 0 and the Deploy step runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)