### PR TITLE
fix(transformers): accept pandas DataFrame in transform_metadata

### DIFF
--- a/application_sdk/transformers/__init__.py
+++ b/application_sdk/transformers/__init__.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 from application_sdk.transformers.errors import TransformerNotImplementedError
 
 if TYPE_CHECKING:
+    import pandas as pd
     import pyarrow as pa
 
 warnings.warn(
@@ -54,7 +55,7 @@ class TransformerInterface(ABC):
     def transform_metadata(
         self,
         typename: str,
-        dataframe: "pa.Table | list[dict[str, Any]]",
+        dataframe: "pa.Table | pd.DataFrame | list[dict[str, Any]]",
         workflow_id: str,
         workflow_run_id: str,
         entity_class_definitions: dict[str, type[Any]] | None = None,

--- a/application_sdk/transformers/atlas/__init__.py
+++ b/application_sdk/transformers/atlas/__init__.py
@@ -130,11 +130,16 @@ class AtlasTransformer(TransformerInterface):
         if isinstance(dataframe, list):
             rows: list[dict[str, Any]] = dataframe
         else:
-            import pandas as pd  # noqa: PLC0415 — optional dep: pandas
+            import sys  # noqa: PLC0415
 
-            if isinstance(dataframe, pd.DataFrame):
-                # Readers (e.g. ParquetFileReader) return pandas; bridge it to
-                # the pyarrow Table this transformer operates on.
+            # Readers (e.g. ParquetFileReader) return pandas; bridge it to the
+            # pyarrow Table this transformer operates on. Producing a pandas
+            # DataFrame in the first place requires pandas to already be
+            # installed and imported, so probing sys.modules here (rather
+            # than importing pandas unconditionally) never forces the
+            # optional dependency on callers passing a pa.Table input.
+            pd = sys.modules.get("pandas")
+            if pd is not None and isinstance(dataframe, pd.DataFrame):
                 import pyarrow as pa  # noqa: PLC0415 — optional dep: pyarrow
 
                 dataframe = pa.Table.from_pandas(dataframe, preserve_index=False)

--- a/application_sdk/transformers/atlas/__init__.py
+++ b/application_sdk/transformers/atlas/__init__.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 from pyatlan.model.enums import AtlanConnectorType, EntityStatus
 
 if TYPE_CHECKING:
+    import pandas as pd
     import pyarrow as pa
 
 from application_sdk.observability.logger_adaptor import get_logger
@@ -113,7 +114,7 @@ class AtlasTransformer(TransformerInterface):
     def transform_metadata(
         self,
         typename: str,
-        dataframe: pa.Table | list[dict[str, Any]],
+        dataframe: pa.Table | pd.DataFrame | list[dict[str, Any]],
         workflow_id: str,
         workflow_run_id: str,
         entity_class_definitions: dict[str, type[Any]] | None = None,
@@ -126,9 +127,18 @@ class AtlasTransformer(TransformerInterface):
         connection_qualified_name = kwargs.get("connection", {}).get(
             "connection_qualified_name", None
         )
-        rows: list[dict[str, Any]] = (
-            dataframe if isinstance(dataframe, list) else dataframe.to_pylist()
-        )
+        if isinstance(dataframe, list):
+            rows: list[dict[str, Any]] = dataframe
+        else:
+            import pandas as pd  # noqa: PLC0415 — optional dep: pandas
+
+            if isinstance(dataframe, pd.DataFrame):
+                # Readers (e.g. ParquetFileReader) return pandas; bridge it to
+                # the pyarrow Table this transformer operates on.
+                import pyarrow as pa  # noqa: PLC0415 — optional dep: pyarrow
+
+                dataframe = pa.Table.from_pandas(dataframe, preserve_index=False)
+            rows = dataframe.to_pylist()
         transformed_metadata_list = []
         for row in rows:
             try:

--- a/application_sdk/transformers/query/__init__.py
+++ b/application_sdk/transformers/query/__init__.py
@@ -9,6 +9,7 @@ import yaml
 from pyatlan.model.enums import AtlanConnectorType
 
 if TYPE_CHECKING:
+    import pandas as pd
     import pyarrow as pa
 
 from application_sdk.observability.logger_adaptor import get_logger
@@ -315,17 +316,22 @@ class QueryBasedTransformer(TransformerInterface):
     def transform_metadata(  # type: ignore
         self,
         typename: str,
-        dataframe: pa.Table | list[dict[str, Any]],
+        dataframe: pa.Table | pd.DataFrame | list[dict[str, Any]],
         workflow_id: str,
         workflow_run_id: str,
         entity_class_definitions: dict[str, type[Any]] | None = None,
         **kwargs: Any,
     ) -> list[dict[str, Any]] | None:
         """Transform records using SQL executed through DuckDB"""
+        import pandas as pd  # noqa: PLC0415 — optional dep: pandas
         import pyarrow as pa  # noqa: PLC0415 — optional dep: pyarrow
 
         if isinstance(dataframe, list):
             dataframe = pa.Table.from_pylist(dataframe) if dataframe else None
+        elif isinstance(dataframe, pd.DataFrame):
+            # Readers (e.g. ParquetFileReader) return pandas; bridge it to the
+            # pyarrow Table this transformer operates on.
+            dataframe = pa.Table.from_pandas(dataframe, preserve_index=False)
         if dataframe is None or len(dataframe) == 0:
             return None
 

--- a/application_sdk/transformers/query/__init__.py
+++ b/application_sdk/transformers/query/__init__.py
@@ -323,14 +323,21 @@ class QueryBasedTransformer(TransformerInterface):
         **kwargs: Any,
     ) -> list[dict[str, Any]] | None:
         """Transform records using SQL executed through DuckDB"""
-        import pandas as pd  # noqa: PLC0415 — optional dep: pandas
+        import sys  # noqa: PLC0415
+
         import pyarrow as pa  # noqa: PLC0415 — optional dep: pyarrow
+
+        # Readers (e.g. ParquetFileReader) return pandas; bridge it to the
+        # pyarrow Table this transformer operates on. Producing a pandas
+        # DataFrame in the first place requires pandas to already be
+        # installed and imported, so probing sys.modules here (rather than
+        # importing pandas unconditionally) never forces the optional
+        # dependency on callers passing a pa.Table or list[dict] input.
+        pd = sys.modules.get("pandas")
 
         if isinstance(dataframe, list):
             dataframe = pa.Table.from_pylist(dataframe) if dataframe else None
-        elif isinstance(dataframe, pd.DataFrame):
-            # Readers (e.g. ParquetFileReader) return pandas; bridge it to the
-            # pyarrow Table this transformer operates on.
+        elif pd is not None and isinstance(dataframe, pd.DataFrame):
             dataframe = pa.Table.from_pandas(dataframe, preserve_index=False)
         if dataframe is None or len(dataframe) == 0:
             return None

--- a/tests/unit/transformers/test_reader_transformer_integration.py
+++ b/tests/unit/transformers/test_reader_transformer_integration.py
@@ -1,0 +1,116 @@
+"""Regression tests for the ParquetFileReader -> transformer seam.
+
+`ParquetFileReader.read()` returns a pandas DataFrame (see
+`tests/unit/storage/formats/readers/test_parquet_reader.py`), but historically
+neither `QueryBasedTransformer.transform_metadata` nor
+`AtlasTransformer.transform_metadata` accepted anything but a `pyarrow.Table`
+or `list[dict]`. Feeding a reader's real output straight into a transformer —
+the standard reader -> transformer usage pattern — raised an ``AttributeError``.
+
+This file drives that exact path end to end (a real parquet file on disk,
+read through the real reader, fed into the real transformer) rather than
+mocking either side, since unit tests on each side in isolation never
+exercised the seam between them.
+"""
+
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from application_sdk.common.types import DataframeType
+from application_sdk.storage.formats.parquet import ParquetFileReader
+from application_sdk.transformers.atlas import AtlasTransformer
+from application_sdk.transformers.query import QueryBasedTransformer
+
+
+def _make_parquet_file(tmp_path: Path) -> str:
+    table = pa.Table.from_pydict(
+        {
+            "table_name": ["table1", "table2"],
+            "table_catalog": ["db1", "db2"],
+            "table_schema": ["schema1", "schema2"],
+        }
+    )
+    path = tmp_path / "data.parquet"
+    pq.write_table(table, path)
+    return str(path)
+
+
+async def _read_via_reader(tmp_path: Path):
+    """Read a parquet file the same way a real activity would."""
+    parquet_file = _make_parquet_file(tmp_path)
+
+    async def dummy_download(path, file_extension, file_names=None):
+        return [parquet_file]
+
+    with patch(
+        "application_sdk.storage.formats.parquet._download_files",
+        side_effect=dummy_download,
+    ):
+        reader = ParquetFileReader(
+            path=str(tmp_path), dataframe_type=DataframeType.pandas
+        )
+        return await reader.read()
+
+
+@pytest.mark.asyncio
+async def test_reader_output_feeds_atlas_transformer(tmp_path: Path) -> None:
+    """AtlasTransformer.transform_metadata must accept a real reader's output."""
+    dataframe = await _read_via_reader(tmp_path)
+
+    transformer = AtlasTransformer(
+        connector_name="test_connector", tenant_id="test_tenant"
+    )
+
+    # Must not raise AttributeError('DataFrame' object has no attribute 'to_pylist').
+    result = transformer.transform_metadata(
+        "TABLE",
+        dataframe,
+        "test_workflow",
+        "test_run",
+        connection={
+            "connection_qualified_name": "default/postgres/123",
+            "connection_name": "test_conn",
+        },
+    )
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_reader_output_feeds_query_based_transformer(tmp_path: Path) -> None:
+    """QueryBasedTransformer.transform_metadata must accept a real reader's output."""
+    dataframe = await _read_via_reader(tmp_path)
+
+    transformer = QueryBasedTransformer(
+        connector_name="test_connector", tenant_id="test_tenant"
+    )
+    transformer.entity_class_definitions = {"TABLE": "dummy_path.yaml"}
+
+    sql_template = {
+        "columns": {
+            "attributes": {
+                "name": {"source_query": "table_name"},
+            }
+        }
+    }
+
+    with (
+        patch("builtins.open", mock_open()),
+        patch("yaml.safe_load", return_value=sql_template),
+    ):
+        # Must not raise AttributeError('DataFrame' object has no attribute 'schema').
+        result = transformer.transform_metadata(
+            "TABLE",
+            dataframe,
+            "test_workflow",
+            "test_run",
+            connection_qualified_name="default/postgres/123",
+            connection_name="test_conn",
+        )
+
+    assert result is not None
+    assert len(result) == 2
+    assert {row["attributes"]["name"] for row in result} == {"table1", "table2"}


### PR DESCRIPTION
## Summary
- `ParquetFileReader.read()` returns a pandas DataFrame, but `QueryBasedTransformer` and `AtlasTransformer` only accepted a `pyarrow.Table` or `list[dict]`. The standard reader -> transformer pattern raised `AttributeError` because that seam was never covered by either side's unit tests (reader tests only assert pandas output in isolation, transformer tests only ever construct `pa.Table`/`list[dict]` fixtures).
- Coerce pandas input to `pyarrow.Table` at the `transform_metadata` entry point in both `QueryBasedTransformer` and `AtlasTransformer` (and update the `TransformerInterface` type hint accordingly).
- Add `tests/unit/transformers/test_reader_transformer_integration.py`, which drives a real parquet file through the real `ParquetFileReader` and feeds that actual output into the real transformers — reproducing the bug before the fix and passing after, with the test file itself unchanged across both runs.

## Test plan
- [x] New regression test fails on `main` with `AttributeError: 'DataFrame' object has no attribute 'schema'` / `to_pylist`
- [x] Same test passes after the coercion fix, unmodified
- [x] `uv run pre-commit run --all-files` clean
- [x] `uv run python -m pytest tests/unit -x -q` — 5431 passed, 9 skipped