### PR TITLE
ci(sdk-review): make soft-success guard work so delivered reviews don't false-fail

### DIFF
--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -651,13 +651,14 @@ jobs:
           # comment that belonged to a previous head.
           #
           # Lower-bound timestamp: the starter comment's created-at, captured
-          # in STARTER_STARTED_AT (posted unconditionally at the very start of
-          # this run). NOTE: `github.run_started_at` is NOT a real field of the
-          # github context — it always expands to empty. The previous code
-          # keyed this bound off it, so the `[ -n ... ]` guard below was always
-          # false and this whole soft-success block never ran: every
-          # delivered-then-dropped review hard-failed. The starter timestamp is
-          # the correct per-run bound and is always populated.
+          # in STARTER_STARTED_AT and set by this run's own starter step via
+          # core.setOutput('started_at', ...). We prefer it over
+          # github.run_started_at because it is deterministically populated by
+          # a step in this run. The previous code keyed this bound off
+          # github.run_started_at, which evaluated to empty here (seen in the
+          # run's env dump); the empty value made the `[ -n ... ]` guard below
+          # false, so this whole soft-success block was skipped and every
+          # delivered-then-dropped review hard-failed.
           VERDICT_POSTED=0
           RUN_STARTED_AT="${STARTER_STARTED_AT:-}"
           if [ -n "${PR_NUMBER}" ] && [ -n "${RUN_STARTED_AT}" ]; then

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -381,7 +381,6 @@ jobs:
           PR_URL: ${{ steps.pr.outputs.html_url }}
           REPO_FULL_NAME: ${{ github.repository }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GHA_RUN_STARTED_AT: ${{ github.run_started_at }}
         run: |
           set -euo pipefail
 
@@ -526,6 +525,10 @@ jobs:
 
           # curl -N: no buffering (required for SSE).
           # --max-time matches mothership's max_timeout_seconds upper bound.
+          # --keepalive-time 15: send TCP keepalive probes so the VPN/nginx/NAT
+          # path doesn't reap an idle-looking connection mid-stream (the
+          # `curl: (56) Recv failure` class). Belt-and-suspenders alongside the
+          # ~15s app-level SSE heartbeats.
           # 2>&1: surface curl's own diagnostics into the same stream.
           while IFS= read -r line; do
             # Idle-watchdog: every line is an opportunity to check
@@ -628,7 +631,7 @@ jobs:
                 echo "[unknown]   ${line}"
                 ;;
             esac
-          done < <(curl -sS -N --max-time 7200 \
+          done < <(curl -sS -N --max-time 7200 --keepalive-time 15 \
             -X POST "${MOTHERSHIP_URL}/api/sandbox/execute" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${HARNESS_TOKEN}" \
@@ -646,12 +649,25 @@ jobs:
           # fail the workflow. The timestamp filter prevents a re-trigger on
           # a new commit from falsely soft-succeeding by counting a verdict
           # comment that belonged to a previous head.
+          #
+          # Lower-bound timestamp: the starter comment's created-at, captured
+          # in STARTER_STARTED_AT (posted unconditionally at the very start of
+          # this run). NOTE: `github.run_started_at` is NOT a real field of the
+          # github context — it always expands to empty. The previous code
+          # keyed this bound off it, so the `[ -n ... ]` guard below was always
+          # false and this whole soft-success block never ran: every
+          # delivered-then-dropped review hard-failed. The starter timestamp is
+          # the correct per-run bound and is always populated.
           VERDICT_POSTED=0
-          RUN_STARTED_AT="${GHA_RUN_STARTED_AT}"
+          RUN_STARTED_AT="${STARTER_STARTED_AT:-}"
           if [ -n "${PR_NUMBER}" ] && [ -n "${RUN_STARTED_AT}" ]; then
+            # --slurp collapses all pages into one array before --jq runs, so
+            # the filter emits a SINGLE count. Without it, `--paginate` runs
+            # the jq per page and prints one number per page — on a PR with
+            # >30 comments that multi-line output breaks `[ ... -gt 0 ]`.
             SUMMARY_COUNT=$(gh api "repos/${REPO_FULL_NAME}/issues/${PR_NUMBER}/comments" \
-              --paginate \
-              --jq "[.[] | select(.body | contains(\"<!-- SDK_REVIEW -->\")) | select(.created_at >= \"${RUN_STARTED_AT}\")] | length" \
+              --paginate --slurp \
+              --jq "[.[][] | select(.body | contains(\"<!-- SDK_REVIEW -->\")) | select(.created_at >= \"${RUN_STARTED_AT}\")] | length" \
               2>/dev/null || echo "0")
             if [ "${SUMMARY_COUNT}" -gt 0 ]; then
               VERDICT_POSTED=1


### PR DESCRIPTION
## What

Fixes the `@sdk-review` (mothership) workflow so a review that **was delivered** to the PR no longer reports a red `sdk-review` status when the long-lived SSE connection drops during cleanup.

## Why

The dispatch step holds a single SSE connection to mothership for up to 2h. When that connection drops mid-stream (the `curl: (56) Recv failure` class, common on the VPN/nginx path) **after** the verdict comment was already posted, a *soft-success* net is supposed to treat it as a pass — the review reached the PR, only the trailing stream broke.

**That net never fired.** It computed its lower-bound timestamp from `${{ github.run_started_at }}`, which evaluated to **empty** in the failing run (visible in the run's env dump as `GHA_RUN_STARTED_AT:` with no value). The empty value made the `[ -n "$RUN_STARTED_AT" ]` guard false, so the verdict-detection block was skipped entirely, `VERDICT_POSTED` stayed `0`, and the delivered-then-dropped review hard-failed.

Observed live on a recent run: the verdict (`NEEDS REBASE`) was posted with the correct `<!-- SDK_REVIEW -->` marker ~6 min in; the stream then dropped at ~15m43s; the workflow exited 1 with `Stream ended without a 'complete' event` despite the review being delivered.

## How

- **Root-cause fix:** use `STARTER_STARTED_AT` — the starter comment's created-at, set by this run's own starter step via `core.setOutput('started_at', ...)` and already wired into the dispatch step env — as the per-run lower bound. It's deterministically populated by a step in this run, so it doesn't depend on `github.run_started_at` being present at expression-eval time. Drop the now-unused `GHA_RUN_STARTED_AT` env.
- **Pagination footgun:** switch the verdict count to `gh api --paginate --slurp` so it emits a single number. The previous `--paginate ... | length` emitted one count *per page* and would break `[ -gt 0 ]` on PRs with >30 comments (latent today; 1 page = fine).
- **Connection hardening:** add `curl --keepalive-time 15` to reduce idle-connection reaping on the VPN/nginx/NAT path (belt-and-suspenders alongside the ~15s SSE heartbeats).

Net effect: a dropped stream after a delivered verdict becomes a clean pass **and** the downstream labeling step runs (e.g. `sdk-review-needs-rebase` gets applied instead of skipped). No mothership-side change is required — the verdict already arrives out-of-band via the PR comment.

## Verification

- `actionlint .github/workflows/sdk-review.yml` — clean.
- `uv run pre-commit run --files .github/workflows/sdk-review.yml` — all hooks pass.

> Title is `ci:`-scoped (workflow-only change) per the Validate-PR-title gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)