### PR TITLE
ci: allow manual dispatch of Publish Contract Toolkit

### DIFF
--- a/.github/workflows/contract-toolkit-publish.yml
+++ b/.github/workflows/contract-toolkit-publish.yml
@@ -7,11 +7,21 @@ name: Publish Contract Toolkit
 # branch, and creates the contract-toolkit-v<version> annotated tag.
 # No GitHub Release is created — that would interleave contract-toolkit
 # versions with SDK v* releases on the repo releases page.
+#
+# Also runnable manually (workflow_dispatch) to retry a publish that failed
+# or timed out without a new release PR — every step is idempotent (gh-pages
+# commit/push, Pages build trigger, and tag creation all no-op if the target
+# is already up to date), so re-running against an unchanged
+# contract-toolkit/src/PklProject version is always safe. workflow_dispatch
+# always builds off `main`, matching the pull_request path — the ref you
+# launch it from is irrelevant, only the explicit `ref: main` checkout below
+# matters.
 
 on:
   pull_request:
     types: [closed]
     branches: [main]
+  workflow_dispatch: {}
 
 permissions:
   contents: write
@@ -28,8 +38,9 @@ jobs:
     name: Publish contract toolkit package
     runs-on: ubuntu-latest
     if: >-
-      github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'release:contract-toolkit')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'release:contract-toolkit'))
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/contract-toolkit-publish.yml
+++ b/.github/workflows/contract-toolkit-publish.yml
@@ -12,10 +12,11 @@ name: Publish Contract Toolkit
 # or timed out without a new release PR — every step is idempotent (gh-pages
 # commit/push, Pages build trigger, and tag creation all no-op if the target
 # is already up to date), so re-running against an unchanged
-# contract-toolkit/src/PklProject version is always safe. workflow_dispatch
-# always builds off `main`, matching the pull_request path — the ref you
-# launch it from is irrelevant, only the explicit `ref: main` checkout below
-# matters.
+# contract-toolkit/src/PklProject version is always safe. Dispatch from
+# `main` to run this workflow's current logic — as with any workflow_dispatch,
+# the ref you dispatch from determines which version of *this file* executes.
+# What's always pinned to `main` regardless of dispatch ref is the *published
+# content*: the actions/checkout step below explicitly checks out `ref: main`.
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` to `.github/workflows/contract-toolkit-publish.yml` so a stuck or timed-out publish can be retried on demand, without waiting for a brand-new release PR to merge.
- Motivated by #2492: three automated attempts to publish contract-toolkit v0.17.0 timed out on a slow GitHub Pages build (fixed there), and there was no way to manually re-invoke this workflow against the current `main` in the meantime — reruns of the original failed run use the workflow file pinned at that run's original trigger commit, so they don't pick up subsequent fixes either.
- Every step in this job is already idempotent (gh-pages commit/push no-ops if content is unchanged, the Pages-build trigger now skips if already built, tag creation skips if the tag already exists), so a manual dispatch against an unchanged `contract-toolkit/src/PklProject` version is always safe to run.
- `workflow_dispatch` always builds off `main` regardless of which ref you launch it from — the job's explicit `ref: main` checkout is unaffected by the dispatch ref.

## Test plan
- [ ] After merge, manually dispatch this workflow from the Actions tab and confirm it runs the `publish` job (rather than skipping).
- [ ] Confirm a `pull_request: closed` merge with the `release:contract-toolkit` label still triggers the job as before (the `if:` condition's existing branch is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)