### PR TITLE
ci(fix): SDK review VPN: probe mothership, not phoenix-ai, and fall back on portal

### DIFF
--- a/.github/actions/globalprotect-connect/action.yml
+++ b/.github/actions/globalprotect-connect/action.yml
@@ -4,14 +4,19 @@ author: "Atlan"
 
 inputs:
   portal-url:
-    description: "GlobalProtect portal URL"
-    required: true
+    description: "GlobalProtect portal URL. Empty falls back to https://vpn2.atlan.app."
+    required: false
+    default: ""
   username:
-    description: "GlobalProtect username"
+    description: "GlobalProtect username (org secret GLOBALPROTECT_USERNAME)"
     required: true
   password:
-    description: "GlobalProtect password"
+    description: "GlobalProtect password (org secret GLOBALPROTECT_PASSWORD)"
     required: true
+  mothership-url:
+    description: "Target service the tunnel must reach; the post-connect health probe hits ${mothership-url}/health. This is what the caller actually needs reachable, so probe it directly instead of an unrelated host."
+    required: false
+    default: "https://mothership.atlan.dev"
   max-attempts:
     description: "Maximum number of connection attempts"
     required: false
@@ -49,23 +54,35 @@ runs:
           sudo apt-get update
           sudo apt-get install -y openconnect
 
-          # Check required inputs
-          if [ -z "${{ inputs.portal-url }}" ]; then
-            echo "portal-url input not provided"
-            exit 1
-          fi
-
+          # Check required credentials. An empty username/password almost
+          # always means the org-level GLOBALPROTECT_* Actions secret is not
+          # granted to this repo (or was descoped) — a repo-settings problem,
+          # not a code one. Say so explicitly so the failure is actionable.
           if [ -z "${{ inputs.username }}" ]; then
-            echo "username input not provided"
+            echo "::error::GLOBALPROTECT_USERNAME is empty. The GlobalProtect VPN secret is not available to this repo — an org admin must grant this repo access to the org-level GLOBALPROTECT_USERNAME/GLOBALPROTECT_PASSWORD secrets (or set them at repo level). A workflow change cannot provision a secret."
             exit 1
           fi
-
           if [ -z "${{ inputs.password }}" ]; then
-            echo "password input not provided"
+            echo "::error::GLOBALPROTECT_PASSWORD is empty. See the GLOBALPROTECT_USERNAME error above — same root cause."
             exit 1
           fi
 
-          echo "Attempting OpenConnect to: ${{ inputs.portal-url }}"
+          # Portal: use the caller-supplied portal, else fall back to the
+          # canonical Atlan portal. A missing GLOBALPROTECT_PORTAL_URL var must
+          # not hard-fail the connect (this mirrors the mothership reviewer
+          # action, which hardcodes the same fallback).
+          PRIMARY="${{ inputs.portal-url }}"
+          [ -z "$PRIMARY" ] && PRIMARY="https://vpn2.atlan.app"
+          case "$PRIMARY" in https://*) ;; *) PRIMARY="https://$PRIMARY" ;; esac
+          FALLBACK="https://vpn2.atlan.app"
+
+          # Probe the service the tunnel actually has to reach. The previous
+          # implementation tested https://phoenix-ai.atlan.com, so a
+          # phoenix-ai outage failed the VPN step even when the tunnel to
+          # mothership was healthy — and, worse, a green phoenix-ai probe
+          # declared success without ever confirming mothership was reachable.
+          MOTHERSHIP_URL="${{ inputs.mothership-url }}"
+          [ -z "$MOTHERSHIP_URL" ] && MOTHERSHIP_URL="https://mothership.atlan.dev"
 
           # Unique per-run client hostname. GlobalProtect treats "same user +
           # same computer" as a session replacement, so without a distinct
@@ -76,18 +93,18 @@ runs:
           LOCAL_HOSTNAME=$(echo "$LOCAL_HOSTNAME" | tr -cd 'a-zA-Z0-9-' | cut -c1-63)
           echo "Using --local-hostname: ${LOCAL_HOSTNAME}"
 
-          # Connect with openconnect in the background.
+          # Connect to one portal, then verify the tunnel reaches mothership.
+          # Returns 0 only when ${MOTHERSHIP_URL}/health answers 200.
           #
           # >/tmp/openconnect.log 2>&1 is required: without it, the
           # daemonized openconnect process inherits the step's stdout/stderr
           # file descriptors and keeps them open for the lifetime of the VPN
           # session. GitHub's log streamer treats the step as "in progress"
           # until those FDs close, so the step badge in the UI never turns
-          # green even after the script exits and the next step starts
-          # running. Redirecting here detaches the daemon's stdio so the
-          # step closes cleanly. (stdin stays on the pipe so --passwd-on-stdin
-          # still reads the password; the pipe closes after echo and the
-          # daemon ends up with stdin at EOF, which is fine.)
+          # green even after the script exits. Redirecting detaches the
+          # daemon's stdio so the step closes cleanly. (stdin stays on the
+          # pipe so --passwd-on-stdin still reads the password; the pipe
+          # closes after echo and the daemon gets stdin at EOF, which is fine.)
           #
           # --verbose surfaces the GlobalProtect HTTP response detail — e.g. the
           # body behind an "Unexpected NNN result from server" auth rejection
@@ -97,42 +114,52 @@ runs:
           # response status/body, not request bodies. Do NOT escalate to -vvvv
           # or --dump-http-traffic — those dump full request bodies and the GP
           # credential POST would leak the password into the runner log.
-          echo "${{ inputs.password }}" | sudo openconnect \
-            --protocol=gp \
-            --user="${{ inputs.username }}" \
-            --passwd-on-stdin \
-            --local-hostname="${LOCAL_HOSTNAME}" \
-            --verbose \
-            --background \
-            "${{ inputs.portal-url }}" >/tmp/openconnect.log 2>&1 || {
-            echo "OpenConnect connection failed"
+          _connect() {
+            local portal="$1"
+            echo "🔌 Connecting to VPN portal: $portal"
+            sudo pkill openconnect 2>/dev/null || true
+            sleep 2
+            echo "${{ inputs.password }}" | sudo openconnect \
+              --protocol=gp \
+              --user="${{ inputs.username }}" \
+              --passwd-on-stdin \
+              --local-hostname="${LOCAL_HOSTNAME}" \
+              --verbose \
+              --background \
+              "$portal" >/tmp/openconnect.log 2>&1 || {
+              echo "OpenConnect connection to $portal failed"
+              cat /tmp/openconnect.log 2>/dev/null || true
+              return 1
+            }
+
+            # Wait for the tunnel + routes to establish.
+            sleep 10
+
+            # Probe the real target. --max-time 30 fails a black-holed route
+            # fast instead of burning the retry budget on one hung TCP connect.
+            local status
+            status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 \
+              "${MOTHERSHIP_URL}/health" || echo "000")
+            echo "  Probe: HTTP $status via $portal → ${MOTHERSHIP_URL}/health"
+            if [ "$status" = "200" ]; then
+              return 0
+            fi
+            # Tunnel may have come up yet be unusable (route blackhole, or a
+            # session displaced by a concurrent run). Dump the VPN log so the
+            # most common real failure mode is diagnosable.
             cat /tmp/openconnect.log 2>/dev/null || true
-            exit 1
+            return 1
           }
 
-          # Wait a moment for connection to establish
-          sleep 10
-
-          # Initial connectivity test
-          echo "Testing initial connectivity to Phoenix AI..."
-          # --max-time 60 ensures a black-holed route (e.g. broken VPN
-          # split-tunnel) fails fast instead of burning the full retry-action
-          # timeout_minutes budget on a single hung TCP connection. 60s is
-          # comfortably above any healthy response time but well below the
-          # 5-min per-attempt cap.
-          time curl -k -sS --max-time 60 https://phoenix-ai.atlan.com -o /dev/null
-
-          if [ $? -eq 0 ]; then
-            echo "Initial connectivity test successful"
-          else
-            echo "Initial connectivity test failed"
-            # Dump the openconnect log on this path too. openconnect may have
-            # exited 0 above (tunnel came up) yet the tunnel is unusable — a
-            # split-tunnel/route blackhole, or a session displaced by a
-            # concurrent run. Without this, the most common real failure mode
-            # logs nothing about the VPN itself.
-            cat /tmp/openconnect.log 2>/dev/null || true
+          if _connect "$PRIMARY"; then
+            echo "✅ VPN connected via primary ($PRIMARY)"
+          elif [ "$PRIMARY" = "$FALLBACK" ]; then
+            echo "❌ Primary VPN failed and equals fallback — no retry possible."
             exit 1
+          else
+            echo "⚠️ Primary ($PRIMARY) unreachable — trying fallback ($FALLBACK)"
+            _connect "$FALLBACK" || { echo "❌ Both VPN portals failed."; exit 1; }
+            echo "✅ VPN connected via fallback ($FALLBACK)"
           fi
 
           # Set output to indicate successful connection

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -293,6 +293,9 @@ jobs:
           portal-url: ${{ vars.GLOBALPROTECT_PORTAL_URL }}
           username: ${{ secrets.GLOBALPROTECT_USERNAME }}
           password: ${{ secrets.GLOBALPROTECT_PASSWORD }}
+          # Probe the actual dispatch target so the VPN step verifies the tunnel
+          # reaches mothership, not an unrelated host.
+          mothership-url: ${{ vars.MOTHERSHIP_URL }}
           max-attempts: '1'
 
       - name: Connect to VPN (attempt 2/3)
@@ -305,6 +308,9 @@ jobs:
           portal-url: ${{ vars.GLOBALPROTECT_PORTAL_URL }}
           username: ${{ secrets.GLOBALPROTECT_USERNAME }}
           password: ${{ secrets.GLOBALPROTECT_PASSWORD }}
+          # Probe the actual dispatch target so the VPN step verifies the tunnel
+          # reaches mothership, not an unrelated host.
+          mothership-url: ${{ vars.MOTHERSHIP_URL }}
           max-attempts: '1'
 
       - name: Connect to VPN (attempt 3/3)
@@ -317,6 +323,9 @@ jobs:
           portal-url: ${{ vars.GLOBALPROTECT_PORTAL_URL }}
           username: ${{ secrets.GLOBALPROTECT_USERNAME }}
           password: ${{ secrets.GLOBALPROTECT_PASSWORD }}
+          # Probe the actual dispatch target so the VPN step verifies the tunnel
+          # reaches mothership, not an unrelated host.
+          mothership-url: ${{ vars.MOTHERSHIP_URL }}
           max-attempts: '1'
 
       # If all three VPN attempts failed, post a comment on the PR so the


### PR DESCRIPTION
## Problem

SDK Review (mothership) has been failing at the VPN step. Digging into the last week of runs surfaced **three distinct causes** stacked under one "VPN broken" symptom:

| window | cause | fixable in code? |
|--------|-------|------------------|
| Jul 1-3 | `Stream ended without a 'complete' event` (mothership-side SSE drop) | no — separate mothership issue |
| Jul 3-6 | `getconfig.esp HTTP 512` — org-wide GlobalProtect portal outage | no — infra, since self-resolved |
| **Jul 7-onward** | **`username input not provided`** → `GLOBALPROTECT_USERNAME` resolves empty | **no — repo secret grant (see below)** |

This PR fixes the **code-level** weaknesses in the VPN action that made these harder to diagnose and less resilient. It does **not**, on its own, restore the reviewer — see the required action.

## ⚠️ Required action this PR cannot do: grant the VPN secret

`atlanhq/application-sdk` has **no** `GLOBALPROTECT_USERNAME` / `GLOBALPROTECT_PASSWORD` at repo level (only `HARNESS_TOKEN`), and the org-level secret is no longer resolving here — the workflow succeeded 33× before Jul 3, so access was lost/rotated around Jul 6-7. A workflow change **cannot provision a secret.**

An org admin must, for `application-sdk`, either:
- add it to the **selected-repositories** list of the org-level `GLOBALPROTECT_USERNAME` + `GLOBALPROTECT_PASSWORD` Actions secrets (same secrets the mothership reviewer uses), **or**
- set those two as **repo-level** secrets.

The repo variables (`GLOBALPROTECT_PORTAL_URL=vpn2.atlan.app`, `MOTHERSHIP_URL`) are already correct.

## What this PR changes

**`globalprotect-connect` action**
- **Probe the real target.** The post-connect health check curled `https://phoenix-ai.atlan.com` — a host the reviewer never talks to. A phoenix-ai blip failed the step despite a healthy mothership tunnel, and a green phoenix-ai probe declared success without ever confirming mothership was reachable. Now probes `${mothership-url}/health` (new `mothership-url` input, default `https://mothership.atlan.dev`), mirroring the working mothership `pr-code-review` action.
- **Portal fallback.** Empty `portal-url` now defaults to `https://vpn2.atlan.app` instead of hard-failing; a primary-portal miss retries the fallback within one attempt. `portal-url` is no longer required.
- **Actionable credential error.** Empty username/password now emits an explicit `::error::` naming the org-secret grant, instead of the bare `username input not provided` that reads like a code bug.

**`sdk-review.yml`**
- Passes `vars.MOTHERSHIP_URL` through to the VPN action so the probe targets the same host the dispatch step uses.

Kept as-is (already correct): `--local-hostname` per-run isolation, `--verbose` (safe — password via stdin, no body dump), stdout/stderr redirect, the outer 3-attempt retry, and the dispatch-step reachability loop.

## Security / control-plane note

This touches `.github/workflows/**` + a composite action (security-relevant CI). No new external actions added; existing pins untouched. No secret values are read, logged, or committed — the credential fix is a settings grant, called out above for a human to perform.

## Verification
- Both files pass `yaml.safe_load`.
- No live code path references `phoenix-ai` (only the explanatory comment).
- Runtime VPN behavior is **not** verified here — it depends on the secret grant landing first. Once the secret is granted, re-run via `@sdk-review` on any open PR.