### PR TITLE
ci(build-publish): mirror semver release tags to Docker Hub for SDR pulls

### DIFF
--- a/.github/scripts/mirror_tags_dockerhub.py
+++ b/.github/scripts/mirror_tags_dockerhub.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Mirror semver release tags from GHCR onto Docker Hub for SDR deploys.
+
+Self-deployed-runtime (SDR) apps pull images by their semver tag from Docker
+Hub (``docker.io/atlanhq/<app>:<version>``).  The merge/build step already
+pushes the full tag ladder (``:X.Y.Z``, ``:X.Y``, ``:X``, ``:latest``) to GHCR
+via ``RELEASE_TAGS``, but the Docker Hub step only ``crane copy``s the
+branch-sha image.  Without this script only the branch-sha tag lands on Docker
+Hub, so any SDR pull of ``:<version>`` 404s with *manifest unknown*.
+
+Each ``crane tag`` is a server-side manifest tag against the same digest that
+was already pushed by the preceding ``crane copy`` — no blob re-upload.
+
+Usage (from within a workflow step)::
+
+    python3 .github/scripts/mirror_tags_dockerhub.py \\
+        --dockerhub-image "docker.io/atlanhq/my-app:main-abc1234" \\
+        --release-tags "ghcr.io/atlanhq/my-app:2.0.1\\nghcr.io/atlanhq/my-app:2.0\\n..."
+
+Exits 0 when no ``--release-tags`` are supplied (no-op for non-release builds).
+
+Replaces inline conditional shell that used to live in the
+*Push to Docker Hub* step of ``.github/workflows/build-and-publish-app.yaml``.
+See ``docs/standards/ci.md`` for why branching logic lives in scripts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+
+def run(cmd: list[str]) -> None:
+    """Execute *cmd* and raise on non-zero exit.
+
+    Single thin wrapper so tests can monkeypatch the external ``crane`` call
+    while letting the rest of the logic run for real.
+    """
+    subprocess.run(cmd, check=True)
+
+
+def mirror_tags(dockerhub_image: str, release_tags: str) -> list[str]:
+    """Apply each tag from *release_tags* to *dockerhub_image* via ``crane tag``.
+
+    Args:
+        dockerhub_image: The Docker Hub image reference that was already pushed
+            (e.g. ``docker.io/atlanhq/my-app:main-abc1234``).  The function
+            derives the registry/repo prefix by stripping the tag suffix.
+        release_tags: Newline-separated GHCR image references whose tags should
+            be mirrored (e.g. ``ghcr.io/atlanhq/my-app:2.0.1``).  Empty string
+            or whitespace-only lines are silently skipped.
+
+    Returns:
+        List of Docker Hub refs that were tagged (for logging / test assertions).
+    """
+    if not release_tags or not release_tags.strip():
+        return []
+
+    # Strip the tag from the DockerHub ref once — shared prefix for echo lines.
+    dh_repo = dockerhub_image.rsplit(":", 1)[0]
+
+    tagged: list[str] = []
+    for ref in release_tags.splitlines():
+        ref = ref.strip()
+        if not ref:
+            continue
+        # ghcr.io/atlanhq/<app>:2.0.1  →  2.0.1
+        tag = ref.rsplit(":", 1)[-1]
+        run(["crane", "tag", dockerhub_image, tag])
+        dest = f"{dh_repo}:{tag}"
+        print(f"Tagged on DockerHub: {dest}", flush=True)
+        tagged.append(dest)
+
+    return tagged
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dockerhub-image",
+        required=True,
+        help="Docker Hub image ref pushed by the preceding crane copy step.",
+    )
+    parser.add_argument(
+        "--release-tags",
+        default="",
+        help="Newline-separated GHCR refs whose tags should be mirrored. "
+        "Empty/omitted → no-op.",
+    )
+    args = parser.parse_args(argv)
+
+    mirror_tags(args.dockerhub_image, args.release_tags)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/.github/scripts/tests/test_mirror_tags_dockerhub.py
+++ b/.github/scripts/tests/test_mirror_tags_dockerhub.py
@@ -1,0 +1,177 @@
+"""Tests for .github/scripts/mirror_tags_dockerhub.py.
+
+Covers the conditional logic that used to be inlined in the
+*Push to Docker Hub* step of build-and-publish-app.yaml:
+
+  * Empty / whitespace-only release_tags → no crane calls (no-op).
+  * Non-empty release_tags → ``crane tag`` called once per non-empty line.
+  * Blank lines inside release_tags are skipped.
+  * The returned list reflects exactly the Docker Hub refs that were tagged.
+  * ``crane`` failures propagate (subprocess.CalledProcessError is not swallowed).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import mirror_tags_dockerhub as mod
+
+DOCKERHUB_IMAGE = "docker.io/atlanhq/atlan-mysql-app:main-abc1234"
+GHCR_BASE = "ghcr.io/atlanhq/atlan-mysql-app"
+DH_REPO = "docker.io/atlanhq/atlan-mysql-app"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_release_tags(*tags: str) -> str:
+    return "\n".join(f"{GHCR_BASE}:{t}" for t in tags)
+
+
+# ---------------------------------------------------------------------------
+# No-op cases
+# ---------------------------------------------------------------------------
+
+
+class TestNoOp:
+    def test_empty_string_no_crane_call(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[list[str]] = []
+        monkeypatch.setattr(mod, "run", lambda cmd: calls.append(cmd))
+        result = mod.mirror_tags(DOCKERHUB_IMAGE, "")
+        assert calls == []
+        assert result == []
+
+    def test_whitespace_only_no_crane_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[list[str]] = []
+        monkeypatch.setattr(mod, "run", lambda cmd: calls.append(cmd))
+        result = mod.mirror_tags(DOCKERHUB_IMAGE, "   \n  \n")
+        assert calls == []
+        assert result == []
+
+    def test_none_release_tags_no_crane_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[list[str]] = []
+        monkeypatch.setattr(mod, "run", lambda cmd: calls.append(cmd))
+        # Simulate omitted --release-tags (argparse default is "")
+        result = mod.mirror_tags(DOCKERHUB_IMAGE, "")
+        assert calls == []
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Tag mirroring
+# ---------------------------------------------------------------------------
+
+
+class TestMirrorTags:
+    def test_single_tag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[list[str]] = []
+        monkeypatch.setattr(mod, "run", lambda cmd: calls.append(cmd))
+
+        release_tags = _make_release_tags("2.0.1")
+        result = mod.mirror_tags(DOCKERHUB_IMAGE, release_tags)
+
+        assert calls == [["crane", "tag", DOCKERHUB_IMAGE, "2.0.1"]]
+        assert result == [f"{DH_REPO}:2.0.1"]
+
+    def test_full_semver_ladder(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """All four tags (:X.Y.Z, :X.Y, :X, :latest) are mirrored."""
+        calls: list[list[str]] = []
+        monkeypatch.setattr(mod, "run", lambda cmd: calls.append(cmd))
+
+        release_tags = _make_release_tags("2.0.1", "2.0", "2", "latest")
+        result = mod.mirror_tags(DOCKERHUB_IMAGE, release_tags)
+
+        assert [c[3] for c in calls] == ["2.0.1", "2.0", "2", "latest"]
+        assert result == [
+            f"{DH_REPO}:2.0.1",
+            f"{DH_REPO}:2.0",
+            f"{DH_REPO}:2",
+            f"{DH_REPO}:latest",
+        ]
+
+    def test_blank_lines_in_tags_are_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[list[str]] = []
+        monkeypatch.setattr(mod, "run", lambda cmd: calls.append(cmd))
+
+        release_tags = f"{GHCR_BASE}:2.0.1\n\n{GHCR_BASE}:2.0\n  \n{GHCR_BASE}:2"
+        result = mod.mirror_tags(DOCKERHUB_IMAGE, release_tags)
+
+        assert [c[3] for c in calls] == ["2.0.1", "2.0", "2"]
+        assert len(result) == 3
+
+    def test_tag_extracted_from_ghcr_ref(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The tag portion after ':' is correctly extracted from GHCR refs."""
+        calls: list[list[str]] = []
+        monkeypatch.setattr(mod, "run", lambda cmd: calls.append(cmd))
+
+        ref = f"{GHCR_BASE}:3.1.4"
+        mod.mirror_tags(DOCKERHUB_IMAGE, ref)
+
+        assert calls[0] == ["crane", "tag", DOCKERHUB_IMAGE, "3.1.4"]
+
+    def test_dockerhub_repo_prefix_derived_correctly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Return value uses the DH repo prefix (without the source tag)."""
+        monkeypatch.setattr(mod, "run", lambda cmd: None)
+
+        release_tags = _make_release_tags("1.2.3")
+        result = mod.mirror_tags("docker.io/atlanhq/other-app:branch-sha", release_tags)
+
+        assert result == ["docker.io/atlanhq/other-app:1.2.3"]
+
+
+# ---------------------------------------------------------------------------
+# Error propagation
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPropagation:
+    def test_crane_failure_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _fail(cmd: list[str]) -> None:
+            raise subprocess.CalledProcessError(1, cmd)
+
+        monkeypatch.setattr(mod, "run", _fail)
+
+        with pytest.raises(subprocess.CalledProcessError):
+            mod.mirror_tags(DOCKERHUB_IMAGE, _make_release_tags("2.0.1"))
+
+
+# ---------------------------------------------------------------------------
+# CLI entry-point
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_main_no_release_tags(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[list[str]] = []
+        monkeypatch.setattr(mod, "run", lambda cmd: calls.append(cmd))
+        mod.main(["--dockerhub-image", DOCKERHUB_IMAGE])
+        assert calls == []
+
+    def test_main_with_release_tags(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[list[str]] = []
+        monkeypatch.setattr(mod, "run", lambda cmd: calls.append(cmd))
+        mod.main(
+            [
+                "--dockerhub-image",
+                DOCKERHUB_IMAGE,
+                "--release-tags",
+                _make_release_tags("2.0.1", "2.0"),
+            ]
+        )
+        assert [c[3] for c in calls] == ["2.0.1", "2.0"]

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -1205,6 +1205,7 @@ jobs:
         env:
           GHCR_IMAGE:      ${{ needs.prepare.outputs.ghcr_image }}
           DOCKERHUB_IMAGE: ${{ needs.prepare.outputs.dockerhub_image }}
+          RELEASE_TAGS:    ${{ needs.prepare.outputs.release_tags }}
         run: |
           set -euo pipefail
           # Use `crane copy`, not `docker buildx imagetools create`, for the
@@ -1217,6 +1218,22 @@ jobs:
           # login steps above.
           crane copy "${GHCR_IMAGE}" "${DOCKERHUB_IMAGE}"
           echo "Pushed to DockerHub: ${DOCKERHUB_IMAGE}"
+
+          # Mirror the release version-tag ladder (e.g. :2.0.1, :2.0, :2, :latest)
+          # onto Docker Hub too. GHCR already got these tags in the merge step, but
+          # self-deployed-runtime (SDR) pulls apps by their semver tag from Docker
+          # Hub — without this only the branch-sha tag lands there, and an SDR pull
+          # of :<version> 404s with "manifest unknown". The image already exists on
+          # Docker Hub from the copy above, so each entry is a server-side tag op
+          # against the same digest (crane tag) — no blob re-upload.
+          if [ -n "${RELEASE_TAGS}" ]; then
+            while IFS= read -r ref; do
+              [ -n "$ref" ] || continue
+              tag="${ref##*:}"          # ghcr.io/atlanhq/<app>:2.0.1 -> 2.0.1
+              crane tag "${DOCKERHUB_IMAGE}" "${tag}"
+              echo "Tagged on DockerHub: ${DOCKERHUB_IMAGE%:*}:${tag}"
+            done <<< "${RELEASE_TAGS}"
+          fi
 
           # Resolve the pushed manifest digest so we can sign by digest (immutable)
           # rather than by tag (mutable). `${DOCKERHUB_IMAGE%%:*}` strips the tag.

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -1220,20 +1220,11 @@ jobs:
           echo "Pushed to DockerHub: ${DOCKERHUB_IMAGE}"
 
           # Mirror the release version-tag ladder (e.g. :2.0.1, :2.0, :2, :latest)
-          # onto Docker Hub too. GHCR already got these tags in the merge step, but
-          # self-deployed-runtime (SDR) pulls apps by their semver tag from Docker
-          # Hub — without this only the branch-sha tag lands there, and an SDR pull
-          # of :<version> 404s with "manifest unknown". The image already exists on
-          # Docker Hub from the copy above, so each entry is a server-side tag op
-          # against the same digest (crane tag) — no blob re-upload.
-          if [ -n "${RELEASE_TAGS}" ]; then
-            while IFS= read -r ref; do
-              [ -n "$ref" ] || continue
-              tag="${ref##*:}"          # ghcr.io/atlanhq/<app>:2.0.1 -> 2.0.1
-              crane tag "${DOCKERHUB_IMAGE}" "${tag}"
-              echo "Tagged on DockerHub: ${DOCKERHUB_IMAGE%:*}:${tag}"
-            done <<< "${RELEASE_TAGS}"
-          fi
+          # onto Docker Hub. Branching logic lives in a tested script per
+          # docs/standards/ci.md.
+          python3 .github/scripts/mirror_tags_dockerhub.py \
+            --dockerhub-image "${DOCKERHUB_IMAGE}" \
+            --release-tags "${RELEASE_TAGS}"
 
           # Resolve the pushed manifest digest so we can sign by digest (immutable)
           # rather than by tag (mutable). `${DOCKERHUB_IMAGE%%:*}` strips the tag.


### PR DESCRIPTION
## Problem

Apps on the semver release model (`release_model: semver`, `self_deployed_runtime: true`) fail to install on the **SDR orchestrator** — it pulls `docker.io/atlanhq/<app>:<version>` and gets `manifest unknown`.

Concrete case (HP / hp-pov, `atlan-mysql-app` 2.0.1):
```
Pulling image: docker.io/atlanhq/atlan-mysql-app:2.0.1
Deployment failed: 404 ... manifest for atlanhq/atlan-mysql-app:2.0.1 not found: manifest unknown
```
- `ghcr.io/atlanhq/atlan-mysql-app:2.0.1` → **exists** (HTTP 200)
- `docker.io/atlanhq/atlan-mysql-app:2.0.1` → **absent**; only `:main-bd2a695` was mirrored there

## Root cause

In the `merge` job, the multi-arch manifest step pushes the full version-tag ladder (`:X.Y.Z`, `:X.Y`, `:X`, `:latest`, `:sha-<sha>`) to **GHCR** via `RELEASE_TAGS`. But the **"Push to Docker Hub"** step only `crane copy`s the branch-sha image (`GHCR_IMAGE` → `DOCKERHUB_IMAGE` = `:<branch>-<sha>`). The semver tags never reach Docker Hub.

GHCR-backed deploys (LM / k8s reconciler) resolve `:<version>` fine because they pull from GHCR. **SDR pulls from Docker Hub by the semver tag**, so it 404s.

## Fix

After the branch-sha copy, mirror the same `RELEASE_TAGS` ladder onto Docker Hub with `crane tag`. The image already exists on Docker Hub from the copy above, so each entry is a server-side manifest tag against the **same digest** — no blob re-upload, no extra build.

```bash
if [ -n "${RELEASE_TAGS}" ]; then
  while IFS= read -r ref; do
    [ -n "$ref" ] || continue
    tag="${ref##*:}"                       # ghcr.io/atlanhq/<app>:2.0.1 -> 2.0.1
    crane tag "${DOCKERHUB_IMAGE}" "${tag}"
  done <<< "${RELEASE_TAGS}"
fi
```

## Scope / safety

- Only affects **release builds** of **`self_deployed_runtime` (SDR)** apps — the step is already gated on `enable_sdr == 'true'`, and `RELEASE_TAGS` is empty for non-release builds, so the loop is a no-op there.
- Branch-sha copy + cosign digest signing are unchanged (all semver tags share one digest, already signed).
- Brings Docker Hub to parity with the GHCR tag set that's already published today.

## Validation

- YAML validated.
- Immediate unblock for the mysql 2.0.1 case is a one-off `crane copy ghcr.io/atlanhq/atlan-mysql-app:2.0.1 docker.io/atlanhq/atlan-mysql-app:2.0.1`; this PR prevents recurrence for every semver SDR release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)