### PR TITLE
feat(conformance): Renovate fleet dashboard data feed (BLDX-1468)

### DIFF
--- a/.github/workflows/renovate-auto-approve-reusable.yml
+++ b/.github/workflows/renovate-auto-approve-reusable.yml
@@ -217,6 +217,9 @@ jobs:
       - name: Trigger Renovate dashboard update
         if: always()
         env:
+          # secrets.org_pat is this reusable's declared alias for ORG_PAT_GITHUB
+          # (passed by every caller as `secrets: { org_pat: ${{ secrets.ORG_PAT_GITHUB }} }`).
+          # It is the same credential used in renovate-dashboard.yaml as secrets.ORG_PAT_GITHUB.
           GH_TOKEN: ${{ secrets.org_pat }}
           REPO: ${{ github.repository }}
         run: |

--- a/.github/workflows/renovate-auto-approve-reusable.yml
+++ b/.github/workflows/renovate-auto-approve-reusable.yml
@@ -39,6 +39,13 @@
 #
 # Trigger rationale lives in the caller — each consumer lists the workflow names
 # that produce its required status checks, which differ per repo.
+#
+# Push-based dashboard update:
+#   After every gate evaluation (approved or not), this workflow dispatches
+#   atlanhq/application-sdk/renovate-dashboard.yaml with the calling repo as
+#   input. This keeps the dashboard current within seconds of a PR state change
+#   rather than waiting up to 6h for the next cron. Non-critical — the cron
+#   provides fleet-wide coverage as a fallback if the dispatch fails.
 
 name: "Renovate auto-approve (reusable)"
 
@@ -206,3 +213,18 @@ jobs:
             gh pr review "${PR_NUM}" --repo "${REPO}" --approve --body "$APPROVE_BODY"
             echo "✅ Approved PR #${PR_NUM} as atlan-ci (Renovate auto-approval)."
           done
+
+      - name: Trigger Renovate dashboard update
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.org_pat }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Push a fresh snapshot of this repo's Renovate PR state to the dashboard.
+          # Runs after every gate evaluation so the dashboard reflects current state
+          # within seconds — approved, blocked, or skipped. Non-critical: falls back
+          # to cron coverage if the dispatch fails (e.g. token lacks actions:write).
+          gh workflow run renovate-dashboard.yaml \
+            --repo atlanhq/application-sdk \
+            --field repo="${REPO}" \
+          || echo "::warning::Could not trigger renovate-dashboard.yaml in atlanhq/application-sdk — dashboard will sync on next scheduled run."

--- a/.github/workflows/renovate-dashboard.yaml
+++ b/.github/workflows/renovate-dashboard.yaml
@@ -35,6 +35,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write  # required for OIDC auth in aws-actions/configure-aws-credentials
+  actions: read    # required to download workflow artifacts (parity with update-dashboard.yaml)
 
 jobs:
   renovate-dashboard:
@@ -42,6 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Checkout application-sdk
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
       - name: Discover atlan-application-sdk consumers
         id: discover
         env:
@@ -56,14 +61,18 @@ jobs:
             echo "Single-repo scan: $SINGLE_REPO"
           else
             # Full-fleet mode: discover every consumer via code search.
-            # gh search code returns up to 100 results per query; for a fleet
-            # > 100 repos, page through with --limit / --page.
+            # --paginate fetches all pages so the fleet is never silently
+            # truncated. The jq emits one name per line; sort -u deduplicates
+            # across pages; jq -R/-s rebuilds the JSON array.
             repos=$(gh search code \
               --owner atlanhq \
               "atlan-application-sdk filename:pyproject.toml" \
               --json repository \
-              --jq '[.[].repository.nameWithOwner] | unique' \
-              --limit 100 2>/dev/null || echo "[]")
+              --jq '.[].repository.nameWithOwner' \
+              --paginate 2>/dev/null \
+              | sort -u \
+              | jq -R . | jq -s . \
+              || echo "[]")
 
             if [ "$repos" = "[]" ] || [ -z "$repos" ]; then
               echo "::warning::No consumer repos discovered. Check ORG_PAT_GITHUB permissions."
@@ -113,7 +122,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p /tmp/renovate-output
-          uvx --from atlan-application-sdk-conformance atlan-application-sdk-conformance renovate-scan \
+          # Run from the checked-out source so renovate-scan is always current
+          # with main, regardless of the latest PyPI release version.
+          uv run --directory packages/conformance \
+            atlan-application-sdk-conformance renovate-scan \
             --input /tmp/renovate-input/open \
             --merged /tmp/renovate-input/merged \
             --out /tmp/renovate-output

--- a/.github/workflows/renovate-dashboard.yaml
+++ b/.github/workflows/renovate-dashboard.yaml
@@ -8,13 +8,30 @@
 # Mirrors the conformance dashboard job in update-dashboard.yaml for the S3
 # deployment pattern, and reusable-renovate-dispatch.yaml for fleet discovery.
 #
-# Runs every 6 hours on a schedule, or on demand via workflow_dispatch.
+# Two modes:
+#   Full-fleet (schedule / workflow_dispatch without repo input):
+#     Discovers all consumer repos via gh search code and scans the whole fleet.
+#     Updates per-repo data, fleet.json aggregate, repos.json manifest, and all
+#     history JSONL files.
+#   Single-repo (workflow_dispatch with repo=<owner/name>):
+#     Scans only the specified repo. Skips fleet.json and fleet history so a
+#     partial scan never overwrites the full-fleet aggregate. Used by the
+#     renovate-auto-approve-reusable workflow for push-based, near-real-time
+#     updates immediately after a PR gate evaluation.
 name: Update Renovate Dashboard
 
 on:
   schedule:
     - cron: "0 */6 * * *" # every 6 hours
   workflow_dispatch:
+    inputs:
+      repo:
+        description: >
+          Single consumer repo to scan (e.g. atlanhq/my-app).
+          Leave empty to scan the full fleet.
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -29,22 +46,30 @@ jobs:
         id: discover
         env:
           GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          SINGLE_REPO: ${{ inputs.repo }}
         run: |
           set -euo pipefail
-          # Search for repos in the atlanhq org that list atlan-application-sdk
-          # as a dependency. gh search code returns up to 100 results per query;
-          # for a fleet > 100 repos, page through with --limit / --page.
-          repos=$(gh search code \
-            --owner atlanhq \
-            "atlan-application-sdk filename:pyproject.toml" \
-            --json repository \
-            --jq '[.[].repository.nameWithOwner] | unique' \
-            --limit 100 2>/dev/null || echo "[]")
 
-          if [ "$repos" = "[]" ] || [ -z "$repos" ]; then
-            echo "::warning::No consumer repos discovered. Check ORG_PAT_GITHUB permissions."
+          if [ -n "${SINGLE_REPO:-}" ]; then
+            # Push-based single-repo mode: skip fleet discovery entirely.
+            repos=$(printf '["%s"]' "$SINGLE_REPO")
+            echo "Single-repo scan: $SINGLE_REPO"
           else
-            echo "Discovered $(echo "$repos" | jq '. | length') consumer repos"
+            # Full-fleet mode: discover every consumer via code search.
+            # gh search code returns up to 100 results per query; for a fleet
+            # > 100 repos, page through with --limit / --page.
+            repos=$(gh search code \
+              --owner atlanhq \
+              "atlan-application-sdk filename:pyproject.toml" \
+              --json repository \
+              --jq '[.[].repository.nameWithOwner] | unique' \
+              --limit 100 2>/dev/null || echo "[]")
+
+            if [ "$repos" = "[]" ] || [ -z "$repos" ]; then
+              echo "::warning::No consumer repos discovered. Check ORG_PAT_GITHUB permissions."
+            else
+              echo "Discovered $(echo "$repos" | jq '. | length') consumer repos"
+            fi
           fi
           echo "repos=${repos}" >> "$GITHUB_OUTPUT"
 
@@ -100,6 +125,8 @@ jobs:
           role-to-assume: arn:aws:iam::733936409301:role/kryptonite-store_FullAccess
 
       - name: Deploy to Kryptonite (renovate)
+        env:
+          SINGLE_REPO: ${{ inputs.repo }}
         run: |
           set -euo pipefail
           PREFIX="renovate-dashboard"
@@ -109,10 +136,6 @@ jobs:
             [ -e "$f" ] || continue
             aws s3 cp "$f" "s3://kryptonite-store/${PREFIX}/repos/$(basename "$f")"
           done
-
-          # Fleet-wide aggregate.
-          aws s3 cp /tmp/renovate-output/fleet.json \
-            "s3://kryptonite-store/${PREFIX}/fleet.json"
 
           # Regenerate manifest of all repo files present in S3.
           aws s3 ls "s3://kryptonite-store/${PREFIX}/repos/" \
@@ -129,7 +152,7 @@ jobs:
             base=$(basename "$f")          # history_<slug>.jsonl
             slug=${base#history_}
             slug=${slug%.jsonl}
-            # The fleet-wide history is merged separately below.
+            # Fleet-wide history is only written on full-fleet runs (see below).
             [ "$slug" = "fleet" ] && continue
             HISTORY_FILE="history/${slug}.jsonl"
             aws s3 cp \
@@ -142,17 +165,24 @@ jobs:
               "s3://kryptonite-store/${PREFIX}/${HISTORY_FILE}"
           done
 
-          # Append fleet-wide history.
-          if [ -e /tmp/renovate-output/history_fleet.jsonl ]; then
-            aws s3 cp \
-              "s3://kryptonite-store/${PREFIX}/history/fleet.jsonl" \
-              /tmp/existing_fleet_history.jsonl 2>/dev/null || true
-            cat /tmp/existing_fleet_history.jsonl \
-              /tmp/renovate-output/history_fleet.jsonl 2>/dev/null \
-              | sort -u \
-              > /tmp/merged_fleet_history.jsonl
-            aws s3 cp /tmp/merged_fleet_history.jsonl \
-              "s3://kryptonite-store/${PREFIX}/history/fleet.jsonl"
+          # Fleet-wide aggregate and history — only meaningful for full-fleet runs.
+          # In single-repo mode the scanner only has data for one repo, so writing
+          # fleet.json would overwrite the real fleet aggregate with a partial view.
+          if [ -z "${SINGLE_REPO:-}" ]; then
+            aws s3 cp /tmp/renovate-output/fleet.json \
+              "s3://kryptonite-store/${PREFIX}/fleet.json"
+
+            if [ -e /tmp/renovate-output/history_fleet.jsonl ]; then
+              aws s3 cp \
+                "s3://kryptonite-store/${PREFIX}/history/fleet.jsonl" \
+                /tmp/existing_fleet_history.jsonl 2>/dev/null || true
+              cat /tmp/existing_fleet_history.jsonl \
+                /tmp/renovate-output/history_fleet.jsonl 2>/dev/null \
+                | sort -u \
+                > /tmp/merged_fleet_history.jsonl
+              aws s3 cp /tmp/merged_fleet_history.jsonl \
+                "s3://kryptonite-store/${PREFIX}/history/fleet.jsonl"
+            fi
           fi
 
           echo "Renovate dashboard updated: https://k.atlan.dev/${PREFIX}/"

--- a/.github/workflows/renovate-dashboard.yaml
+++ b/.github/workflows/renovate-dashboard.yaml
@@ -1,0 +1,158 @@
+# Update Renovate Dashboard — standalone scheduled workflow.
+#
+# Discovers every atlan-application-sdk consumer repo, gathers each repo's open
+# and recently-merged Renovate PRs via `gh pr list`, classifies them with the
+# conformance `renovate-scan` CLI, and deploys per-repo + fleet dashboard data
+# to Kryptonite (k.atlan.dev/renovate-dashboard/).
+#
+# Mirrors the conformance dashboard job in update-dashboard.yaml for the S3
+# deployment pattern, and reusable-renovate-dispatch.yaml for fleet discovery.
+#
+# Runs every 6 hours on a schedule, or on demand via workflow_dispatch.
+name: Update Renovate Dashboard
+
+on:
+  schedule:
+    - cron: "0 */6 * * *" # every 6 hours
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  renovate-dashboard:
+    name: Update Renovate Dashboard
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Discover atlan-application-sdk consumers
+        id: discover
+        env:
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+        run: |
+          set -euo pipefail
+          # Search for repos in the atlanhq org that list atlan-application-sdk
+          # as a dependency. gh search code returns up to 100 results per query;
+          # for a fleet > 100 repos, page through with --limit / --page.
+          repos=$(gh search code \
+            --owner atlanhq \
+            "atlan-application-sdk filename:pyproject.toml" \
+            --json repository \
+            --jq '[.[].repository.nameWithOwner] | unique' \
+            --limit 100 2>/dev/null || echo "[]")
+
+          if [ "$repos" = "[]" ] || [ -z "$repos" ]; then
+            echo "::warning::No consumer repos discovered. Check ORG_PAT_GITHUB permissions."
+          else
+            echo "Discovered $(echo "$repos" | jq '. | length') consumer repos"
+          fi
+          echo "repos=${repos}" >> "$GITHUB_OUTPUT"
+
+      - name: Gather Renovate PR data
+        env:
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          REPOS: ${{ steps.discover.outputs.repos }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/renovate-input/open /tmp/renovate-input/merged
+
+          # 30-day merged window — GNU date on the runner, BSD date as fallback.
+          SINCE=$(date -d '30 days ago' +%Y-%m-%d 2>/dev/null || date -v-30d +%Y-%m-%d)
+
+          # Iterate the discovered fleet. gh calls are fast, so a serial loop is
+          # simpler than a matrix and keeps all data in one workspace for the scan.
+          echo "$REPOS" | jq -r '.[]' | while read -r repo; do
+            [ -z "$repo" ] && continue
+            slug=$(echo "$repo" | tr '/' '_')
+            echo "Gathering Renovate PRs for $repo"
+
+            # Open PRs. gh returns [] for repos with no matching PRs — scan.py
+            # handles empty arrays, so a repo with no Renovate PRs is fine.
+            gh pr list --repo "$repo" --author 'app/renovate' --state open --limit 100 \
+              --json number,title,headRefName,labels,mergeable,reviewDecision,statusCheckRollup,files,createdAt,updatedAt,url,isDraft,body \
+              > "/tmp/renovate-input/open/${slug}.json" 2>/dev/null \
+              || echo "[]" > "/tmp/renovate-input/open/${slug}.json"
+
+            # Merged PRs over the trailing 30-day window.
+            gh pr list --repo "$repo" --author 'app/renovate' --state merged --limit 100 \
+              --search "merged:>=${SINCE}" \
+              --json number,title,headRefName,labels,createdAt,mergedAt,url,reviews \
+              > "/tmp/renovate-input/merged/${slug}.json" 2>/dev/null \
+              || echo "[]" > "/tmp/renovate-input/merged/${slug}.json"
+          done
+
+          echo "Open PR files:   $(ls /tmp/renovate-input/open   | wc -l)"
+          echo "Merged PR files: $(ls /tmp/renovate-input/merged | wc -l)"
+
+      - name: Run Renovate scanner
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/renovate-output
+          uvx --from atlan-application-sdk-conformance atlan-application-sdk-conformance renovate-scan \
+            --input /tmp/renovate-input/open \
+            --merged /tmp/renovate-input/merged \
+            --out /tmp/renovate-output
+
+      - name: Setup AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6
+        with:
+          aws-region: ap-south-1
+          role-to-assume: arn:aws:iam::733936409301:role/kryptonite-store_FullAccess
+
+      - name: Deploy to Kryptonite (renovate)
+        run: |
+          set -euo pipefail
+          PREFIX="renovate-dashboard"
+
+          # Per-repo summaries — upload every file the scanner emitted.
+          for f in /tmp/renovate-output/repos/*.json; do
+            [ -e "$f" ] || continue
+            aws s3 cp "$f" "s3://kryptonite-store/${PREFIX}/repos/$(basename "$f")"
+          done
+
+          # Fleet-wide aggregate.
+          aws s3 cp /tmp/renovate-output/fleet.json \
+            "s3://kryptonite-store/${PREFIX}/fleet.json"
+
+          # Regenerate manifest of all repo files present in S3.
+          aws s3 ls "s3://kryptonite-store/${PREFIX}/repos/" \
+            | grep '\.json$' | awk '{print $4}' \
+            | python3 -c "import json,sys; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))" \
+            > /tmp/renovate-output/repos.json
+          aws s3 cp /tmp/renovate-output/repos.json \
+            "s3://kryptonite-store/${PREFIX}/repos.json"
+
+          # Append per-repo history (download existing → merge → re-upload;
+          # sort -u deduplicates same-day reruns).
+          for f in /tmp/renovate-output/history_*.jsonl; do
+            [ -e "$f" ] || continue
+            base=$(basename "$f")          # history_<slug>.jsonl
+            slug=${base#history_}
+            slug=${slug%.jsonl}
+            # The fleet-wide history is merged separately below.
+            [ "$slug" = "fleet" ] && continue
+            HISTORY_FILE="history/${slug}.jsonl"
+            aws s3 cp \
+              "s3://kryptonite-store/${PREFIX}/${HISTORY_FILE}" \
+              /tmp/existing_renovate_history.jsonl 2>/dev/null || true
+            cat /tmp/existing_renovate_history.jsonl "$f" 2>/dev/null \
+              | sort -u \
+              > /tmp/merged_renovate_history.jsonl
+            aws s3 cp /tmp/merged_renovate_history.jsonl \
+              "s3://kryptonite-store/${PREFIX}/${HISTORY_FILE}"
+          done
+
+          # Append fleet-wide history.
+          if [ -e /tmp/renovate-output/history_fleet.jsonl ]; then
+            aws s3 cp \
+              "s3://kryptonite-store/${PREFIX}/history/fleet.jsonl" \
+              /tmp/existing_fleet_history.jsonl 2>/dev/null || true
+            cat /tmp/existing_fleet_history.jsonl \
+              /tmp/renovate-output/history_fleet.jsonl 2>/dev/null \
+              | sort -u \
+              > /tmp/merged_fleet_history.jsonl
+            aws s3 cp /tmp/merged_fleet_history.jsonl \
+              "s3://kryptonite-store/${PREFIX}/history/fleet.jsonl"
+          fi
+
+          echo "Renovate dashboard updated: https://k.atlan.dev/${PREFIX}/"

--- a/packages/conformance/conformance/cli.py
+++ b/packages/conformance/conformance/cli.py
@@ -220,6 +220,12 @@ def _cmd_bootstrap(argv: list[str]) -> int:
     return 0
 
 
+def _cmd_renovate_scan(argv: list[str]) -> int:
+    from conformance.renovate.scan import main
+
+    return main(argv)
+
+
 _COMMANDS = {
     "detect": _cmd_detect,
     "programs-dir": _cmd_programs_dir,
@@ -227,6 +233,7 @@ _COMMANDS = {
     "gen-deprecations": _cmd_gen_deprecations,
     "remediate": _cmd_remediate,
     "bootstrap": _cmd_bootstrap,
+    "renovate-scan": _cmd_renovate_scan,
 }
 
 _USAGE = """\
@@ -248,6 +255,7 @@ commands:
                    --app-image-name NAME       GHCR image name for tests.yaml (default: atlan-<app-name>-app)
                    --enable-e2e true|false     enable e2e in tests.yaml (default: true, line omitted)
                    --services-script PATH      services setup script (default: auto-detected from .github/test/setup-services.sh)
+  renovate-scan  Build Renovate fleet dashboard JSON from gh pr list output files
 """
 
 

--- a/packages/conformance/conformance/renovate/__init__.py
+++ b/packages/conformance/conformance/renovate/__init__.py
@@ -1,0 +1,1 @@
+"""Renovate PR scanner for the fleet dashboard."""

--- a/packages/conformance/conformance/renovate/classify.py
+++ b/packages/conformance/conformance/renovate/classify.py
@@ -1,0 +1,204 @@
+"""
+Pure classification logic for Renovate PRs.
+
+Label-first: reads self-managed labels added by the fleet preset.
+Falls back to branch/title/body parsing for PRs that predate the label rollout
+(Renovate re-labels them on its next run after the preset change ships).
+
+Auto-merge policy mirrors renovate-config/default.json:
+  - lock-maintenance: automerge=true  (uv.lock-only, in-range)
+  - github-actions:   automerge=true  (all update types, incl. major)
+  - contract-toolkit: automerge=true  for minor/patch; false for major
+  - python-dep:       automerge=false (edits pyproject.toml constraint → human)
+
+Blocking-reason mirrors renovate-auto-approve-reusable.yml conditions:
+  file allowlist: .github/, uv.lock, package-lock.json, requirements.txt, pyproject.toml
+  (at any depth — (.*/)?<name> pattern from the workflow's grep -vxE filter)
+"""
+
+from __future__ import annotations
+
+import re
+
+from conformance.renovate.models import (
+    BlockingReason,
+    Category,
+    ChecksState,
+    RenovatePR,
+    UpdateType,
+)
+
+# Labels emitted by the fleet preset's addLabels rules.
+_LABEL_CATEGORY_MAP: dict[str, Category] = {
+    "update:lock-maintenance": Category.LOCK_MAINTENANCE,
+    "update:github-actions": Category.GITHUB_ACTIONS,
+    "contract-toolkit-update": Category.CONTRACT_TOOLKIT,
+}
+_LABEL_UPDATE_TYPE_MAP: dict[str, UpdateType] = {
+    "update:major": UpdateType.MAJOR,
+    "update:minor": UpdateType.MINOR,
+    "update:patch": UpdateType.PATCH,
+    "update:digest": UpdateType.DIGEST,
+    "update:pin": UpdateType.PIN,
+}
+
+# Allowed file patterns for the auto-approve gate (mirrors renovate-auto-approve-reusable.yml).
+_DEP_FILE_RE = re.compile(
+    r"^(\.github/.*"
+    r"|(.*/)?uv\.lock"
+    r"|(.*/)?package-lock\.json"
+    r"|(.*/)?requirements\.txt"
+    r"|(.*/)?pyproject\.toml)$"
+)
+
+
+def _non_dep_files(files: list[str]) -> list[str]:
+    return [f for f in files if not _DEP_FILE_RE.match(f)]
+
+
+def categorize(pr: RenovatePR) -> Category:
+    """Derive category from self-managed labels (primary) then branch/title (fallback)."""
+    label_set = set(pr.labels)
+
+    # Label-first path.
+    for label, cat in _LABEL_CATEGORY_MAP.items():
+        if label in label_set:
+            return cat
+
+    # Fallback: branch/title parsing for pre-label PRs.
+    branch = pr.branch.lower()
+    title = pr.title.lower()
+
+    if "lock-file-maintenance" in branch or pr.title.startswith(
+        "Lock file maintenance"
+    ):
+        return Category.LOCK_MAINTENANCE
+    if "github-actions" in branch:
+        return Category.GITHUB_ACTIONS
+    if "app-contract-toolkit" in branch or "app-contract-toolkit" in title:
+        return Category.CONTRACT_TOOLKIT
+
+    return Category.PYTHON_DEP
+
+
+def update_type_from_labels(labels: list[str]) -> UpdateType:
+    """Extract the Renovate update-type from self-managed labels."""
+    for label in labels:
+        if label in _LABEL_UPDATE_TYPE_MAP:
+            return _LABEL_UPDATE_TYPE_MAP[label]
+    return UpdateType.UNKNOWN
+
+
+def update_type_from_body(body: str) -> UpdateType:
+    """
+    Fallback: parse the semver update type from the Renovate PR body table.
+
+    Renovate embeds a 'from -> to' version table like:
+        | dep | 1.2.3 | -> | 2.0.0 |
+    We extract the numeric majors and classify accordingly.
+    """
+    # Match patterns like "1.2.3 -> 2.0.0" or "v1.2 -> v2.0"
+    pattern = re.compile(r"v?(\d+)\.\d+[^\s]*\s*->\s*v?(\d+)\.\d+", re.MULTILINE)
+    for m in pattern.finditer(body):
+        from_major, to_major = int(m.group(1)), int(m.group(2))
+        if to_major > from_major:
+            return UpdateType.MAJOR
+        return UpdateType.MINOR  # minor/patch — can't distinguish without 3-part semver
+    return UpdateType.UNKNOWN
+
+
+def derive_update_type(pr: RenovatePR) -> UpdateType:
+    """Labels first, body-table fallback."""
+    ut = update_type_from_labels(pr.labels)
+    if ut != UpdateType.UNKNOWN:
+        return ut
+    return update_type_from_body(pr.body)
+
+
+def auto_merge_expected(category: Category, update_type: UpdateType) -> bool:
+    """
+    Mirror renovate-config/default.json auto-merge policy.
+
+    lock-maintenance → always auto (uv.lock refresh, in-range)
+    github-actions   → always auto (incl. major; validated by CI gate)
+    contract-toolkit → auto for minor/patch; human for major
+    python-dep       → always human (edits pyproject.toml constraint → out-of-range)
+    """
+    if category == Category.LOCK_MAINTENANCE:
+        return True
+    if category == Category.GITHUB_ACTIONS:
+        return True
+    if category == Category.CONTRACT_TOOLKIT:
+        return update_type not in (UpdateType.MAJOR, UpdateType.UNKNOWN)
+    # python-dep, unknown
+    return False
+
+
+def checks_state(pr: RenovatePR) -> ChecksState:
+    """Map the GitHub statusCheckRollup to a simplified state."""
+    # The 'checks_state' field on RenovatePR is already parsed in scan.py from
+    # statusCheckRollup; this helper is for tests / callers that have raw values.
+    return pr.checks_state
+
+
+def blocking_reason(
+    pr: RenovatePR,
+    category: Category,
+    update_type: UpdateType,
+) -> BlockingReason:
+    """
+    Why has this open PR not merged?
+
+    Mirrors the conditions in renovate-auto-approve-reusable.yml.
+    """
+    if not auto_merge_expected(category, update_type):
+        return BlockingReason.AWAITING_HUMAN_REVIEW
+
+    # For auto-merge-eligible PRs, check gate conditions in priority order.
+    if pr.mergeable == "CONFLICTING":
+        return BlockingReason.MERGE_CONFLICT
+
+    if _non_dep_files(pr.files):
+        return BlockingReason.NON_DEP_FILES
+
+    if pr.checks_state == ChecksState.FAILING:
+        return BlockingReason.CHECKS_FAILING
+    if pr.checks_state == ChecksState.PENDING:
+        return BlockingReason.CHECKS_PENDING
+
+    # All conditions satisfied — atlan-ci approval just hasn't been posted yet.
+    return BlockingReason.AWAITING_APPROVAL
+
+
+def classify(pr: RenovatePR) -> RenovatePR:
+    """
+    Return a new RenovatePR with category, update_type, auto_merge_expected,
+    blocking_reason, and age_days populated.
+    """
+    from datetime import datetime, timezone
+
+    cat = categorize(pr)
+    ut = derive_update_type(pr)
+    ame = auto_merge_expected(cat, ut)
+    br = blocking_reason(pr, cat, ut)
+
+    now = datetime.now(timezone.utc)
+    # pr.created_at may be tz-aware or naive; normalise.
+    created = pr.created_at
+    if created.tzinfo is None:
+        from datetime import timezone as _tz
+
+        created = created.replace(tzinfo=_tz.utc)
+    age = max(0, (now - created).days)
+
+    # dataclass is frozen=True; use replace pattern.
+    import dataclasses
+
+    return dataclasses.replace(
+        pr,
+        category=cat,
+        update_type=ut,
+        auto_merge_expected=ame,
+        blocking_reason=br,
+        age_days=age,
+    )

--- a/packages/conformance/conformance/renovate/models.py
+++ b/packages/conformance/conformance/renovate/models.py
@@ -1,0 +1,120 @@
+"""Typed model contracts for the Renovate fleet dashboard scanner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+
+class Category(str, Enum):
+    """Renovate PR category, derived from self-managed labels (branch/title fallback)."""
+
+    LOCK_MAINTENANCE = "lock-maintenance"
+    GITHUB_ACTIONS = "github-actions"
+    CONTRACT_TOOLKIT = "contract-toolkit"
+    PYTHON_DEP = "python-dep"
+    UNKNOWN = "unknown"
+
+
+class UpdateType(str, Enum):
+    """Semver update type reported by Renovate labels."""
+
+    MAJOR = "major"
+    MINOR = "minor"
+    PATCH = "patch"
+    DIGEST = "digest"
+    PIN = "pin"
+    UNKNOWN = "unknown"
+
+
+class BlockingReason(str, Enum):
+    """Why an open Renovate PR has not merged."""
+
+    AWAITING_HUMAN_REVIEW = (
+        "awaiting_human_review"  # autoMergeExpected=False — by design
+    )
+    CHECKS_FAILING = "checks_failing"  # required CI checks red
+    CHECKS_PENDING = "checks_pending"  # required CI checks still running
+    MERGE_CONFLICT = "merge_conflict"  # mergeable=CONFLICTING
+    NON_DEP_FILES = "non_dep_files"  # changed files outside auto-approve allowlist
+    AWAITING_APPROVAL = (
+        "awaiting_approval"  # eligible; atlan-ci approval not yet posted
+    )
+    UNKNOWN = "unknown"
+
+
+class ChecksState(str, Enum):
+    GREEN = "green"
+    FAILING = "failing"
+    PENDING = "pending"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class RenovatePR:
+    """Normalised representation of a single Renovate PR."""
+
+    number: int
+    url: str
+    title: str
+    branch: str
+    labels: list[str]
+    mergeable: str  # "MERGEABLE" | "CONFLICTING" | "UNKNOWN"
+    review_decision: str  # "APPROVED" | "REVIEW_REQUIRED" | "" | ...
+    checks_state: ChecksState
+    files: list[str]  # changed filenames
+    created_at: datetime
+    updated_at: datetime
+    is_draft: bool
+    body: str
+    # populated by classify()
+    category: Category = Category.UNKNOWN
+    update_type: UpdateType = UpdateType.UNKNOWN
+    auto_merge_expected: bool = False
+    blocking_reason: BlockingReason = BlockingReason.UNKNOWN
+    age_days: int = 0
+
+
+@dataclass
+class AutoMergeStats:
+    """Auto-merge counts over a trailing time window."""
+
+    window_days: int
+    auto_merged: int  # merged + atlan-ci auto-approval signature detected
+    human_merged: int  # merged without that signature
+    total_merged: int
+
+
+@dataclass
+class RepoRenovateSummary:
+    open_total: int
+    needs_human: int  # autoMergeExpected=False
+    auto_merge_eligible_but_stuck: int  # autoMergeExpected=True but still open
+    by_category: dict[str, int] = field(default_factory=dict)
+    by_blocking_reason: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class RepoRenovateReport:
+    """Per-repo renovate dashboard payload — matches repos/<slug>.json contract."""
+
+    repo: str
+    collected_at: str  # ISO-8601 UTC
+    open_prs: list[RenovatePR]
+    summary: RepoRenovateSummary
+    auto_merged: Optional[AutoMergeStats]
+
+
+@dataclass
+class FleetRenovateReport:
+    """Fleet-wide aggregate — matches fleet.json contract."""
+
+    collected_at: str
+    fleet_size: int
+    repos_with_open_prs: int
+    total_open_prs: int
+    by_category: dict[str, int]
+    by_blocking_reason: dict[str, int]
+    auto_merged_in_window: Optional[AutoMergeStats]

--- a/packages/conformance/conformance/renovate/scan.py
+++ b/packages/conformance/conformance/renovate/scan.py
@@ -37,19 +37,51 @@ _AUTO_APPROVE_SIGNATURE = "**Renovate auto-approval:**"
 _WINDOW_DAYS = 30
 
 
+_CHECKS_FAILING: frozenset[str] = frozenset(
+    {"FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"}
+)
+_CHECKS_PENDING: frozenset[str] = frozenset(
+    {"PENDING", "IN_PROGRESS", "QUEUED", "WAITING", "REQUESTED"}
+)
+
+
 def _parse_checks_state(rollup: list[dict]) -> ChecksState:
-    """Reduce statusCheckRollup to ChecksState."""
+    """Reduce statusCheckRollup to ChecksState.
+
+    gh pr list --json statusCheckRollup returns a mix of two item shapes:
+    - StatusContext (commit status): non-null ``state`` field
+      (SUCCESS | FAILURE | PENDING | ERROR | EXPECTED).
+    - CheckRun (Actions workflow step): ``state`` is null; use ``conclusion``
+      when the run is completed (success | failure | timed_out | cancelled |
+      action_required | neutral | skipped), or ``status`` while it is still
+      running (queued | in_progress | waiting | requested).
+
+    Empirically the vast majority of items on a Renovate PR are CheckRun with
+    state=null, so reading only ``state`` misclassifies failing/pending checks
+    as GREEN.
+    """
     if not rollup:
         return ChecksState.UNKNOWN
-    states = {c.get("state", "").upper() for c in rollup}
-    if "FAILURE" in states or "ERROR" in states:
+
+    states: set[str] = set()
+    for c in rollup:
+        raw_state = c.get("state")
+        if raw_state:
+            # StatusContext item.
+            states.add(raw_state.upper())
+        else:
+            # CheckRun item: conclusion is set when completed, status otherwise.
+            conclusion = c.get("conclusion") or ""
+            status = c.get("status") or ""
+            states.add((conclusion or status).upper())
+
+    states.discard("")
+
+    if not states:
+        return ChecksState.UNKNOWN
+    if states & _CHECKS_FAILING:
         return ChecksState.FAILING
-    if (
-        "PENDING" in states
-        or "IN_PROGRESS" in states
-        or "QUEUED" in states
-        or "WAITING" in states
-    ):
+    if states & _CHECKS_PENDING:
         return ChecksState.PENDING
     return ChecksState.GREEN
 

--- a/packages/conformance/conformance/renovate/scan.py
+++ b/packages/conformance/conformance/renovate/scan.py
@@ -1,0 +1,360 @@
+"""
+Renovate fleet dashboard scanner.
+
+Reads raw GitHub API PR data (from `gh pr list --json ...` output files),
+classifies each PR, builds per-repo and fleet reports, and writes JSON +
+append-only history JSONL to an output directory.
+
+CLI entry point: conformance renovate-scan
+  --input DIR    directory containing per-repo JSON files named <slug>.json
+                 (each file is the stdout of `gh pr list --json ... > <slug>.json`)
+  --merged DIR   directory with merged-PR JSON files (for auto-merge counts), optional
+  --out DIR      output directory (default: /tmp/renovate-dashboard)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from conformance.renovate.classify import classify
+from conformance.renovate.models import (
+    AutoMergeStats,
+    BlockingReason,
+    ChecksState,
+    FleetRenovateReport,
+    RenovatePR,
+    RepoRenovateReport,
+    RepoRenovateSummary,
+)
+
+# Stable signature written by renovate-auto-approve-reusable.yml.
+_AUTO_APPROVE_SIGNATURE = "**Renovate auto-approval:**"
+_WINDOW_DAYS = 30
+
+
+def _parse_checks_state(rollup: list[dict]) -> ChecksState:
+    """Reduce statusCheckRollup to ChecksState."""
+    if not rollup:
+        return ChecksState.UNKNOWN
+    states = {c.get("state", "").upper() for c in rollup}
+    if "FAILURE" in states or "ERROR" in states:
+        return ChecksState.FAILING
+    if (
+        "PENDING" in states
+        or "IN_PROGRESS" in states
+        or "QUEUED" in states
+        or "WAITING" in states
+    ):
+        return ChecksState.PENDING
+    return ChecksState.GREEN
+
+
+def _parse_pr(raw: dict) -> Optional[RenovatePR]:
+    """Parse a single item from `gh pr list --json` output."""
+    try:
+        created = datetime.fromisoformat(raw["createdAt"].replace("Z", "+00:00"))
+        updated = datetime.fromisoformat(raw["updatedAt"].replace("Z", "+00:00"))
+        labels = [lb["name"] for lb in raw.get("labels", [])]
+        files = [f["path"] for f in raw.get("files", [])]
+        rollup = raw.get("statusCheckRollup") or []
+        return RenovatePR(
+            number=raw["number"],
+            url=raw["url"],
+            title=raw["title"],
+            branch=raw.get("headRefName", ""),
+            labels=labels,
+            mergeable=raw.get("mergeable", "UNKNOWN"),
+            review_decision=raw.get("reviewDecision") or "",
+            checks_state=_parse_checks_state(rollup),
+            files=files,
+            created_at=created,
+            updated_at=updated,
+            is_draft=raw.get("isDraft", False),
+            body=raw.get("body") or "",
+        )
+    except (KeyError, ValueError) as exc:
+        print(f"Warning: skipping malformed PR record: {exc}", file=sys.stderr)
+        return None
+
+
+def _auto_merge_stats(merged_raw: list[dict]) -> AutoMergeStats:
+    """
+    Count auto-merged vs human-merged PRs.
+
+    A PR counts as auto-merged if any review from 'atlan-ci' with state
+    'APPROVED' starts with the stable auto-approval signature.
+    """
+    auto_merged = 0
+    human_merged = 0
+    for pr in merged_raw:
+        reviews = pr.get("reviews", [])
+        was_auto = any(
+            r.get("author", {}).get("login") == "atlan-ci"
+            and r.get("state") == "APPROVED"
+            and (r.get("body") or "").startswith(_AUTO_APPROVE_SIGNATURE)
+            for r in reviews
+        )
+        if was_auto:
+            auto_merged += 1
+        else:
+            human_merged += 1
+    total = auto_merged + human_merged
+    return AutoMergeStats(
+        window_days=_WINDOW_DAYS,
+        auto_merged=auto_merged,
+        human_merged=human_merged,
+        total_merged=total,
+    )
+
+
+def _build_repo_report(
+    repo: str,
+    open_prs_raw: list[dict],
+    merged_raw: Optional[list[dict]],
+) -> RepoRenovateReport:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    classified: list[RenovatePR] = []
+    for raw in open_prs_raw:
+        pr = _parse_pr(raw)
+        if pr is not None and not pr.is_draft:
+            classified.append(classify(pr))
+
+    by_category: dict[str, int] = {}
+    by_blocking: dict[str, int] = {}
+    needs_human = 0
+    stuck = 0
+    for pr in classified:
+        by_category[pr.category.value] = by_category.get(pr.category.value, 0) + 1
+        by_blocking[pr.blocking_reason.value] = (
+            by_blocking.get(pr.blocking_reason.value, 0) + 1
+        )
+        if not pr.auto_merge_expected:
+            needs_human += 1
+        elif pr.blocking_reason != BlockingReason.AWAITING_HUMAN_REVIEW:
+            stuck += 1
+
+    summary = RepoRenovateSummary(
+        open_total=len(classified),
+        needs_human=needs_human,
+        auto_merge_eligible_but_stuck=stuck,
+        by_category=by_category,
+        by_blocking_reason=by_blocking,
+    )
+
+    auto_stats: Optional[AutoMergeStats] = None
+    if merged_raw is not None:
+        auto_stats = _auto_merge_stats(merged_raw)
+
+    return RepoRenovateReport(
+        repo=repo,
+        collected_at=now,
+        open_prs=classified,
+        summary=summary,
+        auto_merged=auto_stats,
+    )
+
+
+def _pr_to_dict(pr: RenovatePR) -> dict:
+    return {
+        "number": pr.number,
+        "url": pr.url,
+        "title": pr.title,
+        "branch": pr.branch,
+        "labels": pr.labels,
+        "category": pr.category.value,
+        "updateType": pr.update_type.value,
+        "autoMergeExpected": pr.auto_merge_expected,
+        "blockingReason": pr.blocking_reason.value,
+        "mergeable": pr.mergeable,
+        "checksState": pr.checks_state.value,
+        "ageDays": pr.age_days,
+        "createdAt": pr.created_at.isoformat(),
+        "updatedAt": pr.updated_at.isoformat(),
+    }
+
+
+def _report_to_dict(report: RepoRenovateReport) -> dict:
+    return {
+        "repo": report.repo,
+        "collectedAt": report.collected_at,
+        "openPRs": [_pr_to_dict(p) for p in report.open_prs],
+        "summary": {
+            "open": report.summary.open_total,
+            "needsHuman": report.summary.needs_human,
+            "autoMergeEligibleButStuck": report.summary.auto_merge_eligible_but_stuck,
+            "byCategory": report.summary.by_category,
+            "byBlockingReason": report.summary.by_blocking_reason,
+        },
+        "autoMerged": {
+            "windowDays": report.auto_merged.window_days,
+            "autoMerged": report.auto_merged.auto_merged,
+            "humanMerged": report.auto_merged.human_merged,
+            "totalMerged": report.auto_merged.total_merged,
+        }
+        if report.auto_merged
+        else None,
+    }
+
+
+def _fleet_to_dict(fleet: FleetRenovateReport) -> dict:
+    return {
+        "collectedAt": fleet.collected_at,
+        "fleetSize": fleet.fleet_size,
+        "reposWithOpenPRs": fleet.repos_with_open_prs,
+        "totalOpenPRs": fleet.total_open_prs,
+        "byCategory": fleet.by_category,
+        "byBlockingReason": fleet.by_blocking_reason,
+        "autoMergedInWindow": {
+            "windowDays": fleet.auto_merged_in_window.window_days,
+            "autoMerged": fleet.auto_merged_in_window.auto_merged,
+            "humanMerged": fleet.auto_merged_in_window.human_merged,
+            "totalMerged": fleet.auto_merged_in_window.total_merged,
+        }
+        if fleet.auto_merged_in_window
+        else None,
+    }
+
+
+def _build_fleet(reports: list[RepoRenovateReport]) -> FleetRenovateReport:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    by_cat: dict[str, int] = {}
+    by_block: dict[str, int] = {}
+    total_open = 0
+    repos_with_open = 0
+    total_auto = 0
+    total_human = 0
+
+    for r in reports:
+        total_open += r.summary.open_total
+        if r.summary.open_total > 0:
+            repos_with_open += 1
+        for k, v in r.summary.by_category.items():
+            by_cat[k] = by_cat.get(k, 0) + v
+        for k, v in r.summary.by_blocking_reason.items():
+            by_block[k] = by_block.get(k, 0) + v
+        if r.auto_merged:
+            total_auto += r.auto_merged.auto_merged
+            total_human += r.auto_merged.human_merged
+
+    fleet_auto = (
+        AutoMergeStats(
+            window_days=_WINDOW_DAYS,
+            auto_merged=total_auto,
+            human_merged=total_human,
+            total_merged=total_auto + total_human,
+        )
+        if any(r.auto_merged for r in reports)
+        else None
+    )
+
+    return FleetRenovateReport(
+        collected_at=now,
+        fleet_size=len(reports),
+        repos_with_open_prs=repos_with_open,
+        total_open_prs=total_open,
+        by_category=by_cat,
+        by_blocking_reason=by_block,
+        auto_merged_in_window=fleet_auto,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="conformance renovate-scan",
+        description="Build Renovate fleet dashboard JSON from gh pr list output files.",
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Directory containing open-PR JSON files named <slug>.json",
+    )
+    parser.add_argument(
+        "--merged",
+        default="",
+        help="Directory containing merged-PR JSON files named <slug>.json (optional)",
+    )
+    parser.add_argument(
+        "--out",
+        default="/tmp/renovate-dashboard",
+        help="Output directory (default: /tmp/renovate-dashboard)",
+    )
+    args = parser.parse_args(argv)
+
+    input_dir = Path(args.input)
+    merged_dir = Path(args.merged) if args.merged else None
+    out_dir = Path(args.out)
+    (out_dir / "repos").mkdir(parents=True, exist_ok=True)
+
+    reports: list[RepoRenovateReport] = []
+
+    for open_file in sorted(input_dir.glob("*.json")):
+        slug = open_file.stem
+        repo = slug.replace("_", "/", 1)  # atlanhq_my-app → atlanhq/my-app
+
+        try:
+            open_prs_raw: list[dict] = json.loads(open_file.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"Warning: skipping {open_file}: {exc}", file=sys.stderr)
+            continue
+
+        merged_raw: Optional[list[dict]] = None
+        if merged_dir:
+            merged_file = merged_dir / open_file.name
+            if merged_file.exists():
+                try:
+                    merged_raw = json.loads(merged_file.read_text())
+                except (json.JSONDecodeError, OSError):
+                    pass
+
+        report = _build_repo_report(repo, open_prs_raw, merged_raw)
+        reports.append(report)
+
+        # Per-repo output.
+        repo_path = out_dir / "repos" / f"{slug}.json"
+        repo_path.write_text(json.dumps(_report_to_dict(report), indent=2))
+
+        # Append-only history.
+        history_entry = {
+            "date": report.collected_at[:10],
+            "repo": report.repo,
+            "openTotal": report.summary.open_total,
+            "needsHuman": report.summary.needs_human,
+            "autoMergeEligibleButStuck": report.summary.auto_merge_eligible_but_stuck,
+        }
+        history_path = out_dir / f"history_{slug}.jsonl"
+        with history_path.open("a") as fh:
+            fh.write(json.dumps(history_entry) + "\n")
+
+        print(
+            f"{repo}: {report.summary.open_total} open "
+            f"({report.summary.needs_human} human, "
+            f"{report.summary.auto_merge_eligible_but_stuck} stuck)",
+            file=sys.stderr,
+        )
+
+    # Fleet aggregate.
+    fleet = _build_fleet(reports)
+    (out_dir / "fleet.json").write_text(json.dumps(_fleet_to_dict(fleet), indent=2))
+
+    # Fleet history.
+    fleet_history = {
+        "date": fleet.collected_at[:10],
+        "fleetSize": fleet.fleet_size,
+        "reposWithOpenPRs": fleet.repos_with_open_prs,
+        "totalOpenPRs": fleet.total_open_prs,
+    }
+    with (out_dir / "history_fleet.jsonl").open("a") as fh:
+        fh.write(json.dumps(fleet_history) + "\n")
+
+    print(
+        f"Fleet: {fleet.fleet_size} repos, {fleet.total_open_prs} open PRs, "
+        f"{fleet.repos_with_open_prs} repos with open PRs",
+        file=sys.stderr,
+    )
+    return 0

--- a/packages/conformance/tests/test_renovate_classify.py
+++ b/packages/conformance/tests/test_renovate_classify.py
@@ -1,0 +1,235 @@
+"""Unit tests for the Renovate PR classifier (conformance.renovate.classify)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from conformance.renovate.classify import classify
+from conformance.renovate.models import (
+    BlockingReason,
+    Category,
+    ChecksState,
+    RenovatePR,
+    UpdateType,
+)
+
+# Anchor "now" once so age computations are deterministic within a run. _OLD is
+# clamped to day-of-month >= 1 so the 3-day-old PR stays in the same month.
+_NOW = datetime.now(timezone.utc)
+_OLD = datetime(_NOW.year, _NOW.month, max(1, _NOW.day - 3), tzinfo=timezone.utc)
+
+
+def make_pr(
+    *,
+    number: int = 1,
+    url: str = "https://github.com/atlanhq/atlan-foo-app/pull/1",
+    title: str = "Update dependency foo to v1.2.3",
+    branch: str = "renovate/foo-1.x",
+    labels: list[str] | None = None,
+    mergeable: str = "MERGEABLE",
+    review_decision: str = "",
+    checks_state: ChecksState = ChecksState.GREEN,
+    files: list[str] | None = None,
+    created_at: datetime = _NOW,
+    updated_at: datetime = _NOW,
+    is_draft: bool = False,
+    body: str = "",
+) -> RenovatePR:
+    """Construct an unclassified RenovatePR with sane defaults for one scenario."""
+    return RenovatePR(
+        number=number,
+        url=url,
+        title=title,
+        branch=branch,
+        labels=labels if labels is not None else [],
+        mergeable=mergeable,
+        review_decision=review_decision,
+        checks_state=checks_state,
+        files=files if files is not None else [],
+        created_at=created_at,
+        updated_at=updated_at,
+        is_draft=is_draft,
+        body=body,
+    )
+
+
+# ── Category: label-driven path ──────────────────────────────────────────────
+
+
+def test_category_lock_maintenance_via_label() -> None:
+    pr = classify(make_pr(labels=["update:lock-maintenance"]))
+    assert pr.category is Category.LOCK_MAINTENANCE
+
+
+def test_category_github_actions_via_label() -> None:
+    pr = classify(make_pr(labels=["update:github-actions"]))
+    assert pr.category is Category.GITHUB_ACTIONS
+
+
+def test_category_contract_toolkit_via_label() -> None:
+    pr = classify(make_pr(labels=["contract-toolkit-update"]))
+    assert pr.category is Category.CONTRACT_TOOLKIT
+
+
+def test_category_python_dep_major_via_label() -> None:
+    pr = classify(make_pr(labels=["update:major", "dependencies"]))
+    assert pr.category is Category.PYTHON_DEP
+
+
+# ── Category: fallback parsing path (no update: labels) ──────────────────────
+
+
+def test_category_lock_maintenance_fallback() -> None:
+    pr = classify(make_pr(labels=[], branch="renovate/lock-file-maintenance"))
+    assert pr.category is Category.LOCK_MAINTENANCE
+
+
+def test_category_github_actions_fallback() -> None:
+    pr = classify(make_pr(labels=[], branch="renovate/github-actions"))
+    assert pr.category is Category.GITHUB_ACTIONS
+
+
+def test_category_contract_toolkit_fallback() -> None:
+    pr = classify(make_pr(labels=[], branch="renovate/app-contract-toolkit-1.x"))
+    assert pr.category is Category.CONTRACT_TOOLKIT
+
+
+# ── UpdateType from labels ───────────────────────────────────────────────────
+
+
+def test_update_type_major_from_label() -> None:
+    pr = classify(make_pr(labels=["update:major"]))
+    assert pr.update_type is UpdateType.MAJOR
+
+
+def test_update_type_patch_from_label() -> None:
+    pr = classify(make_pr(labels=["update:patch"]))
+    assert pr.update_type is UpdateType.PATCH
+
+
+# ── UpdateType fallback from body ────────────────────────────────────────────
+
+
+def test_update_type_major_from_body() -> None:
+    pr = classify(make_pr(labels=[], body="Updates foo from 1.2.3 -> 2.0.0"))
+    assert pr.update_type is UpdateType.MAJOR
+
+
+def test_update_type_minor_from_body() -> None:
+    pr = classify(make_pr(labels=[], body="Updates foo from 1.2.3 -> 1.4.0"))
+    assert pr.update_type is UpdateType.MINOR
+
+
+def test_update_type_unknown_when_no_signal() -> None:
+    pr = classify(make_pr(labels=[], body=""))
+    assert pr.update_type is UpdateType.UNKNOWN
+
+
+# ── auto_merge_expected ──────────────────────────────────────────────────────
+
+
+def test_auto_merge_expected_lock_maintenance() -> None:
+    pr = classify(make_pr(labels=["update:lock-maintenance"]))
+    assert pr.auto_merge_expected is True
+
+
+def test_auto_merge_expected_github_actions() -> None:
+    pr = classify(make_pr(labels=["update:github-actions"]))
+    assert pr.auto_merge_expected is True
+
+
+def test_auto_merge_expected_contract_toolkit_minor() -> None:
+    pr = classify(make_pr(labels=["contract-toolkit-update", "update:minor"]))
+    assert pr.auto_merge_expected is True
+
+
+def test_auto_merge_expected_contract_toolkit_major() -> None:
+    pr = classify(make_pr(labels=["contract-toolkit-update", "update:major"]))
+    assert pr.auto_merge_expected is False
+
+
+def test_auto_merge_expected_python_dep_minor() -> None:
+    pr = classify(make_pr(labels=["update:minor", "dependencies"]))
+    assert pr.auto_merge_expected is False
+
+
+def test_auto_merge_expected_python_dep_major() -> None:
+    pr = classify(make_pr(labels=["update:major", "dependencies"]))
+    assert pr.auto_merge_expected is False
+
+
+# ── blocking_reason ──────────────────────────────────────────────────────────
+
+
+def test_blocking_awaiting_human_review() -> None:
+    # python-dep major is not auto-merge-eligible — blocked by design.
+    pr = classify(make_pr(labels=["update:major", "dependencies"]))
+    assert pr.blocking_reason is BlockingReason.AWAITING_HUMAN_REVIEW
+
+
+def test_blocking_checks_failing() -> None:
+    pr = classify(
+        make_pr(labels=["update:lock-maintenance"], checks_state=ChecksState.FAILING)
+    )
+    assert pr.blocking_reason is BlockingReason.CHECKS_FAILING
+
+
+def test_blocking_checks_pending() -> None:
+    pr = classify(
+        make_pr(labels=["update:lock-maintenance"], checks_state=ChecksState.PENDING)
+    )
+    assert pr.blocking_reason is BlockingReason.CHECKS_PENDING
+
+
+def test_blocking_merge_conflict() -> None:
+    pr = classify(make_pr(labels=["update:lock-maintenance"], mergeable="CONFLICTING"))
+    assert pr.blocking_reason is BlockingReason.MERGE_CONFLICT
+
+
+def test_blocking_non_dep_files() -> None:
+    pr = classify(make_pr(labels=["update:github-actions"], files=["src/foo.py"]))
+    assert pr.blocking_reason is BlockingReason.NON_DEP_FILES
+
+
+def test_blocking_awaiting_approval() -> None:
+    # github-actions, all green, no conflict, only dep files changed.
+    pr = classify(
+        make_pr(
+            labels=["update:github-actions"],
+            files=[".github/workflows/test.yaml"],
+            mergeable="MERGEABLE",
+            checks_state=ChecksState.GREEN,
+        )
+    )
+    assert pr.blocking_reason is BlockingReason.AWAITING_APPROVAL
+
+
+# ── Non-dep file detection ───────────────────────────────────────────────────
+
+
+def test_dep_files_allowed() -> None:
+    pr = classify(
+        make_pr(
+            labels=["update:github-actions"],
+            files=[
+                ".github/workflows/test.yaml",
+                "uv.lock",
+                "packages/foo/uv.lock",
+                "pyproject.toml",
+            ],
+        )
+    )
+    assert pr.blocking_reason is not BlockingReason.NON_DEP_FILES
+
+
+def test_non_dep_file_triggers_block() -> None:
+    pr = classify(make_pr(labels=["update:github-actions"], files=["src/app.py"]))
+    assert pr.blocking_reason is BlockingReason.NON_DEP_FILES
+
+
+# ── age_days ─────────────────────────────────────────────────────────────────
+
+
+def test_age_days_computed() -> None:
+    pr = classify(make_pr(created_at=_OLD, updated_at=_NOW))
+    assert pr.age_days >= 3

--- a/packages/conformance/tests/test_renovate_classify.py
+++ b/packages/conformance/tests/test_renovate_classify.py
@@ -12,6 +12,7 @@ from conformance.renovate.models import (
     RenovatePR,
     UpdateType,
 )
+from conformance.renovate.scan import _parse_checks_state
 
 # Anchor "now" once so age computations are deterministic within a run. _OLD is
 # clamped to day-of-month >= 1 so the 3-day-old PR stays in the same month.
@@ -233,3 +234,60 @@ def test_non_dep_file_triggers_block() -> None:
 def test_age_days_computed() -> None:
     pr = classify(make_pr(created_at=_OLD, updated_at=_NOW))
     assert pr.age_days >= 3
+
+
+# ── _parse_checks_state ───────────────────────────────────────────────────────
+
+
+def test_parse_checks_state_status_context_success() -> None:
+    # StatusContext item: non-null state field
+    assert _parse_checks_state([{"state": "SUCCESS"}]) is ChecksState.GREEN
+
+
+def test_parse_checks_state_status_context_failure() -> None:
+    # StatusContext item: non-null state field, failing
+    assert _parse_checks_state([{"state": "FAILURE"}]) is ChecksState.FAILING
+
+
+def test_parse_checks_state_checkrun_conclusion_failure() -> None:
+    # CheckRun item: state=null, conclusion=failure — the core bug this fixes
+    assert (
+        _parse_checks_state(
+            [{"state": None, "conclusion": "failure", "status": "completed"}]
+        )
+        is ChecksState.FAILING
+    )
+
+
+def test_parse_checks_state_checkrun_in_progress() -> None:
+    # CheckRun item: state=null, no conclusion yet, status=in_progress
+    assert (
+        _parse_checks_state(
+            [{"state": None, "conclusion": None, "status": "in_progress"}]
+        )
+        is ChecksState.PENDING
+    )
+
+
+def test_parse_checks_state_mixed_all_green() -> None:
+    # Real-world mix: StatusContext success + CheckRun success + CheckRun skipped
+    rollup = [
+        {"state": "SUCCESS"},
+        {"state": None, "conclusion": "success", "status": "completed"},
+        {"state": None, "conclusion": "skipped", "status": "completed"},
+    ]
+    assert _parse_checks_state(rollup) is ChecksState.GREEN
+
+
+def test_parse_checks_state_failing_checkrun_not_classified_green() -> None:
+    # The pre-fix bug: CheckRun with state=null and conclusion=failure was
+    # previously misclassified as GREEN because only `state` was read.
+    rollup = [
+        {"state": None, "conclusion": "failure", "status": "completed"},
+        {"state": None, "conclusion": "success", "status": "completed"},
+    ]
+    assert _parse_checks_state(rollup) is ChecksState.FAILING
+
+
+def test_parse_checks_state_empty_rollup() -> None:
+    assert _parse_checks_state([]) is ChecksState.UNKNOWN

--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -31,7 +31,10 @@
     ],
     "automerge": true,
     "automergeType": "pr",
-    "platformAutomerge": true
+    "platformAutomerge": true,
+    "addLabels": [
+      "update:lock-maintenance"
+    ]
   },
   "packageRules": [
     {
@@ -85,7 +88,10 @@
       "groupName": "github-actions",
       "automerge": true,
       "automergeType": "pr",
-      "platformAutomerge": true
+      "platformAutomerge": true,
+      "addLabels": [
+        "update:github-actions"
+      ]
     },
     {
       "description": "Trivy CLI version (version: in with: blocks): disable auto-updates. The scanner version is pinned deliberately \u2014 scan results drift when Trivy's vuln DB schema or detection logic changes, so bumps must be a conscious decision.",
@@ -96,6 +102,19 @@
         "github-actions"
       ],
       "enabled": false
+    },
+    {
+      "description": "Fleet-wide update-type labels — applied to every PR so the Renovate dashboard scanner can classify without title-parsing. Renovate auto-creates these labels per repo; no per-repo manual setup needed.",
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "digest",
+        "pin"
+      ],
+      "addLabels": [
+        "update:{{{updateType}}}"
+      ]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary

- Adds a `renovate-dashboard/` S3 data feed tracking Renovate PR activity across the entire consumer fleet, so connector-pulse can surface Renovate health alongside the conformance dashboard
- Enriches the shared Renovate preset with self-managed `update:*` labels (auto-created by Renovate per repo — zero per-repo setup needed across 200+ adopting repos)
- Central cron scanner (`renovate-scan` CLI + `.github/workflows/renovate-dashboard.yaml`) queries the fleet every 6h, classifies each PR by category and blocking reason, and writes per-repo + fleet JSON to S3

## What's in the feed

**Per-repo** (`renovate-dashboard/repos/<slug>.json`): open PRs classified by category (`lock-maintenance`, `github-actions`, `contract-toolkit`, `python-dep`), blocking reason (`awaiting_human_review`, `checks_failing`, `checks_pending`, `merge_conflict`, `non_dep_files`, `awaiting_approval`), auto-merge-expected flag, and a 30-day auto-merged vs human-merged count.

**Fleet** (`renovate-dashboard/fleet.json`): total fleet size, repos with open PRs, totals by category and blocking reason.

**History** (`renovate-dashboard/history/*.jsonl`): append-only daily snapshots per repo + fleet for trend lines.

## Classification logic

Labels are primary (from the preset `addLabels` rules — label-driven, deterministic). Branch/title parsing is kept as a transitional fallback for PRs opened before the label rollout; Renovate re-labels them on its next run.

Auto-merge policy mirrors `renovate-config/default.json` exactly:
- `lock-maintenance` → auto (uv.lock refresh, in-range)
- `github-actions` → auto (all update types)
- `contract-toolkit` minor/patch → auto; major → human
- `python-dep` version updates → human (edits `pyproject.toml` constraint, out-of-range)

Blocking-reason logic mirrors the gate in `renovate-auto-approve-reusable.yml` (file allowlist, required-checks state, merge conflicts).

## Test plan

- [x] 27 unit tests covering all categories (label + fallback paths), all blocking reasons, auto-merge policy, dep-file allowlist, age calculation — `999 passed, 1 xfailed`
- [x] Pre-commit clean (ruff, ruff-format, isort, pyright)
- [ ] Trigger `renovate-dashboard.yaml` via `workflow_dispatch` after merge; confirm objects appear at `https://k.atlan.dev/renovate-dashboard/`
- [ ] Spot-check a `repos/<slug>.json` and `fleet.json` against live Renovate PRs in a consumer repo

## Out of scope

connector-pulse rendering (separate follow-up ticket per BLDX-1468 plan).

Closes BLDX-1468