### PR TITLE
feat(conformance): default two-store: true in the tests.yaml bootstrap template

### DIFF
--- a/packages/conformance/conformance/bootstrap/templates/tests.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/tests.yaml
@@ -67,17 +67,6 @@ on:
         required: false
         default: ""
         type: string
-      two_store:
-        description: |
-          Set to 'true' to run the e2e job in the ADR-0014 two-store SDR
-          posture (docs/adr/0014-two-store-storage-architecture.md).
-          Requires the e2e test class to run in RunMode.AGENT and (for the
-          full-DAG pipeline) that the app no longer ships an
-          `objectstore.yaml` override under its e2e components dir.
-          Defaults off.
-        required: false
-        default: false
-        type: boolean
 
 jobs:
   tests:
@@ -104,5 +93,14 @@ jobs:
       run-e2e: ${{ inputs.run_e2e }}
       base-image-ref: ${{ inputs.base_image_ref }}
       agent-name-override: ${{ inputs.agent_name_override }}
-      two-store: ${{ inputs.two_store }}
+      # ADR-0014 two-store SDR posture (docs/adr/0014-two-store-storage-
+      # architecture.md in application-sdk): the e2e job's `objectstore`
+      # is forced to the SDK-default CI-local binding and
+      # ENABLE_ATLAN_UPLOAD=true is set on the worker, so a connector
+      # code path that forgets to bridge an artifact via App.upload()
+      # from `objectstore` to `atlan-objectstore` shows up as zero
+      # downstream assets/lineage in Atlas. See atlan-mysql-app#381 for
+      # the first adopter + confirmed end-to-end proof of the boundary
+      # crossing.
+      two-store: true
     secrets: inherit


### PR DESCRIPTION
## Summary
- New connectors scaffolded via `atlan-application-sdk-conformance bootstrap` now get `two-store: true` by default in their `tests.yaml`, matching the ADR-0014 two-store SDR posture already rolled out to the three canonical full-DAG adopters ([atlan-mysql-app#381](https://github.com/atlanhq/atlan-mysql-app/pull/381), [atlan-metabase-app#173](https://github.com/atlanhq/atlan-metabase-app/pull/173), [atlan-openapi-app#209](https://github.com/atlanhq/atlan-openapi-app/pull/209)).
- Drops the previously-added `two_store` `workflow_dispatch` input: `inputs.*` is only populated on an actual `workflow_dispatch` trigger, so forwarding `${{ inputs.two_store }}` never took effect on push/pull_request/merge_group runs — it could never actually deliver a default-on e2e job. Hardcoding `two-store: true` directly in the `with:` block (the form that actually worked in all three adopter PRs) is the only way to make it apply unconditionally.

## Drift verification
Ran the actual C002 bootstrap-drift comparison logic (`_extract_tests_yaml_params` + `render` + `_strip_action_pins`) against each adopter's real, merged `tests.yaml`:
- atlan-metabase-app: **matches canonical, zero drift**
- atlan-openapi-app: **matches canonical, zero drift**
- atlan-mysql-app: does **not** match — its PR used slightly different comment wording before this text was standardized to the (identical) metabase/openapi phrasing. Remains a lone WARN-only C002 finding; drift never blocks CI, and it's a one-line comment reconciliation if anyone wants to clean it up later.

## Test plan
- [x] `uv run pytest packages/conformance/tests/test_bootstrap.py packages/conformance/tests/test_bootstrap_drift.py packages/conformance/tests/test_bootstrap_extract.py -q` — 216 passed
- [x] Rendered the template with `render("tests.yaml", app_name="mysql", app_image_name="atlan-mysql-app")` and confirmed the output parses as valid YAml and contains `two-store: true` with no leftover `two_store` references
- [x] `uv run pre-commit run --files packages/conformance/conformance/bootstrap/templates/tests.yaml` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)