### PR TITLE
chore(scaffold): bootstrap apps with wheel-based Dapr component fetch

### DIFF
--- a/.claude/skills/scaffold-app/SKILL.md
+++ b/.claude/skills/scaffold-app/SKILL.md
@@ -90,7 +90,18 @@ dev-dependencies = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
 ]
+
+[tool.poe.tasks]
+download-components.shell = """
+python -c "
+import application_sdk, pathlib, shutil
+src = pathlib.Path(application_sdk.__file__).parent / 'components'
+shutil.copytree(src, 'components', dirs_exist_ok=True)
+"
+"""
 ```
+
+`download-components` copies the Dapr component YAMLs out of the installed `atlan-application-sdk` wheel — never curl them from `raw.githubusercontent.com` or the GitHub API; that pattern is blocked by conformance rule D009 (see `docs/standards/build-security.md`). Run it after `uv sync` and before starting `daprd` locally or in the Docker build.
 
 ### 3. Generate `atlan.yaml`
 
@@ -114,6 +125,7 @@ WORKDIR /app
 
 COPY pyproject.toml uv.lock* ./
 RUN uv sync --no-dev --frozen
+RUN uv run poe download-components
 
 COPY app/ app/
 
@@ -237,9 +249,12 @@ asyncio.run(
 
 Tell the user:
 1. Run `uv sync` to install dependencies.
-2. Copy and configure `.env.example → .env`.
-3. Run `uv run python run_dev.py` to test the scaffold — this boots the embedded
+2. Run `uv run poe download-components` to copy the Dapr component YAMLs out of the
+   installed SDK wheel into `./components` (needed to run against external Dapr;
+   the embedded runtime in step 4 doesn't require this).
+3. Copy and configure `.env.example → .env`.
+4. Run `uv run python run_dev.py` to test the scaffold — this boots the embedded
    Dapr (`daprd`) + in-process Temporal automatically; no Dapr CLI needed. To
    instead mirror production against external services, see the optional
    external-infrastructure section of [Getting Started](../../docs/guides/getting-started.md).
-4. Run the `contract` skill to generate the PKL contract and `app/generated/` artifacts.
+5. Run the `contract` skill to generate the PKL contract and `app/generated/` artifacts.

--- a/.claude/skills/scaffold-app/SKILL.md
+++ b/.claude/skills/scaffold-app/SKILL.md
@@ -76,6 +76,7 @@ version = "1.0.0"
 requires-python = ">=3.11"
 dependencies = [
     "atlan-application-sdk>=3.0.0",
+    "poethepoet>=0.34.0",
 ]
 
 [project.optional-dependencies]
@@ -101,7 +102,7 @@ shutil.copytree(src, 'components', dirs_exist_ok=True)
 """
 ```
 
-`download-components` copies the Dapr component YAMLs out of the installed `atlan-application-sdk` wheel — never curl them from `raw.githubusercontent.com` or the GitHub API; that pattern is blocked by conformance rule D009 (see `docs/standards/build-security.md`). Run it after `uv sync` and before starting `daprd` locally or in the Docker build.
+`download-components` copies the Dapr component YAMLs out of the installed `atlan-application-sdk` wheel — never curl them from `raw.githubusercontent.com` or the GitHub API; that pattern is blocked by conformance rule D009 (see `docs/standards/build-security.md`). Run it after `uv sync` and before starting `daprd` locally or in the Docker build. `poethepoet` (which provides the `poe` CLI) must be a main dependency, not a `dev`-only one — the Dockerfile's `uv sync --no-dev` would otherwise leave `poe` unavailable during the build.
 
 ### 3. Generate `atlan.yaml`
 

--- a/docs/guides/build-your-first-app.md
+++ b/docs/guides/build-your-first-app.md
@@ -229,8 +229,14 @@ asyncio.run(
 
 Copy the Dapr component definitions into your project. They ship inside the
 `atlan-application-sdk` wheel — don't curl them from GitHub (that hits rate limits under CI
-concurrency and can drift from the SDK version locked in your `uv.lock`). Add a
-`download-components` poe task to `pyproject.toml`:
+concurrency and can drift from the SDK version locked in your `uv.lock`). This uses `poe` from
+the `poethepoet` package, so add it as a dependency first:
+
+```bash
+uv add poethepoet
+```
+
+Then add a `download-components` poe task to `pyproject.toml`:
 
 ```toml
 [tool.poe.tasks]

--- a/docs/guides/build-your-first-app.md
+++ b/docs/guides/build-your-first-app.md
@@ -227,15 +227,26 @@ asyncio.run(
 )
 ```
 
-Copy the Dapr component definitions into your project. The components ship with the SDK repo, not the wheel:
+Copy the Dapr component definitions into your project. They ship inside the
+`atlan-application-sdk` wheel — don't curl them from GitHub (that hits rate limits under CI
+concurrency and can drift from the SDK version locked in your `uv.lock`). Add a
+`download-components` poe task to `pyproject.toml`:
+
+```toml
+[tool.poe.tasks]
+download-components.shell = """
+python -c "
+import application_sdk, pathlib, shutil
+src = pathlib.Path(application_sdk.__file__).parent / 'components'
+shutil.copytree(src, 'components', dirs_exist_ok=True)
+"
+"""
+```
+
+Then run it:
 
 ```bash
-# If you have the SDK repo cloned locally:
-cp -r /path/to/application-sdk/components ./components
-
-# Otherwise, download them directly:
-curl -sL https://github.com/atlanhq/application-sdk/archive/refs/heads/main.tar.gz \
-  | tar -xz --strip-components=2 application-sdk-main/components
+uv run poe download-components
 ```
 
 Start infrastructure and run:

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -119,7 +119,13 @@ The embedded runtime above is the recommended local-dev path. If you want to mir
 The component YAMLs ship inside the `atlan-application-sdk` wheel — copy them out of your
 installed dependency rather than downloading from GitHub (unauthenticated GitHub requests hit
 rate limits under CI concurrency and can drift from the SDK version actually locked in your
-`uv.lock`). Add a `download-components` poe task to `pyproject.toml`:
+`uv.lock`). This uses `poe` from the `poethepoet` package, so add it as a dependency first:
+
+```bash
+uv add poethepoet
+```
+
+Then add a `download-components` poe task to `pyproject.toml`:
 
 ```toml
 [tool.poe.tasks]

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -116,9 +116,26 @@ The embedded runtime above is the recommended local-dev path. If you want to mir
 
 **1. Add the SDK's Dapr component definitions to your project:**
 
+The component YAMLs ship inside the `atlan-application-sdk` wheel — copy them out of your
+installed dependency rather than downloading from GitHub (unauthenticated GitHub requests hit
+rate limits under CI concurrency and can drift from the SDK version actually locked in your
+`uv.lock`). Add a `download-components` poe task to `pyproject.toml`:
+
+```toml
+[tool.poe.tasks]
+download-components.shell = """
+python -c "
+import application_sdk, pathlib, shutil
+src = pathlib.Path(application_sdk.__file__).parent / 'components'
+shutil.copytree(src, 'components', dirs_exist_ok=True)
+"
+"""
+```
+
+Then run it:
+
 ```bash
-curl -sL https://github.com/atlanhq/application-sdk/archive/refs/heads/main.tar.gz \
-  | tar -xz --strip-components=2 application-sdk-main/components
+uv run poe download-components
 ```
 
 **2. Start Temporal and a Dapr sidecar in separate terminals:**


### PR DESCRIPTION
## Summary
- `scaffold-app` now generates a compliant `download-components` poe task in the app's `pyproject.toml`, wires a `uv run poe download-components` step into the generated Dockerfile, and calls it out in the post-scaffold instructions — so freshly scaffolded apps start conformant with D009 `RemoteDaprComponentFetch` instead of relying on after-the-fact remediation.
- `docs/guides/getting-started.md` and `docs/guides/build-your-first-app.md` no longer teach the stale `curl .../archive/refs/heads/main.tar.gz` GitHub-tarball pattern (now blocked by D009); they use the same wheel-based `download-components` snippet already documented in `docs/standards/build-security.md`.

## Test plan
- [x] `uv run pre-commit run --all-files` — clean
- [x] `uv run python -m pytest tests/unit -x -q` — 5378 passed, 9 skipped
- [x] Docs-only / skill-instruction changes — no runtime behavior change to verify manually