### PR TITLE
feat(contract): optional AE WorkflowOwnership field in the app contract

### DIFF
--- a/application_sdk/handler/manifest.py
+++ b/application_sdk/handler/manifest.py
@@ -79,3 +79,7 @@ class AppManifest(BaseModel):
     execution_mode: str
     dag: dict[str, DagNode]
     init_endpoint: str | None = None
+    # AE WorkflowOwnership ("SYSTEM" | "USER"). None when the app does not
+    # declare it — the orchestration layer then derives ownership from the app's
+    # is_system_app registry flag (and AE keeps an existing workflow's value).
+    ownership: str | None = None

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -229,6 +229,14 @@ emitGeneratedArtifacts: Boolean = true
 /// can omit this property entirely.
 workflowType: String?
 
+/// AE WorkflowOwnership written to `manifest.json` as `ownership`.
+/// `"SYSTEM"` = Atlan-managed (hidden from the internal Workflow Center by
+/// default); `"USER"` = customer-managed (visible). When unset (the default),
+/// the orchestration layer resolves ownership from the app's `is_system_app`
+/// registry flag, so most apps omit this — set it only when an app's correct
+/// workflow ownership must differ from that flag.
+ownership: ("SYSTEM"|"USER")?
+
 /// Task queue prefix for the extract node in the AE manifest.
 taskQueuePrefix: String = "atlan-\(name)"
 
@@ -2156,6 +2164,11 @@ class ScheduleSpec {
 
 local manifestData: Mapping<String, Any> = new Mapping {
   ["execution_mode"] = "automation-engine"
+  // AE WorkflowOwnership; omitted when unset so the orchestration layer applies
+  // its is_system_app-derived default (and AE keeps an existing workflow's value).
+  when (ownership != null) {
+    ["ownership"] = ownership
+  }
   ["dag"] = generateDAG()
   // DISTR-815: emit triggers.schedules when the entrypoint declares schedules,
   // so the cron lives in the manifest itself (not a separate file).

--- a/contract-toolkit/tests/fixtures/system_ownership.pkl
+++ b/contract-toolkit/tests/fixtures/system_ownership.pkl
@@ -1,0 +1,8 @@
+/// Fixture: app that declares ownership = "SYSTEM".
+///
+/// Exercises the WorkflowOwnership contract field emitting into the generated
+/// manifest. Reuses the fully-defaulted default-pipeline fixture and only sets
+/// ownership, so the test isolates the ownership behaviour.
+amends "default_pipeline.pkl"
+
+ownership = "SYSTEM"

--- a/contract-toolkit/tests/workflow_ownership_test.pkl
+++ b/contract-toolkit/tests/workflow_ownership_test.pkl
@@ -1,0 +1,32 @@
+// Tests for the AE WorkflowOwnership contract field (App.ownership).
+//
+// ownership is written verbatim to manifest.json as `ownership` when set, and
+// omitted entirely when unset — so the orchestration layer applies its
+// is_system_app-derived default and AE keeps an existing workflow's ownership.
+
+amends "pkl:test"
+
+import "pkl:json"
+import "fixtures/system_ownership.pkl" as systemApp
+import "fixtures/default_pipeline.pkl" as defaultApp
+
+local systemManifest = new json.Parser { useMapping = true }.parse(
+  systemApp.output.files["app/generated/manifest.json"].text
+)
+local defaultManifest = new json.Parser { useMapping = true }.parse(
+  defaultApp.output.files["app/generated/manifest.json"].text
+)
+
+facts {
+  ["ownership = SYSTEM is emitted verbatim into the manifest"] {
+    systemManifest["ownership"] == "SYSTEM"
+  }
+
+  ["an app that omits ownership emits no ownership key (=> orchestration default)"] {
+    !defaultManifest.containsKey("ownership")
+  }
+
+  ["ownership does not disturb execution_mode"] {
+    systemManifest["execution_mode"] == "automation-engine"
+  }
+}

--- a/tests/unit/handler/test_manifest_ownership.py
+++ b/tests/unit/handler/test_manifest_ownership.py
@@ -1,0 +1,19 @@
+"""AppManifest carries the AE WorkflowOwnership field (SYSTEM/USER)."""
+
+from application_sdk.handler.manifest import AppManifest
+
+
+def test_ownership_defaults_to_none_when_absent():
+    m = AppManifest(execution_mode="automation-engine", dag={})
+    assert m.ownership is None
+    # Omitted from serialized output by default so the orchestration layer
+    # applies its is_system_app-derived default.
+    assert "ownership" not in m.model_dump(exclude_none=True)
+
+
+def test_ownership_roundtrips_when_set():
+    m = AppManifest.model_validate(
+        {"execution_mode": "automation-engine", "dag": {}, "ownership": "SYSTEM"}
+    )
+    assert m.ownership == "SYSTEM"
+    assert '"ownership":"SYSTEM"' in m.model_dump_json().replace(" ", "")


### PR DESCRIPTION
## What

Adds an optional **`ownership`** (`SYSTEM` | `USER`) field to the app contract so a **new app can declare its AE WorkflowOwnership in its versioned contract** — correct-by-construction — instead of relying on the `is_system_app` marketplace flag being toggled in the admin UI (which is applied unevenly today: 26/175 apps, inconsistent).

This is the **Phase-2, opt-in override** in the cross-repo ownership rollout. Precedence at workflow create/version time:

```
manifest.ownership  >  is_system_app == true → SYSTEM  >  omit (AE inherits / defaults USER)
```

## Changes

- **`contract-toolkit/src/App.pkl`** — new optional `ownership: ("SYSTEM"|"USER")?`, emitted into `manifest.json` under `when (ownership != null)`. An app that omits it produces **no** `ownership` key, so the orchestration layer applies its `is_system_app`-derived default and AE keeps an existing workflow's value (never clobbered).
- **`application_sdk/handler/manifest.py`** — `AppManifest` gains `ownership: str | None = None`.
- **Tests** — `contract-toolkit/tests/workflow_ownership_test.pkl` (+ `system_ownership` fixture) and `tests/unit/handler/test_manifest_ownership.py`.

## Verification

- `pkl test tests/*.pkl` → **244 passed** (incl. 3 new ownership facts); verified via `pkl eval` that `ownership="SYSTEM"` emits `"ownership":"SYSTEM"` and that omitting it emits no key.
- handler unit tests → **269 passed**; new Python tests green.
- No manifest-key allowlist in the conformance suite rejects the field (validation is structural against `AppManifest`). CI conformance should confirm.

## Consumers

- **atlan-local-marketplace-app#538** already reads `manifest["ownership"]` (tier 1) before falling back to `is_system_app` — no change needed there.
- **heracles#6153** needs a **1-line follow-up** to read the manifest `ownership` on its native-app create path (today it passes `nil` for the manifest tier; the `is_system_app` default already works).

## ⚠️ Coordination

`App.pkl` overlaps in-flight **AUT-1052** contract-toolkit work (the parked #2469 touches the same file). The footprint here is deliberately minimal (one field decl + one guarded emission) to rebase easily — **please coordinate before merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)