### PR TITLE
fix(observability): add monotonic counter to partition filenames to prevent Windows clock-collision

### DIFF
--- a/application_sdk/observability/_objectstore_metric_exporter.py
+++ b/application_sdk/observability/_objectstore_metric_exporter.py
@@ -225,6 +225,7 @@ class ObjectStoreMetricExporter(MetricExporter):
             if ENABLE_OBSERVABILITY_STORE_SINK and ENABLE_ATLAN_UPLOAD
             else None
         )
+        self._writer_seq = 0
 
     def _resolve_store(self, name: str) -> ObjectStore | None:
         from application_sdk.storage.binding import (  # noqa: PLC0415 — deferred to break the observability→storage circular import
@@ -267,7 +268,8 @@ class ObjectStoreMetricExporter(MetricExporter):
 
             now = datetime.now()
             ts_ns = int(now.timestamp() * 1e9)
-            filename = f"{ts_ns}_{DEPLOYMENT_NAME}_{APPLICATION_NAME}.json.gz"
+            self._writer_seq += 1
+            filename = f"{ts_ns}_{self._writer_seq:06d}_{DEPLOYMENT_NAME}_{APPLICATION_NAME}.json.gz"
 
             local_dir = os.path.join(
                 self._data_dir,

--- a/application_sdk/observability/observability.py
+++ b/application_sdk/observability/observability.py
@@ -222,7 +222,7 @@ class AtlanObservability(Generic[T], ABC):
 
         Args:
             partition_time: Timestamp used to derive the year/month/day/hour prefix.
-            filename: The local filename (e.g. ``<ts>_<deployment>_<app>.json.gz``).
+            filename: The local filename (e.g. ``<ts>_<seq>_<deployment>_<app>.json.gz``).
 
         Returns:
             str: The fully qualified S3 key, e.g.
@@ -363,8 +363,10 @@ class AtlanObservability(Generic[T], ABC):
         Records are assumed to arrive in emission order (chronologically), so
         hour-partitions appear as contiguous runs.  If a rare cross-thread reorder
         causes a stale partition to reappear mid-flush, a second uniquely-named
-        ``.json.gz`` file is written for that hour — harmless since filenames carry a
-        nanosecond timestamp.
+        ``.json.gz`` file is written for that hour.  Uniqueness is jointly enforced by
+        the ``ts_ns`` wall-clock prefix and a per-instance monotonic ``_writer_seq``
+        counter, so two writers opened within the same clock tick (e.g. ~15 ms on
+        Windows) still produce distinct filenames.
 
         - Writes gzip-compressed NDJSON (no pandas/pyarrow dependency)
         - SDR path: ``artifacts/apps/observability/sdr/logs/``    (``ENABLE_ATLAN_UPLOAD=true``)

--- a/application_sdk/observability/observability.py
+++ b/application_sdk/observability/observability.py
@@ -146,6 +146,7 @@ class AtlanObservability(Generic[T], ABC):
         self._cleanup_enabled = cleanup_enabled
         self.data_dir = data_dir
         self.file_name = file_name
+        self._writer_seq = 0
 
         # Ensure data directory exists
         os.makedirs(data_dir, exist_ok=True)
@@ -431,10 +432,13 @@ class AtlanObservability(Generic[T], ABC):
                         # Use datetime.now() rather than time.time_ns(): the latter is
                         # restricted inside Temporal's workflow sandbox (non-deterministic),
                         # while datetime.now() is patched by the SDK to be safe there.
+                        # The monotonic _writer_seq counter is a tie-breaker for when
+                        # datetime.now() has insufficient resolution (e.g. ~15 ms on
+                        # Windows), which would otherwise produce duplicate filenames
+                        # when two partition switches happen within the same clock tick.
                         ts_ns = int(datetime.now().timestamp() * 1e9)
-                        filename = (
-                            f"{ts_ns}_{DEPLOYMENT_NAME}_{APPLICATION_NAME}.json.gz"
-                        )
+                        self._writer_seq += 1
+                        filename = f"{ts_ns}_{self._writer_seq:06d}_{DEPLOYMENT_NAME}_{APPLICATION_NAME}.json.gz"
                         local_path = os.path.join(partition_path, filename)
                         current_writer = _PartitionWriter(
                             partition_path=partition_path,


### PR DESCRIPTION
## Summary

- `datetime.now().timestamp()` has ~15 ms resolution on Windows; when `_flush_records` processes multiple partition switches with no real I/O (e.g. mocked upload in tests), two writer opens land on the same clock tick → identical filenames → `test_out_of_order_records_writes_second_file_for_same_hour` fails intermittently on Windows 3.12 CI
- Fix: append a zero-padded per-instance monotonic `_writer_seq` counter to the filename as a deterministic tie-breaker
- Same fix applied proactively to `ObjectStoreMetricExporter` which has the identical pattern

## Why not trailing-zeros overlay?

`datetime.now().timestamp() * 1e9` uses float64, which has only ~15.9 significant decimal digits — not enough precision for a 19-digit nanosecond epoch. The last digits are floating-point rounding noise, not reliable zeros, so there's no safe bit-range to encode a counter.

## Downstream safety

Audited all atlanhq org consumers of the `artifacts/apps/observability/sdr/logs/` prefix. The only code reader is `atlanhq/mdlh` (`sdrLogsPatternRule`), which uses `fileMatcher("*.json.gz")` and maps fields from file **content** only — the filename stem is never parsed. The new format still satisfies the glob.

## Test plan

- [ ] `tests/unit/observability/test_logger_adaptor.py::TestFlushRecordsSinglePass::test_out_of_order_records_writes_second_file_for_same_hour` passes on Windows 3.12 CI (was the failing test)
- [ ] Full observability unit test suite: 349 passed, 1 skipped locally