### PR TITLE
fix(conformance): honor --help/-h on bootstrap without side effects

### DIFF
--- a/packages/conformance/conformance/cli.py
+++ b/packages/conformance/conformance/cli.py
@@ -128,26 +128,9 @@ def _derive_app_name_from_dir(root: pathlib.Path) -> str:
 def _parse_bootstrap_args(argv: list[str]) -> dict[str, str]:
     """Parse bootstrap flags from argv.
 
-    Supports both ``--flag value`` and ``--flag=value`` forms.
-
-    Flags
-    -----
-    --package-name NAME          docstring-coverage package (default: app)
-    --unit-tests-workflow FILE   build-and-publish test workflow (default: tests.yaml)
-    --app-name NAME              connector app name for tests.yaml scaffold
-                                 (default: auto-detected from atlan.yaml, else "app")
-    --app-image-name NAME        GHCR image name for tests.yaml scaffold (default: atlan-<app-name>-app)
-    --enable-e2e BOOL            enable e2e job in tests.yaml scaffold (default: true)
-    --services-script PATH       path to services setup script for tests.yaml scaffold
-                                 (default: auto-detected from .github/test/setup-services.sh)
-    --enforce BOOL               enforcement mode; omit for hard-gate defaults without
-                                 force-updating renovate.json. Pass explicitly (either
-                                 value) to also force-update renovate.json.
-                                 true  — hard gate: conformance blocks on violations,
-                                         Renovate auto-merges when CI is green.
-                                 false — soft/observe mode: conformance tracks violations
-                                         without blocking, Renovate raises PRs but humans
-                                         must merge.
+    Supports both ``--flag value`` and ``--flag=value`` forms. See
+    ``_BOOTSTRAP_USAGE`` below for the authoritative flag documentation —
+    kept in one place so it can't drift out of sync with this parser.
     """
     result: dict[str, str] = {
         "package_name": "app",
@@ -395,21 +378,8 @@ commands:
                  .github/scripts/build_conformance_args.py that conformance-reusable.yaml
                  needs on disk in every caller repo. All of these always overwrite
                  (re-running eradicates drift). tests.yaml, renovate.json, and
-                 contract_schema.lock.json are write-if-absent by default; pass
-                 --enforce true|false to also update renovate.json's enforcement mode.
-                   --package-name NAME         docstring-coverage package (default: app)
-                   --unit-tests-workflow FILE   build-and-publish test workflow (default: tests.yaml)
-                   --app-name NAME             connector app name for tests.yaml (default: from atlan.yaml, else "app")
-                   --app-image-name NAME       GHCR image name for tests.yaml (default: atlan-<app-name>-app)
-                   --enable-e2e true|false     enable e2e in tests.yaml (default: true, line omitted)
-                   --services-script PATH      services setup script (default: auto-detected from .github/test/setup-services.sh)
-                   --enforce true|false        enforcement mode; omit for hard-gate defaults without
-                                               force-updating renovate.json. Pass explicitly (either
-                                               value) to also force-update renovate.json.
-                                               true  — hard gate: conformance blocks on violations,
-                                                       Renovate auto-merges when CI is green.
-                                               false — soft/observe: conformance tracks without blocking,
-                                                       Renovate raises PRs but humans must merge.
+                 contract_schema.lock.json are write-if-absent by default.
+                 Run `bootstrap --help` for the full option list.
   renovate-scan  Build Renovate fleet dashboard JSON from gh pr list output files
 """
 

--- a/packages/conformance/conformance/cli.py
+++ b/packages/conformance/conformance/cli.py
@@ -197,8 +197,40 @@ def _parse_bootstrap_args(argv: list[str]) -> dict[str, str]:
     return result
 
 
+_BOOTSTRAP_USAGE = """\
+usage: atlan-application-sdk-conformance bootstrap [options]
+
+Write .claude/skills/remediate/SKILL.md + all standard CI workflow shims into
+.github/workflows/, plus the vendored .github/actions/run-conformance-detect/action.yaml
+and .github/scripts/build_conformance_args.py that conformance-reusable.yaml needs on
+disk in every caller repo. All of these always overwrite (re-running eradicates drift).
+tests.yaml, renovate.json, and contract_schema.lock.json are write-if-absent by default;
+pass --enforce to update renovate.json's enforcement mode too.
+
+options:
+  --package-name NAME         docstring-coverage package (default: app)
+  --unit-tests-workflow FILE  build-and-publish test workflow (default: tests.yaml)
+  --app-name NAME             connector app name for tests.yaml (default: from atlan.yaml, else "app")
+  --app-image-name NAME       GHCR image name for tests.yaml (default: atlan-<app-name>-app)
+  --enable-e2e true|false     enable e2e in tests.yaml (default: true, line omitted)
+  --services-script PATH      services setup script (default: auto-detected from .github/test/setup-services.sh)
+  --enforce true|false        enforcement mode; omit for hard-gate defaults without
+                              force-updating renovate.json. Pass explicitly (either
+                              value) to also force-update renovate.json.
+                              true  — hard gate: conformance blocks on violations,
+                                      Renovate auto-merges when CI is green.
+                              false — soft/observe: conformance tracks without blocking,
+                                      Renovate raises PRs but humans must merge.
+  -h, --help                  show this help message and exit
+"""
+
+
 def _cmd_bootstrap(argv: list[str]) -> int:
     """Write the SKILL.md shim and standard CI workflows into the current repo."""
+    if "-h" in argv or "--help" in argv:
+        print(_BOOTSTRAP_USAGE)
+        return 0
+
     from conformance.bootstrap.render import (
         MANAGED_ACTION_FILES,
         MANAGED_WORKFLOWS,

--- a/packages/conformance/conformance/cli.py
+++ b/packages/conformance/conformance/cli.py
@@ -396,7 +396,7 @@ commands:
                  needs on disk in every caller repo. All of these always overwrite
                  (re-running eradicates drift). tests.yaml, renovate.json, and
                  contract_schema.lock.json are write-if-absent by default; pass
-                 --enforce to update renovate.json's enforcement mode too.
+                 --enforce true|false to also update renovate.json's enforcement mode.
                    --package-name NAME         docstring-coverage package (default: app)
                    --unit-tests-workflow FILE   build-and-publish test workflow (default: tests.yaml)
                    --app-name NAME             connector app name for tests.yaml (default: from atlan.yaml, else "app")

--- a/packages/conformance/conformance/cli.py
+++ b/packages/conformance/conformance/cli.py
@@ -205,7 +205,7 @@ Write .claude/skills/remediate/SKILL.md + all standard CI workflow shims into
 and .github/scripts/build_conformance_args.py that conformance-reusable.yaml needs on
 disk in every caller repo. All of these always overwrite (re-running eradicates drift).
 tests.yaml, renovate.json, and contract_schema.lock.json are write-if-absent by default;
-pass --enforce to update renovate.json's enforcement mode too.
+pass --enforce true|false to also update renovate.json's enforcement mode.
 
 options:
   --package-name NAME         docstring-coverage package (default: app)

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -134,6 +134,29 @@ def test_cmd_bootstrap_writes_skill_md(
     assert dest.read_text() == render("remediate.md")
 
 
+@pytest.mark.parametrize("help_flag", ["--help", "-h"])
+def test_cmd_bootstrap_help_prints_usage_and_writes_nothing(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    help_flag: str,
+) -> None:
+    """--help/-h must short-circuit before any file is written.
+
+    A hand-rolled flag parser (unlike the other subcommands' argparse-based
+    ones) silently ignores unrecognized flags, so without an explicit guard
+    `bootstrap --help` would fall through and execute the real, mutating
+    bootstrap — surprising callers who expect `--help` to be a no-op.
+    """
+    monkeypatch.chdir(tmp_path)
+    exit_code = _cmd_bootstrap([help_flag])
+    assert exit_code == 0
+    assert (
+        "usage: atlan-application-sdk-conformance bootstrap" in capsys.readouterr().out
+    )
+    assert list(tmp_path.iterdir()) == []
+
+
 def test_cmd_bootstrap_writes_all_managed_workflows(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- `bootstrap --help`/`-h` previously fell through to the real, mutating bootstrap logic instead of printing usage — the subcommand's hand-rolled flag parser silently ignores unrecognized flags, unlike every other subcommand which uses `argparse` and gets `--help` for free.
- Adds an explicit `--help`/`-h` short-circuit in `_cmd_bootstrap` that prints usage and returns before touching any file.
- Adds regression tests asserting `--help`/`-h` exit 0, print usage, and write nothing to disk.

## Test plan
- [x] `uv run pre-commit run --all-files` — clean
- [x] `uv run python -m pytest tests/unit -x -q` — 5313 passed
- [x] `uv run pytest tests/test_bootstrap.py -q` (packages/conformance) — 104 passed
- [x] Manually verified `atlan-application-sdk-conformance bootstrap --help` / `-h` print usage and write no files in a scratch directory