### PR TITLE
ci(conformance): wire app contract ledger into B005/B006 detection

### DIFF
--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -300,6 +300,13 @@ jobs:
         if: (steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push' || inputs.force-all) && inputs.conformance-ref == '' && matrix.needs_env != 'true'
         env:
           EXCLUDE_PATHS: ${{ matrix.exclude_paths }}
+          # B005/B006 (contract-compat) resolve the committed contract ledger
+          # from this path. Pointing it at the caller's ledger-path lets consumer
+          # apps check against their own repo-root contract_schema.lock.json (and
+          # the SDK against its package-data ledger) instead of the package
+          # default — without it, an app's entrypoint-contract fields always read
+          # as "not recorded" and B006 can never pass.
+          ATLAN_CONTRACT_LEDGER_PATH: ${{ inputs.ledger-path }}
         run: |
           args=(--repo . --series ${{ matrix.series }} --output "${{ matrix.slug }}.sarif")
           if [[ -n "$EXCLUDE_PATHS" ]]; then
@@ -311,6 +318,13 @@ jobs:
         if: (steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push' || inputs.force-all) && inputs.conformance-ref != '' && matrix.needs_env != 'true'
         env:
           EXCLUDE_PATHS: ${{ matrix.exclude_paths }}
+          # B005/B006 (contract-compat) resolve the committed contract ledger
+          # from this path. Pointing it at the caller's ledger-path lets consumer
+          # apps check against their own repo-root contract_schema.lock.json (and
+          # the SDK against its package-data ledger) instead of the package
+          # default — without it, an app's entrypoint-contract fields always read
+          # as "not recorded" and B006 can never pass.
+          ATLAN_CONTRACT_LEDGER_PATH: ${{ inputs.ledger-path }}
         run: |
           args=(--repo . --series ${{ matrix.series }} --output "${{ matrix.slug }}.sarif")
           if [[ -n "$EXCLUDE_PATHS" ]]; then
@@ -329,6 +343,13 @@ jobs:
         if: (steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push' || inputs.force-all) && inputs.conformance-ref == '' && matrix.needs_env == 'true'
         env:
           EXCLUDE_PATHS: ${{ matrix.exclude_paths }}
+          # B005/B006 (contract-compat) resolve the committed contract ledger
+          # from this path. Pointing it at the caller's ledger-path lets consumer
+          # apps check against their own repo-root contract_schema.lock.json (and
+          # the SDK against its package-data ledger) instead of the package
+          # default — without it, an app's entrypoint-contract fields always read
+          # as "not recorded" and B006 can never pass.
+          ATLAN_CONTRACT_LEDGER_PATH: ${{ inputs.ledger-path }}
         run: |
           args=(--repo . --series ${{ matrix.series }} --output "${{ matrix.slug }}.sarif")
           if [[ -n "$EXCLUDE_PATHS" ]]; then
@@ -346,6 +367,13 @@ jobs:
         if: (steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push' || inputs.force-all) && inputs.conformance-ref != '' && matrix.needs_env == 'true'
         env:
           EXCLUDE_PATHS: ${{ matrix.exclude_paths }}
+          # B005/B006 (contract-compat) resolve the committed contract ledger
+          # from this path. Pointing it at the caller's ledger-path lets consumer
+          # apps check against their own repo-root contract_schema.lock.json (and
+          # the SDK against its package-data ledger) instead of the package
+          # default — without it, an app's entrypoint-contract fields always read
+          # as "not recorded" and B006 can never pass.
+          ATLAN_CONTRACT_LEDGER_PATH: ${{ inputs.ledger-path }}
         run: |
           args=(--repo . --series ${{ matrix.series }} --output "${{ matrix.slug }}.sarif")
           if [[ -n "$EXCLUDE_PATHS" ]]; then


### PR DESCRIPTION
## Problem

`conformance-reusable.yaml` exposes a `ledger-path` input, but **only** the append-only `contract-ledger-guard` job consumed it. The B-series (`Deprecations`) detection legs run:

```bash
uvx atlan-application-sdk-conformance detect --repo . --series B ...
```

with no `ATLAN_CONTRACT_LEDGER_PATH` in the environment. So `load_ledger()` falls back to the **package-bundled** ledger (`conformance/data/contract_schema.lock.json` — the SDK's own contracts).

For a **consumer app** that is fatal: its entrypoint-contract subclasses (`MetabaseInput`, `MetabaseLineageOutput`, …) are not in the SDK's bundled ledger, so **every** field reads as "not recorded" and **B006 `StaleContractLedger` (BLOCK)** fails — no matter that the app committed a correct repo-root `contract_schema.lock.json`. The result: the `Deprecations` leg is **red fleet-wide** on every consumer app (and stays red even after the app does exactly what B006's message tells it to).

## Fix

Set `ATLAN_CONTRACT_LEDGER_PATH` from the **existing** `ledger-path` input on all four `detect` steps. This is the wiring the `ledger-path` input always implied — the guard job already used it; detection now does too.

- **Apps** (`conformance-ref == ''`, default `ledger-path: contract_schema.lock.json`) → B005/B006 check against the app's repo-root ledger. ✅
- **SDK dogfood** (`conformance-ref != ''`, caller sets `ledger-path: packages/conformance/conformance/data/contract_schema.lock.json`) → unchanged: still checks the SDK's package-data ledger. ✅

No detector or rule change — `RuleDefinition`s, SARIF, and docs are untouched. This is a CI-wiring fix only, so there is no remediation-program counterpart to add.

## Verification

Ran `detect --series B` with the env set, both ways:

| Repo | `ATLAN_CONTRACT_LEDGER_PATH` | B006 result |
|------|------------------------------|-------------|
| `atlan-metabase-app` (with committed ledger) | `contract_schema.lock.json` | **0** (was 35) |
| `application-sdk` (self / dogfood) | `packages/conformance/conformance/data/contract_schema.lock.json` | **0** — no regression (only pre-existing B002/B003/B004 WARNs) |

YAML validated; `pre-commit` passes on the changed file.

## Blast radius

Immediate and fleet-wide (callers reference this workflow `@main`). After merge, any app that has committed a current `contract_schema.lock.json` will see `Deprecations` go green; apps without one keep failing B006 — correctly, with the actionable "run `gen-contract-ledger`" message.

Companion app-side PR (commits the metabase ledger so it greens once this lands): atlanhq/atlan-metabase-app#151.
