### PR TITLE
ci(conformance): fix age_days test date arithmetic across month boundary

### DIFF
--- a/packages/conformance/tests/test_renovate_classify.py
+++ b/packages/conformance/tests/test_renovate_classify.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from conformance.renovate.classify import classify
 from conformance.renovate.models import (
@@ -14,10 +14,9 @@ from conformance.renovate.models import (
 )
 from conformance.renovate.scan import _parse_checks_state
 
-# Anchor "now" once so age computations are deterministic within a run. _OLD is
-# clamped to day-of-month >= 1 so the 3-day-old PR stays in the same month.
+# Anchor "now" once so age computations are deterministic within a run.
 _NOW = datetime.now(timezone.utc)
-_OLD = datetime(_NOW.year, _NOW.month, max(1, _NOW.day - 3), tzinfo=timezone.utc)
+_OLD = _NOW - timedelta(days=3)
 
 
 def make_pr(


### PR DESCRIPTION
## Summary
- `test_age_days_computed` in `packages/conformance/tests/test_renovate_classify.py` failed on the merge queue for PR #2441 (run `28504485693`) because `_OLD` was computed as `datetime(_NOW.year, _NOW.month, max(1, _NOW.day - 3), ...)`, clamping to day 1 instead of rolling back into the previous month.
- On the 1st–3rd of any calendar month this makes `_OLD >= _NOW`, so the classified PR's `age_days` comes out as `0` instead of `>= 3`, failing the assertion. Not flaky — deterministically reproduces on those three days every month.
- Fixed by computing `_OLD = _NOW - timedelta(days=3)`, which correctly rolls across month/year boundaries.

## Test plan
- [x] `uv run pytest tests/test_renovate_classify.py -q` — 34 passed
- [x] `uv run pre-commit run --files packages/conformance/tests/test_renovate_classify.py` — clean