### PR TITLE
fix(storage): hash files off the event loop in materialize_file_reference

### DIFF
--- a/application_sdk/storage/reference.py
+++ b/application_sdk/storage/reference.py
@@ -105,6 +105,19 @@ def _sha256_hex_file(path: Path) -> str:
     return h.hexdigest()
 
 
+async def _sha256_hex_file_async(path: Path) -> str:
+    """Run :func:`_sha256_hex_file` in a worker thread.
+
+    ``_sha256_hex_file`` reads and digests the whole file with no ``await``;
+    calling it directly on the event loop blocks the loop for the full
+    read+hash. A blocked loop cannot run the SDK's auto-heartbeat coroutine, so
+    activities that verify many/large files heartbeat-time-out even while making
+    progress. Offloading to a thread keeps the loop responsive — the same reason
+    directory listing is wrapped in ``asyncio.to_thread`` in ``persist``.
+    """
+    return await asyncio.to_thread(_sha256_hex_file, path)
+
+
 async def _get_stored_sidecar(storage_path: str, store: ObjectStore) -> str | None:
     """Fetch the stored sha256 sidecar for *storage_path*, or None if absent.
 
@@ -409,7 +422,7 @@ async def materialize_file_reference(
         # Fast path: local file exists — validate before deciding to download.
         stored_hash: str | None = None
         if ref.local_path is not None and Path(ref.local_path).exists():
-            local_hash = _sha256_hex_file(Path(ref.local_path))
+            local_hash = await _sha256_hex_file_async(Path(ref.local_path))
             stored_hash = await _get_stored_sidecar(ref.storage_path, store)
 
             if stored_hash is not None and local_hash == stored_hash:
@@ -580,7 +593,7 @@ async def materialize_file_reference(
             # OOM recoveries on the same node) free after the first pass.
             if dest_path.exists() and dest_sidecar.exists():
                 try:
-                    local_hash = _sha256_hex_file(dest_path)
+                    local_hash = await _sha256_hex_file_async(dest_path)
                     if local_hash == dest_sidecar.read_text().strip():
                         logger.debug(
                             "file_ref.materialize.skipped",

--- a/application_sdk/storage/reference.py
+++ b/application_sdk/storage/reference.py
@@ -49,6 +49,7 @@ from typing import TYPE_CHECKING
 
 from application_sdk.common._listing import safe_list_directory
 from application_sdk.contracts.types import FileReference
+from application_sdk.execution.heartbeat import run_in_thread
 
 if TYPE_CHECKING:
     from obstore.store import ObjectStore
@@ -112,10 +113,12 @@ async def _sha256_hex_file_async(path: Path) -> str:
     calling it directly on the event loop blocks the loop for the full
     read+hash. A blocked loop cannot run the SDK's auto-heartbeat coroutine, so
     activities that verify many/large files heartbeat-time-out even while making
-    progress. Offloading to a thread keeps the loop responsive — the same reason
-    directory listing is wrapped in ``asyncio.to_thread`` in ``persist``.
+    progress. Uses ``run_in_thread`` (dedicated pool) rather than
+    ``asyncio.to_thread`` (asyncio's default executor) so this doesn't
+    contend with Temporal's own use of the default executor — same reason
+    directory listing is offloaded this way in ``persist``.
     """
-    return await asyncio.to_thread(_sha256_hex_file, path)
+    return await run_in_thread(_sha256_hex_file, path)
 
 
 async def _get_stored_sidecar(storage_path: str, store: ObjectStore) -> str | None:
@@ -218,8 +221,9 @@ async def persist_file_reference(
     if local.is_dir():
         # ── Directory upload ───────────────────────────────────────────────
         prefix = _make_storage_prefix(ref, output_path=output_path)
-        # to_thread keeps the blocking fsync + scandir off the event loop.
-        files = await asyncio.to_thread(safe_list_directory, local)
+        # run_in_thread keeps the blocking fsync + scandir off the event loop,
+        # using the dedicated pool rather than asyncio's default executor.
+        files = await run_in_thread(safe_list_directory, local)
         _t0 = time.monotonic()
         logger.info(
             "file_ref.persist.start",

--- a/application_sdk/storage/transfer.py
+++ b/application_sdk/storage/transfer.py
@@ -43,6 +43,7 @@ from typing import TYPE_CHECKING
 from application_sdk.common._listing import safe_list_directory
 from application_sdk.constants import MAX_CONCURRENT_STORAGE_TRANSFERS
 from application_sdk.contracts.types import FileReference, StorageTier
+from application_sdk.execution.heartbeat import run_in_thread
 from application_sdk.observability.logger_adaptor import get_logger
 
 _logger = get_logger(__name__)
@@ -492,8 +493,9 @@ async def upload(
             normalize_key,
             append_leaf=False,
         )
-        # to_thread keeps the blocking fsync + scandir off the event loop.
-        files = await asyncio.to_thread(safe_list_directory, src)
+        # run_in_thread keeps the blocking fsync + scandir off the event loop,
+        # using the dedicated pool rather than asyncio's default executor.
+        files = await run_in_thread(safe_list_directory, src)
         if raise_on_empty and not files:
             from application_sdk.storage.errors import (  # noqa: PLC0415
                 StorageEmptyUploadError,

--- a/application_sdk/storage/transfer.py
+++ b/application_sdk/storage/transfer.py
@@ -76,6 +76,19 @@ def _sha256_file(path: Path) -> str:
     return h.hexdigest()
 
 
+async def _sha256_file_async(path: Path) -> str:
+    """Run :func:`_sha256_file` in a worker thread.
+
+    ``_sha256_file`` reads and digests the whole file with no ``await``;
+    calling it directly on the event loop blocks the loop for the full
+    read+hash. A blocked loop cannot run the SDK's auto-heartbeat coroutine, so
+    ``App.upload``/``App.download`` (``skip_if_exists=True``) heartbeat-time-out
+    on large files even while making progress — the same failure mode fixed in
+    ``storage.reference._sha256_hex_file_async``.
+    """
+    return await run_in_thread(_sha256_file, path)
+
+
 async def _get_remote_sha256(store: ObjectStore, key: str) -> str | None:
     """Fetch the stored SHA-256 sidecar for *key*, or ``None`` if absent."""
     from application_sdk.storage.ops import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
@@ -108,7 +121,7 @@ async def _upload_one(
     )
 
     if skip_if_exists:
-        local_digest = _sha256_file(local_file)
+        local_digest = await _sha256_file_async(local_file)
         remote_digest = await _get_remote_sha256(store, store_key)
         if remote_digest == local_digest:
             return False, "skipped:hash_match"
@@ -193,7 +206,7 @@ async def _download_one(
     if skip_if_exists and local_file.exists():
         remote_digest = await _get_remote_sha256(store, store_key)
         if remote_digest is not None:
-            local_digest = _sha256_file(local_file)
+            local_digest = await _sha256_file_async(local_file)
             if local_digest == remote_digest:
                 return False, "skipped:hash_match"
 

--- a/tests/unit/storage/test_reference.py
+++ b/tests/unit/storage/test_reference.py
@@ -17,6 +17,7 @@ from application_sdk.storage.factory import create_memory_store
 from application_sdk.storage.ops import _get_bytes, _put
 from application_sdk.storage.reference import (
     _sha256_hex_file,
+    _sha256_hex_file_async,
     _write_local_sidecar,
     materialize_file_reference,
     persist_file_reference,
@@ -59,14 +60,13 @@ class TestSha256HelperAsync:
     Hashing a file on the event loop blocks it for the full read+digest. A
     blocked loop cannot run the SDK's auto-heartbeat coroutine, so long-running
     activities heartbeat-time-out even while making progress. This was the root
-    cause of the newday1 ``dbt:process`` failures: the extract-output
+    cause of a production RCA: dbt:process pipelines hit repeated
+    heartbeat-timeout failures because the extract-output
     ``materialize_file_reference`` verified thousands of files with the sync
     ``_sha256_hex_file`` on the loop, blocking it ~104s and starving heartbeats.
     """
 
     async def test_async_digest_matches_sync(self, tmp_path) -> None:
-        from application_sdk.storage.reference import _sha256_hex_file_async
-
         f = tmp_path / "data.bin"
         content = b"some bytes here" * 1024
         f.write_bytes(content)
@@ -108,6 +108,27 @@ class TestSha256HelperAsync:
 
         release.set()
         assert await task == "deadbeef"
+
+    async def test_uses_run_in_thread_pool(self, tmp_path) -> None:
+        """Pins the pool choice: must go through ``run_in_thread``, not
+        ``asyncio.to_thread``.
+
+        ``run_in_thread`` dispatches to the SDK's dedicated ``sdk-blocking-*``
+        pool rather than asyncio's shared default executor, which Temporal's
+        own SDK also uses for internal scheduling — sharing that pool risks
+        exhausting it. This fails if a future edit reverts to
+        ``asyncio.to_thread``.
+        """
+        f = tmp_path / "data.bin"
+        f.write_bytes(b"payload")
+
+        with patch.object(
+            reference_mod, "run_in_thread", wraps=reference_mod.run_in_thread
+        ) as mock_run_in_thread:
+            digest = await _sha256_hex_file_async(f)
+
+        mock_run_in_thread.assert_awaited_once_with(_sha256_hex_file, f)
+        assert digest == _hash_bytes(b"payload")
 
 
 class TestWriteLocalSidecar:

--- a/tests/unit/storage/test_reference.py
+++ b/tests/unit/storage/test_reference.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
+import threading
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from application_sdk.contracts.types import FileReference, StorageTier
+from application_sdk.storage import reference as reference_mod
 from application_sdk.storage.errors import StorageError, StorageNotFoundError
 from application_sdk.storage.factory import create_memory_store
 from application_sdk.storage.ops import _get_bytes, _put
@@ -47,6 +50,64 @@ class TestSha256Helper:
         f = tmp_path / "empty.bin"
         f.write_bytes(b"")
         assert _sha256_hex_file(f) == hashlib.sha256(b"").hexdigest()
+
+
+class TestSha256HelperAsync:
+    """``_sha256_hex_file_async`` must offload the synchronous, no-``await``
+    ``_sha256_hex_file`` to a worker thread.
+
+    Hashing a file on the event loop blocks it for the full read+digest. A
+    blocked loop cannot run the SDK's auto-heartbeat coroutine, so long-running
+    activities heartbeat-time-out even while making progress. This was the root
+    cause of the newday1 ``dbt:process`` failures: the extract-output
+    ``materialize_file_reference`` verified thousands of files with the sync
+    ``_sha256_hex_file`` on the loop, blocking it ~104s and starving heartbeats.
+    """
+
+    async def test_async_digest_matches_sync(self, tmp_path) -> None:
+        from application_sdk.storage.reference import _sha256_hex_file_async
+
+        f = tmp_path / "data.bin"
+        content = b"some bytes here" * 1024
+        f.write_bytes(content)
+        assert await _sha256_hex_file_async(f) == _hash_bytes(content)
+
+    async def test_hashing_does_not_block_event_loop(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # Hold whatever thread the sync hash runs on until released, so the loop
+        # stays responsive ONLY if the hash was offloaded off the event loop.
+        entered = threading.Event()
+        release = threading.Event()
+
+        def blocking_hash(_path: Path) -> str:
+            entered.set()
+            if not release.wait(timeout=5):
+                raise AssertionError("release was never signaled")
+            return "deadbeef"
+
+        monkeypatch.setattr(reference_mod, "_sha256_hex_file", blocking_hash)
+
+        f = tmp_path / "f.bin"
+        f.write_bytes(b"data")
+        task = asyncio.create_task(reference_mod._sha256_hex_file_async(f))
+
+        # If hashing ran on the loop, blocking_hash() would freeze the loop here
+        # and these awaits would never progress. Offloaded → loop stays live.
+        for _ in range(500):
+            if entered.is_set():
+                break
+            await asyncio.sleep(0.005)
+        assert entered.is_set(), "hash never started"
+
+        progressed = 0
+        for _ in range(10):
+            await asyncio.sleep(0.005)
+            progressed += 1
+        assert progressed == 10  # loop advanced while the hash held its thread
+
+        release.set()
+        assert await task == "deadbeef"
 
 
 class TestWriteLocalSidecar:

--- a/tests/unit/storage/test_transfer.py
+++ b/tests/unit/storage/test_transfer.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import sys
+import threading
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from application_sdk.contracts.storage import UploadOutput
+from application_sdk.storage import transfer as transfer_mod
 from application_sdk.storage.factory import create_memory_store
 from application_sdk.storage.transfer import download, upload
 
@@ -16,6 +22,80 @@ _IS_WINDOWS = sys.platform == "win32"
 @pytest.fixture
 def store():
     return create_memory_store()
+
+
+def _hash_bytes(data: bytes) -> str:
+    h = hashlib.sha256()
+    h.update(data)
+    return h.hexdigest()
+
+
+class TestSha256FileAsync:
+    """``_sha256_file_async`` must offload the synchronous, no-``await``
+    ``_sha256_file`` to a worker thread — the same failure mode fixed in
+    ``storage.reference._sha256_hex_file_async``: hashing a file on the event
+    loop blocks it for the full read+digest, starving the SDK's auto-heartbeat
+    coroutine and heartbeat-timing-out ``App.upload``/``App.download`` on
+    large files (``skip_if_exists=True``) even while making progress.
+    """
+
+    async def test_async_digest_matches_sync(self, tmp_path) -> None:
+        f = tmp_path / "data.bin"
+        content = b"some bytes here" * 1024
+        f.write_bytes(content)
+        assert await transfer_mod._sha256_file_async(f) == _hash_bytes(content)
+
+    async def test_hashing_does_not_block_event_loop(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # Hold whatever thread the sync hash runs on until released, so the loop
+        # stays responsive ONLY if the hash was offloaded off the event loop.
+        entered = threading.Event()
+        release = threading.Event()
+
+        def blocking_hash(_path: Path) -> str:
+            entered.set()
+            if not release.wait(timeout=5):
+                raise AssertionError("release was never signaled")
+            return "deadbeef"
+
+        monkeypatch.setattr(transfer_mod, "_sha256_file", blocking_hash)
+
+        f = tmp_path / "f.bin"
+        f.write_bytes(b"data")
+        task = asyncio.create_task(transfer_mod._sha256_file_async(f))
+
+        # If hashing ran on the loop, blocking_hash() would freeze the loop here
+        # and these awaits would never progress. Offloaded → loop stays live.
+        for _ in range(500):
+            if entered.is_set():
+                break
+            await asyncio.sleep(0.005)
+        assert entered.is_set(), "hash never started"
+
+        progressed = 0
+        for _ in range(10):
+            await asyncio.sleep(0.005)
+            progressed += 1
+        assert progressed == 10  # loop advanced while the hash held its thread
+
+        release.set()
+        assert await task == "deadbeef"
+
+    async def test_uses_run_in_thread_pool(self, tmp_path) -> None:
+        """Pins the pool choice: must go through ``run_in_thread``, not
+        ``asyncio.to_thread`` (see reference.py's equivalent test for why).
+        """
+        f = tmp_path / "data.bin"
+        f.write_bytes(b"payload")
+
+        with patch.object(
+            transfer_mod, "run_in_thread", wraps=transfer_mod.run_in_thread
+        ) as mock_run_in_thread:
+            digest = await transfer_mod._sha256_file_async(f)
+
+        mock_run_in_thread.assert_awaited_once_with(transfer_mod._sha256_file, f)
+        assert digest == _hash_bytes(b"payload")
 
 
 class TestUploadSingleFile:


### PR DESCRIPTION
### Changelog
- `materialize_file_reference` verified local files with the **synchronous, no-`await` `_sha256_hex_file`** (a full read+digest loop) **directly on the asyncio event loop** — at both the single-file fast path and the per-file multi-file download path.
- On a large reference (e.g. a connector's extract output = thousands of files) this hashing serializes on the loop and blocks it for **100s+ at a stretch**.
- A blocked loop can't run the SDK auto-heartbeat coroutine (`auto_heartbeat_loop`, 20s interval), so activities that materialize/persist sizeable references **heartbeat-time-out even while making progress** and nowhere near OOM.
- Added `_sha256_hex_file_async`, which runs the hash via the dedicated `run_in_thread` pool — the **same pattern already used for directory listing** in `persist_file_reference` (`await run_in_thread(safe_list_directory, ...)`) — and switched both hash-verification sites to it. Digest + cache-skip behaviour are unchanged.
- `run_in_thread` (dedicated `sdk-blocking-*` pool) is used instead of `asyncio.to_thread` (asyncio's shared default executor) so this doesn't contend with Temporal's own use of the default executor.
- `transfer.py`'s `_upload_one`/`_download_one` had the identical hazard for the `skip_if_exists` dedup check (reachable from `App.upload()`/`App.download()`, both heartbeat-enabled `@task` methods). Added `_sha256_file_async` there too and switched both call sites.

### Additional context (e.g. screenshots, logs, links)
- **Root cause of a production RCA: repeated `dbt:process` heartbeat-timeout failures.** `generate_lineage` timed out on all 3 attempts (300s each, **zero heartbeats delivered**). The SDK's own diagnostic fired in ClickHouse:
  `Event loop blocked for 104.6s during task generate_lineage, auto-heartbeating may be unreliable`
  Meanwhile RSS sat at ~18% of the container limit, **0 restarts, 0 CPU throttling** — so this was **not** OOM or a slow-CPU problem. The lineage computation itself is only ~3s; the 100s+ block is this on-loop file hashing during the extract-output `materialize_file_reference`.
- A prior connector-side fix wrapping the lineage compute in `run_in_thread` did **not** help, because the compute was never the bottleneck — the blocking work is this storage-layer hashing on the event loop, which is why the fix belongs in the SDK.
- **Scope note:** `upload_file`'s chunked `fh.read()` loop yields per chunk via `await writer.write(...)`, so it does *not* continuously block the loop; this PR targets the proven continuous blocker (`_sha256_hex_file` / `_sha256_file`). If profiling later shows the per-chunk reads matter, they can be offloaded in a follow-up.
- **Tests:** `tests/unit/storage/test_reference.py::TestSha256HelperAsync` and `tests/unit/storage/test_transfer.py::TestSha256FileAsync` — digest-equivalence, a **deterministic** event-loop-responsiveness test (uses a `threading.Event`-gated fake hash, no timing/sleep assertions) that fails if hashing is ever moved back onto the loop, and a test pinning `run_in_thread` (not `asyncio.to_thread`) as the dispatch pool. Full storage unit suite passes; `ruff`, `ruff-format`, and `pyright` are clean.

### Checklist
- [x] Additional tests added
- [x] All CI checks passed
- [ ] Relevant documentation updated

### Copyleft License Compliance
- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)? — **No.**

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
