### PR TITLE
ci(sdr-e2e): regenerate app contracts against dispatched toolkit version in e2e

### DIFF
--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -99,6 +99,25 @@ inputs:
       FROM untouched — the merge-queue / non-e2e path is unchanged.
     required: false
     default: ""
+  contract-toolkit-version:
+    description: |
+      Optional PUBLISHED app-contract-toolkit version (e.g. "0.15.0").
+      When supplied, the action re-pins app-contract-toolkit in the
+      caller's contract/PklProject, re-resolves the lock, and regenerates
+      app/generated/ (manifest.json, atlan.yaml, input types) BEFORE the
+      Docker image build — so the worker container bakes and serves the
+      new manifest — and AGAIN after setup-deps re-checks-out the
+      workspace, so the host pytest harness seeds the AE workflow version
+      from the same regenerated manifest. Set by cross-repo dispatch from
+      a contract-toolkit release so toolkit changes are exercised
+      end-to-end (worker manifest endpoint + AE version create + run).
+
+      Unlike application-sdk-ref (a git rev), the toolkit is a pkl package
+      resolved from the published package index, so this must be an
+      already-published version. Empty (the default) leaves the committed
+      contract/PklProject pin untouched — today's behavior.
+    required: false
+    default: ""
   components-dir:
     description: |
       App-level directory holding additional Dapr component YAMLs to
@@ -191,6 +210,7 @@ runs:
         rm -rf /tmp/sdr-e2e
         cp -R "${{ github.action_path }}" /tmp/sdr-e2e
         chmod +x /tmp/sdr-e2e/repin-application-sdk.sh || true
+        chmod +x /tmp/sdr-e2e/bump-contract-toolkit.sh || true
 
     - name: Pin application-sdk to dispatched ref (pre-build)
       if: inputs.application-sdk-ref != ''
@@ -206,6 +226,21 @@ runs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         fi
         uv lock
+
+    # Cross-repo dispatch from a contract-toolkit release hands us a
+    # published toolkit version. Re-pin contract/PklProject + regenerate
+    # app/generated/ here, while the workspace is still pristine, so the
+    # image build's `COPY app/ app/` bakes the NEW manifest into the
+    # worker (it serves /workflows/v1/manifest from the baked-in copy).
+    # Repeated again after setup-deps re-checks-out the workspace so the
+    # host pytest harness seeds the AE version from the same manifest.
+    - name: Regenerate contracts for dispatched toolkit (pre-build)
+      if: inputs.contract-toolkit-version != ''
+      shell: bash
+      env:
+        TOOLKIT_VERSION: ${{ inputs.contract-toolkit-version }}
+      run: |
+        ${{ github.action_path }}/bump-contract-toolkit.sh
 
     # Buildx is required for the GHA cache backend below. Set up once
     # per run, before the image build that uses `cache-from/cache-to`.
@@ -313,6 +348,21 @@ runs:
         "$SDR_E2E_ROOT/repin-application-sdk.sh"
         uv lock
         uv sync --all-extras --all-groups
+
+    # setup-deps' actions/checkout wiped the pre-build regeneration. Redo
+    # it from the /tmp stash so the host pytest harness reads the SAME
+    # app/generated/manifest.json the worker image was built from — the
+    # full-DAG harness seeds the AE workflow version off this file
+    # (full_dag/base.py manifest_path). Without this the worker would
+    # serve the new manifest while AE seeds the old, masking real drift.
+    - name: Regenerate contracts for dispatched toolkit (post-setup)
+      if: inputs.contract-toolkit-version != ''
+      shell: bash
+      env:
+        TOOLKIT_VERSION: ${{ inputs.contract-toolkit-version }}
+        SDR_E2E_ROOT: ${{ steps.action_root.outputs.path }}
+      run: |
+        "$SDR_E2E_ROOT/bump-contract-toolkit.sh"
 
     - name: Download atlan-configurator
       shell: bash

--- a/.github/actions/sdr-e2e/bump-contract-toolkit.sh
+++ b/.github/actions/sdr-e2e/bump-contract-toolkit.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Re-pin the app-contract-toolkit pkl package in the caller repo's
+# contract/PklProject to a specific PUBLISHED version, re-resolve the
+# lock, and regenerate app/generated/ (manifest.json, atlan.yaml, the
+# Python input types, ...). Invoked from action.yaml when
+# `contract-toolkit-version` is supplied — i.e. on cross-repo dispatches
+# from a contract-toolkit release.
+#
+# Why this exists: the full-DAG e2e seeds the AE workflow version from
+# the committed app/generated/manifest.json AND the worker container
+# serves /workflows/v1/manifest from app/generated/ baked into its image
+# (Dockerfile `COPY app/ app/`). To genuinely exercise a new toolkit
+# end-to-end, app/generated/ must be regenerated BEFORE the image build
+# (so the worker serves the new manifest) and AGAIN after setup-deps'
+# checkout (so the runner-side harness seeds AE from the same manifest).
+# This script is idempotent, so running it in both places is safe.
+#
+# Unlike repin-application-sdk.sh (a git rev — any branch/SHA resolves),
+# the toolkit is a pkl package resolved from the published package index
+# at atlanhq.github.io. TOOLKIT_VERSION must therefore be a PUBLISHED
+# version, not an arbitrary git ref.
+#
+# Reads:  $TOOLKIT_VERSION  (published app-contract-toolkit version, e.g. 0.15.0)
+#         $PKL_VERSION      (optional; pkl toolchain to install, default 0.27.2)
+# Writes: contract/PklProject, contract/PklProject.deps.json, app/generated/*
+#         in CWD (the caller workspace).
+
+set -euo pipefail
+
+if [ -z "${TOOLKIT_VERSION:-}" ]; then
+  echo "::error::TOOLKIT_VERSION env var not set"
+  exit 1
+fi
+
+if [ ! -f contract/PklProject ]; then
+  echo "::error::contract/PklProject not found in $(pwd)"
+  exit 1
+fi
+
+if [ ! -f contract/app.pkl ]; then
+  echo "::error::contract/app.pkl not found in $(pwd)"
+  exit 1
+fi
+
+# Install pkl if absent. Mirrors renovate-pkl-sync.yaml's pin (0.27.2).
+# Both call sites (pre-build, post-setup) may run on a runner without pkl;
+# the check keeps this a no-op when it is already on PATH.
+PKL_VERSION="${PKL_VERSION:-0.27.2}"
+if ! command -v pkl >/dev/null 2>&1; then
+  echo "Installing pkl ${PKL_VERSION}..."
+  curl -fsSL -o /tmp/pkl \
+    "https://github.com/apple/pkl/releases/download/${PKL_VERSION}/pkl-linux-amd64"
+  chmod +x /tmp/pkl
+  sudo mv /tmp/pkl /usr/local/bin/pkl
+fi
+
+python3 - <<PYEOF
+import os
+import pathlib
+import re
+
+version = os.environ["TOOLKIT_VERSION"]
+path = pathlib.Path("contract/PklProject")
+src = path.read_text()
+
+# Rewrite the version suffix on the app-contract-toolkit package URI,
+# leaving the package path untouched. Matches the published-package form:
+#   package://atlanhq.github.io/application-sdk/contracts/app-contract-toolkit@0.14.2
+pattern = re.compile(
+    r'(app-contract-toolkit@)[^"\s]+',
+)
+replaced, n = pattern.subn(rf'\g<1>{version}', src)
+
+if n == 0:
+    raise SystemExit(
+        "No app-contract-toolkit@<version> pin found in contract/PklProject; "
+        "expected exactly one."
+    )
+if n > 1:
+    raise SystemExit(
+        f"Multiple app-contract-toolkit pins matched ({n}); expected exactly one."
+    )
+
+path.write_text(replaced)
+print(f"Re-pinned app-contract-toolkit to {version}")
+PYEOF
+
+# Re-resolve the lock for the new version, then regenerate app/generated/.
+# These are the same commands the make-contract skill documents and that
+# renovate-pkl-sync.yaml runs for the resolve half.
+pkl project resolve contract/
+pkl eval -m app/generated contract/app.pkl
+echo "Regenerated app/generated/ from contract/app.pkl with toolkit ${TOOLKIT_VERSION}"

--- a/.github/actions/sdr-e2e/bump-contract-toolkit.sh
+++ b/.github/actions/sdr-e2e/bump-contract-toolkit.sh
@@ -86,9 +86,16 @@ path.write_text(replaced)
 print(f"Re-pinned app-contract-toolkit to {version}")
 PYEOF
 
-# Re-resolve the lock for the new version, then regenerate app/generated/.
-# These are the same commands the make-contract skill documents and that
-# renovate-pkl-sync.yaml runs for the resolve half.
+# Re-resolve the lock for the new version, then regenerate the generated
+# artifacts. The eval MUST run from the app root with `--project-dir contract/`
+# and `-m .` (NOT `-m app/generated`): the toolkit's modules already encode
+# their own output paths (`app/generated/manifest.json`, root `atlan.yaml`,
+# root `app.yaml`), so `-m .` lands them correctly. Verified to reproduce a
+# connector's committed app/generated/manifest.json byte-identically; the
+# `-m app/generated` form double-nests to app/generated/app/generated/.
+# (Canonical path is `atlan app contract generate`, but the atlan CLI is not
+# installed in this runner — this is the pkl fallback the make-contract skill
+# documents.)
 pkl project resolve contract/
-pkl eval -m app/generated contract/app.pkl
-echo "Regenerated app/generated/ from contract/app.pkl with toolkit ${TOOLKIT_VERSION}"
+pkl eval --project-dir contract/ -m . contract/app.pkl
+echo "Regenerated contract artifacts from contract/app.pkl with toolkit ${TOOLKIT_VERSION}"

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -118,6 +118,17 @@ on:
         required: false
         type: string
         default: ""
+      contract-toolkit-version:
+        description: |
+          Optional published app-contract-toolkit version. When set, the
+          SDR composite re-pins contract/PklProject + regenerates
+          app/generated/ before the image build and after setup-deps, so
+          the full-DAG e2e exercises the new toolkit's manifest end-to-end
+          (worker manifest endpoint + AE version create). Set by cross-repo
+          dispatch from a contract-toolkit release. Empty = committed pin.
+        required: false
+        type: string
+        default: ""
       distinct-id:
         description: |
           Identifier passed through from the caller's
@@ -206,3 +217,4 @@ jobs:
           pytest-extra-args: "-s"
           application-sdk-ref: ${{ inputs.application-sdk-ref }}
           base-image-ref: ${{ inputs.base-image-ref }}
+          contract-toolkit-version: ${{ inputs.contract-toolkit-version }}

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -103,6 +103,11 @@ on:
         type: string
         default: ""
         description: Runtime base image override for the connector Docker build.
+      contract-toolkit-version:
+        required: false
+        type: string
+        default: ""
+        description: Published app-contract-toolkit version to re-pin + regenerate app/generated/ against in the e2e job. Empty = committed contract/PklProject pin.
       agent-name-override:
         required: false
         type: string
@@ -176,6 +181,7 @@ jobs:
       agent-name-override: ${{ inputs.agent-name-override }}
       application-sdk-ref: ${{ inputs.application-sdk-ref }}
       base-image-ref: ${{ inputs.base-image-ref }}
+      contract-toolkit-version: ${{ inputs.contract-toolkit-version }}
       distinct-id: ${{ inputs.distinct-id }}
     secrets: inherit
 


### PR DESCRIPTION
## What

Adds an opt-in `contract-toolkit-version` input to the SDR/full-DAG e2e composite action (`.github/actions/sdr-e2e`) and the two reusable workflows that wrap it (`e2e-full-reusable.yaml`, `tests-reusable.yaml`).

When set to a **published** `app-contract-toolkit` version, the e2e run re-pins the app's `contract/PklProject`, re-resolves the lock, and regenerates `app/generated/` (`manifest.json`, `atlan.yaml`, input types) — so the full-DAG e2e actually exercises the new toolkit end-to-end. Empty (the default) leaves the committed pin untouched: the merge-queue / non-dispatch path is unchanged.

## Why regenerate in two places

The manifest is consumed by two parties that **must agree**:

1. **Worker container** — serves `/workflows/v1/manifest` from a copy **baked into the image** at build time (connector `Dockerfile: COPY app/ app/`, `ATLAN_CONTRACT_GENERATED_DIR=/app/app/generated`).
2. **Full-DAG test harness** — reads `app/generated/manifest.json` to seed the AE workflow version (`application_sdk/testing/full_dag/base.py`).

So regeneration runs **before the image build** (so the worker bakes the new manifest) **and again after `setup-deps`** (whose checkout wipes the pre-build edit, so the host harness seeds AE from the same regenerated manifest). This mirrors how `application-sdk-ref` re-pins twice.

> Regenerating only before AE submission — the naive approach — would let the worker serve a **stale** manifest while AE seeds the **new** one: the e2e goes green without ever exercising the new toolkit at runtime.

## Notes / constraints

- Unlike `application-sdk-ref` (a git rev — any branch/SHA resolves), the toolkit is a **pkl package** resolved from the published package index, so the value must be an **already-published** version.
- `contract/app.pkl` references the toolkit by name (`@app-contract-toolkit/...`), not version, so only `contract/PklProject` is edited; `pkl project resolve` rewrites `PklProject.deps.json`.
- New script `bump-contract-toolkit.sh` installs pkl if absent (pinned `0.27.2`, matching `renovate-pkl-sync.yaml`), is idempotent, and fails loudly if the pin is missing/ambiguous.

## Validation

- YAML parses; pre-commit clean on changed files.
- Version-rewrite regex verified against the real `contract/PklProject` format (matches exactly once).
- ⚠️ Not yet verified by a live e2e run (real pkl regen + worker manifest serve + AE version create). Structure/syntax/logic only.

## Follow-ups (being evaluated, not in this PR)

- Consumer-side dispatch wiring (passing `contract_toolkit_version` from each app's `tests.yaml`, or centralizing it) — and whether toolkit-change branches should drive e2e across the app fleet against SDK/toolkit/app branches rather than `@main`.
