### PR TITLE
ci(perf): replace per-repo gh pr list loop with batched GraphQL search

### DIFF
--- a/.github/scripts/renovate_fleet_scan.py
+++ b/.github/scripts/renovate_fleet_scan.py
@@ -100,6 +100,7 @@ def build_graphql_payload(search_query: str, fields: str, after: Optional[str]) 
     query = f"""
     query {{
       search(query: {json.dumps(search_query)}, type: ISSUE, first: {PAGE_SIZE}{after_arg}) {{
+        issueCount
         pageInfo {{ hasNextPage endCursor }}
         nodes {{
           ... on PullRequest {{
@@ -139,8 +140,10 @@ def fetch_all_prs(
     fields: str,
     post: PostFn = _post_graphql,
 ) -> list[dict]:
-    """Paginate a GraphQL PR search to completion. Raises on a GraphQL 'errors' response."""
+    """Paginate a GraphQL PR search to completion. Raises on a GraphQL 'errors' response,
+    or if the result was silently truncated by the search API's ~1000-item hard cap."""
     nodes: list[dict] = []
+    issue_count: Optional[int] = None
     after: Optional[str] = None
     for _ in range(MAX_PAGES):
         payload = build_graphql_payload(search_query, fields, after)
@@ -150,6 +153,8 @@ def fetch_all_prs(
                 f"GraphQL errors for query {search_query!r}: {data['errors']}"
             )
         search = data["data"]["search"]
+        if issue_count is None:
+            issue_count = search["issueCount"]
         nodes.extend(search["nodes"])
         page_info = search["pageInfo"]
         if not page_info["hasNextPage"]:
@@ -159,6 +164,14 @@ def fetch_all_prs(
         raise RuntimeError(
             f"exceeded {MAX_PAGES} pages for query {search_query!r} "
             "— fleet larger than the safety backstop expects"
+        )
+
+    if issue_count is not None and len(nodes) < issue_count:
+        raise RuntimeError(
+            f"query {search_query!r} matched {issue_count} results but only "
+            f"{len(nodes)} were returned — the search API's result cap likely "
+            "truncated this query. Narrow it (e.g. split by date range) rather "
+            "than silently reporting incomplete dashboard data."
         )
     return nodes
 
@@ -287,7 +300,11 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument(
         "--repo",
         default=None,
-        help="single repo to scan instead of the whole org, e.g. 'atlanhq/atlan-mysql-app'",
+        help=(
+            "single repo to scan instead of the whole org, e.g. 'atlanhq/atlan-mysql-app'. "
+            "Safe to always pass (even as an empty string) — resolve_scope() falls back to "
+            "--org whenever this is empty/unset."
+        ),
     )
     parser.add_argument(
         "--since",

--- a/.github/scripts/renovate_fleet_scan.py
+++ b/.github/scripts/renovate_fleet_scan.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Fetch open + recently-merged Renovate PRs across the fleet via GraphQL search.
+
+Replaces the O(repos x 2) `gh pr list` REST loop in renovate-dashboard.yaml with a
+constant-ish number of paginated GraphQL search queries (one search covers every repo
+in scope at once), so the workflow's GitHub API call count no longer scales with fleet
+size. Output is written in the exact per-repo JSON file layout that
+`conformance renovate-scan --input/--merged` already expects — see
+packages/conformance/conformance/renovate/scan.py `_parse_pr` / `_auto_merge_stats` for
+the consuming schema this script must match.
+
+Environment:
+    GH_TOKEN   bearer token (GitHub App installation token or PAT) for api.github.com
+
+Usage:
+    renovate_fleet_scan.py --org atlanhq --since 2026-06-06 \\
+        --open-dir /tmp/renovate-input/open --merged-dir /tmp/renovate-input/merged \\
+        --known-repos-file /tmp/repos.json
+
+    renovate_fleet_scan.py --org atlanhq --repo atlanhq/atlan-mysql-app --since 2026-06-06 \\
+        --open-dir /tmp/renovate-input/open --merged-dir /tmp/renovate-input/merged \\
+        --known-repos-file /tmp/repos.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Callable, Optional
+
+GRAPHQL_URL = "https://api.github.com/graphql"
+PAGE_SIZE = 100
+# Safety backstop, not a real ceiling: 50 pages x 100 = 5000 PRs in one search window,
+# far beyond any realistic fleet. Trips only if a query is unexpectedly unbounded.
+MAX_PAGES = 50
+
+_OPEN_PR_FIELDS = """
+number
+url
+title
+createdAt
+updatedAt
+headRefName
+isDraft
+body
+mergeable
+reviewDecision
+repository { nameWithOwner }
+labels(first: 20) { nodes { name } }
+files(first: 100) { nodes { path } }
+commits(last: 1) {
+  nodes {
+    commit {
+      statusCheckRollup {
+        contexts(first: 100) {
+          nodes {
+            __typename
+            ... on StatusContext { state }
+            ... on CheckRun { conclusion status }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+_MERGED_PR_FIELDS = """
+url
+repository { nameWithOwner }
+reviews(first: 50) {
+  nodes {
+    state
+    body
+    author { login }
+  }
+}
+"""
+
+PostFn = Callable[[str, dict], dict]
+
+
+def resolve_scope(org: str, repo: Optional[str]) -> str:
+    """Single-repo mode (repo set) scopes to that repo; otherwise scope to the whole org."""
+    return f"repo:{repo}" if repo else f"org:{org}"
+
+
+def build_search_query(scope: str, extra: str) -> str:
+    """Build a GitHub search-syntax query, e.g. 'org:atlanhq is:pr author:app/renovate is:open'."""
+    return f"{scope} is:pr author:app/renovate {extra}".strip()
+
+
+def build_graphql_payload(search_query: str, fields: str, after: Optional[str]) -> dict:
+    after_arg = f", after: {json.dumps(after)}" if after else ""
+    query = f"""
+    query {{
+      search(query: {json.dumps(search_query)}, type: ISSUE, first: {PAGE_SIZE}{after_arg}) {{
+        pageInfo {{ hasNextPage endCursor }}
+        nodes {{
+          ... on PullRequest {{
+            {fields}
+          }}
+        }}
+      }}
+    }}
+    """
+    return {"query": query}
+
+
+def _post_graphql(token: str, payload: dict) -> dict:
+    req = urllib.request.Request(
+        GRAPHQL_URL,
+        data=json.dumps(payload).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/vnd.github+json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        raise RuntimeError(
+            f"GraphQL request failed: {exc.code} {exc.reason}: {body}"
+        ) from exc
+
+
+def fetch_all_prs(
+    token: str,
+    search_query: str,
+    fields: str,
+    post: PostFn = _post_graphql,
+) -> list[dict]:
+    """Paginate a GraphQL PR search to completion. Raises on a GraphQL 'errors' response."""
+    nodes: list[dict] = []
+    after: Optional[str] = None
+    for _ in range(MAX_PAGES):
+        payload = build_graphql_payload(search_query, fields, after)
+        data = post(token, payload)
+        if "errors" in data:
+            raise RuntimeError(
+                f"GraphQL errors for query {search_query!r}: {data['errors']}"
+            )
+        search = data["data"]["search"]
+        nodes.extend(search["nodes"])
+        page_info = search["pageInfo"]
+        if not page_info["hasNextPage"]:
+            break
+        after = page_info["endCursor"]
+    else:
+        raise RuntimeError(
+            f"exceeded {MAX_PAGES} pages for query {search_query!r} "
+            "— fleet larger than the safety backstop expects"
+        )
+    return nodes
+
+
+def _status_rollup_to_list(pr: dict) -> list[dict]:
+    """Flatten a PullRequest node's last-commit statusCheckRollup to the shape
+    `conformance.renovate.scan._parse_checks_state` expects: a list of either
+    {"state": ...} (StatusContext) or {"conclusion": ..., "status": ...} (CheckRun) dicts.
+    """
+    commits = (pr.get("commits") or {}).get("nodes") or []
+    if not commits:
+        return []
+    rollup = ((commits[0] or {}).get("commit") or {}).get("statusCheckRollup")
+    if not rollup:
+        return []
+    out: list[dict] = []
+    for ctx in (rollup.get("contexts") or {}).get("nodes") or []:
+        if ctx.get("__typename") == "StatusContext":
+            out.append({"state": ctx.get("state")})
+        else:  # CheckRun
+            out.append(
+                {"conclusion": ctx.get("conclusion"), "status": ctx.get("status")}
+            )
+    return out
+
+
+def normalize_open_pr(pr: dict) -> dict:
+    """Map a GraphQL PullRequest node to the `gh pr list --json ...` shape renovate-scan expects."""
+    return {
+        "number": pr["number"],
+        "url": pr["url"],
+        "title": pr["title"],
+        "headRefName": pr.get("headRefName") or "",
+        "labels": [
+            {"name": lb["name"]} for lb in (pr.get("labels") or {}).get("nodes") or []
+        ],
+        "mergeable": pr.get("mergeable") or "UNKNOWN",
+        "reviewDecision": pr.get("reviewDecision"),
+        "statusCheckRollup": _status_rollup_to_list(pr),
+        "files": [
+            {"path": f["path"]} for f in (pr.get("files") or {}).get("nodes") or []
+        ],
+        "createdAt": pr["createdAt"],
+        "updatedAt": pr["updatedAt"],
+        "isDraft": bool(pr.get("isDraft") or False),
+        "body": pr.get("body") or "",
+    }
+
+
+def normalize_merged_pr(pr: dict) -> dict:
+    """Map a GraphQL PullRequest node to the subset of `gh pr list --json ...` fields
+    `conformance.renovate.scan._auto_merge_stats` actually reads (only `reviews`)."""
+    return {
+        "reviews": [
+            {
+                "state": r.get("state"),
+                "body": r.get("body"),
+                "author": {"login": (r.get("author") or {}).get("login")},
+            }
+            for r in (pr.get("reviews") or {}).get("nodes") or []
+        ],
+    }
+
+
+def group_by_repo(
+    prs: list[dict], normalize: Callable[[dict], dict]
+) -> dict[str, list[dict]]:
+    grouped: dict[str, list[dict]] = {}
+    for pr in prs:
+        repo = pr["repository"]["nameWithOwner"]
+        grouped.setdefault(repo, []).append(normalize(pr))
+    return grouped
+
+
+def slug_for(repo: str) -> str:
+    return repo.replace("/", "_")
+
+
+def write_repo_files(
+    grouped: dict[str, list[dict]], out_dir: Path, known_repos: list[str]
+) -> None:
+    """Write one <slug>.json per repo. Repos with no matching PRs still get a `[]`
+    file as long as they're in `known_repos`, preserving the "0 PRs = up to date"
+    vs. "not configured" distinction the dashboard relies on."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for repo in set(known_repos) | set(grouped):
+        path = out_dir / f"{slug_for(repo)}.json"
+        path.write_text(json.dumps(grouped.get(repo, [])))
+
+
+def run(
+    scope: str,
+    since: str,
+    open_dir: Path,
+    merged_dir: Path,
+    known_repos: list[str],
+    token: str,
+    post: PostFn = _post_graphql,
+) -> tuple[dict[str, list[dict]], dict[str, list[dict]]]:
+    open_nodes = fetch_all_prs(
+        token, build_search_query(scope, "is:open"), _OPEN_PR_FIELDS, post
+    )
+    merged_nodes = fetch_all_prs(
+        token,
+        build_search_query(scope, f"is:merged merged:>={since}"),
+        _MERGED_PR_FIELDS,
+        post,
+    )
+
+    open_grouped = group_by_repo(open_nodes, normalize_open_pr)
+    merged_grouped = group_by_repo(merged_nodes, normalize_merged_pr)
+
+    write_repo_files(open_grouped, open_dir, known_repos)
+    write_repo_files(merged_grouped, merged_dir, known_repos)
+
+    return open_grouped, merged_grouped
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--org", required=True, help="org to scan in full-fleet mode, e.g. 'atlanhq'"
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="single repo to scan instead of the whole org, e.g. 'atlanhq/atlan-mysql-app'",
+    )
+    parser.add_argument(
+        "--since",
+        required=True,
+        help="merged:>=YYYY-MM-DD lower bound for the merged-PR window",
+    )
+    parser.add_argument("--open-dir", required=True, type=Path)
+    parser.add_argument("--merged-dir", required=True, type=Path)
+    parser.add_argument(
+        "--known-repos-file",
+        type=Path,
+        default=None,
+        help="JSON array of repo full names to seed with an empty PR list even when they have zero matching PRs",
+    )
+    args = parser.parse_args(argv)
+
+    token = os.environ["GH_TOKEN"]
+
+    known_repos: list[str] = []
+    if args.known_repos_file and args.known_repos_file.exists():
+        known_repos = json.loads(args.known_repos_file.read_text())
+
+    open_grouped, merged_grouped = run(
+        scope=resolve_scope(args.org, args.repo),
+        since=args.since,
+        open_dir=args.open_dir,
+        merged_dir=args.merged_dir,
+        known_repos=known_repos,
+        token=token,
+    )
+
+    open_count = sum(len(v) for v in open_grouped.values())
+    merged_count = sum(len(v) for v in merged_grouped.values())
+    print(
+        f"Open Renovate PRs: {open_count} across {len(open_grouped)} repos",
+        file=sys.stderr,
+    )
+    print(
+        f"Merged Renovate PRs (since {args.since}): {merged_count} across {len(merged_grouped)} repos",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/test_renovate_fleet_scan.py
+++ b/.github/scripts/tests/test_renovate_fleet_scan.py
@@ -67,10 +67,11 @@ def test_build_graphql_payload_escapes_quotes_in_query_string():
 # ---------------------------------------------------------------------------
 
 
-def _page(nodes, has_next, cursor=None):
+def _page(nodes, has_next, cursor=None, issue_count=None):
     return {
         "data": {
             "search": {
+                "issueCount": len(nodes) if issue_count is None else issue_count,
                 "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
                 "nodes": nodes,
             }
@@ -92,9 +93,9 @@ def test_fetch_all_prs_single_page():
 
 def test_fetch_all_prs_paginates_until_exhausted():
     pages = [
-        _page([{"number": 1}], has_next=True, cursor="c1"),
-        _page([{"number": 2}], has_next=True, cursor="c2"),
-        _page([{"number": 3}], has_next=False),
+        _page([{"number": 1}], has_next=True, cursor="c1", issue_count=3),
+        _page([{"number": 2}], has_next=True, cursor="c2", issue_count=3),
+        _page([{"number": 3}], has_next=False, issue_count=3),
     ]
 
     def fake_post(token, payload):
@@ -124,6 +125,29 @@ def test_fetch_all_prs_trips_safety_backstop():
         assert False, "expected RuntimeError"
     except RuntimeError as exc:
         assert "safety backstop" in str(exc)
+
+
+def test_fetch_all_prs_raises_when_search_api_cap_truncates_results():
+    # The search API caps total matches (commonly ~1000) — pageInfo can report
+    # hasNextPage=False while issueCount still exceeds what was actually returned.
+    # This must fail loudly rather than silently reporting an incomplete dashboard.
+    def fake_post(token, payload):
+        return _page([{"number": 1}], has_next=False, issue_count=1500)
+
+    try:
+        rfs.fetch_all_prs("tok", "org:atlanhq is:pr", "number", post=fake_post)
+        assert False, "expected RuntimeError"
+    except RuntimeError as exc:
+        assert "1500" in str(exc)
+        assert "cap" in str(exc).lower()
+
+
+def test_fetch_all_prs_no_error_when_issue_count_matches_returned_nodes():
+    def fake_post(token, payload):
+        return _page([{"number": 1}, {"number": 2}], has_next=False, issue_count=2)
+
+    result = rfs.fetch_all_prs("tok", "org:atlanhq is:pr", "number", post=fake_post)
+    assert len(result) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/tests/test_renovate_fleet_scan.py
+++ b/.github/scripts/tests/test_renovate_fleet_scan.py
@@ -1,0 +1,363 @@
+"""Tests for .github/scripts/renovate_fleet_scan.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import renovate_fleet_scan as rfs
+
+# ---------------------------------------------------------------------------
+# Scope resolution + query building
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_scope_full_fleet_when_no_repo():
+    assert rfs.resolve_scope("atlanhq", None) == "org:atlanhq"
+
+
+def test_resolve_scope_single_repo_when_repo_set():
+    assert (
+        rfs.resolve_scope("atlanhq", "atlanhq/atlan-mysql-app")
+        == "repo:atlanhq/atlan-mysql-app"
+    )
+
+
+def test_build_search_query_full_fleet():
+    q = rfs.build_search_query("org:atlanhq", "is:open")
+    assert q == "org:atlanhq is:pr author:app/renovate is:open"
+
+
+def test_build_search_query_single_repo():
+    q = rfs.build_search_query(
+        "repo:atlanhq/atlan-mysql-app", "is:merged merged:>=2026-06-01"
+    )
+    assert (
+        q
+        == "repo:atlanhq/atlan-mysql-app is:pr author:app/renovate is:merged merged:>=2026-06-01"
+    )
+
+
+def test_build_graphql_payload_first_page_has_no_after_arg():
+    payload = rfs.build_graphql_payload("org:atlanhq is:pr", "number", after=None)
+    assert "after:" not in payload["query"]
+    assert '"org:atlanhq is:pr"' in payload["query"]
+
+
+def test_build_graphql_payload_includes_after_cursor():
+    payload = rfs.build_graphql_payload(
+        "org:atlanhq is:pr", "number", after="CURSOR123"
+    )
+    assert 'after: "CURSOR123"' in payload["query"]
+
+
+def test_build_graphql_payload_escapes_quotes_in_query_string():
+    payload = rfs.build_graphql_payload(
+        'org:atlanhq is:pr "weird"', "number", after=None
+    )
+    # json.dumps must escape the embedded quotes so the GraphQL string literal stays valid.
+    assert '\\"weird\\"' in payload["query"]
+
+
+# ---------------------------------------------------------------------------
+# Pagination
+# ---------------------------------------------------------------------------
+
+
+def _page(nodes, has_next, cursor=None):
+    return {
+        "data": {
+            "search": {
+                "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+                "nodes": nodes,
+            }
+        }
+    }
+
+
+def test_fetch_all_prs_single_page():
+    calls = []
+
+    def fake_post(token, payload):
+        calls.append(payload)
+        return _page([{"number": 1}, {"number": 2}], has_next=False)
+
+    result = rfs.fetch_all_prs("tok", "org:atlanhq is:pr", "number", post=fake_post)
+    assert result == [{"number": 1}, {"number": 2}]
+    assert len(calls) == 1
+
+
+def test_fetch_all_prs_paginates_until_exhausted():
+    pages = [
+        _page([{"number": 1}], has_next=True, cursor="c1"),
+        _page([{"number": 2}], has_next=True, cursor="c2"),
+        _page([{"number": 3}], has_next=False),
+    ]
+
+    def fake_post(token, payload):
+        return pages.pop(0)
+
+    result = rfs.fetch_all_prs("tok", "org:atlanhq is:pr", "number", post=fake_post)
+    assert [pr["number"] for pr in result] == [1, 2, 3]
+
+
+def test_fetch_all_prs_raises_on_graphql_errors():
+    def fake_post(token, payload):
+        return {"errors": [{"message": "boom"}]}
+
+    try:
+        rfs.fetch_all_prs("tok", "org:atlanhq is:pr", "number", post=fake_post)
+        assert False, "expected RuntimeError"
+    except RuntimeError as exc:
+        assert "boom" in str(exc)
+
+
+def test_fetch_all_prs_trips_safety_backstop():
+    def fake_post(token, payload):
+        return _page([{"number": 1}], has_next=True, cursor="same")
+
+    try:
+        rfs.fetch_all_prs("tok", "org:atlanhq is:pr", "number", post=fake_post)
+        assert False, "expected RuntimeError"
+    except RuntimeError as exc:
+        assert "safety backstop" in str(exc)
+
+
+# ---------------------------------------------------------------------------
+# statusCheckRollup mapping — must match conformance.renovate.scan._parse_checks_state's
+# two expected item shapes: {"state": ...} (StatusContext) and
+# {"conclusion": ..., "status": ...} (CheckRun, state omitted).
+# ---------------------------------------------------------------------------
+
+
+def _pr_with_contexts(context_nodes):
+    return {
+        "commits": {
+            "nodes": [
+                {
+                    "commit": {
+                        "statusCheckRollup": {"contexts": {"nodes": context_nodes}}
+                    }
+                }
+            ]
+        }
+    }
+
+
+def test_status_rollup_maps_status_context():
+    pr = _pr_with_contexts([{"__typename": "StatusContext", "state": "SUCCESS"}])
+    assert rfs._status_rollup_to_list(pr) == [{"state": "SUCCESS"}]
+
+
+def test_status_rollup_maps_check_run():
+    pr = _pr_with_contexts(
+        [{"__typename": "CheckRun", "conclusion": "FAILURE", "status": "COMPLETED"}]
+    )
+    assert rfs._status_rollup_to_list(pr) == [
+        {"conclusion": "FAILURE", "status": "COMPLETED"}
+    ]
+
+
+def test_status_rollup_empty_when_no_commits():
+    assert rfs._status_rollup_to_list({"commits": {"nodes": []}}) == []
+
+
+def test_status_rollup_empty_when_rollup_missing():
+    pr = {"commits": {"nodes": [{"commit": {"statusCheckRollup": None}}]}}
+    assert rfs._status_rollup_to_list(pr) == []
+
+
+# ---------------------------------------------------------------------------
+# Normalization — output shape must match what `gh pr list --json ...` would have
+# produced, since conformance.renovate.scan._parse_pr / _auto_merge_stats read it.
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_open_pr_full_shape():
+    pr = {
+        "number": 42,
+        "url": "https://github.com/atlanhq/atlan-mysql-app/pull/42",
+        "title": "Update foo to v2",
+        "headRefName": "renovate/foo-2.x",
+        "labels": {"nodes": [{"name": "update:minor"}]},
+        "mergeable": "MERGEABLE",
+        "reviewDecision": "APPROVED",
+        "files": {"nodes": [{"path": "uv.lock"}]},
+        "createdAt": "2026-06-01T00:00:00Z",
+        "updatedAt": "2026-06-02T00:00:00Z",
+        "isDraft": False,
+        "body": "bumps foo",
+        "commits": {"nodes": [{"commit": {"statusCheckRollup": None}}]},
+    }
+    out = rfs.normalize_open_pr(pr)
+    assert out == {
+        "number": 42,
+        "url": "https://github.com/atlanhq/atlan-mysql-app/pull/42",
+        "title": "Update foo to v2",
+        "headRefName": "renovate/foo-2.x",
+        "labels": [{"name": "update:minor"}],
+        "mergeable": "MERGEABLE",
+        "reviewDecision": "APPROVED",
+        "statusCheckRollup": [],
+        "files": [{"path": "uv.lock"}],
+        "createdAt": "2026-06-01T00:00:00Z",
+        "updatedAt": "2026-06-02T00:00:00Z",
+        "isDraft": False,
+        "body": "bumps foo",
+    }
+
+
+def test_normalize_open_pr_defaults_for_missing_optional_fields():
+    pr = {
+        "number": 1,
+        "url": "https://x/1",
+        "title": "t",
+        "createdAt": "2026-06-01T00:00:00Z",
+        "updatedAt": "2026-06-01T00:00:00Z",
+    }
+    out = rfs.normalize_open_pr(pr)
+    assert out["headRefName"] == ""
+    assert out["labels"] == []
+    assert out["files"] == []
+    assert out["mergeable"] == "UNKNOWN"
+    assert out["statusCheckRollup"] == []
+    assert out["isDraft"] is False
+    assert out["body"] == ""
+    # Never emit a bare None for fields conformance.renovate.scan reads with two-arg
+    # dict.get(key, default) — an explicit null would bypass that default.
+    for key in (
+        "headRefName",
+        "labels",
+        "files",
+        "mergeable",
+        "isDraft",
+        "body",
+        "statusCheckRollup",
+    ):
+        assert out[key] is not None
+
+
+def test_normalize_merged_pr_maps_reviews():
+    pr = {
+        "reviews": {
+            "nodes": [
+                {
+                    "state": "APPROVED",
+                    "body": "**Renovate auto-approval:** ...",
+                    "author": {"login": "atlan-ci"},
+                },
+            ]
+        }
+    }
+    out = rfs.normalize_merged_pr(pr)
+    assert out == {
+        "reviews": [
+            {
+                "state": "APPROVED",
+                "body": "**Renovate auto-approval:** ...",
+                "author": {"login": "atlan-ci"},
+            },
+        ]
+    }
+
+
+def test_normalize_merged_pr_handles_missing_author():
+    pr = {"reviews": {"nodes": [{"state": "COMMENTED", "body": None}]}}
+    out = rfs.normalize_merged_pr(pr)
+    assert out["reviews"][0]["author"] == {"login": None}
+
+
+# ---------------------------------------------------------------------------
+# Grouping + file writing
+# ---------------------------------------------------------------------------
+
+
+def test_group_by_repo():
+    prs = [
+        {"repository": {"nameWithOwner": "atlanhq/a"}, "number": 1},
+        {"repository": {"nameWithOwner": "atlanhq/b"}, "number": 2},
+        {"repository": {"nameWithOwner": "atlanhq/a"}, "number": 3},
+    ]
+    grouped = rfs.group_by_repo(prs, lambda pr: {"n": pr["number"]})
+    assert grouped == {"atlanhq/a": [{"n": 1}, {"n": 3}], "atlanhq/b": [{"n": 2}]}
+
+
+def test_slug_for():
+    assert rfs.slug_for("atlanhq/atlan-mysql-app") == "atlanhq_atlan-mysql-app"
+
+
+def test_write_repo_files_writes_empty_list_for_known_repo_with_no_prs(tmp_path):
+    rfs.write_repo_files({}, tmp_path, known_repos=["atlanhq/quiet-repo"])
+    written = json.loads((tmp_path / "atlanhq_quiet-repo.json").read_text())
+    assert written == []
+
+
+def test_write_repo_files_writes_grouped_data(tmp_path):
+    grouped = {"atlanhq/busy-repo": [{"number": 1}]}
+    rfs.write_repo_files(grouped, tmp_path, known_repos=["atlanhq/busy-repo"])
+    written = json.loads((tmp_path / "atlanhq_busy-repo.json").read_text())
+    assert written == [{"number": 1}]
+
+
+def test_write_repo_files_includes_repos_not_in_known_list_too(tmp_path):
+    # A repo that has PRs but wasn't in the discovery list should still get written —
+    # known_repos only guarantees a floor of `[]` files, never excludes real data.
+    grouped = {"atlanhq/surprise-repo": [{"number": 7}]}
+    rfs.write_repo_files(grouped, tmp_path, known_repos=[])
+    written = json.loads((tmp_path / "atlanhq_surprise-repo.json").read_text())
+    assert written == [{"number": 7}]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end `run()` with a fake transport
+# ---------------------------------------------------------------------------
+
+
+def test_run_writes_open_and_merged_files(tmp_path):
+    open_dir = tmp_path / "open"
+    merged_dir = tmp_path / "merged"
+
+    def fake_post(token, payload):
+        query = payload["query"]
+        if "is:open" in query:
+            return _page(
+                [
+                    {
+                        "number": 1,
+                        "url": "https://x/1",
+                        "title": "t",
+                        "createdAt": "2026-06-01T00:00:00Z",
+                        "updatedAt": "2026-06-01T00:00:00Z",
+                        "repository": {"nameWithOwner": "atlanhq/a"},
+                    }
+                ],
+                has_next=False,
+            )
+        return _page(
+            [
+                {
+                    "url": "https://x/2",
+                    "repository": {"nameWithOwner": "atlanhq/a"},
+                    "reviews": {"nodes": []},
+                }
+            ],
+            has_next=False,
+        )
+
+    rfs.run(
+        scope="org:atlanhq",
+        since="2026-06-01",
+        open_dir=open_dir,
+        merged_dir=merged_dir,
+        known_repos=["atlanhq/a", "atlanhq/b"],
+        token="tok",
+        post=fake_post,
+    )
+
+    assert json.loads((open_dir / "atlanhq_a.json").read_text())[0]["number"] == 1
+    assert json.loads((open_dir / "atlanhq_b.json").read_text()) == []
+    assert json.loads((merged_dir / "atlanhq_a.json").read_text()) == [{"reviews": []}]
+    assert json.loads((merged_dir / "atlanhq_b.json").read_text()) == []

--- a/.github/workflows/renovate-dashboard.yaml
+++ b/.github/workflows/renovate-dashboard.yaml
@@ -1,9 +1,11 @@
 # Update Renovate Dashboard — standalone scheduled workflow.
 #
-# Discovers every atlan-application-sdk consumer repo, gathers each repo's open
-# and recently-merged Renovate PRs via `gh pr list`, classifies them with the
-# conformance `renovate-scan` CLI, and deploys per-repo + fleet dashboard data
-# to Kryptonite (k.atlan.dev/renovate-dashboard/).
+# Discovers every atlan-application-sdk consumer repo, gathers open and
+# recently-merged Renovate PRs across the scanned scope via a handful of paginated
+# GraphQL search queries (renovate_fleet_scan.py — not a per-repo `gh pr list` loop,
+# which used to be the dominant contributor to fleet-wide rate-limit pressure),
+# classifies them with the conformance `renovate-scan` CLI, and deploys per-repo +
+# fleet dashboard data to Kryptonite (k.atlan.dev/renovate-dashboard/).
 #
 # Mirrors the conformance dashboard job in update-dashboard.yaml for the S3
 # deployment pattern, and reusable-renovate-dispatch.yaml for fleet discovery.
@@ -88,34 +90,26 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
           REPOS: ${{ steps.discover.outputs.repos }}
+          SINGLE_REPO: ${{ inputs.repo }}
         run: |
           set -euo pipefail
           mkdir -p /tmp/renovate-input/open /tmp/renovate-input/merged
+          echo "$REPOS" > /tmp/renovate-known-repos.json
 
           # 30-day merged window — GNU date on the runner, BSD date as fallback.
           SINCE=$(date -d '30 days ago' +%Y-%m-%d 2>/dev/null || date -v-30d +%Y-%m-%d)
 
-          # Iterate the discovered fleet. gh calls are fast, so a serial loop is
-          # simpler than a matrix and keeps all data in one workspace for the scan.
-          echo "$REPOS" | jq -r '.[]' | while read -r repo; do
-            [ -z "$repo" ] && continue
-            slug=$(echo "$repo" | tr '/' '_')
-            echo "Gathering Renovate PRs for $repo"
-
-            # Open PRs. gh returns [] for repos with no matching PRs — scan.py
-            # handles empty arrays, so a repo with no Renovate PRs is fine.
-            gh pr list --repo "$repo" --author 'app/renovate' --state open --limit 100 \
-              --json number,title,headRefName,labels,mergeable,reviewDecision,statusCheckRollup,files,createdAt,updatedAt,url,isDraft,body \
-              > "/tmp/renovate-input/open/${slug}.json" 2>/dev/null \
-              || echo "[]" > "/tmp/renovate-input/open/${slug}.json"
-
-            # Merged PRs over the trailing 30-day window.
-            gh pr list --repo "$repo" --author 'app/renovate' --state merged --limit 100 \
-              --search "merged:>=${SINCE}" \
-              --json number,title,headRefName,labels,createdAt,mergedAt,url,reviews \
-              > "/tmp/renovate-input/merged/${slug}.json" 2>/dev/null \
-              || echo "[]" > "/tmp/renovate-input/merged/${slug}.json"
-          done
+          # A handful of paginated GraphQL search calls covers the whole scope (org or
+          # single repo) at once, replacing what used to be two `gh pr list` REST calls
+          # per discovered repo — that O(repos) loop was a major contributor to hitting
+          # GitHub's rate limits at fleet scale. See renovate_fleet_scan.py.
+          python3 .github/scripts/renovate_fleet_scan.py \
+            --org atlanhq \
+            ${SINGLE_REPO:+--repo "$SINGLE_REPO"} \
+            --since "$SINCE" \
+            --open-dir /tmp/renovate-input/open \
+            --merged-dir /tmp/renovate-input/merged \
+            --known-repos-file /tmp/renovate-known-repos.json
 
           echo "Open PR files:   $(ls /tmp/renovate-input/open   | wc -l)"
           echo "Merged PR files: $(ls /tmp/renovate-input/merged | wc -l)"

--- a/.github/workflows/renovate-dashboard.yaml
+++ b/.github/workflows/renovate-dashboard.yaml
@@ -94,7 +94,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p /tmp/renovate-input/open /tmp/renovate-input/merged
-          echo "$REPOS" > /tmp/renovate-known-repos.json
+          printf '%s' "$REPOS" > /tmp/renovate-known-repos.json
 
           # 30-day merged window — GNU date on the runner, BSD date as fallback.
           SINCE=$(date -d '30 days ago' +%Y-%m-%d 2>/dev/null || date -v-30d +%Y-%m-%d)
@@ -103,9 +103,11 @@ jobs:
           # single repo) at once, replacing what used to be two `gh pr list` REST calls
           # per discovered repo — that O(repos) loop was a major contributor to hitting
           # GitHub's rate limits at fleet scale. See renovate_fleet_scan.py.
+          # --repo is always passed (empty string in full-fleet mode); resolve_scope()
+          # in the script treats an empty value as "no repo" and falls back to --org.
           python3 .github/scripts/renovate_fleet_scan.py \
             --org atlanhq \
-            ${SINGLE_REPO:+--repo "$SINGLE_REPO"} \
+            --repo "$SINGLE_REPO" \
             --since "$SINCE" \
             --open-dir /tmp/renovate-input/open \
             --merged-dir /tmp/renovate-input/merged \


### PR DESCRIPTION
## Summary
- `renovate-dashboard.yaml` was making 2 `gh pr list` REST calls per discovered fleet repo (up to ~400 calls/run at 200+ repos, on a 6h schedule plus every push-triggered single-repo scan) — all on the shared `ORG_PAT_GITHUB`, a major contributor to the rate-limit pressure currently blocking cross-repo automation.
- New `.github/scripts/renovate_fleet_scan.py` replaces that loop with a handful of paginated GraphQL search queries covering the whole scan scope (org-wide or single-repo) at once, so API call volume no longer scales with fleet size.
- Output matches the exact per-repo JSON shape the `conformance renovate-scan` CLI already expects (verified against `packages/conformance/conformance/renovate/scan.py`'s actual parsing code), so the downstream scanner needs no changes.
- This is Phase 3a of a broader fleet CI rate-limit remediation (full plan: move fleet automation off the shared PAT to a GitHub App). This piece needs no App and no org-admin involvement, so it ships first as a tactical win.

## Test plan
- [x] `.github/scripts/tests` full suite passes (434 tests, including 25 new tests for `renovate_fleet_scan.py`)
- [x] `uv run pre-commit run --files` clean on all touched files
- [ ] Verify a real scheduled/dispatched run of `renovate-dashboard.yaml` produces dashboard output matching the previous format (per-repo JSON, fleet aggregate, history)
- [ ] Confirm GitHub API call count drops materially on the next full-fleet run (`gh api rate_limit` before/after)