### PR TITLE
chore(ci): sdk-review VPN connectivity smoke test

### DIFF
--- a/.sdk-review-vpn-smoke-test.md
+++ b/.sdk-review-vpn-smoke-test.md
@@ -1,0 +1,5 @@
+# sdk-review VPN connectivity smoke test
+
+Throw-away PR to trigger the sdk-review workflow and verify the VPN
+connect step now succeeds after the repo-level GlobalProtect override
+was removed (falls back to org-level credential). Safe to close.


### PR DESCRIPTION
**Dummy PR — do not merge.**

Triggers `@sdk-review` to verify the VPN connect step succeeds now that the repo-level GlobalProtect secret override was removed (workflow now inherits the org-level credential). Will close once the VPN step result is confirmed.