### PR TITLE
ci: require feat/fix titles for Docker image file changes

### DIFF
--- a/.github/scripts/pr_title_convention.py
+++ b/.github/scripts/pr_title_convention.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""PR title convention driver.
+
+Decides whether a PR title matches the conventional-commit type its changed
+files require, per the precedence rules documented in
+.github/workflows/pr-title-convention.yaml:
+
+  0. Version-bump / release automation -> ignored entirely.
+  1. application_sdk/ touched         -> no restriction.
+  2. Dockerfile / entrypoint.sh       -> feat:/fix: required.
+  3. contract-toolkit/ core           -> feat(contract-toolkit):/fix(contract-toolkit): required.
+  4. packages/conformance/ core       -> feat(conformance):/fix(conformance): required.
+  5. everything else                  -> chore:/ci: required.
+
+Usage:
+    python3 pr_title_convention.py \
+        --pr-title "<title>" \
+        --head-ref "<branch>" \
+        --changed-files <path to newline-delimited changed-file list> \
+        --comment-out <path to write the sticky-comment markdown on violation>
+
+Writes `violation`, `expected`, and `error_message` to $GITHUB_OUTPUT (or
+prints `key=value` lines if $GITHUB_OUTPUT is unset). Always exits 0 — the
+calling workflow gates on the `violation` output in a separate step.
+"""
+
+import argparse
+import fnmatch
+import os
+import re
+import sys
+
+RELEASE_RE = re.compile(r"^chore(\([^)]*\))?: release ")
+BUMP_RE = re.compile(r"^Bump version to ")
+
+DOCKER_RE = re.compile(r"^(feat|fix)(\([^)]*\))?!?:")
+CT_RE = re.compile(r"^(feat|fix)\(contract-toolkit\)!?:")
+CF_RE = re.compile(r"^(feat|fix)\(conformance\)!?:")
+CHORE_RE = re.compile(r"^(chore|ci)(\([^)]*\))?!?:")
+
+DOCKER_IMAGE_FILES = ("Dockerfile", "entrypoint.sh")
+
+CT_EXEMPT_GLOBS = (
+    "contract-toolkit/docs/*",
+    "contract-toolkit/examples/*",
+    "contract-toolkit/scripts/*",
+    "contract-toolkit/tests/*",
+    "contract-toolkit/.github/*",
+)
+CF_EXEMPT_GLOBS = (
+    "packages/conformance/tests/*",
+    "packages/conformance/uv.lock",
+    "packages/conformance/*/package-lock.json",
+    "packages/conformance/*/yarn.lock",
+)
+
+_VALIDATORS = {
+    "docker-img": (DOCKER_RE, "docker-img"),
+    "ct-core": (CT_RE, "ct-core"),
+    "cf-core": (CF_RE, "cf-core"),
+    "other": (CHORE_RE, "chore-ci"),
+}
+
+_LOG_MESSAGES = {
+    "sdk": "application_sdk/ touched — title type unrestricted. ✅",
+    ("docker-img", False): "Docker image file change with a valid feat/fix title. ✅",
+    ("docker-img", True): (
+        "Violation: Docker image file change (Dockerfile/entrypoint.sh) must "
+        "use feat: or fix:."
+    ),
+    ("ct-core", False): "contract-toolkit core change with a valid scoped title. ✅",
+    ("ct-core", True): (
+        "Violation: contract-toolkit core change must use "
+        "feat(contract-toolkit): or fix(contract-toolkit):."
+    ),
+    (
+        "cf-core",
+        False,
+    ): "packages/conformance core change with a valid scoped title. ✅",
+    ("cf-core", True): (
+        "Violation: conformance core change must use feat(conformance): or "
+        "fix(conformance):."
+    ),
+    ("other", False): "Non-source change with a chore/ci title. ✅",
+    ("other", True): "Violation: non-source change must use chore: or ci:.",
+}
+
+_ERROR_MESSAGES = {
+    "docker-img": (
+        "Docker image changes (Dockerfile/entrypoint.sh) must use 'feat:' or 'fix:'."
+    ),
+    "ct-core": (
+        "contract-toolkit core changes must use 'feat(contract-toolkit):' or "
+        "'fix(contract-toolkit):'."
+    ),
+    "cf-core": (
+        "conformance core changes must use 'feat(conformance):' or "
+        "'fix(conformance):'."
+    ),
+    "chore-ci": (
+        "Non-source changes must use 'chore:' or 'ci:' (feat:/fix: are reserved "
+        "for application_sdk/, Dockerfile/entrypoint.sh, contract-toolkit core, "
+        "and packages/conformance core)."
+    ),
+}
+
+_COMMENTS = {
+    "docker-img": """\
+### \U0001f3f7️ Docker image changes need a `feat`/`fix` title
+
+This PR changes a file baked into the published Docker image
+(`Dockerfile` and/or `entrypoint.sh`), so it's user-facing runtime
+behavior and its title must be:
+
+- `feat: …` / `feat(scope): …`
+- `fix: …` / `fix(scope): …`
+
+Editing the PR title re-runs this check and clears this comment automatically.
+""",
+    "ct-core": """\
+### \U0001f3f7️ contract-toolkit changes need a scoped `feat`/`fix` title
+
+This PR changes `contract-toolkit/` source, so its title must use the
+`contract-toolkit` scope:
+
+- `feat(contract-toolkit): …`
+- `fix(contract-toolkit): …`
+
+(Changes confined to `contract-toolkit/{docs,examples,scripts,tests,.github}/`
+should instead be `chore:`/`ci:`.)
+
+Editing the PR title re-runs this check and clears this comment automatically.
+""",
+    "cf-core": """\
+### \U0001f3f7️ conformance package changes need a scoped `feat`/`fix` title
+
+This PR changes `packages/conformance/` source, so its title must use the
+`conformance` scope:
+
+- `feat(conformance): …`
+- `fix(conformance): …`
+
+(Changes confined to `packages/conformance/tests/` or lock files
+such as `uv.lock`/`package-lock.json` should instead be `chore:`/`ci:`.)
+
+Editing the PR title re-runs this check and clears this comment automatically.
+""",
+    "chore-ci": """\
+### \U0001f3f7️ Non-source PR shouldn't use a `feat`/`fix` title
+
+This PR does not change shipped source (`application_sdk/`, the
+Docker image inputs `Dockerfile`/`entrypoint.sh`, `contract-toolkit/`
+core, or `packages/conformance/` core), so a `feat:`/`fix:` title
+would add it to the user-facing SDK changelog as a real feature/fix
+— exactly the noise this check prevents.
+
+**Use a non-surfacing conventional type instead:**
+- `ci:` / `ci(scope):` — changes to CI configuration and scripts
+- `chore:` / `chore(scope):` — everything else not touching shipped source
+
+_Example:_ `ci(publish): use crane to copy large images GHCR → Docker Hub`
+
+Editing the PR title re-runs this check and clears this comment automatically.
+""",
+}
+
+
+def is_version_bump_pr(pr_title: str, head_ref: str) -> bool:
+    """True for generated version-bump / release PRs, which this guard ignores."""
+    return (
+        head_ref.startswith("bump-version")
+        or bool(RELEASE_RE.match(pr_title))
+        or bool(BUMP_RE.match(pr_title))
+    )
+
+
+def classify_files(files: list) -> str:
+    """Return the highest-precedence zone touched by ``files``.
+
+    One of "sdk", "docker-img", "ct-core", "cf-core", or "other".
+    """
+    sdk = docker_img = ct_core = cf_core = False
+    for f in files:
+        if f.startswith("application_sdk/"):
+            sdk = True
+        elif f in DOCKER_IMAGE_FILES:
+            docker_img = True
+        elif any(fnmatch.fnmatch(f, glob) for glob in CT_EXEMPT_GLOBS):
+            continue
+        elif f.startswith("contract-toolkit/"):
+            ct_core = True
+        elif any(fnmatch.fnmatch(f, glob) for glob in CF_EXEMPT_GLOBS):
+            continue
+        elif f.startswith("packages/conformance/"):
+            cf_core = True
+
+    if sdk:
+        return "sdk"
+    if docker_img:
+        return "docker-img"
+    if ct_core:
+        return "ct-core"
+    if cf_core:
+        return "cf-core"
+    return "other"
+
+
+def validate(zone: str, pr_title: str):
+    """Return (violation, expected) for a title against the given zone."""
+    if zone == "sdk":
+        return False, ""
+    regex, expected = _VALIDATORS[zone]
+    if regex.match(pr_title):
+        return False, ""
+    return True, expected
+
+
+def _read_changed_files(path: str) -> list:
+    with open(path) as fh:
+        return [line.strip() for line in fh if line.strip()]
+
+
+def _write_output(key: str, value: str) -> None:
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    line = f"{key}={value}"
+    if github_output:
+        with open(github_output, "a") as fh:
+            fh.write(line + "\n")
+    else:
+        print(line)
+
+
+def run(pr_title: str, head_ref: str, changed_files_path: str, comment_out_path: str):
+    """Core decision logic, returned as (violation, expected) for testing."""
+    if is_version_bump_pr(pr_title, head_ref):
+        print("Version-bump / release PR — ignored by this guard.")
+        return False, ""
+
+    files = _read_changed_files(changed_files_path)
+    if not files:
+        print("No changed files reported; nothing to validate.")
+        return False, ""
+
+    zone = classify_files(files)
+    violation, expected = validate(zone, pr_title)
+    log_key = zone if zone == "sdk" else (zone, violation)
+    print(_LOG_MESSAGES[log_key])
+
+    if violation:
+        with open(comment_out_path, "w") as fh:
+            fh.write(_COMMENTS[expected])
+
+    return violation, expected
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pr-title", required=True)
+    parser.add_argument("--head-ref", default="")
+    parser.add_argument(
+        "--changed-files",
+        required=True,
+        help="Path to a newline-delimited list of changed file paths",
+    )
+    parser.add_argument(
+        "--comment-out",
+        required=True,
+        help="Path to write the sticky-comment markdown when the title is invalid",
+    )
+    args = parser.parse_args()
+
+    print(f"PR title: {args.pr_title}")
+    violation, expected = run(
+        args.pr_title, args.head_ref, args.changed_files, args.comment_out
+    )
+
+    _write_output("violation", "true" if violation else "false")
+    _write_output("expected", expected)
+    _write_output("error_message", _ERROR_MESSAGES.get(expected, ""))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/test_pr_title_convention.py
+++ b/.github/scripts/tests/test_pr_title_convention.py
@@ -1,0 +1,246 @@
+"""Tests for .github/scripts/pr_title_convention.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import pr_title_convention as ptc
+
+# ---------------------------------------------------------------------------
+# is_version_bump_pr
+# ---------------------------------------------------------------------------
+
+
+class TestIsVersionBumpPr:
+    def test_bump_version_branch(self):
+        assert ptc.is_version_bump_pr("chore: unrelated", "bump-version-1.2.3")
+
+    def test_release_title(self):
+        assert ptc.is_version_bump_pr("chore: release 1.2.3", "feature/foo")
+
+    def test_scoped_release_title(self):
+        assert ptc.is_version_bump_pr("chore(release): release 1.2.3", "feature/foo")
+
+    def test_bump_version_title(self):
+        assert ptc.is_version_bump_pr("Bump version to 1.2.3", "feature/foo")
+
+    def test_regular_pr_is_not_a_bump(self):
+        assert not ptc.is_version_bump_pr("fix: handle edge case", "feature/foo")
+
+
+# ---------------------------------------------------------------------------
+# classify_files
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyFiles:
+    def test_application_sdk_wins(self):
+        assert ptc.classify_files(["application_sdk/foo.py"]) == "sdk"
+
+    def test_sdk_takes_precedence_over_docker(self):
+        assert ptc.classify_files(["application_sdk/foo.py", "entrypoint.sh"]) == "sdk"
+
+    def test_dockerfile(self):
+        assert ptc.classify_files(["Dockerfile"]) == "docker-img"
+
+    def test_entrypoint_sh(self):
+        assert ptc.classify_files(["entrypoint.sh"]) == "docker-img"
+
+    def test_nested_dockerfile_does_not_match(self):
+        # Only the root-level Dockerfile/entrypoint.sh count as image inputs.
+        assert ptc.classify_files(["docker/Dockerfile"]) == "other"
+
+    def test_contract_toolkit_core(self):
+        assert ptc.classify_files(["contract-toolkit/src/foo.py"]) == "ct-core"
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "contract-toolkit/docs/readme.md",
+            "contract-toolkit/examples/basic.py",
+            "contract-toolkit/scripts/build.sh",
+            "contract-toolkit/tests/test_foo.py",
+            "contract-toolkit/.github/workflows/ci.yaml",
+        ],
+    )
+    def test_contract_toolkit_exempt_subfolders(self, path):
+        assert ptc.classify_files([path]) == "other"
+
+    def test_conformance_core(self):
+        assert ptc.classify_files(["packages/conformance/conformance/foo.py"]) == (
+            "cf-core"
+        )
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "packages/conformance/tests/test_foo.py",
+            "packages/conformance/uv.lock",
+            "packages/conformance/ui/package-lock.json",
+            "packages/conformance/ui/yarn.lock",
+        ],
+    )
+    def test_conformance_exempt_paths(self, path):
+        assert ptc.classify_files([path]) == "other"
+
+    def test_docs_only_is_other(self):
+        assert ptc.classify_files(["docs/foo.md"]) == "other"
+
+    def test_empty_list_is_other(self):
+        assert ptc.classify_files([]) == "other"
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+class TestValidate:
+    def test_sdk_zone_never_violates(self):
+        assert ptc.validate("sdk", "chore: anything") == (False, "")
+        assert ptc.validate("sdk", "fix: anything") == (False, "")
+
+    @pytest.mark.parametrize(
+        "title",
+        ["fix: handle SIGTERM", "feat: add flag", "fix(entrypoint): x", "fix!: x"],
+    )
+    def test_docker_img_accepts_feat_fix(self, title):
+        assert ptc.validate("docker-img", title) == (False, "")
+
+    def test_docker_img_rejects_chore(self):
+        assert ptc.validate("docker-img", "chore: tweak entrypoint") == (
+            True,
+            "docker-img",
+        )
+
+    def test_ct_core_requires_exact_scope(self):
+        assert ptc.validate("ct-core", "fix(contract-toolkit): x") == (False, "")
+        assert ptc.validate("ct-core", "fix: x") == (True, "ct-core")
+        assert ptc.validate("ct-core", "fix(other-scope): x") == (True, "ct-core")
+
+    def test_cf_core_requires_exact_scope(self):
+        assert ptc.validate("cf-core", "feat(conformance): x") == (False, "")
+        assert ptc.validate("cf-core", "feat: x") == (True, "cf-core")
+
+    def test_other_accepts_chore_or_ci(self):
+        assert ptc.validate("other", "chore: tidy") == (False, "")
+        assert ptc.validate("other", "ci(publish): tidy") == (False, "")
+
+    def test_other_rejects_feat_fix(self):
+        assert ptc.validate("other", "fix: tidy") == (True, "chore-ci")
+
+
+# ---------------------------------------------------------------------------
+# run() / main() integration
+# ---------------------------------------------------------------------------
+
+
+def _write_changed_files(tmp_path: Path, files: list) -> Path:
+    p = tmp_path / "changed_files.txt"
+    p.write_text("\n".join(files) + ("\n" if files else ""))
+    return p
+
+
+class TestRun:
+    def test_version_bump_pr_short_circuits(self, tmp_path: Path):
+        changed = _write_changed_files(tmp_path, ["entrypoint.sh"])
+        comment_out = tmp_path / "comment.md"
+        violation, expected = ptc.run(
+            "chore: release 1.2.3", "main", str(changed), str(comment_out)
+        )
+        assert (violation, expected) == (False, "")
+        assert not comment_out.exists()
+
+    def test_no_changed_files(self, tmp_path: Path):
+        changed = _write_changed_files(tmp_path, [])
+        comment_out = tmp_path / "comment.md"
+        violation, expected = ptc.run(
+            "fix: whatever", "feature/foo", str(changed), str(comment_out)
+        )
+        assert (violation, expected) == (False, "")
+        assert not comment_out.exists()
+
+    def test_entrypoint_with_chore_title_is_a_violation(self, tmp_path: Path):
+        changed = _write_changed_files(tmp_path, ["entrypoint.sh"])
+        comment_out = tmp_path / "comment.md"
+        violation, expected = ptc.run(
+            "chore: tweak entrypoint", "feature/foo", str(changed), str(comment_out)
+        )
+        assert (violation, expected) == (True, "docker-img")
+        assert "feat`/`fix` title" in comment_out.read_text()
+
+    def test_entrypoint_with_fix_title_passes(self, tmp_path: Path):
+        changed = _write_changed_files(tmp_path, ["entrypoint.sh"])
+        comment_out = tmp_path / "comment.md"
+        violation, expected = ptc.run(
+            "fix: handle SIGTERM gracefully",
+            "feature/foo",
+            str(changed),
+            str(comment_out),
+        )
+        assert (violation, expected) == (False, "")
+        assert not comment_out.exists()
+
+
+class TestMain(object):
+    def test_writes_github_output_and_comment(self, tmp_path: Path, monkeypatch):
+        changed = _write_changed_files(tmp_path, ["entrypoint.sh"])
+        comment_out = tmp_path / "comment.md"
+        github_output = tmp_path / "github_output.txt"
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "pr_title_convention.py",
+                "--pr-title",
+                "chore: tweak entrypoint",
+                "--head-ref",
+                "feature/foo",
+                "--changed-files",
+                str(changed),
+                "--comment-out",
+                str(comment_out),
+            ],
+        )
+        monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+        assert ptc.main() == 0
+
+        output = github_output.read_text()
+        assert "violation=true" in output
+        assert "expected=docker-img" in output
+        assert "error_message=" in output
+        assert comment_out.exists()
+
+    def test_passing_title_reports_no_violation(self, tmp_path: Path, monkeypatch):
+        changed = _write_changed_files(tmp_path, ["docs/foo.md"])
+        comment_out = tmp_path / "comment.md"
+        github_output = tmp_path / "github_output.txt"
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "pr_title_convention.py",
+                "--pr-title",
+                "chore: update docs",
+                "--head-ref",
+                "feature/foo",
+                "--changed-files",
+                str(changed),
+                "--comment-out",
+                str(comment_out),
+            ],
+        )
+        monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+        assert ptc.main() == 0
+
+        output = github_output.read_text()
+        assert "violation=false" in output
+        assert "expected=" in output
+        assert not comment_out.exists()

--- a/.github/workflows/pr-title-convention.yaml
+++ b/.github/workflows/pr-title-convention.yaml
@@ -53,6 +53,11 @@
 # skipping) keeps the conclusion "success" so this can be a REQUIRED check
 # without leaving the merge queue permanently pending — the same pattern this
 # repo uses for capability-manifest-check.
+#
+# The classification + title-validation decision logic lives in
+# .github/scripts/pr_title_convention.py (unit-tested in
+# .github/scripts/tests/test_pr_title_convention.py), per docs/standards/ci.md:
+# a workflow `run:` block must not itself contain branching shell.
 
 name: PR Title Convention
 
@@ -76,6 +81,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
       - name: Validate PR title against changed files
         id: detect
         if: github.event_name == 'pull_request'
@@ -87,163 +99,13 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-
           echo "PR #${PR_NUMBER} (${HEAD_REF}): ${PR_TITLE}"
-
-          violation=false
-          expected=""
-
-          # --- Rule 0: ignore version-bump / release automation ---------------
-          release_re='^chore(\([^)]*\))?: release '
-          bump_re='^Bump version to '
-          if [[ "${HEAD_REF}" == bump-version* ]] || [[ "${PR_TITLE}" =~ $release_re ]] || [[ "${PR_TITLE}" =~ $bump_re ]]; then
-            echo "Version-bump / release PR — ignored by this guard."
-          else
-            # Up to the first 100 files; ample for the PRs this guard targets.
-            files=()
-            while IFS= read -r path; do
-              [ -n "$path" ] && files+=("$path")
-            done < <(gh pr view "${PR_NUMBER}" --repo "${REPO}" --json files --jq '.files[].path')
-
-            if [ "${#files[@]}" -eq 0 ]; then
-              echo "No changed files reported; nothing to validate."
-            else
-              # Classify changed paths into zones.
-              sdk=false        # application_sdk/**  (highest precedence)
-              docker_img=false # files baked into the published Docker image
-              ct_core=false    # contract-toolkit/** excluding its docs/examples/scripts/tests/.github
-              cf_core=false    # packages/conformance/** excluding its tests/
-              for f in "${files[@]}"; do
-                case "$f" in
-                  application_sdk/*) sdk=true ;;
-                  Dockerfile|entrypoint.sh) docker_img=true ;;
-                  contract-toolkit/docs/*|contract-toolkit/examples/*|contract-toolkit/scripts/*|contract-toolkit/tests/*|contract-toolkit/.github/*) : ;;
-                  contract-toolkit/*) ct_core=true ;;
-                  packages/conformance/tests/*) : ;;
-                  packages/conformance/uv.lock) : ;;
-                  packages/conformance/*/package-lock.json) : ;;
-                  packages/conformance/*/yarn.lock) : ;;
-                  packages/conformance/*) cf_core=true ;;
-                  *) : ;;
-                esac
-              done
-
-              if [ "$sdk" = true ]; then
-                echo "application_sdk/ touched — title type unrestricted. ✅"
-              elif [ "$docker_img" = true ]; then
-                # Rule 2: files shipped inside the Docker image require feat/fix.
-                docker_re='^(feat|fix)(\([^)]*\))?!?:'
-                if [[ "${PR_TITLE}" =~ $docker_re ]]; then
-                  echo "Docker image file change with a valid feat/fix title. ✅"
-                else
-                  violation=true
-                  expected="docker-img"
-                  echo "Violation: Docker image file change (Dockerfile/entrypoint.sh) must use feat: or fix:."
-                fi
-              elif [ "$ct_core" = true ]; then
-                # Rule 3: contract-toolkit core requires the contract-toolkit scope.
-                ct_re='^(feat|fix)\(contract-toolkit\)!?:'
-                if [[ "${PR_TITLE}" =~ $ct_re ]]; then
-                  echo "contract-toolkit core change with a valid scoped title. ✅"
-                else
-                  violation=true
-                  expected="ct-core"
-                  echo "Violation: contract-toolkit core change must use feat(contract-toolkit): or fix(contract-toolkit):."
-                fi
-              elif [ "$cf_core" = true ]; then
-                # Rule 4: conformance core requires the conformance scope.
-                cf_re='^(feat|fix)\(conformance\)!?:'
-                if [[ "${PR_TITLE}" =~ $cf_re ]]; then
-                  echo "packages/conformance core change with a valid scoped title. ✅"
-                else
-                  violation=true
-                  expected="cf-core"
-                  echo "Violation: conformance core change must use feat(conformance): or fix(conformance):."
-                fi
-              else
-                # Rule 5: everything else must be chore or ci.
-                chore_re='^(chore|ci)(\([^)]*\))?!?:'
-                if [[ "${PR_TITLE}" =~ $chore_re ]]; then
-                  echo "Non-source change with a chore/ci title. ✅"
-                else
-                  violation=true
-                  expected="chore-ci"
-                  echo "Violation: non-source change must use chore: or ci:."
-                fi
-              fi
-            fi
-          fi
-
-          {
-            echo "violation=${violation}"
-            echo "expected=${expected}"
-          } >> "$GITHUB_OUTPUT"
-
-          # Build the sticky-comment body for the violating case.
-          if [ "$violation" = true ]; then
-            if [ "$expected" = "docker-img" ]; then
-              cat > pr-title-comment.md <<'EOF'
-          ### 🏷️ Docker image changes need a `feat`/`fix` title
-
-          This PR changes a file baked into the published Docker image
-          (`Dockerfile` and/or `entrypoint.sh`), so it's user-facing runtime
-          behavior and its title must be:
-
-          - `feat: …` / `feat(scope): …`
-          - `fix: …` / `fix(scope): …`
-
-          Editing the PR title re-runs this check and clears this comment automatically.
-          EOF
-            elif [ "$expected" = "ct-core" ]; then
-              cat > pr-title-comment.md <<'EOF'
-          ### 🏷️ contract-toolkit changes need a scoped `feat`/`fix` title
-
-          This PR changes `contract-toolkit/` source, so its title must use the
-          `contract-toolkit` scope:
-
-          - `feat(contract-toolkit): …`
-          - `fix(contract-toolkit): …`
-
-          (Changes confined to `contract-toolkit/{docs,examples,scripts,tests,.github}/`
-          should instead be `chore:`/`ci:`.)
-
-          Editing the PR title re-runs this check and clears this comment automatically.
-          EOF
-            elif [ "$expected" = "cf-core" ]; then
-              cat > pr-title-comment.md <<'EOF'
-          ### 🏷️ conformance package changes need a scoped `feat`/`fix` title
-
-          This PR changes `packages/conformance/` source, so its title must use the
-          `conformance` scope:
-
-          - `feat(conformance): …`
-          - `fix(conformance): …`
-
-          (Changes confined to `packages/conformance/tests/` or lock files
-          such as `uv.lock`/`package-lock.json` should instead be `chore:`/`ci:`.)
-
-          Editing the PR title re-runs this check and clears this comment automatically.
-          EOF
-            else
-              cat > pr-title-comment.md <<'EOF'
-          ### 🏷️ Non-source PR shouldn't use a `feat`/`fix` title
-
-          This PR does not change shipped source (`application_sdk/`, the
-          Docker image inputs `Dockerfile`/`entrypoint.sh`, `contract-toolkit/`
-          core, or `packages/conformance/` core), so a `feat:`/`fix:` title
-          would add it to the user-facing SDK changelog as a real feature/fix
-          — exactly the noise this check prevents.
-
-          **Use a non-surfacing conventional type instead:**
-          - `ci:` / `ci(scope):` — changes to CI configuration and scripts
-          - `chore:` / `chore(scope):` — everything else not touching shipped source
-
-          _Example:_ `ci(publish): use crane to copy large images GHCR → Docker Hub`
-
-          Editing the PR title re-runs this check and clears this comment automatically.
-          EOF
-            fi
-          fi
+          gh pr view "${PR_NUMBER}" --repo "${REPO}" --json files --jq '.files[].path' > changed_files.txt
+          python3 .github/scripts/pr_title_convention.py \
+            --pr-title "${PR_TITLE}" \
+            --head-ref "${HEAD_REF}" \
+            --changed-files changed_files.txt \
+            --comment-out pr-title-comment.md
 
       - name: Post sticky comment on violation
         if: >-
@@ -268,17 +130,9 @@ jobs:
       - name: Fail on invalid PR title
         if: steps.detect.outputs.violation == 'true'
         env:
-          EXPECTED: ${{ steps.detect.outputs.expected }}
+          ERROR_MESSAGE: ${{ steps.detect.outputs.error_message }}
         run: |
-          if [ "${EXPECTED}" = "docker-img" ]; then
-            echo "::error title=Invalid PR title::Docker image changes (Dockerfile/entrypoint.sh) must use 'feat:' or 'fix:'."
-          elif [ "${EXPECTED}" = "ct-core" ]; then
-            echo "::error title=Invalid PR title::contract-toolkit core changes must use 'feat(contract-toolkit):' or 'fix(contract-toolkit):'."
-          elif [ "${EXPECTED}" = "cf-core" ]; then
-            echo "::error title=Invalid PR title::conformance core changes must use 'feat(conformance):' or 'fix(conformance):'."
-          else
-            echo "::error title=Invalid PR title::Non-source changes must use 'chore:' or 'ci:' (feat:/fix: are reserved for application_sdk/, Dockerfile/entrypoint.sh, contract-toolkit core, and packages/conformance core)."
-          fi
+          echo "::error title=Invalid PR title::${ERROR_MESSAGE}"
           exit 1
 
       - name: Merge queue no-op

--- a/.github/workflows/pr-title-convention.yaml
+++ b/.github/workflows/pr-title-convention.yaml
@@ -17,19 +17,25 @@
 #      Source changes are the legitimate home of feat:/fix: (and may also be
 #      chore:/ci:/etc.). This takes precedence over every rule below.
 #
-#   2. Any change to `contract-toolkit/` *core* (anything under contract-toolkit/
+#   2. Any change to a file baked into the published Docker image
+#      (`Dockerfile`, `entrypoint.sh`)  ->  title must be `feat:`/`feat(...):`
+#      or `fix:`/`fix(...):`. These files ship inside every application image
+#      built from this SDK, so a change here is user-facing runtime behavior —
+#      it belongs in the SDK changelog, not filed away as chore/ci.
+#
+#   3. Any change to `contract-toolkit/` *core* (anything under contract-toolkit/
 #      that is NOT in its docs/, examples/, scripts/, tests/, .github/ subfolders)
 #      ->  title must be `feat(contract-toolkit):` or `fix(contract-toolkit):`.
 #      contract-toolkit ships its own package and changelog, so its source
 #      changes carry that exact scope.
 #
-#   3. Any change to `packages/conformance/` *core* (anything under
+#   4. Any change to `packages/conformance/` *core* (anything under
 #      packages/conformance/ that is NOT in its tests/ subfolder or a lock
 #      file — uv.lock, package-lock.json, yarn.lock)
 #      ->  title must be `feat(conformance):` or `fix(conformance):`.
 #      The conformance package ships independently and owns its own changelog.
 #
-#   4. Everything else (docs, examples, tests, components, renovate-config,
+#   5. Everything else (docs, examples, tests, components, renovate-config,
 #      tools, .github, .claude, .security, root config files, dependency
 #      manifests, contract-toolkit's own docs/tests, conformance tests, ...)
 #      ->  title must be `chore:`/`chore(...):` or `ci:`/`ci(...):`.
@@ -104,11 +110,13 @@ jobs:
             else
               # Classify changed paths into zones.
               sdk=false        # application_sdk/**  (highest precedence)
+              docker_img=false # files baked into the published Docker image
               ct_core=false    # contract-toolkit/** excluding its docs/examples/scripts/tests/.github
               cf_core=false    # packages/conformance/** excluding its tests/
               for f in "${files[@]}"; do
                 case "$f" in
                   application_sdk/*) sdk=true ;;
+                  Dockerfile|entrypoint.sh) docker_img=true ;;
                   contract-toolkit/docs/*|contract-toolkit/examples/*|contract-toolkit/scripts/*|contract-toolkit/tests/*|contract-toolkit/.github/*) : ;;
                   contract-toolkit/*) ct_core=true ;;
                   packages/conformance/tests/*) : ;;
@@ -122,8 +130,18 @@ jobs:
 
               if [ "$sdk" = true ]; then
                 echo "application_sdk/ touched — title type unrestricted. ✅"
+              elif [ "$docker_img" = true ]; then
+                # Rule 2: files shipped inside the Docker image require feat/fix.
+                docker_re='^(feat|fix)(\([^)]*\))?!?:'
+                if [[ "${PR_TITLE}" =~ $docker_re ]]; then
+                  echo "Docker image file change with a valid feat/fix title. ✅"
+                else
+                  violation=true
+                  expected="docker-img"
+                  echo "Violation: Docker image file change (Dockerfile/entrypoint.sh) must use feat: or fix:."
+                fi
               elif [ "$ct_core" = true ]; then
-                # Rule 2: contract-toolkit core requires the contract-toolkit scope.
+                # Rule 3: contract-toolkit core requires the contract-toolkit scope.
                 ct_re='^(feat|fix)\(contract-toolkit\)!?:'
                 if [[ "${PR_TITLE}" =~ $ct_re ]]; then
                   echo "contract-toolkit core change with a valid scoped title. ✅"
@@ -133,7 +151,7 @@ jobs:
                   echo "Violation: contract-toolkit core change must use feat(contract-toolkit): or fix(contract-toolkit):."
                 fi
               elif [ "$cf_core" = true ]; then
-                # Rule 3: conformance core requires the conformance scope.
+                # Rule 4: conformance core requires the conformance scope.
                 cf_re='^(feat|fix)\(conformance\)!?:'
                 if [[ "${PR_TITLE}" =~ $cf_re ]]; then
                   echo "packages/conformance core change with a valid scoped title. ✅"
@@ -143,7 +161,7 @@ jobs:
                   echo "Violation: conformance core change must use feat(conformance): or fix(conformance):."
                 fi
               else
-                # Rule 4: everything else must be chore or ci.
+                # Rule 5: everything else must be chore or ci.
                 chore_re='^(chore|ci)(\([^)]*\))?!?:'
                 if [[ "${PR_TITLE}" =~ $chore_re ]]; then
                   echo "Non-source change with a chore/ci title. ✅"
@@ -163,7 +181,20 @@ jobs:
 
           # Build the sticky-comment body for the violating case.
           if [ "$violation" = true ]; then
-            if [ "$expected" = "ct-core" ]; then
+            if [ "$expected" = "docker-img" ]; then
+              cat > pr-title-comment.md <<'EOF'
+          ### 🏷️ Docker image changes need a `feat`/`fix` title
+
+          This PR changes a file baked into the published Docker image
+          (`Dockerfile` and/or `entrypoint.sh`), so it's user-facing runtime
+          behavior and its title must be:
+
+          - `feat: …` / `feat(scope): …`
+          - `fix: …` / `fix(scope): …`
+
+          Editing the PR title re-runs this check and clears this comment automatically.
+          EOF
+            elif [ "$expected" = "ct-core" ]; then
               cat > pr-title-comment.md <<'EOF'
           ### 🏷️ contract-toolkit changes need a scoped `feat`/`fix` title
 
@@ -197,10 +228,11 @@ jobs:
               cat > pr-title-comment.md <<'EOF'
           ### 🏷️ Non-source PR shouldn't use a `feat`/`fix` title
 
-          This PR does not change shipped source (`application_sdk/`,
-          `contract-toolkit/` core, or `packages/conformance/` core), so a
-          `feat:`/`fix:` title would add it to the user-facing SDK changelog as a
-          real feature/fix — exactly the noise this check prevents.
+          This PR does not change shipped source (`application_sdk/`, the
+          Docker image inputs `Dockerfile`/`entrypoint.sh`, `contract-toolkit/`
+          core, or `packages/conformance/` core), so a `feat:`/`fix:` title
+          would add it to the user-facing SDK changelog as a real feature/fix
+          — exactly the noise this check prevents.
 
           **Use a non-surfacing conventional type instead:**
           - `ci:` / `ci(scope):` — changes to CI configuration and scripts
@@ -238,12 +270,14 @@ jobs:
         env:
           EXPECTED: ${{ steps.detect.outputs.expected }}
         run: |
-          if [ "${EXPECTED}" = "ct-core" ]; then
+          if [ "${EXPECTED}" = "docker-img" ]; then
+            echo "::error title=Invalid PR title::Docker image changes (Dockerfile/entrypoint.sh) must use 'feat:' or 'fix:'."
+          elif [ "${EXPECTED}" = "ct-core" ]; then
             echo "::error title=Invalid PR title::contract-toolkit core changes must use 'feat(contract-toolkit):' or 'fix(contract-toolkit):'."
           elif [ "${EXPECTED}" = "cf-core" ]; then
             echo "::error title=Invalid PR title::conformance core changes must use 'feat(conformance):' or 'fix(conformance):'."
           else
-            echo "::error title=Invalid PR title::Non-source changes must use 'chore:' or 'ci:' (feat:/fix: are reserved for application_sdk/, contract-toolkit core, and packages/conformance core)."
+            echo "::error title=Invalid PR title::Non-source changes must use 'chore:' or 'ci:' (feat:/fix: are reserved for application_sdk/, Dockerfile/entrypoint.sh, contract-toolkit core, and packages/conformance core)."
           fi
           exit 1
 


### PR DESCRIPTION
## Summary
- The PR title convention guard classified `Dockerfile`/`entrypoint.sh` changes as non-source (chore/ci only), even though both files are baked into every published application image and ship user-facing runtime behavior.
- Adds a dedicated rule: any PR touching `Dockerfile` or `entrypoint.sh` must use a `feat:`/`fix:` title (checked right after the `application_sdk/` rule, before the contract-toolkit/conformance core rules).
- Updated the sticky-comment and `::error` messaging for the new violation case, and renumbered the documented precedence rules accordingly.

## Test plan
- [x] `uv run pre-commit run --all-files` — clean
- [x] `uv run python -m pytest tests/unit -x -q` — 5378 passed, 9 skipped
- [x] Simulated the bash classification logic standalone against several file/title combinations (entrypoint.sh + fix → pass, entrypoint.sh + chore → violation, Dockerfile + fix → pass, docs-only + chore → pass, application_sdk/ + entrypoint.sh → unrestricted, contract-toolkit core → unaffected)