### PR TITLE
ci: pass git_token build secret to scan image build

### DIFF
--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -101,6 +101,13 @@ jobs:
           build-args: |
             ACCESS_TOKEN_USR=${{ github.actor }}
             ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
+          # Forward the org PAT as a BuildKit secret too, so Dockerfiles that clone a
+          # private git dependency via `--mount=type=secret,id=git_token` (e.g. apps
+          # pulling atlan-query-redaction) can authenticate during the scan build.
+          # Ignored by Dockerfiles that don't mount it, so it's a no-op for every other
+          # app. Mirrors the token the deploy/publish workflow already provides.
+          secrets: |
+            git_token=${{ secrets.ORG_PAT_GITHUB }}
 
       - name: Upload image artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
## Why

The reusable `build-and-scan.yaml` (the **Vulnerability Scan** workflow) passes `ORG_PAT_GITHUB` to the image build **only as a build-arg** (`ACCESS_TOKEN_PWD`) — never as a BuildKit **secret**.

Dockerfiles that clone a **private git dependency** via a secret mount:

```dockerfile
RUN --mount=type=secret,id=git_token,uid=1000 \
    git config --global url."https://x-access-token:$(cat /run/secrets/git_token)@github.com/".insteadOf "ssh://git@github.com/" && \
    ... uv sync ...
```

therefore fail the **scan** build:

```
cat: /run/secrets/git_token: No such file or directory
× Failed to download and build `query-redaction @ ...`
╰─▶ fatal: Authentication failed for ...github.com/...
```

The empty token makes the private clone fail. The **deploy/publish** build already provides the token, so only the scan job is red.

Hit on `atlanhq/atlan-bigquery-app#166` (the BigQuery app pulls the private `atlan-query-redaction` package): https://github.com/atlanhq/atlan-bigquery-app/actions/runs/28092874613/job/83174951111

## What

Forward the same org PAT as the `git_token` BuildKit secret in the Build image step, so the scan build authenticates the private clone exactly like the deploy build.

```yaml
          secrets: |
            git_token=${{ secrets.ORG_PAT_GITHUB }}
```

## Is it safe? (shared reusable workflow)

- **No-op for other apps.** Unused build secrets are silently ignored by BuildKit — any Dockerfile that doesn't `--mount=type=secret,id=git_token` is completely unaffected.
- **No new secret plumbing.** `ORG_PAT_GITHUB` is already declared and used in this workflow (it's the same value already passed as `ACCESS_TOKEN_PWD`).
- **More secure, not less.** BuildKit secrets don't persist in image layers / `docker history` (unlike build-args).
- **Mirrors deploy.** The deploy/publish workflow already provides this token; this just closes the gap on the scan path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)