### PR TITLE
fix(conformance): skip P030 for apps with no publish stage

### DIFF
--- a/packages/conformance/conformance/docs/rules/prescriptions.md
+++ b/packages/conformance/conformance/docs/rules/prescriptions.md
@@ -997,9 +997,10 @@ Note: P008 flags `self.upload()` *inside* `@task` methods (the wrong location); 
 flags the *absence* of any upload call.  They are complementary: both should be clean
 for a correctly-wired SDR app.
 
-Exemption: this rule is skipped for apps whose `contract/app.pkl` sets `pipeline.publish
-= null` (no publish stage), which compiles to a generated manifest with no `dag.publish`
-node.  An extract-only app has nothing to hand the extracted assets off to, so the
-absence of `self.upload()` is by design, not a gap.
+Exemption: this rule is skipped for apps whose `contract/app.pkl` sets
+`pipeline.publish = null` (no publish stage), which compiles to a generated
+manifest with no `dag.publish` node.  An extract-only app has nothing to hand
+the extracted assets off to, so the absence of `self.upload()` is by design,
+not a gap.
 
 ---

--- a/packages/conformance/conformance/docs/rules/prescriptions.md
+++ b/packages/conformance/conformance/docs/rules/prescriptions.md
@@ -997,4 +997,9 @@ Note: P008 flags `self.upload()` *inside* `@task` methods (the wrong location); 
 flags the *absence* of any upload call.  They are complementary: both should be clean
 for a correctly-wired SDR app.
 
+Exemption: this rule is skipped for apps whose `contract/app.pkl` sets `pipeline.publish
+= null` (no publish stage), which compiles to a generated manifest with no `dag.publish`
+node.  An extract-only app has nothing to hand the extracted assets off to, so the
+absence of `self.upload()` is by design, not a gap.
+
 ---

--- a/packages/conformance/conformance/suite/checks/sdr.py
+++ b/packages/conformance/conformance/suite/checks/sdr.py
@@ -12,7 +12,11 @@ Cross-artifact checks that gate on ``self_deployed_runtime: true`` in
 * ``P030`` — at least one Python source file (outside ``tests/``) must contain
   a ``self.upload(`` call so the ``ENABLE_ATLAN_UPLOAD`` path is reachable.
   Without it extraction "passes" but no assets transfer to the Atlan tenant
-  bucket in SDR deployments.
+  bucket in SDR deployments.  Only applies to apps that actually have a
+  publish stage: an app whose ``contract/app.pkl`` sets ``pipeline.publish =
+  null`` compiles to a ``manifest.json`` with no ``dag.publish`` node, and has
+  nowhere for ``self.upload()`` to hand extracted assets off to — P030 is
+  skipped for those apps.
 
 P026–P028 are reserved by a concurrent PR (GetattrOnTypedContractField,
 AppStateAsCrossTaskChannel, ManualQualifiedNameFString — PR #2417).
@@ -59,8 +63,8 @@ def _is_sdr_app(root: Path) -> bool:
     return m is not None and m.group(1).lower() == "true"
 
 
-def _check_p029(root: Path) -> list[Finding]:
-    """P029: every manifest.json under app/generated/ must have agent_json."""
+def _discover_manifests(root: Path) -> list[Path]:
+    """All app/generated/manifest.json files: single-entrypoint or per-entrypoint."""
     generated = root / "app" / "generated"
     if not generated.is_dir():
         return []
@@ -75,7 +79,35 @@ def _check_p029(root: Path) -> list[Finding]:
                 m = child / "manifest.json"
                 if m.is_file():
                     manifests.append(m)
+    return manifests
 
+
+def _app_has_publish_stage(manifests: list[Path]) -> bool:
+    """True unless every manifest structurally opts out of a publish stage.
+
+    ``contract/app.pkl``'s ``pipeline.publish = null`` (an app-level opt-out of
+    the publish pipeline stage) compiles to a manifest.json whose ``dag`` has
+    no ``publish`` node. An app with no publish stage has nowhere for
+    ``self.upload()`` to hand extracted assets off to, so P030 does not apply.
+
+    No manifests at all (not yet generated) or an unparseable manifest means
+    we cannot establish the opt-out, so this defaults to True (P030 still
+    applies) rather than silently exempting an app we can't actually inspect.
+    """
+    if not manifests:
+        return True
+    for manifest_path in manifests:
+        try:
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return True
+        if (data.get("dag") or {}).get("publish") is not None:
+            return True
+    return False
+
+
+def _check_p029(manifests: list[Path], root: Path) -> list[Finding]:
+    """P029: every manifest.json under app/generated/ must have agent_json."""
     findings: list[Finding] = []
     for manifest_path in manifests:
         try:
@@ -162,9 +194,12 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
     if not _is_sdr_app(root):
         return []
 
+    manifests = _discover_manifests(root)
+
     findings: list[Finding] = []
-    findings.extend(_check_p029(root))
-    findings.extend(_check_p030(paths))
+    findings.extend(_check_p029(manifests, root))
+    if _app_has_publish_stage(manifests):
+        findings.extend(_check_p030(paths))
     return findings
 
 

--- a/packages/conformance/conformance/suite/checks/sdr.py
+++ b/packages/conformance/conformance/suite/checks/sdr.py
@@ -13,10 +13,10 @@ Cross-artifact checks that gate on ``self_deployed_runtime: true`` in
   a ``self.upload(`` call so the ``ENABLE_ATLAN_UPLOAD`` path is reachable.
   Without it extraction "passes" but no assets transfer to the Atlan tenant
   bucket in SDR deployments.  Only applies to apps that actually have a
-  publish stage: an app whose ``contract/app.pkl`` sets ``pipeline.publish =
-  null`` compiles to a ``manifest.json`` with no ``dag.publish`` node, and has
-  nowhere for ``self.upload()`` to hand extracted assets off to — P030 is
-  skipped for those apps.
+  publish stage: an app whose ``contract/app.pkl`` sets
+  ``pipeline.publish = null`` compiles to a ``manifest.json`` with no
+  ``dag.publish`` node, and has nowhere for ``self.upload()`` to hand
+  extracted assets off to — P030 is skipped for those apps.
 
 P026–P028 are reserved by a concurrent PR (GetattrOnTypedContractField,
 AppStateAsCrossTaskChannel, ManualQualifiedNameFString — PR #2417).

--- a/packages/conformance/conformance/suite/rules/sdr.py
+++ b/packages/conformance/conformance/suite/rules/sdr.py
@@ -14,7 +14,10 @@ two structural invariants before they can be considered SDR-ready:
   a ``self.upload(`` call.  Without it the ``ENABLE_ATLAN_UPLOAD`` path is
   never reached: extraction "passes" (workflow status = success) but no assets
   are transferred to the Atlan tenant bucket.  The regression slipped because
-  the SDR test pipeline validated only workflow *status*, not output.
+  the SDR test pipeline validated only workflow *status*, not output.  Does
+  not apply to apps with no publish stage (``pipeline.publish = null`` in
+  ``contract/app.pkl``, reflected as no ``dag.publish`` node in the generated
+  manifest) — there is nowhere for such an app to hand extracted assets off to.
 
 Both rules are APP-scoped (the SDK itself does not declare ``self_deployed_runtime``
 and is therefore always skipped) and gate on ``self_deployed_runtime: true``
@@ -129,6 +132,12 @@ RULES: tuple[RuleDefinition, ...] = (
             "Note: P008 flags ``self.upload()`` *inside* ``@task`` methods (the\n"
             "wrong location); P030 flags the *absence* of any upload call.  They\n"
             "are complementary: both should be clean for a correctly-wired SDR app.\n"
+            "\n"
+            "Exemption: this rule is skipped for apps whose ``contract/app.pkl``\n"
+            "sets ``pipeline.publish = null`` (no publish stage), which compiles\n"
+            "to a generated manifest with no ``dag.publish`` node.  An extract-only\n"
+            "app has nothing to hand the extracted assets off to, so the absence\n"
+            "of ``self.upload()`` is by design, not a gap.\n"
         ),
         help_uri=(
             "https://github.com/atlanhq/application-sdk/blob/main/"

--- a/packages/conformance/tests/test_sdr.py
+++ b/packages/conformance/tests/test_sdr.py
@@ -70,6 +70,21 @@ _MANIFEST_NO_INPUTS = json.dumps(
     indent=2,
 )
 
+_MANIFEST_NO_PUBLISH = json.dumps(
+    {"dag": {"extract": {"inputs": {"args": {"agent_json": "{{agent-json}}"}}}}},
+    indent=2,
+)
+
+_MANIFEST_WITH_PUBLISH = json.dumps(
+    {
+        "dag": {
+            "extract": {"inputs": {"args": {"agent_json": "{{agent-json}}"}}},
+            "publish": {"activity_name": "publish_assets"},
+        }
+    },
+    indent=2,
+)
+
 
 def _write(tmp_path: Path, files: dict[str, str]) -> None:
     for name, content in files.items():
@@ -343,6 +358,92 @@ def test_p030_fires_when_source_dir_empty(tmp_path: Path) -> None:
     _write(tmp_path, {"atlan.yaml": _SDR_ATLAN_YAML})
     findings = _run(tmp_path)
     assert any(f.rule_id == "P030" for f in findings)
+
+
+# ── P030: publish-stage opt-out exemption ───────────────────────────────────
+
+
+def test_p030_silent_when_manifest_has_no_publish_stage(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {
+            "atlan.yaml": _SDR_ATLAN_YAML,
+            "app/generated/manifest.json": _MANIFEST_NO_PUBLISH,
+            "app/connector.py": "class Connector:\n    async def run(self):\n        pass\n",
+        },
+    )
+    # contract/app.pkl's `pipeline.publish = null` compiles to a manifest
+    # with no dag.publish node — nowhere for self.upload() to hand off to.
+    findings = _run(tmp_path)
+    assert not any(f.rule_id == "P030" for f in findings)
+
+
+def test_p030_fires_when_manifest_has_publish_stage(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {
+            "atlan.yaml": _SDR_ATLAN_YAML,
+            "app/generated/manifest.json": _MANIFEST_WITH_PUBLISH,
+            "app/connector.py": "class Connector:\n    async def run(self):\n        pass\n",
+        },
+    )
+    findings = _run(tmp_path)
+    assert any(f.rule_id == "P030" for f in findings)
+
+
+def test_p030_fires_when_no_manifest_at_all(tmp_path: Path) -> None:
+    # No manifest means we cannot establish the opt-out — default to firing
+    # rather than silently exempting an app we can't actually inspect.
+    _write(
+        tmp_path,
+        {
+            "atlan.yaml": _SDR_ATLAN_YAML,
+            "app/connector.py": "class Connector:\n    async def run(self):\n        pass\n",
+        },
+    )
+    findings = _run(tmp_path)
+    assert any(f.rule_id == "P030" for f in findings)
+
+
+def test_p030_fires_when_manifest_unparseable(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {
+            "atlan.yaml": _SDR_ATLAN_YAML,
+            "app/generated/manifest.json": "not json {{{",
+            "app/connector.py": "class Connector:\n    async def run(self):\n        pass\n",
+        },
+    )
+    findings = _run(tmp_path)
+    assert any(f.rule_id == "P030" for f in findings)
+
+
+def test_p030_multi_ep_fires_if_any_manifest_has_publish(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {
+            "atlan.yaml": _SDR_ATLAN_YAML,
+            "app/generated/extract/manifest.json": _MANIFEST_NO_PUBLISH,
+            "app/generated/profile/manifest.json": _MANIFEST_WITH_PUBLISH,
+            "app/connector.py": "class Connector:\n    async def run(self):\n        pass\n",
+        },
+    )
+    findings = _run(tmp_path)
+    assert any(f.rule_id == "P030" for f in findings)
+
+
+def test_p030_multi_ep_silent_when_no_manifest_has_publish(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {
+            "atlan.yaml": _SDR_ATLAN_YAML,
+            "app/generated/extract/manifest.json": _MANIFEST_NO_PUBLISH,
+            "app/generated/profile/manifest.json": _MANIFEST_NO_PUBLISH,
+            "app/connector.py": "class Connector:\n    async def run(self):\n        pass\n",
+        },
+    )
+    findings = _run(tmp_path)
+    assert not any(f.rule_id == "P030" for f in findings)
 
 
 # ── scan_path no-op ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `P030` (`SdrUploadNotCalled`) fired for every `self_deployed_runtime: true` app that never calls `self.upload()`, including extract-only apps that explicitly opt out of the publish pipeline stage via `pipeline.publish = null` in `contract/app.pkl`. Those apps have nowhere to hand extracted assets off to, so the absence of `self.upload()` is by design, not a gap.
- `pipeline.publish = null` compiles to a generated `manifest.json` with no `dag.publish` node — a signal already available on disk (P029 does the same manifest discovery). Factored manifest discovery out of `_check_p029` into `_discover_manifests`, added `_app_has_publish_stage` to read the opt-out signal, and skip `_check_p030` when every discovered manifest agrees.
- No manifest at all, or an unparseable one, defaults to **firing** (cannot establish the opt-out) rather than silently exempting an app we can't actually inspect.
- Regenerated `conformance/docs/rules/prescriptions.md` via `gen-rule-docs` for the updated P030 rationale/full_description, and updated the rule module docstring.

Found while remediating `atlan-hello-world-app` (the reference extract-only app) — it declares `self_deployed_runtime: true` and `pipeline.publish = null`, and P030 was a permanent, unsuppressible false positive for it (the check builds its `Finding` directly against `atlan.yaml` without calling `_parse_directives`, so inline suppression isn't available either).

## Test plan
- [x] `uv run pytest tests/test_sdr.py -q` — 27 passed (21 existing + 6 new covering: no-publish-stage silent, with-publish-stage fires, no-manifest fires, unparseable-manifest fires, multi-entrypoint any-publish fires, multi-entrypoint no-publish silent)
- [x] `uv run pytest -q` (full `packages/conformance` suite) — 1582 passed, 1 pre-existing xfail
- [x] `ruff check` on the three changed Python files — clean
- [x] Verified against the real `atlan-hello-world-app` repo tree: `scan_all` now returns `[]` for P030 where it previously fired

🤖 Generated with [Claude Code](https://claude.com/claude-code)