### PR TITLE
ci(conformance): revert - make conformance-reusable callable cross-repo (full-path action ref)

### DIFF
--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -341,7 +341,7 @@ jobs:
 
       - name: "Run ${{ matrix.series }}-series checks"
         if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push' || inputs.force-all
-        uses: atlanhq/application-sdk/.github/actions/run-conformance-detect@main
+        uses: ./.github/actions/run-conformance-detect
         with:
           series: ${{ matrix.series }}
           slug: ${{ matrix.slug }}


### PR DESCRIPTION
Reverts atlanhq/application-sdk#2549