### PR TITLE
fix(conformance): include S-series (security) in default remediation scope

### DIFF
--- a/.claude/skills/remediate/SKILL.md
+++ b/.claude/skills/remediate/SKILL.md
@@ -15,23 +15,25 @@ description: >
   with the OpenProse skill to use the full Reactor-ready contract semantics; or
   invoke the program directly via the instructions below.
 
-argument-hint: "[--area error-handling|deprecation|dependency|prescriptions|optimizations|dockerfile|tests|logging|ci|contract-toolkit] [--strict] [path]"
+argument-hint: "[--area error-handling|deprecation|dependency|prescriptions|optimizations|dockerfile|tests|logging|ci|contract-toolkit|security] [--strict] [path]"
 
 inputs:
   - name: area
     description: >
       Comma-separated list of areas to remediate.  Defaults to every area the
       top-level program enables (error-handling, deprecation, dependency,
-      prescriptions, optimizations, dockerfile, tests, logging; ci is
+      prescriptions, optimizations, dockerfile, tests, logging, security; ci is
       partially remediated — C002 and C003's absent-file case are fixed
       mechanically via `bootstrap`; C001 is mechanically pinned
       (SHA-resolve + repin) but always escalated to residue for mandatory
       human sign-off — assisted, not autonomous, remediation; C003's
       missing-entry case and drifted `tests.yaml`/
-      `renovate.json` still route to residue with no fix attempted).
+      `renovate.json` still route to residue with no fix attempted; security
+      is suggest-only — every S-series finding is routed to residue with a
+      drafted fix, never auto-applied).
       Example: --area deprecation
     required: false
-    default: "error-handling,deprecation,dependency,prescriptions,optimizations,dockerfile,tests,logging,ci,contract-toolkit"
+    default: "error-handling,deprecation,dependency,prescriptions,optimizations,dockerfile,tests,logging,ci,contract-toolkit,security"
   - name: strict
     description: >
       When present, also remediates WARNING-tier findings.  Each WARNING is
@@ -149,6 +151,7 @@ dispatches each finding to its area prescription.
 | logging | L | ✅ Implemented | Mechanical (L004, L007, L015, L017, L020) auto-fixed; judgment (L001, L002, L005, others) modelled + routed to residue |
 | ci | C | ✅ Partial | C002 (managed-file drift) and C003's absent-`.gitignore` case both mechanical via the same `bootstrap` re-sync, invoked directly for either finding. C001 (unpinned action) mechanical SHA-resolve + repin, always escalated to residue for sign-off (external lookup). C003 missing-entry and drifted `tests.yaml`/`renovate.json` → residue |
 | contract-toolkit | K | ✅ Strict-only | K001/K002 guided migration to App.pkl; verified by pkl-eval gate |
+| security | S | ✅ Suggest-only | S001/S002 (hardcoded credential / raw env access) drafted as proposed fixes routed to residue for mandatory human sign-off — never auto-applied, since no orthogonal gate can confirm a secret-relocation fix resolves the same credential |
 
 To add a new area prescription: author `<programs-dir>/areas/<name>.prose.md`
 and add a dispatch branch to `<programs-dir>/functions/remediate-finding.prose.md`.
@@ -176,7 +179,7 @@ so app-only series no-op on the SDK):
 ```
 let before = call detect-violations
   scope: .
-  series: E,L,C,P,O,D,B,I,T,K
+  series: E,L,C,P,O,D,B,I,T,K,S
   target: if strict then "failing+warning" else "failing"
   path_prefix: <path argument, if any>
 ```
@@ -198,8 +201,8 @@ Execution order (from `conformance-remediation.prose.md`):
 
 1. Run every area responsibility in parallel (error-handling, deprecation,
    dependency, prescriptions, optimizations, dockerfile, tests, logging, ci,
-   contract-toolkit) — the top-level contract fans out to all of them; do not
-   hardcode a subset.
+   contract-toolkit, security) — the top-level contract fans out to all of
+   them; do not hardcode a subset.
 
 2. Each area responsibility calls the `detect-fix-recheck` pattern
    (`patterns/detect-fix-recheck.prose.md`), which loops:
@@ -221,7 +224,7 @@ Call `detect-violations` again and copy the result to `after.sarif`:
 ```
 let after = call detect-violations
   scope: .
-  series: E,L,C,P,O,D,B,I,T,K
+  series: E,L,C,P,O,D,B,I,T,K,S
   target: if strict then "failing+warning" else "failing"
   path_prefix: <path argument, if any>
 ```

--- a/.claude/skills/remediate/SKILL.md
+++ b/.claude/skills/remediate/SKILL.md
@@ -22,12 +22,12 @@ inputs:
     description: >
       Comma-separated list of areas to remediate.  Defaults to every area the
       top-level program enables (error-handling, deprecation, dependency,
-      prescriptions, optimizations, dockerfile, tests, logging, security; ci is
-      partially remediated — C002 and C003's absent-file case are fixed
-      mechanically via `bootstrap`; C001 is mechanically pinned
-      (SHA-resolve + repin) but always escalated to residue for mandatory
-      human sign-off — assisted, not autonomous, remediation; C003's
-      missing-entry case and drifted `tests.yaml`/
+      prescriptions, optimizations, dockerfile, tests, logging,
+      contract-toolkit, security; ci is partially remediated — C002 and
+      C003's absent-file case are fixed mechanically via `bootstrap`; C001 is
+      mechanically pinned (SHA-resolve + repin) but always escalated to
+      residue for mandatory human sign-off — assisted, not autonomous,
+      remediation; C003's missing-entry case and drifted `tests.yaml`/
       `renovate.json` still route to residue with no fix attempted; security
       is suggest-only — every S-series finding is routed to residue with a
       drafted fix, never auto-applied).

--- a/packages/conformance/conformance/programs/conformance-remediation.prose.md
+++ b/packages/conformance/conformance/programs/conformance-remediation.prose.md
@@ -30,7 +30,7 @@ An aggregate of violation counts across all enabled areas:
 Postcondition (deterministic validator — never render-attested):
 
 **Default mode:** `atlan-application-sdk-conformance detect --repo . --series
-E,L,C,P,O,D,B,I,T,K` exits 0 — zero unsuppressed FAILING results across all enabled areas.
+E,L,C,P,O,D,B,I,T,K,S` exits 0 — zero unsuppressed FAILING results across all enabled areas.
 
 **Strict mode** (`--strict`): additionally, the `atlan/summary.warning` count
 in the SARIF output is 0 — zero unsuppressed WARNING results.  Every WARNING

--- a/packages/conformance/conformance/programs/conformance-remediation.prose.md
+++ b/packages/conformance/conformance/programs/conformance-remediation.prose.md
@@ -29,8 +29,7 @@ An aggregate of violation counts across all enabled areas:
 
 Postcondition (deterministic validator — never render-attested):
 
-**Default mode:** `atlan-application-sdk-conformance detect --repo . --series
-E,L,C,P,O,D,B,I,T,K,S` exits 0 — zero unsuppressed FAILING results across all enabled areas.
+**Default mode:** `atlan-application-sdk-conformance detect --repo . --series E,L,C,P,O,D,B,I,T,K,S` exits 0 — zero unsuppressed FAILING results across all enabled areas.
 
 **Strict mode** (`--strict`): additionally, the `atlan/summary.warning` count
 in the SARIF output is 0 — zero unsuppressed WARNING results.  Every WARNING

--- a/packages/conformance/conformance/programs/functions/detect-violations.prose.md
+++ b/packages/conformance/conformance/programs/functions/detect-violations.prose.md
@@ -17,7 +17,7 @@ description: >
   on result URIs after the runner produces the full-repo report.  The runner has
   no `--include` flag; filtering is always done on the parsed output.  When
   omitted, all results are returned.
-- `series` (string, default `"E,L,C,P,O,D,B,I,T,K"`) — comma-separated list of
+- `series` (string, default `"E,L,C,P,O,D,B,I,T,K,S"`) — comma-separated list of
   rule-series letters to run, e.g. `"E"` for error-handling only or `"E,L"` for
   error-handling and logging.
 - `target` (string, default `"failing"`) — which dispositions to return.
@@ -32,8 +32,8 @@ description: >
   - `rule_id` — e.g. `"E002"`.
   - `area` — series letter mapped to area name: `E` → `error-handling`,
     `L` → `logging`, `C` → `ci`, `P` → `prescriptions`, `O` → `optimizations`,
-    `D` → `dependency`, `B` → `deprecation`, `K` → `contract-toolkit`,
-    `S` → `security`.
+    `D` → `dependency`, `B` → `deprecation`, `I` → `dockerfile`, `T` → `tests`,
+    `K` → `contract-toolkit`, `S` → `security`.
   - `file` — repo-relative path.
   - `line`, `column` — location.
   - `fingerprint` — value of `partial_fingerprints["atlanConformance/v1"]`;
@@ -100,7 +100,7 @@ comparing so that `"./application_sdk/foo.py"` matches `"application_sdk"`).
 Tag each result's area by reading the first letter of `result.rule_id`:
 `E` → `error-handling`, `L` → `logging`, `C` → `ci`, `P` → `prescriptions`,
 `O` → `optimizations`, `D` → `dependency`, `B` → `deprecation`,
-`K` → `contract-toolkit`, `S` → `security`.
+`I` → `dockerfile`, `T` → `tests`, `K` → `contract-toolkit`, `S` → `security`.
 
 Extract `atlan/mechanism`, `atlan/autofixable`, `atlan/orthogonalGate`,
 `atlan/forcesExternalInfluence` (default `false` if absent) from


### PR DESCRIPTION
## Summary
- `/remediate` and `/remediate --strict` silently skipped S-series (security) findings, even though the security area was already fully wired into the remediation dispatch table and already enforced as its own matrix leg in CI — the default series/area lists in the OpenProse docs and the repo's SKILL.md just never got `S` added when the security area shipped.
- `packages/conformance/conformance/programs/conformance-remediation.prose.md`: add `S` to the default-mode series
- `packages/conformance/conformance/programs/functions/detect-violations.prose.md`: add `S` to the default `series` param; also fill in the letter→area mapping tables, which were separately missing `I`→dockerfile and `T`→tests
- `.claude/skills/remediate/SKILL.md`: add `security` to `argument-hint`, the area default/description, both `detect-violations` series calls, the execution-order list, and the area-status table

## Test plan
- [x] `uv run pre-commit run --all-files` — clean
- [x] `uv run python -m pytest tests/unit -x -q` — 5429 passed, 9 skipped
- [x] Manually swept the repo (prose programs, CI workflows, doc generators, registry-consistency assertion) for any other place enumerating "all series" — none found; CI's `conformance-reusable.yaml` already runs the S-series matrix leg