### PR TITLE
fix(app): align App.upload() path with WORKFLOW_OUTPUT_PATH_TEMPLATE

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -930,7 +930,7 @@ class App(ABC):
                 (single, "upstream" if single is upstream else "deployment", True)
             ]
 
-        run_prefix = f"artifacts/apps/{self._app_name}/workflows/{self.context.run_id}"
+        run_prefix = f"artifacts/apps/{self._app_name}/workflows/{self.context.workflow_id}/{self.context.run_id}"
         app_prefix = input.tier.upload_prefix(
             run_prefix=run_prefix, app_name=self._app_name
         )
@@ -1574,6 +1574,7 @@ def generate_workflow_class(app_cls: "type[App]", ep: "EntryPointMetadata") -> t
         # from application_sdk.app.client import WorkflowAppClient
         start_time = _safe_now()
         run_id = workflow.info().run_id
+        workflow_id = workflow.info().workflow_id
 
         try:
             with workflow.unsafe.imports_passed_through():
@@ -1596,6 +1597,7 @@ def generate_workflow_class(app_cls: "type[App]", ep: "EntryPointMetadata") -> t
             app_name=app_name,
             app_version=app_version,
             run_id=run_id,
+            workflow_id=workflow_id,
             correlation_id=correlation_id,
             started_at=start_time,
         )

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -39,6 +39,7 @@ from application_sdk.app.context import (
 from application_sdk.app.entrypoint import EntryPointMetadata
 from application_sdk.app.registry import AppMetadata
 from application_sdk.app.task import get_task_metadata, is_task, task
+from application_sdk.constants import LOCAL_WORKFLOW_ID
 from application_sdk.contracts.base import HeartbeatDetails, Input, Output
 from application_sdk.contracts.cleanup import (
     CleanupInput,
@@ -1874,7 +1875,7 @@ def _create_task_activity_wrapper(
             app_name=app_name,
             task_name=task_name,
             run_id=context_data.get("run_id", ""),
-            workflow_id=context_data.get("workflow_id", ""),
+            workflow_id=context_data.get("workflow_id", LOCAL_WORKFLOW_ID),
             heartbeat_timeout_seconds=heartbeat_timeout_seconds,
             auto_heartbeat_seconds=auto_heartbeat_seconds,
         )

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -1615,7 +1615,11 @@ def generate_workflow_class(app_cls: "type[App]", ep: "EntryPointMetadata") -> t
             self._app_instance = app_instance
         app_instance._context = context
 
-        context_data = {"run_id": run_id, "correlation_id": context.correlation_id}
+        context_data = {
+            "run_id": run_id,
+            "workflow_id": workflow_id,
+            "correlation_id": context.correlation_id,
+        }
         # BLDX-878: inter-app calls deactivated pending review.
         # app_instance._client = WorkflowAppClient(context_data)
         _wrap_instance_tasks(app_instance, context_data)
@@ -1781,7 +1785,7 @@ def _wrap_instance_tasks(app_instance: Any, context_data: dict[str, Any]) -> Non
 
     Args:
         app_instance: The app instance.
-        context_data: Context dict with run_id and correlation_id.
+        context_data: Context dict with run_id, workflow_id, and correlation_id.
     """
     for attr_name in dir(app_instance):
         if attr_name.startswith("_"):
@@ -1830,7 +1834,7 @@ def _create_task_activity_wrapper(
         retry_max_attempts: Maximum retry attempts.
         retry_max_interval_seconds: Maximum interval between retries.
         output_type: The typed output class for deserialization.
-        context_data: Context dict with run_id and correlation_id.
+        context_data: Context dict with run_id, workflow_id, and correlation_id.
         heartbeat_timeout_seconds: Heartbeat timeout. None disables.
         auto_heartbeat_seconds: Auto-heartbeat interval. None disables.
         retry_policy: Full retry policy (overrides max_attempts/interval if set).
@@ -1870,6 +1874,7 @@ def _create_task_activity_wrapper(
             app_name=app_name,
             task_name=task_name,
             run_id=context_data.get("run_id", ""),
+            workflow_id=context_data.get("workflow_id", ""),
             heartbeat_timeout_seconds=heartbeat_timeout_seconds,
             auto_heartbeat_seconds=auto_heartbeat_seconds,
         )

--- a/application_sdk/app/context.py
+++ b/application_sdk/app/context.py
@@ -13,6 +13,7 @@ from application_sdk.app.base_errors import (
     SecretStoreNotConfiguredError,
     StateStoreNotConfiguredError,
 )
+from application_sdk.constants import LOCAL_WORKFLOW_ID
 from application_sdk.contracts.base import HeartbeatDetails
 from application_sdk.credentials.resolver import CredentialResolver
 from application_sdk.observability.context import get_execution_context
@@ -205,7 +206,7 @@ class AppContext:
     app_name: str
     app_version: str
     run_id: str = field(default_factory=lambda: str(uuid4()))
-    workflow_id: str = field(default="local-no-temporal")
+    workflow_id: str = field(default=LOCAL_WORKFLOW_ID)
     correlation_id: str = field(default="")
     parent_run_id: str | None = None
     started_at: datetime = field(default_factory=_utc_now)

--- a/application_sdk/app/context.py
+++ b/application_sdk/app/context.py
@@ -221,8 +221,6 @@ class AppContext:
     _cancelled: bool = field(default=False, repr=False)
 
     def __post_init__(self) -> None:
-        if not self.workflow_id:
-            self.workflow_id = "local-no-temporal"
         if not self.correlation_id:
             self.correlation_id = str(self.run_id)
 

--- a/application_sdk/app/context.py
+++ b/application_sdk/app/context.py
@@ -205,7 +205,7 @@ class AppContext:
     app_name: str
     app_version: str
     run_id: str = field(default_factory=lambda: str(uuid4()))
-    workflow_id: str = field(default="")
+    workflow_id: str = field(default="local-no-temporal")
     correlation_id: str = field(default="")
     parent_run_id: str | None = None
     started_at: datetime = field(default_factory=_utc_now)
@@ -221,6 +221,11 @@ class AppContext:
     _cancelled: bool = field(default=False, repr=False)
 
     def __post_init__(self) -> None:
+        if not self.workflow_id:
+            raise ValueError(
+                "AppContext.workflow_id must not be empty; "
+                "pass the Temporal workflow ID or 'local-no-temporal' for tests/local runs"
+            )
         if not self.correlation_id:
             self.correlation_id = str(self.run_id)
 

--- a/application_sdk/app/context.py
+++ b/application_sdk/app/context.py
@@ -205,6 +205,7 @@ class AppContext:
     app_name: str
     app_version: str
     run_id: str = field(default_factory=lambda: str(uuid4()))
+    workflow_id: str = field(default="")
     correlation_id: str = field(default="")
     parent_run_id: str | None = None
     started_at: datetime = field(default_factory=_utc_now)
@@ -220,6 +221,8 @@ class AppContext:
     _cancelled: bool = field(default=False, repr=False)
 
     def __post_init__(self) -> None:
+        if not self.workflow_id:
+            self.workflow_id = "local-no-temporal"
         if not self.correlation_id:
             self.correlation_id = str(self.run_id)
 

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -62,6 +62,7 @@ load_dotenv(dotenv_path=".env")
 
 # Static Constants
 LOCAL_ENVIRONMENT = "local"
+LOCAL_WORKFLOW_ID = "local-no-temporal"
 
 # Application Constants
 #: Name of the application, used for identification

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -116,6 +116,7 @@ def create_activity_from_task(
             app_name=context.app_name,
             app_version=app_metadata.version,
             run_id=run_id,
+            workflow_id=activity.info().workflow_id,
             correlation_id=correlation_id,
         )
 

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -21,7 +21,7 @@ from temporalio import activity
 
 from application_sdk.app.registry import AppRegistry, TaskRegistry
 from application_sdk.app.task import TaskMetadata
-from application_sdk.constants import TRACKED_FILE_REFS_KEY
+from application_sdk.constants import LOCAL_WORKFLOW_ID, TRACKED_FILE_REFS_KEY
 from application_sdk.contracts.base import Input, Output
 from application_sdk.contracts.types import FileReference
 from application_sdk.observability.logger_adaptor import get_logger
@@ -45,7 +45,7 @@ class TaskContext:
     run_id: str
     """Workflow run ID."""
 
-    workflow_id: str = "local-no-temporal"
+    workflow_id: str = LOCAL_WORKFLOW_ID
     """Temporal workflow ID. Set by the workflow side so both sites read from one transport."""
 
     heartbeat_timeout_seconds: int | None = 60

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -45,6 +45,9 @@ class TaskContext:
     run_id: str
     """Workflow run ID."""
 
+    workflow_id: str = ""
+    """Temporal workflow ID. Set by the workflow side so both sites read from one transport."""
+
     heartbeat_timeout_seconds: int | None = 60
     """Heartbeat timeout in seconds. Set to None to disable heartbeating."""
 
@@ -116,7 +119,7 @@ def create_activity_from_task(
             app_name=context.app_name,
             app_version=app_metadata.version,
             run_id=run_id,
-            workflow_id=activity.info().workflow_id,
+            workflow_id=context.workflow_id,
             correlation_id=correlation_id,
         )
 

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -45,7 +45,7 @@ class TaskContext:
     run_id: str
     """Workflow run ID."""
 
-    workflow_id: str = ""
+    workflow_id: str = "local-no-temporal"
     """Temporal workflow ID. Set by the workflow side so both sites read from one transport."""
 
     heartbeat_timeout_seconds: int | None = 60

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -210,7 +210,7 @@ def create_activity_from_task(
 
             all_refs = _find_file_refs(input_data) + _find_file_refs(result)
             if all_refs:
-                _track_file_refs(activity.info().workflow_id, *all_refs)
+                _track_file_refs(context.workflow_id, *all_refs)
 
             return cast("Output", result)
 

--- a/application_sdk/testing/fixtures.py
+++ b/application_sdk/testing/fixtures.py
@@ -70,6 +70,7 @@ def app_context(
     return AppContext(
         app_name="test-app",
         app_version="0.0.1",
+        workflow_id="local-no-temporal",
         _state_store=mock_state_store,
         _secret_store=mock_secret_store,
     )

--- a/application_sdk/testing/fixtures.py
+++ b/application_sdk/testing/fixtures.py
@@ -15,6 +15,7 @@ import pytest
 
 from application_sdk.app.context import AppContext
 from application_sdk.app.registry import AppRegistry, TaskRegistry
+from application_sdk.constants import LOCAL_WORKFLOW_ID
 from application_sdk.testing.mocks import (
     MockBinding,
     MockCredentialStore,
@@ -70,7 +71,7 @@ def app_context(
     return AppContext(
         app_name="test-app",
         app_version="0.0.1",
-        workflow_id="local-no-temporal",
+        workflow_id=LOCAL_WORKFLOW_ID,
         _state_store=mock_state_store,
         _secret_store=mock_secret_store,
     )

--- a/tests/integration/test_app_upload_routing.py
+++ b/tests/integration/test_app_upload_routing.py
@@ -68,6 +68,7 @@ def _make_app(
     deployment_store,
     upstream_store=None,
     run_id: str = "run-routing-test",
+    workflow_id: str = "local-no-temporal",
 ) -> _UploadApp:
     """Build an _UploadApp with the given stores wired into its context."""
     app = _UploadApp()
@@ -75,6 +76,7 @@ def _make_app(
         app_name=app._app_name,
         app_version="1",
         run_id=run_id,
+        workflow_id=workflow_id,
         _storage=deployment_store,
         _upstream_storage=upstream_store,
     )
@@ -700,3 +702,36 @@ async def test_app_upload_dual_write_failure_required_raises_after_upstream(
         f"Upstream write did not complete before the required-mode exception. "
         f"upstream_keys={upstream_keys}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Regression: upload prefix uses real workflow_id, not "local-no-temporal"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_upload_path_embeds_workflow_id_from_context(tmp_path):
+    """App.upload() run_prefix must embed context.workflow_id, not the sentinel.
+
+    Regression guard for the activity-side AppContext construction bug where
+    workflow_id was never plumbed from activity.info().workflow_id, causing
+    uploads to land under the 'local-no-temporal' sentinel in production.
+    """
+    store = create_local_store(tmp_path / "store")
+    src = tmp_path / "artifact.jsonl"
+    src.write_text('{"name": "test"}\n')
+
+    real_workflow_id = "wf-temporal-abc123"
+    app = _make_app(store, workflow_id=real_workflow_id, run_id="run-wfid")
+
+    result = await app.upload(
+        UploadInput(local_path=str(src), tier=StorageTier.RETAINED)
+    )
+
+    storage_path = result.ref.storage_path
+    assert storage_path is not None
+    assert real_workflow_id in storage_path, (
+        f"Expected workflow_id '{real_workflow_id}' in storage path '{storage_path}'. "
+        f"Activities must set app_context.workflow_id from activity.info().workflow_id."
+    )
+    assert "local-no-temporal" not in storage_path

--- a/tests/integration/test_app_upload_routing.py
+++ b/tests/integration/test_app_upload_routing.py
@@ -713,9 +713,10 @@ async def test_app_upload_dual_write_failure_required_raises_after_upstream(
 async def test_upload_path_embeds_workflow_id_from_context(tmp_path):
     """App.upload() run_prefix must embed context.workflow_id, not the sentinel.
 
-    Regression guard for the activity-side AppContext construction bug where
-    workflow_id was never plumbed from activity.info().workflow_id, causing
-    uploads to land under the 'local-no-temporal' sentinel in production.
+    Regression guard: workflow_id was never set on the activity-side AppContext,
+    so uploads landed under the 'local-no-temporal' sentinel in production.
+    The fix threads workflow_id through TaskContext so both construction sites
+    read from one transport (TaskContext.workflow_id).
     """
     store = create_local_store(tmp_path / "store")
     src = tmp_path / "artifact.jsonl"
@@ -732,6 +733,6 @@ async def test_upload_path_embeds_workflow_id_from_context(tmp_path):
     assert storage_path is not None
     assert real_workflow_id in storage_path, (
         f"Expected workflow_id '{real_workflow_id}' in storage path '{storage_path}'. "
-        f"Activities must set app_context.workflow_id from activity.info().workflow_id."
+        f"workflow_id must flow from TaskContext.workflow_id into app_context."
     )
     assert "local-no-temporal" not in storage_path

--- a/tests/unit/app/test_context.py
+++ b/tests/unit/app/test_context.py
@@ -75,6 +75,14 @@ class TestAppMetadata:
 
 
 class TestAppContextIdentity:
+    def test_workflow_id_default_is_local_sentinel(self) -> None:
+        ctx = AppContext(app_name="a", app_version="1")
+        assert ctx.workflow_id == "local-no-temporal"
+
+    def test_workflow_id_empty_string_raises(self) -> None:
+        with pytest.raises(ValueError, match="workflow_id"):
+            AppContext(app_name="a", app_version="1", workflow_id="")
+
     def test_correlation_id_defaults_to_run_id(self) -> None:
         ctx = AppContext(app_name="a", app_version="1", run_id="run-42")
         assert ctx.correlation_id == "run-42"

--- a/tests/unit/execution/test_activities.py
+++ b/tests/unit/execution/test_activities.py
@@ -696,12 +696,15 @@ class TestActivityFnExecution:
         assert result.greeting == "hi i"
 
     @pytest.mark.asyncio
-    async def test_workflow_id_plumbed_from_activity_info(self) -> None:
-        """activity_fn must set app_context.workflow_id from activity.info().workflow_id.
+    async def test_workflow_id_plumbed_through_task_context(self) -> None:
+        """workflow_id must flow from TaskContext into app_context.workflow_id.
 
         Regression guard: previously AppContext was constructed without workflow_id,
         so it silently fell back to the 'local-no-temporal' sentinel. This caused
         App.upload() to write under the wrong object-store prefix in production.
+
+        TaskContext is now the single transport — the workflow side sets workflow_id
+        once; the activity side reads it from context rather than activity.info().
         """
 
         class _WfIdApp(App):
@@ -721,6 +724,7 @@ class TestActivityFnExecution:
             app_name="_wf-id-app",
             task_name="capture",
             run_id="run-wfid",
+            workflow_id="wf-from-temporal",
             heartbeat_timeout_seconds=None,
             auto_heartbeat_seconds=None,
         )
@@ -729,7 +733,7 @@ class TestActivityFnExecution:
             mock.patch.object(
                 activities_module.activity,
                 "info",
-                return_value=mock.MagicMock(workflow_id="wf-from-temporal"),
+                return_value=mock.MagicMock(workflow_id="wf-should-not-be-used"),
             ),
             mock.patch(
                 "application_sdk.infrastructure.context.get_infrastructure",

--- a/tests/unit/execution/test_activities.py
+++ b/tests/unit/execution/test_activities.py
@@ -470,6 +470,10 @@ class _AfnOut(Output, allow_unbounded_fields=True):
     greeting: str = ""
 
 
+class _WfIdOut(Output, allow_unbounded_fields=True):
+    captured_workflow_id: str = ""
+
+
 class TestTrackFileRefs:
     """Tests for _track_file_refs (exercises inline import of _app_state*)."""
 
@@ -578,9 +582,9 @@ class TestActivityFnExecution:
                 "application_sdk.infrastructure.context.get_infrastructure",
                 return_value=None,
             ),
+            pytest.raises(ApplicationError) as exc_info,
         ):
-            with pytest.raises(ApplicationError) as exc_info:
-                await activity_fn(ctx, _AfnIn(name="x"))
+            await activity_fn(ctx, _AfnIn(name="x"))
         # ApplicationError should be flagged non-retryable.
         assert exc_info.value.non_retryable is True
 
@@ -617,9 +621,9 @@ class TestActivityFnExecution:
                 "application_sdk.infrastructure.context.get_infrastructure",
                 return_value=None,
             ),
+            pytest.raises(ValueError, match="ordinary failure"),
         ):
-            with pytest.raises(ValueError, match="ordinary failure"):
-                await activity_fn(ctx, _AfnIn(name="x"))
+            await activity_fn(ctx, _AfnIn(name="x"))
 
     @pytest.mark.asyncio
     async def test_starts_and_stops_auto_heartbeat_loop(self) -> None:
@@ -690,3 +694,48 @@ class TestActivityFnExecution:
         ):
             result = await activity_fn(ctx, _AfnIn(name="i"))
         assert result.greeting == "hi i"
+
+    @pytest.mark.asyncio
+    async def test_workflow_id_plumbed_from_activity_info(self) -> None:
+        """activity_fn must set app_context.workflow_id from activity.info().workflow_id.
+
+        Regression guard: previously AppContext was constructed without workflow_id,
+        so it silently fell back to the 'local-no-temporal' sentinel. This caused
+        App.upload() to write under the wrong object-store prefix in production.
+        """
+
+        class _WfIdApp(App):
+            @task(timeout_seconds=60)
+            async def capture(self, input: _AfnIn) -> _WfIdOut:
+                return _WfIdOut(captured_workflow_id=self.context.workflow_id)
+
+            async def run(self, input: _AfnIn) -> _WfIdOut:
+                return await self.capture(input)
+
+        task_registry = TaskRegistry.get_instance()
+        tasks = task_registry.get_tasks_for_app("_wf-id-app")
+        capture_task = next(t for t in tasks if t.name == "capture")
+        activity_fn = create_activity_from_task(capture_task)
+
+        ctx = TaskContext(
+            app_name="_wf-id-app",
+            task_name="capture",
+            run_id="run-wfid",
+            heartbeat_timeout_seconds=None,
+            auto_heartbeat_seconds=None,
+        )
+
+        with (
+            mock.patch.object(
+                activities_module.activity,
+                "info",
+                return_value=mock.MagicMock(workflow_id="wf-from-temporal"),
+            ),
+            mock.patch(
+                "application_sdk.infrastructure.context.get_infrastructure",
+                return_value=None,
+            ),
+        ):
+            result = await activity_fn(ctx, _AfnIn(name="x"))
+
+        assert result.captured_workflow_id == "wf-from-temporal"


### PR DESCRIPTION
## Summary

- `App.upload()` was constructing its object-store prefix without `workflow_id`, producing `artifacts/apps/{app}/workflows/{run_id}`, while `WORKFLOW_OUTPUT_PATH_TEMPLATE` (used by `PublishInputMixin`, `build_output_path()`, and `sql_app.py`) produces `artifacts/apps/{app}/workflows/{workflow_id}/{run_id}`
- This meant `PublishInputMixin` auto-derived a `transformed_data_prefix` pointing to a path that `App.upload()` never actually wrote to
- Fix: add `workflow_id` to `AppContext`, populate it from `workflow.info().workflow_id` at entrypoint time, and include it in `App.upload()`'s `run_prefix`
- In non-Temporal contexts (local dev, tests), `workflow_id` defaults to `"local-no-temporal"` so local runs group under one browsable prefix

## Test plan

- [x] Pre-commit passes (`uv run pre-commit run --all-files`)
- [x] Unit tests pass (`uv run pytest tests/unit/app/ tests/unit/contracts/ tests/unit/templates/`)
- [ ] Verify a real extraction run writes files to the path `PublishInputMixin` derives