### PR TITLE
test(e2e): make AE client polling resilient to transient network errors

### DIFF
--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -73,6 +73,13 @@ _HTTP_TIMEOUT = 60
 # existing 5xx retry loop handles) rather than a raw TimeoutError.
 _SUBMIT_TIMEOUT = 120
 
+# Transient network-layer errors (DNS blips, read timeouts, connection resets)
+# are common during multi-minute polls over a VPN/loft tunnel to a tenant. Retry
+# each HTTP call a few times before surfacing the failure, so a single blip in a
+# 10-15 min poll doesn't fail the whole run.
+_REQUEST_MAX_ATTEMPTS = 4
+_REQUEST_BACKOFF_SECONDS = 3
+
 # Cadence for "still polling" heartbeat log lines in
 # ``poll_native_status`` — lineage stages take 2-5 min on small
 # datasets and the status string doesn't change during that time, so
@@ -255,25 +262,59 @@ class AEWorkflowClient:
         req.add_header("User-Agent", _USER_AGENT)
         if body is not None:
             req.add_header("Content-Type", "application/json")
-        try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
-                raw = resp.read()
+        last_exc: Exception | None = None
+        for attempt in range(1, _REQUEST_MAX_ATTEMPTS + 1):
+            try:
+                with urllib.request.urlopen(req, timeout=timeout) as resp:
+                    raw = resp.read()
+                    try:
+                        return resp.status, orjson.loads(raw)
+                    except orjson.JSONDecodeError:
+                        logger.warning(
+                            "Response body is not JSON; returning raw text",
+                            exc_info=True,
+                        )
+                        return resp.status, raw.decode(errors="replace")
+            except urllib.error.HTTPError as e:
+                # A real HTTP response (4xx/5xx), NOT a transient network error —
+                # return it so the caller's status-based retry/handling applies.
+                raw = e.read()
                 try:
-                    return resp.status, orjson.loads(raw)
+                    return e.code, orjson.loads(raw)
                 except orjson.JSONDecodeError:
                     logger.warning(
-                        "Response body is not JSON; returning raw text", exc_info=True
+                        "HTTP error body is not JSON; returning raw text",
+                        exc_info=True,
                     )
-                    return resp.status, raw.decode(errors="replace")
-        except urllib.error.HTTPError as e:
-            raw = e.read()
-            try:
-                return e.code, orjson.loads(raw)
-            except orjson.JSONDecodeError:
-                logger.warning(
-                    "HTTP error body is not JSON; returning raw text", exc_info=True
-                )
-                return e.code, raw.decode(errors="replace")
+                    return e.code, raw.decode(errors="replace")
+            except (urllib.error.URLError, TimeoutError, OSError) as e:
+                # Transient network-layer error (DNS blip / read timeout / conn
+                # reset) — common on multi-minute polls over a VPN/loft tunnel.
+                # Retry a few times; if it persists, surface as AtlanApiTimeoutError
+                # (an AppError) so callers' transient-tolerance (e.g. the poll loop)
+                # handles it instead of a raw crash. NOTE: HTTPError is a URLError
+                # subclass but is caught above, so it never reaches here.
+                last_exc = e
+                if attempt < _REQUEST_MAX_ATTEMPTS:
+                    logger.warning(
+                        "transient network error on %s %s (attempt %d/%d): %s — "
+                        "retrying in %ds",
+                        method,
+                        path,
+                        attempt,
+                        _REQUEST_MAX_ATTEMPTS,
+                        e,
+                        _REQUEST_BACKOFF_SECONDS,
+                        exc_info=True,
+                    )
+                    time.sleep(_REQUEST_BACKOFF_SECONDS)
+        raise AtlanApiTimeoutError(
+            message=(
+                f"{method} {path} failed after {_REQUEST_MAX_ATTEMPTS} attempts: "
+                f"{last_exc!r}"
+            ),
+            operation=path,
+        )
 
     # ------------------------------------------------------------------
     # Endpoints
@@ -313,7 +354,7 @@ class AEWorkflowClient:
                 status, resp_body = self._request(
                     "POST", path, body=body, timeout=_SUBMIT_TIMEOUT
                 )
-            except (TimeoutError, OSError) as exc:
+            except (TimeoutError, OSError, AtlanApiTimeoutError) as exc:
                 if attempt < total_attempts:
                     logger.warning(
                         "%s attempt %d/%d: timeout (%s) — retrying in %ds",

--- a/tests/unit/testing/e2e/test_client.py
+++ b/tests/unit/testing/e2e/test_client.py
@@ -7,12 +7,15 @@ transient_streak budget works correctly.
 
 from __future__ import annotations
 
+import io
+import urllib.error
 from unittest.mock import patch
 
 import pytest
 
 from application_sdk.testing.e2e._errors import AtlanApiHttpError, AtlanApiTimeoutError
 from application_sdk.testing.e2e.client import (
+    _REQUEST_MAX_ATTEMPTS,
     AEWorkflowClient,
     DAGNodeResult,
     DAGNodeStatus,
@@ -238,3 +241,78 @@ class TestPostWithRetry:
         assert status == 200
         assert isinstance(body, dict) and body.get("status") == "success"
         mock_sleep.assert_called_once()
+
+
+class _FakeResponse:
+    """Minimal urlopen() return value usable as a context manager."""
+
+    def __init__(self, status: int, raw: bytes):
+        self.status = status
+        self._raw = raw
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self) -> bytes:
+        return self._raw
+
+
+class TestRequestNetworkRetry:
+    """_request: transient network errors retry; sustained ones surface as
+    AtlanApiTimeoutError (an AppError) so the poll loop tolerates them instead
+    of crashing on a raw URLError/TimeoutError mid-poll."""
+
+    def test_retries_transient_then_succeeds(self):
+        """URLError on attempt 1 → succeeds on attempt 2."""
+        client = _make_client()
+        ok = _FakeResponse(200, b'{"ok": true}')
+        with (
+            patch(
+                "application_sdk.testing.e2e.client.urllib.request.urlopen",
+                side_effect=[urllib.error.URLError("dns blip"), ok],
+            ),
+            patch("time.sleep"),
+        ):
+            status, body = client._request("GET", "/native-status")
+        assert status == 200
+        assert body == {"ok": True}
+
+    def test_sustained_network_error_raises_atlan_timeout(self):
+        """URLError on every attempt → AtlanApiTimeoutError after max attempts."""
+        client = _make_client()
+        with (
+            patch(
+                "application_sdk.testing.e2e.client.urllib.request.urlopen",
+                side_effect=urllib.error.URLError("name resolution"),
+            ) as mock_open,
+            patch("time.sleep"),
+            pytest.raises(AtlanApiTimeoutError),
+        ):
+            client._request("GET", "/native-status")
+        assert mock_open.call_count == _REQUEST_MAX_ATTEMPTS
+
+    def test_httperror_returns_immediately_without_retry(self):
+        """A real 5xx HTTP response is returned, not retried as a network error."""
+        client = _make_client()
+        http_err = urllib.error.HTTPError(
+            url="https://tenant.example.com/native-status",
+            code=500,
+            msg="server error",
+            hdrs=None,
+            fp=io.BytesIO(b'{"err": "boom"}'),
+        )
+        with (
+            patch(
+                "application_sdk.testing.e2e.client.urllib.request.urlopen",
+                side_effect=http_err,
+            ) as mock_open,
+            patch("time.sleep") as mock_sleep,
+        ):
+            status, body = client._request("GET", "/native-status")
+        assert status == 500
+        assert body == {"err": "boom"}
+        assert mock_open.call_count == 1
+        mock_sleep.assert_not_called()


### PR DESCRIPTION
## What

The e2e harness (`application_sdk/testing/e2e/client.py`) polls the tenant's `native-status` endpoint for many minutes during an agent-mode SDR run. When that poll runs over a VPN / loft tunnel (as in the LM SDR publish e2e), a single transient network blip — a DNS hiccup ("Temporary failure in name resolution"), a read timeout, or a connection reset — surfaced as a raw `urllib.error.URLError` / `TimeoutError` / `OSError`.

`poll_native_status` only tolerates `AppError` subclasses, so those raw network exceptions escaped its transient-tolerance budget and crashed the entire run, even though the underlying SDR run was healthy and the asset upload had already completed.

## Change

- **`_request`** now retries transient network-layer errors (`URLError`/`TimeoutError`/`OSError`) up to `_REQUEST_MAX_ATTEMPTS` (4) with a short backoff. A real HTTP response (`HTTPError`, i.e. any 4xx/5xx) is still returned immediately — only genuine network-layer failures retry. If the network error persists across all attempts, it is raised as `AtlanApiTimeoutError` (an `AppError`), so every caller's existing transient-tolerance handles it uniformly instead of crashing on a raw exception.
- **`_post_with_retry`** now also treats `AtlanApiTimeoutError` as retriable, preserving submit-path resilience now that `_request` can raise it.

## Tests

Added `TestRequestNetworkRetry` covering: transient error → retry → success; sustained error → `AtlanApiTimeoutError` after max attempts; and a real `HTTPError` returning immediately without retry. Full `tests/unit/testing/e2e/test_client.py` suite passes (12 tests).

## Why this matters

This is the last source of flakiness for the LM SDR publish e2e (atlanhq/local-marketplace#508), where the proven-working publish path was intermittently failing only because of a transient network blip during the multi-minute lineage poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)