### PR TITLE
feat(conformance): async/determinism workflow checks P020-P024

### DIFF
--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -251,6 +251,7 @@ class BaseE2ETest:
                     AtlanClient,
                 )
 
+                # conformance: ignore[P024] e2e harness admin-role lookup runs outside the async execution path; sync pyatlan is intentional
                 _pc = AtlanClient(base_url=tenant_url, api_key=api_token)
                 _guid = _pc.role_cache.get_id_for_name("$admin")
                 if _guid:
@@ -309,6 +310,7 @@ class BaseE2ETest:
             if not tenant_url or not api_token:
                 return
 
+            # conformance: ignore[P024] e2e harness asset lookup runs outside the async execution path; sync pyatlan is intentional
             client = AtlanClient(base_url=tenant_url, api_key=api_token)
 
             # Collect GUIDs for all descendant assets.

--- a/application_sdk/testing/e2e/sql_app.py
+++ b/application_sdk/testing/e2e/sql_app.py
@@ -197,6 +197,7 @@ class SQLAppE2ETest(BaseE2ETest):
         """Look up the tenant's ``$admin`` role GUID via pyatlan."""
         from pyatlan.client.atlan import AtlanClient  # noqa: PLC0415
 
+        # conformance: ignore[P024] e2e harness admin-role lookup runs outside the async execution path; sync pyatlan is intentional
         client = AtlanClient(
             base_url=os.environ["ATLAN_BASE_URL"],
             api_key=os.environ["ATLAN_API_KEY"],

--- a/application_sdk/testing/full_dag/sql_app.py
+++ b/application_sdk/testing/full_dag/sql_app.py
@@ -128,6 +128,7 @@ class SQLAppE2EFullTest(BaseFullDAGE2ETest):
         """
         from pyatlan.client.atlan import AtlanClient  # noqa: PLC0415
 
+        # conformance: ignore[P024] e2e harness admin-role lookup runs outside the async execution path; sync pyatlan is intentional
         client = AtlanClient(
             base_url=os.environ["ATLAN_BASE_URL"],
             api_key=os.environ["ATLAN_API_KEY"],

--- a/packages/conformance/conformance/docs/rules/prescriptions.md
+++ b/packages/conformance/conformance/docs/rules/prescriptions.md
@@ -5,7 +5,7 @@
 
 # Prescription Rules (P-series)
 
-**19 rules** · Checker: `suite.checks.prescriptions` (P001–P003, P008–P015), `suite.checks.orchestration` (P004–P007, scans test files too), `suite.checks.entrypoint_alignment` (P016), `suite.checks.entrypoint` (P017–P018, scans test files too), `suite.checks.client_seam` (P019) (all AST-based)
+**24 rules** · Checker: `suite.checks.prescriptions` (P001–P003, P008–P015), `suite.checks.orchestration` (P004–P007, scans test files too), `suite.checks.entrypoint_alignment` (P016), `suite.checks.entrypoint` (P017–P018, scans test files too), `suite.checks.client_seam` (P019) (all AST-based)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -42,6 +42,11 @@ reassigned.
 | [P017](#p017) | `ManualWorkerBootstrap` | `warn` | `app` | `entrypoint-conformance` | — | 0.6.0 |
 | [P018](#p018) | `ManualServerBootstrap` | `warn` | `app` | `entrypoint-conformance` | — | 0.6.0 |
 | [P019](#p019) | `RawHttpToAtlan` | `warn` | `both` | `client-seam` | — | 0.7.0 |
+| [P020](#p020) | `NonDeterministicPrimitiveInWorkflow` | `warn` | `both` | `determinism` | — | 0.8.0 |
+| [P021](#p021) | `SideEffectIoInWorkflow` | `warn` | `both` | `determinism` | — | 0.8.0 |
+| [P022](#p022) | `UnawaitedCoroutine` | `warn` | `both` | `async-correctness` | — | 0.8.0 |
+| [P023](#p023) | `BlockingCallInAsyncDef` | `warn` | `both` | `async-correctness` | — | 0.8.0 |
+| [P024](#p024) | `SyncAtlanClientInApp` | `warn` | `both` | `async-correctness` | — | 0.8.0 |
 
 ---
 
@@ -633,5 +638,143 @@ marker and stays silent.
 
 Land as `WARN`: a justified inline `# conformance: ignore[P019] <reason>` records any
 unavoidable exception and stays visible in SARIF.
+
+---
+
+## P020 — `NonDeterministicPrimitiveInWorkflow` {#p020}
+
+**Tier:** `warn` · **Scope:** `both` · **Category:** `determinism` · **Autofixable:** — · **Since:** 0.8.0
+
+> Non-deterministic time/uuid/sleep/random call in workflow-context code
+
+**Rationale:** Temporal workflow code is re-executed on replay, so it must be deterministic: the same
+inputs must always produce the same sequence of commands. Reading the wall clock
+(datetime.now/time.time), generating a UUID (uuid.uuid4), sleeping on the wall clock
+(time.sleep/asyncio.sleep), or drawing randomness produces a different value on replay
+and corrupts the workflow history. The SDK exposes deterministic equivalents through its
+seam — self.now()/now, self.uuid()/uuid4, sleep — that record their result in history so
+replay is faithful.
+
+Inside an `App` subclass's workflow-context method (`run`, an `@entrypoint` method, or a
+`@signal` / `@query` / `@update` handler) a call reads wall-clock time, generates a
+UUID, sleeps, or draws randomness.  Workflow code is replayed deterministically, so use
+the SDK seam instead: `self.now()` or `from application_sdk.app import now`;
+`self.uuid()` or `from application_sdk.app import uuid4`; `from application_sdk.app
+import sleep`.  `@task` activity bodies are exempt — they run once and may do any of
+this.
+
+Randomness (`random` / `secrets` / `os.urandom`) is also flagged: it is a real
+determinism bug, but the SDK exposes no deterministic-random primitive, so the fix is to
+move it into a `@task` or raise a seam request with the SDK team rather than a
+mechanical swap.
+
+Matching is receiver-anchored: only a `.now()` whose receiver is `datetime` is flagged,
+so the sanctioned `self.now()` is untouched. Land as `WARN`; record an unavoidable
+exception with `# conformance: ignore[P020] <reason>`.
+
+---
+
+## P021 — `SideEffectIoInWorkflow` {#p021}
+
+**Tier:** `warn` · **Scope:** `both` · **Category:** `determinism` · **Autofixable:** — · **Since:** 0.8.0
+
+> File / network / env / process I/O in workflow-context code
+
+**Rationale:** Workflow code is replayed, so any interaction with the outside world — opening a file,
+making a network call, reading the environment, spawning a thread or process — runs
+again on every replay and produces non-deterministic, un-recorded results that break
+replay correctness. Side effects belong in a @task activity, which runs exactly once and
+whose result is durably recorded in workflow history.
+
+Inside an `App` subclass's workflow-context method a call performs side-effecting I/O —
+`open`, `requests`/`httpx`/`urllib`, `socket`, `subprocess`,
+`threading`/`multiprocessing`, `os.getenv` / `os.environ[...]`.  Move it into a `@task`
+method: workflow code must be deterministic, and activities are where I/O and external
+state belong.
+
+The detected surface is a curated high-signal subset, not an exhaustive list of every
+I/O API.  Remediation is structural (extract a `@task`), so findings route to residue
+rather than an autofix.  Land as `WARN`; suppress a reviewed exception with `#
+conformance: ignore[P021] <reason>`.
+
+---
+
+## P022 — `UnawaitedCoroutine` {#p022}
+
+**Tier:** `warn` · **Scope:** `both` · **Category:** `async-correctness` · **Autofixable:** — · **Since:** 0.8.0
+
+> A same-class async method is called without await (dropped coroutine)
+
+**Rationale:** SDK app methods (run, @task, @entrypoint, interaction handlers) are async and return a
+coroutine. Calling one like a sync function — 'self.fetch(x)' as a bare statement
+instead of 'await self.fetch(x)' — constructs the coroutine and immediately discards it,
+so the work never runs and the bug is silent (no error, no result). This is the most
+common way apps misuse the SDK's async surface.
+
+A bare expression statement calls a same-class `async def` method via `self.<name>(...)`
+without `await` and without wrapping it in `asyncio.create_task` / `asyncio.gather`.
+The call returns a coroutine that is never scheduled, so the work silently does nothing.
+Add `await` (or schedule it explicitly if concurrency is intended).
+
+Scope is intentionally narrow — a bare `self.<async-method>()` statement inside an
+`async def` — so the target is provably a coroutine and the finding is
+false-positive-free.  Land as `WARN`; suppress with `# conformance: ignore[P022]
+<reason>`.
+
+---
+
+## P023 — `BlockingCallInAsyncDef` {#p023}
+
+**Tier:** `warn` · **Scope:** `both` · **Category:** `async-correctness` · **Autofixable:** — · **Since:** 0.8.0
+
+> Event-loop re-entry bridge or blocking sync call inside an async def
+
+**Rationale:** Inside an async function the event loop must never be blocked or re-entered. Calling
+asyncio.run()/loop.run_until_complete() from within a running loop raises or deadlocks;
+calling a synchronous blocking library (requests, time.sleep) stalls the loop and every
+other coroutine on it. The correct pattern is to await an async equivalent, or offload
+blocking work via App.run_in_thread() inside a @task — not to bridge async with a sync
+workaround.
+
+Inside an `async def`, code either re-enters the event loop (`asyncio.run(...)` or
+`*.run_until_complete(...)`, including `loop.run_until_complete` /
+`asyncio.get_event_loop()....`) or makes a blocking synchronous call (`requests.*`,
+`urllib.request.*`, `time.sleep`).  Await the coroutine directly, or offload genuinely
+blocking work with `App.run_in_thread()` inside a `@task`.
+
+Blocking sync I/O is reported only **outside** workflow context — inside workflow
+methods the same calls are owned by P020 (sleep) and P021 (network), so they are not
+double-counted.  Remediation is a restructure, so findings route to residue.  Land as
+`WARN`; suppress with `# conformance: ignore[P023] <reason>`.
+
+---
+
+## P024 — `SyncAtlanClientInApp` {#p024}
+
+**Tier:** `warn` · **Scope:** `both` · **Category:** `async-correctness` · **Autofixable:** — · **Since:** 0.8.0
+
+> Synchronous pyatlan AtlanClient used instead of the async client
+
+**Rationale:** pyatlan (atlan-python) ships both a synchronous AtlanClient and an asynchronous
+AsyncAtlanClient. App code runs in an async execution path (Temporal activities, the
+FastAPI server), so the sync client blocks the event loop on every Atlan call and stalls
+every other coroutine on it. The async client must be used instead — ideally through the
+SDK seam (create_async_atlan_client /
+AtlanClientMixin.get_or_create_async_atlan_client), which returns a configured,
+observability-stamped AsyncAtlanClient. This complements P019 (use pyatlan, not raw
+HTTP) by requiring the async variant of that client.
+
+App code constructs or invokes pyatlan's synchronous `AtlanClient` (or the vendored
+`pyatlan_v9` equivalent) — its constructor or a factory like
+`AtlanClient.from_token(...)`.  Because the app's execution path is async, the sync
+client blocks the event loop.  Use `AsyncAtlanClient` (`pyatlan.client.aio`) —
+preferably via the SDK seam: `await self.get_or_create_async_atlan_client(cred)` on an
+`App` that mixes in `AtlanClientMixin`, or `create_async_atlan_client(cred)` from
+`application_sdk.credentials`.
+
+Matching is receiver-anchored: `AsyncAtlanClient` and the SDK seam helpers are not
+flagged, only the sync `AtlanClient` under a pyatlan root.  Closing it makes downstream
+calls `await`-ed, so remediation is a restructure routed to residue.  Land as `WARN`;
+suppress with `# conformance: ignore[P024] <reason>`.
 
 ---

--- a/packages/conformance/conformance/programs/areas/prescriptions.prose.md
+++ b/packages/conformance/conformance/programs/areas/prescriptions.prose.md
@@ -73,6 +73,17 @@ of which pyatlan surface to use — or whether to suppress when no equivalent ex
 auto-applies.  (This rule is backed by a separate `suite.checks.client_seam` check
 — see its module docs.)
 
+The determinism / async-correctness rules (P020–P024) are also P-series
+and suggest-only.  P020 (non-deterministic primitive in workflow context) has a
+concrete mechanical proposal for time/uuid/sleep — swap to the SDK seam — but its
+randomness case has no seam target, and P021 (workflow I/O) / P023 (blocking call
+in an async def) describe structural moves into a `@task` that no local edit can
+safely perform; P022 (un-awaited coroutine) proposes adding `await`, and P024
+(sync pyatlan client) proposes the async client via the SDK seam — both
+semantically load-bearing.  All five draft a proposal for human review and never
+auto-apply.  (These rules are backed by a separate `suite.checks.determinism`
+check — see its module docs.)
+
 ### Requires
 
 - `scope` — repository root path.
@@ -312,3 +323,54 @@ around `finding.line` before drafting any proposal — the proposal is a
   `# conformance: ignore[P019] <reason>` instead, where the justification names
   the missing surface.  Either way the proposal is recorded for the developer to
   apply or reject; this area never mutates the working tree.
+
+**Determinism / async-correctness rules (P020–P024)** — all suggest-only,
+scope=both, WARN-tier; `classification` is always `"judgment"`.  Read the enclosing
+method around `finding.line` first, and confirm it is workflow context (`run` /
+`@entrypoint` / `@signal` / `@query` / `@update`) versus a `@task` activity before
+drafting.
+
+- **P020 NonDeterministicPrimitiveInWorkflow** — a wall-clock/uuid/sleep/random
+  call runs in a workflow-context method.  Draft, by category:
+  - **time** (`datetime.now`/`utcnow`/`today`, `time.time`/`monotonic`/…) → replace
+    with `self.now()` (or `from application_sdk.app import now`).
+  - **uuid** (`uuid.uuid1`/`uuid.uuid4`) → replace with `self.uuid()` (or
+    `from application_sdk.app import uuid4`).
+  - **sleep** (`time.sleep`/`asyncio.sleep`) → replace with `await sleep(...)`
+    from `application_sdk.app`.
+  - **randomness** (`random.*`/`secrets.*`/`os.urandom`) → **route to residue, do
+    not fabricate a swap**: the SDK exposes no deterministic-random seam.  Note
+    that the randomness must move into a `@task`, or that the SDK should expose a
+    deterministic-random primitive (raise a seam request).
+  Verify the receiver before proposing — `self.now()` / `now()` are already the
+  sanctioned forms and must never be rewritten.
+
+- **P021 SideEffectIoInWorkflow** — file/network/env/process I/O runs in a
+  workflow-context method.  The fix is structural: extract the I/O into a `@task`
+  activity and have the workflow `await` it.  No local edit can perform this
+  safely (it changes the workflow/activity topology) — draft the refactored shape
+  (which call becomes a task, what the task returns) and route to residue.
+
+- **P022 UnawaitedCoroutine** — a bare `self.<async-method>(...)` statement drops a
+  coroutine.  Propose adding `await` (or wrapping in `asyncio.create_task`/`gather`
+  if concurrency is intended).  State which intent you assumed: a missing `await`
+  is the common case, but if the surrounding code suggests fire-and-forget, say so
+  and propose `create_task` instead.  The change is load-bearing, so route to
+  residue for human confirmation.
+
+- **P023 BlockingCallInAsyncDef** — an event-loop re-entry bridge (`asyncio.run`/
+  `run_until_complete`) or a blocking sync call (`requests.*`, `time.sleep`) runs
+  inside an `async def`.  Draft: for a bridge, `await` the coroutine directly
+  instead of re-entering a loop; for blocking I/O, `await` an async equivalent or
+  offload it via `App.run_in_thread()` inside a `@task`.  Both are restructures —
+  route to residue with the proposed shape.
+
+- **P024 SyncAtlanClientInApp** — app code constructs pyatlan's sync `AtlanClient`
+  (or a factory like `AtlanClient.from_token(...)`).  Draft a swap to the async
+  client through the SDK seam: inside an `App` that mixes in `AtlanClientMixin`,
+  `client = await self.get_or_create_async_atlan_client(credential)`; ad-hoc /
+  outside an App, `client = create_async_atlan_client(cred)`
+  (`from application_sdk.credentials import create_async_atlan_client`).  The
+  downstream calls on the client then become `await`-ed, so this is a restructure
+  — route to residue with the proposed shape; do not mechanically rename the
+  class.  Leave `AsyncAtlanClient` usage untouched.

--- a/packages/conformance/conformance/suite/checks/determinism/__init__.py
+++ b/packages/conformance/conformance/suite/checks/determinism/__init__.py
@@ -1,0 +1,98 @@
+"""P-series determinism / async-correctness checks — AST-based.
+
+Enforces that app and SDK code respects the SDK's async and determinism
+expectations in the execution path, so subtle replay-correctness and event-loop
+bugs are caught at CI time rather than under production orchestration.
+
+* ``P020`` NonDeterministicPrimitiveInWorkflow — wall-clock time / uuid / sleep /
+  randomness in a workflow-context method (``run`` / ``@entrypoint`` /
+  ``@signal`` / ``@query`` / ``@update`` on an ``App`` subclass).
+* ``P021`` SideEffectIoInWorkflow — file / network / env / thread-spawn I/O in a
+  workflow-context method (belongs in a ``@task``).
+* ``P022`` UnawaitedCoroutine — a bare ``self.<async-method>()`` statement that is
+  never awaited (the call silently does nothing).
+* ``P023`` BlockingCallInAsyncDef — an event-loop re-entry bridge
+  (``asyncio.run`` / ``run_until_complete``) or a blocking sync I/O call inside an
+  ``async def``.
+* ``P024`` SyncAtlanClientInApp — pyatlan's synchronous ``AtlanClient`` used where
+  the async ``AsyncAtlanClient`` (via the SDK credentials seam) is required.
+
+Discovery
+---------
+Unlike the orchestration P-series, this series uses the **standard** source
+discovery walk — it deliberately **excludes** test files.  Workflow-determinism
+mistakes in throwaway test fixtures are not production replay risks, and toy
+``App`` subclasses in tests would only generate noise.
+
+Scope
+-----
+All five rules are ``both``-scoped: workflow-context code and async SDK usage exist
+in the SDK itself and in every consumer app, so the contract applies to any repo.
+
+Inline suppression
+------------------
+Add ``# conformance: ignore[PXXX] <reason>`` on the offending line (or the
+comment-only line directly above it).
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+from conformance.suite.checks._ast_common import (
+    _parse_directives,
+    discover,
+    make_cli_main,
+)
+from conformance.suite.schema.findings import Finding
+
+from ._p020_primitives import check_p020
+from ._p021_io import check_p021
+from ._p022_unawaited import check_p022
+from ._p023_blocking_async import check_p023
+from ._p024_sync_atlan_client import check_p024
+
+SERIES = "P"
+
+__all__ = ["SERIES", "discover", "main", "scan_path", "scan_text"]
+
+
+def scan_text(text: str, file: str) -> list[Finding]:
+    """Scan a single Python source *text* for all determinism findings (P020–P024)."""
+    try:
+        tree = ast.parse(text, filename=file)
+    except SyntaxError:
+        return []
+    directives = _parse_directives(text)
+    return [
+        *check_p020(tree, file, directives),
+        *check_p021(tree, file, directives),
+        *check_p022(tree, file, directives),
+        *check_p023(tree, file, directives),
+        *check_p024(tree, file, directives),
+    ]
+
+
+def scan_path(path: Path, root: Path) -> list[Finding]:
+    """Scan a single Python file for P020–P024 findings."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        rel = path
+    return scan_text(text, str(rel))
+
+
+main = make_cli_main(
+    scan_all=lambda paths, root: [f for p in paths for f in scan_path(p, root)],
+    description="Determinism / async-correctness P-series checks (P020-P024).",
+)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/conformance/conformance/suite/checks/determinism/_p020_primitives.py
+++ b/packages/conformance/conformance/suite/checks/determinism/_p020_primitives.py
@@ -1,0 +1,114 @@
+"""P020 — NonDeterministicPrimitiveInWorkflow.
+
+Flags wall-clock time, UUID, sleep, and randomness calls inside workflow-context
+methods of an ``App`` subclass.  Workflow code is replayed deterministically, so
+these must use the SDK seam (``self.now()`` / ``now``, ``self.uuid()`` / ``uuid4``,
+``sleep``).  ``random`` / ``secrets`` are flagged too — they are real determinism
+bugs — but have **no** SDK seam replacement, so their remediation is routed to
+residue (raise a deterministic-random seam request) rather than an autofix.
+
+Matching is receiver-anchored (see :func:`resolve_call_target`): only a ``.now()``
+whose receiver resolves to ``datetime`` is flagged, so the sanctioned ``self.now()``
+and ``application_sdk.app.now`` are left untouched.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from conformance.suite.checks._ast_common import _IgnoreDirective, make_finding
+from conformance.suite.checks.orchestration._temporal_common import (
+    collect_import_bindings,
+)
+from conformance.suite.schema.findings import Finding
+
+from ._workflow_methods import resolve_call_target, workflow_method_nodes
+
+RULE_ID = "P020"
+
+_TIME_TARGETS = frozenset(
+    {
+        "datetime.datetime.now",
+        "datetime.datetime.utcnow",
+        "datetime.datetime.today",
+        "datetime.date.today",
+        "time.time",
+        "time.time_ns",
+        "time.monotonic",
+        "time.monotonic_ns",
+        "time.perf_counter",
+        "time.perf_counter_ns",
+        "time.process_time",
+        "time.process_time_ns",
+    }
+)
+# uuid3/uuid5 are namespace-deterministic, so only the time/host (uuid1) and
+# random (uuid4) variants are non-deterministic.
+_UUID_TARGETS = frozenset({"uuid.uuid1", "uuid.uuid4"})
+_SLEEP_TARGETS = frozenset({"time.sleep", "asyncio.sleep"})
+_RANDOM_PREFIXES = ("random.", "secrets.")
+_RANDOM_EXACT = frozenset({"os.urandom"})
+
+_TIME_HINT = (
+    "Workflow code is replayed and must be deterministic: use self.now() or "
+    "'from application_sdk.app import now' instead."
+)
+_UUID_HINT = (
+    "Workflow code is replayed and must be deterministic: use self.uuid() or "
+    "'from application_sdk.app import uuid4' instead."
+)
+_SLEEP_HINT = (
+    "Use 'from application_sdk.app import sleep' — a raw time.sleep()/asyncio.sleep() "
+    "is non-deterministic under workflow replay."
+)
+_RANDOM_HINT = (
+    "Randomness is non-deterministic under workflow replay and has no SDK seam "
+    "replacement yet; move it into a @task or raise a deterministic-random seam "
+    "request with the SDK team."
+)
+
+
+def _classify(target: str) -> str | None:
+    """Return a remediation hint for *target* if it is a banned primitive, else None."""
+    if target in _TIME_TARGETS:
+        return _TIME_HINT
+    if target in _UUID_TARGETS:
+        return _UUID_HINT
+    if target in _SLEEP_TARGETS:
+        return _SLEEP_HINT
+    if target in _RANDOM_EXACT or any(target.startswith(p) for p in _RANDOM_PREFIXES):
+        return _RANDOM_HINT
+    return None
+
+
+def check_p020(
+    tree: ast.AST, filename: str, directives: dict[int, _IgnoreDirective]
+) -> list[Finding]:
+    """Emit P020 findings for non-deterministic primitives in workflow context."""
+    methods = workflow_method_nodes(tree)
+    if not methods:
+        return []
+    bindings = collect_import_bindings(tree)
+    findings: list[Finding] = []
+    for method in methods:
+        for node in ast.walk(method):
+            if not isinstance(node, ast.Call):
+                continue
+            target = resolve_call_target(node.func, bindings)
+            if target is None:
+                continue
+            hint = _classify(target)
+            if hint is None:
+                continue
+            findings.append(
+                make_finding(
+                    filename=filename,
+                    rule_id=RULE_ID,
+                    node=node,
+                    message=(
+                        f"Non-deterministic call '{target}()' in workflow context. {hint}"
+                    ),
+                    directives=directives,
+                )
+            )
+    return findings

--- a/packages/conformance/conformance/suite/checks/determinism/_p021_io.py
+++ b/packages/conformance/conformance/suite/checks/determinism/_p021_io.py
@@ -1,0 +1,94 @@
+"""P021 — SideEffectIoInWorkflow.
+
+Flags a curated, high-signal set of side-effecting I/O calls inside workflow-context
+methods of an ``App`` subclass: file access, network calls, environment reads, and
+spawning threads/processes.  Workflow code is replayed deterministically and must
+not touch the outside world — I/O belongs in a ``@task`` activity.
+
+Remediation is structural ("move it into a @task"), so findings are routed to
+residue rather than auto-fixed.  The list is a deliberate high-signal subset, not
+an exhaustive enumeration of every I/O API.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from conformance.suite.checks._ast_common import _IgnoreDirective, make_finding
+from conformance.suite.checks.orchestration._temporal_common import (
+    collect_import_bindings,
+)
+from conformance.suite.schema.findings import Finding
+
+from ._workflow_methods import resolve_call_target, workflow_method_nodes
+
+RULE_ID = "P021"
+
+# Module-prefixed I/O surfaces: any call under these roots is side-effecting.
+_IO_PREFIXES = (
+    "requests.",
+    "httpx.",
+    "urllib.request.",
+    "http.client.",
+    "socket.",
+    "subprocess.",
+    "threading.",
+    "multiprocessing.",
+    "concurrent.futures.",
+)
+# Exact callables (builtins / specific functions) that perform I/O or env reads.
+_IO_EXACT = frozenset(
+    {
+        "open",
+        "os.getenv",
+        "os.system",
+        "os.popen",
+        "os.environ.get",
+    }
+)
+_ENV_OBJECT = "os.environ"
+
+_HINT = (
+    "Move it into a @task method — workflow code is replayed and must be "
+    "deterministic, so file/network/env I/O belongs in an activity."
+)
+
+
+def _is_io_target(target: str) -> bool:
+    return target in _IO_EXACT or any(target.startswith(p) for p in _IO_PREFIXES)
+
+
+def check_p021(
+    tree: ast.AST, filename: str, directives: dict[int, _IgnoreDirective]
+) -> list[Finding]:
+    """Emit P021 findings for side-effecting I/O in workflow context."""
+    methods = workflow_method_nodes(tree)
+    if not methods:
+        return []
+    bindings = collect_import_bindings(tree)
+    findings: list[Finding] = []
+    for method in methods:
+        for node in ast.walk(method):
+            target: str | None = None
+            label: str | None = None
+            if isinstance(node, ast.Call):
+                target = resolve_call_target(node.func, bindings)
+                if target is not None and _is_io_target(target):
+                    label = f"{target}()"
+            elif isinstance(node, ast.Subscript):
+                # os.environ["X"] read.
+                if resolve_call_target(node.value, bindings) == _ENV_OBJECT:
+                    target = _ENV_OBJECT
+                    label = f"{_ENV_OBJECT}[...]"
+            if label is None:
+                continue
+            findings.append(
+                make_finding(
+                    filename=filename,
+                    rule_id=RULE_ID,
+                    node=node,
+                    message=f"Side-effecting I/O '{label}' in workflow context. {_HINT}",
+                    directives=directives,
+                )
+            )
+    return findings

--- a/packages/conformance/conformance/suite/checks/determinism/_p022_unawaited.py
+++ b/packages/conformance/conformance/suite/checks/determinism/_p022_unawaited.py
@@ -1,0 +1,94 @@
+"""P022 — UnawaitedCoroutine.
+
+Flags a bare expression-statement call to a same-class ``async def`` method
+(``self.<name>(...)`` with ``<name>`` an ``async def`` on the ``App`` subclass)
+that is **not** awaited and **not** wrapped in ``create_task``/``gather``.  Such a
+statement constructs a coroutine and immediately discards it — the work never
+runs.  This is the most common "wrong async usage of the SDK" mistake: calling an
+async SDK method like a sync function.
+
+Scope is deliberately narrow (a bare ``self.<async-method>()`` statement inside an
+``async def``) to stay false-positive-free: the target is provably a coroutine and
+``await`` is a valid fix in the enclosing async context.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from conformance.suite.checks._ast_common import _IgnoreDirective, make_finding
+from conformance.suite.schema.findings import Finding
+
+from ._workflow_methods import async_method_names
+
+RULE_ID = "P022"
+
+_HINT = (
+    "This builds a coroutine and discards it — the call never runs. Add 'await' "
+    "(or wrap it in asyncio.create_task/gather if you intend concurrency)."
+)
+
+
+class _Visitor(ast.NodeVisitor):
+    """Walk the tree tracking the nearest enclosing function's async-ness."""
+
+    def __init__(
+        self,
+        filename: str,
+        directives: dict[int, _IgnoreDirective],
+        async_names: frozenset[str],
+    ) -> None:
+        self.filename = filename
+        self.directives = directives
+        self.async_names = async_names
+        self._async_depth_stack: list[bool] = []
+        self.findings: list[Finding] = []
+
+    def _visit_func(self, node: ast.AST, is_async: bool) -> None:
+        self._async_depth_stack.append(is_async)
+        self.generic_visit(node)
+        self._async_depth_stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_func(node, is_async=False)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_func(node, is_async=True)
+
+    def visit_Expr(self, node: ast.Expr) -> None:
+        # A dropped coroutine is a bare Expr whose value is a Call (an awaited call
+        # would be Expr(value=Await(...)), which never reaches here).
+        call = node.value
+        if (
+            self._async_depth_stack
+            and self._async_depth_stack[-1]
+            and isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and isinstance(call.func.value, ast.Name)
+            and call.func.value.id == "self"
+            and call.func.attr in self.async_names
+        ):
+            self.findings.append(
+                make_finding(
+                    filename=self.filename,
+                    rule_id=RULE_ID,
+                    node=call,
+                    message=(
+                        f"Coroutine 'self.{call.func.attr}()' is never awaited. {_HINT}"
+                    ),
+                    directives=self.directives,
+                )
+            )
+        self.generic_visit(node)
+
+
+def check_p022(
+    tree: ast.AST, filename: str, directives: dict[int, _IgnoreDirective]
+) -> list[Finding]:
+    """Emit P022 findings for dropped (un-awaited) same-class coroutines."""
+    async_names = async_method_names(tree)
+    if not async_names:
+        return []
+    visitor = _Visitor(filename, directives, async_names)
+    visitor.visit(tree)
+    return visitor.findings

--- a/packages/conformance/conformance/suite/checks/determinism/_p023_blocking_async.py
+++ b/packages/conformance/conformance/suite/checks/determinism/_p023_blocking_async.py
@@ -1,0 +1,129 @@
+"""P023 — BlockingCallInAsyncDef.
+
+Enforces "use ``await``, not a sync bridge or blocking lib" inside ``async def``
+code — the second half of the user's async-correctness ask.  Two patterns:
+
+* **Event-loop re-entry bridge** — ``asyncio.run(...)`` or any
+  ``*.run_until_complete(...)`` (incl. ``loop.run_until_complete`` /
+  ``asyncio.get_event_loop().run_until_complete``).  Running a new event loop from
+  inside a running one is an error; ``await`` the coroutine directly.  Flagged in
+  any ``async def``.
+
+* **Blocking sync I/O** — a synchronous library call (``requests.*``,
+  ``urllib.request.*``, ``time.sleep``) that blocks the event loop instead of
+  awaiting an async equivalent / offloading via ``App.run_in_thread()``.  Flagged
+  in ``async def`` bodies **outside** workflow context — inside workflow methods
+  the same calls are already owned by P020 (sleep) and P021 (network), so they are
+  skipped here to avoid double-reporting.
+
+Remediation is a restructure (await / run_in_thread), so findings route to residue.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from conformance.suite.checks._ast_common import _IgnoreDirective, make_finding
+from conformance.suite.checks.orchestration._temporal_common import (
+    collect_import_bindings,
+)
+from conformance.suite.schema.findings import Finding
+
+from ._workflow_methods import resolve_call_target, workflow_method_nodes
+
+RULE_ID = "P023"
+
+_BRIDGE_EXACT = frozenset({"asyncio.run"})
+_BRIDGE_ATTR = "run_until_complete"
+_BLOCKING_EXACT = frozenset({"time.sleep"})
+_BLOCKING_PREFIXES = ("requests.", "urllib.request.")
+
+_BRIDGE_HINT = (
+    "Running an event loop from inside an async function re-enters the loop and "
+    "deadlocks/raises. Await the coroutine directly instead."
+)
+_BLOCKING_HINT = (
+    "This blocks the event loop. Await an async equivalent, or offload it with "
+    "App.run_in_thread() inside a @task."
+)
+
+
+class _Visitor(ast.NodeVisitor):
+    def __init__(
+        self,
+        filename: str,
+        directives: dict[int, _IgnoreDirective],
+        bindings: dict[str, str],
+        workflow_ids: frozenset[int],
+    ) -> None:
+        self.filename = filename
+        self.directives = directives
+        self.bindings = bindings
+        self.workflow_ids = workflow_ids
+        self._async_stack: list[bool] = []
+        self._wf_depth = 0
+        self.findings: list[Finding] = []
+
+    def _visit_func(self, node: ast.AST, is_async: bool) -> None:
+        in_wf = id(node) in self.workflow_ids
+        self._async_stack.append(is_async)
+        if in_wf:
+            self._wf_depth += 1
+        self.generic_visit(node)
+        if in_wf:
+            self._wf_depth -= 1
+        self._async_stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_func(node, is_async=False)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_func(node, is_async=True)
+
+    def _in_async(self) -> bool:
+        return bool(self._async_stack) and self._async_stack[-1]
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if self._in_async():
+            self._check_call(node)
+        self.generic_visit(node)
+
+    def _check_call(self, node: ast.Call) -> None:
+        # Event-loop re-entry bridge — flagged everywhere, incl. workflow context.
+        if isinstance(node.func, ast.Attribute) and node.func.attr == _BRIDGE_ATTR:
+            self._add(node, f".{_BRIDGE_ATTR}()", _BRIDGE_HINT)
+            return
+        target = resolve_call_target(node.func, self.bindings)
+        if target is None:
+            return
+        if target in _BRIDGE_EXACT:
+            self._add(node, f"{target}()", _BRIDGE_HINT)
+            return
+        # Blocking sync I/O — skip inside workflow context (P020/P021 own it).
+        if self._wf_depth == 0 and (
+            target in _BLOCKING_EXACT
+            or any(target.startswith(p) for p in _BLOCKING_PREFIXES)
+        ):
+            self._add(node, f"{target}()", _BLOCKING_HINT)
+
+    def _add(self, node: ast.Call, label: str, hint: str) -> None:
+        self.findings.append(
+            make_finding(
+                filename=self.filename,
+                rule_id=RULE_ID,
+                node=node,
+                message=f"Blocking call '{label}' in an async function. {hint}",
+                directives=self.directives,
+            )
+        )
+
+
+def check_p023(
+    tree: ast.AST, filename: str, directives: dict[int, _IgnoreDirective]
+) -> list[Finding]:
+    """Emit P023 findings for event-loop bridges and blocking sync I/O in async defs."""
+    bindings = collect_import_bindings(tree)
+    workflow_ids = frozenset(id(n) for n in workflow_method_nodes(tree))
+    visitor = _Visitor(filename, directives, bindings, workflow_ids)
+    visitor.visit(tree)
+    return visitor.findings

--- a/packages/conformance/conformance/suite/checks/determinism/_p024_sync_atlan_client.py
+++ b/packages/conformance/conformance/suite/checks/determinism/_p024_sync_atlan_client.py
@@ -1,0 +1,89 @@
+"""P024 — SyncAtlanClientInApp.
+
+``pyatlan`` (atlan-python) is Atlan's client SDK and ships **both** a synchronous
+``AtlanClient`` and an asynchronous ``AsyncAtlanClient`` (``pyatlan.client.aio``).
+App code runs in an async execution path (Temporal activities, the FastAPI
+server), so constructing the **sync** ``AtlanClient`` blocks the event loop on
+every call.  The async client must be used instead — ideally through the SDK seam
+(``application_sdk.credentials.create_async_atlan_client`` /
+``AtlanClientMixin.get_or_create_async_atlan_client``), which returns a configured,
+observability-stamped ``AsyncAtlanClient``.
+
+This complements the client-seam rule P019: P019 says "don't hand-roll
+raw HTTP — use pyatlan"; P024 says "when you use pyatlan, use the *async* client."
+P019 deliberately does not flag client construction (reuse is good); P024 narrows
+that to the sync variant only.
+
+Detection is receiver-anchored via :func:`resolve_call_target`: a call whose
+callable resolves to a ``pyatlan`` (or vendored ``pyatlan_v9``) ``AtlanClient`` —
+the constructor or a factory like ``AtlanClient.from_token(...)`` — is flagged,
+while ``AsyncAtlanClient`` and the SDK seam helpers are left untouched.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from conformance.suite.checks._ast_common import _IgnoreDirective, make_finding
+from conformance.suite.checks.orchestration._temporal_common import (
+    collect_import_bindings,
+)
+from conformance.suite.schema.findings import Finding
+
+from ._workflow_methods import resolve_call_target
+
+RULE_ID = "P024"
+
+# pyatlan is the dependency; pyatlan_v9 is the SDK's vendored alias of v9.
+_PYATLAN_ROOTS = frozenset({"pyatlan", "pyatlan_v9"})
+_SYNC_CLIENT = "AtlanClient"
+_ASYNC_CLIENT = "AsyncAtlanClient"
+
+_HINT = (
+    "pyatlan ships an async client; the sync AtlanClient blocks the event loop in "
+    "the app's async execution path. Use AsyncAtlanClient — ideally via the SDK "
+    "seam 'await self.get_or_create_async_atlan_client(cred)' (AtlanClientMixin) "
+    "or 'create_async_atlan_client(cred)' from application_sdk.credentials."
+)
+
+
+def _is_sync_atlan_client(target: str) -> bool:
+    """True if *target* resolves to a pyatlan **sync** ``AtlanClient`` callable.
+
+    Matches the constructor and its classmethod factories (``AtlanClient`` /
+    ``AtlanClient.from_token`` / …) under a ``pyatlan`` root, while excluding
+    ``AsyncAtlanClient`` (whose segment is a distinct name).
+    """
+    segs = target.split(".")
+    return (
+        segs[0] in _PYATLAN_ROOTS and _SYNC_CLIENT in segs and _ASYNC_CLIENT not in segs
+    )
+
+
+def check_p024(
+    tree: ast.AST, filename: str, directives: dict[int, _IgnoreDirective]
+) -> list[Finding]:
+    """Emit P024 findings for sync pyatlan ``AtlanClient`` construction/use."""
+    bindings = collect_import_bindings(tree)
+    # Only worth resolving calls if a pyatlan AtlanClient name is actually bound.
+    if not any(
+        _is_sync_atlan_client(origin) for origin in bindings.values()
+    ) and not any(root in _PYATLAN_ROOTS for root in bindings.values()):
+        return []
+    findings: list[Finding] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        target = resolve_call_target(node.func, bindings)
+        if target is None or not _is_sync_atlan_client(target):
+            continue
+        findings.append(
+            make_finding(
+                filename=filename,
+                rule_id=RULE_ID,
+                node=node,
+                message=f"Synchronous pyatlan '{_SYNC_CLIENT}' used in app code. {_HINT}",
+                directives=directives,
+            )
+        )
+    return findings

--- a/packages/conformance/conformance/suite/checks/determinism/_workflow_methods.py
+++ b/packages/conformance/conformance/suite/checks/determinism/_workflow_methods.py
@@ -1,0 +1,174 @@
+"""Shared discovery for the determinism / async-correctness rules (P020–P024).
+
+Determinism rules apply **only** to code that runs in the Temporal *workflow replay
+context* — never to ``@task`` activity bodies (which run once and may do I/O,
+sleep, randomness).  The SDK draws this line statically and unambiguously on every
+``App`` subclass (``application_sdk/app/base.py``):
+
+* ``async def run`` → becomes ``@workflow.run`` (workflow context).
+* ``@entrypoint`` methods → one Temporal workflow each (workflow context).
+* ``@signal`` / ``@query`` / ``@update`` methods → relayed handlers (workflow context).
+* ``@task`` methods → Temporal activities (run-once; **never** flagged).
+* undecorated helpers → ambiguous (call-graph dependent); a documented
+  false-negative — see the module docstring of :mod:`...determinism`.
+
+This module provides the two load-bearing primitives the detectors share:
+
+* :func:`workflow_method_nodes` — the precise set of workflow-context function
+  nodes in a module, classified alias-aware via the shared decorator-provenance
+  helpers (so ``@task as t`` / ``@app.task`` are still recognised as activities).
+* :func:`resolve_call_target` — receiver-anchored resolution of a call's callable
+  to a fully-qualified dotted origin (``datetime.datetime.now``, ``time.time``,
+  ``random.randint``), so a detector matches the *real* target rather than a bare
+  method name.  This is what leaves the sanctioned ``self.now()`` / ``self.uuid()``
+  / ``application_sdk.app.now`` untouched.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from conformance.suite.checks.prescriptions._decorator_provenance import (
+    ImportProvenance,
+    collect_import_provenance,
+    is_entrypoint_decorator,
+    is_interaction_decorator,
+    is_task_decorator,
+)
+
+_SDK_PREFIX = "application_sdk"
+
+
+# ── App-subclass discovery ───────────────────────────────────────────────────
+
+
+def _sdk_app_aliases(tree: ast.AST) -> frozenset[str]:
+    """Return local names bound to the SDK ``App`` class in this module.
+
+    Mirrors ``entrypoint_alignment._code_entrypoints._sdk_app_aliases`` so a
+    ``from application_sdk.app import App as Base`` import still anchors discovery.
+    """
+    bound: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or node.level > 0:
+            continue
+        module = node.module or ""
+        if module == _SDK_PREFIX or module.startswith(_SDK_PREFIX + "."):
+            for alias in node.names:
+                if alias.name == "App":
+                    bound.add(alias.asname or alias.name)
+    return frozenset(bound)
+
+
+def _is_app_subclass(node: ast.ClassDef, app_aliases: frozenset[str]) -> bool:
+    """True if *node* directly subclasses the SDK ``App`` class (by alias name)."""
+    for base in node.bases:
+        if isinstance(base, ast.Name) and base.id in app_aliases:
+            return True
+        if isinstance(base, ast.Attribute) and base.attr in app_aliases:
+            return True
+    return False
+
+
+def _is_workflow_method(
+    method: ast.FunctionDef | ast.AsyncFunctionDef, prov: ImportProvenance
+) -> bool:
+    """Classify a method on an ``App`` subclass as workflow-context or not.
+
+    ``@task`` (activity) always wins — a method decorated with both ``@task`` and
+    anything else is an activity and must never be flagged.  Otherwise a method is
+    workflow-context when it is ``run`` or carries ``@entrypoint`` /
+    ``@signal`` / ``@query`` / ``@update``.
+    """
+    decorators = method.decorator_list
+    if any(is_task_decorator(dec, prov) for dec in decorators):
+        return False
+    if method.name == "run":
+        return True
+    return any(
+        is_entrypoint_decorator(dec, prov) or is_interaction_decorator(dec, prov)
+        for dec in decorators
+    )
+
+
+def workflow_method_nodes(
+    tree: ast.AST,
+) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Return every workflow-context method defined on an ``App`` subclass.
+
+    Only methods declared *directly* in an ``App`` subclass body are classified;
+    nested functions inside a workflow method are covered transitively because the
+    detectors ``ast.walk`` each returned node.  Returns ``[]`` when the module does
+    not import the SDK ``App`` (nothing to anchor on).
+    """
+    app_aliases = _sdk_app_aliases(tree)
+    if not app_aliases:
+        return []
+    prov = collect_import_provenance(tree)
+    methods: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.ClassDef) and _is_app_subclass(node, app_aliases)):
+            continue
+        for member in node.body:
+            if isinstance(
+                member, (ast.FunctionDef, ast.AsyncFunctionDef)
+            ) and _is_workflow_method(member, prov):
+                methods.append(member)
+    return methods
+
+
+def async_method_names(tree: ast.AST) -> frozenset[str]:
+    """Return the names of every ``async def`` method across all ``App`` subclasses.
+
+    Used by P022 to recognise a bare ``self.<name>(...)`` call as a dropped
+    coroutine: any ``async def`` method (a ``@task``, ``run``, an ``@entrypoint``,
+    or a plain async helper) returns a coroutine, so calling it without ``await``
+    (and not wrapping it in ``create_task``/``gather``) silently drops the work.
+    """
+    app_aliases = _sdk_app_aliases(tree)
+    if not app_aliases:
+        return frozenset()
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.ClassDef) and _is_app_subclass(node, app_aliases)):
+            continue
+        for member in node.body:
+            if isinstance(member, ast.AsyncFunctionDef):
+                names.add(member.name)
+    return frozenset(names)
+
+
+# ── Receiver-anchored call-target resolution ─────────────────────────────────
+
+
+def resolve_call_target(func: ast.expr, bindings: dict[str, str]) -> str | None:
+    """Resolve a call's callable expression to a fully-qualified dotted origin.
+
+    Walks an attribute chain down to its root ``Name`` and rewrites that root via
+    the module's import bindings (``collect_import_bindings``):
+
+    * ``import datetime;            datetime.datetime.now()`` → ``datetime.datetime.now``
+    * ``from datetime import datetime; datetime.now()``       → ``datetime.datetime.now``
+    * ``import time;                time.time()``             → ``time.time``
+    * ``from time import time;      time()``                  → ``time.time``
+    * ``self.now()``                                          → ``self.now`` (unbound root)
+    * ``open(...)``                                           → ``open``
+
+    Returns ``None`` when the root is not a plain ``Name`` (e.g. a call on a
+    subscript or another call result) — such targets cannot be matched reliably.
+    """
+    attrs: list[str] = []
+    cur: ast.expr = func
+    while isinstance(cur, ast.Attribute):
+        attrs.append(cur.attr)
+        cur = cur.value
+    if not isinstance(cur, ast.Name):
+        return None
+    attrs.append(cur.id)
+    attrs.reverse()  # [root, attr1, attr2, ...]
+    root = attrs[0]
+    origin = bindings.get(root)
+    if origin is None:
+        # Unbound root: a local variable, ``self``, or a builtin (``open``).
+        return ".".join(attrs)
+    return ".".join([origin, *attrs[1:]])

--- a/packages/conformance/conformance/suite/checks/prescriptions/_decorator_provenance.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_decorator_provenance.py
@@ -1,10 +1,14 @@
-"""Shared decorator-provenance helpers for P008, P013, and P014.
+"""Shared decorator-provenance helpers for P008, P013, P014, and the determinism
+series (P020–P024).
 
 Both ``_framework_transfer`` (P008) and ``_typed_boundaries`` (P013/P014) need
 to gate on import provenance to distinguish the SDK's ``@task``/``@entrypoint``
 from third-party decorators with the same local name (e.g. ``@celery.task``,
-``@flask.entrypoint``).  This module centralises that logic so a single change
-propagates to every consumer.
+``@flask.entrypoint``).  The determinism checks (``suite.checks.determinism``,
+P020–P024) consume the same helpers — plus :func:`is_interaction_decorator` and
+the ``sdk``/``non_sdk_interaction_names`` provenance — to classify an ``App``
+subclass's workflow-context methods.  This module centralises that logic so a
+single change propagates to every consumer.
 
 Provenance model
 ----------------
@@ -58,6 +62,17 @@ class ImportProvenance:
     Tracks ``from application_sdk.app import entrypoint as ep`` → ``{"ep"}``.
     """
 
+    sdk_interaction_names: frozenset[str]
+    """Local names bound to ``signal`` / ``query`` / ``update`` from an SDK import.
+
+    Tracks ``from application_sdk.app import signal, query as q`` → ``{"signal", "q"}``.
+    Used by :func:`is_interaction_decorator` to recognise the SDK's workflow-context
+    runtime-interaction decorators (which run in the deterministic replay context).
+    """
+
+    non_sdk_interaction_names: frozenset[str]
+    """Local names bound to ``signal`` / ``query`` / ``update`` from a *non*-SDK import."""
+
     sdk_contract_names: frozenset[str]
     """Local names imported from ``application_sdk.contracts.*`` — valid by provenance."""
 
@@ -72,8 +87,12 @@ def collect_import_provenance(tree: ast.AST) -> ImportProvenance:
     non_sdk_mods: set[str] = set()
     sdk_task: set[str] = set()
     sdk_ep: set[str] = set()
+    sdk_interaction: set[str] = set()
+    non_sdk_interaction: set[str] = set()
     sdk_contracts: set[str] = set()
     sdk_contract_mod_aliases: set[str] = set()
+
+    _INTERACTION_NAMES = {"signal", "query", "update"}
 
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
@@ -88,12 +107,16 @@ def collect_import_provenance(tree: ast.AST) -> ImportProvenance:
                         sdk_task.add(local)
                     if alias.name == "entrypoint":
                         sdk_ep.add(local)
+                    if alias.name in _INTERACTION_NAMES:
+                        sdk_interaction.add(local)
             else:
                 for alias in node.names:
                     if alias.name == "task":
                         non_sdk_task.add(alias.asname or alias.name)
                     if alias.name == "entrypoint":
                         non_sdk_ep.add(alias.asname or alias.name)
+                    if alias.name in _INTERACTION_NAMES:
+                        non_sdk_interaction.add(alias.asname or alias.name)
             # SDK contract provenance from `from application_sdk.contracts import X`
             if is_sdk and any(
                 module == prefix or module.startswith(prefix + ".")
@@ -123,6 +146,8 @@ def collect_import_provenance(tree: ast.AST) -> ImportProvenance:
         non_sdk_module_names=frozenset(non_sdk_mods),
         sdk_task_names=frozenset(sdk_task),
         sdk_ep_names=frozenset(sdk_ep),
+        sdk_interaction_names=frozenset(sdk_interaction),
+        non_sdk_interaction_names=frozenset(non_sdk_interaction),
         sdk_contract_names=frozenset(sdk_contracts),
         sdk_contract_module_aliases=frozenset(sdk_contract_mod_aliases),
     )
@@ -166,6 +191,41 @@ def is_entrypoint_decorator(dec: ast.expr, prov: ImportProvenance) -> bool:
         return dec.id == "entrypoint" and dec.id not in prov.non_sdk_ep_names
     if isinstance(dec, ast.Attribute):
         return dec.attr == "entrypoint" and (
+            not isinstance(dec.value, ast.Name)
+            or dec.value.id not in prov.non_sdk_module_names
+        )
+    return False
+
+
+_INTERACTION_DECORATOR_NAMES = frozenset({"signal", "query", "update"})
+
+
+def is_interaction_decorator(dec: ast.expr, prov: ImportProvenance) -> bool:
+    """True if *dec* is an SDK ``@signal`` / ``@query`` / ``@update`` decorator.
+
+    These declare workflow-context runtime interactions on an ``App`` subclass —
+    they are relayed into the generated ``@workflow.defn`` class and therefore run
+    in the deterministic replay context.  Recognises the canonical
+    names, SDK aliases (``from application_sdk.app import query as q`` → ``@q``),
+    and ``@workflow.signal`` style attribute access, while excluding third-party
+    decorators that merely share a name (``@strawberry.field`` style is unaffected;
+    a non-SDK ``from foo import query`` is not flagged).
+    """
+    if isinstance(dec, ast.Call):
+        dec = dec.func
+    if isinstance(dec, ast.Name):
+        if dec.id in prov.sdk_interaction_names:
+            return True
+        # Bare name — assume SDK unless shadowed by a non-SDK import.
+        return (
+            dec.id in _INTERACTION_DECORATOR_NAMES
+            and dec.id not in prov.non_sdk_interaction_names
+        )
+    if isinstance(dec, ast.Attribute):
+        # e.g. @workflow.signal — attribute access through a module is the SDK/
+        # Temporal seam; a non-SDK module alias (import celery; @celery.update)
+        # is excluded.
+        return dec.attr in _INTERACTION_DECORATOR_NAMES and (
             not isinstance(dec.value, ast.Name)
             or dec.value.id not in prov.non_sdk_module_names
         )

--- a/packages/conformance/conformance/suite/rules/__init__.py
+++ b/packages/conformance/conformance/suite/rules/__init__.py
@@ -13,6 +13,7 @@ from conformance.suite.rules.ci import RULES as _CI_RULES
 from conformance.suite.rules.client_seam import RULES as _CLIENT_SEAM_RULES
 from conformance.suite.rules.dependency import RULES as _D_RULES
 from conformance.suite.rules.deprecation import RULES as _B_RULES
+from conformance.suite.rules.determinism import RULES as _DETERMINISM_RULES
 from conformance.suite.rules.dockerfile import RULES as _I_RULES
 from conformance.suite.rules.entrypoint import RULES as _ENTRYPOINT_RULES
 from conformance.suite.rules.entrypoint_alignment import RULES as _EP_ALIGNMENT_RULES
@@ -46,6 +47,7 @@ _ALL_SERIES: tuple[tuple[RuleDefinition, ...], ...] = (
     _O_RULES,
     _P_RULES,
     _ORCHESTRATION_RULES,
+    _DETERMINISM_RULES,
     _ENTRYPOINT_RULES,
     _STORAGE_RULES,
     _CLIENT_SEAM_RULES,

--- a/packages/conformance/conformance/suite/rules/determinism.py
+++ b/packages/conformance/conformance/suite/rules/determinism.py
@@ -1,0 +1,230 @@
+"""Determinism / async-correctness rule definitions (P020–P024).
+
+App and SDK code must respect the SDK's async and determinism expectations in the
+execution path.  Temporal **workflow** code (an ``App`` subclass's ``run`` /
+``@entrypoint`` / ``@signal`` / ``@query`` / ``@update`` methods) is replayed
+deterministically and must not read wall-clock time, generate randomness, sleep on
+the wall clock, or perform I/O; those belong in a ``@task`` **activity**.  Async
+SDK methods must be awaited, not called like sync functions or bridged through a
+nested event loop.  These bugs are invisible in normal runs and only surface as
+non-deterministic replay failures or event-loop errors under production
+orchestration.
+
+These are P-series (prescription) rules backed by a **separate**
+``suite.checks.determinism`` check registration.  Multiple check modules under one
+series letter is the established pattern (the orchestration P004–P007 rules and the
+prescriptions P001–P003 rules already coexist under ``P``), so this rides the
+existing ``P`` CI matrix leg with no new plumbing.
+
+Scope
+-----
+All five rules are ``both``-scoped: workflow-context code and async SDK usage exist
+in the SDK itself and in every consumer app.
+"""
+
+from __future__ import annotations
+
+from conformance.suite.schema.catalog import RuleDefinition
+from conformance.suite.schema.disposition import (
+    EnforcementTier,
+    RuleMechanism,
+    RuleScope,
+)
+
+_HELP_BASE = (
+    "https://github.com/atlanhq/application-sdk/blob/main/packages/conformance/"
+    "conformance/docs/rules/prescriptions.md"
+)
+
+RULES: tuple[RuleDefinition, ...] = (
+    RuleDefinition(
+        id="P020",
+        scope=RuleScope.BOTH,
+        name="NonDeterministicPrimitiveInWorkflow",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="determinism",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.8.0",
+        rationale=(
+            "Temporal workflow code is re-executed on replay, so it must be "
+            "deterministic: the same inputs must always produce the same sequence "
+            "of commands. Reading the wall clock (datetime.now/time.time), "
+            "generating a UUID (uuid.uuid4), sleeping on the wall clock "
+            "(time.sleep/asyncio.sleep), or drawing randomness produces a different "
+            "value on replay and corrupts the workflow history. The SDK exposes "
+            "deterministic equivalents through its seam — self.now()/now, "
+            "self.uuid()/uuid4, sleep — that record their result in history so "
+            "replay is faithful."
+        ),
+        short_description=(
+            "Non-deterministic time/uuid/sleep/random call in workflow-context code"
+        ),
+        full_description=(
+            "Inside an ``App`` subclass's workflow-context method (``run``, an\n"
+            "``@entrypoint`` method, or a ``@signal`` / ``@query`` / ``@update``\n"
+            "handler) a call reads wall-clock time, generates a UUID, sleeps, or\n"
+            "draws randomness.  Workflow code is replayed deterministically, so use\n"
+            "the SDK seam instead: ``self.now()`` or ``from application_sdk.app\n"
+            "import now``; ``self.uuid()`` or ``from application_sdk.app import\n"
+            "uuid4``; ``from application_sdk.app import sleep``.  ``@task`` activity\n"
+            "bodies are exempt — they run once and may do any of this.\n"
+            "\n"
+            "Randomness (``random`` / ``secrets`` / ``os.urandom``) is also flagged:\n"
+            "it is a real determinism bug, but the SDK exposes no deterministic-random\n"
+            "primitive, so the fix is to move it into a ``@task`` or raise a seam\n"
+            "request with the SDK team rather than a mechanical swap.\n"
+            "\n"
+            "Matching is receiver-anchored: only a ``.now()`` whose receiver is\n"
+            "``datetime`` is flagged, so the sanctioned ``self.now()`` is untouched.\n"
+            "Land as ``WARN``; record an unavoidable exception with\n"
+            "``# conformance: ignore[P020] <reason>``.\n"
+        ),
+        help_uri=f"{_HELP_BASE}#p020",
+    ),
+    RuleDefinition(
+        id="P021",
+        scope=RuleScope.BOTH,
+        name="SideEffectIoInWorkflow",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="determinism",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.8.0",
+        rationale=(
+            "Workflow code is replayed, so any interaction with the outside world — "
+            "opening a file, making a network call, reading the environment, "
+            "spawning a thread or process — runs again on every replay and produces "
+            "non-deterministic, un-recorded results that break replay correctness. "
+            "Side effects belong in a @task activity, which runs exactly once and "
+            "whose result is durably recorded in workflow history."
+        ),
+        short_description="File / network / env / process I/O in workflow-context code",
+        full_description=(
+            "Inside an ``App`` subclass's workflow-context method a call performs\n"
+            "side-effecting I/O — ``open``, ``requests``/``httpx``/``urllib``,\n"
+            "``socket``, ``subprocess``, ``threading``/``multiprocessing``,\n"
+            "``os.getenv`` / ``os.environ[...]``.  Move it into a ``@task`` method:\n"
+            "workflow code must be deterministic, and activities are where I/O and\n"
+            "external state belong.\n"
+            "\n"
+            "The detected surface is a curated high-signal subset, not an exhaustive\n"
+            "list of every I/O API.  Remediation is structural (extract a ``@task``),\n"
+            "so findings route to residue rather than an autofix.  Land as ``WARN``;\n"
+            "suppress a reviewed exception with ``# conformance: ignore[P021]\n"
+            "<reason>``.\n"
+        ),
+        help_uri=f"{_HELP_BASE}#p021",
+    ),
+    RuleDefinition(
+        id="P022",
+        scope=RuleScope.BOTH,
+        name="UnawaitedCoroutine",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="async-correctness",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.8.0",
+        rationale=(
+            "SDK app methods (run, @task, @entrypoint, interaction handlers) are "
+            "async and return a coroutine. Calling one like a sync function — "
+            "'self.fetch(x)' as a bare statement instead of 'await self.fetch(x)' — "
+            "constructs the coroutine and immediately discards it, so the work never "
+            "runs and the bug is silent (no error, no result). This is the most "
+            "common way apps misuse the SDK's async surface."
+        ),
+        short_description="A same-class async method is called without await (dropped coroutine)",
+        full_description=(
+            "A bare expression statement calls a same-class ``async def`` method via\n"
+            "``self.<name>(...)`` without ``await`` and without wrapping it in\n"
+            "``asyncio.create_task`` / ``asyncio.gather``.  The call returns a\n"
+            "coroutine that is never scheduled, so the work silently does nothing.\n"
+            "Add ``await`` (or schedule it explicitly if concurrency is intended).\n"
+            "\n"
+            "Scope is intentionally narrow — a bare ``self.<async-method>()``\n"
+            "statement inside an ``async def`` — so the target is provably a\n"
+            "coroutine and the finding is false-positive-free.  Land as ``WARN``;\n"
+            "suppress with ``# conformance: ignore[P022] <reason>``.\n"
+        ),
+        help_uri=f"{_HELP_BASE}#p022",
+    ),
+    RuleDefinition(
+        id="P023",
+        scope=RuleScope.BOTH,
+        name="BlockingCallInAsyncDef",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="async-correctness",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.8.0",
+        rationale=(
+            "Inside an async function the event loop must never be blocked or "
+            "re-entered. Calling asyncio.run()/loop.run_until_complete() from within "
+            "a running loop raises or deadlocks; calling a synchronous blocking "
+            "library (requests, time.sleep) stalls the loop and every other "
+            "coroutine on it. The correct pattern is to await an async equivalent, "
+            "or offload blocking work via App.run_in_thread() inside a @task — not "
+            "to bridge async with a sync workaround."
+        ),
+        short_description="Event-loop re-entry bridge or blocking sync call inside an async def",
+        full_description=(
+            "Inside an ``async def``, code either re-enters the event loop\n"
+            "(``asyncio.run(...)`` or ``*.run_until_complete(...)``, including\n"
+            "``loop.run_until_complete`` / ``asyncio.get_event_loop()....``) or makes\n"
+            "a blocking synchronous call (``requests.*``, ``urllib.request.*``,\n"
+            "``time.sleep``).  Await the coroutine directly, or offload genuinely\n"
+            "blocking work with ``App.run_in_thread()`` inside a ``@task``.\n"
+            "\n"
+            "Blocking sync I/O is reported only **outside** workflow context — inside\n"
+            "workflow methods the same calls are owned by P020 (sleep) and P021\n"
+            "(network), so they are not double-counted.  Remediation is a restructure,\n"
+            "so findings route to residue.  Land as ``WARN``; suppress with\n"
+            "``# conformance: ignore[P023] <reason>``.\n"
+        ),
+        help_uri=f"{_HELP_BASE}#p023",
+    ),
+    RuleDefinition(
+        id="P024",
+        scope=RuleScope.BOTH,
+        name="SyncAtlanClientInApp",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="async-correctness",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.8.0",
+        rationale=(
+            "pyatlan (atlan-python) ships both a synchronous AtlanClient and an "
+            "asynchronous AsyncAtlanClient. App code runs in an async execution path "
+            "(Temporal activities, the FastAPI server), so the sync client blocks the "
+            "event loop on every Atlan call and stalls every other coroutine on it. "
+            "The async client must be used instead — ideally through the SDK seam "
+            "(create_async_atlan_client / AtlanClientMixin.get_or_create_async_atlan_client), "
+            "which returns a configured, observability-stamped AsyncAtlanClient. This "
+            "complements P019 (use pyatlan, not raw HTTP) by requiring the async "
+            "variant of that client."
+        ),
+        short_description="Synchronous pyatlan AtlanClient used instead of the async client",
+        full_description=(
+            "App code constructs or invokes pyatlan's synchronous ``AtlanClient`` (or\n"
+            "the vendored ``pyatlan_v9`` equivalent) — its constructor or a factory\n"
+            "like ``AtlanClient.from_token(...)``.  Because the app's execution path is\n"
+            "async, the sync client blocks the event loop.  Use\n"
+            "``AsyncAtlanClient`` (``pyatlan.client.aio``) — preferably via the SDK\n"
+            "seam: ``await self.get_or_create_async_atlan_client(cred)`` on an\n"
+            "``App`` that mixes in ``AtlanClientMixin``, or\n"
+            "``create_async_atlan_client(cred)`` from ``application_sdk.credentials``.\n"
+            "\n"
+            "Matching is receiver-anchored: ``AsyncAtlanClient`` and the SDK seam\n"
+            "helpers are not flagged, only the sync ``AtlanClient`` under a pyatlan\n"
+            "root.  Closing it makes downstream calls ``await``-ed, so remediation is a\n"
+            "restructure routed to residue.  Land as ``WARN``; suppress with\n"
+            "``# conformance: ignore[P024] <reason>``.\n"
+        ),
+        help_uri=f"{_HELP_BASE}#p024",
+    ),
+)

--- a/packages/conformance/conformance/suite/runner.py
+++ b/packages/conformance/conformance/suite/runner.py
@@ -30,6 +30,7 @@ from conformance.suite.checks import (
     client_seam,
     dependency_conformance,
     deprecation,
+    determinism,
     dockerfile_conformance,
     entrypoint_alignment,
     error_handling,
@@ -110,6 +111,11 @@ _CHECKS: list[CheckRegistration] = [
         discover=orchestration.discover,
         scan_path=orchestration.scan_path,
         scan_all=orchestration.scan_all,
+    ),
+    CheckRegistration(
+        series=determinism.SERIES,
+        discover=determinism.discover,
+        scan_path=determinism.scan_path,
     ),
     CheckRegistration(
         series=entrypoint.SERIES,

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -263,7 +263,7 @@ def test_catalog_d_series_present() -> None:
 
 
 def test_catalog_p_series_present() -> None:
-    """The P-series prescription rules are exactly P001–P019.
+    """The P-series prescription rules are exactly P001–P024.
 
     Strict equality (not just not-missing): P004–P007 are the orchestration-seam
     rules (BLDX-1417); P008–P012 are the storage-seam rules (BLDX-1398);
@@ -271,7 +271,10 @@ def test_catalog_p_series_present() -> None:
     P016 is the entry-point contract/code alignment rule (BLDX-1425);
     P017–P018 are the entrypoint-conformance rules (BLDX-1411);
     P019 is the client-seam rule — raw HTTP to Atlan instead of pyatlan
-    (BLDX-1430).  A stray or renumbered P-id would slip past a subset check while
+    (BLDX-1430).  P020–P024 are the determinism / async-correctness rules:
+    non-deterministic primitives, side-effect I/O, un-awaited coroutines,
+    blocking calls in async defs, and pyatlan sync ``AtlanClient`` use.
+    A stray or renumbered P-id would slip past a subset check while
     breaking fleet-wide ``# conformance: ignore[Pxxx]`` suppressions.
     """
     rules = load_catalog()
@@ -296,6 +299,11 @@ def test_catalog_p_series_present() -> None:
         "P017",
         "P018",
         "P019",
+        "P020",
+        "P021",
+        "P022",
+        "P023",
+        "P024",
     }
     missing = expected - p_ids
     assert not missing, f"Missing P-series rules: {missing}"

--- a/packages/conformance/tests/test_determinism.py
+++ b/packages/conformance/tests/test_determinism.py
@@ -1,0 +1,334 @@
+"""Meta-tests for the P-series determinism / async-correctness checks (P020–P024).
+
+Each rule is tested to fire *exactly* when it should and stay silent otherwise —
+both false positives and false negatives are guarded.  The load-bearing properties
+get dedicated tests: ``@task`` activity bodies are never flagged, the sanctioned
+SDK seam (``self.now()`` / ``self.uuid()`` / ``now`` / ``sleep``) is left untouched
+(receiver-anchored matching), decorator classification is alias-aware, and the
+P020/P023 dedup holds (a workflow-context blocking call is P020, not also P023).
+"""
+
+from __future__ import annotations
+
+from conformance.suite.checks.determinism import SERIES, scan_text
+from conformance.suite.rules import CATALOG
+from conformance.suite.schema.disposition import RuleScope
+
+_HEADER = (
+    "from application_sdk.app import App, task, entrypoint, signal, query, update\n"
+)
+
+
+def _rule(body: str, rule_id: str, *, header: str = _HEADER) -> list:
+    """Findings of *rule_id* from scanning a module with *body* appended to *header*."""
+    return [f for f in scan_text(header + body, "app/x.py") if f.rule_id == rule_id]
+
+
+def _wrap_run(stmts: str) -> str:
+    """An ``App`` subclass whose async ``run`` body is *stmts* (4-space indented)."""
+    indented = "\n".join("        " + line for line in stmts.strip("\n").splitlines())
+    return f"class MyApp(App):\n    async def run(self, input):\n{indented}\n"
+
+
+# ── series wiring ─────────────────────────────────────────────────────────────
+
+
+def test_series_letter() -> None:
+    assert SERIES == "P"
+
+
+# ── P020 NonDeterministicPrimitiveInWorkflow ─────────────────────────────────
+
+
+def test_p020_flags_datetime_now() -> None:
+    src = "import datetime\n" + _wrap_run("x = datetime.datetime.now()")
+    assert len(_rule(src, "P020")) == 1
+
+
+def test_p020_flags_time_time() -> None:
+    src = "import time\n" + _wrap_run("x = time.time()")
+    assert len(_rule(src, "P020")) == 1
+
+
+def test_p020_flags_uuid4() -> None:
+    src = "import uuid\n" + _wrap_run("x = uuid.uuid4()")
+    assert len(_rule(src, "P020")) == 1
+
+
+def test_p020_flags_time_sleep_and_asyncio_sleep() -> None:
+    src = "import time, asyncio\n" + _wrap_run("time.sleep(1)\nawait asyncio.sleep(2)")
+    assert len(_rule(src, "P020")) == 2
+
+
+def test_p020_flags_random() -> None:
+    src = "import random\n" + _wrap_run("x = random.randint(0, 9)")
+    assert len(_rule(src, "P020")) == 1
+
+
+def test_p020_flags_in_entrypoint_and_interaction_handlers() -> None:
+    body = (
+        "import datetime\n"
+        "class MyApp(App):\n"
+        "    @entrypoint\n"
+        "    async def go(self, input):\n"
+        "        return datetime.datetime.now()\n"
+        "    @signal\n"
+        "    async def ping(self):\n"
+        "        self.t = datetime.datetime.utcnow()\n"
+    )
+    assert len(_rule(body, "P020")) == 2
+
+
+def test_p020_alias_aware_interaction_decorator() -> None:
+    body = (
+        "import datetime\n"
+        "from application_sdk.app import App, query as q\n"
+        "class MyApp(App):\n"
+        "    @q\n"
+        "    def status(self):\n"
+        "        return datetime.datetime.now()\n"
+    )
+    assert len(_rule(body, "P020", header="")) == 1
+
+
+def test_p020_silent_on_sanctioned_self_helpers() -> None:
+    src = _wrap_run("a = self.now()\nb = self.uuid()")
+    assert _rule(src, "P020") == []
+
+
+def test_p020_silent_on_sanctioned_seam_imports() -> None:
+    body = (
+        "from application_sdk.app import App, now, uuid4, sleep\n"
+        "class MyApp(App):\n"
+        "    async def run(self, input):\n"
+        "        a = now()\n"
+        "        b = uuid4()\n"
+        "        await sleep(1)\n"
+    )
+    assert _rule(body, "P020", header="") == []
+
+
+def test_p020_silent_in_task_activity() -> None:
+    body = (
+        "import datetime, time\n"
+        "class MyApp(App):\n"
+        "    @task\n"
+        "    async def fetch(self, input):\n"
+        "        time.sleep(1)\n"
+        "        return datetime.datetime.now()\n"
+    )
+    assert _rule(body, "P020") == []
+
+
+def test_p020_silent_outside_app_subclass() -> None:
+    body = "import datetime\nclass Plain:\n    async def run(self, input):\n        return datetime.datetime.now()\n"
+    assert _rule(body, "P020") == []
+
+
+def test_p020_uuid5_is_deterministic_and_silent() -> None:
+    src = "import uuid\n" + _wrap_run("x = uuid.uuid5(uuid.NAMESPACE_DNS, 'a')")
+    assert _rule(src, "P020") == []
+
+
+def test_p020_suppression() -> None:
+    src = "import datetime\n" + _wrap_run(
+        "x = datetime.datetime.now()  # conformance: ignore[P020] tested elsewhere"
+    )
+    findings = _rule(src, "P020")
+    assert len(findings) == 1 and findings[0].suppressed
+
+
+# ── P021 SideEffectIoInWorkflow ──────────────────────────────────────────────
+
+
+def test_p021_flags_requests() -> None:
+    src = "import requests\n" + _wrap_run("r = requests.get('http://x')")
+    assert len(_rule(src, "P021")) == 1
+
+
+def test_p021_flags_open_builtin() -> None:
+    src = _wrap_run("f = open('/tmp/x')")
+    assert len(_rule(src, "P021")) == 1
+
+
+def test_p021_flags_os_environ_subscript() -> None:
+    src = "import os\n" + _wrap_run("v = os.environ['HOME']")
+    assert len(_rule(src, "P021")) == 1
+
+
+def test_p021_flags_thread_spawn() -> None:
+    src = "import threading\n" + _wrap_run("threading.Thread(target=None).start()")
+    assert len(_rule(src, "P021")) >= 1
+
+
+def test_p021_silent_in_task_activity() -> None:
+    body = (
+        "import requests\n"
+        "class MyApp(App):\n"
+        "    @task\n"
+        "    async def fetch(self, input):\n"
+        "        return requests.get('http://x')\n"
+    )
+    assert _rule(body, "P021") == []
+
+
+# ── P022 UnawaitedCoroutine ──────────────────────────────────────────────────
+
+
+def test_p022_flags_bare_self_task_call() -> None:
+    body = (
+        "class MyApp(App):\n"
+        "    @task\n"
+        "    async def fetch(self, input):\n"
+        "        return input\n"
+        "    async def run(self, input):\n"
+        "        self.fetch(input)\n"
+    )
+    assert len(_rule(body, "P022")) == 1
+
+
+def test_p022_silent_when_awaited() -> None:
+    body = (
+        "class MyApp(App):\n"
+        "    @task\n"
+        "    async def fetch(self, input):\n"
+        "        return input\n"
+        "    async def run(self, input):\n"
+        "        return await self.fetch(input)\n"
+    )
+    assert _rule(body, "P022") == []
+
+
+def test_p022_silent_when_wrapped_in_create_task() -> None:
+    body = (
+        "import asyncio\n"
+        "class MyApp(App):\n"
+        "    @task\n"
+        "    async def fetch(self, input):\n"
+        "        return input\n"
+        "    async def run(self, input):\n"
+        "        asyncio.create_task(self.fetch(input))\n"
+    )
+    # The create_task call itself isn't a dropped same-class coroutine.
+    assert _rule(body, "P022") == []
+
+
+# ── P023 BlockingCallInAsyncDef ──────────────────────────────────────────────
+
+
+def test_p023_flags_asyncio_run() -> None:
+    body = (
+        "import asyncio\n"
+        "class MyApp(App):\n"
+        "    @task\n"
+        "    async def fetch(self, input):\n"
+        "        return asyncio.run(other())\n"
+    )
+    assert len(_rule(body, "P023")) == 1
+
+
+def test_p023_flags_run_until_complete() -> None:
+    body = (
+        "class MyApp(App):\n"
+        "    @task\n"
+        "    async def fetch(self, input):\n"
+        "        loop = get_loop()\n"
+        "        return loop.run_until_complete(other())\n"
+    )
+    assert len(_rule(body, "P023")) == 1
+
+
+def test_p023_flags_blocking_io_in_async_activity() -> None:
+    body = (
+        "import requests\n"
+        "class MyApp(App):\n"
+        "    @task\n"
+        "    async def fetch(self, input):\n"
+        "        return requests.get('http://x')\n"
+    )
+    assert len(_rule(body, "P023")) == 1
+
+
+def test_p023_silent_in_sync_def() -> None:
+    body = (
+        "import requests\n"
+        "class MyApp(App):\n"
+        "    @task\n"
+        "    def fetch(self, input):\n"
+        "        return requests.get('http://x')\n"
+    )
+    assert _rule(body, "P023") == []
+
+
+def test_p023_dedup_workflow_sleep_is_p020_not_p023() -> None:
+    src = "import time\n" + _wrap_run("time.sleep(1)")
+    assert len(_rule(src, "P020")) == 1
+    assert _rule(src, "P023") == []
+
+
+# ── P024 SyncAtlanClientInApp ────────────────────────────────────────────────
+
+
+def test_p024_flags_sync_atlanclient_construction() -> None:
+    body = (
+        "from pyatlan.client.atlan import AtlanClient\n"
+        "def make():\n"
+        "    return AtlanClient(base_url='x', api_key='y')\n"
+    )
+    assert len(_rule(body, "P024", header="")) == 1
+
+
+def test_p024_flags_from_token_factory() -> None:
+    body = "from pyatlan.client.atlan import AtlanClient\nc = AtlanClient.from_token('t')\n"
+    assert len(_rule(body, "P024", header="")) == 1
+
+
+def test_p024_flags_attribute_construction() -> None:
+    body = "import pyatlan\nc = pyatlan.client.atlan.AtlanClient(base_url='x')\n"
+    assert len(_rule(body, "P024", header="")) == 1
+
+
+def test_p024_alias_aware() -> None:
+    body = (
+        "from pyatlan.client.atlan import AtlanClient as Client\n"
+        "c = Client(base_url='x')\n"
+    )
+    assert len(_rule(body, "P024", header="")) == 1
+
+
+def test_p024_silent_on_async_client() -> None:
+    body = "from pyatlan.client.aio import AsyncAtlanClient\nc = AsyncAtlanClient(base_url='x')\n"
+    assert _rule(body, "P024", header="") == []
+
+
+def test_p024_silent_on_sdk_seam() -> None:
+    body = (
+        "from application_sdk.credentials import create_async_atlan_client\n"
+        "c = create_async_atlan_client(cred)\n"
+    )
+    assert _rule(body, "P024", header="") == []
+
+
+def test_p024_silent_on_non_pyatlan_same_name() -> None:
+    # A same-named class from an unrelated package must not be flagged.
+    body = "from mypkg import AtlanClient\nc = AtlanClient()\n"
+    assert _rule(body, "P024", header="") == []
+
+
+def test_p024_suppression() -> None:
+    body = (
+        "from pyatlan.client.atlan import AtlanClient\n"
+        "c = AtlanClient()  # conformance: ignore[P024] legacy sync path\n"
+    )
+    findings = _rule(body, "P024", header="")
+    assert len(findings) == 1 and findings[0].suppressed
+
+
+# ── catalog meta-tests ───────────────────────────────────────────────────────
+
+
+def test_new_rules_present_and_scoped_both() -> None:
+    for rid in ("P020", "P021", "P022", "P023", "P024"):
+        assert rid in CATALOG, f"{rid} missing from catalog"
+        assert CATALOG[rid].scope is RuleScope.BOTH
+        assert CATALOG[rid].rationale.strip(), f"{rid} needs a non-empty rationale"


### PR DESCRIPTION
## What

Adds five deterministic **P-series** conformance rules for **async / workflow-determinism correctness** — the correctness counterpart to the orchestration-seam series (P004–P007). Scoped to **both** the SDK and consumer apps, backed by a new `suite.checks.determinism` AST module.

The workflow-determinism rules fire **only** inside Temporal **workflow-context** methods — `run` / `@entrypoint` / `@signal` / `@query` / `@update` on an `App` subclass — and **never** in `@task` activity bodies. Matching is **receiver-anchored** (resolved through import bindings), so the sanctioned `self.now()` / `self.uuid()` / `application_sdk.app` seam imports are left untouched.

| Rule | Catches | Remediation |
|---|---|---|
| **P020** NonDeterministicPrimitiveInWorkflow | wall-clock time, `uuid1`/`uuid4`, `time.sleep`/`asyncio.sleep`, `random`/`secrets`/`os.urandom` — in workflow context | time/uuid/sleep → seam swap; random → residue (no SDK deterministic-random seam) |
| **P021** SideEffectIoInWorkflow | `open`, `requests`/`httpx`/`urllib`/`socket`, `subprocess`, `threading`/`multiprocessing`, `os.getenv`/`os.environ[…]` — in workflow context | structural → residue (move to a `@task`) |
| **P022** UnawaitedCoroutine | a bare `self.<async-method>()` statement dropped without `await` | add `await` → residue |
| **P023** BlockingCallInAsyncDef | `asyncio.run`/`run_until_complete` bridge, or blocking `requests`/`time.sleep` inside any `async def` | restructure / `App.run_in_thread()` → residue |
| **P024** SyncAtlanClientInApp | pyatlan's **sync** `AtlanClient` (constructor / `from_token`) where the **async** `AsyncAtlanClient` is required | use `AsyncAtlanClient` via `create_async_atlan_client` / `AtlanClientMixin.get_or_create_async_atlan_client` → residue |

All land as **WARN**. P023 is deduped against P020/P021 inside workflow methods.

**P024 in context:** the client-seam rule P019 says *"don't hand-roll raw HTTP — use pyatlan"* and deliberately does not flag client construction. P024 refines that: *when you use pyatlan, use the async client* — the sync `AtlanClient` blocks the event loop in the app's async execution path. Receiver-anchored, so `AsyncAtlanClient` and the SDK seam helpers are untouched, and a same-named class from an unrelated package is not flagged.

## Detection + remediation, same PR

- **Detection**: new `suite/rules/determinism.py` + `suite/checks/determinism/` (reuses the alias-aware decorator-provenance helpers — extended with `signal`/`query`/`update` — and the orchestration import-binding resolver). Registered under the existing **P** CI matrix leg (no new plumbing).
- **Remediation**: wired into the suggest-only `prescriptions` area, since `finding.area` derives from the rule-id's letter. P020 time/uuid/sleep get a seam-swap proposal; everything else routes to residue with guidance.

## Verification

- **36 new tests** + full conformance suite green (1254 passed).
- Root **pinned pre-commit** (ruff v0.6.4, ruff-format, isort, pyright) green; rule docs regenerated; `detect --series P` runs end-to-end.
- **Blast radius** on `atlan-openapi-app`: detector recognized `OpenAPIConnector(App)`, scoped to `run`, excluded its three `@task` activities, 0 false positives.

## Notes

- **Scope nuance**: on the SDK today the workflow rules (P020–P022) are effectively no-ops (the SDK authors no concrete `App` workflow subclasses); P023 scans all SDK async code (clean). P024 found 4 intentional sync-`AtlanClient` uses in the shipped `application_sdk/testing/` e2e harnesses (which run outside the async execution path) — each now carries a justified `# conformance: ignore[P024]`, so the dogfooded SDK gate is genuinely clean (0 active, opt-outs visible in SARIF). Kept all five `both` so they fire on future SDK regressions.
- **Helper-method false-negative (documented, intentional)**: a non-deterministic call inside an undecorated helper called from `run()` is not flagged — classifying it needs call-graph analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
