### PR TITLE
feat(execution): add infra-failure diagnosis scaffold

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -1869,8 +1869,8 @@ def _create_task_activity_wrapper(
         from application_sdk.execution._temporal.activities import (  # noqa: PLC0415 — circular: execution/__init__.py loads _temporal which imports app.base
             TaskContext,
         )
-        from application_sdk.execution._temporal.eviction_retry import (  # noqa: PLC0415 — circular: execution/__init__.py loads _temporal which imports app.base
-            execute_activity_with_eviction_retry,
+        from application_sdk.execution._temporal.infra_diagnosis import (  # noqa: PLC0415 — circular: execution/__init__.py loads _temporal which imports app.base
+            execute_activity_with_infra_diagnosis,
         )
 
     # Build the Temporal RetryPolicy once (not per invocation)
@@ -1905,12 +1905,14 @@ def _create_task_activity_wrapper(
         # Extract summary from input for Temporal UI display
         summary = input_data.summary() if hasattr(input_data, "summary") else None
 
-        # Execute as activity, routed through the SDK eviction-retry loop so
-        # worker pod evictions (SIGTERM mid-activity) re-dispatch as fresh
-        # attempts without burning the application-error retry budget.
-        # When a pool_queue is set the activity is dispatched to the task
-        # queue for that pool; otherwise it runs on the workflow's own queue.
-        result: Output = await execute_activity_with_eviction_retry(
+        # Execute as activity, routed through the SDK eviction-retry loop (so
+        # worker pod evictions re-dispatch without burning the retry budget)
+        # and the infra-diagnosis wrapper (so an abrupt kill surfacing as a
+        # heartbeat timeout gets its cause recorded). Both are inert unless
+        # their respective paths trigger. When a pool_queue is set the activity
+        # is dispatched to that pool's task queue (ADR-0016); otherwise it runs
+        # on the workflow's own queue.
+        result: Output = await execute_activity_with_infra_diagnosis(
             f"{app_name}:{task_name}",
             args=[task_context, input_data],
             start_to_close_timeout=timedelta(seconds=timeout_seconds),

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -311,6 +311,27 @@ def _load_worker_eviction_max_retries() -> int:
 
 WORKER_EVICTION_MAX_RETRIES = _load_worker_eviction_max_retries()
 
+
+#: Feature flag: on a heartbeat timeout (the signature of an abrupt kill —
+#: spot reclaim, OOMKill, node loss), diagnose the cause via the infra-event
+#: service and record it on the workflow. Default OFF: the infra-event service
+#: is a separate build, and until it ships this must stay disabled. When off,
+#: activity execution is byte-for-byte identical to today. See
+#: docs/infra-failure-diagnosis.md.
+ENABLE_INFRA_FAILURE_DIAGNOSIS = (
+    os.getenv("ATLAN_ENABLE_INFRA_FAILURE_DIAGNOSIS", "false").lower() == "true"
+)
+
+#: Base URL of the infra-event service queried by the diagnose_infra_failure
+#: activity. Empty disables the HTTP client (diagnosis records NONE).
+INFRA_EVENT_SERVICE_URL = os.getenv("ATLAN_INFRA_EVENT_SERVICE_URL", "")
+
+#: Start-to-close timeout for the (short, one-HTTP-call) diagnose_infra_failure
+#: activity.
+INFRA_DIAGNOSIS_TIMEOUT_SECONDS = int(
+    os.getenv("ATLAN_INFRA_DIAGNOSIS_TIMEOUT_SECONDS", 30)
+)
+
 # SQL Client Constants
 #: Whether to use server-side cursors for SQL operations
 USE_SERVER_SIDE_CURSOR = bool(os.getenv("ATLAN_SQL_USE_SERVER_SIDE_CURSOR", "true"))

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -194,6 +194,15 @@ def create_activity_from_task(
         )
         app_instance._task_context = task_exec_context
 
+        # Seed pod/node identity into the heartbeat so an abrupt kill (spot
+        # reclaim / OOM) can be attributed after the fact via its last
+        # heartbeat details. No-op unless infra diagnosis is enabled.
+        from application_sdk.execution._temporal.infra_diagnosis import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
+            seed_activity_identity,
+        )
+
+        seed_activity_identity(heartbeat_controller)
+
         stop_event = asyncio.Event()
         heartbeat_task = None
 

--- a/application_sdk/execution/_temporal/infra_diagnosis.py
+++ b/application_sdk/execution/_temporal/infra_diagnosis.py
@@ -1,0 +1,359 @@
+"""Attribution of abrupt worker deaths (spot reclaim / OOM / node loss).
+
+When an activity dies *without* reporting ``WorkerEvicted`` — the signature of a
+kill the worker could not survive (spot reclaim, OOMKill, node loss) — Temporal
+fails the attempt with a **heartbeat timeout**. Unlike a graceful eviction (see
+``eviction_retry.py``), nothing in-process ran to say why. This module turns
+that silent timeout into a recorded cause:
+
+  1. the workflow decodes *where* the activity was running (worker identity +
+     last heartbeat details — both survive the kill),
+  2. runs the :func:`diagnose_infra_failure` activity, which asks the
+     infra-event service what happened to that pod/node,
+  3. maps the verdict onto the SDK failure taxonomy (:mod:`application_sdk.errors`)
+     and records it (Temporal search attribute + structured log), then re-raises
+     the original failure unchanged.
+
+**Phase 1 is attribution only.** Behaviour is unchanged: the activity still
+fails, the workflow still sees the same error. Recording the cause does *not*
+stop spot/OOM from consuming ``max_attempts`` — only rerouting the retry to a
+different task queue does, and that (Phase 2) is gated on a second, on-demand
+worker pool that does not exist yet. See ``docs/infra-failure-diagnosis.md``.
+
+**Determinism.** Everything that runs in workflow context — the predicates,
+:func:`classify_infra_failure`, :func:`workflow.upsert_search_attributes` — is
+pure and replay-safe. All I/O (the service call) lives in the
+:func:`diagnose_infra_failure` *activity*. The correlation time window comes
+from heartbeat details, never a wall clock.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+from temporalio import activity, workflow
+from temporalio.common import SearchAttributeKey
+from temporalio.exceptions import ActivityError
+from temporalio.exceptions import TimeoutError as TemporalTimeoutError
+from temporalio.exceptions import TimeoutType
+
+from application_sdk.execution._temporal.eviction_retry import (
+    execute_activity_with_eviction_retry,
+)
+from application_sdk.execution._temporal.infra_event_client import (
+    ActivityLocation,
+    InfraVerdict,
+    get_infra_event_client,
+)
+from application_sdk.observability.logger_adaptor import get_logger
+
+logger = get_logger(__name__)
+
+#: Temporal wire name of the diagnosis activity. Must be registered on the
+#: worker (see docs → "Wiring").
+DIAGNOSE_ACTIVITY_NAME = "sdk:diagnose_infra_failure"
+
+#: Keyword search attribute recording the diagnosed cause on the workflow.
+#: MUST be registered on the namespace as a Keyword attribute before use
+#: (``tctl admin cluster add-search-attributes`` / operator API).
+INFRA_FAILURE_CAUSE_ATTR = "infra_failure_cause"
+_INFRA_CAUSE_KEY = SearchAttributeKey.for_keyword(INFRA_FAILURE_CAUSE_ATTR)
+
+
+# ---------------------------------------------------------------------------
+# workflow-side: detection
+# ---------------------------------------------------------------------------
+
+
+def _is_heartbeat_timeout(err: ActivityError) -> bool:
+    """True iff this ``ActivityError`` was caused by a *heartbeat* timeout.
+
+    A heartbeat timeout with no preceding ``WorkerEvicted`` is the signature of
+    an abrupt kill (spot reclaim, OOMKill, node loss): the worker died before it
+    could report anything. Start-to-close / schedule timeouts are deliberately
+    excluded — those usually mean genuinely slow work, not a dead worker.
+
+    Contract note (mirrors ``_is_worker_evicted``): relies on
+    ``ActivityError.cause`` returning ``__cause__`` and on
+    ``temporalio.exceptions.TimeoutError.type``. Pinned by the fixture in
+    ``tests/unit/execution/test_infra_diagnosis.py``.
+    """
+    cause = err.cause
+    return (
+        isinstance(cause, TemporalTimeoutError) and cause.type == TimeoutType.HEARTBEAT
+    )
+
+
+def _decode_activity_location(err: ActivityError) -> ActivityLocation:
+    """Best-effort extraction of ``{node, pod, started_at}`` from a failure.
+
+    Two carriers, tried in order:
+
+    1. **Seeded heartbeat details** — the identity dict recorded as the first
+       heartbeat detail by :func:`seed_activity_identity`. Survives into
+       ``TimeoutError.last_heartbeat_details``.
+    2. **Worker identity** (``ActivityError.identity``) — the clobber-proof
+       fallback, parsed from ``"{pod}@{node}"`` when the worker sets it.
+
+    Never raises: returns an empty :class:`ActivityLocation` when nothing is
+    decodable (e.g. OOM before the first heartbeat and no worker identity set).
+    """
+    node = pod = started_at = last_heartbeat_at = None
+
+    cause = err.cause
+    if isinstance(cause, TemporalTimeoutError):
+        details = tuple(cause.last_heartbeat_details or ())
+        if details and isinstance(details[0], dict):
+            ident = details[0]
+            node = ident.get("node")
+            pod = ident.get("pod")
+            started_at = ident.get("started_at")
+            last_heartbeat_at = ident.get("heartbeat_at")
+
+    if not (node or pod):
+        node, pod = _parse_worker_identity(getattr(err, "identity", None))
+
+    return ActivityLocation(
+        node=node, pod=pod, started_at=started_at, last_heartbeat_at=last_heartbeat_at
+    )
+
+
+def _parse_worker_identity(identity: str | None) -> tuple[str | None, str | None]:
+    """Parse ``"{pod}@{node}"`` worker identity → ``(node, pod)``.
+
+    Returns ``(None, None)`` when unset or not in that shape. The SDK only sets
+    this form when configured to encode pod/node into the Temporal worker
+    identity (see docs → "Identity carriers").
+    """
+    if not identity or "@" not in identity:
+        return None, None
+    pod, _, node = identity.partition("@")
+    return (node or None), (pod or None)
+
+
+# ---------------------------------------------------------------------------
+# workflow-side: classification (YOUR policy) + recording
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class RecordedCause:
+    """How an infra verdict is recorded against the failure.
+
+    Fields mirror the SDK taxonomy (:mod:`application_sdk.errors`) so downstream
+    consumers (Automation Engine, SLA dashboards) route on the vocabulary they
+    already use. ``infra_reason`` is the raw verdict, kept for humans.
+    """
+
+    code: str
+    """``AppError.code`` — e.g. ``"RESOURCE_EXHAUSTED"``."""
+    category: str
+    """``FailureCategory`` value — e.g. ``"RESOURCE_EXHAUSTED"``."""
+    audience: str
+    """``Audience`` value — e.g. ``"PLATFORM"``."""
+    retryable: bool
+    infra_reason: str
+    """The raw :class:`InfraCause` value — e.g. ``"OOM_KILLED"``."""
+
+
+def classify_infra_failure(verdict: InfraVerdict) -> RecordedCause:
+    """Map an infra-event verdict onto the SDK failure taxonomy.
+
+    ─── YOUR CALL — the one piece of real judgment in this feature ─────────────
+    Every branch is a policy decision, not a mechanical one. Fill each with the
+    ``code`` / ``category`` / ``audience`` / ``retryable`` matching how on-call
+    and the Automation Engine should treat it. Natural leaf classes from
+    ``application_sdk.errors.leaves`` are noted — swap them if your ownership
+    model differs.
+
+    * ``OOM_KILLED`` — app team's problem (a leak → ``APP_OWNER``, perhaps
+      ``retryable=False`` so attribution flags "don't just re-run") or
+      platform's (undersized limits → ``PLATFORM``)? ``ResourceExhaustedError``
+      is the natural leaf (``RESOURCE_EXHAUSTED`` / ``PLATFORM`` / retryable).
+      You scoped OOM to *record only*, so ``retryable`` here labels intent, it
+      does not drive a retry in Phase 1.
+    * ``SPOT_RECLAIM`` / ``NODE_LOST`` — infra, not the app's fault.
+      ``DependencyUnavailableError`` fits (``DEPENDENCY_UNAVAILABLE`` /
+      ``PLATFORM`` / retryable).
+    * ``NONE`` — service found nothing. The honest label is "timed out, cause
+      unknown": ``AppTimeoutError`` (``TIMEOUT`` / ``APP_OWNER`` / retryable).
+    ────────────────────────────────────────────────────────────────────────────
+
+    Must stay pure (runs in workflow context): no I/O, no clock, no randomness.
+    """
+    # TODO(you): replace this catch-all stub with the per-cause mapping above
+    # (≈5–10 lines, e.g. a dict keyed on ``verdict.cause``).
+    return RecordedCause(
+        code="TIMEOUT",
+        category="TIMEOUT",
+        audience="APP_OWNER",
+        retryable=True,
+        infra_reason=verdict.cause.value,
+    )
+
+
+async def _diagnose_and_record(err: ActivityError) -> None:
+    """Diagnose the infra cause of a heartbeat timeout and record it.
+
+    Best-effort: any failure here is logged and swallowed so the *original*
+    activity failure always propagates unchanged. This never turns an
+    attribution attempt into a second, masking failure.
+    """
+    from datetime import timedelta  # noqa: PLC0415 — keep workflow module top clean
+
+    from temporalio.common import RetryPolicy  # noqa: PLC0415
+
+    from application_sdk.constants import (  # noqa: PLC0415
+        INFRA_DIAGNOSIS_TIMEOUT_SECONDS,
+    )
+
+    try:
+        location = _decode_activity_location(err)
+        verdict: InfraVerdict = await workflow.execute_activity(
+            DIAGNOSE_ACTIVITY_NAME,
+            args=[location],
+            start_to_close_timeout=timedelta(seconds=INFRA_DIAGNOSIS_TIMEOUT_SECONDS),
+            # Small retry with backoff: infra signals (Karpenter events, pod
+            # lastState) often lag the heartbeat timeout by seconds.
+            retry_policy=RetryPolicy(
+                maximum_attempts=3,
+                initial_interval=timedelta(seconds=2),
+                backoff_coefficient=2.0,
+            ),
+            result_type=InfraVerdict,
+        )
+        cause = classify_infra_failure(verdict)
+        workflow.upsert_search_attributes(
+            [_INFRA_CAUSE_KEY.value_set(cause.infra_reason)]
+        )
+        # workflow.logger is a LoggerAdapter — custom fields must nest under
+        # ``extra`` (see eviction_retry.py for the same constraint).
+        workflow.logger.warning(
+            "activity failed on heartbeat timeout; diagnosed infra cause=%s "
+            "(code=%s audience=%s pod=%s node=%s)",
+            cause.infra_reason,
+            cause.code,
+            cause.audience,
+            location.pod,
+            location.node,
+            extra={
+                "infra_reason": cause.infra_reason,
+                "failure_code": cause.code,
+                "failure_audience": cause.audience,
+                "failure_retryable": cause.retryable,
+                "node": location.node,
+                "pod": location.pod,
+            },
+        )
+    except Exception:
+        workflow.logger.warning(
+            "infra diagnosis/record failed; original activity failure "
+            "propagates unchanged",
+            exc_info=True,
+        )
+
+
+async def execute_activity_with_infra_diagnosis(*args: Any, **kwargs: Any) -> Any:
+    """Drop-in for :func:`execute_activity_with_eviction_retry` that also records
+    an infra cause when an activity dies on a heartbeat timeout.
+
+    When ``ENABLE_INFRA_FAILURE_DIAGNOSIS`` is off this is a pure passthrough —
+    byte-for-byte the eviction-retry behaviour, no extra activity, no extra
+    workflow history. That keeps the feature safe to wire in before the
+    infra-event service exists.
+    """
+    from application_sdk.constants import (  # noqa: PLC0415 — read at call time so the flag is togglable
+        ENABLE_INFRA_FAILURE_DIAGNOSIS,
+    )
+
+    try:
+        return await execute_activity_with_eviction_retry(*args, **kwargs)
+    except ActivityError as err:
+        if ENABLE_INFRA_FAILURE_DIAGNOSIS and _is_heartbeat_timeout(err):
+            await _diagnose_and_record(err)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# activity-side: the diagnosis activity + identity seeding
+# ---------------------------------------------------------------------------
+
+
+@activity.defn(name=DIAGNOSE_ACTIVITY_NAME)
+async def diagnose_infra_failure(location: ActivityLocation) -> InfraVerdict:
+    """Ask the infra-event service what happened to a stopped activity's pod.
+
+    Runs as its own short activity (one HTTP call) so it may do I/O and so its
+    result is cached across replay. Fails safe: any problem yields
+    :meth:`InfraVerdict.none` — it never raises, so it cannot turn an
+    attribution attempt into a second failure.
+    """
+    if not location.is_correlatable():
+        return InfraVerdict.none("no node/pod to correlate")
+    client = get_infra_event_client()
+    try:
+        return await client.lookup(location)
+    except Exception:
+        logger.warning(
+            "infra-event lookup failed for pod=%s node=%s; recording NONE",
+            location.pod,
+            location.node,
+            exc_info=True,
+        )
+        return InfraVerdict.none("lookup raised")
+
+
+def read_pod_identity() -> dict[str, str]:
+    """Read pod/node identity from the Kubernetes downward API env.
+
+    Requires the pod spec to expose ``NODE_NAME`` / ``POD_NAME`` via
+    ``fieldRef`` (``spec.nodeName`` / ``metadata.name``). ``HOSTNAME`` is used
+    as a pod-name fallback (equals the pod name in Kubernetes). Missing values
+    are omitted; diagnosis then falls back to worker identity.
+    """
+    import os  # noqa: PLC0415 — activity-side only; keep os out of the workflow module top
+
+    ident: dict[str, str] = {}
+    node = os.getenv("NODE_NAME")
+    pod = os.getenv("POD_NAME") or os.getenv("HOSTNAME")
+    if node:
+        ident["node"] = node
+    if pod:
+        ident["pod"] = pod
+    return ident
+
+
+def seed_activity_identity(heartbeat_controller: Any) -> None:
+    """Seed the heartbeat with pod/node identity so it survives into a timeout.
+
+    Records ``{node, pod, started_at}`` as the first heartbeat detail; the
+    auto-heartbeat keepalive re-sends the same details, so a later
+    ``TimeoutError.last_heartbeat_details`` carries the identity after an abrupt
+    kill. No-op when the feature is disabled or identity env is absent.
+
+    Known limitation: a task that later calls ``heartbeat(progress)`` manually
+    overwrites these details (see ``HeartbeatController.get_last_heartbeat_details``
+    semantics). For those tasks, worker identity (``ActivityError.identity``) is
+    the fallback carrier — see docs → "Identity carriers".
+    """
+    from application_sdk.constants import (  # noqa: PLC0415
+        ENABLE_INFRA_FAILURE_DIAGNOSIS,
+    )
+
+    if not ENABLE_INFRA_FAILURE_DIAGNOSIS:
+        return
+    identity = read_pod_identity()
+    if not identity:
+        return
+
+    from datetime import (  # noqa: PLC0415 — activity-side clock is fine
+        datetime,
+        timezone,
+    )
+
+    identity["started_at"] = datetime.now(timezone.utc).isoformat()
+    try:
+        heartbeat_controller.heartbeat(identity)
+    except Exception:
+        logger.debug("failed to seed activity identity heartbeat", exc_info=True)

--- a/application_sdk/execution/_temporal/infra_event_client.py
+++ b/application_sdk/execution/_temporal/infra_event_client.py
@@ -1,0 +1,150 @@
+"""Client boundary for the (net-new) infra-event service.
+
+The service answers one question: *what happened to this pod/node around the
+time an activity stopped heartbeating?* It ingests spot-interruption notices,
+Kubernetes pod ``lastState.terminated`` reasons (``OOMKilled`` / exit 137), and
+node-lifecycle events (Karpenter, node-termination-handler) into a durable,
+queryable store. Durable matters: pods are garbage-collected and Kubernetes
+Events expire (~1h), so a *live* query at diagnosis time often finds nothing.
+
+This module is the SDK-side *consumer* only. The service itself is a separate
+build; until it exists the client is disabled by default and every lookup
+returns :meth:`InfraVerdict.none`, so diagnosis fails safe. See
+``docs/infra-failure-diagnosis.md``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from enum import Enum
+from typing import Any, Protocol
+
+
+class InfraCause(str, Enum):
+    """Vocabulary the infra-event service returns for a stopped activity."""
+
+    SPOT_RECLAIM = "SPOT_RECLAIM"
+    OOM_KILLED = "OOM_KILLED"
+    NODE_LOST = "NODE_LOST"
+    NONE = "NONE"
+    """No infra event found for this pod/node/window — treat as 'cause unknown',
+    not 'confirmed not-infra'. Could be a genuinely slow activity, or an event
+    the service missed."""
+
+
+@dataclasses.dataclass(frozen=True)
+class ActivityLocation:
+    """Where/when an activity was last known to be running.
+
+    The correlation key for an infra-event lookup, assembled by the workflow
+    from the failed activity's worker identity and last heartbeat details.
+    """
+
+    node: str | None = None
+    pod: str | None = None
+    started_at: str | None = None
+    """ISO-8601, from the seeded identity heartbeat. Lower bound of the window."""
+    last_heartbeat_at: str | None = None
+    """ISO-8601 of the last heartbeat. Approximates time-of-death (upper bound)."""
+
+    def is_correlatable(self) -> bool:
+        """True iff there is at least a node or pod to query by."""
+        return bool(self.node or self.pod)
+
+
+@dataclasses.dataclass(frozen=True)
+class InfraVerdict:
+    """Answer from the infra-event service."""
+
+    cause: InfraCause
+    evidence: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+    @classmethod
+    def none(cls, reason: str) -> InfraVerdict:
+        """A fail-safe 'no infra cause' verdict carrying why we couldn't tell."""
+        return cls(cause=InfraCause.NONE, evidence={"reason": reason})
+
+
+class InfraEventClient(Protocol):
+    """Queries the infra-event service.
+
+    Implementations MUST fail safe: on any error they return
+    :meth:`InfraVerdict.none` rather than raising, so diagnosis never blocks
+    or fails a workflow.
+    """
+
+    async def lookup(self, location: ActivityLocation) -> InfraVerdict: ...
+
+
+class FakeInfraEventClient:
+    """In-memory client for tests and local runs.
+
+    Pre-seed verdicts keyed by pod (falling back to node); unknown keys
+    return ``NONE``.
+    """
+
+    def __init__(self, verdicts: dict[str, InfraVerdict] | None = None) -> None:
+        self._verdicts = verdicts or {}
+
+    async def lookup(self, location: ActivityLocation) -> InfraVerdict:
+        key = location.pod or location.node or ""
+        return self._verdicts.get(key, InfraVerdict.none("no seeded verdict"))
+
+
+class HttpInfraEventClient:
+    """Real client for the net-new infra-event service.
+
+    Contract::
+
+        POST {base_url}/infra-events/lookup
+          { "node": str, "pod": str, "since": iso8601, "until": iso8601 }
+        -> { "cause": "SPOT_RECLAIM|OOM_KILLED|NODE_LOST|NONE",
+             "evidence": { ... } }
+
+    Fails safe: timeouts, non-200, and malformed bodies all return ``NONE``.
+    """
+
+    def __init__(self, base_url: str, timeout_seconds: float = 5.0) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._timeout_seconds = timeout_seconds
+
+    async def lookup(self, location: ActivityLocation) -> InfraVerdict:
+        # TODO(service): implement once the infra-event service ships.
+        # Use an async client (httpx.AsyncClient) — this runs inside an
+        # activity on Temporal's event loop; a blocking client would stall it.
+        #
+        #   payload = {"node": location.node, "pod": location.pod,
+        #              "since": location.started_at, "until": location.last_heartbeat_at}
+        #   try:
+        #       async with httpx.AsyncClient(timeout=self._timeout_seconds) as c:
+        #           resp = await c.post(f"{self._base_url}/infra-events/lookup", json=payload)
+        #       resp.raise_for_status()
+        #       body = resp.json()
+        #       return InfraVerdict(cause=InfraCause(body["cause"]),
+        #                           evidence=body.get("evidence", {}))
+        #   except Exception:
+        #       return InfraVerdict.none("lookup failed")   # never raise
+        return InfraVerdict.none("HttpInfraEventClient not implemented")
+
+
+class _DisabledInfraEventClient:
+    """Returned when the feature is off or unconfigured. Always ``NONE``."""
+
+    async def lookup(self, location: ActivityLocation) -> InfraVerdict:
+        return InfraVerdict.none("infra diagnosis disabled")
+
+
+def get_infra_event_client() -> InfraEventClient:
+    """Return the configured client, or a fail-safe stub when disabled.
+
+    Read at activity time (inside :func:`diagnose_infra_failure`) so the flag
+    can be toggled per-deployment without a workflow code change.
+    """
+    from application_sdk.constants import (  # noqa: PLC0415 — read at call time so tests/deploys can toggle
+        ENABLE_INFRA_FAILURE_DIAGNOSIS,
+        INFRA_EVENT_SERVICE_URL,
+    )
+
+    if not ENABLE_INFRA_FAILURE_DIAGNOSIS or not INFRA_EVENT_SERVICE_URL:
+        return _DisabledInfraEventClient()
+    return HttpInfraEventClient(INFRA_EVENT_SERVICE_URL)

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -451,6 +451,17 @@ def create_worker(
         all_interceptors.append(EventInterceptor())
         task_activities = [*task_activities, publish_event]
 
+    from application_sdk.constants import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
+        ENABLE_INFRA_FAILURE_DIAGNOSIS,
+    )
+
+    if ENABLE_INFRA_FAILURE_DIAGNOSIS:
+        from application_sdk.execution._temporal.infra_diagnosis import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
+            diagnose_infra_failure,
+        )
+
+        task_activities = [*task_activities, diagnose_infra_failure]
+
     # Build sandbox configuration
     config = SandboxConfig()
 

--- a/docs/adr/0016-infra-failure-routing-placement.md
+++ b/docs/adr/0016-infra-failure-routing-placement.md
@@ -1,0 +1,251 @@
+# ADR-0016: Infra-Failure Routing and Interpreter Placement
+
+## Status
+**Proposed**
+
+## Context
+
+Apps run on spot (preemptible) nodes by default for cost. A spot reclaim, OOMKill,
+or node loss kills the worker process abruptly, before any in-process handler can
+run. The worker reports nothing; the activity stops heartbeating, and Temporal fails
+the attempt with a **heartbeat timeout** - which is retryable and **consumes
+`max_attempts`** (see `docs/worker-eviction-and-sigterm.md` for why abrupt kills
+never report `WorkerEvicted`). A workflow on spot can hit this repeatedly, burning
+its retry budget and eventually failing, with every retry landing back on the same
+spot queue.
+
+**Goal of this ADR:** when an activity dies from an infra event, retry it on an
+**on-demand task queue** so the work can finish, instead of re-failing on spot.
+
+**Prior work.** PR #2462 scaffolds detection + a fail-safe `diagnose_infra_failure`
+activity + a `classify_infra_failure` policy stub, all in the SDK
+(`docs/infra-failure-diagnosis.md`), flag-gated off. It stops short of routing
+because a second on-demand worker pool does not exist yet.
+
+This ADR responds to the design-review request (thread on the worker-eviction doc)
+for a full comparison of where this logic should live: in the SDK, in a Temporal
+extension, in a standalone service, or in the Automation Engine (AE).
+
+## Scope
+
+**This ADR decides** where the *interpreter* lives - the layer that turns an infra
+event into a queue-routing action - and the shape of the SDK ↔ recorder interface.
+
+**Out of scope:**
+
+- **Attribution / failure-cause surfacing.** Handled by AE, not the SDK (premise P4).
+- **The recorder's internals.** A net-new, platform-owned service; this ADR only
+  consumes its signal.
+
+## Settled Premises
+
+Four points are not in contention; they frame the actual question.
+
+- **P1 - The signal comes from an external recorder.** Temporal has zero Kubernetes
+  awareness: it sees a bare heartbeat timeout and cannot tell an OOM from a spot
+  reclaim. The dead pod cannot self-report, and the next attempt runs on a
+  *different* pod, so nothing in-process knows the cause. A live k8s query is
+  unreliable (pods GC'd, Events expire ~1h). So the cause must come from a durable,
+  out-of-band **recorder** that ingests spot notices, pod `lastState.terminated`
+  (OOM/137), and node events (Karpenter/NTH).
+
+- **P2 - Routing lives in application-sdk.** Only workflow code can move work between
+  queues: a `RetryPolicy` never changes task queue; a fresh
+  `execute_activity(..., task_queue=...)` does. Every unit AE spawns is a separate
+  SDK-based app that needs the *identical* behaviour, so it belongs in the shared
+  substrate - the SDK - not in any one app or the engine above.
+
+- **P3 - No Kubernetes code in the SDK.** All k8s-aware logic (event ingestion,
+  pod/node watching, `lastState`/Karpenter parsing, k8s API calls) lives in the
+  recorder/controller. The SDK reaches it only over HTTP (wrapped in a fail-safe
+  activity). The SDK's sole *local* infra touch-point is reading `NODE_NAME` /
+  `POD_NAME` from downward-API env for correlation - Helm-wired config, not a k8s
+  call. "No k8s code" is not "no external call": correct routing genuinely needs the
+  lookup.
+
+- **P4 - Attribution is AE's job.** Workflows are orchestrated through
+  `../atlan-automation-engine-app`, which spawns each app as a Temporal **child
+  workflow** and walks the failure chain `ChildWorkflowError → ActivityError →
+  ApplicationError(details)` to the leaf activity failure
+  (`automation_engine/utils/temporal_errors.py`). Holding the last activity's failure
+  reason, AE can query the recorder itself and record the cause - even after the app
+  workflow has exited, which the SDK cannot do. So the SDK does **not** need to
+  design attribution.
+
+### Alternatives ruled out (answering the review's option list)
+
+- **Host routing in AE.** AE observes only at the child-workflow boundary, *after*
+  an app has exhausted its retries and failed - too coarse (whole-app, not
+  per-activity) and too late (cannot save the run). AE stays the attribution
+  consumer (P4), not the routing host.
+- **Temporal extension / interceptor in the SDK.** Pulls infra-detection machinery
+  deeper into the SDK (against P3), and interceptors wrap calls under determinism
+  constraints - they cannot express "catch this `ActivityError`, then re-dispatch on
+  another queue," so routing ends up as explicit workflow code anyway.
+- **Recorder baked into AE.** Couples a cluster-infra concern to the orchestration
+  engine's release cadence, and forces the SDK's routing lookup to depend on AE's
+  availability. The recorder is a standalone platform service instead.
+
+## The Open Question
+
+Given P1-P4, one design choice remains: **who interprets the infra event into a
+routing action, and what does the recorder return?**
+
+- **Cause vocabulary** (infra facts): `SPOT_RECLAIM`, `OOM_KILLED`, `NODE_LOST`,
+  `NONE`.
+- **Action vocabulary** (SDK/Temporal semantics): `REROUTE_ONDEMAND`, `FAIL_FAST`,
+  `RETRY_SAME` (today's behaviour).
+
+The interpreter is the cause → action mapping. It can live in the SDK, in a
+separate service, or inside the recorder.
+
+## Approaches
+
+### Approach 1 - Interpret in the SDK (Recommended)
+
+The recorder returns the raw `{cause, evidence}`. On a heartbeat timeout the SDK
+correlates the dead pod, calls the recorder (fail-safe activity), maps cause → action
+with a fixed policy, and executes.
+
+```
+ heartbeat_timeout ─► SDK correlates {node,pod,window}
+                       └─► recorder.lookup() ─► {cause}
+                            └─► SDK policy: cause → action → execute
+                                 SPOT/NODE_LOST → reroute on-demand
+                                 OOM            → fail-fast
+                                 NONE / down    → retry same (today)
+```
+
+**Pros:**
+- Recorder stays single-responsibility - a pure infra fact store. The same simple
+  contract serves both consumers: AE (attribution) and the SDK (routing). No
+  orchestration semantics leak into an infra service.
+- The action vocabulary is SDK/Temporal knowledge; the component that *executes* the
+  action also *decides* it, so it can never be handed an action it cannot perform.
+  No capability negotiation, no version skew.
+- Cohesive change surface: adding or altering an action is one SDK change, beside the
+  mechanism that implements it.
+- The scaffold already implements this shape (`classify_infra_failure`); lowest
+  friction.
+
+**Cons:**
+- The (app-agnostic) routing policy ships in the SDK, so changing it needs an SDK
+  release across apps. Low cost in practice - the policy is uniform and stable, and a
+  fixed default is acceptable (P2).
+- No fleet-wide *runtime* control of routing behaviour unless a flag/config is added
+  (addressed in the recommendation).
+
+### Approach 2 - Interpret in an external service (returns an action primitive)
+
+The recorder returns raw causes; a separate interpreter service maps cause → action
+and hands the SDK a ready-made **action primitive**. The SDK just executes it.
+
+**Pros:**
+- Policy centralised: change routing behaviour with one deploy, no SDK bump.
+- Fleet-wide runtime control - platform can flip behaviour mid-incident (e.g. stop
+  rerouting when on-demand is *also* constrained) instantly.
+- SDK is a thin, stable executor of a small primitive set.
+
+**Cons:**
+- Leaks orchestration semantics into an infra-adjacent service: to emit a correct
+  primitive it must understand SDK task-queue topology and retry budgets - the wrong
+  knowledge boundary.
+- **Version skew:** the service can emit a primitive a deployed SDK version does not
+  support; needs a capability contract or a safe-ignore rule. More brittle than the
+  executor owning its own actions.
+- Demotes the SDK from orchestrator to actuator, in tension with P2. And the
+  primitive is still SDK-specific, so the service is coupled to SDK concepts anyway -
+  the decoupling is illusory.
+- Adds a second synchronous decision dependency on the failure path (beyond the fact
+  lookup).
+
+### Approach 3 - Fold the interpreter into the recorder (recorder returns the action)
+
+One call: the recorder itself returns the action primitive.
+
+**Pros:**
+- One fewer hop / service than Approach 2; still centralises policy and runtime
+  control.
+
+**Cons:**
+- Destroys the recorder's single responsibility - it must now know SDK orchestration
+  to decide actions - and couples its release cadence to routing-policy changes.
+- Serves AE poorly: AE wants raw facts for attribution, so the recorder must either
+  emit SDK-specific actions AE ignores, or maintain two response shapes.
+- Inherits Approach 2's semantic-leak and version-skew cons, now baked into the
+  shared fact store.
+
+## Recommendation
+
+**Approach 1**, with one addition to capture Approach 2's single real advantage: gate
+the `REROUTE_ONDEMAND` action behind a **platform-controlled env-var switch** the SDK
+reads (off by default). Disabling it is a deploy-time config change across the fleet -
+enough for the urgent case (kill rerouting when on-demand is itself constrained)
+without moving the *decision* out of the SDK. (A live, per-cause toggle - a
+`reroute_allowed` field in the recorder verdict - stays available as a later
+enhancement if instant runtime control is ever needed.)
+
+This keeps the recorder a clean fact store (P1), the action vocabulary owned by its
+executor (no version skew), the SDK as the orchestrator (P2), and reuses the built
+scaffold. It concedes only Approach 2's general "change any policy at runtime"
+flexibility, which a uniform, stable policy does not need.
+
+Routing policy (the cause → action map that ships in the SDK):
+
+| Cause | Action | Why |
+|---|---|---|
+| `SPOT_RECLAIM` / `NODE_LOST` | `REROUTE_ONDEMAND` (if switch on) | On-demand won't be reclaimed - the retry can finish. |
+| `OOM_KILLED` | `FAIL_FAST` (attributed) | Same limits on-demand → same OOM. Rerouting wastes budget; fix limits or the leak. |
+| `NONE` / recorder down | `RETRY_SAME` | No verdict - keep today's behaviour. Fail-safe default. |
+
+## Consequences
+
+**Positive:**
+- The SDK gains no new *success-path* dependency; the recorder is consulted only on
+  the failure/reroute path, as a fail-safe activity (recorder down → `RETRY_SAME`).
+- Every SDK-based app inherits identical routing, with no per-app configuration.
+- No Kubernetes code enters the SDK (P3); the recorder stays a reusable fact store
+  shared with AE.
+- Attribution is fully delegated to AE (P4), including terminal failures the SDK
+  could not attribute.
+- Platform retains a fleet-wide reroute kill-switch (env var) without owning the
+  decision.
+
+**Negative:**
+- The routing policy lives in the SDK, so changing the mapping needs an SDK release
+  (mitigated: uniform, stable policy; runtime kill-switch for the urgent case).
+- Routing carries a soft, failure-path, fail-safe dependency on the recorder; an
+  outage disables smart rerouting (falls back to `RETRY_SAME`) until it recovers.
+- Inert until the app runtime provisions the second on-demand TWD (its own task
+  queue) and the routing env var is set; the SDK depends on but does not create that
+  pool (ADR-0002, ADR-0009 topology).
+
+## Implementation
+
+Resolved decisions:
+
+- **Reroute switch → env var.** A new SDK env var (e.g.
+  `ATLAN_ENABLE_INFRA_FAILURE_ROUTING`), off by default, mirroring
+  `ATLAN_ENABLE_INFRA_FAILURE_DIAGNOSIS`. Deploy-time config, no per-app override.
+- **On-demand pool → provisioned by app runtime as a second TWD.** The app runtime
+  stands up a second worker pool as its own Temporal Worker Deployment (TWD) pinned to
+  on-demand nodes, on its own task queue. The SDK provisions nothing; it reads that
+  queue name from an env var (injected like the existing Worker Deployment vars via
+  the TWD controller / Downward API) and targets it in the reroute
+  `execute_activity(task_queue=<on-demand queue>)`. Until that TWD and env var exist,
+  routing is inert.
+- **Reroute budget → the remaining budget, no separate counter.** Rerouting does not
+  grant a fresh allowance. The SDK's workflow-side re-dispatch (as with eviction
+  retry) redirects the *remaining* `max_attempts` onto the on-demand queue - only the
+  queue for the remaining attempts changes, not the total budget. (Contrast the
+  eviction loop's separate `WORKER_EVICTION_MAX_RETRIES`.)
+
+## Related
+
+- `docs/infra-failure-diagnosis.md` - the Phase-1 scaffold this ADR builds routing on.
+- `docs/worker-eviction-and-sigterm.md` - the graceful SIGTERM counterpart; why abrupt
+  kills surface as heartbeat timeouts.
+- ADR-0002 (Per-App Workers), ADR-0009 (Separate Handler/Worker Deployments) - the
+  one-app-one-queue topology a second on-demand pool must extend.
+- ADR-0013 (Error Hierarchy and Failure Taxonomy) - the vocabulary AE's attribution
+  maps onto.

--- a/docs/adr/0017-infra-failure-routing-placement.md
+++ b/docs/adr/0017-infra-failure-routing-placement.md
@@ -1,4 +1,4 @@
-# ADR-0016: Infra-Failure Routing and Interpreter Placement
+# ADR-0017: Infra-Failure Routing and Interpreter Placement
 
 ## Status
 **Proposed**
@@ -153,11 +153,17 @@ and hands the SDK a ready-made **action primitive**. The SDK just executes it.
 - **Version skew:** the service can emit a primitive a deployed SDK version does not
   support; needs a capability contract or a safe-ignore rule. More brittle than the
   executor owning its own actions.
-- Demotes the SDK from orchestrator to actuator, in tension with P2. And the
-  primitive is still SDK-specific, so the service is coupled to SDK concepts anyway -
-  the decoupling is illusory.
+- Demotes the SDK from orchestrator to actuator, in tension with P2. And it does not
+  actually decouple: the action primitive is still SDK-specific, so externalizing the
+  mapper *inverts* the coupling rather than removing it - an infra-adjacent service now
+  reasons about SDK orchestration, the wrong direction. In-SDK the coupling runs the
+  natural way: the orchestrator consumes an infra vocabulary it already understands.
 - Adds a second synchronous decision dependency on the failure path (beyond the fact
   lookup).
+- Fleet-wide blast radius: a bad or stale policy push misroutes every app at once -
+  fast to fix, but fast to break, and it needs staged-rollout guardrails on the policy
+  itself. In-SDK, a bad mapping ships via a normal SDK release (reviewed, staged,
+  rolled out per app), so it cannot break the whole fleet in a single push.
 
 ### Approach 3 - Fold the interpreter into the recorder (recorder returns the action)
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -20,4 +20,4 @@ ADRs capture the architectural decisions behind the Application SDK — what was
 | [ADR-0014](0014-two-store-storage-architecture.md) | Two-Store Storage Architecture (task-to-task vs app-to-app) |
 | [ADR-0015](0015-directory-listing-race-fix.md) | Directory Listing Race Fix (safe_list_directory primitive) |
 | [ADR-0016](0016-multi-pool-worker-routing.md) | Multi-Pool Worker Routing (N pools per app, @task(pool=...) static affinity) |
-| [ADR-0016](0016-infra-failure-routing-placement.md) | Infra-Failure Routing and Interpreter Placement |
+| [ADR-0017](0017-infra-failure-routing-placement.md) | Infra-Failure Routing and Interpreter Placement |

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -20,3 +20,4 @@ ADRs capture the architectural decisions behind the Application SDK — what was
 | [ADR-0014](0014-two-store-storage-architecture.md) | Two-Store Storage Architecture (task-to-task vs app-to-app) |
 | [ADR-0015](0015-directory-listing-race-fix.md) | Directory Listing Race Fix (safe_list_directory primitive) |
 | [ADR-0016](0016-multi-pool-worker-routing.md) | Multi-Pool Worker Routing (N pools per app, @task(pool=...) static affinity) |
+| [ADR-0016](0016-infra-failure-routing-placement.md) | Infra-Failure Routing and Interpreter Placement |

--- a/docs/infra-failure-diagnosis.md
+++ b/docs/infra-failure-diagnosis.md
@@ -1,0 +1,177 @@
+# Infra-failure diagnosis and attribution
+
+How the SDK turns a silent activity heartbeat timeout - the signature of an abrupt worker kill (spot reclaim, OOMKill, node loss) - into a recorded cause, by asking an out-of-band infra-event service what happened to the pod.
+
+This is the companion action to the *worker eviction and SIGTERM* design (`docs/worker-eviction-and-sigterm.md`, tracked separately), which handles the *graceful* case. Read that first: it explains why abrupt kills never report `WorkerEvicted` and instead surface as heartbeat timeouts.
+
+## TL;DR
+
+- A heartbeat timeout with no preceding `WorkerEvicted` means the worker died before it could say why. The cause is only knowable out-of-band.
+- On that timeout, the workflow runs a short `diagnose_infra_failure` activity that queries a **net-new infra-event service** (`{node, pod, window}` → `SPOT_RECLAIM | OOM_KILLED | NODE_LOST | NONE`), maps the verdict onto the SDK failure taxonomy, records it (Temporal search attribute + structured log), and **re-raises the original failure unchanged**.
+- **Phase 1 (this scaffold) is attribution only.** It labels the failure; it does not change retry or failure behaviour. Recording the cause does **not** stop spot/OOM from consuming `max_attempts` - only rerouting the retry to a different task queue does, and that (Phase 2) needs a second on-demand worker pool that does not exist yet.
+- Everything is behind `ATLAN_ENABLE_INFRA_FAILURE_DIAGNOSIS` (default off). When off, activity execution is byte-for-byte identical to today.
+
+## Why this can't be done in-process
+
+Three facts are load-bearing, and together they force the shape:
+
+1. **The dead worker cannot diagnose itself.** Spot/OOM kill the process before any handler runs (see the eviction doc). So whatever asks "why did it die" must run somewhere that survived - the workflow, on a live worker.
+2. **Temporal retries never change task queue.** A `RetryPolicy` re-runs on the same queue. Anything that reacts to the cause must be workflow-orchestrated, not a retry-policy tweak. (This is why Phase 2 rerouting is a fresh `execute_activity`, exactly like the eviction loop.)
+3. **Correlation needs an identity that outlives the kill.** To ask about a node, the workflow must know the node - but the killed activity reported nothing. Two carriers survive: the **last heartbeat details** (recorded server-side before death) and the **worker identity** on the `ActivityError`.
+
+## Components
+
+| Component | Where | Role |
+|---|---|---|
+| Identity seed | `infra_diagnosis.seed_activity_identity`, called from `activities.py` | Records `{node, pod, started_at}` as the first heartbeat detail so it survives into the timeout |
+| Detection | `infra_diagnosis._is_heartbeat_timeout` | Recognises the abrupt-kill signature on the `ActivityError` |
+| Correlation | `infra_diagnosis._decode_activity_location` | Extracts `{node, pod, window}` from heartbeat details, falling back to worker identity |
+| Diagnosis activity | `infra_diagnosis.diagnose_infra_failure` | Short activity that queries the infra-event service; fails safe to `NONE` |
+| Service client | `infra_event_client.HttpInfraEventClient` (+ `Fake`, `_Disabled`) | The SDK-side boundary to the net-new service |
+| Classification | `infra_diagnosis.classify_infra_failure` | **Your policy**: verdict → SDK failure taxonomy |
+| Recording | `infra_diagnosis._diagnose_and_record` | Upserts the `infra_failure_cause` search attribute + logs |
+| Wrapper | `infra_diagnosis.execute_activity_with_infra_diagnosis` | Drop-in over the eviction loop at the single call site (`base.py`) |
+| **Infra-event service** | **net-new, not in this repo** | Ingests spot/OOM/node events into a durable store; answers the lookup |
+
+The infra-event service is the one net-new build. It exists because a *live* Kubernetes query at diagnosis time is unreliable - pods are garbage-collected and Events expire (~1h). The service ingests spot-interruption notices, pod `lastState.terminated.reason`, and node-lifecycle events (Karpenter, node-termination-handler) into a durable, queryable store.
+
+## Interaction - happy path
+
+```
+ App @task on a spot pod          Temporal server            Workflow (live worker)        Infra-event service
+        │                              │                            │                             │
+        │ heartbeat {node,pod,ts} ────►│ (recorded server-side)     │                             │
+        │ ...working...                │                            │                             │
+        ☠ spot reclaim / OOM (SIGKILL, no time to report)           │                             │
+        │                              │                            │                             │
+        │        heartbeat_timeout elapses                          │                             │
+        │                              │── ActivityError(cause=     │                             │
+        │                              │     TimeoutError.HEARTBEAT)►│                             │
+        │                              │      + last_heartbeat_details, .identity                  │
+        │                              │                            │ _is_heartbeat_timeout ✓     │
+        │                              │                            │ _decode_activity_location   │
+        │                              │◄── execute diagnose_infra_failure(location) ──┐          │
+        │                              │                            │                  └─ lookup ─►│
+        │                              │                            │                  ┌── verdict │
+        │                              │                            │◄─────────────────┘  OOM_KILLED
+        │                              │                            │ classify_infra_failure      │
+        │                              │◄── upsert_search_attributes({infra_failure_cause}) ─      │
+        │                              │                            │ log(cause, pod, node)       │
+        │                              │                            │ raise (original error)      │
+```
+
+## Interaction - fail-safe paths
+
+Diagnosis is strictly additive. Every failure in the diagnosis path degrades to "record `NONE`, propagate the original error":
+
+| Situation | Behaviour |
+|---|---|
+| Feature flag off | Wrapper is a pure passthrough to the eviction loop. No diagnosis activity, no extra history. |
+| No node/pod decodable (OOM before first heartbeat, no worker identity) | `diagnose_infra_failure` returns `NONE` without calling the service. |
+| Service down / times out / malformed body | Client returns `NONE`; activity returns `NONE`. |
+| Service says `NONE` (no event found) | Recorded as `NONE` = "cause unknown" - do **not** infer "confirmed not-infra". |
+| Diagnosis or recording raises | Caught in `_diagnose_and_record`, logged, swallowed. Original `ActivityError` always wins. |
+
+Invariant: infra diagnosis can never fail, block, or alter a workflow beyond adding a search attribute and a log line.
+
+## Data contracts
+
+Heartbeat identity (seeded, first detail):
+```json
+{ "node": "ip-10-0-1-2", "pod": "myapp-abc123", "started_at": "2026-07-01T10:00:00Z" }
+```
+
+Infra-event service:
+```
+POST {base_url}/infra-events/lookup
+  { "node": str, "pod": str, "since": iso8601, "until": iso8601 }
+→ { "cause": "SPOT_RECLAIM|OOM_KILLED|NODE_LOST|NONE", "evidence": { ... } }
+```
+
+Recorded cause (`RecordedCause`), mirroring `application_sdk.errors`:
+```
+code       AppError.code          e.g. "RESOURCE_EXHAUSTED"
+category   FailureCategory value  e.g. "RESOURCE_EXHAUSTED"
+audience   Audience value         e.g. "PLATFORM"
+retryable  bool
+infra_reason  raw InfraCause      e.g. "OOM_KILLED"   ← the search-attribute value
+```
+
+## Identity carriers
+
+Two ways the workflow learns where the activity ran, in priority order:
+
+1. **Heartbeat details** - `seed_activity_identity` records the identity dict as the first heartbeat detail; the auto-heartbeat keepalive re-sends it, so `TimeoutError.last_heartbeat_details` carries it after death. Primary carrier; needs `NODE_NAME`/`POD_NAME` in the pod env.
+   - **Limitation**: a task that later calls `heartbeat(progress)` manually overwrites these details. For those tasks, carrier 2 covers it.
+2. **Worker identity** - `ActivityError.identity`, parsed from `"{pod}@{node}"`. Clobber-proof, but requires setting the Temporal worker/client identity to that form (not wired in this scaffold; see Phase 2 / hardening).
+
+## Determinism and replay
+
+- Workflow-context code (`_is_heartbeat_timeout`, `_decode_activity_location`, `classify_infra_failure`, `upsert_search_attributes`) is pure and replay-safe - no clock, no I/O, no randomness. `classify_infra_failure` **must stay pure**.
+- All I/O is inside `diagnose_infra_failure` (an activity); its result is cached in history and replayed deterministically.
+- The correlation window comes from the heartbeat payload's timestamps, never `workflow.now()`.
+
+## Configuration
+
+| Setting | Env var | Default |
+|---|---|---|
+| Enable diagnosis + attribution | `ATLAN_ENABLE_INFRA_FAILURE_DIAGNOSIS` | `false` |
+| Infra-event service URL | `ATLAN_INFRA_EVENT_SERVICE_URL` | `""` (disables HTTP client) |
+| Diagnosis activity timeout | `ATLAN_INFRA_DIAGNOSIS_TIMEOUT_SECONDS` | `30` |
+
+## Wiring checklist (to turn Phase 1 on)
+
+1. **Build the infra-event service** and point `ATLAN_INFRA_EVENT_SERVICE_URL` at it. Implement `HttpInfraEventClient.lookup` (there's a `# TODO(service)` with the shape).
+2. **Fill `classify_infra_failure`** - the one policy decision (see below).
+3. **Register the search attribute** `infra_failure_cause` (Keyword) on the Temporal namespace. Without it, `upsert_search_attributes` fails (caught, but no attribution).
+4. **Expose pod identity** in the pod spec via the downward API:
+   ```yaml
+   env:
+     - name: NODE_NAME
+       valueFrom: { fieldRef: { fieldPath: spec.nodeName } }
+     - name: POD_NAME
+       valueFrom: { fieldRef: { fieldPath: metadata.name } }
+   ```
+5. **Set** `ATLAN_ENABLE_INFRA_FAILURE_DIAGNOSIS=true`. The diagnosis activity auto-registers on the worker (`worker.py`) and the seed activates.
+
+The activity registration (`worker.py`) and the call-site wrapper (`base.py`) are already wired; both are inert while the flag is off.
+
+## The one decision that's yours
+
+`classify_infra_failure(verdict) -> RecordedCause` maps each infra cause onto your failure taxonomy, and it encodes real judgment, not mechanics. Natural leaves from `errors/leaves.py`:
+
+| Verdict | Suggested leaf | Category / Audience | The question |
+|---|---|---|---|
+| `OOM_KILLED` | `ResourceExhaustedError` | RESOURCE_EXHAUSTED / PLATFORM | Leak (app owns, don't just re-run) or undersized limit (platform)? |
+| `SPOT_RECLAIM` | `DependencyUnavailableError` | DEPENDENCY_UNAVAILABLE / PLATFORM | Infra, not the app's fault |
+| `NODE_LOST` | `DependencyUnavailableError` | DEPENDENCY_UNAVAILABLE / PLATFORM | Same family as spot, or its own? |
+| `NONE` | `AppTimeoutError` | TIMEOUT / APP_OWNER | Honest "timed out, cause unknown" |
+
+## Phase 2 preview - rerouting (not built)
+
+Once a second, on-demand worker pool exists on its own task queue, the `raise` in the wrapper becomes a routing decision:
+
+```python
+cause = classify_infra_failure(verdict)
+decision = route_policy(cause)          # pure: (retry?, task_queue)
+if decision.reroute:
+    kwargs["task_queue"] = decision.task_queue   # workflow.execute_activity supports this
+    return await execute_activity_with_eviction_retry(*args, **kwargs)   # fresh budget
+raise
+```
+
+Prerequisites: the second worker pool + queue, a reliable queue for the diagnosis activity itself (today it shares the single queue - tolerable only because it's short and retried), and `route_policy`. Per current scope, OOM stays record-only even in Phase 2.
+
+## Code references
+
+- `application_sdk/execution/_temporal/infra_diagnosis.py` - detection, correlation, classify (your TODO), diagnosis activity, wrapper, identity seed
+- `application_sdk/execution/_temporal/infra_event_client.py` - service client boundary + fake
+- `application_sdk/execution/_temporal/activities.py` - `seed_activity_identity` call site
+- `application_sdk/execution/_temporal/worker.py` - diagnosis activity registration (flag-gated)
+- `application_sdk/app/base.py` - the single call site routed through the wrapper
+- `application_sdk/constants.py` - the three config vars
+- `tests/unit/execution/test_infra_diagnosis.py` - full path coverage, temporalio `TimeoutError` contract pin
+
+## Related
+
+- *Worker eviction, SIGTERM, and activity retries* (`docs/worker-eviction-and-sigterm.md`, tracked separately) - the graceful counterpart; explains why abrupt kills become heartbeat timeouts.

--- a/docs/worker-eviction-and-sigterm.md
+++ b/docs/worker-eviction-and-sigterm.md
@@ -1,0 +1,108 @@
+# Worker eviction, SIGTERM, and activity retries
+
+How the SDK handles worker pod termination, and when a termination does or does not consume an activity's `RetryPolicy.max_attempts` budget.
+
+## TL;DR
+
+- On `SIGTERM`/`SIGINT` the SDK sets a process-wide shutdown flag, then lets the Temporal worker drain. When an in-flight activity is cancelled during shutdown, the activity wrapper re-raises the `asyncio.CancelledError` as `ApplicationError(type="WorkerEvicted", non_retryable=True)`.
+- `WorkerEvicted` is always added to the activity's `non_retryable_error_types`, so Temporal never retries it. A workflow-side loop (`execute_activity_with_eviction_retry`) re-dispatches the activity as a fresh attempt under its own counter. The eviction therefore does **not** consume the task's `max_attempts` budget.
+- This protection only holds when the worker process survives long enough to (1) cancel the activity and (2) report the failure to the server. Abrupt terminations - spot reclaim, OOMKill, node loss - kill the process first. The activity is never reported as `WorkerEvicted`; the server times it out on heartbeat instead, which is retryable and **does** consume `max_attempts`.
+- A `SIGTERM` carries no cause. The SDK cannot tell a spot reclaim from a rolling deploy, and does not try. Distinguishing requires out-of-band cloud or Kubernetes signals.
+
+## The shutdown path
+
+```
+SIGTERM / SIGINT
+  -> signal handler sets the shutdown flag, then runs worker shutdown
+        main.py: _install_graceful_signal_handlers -> shutdown.mark_worker_shutting_down()
+  -> AppWorker.__aexit__ sleeps SHUTDOWN_DRAIN_DELAY_SECONDS (flush queued completions),
+     then delegates to Worker.__aexit__
+        worker.py: AppWorker.__aexit__   (see related RCA)
+  -> worker stops polling, waits graceful_shutdown_timeout for in-flight activities,
+     then CANCELS the survivors
+        worker.py: graceful_shutdown_timeout wiring; settings.py: graceful_shutdown_timeout_seconds
+  -> cancelled activity body raises asyncio.CancelledError
+        activities.py: `except asyncio.CancelledError`
+           - shutdown flag set -> raise ApplicationError(type=WorkerEvicted, non_retryable=True)
+           - flag not set       -> re-raise CancelledError (ordinary workflow-driven cancel)
+  -> WorkerEvicted is non-retryable at the Temporal layer
+        retry.py: _with_worker_evicted_non_retryable (always appends WORKER_EVICTED_TYPE)
+  -> workflow re-dispatches a FRESH activity, bounded by WORKER_EVICTION_MAX_RETRIES
+        eviction_retry.py: execute_activity_with_eviction_retry / _is_worker_evicted
+```
+
+Key invariant: the cancellation fires only **after** `graceful_shutdown_timeout` elapses (see the `worker.py` docstring: "Seconds to allow in-flight activities to complete after SIGTERM before cancelling them"). If the process dies before that, no cancellation and no `WorkerEvicted` ever happen.
+
+## Two outcomes, two retry costs
+
+| Termination | Signal | Process lives to report? | Failure seen by server | Consumes `max_attempts`? |
+|---|---|---|---|---|
+| Rolling deploy, KEDA scale-down, `kubectl delete`, controlled drain | SIGTERM | Yes - pod has `terminationGracePeriodSeconds` (commonly 12h) | `WorkerEvicted` (non-retryable) | **No** - separate eviction budget |
+| Spot / preemptible node reclaim | usually SIGTERM, but only seconds of grace | No - node reclaimed in ~30s-2min | none reported, then heartbeat timeout | **Yes** |
+| OOMKill, SIGKILL, node/kubelet crash | none (SIGKILL) | No | none reported, then heartbeat timeout | **Yes** |
+
+The dividing line is not the *cause* of the termination. It is whether the worker stays alive long enough to convert the cancel into a reported `WorkerEvicted`.
+
+## Why spot reclaim consumes a retry
+
+`terminationGracePeriodSeconds` is honoured by the kubelet for graceful pod eviction, but a spot or preemptible reclaim physically removes the node on the cloud provider's clock:
+
+- AWS EC2 Spot: ~2 minute interruption notice
+- GCP preemptible / Spot: ~30 second notice
+- Azure Spot: ~30 second eviction notice
+
+The worker's `graceful_shutdown_timeout` (default 3600s / 1h) cannot elapse inside that window, so the in-flight activity is never cancelled in-process and `WorkerEvicted` is never raised or reported. The activity simply stops heartbeating. Once `heartbeat_timeout` passes, the server fails the attempt with a heartbeat timeout, and a heartbeat timeout is retryable - it consumes one `max_attempts`. A run of these can exhaust `max_attempts` and fail the activity (and usually the workflow).
+
+> Counterintuitive: a long `graceful_shutdown_timeout` is too long to help on spot. It is tuned for the long-grace rolling-deploy case. A timeout shorter than the interruption window would let the worker cancel and report `WorkerEvicted` in time, but only when the platform actually delivers a SIGTERM (node-termination handler, Karpenter, kubelet graceful node shutdown). Hard reclaims and OOMKills give no SIGTERM and no time, so they always fall through to heartbeat timeout.
+
+## Can you distinguish a spot SIGTERM from any other SIGTERM?
+
+Not from the signal. `SIGTERM` is signal 15 with no sender and no reason; a rolling deploy, a scale-down, a `kubectl delete`, and a spot drain all deliver the identical signal. The handler in `main.py` reads nothing about the cause - it only flips the shutdown flag. The SDK consults no cloud-metadata or node-state source.
+
+The cause is only available out-of-band:
+
+| Source | How | Notice |
+|---|---|---|
+| AWS IMDS | poll `169.254.169.254/latest/meta-data/spot/instance-action` | ~2 min |
+| GCP metadata | poll `metadata.google.internal/computeMetadata/v1/instance/preempted` | ~30 s |
+| Azure | poll `169.254.169.254/metadata/scheduledevents` for `EventType=Preempt` | ~30 s |
+| Kubernetes | on SIGTERM, read the node's spot label / disruption taint via the API server | handler-dependent |
+| Post-hoc | pod `lastState.terminated.reason` (`OOMKilled`, exit 137), node / Karpenter events | after the fact |
+
+Important: distinguishing is not the bottleneck. The SDK already classifies *any* shutdown-flag cancel as `WorkerEvicted` - it does not need the cause. Spot consumes a retry only because the process dies before it can *report* the failure. Knowing "this is spot" helps only if the worker also acts faster: detect via IMDS, run a short shutdown, and rush the report inside the interruption window, while keeping the long grace for ordinary deploys. That behaviour is not implemented today, and it still cannot save a hard reclaim or OOMKill.
+
+## What an eviction costs even when it does not consume a retry
+
+A re-dispatch from `execute_activity_with_eviction_retry` is a brand-new `workflow.execute_activity` call with identical arguments. It starts at attempt 1 with **no Temporal heartbeat-resume** - heartbeat details (`activity.info().heartbeat_details`) only carry across retries of the *same* scheduled activity, never to a fresh re-dispatch. So an evicted long-running activity restarts from the beginning unless it checkpoints progress externally and reads it back on start. For activities that cannot finish within a termination window, external checkpointing is what prevents repeated restarts.
+
+## Configuration
+
+| Setting | Env var | Default | Defined in |
+|---|---|---|---|
+| Grace for in-flight activities before cancel | `TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT` | 3600 s | `execution/settings.py` (`graceful_shutdown_timeout_seconds`) |
+| Drain delay before worker shutdown (flush completions) | `ATLAN_SHUTDOWN_DRAIN_DELAY_SECONDS` | 5 s | `constants.py` (`SHUTDOWN_DRAIN_DELAY_SECONDS`) |
+| Max eviction re-dispatches per activity call | `ATLAN_WORKER_EVICTION_MAX_RETRIES` | 3 | `constants.py` (`WORKER_EVICTION_MAX_RETRIES`) |
+
+`graceful_shutdown_timeout` is overridable per deployment; some deployments set it to match a 12h `terminationGracePeriodSeconds` (see related RCA).
+
+## Operational guidance
+
+- Keep long-running, non-checkpointing activities off spot. Pin those workers to on-demand nodes (nodeSelector / taint). Spot is a poor fit for activities that cannot finish inside the interruption window, because every reclaim becomes a retry-consuming heartbeat timeout.
+- Checkpoint activity progress externally for long work, so any restart - eviction re-dispatch or heartbeat-timeout retry - resumes instead of starting over.
+- Match `terminationGracePeriodSeconds` to `graceful_shutdown_timeout` for graceful evictions so the worker can cancel and report `WorkerEvicted` before SIGKILL. This does nothing for spot, where the node is gone regardless.
+- A heartbeat timeout in history with no preceding `WorkerEvicted` is the signature of an abrupt kill (spot, OOM, node loss), or of a worker that could not reach the server to heartbeat.
+
+## Code references
+
+- `application_sdk/main.py` - `_install_graceful_signal_handlers`: wires SIGINT/SIGTERM to set the shutdown flag
+- `application_sdk/execution/shutdown.py` - process-wide shutdown flag (`is_worker_shutting_down`, `mark_worker_shutting_down`)
+- `application_sdk/execution/_temporal/activities.py` - `except asyncio.CancelledError`: converts to `WorkerEvicted` when the flag is set
+- `application_sdk/execution/retry.py` - `_with_worker_evicted_non_retryable`: always appends `WORKER_EVICTED_TYPE` to non-retryable types
+- `application_sdk/execution/_temporal/eviction_retry.py` - `execute_activity_with_eviction_retry`, `_is_worker_evicted`: workflow-side re-dispatch loop
+- `application_sdk/execution/_temporal/worker.py` - `AppWorker.__aexit__` (drain delay) and `graceful_shutdown_timeout` wiring
+- `application_sdk/errors/leaves.py` - `WORKER_EVICTED_TYPE`
+- `tests/unit/execution/test_eviction.py` - coverage of the eviction path end to end
+
+## Related
+
+- [RCA: Temporal worker shutdown deadlock - phantom task slot](./rca-shutdown-drain-delay-2026-03-27.md) - why the drain delay exists

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -150,7 +150,7 @@ nav:
       - adr/0009-separate-handler-worker-deployments.md
       - adr/0010-async-first-blocking-code.md
       - adr/0011-logging-level-guidelines.md
-      - adr/0016-infra-failure-routing-placement.md
+      - adr/0017-infra-failure-routing-placement.md
   - Reference:
       - CLI: reference/cli.md
       - HTTP API: reference/http-api.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -150,10 +150,12 @@ nav:
       - adr/0009-separate-handler-worker-deployments.md
       - adr/0010-async-first-blocking-code.md
       - adr/0011-logging-level-guidelines.md
+      - adr/0016-infra-failure-routing-placement.md
   - Reference:
       - CLI: reference/cli.md
       - HTTP API: reference/http-api.md
       - Configuration: configuration.md
+      - Worker Eviction & SIGTERM: worker-eviction-and-sigterm.md
   - Postmortems:
       - Shutdown Drain Delay (2026-03-27): rca-shutdown-drain-delay-2026-03-27.md
   - API Reference: https://k.atlan.dev/application-sdk/main/api

--- a/tests/unit/app/test_task.py
+++ b/tests/unit/app/test_task.py
@@ -477,7 +477,7 @@ class TestTaskPool:
         monkeypatch.setenv("ATLAN_TASK_QUEUE", "qi-app-queue")
 
         with patch(
-            "application_sdk.execution._temporal.eviction_retry.execute_activity_with_eviction_retry",
+            "application_sdk.execution._temporal.infra_diagnosis.execute_activity_with_eviction_retry",
             new_callable=AsyncMock,
         ) as mock_exec:
             mock_exec.return_value = MagicMock()
@@ -509,7 +509,7 @@ class TestTaskPool:
         monkeypatch.setenv("ATLAN_TASK_QUEUE", "qi-app-queue")
 
         with patch(
-            "application_sdk.execution._temporal.eviction_retry.execute_activity_with_eviction_retry",
+            "application_sdk.execution._temporal.infra_diagnosis.execute_activity_with_eviction_retry",
             new_callable=AsyncMock,
         ) as mock_exec:
             mock_exec.return_value = MagicMock()
@@ -536,7 +536,7 @@ class TestTaskPool:
         from application_sdk.app.base import _create_task_activity_wrapper
 
         with patch(
-            "application_sdk.execution._temporal.eviction_retry.execute_activity_with_eviction_retry",
+            "application_sdk.execution._temporal.infra_diagnosis.execute_activity_with_eviction_retry",
             new_callable=AsyncMock,
         ) as mock_exec:
             mock_exec.return_value = MagicMock()
@@ -624,7 +624,7 @@ class TestTaskPool:
         monkeypatch.setenv("ATLAN_TASK_QUEUE", "base-queue")
 
         with patch(
-            "application_sdk.execution._temporal.eviction_retry.execute_activity_with_eviction_retry",
+            "application_sdk.execution._temporal.infra_diagnosis.execute_activity_with_eviction_retry",
             new_callable=AsyncMock,
         ) as mock_exec:
             mock_exec.return_value = MagicMock()

--- a/tests/unit/execution/test_infra_diagnosis.py
+++ b/tests/unit/execution/test_infra_diagnosis.py
@@ -1,0 +1,319 @@
+"""Infra-failure diagnosis path: heartbeat timeout (spot / OOM / node loss) →
+diagnose against the infra-event service → record the cause, then re-raise.
+
+Covers:
+- ``_is_heartbeat_timeout`` distinguishes heartbeat timeout from start-to-close
+  and from an ApplicationError cause
+- ``_decode_activity_location`` reads identity from heartbeat details, falls
+  back to worker identity, and never raises
+- ``classify_infra_failure`` returns the recorded-cause contract shape
+- ``diagnose_infra_failure`` activity fails safe (NONE) and calls the client
+- ``execute_activity_with_infra_diagnosis`` is a passthrough when disabled and
+  diagnoses + records + re-raises on a heartbeat timeout when enabled
+
+The temporalio ``TimeoutError`` construction here PINS the contract the
+detection relies on (``ActivityError.cause`` → ``TimeoutError.type`` /
+``.last_heartbeat_details``). If a temporalio upgrade changes that shape, these
+fixtures fail loudly rather than the feature regressing silently.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from temporalio.exceptions import ActivityError
+from temporalio.exceptions import TimeoutError as TemporalTimeoutError
+from temporalio.exceptions import TimeoutType
+
+from application_sdk.execution._temporal import infra_diagnosis
+from application_sdk.execution._temporal.infra_diagnosis import (
+    RecordedCause,
+    _decode_activity_location,
+    _is_heartbeat_timeout,
+    _parse_worker_identity,
+    classify_infra_failure,
+    diagnose_infra_failure,
+    execute_activity_with_infra_diagnosis,
+    read_pod_identity,
+)
+from application_sdk.execution._temporal.infra_event_client import (
+    ActivityLocation,
+    FakeInfraEventClient,
+    InfraCause,
+    InfraVerdict,
+)
+
+
+def _make_timeout_activity_error(
+    timeout_type: TimeoutType = TimeoutType.HEARTBEAT,
+    heartbeat_details: list[object] | None = None,
+    identity: str = "pod-1@node-1",
+) -> ActivityError:
+    """Build an ``ActivityError`` whose cause is a ``TimeoutError`` of the given
+    type — mirroring what the workflow sees when an activity times out."""
+    cause = TemporalTimeoutError(
+        "activity timeout",
+        type=timeout_type,
+        last_heartbeat_details=heartbeat_details or [],
+    )
+    err = ActivityError(
+        "Activity task failed",
+        scheduled_event_id=1,
+        started_event_id=2,
+        identity=identity,
+        activity_type="dummy",
+        activity_id="dummy-1",
+        retry_state=None,
+    )
+    err.__cause__ = cause
+    return err
+
+
+def _make_app_error_activity_error() -> ActivityError:
+    """An ``ActivityError`` caused by an ApplicationError, not a timeout."""
+    from application_sdk.execution.errors import ApplicationError
+
+    err = ActivityError(
+        "Activity task failed",
+        scheduled_event_id=1,
+        started_event_id=2,
+        identity="test",
+        activity_type="dummy",
+        activity_id="dummy-1",
+        retry_state=None,
+    )
+    err.__cause__ = ApplicationError("boom", type="ValueError")
+    return err
+
+
+# ---------------------------------------------------------------------------
+# detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsHeartbeatTimeout:
+    def test_true_for_heartbeat_timeout(self) -> None:
+        assert _is_heartbeat_timeout(_make_timeout_activity_error()) is True
+
+    def test_false_for_start_to_close_timeout(self) -> None:
+        err = _make_timeout_activity_error(timeout_type=TimeoutType.START_TO_CLOSE)
+        assert _is_heartbeat_timeout(err) is False
+
+    def test_false_for_application_error_cause(self) -> None:
+        assert _is_heartbeat_timeout(_make_app_error_activity_error()) is False
+
+
+class TestDecodeActivityLocation:
+    def test_reads_identity_from_heartbeat_details(self) -> None:
+        err = _make_timeout_activity_error(
+            heartbeat_details=[
+                {"node": "n-hb", "pod": "p-hb", "started_at": "2026-01-01T00:00:00Z"}
+            ],
+            identity="p-wi@n-wi",
+        )
+        loc = _decode_activity_location(err)
+        # Heartbeat details win over worker identity.
+        assert loc.node == "n-hb"
+        assert loc.pod == "p-hb"
+        assert loc.started_at == "2026-01-01T00:00:00Z"
+
+    def test_falls_back_to_worker_identity(self) -> None:
+        err = _make_timeout_activity_error(heartbeat_details=[], identity="p-wi@n-wi")
+        loc = _decode_activity_location(err)
+        assert loc.node == "n-wi"
+        assert loc.pod == "p-wi"
+
+    def test_empty_when_nothing_decodable(self) -> None:
+        err = _make_timeout_activity_error(heartbeat_details=[], identity="")
+        loc = _decode_activity_location(err)
+        assert loc.is_correlatable() is False
+
+    def test_never_raises_on_odd_details(self) -> None:
+        err = _make_timeout_activity_error(
+            heartbeat_details=["not-a-dict"], identity=""
+        )
+        loc = _decode_activity_location(err)  # must not raise
+        assert loc.is_correlatable() is False
+
+
+class TestParseWorkerIdentity:
+    def test_parses_pod_at_node(self) -> None:
+        assert _parse_worker_identity("mypod@mynode") == ("mynode", "mypod")
+
+    def test_none_when_no_at(self) -> None:
+        assert _parse_worker_identity("just-a-string") == (None, None)
+
+    def test_none_when_empty(self) -> None:
+        assert _parse_worker_identity(None) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# classification (contract shape only — the mapping itself is a TODO)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyInfraFailure:
+    @pytest.mark.parametrize(
+        "cause",
+        [
+            InfraCause.SPOT_RECLAIM,
+            InfraCause.OOM_KILLED,
+            InfraCause.NODE_LOST,
+            InfraCause.NONE,
+        ],
+    )
+    def test_returns_recorded_cause_for_every_verdict(self, cause: InfraCause) -> None:
+        recorded = classify_infra_failure(InfraVerdict(cause=cause))
+        assert isinstance(recorded, RecordedCause)
+        assert recorded.infra_reason == cause.value
+        assert recorded.code
+        assert recorded.category
+        assert recorded.audience
+
+
+# ---------------------------------------------------------------------------
+# diagnosis activity
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnoseInfraFailureActivity:
+    async def test_returns_none_when_not_correlatable(self) -> None:
+        verdict = await diagnose_infra_failure(ActivityLocation())
+        assert verdict.cause is InfraCause.NONE
+
+    async def test_uses_client_when_correlatable(self) -> None:
+        fake = FakeInfraEventClient({"p1": InfraVerdict(cause=InfraCause.OOM_KILLED)})
+        with mock.patch.object(
+            infra_diagnosis, "get_infra_event_client", return_value=fake
+        ):
+            verdict = await diagnose_infra_failure(
+                ActivityLocation(pod="p1", node="n1")
+            )
+        assert verdict.cause is InfraCause.OOM_KILLED
+
+    async def test_fails_safe_when_client_raises(self) -> None:
+        boom = mock.Mock()
+        boom.lookup = mock.AsyncMock(side_effect=RuntimeError("network"))
+        with mock.patch.object(
+            infra_diagnosis, "get_infra_event_client", return_value=boom
+        ):
+            verdict = await diagnose_infra_failure(ActivityLocation(pod="p1"))
+        assert verdict.cause is InfraCause.NONE
+
+
+# ---------------------------------------------------------------------------
+# workflow-side wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteActivityWithInfraDiagnosis:
+    def _patch_eviction_loop(self, side_effect: object) -> mock._patch:
+        return mock.patch.object(
+            infra_diagnosis,
+            "execute_activity_with_eviction_retry",
+            mock.AsyncMock(side_effect=side_effect),
+        )
+
+    async def test_returns_result_on_success(self) -> None:
+        with mock.patch.object(
+            infra_diagnosis,
+            "execute_activity_with_eviction_retry",
+            mock.AsyncMock(return_value="ok"),
+        ):
+            result = await execute_activity_with_infra_diagnosis("act")
+        assert result == "ok"
+
+    async def test_passthrough_when_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "application_sdk.constants.ENABLE_INFRA_FAILURE_DIAGNOSIS", False
+        )
+        err = _make_timeout_activity_error()
+        diag = mock.AsyncMock()
+        with (
+            self._patch_eviction_loop(err),
+            mock.patch.object(infra_diagnosis.workflow, "execute_activity", diag),
+            pytest.raises(ActivityError),
+        ):
+            await execute_activity_with_infra_diagnosis("act")
+        diag.assert_not_awaited()
+
+    async def test_diagnoses_and_records_on_heartbeat_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "application_sdk.constants.ENABLE_INFRA_FAILURE_DIAGNOSIS", True
+        )
+        err = _make_timeout_activity_error(
+            heartbeat_details=[{"node": "n1", "pod": "p1"}]
+        )
+        diag = mock.AsyncMock(return_value=InfraVerdict(cause=InfraCause.OOM_KILLED))
+        upsert = mock.MagicMock()
+        with (
+            self._patch_eviction_loop(err),
+            mock.patch.object(infra_diagnosis.workflow, "execute_activity", diag),
+            mock.patch.object(
+                infra_diagnosis.workflow, "upsert_search_attributes", upsert
+            ),
+            mock.patch.object(infra_diagnosis.workflow, "logger", mock.MagicMock()),
+            pytest.raises(ActivityError),
+        ):
+            await execute_activity_with_infra_diagnosis("act")
+        diag.assert_awaited_once()
+        upsert.assert_called_once()
+
+    async def test_does_not_diagnose_non_timeout_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "application_sdk.constants.ENABLE_INFRA_FAILURE_DIAGNOSIS", True
+        )
+        err = _make_app_error_activity_error()
+        diag = mock.AsyncMock()
+        with (
+            self._patch_eviction_loop(err),
+            mock.patch.object(infra_diagnosis.workflow, "execute_activity", diag),
+            pytest.raises(ActivityError),
+        ):
+            await execute_activity_with_infra_diagnosis("act")
+        diag.assert_not_awaited()
+
+    async def test_record_failure_never_masks_original(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If diagnosis itself blows up, the original ActivityError still wins."""
+        monkeypatch.setattr(
+            "application_sdk.constants.ENABLE_INFRA_FAILURE_DIAGNOSIS", True
+        )
+        err = _make_timeout_activity_error()
+        with (
+            self._patch_eviction_loop(err),
+            mock.patch.object(
+                infra_diagnosis.workflow,
+                "execute_activity",
+                mock.AsyncMock(side_effect=RuntimeError("diagnosis broke")),
+            ),
+            mock.patch.object(infra_diagnosis.workflow, "logger", mock.MagicMock()),
+            pytest.raises(ActivityError),
+        ):
+            await execute_activity_with_infra_diagnosis("act")
+
+
+# ---------------------------------------------------------------------------
+# identity seeding (activity-side)
+# ---------------------------------------------------------------------------
+
+
+class TestReadPodIdentity:
+    def test_reads_node_and_pod(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NODE_NAME", "n1")
+        monkeypatch.setenv("POD_NAME", "p1")
+        assert read_pod_identity() == {"node": "n1", "pod": "p1"}
+
+    def test_hostname_fallback_for_pod(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("POD_NAME", raising=False)
+        monkeypatch.setenv("HOSTNAME", "p-host")
+        monkeypatch.delenv("NODE_NAME", raising=False)
+        assert read_pod_identity() == {"pod": "p-host"}


### PR DESCRIPTION
## What

On a heartbeat timeout with **no preceding `WorkerEvicted`** - the signature of an abrupt worker kill (spot reclaim, OOMKill, node loss) - the workflow now diagnoses the cause out-of-band and records it, then re-raises the original failure unchanged.

This is the "abrupt kill" companion to the worker-eviction / SIGTERM handling (which covers the *graceful* case). It closes the gap that design names as unimplemented: abrupt kills surface only as heartbeat timeouts, with no recorded cause.

## Design

Full design, sequence diagrams, and fail-safe matrix live in **`docs/infra-failure-diagnosis.md`** (start there).

Flow: activity heartbeats `{node, pod}` → killed → Temporal raises `ActivityError(cause=TimeoutError.HEARTBEAT)` carrying the last heartbeat details → the workflow (on a live worker) decodes the location → runs a short `diagnose_infra_failure` activity → queries a **net-new infra-event service** → maps the verdict onto the SDK failure taxonomy → upserts an `infra_failure_cause` search attribute + structured log → re-raises.

## Scope: Phase 1 is attribution only

- **Additive and default-off** (`ATLAN_ENABLE_INFRA_FAILURE_DIAGNOSIS`). When off, `execute_activity_with_infra_diagnosis` is a byte-for-byte passthrough to the existing eviction-retry loop - zero behaviour change.
- Records the cause; **does not** reroute or change retry behaviour. Rerouting to an on-demand queue (Phase 2) needs a second worker pool that does not exist yet.
- Fails safe everywhere: any diagnosis error degrades to "record `NONE`, propagate the original error." Diagnosis can never fail, block, or alter a workflow beyond a search attribute + a log line.

## Wired vs. needs-wiring

**Wired (inert while the flag is off):** call-site wrapper (`base.py`), activity registration (`worker.py`), heartbeat identity seed (`activities.py`), config (`constants.py`).

**Needs wiring before it does anything** (see doc → "Wiring checklist"):
1. Build the infra-event service + implement `HttpInfraEventClient.lookup`
2. Fill `classify_infra_failure` (the one policy decision - deliberately a stub)
3. Register the `infra_failure_cause` Keyword search attribute on the namespace
4. Expose `NODE_NAME` / `POD_NAME` via the downward API
5. Set the flag

## For reviewers - open questions

- **`classify_infra_failure` policy**: is OOM `APP_OWNER` (a leak) or `PLATFORM` (undersized limits)? Left as a stub on purpose - it encodes ownership judgment, not mechanics.
- **Is attribution alone the right Phase 1?** It labels the spot/OOM retry-budget bleed but does not stop it (only Phase 2 rerouting does). Confirm this sequencing.
- **Identity carrier**: heartbeat-identity is wired; the worker-identity fallback (`{pod}@{node}`) is not, so a task that *manually* heartbeats progress would clobber the seeded identity. Acceptable, or wire worker identity now?

## Testing

- 24 new unit tests (`tests/unit/execution/test_infra_diagnosis.py`), including a temporalio `TimeoutError` contract pin so a future SDK upgrade fails loudly rather than regressing silently.
- Eviction regression suite green (14).
- pre-commit green (ruff, ruff-format, isort, pyright).
- **Caveat**: the search-attribute `upsert` is mocked in unit tests; the `SearchAttributeKey.value_set` round-trip needs a live-namespace check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
