### PR TITLE
ci(sdr-e2e): give daprd up to 300s to be ready on cold CI runners

### DIFF
--- a/.github/actions/sdr-e2e/docker-compose.ci.yml
+++ b/.github/actions/sdr-e2e/docker-compose.ci.yml
@@ -38,6 +38,15 @@ services:
       # Disable observability upload — the CI atlan-objectstore S3 config
       # is not set up for external access and will crash the container on startup.
       - ATLAN_ENABLE_OBSERVABILITY_DAPR_SINK=false
+      # Wait out slow CI cold-starts before proceeding. On fresh runners daprd's
+      # component init has been observed at ~75s (and 25s on faster ones); the
+      # SDK's 60s default readiness gate then "proceeds anyway" and the first
+      # Dapr call (agent secret-bundle fetch during preflight) races the not-yet-
+      # ready sidecar → "ConnectError: All connection attempts failed" and a
+      # flaky e2e failure (seen on openapi). This is a give-up ceiling only — the
+      # gate returns the instant daprd reports ready, so a healthy ~75s start
+      # still returns at ~75s; 300s just guarantees we never race it in CI.
+      - ATLAN_DAPR_SIDECAR_WAIT_TIMEOUT=300
       # Bridge: configurator → main.py (TLS)
       - ATLAN_TEMPORAL_TLS_ENABLED=true
       # Bridge: ATLAN_BASE_URL → production SDK names


### PR DESCRIPTION
## What
Sets `ATLAN_DAPR_SIDECAR_WAIT_TIMEOUT=300` on the `atlan-app` container in the `sdr-e2e` CI compose overlay.

## Why
Even after #2467 raised the SDK readiness gate 10s→60s, connector e2e (notably **openapi**) still flakes on fresh CI runners where **daprd component init takes ~75s** (observed 74.8s / 76.6s across runs). The 60s gate then *"proceeds anyway"*, and the first Dapr call — the agent secret-bundle fetch during preflight — races the not-yet-ready sidecar:

```
[WARNING] _dapr.http - Dapr sidecar not ready after 60s — proceeding anyway
dapr initialized … Init Elapsed 76632ms
→ AssertionError: Full-DAG e2e failed for connector=openapi
```

## Why 300s (and why it's free)
`wait_for_dapr_sidecar` returns the **instant** daprd reports ready — the timeout is only a *give-up ceiling*, not a fixed sleep. So a healthy ~75s start still returns at ~75s regardless of the cap; a larger cap only widens the safety margin at **zero cost** to normal runs. Observed max is ~76.6s → 300s is ~4× headroom. Scoped to CI (this compose overlay); the SDK's prod default (60s, env-overridable) is unchanged.

## Impact
CI-config only (no Python, no prod behavior change). Unblocks the openapi connector-e2e flake on SDK PRs (e.g. #2432).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
