### PR TITLE
ci(renovate-dashboard): scope discovery to repos with Renovate configured

### DIFF
--- a/.github/workflows/renovate-dashboard.yaml
+++ b/.github/workflows/renovate-dashboard.yaml
@@ -60,16 +60,15 @@ jobs:
             repos=$(printf '["%s"]' "$SINGLE_REPO")
             echo "Single-repo scan: $SINGLE_REPO"
           else
-            # Full-fleet mode: discover every consumer via code search.
-            # --limit 1000 is the GitHub API cap for code search results.
-            # gh search code does not support --paginate (that flag is only
-            # valid for gh api); using it caused the command to fail silently
-            # (error swallowed by 2>/dev/null) and return 0 repos.
-            # jq -cs produces compact single-line output so the value can be
-            # written to GITHUB_OUTPUT safely with echo.
+            # Full-fleet mode: discover repos that have Renovate configured
+            # with the application-sdk preset. Searching for the preset
+            # reference in renovate.json (rather than all pyproject.toml
+            # consumers) excludes repos that don't have Renovate set up —
+            # those always show 0 open PRs which would falsely read as
+            # "up to date" rather than "Renovate not configured".
             repos=$(gh search code \
               --owner atlanhq \
-              "atlan-application-sdk filename:pyproject.toml" \
+              "application-sdk//renovate-config/default.json filename:renovate.json" \
               --json repository \
               --jq '.[].repository.nameWithOwner' \
               --limit 1000 \


### PR DESCRIPTION
## Summary

Searching all `pyproject.toml` consumers (~175 repos) includes repos that don't have Renovate configured. Those repos always return 0 open PRs → classified as `up_to_date` — but Renovate simply never opens PRs there. This makes the freshness signal meaningless and inflates the fleet count.

Narrowed to repos that have a `renovate.json` extending the application-sdk preset (`application-sdk//renovate-config/default.json`) — only repos where Renovate is actively managing dependencies.

This also dramatically reduces the scan scope, cutting runtime and S3 upload count.

## Test plan

- [ ] Trigger `renovate-dashboard.yaml` via `workflow_dispatch` after merge; confirm discovered count is smaller and matches only Renovate-configured repos
- [ ] Confirm `fleet.json` fleet_size reflects the narrower scope
- [ ] Re-trigger `refresh-fleet-freshness-dashboard.yml` in connector-pulse; confirm Freshness dashboard shows correct repos only

🤖 Generated with [Claude Code](https://claude.com/claude-code)