### PR TITLE
ci(conformance): normalise job display names to sentence case + plurals

### DIFF
--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -5,14 +5,16 @@
 # Runs each rule series (C, E, P, O, D, L, T, I) as a separate leg of one matrix job so
 # each appears as its own status check:
 #   Conformance / suite / CI
-#   Conformance / suite / Error-handling
+#   Conformance / suite / Error handling
 #   Conformance / suite / Prescriptions
 #   Conformance / suite / Optimizations
-#   Conformance / suite / Dependency
+#   Conformance / suite / Dependencies
 #   Conformance / suite / Logging
 #   Conformance / suite / Tests
-#   Conformance / suite / Container image
-#   Conformance / suite / Conformance Gate  (required gate)
+#   Conformance / suite / Container images
+#   Conformance / suite / Deprecations
+#   Conformance / Contracts
+#   Conformance / Conformance Gate  (required gate)
 #
 # The series share an identical job body (checkout → changed-files filter → uv →
 # run → upload → Security-tab upload), so they are expressed as a single
@@ -199,7 +201,7 @@ jobs:
             paths: ".github/**"
             exclude_paths: ${{ inputs.exclude-paths-c }}
           - series: E
-            name: "Error-handling"
+            name: "Error handling"
             slug: error-handling
             paths: "**/*.py"
             exclude_paths: ${{ inputs.exclude-paths-e }}
@@ -226,7 +228,7 @@ jobs:
           # staleness is caught on push to main, where every leg runs
           # unconditionally.  Acceptable at WARN tier (mirrors the T-series above).
           - series: D
-            name: "Dependency"
+            name: "Dependencies"
             slug: dependency
             paths: "**/pyproject.toml"
             exclude_paths: ${{ inputs.exclude-paths-d }}
@@ -255,7 +257,7 @@ jobs:
           # since the SDK Dockerfile builds the base image, not a consumer app.
           # Watches only the root Dockerfile so Python-only PRs don't trigger it.
           - series: I
-            name: "Container image"
+            name: "Container images"
             slug: container-image
             paths: "Dockerfile"
             exclude_paths: ${{ inputs.exclude-paths-i }}
@@ -264,7 +266,7 @@ jobs:
           # authoring.  Scope is auto-detected per caller, so on a consumer app
           # only B001 runs and on the SDK only B002–B004 run — no per-app config.
           - series: B
-            name: "Deprecation"
+            name: "Deprecations"
             slug: deprecation
             paths: "**/*.py"
             exclude_paths: ${{ inputs.exclude-paths-b }}
@@ -377,7 +379,7 @@ jobs:
   # Requires fetch-depth: 0 so the full git history (and origin/main) is
   # available to `git show`.  Skipped on push to main (no base-ref diff).
   contract-ledger-guard:
-    name: "Contract Ledger Guard"
+    name: "Contracts"
     runs-on: ubuntu-latest
     if: inputs.event_name != 'push'
     steps:


### PR DESCRIPTION
## Summary

- Sentence-case all multi-word conformance job names (`Error handling`, `Container images`, `Conformance Gate`)
- Pluralise single-word names (`Dependencies`, `Deprecations`)
- Rename `Contract Ledger Guard` → `Contracts`
- Update the header comment listing to match

## Test plan

- [ ] CI passes — no functional changes, display names only