### PR TITLE
ci: poll the live Pages URL instead of GitHub's internal build API

### DIFF
--- a/.github/scripts/tests/test_wait_for_pages_build.py
+++ b/.github/scripts/tests/test_wait_for_pages_build.py
@@ -3,21 +3,17 @@
 Covers the driver's conditional logic — the part that used to be inlined shell
 in contract-toolkit-publish.yml:
 
-  * already built for the target commit -> skip triggering a new build
-  * not yet built, then transitions to built -> succeeds without a false skip
-  * commit mismatch (stale "latest" build) -> keeps polling instead of exiting
-  * errored build -> fails immediately, without exhausting the poll budget
-  * never reaches built -> times out after max_attempts
+  * already live -> skip triggering a new build
+  * not yet live, then goes live -> succeeds without a false skip
+  * never goes live -> times out after max_attempts, without over-polling
 
-`gh` is stubbed; each stubbed `pages/builds/latest` call returns a single
-canned response so status/commit are read together, matching the production
-code's single-call-per-poll contract. The target commit is passed explicitly
-(--commit), not read from a checkout, matching the driver's contract.
+`curl`/`gh` are stubbed. The driver polls the actual published URL (HTTP 200)
+rather than GitHub's internal `gh api .../pages/builds/*` bookkeeping, which
+proved unreliable in practice — see the module docstring.
 """
 
 from __future__ import annotations
 
-import json
 import subprocess
 import sys
 from pathlib import Path
@@ -27,32 +23,25 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 import wait_for_pages_build as mod
 
 REPO = "atlanhq/application-sdk"
-SHA = "9756039c00c9d63becabe6da2bd4f36231857591"
+URL = "https://atlanhq.github.io/application-sdk/contracts/app-contract-toolkit@0.17.0.zip"
 
 
 def _completed(stdout: str) -> subprocess.CompletedProcess:
     return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout)
 
 
-def _build(status: str, commit: str = SHA, error_message: str | None = None) -> dict:
-    build = {"status": status, "commit": commit}
-    if error_message is not None:
-        build["error"] = {"message": error_message}
-    return build
-
-
-def _make_fake_run(build_responses: list[dict]):
-    """Dispatch `gh api .../builds/latest` / `gh api POST .../builds`. Each
-    `builds/latest` call pops the next canned response, so a test can script
-    exactly what each poll iteration sees."""
+def _make_fake_run(http_codes: list[str]):
+    """Dispatch `curl ... -w %{http_code}` / `gh api POST .../builds`. Each
+    curl call pops the next canned status code, so a test can script exactly
+    what each poll iteration sees."""
     calls = {"trigger": 0, "polls": 0}
-    remaining = list(build_responses)
+    remaining = list(http_codes)
 
     def fake_run(cmd: list[str]) -> subprocess.CompletedProcess:
-        if cmd[:2] == ["gh", "api"] and cmd[2] == f"repos/{REPO}/pages/builds/latest":
+        if cmd[0] == "curl":
             calls["polls"] += 1
-            build = remaining.pop(0) if len(remaining) > 1 else remaining[0]
-            return _completed(json.dumps(build))
+            code = remaining.pop(0) if len(remaining) > 1 else remaining[0]
+            return _completed(code)
         if cmd[:4] == ["gh", "api", "--method", "POST"]:
             calls["trigger"] += 1
             return _completed("")
@@ -61,68 +50,65 @@ def _make_fake_run(build_responses: list[dict]):
     return fake_run, calls
 
 
-def test_already_built_skips_trigger(monkeypatch):
-    fake_run, calls = _make_fake_run([_build("built")])
+def test_already_live_skips_trigger(monkeypatch):
+    fake_run, calls = _make_fake_run(["200"])
     monkeypatch.setattr(mod, "run", fake_run)
 
-    assert mod.wait_for_build(REPO, SHA, sleep=lambda s: None) is True
+    assert mod.wait_for_publish(REPO, URL, sleep=lambda s: None) is True
     assert calls["trigger"] == 0
     assert calls["polls"] == 1
 
 
-def test_building_then_built_succeeds(monkeypatch):
-    fake_run, calls = _make_fake_run(
-        [_build("queued"), _build("building"), _build("built")]
-    )
+def test_not_live_then_live_succeeds(monkeypatch):
+    fake_run, calls = _make_fake_run(["404", "404", "200"])
     monkeypatch.setattr(mod, "run", fake_run)
 
-    assert mod.wait_for_build(REPO, SHA, sleep=lambda s: None) is True
+    assert mod.wait_for_publish(REPO, URL, sleep=lambda s: None) is True
     assert calls["trigger"] == 1
+    assert calls["polls"] == 3
 
 
-def test_stale_commit_keeps_polling_until_target_commit_builds(monkeypatch):
-    fake_run, _ = _make_fake_run(
-        [
-            _build("queued"),
-            _build("built", commit="stale-sha"),  # a prior build, not ours
-            _build("building"),
-            _build("built"),
-        ]
-    )
-    monkeypatch.setattr(mod, "run", fake_run)
-
-    assert mod.wait_for_build(REPO, SHA, sleep=lambda s: None) is True
-
-
-def test_errored_build_fails_without_exhausting_budget(monkeypatch):
-    fake_run, calls = _make_fake_run(
-        [_build("queued"), _build("errored", error_message="boom")]
-    )
+def test_timeout_when_never_live(monkeypatch):
+    fake_run, calls = _make_fake_run(["404"])
     monkeypatch.setattr(mod, "run", fake_run)
 
     assert (
-        mod.wait_for_build(REPO, SHA, max_attempts=300, sleep=lambda s: None) is False
+        mod.wait_for_publish(REPO, URL, max_attempts=3, sleep=lambda s: None) is False
     )
-    # Only polled twice (initial skip-check + the errored poll), not 300 times.
-    assert calls["polls"] == 2
-
-
-def test_timeout_when_never_built(monkeypatch):
-    fake_run, calls = _make_fake_run([_build("queued"), _build("building")])
-    monkeypatch.setattr(mod, "run", fake_run)
-
-    assert mod.wait_for_build(REPO, SHA, max_attempts=3, sleep=lambda s: None) is False
     # initial skip-check + 3 poll attempts
     assert calls["polls"] == 4
+    assert calls["trigger"] == 1
+
+
+def test_heartbeat_does_not_change_outcome(monkeypatch, capsys):
+    fake_run, _ = _make_fake_run(["404", "404", "404", "200"])
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    assert (
+        mod.wait_for_publish(REPO, URL, heartbeat_every=2, sleep=lambda s: None) is True
+    )
+    assert "Still waiting" in capsys.readouterr().out
 
 
 def test_main_exit_codes(monkeypatch):
-    fake_run, _ = _make_fake_run([_build("built")])
+    fake_run, _ = _make_fake_run(["200"])
     monkeypatch.setattr(mod, "run", fake_run)
-    assert mod.main(["--repo", REPO, "--commit", SHA]) == 0
+    assert mod.main(["--repo", REPO, "--url", URL]) == 0
 
-    fake_run, _ = _make_fake_run(
-        [_build("queued"), _build("errored", error_message="boom")]
-    )
+    fake_run, _ = _make_fake_run(["404"])
     monkeypatch.setattr(mod, "run", fake_run)
-    assert mod.main(["--repo", REPO, "--commit", SHA]) == 1
+    assert (
+        mod.main(
+            [
+                "--repo",
+                REPO,
+                "--url",
+                URL,
+                "--max-attempts",
+                "1",
+                "--sleep-seconds",
+                "0",
+            ]
+        )
+        == 1
+    )

--- a/.github/scripts/tests/test_wait_for_pages_publish.py
+++ b/.github/scripts/tests/test_wait_for_pages_publish.py
@@ -1,4 +1,4 @@
-"""Tests for .github/scripts/wait_for_pages_build.py.
+"""Tests for .github/scripts/wait_for_pages_publish.py.
 
 Covers the driver's conditional logic — the part that used to be inlined shell
 in contract-toolkit-publish.yml:
@@ -20,7 +20,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-import wait_for_pages_build as mod
+import wait_for_pages_publish as mod
 
 REPO = "atlanhq/application-sdk"
 URL = "https://atlanhq.github.io/application-sdk/contracts/app-contract-toolkit@0.17.0.zip"

--- a/.github/scripts/wait_for_pages_build.py
+++ b/.github/scripts/wait_for_pages_build.py
@@ -1,89 +1,86 @@
 #!/usr/bin/env python3
-"""Wait for a GitHub Pages build of a given commit, triggering one if needed.
+"""Wait for a contract-toolkit package to actually be served live on Pages.
 
 Invoked by .github/workflows/contract-toolkit-publish.yml after the built
 contract-toolkit package is pushed to the gh-pages branch. Moved out of
 inlined shell per docs/standards/ci.md ("No conditional logic in inlined
-shell"): the skip-if-already-built check and the poll loop both branch on
+shell"): the skip-if-already-live check and the poll loop both branch on
 state, so they belong in a tested driver, not a workflow `run:` block.
 
-The target commit is passed in via --commit rather than read from the current
-checkout (e.g. `git rev-parse HEAD`): the calling workflow step runs after a
-prior step has switched the working tree to the gh-pages branch, and needs to
-restore just this script file from main to invoke it at all — relying on
-"whatever HEAD happens to be" at that point is fragile by construction. The
-caller captures the gh-pages commit as a step output right after pushing it.
+Polls the actual public URL rather than GitHub's internal `gh api
+.../pages/builds/*` bookkeeping. That API proved unreliable in practice
+(2026-07-03, contract-toolkit v0.17.0 publish, coinciding with a GitHub Pages
+incident the day before with the same "slow and failing deployments"
+symptom): builds got stuck in `building` for 10+ minutes with zero progress,
+or resolved to `errored` for content that was, in fact, already being served
+correctly from an earlier successful build — because each retry re-triggers
+a brand-new build attempt on top of one that may have already succeeded,
+and "latest" only ever reflects the most recent attempt, not the best one.
+The published artifact's URL is version-qualified and never reused across
+releases, so "is this exact URL returning 200" is unambiguous ground truth
+for "is this release live" — independent of how many redundant or stuck
+build attempts GitHub's queue is juggling internally.
 
-Exits 0 once the target commit's Pages build reaches "built" — including
-immediately, without triggering a redundant new build, if it is already
-built. Exits 1 if the build errors, or once the poll budget is exhausted.
-
-Each poll reads `status` and `commit` from a single `gh api
-.../pages/builds/latest` response rather than two separate calls: the
-"latest" build can change between two independent requests, which would let
-a caller read `status` from one build and `commit` from another.
+Exits 0 once the URL is live — including immediately, without triggering a
+redundant rebuild, if it already is. Exits 1 once the poll budget is
+exhausted without the URL going live.
 """
 
 from __future__ import annotations
 
 import argparse
-import json
 import subprocess
 import sys
 import time
 
 
 def run(cmd: list[str]) -> subprocess.CompletedProcess:
-    """Run a subprocess and capture output. Single seam so tests can stub gh."""
+    """Run a subprocess and capture output. Single seam so tests can stub curl/gh."""
     return subprocess.run(cmd, check=False, text=True, capture_output=True)
 
 
-def latest_build(repo: str) -> dict:
-    result = run(["gh", "api", f"repos/{repo}/pages/builds/latest"])
-    return json.loads(result.stdout)
+def is_live(url: str) -> bool:
+    result = run(["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", url])
+    return result.stdout.strip() == "200"
 
 
 def trigger_build(repo: str) -> None:
     run(["gh", "api", "--method", "POST", f"repos/{repo}/pages/builds"])
 
 
-def wait_for_build(
+def wait_for_publish(
     repo: str,
-    pages_sha: str,
+    url: str,
     *,
     max_attempts: int = 300,
     sleep_seconds: int = 5,
+    heartbeat_every: int = 12,
     sleep=time.sleep,
 ) -> bool:
-    """Poll until `pages_sha`'s Pages build is `built`.
+    """Poll `url` until it's live (HTTP 200).
 
-    Returns True on success (already built, or reached `built` within the poll
-    budget), False on an `errored` build or timeout.
+    Returns True on success (already live, or went live within the poll
+    budget), False on timeout. Prints a heartbeat every `heartbeat_every`
+    attempts so a silent multi-minute wait doesn't look stuck in CI logs.
     """
-    build = latest_build(repo)
-    if build.get("commit") == pages_sha and build.get("status") == "built":
-        print(f"Pages already built for {pages_sha}; skipping rebuild trigger.")
+    if is_live(url):
+        print(f"{url} already live; skipping rebuild trigger.")
         return True
 
     trigger_build(repo)
 
-    for _ in range(max_attempts):
-        build = latest_build(repo)
-        if build.get("commit") != pages_sha:
-            sleep(sleep_seconds)
-            continue
-
-        status = build.get("status")
-        if status == "built":
+    for attempt in range(1, max_attempts + 1):
+        if is_live(url):
+            print(f"{url} is live (after {attempt} attempt(s)).")
             return True
-        if status == "errored":
-            message = (build.get("error") or {}).get("message") or "unknown error"
-            print(f"::error::GitHub Pages build failed: {message}")
-            return False
+
+        if attempt % heartbeat_every == 0:
+            elapsed = attempt * sleep_seconds
+            print(f"Still waiting for {url} to go live ({elapsed}s elapsed)...")
 
         sleep(sleep_seconds)
 
-    print(f"::error::Timed out waiting for GitHub Pages build for {pages_sha}")
+    print(f"::error::Timed out waiting for {url} to go live")
     return False
 
 
@@ -93,9 +90,7 @@ def main(argv: list[str] | None = None) -> int:
         "--repo", required=True, help="owner/repo, e.g. atlanhq/application-sdk"
     )
     parser.add_argument(
-        "--commit",
-        required=True,
-        help="gh-pages commit SHA to wait for (the commit just pushed there).",
+        "--url", required=True, help="Public URL the published package must serve from."
     )
     parser.add_argument(
         "--max-attempts",
@@ -106,9 +101,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--sleep-seconds", type=int, default=5)
     args = parser.parse_args(argv)
 
-    ok = wait_for_build(
+    ok = wait_for_publish(
         args.repo,
-        args.commit,
+        args.url,
         max_attempts=args.max_attempts,
         sleep_seconds=args.sleep_seconds,
     )

--- a/.github/scripts/wait_for_pages_publish.py
+++ b/.github/scripts/wait_for_pages_publish.py
@@ -40,7 +40,13 @@ def run(cmd: list[str]) -> subprocess.CompletedProcess:
 
 
 def is_live(url: str) -> bool:
-    result = run(["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", url])
+    # --max-time bounds a stalled network request to one poll interval's worth
+    # of time, so a hung connection can't block the step indefinitely and
+    # bypass max_attempts/heartbeat — the exact failure mode this script
+    # exists to avoid.
+    result = run(
+        ["curl", "-s", "--max-time", "15", "-o", "/dev/null", "-w", "%{http_code}", url]
+    )
     return result.stdout.strip() == "200"
 
 

--- a/.github/workflows/contract-toolkit-publish.yml
+++ b/.github/workflows/contract-toolkit-publish.yml
@@ -78,7 +78,6 @@ jobs:
         run: cp -R .out /tmp/contract-toolkit-pkl-out
 
       - name: Publish package to GitHub Pages branch
-        id: publish
         run: |
           set -euo pipefail
           version="${{ steps.meta.outputs.version }}"
@@ -102,7 +101,6 @@ jobs:
           git add -A "${PUBLISH_DIR}" .nojekyll
           git diff --cached --quiet || git commit -m "publish ${PKG_NAME}@${version}"
           git push origin gh-pages
-          echo "gh_pages_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Trigger GitHub Pages build
         env:
@@ -110,14 +108,14 @@ jobs:
         run: |
           # The previous step leaves the working tree checked out on gh-pages
           # (which has no .github/scripts/), so restore just this one file
-          # from main rather than switching branches back — the target commit
-          # to poll for is passed in explicitly (steps.publish's gh-pages SHA)
-          # instead of read from the current checkout, so this step's own
-          # branch state never matters to it.
+          # from main rather than switching branches back.
           git checkout main -- .github/scripts/wait_for_pages_build.py
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repo_name="${GITHUB_REPOSITORY##*/}"
+          url="https://${owner}.github.io/${repo_name}/${PUBLISH_DIR}/${PKG_NAME}@${{ steps.meta.outputs.version }}.zip"
           python3 .github/scripts/wait_for_pages_build.py \
             --repo "${GITHUB_REPOSITORY}" \
-            --commit "${{ steps.publish.outputs.gh_pages_sha }}"
+            --url "$url"
 
       - name: Create source tag
         run: |

--- a/.github/workflows/contract-toolkit-publish.yml
+++ b/.github/workflows/contract-toolkit-publish.yml
@@ -109,11 +109,11 @@ jobs:
           # The previous step leaves the working tree checked out on gh-pages
           # (which has no .github/scripts/), so restore just this one file
           # from main rather than switching branches back.
-          git checkout main -- .github/scripts/wait_for_pages_build.py
+          git checkout main -- .github/scripts/wait_for_pages_publish.py
           owner="${GITHUB_REPOSITORY%%/*}"
           repo_name="${GITHUB_REPOSITORY##*/}"
           url="https://${owner}.github.io/${repo_name}/${PUBLISH_DIR}/${PKG_NAME}@${{ steps.meta.outputs.version }}.zip"
-          python3 .github/scripts/wait_for_pages_build.py \
+          python3 .github/scripts/wait_for_pages_publish.py \
             --repo "${GITHUB_REPOSITORY}" \
             --url "$url"
 


### PR DESCRIPTION
## Summary
- Publishing contract-toolkit v0.17.0 has been stuck for ~2.5 hours despite the package content having been live and correctly served (`app-contract-toolkit@0.17.0.zip` → 200) since ~18:43 UTC. What's actually stuck is GitHub's own internal Pages build bookkeeping (`gh api .../pages/builds/latest`): a build sat at `building` with zero progress for 10+ minutes, coinciding almost exactly with a GitHub-acknowledged Pages incident from the day before ("slow and failing Pages deployments" — [status.githubstatus.com](https://www.githubstatus.com), resolved 2026-07-02 18:25 UTC).
- Each retry (mine included, in #2494/#2495) re-triggers a *new* build attempt on top of one that already succeeded, and `/pages/builds/latest` only ever reflects the most recent attempt — not the best one — so polling it for completion is fragile exactly when GitHub's Pages backend is degraded.
- Fix: stop depending on that API for completion detection. The published artifact's URL is version-qualified and never reused across releases, so polling the real public URL directly (HTTP 200) is unambiguous ground truth for "is this release live," regardless of how many redundant/stuck build attempts are in GitHub's internal queue. The build-trigger POST is kept (still needed to prompt a (re)deploy), but success is now judged by the actual artifact being served, not by asking GitHub's queue about itself.
- Also adds a heartbeat log line roughly every 60s so a multi-minute wait shows *something* in the Actions log instead of looking frozen.

## Test plan
- [x] Verified locally against the real, already-live `app-contract-toolkit@0.17.0.zip` (correctly reports live, skips trigger) and a real nonexistent URL (correctly reports not live) — no live-repo side effects from these checks.
- [x] `.github/scripts/tests` suite: 407/407 passing.
- [ ] After merge, manually dispatch this workflow and confirm `contract-toolkit-v0.17.0` finally gets tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)