### PR TITLE
feat(conformance): flag legacy transformer usage via B001, steer apps to asset-mapper (BLDX-1399)

### DIFF
--- a/.claude/skills/remediate/SKILL.md
+++ b/.claude/skills/remediate/SKILL.md
@@ -10,20 +10,22 @@ description: >
   source fixes are verified by re-detection; logic fixes are also verified by
   the orthogonal test gate.
 
-  Backed by the OpenProse program in remediation/programs/. Run with the
-  OpenProse skill to use the full Reactor-ready contract semantics; or invoke
-  the program directly via the instructions below.
+  Backed by the OpenProse program shipped in the
+  atlan-application-sdk-conformance package (resolve it with `programs-dir`). Run
+  with the OpenProse skill to use the full Reactor-ready contract semantics; or
+  invoke the program directly via the instructions below.
 
-argument-hint: "[--area error-handling|logging|ci] [--strict] [path]"
+argument-hint: "[--area error-handling|deprecation|dependency|prescriptions|optimizations|dockerfile|tests|logging|ci] [--strict] [path]"
 
 inputs:
   - name: area
     description: >
-      Comma-separated list of areas to remediate.  Defaults to all enabled
-      areas (error-handling; logging and ci are detected but not yet
-      remediable).  Example: --area error-handling
+      Comma-separated list of areas to remediate.  Defaults to every area the
+      top-level program enables (error-handling, deprecation, dependency,
+      prescriptions, optimizations, dockerfile, tests; logging and ci are
+      detected but route to residue).  Example: --area deprecation
     required: false
-    default: "error-handling,logging,ci"
+    default: "error-handling,deprecation,dependency,prescriptions,optimizations,dockerfile,tests,logging,ci"
   - name: strict
     description: >
       When present, also remediates WARNING-tier findings.  Each WARNING is
@@ -76,7 +78,8 @@ Runs an iterative, gated remediation loop over the conformance suite's findings:
    report; collect FAILING (and, with `--strict`, WARNING) findings.
 2. **Fix or suppress** — for each finding, propose an edit (fix or suppression
    directive) guided by the rule's `atlan/hint` and the area prescription in
-   `remediation/programs/areas/<area>.prose.md`.
+   `$PROGRAMS/areas/<area>.prose.md` (where `PROGRAMS=$(uv run
+   atlan-application-sdk-conformance programs-dir)`).
 3. **Re-check (narrowest gate)** — re-run the suite scoped to the touched file;
    confirm the finding's fingerprint is gone.
 4. **Orthogonal gate** — for source-logic fixes, run the test suite; if it
@@ -109,27 +112,47 @@ always scans the whole repo.  Findings outside the prefix are left untouched.
 WARNING is cleared by either a real fix or a justified inline suppression.  Every
 suppression is routed to the residue report for human audit.
 
-## Area status (phase 1)
+## Area status
+
+The live program (`conformance-remediation.prose.md`, resolved from the installed
+package via `programs-dir`) fans out to every area below; `remediate-finding`
+dispatches each finding to its area prescription.
 
 | Area | Series | Remediation | Notes |
 |---|---|---|---|
 | error-handling | E | ✅ Implemented | Mechanical (E005, E016) auto-fixed; judgment (E002, E013, others) modelled + routed to residue |
+| deprecation | B | ✅ Implemented | B001 guided fix (incl. legacy transformer → asset-mapper, BLDX-1399); B003/B004 detect-only → residue |
+| dependency | D | ✅ Implemented | Guided + mechanical fixes; judgment routed to residue |
+| prescriptions | P | ✅ Suggest-only | Findings modelled + routed to residue |
+| optimizations | O | ✅ Implemented | Below-the-bar recommendations |
+| dockerfile | I | ✅ Suggest-only | Findings modelled + routed to residue |
+| tests | T | ✅ Strict-only | WARNING-tier; strict mode |
 | logging | L | 🚧 Deferred | Detection runs; all findings → residue |
 | ci | C | 🚧 Deferred | Detection runs; all findings → residue |
 
-To add a new area prescription: author `remediation/programs/areas/<name>.prose.md`
-and add a dispatch branch to `remediation/programs/functions/remediate-finding.prose.md`.
+To add a new area prescription: author `<programs-dir>/areas/<name>.prose.md`
+and add a dispatch branch to `<programs-dir>/functions/remediate-finding.prose.md`.
 
 ## Execution instructions
 
+First resolve the live programs directory (the contracts ship inside the
+installed `atlan-application-sdk-conformance` package — the `remediation/programs/`
+tree in the repo root is the design doc only):
+
+```
+PROGRAMS=$(uv run atlan-application-sdk-conformance programs-dir)
+```
+
 ### Phase 1: Baseline
 
-Call `detect-violations` to run the suite and capture the before-state:
+Call `detect-violations` to run the suite and capture the before-state.  Use the
+full enabled series so every remediable area is covered (scope is auto-detected,
+so app-only series no-op on the SDK):
 
 ```
 let before = call detect-violations
   scope: .
-  series: E,L,C
+  series: E,L,C,P,O,D,B,I,T
   target: if strict then "failing+warning" else "failing"
   path_prefix: <path argument, if any>
 ```
@@ -142,22 +165,22 @@ invocation.
 
 ### Phase 2: Execute the remediation loop
 
-Read and execute the OpenProse contracts in `remediation/programs/`, starting
-with `conformance-remediation.prose.md`.  The contracts are self-contained
+Read and execute the OpenProse contracts in `$PROGRAMS`, starting with
+`conformance-remediation.prose.md`.  The contracts are self-contained
 English-plus-ProseScript — execute them directly as an agent (no separate
 OpenProse runtime required for the skill path).
 
 Execution order (from `conformance-remediation.prose.md`):
 
-1. Run the three area responsibilities in parallel:
-   - `areas/error-handling.prose.md` — E-series, fully prescribed
-   - `areas/logging.prose.md` — L-series, detection only → residue
-   - `areas/ci.prose.md` — C-series, detection only → residue
+1. Run every area responsibility in parallel (error-handling, deprecation,
+   dependency, prescriptions, optimizations, dockerfile, tests, logging, ci) —
+   the top-level contract fans out to all of them; do not hardcode a subset.
 
 2. Each area responsibility calls the `detect-fix-recheck` pattern
    (`patterns/detect-fix-recheck.prose.md`), which loops:
    - `functions/detect-violations.prose.md` — run `suite.runner`, parse SARIF
-   - `functions/remediate-finding.prose.md` — propose fix or suppress
+   - `functions/remediate-finding.prose.md` — propose fix or suppress (dispatches
+     on `finding.area`, e.g. `deprecation` → `areas/deprecation.prose.md`)
    - `functions/recheck-narrowest.prose.md` — deterministic re-check
    - `functions/orthogonal-gate.prose.md` — test suite (fix path only)
 
@@ -173,7 +196,7 @@ Call `detect-violations` again and copy the result to `after.sarif`:
 ```
 let after = call detect-violations
   scope: .
-  series: E,L,C
+  series: E,L,C,P,O,D,B,I,T
   target: if strict then "failing+warning" else "failing"
   path_prefix: <path argument, if any>
 ```

--- a/application_sdk/transformers/__init__.py
+++ b/application_sdk/transformers/__init__.py
@@ -34,6 +34,14 @@ class TransformerInterface(ABC):
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
+        # The SDK's own concrete transformers (AtlasTransformer,
+        # QueryBasedTransformer) subclass this ABC; warning on *their* definition
+        # would fire at SDK import with no consumer code to point at, on top of
+        # each class's targeted __init__ warning. Skip those — a consumer
+        # subclass (module outside application_sdk.transformers) still warns here,
+        # and B001 catches the import statically via the manifest regardless.
+        if cls.__module__.startswith("application_sdk.transformers"):
+            return
         warnings.warn(
             "TransformerInterface is deprecated; use the connector-side asset-mapper "
             "pattern (typed records → map_<entity>() → pyatlan_v9 Asset) instead — "

--- a/application_sdk/transformers/__init__.py
+++ b/application_sdk/transformers/__init__.py
@@ -8,9 +8,9 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
 warnings.warn(
-    "application_sdk.transformers is deprecated and will be removed in the next major version. "
-    "Use the connector-side typed-record → mapper-function pattern instead. "
-    "See docs/upgrade-guide-v3.md.",
+    "application_sdk.transformers is deprecated; use the connector-side asset-mapper "
+    "pattern (typed records → map_<entity>() → pyatlan_v9 Asset) instead — will be "
+    "removed in v4.0. See docs/upgrade-guide-v3.md.",
     DeprecationWarning,
     stacklevel=2,
 )
@@ -25,7 +25,22 @@ class TransformerInterface(ABC):
 
     All transformer implementations must inherit from this class and implement
     the transform_metadata method.
+
+    .. deprecated:: 3.20.0
+        Use the connector-side asset-mapper pattern (typed records →
+        ``map_<entity>()`` → ``pyatlan_v9`` Asset) instead — will be removed in
+        v4.0. See ``docs/upgrade-guide-v3.md``.
     """
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        warnings.warn(
+            "TransformerInterface is deprecated; use the connector-side asset-mapper "
+            "pattern (typed records → map_<entity>() → pyatlan_v9 Asset) instead — "
+            "will be removed in v4.0. See docs/upgrade-guide-v3.md.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     @abstractmethod
     def transform_metadata(

--- a/application_sdk/transformers/atlas/__init__.py
+++ b/application_sdk/transformers/atlas/__init__.py
@@ -27,9 +27,9 @@ from application_sdk.transformers.common.last_sync import (
 from application_sdk.transformers.common.utils import process_text
 
 warnings.warn(
-    "application_sdk.transformers.atlas is deprecated and will be removed in the next major version. "
-    "Use the connector-side typed-record → mapper-function pattern instead. "
-    "See docs/upgrade-guide-v3.md.",
+    "application_sdk.transformers.atlas is deprecated; use the connector-side "
+    "asset-mapper pattern (typed records → map_<entity>() → pyatlan_v9 Asset) instead "
+    "— will be removed in v4.0. See docs/upgrade-guide-v3.md.",
     DeprecationWarning,
     stacklevel=2,
 )
@@ -61,6 +61,11 @@ class AtlasTransformer(TransformerInterface):
     Example:
         >>> transformer = AtlasTransformer("sql-connector", "tenant123")
         >>> result = transformer.transform_metadata("DATABASE", data, "workflow1", "run1")
+
+    .. deprecated:: 3.20.0
+        Use the connector-side asset-mapper pattern (typed records →
+        ``map_<entity>()`` → ``pyatlan_v9`` Asset) instead — will be removed in
+        v4.0. See ``docs/upgrade-guide-v3.md``.
     """
 
     def __init__(self, connector_name: str, tenant_id: str, **kwargs: Any):
@@ -73,6 +78,13 @@ class AtlasTransformer(TransformerInterface):
                 current_epoch (str): Current epoch timestamp.
                 connection_qualified_name (str): Qualified name for the connection.
         """
+        warnings.warn(
+            "AtlasTransformer is deprecated; use the connector-side asset-mapper "
+            "pattern (typed records → map_<entity>() → pyatlan_v9 Asset) instead — "
+            "will be removed in v4.0. See docs/upgrade-guide-v3.md.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         from application_sdk.transformers.atlas.sql import (  # noqa: PLC0415 — circular: transformers/atlas/__init__.py loads sibling sql submodule
             Column,
             Database,

--- a/application_sdk/transformers/query/__init__.py
+++ b/application_sdk/transformers/query/__init__.py
@@ -28,9 +28,9 @@ from application_sdk.transformers.query.errors import (
 )
 
 warnings.warn(
-    "application_sdk.transformers.query is deprecated and will be removed in the next major version. "
-    "Use the connector-side typed-record → mapper-function pattern instead. "
-    "See docs/upgrade-guide-v3.md.",
+    "application_sdk.transformers.query is deprecated; use the connector-side "
+    "asset-mapper pattern (typed records → map_<entity>() → pyatlan_v9 Asset) instead "
+    "— will be removed in v4.0. See docs/upgrade-guide-v3.md.",
     DeprecationWarning,
     stacklevel=2,
 )
@@ -60,9 +60,21 @@ class QueryBasedTransformer(TransformerInterface):
         connector_name: Name of the connector
         tenant_id: ID of the tenant
         **kwargs: Additional keyword arguments
+
+    .. deprecated:: 3.20.0
+        Use the connector-side asset-mapper pattern (typed records →
+        ``map_<entity>()`` → ``pyatlan_v9`` Asset) instead — will be removed in
+        v4.0. See ``docs/upgrade-guide-v3.md``.
     """
 
     def __init__(self, connector_name: str, tenant_id: str, **kwargs: Any):
+        warnings.warn(
+            "QueryBasedTransformer is deprecated; use the connector-side asset-mapper "
+            "pattern (typed records → map_<entity>() → pyatlan_v9 Asset) instead — "
+            "will be removed in v4.0. See docs/upgrade-guide-v3.md.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.connector_name = connector_name
         self.tenant_id = tenant_id
         self.entity_class_definitions: dict[str, str] = (

--- a/application_sdk/transformers/query/__init__.py
+++ b/application_sdk/transformers/query/__init__.py
@@ -197,9 +197,10 @@ class QueryBasedTransformer(TransformerInterface):
         return sql_query, literal_columns or None
 
     def _build_struct(self, level: dict, prefix: str = "") -> None:  # type: ignore[return]
-        """Deprecated: struct building is now handled by get_grouped_dataframe_by_prefix.
+        """No-op shim — struct building moved to get_grouped_dataframe_by_prefix.
 
         Kept as a no-op so callers that were patching this in tests do not blow up.
+        (The enclosing class is itself deprecated; see the class notice.)
 
         Args:
             level (dict): The current level of the struct hierarchy

--- a/packages/conformance/conformance/data/deprecated_symbols.json
+++ b/packages/conformance/conformance/data/deprecated_symbols.json
@@ -206,6 +206,33 @@
       "module": "application_sdk.templates.sql_query_extractor",
       "removal_version": "4.0.0",
       "symbol": "SqlQueryExtractor"
+    },
+    {
+      "kind": "class",
+      "marker_via": "warn",
+      "message": "TransformerInterface is deprecated; use the connector-side asset-mapper pattern (typed records \u2192 map_<entity>() \u2192 pyatlan_v9 Asset) instead \u2014 will be removed in v4.0. See docs/upgrade-guide-v3.md.",
+      "migration_target": true,
+      "module": "application_sdk.transformers",
+      "removal_version": "4.0",
+      "symbol": "TransformerInterface"
+    },
+    {
+      "kind": "class",
+      "marker_via": "warn",
+      "message": "AtlasTransformer is deprecated; use the connector-side asset-mapper pattern (typed records \u2192 map_<entity>() \u2192 pyatlan_v9 Asset) instead \u2014 will be removed in v4.0. See docs/upgrade-guide-v3.md.",
+      "migration_target": true,
+      "module": "application_sdk.transformers.atlas",
+      "removal_version": "4.0",
+      "symbol": "AtlasTransformer"
+    },
+    {
+      "kind": "class",
+      "marker_via": "warn",
+      "message": "QueryBasedTransformer is deprecated; use the connector-side asset-mapper pattern (typed records \u2192 map_<entity>() \u2192 pyatlan_v9 Asset) instead \u2014 will be removed in v4.0. See docs/upgrade-guide-v3.md.",
+      "migration_target": true,
+      "module": "application_sdk.transformers.query",
+      "removal_version": "4.0",
+      "symbol": "QueryBasedTransformer"
     }
   ]
 }

--- a/packages/conformance/conformance/programs/areas/deprecation.prose.md
+++ b/packages/conformance/conformance/programs/areas/deprecation.prose.md
@@ -85,6 +85,51 @@ human audit):
   - `class X(BaseMetadataExtractor)` → migrate to `application_sdk.templates.SqlApp`
     per the notice; this is a structural change — draft it and let the test gate
     decide.
+  - **Legacy transformer → asset-mapper** (BLDX-1399): a finding naming
+    `TransformerInterface`, `AtlasTransformer`, or `QueryBasedTransformer`
+    (import / subclass / call of `transform_metadata` / `transform_row`) means the
+    app still runs the half-YAML/half-code transformer path (YAML query templates +
+    DuckDB + memory-heavy DataFrames). Migrate it to the v3-native **asset-mapper**
+    pattern — pure Python functions that map typed records directly to `pyatlan_v9`
+    Asset instances, eliminating the Daft/YAML dependency. This is a structural
+    rewrite (always `"judgment"`); draft it and let the test gate decide. Shape it
+    after the reference apps `atlan-openapi-app` and the migrated
+    `atlan-metabase-app`:
+      - **File layout** — `app/api_types.py` holds the typed intermediate records
+        (`@dataclass` or `msgspec.Struct`); `app/asset_mapper.py` holds pure
+        `map_<entity>(record, connection_qn, ...) -> <pyatlan_v9 Asset>` functions
+        (no I/O, deterministic); the `transform` task lives in the connector/app
+        module.
+      - **Mapper function** — construct the asset from the typed record, set
+        attributes, stamp sync metadata, and `return` the asset:
+        ```python
+        from pyatlan_v9.model.assets import Table
+
+        def map_table(record: TableRecord, connection_qn: str, workflow_id: str) -> Table:
+            asset = Table(
+                qualified_name=f"{connection_qn}/{record.database}/{record.schema}/{record.name}",
+                name=record.name,
+                connector_name="my-connector",
+                connection_qualified_name=connection_qn,
+            )
+            asset.status = "ACTIVE"
+            asset.last_sync_run = workflow_id
+            return asset
+        ```
+      - **Transform task** — read typed records from the input JSONL, map each, and
+        write `asset.to_nested_bytes()` to a typed file output passed downstream as a
+        `FileReference` (no shared `output_path` scan, no `upload_to_atlan()`):
+        ```python
+        @task(timeout_seconds=1800)
+        async def transform(self, input: TransformInput) -> TransformOutput:
+            for record in read_jsonl(input.raw_file, RecordType):
+                asset = map_entity(record, connection_qn, workflow_id)
+                out_f.write(asset.to_nested_bytes() + b"\n")
+            return TransformOutput(output_file=FileReference(local_path=str(output_file)))
+        ```
+      - Drop the YAML query templates, the `TransformerInterface` subclass, and any
+        Daft DataFrame use that existed only to feed the transformer. Full guidance:
+        `docs/upgrade-guide-v3.md` (Step 2 / asset-mapper section).
   Because the migration is non-trivial, `classification` is always `"judgment"`.
   The orthogonal test gate is what makes applying it safe: if the migration
   breaks behaviour, the gate reverts and routes to residue.

--- a/packages/conformance/tests/test_deprecation.py
+++ b/packages/conformance/tests/test_deprecation.py
@@ -208,7 +208,33 @@ def test_b001_real_manifest_flags_legacy_transformers() -> None:
     # two imports + one subclass
     assert [f.rule_id for f in findings] == ["B001", "B001", "B001"]
     # the asset-mapper migration target rides along for the remediation loop
-    assert any("asset-mapper" in f.message for f in findings)
+    assert all("asset-mapper" in f.message for f in findings)
+    assert all("v4.0" in f.message for f in findings)
+
+
+def test_b001_real_manifest_flags_transformer_interface_import() -> None:
+    """The ABC itself is flagged — an app subclassing it directly is the target."""
+    manifest = load_manifest()
+    src = "from application_sdk.transformers import TransformerInterface\n"
+    tree, directives = _tree_and_directives(src)
+    ids = [f.rule_id for f in scan_consumer(tree, "app/x.py", manifest, directives)]
+    assert ids == ["B001"]
+
+
+def test_b001_real_manifest_transformer_suppressible() -> None:
+    """A justified inline suppression silences the transformer finding (and is
+    still emitted to SARIF in its own category by the runner)."""
+    manifest = load_manifest()
+    src = (
+        "from application_sdk.transformers.atlas import AtlasTransformer  "
+        "# conformance: ignore[B001] legacy compat shim\n"
+    )
+    tree, directives = _tree_and_directives(src)
+    findings = scan_consumer(tree, "app/x.py", manifest, directives)
+    # The finding is still emitted (audit trail) but marked suppressed, so the
+    # runner counts it in its own SUPPRESSED category, not as a live WARNING.
+    assert len(findings) == 1
+    assert findings[0].suppressed is True
 
 
 # ── B002 MalformedDeprecationNotice (sdk scope) ─────────────────────────────────

--- a/packages/conformance/tests/test_deprecation.py
+++ b/packages/conformance/tests/test_deprecation.py
@@ -189,6 +189,28 @@ def test_b001_real_manifest_flags_deprecated_discovery_error() -> None:
     assert ids == ["B001"]
 
 
+def test_b001_real_manifest_flags_legacy_transformers() -> None:
+    """BLDX-1399: the real manifest fires on the legacy transformer surface.
+
+    Importing / subclassing ``AtlasTransformer`` / ``QueryBasedTransformer`` /
+    ``TransformerInterface`` is the YAML/Daft transformer path we are steering
+    apps off; B001 must surface it with the asset-mapper migration guidance the
+    SDK's deprecation notice carries.
+    """
+    manifest = load_manifest()
+    src = (
+        "from application_sdk.transformers.atlas import AtlasTransformer\n"
+        "from application_sdk.transformers.query import QueryBasedTransformer\n\n\n"
+        "class MyTransformer(AtlasTransformer):\n    pass\n"
+    )
+    tree, directives = _tree_and_directives(src)
+    findings = scan_consumer(tree, "app/connector.py", manifest, directives)
+    # two imports + one subclass
+    assert [f.rule_id for f in findings] == ["B001", "B001", "B001"]
+    # the asset-mapper migration target rides along for the remediation loop
+    assert any("asset-mapper" in f.message for f in findings)
+
+
 # ── B002 MalformedDeprecationNotice (sdk scope) ─────────────────────────────────
 
 

--- a/packages/conformance/tests/test_deprecations_manifest.py
+++ b/packages/conformance/tests/test_deprecations_manifest.py
@@ -47,6 +47,35 @@ def test_manifest_is_committed() -> None:
     assert manifest.symbols, "committed manifest has no symbols"
 
 
+def test_manifest_contains_legacy_transformers() -> None:
+    """BLDX-1399: the legacy transformer surface is recorded for B001.
+
+    Stronger than the drift test (which only proves the file matches a fresh
+    scan): this pins the *intent* — the three transformer symbols must stay
+    marked, with a well-formed asset-mapper migration target and a v4.0 removal,
+    so B001 keeps steering apps onto the asset-mapper pattern.  If a refactor
+    drops a class-level marker, the drift test would still pass after a
+    regenerate; this one fails loudly.
+    """
+    manifest = load_manifest()
+    by_name = {s.symbol: s for s in manifest.symbols}
+    expected = {
+        "TransformerInterface": "application_sdk.transformers",
+        "AtlasTransformer": "application_sdk.transformers.atlas",
+        "QueryBasedTransformer": "application_sdk.transformers.query",
+    }
+    for symbol, module in expected.items():
+        assert (
+            symbol in by_name
+        ), f"{symbol} missing from manifest — B001 is blind to it"
+        rec = by_name[symbol]
+        assert rec.module == module
+        assert rec.kind == "class"
+        assert rec.migration_target, f"{symbol} notice names no migration target (B002)"
+        assert rec.removal_version == "4.0", f"{symbol} removal version drifted"
+        assert "asset-mapper" in rec.message
+
+
 def test_committed_manifest_matches_fresh_scan() -> None:
     """The committed manifest equals a fresh scan of application_sdk/.
 


### PR DESCRIPTION
## What & why

[BLDX-1399](https://linear.app/atlan-epd/issue/BLDX-1399) — apps should map extracted data to Atlan assets with the optimized `pyatlan_v9` **asset-mapper** pattern (typed records → pure `map_<entity>()` functions → pyatlan Asset → JSONL via `to_nested_bytes()`), **not** the legacy half-YAML/half-code transformer stack (`TransformerInterface`, `AtlasTransformer`, `QueryBasedTransformer` — YAML query templates + DuckDB + memory-heavy DataFrames). The legacy classes stay (back-compat) but must not be used by new/migrating connectors.

This is delivered as **warning-based enforcement** through the existing **B-series deprecation machinery (B001)** — not a new rule. B001 `DeprecatedSdkSymbolUsage` (BLDX-1418) is purpose-built for this: mark a symbol deprecated in SDK source → regenerate a committed manifest → B001 fires **WARN fleet-wide** on any app that imports/subclasses/calls it, with zero per-app config, and the remediation loop already routes it. A new rule would have duplicated the manifest machinery and burned a permanent rule ID.

**Why it wasn't already working:** the three transformer modules already emitted a `DeprecationWarning`, but at *module level* — which the B-series symbol extractor ignores (it only attributes markers in a class's `__init__`/`__init_subclass__` or an `@deprecated` decorator). So the classes were absent from the manifest and B001 missed them. Their notices also had no parseable removal version (B002-malformed).

## Detection (SDK source + manifest)

- Added a **class-attributed** `DeprecationWarning` to each class — `__init_subclass__` on the `TransformerInterface` ABC, `__init__` on `AtlasTransformer`/`QueryBasedTransformer` — using `warnings.warn(...)` (the SDK convention; avoids pyright `reportDeprecated` on internal use). Each message names the **asset-mapper** migration target and a **v4.0** removal, so it satisfies B002 and B001 carries concrete guidance to consumers. Fixed the module-level notices to match.
- Regenerated `deprecated_symbols.json` (23 → 26 symbols; all three with `migration_target: true`, `removal_version: 4.0`).

No new `RuleDefinition`, no new check module, no scope change — B001 (scope `app`, WARN) already exists, and its CI leg (`series: B`, watches `**/*.py`) is already in `conformance-reusable.yaml`, so apps calling the reusable workflow `@main` get the warning automatically.

## Remediation (same change)

- Enriched the B001 fix prescription in `programs/areas/deprecation.prose.md` with the transformer → asset-mapper migration (file layout, mapper-fn shape, `FileReference` transform task, reference apps `atlan-openapi-app` / migrated `atlan-metabase-app`), sourced from the `upgrade-v3` skill. Dispatch (`B`/`deprecation` → `deprecation.prose.md`) and the top-level program (fans out to `deprecation-area`) were already wired — no other `programs/` change.
- **Aligned the SDK-local `remediate` skill doc**, which was design-era: it hardcoded `series: E,L,C`, listed only error-handling/logging/ci, and pointed at the aspirational repo-root `remediation/programs/` tree. Updated it to resolve the live programs dir (`programs-dir`), run the full enabled series (`E,L,C,P,O,D,B,I,T`), and list every live area (incl. deprecation) so the SDK's own loop no longer skips them. (The bootstrapped per-app skill template was already generic/correct.)

## Proof — loop run end to end

On a fixture app (`atlan-legacy-connector-app`) with 3 transformer imports + 1 subclass, the loop's detect step produced **4 × B001**, every one routed to `area=deprecation` with the asset-mapper guidance in the message, and the prescription file the loop loads (`deprecation.prose.md` via `programs-dir`) contains the new "Legacy transformer → asset-mapper" prescription. B001 stays quiet on the SDK itself (scope `app`).

## Tests / checks
- `test_manifest_contains_legacy_transformers` — pins the three symbols in the manifest with the asset-mapper target + v4.0 removal (stronger than the drift test: a dropped marker fails loudly).
- B001 real-manifest cases: `TransformerInterface` import, import+subclass mix (asserts asset-mapper + v4.0 guidance), and a justified suppression.
- Full conformance suite: **1222 passed, 1 xfailed**. SDK transformer tests: **158 passed** (the new DeprecationWarnings are emitted but harmless — no `filterwarnings=error`, no internal instantiation). Repo-root pinned pre-commit (incl. pyright) green; `gen-rule-docs` no diff.

## Notes / decisions
- **Out of scope (stated, not omitted):** YAML query templates and bare `import daft` are **not** separately detected — they are downstream consequences of the transformer import (already caught by B001), and `daft` also appears in legitimate new code, so banning it would be noisy. The prescription tells the remediator to drop the YAML/Daft remnants as part of the migration.
- **`/remediate` was run, not just asserted:** verified end to end on a fixture app (above). The fix half is `judgment`-classified (structural rewrite, test-gated, routed to residue for human audit) — never a blind name swap.
- **Pre-existing `_build_struct` B004** at `transformers/query/__init__.py` — a private no-op shim whose docstring opened with "Deprecated:" but carried no marker and can never be a B001 consumer signal. Since this PR touches that file, reworded the docstring to a factual no-op note so the unmarked-claim warning stops firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)