### PR TITLE
feat(conformance): P013/P014/P015 typed-contract boundary rules (BLDX-1413)

### DIFF
--- a/packages/conformance/conformance/docs/rules/prescriptions.md
+++ b/packages/conformance/conformance/docs/rules/prescriptions.md
@@ -5,7 +5,7 @@
 
 # Prescription Rules (P-series)
 
-**12 rules** · Checker: `suite.checks.prescriptions` (P001–P003, P008–P012), `suite.checks.orchestration` (P004–P007, scans test files too) (all AST-based)
+**15 rules** · Checker: `suite.checks.prescriptions` (P001–P003, P008–P012), `suite.checks.orchestration` (P004–P007, scans test files too) (all AST-based)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -35,6 +35,9 @@ reassigned.
 | [P010](#p010) | `ManualFileReferenceConstruction` | `warn` | `app` | `storage-seam` | — | 0.6.0 |
 | [P011](#p011) | `RawBytesInContract` | `warn` | `app` | `storage-seam` | — | 0.6.0 |
 | [P012](#p012) | `FilePathStringInContract` | `warn` | `app` | `storage-seam` | — | 0.6.0 |
+| [P013](#p013) | `UntypedEntrypointBoundary` | `block` | `app` | `typed-contract-boundary` | — | 0.6.0 |
+| [P014](#p014) | `UntypedTaskBoundary` | `block` | `app` | `typed-contract-boundary` | — | 0.6.0 |
+| [P015](#p015) | `UnmodeledBoundedContractField` | `warn` | `app` | `contract-modeling` | — | 0.6.0 |
 
 ---
 
@@ -363,5 +366,99 @@ This rule is a heuristic — it matches on field name and documentation text —
 field that is genuinely not a transferable path will occasionally be flagged.  Suppress
 a genuine exception with an inline `# conformance: ignore[P012] <reason>`, which stays
 visible in SARIF.
+
+---
+
+## P013 — `UntypedEntrypointBoundary` {#p013}
+
+**Tier:** `block` · **Scope:** `app` · **Category:** `typed-contract-boundary` · **Autofixable:** — · **Since:** 0.6.0
+
+> @entrypoint (or implicit run()) input/output is not an SDK Input/Output subclass
+
+**Rationale:** Every @entrypoint method (and the implicit run() override) is the public API boundary of
+the app — the payload that crosses it must be validated, versioned, and evolvable.
+Using a primitive, a container, or a class that does not subclass Input/Output bypasses
+the SDK's payload-safety validation, config-hash computation, and
+backwards-compatibility tracking.  The runtime @entrypoint decorator already rejects
+these at import time, so no conforming running app is untyped today — this rule surfaces
+the violation earlier (PR/CI) and covers pre-decorator code paths.
+
+A method decorated with `@entrypoint` (or a concrete `run()` override on an `App`
+subclass, which is the implicit single-entrypoint form) must declare:
+
+* its non-`self` parameter as a subclass of `Input`   (`application_sdk.contracts`); *
+its return type as a subclass of `Output`   (`application_sdk.contracts`).
+
+Violations include: missing annotation, a primitive / container type (`dict`, `list`,
+`str`, `Any`, etc. — even subscripted/bounded forms like `dict[str, str]`), or a class
+that exists in the scanned source tree but does not transitively subclass
+`Input`/`Output` (e.g. a plain `pydantic.BaseModel` subclass or a dataclass).
+
+Suppressed declarations are still emitted to the SARIF report. This rule is `BLOCK`
+(suppress-only): an unsuppressed violation fails the conformance gate — suppress with `#
+conformance: ignore[P013] <reason>` at the method definition.
+
+---
+
+## P014 — `UntypedTaskBoundary` {#p014}
+
+**Tier:** `block` · **Scope:** `app` · **Category:** `typed-contract-boundary` · **Autofixable:** — · **Since:** 0.6.0
+
+> @task input/output is not an SDK Input/Output subclass
+
+**Rationale:** Every @task method is an internal activity boundary — the payload must be typed and
+bounded so the SDK can validate it at the activity layer and detect drift across
+deployments.  Using an untyped structure bypasses the SDK's payload-safety enforcement
+and makes the task's I/O invisible to dashboards, schema tooling, and the contract
+registry.  The runtime @task decorator already rejects these at import time, so no
+conforming running app is untyped today — this rule surfaces the violation earlier
+(PR/CI).
+
+A method decorated with `@task` must declare:
+
+* its non-`self` parameter as a subclass of `Input`   (`application_sdk.contracts`); *
+its return type as a subclass of `Output`   (`application_sdk.contracts`).
+
+Violations include: missing annotation, a primitive / container type (`dict`, `list`,
+`str`, `Any`, etc. — even subscripted/bounded forms like `dict[str, str]`), or a class
+that exists in the scanned source tree but does not transitively subclass
+`Input`/`Output` (e.g. a plain `pydantic.BaseModel` subclass or a dataclass).
+
+Suppressed declarations are still emitted to the SARIF report. This rule is `BLOCK`
+(suppress-only): an unsuppressed violation fails the conformance gate — suppress with `#
+conformance: ignore[P014] <reason>` at the method definition.
+
+---
+
+## P015 — `UnmodeledBoundedContractField` {#p015}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `contract-modeling` · **Autofixable:** — · **Since:** 0.6.0
+
+> Input/Output contract field uses a container of primitives/Any — replace with a typed nested model
+
+**Rationale:** Bounded containers (Annotated[dict[str, str], MaxItems(50)]) pass payload-safety
+validation (P001) but are still stringly-typed: keys and values carry no schema, typos
+surface only at runtime, and the field is invisible to contract diffing and schema
+tooling.  The SDK's make-contract guidance explicitly prefers typed properties over
+arbitrary string keys ('avoid stringly-typed contracts where the user can typo a key and
+only discover it at runtime').  WARN (not BLOCK) because the bounded form is technically
+sanctioned; this is a modeling nudge toward a typed nested model.
+
+A field on an `Input`/`Output` contract whose annotation is a container of primitives or
+`Any` — `dict[str, str]`, `list[str]`, `set[int]`, or the bounded equivalents
+`Annotated[dict[str, str], MaxItems(N)]` — is considered an unmodeled boundary.  Even
+though the bounded form satisfies the payload-safety gate (P001), the container has no
+schema: keys and values are opaque strings, typos are runtime-only failures, and the
+field is invisible to contract diffing and the SDK's `is_backwards_compatible` checker.
+
+The SDK contract guidance (`make-contract` skill, §6) prefers typed properties / a
+nested `pydantic.BaseModel` subclass over arbitrary string keys.
+
+**Exempt:** `list[FooModel]`, `dict[str, FooModel]` — containers of a typed class are
+the canonical bounded pattern and are fine.
+
+This rule lands as `WARN` (not `BLOCK`) because the bounded form is technically
+sanctioned — this is a modeling nudge, not a gate failure.  Suppress with `#
+conformance: ignore[P015] <reason>` when a typed replacement is not feasible.
 
 ---

--- a/packages/conformance/conformance/suite/checks/prescriptions/__init__.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/__init__.py
@@ -39,6 +39,18 @@ Currently implemented:
   task boundary.
 * ``P012`` FilePathStringInContract — a ``str`` field on a contract whose name or
   doc marks it as a filesystem path (a worker-local reference).
+* ``P013`` UntypedEntrypointBoundary — a ``@entrypoint`` method (or implicit
+  ``run()`` on an ``App`` subclass) whose input parameter or return type is not
+  a subclass of the SDK's ``Input``/``Output`` contract.  Cross-file; requires
+  ``scan_all``.
+* ``P014`` UntypedTaskBoundary — a ``@task`` method whose input parameter or
+  return type is not a subclass of the SDK's ``Input``/``Output`` contract.
+  Cross-file; requires ``scan_all``.
+* ``P015`` UnmodeledBoundedContractField — a field on an ``Input``/``Output``
+  contract annotated with a container of primitives/``Any`` (``dict[str, str]``,
+  ``list[str]``, or the bounded ``Annotated[dict[…], MaxItems(N)]`` form).
+  Bounded containers pass payload-safety validation (P001) but are stringly-typed.
+  Per-file (like P011/P012).
 
 Inline suppression
 ------------------
@@ -69,7 +81,7 @@ from ._category_override import (
     CategoryOverrideChecker,
     _collect_apperror_subclasses,
 )
-from ._contract_fields import check_p011, check_p012
+from ._contract_fields import check_p011, check_p012, check_p015
 from ._error_code_prefix import (
     LEAF_PREFIX_MAP,
     ClassRecord,
@@ -81,6 +93,7 @@ from ._error_code_prefix import (
 from ._file_reference import check_p010
 from ._framework_transfer import check_p008
 from ._store_construction import check_p009
+from ._typed_boundaries import check_p013_p014
 from ._unbounded_fields import UnboundedContractFieldsChecker
 
 SERIES = "P"
@@ -91,9 +104,10 @@ __all__ = ["SERIES", "discover", "main", "scan_all", "scan_path", "scan_text"]
 def scan_text(text: str, file: str) -> list[Finding]:
     """Scan a single Python source *text* for per-file findings.
 
-    Runs P001, P002, and P008–P012 — every rule that needs only a single file's
-    AST.  P003 needs cross-file context; use :func:`scan_all` for full-suite
-    runs.  Kept for symmetry with the per-file ``scan_path`` runner contract.
+    Runs P001, P002, and P008–P012, P015 — every rule that needs only a single
+    file's AST.  P003, P013, and P014 need cross-file context; use
+    :func:`scan_all` for full-suite runs.  Kept for symmetry with the per-file
+    ``scan_path`` runner contract.
     """
     try:
         tree = ast.parse(text, filename=file)
@@ -118,6 +132,7 @@ def scan_text(text: str, file: str) -> list[Finding]:
     findings_p010 = check_p010(tree, file, directives)
     findings_p011 = check_p011(tree, file, directives)
     findings_p012 = check_p012(tree, file, directives)
+    findings_p015 = check_p015(tree, file, directives)
 
     return (
         p001._findings
@@ -127,11 +142,15 @@ def scan_text(text: str, file: str) -> list[Finding]:
         + findings_p010
         + findings_p011
         + findings_p012
+        + findings_p015
     )
 
 
 def scan_path(path: Path, root: Path) -> list[Finding]:
-    """Scan a single Python file (P001 + P002 + P008–P012).  P003 requires :func:`scan_all`."""
+    """Scan a single Python file (P001 + P002 + P008–P012 + P015).
+
+    P003, P013, and P014 require :func:`scan_all` for cross-file resolution.
+    """
     try:
         text = path.read_text(encoding="utf-8")
     except OSError:
@@ -144,11 +163,12 @@ def scan_path(path: Path, root: Path) -> list[Finding]:
 
 
 def scan_all(paths: list[Path], root: Path) -> list[Finding]:
-    """Multi-pass scan over *paths*, emitting P001 + P002 + P003 findings.
+    """Multi-pass scan over *paths*, emitting all P-series findings.
 
-    Pass 1 — parse every file once, run P001 and P002 per-file, collect every
-    ``ClassDef`` into a name-keyed registry along with its base names and any
-    literal ``code`` declaration.
+    Pass 1 — parse every file once, run P001, P002, P008–P012, P015 per-file,
+    collect every ``ClassDef`` into a name-keyed registry along with its base
+    names and any literal ``code`` declaration.  Store each parsed tree for the
+    P013/P014 cross-file pass.
 
     Pass 2 — for each registered class, walk its (transitive) base chain to
     find the deepest ancestor that names one of the 14 leaves in
@@ -159,12 +179,16 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
     omits its own ``code`` declaration or declares one that does not start
     with the leaf's category prefix + ``_``.  The 14 leaves themselves are
     exempt (their bare codes are the prefix definitions).
+
+    Pass 4 — emit P013/P014 using the pre-built ``by_name`` class registry and
+    stored trees.  Resolution is transitive and memoised across all files.
     """
     findings: list[Finding] = []
 
     # Pass 1
     file_directives: dict[Path, dict[int, _IgnoreDirective]] = {}
     file_records: dict[Path, list[ClassRecord]] = {}
+    file_trees: dict[Path, ast.AST] = {}
     by_name: dict[str, ClassRecord] = {}
 
     for path in paths:
@@ -183,6 +207,7 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
         rel_str = str(rel)
         directives = _parse_directives(text)
         file_directives[path] = directives
+        file_trees[path] = tree
 
         # P001 (per-file)
         checker = UnboundedContractFieldsChecker(
@@ -203,15 +228,16 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
         p002_checker.visit(tree)
         findings.extend(p002_checker._findings)
 
-        # P008–P012 (per-file)
+        # P008–P012, P015 (per-file)
         findings.extend(check_p008(tree, rel_str, directives))
         findings.extend(check_p009(tree, rel_str, directives))
         findings.extend(check_p010(tree, rel_str, directives))
         findings.extend(check_p011(tree, rel_str, directives))
         findings.extend(check_p012(tree, rel_str, directives))
+        findings.extend(check_p015(tree, rel_str, directives))
 
-        # Class registry for P003 — de-alias base names so aliased imports
-        # of leaf classes don't hide the real ancestry.
+        # Class registry for P003 and P013/P014 — de-alias base names so aliased
+        # imports of leaf/base classes don't hide the real ancestry.
         aliases = collect_import_aliases(tree) if isinstance(tree, ast.Module) else {}
         records = collect_classes(tree, rel_str, aliases)
         file_records[path] = records
@@ -236,6 +262,10 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
                 findings.append(emit_p003(rec, leaf_prefix, directives))
             elif not rec.code_value.startswith(f"{leaf_prefix}_"):
                 findings.append(emit_p003(rec, leaf_prefix, directives))
+
+    # Pass 4 — emit P013/P014 (cross-file boundary-type enforcement)
+    findings.extend(check_p013_p014(file_trees, by_name, file_directives, root))
+
     return findings
 
 

--- a/packages/conformance/conformance/suite/checks/prescriptions/_constants.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_constants.py
@@ -1,0 +1,5 @@
+"""Shared string constants for prescriptions checks."""
+
+from __future__ import annotations
+
+_SDK_MODULE_PREFIX = "application_sdk"

--- a/packages/conformance/conformance/suite/checks/prescriptions/_contract_common.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_contract_common.py
@@ -202,7 +202,8 @@ def _terminal_name(node: ast.expr) -> str | None:
     """Return the terminal (rightmost) name of a (possibly subscripted) annotation.
 
     ``dict[str, str]`` → ``"dict"``;  ``List[Any]`` → ``"List"``;
-    ``mod.Output`` → ``"Output"``.  Returns ``None`` for unrecognised forms.
+    ``mod.Output`` → ``"Output"``;  ``None`` literal → ``"None"``.
+    Returns ``None`` for unrecognised forms.
     """
     if isinstance(node, ast.Name):
         return node.id
@@ -210,6 +211,9 @@ def _terminal_name(node: ast.expr) -> str | None:
         return _terminal_name(node.value)
     if isinstance(node, ast.Attribute):
         return node.attr
+    # ``-> None`` parses as ast.Constant(value=None) on Python 3.8+.
+    if isinstance(node, ast.Constant) and node.value is None:
+        return "None"
     return None
 
 
@@ -294,9 +298,15 @@ def unmodeled_container_name(node: ast.expr) -> str | None:
     Returns the container name (e.g. ``"dict"``, ``"list"``) for the finding
     message, or ``None`` when the annotation is not an unmodeled container.
     """
-    # Peer through Annotated[X, ...] and Optional[X] / X | None.
-    inner = _unwrap_annotated(node)
-    inner = _unwrap_optional_node(inner)
+    # Peer through Annotated[X, ...] and Optional[X] / X | None to a fixed point.
+    # A single pass misses Optional[Annotated[...]] when Annotated is the outer wrapper.
+    inner = node
+    while True:
+        unwrapped = _unwrap_annotated(inner)
+        unwrapped = _unwrap_optional_node(unwrapped)
+        if unwrapped is inner:
+            break
+        inner = unwrapped
 
     # Bare container name: dict, list, set, … — always unmodeled.
     if isinstance(inner, ast.Name) and inner.id in _CONTAINER_NAMES:

--- a/packages/conformance/conformance/suite/checks/prescriptions/_contract_common.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_contract_common.py
@@ -21,8 +21,9 @@ from __future__ import annotations
 import ast
 from typing import Iterator
 
+from ._constants import _SDK_MODULE_PREFIX
+
 _CONTRACT_BASE_NAMES: frozenset[str] = frozenset({"Input", "Output"})
-_SDK_MODULE_PREFIX = "application_sdk"
 
 # Builtin bytes-like types that carry the same Temporal payload-size risk.
 _BYTES_LIKE_NAMES: frozenset[str] = frozenset({"bytes", "bytearray", "memoryview"})

--- a/packages/conformance/conformance/suite/checks/prescriptions/_contract_common.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_contract_common.py
@@ -151,6 +151,178 @@ def is_str_annotation(node: ast.expr) -> bool:
     return _is_annotation(node, "str")
 
 
+# ── P015 unmodeled-container helpers ──────────────────────────────────────────
+
+# Container type names that, when used as a field annotation on a contract
+# *without* a nested model as the element/value type, indicate a stringly-typed
+# or otherwise unmodeled boundary payload (P015 UnmodeledBoundedContractField).
+_CONTAINER_NAMES: frozenset[str] = frozenset(
+    {
+        # dict-like
+        "dict",
+        "Dict",
+        "Mapping",
+        "MutableMapping",
+        # list-like
+        "list",
+        "List",
+        "Sequence",
+        "MutableSequence",
+        # set-like
+        "set",
+        "Set",
+        "FrozenSet",
+        "frozenset",
+    }
+)
+
+# Sub-set of container names that take (K, V) type params (dict-like). All
+# others in _CONTAINER_NAMES take a single element type param (list/set-like).
+_DICT_LIKE_NAMES: frozenset[str] = frozenset(
+    {"dict", "Dict", "Mapping", "MutableMapping"}
+)
+
+# Type names that, when used as the element/value parameter of a container,
+# mark the container as *unmodeled* (primitives and Any).
+_PRIMITIVE_NAMES: frozenset[str] = frozenset(
+    {
+        "str",
+        "int",
+        "float",
+        "bool",
+        "bytes",
+        "bytearray",
+        "Any",
+        "object",
+    }
+)
+
+
+def _terminal_name(node: ast.expr) -> str | None:
+    """Return the terminal (rightmost) name of a (possibly subscripted) annotation.
+
+    ``dict[str, str]`` → ``"dict"``;  ``List[Any]`` → ``"List"``;
+    ``mod.Output`` → ``"Output"``.  Returns ``None`` for unrecognised forms.
+    """
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Subscript):
+        return _terminal_name(node.value)
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _unwrap_annotated(node: ast.expr) -> ast.expr:
+    """Peer through ``Annotated[X, ...]`` to the inner type ``X``.
+
+    Returns *node* unchanged if it is not an ``Annotated`` subscript.
+    """
+    if not isinstance(node, ast.Subscript):
+        return node
+    if not _is_name(node.value, "Annotated"):
+        return node
+    slc = node.slice
+    # Annotated[X, metadata, ...] — first element of the slice Tuple is X.
+    if isinstance(slc, ast.Tuple) and slc.elts:
+        return slc.elts[0]
+    return node
+
+
+def _unwrap_optional_node(node: ast.expr) -> ast.expr:
+    """Peer through ``Optional[X]`` / ``X | None`` / ``None | X`` to the inner type.
+
+    Returns *node* unchanged if it is not an optional wrapper.
+    """
+    # X | None  (PEP 604)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        if _is_none(node.right):
+            return node.left
+        if _is_none(node.left):
+            return node.right
+    # Optional[X]
+    if isinstance(node, ast.Subscript) and _is_name(node.value, "Optional"):
+        return node.slice
+    return node
+
+
+def _container_element_type(node: ast.Subscript) -> ast.expr | None:
+    """Return the element / value type of a subscripted container node.
+
+    For dict-like containers (``dict[K, V]``) returns the *value* type ``V``
+    (the last element of the slice Tuple) — the key type is structural metadata
+    and does not determine whether the payload is modeled.  For list/set-like
+    containers (``list[T]``, ``set[T]``) returns ``T``.
+
+    Returns ``None`` when the slice structure is not as expected (e.g. bare
+    unsubscripted container with no type params).
+    """
+    container_name = _terminal_name(node.value)
+    slc = node.slice
+    if container_name in _DICT_LIKE_NAMES:
+        if isinstance(slc, ast.Tuple) and len(slc.elts) >= 2:
+            return slc.elts[-1]  # value type V
+        if not isinstance(slc, ast.Tuple):
+            return slc  # degenerate single-param form
+        return None
+    else:
+        # list/set-like: single element type
+        if isinstance(slc, ast.Tuple):
+            return slc.elts[0] if slc.elts else None
+        return slc  # directly T
+
+
+def unmodeled_container_name(node: ast.expr) -> str | None:
+    """Return the container name if *node* is an unmodeled-container annotation.
+
+    An annotation is an *unmodeled container* when it:
+
+    * names a container type (``dict``, ``list``, ``set`` and their
+      :mod:`typing`-module equivalents, ``Mapping``, ``Sequence``, etc.);
+    * **and** is bare (no type parameters) **or** is parametrised with a
+      primitive / ``Any`` element/value type (``dict[str, str]``,
+      ``list[str]``, ``Annotated[dict[str, Any], MaxItems(50)]``).
+
+    Containers of a typed class (``list[FooModel]``, ``dict[str, FooModel]``)
+    are **exempt** — a collection of models is the canonical bounded pattern
+    and does not need to be replaced.
+
+    ``Annotated[X, ...]`` wrappers (e.g. ``Annotated[dict[…], MaxItems(N)]``)
+    are transparent: the check peers through them to the inner type ``X``
+    before deciding.  ``Optional[X]`` / ``X | None`` are similarly unwrapped.
+
+    Returns the container name (e.g. ``"dict"``, ``"list"``) for the finding
+    message, or ``None`` when the annotation is not an unmodeled container.
+    """
+    # Peer through Annotated[X, ...] and Optional[X] / X | None.
+    inner = _unwrap_annotated(node)
+    inner = _unwrap_optional_node(inner)
+
+    # Bare container name: dict, list, set, … — always unmodeled.
+    if isinstance(inner, ast.Name) and inner.id in _CONTAINER_NAMES:
+        return inner.id
+
+    # Subscripted container: dict[K, V], list[T], etc.
+    if isinstance(inner, ast.Subscript):
+        container_name = _terminal_name(inner.value)
+        if container_name not in _CONTAINER_NAMES:
+            return None
+        elem = _container_element_type(inner)
+        if elem is None:
+            # Unresolvable slice structure → treat as unmodeled.
+            return container_name
+        if isinstance(elem, ast.Name):
+            if elem.id in _PRIMITIVE_NAMES:
+                return container_name  # container of primitives → unmodeled
+            # Non-primitive class name → assumed a nested model → exempt.
+            return None
+        # Complex element type (e.g. list[dict[str,str]], list[Optional[str]])
+        # → treat as unmodeled (conservative).
+        return container_name
+
+    return None
+
+
 def field_doc_text(classdef: ast.ClassDef, ann_node: ast.AnnAssign) -> str:
     """Return documentation text for a field, or ``""`` if none is present.
 

--- a/packages/conformance/conformance/suite/checks/prescriptions/_contract_fields.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_contract_fields.py
@@ -29,6 +29,7 @@ from ._contract_common import (
     is_bytes_annotation,
     is_str_annotation,
     iter_contract_classes,
+    unmodeled_container_name,
 )
 
 _PATH_NAME_RE = re.compile(
@@ -119,6 +120,50 @@ def check_p012(
                         "FileReference field instead. If this is genuinely a string "
                         "(e.g. a URL), suppress with "
                         "'# conformance: ignore[P012] <reason>'."
+                    ),
+                    directives=directives,
+                )
+            )
+    return findings
+
+
+def check_p015(
+    tree: ast.AST,
+    filename: str,
+    directives: dict[int, _IgnoreDirective],
+) -> list[Finding]:
+    """Emit P015 for unmodeled-container fields on contract classes.
+
+    Flags ``dict``/``list``/``set``-family fields (and their :mod:`typing`
+    equivalents) whose element/value type is a primitive or ``Any`` —
+    including the bounded ``Annotated[dict[str, str], MaxItems(N)]`` form
+    that passes payload-safety validation (P001) but is still stringly-typed.
+
+    Containers of a typed class (``list[FooModel]``, ``dict[str, FooModel]``)
+    are exempt: a collection of models is the canonical bounded pattern.
+    """
+    findings: list[Finding] = []
+    foreign = collect_foreign_contract_names(tree)
+    for classdef in iter_contract_classes(tree, foreign):
+        for name, ann_node in _iter_field_annassigns(classdef):
+            container = unmodeled_container_name(ann_node.annotation)
+            if container is None:
+                continue
+            findings.append(
+                make_finding(
+                    filename=filename,
+                    rule_id="P015",
+                    node=ann_node,
+                    message=(
+                        f"Contract field '{name}' uses an unmodeled container type "
+                        f"('{container}' of primitives/Any). Even bounded forms like "
+                        f"Annotated[{container}[...], MaxItems(N)] pass payload safety "
+                        "but remain stringly-typed — the SDK contract guidance is to "
+                        "replace them with a typed nested model (a class inheriting "
+                        "from pydantic.BaseModel). Containers of a typed class "
+                        f"(e.g. {container}[FooModel]) are already exempt. Suppress "
+                        "with '# conformance: ignore[P015] <reason>' when a typed "
+                        "replacement is not feasible."
                     ),
                     directives=directives,
                 )

--- a/packages/conformance/conformance/suite/checks/prescriptions/_decorator_provenance.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_decorator_provenance.py
@@ -1,0 +1,131 @@
+"""Shared decorator-provenance helpers for P008, P013, and P014.
+
+Both ``_framework_transfer`` (P008) and ``_typed_boundaries`` (P013/P014) need
+to gate on import provenance to distinguish the SDK's ``@task``/``@entrypoint``
+from third-party decorators with the same local name (e.g. ``@celery.task``,
+``@flask.entrypoint``).  This module centralises that logic so a single change
+propagates to every consumer.
+
+Provenance model
+----------------
+*  ``from celery import task`` — binds the name ``"task"`` to a non-SDK symbol;
+   recorded in :attr:`ImportProvenance.non_sdk_task_names`.
+*  ``import celery`` — introduces a non-SDK module alias; ``@celery.task``
+   is excluded via :attr:`ImportProvenance.non_sdk_module_names`.
+*  ``from application_sdk.contracts import FetchInput`` — records ``"FetchInput"``
+   in :attr:`ImportProvenance.sdk_contract_names` (valid by provenance).
+*  ``import application_sdk.contracts as c`` — records ``"c"`` in
+   :attr:`ImportProvenance.sdk_contract_module_aliases` so that ``c.FetchInput``
+   annotations are recognised as valid SDK contracts.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+
+_SDK_MODULE_PREFIX = "application_sdk"
+_SDK_CONTRACT_MODULE_PREFIXES: tuple[str, ...] = (
+    "application_sdk.contracts",
+    "application_sdk.handler.contracts",
+)
+
+
+@dataclass(frozen=True)
+class ImportProvenance:
+    """Import-provenance sets needed for decorator and annotation gating."""
+
+    non_sdk_task_names: frozenset[str]
+    """Local names bound to ``task`` from a non-SDK ``from … import task``."""
+
+    non_sdk_ep_names: frozenset[str]
+    """Local names bound to ``entrypoint`` from a non-SDK ``from … import entrypoint``."""
+
+    non_sdk_module_names: frozenset[str]
+    """Local names of imported non-SDK top-level modules (``import celery`` → ``"celery"``)."""
+
+    sdk_contract_names: frozenset[str]
+    """Local names imported from ``application_sdk.contracts.*`` — valid by provenance."""
+
+    sdk_contract_module_aliases: frozenset[str]
+    """Local aliases for ``import application_sdk.contracts as c`` style imports."""
+
+
+def collect_import_provenance(tree: ast.AST) -> ImportProvenance:
+    """Walk *tree* and return all import-provenance sets needed by P008/P013/P014."""
+    non_sdk_task: set[str] = set()
+    non_sdk_ep: set[str] = set()
+    non_sdk_mods: set[str] = set()
+    sdk_contracts: set[str] = set()
+    sdk_contract_mod_aliases: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            is_sdk = module == _SDK_MODULE_PREFIX or module.startswith(
+                _SDK_MODULE_PREFIX + "."
+            )
+            if not is_sdk:
+                for alias in node.names:
+                    if alias.name == "task":
+                        non_sdk_task.add(alias.asname or alias.name)
+                    if alias.name == "entrypoint":
+                        non_sdk_ep.add(alias.asname or alias.name)
+            # SDK contract provenance from `from application_sdk.contracts import X`
+            if is_sdk and any(
+                module == prefix or module.startswith(prefix + ".")
+                for prefix in _SDK_CONTRACT_MODULE_PREFIXES
+            ):
+                for alias in node.names:
+                    sdk_contracts.add(alias.asname or alias.name)
+
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                name = alias.name
+                is_sdk = name == _SDK_MODULE_PREFIX or name.startswith(
+                    _SDK_MODULE_PREFIX + "."
+                )
+                if not is_sdk:
+                    non_sdk_mods.add(alias.asname or name.split(".")[0])
+                # `import application_sdk.contracts as c` style
+                elif any(
+                    name == prefix or name.startswith(prefix + ".")
+                    for prefix in _SDK_CONTRACT_MODULE_PREFIXES
+                ):
+                    sdk_contract_mod_aliases.add(alias.asname or name.split(".")[-1])
+
+    return ImportProvenance(
+        non_sdk_task_names=frozenset(non_sdk_task),
+        non_sdk_ep_names=frozenset(non_sdk_ep),
+        non_sdk_module_names=frozenset(non_sdk_mods),
+        sdk_contract_names=frozenset(sdk_contracts),
+        sdk_contract_module_aliases=frozenset(sdk_contract_mod_aliases),
+    )
+
+
+def is_task_decorator(dec: ast.expr, prov: ImportProvenance) -> bool:
+    """True if *dec* is the SDK ``@task`` decorator (not a third-party one)."""
+    if isinstance(dec, ast.Call):
+        dec = dec.func
+    if isinstance(dec, ast.Name):
+        return dec.id == "task" and dec.id not in prov.non_sdk_task_names
+    if isinstance(dec, ast.Attribute):
+        return dec.attr == "task" and (
+            not isinstance(dec.value, ast.Name)
+            or dec.value.id not in prov.non_sdk_module_names
+        )
+    return False
+
+
+def is_entrypoint_decorator(dec: ast.expr, prov: ImportProvenance) -> bool:
+    """True if *dec* is the SDK ``@entrypoint`` decorator (not a third-party one)."""
+    if isinstance(dec, ast.Call):
+        dec = dec.func
+    if isinstance(dec, ast.Name):
+        return dec.id == "entrypoint" and dec.id not in prov.non_sdk_ep_names
+    if isinstance(dec, ast.Attribute):
+        return dec.attr == "entrypoint" and (
+            not isinstance(dec.value, ast.Name)
+            or dec.value.id not in prov.non_sdk_module_names
+        )
+    return False

--- a/packages/conformance/conformance/suite/checks/prescriptions/_decorator_provenance.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_decorator_provenance.py
@@ -24,7 +24,8 @@ from __future__ import annotations
 import ast
 from dataclasses import dataclass
 
-_SDK_MODULE_PREFIX = "application_sdk"
+from ._constants import _SDK_MODULE_PREFIX
+
 _SDK_CONTRACT_MODULE_PREFIXES: tuple[str, ...] = (
     "application_sdk.contracts",
     "application_sdk.handler.contracts",
@@ -44,6 +45,19 @@ class ImportProvenance:
     non_sdk_module_names: frozenset[str]
     """Local names of imported non-SDK top-level modules (``import celery`` → ``"celery"``)."""
 
+    sdk_task_names: frozenset[str]
+    """Local names bound to ``task`` from an SDK import (including aliases).
+
+    Tracks ``from application_sdk.app import task as sdk_task`` → ``{"sdk_task"}``.
+    Used by :func:`is_task_decorator` to recognise aliased SDK decorators.
+    """
+
+    sdk_ep_names: frozenset[str]
+    """Local names bound to ``entrypoint`` from an SDK import (including aliases).
+
+    Tracks ``from application_sdk.app import entrypoint as ep`` → ``{"ep"}``.
+    """
+
     sdk_contract_names: frozenset[str]
     """Local names imported from ``application_sdk.contracts.*`` — valid by provenance."""
 
@@ -56,6 +70,8 @@ def collect_import_provenance(tree: ast.AST) -> ImportProvenance:
     non_sdk_task: set[str] = set()
     non_sdk_ep: set[str] = set()
     non_sdk_mods: set[str] = set()
+    sdk_task: set[str] = set()
+    sdk_ep: set[str] = set()
     sdk_contracts: set[str] = set()
     sdk_contract_mod_aliases: set[str] = set()
 
@@ -65,7 +81,14 @@ def collect_import_provenance(tree: ast.AST) -> ImportProvenance:
             is_sdk = module == _SDK_MODULE_PREFIX or module.startswith(
                 _SDK_MODULE_PREFIX + "."
             )
-            if not is_sdk:
+            if is_sdk:
+                for alias in node.names:
+                    local = alias.asname or alias.name
+                    if alias.name == "task":
+                        sdk_task.add(local)
+                    if alias.name == "entrypoint":
+                        sdk_ep.add(local)
+            else:
                 for alias in node.names:
                     if alias.name == "task":
                         non_sdk_task.add(alias.asname or alias.name)
@@ -98,16 +121,26 @@ def collect_import_provenance(tree: ast.AST) -> ImportProvenance:
         non_sdk_task_names=frozenset(non_sdk_task),
         non_sdk_ep_names=frozenset(non_sdk_ep),
         non_sdk_module_names=frozenset(non_sdk_mods),
+        sdk_task_names=frozenset(sdk_task),
+        sdk_ep_names=frozenset(sdk_ep),
         sdk_contract_names=frozenset(sdk_contracts),
         sdk_contract_module_aliases=frozenset(sdk_contract_mod_aliases),
     )
 
 
 def is_task_decorator(dec: ast.expr, prov: ImportProvenance) -> bool:
-    """True if *dec* is the SDK ``@task`` decorator (not a third-party one)."""
+    """True if *dec* is the SDK ``@task`` decorator (not a third-party one).
+
+    Recognises both the canonical ``@task`` name and SDK aliases such as
+    ``from application_sdk.app import task as sdk_task`` → ``@sdk_task``.
+    """
     if isinstance(dec, ast.Call):
         dec = dec.func
     if isinstance(dec, ast.Name):
+        # Positively confirmed SDK alias (from application_sdk.app import task as X)
+        if dec.id in prov.sdk_task_names:
+            return True
+        # Bare 'task' name — assume SDK unless shadowed by a non-SDK import
         return dec.id == "task" and dec.id not in prov.non_sdk_task_names
     if isinstance(dec, ast.Attribute):
         return dec.attr == "task" and (
@@ -118,10 +151,18 @@ def is_task_decorator(dec: ast.expr, prov: ImportProvenance) -> bool:
 
 
 def is_entrypoint_decorator(dec: ast.expr, prov: ImportProvenance) -> bool:
-    """True if *dec* is the SDK ``@entrypoint`` decorator (not a third-party one)."""
+    """True if *dec* is the SDK ``@entrypoint`` decorator (not a third-party one).
+
+    Recognises both the canonical ``@entrypoint`` name and SDK aliases such as
+    ``from application_sdk.app import entrypoint as ep`` → ``@ep``.
+    """
     if isinstance(dec, ast.Call):
         dec = dec.func
     if isinstance(dec, ast.Name):
+        # Positively confirmed SDK alias
+        if dec.id in prov.sdk_ep_names:
+            return True
+        # Bare 'entrypoint' name — assume SDK unless shadowed by a non-SDK import
         return dec.id == "entrypoint" and dec.id not in prov.non_sdk_ep_names
     if isinstance(dec, ast.Attribute):
         return dec.attr == "entrypoint" and (

--- a/packages/conformance/conformance/suite/checks/prescriptions/_error_code_prefix.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_error_code_prefix.py
@@ -172,6 +172,54 @@ def resolve_leaf_prefix(
     return result
 
 
+def resolve_ancestor(
+    name: str,
+    target: str,
+    by_name: dict[str, ClassRecord],
+    cache: dict[str, bool | None],
+    visiting: set[str],
+) -> bool | None:
+    """Transitively resolve *name*'s base chain looking for *target*.
+
+    Generic counterpart to :func:`resolve_leaf_prefix` with ``bool | None``
+    semantics for use by P013/P014 boundary resolution.
+
+    Returns
+    -------
+    ``True``
+        *name* IS *target*, or one of its ancestors is.
+    ``False``
+        *name* is in the scanned universe but none of its ancestors reach
+        *target*.  Definitive even when some bases are external/unknown — an
+        external base simply fails to confirm the target.
+    ``None``
+        *name* is not in the scanned universe (unknown / third-party /
+        generated — assumed OK to avoid false positives).
+    """
+    if name == target:
+        return True
+    if name in cache:
+        return cache[name]
+    if name in visiting:
+        # Cycle — treat as unknown to avoid false positives.
+        return None
+    rec = by_name.get(name)
+    if rec is None:
+        cache[name] = None
+        return None
+    visiting.add(name)
+    result: bool = False
+    for base in rec.bases:
+        sub = resolve_ancestor(base, target, by_name, cache, visiting)
+        if sub is True:
+            result = True
+            break
+        # sub is None (external base) or False — keep looking.
+    visiting.discard(name)
+    cache[name] = result
+    return result
+
+
 def emit_p003(
     rec: ClassRecord,
     leaf_prefix: str,

--- a/packages/conformance/conformance/suite/checks/prescriptions/_framework_transfer.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_framework_transfer.py
@@ -12,6 +12,7 @@ The check gates on import provenance: a decorator is only treated as the SDK
 ``@celery.task``, ``@invoke.task``, etc. are excluded by tracking non-SDK
 module names from ``ast.Import`` statements, and bare ``from celery import task``
 style re-exports are excluded by tracking non-SDK ``from … import task`` names.
+Provenance detection is shared with P013/P014 via ``_decorator_provenance``.
 """
 
 from __future__ import annotations
@@ -21,75 +22,9 @@ import ast
 from conformance.suite.checks._ast_common import _IgnoreDirective, make_finding
 from conformance.suite.schema.findings import Finding
 
+from ._decorator_provenance import collect_import_provenance, is_task_decorator
+
 _TRANSFER_METHODS: frozenset[str] = frozenset({"upload", "download"})
-_SDK_MODULE_PREFIX = "application_sdk"
-
-
-def _collect_task_provenance(
-    tree: ast.AST,
-) -> tuple[frozenset[str], frozenset[str]]:
-    """Return ``(non_sdk_task_names, non_sdk_module_names)`` for decorator gating.
-
-    * ``non_sdk_task_names`` — local names bound to ``task`` from a non-SDK
-      ``from … import task`` (e.g. ``from celery import task`` → ``{"task"}``).
-    * ``non_sdk_module_names`` — local names of imported non-SDK top-level
-      modules (e.g. ``import celery`` → ``{"celery"}``).
-
-    P008 skips ``@name`` when ``name`` is in ``non_sdk_task_names``; skips
-    ``@mod.task`` when ``mod`` is in ``non_sdk_module_names``.
-    """
-    non_sdk_task: set[str] = set()
-    non_sdk_mods: set[str] = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom):
-            module = node.module or ""
-            is_sdk = module == _SDK_MODULE_PREFIX or module.startswith(
-                _SDK_MODULE_PREFIX + "."
-            )
-            if not is_sdk:
-                for alias in node.names:
-                    if alias.name == "task":
-                        non_sdk_task.add(alias.asname or alias.name)
-        elif isinstance(node, ast.Import):
-            for alias in node.names:
-                name = alias.name
-                is_sdk = name == _SDK_MODULE_PREFIX or name.startswith(
-                    _SDK_MODULE_PREFIX + "."
-                )
-                if not is_sdk:
-                    non_sdk_mods.add(alias.asname or name.split(".")[0])
-    return frozenset(non_sdk_task), frozenset(non_sdk_mods)
-
-
-def _is_task_decorator(
-    dec: ast.expr,
-    non_sdk_task_names: frozenset[str],
-    non_sdk_module_names: frozenset[str],
-) -> bool:
-    """True if *dec* names the SDK ``task`` decorator (not a third-party one)."""
-    if isinstance(dec, ast.Call):
-        dec = dec.func
-    if isinstance(dec, ast.Name):
-        # @task — fire unless explicitly imported from a non-SDK module
-        return dec.id == "task" and dec.id not in non_sdk_task_names
-    if isinstance(dec, ast.Attribute):
-        # @x.task — fire unless x is a known non-SDK module import
-        return dec.attr == "task" and (
-            not isinstance(dec.value, ast.Name)
-            or dec.value.id not in non_sdk_module_names
-        )
-    return False
-
-
-def _is_task_method(
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
-    non_sdk_task_names: frozenset[str],
-    non_sdk_module_names: frozenset[str],
-) -> bool:
-    return any(
-        _is_task_decorator(dec, non_sdk_task_names, non_sdk_module_names)
-        for dec in node.decorator_list
-    )
 
 
 def _is_self_transfer_call(node: ast.AST) -> bool:
@@ -104,7 +39,7 @@ def _is_self_transfer_call(node: ast.AST) -> bool:
     )
 
 
-def _iter_own_scope(node: ast.AST) -> "list[ast.AST]":
+def _iter_own_scope(node: ast.AST) -> list[ast.AST]:
     """Yield descendants of *node* without crossing into a nested function scope.
 
     Unlike :func:`ast.walk`, this does not descend into the body of any nested
@@ -129,11 +64,11 @@ def check_p008(
 ) -> list[Finding]:
     """Emit P008 for ``self.upload()``/``self.download()`` inside a ``@task`` method."""
     findings: list[Finding] = []
-    non_sdk_task_names, non_sdk_module_names = _collect_task_provenance(tree)
+    prov = collect_import_provenance(tree)
     for func in ast.walk(tree):
         if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
-        if not _is_task_method(func, non_sdk_task_names, non_sdk_module_names):
+        if not any(is_task_decorator(dec, prov) for dec in func.decorator_list):
             continue
         # Inspect the task body only — never descend into nested function
         # scopes, where a transfer call belongs to the inner function.

--- a/packages/conformance/conformance/suite/checks/prescriptions/_typed_boundaries.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_typed_boundaries.py
@@ -1,0 +1,564 @@
+"""P013 UntypedEntrypointBoundary / P014 UntypedTaskBoundary — boundary-type enforcement.
+
+Every ``@entrypoint`` method (P013) and ``@task`` method (P014) on an App must
+declare a properly-typed input parameter (a class that transitively subclasses
+the SDK's ``Input``) and return type (a class that transitively subclasses
+``Output``).
+
+Violations caught:
+
+1. **Missing annotation** — the non-``self`` param or return has no type annotation.
+2. **Clearly untyped** — the annotation is a builtin/typing primitive or container
+   (``dict``, ``list``, ``Any``, ``str``, etc.), including subscripted/bounded forms
+   (``dict[str, str]``) — these never subclass ``Input``/``Output``.
+3. **Resolvable but wrong base** — the annotation class IS in the scanned source
+   tree (or importable from within the app) but does **not** transitively subclass
+   ``Input``/``Output`` (e.g. a plain ``pydantic.BaseModel`` subclass, a dataclass,
+   or an unrelated class).
+
+FP-avoidance: a class name that is *not* in the scanned tree and is *not* a
+clearly-untyped annotation is assumed OK (third-party / generated code we cannot
+follow). Only names resolvable within the scanned universe are flagged.
+
+P013 also covers the **implicit ``run()`` entrypoint**: a method named ``run``
+on a class whose base chain transitively reaches ``App`` is treated as an
+implicit entrypoint and checked under P013.
+
+Decorator provenance
+--------------------
+Mirrors ``_framework_transfer.py``: a decorator is only treated as the SDK
+``task`` / ``entrypoint`` when the name is *not* explicitly imported from a
+non-SDK module.  ``@celery.task``, ``@invoke.task``, and similar third-party
+task decorators are excluded.
+
+Cross-file resolution
+---------------------
+Mirrors the P003 multi-pass pattern: ``check_p013_p014`` operates on the
+pre-built ``by_name`` registry assembled by ``scan_all`` and resolves base
+chains transitively and cycle-safely.  Results are memoised per-call.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Iterator
+
+from conformance.suite.checks._ast_common import _IgnoreDirective, make_finding
+from conformance.suite.schema.findings import Finding
+
+from ._contract_common import _terminal_name, _unwrap_optional_node
+from ._error_code_prefix import ClassRecord
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+# Annotations whose terminal name falls in this set are *always* a violation —
+# they can never be a subclass of Input/Output regardless of type parameters.
+_CLEARLY_UNTYPED: frozenset[str] = frozenset(
+    {
+        # primitives
+        "str",
+        "int",
+        "float",
+        "bool",
+        "bytes",
+        "bytearray",
+        "object",
+        # typing wilds
+        "Any",
+        "None",
+        "NoneType",
+        # containers (bare or subscripted)
+        "dict",
+        "Dict",
+        "list",
+        "List",
+        "tuple",
+        "Tuple",
+        "set",
+        "Set",
+        "frozenset",
+        "FrozenSet",
+        "Mapping",
+        "MutableMapping",
+        "Sequence",
+        "MutableSequence",
+        "Iterable",
+        "Collection",
+        "Iterator",
+        "Generator",
+        "Callable",
+        # typing extras that are never contracts
+        "ClassVar",
+        "Final",
+        "Literal",
+        "Union",
+        "Type",
+        "type",
+    }
+)
+
+_SDK_MODULE_PREFIX = "application_sdk"
+
+# Imports from these module prefixes are valid contracts by provenance —
+# skip cross-file resolution and treat them as correctly typed.
+_SDK_CONTRACT_MODULE_PREFIXES: tuple[str, ...] = (
+    "application_sdk.contracts",
+    "application_sdk.handler.contracts",
+)
+
+# ── Provenance helpers ─────────────────────────────────────────────────────────
+
+
+def _collect_ep_task_provenance(
+    tree: ast.AST,
+) -> tuple[frozenset[str], frozenset[str], frozenset[str], frozenset[str]]:
+    """Collect import-provenance sets needed for decorator and annotation gating.
+
+    Returns
+    -------
+    non_sdk_task_names :
+        Local names bound to ``task`` from a non-SDK ``from … import task``.
+    non_sdk_ep_names :
+        Local names bound to ``entrypoint`` from a non-SDK import.
+    non_sdk_module_names :
+        Local names of imported non-SDK top-level modules (``import celery``).
+    sdk_contract_imports :
+        Local names imported from ``application_sdk.contracts.*`` or
+        ``application_sdk.handler.contracts.*`` — valid by provenance.
+    """
+    non_sdk_task: set[str] = set()
+    non_sdk_ep: set[str] = set()
+    non_sdk_mods: set[str] = set()
+    sdk_contracts: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            is_sdk = module == _SDK_MODULE_PREFIX or module.startswith(
+                _SDK_MODULE_PREFIX + "."
+            )
+            if not is_sdk:
+                for alias in node.names:
+                    if alias.name == "task":
+                        non_sdk_task.add(alias.asname or alias.name)
+                    if alias.name == "entrypoint":
+                        non_sdk_ep.add(alias.asname or alias.name)
+            # SDK contract provenance: any import from application_sdk.contracts.*
+            # or application_sdk.handler.contracts.* is treated as a valid contract.
+            if is_sdk and any(
+                module == prefix or module.startswith(prefix + ".")
+                for prefix in _SDK_CONTRACT_MODULE_PREFIXES
+            ):
+                for alias in node.names:
+                    sdk_contracts.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                name = alias.name
+                is_sdk = name == _SDK_MODULE_PREFIX or name.startswith(
+                    _SDK_MODULE_PREFIX + "."
+                )
+                if not is_sdk:
+                    non_sdk_mods.add(alias.asname or name.split(".")[0])
+
+    return (
+        frozenset(non_sdk_task),
+        frozenset(non_sdk_ep),
+        frozenset(non_sdk_mods),
+        frozenset(sdk_contracts),
+    )
+
+
+# ── Decorator helpers ─────────────────────────────────────────────────────────
+
+
+def _is_task_decorator(
+    dec: ast.expr,
+    non_sdk_task_names: frozenset[str],
+    non_sdk_module_names: frozenset[str],
+) -> bool:
+    """True if *dec* is the SDK ``@task`` decorator (not a third-party one)."""
+    if isinstance(dec, ast.Call):
+        dec = dec.func
+    if isinstance(dec, ast.Name):
+        return dec.id == "task" and dec.id not in non_sdk_task_names
+    if isinstance(dec, ast.Attribute):
+        return dec.attr == "task" and (
+            not isinstance(dec.value, ast.Name)
+            or dec.value.id not in non_sdk_module_names
+        )
+    return False
+
+
+def _is_entrypoint_decorator(
+    dec: ast.expr,
+    non_sdk_ep_names: frozenset[str],
+    non_sdk_module_names: frozenset[str],
+) -> bool:
+    """True if *dec* is the SDK ``@entrypoint`` decorator (not a third-party one)."""
+    if isinstance(dec, ast.Call):
+        dec = dec.func
+    if isinstance(dec, ast.Name):
+        return dec.id == "entrypoint" and dec.id not in non_sdk_ep_names
+    if isinstance(dec, ast.Attribute):
+        return dec.attr == "entrypoint" and (
+            not isinstance(dec.value, ast.Name)
+            or dec.value.id not in non_sdk_module_names
+        )
+    return False
+
+
+# ── Annotation analysis ───────────────────────────────────────────────────────
+
+
+def _annotation_terminal_name(node: ast.expr | None) -> str | None:
+    """Return the terminal class name of an annotation, unwrapping Optional/union.
+
+    ``FetchInput`` → ``"FetchInput"``; ``FetchInput | None`` → ``"FetchInput"``;
+    ``Optional[FetchInput]`` → ``"FetchInput"``; ``dict[str, str]`` → ``"dict"``;
+    ``None`` (missing annotation) → ``None``.
+    """
+    if node is None:
+        return None
+    # Peer through Optional[X] and X | None.
+    inner = _unwrap_optional_node(node)
+    return _terminal_name(inner)
+
+
+def _is_clearly_untyped_annotation(node: ast.expr | None) -> bool:
+    """True when the annotation is clearly untyped (primitive, container, or Any).
+
+    Covers bare names (``dict``), subscripted forms (``dict[str, str]``), and
+    ``Optional``/union wrappers around them.  A ``None`` (missing) annotation is
+    also a violation — the caller is responsible for the finding message.
+    """
+    if node is None:
+        return False  # caller handles missing annotation separately
+    name = _annotation_terminal_name(node)
+    return name is not None and name in _CLEARLY_UNTYPED
+
+
+# ── Cross-file resolution ─────────────────────────────────────────────────────
+
+
+def _resolve_to_base(
+    name: str,
+    target: str,
+    by_name: dict[str, ClassRecord],
+    cache: dict[str, bool | None],
+    visiting: set[str],
+) -> bool | None:
+    """Transitively resolve *name*'s inheritance chain looking for *target*.
+
+    Returns
+    -------
+    ``True``
+        *name* or one of its ancestors IS *target* (valid boundary type).
+    ``False``
+        *name* is in the scanned universe but does *not* reach *target*
+        (violation — the class is a concrete wrong-base type).  This is
+        definitive even when some ancestor bases are external/unknown: an
+        external base that is not in *by_name* simply does not contribute
+        a confirmed path to *target*, so it is treated as non-reaching.
+    ``None``
+        *name* itself is not in the scanned universe (unknown / third-party
+        / generated — assumed OK to avoid false positives).
+    """
+    if name == target:
+        return True
+    if name in cache:
+        return cache[name]
+    if name in visiting:
+        # Cycle detected — treat as unknown to avoid false positives.
+        return None
+    rec = by_name.get(name)
+    if rec is None:
+        # Not in the scanned source tree → cannot determine → assume OK.
+        cache[name] = None
+        return None
+    visiting.add(name)
+    # Class IS in the scanned universe → result is definitive (True or False).
+    # We only return None when the class itself is absent from by_name (line above).
+    # An external/unknown *base* (sub is None) does not make the class's status
+    # unknown — it simply means that base doesn't confirm the target, so we
+    # continue looking at other bases, and if none resolve to True, the class
+    # does NOT reach the target (result stays False → violation).
+    result: bool = False
+    for base in rec.bases:
+        sub = _resolve_to_base(base, target, by_name, cache, visiting)
+        if sub is True:
+            result = True
+            break
+        # sub is None (external base) or False (doesn't reach target) — either
+        # way this base doesn't establish the target; try the next one.
+    visiting.discard(name)
+    cache[name] = result
+    return result
+
+
+# ── Method iteration ──────────────────────────────────────────────────────────
+
+
+def _iter_class_body_methods(
+    class_node: ast.ClassDef,
+) -> Iterator[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Yield direct (non-nested) method defs from *class_node*'s body."""
+    for stmt in class_node.body:
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield stmt
+
+
+def _get_non_self_params(
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> list[ast.arg]:
+    """Return the non-``self``/non-``cls`` parameters of a method."""
+    args = func.args.args
+    if args and args[0].arg in ("self", "cls"):
+        return args[1:]
+    return list(args)
+
+
+# ── Finding helpers ───────────────────────────────────────────────────────────
+
+
+def _make_boundary_finding(
+    *,
+    rule_id: str,
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+    ann_node: ast.expr | None,
+    fallback_node: ast.AST,
+    direction: str,
+    ann_name: str,
+    reason: str,
+    filename: str,
+    directives: dict[int, _IgnoreDirective],
+) -> Finding:
+    """Construct a P013/P014 boundary finding with a canonical message."""
+    target_base = "Input" if direction == "input" else "Output"
+    if direction == "input":
+        guidance = (
+            "Define a class inheriting from Input "
+            "(application_sdk.contracts) and use it as the parameter type."
+        )
+    else:
+        guidance = (
+            "Define a class inheriting from Output "
+            "(application_sdk.contracts) and use it as the return type."
+        )
+    message = (
+        f"Method '{func.name}' {direction} annotation '{ann_name}' {reason}. "
+        f"Boundary types must subclass the SDK's {target_base} "
+        f"(application_sdk.contracts). {guidance}"
+    )
+    node: ast.AST = ann_node if ann_node is not None else fallback_node
+    return make_finding(
+        filename=filename,
+        rule_id=rule_id,
+        node=node,
+        message=message,
+        directives=directives,
+    )
+
+
+def _check_one_annotation(
+    *,
+    annotation: ast.expr | None,
+    fallback_node: ast.AST,
+    target_base: str,
+    direction: str,
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+    rule_id: str,
+    filename: str,
+    directives: dict[int, _IgnoreDirective],
+    by_name: dict[str, ClassRecord],
+    sdk_contract_imports: frozenset[str],
+    cache: dict[str, bool | None],
+) -> Finding | None:
+    """Return a finding for *annotation* when it is not a valid contract, else ``None``."""
+    # ── Case 1: missing annotation ────────────────────────────────────────────
+    if annotation is None:
+        target_base_name = "Input" if direction == "input" else "Output"
+        node: ast.AST = fallback_node
+        message = (
+            f"Method '{func.name}' {direction} is missing a type annotation. "
+            f"Boundary types must subclass the SDK's {target_base_name} "
+            "(application_sdk.contracts). "
+            f"Define a class inheriting from {target_base_name} and annotate "
+            "the parameter/return accordingly."
+        )
+        return make_finding(
+            filename=filename,
+            rule_id=rule_id,
+            node=node,
+            message=message,
+            directives=directives,
+        )
+
+    # ── Case 2: clearly untyped ───────────────────────────────────────────────
+    if _is_clearly_untyped_annotation(annotation):
+        ann_name = _annotation_terminal_name(annotation) or "<untyped>"
+        return _make_boundary_finding(
+            rule_id=rule_id,
+            func=func,
+            ann_node=annotation,
+            fallback_node=fallback_node,
+            direction=direction,
+            ann_name=ann_name,
+            reason="is a primitive, container, or untyped structure",
+            filename=filename,
+            directives=directives,
+        )
+
+    # ── Resolve annotation class name ─────────────────────────────────────────
+    ann_name = _annotation_terminal_name(annotation)
+    if ann_name is None:
+        # Unrecognisable annotation form (e.g. complex subscript) → skip.
+        return None
+
+    # ── Case 3a: SDK contract import by provenance → valid ───────────────────
+    if ann_name in sdk_contract_imports:
+        return None
+
+    # ── Case 3b: cross-file resolution ───────────────────────────────────────
+    result = _resolve_to_base(ann_name, target_base, by_name, cache, set())
+    if result is False:
+        # Found in scanned universe but does not reach Input/Output.
+        return _make_boundary_finding(
+            rule_id=rule_id,
+            func=func,
+            ann_node=annotation,
+            fallback_node=fallback_node,
+            direction=direction,
+            ann_name=ann_name,
+            reason=f"does not subclass the SDK's {'Input' if direction == 'input' else 'Output'}",
+            filename=filename,
+            directives=directives,
+        )
+
+    # result is True (valid) or None (unresolvable → assumed OK) → no finding.
+    return None
+
+
+# ── Main entry point ──────────────────────────────────────────────────────────
+
+
+def check_p013_p014(
+    file_trees: dict[Path, ast.AST],
+    by_name: dict[str, ClassRecord],
+    file_directives: dict[Path, dict[int, _IgnoreDirective]],
+    root: Path,
+) -> list[Finding]:
+    """Emit P013/P014 for entrypoint/task methods with untyped boundary types.
+
+    Operates on the pre-built ``by_name`` class registry and ``file_trees``
+    collected during the Pass 1 scan in ``scan_all`` — both must cover the full
+    set of Python source files so cross-file inheritance resolution is complete.
+
+    P013 fires for ``@entrypoint`` methods and for implicit ``run()`` overrides
+    on ``App`` subclasses.  P014 fires for ``@task`` methods.  Each rule checks
+    both the input parameter annotation and the return annotation.
+    """
+    findings: list[Finding] = []
+
+    # Memoised resolution caches shared across all files (keyed by class name).
+    input_cache: dict[str, bool | None] = {}
+    output_cache: dict[str, bool | None] = {}
+    app_cache: dict[str, bool | None] = {}
+
+    for path, tree in file_trees.items():
+        directives = file_directives.get(path, {})
+        try:
+            rel = path.relative_to(root)
+        except ValueError:
+            rel = path
+        filename = str(rel)
+
+        non_sdk_task, non_sdk_ep, non_sdk_mods, sdk_contracts = (
+            _collect_ep_task_provenance(tree)
+        )
+
+        for class_node in ast.walk(tree):
+            if not isinstance(class_node, ast.ClassDef):
+                continue
+
+            for func in _iter_class_body_methods(class_node):
+                # ── Determine which rule applies ──────────────────────────────
+                rule_id: str | None = None
+
+                if any(
+                    _is_entrypoint_decorator(dec, non_sdk_ep, non_sdk_mods)
+                    for dec in func.decorator_list
+                ):
+                    rule_id = "P013"
+
+                elif any(
+                    _is_task_decorator(dec, non_sdk_task, non_sdk_mods)
+                    for dec in func.decorator_list
+                ):
+                    rule_id = "P014"
+
+                elif func.name == "run" and isinstance(func, ast.AsyncFunctionDef):
+                    # Implicit entrypoint: run() on an App subclass.
+                    for base in class_node.bases:
+                        base_name: str | None = None
+                        if isinstance(base, ast.Name):
+                            base_name = base.id
+                        elif isinstance(base, ast.Attribute):
+                            base_name = base.attr
+                        if base_name is None:
+                            continue
+                        if (
+                            base_name == "App"
+                            or _resolve_to_base(
+                                base_name, "App", by_name, app_cache, set()
+                            )
+                            is True
+                        ):
+                            rule_id = "P013"
+                            break
+
+                if rule_id is None:
+                    continue
+
+                # ── Get the non-self input parameter ─────────────────────────
+                non_self = _get_non_self_params(func)
+                if not non_self:
+                    # Wrong arity — the runtime decorator will reject this.
+                    continue
+                input_param = non_self[0]
+
+                # ── Check input annotation ────────────────────────────────────
+                finding = _check_one_annotation(
+                    annotation=input_param.annotation,
+                    fallback_node=input_param,
+                    target_base="Input",
+                    direction="input",
+                    func=func,
+                    rule_id=rule_id,
+                    filename=filename,
+                    directives=directives,
+                    by_name=by_name,
+                    sdk_contract_imports=sdk_contracts,
+                    cache=input_cache,
+                )
+                if finding is not None:
+                    findings.append(finding)
+
+                # ── Check return annotation ───────────────────────────────────
+                finding = _check_one_annotation(
+                    annotation=func.returns,
+                    fallback_node=func,
+                    target_base="Output",
+                    direction="output",
+                    func=func,
+                    rule_id=rule_id,
+                    filename=filename,
+                    directives=directives,
+                    by_name=by_name,
+                    sdk_contract_imports=sdk_contracts,
+                    cache=output_cache,
+                )
+                if finding is not None:
+                    findings.append(finding)
+
+    return findings

--- a/packages/conformance/conformance/suite/checks/prescriptions/_typed_boundaries.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_typed_boundaries.py
@@ -56,7 +56,7 @@ from typing import Iterator
 from conformance.suite.checks._ast_common import _IgnoreDirective, make_finding
 from conformance.suite.schema.findings import Finding
 
-from ._contract_common import _terminal_name, _unwrap_optional_node
+from ._contract_common import _terminal_name, _unwrap_annotated, _unwrap_optional_node
 from ._decorator_provenance import (
     ImportProvenance,
     collect_import_provenance,
@@ -117,16 +117,27 @@ _CLEARLY_UNTYPED: frozenset[str] = frozenset(
 
 
 def _annotation_terminal_name(node: ast.expr | None) -> str | None:
-    """Return the terminal class name of an annotation, unwrapping Optional/union.
+    """Return the terminal class name of an annotation, unwrapping all wrappers.
 
-    ``FetchInput`` → ``"FetchInput"``; ``FetchInput | None`` → ``"FetchInput"``;
-    ``Optional[FetchInput]`` → ``"FetchInput"``; ``dict[str, str]`` → ``"dict"``;
+    Unwraps ``Optional[X]`` / ``X | None`` and ``Annotated[X, ...]`` in a
+    fixed-point loop so nested forms like ``Optional[Annotated[dict, M]]`` and
+    ``Annotated[Optional[dict]]`` are fully reduced before the terminal name is
+    read.
+
+    ``FetchInput`` → ``"FetchInput"``; ``Optional[FetchInput]`` → ``"FetchInput"``;
+    ``Optional[Annotated[dict[str,str], M]]`` → ``"dict"``;
     ``None`` literal (``-> None``) → ``"None"``.
     """
     if node is None:
         return None
-    # Peer through Optional[X] and X | None.
-    inner = _unwrap_optional_node(node)
+    # Peer through Optional[X] / X | None and Annotated[X, ...] to a fixed point.
+    inner = node
+    while True:
+        unwrapped = _unwrap_optional_node(inner)
+        unwrapped = _unwrap_annotated(unwrapped)
+        if unwrapped is inner:
+            break
+        inner = unwrapped
     return _terminal_name(inner)
 
 
@@ -158,11 +169,18 @@ def _iter_class_body_methods(
 def _get_non_self_params(
     func: ast.FunctionDef | ast.AsyncFunctionDef,
 ) -> list[ast.arg]:
-    """Return the non-``self``/non-``cls`` parameters of a method."""
-    args = func.args.args
-    if args and args[0].arg in ("self", "cls"):
-        return args[1:]
-    return list(args)
+    """Return the non-``self``/non-``cls`` parameters of a method.
+
+    Combines positional-only (``/``), regular, and keyword-only (``*``)
+    parameters so that ``def f(self, *, input: dict)`` and
+    ``def f(self, input: dict, /)`` are both handled correctly.
+    """
+    all_params = (
+        list(func.args.posonlyargs) + list(func.args.args) + list(func.args.kwonlyargs)
+    )
+    if all_params and all_params[0].arg in ("self", "cls"):
+        return all_params[1:]
+    return all_params
 
 
 # ── Finding helpers ───────────────────────────────────────────────────────────
@@ -195,7 +213,9 @@ def _make_boundary_finding(
     message = (
         f"Method '{func.name}' {direction} annotation '{ann_name}' {reason}. "
         f"Boundary types must subclass the SDK's {target_base} "
-        f"(application_sdk.contracts). {guidance}"
+        f"(application_sdk.contracts). {guidance} "
+        f"Suppress with '# conformance: ignore[{rule_id}] <reason>' on the "
+        "def line (the violation node is the annotation, not the call-site)."
     )
     node: ast.AST = ann_node if ann_node is not None else fallback_node
     return make_finding(
@@ -233,7 +253,9 @@ def _check_one_annotation(
             f"Boundary types must subclass the SDK's {target_base_name} "
             "(application_sdk.contracts). "
             f"Define a class inheriting from {target_base_name} and annotate "
-            "the parameter/return accordingly."
+            "the parameter/return accordingly. "
+            f"Suppress with '# conformance: ignore[{rule_id}] <reason>' on the "
+            "def line (the violation node is the annotation, not the call-site)."
         )
         return make_finding(
             filename=filename,
@@ -357,7 +379,10 @@ def check_p013_p014(
                     rule_id = "P014"
 
                 elif func.name == "run" and isinstance(func, ast.AsyncFunctionDef):
-                    # Implicit entrypoint: run() on an App subclass.
+                    # Implicit entrypoint: async run() on an App subclass.
+                    # Only async — App.run() is defined as async-only; a sync
+                    # def run() would be rejected by the runtime before P013
+                    # has any value, so we intentionally skip it here.
                     for base in class_node.bases:
                         base_name: str | None = None
                         if isinstance(base, ast.Name):

--- a/packages/conformance/conformance/suite/checks/prescriptions/_typed_boundaries.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_typed_boundaries.py
@@ -9,8 +9,8 @@ Violations caught:
 
 1. **Missing annotation** — the non-``self`` param or return has no type annotation.
 2. **Clearly untyped** — the annotation is a builtin/typing primitive or container
-   (``dict``, ``list``, ``Any``, ``str``, etc.), including subscripted/bounded forms
-   (``dict[str, str]``) — these never subclass ``Input``/``Output``.
+   (``dict``, ``list``, ``Any``, ``str``, ``None``, etc.), including subscripted/bounded
+   forms (``dict[str, str]``) — these never subclass ``Input``/``Output``.
 3. **Resolvable but wrong base** — the annotation class IS in the scanned source
    tree (or importable from within the app) but does **not** transitively subclass
    ``Input``/``Output`` (e.g. a plain ``pydantic.BaseModel`` subclass, a dataclass,
@@ -26,16 +26,25 @@ implicit entrypoint and checked under P013.
 
 Decorator provenance
 --------------------
-Mirrors ``_framework_transfer.py``: a decorator is only treated as the SDK
-``task`` / ``entrypoint`` when the name is *not* explicitly imported from a
-non-SDK module.  ``@celery.task``, ``@invoke.task``, and similar third-party
-task decorators are excluded.
+Provenance gating is shared with P008 via ``_decorator_provenance``: a decorator
+is only treated as the SDK ``task`` / ``entrypoint`` when the name is *not*
+explicitly imported from a non-SDK module.  ``@celery.task``, ``@flask.entrypoint``,
+and similar third-party decorators are excluded.
 
 Cross-file resolution
 ---------------------
 Mirrors the P003 multi-pass pattern: ``check_p013_p014`` operates on the
 pre-built ``by_name`` registry assembled by ``scan_all`` and resolves base
-chains transitively and cycle-safely.  Results are memoised per-call.
+chains transitively and cycle-safely using ``resolve_ancestor`` from
+``_error_code_prefix``.  Results are memoised per-call.
+
+Alias resolution
+----------------
+``collect_import_aliases`` de-aliases annotation class names before resolution
+so that ``from .contracts import FetchInput as MyAlias`` is resolved correctly.
+Module-level ``import application_sdk.contracts as c`` is handled by the
+``sdk_contract_module_aliases`` provenance set: a ``c.FetchInput`` annotation is
+fast-pathed as valid without needing to be in the scanned tree.
 """
 
 from __future__ import annotations
@@ -48,7 +57,13 @@ from conformance.suite.checks._ast_common import _IgnoreDirective, make_finding
 from conformance.suite.schema.findings import Finding
 
 from ._contract_common import _terminal_name, _unwrap_optional_node
-from ._error_code_prefix import ClassRecord
+from ._decorator_provenance import (
+    ImportProvenance,
+    collect_import_provenance,
+    is_entrypoint_decorator,
+    is_task_decorator,
+)
+from ._error_code_prefix import ClassRecord, collect_import_aliases, resolve_ancestor
 
 # ── Constants ──────────────────────────────────────────────────────────────────
 
@@ -98,116 +113,6 @@ _CLEARLY_UNTYPED: frozenset[str] = frozenset(
     }
 )
 
-_SDK_MODULE_PREFIX = "application_sdk"
-
-# Imports from these module prefixes are valid contracts by provenance —
-# skip cross-file resolution and treat them as correctly typed.
-_SDK_CONTRACT_MODULE_PREFIXES: tuple[str, ...] = (
-    "application_sdk.contracts",
-    "application_sdk.handler.contracts",
-)
-
-# ── Provenance helpers ─────────────────────────────────────────────────────────
-
-
-def _collect_ep_task_provenance(
-    tree: ast.AST,
-) -> tuple[frozenset[str], frozenset[str], frozenset[str], frozenset[str]]:
-    """Collect import-provenance sets needed for decorator and annotation gating.
-
-    Returns
-    -------
-    non_sdk_task_names :
-        Local names bound to ``task`` from a non-SDK ``from … import task``.
-    non_sdk_ep_names :
-        Local names bound to ``entrypoint`` from a non-SDK import.
-    non_sdk_module_names :
-        Local names of imported non-SDK top-level modules (``import celery``).
-    sdk_contract_imports :
-        Local names imported from ``application_sdk.contracts.*`` or
-        ``application_sdk.handler.contracts.*`` — valid by provenance.
-    """
-    non_sdk_task: set[str] = set()
-    non_sdk_ep: set[str] = set()
-    non_sdk_mods: set[str] = set()
-    sdk_contracts: set[str] = set()
-
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom):
-            module = node.module or ""
-            is_sdk = module == _SDK_MODULE_PREFIX or module.startswith(
-                _SDK_MODULE_PREFIX + "."
-            )
-            if not is_sdk:
-                for alias in node.names:
-                    if alias.name == "task":
-                        non_sdk_task.add(alias.asname or alias.name)
-                    if alias.name == "entrypoint":
-                        non_sdk_ep.add(alias.asname or alias.name)
-            # SDK contract provenance: any import from application_sdk.contracts.*
-            # or application_sdk.handler.contracts.* is treated as a valid contract.
-            if is_sdk and any(
-                module == prefix or module.startswith(prefix + ".")
-                for prefix in _SDK_CONTRACT_MODULE_PREFIXES
-            ):
-                for alias in node.names:
-                    sdk_contracts.add(alias.asname or alias.name)
-        elif isinstance(node, ast.Import):
-            for alias in node.names:
-                name = alias.name
-                is_sdk = name == _SDK_MODULE_PREFIX or name.startswith(
-                    _SDK_MODULE_PREFIX + "."
-                )
-                if not is_sdk:
-                    non_sdk_mods.add(alias.asname or name.split(".")[0])
-
-    return (
-        frozenset(non_sdk_task),
-        frozenset(non_sdk_ep),
-        frozenset(non_sdk_mods),
-        frozenset(sdk_contracts),
-    )
-
-
-# ── Decorator helpers ─────────────────────────────────────────────────────────
-
-
-def _is_task_decorator(
-    dec: ast.expr,
-    non_sdk_task_names: frozenset[str],
-    non_sdk_module_names: frozenset[str],
-) -> bool:
-    """True if *dec* is the SDK ``@task`` decorator (not a third-party one)."""
-    if isinstance(dec, ast.Call):
-        dec = dec.func
-    if isinstance(dec, ast.Name):
-        return dec.id == "task" and dec.id not in non_sdk_task_names
-    if isinstance(dec, ast.Attribute):
-        return dec.attr == "task" and (
-            not isinstance(dec.value, ast.Name)
-            or dec.value.id not in non_sdk_module_names
-        )
-    return False
-
-
-def _is_entrypoint_decorator(
-    dec: ast.expr,
-    non_sdk_ep_names: frozenset[str],
-    non_sdk_module_names: frozenset[str],
-) -> bool:
-    """True if *dec* is the SDK ``@entrypoint`` decorator (not a third-party one)."""
-    if isinstance(dec, ast.Call):
-        dec = dec.func
-    if isinstance(dec, ast.Name):
-        return dec.id == "entrypoint" and dec.id not in non_sdk_ep_names
-    if isinstance(dec, ast.Attribute):
-        return dec.attr == "entrypoint" and (
-            not isinstance(dec.value, ast.Name)
-            or dec.value.id not in non_sdk_module_names
-        )
-    return False
-
-
 # ── Annotation analysis ───────────────────────────────────────────────────────
 
 
@@ -216,7 +121,7 @@ def _annotation_terminal_name(node: ast.expr | None) -> str | None:
 
     ``FetchInput`` → ``"FetchInput"``; ``FetchInput | None`` → ``"FetchInput"``;
     ``Optional[FetchInput]`` → ``"FetchInput"``; ``dict[str, str]`` → ``"dict"``;
-    ``None`` (missing annotation) → ``None``.
+    ``None`` literal (``-> None``) → ``"None"``.
     """
     if node is None:
         return None
@@ -236,64 +141,6 @@ def _is_clearly_untyped_annotation(node: ast.expr | None) -> bool:
         return False  # caller handles missing annotation separately
     name = _annotation_terminal_name(node)
     return name is not None and name in _CLEARLY_UNTYPED
-
-
-# ── Cross-file resolution ─────────────────────────────────────────────────────
-
-
-def _resolve_to_base(
-    name: str,
-    target: str,
-    by_name: dict[str, ClassRecord],
-    cache: dict[str, bool | None],
-    visiting: set[str],
-) -> bool | None:
-    """Transitively resolve *name*'s inheritance chain looking for *target*.
-
-    Returns
-    -------
-    ``True``
-        *name* or one of its ancestors IS *target* (valid boundary type).
-    ``False``
-        *name* is in the scanned universe but does *not* reach *target*
-        (violation — the class is a concrete wrong-base type).  This is
-        definitive even when some ancestor bases are external/unknown: an
-        external base that is not in *by_name* simply does not contribute
-        a confirmed path to *target*, so it is treated as non-reaching.
-    ``None``
-        *name* itself is not in the scanned universe (unknown / third-party
-        / generated — assumed OK to avoid false positives).
-    """
-    if name == target:
-        return True
-    if name in cache:
-        return cache[name]
-    if name in visiting:
-        # Cycle detected — treat as unknown to avoid false positives.
-        return None
-    rec = by_name.get(name)
-    if rec is None:
-        # Not in the scanned source tree → cannot determine → assume OK.
-        cache[name] = None
-        return None
-    visiting.add(name)
-    # Class IS in the scanned universe → result is definitive (True or False).
-    # We only return None when the class itself is absent from by_name (line above).
-    # An external/unknown *base* (sub is None) does not make the class's status
-    # unknown — it simply means that base doesn't confirm the target, so we
-    # continue looking at other bases, and if none resolve to True, the class
-    # does NOT reach the target (result stays False → violation).
-    result: bool = False
-    for base in rec.bases:
-        sub = _resolve_to_base(base, target, by_name, cache, visiting)
-        if sub is True:
-            result = True
-            break
-        # sub is None (external base) or False (doesn't reach target) — either
-        # way this base doesn't establish the target; try the next one.
-    visiting.discard(name)
-    cache[name] = result
-    return result
 
 
 # ── Method iteration ──────────────────────────────────────────────────────────
@@ -372,6 +219,8 @@ def _check_one_annotation(
     directives: dict[int, _IgnoreDirective],
     by_name: dict[str, ClassRecord],
     sdk_contract_imports: frozenset[str],
+    sdk_contract_module_aliases: frozenset[str],
+    aliases: dict[str, str],
     cache: dict[str, bool | None],
 ) -> Finding | None:
     """Return a finding for *annotation* when it is not a valid contract, else ``None``."""
@@ -409,18 +258,31 @@ def _check_one_annotation(
             directives=directives,
         )
 
+    # ── Case 3a: module-level SDK contract alias (import ... as c; c.FetchInput) ─
+    # Unwrap Optional so that Optional[c.FetchInput] is also handled.
+    inner_ann = _unwrap_optional_node(annotation)
+    if (
+        isinstance(inner_ann, ast.Attribute)
+        and isinstance(inner_ann.value, ast.Name)
+        and inner_ann.value.id in sdk_contract_module_aliases
+    ):
+        return None  # valid by provenance
+
     # ── Resolve annotation class name ─────────────────────────────────────────
     ann_name = _annotation_terminal_name(annotation)
     if ann_name is None:
         # Unrecognisable annotation form (e.g. complex subscript) → skip.
         return None
 
-    # ── Case 3a: SDK contract import by provenance → valid ───────────────────
+    # De-alias so that `from .contracts import FetchInput as MyAlias` resolves.
+    ann_name = aliases.get(ann_name, ann_name)
+
+    # ── Case 3b: SDK contract import by provenance (from ... import X) → valid ─
     if ann_name in sdk_contract_imports:
         return None
 
-    # ── Case 3b: cross-file resolution ───────────────────────────────────────
-    result = _resolve_to_base(ann_name, target_base, by_name, cache, set())
+    # ── Case 3c: cross-file resolution ───────────────────────────────────────
+    result = resolve_ancestor(ann_name, target_base, by_name, cache, set())
     if result is False:
         # Found in scanned universe but does not reach Input/Output.
         return _make_boundary_finding(
@@ -473,9 +335,10 @@ def check_p013_p014(
             rel = path
         filename = str(rel)
 
-        non_sdk_task, non_sdk_ep, non_sdk_mods, sdk_contracts = (
-            _collect_ep_task_provenance(tree)
-        )
+        prov: ImportProvenance = collect_import_provenance(tree)
+        # Per-file import aliases for de-aliasing annotation class names
+        # (e.g. `from .contracts import FetchInput as MyAlias`).
+        aliases = collect_import_aliases(tree) if isinstance(tree, ast.Module) else {}
 
         for class_node in ast.walk(tree):
             if not isinstance(class_node, ast.ClassDef):
@@ -486,15 +349,11 @@ def check_p013_p014(
                 rule_id: str | None = None
 
                 if any(
-                    _is_entrypoint_decorator(dec, non_sdk_ep, non_sdk_mods)
-                    for dec in func.decorator_list
+                    is_entrypoint_decorator(dec, prov) for dec in func.decorator_list
                 ):
                     rule_id = "P013"
 
-                elif any(
-                    _is_task_decorator(dec, non_sdk_task, non_sdk_mods)
-                    for dec in func.decorator_list
-                ):
+                elif any(is_task_decorator(dec, prov) for dec in func.decorator_list):
                     rule_id = "P014"
 
                 elif func.name == "run" and isinstance(func, ast.AsyncFunctionDef):
@@ -507,9 +366,11 @@ def check_p013_p014(
                             base_name = base.attr
                         if base_name is None:
                             continue
+                        # De-alias before comparing: handles `App as BaseApp`.
+                        base_name = aliases.get(base_name, base_name)
                         if (
                             base_name == "App"
-                            or _resolve_to_base(
+                            or resolve_ancestor(
                                 base_name, "App", by_name, app_cache, set()
                             )
                             is True
@@ -538,7 +399,9 @@ def check_p013_p014(
                     filename=filename,
                     directives=directives,
                     by_name=by_name,
-                    sdk_contract_imports=sdk_contracts,
+                    sdk_contract_imports=prov.sdk_contract_names,
+                    sdk_contract_module_aliases=prov.sdk_contract_module_aliases,
+                    aliases=aliases,
                     cache=input_cache,
                 )
                 if finding is not None:
@@ -555,7 +418,9 @@ def check_p013_p014(
                     filename=filename,
                     directives=directives,
                     by_name=by_name,
-                    sdk_contract_imports=sdk_contracts,
+                    sdk_contract_imports=prov.sdk_contract_names,
+                    sdk_contract_module_aliases=prov.sdk_contract_module_aliases,
+                    aliases=aliases,
                     cache=output_cache,
                 )
                 if finding is not None:

--- a/packages/conformance/conformance/suite/rules/prescriptions.py
+++ b/packages/conformance/conformance/suite/rules/prescriptions.py
@@ -138,4 +138,144 @@ RULES: tuple[RuleDefinition, ...] = (
         ),
         help_uri="https://github.com/atlanhq/application-sdk/blob/main/packages/conformance/conformance/docs/rules/prescriptions.md#p003",
     ),
+    RuleDefinition(
+        id="P013",
+        scope=RuleScope.APP,
+        name="UntypedEntrypointBoundary",
+        tier=EnforcementTier.BLOCK,
+        mechanism=RuleMechanism.STATIC,
+        category="typed-contract-boundary",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.6.0",
+        rationale=(
+            "Every @entrypoint method (and the implicit run() override) is the "
+            "public API boundary of the app — the payload that crosses it must be "
+            "validated, versioned, and evolvable.  Using a primitive, a container, "
+            "or a class that does not subclass Input/Output bypasses the SDK's "
+            "payload-safety validation, config-hash computation, and backwards-"
+            "compatibility tracking.  The runtime @entrypoint decorator already "
+            "rejects these at import time, so no conforming running app is untyped "
+            "today — this rule surfaces the violation earlier (PR/CI) and covers "
+            "pre-decorator code paths."
+        ),
+        short_description=(
+            "@entrypoint (or implicit run()) input/output is not an SDK Input/Output subclass"
+        ),
+        full_description=(
+            "A method decorated with ``@entrypoint`` (or a concrete ``run()`` "
+            "override on an ``App`` subclass, which is the implicit single-"
+            "entrypoint form) must declare:\n"
+            "\n"
+            "* its non-``self`` parameter as a subclass of ``Input``\n"
+            "  (``application_sdk.contracts``);\n"
+            "* its return type as a subclass of ``Output``\n"
+            "  (``application_sdk.contracts``).\n"
+            "\n"
+            "Violations include: missing annotation, a primitive / container type\n"
+            "(``dict``, ``list``, ``str``, ``Any``, etc. — even subscripted/bounded\n"
+            "forms like ``dict[str, str]``), or a class that exists in the scanned\n"
+            "source tree but does not transitively subclass ``Input``/``Output``\n"
+            "(e.g. a plain ``pydantic.BaseModel`` subclass or a dataclass).\n"
+            "\n"
+            "Suppressed declarations are still emitted to the SARIF report.\n"
+            "This rule is ``BLOCK`` (suppress-only): an unsuppressed violation\n"
+            "fails the conformance gate — suppress with\n"
+            "``# conformance: ignore[P013] <reason>`` at the method definition.\n"
+        ),
+        help_uri="https://github.com/atlanhq/application-sdk/blob/main/packages/conformance/conformance/docs/rules/prescriptions.md#p013",
+    ),
+    RuleDefinition(
+        id="P014",
+        scope=RuleScope.APP,
+        name="UntypedTaskBoundary",
+        tier=EnforcementTier.BLOCK,
+        mechanism=RuleMechanism.STATIC,
+        category="typed-contract-boundary",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.6.0",
+        rationale=(
+            "Every @task method is an internal activity boundary — the payload must "
+            "be typed and bounded so the SDK can validate it at the activity layer "
+            "and detect drift across deployments.  Using an untyped structure "
+            "bypasses the SDK's payload-safety enforcement and makes the task's "
+            "I/O invisible to dashboards, schema tooling, and the contract registry.  "
+            "The runtime @task decorator already rejects these at import time, so "
+            "no conforming running app is untyped today — this rule surfaces the "
+            "violation earlier (PR/CI)."
+        ),
+        short_description="@task input/output is not an SDK Input/Output subclass",
+        full_description=(
+            "A method decorated with ``@task`` must declare:\n"
+            "\n"
+            "* its non-``self`` parameter as a subclass of ``Input``\n"
+            "  (``application_sdk.contracts``);\n"
+            "* its return type as a subclass of ``Output``\n"
+            "  (``application_sdk.contracts``).\n"
+            "\n"
+            "Violations include: missing annotation, a primitive / container type\n"
+            "(``dict``, ``list``, ``str``, ``Any``, etc. — even subscripted/bounded\n"
+            "forms like ``dict[str, str]``), or a class that exists in the scanned\n"
+            "source tree but does not transitively subclass ``Input``/``Output``\n"
+            "(e.g. a plain ``pydantic.BaseModel`` subclass or a dataclass).\n"
+            "\n"
+            "Suppressed declarations are still emitted to the SARIF report.\n"
+            "This rule is ``BLOCK`` (suppress-only): an unsuppressed violation\n"
+            "fails the conformance gate — suppress with\n"
+            "``# conformance: ignore[P014] <reason>`` at the method definition.\n"
+        ),
+        help_uri="https://github.com/atlanhq/application-sdk/blob/main/packages/conformance/conformance/docs/rules/prescriptions.md#p014",
+    ),
+    RuleDefinition(
+        id="P015",
+        scope=RuleScope.APP,
+        name="UnmodeledBoundedContractField",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="contract-modeling",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.6.0",
+        rationale=(
+            "Bounded containers (Annotated[dict[str, str], MaxItems(50)]) pass "
+            "payload-safety validation (P001) but are still stringly-typed: "
+            "keys and values carry no schema, typos surface only at runtime, and "
+            "the field is invisible to contract diffing and schema tooling.  "
+            "The SDK's make-contract guidance explicitly prefers typed properties "
+            "over arbitrary string keys ('avoid stringly-typed contracts where the "
+            "user can typo a key and only discover it at runtime').  WARN (not "
+            "BLOCK) because the bounded form is technically sanctioned; this is a "
+            "modeling nudge toward a typed nested model."
+        ),
+        short_description=(
+            "Input/Output contract field uses a container of primitives/Any — "
+            "replace with a typed nested model"
+        ),
+        full_description=(
+            "A field on an ``Input``/``Output`` contract whose annotation is a "
+            "container of primitives or ``Any`` — ``dict[str, str]``,\n"
+            "``list[str]``, ``set[int]``, or the bounded equivalents\n"
+            "``Annotated[dict[str, str], MaxItems(N)]`` — is considered an\n"
+            "unmodeled boundary.  Even though the bounded form satisfies the\n"
+            "payload-safety gate (P001), the container has no schema: keys and\n"
+            "values are opaque strings, typos are runtime-only failures, and the\n"
+            "field is invisible to contract diffing and the SDK's\n"
+            "``is_backwards_compatible`` checker.\n"
+            "\n"
+            "The SDK contract guidance (``make-contract`` skill, §6) prefers\n"
+            "typed properties / a nested ``pydantic.BaseModel`` subclass over\n"
+            "arbitrary string keys.\n"
+            "\n"
+            "**Exempt:** ``list[FooModel]``, ``dict[str, FooModel]`` — containers\n"
+            "of a typed class are the canonical bounded pattern and are fine.\n"
+            "\n"
+            "This rule lands as ``WARN`` (not ``BLOCK``) because the bounded form\n"
+            "is technically sanctioned — this is a modeling nudge, not a gate\n"
+            "failure.  Suppress with\n"
+            "``# conformance: ignore[P015] <reason>`` when a typed replacement\n"
+            "is not feasible.\n"
+        ),
+        help_uri="https://github.com/atlanhq/application-sdk/blob/main/packages/conformance/conformance/docs/rules/prescriptions.md#p015",
+    ),
 )

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -121,6 +121,9 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
     # orchestration layer through the SDK seam, not Temporal/SDK-internals
     # (BLDX-1417). P008–P012: apps must use the SDK's storage seam, not
     # hand-roll object stores or bare path fields (BLDX-1398).
+    # P013/P014: apps must declare typed Input/Output contracts on all
+    # entrypoints and tasks (BLDX-1413). P015: contract fields should use
+    # typed models, not containers of primitives (BLDX-1413).
     # I001–I005: Dockerfile conformance (SDK builds the base image, not consuming it).
     # B001: consuming a deprecated SDK symbol (BLDX-1418).
     assert app_scoped == {
@@ -140,6 +143,9 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
         "P010",
         "P011",
         "P012",
+        "P013",
+        "P014",
+        "P015",
         "I001",
         "I002",
         "I003",
@@ -245,12 +251,13 @@ def test_catalog_d_series_present() -> None:
 
 
 def test_catalog_p_series_present() -> None:
-    """The P-series prescription rules are exactly P001–P012.
+    """The P-series prescription rules are exactly P001–P015.
 
     Strict equality (not just not-missing): P004–P007 are the orchestration-seam
-    rules (BLDX-1417); P008–P012 are the storage-seam rules (BLDX-1398).  A
-    stray or renumbered P-id would slip past a subset check while breaking
-    fleet-wide ``# conformance: ignore[Pxxx]`` suppressions.
+    rules (BLDX-1417); P008–P012 are the storage-seam rules (BLDX-1398);
+    P013–P015 are the typed-contract-boundary rules (BLDX-1413).  A stray or
+    renumbered P-id would slip past a subset check while breaking fleet-wide
+    ``# conformance: ignore[Pxxx]`` suppressions.
     """
     rules = load_catalog()
     p_ids = {r.id for r in rules if r.id.startswith("P")}
@@ -267,6 +274,9 @@ def test_catalog_p_series_present() -> None:
         "P010",
         "P011",
         "P012",
+        "P013",
+        "P014",
+        "P015",
     }
     missing = expected - p_ids
     assert not missing, f"Missing P-series rules: {missing}"

--- a/packages/conformance/tests/test_prescriptions.py
+++ b/packages/conformance/tests/test_prescriptions.py
@@ -1,4 +1,4 @@
-"""Meta-tests for the P-series prescription checks (P001, P002, P003).
+"""Meta-tests for the P-series prescription checks (P001–P015).
 
 These checks are shipped in the conformance package and fanned out across the
 fleet — a buggy check false-positives across hundreds of apps and triggers
@@ -945,3 +945,674 @@ def test_p002_sarif_output_validates(tmp_path: Path) -> None:
     )
     report = SarifReport.model_validate(json.loads(sarif_file.read_text()))
     validate_sarif(report)
+
+
+# ── P013 UntypedEntrypointBoundary ────────────────────────────────────────────
+
+# Shared contract fixtures for P013/P014 tests
+_TYPED_CONTRACTS = (
+    "from application_sdk.contracts import Input, Output\n"
+    "\n"
+    "class FetchInput(Input):\n"
+    "    connection_id: str = ''\n"
+    "\n"
+    "class FetchOutput(Output):\n"
+    "    rows: int = 0\n"
+)
+
+_APP_IMPORTS = "from application_sdk.app import App, entrypoint, task, signal, query\n"
+
+
+def test_p013_fires_on_untyped_dict_input(tmp_path: Path) -> None:
+    """@entrypoint with dict input → P013."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(self, input: dict) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert len(p013) == 1
+    assert "input" in p013[0].message
+
+
+def test_p013_fires_on_subscripted_dict_input(tmp_path: Path) -> None:
+    """@entrypoint with dict[str,str] input — 'even if bounded' → P013."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(self, input: dict[str, str]) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert len(p013) == 1
+
+
+def test_p013_fires_on_any_input(tmp_path: Path) -> None:
+    """@entrypoint with Any input → P013."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from typing import Any\n"
+            "from contracts import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(self, input: Any) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert len(p013) == 1
+
+
+def test_p013_fires_on_missing_input_annotation(tmp_path: Path) -> None:
+    """@entrypoint with unannotated input param → P013."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(self, input) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert len(p013) == 1
+    assert "missing" in p013[0].message.lower()
+
+
+def test_p013_fires_on_untyped_return(tmp_path: Path) -> None:
+    """@entrypoint with dict return type → P013."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchInput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(self, input: FetchInput) -> dict:\n"
+            "        return {}\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert len(p013) == 1
+    assert "output" in p013[0].message
+
+
+def test_p013_fires_on_missing_return_annotation(tmp_path: Path) -> None:
+    """@entrypoint with no return annotation → P013."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchInput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(self, input: FetchInput):\n"
+            "        pass\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert len(p013) == 1
+    assert "missing" in p013[0].message.lower()
+
+
+def test_p013_fires_on_plain_base_model_boundary(tmp_path: Path) -> None:
+    """@entrypoint whose input is a plain BaseModel (not Input subclass) → P013."""
+    files = {
+        "contracts.py": (
+            "from pydantic import BaseModel\n"
+            "\n"
+            "class FetchInput(BaseModel):\n"
+            "    connection_id: str = ''\n"
+        ),
+        "out.py": (
+            "from application_sdk.contracts import Output\n"
+            "class FetchOutput(Output):\n"
+            "    rows: int = 0\n"
+        ),
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchInput\n"
+            "from out import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(self, input: FetchInput) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert len(p013) == 1
+    assert "FetchInput" in p013[0].message
+
+
+def test_p013_silent_on_correctly_typed_entrypoint(tmp_path: Path) -> None:
+    """@entrypoint with proper Input/Output subclasses → no P013."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchInput, FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(self, input: FetchInput) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert p013 == []
+
+
+def test_p013_silent_on_contracts_in_same_file(tmp_path: Path) -> None:
+    """Contracts defined in the same file as the App → resolved correctly."""
+    src = (
+        "from application_sdk.contracts import Input, Output\n"
+        "from application_sdk.app import App, entrypoint\n"
+        "\n"
+        "class FetchInput(Input):\n"
+        "    x: str = ''\n"
+        "\n"
+        "class FetchOutput(Output):\n"
+        "    y: int = 0\n"
+        "\n"
+        "class MyApp(App):\n"
+        "    @entrypoint\n"
+        "    async def run_it(self, input: FetchInput) -> FetchOutput:\n"
+        "        return FetchOutput()\n"
+    )
+    findings = _scan_one(tmp_path, src)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert p013 == []
+
+
+def test_p013_silent_on_third_party_unresolvable_annotation(tmp_path: Path) -> None:
+    """A boundary type imported from a third-party lib (not in scanned tree) is
+    assumed OK — no false-positive."""
+    files = {
+        "connector.py": (
+            _APP_IMPORTS + "from some_third_party import SomeInput, SomeOutput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(self, input: SomeInput) -> SomeOutput:\n"
+            "        return SomeOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert p013 == []
+
+
+def test_p013_silent_on_signal_and_query_methods(tmp_path: Path) -> None:
+    """@signal and @query are runtime interactions, not task boundaries → not P013."""
+    src = (
+        "from application_sdk.app import App, signal, query\n"
+        "\n"
+        "class MyApp(App):\n"
+        "    @signal\n"
+        "    async def pause(self, flag: bool) -> None:\n"
+        "        pass\n"
+        "\n"
+        "    @query\n"
+        "    def status(self) -> str:\n"
+        "        return 'ok'\n"
+    )
+    findings = _scan_one(tmp_path, src)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert p013 == []
+
+
+def test_p013_silent_on_non_sdk_entrypoint_decorator(tmp_path: Path) -> None:
+    """@flask.entrypoint or other non-SDK decorator → not P013 (provenance excluded)."""
+    src = (
+        "from flask import entrypoint\n"
+        "\n"
+        "class MyThing:\n"
+        "    @entrypoint\n"
+        "    async def run_it(self, input: dict) -> dict:\n"
+        "        return {}\n"
+    )
+    findings = _scan_one(tmp_path, src)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert p013 == []
+
+
+def test_p013_implicit_run_fires_on_app_subclass(tmp_path: Path) -> None:
+    """Implicit run() override on an App subclass with untyped input → P013."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            "from application_sdk.app import App\n"
+            "from contracts import FetchOutput\n"
+            "\n"
+            "class MyConnector(App):\n"
+            "    async def run(self, input: dict) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert len(p013) == 1
+    assert "input" in p013[0].message
+
+
+def test_p013_implicit_run_silent_on_non_app_class(tmp_path: Path) -> None:
+    """run() on a class that does not subclass App → not P013."""
+    src = (
+        "class SomeHelper:\n"
+        "    async def run(self, input: dict) -> dict:\n"
+        "        return {}\n"
+    )
+    findings = _scan_one(tmp_path, src)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert p013 == []
+
+
+def test_p013_suppression_directive_clears_gate(tmp_path: Path) -> None:
+    """A justified inline suppression on a P013 violation keeps gate green.
+
+    The suppression comment must be on the same line as the finding (the ``def``
+    line where the annotation lives).  An inline ``# conformance: ignore[P013]``
+    on that line always suppresses regardless of ``comment_only`` status.
+    """
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(self, input: dict) -> FetchOutput:  # conformance: ignore[P013] legacy shim pending contract migration\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    paths = []
+    for name, src in files.items():
+        p = tmp_path / name
+        p.write_text(src)
+        paths.append(p)
+    findings = [f for f in scan_all(paths, tmp_path) if f.rule_id == "P013"]
+    assert len(findings) == 1
+    assert findings[0].suppressed is True
+
+
+def test_p013_is_block_tier() -> None:
+    assert get_rule("P013").tier is EnforcementTier.BLOCK
+
+
+def test_p013_block_violation_fails_gate(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text(
+        "from application_sdk.app import App, entrypoint\n"
+        "class MyApp(App):\n"
+        "    @entrypoint\n"
+        "    async def run_it(self, input: dict) -> dict:\n"
+        "        return {}\n"
+    )
+    code = main(["--root", str(tmp_path), str(tmp_path / "m.py")])
+    assert code == 1
+
+
+def test_p013_result_is_failing_disposition(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text(
+        "from application_sdk.app import App, entrypoint\n"
+        "class MyApp(App):\n"
+        "    @entrypoint\n"
+        "    async def run_it(self, input: dict) -> dict:\n"
+        "        return {}\n"
+    )
+    sarif_file = tmp_path / "out.sarif"
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            str(tmp_path / "m.py"),
+            "--sarif-output",
+            str(sarif_file),
+        ]
+    )
+    report = SarifReport.model_validate(json.loads(sarif_file.read_text()))
+    p013_results = [r for r in report.runs[0].results if r.rule_id == "P013"]
+    assert len(p013_results) >= 1
+    assert all(derive_disposition(r) == Disposition.FAILING for r in p013_results)
+
+
+# ── P014 UntypedTaskBoundary ──────────────────────────────────────────────────
+
+
+def test_p014_fires_on_untyped_dict_input(tmp_path: Path) -> None:
+    """@task with dict input → P014."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @task\n"
+            "    async def fetch(self, input: dict) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p014 = [f for f in findings if f.rule_id == "P014"]
+    assert len(p014) == 1
+    assert "input" in p014[0].message
+
+
+def test_p014_fires_on_untyped_return(tmp_path: Path) -> None:
+    """@task with dict return → P014."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchInput\n"
+            "class MyApp(App):\n"
+            "    @task\n"
+            "    async def fetch(self, input: FetchInput) -> dict:\n"
+            "        return {}\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p014 = [f for f in findings if f.rule_id == "P014"]
+    assert len(p014) == 1
+    assert "output" in p014[0].message
+
+
+def test_p014_fires_on_subscripted_dict_input(tmp_path: Path) -> None:
+    """@task with dict[str,str] input → P014 (bounded containers still untyped)."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @task\n"
+            "    async def fetch(self, input: dict[str, str]) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p014 = [f for f in findings if f.rule_id == "P014"]
+    assert len(p014) == 1
+
+
+def test_p014_fires_on_plain_base_model_boundary(tmp_path: Path) -> None:
+    """@task whose input is a plain BaseModel (in scanned tree, not Input subclass) → P014."""
+    files = {
+        "contracts.py": (
+            "from pydantic import BaseModel\n"
+            "\n"
+            "class FetchInput(BaseModel):\n"
+            "    connection_id: str = ''\n"
+        ),
+        "out.py": (
+            "from application_sdk.contracts import Output\n"
+            "class FetchOutput(Output):\n"
+            "    rows: int = 0\n"
+        ),
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchInput\n"
+            "from out import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @task\n"
+            "    async def fetch(self, input: FetchInput) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p014 = [f for f in findings if f.rule_id == "P014"]
+    assert len(p014) == 1
+    assert "FetchInput" in p014[0].message
+
+
+def test_p014_silent_on_correctly_typed_task(tmp_path: Path) -> None:
+    """@task with proper Input/Output subclasses → no P014."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchInput, FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @task\n"
+            "    async def fetch(self, input: FetchInput) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p014 = [f for f in findings if f.rule_id == "P014"]
+    assert p014 == []
+
+
+def test_p014_silent_on_non_sdk_task_decorator(tmp_path: Path) -> None:
+    """@celery.task with untyped args → not P014 (provenance-excluded)."""
+    src = (
+        "import celery\n"
+        "\n"
+        "class Worker:\n"
+        "    @celery.task\n"
+        "    async def fetch(self, input: dict) -> dict:\n"
+        "        return {}\n"
+    )
+    findings = _scan_one(tmp_path, src)
+    p014 = [f for f in findings if f.rule_id == "P014"]
+    assert p014 == []
+
+
+def test_p014_silent_on_from_celery_import_task(tmp_path: Path) -> None:
+    """``from celery import task`` → not P014."""
+    src = (
+        "from celery import task\n"
+        "\n"
+        "class Worker:\n"
+        "    @task\n"
+        "    async def fetch(self, input: dict) -> dict:\n"
+        "        return {}\n"
+    )
+    findings = _scan_one(tmp_path, src)
+    p014 = [f for f in findings if f.rule_id == "P014"]
+    assert p014 == []
+
+
+def test_p014_silent_on_third_party_unresolvable_annotation(tmp_path: Path) -> None:
+    """Boundary type from a third-party lib (not in tree) is assumed OK."""
+    files = {
+        "connector.py": (
+            _APP_IMPORTS + "from some_lib import SomeInput, SomeOutput\n"
+            "class MyApp(App):\n"
+            "    @task\n"
+            "    async def fetch(self, input: SomeInput) -> SomeOutput:\n"
+            "        return SomeOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p014 = [f for f in findings if f.rule_id == "P014"]
+    assert p014 == []
+
+
+def test_p014_is_block_tier() -> None:
+    assert get_rule("P014").tier is EnforcementTier.BLOCK
+
+
+def test_p014_block_violation_fails_gate(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text(
+        "from application_sdk.app import App, task\n"
+        "class MyApp(App):\n"
+        "    @task\n"
+        "    async def fetch(self, input: dict) -> dict:\n"
+        "        return {}\n"
+    )
+    code = main(["--root", str(tmp_path), str(tmp_path / "m.py")])
+    assert code == 1
+
+
+def test_p014_result_is_failing_disposition(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text(
+        "from application_sdk.app import App, task\n"
+        "class MyApp(App):\n"
+        "    @task\n"
+        "    async def fetch(self, input: dict) -> dict:\n"
+        "        return {}\n"
+    )
+    sarif_file = tmp_path / "out.sarif"
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            str(tmp_path / "m.py"),
+            "--sarif-output",
+            str(sarif_file),
+        ]
+    )
+    report = SarifReport.model_validate(json.loads(sarif_file.read_text()))
+    p014_results = [r for r in report.runs[0].results if r.rule_id == "P014"]
+    assert len(p014_results) >= 1
+    assert all(derive_disposition(r) == Disposition.FAILING for r in p014_results)
+
+
+# ── P015 UnmodeledBoundedContractField ────────────────────────────────────────
+
+
+def _p015_ids(src: str) -> list[str]:
+    return [f.rule_id for f in scan_text(src, "x.py") if f.rule_id == "P015"]
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        "dict",
+        "dict[str, str]",
+        "Dict[str, Any]",
+        "list[str]",
+        "List[int]",
+        "set[str]",
+        "Set[str]",
+        "Mapping[str, str]",
+        "Sequence[str]",
+    ],
+)
+def test_p015_fires_on_unmodeled_container(annotation: str) -> None:
+    """Container of primitives/Any on a contract field → P015."""
+    src = f"class MyInput(Input):\n    data: {annotation}\n"
+    assert _p015_ids(src) == ["P015"], f"Expected P015 for annotation '{annotation}'"
+
+
+def test_p015_fires_on_bounded_annotated_dict(tmp_path: Path) -> None:
+    """Annotated[dict[str, str], MaxItems(50)] — bounded but unmodeled → P015."""
+    src = (
+        "from typing import Annotated\n"
+        "class MyInput(Input):\n"
+        "    data: Annotated[dict[str, str], object()]\n"
+    )
+    assert _p015_ids(src) == ["P015"]
+
+
+def test_p015_fires_on_optional_dict(tmp_path: Path) -> None:
+    """dict[str, str] | None → P015 (optional wrapper doesn't exempt the container)."""
+    src = "class MyInput(Input):\n    data: dict[str, str] | None\n"
+    assert _p015_ids(src) == ["P015"]
+
+
+def test_p015_fires_on_bare_dict_output_field(tmp_path: Path) -> None:
+    """Bare dict on an Output contract → P015."""
+    src = "class MyOutput(Output):\n    result: dict\n"
+    assert _p015_ids(src) == ["P015"]
+
+
+def test_p015_silent_on_list_of_model(tmp_path: Path) -> None:
+    """list[FooModel] — container of a typed class → exempt, no P015."""
+    src = (
+        "class FooModel:\n"
+        "    x: str = ''\n"
+        "\n"
+        "class MyInput(Input):\n"
+        "    items: list[FooModel]\n"
+    )
+    assert _p015_ids(src) == []
+
+
+def test_p015_silent_on_dict_str_model(tmp_path: Path) -> None:
+    """dict[str, FooModel] — dict of model values → exempt, no P015."""
+    src = (
+        "class FooModel:\n"
+        "    x: str = ''\n"
+        "\n"
+        "class MyInput(Input):\n"
+        "    lookup: dict[str, FooModel]\n"
+    )
+    assert _p015_ids(src) == []
+
+
+def test_p015_silent_on_scalar_field(tmp_path: Path) -> None:
+    """Non-container scalar field on a contract → no P015."""
+    src = (
+        "class MyInput(Input):\n"
+        "    connection_id: str\n"
+        "    limit: int\n"
+        "    enabled: bool\n"
+    )
+    assert _p015_ids(src) == []
+
+
+def test_p015_silent_on_non_contract_class(tmp_path: Path) -> None:
+    """dict[str, str] field on a non-contract class → no P015."""
+    src = "class SomeConfig:\n    settings: dict[str, str]\n"
+    assert _p015_ids(src) == []
+
+
+def test_p015_silent_on_foreign_output(tmp_path: Path) -> None:
+    """A class extending Output imported from a non-SDK module is excluded."""
+    src = (
+        "from pydantic_ai import Output\n"
+        "\n"
+        "class MyResult(Output):\n"
+        "    data: dict[str, str]\n"
+    )
+    assert _p015_ids(src) == []
+
+
+def test_p015_suppression_directive(tmp_path: Path) -> None:
+    """# conformance: ignore[P015] suppresses the finding."""
+    src = (
+        "class MyInput(Input):\n"
+        "    # conformance: ignore[P015] schema varies per connector version\n"
+        "    data: dict[str, str]\n"
+    )
+    findings = [f for f in scan_text(src, "x.py") if f.rule_id == "P015"]
+    assert len(findings) == 1
+    assert findings[0].suppressed is True
+
+
+def test_p015_is_warn_tier() -> None:
+    """P015 is WARN, not BLOCK — a modeling nudge, not a gate failure."""
+    assert get_rule("P015").tier is EnforcementTier.WARN
+
+
+def test_p015_warn_violation_passes_gate(tmp_path: Path) -> None:
+    """An unsuppressed P015 (WARN) does not fail the gate (exit 0)."""
+    (tmp_path / "m.py").write_text("class MyInput(Input):\n    data: dict[str, str]\n")
+    code = main(["--root", str(tmp_path), str(tmp_path / "m.py")])
+    assert code == 0
+
+
+def test_p015_result_is_warning_disposition(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text("class MyInput(Input):\n    data: dict[str, str]\n")
+    sarif_file = tmp_path / "out.sarif"
+    main(
+        [
+            "--root",
+            str(tmp_path),
+            str(tmp_path / "m.py"),
+            "--sarif-output",
+            str(sarif_file),
+        ]
+    )
+    report = SarifReport.model_validate(json.loads(sarif_file.read_text()))
+    p015_results = [r for r in report.runs[0].results if r.rule_id == "P015"]
+    assert len(p015_results) >= 1
+    assert all(derive_disposition(r) == Disposition.WARNING for r in p015_results)

--- a/packages/conformance/tests/test_prescriptions.py
+++ b/packages/conformance/tests/test_prescriptions.py
@@ -1475,6 +1475,298 @@ def test_p014_result_is_failing_disposition(tmp_path: Path) -> None:
     assert all(derive_disposition(r) == Disposition.FAILING for r in p014_results)
 
 
+# ── P013/P014 additional coverage ─────────────────────────────────────────────
+
+# TEST 8 — multi-hop transitive resolution
+
+
+def test_p013_silent_on_multi_hop_valid_base(tmp_path: Path) -> None:
+    """FetchInput(MyBaseInput) where MyBaseInput(Input) across files → no P013."""
+    files = {
+        "base.py": (
+            "from application_sdk.contracts import Input\n"
+            "class MyBaseInput(Input):\n"
+            "    x: str = ''\n"
+        ),
+        "contracts.py": (
+            "from base import MyBaseInput\n"
+            "class FetchInput(MyBaseInput):\n"
+            "    y: int = 0\n"
+        ),
+        "out.py": (
+            "from application_sdk.contracts import Output\n"
+            "class FetchOutput(Output):\n"
+            "    rows: int = 0\n"
+        ),
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchInput\n"
+            "from out import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(self, input: FetchInput) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    assert [f for f in findings if f.rule_id == "P013"] == []
+
+
+def test_p013_fires_on_multi_hop_invalid_base(tmp_path: Path) -> None:
+    """FetchInput(MyBaseInput) where MyBaseInput(BaseModel) across files → P013."""
+    files = {
+        "base.py": (
+            "from pydantic import BaseModel\n"
+            "class MyBaseInput(BaseModel):\n"
+            "    x: str = ''\n"
+        ),
+        "contracts.py": (
+            "from base import MyBaseInput\n"
+            "class FetchInput(MyBaseInput):\n"
+            "    y: int = 0\n"
+        ),
+        "out.py": (
+            "from application_sdk.contracts import Output\n"
+            "class FetchOutput(Output):\n"
+            "    rows: int = 0\n"
+        ),
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchInput\n"
+            "from out import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(self, input: FetchInput) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert len(p013) == 1
+    assert "FetchInput" in p013[0].message
+
+
+# TEST 9 — attribute-form non-SDK entrypoint decorator
+
+
+def test_p013_silent_on_flask_entrypoint_attribute_form(tmp_path: Path) -> None:
+    """import flask; @flask.entrypoint → not P013 (provenance-excluded)."""
+    src = (
+        "import flask\n"
+        "\n"
+        "class Foo:\n"
+        "    @flask.entrypoint\n"
+        "    async def run_it(self, input: dict) -> dict:\n"
+        "        return {}\n"
+    )
+    findings = _scan_one(tmp_path, src)
+    assert [f for f in findings if f.rule_id == "P013"] == []
+
+
+# TEST 10 — cycle guard (no RecursionError)
+
+
+def test_p013_p014_cycle_in_class_hierarchy_no_error(tmp_path: Path) -> None:
+    """A cycle A(B)/B(A) in the scanned tree must not cause RecursionError.
+
+    A and B are in the scanned universe but don't reach Input/Output, so
+    findings ARE emitted — this test guards against crashes, not false positives.
+    """
+    src = (
+        "from application_sdk.app import App, entrypoint, task\n"
+        "\n"
+        "class A(B):\n"
+        "    pass\n"
+        "\n"
+        "class B(A):\n"
+        "    pass\n"
+        "\n"
+        "class MyApp(App):\n"
+        "    @entrypoint\n"
+        "    async def run_it(self, input: A) -> B:\n"
+        "        pass\n"
+        "\n"
+        "    @task\n"
+        "    async def fetch(self, input: B) -> A:\n"
+        "        pass\n"
+    )
+    # Must not raise RecursionError or any exception.
+    findings = _scan_one(tmp_path, src)
+    # A and B are in tree but don't reach Input/Output → findings emitted.
+    assert any(f.rule_id in ("P013", "P014") for f in findings)
+
+
+# TEST 11 — SDK-contract-import provenance fast-path
+
+
+def test_p013_silent_when_contracts_imported_directly_from_sdk(
+    tmp_path: Path,
+) -> None:
+    """from application_sdk.contracts import Input, Output → direct SDK import fast-path."""
+    src = (
+        "from application_sdk.contracts import Input, Output\n"
+        "from application_sdk.app import App, entrypoint\n"
+        "\n"
+        "class MyApp(App):\n"
+        "    @entrypoint\n"
+        "    async def run_it(self, input: Input) -> Output:\n"
+        "        pass\n"
+    )
+    findings = _scan_one(tmp_path, src)
+    assert [f for f in findings if f.rule_id == "P013"] == []
+
+
+# TEST 12 — arity-0 entrypoint silently skipped
+
+
+def test_p013_silent_on_arity_zero_entrypoint(tmp_path: Path) -> None:
+    """@entrypoint async def run_it(self) → arity-0, skipped (runtime rejects it)."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(self) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    assert [f for f in findings if f.rule_id == "P013"] == []
+
+
+# TEST 13 — Optional[...] / X | None unwrap for P013
+
+
+def test_p013_silent_on_optional_valid_input(tmp_path: Path) -> None:
+    """Optional[FetchInput] input annotation → valid after unwrap, no P013."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from typing import Optional\n"
+            "from contracts import FetchInput, FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(self, input: Optional[FetchInput]) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    assert [f for f in findings if f.rule_id == "P013"] == []
+
+
+def test_p013_fires_on_optional_dict_input(tmp_path: Path) -> None:
+    """Optional[dict] input annotation → unwraps to dict, still untyped, P013 fires."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from typing import Optional\n"
+            "from contracts import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(self, input: Optional[dict]) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert len(p013) == 1
+    assert "input" in p013[0].message
+
+
+# TEST 13 continued — Optional for P014
+
+
+def test_p014_silent_on_optional_valid_input(tmp_path: Path) -> None:
+    """Optional[FetchInput] input on @task → valid after unwrap, no P014."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from typing import Optional\n"
+            "from contracts import FetchInput, FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @task\n"
+            "    async def fetch(self, input: Optional[FetchInput]) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    assert [f for f in findings if f.rule_id == "P014"] == []
+
+
+def test_p014_fires_on_optional_dict_input(tmp_path: Path) -> None:
+    """Optional[dict] input on @task → unwraps to dict, still untyped, P014 fires."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from typing import Optional\n"
+            "from contracts import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @task\n"
+            "    async def fetch(self, input: Optional[dict]) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p014 = [f for f in findings if f.rule_id == "P014"]
+    assert len(p014) == 1
+    assert "input" in p014[0].message
+
+
+# BUG 1 regression — -> None return annotation fires
+
+
+def test_p013_fires_on_none_return_annotation(tmp_path: Path) -> None:
+    """@entrypoint with ``-> None`` return → treated as clearly untyped, P013 fires."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchInput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(self, input: FetchInput) -> None:\n"
+            "        pass\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert len(p013) == 1
+    assert "output" in p013[0].message
+
+
+def test_p014_fires_on_none_return_annotation(tmp_path: Path) -> None:
+    """@task with ``-> None`` return → treated as clearly untyped, P014 fires."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchInput\n"
+            "class MyApp(App):\n"
+            "    @task\n"
+            "    async def fetch(self, input: FetchInput) -> None:\n"
+            "        pass\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p014 = [f for f in findings if f.rule_id == "P014"]
+    assert len(p014) == 1
+    assert "output" in p014[0].message
+
+
+# BUG 3 regression — App aliased as BaseApp still fires for implicit run()
+
+
+def test_p013_fires_on_implicit_run_with_aliased_app_base(tmp_path: Path) -> None:
+    """from application_sdk.app import App as BaseApp; class MyApp(BaseApp) — implicit run() fires."""
+    src = (
+        "from application_sdk.app import App as BaseApp\n"
+        "\n"
+        "class MyApp(BaseApp):\n"
+        "    async def run(self, input: dict) -> dict:\n"
+        "        return {}\n"
+    )
+    findings = _scan_one(tmp_path, src)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert len(p013) >= 1
+
+
 # ── P015 UnmodeledBoundedContractField ────────────────────────────────────────
 
 
@@ -1563,6 +1855,19 @@ def test_p015_silent_on_non_contract_class(tmp_path: Path) -> None:
     """dict[str, str] field on a non-contract class → no P015."""
     src = "class SomeConfig:\n    settings: dict[str, str]\n"
     assert _p015_ids(src) == []
+
+
+def test_p015_fires_on_optional_annotated_dict(tmp_path: Path) -> None:
+    """Optional[Annotated[dict[str, str], MaxItems(50)]] → BUG 2 regression.
+
+    The unwrap loop must handle both Annotated-outer and Optional-outer orderings.
+    """
+    src = (
+        "from typing import Annotated, Optional\n"
+        "class FetchInput(Input):\n"
+        "    metadata: Optional[Annotated[dict[str, str], 'MaxItems(50)']]\n"
+    )
+    assert _p015_ids(src) == ["P015"]
 
 
 def test_p015_silent_on_foreign_output(tmp_path: Path) -> None:

--- a/packages/conformance/tests/test_prescriptions.py
+++ b/packages/conformance/tests/test_prescriptions.py
@@ -1921,3 +1921,151 @@ def test_p015_result_is_warning_disposition(tmp_path: Path) -> None:
     p015_results = [r for r in report.runs[0].results if r.rule_id == "P015"]
     assert len(p015_results) >= 1
     assert all(derive_disposition(r) == Disposition.WARNING for r in p015_results)
+
+
+# ── P013/P014 fixed-point unwrap regressions ──────────────────────────────────
+
+
+def test_p013_fires_on_optional_annotated_dict_input(tmp_path: Path) -> None:
+    """Optional[Annotated[dict[str,str], M]] input → fixed-point loop unwraps both layers → P013."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from typing import Annotated, Optional\n"
+            "from contracts import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(\n"
+            "        self, input: Optional[Annotated[dict[str, str], object()]]\n"
+            "    ) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert len(p013) == 1
+    assert "input" in p013[0].message
+
+
+def test_p014_fires_on_optional_annotated_dict_input(tmp_path: Path) -> None:
+    """Optional[Annotated[dict[str,str], M]] input on @task → P014."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from typing import Annotated, Optional\n"
+            "from contracts import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @task\n"
+            "    async def fetch(\n"
+            "        self, input: Optional[Annotated[dict[str, str], object()]]\n"
+            "    ) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p014 = [f for f in findings if f.rule_id == "P014"]
+    assert len(p014) == 1
+    assert "input" in p014[0].message
+
+
+def test_p013_fires_on_annotated_optional_dict_input(tmp_path: Path) -> None:
+    """Annotated[Optional[dict], M] input → outer Annotated then Optional unwrapped → P013."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from typing import Annotated, Optional\n"
+            "from contracts import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(\n"
+            "        self, input: Annotated[Optional[dict], object()]\n"
+            "    ) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert len(p013) == 1
+    assert "input" in p013[0].message
+
+
+# ── P013/P014 aliased SDK decorator regressions ───────────────────────────────
+
+
+def test_p013_fires_on_aliased_sdk_entrypoint_decorator(tmp_path: Path) -> None:
+    """from application_sdk.app import entrypoint as ep; @ep with dict input → P013."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            "from application_sdk.app import App\n"
+            "from application_sdk.app import entrypoint as ep\n"
+            "from contracts import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @ep\n"
+            "    async def run_it(self, input: dict) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert len(p013) == 1
+    assert "input" in p013[0].message
+
+
+def test_p014_fires_on_aliased_sdk_task_decorator(tmp_path: Path) -> None:
+    """from application_sdk.app import task as sdk_task; @sdk_task with dict input → P014."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            "from application_sdk.app import App\n"
+            "from application_sdk.app import task as sdk_task\n"
+            "from contracts import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @sdk_task\n"
+            "    async def fetch(self, input: dict) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p014 = [f for f in findings if f.rule_id == "P014"]
+    assert len(p014) == 1
+    assert "input" in p014[0].message
+
+
+# ── P013/P014 keyword-only parameter regressions ──────────────────────────────
+
+
+def test_p014_fires_on_kwonly_input(tmp_path: Path) -> None:
+    """def fetch(self, *, input: dict) — keyword-only param caught by _get_non_self_params → P014."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @task\n"
+            "    async def fetch(self, *, input: dict) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p014 = [f for f in findings if f.rule_id == "P014"]
+    assert len(p014) == 1
+    assert "input" in p014[0].message
+
+
+def test_p013_fires_on_kwonly_input(tmp_path: Path) -> None:
+    """def run_it(self, *, input: dict) — keyword-only input on @entrypoint → P013."""
+    files = {
+        "contracts.py": _TYPED_CONTRACTS,
+        "connector.py": (
+            _APP_IMPORTS + "from contracts import FetchOutput\n"
+            "class MyApp(App):\n"
+            "    @entrypoint\n"
+            "    async def run_it(self, *, input: dict) -> FetchOutput:\n"
+            "        return FetchOutput()\n"
+        ),
+    }
+    findings = _scan_files(tmp_path, files)
+    p013 = [f for f in findings if f.rule_id == "P013"]
+    assert len(p013) == 1
+    assert "input" in p013[0].message


### PR DESCRIPTION
## Summary

Adds three new APP-scoped, static prescription rules to the conformance suite (BLDX-1413 — _Typed-contract boundaries_):

- **P013 `UntypedEntrypointBoundary`** (BLOCK) — `@entrypoint` methods (and implicit `run()` overrides on `App` subclasses) must declare `Input`/`Output` subclasses as boundary types, not primitives, containers, or unrelated classes.
- **P014 `UntypedTaskBoundary`** (BLOCK) — same enforcement for `@task` methods.
- **P015 `UnmodeledBoundedContractField`** (WARN) — `Input`/`Output` contract fields annotated as containers of primitives/`Any` (`dict[str,str]`, `list[str]`, `Annotated[dict[...], MaxItems(N)]`) are nudged toward typed nested models.

The runtime `@entrypoint`/`@task` decorators already reject untyped boundaries at import time, so no conforming running app is untyped today — P013/P014 surface the violation earlier (PR/CI) and cover the implicit `run()` path and pre-decorator code paths.

## Implementation

- **`_typed_boundaries.py`** (new): cross-file P013/P014 checker. Mirrors `_framework_transfer.py` decorator-provenance gating (excludes `@celery.task`, etc.) and the P003 transitive-resolution pattern (`by_name` registry, cycle-safe memoised walk) generalised to targets `Input`/`Output`/`App`. Resolution is definitive for classes in the scanned tree — an external/unknown base does not degrade the parent's result to "unknown"; it simply fails to confirm the target.
- **`_contract_common.py`**: adds `unmodeled_container_name()` helper for P015.
- **`_contract_fields.py`**: adds `check_p015()` alongside `check_p011`/`check_p012`.
- **`prescriptions/__init__.py`**: wires P015 into `scan_text` + per-file pass of `scan_all`; collects `file_trees` in Pass 1; adds Pass 4 for P013/P014.
- **`prescriptions.md`**: regenerated via `gen-rule-docs`.

## Test plan

- [ ] `uv run pytest tests/test_prescriptions.py tests/test_catalog.py -q` → 146 pass, 1 xfail, 3 pre-existing `jsonschema`-missing failures unrelated to this change
- [ ] Catalog invariants: P-series exact set P001–P015 confirmed; P013/P014/P015 in `app_scoped` set confirmed
- [ ] P013/P014: fires on `dict`, `dict[str,str]`, `Any`, missing annotation, plain `BaseModel` subclass (in-tree); silent on correct `Input`/`Output` subclasses, third-party unresolvable annotations, `@celery.task`, `@signal`/`@query`, non-SDK `entrypoint`; implicit `run()` on `App` subclass covered; suppression via inline `# conformance: ignore[P013]` on the `def` line verified
- [ ] P015: fires on bare `dict`/`list`/`set`, `dict[str,str]`, `Dict[str,Any]`, `Annotated[dict[...],...]`; silent on `list[FooModel]`, `dict[str,FooModel]`, scalars, non-contract classes, foreign `Output`; WARN tier (gate always green)