### PR TITLE
feat(errors): add SourceUnavailableError for customer-controlled source systems

### DIFF
--- a/.claude/skills/signal-over-noise/references/error-recovery-patterns.md
+++ b/.claude/skills/signal-over-noise/references/error-recovery-patterns.md
@@ -410,7 +410,7 @@ Mechanical fixes per category. Apply exactly — don't over-engineer.
 the replacement **must** use a typed `AppError` subclass from
 `application_sdk.errors`. See
 [`typed-error-prescription.md`](typed-error-prescription.md) for the full
-catalogue (14 SDK leaves), litmus tests, SDK-context cookbook (§4), the
+catalogue (15 SDK leaves), litmus tests, SDK-context cookbook (§4), the
 exhaustive legacy `AtlanError` → `AppError` migration table (§5), and the
 mandatory `cause`/`from` rules (§6). **Never** propose raising bare
 `Exception` / `ValueError` / `RuntimeError`; **never** propose raising legacy

--- a/.claude/skills/signal-over-noise/references/typed-error-prescription.md
+++ b/.claude/skills/signal-over-noise/references/typed-error-prescription.md
@@ -40,7 +40,7 @@ FailureDetails(
 
 ---
 
-## §2 — The 14 SDK leaves
+## §2 — The 15 SDK leaves
 
 All defined in `application_sdk/errors/leaves.py`. Import path:
 `from application_sdk.errors import <Leaf>`.
@@ -60,7 +60,8 @@ subclass a leaf and override `code` — never add a new category value.
 | `AlreadyExistsError` | ALREADY_EXISTS | USER | False | Entity the caller tried to create already exists (idempotent-create path) |
 | `InvalidInputError` | INVALID_INPUT | USER | False | Argument or payload malformed irrespective of system state |
 | `PreconditionError` | PRECONDITION | USER | False | Inputs syntactically valid but system state forbids the action |
-| `DependencyUnavailableError` | DEPENDENCY_UNAVAILABLE | **PLATFORM** | **True** | Required platform service down or degraded (Dapr, Temporal, object store, source DB) |
+| `DependencyUnavailableError` | DEPENDENCY_UNAVAILABLE | **PLATFORM** | **True** | Required platform service down or degraded (Dapr, Temporal, object store) |
+| `SourceUnavailableError` | SOURCE_UNAVAILABLE | USER | **True** | Customer-controlled source system unreachable (their DB, SaaS API, on-prem endpoint) |
 | `ResourceExhaustedError` | RESOURCE_EXHAUSTED | **PLATFORM** | **True** | Local resource limit hit (OOM, disk full, file handles, worker slots) |
 | `DataIntegrityError` | DATA_INTEGRITY | APP_OWNER | False | Returned data is corrupt or violates expected invariants |
 | `InternalError` | INTERNAL | APP_OWNER | False | SDK or app bug; invariant broken in our code |
@@ -75,8 +76,11 @@ a general pattern: do not use string-typed `ApplicationError` for anything else,
 and do not model new failure types on this approach.
 
 **`audience` override pattern** — when an SDK base default doesn't fit the locus,
-override `audience` on a minimal subclass. For connector apps, the source-side
-network is `audience=USER` (the customer controls it), so they override in their
+override `audience` on a minimal subclass. For an unreachable *source* system,
+prefer `SourceUnavailableError` (already `audience=USER`) over overriding
+`DependencyUnavailableError`. The override pattern still applies where no leaf
+fits the locus — e.g. a source-side read timeout is an `AppTimeoutError` whose
+default `APP_OWNER` should be overridden to `USER` in the connector's
 `failures.py`. The SDK's own code should follow the same logic.
 
 ---
@@ -347,21 +351,26 @@ available.
 
 ### Network unreachable / 5xx from source
 
+The source system is customer-owned (their database, SaaS API, on-prem
+endpoint), so its outage is the customer's to fix — raise
+`SourceUnavailableError`, which already defaults to `audience=USER`:
+
 ```python
-raise DependencyUnavailableError(
+raise SourceUnavailableError(
     message="Source database unreachable",
-    service="source_db",
-    target=host,
+    source_type="postgres",
+    endpoint=host,
     cause=exc,
 ) from exc
 ```
-Subclass code: `DEPENDENCY_UNAVAILABLE_NETWORK`. Audience: default PLATFORM.
+Subclass code: `SOURCE_UNAVAILABLE_NETWORK`. Audience: default USER; retryable by
+default. For a SaaS source returning 5xx, set `http_status=` from the response.
 `cause=exc` routes the exception detail through `cause_repr` automatically — do
-not also set `network_error=str(exc)` as that duplicates what `cause_repr` already
+not also set `network_error=str(exc)`, which duplicates what `cause_repr` already
 carries.
-**Override to USER** when the unreachable host is the customer's own source
-(their firewall / VPC). Add `audience: ClassVar[Audience] = Audience.USER`
-on a minimal subclass if doing this consistently.
+
+Reserve `DependencyUnavailableError` (audience PLATFORM) for Atlan-internal
+platform outages — see the next entry.
 
 ---
 

--- a/.claude/skills/typed-failures/SKILL.md
+++ b/.claude/skills/typed-failures/SKILL.md
@@ -30,7 +30,7 @@ outputs:
   - pyproject.toml (SDK pin bump to >= v3.7.0 if needed)
   - blind-spot report (printed, not committed — phase-2 punch list)
 gates:
-  - "All 14 SDK-provided leaves come from application_sdk.errors. Apps may not invent new categories — only subclass leaves."
+  - "All 15 SDK-provided leaves come from application_sdk.errors. Apps may not invent new categories — only subclass leaves."
   - "Codes follow <CATEGORY>_<SPECIFIC>, connector-agnostic. No vendor name in code."
   - "No logic / control-flow changes unless explicitly approved. Silent-swallow paths report as phase-2 unless owner approves promotion."
 ---
@@ -83,7 +83,7 @@ owner sign-off — surface it in the phase-2 report instead.
 
 ---
 
-## SDK contract — the 14 leaves you may subclass
+## SDK contract — the 15 leaves you may subclass
 
 All leaves are defined in `application_sdk.errors`. **You may not invent new
 categories.** Apps subclass these and override `code` (per the convention below)
@@ -100,7 +100,8 @@ and optionally `audience` (when the locus differs from the SDK base default).
 | `AlreadyExistsError` | ALREADY_EXISTS | USER | False | Idempotent-create conflict |
 | `InvalidInputError` | INVALID_INPUT | USER | False | Argument / payload malformed regardless of system state |
 | `PreconditionError` | PRECONDITION | USER | False | Inputs valid but state forbids action (schema mismatch, version conflict) |
-| `DependencyUnavailableError` | DEPENDENCY_UNAVAILABLE | PLATFORM | **True** | Required service down (Dapr, Temporal, object store, source DB) |
+| `DependencyUnavailableError` | DEPENDENCY_UNAVAILABLE | PLATFORM | **True** | Required service down (Dapr, Temporal, object store) |
+| `SourceUnavailableError` | SOURCE_UNAVAILABLE | USER | **True** | Customer-controlled source system unreachable (their DB, SaaS API, on-prem endpoint) |
 | `ResourceExhaustedError` | RESOURCE_EXHAUSTED | PLATFORM | **True** | Local resource limit (OOM, disk full, file handles) |
 | `DataIntegrityError` | DATA_INTEGRITY | APP_OWNER | False | Returned data corrupt / violates invariants |
 | `InternalError` | INTERNAL | APP_OWNER | False | App / SDK bug, invariant broken |
@@ -210,6 +211,12 @@ class AthenaSourceUnreachable(DependencyUnavailableError):
     code: ClassVar[str] = "DEPENDENCY_UNAVAILABLE_NETWORK"
     audience: ClassVar[Audience] = Audience.USER
 ```
+
+**Note:** new code for an *unreachable* source raises `SourceUnavailableError`
+directly (already `audience=USER`), so no override is needed. The override
+pattern above still applies where no leaf fits the locus — e.g. a source-side
+*timeout* is an `AppTimeoutError` whose `APP_OWNER` default you override to
+`USER`.
 
 If you're tempted to override `audience` more than once or twice per app,
 re-check the SDK base default — most apps don't need to override at all.

--- a/application_sdk/errors/__init__.py
+++ b/application_sdk/errors/__init__.py
@@ -36,13 +36,13 @@ from application_sdk.errors.leaves import (
     CancelledError,
     DataIntegrityError,
     DependencyUnavailableError,
-    SourceUnavailableError,
     InternalError,
     InvalidInputError,
     NotFoundError,
     PreconditionError,
     RateLimitedError,
     ResourceExhaustedError,
+    SourceUnavailableError,
     UnimplementedError,
 )
 from application_sdk.errors.wire import FailureDetails

--- a/application_sdk/errors/__init__.py
+++ b/application_sdk/errors/__init__.py
@@ -12,7 +12,8 @@ Canonical API (v3.x+)::
         NotFoundError, AlreadyExistsError,
         InvalidInputError, PreconditionError,
         RateLimitedError, UnimplementedError,
-        DependencyUnavailableError, ResourceExhaustedError,
+        DependencyUnavailableError, SourceUnavailableError,
+        ResourceExhaustedError,
         DataIntegrityError, CancelledError, InternalError,
     )
 
@@ -35,6 +36,7 @@ from application_sdk.errors.leaves import (
     CancelledError,
     DataIntegrityError,
     DependencyUnavailableError,
+    SourceUnavailableError,
     InternalError,
     InvalidInputError,
     NotFoundError,
@@ -131,6 +133,7 @@ __all__ = [
     "CancelledError",
     "DataIntegrityError",
     "DependencyUnavailableError",
+    "SourceUnavailableError",
     "InternalError",
     "InvalidInputError",
     "NotFoundError",

--- a/application_sdk/errors/categories.py
+++ b/application_sdk/errors/categories.py
@@ -9,6 +9,9 @@ class FailureCategory(Enum):
     Every value maps to exactly one "what happened" — pick the most specific
     one that applies.  When two categories could apply, use these litmus tests:
 
+    - ``SOURCE_UNAVAILABLE`` vs ``DEPENDENCY_UNAVAILABLE``: SOURCE_UNAVAILABLE is for
+      customer-controlled source systems (their DB, SaaS API); DEPENDENCY_UNAVAILABLE is
+      for Atlan-internal platform services (Dapr, Temporal, object store).
     - ``DEPENDENCY_UNAVAILABLE`` vs ``PRECONDITION``: if retrying *the same call*
       without any state change is expected to succeed, use DEPENDENCY_UNAVAILABLE.
       If explicit state must change before the call can succeed, use PRECONDITION.
@@ -52,8 +55,18 @@ class FailureCategory(Enum):
     use DEPENDENCY_UNAVAILABLE if the same call would succeed on retry."""
 
     DEPENDENCY_UNAVAILABLE = "DEPENDENCY_UNAVAILABLE"
-    """Required platform service down or degraded (Dapr, Temporal, object store, source DB).
-    Retrying the same call is expected to succeed; use PRECONDITION if state must change first."""
+    """Required Atlan-internal service down or degraded (Dapr, Temporal, object store).
+    Retrying the same call is expected to succeed; use PRECONDITION if state must change first.
+    For customer-controlled source systems (databases, SaaS APIs), use SOURCE_UNAVAILABLE."""
+
+    SOURCE_UNAVAILABLE = "SOURCE_UNAVAILABLE"
+    """Customer-controlled source system is temporarily unreachable (database, SaaS API, on-prem
+    endpoint).  The connector cannot connect or the source returned a transient server-side error.
+    Retrying is expected to succeed once the source recovers.
+
+    Litmus test vs DEPENDENCY_UNAVAILABLE: SOURCE_UNAVAILABLE is for systems the *customer*
+    owns and operates (their Snowflake account, their on-prem SQL Server); DEPENDENCY_UNAVAILABLE
+    is for Atlan-internal platform services (Dapr, Temporal, object store)."""
 
     RESOURCE_EXHAUSTED = "RESOURCE_EXHAUSTED"
     """Local resource limit hit (OOM, disk full, file handles, worker slots)."""

--- a/application_sdk/errors/leaves.py
+++ b/application_sdk/errors/leaves.py
@@ -145,10 +145,13 @@ class PreconditionError(AppError):
 
 @dataclass(kw_only=True)
 class DependencyUnavailableError(AppError):
-    """Required platform service is temporarily down or degraded.
+    """Required Atlan-internal platform service is temporarily down or degraded.
 
-    Covers Dapr, Temporal, object store, and source databases.  Retrying
-    the same call is expected to succeed once the dependency recovers.
+    Covers Dapr, Temporal, and object store.  Retrying the same call is
+    expected to succeed once the dependency recovers.
+
+    For customer-controlled source systems (databases, SaaS APIs), use
+    SourceUnavailableError instead — those route to USER, not PLATFORM.
 
     Litmus test vs PRECONDITION: if system state must change before the call
     can succeed, use PreconditionError.  If the same call would work on retry,
@@ -163,6 +166,31 @@ class DependencyUnavailableError(AppError):
     default_retryable: ClassVar[bool] = True
     code: ClassVar[str] = "DEPENDENCY_UNAVAILABLE"
     audience: ClassVar[Audience] = Audience.PLATFORM
+
+
+@dataclass(kw_only=True)
+class SourceUnavailableError(AppError):
+    """Customer-controlled source system is temporarily unreachable.
+
+    Use when a connector cannot reach the source (database, SaaS API, on-prem
+    endpoint) due to a transient network or server-side condition.  Retrying
+    is expected to succeed once the source recovers.
+
+    Litmus test vs DependencyUnavailableError: SourceUnavailableError is for
+    systems the *customer* owns and operates (their Snowflake account, their
+    on-prem SQL Server, a third-party SaaS API); DependencyUnavailableError is
+    for Atlan-internal platform services (Dapr, Temporal, object store).
+    """
+
+    source_type: str | None = None
+    endpoint: str | None = None
+    http_status: int | None = None
+    network_error: str | None = None
+
+    category: ClassVar[FailureCategory] = FailureCategory.SOURCE_UNAVAILABLE
+    default_retryable: ClassVar[bool] = True
+    code: ClassVar[str] = "SOURCE_UNAVAILABLE"
+    audience: ClassVar[Audience] = Audience.USER
 
 
 # Temporal wire type string for worker-pod eviction. Set as

--- a/application_sdk/errors/leaves.py
+++ b/application_sdk/errors/leaves.py
@@ -1,4 +1,4 @@
-"""Fourteen categorical leaf error classes — one per FailureCategory."""
+"""Fifteen categorical leaf error classes — one per FailureCategory."""
 
 from __future__ import annotations
 

--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -458,6 +458,10 @@ class SqlApp(App):
             "oserror",
             "operationalerror",
             "interfaceerror",
+            # Match wrapped SDK error classnames surfaced as error_type.
+            # "dependencyunavailable" is retained for legacy wrappers that
+            # predate the SourceUnavailableError migration.
+            "sourceunavailable",
             "dependencyunavailable",
             "socketerror",
         )

--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -86,8 +86,8 @@ from application_sdk.errors import redact_secrets
 from application_sdk.errors.leaves import (
     AppTimeoutError,
     AuthError,
-    DependencyUnavailableError,
     InternalError,
+    SourceUnavailableError,
 )
 from application_sdk.execution import build_output_path, get_object_store_prefix
 from application_sdk.infrastructure.context import get_infrastructure
@@ -290,7 +290,7 @@ class SqlApp(App):
             ``success=False`` + ``error_type`` + ``error_message`` on the
             returned ``PrimeAuthOutput``, and lets ``run()`` short-circuit
             the workflow with a typed error (``AuthError``,
-            ``AppTimeoutError`` or ``DependencyUnavailableError``
+            ``AppTimeoutError`` or ``SourceUnavailableError``
             depending on ``error_type``).
 
             Why return failure instead of raising and letting Temporal
@@ -377,9 +377,10 @@ class SqlApp(App):
           ``AuthenticationError`` class names).
         - ``AppTimeoutError`` for probe timeouts (``TimeoutError`` /
           ``asyncio.TimeoutError`` / message contains ``timed out``).
-        - ``DependencyUnavailableError`` for network / DNS / TLS /
-          connection-refused failures — the source is presumed
-          reachable but didn't respond cleanly.
+        - ``SourceUnavailableError`` for network / DNS / TLS /
+          connection-refused failures — the customer-owned source is
+          presumed reachable but didn't respond cleanly, so the failure
+          routes to the connector owner (USER), not Atlan infra ops.
         - ``InternalError`` as the last-resort fallback so we never
           return ``None`` and never accidentally swallow an unknown
           driver exception class.
@@ -445,9 +446,10 @@ class SqlApp(App):
             )
 
         # Network / DNS / TLS / connection-refused / generic
-        # OperationalError without an auth-keyword message. Default to
-        # DependencyUnavailableError — actionable guidance is "fix the
-        # network path, the source itself may be fine."
+        # OperationalError without an auth-keyword message. Classify as
+        # SourceUnavailableError (audience=USER) — the customer owns the
+        # source system, and the actionable guidance is "fix the network
+        # path, the source itself may be fine."
         network_class_hints = (
             "connectionerror",
             "connectionrefused",
@@ -460,12 +462,12 @@ class SqlApp(App):
             "socketerror",
         )
         if any(h in error_type.lower() for h in network_class_hints):
-            return DependencyUnavailableError(
+            return SourceUnavailableError(
                 message=(
                     "SQL auth-cache prime could not reach the source before "
                     f"parallel extract burst ({error_type})."
                 ),
-                service="sql_source",
+                source_type="sql",
                 network_error=error_message,
                 suggested_action=(
                     "Check DNS resolution, NAT/firewall rules, TLS "

--- a/docs/adr/0013-error-hierarchy-and-failure-taxonomy.md
+++ b/docs/adr/0013-error-hierarchy-and-failure-taxonomy.md
@@ -43,10 +43,11 @@ that keeps legacy `except Domain:` catch sites alive.
 | `Audience` — *who must act* | Enum (3 values) | SDK | Yes |
 | `suggested_action` — *what to do* | `str \| None` | App | No |
 
-**`FailureCategory`** is a closed, SDK-owned vocabulary of 14 values:
+**`FailureCategory`** is a closed, SDK-owned vocabulary of 15 values:
 `CANCELLED`, `TIMEOUT`, `RATE_LIMITED`, `AUTH`, `PERMISSION`, `NOT_FOUND`,
 `ALREADY_EXISTS`, `INVALID_INPUT`, `PRECONDITION`, `DEPENDENCY_UNAVAILABLE`,
-`RESOURCE_EXHAUSTED`, `DATA_INTEGRITY`, `INTERNAL`, `UNIMPLEMENTED`. It is
+`SOURCE_UNAVAILABLE`, `RESOURCE_EXHAUSTED`, `DATA_INTEGRITY`, `INTERNAL`,
+`UNIMPLEMENTED`. It is
 closed so Atlan-internal consumers (Automation Engine, SLA dashboards) can
 branch on it without a lookup table, and so semantic drift requires an SDK
 release with a documented evolution policy.
@@ -247,7 +248,7 @@ also removed in v4.0.
 
 ## Industry precedents
 
-**gRPC `google.rpc.Code`** is the primary vocabulary reference. The 14
+**gRPC `google.rpc.Code`** is the primary vocabulary reference. The 15
 `FailureCategory` values align near 1-to-1:
 
 | gRPC status | FailureCategory |

--- a/docs/adr/0013-error-hierarchy-and-failure-taxonomy.md
+++ b/docs/adr/0013-error-hierarchy-and-failure-taxonomy.md
@@ -39,7 +39,7 @@ that keeps legacy `except Domain:` catch sites alive.
 
 | Axis | Type | Owner | Closed? |
 |---|---|---|---|
-| `FailureCategory` — *what happened* | Enum (14 values) | SDK | Yes |
+| `FailureCategory` — *what happened* | Enum (15 values) | SDK | Yes |
 | `Audience` — *who must act* | Enum (3 values) | SDK | Yes |
 | `suggested_action` — *what to do* | `str \| None` | App | No |
 

--- a/docs/adr/0013-error-hierarchy-and-failure-taxonomy.md
+++ b/docs/adr/0013-error-hierarchy-and-failure-taxonomy.md
@@ -93,7 +93,7 @@ fields (`message`, `retryable`, `cause`, `app_name`, `run_id`,
 `suggested_action`) are the base set. ClassVars (`category`,
 `default_retryable`, `code`, `audience`) carry the per-class identity.
 
-Fourteen **categorical leaves** in `application_sdk/errors/leaves.py` — one
+Fifteen **categorical leaves** in `application_sdk/errors/leaves.py` — one
 per `FailureCategory` — subclass `AppError` and fix all four ClassVars plus
 add dataclass fields for structured, per-category evidence:
 
@@ -109,6 +109,7 @@ add dataclass fields for structured, per-category evidence:
 | `InvalidInputError` | INVALID_INPUT | No | USER | `field`, `constraint`, `value_summary` |
 | `PreconditionError` | PRECONDITION | No | USER | `resource`, `expected_state`, `actual_state` |
 | `DependencyUnavailableError` | DEPENDENCY_UNAVAILABLE | **Yes** | PLATFORM | `service`, `target`, `network_error` |
+| `SourceUnavailableError` | SOURCE_UNAVAILABLE | **Yes** | USER | `source_type`, `endpoint`, `http_status`, `network_error` |
 | `ResourceExhaustedError` | RESOURCE_EXHAUSTED | **Yes** | PLATFORM | `resource`, `limit`, `observed` |
 | `DataIntegrityError` | DATA_INTEGRITY | No | APP_OWNER | `expectation`, `observed`, `location` |
 | `InternalError` | INTERNAL | No | APP_OWNER | `component`, `invariant`, `classification_pending` |

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.19.0
-source-sha:    b8d1704887637534f8a7a9fb0e33e55f177bbbe2
-source-date:   2026-06-24T12:00:54+01:00
+sdk-version:   3.20.3
+source-sha:    16d4fa7ab83e995f65a4d8b149987ce51f55058a
+source-date:   2026-07-03T09:44:09+05:30
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -23,7 +23,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.common` | Shared utilities — SQL filters, concurrency helpers, TaskStatistics, DataframeType | 9 |
 | `application_sdk.contracts` | Typed Pydantic Input/Output base classes, payload safety, storage and type helpers | 28 |
 | `application_sdk.credentials` | Credential resolvers (Atlan, OAuth, Git, agent), registry, vault spec | 41 |
-| `application_sdk.errors` | Structured error codes — ErrorCode dataclass and cross-component constants (APP_ERROR, HANDLER_ERROR, CONTRACT_VALIDATION, etc.) | 53 |
+| `application_sdk.errors` | Structured error codes — ErrorCode dataclass and cross-component constants (APP_ERROR, HANDLER_ERROR, CONTRACT_VALIDATION, etc.) | 54 |
 | `application_sdk.execution` | Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal client | 14 |
 | `application_sdk.handler` | HTTP handler framework — Handler ABC, DefaultHandler, preflight, auth, service factory | 22 |
 | `application_sdk.infrastructure` | Protocol-based infrastructure (StateStore, SecretStore, PubSub, Bindings, CapacityPool) | 34 |
@@ -951,7 +951,7 @@ Structured error codes — ErrorCode dataclass and cross-component constants (AP
 
 - **Import:** `from application_sdk.errors import DependencyUnavailableError`
 - **Signature:** `class DependencyUnavailableError(*, ...)`
-- **Summary:** Required platform service is temporarily down or degraded.
+- **Summary:** Required Atlan-internal platform service is temporarily down or degraded.
 - **Defined in:** `application_sdk/errors/leaves.py`
 
 #### `ErrorCode`
@@ -1015,6 +1015,13 @@ Structured error codes — ErrorCode dataclass and cross-component constants (AP
 - **Import:** `from application_sdk.errors import ResourceExhaustedError`
 - **Signature:** `class ResourceExhaustedError(*, ...)`
 - **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/errors/leaves.py`
+
+#### `SourceUnavailableError`
+
+- **Import:** `from application_sdk.errors import SourceUnavailableError`
+- **Signature:** `class SourceUnavailableError(*, ...)`
+- **Summary:** Customer-controlled source system is temporarily unreachable.
 - **Defined in:** `application_sdk/errors/leaves.py`
 
 #### `UnimplementedError`

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.20.3
-source-sha:    16d4fa7ab83e995f65a4d8b149987ce51f55058a
-source-date:   2026-07-03T09:44:09+05:30
+source-sha:    fe5f52ee89b415f43f84c27e42bd46f52ce70075
+source-date:   2026-07-03T12:27:18+05:30
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/docs/concepts/common.md
+++ b/docs/concepts/common.md
@@ -53,6 +53,7 @@ AppError  (base — application_sdk.errors)
 │   ├── PreconditionError      PRECONDITION               retryable=False  audience=USER
 │   ├── RateLimitedError       RATE_LIMITED               retryable=True   audience=USER
 │   ├── DependencyUnavailableError  DEPENDENCY_UNAVAILABLE retryable=True  audience=PLATFORM
+│   ├── SourceUnavailableError   SOURCE_UNAVAILABLE        retryable=True   audience=USER
 │   ├── ResourceExhaustedError RESOURCE_EXHAUSTED         retryable=True   audience=PLATFORM
 │   ├── AppTimeoutError        TIMEOUT                    retryable=True   audience=APP_OWNER
 │   ├── CancelledError         CANCELLED                  retryable=False  audience=APP_OWNER

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -378,7 +378,7 @@ application_sdk/
 │   └── integration/        # Integration test runner and fixtures
 │
 ├── discovery.py            # Auto-discovery helpers for apps and handlers
-├── errors/                 # Categorical error hierarchy: AppError, FailureCategory, Audience, 14 leaf classes
+├── errors/                 # Categorical error hierarchy: AppError, FailureCategory, Audience, 15 leaf classes
 │   │                       # Legacy errors.py shim kept for back-compat (AAF-{COMPONENT}-{ID} constants)
 ├── constants.py            # Import-time configuration (env vars, path templates)
 ├── version.py              # Package version (__version__)

--- a/docs/standards/exceptions.md
+++ b/docs/standards/exceptions.md
@@ -225,11 +225,11 @@ When reviewing code, check for:
 - **Custom Exceptions**: Use the categorical leaf classes from `application_sdk/errors` for new code. Pick the leaf whose `FailureCategory` matches the failure:
   ```python
   from application_sdk.errors import (
-      AuthError, DependencyUnavailableError, InvalidInputError,
-      NotFoundError, AlreadyExistsError, PreconditionError,
-      RateLimitedError, AppTimeoutError, ResourceExhaustedError,
-      DataIntegrityError, InternalError, UnimplementedError,
-      AppPermissionDeniedError, CancelledError,
+      AuthError, DependencyUnavailableError, SourceUnavailableError,
+      InvalidInputError, NotFoundError, AlreadyExistsError,
+      PreconditionError, RateLimitedError, AppTimeoutError,
+      ResourceExhaustedError, DataIntegrityError, InternalError,
+      UnimplementedError, AppPermissionDeniedError, CancelledError,
   )
 
   # DependencyUnavailableError — retryable=True, audience=PLATFORM

--- a/packages/conformance/conformance/docs/rules/prescriptions.md
+++ b/packages/conformance/conformance/docs/rules/prescriptions.md
@@ -94,7 +94,7 @@ across two buckets), corrupting the reporting layer for every downstream consume
 
 `FailureCategory` is the closed, single-axis taxonomy the SDK owns — every value is the
 canonical answer to *what happened* and is consumed as an immutable reporting metric
-(dashboards, SLA gates, on-call routing). The 14 categorical leaves in
+(dashboards, SLA gates, on-call routing). The 15 categorical leaves in
 `application_sdk.errors.leaves` (and `AppError` itself) are the sole defining sites:
 each leaf binds exactly one `FailureCategory` to its `category` `ClassVar`.
 

--- a/packages/conformance/conformance/programs/areas/prescriptions.prose.md
+++ b/packages/conformance/conformance/programs/areas/prescriptions.prose.md
@@ -158,7 +158,7 @@ above.  `classification` is always `"judgment"` for all P-series rules.
      Return `outcome = "suppress"`.
 
 - **P002 CategoryFieldOverride** — a non-canonical subclass of `AppError` (or
-  any of its 14 categorical leaves) redeclares the `category` ClassVar in its
+  any of its 15 categorical leaves) redeclares the `category` ClassVar in its
   own body.  Read the class definition around `finding.line`, then:
 
   1. Verify that the class inherits from a canonical leaf and that the parent's

--- a/packages/conformance/conformance/suite/checks/error_handling/_constants.py
+++ b/packages/conformance/conformance/suite/checks/error_handling/_constants.py
@@ -52,6 +52,7 @@ LEAF_CLASSES: frozenset[str] = frozenset(
         "InvalidInputError",
         "PreconditionError",
         "DependencyUnavailableError",
+        "SourceUnavailableError",
         "ResourceExhaustedError",
         "DataIntegrityError",
         "InternalError",

--- a/packages/conformance/conformance/suite/checks/prescriptions/__init__.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/__init__.py
@@ -15,7 +15,7 @@ Currently implemented:
 * ``P001`` UnboundedContractFields — an ``Input``/``Output`` contract subclass
   declared with the ``allow_unbounded_fields=True`` class keyword.
 * ``P002`` CategoryFieldOverride — a subclass of ``AppError`` (or any of its
-  14 categorical leaves) that redeclares the ``category`` ``ClassVar`` in its
+  15 categorical leaves) that redeclares the ``category`` ``ClassVar`` in its
   own body, drifting the canonical taxonomy.  The check uses a transitive
   closure of AppError-derived class names within the file so second-generation
   overrides are caught even when the intermediate class is not in the canonical

--- a/packages/conformance/conformance/suite/checks/prescriptions/__init__.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/__init__.py
@@ -178,13 +178,13 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
     Store each parsed tree for the P013/P014 and P027 cross-file passes.
 
     Pass 2 — for each registered class, walk its (transitive) base chain to
-    find the deepest ancestor that names one of the 14 leaves in
+    find the deepest ancestor that names one of the 15 leaves in
     ``LEAF_PREFIX_MAP``.  Cycle-safe via a per-resolution ``visiting`` set;
     results memoised.
 
     Pass 3 — emit P003 for every class that derives from a leaf and either
     omits its own ``code`` declaration or declares one that does not start
-    with the leaf's category prefix + ``_``.  The 14 leaves themselves are
+    with the leaf's category prefix + ``_``.  The 15 leaves themselves are
     exempt (their bare codes are the prefix definitions).
 
     Pass 4 — emit P013/P014 using the pre-built ``by_name`` class registry and

--- a/packages/conformance/conformance/suite/checks/prescriptions/_category_override.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_category_override.py
@@ -1,6 +1,6 @@
 """P002 CategoryFieldOverride — flag ``category`` ClassVar redeclarations.
 
-A subclass of ``AppError`` (or any of its 14 categorical leaves) that
+A subclass of ``AppError`` (or any of its 15 categorical leaves) that
 redeclares the ``category`` ``ClassVar`` in its own body drifts the canonical
 ``FailureCategory`` taxonomy.  Only the canonical SDK error classes themselves
 are the defining sites for ``category``; all other subclasses must inherit it.

--- a/packages/conformance/conformance/suite/checks/prescriptions/_error_code_prefix.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_error_code_prefix.py
@@ -29,6 +29,7 @@ LEAF_PREFIX_MAP: dict[str, str] = {
     "InvalidInputError": "INVALID_INPUT",
     "PreconditionError": "PRECONDITION",
     "DependencyUnavailableError": "DEPENDENCY_UNAVAILABLE",
+    "SourceUnavailableError": "SOURCE_UNAVAILABLE",
     "ResourceExhaustedError": "RESOURCE_EXHAUSTED",
     "DataIntegrityError": "DATA_INTEGRITY",
     "InternalError": "INTERNAL",
@@ -147,7 +148,7 @@ def resolve_leaf_prefix(
 ) -> str | None:
     """Walk the (transitive) base chain of *name* and return the leaf prefix.
 
-    Returns ``None`` if *name* is not derived from one of the 14 leaves.
+    Returns ``None`` if *name* is not derived from one of the 15 leaves.
     Cycle-safe via ``visiting``; results memoised in ``cache``.
     """
     if name in LEAF_PREFIX_MAP:

--- a/packages/conformance/conformance/suite/checks/prescriptions/_error_code_prefix.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_error_code_prefix.py
@@ -16,7 +16,7 @@ from conformance.suite.checks.error_handling._helpers import _get_name
 from conformance.suite.schema.findings import Finding
 
 # Mirrors application_sdk/errors/leaves.py.  Subclasses (transitively) of these
-# 14 classes must declare a ``code: ClassVar[str]`` that starts with the
+# 15 classes must declare a ``code: ClassVar[str]`` that starts with the
 # corresponding prefix followed by an underscore.
 LEAF_PREFIX_MAP: dict[str, str] = {
     "CancelledError": "CANCELLED",

--- a/packages/conformance/conformance/suite/rules/prescriptions.py
+++ b/packages/conformance/conformance/suite/rules/prescriptions.py
@@ -82,7 +82,7 @@ RULES: tuple[RuleDefinition, ...] = (
             "``FailureCategory`` is the closed, single-axis taxonomy the SDK owns —\n"
             "every value is the canonical answer to *what happened* and is consumed as\n"
             "an immutable reporting metric (dashboards, SLA gates, on-call routing).\n"
-            "The 14 categorical leaves in ``application_sdk.errors.leaves`` (and\n"
+            "The 15 categorical leaves in ``application_sdk.errors.leaves`` (and\n"
             "``AppError`` itself) are the sole defining sites: each leaf binds exactly\n"
             "one ``FailureCategory`` to its ``category`` ``ClassVar``.\n"
             "\n"

--- a/packages/conformance/tests/test_prescriptions.py
+++ b/packages/conformance/tests/test_prescriptions.py
@@ -227,7 +227,7 @@ def test_p003_fires_on_bare_leaf_prefix_without_underscore(tmp_path: Path) -> No
 
 
 def test_p003_silent_on_leaf_class_itself(tmp_path: Path) -> None:
-    """The 14 leaves themselves declare ``code = "<PREFIX>"`` — that's the
+    """The 15 leaves themselves declare ``code = "<PREFIX>"`` — that's the
     canonical source, not a violation."""
     src = (
         "from typing import ClassVar\n"
@@ -717,7 +717,7 @@ def test_p002_fires_on_appbase_subclass_redeclaring_category() -> None:
 
 
 def test_p002_silent_on_canonical_leaves_themselves() -> None:
-    # The 14 canonical leaves are the *defining sites* — they MUST set category.
+    # The 15 canonical leaves are the *defining sites* — they MUST set category.
     for leaf, cat in (
         ("CancelledError", "CANCELLED"),
         ("AppTimeoutError", "TIMEOUT"),
@@ -729,6 +729,7 @@ def test_p002_silent_on_canonical_leaves_themselves() -> None:
         ("InvalidInputError", "INVALID_INPUT"),
         ("PreconditionError", "PRECONDITION"),
         ("DependencyUnavailableError", "DEPENDENCY_UNAVAILABLE"),
+        ("SourceUnavailableError", "SOURCE_UNAVAILABLE"),
         ("ResourceExhaustedError", "RESOURCE_EXHAUSTED"),
         ("DataIntegrityError", "DATA_INTEGRITY"),
         ("InternalError", "INTERNAL"),

--- a/tests/unit/errors/test_categorical.py
+++ b/tests/unit/errors/test_categorical.py
@@ -17,6 +17,7 @@ from application_sdk.errors.leaves import (
     PreconditionError,
     RateLimitedError,
     ResourceExhaustedError,
+    SourceUnavailableError,
     UnimplementedError,
 )
 
@@ -100,6 +101,14 @@ _LEAVES = [
         "DEPENDENCY_UNAVAILABLE",
         Audience.PLATFORM,
         ["service", "target", "network_error"],
+    ),
+    (
+        SourceUnavailableError,
+        FailureCategory.SOURCE_UNAVAILABLE,
+        True,
+        "SOURCE_UNAVAILABLE",
+        Audience.USER,
+        ["source_type", "endpoint", "http_status", "network_error"],
     ),
     (
         ResourceExhaustedError,

--- a/tests/unit/templates/test_sql_app.py
+++ b/tests/unit/templates/test_sql_app.py
@@ -2123,18 +2123,20 @@ class TestPrimeSqlAuth:
             ),
         ],
     )
-    async def test_prime_network_failure_raises_dependency_unavailable(
+    async def test_prime_network_failure_raises_source_unavailable(
         self, error_type, error_message
     ):
         """Probe failures that look like network / DNS / TLS /
-        connection-refused must surface as
-        ``DependencyUnavailableError``. The on-call guidance must NOT
-        suggest a credentials check (the credentials path was never
-        exercised) and must NOT suggest ACCOUNT UNLOCK (no failed
-        login attempts were made). Pinned by application-sdk#1835
-        mothership comment-3287630230 (HIGH).
+        connection-refused must surface as ``SourceUnavailableError``
+        (audience=USER) — the customer owns the source, so the failure
+        routes to the connector owner, not Atlan infra ops. The on-call
+        guidance must NOT suggest a credentials check (the credentials
+        path was never exercised) and must NOT suggest ACCOUNT UNLOCK
+        (no failed login attempts were made). Pinned by
+        application-sdk#1835 mothership comment-3287630230 (HIGH).
         """
-        from application_sdk.errors.leaves import DependencyUnavailableError
+        from application_sdk.errors.categories import Audience
+        from application_sdk.errors.leaves import SourceUnavailableError
 
         app = SqlApp.__new__(SqlApp)
         app._app_name = "test-app"
@@ -2158,11 +2160,13 @@ class TestPrimeSqlAuth:
             patch.object(SqlApp, "extract_tables", new=AsyncMock()),
             patch.object(SqlApp, "extract_columns", new=AsyncMock()),
         ):
-            with pytest.raises(DependencyUnavailableError) as exc_info:
+            with pytest.raises(SourceUnavailableError) as exc_info:
                 await app.run(ExtractionInput(output_path="/tmp/test"))
 
         err = exc_info.value
-        assert err.service == "sql_source"
+        # Routes to the customer/connector owner, not Atlan infra ops.
+        assert err.audience is Audience.USER
+        assert err.source_type == "sql"
         assert err.network_error == error_message
         # Must steer the operator toward network/DNS investigation, and
         # explicitly NOT toward auth-lockout work. The classifier's


### PR DESCRIPTION
## Summary

- Introduce `FailureCategory.SOURCE_UNAVAILABLE` and `SourceUnavailableError` to correctly classify transient failures when a connector cannot reach a **customer-controlled** source system (database, SaaS API, on-prem endpoint).
- Previously, `DependencyUnavailableError` (audience=`PLATFORM`) was the only option, misrouting source-connectivity failures to infra ops instead of the user/connector owner who controls the source.
- **Migrate the one SDK site that misclassified a source failure:** the SQL auth-cache prime classifier now raises `SourceUnavailableError` (audience=`USER`) for network/DNS/TLS/connection-refused failures to the source, instead of `DependencyUnavailableError` (audience=`PLATFORM`).
- Fix `DependencyUnavailableError` docstring to remove the misleading "source databases" mention and point callers to the new class.

## Changes

| File | What changed |
|---|---|
| `errors/categories.py` | Add `SOURCE_UNAVAILABLE` enum + litmus test in class doc; fix `DEPENDENCY_UNAVAILABLE` docstring |
| `errors/leaves.py` | Add `SourceUnavailableError` (`retryable=True`, `audience=USER`, fields: `source_type`, `endpoint`, `http_status`, `network_error`); update `DependencyUnavailableError` docstring |
| `errors/__init__.py` | Export `SourceUnavailableError` |
| `templates/sql_app.py` | `_classify_prime_failure` returns `SourceUnavailableError` (`source_type="sql"`) on the network path; update classifier docstrings/comment; drop unused `DependencyUnavailableError` import |
| `conformance/suite/checks/error_handling/_constants.py` | Add `SourceUnavailableError` to `LEAF_CLASSES` (E018 check) |
| `tests/unit/errors/test_categorical.py` | Add parametrized test entry |
| `tests/unit/templates/test_sql_app.py` | Flip the network-failure test to expect `SourceUnavailableError` + assert `audience=USER` |
| `docs/agents/sdk-capabilities.md` | Regenerate for the new public symbol |

## Design decisions

- **`audience=USER`** — the customer owns the source system, so they or their support team acts on it (not Atlan infra ops).
- **`default_retryable=True`** — source unavailability is transient by definition.
- **`http_status`** field — many SaaS source failures surface as HTTP 5xx codes, making this useful structured evidence for triage.
- **Scope: the SQL classifier is the only SDK site migrated.** All other `DependencyUnavailableError` subclasses (Dapr, Temporal, object store, Redis, secrets, state store) are genuinely Atlan-internal and correctly stay `PLATFORM`.
- No breaking changes — `DependencyUnavailableError` behaviour is unchanged.

## Test plan

- [x] `uv run pytest tests/unit/errors/ tests/unit/templates/test_sql_app.py` — 301 passed
- [x] Pre-commit hooks green (isort ordering fixed)
- [x] Capability manifest regenerated (drift check green)
- [x] CI GH Actions green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
