### PR TITLE
ci(renovate-dashboard): touch history files before cat to handle first run

### DIFF
--- a/.github/workflows/renovate-dashboard.yaml
+++ b/.github/workflows/renovate-dashboard.yaml
@@ -176,6 +176,7 @@ jobs:
             aws s3 cp \
               "s3://kryptonite-store/${PREFIX}/${HISTORY_FILE}" \
               /tmp/existing_renovate_history.jsonl 2>/dev/null || true
+            touch /tmp/existing_renovate_history.jsonl
             cat /tmp/existing_renovate_history.jsonl "$f" 2>/dev/null \
               | sort -u \
               > /tmp/merged_renovate_history.jsonl
@@ -194,6 +195,7 @@ jobs:
               aws s3 cp \
                 "s3://kryptonite-store/${PREFIX}/history/fleet.jsonl" \
                 /tmp/existing_fleet_history.jsonl 2>/dev/null || true
+              touch /tmp/existing_fleet_history.jsonl
               cat /tmp/existing_fleet_history.jsonl \
                 /tmp/renovate-output/history_fleet.jsonl 2>/dev/null \
                 | sort -u \


### PR DESCRIPTION
## Summary

On the first run S3 has no existing history files, so `aws s3 cp ... || true` exits but never creates `/tmp/existing_renovate_history.jsonl`. The subsequent `cat /tmp/existing_renovate_history.jsonl ...` exits 1 (file not found), which kills the script immediately under `set -euo pipefail` — explaining the 1-second failure right after `repos.json` uploads.

Adding `touch` after each S3 download guarantees the file exists so `cat` always succeeds regardless of whether S3 had prior history. Same fix applied to both the per-repo and fleet history paths.

Third in the series fixing the initial `renovate-dashboard.yaml` run: #2308 (--paginate), #2309 (missing uv), this PR (first-run history init).

## Test plan

- [ ] Trigger `renovate-dashboard.yaml` via `workflow_dispatch` after merge; confirm it completes end-to-end
- [ ] Confirm `fleet.json` and history files appear at `k.atlan.dev/renovate-dashboard/`
- [ ] Re-trigger `refresh-fleet-freshness-dashboard.yml` in connector-pulse; confirm Freshness dashboard loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)