### PR TITLE
fix(observability): surface OOM kills immediately in logs

### DIFF
--- a/application_sdk/execution/_temporal/eviction_retry.py
+++ b/application_sdk/execution/_temporal/eviction_retry.py
@@ -92,8 +92,13 @@ async def execute_activity_with_eviction_retry(
                 # eviction-retry path itself would crash on the first eviction
                 # if we did not nest under ``extra``. ``AtlanLoggerAdapter``
                 # also reads ``extra`` correctly, so this works in both modes.
-                workflow.logger.info(
-                    "activity re-dispatched after worker eviction",
+                workflow.logger.warning(
+                    "activity re-dispatched after worker eviction "
+                    "(attempt %d/%d) — likely causes: OOM kill (pod exit 137), "
+                    "KEDA scale-down, spot preemption, or rolling deploy; "
+                    "check pod exit code and cluster events for the affected worker",
+                    eviction_attempts,
+                    max_eviction_retries,
                     extra={
                         "eviction_attempts": eviction_attempts,
                         "max_eviction_retries": max_eviction_retries,

--- a/application_sdk/execution/_temporal/eviction_retry.py
+++ b/application_sdk/execution/_temporal/eviction_retry.py
@@ -99,6 +99,7 @@ async def execute_activity_with_eviction_retry(
                     "check pod exit code and cluster events for the affected worker",
                     eviction_attempts,
                     max_eviction_retries,
+                    exc_info=True,
                     extra={
                         "eviction_attempts": eviction_attempts,
                         "max_eviction_retries": max_eviction_retries,

--- a/application_sdk/execution/heartbeat.py
+++ b/application_sdk/execution/heartbeat.py
@@ -17,9 +17,12 @@ import time
 from collections.abc import Callable
 from typing import Any, Protocol, TypeVar
 
+from application_sdk.observability import resource_sampler as _resource_sampler
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
+
+_MEMORY_WARN_THRESHOLD = 0.80
 
 # Dedicated executor for blocking operations dispatched via run_in_thread().
 #
@@ -136,6 +139,7 @@ async def auto_heartbeat_loop(
         task_name: Name of the task (for warning messages).
     """
     warning_threshold = interval_seconds * 0.5
+    _limit_bytes = int(os.environ.get("K8S_POD_MEMORY_LIMIT", "0") or "0")
 
     while not stop_event.is_set():
         loop_start = time.monotonic()
@@ -178,6 +182,23 @@ async def auto_heartbeat_loop(
                 task_name,
             )
             raise
+
+        if _limit_bytes > 0:
+            try:
+                _mem = _resource_sampler.sample()
+                if _mem is not None:
+                    _ratio = _mem.rss_bytes / _limit_bytes
+                    if _ratio >= _MEMORY_WARN_THRESHOLD:
+                        logger.warning(
+                            "Memory pressure on task '%s': %.0f%% of limit (%.2f GiB / %.2f GiB)"
+                            " — OOM kill imminent if this continues rising",
+                            task_name,
+                            _ratio * 100,
+                            _mem.rss_bytes / (1024**3),
+                            _limit_bytes / (1024**3),
+                        )
+            except Exception:  # noqa: S110 — best-effort; must never interrupt the heartbeat loop
+                pass
 
 
 async def run_in_thread(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:

--- a/application_sdk/execution/heartbeat.py
+++ b/application_sdk/execution/heartbeat.py
@@ -19,10 +19,14 @@ from typing import Any, Protocol, TypeVar
 
 from application_sdk.observability import resource_sampler as _resource_sampler
 from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.observability.resource_sampler import parse_pod_memory_limit
 
 logger = get_logger(__name__)
 
 _MEMORY_WARN_THRESHOLD = 0.80
+_MEMORY_WARN_HYSTERESIS = (
+    0.05  # re-arm only once ratio drops below threshold - hysteresis
+)
 
 # Dedicated executor for blocking operations dispatched via run_in_thread().
 #
@@ -139,7 +143,8 @@ async def auto_heartbeat_loop(
         task_name: Name of the task (for warning messages).
     """
     warning_threshold = interval_seconds * 0.5
-    _limit_bytes = int(os.environ.get("K8S_POD_MEMORY_LIMIT", "0") or "0")
+    _limit_bytes = parse_pod_memory_limit(os.environ.get("K8S_POD_MEMORY_LIMIT", ""))
+    _memory_warn_active = False
 
     while not stop_event.is_set():
         loop_start = time.monotonic()
@@ -188,7 +193,8 @@ async def auto_heartbeat_loop(
                 _mem = _resource_sampler.sample()
                 if _mem is not None:
                     _ratio = _mem.rss_bytes / _limit_bytes
-                    if _ratio >= _MEMORY_WARN_THRESHOLD:
+                    if not _memory_warn_active and _ratio >= _MEMORY_WARN_THRESHOLD:
+                        _memory_warn_active = True
                         logger.warning(
                             "Memory pressure on task '%s': %.0f%% of limit (%.2f GiB / %.2f GiB)"
                             " — OOM kill imminent if this continues rising",
@@ -197,6 +203,11 @@ async def auto_heartbeat_loop(
                             _mem.rss_bytes / (1024**3),
                             _limit_bytes / (1024**3),
                         )
+                    elif (
+                        _memory_warn_active
+                        and _ratio < _MEMORY_WARN_THRESHOLD - _MEMORY_WARN_HYSTERESIS
+                    ):
+                        _memory_warn_active = False
             except Exception:  # noqa: S110 — best-effort; must never interrupt the heartbeat loop
                 pass
 

--- a/application_sdk/execution/heartbeat.py
+++ b/application_sdk/execution/heartbeat.py
@@ -17,7 +17,9 @@ import time
 from collections.abc import Callable
 from typing import Any, Protocol, TypeVar
 
-from application_sdk.observability import resource_sampler as _resource_sampler
+from application_sdk.observability import (
+    resource_sampler as _resource_sampler,  # module alias kept so tests can patch _resource_sampler.sample()
+)
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.observability.resource_sampler import parse_pod_memory_limit
 

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -87,8 +87,8 @@ if hasattr(signal, "SIGUSR1"):
     signal.signal(signal.SIGUSR1, _debug_dump_handler)
 
 
-def _log_worker_memory_context() -> None:
-    """Log current RSS vs container memory limit at worker startup.
+def _log_process_memory_baseline() -> None:
+    """Log current RSS vs container memory limit at process startup.
 
     Gives a baseline so that — after an OOM kill — the log of the replacement
     pod shows the limit, and the log of the killed pod shows memory climbing
@@ -98,15 +98,18 @@ def _log_worker_memory_context() -> None:
     from application_sdk.observability import (  # noqa: PLC0415 — cold path: startup only
         resource_sampler as _rs,
     )
+    from application_sdk.observability.resource_sampler import (  # noqa: PLC0415
+        parse_pod_memory_limit,
+    )
 
-    limit_bytes = int(os.environ.get("K8S_POD_MEMORY_LIMIT", "0") or "0")
+    limit_bytes = parse_pod_memory_limit(os.environ.get("K8S_POD_MEMORY_LIMIT", ""))
     if limit_bytes <= 0:
         return
     sample = _rs.sample()
     if sample is None:
         return
     logger.info(
-        "Worker memory at start: %.2f GiB RSS / %.2f GiB limit (%.0f%% of limit)",
+        "Process memory at start: %.2f GiB RSS / %.2f GiB limit (%.0f%% of limit)",
         sample.rss_bytes / (1024**3),
         limit_bytes / (1024**3),
         100.0 * sample.rss_bytes / limit_bytes,
@@ -983,7 +986,7 @@ async def run_worker_mode(config: AppConfig) -> None:
     health_server.set_temporal_client(client)
 
     logger.info("Worker started: app=%s queue=%s", app_name, config.task_queue)
-    _log_worker_memory_context()
+    _log_process_memory_baseline()
     async with health_server, worker:
         await shutdown_event.wait()
 
@@ -1031,6 +1034,7 @@ def run_handler_mode(config: AppConfig) -> None:
         config.handler_host,
         config.handler_port,
     )
+    _log_process_memory_baseline()
 
     app_class = load_app_class(config.app_module)
     validate_app_class(app_class)
@@ -1291,7 +1295,7 @@ async def run_combined_mode(config: AppConfig) -> None:
         config.task_queue,
         config.handler_port,
     )
-    _log_worker_memory_context()
+    _log_process_memory_baseline()
     async with health_server, worker:
         await asyncio.gather(
             uvicorn_server.serve(),

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -86,6 +86,33 @@ def _debug_dump_handler(signum: int, frame: object) -> None:
 if hasattr(signal, "SIGUSR1"):
     signal.signal(signal.SIGUSR1, _debug_dump_handler)
 
+
+def _log_worker_memory_context() -> None:
+    """Log current RSS vs container memory limit at worker startup.
+
+    Gives a baseline so that — after an OOM kill — the log of the replacement
+    pod shows the limit, and the log of the killed pod shows memory climbing
+    toward it via the heartbeat-loop pressure warnings.  No-ops when
+    K8S_POD_MEMORY_LIMIT is unset (local dev / non-Kubernetes environments).
+    """
+    from application_sdk.observability import (  # noqa: PLC0415 — cold path: startup only
+        resource_sampler as _rs,
+    )
+
+    limit_bytes = int(os.environ.get("K8S_POD_MEMORY_LIMIT", "0") or "0")
+    if limit_bytes <= 0:
+        return
+    sample = _rs.sample()
+    if sample is None:
+        return
+    logger.info(
+        "Worker memory at start: %.2f GiB RSS / %.2f GiB limit (%.0f%% of limit)",
+        sample.rss_bytes / (1024**3),
+        limit_bytes / (1024**3),
+        100.0 * sample.rss_bytes / limit_bytes,
+    )
+
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
     from pathlib import Path
@@ -956,6 +983,7 @@ async def run_worker_mode(config: AppConfig) -> None:
     health_server.set_temporal_client(client)
 
     logger.info("Worker started: app=%s queue=%s", app_name, config.task_queue)
+    _log_worker_memory_context()
     async with health_server, worker:
         await shutdown_event.wait()
 
@@ -1263,6 +1291,7 @@ async def run_combined_mode(config: AppConfig) -> None:
         config.task_queue,
         config.handler_port,
     )
+    _log_worker_memory_context()
     async with health_server, worker:
         await asyncio.gather(
             uvicorn_server.serve(),

--- a/application_sdk/observability/resource_sampler.py
+++ b/application_sdk/observability/resource_sampler.py
@@ -33,6 +33,51 @@ class ResourceSample:
     rss_bytes: int  # resident set size in bytes (memory currently in RAM)
 
 
+_BINARY_SUFFIXES: dict[str, int] = {
+    "Ki": 1024,
+    "Mi": 1024**2,
+    "Gi": 1024**3,
+    "Ti": 1024**4,
+    "Pi": 1024**5,
+    "Ei": 1024**6,
+}
+_DECIMAL_SUFFIXES: dict[str, int] = {
+    "k": 1000,
+    "M": 1000**2,
+    "G": 1000**3,
+    "T": 1000**4,
+    "P": 1000**5,
+    "E": 1000**6,
+}
+
+
+def parse_pod_memory_limit(raw: str) -> int:
+    """Parse a K8S_POD_MEMORY_LIMIT value into bytes.
+
+    Accepts plain integer bytes (the value produced by ``resourceFieldRef``
+    with ``divisor: "1"``) and Kubernetes quantity suffixes:
+
+    * Binary: ``Ki``, ``Mi``, ``Gi``, ``Ti``, ``Pi``, ``Ei``
+    * Decimal: ``k``, ``M``, ``G``, ``T``, ``P``, ``E``
+
+    Returns 0 on any parse failure so callers can safely treat 0 as
+    "limit unknown / feature disabled".
+    """
+    raw = raw.strip()
+    if not raw:
+        return 0
+    for suffix, multiplier in {**_BINARY_SUFFIXES, **_DECIMAL_SUFFIXES}.items():
+        if raw.endswith(suffix):
+            try:
+                return int(raw[: -len(suffix)]) * multiplier
+            except ValueError:
+                return 0
+    try:
+        return int(raw)
+    except ValueError:
+        return 0
+
+
 def _read_proc_rss() -> int | None:
     """Read RSS from /proc/self/stat (Linux only, no dependencies)."""
     try:

--- a/docs/concepts/monitoring.md
+++ b/docs/concepts/monitoring.md
@@ -211,6 +211,57 @@ If you need replay logs — for example when using `temporalio.worker.Replayer` 
 
 ---
 
+## Memory pressure and OOM diagnostics
+
+OOM kills produce no application-level log — the kernel sends SIGKILL and the
+process vanishes silently. The SDK surfaces four log signals so operators have
+a clear evidence trail and a short time-to-diagnosis.
+
+### Log surfaces (grep patterns)
+
+| # | When | Level | Where | Grep |
+|---|------|-------|-------|------|
+| 1 | Worker/combined/handler startup | `INFO` | pod log (first lines) | `"Process memory at start"` |
+| 2 | Every 20 s during an active task, once RSS ≥ 80 % of limit | `WARNING` | pod log | `"Memory pressure on task"` |
+| 3 | Immediately after pod restart, if `exitCode == 137` | `CRITICAL` | pod log (first lines of new pod) | `"exit code 137 = SIGKILL"` |
+| 4 | When Temporal re-dispatches an activity after worker loss | `WARNING` | workflow log | `"re-dispatched after worker eviction"` |
+
+Signal 1 establishes a baseline (RSS at startup, limit, %) so you can see
+where memory stood when the pod was last healthy. Signal 2 fires on the rising
+edge and re-arms after the ratio drops below 75 %, giving pre-kill leading
+indicators in the killed pod's log. Signal 3 fires in the **replacement** pod's
+entrypoint immediately on restart — before any Temporal heartbeat timeout — so
+the first thing you see in `kubectl logs` is the exit code, along with the
+diagnostic commands to run. Signal 4 names OOM kill (pod exit 137) explicitly
+alongside KEDA scale-down, spot preemption, and rolling deploys.
+
+### Required Kubernetes configuration
+
+Signal 2 and signal 1's percentage require `K8S_POD_MEMORY_LIMIT` to be
+injected via the Downward API:
+
+```yaml
+env:
+  - name: K8S_POD_MEMORY_LIMIT
+    valueFrom:
+      resourceFieldRef:
+        resource: limits.memory
+        divisor: "1"          # raw bytes; parse_pod_memory_limit() also accepts Ki/Mi/Gi suffixes
+```
+
+When this env var is absent the memory-pressure warning is silently disabled
+(no false positives in local dev / non-Kubernetes environments).
+
+### Diagnostic runbook (OOM kill)
+
+1. **Check exit code in the new pod** (`kubectl logs <pod>` — look for the exit-137 CRITICAL line at the top, or the process memory at start line showing a high baseline).
+2. **Confirm OOM kill** — `kubectl describe pod <pod>` → `lastState.terminated.reason: OOMKilled`.
+3. **Check cluster events** — `kubectl get events -n <namespace> --field-selector=reason=OOMKilling`.
+4. **Review memory trajectory** — search the killed pod's log for `Memory pressure on task` lines to see how fast RSS climbed before the kill.
+5. **Check eviction retries** — search the workflow log for `re-dispatched after worker eviction` to understand how many attempts Temporal made.
+
+---
+
 ## Correlation IDs
 
 The `correlation_id` propagates automatically across:

--- a/docs/standards/env-vars.md
+++ b/docs/standards/env-vars.md
@@ -75,6 +75,72 @@ If the var has no replacement (the controlling feature was removed
 entirely), the chart can drop it whenever the last SDK version that read
 it is retired.
 
+---
+
+## Kubernetes-injected variables
+
+These env vars are **not** set by the app or the SDK — they are injected by the
+Kubernetes Downward API in the pod spec. The SDK reads them but cannot validate
+that they were injected; when absent, the dependent feature is silently
+disabled.
+
+### `K8S_POD_MEMORY_LIMIT`
+
+Gates the memory-pressure observability feature (startup RSS baseline log,
+heartbeat WARNING at ≥ 80 % of limit).
+
+**Inject via:**
+
+```yaml
+env:
+  - name: K8S_POD_MEMORY_LIMIT
+    valueFrom:
+      resourceFieldRef:
+        resource: limits.memory
+        divisor: "1"   # plain bytes string; no suffix
+```
+
+**Accepted formats** (the SDK's `parse_pod_memory_limit()` helper accepts all of these):
+
+| Format | Example | Notes |
+|--------|---------|-------|
+| Raw bytes | `4294967296` | What `resourceFieldRef` with `divisor: "1"` produces |
+| Binary SI | `4Gi`, `512Mi`, `1Ti` | Ki / Mi / Gi / Ti / Pi / Ei (powers of 1024) |
+| Decimal SI | `4G`, `512M`, `1T` | k / M / G / T / P / E (powers of 1000) |
+
+Any other value (including floats like `1.5Gi`) is treated as 0 (feature disabled).
+
+### `K8S_POD_NAME`
+
+The pod's name as assigned by Kubernetes. Used in diagnostic log messages
+(e.g., the entrypoint's exit-137 SIGKILL trailer).
+
+**Inject via:**
+
+```yaml
+env:
+  - name: K8S_POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+```
+
+### `K8S_POD_NAMESPACE`
+
+The pod's namespace. Used in diagnostic log messages alongside `K8S_POD_NAME`.
+
+**Inject via:**
+
+```yaml
+env:
+  - name: K8S_POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+```
+
+---
+
 ## Checklist when removing/renaming an env var
 
 1. Remove the read site (`os.getenv(...)` / `os.environ.get(...)`).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -148,7 +148,7 @@ EXIT_CODE=$?
 
 echo "[entrypoint] App exited with code ${EXIT_CODE}"
 if [ "${EXIT_CODE}" -eq 137 ]; then
-    echo "[entrypoint] CRITICAL: exit code 137 = SIGKILL — almost certainly an OOM kill. Check: kubectl describe pod \${K8S_POD_NAME}; kubectl get events -n \${Namespace} --field-selector=reason=OOMKilling" >&2
+    echo "[entrypoint] CRITICAL: exit code 137 = SIGKILL — almost certainly an OOM kill. Check: kubectl describe pod ${K8S_POD_NAME:-<pod-name>}; kubectl get events -n ${K8S_POD_NAMESPACE:-<namespace>} --field-selector=reason=OOMKilling" >&2
 fi
 
 # Stop daprd after the app exits (normal path — signal handler covers SIGTERM path)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -147,6 +147,9 @@ wait "${APP_PID}"
 EXIT_CODE=$?
 
 echo "[entrypoint] App exited with code ${EXIT_CODE}"
+if [ "${EXIT_CODE}" -eq 137 ]; then
+    echo "[entrypoint] CRITICAL: exit code 137 = SIGKILL — almost certainly an OOM kill. Check: kubectl describe pod \${K8S_POD_NAME}; kubectl get events -n \${Namespace} --field-selector=reason=OOMKilling" >&2
+fi
 
 # Stop daprd after the app exits (normal path — signal handler covers SIGTERM path)
 if kill -0 "${DAPRD_PID}" 2>/dev/null; then

--- a/tests/unit/execution/test_heartbeat.py
+++ b/tests/unit/execution/test_heartbeat.py
@@ -239,6 +239,60 @@ class TestAutoHeartbeatLoop:
 
         assert hb_calls  # heartbeat was sent
 
+    @pytest.mark.asyncio
+    async def test_memory_pressure_silent_when_env_unset(self, monkeypatch) -> None:
+        """No memory-pressure WARNING when K8S_POD_MEMORY_LIMIT is not set."""
+        from application_sdk.execution import heartbeat as hb_mod
+
+        monkeypatch.delenv("K8S_POD_MEMORY_LIMIT", raising=False)
+        stop = asyncio.Event()
+
+        def hb_fn():
+            stop.set()
+
+        with patch.object(hb_mod, "logger") as mock_logger:
+            await auto_heartbeat_loop(0.001, hb_fn, stop, task_name="t")
+
+        memory_warnings = [
+            c for c in mock_logger.warning.call_args_list if "Memory pressure" in str(c)
+        ]
+        assert not memory_warnings
+
+    @pytest.mark.asyncio
+    async def test_memory_pressure_warning_emitted_above_threshold(
+        self, monkeypatch
+    ) -> None:
+        """WARNING is emitted with correct percentage when RSS ≥ 80% of limit."""
+        from application_sdk.execution import heartbeat as hb_mod
+        from application_sdk.observability.resource_sampler import ResourceSample
+
+        limit = 4 * 1024**3  # 4 GiB in bytes
+        rss = int(limit * 0.85)  # 85%
+        monkeypatch.setenv("K8S_POD_MEMORY_LIMIT", str(limit))
+
+        stop = asyncio.Event()
+
+        def hb_fn():
+            stop.set()
+
+        with (
+            patch(
+                "application_sdk.execution.heartbeat._resource_sampler.sample",
+                return_value=ResourceSample(cpu_time_s=1.0, rss_bytes=rss),
+            ),
+            patch.object(hb_mod, "logger") as mock_logger,
+        ):
+            await auto_heartbeat_loop(0.001, hb_fn, stop, task_name="mem-task")
+
+        warning_calls = [
+            c for c in mock_logger.warning.call_args_list if "Memory pressure" in str(c)
+        ]
+        assert warning_calls, "Expected memory-pressure WARNING"
+        # args: (fmt, task_name, pct_float, rss_gib, limit_gib)
+        _fmt, task, pct, *_ = warning_calls[0].args
+        assert task == "mem-task"
+        assert abs(pct - 85.0) < 0.5
+
 
 # ---------------------------------------------------------------------------
 # run_in_thread — must NOT use real threads in tests

--- a/tests/unit/execution/test_heartbeat.py
+++ b/tests/unit/execution/test_heartbeat.py
@@ -293,6 +293,82 @@ class TestAutoHeartbeatLoop:
         assert task == "mem-task"
         assert abs(pct - 85.0) < 0.5
 
+    @pytest.mark.asyncio
+    async def test_memory_pressure_warning_latches_above_threshold(
+        self, monkeypatch
+    ) -> None:
+        """Warning fires exactly once when ratio stays ≥ 80% across N ticks."""
+        from application_sdk.execution import heartbeat as hb_mod
+        from application_sdk.observability.resource_sampler import ResourceSample
+
+        limit = 4 * 1024**3
+        rss = int(limit * 0.85)  # constant 85% — always above threshold
+        monkeypatch.setenv("K8S_POD_MEMORY_LIMIT", str(limit))
+
+        tick = {"n": 0}
+        stop = asyncio.Event()
+
+        def hb_fn():
+            tick["n"] += 1
+            if tick["n"] >= 4:  # run 4 ticks to confirm latch holds
+                stop.set()
+
+        with (
+            patch(
+                "application_sdk.execution.heartbeat._resource_sampler.sample",
+                return_value=ResourceSample(cpu_time_s=1.0, rss_bytes=rss),
+            ),
+            patch.object(hb_mod, "logger") as mock_logger,
+        ):
+            await auto_heartbeat_loop(0.001, hb_fn, stop, task_name="latch-task")
+
+        assert tick["n"] >= 4, "Expected at least 4 ticks"
+        mem_warnings = [
+            c for c in mock_logger.warning.call_args_list if "Memory pressure" in str(c)
+        ]
+        assert (
+            len(mem_warnings) == 1
+        ), f"Expected exactly 1 warning, got {len(mem_warnings)}"
+
+    @pytest.mark.asyncio
+    async def test_memory_pressure_rearms_after_drop_below_hysteresis(
+        self, monkeypatch
+    ) -> None:
+        """Warning fires twice: once at 0.85, re-arms after dropping to 0.70, fires again at 0.85."""
+        from application_sdk.execution import heartbeat as hb_mod
+        from application_sdk.observability.resource_sampler import ResourceSample
+
+        limit = 4 * 1024**3
+        # Sample sequence: 0.85 → 0.70 → 0.85 (must produce 2 warnings)
+        ratios = [0.85, 0.70, 0.85]
+        samples = [
+            ResourceSample(cpu_time_s=float(i), rss_bytes=int(limit * r))
+            for i, r in enumerate(ratios)
+        ]
+        monkeypatch.setenv("K8S_POD_MEMORY_LIMIT", str(limit))
+
+        tick = {"n": 0}
+        stop = asyncio.Event()
+
+        def hb_fn():
+            tick["n"] += 1
+            if tick["n"] >= len(samples):
+                stop.set()
+
+        with (
+            patch(
+                "application_sdk.execution.heartbeat._resource_sampler.sample",
+                side_effect=samples,
+            ),
+            patch.object(hb_mod, "logger") as mock_logger,
+        ):
+            await auto_heartbeat_loop(0.001, hb_fn, stop, task_name="rearm-task")
+
+        mem_warnings = [
+            c for c in mock_logger.warning.call_args_list if "Memory pressure" in str(c)
+        ]
+        assert len(mem_warnings) == 2, f"Expected 2 warnings, got {len(mem_warnings)}"
+
 
 # ---------------------------------------------------------------------------
 # run_in_thread — must NOT use real threads in tests

--- a/tests/unit/observability/test_resource_sampler.py
+++ b/tests/unit/observability/test_resource_sampler.py
@@ -3,9 +3,12 @@
 import sys
 from unittest.mock import patch
 
+import pytest
+
 from application_sdk.observability.resource_sampler import (
     ResourceSample,
     compute_deltas,
+    parse_pod_memory_limit,
     sample,
 )
 
@@ -72,3 +75,46 @@ class TestComputeDeltas:
         end = ResourceSample(cpu_time_s=3.0, rss_bytes=1024**3)
         cpu, mem = compute_deltas(start, end, 10.0)
         assert cpu == 0.0
+
+
+# ---------------------------------------------------------------------------
+# parse_pod_memory_limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Binary SI suffixes
+        ("1Ki", 1024),
+        ("2Mi", 2 * 1024**2),
+        ("3Gi", 3 * 1024**3),
+        ("4Ti", 4 * 1024**4),
+        ("5Pi", 5 * 1024**5),
+        ("6Ei", 6 * 1024**6),
+        # Decimal SI suffixes
+        ("1k", 1000),
+        ("2M", 2 * 1000**2),
+        ("3G", 3 * 1000**3),
+        ("4T", 4 * 1000**4),
+        ("5P", 5 * 1000**5),
+        ("6E", 6 * 1000**6),
+        # Raw bytes (resourceFieldRef divisor="1")
+        ("0", 0),
+        ("1024", 1024),
+        ("4294967296", 4 * 1024**3),
+        # Leading/trailing whitespace is stripped
+        ("  2Gi  ", 2 * 1024**3),
+        # Empty / whitespace-only → 0
+        ("", 0),
+        ("   ", 0),
+        # Suffix only (no numeric part) → 0
+        ("Gi", 0),
+        ("Mi", 0),
+        # Invalid / garbage → 0
+        ("notanumber", 0),
+        ("12.5Gi", 0),  # float not accepted
+    ],
+)
+def test_parse_pod_memory_limit(raw: str, expected: int) -> None:
+    assert parse_pod_memory_limit(raw) == expected

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2220,3 +2220,31 @@ class TestLogProcessMemoryBaseline:
         # args: (fmt, rss_gib, limit_gib, pct_float)
         _fmt, _rss, _lim, pct = info_calls[0].args
         assert abs(pct - 25.0) < 0.5
+
+    def test_silent_when_limit_unset(self, monkeypatch) -> None:
+        """No INFO log when K8S_POD_MEMORY_LIMIT is absent (local dev / non-K8s)."""
+        import application_sdk.main as main_mod
+
+        monkeypatch.delenv("K8S_POD_MEMORY_LIMIT", raising=False)
+
+        with patch.object(main_mod, "logger") as mock_logger:
+            _log_process_memory_baseline()
+
+        mock_logger.info.assert_not_called()
+
+    def test_silent_when_sample_returns_none(self, monkeypatch) -> None:
+        """No INFO log when resource sampling fails (e.g. on Windows)."""
+        import application_sdk.main as main_mod
+
+        monkeypatch.setenv("K8S_POD_MEMORY_LIMIT", str(4 * 1024**3))
+
+        with (
+            patch(
+                "application_sdk.observability.resource_sampler.sample",
+                return_value=None,
+            ),
+            patch.object(main_mod, "logger") as mock_logger,
+        ):
+            _log_process_memory_baseline()
+
+        mock_logger.info.assert_not_called()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -20,6 +20,7 @@ from application_sdk.main import (
     _install_excepthook,
     _install_graceful_signal_handlers,
     _log_dapr_components,
+    _log_process_memory_baseline,
     _loop_exception_handler,
     _parse_all_component_yamls,
     _parse_workflow_max_timeout_hours,
@@ -2184,3 +2185,38 @@ class TestRunCombinedAuth:
         auth_mgr.acquire_initial_token.assert_awaited_once()
         auth_mgr.start_background_refresh.assert_called_once()
         auth_mgr.shutdown.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _log_process_memory_baseline
+# ---------------------------------------------------------------------------
+
+
+class TestLogProcessMemoryBaseline:
+    def test_emits_info_with_percentage(self, monkeypatch) -> None:
+        """INFO log is emitted with RSS/limit ratio when both are available."""
+        import application_sdk.main as main_mod
+        from application_sdk.observability.resource_sampler import ResourceSample
+
+        limit = 8 * 1024**3  # 8 GiB
+        rss = 2 * 1024**3  # 2 GiB → 25%
+        monkeypatch.setenv("K8S_POD_MEMORY_LIMIT", str(limit))
+
+        with (
+            patch(
+                "application_sdk.observability.resource_sampler.sample",
+                return_value=ResourceSample(cpu_time_s=0.5, rss_bytes=rss),
+            ),
+            patch.object(main_mod, "logger") as mock_logger,
+        ):
+            _log_process_memory_baseline()
+
+        info_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if "memory at start" in str(c).lower()
+        ]
+        assert info_calls, "Expected INFO memory baseline log"
+        # args: (fmt, rss_gib, limit_gib, pct_float)
+        _fmt, _rss, _lim, pct = info_calls[0].args
+        assert abs(pct - 25.0) < 0.5


### PR DESCRIPTION
## Summary

- **heartbeat loop**: warn at 80% of `K8S_POD_MEMORY_LIMIT` every 20s — gives a leading indicator of memory pressure _before_ the OOM kill, visible in activity logs while the task is still running
- **worker startup log**: log RSS vs limit at startup (`_log_worker_memory_context`) — establishes a per-pod baseline and makes pod restart boundaries obvious in the log stream
- **eviction retry**: bump log level from `INFO` → `WARNING` and explicitly name OOM kill (pod exit 137) as a likely cause alongside KEDA scale-down, spot preemption, and rolling deploys
- **entrypoint**: emit a `CRITICAL` stderr message on exit code 137 (SIGKILL) with `kubectl describe pod` and `kubectl get events` diagnostic commands — fires immediately on the next pod start, before any Temporal heartbeat timeout

## Motivation

A production incident took ~3 hours to diagnose as an OOM kill because:
1. SIGKILL produces no application-level log — the process simply vanishes
2. Temporal only discovers the loss via heartbeat timeout (~60s), and even that log doesn't say _why_ the worker disappeared
3. Engineers had to manually check `kubectl describe pod` to find `OOMKilled` in `lastState.terminated`

These four changes together create a clear evidence trail: memory climbing → WARNING every 20s → pod restarts → CRITICAL stderr on restart → eviction retry WARNING naming OOM as the cause.

## Test plan

- [x] Unit tests pass (`uv run python -m pytest tests/unit -x -q` — 5253 passed, 9 skipped)
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)
- [ ] `K8S_POD_MEMORY_LIMIT` unset: `_log_worker_memory_context` no-ops silently; heartbeat memory check skipped
- [ ] `K8S_POD_MEMORY_LIMIT` set + RSS < 80%: no WARNING emitted from heartbeat loop
- [ ] `K8S_POD_MEMORY_LIMIT` set + RSS ≥ 80%: WARNING logged every heartbeat interval
- [ ] Exit code 137 in entrypoint: CRITICAL message written to stderr with kubectl commands
- [ ] Exit code 0 (normal graceful shutdown): no CRITICAL message emitted