### PR TITLE
feat(storage): resumable + version-pinned chunked downloads (BLDX-1523)

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -242,6 +242,15 @@ STORAGE_PROGRESS_LOG_INTERVAL_SECONDS = float(
     os.getenv("ATLAN_STORAGE_PROGRESS_LOG_INTERVAL_SECONDS", "30")
 )
 
+#: Kill-switch for resumable chunked downloads (BLDX-1523). When enabled
+#: (default), an interrupted chunked download leaves its partial file plus a
+#: ``.transfer-state`` sidecar on disk, and a retry fetches only the missing
+#: ranges — valid only while the remote object's etag is unchanged. Set to
+#: "false" to restore delete-partial-on-failure behaviour fleet-wide.
+STORAGE_RESUME_DOWNLOADS = (
+    os.getenv("ATLAN_STORAGE_RESUME_DOWNLOADS", "true").strip().lower() != "false"
+)
+
 #: Build ID for worker versioning (injected by TWD controller via Kubernetes Downward API).
 #: When set, workers identify themselves with this build ID so the Temporal server can
 #: route tasks to the correct version during versioned deployments.

--- a/application_sdk/storage/batch.py
+++ b/application_sdk/storage/batch.py
@@ -95,7 +95,9 @@ async def list_keys(
         )
         lsuffix = suffix.lower() if suffix else ""
         return sorted(
-            path for path, _ in items if not lsuffix or path.lower().endswith(lsuffix)
+            path
+            for path, _, _ in items
+            if not lsuffix or path.lower().endswith(lsuffix)
         )
     # conformance: ignore[E004] always re-raises as StorageError; no logging needed at this layer
     except Exception as exc:
@@ -114,13 +116,16 @@ async def list_keys_with_sizes(
     *,
     suffix: str = "",
     normalize: bool = True,
-) -> list[tuple[str, int]]:
-    """Like :func:`list_keys`, but return ``(key, size_bytes)`` tuples.
+) -> list[tuple[str, int, str | None]]:
+    """Like :func:`list_keys`, but return ``(key, size_bytes, e_tag)`` tuples.
 
-    The listing already carries each object's size, so callers that need to
-    decide *per file* whether to chunk a download (large object) or stream it
-    (small object) can do so without a follow-up HEAD per key. Directory-marker
-    filtering, suffix filtering, and sort order match :func:`list_keys`.
+    The listing already carries each object's size and etag, so callers that
+    need to decide *per file* whether to chunk a download (large object) or
+    stream it (small object) — and to version-pin the chunked range GETs —
+    can do so without a follow-up HEAD per key (BLDX-1513 / BLDX-1523).
+    ``e_tag`` may be ``None`` on stores that don't provide one.
+    Directory-marker filtering, suffix filtering, and sort order match
+    :func:`list_keys`.
 
     Raises:
         StorageError: If the listing fails.
@@ -133,8 +138,8 @@ async def list_keys_with_sizes(
         items = await _list_items(resolved, prefix or None)
         lsuffix = suffix.lower() if suffix else ""
         return sorted(
-            (path, size)
-            for path, size in items
+            (path, size, etag)
+            for path, size, etag in items
             if not lsuffix or path.lower().endswith(lsuffix)
         )
     # conformance: ignore[E004] always re-raises as StorageError; no logging needed at this layer
@@ -199,7 +204,7 @@ async def delete_prefix(
             f"Failed to list keys with prefix '{prefix}'", cause=exc
         ) from exc
 
-    paths = [path for path, _ in items]
+    paths = [path for path, _, _ in items]
 
     # Also delete the directory marker at the prefix root itself (e.g. the GCS
     # object "artifacts/run" when prefix = "artifacts/run/").  obstore strips
@@ -280,22 +285,29 @@ async def download_prefix(
     )
     local = Path(local_dir)
     # Reject keys whose resolved path escapes local_dir (e.g. via ".." segments).
-    destinations = [str(_safe_join_under(local, key)) for key, _ in items]
+    destinations = [str(_safe_join_under(local, key)) for key, _, _ in items]
 
     sem = asyncio.Semaphore(max_concurrency)
 
-    async def _download_one(key: str, dest: str, size: int) -> None:
+    async def _download_one(key: str, dest: str, size: int, etag: str | None) -> None:
         async with sem:
-            # Pass the listing's size so a large object is fetched via bounded
-            # parallel range GETs (each with its own timeout / retry budget)
-            # while small objects still stream in a single GET — and no per-file
-            # HEAD is issued, since the size is already known. (BLDX-1513)
+            # Pass the listing's size + etag so a large object is fetched via
+            # bounded parallel range GETs (each with its own timeout / retry
+            # budget, version-pinned via If-Match) while small objects still
+            # stream in a single GET — and no per-file HEAD is issued, since
+            # the metadata is already known. (BLDX-1513 / BLDX-1523)
             await download_file_chunked(
-                key, dest, store, compute_hash=False, normalize=False, file_size=size
+                key,
+                dest,
+                store,
+                compute_hash=False,
+                normalize=False,
+                file_size=size,
+                etag=etag,
             )
 
     await asyncio.gather(
-        *[_download_one(k, d, s) for (k, s), d in zip(items, destinations)]
+        *[_download_one(k, d, s, e) for (k, s, e), d in zip(items, destinations)]
     )
     return destinations
 

--- a/application_sdk/storage/cloud.py
+++ b/application_sdk/storage/cloud.py
@@ -273,7 +273,7 @@ class CloudStore:
 
         sem = asyncio.Semaphore(max_concurrency)
 
-        async def _dl(obj_key: str, size: int) -> Path:
+        async def _dl(obj_key: str, size: int, etag: str | None) -> Path:
             async with sem:
                 rel = (
                     obj_key[len(list_prefix) :]
@@ -282,8 +282,9 @@ class CloudStore:
                 )
                 # Reject keys whose resolved path escapes output (e.g. via ".." segments).
                 local_path = _safe_join_under(output, rel)
-                # Pass the listing's size so large objects chunk and small ones
-                # stream — with no per-file HEAD (size already known). (BLDX-1513)
+                # Pass the listing's size + etag so large objects chunk (with
+                # version-pinned range GETs) and small ones stream — no per-file
+                # HEAD (metadata already known). (BLDX-1513 / BLDX-1523)
                 await download_file_chunked(
                     obj_key,
                     local_path,
@@ -291,10 +292,11 @@ class CloudStore:
                     compute_hash=False,
                     normalize=False,
                     file_size=size,
+                    etag=etag,
                 )
                 return local_path
 
-        results = await asyncio.gather(*[_dl(k, s) for k, s in items])
+        results = await asyncio.gather(*[_dl(k, s, e) for k, s, e in items])
         downloaded = list(results)
         _log().info("Downloaded %d files from prefix=%s", len(downloaded), list_prefix)
         return downloaded
@@ -308,7 +310,7 @@ class CloudStore:
             items = await _list_items(self._store, list_prefix or None)
             return sorted(
                 path
-                for path, _ in items
+                for path, _, _ in items
                 if not lfilter or any(path.lower().endswith(s) for s in lfilter)
             )
         # conformance: ignore[E004] re-raise only; wraps obstore listing failure into StorageError
@@ -319,15 +321,16 @@ class CloudStore:
 
     async def _list_keys_with_sizes(
         self, list_prefix: str, suffix_filter: set[str] | None = None
-    ) -> list[tuple[str, int]]:
-        """Like :meth:`_list_keys` but return ``(key, size_bytes)`` tuples so a
-        prefix download can decide per-file whether to chunk without a HEAD."""
+    ) -> list[tuple[str, int, str | None]]:
+        """Like :meth:`_list_keys` but return ``(key, size_bytes, e_tag)``
+        tuples so a prefix download can decide per-file whether to chunk —
+        and version-pin the range GETs — without a HEAD."""
         lfilter = {s.lower() for s in suffix_filter} if suffix_filter else None
         try:
             items = await _list_items(self._store, list_prefix or None)
             return sorted(
-                (path, size)
-                for path, size in items
+                (path, size, etag)
+                for path, size, etag in items
                 if not lfilter or any(path.lower().endswith(s) for s in lfilter)
             )
         # conformance: ignore[E004] re-raise only; wraps obstore listing failure into StorageError

--- a/application_sdk/storage/ops.py
+++ b/application_sdk/storage/ops.py
@@ -55,9 +55,11 @@ import orjson
 try:  # pragma: no cover — defensive import
     from obstore.exceptions import BaseError as _ObstoreBaseError
     from obstore.exceptions import NotFoundError as _ObstoreNotFoundError
+    from obstore.exceptions import PreconditionError as _ObstorePreconditionError
 except ImportError:  # conformance: ignore[E008,E009] optional dep obstore.exceptions; sentinel fallback for older versions  # pragma: no cover
     _ObstoreBaseError = None  # type: ignore[assignment,misc]
     _ObstoreNotFoundError = None  # type: ignore[assignment,misc]
+    _ObstorePreconditionError = None  # type: ignore[assignment,misc]
 
 
 if TYPE_CHECKING:
@@ -316,6 +318,21 @@ def _exc_class_name(exc: BaseException) -> str:
     return type(exc).__name__
 
 
+def _is_precondition(exc: BaseException) -> bool:
+    """True when *exc* is an etag precondition failure (HTTP 412 / if_match miss).
+
+    Raised by version-pinned range GETs when the remote object was rewritten
+    between the initial HEAD/listing and the chunk fetch. Class-based detection
+    first (obstore ``PreconditionError``), substring fallback for older versions.
+    """
+    if _ObstorePreconditionError is not None and isinstance(
+        exc, _ObstorePreconditionError
+    ):
+        return True
+    msg = str(exc).lower()
+    return "precondition" in msg or "412" in msg
+
+
 def _throughput_mbps(size_bytes: int, elapsed_ms: float) -> float | None:
     """Return MiB/s throughput, or ``None`` when unknown / instantaneous."""
     if elapsed_ms <= 0 or size_bytes <= 0:
@@ -505,12 +522,84 @@ def _log_transfer_progress(
     logger.log(logging.INFO, msg, **extra)
 
 
+# ---------------------------------------------------------------------------
+# Resumable chunked-download state (BLDX-1523)
+#
+# A chunked download writes ranges at fixed offsets into a pre-allocated file.
+# The sidecar below records which chunk indices have landed on disk, plus the
+# identity of the remote object they came from (key / size / chunk size / etag).
+# Its *existence* is the "incomplete" marker: it is deleted on success, so a
+# data file without a state sidecar is always complete. On retry after a crash
+# the download resumes by fetching only the missing chunk indices — valid only
+# while the remote object is unchanged, which is what the etag match enforces.
+# ---------------------------------------------------------------------------
+
+_TRANSFER_STATE_SUFFIX = ".transfer-state"
+
+
+def _transfer_state_path(path: Path) -> Path:
+    """Sidecar path holding resumable-download state for *path*."""
+    return Path(str(path) + _TRANSFER_STATE_SUFFIX)
+
+
+def _load_transfer_state(state_path: Path) -> dict | None:
+    """Load and validate a transfer-state sidecar; ``None`` if absent/corrupt.
+
+    Corrupt or structurally invalid state must never break a download — the
+    caller falls back to a fresh full download, which is always correct.
+    """
+    try:
+        raw = state_path.read_bytes()
+        state = orjson.loads(raw)
+        if not isinstance(state, dict):
+            return None
+        if not isinstance(state.get("key"), str):
+            return None
+        if not isinstance(state.get("file_size"), int):
+            return None
+        if not isinstance(state.get("chunk_size"), int):
+            return None
+        if not isinstance(state.get("done"), list) or not all(
+            isinstance(i, int) for i in state["done"]
+        ):
+            return None
+        return state
+    # conformance: ignore[E004] absent/corrupt checkpoint is an expected condition; falling back to a fresh download is always correct
+    except Exception:
+        return None
+
+
+def _save_transfer_state(state_path: Path, state: dict) -> None:
+    """Atomically persist transfer state (write temp + rename, fsync'd).
+
+    fsync on the temp file is enough for the failure mode resume targets:
+    process death (OOMKill / activity retry) preserves the kernel page cache,
+    so data-file writes that precede this checkpoint are visible on retry.
+    Node death loses the local volume entirely — resume is moot there and the
+    etag check makes the resulting fresh download safe.
+    """
+    tmp = state_path.with_suffix(state_path.suffix + ".tmp")
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, orjson.dumps(state))
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    os.replace(tmp, state_path)
+
+
+def _discard_transfer_state(path: Path) -> None:
+    """Remove the data file and its state sidecar (best-effort)."""
+    path.unlink(missing_ok=True)
+    _transfer_state_path(path).unlink(missing_ok=True)
+
+
 async def _list_items(
     store: ObjectStore,
     prefix: str | None,
     *,
     include_markers: bool = False,
-) -> list[tuple[str, int]]:
+) -> list[tuple[str, int, str | None]]:
     """Collect listing results under *prefix*, optionally filtering GCS directory markers.
 
     Makes a single listing operation (``obstore.list`` returns a native async
@@ -531,26 +620,27 @@ async def _list_items(
             objects are left behind on any store backend.
 
     Returns:
-        ``(path, size)`` tuples in listing order.  Directory markers are excluded
-        unless *include_markers* is ``True``.
+        ``(path, size, e_tag)`` tuples in listing order (``e_tag`` may be
+        ``None`` on stores that don't provide one).  Directory markers are
+        excluded unless *include_markers* is ``True``.
     """
-    all_items: list[tuple[str, int]] = []
+    all_items: list[tuple[str, int, str | None]] = []
     async for batch in obstore.list(store, prefix=prefix):  # native async ListStream
         for item in batch:
-            all_items.append((str(item["path"]), int(item["size"])))
+            all_items.append((str(item["path"]), int(item["size"]), item.get("e_tag")))
 
     if include_markers:
         return all_items
 
     parent_dirs: set[str] = set()
-    for path, _ in all_items:
+    for path, _, _ in all_items:
         parts = path.split("/")
         for i in range(1, len(parts)):
             parent_dirs.add("/".join(parts[:i]))
 
     return [
-        (path, size)
-        for path, size in all_items
+        (path, size, etag)
+        for path, size, etag in all_items
         if not (size == 0 and path in parent_dirs)
     ]
 
@@ -906,6 +996,39 @@ async def get_file_size(
         raise StorageError(f"Failed to head key '{key}'", key=key, cause=exc) from exc
 
 
+async def get_file_meta(
+    key: str,
+    store: BoundStore | ObjectStore | None = None,
+    *,
+    normalize: bool = True,
+) -> tuple[int, str | None] | None:
+    """Return ``(size_bytes, e_tag)`` for *key*, or ``None`` if not found.
+
+    Same single HEAD request as :func:`get_file_size`, but also surfaces the
+    object's etag so callers can version-pin subsequent range GETs
+    (:func:`download_file_chunked` ``etag=``) without a second HEAD.
+
+    Raises:
+        StorageError: For non-404 errors.
+        ObjectStoreNotProvidedError: If *store* is ``None`` and no infrastructure store is set.
+    """
+    resolved = _resolve_store(store)
+    if normalize:
+        key = normalize_key(key)
+    try:
+        meta = await obstore.head_async(resolved, key)
+        return int(meta["size"]), meta.get("e_tag")
+    # conformance: ignore[E004] not-found returns None as documented API contract; other exceptions re-raised via StorageError chain
+    except Exception as exc:
+        if _is_not_found(exc):
+            return None
+        from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
+            StorageError,
+        )
+
+        raise StorageError(f"Failed to head key '{key}'", key=key, cause=exc) from exc
+
+
 async def download_file_chunked(
     key: str,
     local_path: str | Path,
@@ -916,18 +1039,38 @@ async def download_file_chunked(
     compute_hash: bool = True,
     normalize: bool = True,
     file_size: int | None = None,
+    etag: str | None = None,
+    resume: bool | None = None,
 ) -> str | None:
     """Download *key* using parallel range GETs, writing chunks at fixed offsets.
 
     For files larger than *chunk_size_bytes*, issues multiple independent
-    ``get_range_async`` requests (up to *max_concurrent_chunks* in flight at
-    once) and writes each chunk to the correct file offset via ``os.lseek`` +
+    range requests (up to *max_concurrent_chunks* in flight at once) and
+    writes each chunk to the correct file offset via ``os.lseek`` +
     ``os.write`` (``os.pwrite`` is unavailable on Windows).
     Each chunk gets its own obstore retry budget, so a mid-stream stall only
     retries the affected chunk — not the entire file.
 
     Falls through to :func:`download_file` (single streaming GET) when the
     remote object is smaller than *chunk_size_bytes*.
+
+    **Version pinning (BLDX-1523):** when *etag* is known (supplied by the
+    caller from a listing, or captured by the internal HEAD), every range GET
+    carries ``If-Match: etag``. If the remote object is rewritten mid-download
+    the store answers 412 instead of serving bytes from the new version, so
+    chunks can never mix two object generations. On a 412 the partial file is
+    discarded and the download restarts fresh **once** against the new
+    generation; a second 412 raises.
+
+    **Resume (BLDX-1523):** when *resume* is enabled, completed chunk indices
+    are checkpointed to a ``{local_path}.transfer-state`` sidecar after every
+    chunk write, and an interrupted download leaves the partial file + sidecar
+    on disk instead of deleting them. A retry that resolves the same object
+    generation (key / size / chunk size / etag all match) re-fetches only the
+    missing chunks. The sidecar is deleted on success, so a data file without
+    one is always complete. Resume requires the retry to see the same local
+    filesystem (same pod or persistent volume); after node loss the download
+    simply starts fresh.
 
     Args:
         key: Source object key.  Normalised by default.
@@ -944,13 +1087,21 @@ async def download_file_chunked(
             skipped — this avoids a per-file HEAD when fanning out over a prefix
             whose sizes are already known. When ``None`` (default) a HEAD is
             issued, which also serves as the existence check.
+        etag: Pre-known object etag (pairs with *file_size* from the same
+            listing). When ``None`` and a HEAD is issued anyway, the etag is
+            captured from the HEAD. When ``None`` and *file_size* is supplied,
+            range GETs are unpinned — same semantics as before BLDX-1523.
+        resume: Resume an interrupted download from its checkpoint sidecar.
+            ``None`` (default) follows ``ATLAN_STORAGE_RESUME_DOWNLOADS``
+            (enabled unless set to ``"false"``).
 
     Returns:
         Hex-encoded SHA-256 digest if *compute_hash* is ``True``, else ``None``.
 
     Raises:
         StorageNotFoundError: If *key* does not exist.
-        StorageError: If a chunk download or the disk write fails.
+        StorageError: If a chunk download or the disk write fails, or the
+            object was rewritten during both the original and restarted attempt.
         ObjectStoreNotProvidedError: If *store* is ``None`` and no infrastructure store is set.
     """
 
@@ -961,147 +1112,269 @@ async def download_file_chunked(
     path = Path(local_path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    # HEAD to get exact size before allocating; also serves as the existence
-    # check. Skipped when the caller already knows the size (file_size), e.g. a
-    # prefix download whose listing carried per-object sizes.
-    if file_size is None:
-        try:
-            meta = await obstore.head_async(resolved, key)
-            file_size = int(meta["size"])
-        # conformance: ignore[E004] not-found and errors both re-raised via StorageError chain; no silent swallow
-        except Exception as exc:
-            if _is_not_found(exc):
-                from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
-                    StorageNotFoundError,
-                )
+    if resume is None:
+        from application_sdk.constants import STORAGE_RESUME_DOWNLOADS  # noqa: PLC0415
 
-                raise StorageNotFoundError(
-                    f"Key not found in store: {key}", key=key
-                ) from exc
-            from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
-                StorageError,
-            )
-
-            raise StorageError(
-                f"Failed to head key '{key}'", key=key, cause=exc
-            ) from exc
-
-    # Small files: delegate to the single-stream path so they still use the
-    # streaming GET (avoids allocating the whole body in memory via get_range_async).
-    if file_size <= chunk_size_bytes:
-        return await download_file(
-            key, local_path, resolved, compute_hash=compute_hash, normalize=False
-        )
-
-    # Pre-allocate the file at the target size so lseek can address any offset.
-    # 0o600: owner-only — downloaded artifacts can contain extracted customer
-    # metadata; don't rely on the process umask to keep them private.
-    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    try:
-        os.ftruncate(fd, file_size)
-    # conformance: ignore[E004] cleanup-on-error guard; closes fd then re-raises immediately with no swallow
-    except Exception:
-        os.close(fd)
-        raise
-
-    sem = asyncio.Semaphore(max_concurrent_chunks)
+        resume = STORAGE_RESUME_DOWNLOADS
 
     from application_sdk.constants import (  # noqa: PLC0415
         STORAGE_PROGRESS_LOG_INTERVAL_SECONDS as _progress_interval,
     )
 
-    started = time.monotonic()
-    last_progress = started
-    completed_bytes = 0
+    attempt = 0
+    while True:
+        attempt += 1
 
-    async def _fetch_chunk(offset: int) -> None:
-        nonlocal completed_bytes, last_progress
-        length = min(chunk_size_bytes, file_size - offset)
-        async with sem:
-            raw = bytes(
-                await obstore.get_range_async(
-                    resolved, key, start=offset, length=length
-                )
-            )
-            # lseek+write instead of pwrite (Windows lacks pwrite). Safe only
-            # because asyncio is single-threaded: no await between the two
-            # calls means no other coroutine can interleave on the fd position.
-            # WARNING: if _fetch_chunk is ever moved into a thread (e.g. via
-            # asyncio.to_thread), lseek+write becomes a data race — two threads
-            # could interleave their seeks and corrupt each other's writes.
-            # Use os.pwrite (or a per-thread fd) instead if that happens.
-            os.lseek(fd, offset, os.SEEK_SET)
-            os.write(fd, raw)
-            # Progress heartbeat: read-modify-write of the shared counters is
-            # race-free because asyncio is single-threaded and there is no await
-            # between here and the next chunk's update.
-            completed_bytes += len(raw)
-            if _progress_interval > 0:
-                now = time.monotonic()
-                if now - last_progress >= _progress_interval:
-                    _log_transfer_progress(
-                        "download",
-                        key,
-                        bytes_so_far=completed_bytes,
-                        elapsed_ms=(now - started) * 1000.0,
-                        total_bytes=file_size,
+        # HEAD to get exact size before allocating; also serves as the existence
+        # check. Skipped when the caller already knows the size (file_size), e.g.
+        # a prefix download whose listing carried per-object sizes (+ etags).
+        if file_size is None:
+            try:
+                meta = await obstore.head_async(resolved, key)
+                file_size = int(meta["size"])
+                if etag is None:
+                    etag = meta.get("e_tag")
+            # conformance: ignore[E004] not-found and errors both re-raised via StorageError chain; no silent swallow
+            except Exception as exc:
+                if _is_not_found(exc):
+                    from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
+                        StorageNotFoundError,
                     )
-                    last_progress = now
 
-    try:
-        await asyncio.gather(
-            *(_fetch_chunk(off) for off in range(0, file_size, chunk_size_bytes))
-        )
-    # conformance: ignore[E004] chunked-download error handler; closes fd, cleans up, emits the terminal event/metric, then re-raises via StorageError chain
-    except Exception as exc:
+                    raise StorageNotFoundError(
+                        f"Key not found in store: {key}", key=key
+                    ) from exc
+                from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
+                    StorageError,
+                )
+
+                raise StorageError(
+                    f"Failed to head key '{key}'", key=key, cause=exc
+                ) from exc
+
+        # Pin the resolved size for this attempt: `file_size` stays optional
+        # across restarts (reset to None to force a re-HEAD), `size` is the
+        # narrowed int used everywhere below, including the chunk closure.
+        assert file_size is not None
+        size: int = file_size
+        state_path = _transfer_state_path(path)
+
+        # Small files: delegate to the single-stream path so they still use the
+        # streaming GET (avoids materialising the whole body via range GETs).
+        # Drop any stale checkpoint from an earlier, larger object generation.
+        if size <= chunk_size_bytes:
+            state_path.unlink(missing_ok=True)
+            return await download_file(
+                key, local_path, resolved, compute_hash=compute_hash, normalize=False
+            )
+
+        # ── Resume check ────────────────────────────────────────────────────
+        # A checkpoint is only honoured when it describes exactly this object
+        # generation AND the partial data file is still the pre-allocated size.
+        done: set[int] = set()
+        resuming = False
+        if resume:
+            st = _load_transfer_state(state_path)
+            if (
+                st is not None
+                and st.get("key") == key
+                and st.get("file_size") == size
+                and st.get("chunk_size") == chunk_size_bytes
+                and st.get("etag") == etag
+                and path.is_file()
+                and path.stat().st_size == size
+            ):
+                done = set(st["done"])
+                resuming = bool(done)
+            else:
+                state_path.unlink(missing_ok=True)
+
+        # Pre-allocate the file at the target size so lseek can address any
+        # offset. On resume, open WITHOUT O_TRUNC so completed chunks survive.
+        # 0o600: owner-only — downloaded artifacts can contain extracted customer
+        # metadata; don't rely on the process umask to keep them private.
+        flags = os.O_WRONLY | os.O_CREAT | (0 if resuming else os.O_TRUNC)
+        fd = os.open(str(path), flags, 0o600)
+        try:
+            os.ftruncate(fd, size)
+        # conformance: ignore[E004] cleanup-on-error guard; closes fd then re-raises immediately with no swallow
+        except Exception:
+            os.close(fd)
+            raise
+
+        offsets = list(range(0, size, chunk_size_bytes))
+        pending = [(i, off) for i, off in enumerate(offsets) if i not in done]
+        state_base = {
+            "key": key,
+            "file_size": size,
+            "chunk_size": chunk_size_bytes,
+            "etag": etag,
+        }
+
+        sem = asyncio.Semaphore(max_concurrent_chunks)
+        started = time.monotonic()
+        last_progress = started
+        # Bytes already on disk from a previous attempt count toward progress
+        # so the % is truthful; fetched_bytes is what THIS attempt transferred
+        # and is what the terminal event / metrics report.
+        completed_bytes = sum(min(chunk_size_bytes, size - offsets[i]) for i in done)
+        fetched_bytes = 0
+
+        if resuming:
+            _log_storage_event(
+                logging.INFO,
+                "download",
+                key,
+                outcome="resume",
+                size_bytes=completed_bytes,
+            )
+
+        async def _fetch_chunk(idx: int, offset: int) -> None:
+            nonlocal completed_bytes, fetched_bytes, last_progress
+            length = min(chunk_size_bytes, size - offset)
+            async with sem:
+                if etag is not None:
+                    # Version-pinned range GET: 412 (PreconditionError) if the
+                    # object was rewritten — never mixes two generations.
+                    result = await obstore.get_async(
+                        resolved,
+                        key,
+                        options={
+                            "range": (offset, offset + length),
+                            "if_match": etag,
+                        },
+                    )
+                    raw = bytes(await result.bytes_async())
+                else:
+                    raw = bytes(
+                        await obstore.get_range_async(
+                            resolved, key, start=offset, length=length
+                        )
+                    )
+                # lseek+write instead of pwrite (Windows lacks pwrite). Safe only
+                # because asyncio is single-threaded: no await between the two
+                # calls means no other coroutine can interleave on the fd position.
+                # WARNING: if _fetch_chunk is ever moved into a thread (e.g. via
+                # asyncio.to_thread), lseek+write becomes a data race — two threads
+                # could interleave their seeks and corrupt each other's writes.
+                # Use os.pwrite (or a per-thread fd) instead if that happens.
+                os.lseek(fd, offset, os.SEEK_SET)
+                os.write(fd, raw)
+                # Checkpoint + progress: read-modify-write of the shared
+                # counters is race-free because asyncio is single-threaded and
+                # there is no await between here and the next chunk's update.
+                done.add(idx)
+                if resume:
+                    _save_transfer_state(
+                        state_path, {**state_base, "done": sorted(done)}
+                    )
+                completed_bytes += len(raw)
+                fetched_bytes += len(raw)
+                if _progress_interval > 0:
+                    now = time.monotonic()
+                    if now - last_progress >= _progress_interval:
+                        _log_transfer_progress(
+                            "download",
+                            key,
+                            bytes_so_far=completed_bytes,
+                            elapsed_ms=(now - started) * 1000.0,
+                            total_bytes=size,
+                        )
+                        last_progress = now
+
+        chunk_tasks = [
+            asyncio.ensure_future(_fetch_chunk(i, off)) for i, off in pending
+        ]
+        try:
+            await asyncio.gather(*chunk_tasks)
+        # conformance: ignore[E004] chunked-download error handler; cancels siblings, closes fd, checkpoints or cleans up, emits the terminal event/metric, then re-raises via StorageError chain
+        except Exception as exc:
+            # gather() does NOT cancel sibling tasks on first failure — without
+            # this drain, orphaned chunk coroutines would keep running and write
+            # into the fd after it is closed below (and, if the fd number were
+            # reused, into an unrelated file). Cancel and await them all before
+            # touching the fd. (BLDX-1523; latent since the original BLDX-1155
+            # implementation.)
+            for _t in chunk_tasks:
+                _t.cancel()
+            await asyncio.gather(*chunk_tasks, return_exceptions=True)
+            os.close(fd)
+            _log_storage_event(
+                logging.WARNING,
+                "download",
+                key,
+                outcome="failure",
+                elapsed_ms=(time.monotonic() - started) * 1000.0,
+                size_bytes=fetched_bytes,
+                error_class=_exc_class_name(exc),
+            )
+            if _is_precondition(exc):
+                # Object rewritten mid-download: the partial file mixes
+                # generations — discard it and restart fresh ONCE against
+                # whatever is now in the store.
+                _discard_transfer_state(path)
+                if attempt == 1:
+                    logger.warning(
+                        "Object changed during chunked download; restarting fresh: %s",
+                        key,
+                    )
+                    file_size = None
+                    etag = None
+                    continue
+                from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
+                    StorageError,
+                )
+
+                raise StorageError(
+                    f"Object at '{key}' kept changing during chunked download "
+                    f"(etag precondition failed twice)",
+                    key=key,
+                    cause=exc,
+                ) from exc
+            if _is_not_found(exc):
+                _discard_transfer_state(path)
+                from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
+                    StorageNotFoundError,
+                )
+
+                raise StorageNotFoundError(
+                    f"Key not found during chunked download: {key}", key=key
+                ) from exc
+            if not resume:
+                # Legacy behaviour: no checkpoint, so a partial file is garbage.
+                path.unlink(missing_ok=True)
+            # With resume enabled the partial file + sidecar stay on disk —
+            # the next attempt (Temporal retry, same pod) fetches only the
+            # missing ranges recorded in the checkpoint.
+            from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
+                StorageError,
+            )
+
+            raise StorageError(
+                f"Chunked download failed for '{key}'", key=key, cause=exc
+            ) from exc
+
         os.close(fd)
-        path.unlink(missing_ok=True)
-        # Chunked downloads previously emitted no terminal event — unify them
-        # with the single-stream path so their failures are logged + metered
-        # (throughput, error family) like every other transfer. (BLDX-1513)
+        # Success: the checkpoint's existence means "incomplete" — remove it so
+        # the file is observably complete.
+        state_path.unlink(missing_ok=True)
         _log_storage_event(
-            logging.WARNING,
+            logging.DEBUG,
             "download",
             key,
-            outcome="failure",
+            outcome="success",
             elapsed_ms=(time.monotonic() - started) * 1000.0,
-            size_bytes=completed_bytes,
-            error_class=_exc_class_name(exc),
-        )
-        if _is_not_found(exc):
-            from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
-                StorageNotFoundError,
-            )
-
-            raise StorageNotFoundError(
-                f"Key not found during chunked download: {key}", key=key
-            ) from exc
-        from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
-            StorageError,
+            size_bytes=fetched_bytes,
         )
 
-        raise StorageError(
-            f"Chunked download failed for '{key}'", key=key, cause=exc
-        ) from exc
+        if not compute_hash:
+            return None
 
-    os.close(fd)
-    _log_storage_event(
-        logging.DEBUG,
-        "download",
-        key,
-        outcome="success",
-        elapsed_ms=(time.monotonic() - started) * 1000.0,
-        size_bytes=completed_bytes,
-    )
-
-    if not compute_hash:
-        return None
-
-    h = hashlib.sha256()
-    with path.open("rb") as fh:
-        for chunk in iter(lambda: fh.read(1 << 20), b""):
-            h.update(chunk)
-    return h.hexdigest()
+        h = hashlib.sha256()
+        with path.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(1 << 20), b""):
+                h.update(chunk)
+        return h.hexdigest()
 
 
 async def _get_bytes(

--- a/application_sdk/storage/reference.py
+++ b/application_sdk/storage/reference.py
@@ -386,7 +386,7 @@ async def materialize_file_reference(
         _safe_join_under,
         download_file,
         download_file_chunked,
-        get_file_size,
+        get_file_meta,
     )
 
     if not ref.is_durable or ref.storage_path is None:
@@ -396,8 +396,8 @@ async def materialize_file_reference(
     # Sizes come back with the listing so the directory branch can chunk large
     # files without a per-file HEAD (BLDX-1513).
     all_items = await list_keys_with_sizes(ref.storage_path, store)
-    data_items = [(k, s) for k, s in all_items if not k.endswith(".sha256")]
-    data_keys = [k for k, _ in data_items]
+    data_items = [(k, s, e) for k, s, e in all_items if not k.endswith(".sha256")]
+    data_keys = [k for k, _, _ in data_items]
 
     # Structured kwargs in the logger calls below are intentional: every key used
     # (storage_path, local_path, file_size_bytes, bytes_downloaded,
@@ -450,7 +450,10 @@ async def materialize_file_reference(
         # lists empty here, AND some stores (notably GCS with conditional
         # IAM) silently return an empty listing when the caller lacks
         # permission.
-        remote_size = await get_file_size(ref.storage_path, store, normalize=False)
+        remote_meta = await get_file_meta(ref.storage_path, store, normalize=False)
+        remote_size, remote_etag = (
+            remote_meta if remote_meta is not None else (None, None)
+        )
         if remote_size is None:
             raise StorageNotFoundError(
                 f"FileReference path '{ref.storage_path}' resolved to no "
@@ -492,9 +495,11 @@ async def materialize_file_reference(
                     max_concurrent_chunks=FILE_REF_CHUNK_CONCURRENCY,
                     compute_hash=True,
                     normalize=False,
-                    # remote_size already fetched via get_file_size (HEAD) above;
-                    # reuse it so the chunked path doesn't HEAD a second time.
+                    # remote_size/etag already fetched via get_file_meta (HEAD)
+                    # above; reuse both so the chunked path doesn't HEAD a
+                    # second time and its range GETs are version-pinned.
                     file_size=remote_size,
+                    etag=remote_etag,
                 )
             else:
                 sha256 = await download_file(
@@ -571,7 +576,7 @@ async def materialize_file_reference(
 
         prefix = ref.storage_path.rstrip("/") + "/"
 
-        async def _download_one(key: str, size: int) -> bool:
+        async def _download_one(key: str, size: int, etag: str | None) -> bool:
             """Download one file from the prefix. Returns True if skipped (cache hit)."""
             rel = key.removeprefix(prefix)
             # Reject keys whose resolved path escapes local_directory.
@@ -621,6 +626,7 @@ async def materialize_file_reference(
                 compute_hash=True,
                 normalize=False,
                 file_size=size,
+                etag=etag,
             )
             if sha256 is not None:
                 _write_local_sidecar(dest, sha256)
@@ -636,7 +642,7 @@ async def materialize_file_reference(
 
             sem = asyncio.Semaphore(MAX_CONCURRENT_STORAGE_TRANSFERS)
             results = await _gather_with_semaphore(
-                [_download_one(k, s) for k, s in data_items], sem
+                [_download_one(k, s, e) for k, s, e in data_items], sem
             )
             skipped = sum(results)
         except Exception as exc:

--- a/application_sdk/storage/transfer.py
+++ b/application_sdk/storage/transfer.py
@@ -188,12 +188,14 @@ async def _download_one(
     *,
     skip_if_exists: bool,
     file_size: int | None = None,
+    etag: str | None = None,
 ) -> tuple[bool, str]:
     """Download a single file.  Returns ``(transferred, reason)``.
 
-    *file_size* (when known from a prior listing) is threaded to the chunked
-    path so large objects fetch via bounded range GETs without a per-file HEAD;
-    ``None`` lets the chunked path HEAD once (single-file case). (BLDX-1513)
+    *file_size* / *etag* (when known from a prior listing) are threaded to the
+    chunked path so large objects fetch via bounded, version-pinned range GETs
+    without a per-file HEAD; ``None`` lets the chunked path HEAD once
+    (single-file case). (BLDX-1513 / BLDX-1523)
     """
     from application_sdk.storage.ops import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
         download_file_chunked,
@@ -214,6 +216,7 @@ async def _download_one(
         compute_hash=False,
         normalize=False,
         file_size=file_size,
+        etag=etag,
     )
     return True, "downloaded"
 
@@ -750,7 +753,7 @@ async def download(
         # per-file HEAD (BLDX-1513).
         all_items = await list_keys_with_sizes(prefix, resolved, normalize=False)
         # Exclude SHA-256 sidecars from the listing.
-        data_items = [(k, s) for k, s in all_items if not _is_sidecar(k)]
+        data_items = [(k, s, e) for k, s, e in all_items if not _is_sidecar(k)]
 
         if local_path is not None:
             dest_dir = Path(local_path)
@@ -761,12 +764,17 @@ async def download(
         strip = prefix
 
         transferred_count = 0
-        for key, size in data_items:
+        for key, size, etag in data_items:
             rel = key.removeprefix(strip)
             # Reject keys whose resolved path escapes dest_dir (e.g. via ".." segments).
             local_file = _safe_join_under(dest_dir, rel)
             ok, _ = await _download_one(
-                resolved, key, local_file, skip_if_exists=skip_if_exists, file_size=size
+                resolved,
+                key,
+                local_file,
+                skip_if_exists=skip_if_exists,
+                file_size=size,
+                etag=etag,
             )
             if ok:
                 transferred_count += 1

--- a/tests/unit/storage/test_batch.py
+++ b/tests/unit/storage/test_batch.py
@@ -173,7 +173,7 @@ class TestDownloadPrefix:
         with (
             patch(
                 "application_sdk.storage.batch.list_keys_with_sizes",
-                new=AsyncMock(return_value=[("safe/../../canary.txt", 10)]),
+                new=AsyncMock(return_value=[("safe/../../canary.txt", 10, None)]),
             ),
             pytest.raises(StorageError, match="Path traversal"),
         ):

--- a/tests/unit/storage/test_ops.py
+++ b/tests/unit/storage/test_ops.py
@@ -680,6 +680,218 @@ class TestChunkedFileSizeSkipsHead:
             )
 
 
+class TestResumableChunkedDownload:
+    """Resume + etag version pinning for chunked downloads (BLDX-1523).
+
+    Uses a real MemoryStore (which supports ``If-Match`` preconditions) with
+    ``chunk_size_bytes=8`` so multi-chunk behaviour is exercised with tiny
+    payloads. ``max_concurrent_chunks=1`` where determinism matters.
+    """
+
+    CONTENT = bytes(range(38))  # 5 chunks at chunk_size=8 (last chunk 6 bytes)
+
+    def _state_path(self, out: Path) -> Path:
+        return Path(str(out) + ".transfer-state")
+
+    async def test_fresh_download_pins_etag_and_removes_state(
+        self, store, tmp_path
+    ) -> None:
+        await _put("res/f.bin", self.CONTENT, store, normalize=False)
+        out = tmp_path / "f.bin"
+
+        real_get = __import__("obstore").get_async
+        seen_options: list[dict] = []
+
+        async def counting_get(st, key, **kw):
+            seen_options.append(kw.get("options") or {})
+            return await real_get(st, key, **kw)
+
+        with patch("application_sdk.storage.ops.obstore.get_async", new=counting_get):
+            digest = await download_file_chunked(
+                "res/f.bin", out, store, chunk_size_bytes=8, normalize=False
+            )
+
+        assert out.read_bytes() == self.CONTENT
+        assert digest == hashlib.sha256(self.CONTENT).hexdigest()
+        # every range GET carried the etag pin from the internal HEAD
+        assert len(seen_options) == 5
+        assert all(o.get("if_match") for o in seen_options)
+        # checkpoint removed on success — file is observably complete
+        assert not self._state_path(out).exists()
+
+    async def test_interrupted_download_keeps_partial_then_resumes(
+        self, store, tmp_path
+    ) -> None:
+        await _put("res/g.bin", self.CONTENT, store, normalize=False)
+        out = tmp_path / "g.bin"
+        real_get = __import__("obstore").get_async
+
+        async def failing_get(st, key, **kw):
+            rng = (kw.get("options") or {}).get("range")
+            if rng and rng[0] == 16:  # chunk index 2
+                raise RuntimeError("simulated network drop")
+            return await real_get(st, key, **kw)
+
+        with (
+            patch("application_sdk.storage.ops.obstore.get_async", new=failing_get),
+            pytest.raises(StorageError),
+        ):
+            await download_file_chunked(
+                "res/g.bin",
+                out,
+                store,
+                chunk_size_bytes=8,
+                max_concurrent_chunks=1,
+                normalize=False,
+            )
+
+        # Partial file + checkpoint survive the failure (chunks 0,1 done).
+        assert out.exists()
+        state = orjson.loads(self._state_path(out).read_bytes())
+        assert state["done"] == [0, 1]
+
+        # Retry fetches ONLY the missing chunks (2,3,4).
+        fetched_ranges: list[tuple] = []
+
+        async def counting_get(st, key, **kw):
+            fetched_ranges.append((kw.get("options") or {}).get("range"))
+            return await real_get(st, key, **kw)
+
+        with patch("application_sdk.storage.ops.obstore.get_async", new=counting_get):
+            digest = await download_file_chunked(
+                "res/g.bin",
+                out,
+                store,
+                chunk_size_bytes=8,
+                max_concurrent_chunks=1,
+                normalize=False,
+            )
+
+        assert sorted(r[0] for r in fetched_ranges) == [16, 24, 32]
+        assert out.read_bytes() == self.CONTENT
+        assert digest == hashlib.sha256(self.CONTENT).hexdigest()
+        assert not self._state_path(out).exists()
+
+    async def test_object_rewritten_mid_download_restarts_fresh_once(
+        self, store, tmp_path
+    ) -> None:
+        await _put("res/h.bin", self.CONTENT, store, normalize=False)
+        out = tmp_path / "h.bin"
+        # Force a stale etag: every pinned GET 412s, the restart re-HEADs and
+        # succeeds against the current generation.
+        digest = await download_file_chunked(
+            "res/h.bin",
+            out,
+            store,
+            chunk_size_bytes=8,
+            normalize=False,
+            file_size=len(self.CONTENT),
+            etag='"stale-etag"',
+        )
+        assert out.read_bytes() == self.CONTENT
+        assert digest == hashlib.sha256(self.CONTENT).hexdigest()
+        assert not self._state_path(out).exists()
+
+    async def test_persistent_precondition_failure_raises(
+        self, store, tmp_path
+    ) -> None:
+        from obstore.exceptions import PreconditionError
+
+        await _put("res/i.bin", self.CONTENT, store, normalize=False)
+        out = tmp_path / "i.bin"
+
+        async def always_412(st, key, **kw):
+            raise PreconditionError("simulated: object keeps changing")
+
+        with (
+            patch("application_sdk.storage.ops.obstore.get_async", new=always_412),
+            pytest.raises(StorageError, match="kept changing"),
+        ):
+            await download_file_chunked(
+                "res/i.bin", out, store, chunk_size_bytes=8, normalize=False
+            )
+        # Mixed-generation partials are never left behind.
+        assert not out.exists()
+        assert not self._state_path(out).exists()
+
+    async def test_checkpoint_from_other_generation_is_discarded(
+        self, store, tmp_path
+    ) -> None:
+        await _put("res/j.bin", self.CONTENT, store, normalize=False)
+        out = tmp_path / "j.bin"
+        # Plant a full-size file of zeros plus a checkpoint claiming all chunks
+        # done — but for a DIFFERENT etag. The download must not trust it.
+        out.write_bytes(b"\x00" * len(self.CONTENT))
+        self._state_path(out).write_bytes(
+            orjson.dumps(
+                {
+                    "key": "res/j.bin",
+                    "file_size": len(self.CONTENT),
+                    "chunk_size": 8,
+                    "etag": "some-old-generation",
+                    "done": [0, 1, 2, 3, 4],
+                }
+            )
+        )
+        digest = await download_file_chunked(
+            "res/j.bin", out, store, chunk_size_bytes=8, normalize=False
+        )
+        assert out.read_bytes() == self.CONTENT  # zeros were NOT trusted
+        assert digest == hashlib.sha256(self.CONTENT).hexdigest()
+
+    async def test_corrupt_checkpoint_falls_back_to_fresh(
+        self, store, tmp_path
+    ) -> None:
+        await _put("res/k.bin", self.CONTENT, store, normalize=False)
+        out = tmp_path / "k.bin"
+        self._state_path(out).write_bytes(b"not json at all {{{")
+        digest = await download_file_chunked(
+            "res/k.bin", out, store, chunk_size_bytes=8, normalize=False
+        )
+        assert out.read_bytes() == self.CONTENT
+        assert digest == hashlib.sha256(self.CONTENT).hexdigest()
+        assert not self._state_path(out).exists()
+
+    async def test_resume_disabled_deletes_partial_on_failure(
+        self, store, tmp_path
+    ) -> None:
+        await _put("res/l.bin", self.CONTENT, store, normalize=False)
+        out = tmp_path / "l.bin"
+        real_get = __import__("obstore").get_async
+
+        async def failing_get(st, key, **kw):
+            rng = (kw.get("options") or {}).get("range")
+            if rng and rng[0] == 16:
+                raise RuntimeError("boom")
+            return await real_get(st, key, **kw)
+
+        with (
+            patch("application_sdk.storage.ops.obstore.get_async", new=failing_get),
+            pytest.raises(StorageError),
+        ):
+            await download_file_chunked(
+                "res/l.bin",
+                out,
+                store,
+                chunk_size_bytes=8,
+                max_concurrent_chunks=1,
+                normalize=False,
+                resume=False,
+            )
+        # Legacy behaviour: nothing left behind.
+        assert not out.exists()
+        assert not self._state_path(out).exists()
+
+    async def test_small_file_leaves_no_checkpoint(self, store, tmp_path) -> None:
+        await _put("res/small.bin", b"tiny", store, normalize=False)
+        out = tmp_path / "small.bin"
+        await download_file_chunked(
+            "res/small.bin", out, store, chunk_size_bytes=8, normalize=False
+        )
+        assert out.read_bytes() == b"tiny"
+        assert not self._state_path(out).exists()
+
+
 class TestTransferMetrics:
     """Transfers emit metrics via the SDK metrics rail (BLDX-1513)."""
 
@@ -920,27 +1132,30 @@ class TestDownloadFileChunked:
         assert result == hashlib.sha256(content).hexdigest()
 
     async def test_partial_file_cleaned_up_on_error(self, store, tmp_path) -> None:
-        """If a chunk fails mid-download, the partial output file is deleted."""
+        """With resume disabled, a chunk failure deletes the partial output file.
+
+        (With resume enabled — the default since BLDX-1523 — the partial file
+        and its checkpoint sidecar are intentionally KEPT; see
+        TestResumableChunkedDownload for that contract.) Chunk fetches are
+        version-pinned via ``get_async`` when the store provides an etag, so
+        the failure is injected there.
+        """
         content = b"ABCDEFGHIJ"
         await _put("chunked/boom.bin", content, store, normalize=False)
         dest = tmp_path / "out.bin"
 
-        import application_sdk.storage.ops as ops_mod
-
-        real_get_range = ops_mod.obstore.get_range_async
+        real_get = __import__("obstore").get_async
         call_count = 0
 
-        async def flaky_get_range(st, key, *, start, length):
+        async def flaky_get(st, key, **kw):
             nonlocal call_count
             call_count += 1
             if call_count == 2:
                 raise RuntimeError("transient chunk failure")
-            return await real_get_range(st, key, start=start, length=length)
+            return await real_get(st, key, **kw)
 
         with (
-            patch.object(
-                ops_mod.obstore, "get_range_async", side_effect=flaky_get_range
-            ),
+            patch("application_sdk.storage.ops.obstore.get_async", new=flaky_get),
             pytest.raises((StorageError, RuntimeError)),
         ):
             await download_file_chunked(
@@ -949,6 +1164,7 @@ class TestDownloadFileChunked:
                 store,
                 chunk_size_bytes=3,
                 normalize=False,
+                resume=False,
             )
 
         assert not dest.exists(), "partial file must be cleaned up after chunk failure"

--- a/tests/unit/storage/test_reference.py
+++ b/tests/unit/storage/test_reference.py
@@ -387,7 +387,7 @@ class TestMaterializeFileReference:
         with (
             patch(
                 "application_sdk.storage.batch.list_keys_with_sizes",
-                new=AsyncMock(return_value=[("dirkey/../../canary.txt", 10)]),
+                new=AsyncMock(return_value=[("dirkey/../../canary.txt", 10, None)]),
             ),
             pytest.raises(StorageError, match="Path traversal"),
         ):

--- a/tests/unit/storage/test_transfer.py
+++ b/tests/unit/storage/test_transfer.py
@@ -410,7 +410,7 @@ class TestDownloadDirectory:
         with (
             patch(
                 "application_sdk.storage.batch.list_keys_with_sizes",
-                new=AsyncMock(return_value=[("p/safe/../../canary.txt", 10)]),
+                new=AsyncMock(return_value=[("p/safe/../../canary.txt", 10, None)]),
             ),
             pytest.raises(StorageError, match="Path traversal"),
         ):


### PR DESCRIPTION
## What & why

Stacked on #2479 (BLDX-1513). That PR made large transfers survive slow egress via chunked parallel range GETs + a progress-based `read_timeout`. Two gaps remained — this PR closes them ([BLDX-1523](https://linear.app/atlan-epd/issue/BLDX-1523)):

1. **No resume.** An interrupted chunked download deleted its partial file, so a pod crash / Temporal activity retry at 95% re-fetched 100% of the object. On the incident tenant (~1 MiB/s egress, ~250 MB cache files × 217) that makes every retry brutally expensive.
2. **No version pinning.** Parallel range GETs were independent requests: an object rewritten mid-download (connection-cache files are rewritten **every publish run**) could assemble a file mixing two object generations. The FileReference SHA-256 sidecar check caught this after the fact; the `compute_hash=False` paths (prefix / CloudStore / transfer) had **no** guard.

## Changes

**Resume (checkpoint sidecar):**
- Completed chunk indices are checkpointed to `{path}.transfer-state` (atomic write + fsync) after every chunk write. On retry, only the missing ranges are fetched — crash at 95% → retry fetches 5%.
- The checkpoint records the object generation (key / size / chunk size / etag) and is honoured only on an exact match. It is **deleted on success**, so a data file without a sidecar is always complete — incomplete files are unobservable.
- Scope note: resume works when the retry sees the same filesystem (same pod — the incident's exact case — or a PV). Node loss = fresh download, made safe by the etag check.
- Kill-switch: `ATLAN_STORAGE_RESUME_DOWNLOADS=false` restores delete-partial-on-failure.

**Version-pinned range GETs (`If-Match`):**
- Listings now carry per-object etags (`list_keys_with_sizes` → `(key, size, e_tag)`), threaded through every chunked call site (FileReference directory branch, `download_prefix`, `CloudStore`, `transfer`). Single-file paths capture the etag from their existing HEAD (new `get_file_meta` helper). **No extra requests anywhere.**
- Each range GET sends `If-Match: etag` — a concurrent rewrite fails with 412 (typed `PreconditionError`) instead of serving mixed bytes. On 412 the partial is discarded and the download restarts fresh **once** against the new generation; a second 412 raises `StorageError`.
- Works on S3 / GCS / Azure — `If-Match` handling is in the shared object_store Rust layer.

**Latent orphan-task bug fixed** (present since the original BLDX-1155 implementation): `asyncio.gather` does not cancel sibling chunk tasks on first failure, so orphaned coroutines kept running and wrote into the fd **after it was closed** (and, on fd-number reuse, potentially into an unrelated file). Chunk tasks are now cancelled and drained before the fd is closed. Surfaced by the new resume tests.

## What this deliberately does NOT do
- No Python-level retry loop on top of obstore's Rust retry (standing BLDX-1155 decision). Per-chunk retry (5xx / connection errors / read-timeout) already happens in the Rust layer.
- No multipart *upload* resume — uploads are already multipart with per-part Rust-layer retry on all three clouds; re-uploading a local file after a crash is acceptable (stretch item on the ticket, likely won't-do).

## Testing
- New `TestResumableChunkedDownload` suite (real MemoryStore, which enforces `If-Match`): resume-after-interrupt fetches only missing ranges `[16,24,32]`; every range GET carries the etag pin; 412 → restart-once succeeds; persistent 412 raises with nothing left behind; stale-generation / corrupt checkpoints fall back to fresh; `resume=False` restores legacy cleanup; small files never create checkpoints.
- Full unit suite: **5325 passed / 9 skipped**; pre-commit (ruff / ruff-format / isort / pyright) clean.
- Live-verified obstore 0.11.0 semantics before building: `get_async(options={"range": (s,e), "if_match": etag})` → end-exclusive range, typed `PreconditionError` on stale etag.

## Merge order
Base: `vaibhavchopra/bldx-1513` (#2479). Retarget/rebase onto `main` once #2479 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
