### PR TITLE
fix(observability): forward daprd sidecar logs into the SDK pipeline

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -518,18 +518,6 @@ ENABLE_OBSERVABILITY_STORE_SINK: bool = (
     ).lower()
     == "true"
 )
-
-#: Forward the daprd sidecar's own logs into the SDK observability pipeline so
-#: they reach the same store sink (and, in SDR mode, the central lakehouse) as
-#: the application's logs. When enabled, the container entrypoint runs daprd
-#: under ``application_sdk.observability.dapr_log_forwarder``, which streams each
-#: daprd log line into a ``dapr.runtime`` logger while still echoing it to the
-#: container's own stdout. Defaults to off — daprd is chatty, so this is opt-in
-#: and pairs best with ``DAPR_LOG_LEVEL=warn``.
-ENABLE_DAPR_LOG_FORWARDING: bool = (
-    os.getenv("ATLAN_ENABLE_DAPR_LOG_FORWARDING", "false").lower() == "true"
-)
-
 # REMOVED: ATLAN_API_TOKEN_GUID, ATLAN_API_KEY, ATLAN_CLIENT_ID, ATLAN_CLIENT_SECRET — unused.
 # ATLAN_BASE_URL is still used by events interceptor (deferred import).
 ATLAN_BASE_URL = os.getenv("ATLAN_BASE_URL")

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -519,6 +519,17 @@ ENABLE_OBSERVABILITY_STORE_SINK: bool = (
     == "true"
 )
 
+#: Forward the daprd sidecar's own logs into the SDK observability pipeline so
+#: they reach the same store sink (and, in SDR mode, the central lakehouse) as
+#: the application's logs. When enabled, the container entrypoint runs daprd
+#: under ``application_sdk.observability.dapr_log_forwarder``, which streams each
+#: daprd log line into a ``dapr.runtime`` logger while still echoing it to the
+#: container's own stdout. Defaults to off — daprd is chatty, so this is opt-in
+#: and pairs best with ``DAPR_LOG_LEVEL=warn``.
+ENABLE_DAPR_LOG_FORWARDING: bool = (
+    os.getenv("ATLAN_ENABLE_DAPR_LOG_FORWARDING", "false").lower() == "true"
+)
+
 # REMOVED: ATLAN_API_TOKEN_GUID, ATLAN_API_KEY, ATLAN_CLIENT_ID, ATLAN_CLIENT_SECRET — unused.
 # ATLAN_BASE_URL is still used by events interceptor (deferred import).
 ATLAN_BASE_URL = os.getenv("ATLAN_BASE_URL")

--- a/application_sdk/observability/dapr_log_forwarder.py
+++ b/application_sdk/observability/dapr_log_forwarder.py
@@ -71,12 +71,12 @@ def _split_child_command(argv: list[str]) -> list[str]:
     return argv[1:]
 
 
-def _exec_transparently(child_cmd: list[str]) -> "None":
+def _exec_transparently(child_cmd: list[str]) -> None:
     """Replace this process with *child_cmd* (used when forwarding is disabled)."""
     os.execvp(child_cmd[0], child_cmd)
 
 
-def _make_emitter() -> "tuple[Any, Any]":
+def _make_emitter() -> tuple[Any, Any]:
     """Return ``(emit, complete)`` backed by the SDK logger.
 
     ``emit(level, message)`` never raises — if the SDK logger can't be set up it
@@ -116,7 +116,7 @@ def _make_emitter() -> "tuple[Any, Any]":
     return _emit, _complete
 
 
-def _format_line(raw: str) -> "tuple[str, str]":
+def _format_line(raw: str) -> tuple[str, str]:
     """Parse one daprd log line into ``(level, message)``.
 
     daprd emits JSON when run with ``--log-as-json``. The ``scope`` field (e.g.
@@ -139,13 +139,14 @@ def _format_line(raw: str) -> "tuple[str, str]":
     return level, message
 
 
-def _install_signal_forwarding(proc: "asyncio.subprocess.Process") -> None:
+def _install_signal_forwarding(proc: asyncio.subprocess.Process) -> None:
     """Forward SIGTERM/SIGINT to daprd so its graceful shutdown runs."""
 
     def _forward(signum: int) -> None:
         if proc.returncode is None:
             try:
                 proc.send_signal(signum)
+            # conformance: ignore[E002] TOCTOU race: daprd exited between returncode check and send_signal; no logger available in this signal-handler closure
             except ProcessLookupError:  # pragma: no cover - daprd already gone
                 pass
 
@@ -157,7 +158,7 @@ def _install_signal_forwarding(proc: "asyncio.subprocess.Process") -> None:
             signal.signal(sig, lambda s, _f: _forward(s))
 
 
-async def _drain_and_flush(complete: "Any") -> None:
+async def _drain_and_flush(complete: Any) -> None:
     """Drain async sinks and flush buffered records so daprd logs aren't lost."""
     if complete is not None:
         try:
@@ -174,7 +175,7 @@ async def _drain_and_flush(complete: "Any") -> None:
         pass
 
 
-async def _periodic_drain_flush(complete: "Any", interval: float) -> None:
+async def _periodic_drain_flush(complete: Any, interval: float) -> None:
     """Drain + upload buffered records on this loop, every *interval* seconds.
 
     We can't rely on the SDK's own periodic flush here: this forwarder imports
@@ -227,6 +228,7 @@ async def _run(child_cmd: list[str]) -> int:
         flusher.cancel()
         try:
             await flusher
+        # conformance: ignore[E002] expected: CancelledError is the normal result of awaiting an explicitly cancelled asyncio task
         except asyncio.CancelledError:
             pass
         returncode = await proc.wait()
@@ -235,7 +237,7 @@ async def _run(child_cmd: list[str]) -> int:
     return returncode
 
 
-def main(argv: "list[str] | None" = None) -> int:
+def main(argv: list[str] | None = None) -> int:
     """Run daprd as a child and forward its logs to the observability pipeline."""
     argv = list(sys.argv if argv is None else argv)
     child_cmd = _split_child_command(argv)

--- a/application_sdk/observability/dapr_log_forwarder.py
+++ b/application_sdk/observability/dapr_log_forwarder.py
@@ -1,0 +1,201 @@
+"""Forward the daprd sidecar's logs into the SDK observability pipeline.
+
+In production the container entrypoint launches ``daprd`` as a sibling process
+of the Python application, so daprd's own logs go straight to the container's
+stdout/stderr and never reach the SDK observability sink — which means, in SDR
+mode, they never reach the central lakehouse either. Operators can only see them
+by reading the customer's pod/container logs directly.
+
+This module closes that gap. When ``ATLAN_ENABLE_DAPR_LOG_FORWARDING`` is set,
+the entrypoint runs daprd *under* this module:
+
+    python -m application_sdk.observability.dapr_log_forwarder -- daprd <flags> --log-as-json
+
+It spawns daprd as a child, reads its (JSON) log stream line by line, and
+re-emits each line through a ``dapr.runtime`` logger obtained from
+:func:`application_sdk.observability.logger_adaptor.get_logger`. Those records
+flow through the same handler → loguru → store-sink path as the app's own logs,
+so they land in the lakehouse ``app_logs`` table with ``app_name`` / ``is_sdr``
+populated. The SDK logger's existing stdout/stderr sinks keep the lines visible
+in the container's own logs too, so nothing is lost from ``kubectl logs``.
+
+Design constraints:
+
+* **Never take daprd down.** Forwarding is best-effort: any failure to parse or
+  emit a line falls back to writing the raw line to stderr; daprd keeps running.
+* **Preserve graceful shutdown.** SIGTERM/SIGINT are forwarded to daprd so its
+  ``--dapr-graceful-shutdown-seconds`` behaviour (the reason the entrypoint runs
+  daprd directly) is unchanged. This process exits with daprd's exit code.
+* **Transparent when disabled.** If the flag is off, the child command is exec'd
+  directly with zero overhead, so the process tree and PID semantics match
+  running daprd without the wrapper.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+from typing import Any
+
+# daprd (logrus) log levels → AtlanLoggerAdapter method names.
+_LEVEL_TO_METHOD = {
+    "debug": "debug",
+    "info": "info",
+    "warning": "warning",
+    "warn": "warning",
+    "error": "error",
+    "fatal": "critical",
+    "panic": "critical",
+}
+
+
+def _split_child_command(argv: list[str]) -> list[str]:
+    """Return the child command — everything after the first ``--`` separator.
+
+    Falls back to all args (minus the program name) if no separator is present.
+    """
+    if "--" in argv:
+        return argv[argv.index("--") + 1 :]
+    return argv[1:]
+
+
+def _exec_transparently(child_cmd: list[str]) -> "None":
+    """Replace this process with *child_cmd* (used when forwarding is disabled)."""
+    os.execvp(child_cmd[0], child_cmd)
+
+
+def _make_emitter() -> "Any":
+    """Build a best-effort ``emit(level, message)`` callable backed by the SDK logger.
+
+    Returns a callable that never raises. If the SDK logger can't be set up, the
+    callable falls back to writing the message to stderr so the line is never
+    silently dropped.
+    """
+
+    def _stderr_fallback(_level: str, message: str) -> None:
+        # Deliberate stderr write: this path runs when the SDK logger itself is
+        # unavailable/failing, so we must not route through it.
+        print(message, file=sys.stderr, flush=True)  # noqa: T201
+
+    try:
+        from application_sdk.observability.logger_adaptor import (  # noqa: PLC0415 — deferred: avoid importing the heavy logging stack at module load
+            get_logger,
+        )
+
+        logger = get_logger("dapr.runtime")
+    except Exception:  # pragma: no cover - defensive: logging must never break daprd
+        return _stderr_fallback
+
+    def _emit(level: str, message: str) -> None:
+        try:
+            method = getattr(logger, _LEVEL_TO_METHOD.get(level, "info"), logger.info)
+            method(message)
+        except Exception:
+            _stderr_fallback(level, message)
+
+    return _emit
+
+
+def _format_line(raw: str) -> "tuple[str, str]":
+    """Parse one daprd log line into ``(level, message)``.
+
+    daprd emits JSON when run with ``--log-as-json``. The ``scope`` field (e.g.
+    ``dapr.runtime.loader.disk``) is folded into the message so it stays
+    queryable in the lakehouse ``message`` column regardless of which structured
+    fields the schema retains. Non-JSON lines are forwarded verbatim at INFO.
+    """
+    raw = raw.rstrip("\n")
+    try:
+        record = json.loads(raw)
+        if not isinstance(record, dict):
+            return "info", raw
+    except (json.JSONDecodeError, ValueError):
+        return "info", raw
+
+    level = str(record.get("level", "info")).lower()
+    msg = str(record.get("msg", raw))
+    scope = record.get("scope")
+    message = f"[{scope}] {msg}" if scope else msg
+    return level, message
+
+
+def _flush_observability() -> None:
+    """Flush buffered observability records so daprd logs aren't lost on exit."""
+    try:
+        import asyncio  # noqa: PLC0415 — deferred: only needed on shutdown
+
+        from application_sdk.observability.observability import (  # noqa: PLC0415 — deferred: cold shutdown path
+            AtlanObservability,
+        )
+
+        asyncio.run(AtlanObservability.flush_all())
+    except Exception:  # noqa: S110 — pragma: no cover; best-effort shutdown flush
+        pass
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    """Run daprd as a child and forward its logs to the observability pipeline."""
+    argv = list(sys.argv if argv is None else argv)
+    child_cmd = _split_child_command(argv)
+    if not child_cmd:
+        print(  # noqa: T201 — startup arg error, before any logger is set up
+            "dapr_log_forwarder: no child command supplied (expected '-- daprd ...')",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Defensive double-gate: if forwarding is off, behave exactly like running
+    # the child directly. The entrypoint only wraps when the flag is on, but this
+    # keeps the module safe to invoke unconditionally.
+    from application_sdk.constants import (  # noqa: PLC0415 — deferred: read at call time so the flag is patchable/env-fresh
+        ENABLE_DAPR_LOG_FORWARDING,
+    )
+
+    if not ENABLE_DAPR_LOG_FORWARDING:
+        _exec_transparently(child_cmd)  # never returns
+
+    emit = _make_emitter()
+
+    proc = subprocess.Popen(
+        child_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,  # line-buffered
+    )
+
+    # Forward termination signals to daprd; let its graceful shutdown run and the
+    # read loop drain to EOF naturally rather than exiting abruptly here.
+    def _forward_signal(signum: int, _frame: "Any") -> None:
+        if proc.poll() is None:
+            try:
+                proc.send_signal(signum)
+            except Exception:  # noqa: S110 — pragma: no cover; daprd may have just exited
+                pass
+
+    signal.signal(signal.SIGTERM, _forward_signal)
+    signal.signal(signal.SIGINT, _forward_signal)
+
+    try:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            if not line:
+                continue
+            try:
+                level, message = _format_line(line)
+                emit(level, message)
+            except Exception:
+                # Forwarding must never interrupt the stream — fall back to raw.
+                print(line.rstrip("\n"), file=sys.stderr, flush=True)  # noqa: T201
+    finally:
+        returncode = proc.wait()
+        _flush_observability()
+
+    return returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/application_sdk/observability/dapr_log_forwarder.py
+++ b/application_sdk/observability/dapr_log_forwarder.py
@@ -12,10 +12,6 @@ collector — the entrypoint runs daprd *under* this module:
 
     python -m application_sdk.observability.dapr_log_forwarder -- daprd <flags> --log-as-json
 
-On atlan-infra (``ENABLE_ATLAN_UPLOAD=false``) the node-level filelog collector
-already scrapes the container's stdout (daprd included), so forwarding is a
-no-op there and the child is exec'd directly.
-
 It spawns daprd as a child, reads its (JSON) log stream line by line, and
 re-emits each line through a ``dapr.runtime`` logger obtained from
 :func:`application_sdk.observability.logger_adaptor.get_logger`. Those records
@@ -24,24 +20,32 @@ so they land in the lakehouse ``app_logs`` table with ``app_name`` / ``is_sdr``
 populated. The SDK logger's existing stdout/stderr sinks keep the lines visible
 in the container's own logs too, so nothing is lost from ``kubectl logs``.
 
+On atlan-infra (``ENABLE_ATLAN_UPLOAD=false``) the node-level filelog collector
+already scrapes the container's stdout (daprd included), so forwarding is a
+no-op there and the child is exec'd directly.
+
 Design constraints:
 
+* **Run under an event loop.** The SDK's store sink (``parquet_sink``) is an
+  async loguru sink: records only get buffered for upload while an event loop is
+  running in the emitting thread. So the read/emit loop runs inside
+  ``asyncio.run`` and drains the sink (``logger.complete()`` + ``flush_all()``)
+  before exit — otherwise lines reach stdout but never the lakehouse.
 * **Never take daprd down.** Forwarding is best-effort: any failure to parse or
   emit a line falls back to writing the raw line to stderr; daprd keeps running.
 * **Preserve graceful shutdown.** SIGTERM/SIGINT are forwarded to daprd so its
   ``--dapr-graceful-shutdown-seconds`` behaviour (the reason the entrypoint runs
   daprd directly) is unchanged. This process exits with daprd's exit code.
-* **Transparent when disabled.** If the flag is off, the child command is exec'd
-  directly with zero overhead, so the process tree and PID semantics match
-  running daprd without the wrapper.
+* **Transparent when disabled.** Outside SDR mode the child is exec'd directly,
+  so the process tree and PID semantics match running daprd without the wrapper.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import signal
-import subprocess
 import sys
 from typing import Any
 
@@ -72,12 +76,14 @@ def _exec_transparently(child_cmd: list[str]) -> "None":
     os.execvp(child_cmd[0], child_cmd)
 
 
-def _make_emitter() -> "Any":
-    """Build a best-effort ``emit(level, message)`` callable backed by the SDK logger.
+def _make_emitter() -> "tuple[Any, Any]":
+    """Return ``(emit, complete)`` backed by the SDK logger.
 
-    Returns a callable that never raises. If the SDK logger can't be set up, the
-    callable falls back to writing the message to stderr so the line is never
-    silently dropped.
+    ``emit(level, message)`` never raises — if the SDK logger can't be set up it
+    falls back to writing the message to stderr so the line is never silently
+    dropped. ``complete`` is an awaitable that drains loguru's async sinks (so
+    buffered records reach the upload buffer), or ``None`` if logging is
+    unavailable.
     """
 
     def _stderr_fallback(_level: str, message: str) -> None:
@@ -90,9 +96,11 @@ def _make_emitter() -> "Any":
             get_logger,
         )
 
+        # Created inside the running loop (see main) so the SDK's async store
+        # sink and periodic flush bind to that loop.
         logger = get_logger("dapr.runtime")
     except Exception:  # pragma: no cover - defensive: logging must never break daprd
-        return _stderr_fallback
+        return _stderr_fallback, None
 
     def _emit(level: str, message: str) -> None:
         try:
@@ -101,7 +109,11 @@ def _make_emitter() -> "Any":
         except Exception:
             _stderr_fallback(level, message)
 
-    return _emit
+    async def _complete() -> None:
+        # Drain loguru's pending coroutine-sink tasks into the upload buffer.
+        await logger.logger.complete()
+
+    return _emit, _complete
 
 
 def _format_line(raw: str) -> "tuple[str, str]":
@@ -127,18 +139,67 @@ def _format_line(raw: str) -> "tuple[str, str]":
     return level, message
 
 
-def _flush_observability() -> None:
-    """Flush buffered observability records so daprd logs aren't lost on exit."""
-    try:
-        import asyncio  # noqa: PLC0415 — deferred: only needed on shutdown
+def _install_signal_forwarding(proc: "asyncio.subprocess.Process") -> None:
+    """Forward SIGTERM/SIGINT to daprd so its graceful shutdown runs."""
 
+    def _forward(signum: int) -> None:
+        if proc.returncode is None:
+            try:
+                proc.send_signal(signum)
+            except ProcessLookupError:  # pragma: no cover - daprd already gone
+                pass
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, _forward, sig)
+        except (NotImplementedError, RuntimeError):  # pragma: no cover - non-Unix
+            signal.signal(sig, lambda s, _f: _forward(s))
+
+
+async def _drain_and_flush(complete: "Any") -> None:
+    """Drain async sinks and flush buffered records so daprd logs aren't lost."""
+    if complete is not None:
+        try:
+            await complete()
+        except Exception:  # noqa: S110 — best-effort drain
+            pass
+    try:
         from application_sdk.observability.observability import (  # noqa: PLC0415 — deferred: cold shutdown path
             AtlanObservability,
         )
 
-        asyncio.run(AtlanObservability.flush_all())
-    except Exception:  # noqa: S110 — pragma: no cover; best-effort shutdown flush
+        await AtlanObservability.flush_all()
+    except Exception:  # noqa: S110 — best-effort shutdown flush
         pass
+
+
+async def _run(child_cmd: list[str]) -> int:
+    """Spawn daprd, forward its logs through the SDK pipeline, return its code."""
+    emit, complete = _make_emitter()
+
+    proc = await asyncio.create_subprocess_exec(
+        *child_cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    _install_signal_forwarding(proc)
+
+    try:
+        assert proc.stdout is not None
+        async for raw in proc.stdout:
+            line = raw.decode("utf-8", errors="replace")
+            try:
+                level, message = _format_line(line)
+                emit(level, message)
+            except Exception:
+                # Forwarding must never interrupt the stream — fall back to raw.
+                print(line.rstrip("\n"), file=sys.stderr, flush=True)  # noqa: T201
+    finally:
+        returncode = await proc.wait()
+        await _drain_and_flush(complete)
+
+    return returncode
 
 
 def main(argv: "list[str] | None" = None) -> int:
@@ -163,44 +224,7 @@ def main(argv: "list[str] | None" = None) -> int:
     if not ENABLE_ATLAN_UPLOAD:
         _exec_transparently(child_cmd)  # never returns
 
-    emit = _make_emitter()
-
-    proc = subprocess.Popen(
-        child_cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,  # line-buffered
-    )
-
-    # Forward termination signals to daprd; let its graceful shutdown run and the
-    # read loop drain to EOF naturally rather than exiting abruptly here.
-    def _forward_signal(signum: int, _frame: "Any") -> None:
-        if proc.poll() is None:
-            try:
-                proc.send_signal(signum)
-            except Exception:  # noqa: S110 — pragma: no cover; daprd may have just exited
-                pass
-
-    signal.signal(signal.SIGTERM, _forward_signal)
-    signal.signal(signal.SIGINT, _forward_signal)
-
-    try:
-        assert proc.stdout is not None
-        for line in proc.stdout:
-            if not line:
-                continue
-            try:
-                level, message = _format_line(line)
-                emit(level, message)
-            except Exception:
-                # Forwarding must never interrupt the stream — fall back to raw.
-                print(line.rstrip("\n"), file=sys.stderr, flush=True)  # noqa: T201
-    finally:
-        returncode = proc.wait()
-        _flush_observability()
-
-    return returncode
+    return asyncio.run(_run(child_cmd))
 
 
 if __name__ == "__main__":

--- a/application_sdk/observability/dapr_log_forwarder.py
+++ b/application_sdk/observability/dapr_log_forwarder.py
@@ -228,6 +228,7 @@ async def _run(child_cmd: list[str]) -> int:
                 chunk = await proc.stdout.readexactly(exc.consumed)
                 try:
                     await proc.stdout.readuntil(b"\n")
+                # conformance: ignore[E002] draining the remainder of an oversized line; both exceptions are expected best-effort outcomes (further overrun or EOF mid-line)
                 except (asyncio.LimitOverrunError, asyncio.IncompleteReadError):
                     pass
                 prefix = chunk[:256].decode("utf-8", errors="replace").rstrip("\n")

--- a/application_sdk/observability/dapr_log_forwarder.py
+++ b/application_sdk/observability/dapr_log_forwarder.py
@@ -203,6 +203,9 @@ async def _run(child_cmd: list[str]) -> int:
         *child_cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
+        limit=2
+        * 1024
+        * 1024,  # 2 MiB — panic/stack traces can exceed the 64 KiB default
     )
     _install_signal_forwarding(proc)
 
@@ -216,7 +219,26 @@ async def _run(child_cmd: list[str]) -> int:
 
     try:
         assert proc.stdout is not None
-        async for raw in proc.stdout:
+        while True:
+            try:
+                raw = await proc.stdout.readuntil(b"\n")
+            except asyncio.LimitOverrunError as exc:
+                # Line longer than 2 MiB — forward a truncated prefix so the line
+                # is never silently dropped, then drain the rest of it.
+                chunk = await proc.stdout.readexactly(exc.consumed)
+                try:
+                    await proc.stdout.readuntil(b"\n")
+                except (asyncio.LimitOverrunError, asyncio.IncompleteReadError):
+                    pass
+                prefix = chunk[:256].decode("utf-8", errors="replace").rstrip("\n")
+                emit("warning", f"{prefix} ...[{exc.consumed} bytes, line truncated]")
+                continue
+            except asyncio.IncompleteReadError as exc:
+                # EOF — process any trailing bytes without a final newline.
+                if exc.partial:
+                    raw = exc.partial
+                else:
+                    break
             line = raw.decode("utf-8", errors="replace")
             try:
                 level, message = _format_line(line)
@@ -248,10 +270,10 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
-    # Defensive double-gate: forwarding is only meaningful in SDR mode, where the
-    # app runs on customer infra with no node-level log collector. Outside SDR
-    # mode, behave exactly like running the child directly. The entrypoint only
-    # wraps in SDR mode, but this keeps the module safe to invoke unconditionally.
+    # Defensive double-gate: the entrypoint.sh already gates the forwarder on
+    # ENABLE_ATLAN_UPLOAD, but `python -m application_sdk.observability.dapr_log_forwarder`
+    # is a documented entry point ("safe to invoke unconditionally"), so this gate
+    # makes direct invocation safe regardless of the environment.
     from application_sdk.constants import (  # noqa: PLC0415 — deferred: read at call time so the flag is env-fresh/patchable
         ENABLE_ATLAN_UPLOAD,
     )

--- a/application_sdk/observability/dapr_log_forwarder.py
+++ b/application_sdk/observability/dapr_log_forwarder.py
@@ -6,10 +6,15 @@ stdout/stderr and never reach the SDK observability sink — which means, in SDR
 mode, they never reach the central lakehouse either. Operators can only see them
 by reading the customer's pod/container logs directly.
 
-This module closes that gap. When ``ATLAN_ENABLE_DAPR_LOG_FORWARDING`` is set,
-the entrypoint runs daprd *under* this module:
+This module closes that gap. In SDR mode (``ENABLE_ATLAN_UPLOAD=true``) — the
+same signal that tells the app it runs on customer infra with no node-level log
+collector — the entrypoint runs daprd *under* this module:
 
     python -m application_sdk.observability.dapr_log_forwarder -- daprd <flags> --log-as-json
+
+On atlan-infra (``ENABLE_ATLAN_UPLOAD=false``) the node-level filelog collector
+already scrapes the container's stdout (daprd included), so forwarding is a
+no-op there and the child is exec'd directly.
 
 It spawns daprd as a child, reads its (JSON) log stream line by line, and
 re-emits each line through a ``dapr.runtime`` logger obtained from
@@ -147,14 +152,15 @@ def main(argv: "list[str] | None" = None) -> int:
         )
         return 2
 
-    # Defensive double-gate: if forwarding is off, behave exactly like running
-    # the child directly. The entrypoint only wraps when the flag is on, but this
-    # keeps the module safe to invoke unconditionally.
-    from application_sdk.constants import (  # noqa: PLC0415 — deferred: read at call time so the flag is patchable/env-fresh
-        ENABLE_DAPR_LOG_FORWARDING,
+    # Defensive double-gate: forwarding is only meaningful in SDR mode, where the
+    # app runs on customer infra with no node-level log collector. Outside SDR
+    # mode, behave exactly like running the child directly. The entrypoint only
+    # wraps in SDR mode, but this keeps the module safe to invoke unconditionally.
+    from application_sdk.constants import (  # noqa: PLC0415 — deferred: read at call time so the flag is env-fresh/patchable
+        ENABLE_ATLAN_UPLOAD,
     )
 
-    if not ENABLE_DAPR_LOG_FORWARDING:
+    if not ENABLE_ATLAN_UPLOAD:
         _exec_transparently(child_cmd)  # never returns
 
     emit = _make_emitter()

--- a/application_sdk/observability/dapr_log_forwarder.py
+++ b/application_sdk/observability/dapr_log_forwarder.py
@@ -170,8 +170,28 @@ async def _drain_and_flush(complete: "Any") -> None:
         )
 
         await AtlanObservability.flush_all()
-    except Exception:  # noqa: S110 — best-effort shutdown flush
+    except Exception:  # noqa: S110 — best-effort flush
         pass
+
+
+async def _periodic_drain_flush(complete: "Any", interval: float) -> None:
+    """Drain + upload buffered records on this loop, every *interval* seconds.
+
+    We can't rely on the SDK's own periodic flush here: this forwarder imports
+    SDK modules before the event loop starts, so the SDK's flush task binds to a
+    background thread (the no-running-loop fallback) which doesn't reliably
+    upload from this second process. Driving the flush on the forwarder's own
+    loop makes delivery deterministic. Unlike the SDK's task, this stays alive
+    across transient upload errors instead of dying on the first one.
+    """
+    while True:
+        try:
+            await asyncio.sleep(interval)
+            await _drain_and_flush(complete)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: S110 — keep flushing across transient errors
+            pass
 
 
 async def _run(child_cmd: list[str]) -> int:
@@ -185,6 +205,14 @@ async def _run(child_cmd: list[str]) -> int:
     )
     _install_signal_forwarding(proc)
 
+    from application_sdk.constants import (  # noqa: PLC0415 — deferred: env-driven flush cadence
+        LOG_FLUSH_INTERVAL_SECONDS,
+    )
+
+    flusher = asyncio.create_task(
+        _periodic_drain_flush(complete, LOG_FLUSH_INTERVAL_SECONDS)
+    )
+
     try:
         assert proc.stdout is not None
         async for raw in proc.stdout:
@@ -196,6 +224,11 @@ async def _run(child_cmd: list[str]) -> int:
                 # Forwarding must never interrupt the stream — fall back to raw.
                 print(line.rstrip("\n"), file=sys.stderr, flush=True)  # noqa: T201
     finally:
+        flusher.cancel()
+        try:
+            await flusher
+        except asyncio.CancelledError:
+            pass
         returncode = await proc.wait()
         await _drain_and_flush(complete)
 

--- a/docs/concepts/monitoring.md
+++ b/docs/concepts/monitoring.md
@@ -251,3 +251,23 @@ ATLAN_LOG_FLUSH_INTERVAL_SECONDS=10
 ```
 
 See [Configuration](../configuration.md#logging) for all observability variables.
+
+---
+
+## Forwarding daprd Sidecar Logs
+
+By default the `daprd` sidecar's own logs go straight to the container's stdout/stderr and never enter the SDK observability pipeline — so in SDR (customer-infra) deployments, where there's no node-level log collector, they never reach the central lakehouse. They're only visible in the customer's own pod/container logs.
+
+Enable forwarding to route daprd's logs through the SDK pipeline (the same path as the app's own logs, so they land in the lakehouse `app_logs` table with `app_name` / `is_sdr` populated), while still echoing them to the container's own logs:
+
+```bash
+ATLAN_ENABLE_DAPR_LOG_FORWARDING=true   # default: false
+```
+
+When enabled, the container entrypoint runs daprd under `application_sdk.observability.dapr_log_forwarder`, which streams each daprd log line into a `dapr.runtime` logger and forwards `SIGTERM` so graceful shutdown is unaffected. daprd is chatty, so this is opt-in and pairs best with a conservative source level:
+
+```bash
+DAPR_LOG_LEVEL=warn   # forward warn + error (and above); raise to error to drop the rest
+```
+
+`DAPR_LOG_LEVEL` is a minimum-severity floor at the source — `warn` captures both warnings **and** errors. It's the recommended knob for controlling daprd log volume reaching the lakehouse.

--- a/docs/concepts/monitoring.md
+++ b/docs/concepts/monitoring.md
@@ -263,6 +263,8 @@ The `daprd` sidecar's own logs go straight to the container's stdout/stderr and 
 
 So in SDR mode the SDK **automatically** forwards daprd's logs through its own pipeline (the same path as the app's logs, so they land in the lakehouse `app_logs` table with `app_name` / `is_sdr` populated), while still echoing them to the container's own logs. No configuration is required — it is gated on `ENABLE_ATLAN_UPLOAD`. Under the hood the container entrypoint runs daprd under `application_sdk.observability.dapr_log_forwarder`, which streams each daprd log line into a `dapr.runtime` logger and forwards `SIGTERM` so graceful shutdown is unaffected.
 
+> **Note (`kubectl logs` format in SDR mode):** In SDR mode daprd's stdout/stderr is piped into the forwarder, so `kubectl logs` shows the SDK's re-emitted format (with level, `app_name`, timestamp) rather than daprd's raw `--log-as-json` lines. The content is the same; only the format differs.
+
 daprd is chatty, so control the volume at the source with its log level:
 
 ```bash

--- a/docs/concepts/monitoring.md
+++ b/docs/concepts/monitoring.md
@@ -256,18 +256,17 @@ See [Configuration](../configuration.md#logging) for all observability variables
 
 ## Forwarding daprd Sidecar Logs
 
-By default the `daprd` sidecar's own logs go straight to the container's stdout/stderr and never enter the SDK observability pipeline — so in SDR (customer-infra) deployments, where there's no node-level log collector, they never reach the central lakehouse. They're only visible in the customer's own pod/container logs.
+The `daprd` sidecar's own logs go straight to the container's stdout/stderr and don't enter the SDK observability pipeline on their own.
 
-Enable forwarding to route daprd's logs through the SDK pipeline (the same path as the app's own logs, so they land in the lakehouse `app_logs` table with `app_name` / `is_sdr` populated), while still echoing them to the container's own logs:
+- **On atlan-infra** (`ENABLE_ATLAN_UPLOAD=false`) this is fine: a node-level filelog collector scrapes every container's stdout — daprd included — and ships it to the central log backend.
+- **In SDR mode** (`ENABLE_ATLAN_UPLOAD=true`, i.e. customer infra) there is **no** such node-level collector, so daprd's logs would be invisible to Atlan — only present in the customer's own pod logs.
 
-```bash
-ATLAN_ENABLE_DAPR_LOG_FORWARDING=true   # default: false
-```
+So in SDR mode the SDK **automatically** forwards daprd's logs through its own pipeline (the same path as the app's logs, so they land in the lakehouse `app_logs` table with `app_name` / `is_sdr` populated), while still echoing them to the container's own logs. No configuration is required — it is gated on `ENABLE_ATLAN_UPLOAD`. Under the hood the container entrypoint runs daprd under `application_sdk.observability.dapr_log_forwarder`, which streams each daprd log line into a `dapr.runtime` logger and forwards `SIGTERM` so graceful shutdown is unaffected.
 
-When enabled, the container entrypoint runs daprd under `application_sdk.observability.dapr_log_forwarder`, which streams each daprd log line into a `dapr.runtime` logger and forwards `SIGTERM` so graceful shutdown is unaffected. daprd is chatty, so this is opt-in and pairs best with a conservative source level:
+daprd is chatty, so control the volume at the source with its log level:
 
 ```bash
 DAPR_LOG_LEVEL=warn   # forward warn + error (and above); raise to error to drop the rest
 ```
 
-`DAPR_LOG_LEVEL` is a minimum-severity floor at the source — `warn` captures both warnings **and** errors. It's the recommended knob for controlling daprd log volume reaching the lakehouse.
+`DAPR_LOG_LEVEL` is a minimum-severity floor — `warn` captures both warnings **and** errors. It's the recommended knob for controlling daprd log volume reaching the lakehouse.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -213,6 +213,7 @@ Used by `RedisCapacityPool` for distributed slot locking. Leave empty if you use
 | `OTEL_BATCH_SIZE` | `512` | Maximum export batch size. |
 | `OTEL_QUEUE_SIZE` | `2048` | Maximum export queue size. |
 | `ATLAN_ENABLE_OBSERVABILITY_STORE_SINK` | `true` | Write observability data to the object store sink. **Fallback:** `ATLAN_ENABLE_OBSERVABILITY_DAPR_SINK`. |
+| `ATLAN_ENABLE_DAPR_LOG_FORWARDING` | `false` | Forward the daprd sidecar's own logs into the SDK observability pipeline (and, in SDR mode, the central lakehouse). Opt-in; pairs best with `DAPR_LOG_LEVEL=warn`. |
 | `ATLAN_BASE_URL` | _(empty)_ | Atlan instance base URL. Used by the events interceptor. |
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -213,7 +213,6 @@ Used by `RedisCapacityPool` for distributed slot locking. Leave empty if you use
 | `OTEL_BATCH_SIZE` | `512` | Maximum export batch size. |
 | `OTEL_QUEUE_SIZE` | `2048` | Maximum export queue size. |
 | `ATLAN_ENABLE_OBSERVABILITY_STORE_SINK` | `true` | Write observability data to the object store sink. **Fallback:** `ATLAN_ENABLE_OBSERVABILITY_DAPR_SINK`. |
-| `ATLAN_ENABLE_DAPR_LOG_FORWARDING` | `false` | Forward the daprd sidecar's own logs into the SDK observability pipeline (and, in SDR mode, the central lakehouse). Opt-in; pairs best with `DAPR_LOG_LEVEL=warn`. |
 | `ATLAN_BASE_URL` | _(empty)_ | Atlan instance base URL. Used by the events interceptor. |
 
 ---

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,16 +82,18 @@ echo "[entrypoint]   metrics-port:    ${DAPR_METRICS_PORT}"
 echo "[entrypoint]   max-body-size:   ${DAPR_MAX_BODY_SIZE}"
 echo "[entrypoint]   graceful-shutdown-seconds: ${DAPR_GRACEFUL_SHUTDOWN_SECONDS}"
 
-# Optionally forward daprd's own logs into the SDK observability pipeline so they
-# reach the same store sink (and, in SDR mode, the central lakehouse) as the app.
-# When enabled, daprd runs under the forwarder module (which streams its JSON log
-# lines to a dapr.runtime logger and forwards SIGTERM for graceful shutdown) and
-# emits structured JSON so the forwarder can parse it. When disabled, both
-# variables expand to nothing and daprd is launched exactly as before.
+# In SDR mode (ENABLE_ATLAN_UPLOAD=true) the app runs on customer infra with no
+# node-level log collector, so daprd's logs would otherwise be invisible to
+# Atlan. Forward them into the SDK observability pipeline (the same path that
+# reaches the central lakehouse): daprd runs under the forwarder module, which
+# streams its JSON log lines to a dapr.runtime logger and forwards SIGTERM for
+# graceful shutdown. On atlan-infra (ENABLE_ATLAN_UPLOAD!=true) the node-level
+# filelog collector already captures daprd's stdout, so both variables expand to
+# nothing and daprd is launched exactly as before.
 DAPR_LOG_FORWARDER=""
 DAPR_LOG_FORMAT_FLAG=""
-if [ "${ATLAN_ENABLE_DAPR_LOG_FORWARDING:-false}" = "true" ]; then
-    echo "[entrypoint] daprd log forwarding enabled — routing daprd logs through the SDK observability pipeline"
+if [ "$(echo "${ENABLE_ATLAN_UPLOAD:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
+    echo "[entrypoint] SDR mode (ENABLE_ATLAN_UPLOAD=true) — forwarding daprd logs through the SDK observability pipeline"
     DAPR_LOG_FORWARDER="uv run --no-sync python -m application_sdk.observability.dapr_log_forwarder --"
     DAPR_LOG_FORMAT_FLAG="--log-as-json"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,7 +82,24 @@ echo "[entrypoint]   metrics-port:    ${DAPR_METRICS_PORT}"
 echo "[entrypoint]   max-body-size:   ${DAPR_MAX_BODY_SIZE}"
 echo "[entrypoint]   graceful-shutdown-seconds: ${DAPR_GRACEFUL_SHUTDOWN_SECONDS}"
 
-daprd \
+# Optionally forward daprd's own logs into the SDK observability pipeline so they
+# reach the same store sink (and, in SDR mode, the central lakehouse) as the app.
+# When enabled, daprd runs under the forwarder module (which streams its JSON log
+# lines to a dapr.runtime logger and forwards SIGTERM for graceful shutdown) and
+# emits structured JSON so the forwarder can parse it. When disabled, both
+# variables expand to nothing and daprd is launched exactly as before.
+DAPR_LOG_FORWARDER=""
+DAPR_LOG_FORMAT_FLAG=""
+if [ "${ATLAN_ENABLE_DAPR_LOG_FORWARDING:-false}" = "true" ]; then
+    echo "[entrypoint] daprd log forwarding enabled — routing daprd logs through the SDK observability pipeline"
+    DAPR_LOG_FORWARDER="uv run --no-sync python -m application_sdk.observability.dapr_log_forwarder --"
+    DAPR_LOG_FORMAT_FLAG="--log-as-json"
+fi
+
+# Intentional unquoted expansion: the forwarder prefix is empty (no-op) when the
+# flag is off, and a multi-word command when on.
+# shellcheck disable=SC2086
+${DAPR_LOG_FORWARDER} daprd \
     --app-id "${DAPR_APP_ID}" \
     --app-port "${DAPR_APP_PORT}" \
     --dapr-http-port "${DAPR_HTTP_PORT}" \
@@ -93,7 +110,8 @@ daprd \
     --max-body-size "${DAPR_MAX_BODY_SIZE}" \
     --placement-host-address "" \
     --scheduler-host-address "${DAPR_SCHEDULER_HOST_ADDRESS}" \
-    --dapr-graceful-shutdown-seconds "${DAPR_GRACEFUL_SHUTDOWN_SECONDS}" &
+    --dapr-graceful-shutdown-seconds "${DAPR_GRACEFUL_SHUTDOWN_SECONDS}" \
+    ${DAPR_LOG_FORMAT_FLAG} &
 DAPRD_PID=$!
 echo "[entrypoint] daprd started with PID ${DAPRD_PID}"
 

--- a/tests/unit/observability/test_dapr_log_forwarder.py
+++ b/tests/unit/observability/test_dapr_log_forwarder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from unittest.mock import MagicMock, patch
 
@@ -81,7 +82,7 @@ class TestMakeEmitter:
             "application_sdk.observability.logger_adaptor.get_logger",
             return_value=fake_logger,
         ):
-            emit = dlf._make_emitter()
+            emit, _complete = dlf._make_emitter()
             emit("warning", "hello")
         fake_logger.warning.assert_called_once_with("hello")
 
@@ -91,7 +92,7 @@ class TestMakeEmitter:
             "application_sdk.observability.logger_adaptor.get_logger",
             return_value=fake_logger,
         ):
-            emit = dlf._make_emitter()
+            emit, _complete = dlf._make_emitter()
             emit("nonsense", "hello")
         fake_logger.info.assert_called_once_with("hello")
 
@@ -100,8 +101,9 @@ class TestMakeEmitter:
             "application_sdk.observability.logger_adaptor.get_logger",
             side_effect=RuntimeError("boom"),
         ):
-            emit = dlf._make_emitter()
+            emit, complete = dlf._make_emitter()
             emit("error", "still visible")
+        assert complete is None
         assert "still visible" in capsys.readouterr().err
 
     def test_emit_failure_falls_back_to_stderr(self, capsys):
@@ -111,9 +113,35 @@ class TestMakeEmitter:
             "application_sdk.observability.logger_adaptor.get_logger",
             return_value=fake_logger,
         ):
-            emit = dlf._make_emitter()
+            emit, _complete = dlf._make_emitter()
             emit("warning", "fallback line")
         assert "fallback line" in capsys.readouterr().err
+
+
+class _FakeStdout:
+    """Async-iterable stand-in for ``proc.stdout`` yielding raw bytes lines."""
+
+    def __init__(self, lines: list[bytes]):
+        self._lines = list(lines)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> bytes:
+        if not self._lines:
+            raise StopAsyncIteration
+        return self._lines.pop(0)
+
+
+class _FakeProc:
+    def __init__(self, lines: list[bytes], returncode: int):
+        self.stdout = _FakeStdout(lines)
+        self.returncode = None
+        self._rc = returncode
+
+    async def wait(self) -> int:
+        self.returncode = self._rc
+        return self._rc
 
 
 class TestMain:
@@ -134,46 +162,57 @@ class TestMain:
                 dlf.main(["dapr_log_forwarder", "--", "daprd", "--app-id", "app"])
         exec_mock.assert_called_once_with(["daprd", "--app-id", "app"])
 
+
+class TestRun:
     def test_forwards_each_line_and_returns_child_exit_code(self):
         lines = [
-            json.dumps({"level": "warning", "msg": "w", "scope": "s"}) + "\n",
-            json.dumps({"level": "error", "msg": "e"}) + "\n",
+            (
+                json.dumps({"level": "warning", "msg": "w", "scope": "s"}) + "\n"
+            ).encode(),
+            (json.dumps({"level": "error", "msg": "e"}) + "\n").encode(),
         ]
-        fake_proc = MagicMock()
-        fake_proc.stdout = iter(lines)
-        fake_proc.poll.return_value = None
-        fake_proc.wait.return_value = 0
-
+        fake_proc = _FakeProc(lines, returncode=0)
         emitted: list[tuple[str, str]] = []
+
+        async def _create(*_a, **_k):
+            return fake_proc
+
         with (
-            patch("application_sdk.constants.ENABLE_ATLAN_UPLOAD", True),
             patch.object(
                 dlf,
                 "_make_emitter",
-                return_value=lambda lvl, msg: emitted.append((lvl, msg)),
+                return_value=(lambda lvl, msg: emitted.append((lvl, msg)), None),
             ),
-            patch.object(dlf.subprocess, "Popen", return_value=fake_proc),
-            patch.object(dlf.signal, "signal"),
-            patch.object(dlf, "_flush_observability"),
+            patch.object(dlf.asyncio, "create_subprocess_exec", _create),
+            patch.object(dlf, "_install_signal_forwarding"),
+            patch.object(dlf, "_drain_and_flush", new=_async_noop),
         ):
-            rc = dlf.main(["dapr_log_forwarder", "--", "daprd"])
+            rc = asyncio.run(dlf._run(["daprd"]))
 
         assert rc == 0
         assert emitted == [("warning", "[s] w"), ("error", "e")]
 
-    def test_flushes_observability_on_exit(self):
-        fake_proc = MagicMock()
-        fake_proc.stdout = iter([])
-        fake_proc.wait.return_value = 3
+    def test_drains_and_flushes_on_exit(self):
+        fake_proc = _FakeProc([], returncode=3)
+        flushed: list[bool] = []
+
+        async def _create(*_a, **_k):
+            return fake_proc
+
+        async def _drain(_complete):
+            flushed.append(True)
 
         with (
-            patch("application_sdk.constants.ENABLE_ATLAN_UPLOAD", True),
-            patch.object(dlf, "_make_emitter", return_value=lambda *a: None),
-            patch.object(dlf.subprocess, "Popen", return_value=fake_proc),
-            patch.object(dlf.signal, "signal"),
-            patch.object(dlf, "_flush_observability") as flush_mock,
+            patch.object(dlf, "_make_emitter", return_value=(lambda *a: None, None)),
+            patch.object(dlf.asyncio, "create_subprocess_exec", _create),
+            patch.object(dlf, "_install_signal_forwarding"),
+            patch.object(dlf, "_drain_and_flush", new=_drain),
         ):
-            rc = dlf.main(["dapr_log_forwarder", "--", "daprd"])
+            rc = asyncio.run(dlf._run(["daprd"]))
 
         assert rc == 3
-        flush_mock.assert_called_once()
+        assert flushed == [True]
+
+
+async def _async_noop(*_args, **_kwargs):
+    return None

--- a/tests/unit/observability/test_dapr_log_forwarder.py
+++ b/tests/unit/observability/test_dapr_log_forwarder.py
@@ -1,0 +1,178 @@
+"""Unit tests for the daprd log forwarder."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from application_sdk.observability import dapr_log_forwarder as dlf
+
+
+class TestSplitChildCommand:
+    def test_returns_args_after_separator(self):
+        argv = ["dapr_log_forwarder", "--", "daprd", "--app-id", "app"]
+        assert dlf._split_child_command(argv) == ["daprd", "--app-id", "app"]
+
+    def test_falls_back_to_all_args_without_separator(self):
+        argv = ["dapr_log_forwarder", "daprd", "--app-id", "app"]
+        assert dlf._split_child_command(argv) == ["daprd", "--app-id", "app"]
+
+    def test_empty_child_after_separator(self):
+        assert dlf._split_child_command(["dapr_log_forwarder", "--"]) == []
+
+
+class TestFormatLine:
+    def test_parses_json_and_folds_scope_into_message(self):
+        line = json.dumps(
+            {
+                "level": "warning",
+                "msg": "A non-YAML Subscription file ..data was detected",
+                "scope": "dapr.runtime.loader.disk",
+                "type": "log",
+            }
+        )
+        level, message = dlf._format_line(line + "\n")
+        assert level == "warning"
+        assert message == (
+            "[dapr.runtime.loader.disk] "
+            "A non-YAML Subscription file ..data was detected"
+        )
+
+    def test_json_without_scope(self):
+        level, message = dlf._format_line(json.dumps({"level": "info", "msg": "up"}))
+        assert (level, message) == ("info", "up")
+
+    def test_non_json_line_forwarded_verbatim_at_info(self):
+        level, message = dlf._format_line("plain text daprd line\n")
+        assert (level, message) == ("info", "plain text daprd line")
+
+    def test_json_array_treated_as_plain(self):
+        level, message = dlf._format_line("[1, 2, 3]")
+        assert (level, message) == ("info", "[1, 2, 3]")
+
+    def test_missing_level_defaults_to_info(self):
+        level, _ = dlf._format_line(json.dumps({"msg": "no level"}))
+        assert level == "info"
+
+
+class TestLevelMapping:
+    @pytest.mark.parametrize(
+        "dapr_level,method",
+        [
+            ("debug", "debug"),
+            ("info", "info"),
+            ("warning", "warning"),
+            ("warn", "warning"),
+            ("error", "error"),
+            ("fatal", "critical"),
+            ("panic", "critical"),
+        ],
+    )
+    def test_known_levels(self, dapr_level, method):
+        assert dlf._LEVEL_TO_METHOD[dapr_level] == method
+
+
+class TestMakeEmitter:
+    def test_routes_to_logger_method_by_level(self):
+        fake_logger = MagicMock()
+        with patch(
+            "application_sdk.observability.logger_adaptor.get_logger",
+            return_value=fake_logger,
+        ):
+            emit = dlf._make_emitter()
+            emit("warning", "hello")
+        fake_logger.warning.assert_called_once_with("hello")
+
+    def test_unknown_level_falls_back_to_info(self):
+        fake_logger = MagicMock()
+        with patch(
+            "application_sdk.observability.logger_adaptor.get_logger",
+            return_value=fake_logger,
+        ):
+            emit = dlf._make_emitter()
+            emit("nonsense", "hello")
+        fake_logger.info.assert_called_once_with("hello")
+
+    def test_logger_setup_failure_falls_back_to_stderr(self, capsys):
+        with patch(
+            "application_sdk.observability.logger_adaptor.get_logger",
+            side_effect=RuntimeError("boom"),
+        ):
+            emit = dlf._make_emitter()
+            emit("error", "still visible")
+        assert "still visible" in capsys.readouterr().err
+
+    def test_emit_failure_falls_back_to_stderr(self, capsys):
+        fake_logger = MagicMock()
+        fake_logger.warning.side_effect = RuntimeError("sink down")
+        with patch(
+            "application_sdk.observability.logger_adaptor.get_logger",
+            return_value=fake_logger,
+        ):
+            emit = dlf._make_emitter()
+            emit("warning", "fallback line")
+        assert "fallback line" in capsys.readouterr().err
+
+
+class TestMain:
+    def test_no_child_command_returns_error_code(self):
+        assert dlf.main(["dapr_log_forwarder", "--"]) == 2
+
+    def test_transparent_exec_when_flag_disabled(self):
+        # os.execvp never returns in reality; simulate that with SystemExit so
+        # main() doesn't fall through into the forwarding path.
+        with (
+            patch("application_sdk.constants.ENABLE_DAPR_LOG_FORWARDING", False),
+            patch.object(
+                dlf, "_exec_transparently", side_effect=SystemExit(0)
+            ) as exec_mock,
+        ):
+            with pytest.raises(SystemExit):
+                dlf.main(["dapr_log_forwarder", "--", "daprd", "--app-id", "app"])
+        exec_mock.assert_called_once_with(["daprd", "--app-id", "app"])
+
+    def test_forwards_each_line_and_returns_child_exit_code(self):
+        lines = [
+            json.dumps({"level": "warning", "msg": "w", "scope": "s"}) + "\n",
+            json.dumps({"level": "error", "msg": "e"}) + "\n",
+        ]
+        fake_proc = MagicMock()
+        fake_proc.stdout = iter(lines)
+        fake_proc.poll.return_value = None
+        fake_proc.wait.return_value = 0
+
+        emitted: list[tuple[str, str]] = []
+        with (
+            patch("application_sdk.constants.ENABLE_DAPR_LOG_FORWARDING", True),
+            patch.object(
+                dlf,
+                "_make_emitter",
+                return_value=lambda lvl, msg: emitted.append((lvl, msg)),
+            ),
+            patch.object(dlf.subprocess, "Popen", return_value=fake_proc),
+            patch.object(dlf.signal, "signal"),
+            patch.object(dlf, "_flush_observability"),
+        ):
+            rc = dlf.main(["dapr_log_forwarder", "--", "daprd"])
+
+        assert rc == 0
+        assert emitted == [("warning", "[s] w"), ("error", "e")]
+
+    def test_flushes_observability_on_exit(self):
+        fake_proc = MagicMock()
+        fake_proc.stdout = iter([])
+        fake_proc.wait.return_value = 3
+
+        with (
+            patch("application_sdk.constants.ENABLE_DAPR_LOG_FORWARDING", True),
+            patch.object(dlf, "_make_emitter", return_value=lambda *a: None),
+            patch.object(dlf.subprocess, "Popen", return_value=fake_proc),
+            patch.object(dlf.signal, "signal"),
+            patch.object(dlf, "_flush_observability") as flush_mock,
+        ):
+            rc = dlf.main(["dapr_log_forwarder", "--", "daprd"])
+
+        assert rc == 3
+        flush_mock.assert_called_once()

--- a/tests/unit/observability/test_dapr_log_forwarder.py
+++ b/tests/unit/observability/test_dapr_log_forwarder.py
@@ -120,11 +120,12 @@ class TestMain:
     def test_no_child_command_returns_error_code(self):
         assert dlf.main(["dapr_log_forwarder", "--"]) == 2
 
-    def test_transparent_exec_when_flag_disabled(self):
+    def test_transparent_exec_when_not_sdr_mode(self):
+        # Outside SDR mode (ENABLE_ATLAN_UPLOAD=false) the child is exec'd directly.
         # os.execvp never returns in reality; simulate that with SystemExit so
         # main() doesn't fall through into the forwarding path.
         with (
-            patch("application_sdk.constants.ENABLE_DAPR_LOG_FORWARDING", False),
+            patch("application_sdk.constants.ENABLE_ATLAN_UPLOAD", False),
             patch.object(
                 dlf, "_exec_transparently", side_effect=SystemExit(0)
             ) as exec_mock,
@@ -145,7 +146,7 @@ class TestMain:
 
         emitted: list[tuple[str, str]] = []
         with (
-            patch("application_sdk.constants.ENABLE_DAPR_LOG_FORWARDING", True),
+            patch("application_sdk.constants.ENABLE_ATLAN_UPLOAD", True),
             patch.object(
                 dlf,
                 "_make_emitter",
@@ -166,7 +167,7 @@ class TestMain:
         fake_proc.wait.return_value = 3
 
         with (
-            patch("application_sdk.constants.ENABLE_DAPR_LOG_FORWARDING", True),
+            patch("application_sdk.constants.ENABLE_ATLAN_UPLOAD", True),
             patch.object(dlf, "_make_emitter", return_value=lambda *a: None),
             patch.object(dlf.subprocess, "Popen", return_value=fake_proc),
             patch.object(dlf.signal, "signal"),

--- a/tests/unit/observability/test_dapr_log_forwarder.py
+++ b/tests/unit/observability/test_dapr_log_forwarder.py
@@ -119,18 +119,26 @@ class TestMakeEmitter:
 
 
 class _FakeStdout:
-    """Async-iterable stand-in for ``proc.stdout`` yielding raw bytes lines."""
+    """StreamReader-like stand-in for ``proc.stdout`` used by the readuntil loop."""
 
     def __init__(self, lines: list[bytes]):
-        self._lines = list(lines)
+        self._buf = b"".join(lines)
 
-    def __aiter__(self):
-        return self
+    async def readuntil(self, separator: bytes = b"\n") -> bytes:
+        idx = self._buf.find(separator)
+        if idx == -1:
+            partial, self._buf = self._buf, b""
+            raise asyncio.IncompleteReadError(partial, None)
+        end = idx + len(separator)
+        chunk, self._buf = self._buf[:end], self._buf[end:]
+        return chunk
 
-    async def __anext__(self) -> bytes:
-        if not self._lines:
-            raise StopAsyncIteration
-        return self._lines.pop(0)
+    async def readexactly(self, n: int) -> bytes:
+        if len(self._buf) < n:
+            partial, self._buf = self._buf, b""
+            raise asyncio.IncompleteReadError(partial, n)
+        chunk, self._buf = self._buf[:n], self._buf[n:]
+        return chunk
 
 
 class _FakeProc:
@@ -157,9 +165,9 @@ class TestMain:
             patch.object(
                 dlf, "_exec_transparently", side_effect=SystemExit(0)
             ) as exec_mock,
+            pytest.raises(SystemExit),
         ):
-            with pytest.raises(SystemExit):
-                dlf.main(["dapr_log_forwarder", "--", "daprd", "--app-id", "app"])
+            dlf.main(["dapr_log_forwarder", "--", "daprd", "--app-id", "app"])
         exec_mock.assert_called_once_with(["daprd", "--app-id", "app"])
 
 
@@ -191,6 +199,55 @@ class TestRun:
 
         assert rc == 0
         assert emitted == [("warning", "[s] w"), ("error", "e")]
+
+    def test_oversized_line_emits_truncated_warning_and_continues(self):
+        # A line longer than the buffer limit triggers LimitOverrunError.
+        # _FakeStdoutOverrun simulates this directly.
+        oversized = b"X" * 300 + b"\n"
+        normal = (json.dumps({"level": "info", "msg": "ok"}) + "\n").encode()
+        emitted: list[tuple[str, str]] = []
+
+        class _FakeStdoutOverrun:
+            def __init__(self):
+                self._phase = 0
+
+            async def readuntil(self, separator: bytes = b"\n") -> bytes:
+                if self._phase == 0:
+                    self._phase = 1
+                    raise asyncio.LimitOverrunError("too long", 300)
+                if self._phase == 1:
+                    self._phase = 2
+                    return oversized[:300]  # readexactly result fed back; unused here
+                if self._phase == 2:
+                    self._phase = 3
+                    return normal
+                raise asyncio.IncompleteReadError(b"", None)
+
+            async def readexactly(self, n: int) -> bytes:
+                return b"X" * n
+
+        fake_proc = _FakeProc([], returncode=0)
+        fake_proc.stdout = _FakeStdoutOverrun()
+
+        async def _create(*_a, **_k):
+            return fake_proc
+
+        with (
+            patch.object(
+                dlf,
+                "_make_emitter",
+                return_value=(lambda lvl, msg: emitted.append((lvl, msg)), None),
+            ),
+            patch.object(dlf.asyncio, "create_subprocess_exec", _create),
+            patch.object(dlf, "_install_signal_forwarding"),
+            patch.object(dlf, "_drain_and_flush", new=_async_noop),
+        ):
+            rc = asyncio.run(dlf._run(["daprd"]))
+
+        assert rc == 0
+        assert emitted[0][0] == "warning"
+        assert "truncated" in emitted[0][1]
+        assert emitted[1] == ("info", "ok")
 
     def test_drains_and_flushes_on_exit(self):
         fake_proc = _FakeProc([], returncode=3)


### PR DESCRIPTION
## Problem

The `daprd` sidecar is launched by the container entrypoint as a child process **inside the app's main container** (`entrypoint.sh` → `daprd ... &`, daprd is PID ~7), so its logs are interleaved on the container's stdout but **never enter the SDK observability pipeline**.

- **On atlan-infra** this is fine: a node-level OpenTelemetry **filelog collector** (`monitoring/opentelemetry-collector-filelog-collector`, `include: /var/log/pods/*/*/*.log`, only `kubed` excluded) scrapes every container's stdout — daprd included — and ships it via `otlphttp` to the central backend. Verified against a live tenant.
- **In SDR mode (customer infra)** there is **no** such node-level collector, so daprd's logs never reach Atlan's central lakehouse — they're only visible in the customer's own pod logs, which we can't see. This came up from a customer asking about benign daprd `..data` warnings we had no central visibility into.

## What this does

In **SDR mode** (`ENABLE_ATLAN_UPLOAD=true` — the same signal that means "customer infra, no node collector"), the SDK **automatically** forwards daprd's logs through its own pipeline. No new flag to set; gated entirely on `ENABLE_ATLAN_UPLOAD`. On atlan-infra it's a no-op (the filelog collector already handles it) and daprd is exec'd directly with zero overhead.

`entrypoint.sh` runs daprd under `application_sdk.observability.dapr_log_forwarder` (with `--log-as-json`). The forwarder:

- streams each daprd log line into a `dapr.runtime` logger via `get_logger(...)`, so records flow through the **same** `InterceptHandler → loguru → store sink` path as the app's own logs and land in `app_logs` with `app_name` / `is_sdr` populated;
- preserves the daprd severity (`warning→WARNING`, `fatal/panic→CRITICAL`, …) and folds the daprd `scope` (e.g. `dapr.runtime.loader.disk`) into the message so it stays queryable;
- still surfaces the lines in the container's own logs, so `kubectl logs` shows the SDK-formatted re-emission (content unchanged; format differs for SDR pods);
- **forwards `SIGTERM`/`SIGINT` to daprd** so its `--dapr-graceful-shutdown-seconds` behaviour (the reason the entrypoint runs daprd directly) is unchanged, and exits with daprd's exit code;
- is **best-effort** — any parse/emit failure falls back to writing the raw line to stderr, so forwarding can never take daprd down; oversized lines (> 2 MiB) are forwarded as a truncated prefix;
- when not in SDR mode, the child is `exec`'d transparently, so the process tree / PID semantics are identical to today.

Because every connector app image is built on `app-runtime-base` (which ships this `entrypoint.sh`), one change covers all app pods across all four topologies (single-app / orchestrator × docker / k8s).

## Controlling volume

`DAPR_LOG_LEVEL` (already wired, default `warn`) is the knob — it's a minimum-severity floor at the source, so `warn` forwards **both warnings and errors**; raise to `error` to drop the benign `..data`/loader warnings.

## Changes

- `application_sdk/observability/dapr_log_forwarder.py` — new forwarder/supervisor module (gated on `ENABLE_ATLAN_UPLOAD`)
- `entrypoint.sh` — wrap daprd with the forwarder in SDR mode only (no-op otherwise; daprd flag list unchanged)
- `tests/unit/observability/test_dapr_log_forwarder.py` — 23 unit tests
- `docs/concepts/monitoring.md` — document the SDR-mode behaviour and `kubectl logs` format note

## Testing

- `uv run pytest tests/unit/observability/test_dapr_log_forwarder.py` — 23 passed
- `uv run pre-commit run --files <changed>` — clean (ruff/ruff-format/isort/pyright)

## Notes / follow-ups

- No config to enable per-tenant — it follows SDR mode automatically.
- The SDR **orchestrator's own** daprd (launched via `dapr run` in `atlan-local-marketplace-app`) is a separate process and not covered here; a follow-up can apply the same pattern there if we want orchestrator-level daprd logs centrally.
- The atlan-infra filelog path captures daprd as **unstructured** container-log lines; this forwarder lands them as **structured** `app_logs` rows (level/scope/app_name) in the lakehouse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)