### PR TITLE
fix(execution): re-export Temporal client-side failure exceptions

### DIFF
--- a/.claude/skills/capability-manifest/references/extractor.py
+++ b/.claude/skills/capability-manifest/references/extractor.py
@@ -15,7 +15,10 @@ Usage (from repo root):
 from __future__ import annotations
 
 import ast
+import importlib
+import inspect
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -327,6 +330,116 @@ def _resolve_actual_obj(name: str, griffe_obj: Any) -> Any:
     return griffe_obj
 
 
+def _external_alias_target(griffe_obj: Any) -> str | None:
+    """Return the dotted target path if *griffe_obj* is a re-export of a symbol from
+    outside ``application_sdk`` (e.g. ``temporalio.exceptions.ActivityError``), else None.
+
+    Griffe only loads the ``application_sdk`` package (see ``cmd_dump``), so an alias
+    pointing at a third-party module is never resolved through griffe's static graph —
+    accessing ``.docstring``/``.final_target`` on it raises ``AliasResolutionError``.
+    Detecting this case lets the caller fall back to runtime introspection instead of
+    emitting a blanket "no docstring".
+    """
+    if not getattr(griffe_obj, "is_alias", False):
+        return None
+    try:
+        target_path = griffe_obj.target_path
+    except Exception:
+        return None
+    if not target_path or target_path.startswith("application_sdk"):
+        return None
+    return target_path
+
+
+def _import_external_target(target_path: str) -> Any:
+    """Best-effort runtime import of a dotted path like ``temporalio.exceptions.ActivityError``.
+
+    Tries progressively shorter module prefixes (a dotted path can't be split into
+    module/attribute without knowing where the module ends and class attributes begin).
+    """
+    parts = target_path.split(".")
+    for split in range(len(parts) - 1, 0, -1):
+        module_name = ".".join(parts[:split])
+        try:
+            obj = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        try:
+            for attr in parts[split:]:
+                obj = getattr(obj, attr)
+            return obj
+        except AttributeError:
+            continue
+    return None
+
+
+_MEMORY_ADDRESS_RE = re.compile(r" at 0x[0-9a-fA-F]+")
+
+
+def _truncate_signature(full: str, prefix: str, args: str) -> str:
+    """Shorten an ``inspect``-derived signature to a deterministic, readable form.
+
+    Two independent reasons to truncate: the existing 120-char convention shared with
+    the griffe-based renderers, and the fact that ``inspect.signature`` embeds the
+    *repr* of mutable default values — which can contain a live memory address (e.g. a
+    ``DataConverter(...)`` instance default). That address changes every run, which
+    would make this generated, diffed file non-deterministic.
+    """
+    if len(full) <= 120 and not _MEMORY_ADDRESS_RE.search(full):
+        return full
+    first_arg = args.lstrip("(").split(",")[0].split(")")[0].strip()
+    if not first_arg or _MEMORY_ADDRESS_RE.search(first_arg):
+        return prefix + "(...)"
+    return prefix + "(" + first_arg + ", ...)"
+
+
+def _external_alias_symbol(name: str, target_path: str) -> dict[str, Any] | None:
+    """Build a manifest symbol entry for an external re-export via runtime introspection.
+
+    Returns None if the target can't be imported (e.g. an optional dependency isn't
+    installed) — the caller falls back to the normal griffe-based path in that case.
+    """
+    obj = _import_external_target(target_path)
+    if obj is None:
+        return None
+
+    doc = inspect.getdoc(obj)
+    first_line = doc.strip().split("\n")[0].strip() if doc and doc.strip() else None
+    summary = (
+        f"{first_line} _(re-exported from `{target_path}`)_"
+        if first_line
+        else f"_(re-exported from `{target_path}`, no docstring)_"
+    )
+
+    if inspect.isclass(obj):
+        kind = KIND_CLASS
+        try:
+            raw = str(inspect.signature(obj.__init__))
+            args = raw.removeprefix("(self, ").removeprefix("(self)")
+            args = "(" + args if not args.startswith("(") else args
+        except (TypeError, ValueError):
+            args = "()"
+        signature = _truncate_signature(f"class {name}{args}", f"class {name}", args)
+    elif inspect.isroutine(obj):
+        kind = KIND_FUNCTION
+        try:
+            args = str(inspect.signature(obj))
+        except (TypeError, ValueError):
+            args = "(...)"
+        signature = _truncate_signature(name + args, name, args)
+    else:
+        kind = KIND_CONSTANT
+        signature = name
+
+    return {
+        "name": name,
+        "kind": kind,
+        "signature": signature,
+        "summary": summary,
+        "filepath": "",
+    }
+
+
 # ---------------------------------------------------------------------------
 # DUMP subcommand
 # ---------------------------------------------------------------------------
@@ -374,6 +487,16 @@ def cmd_dump() -> None:
         symbols: list[dict[str, Any]] = []
         for name in all_names:
             griffe_obj = griffe_subpkg.members.get(name)
+
+            external_target = _external_alias_target(griffe_obj)
+            if external_target is not None:
+                external_symbol = _external_alias_symbol(name, external_target)
+                if external_symbol is not None:
+                    symbols.append(external_symbol)
+                    continue
+                # Import failed (e.g. optional dependency not installed) — fall through
+                # to the normal griffe-based path, which will emit "no docstring".
+
             resolved = _resolve_actual_obj(name, griffe_obj)
             kind = _classify_symbol(name, griffe_obj)
 

--- a/.claude/skills/capability-manifest/references/extractor.py
+++ b/.claude/skills/capability-manifest/references/extractor.py
@@ -376,7 +376,7 @@ def _import_external_target(target_path: str) -> Any:
 _MEMORY_ADDRESS_RE = re.compile(r" at 0x[0-9a-fA-F]+")
 
 
-def _truncate_signature(full: str, prefix: str, args: str) -> str:
+def _truncate_signature(full: str, prefix: str, sig: inspect.Signature | None) -> str:
     """Shorten an ``inspect``-derived signature to a deterministic, readable form.
 
     Two independent reasons to truncate: the existing 120-char convention shared with
@@ -384,13 +384,19 @@ def _truncate_signature(full: str, prefix: str, args: str) -> str:
     *repr* of mutable default values — which can contain a live memory address (e.g. a
     ``DataConverter(...)`` instance default). That address changes every run, which
     would make this generated, diffed file non-deterministic.
+
+    Takes the actual ``inspect.Signature`` (not a pre-rendered string) so the first
+    parameter can be pulled out structurally — string-splitting on the first comma
+    would cut a generic annotation like ``Dict[str, Any]`` in half.
     """
     if len(full) <= 120 and not _MEMORY_ADDRESS_RE.search(full):
         return full
-    first_arg = args.lstrip("(").split(",")[0].split(")")[0].strip()
-    if not first_arg or _MEMORY_ADDRESS_RE.search(first_arg):
+    if sig is None or not sig.parameters:
         return prefix + "(...)"
-    return prefix + "(" + first_arg + ", ...)"
+    first_param = str(next(iter(sig.parameters.values())))
+    if _MEMORY_ADDRESS_RE.search(first_param):
+        return prefix + "(...)"
+    return prefix + "(" + first_param + ", ...)"
 
 
 def _external_alias_symbol(name: str, target_path: str) -> dict[str, Any] | None:
@@ -414,26 +420,24 @@ def _external_alias_symbol(name: str, target_path: str) -> dict[str, Any] | None
     if inspect.isclass(obj):
         kind = KIND_CLASS
         try:
-            init_sig = inspect.signature(obj.__init__).replace(
+            # inspect.signature() on the class itself (not obj.__init__) already
+            # drops `self` and correctly returns an empty signature when the class
+            # has no custom __init__ — no manual prefix-stripping needed.
+            sig: inspect.Signature | None = inspect.signature(obj).replace(
                 return_annotation=inspect.Signature.empty
             )
-            raw = str(init_sig)
-            if raw.startswith("(self, "):
-                args = "(" + raw[len("(self, ") :]
-            elif raw.startswith("(self)"):
-                args = "()" + raw[len("(self)") :]
-            else:
-                args = raw
         except (TypeError, ValueError):
-            args = "()"
-        signature = _truncate_signature(f"class {name}{args}", f"class {name}", args)
+            sig = None
+        args = str(sig) if sig is not None else "()"
+        signature = _truncate_signature(f"class {name}{args}", f"class {name}", sig)
     elif inspect.isroutine(obj):
         kind = KIND_FUNCTION
         try:
-            args = str(inspect.signature(obj))
+            sig = inspect.signature(obj)
         except (TypeError, ValueError):
-            args = "(...)"
-        signature = _truncate_signature(name + args, name, args)
+            sig = None
+        args = str(sig) if sig is not None else "(...)"
+        signature = _truncate_signature(name + args, name, sig)
     else:
         kind = KIND_CONSTANT
         signature = name
@@ -444,6 +448,58 @@ def _external_alias_symbol(name: str, target_path: str) -> dict[str, Any] | None
         "signature": signature,
         "summary": summary,
         "filepath": "",
+    }
+
+
+def _symbol_for(name: str, griffe_obj: Any) -> dict[str, Any]:
+    """Build one manifest symbol entry for an exported name.
+
+    Tries runtime introspection first for aliases pointing outside
+    ``application_sdk`` (see ``_external_alias_target``); falls back to the
+    griffe-based path for everything else, including an alias whose target
+    turned out to be unimportable.
+    """
+    external_target = _external_alias_target(griffe_obj)
+    if external_target is not None:
+        external_symbol = _external_alias_symbol(name, external_target)
+        if external_symbol is not None:
+            return external_symbol
+        # Import failed (e.g. optional dependency not installed) — fall through
+        # to the normal griffe-based path, which will emit "no docstring".
+
+    resolved = _resolve_actual_obj(name, griffe_obj)
+    kind = _classify_symbol(name, griffe_obj)
+
+    if kind == KIND_CLASS:
+        sig = (
+            _render_class_signature(resolved)
+            if resolved is not None
+            else ("class " + name)
+        )
+    elif kind in (KIND_FUNCTION, KIND_DECORATOR):
+        sig = _render_signature(resolved) if resolved is not None else (name + "(...)")
+    else:
+        # constant/enum
+        ann = (
+            _render_annotation(resolved.annotation)
+            if resolved is not None and hasattr(resolved, "annotation")
+            else ""
+        )
+        sig = name + (": " + ann if ann else "")
+
+    summary = (
+        _docstring_summary(resolved) if resolved is not None else "_(no docstring)_"
+    )
+    if summary == "_(no docstring)_" and resolved is not None and kind == KIND_CONSTANT:
+        summary = _constant_fallback_summary(resolved)
+    filepath = _relative_filepath(resolved) if resolved is not None else ""
+
+    return {
+        "name": name,
+        "kind": kind,
+        "signature": sig,
+        "summary": summary,
+        "filepath": filepath,
     }
 
 
@@ -491,65 +547,9 @@ def cmd_dump() -> None:
 
         eprint(f"  {subpkg_name}: {len(all_names)} exports")
 
-        symbols: list[dict[str, Any]] = []
-        for name in all_names:
-            griffe_obj = griffe_subpkg.members.get(name)
-
-            external_target = _external_alias_target(griffe_obj)
-            if external_target is not None:
-                external_symbol = _external_alias_symbol(name, external_target)
-                if external_symbol is not None:
-                    symbols.append(external_symbol)
-                    continue
-                # Import failed (e.g. optional dependency not installed) — fall through
-                # to the normal griffe-based path, which will emit "no docstring".
-
-            resolved = _resolve_actual_obj(name, griffe_obj)
-            kind = _classify_symbol(name, griffe_obj)
-
-            if kind == KIND_CLASS:
-                sig = (
-                    _render_class_signature(resolved)
-                    if resolved is not None
-                    else ("class " + name)
-                )
-            elif kind in (KIND_FUNCTION, KIND_DECORATOR):
-                sig = (
-                    _render_signature(resolved)
-                    if resolved is not None
-                    else (name + "(...)")
-                )
-            else:
-                # constant/enum
-                ann = (
-                    _render_annotation(resolved.annotation)
-                    if resolved is not None and hasattr(resolved, "annotation")
-                    else ""
-                )
-                sig = name + (": " + ann if ann else "")
-
-            summary = (
-                _docstring_summary(resolved)
-                if resolved is not None
-                else "_(no docstring)_"
-            )
-            if (
-                summary == "_(no docstring)_"
-                and resolved is not None
-                and kind == KIND_CONSTANT
-            ):
-                summary = _constant_fallback_summary(resolved)
-            filepath = _relative_filepath(resolved) if resolved is not None else ""
-
-            symbols.append(
-                {
-                    "name": name,
-                    "kind": kind,
-                    "signature": sig,
-                    "summary": summary,
-                    "filepath": filepath,
-                }
-            )
+        symbols: list[dict[str, Any]] = [
+            _symbol_for(name, griffe_subpkg.members.get(name)) for name in all_names
+        ]
 
         output["subpackages"][subpkg_name] = {
             "all": all_names,

--- a/.claude/skills/capability-manifest/references/extractor.py
+++ b/.claude/skills/capability-manifest/references/extractor.py
@@ -414,9 +414,16 @@ def _external_alias_symbol(name: str, target_path: str) -> dict[str, Any] | None
     if inspect.isclass(obj):
         kind = KIND_CLASS
         try:
-            raw = str(inspect.signature(obj.__init__))
-            args = raw.removeprefix("(self, ").removeprefix("(self)")
-            args = "(" + args if not args.startswith("(") else args
+            init_sig = inspect.signature(obj.__init__).replace(
+                return_annotation=inspect.Signature.empty
+            )
+            raw = str(init_sig)
+            if raw.startswith("(self, "):
+                args = "(" + raw[len("(self, ") :]
+            elif raw.startswith("(self)"):
+                args = "()" + raw[len("(self)") :]
+            else:
+                args = raw
         except (TypeError, ValueError):
             args = "()"
         signature = _truncate_signature(f"class {name}{args}", f"class {name}", args)

--- a/application_sdk/execution/__init__.py
+++ b/application_sdk/execution/__init__.py
@@ -9,6 +9,11 @@ from temporalio.client import WorkflowFailureError as TemporalWorkflowFailureErr
 # `TemporalClient`) so they don't collide with unrelated SDK types of the same short
 # name, e.g. `application_sdk.common.error_codes.ActivityError` and
 # `application_sdk.errors.leaves.CancelledError`.
+#
+# These are raw temporalio exceptions for code awaiting `TemporalClient.execute_workflow(...)`
+# or a workflow handle. For SDK-classified domain failures inside `@task`/`@entrypoint` code,
+# raise/catch `application_sdk.errors.AppError` leaves (`CancelledError`, `AppTimeoutError`,
+# etc.) instead.
 from temporalio.exceptions import ActivityError as TemporalActivityError
 from temporalio.exceptions import CancelledError as TemporalCancelledError
 from temporalio.exceptions import ChildWorkflowError as TemporalChildWorkflowError

--- a/application_sdk/execution/__init__.py
+++ b/application_sdk/execution/__init__.py
@@ -7,8 +7,13 @@ from temporalio.client import WorkflowFailureError as TemporalWorkflowFailureErr
 # Re-export the client-side failure types apps need to catch around
 # `TemporalClient.execute_workflow(...)`. Renamed with a `Temporal` prefix (matching
 # `TemporalClient`) so they don't collide with unrelated SDK types of the same short
-# name, e.g. `application_sdk.common.error_codes.ActivityError`.
+# name, e.g. `application_sdk.common.error_codes.ActivityError` and
+# `application_sdk.errors.leaves.CancelledError`.
 from temporalio.exceptions import ActivityError as TemporalActivityError
+from temporalio.exceptions import CancelledError as TemporalCancelledError
+from temporalio.exceptions import ChildWorkflowError as TemporalChildWorkflowError
+from temporalio.exceptions import TerminatedError as TemporalTerminatedError
+from temporalio.exceptions import TimeoutError as TemporalTimeoutError
 
 from application_sdk.execution._temporal.activity_utils import (
     build_output_path,
@@ -38,8 +43,12 @@ __all__ = [
     "TemporalActivityError",
     "TemporalAuthConfig",
     "TemporalAuthManager",
+    "TemporalCancelledError",
+    "TemporalChildWorkflowError",
     "TemporalClient",
     "TemporalExecutorBackend",
+    "TemporalTerminatedError",
+    "TemporalTimeoutError",
     "TemporalWorkflowFailureError",
     "build_output_path",
     "create_data_converter",

--- a/application_sdk/execution/__init__.py
+++ b/application_sdk/execution/__init__.py
@@ -2,6 +2,13 @@
 
 # Re-export the temporalio Client as TemporalClient for app-side type annotations.
 from temporalio.client import Client as TemporalClient
+from temporalio.client import WorkflowFailureError as TemporalWorkflowFailureError
+
+# Re-export the client-side failure types apps need to catch around
+# `TemporalClient.execute_workflow(...)`. Renamed with a `Temporal` prefix (matching
+# `TemporalClient`) so they don't collide with unrelated SDK types of the same short
+# name, e.g. `application_sdk.common.error_codes.ActivityError`.
+from temporalio.exceptions import ActivityError as TemporalActivityError
 
 from application_sdk.execution._temporal.activity_utils import (
     build_output_path,
@@ -28,10 +35,12 @@ __all__ = [
     "AppWorker",
     "ApplicationError",
     "RetryPolicy",
+    "TemporalActivityError",
     "TemporalAuthConfig",
     "TemporalAuthManager",
     "TemporalClient",
     "TemporalExecutorBackend",
+    "TemporalWorkflowFailureError",
     "build_output_path",
     "create_data_converter",
     "create_data_converter_for_app",

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1300,6 +1300,12 @@ Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal clien
 - **Summary:** Configuration for retry behavior.
 - **Defined in:** `application_sdk/execution/retry.py`
 
+#### `TemporalActivityError`
+
+- **Import:** `from application_sdk.execution import TemporalActivityError`
+- **Signature:** `class TemporalActivityError(message: str, ...)`
+- **Summary:** Error raised on activity failure. _(re-exported from `temporalio.exceptions.ActivityError`)_
+
 #### `TemporalAuthConfig`
 
 - **Import:** `from application_sdk.execution import TemporalAuthConfig`
@@ -1314,12 +1320,48 @@ Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal clien
 - **Summary:** Manages OAuth token lifecycle for Temporal client connections.
 - **Defined in:** `application_sdk/execution/_temporal/auth.py`
 
+#### `TemporalCancelledError`
+
+- **Import:** `from application_sdk.execution import TemporalCancelledError`
+- **Signature:** `class TemporalCancelledError(message: str = 'Cancelled', *details: Any) -> None`
+- **Summary:** Error raised on workflow/activity cancellation. _(re-exported from `temporalio.exceptions.CancelledError`)_
+
+#### `TemporalChildWorkflowError`
+
+- **Import:** `from application_sdk.execution import TemporalChildWorkflowError`
+- **Signature:** `class TemporalChildWorkflowError(message: str, ...)`
+- **Summary:** Error raised on child workflow failure. _(re-exported from `temporalio.exceptions.ChildWorkflowError`)_
+
+#### `TemporalClient`
+
+- **Import:** `from application_sdk.execution import TemporalClient`
+- **Signature:** `class TemporalClient(service_client: 'temporalio.service.ServiceClient', ...)`
+- **Summary:** Client for accessing Temporal. _(re-exported from `temporalio.client.Client`)_
+
 #### `TemporalExecutorBackend`
 
 - **Import:** `from application_sdk.execution import TemporalExecutorBackend`
 - **Signature:** `class TemporalExecutorBackend(client: Client, task_queue: str = 'application-sdk')`
 - **Summary:** Temporal-based executor backend for running Apps as workflows.
 - **Defined in:** `application_sdk/execution/_temporal/backend.py`
+
+#### `TemporalTerminatedError`
+
+- **Import:** `from application_sdk.execution import TemporalTerminatedError`
+- **Signature:** `class TemporalTerminatedError(message: str, *details: Any) -> None`
+- **Summary:** Error raised on workflow cancellation. _(re-exported from `temporalio.exceptions.TerminatedError`)_
+
+#### `TemporalTimeoutError`
+
+- **Import:** `from application_sdk.execution import TemporalTimeoutError`
+- **Signature:** `class TemporalTimeoutError(message: str, ...)`
+- **Summary:** Error raised on workflow/activity timeout. _(re-exported from `temporalio.exceptions.TimeoutError`)_
+
+#### `TemporalWorkflowFailureError`
+
+- **Import:** `from application_sdk.execution import TemporalWorkflowFailureError`
+- **Signature:** `class TemporalWorkflowFailureError(*, cause: 'BaseException') -> 'None'`
+- **Summary:** Error that occurs when a workflow is unsuccessful. _(re-exported from `temporalio.client.WorkflowFailureError`)_
 
 ### Functions
 
@@ -1371,41 +1413,6 @@ Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal clien
 - **Signature:** `needs_lock(max_locks: int = 5, lock_name: Optional[str] = None)`
 - **Summary:** Decorator to mark activities that require distributed locking.
 - **Defined in:** `application_sdk/execution/decorators.py`
-
-#### `TemporalActivityError`
-
-- **Import:** `from application_sdk.execution import TemporalActivityError`
-- **Summary:** _(no docstring)_
-
-#### `TemporalCancelledError`
-
-- **Import:** `from application_sdk.execution import TemporalCancelledError`
-- **Summary:** _(no docstring)_
-
-#### `TemporalChildWorkflowError`
-
-- **Import:** `from application_sdk.execution import TemporalChildWorkflowError`
-- **Summary:** _(no docstring)_
-
-#### `TemporalClient`
-
-- **Import:** `from application_sdk.execution import TemporalClient`
-- **Summary:** _(no docstring)_
-
-#### `TemporalTerminatedError`
-
-- **Import:** `from application_sdk.execution import TemporalTerminatedError`
-- **Summary:** _(no docstring)_
-
-#### `TemporalTimeoutError`
-
-- **Import:** `from application_sdk.execution import TemporalTimeoutError`
-- **Summary:** _(no docstring)_
-
-#### `TemporalWorkflowFailureError`
-
-- **Import:** `from application_sdk.execution import TemporalWorkflowFailureError`
-- **Summary:** _(no docstring)_
 
 ## `application_sdk.handler`
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1323,7 +1323,7 @@ Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal clien
 #### `TemporalCancelledError`
 
 - **Import:** `from application_sdk.execution import TemporalCancelledError`
-- **Signature:** `class TemporalCancelledError(message: str = 'Cancelled', *details: Any) -> None`
+- **Signature:** `class TemporalCancelledError(message: str = 'Cancelled', *details: Any)`
 - **Summary:** Error raised on workflow/activity cancellation. _(re-exported from `temporalio.exceptions.CancelledError`)_
 
 #### `TemporalChildWorkflowError`
@@ -1348,7 +1348,7 @@ Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal clien
 #### `TemporalTerminatedError`
 
 - **Import:** `from application_sdk.execution import TemporalTerminatedError`
-- **Signature:** `class TemporalTerminatedError(message: str, *details: Any) -> None`
+- **Signature:** `class TemporalTerminatedError(message: str, *details: Any)`
 - **Summary:** Error raised on workflow cancellation. _(re-exported from `temporalio.exceptions.TerminatedError`)_
 
 #### `TemporalTimeoutError`
@@ -1360,7 +1360,7 @@ Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal clien
 #### `TemporalWorkflowFailureError`
 
 - **Import:** `from application_sdk.execution import TemporalWorkflowFailureError`
-- **Signature:** `class TemporalWorkflowFailureError(*, cause: 'BaseException') -> 'None'`
+- **Signature:** `class TemporalWorkflowFailureError(*, cause: 'BaseException')`
 - **Summary:** Error that occurs when a workflow is unsuccessful. _(re-exported from `temporalio.client.WorkflowFailureError`)_
 
 ### Functions

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.20.3
-source-sha:    4c520cda9a59c88a617c495583ada92d26cb3015
-source-date:   2026-07-05T12:46:17+01:00
+source-sha:    ace322e5d02463733736b4b11984b32a57943d9e
+source-date:   2026-07-05T13:26:56+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.20.3
-source-sha:    fe5f52ee89b415f43f84c27e42bd46f52ce70075
-source-date:   2026-07-03T12:27:18+05:30
+source-sha:    d5218d299841507797f9be166b74c2af64e9a25a
+source-date:   2026-07-05T12:41:35+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -24,7 +24,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.contracts` | Typed Pydantic Input/Output base classes, payload safety, storage and type helpers | 28 |
 | `application_sdk.credentials` | Credential resolvers (Atlan, OAuth, Git, agent), registry, vault spec | 41 |
 | `application_sdk.errors` | Structured error codes — ErrorCode dataclass and cross-component constants (APP_ERROR, HANDLER_ERROR, CONTRACT_VALIDATION, etc.) | 54 |
-| `application_sdk.execution` | Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal client | 14 |
+| `application_sdk.execution` | Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal client | 16 |
 | `application_sdk.handler` | HTTP handler framework — Handler ABC, DefaultHandler, preflight, auth, service factory | 22 |
 | `application_sdk.infrastructure` | Protocol-based infrastructure (StateStore, SecretStore, PubSub, Bindings, CapacityPool) | 34 |
 | `application_sdk.main` | Dev entry point — run_dev_combined() and AppConfig for local execution and container startup | 2 |
@@ -1372,9 +1372,19 @@ Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal clien
 - **Summary:** Decorator to mark activities that require distributed locking.
 - **Defined in:** `application_sdk/execution/decorators.py`
 
+#### `TemporalActivityError`
+
+- **Import:** `from application_sdk.execution import TemporalActivityError`
+- **Summary:** _(no docstring)_
+
 #### `TemporalClient`
 
 - **Import:** `from application_sdk.execution import TemporalClient`
+- **Summary:** _(no docstring)_
+
+#### `TemporalWorkflowFailureError`
+
+- **Import:** `from application_sdk.execution import TemporalWorkflowFailureError`
 - **Summary:** _(no docstring)_
 
 ## `application_sdk.handler`

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.20.3
-source-sha:    d5218d299841507797f9be166b74c2af64e9a25a
-source-date:   2026-07-05T12:41:35+01:00
+source-sha:    4c520cda9a59c88a617c495583ada92d26cb3015
+source-date:   2026-07-05T12:46:17+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -24,7 +24,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.contracts` | Typed Pydantic Input/Output base classes, payload safety, storage and type helpers | 28 |
 | `application_sdk.credentials` | Credential resolvers (Atlan, OAuth, Git, agent), registry, vault spec | 41 |
 | `application_sdk.errors` | Structured error codes — ErrorCode dataclass and cross-component constants (APP_ERROR, HANDLER_ERROR, CONTRACT_VALIDATION, etc.) | 54 |
-| `application_sdk.execution` | Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal client | 16 |
+| `application_sdk.execution` | Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal client | 20 |
 | `application_sdk.handler` | HTTP handler framework — Handler ABC, DefaultHandler, preflight, auth, service factory | 22 |
 | `application_sdk.infrastructure` | Protocol-based infrastructure (StateStore, SecretStore, PubSub, Bindings, CapacityPool) | 34 |
 | `application_sdk.main` | Dev entry point — run_dev_combined() and AppConfig for local execution and container startup | 2 |
@@ -1377,9 +1377,29 @@ Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal clien
 - **Import:** `from application_sdk.execution import TemporalActivityError`
 - **Summary:** _(no docstring)_
 
+#### `TemporalCancelledError`
+
+- **Import:** `from application_sdk.execution import TemporalCancelledError`
+- **Summary:** _(no docstring)_
+
+#### `TemporalChildWorkflowError`
+
+- **Import:** `from application_sdk.execution import TemporalChildWorkflowError`
+- **Summary:** _(no docstring)_
+
 #### `TemporalClient`
 
 - **Import:** `from application_sdk.execution import TemporalClient`
+- **Summary:** _(no docstring)_
+
+#### `TemporalTerminatedError`
+
+- **Import:** `from application_sdk.execution import TemporalTerminatedError`
+- **Summary:** _(no docstring)_
+
+#### `TemporalTimeoutError`
+
+- **Import:** `from application_sdk.execution import TemporalTimeoutError`
 - **Summary:** _(no docstring)_
 
 #### `TemporalWorkflowFailureError`

--- a/docs/concepts/apps.md
+++ b/docs/concepts/apps.md
@@ -436,6 +436,45 @@ policy = RetryPolicy().with_max_attempts(5).with_non_retryable(ValueError)
 
 ---
 
+## Catching Client-Side Workflow Failures
+
+Code that calls `TemporalClient.execute_workflow(...)` or waits on a workflow handle
+(test harnesses, admin tooling, anything outside `run()`/`@task`) can catch the
+Temporal failure/cause exception family directly from `application_sdk.execution` —
+no need to import `temporalio` yourself:
+
+```python
+from application_sdk.execution import (
+    TemporalActivityError,
+    TemporalCancelledError,
+    TemporalWorkflowFailureError,
+)
+
+try:
+    await temporal_client.execute_workflow(MyConnector.run, input, id=run_id, task_queue=queue)
+except TemporalWorkflowFailureError as e:
+    match e.cause:
+        case TemporalActivityError():
+            ...  # an @task raised
+        case TemporalCancelledError():
+            ...  # the workflow was cancelled
+```
+
+`TemporalWorkflowFailureError` wraps the terminal-state cause on `.cause` — one of
+`TemporalActivityError`, `TemporalCancelledError`, `TemporalChildWorkflowError`,
+`TemporalTerminatedError`, or `TemporalTimeoutError`. These are re-exported (not
+wrapped) with a `Temporal` prefix so they don't collide with unrelated SDK types
+of the same short name, e.g. `application_sdk.common.error_codes.ActivityError`
+and `application_sdk.errors.leaves.CancelledError`.
+
+This is distinct from error handling *inside* `run()`/`@task` code: there, raise
+and catch `application_sdk.errors.AppError` leaves (`CancelledError`,
+`AppTimeoutError`, etc.) instead — those carry the SDK's classified failure
+metadata (category, code, retryable). The `Temporal*Error` types above are raw
+client-side signals for code observing a workflow from the outside.
+
+---
+
 ## Atlan Client Mixin
 
 Mix in `AtlanClientMixin` when your App needs to call the Atlan API. It provides `get_or_create_async_atlan_client()`, which caches the `AsyncAtlanClient` per execution.

--- a/docs/concepts/apps.md
+++ b/docs/concepts/apps.md
@@ -458,14 +458,20 @@ except TemporalWorkflowFailureError as e:
             ...  # an @task raised
         case TemporalCancelledError():
             ...  # the workflow was cancelled
+        case _:
+            ...  # e.g. temporalio.exceptions.ApplicationError when run()/@entrypoint
+            # itself raised directly — still log/handle it, don't ignore silently
 ```
 
-`TemporalWorkflowFailureError` wraps the terminal-state cause on `.cause` — one of
-`TemporalActivityError`, `TemporalCancelledError`, `TemporalChildWorkflowError`,
-`TemporalTerminatedError`, or `TemporalTimeoutError`. These are re-exported (not
-wrapped) with a `Temporal` prefix so they don't collide with unrelated SDK types
-of the same short name, e.g. `application_sdk.common.error_codes.ActivityError`
-and `application_sdk.errors.leaves.CancelledError`.
+`TemporalWorkflowFailureError` wraps the terminal-state cause on `.cause` — commonly
+one of `TemporalActivityError`, `TemporalCancelledError`, `TemporalChildWorkflowError`,
+`TemporalTerminatedError`, or `TemporalTimeoutError`, but not limited to those (e.g. a
+direct raise from `run()`/`@entrypoint` surfaces as the unexported
+`temporalio.exceptions.ApplicationError` — always include a catch-all case). These
+five are re-exported (not wrapped) with a `Temporal` prefix so they don't collide with
+unrelated SDK types of the same short name, e.g.
+`application_sdk.common.error_codes.ActivityError` and
+`application_sdk.errors.leaves.CancelledError`.
 
 This is distinct from error handling *inside* `run()`/`@task` code: there, raise
 and catch `application_sdk.errors.AppError` leaves (`CancelledError`,

--- a/tests/unit/execution/test_converter.py
+++ b/tests/unit/execution/test_converter.py
@@ -71,6 +71,57 @@ class TestPublicSurface:
             "TemporalTimeoutError",
         } <= set(execution.__all__)
 
+    def test_workflow_failure_error_cause_dispatches_via_match_case(self) -> None:
+        """Pins the docs/concepts/apps.md example -- `match e.cause: case
+        TemporalActivityError(): ...` must actually dispatch on the re-exported
+        types via structural pattern matching, not just type-check in isolation."""
+        activity_error = TemporalActivityError(
+            "activity failed",
+            scheduled_event_id=1,
+            started_event_id=2,
+            identity="test-worker",
+            activity_type="my_activity",
+            activity_id="1",
+            retry_state=None,
+        )
+        failure = TemporalWorkflowFailureError(cause=activity_error)
+
+        match failure.cause:
+            case TemporalActivityError():
+                matched = "activity"
+            case TemporalCancelledError():
+                matched = "cancelled"
+            case _:
+                matched = "other"
+
+        assert matched == "activity"
+
+    def test_workflow_failure_error_cause_falls_through_to_catch_all_for_unrecognized_cause(
+        self,
+    ) -> None:
+        """A cause outside the re-exported family -- e.g.
+        temporalio.exceptions.ApplicationError, which is what surfaces when
+        run()/@entrypoint itself raises directly rather than an activity -- must
+        still be reachable via the documented `case _:` catch-all, not silently
+        dropped by a `match` with no fallback branch."""
+        from temporalio.exceptions import (
+            ApplicationError as _TemporalApplicationErrorImpl,
+        )
+
+        failure = TemporalWorkflowFailureError(
+            cause=_TemporalApplicationErrorImpl("boom")
+        )
+
+        match failure.cause:
+            case TemporalActivityError():
+                matched = "activity"
+            case TemporalCancelledError():
+                matched = "cancelled"
+            case _:
+                matched = "other"
+
+        assert matched == "other"
+
     def test_create_data_converter_for_app_is_exported(self) -> None:
         from application_sdk.execution._temporal.converter import (
             create_data_converter_for_app as _internal,

--- a/tests/unit/execution/test_converter.py
+++ b/tests/unit/execution/test_converter.py
@@ -3,10 +3,25 @@
 from __future__ import annotations
 
 from temporalio.client import Client as _TemporalClientImpl
+from temporalio.client import WorkflowFailureError as _TemporalWorkflowFailureErrorImpl
 from temporalio.converter import DataConverter
+from temporalio.exceptions import ActivityError as _TemporalActivityErrorImpl
+from temporalio.exceptions import CancelledError as _TemporalCancelledErrorImpl
+from temporalio.exceptions import ChildWorkflowError as _TemporalChildWorkflowErrorImpl
+from temporalio.exceptions import TerminatedError as _TemporalTerminatedErrorImpl
+from temporalio.exceptions import TimeoutError as _TemporalTimeoutErrorImpl
 
 from application_sdk.contracts.base import Input, Output
-from application_sdk.execution import TemporalClient, create_data_converter_for_app
+from application_sdk.execution import (
+    TemporalActivityError,
+    TemporalCancelledError,
+    TemporalChildWorkflowError,
+    TemporalClient,
+    TemporalTerminatedError,
+    TemporalTimeoutError,
+    TemporalWorkflowFailureError,
+    create_data_converter_for_app,
+)
 from application_sdk.execution._temporal.converter import create_data_converter
 
 
@@ -25,6 +40,24 @@ class TestPublicSurface:
 
     def test_temporal_client_is_exported(self) -> None:
         assert TemporalClient is _TemporalClientImpl
+
+    def test_temporal_workflow_failure_error_is_exported(self) -> None:
+        assert TemporalWorkflowFailureError is _TemporalWorkflowFailureErrorImpl
+
+    def test_temporal_activity_error_is_exported(self) -> None:
+        assert TemporalActivityError is _TemporalActivityErrorImpl
+
+    def test_temporal_cancelled_error_is_exported(self) -> None:
+        assert TemporalCancelledError is _TemporalCancelledErrorImpl
+
+    def test_temporal_child_workflow_error_is_exported(self) -> None:
+        assert TemporalChildWorkflowError is _TemporalChildWorkflowErrorImpl
+
+    def test_temporal_terminated_error_is_exported(self) -> None:
+        assert TemporalTerminatedError is _TemporalTerminatedErrorImpl
+
+    def test_temporal_timeout_error_is_exported(self) -> None:
+        assert TemporalTimeoutError is _TemporalTimeoutErrorImpl
 
     def test_create_data_converter_for_app_is_exported(self) -> None:
         from application_sdk.execution._temporal.converter import (

--- a/tests/unit/execution/test_converter.py
+++ b/tests/unit/execution/test_converter.py
@@ -59,6 +59,18 @@ class TestPublicSurface:
     def test_temporal_timeout_error_is_exported(self) -> None:
         assert TemporalTimeoutError is _TemporalTimeoutErrorImpl
 
+    def test_temporal_error_reexports_are_in_dunder_all(self) -> None:
+        from application_sdk import execution
+
+        assert {
+            "TemporalWorkflowFailureError",
+            "TemporalActivityError",
+            "TemporalCancelledError",
+            "TemporalChildWorkflowError",
+            "TemporalTerminatedError",
+            "TemporalTimeoutError",
+        } <= set(execution.__all__)
+
     def test_create_data_converter_for_app_is_exported(self) -> None:
         from application_sdk.execution._temporal.converter import (
             create_data_converter_for_app as _internal,

--- a/tests/unit/tools/test_capability_manifest_extractor.py
+++ b/tests/unit/tools/test_capability_manifest_extractor.py
@@ -1,0 +1,259 @@
+"""Tests for the external-alias runtime-introspection fallback in
+.claude/skills/capability-manifest/references/extractor.py.
+
+Griffe only loads the application_sdk package, so it can never resolve an alias
+pointing outside it (e.g. a re-exported temporalio class) -- extractor.py falls
+back to importlib/inspect for those. That fallback has no test coverage of its
+own elsewhere: it is exercised only by eyeballing the regenerated
+docs/agents/sdk-capabilities.md. These tests pin its behavior directly.
+
+extractor.py is a standalone script, not a package member, so it is loaded by
+file path (same pattern used for .github/scripts/*.py in
+.github/scripts/tests/).
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(
+    0,
+    str(
+        Path(__file__).resolve().parents[3]
+        / ".claude"
+        / "skills"
+        / "capability-manifest"
+        / "references"
+    ),
+)
+
+import extractor  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures used as re-export targets for _import_external_target /
+# _external_alias_symbol -- referenced by their real dotted module path, the
+# same way a re-exported temporalio symbol would be.
+# ---------------------------------------------------------------------------
+
+
+class _SampleClassWithArgs:
+    """A sample class with constructor args."""
+
+    def __init__(self, value: int, *, flag: bool = False) -> None:
+        self.value = value
+        self.flag = flag
+
+
+class _SampleZeroArgClass:
+    """A sample class with no constructor args."""
+
+    def __init__(self) -> None:
+        pass
+
+
+def _sample_function(x: int, y: int = 2) -> int:
+    """A sample function."""
+    return x + y
+
+
+def _sample_function_no_doc(x: int) -> int:
+    return x
+
+
+class _SampleConstant:
+    """A small sentinel object."""
+
+
+_SAMPLE_CONSTANT = _SampleConstant()
+
+
+def _dotted(obj: object) -> str:
+    return f"{obj.__module__}.{obj.__qualname__}"  # type: ignore[attr-defined]
+
+
+class _FakeGriffeAlias:
+    def __init__(
+        self,
+        is_alias: bool,
+        target_path: str | None = None,
+        raise_on_access: bool = False,
+    ) -> None:
+        self.is_alias = is_alias
+        self._target_path = target_path
+        self._raise_on_access = raise_on_access
+
+    @property
+    def target_path(self) -> str | None:
+        if self._raise_on_access:
+            raise RuntimeError("simulated AliasResolutionError")
+        return self._target_path
+
+
+# ---------------------------------------------------------------------------
+# _external_alias_target
+# ---------------------------------------------------------------------------
+
+
+def test_external_alias_target_none_when_not_alias() -> None:
+    assert extractor._external_alias_target(_FakeGriffeAlias(is_alias=False)) is None
+
+
+def test_external_alias_target_none_when_is_alias_attr_missing() -> None:
+    class Bare:
+        pass
+
+    assert extractor._external_alias_target(Bare()) is None
+
+
+def test_external_alias_target_none_for_internal_target() -> None:
+    obj = _FakeGriffeAlias(
+        is_alias=True, target_path="application_sdk.execution.TemporalClient"
+    )
+    assert extractor._external_alias_target(obj) is None
+
+
+def test_external_alias_target_none_for_empty_target_path() -> None:
+    assert (
+        extractor._external_alias_target(
+            _FakeGriffeAlias(is_alias=True, target_path="")
+        )
+        is None
+    )
+
+
+def test_external_alias_target_none_on_resolution_error() -> None:
+    obj = _FakeGriffeAlias(is_alias=True, raise_on_access=True)
+    assert extractor._external_alias_target(obj) is None
+
+
+def test_external_alias_target_returns_path_for_external_alias() -> None:
+    obj = _FakeGriffeAlias(is_alias=True, target_path="temporalio.client.Client")
+    assert extractor._external_alias_target(obj) == "temporalio.client.Client"
+
+
+# ---------------------------------------------------------------------------
+# _import_external_target
+# ---------------------------------------------------------------------------
+
+
+def test_import_external_target_resolves_class() -> None:
+    assert (
+        extractor._import_external_target(_dotted(_SampleClassWithArgs))
+        is _SampleClassWithArgs
+    )
+
+
+def test_import_external_target_resolves_function() -> None:
+    assert (
+        extractor._import_external_target(_dotted(_sample_function)) is _sample_function
+    )
+
+
+def test_import_external_target_none_for_unimportable_module() -> None:
+    assert extractor._import_external_target("nonexistent_pkg_xyz.Something") is None
+
+
+def test_import_external_target_none_for_missing_attribute() -> None:
+    assert extractor._import_external_target(f"{__name__}.NoSuchAttribute") is None
+
+
+# ---------------------------------------------------------------------------
+# _truncate_signature
+# ---------------------------------------------------------------------------
+
+
+def test_truncate_signature_returns_short_signature_unchanged() -> None:
+    full = "def foo(x: int) -> int"
+    assert extractor._truncate_signature(full, "def foo", "(x: int)") == full
+
+
+def test_truncate_signature_truncates_long_signature_to_first_arg() -> None:
+    args = "(a: int, b: str, c: float)"
+    full = "prefix" + args + " # " + "x" * 100  # force well over the 120-char threshold
+    assert len(full) > 120
+    assert extractor._truncate_signature(full, "prefix", args) == "prefix(a: int, ...)"
+
+
+def test_truncate_signature_truncates_on_embedded_memory_address_even_if_short() -> (
+    None
+):
+    args = "(count: int, obj=<Baz object at 0x7f0000000000>)"
+    full = "prefix" + args
+    assert len(full) <= 120
+    assert (
+        extractor._truncate_signature(full, "prefix", args) == "prefix(count: int, ...)"
+    )
+
+
+def test_truncate_signature_falls_back_to_ellipsis_when_first_arg_has_address() -> None:
+    args = "(obj=<Baz object at 0x7f0000000000>)"
+    full = "prefix" + args
+    assert extractor._truncate_signature(full, "prefix", args) == "prefix(...)"
+
+
+def test_truncate_signature_falls_back_to_ellipsis_when_no_args() -> None:
+    full = "prefix() # " + "x" * 150  # force well over the 120-char threshold
+    assert len(full) > 120
+    assert extractor._truncate_signature(full, "prefix", "()") == "prefix(...)"
+
+
+# ---------------------------------------------------------------------------
+# _external_alias_symbol
+# ---------------------------------------------------------------------------
+
+
+def test_external_alias_symbol_class_with_args() -> None:
+    path = _dotted(_SampleClassWithArgs)
+    result = extractor._external_alias_symbol("AliasedClassName", path)
+    assert result == {
+        "name": "AliasedClassName",
+        "kind": extractor.KIND_CLASS,
+        "signature": "class AliasedClassName(value: int, *, flag: bool = False)",
+        "summary": f"A sample class with constructor args. _(re-exported from `{path}`)_",
+        "filepath": "",
+    }
+
+
+def test_external_alias_symbol_zero_arg_class() -> None:
+    path = _dotted(_SampleZeroArgClass)
+    result = extractor._external_alias_symbol("AliasedZeroArg", path)
+    assert result is not None
+    assert result["kind"] == extractor.KIND_CLASS
+    assert result["signature"] == "class AliasedZeroArg()"
+
+
+def test_external_alias_symbol_function() -> None:
+    path = _dotted(_sample_function)
+    result = extractor._external_alias_symbol("aliased_fn", path)
+    assert result == {
+        "name": "aliased_fn",
+        "kind": extractor.KIND_FUNCTION,
+        "signature": "aliased_fn(x: int, y: int = 2) -> int",
+        "summary": f"A sample function. _(re-exported from `{path}`)_",
+        "filepath": "",
+    }
+
+
+def test_external_alias_symbol_missing_docstring() -> None:
+    path = _dotted(_sample_function_no_doc)
+    result = extractor._external_alias_symbol("aliased_no_doc", path)
+    assert result is not None
+    assert result["summary"] == f"_(re-exported from `{path}`, no docstring)_"
+
+
+def test_external_alias_symbol_constant() -> None:
+    path = f"{__name__}._SAMPLE_CONSTANT"
+    result = extractor._external_alias_symbol("AliasedConstant", path)
+    assert result == {
+        "name": "AliasedConstant",
+        "kind": extractor.KIND_CONSTANT,
+        "signature": "AliasedConstant",
+        "summary": f"A small sentinel object. _(re-exported from `{path}`)_",
+        "filepath": "",
+    }
+
+
+def test_external_alias_symbol_none_when_target_unimportable() -> None:
+    assert (
+        extractor._external_alias_symbol("Ghost", "nonexistent_pkg_xyz.Something")
+        is None
+    )

--- a/tests/unit/tools/test_capability_manifest_extractor.py
+++ b/tests/unit/tools/test_capability_manifest_extractor.py
@@ -12,8 +12,10 @@ file path (same pattern used for .github/scripts/*.py in
 .github/scripts/tests/).
 """
 
+import inspect
 import sys
 from pathlib import Path
+from typing import Any, Dict
 
 sys.path.insert(
     0,
@@ -50,6 +52,24 @@ class _SampleZeroArgClass:
         pass
 
 
+class _SampleClassWithNoCustomInit:
+    """A sample class that doesn't define its own __init__ at all."""
+
+
+class _SampleClassWithGenericFirstArg:
+    """A sample class whose first constructor arg has a comma inside its annotation."""
+
+    def __init__(
+        self,
+        config: Dict[str, Any],
+        timeout_seconds: float = 1.0,
+        retries: int = 3,
+        label: str = "default",
+        extra_flag: bool = False,
+    ) -> None:
+        self.config = config
+
+
 def _sample_function(x: int, y: int = 2) -> int:
     """A sample function."""
     return x + y
@@ -76,10 +96,14 @@ class _FakeGriffeAlias:
         is_alias: bool,
         target_path: str | None = None,
         raise_on_access: bool = False,
+        kind: str = "ATTRIBUTE",
     ) -> None:
         self.is_alias = is_alias
         self._target_path = target_path
         self._raise_on_access = raise_on_access
+        # Only consulted by the griffe-based fallback path (_resolve_actual_obj /
+        # _classify_symbol) when an alias's target turns out to be unimportable.
+        self.kind = kind
 
     @property
     def target_path(self) -> str | None:
@@ -158,42 +182,94 @@ def test_import_external_target_none_for_missing_attribute() -> None:
 
 # ---------------------------------------------------------------------------
 # _truncate_signature
+#
+# Takes a real inspect.Signature (not a pre-rendered string) so the first
+# parameter can be pulled out structurally instead of by splitting on the
+# first comma -- a generic annotation like Dict[str, Any] has a comma inside
+# it, which a naive string split cuts in half (see the two regression tests
+# in the _external_alias_symbol section below for that failure mode fixed).
 # ---------------------------------------------------------------------------
 
 
+def _sig_of(fn: object) -> inspect.Signature:
+    return inspect.signature(fn)  # type: ignore[arg-type]
+
+
 def test_truncate_signature_returns_short_signature_unchanged() -> None:
+    def foo(x: int) -> None: ...
+
     full = "def foo(x: int) -> int"
-    assert extractor._truncate_signature(full, "def foo", "(x: int)") == full
+    assert extractor._truncate_signature(full, "def foo", _sig_of(foo)) == full
+
+
+def test_truncate_signature_ignores_sig_when_full_is_already_short() -> None:
+    # The short-circuit only looks at `full`'s length/content -- a mismatched or
+    # missing `sig` must not matter when no truncation is needed.
+    full = "def foo(x: int) -> int"
+    assert extractor._truncate_signature(full, "def foo", None) == full
 
 
 def test_truncate_signature_truncates_long_signature_to_first_arg() -> None:
-    args = "(a: int, b: str, c: float)"
-    full = "prefix" + args + " # " + "x" * 100  # force well over the 120-char threshold
+    def fn(a: int, b: str, c: float) -> None: ...
+
+    sig = _sig_of(fn)
+    full = "prefix" + str(sig) + " # " + "x" * 100  # force well over 120 chars
     assert len(full) > 120
-    assert extractor._truncate_signature(full, "prefix", args) == "prefix(a: int, ...)"
+    assert extractor._truncate_signature(full, "prefix", sig) == "prefix(a: int, ...)"
+
+
+def test_truncate_signature_preserves_comma_bearing_generic_first_arg() -> None:
+    """Regression: a naive split(",")[0] on the rendered string would cut
+    `Dict[str, Any]` in half, producing an unbalanced-bracket signature."""
+
+    def fn(config: Dict[str, Any], b: str, c: float, d: int) -> None: ...
+
+    sig = _sig_of(fn)
+    full = "prefix" + str(sig) + " # " + "x" * 100  # force well over 120 chars
+    assert len(full) > 120
+    assert (
+        extractor._truncate_signature(full, "prefix", sig)
+        == "prefix(config: Dict[str, Any], ...)"
+    )
 
 
 def test_truncate_signature_truncates_on_embedded_memory_address_even_if_short() -> (
     None
 ):
-    args = "(count: int, obj=<Baz object at 0x7f0000000000>)"
-    full = "prefix" + args
-    assert len(full) <= 120
+    sentinel = object()  # repr is "<object object at 0x...>" -- a real live address
+
+    def fn(count: int, obj: object = sentinel) -> None: ...
+
+    sig = _sig_of(fn)
+    full = "prefix" + str(sig)
+    assert extractor._MEMORY_ADDRESS_RE.search(full)
     assert (
-        extractor._truncate_signature(full, "prefix", args) == "prefix(count: int, ...)"
+        extractor._truncate_signature(full, "prefix", sig) == "prefix(count: int, ...)"
     )
 
 
 def test_truncate_signature_falls_back_to_ellipsis_when_first_arg_has_address() -> None:
-    args = "(obj=<Baz object at 0x7f0000000000>)"
-    full = "prefix" + args
-    assert extractor._truncate_signature(full, "prefix", args) == "prefix(...)"
+    sentinel = object()
+
+    def fn(obj: object = sentinel) -> None: ...
+
+    sig = _sig_of(fn)
+    full = "prefix" + str(sig)
+    assert extractor._truncate_signature(full, "prefix", sig) == "prefix(...)"
 
 
 def test_truncate_signature_falls_back_to_ellipsis_when_no_args() -> None:
+    def fn() -> None: ...
+
+    sig = _sig_of(fn)
     full = "prefix() # " + "x" * 150  # force well over the 120-char threshold
     assert len(full) > 120
-    assert extractor._truncate_signature(full, "prefix", "()") == "prefix(...)"
+    assert extractor._truncate_signature(full, "prefix", sig) == "prefix(...)"
+
+
+def test_truncate_signature_falls_back_to_ellipsis_when_sig_is_none() -> None:
+    full = "prefix() # " + "x" * 150
+    assert extractor._truncate_signature(full, "prefix", None) == "prefix(...)"
 
 
 # ---------------------------------------------------------------------------
@@ -219,6 +295,30 @@ def test_external_alias_symbol_zero_arg_class() -> None:
     assert result is not None
     assert result["kind"] == extractor.KIND_CLASS
     assert result["signature"] == "class AliasedZeroArg()"
+
+
+def test_external_alias_symbol_class_with_no_custom_init() -> None:
+    """Regression: manually stripping a hardcoded "(self, "/"(self)" prefix off
+    obj.__init__'s signature mis-rendered any class with no custom __init__ (it
+    inherits object.__init__'s "(self, /, *args, **kwargs)" slot-wrapper signature,
+    which doesn't match either hardcoded prefix) as "(/, *args, **kwargs)". Calling
+    inspect.signature() on the class itself avoids the issue entirely."""
+    path = _dotted(_SampleClassWithNoCustomInit)
+    result = extractor._external_alias_symbol("AliasedNoInit", path)
+    assert result is not None
+    assert result["kind"] == extractor.KIND_CLASS
+    assert result["signature"] == "class AliasedNoInit()"
+
+
+def test_external_alias_symbol_class_with_generic_first_arg() -> None:
+    """Regression: a first arg annotated Dict[str, Any] has a comma inside the
+    annotation itself -- naive string-splitting on the first comma used to render
+    this as the unbalanced "AliasedGeneric(config: Dict[str, ...)"."""
+    path = _dotted(_SampleClassWithGenericFirstArg)
+    result = extractor._external_alias_symbol("AliasedGeneric", path)
+    assert result is not None
+    assert result["kind"] == extractor.KIND_CLASS
+    assert result["signature"] == "class AliasedGeneric(config: Dict[str, Any], ...)"
 
 
 def test_external_alias_symbol_function() -> None:
@@ -257,3 +357,43 @@ def test_external_alias_symbol_none_when_target_unimportable() -> None:
         extractor._external_alias_symbol("Ghost", "nonexistent_pkg_xyz.Something")
         is None
     )
+
+
+# ---------------------------------------------------------------------------
+# _symbol_for -- the per-symbol branch cmd_dump() delegates to. Exercises the
+# two branches this PR adds: taking the external-alias fast path, and falling
+# back to the pre-existing griffe-based path when the alias target can't be
+# imported (e.g. an optional dependency isn't installed).
+# ---------------------------------------------------------------------------
+
+
+def test_symbol_for_uses_external_alias_fast_path_when_importable() -> None:
+    path = _dotted(_sample_function)
+    griffe_obj = _FakeGriffeAlias(is_alias=True, target_path=path)
+    assert extractor._symbol_for(
+        "aliased_fn", griffe_obj
+    ) == extractor._external_alias_symbol("aliased_fn", path)
+
+
+def test_symbol_for_falls_back_to_griffe_path_when_alias_unimportable() -> None:
+    # is_alias=True + an unimportable target_path takes _external_alias_symbol's
+    # None branch, which must fall through to the griffe-based path (kind=
+    # "ATTRIBUTE" here) rather than raise or silently drop the symbol.
+    griffe_obj = _FakeGriffeAlias(
+        is_alias=True, target_path="nonexistent_pkg_xyz.Something", kind="ATTRIBUTE"
+    )
+    result = extractor._symbol_for("ghost_symbol", griffe_obj)
+    assert result == {
+        "name": "ghost_symbol",
+        "kind": extractor.KIND_CONSTANT,
+        "signature": "ghost_symbol",
+        "summary": "_(no docstring)_",
+        "filepath": "",
+    }
+
+
+def test_symbol_for_uses_griffe_path_directly_when_not_an_alias() -> None:
+    griffe_obj = _FakeGriffeAlias(is_alias=False, kind="ATTRIBUTE")
+    result = extractor._symbol_for("plain_symbol", griffe_obj)
+    assert result["name"] == "plain_symbol"
+    assert result["kind"] == extractor.KIND_CONSTANT


### PR DESCRIPTION
## Summary
- Re-export the client-side Temporal failure/cause exception family from `application_sdk.execution`:
  - `TemporalWorkflowFailureError` (`temporalio.client.WorkflowFailureError`) — raised by `execute_workflow(...)` when a workflow fails.
  - `TemporalActivityError` (`temporalio.exceptions.ActivityError`) — wraps the underlying activity failure.
  - `TemporalCancelledError`, `TemporalTimeoutError`, `TemporalTerminatedError`, `TemporalChildWorkflowError` (`temporalio.exceptions.*`) — the remaining terminal-state causes that can appear behind `WorkflowFailureError.cause` / `ActivityError.cause`.
- Closes the public-seam gap identified during conformance review: consumer app tests asserting on client-side workflow/activity failures had no supported way to do so without importing `temporalio` directly, triggering P004 (`DirectTemporalImport`).
- Names are prefixed with `Temporal` (matching the existing `TemporalClient` re-export) to avoid colliding with unrelated SDK types of the same short name — `application_sdk.common.error_codes.ActivityError`, `application_sdk.errors.leaves.CancelledError`, `application_sdk.errors.leaves.AppTimeoutError`.
- Fixed a capability-manifest generation gap surfaced while documenting these: griffe only loads `application_sdk`, so any re-export of an external symbol (these new ones, plus the pre-existing `TemporalClient`) rendered as `_(no docstring)_` because griffe's alias resolution raised on a target it never loaded. The extractor now falls back to runtime introspection (`importlib`/`inspect`) for such aliases, with truncation and a memory-address guard so the generated doc stays deterministic.
- Regenerated `docs/agents/sdk-capabilities.md` to reflect both the new exports and the docstring fix (all 7 external re-exports in `application_sdk.execution` now show their real docstring/signature and are correctly classified as classes instead of functions).

## Test plan
- [x] `uv run pre-commit run --all-files`
- [x] `uv run python -m pytest tests/unit -x -q` (5313 passed, 9 skipped)
- [x] Manually verified each new re-export is identity-equal (`is`) to its underlying `temporalio` type
- [x] `uv run poe regen-capabilities` — manifest content matches current source, idempotent re-render (ran twice, byte-identical)
- [x] Verified no memory addresses or other non-deterministic content leaked into the regenerated manifest
- [ ] Follow-up (out of scope here): update consumer apps (e.g. `atlan-model-caster-app`) to import from `application_sdk.execution` instead of `temporalio` directly