### PR TITLE
ci: fall back to plain daprd if log-forwarder module missing

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -93,9 +93,20 @@ echo "[entrypoint]   graceful-shutdown-seconds: ${DAPR_GRACEFUL_SHUTDOWN_SECONDS
 DAPR_LOG_FORWARDER=""
 DAPR_LOG_FORMAT_FLAG=""
 if [ "$(echo "${ENABLE_ATLAN_UPLOAD:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
-    echo "[entrypoint] SDR mode (ENABLE_ATLAN_UPLOAD=true) — forwarding daprd logs through the SDK observability pipeline"
-    DAPR_LOG_FORWARDER="uv run --no-sync python -m application_sdk.observability.dapr_log_forwarder --"
-    DAPR_LOG_FORMAT_FLAG="--log-as-json"
+    # Fail-soft on a version skew. The forwarder is daprd's PARENT process
+    # (`forwarder -- daprd ...`), so if `python -m ...dapr_log_forwarder` can't
+    # start, daprd never starts either — the sidecar is lost and the app can't
+    # reach Dapr at all. This happens when the entrypoint (shipped in the base
+    # image) is newer than the app's pinned SDK, which may not have the
+    # forwarder module. Probe the import first; if it's missing, run daprd
+    # directly so we lose daprd log forwarding, not the sidecar.
+    if uv run --no-sync python -c 'import application_sdk.observability.dapr_log_forwarder' >/dev/null 2>&1; then
+        echo "[entrypoint] SDR mode (ENABLE_ATLAN_UPLOAD=true) — forwarding daprd logs through the SDK observability pipeline"
+        DAPR_LOG_FORWARDER="uv run --no-sync python -m application_sdk.observability.dapr_log_forwarder --"
+        DAPR_LOG_FORMAT_FLAG="--log-as-json"
+    else
+        echo "[entrypoint] WARN: application_sdk.observability.dapr_log_forwarder is not importable in the installed SDK — running daprd directly without log forwarding. The base image entrypoint is likely newer than the app's pinned application-sdk; align them to restore daprd log forwarding."
+    fi
 fi
 
 # Intentional unquoted expansion: the forwarder prefix is empty (no-op) when the


### PR DESCRIPTION
## Problem

In SDR mode (`ENABLE_ATLAN_UPLOAD=true`) the entrypoint wraps daprd in the log forwarder:

```sh
DAPR_LOG_FORWARDER="uv run --no-sync python -m application_sdk.observability.dapr_log_forwarder --"
...
${DAPR_LOG_FORWARDER} daprd ...
```

So the forwarder is daprd's **parent** process. If `python -m application_sdk.observability.dapr_log_forwarder` can't import, it exits non-zero and **daprd is never started** — the sidecar is gone and the app can't reach Dapr at all: secret store, bindings, and `/v1.0/metadata` all fail with `ConnectError: All connection attempts failed`.

This bites on a **version skew**. The entrypoint ships in the **base image**; the app installs its own **pinned** `application-sdk` into the venv (`uv sync --locked`), and the entrypoint runs the forwarder against that venv (`uv run --no-sync`). When the base image is newer than the app's pinned SDK, the pinned SDK may not contain the forwarder module yet (it was added in a later release), so:

```
/app/.venv/bin/python3: No module named application_sdk.observability.dapr_log_forwarder
```

…and daprd dies on startup. This was observed in a production SDR deployment where a base-image refresh moved ahead of an app still pinned to an SDK without the module — the connector worker came up healthy but its daprd sidecar never started, so every credential/secret fetch failed.

The existing startup guard (`sleep 0.5; kill -0 "$DAPRD_PID"`) doesn't catch it: with the wrapper, `$DAPRD_PID` is the forwarder's PID, and `uv run` takes longer than 0.5s to reach the `ImportError`, so the check passes and the container limps on with no daprd and no non-zero exit.

## Fix

Probe the import before enabling forwarding; if the module isn't importable, run daprd **directly** and log a warning:

```sh
if uv run --no-sync python -c 'import application_sdk.observability.dapr_log_forwarder' >/dev/null 2>&1; then
    DAPR_LOG_FORWARDER="uv run --no-sync python -m application_sdk.observability.dapr_log_forwarder --"
    DAPR_LOG_FORMAT_FLAG="--log-as-json"
else
    echo "[entrypoint] WARN: ...dapr_log_forwarder not importable — running daprd directly without log forwarding..."
fi
```

A version skew now degrades **daprd log forwarding** (a nice-to-have) instead of taking down the **sidecar** (load-bearing). POSIX `sh`, matches existing style.

## Follow-up (not in this PR)

The startup liveness check assumes `$DAPRD_PID` is daprd; under the forwarder wrapper it's the parent. Worth hardening the check to verify daprd's HTTP port is actually listening rather than that a PID exists — happy to do it separately.

## Testing

- `sh -n entrypoint.sh` clean; pre-commit passes.
- Behavioral test: with the probe forced to fail, `DAPR_LOG_FORWARDER` stays empty → `daprd` runs unwrapped.