### PR TITLE
ci(renovate-pkl-sync): format all generated *.py, not just _input.py

### DIFF
--- a/.github/scripts/renovate_pkl_sync.py
+++ b/.github/scripts/renovate_pkl_sync.py
@@ -125,12 +125,15 @@ def regenerate(contract_dir: str) -> bool:
 
 
 def _format_generated(out_dir: Path) -> None:
-    """ruff-fix + format the generated _input.py, mirroring
-    contract-toolkit/scripts/regenerate-all.sh. Best-effort: this commit
-    bypasses pre-commit, so we format here for apps that lint app/generated,
-    but a ruff hiccup must not fail the sync (many apps exclude app/generated
-    from lint entirely)."""
-    inputs = sorted((out_dir / "app" / "generated").rglob("_input.py"))
+    """ruff-fix + format every generated *.py, mirroring
+    contract-toolkit/scripts/regenerate-all.sh. The contract emits more than
+    _input.py (e.g. _e2e_base.py, _e2e_credential.py, _e2e_substitutions.py);
+    every one must match what pre-commit's ruff-format would produce, or the
+    consumer's pre-commit reformats it on the renovate PR and fails CI. This
+    sync commit bypasses pre-commit, so we format here. Best-effort: a ruff
+    hiccup must not fail the sync (many apps exclude app/generated from lint
+    entirely)."""
+    inputs = sorted((out_dir / "app" / "generated").rglob("*.py"))
     if not inputs:
         return
     paths = [str(p) for p in inputs]

--- a/.github/scripts/tests/test_renovate_pkl_sync.py
+++ b/.github/scripts/tests/test_renovate_pkl_sync.py
@@ -242,6 +242,42 @@ def test_no_changes_makes_no_commit(repo, monkeypatch):
     assert _commit_count(repo) == before  # no new commit
 
 
+def test_format_generated_covers_all_py_not_just_input(tmp_path, monkeypatch):
+    """`_format_generated` must ruff-format every generated *.py, not only
+    _input.py. The contract emits _e2e_*.py too; if those are left unformatted
+    the consumer's pre-commit reformats them on the renovate PR and fails CI
+    (the bug this guards against). `uvx` is stubbed in the other tests as a
+    no-op, so without this assertion the _input.py-only regression is invisible.
+    """
+    gen = tmp_path / "app" / "generated"
+    nested = gen / "crawler"  # bundle layout: rglob must recurse
+    nested.mkdir(parents=True)
+    (gen / "_input.py").write_text("import os\n")
+    (gen / "_e2e_base.py").write_text("import os\n")
+    (gen / "_e2e_credential.py").write_text("import os\n")
+    (gen / "__init__.py").write_text("")
+    (nested / "_e2e_substitutions.py").write_text("import os\n")
+
+    formatted: list[str] = []
+
+    def spy_run(cmd, *, check=False):
+        if cmd[:2] == ["uvx", "ruff"] and cmd[2] == "format":
+            formatted.extend(cmd[3:])
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(mod, "run", spy_run)
+    mod._format_generated(tmp_path)
+
+    formatted_names = {Path(p).name for p in formatted}
+    assert formatted_names == {
+        "_input.py",
+        "_e2e_base.py",
+        "_e2e_credential.py",
+        "__init__.py",
+        "_e2e_substitutions.py",
+    }
+
+
 def test_resolve_failure_is_fatal(repo, monkeypatch):
     def fake_run(cmd, *, check=False):
         if cmd[0] == "pkl" and cmd[1:3] == ["project", "resolve"]:

--- a/contract-toolkit/scripts/regenerate-all.sh
+++ b/contract-toolkit/scripts/regenerate-all.sh
@@ -37,7 +37,9 @@ fi
 
 # Lint + format generated Python files to match what the pre-commit hooks produce.
 # ruff check --fix removes unused imports (F401); ruff format handles whitespace.
-PY_FILES=$(find examples -name '_input.py' | sort)
+# Match every generated *.py (_input.py, _e2e_base.py, _e2e_credential.py,
+# _e2e_substitutions.py, …) — not just _input.py — so none lands unformatted.
+PY_FILES=$(find examples -path '*/app/generated/*.py' | sort)
 if [ -n "$PY_FILES" ]; then
   echo ""
   echo ":: Linting and formatting generated Python files..."


### PR DESCRIPTION
## Problem

Renovate `app-contract-toolkit` bumps in consumer apps fail the **pre-commit** check:

```
ruff....................Passed
ruff-format.............Failed
- files were modified by this hook
1 file reformatted, 24 files left unchanged
```

The reusable `renovate-pkl-sync` workflow regenerates `app/generated/**` via `pkl eval` and commits by pushing directly to the `renovate/**` branch — which **bypasses pre-commit**. So the driver must itself reproduce what the consumer's `ruff-format` hook would produce.

It didn't. Both the sync driver (`_format_generated`) and the toolkit's `regenerate-all.sh` only globbed `_input.py`, but the contract also emits `_e2e_base.py`, `_e2e_credential.py`, and `_e2e_substitutions.py`. Those landed unformatted, so the consumer's pre-commit reformatted one of them on the PR and failed CI. (In the mysql case the `ruff` lint hook passed and only `ruff-format` failed — confirming the gap is purely the missing format pass on the `_e2e_*.py` files, since `_input.py` was already formatted.)

## Fix

- `.github/scripts/renovate_pkl_sync.py` — `_format_generated` now globs `app/generated/**/*.py` instead of `_input.py`.
- `contract-toolkit/scripts/regenerate-all.sh` — same widening, kept in sync per the driver's mirroring comment (recursive, so the `bundle/{crawler,miner}/` layout is covered).
- New unit test asserts every generated `.py` (`_input.py` + `_e2e_*.py`, recursing into nested bundle dirs) is passed to `ruff format`. The existing suite stubs `uvx` as a no-op, so the `_input.py`-only regression was invisible to it.

## Validation

- `pytest .github/scripts/tests/test_renovate_pkl_sync.py` — 9 passed.
- Confirmed the new test fails against the old `_input.py`-only glob (genuinely guards the regression).
- `pre-commit run --files <changed>` — clean.