### PR TITLE
ci(renovate-dashboard): replace --paginate with --limit 1000, compact jq output

### DIFF
--- a/.github/workflows/renovate-dashboard.yaml
+++ b/.github/workflows/renovate-dashboard.yaml
@@ -61,17 +61,20 @@ jobs:
             echo "Single-repo scan: $SINGLE_REPO"
           else
             # Full-fleet mode: discover every consumer via code search.
-            # --paginate fetches all pages so the fleet is never silently
-            # truncated. The jq emits one name per line; sort -u deduplicates
-            # across pages; jq -R/-s rebuilds the JSON array.
+            # --limit 1000 is the GitHub API cap for code search results.
+            # gh search code does not support --paginate (that flag is only
+            # valid for gh api); using it caused the command to fail silently
+            # (error swallowed by 2>/dev/null) and return 0 repos.
+            # jq -cs produces compact single-line output so the value can be
+            # written to GITHUB_OUTPUT safely with echo.
             repos=$(gh search code \
               --owner atlanhq \
               "atlan-application-sdk filename:pyproject.toml" \
               --json repository \
               --jq '.[].repository.nameWithOwner' \
-              --paginate 2>/dev/null \
+              --limit 1000 \
               | sort -u \
-              | jq -R . | jq -s . \
+              | jq -R . | jq -cs '.' \
               || echo "[]")
 
             if [ "$repos" = "[]" ] || [ -z "$repos" ]; then


### PR DESCRIPTION
## Summary

- `gh search code` does not support `--paginate` (that flag is only valid for `gh api`). With `2>/dev/null` swallowing the error and `set -euo pipefail` active, the command exited non-zero on every run → `repos` fell back to `'[]'` → 0 repos discovered → S3 feed never populated → `k.atlan.dev/renovate-dashboard` returns empty, breaking the connector-pulse Freshness dashboard (404 on `/api/v1/metrics/fleet_freshness`)
- Switch to `--limit 1000` (the GitHub API cap for code search results)
- Change `jq -s .` to `jq -cs '.'` so the output is compact single-line JSON; pretty-printed multi-line arrays break `echo "repos=${repos}" >> "$GITHUB_OUTPUT"` (GitHub Actions rejects multi-line values in `name=value` format)

## Test plan

- [ ] Trigger `renovate-dashboard.yaml` via `workflow_dispatch` after merge; confirm "Discovered N consumer repos" in logs
- [ ] Confirm objects appear at `https://k.atlan.dev/renovate-dashboard/`
- [ ] Re-trigger `refresh-fleet-freshness-dashboard.yml` in connector-pulse; confirm freshness dashboard loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)