### PR TITLE
ci: stop wait_for_pages_build.py failing on gh-pages checkout

### DIFF
--- a/.github/scripts/tests/test_wait_for_pages_build.py
+++ b/.github/scripts/tests/test_wait_for_pages_build.py
@@ -9,9 +9,10 @@ in contract-toolkit-publish.yml:
   * errored build -> fails immediately, without exhausting the poll budget
   * never reaches built -> times out after max_attempts
 
-`gh`/`git` are stubbed; each stubbed `pages/builds/latest` call returns a
-single canned response so status/commit are read together, matching the
-production code's single-call-per-poll contract.
+`gh` is stubbed; each stubbed `pages/builds/latest` call returns a single
+canned response so status/commit are read together, matching the production
+code's single-call-per-poll contract. The target commit is passed explicitly
+(--commit), not read from a checkout, matching the driver's contract.
 """
 
 from __future__ import annotations
@@ -41,15 +42,13 @@ def _build(status: str, commit: str = SHA, error_message: str | None = None) -> 
 
 
 def _make_fake_run(build_responses: list[dict]):
-    """Dispatch `git rev-parse` / `gh api .../builds/latest` / `gh api POST
-    .../builds`. Each `builds/latest` call pops the next canned response, so a
-    test can script exactly what each poll iteration sees."""
+    """Dispatch `gh api .../builds/latest` / `gh api POST .../builds`. Each
+    `builds/latest` call pops the next canned response, so a test can script
+    exactly what each poll iteration sees."""
     calls = {"trigger": 0, "polls": 0}
     remaining = list(build_responses)
 
     def fake_run(cmd: list[str]) -> subprocess.CompletedProcess:
-        if cmd[:2] == ["git", "rev-parse"]:
-            return _completed(SHA + "\n")
         if cmd[:2] == ["gh", "api"] and cmd[2] == f"repos/{REPO}/pages/builds/latest":
             calls["polls"] += 1
             build = remaining.pop(0) if len(remaining) > 1 else remaining[0]
@@ -120,10 +119,10 @@ def test_timeout_when_never_built(monkeypatch):
 def test_main_exit_codes(monkeypatch):
     fake_run, _ = _make_fake_run([_build("built")])
     monkeypatch.setattr(mod, "run", fake_run)
-    assert mod.main(["--repo", REPO]) == 0
+    assert mod.main(["--repo", REPO, "--commit", SHA]) == 0
 
     fake_run, _ = _make_fake_run(
         [_build("queued"), _build("errored", error_message="boom")]
     )
     monkeypatch.setattr(mod, "run", fake_run)
-    assert mod.main(["--repo", REPO]) == 1
+    assert mod.main(["--repo", REPO, "--commit", SHA]) == 1

--- a/.github/scripts/wait_for_pages_build.py
+++ b/.github/scripts/wait_for_pages_build.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python3
-"""Wait for a GitHub Pages build of the current commit, triggering one if needed.
+"""Wait for a GitHub Pages build of a given commit, triggering one if needed.
 
 Invoked by .github/workflows/contract-toolkit-publish.yml after the built
 contract-toolkit package is pushed to the gh-pages branch. Moved out of
 inlined shell per docs/standards/ci.md ("No conditional logic in inlined
 shell"): the skip-if-already-built check and the poll loop both branch on
 state, so they belong in a tested driver, not a workflow `run:` block.
+
+The target commit is passed in via --commit rather than read from the current
+checkout (e.g. `git rev-parse HEAD`): the calling workflow step runs after a
+prior step has switched the working tree to the gh-pages branch, and needs to
+restore just this script file from main to invoke it at all — relying on
+"whatever HEAD happens to be" at that point is fragile by construction. The
+caller captures the gh-pages commit as a step output right after pushing it.
 
 Exits 0 once the target commit's Pages build reaches "built" — including
 immediately, without triggering a redundant new build, if it is already
@@ -27,12 +34,8 @@ import time
 
 
 def run(cmd: list[str]) -> subprocess.CompletedProcess:
-    """Run a subprocess and capture output. Single seam so tests can stub gh/git."""
+    """Run a subprocess and capture output. Single seam so tests can stub gh."""
     return subprocess.run(cmd, check=False, text=True, capture_output=True)
-
-
-def current_commit() -> str:
-    return run(["git", "rev-parse", "HEAD"]).stdout.strip()
 
 
 def latest_build(repo: str) -> dict:
@@ -90,6 +93,11 @@ def main(argv: list[str] | None = None) -> int:
         "--repo", required=True, help="owner/repo, e.g. atlanhq/application-sdk"
     )
     parser.add_argument(
+        "--commit",
+        required=True,
+        help="gh-pages commit SHA to wait for (the commit just pushed there).",
+    )
+    parser.add_argument(
         "--max-attempts",
         type=int,
         default=300,
@@ -98,10 +106,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--sleep-seconds", type=int, default=5)
     args = parser.parse_args(argv)
 
-    pages_sha = current_commit()
     ok = wait_for_build(
         args.repo,
-        pages_sha,
+        args.commit,
         max_attempts=args.max_attempts,
         sleep_seconds=args.sleep_seconds,
     )

--- a/.github/workflows/contract-toolkit-publish.yml
+++ b/.github/workflows/contract-toolkit-publish.yml
@@ -78,6 +78,7 @@ jobs:
         run: cp -R .out /tmp/contract-toolkit-pkl-out
 
       - name: Publish package to GitHub Pages branch
+        id: publish
         run: |
           set -euo pipefail
           version="${{ steps.meta.outputs.version }}"
@@ -101,12 +102,22 @@ jobs:
           git add -A "${PUBLISH_DIR}" .nojekyll
           git diff --cached --quiet || git commit -m "publish ${PKG_NAME}@${version}"
           git push origin gh-pages
+          echo "gh_pages_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Trigger GitHub Pages build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python3 .github/scripts/wait_for_pages_build.py --repo "${GITHUB_REPOSITORY}"
+          # The previous step leaves the working tree checked out on gh-pages
+          # (which has no .github/scripts/), so restore just this one file
+          # from main rather than switching branches back — the target commit
+          # to poll for is passed in explicitly (steps.publish's gh-pages SHA)
+          # instead of read from the current checkout, so this step's own
+          # branch state never matters to it.
+          git checkout main -- .github/scripts/wait_for_pages_build.py
+          python3 .github/scripts/wait_for_pages_build.py \
+            --repo "${GITHUB_REPOSITORY}" \
+            --commit "${{ steps.publish.outputs.gh_pages_sha }}"
 
       - name: Create source tag
         run: |


### PR DESCRIPTION
## Summary
- The manual `workflow_dispatch` run just after #2494 merged failed immediately: `python3: can't open file '.../.github/scripts/wait_for_pages_build.py': No such file or directory`.
- Root cause: the prior step ("Publish package to GitHub Pages branch") leaves the working tree checked out on the `gh-pages` branch, which has no `.github/scripts/`. This affects **every** run of this job, not just manual dispatch — the next real automated release (a merged release PR) would have hit the same failure.
- Fix:
  - Restore just the script file from `main` before invoking it (`git checkout main -- .github/scripts/wait_for_pages_build.py`), rather than switching branches back (which isn't needed and adds risk).
  - Stop having the script infer its target commit via `git rev-parse HEAD` (which depended on being checked out on `gh-pages` at exactly the right moment — the source of this fragility). It now takes `--commit` explicitly, captured as a step output (`gh_pages_sha`) right after the `git push origin gh-pages` in the prior step.
- Verified locally against a throwaway repo simulating the exact main → gh-pages → single-file-restore sequence: branch/HEAD stay on `gh-pages` (unaffected), the script becomes invocable, and the captured commit SHA matches regardless of current checkout state.
- Updated `.github/scripts/tests/test_wait_for_pages_build.py` accordingly (dropped the `git rev-parse` stub, `main()` calls now pass `--commit`); full `.github/scripts/tests` suite passes (408/408).

## Test plan
- [ ] Merge, then manually dispatch `contract-toolkit-publish.yml` again and confirm the "Trigger GitHub Pages build" step actually runs the script instead of failing on missing file, and that `contract-toolkit-v0.17.0` finally gets tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)