### PR TITLE
fix(conformance): vendor run-conformance-detect action + arg-builder script into consumer repos

### DIFF
--- a/.github/actions/run-conformance-detect/action.yaml
+++ b/.github/actions/run-conformance-detect/action.yaml
@@ -84,8 +84,26 @@ runs:
           --with "atlan-application-sdk-conformance" \
           -- atlan-application-sdk-conformance detect "${detect_args[@]}"
 
-    - name: "Detect (from git ref)"
-      if: inputs.conformance-ref != ''
+    - name: "Detect (from git ref, isolated env)"
+      if: inputs.conformance-ref != '' && inputs.needs-env != 'true'
+      shell: bash
+      env:
+        SERIES: ${{ inputs.series }}
+        SLUG: ${{ inputs.slug }}
+        EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
+        EXIT_ZERO: ${{ inputs.exit-zero }}
+        CONFORMANCE_REF: ${{ inputs.conformance-ref }}
+      run: |
+        set -euo pipefail
+        raw=$(python "$GITHUB_ACTION_PATH/../../scripts/build_conformance_args.py" \
+          --series "$SERIES" --slug "$SLUG")
+        mapfile -t detect_args <<< "$raw"
+        uv run \
+          --with "atlan-application-sdk-conformance @ git+https://github.com/atlanhq/application-sdk@${CONFORMANCE_REF}#subdirectory=packages/conformance" \
+          -- atlan-application-sdk-conformance detect "${detect_args[@]}"
+
+    - name: "Detect (from git ref, resolved env)"
+      if: inputs.conformance-ref != '' && inputs.needs-env == 'true'
       shell: bash
       env:
         SERIES: ${{ inputs.series }}

--- a/.github/actions/run-conformance-detect/action.yaml
+++ b/.github/actions/run-conformance-detect/action.yaml
@@ -116,6 +116,9 @@ runs:
         raw=$(python "$GITHUB_ACTION_PATH/../../scripts/build_conformance_args.py" \
           --series "$SERIES" --slug "$SLUG")
         mapfile -t detect_args <<< "$raw"
+        # uv run --with overlays this leg's ephemeral requirement onto the resolved
+        # env from the preceding sync step; needed so the suite's own D-series detect
+        # sees consumer deps.
         uv run \
           --with "atlan-application-sdk-conformance @ git+https://github.com/atlanhq/application-sdk@${CONFORMANCE_REF}#subdirectory=packages/conformance" \
           -- atlan-application-sdk-conformance detect "${detect_args[@]}"

--- a/packages/conformance/conformance/bootstrap/render.py
+++ b/packages/conformance/conformance/bootstrap/render.py
@@ -57,11 +57,41 @@ MANAGED_WORKFLOWS: tuple[str, ...] = (
     "renovate-pkl-sync.yaml",
 )
 
+# Non-workflow files that must also be vendored into every consumer repo,
+# keyed by (repo-root-relative dest path, template filename in templates/).
+#
+# ``conformance-reusable.yaml`` references these via a local ``uses: ./...``
+# step and a ``$GITHUB_ACTION_PATH``-relative script path. GitHub resolves
+# both against the *caller's* checkout, not application-sdk's — so every
+# consumer app needs its own copy or the C/D-series (and any other series
+# whose changed-files filter matches) legs fail with "Can't find action.yml"
+# the first time they actually run. Static templates (no per-repo params),
+# always-overwrite like MANAGED_WORKFLOWS.
+MANAGED_ACTION_FILES: tuple[tuple[str, str], ...] = (
+    (
+        ".github/actions/run-conformance-detect/action.yaml",
+        "run-conformance-detect-action.yaml",
+    ),
+    (".github/scripts/build_conformance_args.py", "build_conformance_args.py"),
+)
+
 
 def _load_template(name: str) -> str:
     """Read a template file from the embedded templates directory."""
     pkg = _ir.files("conformance.bootstrap") / "templates"
     return (pkg / name).read_text(encoding="utf-8")  # type: ignore[union-attr]
+
+
+# Templates that are byte-for-byte vendored copies of files living elsewhere
+# (action.yaml / shell scripts) and never take substitution variables. These
+# skip the jinja env entirely rather than relying on "just don't define any
+# << >> vars" — vendored scripts legitimately contain bash constructs like
+# the here-string operator (`<<<`) that collide with our custom `<< `
+# variable-start delimiter (Jinja matches it starting at the *second* `<`,
+# then fails deep in the following line looking for the closing ` >>`).
+_STATIC_TEMPLATES: frozenset[str] = frozenset(
+    template_name for _, template_name in MANAGED_ACTION_FILES
+)
 
 
 def render(
@@ -99,11 +129,14 @@ def render(
     All other keyword arguments are accepted but unused, so callers can pass
     the full variable set without knowing which template is parametric.
     """
+    raw = _load_template(name)
+    if name in _STATIC_TEMPLATES:
+        return raw
+
     # Derive app_image_name from app_name if not supplied.
     if not app_image_name:
         app_image_name = f"atlan-{app_name}-app"
 
-    raw = _load_template(name)
     tmpl = _ENV.from_string(raw)
     return tmpl.render(
         package_name=package_name,

--- a/packages/conformance/conformance/bootstrap/templates/build_conformance_args.py
+++ b/packages/conformance/conformance/bootstrap/templates/build_conformance_args.py
@@ -1,0 +1,53 @@
+"""Build the `detect` argument list for atlan-application-sdk-conformance.
+
+Reads EXCLUDE_PATHS and EXIT_ZERO from the environment (set by GitHub Actions
+``env:`` blocks) and prints one argument per line to stdout.  Callers do:
+
+    mapfile -t detect_args < <(python .github/scripts/build_conformance_args.py \\
+      --series C --slug ci)
+    uvx atlan-application-sdk-conformance detect "${detect_args[@]}"
+
+This keeps all conditional argument-building logic in a tested Python script
+rather than inlined in YAML (per docs/standards/ci.md).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+
+def build_args(
+    series: str,
+    slug: str,
+    *,
+    exclude: str = "",
+    exit_zero: bool = False,
+) -> list[str]:
+    result = ["--repo", ".", "--series", series, "--output", f"{slug}.sarif"]
+    if exclude:
+        result += ["--exclude", exclude]
+    if exit_zero:
+        result.append("--exit-zero")
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--series", required=True, help="Conformance series letter(s)")
+    parser.add_argument("--slug", required=True, help="Series slug for SARIF filename")
+    args = parser.parse_args(argv)
+
+    exclude = os.environ.get("EXCLUDE_PATHS", "")
+    exit_zero = os.environ.get("EXIT_ZERO", "").lower() == "true"
+
+    detect_args = build_args(
+        args.series, args.slug, exclude=exclude, exit_zero=exit_zero
+    )
+    print("\n".join(detect_args))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/conformance/conformance/bootstrap/templates/run-conformance-detect-action.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/run-conformance-detect-action.yaml
@@ -84,8 +84,26 @@ runs:
           --with "atlan-application-sdk-conformance" \
           -- atlan-application-sdk-conformance detect "${detect_args[@]}"
 
-    - name: "Detect (from git ref)"
-      if: inputs.conformance-ref != ''
+    - name: "Detect (from git ref, isolated env)"
+      if: inputs.conformance-ref != '' && inputs.needs-env != 'true'
+      shell: bash
+      env:
+        SERIES: ${{ inputs.series }}
+        SLUG: ${{ inputs.slug }}
+        EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
+        EXIT_ZERO: ${{ inputs.exit-zero }}
+        CONFORMANCE_REF: ${{ inputs.conformance-ref }}
+      run: |
+        set -euo pipefail
+        raw=$(python "$GITHUB_ACTION_PATH/../../scripts/build_conformance_args.py" \
+          --series "$SERIES" --slug "$SLUG")
+        mapfile -t detect_args <<< "$raw"
+        uv run \
+          --with "atlan-application-sdk-conformance @ git+https://github.com/atlanhq/application-sdk@${CONFORMANCE_REF}#subdirectory=packages/conformance" \
+          -- atlan-application-sdk-conformance detect "${detect_args[@]}"
+
+    - name: "Detect (from git ref, resolved env)"
+      if: inputs.conformance-ref != '' && inputs.needs-env == 'true'
       shell: bash
       env:
         SERIES: ${{ inputs.series }}

--- a/packages/conformance/conformance/bootstrap/templates/run-conformance-detect-action.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/run-conformance-detect-action.yaml
@@ -1,0 +1,103 @@
+name: "Run conformance detect"
+description: >
+  Build the conformance detect arg list and invoke atlan-application-sdk-conformance
+  for one matrix leg. Handles all four invocation flavours — published package vs. git-ref,
+  isolated env vs. resolved env — via composite-action step conditions so the reusable
+  workflow needs only one uses: line per leg.
+
+  The arg-building script is read from $GITHUB_ACTION_PATH so it resolves to the SDK's
+  .github/scripts/ regardless of whether the caller is the SDK itself or a consumer app.
+
+inputs:
+  series:
+    description: "Conformance series letter(s), e.g. C or D"
+    required: true
+  slug:
+    description: "Series slug used for the SARIF output filename, e.g. ci or dependency"
+    required: true
+  exclude-paths:
+    description: "Comma-separated repo-root-relative path prefixes to exclude from scanning"
+    required: false
+    default: ""
+  exit-zero:
+    description: >
+      Exit 0 even when blocking violations are found (soft-enforce / observe mode).
+      The SARIF invocation.exitCode still records the real result.
+    required: false
+    default: "false"
+  conformance-ref:
+    description: >
+      Git ref (branch, tag, or SHA) for the conformance package.
+      Empty string (default) installs the latest published PyPI package via uvx.
+      Set to a SHA to test an unreleased suite change before it is published.
+    required: false
+    default: ""
+  needs-env:
+    description: >
+      When true, sync the caller's resolved environment before running detect.
+      Required for D-series (UnusedDependency maps declared deps to import names via
+      installed package metadata).
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Sync resolved env"
+      if: inputs.needs-env == 'true'
+      shell: bash
+      run: |
+        # D003 only needs the core [project.dependencies] importable, which a
+        # plain sync installs; avoid --all-extras/--all-groups so the leg does
+        # not pull heavier or private-index dev/optional deps it never inspects.
+        uv sync
+
+    - name: "Detect (published package, isolated env)"
+      if: inputs.conformance-ref == '' && inputs.needs-env != 'true'
+      shell: bash
+      env:
+        SERIES: ${{ inputs.series }}
+        SLUG: ${{ inputs.slug }}
+        EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
+        EXIT_ZERO: ${{ inputs.exit-zero }}
+      run: |
+        set -euo pipefail
+        raw=$(python "$GITHUB_ACTION_PATH/../../scripts/build_conformance_args.py" \
+          --series "$SERIES" --slug "$SLUG")
+        mapfile -t detect_args <<< "$raw"
+        uvx atlan-application-sdk-conformance detect "${detect_args[@]}"
+
+    - name: "Detect (published package, resolved env)"
+      if: inputs.conformance-ref == '' && inputs.needs-env == 'true'
+      shell: bash
+      env:
+        SERIES: ${{ inputs.series }}
+        SLUG: ${{ inputs.slug }}
+        EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
+        EXIT_ZERO: ${{ inputs.exit-zero }}
+      run: |
+        set -euo pipefail
+        raw=$(python "$GITHUB_ACTION_PATH/../../scripts/build_conformance_args.py" \
+          --series "$SERIES" --slug "$SLUG")
+        mapfile -t detect_args <<< "$raw"
+        uv run \
+          --with "atlan-application-sdk-conformance" \
+          -- atlan-application-sdk-conformance detect "${detect_args[@]}"
+
+    - name: "Detect (from git ref)"
+      if: inputs.conformance-ref != ''
+      shell: bash
+      env:
+        SERIES: ${{ inputs.series }}
+        SLUG: ${{ inputs.slug }}
+        EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
+        EXIT_ZERO: ${{ inputs.exit-zero }}
+        CONFORMANCE_REF: ${{ inputs.conformance-ref }}
+      run: |
+        set -euo pipefail
+        raw=$(python "$GITHUB_ACTION_PATH/../../scripts/build_conformance_args.py" \
+          --series "$SERIES" --slug "$SLUG")
+        mapfile -t detect_args <<< "$raw"
+        uv run \
+          --with "atlan-application-sdk-conformance @ git+https://github.com/atlanhq/application-sdk@${CONFORMANCE_REF}#subdirectory=packages/conformance" \
+          -- atlan-application-sdk-conformance detect "${detect_args[@]}"

--- a/packages/conformance/conformance/bootstrap/templates/run-conformance-detect-action.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/run-conformance-detect-action.yaml
@@ -116,6 +116,9 @@ runs:
         raw=$(python "$GITHUB_ACTION_PATH/../../scripts/build_conformance_args.py" \
           --series "$SERIES" --slug "$SLUG")
         mapfile -t detect_args <<< "$raw"
+        # uv run --with overlays this leg's ephemeral requirement onto the resolved
+        # env from the preceding sync step; needed so the suite's own D-series detect
+        # sees consumer deps.
         uv run \
           --with "atlan-application-sdk-conformance @ git+https://github.com/atlanhq/application-sdk@${CONFORMANCE_REF}#subdirectory=packages/conformance" \
           -- atlan-application-sdk-conformance detect "${detect_args[@]}"

--- a/packages/conformance/conformance/cli.py
+++ b/packages/conformance/conformance/cli.py
@@ -199,7 +199,11 @@ def _parse_bootstrap_args(argv: list[str]) -> dict[str, str]:
 
 def _cmd_bootstrap(argv: list[str]) -> int:
     """Write the SKILL.md shim and standard CI workflows into the current repo."""
-    from conformance.bootstrap.render import MANAGED_WORKFLOWS, render
+    from conformance.bootstrap.render import (
+        MANAGED_ACTION_FILES,
+        MANAGED_WORKFLOWS,
+        render,
+    )
 
     kwargs = _parse_bootstrap_args(argv)
     root = pathlib.Path.cwd()
@@ -234,6 +238,14 @@ def _cmd_bootstrap(argv: list[str]) -> int:
             render(name, **kwargs),
         )
 
+    # Non-workflow files referenced by conformance-reusable.yaml via a local
+    # `./...`-relative path, which GitHub resolves against the caller's
+    # checkout — every consumer repo needs its own copy or the C/D-series
+    # (and any other series whose paths filter matches) legs fail with
+    # "Can't find action.yml". Static, always-overwrite like MANAGED_WORKFLOWS.
+    for dest_rel, template_name in MANAGED_ACTION_FILES:
+        _bootstrap_file(root / dest_rel, render(template_name))
+
     # tests.yaml — write-if-absent scaffold; apps customise freely.
     # C002 tracks drift at WARN only.  Delete + re-run to force-regenerate.
     tests_dest = root / ".github" / "workflows" / "tests.yaml"
@@ -263,8 +275,7 @@ def _cmd_bootstrap(argv: list[str]) -> int:
                 bak = renovate_dest.with_suffix(".json.bak")
                 bak.write_text(existing, encoding="utf-8")
                 print(
-                    f"backed up: {bak}"
-                    "  (had custom content; review before committing)"
+                    f"backed up: {bak}  (had custom content; review before committing)"
                 )
             renovate_dest.write_text(target, encoding="utf-8")
             print(f"updated: {renovate_dest}")
@@ -323,7 +334,10 @@ commands:
                          --ledger-path PATH  repo-relative path to the ledger file
   remediate      Print programs path + version banner (SKILL.md drives execution)
   bootstrap      Write .claude/skills/remediate/SKILL.md + all standard CI workflow
-                 shims into .github/workflows/. The 14 managed shims always overwrite
+                 shims into .github/workflows/, plus the vendored
+                 .github/actions/run-conformance-detect/action.yaml and
+                 .github/scripts/build_conformance_args.py that conformance-reusable.yaml
+                 needs on disk in every caller repo. All of these always overwrite
                  (re-running eradicates drift). tests.yaml and renovate.json are
                  write-if-absent by default; pass --enforce to update them too.
                    --package-name NAME         docstring-coverage package (default: app)

--- a/packages/conformance/conformance/suite/checks/bootstrap_drift.py
+++ b/packages/conformance/conformance/suite/checks/bootstrap_drift.py
@@ -34,8 +34,11 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from conformance.bootstrap.render import MANAGED_WORKFLOWS, render
+from conformance.bootstrap.render import MANAGED_ACTION_FILES, MANAGED_WORKFLOWS, render
 from conformance.suite.schema.findings import Finding
+
+# Dest-path (repo-root-relative) -> template filename, for O(1) lookup in scan_path.
+_MANAGED_ACTION_FILES_BY_DEST = dict(MANAGED_ACTION_FILES)
 
 SERIES = "C"
 RULE_ID = "C002"
@@ -140,6 +143,8 @@ def discover(root: Path) -> list[Path]:
     """
     wf_dir = root / ".github" / "workflows"
     paths = [wf_dir / name for name in MANAGED_WORKFLOWS]
+    # Non-workflow vendored files (composite action + arg-building script).
+    paths.extend(root / dest_rel for dest_rel in _MANAGED_ACTION_FILES_BY_DEST)
     # Write-if-absent scaffolds (WARN-only drift tracking).
     paths.append(wf_dir / _TESTS_WORKFLOW)
     paths.append(root / _RENOVATE_JSON)
@@ -152,7 +157,55 @@ def scan_path(path: Path, root: Path) -> list[Finding]:
         return _scan_tests_yaml(path, root)
     if path.name == _RENOVATE_JSON:
         return _scan_renovate_json(path, root)
+    try:
+        rel = path.relative_to(root).as_posix()
+    except ValueError:
+        rel = None
+    if rel in _MANAGED_ACTION_FILES_BY_DEST:
+        return _scan_managed_action_file(path, root, _MANAGED_ACTION_FILES_BY_DEST[rel])
     return _scan_managed_shim(path, root)
+
+
+def _scan_managed_action_file(
+    path: Path, root: Path, template_name: str
+) -> list[Finding]:
+    """Scan one of the vendored non-workflow files (action.yaml / scripts)."""
+    try:
+        rel = path.relative_to(root).as_posix()
+    except ValueError:
+        rel = str(path)
+
+    if not path.exists():
+        return [
+            Finding(
+                rule_id=RULE_ID,
+                file=rel,
+                line=1,
+                column=1,
+                message=(
+                    f"Managed file '{rel}' is absent. Run `{_CLI_CMD}` to install it."
+                ),
+            )
+        ]
+
+    on_disk = path.read_text(encoding="utf-8")
+    canonical = render(template_name)
+
+    if _strip_action_pins(on_disk) == _strip_action_pins(canonical):
+        return []
+
+    return [
+        Finding(
+            rule_id=RULE_ID,
+            file=rel,
+            line=1,
+            column=1,
+            message=(
+                f"Managed file '{rel}' has drifted from the bootstrap canonical. "
+                f"Run `{_CLI_CMD}` to re-sync."
+            ),
+        )
+    ]
 
 
 def _scan_managed_shim(path: Path, root: Path) -> list[Finding]:

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import pathlib
 
 import pytest
-from conformance.bootstrap.render import MANAGED_WORKFLOWS, render
+from conformance.bootstrap.render import MANAGED_ACTION_FILES, MANAGED_WORKFLOWS, render
 from conformance.cli import (
     _bootstrap_file,
     _cmd_bootstrap,
@@ -144,6 +144,36 @@ def test_cmd_bootstrap_writes_all_managed_workflows(
         dest = wf_dir / name
         assert dest.exists(), f"Missing: {name}"
         assert dest.read_text() == render(name), f"Content mismatch: {name}"
+
+
+def test_cmd_bootstrap_writes_all_managed_action_files(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """conformance-reusable.yaml resolves `./...` paths against the caller's
+
+    checkout, so bootstrap must vendor the composite action + arg-building
+    script it needs into every consumer repo, not just .github/workflows/.
+    """
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    for dest_rel, template_name in MANAGED_ACTION_FILES:
+        dest = tmp_path / dest_rel
+        assert dest.exists(), f"Missing: {dest_rel}"
+        assert dest.read_text() == render(
+            template_name
+        ), f"Content mismatch: {dest_rel}"
+
+
+def test_cmd_bootstrap_managed_action_files_always_overwrite(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    dest_rel, template_name = MANAGED_ACTION_FILES[0]
+    dest = tmp_path / dest_rel
+    dest.write_text("corrupted content")
+    _cmd_bootstrap([])
+    assert dest.read_text() == render(template_name)
 
 
 def test_cmd_bootstrap_adds_remediation_to_gitignore(
@@ -824,6 +854,34 @@ def test_derive_no_affixes(tmp_path: pathlib.Path) -> None:
 def test_derive_hello_world(tmp_path: pathlib.Path) -> None:
     assert (
         _derive_app_name_from_dir(tmp_path / "atlan-hello-world-app") == "hello-world"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Vendored-template sync guard
+#
+# MANAGED_ACTION_FILES ships byte copies of files that also live in this
+# monorepo (used directly by application-sdk's own conformance-reusable.yaml
+# run, and vendored into every consumer repo by `bootstrap`). If the two
+# drift apart, the SDK's own CI would keep exercising the fixed version while
+# every bootstrapped consumer repo silently gets a stale one. Skipped when
+# the monorepo tree isn't checked out (e.g. an isolated sdist build).
+# ---------------------------------------------------------------------------
+
+_MONOREPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.parametrize("dest_rel,template_name", MANAGED_ACTION_FILES)
+def test_managed_action_template_matches_canonical_source(
+    dest_rel: str, template_name: str
+) -> None:
+    canonical = _MONOREPO_ROOT / dest_rel
+    if not canonical.exists():
+        pytest.skip(f"monorepo source not checked out: {canonical}")
+    assert render(template_name) == canonical.read_text(encoding="utf-8"), (
+        f"packages/conformance/conformance/bootstrap/templates/{template_name} has "
+        f"drifted from the canonical {dest_rel} — copy the canonical file's content "
+        "back into the template so consumer repos vendor the current version."
     )
 
 

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -164,12 +164,15 @@ def test_cmd_bootstrap_writes_all_managed_action_files(
         ), f"Content mismatch: {dest_rel}"
 
 
+@pytest.mark.parametrize("dest_rel,template_name", MANAGED_ACTION_FILES)
 def test_cmd_bootstrap_managed_action_files_always_overwrite(
-    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    dest_rel: str,
+    template_name: str,
 ) -> None:
     monkeypatch.chdir(tmp_path)
     _cmd_bootstrap([])
-    dest_rel, template_name = MANAGED_ACTION_FILES[0]
     dest = tmp_path / dest_rel
     dest.write_text("corrupted content")
     _cmd_bootstrap([])

--- a/packages/conformance/tests/test_bootstrap_drift.py
+++ b/packages/conformance/tests/test_bootstrap_drift.py
@@ -14,7 +14,7 @@ import pathlib
 import re
 
 import pytest
-from conformance.bootstrap.render import MANAGED_WORKFLOWS, render
+from conformance.bootstrap.render import MANAGED_ACTION_FILES, MANAGED_WORKFLOWS, render
 from conformance.cli import _cmd_bootstrap
 from conformance.suite.checks.bootstrap_drift import discover, scan_path
 from conformance.suite.rules import get_rule
@@ -64,17 +64,21 @@ def test_c002_is_autofixable() -> None:
 def test_discover_returns_all_managed_paths(tmp_path: pathlib.Path) -> None:
     paths = discover(tmp_path)
     names = {p.name for p in paths}
+    rels = {p.relative_to(tmp_path).as_posix() for p in paths}
     # Must include all managed shims plus the write-if-absent scaffolds.
     assert set(MANAGED_WORKFLOWS).issubset(names)
     assert "tests.yaml" in names
     assert "renovate.json" in names
+    # And the vendored non-workflow files (action.yaml + arg-building script).
+    for dest_rel, _template_name in MANAGED_ACTION_FILES:
+        assert dest_rel in rels
 
 
 def test_discover_returns_paths_even_when_absent(tmp_path: pathlib.Path) -> None:
     """discover() must not filter out non-existent files."""
     paths = discover(tmp_path)
-    # managed shims + tests.yaml + renovate.json scaffolds.
-    assert len(paths) == len(MANAGED_WORKFLOWS) + 2
+    # managed shims + managed action files + tests.yaml + renovate.json scaffolds.
+    assert len(paths) == len(MANAGED_WORKFLOWS) + len(MANAGED_ACTION_FILES) + 2
     # None of them exist yet.
     assert all(not p.exists() for p in paths)
 
@@ -122,6 +126,19 @@ def test_missing_workflow_finding_mentions_bootstrap_command(
     assert "bootstrap" in findings[0].message
 
 
+@pytest.mark.parametrize("dest_rel", [d for d, _ in MANAGED_ACTION_FILES])
+def test_missing_managed_action_file_produces_finding(
+    tmp_path: pathlib.Path, dest_rel: str
+) -> None:
+    # Don't bootstrap — the vendored action/script isn't on disk at all.
+    path = tmp_path / dest_rel
+    findings = scan_path(path, tmp_path)
+    assert len(findings) == 1
+    assert findings[0].rule_id == "C002"
+    assert "absent" in findings[0].message
+    assert dest_rel in findings[0].message
+
+
 # ---------------------------------------------------------------------------
 # Drifted file → finding
 # ---------------------------------------------------------------------------
@@ -143,6 +160,20 @@ def test_drifted_workflow_finding_names_the_file(tmp_path: pathlib.Path) -> None
     wf.write_text("completely wrong content")
     findings = scan_path(wf, tmp_path)
     assert "commits.yaml" in findings[0].message
+
+
+@pytest.mark.parametrize("dest_rel", [d for d, _ in MANAGED_ACTION_FILES])
+def test_drifted_managed_action_file_produces_finding(
+    tmp_path: pathlib.Path, dest_rel: str
+) -> None:
+    _bootstrap(tmp_path)
+    path = tmp_path / dest_rel
+    path.write_text("completely wrong content")
+    findings = scan_path(path, tmp_path)
+    assert len(findings) == 1
+    assert findings[0].rule_id == "C002"
+    assert "drifted" in findings[0].message
+    assert dest_rel in findings[0].message
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`conformance-reusable.yaml` invokes `uses: ./.github/actions/run-conformance-detect`, and that composite action reads its arg-building script via a `$GITHUB_ACTION_PATH`-relative path. Both are local-path references, which GitHub resolves against the **caller's** checkout, not application-sdk's. Every consumer app bootstrapped via `atlan-application-sdk-conformance bootstrap` was therefore missing both files, and hit `Can't find action.yml` the first time any matrix leg's changed-files filter actually matched (e.g. C-series on `.github/**`, D-series on `pyproject.toml`). Found this while bootstrapping conformance into `atlan-model-caster-app` — the `CI` and `Dependencies` legs failed immediately with that error even though the whole point was soft/observe mode (`exit-zero: true`); the job never got far enough to reach that setting.

- Add `MANAGED_ACTION_FILES` to `render.py`: `(dest path, template name)` pairs for the two vendored files, always-overwrite like `MANAGED_WORKFLOWS`.
- `bootstrap` now writes both into every consumer repo.
- C002 (`BootstrapWorkflowDrift`) tracks absence/drift on these files too.
- Added a test that keeps the vendored template bytes in sync with the SDK's own canonical `.github/actions/run-conformance-detect/action.yaml` and `.github/scripts/build_conformance_args.py`, so the two copies can't silently diverge again.
- Along the way: the vendored shell script's `<<<` bash here-string operator collided with the bootstrap templating engine's custom `<<` variable delimiter (Jinja matched the *second* `<` as the delimiter start and then failed deep in a later line). Fixed by having these two static, param-less files skip the jinja render step entirely rather than relying on "just don't define any `<< >>` vars" to dodge the collision.

## Test plan
- [x] `uv run pytest packages/conformance/tests/test_bootstrap.py packages/conformance/tests/test_bootstrap_drift.py` — 151 passed
- [x] `uv run pytest packages/conformance` (full suite) — no new failures (1 pre-existing, unrelated `test_age_days_computed` failure confirmed present on `main` too via `git stash`)
- [x] `ruff check` / `ruff format --check` / `pyright` on all touched files — clean
- [x] Manual smoke test: ran `atlan-application-sdk-conformance bootstrap --enforce false` in a scratch dir, confirmed both vendored files are written, byte-identical to the canonical monorepo copies, valid YAML / valid Python