### PR TITLE
feat(execution): export TemporalExecutorBackend and RetryPolicy from package root

### DIFF
--- a/application_sdk/execution/__init__.py
+++ b/application_sdk/execution/__init__.py
@@ -8,21 +8,27 @@ from application_sdk.execution._temporal.auth import (
     TemporalAuthConfig,
     TemporalAuthManager,
 )
-from application_sdk.execution._temporal.backend import create_temporal_client
+from application_sdk.execution._temporal.backend import (
+    TemporalExecutorBackend,
+    create_temporal_client,
+)
 from application_sdk.execution._temporal.converter import create_data_converter
 from application_sdk.execution._temporal.worker import AppWorker, create_worker
 from application_sdk.execution.decorators import needs_lock
 from application_sdk.execution.errors import ApplicationError
+from application_sdk.execution.retry import RetryPolicy
 
 __all__ = [
-    "ApplicationError",
-    "build_output_path",
-    "get_object_store_prefix",
-    "needs_lock",
     "AppWorker",
-    "create_worker",
-    "create_temporal_client",
-    "create_data_converter",
+    "ApplicationError",
+    "RetryPolicy",
     "TemporalAuthConfig",
     "TemporalAuthManager",
+    "TemporalExecutorBackend",
+    "build_output_path",
+    "create_data_converter",
+    "create_temporal_client",
+    "create_worker",
+    "get_object_store_prefix",
+    "needs_lock",
 ]

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.17.3
-source-sha:    378ae8cf9c74ef573a49601d9f76bd2b185a3066
-source-date:   2026-06-18T16:23:50+01:00
+sdk-version:   3.19.0
+source-sha:    b9c05c5f7ccf3f7dcb821665adfa0627dca5b783
+source-date:   2026-06-23T16:19:57+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -24,7 +24,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.contracts` | Typed Pydantic Input/Output base classes, payload safety, storage and type helpers | 28 |
 | `application_sdk.credentials` | Credential resolvers (Atlan, OAuth, Git, agent), registry, vault spec | 41 |
 | `application_sdk.errors` | Structured error codes — ErrorCode dataclass and cross-component constants (APP_ERROR, HANDLER_ERROR, CONTRACT_VALIDATION, etc.) | 53 |
-| `application_sdk.execution` | Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal client | 10 |
+| `application_sdk.execution` | Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal client | 12 |
 | `application_sdk.handler` | HTTP handler framework — Handler ABC, DefaultHandler, preflight, auth, service factory | 22 |
 | `application_sdk.infrastructure` | Protocol-based infrastructure (StateStore, SecretStore, PubSub, Bindings, CapacityPool) | 34 |
 | `application_sdk.main` | Dev entry point — run_dev_combined() and AppConfig for local execution and container startup | 2 |
@@ -1286,6 +1286,13 @@ Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal clien
 - **Summary:** Wraps Temporal Worker to emit worker_start on startup and to push
 - **Defined in:** `application_sdk/execution/_temporal/worker.py`
 
+#### `RetryPolicy`
+
+- **Import:** `from application_sdk.execution import RetryPolicy`
+- **Signature:** `class RetryPolicy(max_attempts: int = 3, ...)`
+- **Summary:** Configuration for retry behavior.
+- **Defined in:** `application_sdk/execution/retry.py`
+
 #### `TemporalAuthConfig`
 
 - **Import:** `from application_sdk.execution import TemporalAuthConfig`
@@ -1299,6 +1306,13 @@ Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal clien
 - **Signature:** `class TemporalAuthManager(config: TemporalAuthConfig, ...)`
 - **Summary:** Manages OAuth token lifecycle for Temporal client connections.
 - **Defined in:** `application_sdk/execution/_temporal/auth.py`
+
+#### `TemporalExecutorBackend`
+
+- **Import:** `from application_sdk.execution import TemporalExecutorBackend`
+- **Signature:** `class TemporalExecutorBackend(client: Client, task_queue: str = 'application-sdk')`
+- **Summary:** Temporal-based executor backend for running Apps as workflows.
+- **Defined in:** `application_sdk/execution/_temporal/backend.py`
 
 ### Functions
 


### PR DESCRIPTION
## Summary

- Exports `TemporalExecutorBackend` from `application_sdk.execution` so apps/tests no longer need to reach into `application_sdk.execution._temporal.backend` directly
- Exports `RetryPolicy` from `application_sdk.execution` — it was already a pure SDK dataclass (no `temporalio` dependency) but was not re-exported from the package root

## Motivation

Apps can now write:

```python
from application_sdk.execution import RetryPolicy, TemporalExecutorBackend
```

instead of importing Temporal internals directly:

```python
from application_sdk.execution._temporal.backend import TemporalExecutorBackend
from temporalio.common import RetryPolicy
```

This removes the need for the `P005` suppression in app `conftest.py` files that use `TemporalExecutorBackend` to drive an in-process Temporal dev server in integration tests.

## Test plan

- [x] Pre-commit checks pass (`ruff`, `ruff-format`, `isort`, `pyright`)
- [x] All unit tests pass (5180 passed)