### PR TITLE
ci(sdr-e2e): forward git-token to docker buildx as 'git_token' secret

### DIFF
--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -121,6 +121,26 @@ inputs:
       agent-name so the worker registers on its own Temporal queue).
     required: false
     default: ""
+  git-token:
+    description: |
+      Optional GitHub token forwarded to the docker buildx build as the
+      `git_token` build secret. Connectors whose pyproject.toml declares
+      git+ssh / git+https dependencies on other private atlanhq repos
+      (e.g. `query-redaction` from `atlan-query-intelligence-app`) need
+      this so `uv sync` inside the Docker build can authenticate the
+      clone. Pass `${{ secrets.ORG_PAT_GITHUB }}` (an org PAT with
+      cross-repo read) from the caller workflow.
+
+      When empty (the default), no `--secret` flag is appended to the
+      docker buildx invocation — connectors with PyPI-only dependencies
+      stay unaffected.
+
+      Consumed by the Dockerfile as:
+          RUN --mount=type=secret,id=git_token,uid=1000 \
+              git config --global url."https://x-access-token:$(cat /run/secrets/git_token)@github.com/".insteadOf "ssh://git@github.com/" \
+              && uv sync --locked --no-install-project
+    required: false
+    default: ""
 outputs:
   test-outcome:
     description: pytest exit outcome (success/failure)
@@ -208,6 +228,11 @@ runs:
       shell: bash
       env:
         BASE_IMAGE_REF: ${{ inputs.base-image-ref }}
+        # Read by --secret id=git_token,env=GIT_TOKEN below. The env-var
+        # form (vs --secret-file) keeps the token out of the buildx
+        # command line and out of any tmpfile on the runner — buildx
+        # streams it directly into the build context.
+        GIT_TOKEN: ${{ inputs.git-token }}
       run: |
         SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
         IMAGE="ghcr.io/atlanhq/${{ inputs.app-image-name }}:sdr-test-${SHORT_SHA}"
@@ -220,6 +245,15 @@ runs:
         if [ -n "${BASE_IMAGE_REF}" ]; then
           echo "Building connector on dispatched base image: ${BASE_IMAGE_REF}"
           BUILD_ARGS+=(--build-arg "BASE_IMAGE=${BASE_IMAGE_REF}")
+        fi
+        # When the caller supplies git-token, forward it as the
+        # `git_token` build secret so Dockerfiles that clone private
+        # atlanhq repos during `uv sync` can authenticate. Connectors
+        # with PyPI-only deps don't need this — leaving the input empty
+        # skips the flag entirely so their builds stay unchanged.
+        if [ -n "${GIT_TOKEN}" ]; then
+          echo "Forwarding git-token to docker build as 'git_token' secret"
+          BUILD_ARGS+=(--secret "id=git_token,env=GIT_TOKEN")
         fi
         # --push pushes to GHCR; compose pulls from there at run-time
         # (atlan-configurator wires app_image into the generated


### PR DESCRIPTION
## Summary

Adds an optional `git-token` input to the `sdr-e2e` composite action. When supplied, it's forwarded to `docker buildx build` via `--secret id=git_token,env=GIT_TOKEN`, so Dockerfiles that clone private atlanhq repos during `uv sync` can authenticate.

## Why this is needed

`atlan-bigquery-app` (PR #166's run [linked here](https://github.com/atlanhq/atlan-bigquery-app/actions/runs/28010410079/job/82902034939)) has a pyproject git dependency on `query-redaction` from the private `atlanhq/atlan-query-intelligence-app` repo. Its Dockerfile already supports the `git_token` secret mount:

```dockerfile
RUN --mount=type=secret,id=git_token,uid=1000 \
    git config --global url."https://x-access-token:$(cat /run/secrets/git_token)@github.com/".insteadOf "ssh://git@github.com/" \
    && uv sync --locked --no-install-project
```

But this composite action's docker buildx call never passed `--secret`, so the mount resolved to an empty file. `git config` ended up rewriting URLs to `https://x-access-token:@github.com/` (no token), GitHub rejected with the standard `Invalid username or token. Password authentication is not supported` error, and every SDR build failed:

```
× Failed to download and build `query-redaction @ git+ssh://…`
├─▶ Git operation failed
├─▶ failed to fetch commit 2d92af0a…
╰─▶ fatal: Authentication failed for
    'https://github.com/atlanhq/atlan-query-intelligence-app.git/'
```

## What this PR changes

One file: `.github/actions/sdr-e2e/action.yaml`.

- **New input** `git-token` (optional, default `""`). Caller passes `${{ secrets.ORG_PAT_GITHUB }}` — the standard org PAT with cross-repo read.
- **New env-var binding** on the docker-build step (`GIT_TOKEN: ${{ inputs.git-token }}`).
- **Conditional** in the build step: when `GIT_TOKEN` is non-empty, appends `--secret id=git_token,env=GIT_TOKEN` to `BUILD_ARGS`. When empty (the default), no flag is added — existing SDR-onboarded repos with PyPI-only deps stay unchanged.

## Backward compatibility

- Default value is empty → flag is not appended → docker buildx command is byte-for-byte identical for callers that don't opt in.
- Tested mentally against the existing SDR-enabled connectors: postgres / oracle / trino / cloudsql-postgres / kafka — none declare git-based python deps, none need to set `git-token`, all keep working.

## Caller usage

After this lands, atlan-bigquery-app's `tests.yaml` adds one line to its sdr job:

```yaml
- uses: atlanhq/application-sdk/.github/actions/sdr-e2e@main
  with:
    app-name: bigquery
    app-image-name: atlan-bigquery-app
    git-token: ${{ secrets.ORG_PAT_GITHUB }}    # ← NEW
    secrets-script: .github/sdr-e2e/make-secrets.py
```

Then the SDR docker build clones `query-redaction` successfully and the rest of the pipeline runs.

## Security

- Token is forwarded via `env=GIT_TOKEN` (not `--secret-file`) → buildx streams it into the build context, never persists to a tmpfile or logs the value.
- Inside the Dockerfile it's only readable via the `--mount=type=secret,id=git_token` mount, scoped to the single RUN step and torn down after.
- Empty-string default means the token is never set unless the caller explicitly opts in.

## Test plan

- [ ] Sanity: an existing SDR-enabled repo (e.g., postgres / oracle) re-runs its SDR job on this branch via cross-repo dispatch — confirm it still passes without setting `git-token`
- [ ] atlan-bigquery-app#166 (or a follow-up there) is updated to pass `git-token: ${{ secrets.ORG_PAT_GITHUB }}`, then SDR build succeeds and the query-redaction clone resolves
