### PR TITLE
feat(app): add App.iterate for durable page iteration

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -10,7 +10,7 @@ import sys
 import threading
 import warnings
 from abc import ABC
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from datetime import datetime, timedelta
 from typing import Any, ClassVar, Literal, Never, TypeVar, cast, get_type_hints
@@ -29,12 +29,14 @@ from application_sdk.app._ep_registration import (
 )
 from application_sdk.app.base_errors import (
     AbstractRunNotImplementedError,
+    DurableIterateInvalidArgumentError,
     ObjectStoreNotConfiguredError,
 )
 from application_sdk.app.context import (
     AppContext,
     TaskExecutionContext,
     _is_atlan_logger,
+    _is_in_workflow,
 )
 from application_sdk.app.entrypoint import EntryPointMetadata
 from application_sdk.app.registry import AppMetadata, resolve_pool_queue
@@ -77,6 +79,11 @@ except importlib.metadata.PackageNotFoundError:  # conformance: ignore[E009] pac
 # Type variable for require() method
 T = TypeVar("T")
 HT = TypeVar("HT", bound=HeartbeatDetails)
+
+# Type variables for App.iterate() — the durable page-iteration driver.
+_PageInT = TypeVar("_PageInT", bound=Input)
+_PageOutT = TypeVar("_PageOutT", bound=Output)
+_CursorT = TypeVar("_CursorT")
 
 # BLDX-878: inter-app calls deactivated pending review.
 # TChildInput = TypeVar("TChildInput", bound=Input)
@@ -838,6 +845,176 @@ class App(ABC):
             args=[input],
             memo={"correlation_id": self.correlation_id},
         )
+
+    def _iterate_should_continue_as_new(self, history_threshold: int | None) -> bool:
+        """Decide whether the page loop should continue-as-new now.
+
+        Returns True when Temporal itself suggests it (history approaching the
+        50k-event cap) or when an explicit ``history_threshold`` event count has
+        been reached. Returns False outside workflow context (local dev / unit
+        tests), so the loop runs to completion there instead of trying to
+        continue-as-new.
+        """
+        if not _is_in_workflow():
+            return False
+        info = workflow.info()
+        if info.is_continue_as_new_suggested():
+            return True
+        if history_threshold is not None:
+            return info.get_current_history_length() >= history_threshold
+        return False
+
+    async def iterate(
+        self,
+        page_task: Callable[[_PageInT], "Awaitable[_PageOutT]"],
+        *,
+        cursor: "_CursorT | None",
+        input_factory: Callable[["_CursorT | None"], _PageInT],
+        next_cursor: Callable[[_PageOutT], "_CursorT | None"],
+        resume_input: Callable[["_CursorT | None"], Input],
+        history_threshold: int | None = None,
+        max_pages_per_generation: int | None = None,
+    ) -> _PageOutT:
+        """Drive a cursor-paged ``@task`` while keeping workflow history bounded.
+
+        This is the SDK's answer to Temporal's hard **50,000-event history cap**,
+        which force-terminates large connector runs (e.g. lineage / query-history
+        miners on high-volume tenants) mid-flight. The root cause is an *unbounded
+        number of granular, per-item activities*; the fix is to stop writing them.
+
+        **The fix (what does the work): one heartbeating page-activity, not one
+        activity per item.** You write a single ``@task`` that processes a *whole
+        page* internally (looping, calling ``self.heartbeat(cursor)`` per item, and
+        offloading blocking work via ``self.run_in_thread``). That page is one
+        activity — a handful of history events — regardless of page size, and page
+        size is bounded only by memory / payload, never by the heartbeat timeout. At
+        ~4–6 events per activity, coarse pages let a single run absorb millions of
+        items with no history reset. For essentially every connector, this alone
+        keeps history bounded.
+
+        **The safety net (last resort): continue-as-new between pages.** 50k events
+        is a hard limit, so a tenant large enough that even coarse pages approach it
+        must reset history. After each page ``iterate`` checks
+        ``is_continue_as_new_suggested()`` and, *only when Temporal reports history
+        is near the cap*, restarts the workflow with a fresh history via
+        :meth:`continue_with`, resuming exactly at the current cursor. **In the
+        common case this never fires** — it is a backstop, not the mechanism you
+        rely on.
+
+        The safety net is used the way continue-as-new is designed for, not the way
+        it is misused: granularity is fixed first (so it never papers over granular
+        activities), and each page's activity is **awaited before** the boundary, so
+        no activity is ever left pending across it. The loop is deterministic (only
+        cursor state + activity calls), so it is workflow-replay-safe.
+
+        Call from ``run()``. Per-page results must be **persisted by the page-task**
+        (object store / state store) — values accumulated in workflow memory do not
+        survive a continue-as-new boundary. ``iterate`` returns only the final
+        page's ``Output`` (the generation in which the source is exhausted).
+
+        Cursor design: the cursor must round-trip through ``run()``'s ``Input`` so
+        the workflow behaves identically on first run and after continue-as-new.
+        ``resume_input`` builds the next ``run()`` input embedding the cursor;
+        ``run()`` reads that cursor back and passes it as ``cursor=``. Large cursors
+        should ride in ``persistent_state`` (claim-check) rather than inline.
+
+        Example::
+
+            @task
+            async def crawl_page(self, input: PageInput) -> PageOutput:
+                rows, next_token = await self.run_in_thread(
+                    fetch_page, input.page_token
+                )
+                for i, row in enumerate(rows):
+                    process(row)
+                    self.heartbeat(PageProgress(page_token=input.page_token, index=i))
+                return PageOutput(next_page_token=next_token, count=len(rows))
+
+            async def run(self, input: CrawlInput) -> CrawlOutput:
+                final = await self.iterate(
+                    self.crawl_page,
+                    cursor=input.page_token,
+                    input_factory=lambda tok: PageInput(page_token=tok),
+                    next_cursor=lambda out: out.next_page_token,  # None => done
+                    resume_input=lambda tok: replace(input, page_token=tok),
+                )
+                return CrawlOutput(...)
+
+        Args:
+            page_task: The ``@task`` method to invoke once per page (e.g.
+                ``self.crawl_page``). It must process the whole page and return an
+                ``Output`` from which ``next_cursor`` can derive the next cursor.
+            cursor: The starting cursor. ``None`` on the first run; the resumed
+                value (read from ``run()``'s input) after a continue-as-new.
+            input_factory: Builds the page-task's ``Input`` from the current cursor.
+            next_cursor: Extracts the next cursor from a page ``Output``. Return
+                ``None`` to signal the source is exhausted and end iteration.
+            resume_input: Builds the ``run()`` ``Input`` to continue-as-new with,
+                embedding the given cursor. Typically ``dataclasses.replace``.
+            history_threshold: Advanced override — an explicit event-count trigger
+                that forces the continue-as-new safety net earlier than Temporal
+                suggests. Must be >= 1 if provided. Most callers leave this unset
+                and rely on ``is_continue_as_new_suggested()`` alone.
+            max_pages_per_generation: Optional cap on pages processed per workflow
+                generation before forcing a continue-as-new. Must be >= 1 if
+                provided. Useful as a deterministic bound and for testing.
+
+        Returns:
+            The final page's ``Output`` (the generation in which iteration
+            completes). Does not return across a continue-as-new boundary.
+
+        Raises:
+            DurableIterateInvalidArgumentError: If ``history_threshold`` or
+                ``max_pages_per_generation`` is < 1.
+            AppContextError: If called outside ``run()`` execution.
+        """
+        if history_threshold is not None and history_threshold < 1:
+            raise DurableIterateInvalidArgumentError(
+                message=(
+                    f"iterate() history_threshold must be >= 1, "
+                    f"got {history_threshold}"
+                ),
+                field="history_threshold",
+                constraint=">= 1",
+                value_summary=str(history_threshold),
+            )
+        if max_pages_per_generation is not None and max_pages_per_generation < 1:
+            raise DurableIterateInvalidArgumentError(
+                message=(
+                    f"iterate() max_pages_per_generation must be >= 1, "
+                    f"got {max_pages_per_generation}"
+                ),
+                field="max_pages_per_generation",
+                constraint=">= 1",
+                value_summary=str(max_pages_per_generation),
+            )
+        if self._context is None:
+            raise AppContextError("iterate() is only available during run() execution.")
+
+        pages_this_generation = 0
+        while True:
+            page_input = input_factory(cursor)
+            # One activity for the whole page — awaited fully before we ever reach
+            # a continue-as-new boundary, so nothing is left pending across it.
+            output = await page_task(page_input)
+            pages_this_generation += 1
+
+            next_ = next_cursor(output)
+            if next_ is None:
+                # Source exhausted — iteration is complete for good.
+                return output
+            cursor = next_
+
+            reached_page_limit = (
+                max_pages_per_generation is not None
+                and pages_this_generation >= max_pages_per_generation
+            )
+            if reached_page_limit or self._iterate_should_continue_as_new(
+                history_threshold
+            ):
+                # Restart with a fresh history, resuming at the current cursor.
+                # Does not return.
+                self.continue_with(resume_input(cursor))
 
     # =========================================================================
     # Framework-provided storage tasks

--- a/application_sdk/app/base_errors.py
+++ b/application_sdk/app/base_errors.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import ClassVar
 
-from application_sdk.errors.leaves import PreconditionError, UnimplementedError
+from application_sdk.errors.leaves import (
+    InvalidInputError,
+    PreconditionError,
+    UnimplementedError,
+)
 
 
 @dataclass(kw_only=True)
@@ -48,3 +52,10 @@ class AbstractRunNotImplementedError(UnimplementedError):
     code: ClassVar[str] = "UNIMPLEMENTED_APP_RUN"
     app_class: str | None = None
     message: str = "App must implement run() or define @entrypoint methods"
+
+
+@dataclass(kw_only=True)
+class DurableIterateInvalidArgumentError(InvalidInputError):
+    """App.iterate() called with an invalid threshold or page-limit argument."""
+
+    code: ClassVar[str] = "INVALID_INPUT_DURABLE_ITERATE_ARGUMENT"

--- a/docs/adr/0017-durable-page-iteration.md
+++ b/docs/adr/0017-durable-page-iteration.md
@@ -1,0 +1,113 @@
+# ADR-0017: Durable Page Iteration (`App.iterate`) — Bounding Workflow History Without Heartbeat-Timeout Trade-offs
+
+## Status
+
+**Accepted** — motivated by the Workflow-Resiliency triage (Temporal history-cap
+force-terminations of large connector runs). Implements the two patterns Temporal recommends
+for high-cardinality work; builds on the existing `App.continue_with` primitive (ADR-0010,
+async-first) and the heartbeat machinery.
+
+## Context
+
+Temporal enforces a hard **51,200-event / 50 MB** history cap per workflow execution (warning at
+10,240). Large connector runs — lineage, query-history miners, and similar on high-volume tenants
+— fan out **one activity per item**, chunked with a manual `range()` + `asyncio.gather` inside a
+single workflow run (see `application_sdk/templates/incremental_sql_metadata_extractor.py`). Each
+activity contributes several history events, so history grows **linearly with the item count** and
+the history-service force-terminates the run mid-flight. The failure is silent: lineage /
+query-intelligence comes back quietly incomplete for exactly the largest tenants, and it counts
+against the fleet success rate.
+
+Two failure modes are in tension:
+
+1. **History-cap termination** — too many activity events in one workflow.
+2. **Heartbeat timeout** — an activity that runs too long without heartbeating.
+
+Batching the *number* of activities (one activity per chunk) only divides history by a constant
+factor (`O(n / batch_size)`); to keep the largest tenants under the cap you must grow the chunk,
+which lengthens each activity and pushes it toward the **heartbeat-timeout** failure mode. That
+coupling — one knob trading one production failure for another — is the thing to eliminate.
+
+## Decision
+
+Add **`App.iterate(page_task, *, cursor, input_factory, next_cursor, resume_input,
+history_threshold=None, max_pages_per_generation=None)`** — a workflow-context driver whose
+**primary mechanism is the root-cause fix** and which keeps a platform-mandated safety net for the
+extreme tail.
+
+**The fix (primary): one heartbeating page-activity, not one activity per item.** The author writes
+a single `@task` that processes a *whole page* internally, calling `self.heartbeat(cursor)` per item
+and offloading blocking work through `self.run_in_thread`. That page is **one** activity — a handful
+of history events — regardless of page size, and page size is bounded only by memory / payload,
+**never** by the heartbeat timeout (heartbeating *inside* the activity is the canonical
+timeout-prevention mechanism, already automatic via `auto_heartbeat_seconds`). This directly removes
+the "unbounded number of granular activities" root cause: at ~4–6 events per activity and a ~40K
+usable budget, a single run absorbs **millions of items** in coarse pages with no history reset at
+all. For essentially every real connector, this lever alone keeps history bounded.
+
+**The safety net (last resort): continue-as-new between pages.** 50K events is a hard Temporal
+limit, so a tenant large enough that even max-sane pages exceed the budget must reset history
+*somehow* — there is no third option (continue-as-new or child workflows). After each page,
+`iterate` checks `workflow.info().is_continue_as_new_suggested()` and, only when Temporal itself
+reports history is approaching the cap, restarts the workflow with a fresh history via
+`continue_with`, resuming at the current cursor. **In the common case this never fires** — the
+page-activity coarsening has already kept history low. It is a backstop, not the feature.
+
+This is deliberately *not* the misuse continue-as-new is warned against: granularity is fixed
+**first**, so the safety net never papers over granular activities; each page's activity is
+**awaited before** the boundary, so no activity is ever left pending across it; and the reset
+happens only at clean page boundaries with the cursor carried in the input — the exact use
+continue-as-new was designed for. The loop is deterministic, so it is workflow-replay-safe.
+`history_threshold` is an advanced override for teams that want to force the reset earlier than
+Temporal suggests; most callers leave it unset. Invalid `history_threshold` /
+`max_pages_per_generation` raise `DurableIterateInvalidArgumentError` (ADR-0013 `InvalidInputError`
+leaf) at call time.
+
+## Options Considered
+
+### Option 1: `App.iterate` — heartbeating page-activity + continue-as-new iterator (Chosen)
+
+**Pros:**
+- **Bounds history for any `n`** (reset each generation), not by a constant factor.
+- **No heartbeat trade-off** — page size is decoupled from the history lever; heartbeating happens
+  inside the page-activity.
+- **Connectors stop hand-rolling** chunk loops, cursor checkpointing, and continue-as-new.
+- Reuses existing primitives (`continue_with`, `heartbeat`/`get_last_heartbeat_details`,
+  `run_in_thread`, `persistent_state`).
+
+**Cons:**
+- The page is the retry unit — a failed page retries together (mitigated by resuming from
+  heartbeat details within the page-task).
+- Requires the author to design a cursor that round-trips through `run()`'s `Input`.
+
+### Option 2: `map_batched` — batch the number of activities (Not Chosen as the fix)
+
+Chunk fan-out to one activity per chunk. **Cons:** history stays `O(n / batch_size)`; controlling
+history means growing chunks, which reintroduces heartbeat risk. A weaker variant of Option 1's
+lever #1 without the continue-as-new guarantee. May survive as a minor throughput knob but is
+neither necessary nor sufficient for the history cap.
+
+### Option 3: Child-workflow partitioning / sliding window (Deferred)
+
+Temporal's answer for true parallel throughput (each child gets its own 50K budget; the official
+`batch_sliding_window` sample). **Not viable today:** the SDK makes no
+`execute_child_workflow`/`start_child_workflow` calls and inter-app wiring is deactivated under
+BLDX-878. A separate, larger effort — revisit if a single continue-as-new chain can't keep up on
+the biggest tenants.
+
+## Consequences
+
+**Positive:**
+- Large fan-outs stay under the 51,200-event cap regardless of tenant size, without inducing
+  heartbeat timeouts.
+- One documented iteration idiom with cursor resume, ordering, and history bounding.
+
+**Caveat — cleanup fires every generation:** `continue_with` runs `finally: on_complete()` on every
+cycle, which schedules `cleanup_files` / `cleanup_storage` and deletes tracked `FileReference`s +
+temp dirs. Cross-generation data must live in `persistent_state` / the upstream object store, never
+in transient local temp expected to survive a boundary. `App.iterate`'s contract makes per-page
+results the page-task's responsibility to persist, which respects this.
+
+**Follow-up:** a conformance rule (H-series) flagging `asyncio.to_thread` / async-wrapped sync
+activity bodies — the actual cause of most current production heartbeat timeouts — steering authors
+to `run_in_thread`.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -20,3 +20,4 @@ ADRs capture the architectural decisions behind the Application SDK — what was
 | [ADR-0014](0014-two-store-storage-architecture.md) | Two-Store Storage Architecture (task-to-task vs app-to-app) |
 | [ADR-0015](0015-directory-listing-race-fix.md) | Directory Listing Race Fix (safe_list_directory primitive) |
 | [ADR-0016](0016-multi-pool-worker-routing.md) | Multi-Pool Worker Routing (N pools per app, @task(pool=...) static affinity) |
+| [ADR-0017](0017-durable-page-iteration.md) | Durable Page Iteration (App.iterate — bound history via continue-as-new over a heartbeating page-activity) |

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -117,6 +117,41 @@ class MyConnector(App):
             )
 ```
 
+## Processing Large Datasets: `App.iterate`
+
+Temporal force-terminates any workflow whose event history exceeds **~51,200 events / 50 MB**. A connector that dispatches **one activity per item** (10k tables = 10k activities) drives history linearly toward that cap and gets killed mid-run on large tenants. The root-cause fix is to **stop writing per-item activities**; `App.iterate` packages that fix (see [ADR-0017](../adr/0017-durable-page-iteration.md)):
+
+1. **The fix — write one heartbeating page-task, not one activity per item.** A single `@task` processes a whole *page* internally, heartbeating per item (§Manual Heartbeats) and offloading blocking work via `run_in_thread`. That page is **one** activity — a handful of history events — no matter how many items it holds. At ~4–6 events per activity, coarse pages let a single run absorb **millions of items** with no history reset. For essentially every connector, this lever alone keeps history bounded.
+2. **The safety net — continue-as-new between pages.** Because 50K is a hard limit, an extreme tenant whose history still approaches the cap must reset it. `App.iterate` checks `is_continue_as_new_suggested()` after each page and, *only when Temporal reports history is near the cap*, restarts with a fresh history via `continue_with`, resuming at the current cursor. **In the common case this never fires** — it is a backstop, not the mechanism you rely on.
+
+```python
+class CrawlApp(App):
+    @task
+    async def crawl_page(self, input: PageInput) -> PageOutput:
+        rows, next_token = await self.run_in_thread(fetch_page, input.page_token)
+        for i, row in enumerate(rows):
+            persist(row)  # per-page results MUST be persisted here — see caveat
+            self.heartbeat(PageProgress(page_token=input.page_token, index=i))
+        return PageOutput(next_page_token=next_token)  # None => done
+
+    async def run(self, input: CrawlInput) -> CrawlOutput:
+        await self.iterate(
+            self.crawl_page,
+            cursor=input.page_token,                       # None first run; resumed after CAN
+            input_factory=lambda tok: PageInput(page_token=tok),
+            next_cursor=lambda out: out.next_page_token,   # None => iteration complete
+            resume_input=lambda tok: replace(input, page_token=tok),
+        )
+        return CrawlOutput(...)
+```
+
+Design rules:
+
+- **Page size is bounded by memory / payload, *not* by the heartbeat timeout** — heartbeating inside the activity is the timeout-prevention mechanism. Keep a page under the ~2 MB payload limit; use `FileReference` for large per-item data (§FileReference).
+- **The cursor must round-trip through `run()`'s `Input`** so the workflow behaves identically first-run and after continue-as-new. Large cursors belong in `persistent_state` (claim-check), not inline.
+- **Persist per-page results in the page-task** (object/state store). Values accumulated in workflow memory do **not** survive a continue-as-new boundary; `iterate` returns only the final generation's `Output`.
+- **Cleanup runs every generation.** `continue_with` triggers `on_complete()` cleanup (`cleanup_files` / `cleanup_storage`) on each cycle — never rely on transient local temp surviving across a boundary.
+
 ## Infrastructure Access via self.context
 
 Inside a `@task` method, access infrastructure through `self.context`:

--- a/tests/unit/app/test_iterate.py
+++ b/tests/unit/app/test_iterate.py
@@ -1,0 +1,260 @@
+"""Tests for App.iterate() — the durable page-iteration driver.
+
+These exercise the driver's contract without a Temporal worker: the page-task is
+called directly (the @task decorator only attaches metadata), and continue-as-new
+is simulated by patching continue_with / workflow.info.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from application_sdk.app.base import App, AppContextError
+from application_sdk.app.base_errors import DurableIterateInvalidArgumentError
+from application_sdk.app.context import AppContext
+from application_sdk.contracts.base import Input, Output
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+class PageIn(Input, allow_unbounded_fields=True):
+    token: int = 0
+
+
+class PageOut(Output, allow_unbounded_fields=True):
+    processed: int = 0
+    next_token: int | None = None
+
+
+class RunIn(Input, allow_unbounded_fields=True):
+    token: int | None = None
+
+
+class RunOut(Output, allow_unbounded_fields=True):
+    total: int = 0
+
+
+class _Stop(Exception):
+    """Sentinel raised by a mocked continue_with to mimic ContinueAsNewError."""
+
+
+@pytest.fixture(autouse=True)
+def _reset(clean_app_registry, clean_task_registry):  # type: ignore[no-untyped-def]
+    yield
+
+
+def _ctx() -> AppContext:
+    return AppContext(
+        app_name="iter-app",
+        app_version="0.0.1",
+        run_id="rid",
+        correlation_id="corr-1",
+    )
+
+
+def _make_app(pages: int | None):
+    """Build an App whose page-task walks tokens 0,1,2,...
+
+    If ``pages`` is None the source is infinite (next_token always advances);
+    otherwise it is exhausted (next_token=None) once ``pages`` have been served.
+    """
+
+    class _IterApp(App):
+        def __init__(self) -> None:
+            super().__init__()
+            self.seen: list[int] = []
+
+        async def run(self, input: RunIn) -> RunOut:  # pragma: no cover - unused
+            return RunOut()
+
+        async def crawl(self, input: PageIn) -> PageOut:
+            self.seen.append(input.token)
+            if pages is not None and input.token >= pages - 1:
+                nxt = None
+            else:
+                nxt = input.token + 1
+            return PageOut(processed=10, next_token=nxt)
+
+    return _IterApp()
+
+
+def _iterate(app: App, **overrides):
+    kwargs = dict(
+        cursor=0,
+        input_factory=lambda c: PageIn(token=c or 0),
+        next_cursor=lambda out: out.next_token,
+        resume_input=lambda c: RunIn(token=c),
+    )
+    kwargs.update(overrides)
+    return app.iterate(app.crawl, **kwargs)  # type: ignore[attr-defined]
+
+
+# =============================================================================
+# Happy path — runs to completion without continue-as-new
+# =============================================================================
+
+
+class TestCompletion:
+    @pytest.mark.asyncio
+    async def test_single_page_source(self) -> None:
+        app = _make_app(pages=1)
+        app._context = _ctx()
+        out = await _iterate(app)
+        assert app.seen == [0]  # type: ignore[attr-defined]
+        assert out.next_token is None
+
+    @pytest.mark.asyncio
+    async def test_multi_page_runs_to_completion_in_order(self) -> None:
+        app = _make_app(pages=3)
+        app._context = _ctx()
+        out = await _iterate(app)
+        # Cursor advanced 0 -> 1 -> 2, then exhausted.
+        assert app.seen == [0, 1, 2]  # type: ignore[attr-defined]
+        assert out.next_token is None
+
+    @pytest.mark.asyncio
+    async def test_empty_source_returns_first_output(self) -> None:
+        # A source that is immediately exhausted still runs the first page once
+        # (the page-task is the only thing that knows it is empty).
+        app = _make_app(pages=1)
+        app._context = _ctx()
+        out = await _iterate(app)
+        assert isinstance(out, PageOut)
+
+
+# =============================================================================
+# Continue-as-new triggers
+# =============================================================================
+
+
+class TestContinueAsNew:
+    @pytest.mark.asyncio
+    async def test_max_pages_per_generation_triggers_continue_with(self) -> None:
+        app = _make_app(pages=None)  # infinite source
+        app._context = _ctx()
+        with mock.patch.object(app, "continue_with", side_effect=_Stop) as cont:
+            with pytest.raises(_Stop):
+                await _iterate(app, max_pages_per_generation=2)
+        # Two pages fully processed BEFORE the boundary (await-before-CAN),
+        # then continue-as-new with the cursor pointing past them.
+        assert app.seen == [0, 1]  # type: ignore[attr-defined]
+        cont.assert_called_once()
+        assert cont.call_args.args[0] == RunIn(token=2)
+
+    @pytest.mark.asyncio
+    async def test_is_continue_as_new_suggested_triggers(self) -> None:
+        app = _make_app(pages=None)
+        app._context = _ctx()
+        info = mock.MagicMock()
+        info.is_continue_as_new_suggested.return_value = True
+        with (
+            mock.patch("application_sdk.app.base._is_in_workflow", return_value=True),
+            mock.patch("application_sdk.app.base.workflow.info", return_value=info),
+            mock.patch.object(app, "continue_with", side_effect=_Stop) as cont,
+        ):
+            with pytest.raises(_Stop):
+                await _iterate(app)
+        # First page processed, then Temporal-suggested CAN.
+        assert app.seen == [0]  # type: ignore[attr-defined]
+        cont.assert_called_once()
+        assert cont.call_args.args[0] == RunIn(token=1)
+
+    @pytest.mark.asyncio
+    async def test_history_threshold_triggers(self) -> None:
+        app = _make_app(pages=None)
+        app._context = _ctx()
+        info = mock.MagicMock()
+        info.is_continue_as_new_suggested.return_value = False
+        info.get_current_history_length.return_value = 20_000
+        with (
+            mock.patch("application_sdk.app.base._is_in_workflow", return_value=True),
+            mock.patch("application_sdk.app.base.workflow.info", return_value=info),
+            mock.patch.object(app, "continue_with", side_effect=_Stop) as cont,
+        ):
+            with pytest.raises(_Stop):
+                await _iterate(app, history_threshold=15_000)
+        assert app.seen == [0]  # type: ignore[attr-defined]
+        cont.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_below_history_threshold_does_not_trigger(self) -> None:
+        app = _make_app(pages=3)  # finite, so it completes on its own
+        app._context = _ctx()
+        info = mock.MagicMock()
+        info.is_continue_as_new_suggested.return_value = False
+        info.get_current_history_length.return_value = 100
+        with (
+            mock.patch("application_sdk.app.base._is_in_workflow", return_value=True),
+            mock.patch("application_sdk.app.base.workflow.info", return_value=info),
+            mock.patch.object(app, "continue_with", side_effect=_Stop) as cont,
+        ):
+            out = await _iterate(app, history_threshold=15_000)
+        cont.assert_not_called()
+        assert app.seen == [0, 1, 2]  # type: ignore[attr-defined]
+        assert out.next_token is None
+
+    @pytest.mark.asyncio
+    async def test_resume_input_carries_cursor(self) -> None:
+        # After continue-as-new, run() would be re-entered with the resumed input;
+        # a subsequent iterate(cursor=<resumed>) picks up exactly there.
+        app = _make_app(pages=None)
+        app._context = _ctx()
+        with mock.patch.object(app, "continue_with", side_effect=_Stop) as cont:
+            with pytest.raises(_Stop):
+                await _iterate(app, cursor=5, max_pages_per_generation=1)
+        assert app.seen == [5]  # type: ignore[attr-defined]
+        assert cont.call_args.args[0] == RunIn(token=6)
+
+
+# =============================================================================
+# Validation and context guards
+# =============================================================================
+
+
+class TestGuards:
+    @pytest.mark.asyncio
+    async def test_history_threshold_below_one_raises(self) -> None:
+        app = _make_app(pages=1)
+        app._context = _ctx()
+        with pytest.raises(DurableIterateInvalidArgumentError) as exc:
+            await _iterate(app, history_threshold=0)
+        assert exc.value.code == "INVALID_INPUT_DURABLE_ITERATE_ARGUMENT"
+        assert exc.value.field == "history_threshold"
+
+    @pytest.mark.asyncio
+    async def test_max_pages_below_one_raises(self) -> None:
+        app = _make_app(pages=1)
+        app._context = _ctx()
+        with pytest.raises(DurableIterateInvalidArgumentError) as exc:
+            await _iterate(app, max_pages_per_generation=0)
+        assert exc.value.field == "max_pages_per_generation"
+
+    @pytest.mark.asyncio
+    async def test_raises_outside_run(self) -> None:
+        app = _make_app(pages=1)  # no _context set
+        with pytest.raises(AppContextError, match="iterate"):
+            await _iterate(app)
+
+    @pytest.mark.asyncio
+    async def test_page_task_error_propagates(self) -> None:
+        class _BoomApp(App):
+            async def run(self, input: RunIn) -> RunOut:  # pragma: no cover
+                return RunOut()
+
+            async def boom(self, input: PageIn) -> PageOut:
+                raise ValueError("page failed")
+
+        app = _BoomApp()
+        app._context = _ctx()
+        with pytest.raises(ValueError, match="page failed"):
+            await app.iterate(  # type: ignore[attr-defined]
+                app.boom,
+                cursor=0,
+                input_factory=lambda c: PageIn(token=c or 0),
+                next_cursor=lambda out: out.next_token,
+                resume_input=lambda c: RunIn(token=c),
+            )


### PR DESCRIPTION
## Summary

Large connector runs — lineage, query-history miners, big jobs on high-volume tenants — are silently force-terminated by Temporal partway through. Not OOM, not a customer stop: they fan out **one activity per item**, so a single workflow's event history grows linearly with item count and hits Temporal's hard **~51,200-event / 50 MB cap**. The history-service then kills the run mid-flight, returning quietly incomplete lineage / query-intelligence for exactly the largest tenants and counting against the fleet success rate.

**Root cause (as called out in triage): an unbounded number of granular, per-item activities.** The fix is to stop writing them. This PR adds `App.iterate` to package that fix.

## The fix (primary lever): one heartbeating page-activity, not one activity per item

The author writes a single `@task` that processes a **whole page** internally — looping, calling `self.heartbeat(cursor)` per item, offloading blocking work via `self.run_in_thread`. That page is **one** activity — a handful of history events — regardless of page size.

- At ~4–6 events per activity and a ~40K usable budget, coarse pages let a single run absorb **millions of items with no history reset at all**. For essentially every real connector, this lever alone keeps history bounded.
- Page size is bounded by memory / payload, **never by the heartbeat timeout** — heartbeating *inside* the activity is the timeout-prevention mechanism (already automatic via `auto_heartbeat_seconds`). This is what avoids trading the history-cap failure mode for the heartbeat-timeout failure mode.

## The safety net (last resort): continue-as-new between pages

50K is a hard Temporal limit, so a tenant large enough that even coarse pages approach it must reset history *somehow*. After each page, `iterate` checks `workflow.info().is_continue_as_new_suggested()` and — **only when Temporal itself reports history is near the cap** — restarts the workflow with a fresh history via the existing `continue_with`, resuming at the current cursor.

- **In the common case this never fires.** It is a backstop, not the mechanism you rely on.
- It is used the way continue-as-new is *designed* for, not the misuse it's warned against: granularity is fixed **first** (so it never papers over granular activities), each page's activity is **awaited before** the boundary (no pending activity is cancelled across it), and the cursor rides in `run()`'s input for exact resume.

## API

```python
@task
async def crawl_page(self, input: PageInput) -> PageOutput:
    rows, next_token = await self.run_in_thread(fetch_page, input.page_token)
    for i, row in enumerate(rows):
        persist(row)                                     # per-page results persisted here
        self.heartbeat(PageProgress(page_token=input.page_token, index=i))
    return PageOutput(next_page_token=next_token)        # None => done

async def run(self, input: CrawlInput) -> CrawlOutput:
    await self.iterate(
        self.crawl_page,
        cursor=input.page_token,                         # None first run; resumed after CAN
        input_factory=lambda tok: PageInput(page_token=tok),
        next_cursor=lambda out: out.next_page_token,     # None => complete
        resume_input=lambda tok: replace(input, page_token=tok),
    )
    return CrawlOutput(...)
```

`history_threshold` is an advanced override to force the reset earlier than Temporal suggests; most callers leave it unset. Invalid `history_threshold` / `max_pages_per_generation` raise `DurableIterateInvalidArgumentError` (ADR-0013 leaf).

## Why not just batch the number of activities?

Chunking fan-out to one activity per chunk (the earlier `map_batched` direction, closed as #2077) only divides history by a constant factor — history stays `O(n / batch_size)`, and to control it you must grow the chunk, which lengthens each activity and reintroduces heartbeat risk. `App.iterate` instead batches the *work inside one heartbeating activity* (`O(pages)` events, page size bounded by memory not heartbeat) and keeps continue-as-new as a rarely-hit backstop. See ADR-0017 for the full options analysis.

## Deferred

Child-workflow partitioning (Temporal's scale-out for the extreme tail, each child with its own 50K budget) is deferred — the SDK has no child-workflow support today (inter-app wiring disabled under BLDX-878). Revisit only if a single continue-as-new chain can't keep up on the biggest tenants.

## Changes

- `application_sdk/app/base.py` — `App.iterate(...)` + `_iterate_should_continue_as_new()`
- `application_sdk/app/base_errors.py` — `DurableIterateInvalidArgumentError`
- `docs/adr/0017-durable-page-iteration.md` (+ index)
- `docs/concepts/tasks.md` — task-authoring guidance
- `tests/unit/app/test_iterate.py` — 12 tests

## Test plan

- `tests/unit/app/test_iterate.py`: completion, page ordering, all continue-as-new triggers (suggested / history_threshold / max_pages), await-before-CAN, cursor resume, validation, context guard, error propagation.
- 124 tests pass (new + `test_base`); pre-commit clean (ruff / ruff-format / isort / pyright).
- ⚠️ Local-Temporal integration smoke test (real continue-as-new boundary: resume-at-cursor + exactly-once + bounded history) **not yet run** — flagged for follow-up before relying on the backstop in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
