### PR TITLE
fix(clients): trust custom CAs for requests-based vendor SDKs via REQUESTS_CA_BUNDLE

### DIFF
--- a/application_sdk/clients/__init__.py
+++ b/application_sdk/clients/__init__.py
@@ -20,6 +20,9 @@ from application_sdk.clients.models import DatabaseConfig as DatabaseConfig
 from application_sdk.clients.sql import AsyncBaseSQLClient as AsyncBaseSQLClient
 from application_sdk.clients.sql import BaseSQLClient as BaseSQLClient
 from application_sdk.clients.ssl_utils import (
+    configure_requests_ca_bundle as configure_requests_ca_bundle,
+)
+from application_sdk.clients.ssl_utils import (
     create_ssl_context_with_custom_certs as create_ssl_context_with_custom_certs,
 )
 from application_sdk.clients.ssl_utils import get_ssl_context as get_ssl_context
@@ -48,6 +51,7 @@ __all__ = [
     "DatabaseConfig",
     "RedisClient",
     "RedisClientAsync",
+    "configure_requests_ca_bundle",
     "create_ssl_context_with_custom_certs",
     "get_ssl_context",
 ]

--- a/application_sdk/clients/ssl_utils.py
+++ b/application_sdk/clients/ssl_utils.py
@@ -3,6 +3,7 @@
 import functools
 import os
 import ssl
+import tempfile
 
 from application_sdk.constants import SSL_CERT_DIR
 from application_sdk.observability.logger_adaptor import get_logger
@@ -245,3 +246,60 @@ def get_custom_ca_cert_bytes() -> bytes | None:
         len(combined_certs),
     )
     return combined_certs
+
+
+def configure_requests_ca_bundle() -> str | None:
+    """Point ``requests``-based clients at the combined default+custom CA bundle.
+
+    The SDK's own httpx/aiohttp clients trust custom CAs via
+    :func:`get_ssl_context`, and Temporal via :func:`get_custom_ca_cert_bytes`,
+    both driven by ``SSL_CERT_DIR``. But ``requests`` consults neither — it uses
+    the certifi bundle and only honours the ``REQUESTS_CA_BUNDLE`` /
+    ``CURL_CA_BUNDLE`` environment variables. Third-party vendor SDKs that
+    transport over ``requests`` (e.g. ``looker_sdk``) therefore never see a
+    mounted private CA and fail TLS verification against internal endpoints.
+
+    When ``SSL_CERT_DIR`` is configured, this writes the combined
+    default+custom bundle to a file and exports ``REQUESTS_CA_BUNDLE`` /
+    ``CURL_CA_BUNDLE`` so those clients trust both public and private CAs.
+    Because the bundle includes the system defaults, public TLS keeps working.
+
+    Call once at process startup. Idempotent, and a no-op when ``SSL_CERT_DIR``
+    is unset. An explicit operator-set ``REQUESTS_CA_BUNDLE`` is left untouched.
+
+    Returns:
+        The bundle path exported to the environment, or ``None`` when nothing
+        was configured.
+    """
+    existing = os.environ.get("REQUESTS_CA_BUNDLE")
+    if existing:
+        # Respect an explicit override (operator or a previous call).
+        return existing
+
+    ca_bytes = get_custom_ca_cert_bytes()
+    if not ca_bytes:
+        return None
+
+    bundle_dir = os.path.join(tempfile.gettempdir(), "atlan-ca")
+    bundle_path = os.path.join(bundle_dir, "combined-ca-bundle.pem")
+    try:
+        os.makedirs(bundle_dir, exist_ok=True)
+        with open(bundle_path, "wb") as f:
+            f.write(ca_bytes)
+    except OSError:
+        logger.warning(
+            "Failed to write combined CA bundle to %s; requests-based clients "
+            "will not trust custom CAs",
+            bundle_path,
+            exc_info=True,
+        )
+        return None
+
+    os.environ["REQUESTS_CA_BUNDLE"] = bundle_path
+    os.environ.setdefault("CURL_CA_BUNDLE", bundle_path)
+    logger.info(
+        "Exported REQUESTS_CA_BUNDLE for requests-based clients "
+        "(combined default+custom CA bundle): %s",
+        bundle_path,
+    )
+    return bundle_path

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -1584,6 +1584,17 @@ def run_main(config: AppConfig) -> None:
 
     warn_removed_env_vars()
 
+    # Export REQUESTS_CA_BUNDLE from the combined default+custom CA bundle when
+    # SSL_CERT_DIR is configured. httpx/aiohttp/Temporal already trust custom
+    # CAs via ssl_utils, but requests-based vendor SDKs (e.g. looker_sdk) read
+    # only REQUESTS_CA_BUNDLE — without this they fail TLS against internal
+    # endpoints fronted by a private CA. No-op when SSL_CERT_DIR is unset.
+    from application_sdk.clients.ssl_utils import (  # noqa: PLC0415 — cold path: startup-only SSL env setup
+        configure_requests_ca_bundle,
+    )
+
+    configure_requests_ca_bundle()
+
     # Bootstrap the global MeterProvider once per process so any meter
     # consumer (instrumentors, interceptors, decorators, …) resolves to the
     # configured provider. Without this, handler-mode /metrics serves only

--- a/tests/unit/clients/test_ssl_utils.py
+++ b/tests/unit/clients/test_ssl_utils.py
@@ -1,5 +1,6 @@
 """Tests for SSL utilities."""
 
+import os
 import ssl
 import tempfile
 from unittest.mock import patch
@@ -225,3 +226,75 @@ class TestGetCustomCaCertBytes:
                 assert b"-----BEGIN CERTIFICATE-----" in result
                 assert b"-----END CERTIFICATE-----" in result
                 assert result.count(b"-----BEGIN CERTIFICATE-----") > 1
+
+
+class TestConfigureRequestsCaBundle:
+    """Test cases for configure_requests_ca_bundle function."""
+
+    def test_noop_when_no_cert_dir(self, monkeypatch):
+        """Returns None and leaves env untouched when SSL_CERT_DIR is unset."""
+        monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+        monkeypatch.delenv("CURL_CA_BUNDLE", raising=False)
+        with patch("application_sdk.clients.ssl_utils.SSL_CERT_DIR", ""):
+            from application_sdk.clients.ssl_utils import configure_requests_ca_bundle
+
+            result = configure_requests_ca_bundle()
+            assert result is None
+            assert "REQUESTS_CA_BUNDLE" not in os.environ
+
+    def test_respects_existing_override(self, monkeypatch):
+        """An operator-set REQUESTS_CA_BUNDLE is left untouched."""
+        monkeypatch.setenv("REQUESTS_CA_BUNDLE", "/operator/set/bundle.pem")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(f"{tmpdir}/ca.pem", "wb") as f:
+                f.write(b"-----BEGIN CERTIFICATE-----\nX\n-----END CERTIFICATE-----")
+            with patch("application_sdk.clients.ssl_utils.SSL_CERT_DIR", tmpdir):
+                from application_sdk.clients.ssl_utils import (
+                    configure_requests_ca_bundle,
+                )
+
+                result = configure_requests_ca_bundle()
+                assert result == "/operator/set/bundle.pem"
+                assert os.environ["REQUESTS_CA_BUNDLE"] == "/operator/set/bundle.pem"
+
+    def test_exports_combined_bundle_when_cert_dir_set(self, monkeypatch):
+        """Writes the combined default+custom bundle and exports the env vars."""
+        monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+        monkeypatch.delenv("CURL_CA_BUNDLE", raising=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            custom_cert = (
+                b"-----BEGIN CERTIFICATE-----\nCUSTOM_ROOT\n-----END CERTIFICATE-----"
+            )
+            with open(f"{tmpdir}/ca.pem", "wb") as f:
+                f.write(custom_cert)
+            with patch("application_sdk.clients.ssl_utils.SSL_CERT_DIR", tmpdir):
+                from application_sdk.clients.ssl_utils import (
+                    configure_requests_ca_bundle,
+                )
+
+                result = configure_requests_ca_bundle()
+                assert result is not None
+                assert os.environ["REQUESTS_CA_BUNDLE"] == result
+                assert os.environ["CURL_CA_BUNDLE"] == result
+                with open(result, "rb") as f:
+                    written = f.read()
+                # Custom root present AND combined with system defaults.
+                assert b"CUSTOM_ROOT" in written
+                assert written.count(b"-----BEGIN CERTIFICATE-----") > 1
+
+    def test_idempotent(self, monkeypatch):
+        """A second call reuses the already-exported bundle path."""
+        monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+        monkeypatch.delenv("CURL_CA_BUNDLE", raising=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(f"{tmpdir}/ca.pem", "wb") as f:
+                f.write(b"-----BEGIN CERTIFICATE-----\nY\n-----END CERTIFICATE-----")
+            with patch("application_sdk.clients.ssl_utils.SSL_CERT_DIR", tmpdir):
+                from application_sdk.clients.ssl_utils import (
+                    configure_requests_ca_bundle,
+                )
+
+                first = configure_requests_ca_bundle()
+                second = configure_requests_ca_bundle()
+                assert first is not None
+                assert first == second


### PR DESCRIPTION
## Problem

When `SSL_CERT_DIR` is configured (a private/internal CA mounted into the runtime), the SDK's own **httpx/aiohttp** clients trust it via `get_ssl_context()`, and **Temporal** via `get_custom_ca_cert_bytes()`. But third-party vendor SDKs that transport over **`requests`** (e.g. `looker_sdk`) trust neither — `requests` uses the `certifi` bundle and consults only the `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE` env vars, never `SSL_CERT_DIR`.

Result: a connector talking to an internal endpoint fronted by a private CA fails preflight with `SSLError: CERTIFICATE_VERIFY_FAILED: self-signed certificate in certificate chain`, even though the CA is correctly mounted — surfaced during a recent self-deployed-runtime RCA.

## Root cause

`requests` ignores `SSL_CERT_DIR` and the SDK never exported `REQUESTS_CA_BUNDLE`, so the mounted CA was invisible to any `requests`-based client.

## Fix

Add `configure_requests_ca_bundle()` in `clients/ssl_utils.py`:
- when `SSL_CERT_DIR` is set, materialise the **combined default + custom** bundle (reusing `get_custom_ca_cert_bytes()`) to a file and export `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE`;
- because the bundle includes the system defaults, **public TLS keeps working** (this is why we don't point the env var at the raw mount, which would replace trust and break public endpoints);
- no-op when `SSL_CERT_DIR` is unset; an explicit operator-set `REQUESTS_CA_BUNDLE` is preserved.

Called once per process at the start of `run_main()`, so every mode (worker/handler/combined) and every `requests`-based vendor SDK inherits the trust automatically — no per-connector change needed.

## Testing

- `tests/unit/clients/test_ssl_utils.py`: added `TestConfigureRequestsCaBundle` (no-op when unset, respects operator override, exports the combined bundle, idempotent). Full file: 22 passed.
- `pre-commit run` on all changed files: ruff / ruff-format / isort / pyright pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)