### PR TITLE
ci(sdk-review): redact internal infra details from SDK review VPN-failure comment

### DIFF
--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -340,20 +340,19 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          PORTAL_URL: ${{ vars.GLOBALPROTECT_PORTAL_URL }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
             const runUrl = process.env.GHA_RUN_URL;
             const body = [
-              `⚠️ **SDK Review failed: could not connect to VPN.**`,
+              `⚠️ **SDK Review couldn't start due to a transient infrastructure issue.**`,
               ``,
-              `All 3 VPN connection attempts to \`${process.env.PORTAL_URL || 'the VPN portal'}\` failed. This is usually a transient infrastructure issue.`,
+              `The review environment was temporarily unreachable. This is usually transient.`,
               ``,
               `[View workflow logs](${runUrl})`,
               ``,
-              `Please retry by commenting \`@sdk-review\` again. If it keeps failing, flag it in \`#bu-platform-engineering\`.`,
+              `Please retry by commenting \`@sdk-review\` again. If it keeps failing, reach out to the platform team.`,
             ].join('\n');
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## Problem

When the SDK review workflow's VPN connection fails 3×, it posts a comment on the PR. That comment surfaced **internal infrastructure details on a public repo**:

- the internal GlobalProtect **portal hostname** (`vars.GLOBALPROTECT_PORTAL_URL`, e.g. `vpn2.atlan.app`)
- the internal Slack channel `#bu-platform-engineering`

`application-sdk` is public, so anyone viewing the PR (including external contributors) could see these.

## Fix

`.github/workflows/sdk-review.yml` — make the posted comment generic and drop the now-unused `PORTAL_URL` env:

- "could not connect to VPN … attempts to \`<host>\` failed" → "couldn't start due to a transient infrastructure issue … the review environment was temporarily unreachable"
- "flag it in \`#bu-platform-engineering\`" → "reach out to the platform team"

The retry UX is unchanged (author is still told to re-comment `@sdk-review` and still gets the workflow-logs link) — only the infra specifics are removed.

## Note (out of scope, flagging)

The GlobalProtect portal hostname still appears in the **public Actions logs** (openconnect prints `Connecting to VPN portal: https://<host>` during the connect step). Fully scrubbing that lives in the shared mothership VPN-connect action, not here. This PR removes the most prominent leak — the one rendered directly on the PR conversation.