### PR TITLE
ci(sdr-e2e): revert the 300s dapr readiness gate (#2520) — it blocks :8000 bind past the 120s e2e health check

### DIFF
--- a/.github/actions/sdr-e2e/docker-compose.ci.yml
+++ b/.github/actions/sdr-e2e/docker-compose.ci.yml
@@ -38,15 +38,6 @@ services:
       # Disable observability upload — the CI atlan-objectstore S3 config
       # is not set up for external access and will crash the container on startup.
       - ATLAN_ENABLE_OBSERVABILITY_DAPR_SINK=false
-      # Wait out slow CI cold-starts before proceeding. On fresh runners daprd's
-      # component init has been observed at ~75s (and 25s on faster ones); the
-      # SDK's 60s default readiness gate then "proceeds anyway" and the first
-      # Dapr call (agent secret-bundle fetch during preflight) races the not-yet-
-      # ready sidecar → "ConnectError: All connection attempts failed" and a
-      # flaky e2e failure (seen on openapi). This is a give-up ceiling only — the
-      # gate returns the instant daprd reports ready, so a healthy ~75s start
-      # still returns at ~75s; 300s just guarantees we never race it in CI.
-      - ATLAN_DAPR_SIDECAR_WAIT_TIMEOUT=300
       # Bridge: configurator → main.py (TLS)
       - ATLAN_TEMPORAL_TLS_ENABLED=true
       # Bridge: ATLAN_BASE_URL → production SDK names


### PR DESCRIPTION
## Revert #2520

**#2520 regressed all connector e2e.** It set `ATLAN_DAPR_SIDECAR_WAIT_TIMEOUT=300` for the sdr-e2e app container to give daprd more time — but the app awaits `wait_for_dapr_sidecar()` (in `_create_infrastructure`) **before** uvicorn binds `:8000`, and daprd doesn't report ready until the app is on `:8000`. On runs where daprd's readiness waits on the app, the 300s gate makes the app sit in the dapr wait far past the harness's **120s `container-health-timeout`** → the app never serves `:8000` in time → **metabase / mysql / openapi all fail at the container health check** (`OUTCOME: skipped`, daprd logging *"waiting for application to listen on port 8000"* the whole window).

Evidence (metabase, post-#2520): health check `timeout=120s` → skipped; daprd never initialized; the only startup-timing change vs the prior green run is #2520's 300s gate.

## What this restores
Back to the 60s gate (from #2467): the app proceeds within the 120s health window, so **metabase/mysql pass** and **openapi** returns to an edge-timing flake (daprd ready ~76s vs app proceeding at 60s).

## The real openapi fix (follow-up, not a timeout bump)
The gate can't be raised without breaking startup, because it blocks `:8000`. The proper fix is a **startup-ordering** change — bind `:8000` before/independently of the dapr wait (so daprd can discover the app and finish init), or make the workflow's first Dapr calls ride out daprd init — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
