### PR TITLE
fix: add P031 rule for shared-default-executor offload

### DIFF
--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -34,6 +34,7 @@ from application_sdk.common.aws_utils import (
 from application_sdk.constants import AWS_SESSION_NAME, USE_SERVER_SIDE_CURSOR
 from application_sdk.credentials.utils import parse_credentials_extra
 from application_sdk.errors import AppError, sanitize_cause_repr
+from application_sdk.execution.heartbeat import run_in_thread
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
@@ -120,9 +121,11 @@ class BaseSQLClient(ClientInterface):
             install_tolerant_text_decoder_hook(self.engine)
 
             # Test connection briefly to validate credentials.
-            # Wrapped in asyncio.to_thread because SQLAlchemy's synchronous
+            # Wrapped in run_in_thread because SQLAlchemy's synchronous
             # engine.connect() blocks the event loop — critical for Temporal
-            # activities where blocking starves the auto-heartbeat.
+            # activities where blocking starves the auto-heartbeat. run_in_thread
+            # dispatches onto the SDK's dedicated pool rather than asyncio's
+            # shared default executor, which Temporal's own scheduling also uses.
             # Capture engine in a local variable so the closure doesn't need to
             # re-read self.engine (which is typed Optional) and pyright can narrow it.
             _engine = self.engine
@@ -131,7 +134,7 @@ class BaseSQLClient(ClientInterface):
                 with _engine.connect() as _:
                     pass  # Connection test successful
 
-            await asyncio.to_thread(_ping)
+            await run_in_thread(_ping)
 
             # Don't store persistent connection
             self.connection = None

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -1810,7 +1810,8 @@ def _register_workflow_routes(
                 # The hook is async-only (discovery rejects sync defs), so
                 # await it directly. Authors doing CPU/IO-bound work inside
                 # (SQL generation, full DAG rewrite) own offloading it — e.g.
-                # `await self.run_in_thread(...)` — rather than the SDK
+                # `from application_sdk.execution.heartbeat import run_in_thread`
+                # then `await run_in_thread(...)` — rather than the SDK
                 # guessing on their behalf.
                 computed = await compute(manifest_dict, fe_inputs_decoded)
             except HTTPException:

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -28,7 +28,6 @@ Usage::
 
 from __future__ import annotations
 
-import asyncio
 import dataclasses
 import inspect
 import json
@@ -59,6 +58,7 @@ from application_sdk.constants import CONTRACT_GENERATED_DIR as _CONTRACT_GENERA
 from application_sdk.constants import DEPLOYMENT_NAME, LOCAL_ENVIRONMENT
 from application_sdk.errors import AppError
 from application_sdk.errors.categories import FailureCategory
+from application_sdk.execution.heartbeat import run_in_thread
 from application_sdk.handler.base import Handler, HandlerError
 from application_sdk.handler.context import HandlerContext, bind_handler_context
 from application_sdk.handler.contracts import (
@@ -1496,7 +1496,7 @@ def _register_workflow_routes(
                     shutil.copyfileobj(file.file, dst)
                 return os.path.getsize(safe_tmp_path)
 
-            file_size = await asyncio.to_thread(_drain_to_tmp)
+            file_size = await run_in_thread(_drain_to_tmp)
             await _upload_file(key, safe_tmp_path, _storage)
         finally:
             try:
@@ -1810,7 +1810,7 @@ def _register_workflow_routes(
                 # The hook is async-only (discovery rejects sync defs), so
                 # await it directly. Authors doing CPU/IO-bound work inside
                 # (SQL generation, full DAG rewrite) own offloading it — e.g.
-                # `await asyncio.to_thread(...)` — rather than the SDK
+                # `await self.run_in_thread(...)` — rather than the SDK
                 # guessing on their behalf.
                 computed = await compute(manifest_dict, fe_inputs_decoded)
             except HTTPException:

--- a/application_sdk/observability/pushgateway.py
+++ b/application_sdk/observability/pushgateway.py
@@ -35,6 +35,7 @@ from prometheus_client import (
 from prometheus_client.exposition import default_handler
 from prometheus_client.parser import text_string_to_metric_families
 
+from application_sdk.execution.heartbeat import run_in_thread
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.observability.pushgateway_errors import (
     PushGatewayJobRequiredError,
@@ -188,7 +189,7 @@ class PushGatewayClient:
         # this pod is also pushing fresh data.
         if self._sweep_stale_on_start:
             try:
-                await asyncio.to_thread(self._sweep_stale_predecessors_blocking)
+                await run_in_thread(self._sweep_stale_predecessors_blocking)
             except Exception:
                 logger.warning(
                     "Pushgateway startup sweep failed — proceeding with push",
@@ -205,7 +206,7 @@ class PushGatewayClient:
         )
 
     async def push_now(self) -> None:
-        await asyncio.to_thread(self._push_blocking)
+        await run_in_thread(self._push_blocking)
 
     async def stop(self) -> None:
         self._stopped.set()
@@ -248,7 +249,7 @@ class PushGatewayClient:
                     # startup sweep instead.
                     raise
             try:
-                await asyncio.to_thread(self._delete_blocking)
+                await run_in_thread(self._delete_blocking)
             except Exception:
                 logger.warning("Pushgateway delete on shutdown failed", exc_info=True)
 

--- a/packages/conformance/conformance/docs/rules/prescriptions.md
+++ b/packages/conformance/conformance/docs/rules/prescriptions.md
@@ -5,7 +5,7 @@
 
 # Prescription Rules (P-series)
 
-**30 rules** · Checker: `suite.checks.prescriptions` (P001–P003, P008–P015), `suite.checks.orchestration` (P004–P007, scans test files too), `suite.checks.entrypoint_alignment` (P016), `suite.checks.entrypoint` (P017–P018, scans test files too), `suite.checks.client_seam` (P019), `suite.checks.determinism` (P020–P024), `suite.checks.app_name_alignment` (P025) (all AST-based / cross-artifact)
+**31 rules** · Checker: `suite.checks.prescriptions` (P001–P003, P008–P015), `suite.checks.orchestration` (P004–P007, scans test files too), `suite.checks.entrypoint_alignment` (P016), `suite.checks.entrypoint` (P017–P018, scans test files too), `suite.checks.client_seam` (P019), `suite.checks.determinism` (P020–P024, P031), `suite.checks.app_name_alignment` (P025) (all AST-based / cross-artifact)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -53,6 +53,7 @@ reassigned.
 | [P028](#p028) | `ManualQualifiedNameFString` | `warn` | `app` | `asset-modeling` | — | 0.9.0 |
 | [P029](#p029) | `SdrManifestMissingAgentJson` | `block` | `app` | `sdr-readiness` | — | 0.9.0 |
 | [P030](#p030) | `SdrUploadNotCalled` | `warn` | `app` | `sdr-readiness` | — | 0.9.0 |
+| [P031](#p031) | `SharedDefaultExecutorOffload` | `warn` | `both` | `async-correctness` | — | 0.13.0 |
 
 ---
 
@@ -1015,5 +1016,39 @@ Exemption: this rule is skipped for apps whose `contract/app.pkl` sets `pipeline
 = null` (no publish stage), which compiles to a generated manifest with no `dag.publish`
 node.  An extract-only app has nothing to hand the extracted assets off to, so the
 absence of `self.upload()` is by design, not a gap.
+
+---
+
+## P031 — `SharedDefaultExecutorOffload` {#p031}
+
+**Tier:** `warn` · **Scope:** `both` · **Category:** `async-correctness` · **Autofixable:** — · **Since:** 0.13.0
+
+> Thread offload onto asyncio's shared default executor instead of run_in_thread()
+
+**Rationale:** asyncio.to_thread(...) and run_in_executor(None, ...) both dispatch onto asyncio's
+shared default executor. Temporal's Python SDK uses that same default executor
+internally for its own scheduling, so routing long-running blocking work through it can
+exhaust the pool and deadlock the worker. The SDK exposes a dedicated escape hatch,
+run_in_thread(), which dispatches onto its own thread pool specifically to avoid this
+contention — a prior fix shipped a raw asyncio.to_thread(...) call that nothing caught
+in review.
+
+A call offloads blocking work onto asyncio's **shared default** executor instead of the
+SDK's dedicated `run_in_thread()` pool: `asyncio.to_thread(...)`, or
+`run_in_executor(None, ...)` (including `loop.run_in_executor(None, ...)` /
+`asyncio.get_event_loop().run_in_executor(None, ...)`).  Temporal's Python SDK uses that
+same default executor for its own internal scheduling, so sharing it with long-running
+blocking calls can exhaust the pool and deadlock the worker.  Use `run_in_thread()` —
+`App.run_in_thread()` or `self.task_context.run_in_thread()` — which dispatches onto the
+SDK's own dedicated `sdk-blocking-*` thread pool.
+
+`run_in_executor(<some-executor>, ...)` with any executor other than `None` is not
+flagged — a call-site-owned `ThreadPoolExecutor` is not the shared-pool contention this
+rule targets. `application_sdk/execution/heartbeat.py` is exempt: that is where
+`run_in_thread()`'s own dedicated-executor dispatch lives.
+
+Remediation is a restructure (swap in `run_in_thread()`), so findings route to residue.
+Land as `WARN`; suppress a reviewed exception with `# conformance: ignore[P031]
+<reason>`.
 
 ---

--- a/packages/conformance/conformance/suite/checks/determinism/__init__.py
+++ b/packages/conformance/conformance/suite/checks/determinism/__init__.py
@@ -16,6 +16,9 @@ bugs are caught at CI time rather than under production orchestration.
   ``async def``.
 * ``P024`` SyncAtlanClientInApp — pyatlan's synchronous ``AtlanClient`` used where
   the async ``AsyncAtlanClient`` (via the SDK credentials seam) is required.
+* ``P031`` SharedDefaultExecutorOffload — ``asyncio.to_thread(...)`` or
+  ``run_in_executor(None, ...)``, which land on asyncio's shared default executor
+  instead of the SDK's dedicated ``run_in_thread()`` pool.
 
 Discovery
 ---------
@@ -53,6 +56,7 @@ from ._p021_io import check_p021
 from ._p022_unawaited import check_p022
 from ._p023_blocking_async import check_p023
 from ._p024_sync_atlan_client import check_p024
+from ._p031_executor_offload import check_p031
 
 SERIES = "P"
 
@@ -60,7 +64,7 @@ __all__ = ["SERIES", "discover", "main", "scan_path", "scan_text"]
 
 
 def scan_text(text: str, file: str) -> list[Finding]:
-    """Scan a single Python source *text* for all determinism findings (P020–P024)."""
+    """Scan a single Python source *text* for all determinism findings (P020–P024, P031)."""
     try:
         tree = ast.parse(text, filename=file)
     except SyntaxError:
@@ -72,11 +76,12 @@ def scan_text(text: str, file: str) -> list[Finding]:
         *check_p022(tree, file, directives),
         *check_p023(tree, file, directives),
         *check_p024(tree, file, directives),
+        *check_p031(tree, file, directives),
     ]
 
 
 def scan_path(path: Path, root: Path) -> list[Finding]:
-    """Scan a single Python file for P020–P024 findings."""
+    """Scan a single Python file for P020–P024, P031 findings."""
     try:
         text = path.read_text(encoding="utf-8")
     except OSError:
@@ -90,7 +95,7 @@ def scan_path(path: Path, root: Path) -> list[Finding]:
 
 main = make_cli_main(
     scan_all=lambda paths, root: [f for p in paths for f in scan_path(p, root)],
-    description="Determinism / async-correctness P-series checks (P020-P024).",
+    description="Determinism / async-correctness P-series checks (P020-P024, P031).",
 )
 
 

--- a/packages/conformance/conformance/suite/checks/determinism/_p031_executor_offload.py
+++ b/packages/conformance/conformance/suite/checks/determinism/_p031_executor_offload.py
@@ -1,0 +1,115 @@
+"""P031 — SharedDefaultExecutorOffload.
+
+Flags thread offloads that land on asyncio's **shared default executor** instead
+of the SDK's dedicated ``run_in_thread()`` pool:
+
+* ``asyncio.to_thread(...)`` — always dispatches onto the default executor; there
+  is no way to pass a different one.
+* ``loop.run_in_executor(None, ...)`` / ``asyncio.get_event_loop().run_in_executor(None, ...)``
+  — the ``None`` executor argument means "use the default executor."
+
+Temporal's Python SDK uses that same default executor internally for its own
+scheduling (see the ``_BLOCKING_EXECUTOR`` comment in
+``application_sdk/execution/heartbeat.py``).  Sharing it with long-running
+blocking calls can exhaust the pool and deadlock the worker.  The SDK exposes a
+dedicated escape hatch, ``run_in_thread()`` (``App.run_in_thread()`` /
+``self.task_context.run_in_thread()``), which dispatches onto its own
+``sdk-blocking-*`` ``ThreadPoolExecutor`` specifically to avoid this.  A prior fix
+in ``storage/reference.py`` shipped with a raw ``asyncio.to_thread(...)`` call
+that nothing caught in review; this rule closes that gap.
+
+This deliberately does **not** flag ``run_in_executor(<some-executor>, ...)`` when
+the executor is anything other than the ``None`` literal — a call-site-owned
+``ThreadPoolExecutor`` (e.g. ``clients/sql.py``'s per-connection pool) is not the
+shared-pool contention this rule is about.
+
+``execution/heartbeat.py`` itself is exempt: that is where ``run_in_thread()``'s
+own dedicated-executor dispatch lives, and it never calls into the shared default
+executor (it always names ``_BLOCKING_EXECUTOR`` explicitly).
+"""
+
+from __future__ import annotations
+
+import ast
+
+from conformance.suite.checks._ast_common import _IgnoreDirective, make_finding
+from conformance.suite.checks.orchestration._temporal_common import (
+    collect_import_bindings,
+)
+from conformance.suite.schema.findings import Finding
+
+from ._workflow_methods import resolve_call_target
+
+RULE_ID = "P031"
+
+_TO_THREAD_EXACT = frozenset({"asyncio.to_thread"})
+_EXECUTOR_ATTR = "run_in_executor"
+
+# The one file allowed to touch the shared default executor's counterpart: this is
+# where run_in_thread()'s own dedicated-executor dispatch lives.
+_EXEMPT_SUFFIX = "execution/heartbeat.py"
+
+_HINT = (
+    "This offloads onto asyncio's shared default executor, which Temporal's "
+    "Python SDK also uses internally for its own scheduling — sharing it can "
+    "exhaust the pool and deadlock the worker. Use run_in_thread() / "
+    "App.run_in_thread() / self.task_context.run_in_thread() instead, which "
+    "dispatches onto the SDK's dedicated thread pool."
+)
+
+
+def _is_none_literal(node: ast.expr) -> bool:
+    return isinstance(node, ast.Constant) and node.value is None
+
+
+def _executor_arg_is_none(node: ast.Call) -> bool:
+    """True if *node* is a ``run_in_executor(...)`` call whose executor is ``None``.
+
+    The executor is the first positional argument, or the ``executor`` keyword.
+    """
+    if node.args:
+        return _is_none_literal(node.args[0])
+    for kw in node.keywords:
+        if kw.arg == "executor":
+            return _is_none_literal(kw.value)
+    return False
+
+
+def check_p031(
+    tree: ast.AST, filename: str, directives: dict[int, _IgnoreDirective]
+) -> list[Finding]:
+    """Emit P031 findings for offloads onto asyncio's shared default executor."""
+    if filename.replace("\\", "/").endswith(_EXEMPT_SUFFIX):
+        return []
+    bindings = collect_import_bindings(tree)
+    findings: list[Finding] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Attribute) and node.func.attr == _EXECUTOR_ATTR:
+            if _executor_arg_is_none(node):
+                findings.append(
+                    make_finding(
+                        filename=filename,
+                        rule_id=RULE_ID,
+                        node=node,
+                        message=(
+                            f"'.{_EXECUTOR_ATTR}(None, ...)' offloads onto the "
+                            f"shared default executor. {_HINT}"
+                        ),
+                        directives=directives,
+                    )
+                )
+            continue
+        target = resolve_call_target(node.func, bindings)
+        if target in _TO_THREAD_EXACT:
+            findings.append(
+                make_finding(
+                    filename=filename,
+                    rule_id=RULE_ID,
+                    node=node,
+                    message=f"'{target}()' offloads onto the shared default executor. {_HINT}",
+                    directives=directives,
+                )
+            )
+    return findings

--- a/packages/conformance/conformance/suite/rules/determinism.py
+++ b/packages/conformance/conformance/suite/rules/determinism.py
@@ -1,4 +1,4 @@
-"""Determinism / async-correctness rule definitions (P020–P024).
+"""Determinism / async-correctness rule definitions (P020–P024, P031).
 
 App and SDK code must respect the SDK's async and determinism expectations in the
 execution path.  Temporal **workflow** code (an ``App`` subclass's ``run`` /
@@ -226,5 +226,53 @@ RULES: tuple[RuleDefinition, ...] = (
             "``# conformance: ignore[P024] <reason>``.\n"
         ),
         help_uri=f"{_HELP_BASE}#p024",
+    ),
+    RuleDefinition(
+        id="P031",
+        scope=RuleScope.BOTH,
+        name="SharedDefaultExecutorOffload",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="async-correctness",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.13.0",
+        rationale=(
+            "asyncio.to_thread(...) and run_in_executor(None, ...) both dispatch "
+            "onto asyncio's shared default executor. Temporal's Python SDK uses "
+            "that same default executor internally for its own scheduling, so "
+            "routing long-running blocking work through it can exhaust the pool "
+            "and deadlock the worker. The SDK exposes a dedicated escape hatch, "
+            "run_in_thread(), which dispatches onto its own thread pool "
+            "specifically to avoid this contention — a prior fix shipped a raw "
+            "asyncio.to_thread(...) call that nothing caught in review."
+        ),
+        short_description=(
+            "Thread offload onto asyncio's shared default executor instead of "
+            "run_in_thread()"
+        ),
+        full_description=(
+            "A call offloads blocking work onto asyncio's **shared default**\n"
+            "executor instead of the SDK's dedicated ``run_in_thread()`` pool:\n"
+            "``asyncio.to_thread(...)``, or ``run_in_executor(None, ...)``\n"
+            "(including ``loop.run_in_executor(None, ...)`` /\n"
+            "``asyncio.get_event_loop().run_in_executor(None, ...)``).  Temporal's\n"
+            "Python SDK uses that same default executor for its own internal\n"
+            "scheduling, so sharing it with long-running blocking calls can exhaust\n"
+            "the pool and deadlock the worker.  Use ``run_in_thread()`` —\n"
+            "``App.run_in_thread()`` or ``self.task_context.run_in_thread()`` — which\n"
+            "dispatches onto the SDK's own dedicated ``sdk-blocking-*`` thread pool.\n"
+            "\n"
+            "``run_in_executor(<some-executor>, ...)`` with any executor other than\n"
+            "``None`` is not flagged — a call-site-owned ``ThreadPoolExecutor`` is\n"
+            "not the shared-pool contention this rule targets.\n"
+            "``application_sdk/execution/heartbeat.py`` is exempt: that is where\n"
+            "``run_in_thread()``'s own dedicated-executor dispatch lives.\n"
+            "\n"
+            "Remediation is a restructure (swap in ``run_in_thread()``), so findings\n"
+            "route to residue.  Land as ``WARN``; suppress a reviewed exception with\n"
+            "``# conformance: ignore[P031] <reason>``.\n"
+        ),
+        help_uri=f"{_HELP_BASE}#p031",
     ),
 )

--- a/packages/conformance/conformance/tools/generate_rule_docs.py
+++ b/packages/conformance/conformance/tools/generate_rule_docs.py
@@ -133,7 +133,7 @@ _SERIES_META: list[SeriesMeta] = [
             "`suite.checks.entrypoint_alignment` (P016), "
             "`suite.checks.entrypoint` (P017–P018, scans test files too), "
             "`suite.checks.client_seam` (P019), "
-            "`suite.checks.determinism` (P020–P024), "
+            "`suite.checks.determinism` (P020–P024, P031), "
             "`suite.checks.app_name_alignment` (P025) "
             "(all AST-based / cross-artifact)"
         ),

--- a/packages/conformance/pyproject.toml
+++ b/packages/conformance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atlan-application-sdk-conformance"
-version = "0.12.0"
+version = "0.13.0"
 description = "Conformance suite, remediation programs, and CLI for the Atlan Application SDK"
 license = "Apache-2.0"
 authors = [

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -344,7 +344,7 @@ def test_catalog_d_series_present() -> None:
 
 
 def test_catalog_p_series_present() -> None:
-    """The P-series prescription rules are exactly P001–P025.
+    """The P-series prescription rules are exactly P001–P025, P031.
 
     Strict equality (not just not-missing): P004–P007 are the orchestration-seam
     rules (BLDX-1417); P008–P012 are the storage-seam rules (BLDX-1398);
@@ -361,6 +361,9 @@ def test_catalog_p_series_present() -> None:
     AppStateAsCrossTaskChannel, ManualQualifiedNameFString).
     P029/P030 are the SDR-readiness rules — manifest agent_json slot and
     upload call presence (DISTR-752).
+    P031 is SharedDefaultExecutorOffload — asyncio.to_thread(...) /
+    run_in_executor(None, ...) bypass the SDK's dedicated run_in_thread() pool
+    and land on asyncio's shared default executor instead (BLDX-1525).
     A stray or renumbered P-id would slip past a subset check while
     breaking fleet-wide ``# conformance: ignore[Pxxx]`` suppressions.
     """
@@ -397,6 +400,7 @@ def test_catalog_p_series_present() -> None:
         "P028",
         "P029",
         "P030",
+        "P031",
     }
     missing = expected - p_ids
     assert not missing, f"Missing P-series rules: {missing}"

--- a/packages/conformance/tests/test_determinism.py
+++ b/packages/conformance/tests/test_determinism.py
@@ -1,4 +1,4 @@
-"""Meta-tests for the P-series determinism / async-correctness checks (P020–P024).
+"""Meta-tests for the P-series determinism / async-correctness checks (P020–P024, P031).
 
 Each rule is tested to fire *exactly* when it should and stay silent otherwise —
 both false positives and false negatives are guarded.  The load-bearing properties
@@ -324,11 +324,71 @@ def test_p024_suppression() -> None:
     assert len(findings) == 1 and findings[0].suppressed
 
 
+# ── P031 SharedDefaultExecutorOffload ────────────────────────────────────────
+
+
+def test_p031_flags_asyncio_to_thread() -> None:
+    body = "import asyncio\nasync def f():\n    return await asyncio.to_thread(g)\n"
+    assert len(_rule(body, "P031", header="")) == 1
+
+
+def test_p031_flags_to_thread_from_import() -> None:
+    body = (
+        "from asyncio import to_thread\n"
+        "async def f():\n"
+        "    return await to_thread(g)\n"
+    )
+    assert len(_rule(body, "P031", header="")) == 1
+
+
+def test_p031_flags_run_in_executor_none() -> None:
+    body = "async def f(loop):\n" "    return await loop.run_in_executor(None, g)\n"
+    assert len(_rule(body, "P031", header="")) == 1
+
+
+def test_p031_flags_get_event_loop_run_in_executor_none() -> None:
+    body = (
+        "import asyncio\n"
+        "async def f():\n"
+        "    return await asyncio.get_event_loop().run_in_executor(None, g)\n"
+    )
+    assert len(_rule(body, "P031", header="")) == 1
+
+
+def test_p031_silent_on_custom_executor() -> None:
+    body = (
+        "async def f(loop, pool):\n" "    return await loop.run_in_executor(pool, g)\n"
+    )
+    assert _rule(body, "P031", header="") == []
+
+
+def test_p031_exempts_heartbeat_module() -> None:
+    from conformance.suite.checks.determinism import scan_text as _scan_text
+
+    body = "import asyncio\nasync def f():\n    return await asyncio.to_thread(g)\n"
+    findings = [
+        f
+        for f in _scan_text(body, "application_sdk/execution/heartbeat.py")
+        if f.rule_id == "P031"
+    ]
+    assert findings == []
+
+
+def test_p031_suppression() -> None:
+    body = (
+        "import asyncio\n"
+        "async def f():\n"
+        "    return await asyncio.to_thread(g)  # conformance: ignore[P031] legacy\n"
+    )
+    findings = _rule(body, "P031", header="")
+    assert len(findings) == 1 and findings[0].suppressed
+
+
 # ── catalog meta-tests ───────────────────────────────────────────────────────
 
 
 def test_new_rules_present_and_scoped_both() -> None:
-    for rid in ("P020", "P021", "P022", "P023", "P024"):
+    for rid in ("P020", "P021", "P022", "P023", "P024", "P031"):
         assert rid in CATALOG, f"{rid} missing from catalog"
         assert CATALOG[rid].scope is RuleScope.BOTH
         assert CATALOG[rid].rationale.strip(), f"{rid} needs a non-empty rationale"

--- a/packages/conformance/uv.lock
+++ b/packages/conformance/uv.lock
@@ -219,7 +219,7 @@ wheels = [
 
 [[package]]
 name = "atlan-application-sdk-conformance"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },

--- a/tests/unit/clients/test_sql_client.py
+++ b/tests/unit/clients/test_sql_client.py
@@ -92,7 +92,7 @@ def test_load_respects_pool_pre_ping_override(
 
 
 @pytest.mark.asyncio
-@patch("application_sdk.clients.sql.run_in_thread")
+@patch("application_sdk.clients.sql.run_in_thread", new_callable=AsyncMock)
 @patch("sqlalchemy.create_engine")
 async def test_load_uses_run_in_thread_for_ping(
     mock_create_engine: Any, mock_run_in_thread: AsyncMock, sql_client: BaseSQLClient
@@ -105,21 +105,15 @@ async def test_load_uses_run_in_thread_for_ping(
     asyncio.to_thread — which would land on asyncio's shared default executor
     instead of the SDK's dedicated pool).
     """
-    from unittest.mock import AsyncMock as _AsyncMock
-
     mock_engine = MagicMock()
     mock_create_engine.return_value = mock_engine
-    mock_run_in_thread.return_value = None  # AsyncMock already returns a coroutine
-    mock_run_in_thread.__class__ = _AsyncMock
+    mock_run_in_thread.return_value = None
 
-    # Replace with a true AsyncMock so await works
-    actual_async_mock = _AsyncMock(return_value=None)
-    with patch("application_sdk.clients.sql.run_in_thread", actual_async_mock):
-        await sql_client.load({"username": "u", "password": "p"})
+    await sql_client.load({"username": "u", "password": "p"})
 
-    actual_async_mock.assert_called_once()
+    mock_run_in_thread.assert_called_once()
     # The callable passed to run_in_thread should trigger engine.connect when called
-    ping_fn = actual_async_mock.call_args[0][0]
+    ping_fn = mock_run_in_thread.call_args[0][0]
     ping_fn()
     mock_engine.connect.assert_called_once()
 

--- a/tests/unit/clients/test_sql_client.py
+++ b/tests/unit/clients/test_sql_client.py
@@ -92,31 +92,33 @@ def test_load_respects_pool_pre_ping_override(
 
 
 @pytest.mark.asyncio
-@patch("application_sdk.clients.sql.asyncio.to_thread")
+@patch("application_sdk.clients.sql.run_in_thread")
 @patch("sqlalchemy.create_engine")
-async def test_load_uses_asyncio_to_thread_for_ping(
-    mock_create_engine: Any, mock_to_thread: AsyncMock, sql_client: BaseSQLClient
+async def test_load_uses_run_in_thread_for_ping(
+    mock_create_engine: Any, mock_run_in_thread: AsyncMock, sql_client: BaseSQLClient
 ):
-    """load() must delegate the blocking engine.connect() ping to asyncio.to_thread.
+    """load() must delegate the blocking engine.connect() ping to run_in_thread.
 
     The ping closes the event loop for the duration of the ODBC handshake; running
     it on the event loop directly starves Temporal's auto-heartbeat. Verify that
-    asyncio.to_thread is called (not a direct engine.connect() on the loop).
+    run_in_thread is called (not a direct engine.connect() on the loop, and not
+    asyncio.to_thread — which would land on asyncio's shared default executor
+    instead of the SDK's dedicated pool).
     """
     from unittest.mock import AsyncMock as _AsyncMock
 
     mock_engine = MagicMock()
     mock_create_engine.return_value = mock_engine
-    mock_to_thread.return_value = None  # AsyncMock already returns a coroutine
-    mock_to_thread.__class__ = _AsyncMock
+    mock_run_in_thread.return_value = None  # AsyncMock already returns a coroutine
+    mock_run_in_thread.__class__ = _AsyncMock
 
     # Replace with a true AsyncMock so await works
     actual_async_mock = _AsyncMock(return_value=None)
-    with patch("application_sdk.clients.sql.asyncio.to_thread", actual_async_mock):
+    with patch("application_sdk.clients.sql.run_in_thread", actual_async_mock):
         await sql_client.load({"username": "u", "password": "p"})
 
     actual_async_mock.assert_called_once()
-    # The callable passed to to_thread should trigger engine.connect when called
+    # The callable passed to run_in_thread should trigger engine.connect when called
     ping_fn = actual_async_mock.call_args[0][0]
     ping_fn()
     mock_engine.connect.assert_called_once()
@@ -671,9 +673,9 @@ async def test_load_wraps_engine_failure_as_client_error(
     mock_engine = MagicMock()
     mock_create_engine.return_value = mock_engine
 
-    # Force the connect-test inside asyncio.to_thread to fail
+    # Force the connect-test inside run_in_thread to fail
     actual_async_mock = AsyncMock(side_effect=RuntimeError("auth handshake failed"))
-    with patch("application_sdk.clients.sql.asyncio.to_thread", actual_async_mock):
+    with patch("application_sdk.clients.sql.run_in_thread", actual_async_mock):
         with pytest.raises(SqlClientAuthFailedError) as exc_info:
             await sql_client.load({"username": "u", "password": "p"})
     assert isinstance(exc_info.value.cause, RuntimeError)

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -5152,7 +5152,7 @@ class TestComputeManifestHook:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """An ``async def compute_manifest`` is awaited directly (not run via
-        run_in_thread, which would hand back an un-awaited coroutine)."""
+        ``run_in_thread``, which would hand back an un-awaited coroutine)."""
         from application_sdk.handler import service as svc_module
 
         contract_dir = tmp_path / "generated"
@@ -5229,7 +5229,7 @@ class TestComputeManifestHook:
     ) -> None:
         """The hook is async-only: a *sync* ``def compute_manifest`` is not
         discovered and the route serves the static manifest unchanged (rather
-        than running it via run_in_thread)."""
+        than running it via ``run_in_thread``)."""
         from application_sdk.handler import service as svc_module
 
         contract_dir = tmp_path / "generated"

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -5152,7 +5152,7 @@ class TestComputeManifestHook:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """An ``async def compute_manifest`` is awaited directly (not run via
-        asyncio.to_thread, which would hand back an un-awaited coroutine)."""
+        run_in_thread, which would hand back an un-awaited coroutine)."""
         from application_sdk.handler import service as svc_module
 
         contract_dir = tmp_path / "generated"
@@ -5229,7 +5229,7 @@ class TestComputeManifestHook:
     ) -> None:
         """The hook is async-only: a *sync* ``def compute_manifest`` is not
         discovered and the route serves the static manifest unchanged (rather
-        than running it via asyncio.to_thread)."""
+        than running it via run_in_thread)."""
         from application_sdk.handler import service as svc_module
 
         contract_dir = tmp_path / "generated"

--- a/tests/unit/observability/test_pushgateway.py
+++ b/tests/unit/observability/test_pushgateway.py
@@ -14,7 +14,7 @@ from application_sdk.observability.pushgateway import (
 
 _PUSH_TARGET = "application_sdk.observability.pushgateway.push_to_gateway"
 _DELETE_TARGET = "application_sdk.observability.pushgateway.delete_from_gateway"
-_TO_THREAD_TARGET = "application_sdk.observability.pushgateway.asyncio.to_thread"
+_RUN_IN_THREAD_TARGET = "application_sdk.observability.pushgateway.run_in_thread"
 
 _PROMETHEUS_TEXT = (
     "# HELP test_counter A test counter\n"
@@ -24,11 +24,11 @@ _PROMETHEUS_TEXT = (
 
 
 @pytest.fixture
-def mock_to_thread():
+def mock_run_in_thread():
     async def inline(func, *args, **kwargs):
         return func(*args, **kwargs)
 
-    with patch(_TO_THREAD_TARGET, side_effect=inline):
+    with patch(_RUN_IN_THREAD_TARGET, side_effect=inline):
         yield
 
 
@@ -140,12 +140,14 @@ class TestPushGatewayClientInit:
 
 
 class TestPushGatewayClientPushNow:
-    async def test_push_now_calls_push_to_gateway(self, client, mock_to_thread):
+    async def test_push_now_calls_push_to_gateway(self, client, mock_run_in_thread):
         with patch(_PUSH_TARGET) as mock_push:
             await client.push_now()
         mock_push.assert_called_once()
 
-    async def test_push_now_passes_correct_url_and_job(self, client, mock_to_thread):
+    async def test_push_now_passes_correct_url_and_job(
+        self, client, mock_run_in_thread
+    ):
         with patch(_PUSH_TARGET) as mock_push:
             await client.push_now()
         _, kwargs = mock_push.call_args
@@ -157,12 +159,12 @@ class TestPushGatewayClientPushNow:
         url_arg = args[0] if args else kwargs.get("gateway")
         assert "localhost:9091" in str(url_arg)
 
-    async def test_push_now_propagates_push_exception(self, client, mock_to_thread):
+    async def test_push_now_propagates_push_exception(self, client, mock_run_in_thread):
         with patch(_PUSH_TARGET, side_effect=ConnectionError("refused")):
             with pytest.raises(ConnectionError):
                 await client.push_now()
 
-    async def test_push_passes_http_timeout(self, mock_to_thread):
+    async def test_push_passes_http_timeout(self, mock_run_in_thread):
         """The configured http_timeout_s must reach push_to_gateway so a hung
         gateway can't tie up the worker thread for the prometheus_client
         default of 30s."""
@@ -176,7 +178,7 @@ class TestPushGatewayClientPushNow:
             await c.push_now()
         assert mock_push.call_args.kwargs.get("timeout") == 7.5
 
-    async def test_delete_on_shutdown_passes_http_timeout(self, mock_to_thread):
+    async def test_delete_on_shutdown_passes_http_timeout(self, mock_run_in_thread):
         """Same timeout knob must apply to DELETE_ON_SHUTDOWN; otherwise a
         down gateway at shutdown burns the prometheus_client default 30s
         and pushes us past terminationGracePeriodSeconds."""
@@ -194,12 +196,14 @@ class TestPushGatewayClientPushNow:
 
 
 class TestPushGatewayClientStop:
-    async def test_stop_makes_final_push(self, client, mock_to_thread):
+    async def test_stop_makes_final_push(self, client, mock_run_in_thread):
         with patch(_PUSH_TARGET) as mock_push:
             await client.stop()
         mock_push.assert_called_once()
 
-    async def test_stop_calls_push_before_delete_when_flag_set(self, mock_to_thread):
+    async def test_stop_calls_push_before_delete_when_flag_set(
+        self, mock_run_in_thread
+    ):
         c = PushGatewayClient(
             url="http://localhost:9091",
             job="j",
@@ -217,7 +221,9 @@ class TestPushGatewayClientStop:
             await c.stop()
         assert call_order == ["push", "delete"]
 
-    async def test_stop_calls_delete_when_delete_on_shutdown_true(self, mock_to_thread):
+    async def test_stop_calls_delete_when_delete_on_shutdown_true(
+        self, mock_run_in_thread
+    ):
         c = PushGatewayClient(
             url="http://localhost:9091",
             job="my-job",
@@ -233,7 +239,7 @@ class TestPushGatewayClientStop:
         assert "localhost:9091" in str(url_arg)
 
     async def test_stop_sleeps_before_delete_to_allow_prometheus_scrape(
-        self, mock_to_thread
+        self, mock_run_in_thread
     ):
         """Default behavior: between final push and DELETE, sleep for the
         shutdown_delete_delay_s window so Prometheus has at least one scrape
@@ -264,7 +270,7 @@ class TestPushGatewayClientStop:
         # push → sleep → delete, in that order
         assert events == [("push",), ("sleep", 15.0), ("delete",)]
 
-    async def test_stop_skips_sleep_when_delay_is_zero(self, mock_to_thread):
+    async def test_stop_skips_sleep_when_delay_is_zero(self, mock_run_in_thread):
         """shutdown_delete_delay_s=0 disables the wait — useful for tests and for
         apps that want the legacy fast-shutdown behavior."""
         c = PushGatewayClient(
@@ -292,25 +298,25 @@ class TestPushGatewayClientStop:
         assert sleep_calls == []
 
     async def test_stop_does_not_call_delete_when_flag_false(
-        self, client, mock_to_thread
+        self, client, mock_run_in_thread
     ):
         with patch(_PUSH_TARGET), patch(_DELETE_TARGET) as mock_delete:
             await client.stop()
         mock_delete.assert_not_called()
 
-    async def test_stop_swallows_push_failure(self, client, mock_to_thread):
+    async def test_stop_swallows_push_failure(self, client, mock_run_in_thread):
         with patch(_PUSH_TARGET, side_effect=ConnectionError("gateway down")):
             await client.stop()  # must not raise
 
 
 class TestPushGatewayClientLifecycle:
-    async def test_start_creates_background_task(self, client, mock_to_thread):
+    async def test_start_creates_background_task(self, client, mock_run_in_thread):
         with patch(_PUSH_TARGET):
             await client.start()
             assert client._task is not None
             await client.stop()
 
-    async def test_start_is_idempotent(self, client, mock_to_thread):
+    async def test_start_is_idempotent(self, client, mock_run_in_thread):
         with patch(_PUSH_TARGET):
             await client.start()
             first_task = client._task


### PR DESCRIPTION
## Summary
- Add a new conformance rule, **P031 — SharedDefaultExecutorOffload**, to the determinism check series. It flags `asyncio.to_thread(...)` and `run_in_executor(None, ...)` calls that dispatch onto asyncio's *shared default* executor — the same pool Temporal's Python SDK uses internally for its own scheduling — instead of the SDK's dedicated `run_in_thread()` pool. `execution/heartbeat.py` (where `run_in_thread()`'s own dispatch lives) is exempt, and calls passing a custom executor are intentionally not flagged.
- Migrate the SDK's own pre-existing `asyncio.to_thread` call sites (which the P-series self-scan against `application_sdk/` would otherwise flag) to `run_in_thread()`: `handler/service.py`'s upload drain, `clients/sql.py`'s connection ping, and `observability/pushgateway.py`'s sweep/push/delete calls.
- Update the corresponding unit tests to mock `run_in_thread` instead of `asyncio.to_thread`.

Closes BLDX-1525.

## Test plan
- [x] `packages/conformance` unit tests pass (1754 passed, 1 xfailed), including new P031 behavioral tests (flags to_thread, aliased import, `run_in_executor(None, ...)`, `get_event_loop()` variant; silent on custom executor; heartbeat exemption; suppression directive)
- [x] `conformance/tests/test_catalog.py` updated — P-series catalog set includes P031
- [x] Rule docs regenerated (`gen-rule-docs`) and verified fresh (`gen-rule-docs --check`)
- [x] Self-scan of `application_sdk/` for P031 returns zero findings post-migration
- [x] Full SDK unit test suite passes (5429 passed, 9 skipped)
- [x] `pre-commit run --all-files` clean (ruff, ruff-format, isort, pyright)