### PR TITLE
test(sdr): moderate coverage — publish round-trip, statestore, non-crawler routing (DISTR-849)

### DIFF
--- a/.github/actions/sdr-e2e/components/statestore.yaml
+++ b/.github/actions/sdr-e2e/components/statestore.yaml
@@ -1,0 +1,25 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  version: v1
+  # A DURABLE state store for the SDR e2e stack. The set previously shipped only
+  # eventstore/objectstore/secretstore, so a connector that calls
+  # AppContext.save_state/load_state (miner cursors, incremental checkpoints,
+  # long-running scan bookmarks) had NO statestore component in SDR CI — daprd
+  # 500s on the state API and the run fails, or the gap goes unexercised. The dev
+  # embedded statestore is `state.in-memory`, which is non-durable: state is lost
+  # across a worker restart / KEDA scale-to-zero, so an in-memory store would let
+  # a durability regression pass in CI. `state.sqlite` persists to a local file
+  # (no external dependency), matching the SDK dev/default statestore backend, so
+  # a connector's save_state → load_state round-trips durably in SDR e2e.
+  #
+  # Copied into ci-deploy/components/ by the action's "Override CI Dapr
+  # components" step (cp of every *.yaml here) — no additional wiring needed.
+  type: state.sqlite
+  ignoreErrors: true
+  metadata:
+    # File path; /tmp exists in the container, sqlite creates the DB on first use.
+    - name: connectionString
+      value: "/tmp/atlan-statestore.db"

--- a/application_sdk/testing/sdr/base.py
+++ b/application_sdk/testing/sdr/base.py
@@ -120,6 +120,22 @@ class BaseSDRIntegrationTest(BaseIntegrationTest):
     #: Empty string ("") keeps the legacy hand-written behaviour.
     manifest_path: ClassVar[str] = ""
 
+    #: Which manifest DAG node the workflow input is built from. Defaults to
+    #: ``"extract"`` (the crawler entrypoint). Set it to a non-crawler entrypoint
+    #: node — ``"miner"``, ``"lineage"``, ``"clean"`` — for a suite that exercises
+    #: that entrypoint, so the SDR run is built from (and agent-routed through)
+    #: ``dag.<manifest_node>.inputs.args`` instead of ``dag.extract``. These
+    #: entrypoints also resolve source credentials via ``agent_json`` (statically
+    #: checked by conformance P029); pointing the SDR harness at their node is what
+    #: lets that agent routing be exercised dynamically, not just linted.
+    #:
+    #: This is the manifest DAG node KEY — distinct from :pyattr:`workflow_type`
+    #: (the SDK entrypoint name sent in the start body) and from the manifest's
+    #: sibling ``inputs.workflow_type`` (the AE workflow-type slug); a
+    #: multi-entrypoint SQL app whose variants (e.g. ``ecc``/``s4``) still crawl
+    #: through the single ``dag.extract`` node keeps the default.
+    manifest_node: ClassVar[str] = "extract"
+
     #: When True, a workflow scenario that runs to completion must have written
     #: NON-EMPTY extracted output at ``extracted_output_base_path`` — catching the
     #: "COMPLETED with status success but zero assets" silent SDR failure (and,
@@ -184,12 +200,14 @@ class BaseSDRIntegrationTest(BaseIntegrationTest):
                 args["workflow_type"] = self.workflow_type
         return args
 
-    def _manifest_extract_inputs(self) -> dict[str, Any]:
-        """Load the connector's manifest and return its extract node's ``args``.
+    def _manifest_node_inputs(self, node: str = "extract") -> dict[str, Any]:
+        """Load the connector's manifest and return the ``args`` of its *node*
+        DAG node (``"extract"`` by default; ``"miner"`` / ``"lineage"`` / … for a
+        non-crawler entrypoint — see :pyattr:`manifest_node`).
 
-        Raises if the manifest is missing or has no ``dag.extract.inputs.args``
-        — a manifest-driven SDR test with no usable extract node is a config
-        error, not something to silently fall back on.
+        Raises if the manifest is missing or the selected node has no
+        ``dag.<node>.inputs.args`` — a manifest-driven SDR test with no usable
+        node is a config error, not something to silently fall back on.
 
         Note: the sibling ``inputs.workflow_type`` (the AE workflow-type slug) is
         deliberately NOT read — see :meth:`_workflow_args_from_manifest`.
@@ -203,18 +221,23 @@ class BaseSDRIntegrationTest(BaseIntegrationTest):
                 "connector's manifest.json, or '' to use agent_spec_template."
             )
         manifest = orjson.loads(path.read_bytes())
-        inputs = ((manifest.get("dag") or {}).get("extract") or {}).get("inputs") or {}
+        dag = manifest.get("dag") or {}
+        inputs = (dag.get(node) or {}).get("inputs") or {}
         if not isinstance(inputs.get("args"), dict):
             raise ValueError(
-                f"Manifest at {path} has no `dag.extract.inputs.args` object — "
-                "cannot derive the workflow input from it."
+                f"Manifest at {path} has no `dag.{node}.inputs.args` object — "
+                f"cannot derive the workflow input from it (available DAG nodes: "
+                f"{sorted(dag)})."
             )
         return inputs["args"]
 
     def _workflow_args_from_manifest(self, base_args: dict[str, Any]) -> dict[str, Any]:
         """Build workflow input from the manifest's extract args + substitutions.
 
-        Only ``dag.extract.inputs.args`` is substituted — exactly like the e2e /
+        Only the selected node's ``dag.<manifest_node>.inputs.args`` is
+        substituted (``manifest_node`` defaults to ``"extract"``; set it to a
+        non-crawler entrypoint node — ``"miner"`` / ``"lineage"`` / ``"clean"`` —
+        to build + agent-route that entrypoint's SDR run) — exactly like the e2e /
         full_dag walker. The base fills the *universal* SDR slots every
         SDR-capable connector has (``connection``, ``credential`` /
         ``credential-guid``, ``extraction-method``, ``agent-json``,
@@ -237,7 +260,7 @@ class BaseSDRIntegrationTest(BaseIntegrationTest):
         (agent mode) the end state matches; a direct-mode suite opted into this
         would diverge from the legacy local-vault provisioning path.
         """
-        extract_args = self._manifest_extract_inputs()
+        node_args = self._manifest_node_inputs(self.manifest_node)
         method = "agent" if self.agent_spec_template else "direct"
         # A manifest-driven suite with no agent_spec_template silently degrades to
         # direct mode (no agent spec injected) — warn so the misconfig isn't silent.
@@ -276,7 +299,7 @@ class BaseSDRIntegrationTest(BaseIntegrationTest):
                 continue
             subs[placeholder] = value
 
-        placeholders = _collect_placeholders(extract_args)
+        placeholders = _collect_placeholders(node_args)
         # A metadata key that matches no placeholder (e.g. hyphen-vs-underscore:
         # metadata ``include-filter`` against a manifest ``{{include_filter}}``)
         # would otherwise be silently ignored — surface it.
@@ -305,7 +328,7 @@ class BaseSDRIntegrationTest(BaseIntegrationTest):
                     placeholder,
                 )
                 subs[placeholder] = ""
-        wf_args = _apply_mustache_subs(extract_args, subs)
+        wf_args = _apply_mustache_subs(node_args, subs)
         # Carry credentials through for the start endpoint (agent mode resolves
         # via agent_json; direct mode + the client's credential provisioning use
         # these). The manifest-substituted args are authoritative for the run;

--- a/tests/integration/storage/test_binding_sdr_workflow_publish.py
+++ b/tests/integration/storage/test_binding_sdr_workflow_publish.py
@@ -41,6 +41,8 @@ from temporalio import activity, workflow
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
+from application_sdk.constants import WORKFLOW_OUTPUT_PATH_TEMPLATE
+from application_sdk.contracts.base import PublishInputMixin
 from application_sdk.contracts.types import FileReference, StorageTier
 from application_sdk.storage import ops
 from application_sdk.storage.binding import create_store_from_binding
@@ -273,6 +275,80 @@ async def test_workflow_output_persists_via_file_ref_locally(tmp_path):
     assert any(
         p.endswith(".sha256") for p in landed
     ), f"no sha256 sidecar persisted under {run_prefix}: {landed}"
+
+
+async def _read_records_from_store(store, prefix: str) -> list[dict]:
+    """Read every JSON record file under *prefix* the way the Publish app's
+    input reader does — list the prefix, fetch each object's bytes, flatten the
+    record lists. The ``.sha256`` integrity sidecars are skipped."""
+    records: list[dict] = []
+    async for batch in obstore.list(store, prefix=prefix):
+        for item in batch:
+            key = str(item["path"])
+            if not key.endswith(".json"):
+                continue
+            result = await obstore.get_async(store, key)
+            records.extend(json.loads(bytes(await result.bytes_async())))
+    return records
+
+
+@pytest.mark.integration
+async def test_publish_reads_back_exactly_what_extract_wrote(tmp_path):
+    """Two-app round trip, creds-free: EXTRACT writes asset records through the
+    SDK writer and persists them to the object store under its ``output_path``'s
+    ``transformed/`` prefix; the PUBLISH app then independently derives that same
+    prefix from the extract output — via ``PublishInputMixin.transformed_data_prefix``
+    (``WORKFLOW_OUTPUT_PATH_TEMPLATE`` + ``/transformed``) — and reads it back.
+    Asserts the records Publish reads equal what Extract wrote (count + content).
+
+    This pins the publish↔extract egress contract at the SDK level: a divergence
+    between the prefix Extract writes to and the prefix Publish derives (the class
+    of bug that lands 0 published assets) fails here, creds-free, on every SDK PR —
+    complementing the unit-contract test and the connector two-store e2e guards."""
+    # EXTRACT side: run the workflow, then persist its output to the store under
+    # the run's output_path + /transformed — the exact prefix Publish will read.
+    out_dir = await _run_extract_workflow(str(tmp_path / "extract"))
+    store = create_local_store(tmp_path / "objectstore")
+
+    output_path = WORKFLOW_OUTPUT_PATH_TEMPLATE.format(
+        application_name="sdr-generic",
+        workflow_id="wf-roundtrip",
+        run_id="run-roundtrip",
+    )
+    transformed_prefix = f"{output_path}/transformed"
+    ref = FileReference.from_local(out_dir, tier=StorageTier.RETAINED)
+    await persist_file_refs(store, {"output": ref}, output_path=transformed_prefix)
+
+    # PUBLISH side: derive the input prefix the way the Publish app does — from
+    # the extract output_path via PublishInputMixin — and confirm it resolves to
+    # exactly where Extract persisted the transformed records.
+    publish_input = PublishInputMixin(output_path=output_path)
+    assert (
+        publish_input.transformed_data_prefix == transformed_prefix
+    ), "Publish derived a different transformed prefix than Extract wrote to"
+
+    # What EXTRACT wrote (source of truth: the local writer output).
+    written: list[dict] = []
+    for name in os.listdir(out_dir):
+        if name.endswith(".json"):
+            with open(os.path.join(out_dir, name)) as fh:
+                written.extend(json.load(fh))
+
+    # What PUBLISH reads (from the store at the derived prefix).
+    read_back = await _read_records_from_store(
+        store, publish_input.transformed_data_prefix
+    )
+
+    # COUNT — every extracted record is visible to Publish.
+    assert len(read_back) == _N_RECORDS, (
+        f"Publish read {len(read_back)} records at "
+        f"{publish_input.transformed_data_prefix}, expected {_N_RECORDS}"
+    )
+    assert len(read_back) == len(written)
+    # CONTENT — Publish reads exactly the records Extract wrote (order-independent).
+    assert sorted(read_back, key=lambda r: r["qualifiedName"]) == sorted(
+        written, key=lambda r: r["qualifiedName"]
+    ), "records Publish read back differ from what Extract wrote"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/infrastructure/test_statestore_durability.py
+++ b/tests/unit/infrastructure/test_statestore_durability.py
@@ -1,0 +1,166 @@
+"""Durability guard for the SDR statestore (DISTR-849, gap #11).
+
+The SDR e2e component set historically shipped only eventstore / objectstore /
+secretstore — no ``statestore`` — and the dev embedded statestore is
+``state.in-memory`` (non-durable: a connector's ``save_state`` is lost across a
+worker restart / KEDA scale-to-zero). The SDR e2e set now ships a durable
+``state.sqlite`` statestore component so a connector that uses
+``save_state`` / ``load_state`` is exercised in SDR CI against a durable backend.
+
+This module pins the durability CONTRACT that component provides, driving the
+production ``AppContext.save_state`` / ``load_state`` → ``DaprStateStore`` code
+path: a value written through the state store survives a FRESH store instance
+rebound to the same on-disk backend (the simulated restart / scale-to-zero) —
+the property ``state.in-memory`` lacks (asserted by the contrast test).
+
+A SQLite file stands in for Dapr's ``state.sqlite`` backend (the same durable
+medium the shipped component uses) so the test is creds-free and needs no live
+daprd; the live component itself is exercised end-to-end by the SDR e2e wiring.
+The static test at the bottom guards the shipped component against regressing
+back to ``state.in-memory`` or being dropped.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from application_sdk.app.context import AppContext
+from application_sdk.infrastructure._dapr.client import DaprStateStore
+
+# Repo root: tests/unit/infrastructure/<this file> → parents[3].
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SDR_STATESTORE_COMPONENT = (
+    _REPO_ROOT / ".github/actions/sdr-e2e/components/statestore.yaml"
+)
+
+
+class _SqliteDaprClient:
+    """Minimal ``AsyncDaprClient`` stand-in whose state API persists to a SQLite
+    file — mirroring Dapr's ``state.sqlite`` durable backend. Only the three
+    methods :class:`DaprStateStore` calls are implemented. Every instance rebinds
+    to the same file, so a fresh instance sees state written by a prior one — the
+    durability the shipped SDR statestore component provides."""
+
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+        with sqlite3.connect(self._db_path) as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS state "
+                "(store TEXT, key TEXT, value TEXT, PRIMARY KEY (store, key))"
+            )
+
+    async def save_state(self, store_name: str, key: str, value: Any) -> None:
+        with sqlite3.connect(self._db_path) as conn:
+            conn.execute(
+                "INSERT INTO state (store, key, value) VALUES (?, ?, ?) "
+                "ON CONFLICT(store, key) DO UPDATE SET value = excluded.value",
+                (store_name, key, json.dumps(value)),
+            )
+
+    async def get_state(self, store_name: str, key: str) -> bytes | None:
+        with sqlite3.connect(self._db_path) as conn:
+            row = conn.execute(
+                "SELECT value FROM state WHERE store = ? AND key = ?",
+                (store_name, key),
+            ).fetchone()
+        return row[0].encode() if row else None
+
+    async def delete_state(self, store_name: str, key: str) -> None:
+        with sqlite3.connect(self._db_path) as conn:
+            conn.execute(
+                "DELETE FROM state WHERE store = ? AND key = ?", (store_name, key)
+            )
+
+
+class _InMemoryDaprClient:
+    """Non-durable ``AsyncDaprClient`` stand-in — mirrors ``state.in-memory``:
+    state lives only in this instance and is gone once it is discarded."""
+
+    def __init__(self) -> None:
+        self._data: dict[tuple[str, str], str] = {}
+
+    async def save_state(self, store_name: str, key: str, value: Any) -> None:
+        self._data[(store_name, key)] = json.dumps(value)
+
+    async def get_state(self, store_name: str, key: str) -> bytes | None:
+        raw = self._data.get((store_name, key))
+        return raw.encode() if raw is not None else None
+
+    async def delete_state(self, store_name: str, key: str) -> None:
+        self._data.pop((store_name, key), None)
+
+
+def _ctx(state_store: DaprStateStore) -> AppContext:
+    """An AppContext wired to *state_store*, with a fixed app/run so the
+    namespaced key (``app:run:key``) is stable across instances."""
+    return AppContext(
+        app_name="miner-app",
+        app_version="1",
+        run_id="run-1",
+        _state_store=state_store,
+    )
+
+
+class TestStateStoreDurability:
+    async def test_save_state_load_state_round_trips(self, tmp_path) -> None:
+        """AppContext.save_state → load_state round-trips through the production
+        DaprStateStore against a durable (sqlite) backend."""
+        client = _SqliteDaprClient(str(tmp_path / "statestore.db"))
+        ctx = _ctx(DaprStateStore(client, store_name="statestore"))
+
+        await ctx.save_state("cursor", {"page": 7, "seen": ["a", "b"]})
+        assert await ctx.load_state("cursor") == {"page": 7, "seen": ["a", "b"]}
+
+    async def test_state_survives_a_fresh_store_instance(self, tmp_path) -> None:
+        """The durability property: state written by one store instance is still
+        readable by a FRESH DaprStateStore + client bound to the same on-disk
+        backend — i.e. it survives a worker restart / KEDA scale-to-zero. This is
+        exactly what ``state.in-memory`` cannot do (see the contrast test)."""
+        db_path = str(tmp_path / "statestore.db")
+
+        # Instance #1 writes, then goes away (simulated restart).
+        writer = _ctx(
+            DaprStateStore(_SqliteDaprClient(db_path), store_name="statestore")
+        )
+        await writer.save_state("cursor", {"page": 42})
+
+        # Instance #2 is brand new but bound to the same durable backend.
+        reader = _ctx(
+            DaprStateStore(_SqliteDaprClient(db_path), store_name="statestore")
+        )
+        assert await reader.load_state("cursor") == {"page": 42}
+
+    async def test_in_memory_backend_loses_state_across_restart(self) -> None:
+        """Contrast: with a non-durable (in-memory) backend, a fresh store
+        instance has NONE of the prior instance's state — the failure mode the
+        durable ``state.sqlite`` SDR component is there to prevent."""
+        writer = _ctx(DaprStateStore(_InMemoryDaprClient(), store_name="statestore"))
+        await writer.save_state("cursor", {"page": 42})
+
+        reader = _ctx(DaprStateStore(_InMemoryDaprClient(), store_name="statestore"))
+        assert await reader.load_state("cursor") is None
+
+
+class TestSdrStatestoreComponent:
+    def test_component_shipped_and_durable(self) -> None:
+        """The SDR e2e component set ships a ``statestore`` component and it is a
+        DURABLE backend (``state.sqlite``), not ``state.in-memory`` — guards
+        against dropping it or regressing it back to non-durable."""
+        assert (
+            _SDR_STATESTORE_COMPONENT.is_file()
+        ), f"SDR statestore component missing at {_SDR_STATESTORE_COMPONENT}"
+        assert "name: statestore" in _SDR_STATESTORE_COMPONENT.read_text()
+        # Match the component's ``type:`` spec value, not a bare substring — the
+        # explanatory comment mentions ``state.in-memory`` on purpose.
+        types = {
+            line.split(":", 1)[1].strip()
+            for line in _SDR_STATESTORE_COMPONENT.read_text().splitlines()
+            if line.strip().startswith("type:")
+        }
+        assert types == {"state.sqlite"}, (
+            "SDR statestore must declare a durable `type: state.sqlite` "
+            f"(not state.in-memory); found {types}"
+        )

--- a/tests/unit/testing/sdr/test_base.py
+++ b/tests/unit/testing/sdr/test_base.py
@@ -331,7 +331,7 @@ def test_manifest_without_extract_args_raises(
 ) -> None:
     """A manifest whose extract node has no ``args`` object raises ValueError
     (rather than silently deriving an empty input). Pins the second raise branch
-    of ``_manifest_extract_inputs`` (the first, FileNotFoundError, is covered above).
+    of ``_manifest_node_inputs`` (the first, FileNotFoundError, is covered above).
     """
     manifest = {
         "execution_mode": "automation-engine",
@@ -347,6 +347,100 @@ def test_manifest_without_extract_args_raises(
 
     with pytest.raises(ValueError, match="dag.extract.inputs.args"):
         _NoArgsManifestSuite()._build_scenario_args(workflow_scenario)
+
+
+# ---------------------------------------------------------------------------
+# Non-crawler entrypoint routing — build the SDR run from a non-extract DAG
+# node (miner / lineage / clean) so those agent-credentialed entrypoints are
+# routed dynamically in SDR, not just checked statically (conformance P029).
+# ---------------------------------------------------------------------------
+
+
+def _write_manifest_with_nodes(tmp_path, nodes: dict[str, dict[str, Any]]) -> str:
+    """Write a manifest whose ``dag`` has one node per ``nodes`` entry (name → args)."""
+    manifest = {
+        "execution_mode": "automation-engine",
+        "dag": {name: {"inputs": {"args": args}} for name, args in nodes.items()},
+    }
+    path = tmp_path / "manifest.json"
+    path.write_bytes(orjson.dumps(manifest))
+    return str(path)
+
+
+# A non-crawler (miner) entrypoint's args: it needs source creds via agent_json
+# too, and carries a distinctive, non-placeholder key so a test can tell the
+# miner node's args apart from the extract node's.
+_MINER_ARGS: dict[str, Any] = {
+    "connection": "{{connection}}",
+    "extraction_method": "{{extraction-method}}",
+    "agent_json": "{{agent-json}}",
+    "miner_only": "miner-value",
+}
+
+
+def test_manifest_node_selects_non_crawler_node(
+    tmp_path, workflow_scenario: Scenario
+) -> None:
+    """With ``manifest_node`` set to a non-extract node, the workflow input is
+    built from THAT node's args — and the entrypoint still gets source-cred agent
+    routing (the P029 concern), so miner/lineage runs are exercised dynamically."""
+
+    class _MinerSuite(BaseSDRIntegrationTest):
+        manifest_path = _write_manifest_with_nodes(
+            tmp_path,
+            {"extract": dict(_ARGS_WITH_AGENT_JSON), "miner": dict(_MINER_ARGS)},
+        )
+        manifest_node = "miner"
+        agent_spec_template = {"agent-name": "miner-agent", "secret-path": "creds"}
+        default_connection = {
+            "typeName": "Connection",
+            "attributes": {"qualifiedName": "default/x/1"},
+        }
+        scenarios = []
+
+    args = _MinerSuite()._build_scenario_args(workflow_scenario)
+    # Built from the MINER node, not extract.
+    assert args["miner_only"] == "miner-value"
+    assert "include_filter" not in args, "extract-only slot leaked into a miner run"
+    # The non-crawler entrypoint is agent-routed for its source credentials.
+    assert args["extraction_method"] == "agent"
+    assert args["agent_json"] == _MinerSuite.agent_spec_template
+    assert args["connection"] == _MinerSuite.default_connection
+
+
+def test_manifest_node_defaults_to_extract(
+    tmp_path, workflow_scenario: Scenario
+) -> None:
+    """Unset ``manifest_node`` still reads ``dag.extract`` even when other nodes
+    exist — the default is fully backward compatible."""
+
+    class _DefaultSuite(BaseSDRIntegrationTest):
+        manifest_path = _write_manifest_with_nodes(
+            tmp_path,
+            {"extract": dict(_ARGS_WITH_AGENT_JSON), "miner": dict(_MINER_ARGS)},
+        )
+        agent_spec_template = {"agent-name": "a", "secret-path": "p"}
+        scenarios = []
+
+    args = _DefaultSuite()._build_scenario_args(workflow_scenario)
+    assert "include_filter" in args  # extract node's slot present
+    assert "miner_only" not in args  # miner node's slot NOT used
+
+
+def test_manifest_node_missing_raises(tmp_path, workflow_scenario: Scenario) -> None:
+    """Selecting a node the manifest doesn't declare raises a diagnostic
+    ValueError naming the missing node (not a silent empty input)."""
+
+    class _NoLineageSuite(BaseSDRIntegrationTest):
+        manifest_path = _write_manifest_with_nodes(
+            tmp_path, {"extract": dict(_ARGS_WITH_AGENT_JSON)}
+        )
+        manifest_node = "lineage"
+        agent_spec_template = {"agent-name": "a", "secret-path": "p"}
+        scenarios = []
+
+    with pytest.raises(ValueError, match=r"dag\.lineage\.inputs\.args"):
+        _NoLineageSuite()._build_scenario_args(workflow_scenario)
 
 
 def test_execute_scenario_polls_workflow_completion(


### PR DESCRIPTION
Stacked on #2552 (SDR harness + two-store CI action) — **base branch is `adityachoudhury/sdr-harness-output-floor`**, so this diff shows only the new work and merges after #2552.

Three moderate SDR-readiness gaps from DISTR-849. All additive; no changes to the two-store block, the SDR guard step, `two-store/sdr_asset_guards.py`, or the `_assert_*`/`_execute_scenario`/`_sdr_flag`/`require_*` code.

### Gap #8 — live two-app publish↔extract round trip
There was no SDK-level test that PUBLISH reads exactly what EXTRACT wrote across the egress path (only a unit-contract test + connector e2e). Added a creds-free integration test to `tests/integration/storage/test_binding_sdr_workflow_publish.py`:
- EXTRACT runs the workflow → SDK `RollingFileWriter` → `persist_file_refs` into the object store under `output_path/transformed`.
- PUBLISH independently derives that same prefix from the extract output via `PublishInputMixin.transformed_data_prefix` (`WORKFLOW_OUTPUT_PATH_TEMPLATE` + `/transformed`) and reads it back.
- Asserts the derived prefix matches, and the records read back equal what extract wrote (**count + content**), against a `LocalStore`.

A prefix divergence between what extract writes and what publish derives (the class of bug that publishes 0 assets) now fails creds-free on every SDK PR.

### Gap #11 — durable Dapr statestore in SDR
The SDR e2e component set (`.github/actions/sdr-e2e/components/`) shipped only eventstore/objectstore/secretstore — no `statestore` — and the dev default is `state.in-memory` (non-durable under KEDA scale-to-zero). Added:
- `components/statestore.yaml` — a durable `state.sqlite` statestore. Wiring is automatic: the action's existing "Override CI Dapr components" step `cp`s every `*.yaml` here into `ci-deploy/components/`, so a connector using `save_state`/`load_state` is now exercised in SDR CI against a durable backend.
- `tests/unit/infrastructure/test_statestore_durability.py` — drives the production `AppContext.save_state`/`load_state` → `DaprStateStore` and asserts save→load round-trips **and survives a fresh store instance rebound to the same on-disk backend** (the property `state.in-memory` lacks — asserted by a contrast test). SQLite stands in for Dapr's `state.sqlite`; the live component is exercised by the e2e wiring. A static test guards the shipped component against regressing to `state.in-memory` or being dropped.

### Gap #10 — non-crawler entrypoint agent routing
`_workflow_args_from_manifest` hardcoded the `dag.extract` node, so miner/lineage/clean entrypoints (which resolve source creds via `agent_json`, statically checked by conformance P029) were never routed dynamically in SDR. Added a `manifest_node` ClassVar (default `"extract"`, fully backward compatible) and generalized the manifest reader (`_manifest_extract_inputs` → `_manifest_node_inputs(node)`) so a suite can build + agent-route a non-extract node's args. Confined to that helper + `_workflow_args_from_manifest` + tests. Chose an explicit node selector over overloading `workflow_type` (which stays the start-body entrypoint slug; overloading it would break the saperp ecc/s4 multi-entrypoint pattern that still crawls through the single `dag.extract` node).

### Tests
- `tests/unit/testing/sdr/test_base.py` — 40 passed (+3 for Gap #10: miner-node selection, default-to-extract, missing-node raises).
- `tests/unit/infrastructure/test_statestore_durability.py` — 4 passed.
- `tests/integration/storage/test_binding_sdr_workflow_publish.py` — 3 passed (incl. new round-trip; creds-free `integration` marker).
- `uvx ruff@0.6.4 format` + `check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
