### PR TITLE
ci(security): retire CVEs on first clean scan + explain ticket closes

### DIFF
--- a/.github/scripts/reconcile_allowlist.py
+++ b/.github/scripts/reconcile_allowlist.py
@@ -5,11 +5,11 @@ Closing the loop on the zero-human-touch CVE flow: once a CVE stops showing up
 in the scan (its bump merged & shipped, or the base image was rebuilt), its
 allowlist entry and Linear ticket should be retired automatically.
 
-**3-consecutive-clean-scan debounce.** A CVE is treated as *resolved* only if it
-is absent from the current scan AND the previous two hourly scans (three runs in
-agreement). CVEs vanish transiently — Trivy DB reclassification, a partial scan,
-or the `uv sync` native-lockfile step not materializing a wheel — so a single
-clean scan is not enough to yank a valid suppression.
+**Resolution & debounce.** By default a CVE is treated as *resolved* as soon as
+it is absent from the latest scan (`DEBOUNCE_SCANS` = 1). Raise `DEBOUNCE_SCANS`
+to require it to be absent from that many consecutive successful scans before
+acting — a debounce against transient drops (Trivy DB reclassification, a partial
+scan, or the `uv sync` native-lockfile step not materializing a wheel).
 
 Two INDEPENDENT actions run off the same scan history (don't couple them):
   * **Allowlist removal PR** — for *allowlisted* CVEs gone for `debounce` scans:
@@ -34,7 +34,8 @@ Environment:
 
 Optional:
     LINEAR_VULN_LABEL_NAME  default 'vulnerabilities'
-    DEBOUNCE_SCANS          default 3 (this scan + N-1 prior)
+    DEBOUNCE_SCANS          default 1 — act on the first clean scan (this scan +
+                            N-1 prior successful scans); raise to debounce churn
 """
 
 from __future__ import annotations
@@ -56,6 +57,10 @@ Runner = Callable[..., subprocess.CompletedProcess]
 ALLOWLIST_PATH = ".security/base-allowlist.json"
 TRIVY_FILES = ["trivy-image-results.json", "trivy-fs-results.json"]
 DEFAULT_WORKFLOW = "daily-security-scan.yml"
+# Act on the first clean scan by default; both the allowlist removal PR and the
+# ticket close are gated on this same window. Raise via DEBOUNCE_SCANS to require
+# N consecutive clean scans (debounce against transient scanner drops).
+DEFAULT_DEBOUNCE = 1
 
 
 # ---------------------------------------------------------------------------
@@ -295,6 +300,41 @@ def close_ticket(issue_id: str, state_id: str) -> None:
     )
 
 
+def comment_on_ticket(issue_id: str, body: str) -> None:
+    ssl.gql(
+        """
+        mutation Comment($input: CommentCreateInput!) {
+          commentCreate(input: $input) { success }
+        }
+        """,
+        {"input": {"issueId": issue_id, "body": body}},
+    )
+
+
+def _run_url() -> str:
+    """The reconcile workflow run URL, from GitHub-provided env (empty locally)."""
+    server = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    return f"{server}/{repo}/actions/runs/{run_id}" if repo and run_id else ""
+
+
+def close_comment_body(cves: list[str], run_url: str) -> str:
+    """The explanatory comment posted on a ticket as it is auto-closed."""
+    plural = "y" if len(cves) == 1 else "ies"
+    cve_list = ", ".join(f"`{c}`" for c in sorted(cves))
+    lines = [
+        "**Auto-resolved by the hourly security scan.**",
+        "",
+        f"The scanner no longer reports the tracked vulnerabilit{plural} "
+        f"({cve_list}), so this ticket is being closed automatically. If the "
+        "finding resurfaces, the next scan files a fresh ticket.",
+    ]
+    if run_url:
+        lines += ["", f"Reconcile run: {run_url}"]
+    return "\n".join(lines)
+
+
 def rewrite_marker(issue_id: str, description: str, remaining_ids: list[str]) -> None:
     marker = (
         f"{ssl.VULN_MARKER_PREFIX}{','.join(remaining_ids)}{ssl.VULN_MARKER_SUFFIX}"
@@ -336,8 +376,11 @@ def reconcile_tickets(scan_sets: list[set[str]], debounce: int) -> None:
         print("No open ticket has its tracked CVE(s) resolved — nothing to close.")
         return
     done_state = resolve_done_state_id(team_id) if to_close else None
+    run_url = _run_url()
     for t in to_close:
         if done_state:
+            cves = sorted(ssl.extract_vuln_ids_from_description(t.get("description")))
+            comment_on_ticket(t["id"], close_comment_body(cves, run_url))
             close_ticket(t["id"], done_state)
             print(f"Closed {t['identifier']} (all tracked CVEs resolved).")
         else:
@@ -366,7 +409,7 @@ def main(runner: Runner = subprocess.run) -> int:
     repo = os.environ.get("REPO", "atlanhq/application-sdk")
     workflow = os.environ.get("SCAN_WORKFLOW", DEFAULT_WORKFLOW)
     run_date = os.environ.get("RUN_DATE", "")
-    debounce = int(os.environ.get("DEBOUNCE_SCANS", "3"))
+    debounce = int(os.environ.get("DEBOUNCE_SCANS", str(DEFAULT_DEBOUNCE)))
 
     current = load_current_cves()
     priors = load_prior_scan_cves(repo, workflow, debounce - 1, runner)

--- a/.github/scripts/reconcile_allowlist.py
+++ b/.github/scripts/reconcile_allowlist.py
@@ -221,8 +221,15 @@ def load_prior_scan_cves(
     return sets
 
 
+def _resolution_phrase(debounce: int) -> str:
+    """Honest rationale string for any DEBOUNCE_SCANS value."""
+    if debounce <= 1:
+        return "the latest clean scan"
+    return f"{debounce} consecutive clean scans"
+
+
 def open_removal_pr(
-    repo: str, removed: list[str], run_date: str, runner: Runner
+    repo: str, removed: list[str], run_date: str, debounce: int, runner: Runner
 ) -> None:
     """Drop resolved entries from the allowlist and open an auto-merge PR."""
     data = json.loads(Path(ALLOWLIST_PATH).read_text())
@@ -261,8 +268,8 @@ def open_removal_pr(
             "--label",
             "vuln-auto-merge",
             "--body",
-            "Resolved by 3 consecutive clean scans (scanner no longer reports "
-            "these CVEs):\n\n" + "\n".join(f"- `{c}`" for c in removed),
+            f"Resolved by {_resolution_phrase(debounce)} — the scanner no longer "
+            "reports these CVEs:\n\n" + "\n".join(f"- `{c}`" for c in removed),
         ],
         check=True,
     )
@@ -289,8 +296,8 @@ def resolve_done_state_id(team_id: str) -> str | None:
     return None
 
 
-def close_ticket(issue_id: str, state_id: str) -> None:
-    ssl.gql(
+def close_ticket(issue_id: str, state_id: str) -> bool:
+    data = ssl.gql(
         """
         mutation Close($id: String!, $stateId: String!) {
           issueUpdate(id: $id, input: { stateId: $stateId }) { success }
@@ -298,6 +305,7 @@ def close_ticket(issue_id: str, state_id: str) -> None:
         """,
         {"id": issue_id, "stateId": state_id},
     )
+    return bool((data.get("issueUpdate") or {}).get("success"))
 
 
 def comment_on_ticket(issue_id: str, body: str) -> None:
@@ -378,15 +386,21 @@ def reconcile_tickets(scan_sets: list[set[str]], debounce: int) -> None:
     done_state = resolve_done_state_id(team_id) if to_close else None
     run_url = _run_url()
     for t in to_close:
-        if done_state:
-            cves = sorted(ssl.extract_vuln_ids_from_description(t.get("description")))
-            comment_on_ticket(t["id"], close_comment_body(cves, run_url))
-            close_ticket(t["id"], done_state)
-            print(f"Closed {t['identifier']} (all tracked CVEs resolved).")
-        else:
+        if not done_state:
             print(
                 f"Could not resolve a completed state — leaving {t['identifier']} open."
             )
+            continue
+        # Close FIRST; only comment once the close succeeds. If the close fails we
+        # post nothing (no self-contradicting "closing" note), and if the comment
+        # later fails the ticket is already closed so the next run won't re-close
+        # or duplicate it.
+        if not close_ticket(t["id"], done_state):
+            print(f"Failed to close {t['identifier']} — will retry next run.")
+            continue
+        cves = sorted(ssl.extract_vuln_ids_from_description(t.get("description")))
+        comment_on_ticket(t["id"], close_comment_body(cves, run_url))
+        print(f"Closed {t['identifier']} (all tracked CVEs resolved).")
     for t in to_update:
         rewrite_marker(t["id"], t.get("description", ""), t["remaining_ids"])
         print(f"Updated {t['identifier']} marker (dropped resolved CVEs).")
@@ -430,7 +444,7 @@ def main(runner: Runner = subprocess.run) -> int:
         print(
             f"Allowlist entries resolved (gone for {debounce} scans): {', '.join(removed)}"
         )
-        open_removal_pr(repo, removed, run_date, runner)
+        open_removal_pr(repo, removed, run_date, debounce, runner)
     else:
         print(
             f"No allowlisted CVE absent across {debounce} scans "

--- a/.github/scripts/tests/test_reconcile_allowlist.py
+++ b/.github/scripts/tests/test_reconcile_allowlist.py
@@ -177,3 +177,51 @@ def test_close_comment_body_plural_and_no_run_url():
     body = rec.close_comment_body(["CVE-1", "CVE-2"], "")
     assert "vulnerabilities" in body  # plural for two
     assert "Reconcile run:" not in body  # omitted when no run URL
+
+
+def test_resolution_phrase():
+    assert rec._resolution_phrase(1) == "the latest clean scan"
+    assert "3 consecutive" in rec._resolution_phrase(3)
+
+
+# ---------------------------------------------------------------------------
+# reconcile_tickets — side-effect wiring (close before comment; CVEs in body)
+# ---------------------------------------------------------------------------
+
+
+def _wire_linear(monkeypatch, tickets, *, close_ok=True):
+    """Monkeypatch the Linear I/O reconcile_tickets depends on; return a call log."""
+    calls: list[tuple] = []
+    monkeypatch.setenv("LINEAR_API_KEY", "k")
+    monkeypatch.setenv("LINEAR_TEAM_ID", "team-1")
+    monkeypatch.setattr(rec.ssl, "resolve_label_id", lambda *a, **k: "label-1")
+    monkeypatch.setattr(rec.ssl, "fetch_open_labelled_issues", lambda *a, **k: tickets)
+    monkeypatch.setattr(rec, "resolve_done_state_id", lambda *a, **k: "done-state")
+
+    def fake_close(issue_id, state_id):
+        calls.append(("close", issue_id))
+        return close_ok
+
+    def fake_comment(issue_id, body):
+        calls.append(("comment", issue_id, body))
+
+    monkeypatch.setattr(rec, "close_ticket", fake_close)
+    monkeypatch.setattr(rec, "comment_on_ticket", fake_comment)
+    return calls
+
+
+def test_reconcile_tickets_closes_then_comments_with_cves(monkeypatch):
+    ticket = _ticket("BLDX-1", ["CVE-A", "CVE-B"])
+    calls = _wire_linear(monkeypatch, [ticket])
+    rec.reconcile_tickets([set()], debounce=1)  # both CVEs absent → resolved
+    # Close runs before comment, each once.
+    assert [c[0] for c in calls] == ["close", "comment"]
+    body = calls[1][2]
+    assert "CVE-A" in body and "CVE-B" in body
+
+
+def test_reconcile_tickets_skips_comment_when_close_fails(monkeypatch):
+    ticket = _ticket("BLDX-2", ["CVE-A"])
+    calls = _wire_linear(monkeypatch, [ticket], close_ok=False)
+    rec.reconcile_tickets([set()], debounce=1)
+    assert [c[0] for c in calls] == ["close"]  # no comment after a failed close

--- a/.github/scripts/tests/test_reconcile_allowlist.py
+++ b/.github/scripts/tests/test_reconcile_allowlist.py
@@ -146,3 +146,34 @@ def test_resolve_tickets_failsafe_with_thin_history():
     scans = [set(), set()]  # only 2 scans of history (< debounce 3)
     to_close, to_update = rec.resolve_tickets(tickets, scans, debounce=3)
     assert to_close == [] and to_update == []
+
+
+def test_resolve_tickets_closes_on_first_clean_scan_with_debounce_one():
+    # Default behavior: a ticket closes as soon as its CVE is absent from the
+    # latest scan (debounce=1) — no waiting for prior scans.
+    tickets = [_ticket("BLDX-12", ["CVE-Y"])]
+    to_close, _ = rec.resolve_tickets(tickets, [set()], debounce=1)
+    assert [t["identifier"] for t in to_close] == ["BLDX-12"]
+
+
+# ---------------------------------------------------------------------------
+# defaults + close comment
+# ---------------------------------------------------------------------------
+
+
+def test_default_debounce_is_one():
+    assert rec.DEFAULT_DEBOUNCE == 1
+
+
+def test_close_comment_body_mentions_cves_and_run():
+    body = rec.close_comment_body(["CVE-2026-2303"], "https://x/run/1")
+    assert "Auto-resolved" in body
+    assert "`CVE-2026-2303`" in body
+    assert "vulnerability" in body  # singular for one CVE
+    assert "https://x/run/1" in body
+
+
+def test_close_comment_body_plural_and_no_run_url():
+    body = rec.close_comment_body(["CVE-1", "CVE-2"], "")
+    assert "vulnerabilities" in body  # plural for two
+    assert "Reconcile run:" not in body  # omitted when no run URL

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -160,9 +160,10 @@ jobs:
 
   # ── Reconcile the allowlist + tickets against what the scanner still sees.
   #    Runs every scan (even with no new findings) so resolved CVEs are retired
-  #    automatically. A CVE is only removed after 3 consecutive clean scans
-  #    (debounce) — see reconcile_allowlist.py. Checks out as atlan-ci so the
-  #    removal PR it opens is auto-merged by vuln-auto-merge.yml.
+  #    automatically: by default a CVE is retired on the first scan that no longer
+  #    reports it (DEBOUNCE_SCANS=1; raise it to debounce transient drops) — see
+  #    reconcile_allowlist.py. Checks out as atlan-ci so the removal PR it opens
+  #    is auto-merged by vuln-auto-merge.yml.
   reconcile:
     name: Reconcile allowlist + tickets
     needs: scan-and-ticket
@@ -183,7 +184,7 @@ jobs:
         with:
           name: security-scan-raw-results
 
-      - name: Reconcile resolved CVEs (3-scan debounce)
+      - name: Reconcile resolved CVEs (acts on first clean scan)
         env:
           GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## What & why

Follow-up to #2348 / #2352. Two tweaks to the reconcile loop:

### 1. Act on the **first** clean scan (debounce 3 → 1)
`DEFAULT_DEBOUNCE` is now **1**: a CVE is retired as soon as the latest scan no longer reports it. Both the **allowlist removal PR** and the **ticket close** are gated on the *same* window, so the single default covers both — there's no separate knob. `DEBOUNCE_SCANS` can still be raised to require N consecutive clean scans if transient scanner drops cause churn.

### 2. Explain the closure on the ticket
When the reconcile job auto-closes a ticket, it now posts a comment first — which CVE(s) the scanner no longer reports and a link to the reconcile run — so the closure is self-documenting instead of silent:

> **Auto-resolved by the hourly security scan.**
> The scanner no longer reports the tracked vulnerability (`CVE-…`), so this ticket is being closed automatically. If the finding resurfaces, the next scan files a fresh ticket.
> Reconcile run: …

## Verification
- 366 unit tests pass (19 in the reconcile suite, incl. new debounce-1 + close-comment tests) + pre-commit green.

## Tradeoff (called out)
Debounce=1 removes the safety margin against a *transient* scanner drop (e.g. a Trivy DB reclassification or a one-off partial scan): a single clean scan now both opens a removal PR and closes the ticket. If that churn shows up in practice, set `DEBOUNCE_SCANS: "2"` (or 3) on the reconcile step — no code change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
