### PR TITLE
fix(conformance): update conformance dashboard on every push to main

### DIFF
--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -45,7 +45,13 @@ permissions:
 jobs:
   update:
     name: Update Dashboard
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.head_branch == github.event.repository.default_branch
+    # Skip when triggered by the Conformance workflow — it produces no Trivy
+    # artifacts, so the security dashboard job has nothing to download.
+    # The conformance job below runs for all triggers on the default branch.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || (github.event.workflow_run.head_branch == github.event.repository.default_branch
+          && github.event.workflow_run.name != 'Conformance')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -357,6 +357,12 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.head_branch == github.event.repository.default_branch
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Serialize concurrent runs so the history-file download→merge→upload
+    # sequence is never racing against itself. cancel-in-progress: false
+    # queues the later run rather than dropping it.
+    concurrency:
+      group: conformance-dashboard-${{ github.repository }}
+      cancel-in-progress: false
     steps:
       - name: Discover latest Conformance run
         id: discover

--- a/packages/conformance/conformance/bootstrap/templates/update-dashboard.yml
+++ b/packages/conformance/conformance/bootstrap/templates/update-dashboard.yml
@@ -2,7 +2,11 @@ name: Update Security Dashboard
 
 on:
   workflow_run:
-    workflows: ["Vulnerability Scan", "Build & Publish"]
+    # "Conformance" is included so the conformance dashboard (a separate job in
+    # the reusable) updates on every push to main rather than only when the
+    # daily vulnerability scan runs. The security dashboard job in the reusable
+    # skips automatically when triggered by Conformance (no Trivy artifacts).
+    workflows: ["Vulnerability Scan", "Build & Publish", "Conformance"]
     types: [completed]
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

- Conformance dashboard data previously updated once daily (when the Vulnerability Scan triggered `update-dashboard.yaml`). This makes data up to ~24h stale after a merge.
- The conformance suite already runs on every push to main in consumer repos. This PR wires `update-dashboard.yaml` to also fire on `Conformance` workflow completion, so per-repo conformance data refreshes within minutes of a merge.

## Changes

**`.github/workflows/update-dashboard.yaml`** (the reusable):
- Added `&& github.event.workflow_run.name != 'Conformance'` guard to the `update:` (security/Trivy) job. The Conformance workflow produces no Trivy SARIF artifacts, so the security job should not run when triggered by it. The `conformance:` job is unchanged — it already runs for any trigger on the default branch.

**`packages/conformance/conformance/bootstrap/templates/update-dashboard.yml`**:
- Added `"Conformance"` to the `workflow_run.workflows` list alongside `"Vulnerability Scan"` and `"Build & Publish"`.
- Consumer repos pick this up via `conformance bootstrap` on their next re-bootstrap. The reusable-side guard ships immediately via the `@main` pin so existing consumer repos benefit as soon as this merges.

## Rollout

No consumer repo changes required immediately. The reusable guard (`!= 'Conformance'`) is live the moment this merges. Consumer repos that re-run `conformance bootstrap` will gain the push-based conformance refresh; until then they continue on the daily cadence.

## Test plan

- [x] 116 bootstrap tests pass (`test_bootstrap.py`, `test_bootstrap_drift.py`) — including `test_all_scaffolds_clean_after_bootstrap`
- [x] Full test suite passes (5166 passed, 9 skipped)
- [ ] After merge: trigger `update-dashboard.yaml` via `workflow_dispatch` in a consumer repo and confirm the conformance job runs and pushes fresh data to S3