### PR TITLE
fix(storage): remove delete from preflight probe; use fixed key

### DIFF
--- a/application_sdk/storage/preflight.py
+++ b/application_sdk/storage/preflight.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import asyncio
 import os
 import re
-import socket
 from typing import TYPE_CHECKING
 
 from application_sdk.observability.logger_adaptor import get_logger
@@ -62,12 +61,14 @@ if _raw_timeout is not None:
         )
 del _raw_timeout
 
-# Stable probe key reused across boots on the same host so that a principal
-# with put+head but no delete permission doesn't accumulate one orphaned
-# object per boot.  Must stay under ``artifacts/apps/`` (or another allowed
-# prefix) — the Kong s3proxy plugin enforces an upstream_path_prefixes
-# allowlist and rejects anything outside it with 403 code 1009.
-_PROBE_KEY = f"{_PREFLIGHT_PREFIX}/probe-{socket.gethostname()}"
+# Fixed probe key overwritten on every boot — guarantees a single object per
+# store with no accumulation.  A hostname-scoped key would create one object
+# per unique pod name in k8s and never converge.  Since we always write before
+# reading, a stale probe from a previous run cannot produce a false positive.
+# Must stay under ``artifacts/apps/`` (or another allowed prefix) — the Kong
+# s3proxy plugin enforces an upstream_path_prefixes allowlist and rejects
+# anything outside it with 403 code 1009.
+_PROBE_KEY = f"{_PREFLIGHT_PREFIX}/probe"
 
 # Pre-compiled patterns for HTTP status codes.  Word-boundary anchors prevent
 # false positives from request IDs, byte counts, or longer strings that happen
@@ -108,9 +109,9 @@ def _classify_access_error(exc: BaseException) -> tuple[str, str]:
     ):
         return (
             "permission denied",
-            "The credentials are valid but lack the required read/write/delete "
+            "The credentials are valid but lack the required read/write "
             "permissions on this bucket. Grant the IAM/ACL permissions needed "
-            "for get, put, and delete operations.",
+            "for get and put operations.",
         )
 
     if _RE_401.search(msg) or any(
@@ -137,12 +138,14 @@ def _classify_access_error(exc: BaseException) -> tuple[str, str]:
 
 
 async def _probe_store(store: object, label: str, binding_name: str) -> str | None:
-    """Run a write → read → delete round-trip against *store*.
+    """Run a write → read round-trip against *store*.
 
     Each operation is unbounded in this function; the caller wraps the whole
     coroutine in ``asyncio.wait_for`` to enforce the boot-time timeout.
 
-    Delete is best-effort: a delete failure logs a warning but does not raise.
+    The probe key is fixed and overwritten on every call — no delete is needed
+    or performed.  Environments that prohibit deletes (e.g. an S3 reverse-proxy
+    with an intentional no-delete policy) are therefore fully supported.
 
     Args:
         store: An obstore-compatible store instance.
@@ -173,44 +176,32 @@ async def _probe_store(store: object, label: str, binding_name: str) -> str | No
             f"    Hint:  {hint}"
         )
 
-    # Read (HEAD) — confirms read permission and that the write was committed
-    read_failure: str | None = None
+    # Read (HEAD) — confirms read permission and that the write was committed.
+    # The probe key is fixed; we always overwrite it rather than deleting, so
+    # no cleanup is needed and delete permission is never required.
     try:
         await obstore.head_async(store, probe_key)
     except Exception as exc:
         error_class, hint = _classify_access_error(exc)
-        read_failure = (
+        return (
             f"  * {label} store (binding: '{binding_name}'): read/head failed [{error_class}]\n"
             f"    Cause: {exc}\n"
             f"    Hint:  {hint}"
         )
 
-    # Delete — best-effort cleanup; uses the stable per-host key so a missing
-    # delete permission doesn't accumulate one new object per boot.
-    try:
-        await obstore.delete_async(store, probe_key)
-    except Exception as exc:
-        logger.warning(
-            "SDR preflight: could not delete probe object from %s store "
-            "(binding='%s', key=%s): %s — object may be left behind",
-            label,
-            binding_name,
-            probe_key,
-            exc,
-            exc_info=True,
-        )
-
-    return read_failure
+    return None
 
 
 async def verify_object_store_access(infra: InfrastructureContext) -> None:
     """In SDR mode, verify read+write access to every configured object store.
 
-    Performs a write → read → delete round-trip on the deployment store and,
-    when configured, the upstream Atlan store.  Also hard-fails if SDR mode is
-    active but the upstream store is absent — this is a defense-in-depth check;
-    the primary guard is ``_create_store_from_binding_optional_with_put_attrs``
-    raising ``StorageBindingNotFoundError`` at construction time.
+    Performs a write → read round-trip on the deployment store and, when
+    configured, the upstream Atlan store.  The probe key is fixed and
+    overwritten on each call — no delete permission is required.  Also
+    hard-fails if SDR mode is active but the upstream store is absent — this is
+    a defense-in-depth check; the primary guard is
+    ``_create_store_from_binding_optional_with_put_attrs`` raising
+    ``StorageBindingNotFoundError`` at construction time.
 
     Each per-store probe is bounded by ``ATLAN_SDR_PREFLIGHT_TIMEOUT_SECS``
     (default: 30 s).  A probe that times out is classified as

--- a/tests/integration/storage/test_emulator_preflight.py
+++ b/tests/integration/storage/test_emulator_preflight.py
@@ -2,7 +2,7 @@
 
 Exercises ``verify_object_store_access`` against real MinIO stores, covering the
 actual obstore code paths including network I/O, credential checking, and
-round-trip write/read/delete semantics.
+write/read round-trip semantics (no delete required or performed).
 
 Marked ``storage_emulator`` (deselected by default; run in CI with a MinIO sidecar).
 Local:

--- a/tests/unit/storage/test_preflight.py
+++ b/tests/unit/storage/test_preflight.py
@@ -93,13 +93,12 @@ def _fake_store() -> Any:
 
 
 async def _run_probe(
-    store: Any, put_side_effect=None, head_side_effect=None, delete_side_effect=None
+    store: Any, put_side_effect=None, head_side_effect=None
 ) -> str | None:
     """Run ``_probe_store`` with obstore functions replaced by async fakes."""
     fake_obstore = MagicMock()
     fake_obstore.put_async = AsyncMock(side_effect=put_side_effect)
     fake_obstore.head_async = AsyncMock(side_effect=head_side_effect)
-    fake_obstore.delete_async = AsyncMock(side_effect=delete_side_effect)
 
     with patch.dict("sys.modules", {"obstore": fake_obstore}):
         return await _probe_store(store, "deployment", "objectstore")
@@ -107,7 +106,7 @@ async def _run_probe(
 
 @pytest.mark.asyncio
 async def test_probe_store_success() -> None:
-    """All three operations succeed → None returned."""
+    """Write and read both succeed → None returned."""
     result = await _run_probe(_fake_store())
     assert result is None
 
@@ -138,29 +137,15 @@ async def test_probe_store_write_fails_invalid_credentials() -> None:
 
 @pytest.mark.asyncio
 async def test_probe_store_head_fails_after_write_succeeds() -> None:
-    """Write succeeds, HEAD fails → read failure returned; delete still attempted."""
+    """Write succeeds, HEAD fails → read failure returned."""
     result = await _run_probe(
         _fake_store(),
         put_side_effect=None,
         head_side_effect=Exception("403 Forbidden"),
-        delete_side_effect=None,
     )
     assert result is not None
     assert "read/head failed" in result
     assert "permission denied" in result
-
-
-@pytest.mark.asyncio
-async def test_probe_store_delete_fails_is_nonfatal() -> None:
-    """Write and HEAD succeed; delete fails → None returned (best-effort cleanup)."""
-    result = await _run_probe(
-        _fake_store(),
-        put_side_effect=None,
-        head_side_effect=None,
-        delete_side_effect=Exception("403 Forbidden on delete"),
-    )
-    # Delete failure is logged at WARNING but must not surface as a probe failure
-    assert result is None
 
 
 # ---------------------------------------------------------------------------
@@ -206,7 +191,6 @@ async def test_verify_fails_when_upstream_absent_in_sdr(monkeypatch) -> None:
     fake_obstore = MagicMock()
     fake_obstore.put_async = AsyncMock()
     fake_obstore.head_async = AsyncMock()
-    fake_obstore.delete_async = AsyncMock()
 
     infra = _make_infra(storage=fake_store, upstream_storage=None)
 
@@ -234,7 +218,6 @@ async def test_verify_fails_when_store_is_none_in_sdr(monkeypatch) -> None:
     fake_obstore = MagicMock()
     fake_obstore.put_async = AsyncMock()
     fake_obstore.head_async = AsyncMock()
-    fake_obstore.delete_async = AsyncMock()
 
     infra = _make_infra(storage=None, upstream_storage=fake_store)
 
@@ -258,7 +241,6 @@ async def test_verify_passes_both_stores_healthy(monkeypatch) -> None:
     fake_obstore = MagicMock()
     fake_obstore.put_async = AsyncMock()
     fake_obstore.head_async = AsyncMock()
-    fake_obstore.delete_async = AsyncMock()
 
     infra = _make_infra(storage=fake_store, upstream_storage=fake_store)
 
@@ -282,7 +264,6 @@ async def test_verify_timeout_classified_as_connectivity(monkeypatch) -> None:
     fake_obstore = MagicMock()
     fake_obstore.put_async = AsyncMock()
     fake_obstore.head_async = AsyncMock()
-    fake_obstore.delete_async = AsyncMock()
 
     infra = _make_infra(storage=_fake_store(), upstream_storage=fake_upstream)
 
@@ -311,7 +292,6 @@ async def test_verify_probe_failure_propagates_to_preflight_error(monkeypatch) -
     # put_async raises 403 → _probe_store returns a non-None failure string
     fake_obstore.put_async = AsyncMock(side_effect=Exception("403 Forbidden"))
     fake_obstore.head_async = AsyncMock()
-    fake_obstore.delete_async = AsyncMock()
 
     infra = _make_infra(storage=fake_store, upstream_storage=fake_store)
 


### PR DESCRIPTION
## Summary

- Replaces the hostname-scoped probe key with a single fixed key (`artifacts/apps/.atlan-sdk-preflight/probe`) that is overwritten on every boot
- Removes the `delete_async` call entirely — no delete permission is needed or attempted
- Updates the permission-denied hint to no longer mention delete operations

## Motivation

The preflight probe had two compounding problems:

1. **No-delete environments**: A production S3 reverse-proxy intentionally blocks deletes. The best-effort delete produced a spurious WARNING on every boot with no way to suppress it.
2. **k8s pod churn**: The probe key was scoped to `socket.gethostname()` to avoid accumulation, but in k8s each pod has a unique hostname — so the "avoid accumulation" mechanism was the cause of accumulation.

**Why always-overwrite is safe**: we write before reading, so a stale probe object from a prior run cannot produce a false positive. If the write fails, we catch it. If the read fails after a successful write, we catch that too.

## Race-condition analysis (concurrent pod boot)

With a single fixed key, multiple SDR pods starting simultaneously all write to the same object. This is safe:

- **Object stores guarantee read-your-writes consistency.** After `put_async` returns success for Pod A, Pod A's subsequent `head_async` will always see the object — regardless of concurrent writes from Pod B. Pod B's overwrite doesn't temporarily remove the object; it replaces the content atomically. The object is never absent between a pod's write and its read.
- **The payload is an identical constant.** `head_async` only checks that the object exists — it doesn't verify pod-specific content. Even if Pod B's write lands between Pod A's write and read, the object still exists with the same `b"atlan-preflight"` bytes.

The only pattern that would be unsafe is write-unique-nonce → read-back-nonce → assert-match. We don't do that; HEAD just confirms the object is present and accessible.

**The old hostname-scoped design was not protecting against a write/read race** — it was protecting against the DELETE racing: with a fixed key, one pod's delete could remove another pod's object mid-probe. Eliminating delete entirely removes the only operation that could have caused a genuine concurrent-boot race.

## Test plan

- [ ] Unit tests: `uv run pytest tests/unit/storage/test_preflight.py -v` — 31/31 passing
- [ ] Integration tests (requires MinIO): `uv run pytest tests/integration/storage/test_emulator_preflight.py -m storage_emulator -v`
- [ ] Verify no WARNING logged on boot in a no-delete S3 environment

Closes BLDX-1483

🤖 Generated with [Claude Code](https://claude.com/claude-code)