### PR TITLE
fix(conformance): add pull-requests: read for private repos; fix gen-contract-ledger outfile default

### DIFF
--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -180,6 +180,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   # ── Per-series checks (one matrix leg per rule series) ──────────────────────

--- a/packages/conformance/conformance/bootstrap/templates/conformance.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/conformance.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   suite:

--- a/packages/conformance/conformance/cli.py
+++ b/packages/conformance/conformance/cli.py
@@ -264,7 +264,7 @@ commands:
   gen-deprecations  Regenerate the deprecated-symbol manifest from SDK source
   gen-contract-ledger  Regenerate the entrypoint-contract ledger (contract_schema.lock.json)
                        --repo DIR    repo root to scan (default: auto-detected)
-                       --outfile PATH  ledger path (default: package data)
+                       --outfile PATH  ledger path (default: contract_schema.lock.json in cwd)
                        --check       verify ledger is current; exit 1 if stale
   ledger-guard         CI append-only guard: block ledger deletions and type changes between
                        base ref and HEAD (run after fetch-depth: 0 checkout)

--- a/packages/conformance/conformance/suite/checks/deprecation/__init__.py
+++ b/packages/conformance/conformance/suite/checks/deprecation/__init__.py
@@ -104,7 +104,7 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
         if run_authoring:
             findings.extend(scan_authoring(tree, rel, version, directives))
 
-    ledger = load_ledger()
+    ledger = load_ledger(repo_root=root)
     findings.extend(scan_contract_compat(paths, root, ledger))
     return findings
 

--- a/packages/conformance/conformance/suite/checks/deprecation/_contract_compat.py
+++ b/packages/conformance/conformance/suite/checks/deprecation/_contract_compat.py
@@ -445,8 +445,9 @@ def scan_contract_compat(
                                 "recorded in the contract ledger "
                                 "(contract_schema.lock.json). Run "
                                 "'uv run atlan-application-sdk-conformance "
-                                "gen-contract-ledger' and commit the updated ledger "
-                                "in the same PR. The generator is append-only — it "
+                                "gen-contract-ledger' (writes contract_schema.lock.json "
+                                "in the repo root) and commit that file in the same PR. "
+                                "The generator is append-only — it "
                                 "can never launder a removal."
                             ),
                             directives=directives,

--- a/packages/conformance/conformance/suite/checks/deprecation/_ledger_schema.py
+++ b/packages/conformance/conformance/suite/checks/deprecation/_ledger_schema.py
@@ -74,11 +74,19 @@ def _parse(payload: dict) -> ContractLedger:
     return ContractLedger(version=payload.get("version", LEDGER_VERSION), fields=fields)
 
 
-def load_ledger(path: Path | None = None) -> ContractLedger:
+def load_ledger(
+    path: Path | None = None, *, repo_root: Path | None = None
+) -> ContractLedger:
     """Load the committed ledger.
 
-    With *path* ``None`` (the normal B005/B006 path) reads from the
-    ``conformance`` package resource.  A *path* override is used by tests.
+    Resolution order (first match wins):
+    1. *path* — explicit override used by tests and the generator.
+    2. ``ATLAN_CONTRACT_LEDGER_PATH`` env var — CI override.
+    3. ``<repo_root>/contract_schema.lock.json`` — the app's committed ledger
+       when the detector is given a repo root (the normal B005/B006 path for
+       consumer apps).  Skipped when the file is absent so the SDK, which
+       keeps its ledger inside the package, falls through to step 4.
+    4. Package data — the SDK's own bundled ledger (fallback / SDK-self-scan).
 
     A genuinely **absent** ledger yields an empty result silently (graceful
     degradation — an older wheel without the file simply produces no B005
@@ -86,7 +94,12 @@ def load_ledger(path: Path | None = None) -> ContractLedger:
     """
     if path is None:
         env_override = os.environ.get("ATLAN_CONTRACT_LEDGER_PATH")
-        path = Path(env_override) if env_override else None
+        if env_override:
+            path = Path(env_override)
+        elif repo_root is not None:
+            candidate = repo_root / "contract_schema.lock.json"
+            if candidate.exists():
+                path = candidate
     try:
         if path is None:
             text = (

--- a/packages/conformance/conformance/tools/generate_contract_ledger.py
+++ b/packages/conformance/conformance/tools/generate_contract_ledger.py
@@ -40,7 +40,6 @@ from conformance.suite.checks.deprecation._contract_compat import (
     _iter_fields,
 )
 from conformance.suite.checks.deprecation._ledger_schema import (
-    LEDGER_PATH,
     ContractField,
     ContractLedger,
     load_ledger,
@@ -165,8 +164,8 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--outfile",
         type=Path,
-        default=LEDGER_PATH,
-        help=f"Ledger path to write (default: {LEDGER_PATH}).",
+        default=Path("contract_schema.lock.json"),
+        help="Ledger path to write (default: contract_schema.lock.json in cwd).",
     )
     parser.add_argument(
         "--check",

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -206,6 +206,12 @@ def test_conformance_workflow_contains_event_name() -> None:
     assert "sdk-ref" not in content
 
 
+def test_conformance_workflow_has_pull_requests_read() -> None:
+    """pull-requests: read is required for dorny/paths-filter on private repos."""
+    content = render("conformance.yaml")
+    assert "pull-requests: read" in content
+
+
 def test_conformance_upload_sarif_workflow_run_trigger() -> None:
     """Upload workflow is triggered by the Conformance workflow_run on main."""
     content = render("conformance-upload-sarif.yaml")

--- a/packages/conformance/tests/test_contract_ledger_drift.py
+++ b/packages/conformance/tests/test_contract_ledger_drift.py
@@ -19,11 +19,13 @@ would produce from the current SDK source.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 from conformance.suite.checks.deprecation._ledger_schema import (
     LEDGER_PATH,
+    LEDGER_VERSION,
     load_ledger,
     serialize,
 )
@@ -47,6 +49,77 @@ def test_ledger_is_committed() -> None:
     ledger = load_ledger()
     # Empty ledger is valid; SDK has no app entrypoints
     assert isinstance(ledger.fields, list)
+
+
+# ── load_ledger repo_root resolution ─────────────────────────────────────────
+
+
+def test_load_ledger_repo_root_picks_up_committed_file(tmp_path: Path) -> None:
+    """repo_root/contract_schema.lock.json is loaded when present."""
+    ledger_data = {"version": LEDGER_VERSION, "fields": []}
+    (tmp_path / "contract_schema.lock.json").write_text(
+        json.dumps(ledger_data), encoding="utf-8"
+    )
+    ledger = load_ledger(repo_root=tmp_path)
+    assert ledger.fields == []
+
+
+def test_load_ledger_repo_root_falls_back_to_package_data_when_absent(
+    tmp_path: Path,
+) -> None:
+    """When no contract_schema.lock.json exists in repo_root, package data is used."""
+    ledger = load_ledger(repo_root=tmp_path)
+    # Package data has the SDK template contracts — non-empty for a real install.
+    assert isinstance(ledger.fields, list)
+
+
+def test_load_ledger_env_override_takes_priority_over_repo_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ATLAN_CONTRACT_LEDGER_PATH wins over repo_root when both are set."""
+    env_file = tmp_path / "env_ledger.json"
+    env_data = {
+        "version": LEDGER_VERSION,
+        "fields": [
+            {"contract": "Env", "field": "x", "type": "str", "status": "active"}
+        ],
+    }
+    env_file.write_text(json.dumps(env_data), encoding="utf-8")
+
+    repo_file = tmp_path / "contract_schema.lock.json"
+    repo_data = {"version": LEDGER_VERSION, "fields": []}
+    repo_file.write_text(json.dumps(repo_data), encoding="utf-8")
+
+    monkeypatch.setenv("ATLAN_CONTRACT_LEDGER_PATH", str(env_file))
+    ledger = load_ledger(repo_root=tmp_path)
+    assert len(ledger.fields) == 1
+    assert ledger.fields[0].contract == "Env"
+
+
+def test_load_ledger_explicit_path_takes_priority_over_repo_root(
+    tmp_path: Path,
+) -> None:
+    """An explicit *path* argument wins over repo_root."""
+    explicit_file = tmp_path / "explicit.json"
+    explicit_data = {
+        "version": LEDGER_VERSION,
+        "fields": [
+            {"contract": "Explicit", "field": "y", "type": "int", "status": "active"}
+        ],
+    }
+    explicit_file.write_text(json.dumps(explicit_data), encoding="utf-8")
+
+    repo_file = tmp_path / "contract_schema.lock.json"
+    repo_file.write_text(
+        json.dumps({"version": LEDGER_VERSION, "fields": []}), encoding="utf-8"
+    )
+
+    ledger = load_ledger(path=explicit_file, repo_root=tmp_path)
+    assert len(ledger.fields) == 1
+    assert ledger.fields[0].contract == "Explicit"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 
 
 def test_committed_ledger_matches_fresh_scan() -> None:


### PR DESCRIPTION
## Summary

- Add `pull-requests: read` to `conformance-reusable.yaml` and the bootstrap template `conformance.yaml` — `dorny/paths-filter` needs this permission to list changed files on PR events in private repos; without it every series silently skips and the gate trivially passes
- Fix `gen-contract-ledger --outfile` default from the installed package's `.venv` data dir to `contract_schema.lock.json` in the cwd (repo root), so the file is immediately stageable after running the command
- Update the B006 violation message and CLI usage docs to reflect the new default path

## Test plan

- [ ] `test_conformance_workflow_has_pull_requests_read` — new test guards the bootstrap template permission
- [ ] `test_cmd_bootstrap_always_overwrites_on_rerun` and drift tests still pass (bootstrap template renders correctly)
- [ ] All 126 conformance package tests pass (`uv run pytest` in `packages/conformance/`)
- [ ] Pre-commit clean (`ruff`, `pyright`, `ruff-format`)
- [ ] Verify a private repo bootstrapped with the new template no longer has `dorny/paths-filter` silently skip series legs on PRs