### PR TITLE
fix(conformance): suppress T201 inline in build_conformance_args.py

### DIFF
--- a/.github/scripts/build_conformance_args.py
+++ b/.github/scripts/build_conformance_args.py
@@ -45,7 +45,11 @@ def main(argv: list[str] | None = None) -> int:
     detect_args = build_args(
         args.series, args.slug, exclude=exclude, exit_zero=exit_zero
     )
-    print("\n".join(detect_args))
+    # This print is the script's actual output mechanism — the calling composite
+    # action reads stdout via `mapfile`, not application logging — so callers
+    # that enable ruff's T201 (no bare prints) don't need a per-repo pyproject.toml
+    # ignore for this bootstrap-managed file.
+    print("\n".join(detect_args))  # noqa: T201
     return 0
 
 

--- a/packages/conformance/conformance/bootstrap/templates/build_conformance_args.py
+++ b/packages/conformance/conformance/bootstrap/templates/build_conformance_args.py
@@ -45,7 +45,11 @@ def main(argv: list[str] | None = None) -> int:
     detect_args = build_args(
         args.series, args.slug, exclude=exclude, exit_zero=exit_zero
     )
-    print("\n".join(detect_args))
+    # This print is the script's actual output mechanism — the calling composite
+    # action reads stdout via `mapfile`, not application logging — so callers
+    # that enable ruff's T201 (no bare prints) don't need a per-repo pyproject.toml
+    # ignore for this bootstrap-managed file.
+    print("\n".join(detect_args))  # noqa: T201
     return 0
 
 


### PR DESCRIPTION
## Summary
- `build_conformance_args.py` (bootstrap-managed, vendored into every consumer repo via `atlan-application-sdk-conformance bootstrap`) uses `print()` as its actual output mechanism — the `run-conformance-detect` composite action reads stdout via `mapfile`, not application logging.
- Consumer repos with ruff's `T201` (no bare prints) enabled hit a pre-commit failure on every fresh bootstrap, and had to work around it by adding their own `pyproject.toml` per-file-ignore (discovered while re-bootstrapping `atlan-hello-world-app`).
- Add an inline `# noqa: T201` with an explanatory comment directly in the template so every repo that bootstraps gets a clean file for free — no per-repo config change needed.
- Synced the repo-root vendored copy (`.github/scripts/build_conformance_args.py`) to match, since it's tracked by the C002 bootstrap-drift check.

## Test plan
- [x] `uv run pre-commit run --all-files` — clean
- [x] `uv run python -m pytest .github/scripts/tests/test_build_conformance_args.py -q` — 9 passed
- [x] `uv run --extra test python -m pytest -q` (packages/conformance) — 1576 passed, 1 xfailed
- [x] `atlan-application-sdk-conformance detect --series C` — no C002 drift findings