### PR TITLE
fix(conformance): ignore action SHA pins in C002 drift comparison

### DIFF
--- a/packages/conformance/conformance/suite/checks/bootstrap_drift.py
+++ b/packages/conformance/conformance/suite/checks/bootstrap_drift.py
@@ -49,6 +49,16 @@ _RENOVATE_JSON = "renovate.json"
 # Managed shim (in MANAGED_WORKFLOWS) that tolerates a sanctioned per-repo override.
 _RENOVATE_PKL_SYNC = "renovate-pkl-sync.yaml"
 
+# Matches a pinned SHA (40 lowercase hex chars) and its optional trailing version
+# comment so automated pin bumps (Renovate/Dependabot) are not flagged as drift.
+# Example: "@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3" → "@<pinned>"
+_ACTION_PIN_RE = re.compile(r"@[0-9a-f]{40}(?:[ \t]+#[^\n]*)?")
+
+
+def _strip_action_pins(text: str) -> str:
+    return _ACTION_PIN_RE.sub("@<pinned>", text)
+
+
 # The renovate-pkl-sync caller regenerates contract artifacts by default
 # (the reusable's regenerate-contract input defaults to true). An app may opt
 # out by adding a `with: regenerate-contract: false` override to the caller.
@@ -185,7 +195,7 @@ def _scan_managed_shim(path: Path, root: Path) -> list[Finding]:
 
     canonical = render(name, **kwargs)
 
-    if on_disk == canonical:
+    if _strip_action_pins(on_disk) == _strip_action_pins(canonical):
         return []
 
     return [
@@ -231,7 +241,7 @@ def _scan_renovate_json(path: Path, root: Path) -> list[Finding]:
     on_disk = path.read_text(encoding="utf-8")
     canonical = render(_RENOVATE_JSON)
 
-    if on_disk == canonical:
+    if _strip_action_pins(on_disk) == _strip_action_pins(canonical):
         return []
 
     return [
@@ -281,7 +291,7 @@ def _scan_tests_yaml(path: Path, root: Path) -> list[Finding]:
     params = _extract_tests_yaml_params(on_disk)
     canonical = render(_TESTS_WORKFLOW, **params)
 
-    if on_disk == canonical:
+    if _strip_action_pins(on_disk) == _strip_action_pins(canonical):
         return []
 
     return [

--- a/packages/conformance/tests/test_bootstrap_drift.py
+++ b/packages/conformance/tests/test_bootstrap_drift.py
@@ -11,6 +11,7 @@ Covers:
 from __future__ import annotations
 
 import pathlib
+import re
 
 import pytest
 from conformance.bootstrap.render import MANAGED_WORKFLOWS, render
@@ -142,6 +143,46 @@ def test_drifted_workflow_finding_names_the_file(tmp_path: pathlib.Path) -> None
     wf.write_text("completely wrong content")
     findings = scan_path(wf, tmp_path)
     assert "commits.yaml" in findings[0].message
+
+
+# ---------------------------------------------------------------------------
+# Action pin bumps — ignored during drift comparison
+# ---------------------------------------------------------------------------
+
+_SHA_A = "a" * 40
+_SHA_B = "b" * 40
+
+
+def test_pin_only_change_not_flagged(tmp_path: pathlib.Path) -> None:
+    """Automations may bump SHA pins freely — a pin-only diff must not flag C002."""
+    _bootstrap(tmp_path)
+    wf = tmp_path / ".github" / "workflows" / "checks.yml"
+    bumped = re.sub(r"@[0-9a-f]{40}", f"@{_SHA_B}", wf.read_text())
+    wf.write_text(bumped)
+    assert scan_path(wf, tmp_path) == []
+
+
+def test_pin_and_comment_change_not_flagged(tmp_path: pathlib.Path) -> None:
+    """Renovate typically updates both the SHA and the adjacent version comment."""
+    _bootstrap(tmp_path)
+    wf = tmp_path / ".github" / "workflows" / "checks.yml"
+    bumped = re.sub(
+        r"@[0-9a-f]{40}(?:[ \t]+#[^\n]*)?", f"@{_SHA_B} # v99", wf.read_text()
+    )
+    wf.write_text(bumped)
+    assert scan_path(wf, tmp_path) == []
+
+
+def test_structural_change_alongside_pin_still_flagged(tmp_path: pathlib.Path) -> None:
+    """A structural edit is caught even when the SHA pin was also bumped."""
+    _bootstrap(tmp_path)
+    wf = tmp_path / ".github" / "workflows" / "checks.yml"
+    bumped = re.sub(r"@[0-9a-f]{40}", f"@{_SHA_B}", wf.read_text())
+    drifted = bumped + "\n# injected structural drift\n"
+    wf.write_text(drifted)
+    findings = scan_path(wf, tmp_path)
+    assert len(findings) == 1
+    assert findings[0].rule_id == "C002"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- C002 bootstrap drift check was doing a byte-exact comparison, which flagged automated SHA pin bumps (Renovate/Dependabot) as drift violations
- Adds `_strip_action_pins()` that normalises `@<40-hex-sha>` plus any trailing version comment to `@<pinned>` on both sides before comparing
- Structural changes are still caught; only pin-only and pin+comment diffs are now silently ignored

## Test plan

- [ ] `test_pin_only_change_not_flagged` — bumping SHA only on `checks.yml` produces no finding
- [ ] `test_pin_and_comment_change_not_flagged` — bumping SHA + adjacent `# version` comment produces no finding
- [ ] `test_structural_change_alongside_pin_still_flagged` — a structural edit alongside a pin bump is still caught
- [ ] All 51 existing C002 tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)