### PR TITLE
ci: remove dead repo:branch label override from matrix-builder

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -176,23 +176,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Get PR Labels
-        id: get-labels
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number
-            });
-            const labelNames = labels.map(label => label.name).join(',');
-            console.log(`PR Labels: ${labelNames}`);
-            core.setOutput('labels', labelNames);
-
-      - name: Build matrix from PR labels
+      - name: Build matrix
         id: set-matrix
         run: |
           # For pull_request, github.base_ref is the branch name (e.g. 'main').
@@ -203,51 +187,8 @@ jobs:
             TARGET_BRANCH="${{ github.event.merge_group.base_ref }}"
             TARGET_BRANCH="${TARGET_BRANCH#refs/heads/}"
           fi
-          # Default matrix if no label provided
-          DEFAULT_MATRIX="{\"include\":[{\"repo_name\":\"atlan-openapi-app\",\"target_branch\":\"${TARGET_BRANCH}\"},{\"repo_name\":\"atlan-mysql-app\",\"target_branch\":\"${TARGET_BRANCH}\"},{\"repo_name\":\"atlan-metabase-app\",\"target_branch\":\"${TARGET_BRANCH}\"}]}"
-
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # Parse labels from GitHub Script output
-            LABELS="${{ steps.get-labels.outputs.labels }}"
-
-            FOUND_LABEL=false
-            INCLUDES=""
-
-            echo "Found labels: ${LABELS}"
-
-            IFS=',' read -ra LABEL_ARRAY <<< "$LABELS"
-            for LABEL in "${LABEL_ARRAY[@]}"; do
-              if [[ $LABEL =~ ^([^:]+):([^:]+)$ ]]; then
-                REPO="${BASH_REMATCH[1]}"
-                BRANCH="${BASH_REMATCH[2]}"
-
-                # Add comma if not the first entry
-                if [[ "$FOUND_LABEL" == "true" ]]; then
-                  INCLUDES="${INCLUDES},"
-                fi
-
-                # Add this pair as a direct include entry
-                INCLUDES="${INCLUDES}{\"repo_name\":\"${REPO}\",\"target_branch\":\"${BRANCH}\"}"
-                FOUND_LABEL=true
-                echo "Added pair: $REPO:$BRANCH"
-              fi
-            done
-
-            # Generate matrix JSON with includes
-            if [[ "$FOUND_LABEL" == "true" ]]; then
-              MATRIX="{\"include\":[${INCLUDES}]}"
-              echo "Generated matrix from labels: $MATRIX"
-            else
-              MATRIX="$DEFAULT_MATRIX"
-              echo "No repo:branch labels found, using default matrix"
-            fi
-          else
-            MATRIX="$DEFAULT_MATRIX"
-            echo "Not a PR event, using default matrix"
-          fi
-
+          MATRIX="{\"include\":[{\"repo_name\":\"atlan-openapi-app\",\"target_branch\":\"${TARGET_BRANCH}\"},{\"repo_name\":\"atlan-mysql-app\",\"target_branch\":\"${TARGET_BRANCH}\"},{\"repo_name\":\"atlan-metabase-app\",\"target_branch\":\"${TARGET_BRANCH}\"}]}"
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
-          echo "Matrix output: $MATRIX"
 
   # Build a PR-scoped SDK runtime base image so the connector e2e tests can
   # build the connector FROM the *rebuilt* base — exercising Dockerfile /


### PR DESCRIPTION
## Summary

- Removes the `Get PR Labels` step and the `repo:branch` regex-parsing block from the `matrix-builder` job in `pull_request.yaml` — both were dead code left over from a former per-repo dispatch mechanism superseded by the plain `e2e` label.
- The matrix-builder job itself is kept (connector-tests and connector-gate both depend on its output); it now always emits the fixed default three-repo matrix.

## Root cause fixed

Renovate's `update:minor` label matched the overly-broad `^([^:]+):([^:]+)$` regex, causing the matrix-builder to treat it as `repo=update`, `branch=minor`. The connector-tests job then tried to dispatch `tests.yaml` to `atlanhq/update` on `refs/heads/minor` — neither exists — failing with `Not Found`. Observed on #2362.

## Test plan

- [x] Confirm `Build Test Matrix` passes on this PR
- [x] Confirm `Connector Tests Gate` passes (skipped on non-e2e PRs is the expected outcome)
- [ ] Verify a Renovate dep-bump PR with `update:minor` label no longer triggers a spurious connector-tests failure