### PR TITLE
feat(conformance): bundle Dapr component YAMLs into the SDK wheel

### DIFF
--- a/docs/standards/build-security.md
+++ b/docs/standards/build-security.md
@@ -6,7 +6,27 @@
 
 - **Image base**: `cgr.dev/chainguard-private/python` -> golden images -> SDK -> apps
 - **Dapr runtime**: baked into the `app-framework-golden` base image via Chainguard Custom Assembly (0 CVEs). The container's daprd version is owned by the Custom Assembly config — the Dockerfile no longer installs it. (The `__dapr_version` pin in `application_sdk/version.py` governs only the local-dev auto-download, a separate path.)
+- **Dapr component YAMLs**: shipped inside the `atlan-application-sdk` wheel at `application_sdk/components/` (see `[tool.hatch.build.targets.wheel.force-include]` in `pyproject.toml`, mirroring this repo's own `components/` dir). Consumer apps get them for free from their existing `application-sdk` dependency — no network download needed, and they're always in sync with whatever SDK version is locked in that app's `uv.lock`.
 - **Registries**: Harbor (`registry.atlan.com`) for production, GHCR for CI
+
+## Consuming Dapr components in an app repo
+
+App repos should **not** curl these files from `raw.githubusercontent.com` or the GitHub contents API pinned to a hardcoded SDK tag (that pattern hits GitHub's unauthenticated rate limit under CI concurrency and silently drifts from the app's actual `application-sdk` version). Instead, copy them out of the installed package, e.g. as the app's `download-components` poe task:
+
+```toml
+[tool.poe.tasks]
+download-components.shell = """
+python -c "
+import application_sdk, pathlib, shutil
+src = pathlib.Path(application_sdk.__file__).parent / 'components'
+shutil.copytree(src, 'components', dirs_exist_ok=True)
+"
+"""
+```
+
+This requires `application-sdk` to already be installed into the venv before the task runs (true for both local dev and the Docker build, where `uv sync` happens before `poe download-components`).
+
+This is enforced fleet-wide by the conformance suite's **D009 `RemoteDaprComponentFetch`** rule (BLOCK-tier, autofixable) — see `packages/conformance/conformance/docs/rules/dependency.md#d009`. Run the `remediate` skill/loop with `--series D` against an app repo to detect and fix this pattern automatically.
 
 ## Build & Scan Commands
 

--- a/docs/standards/build-security.md
+++ b/docs/standards/build-security.md
@@ -6,12 +6,12 @@
 
 - **Image base**: `cgr.dev/chainguard-private/python` -> golden images -> SDK -> apps
 - **Dapr runtime**: baked into the `app-framework-golden` base image via Chainguard Custom Assembly (0 CVEs). The container's daprd version is owned by the Custom Assembly config — the Dockerfile no longer installs it. (The `__dapr_version` pin in `application_sdk/version.py` governs only the local-dev auto-download, a separate path.)
-- **Dapr component YAMLs**: shipped inside the `atlan-application-sdk` wheel at `application_sdk/components/` (see `[tool.hatch.build.targets.wheel.force-include]` in `pyproject.toml`, mirroring this repo's own `components/` dir). Consumer apps get them for free from their existing `application-sdk` dependency — no network download needed, and they're always in sync with whatever SDK version is locked in that app's `uv.lock`.
+- **Dapr component YAMLs**: shipped inside the `atlan-application-sdk` wheel at `application_sdk/components/` (see `[tool.hatch.build.targets.wheel.force-include]` in `pyproject.toml`, mirroring this repo's own `components/` dir). Consumer apps get them for free from their existing `atlan-application-sdk` dependency — no network download needed, and they're always in sync with whatever SDK version is locked in that app's `uv.lock`.
 - **Registries**: Harbor (`registry.atlan.com`) for production, GHCR for CI
 
 ## Consuming Dapr components in an app repo
 
-App repos should **not** curl these files from `raw.githubusercontent.com` or the GitHub contents API pinned to a hardcoded SDK tag (that pattern hits GitHub's unauthenticated rate limit under CI concurrency and silently drifts from the app's actual `application-sdk` version). Instead, copy them out of the installed package, e.g. as the app's `download-components` poe task:
+App repos should **not** curl these files from `raw.githubusercontent.com` or the GitHub contents API pinned to a hardcoded SDK tag (that pattern hits GitHub's unauthenticated rate limit under CI concurrency and silently drifts from the app's actual `atlan-application-sdk` version). Instead, copy them out of the installed package, e.g. as the app's `download-components` poe task:
 
 ```toml
 [tool.poe.tasks]
@@ -24,7 +24,7 @@ shutil.copytree(src, 'components', dirs_exist_ok=True)
 """
 ```
 
-This requires `application-sdk` to already be installed into the venv before the task runs (true for both local dev and the Docker build, where `uv sync` happens before `poe download-components`).
+This requires `atlan-application-sdk` to already be installed into the venv before the task runs (true for both local dev and the Docker build, where `uv sync` happens before `poe download-components`).
 
 This is enforced fleet-wide by the conformance suite's **D009 `RemoteDaprComponentFetch`** rule (BLOCK-tier, autofixable) — see `packages/conformance/conformance/docs/rules/dependency.md#d009`. Run the `remediate` skill/loop with `--series D` against an app repo to detect and fix this pattern automatically.
 

--- a/packages/conformance/conformance/docs/rules/dependency.md
+++ b/packages/conformance/conformance/docs/rules/dependency.md
@@ -5,7 +5,7 @@
 
 # Dependency Rules (D-series)
 
-**8 rules** · Checker: `suite.checks.dependency_conformance` (TOML-based, static)
+**9 rules** · Checker: `suite.checks.dependency_conformance` (TOML-based, static)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -23,6 +23,7 @@ Suppress a finding on the violating line or the line directly above it:
 | [D006](#d006) | `IncompatibleRequiresPython` | `warn` | `app` | `python-version` | yes | 0.5.0 |
 | [D007](#d007) | `NonStandardBuildBackend` | `warn` | `app` | `build-system` | yes | 0.5.0 |
 | [D008](#d008) | `WeakenedTypeChecking` | `warn` | `app` | `tooling-baseline` | yes | 0.5.0 |
+| [D009](#d009) | `RemoteDaprComponentFetch` | `block` | `app` | `dapr-components` | yes | 0.12.0 |
 
 ---
 
@@ -194,5 +195,30 @@ APIs pass app CI unnoticed, defeating the point of the typed surface.
 regressions against the SDK's typed APIs slip through app CI.  A pyproject that does not
 set `typeCheckingMode` is not flagged; blanket `reportX = false` overrides are out of
 scope (they can be legitimate).  Cite: BLDX-1410.
+
+---
+
+## D009 — `RemoteDaprComponentFetch` {#d009}
+
+**Tier:** `block` · **Scope:** `app` · **Category:** `dapr-components` · **Autofixable:** yes · **Since:** 0.12.0
+
+> A poe task fetches Dapr component YAMLs from GitHub instead of the installed application-sdk wheel
+
+**Rationale:** Fetching Dapr component YAMLs from raw.githubusercontent.com or the GitHub contents API
+at build time hits GitHub's unauthenticated rate limit under CI concurrency, turning
+routine builds into flaky 429s across the fleet. The hardcoded SDK ref these fetches pin
+to also drifts from whatever application-sdk version is actually locked in the app's own
+uv.lock. The installed SDK wheel already bundles these files at
+application_sdk/components/, so the network round-trip is both fragile and redundant.
+
+No `[tool.poe.tasks.*]` entry (in either the shorthand `task.shell = "..."` form or the
+full `[tool.poe.tasks.task]` table form) may reference `raw.githubusercontent.com` or
+`api.github.com` for `atlanhq/application-sdk`. Dapr component YAMLs are bundled inside
+the `atlan-application-sdk` wheel at `application_sdk/components/` — copy them from
+there instead, e.g. `shutil.copytree(pathlib.Path(application_sdk.__file__).parent /
+'components', 'components', dirs_exist_ok=True)`. This requires application-sdk to
+already be installed into the venv before the task runs (true both locally and in the
+Docker build, where `uv sync` precedes `poe download-components`). Inline suppression:
+`# conformance: ignore[D009] <reason>` on the line above the offending entry.
 
 ---

--- a/packages/conformance/conformance/programs/areas/dependency.prose.md
+++ b/packages/conformance/conformance/programs/areas/dependency.prose.md
@@ -133,11 +133,13 @@ fix.  The re-detection gate is authoritative for this area — see
   `"standard"` (leave `"strict"` untouched; only `"off"`/`"basic"` are flagged).
   Replace only the mode value.
 
-- **D009 RemoteDaprComponentFetch** — the named `[tool.poe.tasks.*]` entry
-  fetches Dapr component YAMLs from `raw.githubusercontent.com` or the GitHub
-  contents API for `atlanhq/application-sdk`. Replace the task's body
-  (whichever form it's written in — `task.shell = "..."` shorthand or a full
-  `[tool.poe.tasks.task]` table) with a local copy from the installed wheel:
+- **D009 RemoteDaprComponentFetch** — `finding.line` points at the offending
+  URL; find the enclosing `[tool.poe.tasks.*]` entry (whichever form it's
+  written in — `task.shell = "..."` shorthand or a full
+  `[tool.poe.tasks.task]` table) — it fetches Dapr component YAMLs from
+  `raw.githubusercontent.com` or the GitHub contents API for
+  `atlanhq/application-sdk`. Replace that task's body with a local copy from
+  the installed wheel, preserving the task's name:
 
   ```toml
   [tool.poe.tasks]

--- a/packages/conformance/conformance/programs/areas/dependency.prose.md
+++ b/packages/conformance/conformance/programs/areas/dependency.prose.md
@@ -18,8 +18,8 @@ findings in the working tree, as reported by `suite.runner --series D`.
 
 The fingerprint-set of all unsuppressed FAILING D-series results.  Extends to
 include WARNING results in strict mode — D002/D003/D004/D005/D006/D007/D008 are
-WARN-tier, so they are processed in strict mode; D001 is BLOCK-tier and
-processed in both modes.
+WARN-tier, so they are processed in strict mode; D001 and D009 are BLOCK-tier
+and processed in both modes.
 
 This facet's fingerprint moves when any D-series finding is resolved (fixed or
 suppressed with justification) or when new ones appear.  An unchanged
@@ -133,6 +133,26 @@ fix.  The re-detection gate is authoritative for this area — see
   `"standard"` (leave `"strict"` untouched; only `"off"`/`"basic"` are flagged).
   Replace only the mode value.
 
+- **D009 RemoteDaprComponentFetch** — the named `[tool.poe.tasks.*]` entry
+  fetches Dapr component YAMLs from `raw.githubusercontent.com` or the GitHub
+  contents API for `atlanhq/application-sdk`. Replace the task's body
+  (whichever form it's written in — `task.shell = "..."` shorthand or a full
+  `[tool.poe.tasks.task]` table) with a local copy from the installed wheel:
+
+  ```toml
+  [tool.poe.tasks]
+  download-components.shell = """
+  python -c "
+  import application_sdk, pathlib, shutil
+  src = pathlib.Path(application_sdk.__file__).parent / 'components'
+  shutil.copytree(src, 'components', dirs_exist_ok=True)
+  "
+  """
+  ```
+
+  Preserve the task's existing name; only its body changes. This is BLOCK-tier
+  and has no suppress path in default mode, same as D001.
+
 **Advisory rules** (`autofixable = false`, `classification = "judgment"`;
 WARN-tier — route to residue for human decision):
 
@@ -189,4 +209,5 @@ justified exception for this app.  Applicable rules and notes:
 
 The justification must describe *why* the deviation is acceptable here, not
 merely that the rule is being suppressed.  Route every suppression to residue
-for human audit.  D001 is BLOCK-tier and has no suppress path in default mode.
+for human audit.  D001 and D009 are BLOCK-tier and have no suppress path in
+default mode.

--- a/packages/conformance/conformance/suite/checks/dependency_conformance.py
+++ b/packages/conformance/conformance/suite/checks/dependency_conformance.py
@@ -74,7 +74,8 @@ PYRIGHT_WEAK_MODES = frozenset({"off", "basic"})
 # limits under CI concurrency, and a hardcoded ref drifts from whatever SDK
 # version is actually locked in the app's uv.lock.
 _REMOTE_COMPONENT_FETCH_RE = re.compile(
-    r"(?:raw\.githubusercontent\.com|api\.github\.com)[^\s\"'\\]*/atlanhq/application-sdk\b",
+    r"(?:raw\.githubusercontent\.com|api\.github\.com)[^\s\"'\\]*"
+    r"/atlanhq/application-sdk(?![\w-])",
     re.IGNORECASE,
 )
 
@@ -891,44 +892,42 @@ def scan_text(
         )
 
     # ── D009 (pure-text) ────────────────────────────────────────────────────
+    # Structural check (via `data`) just decides whether any poe task fetches
+    # components remotely; the actual findings are anchored by a single
+    # line-based scan of the raw text so a violation is never mis-attributed
+    # to the wrong task name when more than one task matches.
     tasks = _poe_tasks(data)
-    if tasks is not None:
-        reported_lines: set[int] = set()
-        for task_name, task_def in tasks.items():
-            if not any(
-                _REMOTE_COMPONENT_FETCH_RE.search(s) for s in _iter_strings(task_def)
-            ):
+    if tasks is not None and any(
+        _REMOTE_COMPONENT_FETCH_RE.search(s)
+        for task_def in tasks.values()
+        for s in _iter_strings(task_def)
+    ):
+        for ln, line in enumerate(text.splitlines(), start=1):
+            if not _REMOTE_COMPONENT_FETCH_RE.search(line):
                 continue
-            for ln, line in enumerate(text.splitlines(), start=1):
-                if ln in reported_lines or not _REMOTE_COMPONENT_FETCH_RE.search(line):
-                    continue
-                reported_lines.add(ln)
-                findings.append(
-                    _make_finding(
-                        rule_id=RULE_D009,
-                        file=file,
-                        line=ln,
-                        column=1,
-                        message=(
-                            f"poe task '{task_name}' fetches Dapr component "
-                            f"YAMLs from GitHub over the network instead of "
-                            f"reading them from the installed "
-                            f"'{SDK_PACKAGE}' wheel, which bundles them at "
-                            f"application_sdk/components/. Unauthenticated "
-                            f"GitHub requests hit rate limits under CI "
-                            f"concurrency, and a hardcoded ref drifts from "
-                            f"whatever SDK version is actually locked in "
-                            f"uv.lock. Copy from the installed package "
-                            f'instead, e.g. `python -c "import '
-                            f"application_sdk, pathlib, shutil; "
-                            f"shutil.copytree(pathlib.Path("
-                            f"application_sdk.__file__).parent / "
-                            f"'components', 'components', "
-                            f'dirs_exist_ok=True)"`.'
-                        ),
-                        suppressions=suppressions,
-                    )
+            findings.append(
+                _make_finding(
+                    rule_id=RULE_D009,
+                    file=file,
+                    line=ln,
+                    column=1,
+                    message=(
+                        "A poe task fetches Dapr component YAMLs from GitHub "
+                        f"over the network instead of reading them from the "
+                        f"installed '{SDK_PACKAGE}' wheel, which bundles them "
+                        f"at application_sdk/components/. Unauthenticated "
+                        f"GitHub requests hit rate limits under CI "
+                        f"concurrency, and a hardcoded ref drifts from "
+                        f"whatever SDK version is actually locked in "
+                        f"uv.lock. Copy from the installed package instead, "
+                        f'e.g. `python -c "import application_sdk, pathlib, '
+                        f"shutil; shutil.copytree(pathlib.Path("
+                        f"application_sdk.__file__).parent / 'components', "
+                        f"'components', dirs_exist_ok=True)\"`."
+                    ),
+                    suppressions=suppressions,
                 )
+            )
 
     # ── D002 / D004: redeclaration of SDK-managed core deps (metadata) ──────
     if sdk_managed_packages is None:

--- a/packages/conformance/conformance/suite/checks/dependency_conformance.py
+++ b/packages/conformance/conformance/suite/checks/dependency_conformance.py
@@ -19,8 +19,12 @@ Rules in this check module:
   Hatchling.
 * **D008 WeakenedTypeChecking** — ``[tool.pyright].typeCheckingMode`` must not
   be weaker than the SDK baseline ``standard``.
+* **D009 RemoteDaprComponentFetch** — no ``[tool.poe.tasks.*]`` entry may fetch
+  Dapr component YAMLs from ``raw.githubusercontent.com`` or the GitHub
+  contents API for ``atlanhq/application-sdk``; the installed SDK wheel
+  bundles them at ``application_sdk/components/``.
 
-D004/D005 are metadata-based (need the SDK importable) like D002; D006/D007/D008
+D004/D005 are metadata-based (need the SDK importable) like D002; D006/D007/D008/D009
 are pure-text.
 
 Self-check exemption: any pyproject whose ``[project].name`` starts with
@@ -53,6 +57,7 @@ RULE_D005 = "D005"
 RULE_D006 = "D006"
 RULE_D007 = "D007"
 RULE_D008 = "D008"
+RULE_D009 = "D009"
 
 SDK_PACKAGE = "atlan-application-sdk"
 
@@ -61,6 +66,17 @@ HATCHLING_BACKEND = "hatchling.build"
 
 # pyright type-checking modes weaker than the SDK baseline ``standard`` (D008).
 PYRIGHT_WEAK_MODES = frozenset({"off", "basic"})
+
+# Matches a poe task fetching Dapr component YAMLs straight from GitHub
+# (raw.githubusercontent.com or the contents API) for atlanhq/application-sdk,
+# instead of copying them from the installed wheel, which bundles them at
+# application_sdk/components/ (D009). Unauthenticated GitHub requests hit rate
+# limits under CI concurrency, and a hardcoded ref drifts from whatever SDK
+# version is actually locked in the app's uv.lock.
+_REMOTE_COMPONENT_FETCH_RE = re.compile(
+    r"(?:raw\.githubusercontent\.com|api\.github\.com)[^\s\"'\\]*/atlanhq/application-sdk\b",
+    re.IGNORECASE,
+)
 
 # The SDK's own ``[project].requires-python`` lower bound, as ``(major, minor)``.
 # Hardcoded (not read from metadata) so D006 stays a pure-text check that works
@@ -689,6 +705,31 @@ def _pyright_mode(
     return mode, _line_of(text, "typeCheckingMode", section="tool.pyright")
 
 
+def _poe_tasks(data: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """Return ``[tool.poe.tasks]`` as a mapping, or ``None`` when absent."""
+    tool = data.get("tool")
+    poe = tool.get("poe") if isinstance(tool, dict) else None
+    tasks = poe.get("tasks") if isinstance(poe, dict) else None
+    return tasks if isinstance(tasks, dict) else None
+
+
+def _iter_strings(value: Any) -> Iterator[str]:
+    """Recursively yield every string leaf under a poe task definition.
+
+    A task may be a bare string, a ``{shell = "..."}``/``{cmd = "..."}``/
+    ``{interpreter = "python", shell = "..."}`` table, or a sequence-task list
+    of steps — this walks all of those shapes uniformly.
+    """
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for v in value.values():
+            yield from _iter_strings(v)
+    elif isinstance(value, list):
+        for v in value:
+            yield from _iter_strings(v)
+
+
 def _is_self_check(name: str | None) -> bool:
     """Return True for the SDK and its sibling packages (exempt from D-series).
 
@@ -848,6 +889,46 @@ def scan_text(
                 suppressions=suppressions,
             )
         )
+
+    # ── D009 (pure-text) ────────────────────────────────────────────────────
+    tasks = _poe_tasks(data)
+    if tasks is not None:
+        reported_lines: set[int] = set()
+        for task_name, task_def in tasks.items():
+            if not any(
+                _REMOTE_COMPONENT_FETCH_RE.search(s) for s in _iter_strings(task_def)
+            ):
+                continue
+            for ln, line in enumerate(text.splitlines(), start=1):
+                if ln in reported_lines or not _REMOTE_COMPONENT_FETCH_RE.search(line):
+                    continue
+                reported_lines.add(ln)
+                findings.append(
+                    _make_finding(
+                        rule_id=RULE_D009,
+                        file=file,
+                        line=ln,
+                        column=1,
+                        message=(
+                            f"poe task '{task_name}' fetches Dapr component "
+                            f"YAMLs from GitHub over the network instead of "
+                            f"reading them from the installed "
+                            f"'{SDK_PACKAGE}' wheel, which bundles them at "
+                            f"application_sdk/components/. Unauthenticated "
+                            f"GitHub requests hit rate limits under CI "
+                            f"concurrency, and a hardcoded ref drifts from "
+                            f"whatever SDK version is actually locked in "
+                            f"uv.lock. Copy from the installed package "
+                            f'instead, e.g. `python -c "import '
+                            f"application_sdk, pathlib, shutil; "
+                            f"shutil.copytree(pathlib.Path("
+                            f"application_sdk.__file__).parent / "
+                            f"'components', 'components', "
+                            f'dirs_exist_ok=True)"`.'
+                        ),
+                        suppressions=suppressions,
+                    )
+                )
 
     # ── D002 / D004: redeclaration of SDK-managed core deps (metadata) ──────
     if sdk_managed_packages is None:

--- a/packages/conformance/conformance/suite/rules/dependency.py
+++ b/packages/conformance/conformance/suite/rules/dependency.py
@@ -22,6 +22,8 @@ SDK upgrades.  These rules enforce two invariants:
 * ``D007`` — the app builds with Hatchling.
 * ``D008`` — the app's pyright ``typeCheckingMode`` is not weaker than
   ``standard``.
+* ``D009`` — no ``[tool.poe.tasks.*]`` entry fetches Dapr component YAMLs
+  from GitHub over the network; the installed SDK wheel bundles them.
 """
 
 from __future__ import annotations
@@ -315,6 +317,50 @@ RULES: tuple[RuleDefinition, ...] = (
         help_uri=(
             "https://github.com/atlanhq/application-sdk/blob/main/"
             "packages/conformance/conformance/docs/rules/dependency.md#d003"
+        ),
+    ),
+    RuleDefinition(
+        id="D009",
+        scope=RuleScope.APP,
+        name="RemoteDaprComponentFetch",
+        tier=EnforcementTier.BLOCK,
+        mechanism=RuleMechanism.STATIC,
+        category="dapr-components",
+        autofixable=True,
+        since="0.12.0",
+        rationale=(
+            "Fetching Dapr component YAMLs from raw.githubusercontent.com or "
+            "the GitHub contents API at build time hits GitHub's unauthenticated "
+            "rate limit under CI concurrency, turning routine builds into flaky "
+            "429s across the fleet. The hardcoded SDK ref these fetches pin to "
+            "also drifts from whatever application-sdk version is actually "
+            "locked in the app's own uv.lock. The installed SDK wheel already "
+            "bundles these files at application_sdk/components/, so the "
+            "network round-trip is both fragile and redundant."
+        ),
+        short_description=(
+            "A poe task fetches Dapr component YAMLs from GitHub instead of "
+            "the installed application-sdk wheel"
+        ),
+        full_description=(
+            "No ``[tool.poe.tasks.*]`` entry (in either the shorthand "
+            '``task.shell = "..."`` form or the full ``[tool.poe.tasks.'
+            "task]`` table form) may reference ``raw.githubusercontent.com`` "
+            "or ``api.github.com`` for ``atlanhq/application-sdk``. Dapr "
+            "component YAMLs are bundled inside the ``atlan-application-sdk`` "
+            "wheel at ``application_sdk/components/`` — copy them from there "
+            "instead, e.g. ``shutil.copytree(pathlib.Path(application_sdk."
+            "__file__).parent / 'components', 'components', "
+            "dirs_exist_ok=True)``. This requires application-sdk to already "
+            "be installed into the venv before the task runs (true both "
+            "locally and in the Docker build, where ``uv sync`` precedes "
+            "``poe download-components``). Inline suppression: "
+            "``# conformance: ignore[D009] <reason>`` on the line above the "
+            "offending entry."
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/dependency.md#d009"
         ),
     ),
 )

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -122,7 +122,10 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
     # C002/D001/D002: publisher-side contract. D004/D005: the same
     # redeclaration/extra contract on dependency-groups and SDK extras.
     # D006/D007/D008: the app pyproject baseline (python floor, build backend,
-    # type-checking) the SDK publishes. P004/P005: apps must reach the
+    # type-checking) the SDK publishes. D009: apps fetching Dapr components
+    # from GitHub instead of the installed wheel — the SDK's own
+    # download-components task never does this (it lists local files).
+    # P004/P005: apps must reach the
     # orchestration layer through the SDK seam, not Temporal/SDK-internals
     # (BLDX-1417). P008–P012: apps must use the SDK's storage seam, not
     # hand-roll object stores or bare path fields (BLDX-1398).
@@ -178,6 +181,7 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
         "D006",
         "D007",
         "D008",
+        "D009",
         "E020",
         "K001",
         "K002",
@@ -311,7 +315,17 @@ def test_catalog_d_series_present() -> None:
     """The D-series dependency rules are all present."""
     rules = load_catalog()
     d_ids = {r.id for r in rules if r.id.startswith("D")}
-    expected = {"D001", "D002", "D003", "D004", "D005", "D006", "D007", "D008"}
+    expected = {
+        "D001",
+        "D002",
+        "D003",
+        "D004",
+        "D005",
+        "D006",
+        "D007",
+        "D008",
+        "D009",
+    }
     missing = expected - d_ids
     assert not missing, f"Missing D-series rules: {missing}"
 

--- a/packages/conformance/tests/test_dependency_conformance.py
+++ b/packages/conformance/tests/test_dependency_conformance.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 from conformance.suite.checks.dependency_conformance import (
+    _REMOTE_COMPONENT_FETCH_RE,
     SDK_PYTHON_FLOOR,
     _is_bounded_specifier,
     _iter_dep_entries,
@@ -831,7 +832,7 @@ def test_d009_multiple_tasks_one_violating_reports_once_at_correct_line() -> Non
     expected_line = next(
         ln
         for ln, line in enumerate(text.splitlines(), start=1)
-        if "raw.githubusercontent.com" in line
+        if _REMOTE_COMPONENT_FETCH_RE.search(line)
     )
     assert findings[0].line == expected_line
 

--- a/packages/conformance/tests/test_dependency_conformance.py
+++ b/packages/conformance/tests/test_dependency_conformance.py
@@ -778,6 +778,64 @@ def test_d009_suppressed_inline_directive_above() -> None:
     assert findings[0].suppressed is True
 
 
+def test_d009_does_not_match_similarly_prefixed_repo_name() -> None:
+    """A repo merely starting with 'application-sdk' must not false-positive."""
+    task = (
+        "[tool.poe.tasks]\n"
+        "download-components.shell = "
+        '"curl -O https://raw.githubusercontent.com/atlanhq/application-sdk-extra/'
+        'v1.0.0/components/statestore.yaml"\n'
+    )
+    findings = scan_text(
+        _poe_pyproject(task),
+        "pyproject.toml",
+        sdk_managed_packages=set(),
+        sdk_published_extras=set(),
+    )
+    assert findings == []
+
+
+def test_d009_matches_bare_repo_reference_with_no_trailing_path() -> None:
+    task = (
+        "[tool.poe.tasks]\n"
+        "download-components.shell = "
+        '"echo https://api.github.com/repos/atlanhq/application-sdk"\n'
+    )
+    findings = scan_text(
+        _poe_pyproject(task),
+        "pyproject.toml",
+        sdk_managed_packages=set(),
+        sdk_published_extras=set(),
+    )
+    assert [f.rule_id for f in findings] == ["D009"]
+
+
+def test_d009_multiple_tasks_one_violating_reports_once_at_correct_line() -> None:
+    """A finding must anchor to the actual offending line, not misattribute
+    across tasks when only one of several poe tasks violates the rule."""
+    task = (
+        "[tool.poe.tasks]\n"
+        'start-dapr = "dapr run --app-id app"\n'
+        "download-components.shell = "
+        '"curl -O https://raw.githubusercontent.com/atlanhq/application-sdk/'
+        'v3.14.0/components/statestore.yaml"\n'
+    )
+    text = _poe_pyproject(task)
+    findings = scan_text(
+        text,
+        "pyproject.toml",
+        sdk_managed_packages=set(),
+        sdk_published_extras=set(),
+    )
+    assert len(findings) == 1
+    expected_line = next(
+        ln
+        for ln, line in enumerate(text.splitlines(), start=1)
+        if "raw.githubusercontent.com" in line
+    )
+    assert findings[0].line == expected_line
+
+
 def test_inline_duplicate_entries_get_distinct_columns() -> None:
     # A repeated requirement on one inline line must not alias to the first
     # match's column (the raw_line.index → offset-cursor fix).

--- a/packages/conformance/tests/test_dependency_conformance.py
+++ b/packages/conformance/tests/test_dependency_conformance.py
@@ -1,4 +1,4 @@
-"""Tests for the D-series (D001/D002/D003/D004/D005/D006/D007/D008) dependency_conformance check."""
+"""Tests for the D-series (D001-D009) dependency_conformance check."""
 
 from __future__ import annotations
 
@@ -676,6 +676,106 @@ def test_d008_line_anchors_in_pyright_section_not_decoy() -> None:
         if ln.strip() == 'typeCheckingMode = "basic"'
     )
     assert findings[0].line == expected
+
+
+# ── D009: remote Dapr component fetch ────────────────────────────────────────
+
+
+def _poe_pyproject(task_toml: str) -> str:
+    return (
+        '[project]\nname = "demo-app"\nversion = "0.1.0"\ndependencies = [\n'
+        '    "atlan-application-sdk>=3.17,<4.0.0",\n]\n\n'
+        f"{task_toml}\n"
+    )
+
+
+def test_d009_fires_on_github_contents_api_fetch() -> None:
+    task = (
+        "[tool.poe.tasks.download-components]\n"
+        'interpreter = "python"\n'
+        'env = { SDK_VERSION = "v3.14.0" }\n'
+        'shell = """\n'
+        "import requests\n"
+        'api_url = "https://api.github.com/repos/atlanhq/application-sdk/contents/components"\n'
+        'requests.get(api_url, params={"ref": "v3.14.0"})\n'
+        '"""\n'
+    )
+    findings = scan_text(
+        _poe_pyproject(task),
+        "pyproject.toml",
+        sdk_managed_packages=set(),
+        sdk_published_extras=set(),
+    )
+    assert [f.rule_id for f in findings] == ["D009"]
+
+
+def test_d009_fires_on_raw_githubusercontent_fetch() -> None:
+    task = (
+        "[tool.poe.tasks]\n"
+        "download-components.shell = "
+        '"curl -O https://raw.githubusercontent.com/atlanhq/application-sdk/'
+        'v3.14.0/components/statestore.yaml"\n'
+    )
+    findings = scan_text(
+        _poe_pyproject(task),
+        "pyproject.toml",
+        sdk_managed_packages=set(),
+        sdk_published_extras=set(),
+    )
+    assert [f.rule_id for f in findings] == ["D009"]
+
+
+def test_d009_passes_for_local_copy_from_installed_wheel() -> None:
+    task = (
+        "[tool.poe.tasks]\n"
+        'download-components.shell = "python -c \\"import application_sdk\\""\n'
+    )
+    findings = scan_text(
+        _poe_pyproject(task),
+        "pyproject.toml",
+        sdk_managed_packages=set(),
+        sdk_published_extras=set(),
+    )
+    assert findings == []
+
+
+def test_d009_no_poe_tasks_no_finding() -> None:
+    findings = scan_text(
+        _poe_pyproject(""),
+        "pyproject.toml",
+        sdk_managed_packages=set(),
+        sdk_published_extras=set(),
+    )
+    assert findings == []
+
+
+def test_d009_unrelated_poe_task_no_finding() -> None:
+    task = '[tool.poe.tasks]\nstart-dapr = "dapr run --app-id app"\n'
+    findings = scan_text(
+        _poe_pyproject(task),
+        "pyproject.toml",
+        sdk_managed_packages=set(),
+        sdk_published_extras=set(),
+    )
+    assert findings == []
+
+
+def test_d009_suppressed_inline_directive_above() -> None:
+    task = (
+        "[tool.poe.tasks]\n"
+        "# conformance: ignore[D009] migration tracked separately\n"
+        "download-components.shell = "
+        '"curl -O https://raw.githubusercontent.com/atlanhq/application-sdk/'
+        'v3.14.0/components/statestore.yaml"\n'
+    )
+    findings = scan_text(
+        _poe_pyproject(task),
+        "pyproject.toml",
+        sdk_managed_packages=set(),
+        sdk_published_extras=set(),
+    )
+    assert len(findings) == 1
+    assert findings[0].suppressed is True
 
 
 def test_inline_duplicate_entries_get_distinct_columns() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,12 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["application_sdk"]
 
+# Ship the Dapr component YAMLs inside the wheel so consumer apps get them
+# for free from their existing application-sdk dependency instead of
+# downloading them over the network (see docs/standards/build-security.md).
+[tool.hatch.build.targets.wheel.force-include]
+"components" = "application_sdk/components"
+
 [tool.pyright]
 venvPath = "."
 venv = ".venv"


### PR DESCRIPTION
## Summary
- Bundle `components/*.yaml` into the `atlan-application-sdk` wheel at `application_sdk/components/` (via `[tool.hatch.build.targets.wheel.force-include]`), so consumer apps get the Dapr component YAMLs from their existing `application-sdk` dependency instead of downloading them from GitHub at build time.
- Document the replacement pattern for app repos in `docs/standards/build-security.md`.
- Add conformance rule **D009 `RemoteDaprComponentFetch`** (BLOCK-tier, autofixable) to detect the network-fetch pattern in `[tool.poe.tasks.*]` and route it through the existing D-series remediation loop.

### Context
App repos (e.g. `atlan-mysql-app`) curl Dapr component YAMLs from `raw.githubusercontent.com`/the GitHub contents API, pinned to a hardcoded SDK tag (e.g. `v3.14.0`). This hits GitHub's unauthenticated rate limit under CI concurrency (429s breaking builds) and drifts from whatever `application-sdk` version is actually locked in the app's `uv.lock`. Since the SDK wheel now bundles these files, apps can copy them locally instead — no network call, and always in sync with the installed SDK version.

## Test plan
- [x] `uv build --wheel` and verified `application_sdk/components/*.yaml` are present in the built wheel
- [x] `uv run pre-commit run --all-files` — clean
- [x] `uv run python -m pytest tests/unit -x -q` — 5378 passed
- [x] `packages/conformance`: `uv run pytest tests/` — 1663 passed, 1 xfailed
- [x] `uv run atlan-application-sdk-conformance gen-rule-docs --check` — up-to-date
- [x] End-to-end: ran `atlan-application-sdk-conformance detect --series D` against a synthetic pyproject.toml mirroring `atlan-mysql-app`'s actual `download-components` task — D009 fires as a BLOCK finding at the correct line