### PR TITLE
ci(renovate-dashboard): add missing Install uv step before scanner

### DIFF
--- a/.github/workflows/renovate-dashboard.yaml
+++ b/.github/workflows/renovate-dashboard.yaml
@@ -61,17 +61,20 @@ jobs:
             echo "Single-repo scan: $SINGLE_REPO"
           else
             # Full-fleet mode: discover every consumer via code search.
-            # --paginate fetches all pages so the fleet is never silently
-            # truncated. The jq emits one name per line; sort -u deduplicates
-            # across pages; jq -R/-s rebuilds the JSON array.
+            # --limit 1000 is the GitHub API cap for code search results.
+            # gh search code does not support --paginate (that flag is only
+            # valid for gh api); using it caused the command to fail silently
+            # (error swallowed by 2>/dev/null) and return 0 repos.
+            # jq -cs produces compact single-line output so the value can be
+            # written to GITHUB_OUTPUT safely with echo.
             repos=$(gh search code \
               --owner atlanhq \
               "atlan-application-sdk filename:pyproject.toml" \
               --json repository \
               --jq '.[].repository.nameWithOwner' \
-              --paginate 2>/dev/null \
+              --limit 1000 \
               | sort -u \
-              | jq -R . | jq -s . \
+              | jq -R . | jq -cs '.' \
               || echo "[]")
 
             if [ "$repos" = "[]" ] || [ -z "$repos" ]; then

--- a/.github/workflows/renovate-dashboard.yaml
+++ b/.github/workflows/renovate-dashboard.yaml
@@ -121,6 +121,9 @@ jobs:
           echo "Open PR files:   $(ls /tmp/renovate-input/open   | wc -l)"
           echo "Merged PR files: $(ls /tmp/renovate-input/merged | wc -l)"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
       - name: Run Renovate scanner
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

`uv` is not pre-installed on `ubuntu-latest` runners. The "Run Renovate scanner" step was failing with `uv: command not found` (exit 127). Adds the same pinned `astral-sh/setup-uv` action used by other workflows in this repo.

Discovered after the `--paginate` fix in #2308 — once fleet discovery started working, the scanner step became the next failure.

## Test plan

- [ ] Trigger `renovate-dashboard.yaml` via `workflow_dispatch` after merge; confirm it runs end-to-end
- [ ] Confirm objects appear at `https://k.atlan.dev/renovate-dashboard/`
- [ ] Re-trigger `refresh-fleet-freshness-dashboard.yml` in connector-pulse; confirm Freshness dashboard loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)