### PR TITLE
ci(dapr): drop Dapr CLI from CI actions; download daprd runtime directly (fix CLI v1.18.1 404)

### DIFF
--- a/.claude/skills/local-dev-bootstrap/SKILL.md
+++ b/.claude/skills/local-dev-bootstrap/SKILL.md
@@ -38,8 +38,10 @@ Check that each tool is installed:
 python --version          # must be 3.11+
 uv --version
 temporal --version        # temporal CLI
-dapr --version
 ```
+
+> No Dapr CLI is required. The `daprd` runtime is fetched and pinned by the SDK
+> (`application_sdk.dev._dapr`) and invoked directly — see step 5.
 
 If any are missing, point the user to the platform setup guide:
 - [macOS](../../docs/setup/MAC.md)
@@ -102,7 +104,9 @@ else
     exit 1
   fi
 
-  dapr run \
+  # Resolve the pinned daprd binary via the SDK (no Dapr CLI), then run it directly.
+  DAPRD=$(uv run python -c "from application_sdk.dev._dapr import _ensure_daprd_binary; print(_ensure_daprd_binary())")
+  "$DAPRD" \
     --app-id app \
     --app-port 8000 \
     --dapr-http-port 3500 \
@@ -195,8 +199,8 @@ To stop all local processes cleanly:
 
 ```bash
 # Stop the app (Ctrl-C in the terminal running run_dev.py)
-# Stop Dapr
-dapr stop --app-id app
+# Stop Dapr (daprd was launched directly, so stop it directly)
+pkill -f "daprd --app-id app"
 # Stop Temporal (if started by this skill)
 pkill -f "temporal server"   # temporal has no "server stop" subcommand; use pkill or Ctrl-C
 ```

--- a/.claude/skills/scaffold-app/SKILL.md
+++ b/.claude/skills/scaffold-app/SKILL.md
@@ -238,6 +238,8 @@ asyncio.run(
 Tell the user:
 1. Run `uv sync` to install dependencies.
 2. Copy and configure `.env.example → .env`.
-3. Start local deps: `temporal server start-dev` + `dapr run ...` (see [Getting Started](../../docs/guides/getting-started.md)).
-4. Run `uv run python run_dev.py` to test the scaffold.
-5. Run the `contract` skill to generate the PKL contract and `app/generated/` artifacts.
+3. Run `uv run python run_dev.py` to test the scaffold — this boots the embedded
+   Dapr (`daprd`) + in-process Temporal automatically; no Dapr CLI needed. To
+   instead mirror production against external services, see the optional
+   external-infrastructure section of [Getting Started](../../docs/guides/getting-started.md).
+4. Run the `contract` skill to generate the PKL contract and `app/generated/` artifacts.

--- a/.github/actions/ae-stack-up/ae-stack-up.sh
+++ b/.github/actions/ae-stack-up/ae-stack-up.sh
@@ -144,8 +144,24 @@ for i in $(seq 1 30); do
   sleep 1
 done
 
+# Best-effort readiness gate for a freshly-launched daprd: poll its HTTP API
+# until it answers, then let the app start. We poll /v1.0/metadata (HTTP server
+# up) rather than /v1.0/healthz — daprd 1.14+ holds healthz until ALL components
+# finish initializing, which can outlast this bound and would needlessly serialize
+# startup. Bounded + non-fatal: the SDK's Dapr client retries connect anyway, so
+# if daprd is a touch slow we proceed and let the existing wait_ready loops absorb
+# the slack (no worse than `dapr run`, which was also async).
+wait_daprd() { # $1 dapr-http-port  $2 timeout(s, default 15)
+  local port="$1" to="${2:-15}"
+  for _ in $(seq 1 "$to"); do
+    curl -sf "http://localhost:${port}/v1.0/metadata" >/dev/null 2>&1 && return 0
+    sleep 1
+  done
+  return 0
+}
+
 # ── 4. Generic worker launcher ───────────────────────────────────────────────
-# Every app starts the same way: uv sync, dapr-run its main.py with a unique
+# Every app starts the same way: uv sync, start daprd + its main.py with a unique
 # port block + its task queue. Ports are derived from a per-app index so they
 # never collide.
 PORT_IDX=0
@@ -177,6 +193,7 @@ start_worker() {
       --scheduler-host-address '' --placement-host-address '' \
       --max-body-size 100Mi --resources-path components --log-level warn \
       > "$LOG_DIR/${appid}-daprd.log" 2>&1 &
+    wait_daprd "$dhttp"
     env \
       ATLAN_APPLICATION_NAME="$appname" \
       ATLAN_DEPLOYMENT_NAME="$DEPLOYMENT" \
@@ -214,6 +231,7 @@ log "starting automation-engine on :8000"
     --metrics-port 3100 --scheduler-host-address '' --placement-host-address '' \
     --resources-path components --log-level warn \
     > "$LOG_DIR/automation-engine-daprd.log" 2>&1 &
+  wait_daprd 3500
   env \
     ATLAN_APPLICATION_NAME=automation-engine ATLAN_DEPLOYMENT_NAME="$DEPLOYMENT" \
     ATLAN_REGISTRY_TYPE=sql ATLAN_WORKFLOW_HOST=localhost ATLAN_WORKFLOW_PORT=7233 \

--- a/.github/actions/ae-stack-up/ae-stack-up.sh
+++ b/.github/actions/ae-stack-up/ae-stack-up.sh
@@ -7,9 +7,10 @@
 # owning app, and starts exactly those workers (always AE + the connector;
 # publish / query-intelligence / lineage only when the DAG references them).
 #
-# Everything runs in-runner: Temporal dev server + Dapr (slim) + one `dapr run`
-# per app. No live tenant is contacted for orchestration — only the source
-# (via injected creds) and, for the publish app, OAuth to fetch a token.
+# Everything runs in-runner: Temporal dev server + one `daprd` sidecar per app
+# (the daprd runtime invoked directly — no Dapr CLI / `dapr init` / `dapr run`).
+# No live tenant is contacted for orchestration — only the source (via injected
+# creds) and, for the publish app, OAuth to fetch a token.
 #
 # Inputs come from env (set by action.yaml):
 #   WORKSPACE         — $GITHUB_WORKSPACE (parent of all checkouts)
@@ -65,22 +66,23 @@ PYEOF
 )
 log "DAG needs sibling apps: $(echo "$NEEDS" | cut -d'|' -f1 | tr '\n' ' ' )"
 
-# ── 2. Toolchain: Dapr (slim) + Temporal CLI + uv ────────────────────────────
-# Single source of truth for the daprd pin is __dapr_version in
-# application_sdk/version.py. This action ships inside the application-sdk repo,
-# so version.py sits three dirs up from the action dir; grep it (the same
-# one-liner check-dapr-version.yaml and the SDK docstring sanction) rather than
-# hard-coding. The CLI download and the daprd runtime share the one version.
+# ── 2. Toolchain: daprd runtime + Temporal CLI + uv ──────────────────────────
+# No Dapr CLI: we download the daprd RUNTIME binary directly from dapr/dapr
+# releases and invoke it directly (same pattern as the SDK's entrypoint.sh and
+# embedded local-dev runtime). Avoids the CLI's separate release stream, which
+# can lag the runtime (a daprd-only release leaves dapr/cli without a matching
+# tag → 404). Single source of truth for the daprd pin is __dapr_version in
+# application_sdk/version.py — three dirs up from the action dir; grep it (the
+# same one-liner check-dapr-version.yaml and the SDK docstring sanction).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DAPR_VERSION="$(grep '^__dapr_version' "$SCRIPT_DIR/../../../application_sdk/version.py" | cut -d'"' -f2)"
 [ -n "$DAPR_VERSION" ] || err "could not read __dapr_version from application_sdk/version.py"
-if ! command -v dapr >/dev/null 2>&1; then
-  wget -q "https://github.com/dapr/cli/releases/download/v${DAPR_VERSION}/dapr_linux_amd64.tar.gz" -O /tmp/dapr.tar.gz
-  tar -xzf /tmp/dapr.tar.gz -C /tmp && sudo mv /tmp/dapr /usr/local/bin/
-  dapr init --runtime-version "${DAPR_VERSION}" --slim
+if ! command -v daprd >/dev/null 2>&1; then
+  wget -q "https://github.com/dapr/dapr/releases/download/v${DAPR_VERSION}/daprd_linux_amd64.tar.gz" -O /tmp/daprd.tar.gz
+  tar -xzf /tmp/daprd.tar.gz -C /tmp && sudo mv /tmp/daprd /usr/local/bin/ && sudo chmod +x /usr/local/bin/daprd
 fi
 command -v temporal >/dev/null 2>&1 || curl -sSf https://temporal.download/cli.sh | sh
-export PATH="$HOME/.dapr/bin:$HOME/.temporalio/bin:$PATH"
+export PATH="$HOME/.temporalio/bin:$PATH"
 
 # Shared object-store bucket so every app's localstorage binding resolves the
 # same files on disk (extract writes, publish/qi/lineage read).
@@ -160,24 +162,33 @@ start_worker() {
   write_components "$dir"
   ( cd "$dir" && uv sync --all-groups >/dev/null 2>&1 || uv sync >/dev/null 2>&1 || true )
   log "starting $appid (queue=$queue, port=$app_port)"
+  # Start daprd directly (no `dapr run` wrapper), then the app process — the
+  # wrapper used to start both and inject DAPR_HTTP_PORT/DAPR_GRPC_PORT/DAPR_APP_ID
+  # into the app; doing it by hand, we export those ourselves so the SDK finds
+  # the sidecar (it keys off the standard DAPR_* vars, not the ATLAN_DAPR_* ones).
   # $extra is placed LAST so a worker can override a default (e.g. the connector
   # sets ATLAN_DEPLOYMENT_NAME=local to unlock the dev local-vault while still
   # listening on the explicit ATLAN_TASK_QUEUE below).
-  ( cd "$dir" && env \
+  (
+    cd "$dir" || exit 1
+    daprd --app-id "$appid" --app-port "$app_port" \
+      --dapr-http-port "$dhttp" --dapr-grpc-port "$dgrpc" \
+      --dapr-internal-grpc-port "$dinternal" --metrics-port "$metrics" \
+      --scheduler-host-address '' --placement-host-address '' \
+      --max-body-size 100Mi --resources-path components --log-level warn \
+      > "$LOG_DIR/${appid}-daprd.log" 2>&1 &
+    env \
       ATLAN_APPLICATION_NAME="$appname" \
       ATLAN_DEPLOYMENT_NAME="$DEPLOYMENT" \
       ATLAN_WORKFLOW_HOST=localhost ATLAN_WORKFLOW_PORT=7233 \
       ATLAN_TASK_QUEUE="$queue" \
       ATLAN_APP_HTTP_PORT="$app_port" ATLAN_HANDLER_PORT="$app_port" \
       ATLAN_DAPR_HTTP_PORT="$dhttp" ATLAN_DAPR_GRPC_PORT="$dgrpc" \
+      DAPR_HTTP_PORT="$dhttp" DAPR_GRPC_PORT="$dgrpc" DAPR_APP_ID="$appid" \
       ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS="0.0.0.0:${prom}" \
       $extra \
-      dapr run --app-id "$appid" --app-port "$app_port" \
-        --dapr-http-port "$dhttp" --dapr-grpc-port "$dgrpc" \
-        --dapr-internal-grpc-port "$dinternal" --metrics-port "$metrics" \
-        --scheduler-host-address '' --placement-host-address '' \
-        --max-body-size 100Mi --resources-path components --log-level warn \
-        -- uv run python main.py > "$LOG_DIR/${appid}.log" 2>&1 & )
+      uv run python main.py > "$LOG_DIR/${appid}.log" 2>&1 &
+  )
   STARTED="$STARTED $appid"
   PORT_IDX=$((PORT_IDX + 1))
 }
@@ -196,17 +207,22 @@ wait_ready() { # $1 app-id  $2 grep-marker  $3 timeout
 write_components "$AE_DIR"
 ( cd "$AE_DIR" && uv sync --all-groups >/dev/null 2>&1 || true )
 log "starting automation-engine on :8000"
-( cd "$AE_DIR" && env \
+(
+  cd "$AE_DIR" || exit 1
+  daprd --app-id automation-engine --app-port 8000 \
+    --dapr-http-port 3500 --dapr-grpc-port 50001 --dapr-internal-grpc-port 50002 \
+    --metrics-port 3100 --scheduler-host-address '' --placement-host-address '' \
+    --resources-path components --log-level warn \
+    > "$LOG_DIR/automation-engine-daprd.log" 2>&1 &
+  env \
     ATLAN_APPLICATION_NAME=automation-engine ATLAN_DEPLOYMENT_NAME="$DEPLOYMENT" \
     ATLAN_REGISTRY_TYPE=sql ATLAN_WORKFLOW_HOST=localhost ATLAN_WORKFLOW_PORT=7233 \
     ATLAN_APP_HTTP_PORT=8000 ATLAN_HANDLER_PORT=8000 \
     ATLAN_DAPR_HTTP_PORT=3500 ATLAN_DAPR_GRPC_PORT=50001 \
+    DAPR_HTTP_PORT=3500 DAPR_GRPC_PORT=50001 DAPR_APP_ID=automation-engine \
     ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS=0.0.0.0:9465 \
-    dapr run --app-id automation-engine --app-port 8000 \
-      --dapr-http-port 3500 --dapr-grpc-port 50001 --dapr-internal-grpc-port 50002 \
-      --metrics-port 3100 --scheduler-host-address '' --placement-host-address '' \
-      --resources-path components --log-level warn \
-      -- uv run automation_engine/main.py > "$LOG_DIR/automation-engine.log" 2>&1 & )
+    uv run automation_engine/main.py > "$LOG_DIR/automation-engine.log" 2>&1 &
+)
 for i in $(seq 1 60); do
   curl -sf "http://localhost:8000/api/v1/workflows" >/dev/null 2>&1 && { log "AE ready (${i}s)"; break; }
   [ "$i" -eq 60 ] && { tail -30 "$LOG_DIR/automation-engine.log"; err "AE failed to start"; }

--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -268,14 +268,18 @@ runs:
     - name: Start daprd + Temporal
       if: steps.runtime.outputs.embedded != 'true' || inputs.force-external-runtime == 'true'
       shell: bash
+      env:
+        APP_PORT: ${{ inputs.app-port }}
       run: |
         # Start daprd directly (no `dapr run` wrapper). App-less sidecar on the
         # default ports; the app server (next step) connects to it. We do NOT
         # delegate to the caller's `poe start-deps` because that task lives in
         # the *connector's* pyproject and runs `dapr run`, which needs the CLI.
+        # Record PIDs so cleanup kills exactly these processes (not every daprd
+        # on the box — matters on self-hosted runners).
         daprd \
           --app-id app \
-          --app-port "${{ inputs.app-port }}" \
+          --app-port "$APP_PORT" \
           --dapr-http-port 3500 \
           --dapr-grpc-port 50001 \
           --resources-path components \
@@ -284,12 +288,20 @@ runs:
           --scheduler-host-address '' \
           --max-body-size 1024Mi \
           > daprd.log 2>&1 &
+        echo $! > daprd.pid
         temporal server start-dev --db-filename /tmp/temporal.db > temporal.log 2>&1 &
+        echo $! > temporal.pid
         # Export the sidecar ports so the (separate) app-server step runs in
         # Dapr-backed mode — the SDK keys off DAPR_HTTP_PORT being set.
         echo "DAPR_HTTP_PORT=3500" >> "$GITHUB_ENV"
         echo "DAPR_GRPC_PORT=50001" >> "$GITHUB_ENV"
-        sleep 5
+        # Wait for daprd's HTTP API to answer (bounded, non-fatal). Poll
+        # /v1.0/metadata, not /v1.0/healthz — daprd holds healthz until all
+        # components init, which can outlast this bound.
+        for _ in $(seq 1 15); do
+          curl -sf http://localhost:3500/v1.0/metadata >/dev/null 2>&1 && break
+          sleep 1
+        done
 
     - name: Start runtime services (services-script hook)
       if: inputs.services-script != ''
@@ -357,7 +369,9 @@ runs:
       shell: bash
       run: |
         kill $(lsof -t -i :${{ inputs.app-port }}) 2>/dev/null || true
-        # Kill the daprd + Temporal we started directly (no `poe stop-deps`,
-        # which is a connector-side task and was tied to the old CLI flow).
-        pkill -f daprd 2>/dev/null || true
-        pkill -f "temporal server" 2>/dev/null || true
+        # Kill exactly the daprd + Temporal we started (by recorded PID, not a
+        # broad pkill -f — avoids killing other jobs' processes on self-hosted
+        # runners). No `poe stop-deps`: that is a connector-side, CLI-era task.
+        for p in daprd.pid temporal.pid; do
+          [ -f "$p" ] && kill "$(cat "$p")" 2>/dev/null || true
+        done

--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -129,10 +129,19 @@ inputs:
   force-external-runtime:
     required: false
     description: >
-      Force the external Dapr CLI + Temporal CLI install steps to run even when the
-      installed SDK reports embedded runtime support (SDK >= 3.13). Use when the
-      connector's main.py has NOT been migrated to the embedded runtime path yet
-      and still expects external daprd at localhost:3500 + temporal at localhost:7233.
+      Force the external daprd + Temporal CLI install/start steps to run even when
+      the installed SDK reports embedded runtime support (SDK >= 3.13). Set this
+      only when the connector's main.py has NOT been migrated to the embedded
+      runtime path yet and still expects external daprd at localhost:3500 +
+      temporal at localhost:7233.
+
+      PREFER THE EMBEDDED RUNTIME (leave this unset / "false"). On SDK >= 3.13 the
+      app boots daprd + an in-process Temporal itself from `python main.py`, so CI
+      needs no external runtime at all — this is what the v3 reference connectors
+      (atlan-metabase-app, atlan-openapi-app, atlan-mysql-app) do. Migrating your
+      main.py to the embedded runtime and dropping this flag is the recommended
+      end state; see docs/guides/integration-testing.md. (Even when set, this no
+      longer uses the Dapr CLI — daprd is downloaded and run directly.)
     default: "false"
   application-sdk-ref:
     required: false

--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -20,9 +20,12 @@ description: |
     SDK >= 3.13 this boots an embedded daprd + in-process Temporal itself
     (`application_sdk.dev`), so no external runtime install is needed — that is
     the default.
-  - Only on SDK < 3.13 (or when `force-external-runtime: true`): installs the
-    Dapr CLI + Temporal CLI and starts them via `poe start-deps` before the app
-    server. The daprd version then follows the SDK's pinned `__dapr_version`.
+  - Only on SDK < 3.13 (or when `force-external-runtime: true`): downloads the
+    `daprd` runtime binary (NOT the Dapr CLI) + Temporal CLI and starts daprd
+    directly alongside a Temporal dev server before the app server. The daprd
+    version follows the SDK's pinned `__dapr_version`. No Dapr CLI / `dapr init`
+    / `dapr run` is involved anywhere — daprd is invoked directly, the same way
+    the SDK container entrypoint and embedded local-dev runtime do.
   - Runs `pytest tests/integration/` with pytest-xdist for in-process parallelism.
   - Uploads junit XML + raw test output as artifacts.
   - Cleans up the app server (and the external Dapr/Temporal when they were started).
@@ -104,20 +107,24 @@ inputs:
     required: false
     description: How long to wait for the app server to become healthy.
     default: "60"
-  # MIGRATION: the separate ``dapr-cli-version`` input was removed — the CLI now
-  # always tracks the runtime version (one ``dapr-version`` drives both). GitHub
-  # Actions silently ignores unknown ``with:`` keys, so a caller still passing
-  # ``dapr-cli-version:`` won't error — that override is simply no longer honoured.
+  # MIGRATION: the Dapr CLI was removed entirely — this action now downloads the
+  # ``daprd`` runtime binary directly from ``dapr/dapr`` releases and invokes it
+  # directly (no ``dapr init`` / ``dapr run``). The earlier ``dapr-cli-version``
+  # input is long gone; GitHub Actions silently ignores unknown ``with:`` keys,
+  # so a caller still passing it won't error — it is simply not honoured.
   dapr-version:
     required: false
     description: |
-      Dapr version used for BOTH the CLI download and the daprd runtime.
+      Version of the ``daprd`` runtime to download from ``dapr/dapr`` releases.
       Leave empty (the default) to read the SDK's pinned ``__dapr_version``
       from ``application_sdk/version.py`` — the single source of truth, bumped
       by ``.github/workflows/check-dapr-version.yaml``. Set this only to force a
       specific version (e.g. to reproduce an issue on an older daprd).
 
-      (Replaces the removed ``dapr-cli-version`` input — see note above.)
+      NOTE: this is the daprd *runtime* version (``dapr/dapr`` releases), which
+      is independent of the ``dapr/cli`` release cadence — the CLI is no longer
+      downloaded, so a runtime-only release (daprd published without a matching
+      CLI release) no longer breaks this action.
     default: ""
   force-external-runtime:
     required: false
@@ -193,13 +200,12 @@ runs:
 
     # SDK 3.13+ boots an embedded daprd + Temporal directly from
     # `python main.py` (application_sdk/dev/_dapr.py + _embedded.py), each
-    # downloading its own runtime. On those versions the external Dapr CLI /
-    # Temporal CLI / `poe download-components` / `poe start-deps` below are
-    # redundant — worse, the embedded daprd roots its objectstore at
-    # ./local/objectstore while the external one roots at
-    # ./local/dapr/objectstore, so running both is a source of confusion.
-    # Detect the installed SDK version and skip the external infra when the
-    # embedded runtime is available. Pre-3.13 connectors still need it.
+    # downloading its own runtime. On those versions the external daprd +
+    # Temporal CLI install/start steps below are redundant — worse, the embedded
+    # daprd roots its objectstore at ./local/objectstore while the external one
+    # roots at ./local/dapr/objectstore, so running both is a source of
+    # confusion. Detect the installed SDK version and skip the external infra
+    # when the embedded runtime is available. Pre-3.13 connectors still need it.
     - name: Detect embedded runtime (SDK >= 3.13)
       id: runtime
       shell: bash
@@ -209,16 +215,21 @@ runs:
         echo "embedded=${EMBEDDED}" >> "$GITHUB_OUTPUT"
         echo "SDK ${VER} -> embedded runtime: ${EMBEDDED}"
 
-    - name: Install Dapr CLI
+    - name: Install daprd runtime (no Dapr CLI)
       if: steps.runtime.outputs.embedded != 'true' || inputs.force-external-runtime == 'true'
       shell: bash
       env:
         DAPR_VERSION_INPUT: ${{ inputs.dapr-version }}
       run: |
+        # Download the daprd RUNTIME binary directly from dapr/dapr releases —
+        # NOT the `dapr` CLI from dapr/cli. The CLI is intentionally not used:
+        # it adds a second release stream that can lag the runtime (a daprd-only
+        # release leaves `dapr/cli` without a matching tag → 404), and daprd is
+        # all we need (we invoke it directly, like the SDK's entrypoint.sh).
+        #
         # Default to the SDK's pinned __dapr_version (single source of truth).
         # This action ships inside application-sdk, so version.py sits three
         # dirs up from the action dir. An explicit dapr-version input overrides.
-        # The CLI download and the daprd runtime share the one version.
         DAPR_VERSION="${DAPR_VERSION_INPUT}"
         if [ -z "$DAPR_VERSION" ]; then
           DAPR_VERSION="$(grep '^__dapr_version' "${{ github.action_path }}/../../../application_sdk/version.py" | cut -d'"' -f2)"
@@ -227,35 +238,48 @@ runs:
           echo "::error::Could not resolve Dapr version (input empty and __dapr_version unreadable)"
           exit 1
         fi
-        echo "Using Dapr version: $DAPR_VERSION"
-        wget -q "https://github.com/dapr/cli/releases/download/v${DAPR_VERSION}/dapr_linux_amd64.tar.gz" -O /tmp/dapr.tar.gz
-        tar -xzf /tmp/dapr.tar.gz -C /tmp
-        sudo mv /tmp/dapr /usr/local/bin/
-        chmod +x /usr/local/bin/dapr
-        dapr init --runtime-version "${DAPR_VERSION}" --slim
+        echo "Installing daprd runtime v$DAPR_VERSION (no Dapr CLI)"
+        wget -q "https://github.com/dapr/dapr/releases/download/v${DAPR_VERSION}/daprd_linux_amd64.tar.gz" -O /tmp/daprd.tar.gz
+        tar -xzf /tmp/daprd.tar.gz -C /tmp
+        sudo mv /tmp/daprd /usr/local/bin/
+        sudo chmod +x /usr/local/bin/daprd
+        daprd --version
 
     - name: Install Temporal CLI
       if: steps.runtime.outputs.embedded != 'true' || inputs.force-external-runtime == 'true'
       shell: bash
       run: curl -sSf https://temporal.download/cli.sh | sh
 
-    - name: Add Dapr and Temporal to PATH
+    - name: Add Temporal to PATH
+      if: steps.runtime.outputs.embedded != 'true' || inputs.force-external-runtime == 'true'
+      shell: bash
+      # daprd is already on PATH (/usr/local/bin); only the Temporal CLI needs adding.
+      run: echo "$HOME/.temporalio/bin" >> "$GITHUB_PATH"
+
+    - name: Start daprd + Temporal
       if: steps.runtime.outputs.embedded != 'true' || inputs.force-external-runtime == 'true'
       shell: bash
       run: |
-        echo "$HOME/.dapr/bin" >> "$GITHUB_PATH"
-        echo "$HOME/.temporalio/bin" >> "$GITHUB_PATH"
-
-    - name: Download Dapr components
-      if: steps.runtime.outputs.embedded != 'true' || inputs.force-external-runtime == 'true'
-      shell: bash
-      run: uv run poe download-components
-
-    - name: Start Dapr + Temporal
-      if: steps.runtime.outputs.embedded != 'true' || inputs.force-external-runtime == 'true'
-      shell: bash
-      run: |
-        uv run poe start-deps
+        # Start daprd directly (no `dapr run` wrapper). App-less sidecar on the
+        # default ports; the app server (next step) connects to it. We do NOT
+        # delegate to the caller's `poe start-deps` because that task lives in
+        # the *connector's* pyproject and runs `dapr run`, which needs the CLI.
+        daprd \
+          --app-id app \
+          --app-port "${{ inputs.app-port }}" \
+          --dapr-http-port 3500 \
+          --dapr-grpc-port 50001 \
+          --resources-path components \
+          --log-level warn \
+          --placement-host-address '' \
+          --scheduler-host-address '' \
+          --max-body-size 1024Mi \
+          > daprd.log 2>&1 &
+        temporal server start-dev --db-filename /tmp/temporal.db > temporal.log 2>&1 &
+        # Export the sidecar ports so the (separate) app-server step runs in
+        # Dapr-backed mode — the SDK keys off DAPR_HTTP_PORT being set.
+        echo "DAPR_HTTP_PORT=3500" >> "$GITHUB_ENV"
+        echo "DAPR_GRPC_PORT=50001" >> "$GITHUB_ENV"
         sleep 5
 
     - name: Start runtime services (services-script hook)
@@ -324,4 +348,7 @@ runs:
       shell: bash
       run: |
         kill $(lsof -t -i :${{ inputs.app-port }}) 2>/dev/null || true
-        uv run poe stop-deps || true
+        # Kill the daprd + Temporal we started directly (no `poe stop-deps`,
+        # which is a connector-side task and was tied to the old CLI flow).
+        pkill -f daprd 2>/dev/null || true
+        pkill -f "temporal server" 2>/dev/null || true

--- a/components/README.md
+++ b/components/README.md
@@ -3,7 +3,9 @@
 This folder contains Dapr PaaS components for various services.
 
 ## Requirements
-- Install [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
+- No Dapr CLI needed. The `daprd` runtime is fetched and pinned by the SDK
+  (`application_sdk.dev._dapr`) and invoked directly — `uv run poe start-dapr`
+  resolves and launches it for you.
 
 ## Local Development
 1. State store - Uses SQLite as the state store at `./local/dapr/statestore.db`
@@ -11,7 +13,8 @@ This folder contains Dapr PaaS components for various services.
 3. Secret store - Uses system environment variables
 
 ## Testing Dapr components only
-- Run the dapr sidecar manually `make dapr-sidecar`
+- Run the dapr sidecar manually with `uv run poe start-dapr` (launches `daprd`
+  directly against the YAMLs in this folder; no Dapr CLI involved)
 - Test the state store components - Uses SQLite as the state store
     - Save state
 ```bash

--- a/docs/guides/build-your-first-app.md
+++ b/docs/guides/build-your-first-app.md
@@ -244,8 +244,9 @@ Start infrastructure and run:
 # Terminal 1
 temporal server start-dev --db-filename temporal.db
 
-# Terminal 2
-dapr run \
+# Terminal 2 — resolve the pinned daprd binary via the SDK (no Dapr CLI), then run it
+DAPRD=$(uv run python -c "from application_sdk.dev._dapr import _ensure_daprd_binary; print(_ensure_daprd_binary())")
+"$DAPRD" \
   --app-id app \
   --app-port 8000 \
   --dapr-http-port 3500 \

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -112,7 +112,7 @@ curl -s -X POST http://localhost:8000/workflows/v1/start \
 
 ## Optional: run against external Dapr + Temporal
 
-The embedded runtime above is the recommended local-dev path. If you want to mirror production more closely — where the app runs against a Dapr **sidecar** and a standalone **Temporal cluster** — install the [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/) and [Temporal CLI](https://docs.temporal.io/cli#install), then:
+The embedded runtime above is the recommended local-dev path. If you want to mirror production more closely — where the app runs against a Dapr **sidecar** and a standalone **Temporal cluster** — you only need the [Temporal CLI](https://docs.temporal.io/cli#install). You do **not** need the Dapr CLI: production runs the `daprd` runtime directly (see the SDK container entrypoint), and the SDK can fetch the same pinned `daprd` binary for you. Then:
 
 **1. Add the SDK's Dapr component definitions to your project:**
 
@@ -128,7 +128,11 @@ temporal server start-dev --db-filename temporal.db
 ```
 
 ```bash
-dapr run \
+# Resolve the pinned daprd binary via the SDK (downloads it on first use;
+# no Dapr CLI / `dapr init` required), then run daprd directly:
+DAPRD=$(uv run python -c "from application_sdk.dev._dapr import _ensure_daprd_binary; print(_ensure_daprd_binary())")
+
+"$DAPRD" \
   --app-id app \
   --app-port 8000 \
   --dapr-http-port 3500 \

--- a/docs/guides/rest-api-application-guide.md
+++ b/docs/guides/rest-api-application-guide.md
@@ -263,8 +263,9 @@ Start dependencies and run:
 # Terminal 1 — Temporal
 temporal server start-dev --db-filename temporal.db
 
-# Terminal 2 — Dapr
-dapr run \
+# Terminal 2 — Dapr (resolve the pinned daprd binary via the SDK; no Dapr CLI)
+DAPRD=$(uv run python -c "from application_sdk.dev._dapr import _ensure_daprd_binary; print(_ensure_daprd_binary())")
+"$DAPRD" \
   --app-id app \
   --app-port 8000 \
   --dapr-http-port 3500 \

--- a/docs/setup/LINUX.md
+++ b/docs/setup/LINUX.md
@@ -51,9 +51,10 @@ Python and uv.
 
 > [!NOTE]
 > Prefer to run against an external Dapr sidecar and Temporal server to mirror
-> production? Install the [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
-> and [Temporal CLI](https://docs.temporal.io/cli#install), then follow the
-> optional external-infrastructure section of the Getting Started guide.
+> production? You only need the [Temporal CLI](https://docs.temporal.io/cli#install) —
+> not the Dapr CLI; the SDK fetches the pinned `daprd` runtime for you and you run
+> it directly. Then follow the optional external-infrastructure section of the
+> Getting Started guide.
 
 > [!NOTE]
 > Your development environment is now ready! Head over to our [Getting Started Guide](../guides/getting-started.md) to learn how to:

--- a/docs/setup/MAC.md
+++ b/docs/setup/MAC.md
@@ -49,9 +49,10 @@ Python and uv.
 
 > [!NOTE]
 > Prefer to run against an external Dapr sidecar and Temporal server to mirror
-> production? Install the [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
-> and [Temporal CLI](https://docs.temporal.io/cli#install), then follow the
-> optional external-infrastructure section of the Getting Started guide.
+> production? You only need the [Temporal CLI](https://docs.temporal.io/cli#install) —
+> not the Dapr CLI; the SDK fetches the pinned `daprd` runtime for you and you run
+> it directly. Then follow the optional external-infrastructure section of the
+> Getting Started guide.
 
 > [!NOTE]
 > Your development environment is now ready! Head over to our [Getting Started Guide](../guides/getting-started.md) to learn how to:

--- a/docs/setup/WINDOWS.md
+++ b/docs/setup/WINDOWS.md
@@ -36,9 +36,10 @@ Python and uv.
 
 > [!NOTE]
 > Prefer to run against an external Dapr sidecar and Temporal server to mirror
-> production? Install the [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
-> and [Temporal CLI](https://docs.temporal.io/cli#install), then follow the
-> optional external-infrastructure section of the Getting Started guide.
+> production? You only need the [Temporal CLI](https://docs.temporal.io/cli#install) —
+> not the Dapr CLI; the SDK fetches the pinned `daprd` runtime for you and you run
+> it directly. Then follow the optional external-infrastructure section of the
+> Getting Started guide.
 
 > [!NOTE]
 > Your development environment is now ready! Head over to our [Getting Started Guide](../guides/getting-started.md) to learn how to:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,11 +165,15 @@ docs = [
 
 [tool.poe.tasks]
 download-components.shell = "ls -l components/*.yaml"
-# Dapr and Temporal service tasks
-start-dapr = "dapr run --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi --config components/configuration.yaml --resources-path components"
+# Dapr and Temporal service tasks.
+# No Dapr CLI: resolve the daprd binary via the SDK's own downloader
+# (application_sdk.dev._dapr — the same binary the embedded local-dev runtime
+# uses, pinned to __dapr_version) and invoke daprd directly, exactly like the
+# SDK container entrypoint. First run downloads daprd into ~/.cache/atlan-sdk.
+start-dapr.shell = "DAPRD=$(uv run python -c 'from application_sdk.dev._dapr import _ensure_daprd_binary; print(_ensure_daprd_binary())') && \"$DAPRD\" --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi --config components/configuration.yaml --resources-path components"
 
 # if you need to test dapr with environment values for an app
-#start-dapr.shell = "set -a && source .env && set +a && dapr run --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi --config components/configuration.yaml --resources-path components"
+#start-dapr.shell = "set -a && source .env && set +a && DAPRD=$(uv run python -c 'from application_sdk.dev._dapr import _ensure_daprd_binary; print(_ensure_daprd_binary())') && \"$DAPRD\" --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi --config components/configuration.yaml --resources-path components"
 
 start-temporal = "temporal server start-dev --db-filename ./temporal.db"
 # Export Dapr ports before backgrounding so `uv run main.py` (run separately)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,15 +165,11 @@ docs = [
 
 [tool.poe.tasks]
 download-components.shell = "ls -l components/*.yaml"
-# Dapr and Temporal service tasks.
-# No Dapr CLI: resolve the daprd binary via the SDK's own downloader
-# (application_sdk.dev._dapr — the same binary the embedded local-dev runtime
-# uses, pinned to __dapr_version) and invoke daprd directly, exactly like the
-# SDK container entrypoint. First run downloads daprd into ~/.cache/atlan-sdk.
-start-dapr.shell = "DAPRD=$(uv run python -c 'from application_sdk.dev._dapr import _ensure_daprd_binary; print(_ensure_daprd_binary())') && \"$DAPRD\" --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi --config components/configuration.yaml --resources-path components"
+# Dapr and Temporal service tasks
+start-dapr = "dapr run --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi --config components/configuration.yaml --resources-path components"
 
 # if you need to test dapr with environment values for an app
-#start-dapr.shell = "set -a && source .env && set +a && DAPRD=$(uv run python -c 'from application_sdk.dev._dapr import _ensure_daprd_binary; print(_ensure_daprd_binary())') && \"$DAPRD\" --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi --config components/configuration.yaml --resources-path components"
+#start-dapr.shell = "set -a && source .env && set +a && dapr run --enable-api-logging --log-level debug --app-id app --app-port 8000 --dapr-http-port 3500 --dapr-grpc-port 50001 --scheduler-host-address '' --placement-host-address '' --max-body-size 1024Mi --config components/configuration.yaml --resources-path components"
 
 start-temporal = "temporal server start-dev --db-filename ./temporal.db"
 # Export Dapr ports before backgrounding so `uv run main.py` (run separately)


### PR DESCRIPTION
## Problem

After #2297 (`6419a83`), the shared **connector-integration-tests** action and **ae-stack-up.sh** downloaded the **Dapr CLI** from `dapr/cli` releases at `__dapr_version` (currently `1.18.1`).

Dapr publishes the **daprd runtime** and the **CLI** as *independent* release streams. A runtime-only release — daprd `v1.18.1` with **no matching `dapr/cli` tag** — made every CLI download 404:

```
https://github.com/dapr/cli/releases/download/v1.18.1/dapr_linux_amd64.tar.gz  → 404
```

This broke CI for **all connectors** using `force-external-runtime: "true"` against `@main` of the shared action (since ~Jun 24 06:06 UTC).

## Fix — stop using the Dapr CLI in CI

Download the **`daprd` runtime binary** directly from `dapr/dapr` releases and invoke it directly — the same pattern the SDK container `entrypoint.sh` already uses. daprd `v1.18.1` **does** exist, so this fixes the breakage and removes the dual-release coupling for good (a future runtime-only release can no longer wedge CI).

`__dapr_version` stays **`1.18.1`** (the runtime, which exists). The `_dapr/client.py` / `DaprClient` Python *SDK* client is unrelated to the CLI and is untouched.

## Scope

Everything that **downloaded** the CLI in CI, plus docs that told humans to install it:

| File | Change |
|------|--------|
| `.github/actions/connector-integration-tests/action.yaml` | Install `daprd` from `dapr/dapr` (no `dapr init`); start daprd app-less + `temporal server start-dev` directly instead of the connector's CLI-based `poe start-deps`; export `DAPR_HTTP_PORT`/`DAPR_GRPC_PORT` so the app-server step runs Dapr-backed; also steer `force-external-runtime` callers toward the embedded runtime |
| `.github/actions/ae-stack-up/ae-stack-up.sh` | Download daprd; split each `dapr run -- cmd` into background daprd + background app, handing each app the standard `DAPR_*` env vars `dapr run` used to auto-inject |
| docs (`setup/{MAC,LINUX,WINDOWS}`, `getting-started`, `build-your-first-app`, `rest-api-application-guide`), `components/README.md`, skills (`local-dev-bootstrap`, `scaffold-app`) | Drop "install the Dapr CLI" guidance; resolve `daprd` via the SDK for the optional external-runtime path |

### Why the action self-provisions (subtle)

The connector action checks out the **connector's** repo, so its `poe start-deps` runs the *connector's* `dapr run`. Simply removing the CLI install step would have flipped `CLI 404` → `dapr: command not found`. The action now starts daprd + Temporal itself rather than delegating to the connector's CLI-based poe tasks.

### Out of scope (intentionally)

- **`pyproject.toml` `start-dapr`** (local-dev poe task) is left as-is. It still references `dapr run`, but it is a developer convenience invoked manually — it was never part of the breakage, and **production never uses it** (prod boots via `entrypoint.sh` → `daprd` directly). Keeping this PR scoped to what actually broke.
- **Migrating connectors off `force-external-runtime`** (the embedded-adoption drift this surfaced) is tracked separately — a conformance/drift check is coming in its own PR.

## Verification

- ✅ `_ensure_daprd_binary()` downloads daprd **v1.18.1** and `daprd --version` → `1.18.1` (confirms the runtime asset the CLI lacked)
- ✅ `bash -n` (ae-stack-up.sh), YAML parse (action) — clean
- ✅ pre-commit passed on all changed files