### PR TITLE
feat(conformance): add contract-toolkit hygiene rules and fix K002 false positive

### DIFF
--- a/packages/conformance/conformance/cli.py
+++ b/packages/conformance/conformance/cli.py
@@ -49,6 +49,16 @@ def _cmd_gen_deprecations(argv: list[str]) -> int:
         return int(e.code) if e.code is not None else 0
 
 
+def _cmd_gen_toolkit_baseline(argv: list[str]) -> int:
+    from conformance.tools.generate_toolkit_baseline import main
+
+    try:
+        main(argv)
+        return 0
+    except SystemExit as e:
+        return int(e.code) if e.code is not None else 0
+
+
 def _cmd_ledger_guard(argv: list[str]) -> int:
     from conformance.tools.ledger_guard import main
 
@@ -99,6 +109,7 @@ _COMMANDS = {
     "gen-rule-docs": _cmd_gen_rule_docs,
     "gen-deprecations": _cmd_gen_deprecations,
     "gen-contract-ledger": _cmd_gen_contract_ledger,
+    "gen-toolkit-baseline": _cmd_gen_toolkit_baseline,
     "ledger-guard": _cmd_ledger_guard,
     "remediate": _cmd_remediate,
     "bootstrap": _cmd_bootstrap,
@@ -117,6 +128,9 @@ commands:
                        --repo DIR    repo root to scan (default: auto-detected)
                        --outfile PATH  ledger path (default: contract_schema.lock.json in cwd)
                        --check       verify ledger is current; exit 1 if stale
+  gen-toolkit-baseline Regenerate data/toolkit_baseline.json from contract-toolkit/src/PklProject
+                       --sdk-root DIR  repo root to read (default: auto-detected)
+                       --check       verify baseline is current; exit 1 if stale
   ledger-guard         CI append-only guard: block ledger deletions and type changes between
                        base ref and HEAD (run after fetch-depth: 0 checkout)
                          --base-ref REF      git ref for the base (default: origin/main)

--- a/packages/conformance/conformance/data/toolkit_baseline.json
+++ b/packages/conformance/conformance/data/toolkit_baseline.json
@@ -1,0 +1,4 @@
+{
+  "canonical_base": "atlanhq.github.io/application-sdk/contracts/app-contract-toolkit",
+  "latest_version": "0.18.0"
+}

--- a/packages/conformance/conformance/docs/rules/contract-toolkit.md
+++ b/packages/conformance/conformance/docs/rules/contract-toolkit.md
@@ -5,7 +5,7 @@
 
 # Contract-Toolkit Conformance Rules (K-series)
 
-**6 rules** · Checker: `suite.checks.legacy_contract` (K001–K002, pkl-source regex, scans ``contract/**/*.pkl``), `suite.checks.generated_freshness` (K003–K005, scans ``contract/PklProject``, ``contract/PklProject.deps.json``, ``atlan.yaml``, ``app.yaml``, and ``app/generated/**``), `suite.checks.manifest_contract` (K006, cross-references ``app/generated/**/manifest.json`` against Python ``Output`` contracts)
+**10 rules** · Checker: `suite.checks.legacy_contract` (K001–K002, pkl-source regex, scans ``contract/**/*.pkl``), `suite.checks.generated_freshness` (K003–K005, scans ``contract/PklProject``, ``contract/PklProject.deps.json``, ``atlan.yaml``, ``app.yaml``, and ``app/generated/**``), `suite.checks.manifest_contract` (K006, cross-references ``app/generated/**/manifest.json`` against Python ``Output`` contracts)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -21,6 +21,10 @@ Suppress a finding on the violating line or the line directly above it:
 | [K004](#k004) | `MissingGeneratedArtifact` | `warn` | `app` | `contract-toolkit` | — | 0.9.0 |
 | [K005](#k005) | `GeneratedArtifactBannerStripped` | `warn` | `app` | `contract-toolkit` | — | 0.9.0 |
 | [K006](#k006) | `ManifestContractFieldMismatch` | `warn` | `app` | `contract-toolkit` | — | 0.13.0 |
+| [K007](#k007) | `ToolkitVersionOutdated` | `warn` | `app` | `contract-toolkit` | — | 0.12.0 |
+| [K008](#k008) | `ToolkitSourceNonCanonical` | `warn` | `app` | `contract-toolkit` | — | 0.12.0 |
+| [K009](#k009) | `UnresolvedScaffoldPlaceholder` | `block` | `app` | `contract-toolkit` | — | 0.12.0 |
+| [K010](#k010) | `E2EScaffoldingMissing` | `warn` | `app` | `contract-toolkit` | — | 0.12.0 |
 
 ---
 
@@ -82,12 +86,11 @@ migration tracked in a follow-on ticket).
 **Rationale:** Several properties and imports that exist in NativeApp.pkl were intentionally dropped
 when App.pkl was designed: flatManifestArgs and manifestMetadataArgs (App.pkl always
 emits flat top-level args), workflowTypeOverride (App.pkl takes a verbatim
-workflowType), and explicit imports of
-Config.pkl/Connectors.pkl/Credential.pkl/Renderers.pkl (App.pkl re-exports what apps
-need as typealiases).  Their presence in a contract that claims to amend App.pkl (or
-that will be migrated to App.pkl) indicates that the migration is incomplete.  When any
-of these knobs remain after the amends line is changed, pkl eval fails, blocking CI
-(BLDX-1479).
+workflowType), and explicit imports of Config.pkl/Credential.pkl/Renderers.pkl (Argo-era
+modules App.pkl no longer uses).  Their presence in a contract that claims to amend
+App.pkl (or that will be migrated to App.pkl) indicates that the migration is
+incomplete.  When any of these knobs remain after the amends line is changed, pkl eval
+fails, blocking CI (BLDX-1479).
 
 The `contract/**/*.pkl` file contains one or more NativeApp-only properties or imports
 that do not exist in `App.pkl`:
@@ -104,11 +107,13 @@ App.pkl's `workflowType`, then remove `workflowTypeOverride`.
 re-exports all widget types as typealiases (`TextInput`, `UIConfig`, etc.) — remove the
 import and switch `Config.UIConfig` → `UIConfig`, `Config.TextInput` → `TextInput`, etc.
 
-* `import "…Connectors.pkl"` — App.pkl exposes connector constants as `Connectors.*`
-with no import needed; remove the explicit import.
-
 * `import "…Credential.pkl"` and `import "…Renderers.pkl"` (Argo-era modules) — no
 longer used by App.pkl; remove both.
+
+Note: `import "…Connectors.pkl"` is **not** flagged — the Connectors registry is still
+imported explicitly by App.pkl consumers (App.pkl imports it internally and types
+`connector` as `Connectors.Type` but does not re-export the constants), so the import is
+required, not legacy.
 
 **Note:** if the contract also has a K001 finding (still amending a legacy module),
 address K001 first — many K002 knobs disappear automatically when the module changes,
@@ -292,5 +297,132 @@ in `contract/app.pkl` and re-run `pkl eval -m . contract/app.pkl` instead.
 **Suppress** with `# conformance: ignore[K006] <reason>` on the `Output` class
 definition (or the comment-only line directly above it) when a mismatch is understood
 and deliberately deferred.
+
+---
+
+## K007 — `ToolkitVersionOutdated` {#k007}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `contract-toolkit` · **Autofixable:** — · **Since:** 0.12.0
+
+> app-contract-toolkit dependency resolves to a version below the latest published one — bump and regenerate
+
+**Rationale:** The app-contract-toolkit ships fixes and new contract capabilities in every release; an
+app pinned to an old version regenerates stale artifacts, misses schema changes, and is
+the usual root cause of leftover scaffold placeholders (K009) and legacy-API drift
+(K002). The latest published version is read from the baked-in toolkit baseline
+(data/toolkit_baseline.json), regenerated from the toolkit's own PklProject and guarded
+against drift in CI, so the check stays correct offline inside any consumer repo.
+
+The `app-contract-toolkit` dependency in `contract/PklProject` resolves (per
+`contract/PklProject.deps.json`) to a version older than the latest the SDK publishes.
+
+The check uses the resolved lock as the ground truth for the version actually in use; a
+missing or stale lock is K003's concern, so K007 stays quiet in that case rather than
+guessing from a broad pin.
+
+**Fix:** bump the `@<version>` in `contract/PklProject` to the latest, run `pkl project
+resolve` to refresh the lock, then regenerate with `pkl eval -m . contract/app.pkl`. On
+a `renovate/**` branch this happens automatically via renovate-pkl-sync.
+
+**Suppress** with `// conformance: ignore[K007] <reason>` on the `uri` line (or the
+comment-only line directly above it) when a deliberate lag is justified.
+
+---
+
+## K008 — `ToolkitSourceNonCanonical` {#k008}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `contract-toolkit` · **Autofixable:** — · **Since:** 0.12.0
+
+> app-contract-toolkit is sourced from a non-canonical base URI (fork / local path / wrong host)
+
+**Rationale:** Every app must consume the app-contract-toolkit from the single SDK-published package so
+the whole fleet generates from the same contract semantics and receives version bumps
+through the standard renovate flow. A dependency pointed at a fork, a local file path,
+or a different host silently diverges — it can pin behavior the SDK no longer supports
+and is invisible to the version floor (K007), which only compares against the canonical
+package. The canonical base URI is read from the baked-in toolkit baseline.
+
+The `app-contract-toolkit` dependency in `contract/PklProject` is pointed at a base URI
+other than the canonical SDK-published package
+(`package://atlanhq.github.io/application-sdk/contracts/app-contract-toolkit`).
+
+The dependency is identified by its `["app-contract-toolkit"]` mapping key (falling back
+to any URI whose path segment is `app-contract-toolkit`), so a fork under the canonical
+key is still caught.
+
+**Fix:** point the dependency at the canonical package
+`package://atlanhq.github.io/application-sdk/contracts/app-contract-toolkit@<latest>`
+and run `pkl project resolve`.
+
+**Suppress** with `// conformance: ignore[K008] <reason>` on the `uri` line (or the
+comment-only line directly above it).
+
+---
+
+## K009 — `UnresolvedScaffoldPlaceholder` {#k009}
+
+**Tier:** `block` · **Scope:** `app` · **Category:** `contract-toolkit` · **Autofixable:** — · **Since:** 0.12.0
+
+> Generated artifact contains an unresolved single-brace scaffold placeholder ({app_name}, {name}, …) — upgrade the toolkit and regenerate
+
+**Rationale:** A committed generated artifact that still contains a single-brace scaffold token such as
+{app_name} is shipping template text where a rendered value belongs — the current
+toolkit resolves {app_name} to the app's literal name, so a leftover means the artifact
+was generated by an outdated toolkit (or a legacy NativeApp.pkl base) and is objectively
+wrong on the wire, not merely stylistically stale. Because it is never a false positive
+(the {{...}} double-brace runtime tokens are excluded, and the one legitimate
+single-brace token {deployment_name} is not in the flagged set), this is a BLOCK-tier
+rule rather than the usual land-as-WARN default: the only correct resolution is to
+upgrade to the latest app-contract-toolkit and regenerate.
+
+A committed generated artifact (`atlan.yaml`, `app.yaml`, or a file under
+`app/generated/`) contains a single-brace scaffold placeholder token — `{app_name}`,
+`{name}`, `{app-name}`, `{entrypoint_name}`, `{connection_name}`, and related scaffold
+vars.
+
+These are filled in by `pkl eval`; a literal leftover means the artifact was generated
+by an outdated toolkit (or a legacy `NativeApp.pkl` base) that never rendered the field.
+The current toolkit resolves `{app_name}` to the app's literal name, so this artifact is
+wrong as shipped — hence BLOCK, not WARN.
+
+Intentional `{{credential}}` / `{{connection}}` double-brace E2E runtime-substitution
+tokens are excluded, as is the legitimate `{deployment_name}` deploy-time token the
+current toolkit still emits verbatim; none of these are ever flagged.
+
+**Fix (required):** upgrade `app-contract-toolkit` to the latest published version (see
+K007), migrate off any legacy `NativeApp.pkl` base (see K001), and regenerate with `pkl
+eval -m . contract/app.pkl`. Never hand-edit the artifact to delete the token.
+
+**Suppress** with `# conformance: ignore[K009] <reason>` on the placeholder's line (or
+the comment-only line directly above it) — available for text artifacts; a placeholder
+in a `.json` output has no comment syntax to suppress and must be regenerated.
+
+---
+
+## K010 — `E2EScaffoldingMissing` {#k010}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `contract-toolkit` · **Autofixable:** — · **Since:** 0.12.0
+
+> Single-entrypoint contract/app.pkl exists but generated app/generated/_e2e_base.py is missing
+
+**Rationale:** The toolkit emits app/generated/_e2e_base.py for every single-entrypoint app, and the
+SDK's E2E framework imports it; a missing file means the contract was never generated
+(or the output was deleted), so the app's E2E tests cannot resolve their typed base.
+Multi-entrypoint bundles emit E2E scaffolding into per-entrypoint subfolders instead, so
+the rule only applies when the contract declares no entrypoints block.
+
+A single-entrypoint `contract/app.pkl` exists but its generated E2E scaffolding
+`app/generated/_e2e_base.py` is absent. The toolkit emits this module unconditionally
+for single-entrypoint apps, and `application_sdk.testing.e2e` imports it as the typed
+E2E base.
+
+Contracts that declare an `entrypoints` block (multi-entrypoint bundles) are out of
+scope — their E2E scaffolding lands in per-entrypoint subfolders, not the
+single-entrypoint path.
+
+**Fix:** regenerate with `pkl eval -m . contract/app.pkl` and commit the result.
+
+**Suppress** with `// conformance: ignore[K010] <reason>` on the `amends` line of
+`contract/app.pkl` when the app legitimately ships no E2E scaffolding.
 
 ---

--- a/packages/conformance/conformance/programs/areas/contract-toolkit.prose.md
+++ b/packages/conformance/conformance/programs/areas/contract-toolkit.prose.md
@@ -13,7 +13,12 @@ description: >
   (a manifest.json JSONPath reference the Python Output contract does not
   declare) is fixed on the Python side — declare the field or mix in the SDK
   contract base that supplies it — and verified by the test-suite gate, not
-  pkl-eval.
+  pkl-eval.  K007 (toolkit version below the latest published), K008 (toolkit
+  sourced from a non-canonical base URI), K009 (unresolved scaffold placeholder
+  in a generated artifact), and K010 (missing generated E2E scaffolding) are
+  toolkit-hygiene findings fixed by re-pointing/bumping the PklProject dependency
+  and regenerating — all verified by the pkl-eval gate.  K009 is BLOCK-tier (fails
+  the gate in default mode); the rest of the K-series is WARN.
 ---
 
 ### Maintains
@@ -26,11 +31,14 @@ findings in the working tree, classified by disposition and remediability.
 The fingerprint-set of all unsuppressed FAILING/WARNING K-series results in the
 current working tree, as reported by `suite.runner --series K`.
 
-K-series rules are WARN-tier, so in **default** mode this facet is always empty
-(warnings do not fail the gate).  In **strict** mode the fingerprint-set includes
-unsuppressed WARNING results, which is where K-series remediation actually runs.
+All K-series rules are WARN-tier **except K009 (BLOCK)**.  So in **default** mode
+this facet is empty *unless* a K009 (unresolved scaffold placeholder) finding is
+present — K009 is a FAILING result that fails the gate and must be remediated in
+default mode.  In **strict** mode the fingerprint-set also includes the
+unsuppressed WARNING results (K003/K004/K005/K007/K008/K010), which is where the
+rest of K-series remediation runs.
 
-The active scope decides which rules can appear: K001–K006 are all `scope=APP`,
+The active scope decides which rules can appear: K001–K010 are all `scope=APP`,
 so they surface only on consumer app repos.  The runner auto-detects scope, so
 the SDK repo sees 0 findings.
 
@@ -72,17 +80,19 @@ call detect-fix-recheck
 
 _Read by `remediate-finding` when `finding.area == "contract-toolkit"`._
 
-All K-series rules are **WARN-tier** — they surface only under `--strict` mode.
+All K-series rules are **WARN-tier except K009 (BLOCK)** — the WARN rules surface
+only under `--strict` mode, while K009 (unresolved scaffold placeholder) is a
+FAILING result that must be remediated even in default mode.
 Before proposing any edit, read the actual lines around `finding.line` in
 `finding.file`.  **Never hand-edit `atlan.yaml`, `app/generated/`, or any other
 generated artifact directly** — those are outputs of `pkl eval`, and K004/K005
 catch the staleness that hand-editing causes.  The *only* sanctioned way to
 change a generated artifact is to regenerate it from the contract.  After every
-edit to `contract/**/*.pkl` (K001/K002) or the Pkl lock (K003/K004/K005), the
-`pkl-eval` gate runs `pkl eval` to verify the contract compiled and regenerated
-cleanly.  **K006 is the one exception**: its fix is a plain Python edit (see
-below) with no `.pkl` or generated-artifact involvement, so it is verified by
-the standard test-suite gate instead of `pkl-eval`.
+edit to `contract/**/*.pkl`, `contract/PklProject`, or the Pkl lock (K001–K005,
+K007–K010), the `pkl-eval` gate runs `pkl eval` to verify the contract compiled
+and regenerated cleanly.  **K006 is the one exception**: its fix is a plain
+Python edit (see below) with no `.pkl` or generated-artifact involvement, so it
+is verified by the standard test-suite gate instead of `pkl-eval`.
 
 The freshness rules (K003/K004/K005) are remediated by running a pkl command
 (`pkl project resolve` and/or `pkl eval -m . contract/app.pkl`), so they are
@@ -149,11 +159,12 @@ Read the specific knob(s) named in the `finding.message` and apply:
   directly (e.g. `Config.UIConfig` → `UIConfig`, `Config.TextInput` →
   `TextInput`).
 
-- **`import "…Connectors.pkl"`** — remove the import.  App.pkl re-exports all
-  connector constants as `Connectors.*` with no import needed.
-
 - **`import "…Credential.pkl"`** (Argo-era) and **`import "…Renderers.pkl"`**
   (Argo-era) — remove both; these modules are no longer used by App.pkl.
+
+  (Note: `import "…Connectors.pkl"` is NOT a K002 finding — the Connectors
+  registry is still imported explicitly by App.pkl consumers, so it is not
+  flagged and needs no fix.)
 
 If the contract file also has a K001 finding (amends a legacy module), address
 K001 first — many K002 knobs disappear automatically when the module changes
@@ -277,11 +288,104 @@ Output contract class. Read the actual `Output` class at `finding.line` in
 
 ---
 
+**K007 ToolkitVersionOutdated** — the `app-contract-toolkit` dependency in
+`contract/PklProject` resolves (per the lock) to a version below the latest
+published one.  `classification = "mechanical"`; **requires `pkl`**.
+
+*Procedure:*
+
+1. Bump the `@<version>` on the `app-contract-toolkit` `uri` line in
+   `contract/PklProject` to the latest published version (the finding message
+   names it).
+2. Run `pkl project resolve` to refresh `contract/PklProject.deps.json`, then
+   `pkl eval -m . contract/app.pkl` to regenerate the artifacts against the new
+   toolkit.  Do NOT run `pkl eval` manually to fix `touched_files` — the
+   `pkl-eval` gate does it; set `touched_files` the deterministic way described
+   in K003 step 4 (the union of paths `git status --porcelain` reports changed).
+3. If the lag is deliberate, suppress with `// conformance: ignore[K007]
+   <reason>` on the `uri` line and route to residue.
+
+If `pkl` is unavailable, route to residue with a bump-and-resolve-locally note
+(the `renovate-pkl-sync` workflow does this automatically on renovate bumps).
+
+---
+
+**K008 ToolkitSourceNonCanonical** — the `app-contract-toolkit` dependency is
+pointed at a base URI other than the canonical SDK-published package.
+`classification = "mechanical"` when the fix is a straight re-point;
+`"judgment"` when the fork is deliberate.  **requires `pkl`**.
+
+*Procedure:*
+
+1. Change the dependency `uri` in `contract/PklProject` to the canonical
+   package base named in the finding message
+   (`package://atlanhq.github.io/application-sdk/contracts/app-contract-toolkit@<latest>`).
+2. Run `pkl project resolve`, then `pkl eval -m . contract/app.pkl`; set
+   `touched_files` the K003-step-4 way.
+3. If the app deliberately consumes a fork (rare — e.g. an in-flight toolkit
+   change under review), `classification = "judgment"`: suppress with
+   `// conformance: ignore[K008] <reason>` on the `uri` line and route to residue.
+
+If `pkl` is unavailable, route to residue.
+
+---
+
+**K009 UnresolvedScaffoldPlaceholder** — a committed generated artifact
+(`atlan.yaml`, `app.yaml`, or a file under `app/generated/`) still contains a
+single-brace scaffold token (`{app_name}`, `{name}`, …).  **This is a BLOCK-tier
+finding** — it fails the gate in default mode, because the current toolkit
+renders these tokens to literals, so the artifact is wrong as shipped.
+`classification = "judgment"` — the leftover is a symptom of a deeper cause
+(outdated toolkit, never instantiated, or a legacy `NativeApp.pkl` base), so the
+real fix is upstream, not a text substitution.  **requires `pkl`**.
+
+*Procedure:*
+
+1. **Upgrade the toolkit to the latest version first.** A leftover `{app_name}`
+   almost always means the app is on an outdated `app-contract-toolkit` (a K007
+   finding is usually present alongside): bump the `@<version>` in
+   `contract/PklProject` to the latest and `pkl project resolve`. If the contract
+   still amends `NativeApp.pkl` (K001), migrate to `App.pkl` first.
+   **Never hand-edit the artifact** to delete or fill the placeholder — it is a
+   `pkl eval` output; the token must disappear because the toolkit now renders it.
+2. Regenerate with `pkl eval -m . contract/app.pkl` and stage the result; set
+   `touched_files` the K003-step-4 way so a gate rejection reverts every
+   regenerated artifact.  Confirm no `{...}` scaffold token remains.
+3. `{{…}}` double-brace tokens are intentional E2E runtime substitutions and are
+   never flagged — if one appears in a finding, that is a bug in the rule, not a
+   fix target.
+4. A placeholder in a `.json` output has no comment syntax to carry an inline
+   suppression, so it cannot be suppressed in place — it must be regenerated (or
+   the root-cause rule suppressed).  For a text artifact, suppress with
+   `# conformance: ignore[K009] <reason>` on the placeholder line and route to
+   residue.
+
+If `pkl` is unavailable, route to residue with a regenerate-locally note.
+
+---
+
+**K010 E2EScaffoldingMissing** — a single-entrypoint `contract/app.pkl` exists
+but the generated `app/generated/_e2e_base.py` the toolkit always emits for it is
+absent.  `classification = "mechanical"`; **requires `pkl`**.
+
+*Procedure:*
+
+1. Run `pkl eval -m . contract/app.pkl` to regenerate all outputs (including
+   `_e2e_base.py`), then stage them; set `touched_files` the K003-step-4 way.
+2. If the app legitimately ships no E2E scaffolding, `classification =
+   "judgment"`: suppress with `// conformance: ignore[K010] <reason>` on the
+   `amends` line of `contract/app.pkl` and route to residue.
+
+If `pkl` is unavailable, route to residue with a regenerate-locally note.
+
+---
+
 **Suppress outcome (strict mode only, WARNING-tier findings)**: the model may
 propose an inline suppression comment — `// conformance: ignore[Kxxx]
-<8–40 word justification>` for K001–K005 (`.pkl` source, `//` comments) or
-`# conformance: ignore[K006] <8–40 word justification>` (Python source, `#`
-comments) — on the violating line or the comment-only line directly above it
-when a legitimate exception exists (e.g. a K001 finding on a contract
-intentionally kept at the legacy module during a phased migration with a
-tracked follow-on ticket).  Route every suppression to residue for human audit.
+<8–40 word justification>` for the `.pkl`-source / `PklProject`-anchored rules
+(K001–K005, K007, K008, K010; `//` comments) or `# conformance: ignore[Kxxx]
+<8–40 word justification>` for the artifact/Python-anchored rules (K006 Python,
+K009 text artifact; `#` comments) — on the violating line or the comment-only
+line directly above it when a legitimate exception exists (e.g. a K001 finding on
+a contract intentionally kept at the legacy module during a phased migration with
+a tracked follow-on ticket).  Route every suppression to residue for human audit.

--- a/packages/conformance/conformance/suite/checks/_toolkit_baseline.py
+++ b/packages/conformance/conformance/suite/checks/_toolkit_baseline.py
@@ -1,0 +1,109 @@
+"""Baked-in contract-toolkit baseline — the offline source-of-truth for K007/K008.
+
+The conformance suite ships as a standalone package and runs *inside consumer app
+repos*, where the SDK's ``contract-toolkit/src/PklProject`` (which declares the
+toolkit's canonical package URI and current published version) is **not** on disk.
+The suite is also deterministic and offline, so it cannot fetch that value at scan
+time.
+
+The fix mirrors the B-series deprecation manifest: a generator
+(``tools/generate_toolkit_baseline.py``) reads ``contract-toolkit/src/PklProject``
+at SDK-dev time and writes the committed JSON this module loads, and a drift-guard
+test (``tests/test_toolkit_baseline_drift.py``) fails CI if the toolkit is bumped
+without regenerating.  At scan time in a consumer repo, ``load_baseline()`` reads
+the JSON baked into the installed wheel via ``importlib.resources`` — no SDK
+source and no network required.
+"""
+
+from __future__ import annotations
+
+import importlib.resources as _ir
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+# Committed JSON, relative to the ``conformance`` package root (ships in the wheel
+# under ``conformance/data/`` — same mechanism as the deprecation manifest).
+_BASELINE_RELPATH: tuple[str, ...] = ("data", "toolkit_baseline.json")
+
+# The toolkit's own package manifest, relative to the SDK repo root.  Only read by
+# the generator (SDK-dev time); never present in a consumer app repo.
+TOOLKIT_PKLPROJECT_RELPATH: tuple[str, ...] = ("contract-toolkit", "src", "PklProject")
+
+
+def _baseline_path() -> Path:
+    return Path(str(_ir.files("conformance"))).joinpath(*_BASELINE_RELPATH)
+
+
+BASELINE_PATH = _baseline_path()
+
+
+@dataclass(frozen=True)
+class ToolkitBaseline:
+    """The canonical toolkit package base URI and latest published version.
+
+    ``canonical_base`` is scheme-less (``package://`` stripped) so it compares
+    directly against the base returned by ``generated_freshness._split_uri``.
+    """
+
+    canonical_base: str
+    latest_version: str
+
+
+_NAME_RE = re.compile(r'\bname\s*=\s*"([^"]+)"')
+_VERSION_RE = re.compile(r'\bversion\s*=\s*"([^"]+)"')
+_BASEURI_RE = re.compile(r'\bbaseUri\s*=\s*"([^"]+)"')
+
+
+def build_baseline(sdk_root: Path) -> ToolkitBaseline:
+    """Parse ``contract-toolkit/src/PklProject`` into a :class:`ToolkitBaseline`.
+
+    Resolves the ``\\(name)`` interpolation in ``baseUri`` and strips the URI
+    scheme so the stored base matches the scan-time comparison form.
+    """
+    pkl_project = sdk_root.joinpath(*TOOLKIT_PKLPROJECT_RELPATH)
+    text = pkl_project.read_text(encoding="utf-8")
+
+    name_m = _NAME_RE.search(text)
+    version_m = _VERSION_RE.search(text)
+    baseuri_m = _BASEURI_RE.search(text)
+    if not (name_m and version_m and baseuri_m):
+        raise ValueError(
+            f"{pkl_project} is missing name/version/baseUri — cannot build the "
+            f"toolkit baseline."
+        )
+
+    name = name_m.group(1)
+    version = version_m.group(1)
+    base_uri = baseuri_m.group(1).replace("\\(name)", name)
+    canonical_base = base_uri.split("://", 1)[-1]
+    return ToolkitBaseline(canonical_base=canonical_base, latest_version=version)
+
+
+def serialize(baseline: ToolkitBaseline) -> str:
+    """Deterministic JSON so ``--check`` is a stable staleness gate."""
+    payload = {
+        "canonical_base": baseline.canonical_base,
+        "latest_version": baseline.latest_version,
+    }
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def load_baseline() -> ToolkitBaseline | None:
+    """Load the committed baseline, or ``None`` when it is absent/unparseable.
+
+    Returning ``None`` (rather than raising) lets K007/K008 no-op gracefully if
+    the baked data ever goes missing — the suite must never crash a consumer's CI.
+    """
+    try:
+        data = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    base = data.get("canonical_base")
+    version = data.get("latest_version")
+    if not isinstance(base, str) or not isinstance(version, str):
+        return None
+    return ToolkitBaseline(canonical_base=base, latest_version=version)

--- a/packages/conformance/conformance/suite/checks/_version.py
+++ b/packages/conformance/conformance/suite/checks/_version.py
@@ -1,9 +1,10 @@
-"""Tiny version parsing/comparison for the B-series — no external dependency.
+"""Tiny version parsing/comparison shared across checks — no external dependency.
 
 The conformance package is deliberately lean (it scans source text), so rather
-than pull in ``packaging`` just to compare deprecation removal versions, we parse
-the small, well-behaved version strings the SDK actually writes — ``"v3.2.0"``,
-``"4.0"``, ``"3.18.0"`` — into comparable integer tuples.
+than pull in ``packaging`` just to compare version strings, we parse the small,
+well-behaved versions the SDK and toolkit actually write — ``"v3.2.0"``,
+``"4.0"``, ``"3.18.0"`` — into comparable integer tuples. Used by the B-series
+deprecation removal check and the K-series toolkit version floor.
 
 Only the dotted numeric release segment is understood; any pre-release / local
 suffix is ignored.  A string with no leading numeric component yields ``None``

--- a/packages/conformance/conformance/suite/checks/deprecation/_authoring.py
+++ b/packages/conformance/conformance/suite/checks/deprecation/_authoring.py
@@ -26,8 +26,8 @@ from dataclasses import dataclass
 from conformance.suite.checks._ast_common import _IgnoreDirective, make_finding
 from conformance.suite.schema.findings import Finding
 
+from .._version import parse_version, version_reached
 from ._extractor import extract_notices, extract_sites
-from ._version import parse_version, version_reached
 
 
 @dataclass(frozen=True)

--- a/packages/conformance/conformance/suite/checks/generated_freshness.py
+++ b/packages/conformance/conformance/suite/checks/generated_freshness.py
@@ -1,38 +1,48 @@
-"""K003/K004/K005 — generated-artifact freshness (BLDX-1414).
+"""K003–K010 — generated-artifact freshness and toolkit hygiene.
 
 A repo-level (``scan_all``) check under the **K** series that guards the *outputs*
-of ``pkl eval`` (``atlan.yaml``, ``app/generated/**``) rather than the ``.pkl``
-source that ``legacy_contract`` (K001/K002) scans.  Multiple check modules under
-one series letter is the established pattern (P = ``prescriptions`` +
-``determinism``); this registration rides the existing ``K`` CI matrix leg.
+of ``pkl eval`` (``atlan.yaml``, ``app/generated/**``) and the toolkit dependency
+declaration, rather than the ``.pkl`` source that ``legacy_contract`` (K001/K002)
+scans.  Multiple check modules under one series letter is the established pattern
+(P = ``prescriptions`` + ``determinism``); this rides the existing ``K`` CI leg.
 
 What each rule catches — all **deterministic, no pkl toolchain required**:
 
 * **K003 ContractLockDrift** — ``contract/PklProject`` pins a dependency at an
   exact ``@<version>`` that the resolved lock ``contract/PklProject.deps.json``
-  does not match (or the lock is missing / lacks the dependency).  A stale lock
-  means ``pkl eval`` regenerates from the wrong toolkit version.
+  does not match (or the lock is missing / lacks the dependency).
 * **K004 MissingGeneratedArtifact** — ``contract/app.pkl`` exists but an expected
   output (``atlan.yaml``, ``app/generated/manifest.json``,
   ``app/generated/_input.py``) is absent — the contract was never generated.
-* **K005 GeneratedArtifactBannerStripped** — a generated text artifact
-  (``atlan.yaml`` / ``app.yaml`` / ``app/generated/*.py`` other than
-  ``__init__.py``) is missing its ``… DO NOT EDIT …`` provenance banner — a
-  heuristic hand-edit signal.  Content-level hand-edits that keep the banner are
-  invisible here; only the CI regenerate-and-diff gate proves full freshness.
+* **K005 GeneratedArtifactBannerStripped** — a generated text artifact is missing
+  its ``… DO NOT EDIT …`` provenance banner — a heuristic hand-edit signal.
+* **K007 ToolkitVersionOutdated** — the app's ``app-contract-toolkit`` dependency
+  resolves (per the lock) to a version below the latest published one.
+* **K008 ToolkitSourceNonCanonical** — the toolkit dependency is sourced from a
+  base URI other than the canonical SDK-published package.
+* **K009 UnresolvedScaffoldPlaceholder** — a generated artifact still contains a
+  single-brace scaffold token (``{app_name}``, ``{name}``, …); ``{{…}}`` E2E
+  runtime tokens are intentional and excluded.
+* **K010 E2EScaffoldingMissing** — a single-entrypoint app is missing the
+  generated ``app/generated/_e2e_base.py`` the toolkit always emits for it.
+
+K007/K008 read the canonical base + latest version from the baked-in
+``data/toolkit_baseline.json`` (``_toolkit_baseline``): the SDK's toolkit source
+is not present in a consumer repo, so the value ships with the wheel and a
+drift-guard test keeps it fresh.
 
 Scope
 -----
-All three are ``APP``-scoped and gated on the relevant ``contract/`` file being
-present, so they no-op on the SDK (no ``contract/`` at its root) and on any repo
-that excludes ``contract/`` from the scan.
+All are ``APP``-scoped and gated on the relevant ``contract/`` file being present,
+so they no-op on the SDK (no ``contract/`` at its root) and on any repo that
+excludes ``contract/`` from the scan.
 
 Suppression
 -----------
-K003/K004 anchor on pkl source (``PklProject`` / ``app.pkl``) and reuse the
-``// conformance: ignore[...]`` parser from ``legacy_contract``.  K005 anchors on
-the artifact file (``#`` comments in both ``.yaml`` and ``.py``) and uses the
-``# conformance: ignore[K005] <reason>`` form.
+Rules anchored on pkl source (``PklProject`` / ``app.pkl``: K003/K004/K007/K008/
+K010) reuse the ``// conformance: ignore[...]`` parser from ``legacy_contract``.
+Rules anchored on the artifact file (K005/K009) use the ``# conformance:
+ignore[...] <reason>`` form (both ``.yaml`` and ``.py`` use ``#``).
 """
 
 from __future__ import annotations
@@ -43,6 +53,8 @@ import sys
 from pathlib import Path
 
 from conformance.suite.checks._ast_common import TOOL_VERSION, make_cli_main
+from conformance.suite.checks._toolkit_baseline import ToolkitBaseline, load_baseline
+from conformance.suite.checks._version import parse_version, version_reached
 from conformance.suite.checks.legacy_contract._directives_pkl import (
     _make_pkl_finding_suppressed,
     _parse_pkl_directives,
@@ -72,11 +84,41 @@ _BANNER_GENERATED_RE = re.compile(r"generated", re.IGNORECASE)
 _BANNER_DONOTEDIT_RE = re.compile(r"do not edit", re.IGNORECASE)
 _BANNER_SCAN_LINES = 5
 
-# ``#``-comment suppression (K005 — both YAML and Python use ``#``).
+# ``#``-comment suppression (K005/K009 — both YAML and Python use ``#``).
 _HASH_SUPPRESS_RE = re.compile(
     r"#\s*conformance\s*:\s*ignore\s*(?:\[([^\]]*)\])?\s*(.*)",
     re.IGNORECASE,
 )
+
+# The pkl dependency-block key an app uses for the toolkit: ``["app-contract-toolkit"]``.
+_TOOLKIT_DEP_KEY = "app-contract-toolkit"
+_DEP_KEY_RE = re.compile(r'\["([^"]+)"\]')
+
+# K009 — unresolved scaffold placeholder tokens left in a generated artifact.
+# Single-brace ``{token}`` the current toolkit resolves at ``pkl eval`` time; a
+# literal leftover means the artifact was generated by an outdated toolkit (or a
+# legacy base) that never rendered it — e.g. ``{app_name}``, which 0.18.0+ resolves
+# to the app's literal name.
+#
+# Two things are deliberately NOT flagged and must stay out of this set:
+#   * ``{{...}}`` — Automation-Engine runtime-substitution tokens (credential,
+#     connection, …), resolved at run time. Excluded by the ``(?<!\{)``/``(?!\})``
+#     guards.
+#   * ``{deployment_name}`` — a deploy-time token the current toolkit STILL emits
+#     verbatim into every manifest (task_queue), so it is legitimate, not a
+#     leftover. It is absent from the alternation below; do not add it.
+_SCAFFOLD_PLACEHOLDER_RE = re.compile(
+    r"(?<!\{)\{(?:app_name|app-name|name|entrypoint_name|entrypoint-kebab-name"
+    r"|fetch_task_name|connection_name)\}(?!\})"
+)
+
+# K010 — E2E scaffolding module that ``pkl eval`` emits for a single-entrypoint app.
+_E2E_BASE_OUTPUT = "app/generated/_e2e_base.py"
+
+# A contract that declares an ``entrypoints`` block is a multi-entrypoint bundle;
+# its E2E scaffolding lands in per-entrypoint subfolders, so K010 (which requires
+# the single-entrypoint _e2e_base.py path) does not apply.
+_ENTRYPOINTS_RE = re.compile(r"(?m)^\s*entrypoints\b")
 
 
 # ---------------------------------------------------------------------------
@@ -104,19 +146,37 @@ def _split_uri(uri: str) -> tuple[str, str] | None:
     return base, version
 
 
-def _parse_pkl_project_pins(text: str) -> list[tuple[str, str, int]]:
-    """Return ``[(base, version, lineno)]`` for every versioned dependency URI
-    pinned in a ``PklProject`` file."""
-    pins: list[tuple[str, str, int]] = []
+def _parse_pkl_project_deps(
+    text: str,
+) -> list[tuple[str | None, str, str | None, int]]:
+    """Return ``[(dep_key, base, version, uri_lineno)]`` for every dependency URI
+    in a ``PklProject`` — the single parser behind K003 (version drift) and
+    K007/K008 (toolkit floor / source).
+
+    ``dep_key`` is the ``["…"]`` mapping key most recently preceding the ``uri =``
+    line (``None`` if the URI has no enclosing key), used to identify the toolkit
+    even when its URI points at a non-canonical source.  ``base`` is scheme-less
+    (so a ``package://`` pin and a ``projectpackage://`` lock entry compare
+    equal); ``version`` is ``None`` for an unversioned URI (e.g. a local
+    ``file://`` fork).
+    """
+    deps: list[tuple[str | None, str, str | None, int]] = []
+    current_key: str | None = None
     for lineno, line in enumerate(text.splitlines(), start=1):
-        m = _URI_RE.search(line)
-        if m is None:
+        key_m = _DEP_KEY_RE.search(line)
+        if key_m is not None:
+            current_key = key_m.group(1)
+        uri_m = _URI_RE.search(line)
+        if uri_m is None:
             continue
-        split = _split_uri(m.group(1))
-        if split is None:
-            continue
-        pins.append((split[0], split[1], lineno))
-    return pins
+        split = _split_uri(uri_m.group(1))
+        if split is not None:
+            base, version = split
+        else:
+            base, version = uri_m.group(1).split("://", 1)[-1], None
+        deps.append((current_key, base, version, lineno))
+        current_key = None
+    return deps
 
 
 def _parse_deps_lock(text: str) -> dict[str, str] | None:
@@ -156,6 +216,123 @@ def _version_satisfied(pin: str, resolved: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Toolkit dependency selection (K007/K008)
+# ---------------------------------------------------------------------------
+
+
+def _find_toolkit_dep(
+    deps: list[tuple[str | None, str, str | None, int]],
+) -> tuple[str, str | None, int] | None:
+    """Return ``(base, version, lineno)`` for the app-contract-toolkit dependency.
+
+    Identified by the ``["app-contract-toolkit"]`` mapping key first (the name an
+    app amends via ``@app-contract-toolkit/App.pkl``), falling back to any URI
+    whose path segment is ``app-contract-toolkit`` — so a dep pointed at a fork
+    under a different key is still recognised as the toolkit.
+    """
+    for key, base, version, lineno in deps:
+        if key == _TOOLKIT_DEP_KEY or base.rstrip("/").endswith(f"/{_TOOLKIT_DEP_KEY}"):
+            return base, version, lineno
+    return None
+
+
+def _resolved_toolkit_version(root: Path, base: str) -> str | None:
+    """Return the version the lock resolved for *base*, or ``None`` when the lock
+    is absent/unparseable/does not carry the dependency."""
+    deps_path = root / "contract" / "PklProject.deps.json"
+    if not deps_path.is_file():
+        return None
+    try:
+        lock = _parse_deps_lock(deps_path.read_text(encoding="utf-8"))
+    except OSError:
+        return None
+    if not lock:
+        return None
+    return lock.get(base)
+
+
+def _scan_toolkit_dependency(
+    root: Path, present: set[str], baseline: ToolkitBaseline | None
+) -> list[Finding]:
+    """K007/K008 — the app's toolkit dependency must come from the canonical
+    source (K008) and be at/above the latest published version (K007)."""
+    if baseline is None or "contract/PklProject" not in present:
+        return []
+    pkl_project = root / "contract" / "PklProject"
+    try:
+        text = pkl_project.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    toolkit = _find_toolkit_dep(_parse_pkl_project_deps(text))
+    if toolkit is None:
+        return []
+    base, _pin_version, lineno = toolkit
+
+    directives = _parse_pkl_directives(text)
+    rel = "contract/PklProject"
+
+    if base != baseline.canonical_base:
+        suppressed, justification = _make_pkl_finding_suppressed(
+            rule_id="K008", line=lineno, directives=directives
+        )
+        return [
+            Finding(
+                rule_id="K008",
+                file=rel,
+                line=lineno,
+                column=1,
+                message=(
+                    f"app-contract-toolkit is sourced from '{base}' instead of the "
+                    f"canonical '{baseline.canonical_base}'. Point the dependency at "
+                    f"the SDK-published package "
+                    f"'package://{baseline.canonical_base}@{baseline.latest_version}' "
+                    f"and re-run 'pkl project resolve'. "
+                    f"Suppress with: // conformance: ignore[K008] <reason>"
+                ),
+                snippet=None,
+                suppressed=suppressed,
+                suppression_justification=justification,
+            )
+        ]
+
+    # Canonical source: use the resolved lock as the ground truth for the version
+    # actually in use.  A missing/stale lock is K003's concern, so K007 stays quiet
+    # rather than guessing from a broad pin (e.g. ``@0``).
+    resolved = _resolved_toolkit_version(root, base)
+    if resolved is None:
+        return []
+    current = parse_version(resolved)
+    latest = parse_version(baseline.latest_version)
+    if current is None or latest is None or version_reached(latest, current):
+        return []
+
+    suppressed, justification = _make_pkl_finding_suppressed(
+        rule_id="K007", line=lineno, directives=directives
+    )
+    return [
+        Finding(
+            rule_id="K007",
+            file=rel,
+            line=lineno,
+            column=1,
+            message=(
+                f"app-contract-toolkit resolves to '{resolved}' but the latest "
+                f"published version is '{baseline.latest_version}'. Bump the pin in "
+                f"contract/PklProject, run 'pkl project resolve', then regenerate "
+                f"with 'pkl eval -m . contract/app.pkl'. An outdated toolkit is the "
+                f"usual root cause of stale generated artifacts and leftover "
+                f"placeholders (K009). "
+                f"Suppress with: // conformance: ignore[K007] <reason>"
+            ),
+            snippet=None,
+            suppressed=suppressed,
+            suppression_justification=justification,
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # K005 banner / suppression helpers
 # ---------------------------------------------------------------------------
 
@@ -174,22 +351,33 @@ def _has_banner(text: str) -> bool:
     )
 
 
+def _match_hash_directive(line: str, rule_id: str) -> str | None:
+    """Return the justification for a ``# conformance: ignore`` directive on *line*
+    that applies to *rule_id*, or ``None``.
+
+    Searches the whole line rather than anchoring on the first ``#`` so a directive
+    following an earlier ``#`` (e.g. a URL fragment in a YAML value) is still
+    honoured. A directive with no justification text is rejected — it never
+    silently suppresses.
+    """
+    m = _HASH_SUPPRESS_RE.search(line)
+    if m is None:
+        return None
+    justification = m.group(2).strip()
+    if not justification:
+        return None
+    ids = {s.strip() for s in (m.group(1) or "").split(",") if s.strip()}
+    if not ids or rule_id in ids:
+        return justification
+    return None
+
+
 def _hash_suppressed(text: str, rule_id: str) -> tuple[bool, str | None]:
     """Return ``(suppressed, justification)`` for a ``#``-comment directive in the
     file header (K005 anchors on line 1, so only the header can suppress it)."""
     for line in text.splitlines()[: _BANNER_SCAN_LINES + 1]:
-        idx = line.find("#")
-        if idx == -1:
-            continue
-        m = _HASH_SUPPRESS_RE.match(line[idx:])
-        if m is None:
-            continue
-        ids_blob = (m.group(1) or "").strip()
-        justification = m.group(2).strip()
-        if not justification:
-            continue
-        ids = {s.strip() for s in ids_blob.split(",") if s.strip()}
-        if not ids or rule_id in ids:
+        justification = _match_hash_directive(line, rule_id)
+        if justification is not None:
             return True, justification
     return False, None
 
@@ -208,7 +396,11 @@ def _scan_lock_drift(root: Path, present: set[str]) -> list[Finding]:
         text = pkl_project.read_text(encoding="utf-8")
     except OSError:
         return []
-    pins = _parse_pkl_project_pins(text)
+    pins = [
+        (base, version, lineno)
+        for _key, base, version, lineno in _parse_pkl_project_deps(text)
+        if version is not None
+    ]
     if not pins:
         return []
 
@@ -347,7 +539,7 @@ def _scan_banners(root: Path, present: set[str]) -> list[Finding]:
             continue
         try:
             text = (root / rel).read_text(encoding="utf-8")
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
         if _has_banner(text):
             continue
@@ -375,12 +567,127 @@ def _scan_banners(root: Path, present: set[str]) -> list[Finding]:
 
 
 # ---------------------------------------------------------------------------
+# K009 placeholder / K010 E2E scaffolding
+# ---------------------------------------------------------------------------
+
+
+def _line_hash_suppressed(
+    lines: list[str], lineno: int, rule_id: str
+) -> tuple[bool, str | None]:
+    """Return ``(suppressed, justification)`` for a ``#``-comment directive on the
+    finding's own line or the comment-only line directly above it."""
+    for check_line in (lineno, lineno - 1):
+        if check_line < 1 or check_line > len(lines):
+            continue
+        raw = lines[check_line - 1]
+        if check_line == lineno - 1 and raw.lstrip()[:1] != "#":
+            # A trailing inline directive on a content line must not absorb the
+            # finding on the following line.
+            continue
+        justification = _match_hash_directive(raw, rule_id)
+        if justification is not None:
+            return True, justification
+    return False, None
+
+
+def _is_generated_artifact(rel: str) -> bool:
+    """True for a committed ``pkl eval`` output that should never carry a
+    leftover scaffold placeholder — ``atlan.yaml`` / ``app.yaml`` and anything
+    under ``app/generated/``."""
+    return rel in ("atlan.yaml", "app.yaml") or rel.startswith("app/generated/")
+
+
+def _scan_placeholders(root: Path, present: set[str]) -> list[Finding]:
+    """K009 — flag unresolved scaffold placeholder tokens in generated artifacts."""
+    if "contract/app.pkl" not in present:
+        return []
+    findings: list[Finding] = []
+    for rel in sorted(present):
+        if "__pycache__" in rel or not _is_generated_artifact(rel):
+            continue
+        try:
+            text = (root / rel).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            # ``app/generated/`` can hold non-text blobs (e.g. a stray binary or
+            # .DS_Store); skip them rather than crash the whole suite run.
+            continue
+        lines = text.splitlines()
+        for i, line in enumerate(lines, start=1):
+            for m in _SCAFFOLD_PLACEHOLDER_RE.finditer(line):
+                suppressed, justification = _line_hash_suppressed(lines, i, "K009")
+                findings.append(
+                    Finding(
+                        rule_id="K009",
+                        file=rel,
+                        line=i,
+                        column=m.start() + 1,
+                        message=(
+                            f"Generated artifact '{rel}' contains the unresolved "
+                            f"scaffold placeholder '{m.group(0)}' — the current toolkit "
+                            f"renders this to a literal value, so the artifact was "
+                            f"generated by an outdated toolkit or a legacy NativeApp.pkl "
+                            f"base and is wrong as shipped. Upgrade app-contract-toolkit "
+                            f"to the latest version (and migrate to App.pkl if still on "
+                            f"NativeApp.pkl), then regenerate with "
+                            f"'pkl eval -m . contract/app.pkl'. "
+                            f"Suppress with: # conformance: ignore[K009] <reason>"
+                        ),
+                        snippet=None,
+                        suppressed=suppressed,
+                        suppression_justification=justification,
+                    )
+                )
+    return findings
+
+
+def _scan_e2e_scaffolding(root: Path, present: set[str]) -> list[Finding]:
+    """K010 — a single-entrypoint app must ship the generated ``_e2e_base.py``."""
+    if "contract/app.pkl" not in present:
+        return []
+    app_pkl = root / "contract" / "app.pkl"
+    try:
+        text = app_pkl.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    if _ENTRYPOINTS_RE.search(text):
+        # Multi-entrypoint bundle: E2E scaffolding lands per-entrypoint, not at the
+        # single-entrypoint _e2e_base.py path — out of scope for K010.
+        return []
+    if _E2E_BASE_OUTPUT in present:
+        return []
+
+    directives = _parse_pkl_directives(text)
+    anchor = _amends_line(text)
+    suppressed, justification = _make_pkl_finding_suppressed(
+        rule_id="K010", line=anchor, directives=directives
+    )
+    return [
+        Finding(
+            rule_id="K010",
+            file="contract/app.pkl",
+            line=anchor,
+            column=1,
+            message=(
+                f"contract/app.pkl exists but the generated E2E scaffolding "
+                f"'{_E2E_BASE_OUTPUT}' is missing. The toolkit emits it for every "
+                f"single-entrypoint app; regenerate with "
+                f"'pkl eval -m . contract/app.pkl' and commit the result. "
+                f"Suppress with: // conformance: ignore[K010] <reason>"
+            ),
+            snippet=None,
+            suppressed=suppressed,
+            suppression_justification=justification,
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Scan API
 # ---------------------------------------------------------------------------
 
 
 def scan_all(paths: list[Path], root: Path) -> list[Finding]:
-    """Run K003/K004/K005 over the discovered *paths*.
+    """Run the K003–K010 generated-artifact / toolkit rules over *paths*.
 
     ``paths`` is the post-exclusion discovery list; membership gates each rule so
     excluding ``contract/`` disables the whole check for a repo.
@@ -391,10 +698,14 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
             present.add(p.relative_to(root).as_posix())
         except ValueError:
             continue
+    baseline = load_baseline()
     findings: list[Finding] = []
     findings.extend(_scan_lock_drift(root, present))
     findings.extend(_scan_missing_outputs(root, present))
     findings.extend(_scan_banners(root, present))
+    findings.extend(_scan_toolkit_dependency(root, present, baseline))
+    findings.extend(_scan_placeholders(root, present))
+    findings.extend(_scan_e2e_scaffolding(root, present))
     return findings
 
 

--- a/packages/conformance/conformance/suite/checks/legacy_contract/_scan.py
+++ b/packages/conformance/conformance/suite/checks/legacy_contract/_scan.py
@@ -56,8 +56,14 @@ _K002_PROP_RE = re.compile(
 )
 # Same (?:[^"]*/)? anchor as K001: "AppConfig.pkl" and "MyConfig.pkl" must not
 # match — only the exact legacy module names directly after a path separator.
+#
+# Connectors.pkl is deliberately NOT here: unlike Config/Credential/Renderers
+# (Argo-era, dropped by App.pkl), the Connectors registry is still imported
+# explicitly by consumers — App.pkl imports it internally and types `connector`
+# as `Connectors.Type`, but does not re-export the constants, so every current
+# toolkit example still `import`s it. Flagging it is a false positive.
 _K002_IMPORT_RE = re.compile(
-    r'\bimport\s+"(?:[^"]*/)?(?:Config|Connectors|Credential|Renderers)\.pkl"'
+    r'\bimport\s+"(?:[^"]*/)?(?:Config|Credential|Renderers)\.pkl"'
 )
 
 # ---------------------------------------------------------------------------
@@ -248,11 +254,6 @@ def _k002_import_hint(import_str: str) -> str:
             "App.pkl re-exports widget types as typealiases (UIConfig, TextInput, "
             "etc.) — remove this import and replace Config.* references with the "
             "unqualified names."
-        )
-    if "Connectors.pkl" in import_str:
-        return (
-            "App.pkl exposes connector constants as Connectors.* without an "
-            "explicit import — remove this import."
         )
     if "Credential.pkl" in import_str:
         return "Credential.pkl is an Argo-era module not used by App.pkl — remove this import."

--- a/packages/conformance/conformance/suite/rules/contract_toolkit.py
+++ b/packages/conformance/conformance/suite/rules/contract_toolkit.py
@@ -166,8 +166,8 @@ RULES: tuple[RuleDefinition, ...] = (
             "intentionally dropped when App.pkl was designed: flatManifestArgs and "
             "manifestMetadataArgs (App.pkl always emits flat top-level args), "
             "workflowTypeOverride (App.pkl takes a verbatim workflowType), and "
-            "explicit imports of Config.pkl/Connectors.pkl/Credential.pkl/"
-            "Renderers.pkl (App.pkl re-exports what apps need as typealiases).  "
+            "explicit imports of Config.pkl/Credential.pkl/Renderers.pkl "
+            "(Argo-era modules App.pkl no longer uses).  "
             "Their presence in a contract that claims to amend App.pkl (or that "
             "will be migrated to App.pkl) indicates that the migration is "
             "incomplete.  When any of these knobs remain after the amends line is "
@@ -198,12 +198,14 @@ RULES: tuple[RuleDefinition, ...] = (
             "import and switch ``Config.UIConfig`` → ``UIConfig``, "
             "``Config.TextInput`` → ``TextInput``, etc.\n"
             "\n"
-            '* ``import "…Connectors.pkl"`` — App.pkl exposes connector '
-            "constants as ``Connectors.*`` with no import needed; remove the "
-            "explicit import.\n"
-            "\n"
             '* ``import "…Credential.pkl"`` and ``import "…Renderers.pkl"`` '
             "(Argo-era modules) — no longer used by App.pkl; remove both.\n"
+            "\n"
+            'Note: ``import "…Connectors.pkl"`` is **not** flagged — the '
+            "Connectors registry is still imported explicitly by App.pkl "
+            "consumers (App.pkl imports it internally and types ``connector`` as "
+            "``Connectors.Type`` but does not re-export the constants), so the "
+            "import is required, not legacy.\n"
             "\n"
             "**Note:** if the contract also has a K001 finding (still amending a "
             "legacy module), address K001 first — many K002 knobs disappear "
@@ -475,6 +477,205 @@ RULES: tuple[RuleDefinition, ...] = (
         help_uri=(
             "https://github.com/atlanhq/application-sdk/blob/main/"
             "packages/conformance/conformance/docs/rules/contract-toolkit.md#k006"
+        ),
+    ),
+    RuleDefinition(
+        id="K007",
+        scope=RuleScope.APP,
+        name="ToolkitVersionOutdated",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="contract-toolkit",
+        autofixable=False,
+        since="0.12.0",
+        orthogonal_gate="pkl-eval",
+        rationale=(
+            "The app-contract-toolkit ships fixes and new contract capabilities in "
+            "every release; an app pinned to an old version regenerates stale "
+            "artifacts, misses schema changes, and is the usual root cause of "
+            "leftover scaffold placeholders (K009) and legacy-API drift (K002). The "
+            "latest published version is read from the baked-in toolkit baseline "
+            "(data/toolkit_baseline.json), regenerated from the toolkit's own "
+            "PklProject and guarded against drift in CI, so the check stays correct "
+            "offline inside any consumer repo."
+        ),
+        short_description=(
+            "app-contract-toolkit dependency resolves to a version below the latest "
+            "published one — bump and regenerate"
+        ),
+        full_description=(
+            "The ``app-contract-toolkit`` dependency in ``contract/PklProject`` "
+            "resolves (per ``contract/PklProject.deps.json``) to a version older "
+            "than the latest the SDK publishes.\n"
+            "\n"
+            "The check uses the resolved lock as the ground truth for the version "
+            "actually in use; a missing or stale lock is K003's concern, so K007 "
+            "stays quiet in that case rather than guessing from a broad pin.\n"
+            "\n"
+            "**Fix:** bump the ``@<version>`` in ``contract/PklProject`` to the "
+            "latest, run ``pkl project resolve`` to refresh the lock, then "
+            "regenerate with ``pkl eval -m . contract/app.pkl``. On a "
+            "``renovate/**`` branch this happens automatically via renovate-pkl-sync.\n"
+            "\n"
+            "**Suppress** with ``// conformance: ignore[K007] <reason>`` on the "
+            "``uri`` line (or the comment-only line directly above it) when a "
+            "deliberate lag is justified.\n"
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/contract-toolkit.md#k007"
+        ),
+    ),
+    RuleDefinition(
+        id="K008",
+        scope=RuleScope.APP,
+        name="ToolkitSourceNonCanonical",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="contract-toolkit",
+        autofixable=False,
+        since="0.12.0",
+        orthogonal_gate="pkl-eval",
+        rationale=(
+            "Every app must consume the app-contract-toolkit from the single "
+            "SDK-published package so the whole fleet generates from the same "
+            "contract semantics and receives version bumps through the standard "
+            "renovate flow. A dependency pointed at a fork, a local file path, or a "
+            "different host silently diverges — it can pin behavior the SDK no "
+            "longer supports and is invisible to the version floor (K007), which "
+            "only compares against the canonical package. The canonical base URI is "
+            "read from the baked-in toolkit baseline."
+        ),
+        short_description=(
+            "app-contract-toolkit is sourced from a non-canonical base URI (fork / "
+            "local path / wrong host)"
+        ),
+        full_description=(
+            "The ``app-contract-toolkit`` dependency in ``contract/PklProject`` is "
+            "pointed at a base URI other than the canonical SDK-published package "
+            "(``package://atlanhq.github.io/application-sdk/contracts/"
+            "app-contract-toolkit``).\n"
+            "\n"
+            'The dependency is identified by its ``["app-contract-toolkit"]`` '
+            "mapping key (falling back to any URI whose path segment is "
+            "``app-contract-toolkit``), so a fork under the canonical key is still "
+            "caught.\n"
+            "\n"
+            "**Fix:** point the dependency at the canonical package "
+            "``package://atlanhq.github.io/application-sdk/contracts/"
+            "app-contract-toolkit@<latest>`` and run ``pkl project resolve``.\n"
+            "\n"
+            "**Suppress** with ``// conformance: ignore[K008] <reason>`` on the "
+            "``uri`` line (or the comment-only line directly above it).\n"
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/contract-toolkit.md#k008"
+        ),
+    ),
+    RuleDefinition(
+        id="K009",
+        scope=RuleScope.APP,
+        name="UnresolvedScaffoldPlaceholder",
+        tier=EnforcementTier.BLOCK,
+        mechanism=RuleMechanism.STATIC,
+        category="contract-toolkit",
+        autofixable=False,
+        since="0.12.0",
+        orthogonal_gate="pkl-eval",
+        rationale=(
+            "A committed generated artifact that still contains a single-brace "
+            "scaffold token such as {app_name} is shipping template text where a "
+            "rendered value belongs — the current toolkit resolves {app_name} to the "
+            "app's literal name, so a leftover means the artifact was generated by an "
+            "outdated toolkit (or a legacy NativeApp.pkl base) and is objectively "
+            "wrong on the wire, not merely stylistically stale. Because it is never a "
+            "false positive (the {{...}} double-brace runtime tokens are excluded, "
+            "and the one legitimate single-brace token {deployment_name} is not in "
+            "the flagged set), this is a BLOCK-tier rule rather than the usual "
+            "land-as-WARN default: the only correct resolution is to upgrade to the "
+            "latest app-contract-toolkit and regenerate."
+        ),
+        short_description=(
+            "Generated artifact contains an unresolved single-brace scaffold "
+            "placeholder ({app_name}, {name}, …) — upgrade the toolkit and regenerate"
+        ),
+        full_description=(
+            "A committed generated artifact (``atlan.yaml``, ``app.yaml``, or a file "
+            "under ``app/generated/``) contains a single-brace scaffold placeholder "
+            "token — ``{app_name}``, ``{name}``, ``{app-name}``, "
+            "``{entrypoint_name}``, ``{connection_name}``, and related scaffold "
+            "vars.\n"
+            "\n"
+            "These are filled in by ``pkl eval``; a literal leftover means the "
+            "artifact was generated by an outdated toolkit (or a legacy "
+            "``NativeApp.pkl`` base) that never rendered the field. The current "
+            "toolkit resolves ``{app_name}`` to the app's literal name, so this "
+            "artifact is wrong as shipped — hence BLOCK, not WARN.\n"
+            "\n"
+            "Intentional ``{{credential}}`` / ``{{connection}}`` double-brace E2E "
+            "runtime-substitution tokens are excluded, as is the legitimate "
+            "``{deployment_name}`` deploy-time token the current toolkit still emits "
+            "verbatim; none of these are ever flagged.\n"
+            "\n"
+            "**Fix (required):** upgrade ``app-contract-toolkit`` to the latest "
+            "published version (see K007), migrate off any legacy ``NativeApp.pkl`` "
+            "base (see K001), and regenerate with ``pkl eval -m . contract/app.pkl``. "
+            "Never hand-edit the artifact to delete the token.\n"
+            "\n"
+            "**Suppress** with ``# conformance: ignore[K009] <reason>`` on the "
+            "placeholder's line (or the comment-only line directly above it) — "
+            "available for text artifacts; a placeholder in a ``.json`` output has "
+            "no comment syntax to suppress and must be regenerated.\n"
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/contract-toolkit.md#k009"
+        ),
+    ),
+    RuleDefinition(
+        id="K010",
+        scope=RuleScope.APP,
+        name="E2EScaffoldingMissing",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="contract-toolkit",
+        autofixable=False,
+        since="0.12.0",
+        orthogonal_gate="pkl-eval",
+        rationale=(
+            "The toolkit emits app/generated/_e2e_base.py for every "
+            "single-entrypoint app, and the SDK's E2E framework imports it; a "
+            "missing file means the contract was never generated (or the output was "
+            "deleted), so the app's E2E tests cannot resolve their typed base. "
+            "Multi-entrypoint bundles emit E2E scaffolding into per-entrypoint "
+            "subfolders instead, so the rule only applies when the contract "
+            "declares no entrypoints block."
+        ),
+        short_description=(
+            "Single-entrypoint contract/app.pkl exists but generated "
+            "app/generated/_e2e_base.py is missing"
+        ),
+        full_description=(
+            "A single-entrypoint ``contract/app.pkl`` exists but its generated E2E "
+            "scaffolding ``app/generated/_e2e_base.py`` is absent. The toolkit emits "
+            "this module unconditionally for single-entrypoint apps, and "
+            "``application_sdk.testing.e2e`` imports it as the typed E2E base.\n"
+            "\n"
+            "Contracts that declare an ``entrypoints`` block (multi-entrypoint "
+            "bundles) are out of scope — their E2E scaffolding lands in "
+            "per-entrypoint subfolders, not the single-entrypoint path.\n"
+            "\n"
+            "**Fix:** regenerate with ``pkl eval -m . contract/app.pkl`` and commit "
+            "the result.\n"
+            "\n"
+            "**Suppress** with ``// conformance: ignore[K010] <reason>`` on the "
+            "``amends`` line of ``contract/app.pkl`` when the app legitimately ships "
+            "no E2E scaffolding.\n"
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/contract-toolkit.md#k010"
         ),
     ),
 )

--- a/packages/conformance/conformance/tools/generate_toolkit_baseline.py
+++ b/packages/conformance/conformance/tools/generate_toolkit_baseline.py
@@ -1,0 +1,114 @@
+"""Generate the contract-toolkit baseline from the toolkit's PklProject.
+
+Usage
+-----
+Regenerate the committed baseline (normal developer workflow):
+
+    uv run atlan-application-sdk-conformance gen-toolkit-baseline
+
+Check whether the committed baseline is up-to-date (CI gate / drift test):
+
+    uv run atlan-application-sdk-conformance gen-toolkit-baseline --check
+
+Direct invocation:
+
+    python -m conformance.tools.generate_toolkit_baseline [--sdk-root DIR] [--check]
+
+Design
+------
+Reads ``contract-toolkit/src/PklProject`` (the toolkit's own package manifest) and
+records the canonical package base URI + current published version into the
+committed ``data/toolkit_baseline.json``.  Output is deterministic, so ``--check``
+is the forcing function that fails CI when the toolkit is bumped but the baseline
+is not regenerated in the same PR — keeping K007/K008 honest offline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from conformance.suite.checks._toolkit_baseline import (
+    BASELINE_PATH,
+    TOOLKIT_PKLPROJECT_RELPATH,
+    build_baseline,
+    serialize,
+)
+
+
+def _find_sdk_root() -> Path | None:
+    """Locate the repo root containing ``contract-toolkit/src/PklProject``."""
+    starts = [Path.cwd(), Path(__file__).resolve()]
+    for start in starts:
+        for parent in [start, *start.parents]:
+            if parent.joinpath(*TOOLKIT_PKLPROJECT_RELPATH).is_file():
+                return parent
+    return None
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the contract-toolkit baseline from the toolkit PklProject.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--sdk-root",
+        type=Path,
+        default=None,
+        help="Repo root containing contract-toolkit/src/PklProject (default: auto-detected).",
+    )
+    parser.add_argument(
+        "--outfile",
+        type=Path,
+        default=BASELINE_PATH,
+        help=f"Baseline path to write (default: {BASELINE_PATH}).",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify the committed baseline matches generated output (exit 1 if stale).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+
+    sdk_root: Path | None = args.sdk_root or _find_sdk_root()
+    if sdk_root is None or not sdk_root.joinpath(*TOOLKIT_PKLPROJECT_RELPATH).is_file():
+        print(
+            "error: could not locate contract-toolkit/src/PklProject — pass --sdk-root DIR.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    baseline = build_baseline(sdk_root)
+    content = serialize(baseline)
+    outfile: Path = args.outfile
+
+    if args.check:
+        if not outfile.exists():
+            print(f"MISSING: {outfile}", file=sys.stderr)
+            sys.exit(1)
+        if outfile.read_text(encoding="utf-8") != content:
+            print(
+                f"STALE: {outfile}\nRun `uv run atlan-application-sdk-conformance "
+                "gen-toolkit-baseline` to update.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(
+            f"Baseline up-to-date (toolkit {baseline.latest_version} @ "
+            f"{baseline.canonical_base})."
+        )
+        return
+
+    outfile.parent.mkdir(parents=True, exist_ok=True)
+    outfile.write_text(content, encoding="utf-8")
+    print(f"Wrote {outfile} (toolkit {baseline.latest_version}).")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -167,6 +167,11 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
     # K006: manifest-vs-contract field validation — only app repos have a
     # generated app/generated/**/manifest.json DAG to cross-reference against a
     # Python Output contract; the SDK has no such generated artifact (BLDX-1527).
+    # K007/K008: toolkit version floor + source provenance — the app's PklProject
+    # declares the app-contract-toolkit dependency; the SDK *is* the publisher, so
+    # it has no such dependency to grade (BLDX-1479). K009: unresolved scaffold
+    # placeholder in a generated artifact; K010: missing generated E2E scaffolding
+    # — both are app-repo generated-output concerns (BLDX-1479).
     # E020: HTTP-failure-to-empty-return — the harm (publishing a partial crawl as
     # complete) is a connector extract/publish concern; the SDK's matching sites are
     # legitimate best-effort infra (health/metric scrapes), not crawlers (BLDX-1503).
@@ -200,6 +205,10 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
         "K004",
         "K005",
         "K006",
+        "K007",
+        "K008",
+        "K009",
+        "K010",
         "P004",
         "P005",
         "P008",
@@ -442,12 +451,25 @@ def test_catalog_b_series_present() -> None:
 
 
 def test_catalog_k_series_present() -> None:
-    """The K-series contract-toolkit rules are K001/K002 (source) plus the
-    generated-artifact freshness rules K003/K004/K005 (BLDX-1414), plus the
-    manifest-vs-contract field validation rule K006 (BLDX-1527)."""
+    """The K-series contract-toolkit rules are K001/K002 (source), the
+    generated-artifact freshness rules K003/K004/K005 (BLDX-1414), the
+    manifest-vs-contract field validation rule K006 (BLDX-1527), and the toolkit
+    hygiene rules K007–K010 (version floor, source provenance, unresolved
+    placeholder, missing E2E scaffolding) (BLDX-1479)."""
     rules = load_catalog()
     k_ids = {r.id for r in rules if r.id.startswith("K")}
-    expected = {"K001", "K002", "K003", "K004", "K005", "K006"}
+    expected = {
+        "K001",
+        "K002",
+        "K003",
+        "K004",
+        "K005",
+        "K006",
+        "K007",
+        "K008",
+        "K009",
+        "K010",
+    }
     missing = expected - k_ids
     assert not missing, f"Missing K-series rules: {missing}"
     extra = k_ids - expected

--- a/packages/conformance/tests/test_deprecation.py
+++ b/packages/conformance/tests/test_deprecation.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import ast
 
 from conformance.suite.checks._ast_common import _parse_directives
+from conformance.suite.checks._version import parse_version, version_reached
 from conformance.suite.checks.deprecation._authoring import scan_authoring
 from conformance.suite.checks.deprecation._consumer import scan_consumer
 from conformance.suite.checks.deprecation._extractor import (
@@ -22,7 +23,6 @@ from conformance.suite.checks.deprecation._manifest import (
     Manifest,
     load_manifest,
 )
-from conformance.suite.checks.deprecation._version import parse_version, version_reached
 
 
 def _tree_and_directives(src: str) -> tuple[ast.Module, dict]:

--- a/packages/conformance/tests/test_generated_freshness.py
+++ b/packages/conformance/tests/test_generated_freshness.py
@@ -7,9 +7,11 @@ paths, and asserts on the returned findings by ``rule_id``.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from textwrap import dedent
 
+from conformance.suite.checks._toolkit_baseline import load_baseline
 from conformance.suite.checks.generated_freshness import discover, scan_all
 from conformance.suite.rules import get_rule
 from conformance.suite.schema.disposition import EnforcementTier, RuleScope
@@ -18,27 +20,45 @@ from conformance.suite.schema.disposition import EnforcementTier, RuleScope
 # Fixtures / helpers
 # ---------------------------------------------------------------------------
 
-_PKL_PROJECT = dedent("""\
-    amends "pkl:Project"
-    dependencies {
-      ["app-contract-toolkit"] {
-        uri = "package://atlanhq.github.io/application-sdk/contracts/app-contract-toolkit@0.16.0"
-      }
-    }
-""")
+# The toolkit version floor (K007) and source check (K008) compare against the
+# committed baseline, so the clean fixtures track it rather than a literal — that
+# keeps this suite green across toolkit bumps (a bump regenerates the baseline).
+_BASELINE = load_baseline()
+assert _BASELINE is not None, "data/toolkit_baseline.json must be committed"
+_LATEST = _BASELINE.latest_version
+_CANONICAL = _BASELINE.canonical_base
+# Comfortably older than any real toolkit release, for outdated/drift cases.
+_OLDER = "0.0.1"
 
-_DEPS_JSON = dedent("""\
-    {
-      "schemaVersion": 1,
-      "resolvedDependencies": {
-        "package://atlanhq.github.io/application-sdk/contracts/app-contract-toolkit@0": {
-          "type": "remote",
-          "uri": "projectpackage://atlanhq.github.io/application-sdk/contracts/app-contract-toolkit@0.16.0",
-          "checksums": {"sha256": "deadbeef"}
+
+def _pkl_project(version: str = _LATEST, base: str = _CANONICAL) -> str:
+    return (
+        'amends "pkl:Project"\n'
+        "dependencies {\n"
+        '  ["app-contract-toolkit"] {\n'
+        f'    uri = "package://{base}@{version}"\n'
+        "  }\n"
+        "}\n"
+    )
+
+
+def _deps_json(
+    resolved: str = _LATEST, base: str = _CANONICAL, present: bool = True
+) -> str:
+    deps: dict[str, object] = {}
+    if present:
+        deps[f"package://{base}@0"] = {
+            "type": "remote",
+            "uri": f"projectpackage://{base}@{resolved}",
+            "checksums": {"sha256": "deadbeef"},
         }
-      }
-    }
-""")
+    return (
+        json.dumps({"schemaVersion": 1, "resolvedDependencies": deps}, indent=2) + "\n"
+    )
+
+
+_PKL_PROJECT = _pkl_project()
+_DEPS_JSON = _deps_json()
 
 _APP_PKL = dedent("""\
     amends "@app-contract-toolkit/App.pkl"
@@ -61,6 +81,7 @@ def _clean_files() -> dict[str, str]:
         "atlan.yaml": _BANNER + "name: demo\n",
         "app/generated/manifest.json": "{}\n",
         "app/generated/_input.py": _BANNER + "x = 1\n",
+        "app/generated/_e2e_base.py": _BANNER + "class BaseE2E:\n    pass\n",
         "app/generated/__init__.py": "",
     }
 
@@ -101,7 +122,8 @@ def test_no_contract_dir_no_findings(tmp_path: Path) -> None:
 
 def test_k003_stale_lock(tmp_path: Path) -> None:
     files = _clean_files()
-    files["contract/PklProject.deps.json"] = _DEPS_JSON.replace("@0.16.0", "@0.15.0")
+    # Pin at latest, lock resolves something else -> pin-vs-lock drift.
+    files["contract/PklProject.deps.json"] = _deps_json(resolved=_OLDER)
     findings = [f for f in _scan(tmp_path, files) if f.rule_id == "K003"]
     assert len(findings) == 1
     assert findings[0].file == "contract/PklProject"
@@ -116,21 +138,21 @@ def test_k003_missing_lock(tmp_path: Path) -> None:
 
 def test_k003_dependency_absent_from_lock(tmp_path: Path) -> None:
     files = _clean_files()
-    files["contract/PklProject.deps.json"] = '{"resolvedDependencies": {}}'
+    files["contract/PklProject.deps.json"] = _deps_json(present=False)
     assert _ids([f for f in _scan(tmp_path, files) if f.rule_id == "K003"]) == ["K003"]
 
 
 def test_k003_broad_pin_satisfied_no_finding(tmp_path: Path) -> None:
     """A broad pin (@0) is satisfied by any resolved 0.y.z — not drift."""
     files = _clean_files()
-    files["contract/PklProject"] = _PKL_PROJECT.replace("@0.16.0", "@0")
+    files["contract/PklProject"] = _pkl_project(version="0")
     assert [f for f in _scan(tmp_path, files) if f.rule_id == "K003"] == []
 
 
 def test_k003_suppressed_via_pkl_directive(tmp_path: Path) -> None:
     files = _clean_files()
-    files["contract/PklProject.deps.json"] = _DEPS_JSON.replace("@0.16.0", "@0.15.0")
-    files["contract/PklProject"] = _PKL_PROJECT.replace(
+    files["contract/PklProject.deps.json"] = _deps_json(resolved=_OLDER)
+    files["contract/PklProject"] = _pkl_project().replace(
         "    uri =", "    // conformance: ignore[K003] phased bump\n    uri ="
     )
     findings = [f for f in _scan(tmp_path, files) if f.rule_id == "K003"]
@@ -252,13 +274,241 @@ def test_k005_not_fired_without_contract(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# K007 — toolkit version outdated
+# ---------------------------------------------------------------------------
+
+
+def test_k007_outdated_toolkit(tmp_path: Path) -> None:
+    files = _clean_files()
+    files["contract/PklProject"] = _pkl_project(version=_OLDER)
+    files["contract/PklProject.deps.json"] = _deps_json(resolved=_OLDER)
+    findings = [f for f in _scan(tmp_path, files) if f.rule_id == "K007"]
+    assert len(findings) == 1
+    assert findings[0].file == "contract/PklProject"
+    assert not findings[0].suppressed
+
+
+def test_k007_latest_no_finding(tmp_path: Path) -> None:
+    assert [f for f in _scan(tmp_path, _clean_files()) if f.rule_id == "K007"] == []
+
+
+def test_k007_ahead_no_finding(tmp_path: Path) -> None:
+    """An app on a newer toolkit than the recorded baseline is not flagged."""
+    files = _clean_files()
+    files["contract/PklProject.deps.json"] = _deps_json(resolved="999.0.0")
+    assert [f for f in _scan(tmp_path, files) if f.rule_id == "K007"] == []
+
+
+def test_k007_no_lock_defers_to_k003(tmp_path: Path) -> None:
+    """Without a resolved lock K007 stays quiet — the missing lock is K003's job."""
+    files = _clean_files()
+    files["contract/PklProject"] = _pkl_project(version=_OLDER)
+    del files["contract/PklProject.deps.json"]
+    assert [f for f in _scan(tmp_path, files) if f.rule_id == "K007"] == []
+
+
+def test_k007_suppressed(tmp_path: Path) -> None:
+    files = _clean_files()
+    files["contract/PklProject.deps.json"] = _deps_json(resolved=_OLDER)
+    files["contract/PklProject"] = _pkl_project(version=_OLDER).replace(
+        "    uri =", "    // conformance: ignore[K007] pinned intentionally\n    uri ="
+    )
+    findings = [f for f in _scan(tmp_path, files) if f.rule_id == "K007"]
+    assert len(findings) == 1
+    assert findings[0].suppressed
+    assert findings[0].suppression_justification == "pinned intentionally"
+
+
+# ---------------------------------------------------------------------------
+# K008 — non-canonical toolkit source
+# ---------------------------------------------------------------------------
+
+
+def test_k008_noncanonical_source(tmp_path: Path) -> None:
+    files = _clean_files()
+    files["contract/PklProject"] = _pkl_project(
+        base="github.com/someone/fork/app-contract-toolkit"
+    )
+    findings = [f for f in _scan(tmp_path, files) if f.rule_id == "K008"]
+    assert len(findings) == 1
+    assert findings[0].file == "contract/PklProject"
+
+
+def test_k008_noncanonical_suppresses_version_check(tmp_path: Path) -> None:
+    """A non-canonical source reports K008 only — the version floor is moot."""
+    files = _clean_files()
+    files["contract/PklProject"] = _pkl_project(
+        version=_OLDER, base="example.com/fork/app-contract-toolkit"
+    )
+    ids = _ids([f for f in _scan(tmp_path, files) if f.rule_id in ("K007", "K008")])
+    assert ids == ["K008"]
+
+
+def test_k008_canonical_no_finding(tmp_path: Path) -> None:
+    assert [f for f in _scan(tmp_path, _clean_files()) if f.rule_id == "K008"] == []
+
+
+def test_k008_suppressed(tmp_path: Path) -> None:
+    files = _clean_files()
+    files["contract/PklProject"] = _pkl_project(
+        base="example.com/fork/app-contract-toolkit"
+    ).replace("    uri =", "    // conformance: ignore[K008] vendored fork\n    uri =")
+    findings = [f for f in _scan(tmp_path, files) if f.rule_id == "K008"]
+    assert len(findings) == 1
+    assert findings[0].suppressed
+    assert findings[0].suppression_justification == "vendored fork"
+
+
+# ---------------------------------------------------------------------------
+# K009 — unresolved scaffold placeholder
+# ---------------------------------------------------------------------------
+
+
+def test_k009_placeholder_in_yaml(tmp_path: Path) -> None:
+    files = _clean_files()
+    files["atlan.yaml"] = _BANNER + "app_id: {app_name}\n"
+    findings = [f for f in _scan(tmp_path, files) if f.rule_id == "K009"]
+    assert len(findings) == 1
+    assert findings[0].file == "atlan.yaml"
+
+
+def test_k009_placeholder_in_json(tmp_path: Path) -> None:
+    files = _clean_files()
+    files["app/generated/manifest.json"] = '{"conn": "{connection_name}"}\n'
+    findings = [f for f in _scan(tmp_path, files) if f.rule_id == "K009"]
+    assert len(findings) == 1
+    assert findings[0].file == "app/generated/manifest.json"
+
+
+def test_k009_double_brace_runtime_token_excluded(tmp_path: Path) -> None:
+    """{{...}} E2E runtime-substitution tokens are intentional — never flagged."""
+    files = _clean_files()
+    files["app/generated/manifest.json"] = (
+        '{"cred": "{{credential}}", "name": "{{name}}"}\n'
+    )
+    assert [f for f in _scan(tmp_path, files) if f.rule_id == "K009"] == []
+
+
+def test_k009_deployment_name_token_is_legitimate(tmp_path: Path) -> None:
+    """{deployment_name} is a deploy-time token the current toolkit still emits
+    verbatim into every manifest task_queue — never a K009 leftover. Modeled on a
+    real stale-toolkit manifest: {app_name} IS flagged, {deployment_name} is not."""
+    files = _clean_files()
+    files["app/generated/manifest.json"] = (
+        "{\n"
+        '  "app_name": "{app_name}",\n'
+        '  "task_queue": "atlan-glue-{deployment_name}",\n'
+        '  "args": {"connection": "{{connection}}"}\n'
+        "}\n"
+    )
+    findings = [f for f in _scan(tmp_path, files) if f.rule_id == "K009"]
+    assert len(findings) == 1
+    assert findings[0].line == 2  # only the {app_name} line
+
+
+def test_k009_suppressed_in_yaml(tmp_path: Path) -> None:
+    files = _clean_files()
+    files["atlan.yaml"] = (
+        _BANNER
+        + "# conformance: ignore[K009] legacy placeholder, migration tracked\n"
+        + "app_id: {app_name}\n"
+    )
+    findings = [f for f in _scan(tmp_path, files) if f.rule_id == "K009"]
+    assert len(findings) == 1
+    assert findings[0].suppressed
+    assert (
+        findings[0].suppression_justification == "legacy placeholder, migration tracked"
+    )
+
+
+def test_k009_clean_no_finding(tmp_path: Path) -> None:
+    assert [f for f in _scan(tmp_path, _clean_files()) if f.rule_id == "K009"] == []
+
+
+def test_k009_non_utf8_artifact_does_not_crash(tmp_path: Path) -> None:
+    """A non-UTF-8 blob under app/generated/ is skipped, never crashes the run."""
+    for rel, content in _clean_files().items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    (tmp_path / "app/generated/logo.bin").write_bytes(b"\xff\xfe\x00{app_name}")
+    findings = scan_all(discover(tmp_path), tmp_path)
+    assert [f for f in findings if f.rule_id == "K009"] == []
+
+
+def test_k009_suppressed_after_earlier_hash(tmp_path: Path) -> None:
+    """A directive after an earlier # (e.g. a URL fragment) still suppresses."""
+    files = _clean_files()
+    files["atlan.yaml"] = (
+        _BANNER
+        + 'app_id: "{app_name}#frag"  # conformance: ignore[K009] migration tracked\n'
+    )
+    findings = [f for f in _scan(tmp_path, files) if f.rule_id == "K009"]
+    assert len(findings) == 1
+    assert findings[0].suppressed
+    assert findings[0].suppression_justification == "migration tracked"
+
+
+# ---------------------------------------------------------------------------
+# K010 — missing E2E scaffolding
+# ---------------------------------------------------------------------------
+
+
+def test_k010_missing_e2e_base(tmp_path: Path) -> None:
+    files = _clean_files()
+    del files["app/generated/_e2e_base.py"]
+    findings = [f for f in _scan(tmp_path, files) if f.rule_id == "K010"]
+    assert len(findings) == 1
+    assert findings[0].file == "contract/app.pkl"
+
+
+def test_k010_present_no_finding(tmp_path: Path) -> None:
+    assert [f for f in _scan(tmp_path, _clean_files()) if f.rule_id == "K010"] == []
+
+
+def test_k010_multi_entrypoint_bundle_skipped(tmp_path: Path) -> None:
+    """A bundle (entrypoints block) emits E2E scaffolding per-entrypoint — no K010."""
+    files = _clean_files()
+    del files["app/generated/_e2e_base.py"]
+    files["contract/app.pkl"] = (
+        'amends "@app-contract-toolkit/App.pkl"\n\n'
+        'name = "demo"\n\n'
+        "entrypoints {\n"
+        '  ["crawler"] { name = "crawler" }\n'
+        "}\n"
+    )
+    assert [f for f in _scan(tmp_path, files) if f.rule_id == "K010"] == []
+
+
+def test_k010_suppressed(tmp_path: Path) -> None:
+    files = _clean_files()
+    del files["app/generated/_e2e_base.py"]
+    files["contract/app.pkl"] = (
+        "// conformance: ignore[K010] utility app ships no e2e\n" + _APP_PKL
+    )
+    findings = [f for f in _scan(tmp_path, files) if f.rule_id == "K010"]
+    assert len(findings) == 1
+    assert findings[0].suppressed
+
+
+# ---------------------------------------------------------------------------
 # Rule metadata
 # ---------------------------------------------------------------------------
 
 
 def test_rule_metadata_app_scoped_warn() -> None:
-    for rid in ("K003", "K004", "K005"):
+    for rid in ("K003", "K004", "K005", "K007", "K008", "K010"):
         rule = get_rule(rid)
         assert rule.scope == RuleScope.APP
         assert rule.tier == EnforcementTier.WARN
         assert rule.rationale, f"{rid} must have a non-empty rationale"
+
+
+def test_k009_is_block_tier() -> None:
+    """K009 is the one BLOCK-tier K-rule: an unresolved {app_name} ships a wrong
+    artifact and is never a false positive, so it hard-fails the gate rather than
+    landing as WARN."""
+    rule = get_rule("K009")
+    assert rule.scope == RuleScope.APP
+    assert rule.tier == EnforcementTier.BLOCK
+    assert rule.rationale

--- a/packages/conformance/tests/test_legacy_contract.py
+++ b/packages/conformance/tests/test_legacy_contract.py
@@ -283,13 +283,18 @@ def test_k002_config_import(tmp_path: Path) -> None:
     assert "re-exports widget types" in k002[0].message
 
 
-def test_k002_connectors_import(tmp_path: Path) -> None:
-    """K002 fires for ``import "…Connectors.pkl"``."""
+def test_k002_connectors_import_is_legitimate(tmp_path: Path) -> None:
+    """K002 must NOT fire for ``import "…Connectors.pkl"``.
+
+    Unlike Config/Credential/Renderers, the Connectors registry is still imported
+    explicitly by App.pkl consumers (App.pkl does not re-export its constants),
+    so flagging it would be a false positive — verified against every current
+    toolkit example, which imports it and uses ``Connectors.*``.
+    """
     content = 'amends "@app-contract-toolkit/App.pkl"\nimport "@app-contract-toolkit/Connectors.pkl"\n'
     findings = _scan_all(tmp_path, {"contract/app.pkl": content})
     k002 = [f for f in findings if f.rule_id == "K002"]
-    assert len(k002) == 1
-    assert "Connectors.pkl" in k002[0].message
+    assert k002 == [], f"Unexpected K002 firing on a legitimate import: {k002}"
 
 
 def test_k002_credential_import(tmp_path: Path) -> None:
@@ -369,8 +374,9 @@ def test_k001_and_k002_together(tmp_path: Path) -> None:
     k001 = [f for f in findings if f.rule_id == "K001"]
     k002 = [f for f in findings if f.rule_id == "K002"]
     assert len(k001) == 1
-    # flatManifestArgs + workflowTypeOverride + Config.pkl import + Connectors.pkl import
-    assert len(k002) == 4
+    # flatManifestArgs + workflowTypeOverride + Config.pkl import (Connectors.pkl
+    # is a legitimate import and must NOT fire).
+    assert len(k002) == 3
     # All unsuppressed
     assert all(not f.suppressed for f in k001 + k002)
 

--- a/packages/conformance/tests/test_toolkit_baseline_drift.py
+++ b/packages/conformance/tests/test_toolkit_baseline_drift.py
@@ -1,0 +1,64 @@
+"""Drift guard for the contract-toolkit baseline — the forcing function for K007/K008.
+
+The committed ``conformance/data/toolkit_baseline.json`` is what lets K007 (version
+floor) and K008 (source provenance) run offline inside a consumer app repo, which
+never has the SDK's ``contract-toolkit/src/PklProject`` on disk. For that to mean
+anything the committed file must always equal a fresh read of the toolkit source —
+otherwise the fleet would be graded against a stale "latest version".
+
+This test makes a toolkit version/baseUri bump fail CI until the baseline is
+regenerated in the same PR:
+
+    uv run atlan-application-sdk-conformance gen-toolkit-baseline
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from conformance.suite.checks._toolkit_baseline import (
+    BASELINE_PATH,
+    TOOLKIT_PKLPROJECT_RELPATH,
+    build_baseline,
+    load_baseline,
+    serialize,
+)
+
+
+def _find_sdk_root() -> Path | None:
+    """Locate the repo root containing contract-toolkit/src/PklProject."""
+    for parent in Path(__file__).resolve().parents:
+        if parent.joinpath(*TOOLKIT_PKLPROJECT_RELPATH).is_file():
+            return parent
+    return None
+
+
+def test_baseline_is_committed() -> None:
+    """The baseline file exists, parses, and carries both fields."""
+    assert BASELINE_PATH.is_file(), (
+        f"{BASELINE_PATH} is missing — run "
+        "`uv run atlan-application-sdk-conformance gen-toolkit-baseline`."
+    )
+    baseline = load_baseline()
+    assert baseline is not None
+    assert baseline.canonical_base
+    assert baseline.latest_version
+
+
+def test_committed_baseline_matches_fresh_read() -> None:
+    """The committed baseline equals a fresh read of contract-toolkit/src/PklProject.
+
+    If this fails, the toolkit's version or baseUri changed but the baseline was
+    not regenerated. Run ``gen-toolkit-baseline`` and commit the result.
+    """
+    sdk_root = _find_sdk_root()
+    if sdk_root is None:
+        pytest.skip("contract-toolkit/src/PklProject not found alongside the package")
+
+    fresh = build_baseline(sdk_root)
+    on_disk = BASELINE_PATH.read_text(encoding="utf-8")
+    assert on_disk == serialize(fresh), (
+        "toolkit_baseline.json is stale — regenerate with "
+        "`uv run atlan-application-sdk-conformance gen-toolkit-baseline` and commit it."
+    )


### PR DESCRIPTION
### Changelog

TL;DR: four new K-series conformance rules that catch consumer apps drifting on app-contract-toolkit usage, plus a fix for a pre-existing K002 false positive.

- **K007 ToolkitVersionOutdated** (WARN) — the app's `app-contract-toolkit` resolves (per the lock) below the latest published version.
- **K008 ToolkitSourceNonCanonical** (WARN) — the toolkit is sourced from a non-canonical base URI (fork / local path / wrong host).
- **K009 UnresolvedScaffoldPlaceholder** (BLOCK) — a single-brace scaffold token like `{app_name}` is left in a generated artifact. The current toolkit renders these to literals, so a leftover means the artifact was generated by an outdated toolkit and is wrong as shipped. Excludes `{{...}}` runtime tokens and the legitimate `{deployment_name}` deploy-time token. Hard-fails the gate; the only fix is to upgrade the toolkit and regenerate.
- **K010 E2EScaffoldingMissing** (WARN) — a single-entrypoint app is missing the generated `app/generated/_e2e_base.py`.
- K007/K008 read the canonical base + latest version from a baked-in `data/toolkit_baseline.json`, generated from the toolkit's own PklProject and drift-guarded in CI (`gen-toolkit-baseline --check`) — the SDK source isn't present in a consumer repo and the suite is offline/deterministic.
- **Fix K002 false positive** — it flagged `import "…Connectors.pkl"` as a legacy import, but the Connectors registry is still imported explicitly by App.pkl consumers (App.pkl imports it internally but does not re-export the constants). Removed it from the legacy-import set; Config/Credential/Renderers still fire.
- Added paired remediation Fix Prescriptions for K007–K010 so `/remediate` can act on them.
- Review fixes rolled in: K005/K009 no longer crash the run on a non-UTF-8 file under `app/generated/`; promoted the shared version comparator out of the deprecation package; consolidated the duplicated PklProject parsing and hash-directive matching.

### Additional context (e.g. screenshots, logs, links)

- Linear: [CNCT-58](https://linear.app/atlan-epd/issue/CNCT-58/conformance-contract-toolkit-hygiene-rules-k007-k010-k002-connectors)
- Validated against `atlan-glue-app` (toolkit pinned 0.11.0): fires K007 ×1, K009 ×2 (`{app_name}` in `manifest.json`), K010 ×1 as predicted; K002 no longer false-fires; K009 hard-fails the gate (exit 1).
- Note: K009 lands at BLOCK, so any consumer app currently shipping `{app_name}` in a generated artifact will fail CI on its next push until the toolkit is bumped and artifacts regenerated. This is the intended forcing function.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.
