### PR TITLE
ci(conformance): make conformance-reusable callable cross-repo (full-path action ref)

### DIFF
--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -341,7 +341,7 @@ jobs:
 
       - name: "Run ${{ matrix.series }}-series checks"
         if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push' || inputs.force-all
-        uses: ./.github/actions/run-conformance-detect
+        uses: atlanhq/application-sdk/.github/actions/run-conformance-detect@main
         with:
           series: ${{ matrix.series }}
           slug: ${{ matrix.slug }}


### PR DESCRIPTION
The connector apps that adopt the conformance gate (DISTR-850) call `conformance-reusable.yaml@main` cross-repo. That call currently **startup-fails** because the reusable references its detect action locally:

```
uses: ./.github/actions/run-conformance-detect
```

A `./` action path inside a reusable workflow resolves against the **caller** repo when invoked cross-repo — the caller (e.g. `atlan-oracle-app`) has no such action, so the run fails at startup (verified on atlan-oracle-app#188 → `startup_failure`, 1s). The SDK's own `conformance.yaml` calls the reusable locally, so it never hit this.

**Fix:** reference the action by full path so it always resolves to this repo:
```
uses: atlanhq/application-sdk/.github/actions/run-conformance-detect@main
```

One-line change; behavior identical for the SDK's own (local) invocation, and it unblocks the 5 app enforcement PRs (mssql/oracle/redshift/tableau/saperp) whose Conformance check currently startup-fails. No other `./` local action refs exist in the reusable. (Minor known trade-off: for SDK PRs that edit `run-conformance-detect` itself, the reusable now picks it up from `@main` rather than the PR sha — acceptable; the detect action is low-churn.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)