### PR TITLE
ci(conformance-dashboard): carry description/rationale in rule catalog

### DIFF
--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -459,19 +459,23 @@ jobs:
                       tool_versions.add(driver["version"])
 
                   # Build rule catalog from the embedded descriptors — carry
-                  # tier/category/series/since so connector-pulse never needs
-                  # to re-fetch the rule metadata separately.
+                  # tier/category/series/since/description/rationale so
+                  # connector-pulse never needs to re-fetch the rule metadata
+                  # (or bundle its own static copy) separately.
                   for rule in driver.get("rules", []):
                       rid = rule.get("id")
                       if rid and rid not in rule_catalog:
                           props = rule.get("properties", {})
                           rule_catalog[rid] = {
-                              "name":     rule.get("name", ""),
-                              "tier":     props.get("atlan/tier", ""),
-                              "category": props.get("atlan/category", ""),
-                              "series":   props.get("atlan/series", ""),
-                              "since":    props.get("atlan/since", ""),
-                              "helpUri":  rule.get("helpUri", ""),
+                              "name":             rule.get("name", ""),
+                              "tier":             props.get("atlan/tier", ""),
+                              "category":         props.get("atlan/category", ""),
+                              "series":           props.get("atlan/series", ""),
+                              "since":            props.get("atlan/since", ""),
+                              "helpUri":          rule.get("helpUri", ""),
+                              "shortDescription": (rule.get("shortDescription") or {}).get("text", ""),
+                              "fullDescription":  (rule.get("fullDescription") or {}).get("text", ""),
+                              "rationale":        props.get("atlan/rationale", ""),
                           }
 
                   # Run-level pre-computed summary (accurate counts from the suite).


### PR DESCRIPTION
## Summary
- `update-dashboard.yaml`'s per-repo summary parser builds `ruleCatalog` from each SARIF's embedded rule descriptors, but only pulled `tier`/`category`/`series`/`since`/`helpUri`. Every descriptor already carries `shortDescription`/`fullDescription` (top-level `ReportingDescriptor` fields) and `rationale` (`properties["atlan/rationale"]`) — `RuleDefinition.to_reporting_descriptor()` has set these for a while, they just weren't being read on the dashboard side.
- Adds those three fields to the same dict build. Rides the existing 6-hourly refresh — no new publishing step, no schema version bump.
- Context: connector-pulse (the external consumer of `k.atlan.dev/conformance-dashboard`) wants to show rule descriptions/rationale on hover, and currently has to bundle its own static, manually-regenerated snapshot of this same data (from the typed rule registry) because the dashboard JSON didn't carry it. Once this ships, that snapshot can be deleted — see [connector-pulse#485](https://github.com/atlanhq/connector-pulse/pull/485).

## Test plan
- [x] `python -m py_compile` on the dedented embedded Python block — syntax clean
- [x] `yaml.safe_load` on the workflow file — structure valid
- [x] Confirmed the exact SARIF field shape (`shortDescription.text`, `fullDescription.text`, `properties["atlan/rationale"]`) by calling `RuleDefinition.to_reporting_descriptor()` directly against a live rule (T001) in `packages/conformance`
- [ ] `workflow_dispatch` on this branch to confirm a real per-repo `repos/<slug>.json` picks up the new fields (workflow needs GH Actions to actually run — flagging for reviewer to trigger, or I can if you'd like)

🤖 Generated with [Claude Code](https://claude.com/claude-code)