### PR TITLE
ci: fix invalid YAML in connector-integration-tests action (fleet-down)

### DIFF
--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -258,7 +258,11 @@ runs:
     - name: Install Temporal CLI
       if: steps.runtime.outputs.embedded != 'true' || inputs.force-external-runtime == 'true'
       shell: bash
-      run: "${{ github.action_path }}/../../scripts/with-retry.sh" bash -c "curl -sSf https://temporal.download/cli.sh | sh"
+      # Block scalar: a `run:` value that *starts* with a quote is parsed by YAML
+      # as a single quoted string, leaving the trailing args as an unexpected
+      # token (this exact line took the connector fleet down — invalid manifest).
+      run: |
+        "${{ github.action_path }}/../../scripts/with-retry.sh" bash -c "curl -sSf https://temporal.download/cli.sh | sh"
 
     - name: Add Temporal to PATH
       if: steps.runtime.outputs.embedded != 'true' || inputs.force-external-runtime == 'true'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,13 @@ repos:
       - id: debug-statements
       - id: fix-byte-order-marker
       - id: trailing-whitespace
+      # Guard the composite-action manifests: a malformed action.yaml fails to
+      # load for EVERY repo that `uses:` it via @main, taking the whole connector
+      # fleet down before any step runs. Parse them on every commit so an invalid
+      # manifest can never reach main again.
+      - id: check-yaml
+        name: check-yaml (GitHub composite-action manifests)
+        files: ^\.github/actions/.*/action\.ya?ml$
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:


### PR DESCRIPTION
## Incident

Every connector that `uses:` `atlanhq/application-sdk/.github/actions/connector-integration-tests@main` is currently failing at **"Set up job"** — before any step runs:

```
atlanhq/application-sdk/main/.github/actions/connector-integration-tests/action.yaml:
(Line: 261, Col: 68) While parsing a block mapping, did not find expected key.
Failed to load ... connector-integration-tests/action.yaml
```

The action's `action.yaml` on `main` is **invalid YAML**, so GitHub can't load the action manifest. This takes down the whole connector fleet on `@main` (powerbi, postgres, snowflake, … — [example run](https://github.com/atlanhq/atlan-powerbi-app/actions/runs/28109245696/job/83231814665)). Reproduced locally: `yaml.safe_load` throws the identical error at line 261, col 68.

## Root cause

Introduced by #2301 ("harden CI test pipeline against ephemeral failures"). The `Install Temporal CLI` step was written as:

```yaml
run: "${{ github.action_path }}/../../scripts/with-retry.sh" bash -c "curl -sSf https://temporal.download/cli.sh | sh"
```

A YAML scalar that **starts with `"`** is parsed as a single double-quoted string (ending at `with-retry.sh"`); the trailing ` bash -c "..."` is then an unexpected token → manifest fails to load.

## Fix

Make it a block scalar so the whole command is literal text:

```yaml
run: |
  "${{ github.action_path }}/../../scripts/with-retry.sh" bash -c "curl -sSf https://temporal.download/cli.sh | sh"
```

This was the only broken line — the daprd-install retry usage is already inside a `run: |` block.

## Recurrence guard

Added a scoped `check-yaml` pre-commit hook over `.github/actions/**/action.yaml`. Composite-action manifests are the high-blast-radius class: a malformed one breaks *every* repo that consumes it via `@main`, before any step runs. The repo had **no** YAML parse hook, which is why this (and #2301) reached `main`. This guard would have caught both.

## Verification

- ✅ `yaml.safe_load` on the fixed `action.yaml` → parses
- ✅ Scanned all 76 `.github` workflow + action files; all action manifests parse
- ✅ `pre-commit run check-yaml --all-files` → Passed
- ✅ `pre-commit` clean on changed files

## Separate finding (not fixed here — flagging)

`.github/workflows/scheduled-trivy-scan.yml` is **also** invalid YAML (a bash heredoc body at column 1 dedents below its `run: |` block scalar, ~line 212-217 → `while scanning an alias`). It's a *scheduled* workflow (fails only on cron, breaks only itself), so it's out of scope for this fleet-down hotfix — tracking as a follow-up. The guard here is scoped to action manifests and intentionally does not block on it.