### PR TITLE
[Parked — superseded by AUT-1052] feat(contract-toolkit): default notifications on for connector and miner apps

### DIFF
--- a/contract-toolkit/examples/agent-e2e/app/generated/manifest.json
+++ b/contract-toolkit/examples/agent-e2e/app/generated/manifest.json
@@ -19,6 +19,44 @@
           "agent_json": "{{agent-json}}"
         }
       }
+    },
+    "notifications": {
+      "activity_name": "execute_workflow",
+      "activity_display_name": "Notify on workflow completion",
+      "app_name": "notification-app",
+      "inputs": {
+        "workflow_type": "NotificationWorkflow",
+        "app_name": "notification-app",
+        "task_queue": "atlan-notification-app-{deployment_name}",
+        "args": {
+          "metadata": {
+            "notification_type": "workflow_completion_alert",
+            "workflow_name": "$.workflow.name",
+            "workflow_qualified_name": "$.workflow.qualified_name",
+            "workflow_slug": "$.workflow.slug",
+            "connector": "$.workflow.connector",
+            "status": "$.workflow.status",
+            "started_at": "$.workflow.started_at",
+            "completed_at": "$.workflow.completed_at",
+            "duration_ms": "$.workflow.duration_ms",
+            "schedule": "$.workflow.schedule",
+            "next_run_time": "$.workflow.next_run_time",
+            "last_runs": "$.workflow.last_runs",
+            "creator_name": "$.workflow.creator_name",
+            "modified_by_name": "$.workflow.modified_by_name",
+            "run_details_url": "$.workflow.run_url",
+            "workflow_run_guid": "$.workflow.run_id",
+            "error_message": "$.failure.message",
+            "error_category": "$.failure.category",
+            "suggested_action": "$.failure.suggested_action",
+            "failed_node_id": "$.failure.node_id",
+            "failed_activity": "$.failure.activity"
+          }
+        }
+      },
+      "depends_on": {
+        "tag": "workflow_complete"
+      }
     }
   }
 }

--- a/contract-toolkit/examples/bundle/app/generated/crawler/manifest.json
+++ b/contract-toolkit/examples/bundle/app/generated/crawler/manifest.json
@@ -49,6 +49,44 @@
       "error_handling": {
         "start_to_close_timeout_seconds": 259200
       }
+    },
+    "notifications": {
+      "activity_name": "execute_workflow",
+      "activity_display_name": "Notify on workflow completion",
+      "app_name": "notification-app",
+      "inputs": {
+        "workflow_type": "NotificationWorkflow",
+        "app_name": "notification-app",
+        "task_queue": "atlan-notification-app-{deployment_name}",
+        "args": {
+          "metadata": {
+            "notification_type": "workflow_completion_alert",
+            "workflow_name": "$.workflow.name",
+            "workflow_qualified_name": "$.workflow.qualified_name",
+            "workflow_slug": "$.workflow.slug",
+            "connector": "$.workflow.connector",
+            "status": "$.workflow.status",
+            "started_at": "$.workflow.started_at",
+            "completed_at": "$.workflow.completed_at",
+            "duration_ms": "$.workflow.duration_ms",
+            "schedule": "$.workflow.schedule",
+            "next_run_time": "$.workflow.next_run_time",
+            "last_runs": "$.workflow.last_runs",
+            "creator_name": "$.workflow.creator_name",
+            "modified_by_name": "$.workflow.modified_by_name",
+            "run_details_url": "$.workflow.run_url",
+            "workflow_run_guid": "$.workflow.run_id",
+            "error_message": "$.failure.message",
+            "error_category": "$.failure.category",
+            "suggested_action": "$.failure.suggested_action",
+            "failed_node_id": "$.failure.node_id",
+            "failed_activity": "$.failure.activity"
+          }
+        }
+      },
+      "depends_on": {
+        "tag": "workflow_complete"
+      }
     }
   }
 }

--- a/contract-toolkit/examples/bundle/app/generated/miner/manifest.json
+++ b/contract-toolkit/examples/bundle/app/generated/miner/manifest.json
@@ -19,6 +19,44 @@
           "max_queries": "{{max-queries}}"
         }
       }
+    },
+    "notifications": {
+      "activity_name": "execute_workflow",
+      "activity_display_name": "Notify on workflow completion",
+      "app_name": "notification-app",
+      "inputs": {
+        "workflow_type": "NotificationWorkflow",
+        "app_name": "notification-app",
+        "task_queue": "atlan-notification-app-{deployment_name}",
+        "args": {
+          "metadata": {
+            "notification_type": "workflow_completion_alert",
+            "workflow_name": "$.workflow.name",
+            "workflow_qualified_name": "$.workflow.qualified_name",
+            "workflow_slug": "$.workflow.slug",
+            "connector": "$.workflow.connector",
+            "status": "$.workflow.status",
+            "started_at": "$.workflow.started_at",
+            "completed_at": "$.workflow.completed_at",
+            "duration_ms": "$.workflow.duration_ms",
+            "schedule": "$.workflow.schedule",
+            "next_run_time": "$.workflow.next_run_time",
+            "last_runs": "$.workflow.last_runs",
+            "creator_name": "$.workflow.creator_name",
+            "modified_by_name": "$.workflow.modified_by_name",
+            "run_details_url": "$.workflow.run_url",
+            "workflow_run_guid": "$.workflow.run_id",
+            "error_message": "$.failure.message",
+            "error_category": "$.failure.category",
+            "suggested_action": "$.failure.suggested_action",
+            "failed_node_id": "$.failure.node_id",
+            "failed_activity": "$.failure.activity"
+          }
+        }
+      },
+      "depends_on": {
+        "tag": "workflow_complete"
+      }
     }
   }
 }

--- a/contract-toolkit/examples/connection-ref/app/generated/manifest.json
+++ b/contract-toolkit/examples/connection-ref/app/generated/manifest.json
@@ -18,6 +18,44 @@
           "connections": "{{connections}}"
         }
       }
+    },
+    "notifications": {
+      "activity_name": "execute_workflow",
+      "activity_display_name": "Notify on workflow completion",
+      "app_name": "notification-app",
+      "inputs": {
+        "workflow_type": "NotificationWorkflow",
+        "app_name": "notification-app",
+        "task_queue": "atlan-notification-app-{deployment_name}",
+        "args": {
+          "metadata": {
+            "notification_type": "workflow_completion_alert",
+            "workflow_name": "$.workflow.name",
+            "workflow_qualified_name": "$.workflow.qualified_name",
+            "workflow_slug": "$.workflow.slug",
+            "connector": "$.workflow.connector",
+            "status": "$.workflow.status",
+            "started_at": "$.workflow.started_at",
+            "completed_at": "$.workflow.completed_at",
+            "duration_ms": "$.workflow.duration_ms",
+            "schedule": "$.workflow.schedule",
+            "next_run_time": "$.workflow.next_run_time",
+            "last_runs": "$.workflow.last_runs",
+            "creator_name": "$.workflow.creator_name",
+            "modified_by_name": "$.workflow.modified_by_name",
+            "run_details_url": "$.workflow.run_url",
+            "workflow_run_guid": "$.workflow.run_id",
+            "error_message": "$.failure.message",
+            "error_category": "$.failure.category",
+            "suggested_action": "$.failure.suggested_action",
+            "failed_node_id": "$.failure.node_id",
+            "failed_activity": "$.failure.activity"
+          }
+        }
+      },
+      "depends_on": {
+        "tag": "workflow_complete"
+      }
     }
   }
 }

--- a/contract-toolkit/examples/deploy/app/generated/manifest.json
+++ b/contract-toolkit/examples/deploy/app/generated/manifest.json
@@ -17,6 +17,44 @@
           "target": "{{target}}"
         }
       }
+    },
+    "notifications": {
+      "activity_name": "execute_workflow",
+      "activity_display_name": "Notify on workflow completion",
+      "app_name": "notification-app",
+      "inputs": {
+        "workflow_type": "NotificationWorkflow",
+        "app_name": "notification-app",
+        "task_queue": "atlan-notification-app-{deployment_name}",
+        "args": {
+          "metadata": {
+            "notification_type": "workflow_completion_alert",
+            "workflow_name": "$.workflow.name",
+            "workflow_qualified_name": "$.workflow.qualified_name",
+            "workflow_slug": "$.workflow.slug",
+            "connector": "$.workflow.connector",
+            "status": "$.workflow.status",
+            "started_at": "$.workflow.started_at",
+            "completed_at": "$.workflow.completed_at",
+            "duration_ms": "$.workflow.duration_ms",
+            "schedule": "$.workflow.schedule",
+            "next_run_time": "$.workflow.next_run_time",
+            "last_runs": "$.workflow.last_runs",
+            "creator_name": "$.workflow.creator_name",
+            "modified_by_name": "$.workflow.modified_by_name",
+            "run_details_url": "$.workflow.run_url",
+            "workflow_run_guid": "$.workflow.run_id",
+            "error_message": "$.failure.message",
+            "error_category": "$.failure.category",
+            "suggested_action": "$.failure.suggested_action",
+            "failed_node_id": "$.failure.node_id",
+            "failed_activity": "$.failure.activity"
+          }
+        }
+      },
+      "depends_on": {
+        "tag": "workflow_complete"
+      }
     }
   }
 }

--- a/contract-toolkit/examples/fanin/app/generated/manifest.json
+++ b/contract-toolkit/examples/fanin/app/generated/manifest.json
@@ -120,6 +120,44 @@
           }
         ]
       }
+    },
+    "notifications": {
+      "activity_name": "execute_workflow",
+      "activity_display_name": "Notify on workflow completion",
+      "app_name": "notification-app",
+      "inputs": {
+        "workflow_type": "NotificationWorkflow",
+        "app_name": "notification-app",
+        "task_queue": "atlan-notification-app-{deployment_name}",
+        "args": {
+          "metadata": {
+            "notification_type": "workflow_completion_alert",
+            "workflow_name": "$.workflow.name",
+            "workflow_qualified_name": "$.workflow.qualified_name",
+            "workflow_slug": "$.workflow.slug",
+            "connector": "$.workflow.connector",
+            "status": "$.workflow.status",
+            "started_at": "$.workflow.started_at",
+            "completed_at": "$.workflow.completed_at",
+            "duration_ms": "$.workflow.duration_ms",
+            "schedule": "$.workflow.schedule",
+            "next_run_time": "$.workflow.next_run_time",
+            "last_runs": "$.workflow.last_runs",
+            "creator_name": "$.workflow.creator_name",
+            "modified_by_name": "$.workflow.modified_by_name",
+            "run_details_url": "$.workflow.run_url",
+            "workflow_run_guid": "$.workflow.run_id",
+            "error_message": "$.failure.message",
+            "error_category": "$.failure.category",
+            "suggested_action": "$.failure.suggested_action",
+            "failed_node_id": "$.failure.node_id",
+            "failed_activity": "$.failure.activity"
+          }
+        }
+      },
+      "depends_on": {
+        "tag": "workflow_complete"
+      }
     }
   }
 }

--- a/contract-toolkit/examples/minimal/app/generated/manifest.json
+++ b/contract-toolkit/examples/minimal/app/generated/manifest.json
@@ -17,6 +17,44 @@
           "target": "{{target}}"
         }
       }
+    },
+    "notifications": {
+      "activity_name": "execute_workflow",
+      "activity_display_name": "Notify on workflow completion",
+      "app_name": "notification-app",
+      "inputs": {
+        "workflow_type": "NotificationWorkflow",
+        "app_name": "notification-app",
+        "task_queue": "atlan-notification-app-{deployment_name}",
+        "args": {
+          "metadata": {
+            "notification_type": "workflow_completion_alert",
+            "workflow_name": "$.workflow.name",
+            "workflow_qualified_name": "$.workflow.qualified_name",
+            "workflow_slug": "$.workflow.slug",
+            "connector": "$.workflow.connector",
+            "status": "$.workflow.status",
+            "started_at": "$.workflow.started_at",
+            "completed_at": "$.workflow.completed_at",
+            "duration_ms": "$.workflow.duration_ms",
+            "schedule": "$.workflow.schedule",
+            "next_run_time": "$.workflow.next_run_time",
+            "last_runs": "$.workflow.last_runs",
+            "creator_name": "$.workflow.creator_name",
+            "modified_by_name": "$.workflow.modified_by_name",
+            "run_details_url": "$.workflow.run_url",
+            "workflow_run_guid": "$.workflow.run_id",
+            "error_message": "$.failure.message",
+            "error_category": "$.failure.category",
+            "suggested_action": "$.failure.suggested_action",
+            "failed_node_id": "$.failure.node_id",
+            "failed_activity": "$.failure.activity"
+          }
+        }
+      },
+      "depends_on": {
+        "tag": "workflow_complete"
+      }
     }
   }
 }

--- a/contract-toolkit/examples/publish-controls/app/generated/manifest.json
+++ b/contract-toolkit/examples/publish-controls/app/generated/manifest.json
@@ -52,6 +52,44 @@
       "error_handling": {
         "start_to_close_timeout_seconds": 14400
       }
+    },
+    "notifications": {
+      "activity_name": "execute_workflow",
+      "activity_display_name": "Notify on workflow completion",
+      "app_name": "notification-app",
+      "inputs": {
+        "workflow_type": "NotificationWorkflow",
+        "app_name": "notification-app",
+        "task_queue": "atlan-notification-app-{deployment_name}",
+        "args": {
+          "metadata": {
+            "notification_type": "workflow_completion_alert",
+            "workflow_name": "$.workflow.name",
+            "workflow_qualified_name": "$.workflow.qualified_name",
+            "workflow_slug": "$.workflow.slug",
+            "connector": "$.workflow.connector",
+            "status": "$.workflow.status",
+            "started_at": "$.workflow.started_at",
+            "completed_at": "$.workflow.completed_at",
+            "duration_ms": "$.workflow.duration_ms",
+            "schedule": "$.workflow.schedule",
+            "next_run_time": "$.workflow.next_run_time",
+            "last_runs": "$.workflow.last_runs",
+            "creator_name": "$.workflow.creator_name",
+            "modified_by_name": "$.workflow.modified_by_name",
+            "run_details_url": "$.workflow.run_url",
+            "workflow_run_guid": "$.workflow.run_id",
+            "error_message": "$.failure.message",
+            "error_category": "$.failure.category",
+            "suggested_action": "$.failure.suggested_action",
+            "failed_node_id": "$.failure.node_id",
+            "failed_activity": "$.failure.activity"
+          }
+        }
+      },
+      "depends_on": {
+        "tag": "workflow_complete"
+      }
     }
   }
 }

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -305,17 +305,22 @@ extraNodes: Mapping<String, DAGNode> = new Mapping {}
 /// When `true`, appends a run-level notification node (`NotificationNode`, key
 /// `notifications`) that fires once when the workflow run reaches any
 /// terminal state (success or failure) and dispatches the notification app to
-/// fan alerts out to the tenant's enabled integrations (Teams, etc.). The
+/// fan alerts out to the tenant's enabled integrations (Teams, Slack, etc.). The
 /// notification app decides delivery per integration via its
 /// `alertsWorkflowChannel.failureOnly` config (failure-only vs. all runs) — so
 /// this flag is purely the broad app-level switch; *which* runs and *which*
 /// channels are the customer's call.
 ///
-/// Default `false`, so apps must explicitly opt in with `notifications = true`
-/// before the generated manifest includes the notification node. Override the
-/// node by defining `extraNodes["notifications"]`, which suppresses the
-/// toolkit-generated node.
-notifications: Boolean = false
+/// Defaults ON for customer-facing data apps (`type` `connector` or `miner`) and
+/// OFF for everything else (internal/infra apps: `utility`, `system`, studios,
+/// …). This restores the pre-AE-migration behavior where connector/miner runs
+/// alerted by default, without turning notifications on for internal apps (e.g.
+/// the notification app itself, a `utility`, must not self-notify). Delivery is
+/// still fully customer-gated: no enabled integration → nothing is sent.
+///
+/// Override per app: set `notifications = true` / `false` explicitly, or define
+/// `extraNodes["notifications"]` to replace the toolkit-generated node.
+notifications: Boolean = List("connector", "miner").contains(type.toLowerCase())
 
 /// Mapping of manifest arg name → form field name for top-level extract args.
 manifestTopLevelArgs: Mapping<String, String> = new Mapping {

--- a/contract-toolkit/tests/fixtures/notify_miner_default.pkl
+++ b/contract-toolkit/tests/fixtures/notify_miner_default.pkl
@@ -1,0 +1,23 @@
+/// Fixture: a `miner` app that does NOT set `notifications`.
+///
+/// Exercises the connector/miner-gated default: miner apps (like connectors)
+/// get the run-level notification node by default, no explicit opt-in needed.
+amends "../../src/App.pkl"
+
+name = "notify-miner-default"
+displayName = "Notify Miner Default"
+icon = "https://assets.atlan.com/assets/fullscreen-exit.svg"
+hasCredentialConfig = false
+type = "miner"
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs {
+        ["connection"] = new ConnectionCreator {
+          placeholderText = "Connection Name"
+        }
+      }
+    }
+  }
+}

--- a/contract-toolkit/tests/fixtures/notify_utility_default.pkl
+++ b/contract-toolkit/tests/fixtures/notify_utility_default.pkl
@@ -1,0 +1,23 @@
+/// Fixture: an internal (`utility`) app that does NOT set `notifications`.
+///
+/// Exercises the connector/miner-gated default: internal/infra app types get
+/// no notification node unless they explicitly opt in with `notifications = true`.
+amends "../../src/App.pkl"
+
+name = "notify-utility-default"
+displayName = "Notify Utility Default"
+icon = "https://assets.atlan.com/assets/fullscreen-exit.svg"
+hasCredentialConfig = false
+type = "utility"
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs {
+        ["connection"] = new ConnectionCreator {
+          placeholderText = "Connection Name"
+        }
+      }
+    }
+  }
+}

--- a/contract-toolkit/tests/notifications_test.pkl
+++ b/contract-toolkit/tests/notifications_test.pkl
@@ -1,8 +1,10 @@
 // Tests for the built-in run-level notification node (NotificationNode) and the
 // `notifications` app-level on/off toggle.
 //
-// Background: apps can opt in to workflow-run alerts by setting
-// `notifications = true`. The toolkit then appends a `notifications`
+// Background: notifications default ON for customer-facing data apps (`type`
+// `connector` or `miner`) and OFF for everything else (internal/infra apps); any
+// app can override with an explicit `notifications = true`/`false`. When on, the
+// toolkit appends a `notifications`
 // finalizer node that depends on the reserved run-level `workflow_complete` tag
 // (a node-less DependencyCondition) so Automation Engine runs it once per run on
 // any terminal state (success or failure), carrying the real status, and
@@ -17,6 +19,8 @@ import "pkl:json"
 import "../examples/full/app.pkl" as enabledApp
 import "fixtures/default_pipeline.pkl" as defaultApp
 import "fixtures/notify_disabled.pkl" as disabledApp
+import "fixtures/notify_utility_default.pkl" as utilityApp
+import "fixtures/notify_miner_default.pkl" as minerApp
 import "../src/App.pkl" as App
 
 // App that retargets the notify node via extraNodes (replaces the default).
@@ -47,11 +51,24 @@ local overrideApp = (App) {
   }
 }
 
-// Default app (no pipeline block, notifications defaults false).
+// Default app (no pipeline block, no explicit `notifications`). Its `type`
+// inherits the toolkit default `connector`, so notifications are ON by default.
 local defaultManifest = new json.Parser { useMapping = true }.parse(
   defaultApp.output.files["app/generated/manifest.json"].text
 )
 local defaultDag = defaultManifest["dag"]
+
+// Internal (utility) app, no explicit `notifications` → OFF by default.
+local utilityManifest = new json.Parser { useMapping = true }.parse(
+  utilityApp.output.files["app/generated/manifest.json"].text
+)
+local utilityDag = utilityManifest["dag"]
+
+// Miner app, no explicit `notifications` → ON by default (like a connector).
+local minerManifest = new json.Parser { useMapping = true }.parse(
+  minerApp.output.files["app/generated/manifest.json"].text
+)
+local minerDag = minerManifest["dag"]
 
 // Existing full example opts in (notifications = true).
 local enabledManifest = new json.Parser { useMapping = true }.parse(
@@ -74,11 +91,19 @@ local overrideNode = overrideManifest["dag"]["notifications"]
 
 facts {
   // -----------------------------------------------------------------------
-  // Default: the node is absent unless the app opts in.
+  // Default is gated on app `type`: connector/miner ON, everything else OFF.
   // -----------------------------------------------------------------------
 
-  ["App with no pipeline declaration does not get a notifications node by default"] {
-    !defaultDag.containsKey("notifications")
+  ["Connector app gets a notifications node by default (no explicit opt-in)"] {
+    defaultDag.containsKey("notifications")
+  }
+
+  ["Miner app gets a notifications node by default"] {
+    minerDag.containsKey("notifications")
+  }
+
+  ["Internal (utility) app has no notifications node by default"] {
+    !utilityDag.containsKey("notifications")
   }
 
   ["App with notifications=true gets a notifications node"] {


### PR DESCRIPTION
## Why

Notifications was opt-in in the contract toolkit (`notifications: Boolean = false`). Every app migrated to Automation Engine therefore **silently lost** the workflow-failure alerts the legacy Argo pipeline used to send by default — the ARUN-619 / AUT-1017 cohort (Gravie, Fivetran, Rightworks, …), now surfacing as customer escalations for migrated V3 apps.

Slack context: [thread](https://atlanhq.slack.com/archives/C09NMHGRSLT/p1782972594278779) — decision to flip the default, keeping internal apps off.

## What

Gate the default on app `type` instead of a blanket flag:

```pkl
notifications: Boolean = List("connector", "miner").contains(type.toLowerCase())
```

- **ON by default** for customer-facing data apps: `type` = `connector` or `miner`.
- **OFF by default** for everything else (internal/infra: `utility`, `system`, studios, …) — including **`atlan-notification-app` itself** (a `utility`, which must not self-notify).
- **No per-app opt-out needed** for internal apps — they're excluded by type.
- Still fully overridable: `notifications = true`/`false`, or `extraNodes["notifications"]`.
- Delivery remains **customer-gated**: the node only dispatches; the notification app fans out only to the tenant's *enabled* integrations and honors `alertsWorkflowChannel.failureOnly`. No integration → nothing sent.

Design chosen from a survey of all 167 `atlanhq/*-app` repos: `type == "connector"` is a clean signal (81 connectors, none mislabeled); internal apps are spread across `utility`/`system`/etc.; `visibility` is unusable (124 public, incl. internal apps). `miner` added because miners are customer-facing data apps too.

## Tests

- `notifications_test.pkl`: reworked default facts → connector **and** miner apps get the node by default; internal (utility) app does **not**; explicit `notifications=false` and `extraNodes` override still honored. New fixtures `notify_utility_default.pkl`, `notify_miner_default.pkl`.
- Full toolkit suite: **215 pkl tests pass**; `check-invariants.sh` passes.
- Regenerated the 8 connector/miner example manifests (each purely gains the notifications node; no other diffs).

## Follow-up (not in this PR)

- **`atlan-generic-miner-app` is currently typed `utility`**, so it won't be caught by the miner gate — it should be retyped to `type = "miner"` (correct taxonomy) or set `notifications = true` explicitly. (`atlan-query-intelligence-app` is already `type = connector`, so it's covered.)
- Apps pick this up on their next contract-toolkit bump + regenerate + redeploy.
- Card-quality fixes that pair with this: duration (atlan-automation-engine-app #1009) and timestamp formatting + Slack provider (atlan-notification-app #9).

Validated end-to-end on ai-steward: an Athena (connector) run's notify finalizer fanned out to Teams ✅ and Slack ✅.