### PR TITLE
ci(renovate): force chore commit type for dep updates

### DIFF
--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -115,6 +115,20 @@
       "addLabels": [
         "update:{{{updateType}}}"
       ]
+    },
+    {
+      "description": "Force chore commit type for all dependency updates. config:recommended includes :semanticPrefixFixDepsChoreOthers which sets semanticCommitType=fix via a packageRule, overriding any top-level semanticCommitType setting. Placing this rule last gives it higher precedence.",
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "digest",
+        "pin",
+        "pinDigest",
+        "rollback",
+        "replacement"
+      ],
+      "semanticCommitType": "chore"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary

- `config:recommended` bundles `:semanticPrefixFixDepsChoreOthers`, which applies `semanticCommitType: "fix"` for dependency bump PRs via a **packageRule**
- PackageRules always override top-level config settings, so the existing `semanticCommitType: "chore"` in `renovate.json` was silently losing
- This caused Renovate to open PRs like `fix(deps): update dependency obstore …`, which fails the `Validate PR title` gate (non-source PRs must use `chore:`/`ci:`, not `fix:`)

Fixes the root cause by adding a packageRule to the end of `default.json`'s `packageRules` array — being last, it takes precedence over the `config:recommended` rule and forces `chore` for all dependency update types.

PR #2362 has already been renamed from `fix(deps):` to `chore(deps):` to unblock its auto-merge.

## Test plan

- [ ] `Validate PR title` passes on PR #2362 after rename
- [ ] Future Renovate dep-bump PRs open with `chore(deps):` titles