### PR TITLE
fix(e2e): add opt-in two-store SDR posture to the full-DAG suite

### DIFF
--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -141,6 +141,20 @@ inputs:
               && uv sync --locked --no-install-project
     required: false
     default: ""
+  enable-two-store:
+    description: |
+      Opt-in ADR-0014 two-store SDR posture (docs/adr/0014-two-store-
+      storage-architecture.md). When "true": the connector's `objectstore`
+      component is forced to the SDK default (an app-level
+      `objectstore.yaml` override is ignored) so it stays physically
+      distinct from the configurator-emitted `atlan-objectstore`; the
+      composite hard-fails if `atlan-objectstore.yaml` isn't present; and
+      ENABLE_ATLAN_UPLOAD=true / ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE=required
+      are set on the worker via docker-compose.two-store.yml. Set by
+      e2e-full-reusable.yaml's `two-store` input; the pure-SDR pipeline
+      never sets this.
+    required: false
+    default: "false"
 outputs:
   test-outcome:
     description: pytest exit outcome (success/failure)
@@ -404,49 +418,45 @@ runs:
         fi
 
     # SDK defaults first, app overrides on top so apps can replace any single
-    # component file without forking the whole set.
-    - name: Override CI Dapr components
+    # component file without forking the whole set. Two-store mode is the one
+    # exception: see select_dapr_components.py docstring for why the app's
+    # own objectstore.yaml override is skipped in that mode. Branching logic
+    # lives in the tested script per docs/standards/ci.md; this step is
+    # straight-line.
+    - name: Select CI Dapr components
       shell: bash
       env:
-        SDK_COMPONENTS: ${{ steps.action_root.outputs.path }}/components
+        SDR_E2E_ROOT: ${{ steps.action_root.outputs.path }}
         APP_COMPONENTS: ${{ inputs.components-dir }}
+        TWO_STORE: ${{ inputs.enable-two-store }}
       run: |
-        cp "${SDK_COMPONENTS}"/*.yaml ci-deploy/components/
-        # Resolve effective overrides directory: explicit input wins,
-        # otherwise fall back to $SDR_CONFIG_DIR/components convention.
-        if [ -n "${APP_COMPONENTS}" ]; then
-          OVERRIDE_DIR="${APP_COMPONENTS}"
-        else
-          OVERRIDE_DIR="$SDR_CONFIG_DIR/components"
-        fi
-        if [ -d "${OVERRIDE_DIR}" ] && [ -n "$(ls -A "${OVERRIDE_DIR}" 2>/dev/null)" ]; then
-          echo "Applying app-level component overrides from ${OVERRIDE_DIR}"
-          cp "${OVERRIDE_DIR}"/*.yaml ci-deploy/components/
-        fi
+        python3 "$SDR_E2E_ROOT/select_dapr_components.py" \
+          --ci-components-dir ci-deploy/components \
+          --sdk-components-dir "$SDR_E2E_ROOT/components" \
+          --app-components-dir "${APP_COMPONENTS}" \
+          --sdr-config-dir "$SDR_CONFIG_DIR" \
+          --two-store "${TWO_STORE}"
 
+    # Order: configurator-generated base → SDK CI overrides → optional app
+    # layer → two-store overlay (only when enabled, always last — see
+    # build_compose_chain.py). Branching logic lives in the tested script
+    # per docs/standards/ci.md; this step is straight-line.
     - name: Build compose -f chain
       id: compose_files
       shell: bash
       env:
-        SDK_COMPOSE: ${{ steps.action_root.outputs.path }}/docker-compose.ci.yml
+        SDR_E2E_ROOT: ${{ steps.action_root.outputs.path }}
         APP_COMPOSE: ${{ inputs.compose-overlay }}
+        TWO_STORE: ${{ inputs.enable-two-store }}
       run: |
-        # Order: configurator-generated base → SDK CI overrides → optional app layer.
-        FILES=("-f" "ci-deploy/docker-compose.yaml" "-f" "${SDK_COMPOSE}")
-        # Resolve effective compose overlay: explicit input wins,
-        # otherwise fall back to $SDR_CONFIG_DIR/docker-compose.ci.yml convention.
-        if [ -n "${APP_COMPOSE}" ]; then
-          OVERLAY="${APP_COMPOSE}"
-        else
-          OVERLAY="$SDR_CONFIG_DIR/docker-compose.ci.yml"
-        fi
-        if [ -f "${OVERLAY}" ]; then
-          echo "Adding app-level compose layer from ${OVERLAY}"
-          FILES+=("-f" "${OVERLAY}")
-        fi
-        # Persist the array as a single space-joined string (compose -f flags
-        # are simple paths, no whitespace issues).
-        echo "files=${FILES[*]}" >> "$GITHUB_OUTPUT"
+        OUT=$(python3 "$SDR_E2E_ROOT/build_compose_chain.py" \
+          --base-compose ci-deploy/docker-compose.yaml \
+          --sdk-compose "$SDR_E2E_ROOT/docker-compose.ci.yml" \
+          --app-compose "${APP_COMPOSE}" \
+          --sdr-config-dir "$SDR_CONFIG_DIR" \
+          --two-store "${TWO_STORE}" \
+          --two-store-compose "$SDR_E2E_ROOT/docker-compose.two-store.yml")
+        echo "$OUT" >> "$GITHUB_OUTPUT"
 
     # GH-runner docker bridges have no global IPv6 routing, but
     # temporalio's bundled Rust gRPC resolver returns AAAA records and
@@ -512,6 +522,9 @@ runs:
       shell: bash
       env:
         ATLAN_APPLICATION_NAME: ${{ inputs.app-name }}
+        # Read by BaseE2ETest.setup_method() to warn if two-store is on
+        # but the test class runs in RunMode.DIRECT, where it has no effect.
+        TWO_STORE: ${{ inputs.enable-two-store }}
       run: |
         mkdir -p results
         set +e
@@ -756,6 +769,7 @@ runs:
       shell: bash
       env:
         SDR_TEST_TENANT: ${{ env.SDR_TEST_TENANT }}
+        TWO_STORE: ${{ inputs.enable-two-store }}
       run: |
         uv run python3 - <<'PYEOF'
         import os
@@ -900,11 +914,37 @@ runs:
             assets_match = next(iter(list(assets_re.finditer(test_text))[::-1]), None)
             lineage_match = next(iter(list(lineage_re.finditer(test_text))[::-1]), None)
             if assets_match:
+                atlas_counts = _safe_dict(assets_match.group("counts"))
                 lines.extend(_render_section(
                     "Assets in Atlas",
                     assets_match.group("qn"),
-                    _safe_dict(assets_match.group("counts")),
+                    atlas_counts,
                 ))
+                # Two-store diagnostic (not a gate — the existing
+                # expected_min_asset_counts / require_nonempty_assets
+                # assertions already fail the run on this condition).
+                # Extraction succeeding locally while nothing reaches
+                # Atlas is exactly the ADR-0014 hand-off gap this posture
+                # exists to catch: the interceptor wrote to `objectstore`
+                # but the connector never bridged it to `atlan-objectstore`
+                # via App.upload(), so publish/QI/lineage read an empty
+                # upstream bucket.
+                if os.environ.get("TWO_STORE") == "true":
+                    total_transformed = sum(
+                        n
+                        for entity_counts in transformed.values()
+                        for n in entity_counts.values()
+                    )
+                    if total_transformed > 0 and sum(atlas_counts.values()) == 0:
+                        lines.append(
+                            "> ⚠️ **Possible missing hand-off:** the connector "
+                            f"transformed {total_transformed} record(s) locally "
+                            "but 0 assets reached Atlas. Check for a missing "
+                            "`App.upload()` bridging the transformed-data prefix "
+                            "from the deployment `objectstore` to "
+                            "`atlan-objectstore` (see ADR-0014)."
+                        )
+                        lines.append("")
             if lineage_match:
                 lineage_counts = _safe_dict(lineage_match.group("counts"))
                 lines.extend(_render_section(

--- a/.github/actions/sdr-e2e/build_compose_chain.py
+++ b/.github/actions/sdr-e2e/build_compose_chain.py
@@ -1,0 +1,116 @@
+"""
+Build the ``docker compose -f ...`` file chain for the sdr-e2e composite action.
+
+Layering order (later files win on conflicting keys):
+
+  1. atlan-configurator-generated base compose (``ci-deploy/docker-compose.yaml``)
+  2. SDK CI overrides (``docker-compose.ci.yml``)
+  3. optional app-level overlay (explicit ``compose-overlay`` input, else the
+     ``<sdr-config-dir>/docker-compose.ci.yml`` convention)
+  4. two-store overlay (``docker-compose.two-store.yml``), only when two-store
+     mode is enabled — applied LAST so ``ENABLE_ATLAN_UPLOAD`` /
+     ``ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE`` always win over anything an app
+     overlay might set.
+
+Mirrors the "Build compose -f chain" step in
+``.github/actions/sdr-e2e/action.yaml`` — moved here (rather than left as
+inline ``if`` shell) per ``docs/standards/ci.md``, which reserves
+conditional logic in ``run:`` blocks for tested Python.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def build_compose_files(
+    base_compose: Path,
+    sdk_compose: Path,
+    app_compose: str,
+    sdr_config_dir: str,
+    *,
+    two_store: bool,
+    two_store_compose: Path | None = None,
+) -> list[str]:
+    """Return the ordered list of docker compose file paths to layer.
+
+    *app_compose* / *sdr_config_dir* are raw strings (possibly empty) as
+    they arrive from GitHub Actions inputs/env — empty means "not set",
+    not "a file named ''".
+
+    Raises ``ValueError`` if *two_store* is true but *two_store_compose*
+    wasn't supplied — that overlay is SDK-owned and always expected to
+    exist, so a missing path here is a caller bug, not a per-app condition.
+    """
+    files = [str(base_compose), str(sdk_compose)]
+
+    overlay = app_compose or (
+        str(Path(sdr_config_dir) / "docker-compose.ci.yml") if sdr_config_dir else ""
+    )
+    if overlay and Path(overlay).is_file():
+        files.append(overlay)
+
+    if two_store:
+        if two_store_compose is None:
+            raise ValueError("two_store_compose is required when two_store=True")
+        files.append(str(two_store_compose))
+
+    return files
+
+
+def _compose_flags(files: list[str]) -> str:
+    flags: list[str] = []
+    for f in files:
+        flags.extend(("-f", f))
+    return " ".join(flags)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-compose", required=True, type=Path)
+    parser.add_argument("--sdk-compose", required=True, type=Path)
+    parser.add_argument("--app-compose", default="")
+    parser.add_argument("--sdr-config-dir", default="")
+    parser.add_argument(
+        "--two-store",
+        choices=("true", "false"),
+        default="false",
+        help="Enable the ADR-0014 two-store posture (default: false).",
+    )
+    parser.add_argument(
+        "--two-store-compose",
+        type=Path,
+        default=None,
+        help="Path to docker-compose.two-store.yml; required when --two-store=true.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    two_store = args.two_store == "true"
+
+    try:
+        files = build_compose_files(
+            args.base_compose,
+            args.sdk_compose,
+            args.app_compose,
+            args.sdr_config_dir,
+            two_store=two_store,
+            two_store_compose=args.two_store_compose,
+        )
+    except ValueError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    print(f"Effective compose chain: {' '.join(files)}", file=sys.stderr)
+    if two_store:
+        print("two-store mode: appended docker-compose.two-store.yml", file=sys.stderr)
+    print(f"files={_compose_flags(files)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/actions/sdr-e2e/docker-compose.two-store.yml
+++ b/.github/actions/sdr-e2e/docker-compose.two-store.yml
@@ -1,0 +1,24 @@
+# ADR-0014 two-store SDR posture (docs/adr/0014-two-store-storage-architecture.md).
+#
+# Applied only when the sdr-e2e composite's `enable-two-store` input is
+# true, and layered LAST in the compose -f chain (see
+# build_compose_chain.py) so these env vars always win over anything an
+# app-level compose overlay sets.
+#
+# ENABLE_ATLAN_UPLOAD activates SDR mode: the connector's boot-time
+# `verify_object_store_access` preflight now runs and requires the
+# `atlan-objectstore` component (asserted present by
+# select_dapr_components.py before this container ever starts) —
+# hard-failing at boot rather than surfacing as a later, harder-to-diagnose
+# test failure if that component is somehow missing.
+#
+# ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE=required makes a deployment-store
+# (localstorage) write failure fatal to the run — a stricter signal than
+# the SDK's `best_effort` default, appropriate for a CI gate whose whole
+# purpose is to catch storage hand-off bugs loudly.
+
+services:
+  atlan-app:
+    environment:
+      - ENABLE_ATLAN_UPLOAD=true
+      - ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE=required

--- a/.github/actions/sdr-e2e/select_dapr_components.py
+++ b/.github/actions/sdr-e2e/select_dapr_components.py
@@ -1,0 +1,163 @@
+"""
+Select and layer the Dapr CI components used by the sdr-e2e composite action.
+
+Mirrors what the "Override CI Dapr components" step in
+``.github/actions/sdr-e2e/action.yaml`` used to do inline: copy the SDK's
+default component set into ``ci-deploy/components/``, then layer the app's
+own overrides on top so a connector can replace any single component file
+without forking the whole set.
+
+Two-store mode (ADR-0014, docs/adr/0014-two-store-storage-architecture.md)
+adds one twist: the connector's own ``objectstore.yaml`` override — in the
+full-DAG pipeline this has historically pointed ``objectstore`` directly at
+the tenant blobstorage proxy — is skipped, so the SDK-default localstorage
+binding always wins. That is what keeps the deployment store
+(``objectstore``) and the upstream store (``atlan-objectstore``, emitted by
+the atlan-configurator from the ``atlan:`` block in test-config.yaml)
+physically distinct. Without that split, a connector that forgets to bridge
+an artifact via ``App.upload()`` would still have it land in the one shared
+bucket the downstream system apps read, and the gap would go unnoticed by
+the full-DAG e2e suite.
+
+In two-store mode this also hard-asserts that the configurator actually
+emitted ``atlan-objectstore.yaml``, failing fast with an actionable message
+instead of leaving the run to hit a boot-time storage preflight failure
+much later in the pipeline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+# The one component two-store mode refuses to let an app override — see
+# module docstring. A tuple (not a single constant) so a future component
+# needing the same treatment is an explicit, reviewed addition.
+_TWO_STORE_PROTECTED_COMPONENTS = ("objectstore.yaml",)
+
+_UPSTREAM_COMPONENT = "atlan-objectstore.yaml"
+
+
+class MissingUpstreamComponentError(RuntimeError):
+    """Two-store mode is on but the configurator never emitted atlan-objectstore.yaml."""
+
+
+def _resolve_app_components_dir(
+    app_components_dir: str, sdr_config_dir: str
+) -> Path | None:
+    """Resolve the effective app-override directory from raw CLI strings.
+
+    Mirrors the bash fallback this replaces: an explicit ``app_components_dir``
+    wins; otherwise fall back to the ``<sdr_config_dir>/components`` convention;
+    otherwise there is no app-override directory at all. Both inputs may be
+    empty strings (GitHub Actions passes "" for an unset input), which is
+    treated the same as "not provided".
+    """
+    if app_components_dir:
+        return Path(app_components_dir)
+    if sdr_config_dir:
+        return Path(sdr_config_dir) / "components"
+    return None
+
+
+def select_components(
+    ci_components_dir: Path,
+    sdk_components_dir: Path,
+    app_components_dir: Path | None,
+    *,
+    two_store: bool,
+) -> list[str]:
+    """Populate *ci_components_dir* with the effective component set.
+
+    Copies every SDK-default component, then layers non-skipped app
+    overrides on top (existing files with the same name are replaced).
+    Files already present in *ci_components_dir* that aren't touched here
+    (e.g. the configurator's own generated components) are left alone.
+
+    Returns the sorted list of app-override filenames skipped because
+    two-store mode protects them (empty unless that happened).
+
+    Raises ``MissingUpstreamComponentError`` if two-store mode is on and
+    *ci_components_dir* doesn't end up with an ``atlan-objectstore.yaml``.
+    """
+    ci_components_dir.mkdir(parents=True, exist_ok=True)
+
+    for component in sorted(sdk_components_dir.glob("*.yaml")):
+        shutil.copy2(component, ci_components_dir / component.name)
+
+    skipped: list[str] = []
+    if app_components_dir is not None and app_components_dir.is_dir():
+        for component in sorted(app_components_dir.glob("*.yaml")):
+            if two_store and component.name in _TWO_STORE_PROTECTED_COMPONENTS:
+                skipped.append(component.name)
+                continue
+            shutil.copy2(component, ci_components_dir / component.name)
+
+    if two_store and not (ci_components_dir / _UPSTREAM_COMPONENT).is_file():
+        raise MissingUpstreamComponentError(
+            f"two-store mode is enabled but {ci_components_dir / _UPSTREAM_COMPONENT} "
+            "is missing. The atlan-configurator only emits this component when the "
+            "resolved test-config.yaml carries an `atlan:` block (domain / client_id "
+            "/ client_secret). If this app ships a custom test-config.yaml.tmpl for "
+            "the full-DAG pipeline, make sure it still includes that block."
+        )
+
+    return sorted(skipped)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ci-components-dir", required=True, type=Path)
+    parser.add_argument("--sdk-components-dir", required=True, type=Path)
+    parser.add_argument(
+        "--app-components-dir",
+        default="",
+        help="Explicit app-override dir (empty = fall back to --sdr-config-dir convention).",
+    )
+    parser.add_argument(
+        "--sdr-config-dir",
+        default="",
+        help="Base SDR config dir; <this>/components is the override-dir convention.",
+    )
+    parser.add_argument(
+        "--two-store",
+        choices=("true", "false"),
+        default="false",
+        help="Enable the ADR-0014 two-store posture (default: false).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    app_dir = _resolve_app_components_dir(args.app_components_dir, args.sdr_config_dir)
+    two_store = args.two_store == "true"
+
+    try:
+        skipped = select_components(
+            args.ci_components_dir,
+            args.sdk_components_dir,
+            app_dir,
+            two_store=two_store,
+        )
+    except MissingUpstreamComponentError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    for name in skipped:
+        print(
+            f"Skipping app override {name} — two-store mode keeps the "
+            "SDK-default localstorage objectstore so the deployment and "
+            "upstream stores stay physically distinct.",
+            file=sys.stderr,
+        )
+    print(f"Effective components in {args.ci_components_dir}:", file=sys.stderr)
+    for component in sorted(args.ci_components_dir.glob("*.yaml")):
+        print(f"  {component.name}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_build_compose_chain.py
+++ b/.github/scripts/tests/test_build_compose_chain.py
@@ -1,0 +1,167 @@
+"""Tests for .github/actions/sdr-e2e/build_compose_chain.py.
+
+See test_select_dapr_components.py for why the module under test lives
+under .github/actions/sdr-e2e/ rather than .github/scripts/, and why the
+test itself still lives here.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "actions" / "sdr-e2e"))
+
+from build_compose_chain import build_compose_files, main  # noqa: E402
+
+
+def test_base_and_sdk_only_when_no_app_overlay_and_no_two_store(
+    tmp_path: Path,
+) -> None:
+    base = tmp_path / "base.yaml"
+    sdk = tmp_path / "sdk-ci.yaml"
+
+    files = build_compose_files(base, sdk, "", "", two_store=False)
+
+    assert files == [str(base), str(sdk)]
+
+
+def test_explicit_app_overlay_wins_when_file_exists(tmp_path: Path) -> None:
+    base = tmp_path / "base.yaml"
+    sdk = tmp_path / "sdk-ci.yaml"
+    overlay = tmp_path / "app-overlay.yaml"
+    overlay.write_text("services: {}")
+
+    files = build_compose_files(base, sdk, str(overlay), "", two_store=False)
+
+    assert files == [str(base), str(sdk), str(overlay)]
+
+
+def test_falls_back_to_sdr_config_dir_convention(tmp_path: Path) -> None:
+    base = tmp_path / "base.yaml"
+    sdk = tmp_path / "sdk-ci.yaml"
+    sdr_dir = tmp_path / ".github" / "e2e"
+    sdr_dir.mkdir(parents=True)
+    (sdr_dir / "docker-compose.ci.yml").write_text("services: {}")
+
+    files = build_compose_files(base, sdk, "", str(sdr_dir), two_store=False)
+
+    assert files[-1] == str(sdr_dir / "docker-compose.ci.yml")
+
+
+def test_missing_overlay_file_is_skipped(tmp_path: Path) -> None:
+    base = tmp_path / "base.yaml"
+    sdk = tmp_path / "sdk-ci.yaml"
+
+    files = build_compose_files(
+        base, sdk, str(tmp_path / "does-not-exist.yaml"), "", two_store=False
+    )
+
+    assert files == [str(base), str(sdk)]
+
+
+def test_two_store_appends_overlay_last_after_app_overlay(tmp_path: Path) -> None:
+    base = tmp_path / "base.yaml"
+    sdk = tmp_path / "sdk-ci.yaml"
+    overlay = tmp_path / "app-overlay.yaml"
+    overlay.write_text("services: {}")
+    two_store_compose = tmp_path / "docker-compose.two-store.yml"
+
+    files = build_compose_files(
+        base,
+        sdk,
+        str(overlay),
+        "",
+        two_store=True,
+        two_store_compose=two_store_compose,
+    )
+
+    assert files == [str(base), str(sdk), str(overlay), str(two_store_compose)]
+
+
+def test_two_store_without_app_overlay(tmp_path: Path) -> None:
+    base = tmp_path / "base.yaml"
+    sdk = tmp_path / "sdk-ci.yaml"
+    two_store_compose = tmp_path / "docker-compose.two-store.yml"
+
+    files = build_compose_files(
+        base, sdk, "", "", two_store=True, two_store_compose=two_store_compose
+    )
+
+    assert files == [str(base), str(sdk), str(two_store_compose)]
+
+
+def test_two_store_requires_compose_path() -> None:
+    with pytest.raises(ValueError):
+        build_compose_files(Path("a"), Path("b"), "", "", two_store=True)
+
+
+def test_two_store_compose_appended_even_if_it_does_not_exist_on_disk(
+    tmp_path: Path,
+) -> None:
+    # docker-compose.two-store.yml is SDK-owned and always shipped alongside
+    # this script; unlike the app overlay it isn't existence-checked.
+    base = tmp_path / "base.yaml"
+    sdk = tmp_path / "sdk-ci.yaml"
+    two_store_compose = tmp_path / "does-not-exist.yml"
+
+    files = build_compose_files(
+        base, sdk, "", "", two_store=True, two_store_compose=two_store_compose
+    )
+
+    assert str(two_store_compose) in files
+
+
+def test_main_emits_files_output_line(tmp_path: Path, capsys) -> None:
+    base = tmp_path / "base.yaml"
+    sdk = tmp_path / "sdk-ci.yaml"
+    two_store_compose = tmp_path / "two-store.yml"
+
+    rc = main(
+        [
+            "--base-compose",
+            str(base),
+            "--sdk-compose",
+            str(sdk),
+            "--two-store",
+            "true",
+            "--two-store-compose",
+            str(two_store_compose),
+        ]
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert out.strip() == f"files=-f {base} -f {sdk} -f {two_store_compose}"
+
+
+def test_main_single_store_default(tmp_path: Path, capsys) -> None:
+    base = tmp_path / "base.yaml"
+    sdk = tmp_path / "sdk-ci.yaml"
+
+    rc = main(["--base-compose", str(base), "--sdk-compose", str(sdk)])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert out.strip() == f"files=-f {base} -f {sdk}"
+
+
+def test_main_two_store_without_compose_path_errors(tmp_path: Path, capsys) -> None:
+    base = tmp_path / "base.yaml"
+    sdk = tmp_path / "sdk-ci.yaml"
+
+    rc = main(
+        [
+            "--base-compose",
+            str(base),
+            "--sdk-compose",
+            str(sdk),
+            "--two-store",
+            "true",
+        ]
+    )
+
+    assert rc == 1
+    assert "::error::" in capsys.readouterr().err

--- a/.github/scripts/tests/test_select_dapr_components.py
+++ b/.github/scripts/tests/test_select_dapr_components.py
@@ -1,0 +1,224 @@
+"""Tests for .github/actions/sdr-e2e/select_dapr_components.py.
+
+The module under test lives alongside the sdr-e2e composite action (not
+under .github/scripts/) because it's invoked via the action's
+`${{ steps.action_root.outputs.path }}` — the same co-location the
+composite already uses for test-config.yaml.tmpl and components/*.yaml, so
+it resolves correctly whether the action is referenced remotely
+(`uses: atlanhq/application-sdk/.github/actions/sdr-e2e@main`) or locally.
+The test itself stays under .github/scripts/tests/ so `scripts-tests.yaml`
+picks it up without a new pytest invocation, importing by explicit path
+the same way test_write_dapr_components.py does.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "actions" / "sdr-e2e"))
+
+from select_dapr_components import (  # noqa: E402
+    MissingUpstreamComponentError,
+    _resolve_app_components_dir,
+    main,
+    select_components,
+)
+
+
+def _write(path: Path, name: str, kind: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"apiVersion: dapr.io/v1alpha1\nkind: Component\nmetadata:\n  name: {name}\nspec:\n  type: {kind}\n"
+    )
+
+
+def _make_sdk_defaults(tmp_path: Path) -> Path:
+    sdk_dir = tmp_path / "sdk-components"
+    _write(sdk_dir / "objectstore.yaml", "objectstore", "bindings.localstorage")
+    _write(sdk_dir / "statestore.yaml", "statestore", "state.in-memory")
+    return sdk_dir
+
+
+def test_single_store_copies_sdk_defaults_then_app_overrides(tmp_path: Path) -> None:
+    sdk_dir = _make_sdk_defaults(tmp_path)
+    app_dir = tmp_path / "app-components"
+    _write(app_dir / "objectstore.yaml", "objectstore", "bindings.aws.s3")
+    ci_dir = tmp_path / "ci-deploy" / "components"
+
+    skipped = select_components(ci_dir, sdk_dir, app_dir, two_store=False)
+
+    assert skipped == []
+    assert "bindings.aws.s3" in (ci_dir / "objectstore.yaml").read_text()
+    assert (ci_dir / "statestore.yaml").exists()
+
+
+def test_two_store_skips_app_objectstore_override(tmp_path: Path) -> None:
+    sdk_dir = _make_sdk_defaults(tmp_path)
+    app_dir = tmp_path / "app-components"
+    _write(app_dir / "objectstore.yaml", "objectstore", "bindings.aws.s3")
+    ci_dir = tmp_path / "ci-deploy" / "components"
+    _write(ci_dir / "atlan-objectstore.yaml", "atlan-objectstore", "bindings.aws.s3")
+
+    skipped = select_components(ci_dir, sdk_dir, app_dir, two_store=True)
+
+    assert skipped == ["objectstore.yaml"]
+    # SDK-default localstorage wins, not the app's tenant-blobstorage override.
+    assert "bindings.localstorage" in (ci_dir / "objectstore.yaml").read_text()
+
+
+def test_two_store_applies_non_objectstore_app_overrides(tmp_path: Path) -> None:
+    sdk_dir = _make_sdk_defaults(tmp_path)
+    app_dir = tmp_path / "app-components"
+    _write(app_dir / "statestore.yaml", "statestore", "state.redis")
+    ci_dir = tmp_path / "ci-deploy" / "components"
+    _write(ci_dir / "atlan-objectstore.yaml", "atlan-objectstore", "bindings.aws.s3")
+
+    select_components(ci_dir, sdk_dir, app_dir, two_store=True)
+
+    assert "state.redis" in (ci_dir / "statestore.yaml").read_text()
+
+
+def test_two_store_missing_atlan_objectstore_raises(tmp_path: Path) -> None:
+    sdk_dir = _make_sdk_defaults(tmp_path)
+    ci_dir = tmp_path / "ci-deploy" / "components"
+
+    raised = False
+    try:
+        select_components(ci_dir, sdk_dir, None, two_store=True)
+    except MissingUpstreamComponentError as exc:
+        raised = True
+        assert "atlan-objectstore.yaml" in str(exc)
+    assert raised, "expected MissingUpstreamComponentError"
+
+
+def test_single_store_missing_atlan_objectstore_is_fine(tmp_path: Path) -> None:
+    sdk_dir = _make_sdk_defaults(tmp_path)
+    ci_dir = tmp_path / "ci-deploy" / "components"
+
+    skipped = select_components(ci_dir, sdk_dir, None, two_store=False)
+
+    assert skipped == []
+    assert not (ci_dir / "atlan-objectstore.yaml").exists()
+
+
+def test_no_app_dir_is_a_noop(tmp_path: Path) -> None:
+    sdk_dir = _make_sdk_defaults(tmp_path)
+    ci_dir = tmp_path / "ci-deploy" / "components"
+
+    skipped = select_components(ci_dir, sdk_dir, None, two_store=False)
+
+    assert skipped == []
+    assert (ci_dir / "objectstore.yaml").exists()
+
+
+def test_empty_app_dir_is_a_noop(tmp_path: Path) -> None:
+    sdk_dir = _make_sdk_defaults(tmp_path)
+    app_dir = tmp_path / "app-components"
+    app_dir.mkdir()
+    ci_dir = tmp_path / "ci-deploy" / "components"
+
+    skipped = select_components(ci_dir, sdk_dir, app_dir, two_store=False)
+
+    assert skipped == []
+
+
+def test_existing_configurator_output_is_not_clobbered(tmp_path: Path) -> None:
+    # ci_components_dir already has configurator-generated files (e.g.
+    # atlan-objectstore.yaml + secretstore.yaml) before this script ever
+    # runs; select_components only writes the filenames it knows about.
+    sdk_dir = _make_sdk_defaults(tmp_path)
+    ci_dir = tmp_path / "ci-deploy" / "components"
+    _write(ci_dir / "atlan-objectstore.yaml", "atlan-objectstore", "bindings.aws.s3")
+    _write(ci_dir / "secretstore.yaml", "secretstore", "secretstores.local.env")
+
+    select_components(ci_dir, sdk_dir, None, two_store=True)
+
+    assert "secretstores.local.env" in (ci_dir / "secretstore.yaml").read_text()
+    assert "bindings.aws.s3" in (ci_dir / "atlan-objectstore.yaml").read_text()
+
+
+def test_resolve_app_components_dir_prefers_explicit_input() -> None:
+    resolved = _resolve_app_components_dir("explicit/dir", ".github/e2e")
+    assert resolved == Path("explicit/dir")
+
+
+def test_resolve_app_components_dir_falls_back_to_sdr_config_convention() -> None:
+    resolved = _resolve_app_components_dir("", ".github/e2e")
+    assert resolved == Path(".github/e2e/components")
+
+
+def test_resolve_app_components_dir_none_when_neither_set() -> None:
+    assert _resolve_app_components_dir("", "") is None
+
+
+def test_main_two_store_missing_atlan_objectstore_exits_nonzero(
+    tmp_path: Path, capsys
+) -> None:
+    sdk_dir = _make_sdk_defaults(tmp_path)
+    ci_dir = tmp_path / "ci-deploy" / "components"
+
+    rc = main(
+        [
+            "--ci-components-dir",
+            str(ci_dir),
+            "--sdk-components-dir",
+            str(sdk_dir),
+            "--two-store",
+            "true",
+        ]
+    )
+
+    assert rc == 1
+    assert "::error::" in capsys.readouterr().err
+
+
+def test_main_two_store_success_reports_effective_components(
+    tmp_path: Path, capsys
+) -> None:
+    sdk_dir = _make_sdk_defaults(tmp_path)
+    ci_dir = tmp_path / "ci-deploy" / "components"
+    _write(ci_dir / "atlan-objectstore.yaml", "atlan-objectstore", "bindings.aws.s3")
+
+    rc = main(
+        [
+            "--ci-components-dir",
+            str(ci_dir),
+            "--sdk-components-dir",
+            str(sdk_dir),
+            "--two-store",
+            "true",
+        ]
+    )
+
+    assert rc == 0
+    assert "atlan-objectstore.yaml" in capsys.readouterr().err
+
+
+def test_main_resolves_app_components_dir_from_sdr_config_dir(
+    tmp_path: Path,
+) -> None:
+    sdk_dir = _make_sdk_defaults(tmp_path)
+    ci_dir = tmp_path / "ci-deploy" / "components"
+    sdr_config_dir = tmp_path / ".github" / "e2e"
+    _write(
+        sdr_config_dir / "components" / "objectstore.yaml",
+        "objectstore",
+        "bindings.aws.s3",
+    )
+
+    rc = main(
+        [
+            "--ci-components-dir",
+            str(ci_dir),
+            "--sdk-components-dir",
+            str(sdk_dir),
+            "--sdr-config-dir",
+            str(sdr_config_dir),
+            "--two-store",
+            "false",
+        ]
+    )
+
+    assert rc == 0
+    assert "bindings.aws.s3" in (ci_dir / "objectstore.yaml").read_text()

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -128,6 +128,29 @@ on:
         required: false
         type: string
         default: ""
+      two-store:
+        description: |
+          Opt-in ADR-0014 two-store SDR posture (docs/adr/0014-two-store-
+          storage-architecture.md). When true, the connector's deployment
+          `objectstore` is forced to the SDK-default CI-local binding
+          (never the tenant-blobstorage override some connectors ship),
+          `atlan-objectstore` stays the configurator-emitted tenant
+          binding, and ENABLE_ATLAN_UPLOAD=true is set on the worker.
+          This makes the two stores physically distinct so a connector
+          that forgets to bridge an artifact via `App.upload()` shows up
+          as zero downstream assets/lineage in Atlas instead of being
+          silently masked by a single shared bucket.
+
+          Only meaningful when the test class runs in RunMode.AGENT —
+          in RunMode.DIRECT the connector's extract activity runs on the
+          tenant's own pod, whose storage config this harness does not
+          control, so the gap is not observable there.
+
+          Default false: existing full-DAG adopters are unaffected until
+          they opt in per docs/standards/connector-ci-e2e.md.
+        required: false
+        type: boolean
+        default: false
     secrets:
       SDR_TEST_TENANT:
         description: Tenant FQDN (e.g. devex.atlan.com — no https:// prefix). ATLAN_BASE_URL is derived from this.
@@ -206,3 +229,4 @@ jobs:
           pytest-extra-args: "-s"
           application-sdk-ref: ${{ inputs.application-sdk-ref }}
           base-image-ref: ${{ inputs.base-image-ref }}
+          enable-two-store: ${{ inputs.two-store }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -351,43 +351,13 @@ jobs:
           workflow: sdr-k8s-e2e.yaml
           workflow-inputs: ${{ github.event_name == 'merge_group' && format('{{"application_sdk_ref":"{0}"}}', github.sha) || format('{{"application_sdk_ref":"{0}"}}', github.event.pull_request.head.sha) }}
 
-  # Two-store SDR hand-off e2e — dispatched cross-repo to atlan-mysql-app's
-  # full-DAG suite (via its `tests.yaml`) with `two_store: true`. This
-  # regression-guards the ADR-0014 two-store posture
-  # (docs/adr/0014-two-store-storage-architecture.md): a connector that
-  # forgets to bridge an artifact via `App.upload()` from its deployment
-  # `objectstore` to the upstream `atlan-objectstore` now shows up as zero
-  # downstream assets/lineage in Atlas instead of being silently masked by
-  # a single shared bucket. Mysql is the canonical first adopter — the
-  # connector where this exact gap was originally found.
-  #
-  # Opt-in via a dedicated 'two-store-e2e' label (not 'e2e' or the sdk/
-  # container/ci path filter) while this is new on both sides: the SDK
-  # capability landing here, and the per-connector config each adopter
-  # still needs (docs/standards/connector-ci-e2e.md). No merge_group leg
-  # yet and not part of connector-gate — promote once mysql (and other
-  # adopters) have migrated and this has proven stable. Omits
-  # base_image_ref: this check exercises the two-store harness logic, not
-  # the connector's runtime base image, so mysql builds from its own
-  # Dockerfile's default base here (same as the merge_group leg of
-  # connector-tests).
-  two-store-e2e:
-    name: Two-Store E2E (mysql)
-    if: |
-      github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.labels.*.name, 'two-store-e2e') &&
-      github.event.pull_request.head.repo.fork != true &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: "./.github/actions/e2e-apps"
-        with:
-          github-token: ${{ secrets.ORG_PAT_GITHUB }}
-          repo-name: atlan-mysql-app
-          target-branch: "refs/heads/main"
-          workflow: tests.yaml
-          workflow-inputs: ${{ format('{{"application_sdk_ref":"{0}","run_e2e":"true","two_store":"true"}}', github.event.pull_request.head.sha) }}
+  # (No dedicated two-store-e2e job: mysql's own tests.yaml hardcodes
+  # `two-store: true` unconditionally, so its EXISTING full-DAG run —
+  # already dispatched by connector-tests below via the 'e2e' label —
+  # regression-guards the ADR-0014 two-store posture with no extra SDK-
+  # side dispatch glue. A standalone per-connector job here would repeat
+  # the exact mistake sdr-matrix-builder / sdr-e2e-apps / e2e-full-mysql
+  # were removed for — see the comment near the bottom of this file.)
 
   # ── The single required check for the connector e2e area ────────────────────
   # Always runs and always concludes, so branch protection / the merge queue can

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -351,6 +351,44 @@ jobs:
           workflow: sdr-k8s-e2e.yaml
           workflow-inputs: ${{ github.event_name == 'merge_group' && format('{{"application_sdk_ref":"{0}"}}', github.sha) || format('{{"application_sdk_ref":"{0}"}}', github.event.pull_request.head.sha) }}
 
+  # Two-store SDR hand-off e2e — dispatched cross-repo to atlan-mysql-app's
+  # full-DAG suite (via its `tests.yaml`) with `two_store: true`. This
+  # regression-guards the ADR-0014 two-store posture
+  # (docs/adr/0014-two-store-storage-architecture.md): a connector that
+  # forgets to bridge an artifact via `App.upload()` from its deployment
+  # `objectstore` to the upstream `atlan-objectstore` now shows up as zero
+  # downstream assets/lineage in Atlas instead of being silently masked by
+  # a single shared bucket. Mysql is the canonical first adopter — the
+  # connector where this exact gap was originally found.
+  #
+  # Opt-in via a dedicated 'two-store-e2e' label (not 'e2e' or the sdk/
+  # container/ci path filter) while this is new on both sides: the SDK
+  # capability landing here, and the per-connector config each adopter
+  # still needs (docs/standards/connector-ci-e2e.md). No merge_group leg
+  # yet and not part of connector-gate — promote once mysql (and other
+  # adopters) have migrated and this has proven stable. Omits
+  # base_image_ref: this check exercises the two-store harness logic, not
+  # the connector's runtime base image, so mysql builds from its own
+  # Dockerfile's default base here (same as the merge_group leg of
+  # connector-tests).
+  two-store-e2e:
+    name: Two-Store E2E (mysql)
+    if: |
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'two-store-e2e') &&
+      github.event.pull_request.head.repo.fork != true &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: "./.github/actions/e2e-apps"
+        with:
+          github-token: ${{ secrets.ORG_PAT_GITHUB }}
+          repo-name: atlan-mysql-app
+          target-branch: "refs/heads/main"
+          workflow: tests.yaml
+          workflow-inputs: ${{ format('{{"application_sdk_ref":"{0}","run_e2e":"true","two_store":"true"}}', github.event.pull_request.head.sha) }}
+
   # ── The single required check for the connector e2e area ────────────────────
   # Always runs and always concludes, so branch protection / the merge queue can
   # require exactly this one stable context instead of the matrix legs

--- a/.github/workflows/scripts-tests.yaml
+++ b/.github/workflows/scripts-tests.yaml
@@ -15,6 +15,13 @@ on:
   pull_request:
     paths:
       - ".github/scripts/**"
+      # select_dapr_components.py / build_compose_chain.py live here (not
+      # under .github/scripts/) so the sdr-e2e composite can resolve them
+      # via github.action_path in every invocation context — see
+      # test_select_dapr_components.py's module docstring. Their tests
+      # still live under .github/scripts/tests/, so this path is only
+      # needed to make edits to the modules themselves trigger this gate.
+      - ".github/actions/sdr-e2e/*.py"
       - ".github/workflows/scripts-tests.yaml"
 
 permissions:

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -118,6 +118,15 @@ on:
         type: string
         default: ""
         description: Set to 'true' to trigger the e2e job from workflow_dispatch.
+      two-store:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          Forwarded to e2e-full-reusable.yaml's `two-store` input — opt-in
+          ADR-0014 two-store SDR posture for the e2e job. See that
+          workflow's input description. Default false: existing callers
+          are unaffected.
 
 jobs:
 
@@ -177,6 +186,7 @@ jobs:
       application-sdk-ref: ${{ inputs.application-sdk-ref }}
       base-image-ref: ${{ inputs.base-image-ref }}
       distinct-id: ${{ inputs.distinct-id }}
+      two-store: ${{ inputs.two-store }}
     secrets: inherit
 
   # ── Aggregator gate (single required check for branch protection) ────────

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -232,6 +232,25 @@ class BaseE2ETest:
                     field=required,
                 )
 
+        # ADR-0014 two-store posture (sdr-e2e's `enable-two-store` input,
+        # threaded through as this env var) only changes anything on the
+        # CI-built worker container, which is only in the extraction path
+        # under RunMode.AGENT — the harness submits to that worker's own
+        # dynamic queue. Under RunMode.DIRECT extraction runs on the
+        # tenant's already-deployed production pod instead, whose storage
+        # config this harness never touches, so a missing App.upload()
+        # hand-off would not be caught even with two-store enabled here.
+        # Warn rather than fail: a DIRECT-mode run is still valid and
+        # useful on its own terms, just not a two-store hand-off check.
+        if os.environ.get("TWO_STORE") == "true" and self.mode is RunMode.DIRECT:
+            logger.warning(
+                "two-store mode is enabled but %s runs in RunMode.DIRECT — "
+                "extraction happens on the tenant's own production pod, not "
+                "the CI worker the two-store env vars were applied to, so a "
+                "missing App.upload() hand-off will NOT be caught by this run.",
+                type(self).__name__,
+            )
+
         tenant_url = os.environ.get("ATLAN_BASE_URL", "").rstrip("/")
         api_token = os.environ.get("ATLAN_API_KEY", "")
         if not tenant_url or not api_token:

--- a/packages/conformance/conformance/bootstrap/templates/tests.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/tests.yaml
@@ -67,6 +67,17 @@ on:
         required: false
         default: ""
         type: string
+      two_store:
+        description: |
+          Set to 'true' to run the e2e job in the ADR-0014 two-store SDR
+          posture (docs/adr/0014-two-store-storage-architecture.md).
+          Requires the e2e test class to run in RunMode.AGENT and (for the
+          full-DAG pipeline) that the app no longer ships an
+          `objectstore.yaml` override under its e2e components dir.
+          Defaults off.
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   tests:
@@ -93,4 +104,5 @@ jobs:
       run-e2e: ${{ inputs.run_e2e }}
       base-image-ref: ${{ inputs.base_image_ref }}
       agent-name-override: ${{ inputs.agent_name_override }}
+      two-store: ${{ inputs.two_store }}
     secrets: inherit

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -272,3 +273,77 @@ class TestSeedDagFromManifest:
         self.harness.manifest_path = str(_write_manifest(tmp_path, dag))  # type: ignore[attr-defined]
         result = self.harness._seed_dag_from_manifest("atlan-openapi-agent-1")
         assert set(result.keys()) == {"extract", "publish"}
+
+
+# ---------------------------------------------------------------------------
+# setup_method — two-store / RunMode.DIRECT warning
+# ---------------------------------------------------------------------------
+
+
+class _AgentModeE2ETest(_ConcreteE2ETest):
+    """Same as _ConcreteE2ETest but RunMode.AGENT — two-store is meaningful here."""
+
+    mode = RunMode.AGENT
+    # Skips the $admin-role AtlanClient network lookup in setup_method, which
+    # is irrelevant to this test and would otherwise also log a (harmless)
+    # warning against the fake tenant URL, muddying the assertion.
+    connection_admin_roles = ("test-admin-role-guid",)
+
+
+class TestTwoStoreDirectModeWarning:
+    """ADR-0014 two-store CI wiring only has an effect under RunMode.AGENT —
+    see the comment in BaseE2ETest.setup_method(). These tests exercise the
+    warning-vs-silent behavior without a real tenant (the $admin-role lookup
+    network call fails against the fake URL and is caught + logged
+    separately by setup_method(), so admin-role attrs are set here to keep
+    each test isolated to the one warning under test).
+    """
+
+    def _bootstrap_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATLAN_BASE_URL", "https://test.example.invalid")
+        monkeypatch.setenv("ATLAN_API_KEY", "test-token")
+        monkeypatch.setenv("GITHUB_RUN_ID", "9999999")
+
+    def test_warns_when_two_store_enabled_and_mode_is_direct(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._bootstrap_env(monkeypatch)
+        monkeypatch.setenv("TWO_STORE", "true")
+        mock_logger = MagicMock()
+        monkeypatch.setattr("application_sdk.testing.e2e.base.logger", mock_logger)
+
+        class _DirectModeTest(_ConcreteE2ETest):
+            connection_admin_roles = ("test-admin-role-guid",)
+
+        _DirectModeTest().setup_method()
+
+        assert mock_logger.warning.called
+        message = mock_logger.warning.call_args[0][0]
+        assert "RunMode.DIRECT" in message
+
+    def test_no_warning_when_mode_is_agent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._bootstrap_env(monkeypatch)
+        monkeypatch.setenv("TWO_STORE", "true")
+        mock_logger = MagicMock()
+        monkeypatch.setattr("application_sdk.testing.e2e.base.logger", mock_logger)
+
+        _AgentModeE2ETest().setup_method()
+
+        mock_logger.warning.assert_not_called()
+
+    def test_no_warning_when_two_store_not_enabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._bootstrap_env(monkeypatch)
+        monkeypatch.delenv("TWO_STORE", raising=False)
+        mock_logger = MagicMock()
+        monkeypatch.setattr("application_sdk.testing.e2e.base.logger", mock_logger)
+
+        class _DirectModeTest(_ConcreteE2ETest):
+            connection_admin_roles = ("test-admin-role-guid",)
+
+        _DirectModeTest().setup_method()
+
+        mock_logger.warning.assert_not_called()


### PR DESCRIPTION
## Summary
- Adds an opt-in `two-store` capability to the live-tenant full-DAG e2e suite (ADR-0014, `docs/adr/0014-two-store-storage-architecture.md`), so a connector that forgets to bridge an artifact via `App.upload()` from its deployment `objectstore` to the upstream `atlan-objectstore` shows up as zero downstream assets/lineage in Atlas, instead of being silently masked by a single shared bucket.
- Replaces the `sdr-e2e` composite's inline conditional shell ("Override CI Dapr components" / "Build compose -f chain") with tested Python (`select_dapr_components.py`, `build_compose_chain.py`) per `docs/standards/ci.md`. In two-store mode these force the SDK-default localstorage `objectstore` (ignoring any app-level override) and hard-fail if the configurator didn't emit `atlan-objectstore.yaml`.
- New `docker-compose.two-store.yml` overlay sets `ENABLE_ATLAN_UPLOAD=true` + `ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE=required` on the worker only in two-store mode.
- Threads a `two-store` input through `e2e-full-reusable.yaml` → `sdr-e2e` action → `tests-reusable.yaml` → the `tests.yaml` bootstrap template, default `false` so existing adopters are unaffected.
- Adds a diagnostic PR-comment annotation when extraction produced records locally but zero reached Atlas (defense-in-depth signal, not a gate — the existing `expected_min_asset_counts` / `require_nonempty_assets` / `expect_lineage` assertions already fail the run).
- Adds a warning in `BaseE2ETest.setup_method()` when two-store is enabled but the test class runs in `RunMode.DIRECT`, where the posture has no effect (extraction runs on the tenant's own pod, not the CI worker).
- Adds a non-blocking `two-store-e2e` PR-CI job in `pull_request.yaml` that dispatches `atlan-mysql-app`'s full-DAG suite, gated behind a dedicated `two-store-e2e` label (not required/blocking while this is new).
- Companion adopter PR: [atlanhq/atlan-mysql-app#381](https://github.com/atlanhq/atlan-mysql-app/pull/381) flips `two-store: true` for mysql, the first adopter.

## Test plan
- [x] `uv run pre-commit run --all-files` — clean
- [x] `uv run python -m pytest tests/unit -x -q` — 5432 passed, 9 skipped
- [x] `uv run --extra workflows --with pytest python -m pytest .github/scripts/tests -q` — 500 passed (25 new for the two new scripts)
- [x] `uv run pytest tests/unit/testing/e2e tests/unit/testing/full_dag tests/unit/testing/sdr -q` — 168 passed, including new `RunMode.DIRECT` warning coverage
- [ ] After merge, land the mysql adopter PR and confirm its full-DAG suite goes green with `two-store: true`, then confirm it goes red when the `App.upload()` hand-off is temporarily removed on a scratch branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)