### PR TITLE
feat(egress): application-layer gateway auth on OAuth + event + Temporal egress

### DIFF
--- a/application_sdk/clients/gateway_auth.py
+++ b/application_sdk/clients/gateway_auth.py
@@ -1,0 +1,67 @@
+"""Application-layer gateway auth headers.
+
+Some deployments route all Atlan-bound egress through a customer-managed API
+gateway that authenticates *every request itself* (custom headers, Basic, or a
+signed JWT) rather than accepting standard HTTP forward-proxy env vars. This
+module surfaces those headers from a single env var (``ATLAN_GATEWAY_AUTH_HEADERS``)
+so they can be injected on the HTTP egress paths that can carry an
+application-layer header:
+
+* the OAuth token exchange (``credentials/oauth.py``), and
+* the event binding (``execution/_temporal/interceptors/events.py``).
+
+Egress whose wire auth cannot carry an extra header is intentionally **not**
+covered here:
+
+* object-store upload — SigV4 signs the request; an added/rewritten header
+  breaks the signature. Route via TCP/TLS pass-through (obstore ``proxy_url``).
+* Temporal — gRPC/TLS; use mTLS at the edge (Temporal ``TLSConfig`` client cert
+  / ``HttpConnectProxyConfig``).
+
+Gated: returns ``{}`` unless ``ATLAN_GATEWAY_AUTH_HEADERS`` is set to a JSON
+object, so non-gateway deployments are completely unaffected.
+"""
+
+from __future__ import annotations
+
+import json
+
+from application_sdk.observability.logger_adaptor import get_logger
+
+logger = get_logger(__name__)
+
+
+def gateway_auth_headers() -> dict[str, str]:
+    """Return the configured application-layer gateway auth headers.
+
+    Reads ``ATLAN_GATEWAY_AUTH_HEADERS`` (a JSON object of ``{header: value}``)
+    at call time. Returns an empty dict when unset, empty, not valid JSON, or
+    not a JSON object — a misconfiguration never raises and never partially
+    injects; it degrades to "no gateway headers" and logs a warning.
+
+    Values are stringified. Header names are used verbatim.
+    """
+    # Read via the module attribute (not a cached import) so the value tracks
+    # the process env and stays overridable in tests.
+    from application_sdk import (  # noqa: PLC0415 — avoid import cycle at module load
+        constants,
+    )
+
+    raw = constants.GATEWAY_AUTH_HEADERS
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning(
+            "ATLAN_GATEWAY_AUTH_HEADERS is not valid JSON — ignoring; no gateway "
+            "auth headers will be injected"
+        )
+        return {}
+    if not isinstance(parsed, dict):
+        logger.warning(
+            "ATLAN_GATEWAY_AUTH_HEADERS must be a JSON object of {header: value} "
+            "— ignoring"
+        )
+        return {}
+    return {str(k): str(v) for k, v in parsed.items()}

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -351,6 +351,18 @@ _HTTP_POOL_TIMEOUT_SECONDS = 30.0
 #: Whether to enable Atlan storage upload
 ENABLE_ATLAN_UPLOAD = os.getenv("ENABLE_ATLAN_UPLOAD", "false").lower() == "true"
 
+#: Application-layer gateway auth headers, as a JSON object of ``{header: value}``.
+#: Some deployments route Atlan-bound egress through a customer-managed API
+#: gateway that authenticates every request itself (custom headers, Basic, or a
+#: signed JWT) instead of accepting standard HTTP forward-proxy env vars. These
+#: headers are injected on the HTTP egress paths that can carry an application-
+#: layer header — the OAuth token exchange and the event binding. Empty (the
+#: default) means no injection, so non-gateway deployments are unaffected.
+#: Egress whose wire auth can't carry an extra header (object-store SigV4,
+#: Temporal gRPC) is out of scope here — it transits the gateway via TCP/TLS
+#: pass-through with mTLS at the edge (object-store ``proxy_url`` / Temporal mTLS).
+GATEWAY_AUTH_HEADERS = os.getenv("ATLAN_GATEWAY_AUTH_HEADERS", "")
+
 # Dual-write — BLDX-1464: when both stores are configured (SDR), App.upload writes
 # to the deployment (customer) store first, then to upstream (Atlan), at the same
 # run-scoped key.  See ADR-0014 §"App.upload() — dual-write when both stores are

--- a/application_sdk/credentials/oauth.py
+++ b/application_sdk/credentials/oauth.py
@@ -230,6 +230,9 @@ class OAuthTokenService:
         """
         import httpx  # deferred: matches existing lazy-import pattern for optional heavy deps  # noqa: PLC0415 — circular: credentials/__init__.py loads sibling modules
 
+        from application_sdk.clients.gateway_auth import (  # noqa: PLC0415 — circular: credentials/__init__.py loads sibling modules
+            gateway_auth_headers,
+        )
         from application_sdk.clients.ssl_utils import (  # noqa: PLC0415 — circular: credentials/__init__.py loads sibling modules
             get_ssl_context,
         )
@@ -253,7 +256,14 @@ class OAuthTokenService:
             async with httpx.AsyncClient(
                 timeout=30.0, verify=get_ssl_context()
             ) as http:
-                response = await http.post(self._base.token_url, data=data)
+                # Inject application-layer gateway auth headers when the
+                # deployment routes egress through an authenticating API gateway
+                # (no-op when ATLAN_GATEWAY_AUTH_HEADERS is unset).
+                response = await http.post(
+                    self._base.token_url,
+                    data=data,
+                    headers=gateway_auth_headers(),
+                )
                 response.raise_for_status()
                 body: dict = response.json()
         except httpx.HTTPStatusError as exc:

--- a/application_sdk/execution/_temporal/backend.py
+++ b/application_sdk/execution/_temporal/backend.py
@@ -639,6 +639,19 @@ async def create_temporal_client(
     if proxy_config is not None:
         kwargs["http_connect_proxy_config"] = proxy_config
 
+    # Carry application-layer gateway auth on the Temporal connection too, as
+    # gRPC metadata (the same headers injected on the HTTP egress paths), so a
+    # deployment that routes egress through an authenticating API gateway can
+    # authenticate the Temporal stream with the same credentials. gRPC metadata
+    # keys must be lowercase. No-op when ATLAN_GATEWAY_AUTH_HEADERS is unset.
+    from application_sdk.clients.gateway_auth import (  # noqa: PLC0415 — cold path: only at connect
+        gateway_auth_headers,
+    )
+
+    _gateway_md = {k.lower(): v for k, v in gateway_auth_headers().items()}
+    if _gateway_md:
+        kwargs["rpc_metadata"] = _gateway_md
+
     # Configure Temporal runtime (with or without Prometheus metrics)
     kwargs["runtime"] = _get_or_create_runtime(
         enable_prometheus=enable_prometheus,

--- a/application_sdk/execution/_temporal/interceptors/events.py
+++ b/application_sdk/execution/_temporal/interceptors/events.py
@@ -264,6 +264,18 @@ async def _publish_event_via_binding(event: Event) -> None:
             exc_info=True,
         )
 
+    # Inject application-layer gateway auth headers when the deployment routes
+    # egress through an authenticating API gateway (no-op when unset). Use
+    # setdefault so they never clobber the OAuth bearer / content-type already
+    # set above — the gateway auth for this path must be a non-Authorization
+    # header (the Authorization slot carries the Atlan bearer).
+    from application_sdk.clients.gateway_auth import (  # noqa: PLC0415 — cold path: only on event publish
+        gateway_auth_headers,
+    )
+
+    for _hdr, _val in gateway_auth_headers().items():
+        binding_metadata.setdefault(_hdr, _val)
+
     await infra.event_binding.invoke(
         operation="create",
         data=payload,

--- a/tests/unit/clients/test_gateway_auth.py
+++ b/tests/unit/clients/test_gateway_auth.py
@@ -1,0 +1,38 @@
+"""Unit tests for application_sdk.clients.gateway_auth.gateway_auth_headers."""
+
+import pytest
+
+from application_sdk.clients.gateway_auth import gateway_auth_headers
+
+
+def _set(monkeypatch, value):
+    monkeypatch.setattr("application_sdk.constants.GATEWAY_AUTH_HEADERS", value)
+
+
+def test_unset_returns_empty(monkeypatch):
+    _set(monkeypatch, "")
+    assert gateway_auth_headers() == {}
+
+
+def test_valid_json_object(monkeypatch):
+    _set(
+        monkeypatch,
+        '{"X-Client-Id": "abc", "X-Client-Secret": "def"}',
+    )
+    assert gateway_auth_headers() == {"X-Client-Id": "abc", "X-Client-Secret": "def"}
+
+
+def test_values_are_stringified(monkeypatch):
+    _set(monkeypatch, '{"X-Retry": 3, "X-Enabled": true}')
+    assert gateway_auth_headers() == {"X-Retry": "3", "X-Enabled": "True"}
+
+
+def test_invalid_json_returns_empty(monkeypatch):
+    _set(monkeypatch, "not-json{")
+    assert gateway_auth_headers() == {}
+
+
+@pytest.mark.parametrize("value", ['["a", "b"]', '"just-a-string"', "42"])
+def test_non_object_json_returns_empty(monkeypatch, value):
+    _set(monkeypatch, value)
+    assert gateway_auth_headers() == {}

--- a/tests/unit/execution/test_backend.py
+++ b/tests/unit/execution/test_backend.py
@@ -366,6 +366,40 @@ class TestCreateTemporalClient:
         assert connect.await_args.kwargs["api_key"] == "secret-token"
 
     @pytest.mark.asyncio
+    async def test_gateway_headers_passed_as_lowercased_rpc_metadata(self) -> None:
+        with (
+            mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(
+                backend_module.Client,
+                "connect",
+                new=mock.AsyncMock(return_value=mock.MagicMock()),
+            ) as connect,
+            mock.patch(
+                "application_sdk.constants.GATEWAY_AUTH_HEADERS",
+                '{"X-Client-Id": "abc", "X-Client-Secret": "def"}',
+            ),
+        ):
+            await create_temporal_client(connect_max_attempts=1)
+        assert connect.await_args.kwargs["rpc_metadata"] == {
+            "x-client-id": "abc",
+            "x-client-secret": "def",
+        }
+
+    @pytest.mark.asyncio
+    async def test_no_rpc_metadata_when_gateway_unset(self) -> None:
+        with (
+            mock.patch.object(backend_module, "_get_or_create_runtime"),
+            mock.patch.object(
+                backend_module.Client,
+                "connect",
+                new=mock.AsyncMock(return_value=mock.MagicMock()),
+            ) as connect,
+            mock.patch("application_sdk.constants.GATEWAY_AUTH_HEADERS", ""),
+        ):
+            await create_temporal_client(connect_max_attempts=1)
+        assert "rpc_metadata" not in connect.await_args.kwargs
+
+    @pytest.mark.asyncio
     async def test_tls_with_no_paths_uses_custom_ca_when_available(self) -> None:
         """Exercises inline imports of clients.ssl_utils and temporalio.service."""
         with (


### PR DESCRIPTION
## Context

Some deployments route **all** Atlan-bound egress through a customer-managed API gateway that authenticates *every request itself* (custom headers / Basic / signed JWT) and does **not** accept HTTP forward-proxy env vars. This adds the hook for every egress path that can carry an application-layer credential — HTTP **and** the Temporal gRPC stream — using one env var.

Fresh egress audit (v3.21.0):

| Egress | Transport | Carries an app-layer credential? | Covered here |
|---|---|---|---|
| OAuth token exchange | HTTPS | yes (request header) | ✅ |
| Event binding (trigger + poll) | HTTPS (Dapr `bindings.http`) | yes (non-Authorization header) | ✅ |
| **Temporal** | gRPC/TLS | yes (**gRPC metadata**) | ✅ (new) |
| Object-store upload | HTTPS, **SigV4** | no — added/rewritten header breaks the signature | ❌ presigned-URL upload or TCP/TLS pass-through (separate) |
| OTLP telemetry (optional) | gRPC/HTTP | yes | standard `OTEL_EXPORTER_OTLP_HEADERS` (no code) |

## Change

- `application_sdk/clients/gateway_auth.py::gateway_auth_headers()` — env-gated helper reading `ATLAN_GATEWAY_AUTH_HEADERS` (JSON `{header: value}`); returns `{}` when unset/malformed (warns, never raises).
- **OAuth** (`credentials/oauth.py`) — headers on the token POST.
- **Event binding** (`interceptors/events.py`) — merged via `setdefault` so it can't clobber the OAuth bearer / content-type (gateway header here must be non-Authorization).
- **Temporal** (`execution/_temporal/backend.py`) — same headers injected as **`rpc_metadata`** on `Client.connect`, lowercased per gRPC convention; coexists with `api_key` (the Authorization bearer).

## Blast radius

Additive and feature-flagged. `ATLAN_GATEWAY_AUTH_HEADERS` unset (default) → `{}` → all three call sites unchanged → every non-gateway deployment unaffected.

## Not in this PR (deliberately)

- **Object-store presigned-URL upload.** Client-side SigV4 can't carry an added header. The clean fix (mirror the customer's presigned-URL + dumb-PUT model) is a new subsystem — an Atlan files API client + an alternate upload path — and presigned-per-file scales poorly at connector file volumes. It needs its own design; TCP/TLS pass-through or PrivateLink may be the better answer. Not jammed in here.
- **Dependency:** the Temporal piece assumes the gateway can proxy long-lived HTTP/2 gRPC. If it can't, Temporal egress needs PrivateLink instead.

## Tests

`tests/unit/clients/test_gateway_auth.py` (7) + `tests/unit/execution/test_backend.py` (rpc_metadata set when configured / absent when unset). pre-commit (ruff, ruff-format, pyright, isort) clean.