### PR TITLE
ci(build-and-publish-app): expose ghcr_image as a workflow_call output

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -30,6 +30,13 @@ name: Build & Publish Atlan App
 
 on:
   workflow_call:
+    outputs:
+      ghcr_image:
+        description: "Immutable GHCR image ref that was built+pushed (e.g. ghcr.io/atlanhq/atlan-foo-app:branch-sha7). Lets callers consume the exact tag instead of recomputing it."
+        value: ${{ jobs.prepare.outputs.ghcr_image }}
+      dockerhub_image:
+        description: "Docker Hub image ref (set when published)."
+        value: ${{ jobs.prepare.outputs.dockerhub_image }}
     inputs:
       ref:
         description: "Branch or SHA to checkout and build (default: caller's ref)"


### PR DESCRIPTION
Surfaces the `prepare` job's already-computed `ghcr_image` (+ `dockerhub_image`) as `workflow_call` outputs, so callers consume the **exact** built+pushed ref instead of recomputing the tag (which drifts from this workflow's derivation — e.g. passing a SHA as `ref` makes the branch-slug the full SHA).

Unblocks the per-app SDR e2e callers (atlan-oracle-app#178, atlan-mssql-app#181) which pass `version_b_image` = the PR build; they'll switch from a recomputed tag to `needs.build-pr-image.outputs.ghcr_image`.

Additive + backward-compatible — no behaviour change for existing callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)