### PR TITLE
feat(conformance): schedule force-refresh runs of the conformance suite

### DIFF
--- a/packages/conformance/conformance/bootstrap/templates/conformance.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/conformance.yaml
@@ -5,6 +5,17 @@ on:
   merge_group: {}
   push:
     branches: [main]
+  # Force-refresh: re-run the full suite against the latest published rules
+  # every 6h, independent of whether Renovate's conformance-package lock bump
+  # has been merged. Timed 30 min ahead of connector-pulse's fleet ingest
+  # (refresh-conformance-dashboard.yml polls k.atlan.dev at :47 past every
+  # 6th hour UTC) so this run, plus the dashboard publish it triggers, land
+  # before that pull.
+  schedule:
+    - cron: "17 */6 * * *"
+  # Lets a human force an out-of-band refresh right after a conformance
+  # release lands, without waiting for the next cron tick.
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -15,4 +26,9 @@ jobs:
     uses: atlanhq/application-sdk/.github/workflows/conformance-reusable.yaml@main
     with:
       event_name: ${{ github.event_name }}
-      exit-zero: << exit_zero >>
+      # Scheduled/manual force-refresh runs have no PR base to diff against
+      # and nothing to block — always run every series, and never fail the
+      # run itself. The SARIF still records the real result, so the
+      # dashboard/Security tab reflect the true drift.
+      force-all: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+      exit-zero: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || << exit_zero >> }}

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -257,46 +257,67 @@ def test_parse_bootstrap_args_enforce_invalid(
     assert "--enforce" in capsys.readouterr().err
 
 
+_EXIT_ZERO_SCHEDULE_PREFIX = (
+    "exit-zero: ${{ github.event_name == 'schedule' "
+    "|| github.event_name == 'workflow_dispatch' || "
+)
+_EXIT_ZERO_HARD = _EXIT_ZERO_SCHEDULE_PREFIX + "false }}"
+_EXIT_ZERO_SOFT = _EXIT_ZERO_SCHEDULE_PREFIX + "true }}"
+_FORCE_ALL_SCHEDULE = (
+    "force-all: ${{ github.event_name == 'schedule' "
+    "|| github.event_name == 'workflow_dispatch' }}"
+)
+_SCHEDULE_CRON = '- cron: "17 */6 * * *"'
+
+
 def test_conformance_yaml_default_exit_zero_false() -> None:
-    """Default bootstrap renders the hard-gate tail (schedule/dispatch still exit-zero)."""
+    """Default bootstrap renders the full hard-gate expression (schedule/dispatch still exit-zero)."""
     content = render("conformance.yaml")
-    assert "workflow_dispatch' || false }}" in content
+    assert _EXIT_ZERO_HARD in content
 
 
 def test_conformance_yaml_exit_zero_true() -> None:
-    """render() with exit_zero='true' renders the soft-mode tail."""
+    """render() with exit_zero='true' renders the full soft-mode expression."""
     content = render("conformance.yaml", exit_zero="true")
-    assert "workflow_dispatch' || true }}" in content
+    assert _EXIT_ZERO_SOFT in content
 
 
 def test_cmd_bootstrap_enforce_false_writes_soft_mode(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """--enforce false writes the soft-mode tail into conformance.yaml."""
+    """--enforce false writes the full soft-mode expression into conformance.yaml."""
     monkeypatch.chdir(tmp_path)
     _cmd_bootstrap(["--enforce", "false"])
     conformance = (tmp_path / ".github" / "workflows" / "conformance.yaml").read_text()
-    assert "workflow_dispatch' || true }}" in conformance
+    assert _EXIT_ZERO_SOFT in conformance
 
 
 def test_cmd_bootstrap_enforce_true_writes_hard_mode(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """--enforce true writes the hard-gate tail into conformance.yaml."""
+    """--enforce true writes the full hard-gate expression into conformance.yaml."""
     monkeypatch.chdir(tmp_path)
     _cmd_bootstrap(["--enforce", "true"])
     conformance = (tmp_path / ".github" / "workflows" / "conformance.yaml").read_text()
-    assert "workflow_dispatch' || false }}" in conformance
+    assert _EXIT_ZERO_HARD in conformance
 
 
 def test_cmd_bootstrap_no_enforce_defaults_hard_mode(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Without --enforce, bootstrap defaults to the hard-gate tail."""
+    """Without --enforce, bootstrap defaults to the full hard-gate expression."""
     monkeypatch.chdir(tmp_path)
     _cmd_bootstrap([])
     conformance = (tmp_path / ".github" / "workflows" / "conformance.yaml").read_text()
-    assert "workflow_dispatch' || false }}" in conformance
+    assert _EXIT_ZERO_HARD in conformance
+
+
+def test_conformance_yaml_schedule_force_refresh_trigger() -> None:
+    """Bootstrap wires the force-refresh schedule/dispatch trigger and force-all override."""
+    content = render("conformance.yaml")
+    assert _SCHEDULE_CRON in content
+    assert "workflow_dispatch: {}" in content
+    assert _FORCE_ALL_SCHEDULE in content
 
 
 def test_conformance_workflow_contains_event_name() -> None:

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -267,7 +267,7 @@ _FORCE_ALL_SCHEDULE = (
     "force-all: ${{ github.event_name == 'schedule' "
     "|| github.event_name == 'workflow_dispatch' }}"
 )
-_SCHEDULE_CRON = '- cron: "17 */6 * * *"'
+_SCHEDULE_BLOCK = 'schedule:\n    - cron: "17 */6 * * *"'
 
 
 def test_conformance_yaml_default_exit_zero_false() -> None:
@@ -315,7 +315,7 @@ def test_cmd_bootstrap_no_enforce_defaults_hard_mode(
 def test_conformance_yaml_schedule_force_refresh_trigger() -> None:
     """Bootstrap wires the force-refresh schedule/dispatch trigger and force-all override."""
     content = render("conformance.yaml")
-    assert _SCHEDULE_CRON in content
+    assert _SCHEDULE_BLOCK in content
     assert "workflow_dispatch: {}" in content
     assert _FORCE_ALL_SCHEDULE in content
 

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -258,45 +258,45 @@ def test_parse_bootstrap_args_enforce_invalid(
 
 
 def test_conformance_yaml_default_exit_zero_false() -> None:
-    """Default bootstrap renders exit-zero: false (hard gate)."""
+    """Default bootstrap renders the hard-gate tail (schedule/dispatch still exit-zero)."""
     content = render("conformance.yaml")
-    assert "exit-zero: false" in content
+    assert "workflow_dispatch' || false }}" in content
 
 
 def test_conformance_yaml_exit_zero_true() -> None:
-    """render() with exit_zero='true' renders exit-zero: true for soft mode."""
+    """render() with exit_zero='true' renders the soft-mode tail."""
     content = render("conformance.yaml", exit_zero="true")
-    assert "exit-zero: true" in content
+    assert "workflow_dispatch' || true }}" in content
 
 
 def test_cmd_bootstrap_enforce_false_writes_soft_mode(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """--enforce false writes exit-zero: true into conformance.yaml."""
+    """--enforce false writes the soft-mode tail into conformance.yaml."""
     monkeypatch.chdir(tmp_path)
     _cmd_bootstrap(["--enforce", "false"])
     conformance = (tmp_path / ".github" / "workflows" / "conformance.yaml").read_text()
-    assert "exit-zero: true" in conformance
+    assert "workflow_dispatch' || true }}" in conformance
 
 
 def test_cmd_bootstrap_enforce_true_writes_hard_mode(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """--enforce true writes exit-zero: false into conformance.yaml."""
+    """--enforce true writes the hard-gate tail into conformance.yaml."""
     monkeypatch.chdir(tmp_path)
     _cmd_bootstrap(["--enforce", "true"])
     conformance = (tmp_path / ".github" / "workflows" / "conformance.yaml").read_text()
-    assert "exit-zero: false" in conformance
+    assert "workflow_dispatch' || false }}" in conformance
 
 
 def test_cmd_bootstrap_no_enforce_defaults_hard_mode(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Without --enforce, bootstrap defaults to hard mode (exit-zero: false)."""
+    """Without --enforce, bootstrap defaults to the hard-gate tail."""
     monkeypatch.chdir(tmp_path)
     _cmd_bootstrap([])
     conformance = (tmp_path / ".github" / "workflows" / "conformance.yaml").read_text()
-    assert "exit-zero: false" in conformance
+    assert "workflow_dispatch' || false }}" in conformance
 
 
 def test_conformance_workflow_contains_event_name() -> None:


### PR DESCRIPTION
## Summary
- Adds `schedule` (`17 */6 * * *`, 30 min ahead of connector-pulse's fleet-dashboard ingest at :47 past every 6th hour UTC) and `workflow_dispatch` triggers to the bootstrapped `conformance.yaml`, so every app re-runs the full conformance suite against the latest published rules on a fixed cadence — independent of whether its Renovate conformance-package lock bump has actually been merged.
- Scheduled/manual runs set `force-all: true` (no PR base to diff against, so every series must run unconditionally) and `exit-zero: true` (nothing to block; the SARIF still records the true result so the dashboard reflects real drift), regardless of the app's own hard/soft gate mode.
- Updates `test_bootstrap.py` assertions to match the new `exit-zero` expression.

## Test plan
- [x] `uv run pre-commit run --all-files` — clean
- [x] `uv run python -m pytest tests/unit -x -q` — 5307 passed
- [x] `uv run pytest packages/conformance/tests/` — 1510 passed
- [x] Rendered `conformance.yaml` template manually verified to be valid YAML
- [ ] Once merged and a conformance release goes out, confirm C002 flags drifted apps and that a bootstrapped app's scheduled run lands in the connector-pulse dashboard within the 30-min buffer