### PR TITLE
ci(e2e): replace cross-repo e2e busy-poll with a check-run callback

### DIFF
--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -63,7 +63,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Only callback mode needs the repo on disk (it runs .github/scripts/*.py
+    # directly). Poll mode's steps (codex-/return-dispatch, curl, gh api,
+    # github-script) never touch local files, and the calling job has
+    # already checked out the repo before invoking this local composite
+    # action anyway — so this would be a pure no-op there.
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      if: inputs.wait-mode == 'callback'
       with:
         ref: ${{ github.ref }}
 

--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -39,6 +39,26 @@ inputs:
       SDR path to forward application_sdk_ref so the connector can pin
       atlan-application-sdk to the apps-sdk PR's head SHA. Defaults to
       an empty object so codex-/return-dispatch always sees valid JSON.
+  wait-mode:
+    required: false
+    default: poll
+    description: |
+      'poll' (default, legacy): dispatch, then busy-poll the dispatched
+      run's status via the REST API every 60s for up to 2h, all against
+      the shared org PAT. 'callback': create an in_progress GitHub check
+      run on this repo's own SHA (github-token's own rate-limit bucket),
+      dispatch, and exit immediately — the connector's own workflow
+      completes the check run directly when it finishes (see
+      tests-reusable.yaml's report-to-sdk job), so there is no polling
+      and no wait at all on this side. Requires check-run-name + check-sha.
+  check-run-name:
+    required: false
+    default: ""
+    description: Required when wait-mode is 'callback'. Name of the check run to create, e.g. "Connector E2E / atlan-mysql-app".
+  check-sha:
+    required: false
+    default: ""
+    description: Required when wait-mode is 'callback'. SHA on this repo to attach the check run to (the PR head or merge-queue SHA).
 
 runs:
   using: "composite"
@@ -48,6 +68,7 @@ runs:
         ref: ${{ github.ref }}
 
     - name: Get the application-sdk commit SHA
+      if: inputs.wait-mode != 'callback'
       shell: bash
       run: |
         if [ "${{ github.event.pull_request.head.sha }}" ]; then
@@ -62,7 +83,55 @@ runs:
           echo "base_branch=${{ github.ref }}" >> $GITHUB_ENV
         fi
 
+    # ── callback mode: create the check, dispatch, exit — no polling ──────
+    - name: Validate callback-mode inputs
+      if: inputs.wait-mode == 'callback'
+      shell: bash
+      env:
+        CHECK_RUN_NAME: ${{ inputs.check-run-name }}
+        CHECK_SHA: ${{ inputs.check-sha }}
+      run: |
+        if [ -z "$CHECK_RUN_NAME" ] || [ -z "$CHECK_SHA" ]; then
+          echo "::error::wait-mode=callback requires both check-run-name and check-sha"
+          exit 1
+        fi
+
+    - name: Create pending check run
+      if: inputs.wait-mode == 'callback'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.check-sha }}
+        NAME: ${{ inputs.check-run-name }}
+        REPO_NAME: ${{ inputs.repo-name }}
+      run: |
+        python3 .github/scripts/create_check_run.py \
+          --repo "$REPO" \
+          --sha "$SHA" \
+          --name "$NAME" \
+          --details-url "https://github.com/atlanhq/${REPO_NAME}/actions" \
+          --summary "Dispatched to ${REPO_NAME}; awaiting results — this check completes when that run finishes."
+
+    - name: Dispatch connector workflow
+      if: inputs.wait-mode == 'callback'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO_NAME: ${{ inputs.repo-name }}
+        WORKFLOW: ${{ inputs.workflow }}
+        TARGET_BRANCH: ${{ inputs.target-branch }}
+        WORKFLOW_INPUTS: ${{ inputs.workflow-inputs }}
+      run: |
+        python3 .github/scripts/dispatch_workflow.py \
+          --repo "atlanhq/${REPO_NAME}" \
+          --workflow "$WORKFLOW" \
+          --ref "$TARGET_BRANCH" \
+          --inputs "$WORKFLOW_INPUTS"
+
+    # ── poll mode (legacy): dispatch, busy-poll, fetch artifact, comment ──
     - name: Trigger E2E Integrations Tests
+      if: inputs.wait-mode != 'callback'
       uses: codex-/return-dispatch@16fa9d14771c4d56ae0196bbda1d3c17f7f3650f # v3
       id: return_dispatch
       with:
@@ -81,12 +150,14 @@ runs:
         workflow_inputs: ${{ inputs.workflow-inputs }}
 
     - name: Check the test logs using the below run URL
+      if: inputs.wait-mode != 'callback'
       shell: bash
       run: |
         echo ${{steps.return_dispatch.outputs.run_id}}
         echo ${{steps.return_dispatch.outputs.run_url}}
 
     - name: Check Workflow Status
+      if: inputs.wait-mode != 'callback'
       id: status
       shell: bash
       run: |
@@ -165,7 +236,7 @@ runs:
     # (dispatch failed, run cancelled before tests, etc.).
     - name: Fetch dispatched-run report body
       id: dispatched_summary
-      if: always() && steps.return_dispatch.outputs.run_id != ''
+      if: always() && inputs.wait-mode != 'callback' && steps.return_dispatch.outputs.run_id != ''
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
@@ -196,7 +267,7 @@ runs:
     # connector run. Uses updateComment in-place when a prior marker
     # exists so re-pushes don't spam the PR thread.
     - name: Post dispatched-run status to SDK PR
-      if: always() && github.event_name == 'pull_request'
+      if: always() && inputs.wait-mode != 'callback' && github.event_name == 'pull_request'
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
       env:
         REPO_NAME: ${{ inputs.repo-name }}
@@ -301,8 +372,11 @@ runs:
 
     # Re-emit the failure exit code AFTER the comment lands, so the job
     # still fails the PR check but the reviewer sees a comment either way.
+    # Only applies to poll mode: in callback mode this job's own success
+    # means "dispatched OK" — the actual pass/fail comes later via the
+    # check run the connector completes directly (report-to-sdk).
     - name: Fail job if dispatched run did not succeed
-      if: always()
+      if: always() && inputs.wait-mode != 'callback'
       shell: bash
       env:
         DISPATCHED_CONCLUSION: ${{ steps.status.outputs.conclusion }}

--- a/.github/scripts/build_callback_summary.py
+++ b/.github/scripts/build_callback_summary.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Determine the check-run conclusion + summary body for the cross-repo e2e
+callback (tests-reusable.yaml's report-to-sdk job).
+
+Moved out of an inlined `run:` block per docs/standards/ci.md: deciding the
+conclusion and picking which summary file to use are both branches, which
+belong in a tested driver rather than workflow YAML.
+
+Prefers the e2e leg's already-rendered report (asset/lineage tables etc.,
+written by sdr-e2e's PR-comment step) over a plain fallback, which only
+applies when e2e was skipped or its artifact never materialised.
+
+Writes conclusion=<success|failure> and summary_file=<path> to $GITHUB_OUTPUT.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+PASSING_E2E_RESULTS = {"success", "skipped"}
+
+
+def determine_conclusion(tests_result: str, e2e_result: str) -> str:
+    if tests_result == "success" and e2e_result in PASSING_E2E_RESULTS:
+        return "success"
+    return "failure"
+
+
+def build_fallback_summary(
+    tests_result: str, e2e_result: str, tests_summary: str
+) -> str:
+    return (
+        "## Tests Summary\n\n"
+        f"**tests:** {tests_result} ({tests_summary or 'no summary'})\n"
+        f"**e2e:** {e2e_result}\n"
+    )
+
+
+def resolve_summary_file(
+    artifact_summary_path: str,
+    fallback_path: str,
+    tests_result: str,
+    e2e_result: str,
+    tests_summary: str,
+) -> str:
+    if os.path.isfile(artifact_summary_path):
+        return artifact_summary_path
+    with open(fallback_path, "w", encoding="utf-8") as fh:
+        fh.write(build_fallback_summary(tests_result, e2e_result, tests_summary))
+    return fallback_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tests-result", required=True)
+    parser.add_argument("--e2e-result", required=True)
+    parser.add_argument("--tests-summary", default="")
+    parser.add_argument(
+        "--artifact-summary-path", default="connector-results/pr-comment-body.md"
+    )
+    parser.add_argument("--fallback-path", default="fallback-summary.md")
+    args = parser.parse_args(argv)
+
+    conclusion = determine_conclusion(args.tests_result, args.e2e_result)
+    summary_file = resolve_summary_file(
+        args.artifact_summary_path,
+        args.fallback_path,
+        args.tests_result,
+        args.e2e_result,
+        args.tests_summary,
+    )
+
+    lines = [f"conclusion={conclusion}", f"summary_file={summary_file}"]
+    github_output = os.environ.get("GITHUB_OUTPUT", "")
+    if github_output:
+        with open(github_output, "a") as fh:
+            fh.write("\n".join(lines) + "\n")
+    else:
+        for line in lines:
+            print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/complete_check_run.py
+++ b/.github/scripts/complete_check_run.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Complete a GitHub check run by name — the callback side of the cross-repo
+e2e callback pattern.
+
+Called from the *connector* repo's own workflow run (``tests-reusable.yaml``'s
+``report-to-sdk`` job), authenticated with the org PAT, at the very end of the
+run (``if: always()``). It finds the check run that ``create_check_run.py``
+created on application-sdk's PR SHA and PATCHes it to ``completed`` with the
+real conclusion and the rendered report as output. This is the push: the
+SDK-side check flips the instant this script runs, with no polling on either
+side.
+
+Falls back to creating the check run directly (as already-completed) if none
+is found — covers a manual/legacy dispatch that skipped the create step.
+
+Summary text is read from --summary-file when given (the connector's already-
+rendered pr-comment-body.md), else --summary. Truncated defensively: the
+Checks API output.summary field has a 65535-character limit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+MAX_SUMMARY_CHARS = 60_000
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Single seam so tests can stub the `gh` CLI."""
+    return subprocess.run(cmd, **kwargs)
+
+
+def list_check_runs(repo: str, sha: str) -> list[dict]:
+    result = run(
+        ["gh", "api", f"repos/{repo}/commits/{sha}/check-runs?per_page=100"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"::error::failed to list check runs for {repo}@{sha}: {result.stderr}"
+        )
+    return json.loads(result.stdout).get("check_runs", [])
+
+
+def find_check_run(check_runs: list[dict], name: str) -> dict | None:
+    matches = [c for c in check_runs if c.get("name") == name]
+    if not matches:
+        return None
+    # Most recently created wins, in case a retry left more than one.
+    return max(matches, key=lambda c: c.get("id", 0))
+
+
+def truncate_summary(summary: str) -> str:
+    if len(summary) <= MAX_SUMMARY_CHARS:
+        return summary
+    return summary[:MAX_SUMMARY_CHARS] + "\n\n… (truncated)"
+
+
+def complete_check_run(
+    repo: str,
+    sha: str,
+    name: str,
+    conclusion: str,
+    summary: str,
+    *,
+    title: str | None = None,
+    details_url: str | None = None,
+) -> None:
+    existing = find_check_run(list_check_runs(repo, sha), name)
+    payload = {
+        "name": name,
+        "head_sha": sha,
+        "status": "completed",
+        "completed_at": now_iso(),
+        "conclusion": conclusion,
+        "output": {"title": title or name, "summary": truncate_summary(summary)},
+    }
+    if details_url:
+        payload["details_url"] = details_url
+
+    if existing:
+        cmd = [
+            "gh",
+            "api",
+            "--method",
+            "PATCH",
+            f"repos/{repo}/check-runs/{existing['id']}",
+            "--input",
+            "-",
+        ]
+        target = f"check run id={existing['id']}"
+    else:
+        cmd = [
+            "gh",
+            "api",
+            "--method",
+            "POST",
+            f"repos/{repo}/check-runs",
+            "--input",
+            "-",
+        ]
+        target = "new check run (no matching in-progress run found)"
+
+    result = run(
+        cmd, input=json.dumps(payload), capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"::error::failed to complete {target} on {repo}@{sha}: {result.stderr}"
+        )
+    print(f"Completed '{name}' on {repo}@{sha} ({target}) — conclusion={conclusion}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo",
+        required=True,
+        help="owner/repo the check run lives on, e.g. atlanhq/application-sdk",
+    )
+    parser.add_argument(
+        "--sha", required=True, help="Head SHA the check run is attached to."
+    )
+    parser.add_argument(
+        "--name",
+        required=True,
+        help="Check run name, e.g. 'Connector E2E / atlan-mysql-app'.",
+    )
+    parser.add_argument(
+        "--conclusion",
+        required=True,
+        choices=[
+            "success",
+            "failure",
+            "cancelled",
+            "timed_out",
+            "neutral",
+            "action_required",
+            "skipped",
+        ],
+    )
+    parser.add_argument("--title", default=None)
+    parser.add_argument("--details-url", default=None)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--summary", help="Inline summary text.")
+    group.add_argument(
+        "--summary-file", help="Path to a file containing the summary markdown."
+    )
+    args = parser.parse_args(argv)
+
+    if args.summary_file:
+        try:
+            with open(args.summary_file, encoding="utf-8") as fh:
+                summary = fh.read()
+        except OSError as e:
+            raise SystemExit(
+                f"::error::could not read --summary-file {args.summary_file}: {e}"
+            )
+    else:
+        summary = args.summary
+
+    complete_check_run(
+        args.repo,
+        args.sha,
+        args.name,
+        args.conclusion,
+        summary,
+        title=args.title,
+        details_url=args.details_url,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/complete_check_run.py
+++ b/.github/scripts/complete_check_run.py
@@ -39,8 +39,20 @@ def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
 
 
 def list_check_runs(repo: str, sha: str) -> list[dict]:
+    # --paginate follows the Link: rel="next" header across pages; --jq
+    # flattens each page's nested `check_runs` array and `tojson`-encodes
+    # each entry so every check run prints on its own line regardless of
+    # how many pages it took to fetch them all (a commit with >100 check
+    # runs would otherwise silently lose the ones on page 2+).
     result = run(
-        ["gh", "api", f"repos/{repo}/commits/{sha}/check-runs?per_page=100"],
+        [
+            "gh",
+            "api",
+            "--paginate",
+            f"repos/{repo}/commits/{sha}/check-runs?per_page=100",
+            "--jq",
+            ".check_runs[] | tojson",
+        ],
         capture_output=True,
         text=True,
         check=False,
@@ -49,7 +61,7 @@ def list_check_runs(repo: str, sha: str) -> list[dict]:
         raise SystemExit(
             f"::error::failed to list check runs for {repo}@{sha}: {result.stderr}"
         )
-    return json.loads(result.stdout).get("check_runs", [])
+    return [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
 
 
 def find_check_run(check_runs: list[dict], name: str) -> dict | None:

--- a/.github/scripts/create_check_run.py
+++ b/.github/scripts/create_check_run.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Create an in_progress GitHub check run — the dispatch side of the
+cross-repo e2e callback pattern.
+
+Used by ``.github/actions/e2e-apps`` (``wait-mode: callback``) right after
+dispatching a connector's ``tests.yaml``. The dispatching job creates this
+check on *this* repo's PR/merge-queue SHA using ``github.token``, then exits
+immediately — no polling. The connector reports back later by PATCHing this
+same check run to ``completed`` (see ``complete_check_run.py``), which lives
+in the connector's own workflow run and therefore updates the check the
+instant the connector's tests finish.
+
+Replaces a busy-poll loop that re-authenticated every request against the
+shared org PAT (see docs/standards/ci.md and the e2e-apps action comments)
+with a single POST here plus a single PATCH from the connector — the actual
+wait no longer costs any API calls at all.
+
+Prints ``check_run_id=<id>`` to $GITHUB_OUTPUT (or stdout if unset), mirroring
+the convention in sdk_changes_non_md.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Single seam so tests can stub the `gh` CLI."""
+    return subprocess.run(cmd, **kwargs)
+
+
+def create_check_run(
+    repo: str,
+    sha: str,
+    name: str,
+    *,
+    title: str | None = None,
+    summary: str,
+    details_url: str | None = None,
+) -> int:
+    """POST a new in_progress check run. Returns its id."""
+    payload = {
+        "name": name,
+        "head_sha": sha,
+        "status": "in_progress",
+        "started_at": now_iso(),
+        "output": {"title": title or name, "summary": summary},
+    }
+    if details_url:
+        payload["details_url"] = details_url
+
+    result = run(
+        ["gh", "api", "--method", "POST", f"repos/{repo}/check-runs", "--input", "-"],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"::error::failed to create check run '{name}' on {repo}@{sha}: {result.stderr}"
+        )
+    body = json.loads(result.stdout)
+    return body["id"]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo", required=True, help="owner/repo, e.g. atlanhq/application-sdk"
+    )
+    parser.add_argument(
+        "--sha", required=True, help="Head SHA to attach the check run to."
+    )
+    parser.add_argument(
+        "--name",
+        required=True,
+        help="Check run name, e.g. 'Connector E2E / atlan-mysql-app'.",
+    )
+    parser.add_argument("--title", default=None)
+    parser.add_argument("--summary", required=True)
+    parser.add_argument("--details-url", default=None)
+    args = parser.parse_args(argv)
+
+    check_run_id = create_check_run(
+        args.repo,
+        args.sha,
+        args.name,
+        title=args.title,
+        summary=args.summary,
+        details_url=args.details_url,
+    )
+
+    line = f"check_run_id={check_run_id}"
+    github_output = os.environ.get("GITHUB_OUTPUT", "")
+    if github_output:
+        with open(github_output, "a") as fh:
+            fh.write(line + "\n")
+    else:
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/dispatch_workflow.py
+++ b/.github/scripts/dispatch_workflow.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Dispatch a workflow_dispatch-triggered workflow in another repo via the
+raw REST API.
+
+Used by e2e-apps' callback mode (wait-mode: callback) — the dispatch half of
+what codex-/return-dispatch does internally, minus the run-locate polling
+that mode doesn't need (the connector reports back directly; see
+complete_check_run.py). `gh workflow run` only accepts inputs as individual
+`-f key=value` flags, which doesn't fit an arbitrary JSON object of inputs
+assembled by the caller (pull_request.yaml's workflow-inputs), so this goes
+straight to the dispatches endpoint with a JSON body instead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Single seam so tests can stub the `gh` CLI."""
+    return subprocess.run(cmd, **kwargs)
+
+
+def dispatch(repo: str, workflow: str, ref: str, inputs: dict) -> None:
+    payload = {"ref": ref, "inputs": inputs}
+    result = run(
+        [
+            "gh",
+            "api",
+            "--method",
+            "POST",
+            f"repos/{repo}/actions/workflows/{workflow}/dispatches",
+            "--input",
+            "-",
+        ],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"::error::failed to dispatch {workflow} on {repo}@{ref}: {result.stderr}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo", required=True, help="owner/repo, e.g. atlanhq/atlan-mysql-app"
+    )
+    parser.add_argument(
+        "--workflow", required=True, help="Workflow filename, e.g. tests.yaml"
+    )
+    parser.add_argument("--ref", required=True)
+    parser.add_argument(
+        "--inputs", required=True, help="JSON object of workflow_dispatch inputs"
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        inputs = json.loads(args.inputs)
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"::error::--inputs is not valid JSON: {e}")
+    if not isinstance(inputs, dict):
+        raise SystemExit("::error::--inputs must be a JSON object")
+
+    dispatch(args.repo, args.workflow, args.ref, inputs)
+    print(f"Dispatched {args.workflow} on {args.repo}@{args.ref}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/poll_check_runs_gate.py
+++ b/.github/scripts/poll_check_runs_gate.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import subprocess
 import sys
 import time
@@ -45,6 +46,8 @@ def gh_api_conditional(path: str, *, etag: str | None = None):
     if etag:
         cmd += ["-H", f"If-None-Match: {etag}"]
     result = run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise SystemExit(f"::error::gh api failed for {path}: {result.stderr}")
     raw = result.stdout.replace("\r\n", "\n")
     if "\n\n" not in raw:
         raise SystemExit(
@@ -82,7 +85,11 @@ def wait_for_checks(
     path = f"repos/{repo}/commits/{sha}/check-runs?per_page=100"
     etag: str | None = None
     latest: dict[str, dict] = {}
-    max_attempts = max(1, timeout_seconds // interval_seconds)
+    # Ceiling division: a timeout that isn't an exact multiple of the
+    # interval (e.g. 31s timeout / 30s interval) must still get its full
+    # attempt within budget, not be truncated to fewer attempts than the
+    # timeout actually allows.
+    max_attempts = max(1, math.ceil(timeout_seconds / interval_seconds))
 
     for attempt in range(1, max_attempts + 1):
         status_code, etag, body = gh_api_conditional(path, etag=etag)

--- a/.github/scripts/poll_check_runs_gate.py
+++ b/.github/scripts/poll_check_runs_gate.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Roll up the async ``Connector E2E / *`` check runs into a single pass/fail
+for the required "Test Gate" (Connector Tests Gate).
+
+The dispatch side (create_check_run.py, invoked from e2e-apps) exits right
+after dispatching; the actual result arrives later via a callback from each
+connector (complete_check_run.py) that PATCHes its check run directly — no
+polling on that side. This script is the one place that still polls, and it
+does so cheaply:
+
+* ONE endpoint (``commits/{sha}/check-runs``) covers every connector in a
+  single call, instead of one busy-poll per matrix leg.
+* Uses conditional requests (``If-None-Match``) — an unchanged poll gets back
+  HTTP 304 and does not count against the token's rate limit at all.
+* Runs on ``github.token`` (this repo's own bucket), never the shared org PAT
+  that the dispatch side still uses to fire the initial workflow_dispatch.
+
+Exits 0 once every name in --name is 'completed' with a passing conclusion,
+1 if any concludes non-passing, 1 on timeout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+
+PASSING_CONCLUSIONS = {"success", "neutral", "skipped"}
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Single seam so tests can stub the `gh` CLI."""
+    return subprocess.run(cmd, **kwargs)
+
+
+def gh_api_conditional(path: str, *, etag: str | None = None):
+    """GET `path` via `gh api -i`, returning (status_code, new_etag, body_json_or_None).
+
+    `-i` includes the response headers so the ETag can be read and replayed
+    on the next call; body is None on a 304 (nothing changed since last poll).
+    """
+    cmd = ["gh", "api", "-i", path]
+    if etag:
+        cmd += ["-H", f"If-None-Match: {etag}"]
+    result = run(cmd, capture_output=True, text=True, check=False)
+    raw = result.stdout.replace("\r\n", "\n")
+    if "\n\n" not in raw:
+        raise SystemExit(
+            f"::error::unexpected gh api response for {path}: {raw[:300]!r}"
+        )
+    header_block, _, body = raw.partition("\n\n")
+    lines = header_block.splitlines()
+    try:
+        status_code = int(lines[0].split()[1])
+    except (IndexError, ValueError):
+        raise SystemExit(
+            f"::error::could not parse HTTP status line: {lines[0] if lines else ''!r}"
+        )
+
+    new_etag = etag
+    for line in lines[1:]:
+        if line.lower().startswith("etag:"):
+            new_etag = line.split(":", 1)[1].strip()
+
+    body_json = json.loads(body) if status_code == 200 and body.strip() else None
+    return status_code, new_etag, body_json
+
+
+def wait_for_checks(
+    repo: str,
+    sha: str,
+    expected_names: list[str],
+    *,
+    interval_seconds: int = 30,
+    timeout_seconds: int = 7800,
+    sleep=time.sleep,
+) -> bool:
+    """Poll until every name in `expected_names` has a 'completed' check run
+    on `sha`, or the timeout elapses. Returns True iff all conclusions pass."""
+    path = f"repos/{repo}/commits/{sha}/check-runs?per_page=100"
+    etag: str | None = None
+    latest: dict[str, dict] = {}
+    max_attempts = max(1, timeout_seconds // interval_seconds)
+
+    for attempt in range(1, max_attempts + 1):
+        status_code, etag, body = gh_api_conditional(path, etag=etag)
+        if status_code == 200 and body is not None:
+            for check_run in body.get("check_runs", []):
+                if check_run.get("name") in expected_names:
+                    latest[check_run["name"]] = check_run
+        elif status_code != 304:
+            raise SystemExit(f"::error::unexpected status {status_code} polling {path}")
+
+        missing = [n for n in expected_names if n not in latest]
+        pending = [
+            n
+            for n in expected_names
+            if n in latest and latest[n].get("status") != "completed"
+        ]
+        if not missing and not pending:
+            break
+
+        print(
+            f"[{attempt}/{max_attempts}] waiting on checks — missing={missing} pending={pending}"
+        )
+        if attempt < max_attempts:
+            sleep(interval_seconds)
+    else:
+        missing = [n for n in expected_names if n not in latest]
+        pending = [
+            n
+            for n in expected_names
+            if n in latest and latest[n].get("status") != "completed"
+        ]
+
+    if missing or pending:
+        print(
+            f"::error::timed out waiting for check runs — missing={missing} pending={pending}"
+        )
+        return False
+
+    failed = [
+        n
+        for n in expected_names
+        if latest[n].get("conclusion") not in PASSING_CONCLUSIONS
+    ]
+    if failed:
+        print(f"::error::check runs did not pass: {failed}")
+        return False
+
+    print(f"All {len(expected_names)} connector check run(s) passed.")
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo", required=True, help="owner/repo, e.g. atlanhq/application-sdk"
+    )
+    parser.add_argument(
+        "--sha", required=True, help="Head/merge SHA the check runs are attached to."
+    )
+    name_group = parser.add_mutually_exclusive_group(required=True)
+    name_group.add_argument(
+        "--name",
+        action="append",
+        dest="names",
+        help="Expected check run name; repeat once per connector.",
+    )
+    name_group.add_argument(
+        "--names-json",
+        help="Expected check run names as a JSON array, e.g. from a matrix built with jq — "
+        "avoids the caller having to loop to build repeated --name flags.",
+    )
+    parser.add_argument("--interval-seconds", type=int, default=30)
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=7800,
+        help="Overall poll budget (default 7800s = 130min, safely above the 120min connector job ceiling).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.names_json is not None:
+        try:
+            names = json.loads(args.names_json)
+        except json.JSONDecodeError as e:
+            raise SystemExit(f"::error::--names-json is not valid JSON: {e}")
+        if not isinstance(names, list) or not all(isinstance(n, str) for n in names):
+            raise SystemExit("::error::--names-json must be a JSON array of strings")
+    else:
+        names = args.names
+
+    ok = wait_for_checks(
+        args.repo,
+        args.sha,
+        names,
+        interval_seconds=args.interval_seconds,
+        timeout_seconds=args.timeout_seconds,
+    )
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/poll_check_runs_gate.py
+++ b/.github/scripts/poll_check_runs_gate.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
 import subprocess
 import sys
 import time
@@ -32,27 +33,56 @@ PASSING_CONCLUSIONS = {"success", "neutral", "skipped"}
 
 
 def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
-    """Single seam so tests can stub the `gh` CLI."""
+    """Single seam so tests can stub the HTTP client."""
     return subprocess.run(cmd, **kwargs)
 
 
 def gh_api_conditional(path: str, *, etag: str | None = None):
-    """GET `path` via `gh api -i`, returning (status_code, new_etag, body_json_or_None).
+    """GET https://api.github.com/{path}, returning (status_code, new_etag, body_json_or_None).
 
-    `-i` includes the response headers so the ETag can be read and replayed
-    on the next call; body is None on a 304 (nothing changed since last poll).
+    Uses curl, not `gh api`: `gh api` treats ANY non-2xx response — including
+    a 304 Not Modified, which is the entire point of this conditional-request
+    pattern — as a command failure, printing its own short diagnostic instead
+    of the actual response, so a 304 can't be distinguished from a real error.
+    Confirmed in production (run 28949755456): the very first poll that hit an
+    unchanged state failed with "gh: HTTP 304" instead of being treated as
+    "nothing changed yet" — and since a dispatched e2e run can easily run for
+    20+ minutes without its check run changing, an unchanged poll is the
+    *common* case here, not an edge case.
+
+    curl without --fail prints the full response (headers + body, via -i) for
+    any status code and only exits non-zero on a genuine transport failure
+    (timeout, DNS, connection refused) — exactly the raw-HTTP-semantics
+    reference used elsewhere in these scripts (see wait_for_pages_publish.py).
     """
-    cmd = ["gh", "api", "-i", path]
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise SystemExit("::error::GH_TOKEN (or GITHUB_TOKEN) must be set")
+
+    cmd = [
+        "curl",
+        "-sS",
+        "-i",
+        "--max-time",
+        "30",
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-H",
+        "X-GitHub-Api-Version: 2022-11-28",
+        "-H",
+        f"Authorization: Bearer {token}",
+    ]
     if etag:
         cmd += ["-H", f"If-None-Match: {etag}"]
+    cmd.append(f"https://api.github.com/{path}")
+
     result = run(cmd, capture_output=True, text=True, check=False)
     if result.returncode != 0:
-        raise SystemExit(f"::error::gh api failed for {path}: {result.stderr}")
+        raise SystemExit(f"::error::curl failed for {path}: {result.stderr}")
+
     raw = result.stdout.replace("\r\n", "\n")
     if "\n\n" not in raw:
-        raise SystemExit(
-            f"::error::unexpected gh api response for {path}: {raw[:300]!r}"
-        )
+        raise SystemExit(f"::error::unexpected response for {path}: {raw[:300]!r}")
     header_block, _, body = raw.partition("\n\n")
     lines = header_block.splitlines()
     try:
@@ -66,6 +96,11 @@ def gh_api_conditional(path: str, *, etag: str | None = None):
     for line in lines[1:]:
         if line.lower().startswith("etag:"):
             new_etag = line.split(":", 1)[1].strip()
+
+    if status_code >= 400:
+        raise SystemExit(
+            f"::error::GitHub API returned {status_code} for {path}: {body[:500]}"
+        )
 
     body_json = json.loads(body) if status_code == 200 and body.strip() else None
     return status_code, new_etag, body_json

--- a/.github/scripts/poll_check_runs_gate.py
+++ b/.github/scripts/poll_check_runs_gate.py
@@ -94,7 +94,22 @@ def wait_for_checks(
     for attempt in range(1, max_attempts + 1):
         status_code, etag, body = gh_api_conditional(path, etag=etag)
         if status_code == 200 and body is not None:
-            for check_run in body.get("check_runs", []):
+            check_runs = body.get("check_runs", [])
+            # Conditional caching (If-None-Match) only covers this single
+            # page — a page-1 ETag match doesn't prove pages 2+ are
+            # unchanged too, so paginating here would risk silently missing
+            # a failing check run on a later page. That's worse than
+            # failing loudly: fail closed instead of paginating "for free".
+            total_count = body.get("total_count", len(check_runs))
+            if total_count > len(check_runs):
+                raise SystemExit(
+                    f"::error::{repo}@{sha} has {total_count} check runs, more than "
+                    f"the {len(check_runs)} this poll fetches (per_page=100) — "
+                    "pagination isn't supported here since ETag caching can't "
+                    "safely cover multiple pages. Reduce the matrix size or "
+                    "extend poll_check_runs_gate.py."
+                )
+            for check_run in check_runs:
                 if check_run.get("name") in expected_names:
                     latest[check_run["name"]] = check_run
         elif status_code != 304:

--- a/.github/scripts/tests/test_build_callback_summary.py
+++ b/.github/scripts/tests/test_build_callback_summary.py
@@ -1,0 +1,110 @@
+"""Tests for .github/scripts/build_callback_summary.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import build_callback_summary as mod
+
+
+def test_determine_conclusion_success_and_success():
+    assert mod.determine_conclusion("success", "success") == "success"
+
+
+def test_determine_conclusion_success_and_skipped():
+    assert mod.determine_conclusion("success", "skipped") == "success"
+
+
+def test_determine_conclusion_tests_failed():
+    assert mod.determine_conclusion("failure", "success") == "failure"
+
+
+def test_determine_conclusion_e2e_failed():
+    assert mod.determine_conclusion("success", "failure") == "failure"
+
+
+def test_determine_conclusion_tests_cancelled():
+    assert mod.determine_conclusion("cancelled", "skipped") == "failure"
+
+
+def test_resolve_summary_file_prefers_artifact(tmp_path):
+    artifact = tmp_path / "pr-comment-body.md"
+    artifact.write_text("rendered report")
+    fallback = tmp_path / "fallback.md"
+
+    result = mod.resolve_summary_file(
+        str(artifact), str(fallback), "success", "success", ""
+    )
+
+    assert result == str(artifact)
+    assert not fallback.exists()
+
+
+def test_resolve_summary_file_falls_back_when_artifact_missing(tmp_path):
+    artifact = tmp_path / "missing.md"
+    fallback = tmp_path / "fallback.md"
+
+    result = mod.resolve_summary_file(
+        str(artifact), str(fallback), "success", "skipped", "5 passed"
+    )
+
+    assert result == str(fallback)
+    content = fallback.read_text()
+    assert "**tests:** success (5 passed)" in content
+    assert "**e2e:** skipped" in content
+
+
+def test_build_fallback_summary_defaults_when_no_summary():
+    body = mod.build_fallback_summary("failure", "success", "")
+    assert "**tests:** failure (no summary)" in body
+
+
+def test_main_writes_github_output(tmp_path, monkeypatch):
+    artifact = tmp_path / "connector-results" / "pr-comment-body.md"
+    artifact.parent.mkdir()
+    artifact.write_text("rendered")
+    output_file = tmp_path / "gh_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+    rc = mod.main(
+        [
+            "--tests-result",
+            "success",
+            "--e2e-result",
+            "success",
+            "--artifact-summary-path",
+            str(artifact),
+            "--fallback-path",
+            str(tmp_path / "fallback.md"),
+        ]
+    )
+
+    assert rc == 0
+    content = output_file.read_text()
+    assert "conclusion=success" in content
+    assert f"summary_file={artifact}" in content
+
+
+def test_main_prints_when_no_github_output(tmp_path, monkeypatch, capsys):
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    rc = mod.main(
+        [
+            "--tests-result",
+            "failure",
+            "--e2e-result",
+            "skipped",
+            "--artifact-summary-path",
+            str(tmp_path / "missing.md"),
+            "--fallback-path",
+            str(tmp_path / "fallback.md"),
+        ]
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "conclusion=failure" in out
+    assert "summary_file=" in out

--- a/.github/scripts/tests/test_complete_check_run.py
+++ b/.github/scripts/tests/test_complete_check_run.py
@@ -20,6 +20,19 @@ def _completed(stdout: str) -> subprocess.CompletedProcess:
     return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
 
 
+def _list_check_runs_call(cmd: list[str]) -> bool:
+    """True for the paginated 'gh api --paginate .../check-runs ... --jq' call."""
+    return "--paginate" in cmd and any(
+        "check-runs?per_page=100" in part for part in cmd
+    )
+
+
+def _ndjson(runs: list[dict]) -> subprocess.CompletedProcess:
+    """What `--jq '.check_runs[] | tojson'` produces: one compact JSON object
+    per line, regardless of how many pages it took to gather them."""
+    return _completed("\n".join(json.dumps(r) for r in runs) + ("\n" if runs else ""))
+
+
 def test_find_check_run_picks_highest_id_on_duplicates():
     runs = [
         {"id": 1, "name": NAME},
@@ -45,13 +58,49 @@ def test_truncate_summary_long_gets_truncated():
     assert result.endswith("(truncated)")
 
 
+def test_list_check_runs_uses_paginate_and_parses_ndjson(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _ndjson([{"id": 1, "name": NAME}, {"id": 2, "name": "other"}])
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    runs = mod.list_check_runs(REPO, SHA)
+
+    assert "--paginate" in captured["cmd"]
+    assert "--jq" in captured["cmd"]
+    assert runs == [{"id": 1, "name": NAME}, {"id": 2, "name": "other"}]
+
+
+def test_list_check_runs_handles_empty_result(monkeypatch):
+    monkeypatch.setattr(mod, "run", lambda cmd, **kw: _ndjson([]))
+    assert mod.list_check_runs(REPO, SHA) == []
+
+
+def test_list_check_runs_raises_on_failure(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="rate limited"
+        )
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    try:
+        mod.list_check_runs(REPO, SHA)
+        assert False, "expected SystemExit"
+    except SystemExit as e:
+        assert "rate limited" in str(e)
+
+
 def test_complete_check_run_patches_existing(monkeypatch):
     calls = []
 
     def fake_run(cmd, **kwargs):
         calls.append((cmd, kwargs.get("input")))
-        if cmd[0:2] == ["gh", "api"] and "check-runs?per_page=100" in cmd[2]:
-            return _completed(json.dumps({"check_runs": [{"id": 55, "name": NAME}]}))
+        if _list_check_runs_call(cmd):
+            return _ndjson([{"id": 55, "name": NAME}])
         return _completed("{}")
 
     monkeypatch.setattr(mod, "run", fake_run)
@@ -73,8 +122,8 @@ def test_complete_check_run_creates_when_missing(monkeypatch):
 
     def fake_run(cmd, **kwargs):
         calls.append((cmd, kwargs.get("input")))
-        if "check-runs?per_page=100" in cmd[2]:
-            return _completed(json.dumps({"check_runs": []}))
+        if _list_check_runs_call(cmd):
+            return _ndjson([])
         return _completed("{}")
 
     monkeypatch.setattr(mod, "run", fake_run)
@@ -91,8 +140,8 @@ def test_complete_check_run_creates_when_missing(monkeypatch):
 
 def test_complete_check_run_raises_on_patch_failure(monkeypatch):
     def fake_run(cmd, **kwargs):
-        if "check-runs?per_page=100" in cmd[2]:
-            return _completed(json.dumps({"check_runs": [{"id": 1, "name": NAME}]}))
+        if _list_check_runs_call(cmd):
+            return _ndjson([{"id": 1, "name": NAME}])
         return subprocess.CompletedProcess(
             args=[], returncode=1, stdout="", stderr="nope"
         )
@@ -113,8 +162,8 @@ def test_main_reads_summary_file(monkeypatch, tmp_path):
 
     def fake_run(cmd, **kwargs):
         calls.append((cmd, kwargs.get("input")))
-        if "check-runs?per_page=100" in cmd[2]:
-            return _completed(json.dumps({"check_runs": [{"id": 9, "name": NAME}]}))
+        if _list_check_runs_call(cmd):
+            return _ndjson([{"id": 9, "name": NAME}])
         return _completed("{}")
 
     monkeypatch.setattr(mod, "run", fake_run)

--- a/.github/scripts/tests/test_complete_check_run.py
+++ b/.github/scripts/tests/test_complete_check_run.py
@@ -1,0 +1,159 @@
+"""Tests for .github/scripts/complete_check_run.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import complete_check_run as mod
+
+REPO = "atlanhq/application-sdk"
+SHA = "abc123"
+NAME = "Connector E2E / atlan-mysql-app"
+
+
+def _completed(stdout: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def test_find_check_run_picks_highest_id_on_duplicates():
+    runs = [
+        {"id": 1, "name": NAME},
+        {"id": 5, "name": NAME},
+        {"id": 3, "name": "Connector E2E / atlan-openapi-app"},
+    ]
+    found = mod.find_check_run(runs, NAME)
+    assert found["id"] == 5
+
+
+def test_find_check_run_returns_none_when_absent():
+    assert mod.find_check_run([{"id": 1, "name": "other"}], NAME) is None
+
+
+def test_truncate_summary_short_passthrough():
+    assert mod.truncate_summary("hello") == "hello"
+
+
+def test_truncate_summary_long_gets_truncated():
+    long = "x" * (mod.MAX_SUMMARY_CHARS + 100)
+    result = mod.truncate_summary(long)
+    assert len(result) <= mod.MAX_SUMMARY_CHARS + len("\n\n… (truncated)")
+    assert result.endswith("(truncated)")
+
+
+def test_complete_check_run_patches_existing(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs.get("input")))
+        if cmd[0:2] == ["gh", "api"] and "check-runs?per_page=100" in cmd[2]:
+            return _completed(json.dumps({"check_runs": [{"id": 55, "name": NAME}]}))
+        return _completed("{}")
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    mod.complete_check_run(REPO, SHA, NAME, "success", "All good")
+
+    patch_call = next(
+        c for c in calls if c[0][:3] == ["gh", "api", "--method"] and c[0][3] == "PATCH"
+    )
+    assert patch_call[0][4] == f"repos/{REPO}/check-runs/55"
+    payload = json.loads(patch_call[1])
+    assert payload["status"] == "completed"
+    assert payload["conclusion"] == "success"
+    assert payload["output"]["summary"] == "All good"
+
+
+def test_complete_check_run_creates_when_missing(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs.get("input")))
+        if "check-runs?per_page=100" in cmd[2]:
+            return _completed(json.dumps({"check_runs": []}))
+        return _completed("{}")
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    mod.complete_check_run(REPO, SHA, NAME, "failure", "Broke")
+
+    post_call = next(
+        c for c in calls if c[0][:3] == ["gh", "api", "--method"] and c[0][3] == "POST"
+    )
+    assert post_call[0][4] == f"repos/{REPO}/check-runs"
+    payload = json.loads(post_call[1])
+    assert payload["conclusion"] == "failure"
+
+
+def test_complete_check_run_raises_on_patch_failure(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        if "check-runs?per_page=100" in cmd[2]:
+            return _completed(json.dumps({"check_runs": [{"id": 1, "name": NAME}]}))
+        return subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="nope"
+        )
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    try:
+        mod.complete_check_run(REPO, SHA, NAME, "success", "x")
+        assert False, "expected SystemExit"
+    except SystemExit as e:
+        assert "nope" in str(e)
+
+
+def test_main_reads_summary_file(monkeypatch, tmp_path):
+    summary_file = tmp_path / "body.md"
+    summary_file.write_text("rendered report")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs.get("input")))
+        if "check-runs?per_page=100" in cmd[2]:
+            return _completed(json.dumps({"check_runs": [{"id": 9, "name": NAME}]}))
+        return _completed("{}")
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    rc = mod.main(
+        [
+            "--repo",
+            REPO,
+            "--sha",
+            SHA,
+            "--name",
+            NAME,
+            "--conclusion",
+            "success",
+            "--summary-file",
+            str(summary_file),
+        ]
+    )
+    assert rc == 0
+    patch_call = next(c for c in calls if len(c[0]) > 3 and c[0][3] == "PATCH")
+    assert json.loads(patch_call[1])["output"]["summary"] == "rendered report"
+
+
+def test_main_missing_summary_file_errors(monkeypatch):
+    monkeypatch.setattr(mod, "run", lambda *a, **k: _completed("{}"))
+    try:
+        mod.main(
+            [
+                "--repo",
+                REPO,
+                "--sha",
+                SHA,
+                "--name",
+                NAME,
+                "--conclusion",
+                "success",
+                "--summary-file",
+                "/no/such/file",
+            ]
+        )
+        assert False, "expected SystemExit"
+    except SystemExit as e:
+        assert "could not read" in str(e)

--- a/.github/scripts/tests/test_create_check_run.py
+++ b/.github/scripts/tests/test_create_check_run.py
@@ -1,0 +1,110 @@
+"""Tests for .github/scripts/create_check_run.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import create_check_run as mod
+
+REPO = "atlanhq/application-sdk"
+SHA = "abc123"
+NAME = "Connector E2E / atlan-mysql-app"
+
+
+def _completed(stdout: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def test_create_check_run_posts_in_progress_and_returns_id(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["payload"] = json.loads(kwargs["input"])
+        return _completed(json.dumps({"id": 4242}))
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    check_run_id = mod.create_check_run(
+        REPO, SHA, NAME, summary="Dispatched; awaiting results."
+    )
+
+    assert check_run_id == 4242
+    assert captured["cmd"][:4] == ["gh", "api", "--method", "POST"]
+    assert captured["cmd"][4] == f"repos/{REPO}/check-runs"
+    payload = captured["payload"]
+    assert payload["name"] == NAME
+    assert payload["head_sha"] == SHA
+    assert payload["status"] == "in_progress"
+    assert payload["output"]["summary"] == "Dispatched; awaiting results."
+    assert payload["output"]["title"] == NAME
+    assert "details_url" not in payload
+
+
+def test_create_check_run_includes_details_url_and_title(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["payload"] = json.loads(kwargs["input"])
+        return _completed(json.dumps({"id": 1}))
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    mod.create_check_run(
+        REPO,
+        SHA,
+        NAME,
+        title="Custom Title",
+        summary="x",
+        details_url="https://example.com/run/1",
+    )
+
+    assert captured["payload"]["output"]["title"] == "Custom Title"
+    assert captured["payload"]["details_url"] == "https://example.com/run/1"
+
+
+def test_create_check_run_raises_on_failure(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="boom"
+        )
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    try:
+        mod.create_check_run(REPO, SHA, NAME, summary="x")
+        assert False, "expected SystemExit"
+    except SystemExit as e:
+        assert "boom" in str(e)
+
+
+def test_main_writes_github_output(monkeypatch, tmp_path):
+    def fake_run(cmd, **kwargs):
+        return _completed(json.dumps({"id": 99}))
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    output_file = tmp_path / "gh_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+    rc = mod.main(["--repo", REPO, "--sha", SHA, "--name", NAME, "--summary", "x"])
+
+    assert rc == 0
+    assert output_file.read_text() == "check_run_id=99\n"
+
+
+def test_main_prints_when_no_github_output(monkeypatch, capsys):
+    def fake_run(cmd, **kwargs):
+        return _completed(json.dumps({"id": 7}))
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    rc = mod.main(["--repo", REPO, "--sha", SHA, "--name", NAME, "--summary", "x"])
+
+    assert rc == 0
+    assert "check_run_id=7" in capsys.readouterr().out

--- a/.github/scripts/tests/test_dispatch_workflow.py
+++ b/.github/scripts/tests/test_dispatch_workflow.py
@@ -1,0 +1,96 @@
+"""Tests for .github/scripts/dispatch_workflow.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import dispatch_workflow as mod
+
+REPO = "atlanhq/atlan-mysql-app"
+WORKFLOW = "tests.yaml"
+REF = "refs/heads/main"
+
+
+def _completed(returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout="", stderr=stderr
+    )
+
+
+def test_dispatch_posts_ref_and_inputs(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["payload"] = json.loads(kwargs["input"])
+        return _completed()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    mod.dispatch(
+        REPO, WORKFLOW, REF, {"application_sdk_ref": "abc123", "run_e2e": "true"}
+    )
+
+    assert captured["cmd"][:4] == ["gh", "api", "--method", "POST"]
+    assert captured["cmd"][4] == f"repos/{REPO}/actions/workflows/{WORKFLOW}/dispatches"
+    assert captured["payload"] == {
+        "ref": REF,
+        "inputs": {"application_sdk_ref": "abc123", "run_e2e": "true"},
+    }
+
+
+def test_dispatch_raises_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        mod, "run", lambda cmd, **kw: _completed(returncode=1, stderr="boom")
+    )
+
+    try:
+        mod.dispatch(REPO, WORKFLOW, REF, {})
+        assert False, "expected SystemExit"
+    except SystemExit as e:
+        assert "boom" in str(e)
+
+
+def test_main_rejects_invalid_json(monkeypatch):
+    try:
+        mod.main(
+            [
+                "--repo",
+                REPO,
+                "--workflow",
+                WORKFLOW,
+                "--ref",
+                REF,
+                "--inputs",
+                "not json",
+            ]
+        )
+        assert False, "expected SystemExit"
+    except SystemExit as e:
+        assert "not valid JSON" in str(e)
+
+
+def test_main_rejects_non_object_json(monkeypatch):
+    try:
+        mod.main(
+            ["--repo", REPO, "--workflow", WORKFLOW, "--ref", REF, "--inputs", "[1, 2]"]
+        )
+        assert False, "expected SystemExit"
+    except SystemExit as e:
+        assert "must be a JSON object" in str(e)
+
+
+def test_main_success(monkeypatch, capsys):
+    monkeypatch.setattr(mod, "run", lambda cmd, **kw: _completed())
+
+    rc = mod.main(
+        ["--repo", REPO, "--workflow", WORKFLOW, "--ref", REF, "--inputs", "{}"]
+    )
+
+    assert rc == 0
+    assert f"Dispatched {WORKFLOW} on {REPO}@{REF}" in capsys.readouterr().out

--- a/.github/scripts/tests/test_poll_check_runs_gate.py
+++ b/.github/scripts/tests/test_poll_check_runs_gate.py
@@ -1,0 +1,203 @@
+"""Tests for .github/scripts/poll_check_runs_gate.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import poll_check_runs_gate as mod
+
+REPO = "atlanhq/application-sdk"
+SHA = "abc123"
+NAMES = ["Connector E2E / atlan-openapi-app", "Connector E2E / atlan-mysql-app"]
+
+
+def _http_response(
+    status: int, etag: str | None, body: dict | None
+) -> subprocess.CompletedProcess:
+    headers = [f"HTTP/2.0 {status} whatever"]
+    if etag:
+        headers.append(f"ETag: {etag}")
+    body_text = json.dumps(body) if body is not None else ""
+    raw = "\n".join(headers) + "\n\n" + body_text
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=raw, stderr="")
+
+
+def _check_runs_body(runs: list[dict]) -> dict:
+    return {"total_count": len(runs), "check_runs": runs}
+
+
+def test_gh_api_conditional_parses_200_and_etag(monkeypatch):
+    monkeypatch.setattr(
+        mod, "run", lambda cmd, **kw: _http_response(200, '"v1"', {"check_runs": []})
+    )
+
+    status, etag, body = mod.gh_api_conditional("some/path")
+    assert status == 200
+    assert etag == '"v1"'
+    assert body == {"check_runs": []}
+
+
+def test_gh_api_conditional_304_has_no_body_and_keeps_prior_etag(monkeypatch):
+    monkeypatch.setattr(mod, "run", lambda cmd, **kw: _http_response(304, None, None))
+
+    status, etag, body = mod.gh_api_conditional("some/path", etag='"v1"')
+    assert status == 304
+    assert etag == '"v1"'
+    assert body is None
+
+
+def test_wait_for_checks_succeeds_immediately_when_all_pass(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        runs = [
+            {"name": n, "status": "completed", "conclusion": "success"} for n in NAMES
+        ]
+        return _http_response(200, '"v1"', _check_runs_body(runs))
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    ok = mod.wait_for_checks(REPO, SHA, NAMES, sleep=lambda s: None)
+    assert ok is True
+
+
+def test_wait_for_checks_polls_until_completed(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            runs = [{"name": NAMES[0], "status": "in_progress"}]
+            return _http_response(200, '"v1"', _check_runs_body(runs))
+        runs = [
+            {"name": n, "status": "completed", "conclusion": "success"} for n in NAMES
+        ]
+        return _http_response(200, '"v2"', _check_runs_body(runs))
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    ok = mod.wait_for_checks(
+        REPO, SHA, NAMES, interval_seconds=1, timeout_seconds=10, sleep=lambda s: None
+    )
+    assert ok is True
+    assert calls["n"] == 3
+
+
+def test_wait_for_checks_uses_304_cache_without_losing_state(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            runs = [
+                {"name": n, "status": "completed", "conclusion": "success"}
+                for n in NAMES
+            ]
+            return _http_response(200, '"v1"', _check_runs_body(runs))
+        # Every subsequent poll is a 304 — nothing changed, but state from the
+        # first successful call must still be treated as authoritative.
+        return _http_response(304, None, None)
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    ok = mod.wait_for_checks(REPO, SHA, NAMES, sleep=lambda s: None)
+    assert ok is True
+    assert calls["n"] == 1  # loop breaks right after the first (complete) poll
+
+
+def test_wait_for_checks_fails_on_bad_conclusion(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        runs = [
+            {"name": NAMES[0], "status": "completed", "conclusion": "failure"},
+            {"name": NAMES[1], "status": "completed", "conclusion": "success"},
+        ]
+        return _http_response(200, '"v1"', _check_runs_body(runs))
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    ok = mod.wait_for_checks(REPO, SHA, NAMES, sleep=lambda s: None)
+    assert ok is False
+
+
+def test_wait_for_checks_times_out_when_never_complete(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        runs = [{"name": NAMES[0], "status": "in_progress"}]
+        return _http_response(200, '"v1"', _check_runs_body(runs))
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    ok = mod.wait_for_checks(
+        REPO, SHA, NAMES, interval_seconds=1, timeout_seconds=3, sleep=lambda s: None
+    )
+    assert ok is False
+
+
+def test_main_exit_codes(monkeypatch):
+    def fake_run_pass(cmd, **kwargs):
+        runs = [
+            {"name": n, "status": "completed", "conclusion": "success"} for n in NAMES
+        ]
+        return _http_response(200, '"v1"', _check_runs_body(runs))
+
+    monkeypatch.setattr(mod, "run", fake_run_pass)
+    rc = mod.main(
+        ["--repo", REPO, "--sha", SHA, "--name", NAMES[0], "--name", NAMES[1]]
+    )
+    assert rc == 0
+
+    def fake_run_fail(cmd, **kwargs):
+        runs = [{"name": NAMES[0], "status": "completed", "conclusion": "failure"}]
+        return _http_response(200, '"v1"', _check_runs_body(runs))
+
+    monkeypatch.setattr(mod, "run", fake_run_fail)
+    rc = mod.main(
+        [
+            "--repo",
+            REPO,
+            "--sha",
+            SHA,
+            "--name",
+            NAMES[0],
+            "--interval-seconds",
+            "1",
+            "--timeout-seconds",
+            "1",
+        ]
+    )
+    assert rc == 1
+
+
+def test_main_accepts_names_json(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        runs = [
+            {"name": n, "status": "completed", "conclusion": "success"} for n in NAMES
+        ]
+        return _http_response(200, '"v1"', _check_runs_body(runs))
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    rc = mod.main(["--repo", REPO, "--sha", SHA, "--names-json", json.dumps(NAMES)])
+    assert rc == 0
+
+
+def test_main_rejects_invalid_names_json(monkeypatch):
+    try:
+        mod.main(["--repo", REPO, "--sha", SHA, "--names-json", "not json"])
+        assert False, "expected SystemExit"
+    except SystemExit as e:
+        assert "not valid JSON" in str(e)
+
+
+def test_main_rejects_non_list_names_json(monkeypatch):
+    try:
+        mod.main(["--repo", REPO, "--sha", SHA, "--names-json", '{"a": 1}'])
+        assert False, "expected SystemExit"
+    except SystemExit as e:
+        assert "must be a JSON array" in str(e)
+
+
+def test_main_rejects_both_name_and_names_json(monkeypatch):
+    try:
+        mod.main(
+            ["--repo", REPO, "--sha", SHA, "--name", NAMES[0], "--names-json", "[]"]
+        )
+        assert False, "expected SystemExit (argparse mutually exclusive)"
+    except SystemExit:
+        pass

--- a/.github/scripts/tests/test_poll_check_runs_gate.py
+++ b/.github/scripts/tests/test_poll_check_runs_gate.py
@@ -51,6 +51,21 @@ def test_gh_api_conditional_304_has_no_body_and_keeps_prior_etag(monkeypatch):
     assert body is None
 
 
+def test_gh_api_conditional_raises_with_stderr_on_gh_failure(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="API rate limit exceeded"
+        )
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    try:
+        mod.gh_api_conditional("some/path")
+        assert False, "expected SystemExit"
+    except SystemExit as e:
+        assert "API rate limit exceeded" in str(e)
+
+
 def test_wait_for_checks_succeeds_immediately_when_all_pass(monkeypatch):
     def fake_run(cmd, **kwargs):
         runs = [
@@ -128,6 +143,33 @@ def test_wait_for_checks_times_out_when_never_complete(monkeypatch):
         REPO, SHA, NAMES, interval_seconds=1, timeout_seconds=3, sleep=lambda s: None
     )
     assert ok is False
+
+
+def test_wait_for_checks_ceiling_divides_timeout_into_attempts(monkeypatch):
+    # timeout=31s / interval=30s must allow 2 attempts, not floor-truncate
+    # to 1 — the second attempt is what completes here, so this fails under
+    # floor division (which would give up after the first).
+    calls = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        calls["n"] += 1
+        if calls["n"] < 2:
+            runs = [{"name": NAMES[0], "status": "in_progress"}]
+        else:
+            runs = [{"name": NAMES[0], "status": "completed", "conclusion": "success"}]
+        return _http_response(200, '"v1"', _check_runs_body(runs))
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    ok = mod.wait_for_checks(
+        REPO,
+        SHA,
+        [NAMES[0]],
+        interval_seconds=30,
+        timeout_seconds=31,
+        sleep=lambda s: None,
+    )
+    assert ok is True
+    assert calls["n"] == 2
 
 
 def test_main_exit_codes(monkeypatch):

--- a/.github/scripts/tests/test_poll_check_runs_gate.py
+++ b/.github/scripts/tests/test_poll_check_runs_gate.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import poll_check_runs_gate as mod
@@ -14,6 +16,11 @@ import poll_check_runs_gate as mod
 REPO = "atlanhq/application-sdk"
 SHA = "abc123"
 NAMES = ["Connector E2E / atlan-openapi-app", "Connector E2E / atlan-mysql-app"]
+
+
+@pytest.fixture(autouse=True)
+def _gh_token(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "test-token")
 
 
 def _http_response(
@@ -31,6 +38,13 @@ def _check_runs_body(runs: list[dict]) -> dict:
     return {"total_count": len(runs), "check_runs": runs}
 
 
+def _completed_raw(status: int, body_text: str) -> subprocess.CompletedProcess:
+    """Like _http_response, but for a raw (non-JSON-dict) body string —
+    e.g. a GitHub error response's raw text."""
+    raw = f"HTTP/2.0 {status} whatever\n\n{body_text}"
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=raw, stderr="")
+
+
 def test_gh_api_conditional_parses_200_and_etag(monkeypatch):
     monkeypatch.setattr(
         mod, "run", lambda cmd, **kw: _http_response(200, '"v1"', {"check_runs": []})
@@ -43,6 +57,12 @@ def test_gh_api_conditional_parses_200_and_etag(monkeypatch):
 
 
 def test_gh_api_conditional_304_has_no_body_and_keeps_prior_etag(monkeypatch):
+    # Regression test for a real production failure (merge-queue run
+    # 28949755456): the original implementation shelled out to `gh api`,
+    # which treats a 304 as a command failure (exits non-zero, prints
+    # "gh: HTTP 304" instead of the response) — indistinguishable from a
+    # genuine error. curl without --fail returns 0 and the real response
+    # for ANY status code, so a 304 must parse cleanly here, not raise.
     monkeypatch.setattr(mod, "run", lambda cmd, **kw: _http_response(304, None, None))
 
     status, etag, body = mod.gh_api_conditional("some/path", etag='"v1"')
@@ -51,10 +71,37 @@ def test_gh_api_conditional_304_has_no_body_and_keeps_prior_etag(monkeypatch):
     assert body is None
 
 
-def test_gh_api_conditional_raises_with_stderr_on_gh_failure(monkeypatch):
+def test_gh_api_conditional_uses_curl_not_gh(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _http_response(200, '"v1"', {"check_runs": []})
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    mod.gh_api_conditional("some/path")
+
+    assert captured["cmd"][0] == "curl"
+    assert "gh" not in captured["cmd"]
+    assert any("Authorization: Bearer test-token" == p for p in captured["cmd"])
+    assert captured["cmd"][-1] == "https://api.github.com/some/path"
+
+
+def test_gh_api_conditional_requires_a_token(monkeypatch):
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    try:
+        mod.gh_api_conditional("some/path")
+        assert False, "expected SystemExit"
+    except SystemExit as e:
+        assert "GH_TOKEN" in str(e)
+
+
+def test_gh_api_conditional_raises_on_transport_failure(monkeypatch):
     def fake_run(cmd, **kwargs):
         return subprocess.CompletedProcess(
-            args=[], returncode=1, stdout="", stderr="API rate limit exceeded"
+            args=[], returncode=28, stdout="", stderr="curl: (28) Operation timed out"
         )
 
     monkeypatch.setattr(mod, "run", fake_run)
@@ -63,6 +110,21 @@ def test_gh_api_conditional_raises_with_stderr_on_gh_failure(monkeypatch):
         mod.gh_api_conditional("some/path")
         assert False, "expected SystemExit"
     except SystemExit as e:
+        assert "Operation timed out" in str(e)
+
+
+def test_gh_api_conditional_raises_on_http_error_status(monkeypatch):
+    monkeypatch.setattr(
+        mod,
+        "run",
+        lambda cmd, **kw: _completed_raw(403, '{"message": "API rate limit exceeded"}'),
+    )
+
+    try:
+        mod.gh_api_conditional("some/path")
+        assert False, "expected SystemExit"
+    except SystemExit as e:
+        assert "403" in str(e)
         assert "API rate limit exceeded" in str(e)
 
 

--- a/.github/scripts/tests/test_poll_check_runs_gate.py
+++ b/.github/scripts/tests/test_poll_check_runs_gate.py
@@ -120,6 +120,29 @@ def test_wait_for_checks_uses_304_cache_without_losing_state(monkeypatch):
     assert calls["n"] == 1  # loop breaks right after the first (complete) poll
 
 
+def test_wait_for_checks_fails_loudly_when_truncated(monkeypatch):
+    # total_count exceeds what a single per_page=100 page returns — ETag
+    # caching can't safely span multiple pages (a page-1 match doesn't
+    # prove page 2 is unchanged), so this must fail closed rather than
+    # silently missing check runs that live past page 1.
+    def fake_run(cmd, **kwargs):
+        body = {
+            "total_count": 150,
+            "check_runs": [
+                {"name": NAMES[0], "status": "completed", "conclusion": "success"}
+            ],
+        }
+        return _http_response(200, '"v1"', body)
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    try:
+        mod.wait_for_checks(REPO, SHA, NAMES, sleep=lambda s: None)
+        assert False, "expected SystemExit"
+    except SystemExit as e:
+        assert "150 check runs" in str(e)
+        assert "pagination isn't supported" in str(e)
+
+
 def test_wait_for_checks_fails_on_bad_conclusion(monkeypatch):
     def fake_run(cmd, **kwargs):
         runs = [

--- a/.github/scripts/tests/test_timeout_stale_check_runs.py
+++ b/.github/scripts/tests/test_timeout_stale_check_runs.py
@@ -1,0 +1,133 @@
+"""Tests for .github/scripts/timeout_stale_check_runs.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import timeout_stale_check_runs as mod
+
+REPO = "atlanhq/application-sdk"
+NOW = datetime(2026, 7, 5, 12, 0, 0, tzinfo=timezone.utc)
+PREFIX = "Connector E2E / "
+
+
+def _completed(stdout: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_is_stale_only_flags_old_in_progress_runs():
+    stale = {"status": "in_progress", "started_at": _iso(NOW - timedelta(minutes=200))}
+    fresh = {"status": "in_progress", "started_at": _iso(NOW - timedelta(minutes=5))}
+    done = {"status": "completed", "started_at": _iso(NOW - timedelta(minutes=200))}
+    max_age = timedelta(minutes=130)
+
+    assert mod.is_stale(stale, max_age, NOW) is True
+    assert mod.is_stale(fresh, max_age, NOW) is False
+    assert mod.is_stale(done, max_age, NOW) is False
+
+
+def test_is_stale_handles_missing_started_at():
+    assert mod.is_stale({"status": "in_progress"}, timedelta(minutes=1), NOW) is False
+
+
+def test_sweep_times_out_only_stale_matching_checks(monkeypatch):
+    prs = [{"number": 42, "head": {"sha": "sha1"}}]
+    check_runs = [
+        {
+            "id": 1,
+            "name": f"{PREFIX}atlan-openapi-app",
+            "status": "in_progress",
+            "started_at": _iso(NOW - timedelta(minutes=200)),
+        },
+        {
+            "id": 2,
+            "name": f"{PREFIX}atlan-mysql-app",
+            "status": "in_progress",
+            "started_at": _iso(NOW - timedelta(minutes=5)),
+        },
+        {
+            "id": 3,
+            "name": "Unrelated Check",
+            "status": "in_progress",
+            "started_at": _iso(NOW - timedelta(minutes=999)),
+        },
+    ]
+    patched = []
+
+    def fake_run(cmd, **kwargs):
+        if "pulls?state=open" in cmd[2]:
+            return _completed(json.dumps(prs))
+        if "check-runs?per_page=100" in cmd[2]:
+            return _completed(json.dumps({"check_runs": check_runs}))
+        if cmd[:3] == ["gh", "api", "--method"]:
+            patched.append((cmd[4], json.loads(kwargs["input"])))
+            return _completed("{}")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    timed_out = mod.sweep(REPO, PREFIX, 130, now=NOW)
+
+    assert timed_out == [f"{PREFIX}atlan-openapi-app (PR #42)"]
+    assert len(patched) == 1
+    endpoint, payload = patched[0]
+    assert endpoint == f"repos/{REPO}/check-runs/1"
+    assert payload["conclusion"] == "timed_out"
+    assert payload["status"] == "completed"
+
+
+def test_sweep_returns_empty_when_nothing_stale(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        if "pulls?state=open" in cmd[2]:
+            return _completed(json.dumps([]))
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    assert mod.sweep(REPO, PREFIX, 130, now=NOW) == []
+
+
+def test_list_open_prs_raises_on_failure(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="rate limited"
+        )
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    try:
+        mod.list_open_prs(REPO)
+        assert False, "expected SystemExit"
+    except SystemExit as e:
+        assert "rate limited" in str(e)
+
+
+def test_main_reports_timed_out_runs(monkeypatch, capsys):
+    prs = [{"number": 1, "head": {"sha": "s"}}]
+    check_runs = [
+        {
+            "id": 9,
+            "name": f"{PREFIX}atlan-mysql-app",
+            "status": "in_progress",
+            "started_at": _iso(NOW - timedelta(minutes=999)),
+        }
+    ]
+
+    def fake_run(cmd, **kwargs):
+        if "pulls?state=open" in cmd[2]:
+            return _completed(json.dumps(prs))
+        if "check-runs?per_page=100" in cmd[2]:
+            return _completed(json.dumps({"check_runs": check_runs}))
+        return _completed("{}")
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    rc = mod.main(["--repo", REPO])
+    assert rc == 0
+    assert "Timed out 1 stuck check run" in capsys.readouterr().out

--- a/.github/scripts/tests/test_timeout_stale_check_runs.py
+++ b/.github/scripts/tests/test_timeout_stale_check_runs.py
@@ -21,6 +21,20 @@ def _completed(stdout: str) -> subprocess.CompletedProcess:
     return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
 
 
+def _ndjson(items: list[dict]) -> subprocess.CompletedProcess:
+    """What `gh api --paginate --jq '... | tojson'` produces: one compact
+    JSON object per line, across however many pages it took."""
+    return _completed("\n".join(json.dumps(i) for i in items) + ("\n" if items else ""))
+
+
+def _is_open_prs_call(cmd: list[str]) -> bool:
+    return any("pulls?state=open" in part for part in cmd)
+
+
+def _is_check_runs_call(cmd: list[str]) -> bool:
+    return any("check-runs?per_page=100" in part for part in cmd)
+
+
 def _iso(dt: datetime) -> str:
     return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -38,6 +52,34 @@ def test_is_stale_only_flags_old_in_progress_runs():
 
 def test_is_stale_handles_missing_started_at():
     assert mod.is_stale({"status": "in_progress"}, timedelta(minutes=1), NOW) is False
+
+
+def test_list_open_prs_uses_paginate(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _ndjson([{"number": 1, "head": {"sha": "s"}}])
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    prs = mod.list_open_prs(REPO)
+
+    assert "--paginate" in captured["cmd"]
+    assert prs == [{"number": 1, "head": {"sha": "s"}}]
+
+
+def test_list_check_runs_uses_paginate(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _ndjson([{"id": 1, "name": "x"}])
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    runs = mod.list_check_runs(REPO, "sha1")
+
+    assert "--paginate" in captured["cmd"]
+    assert runs == [{"id": 1, "name": "x"}]
 
 
 def test_sweep_times_out_only_stale_matching_checks(monkeypatch):
@@ -65,10 +107,10 @@ def test_sweep_times_out_only_stale_matching_checks(monkeypatch):
     patched = []
 
     def fake_run(cmd, **kwargs):
-        if "pulls?state=open" in cmd[2]:
-            return _completed(json.dumps(prs))
-        if "check-runs?per_page=100" in cmd[2]:
-            return _completed(json.dumps({"check_runs": check_runs}))
+        if _is_open_prs_call(cmd):
+            return _ndjson(prs)
+        if _is_check_runs_call(cmd):
+            return _ndjson(check_runs)
         if cmd[:3] == ["gh", "api", "--method"]:
             patched.append((cmd[4], json.loads(kwargs["input"])))
             return _completed("{}")
@@ -87,8 +129,8 @@ def test_sweep_times_out_only_stale_matching_checks(monkeypatch):
 
 def test_sweep_returns_empty_when_nothing_stale(monkeypatch):
     def fake_run(cmd, **kwargs):
-        if "pulls?state=open" in cmd[2]:
-            return _completed(json.dumps([]))
+        if _is_open_prs_call(cmd):
+            return _ndjson([])
         raise AssertionError(f"unexpected command: {cmd}")
 
     monkeypatch.setattr(mod, "run", fake_run)
@@ -121,10 +163,10 @@ def test_main_reports_timed_out_runs(monkeypatch, capsys):
     ]
 
     def fake_run(cmd, **kwargs):
-        if "pulls?state=open" in cmd[2]:
-            return _completed(json.dumps(prs))
-        if "check-runs?per_page=100" in cmd[2]:
-            return _completed(json.dumps({"check_runs": check_runs}))
+        if _is_open_prs_call(cmd):
+            return _ndjson(prs)
+        if _is_check_runs_call(cmd):
+            return _ndjson(check_runs)
         return _completed("{}")
 
     monkeypatch.setattr(mod, "run", fake_run)

--- a/.github/scripts/tests/test_verify_connector_gate_upstream.py
+++ b/.github/scripts/tests/test_verify_connector_gate_upstream.py
@@ -1,0 +1,132 @@
+"""Tests for .github/scripts/verify_connector_gate_upstream.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import verify_connector_gate_upstream as mod
+
+
+def test_evaluate_fails_when_changes_did_not_succeed():
+    error, dispatched = mod.evaluate("failure", "success", "success", "success")
+    assert error is not None
+    assert "Detect Changes" in error
+    assert dispatched is False
+
+
+def test_evaluate_fails_when_matrix_did_not_succeed():
+    error, _ = mod.evaluate("success", "failure", "success", "success")
+    assert error is not None
+    assert "Build Test Matrix" in error
+
+
+def test_evaluate_fails_when_base_image_failed():
+    error, _ = mod.evaluate("success", "success", "failure", "success")
+    assert error is not None
+    assert "Build SDK base image" in error
+
+
+def test_evaluate_allows_base_image_skipped():
+    error, dispatched = mod.evaluate("success", "success", "skipped", "success")
+    assert error is None
+    assert dispatched is True
+
+
+def test_evaluate_fails_when_connector_tests_failed():
+    error, _ = mod.evaluate("success", "success", "success", "failure")
+    assert error is not None
+    assert "Connector Tests dispatch" in error
+
+
+def test_evaluate_connector_skipped_is_ok_but_not_dispatched():
+    error, dispatched = mod.evaluate("success", "success", "success", "skipped")
+    assert error is None
+    assert dispatched is False
+
+
+def test_evaluate_connector_success_is_dispatched():
+    error, dispatched = mod.evaluate("success", "success", "success", "success")
+    assert error is None
+    assert dispatched is True
+
+
+def test_main_exits_1_on_upstream_failure(capsys):
+    rc = mod.main(
+        [
+            "--changes-result",
+            "failure",
+            "--matrix-result",
+            "success",
+            "--base-image-result",
+            "success",
+            "--connector-result",
+            "success",
+        ]
+    )
+    assert rc == 1
+    assert "::error::" in capsys.readouterr().out
+
+
+def test_main_writes_dispatched_true(tmp_path, monkeypatch):
+    output_file = tmp_path / "gh_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+    rc = mod.main(
+        [
+            "--changes-result",
+            "success",
+            "--matrix-result",
+            "success",
+            "--base-image-result",
+            "success",
+            "--connector-result",
+            "success",
+        ]
+    )
+
+    assert rc == 0
+    assert output_file.read_text() == "dispatched=true\n"
+
+
+def test_main_writes_dispatched_false_for_docs_only_skip(tmp_path, monkeypatch):
+    output_file = tmp_path / "gh_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+    rc = mod.main(
+        [
+            "--changes-result",
+            "success",
+            "--matrix-result",
+            "success",
+            "--base-image-result",
+            "skipped",
+            "--connector-result",
+            "skipped",
+        ]
+    )
+
+    assert rc == 0
+    assert output_file.read_text() == "dispatched=false\n"
+
+
+def test_main_prints_when_no_github_output(monkeypatch, capsys):
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    rc = mod.main(
+        [
+            "--changes-result",
+            "success",
+            "--matrix-result",
+            "success",
+            "--base-image-result",
+            "success",
+            "--connector-result",
+            "success",
+        ]
+    )
+
+    assert rc == 0
+    assert "dispatched=true" in capsys.readouterr().out

--- a/.github/scripts/timeout_stale_check_runs.py
+++ b/.github/scripts/timeout_stale_check_runs.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Watchdog for the cross-repo e2e callback pattern: time out any
+``Connector E2E / *`` check run that's been stuck ``in_progress`` past the
+window a connector run could legitimately still be running.
+
+This only matters when a connector runner dies before its ``report-to-sdk``
+callback step (complete_check_run.py) gets to run (crash, force-cancel,
+runner reclaim) — the check run would otherwise sit "in_progress" forever.
+It is *not* what makes a merge queue entry fail promptly: the gate job
+(poll_check_runs_gate.py) is bounded by its own timeout regardless. This is
+cosmetic-but-important cleanup so an abandoned PR doesn't show a permanently
+pending check.
+
+Sweeps open PRs only — a merge-queue gate resolves (and times out) within its
+own run, so there's nothing there to leak.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Single seam so tests can stub the `gh` CLI."""
+    return subprocess.run(cmd, **kwargs)
+
+
+def list_open_prs(repo: str) -> list[dict]:
+    result = run(
+        ["gh", "api", f"repos/{repo}/pulls?state=open&per_page=100"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"::error::failed to list open PRs for {repo}: {result.stderr}"
+        )
+    return json.loads(result.stdout)
+
+
+def list_check_runs(repo: str, sha: str) -> list[dict]:
+    result = run(
+        ["gh", "api", f"repos/{repo}/commits/{sha}/check-runs?per_page=100"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"::error::failed to list check runs for {repo}@{sha}: {result.stderr}"
+        )
+    return json.loads(result.stdout).get("check_runs", [])
+
+
+def is_stale(check_run: dict, max_age: timedelta, now: datetime) -> bool:
+    if check_run.get("status") != "in_progress":
+        return False
+    started = check_run.get("started_at")
+    if not started:
+        return False
+    started_dt = datetime.fromisoformat(started.replace("Z", "+00:00"))
+    return (now - started_dt) > max_age
+
+
+def timeout_check_run(repo: str, check_run_id: int, name: str) -> None:
+    payload = {
+        "status": "completed",
+        "completed_at": now_iso(),
+        "conclusion": "timed_out",
+        "output": {
+            "title": name,
+            "summary": (
+                "Timed out by the e2e-callback watchdog: no completion signal "
+                "arrived within the expected window. The connector run likely "
+                "crashed or was cancelled before it could report back."
+            ),
+        },
+    }
+    result = run(
+        [
+            "gh",
+            "api",
+            "--method",
+            "PATCH",
+            f"repos/{repo}/check-runs/{check_run_id}",
+            "--input",
+            "-",
+        ],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"::error::failed to time out check run {check_run_id} on {repo}: {result.stderr}"
+        )
+
+
+def sweep(
+    repo: str,
+    name_prefix: str,
+    max_age_minutes: int,
+    *,
+    now: datetime | None = None,
+) -> list[str]:
+    """Time out stale check runs across every open PR. Returns the list of
+    'name (PR #n)' descriptions that were timed out, for logging."""
+    now = now or datetime.now(timezone.utc)
+    max_age = timedelta(minutes=max_age_minutes)
+    timed_out = []
+
+    for pr in list_open_prs(repo):
+        sha = pr["head"]["sha"]
+        for check_run in list_check_runs(repo, sha):
+            name = check_run.get("name", "")
+            if not name.startswith(name_prefix):
+                continue
+            if is_stale(check_run, max_age, now):
+                timeout_check_run(repo, check_run["id"], name)
+                timed_out.append(f"{name} (PR #{pr['number']})")
+
+    return timed_out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo", required=True, help="owner/repo, e.g. atlanhq/application-sdk"
+    )
+    parser.add_argument("--name-prefix", default="Connector E2E / ")
+    parser.add_argument(
+        "--max-age-minutes",
+        type=int,
+        default=130,
+        help="Age past which an in_progress check is considered stuck (default 130min, "
+        "safely above the 120min connector job ceiling).",
+    )
+    args = parser.parse_args(argv)
+
+    timed_out = sweep(args.repo, args.name_prefix, args.max_age_minutes)
+    if timed_out:
+        print(f"Timed out {len(timed_out)} stuck check run(s): {timed_out}")
+    else:
+        print("No stuck check runs found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/timeout_stale_check_runs.py
+++ b/.github/scripts/timeout_stale_check_runs.py
@@ -34,8 +34,19 @@ def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
 
 
 def list_open_prs(repo: str) -> list[dict]:
+    # --paginate follows Link: rel="next" across pages; --jq + tojson prints
+    # one compact JSON object per PR regardless of page count, so a repo
+    # with >100 open PRs doesn't silently lose the watchdog's coverage of
+    # the rest.
     result = run(
-        ["gh", "api", f"repos/{repo}/pulls?state=open&per_page=100"],
+        [
+            "gh",
+            "api",
+            "--paginate",
+            f"repos/{repo}/pulls?state=open&per_page=100",
+            "--jq",
+            ".[] | tojson",
+        ],
         capture_output=True,
         text=True,
         check=False,
@@ -44,12 +55,21 @@ def list_open_prs(repo: str) -> list[dict]:
         raise SystemExit(
             f"::error::failed to list open PRs for {repo}: {result.stderr}"
         )
-    return json.loads(result.stdout)
+    return [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
 
 
 def list_check_runs(repo: str, sha: str) -> list[dict]:
+    # Same pagination rationale as list_open_prs, applied to the nested
+    # `check_runs` array.
     result = run(
-        ["gh", "api", f"repos/{repo}/commits/{sha}/check-runs?per_page=100"],
+        [
+            "gh",
+            "api",
+            "--paginate",
+            f"repos/{repo}/commits/{sha}/check-runs?per_page=100",
+            "--jq",
+            ".check_runs[] | tojson",
+        ],
         capture_output=True,
         text=True,
         check=False,
@@ -58,7 +78,7 @@ def list_check_runs(repo: str, sha: str) -> list[dict]:
         raise SystemExit(
             f"::error::failed to list check runs for {repo}@{sha}: {result.stderr}"
         )
-    return json.loads(result.stdout).get("check_runs", [])
+    return [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
 
 
 def is_stale(check_run: dict, max_age: timedelta, now: datetime) -> bool:

--- a/.github/scripts/verify_connector_gate_upstream.py
+++ b/.github/scripts/verify_connector_gate_upstream.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Verify the upstream jobs the connector e2e gate (Connector Tests Gate)
+depends on, before deciding whether there's anything left to wait on.
+
+Moved out of an inlined `run:` block per docs/standards/ci.md: this is a
+chain of conditional checks, which belongs in a tested driver rather than
+workflow YAML.
+
+Fail-closed, mirroring SDK Gate: connector-tests is skipped both
+legitimately (docs-only PR: sdk==false && container==false) AND on upstream
+failure (matrix-builder failed, or the e2e-path base build failed). A naive
+"skipped -> pass" would go green when ZERO connector tests ran because an
+upstream job died. So changes + matrix-builder must have SUCCEEDED and
+build-sdk-base-image must be success|skipped (never failure) before treating
+a skipped connector-tests as the genuine docs-only skip.
+
+connector-tests now only dispatches (e2e-apps wait-mode: callback) — its own
+success means "dispatch succeeded", not "tests passed". The actual pass/fail
+lands later via the check runs each connector completes directly
+(tests-reusable.yaml's report-to-sdk job); "dispatched" here just tells the
+caller whether there's anything to poll for.
+
+Exits 1 (with an ::error:: line) if any upstream job failed. On success,
+writes dispatched=true|false to $GITHUB_OUTPUT.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+OK_BASE_IMAGE_RESULTS = {"success", "skipped"}
+OK_CONNECTOR_RESULTS = {"success", "skipped"}
+
+
+def evaluate(
+    changes_result: str,
+    matrix_result: str,
+    base_image_result: str,
+    connector_result: str,
+) -> tuple[str | None, bool]:
+    """Returns (error_message, dispatched). error_message is None on success."""
+    if changes_result != "success":
+        return (
+            f"Detect Changes did not succeed ({changes_result}) — failing the gate closed.",
+            False,
+        )
+    if matrix_result != "success":
+        return (
+            f"Build Test Matrix did not succeed ({matrix_result}) — failing the gate closed.",
+            False,
+        )
+    if base_image_result not in OK_BASE_IMAGE_RESULTS:
+        return (
+            f"Build SDK base image did not succeed ({base_image_result}) — failing the gate closed.",
+            False,
+        )
+    if connector_result not in OK_CONNECTOR_RESULTS:
+        return (
+            f"Connector Tests dispatch did not succeed ({connector_result}) — failing the gate.",
+            False,
+        )
+    return None, connector_result == "success"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--changes-result", required=True)
+    parser.add_argument("--matrix-result", required=True)
+    parser.add_argument("--base-image-result", required=True)
+    parser.add_argument("--connector-result", required=True)
+    args = parser.parse_args(argv)
+
+    error, dispatched = evaluate(
+        args.changes_result,
+        args.matrix_result,
+        args.base_image_result,
+        args.connector_result,
+    )
+    if error:
+        print(f"::error::{error}")
+        return 1
+
+    if dispatched:
+        print("Connector Tests dispatched — waiting on check runs.")
+    else:
+        print("✓ Connector Tests skipped (docs-only) — nothing to wait on.")
+
+    line = f"dispatched={'true' if dispatched else 'false'}"
+    github_output = os.environ.get("GITHUB_OUTPUT", "")
+    if github_output:
+        with open(github_output, "a") as fh:
+            fh.write(line + "\n")
+    else:
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/e2e-callback-watchdog.yml
+++ b/.github/workflows/e2e-callback-watchdog.yml
@@ -1,0 +1,48 @@
+name: E2E Callback Watchdog
+
+# Safety net for the cross-repo e2e callback pattern (see e2e-apps'
+# wait-mode: callback and tests-reusable.yaml's report-to-sdk job).
+#
+# Each connector reports back by PATCHing its own 'Connector E2E / <repo>'
+# check run to completed the instant its run finishes — there's no polling
+# on the happy path. But if a connector runner dies before that callback
+# step runs (crash, force-cancel, runner reclaim), the check run is left
+# 'in_progress' forever. That's cosmetic, not a merge-blocking risk — the
+# required Connector Tests Gate (pull_request.yaml) has its own bounded
+# poll timeout regardless — but an abandoned PR showing a permanently
+# pending check is confusing, so this sweeps them out periodically.
+#
+# 15-minute cadence, one call per open PR plus one per stale check found —
+# negligible against github.token's own rate-limit bucket regardless of how
+# many connectors or PRs are open.
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
+concurrency:
+  group: e2e-callback-watchdog
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Time out stuck connector check runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Sweep for stale check runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/scripts/timeout_stale_check_runs.py \
+            --repo "${{ github.repository }}"

--- a/.github/workflows/e2e-callback-watchdog.yml
+++ b/.github/workflows/e2e-callback-watchdog.yml
@@ -34,6 +34,11 @@ jobs:
   sweep:
     name: Time out stuck connector check runs
     runs-on: ubuntu-latest
+    # Without an explicit ceiling this inherits GitHub's 6h default. Paired
+    # with concurrency: cancel-in-progress: false, a hung run (stuck gh api
+    # call, network partition) would then queue up every subsequent 15-min
+    # cron tick behind it instead of just skipping a cycle.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -11,11 +11,6 @@ permissions:
   pull-requests: write
   issues: write
   security-events: write
-  # Connector E2E callback pattern (e2e-apps wait-mode: callback):
-  # connector-tests creates an in_progress check run on github.token's own
-  # rate-limit bucket; connector-gate polls it back via the same token
-  # (checks:write covers read too). See docs/standards/ci.md.
-  checks: write
 
 jobs:
   # Detect which files changed
@@ -304,6 +299,14 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
+    # Least-privilege override: this is the only job that creates check runs
+    # (e2e-apps wait-mode: callback, via github.token — see docs/standards/ci.md),
+    # so checks:write is scoped here instead of at workflow level. A job-level
+    # permissions block replaces rather than merges with the workflow
+    # defaults, so contents:read is repeated here for the checkout step.
+    permissions:
+      contents: read
+      checks: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrix-builder.outputs.matrix) }}
@@ -424,6 +427,7 @@ jobs:
           MATRIX_JSON: ${{ needs.matrix-builder.outputs.matrix }}
           SHA: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
         run: |
+          set -euo pipefail
           NAMES_JSON=$(jq -c '[.include[] | "Connector E2E / " + .repo_name]' <<< "$MATRIX_JSON")
           python3 .github/scripts/poll_check_runs_gate.py \
             --repo "${{ github.repository }}" \

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -388,6 +388,8 @@ jobs:
       contents: read
       checks: read
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
       # connector-tests now only dispatches (e2e-apps wait-mode: callback) —
       # its own success means "dispatch succeeded", not "tests passed". The
       # actual pass/fail lands later via the Connector E2E / <repo> check
@@ -402,40 +404,11 @@ jobs:
           BASE_IMAGE_RESULT: ${{ needs.build-sdk-base-image.result }}
           CONNECTOR_RESULT: ${{ needs.connector-tests.result }}
         run: |
-          set -euo pipefail
-          # Detection / matrix build have no path-skip — anything other than
-          # success means we cannot trust whether the connector legs ran. A
-          # connector-tests skip downstream of these would then be an
-          # upstream-failure skip, not the docs-only skip. Fail closed.
-          if [[ "$CHANGES_RESULT" != "success" ]]; then
-            echo "::error::Detect Changes did not succeed ($CHANGES_RESULT) — failing the gate closed."
-            exit 1
-          fi
-          if [[ "$MATRIX_RESULT" != "success" ]]; then
-            echo "::error::Build Test Matrix did not succeed ($MATRIX_RESULT) — failing the gate closed."
-            exit 1
-          fi
-          # build-sdk-base-image is legitimately skipped on merge_group and on
-          # non-e2e PRs; only a genuine build FAILURE must block (a base that
-          # won't build is the signal, per the connector-tests if: comment).
-          if [[ "$BASE_IMAGE_RESULT" != "success" && "$BASE_IMAGE_RESULT" != "skipped" ]]; then
-            echo "::error::Build SDK base image did not succeed ($BASE_IMAGE_RESULT) — failing the gate closed."
-            exit 1
-          fi
-          if [[ "$CONNECTOR_RESULT" != "success" && "$CONNECTOR_RESULT" != "skipped" ]]; then
-            echo "::error::Connector Tests dispatch did not succeed ($CONNECTOR_RESULT) — failing the gate."
-            exit 1
-          fi
-          # With upstream proven healthy, a skipped connector-tests is the
-          # genuine docs-only skip (sdk==false && container==false) → pass
-          # with nothing to wait on. dispatched=true only when check runs
-          # actually exist to poll.
-          if [[ "$CONNECTOR_RESULT" == "success" ]]; then
-            echo "dispatched=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "dispatched=false" >> "$GITHUB_OUTPUT"
-            echo "✓ Connector Tests skipped (docs-only) — nothing to wait on."
-          fi
+          python3 .github/scripts/verify_connector_gate_upstream.py \
+            --changes-result "$CHANGES_RESULT" \
+            --matrix-result "$MATRIX_RESULT" \
+            --base-image-result "$BASE_IMAGE_RESULT" \
+            --connector-result "$CONNECTOR_RESULT"
 
       # Rolls up every 'Connector E2E / <repo>' check run in ONE endpoint
       # call per poll (not one busy-poll per matrix leg), using conditional

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -11,6 +11,11 @@ permissions:
   pull-requests: write
   issues: write
   security-events: write
+  # Connector E2E callback pattern (e2e-apps wait-mode: callback):
+  # connector-tests creates an in_progress check run on github.token's own
+  # rate-limit bucket; connector-gate polls it back via the same token
+  # (checks:write covers read too). See docs/standards/ci.md.
+  checks: write
 
 jobs:
   # Detect which files changed
@@ -311,6 +316,9 @@ jobs:
           target-branch: "refs/heads/${{ matrix.target_branch }}"
           workflow: tests.yaml
           workflow-inputs: ${{ github.event_name == 'merge_group' && format('{{"application_sdk_ref":"{0}"}}', github.sha) || format('{{"application_sdk_ref":"{0}","run_e2e":"true","base_image_ref":"{1}"}}', github.event.pull_request.head.sha, needs.build-sdk-base-image.outputs.image) }}
+          wait-mode: callback
+          check-run-name: "Connector E2E / ${{ matrix.repo_name }}"
+          check-sha: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
 
   # SDR-on-Kubernetes e2e — dispatched cross-repo to atlan-local-marketplace-app,
   # which owns the orchestrator + charts and runs the hermetic kind e2e. LM
@@ -350,6 +358,11 @@ jobs:
           target-branch: "refs/heads/main"
           workflow: sdr-k8s-e2e.yaml
           workflow-inputs: ${{ github.event_name == 'merge_group' && format('{{"application_sdk_ref":"{0}"}}', github.sha) || format('{{"application_sdk_ref":"{0}"}}', github.event.pull_request.head.sha) }}
+          # sdr-k8s-e2e.yaml (atlan-local-marketplace-app) doesn't yet report
+          # back via the Checks API callback — stays on the legacy busy-poll
+          # until that's added there too. Explicit so it doesn't silently
+          # inherit a future default change.
+          wait-mode: poll
 
   # ── The single required check for the connector e2e area ────────────────────
   # Always runs and always concludes, so branch protection / the merge queue can
@@ -371,8 +384,18 @@ jobs:
     needs: [changes, matrix-builder, build-sdk-base-image, connector-tests]
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: read
     steps:
-      - name: Evaluate connector e2e area
+      # connector-tests now only dispatches (e2e-apps wait-mode: callback) —
+      # its own success means "dispatch succeeded", not "tests passed". The
+      # actual pass/fail lands later via the Connector E2E / <repo> check
+      # runs that each connector completes directly (tests-reusable.yaml's
+      # report-to-sdk job); this step still validates the upstream chain
+      # that had to succeed for those checks to exist at all.
+      - name: Verify upstream jobs + dispatch succeeded
+        id: upstream
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
           MATRIX_RESULT: ${{ needs.matrix-builder.result }}
@@ -399,15 +422,40 @@ jobs:
             echo "::error::Build SDK base image did not succeed ($BASE_IMAGE_RESULT) — failing the gate closed."
             exit 1
           fi
-          # With upstream proven healthy, a skipped connector-tests is the
-          # genuine docs-only skip (sdk==false && container==false) → pass.
-          if [[ "$CONNECTOR_RESULT" == "success" || "$CONNECTOR_RESULT" == "skipped" ]]; then
-            echo "✓ Connector Tests: $CONNECTOR_RESULT"
-            echo "Connector gate passed."
-          else
-            echo "::error::Connector Tests did not pass ($CONNECTOR_RESULT) — failing the gate."
+          if [[ "$CONNECTOR_RESULT" != "success" && "$CONNECTOR_RESULT" != "skipped" ]]; then
+            echo "::error::Connector Tests dispatch did not succeed ($CONNECTOR_RESULT) — failing the gate."
             exit 1
           fi
+          # With upstream proven healthy, a skipped connector-tests is the
+          # genuine docs-only skip (sdk==false && container==false) → pass
+          # with nothing to wait on. dispatched=true only when check runs
+          # actually exist to poll.
+          if [[ "$CONNECTOR_RESULT" == "success" ]]; then
+            echo "dispatched=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dispatched=false" >> "$GITHUB_OUTPUT"
+            echo "✓ Connector Tests skipped (docs-only) — nothing to wait on."
+          fi
+
+      # Rolls up every 'Connector E2E / <repo>' check run in ONE endpoint
+      # call per poll (not one busy-poll per matrix leg), using conditional
+      # requests so an unchanged poll doesn't count against the rate limit.
+      # Each check flips the instant its connector's own run reports back
+      # (tests-reusable.yaml's report-to-sdk job) — this only has to notice
+      # that within one poll interval, not sit through a whole poll cycle
+      # itself.
+      - name: Wait for connector check runs to complete
+        if: steps.upstream.outputs.dispatched == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MATRIX_JSON: ${{ needs.matrix-builder.outputs.matrix }}
+          SHA: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
+        run: |
+          NAMES_JSON=$(jq -c '[.include[] | "Connector E2E / " + .repo_name]' <<< "$MATRIX_JSON")
+          python3 .github/scripts/poll_check_runs_gate.py \
+            --repo "${{ github.repository }}" \
+            --sha "$SHA" \
+            --names-json "$NAMES_JSON"
 
   # Real-cloud storage integration tests (S3 / Azure / GCS) — exercise
   # create_store_from_binding + CloudStore against real buckets/vaults using the

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -197,11 +197,16 @@ jobs:
     permissions:
       contents: read
     steps:
+      # Pinned to the exact SHA that dispatched this run (not `main`): that
+      # SHA is what created the check run we're about to complete, so the
+      # callback script version can never drift from it. Also required for
+      # this PR itself to be testable pre-merge — the callback scripts don't
+      # exist on `main` until this PR lands.
       - name: Checkout application-sdk callback script
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: atlanhq/application-sdk
-          ref: main
+          ref: ${{ inputs.application-sdk-ref }}
           token: ${{ secrets.ORG_PAT_GITHUB }}
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
@@ -217,32 +222,15 @@ jobs:
 
       - name: Determine conclusion + build summary
         id: report
-        shell: bash
         env:
           TESTS_RESULT: ${{ needs.tests.result }}
           E2E_RESULT: ${{ needs.e2e.result }}
           TESTS_SUMMARY: ${{ needs.tests.outputs.summary }}
         run: |
-          if [ "$TESTS_RESULT" = "success" ] && { [ "$E2E_RESULT" = "success" ] || [ "$E2E_RESULT" = "skipped" ]; }; then
-            echo "conclusion=success" >> "$GITHUB_OUTPUT"
-          else
-            echo "conclusion=failure" >> "$GITHUB_OUTPUT"
-          fi
-
-          # Prefer the e2e leg's already-rendered report (asset/lineage
-          # tables etc.); fall back to a plain summary when e2e was
-          # skipped or its artifact didn't materialise.
-          if [ -f connector-results/pr-comment-body.md ]; then
-            echo "summary_file=connector-results/pr-comment-body.md" >> "$GITHUB_OUTPUT"
-          else
-            {
-              echo "## Tests Summary"
-              echo ""
-              echo "**tests:** ${TESTS_RESULT} (${TESTS_SUMMARY:-no summary})"
-              echo "**e2e:** ${E2E_RESULT}"
-            } > fallback-summary.md
-            echo "summary_file=fallback-summary.md" >> "$GITHUB_OUTPUT"
-          fi
+          python3 application-sdk-scripts/.github/scripts/build_callback_summary.py \
+            --tests-result "$TESTS_RESULT" \
+            --e2e-result "$E2E_RESULT" \
+            --tests-summary "$TESTS_SUMMARY"
 
       - name: Complete the check run on application-sdk
         env:

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -179,6 +179,86 @@ jobs:
       distinct-id: ${{ inputs.distinct-id }}
     secrets: inherit
 
+  # ── Callback: report the result back to the application-sdk PR/commit ────
+  # that dispatched this run. application-sdk's e2e-apps composite
+  # (wait-mode: callback) creates an in_progress check run on its own SHA
+  # before dispatching, then exits without polling; this job is the push
+  # that completes it the instant this run finishes — no polling on either
+  # side. Only fires on the cross-repo dispatch path: application-sdk-ref is
+  # empty on the connector's own same-repo pull_request/push runs.
+  report-to-sdk:
+    name: Report to application-sdk
+    needs: [tests, e2e]
+    if: |
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      inputs.application-sdk-ref != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout application-sdk callback script
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: atlanhq/application-sdk
+          ref: main
+          token: ${{ secrets.ORG_PAT_GITHUB }}
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+          path: application-sdk-scripts
+
+      - name: Download connector e2e results
+        if: needs.e2e.result != 'skipped'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        continue-on-error: true
+        with:
+          name: sdr-integration-tests-${{ inputs.app-name }}-results
+          path: connector-results
+
+      - name: Determine conclusion + build summary
+        id: report
+        shell: bash
+        env:
+          TESTS_RESULT: ${{ needs.tests.result }}
+          E2E_RESULT: ${{ needs.e2e.result }}
+          TESTS_SUMMARY: ${{ needs.tests.outputs.summary }}
+        run: |
+          if [ "$TESTS_RESULT" = "success" ] && { [ "$E2E_RESULT" = "success" ] || [ "$E2E_RESULT" = "skipped" ]; }; then
+            echo "conclusion=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "conclusion=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Prefer the e2e leg's already-rendered report (asset/lineage
+          # tables etc.); fall back to a plain summary when e2e was
+          # skipped or its artifact didn't materialise.
+          if [ -f connector-results/pr-comment-body.md ]; then
+            echo "summary_file=connector-results/pr-comment-body.md" >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "## Tests Summary"
+              echo ""
+              echo "**tests:** ${TESTS_RESULT} (${TESTS_SUMMARY:-no summary})"
+              echo "**e2e:** ${E2E_RESULT}"
+            } > fallback-summary.md
+            echo "summary_file=fallback-summary.md" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Complete the check run on application-sdk
+        env:
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          SHA: ${{ inputs.application-sdk-ref }}
+          REPO_SHORT: ${{ github.event.repository.name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 application-sdk-scripts/.github/scripts/complete_check_run.py \
+            --repo atlanhq/application-sdk \
+            --sha "$SHA" \
+            --name "Connector E2E / ${REPO_SHORT}" \
+            --conclusion "${{ steps.report.outputs.conclusion }}" \
+            --summary-file "${{ steps.report.outputs.summary_file }}" \
+            --details-url "$RUN_URL"
+
   # ── Aggregator gate (single required check for branch protection) ────────
   tests-passed:
     name: Tests Gate


### PR DESCRIPTION
## Summary
- Connector e2e dispatch (the `connector-tests` matrix in `pull_request.yaml`) busy-polled each dispatched run's status every 60s for up to 2h, all against the shared org PAT (`ORG_PAT_GITHUB`) — exhausting its 5,000/hr rate limit under concurrent PRs and failing dispatch on the very first API call (see run 28740160967, `API rate limit exceeded for user ID 62283865`).
- Replaces polling with a push-based callback via the GitHub Checks API:
  - `e2e-apps` gains a `wait-mode` input. In `callback` mode it creates an `in_progress` check run on the SDK PR's own SHA (`github.token`'s own rate-limit bucket, not the shared PAT), dispatches the connector workflow, and exits immediately — no polling, no artifact fetch, no PR comment.
  - `tests-reusable.yaml` gains a `report-to-sdk` job: the connector PATCHes that check run to `completed` the instant its own run finishes, reusing the report `sdr-e2e` already renders. **No connector-repo edits needed** — every connector's `tests.yaml` already delegates to this reusable workflow.
  - `connector-gate` ("Test Gate") rolls up the async check runs via one ETag-conditional endpoint call per poll (not one busy-poll per matrix leg), so unchanged polls don't count against the rate limit either.
  - A new 15-minute cron watchdog (`e2e-callback-watchdog.yml`) times out any check left stuck `in_progress` if a connector runner dies before its callback step runs.
- `sdr-k8s-e2e` (dispatches to `atlan-local-marketplace-app`) stays on the legacy `wait-mode: poll` until that repo gets the same callback treatment — tracked as a follow-up.

## Test plan
- [x] `uv run pre-commit run --all-files` — clean
- [x] `uv run python -m pytest tests/unit -x -q` — 5313 passed, 9 skipped
- [x] `uv run --extra workflows --with pytest python -m pytest .github/scripts/tests -q` — 446 passed (all new scripts unit-tested: `create_check_run.py`, `complete_check_run.py`, `dispatch_workflow.py`, `poll_check_runs_gate.py`, `timeout_stale_check_runs.py`)
- [x] All touched/new YAML validated with `yaml.safe_load`
- [ ] `actionlint` wasn't available in the dev sandbox — worth a pass before merge, or validate via a real dispatch on this PR with the `e2e` label:
  - [ ] Each `connector-tests` leg finishes in <1 min (dispatch-and-exit)
  - [ ] A `Connector E2E / <repo>` check appears `in_progress` immediately, then flips to success/failure the moment each connector run completes
  - [ ] The Test Gate resolves shortly after the last connector finishes
  - [ ] `gh api rate_limit` shows the e2e path consuming only a few calls per leg, not ~125