### PR TITLE
ci(security): close vuln tickets from the scan, not the allowlist

### DIFF
--- a/.github/scripts/reconcile_allowlist.py
+++ b/.github/scripts/reconcile_allowlist.py
@@ -11,12 +11,16 @@ agreement). CVEs vanish transiently — Trivy DB reclassification, a partial sca
 or the `uv sync` native-lockfile step not materializing a wheel — so a single
 clean scan is not enough to yank a valid suppression.
 
-For each resolved CVE:
-  * if it has an open allowlist entry → open an **allowlist removal PR** (touches
-    only `.security/base-allowlist.json`, label `vuln-auto-merge` → auto-merges
-    via vuln-auto-merge.yml as `atlan-ci`).
-  * a Linear ticket is closed only when ALL the CVEs it tracks are resolved;
-    otherwise its marker is rewritten to drop just the resolved CVE.
+Two INDEPENDENT actions run off the same scan history (don't couple them):
+  * **Allowlist removal PR** — for *allowlisted* CVEs gone for `debounce` scans:
+    open a removal PR (touches only `.security/base-allowlist.json`, label
+    `vuln-auto-merge` → auto-merges via vuln-auto-merge.yml as `atlan-ci`).
+  * **Ticket reconciliation** — for any open `vulnerabilities` ticket whose
+    tracked CVEs are gone for `debounce` scans, close it (or trim its marker if
+    only some are gone). This is keyed on the SCAN, NOT the allowlist — so
+    Medium/Low tickets (which are never allowlisted) and any CVE fixed before it
+    was ever allowlisted still get closed. Reconciliation runs even when the
+    allowlist is empty.
 
 Pure decision logic (the debounce + ticket plan) lives in tested functions;
 GitHub/Linear I/O is wired in main(), per docs/standards/ci.md.
@@ -71,20 +75,22 @@ def cve_ids_from_trivy(data: dict) -> set[str]:
 
 
 def resolved_cves(
-    allowlisted: set[str],
+    candidates: set[str],
     scan_sets: list[set[str]],
     debounce: int,
 ) -> set[str]:
-    """Allowlisted CVEs absent from EVERY one of the last ``debounce`` scans.
+    """CVEs from ``candidates`` absent from EVERY one of the last ``debounce``
+    scans. Used for both the allowlist (candidates = allowlisted CVEs) and ticket
+    closing (candidates = CVEs tracked by open tickets).
 
     ``scan_sets`` is the CVE set per recent scan (current + priors). If we have
     fewer than ``debounce`` scans we cannot confirm the debounce, so nothing is
-    resolved (fail-safe — never yank a suppression on thin evidence).
+    resolved (fail-safe — never act on thin evidence).
     """
     if len(scan_sets) < debounce:
         return set()
     seen_in_any = set().union(*scan_sets) if scan_sets else set()
-    return {cve for cve in allowlisted if cve not in seen_in_any}
+    return {cve for cve in candidates if cve not in seen_in_any}
 
 
 def plan_ticket_updates(
@@ -111,6 +117,20 @@ def plan_ticket_updates(
         else:
             to_update.append({**t, "remaining_ids": sorted(remaining)})
     return to_close, to_update
+
+
+def resolve_tickets(
+    tickets: list[dict], scan_sets: list[set[str]], debounce: int
+) -> tuple[list[dict], list[dict]]:
+    """Decide which open tickets to close/update based purely on whether their
+    tracked CVEs are gone for ``debounce`` scans — INDEPENDENT of the allowlist,
+    so Medium/Low tickets (never allowlisted) and CVEs fixed before they were
+    ever allowlisted still get closed."""
+    all_tracked: set[str] = set()
+    for t in tickets:
+        all_tracked |= ssl.extract_vuln_ids_from_description(t.get("description"))
+    resolved = resolved_cves(all_tracked, scan_sets, debounce)
+    return plan_ticket_updates(tickets, resolved)
 
 
 # ---------------------------------------------------------------------------
@@ -300,7 +320,7 @@ def rewrite_marker(issue_id: str, description: str, remaining_ids: list[str]) ->
     )
 
 
-def reconcile_tickets(resolved: set[str]) -> None:
+def reconcile_tickets(scan_sets: list[set[str]], debounce: int) -> None:
     if not os.environ.get("LINEAR_API_KEY") or not os.environ.get("LINEAR_TEAM_ID"):
         print("LINEAR_API_KEY/TEAM_ID not set — skipping ticket reconciliation.")
         return
@@ -311,12 +331,19 @@ def reconcile_tickets(resolved: set[str]) -> None:
         print(f"label {label_name!r} not found — skipping ticket reconciliation.")
         return
     tickets = ssl.fetch_open_labelled_issues(label_id)
-    to_close, to_update = plan_ticket_updates(tickets, resolved)
+    to_close, to_update = resolve_tickets(tickets, scan_sets, debounce)
+    if not to_close and not to_update:
+        print("No open ticket has its tracked CVE(s) resolved — nothing to close.")
+        return
     done_state = resolve_done_state_id(team_id) if to_close else None
     for t in to_close:
         if done_state:
             close_ticket(t["id"], done_state)
             print(f"Closed {t['identifier']} (all tracked CVEs resolved).")
+        else:
+            print(
+                f"Could not resolve a completed state — leaving {t['identifier']} open."
+            )
     for t in to_update:
         rewrite_marker(t["id"], t.get("description", ""), t["remaining_ids"])
         print(f"Updated {t['identifier']} marker (dropped resolved CVEs).")
@@ -341,27 +368,36 @@ def main(runner: Runner = subprocess.run) -> int:
     run_date = os.environ.get("RUN_DATE", "")
     debounce = int(os.environ.get("DEBOUNCE_SCANS", "3"))
 
-    allowlisted = load_allowlisted_cves()
-    if not allowlisted:
-        print("Allowlist has no entries — nothing to reconcile.")
-        return 0
-
     current = load_current_cves()
     priors = load_prior_scan_cves(repo, workflow, debounce - 1, runner)
     scan_sets = [current, *priors]
-
-    resolved = resolved_cves(allowlisted, scan_sets, debounce)
-    if not resolved:
+    if len(scan_sets) < debounce:
         print(
-            f"No allowlisted CVE absent across {debounce} consecutive scans "
-            f"(have {len(scan_sets)} scan set(s)). Nothing to remove."
+            f"Only {len(scan_sets)} scan(s) of history (<{debounce}) — "
+            "skipping reconciliation (fail-safe)."
         )
         return 0
 
-    removed = sorted(resolved)
-    print(f"Resolved (gone for {debounce} scans): {', '.join(removed)}")
-    open_removal_pr(repo, removed, run_date, runner)
-    reconcile_tickets(resolved)
+    # 1) Allowlist removal PR — scoped to *allowlisted* CVEs gone for `debounce`
+    #    scans. (No early return on an empty allowlist — tickets still reconcile.)
+    allowlisted = load_allowlisted_cves()
+    resolved_allowlisted = resolved_cves(allowlisted, scan_sets, debounce)
+    if resolved_allowlisted:
+        removed = sorted(resolved_allowlisted)
+        print(
+            f"Allowlist entries resolved (gone for {debounce} scans): {', '.join(removed)}"
+        )
+        open_removal_pr(repo, removed, run_date, runner)
+    else:
+        print(
+            f"No allowlisted CVE absent across {debounce} scans "
+            f"({len(allowlisted)} allowlist entr{'y' if len(allowlisted) == 1 else 'ies'}) "
+            "— no removal PR."
+        )
+
+    # 2) Ticket reconciliation — keyed on the SCAN, independent of the allowlist,
+    #    so Medium/Low and pre-allowlist tickets are closed too.
+    reconcile_tickets(scan_sets, debounce)
     return 0
 
 

--- a/.github/scripts/tests/test_reconcile_allowlist.py
+++ b/.github/scripts/tests/test_reconcile_allowlist.py
@@ -109,3 +109,40 @@ def test_ticket_with_no_marker_untouched():
     tickets = [{"id": "x", "identifier": "BLDX-4", "description": "no marker here"}]
     to_close, to_update = rec.plan_ticket_updates(tickets, {"CVE-A"})
     assert to_close == [] and to_update == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_tickets — ticket closing decoupled from the allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_medium_ticket_closes_without_any_allowlist_entry():
+    # Regression for BLDX-1465: a Medium CVE ticket (never allowlisted) must
+    # still close once the scanner stops seeing it for `debounce` scans.
+    tickets = [_ticket("BLDX-1465", ["CVE-2026-2303"])]
+    scans = [set(), set(), set()]  # gone in all 3 scans; no allowlist involved
+    to_close, to_update = rec.resolve_tickets(tickets, scans, debounce=3)
+    assert [t["identifier"] for t in to_close] == ["BLDX-1465"]
+    assert to_update == []
+
+
+def test_resolve_tickets_keeps_ticket_with_present_cve():
+    tickets = [_ticket("BLDX-9", ["CVE-STILL"])]
+    scans = [{"CVE-STILL"}, {"CVE-STILL"}, {"CVE-STILL"}]
+    to_close, to_update = rec.resolve_tickets(tickets, scans, debounce=3)
+    assert to_close == [] and to_update == []
+
+
+def test_resolve_tickets_trims_marker_when_partially_resolved():
+    tickets = [_ticket("BLDX-10", ["CVE-GONE", "CVE-STILL"])]
+    scans = [{"CVE-STILL"}, {"CVE-STILL"}, {"CVE-STILL"}]  # CVE-GONE absent in all
+    to_close, to_update = rec.resolve_tickets(tickets, scans, debounce=3)
+    assert to_close == []
+    assert to_update[0]["remaining_ids"] == ["CVE-STILL"]
+
+
+def test_resolve_tickets_failsafe_with_thin_history():
+    tickets = [_ticket("BLDX-11", ["CVE-X"])]
+    scans = [set(), set()]  # only 2 scans of history (< debounce 3)
+    to_close, to_update = rec.resolve_tickets(tickets, scans, debounce=3)
+    assert to_close == [] and to_update == []


### PR DESCRIPTION
## What & why

Follow-up to #2348 (BLDX-1449). The hourly reconcile job never closed the open security ticket [BLDX-1465](https://linear.app/atlan-epd/issue/BLDX-1465) — its log showed `Allowlist has no entries — nothing to reconcile.`

Two bugs in `reconcile_allowlist.py`, both around coupling ticket-closing to the allowlist:

1. **Early-return on empty allowlist** — `main()` bailed before ever fetching tickets when `base-allowlist.json` had no entries (which is the current state), so no ticket was ever considered.
2. **Ticket-closing keyed on the allowlist** — the "resolved" set was computed *only* over allowlisted CVEs. BLDX-1465's CVE (`CVE-2026-2303`) is **Medium**, and Medium/Low are never allowlisted by design — so such tickets could never resolve. Same for any CVE fixed before it was ever allowlisted.

## Fix — decouple the two reconcile actions

- **Allowlist removal PR** → unchanged: still scoped to *allowlisted* CVEs gone for the debounce window.
- **Ticket close/trim** → now keyed purely on the **scan**: a ticket closes when all its tracked CVEs are absent from the last `debounce` (3) scans, and its marker is trimmed when only some are — independent of the allowlist. So Medium/Low and pre-allowlist tickets close too.
- `main()` no longer short-circuits on an empty allowlist; ticket reconciliation always runs (still gated by the 3-scan debounce fail-safe).

New pure `resolve_tickets()` carries the logic, with tests for the Medium-ticket-closes-without-allowlist case, partial-resolution marker trim, present-CVE-stays-open, and the thin-history (<3 scans) fail-safe.

## Verification
- 362 unit tests pass (15 in the reconcile suite, incl. 4 new) + pre-commit green.
- Note: `CVE-2026-2303` only closes BLDX-1465 once it's actually absent from 3 consecutive scans — if the Dapr base image still reports it, the ticket correctly stays open; this PR just ensures reconcile *checks*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
