### PR TITLE
ci(security): zero-touch CVE auto-SLA tracking + expiry gating (BLDX-1449)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,2 @@
 * @atlan-ci @cmgrote @OnkarVO7 @louisnow @Aryamanz29 @vaibhavatlan
 /contract-toolkit/ @cmgrote @vaibhavatlan @Aryamanz29 @fyzanshaik-atlan
-# Security allowlist: SDK/security owners + atlan-ci. atlan-ci's automated
-# approval on a vuln-triage allowlist-only PR satisfies code-owner review so
-# the CVE-SLA flow can stay zero-human-touch (see vuln-auto-merge.yml).
-/.security/ @atlan-ci @cmgrote @vaibhavatlan @Aryamanz29

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
 * @atlan-ci @cmgrote @OnkarVO7 @louisnow @Aryamanz29 @vaibhavatlan
 /contract-toolkit/ @cmgrote @vaibhavatlan @Aryamanz29 @fyzanshaik-atlan
+# Security allowlist: SDK/security owners + atlan-ci. atlan-ci's automated
+# approval on a vuln-triage allowlist-only PR satisfies code-owner review so
+# the CVE-SLA flow can stay zero-human-touch (see vuln-auto-merge.yml).
+/.security/ @atlan-ci @cmgrote @vaibhavatlan @Aryamanz29

--- a/.github/scripts/dispatch_vuln_triage.py
+++ b/.github/scripts/dispatch_vuln_triage.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Dispatch the vuln-triage rover once per newly-filed security ticket.
+
+``security_scan_create_linear.py`` emits a ``new_issues`` output — a JSON
+array of ``{identifier, url, severity}``. This script reads that array and
+runs ``gh workflow run vuln-triage-cron.yml`` once per ticket, passing the
+ticket identifier and its severity.
+
+Loop logic lives here (a tested script) rather than inlined in the workflow
+YAML, per docs/standards/ci.md.
+
+Environment:
+    NEW_ISSUES   JSON array of {identifier, severity, ...} (default "[]")
+    GH_REF       git ref to dispatch the workflow on (default "main")
+    GH_TOKEN     consumed by ``gh`` for auth (not read here directly)
+
+Optional:
+    VULN_TRIAGE_WORKFLOW   workflow file name (default "vuln-triage-cron.yml")
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from typing import Any
+
+DEFAULT_WORKFLOW = "vuln-triage-cron.yml"
+
+
+def parse_issues(raw: str | None) -> list[dict[str, Any]]:
+    """Parse the NEW_ISSUES JSON, tolerating empty/missing input."""
+    if not raw or not raw.strip():
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"::error::NEW_ISSUES is not valid JSON: {e}")
+    if not isinstance(data, list):
+        raise SystemExit("::error::NEW_ISSUES must be a JSON array")
+    return data
+
+
+def dispatch(
+    issues: list[dict[str, Any]],
+    ref: str,
+    workflow: str = DEFAULT_WORKFLOW,
+    runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> int:
+    """Run ``gh workflow run`` once per issue. Returns the number of
+    successful dispatches; raises SystemExit if any ticket is malformed or a
+    dispatch fails."""
+    dispatched = 0
+    for issue in issues:
+        ticket = (issue or {}).get("identifier")
+        severity = (issue or {}).get("severity", "")
+        if not ticket:
+            raise SystemExit(f"::error::issue entry missing 'identifier': {issue}")
+        cmd = [
+            "gh",
+            "workflow",
+            "run",
+            workflow,
+            "--ref",
+            ref,
+            "-f",
+            f"ticket={ticket}",
+            "-f",
+            f"severity={severity}",
+        ]
+        print(f"Dispatching {workflow} for {ticket} (severity={severity or 'n/a'})")
+        result = runner(cmd, check=False)
+        if result.returncode != 0:
+            raise SystemExit(
+                f"::error::failed to dispatch {workflow} for {ticket} "
+                f"(exit {result.returncode})"
+            )
+        dispatched += 1
+    return dispatched
+
+
+def main() -> int:
+    issues = parse_issues(os.environ.get("NEW_ISSUES"))
+    if not issues:
+        print("No new issues to dispatch.")
+        return 0
+    ref = os.environ.get("GH_REF", "main")
+    workflow = os.environ.get("VULN_TRIAGE_WORKFLOW", DEFAULT_WORKFLOW)
+    n = dispatch(issues, ref, workflow)
+    print(f"Dispatched vuln-triage for {n} ticket(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/mothership_sandbox_dispatch.py
+++ b/.github/scripts/mothership_sandbox_dispatch.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Dispatch a vuln-triage run to mothership's Rover Direct API and stream it.
+
+Replaces the inline SSE-parsing shell (a `while`/`case` state machine) in
+vuln-triage-cron.yml — that conditional logic now lives here (tested) per
+docs/standards/ci.md. The HTTP itself is irreducible I/O; the event handling
+and exit decision are pure and unit-tested.
+
+Flow: check mothership reachability (retries) → build the run prompt + payload
+→ POST /api/sandbox/execute and stream Server-Sent Events → exit non-zero on a
+sandbox error / incomplete stream / non-'completed' final status.
+
+Environment:
+    MOTHERSHIP_URL   base URL (e.g. https://mothership.atlan.dev)
+    HARNESS_TOKEN    bearer for /api/sandbox/execute
+    TICKET           Linear ticket to triage
+    SEVERITY         severity bucket of the ticket
+    GHA_RUN_URL      this workflow run's URL
+    RUN_DATE         ISO date (computed if absent)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Iterable
+from typing import Any
+
+HEALTH_RETRIES = 5
+HEALTH_BACKOFF_SECONDS = 5
+STREAM_TIMEOUT_SECONDS = 7200
+
+
+def build_prompt(ticket: str, severity: str, run_date: str, gha_run_url: str) -> str:
+    return f"""You are running the vuln-triage rover in a Cloudflare sandbox.
+
+Repository cloned at: /workspace/application-sdk (on main).
+Working directory: cd /workspace/application-sdk
+
+Read and follow the orchestration:
+  .mothership/vuln-triage/ORCHESTRATION.md
+  .mothership/vuln-triage/CLAUDE.md
+  .mothership/vuln-triage/tools.md
+
+Run metadata (use these verbatim):
+  TICKET:       {ticket}        # the Linear ticket to triage
+  SEVERITY:     {severity}      # severity bucket of this ticket
+  RUN_DATE:     {run_date}
+  GHA_RUN_URL:  {gha_run_url}
+
+GITHUB_TOKEN is pre-injected by the sandbox. Use `gh` for all GitHub operations.
+
+Triage every CVE listed on ticket {ticket}. For each, classify per
+ORCHESTRATION.md, then enact the SLA flow:
+  - Critical/High -> open an allowlist PR (touching ONLY
+    .security/base-allowlist.json, label "vuln-auto-merge") with expires =
+    detection + SLA (CRITICAL 7d, HIGH 30d). For Case 1 also open a bump PR
+    (touching ONLY the dep manifests, same label).
+  - Medium/Low -> detail on the ticket with its SLA; never allowlist.
+Both PR shapes auto-merge via vuln-auto-merge.yml once CI is green -- never
+merge or push to main yourself. Keep the two PR shapes separate (the GHA
+path-allowlist refuses anything mixed). Include a link to GHA_RUN_URL in the
+ticket summary. Tag Vaibhav or Chris only when human action is genuinely
+required (a bump needing source edits, or a base-image rebuild).
+
+Linear / GPT proxy access: use the $PROXY_BASE and $PROXY_JWT env vars
+injected by mothership (see tools.md)."""
+
+
+def build_payload(
+    ticket: str, severity: str, run_date: str, gha_run_url: str
+) -> dict[str, Any]:
+    return {
+        "mode": "direct",
+        "stream": True,
+        "source": "github-cron",
+        "source_id": f"vuln-triage-{ticket}-{run_date}",
+        "repositories": ["atlanhq/application-sdk"],
+        "base_branch": "main",
+        "snapshot": "_base",
+        "prompt": build_prompt(ticket, severity, run_date, gha_run_url),
+        "max_timeout_seconds": 7200,
+        "idle_timeout_seconds": 1800,
+        "metadata": {"ticket": ticket, "severity": severity, "run_date": run_date},
+    }
+
+
+class SSEState:
+    """Accumulates the outcome of the Rover Direct SSE stream."""
+
+    def __init__(self) -> None:
+        self.event = ""
+        self.got_event = False
+        self.completed = False
+        self.errored = False
+        self.status = ""
+        self.cost = ""
+        self.err_code = ""
+        self.err_msg = ""
+
+
+def _jget(data: str, *keys: str, default: str = "") -> str:
+    try:
+        obj = json.loads(data)
+    except json.JSONDecodeError:
+        return default
+    for k in keys:
+        if isinstance(obj, dict) and k in obj:
+            obj = obj[k]
+        else:
+            return default
+    return str(obj) if obj is not None else default
+
+
+def process_line(line: str, st: SSEState) -> str | None:
+    """Apply one raw SSE line to the state. Returns a log line (or None)."""
+    if line == "":
+        st.event = ""
+        return None
+    if line.startswith(":"):
+        return None
+    if line.startswith("event: "):
+        st.event = line[len("event: ") :]
+        st.got_event = True
+        return None
+    if line.startswith("id: "):
+        return None
+    if not line.startswith("data: "):
+        return None
+
+    data = line[len("data: ") :]
+    if st.event == "started":
+        return f"[started]   session={_jget(data, 'session_id')} sandbox={_jget(data, 'sandbox_id')}"
+    if st.event == "action":
+        name = _jget(data, "action_name")
+        return f"[action]    {name}" if name else None
+    if st.event == "thought":
+        return None
+    if st.event == "response":
+        return "[response]  (agent posted a response)"
+    if st.event == "elicitation":
+        st.errored = True
+        st.err_code = "elicitation"
+        st.err_msg = "Sandbox requires interactive input; cannot answer from GHA"
+        return "[elicit]    sandbox requested user input — treating as error"
+    if st.event == "error":
+        st.errored = True
+        st.err_code = _jget(data, "code", default="unknown")
+        st.err_msg = _jget(data, "message")
+        return f"[error]     code={st.err_code} message={st.err_msg}"
+    if st.event == "complete":
+        st.completed = True
+        st.status = _jget(data, "status", default="unknown")
+        st.cost = _jget(data, "cost_usd")
+        if st.status == "error":
+            st.err_code = _jget(data, "error", "code", default="none")
+            st.err_msg = _jget(data, "error", "message")
+        return f"[complete]  status={st.status} cost_usd={st.cost}"
+    return None
+
+
+def process_stream(lines: Iterable[str]) -> SSEState:
+    st = SSEState()
+    for raw in lines:
+        msg = process_line(raw.rstrip("\n"), st)
+        if msg:
+            print(msg)
+    return st
+
+
+def decide_exit(st: SSEState) -> tuple[int, str]:
+    """Map the final stream state to (exit_code, message)."""
+    if st.errored:
+        return 1, f"::error::Sandbox error: code={st.err_code} message={st.err_msg}"
+    if not st.got_event:
+        return (
+            1,
+            "::error::Stream ended without a single SSE event — likely VPN/network/proxy issue",
+        )
+    if not st.completed:
+        return 1, "::error::Stream ended without a 'complete' event"
+    if st.status != "completed":
+        return 1, f"::error::Sandbox final status={st.status} (expected 'completed')"
+    return 0, f"Vuln triage completed successfully (cost={st.cost})."
+
+
+def check_health(
+    base_url: str,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> bool:
+    for attempt in range(1, HEALTH_RETRIES + 1):
+        try:
+            with opener(f"{base_url}/health", timeout=10) as resp:
+                status = getattr(resp, "status", None)
+                if status is None:
+                    status = resp.getcode()
+                if status == 200:
+                    print(f"Mothership reachable (attempt {attempt})")
+                    return True
+        except (urllib.error.URLError, OSError) as e:
+            print(f"Mothership unreachable ({e}), retry {attempt}/{HEALTH_RETRIES}")
+        else:
+            print(f"Mothership non-200, retry {attempt}/{HEALTH_RETRIES}")
+        if attempt < HEALTH_RETRIES:
+            sleeper(HEALTH_BACKOFF_SECONDS)
+    return False
+
+
+def main() -> int:
+    base_url = os.environ["MOTHERSHIP_URL"].rstrip("/")
+    token = os.environ["HARNESS_TOKEN"]
+    ticket = os.environ["TICKET"]
+    severity = os.environ.get("SEVERITY", "")
+    gha_run_url = os.environ.get("GHA_RUN_URL", "")
+    run_date = os.environ.get("RUN_DATE") or time.strftime("%Y-%m-%d", time.gmtime())
+
+    if not check_health(base_url):
+        print("::error::Cannot reach mothership after retries")
+        return 1
+
+    payload = build_payload(ticket, severity, run_date, gha_run_url)
+    req = urllib.request.Request(
+        f"{base_url}/api/sandbox/execute",
+        data=json.dumps(payload).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=STREAM_TIMEOUT_SECONDS) as resp:
+            st = process_stream(raw.decode("utf-8", "replace") for raw in resp)
+    except urllib.error.URLError as e:
+        print(f"::error::Sandbox dispatch HTTP error: {e}")
+        return 1
+
+    code, message = decide_exit(st)
+    print(message)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/parse_scan_results.py
+++ b/.github/scripts/parse_scan_results.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Parse the hourly Trivy scan results: counts, step output, workflow summary.
+
+Replaces the inline shell that counted findings and built the GitHub step
+summary — that branching/looping logic now lives here (tested) per
+docs/standards/ci.md.
+
+Reads ``trivy-image-results.json`` and ``trivy-fs-results.json`` from the cwd
+(either may be absent) and:
+  * emits ``total_actionable`` to ``$GITHUB_OUTPUT`` (the Linear-ticket step
+    gates on it);
+  * writes the human-readable vulnerability summary to ``$GITHUB_STEP_SUMMARY``.
+
+Environment:
+    GITHUB_OUTPUT         step output is appended here (optional locally)
+    GITHUB_STEP_SUMMARY   markdown summary is appended here (optional locally)
+    TARGET_IMAGE          shown in the summary header
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+SEVERITIES = ("CRITICAL", "HIGH", "MEDIUM", "LOW")
+IMAGE_FILE = "trivy-image-results.json"
+FS_FILE = "trivy-fs-results.json"
+
+
+def count_by_severity(data: dict | None) -> dict[str, int]:
+    """Count vulnerabilities per severity in a parsed Trivy document."""
+    counts = dict.fromkeys(SEVERITIES, 0)
+    if not data:
+        return counts
+    for result in data.get("Results", []) or []:
+        for vuln in result.get("Vulnerabilities", []) or []:
+            sev = (vuln.get("Severity") or "").upper()
+            if sev in counts:
+                counts[sev] += 1
+    return counts
+
+
+def load(path: str) -> dict | None:
+    p = Path(path)
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except json.JSONDecodeError:
+        print(f"warning: {path} is not valid JSON; treating as empty")
+        return None
+
+
+def build_summary(image: dict[str, int], fs: dict[str, int], target_image: str) -> str:
+    total = {s: image[s] + fs[s] for s in SEVERITIES}
+    total_actionable = sum(total.values())
+    emoji = {"CRITICAL": "🔴", "HIGH": "🟠", "MEDIUM": "🟡", "LOW": "🔵"}
+    label = {"CRITICAL": "Critical", "HIGH": "High", "MEDIUM": "Medium", "LOW": "Low"}
+    lines = [
+        f"## Hourly Security Scan — `{target_image}` + SDK Python Deps",
+        "",
+        "### Vulnerability Summary",
+        "",
+        "| Severity | Trivy (Image) | Trivy (Deps) | Total |",
+        "|----------|:-------------:|:--------------:|------:|",
+    ]
+    for s in SEVERITIES:
+        lines.append(
+            f"| {emoji[s]} {label[s]} | {image[s]} | {fs[s]} | **{total[s]}** |"
+        )
+    lines.append("")
+    if total_actionable > 0:
+        lines.append(
+            f"> ⚠️ **{total_actionable} findings (all severities) — "
+            "see Linear ticket step below**"
+        )
+    else:
+        lines.append("> ✅ **No findings**")
+    return "\n".join(lines)
+
+
+def _emit_output(name: str, value: str) -> None:
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a") as f:
+            f.write(f"{name}={value}\n")
+
+
+def _emit_summary(text: str) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if path:
+        with open(path, "a") as f:
+            f.write(text + "\n")
+
+
+def main() -> int:
+    image = count_by_severity(load(IMAGE_FILE))
+    fs = count_by_severity(load(FS_FILE))
+    total_actionable = sum(image[s] + fs[s] for s in SEVERITIES)
+
+    _emit_output("total_actionable", str(total_actionable))
+    _emit_summary(build_summary(image, fs, os.environ.get("TARGET_IMAGE", "(unknown)")))
+
+    print(
+        f"Trivy Image  — C:{image['CRITICAL']} H:{image['HIGH']} "
+        f"M:{image['MEDIUM']} L:{image['LOW']}"
+    )
+    print(
+        f"Trivy Python — C:{fs['CRITICAL']} H:{fs['HIGH']} "
+        f"M:{fs['MEDIUM']} L:{fs['LOW']}"
+    )
+    print(f"Total findings (all severities): {total_actionable}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/reconcile_allowlist.py
+++ b/.github/scripts/reconcile_allowlist.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Reconcile the allowlist + tickets against what the scanner still sees.
+
+Closing the loop on the zero-human-touch CVE flow: once a CVE stops showing up
+in the scan (its bump merged & shipped, or the base image was rebuilt), its
+allowlist entry and Linear ticket should be retired automatically.
+
+**3-consecutive-clean-scan debounce.** A CVE is treated as *resolved* only if it
+is absent from the current scan AND the previous two hourly scans (three runs in
+agreement). CVEs vanish transiently — Trivy DB reclassification, a partial scan,
+or the `uv sync` native-lockfile step not materializing a wheel — so a single
+clean scan is not enough to yank a valid suppression.
+
+For each resolved CVE:
+  * if it has an open allowlist entry → open an **allowlist removal PR** (touches
+    only `.security/base-allowlist.json`, label `vuln-auto-merge` → auto-merges
+    via vuln-auto-merge.yml as `atlan-ci`).
+  * a Linear ticket is closed only when ALL the CVEs it tracks are resolved;
+    otherwise its marker is rewritten to drop just the resolved CVE.
+
+Pure decision logic (the debounce + ticket plan) lives in tested functions;
+GitHub/Linear I/O is wired in main(), per docs/standards/ci.md.
+
+Environment:
+    REPO                 owner/name (default atlanhq/application-sdk)
+    GH_TOKEN             atlan-ci PAT (push branch + open the removal PR)
+    LINEAR_API_KEY       to close / update tickets (optional; skipped if unset)
+    SCAN_WORKFLOW        default 'daily-security-scan.yml'
+    RUN_DATE             ISO date, for branch/commit naming
+
+Optional:
+    LINEAR_VULN_LABEL_NAME  default 'vulnerabilities'
+    DEBOUNCE_SCANS          default 3 (this scan + N-1 prior)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import security_scan_create_linear as ssl  # reuse Linear helpers
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+ALLOWLIST_PATH = ".security/base-allowlist.json"
+TRIVY_FILES = ["trivy-image-results.json", "trivy-fs-results.json"]
+DEFAULT_WORKFLOW = "daily-security-scan.yml"
+
+
+# ---------------------------------------------------------------------------
+# Pure logic (tested)
+# ---------------------------------------------------------------------------
+
+
+def cve_ids_from_trivy(data: dict) -> set[str]:
+    """Every VulnerabilityID across a parsed Trivy JSON document."""
+    ids: set[str] = set()
+    for result in data.get("Results", []) or []:
+        for vuln in result.get("Vulnerabilities", []) or []:
+            vid = vuln.get("VulnerabilityID")
+            if vid:
+                ids.add(vid)
+    return ids
+
+
+def resolved_cves(
+    allowlisted: set[str],
+    scan_sets: list[set[str]],
+    debounce: int,
+) -> set[str]:
+    """Allowlisted CVEs absent from EVERY one of the last ``debounce`` scans.
+
+    ``scan_sets`` is the CVE set per recent scan (current + priors). If we have
+    fewer than ``debounce`` scans we cannot confirm the debounce, so nothing is
+    resolved (fail-safe — never yank a suppression on thin evidence).
+    """
+    if len([s for s in scan_sets if s is not None]) < debounce:
+        return set()
+    seen_in_any = set().union(*scan_sets) if scan_sets else set()
+    return {cve for cve in allowlisted if cve not in seen_in_any}
+
+
+def plan_ticket_updates(
+    tickets: list[dict], resolved: set[str]
+) -> tuple[list[dict], list[dict]]:
+    """Split open tickets into (to_close, to_update).
+
+    A ticket's tracked CVEs come from its ``<!-- vuln-ids: ... -->`` marker.
+    Close it when every tracked CVE is resolved; otherwise rewrite the marker to
+    drop the resolved ones. Tickets with no resolved CVEs are left untouched.
+    """
+    to_close: list[dict] = []
+    to_update: list[dict] = []
+    for t in tickets:
+        tracked = ssl.extract_vuln_ids_from_description(t.get("description"))
+        if not tracked:
+            continue
+        resolved_here = tracked & resolved
+        if not resolved_here:
+            continue
+        remaining = tracked - resolved
+        if not remaining:
+            to_close.append(t)
+        else:
+            to_update.append({**t, "remaining_ids": sorted(remaining)})
+    return to_close, to_update
+
+
+# ---------------------------------------------------------------------------
+# GitHub I/O
+# ---------------------------------------------------------------------------
+
+
+def load_current_cves() -> set[str]:
+    ids: set[str] = set()
+    for fname in TRIVY_FILES:
+        p = Path(fname)
+        if p.exists():
+            try:
+                ids |= cve_ids_from_trivy(json.loads(p.read_text()))
+            except json.JSONDecodeError:
+                print(f"warning: {fname} invalid JSON; skipping")
+    return ids
+
+
+def load_prior_scan_cves(
+    repo: str, workflow: str, count: int, runner: Runner
+) -> list[set[str]]:
+    """Download the ``count`` most recent prior successful scan artifacts and
+    return their CVE sets. Best-effort: runs without the artifact are skipped."""
+    listing = runner(
+        [
+            "gh",
+            "run",
+            "list",
+            "-R",
+            repo,
+            "--workflow",
+            workflow,
+            "--status",
+            "success",
+            "--limit",
+            str(count + 2),
+            "--json",
+            "databaseId",
+            "--jq",
+            ".[].databaseId",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if listing.returncode != 0 or not (listing.stdout or "").strip():
+        return []
+    run_ids = listing.stdout.split()
+    sets: list[set[str]] = []
+    for rid in run_ids:
+        if len(sets) >= count:
+            break
+        with tempfile.TemporaryDirectory() as td:
+            dl = runner(
+                [
+                    "gh",
+                    "run",
+                    "download",
+                    rid,
+                    "-R",
+                    repo,
+                    "-n",
+                    "security-scan-raw-results",
+                    "-D",
+                    td,
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if dl.returncode != 0:
+                continue
+            ids: set[str] = set()
+            for fname in TRIVY_FILES:
+                p = Path(td) / fname
+                if p.exists():
+                    try:
+                        ids |= cve_ids_from_trivy(json.loads(p.read_text()))
+                    except json.JSONDecodeError:
+                        pass
+            sets.append(ids)
+    return sets
+
+
+def open_removal_pr(
+    repo: str, removed: list[str], run_date: str, runner: Runner
+) -> None:
+    """Drop resolved entries from the allowlist and open an auto-merge PR."""
+    data = json.loads(Path(ALLOWLIST_PATH).read_text())
+    for cve in removed:
+        data.pop(cve, None)
+    Path(ALLOWLIST_PATH).write_text(json.dumps(data, indent=2) + "\n")
+
+    # GITHUB_RUN_ID keeps the branch unique across same-day reconcile runs.
+    suffix = os.environ.get("GITHUB_RUN_ID", run_date) or run_date
+    branch = f"chore/allowlist-remove-{suffix}"
+    joined = ", ".join(removed)
+    runner(["git", "checkout", "-b", branch], check=True)
+    runner(["git", "add", ALLOWLIST_PATH], check=True)
+    runner(
+        [
+            "git",
+            "commit",
+            "-m",
+            f"chore(security): remove resolved allowlist entries ({joined})",
+        ],
+        check=True,
+    )
+    runner(["git", "push", "origin", branch], check=True)
+    runner(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            repo,
+            "--base",
+            "main",
+            "--title",
+            f"chore(security): remove {len(removed)} resolved allowlist entr"
+            + ("y" if len(removed) == 1 else "ies"),
+            "--label",
+            "vuln-auto-merge",
+            "--body",
+            "Resolved by 3 consecutive clean scans (scanner no longer reports "
+            "these CVEs):\n\n" + "\n".join(f"- `{c}`" for c in removed),
+        ],
+        check=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Linear I/O
+# ---------------------------------------------------------------------------
+
+
+def resolve_done_state_id(team_id: str) -> str | None:
+    data = ssl.gql(
+        """
+        query TeamStates($teamId: String!) {
+          team(id: $teamId) { states { nodes { id name type } } }
+        }
+        """,
+        {"teamId": team_id},
+    )
+    states = ((data.get("team") or {}).get("states") or {}).get("nodes") or []
+    for s in states:
+        if s.get("type") == "completed":
+            return s["id"]
+    return None
+
+
+def close_ticket(issue_id: str, state_id: str) -> None:
+    ssl.gql(
+        """
+        mutation Close($id: String!, $stateId: String!) {
+          issueUpdate(id: $id, input: { stateId: $stateId }) { success }
+        }
+        """,
+        {"id": issue_id, "stateId": state_id},
+    )
+
+
+def rewrite_marker(issue_id: str, description: str, remaining_ids: list[str]) -> None:
+    marker = (
+        f"{ssl.VULN_MARKER_PREFIX}{','.join(remaining_ids)}{ssl.VULN_MARKER_SUFFIX}"
+    )
+    new_desc = []
+    replaced = False
+    for line in (description or "").splitlines():
+        s = line.strip()
+        if s.startswith(ssl.VULN_MARKER_PREFIX) and s.endswith(ssl.VULN_MARKER_SUFFIX):
+            new_desc.append(marker)
+            replaced = True
+        else:
+            new_desc.append(line)
+    if not replaced:
+        new_desc.append(marker)
+    ssl.gql(
+        """
+        mutation Update($id: String!, $desc: String!) {
+          issueUpdate(id: $id, input: { description: $desc }) { success }
+        }
+        """,
+        {"id": issue_id, "desc": "\n".join(new_desc)},
+    )
+
+
+def reconcile_tickets(resolved: set[str]) -> None:
+    if not os.environ.get("LINEAR_API_KEY") or not os.environ.get("LINEAR_TEAM_ID"):
+        print("LINEAR_API_KEY/TEAM_ID not set — skipping ticket reconciliation.")
+        return
+    team_id = os.environ["LINEAR_TEAM_ID"]
+    label_name = os.environ.get("LINEAR_VULN_LABEL_NAME", "vulnerabilities")
+    label_id = ssl.resolve_label_id(label_name, team_id)
+    if not label_id:
+        print(f"label {label_name!r} not found — skipping ticket reconciliation.")
+        return
+    tickets = ssl.fetch_open_labelled_issues(label_id)
+    to_close, to_update = plan_ticket_updates(tickets, resolved)
+    done_state = resolve_done_state_id(team_id) if to_close else None
+    for t in to_close:
+        if done_state:
+            close_ticket(t["id"], done_state)
+            print(f"Closed {t['identifier']} (all tracked CVEs resolved).")
+    for t in to_update:
+        rewrite_marker(t["id"], t.get("description", ""), t["remaining_ids"])
+        print(f"Updated {t['identifier']} marker (dropped resolved CVEs).")
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def load_allowlisted_cves() -> set[str]:
+    try:
+        data = json.loads(Path(ALLOWLIST_PATH).read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return set()
+    return {k for k in data if not k.startswith("_")}
+
+
+def main(runner: Runner = subprocess.run) -> int:
+    repo = os.environ.get("REPO", "atlanhq/application-sdk")
+    workflow = os.environ.get("SCAN_WORKFLOW", DEFAULT_WORKFLOW)
+    run_date = os.environ.get("RUN_DATE", "")
+    debounce = int(os.environ.get("DEBOUNCE_SCANS", "3"))
+
+    allowlisted = load_allowlisted_cves()
+    if not allowlisted:
+        print("Allowlist has no entries — nothing to reconcile.")
+        return 0
+
+    current = load_current_cves()
+    priors = load_prior_scan_cves(repo, workflow, debounce - 1, runner)
+    scan_sets = [current, *priors]
+
+    resolved = resolved_cves(allowlisted, scan_sets, debounce)
+    if not resolved:
+        print(
+            f"No allowlisted CVE absent across {debounce} consecutive scans "
+            f"(have {len(scan_sets)} scan set(s)). Nothing to remove."
+        )
+        return 0
+
+    removed = sorted(resolved)
+    print(f"Resolved (gone for {debounce} scans): {', '.join(removed)}")
+    open_removal_pr(repo, removed, run_date, runner)
+    reconcile_tickets(resolved)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/reconcile_allowlist.py
+++ b/.github/scripts/reconcile_allowlist.py
@@ -81,7 +81,7 @@ def resolved_cves(
     fewer than ``debounce`` scans we cannot confirm the debounce, so nothing is
     resolved (fail-safe — never yank a suppression on thin evidence).
     """
-    if len([s for s in scan_sets if s is not None]) < debounce:
+    if len(scan_sets) < debounce:
         return set()
     seen_in_any = set().union(*scan_sets) if scan_sets else set()
     return {cve for cve in allowlisted if cve not in seen_in_any}

--- a/.github/scripts/security_scan_create_linear.py
+++ b/.github/scripts/security_scan_create_linear.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Create a Linear ticket for daily security scan findings, with dedup.
+"""Create Linear tickets for daily security scan findings, with dedup.
+
+One ticket is filed **per severity level** (Critical / High / Medium / Low)
+so each carries its own remediation SLA and priority and is triaged
+independently by the vuln-triage rover.
 
 Compared to a naive "create one ticket per run":
 - Every finding (all severities) is identified by a stable ID (Trivy CVE).
@@ -8,14 +12,16 @@ Compared to a naive "create one ticket per run":
   hidden marker line in each description:
       <!-- vuln-ids: id1,id2,id3 -->
   IDs already covered by an open labelled issue are removed from
-  today's set.
+  today's set (dedup is global — a CVE tracked by any open ticket of any
+  severity is not refiled).
 - If every finding is already covered, no new issue is created — we
   just record that fact in the workflow summary.
-- Otherwise, a new issue is created listing only the *new* IDs, tagged
-  with the same label so the next run dedups against it. The full
-  marker (every finding seen today) is included.
+- Otherwise the remaining *new* findings are partitioned by severity and
+  one ticket per non-empty severity is created, tagged with the same label
+  so the next run dedups against it. Each ticket's marker lists only the
+  CVE IDs of its own severity (the ones it tracks).
 
-The new issue is created in the team's "Backlog" state (not Triage).
+Each new issue is created in the team's "Backlog" state (not Triage).
 The ``Backlog`` state is resolved at runtime from the team's workflow.
 
 The label name defaults to ``vulnerabilities`` and must already exist
@@ -35,7 +41,8 @@ Optional:
     LINEAR_ASSIGNEE_ID
     LINEAR_VULN_LABEL_NAME  default: "vulnerabilities"
     GITHUB_STEP_SUMMARY     Markdown is appended for visibility
-    GITHUB_OUTPUT           new_issue_identifier / new_issue_url emitted here
+    GITHUB_OUTPUT           ``new_issues`` (JSON array of {identifier, url,
+                            severity}) is emitted here for the dispatch step
 """
 
 from __future__ import annotations
@@ -66,6 +73,17 @@ ACTIONABLE_SEVERITIES_TRIVY = {"CRITICAL", "HIGH", "MEDIUM", "LOW"}
 
 # Lower rank sorts first.
 SEVERITY_RANK = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3}
+
+# One ticket is filed per severity level so each carries the right SLA and
+# priority and is triaged independently. Map each severity to a Linear
+# priority (1=Urgent … 4=Low) and a human label for the title.
+SEVERITY_PRIORITY = {"CRITICAL": 1, "HIGH": 2, "MEDIUM": 3, "LOW": 4}
+SEVERITY_LABEL = {
+    "CRITICAL": "Critical",
+    "HIGH": "High",
+    "MEDIUM": "Medium",
+    "LOW": "Low",
+}
 
 
 def gql(query: str, variables: dict[str, Any]) -> dict[str, Any]:
@@ -261,25 +279,28 @@ def render_table(findings: list[dict]) -> str:
 
 def build_description(
     new_findings: list[dict],
-    all_today_ids: list[str],
+    severity: str,
     target_image: str,
     scan_date: str,
     run_url: str,
 ) -> str:
+    """Render a per-severity ticket body. The marker lists only this
+    severity's CVE IDs (the ones this ticket tracks)."""
     new_ids = [f["id"] for f in new_findings]
     visible_ids = "\n".join(f"- `{vid}`" for vid in new_ids)
     table = render_table(new_findings)
-    marker = f"{VULN_MARKER_PREFIX}{','.join(all_today_ids)}{VULN_MARKER_SUFFIX}"
+    marker = f"{VULN_MARKER_PREFIX}{','.join(new_ids)}{VULN_MARKER_SUFFIX}"
     plural = "y" if len(new_findings) == 1 else "ies"
-    return f"""## Daily Security Scan — New Findings
+    sev_label = SEVERITY_LABEL.get(severity, severity.title())
+    return f"""## Daily Security Scan — New {sev_label} Findings
 
 **Image:** `{target_image}`
 **Python deps:** `pyproject.toml` / `uv.lock` (application-sdk)
 **Scan date:** {scan_date}
 **Workflow run:** [View logs]({run_url})
 
-This issue tracks **{len(new_findings)} new** vulnerabilit{plural} \
-(all severities) not already covered by an open Linear issue in this project.
+This issue tracks **{len(new_findings)} new {sev_label}** vulnerabilit{plural} \
+not already covered by an open Linear issue in this project.
 
 ---
 
@@ -321,6 +342,76 @@ def emit_output(name: str, value: str) -> None:
     if output_path:
         with open(output_path, "a") as f:
             f.write(f"{name}={value}\n")
+
+
+def create_issue(
+    severity: str,
+    bucket: list[dict],
+    *,
+    team_id: str,
+    project_id: str,
+    label_id: str,
+    backlog_state_id: str | None,
+    target_image: str,
+    scan_date: str,
+    run_url: str,
+) -> dict | None:
+    """Create one per-severity Linear issue. Returns {identifier, url,
+    severity} on success, else None."""
+    sev_label = SEVERITY_LABEL.get(severity, severity.title())
+    description = build_description(bucket, severity, target_image, scan_date, run_url)
+    title = (
+        f"[Security][{sev_label}] {len(bucket)} new "
+        f"vulnerabilit{'y' if len(bucket) == 1 else 'ies'} ({scan_date})"
+    )
+
+    issue_input: dict[str, Any] = {
+        "title": title,
+        "description": description,
+        "teamId": team_id,
+        "projectId": project_id,
+        "priority": SEVERITY_PRIORITY.get(severity, 2),
+        "labelIds": [label_id],
+    }
+    for env_key, payload_key in [
+        ("LINEAR_MILESTONE_ID", "projectMilestoneId"),
+        ("LINEAR_ASSIGNEE_ID", "assigneeId"),
+    ]:
+        val = os.environ.get(env_key)
+        if val:
+            issue_input[payload_key] = val
+    if backlog_state_id:
+        issue_input["stateId"] = backlog_state_id
+
+    data = gql(
+        """
+        mutation CreateIssue($input: IssueCreateInput!) {
+          issueCreate(input: $input) {
+            success
+            issue { id identifier url }
+          }
+        }
+        """,
+        {"input": issue_input},
+    )
+    result = data.get("issueCreate") or {}
+    if not result.get("success"):
+        sys.stderr.write(
+            f"Linear issueCreate returned success=false for {severity}: "
+            f"{json.dumps(data)}\n"
+        )
+        return None
+
+    issue = result.get("issue") or {}
+    write_summary(
+        f"### Linear Issue ({sev_label}): "
+        f"[{issue.get('identifier')}]({issue.get('url')})"
+    )
+    return {
+        "identifier": issue.get("identifier") or "",
+        "url": issue.get("url") or "",
+        "severity": severity,
+    }
 
 
 def main() -> int:
@@ -375,64 +466,44 @@ def main() -> int:
         )
         return 0
 
-    write_summary(f"> ⚠️ {len(new_findings)} new finding(s) — creating Linear issue.")
+    # Partition new findings by severity → one ticket per non-empty bucket.
+    buckets: dict[str, list[dict]] = {}
+    for f in new_findings:
+        buckets.setdefault(f["severity"], []).append(f)
+    ordered_severities = sorted(buckets, key=lambda s: SEVERITY_RANK.get(s, 99))
+
+    write_summary(
+        f"> ⚠️ {len(new_findings)} new finding(s) across "
+        f"{len(ordered_severities)} severit{'y' if len(ordered_severities) == 1 else 'ies'} "
+        "— creating one Linear issue per severity."
+    )
 
     backlog_state_id = resolve_backlog_state_id(team_id)
     if not backlog_state_id:
-        print("warning: could not resolve Backlog state — issue will use team default")
+        print("warning: could not resolve Backlog state — issues will use team default")
 
     target_image = os.environ.get("TARGET_IMAGE", "(unknown)")
     scan_date = os.environ.get("SCAN_DATE", "")
     run_url = os.environ.get("RUN_URL", "")
 
-    description = build_description(
-        new_findings, today_ids, target_image, scan_date, run_url
-    )
-    title = (
-        f"[Security] {len(new_findings)} new "
-        f"vulnerabilit{'y' if len(new_findings) == 1 else 'ies'} ({scan_date})"
-    )
-
-    issue_input: dict[str, Any] = {
-        "title": title,
-        "description": description,
-        "teamId": team_id,
-        "projectId": project_id,
-        "priority": 2,
-        "labelIds": [label_id],
-    }
-    for env_key, payload_key in [
-        ("LINEAR_MILESTONE_ID", "projectMilestoneId"),
-        ("LINEAR_ASSIGNEE_ID", "assigneeId"),
-    ]:
-        val = os.environ.get(env_key)
-        if val:
-            issue_input[payload_key] = val
-    if backlog_state_id:
-        issue_input["stateId"] = backlog_state_id
-
-    data = gql(
-        """
-        mutation CreateIssue($input: IssueCreateInput!) {
-          issueCreate(input: $input) {
-            success
-            issue { id identifier url }
-          }
-        }
-        """,
-        {"input": issue_input},
-    )
-    result = data.get("issueCreate") or {}
-    if not result.get("success"):
-        sys.stderr.write(
-            f"Linear issueCreate returned success=false: {json.dumps(data)}\n"
+    created: list[dict] = []
+    for severity in ordered_severities:
+        issue = create_issue(
+            severity,
+            buckets[severity],
+            team_id=team_id,
+            project_id=project_id,
+            label_id=label_id,
+            backlog_state_id=backlog_state_id,
+            target_image=target_image,
+            scan_date=scan_date,
+            run_url=run_url,
         )
-        return 1
+        if issue is None:
+            return 1
+        created.append(issue)
 
-    issue = result.get("issue") or {}
-    write_summary(f"### Linear Issue: [{issue.get('identifier')}]({issue.get('url')})")
-    emit_output("new_issue_identifier", issue.get("identifier") or "")
-    emit_output("new_issue_url", issue.get("url") or "")
+    emit_output("new_issues", json.dumps(created))
     return 0
 
 

--- a/.github/scripts/tests/test_dispatch_vuln_triage.py
+++ b/.github/scripts/tests/test_dispatch_vuln_triage.py
@@ -1,0 +1,92 @@
+"""Tests for .github/scripts/dispatch_vuln_triage.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import dispatch_vuln_triage as dvt
+
+
+def _ok(*_args, **_kwargs):
+    return subprocess.CompletedProcess(args=[], returncode=0)
+
+
+def test_parse_issues_empty():
+    assert dvt.parse_issues(None) == []
+    assert dvt.parse_issues("") == []
+    assert dvt.parse_issues("  ") == []
+    assert dvt.parse_issues("[]") == []
+
+
+def test_parse_issues_valid():
+    raw = '[{"identifier": "BLDX-1", "severity": "CRITICAL"}]'
+    assert dvt.parse_issues(raw) == [{"identifier": "BLDX-1", "severity": "CRITICAL"}]
+
+
+def test_parse_issues_invalid_json():
+    with pytest.raises(SystemExit):
+        dvt.parse_issues("{not json")
+
+
+def test_parse_issues_not_a_list():
+    with pytest.raises(SystemExit):
+        dvt.parse_issues('{"identifier": "BLDX-1"}')
+
+
+def test_dispatch_runs_once_per_issue():
+    calls = []
+
+    def runner(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+    issues = [
+        {"identifier": "BLDX-1", "severity": "CRITICAL"},
+        {"identifier": "BLDX-2", "severity": "HIGH"},
+    ]
+    n = dvt.dispatch(issues, ref="main", runner=runner)
+    assert n == 2
+    assert len(calls) == 2
+    # Each command carries the ticket and severity as -f args.
+    assert "ticket=BLDX-1" in calls[0]
+    assert "severity=CRITICAL" in calls[0]
+    assert "ticket=BLDX-2" in calls[1]
+    assert "severity=HIGH" in calls[1]
+    assert "--ref" in calls[0] and "main" in calls[0]
+
+
+def test_dispatch_missing_identifier_raises():
+    with pytest.raises(SystemExit):
+        dvt.dispatch([{"severity": "HIGH"}], ref="main", runner=_ok)
+
+
+def test_dispatch_nonzero_exit_raises():
+    def runner(cmd, **kwargs):
+        return subprocess.CompletedProcess(args=cmd, returncode=1)
+
+    with pytest.raises(SystemExit):
+        dvt.dispatch(
+            [{"identifier": "BLDX-1", "severity": "HIGH"}], ref="main", runner=runner
+        )
+
+
+def test_dispatch_uses_custom_workflow_name():
+    calls = []
+
+    def runner(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+    dvt.dispatch(
+        [{"identifier": "BLDX-1", "severity": "LOW"}],
+        ref="feature",
+        workflow="custom.yml",
+        runner=runner,
+    )
+    assert "custom.yml" in calls[0]

--- a/.github/scripts/tests/test_mothership_sandbox_dispatch.py
+++ b/.github/scripts/tests/test_mothership_sandbox_dispatch.py
@@ -1,0 +1,144 @@
+"""Tests for .github/scripts/mothership_sandbox_dispatch.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import mothership_sandbox_dispatch as md
+
+
+def _stream(*lines: str):
+    return md.process_stream(list(lines))
+
+
+# ---------------------------------------------------------------------------
+# SSE state machine + exit decision
+# ---------------------------------------------------------------------------
+
+
+def test_successful_complete_stream():
+    st = _stream(
+        "event: started",
+        'data: {"session_id": "s1", "sandbox_id": "b1"}',
+        "",
+        "event: complete",
+        'data: {"status": "completed", "cost_usd": "0.42"}',
+        "",
+    )
+    code, msg = md.decide_exit(st)
+    assert code == 0
+    assert "completed successfully" in msg
+    assert st.cost == "0.42"
+
+
+def test_error_event_fails():
+    st = _stream(
+        "event: error",
+        'data: {"code": "boom", "message": "kaboom"}',
+        "",
+    )
+    code, msg = md.decide_exit(st)
+    assert code == 1
+    assert "boom" in msg
+
+
+def test_elicitation_treated_as_error():
+    st = _stream("event: elicitation", "data: {}", "")
+    assert st.errored is True
+    assert md.decide_exit(st)[0] == 1
+
+
+def test_complete_with_error_status_fails():
+    st = _stream(
+        "event: complete",
+        'data: {"status": "error", "error": {"code": "X", "message": "y"}}',
+        "",
+    )
+    code, _ = md.decide_exit(st)
+    assert code == 1
+    assert st.status == "error"
+
+
+def test_no_events_fails():
+    st = _stream("", ":", "  ")  # comments / blanks only
+    code, msg = md.decide_exit(st)
+    assert code == 1
+    assert "without a single SSE event" in msg
+
+
+def test_events_but_no_complete_fails():
+    st = _stream("event: action", 'data: {"action_name": "Read"}', "")
+    code, msg = md.decide_exit(st)
+    assert code == 1
+    assert "without a 'complete' event" in msg
+
+
+def test_event_resets_on_blank_line():
+    # A data line after a blank line (no event) is ignored, not misattributed.
+    st = _stream("event: started", "", 'data: {"status": "completed"}')
+    assert st.completed is False  # the trailing data had no active event
+
+
+def test_malformed_json_data_does_not_crash():
+    st = _stream("event: complete", "data: {not json", "")
+    # complete was seen, status defaults to "unknown" -> non-completed -> fail
+    assert st.completed is True
+    assert md.decide_exit(st)[0] == 1
+
+
+# ---------------------------------------------------------------------------
+# prompt / payload
+# ---------------------------------------------------------------------------
+
+
+def test_payload_shape():
+    p = md.build_payload("BLDX-1", "CRITICAL", "2026-06-25", "http://run")
+    assert p["mode"] == "direct"
+    assert p["repositories"] == ["atlanhq/application-sdk"]
+    assert p["source_id"] == "vuln-triage-BLDX-1-2026-06-25"
+    assert p["metadata"]["severity"] == "CRITICAL"
+    assert "BLDX-1" in p["prompt"] and "CRITICAL" in p["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# health check
+# ---------------------------------------------------------------------------
+
+
+class _Resp:
+    def __init__(self, status):
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_health_succeeds_first_try():
+    calls = []
+
+    def opener(url, timeout=0):
+        calls.append(url)
+        return _Resp(200)
+
+    assert md.check_health("http://m", opener=opener, sleeper=lambda _s: None) is True
+    assert len(calls) == 1
+
+
+def test_health_retries_then_fails():
+    attempts = []
+
+    def opener(url, timeout=0):
+        attempts.append(url)
+        return _Resp(503)
+
+    slept = []
+    ok = md.check_health("http://m", opener=opener, sleeper=lambda s: slept.append(s))
+    assert ok is False
+    assert len(attempts) == md.HEALTH_RETRIES
+    assert len(slept) == md.HEALTH_RETRIES - 1  # no sleep after the last attempt

--- a/.github/scripts/tests/test_parse_scan_results.py
+++ b/.github/scripts/tests/test_parse_scan_results.py
@@ -1,0 +1,80 @@
+"""Tests for .github/scripts/parse_scan_results.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import parse_scan_results as psr
+
+
+def _doc(*sevs: str) -> dict:
+    return {
+        "Results": [
+            {
+                "Vulnerabilities": [
+                    {
+                        "Severity": s,
+                        "PkgName": "p",
+                        "InstalledVersion": "1",
+                        "FixedVersion": "2",
+                        "VulnerabilityID": f"CVE-{i}",
+                    }
+                    for i, s in enumerate(sevs)
+                ]
+            }
+        ]
+    }
+
+
+def test_count_by_severity():
+    counts = psr.count_by_severity(_doc("CRITICAL", "HIGH", "HIGH", "low", "UNKNOWN"))
+    assert counts == {"CRITICAL": 1, "HIGH": 2, "MEDIUM": 0, "LOW": 1}
+
+
+def test_count_empty_or_none():
+    assert psr.count_by_severity(None) == dict.fromkeys(psr.SEVERITIES, 0)
+    assert psr.count_by_severity({}) == dict.fromkeys(psr.SEVERITIES, 0)
+
+
+def test_build_summary_with_findings():
+    image = {"CRITICAL": 1, "HIGH": 0, "MEDIUM": 2, "LOW": 0}
+    fs = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 0, "LOW": 3}
+    out = psr.build_summary(image, fs, "img:1")
+    assert "img:1" in out
+    assert "**7 findings" in out  # 1+2+1+3
+    # Medium total is rendered as 2 (regression guard for the key-suffix bug).
+    assert "| 🟡 Medium | 2 | 0 | **2** |" in out
+
+
+def test_build_summary_no_findings():
+    zero = dict.fromkeys(psr.SEVERITIES, 0)
+    out = psr.build_summary(zero, zero, "img:1")
+    assert "✅ **No findings**" in out
+
+
+def test_main_emits_output_and_summary(tmp_path, monkeypatch):
+    (tmp_path / "trivy-image-results.json").write_text(json.dumps(_doc("CRITICAL")))
+    (tmp_path / "trivy-fs-results.json").write_text(json.dumps(_doc("HIGH", "MEDIUM")))
+    monkeypatch.chdir(tmp_path)
+    out = tmp_path / "out.txt"
+    summ = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summ))
+    monkeypatch.setenv("TARGET_IMAGE", "img:1")
+
+    assert psr.main() == 0
+    assert "total_actionable=3" in out.read_text()
+    assert "Vulnerability Summary" in summ.read_text()
+
+
+def test_main_no_files_is_zero(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    out = tmp_path / "out.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    assert psr.main() == 0
+    assert "total_actionable=0" in out.read_text()

--- a/.github/scripts/tests/test_reconcile_allowlist.py
+++ b/.github/scripts/tests/test_reconcile_allowlist.py
@@ -1,0 +1,111 @@
+"""Tests for .github/scripts/reconcile_allowlist.py (debounce + ticket plan)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import reconcile_allowlist as rec
+
+# ---------------------------------------------------------------------------
+# cve_ids_from_trivy
+# ---------------------------------------------------------------------------
+
+
+def test_cve_ids_from_trivy():
+    data = {
+        "Results": [
+            {
+                "Vulnerabilities": [
+                    {"VulnerabilityID": "CVE-1"},
+                    {"VulnerabilityID": "CVE-2"},
+                ]
+            },
+            {"Vulnerabilities": [{"VulnerabilityID": "CVE-2"}]},
+            {"Vulnerabilities": None},
+        ]
+    }
+    assert rec.cve_ids_from_trivy(data) == {"CVE-1", "CVE-2"}
+
+
+def test_cve_ids_from_empty():
+    assert rec.cve_ids_from_trivy({}) == set()
+
+
+# ---------------------------------------------------------------------------
+# resolved_cves — the 3-scan debounce
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_when_absent_in_all_three_scans():
+    allowlisted = {"CVE-GONE", "CVE-STILL"}
+    scans = [{"CVE-STILL"}, {"CVE-STILL"}, {"CVE-STILL"}]  # CVE-GONE absent in all
+    assert rec.resolved_cves(allowlisted, scans, debounce=3) == {"CVE-GONE"}
+
+
+def test_not_resolved_if_present_in_one_recent_scan():
+    allowlisted = {"CVE-X"}
+    scans = [set(), {"CVE-X"}, set()]  # reappeared in the middle scan
+    assert rec.resolved_cves(allowlisted, scans, debounce=3) == set()
+
+
+def test_not_resolved_with_insufficient_scan_history():
+    # Only 2 scans available but debounce wants 3 → fail-safe, remove nothing.
+    allowlisted = {"CVE-X"}
+    scans = [set(), set()]
+    assert rec.resolved_cves(allowlisted, scans, debounce=3) == set()
+
+
+def test_only_allowlisted_cves_are_candidates():
+    allowlisted = {"CVE-A"}
+    scans = [set(), set(), set()]  # CVE-B never allowlisted, so never "resolved"
+    out = rec.resolved_cves(allowlisted, scans, debounce=3)
+    assert out == {"CVE-A"}
+    assert "CVE-B" not in out
+
+
+def test_debounce_of_one_resolves_on_single_clean_scan():
+    assert rec.resolved_cves({"CVE-X"}, [set()], debounce=1) == {"CVE-X"}
+
+
+# ---------------------------------------------------------------------------
+# plan_ticket_updates
+# ---------------------------------------------------------------------------
+
+
+def _ticket(ident: str, ids: list[str]) -> dict:
+    marker = f"<!-- vuln-ids: {','.join(ids)} -->"
+    return {
+        "id": f"id-{ident}",
+        "identifier": ident,
+        "description": f"body\n{marker}\n",
+    }
+
+
+def test_ticket_fully_resolved_is_closed():
+    tickets = [_ticket("BLDX-1", ["CVE-A", "CVE-B"])]
+    to_close, to_update = rec.plan_ticket_updates(tickets, {"CVE-A", "CVE-B"})
+    assert [t["identifier"] for t in to_close] == ["BLDX-1"]
+    assert to_update == []
+
+
+def test_ticket_partially_resolved_is_updated():
+    tickets = [_ticket("BLDX-2", ["CVE-A", "CVE-B"])]
+    to_close, to_update = rec.plan_ticket_updates(tickets, {"CVE-A"})
+    assert to_close == []
+    assert to_update[0]["identifier"] == "BLDX-2"
+    assert to_update[0]["remaining_ids"] == ["CVE-B"]
+
+
+def test_ticket_with_no_resolved_cves_untouched():
+    tickets = [_ticket("BLDX-3", ["CVE-A"])]
+    to_close, to_update = rec.plan_ticket_updates(tickets, {"CVE-Z"})
+    assert to_close == [] and to_update == []
+
+
+def test_ticket_with_no_marker_untouched():
+    tickets = [{"id": "x", "identifier": "BLDX-4", "description": "no marker here"}]
+    to_close, to_update = rec.plan_ticket_updates(tickets, {"CVE-A"})
+    assert to_close == [] and to_update == []

--- a/.github/scripts/tests/test_security_scan_create_linear.py
+++ b/.github/scripts/tests/test_security_scan_create_linear.py
@@ -1,0 +1,205 @@
+"""Tests for .github/scripts/security_scan_create_linear.py (per-severity)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import security_scan_create_linear as ssl
+
+
+def _finding(vid: str, severity: str, pkg: str = "libfoo") -> dict[str, Any]:
+    return {
+        "id": vid,
+        "severity": severity,
+        "package": pkg,
+        "version": "1.0.0",
+        "fixed": "1.0.1",
+        "title": "",
+        "source": "trivy",
+        "scanner_target": "trivy-image-results.json",
+    }
+
+
+# ---------------------------------------------------------------------------
+# build_description
+# ---------------------------------------------------------------------------
+
+
+def test_marker_lists_only_this_severitys_ids():
+    bucket = [_finding("CVE-1", "HIGH"), _finding("CVE-2", "HIGH")]
+    desc = ssl.build_description(bucket, "HIGH", "img:1", "2026-06-25", "http://run")
+    ids = ssl.extract_vuln_ids_from_description(desc)
+    assert ids == {"CVE-1", "CVE-2"}
+    assert "High" in desc
+
+
+def test_description_severity_heading():
+    desc = ssl.build_description(
+        [_finding("CVE-9", "CRITICAL")], "CRITICAL", "img:1", "2026-06-25", "http://run"
+    )
+    assert "Critical" in desc
+
+
+# ---------------------------------------------------------------------------
+# collect_findings (reads trivy json from cwd)
+# ---------------------------------------------------------------------------
+
+
+def test_collect_findings_dedups_and_sorts(tmp_path, monkeypatch):
+    image = {
+        "Results": [
+            {
+                "Vulnerabilities": [
+                    {
+                        "VulnerabilityID": "CVE-LOW",
+                        "Severity": "LOW",
+                        "PkgName": "a",
+                        "InstalledVersion": "1",
+                        "FixedVersion": "2",
+                    },
+                    {
+                        "VulnerabilityID": "CVE-CRIT",
+                        "Severity": "CRITICAL",
+                        "PkgName": "b",
+                        "InstalledVersion": "1",
+                        "FixedVersion": "2",
+                    },
+                ]
+            }
+        ]
+    }
+    (tmp_path / "trivy-image-results.json").write_text(json.dumps(image))
+    monkeypatch.chdir(tmp_path)
+    findings = ssl.collect_findings()
+    # CRITICAL sorts before LOW.
+    assert [f["id"] for f in findings] == ["CVE-CRIT", "CVE-LOW"]
+
+
+# ---------------------------------------------------------------------------
+# main — per-severity ticket creation (gql mocked)
+# ---------------------------------------------------------------------------
+
+
+class _FakeGql:
+    """Routes Linear GraphQL queries by substring and records issueCreate."""
+
+    def __init__(self):
+        self.created: list[dict] = []
+        self._counter = 0
+
+    def __call__(self, query: str, variables: dict) -> dict:
+        if "issueLabels" in query:
+            return {
+                "issueLabels": {
+                    "nodes": [
+                        {
+                            "id": "label-1",
+                            "name": "vulnerabilities",
+                            "team": {"id": "team-1"},
+                        }
+                    ]
+                }
+            }
+        if "OpenLabelled" in query or "issues(" in query:
+            return {"issues": {"pageInfo": {"hasNextPage": False}, "nodes": []}}
+        if "TeamStates" in query or "team(id" in query:
+            return {
+                "team": {
+                    "states": {
+                        "nodes": [
+                            {"id": "st-backlog", "name": "Backlog", "type": "backlog"}
+                        ]
+                    }
+                }
+            }
+        if "issueCreate" in query:
+            self._counter += 1
+            self.created.append(variables["input"])
+            ident = f"BLDX-{self._counter}"
+            return {
+                "issueCreate": {
+                    "success": True,
+                    "issue": {
+                        "id": f"id-{self._counter}",
+                        "identifier": ident,
+                        "url": f"http://x/{ident}",
+                    },
+                }
+            }
+        raise AssertionError(f"unexpected query: {query[:60]}")
+
+
+def _env(monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "k")
+    monkeypatch.setenv("LINEAR_TEAM_ID", "team-1")
+    monkeypatch.setenv("LINEAR_PROJECT_ID", "proj-1")
+    monkeypatch.setenv("SCAN_DATE", "2026-06-25")
+    monkeypatch.setenv("TARGET_IMAGE", "img:1")
+
+
+def test_main_creates_one_issue_per_severity(tmp_path, monkeypatch):
+    _env(monkeypatch)
+    findings = [
+        _finding("CVE-C", "CRITICAL"),
+        _finding("CVE-H1", "HIGH"),
+        _finding("CVE-H2", "HIGH"),
+        _finding("CVE-M", "MEDIUM"),
+    ]
+    monkeypatch.setattr(ssl, "collect_findings", lambda: findings)
+    fake = _FakeGql()
+    monkeypatch.setattr(ssl, "gql", fake)
+    out = tmp_path / "out.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+
+    assert ssl.main() == 0
+
+    # One issue per distinct severity (CRITICAL, HIGH, MEDIUM) = 3.
+    assert len(fake.created) == 3
+    priorities = [c["priority"] for c in fake.created]
+    # Ordered CRITICAL(1), HIGH(2), MEDIUM(3).
+    assert priorities == [1, 2, 3]
+
+    emitted = out.read_text()
+    assert "new_issues=" in emitted
+    payload = json.loads(emitted.split("new_issues=", 1)[1].strip())
+    severities = {e["severity"] for e in payload}
+    assert severities == {"CRITICAL", "HIGH", "MEDIUM"}
+
+
+def test_main_dedups_against_open_issue(tmp_path, monkeypatch):
+    _env(monkeypatch)
+    findings = [_finding("CVE-C", "CRITICAL")]
+    monkeypatch.setattr(ssl, "collect_findings", lambda: findings)
+
+    class _Covered(_FakeGql):
+        def __call__(self, query, variables):
+            if "OpenLabelled" in query or "issues(" in query:
+                return {
+                    "issues": {
+                        "pageInfo": {"hasNextPage": False},
+                        "nodes": [
+                            {
+                                "id": "i1",
+                                "identifier": "BLDX-OLD",
+                                "url": "http://x",
+                                "title": "t",
+                                "description": "<!-- vuln-ids: CVE-C -->",
+                                "state": {"type": "started"},
+                            }
+                        ],
+                    }
+                }
+            return super().__call__(query, variables)
+
+    fake = _Covered()
+    monkeypatch.setattr(ssl, "gql", fake)
+    monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "out.txt"))
+
+    assert ssl.main() == 0
+    # Already covered → no new issue created.
+    assert fake.created == []

--- a/.github/scripts/tests/test_validate_allowlist.py
+++ b/.github/scripts/tests/test_validate_allowlist.py
@@ -1,0 +1,113 @@
+"""Tests for .github/scripts/validate_allowlist.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import validate_allowlist
+
+
+def _future(days: int) -> str:
+    return (date.today() + timedelta(days=days)).strftime("%Y-%m-%d")
+
+
+def _entry(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "package": "example-pkg",
+        "severity": "HIGH",
+        "reason": "Case 2: no fix yet; vulnerable path not exercised.",
+        "expires": _future(20),
+        "added_by": "@atlan-ci",
+        "case": 2,
+        "ticket": "BLDX-1234",
+    }
+    base.update(overrides)
+    return base
+
+
+def _run(entries: dict[str, Any], tmp_path: Path, monkeypatch, policy=None) -> int:
+    data: dict[str, Any] = {"_expiry_policy": policy or {"CRITICAL": 7, "HIGH": 30}}
+    data.update(entries)
+    p = tmp_path / "base-allowlist.json"
+    p.write_text(json.dumps(data))
+    monkeypatch.setattr(validate_allowlist, "ALLOWLIST_PATH", str(p))
+    return validate_allowlist.main()
+
+
+def test_valid_high_entry_passes(tmp_path, monkeypatch):
+    assert _run({"CVE-2026-1": _entry()}, tmp_path, monkeypatch) == 0
+
+
+def test_valid_critical_within_7_days_passes(tmp_path, monkeypatch):
+    entry = _entry(severity="CRITICAL", expires=_future(6), case=1)
+    assert _run({"CVE-2026-2": entry}, tmp_path, monkeypatch) == 0
+
+
+def test_critical_beyond_7_days_fails(tmp_path, monkeypatch):
+    entry = _entry(severity="CRITICAL", expires=_future(10))
+    assert _run({"CVE-2026-3": entry}, tmp_path, monkeypatch) == 1
+
+
+def test_medium_severity_rejected(tmp_path, monkeypatch):
+    # MEDIUM/LOW are never allowlisted — unknown severity in policy.
+    entry = _entry(severity="MEDIUM")
+    assert _run({"CVE-2026-4": entry}, tmp_path, monkeypatch) == 1
+
+
+def test_missing_case_fails(tmp_path, monkeypatch):
+    entry = _entry()
+    del entry["case"]
+    assert _run({"CVE-2026-5": entry}, tmp_path, monkeypatch) == 1
+
+
+def test_missing_ticket_fails(tmp_path, monkeypatch):
+    entry = _entry()
+    del entry["ticket"]
+    assert _run({"CVE-2026-6": entry}, tmp_path, monkeypatch) == 1
+
+
+def test_invalid_case_value_fails(tmp_path, monkeypatch):
+    entry = _entry(case=5)
+    assert _run({"CVE-2026-7": entry}, tmp_path, monkeypatch) == 1
+
+
+def test_case_as_string_accepted(tmp_path, monkeypatch):
+    entry = _entry(case="3")
+    assert _run({"CVE-2026-8": entry}, tmp_path, monkeypatch) == 0
+
+
+def test_fix_pr_must_be_https(tmp_path, monkeypatch):
+    entry = _entry(case=1, fix_pr="#1234")
+    assert _run({"CVE-2026-9": entry}, tmp_path, monkeypatch) == 1
+
+
+def test_valid_fix_pr_passes(tmp_path, monkeypatch):
+    entry = _entry(case=1, fix_pr="https://github.com/atlanhq/application-sdk/pull/1")
+    assert _run({"CVE-2026-10": entry}, tmp_path, monkeypatch) == 0
+
+
+def test_already_expired_fails(tmp_path, monkeypatch):
+    entry = _entry(expires=_future(-1))
+    assert _run({"CVE-2026-11": entry}, tmp_path, monkeypatch) == 1
+
+
+def test_empty_allowlist_passes(tmp_path, monkeypatch):
+    assert _run({}, tmp_path, monkeypatch) == 0
+
+
+def test_entry_schema_doc_key_is_ignored(tmp_path, monkeypatch):
+    # The "_entry_schema" documentation key must not be validated as an entry.
+    data = {
+        "_expiry_policy": {"CRITICAL": 7, "HIGH": 30},
+        "_entry_schema": {"_doc": "x", "CVE-0000": {"severity": "MEDIUM"}},
+    }
+    p = tmp_path / "base-allowlist.json"
+    p.write_text(json.dumps(data))
+    monkeypatch.setattr(validate_allowlist, "ALLOWLIST_PATH", str(p))
+    assert validate_allowlist.main() == 0

--- a/.github/scripts/tests/test_vuln_auto_merge_gate.py
+++ b/.github/scripts/tests/test_vuln_auto_merge_gate.py
@@ -1,0 +1,209 @@
+"""Tests for .github/scripts/vuln_auto_merge_gate.py — the auto-merge boundary."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import vuln_auto_merge_gate as gate
+
+TRUSTED = {"atlan-ci", "mothership-ai[bot]"}
+LABEL = "vuln-auto-merge"
+
+
+# ---------------------------------------------------------------------------
+# classify_shape — the path allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_only_is_allowlist_shape():
+    assert classify(".security/base-allowlist.json") == "allowlist"
+
+
+def classify(*files):
+    return gate.classify_shape(list(files))
+
+
+def test_bump_subset_is_bump_shape():
+    assert classify("uv.lock") == "bump"
+    assert classify("pyproject.toml", "uv.lock") == "bump"
+    assert classify("pyproject.toml", "uv.lock", "requirements.txt") == "bump"
+
+
+def test_empty_is_none():
+    assert classify() is None
+    assert gate.classify_shape([""]) is None
+
+
+def test_allowlist_plus_extra_file_is_none():
+    # An allowlist PR that also touches anything else must NOT match.
+    assert classify(".security/base-allowlist.json", "README.md") is None
+
+
+def test_bump_plus_source_file_is_none():
+    # Plan verification (c): a bump that also edits a .py source file is refused.
+    assert classify("uv.lock", "application_sdk/foo.py") is None
+    assert classify("pyproject.toml", "Dockerfile") is None
+
+
+def test_mixed_allowlist_and_bump_is_none():
+    # The two shapes are strictly separate.
+    assert classify(".security/base-allowlist.json", "uv.lock") is None
+
+
+def test_same_named_file_in_subdir_is_none():
+    # Only root-level manifests count; a nested pyproject.toml must not ride.
+    assert classify("packages/conformance/pyproject.toml") is None
+    assert classify("subdir/uv.lock") is None
+
+
+# ---------------------------------------------------------------------------
+# evaluate — full gate
+# ---------------------------------------------------------------------------
+
+
+def _eval(**overrides):
+    base = dict(
+        author="atlan-ci",
+        state="open",
+        draft=False,
+        head_sha="abc",
+        eval_sha="abc",
+        labels=[LABEL],
+        filenames=[".security/base-allowlist.json"],
+        label_name=LABEL,
+        trusted_authors=TRUSTED,
+    )
+    base.update(overrides)
+    return gate.evaluate(**base)
+
+
+def test_evaluate_happy_path_allowlist():
+    ok, _reason, shape = _eval()
+    assert ok and shape == "allowlist"
+
+
+def test_evaluate_happy_path_bump():
+    ok, _reason, shape = _eval(filenames=["pyproject.toml", "uv.lock"])
+    assert ok and shape == "bump"
+
+
+def test_evaluate_untrusted_author_rejected():
+    ok, _r, _s = _eval(author="random-user")
+    assert not ok
+
+
+def test_evaluate_mothership_bot_trusted():
+    ok, _r, _s = _eval(author="mothership-ai[bot]")
+    assert ok
+
+
+def test_evaluate_draft_rejected():
+    assert not _eval(draft=True)[0]
+
+
+def test_evaluate_closed_rejected():
+    assert not _eval(state="closed")[0]
+
+
+def test_evaluate_head_moved_rejected():
+    # Plan verification: race guard.
+    assert not _eval(head_sha="def", eval_sha="abc")[0]
+
+
+def test_evaluate_missing_label_rejected():
+    # Plan verification (d): no label → refused.
+    assert not _eval(labels=[])[0]
+
+
+def test_evaluate_non_matching_files_rejected():
+    assert not _eval(filenames=["application_sdk/foo.py"])[0]
+
+
+# ---------------------------------------------------------------------------
+# process_pr — wired with a fake gh runner
+# ---------------------------------------------------------------------------
+
+
+class _FakeRunner:
+    """Minimal gh stub: returns canned JSON per api call, records actions."""
+
+    def __init__(self, meta, files, approved_count=0):
+        self.meta = meta
+        self.files = files
+        self.approved_count = approved_count
+        self.reviews = []
+        self.merges = []
+
+    def __call__(self, cmd, check=False, capture_output=False, text=False):
+        joined = " ".join(cmd)
+        out = ""
+        if "/files" in joined:
+            out = "\n".join(self.files)
+        elif "/reviews" in joined:
+            out = str(self.approved_count)
+        elif "/pulls/" in joined and "--jq" in joined:
+            out = json.dumps(self.meta)
+        elif cmd[:3] == ["gh", "pr", "review"]:
+            self.reviews.append(cmd)
+        elif cmd[:3] == ["gh", "pr", "merge"]:
+            self.merges.append(cmd)
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout=out, stderr=""
+        )
+
+
+APPROVER = "atlan-ci"
+
+
+def _meta(author="mothership-ai[bot]", **kw):
+    base = {
+        "author": author,
+        "state": "open",
+        "draft": False,
+        "head_sha": "abc",
+        "labels": [LABEL],
+    }
+    base.update(kw)
+    return base
+
+
+def test_process_pr_approves_and_merges_rover_pr():
+    # Rover PR (mothership-ai[bot]) → atlan-ci approves + auto-merges.
+    r = _FakeRunner(_meta(), [".security/base-allowlist.json"])
+    acted = gate.process_pr("o/r", "5", "abc", LABEL, TRUSTED, APPROVER, r)
+    assert acted is True
+    assert len(r.reviews) == 1
+    assert len(r.merges) == 1
+    assert "--auto" in r.merges[0]
+
+
+def test_process_pr_self_authored_skips_approval():
+    # Reconcile removal PR authored by atlan-ci (the approver) → NO self-approval
+    # (would 422); bypass-merge only.
+    r = _FakeRunner(_meta(author="atlan-ci"), [".security/base-allowlist.json"])
+    acted = gate.process_pr("o/r", "5", "abc", LABEL, TRUSTED, APPROVER, r)
+    assert acted is False
+    assert r.reviews == []  # never self-approve
+    assert len(r.merges) == 1  # but still auto-merge (bypass actor)
+
+
+def test_process_pr_skips_when_files_unsafe():
+    r = _FakeRunner(_meta(), ["uv.lock", "application_sdk/foo.py"])
+    acted = gate.process_pr("o/r", "5", "abc", LABEL, TRUSTED, APPROVER, r)
+    assert acted is False
+    assert r.reviews == []
+    assert r.merges == []
+
+
+def test_process_pr_idempotent_when_already_approved():
+    r = _FakeRunner(_meta(), [".security/base-allowlist.json"], approved_count=1)
+    acted = gate.process_pr("o/r", "5", "abc", LABEL, TRUSTED, APPROVER, r)
+    assert acted is False
+    # No new approval, but auto-merge is (re-)ensured.
+    assert r.reviews == []
+    assert len(r.merges) == 1

--- a/.github/scripts/validate_allowlist.py
+++ b/.github/scripts/validate_allowlist.py
@@ -3,19 +3,27 @@
 Validate base-allowlist.json entries against the expiry policy.
 
 Rules enforced:
-  1. Every entry must have: package, severity, reason, expires, added_by
+  1. Every entry must have: package, severity, reason, expires, added_by,
+     case, ticket
   2. `expires` must be a valid YYYY-MM-DD date
   3. `expires` must not already be in the past
   4. `expires` must be within the max window for the entry's severity:
-       CRITICAL → _expiry_policy.CRITICAL days (default 15)
+       CRITICAL → _expiry_policy.CRITICAL days (default 7)
        HIGH     → _expiry_policy.HIGH days     (default 30)
+     Only CRITICAL and HIGH are allowlistable — MEDIUM/LOW are tracked on
+     Linear tickets only (their SLAs are not gated), so any other severity
+     is rejected here.
+  5. `case` must be one of 1|2|3|4 (the vuln-triage classification), `ticket`
+     the Linear identifier driving the entry, and `fix_pr` (optional) a URL.
 
-The expiry policy is read from the `_expiry_policy` metadata key in the
-allowlist itself so the security team can adjust limits without touching code:
+The expiry windows ARE the remediation SLA, measured from first detection:
+CRITICAL 7 days, HIGH 30 days. They are read from the `_expiry_policy`
+metadata key in the allowlist itself so the security team can adjust limits
+without touching code:
 
   {
-    "_expiry_policy": { "CRITICAL": 15, "HIGH": 30 },
-    "CVE-2026-12345": { ... }
+    "_expiry_policy": { "CRITICAL": 7, "HIGH": 30 },
+    "CVE-2026-12345": { "case": 1, "ticket": "BLDX-1234", ... }
   }
 """
 
@@ -24,8 +32,19 @@ import sys
 from datetime import datetime, timedelta
 
 ALLOWLIST_PATH = ".security/base-allowlist.json"
-DEFAULT_POLICY = {"CRITICAL": 15, "HIGH": 30}
-REQUIRED_FIELDS = ["package", "severity", "reason", "expires", "added_by"]
+DEFAULT_POLICY = {"CRITICAL": 7, "HIGH": 30}
+REQUIRED_FIELDS = [
+    "package",
+    "severity",
+    "reason",
+    "expires",
+    "added_by",
+    "case",
+    "ticket",
+]
+
+# Valid vuln-triage classification cases (see .mothership/vuln-triage/ORCHESTRATION.md).
+VALID_CASES = {"1", "2", "3", "4"}
 
 # F-cross.2 compliance fields. Optional during the migration window; promoted
 # to required once all entries are filled in.
@@ -117,6 +136,20 @@ def main() -> int:
         if sup is not None and not isinstance(sup, bool):
             errors.append(
                 f"{cve_id}: suppressed must be a bool, got {type(sup).__name__}"
+            )
+
+        # 6. Triage metadata: case (1-4) and an optional fix PR URL.
+        case = entry.get("case")
+        if str(case) not in VALID_CASES:
+            errors.append(
+                f"{cve_id}: case '{case}' must be one of 1, 2, 3, 4 "
+                f"(vuln-triage classification)"
+            )
+
+        fix_pr = entry.get("fix_pr")
+        if fix_pr is not None and not str(fix_pr).startswith("https://"):
+            errors.append(
+                f"{cve_id}: fix_pr '{fix_pr}' must be an https URL to the fix PR"
             )
 
     if errors:

--- a/.github/scripts/validate_allowlist.py
+++ b/.github/scripts/validate_allowlist.py
@@ -29,7 +29,7 @@ without touching code:
 
 import json
 import sys
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 ALLOWLIST_PATH = ".security/base-allowlist.json"
 DEFAULT_POLICY = {"CRITICAL": 7, "HIGH": 30}
@@ -63,7 +63,7 @@ def main() -> int:
         return 1
 
     policy = {**DEFAULT_POLICY, **data.get("_expiry_policy", {})}
-    today = datetime.utcnow().date()
+    today = datetime.now(UTC).date()
     errors = []
 
     entries = {k: v for k, v in data.items() if not k.startswith("_")}

--- a/.github/scripts/vuln_auto_merge_gate.py
+++ b/.github/scripts/vuln_auto_merge_gate.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Auto-approve + auto-merge gate for vuln-triage PRs.
+
+This is the **deterministic safety boundary** for the zero-human-touch CVE
+flow. The vuln-triage rover opens two — and only two — shapes of PR, each
+labelled ``vuln-auto-merge``:
+
+  * **allowlist PR** — touches ONLY ``.security/base-allowlist.json``
+  * **bump PR**      — touches ONLY a subset of ``pyproject.toml``,
+                       ``uv.lock``, ``requirements.txt``
+
+A PR is approved (as ``atlan-ci``, satisfying code-owner review) and put on
+GitHub auto-merge (``gh pr merge --auto --squash``) iff ALL hold:
+
+  1. author is one of the trusted rover identities,
+  2. PR is open and not a draft,
+  3. its HEAD SHA still matches the SHA whose checks just completed (race guard),
+  4. it carries the ``vuln-auto-merge`` label, and
+  5. every changed file matches exactly one of the two shapes above.
+
+GitHub itself enforces "merge only when required checks pass" via auto-merge,
+so this gate never merges a red PR. A bump PR that ALSO touches source files
+(e.g. changelog-mandated code edits) fails the path-allowlist (5) and is
+therefore NOT auto-merged — it falls back to human / @sdk-review review. That
+is intended, not a bug: the rover's prose is never trusted to bound what it
+touches; this file is.
+
+Loop / conditional logic lives here (a tested script) rather than inlined in
+the workflow YAML, per docs/standards/ci.md.
+
+Environment:
+    GH_TOKEN                 PAT owned by atlan-ci (repo read + PR write).
+    REPO                     owner/name (github.repository).
+    EVENT_NAME               'workflow_run' or 'workflow_dispatch'.
+    RUN_SHA                  workflow_run head_sha (empty for dispatch).
+    DISPATCH_PR              PR number (workflow_dispatch manual testing).
+
+Optional:
+    VULN_AUTOMERGE_LABEL     default 'vuln-auto-merge'.
+    VULN_AUTOMERGE_AUTHORS   comma-separated trusted PR authors;
+                             default 'atlan-ci,mothership-ai[bot]'.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from typing import Any
+
+ALLOWLIST_FILE = ".security/base-allowlist.json"
+# Root-level dependency manifests for the SDK. Matched exactly (no subpaths) so
+# a stray same-named file deeper in the tree can never ride this gate.
+BUMP_FILES = {"pyproject.toml", "uv.lock", "requirements.txt"}
+
+APPROVAL_SIGNATURE = "**Vuln auto-merge:**"
+DEFAULT_LABEL = "vuln-auto-merge"
+# Trusted PR authors:
+#   - mothership-ai[bot] — the rover's allowlist + bump PRs. NOT a code owner, so
+#     these need an atlan-ci approval to satisfy require_code_owner_review.
+#   - atlan-ci — the reconcile removal PR (opened via ORG_PAT_GITHUB). atlan-ci is
+#     a main-ruleset BYPASS actor, so it needs NO approval — and GitHub forbids a
+#     PR author approving their own PR, so we must NOT try to self-approve it.
+DEFAULT_AUTHORS = "atlan-ci,mothership-ai[bot]"
+# The login the gate's GH_TOKEN (ORG_PAT_GITHUB) acts as. A PR authored by this
+# identity is bypass-merged without an approval (self-approval is rejected by
+# GitHub).
+DEFAULT_APPROVER = "atlan-ci"
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+# ---------------------------------------------------------------------------
+# Pure decision logic (the safety boundary — exhaustively unit-tested)
+# ---------------------------------------------------------------------------
+
+
+def classify_shape(filenames: list[str]) -> str | None:
+    """Return 'allowlist', 'bump', or None for the given changed files.
+
+    'allowlist' → exactly {.security/base-allowlist.json}
+    'bump'      → non-empty subset of {pyproject.toml, uv.lock, requirements.txt}
+    None        → anything else (mixed, extra, or empty) → no auto-merge.
+    """
+    files = {f for f in filenames if f}
+    if not files:
+        return None
+    if files == {ALLOWLIST_FILE}:
+        return "allowlist"
+    if files <= BUMP_FILES:
+        return "bump"
+    return None
+
+
+def evaluate(
+    *,
+    author: str,
+    state: str,
+    draft: bool,
+    head_sha: str,
+    eval_sha: str,
+    labels: list[str],
+    filenames: list[str],
+    label_name: str,
+    trusted_authors: set[str],
+) -> tuple[bool, str, str | None]:
+    """Decide whether to approve + auto-merge a PR.
+
+    Returns (ok, reason, shape). ``ok`` True means approve + enable auto-merge.
+    """
+    if author not in trusted_authors:
+        return False, f"author '{author}' is not a trusted vuln-triage identity", None
+    if state != "open" or draft:
+        return False, f"PR state='{state}' draft={draft}", None
+    if head_sha != eval_sha:
+        return False, f"HEAD moved ({eval_sha} → {head_sha})", None
+    if label_name not in labels:
+        return False, f"missing '{label_name}' label", None
+    shape = classify_shape(filenames)
+    if shape is None:
+        return False, "changed files do not match an allowlist/bump shape", None
+    return True, f"matches {shape} shape", shape
+
+
+# ---------------------------------------------------------------------------
+# gh I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def _gh_text(args: list[str], runner: Runner) -> str | None:
+    """Run a gh command and return its stripped stdout (None on failure/empty).
+
+    Use for ``--jq`` queries that emit RAW values — gh prints jq strings
+    unquoted and emits one line per result, which is not valid JSON.
+    """
+    result = runner(["gh", *args], check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        return None
+    out = (result.stdout or "").strip()
+    return out or None
+
+
+def _gh_json(args: list[str], runner: Runner) -> Any:
+    """Run a gh command whose ``--jq`` emits a single JSON object/array."""
+    out = _gh_text(args, runner)
+    if out is None:
+        return None
+    return json.loads(out)
+
+
+def resolve_pr_numbers(
+    repo: str, event_name: str, run_sha: str, dispatch_pr: str, runner: Runner
+) -> tuple[list[str], str]:
+    """Return (pr_numbers, eval_sha) for the triggering event."""
+    if event_name == "workflow_dispatch":
+        sha = _gh_text(
+            ["api", f"repos/{repo}/pulls/{dispatch_pr}", "--jq", ".head.sha"], runner
+        )
+        return ([dispatch_pr] if dispatch_pr else []), (sha or "")
+    nums = _gh_text(
+        [
+            "api",
+            f"repos/{repo}/commits/{run_sha}/pulls",
+            "--jq",
+            '.[] | select(.state == "open") | .number',
+        ],
+        runner,
+    )
+    if not nums:
+        return [], run_sha
+    return nums.split(), run_sha
+
+
+def already_approved(repo: str, pr: str, runner: Runner) -> bool:
+    n = _gh_text(
+        [
+            "api",
+            f"repos/{repo}/pulls/{pr}/reviews",
+            "--paginate",
+            "--jq",
+            '[.[] | select(.user.login == "atlan-ci" and .state == "APPROVED" '
+            f'and ((.body // "") | startswith("{APPROVAL_SIGNATURE}")))] | length',
+        ],
+        runner,
+    )
+    try:
+        return int(n or "0") > 0
+    except ValueError:
+        return False
+
+
+def approve(repo: str, pr: str, shape: str, runner: Runner) -> None:
+    body = (
+        f"{APPROVAL_SIGNATURE} {shape} PR from the vuln-triage rover.\n\n"
+        "Automated code-owner approval by `atlan-ci`. The PR is on GitHub "
+        "auto-merge and will squash-merge only once all required checks pass. "
+        "Dismissed on any new push (`dismiss_stale_reviews_on_push`)."
+    )
+    runner(
+        ["gh", "pr", "review", pr, "--repo", repo, "--approve", "--body", body],
+        check=True,
+    )
+
+
+def enable_automerge(repo: str, pr: str, runner: Runner, *, check: bool = True) -> None:
+    runner(
+        ["gh", "pr", "merge", pr, "--repo", repo, "--auto", "--squash"],
+        check=check,
+    )
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def process_pr(
+    repo: str,
+    pr: str,
+    eval_sha: str,
+    label_name: str,
+    trusted_authors: set[str],
+    approver_login: str,
+    runner: Runner,
+) -> bool:
+    """Evaluate one PR; approve (if needed) + auto-merge if it passes.
+
+    Returns True if a new approval was posted.
+    """
+    meta = _gh_json(
+        [
+            "api",
+            f"repos/{repo}/pulls/{pr}",
+            "--jq",
+            "{author: .user.login, state: .state, draft: .draft, head_sha: .head.sha, "
+            "labels: [.labels[].name]}",
+        ],
+        runner,
+    )
+    if not meta:
+        print(f"PR #{pr}: could not fetch metadata — skipping.")
+        return False
+
+    files_raw = _gh_text(
+        ["api", f"repos/{repo}/pulls/{pr}/files", "--paginate", "--jq", ".[].filename"],
+        runner,
+    )
+    filenames = files_raw.splitlines() if files_raw else []
+
+    author = meta.get("author", "")
+    ok, reason, shape = evaluate(
+        author=author,
+        state=meta.get("state", ""),
+        draft=bool(meta.get("draft")),
+        head_sha=meta.get("head_sha", ""),
+        eval_sha=eval_sha,
+        labels=meta.get("labels", []) or [],
+        filenames=filenames,
+        label_name=label_name,
+        trusted_authors=trusted_authors,
+    )
+    if not ok:
+        print(f"PR #{pr}: skip — {reason}.")
+        return False
+
+    # A PR authored by the approver identity (atlan-ci) cannot be self-approved
+    # (GitHub 422). atlan-ci is a main-ruleset bypass actor, so just enable
+    # auto-merge — no approval needed.
+    if author == approver_login:
+        print(f"PR #{pr}: authored by {author} (bypass actor) — enabling auto-merge.")
+        enable_automerge(repo, pr, runner, check=False)
+        return False
+
+    if already_approved(repo, pr, runner):
+        print(f"PR #{pr}: already approved by atlan-ci — ensuring auto-merge only.")
+        enable_automerge(repo, pr, runner, check=False)
+        return False
+
+    print(f"PR #{pr}: {reason} — approving + enabling auto-merge.")
+    approve(repo, pr, shape or "", runner)
+    enable_automerge(repo, pr, runner)
+    print(f"✅ PR #{pr}: approved as atlan-ci and queued for auto-merge ({shape}).")
+    return True
+
+
+def main(runner: Runner = subprocess.run) -> int:
+    repo = os.environ["REPO"]
+    event_name = os.environ.get("EVENT_NAME", "workflow_run")
+    run_sha = os.environ.get("RUN_SHA", "")
+    dispatch_pr = os.environ.get("DISPATCH_PR", "")
+    label_name = os.environ.get("VULN_AUTOMERGE_LABEL", DEFAULT_LABEL)
+    approver_login = os.environ.get("VULN_AUTOMERGE_APPROVER", DEFAULT_APPROVER)
+    trusted_authors = {
+        a.strip()
+        for a in os.environ.get("VULN_AUTOMERGE_AUTHORS", DEFAULT_AUTHORS).split(",")
+        if a.strip()
+    }
+
+    pr_numbers, eval_sha = resolve_pr_numbers(
+        repo, event_name, run_sha, dispatch_pr, runner
+    )
+    if not pr_numbers:
+        print(f"No open PRs to evaluate for SHA {eval_sha or '(none)'}.")
+        return 0
+
+    for pr in pr_numbers:
+        print(f"--- Evaluating PR #{pr} ---")
+        process_pr(
+            repo, pr, eval_sha, label_name, trusted_authors, approver_login, runner
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -112,109 +112,15 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
-      - name: Parse scan results
+      # Counting + summary logic lives in parse_scan_results.py (tested) rather
+      # than inlined here — see docs/standards/ci.md. It emits total_actionable
+      # for the Linear step's gate and writes the workflow summary directly.
+      - name: Parse scan results + publish summary
         id: parse
-        run: |
-          # Trivy: same shape across versions (.Results[].Vulnerabilities[]).
-          count_trivy_file() {
-            jq --arg sev "$2" '[.Results[]?.Vulnerabilities[]? | select(.Severity == $sev)] | length' "$1" 2>/dev/null || echo 0
-          }
-
-          TI_CRIT=0; TI_HIGH=0; TI_MED=0; TI_LOW=0
-          TF_CRIT=0; TF_HIGH=0; TF_MED=0; TF_LOW=0
-
-          if [ -f trivy-image-results.json ]; then
-            TI_CRIT=$(count_trivy_file trivy-image-results.json CRITICAL)
-            TI_HIGH=$(count_trivy_file trivy-image-results.json HIGH)
-            TI_MED=$(count_trivy_file  trivy-image-results.json MEDIUM)
-            TI_LOW=$(count_trivy_file  trivy-image-results.json LOW)
-          fi
-
-          if [ -f trivy-fs-results.json ]; then
-            TF_CRIT=$(count_trivy_file trivy-fs-results.json CRITICAL)
-            TF_HIGH=$(count_trivy_file trivy-fs-results.json HIGH)
-            TF_MED=$(count_trivy_file  trivy-fs-results.json MEDIUM)
-            TF_LOW=$(count_trivy_file  trivy-fs-results.json LOW)
-          fi
-
-          TOTAL_CRIT=$((TI_CRIT + TF_CRIT))
-          TOTAL_HIGH=$((TI_HIGH + TF_HIGH))
-          TOTAL_MED=$((TI_MED  + TF_MED))
-          TOTAL_LOW=$((TI_LOW  + TF_LOW))
-          # All severities are actionable — we file + triage every finding.
-          TOTAL_ACTIONABLE=$((TOTAL_CRIT + TOTAL_HIGH + TOTAL_MED + TOTAL_LOW))
-
-          echo "ti_crit=$TI_CRIT" >> "$GITHUB_OUTPUT"
-          echo "ti_high=$TI_HIGH" >> "$GITHUB_OUTPUT"
-          echo "ti_med=$TI_MED"   >> "$GITHUB_OUTPUT"
-          echo "ti_low=$TI_LOW"   >> "$GITHUB_OUTPUT"
-          echo "tf_crit=$TF_CRIT" >> "$GITHUB_OUTPUT"
-          echo "tf_high=$TF_HIGH" >> "$GITHUB_OUTPUT"
-          echo "tf_med=$TF_MED"   >> "$GITHUB_OUTPUT"
-          echo "tf_low=$TF_LOW"   >> "$GITHUB_OUTPUT"
-          echo "total_crit=$TOTAL_CRIT"             >> "$GITHUB_OUTPUT"
-          echo "total_high=$TOTAL_HIGH"             >> "$GITHUB_OUTPUT"
-          echo "total_med=$TOTAL_MED"               >> "$GITHUB_OUTPUT"
-          echo "total_low=$TOTAL_LOW"               >> "$GITHUB_OUTPUT"
-          echo "total_actionable=$TOTAL_ACTIONABLE" >> "$GITHUB_OUTPUT"
-
-          if [ "$TOTAL_ACTIONABLE" -gt 0 ]; then
-            {
-              echo 'vuln_detail<<VULN_EOF'
-
-              if [ "$((TI_CRIT + TI_HIGH + TI_MED + TI_LOW))" -gt 0 ]; then
-                echo "### Trivy — Image (app-runtime-base)"
-                echo ""
-                echo "| Severity | Package | Installed | Fixed | CVE |"
-                echo "|----------|---------|-----------|-------|-----|"
-                jq -r '.Results[]?.Vulnerabilities[]?
-                  | "| \(.Severity) | \(.PkgName) | \(.InstalledVersion) | \(.FixedVersion // "N/A") | \(.VulnerabilityID) |"' \
-                  trivy-image-results.json | sort -t'|' -k2,2 | head -200
-                echo ""
-              fi
-
-              if [ "$((TF_CRIT + TF_HIGH + TF_MED + TF_LOW))" -gt 0 ]; then
-                echo "### Trivy — SDK Deps (lockfiles + installed wheel artifacts)"
-                echo ""
-                echo "| Severity | Package | Installed | Fixed | CVE |"
-                echo "|----------|---------|-----------|-------|-----|"
-                jq -r '.Results[]?.Vulnerabilities[]?
-                  | "| \(.Severity) | \(.PkgName) | \(.InstalledVersion) | \(.FixedVersion // "N/A") | \(.VulnerabilityID) |"' \
-                  trivy-fs-results.json | sort -t'|' -k2,2 | head -200
-                echo ""
-              fi
-
-              echo 'VULN_EOF'
-            } >> "$GITHUB_OUTPUT"
-          fi
-
-          echo "Trivy Image  — C:$TI_CRIT H:$TI_HIGH M:$TI_MED L:$TI_LOW"
-          echo "Trivy Python — C:$TF_CRIT H:$TF_HIGH M:$TF_MED L:$TF_LOW"
-          echo "Total findings (all severities): $TOTAL_ACTIONABLE"
-
-      # ── Workflow summary ──────────────────────────────────────────────────
-
-      - name: Publish workflow summary
         if: always()
-        run: |
-          {
-            echo "## Hourly Security Scan — \`$TARGET_IMAGE\` + SDK Python Deps"
-            echo ""
-            echo "### Vulnerability Summary"
-            echo ""
-            echo "| Severity | Trivy (Image) | Trivy (Deps) | Total |"
-            echo "|----------|:-------------:|:--------------:|------:|"
-            echo "| 🔴 Critical | ${{ steps.parse.outputs.ti_crit || 0 }} | ${{ steps.parse.outputs.tf_crit || 0 }} | **${{ steps.parse.outputs.total_crit || 0 }}** |"
-            echo "| 🟠 High     | ${{ steps.parse.outputs.ti_high || 0 }} | ${{ steps.parse.outputs.tf_high || 0 }} | **${{ steps.parse.outputs.total_high || 0 }}** |"
-            echo "| 🟡 Medium   | ${{ steps.parse.outputs.ti_med  || 0 }} | ${{ steps.parse.outputs.tf_med  || 0 }} | **${{ steps.parse.outputs.total_med  || 0 }}** |"
-            echo "| 🔵 Low      | ${{ steps.parse.outputs.ti_low  || 0 }} | ${{ steps.parse.outputs.tf_low  || 0 }} | **${{ steps.parse.outputs.total_low  || 0 }}** |"
-            echo ""
-            if [ "${{ steps.parse.outputs.total_actionable || 0 }}" -gt 0 ]; then
-              echo "> ⚠️ **${{ steps.parse.outputs.total_actionable }} findings (all severities) — see Linear ticket step below**"
-            else
-              echo "> ✅ **No findings**"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          TARGET_IMAGE: ${{ env.TARGET_IMAGE }}
+        run: python3 .github/scripts/parse_scan_results.py
 
       # ── Create Linear issues (one per severity, deduped against open
       #    issues carrying the "vulnerabilities" label so we don't refile

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -1,3 +1,8 @@
+# NOTE: the schedule is HOURLY (cron below). The filename "daily-security-scan.yml"
+# is retained deliberately — it is referenced by exact name in
+# reconcile_allowlist.py (`gh run list --workflow daily-security-scan.yml`) and in
+# .mothership/vuln-triage/tools.md; renaming would break those lookups and the
+# prior-run history they page through. The display name reflects the real cadence.
 name: Hourly Security Scan — app-runtime-base + SDK Python Deps
 
 on:

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -216,7 +216,7 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # ── Create Linear issue (all severities, deduped against open
+      # ── Create Linear issues (one per severity, deduped against open
       #    issues carrying the "vulnerabilities" label so we don't refile
       #    the same vulns every day). New issues land in the team's
       #    "Backlog" state.
@@ -234,14 +234,53 @@ jobs:
           export SCAN_DATE=$(date -u +%Y-%m-%d)
           python3 .github/scripts/security_scan_create_linear.py
 
-      # ── Dispatch the vuln-triage rover for the newly-created ticket. Only
-      #    fires when a *new* (non-deduped) issue was filed this run, so the
-      #    heavy VPN/mothership job runs only when there's something to triage.
-      - name: Dispatch vuln-triage rover
-        if: steps.linear.outputs.new_issue_identifier != ''
+      # ── Dispatch the vuln-triage rover once per newly-created ticket (one
+      #    per severity). Only fires when a *new* (non-deduped) issue was filed
+      #    this run, so the heavy VPN/mothership job runs only when there's
+      #    something to triage. The loop lives in dispatch_vuln_triage.py
+      #    (tested) rather than inlined here — see docs/standards/ci.md.
+      - name: Dispatch vuln-triage rover (one per new ticket)
+        if: steps.linear.outputs.new_issues != '' && steps.linear.outputs.new_issues != '[]'
         env:
           GH_TOKEN: ${{ github.token }}
-          TICKET: ${{ steps.linear.outputs.new_issue_identifier }}
+          NEW_ISSUES: ${{ steps.linear.outputs.new_issues }}
+          GH_REF: ${{ github.ref_name }}
+        run: python3 .github/scripts/dispatch_vuln_triage.py
+
+  # ── Reconcile the allowlist + tickets against what the scanner still sees.
+  #    Runs every scan (even with no new findings) so resolved CVEs are retired
+  #    automatically. A CVE is only removed after 3 consecutive clean scans
+  #    (debounce) — see reconcile_allowlist.py. Checks out as atlan-ci so the
+  #    removal PR it opens is auto-merged by vuln-auto-merge.yml.
+  reconcile:
+    name: Reconcile allowlist + tickets
+    needs: scan-and-ticket
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read # download this run's scan artifact
+    steps:
+      - name: Checkout (as atlan-ci so the removal PR auto-merges)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ secrets.ORG_PAT_GITHUB }}
+
+      - name: Download this run's scan results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: security-scan-raw-results
+
+      - name: Reconcile resolved CVEs (3-scan debounce)
+        env:
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          REPO: ${{ github.repository }}
+          SCAN_WORKFLOW: daily-security-scan.yml
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          LINEAR_TEAM_ID: ${{ vars.LINEAR_SECURITY_SCAN_TEAM_ID }}
         run: |
-          echo "Dispatching vuln-triage rover for ticket: $TICKET"
-          gh workflow run vuln-triage-cron.yml --ref "${{ github.ref_name }}" -f ticket="$TICKET"
+          export RUN_DATE=$(date -u +%Y-%m-%d)
+          git config user.name "atlan-ci"
+          git config user.email "atlan-ci@users.noreply.github.com"
+          python3 .github/scripts/reconcile_allowlist.py

--- a/.github/workflows/vuln-auto-merge.yml
+++ b/.github/workflows/vuln-auto-merge.yml
@@ -10,9 +10,9 @@
 # in .github/scripts/vuln_auto_merge_gate.py (unit-tested), per
 # docs/standards/ci.md. This workflow only wires the trigger and runs it.
 #
-# Why atlan-ci: atlan-ci is a CODEOWNER (the `*` rule and the explicit
-# /.security/ rule) and a bypass actor on the main ruleset, so its approval
-# satisfies require_code_owner_review and `--auto` merges once checks pass.
+# Why atlan-ci: atlan-ci is a CODEOWNER (via the `*` rule in .github/CODEOWNERS,
+# which already covers .security/) and a bypass actor on the main ruleset, so its
+# approval satisfies require_code_owner_review and `--auto` merges once checks pass.
 # GitHub auto-merge enforces "merge only when required checks pass", so a red
 # PR is never merged here.
 

--- a/.github/workflows/vuln-auto-merge.yml
+++ b/.github/workflows/vuln-auto-merge.yml
@@ -1,0 +1,69 @@
+# Auto-approve + auto-merge for vuln-triage PRs.
+#
+# Once required CI is green on a vuln-triage PR, post an atlan-ci code-owner
+# approval and put it on GitHub auto-merge — but ONLY for the two safe shapes
+# the rover produces (an allowlist-only PR, or a dependency-bump-only PR),
+# carrying the `vuln-auto-merge` label, from a trusted rover identity.
+#
+# ALL of the gating logic — author check, label check, race guard, and the
+# strict changed-files path-allowlist that is the real safety boundary — lives
+# in .github/scripts/vuln_auto_merge_gate.py (unit-tested), per
+# docs/standards/ci.md. This workflow only wires the trigger and runs it.
+#
+# Why atlan-ci: atlan-ci is a CODEOWNER (the `*` rule and the explicit
+# /.security/ rule) and a bypass actor on the main ruleset, so its approval
+# satisfies require_code_owner_review and `--auto` merges once checks pass.
+# GitHub auto-merge enforces "merge only when required checks pass", so a red
+# PR is never merged here.
+
+name: Vuln triage — auto-merge allowlist/bump PRs
+
+on:
+  workflow_run:
+    # The workflows that produce this repo's required status checks (kept in
+    # sync with renovate-auto-approve.yml). We re-evaluate when any completes.
+    workflows: [SDK Gate, PR Checks, Conformance, Capability Manifest Check, CodeQL Advanced]
+    types: [completed]
+    # Only the rover's branch prefixes — avoids spending a runner on every
+    # workflow completion across the repo. Branch naming that drifts simply
+    # fails closed (no auto-merge), which is the safe direction.
+    branches:
+      - 'chore/allowlist-**'
+      - 'fix/bump-**'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to evaluate (manual testing / re-approval)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    # Skip failed/cancelled upstream runs; workflow_dispatch always runs.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Serialize runs for the same SHA so the idempotency guard is reliable.
+    concurrency:
+      group: vuln-auto-merge-${{ github.event.workflow_run.head_sha || inputs.pr_number }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout (for the gate script)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Evaluate + approve + auto-merge
+        env:
+          # atlan-ci identity: its approval satisfies code-owner review and it
+          # is a main-ruleset bypass actor (see check-dapr-version.yaml).
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          DISPATCH_PR: ${{ inputs.pr_number }}
+        run: python3 .github/scripts/vuln_auto_merge_gate.py

--- a/.github/workflows/vuln-triage-cron.yml
+++ b/.github/workflows/vuln-triage-cron.yml
@@ -12,6 +12,9 @@
 # files a new "vulnerabilities" ticket, passing that ticket's identifier,
 # and (2) manually via workflow_dispatch for re-runs / backfill.
 #
+# The dispatch + SSE-stream parsing lives in mothership_sandbox_dispatch.py
+# (tested) rather than inlined here — see docs/standards/ci.md.
+#
 # Required configuration (shared with sdk-evolution-cron.yml):
 #   secrets.HARNESS_TOKEN           Bearer token for /api/sandbox/execute.
 #   secrets.GLOBALPROTECT_USERNAME  VPN auth.
@@ -41,7 +44,7 @@ jobs:
   trigger:
     runs-on: ubuntu-latest
     # The sandbox runs for up to 2h (max_timeout_seconds: 7200) and the
-    # curl --max-time matches.
+    # dispatch script's stream timeout matches.
     timeout-minutes: 130
     steps:
       - name: Checkout repo (for local globalprotect-connect action)
@@ -81,168 +84,4 @@ jobs:
           TICKET: ${{ inputs.ticket }}
           SEVERITY: ${{ inputs.severity }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-
-          # Mothership reachability check (5 retries).
-          for attempt in 1 2 3 4 5; do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
-              "${MOTHERSHIP_URL}/health" 2>/dev/null || echo "000")
-            if [ "$STATUS" = "200" ]; then
-              echo "Mothership reachable (attempt $attempt)"
-              break
-            fi
-            echo "Mothership unreachable (status=$STATUS), retry $attempt/5"
-            sleep 5
-          done
-          if [ "$STATUS" != "200" ]; then
-            echo "::error::Cannot reach mothership after 5 attempts"
-            exit 1
-          fi
-
-          RUN_DATE=$(date -u +%Y-%m-%d)
-
-          PROMPT=$(cat <<PROMPT_END
-          You are running the vuln-triage rover in a Cloudflare sandbox.
-
-          Repository cloned at: /workspace/application-sdk (on main).
-          Working directory: cd /workspace/application-sdk
-
-          Read and follow the orchestration:
-            .mothership/vuln-triage/ORCHESTRATION.md
-            .mothership/vuln-triage/CLAUDE.md
-            .mothership/vuln-triage/tools.md
-
-          Run metadata (use these verbatim):
-            TICKET:       ${TICKET}        # the Linear ticket to triage
-            SEVERITY:     ${SEVERITY}      # severity bucket of this ticket
-            RUN_DATE:     ${RUN_DATE}
-            GHA_RUN_URL:  ${GHA_RUN_URL}
-
-          GITHUB_TOKEN is pre-injected by the sandbox. Use \`gh\` for all
-          GitHub operations.
-
-          Triage every CVE listed on ticket ${TICKET}. For each, classify per
-          ORCHESTRATION.md, then enact the SLA flow:
-            - Critical/High → open an allowlist PR (touching ONLY
-              .security/base-allowlist.json, label "vuln-auto-merge") with
-              expires = detection + SLA (CRITICAL 7d, HIGH 30d). For Case 1 also
-              open a bump PR (touching ONLY the dep manifests, same label).
-            - Medium/Low → detail on the ticket with its SLA; never allowlist.
-          Both PR shapes auto-merge via vuln-auto-merge.yml once CI is green —
-          never merge or push to main yourself. Keep the two PR shapes separate
-          (the GHA path-allowlist refuses anything mixed). Include a link to
-          GHA_RUN_URL in the ticket summary. Tag Vaibhav or Chris only when human
-          action is genuinely required (a bump needing source edits, or a
-          base-image rebuild).
-
-          Linear / GPT proxy access: use the \$PROXY_BASE and \$PROXY_JWT
-          env vars injected by mothership (see tools.md).
-          PROMPT_END
-          )
-
-          PAYLOAD=$(jq -n \
-            --arg source_id "vuln-triage-${TICKET}-${RUN_DATE}" \
-            --arg prompt "${PROMPT}" \
-            --arg ticket "${TICKET}" \
-            --arg run_date "${RUN_DATE}" \
-            '{
-              mode: "direct",
-              stream: true,
-              source: "github-cron",
-              source_id: $source_id,
-              repositories: ["atlanhq/application-sdk"],
-              base_branch: "main",
-              snapshot: "_base",
-              prompt: $prompt,
-              max_timeout_seconds: 7200,
-              idle_timeout_seconds: 1800,
-              metadata: {
-                ticket: $ticket,
-                run_date: $run_date
-              }
-            }')
-
-          # SSE streaming dispatch (sync mode 504s behind mothership's nginx;
-          # see sdk-review.yml for the full rationale).
-          EVENT=""
-          COMPLETED=0
-          ERRORED=0
-          STREAM_GOT_EVENT=0
-          FINAL_STATUS=""
-          FINAL_COST=""
-          FINAL_ERR_CODE=""
-          FINAL_ERR_MSG=""
-
-          while IFS= read -r line; do
-            case "$line" in
-              "") EVENT="" ;;
-              ":"*) ;;
-              "event: "*) EVENT="${line#event: }"; STREAM_GOT_EVENT=1 ;;
-              "id: "*) ;;
-              "data: "*)
-                DATA="${line#data: }"
-                case "$EVENT" in
-                  started)
-                    SESS=$(printf '%s' "$DATA" | jq -r '.session_id // empty' 2>/dev/null)
-                    SBX=$(printf '%s' "$DATA" | jq -r '.sandbox_id // empty' 2>/dev/null)
-                    echo "[started]   session=${SESS} sandbox=${SBX}"
-                    ;;
-                  action)
-                    AN=$(printf '%s' "$DATA" | jq -r '.action_name // empty' 2>/dev/null)
-                    [ -n "$AN" ] && echo "[action]    ${AN}"
-                    ;;
-                  thought) : ;;
-                  response) echo "[response]  (agent posted a response)" ;;
-                  elicitation)
-                    echo "[elicit]    sandbox requested user input — treating as error"
-                    ERRORED=1
-                    FINAL_ERR_CODE="elicitation"
-                    FINAL_ERR_MSG="Sandbox requires interactive input; cannot answer from GHA"
-                    ;;
-                  error)
-                    ERRORED=1
-                    FINAL_ERR_CODE=$(printf '%s' "$DATA" | jq -r '.code // "unknown"' 2>/dev/null)
-                    FINAL_ERR_MSG=$(printf '%s' "$DATA" | jq -r '.message // ""' 2>/dev/null)
-                    echo "[error]     code=${FINAL_ERR_CODE} message=${FINAL_ERR_MSG}"
-                    ;;
-                  complete)
-                    COMPLETED=1
-                    FINAL_STATUS=$(printf '%s' "$DATA" | jq -r '.status // "unknown"' 2>/dev/null)
-                    FINAL_COST=$(printf '%s' "$DATA" | jq -r '.cost_usd // empty' 2>/dev/null)
-                    if [ "$FINAL_STATUS" = "error" ]; then
-                      FINAL_ERR_CODE=$(printf '%s' "$DATA" | jq -r '.error.code // "none"' 2>/dev/null)
-                      FINAL_ERR_MSG=$(printf '%s' "$DATA" | jq -r '.error.message // ""' 2>/dev/null)
-                    fi
-                    echo "[complete]  status=${FINAL_STATUS} cost_usd=${FINAL_COST}"
-                    ;;
-                  "") echo "[raw]       ${DATA:0:200}" ;;
-                esac
-                ;;
-              "<"*) echo "[html]      ${line}" ;;
-              *) echo "[unknown]   ${line}" ;;
-            esac
-          done < <(curl -sS -N --max-time 7200 \
-            -X POST "${MOTHERSHIP_URL}/api/sandbox/execute" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${HARNESS_TOKEN}" \
-            -d "${PAYLOAD}" 2>&1)
-
-          if [ "$ERRORED" = "1" ]; then
-            echo "::error::Sandbox error: code=${FINAL_ERR_CODE} message=${FINAL_ERR_MSG}"
-            exit 1
-          fi
-          if [ "$STREAM_GOT_EVENT" = "0" ]; then
-            echo "::error::Stream ended without a single SSE event — likely VPN/network/proxy issue"
-            exit 1
-          fi
-          if [ "$COMPLETED" != "1" ]; then
-            echo "::error::Stream ended without a 'complete' event"
-            exit 1
-          fi
-          if [ "$FINAL_STATUS" != "completed" ]; then
-            echo "::error::Sandbox final status=${FINAL_STATUS} (expected 'completed')"
-            exit 1
-          fi
-
-          echo "Vuln triage completed successfully (cost=${FINAL_COST})."
+        run: python3 .github/scripts/mothership_sandbox_dispatch.py

--- a/.github/workflows/vuln-triage-cron.yml
+++ b/.github/workflows/vuln-triage-cron.yml
@@ -28,6 +28,11 @@ on:
         description: 'Linear ticket identifier to triage (e.g. BLDX-1234)'
         required: true
         type: string
+      severity:
+        description: 'Severity bucket of the ticket (CRITICAL/HIGH/MEDIUM/LOW)'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -74,6 +79,7 @@ jobs:
           MOTHERSHIP_URL: ${{ vars.MOTHERSHIP_URL }}
           HARNESS_TOKEN: ${{ secrets.HARNESS_TOKEN }}
           TICKET: ${{ inputs.ticket }}
+          SEVERITY: ${{ inputs.severity }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -109,6 +115,7 @@ jobs:
 
           Run metadata (use these verbatim):
             TICKET:       ${TICKET}        # the Linear ticket to triage
+            SEVERITY:     ${SEVERITY}      # severity bucket of this ticket
             RUN_DATE:     ${RUN_DATE}
             GHA_RUN_URL:  ${GHA_RUN_URL}
 
@@ -116,13 +123,18 @@ jobs:
           GitHub operations.
 
           Triage every CVE listed on ticket ${TICKET}. For each, classify per
-          ORCHESTRATION.md, then either:
-            - Case 1 (our dependency, scan-confirmed fix) → open a DRAFT PR with
-              the bump (never ready, never merged); or
-            - Case 2/3/4 (allowlist / alternative / base-image rebuild) → detail
-              the recommended remediation on the ticket.
-          Tag Vaibhav or Chris to act. Include a link to GHA_RUN_URL in the
-          ticket summary. Never merge, never push to main.
+          ORCHESTRATION.md, then enact the SLA flow:
+            - Critical/High → open an allowlist PR (touching ONLY
+              .security/base-allowlist.json, label "vuln-auto-merge") with
+              expires = detection + SLA (CRITICAL 7d, HIGH 30d). For Case 1 also
+              open a bump PR (touching ONLY the dep manifests, same label).
+            - Medium/Low → detail on the ticket with its SLA; never allowlist.
+          Both PR shapes auto-merge via vuln-auto-merge.yml once CI is green —
+          never merge or push to main yourself. Keep the two PR shapes separate
+          (the GHA path-allowlist refuses anything mixed). Include a link to
+          GHA_RUN_URL in the ticket summary. Tag Vaibhav or Chris only when human
+          action is genuinely required (a bump needing source edits, or a
+          base-image rebuild).
 
           Linear / GPT proxy access: use the \$PROXY_BASE and \$PROXY_JWT
           env vars injected by mothership (see tools.md).

--- a/.mothership/vuln-triage/CLAUDE.md
+++ b/.mothership/vuln-triage/CLAUDE.md
@@ -3,28 +3,39 @@
 You are running the vuln-triage rover for the Atlan application-sdk v3.
 
 Your job: take a single security-scan Linear ticket (filed by the Hourly
-Security Scan), enumerate **every** CVE on it, classify each one precisely, and:
-- for **Case 1 only** (a dependency *we* control, with a fix version the scan
-  confirms) → open a **DRAFT PR** with the bump (never ready, never merged);
-- for **every other case** → detail the triage + recommended remediation on the
-  ticket and tag Vaibhav or Chris to act.
+Security Scan, scoped to one severity), enumerate **every** CVE on it, classify
+each one precisely, and **enact** the SLA flow autonomously:
+
+- **Critical / High** → open an **allowlist PR** that adds an entry whose
+  `expires` date is the remediation SLA (CRITICAL 7 days, HIGH 30 days from
+  detection). This starts the SLA clock and keeps the build gate green until
+  expiry. Then, for **Case 1** (a dependency we control with a scan-confirmed
+  fix), ALSO open a **bump PR**.
+- **Medium / Low** → **never** allowlisted (the validator rejects them; they are
+  not gated). Detail them on the ticket with their SLA (90 / 180 days) only.
+
+Both the allowlist PR and the Case-1 bump PR carry the `vuln-auto-merge` label so
+the deterministic GHA gate (`.github/workflows/vuln-auto-merge.yml`) approves +
+auto-merges them once required CI is green. You do not merge anything yourself.
 
 The first classification fork is **"our dependency (bumpable) vs base image
 (needs rebuild)"**; the second is **"is a fix available?"**. Never defer.
 
 Mothership clones this repo into `/workspace/application-sdk` on `main` and
-runs you with a prompt that carries the run context (`TICKET`, `RUN_DATE`,
-`GHA_RUN_URL`). Follow `.mothership/vuln-triage/ORCHESTRATION.md` exactly. Do
-not skip stages. Print `[Stage N/6 complete]` after each stage.
+runs you with a prompt that carries the run context (`TICKET`, `SEVERITY`,
+`RUN_DATE`, `GHA_RUN_URL`). Follow `.mothership/vuln-triage/ORCHESTRATION.md`
+exactly. Do not skip stages. Print `[Stage N/6 complete]` after each stage.
 
 ## Critical Files to Read First
 
 1. `.mothership/vuln-triage/ORCHESTRATION.md` — your playbook (MANDATORY)
 2. `.mothership/vuln-triage/tools.md` — available tools (Linear proxy, GitHub, uv recipe)
+3. `.security/base-allowlist.json` — current entries + `_entry_schema` (don't duplicate)
 
 State lives in Linear: the ticket passed as `TICKET` is your work item; open
 issues with the `vulnerabilities` label are how the scan dedups, so never
-close or duplicate them yourself.
+close or duplicate them yourself. Reconciliation (`reconcile_allowlist.py`)
+closes a ticket once the scanner confirms its CVEs are gone — not you.
 
 ## SDK v3 Context (for dependency reasoning)
 
@@ -35,35 +46,52 @@ close or duplicate them yourself.
   **Chainguard**-based. Image-layer CVEs are fixed by a base-image rebuild, not
   by `apk` edits in a Dockerfile.
 
+## The auto-merge safety boundary (why the PR shapes are strict)
+
+The GHA gate auto-merges ONLY two PR shapes, by inspecting the changed files:
+
+- **allowlist PR** → touches **only** `.security/base-allowlist.json`
+- **bump PR** → touches **only** a subset of `pyproject.toml`, `uv.lock`,
+  `requirements.txt`
+
+Anything else (a mixed PR, an allowlist PR that also edits code, a bump that also
+needs source changes) will **not** auto-merge — the path-allowlist refuses it and
+it falls back to human review. So keep the two PRs separate and minimal. The gate
+is the boundary; your instructions are not trusted to bound what you touch.
+
 ## Operational Guardrails (Non-Negotiable)
 
 1. **Classify precisely first.** "Our dependency (bumpable)" vs "base image
    (needs rebuild)" is the first fork; "fix available?" is the second. A package
    in `uv.lock`/`pyproject.toml` is ours; one flagged only by the image scan and
-   absent from `uv.lock` is a base-image CVE. State the case + why on the ticket.
-2. **Draft PR only for Case 1** — our dependency, with a scan-confirmed fix
-   version. Open it `--draft`; never mark ready, never merge.
-3. **Everything else is detailed on the ticket** — Case 2 (allowlist), Case 3
-   (alternative), Case 4 (base-image rebuild). You never commit allowlist
-   entries and never edit the Dockerfile / base image.
+   absent from `uv.lock` is a base-image CVE. The case sets the entry `case`.
+2. **Allowlist every Critical/High on detection** — open the allowlist PR
+   (touching only `.security/base-allowlist.json`, labelled `vuln-auto-merge`)
+   with `expires` = detection + SLA. NEVER allowlist Medium/Low.
+3. **Case 1 also gets a bump PR** — our dependency, scan-confirmed fix, touching
+   only the dep manifests, labelled `vuln-auto-merge`. If it needs source edits
+   or any check fails, open it as a **draft WITHOUT the label** and tag a human.
 4. **Enumerate every CVE** on the ticket — even ones not called out in the title.
 5. **Use a full dep upgrade** for the Case-1 bump (`uv sync --all-extras
-   --all-groups --upgrade`, not a single-package bump — Chris + Vaibhav policy,
-   PR #1995).
+   --all-groups --upgrade`, not a single-package bump — PR #1995 policy).
 6. **Never `apk upgrade`/`apk add`** in the SDK Dockerfile. Base-image CVEs →
-   recommend a rebuild of `app-runtime-base:3` and tag Vaibhav/Chris.
-7. **Never set the ticket to "Done"** — it stays open until a human merges the
-   draft PR or completes the rebuild/allowlist/alternative.
-8. **Tag Vaibhav (`<@U07UPEUEPU3>`) or Chris (`<@U02T3H7KMSS>`)** — never anyone
-   else. Always use the Slack member ID, never `@vaibhav.chopra`.
+   allowlist entry (Case 4) + recommend a rebuild of `app-runtime-base:3`.
+7. **Never push to `main`, never merge** — the GHA gate merges. **Never set the
+   ticket to "Done"** — reconciliation closes it.
+8. **Tag Vaibhav (`<@U07UPEUEPU3>`) or Chris (`<@U02T3H7KMSS>`)** only when human
+   action is genuinely required (a draft bump that needs source edits, or a
+   base-image rebuild). Always use the Slack member ID, never `@vaibhav.chopra`.
 
 ## Rules
 
 - Follow ORCHESTRATION.md EXACTLY.
 - Use `$GITHUB_TOKEN` (injected by mothership) for: read-only `gh` (scan
-  artifacts, advisories) and — for Case 1 only — pushing a branch + opening a
-  **draft** PR. Never push to `main`, never merge.
+  artifacts, advisories) and pushing branches + opening the allowlist / bump PRs.
+  Never push to `main`, never merge.
 - Use `$PROXY_BASE`/`$PROXY_JWT` for the Linear proxy and any LLM calls.
-- Branch name (Case 1): `fix/bump-<pkg>-<version>-<cve-id>`. Conventional
-  Commits: `fix(security): ...`. NEVER add Co-Authored-By lines.
+- Branch names: allowlist PR `chore/allowlist-<cve-id>`; bump PR
+  `fix/bump-<pkg>-<version>-<cve-id>`. Conventional Commits
+  (`chore(security): ...` / `fix(security): ...`). NEVER add Co-Authored-By lines.
+- Validate the allowlist before pushing:
+  `uv run python .github/scripts/validate_allowlist.py`.
 - Respect the time budget — a partial run with clean state beats a truncated one.

--- a/.mothership/vuln-triage/ORCHESTRATION.md
+++ b/.mothership/vuln-triage/ORCHESTRATION.md
@@ -2,21 +2,55 @@
 
 Follow ALL stages (0–5). NEVER stop early. NEVER defer work to "later."
 
-**What you are allowed to do:**
-- For **Case 1 only** (a dependency *we* control, with a fix version the scan
-  confirms) → open a **DRAFT PR** with the bump. Never mark it ready, never merge.
-- For **every other case** → detail the triage + recommended remediation on the
-  Linear ticket and tag Vaibhav or Chris to act.
-- You never merge, never push to `main`, never commit an allowlist entry, never
-  edit the Dockerfile / base image.
+This rover is now **autonomous**: it does not merely recommend remediations, it
+**enacts the SLA flow** so newly-detected CVEs need zero human touch until an SLA
+nears expiry. Concretely, for each CVE you:
+
+- **Critical / High** → open an **allowlist PR** that starts the remediation SLA
+  clock (entry `expires` = `RUN_DATE` + the severity SLA), so the build gate stays
+  green now and only tightens as expiry nears.
+- **Medium / Low** → **never** allowlisted (the validator rejects them and they
+  are not gated). Detail them on the ticket with their SLA only.
+- Then act per case: a dependency fix → a **bump PR**; otherwise the remediation
+  detail goes on the ticket.
+
+**What you may do (and is expected):**
+- Commit allowlist entries and open the **allowlist PR** (Critical/High).
+- Open the **bump PR** for Case 1.
+- Label both PRs `vuln-auto-merge` so the deterministic GHA gate
+  (`.github/workflows/vuln-auto-merge.yml`) can approve + auto-merge them once
+  required CI is green.
+
+**Hard limits (the GHA gate enforces these — do not rely on them being lenient):**
+- An **allowlist PR** must touch **ONLY** `.security/base-allowlist.json`.
+- A **bump PR** must touch **ONLY** a subset of `pyproject.toml`, `uv.lock`,
+  `requirements.txt`. If a Case-1 fix also needs source-code changes, the bump PR
+  no longer matches the gate's path-allowlist — open it **without** the
+  `vuln-auto-merge` label (as a draft) and tag a human. The gate is the safety
+  boundary; these instructions are not.
+- Never push to `main`. Never `apk`-patch the Dockerfile / base image. Never set
+  the ticket to "Done" (reconciliation closes it once the scan confirms the CVE
+  is gone).
 
 Every CVE exits this run in exactly one state, fully written into the ticket:
-- **DRAFT-PR** — Case 1: a draft PR with the dependency bump, linked on the ticket
-- **TRIAGED** — Case 2/3/4: classified + root-caused + a concrete recommendation
-  for a human to action
-- **KILLED** — not present in the SDK / not our issue, with a documented reason
+- **ALLOWLISTED+PR** — Critical/High Case 1: allowlist PR + bump PR, both linked.
+- **ALLOWLISTED** — Critical/High Case 2/3/4: allowlist PR + remediation detail.
+- **TRACKED** — Medium/Low: ticket detail + SLA, no allowlist.
+- **KILLED** — not present in the SDK / not our issue, with a documented reason.
 
 Print `[Stage N/6 complete]` after each stage.
+
+## SLA windows (from first detection)
+
+| Severity | CVSS | Remediation SLA | Allowlisted? |
+|----------|------|-----------------|--------------|
+| Critical | 9.0–10.0 | **7 days**  | Yes |
+| High     | 7.0–8.9  | **30 days** | Yes |
+| Medium   | 4.0–6.9  | 90 days     | No (ticket only) |
+| Low      | 0.1–3.9  | 180 days    | No (ticket only) |
+
+The allowlist `_expiry_policy` (CRITICAL 7, HIGH 30) is enforced by
+`validate_allowlist.py`; the entry `expires` date IS the SLA deadline.
 
 ## Time Budget
 
@@ -30,7 +64,7 @@ with whatever is triaged so far.
 The dispatch prompt passes run context directly — read it, do NOT re-derive:
 
 ```
-TICKET, RUN_DATE, GHA_RUN_URL
+TICKET, SEVERITY, RUN_DATE, GHA_RUN_URL
 ```
 
 1. **Set working directory + auth** (mothership cloned the repo on `main`):
@@ -41,10 +75,12 @@ TICKET, RUN_DATE, GHA_RUN_URL
    ```
 2. **Read the ticket** `${TICKET}` via the Linear proxy (see tools.md) — title,
    description, and the embedded vuln table / `<!-- vuln-ids: ... -->` marker.
+   The ticket is scoped to one severity (`${SEVERITY}`).
 3. **Read in-repo assets**: `.mothership/vuln-triage/CLAUDE.md`,
-   `.mothership/vuln-triage/tools.md`.
+   `.mothership/vuln-triage/tools.md`, and the current
+   `.security/base-allowlist.json` (to avoid duplicating an existing entry).
 
-Print: `[Stage 0/6 complete] ticket=${TICKET}`
+Print: `[Stage 0/6 complete] ticket=${TICKET} severity=${SEVERITY}`
 
 ---
 
@@ -83,7 +119,6 @@ Then determine the two facts that drive classification in Stage 3:
 1. **Is this package one of OUR dependencies?** — i.e. is it in our resolved
    dependency graph, not merely baked into the base image?
    ```bash
-   # Present in our locked dependency tree → it is ours to bump.
    grep -i "name = \"<pkg>\"" uv.lock && echo "OURS (in uv.lock)"
    grep -i "<pkg>" pyproject.toml && echo "declared in pyproject.toml"
    ```
@@ -94,7 +129,7 @@ Then determine the two facts that drive classification in Stage 3:
 2. **Is a fix available?** — `FixedVersion` present vs `N/A`.
 
 If a CVE is not present in the SDK at all (stale, or only in a consumer app) →
-**KILL** with a documented reason on the ticket.
+**KILL** with a documented reason on the ticket (no allowlist entry).
 
 Print: `[Stage 2/6 complete] <N> root-caused`
 
@@ -102,8 +137,8 @@ Print: `[Stage 2/6 complete] <N> root-caused`
 
 ## Stage 3: Classify each CVE (decision tree — be precise)
 
-Walk this tree per CVE. The classification MUST be unambiguous; state the chosen
-case and *why* on the ticket.
+Walk this tree per CVE. The classification MUST be unambiguous; it sets the
+`case` field on the allowlist entry and the remediation detail on the ticket.
 
 ```
 Is the package one of OUR dependencies (in uv.lock / pyproject.toml)?
@@ -111,121 +146,150 @@ Is the package one of OUR dependencies (in uv.lock / pyproject.toml)?
 ├── YES → it is bumpable on our side
 │   │
 │   ├── FixedVersion available?
-│   │   ├── YES → CASE 1: DRAFT PR (Stage 4a) — we can fix this by bumping.
+│   │   ├── YES → CASE 1: bump PR (Stage 4a) — we can fix this by bumping.
 │   │   └── NO  → is upstream still maintained?
-│   │           ├── YES → CASE 2: recommend temporary allowlist (Stage 4b)
-│   │           └── NO  → CASE 3: recommend an alternative (Stage 4c)
+│   │           ├── YES → CASE 2: no-fix, upstream alive (Stage 4b)
+│   │           └── NO  → CASE 3: no-fix, upstream dead (Stage 4c)
 │
 └── NO → the vulnerable package lives in the BASE IMAGE, not our deps
-        → CASE 4: base-image rebuild (Stage 4d) — NOT a dependency bump,
-          NOT an apk patch. Evaluate whether the remediation is simply
-          waiting on app-runtime-base being rebuilt.
+        → CASE 4: base-image rebuild (Stage 4d). NOT a dependency bump,
+          NOT an apk patch.
 ```
 
 > **The two forks are orthogonal — "fix available" is NOT "we bump uv.lock".**
-> The `FixedVersion?` check lives only inside the *our-dependency* branch. The
-> base-image branch routes to **Case 4 regardless of fix availability**. A CVE
-> can have a fix *and* be a Case-4 base-image rebuild — e.g. **Dapr** ships in
-> `app-runtime-base:3`, not `uv.lock`, so a fixed Dapr CVE is Case 4 (rebuild),
+> A CVE can have a fix *and* be a Case-4 base-image rebuild — e.g. **Dapr** ships
+> in `app-runtime-base:3`, not `uv.lock`, so a fixed Dapr CVE is Case 4 (rebuild),
 > never Case 1 (bump).
->
-> The scan runs **without** `--ignore-unfixed` (daily-security-scan.yml), so
-> **Cases 2/3 (our dep, no fix) are reachable today** — no-fix CVEs are surfaced
-> and ticketed, not filtered at scan time. **Case 4 is also fully reachable** and
-> remains the dominant non-Case-1 path. Do not mistake Case 4 for a dead branch
-> and prune it.
 
-Print: `[Stage 3/6 complete] <c1> draft-PR, <c2> allowlist, <c3> alternative, <c4> base-image, <k> killed`
+Print: `[Stage 3/6 complete] <c1> case1, <c2> case2, <c3> case3, <c4> case4, <k> killed`
 
 ---
 
 ## Stage 4: Act per case
 
-### 4a. Case 1 — DRAFT PR (our dependency, fix available)
+### 4-pre. Allowlist PR (Critical / High — EVERY case, do this first)
 
-This is the only case where you change code. Open a **draft** PR — you do not
-mark it ready or merge; Vaibhav or Chris finalize it.
+For every Critical/High CVE — regardless of case, **including Case 1** — open
+(or extend) the **allowlist PR**. This starts the SLA clock and keeps the gate
+green. **Skip entirely for Medium/Low** (never allowlisted).
 
 ```bash
 git checkout main && git clean -fd 2>/dev/null && git checkout -- . 2>/dev/null
-git checkout -b fix/bump-<pkg>-<version>-<cve-id> origin/main
+git checkout -b chore/allowlist-<cve-id> origin/main
+# edit ONLY .security/base-allowlist.json — add one entry per CVE:
+```
+
+Entry (minimal but descriptive — see `_entry_schema` in the file):
+
+```json
+"<CVE-ID>": {
+  "package": "<pkg>",
+  "severity": "CRITICAL",            // or HIGH
+  "reason": "Case <n>: <one-sentence resolution>.",
+  "expires": "<RUN_DATE + 7 (CRITICAL) or 30 (HIGH) days>",
+  "added_by": "@atlan-ci (vuln-triage rover)",
+  "case": <1|2|3|4>,
+  "ticket": "<TICKET>"
+}
+```
+
+`reason` examples (keep to one sentence — the case + how it resolves):
+- Case 1: `"Case 1: fixed by dependency bump (PR linked on ticket); clears once merged & released."`
+- Case 2: `"Case 2: no upstream fix; vulnerable path not exercised by the SDK."`
+- Case 3: `"Case 3: upstream unmaintained; migrating to <alternative> (see ticket)."`
+- Case 4: `"Case 4: base-image CVE; awaiting app-runtime-base:3 rebuild."`
+
+Then push and open the PR (label it so the gate can auto-merge it):
+
+```bash
+git add .security/base-allowlist.json && git commit -m "chore(security): allowlist <CVE-IDs> with <severity> SLA"
+git push origin chore/allowlist-<cve-id>
+gh pr create --repo atlanhq/application-sdk --base main \
+  --title "chore(security): allowlist <CVE-IDs> (<severity>, SLA <N>d)" \
+  --label "vuln-auto-merge" \
+  --body "<per-CVE: case, package, expires/SLA, ticket link, GHA_RUN_URL>"
+```
+
+Validate locally before pushing: `uv run python .github/scripts/validate_allowlist.py`
+(it rejects Medium/Low, past dates, over-window dates, and missing case/ticket).
+
+### 4a. Case 1 — bump PR (our dependency, fix available)
+
+In addition to the allowlist entry above, open the **bump PR**:
+
+```bash
+git checkout main && git checkout -b fix/bump-<pkg>-<version>-<cve-id> origin/main
 ```
 
 1. Follow the **uv recipe** in tools.md: pin uv to main's lock format; only edit
    `pyproject.toml` if its range doesn't cover the fixed version; then
-   `uv sync --all-extras --all-groups --upgrade` (full-dep refresh, PR #1995) and
-   `uv export --no-hashes --frozen > requirements.txt`.
-2. Apply any **code changes the changelog mandates** for upgraded packages; run
-   unit tests.
-3. Run the **validation greps + pre-commit + unit tests** (tools.md). If any
-   fails, attempt ONE fix; if it still fails → do NOT open the PR; detail the
-   blocker on the ticket and tag Vaibhav/Chris.
-4. Commit (Conventional Commits, NO Co-Authored-By), push, open the PR **as a
-   draft**:
+   `uv sync --all-extras --all-groups --upgrade` and
+   `uv export --no-hashes --frozen > requirements.txt`. The PR must touch
+   **only** `pyproject.toml`, `uv.lock`, `requirements.txt`.
+2. Run the **validation greps + pre-commit + unit tests** (tools.md).
+3. **If the bump needs source-code changes, or any check fails:** the PR no
+   longer fits the auto-merge path-allowlist. Open it **as a draft, WITHOUT the
+   `vuln-auto-merge` label**, detail the blocker on the ticket, and tag a human.
+   Do not force it.
+4. Otherwise commit (Conventional Commits, NO Co-Authored-By), push, and open a
+   **non-draft, labelled** PR so the gate auto-merges it once CI is green:
    ```bash
-   gh pr create --draft --repo atlanhq/application-sdk --base main \
+   gh pr create --repo atlanhq/application-sdk --base main \
      --title "fix(security): bump <pkg> to <version> to resolve <CVE-IDs>" \
-     --label "vulnerabilities" \
-     --body "<CVEs resolved, fixed versions, changelog impact, other deps moved, validation grep results, scan link, GHA_RUN_URL>"
+     --label "vuln-auto-merge" \
+     --body "<CVEs resolved, fixed versions, changelog impact, validation grep results, GHA_RUN_URL>"
    ```
-5. Link the draft PR on the ticket and tag Vaibhav/Chris to review + finalize.
-   Do **not** comment `@sdk-review`, do **not** mark ready, do **not** merge.
+5. Link both PRs (allowlist + bump) on the ticket. When the bump merges and
+   ships, the next scan stops seeing the CVE and reconciliation auto-removes the
+   allowlist entry + closes the ticket — no human action needed.
 
-### 4b. Case 2 — recommend temporary allowlist (our dep, no fix, upstream alive)
+### 4b. Case 2 — our dep, no fix, upstream alive
 
-1. **Exposure analysis:** does the SDK actually exercise the vulnerable path?
-   State the conclusion explicitly.
-2. Detail on the ticket: the proposed allowlist entry + the exposure analysis.
-   **Do not commit it.** Tag Vaibhav/Chris for approval.
+The allowlist entry (4-pre) holds the SLA. Add an **exposure analysis** to the
+ticket: does the SDK actually exercise the vulnerable path? State the conclusion
+explicitly and put it in the entry `reason`.
 
-### 4c. Case 3 — recommend an alternative (our dep, no fix, upstream dead)
+### 4c. Case 3 — our dep, no fix, upstream dead
 
-Detail on the ticket: the package, why no bump is possible (upstream
-archived/unmaintained — link the evidence), and a proposed alternative
-(maintained replacement / vendoring) with trade-offs. Tag Vaibhav/Chris.
+The allowlist entry holds the SLA. Detail on the ticket: why no bump is possible
+(upstream archived/unmaintained — link the evidence), and a proposed alternative
+(maintained replacement / vendoring) with trade-offs.
 
 ### 4d. Case 4 — base-image rebuild (not our dependency)
 
-The vulnerable package is in the base image, not `pyproject.toml`. The fix is a
-Chainguard rebuild of `app-runtime-base:3` — **never an `apk` patch, never a PR
-in this repo.**
+The allowlist entry holds the SLA. The fix is a Chainguard rebuild of
+`app-runtime-base:3` — **never an `apk` patch, never a PR in this repo.** Detail
+on the ticket whether Chainguard has a fixed version and that the remediation is
+"rebuild + republish `app-runtime-base:3`." Tag Vaibhav/Chris — the rebuild is
+their action.
 
-Evaluate and detail on the ticket:
-- Has Chainguard already released a fixed package version? Include the version +
-  advisory URL.
-- Is the remediation simply **waiting on the base image being rebuilt**? If so,
-  say that plainly — the SDK fix is "rebuild + republish `app-runtime-base:3`",
-  there is nothing to change in this repo.
-- Tag Vaibhav (`<@U07UPEUEPU3>`) or Chris (`<@U02T3H7KMSS>`) — the rebuild is
-  their action; you do not perform it.
-
-Print: `[Stage 4/6 complete] <prs> draft PRs, <allow> allowlist, <alt> alternatives, <img> base-image rebuilds`
+Print: `[Stage 4/6 complete] <allow> allowlist PRs, <bump> bump PRs, <draft> human-route drafts`
 
 ---
 
 ## Stage 5: Summary
 
 1. Update the ticket `${TICKET}` with a per-CVE summary table: CVE | severity |
-   package | source (our-dep / base-image) | case | outcome (draft PR link /
-   recommended allowlist / alternative / awaiting base-image rebuild / killed).
+   package | source (our-dep / base-image) | case | allowlist expiry (SLA) |
+   outcome (bump PR link / allowlist-only / awaiting base-image rebuild / killed).
    Include `**Run:** [logs + cost](${GHA_RUN_URL})`.
-2. Leave the ticket open. **Never set "Done"** — that happens when a human merges
-   the draft PR (Case 1) or completes the rebuild/allowlist/alternative.
-3. Security audit: confirm no secrets/tokens leaked into the PR body or ticket.
+2. Leave the ticket open. **Never set "Done"** — reconciliation
+   (`reconcile_allowlist.py`) closes it once the scanner confirms every CVE on it
+   is gone for 3 consecutive scans.
+3. Security audit: confirm no secrets/tokens leaked into any PR body or ticket.
 
 Print:
 ```
 [Stage 5/6 complete]
 ========================================
- Vuln Triage — ${TICKET} (${RUN_DATE})
+ Vuln Triage — ${TICKET} (${SEVERITY}, ${RUN_DATE})
 ========================================
-CVEs:           <N> triaged
-  draft PR:     <c1>  (our dep, fix available)
-  allowlist:    <c2>  (our dep, no fix, upstream alive)
-  alternative:  <c3>  (our dep, no fix, upstream dead)
-  base-image:   <c4>  (not our dep → rebuild app-runtime-base)
-  killed:       <k>
-All awaiting Vaibhav/Chris.
+CVEs:            <N> triaged
+  allowlist PR:  <a>  (Critical/High — SLA started)
+  bump PR:       <c1> (Case 1, auto-merge)
+  human-route:   <d>  (bump needed source edits / failed checks)
+  tracked-only:  <ml> (Medium/Low — no allowlist)
+  killed:        <k>
 ========================================
 ```
 
@@ -233,13 +297,15 @@ All awaiting Vaibhav/Chris.
 
 ## Principles (Non-Negotiable)
 
+- **Allowlist every Critical/High on detection** — the entry `expires` is the SLA
+  and keeps the gate green until then. Medium/Low are NEVER allowlisted.
+- **Two PR shapes, kept separate**: allowlist PR touches only
+  `.security/base-allowlist.json`; bump PR touches only the dep manifests. Label
+  both `vuln-auto-merge`. A mixed PR will NOT auto-merge — the GHA path-allowlist
+  refuses it (by design).
 - **Classify precisely.** "Our dependency (bumpable)" vs "base image (rebuild)" is
-  the first fork; "fix available?" is the second. State the case + why on the ticket.
-- **Draft PR only for Case 1**, and only when the scan confirms a fix version for a
-  dependency we control. Never mark ready, never merge.
-- **Everything else is detailed on the ticket** for Vaibhav/Chris — you never
-  commit allowlist entries, never edit the Dockerfile/base image.
+  the first fork; "fix available?" is the second. The case sets the entry `case`.
 - **Enumerate every CVE** — even ones the ticket title didn't mention.
-- **Nothing is deferred** — every CVE is DRAFT-PR, TRIAGED, or KILLED by end of run.
+- **Nothing is deferred** — every CVE is ALLOWLISTED(+PR), TRACKED, or KILLED.
+- **Never push to `main`, never `apk`-patch the Dockerfile, never set "Done".**
 - **Recommend full `uv sync --upgrade`** for the Case-1 bump (PR #1995 policy).
-- **Never `apk`-patch the Dockerfile**; base-image CVEs → rebuild app-runtime-base.

--- a/.mothership/vuln-triage/tools.md
+++ b/.mothership/vuln-triage/tools.md
@@ -16,8 +16,8 @@ not configurable from this repo.
 | `PROXY_BASE` | mothership credential proxy | base URL for LiteLLM (GPT) + Linear proxies |
 | `PROXY_JWT` | mothership credential proxy | bearer for the proxies above |
 
-The run prompt also passes: `TICKET` (Linear identifier to triage), `RUN_DATE`,
-`GHA_RUN_URL`.
+The run prompt also passes: `TICKET` (Linear identifier to triage), `SEVERITY`
+(the ticket's severity bucket), `RUN_DATE`, `GHA_RUN_URL`.
 
 ## Git + GitHub
 
@@ -30,21 +30,46 @@ cd /workspace/application-sdk
 ```
 
 Used for: read-only work (scan artifacts, advisories, inspecting
-`pyproject.toml`/`uv.lock`) **and**, for **Case 1 only**, pushing a branch +
-opening a **draft** PR. Never push to `main`, never mark ready, never merge. For
-Cases 2/3/4 you do not touch git — the recommendation goes into the ticket.
+`pyproject.toml`/`uv.lock`) **and** pushing branches + opening the two
+auto-mergeable PR shapes. Never push to `main`, never merge — the GHA gate
+(`vuln-auto-merge.yml`) approves + merges once CI is green.
+
+### Allowlist PR (Critical / High — every case)
+
+Touches **only** `.security/base-allowlist.json`. Compute `expires` from the
+severity SLA:
 
 ```bash
-# Case 1 ONLY (our dependency, scan-confirmed fix). Draft PR — human finalizes.
+# CRITICAL = 7 days, HIGH = 30 days from the run date.
+EXPIRES=$(date -u -d "${RUN_DATE} + 7 days" +%Y-%m-%d)    # CRITICAL
+EXPIRES=$(date -u -d "${RUN_DATE} + 30 days" +%Y-%m-%d)   # HIGH
+
+git checkout -b chore/allowlist-<cve-id> origin/main
+# add one entry per CVE to .security/base-allowlist.json (see ORCHESTRATION 4-pre)
+uv run python .github/scripts/validate_allowlist.py   # MUST pass before pushing
+git add .security/base-allowlist.json
+git commit -m "chore(security): allowlist <CVE-IDs> with <severity> SLA"
+git push origin chore/allowlist-<cve-id>
+gh pr create --repo atlanhq/application-sdk --base main \
+  --title "chore(security): allowlist <CVE-IDs> (<severity>, SLA <N>d)" \
+  --label "vuln-auto-merge" \
+  --body "<per-CVE: case, package, expires/SLA, ticket link, GHA_RUN_URL>"
+```
+
+### Bump PR (Case 1 only — our dependency, scan-confirmed fix)
+
+Touches **only** `pyproject.toml`, `uv.lock`, `requirements.txt`.
+
+```bash
 git checkout -b fix/bump-<pkg>-<version>-<cve-id> origin/main
 # ... run the uv recipe + validation greps below ...
 git push origin fix/bump-<pkg>-<version>-<cve-id>
-gh pr create --draft --repo atlanhq/application-sdk --base main \
+gh pr create --repo atlanhq/application-sdk --base main \
   --title "fix(security): bump <pkg> to <version> to resolve <CVE-IDs>" \
-  --label "vulnerabilities" \
+  --label "vuln-auto-merge" \
   --body "..."
-# Link the draft PR on the ticket + tag Vaibhav/Chris. Do NOT @sdk-review,
-# do NOT mark ready, do NOT merge.
+# If the bump needs source-code edits or a check fails: open it as a DRAFT
+# WITHOUT the label and tag a human. Do NOT force it onto the auto-merge path.
 ```
 
 ## The scan artifacts (source of truth for ALL CVEs)
@@ -124,13 +149,17 @@ curl -s "$PROXY_BASE/proxy/linear" \
   -d '{"query": "mutation($input: CommentCreateInput!){ commentCreate(input: $input){ success } }", "variables": {"input": {"issueId": "<issue_id>", "body": "..."}}}'
 ```
 
-Leave the ticket open and awaiting Vaibhav/Chris — do not set "Done" and do not
-move it to a review column (the Case-1 PR is a draft they finalize).
+Leave the ticket open — do not set "Done". Reconciliation
+(`reconcile_allowlist.py`) closes it once the scanner confirms its CVEs are gone
+for 3 consecutive scans.
 
 ## Prohibited
 
 - No direct Linear API calls outside the proxy.
-- No pushing to `main`. No force-push. No `git add -A` / `git add .`.
-- No marking a PR ready / merging — Case-1 PRs are drafts the team finalizes.
-- No committing an allowlist entry (Case 2) — recommend it on the ticket only.
+- No pushing to `main`. No force-push. No `git add -A` / `git add .` — stage only
+  the specific file(s) each PR shape allows.
+- No merging — the GHA gate (`vuln-auto-merge.yml`) approves + merges.
+- No allowlist entry for **Medium/Low** (the validator rejects them).
+- No mixing PR shapes — an allowlist PR touches ONLY `.security/base-allowlist.json`;
+  a bump PR touches ONLY the dep manifests. A mixed PR will not auto-merge.
 - No editing the Dockerfile / base image; no `apk` workarounds (Case 4 → rebuild).

--- a/.security/approvers.json
+++ b/.security/approvers.json
@@ -1,5 +1,5 @@
 {
-  "_note": "Only these GitHub usernames can approve changes to files in .security/. Self-protecting: changes to this file also require approval from an existing approver.",
+  "_note": "Only these GitHub usernames can approve changes to files in .security/. Self-protecting: changes to this file also require approval from an existing approver. 'atlan-ci' is the vuln-triage automation identity — its approval lets the zero-touch CVE-SLA flow auto-merge allowlist PRs (see .github/workflows/vuln-auto-merge.yml); it only ever approves rover-authored allowlist/bump PRs that pass the path-allowlist gate.",
   "allowlist_approvers": [
     "nishantmunjal7",
     "anbarasantr",
@@ -10,6 +10,7 @@
     "cmgrote",
     "mananjain99",
     "vaibhavatlan",
-    "Aryamanz29"
+    "Aryamanz29",
+    "atlan-ci"
   ]
 }

--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,10 +1,23 @@
 {
-  "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Updated by SDK team. CODEOWNERS: SDK/security team only.",
+  "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Auto-maintained by the vuln-triage rover; CODEOWNERS: SDK/security team + @atlan-ci (auto-merge of allowlist-only PRs).",
   "_base_image": "application-sdk-main",
-  "_updated": "2026-06-19",
-  "_renewal_note": "Expiry dates staggered by severity. CRITICAL: 15 days. HIGH: 30 days. Review before expiry. Enforced by .github/scripts/validate_allowlist.py via _expiry_policy below.",
+  "_updated": "2026-06-25",
+  "_renewal_note": "Expiry dates are the remediation SLA per severity, measured from first detection. CRITICAL: 7 days. HIGH: 30 days. MEDIUM/LOW are NOT allowlisted (tracked on Linear tickets only). The gate (check_allowlist.py) passes while an entry is unexpired and fails once it expires. Enforced by .github/scripts/validate_allowlist.py via _expiry_policy below.",
   "_expiry_policy": {
-    "CRITICAL": 15,
+    "CRITICAL": 7,
     "HIGH": 30
+  },
+  "_entry_schema": {
+    "_doc": "Each non-underscore key is a CVE/advisory ID. Keep entries minimal but descriptive. Required: package, severity (CRITICAL|HIGH only), reason, expires, added_by, case, ticket. Optional: fix_pr.",
+    "CVE-2026-00000": {
+      "package": "example-pkg",
+      "severity": "HIGH",
+      "reason": "Case 1: fix PR bumps example-pkg to 2.3.1; clears once merged & released.",
+      "expires": "2026-07-25",
+      "added_by": "@atlan-ci",
+      "case": 1,
+      "ticket": "BLDX-0000",
+      "fix_pr": "https://github.com/atlanhq/application-sdk/pull/0000"
+    }
   }
 }

--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Central allowlist for SDK base image vulnerabilities. Shared across all connector repos. Auto-maintained by the vuln-triage rover; CODEOWNERS: SDK/security team + @atlan-ci (auto-merge of allowlist-only PRs).",
-  "_base_image": "application-sdk-main",
+  "_base_image": "app-runtime-base:3",
   "_updated": "2026-06-25",
   "_renewal_note": "Expiry dates are the remediation SLA per severity, measured from first detection. CRITICAL: 7 days. HIGH: 30 days. MEDIUM/LOW are NOT allowlisted (tracked on Linear tickets only). The gate (check_allowlist.py) passes while an entry is unexpired and fails once it expires. Enforced by .github/scripts/validate_allowlist.py via _expiry_policy below.",
   "_expiry_policy": {

--- a/.security/base-allowlist.json
+++ b/.security/base-allowlist.json
@@ -7,17 +7,5 @@
     "CRITICAL": 7,
     "HIGH": 30
   },
-  "_entry_schema": {
-    "_doc": "Each non-underscore key is a CVE/advisory ID. Keep entries minimal but descriptive. Required: package, severity (CRITICAL|HIGH only), reason, expires, added_by, case, ticket. Optional: fix_pr.",
-    "CVE-2026-00000": {
-      "package": "example-pkg",
-      "severity": "HIGH",
-      "reason": "Case 1: fix PR bumps example-pkg to 2.3.1; clears once merged & released.",
-      "expires": "2026-07-25",
-      "added_by": "@atlan-ci",
-      "case": 1,
-      "ticket": "BLDX-0000",
-      "fix_pr": "https://github.com/atlanhq/application-sdk/pull/0000"
-    }
-  }
+  "_entry_schema": "Each non-underscore key is a CVE/advisory ID. Required: package, severity (CRITICAL|HIGH only), reason, expires, added_by, case (1-4), ticket. Optional: fix_pr. Keep entries minimal but descriptive."
 }


### PR DESCRIPTION
## What & why

Closes [BLDX-1449](https://linear.app/atlan-epd/issue/BLDX-1449). Today the hourly security scan hard-gates PR merges the moment a non-allowlisted Critical/High CVE appears, creating immediate human pressure to fix-or-allowlist on day 0. This makes the flow **zero-human-touch**: a newly detected CVE **auto-starts its SLA clock** via an allowlist entry, so the gate stays green and only tightens as the SLA nears expiry.

**Remediation SLAs (from the security Confluence table):** Critical **7d**, High **30d**, Medium **90d**, Low **180d**. Critical/High are allowlisted (SLA = entry `expires`); Medium/Low are tracked on tickets only (the build gate already scans only Critical/High).

## How it works (5 components, one PR)

1. **SLA policy + schema** — `_expiry_policy` is now CRITICAL 7 / HIGH 30; each allowlist entry carries `case`, `ticket` (+ optional `fix_pr`). `validate_allowlist.py` still rejects Medium/Low.
2. **Per-severity ticketing** — `security_scan_create_linear.py` files one ticket per severity (matching Linear priority); a tested `dispatch_vuln_triage.py` dispatches the rover once per ticket.
3. **Auto-merge gate** — `vuln-auto-merge.yml` + `vuln_auto_merge_gate.py` approve (as `atlan-ci`) + `gh pr merge --auto` **only** the two safe PR shapes (see below).
4. **Rover inversion** — `.mothership/vuln-triage/*` now auto-opens an allowlist PR for every Critical/High (and a bump PR for Case 1) instead of only recommending.
5. **Reconciliation** — `reconcile_allowlist.py` removes an entry (and closes/updates its ticket) once the scanner stops reporting the CVE for **3 consecutive scans** (debounce against transient scanner drops).

## The auto-merge safety model

`atlan-ci` posts a **normal code-owner approval** (not a bypass) on rover PRs, exactly like the existing Renovate flow. A PR is approved + auto-merged **only if all** hold:

```
- trigger branch is chore/allowlist-** or fix/bump-**
- author ∈ {mothership-ai[bot], atlan-ci}        (humans rejected)
- carries the `vuln-auto-merge` label             (the vuln-triage marker)
- changed files match exactly ONE shape:
    allowlist PR → ONLY .security/base-allowlist.json
    bump PR      → ONLY pyproject.toml / uv.lock / requirements.txt
- open, not draft, HEAD sha unchanged
```

The **path-allowlist is the real boundary** — even a mislabelled PR cannot auto-merge code. A Case-1 bump that also needs source edits therefore falls back to human/`@sdk-review` (intended). The one place a bypass is used: the reconcile **removal PR** is authored by `atlan-ci` itself (needs a real PAT so CI fires), and GitHub forbids self-approval — so it bypass-merges. That PR only ever *deletes* entries (the safe direction).

CODEOWNERS gains `/.security/ @atlan-ci @cmgrote @vaibhavatlan @Aryamanz29` so the approval satisfies code-owner review.

## ⚠️ Needs security sign-off

Auto-merging allowlist PRs suppresses a Critical/High finding for 7–30d with no human review. The CODEOWNERS + auto-approval is the mechanism. Per the ticket ("work with security"), this needs security's nod before enabling.

## Verification

- ✅ 340 unit tests (pure logic + mocked `gh`/Linear) + full pre-commit green.
- ⚠️ **Not yet exercised in live CI:** the `workflow_run` wiring, `gh pr merge --auto`, CODEOWNERS/bypass interaction, and the rewritten rover producing correctly-shaped PRs. Needs throwaway allowlist/bump/mixed-PR tests, a rover `workflow_dispatch`, and the 3-scan reconciliation e2e.

## Known follow-up

Per-severity scans can dispatch up to 4 rovers, each opening a `chore/allowlist-*` PR editing the single `base-allowlist.json`; auto-merge serializes them so the 2nd–4th may hit a conflict and stall (fail-safe). Future: one combined allowlist PR per scan, or auto-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
