### PR TITLE
ci(fix): checkout SDK scripts before mirror_tags_dockerhub.py in merge job

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -1183,6 +1183,19 @@ jobs:
             while IFS= read -r tag; do [ -n "$tag" ] && echo "    ${tag}"; done <<< "${RELEASE_TAGS}"
           fi
 
+      - name: Checkout SDK helper scripts
+        # mirror_tags_dockerhub.py lives in the SDK repo, not the caller repo —
+        # this job has no checkout of its own (unlike prepare/certify/leak-scan),
+        # so the script must be pulled in explicitly before it's invoked below.
+        if: needs.prepare.outputs.enable_sdr == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: atlanhq/application-sdk
+          ref: main
+          path: .sdk-entrypoint
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
       - name: Install crane
         if: needs.prepare.outputs.enable_sdr == 'true'
         uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
@@ -1222,7 +1235,7 @@ jobs:
           # Mirror the release version-tag ladder (e.g. :2.0.1, :2.0, :2, :latest)
           # onto Docker Hub. Branching logic lives in a tested script per
           # docs/standards/ci.md.
-          python3 .github/scripts/mirror_tags_dockerhub.py \
+          python3 .sdk-entrypoint/.github/scripts/mirror_tags_dockerhub.py \
             --dockerhub-image "${DOCKERHUB_IMAGE}" \
             --release-tags "${RELEASE_TAGS}"
 


### PR DESCRIPTION
## Summary
- #2607 added a call to `mirror_tags_dockerhub.py` in the `merge` job of `build-and-publish-app.yaml`, but that job never checks out any repository — the script only lives in application-sdk, not in caller repos.
- Every SDR-enabled connector app build (atlan-powerbi-app, atlan-snowflake-app, atlan-tableau-app, etc.) has been failing since #2607 merged with `python3: can't open file '.../mirror_tags_dockerhub.py': [Errno 2] No such file or directory`.
- Adds a sparse checkout of the SDK's `.github/scripts` before the Docker Hub push step, mirroring the pattern already used by the `prepare`, `certify`, and `leak-scan` jobs in this same workflow.

Reported in Slack (external repos blocked from building/publishing).

## Test plan
- [x] `pre-commit run --files .github/workflows/build-and-publish-app.yaml` passes (done locally)
- [x] YAML parses cleanly (verified locally)
- [ ] Re-run a build in an SDR-enabled connector app (e.g. atlan-powerbi-app) against this branch ref and confirm the merge job's Docker Hub push step succeeds