### PR TITLE
perf(observability): optimize flush path and rename parquet machinery

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -464,6 +464,11 @@ LOG_RETENTION_DAYS = int(os.environ.get("ATLAN_LOG_RETENTION_DAYS", 30))
 LOG_CLEANUP_ENABLED = os.getenv("ATLAN_LOG_CLEANUP_ENABLED", "false").lower() == "true"
 
 # Log Location configuration
+# NOTE: Despite the ".parquet" default value, LOG_FILE_NAME is used purely as a
+# signal-type discriminator in AtlanObservability._get_signal_type() to route records
+# to the correct observability sub-path (logs / metrics / traces).  The actual output
+# format is gzip-compressed NDJSON (.json.gz) — not parquet.  Do not change the
+# default value; doing so would silently reroute log records to the "other" sub-path.
 LOG_FILE_NAME = os.environ.get("ATLAN_LOG_FILE_NAME", "log.parquet")
 # REMOVED: ENABLE_HIVE_PARTITIONING — unused.
 
@@ -476,6 +481,7 @@ METRICS_RETENTION_DAYS = int(os.environ.get("ATLAN_METRICS_RETENTION_DAYS", 30))
 METRICS_CLEANUP_ENABLED = (
     os.getenv("ATLAN_METRICS_CLEANUP_ENABLED", "false").lower() == "true"
 )
+# Same signal-discriminator convention as LOG_FILE_NAME above — not a real file name.
 METRICS_FILE_NAME = os.environ.get("ATLAN_METRICS_FILE_NAME", "metrics.parquet")
 TRACES_FILE_NAME = os.environ.get("ATLAN_TRACES_FILE_NAME", "traces.parquet")
 

--- a/application_sdk/observability/dapr_log_forwarder.py
+++ b/application_sdk/observability/dapr_log_forwarder.py
@@ -26,9 +26,10 @@ no-op there and the child is exec'd directly.
 
 Design constraints:
 
-* **Run under an event loop.** The SDK's store sink (``parquet_sink``) is an
-  async loguru sink: records only get buffered for upload while an event loop is
-  running in the emitting thread. So the read/emit loop runs inside
+* **Run under an event loop.** The SDK's store sink (``_log_sink``, registered
+  by :class:`~application_sdk.observability.logger_adaptor.AtlanLoggerAdapter`)
+  is an async loguru sink: records only get buffered for upload while an event
+  loop is running in the emitting thread. So the read/emit loop runs inside
   ``asyncio.run`` and drains the sink (``logger.complete()`` + ``flush_all()``)
   before exit — otherwise lines reach stdout but never the lakehouse.
 * **Never take daprd down.** Forwarding is best-effort: any failure to parse or

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -591,6 +591,9 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
         self.logger_name = logger_name
         # Bind the logger name when creating the logger instance
         self.logger = logger
+        # Declared here so _log_sink can use ``is not None`` instead of hasattr —
+        # more explicit and survives a partial-init in the OTLP try/except below.
+        self.logger_provider: LoggerProvider | None = None
         # Suppress workflow-body logs during Temporal replay by default,
         # matching the behaviour of Temporal's native ``workflow.logger``
         # (``log_during_replay=False``).  Set to True on this instance — or
@@ -737,7 +740,7 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
         # and fans it out to all active targets.  When both the object-store sink and
         # OTLP are enabled, this halves the per-record dict-build CPU compared to
         # registering two independent sinks.
-        _has_otlp = hasattr(self, "logger_provider")
+        _has_otlp = self.logger_provider is not None
         if ENABLE_OBSERVABILITY_STORE_SINK or _has_otlp:
             self.logger.add(self._log_sink, level=SEVERITY_MAPPING[LOG_LEVEL])
             # Start the periodic flush task only when the object-store sink is active.
@@ -1149,6 +1152,8 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
         - Emits the log record
         """
         try:
+            if self.logger_provider is None:
+                return
             otel_record = self._create_log_record(record)
             otel_logger = self.logger_provider.get_logger(SERVICE_NAME)
             otel_logger.emit(otel_record)
@@ -1215,7 +1220,7 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
             log_record = _make_log_record_dict(message)
             if ENABLE_OBSERVABILITY_STORE_SINK:
                 self.add_record(log_record)
-            if hasattr(self, "logger_provider"):
+            if self.logger_provider is not None:
                 self._send_to_otel(log_record)
         except Exception:
             logging.error("Error in log sink", exc_info=True)

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -542,7 +542,7 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
     This adapter provides enhanced logging capabilities including:
     - Structured logging with context
     - OpenTelemetry integration
-    - Parquet file logging
+    - Object-store file logging (gzip-compressed NDJSON)
     - Custom log levels for activities, metrics, and tracing
     - Temporal workflow and activity context integration
     """
@@ -577,7 +577,7 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
         - Sets up Loguru with custom formatting
         - Configures custom log levels (ACTIVITY, METRIC, TRACING)
         - Sets up OTLP logging if enabled
-        - Initializes parquet logging if Dapr sink is enabled
+        - Initializes the object-store log sink when ENABLE_OBSERVABILITY_STORE_SINK is true
         - Starts periodic flush task for log buffering
         """
         super().__init__(

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -788,7 +788,7 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
     def export_record(self, record: Any) -> None:
         """Export a log record to external systems.
 
-        OTLP export is handled exclusively by the otlp_sink; this path is a no-op.
+        OTLP export is handled by the unified _log_sink (which calls _send_to_otel); this path is a no-op.
         """
 
     def _create_log_record(self, record: dict) -> LogRecord:

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -683,26 +683,10 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
             colorize=colorize,
         )
 
-        # Add sink for store logging only if store sink is enabled
-        if ENABLE_OBSERVABILITY_STORE_SINK:
-            self.logger.add(self.parquet_sink, level=SEVERITY_MAPPING[LOG_LEVEL])
-            # Start flush task only if Dapr sink is enabled
-            if not AtlanLoggerAdapter._flush_task_started:
-                try:
-                    try:
-                        loop = asyncio.get_running_loop()
-                        AtlanLoggerAdapter._flush_task = loop.create_task(
-                            self._periodic_flush()
-                        )
-                    except RuntimeError:
-                        self._spawn_flush_thread()
-                    AtlanLoggerAdapter._flush_task_started = True
-                except Exception:
-                    logging.error("Failed to start flush task", exc_info=True)
-
         # OTLP log export — primary exporter to OTEL_EXPORTER_OTLP_ENDPOINT,
         # plus an optional secondary exporter to OTEL_WORKFLOW_LOGS_ENDPOINT
         # for archival pipelines (e.g. an OTel collector that writes to S3).
+        # Set up the provider first so _log_sink can see logger_provider below.
         try:
             otlp_processors = []
 
@@ -746,10 +730,32 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
                 for processor in otlp_processors:
                     self.logger_provider.add_log_record_processor(processor)
 
-                self.logger.add(self.otlp_sink, level=SEVERITY_MAPPING[LOG_LEVEL])
-
         except Exception:
             logging.error("Failed to setup OTLP logging", exc_info=True)
+
+        # Register a single unified loguru sink that builds the log-record dict once
+        # and fans it out to all active targets.  When both the object-store sink and
+        # OTLP are enabled, this halves the per-record dict-build CPU compared to
+        # registering two independent sinks.
+        _has_otlp = hasattr(self, "logger_provider")
+        if ENABLE_OBSERVABILITY_STORE_SINK or _has_otlp:
+            self.logger.add(self._log_sink, level=SEVERITY_MAPPING[LOG_LEVEL])
+            # Start the periodic flush task only when the object-store sink is active.
+            if (
+                ENABLE_OBSERVABILITY_STORE_SINK
+                and not AtlanLoggerAdapter._flush_task_started
+            ):
+                try:
+                    try:
+                        loop = asyncio.get_running_loop()
+                        AtlanLoggerAdapter._flush_task = loop.create_task(
+                            self._periodic_flush()
+                        )
+                    except RuntimeError:
+                        self._spawn_flush_thread()
+                    AtlanLoggerAdapter._flush_task_started = True
+                except Exception:
+                    logging.error("Failed to start flush task", exc_info=True)
 
         # Mark initialization complete only after all sinks are successfully added
         AtlanLoggerAdapter._initialized = True
@@ -1194,15 +1200,40 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
         processed_msg, processed_kwargs = self.process(msg, local_kwargs)
         self.logger.bind(**processed_kwargs).log("TRACING", processed_msg, *args)
 
-    async def parquet_sink(self, message: Any):
-        """Process log message and store in parquet format.
+    async def _log_sink(self, message: Any) -> None:
+        """Unified loguru sink: build the log-record dict once and fan out to active targets.
+
+        Replaces separate ``objectstore_sink`` and ``otlp_sink`` loguru sink
+        registrations.  When both the object-store sink and an OTLP exporter are
+        configured, the record dict is built a single time — halving the per-record
+        ``_make_log_record_dict`` CPU on that common path.
 
         Args:
-            message (Any): Log message to process and store
+            message: Loguru message object passed by the loguru dispatcher.
+        """
+        try:
+            log_record = _make_log_record_dict(message)
+            if ENABLE_OBSERVABILITY_STORE_SINK:
+                self.add_record(log_record)
+            if hasattr(self, "logger_provider"):
+                self._send_to_otel(log_record)
+        except Exception:
+            logging.error("Error in log sink", exc_info=True)
 
-        This method:
-        - Builds a log record dict from the message
-        - Adds the record to the buffer for parquet storage
+    async def objectstore_sink(self, message: Any) -> None:
+        """Buffer a log message for object-store upload.
+
+        Builds a log-record dict from *message* and appends it to the in-memory
+        buffer for periodic flush to gzip-compressed NDJSON files in the object
+        store.
+
+        .. note::
+            This method is not registered as a loguru sink directly — the unified
+            :meth:`_log_sink` handles dispatch.  It is kept as a public method so
+            tests can call it in isolation without triggering OTLP side-effects.
+
+        Args:
+            message: Loguru message object (must have a ``.record`` dict attribute).
         """
         try:
             log_record = _make_log_record_dict(message)
@@ -1210,15 +1241,19 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
         except Exception:
             logging.error("Error buffering log", exc_info=True)
 
-    def otlp_sink(self, message: Any):
-        """Process log message and emit to OTLP.
+    def otlp_sink(self, message: Any) -> None:
+        """Emit a log message to the configured OTLP exporter.
+
+        Builds a log-record dict from *message* and forwards it to the
+        OpenTelemetry logger provider.
+
+        .. note::
+            This method is not registered as a loguru sink directly — the unified
+            :meth:`_log_sink` handles dispatch.  It is kept as a public method so
+            tests can exercise the OTLP path in isolation.
 
         Args:
-            message (Any): Log message to process and emit
-
-        This method:
-        - Builds a log record dict from the message
-        - Sends the record to OpenTelemetry
+            message: Loguru message object (must have a ``.record`` dict attribute).
         """
         try:
             log_record = _make_log_record_dict(message)

--- a/application_sdk/observability/metrics_adaptor.py
+++ b/application_sdk/observability/metrics_adaptor.py
@@ -40,7 +40,7 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
     """A metrics adapter for Atlan that extends AtlanObservability.
 
     This adapter provides functionality for recording, processing, and exporting
-    metrics to various backends including OpenTelemetry, Segment API, and parquet files.
+    metrics to various backends including OpenTelemetry, Segment API, and gzip-compressed NDJSON files.
 
     Features:
     - Metric recording with labels and units
@@ -48,7 +48,7 @@ class AtlanMetricsAdapter(AtlanObservability[MetricRecord]):
     - Segment API integration
     - Periodic metric flushing
     - Console logging
-    - Parquet file storage
+    - Gzip-compressed NDJSON file storage
     """
 
     _flush_task_started: ClassVar[bool] = False

--- a/application_sdk/observability/observability.py
+++ b/application_sdk/observability/observability.py
@@ -4,6 +4,7 @@ import logging
 import os
 import threading
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from time import time
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
@@ -47,6 +48,22 @@ OBSERVABILITY_S3_PREFIX_MAP = {
 
 
 T = TypeVar("T")
+
+
+@dataclass
+class _PartitionWriter:
+    """State for the single open gzip partition file inside ``_flush_records``.
+
+    Invariant: an instance is live (file open, local file on disk) from the moment
+    it is created until ``_upload_and_delete`` completes or the outer ``finally``
+    block of ``_flush_records`` cleans it up.  The local ``current_writer`` variable
+    being ``None`` is the signal that no partition file is currently open.
+    """
+
+    partition_path: str
+    local_path: str
+    remote_key: str
+    file: gzip.GzipFile
 
 
 class AtlanObservability(Generic[T], ABC):
@@ -369,11 +386,13 @@ class AtlanObservability(Generic[T], ABC):
         except ImportError:  # conformance: ignore[E002,E008] Temporal sandbox check unavailable outside a worker; normal flush
             pass
 
-        # Active partition state — only one gzip file is open at a time.
-        current_partition_path: str | None = None
-        current_file: gzip.GzipFile | None = None
-        current_local_path: str | None = None
-        current_remote_key: str | None = None
+        # ``current_writer`` is non-None iff a gzip partition file is currently open.
+        # The _PartitionWriter dataclass bundles all four related state fields so they
+        # are always updated atomically — preventing the bug where an upload failure
+        # left current_partition_path pointing at the closed partition while
+        # current_file was None, causing the next same-partition record to call
+        # write() on None.
+        current_writer: _PartitionWriter | None = None
 
         try:
             for record in records:
@@ -381,17 +400,26 @@ class AtlanObservability(Generic[T], ABC):
                     record_time = datetime.fromtimestamp(record["timestamp"])
                     partition_path = self._get_partition_path(record_time)
 
-                    if partition_path != current_partition_path:
+                    if (
+                        current_writer is None
+                        or partition_path != current_writer.partition_path
+                    ):
                         # Finalize the current partition before switching.
-                        if current_file is not None:
-                            current_file.close()
-                            current_file = None
-                            # _upload_and_delete unlinks local_path in its finally
-                            await self._upload_and_delete(
-                                current_local_path,  # type: ignore[arg-type]
-                                current_remote_key,  # type: ignore[arg-type]
-                            )
-                            current_local_path = None
+                        if current_writer is not None:
+                            try:
+                                current_writer.file.close()
+                                # _upload_and_delete unlinks the local file in its own finally.
+                                await self._upload_and_delete(
+                                    current_writer.local_path,
+                                    current_writer.remote_key,
+                                )
+                            finally:
+                                # Reset atomically on both success and failure.  On failure,
+                                # _upload_and_delete's own finally already removed the local
+                                # file, so there is no disk leak.  Resetting here ensures the
+                                # next same-partition record opens a fresh file rather than
+                                # writing to a None handle.
+                                current_writer = None
 
                         # Open a fresh gzip file for the new partition.
                         os.makedirs(partition_path, exist_ok=True)
@@ -403,27 +431,29 @@ class AtlanObservability(Generic[T], ABC):
                         filename = (
                             f"{ts_ns}_{DEPLOYMENT_NAME}_{APPLICATION_NAME}.json.gz"
                         )
-                        current_local_path = os.path.join(partition_path, filename)
-                        current_remote_key = self._build_remote_key(
-                            record_time, filename
+                        local_path = os.path.join(partition_path, filename)
+                        current_writer = _PartitionWriter(
+                            partition_path=partition_path,
+                            local_path=local_path,
+                            remote_key=self._build_remote_key(record_time, filename),
+                            file=gzip.open(local_path, "wb"),
                         )
-                        current_file = gzip.open(current_local_path, "wb")
-                        current_partition_path = partition_path
 
-                    current_file.write(orjson.dumps(record) + b"\n")  # type: ignore[union-attr]
+                    current_writer.file.write(orjson.dumps(record) + b"\n")
 
                 except Exception:
                     logging.error("Error writing observability record", exc_info=True)
 
             # Finalize the last open partition.
-            if current_file is not None:
-                current_file.close()
-                current_file = None
-                await self._upload_and_delete(
-                    current_local_path,  # type: ignore[arg-type]
-                    current_remote_key,  # type: ignore[arg-type]
-                )
-                current_local_path = None
+            if current_writer is not None:
+                try:
+                    current_writer.file.close()
+                    await self._upload_and_delete(
+                        current_writer.local_path,
+                        current_writer.remote_key,
+                    )
+                finally:
+                    current_writer = None
 
             # Clean up old records if enabled
             if self._cleanup_enabled:
@@ -433,15 +463,15 @@ class AtlanObservability(Generic[T], ABC):
             logging.error("Error flushing records batch", exc_info=True)
 
         finally:
-            # Defensive: if an unexpected exception left a file handle open, close it
-            # and remove any orphaned local file to prevent descriptor/disk leaks.
-            if current_file is not None:
+            # Defensive: if an unexpected exception left the writer open, close its
+            # file handle and remove any orphaned local file to prevent leaks.
+            if current_writer is not None:
                 try:
-                    current_file.close()
+                    current_writer.file.close()
                 except Exception:
                     logging.warning("Error closing orphaned gzip file", exc_info=True)
-            if current_local_path and os.path.exists(current_local_path):
-                os.unlink(current_local_path)
+                if os.path.exists(current_writer.local_path):
+                    os.unlink(current_writer.local_path)
 
     async def _check_and_cleanup(self):
         """Check if cleanup is needed and perform it if necessary.

--- a/application_sdk/observability/observability.py
+++ b/application_sdk/observability/observability.py
@@ -77,7 +77,7 @@ class AtlanObservability(Generic[T], ABC):
     - Periodic flushing to storage
     - Data retention management
     - Error handling and signal management
-    - Parquet file storage
+    - Gzip-compressed NDJSON file storage
     - Dapr object store integration
 
     Attributes:
@@ -406,20 +406,24 @@ class AtlanObservability(Generic[T], ABC):
                     ):
                         # Finalize the current partition before switching.
                         if current_writer is not None:
+                            # Swap out before close+upload so the triggering record is
+                            # never dropped: current_writer=None first means the code
+                            # below always opens a fresh writer for the new partition,
+                            # even if the upload raises.  _upload_and_delete's own
+                            # finally unlinks the local file, so no disk leak on failure.
+                            prev_writer = current_writer
+                            current_writer = None
                             try:
-                                current_writer.file.close()
-                                # _upload_and_delete unlinks the local file in its own finally.
+                                prev_writer.file.close()
                                 await self._upload_and_delete(
-                                    current_writer.local_path,
-                                    current_writer.remote_key,
+                                    prev_writer.local_path,
+                                    prev_writer.remote_key,
                                 )
-                            finally:
-                                # Reset atomically on both success and failure.  On failure,
-                                # _upload_and_delete's own finally already removed the local
-                                # file, so there is no disk leak.  Resetting here ensures the
-                                # next same-partition record opens a fresh file rather than
-                                # writing to a None handle.
-                                current_writer = None
+                            except Exception:
+                                logging.error(
+                                    "Error finalizing observability partition",
+                                    exc_info=True,
+                                )
 
                         # Open a fresh gzip file for the new partition.
                         os.makedirs(partition_path, exist_ok=True)

--- a/application_sdk/observability/observability.py
+++ b/application_sdk/observability/observability.py
@@ -129,7 +129,6 @@ class AtlanObservability(Generic[T], ABC):
         self._cleanup_enabled = cleanup_enabled
         self.data_dir = data_dir
         self.file_name = file_name
-        self._update_parquet_path()
 
         # Ensure data directory exists
         os.makedirs(data_dir, exist_ok=True)
@@ -200,12 +199,69 @@ class AtlanObservability(Generic[T], ABC):
             f"hour={timestamp.hour:02d}",
         )
 
-    def _update_parquet_path(self):
-        """Update the parquet file path based on current timestamp."""
-        current_time = datetime.now()
-        partition_path = self._get_partition_path(current_time)
-        os.makedirs(partition_path, exist_ok=True)
-        self.parquet_path = os.path.join(partition_path, "data.parquet")
+    def _build_remote_key(self, partition_time: datetime, filename: str) -> str:
+        """Build the S3 remote key for a partition file.
+
+        Args:
+            partition_time: Timestamp used to derive the year/month/day/hour prefix.
+            filename: The local filename (e.g. ``<ts>_<deployment>_<app>.json.gz``).
+
+        Returns:
+            str: The fully qualified S3 key, e.g.
+                ``artifacts/apps/observability/sdr/logs/year=2025/month=06/day=29/hour=14/<filename>``.
+        """
+        signal_type = self._get_signal_type()
+        s3_prefix = OBSERVABILITY_S3_PREFIX_MAP.get(
+            signal_type,
+            f"artifacts/apps/observability/{_OBS_MODE}/other",
+        )
+        return os.path.join(
+            s3_prefix,
+            f"year={partition_time.year}",
+            f"month={partition_time.month:02d}",
+            f"day={partition_time.day:02d}",
+            f"hour={partition_time.hour:02d}",
+            filename,
+        )
+
+    async def _upload_and_delete(self, local_path: str, remote_key: str) -> None:
+        """Upload *local_path* to object store(s) then remove the local file.
+
+        The deployment-store upload is non-fatal (failure is logged at WARNING and
+        the method continues). The upstream-store upload (when ``ENABLE_ATLAN_UPLOAD``
+        is true) is allowed to propagate — the caller handles it.  The local file is
+        always deleted in the ``finally`` block to prevent disk leaks.
+
+        Args:
+            local_path: Absolute path to the local ``.json.gz`` file.
+            remote_key: S3 key (from :meth:`_build_remote_key`) to upload to.
+        """
+        from application_sdk.storage import upload_file  # noqa: PLC0415
+
+        try:
+            try:
+                await upload_file(
+                    remote_key,
+                    local_path,
+                    store=self._get_deployment_store(),
+                )
+            except Exception:
+                logging.warning(
+                    "Deployment objectstore upload failed (non-fatal)",
+                    exc_info=True,
+                )
+
+            if ENABLE_ATLAN_UPLOAD:
+                await upload_file(
+                    remote_key,
+                    local_path,
+                    store=self._get_upstream_store(),
+                )
+
+            logging.debug("Exported records → %s", remote_key)
+        finally:
+            if os.path.exists(local_path):
+                os.unlink(local_path)
 
     @abstractmethod
     def process_record(self, record: T) -> dict[str, Any]:
@@ -264,8 +320,10 @@ class AtlanObservability(Generic[T], ABC):
         """
         with self._buffer_lock:
             if self._buffer:
-                buffer_copy = self._buffer[:]
-                self._buffer.clear()
+                # Swap rather than copy: O(1) instead of O(n) — the old list reference
+                # is handed off to the flusher while a fresh list starts accumulating.
+                buffer_copy = self._buffer
+                self._buffer = []
             else:
                 buffer_copy = None
         if buffer_copy:
@@ -277,18 +335,27 @@ class AtlanObservability(Generic[T], ABC):
         Args:
             records: List of records to flush
 
-        This method:
-        - Groups records by partition (year/month/day/hour)
-        - Writes json.gz format (lightweight, no pandas dependency)
-        - Uses centralized path based on ENABLE_ATLAN_UPLOAD
-        - SDR path: artifacts/apps/observability/sdr-logs/ (MDLH reads from Atlan bucket)
-        - Non-SDR path: artifacts/apps/observability/logs/ (to be deprecated)
+        Uses a **single-pass streaming writer** to reduce peak memory.  Rather than
+        grouping all records into a ``partition_records`` dict (which holds two copies
+        of the full batch at peak), the method opens one gzip file per active partition
+        and writes each record as an NDJSON line as it is consumed.  Only one record
+        and one gzip write buffer are alive at any moment — O(1) extra memory
+        regardless of batch size.
+
+        Records are assumed to arrive in emission order (chronologically), so
+        hour-partitions appear as contiguous runs.  If a rare cross-thread reorder
+        causes a stale partition to reappear mid-flush, a second uniquely-named
+        ``.json.gz`` file is written for that hour — harmless since filenames carry a
+        nanosecond timestamp.
+
+        - Writes gzip-compressed NDJSON (no pandas/pyarrow dependency)
+        - SDR path: ``artifacts/apps/observability/sdr/logs/``    (``ENABLE_ATLAN_UPLOAD=true``)
+        - Non-SDR path: ``artifacts/apps/observability/non-sdr/logs/``
         - Uploads to customer bucket (DEPLOYMENT_OBJECT_STORE) always
-        - Uploads to Atlan bucket (UPSTREAM_OBJECT_STORE) when ENABLE_ATLAN_UPLOAD=true
+        - Uploads to Atlan bucket (UPSTREAM_OBJECT_STORE) when ``ENABLE_ATLAN_UPLOAD=true``
         """
         if not ENABLE_OBSERVABILITY_STORE_SINK or not records:
             return
-        from application_sdk.storage import upload_file  # noqa: PLC0415
 
         # File I/O is restricted inside Temporal's workflow sandbox — skip the
         # store sink there; records are still exported via OTLP/console.
@@ -301,89 +368,62 @@ class AtlanObservability(Generic[T], ABC):
                 return
         except ImportError:  # conformance: ignore[E002,E008] Temporal sandbox check unavailable outside a worker; normal flush
             pass
+
+        # Active partition state — only one gzip file is open at a time.
+        current_partition_path: str | None = None
+        current_file: gzip.GzipFile | None = None
+        current_local_path: str | None = None
+        current_remote_key: str | None = None
+
         try:
-            # Group records by partition using record's own timestamp
-            partition_records: dict[str, list[dict[str, Any]]] = {}
             for record in records:
-                record_time = datetime.fromtimestamp(record["timestamp"])
-                partition_path = self._get_partition_path(record_time)
-
-                if partition_path not in partition_records:
-                    partition_records[partition_path] = []
-                partition_records[partition_path].append(record)
-
-            # Write each partition as json.gz and upload
-            for partition_path, partition_data in partition_records.items():
-                local_path = None
                 try:
-                    os.makedirs(partition_path, exist_ok=True)
+                    record_time = datetime.fromtimestamp(record["timestamp"])
+                    partition_path = self._get_partition_path(record_time)
 
-                    # Get timestamp from first record for remote key partitioning
-                    first_record_time = datetime.fromtimestamp(
-                        partition_data[0]["timestamp"]
-                    )
+                    if partition_path != current_partition_path:
+                        # Finalize the current partition before switching.
+                        if current_file is not None:
+                            current_file.close()
+                            current_file = None
+                            # _upload_and_delete unlinks local_path in its finally
+                            await self._upload_and_delete(
+                                current_local_path,  # type: ignore[arg-type]
+                                current_remote_key,  # type: ignore[arg-type]
+                            )
+                            current_local_path = None
 
-                    # Lexi-sortable filename.
-                    # Use datetime.now() rather than time.time_ns(): the latter is
-                    # restricted inside Temporal's workflow sandbox (non-deterministic),
-                    # while datetime.now() is patched by the SDK to be safe there.
-                    ts_ns = int(datetime.now().timestamp() * 1e9)
-                    filename = f"{ts_ns}_{DEPLOYMENT_NAME}_{APPLICATION_NAME}.json.gz"
-                    local_path = os.path.join(partition_path, filename)
-
-                    # Write NDJSON with gzip compression
-                    with gzip.open(local_path, "wb") as f:
-                        for record in partition_data:
-                            f.write(orjson.dumps(record) + b"\n")
-
-                    # Compute remote key using signal-type-specific S3 prefix
-                    signal_type = self._get_signal_type()
-                    s3_prefix = OBSERVABILITY_S3_PREFIX_MAP.get(
-                        signal_type,
-                        f"artifacts/apps/observability/{_OBS_MODE}/other",
-                    )
-                    remote_key = os.path.join(
-                        s3_prefix,
-                        f"year={first_record_time.year}",
-                        f"month={first_record_time.month:02d}",
-                        f"day={first_record_time.day:02d}",
-                        f"hour={first_record_time.hour:02d}",
-                        filename,
-                    )
-
-                    # Upload to customer bucket (non-fatal if fails)
-                    try:
-                        await upload_file(
-                            remote_key,
-                            local_path,
-                            store=self._get_deployment_store(),
+                        # Open a fresh gzip file for the new partition.
+                        os.makedirs(partition_path, exist_ok=True)
+                        # Lexi-sortable filename.
+                        # Use datetime.now() rather than time.time_ns(): the latter is
+                        # restricted inside Temporal's workflow sandbox (non-deterministic),
+                        # while datetime.now() is patched by the SDK to be safe there.
+                        ts_ns = int(datetime.now().timestamp() * 1e9)
+                        filename = (
+                            f"{ts_ns}_{DEPLOYMENT_NAME}_{APPLICATION_NAME}.json.gz"
                         )
-                    except Exception:
-                        logging.warning(
-                            "Deployment objectstore upload failed (non-fatal)",
-                            exc_info=True,
+                        current_local_path = os.path.join(partition_path, filename)
+                        current_remote_key = self._build_remote_key(
+                            record_time, filename
                         )
+                        current_file = gzip.open(current_local_path, "wb")
+                        current_partition_path = partition_path
 
-                    # Upload to Atlan bucket (independent, MDLH reads from here)
-                    if ENABLE_ATLAN_UPLOAD:
-                        await upload_file(
-                            remote_key,
-                            local_path,
-                            store=self._get_upstream_store(),
-                        )
-
-                    logging.debug(
-                        "Exported %d records → %s", len(partition_data), remote_key
-                    )
+                    current_file.write(orjson.dumps(record) + b"\n")  # type: ignore[union-attr]
 
                 except Exception:
-                    logging.error(
-                        "Error processing partition %s", partition_path, exc_info=True
-                    )
-                finally:
-                    # Always clean up local file to prevent disk leaks
-                    if local_path and os.path.exists(local_path):
-                        os.unlink(local_path)
+                    logging.error("Error writing observability record", exc_info=True)
+
+            # Finalize the last open partition.
+            if current_file is not None:
+                current_file.close()
+                current_file = None
+                await self._upload_and_delete(
+                    current_local_path,  # type: ignore[arg-type]
+                    current_remote_key,  # type: ignore[arg-type]
+                )
+                current_local_path = None
 
             # Clean up old records if enabled
             if self._cleanup_enabled:
@@ -391,6 +431,17 @@ class AtlanObservability(Generic[T], ABC):
 
         except Exception:
             logging.error("Error flushing records batch", exc_info=True)
+
+        finally:
+            # Defensive: if an unexpected exception left a file handle open, close it
+            # and remove any orphaned local file to prevent descriptor/disk leaks.
+            if current_file is not None:
+                try:
+                    current_file.close()
+                except Exception:
+                    logging.warning("Error closing orphaned gzip file", exc_info=True)
+            if current_local_path and os.path.exists(current_local_path):
+                os.unlink(current_local_path)
 
     async def _check_and_cleanup(self):
         """Check if cleanup is needed and perform it if necessary.
@@ -529,8 +580,9 @@ class AtlanObservability(Generic[T], ABC):
                     or (now - self._last_flush_time) >= self._flush_interval
                 ):
                     self._last_flush_time = now
-                    buffer_copy = self._buffer[:]
-                    self._buffer.clear()
+                    # Swap rather than copy: O(1) instead of O(n).
+                    buffer_copy = self._buffer
+                    self._buffer = []
                 else:
                     buffer_copy = None
 

--- a/application_sdk/observability/traces_adaptor.py
+++ b/application_sdk/observability/traces_adaptor.py
@@ -28,7 +28,7 @@ from application_sdk.observability.utils import (
     get_observability_dir,
 )
 
-# Local traces-parquet sink tuning. Hardcoded — production does not yet
+# Local traces object-store sink tuning. Hardcoded — production does not yet
 # support traces; the local sink is dormant until the trace pipeline lands.
 _TRACES_BATCH_SIZE = 100
 _TRACES_FLUSH_INTERVAL_SECONDS = 5
@@ -47,14 +47,14 @@ class AtlanTracesAdapter(AtlanObservability[TraceRecord]):
     """A traces adapter for Atlan that extends AtlanObservability.
 
     This adapter provides functionality for recording, processing, and exporting
-    distributed traces to various backends including OpenTelemetry and parquet files.
+    distributed traces to various backends including OpenTelemetry and gzip-compressed NDJSON files.
 
     Features:
     - Distributed tracing with spans and events
     - OpenTelemetry integration
     - Periodic trace flushing
     - Console logging
-    - Parquet file storage
+    - Gzip-compressed NDJSON file storage
     """
 
     _flush_task_started: ClassVar[bool] = False
@@ -231,7 +231,9 @@ class AtlanTracesAdapter(AtlanObservability[TraceRecord]):
         Returns:
             Dict[str, Any]: Standardized dictionary representation of the trace
 
-        This method ensures traces are properly formatted for storage in traces.parquet.
+        This method ensures traces are properly formatted for storage in gzip-compressed NDJSON
+        (the traces.parquet env-var name is a signal-type discriminator, not an on-disk format — see
+        constants.py TRACES_FILE_NAME).
         It converts the TraceRecord into a dictionary with all necessary fields.
         """
         if isinstance(record, TraceRecord):

--- a/docs/concepts/monitoring.md
+++ b/docs/concepts/monitoring.md
@@ -234,7 +234,7 @@ cid = ctx.correlation_id if ctx else None  # str (empty when unset) or None when
 
 ## Observability Store Sink
 
-By default, logs, metrics, and traces are also written to parquet files in the object store under `artifacts/apps/{app_name}/{deployment_name}/observability/`. This enables historical querying even when the live pipelines (OTLP for logs/traces, Prometheus scrape / Pushgateway push for metrics) are unavailable.
+By default, logs, metrics, and traces are also written to gzip-compressed NDJSON files (`.json.gz`) in the object store under `artifacts/apps/{app_name}/{deployment_name}/observability/`. This enables historical querying even when the live pipelines (OTLP for logs/traces, Prometheus scrape / Pushgateway push for metrics) are unavailable.
 
 Control with:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,11 +160,11 @@ Used by `RedisCapacityPool` for distributed slot locking. Leave empty if you use
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ATLAN_LOG_LEVEL` | `INFO` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`). **Fallback:** `LOG_LEVEL`. `CRITICAL` is accepted by loguru but prohibited in app code per [ADR-0011](adr/0011-logging-level-guidelines.md). |
-| `ATLAN_LOG_BATCH_SIZE` | `100` | Records buffered before flushing to the parquet sink. |
-| `ATLAN_LOG_FLUSH_INTERVAL_SECONDS` | `10` | Seconds between parquet sink flushes. |
-| `ATLAN_LOG_RETENTION_DAYS` | `30` | Days to retain parquet log files before cleanup. |
+| `ATLAN_LOG_BATCH_SIZE` | `100` | Records buffered before flushing to the object-store sink. |
+| `ATLAN_LOG_FLUSH_INTERVAL_SECONDS` | `10` | Seconds between object-store sink flushes. |
+| `ATLAN_LOG_RETENTION_DAYS` | `30` | Days to retain log files in the object store before cleanup. |
 | `ATLAN_LOG_CLEANUP_ENABLED` | `false` | Enable automatic cleanup of old log files. Any non-empty string value (including `"false"`) is treated as `true` by `bool()`; unset or empty to disable. |
-| `ATLAN_LOG_FILE_NAME` | `log.parquet` | Parquet log file name. |
+| `ATLAN_LOG_FILE_NAME` | `log.parquet` | Signal-type discriminator used internally to route records to the correct observability sub-path (logs / metrics / traces). **The default is kept as `log.parquet` for back-compat; the on-disk and object-store format is gzip-compressed NDJSON (`.json.gz`), not parquet.** |
 
 ---
 
@@ -172,8 +172,8 @@ Used by `RedisCapacityPool` for distributed slot locking. Leave empty if you use
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ATLAN_METRICS_BATCH_SIZE` | `100` | Records buffered before flushing to the parquet sink. |
-| `ATLAN_METRICS_FLUSH_INTERVAL_SECONDS` | `10` | Seconds between parquet sink flushes. |
+| `ATLAN_METRICS_BATCH_SIZE` | `100` | Records buffered before flushing to the object-store sink. |
+| `ATLAN_METRICS_FLUSH_INTERVAL_SECONDS` | `10` | Seconds between object-store sink flushes. |
 | `ATLAN_METRICS_RETENTION_DAYS` | `30` | Days to retain parquet metric files. |
 | `ATLAN_METRICS_CLEANUP_ENABLED` | `false` | Enable automatic cleanup of old metric files. Uses `.lower() == "true"` — safe to set to `"false"` to disable. |
 | `ATLAN_ENABLE_TEMPORAL_CORE_METRICS` | `true` | Bind the Temporal Rust-core Prometheus endpoint at `ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS` (loopback) in worker/combined mode so its metric set (`temporal_workflow_*`, `temporal_activity_*`, etc.) is reachable for the combined-mode FastAPI `/metrics` proxy and the worker's `TemporalCoreCollector`. The FastAPI `/metrics` route is always exposed regardless of this flag — when this flag is `false`, or in handler-only mode, the response simply omits the proxied Temporal Rust-core families. `run_dev_combined()` defaults to `false` to avoid hot-reload port collisions. See [Monitoring](concepts/monitoring.md). |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,7 +174,7 @@ Used by `RedisCapacityPool` for distributed slot locking. Leave empty if you use
 |----------|---------|-------------|
 | `ATLAN_METRICS_BATCH_SIZE` | `100` | Records buffered before flushing to the object-store sink. |
 | `ATLAN_METRICS_FLUSH_INTERVAL_SECONDS` | `10` | Seconds between object-store sink flushes. |
-| `ATLAN_METRICS_RETENTION_DAYS` | `30` | Days to retain parquet metric files. |
+| `ATLAN_METRICS_RETENTION_DAYS` | `30` | Days to retain metric files in the object store before cleanup. |
 | `ATLAN_METRICS_CLEANUP_ENABLED` | `false` | Enable automatic cleanup of old metric files. Uses `.lower() == "true"` — safe to set to `"false"` to disable. |
 | `ATLAN_ENABLE_TEMPORAL_CORE_METRICS` | `true` | Bind the Temporal Rust-core Prometheus endpoint at `ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS` (loopback) in worker/combined mode so its metric set (`temporal_workflow_*`, `temporal_activity_*`, etc.) is reachable for the combined-mode FastAPI `/metrics` proxy and the worker's `TemporalCoreCollector`. The FastAPI `/metrics` route is always exposed regardless of this flag — when this flag is `false`, or in handler-only mode, the response simply omits the proxied Temporal Rust-core families. `run_dev_combined()` defaults to `false` to avoid hot-reload port collisions. See [Monitoring](concepts/monitoring.md). |
 | `ATLAN_PROMETHEUS_PUSHGATEWAY_URL` | _(empty)_ | Pushgateway URL workers push to (split deployment). Empty disables push — combined-mode pods leave it unset and rely on direct `/metrics` scrape. |

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -304,13 +304,6 @@ def test_process_with_complex_types(logger_adapter: AtlanLoggerAdapter, mock_log
         logger_adapter.logger = original_logger
 
 
-@pytest.fixture
-def mock_parquet_file(tmp_path):
-    """Create a temporary parquet file for testing."""
-    parquet_path = tmp_path / "logs.parquet"
-    return parquet_path
-
-
 @pytest.fixture(autouse=True)
 def clear_log_buffer(logger_adapter):
     """Clear the log buffer before each test."""
@@ -320,12 +313,9 @@ def clear_log_buffer(logger_adapter):
 
 
 @pytest.mark.asyncio
-async def test_parquet_sink_buffering(mock_parquet_file):
-    """Test that parquet_sink properly buffers logs."""
+async def test_objectstore_sink_buffering():
+    """Test that objectstore_sink properly buffers logs."""
     with create_logger_adapter() as logger_adapter:
-        # Set the parquet file path directly on the instance
-        logger_adapter.parquet_path = str(mock_parquet_file)
-
         # Create a test message
         test_message = mock.MagicMock()
         level_mock = mock.MagicMock()
@@ -341,8 +331,8 @@ async def test_parquet_sink_buffering(mock_parquet_file):
             "function": "test_function",
         }
 
-        # Call parquet_sink
-        await logger_adapter.parquet_sink(test_message)
+        # Call objectstore_sink
+        await logger_adapter.objectstore_sink(test_message)
 
         # Verify log was added to buffer
         assert len(logger_adapter._buffer) == 1
@@ -353,12 +343,9 @@ async def test_parquet_sink_buffering(mock_parquet_file):
 
 
 @pytest.mark.asyncio
-async def test_parquet_sink_error_handling(mock_parquet_file):
-    """Test that parquet_sink handles errors gracefully."""
+async def test_objectstore_sink_error_handling():
+    """Test that objectstore_sink handles errors gracefully."""
     with create_logger_adapter() as logger_adapter:
-        # Set the parquet file path directly on the instance
-        logger_adapter.parquet_path = str(mock_parquet_file)
-
         # Create a test message with invalid data
         test_message = mock.MagicMock()
         test_message.record = {
@@ -371,11 +358,131 @@ async def test_parquet_sink_error_handling(mock_parquet_file):
             "function": "test_function",
         }
 
-        # Call parquet_sink - should not raise exception
-        await logger_adapter.parquet_sink(test_message)
+        # Call objectstore_sink - should not raise exception
+        await logger_adapter.objectstore_sink(test_message)
 
-        # Verify buffer is empty (error was handled
+        # Verify buffer is empty (error was handled)
         assert len(logger_adapter._buffer) == 0
+
+
+class TestFlushRecordsSinglePass:
+    """Direct coverage for AtlanObservability._flush_records single-pass writer.
+
+    The single-pass writer opens one gzip file per active hour-partition and
+    uploads it when the partition changes (or at end of batch).  These tests
+    assert the file count, remote key structure, and NDJSON content without
+    touching real object stores.
+    """
+
+    @staticmethod
+    def _make_record(ts: float, message: str = "test") -> dict:
+        return {
+            "timestamp": ts,
+            "level": "INFO",
+            "logger_name": "test",
+            "message": message,
+            "file": "test.py",
+            "line": 1,
+            "function": "test_fn",
+            "extra": {},
+        }
+
+    @pytest.mark.asyncio
+    async def test_single_partition_writes_one_file(self, tmp_path):
+        """Records within the same hour produce exactly one upload call.
+
+        Verifies that the written file is valid gzip-compressed NDJSON and that
+        all records appear in the order they were passed.
+        """
+        import gzip as _gzip
+
+        import orjson as _orjson
+
+        base_ts = datetime(2025, 6, 15, 10, 30, 0).timestamp()
+        records = [self._make_record(base_ts + i, f"msg-{i}") for i in range(3)]
+        uploaded: list[tuple[str, str]] = []
+
+        async def _fake_upload(local_path: str, remote_key: str) -> None:
+            # Record args but skip unlink so the test can read the file.
+            uploaded.append((local_path, remote_key))
+
+        with create_logger_adapter() as adapter:
+            adapter.data_dir = str(tmp_path)
+            with (
+                mock.patch.object(
+                    adapter, "_upload_and_delete", side_effect=_fake_upload
+                ),
+                mock.patch(
+                    "application_sdk.observability.observability.ENABLE_OBSERVABILITY_STORE_SINK",
+                    True,
+                ),
+            ):
+                await adapter._flush_records(records)
+
+        assert len(uploaded) == 1, f"Expected 1 upload, got {len(uploaded)}"
+        local_path, remote_key = uploaded[0]
+        assert "year=2025" in remote_key
+        assert "month=06" in remote_key
+        assert "day=15" in remote_key
+        assert "hour=10" in remote_key
+        assert local_path.endswith(".json.gz")
+
+        with _gzip.open(local_path, "rb") as fh:
+            lines = fh.read().splitlines()
+        assert len(lines) == 3
+        messages = [_orjson.loads(ln)["message"] for ln in lines]
+        assert messages == ["msg-0", "msg-1", "msg-2"]
+
+    @pytest.mark.asyncio
+    async def test_multi_partition_writes_separate_files(self, tmp_path):
+        """Records spanning two different hours produce two separate upload calls.
+
+        Asserts that the remote keys correctly map to the hour derived from each
+        record's timestamp — not the hour of the flush call.
+        """
+        ts_h10 = datetime(2025, 6, 15, 10, 59, 0).timestamp()
+        ts_h11 = datetime(2025, 6, 15, 11, 1, 0).timestamp()
+        records = [
+            self._make_record(ts_h10, "hour10"),
+            self._make_record(ts_h11, "hour11"),
+        ]
+        uploaded: list[tuple[str, str]] = []
+
+        async def _fake_upload(local_path: str, remote_key: str) -> None:
+            uploaded.append((local_path, remote_key))
+
+        with create_logger_adapter() as adapter:
+            adapter.data_dir = str(tmp_path)
+            with (
+                mock.patch.object(
+                    adapter, "_upload_and_delete", side_effect=_fake_upload
+                ),
+                mock.patch(
+                    "application_sdk.observability.observability.ENABLE_OBSERVABILITY_STORE_SINK",
+                    True,
+                ),
+            ):
+                await adapter._flush_records(records)
+
+        assert len(uploaded) == 2, f"Expected 2 uploads, got {len(uploaded)}"
+        remote_keys = [u[1] for u in uploaded]
+        assert any("hour=10" in k for k in remote_keys), remote_keys
+        assert any("hour=11" in k for k in remote_keys), remote_keys
+        # Each partition produces a distinct local file
+        local_paths = [u[0] for u in uploaded]
+        assert local_paths[0] != local_paths[1]
+
+    @pytest.mark.asyncio
+    async def test_empty_records_is_noop(self):
+        """An empty record list never reaches the gzip/upload path."""
+        with create_logger_adapter() as adapter:
+            with mock.patch.object(adapter, "_upload_and_delete") as mock_upload:
+                with mock.patch(
+                    "application_sdk.observability.observability.ENABLE_OBSERVABILITY_STORE_SINK",
+                    True,
+                ):
+                    await adapter._flush_records([])
+        mock_upload.assert_not_called()
 
 
 class TestCorrelationContext:

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -484,6 +484,131 @@ class TestFlushRecordsSinglePass:
                     await adapter._flush_records([])
         mock_upload.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_out_of_order_records_writes_second_file_for_same_hour(
+        self, tmp_path
+    ):
+        """Out-of-order records (A, B, A) produce a second file for hour A.
+
+        The docstring promises that a rare cross-thread reorder causes a second
+        uniquely-named ``.json.gz`` for the reappearing partition.  Sequence the
+        records as [hour10, hour11, hour10] and assert three distinct upload calls
+        with two calls targeting hour10 and one targeting hour11, all with distinct
+        local file paths.
+        """
+        ts_h10a = datetime(2025, 6, 15, 10, 30, 0).timestamp()
+        ts_h11 = datetime(2025, 6, 15, 11, 10, 0).timestamp()
+        ts_h10b = datetime(2025, 6, 15, 10, 55, 0).timestamp()
+        records = [
+            self._make_record(ts_h10a, "h10-first"),
+            self._make_record(ts_h11, "h11"),
+            self._make_record(ts_h10b, "h10-second"),
+        ]
+        uploaded: list[tuple[str, str]] = []
+
+        async def _fake_upload(local_path: str, remote_key: str) -> None:
+            uploaded.append((local_path, remote_key))
+
+        with create_logger_adapter() as adapter:
+            adapter.data_dir = str(tmp_path)
+            with (
+                mock.patch.object(
+                    adapter, "_upload_and_delete", side_effect=_fake_upload
+                ),
+                mock.patch(
+                    "application_sdk.observability.observability.ENABLE_OBSERVABILITY_STORE_SINK",
+                    True,
+                ),
+            ):
+                await adapter._flush_records(records)
+
+        assert len(uploaded) == 3, f"Expected 3 uploads, got {len(uploaded)}"
+        remote_keys = [u[1] for u in uploaded]
+        local_paths = [u[0] for u in uploaded]
+        # Two uploads for hour10, one for hour11
+        assert sum(1 for k in remote_keys if "hour=10" in k) == 2, remote_keys
+        assert sum(1 for k in remote_keys if "hour=11" in k) == 1, remote_keys
+        # All three local paths must be distinct (lexi-sortable unique names)
+        assert len(set(local_paths)) == 3, local_paths
+
+
+class TestLogSinkFanOut:
+    """Tests for _log_sink fan-out to both object-store and OTLP targets."""
+
+    @pytest.mark.asyncio
+    async def test_log_sink_calls_both_targets_when_both_active(self):
+        """_log_sink builds the record dict once and fans to add_record + _send_to_otel.
+
+        When both the object-store sink and OTLP are enabled, each should receive
+        exactly one call — and _make_log_record_dict is only invoked once (not twice
+        as would happen with two independent sinks).
+        """
+        test_message = mock.MagicMock()
+        level_mock = mock.MagicMock()
+        level_mock.name = "INFO"
+        test_message.record = {
+            "time": datetime.now(),
+            "level": level_mock,
+            "extra": {"logger_name": "test"},
+            "message": "fan-out test",
+            "file": mock.MagicMock(path="test.py"),
+            "line": 1,
+            "function": "fn",
+        }
+
+        with create_logger_adapter() as adapter:
+            # Simulate OTLP being configured by setting logger_provider.
+            adapter.logger_provider = mock.MagicMock()
+
+            with (
+                mock.patch.object(adapter, "add_record") as mock_add_record,
+                mock.patch.object(adapter, "_send_to_otel") as mock_send_otel,
+                mock.patch(
+                    "application_sdk.observability.logger_adaptor.ENABLE_OBSERVABILITY_STORE_SINK",
+                    True,
+                ),
+            ):
+                await adapter._log_sink(test_message)
+
+        mock_add_record.assert_called_once()
+        mock_send_otel.assert_called_once()
+        # Both targets receive the same dict object (built once).
+        store_arg = mock_add_record.call_args[0][0]
+        otel_arg = mock_send_otel.call_args[0][0]
+        assert store_arg is otel_arg
+
+    @pytest.mark.asyncio
+    async def test_log_sink_store_only_when_otlp_not_configured(self):
+        """_log_sink skips _send_to_otel when logger_provider is None."""
+        test_message = mock.MagicMock()
+        level_mock = mock.MagicMock()
+        level_mock.name = "INFO"
+        test_message.record = {
+            "time": datetime.now(),
+            "level": level_mock,
+            "extra": {"logger_name": "test"},
+            "message": "store only",
+            "file": mock.MagicMock(path="test.py"),
+            "line": 1,
+            "function": "fn",
+        }
+
+        with create_logger_adapter() as adapter:
+            adapter.logger_provider = None  # no OTLP
+
+            with (
+                mock.patch.object(adapter, "add_record") as mock_add_record,
+                mock.patch.object(adapter, "_send_to_otel") as mock_send_otel,
+                mock.patch(
+                    "application_sdk.observability.logger_adaptor.ENABLE_OBSERVABILITY_STORE_SINK",
+                    True,
+                ),
+            ):
+                await adapter._log_sink(test_message)
+
+        mock_add_record.assert_called_once()
+        mock_send_otel.assert_not_called()
+
 
 class TestCorrelationContext:
     """Tests for correlation context in logging."""

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -485,6 +485,55 @@ class TestFlushRecordsSinglePass:
         mock_upload.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_partition_switch_after_upload_failure_continues(self, tmp_path):
+        """Upload failure on partition switch does not drop the triggering record.
+
+        The _PartitionWriter swap-before-upload pattern ensures current_writer=None
+        before the upload attempt.  If the upload raises, the exception is caught
+        locally so the triggering record still reaches the fresh-writer-open path
+        below, and subsequent partitions are processed normally.
+        """
+        ts_h10 = datetime(2025, 6, 15, 10, 30, 0).timestamp()
+        ts_h11 = datetime(2025, 6, 15, 11, 10, 0).timestamp()
+        ts_h10b = datetime(2025, 6, 15, 10, 55, 0).timestamp()
+        records = [
+            self._make_record(ts_h10, "h10-first"),
+            self._make_record(ts_h11, "h11"),  # triggers switch; first upload raises
+            self._make_record(ts_h10b, "h10-second"),  # triggers second switch
+        ]
+        call_args: list[tuple[str, str]] = []
+
+        async def _upload_raises_first(local_path: str, remote_key: str) -> None:
+            call_args.append((local_path, remote_key))
+            if len(call_args) == 1:
+                raise OSError("simulated upstream upload failure")
+
+        with create_logger_adapter() as adapter:
+            adapter.data_dir = str(tmp_path)
+            with (
+                mock.patch.object(
+                    adapter, "_upload_and_delete", side_effect=_upload_raises_first
+                ),
+                mock.patch(
+                    "application_sdk.observability.observability.ENABLE_OBSERVABILITY_STORE_SINK",
+                    True,
+                ),
+            ):
+                # Must not propagate despite the first upload failing.
+                await adapter._flush_records(records)
+
+        # Three upload attempts: h10 (fails), h11 (succeeds), trailing h10 (succeeds).
+        assert len(call_args) == 3, f"Expected 3 upload attempts, got {len(call_args)}"
+        remote_keys = [a[1] for a in call_args]
+        assert "hour=10" in remote_keys[0], "first attempt should be for hour10"
+        assert "hour=11" in remote_keys[1], "second attempt should be for hour11"
+        assert "hour=10" in remote_keys[2], "third attempt should be trailing hour10"
+        # The trailing hour10 record reached a new file (different local path from the first h10).
+        assert (
+            call_args[0][0] != call_args[2][0]
+        ), "trailing hour10 record must be in a new file, not the failed-upload file"
+
+    @pytest.mark.asyncio
     async def test_out_of_order_records_writes_second_file_for_same_hour(
         self, tmp_path
     ):


### PR DESCRIPTION
## Summary

Implements the still-valid optimizations from BLDX-764 against the current codebase. The ticket's premise (Pydantic `LogRecord`, parquet/pandas) was already resolved; this PR addresses the three remaining issues:

- **Single-pass partition writer**: replaces the `partition_records: dict` grouping that materialized ~2× the buffer in memory. Records are now streamed as NDJSON lines into one open gzip file per active hour-partition. Peak extra memory is O(1) (one record + OS gzip write buffer) regardless of batch size.
- **Buffer swap instead of copy**: `_flush_buffer` and `add_record` now do `buffer_copy = self._buffer; self._buffer = []` — O(1) reference swap instead of an O(n) list copy at every flush cycle.
- **Unified `_log_sink`**: replaces the two independent loguru sinks (`parquet_sink` + `otlp_sink`), each of which called `_make_log_record_dict(message)` separately. The new sink builds the dict once and fans out, halving per-record dict-build CPU when both targets are active.
- **Dead "parquet" machinery removed**: deletes `_update_parquet_path()` / `self.parquet_path` (computed `data.parquet` but was never read by `_flush_records`), renames `parquet_sink` → `objectstore_sink`, and documents the `LOG_FILE_NAME` signal-discriminator convention in `constants.py`.

The shared `AtlanObservability` base class means logs, metrics, and traces adaptors all benefit.

## Test plan

- [x] `uv run pytest tests/unit/observability/ tests/unit/test_main.py -q` — 475 tests pass, 0 failures
- [x] `uv run pre-commit run --all-files` — pyright and ruff clean
- [ ] New `TestFlushRecordsSinglePass` class covers `_flush_records` directly: single-partition write (content verified via gzip/NDJSON decode), multi-partition routing (two upload calls with correct hour keys), empty-batch no-op
- [ ] `test_parquet_sink_buffering` / `test_parquet_sink_error_handling` renamed to `test_objectstore_sink_*` to match the rename

Closes BLDX-764