### PR TITLE
chore(claude): replace per-edit ruff hook with pre-commit hook on git commit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "if": "Bash(git commit*)",
+            "if": "Bash(git commit *)",
             "command": "staged=$(git diff --name-only --cached); for i in 1 2 3; do uv run pre-commit run && exit 0; while IFS= read -r f; do [ -n \"$f\" ] && git add -- \"$f\"; done <<< \"$staged\"; done; exit 1",
             "statusMessage": "Running pre-commit checks..."
           }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "if": "Bash(git commit *)",
-            "command": "staged=$(git diff --name-only --cached); for i in 1 2 3; do uv run pre-commit run && exit 0; while IFS= read -r f; do [ -n \"$f\" ] && git add -- \"$f\"; done <<< \"$staged\"; done; exit 1",
+            "command": "staged=$(git diff --name-only --cached); for i in 1 2 3; do uv run pre-commit run && exit 0; while IFS= read -r f; do [ -n \"$f\" ] && git add -- \"$f\"; done <<< \"$staged\"; done; exit 2",
             "statusMessage": "Running pre-commit checks..."
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,17 @@
 {
-  "hooks": {}
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit*)",
+            "command": "uv run pre-commit run",
+            "statusMessage": "Running pre-commit checks..."
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,16 +1,3 @@
 {
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.file_path // empty' | { read -r f; [ -n \"$f\" ] && uvx ruff check --fix \"$f\" && uvx ruff format \"$f\"; } 2>/dev/null || true",
-            "statusMessage": "Linting with ruff..."
-          }
-        ]
-      }
-    ]
-  }
+  "hooks": {}
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "if": "Bash(git commit*)",
-            "command": "uv run pre-commit run",
+            "command": "staged=$(git diff --name-only --cached); for i in 1 2 3; do uv run pre-commit run && exit 0; while IFS= read -r f; do [ -n \"$f\" ] && git add -- \"$f\"; done <<< \"$staged\"; done; exit 1",
             "statusMessage": "Running pre-commit checks..."
           }
         ]


### PR DESCRIPTION
## Summary

Replaces the old \`PostToolUse\` ruff hook with a \`PreToolUse\` hook that runs \`pre-commit\` immediately before any \`git commit\` command, with a retry loop to handle auto-fixes cleanly.

## Why remove the old hook

The previous hook ran \`ruff check --fix\` + \`ruff format\` after every individual Edit/Write call. This caused two concrete problems:

1. **Edit loop thrashing** — ruff's auto-fixes (e.g. removing an unused import) would conflict with the next edit step that needed that import, which would re-add it, triggering another fix that stripped it again. This cycle repeated indefinitely, wasting significant time and often leaving files in a broken intermediate state.

2. **Redundant with pre-commit** — pre-commit already runs ruff across *all* changed files in one pass before a commit lands. Running it file-by-file mid-edit is strictly worse: it operates on partial state, can't reason across files, and duplicates work that pre-commit handles correctly at the right moment.

## What the new hook does

```json
{
  "PreToolUse": [{
    "matcher": "Bash",
    "hooks": [{
      "type": "command",
      "if": "Bash(git commit*)",
      "command": "staged=$(git diff --name-only --cached); for i in 1 2 3; do uv run pre-commit run && exit 0; while IFS= read -r f; do [ -n \"$f\" ] && git add -- \"$f\"; done <<< \"$staged\"; done; exit 1",
      "statusMessage": "Running pre-commit checks..."
    }]
  }]
}
```

- The `if: "Bash(git commit*)"` field filters the hook so it only fires on `git commit` commands — no other Bash calls are affected.
- `uv run pre-commit run` (without `--all-files`) runs pre-commit on staged files only — the right scope for a commit gate.
- **Retry loop**: Python linters (ruff) auto-fix files and exit non-zero on the first pass. The loop retries up to 3 times. After each failed run, it re-stages only the files that were staged at the start of the commit (captured upfront with `git diff --name-only --cached`) — so intentionally unstaged work is never pulled in accidentally.
- Blocks the commit (exits 1) only if pre-commit is still failing after 3 passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)