### PR TITLE
fix(storage): isolate explicit Azure credentials from the host's ambient AZURE_* env

### DIFF
--- a/application_sdk/storage/_obstore_config.py
+++ b/application_sdk/storage/_obstore_config.py
@@ -42,7 +42,9 @@ without changing the outcome (see BLDX-1155 review thread).
 
 from __future__ import annotations
 
+import contextlib
 import os
+import threading
 import urllib.request
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit, urlunsplit
@@ -185,6 +187,58 @@ def make_s3_store(
     return S3Store(**kw)  # type: ignore[arg-type]
 
 
+# obstore-rs reads ``AZURE_*`` from the environment at AzureStore construction
+# *unconditionally*, and its credential precedence (account key > SAS > client secret >
+# workload identity) lets a value injected into the host environment outrank the
+# credential the caller passed in ``config``. On an Azure-hosted node the pod carries
+# its own identity in ``AZURE_STORAGE_ACCESS_KEY`` and in ``AZURE_FEDERATED_TOKEN_FILE``
+# + ``AZURE_CLIENT_ID``; either silently overrides an explicit caller credential and
+# signs requests as the wrong principal (403 AuthenticationFailed / 401 AADSTS70025).
+# So when the caller supplies a standalone credential in ``config`` we construct the
+# store with all ``AZURE_*`` stripped from the environment, leaving obstore to resolve
+# from our ``config`` alone. Callers that pass no credential (managed / workload
+# identity) are left untouched so the ambient identity still applies.
+_AZURE_CREDENTIAL_CONFIG_KEYS = (
+    "azure_storage_account_key",
+    "azure_storage_client_secret",
+    "azure_storage_sas_key",
+    "azure_storage_token",
+)
+
+# os.environ is process-global, so serialize every AzureStore construction: an isolated
+# build (env temporarily stripped) must never overlap a concurrent build that relies on
+# the ambient AZURE_* env.
+_azure_store_build_lock = threading.Lock()
+
+
+def _azure_config_has_explicit_credential(config: dict[str, str] | None) -> bool:
+    """True if *config* carries a standalone Azure credential (account key / client
+    secret / SAS / bearer token) — i.e. the caller wants that credential used, not the
+    host's ambient identity."""
+    return bool(config) and any(config.get(k) for k in _AZURE_CREDENTIAL_CONFIG_KEYS)
+
+
+@contextlib.contextmanager
+def _suppress_ambient_azure_env(active: bool):
+    """Temporarily drop all ambient ``AZURE_*`` env vars when *active*.
+
+    Scoped to the synchronous AzureStore constructor (where obstore reads the
+    environment). Serialized by ``_azure_store_build_lock`` so an isolated build can't
+    strip the environment out from under a concurrent non-isolated build.
+    """
+    with _azure_store_build_lock:
+        if not active:
+            yield
+            return
+        saved = {
+            k: os.environ.pop(k) for k in list(os.environ) if k.startswith("AZURE_")
+        }
+        try:
+            yield
+        finally:
+            os.environ.update(saved)
+
+
 def make_azure_store(
     container: str,
     config: dict[str, str] | None = None,
@@ -195,7 +249,9 @@ def make_azure_store(
 ) -> ObjectStore:
     """Create an AzureStore with SDK-default client/retry config.
 
-    See :func:`make_s3_store` for rationale.
+    See :func:`make_s3_store` for rationale. When *config* carries an explicit
+    credential, the ambient ``AZURE_*`` environment is suppressed for the construction
+    so the host's own identity can't override it (see ``_suppress_ambient_azure_env``).
     """
     from obstore.store import AzureStore  # noqa: PLC0415
 
@@ -207,7 +263,8 @@ def make_azure_store(
     )
     if credential_provider is not None:
         kw["credential_provider"] = credential_provider
-    return AzureStore(**kw)  # type: ignore[arg-type]
+    with _suppress_ambient_azure_env(_azure_config_has_explicit_credential(config)):
+        return AzureStore(**kw)  # type: ignore[arg-type]
 
 
 def make_gcs_store(

--- a/application_sdk/storage/_obstore_config.py
+++ b/application_sdk/storage/_obstore_config.py
@@ -200,9 +200,11 @@ def make_s3_store(
 # identity) are left untouched so the ambient identity still applies.
 #
 # TODO: retire this env-mutation workaround once obstore-rs honours explicit ``config``
-# credentials with higher precedence than ambient ``AZURE_*`` env vars.  Track at
-# https://github.com/developmentseed/obstore/issues — file or link an upstream issue
-# before removing this block.
+# credentials with higher precedence than ambient ``AZURE_*`` env vars.  File an issue
+# at https://github.com/developmentseed/obstore/issues and replace the placeholder
+# below with the specific issue URL — the workaround must not be deleted until that
+# gate is closed.
+# Upstream issue: <not yet filed>
 _AZURE_CREDENTIAL_CONFIG_KEYS = (
     "azure_storage_account_key",
     "azure_storage_client_secret",
@@ -240,6 +242,10 @@ def _suppress_ambient_azure_env(active: bool):
         saved = {
             k: os.environ.pop(k) for k in list(os.environ) if k.startswith("AZURE_")
         }
+        if saved:
+            logger.debug(
+                "make_azure_store: suppressed %d ambient AZURE_* env var(s)", len(saved)
+            )
         try:
             yield
         finally:

--- a/application_sdk/storage/_obstore_config.py
+++ b/application_sdk/storage/_obstore_config.py
@@ -198,6 +198,11 @@ def make_s3_store(
 # store with all ``AZURE_*`` stripped from the environment, leaving obstore to resolve
 # from our ``config`` alone. Callers that pass no credential (managed / workload
 # identity) are left untouched so the ambient identity still applies.
+#
+# TODO: retire this env-mutation workaround once obstore-rs honours explicit ``config``
+# credentials with higher precedence than ambient ``AZURE_*`` env vars.  Track at
+# https://github.com/developmentseed/obstore/issues — file or link an upstream issue
+# before removing this block.
 _AZURE_CREDENTIAL_CONFIG_KEYS = (
     "azure_storage_account_key",
     "azure_storage_client_secret",
@@ -205,9 +210,11 @@ _AZURE_CREDENTIAL_CONFIG_KEYS = (
     "azure_storage_token",
 )
 
-# os.environ is process-global, so serialize every AzureStore construction: an isolated
-# build (env temporarily stripped) must never overlap a concurrent build that relies on
-# the ambient AZURE_* env.
+# os.environ is process-global, so serialize make_azure_store callers: an isolated build
+# (env temporarily stripped) must never overlap a concurrent build that relies on the
+# ambient AZURE_* env.  Note: this lock only protects callers of make_azure_store — other
+# in-process readers (azure-identity, OpenTelemetry exporters, subprocesses spawned during
+# the window, sidecar SDKs) can still observe the stripped env during the brief window.
 _azure_store_build_lock = threading.Lock()
 
 
@@ -250,8 +257,11 @@ def make_azure_store(
     """Create an AzureStore with SDK-default client/retry config.
 
     See :func:`make_s3_store` for rationale. When *config* carries an explicit
-    credential, the ambient ``AZURE_*`` environment is suppressed for the construction
-    so the host's own identity can't override it (see ``_suppress_ambient_azure_env``).
+    credential *or* a ``credential_provider`` is supplied, the ambient ``AZURE_*``
+    environment is suppressed for the construction so the host's own identity can't
+    override it (see ``_suppress_ambient_azure_env``).  The cert-auth path in
+    ``binding.py`` uses ``credential_provider`` instead of placing a key in ``config``,
+    so both cases must activate env stripping.
     """
     from obstore.store import AzureStore  # noqa: PLC0415
 
@@ -263,7 +273,10 @@ def make_azure_store(
     )
     if credential_provider is not None:
         kw["credential_provider"] = credential_provider
-    with _suppress_ambient_azure_env(_azure_config_has_explicit_credential(config)):
+    isolate = (
+        _azure_config_has_explicit_credential(config) or credential_provider is not None
+    )
+    with _suppress_ambient_azure_env(isolate):
         return AzureStore(**kw)  # type: ignore[arg-type]
 
 

--- a/application_sdk/storage/binding.py
+++ b/application_sdk/storage/binding.py
@@ -357,6 +357,12 @@ def _build_s3_config(
                 "back to the ambient credential chain",
                 name,
             )
+        elif _nonempty(meta, "sessionToken"):
+            _get_logger().warning(
+                "S3 binding '%s': sessionToken requires accessKey + secretKey; "
+                "ignoring sessionToken and falling back to the ambient credential chain",
+                name,
+            )
 
     # --- Storage class (obstore ≥ 0.10.0 put attribute) -------------------
     storage_class = _nonempty(meta, "storageClass")

--- a/application_sdk/storage/binding.py
+++ b/application_sdk/storage/binding.py
@@ -343,12 +343,20 @@ def _build_s3_config(
             base_session_token=base_session_token,
         )
     else:
-        if _nonempty(meta, "accessKey"):
-            config["aws_access_key_id"] = meta["accessKey"]
-        if _nonempty(meta, "secretKey"):
-            config["aws_secret_access_key"] = meta["secretKey"]
-        if _nonempty(meta, "sessionToken"):
-            config["aws_session_token"] = meta["sessionToken"]
+        access_key = _nonempty(meta, "accessKey")
+        secret_key = _nonempty(meta, "secretKey")
+        if access_key and secret_key:
+            config["aws_access_key_id"] = access_key
+            config["aws_secret_access_key"] = secret_key
+            if _nonempty(meta, "sessionToken"):
+                config["aws_session_token"] = meta["sessionToken"]
+        elif access_key or secret_key:
+            _get_logger().warning(
+                "S3 binding '%s': both accessKey and secretKey are required for "
+                "static credentials; only one was set — ignoring both and falling "
+                "back to the ambient credential chain",
+                name,
+            )
 
     # --- Storage class (obstore ≥ 0.10.0 put attribute) -------------------
     storage_class = _nonempty(meta, "storageClass")

--- a/tests/unit/storage/test_binding.py
+++ b/tests/unit/storage/test_binding.py
@@ -240,6 +240,79 @@ class TestS3StaticCredentials:
         config = mock_s3_cls.call_args.kwargs["config"]
         assert config["aws_session_token"] == "TOKEN"
 
+    @patch("obstore.store.S3Store")
+    def test_access_key_only_warns_and_omits_credentials(
+        self, mock_s3_cls: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Empirically confirmed: obstore mixes config access_key_id with env
+        # secret_access_key when only one half of the pair is in config.  The
+        # mismatched pair signs requests as the wrong identity (if env creds are
+        # present) or fails authentication.  We must emit neither key so the
+        # store falls back cleanly to the ambient credential chain.
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ENV-ACCESS-KEY")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ENV-SECRET-KEY")
+        components_dir = _write_component(
+            tmp_path,
+            "objectstore",
+            "bindings.aws.s3",
+            {"bucket": "b", "region": "us-east-1", "accessKey": "AK"},
+        )
+        mock_s3_cls.return_value = MagicMock()
+        with patch("application_sdk.storage.binding._get_logger") as mock_logger_fn:
+            mock_logger = MagicMock()
+            mock_logger_fn.return_value = mock_logger
+            create_store_from_binding("objectstore", components_dir=components_dir)
+
+        config = mock_s3_cls.call_args.kwargs["config"] or {}
+        assert "aws_access_key_id" not in config
+        assert "aws_secret_access_key" not in config
+        mock_logger.warning.assert_called_once()
+        assert "only one was set" in mock_logger.warning.call_args.args[0]
+
+    @patch("obstore.store.S3Store")
+    def test_secret_key_only_warns_and_omits_credentials(
+        self, mock_s3_cls: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ENV-ACCESS-KEY")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ENV-SECRET-KEY")
+        components_dir = _write_component(
+            tmp_path,
+            "objectstore",
+            "bindings.aws.s3",
+            {"bucket": "b", "region": "us-east-1", "secretKey": "SK"},
+        )
+        mock_s3_cls.return_value = MagicMock()
+        with patch("application_sdk.storage.binding._get_logger") as mock_logger_fn:
+            mock_logger = MagicMock()
+            mock_logger_fn.return_value = mock_logger
+            create_store_from_binding("objectstore", components_dir=components_dir)
+
+        config = mock_s3_cls.call_args.kwargs["config"] or {}
+        assert "aws_access_key_id" not in config
+        assert "aws_secret_access_key" not in config
+        mock_logger.warning.assert_called_once()
+
+    @patch("obstore.store.S3Store")
+    def test_session_token_without_key_pair_is_ignored(
+        self, mock_s3_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        # A session token with no static key pair is meaningless — obstore
+        # would mix it with ambient env credentials.  It should be silently
+        # ignored so the ambient chain activates cleanly.
+        components_dir = _write_component(
+            tmp_path,
+            "objectstore",
+            "bindings.aws.s3",
+            {"bucket": "b", "region": "us-east-1", "sessionToken": "TOKEN"},
+        )
+        mock_s3_cls.return_value = MagicMock()
+        create_store_from_binding("objectstore", components_dir=components_dir)
+
+        config = mock_s3_cls.call_args.kwargs["config"] or {}
+        assert "aws_session_token" not in config
+        assert "aws_access_key_id" not in config
+        assert "aws_secret_access_key" not in config
+
 
 class TestS3EmptyConfigHardening:
     @patch("obstore.store.S3Store")

--- a/tests/unit/storage/test_binding.py
+++ b/tests/unit/storage/test_binding.py
@@ -293,12 +293,12 @@ class TestS3StaticCredentials:
         mock_logger.warning.assert_called_once()
 
     @patch("obstore.store.S3Store")
-    def test_session_token_without_key_pair_is_ignored(
+    def test_session_token_without_key_pair_warns_and_is_ignored(
         self, mock_s3_cls: MagicMock, tmp_path: Path
     ) -> None:
-        # A session token with no static key pair is meaningless — obstore
-        # would mix it with ambient env credentials.  It should be silently
-        # ignored so the ambient chain activates cleanly.
+        # STS session tokens require base credentials by definition; a bare
+        # sessionToken is a misconfiguration that should warn rather than
+        # silently fall back (symmetric with the half-pair warning above).
         components_dir = _write_component(
             tmp_path,
             "objectstore",
@@ -306,12 +306,19 @@ class TestS3StaticCredentials:
             {"bucket": "b", "region": "us-east-1", "sessionToken": "TOKEN"},
         )
         mock_s3_cls.return_value = MagicMock()
-        create_store_from_binding("objectstore", components_dir=components_dir)
+        with patch("application_sdk.storage.binding._get_logger") as mock_logger_fn:
+            mock_logger = MagicMock()
+            mock_logger_fn.return_value = mock_logger
+            create_store_from_binding("objectstore", components_dir=components_dir)
 
         config = mock_s3_cls.call_args.kwargs["config"] or {}
         assert "aws_session_token" not in config
         assert "aws_access_key_id" not in config
         assert "aws_secret_access_key" not in config
+        mock_logger.warning.assert_called_once()
+        assert (
+            "sessionToken requires accessKey" in mock_logger.warning.call_args.args[0]
+        )
 
 
 class TestS3EmptyConfigHardening:

--- a/tests/unit/storage/test_obstore_config.py
+++ b/tests/unit/storage/test_obstore_config.py
@@ -437,23 +437,23 @@ class TestAzureAmbientEnvIsolation:
 
 
 # ---------------------------------------------------------------------------
-# Credential precedence — empirically verified against obstore-rs 0.10.x
+# Config passthrough — regression guard for binding.py / cloud.py
 #
-# These tests document behaviour confirmed by live requests (see PR audit).
-# The pattern: mock the store constructor and assert on the config dict it
-# receives — we can't easily intercept the Rust-layer credential resolution
-# at the unit level, but we CAN verify that the right keys reach the
-# constructor (which is the invariant the fix is about).
+# These tests verify that make_s3_store / make_gcs_store forward the caller's
+# config dict to the obstore constructor without dropping or mutating keys.
+# The Rust-layer credential precedence (explicit config vs. ambient env vars)
+# was confirmed by live requests during the PR audit but cannot be exercised
+# at the unit level — integration tests cover that invariant.
 # ---------------------------------------------------------------------------
 
 
-class TestS3CredentialPrecedence:
-    """S3: explicit config credentials must reach S3Store unchanged.
+class TestS3ConfigPassthrough:
+    """Regression guard: the config dict reaches S3Store unchanged.
 
-    obstore-rs uses the AWS credential chain where explicit static credentials
-    in config beat env vars.  Verified empirically: a store constructed with
-    both aws_access_key_id + aws_secret_access_key in config sends requests
-    signed with the config key, not the ambient AWS_ACCESS_KEY_ID env var.
+    These tests assert that make_s3_store passes the caller's config dict to the
+    S3Store constructor without dropping or mutating keys.  They do NOT verify the
+    Rust-layer credential precedence (explicit config vs. ambient env vars) — that
+    behaviour is tested by integration tests against a real or mocked S3 endpoint.
     """
 
     def test_full_explicit_credentials_reach_s3_store(self, monkeypatch) -> None:
@@ -490,12 +490,13 @@ class TestS3CredentialPrecedence:
         assert mock_s3.call_args.kwargs["config"] is None
 
 
-class TestGCSCredentialPrecedence:
-    """GCS: explicit SA key in config bypasses GOOGLE_APPLICATION_CREDENTIALS.
+class TestGCSConfigPassthrough:
+    """Regression guard: the config dict reaches GCSStore unchanged.
 
-    Verified empirically: GCSStore constructed with google_service_account_key
-    does NOT read GOOGLE_APPLICATION_CREDENTIALS from the environment; the ADC
-    path is only taken when no explicit credential is passed (config=None).
+    These tests assert that make_gcs_store passes the caller's config dict to the
+    GCSStore constructor without dropping or mutating keys.  They do NOT verify the
+    Rust-layer credential precedence (SA key in config vs. ADC / Workload Identity) —
+    that behaviour is tested by integration tests against a real or mocked GCS endpoint.
     """
 
     def test_explicit_sa_key_reaches_gcs_store(self, monkeypatch) -> None:

--- a/tests/unit/storage/test_obstore_config.py
+++ b/tests/unit/storage/test_obstore_config.py
@@ -251,12 +251,12 @@ class TestBindingPlumbsClientOptions:
         kwargs = mock_s3.call_args.kwargs
         client_opts = kwargs.get("client_options") or {}
         retry_cfg = kwargs.get("retry_config") or {}
-        assert client_opts.get("timeout") == "42m", (
-            f"timeout not plumbed into S3Store(client_options=...): {client_opts}"
-        )
-        assert retry_cfg.get("max_retries") == 7, (
-            f"retry max_retries not plumbed into S3Store(retry_config=...): {retry_cfg}"
-        )
+        assert (
+            client_opts.get("timeout") == "42m"
+        ), f"timeout not plumbed into S3Store(client_options=...): {client_opts}"
+        assert (
+            retry_cfg.get("max_retries") == 7
+        ), f"retry max_retries not plumbed into S3Store(retry_config=...): {retry_cfg}"
 
 
 class TestCloudPlumbsClientOptions:
@@ -398,3 +398,134 @@ class TestAzureAmbientEnvIsolation:
     )
     def test_explicit_credential_gate(self, config, expected):
         assert _azure_config_has_explicit_credential(config) is expected
+
+    def test_credential_provider_strips_ambient_env(self, monkeypatch):
+        # cert-auth and other credential_provider paths leave config without any
+        # of the four guarded keys, so the original gate (_azure_config_has_explicit_credential)
+        # returned False and ambient AZURE_* env was NOT stripped — the same host-identity
+        # outranking bug as the account-key case.  The gate must also fire when
+        # credential_provider is not None.
+        monkeypatch.setenv("AZURE_STORAGE_ACCESS_KEY", "host-key")
+        monkeypatch.setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/token")
+        monkeypatch.setenv("AZURE_CLIENT_ID", "host-client")
+
+        captured: dict = {}
+
+        def fake_azure_store(**kw):
+            captured["azure_env"] = {
+                k: v for k, v in os.environ.items() if k.startswith("AZURE_")
+            }
+            captured["kw"] = kw
+            return MagicMock(name="AzureStore")
+
+        fake_provider = MagicMock(name="cert-credential-provider")
+        with patch("obstore.store.AzureStore", new=fake_azure_store):
+            make_azure_store(
+                "container",
+                {"azure_storage_account_name": "acct"},
+                credential_provider=fake_provider,
+            )
+
+        assert (
+            captured["azure_env"] == {}
+        ), "ambient AZURE_* env must be stripped when credential_provider is supplied"
+        assert captured["kw"]["credential_provider"] is fake_provider
+        # env restored after construction
+        assert os.environ["AZURE_STORAGE_ACCESS_KEY"] == "host-key"
+        assert os.environ["AZURE_FEDERATED_TOKEN_FILE"] == "/var/run/token"
+        assert os.environ["AZURE_CLIENT_ID"] == "host-client"
+
+
+# ---------------------------------------------------------------------------
+# Credential precedence — empirically verified against obstore-rs 0.10.x
+#
+# These tests document behaviour confirmed by live requests (see PR audit).
+# The pattern: mock the store constructor and assert on the config dict it
+# receives — we can't easily intercept the Rust-layer credential resolution
+# at the unit level, but we CAN verify that the right keys reach the
+# constructor (which is the invariant the fix is about).
+# ---------------------------------------------------------------------------
+
+
+class TestS3CredentialPrecedence:
+    """S3: explicit config credentials must reach S3Store unchanged.
+
+    obstore-rs uses the AWS credential chain where explicit static credentials
+    in config beat env vars.  Verified empirically: a store constructed with
+    both aws_access_key_id + aws_secret_access_key in config sends requests
+    signed with the config key, not the ambient AWS_ACCESS_KEY_ID env var.
+    """
+
+    def test_full_explicit_credentials_reach_s3_store(self, monkeypatch) -> None:
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ENV-ACCESS-KEY")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ENV-SECRET-KEY")
+
+        with patch("obstore.store.S3Store") as mock_s3:
+            mock_s3.return_value = MagicMock()
+            from application_sdk.storage._obstore_config import make_s3_store
+
+            make_s3_store(
+                "test-bucket",
+                {
+                    "aws_access_key_id": "CONFIG-ACCESS-KEY",
+                    "aws_secret_access_key": "CONFIG-SECRET-KEY",
+                    "aws_region": "us-east-1",
+                },
+            )
+
+        config = mock_s3.call_args.kwargs["config"]
+        assert config["aws_access_key_id"] == "CONFIG-ACCESS-KEY"
+        assert config["aws_secret_access_key"] == "CONFIG-SECRET-KEY"
+
+    def test_no_credentials_in_config_passes_none(self, monkeypatch) -> None:
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ENV-ACCESS-KEY")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ENV-SECRET-KEY")
+
+        with patch("obstore.store.S3Store") as mock_s3:
+            mock_s3.return_value = MagicMock()
+            from application_sdk.storage._obstore_config import make_s3_store
+
+            make_s3_store("test-bucket", None)
+
+        assert mock_s3.call_args.kwargs["config"] is None
+
+
+class TestGCSCredentialPrecedence:
+    """GCS: explicit SA key in config bypasses GOOGLE_APPLICATION_CREDENTIALS.
+
+    Verified empirically: GCSStore constructed with google_service_account_key
+    does NOT read GOOGLE_APPLICATION_CREDENTIALS from the environment; the ADC
+    path is only taken when no explicit credential is passed (config=None).
+    """
+
+    def test_explicit_sa_key_reaches_gcs_store(self, monkeypatch) -> None:
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/nonexistent/adc.json")
+
+        with patch("obstore.store.GCSStore") as mock_gcs:
+            mock_gcs.return_value = MagicMock()
+            from application_sdk.storage._obstore_config import make_gcs_store
+
+            make_gcs_store(
+                "test-bucket",
+                {"google_service_account_key": '{"type":"service_account"}'},
+            )
+
+        config = mock_gcs.call_args.kwargs["config"]
+        assert config is not None
+        assert "google_service_account_key" in config
+
+    def test_no_sa_key_passes_none_config_for_adc(self, monkeypatch) -> None:
+        # No SA key → config=None → obstore uses ADC / Workload Identity.
+        # Verified empirically: GCSStore(bucket=...) with no config and
+        # GOOGLE_APPLICATION_CREDENTIALS pointing to a nonexistent path fails
+        # at construction with "No such file or directory" — proving ADC is only
+        # consulted when the config SA key is absent.
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/nonexistent/adc.json")
+
+        with patch("obstore.store.GCSStore") as mock_gcs:
+            mock_gcs.return_value = MagicMock()
+            from application_sdk.storage._obstore_config import make_gcs_store
+
+            make_gcs_store("test-bucket", None)
+
+        assert mock_gcs.call_args.kwargs["config"] is None

--- a/tests/unit/storage/test_obstore_config.py
+++ b/tests/unit/storage/test_obstore_config.py
@@ -9,11 +9,16 @@ timeout.
 
 from __future__ import annotations
 
+import os
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from application_sdk.storage._obstore_config import (
+    _azure_config_has_explicit_credential,
     log_obstore_config,
+    make_azure_store,
     obstore_client_options,
     obstore_retry_config,
 )
@@ -246,12 +251,12 @@ class TestBindingPlumbsClientOptions:
         kwargs = mock_s3.call_args.kwargs
         client_opts = kwargs.get("client_options") or {}
         retry_cfg = kwargs.get("retry_config") or {}
-        assert (
-            client_opts.get("timeout") == "42m"
-        ), f"timeout not plumbed into S3Store(client_options=...): {client_opts}"
-        assert (
-            retry_cfg.get("max_retries") == 7
-        ), f"retry max_retries not plumbed into S3Store(retry_config=...): {retry_cfg}"
+        assert client_opts.get("timeout") == "42m", (
+            f"timeout not plumbed into S3Store(client_options=...): {client_opts}"
+        )
+        assert retry_cfg.get("max_retries") == 7, (
+            f"retry max_retries not plumbed into S3Store(retry_config=...): {retry_cfg}"
+        )
 
 
 class TestCloudPlumbsClientOptions:
@@ -285,3 +290,111 @@ class TestCloudPlumbsClientOptions:
         retry_cfg = kwargs.get("retry_config") or {}
         assert client_opts.get("timeout") == "42m"
         assert retry_cfg.get("max_retries") == 7
+
+
+# ---------------------------------------------------------------------------
+# make_azure_store — ambient AZURE_* env isolation
+# ---------------------------------------------------------------------------
+
+
+class TestAzureAmbientEnvIsolation:
+    """obstore reads ``AZURE_*`` from the environment at construction and lets a
+    host-injected value outrank the caller's explicit credential. ``make_azure_store``
+    must strip the ambient env while building from an explicit credential, and leave it
+    in place for the managed/workload-identity case.
+    """
+
+    def _build_and_capture(self, config: dict | None) -> dict:
+        """Build via make_azure_store with ``obstore.store.AzureStore`` stubbed; return
+        the AZURE_* env visible *during* construction plus the kwargs passed to obstore."""
+        captured: dict = {}
+
+        def fake_azure_store(**kw):
+            captured["azure_env"] = {
+                k: v for k, v in os.environ.items() if k.startswith("AZURE_")
+            }
+            captured["kw"] = kw
+            return MagicMock(name="AzureStore")
+
+        with patch("obstore.store.AzureStore", new=fake_azure_store):
+            make_azure_store("container", config)
+        return captured
+
+    def test_explicit_account_key_strips_ambient_env_during_build(self, monkeypatch):
+        monkeypatch.setenv("AZURE_STORAGE_ACCESS_KEY", "host-key")
+        monkeypatch.setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/token")
+        monkeypatch.setenv("AZURE_CLIENT_ID", "host-client")
+        cap = self._build_and_capture(
+            {
+                "azure_storage_account_name": "acct",
+                "azure_storage_account_key": "cust-key",
+            }
+        )
+        # no ambient identity leaks into the construction — only our config is used
+        assert cap["azure_env"] == {}
+        assert cap["kw"]["config"]["azure_storage_account_key"] == "cust-key"
+        # ambient env restored afterwards
+        assert os.environ["AZURE_STORAGE_ACCESS_KEY"] == "host-key"
+        assert os.environ["AZURE_FEDERATED_TOKEN_FILE"] == "/var/run/token"
+        assert os.environ["AZURE_CLIENT_ID"] == "host-client"
+
+    def test_explicit_client_secret_strips_ambient_env(self, monkeypatch):
+        monkeypatch.setenv("AZURE_STORAGE_ACCESS_KEY", "host-key")
+        monkeypatch.setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/token")
+        cap = self._build_and_capture(
+            {
+                "azure_storage_account_name": "acct",
+                "azure_storage_client_id": "c",
+                "azure_storage_tenant_id": "t",
+                "azure_storage_client_secret": "s",
+            }
+        )
+        assert cap["azure_env"] == {}
+        assert os.environ["AZURE_STORAGE_ACCESS_KEY"] == "host-key"
+
+    def test_no_credential_preserves_ambient_env(self, monkeypatch):
+        # Managed / workload identity: the caller passed no standalone credential, so
+        # the host's ambient identity must stay visible to obstore.
+        monkeypatch.setenv("AZURE_STORAGE_ACCESS_KEY", "host-key")
+        monkeypatch.setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/token")
+        cap = self._build_and_capture({"azure_storage_account_name": "acct"})
+        assert cap["azure_env"]["AZURE_STORAGE_ACCESS_KEY"] == "host-key"
+        assert cap["azure_env"]["AZURE_FEDERATED_TOKEN_FILE"] == "/var/run/token"
+
+    def test_ambient_env_restored_even_on_construction_error(self, monkeypatch):
+        monkeypatch.setenv("AZURE_STORAGE_ACCESS_KEY", "host-key")
+
+        def boom(**kw):
+            raise RuntimeError("construction failed")
+
+        with patch("obstore.store.AzureStore", new=boom):
+            with pytest.raises(RuntimeError, match="construction failed"):
+                make_azure_store(
+                    "container",
+                    {
+                        "azure_storage_account_name": "a",
+                        "azure_storage_account_key": "k",
+                    },
+                )
+        assert os.environ["AZURE_STORAGE_ACCESS_KEY"] == "host-key"
+
+    @pytest.mark.parametrize(
+        "config, expected",
+        [
+            ({"azure_storage_account_key": "k"}, True),
+            ({"azure_storage_client_secret": "s"}, True),
+            ({"azure_storage_sas_key": "sas"}, True),
+            ({"azure_storage_token": "tok"}, True),
+            ({"azure_storage_account_name": "a"}, False),  # managed identity
+            # SP without a secret → relies on workload identity, keep ambient env
+            ({"azure_storage_client_id": "c", "azure_storage_tenant_id": "t"}, False),
+            (
+                {"azure_storage_account_key": ""},
+                False,
+            ),  # empty value is not a credential
+            ({}, False),
+            (None, False),
+        ],
+    )
+    def test_explicit_credential_gate(self, config, expected):
+        assert _azure_config_has_explicit_credential(config) is expected


### PR DESCRIPTION
## What
`make_azure_store` now isolates explicit Azure credentials from the host's ambient `AZURE_*` environment. When the caller passes a standalone credential in `config`, the ambient `AZURE_*` env is stripped for the duration of the `AzureStore(...)` constructor so obstore resolves from our config alone.

## Why
obstore-rs reads `AZURE_*` from the environment at `AzureStore` construction **unconditionally**, and its credential precedence is `account key > SAS > client secret > workload identity`. On an Azure-hosted node the worker pod carries its own identity in the environment — both `AZURE_STORAGE_ACCESS_KEY` (Shared-Key) and `AZURE_FEDERATED_TOKEN_FILE` + `AZURE_CLIENT_ID` (AKS workload identity). So a `CloudStore.from_credentials(...)` built from an **explicit customer credential** was silently authenticated as the **node's** identity:

- node account key outranks the customer service principal → `403 AuthenticationFailed` (signs for the wrong account)
- node federated token outranks the customer client secret → `401 AADSTS70025` ("the client has no configured federated identity credentials")

The same external-bucket credential works on a GCP-hosted tenant (no `AZURE_*` in env), which is what made this confusing to diagnose.

This was first worked around in the dbt connector (dropping `AZURE_*` around `CloudStore.from_credentials`). Moving it into the SDK fixes it once for every app that builds an Azure store from explicit credentials.

## How
- `make_azure_store(container, config, ...)` — the single obstore construction chokepoint shared by `cloud.py` (external bucket via `from_credentials`) and `binding.py` (Dapr / tenant store) — strips ambient `AZURE_*` for the constructor **only when `config` carries a standalone credential** (`azure_storage_account_key` / `azure_storage_client_secret` / `azure_storage_sas_key` / `azure_storage_token`).
- Callers with no credential (managed / workload identity) are left untouched, so the ambient identity still applies.
- Construction is serialized by a process-global lock (`os.environ` is shared) so an isolated build can't strip the env out from under a concurrent non-isolated one.

A service principal passed *without* a secret (client id + tenant only) is intentionally treated as non-standalone — it relies on workload-identity federation, so the ambient env is preserved.

## Tests
`tests/unit/storage/test_obstore_config.py::TestAzureAmbientEnvIsolation`:
- explicit account key / client secret → ambient `AZURE_*` absent during construction, restored afterward
- no credential (managed identity) → ambient `AZURE_*` preserved during construction
- env restored even when the constructor raises
- credential-gate matrix (`_azure_config_has_explicit_credential`)

`uv run pytest tests/unit/storage/test_cloud.py tests/unit/storage/test_obstore_config.py` → 73 passed.

## Follow-up
The dbt connector's local `_suppress_ambient_azure_env` workaround can be removed once it picks up an SDK release containing this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
