### PR TITLE
ci(e2e): bump container-health-timeout-seconds to 300s

### DIFF
--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -198,8 +198,12 @@ jobs:
           compose-overlay: ${{ inputs.compose-overlay }}
           # Bump the container-health wait because the worker has to
           # establish the Temporal connection with TLS + auth before
-          # /server/health turns green.
-          container-health-timeout-seconds: "120"
+          # /server/health turns green. Matches ATLAN_DAPR_SIDECAR_WAIT_TIMEOUT
+          # in .github/actions/sdr-e2e/docker-compose.ci.yml — the app can wait
+          # up to that long on a cold daprd sidecar before it ever starts
+          # serving /server/health, so this outer gate must be >= it or a slow
+          # (but healthy) cold start trips this timeout first.
+          container-health-timeout-seconds: "300"
           # `-s` streams the harness's poll-loop output in real time so
           # operators can watch the colour-emoji DAG progression
           # instead of waiting for a final dump.


### PR DESCRIPTION
## Summary
- `container-health-timeout-seconds` in `.github/workflows/e2e-full-reusable.yaml` was still hardcoded at `120`, while #2520 (same-day) raised `ATLAN_DAPR_SIDECAR_WAIT_TIMEOUT` to `300` in `.github/actions/sdr-e2e/docker-compose.ci.yml` to tolerate slow daprd cold starts.
- The app can now legitimately wait up to 300s on the Dapr sidecar before it ever starts serving `/server/health`, so the outer wait must be at least as long or a slow-but-healthy cold start trips this timeout first and fails the job with `SDR container failed to start within 120s`.
- Bumps the outer gate to `300` to match, and documents the coupling in a comment so the two don't drift again.

Observed as the root cause of all three `Connector Tests` jobs (metabase, mysql, openapi) failing on a downstream PR with this exact symptom.

## Test plan
- [ ] `Connector Tests` / `SDR K8s E2E` checks pass on this PR
- [ ] No regression in wall-clock time on healthy (non-cold) runners — gate returns as soon as the sidecar reports ready, so this only changes the ceiling