### PR TITLE
ci: extend contract-toolkit Pages build timeout, skip redundant retrigger

### DIFF
--- a/.github/scripts/tests/test_wait_for_pages_build.py
+++ b/.github/scripts/tests/test_wait_for_pages_build.py
@@ -1,0 +1,129 @@
+"""Tests for .github/scripts/wait_for_pages_build.py.
+
+Covers the driver's conditional logic — the part that used to be inlined shell
+in contract-toolkit-publish.yml:
+
+  * already built for the target commit -> skip triggering a new build
+  * not yet built, then transitions to built -> succeeds without a false skip
+  * commit mismatch (stale "latest" build) -> keeps polling instead of exiting
+  * errored build -> fails immediately, without exhausting the poll budget
+  * never reaches built -> times out after max_attempts
+
+`gh`/`git` are stubbed; each stubbed `pages/builds/latest` call returns a
+single canned response so status/commit are read together, matching the
+production code's single-call-per-poll contract.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import wait_for_pages_build as mod
+
+REPO = "atlanhq/application-sdk"
+SHA = "9756039c00c9d63becabe6da2bd4f36231857591"
+
+
+def _completed(stdout: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout)
+
+
+def _build(status: str, commit: str = SHA, error_message: str | None = None) -> dict:
+    build = {"status": status, "commit": commit}
+    if error_message is not None:
+        build["error"] = {"message": error_message}
+    return build
+
+
+def _make_fake_run(build_responses: list[dict]):
+    """Dispatch `git rev-parse` / `gh api .../builds/latest` / `gh api POST
+    .../builds`. Each `builds/latest` call pops the next canned response, so a
+    test can script exactly what each poll iteration sees."""
+    calls = {"trigger": 0, "polls": 0}
+    remaining = list(build_responses)
+
+    def fake_run(cmd: list[str]) -> subprocess.CompletedProcess:
+        if cmd[:2] == ["git", "rev-parse"]:
+            return _completed(SHA + "\n")
+        if cmd[:2] == ["gh", "api"] and cmd[2] == f"repos/{REPO}/pages/builds/latest":
+            calls["polls"] += 1
+            build = remaining.pop(0) if len(remaining) > 1 else remaining[0]
+            return _completed(json.dumps(build))
+        if cmd[:4] == ["gh", "api", "--method", "POST"]:
+            calls["trigger"] += 1
+            return _completed("")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    return fake_run, calls
+
+
+def test_already_built_skips_trigger(monkeypatch):
+    fake_run, calls = _make_fake_run([_build("built")])
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    assert mod.wait_for_build(REPO, SHA, sleep=lambda s: None) is True
+    assert calls["trigger"] == 0
+    assert calls["polls"] == 1
+
+
+def test_building_then_built_succeeds(monkeypatch):
+    fake_run, calls = _make_fake_run(
+        [_build("queued"), _build("building"), _build("built")]
+    )
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    assert mod.wait_for_build(REPO, SHA, sleep=lambda s: None) is True
+    assert calls["trigger"] == 1
+
+
+def test_stale_commit_keeps_polling_until_target_commit_builds(monkeypatch):
+    fake_run, _ = _make_fake_run(
+        [
+            _build("queued"),
+            _build("built", commit="stale-sha"),  # a prior build, not ours
+            _build("building"),
+            _build("built"),
+        ]
+    )
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    assert mod.wait_for_build(REPO, SHA, sleep=lambda s: None) is True
+
+
+def test_errored_build_fails_without_exhausting_budget(monkeypatch):
+    fake_run, calls = _make_fake_run(
+        [_build("queued"), _build("errored", error_message="boom")]
+    )
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    assert (
+        mod.wait_for_build(REPO, SHA, max_attempts=300, sleep=lambda s: None) is False
+    )
+    # Only polled twice (initial skip-check + the errored poll), not 300 times.
+    assert calls["polls"] == 2
+
+
+def test_timeout_when_never_built(monkeypatch):
+    fake_run, calls = _make_fake_run([_build("queued"), _build("building")])
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    assert mod.wait_for_build(REPO, SHA, max_attempts=3, sleep=lambda s: None) is False
+    # initial skip-check + 3 poll attempts
+    assert calls["polls"] == 4
+
+
+def test_main_exit_codes(monkeypatch):
+    fake_run, _ = _make_fake_run([_build("built")])
+    monkeypatch.setattr(mod, "run", fake_run)
+    assert mod.main(["--repo", REPO]) == 0
+
+    fake_run, _ = _make_fake_run(
+        [_build("queued"), _build("errored", error_message="boom")]
+    )
+    monkeypatch.setattr(mod, "run", fake_run)
+    assert mod.main(["--repo", REPO]) == 1

--- a/.github/scripts/wait_for_pages_build.py
+++ b/.github/scripts/wait_for_pages_build.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Wait for a GitHub Pages build of the current commit, triggering one if needed.
+
+Invoked by .github/workflows/contract-toolkit-publish.yml after the built
+contract-toolkit package is pushed to the gh-pages branch. Moved out of
+inlined shell per docs/standards/ci.md ("No conditional logic in inlined
+shell"): the skip-if-already-built check and the poll loop both branch on
+state, so they belong in a tested driver, not a workflow `run:` block.
+
+Exits 0 once the target commit's Pages build reaches "built" — including
+immediately, without triggering a redundant new build, if it is already
+built. Exits 1 if the build errors, or once the poll budget is exhausted.
+
+Each poll reads `status` and `commit` from a single `gh api
+.../pages/builds/latest` response rather than two separate calls: the
+"latest" build can change between two independent requests, which would let
+a caller read `status` from one build and `commit` from another.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+
+
+def run(cmd: list[str]) -> subprocess.CompletedProcess:
+    """Run a subprocess and capture output. Single seam so tests can stub gh/git."""
+    return subprocess.run(cmd, check=False, text=True, capture_output=True)
+
+
+def current_commit() -> str:
+    return run(["git", "rev-parse", "HEAD"]).stdout.strip()
+
+
+def latest_build(repo: str) -> dict:
+    result = run(["gh", "api", f"repos/{repo}/pages/builds/latest"])
+    return json.loads(result.stdout)
+
+
+def trigger_build(repo: str) -> None:
+    run(["gh", "api", "--method", "POST", f"repos/{repo}/pages/builds"])
+
+
+def wait_for_build(
+    repo: str,
+    pages_sha: str,
+    *,
+    max_attempts: int = 300,
+    sleep_seconds: int = 5,
+    sleep=time.sleep,
+) -> bool:
+    """Poll until `pages_sha`'s Pages build is `built`.
+
+    Returns True on success (already built, or reached `built` within the poll
+    budget), False on an `errored` build or timeout.
+    """
+    build = latest_build(repo)
+    if build.get("commit") == pages_sha and build.get("status") == "built":
+        print(f"Pages already built for {pages_sha}; skipping rebuild trigger.")
+        return True
+
+    trigger_build(repo)
+
+    for _ in range(max_attempts):
+        build = latest_build(repo)
+        if build.get("commit") != pages_sha:
+            sleep(sleep_seconds)
+            continue
+
+        status = build.get("status")
+        if status == "built":
+            return True
+        if status == "errored":
+            message = (build.get("error") or {}).get("message") or "unknown error"
+            print(f"::error::GitHub Pages build failed: {message}")
+            return False
+
+        sleep(sleep_seconds)
+
+    print(f"::error::Timed out waiting for GitHub Pages build for {pages_sha}")
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo", required=True, help="owner/repo, e.g. atlanhq/application-sdk"
+    )
+    parser.add_argument(
+        "--max-attempts",
+        type=int,
+        default=300,
+        help="Poll iterations before giving up (default: 300 * 5s = 25 minutes).",
+    )
+    parser.add_argument("--sleep-seconds", type=int, default=5)
+    args = parser.parse_args(argv)
+
+    pages_sha = current_commit()
+    ok = wait_for_build(
+        args.repo,
+        pages_sha,
+        max_attempts=args.max_attempts,
+        sleep_seconds=args.sleep_seconds,
+    )
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/contract-toolkit-publish.yml
+++ b/.github/workflows/contract-toolkit-publish.yml
@@ -96,9 +96,28 @@ jobs:
         run: |
           set -euo pipefail
           pages_sha="$(git rev-parse HEAD)"
+
+          # Skip re-triggering if this exact commit already finished building
+          # (e.g. a prior run's build completed after that run had already
+          # timed out and failed). Posting a fresh build request unconditionally
+          # on every retry restarts the clock on a brand-new build ID instead of
+          # noticing the existing one already succeeded.
+          latest_status="$(gh api "repos/${GITHUB_REPOSITORY}/pages/builds/latest" --jq '.status')"
+          latest_commit="$(gh api "repos/${GITHUB_REPOSITORY}/pages/builds/latest" --jq '.commit')"
+          if [ "$latest_commit" = "$pages_sha" ] && [ "$latest_status" = "built" ]; then
+            echo "Pages already built for ${pages_sha}; skipping rebuild trigger."
+            exit 0
+          fi
+
           gh api --method POST "repos/${GITHUB_REPOSITORY}/pages/builds"
 
-          for attempt in $(seq 1 60); do
+          # Observed build latency for this repo has run up to ~9 minutes
+          # (2026-07-03, contract-toolkit v0.17.0 publish), well past the
+          # previous 5-minute budget (60 * 5s) — every attempt timed out here
+          # even though the build went on to succeed moments later. Poll for
+          # up to 25 minutes (300 * 5s) to leave real headroom above observed
+          # latency instead of racing it.
+          for attempt in $(seq 1 300); do
             status="$(gh api "repos/${GITHUB_REPOSITORY}/pages/builds/latest" --jq '.status')"
             commit="$(gh api "repos/${GITHUB_REPOSITORY}/pages/builds/latest" --jq '.commit')"
 

--- a/.github/workflows/contract-toolkit-publish.yml
+++ b/.github/workflows/contract-toolkit-publish.yml
@@ -94,54 +94,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
-          pages_sha="$(git rev-parse HEAD)"
-
-          # Skip re-triggering if this exact commit already finished building
-          # (e.g. a prior run's build completed after that run had already
-          # timed out and failed). Posting a fresh build request unconditionally
-          # on every retry restarts the clock on a brand-new build ID instead of
-          # noticing the existing one already succeeded.
-          latest_status="$(gh api "repos/${GITHUB_REPOSITORY}/pages/builds/latest" --jq '.status')"
-          latest_commit="$(gh api "repos/${GITHUB_REPOSITORY}/pages/builds/latest" --jq '.commit')"
-          if [ "$latest_commit" = "$pages_sha" ] && [ "$latest_status" = "built" ]; then
-            echo "Pages already built for ${pages_sha}; skipping rebuild trigger."
-            exit 0
-          fi
-
-          gh api --method POST "repos/${GITHUB_REPOSITORY}/pages/builds"
-
-          # Observed build latency for this repo has run up to ~9 minutes
-          # (2026-07-03, contract-toolkit v0.17.0 publish), well past the
-          # previous 5-minute budget (60 * 5s) — every attempt timed out here
-          # even though the build went on to succeed moments later. Poll for
-          # up to 25 minutes (300 * 5s) to leave real headroom above observed
-          # latency instead of racing it.
-          for attempt in $(seq 1 300); do
-            status="$(gh api "repos/${GITHUB_REPOSITORY}/pages/builds/latest" --jq '.status')"
-            commit="$(gh api "repos/${GITHUB_REPOSITORY}/pages/builds/latest" --jq '.commit')"
-
-            if [ "$commit" != "$pages_sha" ]; then
-              sleep 5
-              continue
-            fi
-
-            case "$status" in
-              built)
-                exit 0
-                ;;
-              errored)
-                message="$(gh api "repos/${GITHUB_REPOSITORY}/pages/builds/latest" --jq '.error.message // "unknown error"')"
-                echo "::error::GitHub Pages build failed: ${message}"
-                exit 1
-                ;;
-            esac
-
-            sleep 5
-          done
-
-          echo "::error::Timed out waiting for GitHub Pages build for ${pages_sha}"
-          exit 1
+          python3 .github/scripts/wait_for_pages_build.py --repo "${GITHUB_REPOSITORY}"
 
       - name: Create source tag
         run: |


### PR DESCRIPTION
## Summary
- Publishing contract-toolkit v0.17.0 timed out three times in a row on `contract-toolkit-publish.yml`'s "Trigger GitHub Pages build" step. The poll loop gave up after 5 minutes (`60 * 5s`), but the Pages build for this repo consistently took ~8.5–9 minutes to actually finish — the workflow failed right before the build it triggered would have succeeded.
- Each retry also unconditionally POSTed a brand-new `pages/builds` request (a fresh build ID every time), so rerunning never picked up on a build that had already completed — it just restarted the clock.
- This fix (a) extends the poll budget to 25 minutes (`300 * 5s`) for real headroom above observed latency, and (b) checks whether the latest build for the exact target commit is already `built` before triggering a new one, so retries are idempotent instead of wasteful.
- Net effect: the "Create source tag" step (which never ran across all 3 failed attempts) will actually get a chance to execute, so `contract-toolkit-v<version>` tags get cut reliably and Renovate can pick up new releases without manual intervention.

## Test plan
- [ ] Merge and observe the next contract-toolkit release PR merge to confirm `contract-toolkit-publish.yml` completes and the tag is created without manual reruns.
- [ ] Confirm a rerun on an already-`built` commit exits early via the new skip check instead of re-POSTing a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)