### PR TITLE
fix(execution): guard Temporal failure serialiser against deep/cyclic exception chains (BLDX-1512)

### DIFF
--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -28,6 +28,43 @@ from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
 
+# Temporal's failure serializer (_error_to_failure) recurses into __cause__ /
+# __context__ chains without a depth bound.  A deep or cyclic chain hits
+# Python's recursion limit and the serializer's own crash replaces the real
+# error with "Failed building exception result: maximum recursion depth
+# exceeded" (BLDX-1512).  We sever the chain at this depth before raising
+# ApplicationError so the serializer can always complete safely.
+#
+# Safety maths: serializer uses 2 call frames per level; baseline async call
+# stack is ~30–50 frames; at depth 50 we reach ~150 frames total vs. Python's
+# default limit of 1000.  Each stack trace is typically 1–5 KB, so 50 levels ≈
+# 50–250 KB — well inside Temporal's default 2 MB payload limit.
+_MAX_CHAIN_DEPTH = 50
+
+
+def _sever_cause_chain(exc: BaseException) -> None:
+    """Sever the __cause__/__context__ chain at _MAX_CHAIN_DEPTH.
+
+    Walks the chain iteratively (safe against deep stacks) and cuts the link
+    once we hit the depth cap or detect a cycle via object identity.  Mutates
+    the exception objects in place — safe because this is called immediately
+    before we raise a fresh ApplicationError that will own the chain.
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    depth = 0
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        depth += 1
+        nxt = current.__cause__ or (
+            current.__context__ if not current.__suppress_context__ else None
+        )
+        if nxt is not None and (depth >= _MAX_CHAIN_DEPTH or id(nxt) in seen):
+            current.__cause__ = None
+            current.__context__ = None
+            break
+        current = nxt
+
 
 @dataclasses.dataclass
 class TaskContext:
@@ -262,9 +299,26 @@ def create_activity_from_task(
                     ApplicationError,
                 )
 
+                # Guard FailureDetails construction: evidence fields may contain
+                # non-serialisable values; fall back to details-free ApplicationError
+                # rather than letting a secondary error mask the original.
+                try:
+                    details: tuple[Any, ...] = (e.to_failure_details(),)
+                except Exception:
+                    logger.warning(
+                        "Failed to build FailureDetails for %s; raising without structured details",
+                        type(e).__name__,
+                        exc_info=True,
+                    )
+                    details = ()
+
+                # Sever deep / cyclic __cause__ / __context__ chains before
+                # Temporal's failure serializer walks them (BLDX-1512).
+                _sever_cause_chain(e)
+
                 raise ApplicationError(
                     str(e),
-                    e.to_failure_details(),
+                    *details,
                     type=type(e).__name__,
                     non_retryable=not e.effective_retryable,
                 ) from e

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -49,6 +49,12 @@ def _sever_cause_chain(exc: BaseException) -> None:
     once we hit the depth cap or detect a cycle via object identity.  Mutates
     the exception objects in place — safe because this is called immediately
     before we raise a fresh ApplicationError that will own the chain.
+
+    At the cut point both ``__cause__`` and ``__context__`` are nulled out so
+    that neither link re-opens the chain.  Any un-traversed alternate link
+    (e.g. a ``__context__`` branch not followed because ``__cause__`` was
+    taken) is also discarded — this is a deliberate trade-off to guarantee
+    termination; the primary causal path up to the depth cap is preserved.
     """
     seen: set[int] = set()
     current: BaseException | None = exc
@@ -281,6 +287,7 @@ def create_activity_from_task(
                     ApplicationError,
                 )
 
+                _sever_cause_chain(e)
                 raise ApplicationError(
                     "Activity terminated because the worker pod is shutting down",
                     type=WORKER_EVICTED_TYPE,

--- a/application_sdk/execution/_temporal/interceptors/log.py
+++ b/application_sdk/execution/_temporal/interceptors/log.py
@@ -61,7 +61,9 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-_MAX_CHAIN_WALK = 20  # belt-and-suspenders depth cap alongside cycle detection
+# Must match _MAX_CHAIN_DEPTH in activities.py: an AppError sitting between the
+# walk cap and the sever cap would be silently invisible to OTel attributes.
+_MAX_CHAIN_WALK = 50
 
 
 def _extract_failure_attrs(exc: BaseException | None) -> dict[str, str]:

--- a/application_sdk/execution/_temporal/interceptors/log.py
+++ b/application_sdk/execution/_temporal/interceptors/log.py
@@ -61,6 +61,9 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+_MAX_CHAIN_WALK = 20  # belt-and-suspenders depth cap alongside cycle detection
+
+
 def _extract_failure_attrs(exc: BaseException | None) -> dict[str, str]:
     """Flatten SDK error classification onto OTel attributes for ERROR logs.
 
@@ -84,8 +87,10 @@ def _extract_failure_attrs(exc: BaseException | None) -> dict[str, str]:
         return {}
     seen: set[int] = set()
     current: BaseException | None = exc
-    while current is not None and id(current) not in seen:
+    depth = 0
+    while current is not None and id(current) not in seen and depth < _MAX_CHAIN_WALK:
         seen.add(id(current))
+        depth += 1
         if isinstance(current, AppError):
             return {
                 "failure.category": current.category.value,

--- a/tests/unit/execution/test_cause_chain_guard.py
+++ b/tests/unit/execution/test_cause_chain_guard.py
@@ -8,14 +8,18 @@ exceeded".
 These tests verify that:
   1. _sever_cause_chain caps the chain at _MAX_CHAIN_DEPTH — linear and cyclic.
   2. _extract_failure_attrs stops at _MAX_CHAIN_WALK even on a deep chain.
-  3. An AppError with a 1 000-link chain does not raise RecursionError when the
-     activity exception handler processes it (the integration path).
+  3. An AppError with a 600-link chain does not raise RecursionError when run
+     through the real activity_fn produced by create_activity_from_task().
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from unittest import mock
 
+import pytest
+
+from application_sdk.contracts.base import Input, Output
 from application_sdk.errors.base import AppError
 from application_sdk.errors.categories import Audience, FailureCategory
 from application_sdk.execution._temporal.activities import (
@@ -40,7 +44,7 @@ class _ConfigError(AppError):
 
 
 # ---------------------------------------------------------------------------
-# _sever_cause_chain — linear chain
+# _sever_cause_chain — linear __cause__ chains and __suppress_context__
 # ---------------------------------------------------------------------------
 
 
@@ -85,9 +89,33 @@ class TestSeverCauseChainLinear:
         _sever_cause_chain(chain)
         assert self._chain_depth(chain) == _MAX_CHAIN_DEPTH
 
+    def test_suppress_context_stops_descent(self) -> None:
+        # Simulates `raise a from None`: __suppress_context__ is True so the
+        # walker must not follow __context__ even if it carries a long chain.
+        a = ValueError("a")
+        b = ValueError("b")
+        c = ValueError("c")
+        b.__cause__ = c  # b has its own cause — untouched if walker skips b
+        a.__context__ = b
+        a.__suppress_context__ = True
+        _sever_cause_chain(a)
+        # The walker exited at `a` without entering `b`; b's chain is intact.
+        assert b.__cause__ is c
+
+    def test_context_only_chain_depth_cap(self) -> None:
+        # Build a deep chain using only __context__ (no __cause__).
+        head = ValueError("head")
+        current = head
+        for i in range(_MAX_CHAIN_DEPTH + 20):
+            nxt = ValueError(f"ctx-{i}")
+            current.__context__ = nxt
+            current = nxt
+        _sever_cause_chain(head)
+        assert self._chain_depth(head) <= _MAX_CHAIN_DEPTH
+
 
 # ---------------------------------------------------------------------------
-# _sever_cause_chain — cyclic chain
+# _sever_cause_chain — cyclic chains
 # ---------------------------------------------------------------------------
 
 
@@ -98,15 +126,11 @@ class TestSeverCauseChainCycle:
         a.__cause__ = b
         b.__cause__ = a  # cycle
         _sever_cause_chain(a)
-        # After severing, the chain must be finite
-        seen: set[int] = set()
-        current: BaseException | None = a
-        count = 0
-        while current is not None and id(current) not in seen:
-            seen.add(id(current))
-            count += 1
-            current = current.__cause__ or current.__context__
-        assert count <= _MAX_CHAIN_DEPTH
+        # The sever point is b (it would next point back to a, which is in seen).
+        # Assert the mutation directly rather than re-walking with id() guards
+        # (which would also terminate on the cycle regardless of the fix).
+        assert b.__cause__ is None
+        assert b.__context__ is None
 
     def test_self_referential_cause_is_severed(self) -> None:
         a = ValueError("self")
@@ -120,15 +144,8 @@ class TestSeverCauseChainCycle:
         a.__context__ = b
         b.__context__ = a  # cycle via __context__
         _sever_cause_chain(a)
-        # Must terminate without RecursionError
-        seen: set[int] = set()
-        current: BaseException | None = a
-        count = 0
-        while current is not None and id(current) not in seen:
-            seen.add(id(current))
-            count += 1
-            current = current.__cause__ or current.__context__
-        assert count <= _MAX_CHAIN_DEPTH
+        # b would next point back to a (in seen) — assert the link is cut.
+        assert b.__context__ is None
 
 
 # ---------------------------------------------------------------------------
@@ -137,7 +154,7 @@ class TestSeverCauseChainCycle:
 
 
 class TestExtractFailureAttrsDepthCap:
-    def _build_chain(self, length: int) -> BaseException:
+    def _build_plain_chain(self, length: int) -> BaseException:
         head = ValueError("link-0")
         current = head
         for i in range(1, length):
@@ -146,14 +163,35 @@ class TestExtractFailureAttrsDepthCap:
             current = nxt
         return head
 
-    def test_returns_empty_for_plain_chain_beyond_max(self) -> None:
-        chain = self._build_chain(_MAX_CHAIN_WALK + 100)
-        result = _extract_failure_attrs(chain)
+    def test_app_error_beyond_cap_is_not_found(self) -> None:
+        # _MAX_CHAIN_WALK plain links at positions 1…_MAX_CHAIN_WALK, then
+        # AppError at position _MAX_CHAIN_WALK+1 — just outside the walk window.
+        head = ValueError("link-0")
+        current = head
+        for i in range(1, _MAX_CHAIN_WALK):
+            nxt = ValueError(f"link-{i}")
+            current.__cause__ = nxt
+            current = nxt
+        current.__cause__ = _ConfigError(message="hidden")
+        result = _extract_failure_attrs(head)
         assert result == {}
 
+    def test_app_error_at_cap_boundary_is_found(self) -> None:
+        # _MAX_CHAIN_WALK-1 plain links, then AppError at position _MAX_CHAIN_WALK
+        # — the last item the walker inspects.
+        head = ValueError("link-0")
+        current = head
+        for i in range(1, _MAX_CHAIN_WALK - 1):
+            nxt = ValueError(f"link-{i}")
+            current.__cause__ = nxt
+            current = nxt
+        current.__cause__ = _ConfigError(message="visible")
+        result = _extract_failure_attrs(head)
+        assert result.get("failure.code") == "NO_ASSETS"
+
     def test_finds_app_error_within_depth(self) -> None:
-        chain = self._build_chain(3)
-        # Wrap the chain: AppError at depth 2
+        chain = self._build_plain_chain(3)
+        # AppError at depth 2
         app_err = _ConfigError(message="no assets")
         app_err.__cause__ = chain
         wrapper = ValueError("outer")
@@ -162,7 +200,7 @@ class TestExtractFailureAttrsDepthCap:
         assert result.get("failure.code") == "NO_ASSETS"
 
     def test_does_not_recurse_on_deep_chain(self) -> None:
-        chain = self._build_chain(1_000)
+        chain = self._build_plain_chain(1_000)
         # Must not raise RecursionError
         _extract_failure_attrs(chain)
 
@@ -177,16 +215,47 @@ class TestExtractFailureAttrsDepthCap:
 
 
 # ---------------------------------------------------------------------------
-# Integration: AppError with deep chain → activity exception handler
+# Integration: AppError with deep chain → real activity_fn
 # ---------------------------------------------------------------------------
 
 
-class TestActivityExceptionHandlerDeepChain:
-    """Verify that the activity_fn exception handler does not raise RecursionError
-    when the AppError carries a chain longer than Python's recursion limit / 2."""
+class _DeepErrIn(Input, allow_unbounded_fields=True):
+    x: str = ""
 
-    def _build_app_error_with_chain(self, chain_length: int) -> _ConfigError:
-        # Build a chain of plain exceptions
+
+class _DeepErrOut(Output, allow_unbounded_fields=True):
+    y: str = ""
+
+
+class _DeepMsgIn(Input, allow_unbounded_fields=True):
+    x: str = ""
+
+
+class _DeepMsgOut(Output, allow_unbounded_fields=True):
+    y: str = ""
+
+
+class TestActivityExceptionHandlerDeepChain:
+    """Verify the activity_fn exception handler does not raise RecursionError
+    when the AppError carries a chain longer than Python's recursion limit / 2.
+
+    Uses create_activity_from_task() rather than reconstructing the handler
+    inline so regressions in the actual handler path are caught.
+    """
+
+    def setup_method(self) -> None:
+        from application_sdk.app.registry import AppRegistry, TaskRegistry
+
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    def teardown_method(self) -> None:
+        from application_sdk.app.registry import AppRegistry, TaskRegistry
+
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    def _build_deep_chain_error(self, chain_length: int) -> _ConfigError:
         tail = ValueError("tail")
         current: BaseException = tail
         for i in range(chain_length - 1):
@@ -195,28 +264,58 @@ class TestActivityExceptionHandlerDeepChain:
             current = nxt
         return _ConfigError(message="no accessible assets", cause=current)
 
-    def test_handler_raises_application_error_not_recursion_error(self) -> None:
-        from application_sdk.execution._temporal.activities import _sever_cause_chain
+    @pytest.mark.asyncio
+    async def test_handler_raises_application_error_not_recursion_error(
+        self,
+    ) -> None:
+        from application_sdk.app.base import App
+        from application_sdk.app.registry import TaskRegistry
+        from application_sdk.app.task import task
+        from application_sdk.execution._temporal import activities as activities_module
+        from application_sdk.execution._temporal.activities import (
+            TaskContext,
+            create_activity_from_task,
+        )
         from application_sdk.execution.errors import ApplicationError
 
-        app_err = self._build_app_error_with_chain(600)
+        deep_err = self._build_deep_chain_error(600)
 
-        # Replicate what the activity exception handler does
-        try:
-            details: tuple = (app_err.to_failure_details(),)
-        except Exception:
-            details = ()
+        class _DeepErrApp(App):
+            @task(timeout_seconds=60)
+            async def deep_fail(self, input: _DeepErrIn) -> _DeepErrOut:
+                raise deep_err
 
-        _sever_cause_chain(app_err)
+            async def run(self, input: _DeepErrIn) -> _DeepErrOut:  # type: ignore[override]
+                return await self.deep_fail(input)
 
-        raised = ApplicationError(
-            str(app_err),
-            *details,
-            type=type(app_err).__name__,
-            non_retryable=not app_err.effective_retryable,
+        task_registry = TaskRegistry.get_instance()
+        tasks = task_registry.get_tasks_for_app("_deep-err-app")
+        deep_fail_task = next(t for t in tasks if t.name == "deep_fail")
+        activity_fn = create_activity_from_task(deep_fail_task)
+
+        ctx = TaskContext(
+            app_name="_deep-err-app",
+            task_name="deep_fail",
+            run_id="run-1",
+            heartbeat_timeout_seconds=None,
+            auto_heartbeat_seconds=None,
         )
-        raised.__cause__ = app_err
 
+        with (
+            mock.patch.object(
+                activities_module.activity,
+                "info",
+                return_value=mock.MagicMock(workflow_id="wf-deep"),
+            ),
+            mock.patch(
+                "application_sdk.infrastructure.context.get_infrastructure",
+                return_value=None,
+            ),
+            pytest.raises(ApplicationError) as exc_info,
+        ):
+            await activity_fn(ctx, _DeepErrIn(x=""))
+
+        raised = exc_info.value
         # The chain rooted at raised must be finite and within safe bounds
         seen: set[int] = set()
         current: BaseException | None = raised
@@ -226,29 +325,60 @@ class TestActivityExceptionHandlerDeepChain:
             depth += 1
             current = current.__cause__ or current.__context__
 
-        # _MAX_CHAIN_DEPTH + 1 for the ApplicationError wrapper itself
+        # +1 for the ApplicationError wrapper itself, +1 buffer for __context__
         assert depth <= _MAX_CHAIN_DEPTH + 2
+        assert raised.type == "_ConfigError"
 
-    def test_details_carry_original_type_and_message(self) -> None:
-        from application_sdk.execution._temporal.activities import _sever_cause_chain
+    @pytest.mark.asyncio
+    async def test_details_carry_original_type_and_message(self) -> None:
+        from application_sdk.app.base import App
+        from application_sdk.app.registry import TaskRegistry
+        from application_sdk.app.task import task
+        from application_sdk.execution._temporal import activities as activities_module
+        from application_sdk.execution._temporal.activities import (
+            TaskContext,
+            create_activity_from_task,
+        )
         from application_sdk.execution.errors import ApplicationError
 
-        app_err = self._build_app_error_with_chain(600)
+        deep_err = self._build_deep_chain_error(600)
 
-        try:
-            details: tuple = (app_err.to_failure_details(),)
-        except Exception:
-            details = ()
+        class _DeepMsgApp(App):
+            @task(timeout_seconds=60)
+            async def deep_fail(self, input: _DeepMsgIn) -> _DeepMsgOut:
+                raise deep_err
 
-        _sever_cause_chain(app_err)
+            async def run(self, input: _DeepMsgIn) -> _DeepMsgOut:  # type: ignore[override]
+                return await self.deep_fail(input)
 
-        raised = ApplicationError(
-            str(app_err),
-            *details,
-            type=type(app_err).__name__,
-            non_retryable=not app_err.effective_retryable,
+        task_registry = TaskRegistry.get_instance()
+        tasks = task_registry.get_tasks_for_app("_deep-msg-app")
+        deep_fail_task = next(t for t in tasks if t.name == "deep_fail")
+        activity_fn = create_activity_from_task(deep_fail_task)
+
+        ctx = TaskContext(
+            app_name="_deep-msg-app",
+            task_name="deep_fail",
+            run_id="run-2",
+            heartbeat_timeout_seconds=None,
+            auto_heartbeat_seconds=None,
         )
 
+        with (
+            mock.patch.object(
+                activities_module.activity,
+                "info",
+                return_value=mock.MagicMock(workflow_id="wf-msg"),
+            ),
+            mock.patch(
+                "application_sdk.infrastructure.context.get_infrastructure",
+                return_value=None,
+            ),
+            pytest.raises(ApplicationError) as exc_info,
+        ):
+            await activity_fn(ctx, _DeepMsgIn(x=""))
+
+        raised = exc_info.value
         assert raised.type == "_ConfigError"
         assert "no accessible assets" in raised.message
         assert len(raised.details) == 1

--- a/tests/unit/execution/test_cause_chain_guard.py
+++ b/tests/unit/execution/test_cause_chain_guard.py
@@ -1,0 +1,257 @@
+"""Regression tests for BLDX-1512.
+
+Temporal's failure serializer recurses into __cause__/__context__ chains without
+a depth bound.  A deep or cyclic chain overflows the call stack and replaces the
+real error with "Failed building exception result: maximum recursion depth
+exceeded".
+
+These tests verify that:
+  1. _sever_cause_chain caps the chain at _MAX_CHAIN_DEPTH — linear and cyclic.
+  2. _extract_failure_attrs stops at _MAX_CHAIN_WALK even on a deep chain.
+  3. An AppError with a 1 000-link chain does not raise RecursionError when the
+     activity exception handler processes it (the integration path).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from application_sdk.errors.base import AppError
+from application_sdk.errors.categories import Audience, FailureCategory
+from application_sdk.execution._temporal.activities import (
+    _MAX_CHAIN_DEPTH,
+    _sever_cause_chain,
+)
+from application_sdk.execution._temporal.interceptors.log import (
+    _MAX_CHAIN_WALK,
+    _extract_failure_attrs,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal AppError subclass used throughout
+# ---------------------------------------------------------------------------
+
+
+@dataclass(kw_only=True)
+class _ConfigError(AppError):
+    category: FailureCategory = FailureCategory.INVALID_INPUT  # type: ignore[assignment]
+    code: str = "NO_ASSETS"  # type: ignore[assignment]
+    audience: Audience = Audience.USER  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# _sever_cause_chain — linear chain
+# ---------------------------------------------------------------------------
+
+
+class TestSeverCauseChainLinear:
+    def _build_chain(self, length: int) -> BaseException:
+        head = ValueError("link-0")
+        current = head
+        for i in range(1, length):
+            nxt = ValueError(f"link-{i}")
+            current.__cause__ = nxt
+            current = nxt
+        return head
+
+    def _chain_depth(self, exc: BaseException | None) -> int:
+        seen: set[int] = set()
+        depth = 0
+        current = exc
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            depth += 1
+            current = current.__cause__ or current.__context__
+        return depth
+
+    def test_short_chain_is_untouched(self) -> None:
+        chain = self._build_chain(_MAX_CHAIN_DEPTH - 1)
+        _sever_cause_chain(chain)
+        assert self._chain_depth(chain) == _MAX_CHAIN_DEPTH - 1
+
+    def test_chain_at_max_depth_is_untouched(self) -> None:
+        chain = self._build_chain(_MAX_CHAIN_DEPTH)
+        _sever_cause_chain(chain)
+        assert self._chain_depth(chain) == _MAX_CHAIN_DEPTH
+
+    def test_deep_chain_is_severed(self) -> None:
+        chain = self._build_chain(_MAX_CHAIN_DEPTH + 50)
+        _sever_cause_chain(chain)
+        assert self._chain_depth(chain) == _MAX_CHAIN_DEPTH
+
+    def test_very_deep_chain_does_not_recurse(self) -> None:
+        chain = self._build_chain(1_000)
+        # Must not raise RecursionError — the function is iterative
+        _sever_cause_chain(chain)
+        assert self._chain_depth(chain) == _MAX_CHAIN_DEPTH
+
+
+# ---------------------------------------------------------------------------
+# _sever_cause_chain — cyclic chain
+# ---------------------------------------------------------------------------
+
+
+class TestSeverCauseChainCycle:
+    def test_two_node_cycle_is_severed(self) -> None:
+        a = ValueError("a")
+        b = ValueError("b")
+        a.__cause__ = b
+        b.__cause__ = a  # cycle
+        _sever_cause_chain(a)
+        # After severing, the chain must be finite
+        seen: set[int] = set()
+        current: BaseException | None = a
+        count = 0
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            count += 1
+            current = current.__cause__ or current.__context__
+        assert count <= _MAX_CHAIN_DEPTH
+
+    def test_self_referential_cause_is_severed(self) -> None:
+        a = ValueError("self")
+        a.__cause__ = a  # self-loop
+        _sever_cause_chain(a)
+        assert a.__cause__ is None
+
+    def test_context_cycle_is_severed(self) -> None:
+        a = ValueError("a")
+        b = ValueError("b")
+        a.__context__ = b
+        b.__context__ = a  # cycle via __context__
+        _sever_cause_chain(a)
+        # Must terminate without RecursionError
+        seen: set[int] = set()
+        current: BaseException | None = a
+        count = 0
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            count += 1
+            current = current.__cause__ or current.__context__
+        assert count <= _MAX_CHAIN_DEPTH
+
+
+# ---------------------------------------------------------------------------
+# _extract_failure_attrs — depth cap
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFailureAttrsDepthCap:
+    def _build_chain(self, length: int) -> BaseException:
+        head = ValueError("link-0")
+        current = head
+        for i in range(1, length):
+            nxt = ValueError(f"link-{i}")
+            current.__cause__ = nxt
+            current = nxt
+        return head
+
+    def test_returns_empty_for_plain_chain_beyond_max(self) -> None:
+        chain = self._build_chain(_MAX_CHAIN_WALK + 100)
+        result = _extract_failure_attrs(chain)
+        assert result == {}
+
+    def test_finds_app_error_within_depth(self) -> None:
+        chain = self._build_chain(3)
+        # Wrap the chain: AppError at depth 2
+        app_err = _ConfigError(message="no assets")
+        app_err.__cause__ = chain
+        wrapper = ValueError("outer")
+        wrapper.__cause__ = app_err
+        result = _extract_failure_attrs(wrapper)
+        assert result.get("failure.code") == "NO_ASSETS"
+
+    def test_does_not_recurse_on_deep_chain(self) -> None:
+        chain = self._build_chain(1_000)
+        # Must not raise RecursionError
+        _extract_failure_attrs(chain)
+
+    def test_cycle_does_not_loop(self) -> None:
+        a = ValueError("a")
+        b = ValueError("b")
+        a.__cause__ = b
+        b.__cause__ = a
+        # Must not hang or raise RecursionError
+        result = _extract_failure_attrs(a)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Integration: AppError with deep chain → activity exception handler
+# ---------------------------------------------------------------------------
+
+
+class TestActivityExceptionHandlerDeepChain:
+    """Verify that the activity_fn exception handler does not raise RecursionError
+    when the AppError carries a chain longer than Python's recursion limit / 2."""
+
+    def _build_app_error_with_chain(self, chain_length: int) -> _ConfigError:
+        # Build a chain of plain exceptions
+        tail = ValueError("tail")
+        current: BaseException = tail
+        for i in range(chain_length - 1):
+            nxt = ValueError(f"link-{i}")
+            nxt.__cause__ = current
+            current = nxt
+        return _ConfigError(message="no accessible assets", cause=current)
+
+    def test_handler_raises_application_error_not_recursion_error(self) -> None:
+        from application_sdk.execution._temporal.activities import _sever_cause_chain
+        from application_sdk.execution.errors import ApplicationError
+
+        app_err = self._build_app_error_with_chain(600)
+
+        # Replicate what the activity exception handler does
+        try:
+            details: tuple = (app_err.to_failure_details(),)
+        except Exception:
+            details = ()
+
+        _sever_cause_chain(app_err)
+
+        raised = ApplicationError(
+            str(app_err),
+            *details,
+            type=type(app_err).__name__,
+            non_retryable=not app_err.effective_retryable,
+        )
+        raised.__cause__ = app_err
+
+        # The chain rooted at raised must be finite and within safe bounds
+        seen: set[int] = set()
+        current: BaseException | None = raised
+        depth = 0
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            depth += 1
+            current = current.__cause__ or current.__context__
+
+        # _MAX_CHAIN_DEPTH + 1 for the ApplicationError wrapper itself
+        assert depth <= _MAX_CHAIN_DEPTH + 2
+
+    def test_details_carry_original_type_and_message(self) -> None:
+        from application_sdk.execution._temporal.activities import _sever_cause_chain
+        from application_sdk.execution.errors import ApplicationError
+
+        app_err = self._build_app_error_with_chain(600)
+
+        try:
+            details: tuple = (app_err.to_failure_details(),)
+        except Exception:
+            details = ()
+
+        _sever_cause_chain(app_err)
+
+        raised = ApplicationError(
+            str(app_err),
+            *details,
+            type=type(app_err).__name__,
+            non_retryable=not app_err.effective_retryable,
+        )
+
+        assert raised.type == "_ConfigError"
+        assert "no accessible assets" in raised.message
+        assert len(raised.details) == 1
+        fd = raised.details[0]
+        assert fd.code == "NO_ASSETS"
+        assert fd.message == "no accessible assets"

--- a/tests/unit/execution/test_cause_chain_guard.py
+++ b/tests/unit/execution/test_cause_chain_guard.py
@@ -219,19 +219,11 @@ class TestExtractFailureAttrsDepthCap:
 # ---------------------------------------------------------------------------
 
 
-class _DeepErrIn(Input, allow_unbounded_fields=True):
+class _DeepIn(Input, allow_unbounded_fields=True):
     x: str = ""
 
 
-class _DeepErrOut(Output, allow_unbounded_fields=True):
-    y: str = ""
-
-
-class _DeepMsgIn(Input, allow_unbounded_fields=True):
-    x: str = ""
-
-
-class _DeepMsgOut(Output, allow_unbounded_fields=True):
+class _DeepOut(Output, allow_unbounded_fields=True):
     y: str = ""
 
 
@@ -242,18 +234,6 @@ class TestActivityExceptionHandlerDeepChain:
     Uses create_activity_from_task() rather than reconstructing the handler
     inline so regressions in the actual handler path are caught.
     """
-
-    def setup_method(self) -> None:
-        from application_sdk.app.registry import AppRegistry, TaskRegistry
-
-        AppRegistry.reset()
-        TaskRegistry.reset()
-
-    def teardown_method(self) -> None:
-        from application_sdk.app.registry import AppRegistry, TaskRegistry
-
-        AppRegistry.reset()
-        TaskRegistry.reset()
 
     def _build_deep_chain_error(self, chain_length: int) -> _ConfigError:
         tail = ValueError("tail")
@@ -282,10 +262,10 @@ class TestActivityExceptionHandlerDeepChain:
 
         class _DeepErrApp(App):
             @task(timeout_seconds=60)
-            async def deep_fail(self, input: _DeepErrIn) -> _DeepErrOut:
+            async def deep_fail(self, input: _DeepIn) -> _DeepOut:
                 raise deep_err
 
-            async def run(self, input: _DeepErrIn) -> _DeepErrOut:  # type: ignore[override]
+            async def run(self, input: _DeepIn) -> _DeepOut:  # type: ignore[override]
                 return await self.deep_fail(input)
 
         task_registry = TaskRegistry.get_instance()
@@ -313,7 +293,7 @@ class TestActivityExceptionHandlerDeepChain:
             ),
             pytest.raises(ApplicationError) as exc_info,
         ):
-            await activity_fn(ctx, _DeepErrIn(x=""))
+            await activity_fn(ctx, _DeepIn(x=""))
 
         raised = exc_info.value
         # The chain rooted at raised must be finite and within safe bounds
@@ -345,10 +325,10 @@ class TestActivityExceptionHandlerDeepChain:
 
         class _DeepMsgApp(App):
             @task(timeout_seconds=60)
-            async def deep_fail(self, input: _DeepMsgIn) -> _DeepMsgOut:
+            async def deep_fail(self, input: _DeepIn) -> _DeepOut:
                 raise deep_err
 
-            async def run(self, input: _DeepMsgIn) -> _DeepMsgOut:  # type: ignore[override]
+            async def run(self, input: _DeepIn) -> _DeepOut:  # type: ignore[override]
                 return await self.deep_fail(input)
 
         task_registry = TaskRegistry.get_instance()
@@ -376,7 +356,7 @@ class TestActivityExceptionHandlerDeepChain:
             ),
             pytest.raises(ApplicationError) as exc_info,
         ):
-            await activity_fn(ctx, _DeepMsgIn(x=""))
+            await activity_fn(ctx, _DeepIn(x=""))
 
         raised = exc_info.value
         assert raised.type == "_ConfigError"


### PR DESCRIPTION
## Summary

- Temporal's `_error_to_failure` recurses into `__cause__`/`__context__` chains without a depth bound. A chain deeper than ~500 links (2 frames/level) exhausts Python's call stack; the serialiser's own `RecursionError` then replaces the real connector error with "Failed building exception result: maximum recursion depth exceeded".
- Add `_sever_cause_chain()` in `activities.py`: iterative walk with depth cap (`_MAX_CHAIN_DEPTH=50`) and cycle detection via `id()`-based seen set; severs the chain before raising `ApplicationError` so Temporal's serialiser always terminates safely.
- Wrap `e.to_failure_details()` in `try/except` so a secondary failure during `FailureDetails` construction cannot mask the original error.
- Add `_MAX_CHAIN_WALK=20` depth cap to `_extract_failure_attrs` in `log.py` alongside the existing cycle guard.

## Safety bounds

The depth cap of 50 was chosen deliberately:
- Temporal's serialiser uses 2 call frames per chain level
- Baseline async activity call stack is ~30–50 frames
- 50 levels × 2 frames + 50 baseline ≈ 150 total vs. Python's 1000 limit
- Each stack trace is ~1–5 KB; 50 levels ≈ 50–250 KB vs. Temporal's default 2 MB payload limit

Legitimate connector chains (GCP SDK → connector-specific → AppError) typically reach 5–15 levels; the cap is generous while still bounding the worst case.

## Test plan

- [ ] 13 regression tests in `tests/unit/execution/test_cause_chain_guard.py` cover: linear chains short/at-cap/over-cap, 1000-link chain (no RecursionError), two-node cycle, self-referential cycle, `__context__` cycle, `_extract_failure_attrs` depth cap, and the full activity exception handler path with a 600-link `AppError`
- [ ] All 275 existing execution unit tests still pass
- [ ] Pre-commit clean (ruff, pyright, isort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)