### PR TITLE
fix(conformance): group the remediation residue report by root cause

### DIFF
--- a/.claude/skills/remediate/SKILL.md
+++ b/.claude/skills/remediate/SKILL.md
@@ -234,13 +234,24 @@ equal to the escalated residue count — never silently passed).  In strict mode
 ### Phase 4: Residue report
 
 All residue items (judgment fixes, suppressions, recheck-failures,
-oscillations) are written to `remediation/runs/residue.md` with:
+oscillations) are written to `remediation/runs/residue.md`, **grouped by
+root cause** — keyed on `rule_id`. Findings of the same rule are co-located
+so the shared prescription and rule rationale are stated once and sibling
+sites sit side by side:
 - rule_id, file, line, fingerprint
 - proposed edit (if any)
 - classification and outcome
 - reason the item is in residue
 
-Review each item before merging.
+Grouping organises the report and makes cross-site inconsistencies visible —
+it does **not** mean one fix for the whole group. Residue is where judgment
+findings land, and same rule does not mean same disposition: an exception
+swallow that is correct as best-effort at one site may be a bug at another;
+a stacktrace may be safe to log at one site and leak sensitive data at
+another. Review each item as its own decision, using the group to apply the
+same call where it fits and to consciously justify the exceptions. The
+grouping itself is a mechanical partition on `rule_id`, so it adds no
+judgment and is stable across runs.
 
 ## Anti-gaming disciplines (design §6)
 

--- a/packages/conformance/conformance/programs/conformance-remediation.prose.md
+++ b/packages/conformance/conformance/programs/conformance-remediation.prose.md
@@ -52,6 +52,17 @@ the reason each was routed here:
 - `oscillation` — the loop detected a repeating violation-set and froze.
 - `max-attempts` — the cap was reached with violations remaining.
 
+The report is **grouped by root cause** (keyed on `rule_id`) so findings of
+the same rule are co-located: the shared prescription and rule rationale are
+stated once, and sibling sites sit side by side. Grouping organises the
+report and surfaces cross-site inconsistencies — it does **not** collapse a
+group into one decision. Residue is judgment territory, and same rule need
+not mean same disposition (a swallow that is correct as best-effort at one
+site may be a bug at another; a stacktrace safe to log at one site may leak
+at another), so each item stays an independent call — the group is context
+for that call, not a substitute for it. The partition itself is a purely
+mechanical group-by on an existing field — no model judgment.
+
 ### Requires
 
 - `violations-error-handling` from `error-handling-area`
@@ -114,6 +125,8 @@ parallel:
     scope: scope
     mode: mode
 
-# Collect residue from all areas and emit the unified report.
-emit violations-summary and residue
+# Collect residue from all areas and emit the unified report, grouped by
+# root cause (rule_id) so each class of leftover findings reads as one
+# decision — see the residue facet above and detect-fix-recheck's emit step.
+emit violations-summary and residue grouped by root cause
 ```

--- a/packages/conformance/conformance/programs/patterns/detect-fix-recheck.prose.md
+++ b/packages/conformance/conformance/programs/patterns/detect-fix-recheck.prose.md
@@ -104,12 +104,49 @@ loop until violations is empty or attempts >= max_attempts:
 if violations is not empty:
   escalate "max attempts reached with %d violations remaining" % len(violations)
 
-emit residue as structured report
-  for each item in residue:
-    - rule_id, file, line, fingerprint
-    - proposed edit (if any)
-    - classification and outcome
-    - reason the item is in residue (judgment / suppression / recheck-failed / not-remediable)
+# Group residue by root cause before emitting. The cluster key is rule_id:
+# every finding of a rule shares one prescription and one rule rationale, so
+# grouping co-locates them — the reviewer reads that shared context once
+# instead of per row, and sees sibling sites side by side.
+#
+# Grouping does NOT collapse the group into one decision. Residue is where
+# the *judgment* findings land, and same rule does not mean same disposition:
+# an exception swallow may be correct as best-effort at one site and a latent
+# bug at another; a stacktrace may be safe to log at one site and leak
+# sensitive data at another. Each item stays an independent decision. What
+# grouping buys is that an inconsistent call across similar sites becomes
+# visible — so the reviewer can apply the same fix where it fits and
+# consciously justify the exceptions, rather than silently diverge (or
+# force-align sites that legitimately differ).
+#
+# The partition itself is purely mechanical (a group-by on an existing
+# field): no model judgment, nothing to game, stable across runs.
+#
+# This is REPORT-only grouping. It deliberately does not touch how fixes are
+# decided: each finding is still remediated on its own merits, in its own
+# small context, and gated on its own (see the per-finding loop above). A
+# cluster-*fix* pre-pass — one agent deciding a single edit for many sites at
+# once — is intentionally NOT pursued here, and this grouping is not a step
+# toward one. Per-site independence is a feature, not a limitation: it keeps
+# fix-vs-suppress a per-site call (the right answer at one E013 site can be
+# the opposite of another's), keeps each context small, and keeps model
+# errors uncorrelated so recheck catches them one finding at a time. One
+# large context deciding all N sites would instead risk a single
+# wrong-but-fingerprint-clearing edit passing for the whole group — a
+# correlated false-negative the gate can't catch. Do not read "grouped by
+# root cause" as license to merge the decisions.
+emit residue as structured report, grouped by root cause
+  for each cluster in group(residue by rule_id), ordered by rule_id:
+    - class header: rule_id, area, count of items in this cluster
+    - the shared prescription and rule rationale, stated once (from the area
+      prescription) — a starting point for each site, not a verdict for the group
+    - for each item in cluster, ordered by file then line:
+      - file, line, fingerprint
+      - proposed edit (if any)
+      - classification and outcome
+      - reason this item is in residue (judgment / suppression / recheck-failed
+        / not-remediable) — items in one cluster may differ here, and each is
+        decided on its own merits
 ```
 
 ### Notes


### PR DESCRIPTION
## Summary

Applies the root-cause clustering idea (see #2511 for the sdk-review reviewer side) to the **remediate skill** — but only the piece that transfers cleanly: **grouping the residue report by root cause.** Report-only; the gated loop is untouched.

The residue report emitted at the end of the detect → fix → recheck loop currently lists every leftover finding as an independent row. When one rule produces many findings, a human re-reads the same prescription and rule rationale per row and can't easily see sibling sites side by side.

## What grouping does

Cluster key is `rule_id`: every finding of a rule shares one prescription and one rule rationale, so grouping **co-locates** them — shared context stated once, siblings together. The partition is a purely mechanical group-by on an existing field: no model judgment, nothing to game, stable across runs.

## Two things it is careful NOT to do

**1. It does not collapse a group into one decision.** Residue is where the *judgment* findings land (E/L-series), and same rule does **not** mean same disposition:
- an exception swallow may be correct as best-effort at one site and a latent bug at another;
- a stacktrace may be safe to log at one site and leak sensitive data at another.

Each item stays an independent call; the group is *context* for that call, not a substitute. This is the "extend the same fix to peers **or** justify the exception" posture — grouping makes both the peers and the legitimate exceptions visible.

**2. It does not change how fixes are decided, and is not a step toward a cluster-*fix* pre-pass.** This is where the sdk-review analogy deliberately stops. sdk-review is a single serial reviewer whose failure was *under*-generalization across human round-trips. Conformance execution already fans out into independent, small-context, individually-gated decisions — and that fan-out is a **feature**:
- fix-vs-suppress stays a per-site call;
- each context stays small;
- model errors stay **uncorrelated**, so recheck catches them one finding at a time.

A cluster-*fix* pre-pass (one agent deciding a single edit for many sites) would trade that away: one large context risks a single wrong-but-fingerprint-clearing edit passing for the whole group — a correlated false-negative the gate can't catch. So it's **deliberately out of scope for conformance, not merely deferred.** The loop already picks up siblings on its next self-iteration, so there's no round-count problem to solve here in the first place.

## Change

- `patterns/detect-fix-recheck.prose.md` — emit residue grouped by `rule_id`, class header + shared context once; each item an independent decision; explicit note that grouping is not license to merge fix decisions.
- `programs/conformance-remediation.prose.md` — document the grouping and its non-collapsing nature on the `#### residue` facet and the top-level emit step.
- `.claude/skills/remediate/SKILL.md` — Phase 4 describes the grouped report; reviewer decides each item on its merits.

Docs/program-prose only; no Python code paths, no test assertions on the residue format (verified), pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)