### PR TITLE
feat(conformance): add K006 rule for manifest-vs-contract field validation

### DIFF
--- a/packages/conformance/conformance/docs/rules/contract-toolkit.md
+++ b/packages/conformance/conformance/docs/rules/contract-toolkit.md
@@ -20,7 +20,7 @@ Suppress a finding on the violating line or the line directly above it:
 | [K003](#k003) | `ContractLockDrift` | `warn` | `app` | `contract-toolkit` | — | 0.9.0 |
 | [K004](#k004) | `MissingGeneratedArtifact` | `warn` | `app` | `contract-toolkit` | — | 0.9.0 |
 | [K005](#k005) | `GeneratedArtifactBannerStripped` | `warn` | `app` | `contract-toolkit` | — | 0.9.0 |
-| [K006](#k006) | `ManifestContractFieldMismatch` | `warn` | `app` | `contract-toolkit` | — | 0.14.0 |
+| [K006](#k006) | `ManifestContractFieldMismatch` | `warn` | `app` | `contract-toolkit` | — | 0.13.0 |
 
 ---
 
@@ -248,7 +248,7 @@ proves full freshness.
 
 ## K006 — `ManifestContractFieldMismatch` {#k006}
 
-**Tier:** `warn` · **Scope:** `app` · **Category:** `contract-toolkit` · **Autofixable:** — · **Since:** 0.14.0
+**Tier:** `warn` · **Scope:** `app` · **Category:** `contract-toolkit` · **Autofixable:** — · **Since:** 0.13.0
 
 > app/generated/**/manifest.json references an $.extract.outputs.<field> the entrypoint's Output contract does not declare
 

--- a/packages/conformance/conformance/docs/rules/contract-toolkit.md
+++ b/packages/conformance/conformance/docs/rules/contract-toolkit.md
@@ -5,7 +5,7 @@
 
 # Contract-Toolkit Conformance Rules (K-series)
 
-**5 rules** · Checker: `suite.checks.legacy_contract` (K001–K002, pkl-source regex, scans ``contract/**/*.pkl``), `suite.checks.generated_freshness` (K003–K005, scans ``contract/PklProject``, ``contract/PklProject.deps.json``, ``atlan.yaml``, ``app.yaml``, and ``app/generated/**``)
+**6 rules** · Checker: `suite.checks.legacy_contract` (K001–K002, pkl-source regex, scans ``contract/**/*.pkl``), `suite.checks.generated_freshness` (K003–K005, scans ``contract/PklProject``, ``contract/PklProject.deps.json``, ``atlan.yaml``, ``app.yaml``, and ``app/generated/**``), `suite.checks.manifest_contract` (K006, cross-references ``app/generated/**/manifest.json`` against Python ``Output`` contracts)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -20,6 +20,7 @@ Suppress a finding on the violating line or the line directly above it:
 | [K003](#k003) | `ContractLockDrift` | `warn` | `app` | `contract-toolkit` | — | 0.9.0 |
 | [K004](#k004) | `MissingGeneratedArtifact` | `warn` | `app` | `contract-toolkit` | — | 0.9.0 |
 | [K005](#k005) | `GeneratedArtifactBannerStripped` | `warn` | `app` | `contract-toolkit` | — | 0.9.0 |
+| [K006](#k006) | `ManifestContractFieldMismatch` | `warn` | `app` | `contract-toolkit` | — | 0.14.0 |
 
 ---
 
@@ -242,5 +243,54 @@ proves full freshness.
 
 **Suppress** with `# conformance: ignore[K005] <reason>` on the first line of the file
 (or the line above it) for an app that deliberately hand-maintains this artifact.
+
+---
+
+## K006 — `ManifestContractFieldMismatch` {#k006}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `contract-toolkit` · **Autofixable:** — · **Since:** 0.14.0
+
+> app/generated/**/manifest.json references an $.extract.outputs.<field> the entrypoint's Output contract does not declare
+
+**Rationale:** App.pkl's pipeline nodes (e.g. PublishNode) unconditionally wire a downstream node's
+args to the entrypoint's runtime output via a JSONPath such as
+$.extract.outputs.publish_state_prefix. Pkl compiles this before any Python runs and has
+zero visibility into the app's Output model; the B005 contract-ledger checker only knows
+a field 'was tracked and disappeared,' with no knowledge of the manifest's JSONPath
+requirements. An app can therefore silently delete a field the manifest depends on, and
+nothing static catches it — only a rarely-run, non-deterministic full-DAG e2e run
+against a real Automation Engine does. This is exactly what happened when
+OpenAPIConnectorOutput lost publish_state_prefix and current_state_prefix in an
+unrelated conformance-cleanup PR and went undetected for about 12 days (BLDX-1527). K006
+closes the loop with a structural manifest-vs-contract diff, computed once both
+artifacts exist, without either layer needing visibility into the other's language.
+
+A `$.extract.outputs.<field>` JSONPath reference in a committed
+`app/generated/**/manifest.json` DAG node's `inputs.args` names a field that the
+corresponding entrypoint's Python `Output` contract does not declare — not directly, and
+not via any inherited base class or SDK mixin.
+
+The Automation Engine resolves this JSONPath at runtime against the object the
+entrypoint's workflow actually returned. A missing field means the reference never
+resolves, and the dependent pipeline step (most commonly the default `publish` step)
+fails at runtime with an unresolved-JSONPath error — the one signal that would have
+caught this is a rarely-run, opt-in-labeled, non-deterministic full-DAG e2e test.
+
+**Fix:** declare the missing field(s) on the entrypoint's `Output` model, or mix in the
+SDK contract base that already supplies them. For the publish-state fields specifically
+(`connection_qualified_name`, `transformed_data_prefix`, `publish_state_prefix`,
+`current_state_prefix`), mix in `application_sdk.contracts.base.PublishInputMixin`
+rather than hand-declaring each field — it also derives the values correctly from
+`connection_qualified_name`.
+
+**Never hand-edit** `app/generated/manifest.json` to work around a finding — it is a
+`pkl eval` output (K004/K005 and the generated-artifact freshness gate catch a
+hand-edited manifest). If the referenced field is genuinely not needed (e.g. the
+pipeline step that consumes it should not be enabled), remove or reconfigure that step
+in `contract/app.pkl` and re-run `pkl eval -m . contract/app.pkl` instead.
+
+**Suppress** with `# conformance: ignore[K006] <reason>` on the `Output` class
+definition (or the comment-only line directly above it) when a mismatch is understood
+and deliberately deferred.
 
 ---

--- a/packages/conformance/conformance/programs/areas/contract-toolkit.prose.md
+++ b/packages/conformance/conformance/programs/areas/contract-toolkit.prose.md
@@ -9,7 +9,11 @@ description: >
   Config/Connectors/Credential/Renderers imports) are guided migration fixes.
   K003 (stale Pkl lock), K004 (missing generated output), and K005 (stripped
   provenance banner) are generated-artifact freshness findings fixed by
-  re-resolving / regenerating — all verified by the pkl-eval gate.
+  re-resolving / regenerating — all verified by the pkl-eval gate.  K006
+  (a manifest.json JSONPath reference the Python Output contract does not
+  declare) is fixed on the Python side — declare the field or mix in the SDK
+  contract base that supplies it — and verified by the test-suite gate, not
+  pkl-eval.
 ---
 
 ### Maintains
@@ -26,7 +30,7 @@ K-series rules are WARN-tier, so in **default** mode this facet is always empty
 (warnings do not fail the gate).  In **strict** mode the fingerprint-set includes
 unsuppressed WARNING results, which is where K-series remediation actually runs.
 
-The active scope decides which rules can appear: K001–K005 are all `scope=APP`,
+The active scope decides which rules can appear: K001–K006 are all `scope=APP`,
 so they surface only on consumer app repos.  The runner auto-detects scope, so
 the SDK repo sees 0 findings.
 
@@ -74,8 +78,11 @@ Before proposing any edit, read the actual lines around `finding.line` in
 generated artifact directly** — those are outputs of `pkl eval`, and K004/K005
 catch the staleness that hand-editing causes.  The *only* sanctioned way to
 change a generated artifact is to regenerate it from the contract.  After every
-edit, the `pkl-eval` gate runs `pkl eval` to verify the contract compiled and
-regenerated cleanly.
+edit to `contract/**/*.pkl` (K001/K002) or the Pkl lock (K003/K004/K005), the
+`pkl-eval` gate runs `pkl eval` to verify the contract compiled and regenerated
+cleanly.  **K006 is the one exception**: its fix is a plain Python edit (see
+below) with no `.pkl` or generated-artifact involvement, so it is verified by
+the standard test-suite gate instead of `pkl-eval`.
 
 The freshness rules (K003/K004/K005) are remediated by running a pkl command
 (`pkl project resolve` and/or `pkl eval -m . contract/app.pkl`), so they are
@@ -223,9 +230,58 @@ K005 never graduates to BLOCK; a hand-maintaining app suppresses per file.
 
 ---
 
+**K006 ManifestContractFieldMismatch** — a `$.extract.outputs.<field>` reference
+in a committed `app/generated/**/manifest.json` DAG node names a field the
+entrypoint's Python `Output` contract does not declare (directly, or via an
+inherited base/mixin).  `classification = "mechanical"` when the fix is
+"mix in the SDK contract base that already supplies this field" (see below);
+`"judgment"` when it requires deciding what value the app itself should
+compute and declaring a new field by hand.  **Does not require `pkl`** — this
+is a pure Python edit, verified by the test-suite gate.
+
+`finding.message` names the missing field(s), the manifest path, and the
+Output contract class. Read the actual `Output` class at `finding.line` in
+`finding.file` before proposing an edit.
+
+*Procedure:*
+
+1. **Check whether an SDK contract mixin already supplies the field(s)** named
+   in the finding — most commonly `application_sdk.contracts.base.PublishInputMixin`
+   for `connection_qualified_name`, `transformed_data_prefix`,
+   `publish_state_prefix`, and `current_state_prefix` (the publish-pipeline
+   fields; it also derives their values correctly from
+   `connection_qualified_name`, so hand-declaring them independently is both
+   unnecessary and a second place to drift). If so, add the mixin to the
+   `Output` class's base classes — `classification = "mechanical"`.
+2. **Otherwise, declare the missing field(s) directly** on the `Output` model
+   with an appropriate type and a sensible default, and set its value wherever
+   the class is constructed. `classification = "judgment"` — the fix requires
+   understanding what the field should actually contain.
+3. **Do not edit `app/generated/manifest.json`** to work around the finding —
+   it is a `pkl eval` output, not the source of truth for what fields exist. If
+   the referenced field is genuinely not needed (the pipeline step that
+   consumes it should not be enabled for this app), the real fix is in
+   `contract/app.pkl` (e.g. `pipeline.publish = null`) followed by
+   `pkl eval -m . contract/app.pkl` — that is a **K001/K002-style contract
+   change**, not a K006 fix; route it there instead if this is the actual
+   intent.
+4. **Verification is the standard test-suite gate**, not `pkl-eval` — a plain
+   `uv run pytest` (or the app's configured test command) after staging the
+   Python edit. Re-running `atlan-application-sdk-conformance detect --series K`
+   also directly re-checks the fixed field is now visible (including through
+   the mixin's inheritance chain).
+5. If the mismatch is understood and deliberately deferred (e.g. the pipeline
+   step is being removed in a separate, already-tracked change), suppress with
+   `# conformance: ignore[K006] <reason>` on the `Output` class definition (or
+   the comment-only line directly above it) and route to residue.
+
+---
+
 **Suppress outcome (strict mode only, WARNING-tier findings)**: the model may
-propose an inline `// conformance: ignore[Kxxx] <8–40 word justification>` on
-the violating line or the comment-only line directly above it when a legitimate
-exception exists (e.g. a K001 finding on a contract intentionally kept at the
-legacy module during a phased migration with a tracked follow-on ticket).  Route
-every suppression to residue for human audit.
+propose an inline suppression comment — `// conformance: ignore[Kxxx]
+<8–40 word justification>` for K001–K005 (`.pkl` source, `//` comments) or
+`# conformance: ignore[K006] <8–40 word justification>` (Python source, `#`
+comments) — on the violating line or the comment-only line directly above it
+when a legitimate exception exists (e.g. a K001 finding on a contract
+intentionally kept at the legacy module during a phased migration with a
+tracked follow-on ticket).  Route every suppression to residue for human audit.

--- a/packages/conformance/conformance/suite/checks/manifest_contract/__init__.py
+++ b/packages/conformance/conformance/suite/checks/manifest_contract/__init__.py
@@ -1,0 +1,44 @@
+"""K006 ManifestContractFieldMismatch — manifest-vs-contract field cross-check (BLDX-1527).
+
+Detects a ``$.<node>.outputs.<field>`` JSONPath reference in the generated
+``app/generated/**/manifest.json`` DAG that the referenced entrypoint's Python
+``Output`` contract does not declare — directly or via an inherited base/mixin
+(e.g. ``application_sdk.contracts.base.PublishInputMixin``).
+
+This is a **cross-file + cross-artifact** check: it scans all Python files to
+build the entrypoint -> Output contract map, then reads the committed
+``app/generated/`` tree. Per-file scanning has no meaning here, so
+``scan_path`` is a no-op and ``scan_all`` does all the work — mirrors P016
+(``entrypoint_alignment``), the closest existing cross-artifact check.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from conformance.suite.checks._ast_common import discover, make_cli_main
+from conformance.suite.schema.findings import Finding
+
+from ._check import scan_all
+
+SERIES = "K"
+
+__all__ = ["SERIES", "discover", "main", "scan_all", "scan_path"]
+
+
+def scan_path(path: Path, root: Path) -> list[Finding]:  # noqa: ARG001
+    """No-op: K006 requires cross-file + cross-artifact analysis; use :func:`scan_all`."""
+    return []
+
+
+main = make_cli_main(
+    scan_all=scan_all,
+    description=(
+        "K006 ManifestContractFieldMismatch: verify manifest.json "
+        "$.<node>.outputs.<field> refs against the Python Output contract (BLDX-1527)."
+    ),
+)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/conformance/conformance/suite/checks/manifest_contract/_check.py
+++ b/packages/conformance/conformance/suite/checks/manifest_contract/_check.py
@@ -1,0 +1,199 @@
+"""K006 ManifestContractFieldMismatch — check implementation.
+
+Cross-references every ``$.extract.outputs.<field>`` reference in the
+committed ``app/generated/**/manifest.json`` DAG against the entrypoint's
+Python ``Output`` contract (resolved across its full inheritance chain via the
+shared :func:`resolve_contract_fields`, so a field supplied by an SDK mixin
+such as ``PublishInputMixin`` counts as declared). A field the manifest
+requires but the contract does not declare — anywhere in its MRO — is the
+exact class of bug this rule exists to catch (BLDX-1527): the field is
+load-bearing for a platform-orchestrated pipeline step (e.g. ``publish``) but
+nothing in either language's own tooling notices its removal.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from conformance.suite.checks._ast_common import (
+    _IgnoreDirective,
+    _parse_directives,
+    make_finding,
+)
+from conformance.suite.checks._entrypoint_contract_fields import resolve_contract_fields
+from conformance.suite.checks.entrypoint_alignment._contract_entrypoints import (
+    scan_contract as scan_contract_entrypoints,
+)
+from conformance.suite.checks.prescriptions._decorator_provenance import (
+    collect_import_provenance,
+)
+from conformance.suite.checks.prescriptions._error_code_prefix import (
+    ClassRecord,
+    collect_classes,
+    collect_import_aliases,
+)
+from conformance.suite.schema.findings import Finding
+
+from ._code_outputs import (
+    CodeOutputScan,
+    EntrypointOutput,
+    scan_file_for_entrypoint_outputs,
+)
+from ._manifest_refs import ManifestDag, read_manifest
+
+_RULE_ID = "K006"
+
+
+def _manifest_paths_for_contract(root: Path, contract) -> list[Path]:  # noqa: ANN001
+    """Return the ``manifest.json`` paths implied by the P016 contract-scan mode."""
+    generated = root / "app" / "generated"
+    if contract.mode == "single":
+        return [generated / "manifest.json"]
+    if contract.mode == "multi":
+        return [generated / name / "manifest.json" for name in sorted(contract.names)]
+    return []
+
+
+def _target_entrypoint(
+    manifest: ManifestDag,
+    mode: str,
+    entrypoints: list[EntrypointOutput],
+) -> EntrypointOutput | None:
+    """Resolve which entrypoint a manifest's own (``"extract"``) node belongs to.
+
+    ``single`` mode: unambiguous only when code declares exactly one
+    entrypoint (mirrors P016 — a single-EP contract's entrypoint name is
+    otherwise unconstrained).
+
+    ``multi`` mode: the manifest's parent directory name is the contract's
+    entry-point name (the P016 invariant); match it against the wire name.
+    """
+    if mode == "single":
+        if len(entrypoints) != 1:
+            return None
+        return entrypoints[0]
+
+    ep_name = Path(manifest.manifest_path).parent.name
+    matches = [ep for ep in entrypoints if ep.wire_name == ep_name]
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
+def scan_all(paths: list[Path], root: Path) -> list[Finding]:
+    """Cross-reference manifest JSONPath refs against Python Output contracts.
+
+    No-ops when ``app/generated/`` is absent, when no manifest carries a
+    parseable ``dag``, or when no ``@entrypoint``/implicit ``App.run()`` is
+    found in code — all conservative (WARN rule; prefers a false negative to a
+    false positive on a repo shape this check does not understand).
+    """
+    if not (root / "app" / "generated").is_dir():
+        return []
+
+    contract = scan_contract_entrypoints(root)
+    if contract.mode == "absent":
+        return []
+
+    manifest_paths = _manifest_paths_for_contract(root, contract)
+    manifests = [
+        m for m in (read_manifest(p, root) for p in manifest_paths) if m is not None
+    ]
+    if not manifests:
+        return []
+
+    # Pass 1: parse every file; build the cross-file class registry (`by_name`)
+    # and per-file directives/aliases, all keyed by repo-relative path so a
+    # class's *own* file's aliases can be looked up later regardless of which
+    # file is currently being iterated (mirrors scan_contract_compat, but
+    # keyed by the relative string directly since ClassRecord.file already is).
+    file_trees: dict[str, ast.AST] = {}
+    file_directives: dict[str, dict[int, _IgnoreDirective]] = {}
+    file_aliases: dict[str, dict[str, str]] = {}
+    by_name: dict[str, ClassRecord] = {}
+
+    for path in paths:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            tree = ast.parse(text, filename=str(path))
+        except SyntaxError:
+            continue
+        try:
+            rel = str(path.relative_to(root))
+        except ValueError:
+            rel = str(path)
+
+        file_trees[rel] = tree
+        file_directives[rel] = _parse_directives(text)
+        aliases = collect_import_aliases(tree) if isinstance(tree, ast.Module) else {}
+        file_aliases[rel] = aliases
+        for rec in collect_classes(tree, rel, aliases):
+            by_name.setdefault(rec.name, rec)
+
+    # Pass 2: collect the per-entrypoint (wire_name -> Output class) map.
+    code = CodeOutputScan()
+    app_cache: dict[str, bool | None] = {}
+    for rel, tree in file_trees.items():
+        if not isinstance(tree, ast.Module):
+            continue
+        prov = collect_import_provenance(tree)
+        scan_file_for_entrypoint_outputs(
+            tree, rel, file_aliases.get(rel, {}), prov, by_name, app_cache, code
+        )
+
+    if not code.entrypoints:
+        return []
+
+    # Pass 3: for each manifest, resolve its target entrypoint's Output field
+    # set and diff against the manifest's own-node references.
+    findings: list[Finding] = []
+
+    for manifest in manifests:
+        target = _target_entrypoint(manifest, contract.mode, code.entrypoints)
+        if target is None or target.output_class_name is None:
+            continue
+
+        output_rec = by_name.get(target.output_class_name)
+        if output_rec is None:
+            continue  # Output class not resolvable in scanned source — skip.
+
+        output_aliases = file_aliases.get(output_rec.file, {})
+        live_fields = resolve_contract_fields(output_rec.node, output_aliases, by_name)
+        live_names = {f.name for f in live_fields}
+        directives = file_directives.get(output_rec.file, {})
+
+        missing_fields = sorted(
+            {ref.field for ref in manifest.own_refs() if ref.field not in live_names}
+        )
+        for missing_field in missing_fields:
+            findings.append(
+                make_finding(
+                    filename=output_rec.file,
+                    rule_id=_RULE_ID,
+                    node=output_rec.node,
+                    message=(
+                        f"'{manifest.manifest_path}' references "
+                        f"'$.extract.outputs.{missing_field}', but "
+                        f"'{output_rec.name}' (the entrypoint's Output contract) "
+                        f"does not declare a '{missing_field}' field — directly or "
+                        "via an inherited base/mixin. The Automation Engine resolves "
+                        "this JSONPath at runtime against the entrypoint's returned "
+                        "Output; a missing field fails the dependent pipeline step "
+                        "(e.g. publish) with an unresolved-JSONPath error. Declare "
+                        f"'{missing_field}' on '{output_rec.name}', or mix in the SDK "
+                        "contract base that supplies it (e.g. "
+                        "'application_sdk.contracts.base.PublishInputMixin' for the "
+                        "publish-state fields). Never hand-edit the generated "
+                        "manifest.json to work around this — it is a pkl eval output. "
+                        "Suppress with '# conformance: ignore[K006] <reason>' on the "
+                        "Output class definition."
+                    ),
+                    directives=directives,
+                )
+            )
+
+    return findings

--- a/packages/conformance/conformance/suite/checks/manifest_contract/_code_outputs.py
+++ b/packages/conformance/conformance/suite/checks/manifest_contract/_code_outputs.py
@@ -59,12 +59,19 @@ def _method_name_to_kebab(name: str) -> str:
 def _extract_wire_name(deco: ast.expr, method_name: str) -> tuple[str | None, bool]:
     """Parse an ``@entrypoint`` decorator expression for its wire name.
 
-    Returns ``(name, is_unresolved)`` — mirrors
-    ``entrypoint_alignment._code_entrypoints._extract_ep_name``.
+    Returns ``(name, is_unresolved)``. Handles both ``ast.Name``/``ast.Attribute``
+    bare-decorator forms (``@entrypoint`` / ``@app.entrypoint``) and their
+    ``ast.Call`` counterparts (``@entrypoint(...)`` / ``@app.entrypoint(...)``) —
+    unlike ``entrypoint_alignment._code_entrypoints._extract_ep_name`` (which this
+    otherwise mirrors), the decorator-detection this module uses
+    (``is_entrypoint_decorator``) also recognises attribute-form decorators via a
+    module alias (e.g. ``import application_sdk.app as app`` -> ``@app.entrypoint``),
+    so wire-name extraction must handle that form too or a matching entrypoint
+    silently resolves to ``wire_name=None`` and never matches a manifest subdir.
     """
-    if isinstance(deco, ast.Name):
+    if isinstance(deco, (ast.Name, ast.Attribute)):
         return _method_name_to_kebab(method_name), False
-    if isinstance(deco, ast.Call) and isinstance(deco.func, ast.Name):
+    if isinstance(deco, ast.Call) and isinstance(deco.func, (ast.Name, ast.Attribute)):
         for kw in deco.keywords:
             if kw.arg == "name":
                 if isinstance(kw.value, ast.Constant) and isinstance(

--- a/packages/conformance/conformance/suite/checks/manifest_contract/_code_outputs.py
+++ b/packages/conformance/conformance/suite/checks/manifest_contract/_code_outputs.py
@@ -1,0 +1,178 @@
+"""Collect a per-entrypoint ``(wire_name, Output contract class name)`` map.
+
+Neither existing collector is quite what K006 needs:
+
+* ``entrypoint_alignment._code_entrypoints`` (P016) derives wire names but not
+  the entrypoint's return-type (``Output``) contract.
+* ``_entrypoint_contract_fields.collect_entrypoint_contract_names`` (shared,
+  backs B005/B006) collects Input/Output class names but flattens them into a
+  single ``frozenset`` with no association back to a wire name or entrypoint.
+
+K006 needs both together, so a manifest's ``$.extract.outputs.<field>``
+reference (see ``_manifest_refs.py``) can be resolved to the *specific*
+entrypoint's Output class in a multi-entrypoint (bundle) app.
+
+Wire-name derivation mirrors
+``entrypoint_alignment._code_entrypoints._extract_ep_name`` exactly (bare
+``@entrypoint`` → kebab-cased method name; ``@entrypoint(name="literal")`` →
+the literal; non-literal ``name=`` → unresolved, skipped here since P016
+already reports it and K006 cannot map an unresolved name to a manifest
+subdir). It is duplicated locally rather than imported cross-series, matching
+the existing precedent of small AST literal-extraction helpers living next to
+their one caller.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+
+from conformance.suite.checks.prescriptions._decorator_provenance import (
+    ImportProvenance,
+    is_entrypoint_decorator,
+    is_task_decorator,
+)
+from conformance.suite.checks.prescriptions._error_code_prefix import (
+    ClassRecord,
+    resolve_ancestor,
+)
+from conformance.suite.checks.prescriptions._typed_boundaries import (
+    _annotation_terminal_name,
+    _iter_class_body_methods,
+)
+
+
+def _base_name(base: ast.expr) -> str | None:
+    """Return the simple name of a base-class expression (``Name`` or ``Attribute``)."""
+    if isinstance(base, ast.Name):
+        return base.id
+    if isinstance(base, ast.Attribute):
+        return base.attr
+    return None
+
+
+def _method_name_to_kebab(name: str) -> str:
+    """``'extract_metadata'`` -> ``'extract-metadata'`` (mirrors ``application_sdk.app.entrypoint``)."""
+    return name.replace("_", "-")
+
+
+def _extract_wire_name(deco: ast.expr, method_name: str) -> tuple[str | None, bool]:
+    """Parse an ``@entrypoint`` decorator expression for its wire name.
+
+    Returns ``(name, is_unresolved)`` — mirrors
+    ``entrypoint_alignment._code_entrypoints._extract_ep_name``.
+    """
+    if isinstance(deco, ast.Name):
+        return _method_name_to_kebab(method_name), False
+    if isinstance(deco, ast.Call) and isinstance(deco.func, ast.Name):
+        for kw in deco.keywords:
+            if kw.arg == "name":
+                if isinstance(kw.value, ast.Constant) and isinstance(
+                    kw.value.value, str
+                ):
+                    return kw.value.value, False
+                return None, True
+        return _method_name_to_kebab(method_name), False
+    return None, False
+
+
+@dataclass(frozen=True)
+class EntrypointOutput:
+    """One entrypoint's wire name and (if resolvable) its declared Output class."""
+
+    wire_name: str | None
+    """Kebab-case wire name, or ``None`` for an implicit ``App.run()`` entrypoint
+    (only meaningful for single-entrypoint-mode matching)."""
+
+    output_class_name: str | None
+    """De-aliased class name of the entrypoint's return-type annotation, or
+    ``None`` when unannotated / not a simple class reference."""
+
+    filename: str
+    """Repo-relative path of the file the entrypoint method is defined in."""
+
+
+@dataclass
+class CodeOutputScan:
+    """Accumulated per-entrypoint output-contract data across all scanned files."""
+
+    entrypoints: list[EntrypointOutput] = field(default_factory=list)
+
+
+def scan_file_for_entrypoint_outputs(
+    tree: ast.Module,
+    filename: str,
+    aliases: dict[str, str],
+    prov: ImportProvenance,
+    by_name: dict[str, ClassRecord],
+    app_cache: dict[str, bool | None],
+    result: CodeOutputScan,
+) -> None:
+    """Scan one parsed module, appending discovered entrypoints to *result*.
+
+    Mirrors the entrypoint-detection logic in
+    ``_entrypoint_contract_fields.collect_entrypoint_contract_names`` (decorator
+    provenance + implicit ``App.run()``), but keeps the wire name and Output
+    class name paired per entrypoint instead of flattening into a name set.
+    """
+    for class_node in ast.walk(tree):
+        if not isinstance(class_node, ast.ClassDef):
+            continue
+
+        for func in _iter_class_body_methods(class_node):
+            is_ep = False
+            ep_deco: ast.expr | None = None
+
+            for dec in func.decorator_list:
+                if is_entrypoint_decorator(dec, prov):
+                    is_ep = True
+                    ep_deco = dec
+                    break
+            if not is_ep and any(
+                is_task_decorator(dec, prov) for dec in func.decorator_list
+            ):
+                continue  # @task — skip entirely
+
+            if (
+                not is_ep
+                and func.name == "run"
+                and isinstance(func, ast.AsyncFunctionDef)
+            ):
+                for base in class_node.bases:
+                    bname = _base_name(base)
+                    if bname is None:
+                        continue
+                    bname = aliases.get(bname, bname)
+                    if (
+                        bname == "App"
+                        or resolve_ancestor(bname, "App", by_name, app_cache, set())
+                        is True
+                    ):
+                        is_ep = True
+                        break
+
+            if not is_ep:
+                continue
+
+            wire_name: str | None = None
+            if ep_deco is not None:
+                wire_name, is_unresolved = _extract_wire_name(ep_deco, func.name)
+                if is_unresolved:
+                    # P016 (K001-adjacent) already reports unresolved names;
+                    # K006 cannot map an unresolved name to a manifest subdir.
+                    continue
+            # else: implicit App.run() — wire_name stays None (single-EP only).
+
+            output_name: str | None = None
+            if func.returns is not None:
+                name = _annotation_terminal_name(func.returns)
+                if name:
+                    output_name = aliases.get(name, name)
+
+            result.entrypoints.append(
+                EntrypointOutput(
+                    wire_name=wire_name,
+                    output_class_name=output_name,
+                    filename=filename,
+                )
+            )

--- a/packages/conformance/conformance/suite/checks/manifest_contract/_manifest_refs.py
+++ b/packages/conformance/conformance/suite/checks/manifest_contract/_manifest_refs.py
@@ -1,0 +1,112 @@
+"""Read ``app/generated/**/manifest.json`` and extract ``$.<node>.outputs.<field>`` refs.
+
+The Automation Engine DAG the contract-toolkit emits wires a downstream node's
+args to an upstream node's runtime output via a JSONPath string such as
+``$.extract.outputs.publish_state_prefix`` (see ``PublishNode`` /
+``generateDAG()`` in ``contract-toolkit/src/App.pkl``). These strings appear
+anywhere inside a node's ``inputs.args`` value (which may itself be a nested
+dict, e.g. the ``notifications`` node's ``metadata`` block).
+
+The entrypoint's own DAG node id is always the literal string ``"extract"``
+— confirmed in ``App.pkl``'s ``generateDAG()`` (its own doc comment: "the node
+id is always `extract`") and empirically in every example manifest, including
+the multi-entrypoint ``bundle`` example's two per-entrypoint manifests. So a
+reference is in K006's scope iff its node is ``"extract"`` — no app_name or
+contract-name lookup is needed to identify "my own" node.
+
+``$.workflow.*`` / ``$.failure.*`` references (AE run/failure context injected
+into the ``notifications`` node) never match ``outputs`` and are naturally
+excluded by the regex.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+_REF_RE = re.compile(r"^\$\.(?P<node>[\w-]+)\.outputs\.(?P<field>\w+)$")
+
+_EXTRACT_NODE_ID = "extract"
+
+
+@dataclass(frozen=True)
+class ManifestRef:
+    """A single ``$.<node>.outputs.<field>`` reference found in a manifest."""
+
+    node: str
+    field: str
+
+
+@dataclass(frozen=True)
+class ManifestDag:
+    """Parsed ``dag`` block of one ``manifest.json``."""
+
+    manifest_path: str
+    """Repo-relative path, e.g. ``app/generated/manifest.json`` or
+    ``app/generated/<entrypoint>/manifest.json``."""
+
+    refs: list[ManifestRef] = field(default_factory=list)
+
+    def own_refs(self) -> Iterator[ManifestRef]:
+        """Yield references whose node is the entrypoint's own (``"extract"``) node."""
+        for ref in self.refs:
+            if ref.node == _EXTRACT_NODE_ID:
+                yield ref
+
+
+def _iter_strings(value: Any) -> Iterator[str]:
+    """Recursively yield every string leaf inside a JSON value (dict/list/str)."""
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for v in value.values():
+            yield from _iter_strings(v)
+    elif isinstance(value, list):
+        for v in value:
+            yield from _iter_strings(v)
+
+
+def _extract_refs(dag: dict[str, Any]) -> list[ManifestRef]:
+    refs: list[ManifestRef] = []
+    for node_data in dag.values():
+        if not isinstance(node_data, dict):
+            continue
+        inputs = node_data.get("inputs")
+        if not isinstance(inputs, dict):
+            continue
+        args = inputs.get("args")
+        if args is None:
+            continue
+        for s in _iter_strings(args):
+            m = _REF_RE.match(s)
+            if m:
+                refs.append(ManifestRef(node=m.group("node"), field=m.group("field")))
+    return refs
+
+
+def read_manifest(path: Path, root: Path) -> ManifestDag | None:
+    """Parse *path* and extract its ``$.<node>.outputs.<field>`` references.
+
+    Returns ``None`` when the file is absent, unreadable, malformed JSON, or
+    has no ``dag`` object — all treated as "nothing to check" (conservative;
+    K006 is WARN and prefers a false negative over a false positive on a
+    partially-generated or unexpected manifest shape).
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    dag = data.get("dag")
+    if not isinstance(dag, dict):
+        return None
+
+    try:
+        rel = str(path.relative_to(root))
+    except ValueError:
+        rel = str(path)
+
+    return ManifestDag(manifest_path=rel, refs=_extract_refs(dag))

--- a/packages/conformance/conformance/suite/rules/contract_toolkit.py
+++ b/packages/conformance/conformance/suite/rules/contract_toolkit.py
@@ -413,7 +413,7 @@ RULES: tuple[RuleDefinition, ...] = (
         mechanism=RuleMechanism.STATIC,
         category="contract-toolkit",
         autofixable=False,
-        since="0.14.0",
+        since="0.13.0",
         orthogonal_gate="tests",
         rationale=(
             "App.pkl's pipeline nodes (e.g. PublishNode) unconditionally wire a "

--- a/packages/conformance/conformance/suite/rules/contract_toolkit.py
+++ b/packages/conformance/conformance/suite/rules/contract_toolkit.py
@@ -32,6 +32,25 @@ freshness (a hand-edit that keeps the banner is invisible to a static scanner);
 that guarantee belongs to the CI regenerate-and-diff freshness gate. All three
 are WARN and APP-scoped, and no-op on any repo without a ``contract/`` directory.
 
+Manifest-vs-contract field validation (BLDX-1527)
+--------------------------------------------------
+K006 closes a different structural gap: ``App.pkl``'s pipeline nodes (e.g.
+``PublishNode``) unconditionally wire a downstream node's args to the
+entrypoint's runtime output via a JSONPath such as
+``$.extract.outputs.publish_state_prefix``. Pkl compiles this before any
+Python runs and has zero visibility into the app's ``Output`` model; the B005
+contract-ledger checker only knows a field "was tracked and disappeared," with
+no knowledge of the manifest's JSONPath requirements. An app can silently
+delete a field the manifest depends on and nothing static catches it — only a
+rarely-run, non-deterministic full-DAG e2e does (the incident that motivated
+this rule: ``OpenAPIConnectorOutput`` lost ``publish_state_prefix`` /
+``current_state_prefix`` in a cleanup PR and went undetected for ~12 days).
+K006 cross-references every ``$.extract.outputs.<field>`` reference in the
+committed ``app/generated/**/manifest.json`` against the entrypoint's Python
+``Output`` contract, resolved across its full inheritance chain (so a field
+supplied by an SDK mixin such as ``PublishInputMixin`` counts as declared).
+WARN and APP-scoped; no-op on any repo without ``app/generated/``.
+
 Scope
 -----
 ``APP`` only: consumer apps have a ``contract/`` directory; the SDK itself does
@@ -384,6 +403,78 @@ RULES: tuple[RuleDefinition, ...] = (
         help_uri=(
             "https://github.com/atlanhq/application-sdk/blob/main/"
             "packages/conformance/conformance/docs/rules/contract-toolkit.md#k005"
+        ),
+    ),
+    RuleDefinition(
+        id="K006",
+        scope=RuleScope.APP,
+        name="ManifestContractFieldMismatch",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="contract-toolkit",
+        autofixable=False,
+        since="0.14.0",
+        orthogonal_gate="tests",
+        rationale=(
+            "App.pkl's pipeline nodes (e.g. PublishNode) unconditionally wire a "
+            "downstream node's args to the entrypoint's runtime output via a "
+            "JSONPath such as $.extract.outputs.publish_state_prefix. Pkl compiles "
+            "this before any Python runs and has zero visibility into the app's "
+            "Output model; the B005 contract-ledger checker only knows a field 'was "
+            "tracked and disappeared,' with no knowledge of the manifest's JSONPath "
+            "requirements. An app can therefore silently delete a field the manifest "
+            "depends on, and nothing static catches it — only a rarely-run, "
+            "non-deterministic full-DAG e2e run against a real Automation Engine "
+            "does. This is exactly what happened when OpenAPIConnectorOutput lost "
+            "publish_state_prefix and current_state_prefix in an unrelated "
+            "conformance-cleanup PR and went undetected for about 12 days (BLDX-1527). "
+            "K006 closes the loop with a structural manifest-vs-contract diff, "
+            "computed once both artifacts exist, without either layer needing "
+            "visibility into the other's language."
+        ),
+        short_description=(
+            "app/generated/**/manifest.json references an "
+            "$.extract.outputs.<field> the entrypoint's Output contract "
+            "does not declare"
+        ),
+        full_description=(
+            "A ``$.extract.outputs.<field>`` JSONPath reference in a committed "
+            "``app/generated/**/manifest.json`` DAG node's ``inputs.args`` names a "
+            "field that the corresponding entrypoint's Python ``Output`` contract "
+            "does not declare — not directly, and not via any inherited base class "
+            "or SDK mixin.\n"
+            "\n"
+            "The Automation Engine resolves this JSONPath at runtime against the "
+            "object the entrypoint's workflow actually returned. A missing field "
+            "means the reference never resolves, and the dependent pipeline step "
+            "(most commonly the default ``publish`` step) fails at runtime with an "
+            "unresolved-JSONPath error — the one signal that would have caught this "
+            "is a rarely-run, opt-in-labeled, non-deterministic full-DAG e2e test.\n"
+            "\n"
+            "**Fix:** declare the missing field(s) on the entrypoint's ``Output`` "
+            "model, or mix in the SDK contract base that already supplies them. For "
+            "the publish-state fields specifically "
+            "(``connection_qualified_name``, ``transformed_data_prefix``, "
+            "``publish_state_prefix``, ``current_state_prefix``), mix in "
+            "``application_sdk.contracts.base.PublishInputMixin`` rather than "
+            "hand-declaring each field — it also derives the values correctly from "
+            "``connection_qualified_name``.\n"
+            "\n"
+            "**Never hand-edit** ``app/generated/manifest.json`` to work around a "
+            "finding — it is a ``pkl eval`` output (K004/K005 and the generated-"
+            "artifact freshness gate catch a hand-edited manifest). If the "
+            "referenced field is genuinely not needed (e.g. the pipeline step that "
+            "consumes it should not be enabled), remove or reconfigure that step in "
+            "``contract/app.pkl`` and re-run ``pkl eval -m . contract/app.pkl`` "
+            "instead.\n"
+            "\n"
+            "**Suppress** with ``# conformance: ignore[K006] <reason>`` on the "
+            "``Output`` class definition (or the comment-only line directly above "
+            "it) when a mismatch is understood and deliberately deferred.\n"
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/contract-toolkit.md#k006"
         ),
     ),
 )

--- a/packages/conformance/conformance/suite/runner.py
+++ b/packages/conformance/conformance/suite/runner.py
@@ -43,6 +43,7 @@ from conformance.suite.checks import (
     gitignore_entries,
     integration_marking,
     legacy_contract,
+    manifest_contract,
     optimizations,
     orchestration,
     prescriptions,
@@ -192,6 +193,12 @@ _CHECKS: list[CheckRegistration] = [
         discover=generated_freshness.discover,
         scan_path=generated_freshness.scan_path,
         scan_all=generated_freshness.scan_all,
+    ),
+    CheckRegistration(
+        series=manifest_contract.SERIES,
+        discover=manifest_contract.discover,
+        scan_path=manifest_contract.scan_path,
+        scan_all=manifest_contract.scan_all,
     ),
     CheckRegistration(
         series=sdr_checks.SERIES,

--- a/packages/conformance/conformance/tools/generate_rule_docs.py
+++ b/packages/conformance/conformance/tools/generate_rule_docs.py
@@ -208,7 +208,9 @@ _SERIES_META: list[SeriesMeta] = [
             "``contract/**/*.pkl``), "
             "`suite.checks.generated_freshness` (K003–K005, scans "
             "``contract/PklProject``, ``contract/PklProject.deps.json``, "
-            "``atlan.yaml``, ``app.yaml``, and ``app/generated/**``)"
+            "``atlan.yaml``, ``app.yaml``, and ``app/generated/**``), "
+            "`suite.checks.manifest_contract` (K006, cross-references "
+            "``app/generated/**/manifest.json`` against Python ``Output`` contracts)"
         ),
         suppression_example=(
             "// conformance: ignore[K001] intentional: phased migration tracked in BLDX-XXXX"

--- a/packages/conformance/pyproject.toml
+++ b/packages/conformance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atlan-application-sdk-conformance"
-version = "0.14.0"
+version = "0.13.0"
 description = "Conformance suite, remediation programs, and CLI for the Atlan Application SDK"
 license = "Apache-2.0"
 authors = [

--- a/packages/conformance/pyproject.toml
+++ b/packages/conformance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atlan-application-sdk-conformance"
-version = "0.13.0"
+version = "0.14.0"
 description = "Conformance suite, remediation programs, and CLI for the Atlan Application SDK"
 license = "Apache-2.0"
 authors = [

--- a/packages/conformance/pyproject.toml
+++ b/packages/conformance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atlan-application-sdk-conformance"
-version = "0.13.0"
+version = "0.12.0"
 description = "Conformance suite, remediation programs, and CLI for the Atlan Application SDK"
 license = "Apache-2.0"
 authors = [

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -164,6 +164,9 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
     # K003/K004/K005: generated-artifact freshness — a stale Pkl lock, a missing
     # generated output, or a stripped provenance banner are all app-repo concerns
     # (the SDK has no contract/ + generated app artifacts) (BLDX-1414).
+    # K006: manifest-vs-contract field validation — only app repos have a
+    # generated app/generated/**/manifest.json DAG to cross-reference against a
+    # Python Output contract; the SDK has no such generated artifact (BLDX-1527).
     # E020: HTTP-failure-to-empty-return — the harm (publishing a partial crawl as
     # complete) is a connector extract/publish concern; the SDK's matching sites are
     # legitimate best-effort infra (health/metric scrapes), not crawlers (BLDX-1503).
@@ -196,6 +199,7 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
         "K003",
         "K004",
         "K005",
+        "K006",
         "P004",
         "P005",
         "P008",
@@ -439,10 +443,11 @@ def test_catalog_b_series_present() -> None:
 
 def test_catalog_k_series_present() -> None:
     """The K-series contract-toolkit rules are K001/K002 (source) plus the
-    generated-artifact freshness rules K003/K004/K005 (BLDX-1414)."""
+    generated-artifact freshness rules K003/K004/K005 (BLDX-1414), plus the
+    manifest-vs-contract field validation rule K006 (BLDX-1527)."""
     rules = load_catalog()
     k_ids = {r.id for r in rules if r.id.startswith("K")}
-    expected = {"K001", "K002", "K003", "K004", "K005"}
+    expected = {"K001", "K002", "K003", "K004", "K005", "K006"}
     missing = expected - k_ids
     assert not missing, f"Missing K-series rules: {missing}"
     extra = k_ids - expected

--- a/packages/conformance/tests/test_manifest_contract.py
+++ b/packages/conformance/tests/test_manifest_contract.py
@@ -342,6 +342,68 @@ def test_k006_multi_entrypoint_maps_subdir_to_wire_name(tmp_path: Path) -> None:
     assert "CrawlOutput" in k006[0].message
 
 
+_BUNDLE_APP_ATTRIBUTE_DECORATOR = """\
+import application_sdk.app as sdk
+
+class CrawlInput:
+    url: str
+
+class CrawlOutput:
+    connection_qualified_name: str
+    # publish_state_prefix removed — should fire only for the crawler manifest.
+
+class MineInput:
+    path: str
+
+class MineOutput:
+    connection_qualified_name: str
+    publish_state_prefix: str
+
+class MyApp(sdk.App):
+    @sdk.entrypoint(name="crawler")
+    async def crawl(self, input: CrawlInput) -> CrawlOutput:
+        pass
+
+    @sdk.entrypoint(name="miner")
+    async def mine(self, input: MineInput) -> MineOutput:
+        pass
+"""
+
+
+def test_k006_multi_entrypoint_with_attribute_style_decorator(tmp_path: Path) -> None:
+    """Attribute-form decorators (``@sdk.entrypoint``, via a module alias) must
+    resolve a wire name just like the bare ``@entrypoint`` form.
+
+    ``is_entrypoint_decorator`` (used for entrypoint detection) recognises
+    attribute-form decorators, so wire-name extraction must too — otherwise
+    the entrypoint resolves with ``wire_name=None``, never matches its manifest
+    subdir, and K006 silently skips it (a false negative)."""
+    paths = _write_py(tmp_path, {"app.py": _BUNDLE_APP_ATTRIBUTE_DECORATOR})
+    _write_manifest(
+        tmp_path / "app" / "generated" / "crawler" / "manifest.json",
+        {
+            "extract": _extract_node("crawler"),
+            "publish": _publish_node(
+                ["connection_qualified_name", "publish_state_prefix"]
+            ),
+        },
+    )
+    _write_manifest(
+        tmp_path / "app" / "generated" / "miner" / "manifest.json",
+        {
+            "extract": _extract_node("miner"),
+            "publish": _publish_node(
+                ["connection_qualified_name", "publish_state_prefix"]
+            ),
+        },
+    )
+    findings = scan_all(paths, tmp_path)
+    k006 = _k006(findings)
+    assert len(k006) == 1
+    assert "publish_state_prefix" in k006[0].message
+    assert "CrawlOutput" in k006[0].message
+
+
 # ---------------------------------------------------------------------------
 # Ambiguous / no-op scenarios
 # ---------------------------------------------------------------------------

--- a/packages/conformance/tests/test_manifest_contract.py
+++ b/packages/conformance/tests/test_manifest_contract.py
@@ -1,0 +1,466 @@
+"""Tests for K006 ManifestContractFieldMismatch.
+
+Covers the manifest-vs-contract cross-check: every ``$.extract.outputs.<field>``
+reference in a committed ``app/generated/**/manifest.json`` DAG node's
+``inputs.args`` must be a field the entrypoint's Python ``Output`` contract
+declares — directly, or via an inherited base/mixin (e.g.
+``PublishInputMixin``, the fix that resolved the motivating incident).
+
+Test helpers
+------------
+``_write_py``: writes ``{relative_path: source_text}`` under ``tmp_path``.
+``_write_manifest``: writes a ``manifest.json`` with a given ``dag`` dict at a
+given path — richer than the ``{"dag": {}}`` placeholder P016's tests use,
+since K006 needs real ``inputs.args`` JSONPath strings.
+``_run``: writes both, calls :func:`scan_all`, returns its findings.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from conformance.suite.checks.manifest_contract import scan_all
+from conformance.suite.rules import get_rule
+from conformance.suite.schema.disposition import EnforcementTier, RuleScope
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_py(tmp_path: Path, py_files: dict[str, str]) -> list[Path]:
+    paths: list[Path] = []
+    for name, src in py_files.items():
+        p = tmp_path / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(src, encoding="utf-8")
+        paths.append(p)
+    return paths
+
+
+def _write_manifest(path: Path, dag: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"dag": dag}), encoding="utf-8")
+
+
+def _extract_node(app_name: str = "myapp") -> dict:
+    """A minimal root 'extract' node (no depends_on, no downstream refs)."""
+    return {
+        "activity_name": "execute_workflow",
+        "app_name": app_name,
+        "inputs": {
+            "workflow_type": "MyWorkflow",
+            "app_name": app_name,
+            "task_queue": "q",
+            "args": {},
+        },
+    }
+
+
+def _publish_node(fields: list[str]) -> dict:
+    """A downstream node referencing ``$.extract.outputs.<field>`` for each *fields*."""
+    return {
+        "activity_name": "execute_workflow",
+        "app_name": "publish",
+        "inputs": {
+            "workflow_type": "PublishWorkflow",
+            "app_name": "publish",
+            "task_queue": "q",
+            "args": {f: f"$.extract.outputs.{f}" for f in fields},
+        },
+        "depends_on": {"node_id": "extract"},
+    }
+
+
+def _k006(findings: list) -> list:
+    return [f for f in findings if f.rule_id == "K006"]
+
+
+def _ids(findings: list) -> list[str]:
+    """Rule IDs of unsuppressed findings (matching runner gate semantics)."""
+    return [f.rule_id for f in findings if not f.suppressed]
+
+
+# ---------------------------------------------------------------------------
+# Rule metadata
+# ---------------------------------------------------------------------------
+
+
+def test_k006_rule_metadata() -> None:
+    rule = get_rule("K006")
+    assert rule.tier is EnforcementTier.WARN
+    assert rule.scope is RuleScope.APP
+    assert rule.category == "contract-toolkit"
+
+
+# ---------------------------------------------------------------------------
+# The motivating incident: a mixin-derived field silently deleted
+# ---------------------------------------------------------------------------
+
+_EXTRACT_MISSING_PUBLISH_FIELDS = """\
+from application_sdk.app import App, entrypoint
+
+class ExtractInput:
+    url: str
+
+class ExtractOutput:
+    connection_qualified_name: str
+    # publish_state_prefix and current_state_prefix were removed here —
+    # the exact shape of the incident this rule exists to catch.
+
+class MyApp(App):
+    @entrypoint
+    async def extract(self, input: ExtractInput) -> ExtractOutput:
+        pass
+"""
+
+_PUBLISH_FIELDS = [
+    "connection_qualified_name",
+    "transformed_data_prefix",
+    "publish_state_prefix",
+    "current_state_prefix",
+]
+
+
+def test_k006_fires_when_referenced_field_missing_from_output(tmp_path: Path) -> None:
+    paths = _write_py(tmp_path, {"app.py": _EXTRACT_MISSING_PUBLISH_FIELDS})
+    _write_manifest(
+        tmp_path / "app" / "generated" / "manifest.json",
+        {"extract": _extract_node(), "publish": _publish_node(_PUBLISH_FIELDS)},
+    )
+    findings = scan_all(paths, tmp_path)
+    k006 = _k006(findings)
+    missing = {f.message for f in k006}
+    # publish_state_prefix, current_state_prefix, and transformed_data_prefix are
+    # all referenced by _publish_node(_PUBLISH_FIELDS) but not declared on
+    # ExtractOutput — all three must be flagged.
+    assert any("publish_state_prefix" in m for m in missing)
+    assert any("current_state_prefix" in m for m in missing)
+    assert any("transformed_data_prefix" in m for m in missing)
+    assert not any(
+        "connection_qualified_name" in m for m in missing
+    ), "connection_qualified_name is declared — must not be flagged"
+
+
+def test_k006_finding_anchored_on_output_class(tmp_path: Path) -> None:
+    paths = _write_py(tmp_path, {"app.py": _EXTRACT_MISSING_PUBLISH_FIELDS})
+    _write_manifest(
+        tmp_path / "app" / "generated" / "manifest.json",
+        {
+            "extract": _extract_node(),
+            "publish": _publish_node(["publish_state_prefix"]),
+        },
+    )
+    findings = scan_all(paths, tmp_path)
+    k006 = _k006(findings)
+    assert k006
+    assert k006[0].file == "app.py"
+
+
+# ---------------------------------------------------------------------------
+# Fixed via PublishInputMixin (inherited fields) — the actual downstream fix
+# ---------------------------------------------------------------------------
+
+_EXTRACT_WITH_MIXIN = """\
+from application_sdk.app import App, entrypoint
+from application_sdk.contracts.base import PublishInputMixin
+
+class ExtractInput:
+    url: str
+
+class ExtractOutput(PublishInputMixin):
+    pass
+
+class MyApp(App):
+    @entrypoint
+    async def extract(self, input: ExtractInput) -> ExtractOutput:
+        pass
+"""
+
+
+def test_k006_silent_when_field_provided_via_sdk_mixin(tmp_path: Path) -> None:
+    """Guards the actual fix: PublishInputMixin resolves all four publish fields.
+
+    This is the case that requires the shared, inheritance-aware
+    ``resolve_contract_fields`` (BLDX-1528) — a same-body-only field scan would
+    false-positive here.
+    """
+    paths = _write_py(tmp_path, {"app.py": _EXTRACT_WITH_MIXIN})
+    _write_manifest(
+        tmp_path / "app" / "generated" / "manifest.json",
+        {"extract": _extract_node(), "publish": _publish_node(_PUBLISH_FIELDS)},
+    )
+    findings = scan_all(paths, tmp_path)
+    assert "K006" not in _ids(findings)
+
+
+# ---------------------------------------------------------------------------
+# Fields declared directly on the Output's own body
+# ---------------------------------------------------------------------------
+
+_EXTRACT_OWN_BODY_FIELDS = """\
+from application_sdk.app import App, entrypoint
+
+class ExtractInput:
+    url: str
+
+class ExtractOutput:
+    connection_qualified_name: str
+    transformed_data_prefix: str
+    publish_state_prefix: str
+    current_state_prefix: str
+
+class MyApp(App):
+    @entrypoint
+    async def extract(self, input: ExtractInput) -> ExtractOutput:
+        pass
+"""
+
+
+def test_k006_silent_when_field_declared_on_own_body(tmp_path: Path) -> None:
+    paths = _write_py(tmp_path, {"app.py": _EXTRACT_OWN_BODY_FIELDS})
+    _write_manifest(
+        tmp_path / "app" / "generated" / "manifest.json",
+        {"extract": _extract_node(), "publish": _publish_node(_PUBLISH_FIELDS)},
+    )
+    findings = scan_all(paths, tmp_path)
+    assert "K006" not in _ids(findings)
+
+
+# ---------------------------------------------------------------------------
+# References to a non-"extract" node are out of scope
+# ---------------------------------------------------------------------------
+
+
+def test_k006_ignores_refs_to_a_different_node(tmp_path: Path) -> None:
+    """A '$.qi.outputs.*' ref (not '$.extract.outputs.*') is never K006's concern,
+    even when ExtractOutput plainly lacks a matching field."""
+    paths = _write_py(tmp_path, {"app.py": _EXTRACT_MISSING_PUBLISH_FIELDS})
+    other_node = {
+        "activity_name": "execute_workflow",
+        "app_name": "query-intelligence",
+        "inputs": {
+            "workflow_type": "QueryIntelligenceWorkflow",
+            "app_name": "query-intelligence",
+            "task_queue": "q",
+            "args": {"input_prefix": "$.qi.outputs.something_unrelated"},
+        },
+        "depends_on": {"node_id": "extract"},
+    }
+    _write_manifest(
+        tmp_path / "app" / "generated" / "manifest.json",
+        {"extract": _extract_node(), "qi": other_node},
+    )
+    findings = scan_all(paths, tmp_path)
+    assert "K006" not in _ids(findings)
+
+
+def test_k006_ignores_workflow_and_failure_refs(tmp_path: Path) -> None:
+    """'$.workflow.*' / '$.failure.*' (AE run/failure context) never match 'outputs'."""
+    paths = _write_py(tmp_path, {"app.py": _EXTRACT_MISSING_PUBLISH_FIELDS})
+    notifications_node = {
+        "activity_name": "execute_workflow",
+        "app_name": "notification-app",
+        "inputs": {
+            "workflow_type": "NotificationWorkflow",
+            "app_name": "notification-app",
+            "task_queue": "q",
+            "args": {
+                "metadata": {
+                    "workflow_name": "$.workflow.name",
+                    "error_message": "$.failure.message",
+                }
+            },
+        },
+        "depends_on": {"tag": "workflow_complete"},
+    }
+    _write_manifest(
+        tmp_path / "app" / "generated" / "manifest.json",
+        {"extract": _extract_node(), "notifications": notifications_node},
+    )
+    findings = scan_all(paths, tmp_path)
+    assert "K006" not in _ids(findings)
+
+
+# ---------------------------------------------------------------------------
+# Multi-entrypoint (bundle): subdir <-> wire-name mapping
+# ---------------------------------------------------------------------------
+
+_BUNDLE_APP = """\
+from application_sdk.app import App, entrypoint
+
+class CrawlInput:
+    url: str
+
+class CrawlOutput:
+    connection_qualified_name: str
+    # publish_state_prefix removed — should fire only for the crawler manifest.
+
+class MineInput:
+    path: str
+
+class MineOutput:
+    connection_qualified_name: str
+    publish_state_prefix: str
+
+class MyApp(App):
+    @entrypoint(name="crawler")
+    async def crawl(self, input: CrawlInput) -> CrawlOutput:
+        pass
+
+    @entrypoint(name="miner")
+    async def mine(self, input: MineInput) -> MineOutput:
+        pass
+"""
+
+
+def test_k006_multi_entrypoint_maps_subdir_to_wire_name(tmp_path: Path) -> None:
+    paths = _write_py(tmp_path, {"app.py": _BUNDLE_APP})
+    _write_manifest(
+        tmp_path / "app" / "generated" / "crawler" / "manifest.json",
+        {
+            "extract": _extract_node("crawler"),
+            "publish": _publish_node(
+                ["connection_qualified_name", "publish_state_prefix"]
+            ),
+        },
+    )
+    _write_manifest(
+        tmp_path / "app" / "generated" / "miner" / "manifest.json",
+        {
+            "extract": _extract_node("miner"),
+            "publish": _publish_node(
+                ["connection_qualified_name", "publish_state_prefix"]
+            ),
+        },
+    )
+    findings = scan_all(paths, tmp_path)
+    k006 = _k006(findings)
+    assert len(k006) == 1
+    assert "publish_state_prefix" in k006[0].message
+    assert "CrawlOutput" in k006[0].message
+
+
+# ---------------------------------------------------------------------------
+# Ambiguous / no-op scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_k006_noop_when_app_generated_absent(tmp_path: Path) -> None:
+    paths = _write_py(tmp_path, {"app.py": _EXTRACT_MISSING_PUBLISH_FIELDS})
+    assert scan_all(paths, tmp_path) == []
+
+
+def test_k006_noop_when_no_entrypoints_in_code(tmp_path: Path) -> None:
+    paths = _write_py(tmp_path, {"app.py": "x = 1\n"})
+    _write_manifest(
+        tmp_path / "app" / "generated" / "manifest.json",
+        {"extract": _extract_node(), "publish": _publish_node(_PUBLISH_FIELDS)},
+    )
+    assert scan_all(paths, tmp_path) == []
+
+
+_TWO_ENTRYPOINTS_SINGLE_MANIFEST = """\
+from application_sdk.app import App, entrypoint
+
+class AInput:
+    url: str
+
+class AOutput:
+    pass
+
+class BInput:
+    url: str
+
+class BOutput:
+    pass
+
+class MyApp(App):
+    @entrypoint
+    async def a(self, input: AInput) -> AOutput:
+        pass
+
+    @entrypoint
+    async def b(self, input: BInput) -> BOutput:
+        pass
+"""
+
+
+def test_k006_skips_single_manifest_when_code_has_multiple_entrypoints(
+    tmp_path: Path,
+) -> None:
+    """Ambiguous mapping (single-EP manifest, >1 entrypoint in code) is skipped
+    rather than guessed — conservative, matches P016's own-mode semantics."""
+    paths = _write_py(tmp_path, {"app.py": _TWO_ENTRYPOINTS_SINGLE_MANIFEST})
+    _write_manifest(
+        tmp_path / "app" / "generated" / "manifest.json",
+        {"extract": _extract_node(), "publish": _publish_node(["missing_field"])},
+    )
+    assert scan_all(paths, tmp_path) == []
+
+
+_EXTRACT_OUTPUT_NOT_IN_REPO = """\
+from application_sdk.app import App, entrypoint
+from some_external_package import ExternalOutput
+
+class ExtractInput:
+    url: str
+
+class MyApp(App):
+    @entrypoint
+    async def extract(self, input: ExtractInput) -> ExternalOutput:
+        pass
+"""
+
+
+def test_k006_skips_when_output_class_not_resolvable_in_repo(tmp_path: Path) -> None:
+    """An Output class not defined anywhere in the scanned source (e.g. imported
+    from a third-party package) cannot be resolved — skip conservatively rather
+    than false-positive on every field."""
+    paths = _write_py(tmp_path, {"app.py": _EXTRACT_OUTPUT_NOT_IN_REPO})
+    _write_manifest(
+        tmp_path / "app" / "generated" / "manifest.json",
+        {
+            "extract": _extract_node(),
+            "publish": _publish_node(["connection_qualified_name"]),
+        },
+    )
+    assert scan_all(paths, tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Suppression
+# ---------------------------------------------------------------------------
+
+_EXTRACT_MISSING_FIELD_SUPPRESSED = """\
+from application_sdk.app import App, entrypoint
+
+class ExtractInput:
+    url: str
+
+# conformance: ignore[K006] intentional: publish disabled in a follow-up PR
+class ExtractOutput:
+    connection_qualified_name: str
+
+class MyApp(App):
+    @entrypoint
+    async def extract(self, input: ExtractInput) -> ExtractOutput:
+        pass
+"""
+
+
+def test_k006_suppression_directive_on_output_class(tmp_path: Path) -> None:
+    paths = _write_py(tmp_path, {"app.py": _EXTRACT_MISSING_FIELD_SUPPRESSED})
+    _write_manifest(
+        tmp_path / "app" / "generated" / "manifest.json",
+        {
+            "extract": _extract_node(),
+            "publish": _publish_node(["publish_state_prefix"]),
+        },
+    )
+    findings = scan_all(paths, tmp_path)
+    k006 = _k006(findings)
+    assert k006
+    assert all(f.suppressed for f in k006)
+    assert "K006" not in _ids(findings)

--- a/packages/conformance/uv.lock
+++ b/packages/conformance/uv.lock
@@ -219,7 +219,7 @@ wheels = [
 
 [[package]]
 name = "atlan-application-sdk-conformance"
-version = "0.13.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },

--- a/packages/conformance/uv.lock
+++ b/packages/conformance/uv.lock
@@ -219,7 +219,7 @@ wheels = [
 
 [[package]]
 name = "atlan-application-sdk-conformance"
-version = "0.14.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },

--- a/packages/conformance/uv.lock
+++ b/packages/conformance/uv.lock
@@ -219,7 +219,7 @@ wheels = [
 
 [[package]]
 name = "atlan-application-sdk-conformance"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

- Adds **K006 `ManifestContractFieldMismatch`**: a cross-artifact conformance check that cross-references every `$.extract.outputs.<field>` JSONPath reference in a committed `app/generated/**/manifest.json` DAG against the corresponding entrypoint's Python `Output` contract — resolved across its full inheritance chain (via BLDX-1528's `resolve_contract_fields`), so a field supplied by an SDK mixin such as `PublishInputMixin` counts as declared.
- Closes the structural gap described in [BLDX-1527](https://linear.app/atlan-epd/issue/BLDX-1527): `App.pkl`'s pipeline nodes (e.g. `PublishNode`) wire a downstream node's args to the entrypoint's runtime output via a JSONPath compiled *before* any Python runs, with zero visibility into the app's `Output` model. B005's ledger checker only knows a field "was tracked and disappeared" — it has no knowledge of manifest JSONPath requirements. A silently deleted field (exactly what happened to `OpenAPIConnectorOutput`'s `publish_state_prefix`/`current_state_prefix`) went undetected for ~12 days, surfacing only via a rarely-run, non-deterministic full-DAG e2e test.
- WARN-tier, APP-scoped (consistent with K001–K005; no-ops on the SDK repo and on repos without `app/generated/`).
- Registered in the runner, added to the rule catalog + generated docs (`docs/rules/contract-toolkit.md`), and given remediation guidance in the `contract-toolkit` OpenProse program (`programs/areas/contract-toolkit.prose.md`) consumed by `/remediate`.
- Builds on BLDX-1528 (#2557, merged) for the shared, inheritance-aware `resolve_contract_fields` used to resolve Output fields across base classes and SDK mixins.

## Test plan

- [x] `uv run pytest tests/test_manifest_contract.py -v` — 13 new tests: missing field (the incident), field resolved via `PublishInputMixin` (inherited), field on own body, refs to a non-`extract` node ignored, `$.workflow.*`/`$.failure.*` ignored, multi-entrypoint subdir↔wire-name mapping, ambiguous single-EP skip, unresolvable Output class skip, suppression directive, rule metadata.
- [x] `uv run pytest tests/ -q` (full conformance package) — 1778 passed, 1 xfailed.
- [x] `uv run atlan-application-sdk-conformance gen-rule-docs --check` — docs up to date.
- [x] `uv run atlan-application-sdk-conformance detect --repo . --series K` (SDK repo self-scan) — exit 0, no findings (correct APP-scope no-op).
- [x] **End-to-end against real `atlan-openapi-app`**: fires 2 K006 findings against a synthetic pre-fix repro of the incident; silent (0 findings) against the current `atlan-openapi-app@main` (which mixes in `PublishInputMixin`), confirmed via a fresh `gh repo clone`.
- [x] `uv run pre-commit run --all-files` — clean.
- [x] `uv run python -m pytest tests/unit -x -q` (SDK unit tests) — 5429 passed, 9 skipped.