### PR TITLE
chore: add atlan-ci to contract-toolkit CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @atlan-ci @cmgrote @OnkarVO7 @louisnow @Aryamanz29 @vaibhavatlan
-/contract-toolkit/ @cmgrote @vaibhavatlan @Aryamanz29 @fyzanshaik-atlan
+/contract-toolkit/ @atlan-ci @cmgrote @vaibhavatlan @Aryamanz29 @fyzanshaik-atlan


### PR DESCRIPTION
Add `@atlan-ci` to the `/contract-toolkit/` CODEOWNERS entry so bot-approved PRs that touch that directory can satisfy the code owner review requirement and auto-merge without waiting for a human reviewer.