### PR TITLE
fix(observability): suppress SDK logger output during workflow replay

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -416,6 +416,13 @@ OTEL_EXPORTER_OTLP_ENDPOINT: str = os.getenv(
 )
 #: Whether to enable OpenTelemetry log export
 ENABLE_OTLP_LOGS: bool = os.getenv("ENABLE_OTLP_LOGS", "false").lower() == "true"
+#: Whether to emit SDK logger output during Temporal workflow replay.
+#: Default is False, matching Temporal's native ``workflow.logger`` behaviour.
+#: Set to True to re-enable replay logs for debugging (e.g. when using the
+#: ``temporalio.worker.Replayer`` to inspect history locally).
+ENABLE_WORKFLOW_REPLAY_LOGS: bool = (
+    os.getenv("ENABLE_WORKFLOW_REPLAY_LOGS", "false").lower() == "true"
+)
 #: Whether to enable a secondary OpenTelemetry log exporter for workflow-log
 #: archival (e.g. S3 sink). When true, logs are emitted to both the primary
 #: OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_WORKFLOW_LOGS_ENDPOINT.

--- a/application_sdk/execution/_temporal/interceptors/log.py
+++ b/application_sdk/execution/_temporal/interceptors/log.py
@@ -44,6 +44,7 @@ from application_sdk.errors.wire import FailureDetails
 from application_sdk.observability.context import (
     ExecutionContext,
     set_execution_context,
+    set_replay_predicate,
 )
 from application_sdk.observability.correlation import (
     CorrelationContext,
@@ -331,6 +332,14 @@ class _LogWorkflowInboundInterceptor(WorkflowInboundInterceptor):
         correlation_id = self._resolve_correlation_id(input)
         self._correlation_id = correlation_id
         set_correlation_context(CorrelationContext(correlation_id=correlation_id))
+
+        # Inject the live replay predicate so the SDK logger can suppress
+        # workflow-body log emissions during replay without importing temporalio.
+        # Uses ``is_replaying_history_events`` (not plain ``is_replaying``) to
+        # match Temporal's own LoggerAdapter: it returns False during
+        # read-only operations (queries, update validators) where
+        # ``is_replaying`` may still be True, preventing over-suppression.
+        set_replay_predicate(workflow.unsafe.is_replaying_history_events)
 
         if workflow.unsafe.is_replaying():
             return await self.next.execute_workflow(input)

--- a/application_sdk/observability/context.py
+++ b/application_sdk/observability/context.py
@@ -5,8 +5,26 @@ multiple observability modules to avoid circular imports.
 """
 
 import dataclasses
+from collections.abc import Callable
 from contextvars import ContextVar
 from typing import Any
+
+# ---------------------------------------------------------------------------
+# Replay-predicate ContextVar
+# ---------------------------------------------------------------------------
+# Set by the workflow log interceptor to ``workflow.unsafe.is_replaying_history_events``
+# (a per-call live check) so the logger adapter can suppress emissions during
+# replay without importing temporalio directly.  The ContextVar holds a
+# *callable* rather than a captured bool so every invocation evaluates the
+# current replay state — a captured bool would be stale after the workflow
+# catches up to the live edge and replay ends mid-execution.
+#
+# Outside Temporal (tests, CLI tools, activities) the default is None, and
+# ``is_replaying()`` returns False with a single ContextVar.get() — no
+# callable invocation, no exception machinery.
+_replay_predicate: ContextVar[Callable[[], bool] | None] = ContextVar(
+    "replay_predicate", default=None
+)
 
 # Context variable for request-scoped data (e.g., request_id from HTTP middleware)
 request_context: ContextVar[dict[str, Any] | None] = ContextVar(
@@ -64,3 +82,32 @@ def set_execution_context(ctx: ExecutionContext) -> None:
     workflow/activity execution.
     """
     _execution_ctx.set(ctx)
+
+
+def set_replay_predicate(pred: Callable[[], bool] | None) -> None:
+    """Inject the replay-detection callable into the current async context.
+
+    Called by the workflow log interceptor with
+    ``workflow.unsafe.is_replaying_history_events`` before any user code runs
+    (and before the ``is_replaying()`` early-return gate, so the predicate is
+    available on every replay turn).  Pass ``None`` to clear the predicate
+    (e.g. in tests).
+    """
+    _replay_predicate.set(pred)
+
+
+def is_replaying() -> bool:
+    """Return True only when executing inside a replaying workflow.
+
+    Safe to call from anywhere — never raises.  Returns False immediately
+    (single ContextVar.get()) outside Temporal (CLI, tests, activities, HTTP).
+    Inside a workflow the predicate is evaluated per-call so the result tracks
+    the live replay/live boundary correctly.
+    """
+    pred = _replay_predicate.get()
+    if pred is None:
+        return False
+    try:
+        return bool(pred())
+    except Exception:
+        return False

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -18,6 +18,7 @@ from application_sdk.constants import (
     ENABLE_OBSERVABILITY_STORE_SINK,
     ENABLE_OTLP_LOGS,
     ENABLE_OTLP_WORKFLOW_LOGS,
+    ENABLE_WORKFLOW_REPLAY_LOGS,
     LOG_BATCH_SIZE,
     LOG_CLEANUP_ENABLED,
     LOG_CLOUDFLARE_504_SUMMARY_INTERVAL_SECONDS,
@@ -33,7 +34,11 @@ from application_sdk.constants import (
     OTEL_WORKFLOW_LOGS_ENDPOINT,
     SERVICE_NAME,
 )
-from application_sdk.observability.context import correlation_context, request_context
+from application_sdk.observability.context import (
+    correlation_context,
+    is_replaying,
+    request_context,
+)
 from application_sdk.observability.logger_adaptor_errors import (
     UnsupportedLogRecordError,
 )
@@ -344,6 +349,12 @@ class InterceptHandler(logging.Handler):
     """
 
     def emit(self, record: logging.LogRecord) -> None:
+        # Suppress stdlib/third-party logs emitted from within a replaying
+        # workflow so they don't duplicate alongside SDK-adapter logs.
+        # Honour the same ENABLE_WORKFLOW_REPLAY_LOGS env toggle.
+        if not ENABLE_WORKFLOW_REPLAY_LOGS and is_replaying():
+            return
+
         # Get corresponding Loguru level if it exists
         try:
             level = logger.level(record.levelname).name
@@ -577,6 +588,13 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
         self.logger_name = logger_name
         # Bind the logger name when creating the logger instance
         self.logger = logger
+        # Suppress workflow-body logs during Temporal replay by default,
+        # matching the behaviour of Temporal's native ``workflow.logger``
+        # (``log_during_replay=False``).  Set to True on this instance — or
+        # export ENABLE_WORKFLOW_REPLAY_LOGS=true — to re-enable replay logs
+        # for debugging (e.g. when using ``temporalio.worker.Replayer``
+        # locally to inspect workflow history).
+        self.log_during_replay: bool = ENABLE_WORKFLOW_REPLAY_LOGS
 
         if AtlanLoggerAdapter._initialized:
             return
@@ -855,6 +873,18 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
         _apply_atlan_context(kwargs, prefer_caller=False)
         return msg, kwargs
 
+    def _suppress_replay_log(self) -> bool:
+        """Return True when the current log call should be dropped.
+
+        Suppresses if ``log_during_replay`` is False AND the current execution
+        is inside a replaying Temporal workflow.  Returns False immediately
+        (single ContextVar.get()) for all non-workflow contexts — activities,
+        HTTP, CLI, tests — with no callable invocation or exception overhead.
+        """
+        if self.log_during_replay:
+            return False
+        return is_replaying()
+
     def debug(self, msg: str, *args: Any, **kwargs: Any):
         """Log a debug level message.
 
@@ -863,6 +893,8 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
             *args: Additional positional arguments
             **kwargs: Additional keyword arguments for context
         """
+        if self._suppress_replay_log():
+            return
         try:
             msg, args = _format_printf_args(msg, args)
             exc_info = kwargs.pop("exc_info", False)
@@ -884,6 +916,8 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
             *args: Additional positional arguments
             **kwargs: Additional keyword arguments for context
         """
+        if self._suppress_replay_log():
+            return
         try:
             msg, args = _format_printf_args(msg, args)
             exc_info = kwargs.pop("exc_info", False)
@@ -905,6 +939,8 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
             *args: Additional positional arguments
             **kwargs: Additional keyword arguments for context
         """
+        if self._suppress_replay_log():
+            return
         try:
             msg, args = _format_printf_args(msg, args)
             exc_info = kwargs.pop("exc_info", False)
@@ -928,6 +964,8 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
 
         Note: Forces an immediate flush of logs when called.
         """
+        if self._suppress_replay_log():
+            return
         try:
             msg, args = _format_printf_args(msg, args)
             exc_info = kwargs.pop("exc_info", False)
@@ -968,6 +1006,8 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
 
         Note: Forces an immediate flush of logs when called.
         """
+        if self._suppress_replay_log():
+            return
         try:
             msg, args = _format_printf_args(msg, args)
             exc_info = kwargs.pop("exc_info", False)
@@ -1027,6 +1067,8 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
 
         This method adds activity-specific context to the log message.
         """
+        if self._suppress_replay_log():
+            return
         try:
             msg, args = _format_printf_args(msg, args)
             local_kwargs = kwargs.copy()
@@ -1047,6 +1089,8 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
 
         This method adds metric-specific context to the log message.
         """
+        if self._suppress_replay_log():
+            return
         try:
             msg, args = _format_printf_args(msg, args)
             local_kwargs = kwargs.copy()
@@ -1110,6 +1154,8 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
 
         This method adds trace-specific context to the log message.
         """
+        if self._suppress_replay_log():
+            return
         msg, args = _format_printf_args(msg, args)
         local_kwargs = kwargs.copy()
         local_kwargs["log_type"] = "trace"

--- a/docs/concepts/monitoring.md
+++ b/docs/concepts/monitoring.md
@@ -200,6 +200,15 @@ class MyConnector(App):
 
 Use **%-style** message bodies (`"fetching page=%d", page_num`) rather than keyword arguments. See [Logging Standards](../standards/logging.md) and [ADR-0011](../adr/0011-logging-level-guidelines.md).
 
+### Replay suppression
+
+`self.logger` suppresses log output during Temporal workflow replay by default, matching the behaviour of Temporal's native `workflow.logger`. This prevents duplicate bare lines (missing `workflow_id`/`run_id`) that would otherwise appear in Grafana when a worker replays history after a sticky-cache eviction.
+
+If you need replay logs — for example when using `temporalio.worker.Replayer` locally to inspect workflow history — re-enable them in two ways:
+
+- **Per-instance** (in-code): `self.logger.log_during_replay = True`
+- **Globally** (env flag): `ENABLE_WORKFLOW_REPLAY_LOGS=true`
+
 ---
 
 ## Correlation IDs

--- a/tests/unit/interceptors/test_log_interceptor.py
+++ b/tests/unit/interceptors/test_log_interceptor.py
@@ -18,7 +18,11 @@ from application_sdk.execution._temporal.interceptors.log import (
     _LogWorkflowInboundInterceptor,
     _LogWorkflowOutboundInterceptor,
 )
-from application_sdk.observability.context import ExecutionContext, _execution_ctx
+from application_sdk.observability.context import (
+    ExecutionContext,
+    _execution_ctx,
+    _replay_predicate,
+)
 from application_sdk.observability.correlation import (
     CorrelationContext,
     _correlation_ctx,
@@ -81,9 +85,11 @@ class MockExecuteActivityInput:
 def reset_context():
     _correlation_ctx.set(None)
     _execution_ctx.set(ExecutionContext())
+    _replay_predicate.set(None)
     yield
     _correlation_ctx.set(None)
     _execution_ctx.set(ExecutionContext())
+    _replay_predicate.set(None)
 
 
 # ---------------------------------------------------------------------------
@@ -1028,3 +1034,113 @@ class TestActivityInboundReadsParentHeaders:
         ctx = _execution_ctx.get()
         assert ctx.parent_workflow_id == "A"
         assert ctx.parent_run_id == "A_run"
+
+
+# ---------------------------------------------------------------------------
+# TestReplayPredicateInjection
+# ---------------------------------------------------------------------------
+
+
+class TestReplayPredicateInjection:
+    """The workflow log interceptor must inject the replay predicate into the
+    replay_predicate ContextVar so the SDK logger can suppress workflow-body
+    logs during replay without importing temporalio."""
+
+    @pytest.fixture(autouse=True)
+    def reset_replay_predicate(self):
+        _replay_predicate.set(None)
+        yield
+        _replay_predicate.set(None)
+
+    @pytest.fixture
+    def mock_next(self):
+        n = AsyncMock()
+        n.execute_workflow = AsyncMock(return_value="wf-result")
+        return n
+
+    @pytest.fixture
+    def interceptor(self, mock_next):
+        return _LogWorkflowInboundInterceptor(mock_next)
+
+    async def test_injects_predicate_on_live_execution(self, interceptor, mock_next):
+        """On a live (non-replay) execution the predicate must be set to the
+        ``workflow.unsafe.is_replaying_history_events`` callable."""
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = False
+            mock_wf.unsafe.is_replaying_history_events = lambda: False
+            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.memo.return_value = {}
+            await interceptor.execute_workflow(MockExecuteWorkflowInput())
+
+        pred = _replay_predicate.get()
+        assert pred is not None, "Replay predicate must be set after execute_workflow"
+        assert callable(pred)
+
+    async def test_injects_predicate_on_replay(self, interceptor, mock_next):
+        """On replay the predicate must also be set (before the is_replaying()
+        early-return gate) so the logger can check live state for workflow-tail
+        log calls once replay finishes."""
+        with patch(
+            "application_sdk.execution._temporal.interceptors.log.workflow"
+        ) as mock_wf:
+            mock_wf.unsafe.is_replaying.return_value = True
+            mock_wf.unsafe.is_replaying_history_events = lambda: True
+            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.memo.return_value = {}
+            await interceptor.execute_workflow(MockExecuteWorkflowInput())
+
+        pred = _replay_predicate.get()
+        assert pred is not None, (
+            "Replay predicate must be set even during replay so logger can "
+            "check live state once the replay tail completes"
+        )
+        assert callable(pred)
+
+    async def test_predicate_is_injected_before_replay_gate(
+        self, interceptor, mock_next
+    ):
+        """set_replay_predicate must be called before is_replaying() is checked
+        so the predicate is always present when user workflow code runs.
+
+        Patches the module-level ``set_replay_predicate`` name in the
+        interceptor module (not the ContextVar.set method, which is read-only)
+        to track call order vs the ``is_replaying()`` gate.
+        """
+        injection_order: list[str] = []
+
+        from application_sdk.observability.context import (
+            set_replay_predicate as _orig_srp,
+        )
+
+        def _tracking_srp(pred: object) -> None:
+            injection_order.append("predicate_set")
+            _orig_srp(pred)  # type: ignore[arg-type]
+
+        with (
+            patch(
+                "application_sdk.execution._temporal.interceptors.log.workflow"
+            ) as mock_wf,
+            patch(
+                "application_sdk.execution._temporal.interceptors.log.set_replay_predicate",
+                side_effect=_tracking_srp,
+            ),
+        ):
+            mock_wf.unsafe.is_replaying.side_effect = lambda: (
+                injection_order.append("is_replaying_checked") or True
+            )
+            mock_wf.unsafe.is_replaying_history_events = lambda: True
+            mock_wf.info.return_value = MockWorkflowInfo()
+            mock_wf.memo.return_value = {}
+            await interceptor.execute_workflow(MockExecuteWorkflowInput())
+
+        assert (
+            "predicate_set" in injection_order
+        ), "set_replay_predicate was never called"
+        pred_idx = injection_order.index("predicate_set")
+        gate_idx = injection_order.index("is_replaying_checked")
+        assert pred_idx < gate_idx, (
+            f"Predicate must be injected before is_replaying() gate; "
+            f"got order {injection_order}"
+        )

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -2244,3 +2244,180 @@ class TestCloudflareTimeoutFilter:
             f.filter(_make_temporalio_record())
             second_msg = mock_adapter.info.call_args_list[1][0][0]
             assert "2" in second_msg
+
+
+# ---------------------------------------------------------------------------
+# TestReplayLogSuppression
+# ---------------------------------------------------------------------------
+
+
+class TestReplayLogSuppression:
+    """Tests for replay-aware log suppression in AtlanLoggerAdapter.
+
+    The adapter must drop workflow-body logs during Temporal replay
+    (matching ``workflow.logger``'s default ``log_during_replay=False``).
+    All checks are done by injecting a replay predicate via ContextVar —
+    no temporalio mocking required.
+    """
+
+    @pytest.fixture(autouse=True)
+    def reset_replay_predicate(self):
+        """Clear the replay predicate before and after each test."""
+        from application_sdk.observability.context import set_replay_predicate
+
+        set_replay_predicate(None)
+        yield
+        set_replay_predicate(None)
+
+    def _make_adapter_with_sink(self) -> tuple[AtlanLoggerAdapter, list[str]]:
+        """Return an adapter and a list that collects emitted log messages.
+
+        The capture sink is added AFTER adapter construction because
+        ``AtlanLoggerAdapter.__init__`` calls ``logger.remove()`` to clear
+        all existing sinks before registering its own — adding the sink first
+        would have it removed immediately.
+        """
+        AtlanLoggerAdapter._reset_for_testing()
+        from loguru import logger as loguru_logger
+
+        with mock.patch.dict(
+            "os.environ",
+            {
+                "LOG_LEVEL": "DEBUG",
+                "ENABLE_OTLP_LOGS": "false",
+                "ENABLE_WORKFLOW_REPLAY_LOGS": "false",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+            },
+        ):
+            adapter = AtlanLoggerAdapter("test_replay")
+
+        # Add capture sink after __init__ so it isn't removed by logger.remove()
+        emitted: list[str] = []
+
+        def _capture_sink(msg: object) -> None:
+            emitted.append(str(msg))
+
+        loguru_logger.add(_capture_sink, format="{message}", level="DEBUG")
+        return adapter, emitted
+
+    def test_suppresses_all_methods_when_replaying(self):
+        """All log methods must be silent during replay (predicate=True)."""
+        from application_sdk.observability.context import set_replay_predicate
+
+        adapter, emitted = self._make_adapter_with_sink()
+        set_replay_predicate(lambda: True)
+
+        adapter.debug("should-suppress-debug")
+        adapter.info("should-suppress-info")
+        adapter.warning("should-suppress-warning")
+        adapter.error("should-suppress-error")
+        adapter.critical("should-suppress-critical")
+        adapter.activity("should-suppress-activity")
+        adapter.metric("should-suppress-metric")
+        adapter.tracing("should-suppress-tracing")
+
+        assert not any(
+            "should-suppress" in m for m in emitted
+        ), f"Expected no emission during replay, got: {emitted}"
+
+    def test_emits_when_not_replaying(self):
+        """Log methods must emit normally when predicate returns False."""
+        from application_sdk.observability.context import set_replay_predicate
+
+        adapter, emitted = self._make_adapter_with_sink()
+        set_replay_predicate(lambda: False)
+
+        adapter.info("live-log")
+
+        assert any(
+            "live-log" in m for m in emitted
+        ), f"Expected 'live-log' in emissions, got: {emitted}"
+
+    def test_emits_when_predicate_is_none(self):
+        """No predicate set (default outside Temporal) → normal emission."""
+        adapter, emitted = self._make_adapter_with_sink()
+        # predicate is None by default (reset_replay_predicate fixture)
+
+        adapter.info("outside-temporal-log")
+
+        assert any(
+            "outside-temporal-log" in m for m in emitted
+        ), f"Expected 'outside-temporal-log' in emissions, got: {emitted}"
+
+    def test_log_during_replay_true_overrides_suppression(self):
+        """When log_during_replay=True the guard is bypassed even during replay."""
+        from application_sdk.observability.context import set_replay_predicate
+
+        adapter, emitted = self._make_adapter_with_sink()
+        adapter.log_during_replay = True
+        set_replay_predicate(lambda: True)
+
+        adapter.info("replay-with-opt-in")
+
+        assert any(
+            "replay-with-opt-in" in m for m in emitted
+        ), f"Expected emission with log_during_replay=True, got: {emitted}"
+
+    def test_suppression_is_per_emission_not_one_shot(self):
+        """Guard evaluates live per call: suppressed on replay, emitted on live."""
+        from application_sdk.observability.context import set_replay_predicate
+
+        adapter, emitted = self._make_adapter_with_sink()
+
+        replaying = True
+
+        def _live_predicate() -> bool:
+            return replaying
+
+        set_replay_predicate(_live_predicate)
+
+        adapter.info("during-replay")  # suppressed
+
+        replaying = False  # simulate replay → live transition
+
+        adapter.info("after-replay")  # should emit
+
+        assert not any(
+            "during-replay" in m for m in emitted
+        ), f"Expected 'during-replay' suppressed, got: {emitted}"
+        assert any(
+            "after-replay" in m for m in emitted
+        ), f"Expected 'after-replay' emitted, got: {emitted}"
+
+    def test_intercept_handler_suppressed_during_replay(self):
+        """The stdlib bridge (InterceptHandler) also drops records during replay."""
+        from application_sdk.observability.context import set_replay_predicate
+        from application_sdk.observability.logger_adaptor import InterceptHandler
+
+        AtlanLoggerAdapter._reset_for_testing()
+        set_replay_predicate(lambda: True)
+
+        handler = InterceptHandler()
+        emitted: list[str] = []
+
+        with mock.patch(
+            "application_sdk.observability.logger_adaptor.logger"
+        ) as mock_loguru:
+            mock_loguru.opt.return_value.bind.return_value.log = mock.MagicMock(
+                side_effect=lambda *a, **kw: emitted.append(a[1] if len(a) > 1 else "")
+            )
+            record = logging.LogRecord(
+                name="test",
+                level=logging.INFO,
+                pathname="",
+                lineno=0,
+                msg="stdlib-during-replay",
+                args=(),
+                exc_info=None,
+            )
+            handler.emit(record)
+
+        assert (
+            not emitted
+        ), f"Expected InterceptHandler to suppress during replay, got: {emitted}"
+        mock_loguru.opt.assert_not_called()
+
+    def test_default_log_during_replay_is_false(self):
+        """log_during_replay defaults to False (env flag default=false)."""
+        adapter, _ = self._make_adapter_with_sink()
+        assert adapter.log_during_replay is False

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -2280,12 +2280,16 @@ class TestReplayLogSuppression:
         AtlanLoggerAdapter._reset_for_testing()
         from loguru import logger as loguru_logger
 
+        # ENABLE_WORKFLOW_REPLAY_LOGS is read once at import and frozen as a
+        # module-level constant, so patching os.environ after import is a
+        # no-op. Patch the constant in the adapter module directly when a test
+        # needs to control it; here we only need the default (False) so no
+        # patch is required.
         with mock.patch.dict(
             "os.environ",
             {
                 "LOG_LEVEL": "DEBUG",
                 "ENABLE_OTLP_LOGS": "false",
-                "ENABLE_WORKFLOW_REPLAY_LOGS": "false",
                 "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
             },
         ):


### PR DESCRIPTION
## Summary

- **Root cause**: `AtlanLoggerAdapter` had no replay guard, so workflow-body log calls re-emitted on every Temporal replay. Under frequent sticky-cache eviction the replay re-emissions swamped the single live (attributed) emission — workflow logs appeared in Grafana as bare lines with no `workflow_id`/`run_id`.
- **Fix**: adds replay suppression to the SDK logger matching Temporal's native `workflow.logger` (`log_during_replay=False` by default), using a ContextVar-injected predicate that keeps `observability/` free of `temporalio` imports and evaluates per-emission (correctly tracks the replay→live boundary mid-workflow).
- **Toggle**: `ENABLE_WORKFLOW_REPLAY_LOGS=true` (env) or `get_logger().log_during_replay = True` (in-code) re-enables replay logs for debugging.

**Note**: the ticket's secondary suggestion ("set execution context before the early return") is already implemented on `main` (`interceptors/log.py:317–336`); no work needed there.

## Changes

| File | Change |
|---|---|
| `application_sdk/constants.py` | Add `ENABLE_WORKFLOW_REPLAY_LOGS` env flag (default `false`) |
| `application_sdk/observability/context.py` | Add `_replay_predicate` ContextVar, `set_replay_predicate()`, `is_replaying()` — stdlib-only, sandbox-safe |
| `application_sdk/execution/_temporal/interceptors/log.py` | Inject `workflow.unsafe.is_replaying_history_events` as replay predicate before the `is_replaying()` gate |
| `application_sdk/observability/logger_adaptor.py` | `log_during_replay` attribute, `_suppress_replay_log()` helper, guard on all 8 emitting log methods + `InterceptHandler.emit` |
| `tests/unit/observability/test_logger_adaptor.py` | 7 new tests in `TestReplayLogSuppression` |
| `tests/unit/interceptors/test_log_interceptor.py` | 3 new tests in `TestReplayPredicateInjection` |

## Design notes

The guard uses `workflow.unsafe.is_replaying_history_events` (not plain `is_replaying`) to match Temporal's own `LoggerAdapter` internals — it returns `False` during read-only operations (queries, update validators) where `is_replaying` may still be `True`, preventing over-suppression.

The predicate is a **callable** stored in a ContextVar (not a captured bool) so each log call evaluates the live replay state. A captured bool would be stale once replay catches up to the live edge and the workflow continues — that half of a long workflow would be wrongly silenced.

The ContextVar predicate approach keeps `observability/` free of `temporalio` imports (sandbox-safe, importable without temporalio) and mirrors the existing `ExecutionContext` injection pattern.

## Test plan

- [x] `uv run pytest tests/unit/observability/test_logger_adaptor.py tests/unit/interceptors/test_log_interceptor.py` — 187 passed
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [ ] Verify in Grafana that workflow `run()` logs carry `workflow_id`/`run_id` after a sticky-cache eviction replay

Closes BLDX-1466