### PR TITLE
ci(sdk-review): resolver can trigger @sdk-review + hands PR to human review

### DIFF
--- a/.github/scripts/sdk_resolve_dispatch.py
+++ b/.github/scripts/sdk_resolve_dispatch.py
@@ -17,6 +17,8 @@ Environment:
     HARNESS_TOKEN       bearer for /api/sandbox/execute
     PR_NUMBER           the open PR to drive to merge-ready
     MAX_ROUNDS          max @sdk-review rounds before stopping (default 8)
+    REVIEWERS           comma-separated GitHub handles to request + tag at the end
+    REQUESTER           login that invoked @sdk-resolve (also tagged)
     GHA_RUN_URL         this workflow run's URL
     RUN_DATE            ISO date (computed if absent)
     GITHUB_STEP_SUMMARY path GitHub Actions gives us to render the run summary
@@ -62,7 +64,12 @@ SUMMARY_ROWS = (
 )
 
 
-def build_prompt(pr_number: str, gha_run_url: str, max_rounds: int) -> str:
+def build_prompt(
+    pr_number: str, gha_run_url: str, max_rounds: int, reviewers: str, requester: str
+) -> str:
+    # Reviewers to request + the requester who triggered the run — tagged at the
+    # end so a human takes the merge from a green, review-requested PR.
+    tag_list = ", ".join(f"@{h}" for h in _reviewer_handles(reviewers, requester))
     return f"""You are running the SDK Resolver in a Cloudflare sandbox.
 
 Repository cloned at: /workspace/application-sdk.
@@ -76,22 +83,45 @@ Run metadata (use these verbatim):
   PR_NUMBER:    {pr_number}
   MAX_ROUNDS:   {max_rounds}
   GHA_RUN_URL:  {gha_run_url}
+  REVIEWERS:    {reviewers}          # GitHub handles to request as reviewers
+  REQUESTER:    {requester}          # who invoked @sdk-resolve
+  TAG_LIST:     {tag_list}           # @-mention these at the end
 
 GITHUB_TOKEN is pre-injected by the sandbox. Use `gh` for all GitHub operations.
 
 Drive PR #{pr_number} to MERGE-READY: green required CI + zero @sdk-review
 findings (nits included, unless proven false with a recorded rationale) +
 verdict READY_TO_MERGE. You are the only writer — the reviewer runs in its own
-separate sandbox; you trigger it with `@sdk-review` and consume its comment.
-Do NOT `gh pr merge` — stop at merge-ready and hand back to a human. Expect each
-push to reset the reviewer labels/status (reset-on-push) — that is normal; key
-the loop off findings + CI, not labels. Stop after MAX_ROUNDS rounds, or if a
-dismissed finding is re-raised, and report. At the very end print the
-`=== SDK RESOLVE SUMMARY ===` block from ORCHESTRATION Phase 4 verbatim."""
+separate sandbox; you trigger it with `@sdk-review` (post as-is; the reviewer
+workflow now accepts the sandbox bot identity) and consume its comment.
+Do NOT `gh pr merge` — stop at merge-ready and hand back to a human. When you
+finish (merge-ready OR NEEDS_HUMAN), REQUEST HUMAN REVIEW: run
+`gh pr edit {pr_number} --add-reviewer {reviewers}` (ignore "can't request from
+the author" errors) and post the final report @-mentioning {tag_list} so they
+know it's their turn. Expect each push to reset the reviewer labels/status
+(reset-on-push) — that is normal; key the loop off findings + CI, not labels.
+Stop after MAX_ROUNDS rounds, or if a dismissed finding is re-raised, and
+report. At the very end print the `=== SDK RESOLVE SUMMARY ===` block from
+ORCHESTRATION Phase 4 verbatim."""
+
+
+def _reviewer_handles(reviewers: str, requester: str) -> list[str]:
+    """Ordered, de-duplicated GitHub handles: configured reviewers + requester."""
+    handles: list[str] = []
+    for h in [*reviewers.split(","), requester]:
+        h = h.strip().lstrip("@")
+        if h and h not in handles:
+            handles.append(h)
+    return handles
 
 
 def build_payload(
-    pr_number: str, gha_run_url: str, max_rounds: int, run_date: str
+    pr_number: str,
+    gha_run_url: str,
+    max_rounds: int,
+    run_date: str,
+    reviewers: str,
+    requester: str,
 ) -> dict[str, Any]:
     return {
         "mode": "direct",
@@ -101,13 +131,17 @@ def build_payload(
         "repositories": ["atlanhq/application-sdk"],
         "base_branch": "main",
         "snapshot": "_base",
-        "prompt": build_prompt(pr_number, gha_run_url, max_rounds),
+        "prompt": build_prompt(
+            pr_number, gha_run_url, max_rounds, reviewers, requester
+        ),
         "max_timeout_seconds": STREAM_TIMEOUT_SECONDS,
         "idle_timeout_seconds": 1800,
         "metadata": {
             "pr_number": pr_number,
             "max_rounds": max_rounds,
             "run_date": run_date,
+            "reviewers": reviewers,
+            "requester": requester,
         },
     }
 
@@ -355,13 +389,17 @@ def main() -> int:
     gha_run_url = os.environ.get("GHA_RUN_URL", "")
     run_date = os.environ.get("RUN_DATE") or time.strftime("%Y-%m-%d", time.gmtime())
     max_rounds = _max_rounds()
+    reviewers = os.environ.get("REVIEWERS", "cmgrote,vaibhavatlan")
+    requester = os.environ.get("REQUESTER", "")
     print(f"Dispatching SDK Resolve: pr={pr_number} max_rounds={max_rounds}")
 
     if not check_health(base_url):
         print("::error::Cannot reach mothership after retries")
         return 1
 
-    payload = build_payload(pr_number, gha_run_url, max_rounds, run_date)
+    payload = build_payload(
+        pr_number, gha_run_url, max_rounds, run_date, reviewers, requester
+    )
     req = urllib.request.Request(
         f"{base_url}/api/sandbox/execute",
         data=json.dumps(payload).encode(),

--- a/.github/scripts/tests/test_sdk_resolve_dispatch.py
+++ b/.github/scripts/tests/test_sdk_resolve_dispatch.py
@@ -21,20 +21,41 @@ def _stream(*lines: str):
 
 
 def test_payload_shape():
-    p = sr.build_payload("1234", "http://run", 8, "2026-07-08")
+    p = sr.build_payload(
+        "1234", "http://run", 8, "2026-07-08", "cmgrote,vaibhavatlan", "octocat"
+    )
     assert p["mode"] == "direct" and p["stream"] is True
     assert p["source_id"] == "sdk-resolve-1234-2026-07-08"
     assert p["repositories"] == ["atlanhq/application-sdk"]
     assert p["metadata"]["pr_number"] == "1234"
     assert p["metadata"]["max_rounds"] == 8
+    assert p["metadata"]["reviewers"] == "cmgrote,vaibhavatlan"
+    assert p["metadata"]["requester"] == "octocat"
 
 
-def test_prompt_carries_pr_and_stop_line():
-    prompt = sr.build_prompt("42", "u", 8)
+def test_prompt_carries_pr_stop_line_and_review_request():
+    prompt = sr.build_prompt("42", "u", 8, "cmgrote,vaibhavatlan", "octocat")
     assert "PR_NUMBER:    42" in prompt
     assert "MERGE-READY" in prompt
     assert "Do NOT `gh pr merge`" in prompt  # human merges
     assert "pr-resolve/ORCHESTRATION.md" in prompt
+    # requests human review + tags reviewers AND the requester
+    assert "gh pr edit 42 --add-reviewer cmgrote,vaibhavatlan" in prompt
+    assert "@cmgrote" in prompt and "@vaibhavatlan" in prompt and "@octocat" in prompt
+
+
+def test_reviewer_handles_dedupe_and_strip():
+    # strips '@', de-dupes, appends requester, drops blanks
+    assert sr._reviewer_handles("@cmgrote, vaibhavatlan", "octocat") == [
+        "cmgrote",
+        "vaibhavatlan",
+        "octocat",
+    ]
+    # requester already in the reviewer list → not duplicated
+    assert sr._reviewer_handles("cmgrote,vaibhavatlan", "cmgrote") == [
+        "cmgrote",
+        "vaibhavatlan",
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/.github/workflows/sdk-resolve.yml
+++ b/.github/workflows/sdk-resolve.yml
@@ -49,7 +49,7 @@ jobs:
       github.event_name == 'workflow_dispatch'
       || (
         github.event.issue.pull_request
-        && contains(github.event.comment.body, '@sdk-resolve')
+        && startsWith(github.event.comment.body, '@sdk-resolve')
         && (
           github.event.comment.author_association == 'OWNER'
           || github.event.comment.author_association == 'MEMBER'

--- a/.github/workflows/sdk-resolve.yml
+++ b/.github/workflows/sdk-resolve.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Checkout repo (for local globalprotect-connect action)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Resolve PR number
+      - name: Resolve PR number + requester
         id: parse
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
@@ -77,10 +77,19 @@ jobs:
             const prNumber = isDispatch
               ? context.payload.inputs.pr_number
               : String(context.payload.issue.number);
+            const requester = isDispatch
+              ? context.actor
+              : context.payload.comment.user.login;
             core.setOutput('pr_number', prNumber);
+            core.setOutput('requester', requester);
 
-      - name: React to comment
+      # Acknowledge with an eyes reaction AND a visible comment carrying the
+      # run link, so the requester has an immediate status handle to follow
+      # (the sandbox loop runs out-of-band for many minutes).
+      - name: Acknowledge + link the run
         if: github.event_name == 'issue_comment'
+        env:
+          GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
@@ -89,6 +98,20 @@ jobs:
               repo: context.repo.repo,
               comment_id: context.payload.comment.id,
               content: 'eyes',
+            });
+            const body = [
+              `<!-- SDK_RESOLVE_STARTED -->`,
+              `🤖 **SDK Resolve started.** Driving this PR toward merge-ready — fixing CI + every \`@sdk-review\` finding, then requesting human review.`,
+              ``,
+              `[Follow progress →](${process.env.GHA_RUN_URL})`,
+              ``,
+              `_This runs out-of-band and can take several minutes; I'll comment here when it finishes._`,
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: parseInt('${{ steps.parse.outputs.pr_number }}', 10),
+              body,
             });
 
       - name: Connect to VPN (attempt 1/3)
@@ -163,5 +186,9 @@ jobs:
           HARNESS_TOKEN: ${{ secrets.HARNESS_TOKEN }}
           PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
           MAX_ROUNDS: ${{ inputs.max_rounds || '8' }}
+          # Human reviewers to request + tag when the PR reaches merge-ready
+          # (Chris = cmgrote, Vaibhav = vaibhavatlan); the requester is added too.
+          REVIEWERS: cmgrote,vaibhavatlan
+          REQUESTER: ${{ steps.parse.outputs.requester }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: python3 .github/scripts/sdk_resolve_dispatch.py

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -86,6 +86,10 @@ jobs:
           || github.event.comment.author_association == 'MEMBER'
           || github.event.comment.author_association == 'COLLABORATOR'
           || github.event.comment.user.login == 'atlan-ci'
+          || (
+            github.event.comment.user.login == 'mothership-ai[bot]'
+            && !contains(github.event.comment.body, '<!-- SDK_REVIEW -->')
+          )
         )
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -80,16 +80,13 @@ jobs:
       github.event_name == 'workflow_dispatch'
       || (
         github.event.issue.pull_request
-        && contains(github.event.comment.body, '@sdk-review')
+        && startsWith(github.event.comment.body, '@sdk-review')
         && (
           github.event.comment.author_association == 'OWNER'
           || github.event.comment.author_association == 'MEMBER'
           || github.event.comment.author_association == 'COLLABORATOR'
           || github.event.comment.user.login == 'atlan-ci'
-          || (
-            github.event.comment.user.login == 'mothership-ai[bot]'
-            && !contains(github.event.comment.body, '<!-- SDK_REVIEW -->')
-          )
+          || github.event.comment.user.login == 'mothership-ai[bot]'
         )
       )
     runs-on: ubuntu-latest

--- a/.mothership/pr-resolve/ORCHESTRATION.md
+++ b/.mothership/pr-resolve/ORCHESTRATION.md
@@ -137,13 +137,22 @@ Print at end: `[Phase 3 complete] rounds=<R>, converged=<yes|no>`
 
 ---
 
-## Phase 4: Stop at merge-ready + report (do NOT merge)
+## Phase 4: Hand to human review + report (do NOT merge)
 
-1. Post a final PR comment: rounds taken, findings fixed vs dismissed (with the
-   dismissal rationales), final CI + verdict, and — if stopped short — exactly
-   what remains and why (round cap / re-raised-after-dismiss / ambiguous fork).
-2. **Do NOT `gh pr merge`.** Leave the merge to a human.
-3. Emit this block verbatim (the dispatch script parses it):
+1. **Request human review** (from the prompt header: `REVIEWERS` handles +
+   `REQUESTER`). This runs whether the outcome is merge-ready OR `NEEDS_HUMAN` —
+   either way the PR is now a human's:
+   ```bash
+   gh pr edit <PR> --add-reviewer <REVIEWERS>   # ignore "can't request from the author"
+   ```
+2. Post a final PR comment that **@-mentions `TAG_LIST`** (the reviewers + the
+   requester) so they know it's their turn, and includes: rounds taken, findings
+   fixed vs dismissed (with dismissal rationales), final CI + verdict, and — if
+   stopped short — exactly what remains and why (round cap /
+   re-raised-after-dismiss / ambiguous fork). State plainly whether it's
+   merge-ready (green + zero findings + `READY_TO_MERGE`) or needs their call.
+3. **Do NOT `gh pr merge`.** Leave the merge to a human.
+4. Emit this block verbatim (the dispatch script parses it):
    ```
    === SDK RESOLVE SUMMARY ===
    pr: <N>


### PR DESCRIPTION
Follow-up to #2583, from the first live `@sdk-resolve` test on #2482.

## What the test showed
The resolver **worked** — it fixed 7 review findings, dismissed 1 with a recorded rationale, and got CI green (48 checks pass). But it **couldn't close the loop**: the sandbox authenticates as `mothership-ai[bot]` (`author_association: CONTRIBUTOR`), and `sdk-review.yml`'s gate only allowed OWNER/MEMBER/COLLABORATOR/`atlan-ci`. So its programmatic `@sdk-review` re-trigger comments were **skipped**, and it stopped at `NEEDS_HUMAN` asking a person to post `@sdk-review`. It also gave no visible status (just an 👀 reaction).

## Fixes

**1. Let the resolver trigger the reviewer (the core unblock)**
`sdk-review.yml` now also fires for comments from **`mothership-ai[bot]`**, guarded so it triggers *only* on a plain `@sdk-review` comment — **never** on the reviewer's own output (any comment carrying the `<!-- SDK_REVIEW -->` marker), which would create a self-review loop. This lets `@sdk-resolve` drive the review↔fix loop to conclusion with no human in the middle.

**2. Hand the PR to human review at the end** *(new requirement)*
When the resolver finishes — merge-ready **or** `NEEDS_HUMAN` — it now:
- `gh pr edit <PR> --add-reviewer cmgrote,vaibhavatlan` (requests Chris + Vaibhav)
- posts a final comment **@-mentioning the reviewers + the person who ran `@sdk-resolve`**, stating plainly whether it's merge-ready or needs their call.

**3. Visible status**
`@sdk-resolve` now posts a "SDK Resolve started" comment with the **run link** (`<!-- SDK_RESOLVE_STARTED -->`) so the requester has something to follow, instead of just an emoji reaction.

## Handles
Chris = `cmgrote`, Vaibhav = `vaibhavatlan` (from CODEOWNERS). Reviewers are a workflow env (`REVIEWERS`) so they're easy to change.

## Test
`python -m pytest .github/scripts/tests/test_sdk_resolve_dispatch.py` — **19 green**, ruff clean, both workflow YAMLs valid. New coverage: reviewer-handle de-dup, review-request wording in the prompt, requester tagging.

## Note
Once merged, re-run `@sdk-resolve` on #2482 — it should now trigger the reviewer itself, converge, request Chris/Vaibhav as reviewers, and tag you. The mothership `workflow_dispatch` 403 is separate (installation-token scope) and not needed for the comment-trigger path.