### PR TITLE
feat(handler): add flatten_handler_credentials decoder + HandlerContext.as_credentials_dict (BLDX-1509)

### DIFF
--- a/application_sdk/handler/__init__.py
+++ b/application_sdk/handler/__init__.py
@@ -24,6 +24,7 @@ from application_sdk.handler.contracts import (
     PreflightStatus,
     SqlMetadataObject,
     SqlMetadataOutput,
+    flatten_handler_credentials,
 )
 from application_sdk.handler.service import (
     create_app_handler_service,
@@ -51,6 +52,7 @@ __all__ = [
     "PreflightStatus",
     "SqlMetadataObject",
     "SqlMetadataOutput",
+    "flatten_handler_credentials",
     "create_app_handler_service",
     "run_app_handler_service",
 ]

--- a/application_sdk/handler/context.py
+++ b/application_sdk/handler/context.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from application_sdk.app.base_errors import SecretStoreNotConfiguredError
+from application_sdk.handler.contracts import flatten_handler_credentials
 from application_sdk.observability.logger_adaptor import get_logger
 
 if TYPE_CHECKING:
@@ -78,6 +79,17 @@ class HandlerContext:
     def has_credential(self, key: str) -> bool:
         """Check if a credential exists in the context."""
         return any(cred.key == key for cred in self._credentials)
+
+    def as_credentials_dict(self) -> dict[str, Any]:
+        """Return all credentials as a flat dict, re-nesting ``extra.*`` keys.
+
+        Convenience over :attr:`credentials` for handlers that need the whole
+        credential payload (e.g. to build a connection string) rather than a
+        single key via :meth:`get_credential`.  Delegates to
+        :func:`application_sdk.handler.contracts.flatten_handler_credentials` —
+        use this instead of re-implementing the ``extra.``-prefix decode loop.
+        """
+        return flatten_handler_credentials(self._credentials)
 
     @property
     def log(self) -> Any:

--- a/application_sdk/handler/contracts.py
+++ b/application_sdk/handler/contracts.py
@@ -177,6 +177,42 @@ class HandlerCredential(BaseModel):
     """Credential value (sensitive — never log this directly)."""
 
 
+def flatten_handler_credentials(
+    credentials: list[HandlerCredential],
+) -> dict[str, Any]:
+    """Re-nest a list of ``HandlerCredential`` pairs into a flat credential dict.
+
+    This is the inverse of the SDK's wire encoder (``_flatten_to_pairs``): a
+    top-level pair such as ``{"host": "..."}`` maps directly, and every
+    ``extra.<subkey>`` pair is collected back under a single nested ``extra``
+    dict.  It is the canonical way for a handler to turn the
+    ``list[HandlerCredential]`` it receives into the connection dict its client
+    expects — call this instead of re-implementing the
+    ``cred.key.startswith("extra.")`` loop in each connector.
+
+    Values are the opaque strings carried on the wire; no type coercion is
+    performed.  On a duplicate key the last pair wins, matching dict-construction
+    semantics.
+
+    Example::
+
+        # ctx.credentials == [HandlerCredential(key="host", value="db"),
+        #                     HandlerCredential(key="extra.region", value="us")]
+        flatten_handler_credentials(ctx.credentials)
+        # -> {"host": "db", "extra": {"region": "us"}}
+    """
+    flat: dict[str, Any] = {}
+    extra: dict[str, str] = {}
+    for cred in credentials:
+        if cred.key.startswith("extra."):
+            extra[cred.key[len("extra.") :]] = cred.value
+        else:
+            flat[cred.key] = cred.value
+    if extra:
+        flat["extra"] = extra
+    return flat
+
+
 class AuthStatus(SerializableEnum):
     """Result of an authentication attempt."""
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.19.0
-source-sha:    b8d1704887637534f8a7a9fb0e33e55f177bbbe2
-source-date:   2026-06-24T12:00:54+01:00
+sdk-version:   3.20.2
+source-sha:    608918bbf110ce7c48028ce7b12af3b24d767cec
+source-date:   2026-06-30T21:51:41+05:30
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -25,7 +25,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.credentials` | Credential resolvers (Atlan, OAuth, Git, agent), registry, vault spec | 41 |
 | `application_sdk.errors` | Structured error codes — ErrorCode dataclass and cross-component constants (APP_ERROR, HANDLER_ERROR, CONTRACT_VALIDATION, etc.) | 53 |
 | `application_sdk.execution` | Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal client | 14 |
-| `application_sdk.handler` | HTTP handler framework — Handler ABC, DefaultHandler, preflight, auth, service factory | 22 |
+| `application_sdk.handler` | HTTP handler framework — Handler ABC, DefaultHandler, preflight, auth, service factory | 23 |
 | `application_sdk.infrastructure` | Protocol-based infrastructure (StateStore, SecretStore, PubSub, Bindings, CapacityPool) | 34 |
 | `application_sdk.main` | Dev entry point — run_dev_combined() and AppConfig for local execution and container startup | 2 |
 | `application_sdk.observability` | Logging context — ExecutionContext, CorrelationContext, request/correlation helpers | 11 |
@@ -1524,6 +1524,13 @@ HTTP handler framework — Handler ABC, DefaultHandler, preflight, auth, service
 - **Signature:** `create_app_handler_service(handler: Handler, ...)`
 - **Summary:** Create a FastAPI app for a single handler.
 - **Defined in:** `application_sdk/handler/service.py`
+
+#### `flatten_handler_credentials`
+
+- **Import:** `from application_sdk.handler import flatten_handler_credentials`
+- **Signature:** `flatten_handler_credentials(credentials: list[HandlerCredential])`
+- **Summary:** Re-nest a list of ``HandlerCredential`` pairs into a flat credential dict.
+- **Defined in:** `application_sdk/handler/contracts.py`
 
 #### `run_app_handler_service`
 

--- a/tests/unit/handler/test_contracts.py
+++ b/tests/unit/handler/test_contracts.py
@@ -20,6 +20,7 @@ from application_sdk.handler.contracts import (
     PreflightStatus,
     SqlMetadataObject,
     SqlMetadataOutput,
+    flatten_handler_credentials,
 )
 
 
@@ -513,3 +514,61 @@ class TestEntrypointRefAlias:
         )
         assert inp.entrypoint == "asset-export-advanced"
         assert inp.entrypoint_ref == "csa-uber-asset-export-advanced"
+
+
+class TestFlattenHandlerCredentials:
+    def test_flattens_top_level_and_extra(self):
+        creds = [
+            HandlerCredential(key="host", value="db.example.com"),
+            HandlerCredential(key="username", value="svc"),
+            HandlerCredential(key="extra.region", value="us-east-1"),
+            HandlerCredential(key="extra.role", value="reader"),
+        ]
+        assert flatten_handler_credentials(creds) == {
+            "host": "db.example.com",
+            "username": "svc",
+            "extra": {"region": "us-east-1", "role": "reader"},
+        }
+
+    def test_empty_list(self):
+        assert flatten_handler_credentials([]) == {}
+
+    def test_no_extra_keys(self):
+        creds = [HandlerCredential(key="host", value="db")]
+        result = flatten_handler_credentials(creds)
+        assert result == {"host": "db"}
+        assert "extra" not in result
+
+    def test_duplicate_key_last_wins(self):
+        creds = [
+            HandlerCredential(key="host", value="old"),
+            HandlerCredential(key="host", value="new"),
+        ]
+        assert flatten_handler_credentials(creds) == {"host": "new"}
+
+    def test_round_trip_inverse_of_flatten_to_pairs(self):
+        # flatten_handler_credentials is the documented inverse of the wire
+        # encoder _flatten_to_pairs (values are stringified on the wire).
+        from application_sdk.handler.service import _flatten_to_pairs
+
+        pairs = _flatten_to_pairs(
+            {"host": "db", "port": 5432, "extra": {"region": "us"}}
+        )
+        creds = [HandlerCredential(key=p["key"], value=p["value"]) for p in pairs]
+        assert flatten_handler_credentials(creds) == {
+            "host": "db",
+            "port": "5432",
+            "extra": {"region": "us"},
+        }
+
+    def test_context_as_credentials_dict(self):
+        from application_sdk.handler.context import HandlerContext
+
+        ctx = HandlerContext(
+            app_name="test-app",
+            _credentials=[
+                HandlerCredential(key="host", value="db"),
+                HandlerCredential(key="extra.region", value="us"),
+            ],
+        )
+        assert ctx.as_credentials_dict() == {"host": "db", "extra": {"region": "us"}}


### PR DESCRIPTION
## What

Adds the missing public SDK capability for turning the credentials a handler receives into a usable connection dict:

- **`flatten_handler_credentials(credentials: list[HandlerCredential]) -> dict`** — the documented inverse of the SDK's wire encoder `_flatten_to_pairs`: top-level pairs map directly, `extra.<subkey>` pairs are re-nested under a single `extra` dict. Opaque string values, last-writer-wins on duplicate keys.
- **`HandlerContext.as_credentials_dict()`** — convenience over `.credentials`.
- Exported from `application_sdk.handler`.

## Why

Connectors receive credentials as `list[HandlerCredential]` but their clients need a flat connection dict, so **every connector re-implements the same `cred.key.startswith("extra.")` decode loop** — found verbatim in **13/13** sampled SQL connectors in the credential-handling fleet sweep (BLDX-1502). The SDK already shipped the *encoder* (`_flatten_to_pairs`) and per-key `get_credential()`, but **no public decoder for the whole payload** — so this is a genuine SDK gap, not just an app problem.

This is the **feature-first** half of BLDX-1509: ship the seam now, then (separately) add the conformance rule that bans the hand-rolled loop once consumers migrate.

## SDK self-audit ("close gaps if they exist in the SDK itself")

Audited `application_sdk` for all five credential anti-patterns from the sweep:
- **Sc (hand-rolled `extra.` decode):** the two hits are a *private test-infra decoder* (`testing/integration/client.py`, operates on raw `list[dict]`) and a *richer agent-JSON transform* (`common/transforms.py`, handles `{authType}.extra.field`) — neither is this public gap, so neither is refactored.
- **Sb (raw auth header):** all hits are the SDK's own primitives (`BearerTokenCredential.to_auth_header`, the oauth seam), docstring examples, or legit third-party Basic-auth (Segment) — no anti-pattern.
- **Sd (`os.environ` cred mutation):** only *reads* in test code, no `os.environ[...] =` mutation — none.
- **Se (TLS `CERT_NONE`):** none.

So the gap to close *in the SDK itself* was the **missing public decoder** — now added.

## Verification

- `uv run pytest tests/unit/handler/` — **343 passed** (6 new: top-level+extra nesting, empty, no-extra, duplicate-key, `as_credentials_dict`, and a round-trip against `_flatten_to_pairs`).
- Public import + cycle check pass; repo-root pre-commit (ruff/pyright/isort) green.

Part of BLDX-1502 → BLDX-1509. The conformance rule (step 2) remains deferred until consumers adopt this helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)