### PR TITLE
feat(contract-toolkit): emit agent_json in extract manifest args by default

### DIFF
--- a/contract-toolkit/examples/bundle/app/generated/crawler/manifest.json
+++ b/contract-toolkit/examples/bundle/app/generated/crawler/manifest.json
@@ -13,6 +13,7 @@
         "task_queue": "atlan-crawler-{deployment_name}",
         "args": {
           "credential": "{{credential}}",
+          "agent_json": "{{agent-json}}",
           "credential_guid": "{{credential-guid}}",
           "connection": "{{connection}}",
           "include_filter": "{{include-filter}}",

--- a/contract-toolkit/examples/bundle/app/generated/miner/manifest.json
+++ b/contract-toolkit/examples/bundle/app/generated/miner/manifest.json
@@ -13,6 +13,7 @@
         "task_queue": "atlan-miner-{deployment_name}",
         "args": {
           "credential": "{{credential}}",
+          "agent_json": "{{agent-json}}",
           "credential_guid": "{{credential-guid}}",
           "lookback_days": "{{lookback-days}}",
           "max_queries": "{{max-queries}}"

--- a/contract-toolkit/examples/connection-ref/app/generated/manifest.json
+++ b/contract-toolkit/examples/connection-ref/app/generated/manifest.json
@@ -13,6 +13,7 @@
         "task_queue": "atlan-connection-ref-{deployment_name}",
         "args": {
           "credential": "{{credential}}",
+          "agent_json": "{{agent-json}}",
           "connection": "{{connection}}",
           "connections": "{{connections}}"
         }

--- a/contract-toolkit/examples/deploy/app/generated/manifest.json
+++ b/contract-toolkit/examples/deploy/app/generated/manifest.json
@@ -13,6 +13,7 @@
         "task_queue": "atlan-deploy-{deployment_name}",
         "args": {
           "credential": "{{credential}}",
+          "agent_json": "{{agent-json}}",
           "target": "{{target}}"
         }
       }

--- a/contract-toolkit/examples/fanin/app/generated/manifest.json
+++ b/contract-toolkit/examples/fanin/app/generated/manifest.json
@@ -13,6 +13,7 @@
         "task_queue": "atlan-fanin-{deployment_name}",
         "args": {
           "credential": "{{credential}}",
+          "agent_json": "{{agent-json}}",
           "credential_guid": "{{credential-guid}}"
         }
       }

--- a/contract-toolkit/examples/full/app/generated/manifest.json
+++ b/contract-toolkit/examples/full/app/generated/manifest.json
@@ -13,6 +13,7 @@
         "task_queue": "atlan-full-featured-{deployment_name}",
         "args": {
           "credential": "{{credential}}",
+          "agent_json": "{{agent-json}}",
           "credential_guid": "{{credential-guid}}",
           "connection": "{{connection}}",
           "include_filter": "{{include_filter}}",

--- a/contract-toolkit/examples/minimal/app/generated/manifest.json
+++ b/contract-toolkit/examples/minimal/app/generated/manifest.json
@@ -13,6 +13,7 @@
         "task_queue": "atlan-minimal-{deployment_name}",
         "args": {
           "credential": "{{credential}}",
+          "agent_json": "{{agent-json}}",
           "target": "{{target}}"
         }
       }

--- a/contract-toolkit/examples/publish-controls/app/generated/manifest.json
+++ b/contract-toolkit/examples/publish-controls/app/generated/manifest.json
@@ -13,6 +13,7 @@
         "task_queue": "atlan-publish-controls-{deployment_name}",
         "args": {
           "credential": "{{credential}}",
+          "agent_json": "{{agent-json}}",
           "credential_guid": "{{credential-guid}}",
           "connection": "{{connection}}",
           "extraction_method": "{{extraction-method}}",

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -2378,8 +2378,11 @@ local function generateExtractNode(): Mapping<String, Any> =
         // that silently broke MSSQL's SDR rollout (atlan-mssql-app#177). Skipped
         // when the app DOES model `agent-json` (the loop below already emits it),
         // to avoid a duplicate key. Harmless for direct-only runs: AE leaves the
-        // unused slot empty.
-        when (uiConfig == null || !uiConfig!!.properties.containsKey("agent-json")) {
+        // unused slot empty. The guard mirrors the loop's emit condition exactly
+        // (`containsKey && includeInManifest`) — so an app that models `agent-json`
+        // but sets `includeInManifest = false` still gets the default rather than
+        // ending up with no slot at all.
+        when (uiConfig == null || !(uiConfig!!.properties.containsKey("agent-json") && uiConfig!!.properties["agent-json"].includeInManifest)) {
           ["agent_json"] = "{{agent-json}}"
         }
         for (argName, formField in manifestTopLevelArgs) {

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -2372,6 +2372,16 @@ local function generateExtractNode(): Mapping<String, Any> =
       ["task_queue"] = "\(taskQueuePrefix)-{deployment_name}"
       ["args"] = new Mapping {
         ["credential"] = "{{credential}}"
+        // SDR / agent-mode credential slot. Emitted by default so an agent-mode
+        // run can carry its credential spec (`agent_json`) even when the app's
+        // hand-authored uiConfig doesn't model an `agent-json` field — the gap
+        // that silently broke MSSQL's SDR rollout (atlan-mssql-app#177). Skipped
+        // when the app DOES model `agent-json` (the loop below already emits it),
+        // to avoid a duplicate key. Harmless for direct-only runs: AE leaves the
+        // unused slot empty.
+        when (uiConfig == null || !uiConfig!!.properties.containsKey("agent-json")) {
+          ["agent_json"] = "{{agent-json}}"
+        }
         for (argName, formField in manifestTopLevelArgs) {
           when (uiConfig != null && uiConfig!!.properties.containsKey(formField) && uiConfig!!.properties[formField].includeInManifest) {
             [argName] = "{{" + formField + "}}"

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -2627,8 +2627,11 @@ local function generateExtractNode(): Mapping<String, Any> =
         // that silently broke MSSQL's SDR rollout (atlan-mssql-app#177). Skipped
         // when the app DOES model `agent-json` (the loops below already emit it),
         // to avoid a duplicate key. Harmless for direct-only runs: AE leaves the
-        // unused slot empty.
-        when (!uiConfig.properties.containsKey("agent-json")) {
+        // unused slot empty. The guard mirrors the loops' emit condition exactly
+        // (`containsKey && includeInManifest`) — so an app that models `agent-json`
+        // but sets `includeInManifest = false` still gets the default rather than
+        // ending up with no slot at all.
+        when (!(uiConfig.properties.containsKey("agent-json") && uiConfig.properties["agent-json"].includeInManifest)) {
           ["agent_json"] = "{{agent-json}}"
         }
         for (argName, formField in manifestTopLevelArgs) {

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -2621,6 +2621,16 @@ local function generateExtractNode(): Mapping<String, Any> =
       ["task_queue"] = "\(taskQueuePrefix)-{deployment_name}"
       ["args"] = new Mapping {
         ["credential"] = "{{credential}}"
+        // SDR / agent-mode credential slot. Emitted by default so an agent-mode
+        // run can carry its credential spec (`agent_json`) even when the app's
+        // hand-authored uiConfig doesn't model an `agent-json` field — the gap
+        // that silently broke MSSQL's SDR rollout (atlan-mssql-app#177). Skipped
+        // when the app DOES model `agent-json` (the loops below already emit it),
+        // to avoid a duplicate key. Harmless for direct-only runs: AE leaves the
+        // unused slot empty.
+        when (!uiConfig.properties.containsKey("agent-json")) {
+          ["agent_json"] = "{{agent-json}}"
+        }
         for (argName, formField in manifestTopLevelArgs) {
           when (uiConfig.properties.containsKey(formField) && uiConfig.properties[formField].includeInManifest) {
             [argName] = "{{" + formField + "}}"


### PR DESCRIPTION
## Draft — for Chris/Vaibhav to confirm the policy before merge

Follow-up to the thread on #2312: make the `agent_json` manifest slot a toolkit default instead of a per-app opt-in.

## Why
SDR/agent extraction needs `agent_json` in the extract node's manifest `args` for the agent to receive its credential spec. Today the toolkit emits it **only when an app's hand-authored `uiConfig` models an `agent-json` field** (`AgentSelector`). Apps that hand-author their credential form omit it → Heracles drops the collected `agent_json` when substituting the DAG → a real SDR run hits `CredentialRoutingError`. That's the gap that silently broke MSSQL (patched per-app in **atlan-mssql-app#177**) and, per #177, likely affects other hand-authored-credential connectors.

## What
Emit `"agent_json": "{{agent-json}}"` by default in `generateExtractNode`, in **both** base modules:
- `src/App.pkl` (used by e.g. **Metabase**)
- `src/NativeApp.pkl` (used by e.g. **MSSQL**)

Skipped when the app already models `agent-json` (the existing loops emit it) — idempotent, no duplicate key. Regenerated the **8** App.pkl example manifests (now carry the slot); **no `_input.py` changes** (`agent_json` is a parent `ExtractionInput` field). 177 pkl tests + invariant checks pass.

```diff
  "args": {
    "credential": "{{credential}}",
+   "agent_json": "{{agent-json}}",
    "target": "{{target}}"
  }
```

## Decision for the toolkit owners 🙏
This implements Chris's **"just always include it"** option (reply: harmless for direct-only runs — AE leaves the unused slot empty). Two things to confirm:
1. **Always-include vs SDR-gated.** I did always-include because `selfDeployedRuntime` is a *bundle*-level flag (`NativeAppBundle.pkl`) and isn't reachable inside `generateExtractNode` (per-entrypoint). If you'd rather gate on `self_deployed_runtime` (emit only when SDR-enabled), that needs threading the bundle flag down — happy to do it if preferred.
2. **Direct-mode substitution safety.** Please confirm Heracles substitutes an absent `{{agent-json}}` to empty/null for pure-direct apps (rather than leaking the literal placeholder). If there's any risk there, we should SDR-gate (option 1) instead of always-include.

🤖 Generated with [Claude Code](https://claude.com/claude-code)