### PR TITLE
feat(execution): expose TemporalClient and create_data_converter_for_app publicly

### DIFF
--- a/application_sdk/execution/__init__.py
+++ b/application_sdk/execution/__init__.py
@@ -1,5 +1,6 @@
 """Execution layer for running Apps on Temporal."""
 
+# Re-export the temporalio Client as TemporalClient for app-side type annotations.
 from temporalio.client import Client as TemporalClient
 
 from application_sdk.execution._temporal.activity_utils import (

--- a/application_sdk/execution/__init__.py
+++ b/application_sdk/execution/__init__.py
@@ -1,5 +1,7 @@
 """Execution layer for running Apps on Temporal."""
 
+from temporalio.client import Client as TemporalClient
+
 from application_sdk.execution._temporal.activity_utils import (
     build_output_path,
     get_object_store_prefix,
@@ -12,7 +14,10 @@ from application_sdk.execution._temporal.backend import (
     TemporalExecutorBackend,
     create_temporal_client,
 )
-from application_sdk.execution._temporal.converter import create_data_converter
+from application_sdk.execution._temporal.converter import (
+    create_data_converter,
+    create_data_converter_for_app,
+)
 from application_sdk.execution._temporal.worker import AppWorker, create_worker
 from application_sdk.execution.decorators import needs_lock
 from application_sdk.execution.errors import ApplicationError
@@ -24,9 +29,11 @@ __all__ = [
     "RetryPolicy",
     "TemporalAuthConfig",
     "TemporalAuthManager",
+    "TemporalClient",
     "TemporalExecutorBackend",
     "build_output_path",
     "create_data_converter",
+    "create_data_converter_for_app",
     "create_temporal_client",
     "create_worker",
     "get_object_store_prefix",

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.19.0
-source-sha:    b9c05c5f7ccf3f7dcb821665adfa0627dca5b783
-source-date:   2026-06-23T16:19:57+01:00
+source-sha:    0f91c8adcc30264a1ad4ad67992c0075c47cc503
+source-date:   2026-06-24T09:24:07+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -24,7 +24,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.contracts` | Typed Pydantic Input/Output base classes, payload safety, storage and type helpers | 28 |
 | `application_sdk.credentials` | Credential resolvers (Atlan, OAuth, Git, agent), registry, vault spec | 41 |
 | `application_sdk.errors` | Structured error codes — ErrorCode dataclass and cross-component constants (APP_ERROR, HANDLER_ERROR, CONTRACT_VALIDATION, etc.) | 53 |
-| `application_sdk.execution` | Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal client | 12 |
+| `application_sdk.execution` | Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal client | 14 |
 | `application_sdk.handler` | HTTP handler framework — Handler ABC, DefaultHandler, preflight, auth, service factory | 22 |
 | `application_sdk.infrastructure` | Protocol-based infrastructure (StateStore, SecretStore, PubSub, Bindings, CapacityPool) | 34 |
 | `application_sdk.main` | Dev entry point — run_dev_combined() and AppConfig for local execution and container startup | 2 |
@@ -1330,6 +1330,13 @@ Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal clien
 - **Summary:** Create a data converter with Pydantic support.
 - **Defined in:** `application_sdk/execution/_temporal/converter.py`
 
+#### `create_data_converter_for_app`
+
+- **Import:** `from application_sdk.execution import create_data_converter_for_app`
+- **Signature:** `create_data_converter_for_app(app_class: type[App])`
+- **Summary:** Create a data converter for a specific app, including any app-specific converters.
+- **Defined in:** `application_sdk/execution/_temporal/converter.py`
+
 #### `create_temporal_client`
 
 - **Import:** `from application_sdk.execution import create_temporal_client`
@@ -1357,6 +1364,11 @@ Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal clien
 - **Signature:** `needs_lock(max_locks: int = 5, lock_name: Optional[str] = None)`
 - **Summary:** Decorator to mark activities that require distributed locking.
 - **Defined in:** `application_sdk/execution/decorators.py`
+
+#### `TemporalClient`
+
+- **Import:** `from application_sdk.execution import TemporalClient`
+- **Summary:** _(no docstring)_
 
 ## `application_sdk.handler`
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.19.0
-source-sha:    0f91c8adcc30264a1ad4ad67992c0075c47cc503
-source-date:   2026-06-24T09:24:07+01:00
+source-sha:    b8d1704887637534f8a7a9fb0e33e55f177bbbe2
+source-date:   2026-06-24T12:00:54+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/tests/unit/execution/test_converter.py
+++ b/tests/unit/execution/test_converter.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
+from temporalio.client import Client as _TemporalClientImpl
 from temporalio.converter import DataConverter
 
 from application_sdk.contracts.base import Input, Output
-from application_sdk.execution._temporal.converter import (
-    create_data_converter,
-    create_data_converter_for_app,
-)
+from application_sdk.execution import TemporalClient, create_data_converter_for_app
+from application_sdk.execution._temporal.converter import create_data_converter
 
 
 class _ConverterInput(Input):
@@ -19,6 +18,20 @@ class _ConverterInput(Input):
 class _ConverterOutput(Output):
     result: str = ""
     success: bool = True
+
+
+class TestPublicSurface:
+    """Smoke tests for the application_sdk.execution public surface."""
+
+    def test_temporal_client_is_exported(self) -> None:
+        assert TemporalClient is _TemporalClientImpl
+
+    def test_create_data_converter_for_app_is_exported(self) -> None:
+        from application_sdk.execution._temporal.converter import (
+            create_data_converter_for_app as _internal,
+        )
+
+        assert create_data_converter_for_app is _internal
 
 
 class TestCreateDataConverter:


### PR DESCRIPTION
## Summary

- Re-exports `temporalio.client.Client` as `TemporalClient` from `application_sdk.execution` so app code has a stable SDK-level type for annotations and `TemporalClient.connect(...)` calls
- Promotes `create_data_converter_for_app` from the private `_temporal.converter` module to the public `application_sdk.execution` surface alongside `create_data_converter`

## Motivation

App test fixtures (e.g. `conftest.py`) previously had to reach into `temporalio` directly:

```python
from temporalio.client import Client
from application_sdk.execution._temporal.converter import create_data_converter_for_app
```

With these exports they can use a single SDK import:

```python
from application_sdk.execution import TemporalClient, create_data_converter_for_app
```

## Test plan

- [ ] `uv run pre-commit run --files application_sdk/execution/__init__.py` passes
- [ ] Confirm `from application_sdk.execution import TemporalClient, create_data_converter_for_app` resolves correctly in a consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)