### PR TITLE
ci(sdr-e2e): drop ${{ }} template expression from git-token description

### DIFF
--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -128,8 +128,8 @@ inputs:
       git+ssh / git+https dependencies on other private atlanhq repos
       (e.g. `query-redaction` from `atlan-query-intelligence-app`) need
       this so `uv sync` inside the Docker build can authenticate the
-      clone. Pass `${{ secrets.ORG_PAT_GITHUB }}` (an org PAT with
-      cross-repo read) from the caller workflow.
+      clone. The caller workflow passes the org-scoped PAT from its own
+      secrets context (typically `secrets.ORG_PAT_GITHUB`).
 
       When empty (the default), no `--secret` flag is appended to the
       docker buildx invocation — connectors with PyPI-only dependencies


### PR DESCRIPTION
## Summary

**Hotfix for #2298.** The description text I added contained a literal `${{ secrets.ORG_PAT_GITHUB }}` as an example. GitHub Actions parses `${{ }}` expressions **everywhere** in an action.yaml — including inside `description:` blocks — and `secrets` isn't a valid context for composite actions.

Result: every caller that loads `atlanhq/application-sdk/.github/actions/sdr-e2e@main` at runtime now fails immediately at "Set up job":

```
##[error] Unrecognized named-value: 'secrets'.
Located at position 1 within expression: secrets.ORG_PAT_GITHUB
##[error] Failed to load atlanhq/application-sdk/main/.github/actions/sdr-e2e/action.yaml
```

This blocks **all** SDR jobs across the rollout, not just bigquery.

## Repro

Any repo with `uses: atlanhq/application-sdk/.github/actions/sdr-e2e@main` in its `sdr` job — e.g. atlan-bigquery-app#166 [run 28023901540 job 82946771261](https://github.com/atlanhq/atlan-bigquery-app/actions/runs/28023901540/job/82946771261).

## Fix

Rewrite the description in plain prose, no `${{ }}` tokens. The actual behavior — input flows through to docker buildx as `--secret id=git_token,env=GIT_TOKEN` — is unchanged.

## Urgency

⚠️ Should merge ASAP. Until this lands, every SDR-using repo's tests.yaml on main is broken at the workflow-load stage.