### PR TITLE
feat(contract-toolkit): emit marketplace metadata from app.pkl into atlan.yaml (BLDX-1451)

### DIFF
--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -160,6 +160,7 @@ Typed Python `AppInputContract` dataclass. SDK-owned fields inherited from `Extr
 The single entry point for all new native app contracts. Amend this module and declare:
 
 - App metadata: `name`, `displayName`, `connector`, `icon`
+- Marketplace metadata: `docsUrl`, `shortDescription`, `longDescription`, `tags` (emitted top-level into `atlan.yaml`; consumed by the Atlan CLI on `atlan app register` and forwarded to the Global Marketplace App row)
 - Credential config: `credentialCommonFields`, `credentialAuthOptions`, `credentialConnectorType`
 - Workflow config: `uiConfig` (form steps and fields using `Widgets.*` types)
 - Pipeline: typed `pipeline` block (extract → parseQueries → popularity → lineage → publish)

--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -160,7 +160,7 @@ Typed Python `AppInputContract` dataclass. SDK-owned fields inherited from `Extr
 The single entry point for all new native app contracts. Amend this module and declare:
 
 - App metadata: `name`, `displayName`, `connector`, `icon`
-- Marketplace metadata: `docsUrl`, `shortDescription`, `longDescription`, `tags` (emitted top-level into `atlan.yaml`; consumed by the Atlan CLI on `atlan app register` and forwarded to the Global Marketplace App row)
+- Marketplace metadata: `shortDescription`, `longDescription`, `tags` (emitted top-level into `atlan.yaml`; consumed by the Atlan CLI on `atlan app register` and forwarded to the Global Marketplace App row); `docsUrl` (emitted top-level into `atlan.yaml`)
 - Credential config: `credentialCommonFields`, `credentialAuthOptions`, `credentialConnectorType`
 - Workflow config: `uiConfig` (form steps and fields using `Widgets.*` types)
 - Pipeline: typed `pipeline` block (extract → parseQueries → popularity → lineage → publish)

--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -107,7 +107,7 @@ The `examples/` directory contains executable contracts that teach stable toolki
 
 ### `atlan.yaml` (repo root)
 
-Marketplace deployment manifest. Contains app identity, entrypoints list, and the typed `deploy` block (KEDA, Dapr, resources, env, and any `deployOverrides`). Emitted with a DO-NOT-EDIT header — edit `contract/app.pkl` instead.
+Marketplace deployment manifest. Contains app identity (`name`, `display_name`, `icon_url`), marketplace metadata (`short_description`, `long_description`, `docs_url`, `tags`), entrypoints list, and the typed `deploy` block (KEDA, Dapr, resources, env, and any `deployOverrides`). Emitted with a DO-NOT-EDIT header — edit `contract/app.pkl` instead.
 
 ### `app.yaml` (repo root)
 

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -90,13 +90,16 @@ The single entry point for all new native app contracts. Supersedes `NativeApp.p
 | `displayName` | String | `name.capitalize()` | UI display name. |
 | `connector` | Connectors.Type? | null | Connector from the registry. Required when `hasCredentialConfig = true`. |
 | `icon` | String | required | Icon URL. |
-| `docsUrl` | String | `""` | Documentation link. |
+| `docsUrl` | String | `""` | Documentation link. Emitted as top-level `docs_url` in `atlan.yaml` (omitted when empty); the Atlan CLI forwards it to the Global Marketplace App row on `atlan app register`. |
 | `logo` | String | `icon` | Logo URL. |
 | `helpdeskLink` | String | `""` | Helpdesk link for credential form. |
 | `type` | String | `"connector"` | Marketplace type. |
 | `visibility` | String | `"public"` | Marketplace visibility. |
 | `buildTag` | String | `"v1"` | Emitted as `build_tag`. |
 | `selfDeployedRuntime` | Boolean | `true` | Emitted as `self_deployed_runtime`. |
+| `shortDescription` | String | `""` | One-line marketplace card description. Emitted as top-level `short_description` (omitted when empty). |
+| `longDescription` | String | `""` | Long-form marketplace detail-page description (markdown). Emitted as top-level `long_description` (omitted when empty); multi-line strings render as YAML literal blocks. |
+| `tags` | Listing\<String\> | `[]` | Free-form marketplace category tags. Emitted as top-level `tags` (omitted when empty). |
 
 ### Workflow & Manifest
 

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -90,7 +90,7 @@ The single entry point for all new native app contracts. Supersedes `NativeApp.p
 | `displayName` | String | `name.capitalize()` | UI display name. |
 | `connector` | Connectors.Type? | null | Connector from the registry. Required when `hasCredentialConfig = true`. |
 | `icon` | String | required | Icon URL. |
-| `docsUrl` | String | `""` | Documentation link. Emitted as top-level `docs_url` in `atlan.yaml` (omitted when empty); the Atlan CLI forwards it to the Global Marketplace App row on `atlan app register`. |
+| `docsUrl` | String | `""` | Documentation link. Emitted as top-level `docs_url` in `atlan.yaml` (omitted when empty). |
 | `logo` | String | `icon` | Logo URL. |
 | `helpdeskLink` | String | `""` | Helpdesk link for credential form. |
 | `type` | String | `"connector"` | Marketplace type. |

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -305,11 +305,13 @@ Set `entrypoints` to serve multiple marketplace tiles from one deployment. Per-e
 |---|---|---|---|
 | `name` | String | required | SDK entrypoint key and generated subfolder (`crawler`, `miner`). |
 | `displayName` | String | `name.capitalize()` | Card display name. |
-| `description` | String? | null | Card description. |
-| `icon` | String? | null | Card icon. |
+| `description` | String? | null | Card description. Falls back to the app-level `shortDescription` when null. |
+| `iconUrl` | String? | null | Card icon URL. Falls back to the app-level `iconUrl` when null. |
 | `type` | String | `"connector"` | Card type. |
 | `source` | String? | null | Source slug. |
 | `sourceCategory` | String? | null | Source category. |
+| `categories` | Listing\<String\> | `[]` | Marketplace category tags for this entrypoint. |
+| `docsUrl` | String? | null | Documentation URL. Falls back to the app-level `docsUrl` when null. |
 | `contract` | Typed? | null | The entrypoint's `App.pkl` contract whose `output.files` are emitted. |
 
 Bundle output layout:

--- a/contract-toolkit/examples/full/app.pkl
+++ b/contract-toolkit/examples/full/app.pkl
@@ -10,6 +10,7 @@
 ///               conditional UIRule, CredentialInput, ConnectionCreator
 ///   - extraNodes: custom DAG node outside the typed pipeline
 ///   - notifications: explicit opt-in to the run-completion notification node
+///   - marketplace metadata: docsUrl, shortDescription, longDescription, tags
 amends "../../src/App.pkl"
 
 import "../../src/Connectors.pkl"
@@ -19,6 +20,20 @@ displayName = "Full-Featured Example"
 connector = Connectors.POSTGRES
 workflowType = "FullFeaturedExampleWorkflow"
 icon = "https://assets.atlan.com/assets/fullscreen-open.svg"
+docsUrl = "https://docs.example.com/apps/full-featured"
+shortDescription = "Reference contract that exercises every App.pkl property."
+longDescription = """
+Full-featured reference contract used by the toolkit's own tests.
+
+Covers JDBC URL auth, every pipeline step, diverse widgets, UIRules,
+extraNodes, run-completion notifications, and the full marketplace
+metadata block emitted into atlan.yaml.
+"""
+tags = new Listing {
+  "reference"
+  "example"
+  "postgres"
+}
 credentialConnectorType = "jdbc"
 notifications = true
 

--- a/contract-toolkit/examples/full/atlan.yaml
+++ b/contract-toolkit/examples/full/atlan.yaml
@@ -2,12 +2,24 @@
 # To regenerate: pkl eval -m . contract/app.pkl
 name: full-featured
 display_name: Full-Featured Example
+short_description: Reference contract that exercises every App.pkl property.
+long_description: |-
+  Full-featured reference contract used by the toolkit's own tests.
+
+  Covers JDBC URL auth, every pipeline step, diverse widgets, UIRules,
+  extraNodes, run-completion notifications, and the full marketplace
+  metadata block emitted into atlan.yaml.
+docs_url: https://docs.example.com/apps/full-featured
 type: connector
 execution_mode: native
 icon_url: https://assets.atlan.com/assets/fullscreen-open.svg
 visibility: public
 build_tag: v1
 self_deployed_runtime: true
+tags:
+- reference
+- example
+- postgres
 entrypoints:
 - name: full-featured
   display_name: Full-Featured Example

--- a/contract-toolkit/examples/full/atlan.yaml
+++ b/contract-toolkit/examples/full/atlan.yaml
@@ -23,8 +23,10 @@ tags:
 entrypoints:
 - name: full-featured
   display_name: Full-Featured Example
+  description: Reference contract that exercises every App.pkl property.
   icon_url: https://assets.atlan.com/assets/fullscreen-open.svg
   type: connector
+  docs_url: https://docs.example.com/apps/full-featured
 deploy:
   execution_mode: native
   splitDeploymentEnabled: true

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -3113,13 +3113,13 @@ local function renderEntrypoint(e: Entrypoint): Mapping<String, Any> = new Mappi
   when (e.id != null) { ["id"] = e.id }
   ["name"] = e.name
   ["display_name"] = e.displayName
-  when (e.description != null) { ["description"] = e.description }
+  when (e.description != null || shortDescription != "") { ["description"] = e.description ?? shortDescription }
   when (e.iconUrl != null || iconUrl != null) { ["icon_url"] = e.iconUrl ?? iconUrl }
   ["type"] = e.type
   when (e.source != null) { ["source"] = e.source }
   when (e.sourceCategory != null) { ["source_category"] = e.sourceCategory }
   when (!e.categories.isEmpty) { ["categories"] = e.categories }
-  when (e.docsUrl != null) { ["docs_url"] = e.docsUrl }
+  when (e.docsUrl != null || docsUrl != "") { ["docs_url"] = e.docsUrl ?? docsUrl }
   ...e.metadata
 }
 

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -140,6 +140,36 @@ buildTag: String = "v1"
 /// Whether images are published for self-deployed runtime.
 selfDeployedRuntime: Boolean = true
 
+/// One-line app description for the marketplace card.
+///
+/// Default: `""` (omitted from `atlan.yaml`). Set this when the connector
+/// should advertise a tagline alongside its `displayName` in the marketplace
+/// listing. The Atlan CLI reads it from the rendered top-level
+/// `short_description` key during `atlan app register` and forwards it to the
+/// Global Marketplace App row, so the source of truth follows the contract on
+/// every regenerate. Authors who would have set this via the `metadata`
+/// escape-hatch should migrate to this typed property; the `metadata` value
+/// continues to win on conflict (deep-merge order is preserved).
+shortDescription: String = ""
+
+/// Long-form description (markdown) shown on the marketplace detail page.
+///
+/// Default: `""` (omitted from `atlan.yaml`). Use this for the multi-paragraph
+/// "About this app" block in the marketplace UI. Same publish path as
+/// `shortDescription` — emitted as top-level `long_description` and consumed
+/// by the CLI's `atlan app register`. Multi-line strings are rendered as
+/// YAML literal blocks by the toolkit's `YamlRenderer`.
+longDescription: String = ""
+
+/// Marketplace category tags for filtering / search.
+///
+/// Default: `[]` (omitted from `atlan.yaml`). Each entry is a free-form
+/// string; the marketplace surface decides how to render them. Emitted as a
+/// top-level `tags` YAML list, consumed by the CLI's `atlan app register`,
+/// and forwarded to the Global Marketplace App row. Empty Listings produce
+/// no key in the rendered yaml (the `when` guard suppresses emission).
+tags: Listing<String> = new Listing {}
+
 /// Extra top-level metadata fields for atlan.yaml.
 metadata: Mapping<String, Any> = new Mapping {}
 
@@ -3048,6 +3078,9 @@ local generatedAtlanYamlData: Mapping<String, Any> = new Mapping {
   ["name"] = name
   when (appId != "") { ["app_id"] = appId }
   ["display_name"] = displayName
+  when (shortDescription != "") { ["short_description"] = shortDescription }
+  when (longDescription != "") { ["long_description"] = longDescription }
+  when (docsUrl != "") { ["docs_url"] = docsUrl }
   when (creatorOrg != null) { ["creator_org"] = creatorOrg }
   ["type"] = type
   ["execution_mode"] = deploy.executionMode
@@ -3055,6 +3088,7 @@ local generatedAtlanYamlData: Mapping<String, Any> = new Mapping {
   ["visibility"] = visibility
   ["build_tag"] = buildTag
   ["self_deployed_runtime"] = selfDeployedRuntime
+  when (tags.toList().length > 0) { ["tags"] = tags }
   when (emitEntrypoints) {
     ["entrypoints"] = new Listing {
       for (ep in effectiveEntrypoints) {

--- a/contract-toolkit/tests/open_source_examples_test.pkl
+++ b/contract-toolkit/tests/open_source_examples_test.pkl
@@ -212,6 +212,20 @@ facts {
     !minimalAtlanYaml.contains("tags:")
   }
 
+  ["Full example fallback emits app-level description and docs_url inside entrypoints[]"] {
+    // Indented (2-space) forms only appear inside the entrypoints block, not at top level.
+    fullAtlanYaml.contains("  description: Reference contract that exercises every App.pkl property.")
+    fullAtlanYaml.contains("  docs_url: https://docs.example.com/apps/full-featured")
+  }
+
+  ["Bundle example preserves clean entrypoints when no marketplace metadata is set"] {
+    local bundleYaml: String = bundleApp.output.files["atlan.yaml"].text
+    // Neither the bundle app nor its entrypoints set shortDescription / docsUrl,
+    // so description: and docs_url: must not appear in any per-entrypoint block.
+    !bundleYaml.split("entrypoints:").last.contains("description:")
+    !bundleYaml.split("entrypoints:").last.contains("docs_url:")
+  }
+
   ["ConnectionRef example uses public connector filters"] {
     connectionRefWorkflowJson.contains("\"widget\": \"connectionSelector\"")
     connectionRefWorkflowJson.contains("\"shouldIncludeConnectionInfo\": true")

--- a/contract-toolkit/tests/open_source_examples_test.pkl
+++ b/contract-toolkit/tests/open_source_examples_test.pkl
@@ -19,10 +19,12 @@ local fullWorkflowJson: String = fullApp.output.files["app/generated/full-featur
 local fullCredentialJson: String = fullApp.output.files["app/generated/atlan-connectors-full-featured.json"].text
 local fullManifestJson: String = fullApp.output.files["app/generated/manifest.json"].text
 local fullInputPy: String = fullApp.output.files["app/generated/_input.py"].text
+local fullAtlanYaml: String = fullApp.output.files["atlan.yaml"].text
 
 local minimalWorkflowJson: String = minimalApp.output.files["app/generated/minimal.json"].text
 local minimalManifestJson: String = minimalApp.output.files["app/generated/manifest.json"].text
 local minimalInputPy: String = minimalApp.output.files["app/generated/_input.py"].text
+local minimalAtlanYaml: String = minimalApp.output.files["atlan.yaml"].text
 
 local publishControlsManifestJson: String = publishControlsApp.output.files["app/generated/manifest.json"].text
 local publishControlsInputPy: String = publishControlsApp.output.files["app/generated/_input.py"].text
@@ -190,6 +192,24 @@ facts {
     // Form widget + publish scaffold overlap must not produce a duplicate class member.
     // Expected occurrences: once in _config_hash_exclude, once as the field → split length 3.
     fullInputPy.split("load_to_atlan").length == 3
+  }
+
+  ["Full example emits typed marketplace metadata at the top of atlan.yaml"] {
+    fullAtlanYaml.contains("short_description: Reference contract that exercises every App.pkl property.")
+    fullAtlanYaml.contains("long_description: |")
+    fullAtlanYaml.contains("Full-featured reference contract used by the toolkit's own tests.")
+    fullAtlanYaml.contains("docs_url: https://docs.example.com/apps/full-featured")
+    fullAtlanYaml.contains("tags:")
+    fullAtlanYaml.contains("- reference")
+    fullAtlanYaml.contains("- example")
+    fullAtlanYaml.contains("- postgres")
+  }
+
+  ["Minimal example omits empty marketplace metadata keys from atlan.yaml"] {
+    !minimalAtlanYaml.contains("short_description")
+    !minimalAtlanYaml.contains("long_description")
+    !minimalAtlanYaml.contains("docs_url")
+    !minimalAtlanYaml.contains("tags:")
   }
 
   ["ConnectionRef example uses public connector filters"] {


### PR DESCRIPTION
## Summary

- Adds `shortDescription`, `longDescription`, and `tags` fields to `App.pkl`; emits them as top-level `short_description`, `long_description`, and `tags` in `atlan.yaml`
- Emits the existing `docsUrl` field to the top-level `docs_url` in `atlan.yaml` (field existed but wasn't being rendered)
- Fixes `renderEntrypoint` so that `description` and `docs_url` fall back to the app-level `shortDescription` / `docsUrl` when an entrypoint doesn't set its own — matching the existing `iconUrl` fallback pattern

For single-entrypoint apps, `shortDescription` and `docsUrl` were landing in the top-level `atlan.yaml` block but **not** inside the `entrypoints:` list. The marketplace tile reads description from the per-entrypoint annotation, so the value was invisible to the FE even when set by the author.

## Test plan

- [x] All 211 PKL tests pass (`pkl test tests/*.pkl`)
- [x] Invariant checks pass (`./scripts/check-invariants.sh`)
- [x] All examples regenerate cleanly (`./scripts/regenerate-all.sh`)
- [x] Full example `atlan.yaml` shows `description` and `docs_url` inside `entrypoints[0]`
- [x] Minimal example `atlan.yaml` omits empty metadata keys (no regressions)

Closes BLDX-1451

🤖 Generated with [Claude Code](https://claude.com/claude-code)