### PR TITLE
ci: regenerate manifest.json before connector tests (BLDX-1493)

### DIFF
--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -208,6 +208,23 @@ runs:
         "${{ github.action_path }}/repin-application-sdk.sh"
         uv sync --all-extras --all-groups
 
+    # Regenerate app/generated/** (manifest.json, configmaps, typed _input.py)
+    # from contract/app.pkl BEFORE the app server starts, so the manifest the
+    # app server and integration tests read reflects current contract + toolkit
+    # source rather than a possibly-stale committed file (BLDX-1493). On
+    # cross-repo dispatch (application-sdk-ref set) the @app-contract-toolkit
+    # dependency is overridden to the SDK PR's contract-toolkit/src so toolkit
+    # changes are exercised against the real connector. Otherwise it regenerates
+    # from the app's pinned toolkit and warns (never fails) on a stale committed
+    # app/generated/. Self-skips when there is no contract/app.pkl. uv is
+    # already installed (setup-deps), so generated Python is ruff-formatted for
+    # a clean drift comparison.
+    - name: Regenerate contract artifacts (manifest.json) before tests
+      uses: atlanhq/application-sdk/.github/actions/regenerate-contract@main
+      with:
+        application-sdk-ref: ${{ inputs.application-sdk-ref }}
+        check-drift: "true"
+
     # SDK 3.13+ boots an embedded daprd + Temporal directly from
     # `python main.py` (application_sdk/dev/_dapr.py + _embedded.py), each
     # downloading its own runtime. On those versions the external daprd +

--- a/.github/actions/regenerate-contract/action.yaml
+++ b/.github/actions/regenerate-contract/action.yaml
@@ -1,0 +1,113 @@
+name: Regenerate contract artifacts
+description: |
+  Regenerate an app's contract artifacts (app/generated/** — manifest.json,
+  configmaps, typed _input.py — plus atlan.yaml / app.yaml) from
+  contract/app.pkl BEFORE tests run, so the manifest the tests AND the worker
+  container consume reflects current contract + toolkit source instead of a
+  possibly-stale committed file. See BLDX-1493.
+
+  Runs in the CALLER's (connector's) workspace. Self-skips when there is no
+  contract/app.pkl (non-standard layouts), so it is safe to wire into shared
+  reusable workflows unconditionally.
+
+  When `application-sdk-ref` is set (apps-sdk cross-repo dispatch), shallow-
+  clones the SDK at that ref and overrides the @app-contract-toolkit dependency
+  to the PR's contract-toolkit/src — so a toolkit change in the SDK PR is
+  exercised against the real connector contract end-to-end. Otherwise it
+  regenerates from the app's own pinned toolkit version and (warn-only) flags a
+  stale committed app/generated/.
+
+  All conditional logic lives in the unit-tested .github/scripts/
+  regenerate_contract.py (per docs/standards/ci.md); the steps here only
+  install pkl, fetch the SDK toolkit source when needed, and invoke the script.
+
+inputs:
+  contract-dir:
+    required: false
+    default: contract
+    description: Directory containing PklProject and app.pkl (relative to the caller repo root).
+  application-sdk-ref:
+    required: false
+    default: ""
+    description: |
+      Branch/SHA of atlanhq/application-sdk. When non-empty, the
+      @app-contract-toolkit dependency is overridden to that ref's
+      contract-toolkit/src so SDK-level toolkit changes are tested. Empty =
+      app-level (the app's pinned toolkit).
+  check-drift:
+    required: false
+    default: "true"
+    description: |
+      'true' (default) to warn — never fail — when committed app/generated/
+      drifts from freshly-generated output. Set 'false' on pre-build
+      invocations where uv (hence ruff formatting) is not yet available.
+      Ignored when application-sdk-ref is set (drift is expected).
+  pkl-version:
+    required: false
+    default: "0.27.2"
+    description: pkl runtime version to download. Matches the contract-toolkit-* workflows.
+
+runs:
+  using: composite
+  steps:
+    # hashFiles returns '' when the glob matches nothing, so this resolves to
+    # 'true'/'false' with no inlined conditional shell.
+    - name: Detect contract
+      id: guard
+      shell: bash
+      run: echo "present=${{ hashFiles(format('{0}/app.pkl', inputs.contract-dir)) != '' }}" >> "$GITHUB_OUTPUT"
+
+    - name: Install pkl
+      if: steps.guard.outputs.present == 'true'
+      shell: bash
+      env:
+        PKL_VERSION: ${{ inputs.pkl-version }}
+      run: |
+        set -euo pipefail
+        # with-retry wraps the download: this step is on the always-on
+        # integration job (and the merge-queue gate), so a transient
+        # github.com hiccup must not fail the job over a flaky fetch.
+        "${{ github.action_path }}/../../scripts/with-retry.sh" \
+          curl -fsSL -o /tmp/pkl "https://github.com/apple/pkl/releases/download/${PKL_VERSION}/pkl-linux-amd64"
+        chmod +x /tmp/pkl
+        sudo mv /tmp/pkl /usr/local/bin/pkl
+        pkl --version
+
+    # SDK-level only: fetch just the toolkit source at the dispatched ref. A
+    # sparse, blobless clone keeps this to a few hundred KB rather than the full
+    # SDK history. The script overrides the connector's @app-contract-toolkit
+    # dependency to this path.
+    #
+    # No token: atlanhq/application-sdk is public, so the clone works on every
+    # path — including the pre-setup-deps invocation in sdr-e2e (where no
+    # actions/checkout http.extraheader is configured) and the merge-queue gate.
+    - name: Fetch SDK contract-toolkit at dispatched ref
+      id: sdk
+      if: steps.guard.outputs.present == 'true' && inputs.application-sdk-ref != ''
+      shell: bash
+      env:
+        SDK_REF: ${{ inputs.application-sdk-ref }}
+      run: |
+        set -euo pipefail
+        SDK_DIR="$(mktemp -d)/application-sdk"
+        "${{ github.action_path }}/../../scripts/with-retry.sh" \
+          git clone --quiet --filter=blob:none --no-checkout https://github.com/atlanhq/application-sdk "$SDK_DIR"
+        git -C "$SDK_DIR" sparse-checkout init --cone
+        git -C "$SDK_DIR" sparse-checkout set contract-toolkit/src
+        git -C "$SDK_DIR" checkout --quiet "$SDK_REF"
+        echo "toolkit-src=${SDK_DIR}/contract-toolkit/src" >> "$GITHUB_OUTPUT"
+        echo "Using SDK contract-toolkit/src from ${SDK_REF}"
+
+    - name: Regenerate contract artifacts
+      if: steps.guard.outputs.present == 'true'
+      shell: bash
+      env:
+        CONTRACT_DIR: ${{ inputs.contract-dir }}
+        CHECK_DRIFT: ${{ inputs.check-drift }}
+        SDK_TOOLKIT_SRC: ${{ steps.sdk.outputs.toolkit-src }}
+      run: |
+        set -euo pipefail
+        python3 "${{ github.action_path }}/../../scripts/regenerate_contract.py" \
+          --contract-dir "${CONTRACT_DIR}" \
+          --check-drift "${CHECK_DRIFT}" \
+          --sdk-toolkit-src "${SDK_TOOLKIT_SRC:-}"

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -207,6 +207,22 @@ runs:
         fi
         uv lock
 
+    # Regenerate app/generated/** from contract/app.pkl BEFORE the image build
+    # COPYs the tree (BLDX-1493). The connector image bakes app/generated/ at
+    # build time and the worker reads manifest.json at runtime
+    # (CONTRACT_GENERATED_DIR), so regenerating after the build would diverge
+    # the baked manifest from the freshly-generated one. On cross-repo dispatch
+    # (application-sdk-ref set) the @app-contract-toolkit dependency is
+    # overridden to the SDK PR's contract-toolkit/src so toolkit changes are
+    # exercised end-to-end. check-drift=false: uv (hence ruff) isn't installed
+    # until setup-deps below, and the drift gate lives in the always-run
+    # integration job; here we only need fresh artifacts baked into the image.
+    - name: Regenerate contract artifacts (manifest.json) before image build
+      uses: atlanhq/application-sdk/.github/actions/regenerate-contract@main
+      with:
+        application-sdk-ref: ${{ inputs.application-sdk-ref }}
+        check-drift: "false"
+
     # Buildx is required for the GHA cache backend below. Set up once
     # per run, before the image build that uses `cache-from/cache-to`.
     - name: Set up Docker Buildx
@@ -313,6 +329,19 @@ runs:
         "$SDR_E2E_ROOT/repin-application-sdk.sh"
         uv lock
         uv sync --all-extras --all-groups
+
+    # setup-deps' actions/checkout above wiped the pre-build regeneration along
+    # with the rest of the workspace, restoring the committed app/generated/.
+    # Regenerate again so the HOST pytest runtime (BaseSDRIntegrationTest /
+    # full-DAG payload read manifest.json) and the regenerated app.yaml consumed
+    # by the config-resolution steps below agree with the manifest baked into
+    # the image (BLDX-1493). Mirrors the double-repin pattern directly above.
+    # check-drift=false — the drift gate lives in the always-run integration job.
+    - name: Regenerate contract artifacts (manifest.json) after re-checkout
+      uses: atlanhq/application-sdk/.github/actions/regenerate-contract@main
+      with:
+        application-sdk-ref: ${{ inputs.application-sdk-ref }}
+        check-drift: "false"
 
     - name: Download atlan-configurator
       shell: bash

--- a/.github/scripts/regenerate_contract.py
+++ b/.github/scripts/regenerate_contract.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Regenerate an app's contract artifacts before tests run (BLDX-1493).
+
+Invoked by the ``regenerate-contract`` composite action from
+``connector-integration-tests`` and ``sdr-e2e`` so the ``manifest.json`` the
+tests — and the worker container, which COPYs ``app/generated/`` at build time
+and reads ``manifest.json`` at runtime — consume is generated from the current
+contract + toolkit source rather than a possibly-stale committed
+``app/generated/``.
+
+Two modes:
+
+  * **App-level** (default): regenerate from the app's own pinned
+    ``@app-contract-toolkit`` version (the committed ``PklProject.deps.json``
+    lock). Optionally **warn** (never fail) when the committed
+    ``app/generated/`` drifts from freshly-generated output, so a contract
+    change that was not regenerated is surfaced without blocking the fleet.
+
+  * **SDK-level** (``--sdk-toolkit-src`` given): override the
+    ``app-contract-toolkit`` dependency to a local checkout of the SDK PR's
+    ``contract-toolkit/src`` and re-resolve the lock, so a toolkit change in
+    the SDK PR is exercised against the *real* connector contract end-to-end.
+    Drift is expected in this mode, so the drift check is skipped and an
+    ``eval`` failure is **fatal** (the toolkit change does not generate valid
+    artifacts for this connector).
+
+Why this is a script and not inlined YAML: it carries the conditional logic
+(self-skip, mode branching, eval-failure policy, drift warning) and is
+therefore unit-tested in ``.github/scripts/tests/test_regenerate_contract.py``.
+Inlined shell with branching cannot be regression-tested (see
+``docs/standards/ci.md``). Mirrors ``renovate_pkl_sync.py``.
+
+Safety contract — this can never make CI *worse* than the prior behaviour
+(tests reading the committed manifest):
+
+  * Self-skip: no ``contract/app.pkl`` (non-standard layouts) -> exit 0,
+    nothing touched.
+  * App-level eval failure: warn and leave the committed artifacts untouched
+    so tests run against the committed manifest exactly as before.
+  * Drift is warn-only in app-level mode; it never fails the job.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Everything ``pkl eval -m .`` emits, relative to the repo root. Mirrors the
+# cleanup/stage list in contract-toolkit/scripts/regenerate-all.sh and
+# renovate_pkl_sync.py.
+OUTPUT_PATHS = ["app/generated", "atlan.yaml", "app.yaml"]
+
+# Matches the ``["app-contract-toolkit"]`` dependency entry in a consumer's
+# contract/PklProject, in either the block form
+#   ["app-contract-toolkit"] { uri = "package://...@x.y.z" }
+# or the shorthand assignment form
+#   ["app-contract-toolkit"] = "package://...@x.y.z"
+# The block alternative assumes no nested braces inside the entry (true for a
+# bare ``uri = "..."``), which is the documented consumer format.
+TOOLKIT_DEP_RE = re.compile(r'(\["app-contract-toolkit"\]\s*)(\{[^{}]*\}|=\s*[^\n]+)')
+
+
+def run(cmd: list[str], *, check: bool = False) -> subprocess.CompletedProcess:
+    """Run a subprocess. Single seam so tests can stub pkl/uvx and let git run
+    for real against a throwaway repo."""
+    return subprocess.run(cmd, check=check, text=True)
+
+
+def override_toolkit(contract_dir: str, toolkit_src: str) -> None:
+    """Repoint the ``app-contract-toolkit`` dependency at a local checkout of
+    the SDK PR's ``contract-toolkit/src`` (a Pkl *local dependency*), so
+    ``pkl eval`` generates from the PR's toolkit instead of the published
+    package. Fatal when no entry is found — silently proceeding would test the
+    published toolkit and give a false green for an SDK-level change."""
+    pkl_project = Path(contract_dir) / "PklProject"
+    src = pkl_project.read_text()
+    local = Path(toolkit_src).resolve() / "PklProject"
+    new, n = TOOLKIT_DEP_RE.subn(lambda m: f'{m.group(1)}= import("{local}")', src)
+    if n == 0:
+        raise SystemExit(
+            f"::error::No app-contract-toolkit dependency entry found in "
+            f"{pkl_project} to override for SDK-level testing."
+        )
+    pkl_project.write_text(new)
+    print(f"Overrode app-contract-toolkit -> local {local} (SDK-level toolkit test).")
+
+
+def resolve(contract_dir: str) -> None:
+    """Re-resolve the Pkl lock. Fatal on failure: with a changed (local-override)
+    dependency, an unresolved lock means eval would resolve the wrong toolkit."""
+    run(["pkl", "project", "resolve", f"{contract_dir}/"], check=True)
+
+
+def evaluate(contract_dir: str) -> bool:
+    """Regenerate artifacts in place via ``pkl eval``. Returns True on success.
+
+    ``--project-dir``: the contract is a Pkl project declaring
+    app-contract-toolkit as a dependency, so eval must load that project to
+    resolve the ``@app-contract-toolkit`` import. ``-m .`` writes each output
+    key (app/generated/**, atlan.yaml, app.yaml) at its natural path relative
+    to the repo root — exactly where the Docker build COPYs from and the tests
+    read."""
+    app_pkl = str(Path(contract_dir) / "app.pkl")
+    proc = run(["pkl", "eval", "--project-dir", contract_dir, "-m", ".", app_pkl])
+    return proc.returncode == 0
+
+
+def _format_generated(root: Path) -> None:
+    """ruff-fix + format every generated ``*.py``, mirroring
+    contract-toolkit/scripts/regenerate-all.sh and renovate_pkl_sync.py, so the
+    in-tree artifacts match what the consumer's pre-commit ruff would produce.
+
+    Best-effort: skipped when neither ``uvx`` nor ``ruff`` is on PATH (the e2e
+    pre-build invocation runs before ``setup-deps`` installs uv) — unformatted
+    but valid generated Python still imports at runtime."""
+    gen = root / "app" / "generated"
+    if not gen.is_dir():
+        return
+    py_files = sorted(str(p) for p in gen.rglob("*.py"))
+    if not py_files:
+        return
+    if shutil.which("uvx"):
+        prefix = ["uvx", "ruff"]
+    elif shutil.which("ruff"):
+        prefix = ["ruff"]
+    else:
+        print("::notice::ruff/uvx not on PATH — skipping generated-Python formatting.")
+        return
+    run([*prefix, "check", "--fix", "--select", "F401", "--quiet", *py_files])
+    run([*prefix, "format", *py_files])
+
+
+def warn_on_drift() -> bool:
+    """Warn (never fail) when the committed contract artifacts differ from the
+    freshly-generated ones. Compares the working tree (just regenerated in
+    place) against HEAD. Returns True when drift was found."""
+    drifted = [
+        path
+        for path in OUTPUT_PATHS
+        if os.path.exists(path)
+        and run(["git", "diff", "--quiet", "--", path]).returncode != 0
+    ]
+    if drifted:
+        print(
+            "::warning::Committed contract artifacts are stale vs contract/app.pkl: "
+            + ", ".join(drifted)
+            + ". Run `pkl eval -m . contract/app.pkl` (or `poe generate`) and commit "
+            "them. Tests are running against the freshly-generated manifest."
+        )
+        return True
+    print("Committed contract artifacts are up to date with contract/app.pkl.")
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--contract-dir",
+        default="contract",
+        help="Directory containing PklProject and app.pkl (default: contract).",
+    )
+    parser.add_argument(
+        "--sdk-toolkit-src",
+        default="",
+        help="Path to a local SDK contract-toolkit/src checkout. When set, "
+        "the app-contract-toolkit dependency is overridden to it (SDK-level "
+        "test mode). Empty = app-level (use the app's pinned toolkit).",
+    )
+    parser.add_argument(
+        "--check-drift",
+        choices=["true", "false"],
+        default="true",
+        help="'true' (default) to warn (never fail) when committed app/generated "
+        "drifts from freshly-generated output. Ignored in SDK-level mode.",
+    )
+    args = parser.parse_args(argv)
+
+    contract_dir = args.contract_dir
+    if not (Path(contract_dir) / "app.pkl").exists():
+        print(f"::notice::No {contract_dir}/app.pkl — skipping contract regeneration.")
+        return 0
+
+    sdk_mode = bool(args.sdk_toolkit_src)
+    if sdk_mode:
+        # Override the toolkit, then re-resolve so the lock points at the local
+        # source. App-level mode uses the committed lock as-is.
+        override_toolkit(contract_dir, args.sdk_toolkit_src)
+        resolve(contract_dir)
+
+    if not evaluate(contract_dir):
+        if sdk_mode:
+            print(
+                "::error::pkl eval failed using the SDK PR's contract-toolkit — "
+                "the toolkit change does not generate valid artifacts for this "
+                "connector contract."
+            )
+            return 1
+        print(
+            "::warning::pkl eval failed — committed contract artifacts left "
+            "unchanged; tests will run against the committed manifest (prior "
+            "behaviour)."
+        )
+        return 0
+
+    _format_generated(Path("."))
+
+    if args.check_drift == "true" and not sdk_mode:
+        warn_on_drift()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/test_regenerate_contract.py
+++ b/.github/scripts/tests/test_regenerate_contract.py
@@ -1,0 +1,264 @@
+"""Tests for .github/scripts/regenerate_contract.py.
+
+Covers the driver's conditional logic — the part that would otherwise be
+inlined shell in the regenerate-contract composite action:
+
+  * no contract/app.pkl                 -> self-skip, exit 0, no pkl
+  * app-level, eval OK                   -> regenerate in place, no resolve
+  * app-level, eval fails                -> warn, exit 0, artifacts untouched
+  * app-level, committed artifacts stale -> warn-only drift annotation
+  * app-level, committed artifacts fresh -> no drift annotation
+  * SDK-level                            -> toolkit overridden + lock resolved,
+                                            drift NOT checked
+  * SDK-level, eval fails                -> fatal (exit 1)
+  * SDK-level, no toolkit entry          -> fatal (SystemExit)
+
+`pkl` and `uvx` are stubbed; `git` runs for real against a throwaway repo in
+tmp_path so the drift comparison is exercised end to end.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import regenerate_contract as mod
+
+STALE_MANIFEST = '{"app_name": "{{app_name}}"}\n'
+FRESH_MANIFEST = '{"app_name": "metabase"}\n'
+
+REMOTE_PKLPROJECT = """\
+amends "pkl:Project"
+
+dependencies {
+  ["app-contract-toolkit"] {
+    uri = "package://atlanhq.github.io/application-sdk/contracts/app-contract-toolkit@0.16.0"
+  }
+}
+"""
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A throwaway connector repo: a contract, a committed lock, and a committed
+    (stale) manifest — the state of a PR before regeneration."""
+    contract = tmp_path / "contract"
+    contract.mkdir()
+    (contract / "app.pkl").write_text('amends "@app-contract-toolkit/App.pkl"\n')
+    (contract / "PklProject").write_text(REMOTE_PKLPROJECT)
+    (contract / "PklProject.deps.json").write_text('{"resolved": "0.16.0"}\n')
+    gen = tmp_path / "app" / "generated"
+    gen.mkdir(parents=True)
+    (gen / "manifest.json").write_text(STALE_MANIFEST)
+    (gen / "_input.py").write_text("import os\n")
+
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "test")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "init")
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _make_fake_run(
+    repo: Path,
+    *,
+    eval_rc: int = 0,
+    fresh_manifest: str = FRESH_MANIFEST,
+    calls: list | None = None,
+):
+    """Build a `run` replacement: simulate pkl/uvx, pass git through to real
+    subprocess so the drift comparison is genuinely exercised. Records pkl
+    invocations into `calls` when provided."""
+    real_run = subprocess.run
+
+    def fake_run(cmd, *, check=False):
+        if calls is not None and cmd and cmd[0] == "pkl":
+            calls.append(cmd)
+        prog = cmd[0]
+        if prog == "pkl" and cmd[1:3] == ["project", "resolve"]:
+            return types.SimpleNamespace(returncode=0)
+        if prog == "pkl" and cmd[1] == "eval":
+            if eval_rc == 0:
+                out_dir = Path(cmd[cmd.index("-m") + 1])
+                gen = out_dir / "app" / "generated"
+                gen.mkdir(parents=True, exist_ok=True)
+                (gen / "manifest.json").write_text(fresh_manifest)
+                (gen / "_input.py").write_text("import os\n")
+            return types.SimpleNamespace(returncode=eval_rc)
+        if prog in ("uvx", "ruff"):  # formatter — no-op in tests
+            return types.SimpleNamespace(returncode=0)
+        # Everything else (git) runs for real.
+        return real_run(cmd, check=check, text=True, capture_output=True)
+
+    return fake_run
+
+
+def test_missing_app_pkl_self_skips(repo, monkeypatch):
+    (repo / "contract" / "app.pkl").unlink()
+    calls: list = []
+    monkeypatch.setattr(mod, "run", _make_fake_run(repo, calls=calls))
+
+    assert mod.main([]) == 0
+
+    assert calls == []  # no pkl invoked
+    assert (repo / "app" / "generated" / "manifest.json").read_text() == STALE_MANIFEST
+
+
+def test_app_level_regenerates_in_place_without_resolve(repo, monkeypatch):
+    calls: list = []
+    monkeypatch.setattr(mod, "run", _make_fake_run(repo, calls=calls))
+
+    assert mod.main([]) == 0
+
+    # Fresh manifest written in place; no `pkl project resolve` in app-level mode.
+    assert (repo / "app" / "generated" / "manifest.json").read_text() == FRESH_MANIFEST
+    assert not any(c[1:3] == ["project", "resolve"] for c in calls)
+    assert any(c[1] == "eval" for c in calls)
+
+
+def test_app_level_eval_failure_warns_not_fatal(repo, monkeypatch, capsys):
+    monkeypatch.setattr(mod, "run", _make_fake_run(repo, eval_rc=1))
+
+    assert mod.main([]) == 0  # never fatal in app-level mode
+
+    # Committed manifest left untouched (no half-regenerated state).
+    assert (repo / "app" / "generated" / "manifest.json").read_text() == STALE_MANIFEST
+    assert "::warning::pkl eval failed" in capsys.readouterr().out
+
+
+def test_app_level_drift_warns_when_stale(repo, monkeypatch, capsys):
+    # eval produces output different from the committed manifest -> drift.
+    monkeypatch.setattr(mod, "run", _make_fake_run(repo))
+
+    assert mod.main(["--check-drift", "true"]) == 0
+
+    out = capsys.readouterr().out
+    assert "::warning::Committed contract artifacts are stale" in out
+    assert "app/generated" in out
+
+
+def test_app_level_no_drift_when_fresh(repo, monkeypatch, capsys):
+    # eval reproduces exactly the committed manifest -> no drift warning.
+    monkeypatch.setattr(mod, "run", _make_fake_run(repo, fresh_manifest=STALE_MANIFEST))
+
+    assert mod.main(["--check-drift", "true"]) == 0
+
+    out = capsys.readouterr().out
+    assert "::warning::Committed contract artifacts are stale" not in out
+    assert "up to date" in out
+
+
+def test_sdk_level_overrides_toolkit_and_resolves(repo, monkeypatch, tmp_path, capsys):
+    toolkit = tmp_path / "sdk" / "contract-toolkit" / "src"
+    toolkit.mkdir(parents=True)
+    (toolkit / "PklProject").write_text('amends "pkl:Project"\n')
+    calls: list = []
+    monkeypatch.setattr(mod, "run", _make_fake_run(repo, calls=calls))
+
+    assert mod.main(["--sdk-toolkit-src", str(toolkit)]) == 0
+
+    # PklProject now points the dependency at the local toolkit checkout.
+    pkl_project = (repo / "contract" / "PklProject").read_text()
+    assert f'import("{toolkit.resolve()}/PklProject")' in pkl_project
+    assert "package://" not in pkl_project
+    # Lock re-resolved (override changed the dependency) and eval ran.
+    assert any(c[1:3] == ["project", "resolve"] for c in calls)
+    assert any(c[1] == "eval" for c in calls)
+    # Drift is expected with the PR toolkit, so it is NOT checked.
+    assert (
+        "::warning::Committed contract artifacts are stale"
+        not in capsys.readouterr().out
+    )
+
+
+def test_sdk_level_eval_failure_is_fatal(repo, monkeypatch, tmp_path, capsys):
+    toolkit = tmp_path / "sdk" / "contract-toolkit" / "src"
+    toolkit.mkdir(parents=True)
+    (toolkit / "PklProject").write_text('amends "pkl:Project"\n')
+    monkeypatch.setattr(mod, "run", _make_fake_run(repo, eval_rc=1))
+
+    assert mod.main(["--sdk-toolkit-src", str(toolkit)]) == 1
+    assert "::error::pkl eval failed" in capsys.readouterr().out
+
+
+def test_sdk_level_no_toolkit_entry_is_fatal(repo, monkeypatch, tmp_path):
+    (repo / "contract" / "PklProject").write_text('amends "pkl:Project"\n')
+    toolkit = tmp_path / "sdk" / "contract-toolkit" / "src"
+    toolkit.mkdir(parents=True)
+    monkeypatch.setattr(mod, "run", _make_fake_run(repo))
+
+    with pytest.raises(SystemExit):
+        mod.main(["--sdk-toolkit-src", str(toolkit)])
+
+
+def test_override_toolkit_rewrites_block_form(tmp_path):
+    pkl_project = tmp_path / "PklProject"
+    pkl_project.write_text(REMOTE_PKLPROJECT)
+    toolkit = tmp_path / "toolkit-src"
+    toolkit.mkdir()
+
+    mod.override_toolkit(str(tmp_path), str(toolkit))
+
+    text = pkl_project.read_text()
+    assert (
+        f'["app-contract-toolkit"] = import("{toolkit.resolve()}/PklProject")' in text
+    )
+    assert "uri =" not in text
+
+
+def test_resolve_failure_is_fatal(repo, monkeypatch, tmp_path):
+    toolkit = tmp_path / "sdk" / "contract-toolkit" / "src"
+    toolkit.mkdir(parents=True)
+    (toolkit / "PklProject").write_text('amends "pkl:Project"\n')
+
+    def fake_run(cmd, *, check=False):
+        if cmd[0] == "pkl" and cmd[1:3] == ["project", "resolve"]:
+            if check:
+                raise subprocess.CalledProcessError(1, cmd)
+            return types.SimpleNamespace(returncode=1)
+        return subprocess.run(cmd, check=check, text=True, capture_output=True)
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        mod.main(["--sdk-toolkit-src", str(toolkit)])
+
+
+def test_format_generated_covers_all_py(tmp_path, monkeypatch):
+    """`_format_generated` must ruff-format every generated *.py (not just
+    _input.py) so none lands unformatted and trips the consumer's pre-commit."""
+    gen = tmp_path / "app" / "generated"
+    nested = gen / "crawler"
+    nested.mkdir(parents=True)
+    (gen / "_input.py").write_text("import os\n")
+    (gen / "_e2e_base.py").write_text("import os\n")
+    (nested / "_e2e_substitutions.py").write_text("import os\n")
+
+    formatted: list[str] = []
+
+    def spy_run(cmd, *, check=False):
+        if cmd[:2] == ["uvx", "ruff"] and cmd[2] == "format":
+            formatted.extend(cmd[3:])
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/uvx")
+    monkeypatch.setattr(mod, "run", spy_run)
+    mod._format_generated(tmp_path)
+
+    assert {Path(p).name for p in formatted} == {
+        "_input.py",
+        "_e2e_base.py",
+        "_e2e_substitutions.py",
+    }

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -125,6 +125,20 @@ Mechanism: `codex-/return-dispatch@v3` in `e2e-apps/action.yaml` fires `workflow
 
 The SDR composite renders one PR-comment body, writes it to `results/pr-comment-body.md`, and uploads it as part of the test artifact. Both posting sides (connector PR + cross-repo SDK PR) read this same file and post it as a sticky-update comment, swapping the marker line so updates don't collide.
 
+## Contract regeneration before tests
+
+Tests read `app/generated/manifest.json` (the Automation Engine DAG) — the host-side test harness (`BaseSDRIntegrationTest` / full-DAG payload) and the worker container, which COPYs `app/generated/` at build time and reads `manifest.json` at runtime (`CONTRACT_GENERATED_DIR`). To keep that manifest honest, the shared [`regenerate-contract`](../../.github/actions/regenerate-contract/action.yaml) composite regenerates `app/generated/**` from `contract/app.pkl` **before** tests run (driver: [`.github/scripts/regenerate_contract.py`](../../.github/scripts/regenerate_contract.py)). It self-skips when there is no `contract/app.pkl`.
+
+| Where it runs | Mode | Drift gate |
+|---|---|---|
+| `connector-integration-tests` (always-on `tests` job) | App-level (or SDK-level on dispatch) | **Warn-only** — annotates a stale committed `app/generated/`, never fails |
+| `sdr-e2e` — once **before** the image build, once **after** `setup-deps` re-checkout | Same | Off (the integration job owns the gate) |
+
+- **App-level** (default): regenerate from the app's pinned `@app-contract-toolkit` version, so a `contract/app.pkl` change is exercised even if the committed manifest was not regenerated.
+- **SDK-level** (cross-repo dispatch, `application-sdk-ref` set): the `@app-contract-toolkit` dependency is overridden to the SDK PR's `contract-toolkit/src`, so a toolkit change in the SDK PR is exercised against the *real* connector contract end-to-end. Drift is expected here, so the gate is skipped and a `pkl eval` failure is fatal.
+
+The e2e path regenerates twice because `setup-deps`' inner `actions/checkout` (after the image build) restores the committed tree — mirroring the existing double-repin pattern, so the manifest baked into the image and the one the host pytest reads agree.
+
 ## Workspace-wipe defences (local-action mode)
 
 When the SDR composite is invoked via local path (`./.application-sdk/.github/actions/sdr-e2e`) during cross-repo dispatch, `setup-deps`' inner `actions/checkout` wipes the entire workspace — including `${{ github.action_path }}` itself. The composite:


### PR DESCRIPTION
## Why

Closes [BLDX-1493](https://linear.app/atlan-epd/issue/BLDX-1493/e2e-tests-dont-update-manifestjson).

Tests and the worker container **read** `app/generated/manifest.json` (the Automation Engine DAG), but the connector CI flow never **regenerated** it from `contract/app.pkl`. As a result, Contract Toolkit changes — at the **app level** (`contract/app.pkl`) or the **SDK level** (`contract-toolkit/src`) — ran against a possibly-stale committed manifest and were never actually exercised.

## What

A shared, unit-tested regeneration step that runs **before** tests, so the manifest the tests *and* the worker container consume reflects current contract + toolkit source.

**`.github/scripts/regenerate_contract.py`** (+ `tests/`, 11 tests) — `pkl eval`s the contract in place. Conditional logic stays in the tested script per `docs/standards/ci.md`; mirrors `renovate_pkl_sync.py`.
- **App-level** (default): regenerate from the app's pinned `@app-contract-toolkit`; **warn-only** drift annotation when the committed `app/generated/` is stale (never fails — won't block the fleet). An app-level `pkl eval` failure degrades to a warning (tests run against the committed manifest = prior behaviour).
- **SDK-level** (`--sdk-toolkit-src`): override the `@app-contract-toolkit` dependency to the SDK PR's `contract-toolkit/src` (Pkl local `import()`), so a toolkit change in the SDK PR is exercised against the *real* connector contract end-to-end. Drift is expected → skipped; an eval failure is fatal.
- Self-skips when there is no `contract/app.pkl`.

**`.github/actions/regenerate-contract`** — composite that installs `pkl` (retry-wrapped), shallow-clones the SDK toolkit at the dispatched ref when SDK-level (tokenless — `atlanhq/application-sdk` is public), and invokes the script.

**Wiring** (SDK-owned → propagates to openapi / metabase / mysql via `@main`):
- `connector-integration-tests` — regen after deps install, before the app server. App-level on **every** PR + owns the warn-only drift gate; SDK-level on cross-repo dispatch.
- `sdr-e2e` — regen **twice**: before the image build (the connector image COPYs `app/generated/` and the worker reads `manifest.json` at runtime via `CONTRACT_GENERATED_DIR`) and after `setup-deps`' re-checkout (so the host pytest matches), mirroring the existing double-repin pattern.

Documented in `docs/standards/connector-ci-e2e.md`.

## Decisions

- **Scope**: app + SDK level (the SDK-override mechanism was validated with a real `pkl` spike).
- **Drift gate**: warn-only first (like conformance C002), so existing connector PRs aren't blocked; can promote to hard-fail once the three reference connectors are confirmed clean.

## Testing

- 11 unit tests (real `git`, stubbed `pkl`/`uvx`); pre-commit + pyright clean.
- Real-`pkl` end-to-end confirmed both modes: SDK-override regenerated the manifest from local toolkit source; app-level drift warning fired on a stale committed manifest.

## Note

All wiring resolves at `@main`, so an `e2e`-labelled run on *this* PR still uses the pre-merge `@main` actions — the regen first executes on the next connector/SDK `merge_group` post-merge. Worth watching that first post-merge connector run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)