### PR TITLE
ci(renovate): unblock app-contract-toolkit auto-merge by allowlisting Pkl files

### DIFF
--- a/.github/workflows/renovate-auto-approve-reusable.yml
+++ b/.github/workflows/renovate-auto-approve-reusable.yml
@@ -33,7 +33,8 @@
 #   1. PR author is renovate[bot]
 #   2. PR is open and not a draft
 #   3. Current HEAD SHA matches the evaluated SHA (race guard)
-#   4. Every changed file is under .github/, uv.lock, requirements.txt, or pyproject.toml
+#   4. Every changed file is under .github/, uv.lock, requirements.txt,
+#      pyproject.toml, or contract/PklProject(.deps.json) (the Pkl toolkit pin + lock)
 #   5. All ruleset-required checks are green (gh pr checks --required exits 0)
 #   6. atlan-ci has not already posted an APPROVED review with this signature
 #
@@ -152,9 +153,13 @@ jobs:
             # d. All changed files must be dependency-related.
             #    Allowed: anything under .github/, or lock/manifest files at
             #    any depth: uv.lock, package-lock.json, requirements.txt,
-            #    pyproject.toml.  The (.*/)?  prefix in each pattern makes
-            #    -x (full-line) matching work for both root-level and
-            #    workspace-relative paths (e.g. packages/conformance/uv.lock).
+            #    pyproject.toml — plus the Pkl contract-toolkit pin and lock,
+            #    contract/PklProject and contract/PklProject.deps.json, which
+            #    are what a Renovate app-contract-toolkit bump touches (the
+            #    version bump + the renovate-pkl-sync re-resolve).  The (.*/)?
+            #    prefix in each pattern makes -x (full-line) matching work for
+            #    both root-level and workspace-relative paths (e.g.
+            #    packages/conformance/uv.lock).
             FILENAMES=$(gh api "repos/${REPO}/pulls/${PR_NUM}/files" \
               --paginate --jq '.[].filename')
             if [ -z "$FILENAMES" ]; then
@@ -164,7 +169,7 @@ jobs:
 
             NON_DEP_FILES=$(echo "$FILENAMES" \
               | grep -v '^\.github/' \
-              | grep -vxE '(.*/)?uv\.lock|(.*/)?package-lock\.json|(.*/)?requirements\.txt|(.*/)?pyproject\.toml' \
+              | grep -vxE '(.*/)?uv\.lock|(.*/)?package-lock\.json|(.*/)?requirements\.txt|(.*/)?pyproject\.toml|(.*/)?contract/PklProject|(.*/)?contract/PklProject\.deps\.json' \
               || true)
             if [ -n "$NON_DEP_FILES" ]; then
               echo "PR #${PR_NUM}: contains non-dependency files:"


### PR DESCRIPTION
## What

Adds `contract/PklProject` and `contract/PklProject.deps.json` to the dependency-file allowlist in the reusable Renovate auto-approve workflow (`renovate-auto-approve-reusable.yml`, condition **d**).

## Why

When Renovate bumps `app-contract-toolkit`, the PR touches exactly two files:
- `contract/PklProject` — the `@<version>` pin (bumped by Renovate's custom regex manager)
- `contract/PklProject.deps.json` — the Pkl lock, re-resolved by the `renovate-pkl-sync` reusable workflow

Neither matched the previous allowlist (`.github/`, `uv.lock`, `package-lock.json`, `requirements.txt`, `pyproject.toml`), so the gate classified every toolkit-bump PR as containing "non-dependency files" and **skipped posting the `atlan-ci` code-owner approval**. Because branch protection requires that approval, these PRs sat at `REVIEW_REQUIRED` / `BLOCKED` indefinitely across the fleet — even with all CI green and platform auto-merge enabled.

Verified against a live downstream toolkit PR: the auto-approve run logged
```
PR #...: contains non-dependency files:
  contract/PklProject
  contract/PklProject.deps.json
Skipping.
```

## Scope / blast radius

Fleet-wide and retroactive: every `atlan-*-app` references this reusable via `@main`, so currently-blocked toolkit PRs auto-merge on their next green re-evaluation once this lands. No per-app change needed.

Regex validated: the two Pkl paths (and existing allowed files) pass; unrelated paths — `app/generated/**`, `contract/app.pkl`, `atlan.yaml`, source files — remain correctly rejected.

## Follow-up (separate PR)

A second change will extend `renovate-pkl-sync` to also run `pkl eval` and regenerate `app/generated/**` on a toolkit bump (today the bump re-locks but leaves generated artifacts stale), widening this allowlist accordingly.