### PR TITLE
ci(security): reconcile allowlist + tickets on release, not hourly (BLDX-1495)

### DIFF
--- a/.github/scripts/reconcile_allowlist.py
+++ b/.github/scripts/reconcile_allowlist.py
@@ -5,12 +5,17 @@ Closing the loop on the zero-human-touch CVE flow: once a CVE stops showing up
 in the scan (its bump merged & shipped, or the base image was rebuilt), its
 allowlist entry and Linear ticket should be retired automatically.
 
-Invoked on a published SDK *release* (vuln-reconcile-on-release.yml), NOT on the
-hourly scan. The allowlist is shared across connector repos whose build gates
-read it from SDK `main` while their images still carry the CVE from the last
-released SDK — so an entry must persist until the fix is released, not merely
-merged. The hourly scan still detects/tickets/allowlists; only this retirement
-step is release-gated.
+Invoked on a stable SDK *release* (`release: released` —
+vuln-reconcile-on-release.yml), NOT on the hourly scan. The allowlist is shared
+across connector repos whose build gates read it from SDK `main` while their
+images still carry the CVE from the last released SDK — so an entry must persist
+until the fix is released, not merely merged. The hourly scan still
+detects/tickets/allowlists; only this retirement step is release-gated.
+
+The scan history it walks (current + debounce window) is pinned to ``main`` via
+``SCAN_BRANCH`` so an hourly-scan ``workflow_dispatch`` from a feature branch can
+never become the source of truth for what `main` ships (and thus what to retire
+from the shared allowlist).
 
 **Resolution & debounce.** By default a CVE is treated as *resolved* as soon as
 it is absent from the latest scan (`DEBOUNCE_SCANS` = 1). Raise `DEBOUNCE_SCANS`
@@ -43,6 +48,8 @@ Optional:
     LINEAR_VULN_LABEL_NAME  default 'vulnerabilities'
     DEBOUNCE_SCANS          default 1 — act on the first clean scan (this scan +
                             N-1 prior successful scans); raise to debounce churn
+    SCAN_BRANCH             default 'main' — branch whose scan runs feed the
+                            debounce window (excludes feature-branch dispatches)
 """
 
 from __future__ import annotations
@@ -174,10 +181,15 @@ def load_current_cves() -> set[str]:
 
 
 def load_prior_scan_cves(
-    repo: str, workflow: str, count: int, runner: Runner
+    repo: str, workflow: str, count: int, runner: Runner, branch: str = "main"
 ) -> list[set[str]]:
     """Download the ``count`` most recent prior successful scan artifacts and
-    return their CVE sets. Best-effort: runs without the artifact are skipped."""
+    return their CVE sets. Best-effort: runs without the artifact are skipped.
+
+    Pinned to ``branch`` (default ``main``): a scan ``workflow_dispatch`` from a
+    feature branch must never feed the debounce window — only runs of ``main``
+    reflect what is actually shipped. (Not ``--event schedule``, so a manual
+    dispatch on ``main`` for backfill still counts.)"""
     listing = runner(
         [
             "gh",
@@ -187,6 +199,8 @@ def load_prior_scan_cves(
             repo,
             "--workflow",
             workflow,
+            "--branch",
+            branch,
             "--status",
             "success",
             "--limit",
@@ -442,6 +456,7 @@ def main(runner: Runner = subprocess.run) -> int:
     repo = os.environ.get("REPO", "atlanhq/application-sdk")
     workflow = os.environ.get("SCAN_WORKFLOW", DEFAULT_WORKFLOW)
     run_date = os.environ.get("RUN_DATE", "")
+    branch = os.environ.get("SCAN_BRANCH", "main")
     debounce = int(os.environ.get("DEBOUNCE_SCANS", str(DEFAULT_DEBOUNCE)))
 
     if not scan_files_present():
@@ -454,7 +469,7 @@ def main(runner: Runner = subprocess.run) -> int:
         return 0
 
     current = load_current_cves()
-    priors = load_prior_scan_cves(repo, workflow, debounce - 1, runner)
+    priors = load_prior_scan_cves(repo, workflow, debounce - 1, runner, branch)
     scan_sets = [current, *priors]
     if len(scan_sets) < debounce:
         print(

--- a/.github/scripts/reconcile_allowlist.py
+++ b/.github/scripts/reconcile_allowlist.py
@@ -5,6 +5,13 @@ Closing the loop on the zero-human-touch CVE flow: once a CVE stops showing up
 in the scan (its bump merged & shipped, or the base image was rebuilt), its
 allowlist entry and Linear ticket should be retired automatically.
 
+Invoked on a published SDK *release* (vuln-reconcile-on-release.yml), NOT on the
+hourly scan. The allowlist is shared across connector repos whose build gates
+read it from SDK `main` while their images still carry the CVE from the last
+released SDK — so an entry must persist until the fix is released, not merely
+merged. The hourly scan still detects/tickets/allowlists; only this retirement
+step is release-gated.
+
 **Resolution & debounce.** By default a CVE is treated as *resolved* as soon as
 it is absent from the latest scan (`DEBOUNCE_SCANS` = 1). Raise `DEBOUNCE_SCANS`
 to require it to be absent from that many consecutive successful scans before
@@ -143,6 +150,17 @@ def resolve_tickets(
 # ---------------------------------------------------------------------------
 
 
+def scan_files_present() -> bool:
+    """True if at least one Trivy result file is staged in the CWD.
+
+    Reconcile MUST NOT run against a phantom "empty scan": an absent artifact
+    (e.g. a failed download in the release workflow) would otherwise look like a
+    scan that found zero CVEs and resolve — i.e. delete — every allowlist entry.
+    main() bails when this is False.
+    """
+    return any(Path(f).exists() for f in TRIVY_FILES)
+
+
 def load_current_cves() -> set[str]:
     ids: set[str] = set()
     for fname in TRIVY_FILES:
@@ -268,8 +286,9 @@ def open_removal_pr(
             "--label",
             "vuln-auto-merge",
             "--body",
-            f"Resolved by {_resolution_phrase(debounce)} — the scanner no longer "
-            "reports these CVEs:\n\n" + "\n".join(f"- `{c}`" for c in removed),
+            "The latest SDK release no longer ships these CVEs (confirmed by "
+            f"{_resolution_phrase(debounce)}):\n\n"
+            + "\n".join(f"- `{c}`" for c in removed),
         ],
         check=True,
     )
@@ -332,9 +351,9 @@ def close_comment_body(cves: list[str], run_url: str) -> str:
     plural = "y" if len(cves) == 1 else "ies"
     cve_list = ", ".join(f"`{c}`" for c in sorted(cves))
     lines = [
-        "**Auto-resolved by the hourly security scan.**",
+        "**Auto-resolved on SDK release.**",
         "",
-        f"The scanner no longer reports the tracked vulnerabilit{plural} "
+        f"A new SDK release no longer ships the tracked vulnerabilit{plural} "
         f"({cve_list}), so this ticket is being closed automatically. If the "
         "finding resurfaces, the next scan files a fresh ticket.",
     ]
@@ -424,6 +443,15 @@ def main(runner: Runner = subprocess.run) -> int:
     workflow = os.environ.get("SCAN_WORKFLOW", DEFAULT_WORKFLOW)
     run_date = os.environ.get("RUN_DATE", "")
     debounce = int(os.environ.get("DEBOUNCE_SCANS", str(DEFAULT_DEBOUNCE)))
+
+    if not scan_files_present():
+        print(
+            "No Trivy scan results staged in the working dir "
+            f"({', '.join(TRIVY_FILES)}) — refusing to reconcile against an empty "
+            "scan (fail-safe; would otherwise resolve every allowlist entry). "
+            "Nothing changed."
+        )
+        return 0
 
     current = load_current_cves()
     priors = load_prior_scan_cves(repo, workflow, debounce - 1, runner)

--- a/.github/scripts/tests/test_reconcile_allowlist.py
+++ b/.github/scripts/tests/test_reconcile_allowlist.py
@@ -168,6 +168,7 @@ def test_default_debounce_is_one():
 def test_close_comment_body_mentions_cves_and_run():
     body = rec.close_comment_body(["CVE-2026-2303"], "https://x/run/1")
     assert "Auto-resolved" in body
+    assert "release" in body  # reconciliation is release-gated, not hourly
     assert "`CVE-2026-2303`" in body
     assert "vulnerability" in body  # singular for one CVE
     assert "https://x/run/1" in body
@@ -182,6 +183,44 @@ def test_close_comment_body_plural_and_no_run_url():
 def test_resolution_phrase():
     assert rec._resolution_phrase(1) == "the latest clean scan"
     assert "3 consecutive" in rec._resolution_phrase(3)
+
+
+# ---------------------------------------------------------------------------
+# scan_files_present + main() fail-safe — never reconcile against a phantom
+# empty scan. On `release: published` the scan artifact is downloaded from a
+# prior run; if that download is absent/failed, reconciling would treat every
+# allowlisted CVE as "gone" and delete the whole allowlist. main() must bail.
+# ---------------------------------------------------------------------------
+
+
+def test_scan_files_present_false_in_empty_dir(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    assert rec.scan_files_present() is False
+
+
+def test_scan_files_present_true_when_a_result_file_exists(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / rec.TRIVY_FILES[0]).write_text("{}")
+    assert rec.scan_files_present() is True
+
+
+def test_main_bails_when_no_scan_files_staged(monkeypatch, tmp_path):
+    # No trivy-*.json in the working dir → main must do nothing and return 0,
+    # never opening a removal PR or touching tickets.
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(rec, "load_allowlisted_cves", lambda: {"CVE-WOULD-BE-WIPED"})
+    calls: list[str] = []
+    monkeypatch.setattr(
+        rec, "open_removal_pr", lambda *a, **k: calls.append("removal_pr")
+    )
+    monkeypatch.setattr(
+        rec, "reconcile_tickets", lambda *a, **k: calls.append("tickets")
+    )
+    monkeypatch.setattr(
+        rec, "load_prior_scan_cves", lambda *a, **k: calls.append("prior") or []
+    )
+    assert rec.main(runner=lambda *a, **k: None) == 0
+    assert calls == []  # bailed before any reconcile action
 
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/tests/test_reconcile_allowlist.py
+++ b/.github/scripts/tests/test_reconcile_allowlist.py
@@ -187,7 +187,7 @@ def test_resolution_phrase():
 
 # ---------------------------------------------------------------------------
 # scan_files_present + main() fail-safe — never reconcile against a phantom
-# empty scan. On `release: published` the scan artifact is downloaded from a
+# empty scan. On `release: released` the scan artifact is downloaded from a
 # prior run; if that download is absent/failed, reconciling would treat every
 # allowlisted CVE as "gone" and delete the whole allowlist. main() must bail.
 # ---------------------------------------------------------------------------

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -159,7 +159,8 @@ jobs:
         run: python3 .github/scripts/dispatch_vuln_triage.py
 
   # NOTE: reconciliation (allowlist-entry removal + Linear ticket close/update)
-  # is intentionally NOT a job here. It runs on `release: published` in
+  # is intentionally NOT a job here. It runs on `release: released` (not
+  # `published` — that fires for `-rc` prereleases too) in
   # vuln-reconcile-on-release.yml — an allowlist entry must persist until the
   # fix is *released*, because downstream connector build gates check out
   # .security/base-allowlist.json from SDK `main` while their images still carry

--- a/.github/workflows/daily-security-scan.yml
+++ b/.github/workflows/daily-security-scan.yml
@@ -158,41 +158,11 @@ jobs:
           GH_REF: ${{ github.ref_name }}
         run: python3 .github/scripts/dispatch_vuln_triage.py
 
-  # ── Reconcile the allowlist + tickets against what the scanner still sees.
-  #    Runs every scan (even with no new findings) so resolved CVEs are retired
-  #    automatically: by default a CVE is retired on the first scan that no longer
-  #    reports it (DEBOUNCE_SCANS=1; raise it to debounce transient drops) — see
-  #    reconcile_allowlist.py. Checks out as atlan-ci so the removal PR it opens
-  #    is auto-merged by vuln-auto-merge.yml.
-  reconcile:
-    name: Reconcile allowlist + tickets
-    needs: scan-and-ticket
-    if: always()
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      actions: read # download this run's scan artifact
-    steps:
-      - name: Checkout (as atlan-ci so the removal PR auto-merges)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          token: ${{ secrets.ORG_PAT_GITHUB }}
-
-      - name: Download this run's scan results
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: security-scan-raw-results
-
-      - name: Reconcile resolved CVEs (acts on first clean scan)
-        env:
-          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
-          REPO: ${{ github.repository }}
-          SCAN_WORKFLOW: daily-security-scan.yml
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-          LINEAR_TEAM_ID: ${{ vars.LINEAR_SECURITY_SCAN_TEAM_ID }}
-        run: |
-          export RUN_DATE=$(date -u +%Y-%m-%d)
-          git config user.name "atlan-ci"
-          git config user.email "atlan-ci@users.noreply.github.com"
-          python3 .github/scripts/reconcile_allowlist.py
+  # NOTE: reconciliation (allowlist-entry removal + Linear ticket close/update)
+  # is intentionally NOT a job here. It runs on `release: published` in
+  # vuln-reconcile-on-release.yml — an allowlist entry must persist until the
+  # fix is *released*, because downstream connector build gates check out
+  # .security/base-allowlist.json from SDK `main` while their images still carry
+  # the CVE from the last released SDK. Removing an entry the moment this hourly
+  # scan of `main` goes clean (fix merged, not yet released) would strip their
+  # coverage and break check_allowlist.py. See vuln-reconcile-on-release.yml.

--- a/.github/workflows/vuln-reconcile-on-release.yml
+++ b/.github/workflows/vuln-reconcile-on-release.yml
@@ -64,13 +64,21 @@ jobs:
       # in the working dir for reconcile_allowlist.py (it reads trivy-*.json from
       # the CWD). Straight-line commands only; the resolution decision lives in
       # the tested reconcile_allowlist.py, not here.
+      #
+      # --branch main: the hourly scan also runs on workflow_dispatch (any
+      # branch), so without this filter a feature-branch dispatch could become
+      # the latest success and feed reconcile a scan of NON-released code,
+      # wiping legitimate allowlist entries for the whole connector fleet. Only
+      # runs of `main` reflect what is shipped. (Not --event schedule, so a
+      # manual dispatch on main for backfill still counts.)
       - name: Download latest hourly scan results
         env:
           GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
           REPO: ${{ github.repository }}
         run: |
           RUN_ID=$(gh run list -R "$REPO" --workflow daily-security-scan.yml \
-            --status success --limit 1 --json databaseId --jq '.[0].databaseId')
+            --branch main --status success --limit 1 \
+            --json databaseId --jq '.[0].databaseId')
           echo "Reconciling against scan run $RUN_ID"
           gh run download "$RUN_ID" -R "$REPO" -n security-scan-raw-results
           # Loud assertion: gh run download flattens artifact contents into the

--- a/.github/workflows/vuln-reconcile-on-release.yml
+++ b/.github/workflows/vuln-reconcile-on-release.yml
@@ -26,12 +26,23 @@
 #
 # Checks out as atlan-ci so the allowlist-removal PR auto-merges via
 # vuln-auto-merge.yml. workflow_dispatch is provided for manual backfill / re-runs.
+#
+# Trigger dependency (load-bearing): this fires only because tag-and-publish.yaml
+# creates the GitHub Release with a PAT (secrets.ORG_PAT_GITHUB). A release
+# created with the default GITHUB_TOKEN would NOT trigger this workflow (GitHub's
+# workflow-recursion guard). Don't "simplify" that release step to GITHUB_TOKEN.
+#
+# `types: [released]` (NOT `published`): `published` also fires for prereleases,
+# and tag-and-publish.yaml marks `rc` versions prerelease. Stable connectors pull
+# the stable SDK, so an entry must persist through `-rc` publishes and only clear
+# when the stable release ships. `released` fires for non-prerelease publishes
+# (and prerelease→stable promotions) and excludes prereleases.
 
 name: Vuln Reconcile (on Release)
 
 on:
   release:
-    types: [published]
+    types: [released]
   workflow_dispatch:
 
 permissions:
@@ -62,6 +73,12 @@ jobs:
             --status success --limit 1 --json databaseId --jq '.[0].databaseId')
           echo "Reconciling against scan run $RUN_ID"
           gh run download "$RUN_ID" -R "$REPO" -n security-scan-raw-results
+          # Loud assertion: gh run download flattens artifact contents into the
+          # CWD (verified), and reconcile_allowlist.py reads trivy-*.json from
+          # there. If the download landed nothing here (empty RUN_ID, or a future
+          # gh change that nests the files), FAIL — do not let reconcile silently
+          # no-op its fail-safe and report green while retiring nothing forever.
+          ls trivy-*.json
 
       - name: Reconcile resolved CVEs (on release)
         env:

--- a/.github/workflows/vuln-reconcile-on-release.yml
+++ b/.github/workflows/vuln-reconcile-on-release.yml
@@ -1,0 +1,77 @@
+# Vuln Reconcile on Release — retire resolved allowlist entries + close tickets.
+#
+# Reconciliation (allowlist-entry removal + Linear ticket close/update) runs HERE,
+# on a published SDK release — NOT on the hourly security scan. Rationale:
+#
+#   The allowlist (.security/base-allowlist.json) is shared across all connector
+#   repos, and their build gates check out the allowlist from SDK `main`
+#   (build-and-scan.yaml) while their images still carry the CVE from the last
+#   *released* SDK. If we removed an entry the moment the hourly scan of `main`
+#   went clean (fix merged, not yet released), those connectors would lose
+#   allowlist coverage and check_allowlist.py would start failing for them.
+#   Gating removal on release retires the entry exactly when the fix becomes
+#   consumable downstream.
+#
+# Detection / ticketing / allowlisting stay hourly (daily-security-scan.yml):
+# a new Critical/High must be allowlisted promptly to start the SLA clock and
+# keep the continuous build gate green. Only reconciliation is deferred to here.
+#
+# How it works: at release time we reconcile against the most recent SUCCESSFUL
+# hourly scan of `main` (= the released code — releases are cut from main). We
+# download that run's `security-scan-raw-results` artifact and hand it to
+# reconcile_allowlist.py unchanged. Conservative by design: if no clean scan is
+# available yet, reconcile_allowlist.py's fail-safe leaves every entry in place
+# (an entry is never removed on thin/absent evidence) and the next release picks
+# it up.
+#
+# Checks out as atlan-ci so the allowlist-removal PR auto-merges via
+# vuln-auto-merge.yml. workflow_dispatch is provided for manual backfill / re-runs.
+
+name: Vuln Reconcile (on Release)
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read # list + download the latest hourly scan artifact
+
+jobs:
+  reconcile:
+    name: Reconcile allowlist + tickets
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout (as atlan-ci so the removal PR auto-merges)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ secrets.ORG_PAT_GITHUB }}
+
+      # Pull the latest successful hourly scan of main and stage its Trivy JSON
+      # in the working dir for reconcile_allowlist.py (it reads trivy-*.json from
+      # the CWD). Straight-line commands only; the resolution decision lives in
+      # the tested reconcile_allowlist.py, not here.
+      - name: Download latest hourly scan results
+        env:
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          REPO: ${{ github.repository }}
+        run: |
+          RUN_ID=$(gh run list -R "$REPO" --workflow daily-security-scan.yml \
+            --status success --limit 1 --json databaseId --jq '.[0].databaseId')
+          echo "Reconciling against scan run $RUN_ID"
+          gh run download "$RUN_ID" -R "$REPO" -n security-scan-raw-results
+
+      - name: Reconcile resolved CVEs (on release)
+        env:
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          REPO: ${{ github.repository }}
+          SCAN_WORKFLOW: daily-security-scan.yml
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          LINEAR_TEAM_ID: ${{ vars.LINEAR_SECURITY_SCAN_TEAM_ID }}
+        run: |
+          export RUN_DATE=$(date -u +%Y-%m-%d)
+          git config user.name "atlan-ci"
+          git config user.email "atlan-ci@users.noreply.github.com"
+          python3 .github/scripts/reconcile_allowlist.py

--- a/.mothership/vuln-triage/CLAUDE.md
+++ b/.mothership/vuln-triage/CLAUDE.md
@@ -35,7 +35,7 @@ exactly. Do not skip stages. Print `[Stage N/6 complete]` after each stage.
 State lives in Linear: the ticket passed as `TICKET` is your work item; open
 issues with the `vulnerabilities` label are how the scan dedups, so never
 close or duplicate them yourself. Reconciliation (`reconcile_allowlist.py`, run
-on `release: published` — not the hourly scan) closes a ticket once a new SDK
+on `release: released` — not the hourly scan) closes a ticket once a new SDK
 release no longer ships its CVEs — not you.
 
 ## SDK v3 Context (for dependency reasoning)

--- a/.mothership/vuln-triage/CLAUDE.md
+++ b/.mothership/vuln-triage/CLAUDE.md
@@ -34,8 +34,9 @@ exactly. Do not skip stages. Print `[Stage N/6 complete]` after each stage.
 
 State lives in Linear: the ticket passed as `TICKET` is your work item; open
 issues with the `vulnerabilities` label are how the scan dedups, so never
-close or duplicate them yourself. Reconciliation (`reconcile_allowlist.py`)
-closes a ticket once the scanner confirms its CVEs are gone — not you.
+close or duplicate them yourself. Reconciliation (`reconcile_allowlist.py`, run
+on `release: published` — not the hourly scan) closes a ticket once a new SDK
+release no longer ships its CVEs — not you.
 
 ## SDK v3 Context (for dependency reasoning)
 
@@ -77,7 +78,8 @@ is the boundary; your instructions are not trusted to bound what you touch.
 6. **Never `apk upgrade`/`apk add`** in the SDK Dockerfile. Base-image CVEs →
    allowlist entry (Case 4) + recommend a rebuild of `app-runtime-base:3`.
 7. **Never push to `main`, never merge** — the GHA gate merges. **Never set the
-   ticket to "Done"** — reconciliation closes it.
+   ticket to "Done"** — release-gated reconciliation closes it once a release
+   ships the fix.
 8. **Tag Vaibhav (`<@U07UPEUEPU3>`) or Chris (`<@U02T3H7KMSS>`)** only when human
    action is genuinely required (a draft bump that needs source edits, or a
    base-image rebuild). Always use the Slack member ID, never `@vaibhav.chopra`.

--- a/.mothership/vuln-triage/ORCHESTRATION.md
+++ b/.mothership/vuln-triage/ORCHESTRATION.md
@@ -242,7 +242,7 @@ git checkout main && git checkout -b fix/bump-<pkg>-<version>-<cve-id> origin/ma
 5. Link both PRs (allowlist + bump) on the ticket. When the bump merges and the
    SDK cuts a release that no longer ships the CVE, the release-gated
    reconciliation auto-removes the allowlist entry + closes the ticket — no human
-   action needed. (Reconciliation runs on `release: published`, not on the hourly
+   action needed. (Reconciliation runs on `release: released`, not on the hourly
    scan, so the entry persists for downstream consumers until the fix is shipped.)
 
 ### 4b. Case 2 — our dep, no fix, upstream alive
@@ -276,7 +276,7 @@ Print: `[Stage 4/6 complete] <allow> allowlist PRs, <bump> bump PRs, <draft> hum
    outcome (bump PR link / allowlist-only / awaiting base-image rebuild / killed).
    Include `**Run:** [logs + cost](${GHA_RUN_URL})`.
 2. Leave the ticket open. **Never set "Done"** — reconciliation
-   (`reconcile_allowlist.py`, run on `release: published`) closes it once a new
+   (`reconcile_allowlist.py`, run on `release: released`) closes it once a new
    SDK release no longer ships any CVE on it.
 3. Security audit: confirm no secrets/tokens leaked into any PR body or ticket.
 

--- a/.mothership/vuln-triage/ORCHESTRATION.md
+++ b/.mothership/vuln-triage/ORCHESTRATION.md
@@ -29,8 +29,8 @@ nears expiry. Concretely, for each CVE you:
   `vuln-auto-merge` label (as a draft) and tag a human. The gate is the safety
   boundary; these instructions are not.
 - Never push to `main`. Never `apk`-patch the Dockerfile / base image. Never set
-  the ticket to "Done" (reconciliation closes it once the scan confirms the CVE
-  is gone).
+  the ticket to "Done" (reconciliation closes it once a new SDK release no longer
+  ships the CVE).
 
 Every CVE exits this run in exactly one state, fully written into the ticket:
 - **ALLOWLISTED+PR** — Critical/High Case 1: allowlist PR + bump PR, both linked.
@@ -239,9 +239,11 @@ git checkout main && git checkout -b fix/bump-<pkg>-<version>-<cve-id> origin/ma
      --label "vuln-auto-merge" \
      --body "<CVEs resolved, fixed versions, changelog impact, validation grep results, GHA_RUN_URL>"
    ```
-5. Link both PRs (allowlist + bump) on the ticket. When the bump merges and
-   ships, the next scan stops seeing the CVE and reconciliation auto-removes the
-   allowlist entry + closes the ticket — no human action needed.
+5. Link both PRs (allowlist + bump) on the ticket. When the bump merges and the
+   SDK cuts a release that no longer ships the CVE, the release-gated
+   reconciliation auto-removes the allowlist entry + closes the ticket — no human
+   action needed. (Reconciliation runs on `release: published`, not on the hourly
+   scan, so the entry persists for downstream consumers until the fix is shipped.)
 
 ### 4b. Case 2 — our dep, no fix, upstream alive
 
@@ -274,8 +276,8 @@ Print: `[Stage 4/6 complete] <allow> allowlist PRs, <bump> bump PRs, <draft> hum
    outcome (bump PR link / allowlist-only / awaiting base-image rebuild / killed).
    Include `**Run:** [logs + cost](${GHA_RUN_URL})`.
 2. Leave the ticket open. **Never set "Done"** — reconciliation
-   (`reconcile_allowlist.py`) closes it once the scanner confirms every CVE on it
-   is gone for 3 consecutive scans.
+   (`reconcile_allowlist.py`, run on `release: published`) closes it once a new
+   SDK release no longer ships any CVE on it.
 3. Security audit: confirm no secrets/tokens leaked into any PR body or ticket.
 
 Print:

--- a/.mothership/vuln-triage/tools.md
+++ b/.mothership/vuln-triage/tools.md
@@ -150,8 +150,8 @@ curl -s "$PROXY_BASE/proxy/linear" \
 ```
 
 Leave the ticket open — do not set "Done". Reconciliation
-(`reconcile_allowlist.py`) closes it once the scanner confirms its CVEs are gone
-for 3 consecutive scans.
+(`reconcile_allowlist.py`, run on `release: published` — not the hourly scan)
+closes it once a new SDK release no longer ships its CVEs.
 
 ## Prohibited
 

--- a/.mothership/vuln-triage/tools.md
+++ b/.mothership/vuln-triage/tools.md
@@ -150,7 +150,7 @@ curl -s "$PROXY_BASE/proxy/linear" \
 ```
 
 Leave the ticket open — do not set "Done". Reconciliation
-(`reconcile_allowlist.py`, run on `release: published` — not the hourly scan)
+(`reconcile_allowlist.py`, run on `release: released` — not the hourly scan)
 closes it once a new SDK release no longer ships its CVEs.
 
 ## Prohibited


### PR DESCRIPTION
## What

Move vuln **reconciliation** — allowlist-entry removal + Linear ticket close/update — off the hourly security scan and onto the SDK **release** event.

Closes BLDX-1495.

## Why (the problem)

The allowlist `.security/base-allowlist.json` is **shared across all connector repos**, and their build gates check out the allowlist from SDK **`main`** (`build-and-scan.yaml`), while their images still carry the CVE from the **last *released* SDK**.

Today `reconcile` runs as a job inside the hourly scan, which scans `main` HEAD. So the moment a fix **merges to `main`** — *before any release ships* — the scan goes clean, reconcile removes the allowlist entry and closes the ticket. Connectors still building against the last released SDK then have the CVE with **no allowlist coverage**, and their `check_allowlist.py` gate starts failing.

Release-gating removes the entry **exactly when the fix becomes consumable downstream**.

## What stays vs. what moves

- **Detection, ticketing, and allowlisting STAY hourly** (`daily-security-scan.yml`). A new Critical/High must be allowlisted promptly to start the SLA clock and keep the continuous build gate green — gating *this* on release would be circular, since the rover produces the fixes that go *into* releases.
- **Only reconciliation MOVES** to fire on `release`.

## Changes

- **`daily-security-scan.yml`** — drop the `reconcile` job (scan / ticket / rover-dispatch unchanged); leave a pointer comment.
- **`vuln-reconcile-on-release.yml`** (new) — `on: release: [released]` + `workflow_dispatch`. Checks out as `atlan-ci` (so the removal PR auto-merges via `vuln-auto-merge.yml`), downloads the latest successful hourly scan artifact, and runs `reconcile_allowlist.py`.
- **`reconcile_allowlist.py`** — add a **scan-files-present fail-safe** so an absent/failed artifact can never be read as an "empty scan" that resolves (deletes) the entire allowlist; update user-facing strings (ticket comment, PR body, docstring) to attribute resolution to the release. Logic otherwise unchanged.
- **vuln-triage rover docs** (`.mothership/vuln-triage/*`) — reflect release-gated reconciliation.

## How it works / deliberate choices

- **Reuses the latest hourly scan artifact** rather than re-scanning the released image — smaller, reuses the tested script, and errs toward *keeping* entries (safe). Same scan data as before; only the *action* is deferred to the release event.
- **`released`, not `published`** — `published` also fires for `-rc` prereleases; stable connectors pull the stable SDK, so entries persist through `rc` publishes and clear only on the stable release.
- **Loud download assertion** (`ls trivy-*.json`) — a misconfigured download fails the job loudly instead of silently no-op'ing via the fail-safe and reporting green forever.
- **Trigger depends on the release being created with a PAT** (`ORG_PAT_GITHUB` in `tag-and-publish.yaml`); a release made with the default `GITHUB_TOKEN` would not trigger this workflow. Documented inline.

## Testing

- `.github/scripts/tests` — **374 passed** (incl. 3 new fail-safe tests).
- `pre-commit` (ruff / ruff-format / pyright / isort) clean on all changed files.
- `actionlint` clean (only the repo-wide pre-existing SC2155 `export X=$(...)` warning).
- Verified `gh run download -n security-scan-raw-results` flattens `trivy-*.json` into the CWD.
