### PR TITLE
ci(renovate-dashboard): raise timeout to 45m

### DIFF
--- a/.github/workflows/renovate-dashboard.yaml
+++ b/.github/workflows/renovate-dashboard.yaml
@@ -42,7 +42,7 @@ jobs:
   renovate-dashboard:
     name: Update Renovate Dashboard
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
     steps:
       - name: Checkout application-sdk
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Summary

Serial `gh pr list` calls across 100+ repos plus per-repo S3 uploads exceed the original 15-minute limit. Raising to 45m gives comfortable headroom for the full fleet scan.

Fourth fix in the series for the initial `renovate-dashboard.yaml` run (#2308, #2309, #2310, this PR).

## Test plan

- [ ] Trigger `renovate-dashboard.yaml` via `workflow_dispatch` after merge; confirm it completes within 45m
- [ ] Re-trigger `refresh-fleet-freshness-dashboard.yml` in connector-pulse; confirm Freshness dashboard loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)