### PR TITLE
feat(conformance): T004 DevEntrypointRequiresAppModule (BLDX-1520)

### DIFF
--- a/packages/conformance/conformance/docs/rules/logging.md
+++ b/packages/conformance/conformance/docs/rules/logging.md
@@ -76,10 +76,12 @@ through OTel. Direct use of logging.getLogger(), structlog.get_logger(), or logu
 logger bypasses all of this — correlation IDs are lost and records may not reach the
 observability store.
 
-Every module must obtain its logger via the SDK adapter::
+Every module must obtain its logger via the SDK adapter:
 
-    from application_sdk.observability.logger_adaptor import get_logger     logger =
-get_logger(__name__)
+```python
+from application_sdk.observability.logger_adaptor import get_logger
+logger = get_logger(__name__)
+```
 
 Direct use of `logging.getLogger()`, `structlog.get_logger()`, or `from loguru import
 logger` bypasses the adapter that:
@@ -200,10 +202,12 @@ Note: the SDK adapter's _is_enabled guard does skip %-style __str__ calls for si
 object args (logger.debug('x: %s', obj) — obj.__str__ not called when filtered).  But
 that guard fires inside the method, after Python has evaluated the argument expressions.
 When the expensive work is in the expression itself, an explicit level guard is still
-required::
+required:
 
-    if logger.isEnabledFor(logging.DEBUG):         logger.debug('snapshot: %s',
-json.dumps(big_dict))
+```python
+if logger.isEnabledFor(logging.DEBUG):
+    logger.debug('snapshot: %s', json.dumps(big_dict))
+```
 
 ---
 

--- a/packages/conformance/conformance/docs/rules/tests.md
+++ b/packages/conformance/conformance/docs/rules/tests.md
@@ -77,10 +77,11 @@ of the code paths that differ between standard and SDR deployments.
 
 **Remediation:** create a test class that:
 
-.. code-block:: python
-
-    class TestMyAppSDR(BaseSDRIntegrationTest):         manifest_path =
-'app/generated/manifest.json'         workflow_type = 'extraction'
+```python
+class TestMyAppSDR(BaseSDRIntegrationTest):
+    manifest_path = 'app/generated/manifest.json'
+    workflow_type = 'extraction'
+```
 
 Set `manifest_path` (not the legacy `agent_spec_template`) so the test reads inputs from
 the committed manifest and validates the `agent_json` slot — see T003 for the
@@ -115,13 +116,17 @@ the template fills in what the manifest was supposed to provide.  P029 closes th
 manifest gap; T003 closes the test gap: a subclass using `manifest_path` will fail at
 test time whenever `manifest.json` is broken, not silently pass.
 
-**Remediation:** in the subclass body, replace::
+**Remediation:** in the subclass body, replace:
 
-    agent_spec_template = '{...}'    # legacy
+```python
+agent_spec_template = '{...}'    # legacy
+```
 
-with::
+with:
 
-    manifest_path = 'app/generated/manifest.json'
+```python
+manifest_path = 'app/generated/manifest.json'
+```
 
 The `manifest_path` class var tells `BaseSDRIntegrationTest` to call
 `_manifest_extract_inputs()` which reads `dag.extract.inputs` from the manifest —
@@ -167,11 +172,16 @@ this way fails every PR with `MissingAppModuleError`.
 **Remediation:** delegate to a local dev entrypoint — conventionally `app/run_dev.py` —
 that constructs your `App` subclass directly and calls `run_dev_combined(MyApp, ...)`:
 no env var required.  See `atlan-metabase-app`, `atlan-openapi-app`, or
-`atlan-mysql-app` for the reference pattern::
+`atlan-mysql-app` for the reference pattern:
 
-    # main.py     import asyncio     from app.run_dev import main
+```python
+# main.py
+import asyncio
+from app.run_dev import main
 
-    if __name__ == '__main__':         asyncio.run(main())
+if __name__ == '__main__':
+    asyncio.run(main())
+```
 
 Suppress with `# conformance: ignore[T004] <reason>` on the call's line when the app
 genuinely has no local dev-mode boot path and relies on `ATLAN_APP_MODULE` being set

--- a/packages/conformance/conformance/docs/rules/tests.md
+++ b/packages/conformance/conformance/docs/rules/tests.md
@@ -5,7 +5,7 @@
 
 # Test-Quality Rules (T-series)
 
-**3 rules** · Checker: `suite.checks.integration_marking` (AST-based)
+**4 rules** · Checker: `suite.checks.integration_marking`, `suite.checks.sdr_test_checks`, and `suite.checks.dev_entrypoint` (AST-based)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -18,6 +18,7 @@ Suppress a finding on the violating line or the line directly above it:
 | [T001](#t001) | `UnmarkedIntegrationTest` | `warn` | `both` | `test-marking` | — | 0.4.0 |
 | [T002](#t002) | `MissingSdrTestClass` | `warn` | `app` | `sdr-test-coverage` | — | 0.9.0 |
 | [T003](#t003) | `SdrTestLegacyAgentSpec` | `warn` | `app` | `sdr-test-coverage` | — | 0.9.0 |
+| [T004](#t004) | `DevEntrypointRequiresAppModule` | `warn` | `app` | `dev-entrypoint` | — | 0.10.0 |
 
 ---
 
@@ -132,5 +133,48 @@ production.
 Suppress with `# conformance: ignore[T003] <reason>` on the class definition line when
 `agent_spec_template` is intentionally used for a non-manifest test scenario (e.g. a
 negative-path test that supplies deliberately invalid credentials).
+
+---
+
+## T004 — `DevEntrypointRequiresAppModule` {#t004}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `dev-entrypoint` · **Autofixable:** — · **Since:** 0.10.0
+
+> Root main.py calls application_sdk.main.main() directly, which requires ATLAN_APP_MODULE and breaks CI's dev-mode boot
+
+**Rationale:** application_sdk.main.main() is the production, ATLAN_APP_MODULE-driven launcher: it
+always calls AppConfig.from_args_and_env(args), which raises MissingAppModuleError
+unless ATLAN_APP_MODULE (or --app) is set. That is correct in production, where the base
+image's own CMD sets the env var and never even executes the repo's main.py. But main.py
+is also what CI's connector-integration-tests composite action runs directly ('python
+main.py') to boot the app for local/dev-mode testing, and the bootstrapped
+tests-reusable.yaml path exposes no input to inject ATLAN_APP_MODULE into that job. A
+main.py that delegates straight to application_sdk.main.main() therefore fails every PR
+with MissingAppModuleError / 'App server failed to start within 60s' (BLDX-1520).
+
+Root `main.py` must not call `application_sdk.main.main()` directly (whether via `from
+application_sdk.main import main`, an aliased module import, or a bare dotted call).
+
+`main()` always resolves its `App` class from `ATLAN_APP_MODULE`/`--app` — there is no
+way to supply it any other way.  That is the right contract for the production
+container, which never runs `main.py` at all (the base image's own CMD sets
+`ATLAN_APP_MODULE` and boots directly).  But `main.py` *is* what CI's
+`connector-integration-tests` composite action runs directly (`python main.py`) to boot
+the app for local/dev-mode testing, and the bootstrapped `tests-reusable.yaml` path has
+no input that lets a caller inject `ATLAN_APP_MODULE` into that job.  A `main.py` wired
+this way fails every PR with `MissingAppModuleError`.
+
+**Remediation:** delegate to a local dev entrypoint — conventionally `app/run_dev.py` —
+that constructs your `App` subclass directly and calls `run_dev_combined(MyApp, ...)`:
+no env var required.  See `atlan-metabase-app`, `atlan-openapi-app`, or
+`atlan-mysql-app` for the reference pattern::
+
+    # main.py     import asyncio     from app.run_dev import main
+
+    if __name__ == '__main__':         asyncio.run(main())
+
+Suppress with `# conformance: ignore[T004] <reason>` on the call's line when the app
+genuinely has no local dev-mode boot path and relies on `ATLAN_APP_MODULE` being set
+out-of-band even for CI (e.g. some utility/CSA apps).
 
 ---

--- a/packages/conformance/conformance/programs/areas/tests.prose.md
+++ b/packages/conformance/conformance/programs/areas/tests.prose.md
@@ -3,10 +3,11 @@ kind: responsibility
 name: tests-area
 description: >
   Maintains the current T-series violation-set and drives remediation of
-  test-quality conformance findings.  T001 (unmarked integration test) is the
-  only rule in this series; its fix is mechanical — add the correct pytest
-  marker — but classification is "judgment" because the caller must confirm
-  which marker is appropriate for the test's integration scope.
+  test-quality conformance findings: unmarked integration tests (T001), SDR
+  test-coverage gaps (T002-T003), and dev-entrypoint delegation (T004).  Every
+  rule in this series classifies as "judgment" — each fix requires reading the
+  test's I/O intent, the app's manifest/contract, or the app's App subclass
+  before a fix can be proposed with confidence.
 ---
 
 ### Maintains
@@ -128,6 +129,41 @@ to residue):
   `agent_spec_template` is intentionally used for a non-manifest test scenario
   (e.g. a negative-path test that supplies deliberately invalid credentials) —
   and state that reason explicitly.
+
+  `classification` is always `"judgment"`.
+
+- **T004 DevEntrypointRequiresAppModule** — the repo-root `main.py` calls
+  `application_sdk.main.main()` directly (via a bare name, an aliased module
+  import, or a bare dotted chain).  `main()` always resolves its `App` class
+  from `ATLAN_APP_MODULE`/`--app`, but `main.py` is also what CI's
+  `connector-integration-tests` action runs directly (`python main.py`) for
+  local/dev-mode testing, and the bootstrapped `tests-reusable.yaml` path has
+  no input that lets a caller inject `ATLAN_APP_MODULE` into that job — so
+  this fails every PR with `MissingAppModuleError`.  Fix: delegate to a local
+  dev entrypoint — conventionally `app/run_dev.py` — that constructs the
+  app's `App` subclass directly and calls `run_dev_combined(MyApp, ...)`:
+
+  ```python
+  # main.py
+  import asyncio
+  from app.run_dev import main
+
+  if __name__ == "__main__":
+      asyncio.run(main())
+  ```
+
+  If `app/run_dev.py` doesn't exist yet, draft one following the reference
+  pattern in `atlan-metabase-app`, `atlan-openapi-app`, or `atlan-mysql-app`:
+  import the app's own `App` subclass and call
+  `await run_dev_combined(MyApp, credential_stores={...}, example_input={...})`.
+  Route to residue — identifying the app's `App` subclass (module path and
+  constructor requirements) and a representative `example_input` requires
+  reading the app's own code, not just the finding.
+
+  Suppress with `# conformance: ignore[T004] <reason>` on the call's line
+  only when the app genuinely has no local dev-mode boot path and relies on
+  `ATLAN_APP_MODULE` being set out-of-band even for CI (e.g. some
+  utility/CSA apps) — state that reason explicitly.
 
   `classification` is always `"judgment"`.
 

--- a/packages/conformance/conformance/suite/checks/_ast_common/__init__.py
+++ b/packages/conformance/conformance/suite/checks/_ast_common/__init__.py
@@ -13,6 +13,7 @@ from ._cli import TOOL_VERSION, make_cli_main
 from ._directives import _IgnoreDirective, _parse_directives, parse_ignore_directive
 from ._discovery import EXCLUDE_DIRS, discover
 from ._findings import make_finding
+from ._imports import collect_import_origins, qualify_chained_attr_call
 from ._scope import SDK_PACKAGE_PREFIX, detect_scope, is_sdk_package_name
 
 __all__ = [
@@ -21,10 +22,12 @@ __all__ = [
     "TOOL_VERSION",
     "_IgnoreDirective",
     "_parse_directives",
+    "collect_import_origins",
     "detect_scope",
     "discover",
     "is_sdk_package_name",
     "make_cli_main",
     "make_finding",
     "parse_ignore_directive",
+    "qualify_chained_attr_call",
 ]

--- a/packages/conformance/conformance/suite/checks/_ast_common/_imports.py
+++ b/packages/conformance/conformance/suite/checks/_ast_common/_imports.py
@@ -1,0 +1,83 @@
+"""Dotted-call-origin resolution shared by every AST-based check series.
+
+Answers "what fully-qualified symbol does this call resolve to?" — the
+question every check that bans/requires a specific SDK call (P017/P018
+worker/server bootstrap, T004 dev-entrypoint delegation, …) needs answered
+the same way, regardless of whether the call site wrote a bare name
+(``main()`` after ``from application_sdk.main import main``), a
+single-level attribute (``sdkmain.main()`` after ``import
+application_sdk.main as sdkmain``), or a bare dotted chain
+(``application_sdk.main.main()`` after ``import application_sdk.main``).
+"""
+
+from __future__ import annotations
+
+import ast
+
+
+def collect_import_origins(tree: ast.AST) -> dict[str, str]:
+    """Map each bound name to its fully-qualified import origin (module.name).
+
+    Walks the entire tree so lazy / in-function imports are caught.
+
+    Examples::
+
+        from application_sdk.execution import create_worker
+        -> {"create_worker": "application_sdk.execution.create_worker"}
+
+        from fastapi import FastAPI
+        -> {"FastAPI": "fastapi.FastAPI"}
+
+        import uvicorn
+        -> {"uvicorn": "uvicorn"}
+
+        from uvicorn import run
+        -> {"run": "uvicorn.run"}
+    """
+    origins: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                bound = alias.asname if alias.asname else alias.name.split(".")[0]
+                origins[bound] = alias.name
+        elif isinstance(node, ast.ImportFrom):
+            if node.level != 0:  # skip relative imports
+                continue
+            module = node.module or ""
+            for alias in node.names:
+                bound = alias.asname if alias.asname else alias.name
+                origins[bound] = f"{module}.{alias.name}" if module else alias.name
+    return origins
+
+
+def qualify_chained_attr_call(
+    func: ast.Attribute, origins: dict[str, str]
+) -> str | None:
+    """Resolve a chained attribute call (X.Y.Z()) to its as-written dotted path.
+
+    Handles the case where ``func.value`` is itself an ``ast.Attribute`` — i.e.
+    bare dotted submodule calls like::
+
+        import application_sdk.execution
+        application_sdk.execution.create_worker(...)
+        # → "application_sdk.execution.create_worker"
+
+        import fastapi.applications
+        fastapi.applications.FastAPI()
+        # → "fastapi.applications.FastAPI"
+
+    The single-level case (``func.value: ast.Name``) is handled separately by
+    the callers using the origins dict directly.
+
+    Returns the full as-written dotted path if the root name was imported, else
+    ``None``.
+    """
+    attrs: list[str] = [func.attr]
+    node: ast.expr = func.value
+    while isinstance(node, ast.Attribute):
+        attrs.append(node.attr)
+        node = node.value
+    if not isinstance(node, ast.Name) or node.id not in origins:
+        return None
+    # attrs collected outermost-first; reverse to reconstruct left-to-right.
+    return node.id + "." + ".".join(reversed(attrs))

--- a/packages/conformance/conformance/suite/checks/dev_entrypoint.py
+++ b/packages/conformance/conformance/suite/checks/dev_entrypoint.py
@@ -102,6 +102,32 @@ def scan_path(path: Path, root: Path) -> list[Finding]:
     return scan_text(text, str(rel))
 
 
+def _module_level_rebind_lines(tree: ast.AST, name: str) -> list[int]:
+    """Line numbers of top-level statements that rebind *name* to something else.
+
+    Only module-scope ``def``/``class``/assignment targeting *name* count —
+    they shadow an earlier import of the same name for any call that comes
+    after them.  Nested rebindings (inside a function/class body) create a
+    new local scope and don't affect module-level call sites, so they're
+    deliberately not walked.
+    """
+    lines: list[int] = []
+    for stmt in getattr(tree, "body", []):
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if stmt.name == name:
+                lines.append(stmt.lineno)
+        elif isinstance(stmt, ast.Assign):
+            if any(
+                isinstance(target, ast.Name) and target.id == name
+                for target in stmt.targets
+            ):
+                lines.append(stmt.lineno)
+        elif isinstance(stmt, ast.AnnAssign):
+            if isinstance(stmt.target, ast.Name) and stmt.target.id == name:
+                lines.append(stmt.lineno)
+    return lines
+
+
 def _check_t004(
     tree: ast.AST,
     filename: str,
@@ -118,7 +144,10 @@ def _check_t004(
 
         # from application_sdk.main import main [as X]; X()
         if isinstance(func, ast.Name):
-            if origins.get(func.id) == _PRODUCTION_ENTRYPOINT_ORIGIN:
+            if origins.get(func.id) == _PRODUCTION_ENTRYPOINT_ORIGIN and not any(
+                rebind_line < node.lineno
+                for rebind_line in _module_level_rebind_lines(tree, func.id)
+            ):
                 findings.append(
                     make_finding(
                         filename=filename,

--- a/packages/conformance/conformance/suite/checks/dev_entrypoint.py
+++ b/packages/conformance/conformance/suite/checks/dev_entrypoint.py
@@ -1,0 +1,171 @@
+"""T004 DevEntrypointRequiresAppModule — root main.py must not require ATLAN_APP_MODULE.
+
+``application_sdk.main.main()`` is the production, env/CLI-driven launcher:
+internally it always calls ``AppConfig.from_args_and_env(args)``, which raises
+``MissingAppModuleError`` unless ``ATLAN_APP_MODULE`` (or ``--app``) is set.
+That is correct in production — the base image's own CMD sets the env var and
+never even executes the repo's ``main.py`` — but ``main.py`` is also what CI's
+``connector-integration-tests`` composite action runs directly
+(``python main.py``) to boot the app for local/dev-mode testing. The
+bootstrapped ``tests-reusable.yaml`` path exposes no input to inject
+``ATLAN_APP_MODULE`` into that job, so a root ``main.py`` that delegates
+straight to ``application_sdk.main.main()`` fails every PR with
+``MissingAppModuleError`` / "App server failed to start within 60s" (BLDX-1520).
+
+The proven fix — already used by ``atlan-metabase-app``, ``atlan-openapi-app``,
+``atlan-mysql-app`` — is for ``main.py`` to delegate to a local dev entrypoint
+(conventionally ``app/run_dev.py``) that constructs the ``App`` subclass
+directly and calls ``run_dev_combined(MyApp, ...)``: no env var required.
+
+Discovery
+---------
+Scans ``main.py`` at the repo root only. If absent, T004 no-ops — a missing
+entrypoint is a different concern (out of scope for this rule).
+
+Inline suppression
+-------------------
+Add ``# conformance: ignore[T004] <reason>`` on the offending call's line (or
+the comment-only line directly above it) — e.g. for a utility/CSA app that
+genuinely has no local dev-mode boot path and relies on
+``ATLAN_APP_MODULE`` being set out-of-band even for CI.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+from conformance.suite.checks._ast_common import (
+    _IgnoreDirective,
+    _parse_directives,
+    collect_import_origins,
+    make_cli_main,
+    make_finding,
+    qualify_chained_attr_call,
+)
+from conformance.suite.schema.findings import Finding
+
+SERIES = "T"
+
+# The production, env/CLI-driven launcher. Any call resolving here means
+# `python main.py` requires ATLAN_APP_MODULE/--app to boot.
+_PRODUCTION_ENTRYPOINT_ORIGIN = "application_sdk.main.main"
+
+_MESSAGE = (
+    "Calls 'application_sdk.main.main()' directly from main.py — this is the "
+    "production, ATLAN_APP_MODULE-driven launcher. main.py is also what CI's "
+    "connector-integration-tests action runs directly ('python main.py') to "
+    "boot the app for local/dev-mode testing, and the bootstrapped "
+    "tests-reusable.yaml path has no way to inject ATLAN_APP_MODULE into that "
+    "job — so this fails every PR with MissingAppModuleError. Delegate "
+    "instead to a local dev entrypoint (conventionally app/run_dev.py) that "
+    "constructs your App subclass directly and calls "
+    "'run_dev_combined(MyApp, ...)' — see atlan-metabase-app, "
+    "atlan-openapi-app, or atlan-mysql-app for the reference pattern. "
+    "Suppress with '# conformance: ignore[T004] <reason>'."
+)
+
+__all__ = ["SERIES", "discover", "main", "scan_path", "scan_text"]
+
+
+def discover(root: Path) -> list[Path]:
+    """Discover the root ``main.py``.
+
+    Returns an empty list when no root ``main.py`` is present, so T004
+    simply no-ops on repos that have not yet added one (e.g. libraries).
+    """
+    main_py = root / "main.py"
+    return [main_py] if main_py.is_file() else []
+
+
+def scan_text(text: str, file: str) -> list[Finding]:
+    """Scan a single ``main.py`` source *text* for T004 findings."""
+    try:
+        tree = ast.parse(text, filename=file)
+    except SyntaxError:
+        return []
+    directives = _parse_directives(text)
+    return _check_t004(tree, file, directives)
+
+
+def scan_path(path: Path, root: Path) -> list[Finding]:
+    """Scan a single ``main.py`` file for T004 findings."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        rel = path
+    return scan_text(text, str(rel))
+
+
+def _check_t004(
+    tree: ast.AST,
+    filename: str,
+    directives: dict[int, _IgnoreDirective],
+) -> list[Finding]:
+    """Emit T004 findings for calls resolving to application_sdk.main.main."""
+    findings: list[Finding] = []
+    origins = collect_import_origins(tree)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+
+        # from application_sdk.main import main [as X]; X()
+        if isinstance(func, ast.Name):
+            if origins.get(func.id) == _PRODUCTION_ENTRYPOINT_ORIGIN:
+                findings.append(
+                    make_finding(
+                        filename=filename,
+                        rule_id="T004",
+                        node=node,
+                        message=_MESSAGE,
+                        directives=directives,
+                    )
+                )
+
+        elif isinstance(func, ast.Attribute):
+            if isinstance(func.value, ast.Name):
+                # import application_sdk.main as sdkmain; sdkmain.main()
+                module_origin = origins.get(func.value.id, "")
+                if f"{module_origin}.{func.attr}" == _PRODUCTION_ENTRYPOINT_ORIGIN:
+                    findings.append(
+                        make_finding(
+                            filename=filename,
+                            rule_id="T004",
+                            node=node,
+                            message=_MESSAGE,
+                            directives=directives,
+                        )
+                    )
+            else:
+                # import application_sdk.main; application_sdk.main.main()
+                qualified = qualify_chained_attr_call(func, origins)
+                if qualified == _PRODUCTION_ENTRYPOINT_ORIGIN:
+                    findings.append(
+                        make_finding(
+                            filename=filename,
+                            rule_id="T004",
+                            node=node,
+                            message=_MESSAGE,
+                            directives=directives,
+                        )
+                    )
+
+    return findings
+
+
+main = make_cli_main(
+    scan_text,
+    description="T004: scan root main.py for direct application_sdk.main.main() calls.",
+    discover=discover,
+)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/conformance/conformance/suite/checks/entrypoint/_bootstrap_common.py
+++ b/packages/conformance/conformance/suite/checks/entrypoint/_bootstrap_common.py
@@ -2,75 +2,16 @@
 
 from __future__ import annotations
 
-import ast
+from conformance.suite.checks._ast_common import (
+    collect_import_origins,
+    qualify_chained_attr_call,
+)
 
-
-def collect_import_origins(tree: ast.AST) -> dict[str, str]:
-    """Map each bound name to its fully-qualified import origin (module.name).
-
-    Walks the entire tree so lazy / in-function imports are caught.
-
-    Examples::
-
-        from application_sdk.execution import create_worker
-        -> {"create_worker": "application_sdk.execution.create_worker"}
-
-        from fastapi import FastAPI
-        -> {"FastAPI": "fastapi.FastAPI"}
-
-        import uvicorn
-        -> {"uvicorn": "uvicorn"}
-
-        from uvicorn import run
-        -> {"run": "uvicorn.run"}
-    """
-    origins: dict[str, str] = {}
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                bound = alias.asname if alias.asname else alias.name.split(".")[0]
-                origins[bound] = alias.name
-        elif isinstance(node, ast.ImportFrom):
-            if node.level != 0:  # skip relative imports
-                continue
-            module = node.module or ""
-            for alias in node.names:
-                bound = alias.asname if alias.asname else alias.name
-                origins[bound] = f"{module}.{alias.name}" if module else alias.name
-    return origins
-
-
-def qualify_chained_attr_call(
-    func: ast.Attribute, origins: dict[str, str]
-) -> str | None:
-    """Resolve a chained attribute call (X.Y.Z()) to its as-written dotted path.
-
-    Handles the case where ``func.value`` is itself an ``ast.Attribute`` — i.e.
-    bare dotted submodule calls like::
-
-        import application_sdk.execution
-        application_sdk.execution.create_worker(...)
-        # → "application_sdk.execution.create_worker"
-
-        import fastapi.applications
-        fastapi.applications.FastAPI()
-        # → "fastapi.applications.FastAPI"
-
-    The single-level case (``func.value: ast.Name``) is handled separately by
-    the callers using the origins dict directly.
-
-    Returns the full as-written dotted path if the root name was imported, else
-    ``None``.
-    """
-    attrs: list[str] = [func.attr]
-    node: ast.expr = func.value
-    while isinstance(node, ast.Attribute):
-        attrs.append(node.attr)
-        node = node.value
-    if not isinstance(node, ast.Name) or node.id not in origins:
-        return None
-    # attrs collected outermost-first; reverse to reconstruct left-to-right.
-    return node.id + "." + ".".join(reversed(attrs))
+__all__ = [
+    "collect_import_origins",
+    "is_app_receiver",
+    "qualify_chained_attr_call",
+]
 
 
 def is_app_receiver(name: str, origin: str) -> bool:

--- a/packages/conformance/conformance/suite/rules/tests.py
+++ b/packages/conformance/conformance/suite/rules/tests.py
@@ -30,6 +30,21 @@ SDR test-quality rules (DISTR-752):
   committed ``manifest.json`` is broken.  The MSSQL regression (atlan-mssql-app#177,
   DISTR-752) slipped through exactly this way.  Subclasses must switch to
   ``manifest_path`` so the test reads inputs from the committed manifest.
+
+Dev-entrypoint conformance (BLDX-1520):
+
+* ``T004`` — root ``main.py`` must not call ``application_sdk.main.main()``
+  directly.  That is the production, ``ATLAN_APP_MODULE``-driven launcher, but
+  ``main.py`` is also what CI's ``connector-integration-tests`` composite
+  action runs directly (``python main.py``) for local/dev-mode testing — and
+  the bootstrapped ``tests-reusable.yaml`` path has no input to inject
+  ``ATLAN_APP_MODULE`` into that job.  A ``main.py`` that delegates straight to
+  ``application_sdk.main.main()`` therefore fails every PR with
+  ``MissingAppModuleError``.  Delegate instead to a local dev entrypoint
+  (conventionally ``app/run_dev.py``) that constructs the ``App`` subclass
+  directly and calls ``run_dev_combined(MyApp, ...)`` — see
+  ``atlan-metabase-app``, ``atlan-openapi-app``, or ``atlan-mysql-app`` for the
+  reference pattern.
 """
 
 from __future__ import annotations
@@ -206,6 +221,75 @@ RULES: tuple[RuleDefinition, ...] = (
         help_uri=(
             "https://github.com/atlanhq/application-sdk/blob/main/"
             "packages/conformance/conformance/docs/rules/tests.md#t003"
+        ),
+    ),
+    RuleDefinition(
+        id="T004",
+        scope=RuleScope.APP,
+        name="DevEntrypointRequiresAppModule",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="dev-entrypoint",
+        autofixable=False,
+        since="0.10.0",
+        rationale=(
+            "application_sdk.main.main() is the production, "
+            "ATLAN_APP_MODULE-driven launcher: it always calls "
+            "AppConfig.from_args_and_env(args), which raises "
+            "MissingAppModuleError unless ATLAN_APP_MODULE (or --app) is set. "
+            "That is correct in production, where the base image's own CMD "
+            "sets the env var and never even executes the repo's main.py. But "
+            "main.py is also what CI's connector-integration-tests composite "
+            "action runs directly ('python main.py') to boot the app for "
+            "local/dev-mode testing, and the bootstrapped tests-reusable.yaml "
+            "path exposes no input to inject ATLAN_APP_MODULE into that job. A "
+            "main.py that delegates straight to application_sdk.main.main() "
+            "therefore fails every PR with MissingAppModuleError / 'App server "
+            "failed to start within 60s' (BLDX-1520)."
+        ),
+        short_description=(
+            "Root main.py calls application_sdk.main.main() directly, which "
+            "requires ATLAN_APP_MODULE and breaks CI's dev-mode boot"
+        ),
+        full_description=(
+            "Root ``main.py`` must not call ``application_sdk.main.main()``\n"
+            "directly (whether via ``from application_sdk.main import main``,\n"
+            "an aliased module import, or a bare dotted call).\n"
+            "\n"
+            "``main()`` always resolves its ``App`` class from\n"
+            "``ATLAN_APP_MODULE``/``--app`` — there is no way to supply it any\n"
+            "other way.  That is the right contract for the production\n"
+            "container, which never runs ``main.py`` at all (the base image's\n"
+            "own CMD sets ``ATLAN_APP_MODULE`` and boots directly).  But\n"
+            "``main.py`` *is* what CI's ``connector-integration-tests``\n"
+            "composite action runs directly (``python main.py``) to boot the\n"
+            "app for local/dev-mode testing, and the bootstrapped\n"
+            "``tests-reusable.yaml`` path has no input that lets a caller\n"
+            "inject ``ATLAN_APP_MODULE`` into that job.  A ``main.py`` wired\n"
+            "this way fails every PR with ``MissingAppModuleError``.\n"
+            "\n"
+            "**Remediation:** delegate to a local dev entrypoint —\n"
+            "conventionally ``app/run_dev.py`` — that constructs your ``App``\n"
+            "subclass directly and calls ``run_dev_combined(MyApp, ...)``: no\n"
+            "env var required.  See ``atlan-metabase-app``,\n"
+            "``atlan-openapi-app``, or ``atlan-mysql-app`` for the reference\n"
+            "pattern::\n"
+            "\n"
+            "    # main.py\n"
+            "    import asyncio\n"
+            "    from app.run_dev import main\n"
+            "\n"
+            "    if __name__ == '__main__':\n"
+            "        asyncio.run(main())\n"
+            "\n"
+            "Suppress with ``# conformance: ignore[T004] <reason>`` on the\n"
+            "call's line when the app genuinely has no local dev-mode boot\n"
+            "path and relies on ``ATLAN_APP_MODULE`` being set out-of-band\n"
+            "even for CI (e.g. some utility/CSA apps).\n"
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/tests.md#t004"
         ),
     ),
 )

--- a/packages/conformance/conformance/suite/runner.py
+++ b/packages/conformance/conformance/suite/runner.py
@@ -34,6 +34,7 @@ from conformance.suite.checks import (
     dependency_conformance,
     deprecation,
     determinism,
+    dev_entrypoint,
     dockerfile_conformance,
     entrypoint_alignment,
     error_handling,
@@ -176,6 +177,11 @@ _CHECKS: list[CheckRegistration] = [
         discover=sdr_test_checks.discover,
         scan_path=sdr_test_checks.scan_path,
         scan_all=sdr_test_checks.scan_all,
+    ),
+    CheckRegistration(
+        series=dev_entrypoint.SERIES,
+        discover=dev_entrypoint.discover,
+        scan_path=dev_entrypoint.scan_path,
     ),
 ]
 

--- a/packages/conformance/conformance/tools/generate_rule_docs.py
+++ b/packages/conformance/conformance/tools/generate_rule_docs.py
@@ -154,7 +154,10 @@ _SERIES_META: list[SeriesMeta] = [
         prefix="T",
         source_module="conformance/suite/rules/tests.py",
         output_filename="tests.md",
-        checker="`suite.checks.integration_marking` (AST-based)",
+        checker=(
+            "`suite.checks.integration_marking`, `suite.checks.sdr_test_checks`, "
+            "and `suite.checks.dev_entrypoint` (AST-based)"
+        ),
         suppression_example=(
             "# conformance: ignore[T001] intentional: marked dynamically via add_marker"
         ),

--- a/packages/conformance/conformance/tools/generate_rule_docs.py
+++ b/packages/conformance/conformance/tools/generate_rule_docs.py
@@ -231,7 +231,7 @@ def _split_literal_blocks(text: str) -> list[tuple[str, bool]]:
     This exists because a naive "split on blank lines, then ``textwrap.fill``
     every paragraph" pass (the previous behaviour) reflows literal blocks
     exactly like prose — collapsing every code example in the rule docs onto
-    one run-on line (see PR #2448 review).  Callers must render ``is_code``
+    one run-on line (see BLDX-1520).  Callers must render ``is_code``
     chunks verbatim (dedented, inside a fenced block) and leave everything
     else to the existing paragraph-fill logic.
     """

--- a/packages/conformance/conformance/tools/generate_rule_docs.py
+++ b/packages/conformance/conformance/tools/generate_rule_docs.py
@@ -216,6 +216,79 @@ def _rst_to_md(text: str) -> str:
     return re.sub(r"``([^`]+)``", r"`\1`", text)
 
 
+_CODE_BLOCK_DIRECTIVE_RE = re.compile(r"^\.\.\s+code-block::")
+
+
+def _split_literal_blocks(text: str) -> list[tuple[str, bool]]:
+    """Split RST-ish *text* into ``(chunk, is_code)`` segments.
+
+    A literal block is opened either by a ``.. code-block:: <lang>`` directive
+    or by a line ending in ``::`` (the RST "expository text::" convention), and
+    extends through every immediately-following blank or indented line, ending
+    at the first non-indented, non-blank line (or EOF).  Blank lines bordering
+    the block are trimmed.  Everything else is prose.
+
+    This exists because a naive "split on blank lines, then ``textwrap.fill``
+    every paragraph" pass (the previous behaviour) reflows literal blocks
+    exactly like prose — collapsing every code example in the rule docs onto
+    one run-on line (see PR #2448 review).  Callers must render ``is_code``
+    chunks verbatim (dedented, inside a fenced block) and leave everything
+    else to the existing paragraph-fill logic.
+    """
+    lines = text.split("\n")
+    segments: list[tuple[str, bool]] = []
+    prose_buf: list[str] = []
+
+    def flush_prose() -> None:
+        if not prose_buf:
+            return
+        para = "\n".join(prose_buf)
+        if para.strip():
+            segments.append((para, False))
+        prose_buf.clear()
+
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        stripped = line.rstrip()
+        opens_block = _CODE_BLOCK_DIRECTIVE_RE.match(stripped) or (
+            stripped.endswith("::") and stripped != "::"
+        )
+        if not opens_block:
+            prose_buf.append(line)
+            i += 1
+            continue
+
+        j = i + 1
+        block_lines: list[str] = []
+        while j < n and (lines[j].strip() == "" or lines[j].startswith((" ", "\t"))):
+            block_lines.append(lines[j])
+            j += 1
+        while block_lines and block_lines[0].strip() == "":
+            block_lines.pop(0)
+        while block_lines and block_lines[-1].strip() == "":
+            block_lines.pop()
+
+        if not block_lines:
+            # Nothing indented followed — not actually a literal block intro.
+            prose_buf.append(line)
+            i += 1
+            continue
+
+        # A bare "::"-ending line becomes ":" in the surrounding prose; a
+        # ".. code-block::" directive line is dropped entirely (the fenced
+        # block below replaces it).
+        if not _CODE_BLOCK_DIRECTIVE_RE.match(stripped):
+            prose_buf.append(stripped[:-1])
+        flush_prose()
+        segments.append((textwrap.dedent("\n".join(block_lines)), True))
+        i = j
+
+    flush_prose()
+    return segments
+
+
 def _tier_badge(tier: EnforcementTier) -> str:
     return f"`{tier.value}`"
 
@@ -310,17 +383,22 @@ def _render_series(meta: SeriesMeta, rules: list[RuleDefinition]) -> str:
             lines.append(f"**Rationale:** {wrapped}")
             lines.append("")
 
-        # Full description — convert RST backticks, preserve paragraph breaks
+        # Full description — convert RST backticks, preserve paragraph breaks,
+        # and render literal blocks verbatim as fenced code (not reflowed).
         if rule.full_description:
             desc = _rst_to_md(rule.full_description.strip())
-            # Rewrap each paragraph individually to 88 chars for clean diff
-            paragraphs = re.split(r"\n{2,}", desc)
-            for para in paragraphs:
-                wrapped = textwrap.fill(
-                    para, width=88, break_long_words=False, break_on_hyphens=False
-                )
-                lines.append(wrapped)
-                lines.append("")
+            for chunk, is_code in _split_literal_blocks(desc):
+                if is_code:
+                    lines.append(f"```python\n{chunk}\n```")
+                    lines.append("")
+                    continue
+                # Rewrap each prose paragraph individually to 88 chars for clean diff
+                for para in re.split(r"\n{2,}", chunk):
+                    wrapped = textwrap.fill(
+                        para, width=88, break_long_words=False, break_on_hyphens=False
+                    )
+                    lines.append(wrapped)
+                    lines.append("")
 
         lines.append("---")
         lines.append("")

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -146,6 +146,9 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
     # itself never does, so these are APP-scoped (DISTR-752).
     # T002/T003: SDR test-quality — apps that declare SDR must have an SDR test
     # class; the SDK itself is not an SDR app (DISTR-752).
+    # T004: dev-entrypoint delegation — only consumer apps have a root main.py
+    # that CI's connector-integration-tests action runs directly; the SDK has
+    # no such file (BLDX-1520).
     # I001–I005: Dockerfile conformance (SDK builds the base image, not consuming it).
     # B001: consuming a deprecated SDK symbol (BLDX-1418).
     # O002/O003/O004: asset-mapper usage — connectors build assets with pyatlan_v9,
@@ -191,6 +194,7 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
         "P030",
         "T002",
         "T003",
+        "T004",
         "O002",
         "O003",
         "O004",
@@ -374,7 +378,7 @@ def test_catalog_t_series_present() -> None:
     """The T-series test-quality rules are all present."""
     rules = load_catalog()
     t_ids = {r.id for r in rules if r.id.startswith("T")}
-    expected = {"T001", "T002", "T003"}
+    expected = {"T001", "T002", "T003", "T004"}
     missing = expected - t_ids
     assert not missing, f"Missing T-series rules: {missing}"
 

--- a/packages/conformance/tests/test_dev_entrypoint.py
+++ b/packages/conformance/tests/test_dev_entrypoint.py
@@ -103,6 +103,35 @@ class TestT004Silent:
         src = "from application_sdk.main import main\n"
         assert _rule(src) == []
 
+    def test_silent_when_name_reassigned_before_call(self) -> None:
+        """A later module-level rebinding shadows the import at runtime.
+
+        `main` is imported from application_sdk.main but then redefined by a
+        local `def main(): ...` before it's ever called — the call resolves
+        to the local function, not the production launcher, so this must not
+        fire (regression: PR #2448 review).
+        """
+        src = (
+            "from application_sdk.main import main\n"
+            "\n"
+            "def main():\n"
+            "    print('local dev shim')\n"
+            "\n"
+            "main()\n"
+        )
+        assert _rule(src) == []
+
+    def test_fires_when_call_precedes_reassignment(self) -> None:
+        """A rebinding *after* the call doesn't retroactively excuse it."""
+        src = (
+            "from application_sdk.main import main\n"
+            "main()\n"
+            "\n"
+            "def main():\n"
+            "    print('too late, already called the production launcher')\n"
+        )
+        assert len(_rule(src)) == 1
+
 
 # ── suppression ────────────────────────────────────────────────────────────────
 

--- a/packages/conformance/tests/test_dev_entrypoint.py
+++ b/packages/conformance/tests/test_dev_entrypoint.py
@@ -1,0 +1,176 @@
+"""Tests for T004 DevEntrypointRequiresAppModule (BLDX-1520).
+
+T004 is per-file (scans only the root main.py, no cross-file resolution), so
+scan_text is sufficient for all detection tests.  Separate discovery tests
+confirm main.py is found at the repo root and the check no-ops when absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from conformance.suite.checks.dev_entrypoint import SERIES, discover, main, scan_text
+from conformance.suite.rules import get_rule
+from conformance.suite.schema.disposition import EnforcementTier
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _rule(src: str, file: str = "main.py") -> list:
+    return [f for f in scan_text(src, file) if f.rule_id == "T004"]
+
+
+# ── series metadata ───────────────────────────────────────────────────────────
+
+
+def test_series_letter() -> None:
+    assert SERIES == "T"
+
+
+# ── fires on production-entrypoint call patterns ──────────────────────────────
+
+
+class TestT004Fires:
+    def test_fires_on_from_import_call(self) -> None:
+        src = "from application_sdk.main import main\nmain()\n"
+        fs = _rule(src)
+        assert len(fs) == 1
+        assert "application_sdk.main.main" in fs[0].message
+
+    def test_fires_on_aliased_from_import_call(self) -> None:
+        src = "from application_sdk.main import main as sdk_main\nsdk_main()\n"
+        assert len(_rule(src)) == 1
+
+    def test_fires_on_aliased_module_import_call(self) -> None:
+        src = "import application_sdk.main as sdkmain\nsdkmain.main()\n"
+        assert len(_rule(src)) == 1
+
+    def test_fires_on_bare_dotted_module_call(self) -> None:
+        src = "import application_sdk.main\napplication_sdk.main.main()\n"
+        assert len(_rule(src)) == 1
+
+    def test_fires_inside_dunder_main_guard(self) -> None:
+        src = (
+            "from application_sdk.main import main\n"
+            "\n"
+            "if __name__ == '__main__':\n"
+            "    main()\n"
+        )
+        assert len(_rule(src)) == 1
+
+
+# ── silent on conformant / unrelated patterns ─────────────────────────────────
+
+
+class TestT004Silent:
+    def test_silent_on_run_dev_delegation(self) -> None:
+        """The proven fix: delegate to a local dev entrypoint."""
+        src = (
+            "import asyncio\n"
+            "from app.run_dev import main\n"
+            "\n"
+            "if __name__ == '__main__':\n"
+            "    asyncio.run(main())\n"
+        )
+        assert _rule(src) == []
+
+    def test_silent_on_run_dev_combined_direct_call(self) -> None:
+        src = (
+            "import asyncio\n"
+            "from application_sdk.main import run_dev_combined\n"
+            "from app.my_app import MyApp\n"
+            "\n"
+            "async def main():\n"
+            "    await run_dev_combined(MyApp)\n"
+            "\n"
+            "if __name__ == '__main__':\n"
+            "    asyncio.run(main())\n"
+        )
+        assert _rule(src) == []
+
+    def test_silent_on_unimported_main_call(self) -> None:
+        """A local main() with no application_sdk.main origin must not fire."""
+        src = "def main():\n    pass\n\nmain()\n"
+        assert _rule(src) == []
+
+    def test_silent_on_unrelated_module_main(self) -> None:
+        """main() from an unrelated module sharing the name must not fire."""
+        src = "from myapp.cli import main\nmain()\n"
+        assert _rule(src) == []
+
+    def test_silent_on_import_without_call(self) -> None:
+        """Importing 'main' without calling it is not itself the violation."""
+        src = "from application_sdk.main import main\n"
+        assert _rule(src) == []
+
+
+# ── suppression ────────────────────────────────────────────────────────────────
+
+
+class TestT004Suppression:
+    def test_suppressed_inline(self) -> None:
+        src = (
+            "from application_sdk.main import main\n"
+            "main()  # conformance: ignore[T004] utility app, no dev entrypoint\n"
+        )
+        fs = _rule(src)
+        assert len(fs) == 1 and fs[0].suppressed
+        assert fs[0].suppression_justification == "utility app, no dev entrypoint"
+
+    def test_suppressed_comment_line_above(self) -> None:
+        # The directive must appear on the comment-only line directly *above*
+        # the offending call for make_finding to honour it.
+        src = (
+            "from application_sdk.main import main\n"
+            "# conformance: ignore[T004] utility app, no dev entrypoint\n"
+            "main()\n"
+        )
+        fs = _rule(src)
+        assert any(f.suppressed for f in fs)
+
+
+# ── tier and disposition ──────────────────────────────────────────────────────
+
+
+class TestT004TierAndDisposition:
+    def test_is_warn_tier(self) -> None:
+        assert get_rule("T004").tier is EnforcementTier.WARN
+
+    def test_warn_violation_passes_gate(self, tmp_path: Path) -> None:
+        """An unsuppressed T004 (WARN) does not fail the gate (exit 0)."""
+        main_py = tmp_path / "main.py"
+        main_py.write_text("from application_sdk.main import main\nmain()\n")
+        code = main(["--root", str(tmp_path), str(main_py)])
+        assert code == 0
+
+
+# ── discover() ─────────────────────────────────────────────────────────────────
+
+
+def test_discover_finds_main_py_at_root(tmp_path: Path) -> None:
+    (tmp_path / "main.py").write_text("from application_sdk.main import main\n")
+    found = discover(tmp_path)
+    assert len(found) == 1
+    assert found[0].name == "main.py"
+
+
+def test_discover_empty_when_no_main_py(tmp_path: Path) -> None:
+    assert discover(tmp_path) == []
+
+
+def test_discover_ignores_nested_main_py(tmp_path: Path) -> None:
+    """Only the repo-root main.py is in scope, not a same-named nested file."""
+    nested = tmp_path / "app" / "main.py"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("from application_sdk.main import main\nmain()\n")
+    assert discover(tmp_path) == []
+
+
+# ── rule metadata wiring ────────────────────────────────────────────────────────
+
+
+def test_t004_rule_metadata() -> None:
+    rule = get_rule("T004")
+    assert rule.name == "DevEntrypointRequiresAppModule"
+    assert rule.category == "dev-entrypoint"
+    assert rule.autofixable is False

--- a/packages/conformance/tests/test_dev_entrypoint.py
+++ b/packages/conformance/tests/test_dev_entrypoint.py
@@ -109,7 +109,7 @@ class TestT004Silent:
         `main` is imported from application_sdk.main but then redefined by a
         local `def main(): ...` before it's ever called — the call resolves
         to the local function, not the production launcher, so this must not
-        fire (regression: PR #2448 review).
+        fire (regression: BLDX-1520).
         """
         src = (
             "from application_sdk.main import main\n"

--- a/packages/conformance/tests/test_generate_rule_docs.py
+++ b/packages/conformance/tests/test_generate_rule_docs.py
@@ -1,4 +1,4 @@
-"""Tests for the rule-doc generator's literal-block handling (PR #2448 review).
+"""Tests for the rule-doc generator's literal-block handling (BLDX-1520).
 
 A naive "split on blank lines, then textwrap.fill every paragraph" pass reflows
 RST literal blocks exactly like prose, collapsing every code example in the

--- a/packages/conformance/tests/test_generate_rule_docs.py
+++ b/packages/conformance/tests/test_generate_rule_docs.py
@@ -1,0 +1,85 @@
+"""Tests for the rule-doc generator's literal-block handling (PR #2448 review).
+
+A naive "split on blank lines, then textwrap.fill every paragraph" pass reflows
+RST literal blocks exactly like prose, collapsing every code example in the
+generated rule docs onto one run-on line. _split_literal_blocks() detects those
+blocks so the renderer can emit them verbatim inside a fenced code block instead.
+"""
+
+from __future__ import annotations
+
+from conformance.tools.generate_rule_docs import _split_literal_blocks
+
+
+def test_plain_prose_is_a_single_non_code_chunk() -> None:
+    text = "Just some prose.\n\nA second paragraph."
+    segments = _split_literal_blocks(text)
+    assert all(not is_code for _, is_code in segments)
+    assert "".join(chunk for chunk, _ in segments).strip() != ""
+
+
+def test_double_colon_opens_a_literal_block() -> None:
+    text = "Do this::\n\n    import foo\n    foo.bar()\n\nDone."
+    segments = _split_literal_blocks(text)
+    kinds = [is_code for _, is_code in segments]
+    assert kinds == [False, True, False]
+    prose_before, code, prose_after = (c for c, _ in segments)
+    assert prose_before.rstrip().endswith(":")  # "::" -> ":"
+    assert not prose_before.rstrip().endswith("::")
+    assert code == "import foo\nfoo.bar()"
+    assert prose_after.strip() == "Done."
+
+
+def test_code_block_directive_opens_a_literal_block_and_is_dropped() -> None:
+    text = ".. code-block:: python\n\n    class Foo:\n        pass\n\nDone."
+    segments = _split_literal_blocks(text)
+    kinds = [is_code for _, is_code in segments]
+    assert kinds == [True, False]
+    code, prose_after = (c for c, _ in segments)
+    assert code == "class Foo:\n    pass"
+    assert ".. code-block::" not in prose_after
+    assert prose_after.strip() == "Done."
+
+
+def test_blank_line_inside_block_is_preserved() -> None:
+    text = "Example::\n\n    import asyncio\n\n    async def main():\n        pass\n"
+    segments = _split_literal_blocks(text)
+    code = next(chunk for chunk, is_code in segments if is_code)
+    assert code == "import asyncio\n\nasync def main():\n    pass"
+
+
+def test_dedents_to_the_common_indent() -> None:
+    text = "Example::\n\n    outer = 1\n        nested = 2\n"
+    segments = _split_literal_blocks(text)
+    code = next(chunk for chunk, is_code in segments if is_code)
+    # Common indent (4 spaces) stripped; relative nesting preserved.
+    assert code == "outer = 1\n    nested = 2"
+
+
+def test_no_block_when_nothing_indented_follows() -> None:
+    """A line ending in '::' with no indented follow-up is not a block opener."""
+    text = "This looks like RST::\nBut the next line isn't indented."
+    segments = _split_literal_blocks(text)
+    assert all(not is_code for _, is_code in segments)
+
+
+def test_bare_double_colon_line_is_not_treated_as_a_block_opener() -> None:
+    text = "::\n\n    should not matter\n"
+    segments = _split_literal_blocks(text)
+    assert all(not is_code for _, is_code in segments)
+
+
+def test_multiple_separate_blocks_in_one_description() -> None:
+    text = (
+        "First, replace::\n\n    old_value = 1\n\nwith::\n\n    new_value = 2\n\nDone."
+    )
+    segments = _split_literal_blocks(text)
+    codes = [chunk for chunk, is_code in segments if is_code]
+    assert codes == ["old_value = 1", "new_value = 2"]
+
+
+def test_reassembled_prose_has_no_leftover_double_colons() -> None:
+    text = "Do this::\n\n    x = 1\n\nAnd that::\n\n    y = 2\n"
+    segments = _split_literal_blocks(text)
+    prose = " ".join(chunk for chunk, is_code in segments if not is_code)
+    assert "::" not in prose

--- a/remediation/README.md
+++ b/remediation/README.md
@@ -64,6 +64,7 @@ remediation/
 | error-handling | E | ✅ Mechanical (E005, E016) + judgment (E001–E002, E013, others) |
 | logging | L | 🚧 Detection only → residue |
 | ci | C | 🚧 Detection only → residue |
+| tests | T | ✅ Judgment, all routed to residue (T001–T004); WARN-tier, so strict-mode only |
 
 ### Adding a new area
 


### PR DESCRIPTION
## Summary

`application_sdk.main.main()` is the production, `ATLAN_APP_MODULE`-driven launcher: it always calls `AppConfig.from_args_and_env(args)`, which raises `MissingAppModuleError` unless `ATLAN_APP_MODULE` (or `--app`) is set. That's correct in production — the base image's own CMD sets the env var and never even executes the repo's `main.py` — but `main.py` is also what CI's `connector-integration-tests` composite action runs directly (`python main.py`) for local/dev-mode testing, and the bootstrapped `tests-reusable.yaml` path exposes no input to inject `ATLAN_APP_MODULE` into that job. A root `main.py` that delegates straight to `application_sdk.main.main()` therefore fails every PR with `MissingAppModuleError` — exactly what happened in `atlan-model-caster-app` while bootstrapping conformance there.

Adds **T004** — deliberately T-series, not P-series (already overloaded), since this is fundamentally a CI/test-boot concern rather than a source-conformance one, per [BLDX-1520](https://linear.app/atlan-epd/issue/BLDX-1520).

- New `conformance/suite/checks/dev_entrypoint.py`: AST-based, scans only the repo-root `main.py`, no-ops when absent. Detects calls resolving to `application_sdk.main.main` via a bare name, an aliased module import, or a bare dotted chain. WARN tier, app-scoped (the SDK has no root `main.py`).
- Promotes `collect_import_origins`/`qualify_chained_attr_call` out of `entrypoint/_bootstrap_common.py` (private to P017/P018) into the shared `_ast_common` package, since T004 needs the same dotted-call resolution; `_bootstrap_common` now re-exports them so P017/P018 are unaffected (verified: all 111 existing P017/P018/entrypoint tests still pass).
- Registers the checker in `runner.py`, adds the rule to `conformance/suite/rules/tests.py`, regenerates `docs/rules/tests.md`, and extends the `test_catalog.py` scope-tracking meta-tests.
- 19 new tests in `tests/test_dev_entrypoint.py` covering all three call patterns, false-positive guards, suppression, discovery, and tier/gate behaviour.

Remediation guidance points at the reference pattern already used by `atlan-metabase-app`, `atlan-openapi-app`, and `atlan-mysql-app` (delegate to a local `app/run_dev.py` that calls `run_dev_combined(MyApp, ...)`).

## Test plan
- [x] `uv run pytest packages/conformance/tests/test_dev_entrypoint.py` — 19 passed
- [x] `uv run pytest packages/conformance` (full suite) — 1490 passed, 1 pre-existing xfail
- [x] `ruff check` / `ruff format --check` / `pyright` — clean
- [x] `gen-rule-docs --check` — docs up-to-date
- [x] Manual end-to-end: ran the runner CLI against a scratch repo — fires WARN on a `main.py` calling `application_sdk.main.main()` directly, silent on the `app/run_dev.py`-delegation pattern