### PR TITLE
fix(contract-toolkit): bake NativeApp manifest app_name from contract name

### DIFF
--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -2625,10 +2625,15 @@ local function generateExtractNode(): Mapping<String, Any> =
   new Mapping {
     ["activity_name"] = "execute_workflow"
     ["activity_display_name"] = extractActivityDisplayName ?? "Extract \(displayName) Metadata"
-    ["app_name"] = "{app_name}"
+    // Log identity: bake the contract `name` directly. This is the value the
+    // AE DAG (and Pulse) attributes failures to, and it must match the app's
+    // ATLAN_APPLICATION_NAME so failure logs correlate (HYP-1678 / HYP-1954).
+    // The SDK no longer substitutes a `{app_name}` placeholder at serve time
+    // (#2271); bake it here as App.pkl does, or it stays literal in the DAG.
+    ["app_name"] = name
     ["inputs"] = new Mapping {
       ["workflow_type"] = workflowTypeResolved
-      ["app_name"] = "{app_name}"
+      ["app_name"] = name
       ["app_id"] = ""
       ["argo_workflow_slug"] = ""
       ["task_queue"] = "\(taskQueuePrefix)-{deployment_name}"

--- a/contract-toolkit/tests/fixtures/native_app_pipeline.pkl
+++ b/contract-toolkit/tests/fixtures/native_app_pipeline.pkl
@@ -1,0 +1,40 @@
+/// Minimal contract amending the legacy `NativeApp.pkl` template.
+///
+/// Exists so `native_app_appname_test.pkl` can assert the generated AE
+/// manifest extract node bakes `app_name` from the contract `name` (the
+/// HYP-1954 fix), the same guard the App.pkl fixtures give for App.pkl.
+amends "../../src/NativeApp.pkl"
+
+import "../../src/Connectors.pkl"
+import "../../src/Config.pkl"
+
+name = "native-app-pipeline"
+connector = Connectors.POSTGRES
+icon = "https://assets.atlan.com/assets/postgres.svg"
+workflowType = "PostgresWorkflow"
+
+credentialCommonFields {
+  new FieldSpec { name = "host"; displayName = "Host"; width = 6 }
+}
+
+credentialAuthOptions {
+  ["basic"] = new AuthOption {
+    label = "Basic"
+    fields {
+      new FieldSpec { name = "username"; displayName = "Username"; width = 4 }
+      new FieldSpec { name = "password"; sensitive = true; displayName = "Password"; width = 4 }
+    }
+  }
+}
+
+uiConfig = new Config.UIConfig {
+  tasks {
+    ["Credential"] {
+      inputs {
+        ["credential-guid"] = new Config.CredentialInput {
+          credType = "atlan-connectors-native-app-pipeline"
+        }
+      }
+    }
+  }
+}

--- a/contract-toolkit/tests/native_app_appname_test.pkl
+++ b/contract-toolkit/tests/native_app_appname_test.pkl
@@ -14,7 +14,18 @@
 
 amends "pkl:test"
 
+import "pkl:json"
 import "../src/NativeApp.pkl" as NativeApp
+import "fixtures/native_app_pipeline.pkl" as nativeApp
+
+// The generated AE-manifest extract node for a NativeApp contract. `app_name`
+// must be baked from the contract `name` — the SDK stopped substituting a
+// runtime `{app_name}` placeholder (#2271), so a literal placeholder here
+// freezes into the DAG and strips failure attribution in Pulse (HYP-1954).
+local extractNode =
+  let (text = nativeApp.output.files["manifest.json"].text)
+  let (manifest = new json.Parser { useMapping = true }.parse(text))
+    manifest["dag"]["extract"]
 
 local qiNode = new NativeApp.QueryIntelligenceNode {
   vendorName = "athena"
@@ -54,5 +65,18 @@ facts {
 
   ["PopularityNode identifies the popularity app"] {
     popularityNode.appName == "popularity"
+  }
+
+  // Extract node bakes app_name from the contract `name` — not a literal
+  // "{app_name}" placeholder. The SDK no longer fills that placeholder at
+  // serve time (#2271); a literal here would freeze into the AE DAG and drop
+  // failure attribution in Pulse (HYP-1954). Guards the top-level and inputs
+  // copies the frozen manifests of dbt/postgres/quicksight actually carried.
+  ["extract node bakes app_name from the contract name"] {
+    extractNode["app_name"] == "native-app-pipeline"
+  }
+
+  ["extract node inputs bake app_name from the contract name"] {
+    extractNode["inputs"]["app_name"] == "native-app-pipeline"
   }
 }


### PR DESCRIPTION
## Problem
Multiple apps' runs show a literal `{app_name}` as the connector name in the AE workflow DAG / Pulse, so failures aren't attributed to any app.

Root cause: **#2271** removed the SDK's runtime substitution of the `{app_name}` placeholder (`handler/service.py`) and instead baked the name into the generated manifest — but that change was only applied to `App.pkl`. The legacy `NativeApp.pkl` template still emitted the literal `"{app_name}"` in its extract node. Apps still amending `NativeApp.pkl` / `NativeAppBundle.pkl` (dbt, quicksight, postgres, …) therefore froze a literal `{app_name}` into their committed `manifest.json`, and with the runtime fill gone it is served as-is into the DAG → no attribution in Pulse.

## Fix

Mirror #2271 in `NativeApp.pkl`: bake the extract node's `app_name` (both the top-level and `inputs` copies) from the contract `name` instead of the `"{app_name}"` placeholder. NativeAppBundle apps inherit this (the bundle has no own extract node).

## Tests

- New minimal `tests/fixtures/native_app_pipeline.pkl` (no NativeApp-amending fixture existed before).
- Two regression guards in `native_app_appname_test.pkl` asserting the generated manifest extract node bakes `app_name` from `name`. Verified they **fail** on the pre-fix source and pass after.
- Full pkl suite (223 tests / 560 asserts), `regenerate-all.sh`, `check-invariants.sh`, `test-sdk-import.py`, and pre-commit all pass.

## Rollout notes for consumer apps

- This fixes the **template**. Affected apps must **bump the toolkit and regenerate contracts** to clear the frozen `{app_name}` in prod — this PR does not touch their already-committed `manifest.json`.
- Log correlation: `ATLAN_APPLICATION_NAME` is Helm-injected from each app's hand-maintained `atlan.yaml` `name` (NativeApp does not generate that file). **dbt** is aligned (`name: dbt`). **quicksight** has drift — `atlan.yaml name: QuickSight` vs contract `name: quicksight` — and needs a case reconcile for failures to fully correlate, in addition to the regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)