### PR TITLE
fix(storage): plumb custom CA and NO_PROXY into obstore

### DIFF
--- a/application_sdk/storage/_obstore_config.py
+++ b/application_sdk/storage/_obstore_config.py
@@ -41,6 +41,14 @@ Client options (passed via ``S3Store(client_options=…)``):
   ``"atlan-application-sdk/{version}"`` so tenant operators can identify
   SDK traffic in S3 access logs.
 
+Proxy / TLS (obstore reads none of these itself, so we plumb them explicitly):
+
+* ``HTTPS_PROXY`` / ``HTTP_PROXY`` — obstore's ``proxy_url``.
+* ``NO_PROXY`` — obstore's ``proxy_excludes`` (only when a proxy is set).
+* ``SSL_CERT_DIR`` — custom CA certs for private-CA stores (e.g. self-hosted
+  MinIO), loaded into obstore's ``root_certificate``. Same env var httpx/aiohttp
+  and Temporal honor via ``clients/ssl_utils.py``.
+
 Retry config (passed via ``S3Store(retry_config=…)``):
 
 * ``ATLAN_OBSTORE_RETRY_MAX_RETRIES`` — overrides obstore's default of 10.
@@ -104,11 +112,20 @@ def _default_user_agent() -> str:
 def _obstore_proxy_url() -> str | None:
     """Return the proxy URL from HTTPS_PROXY/HTTP_PROXY, or None.
 
-    obstore doesn't read proxy env vars itself, so we pass ``proxy_url``
-    explicitly. NO_PROXY isn't honored — the binding has no per-host excludes.
+    obstore doesn't read proxy env vars itself, so we pass it explicitly.
     """
     proxies = urllib.request.getproxies()
     return proxies.get("https") or proxies.get("http") or None
+
+
+def _obstore_proxy_excludes() -> str | None:
+    """Return NO_PROXY (obstore's ``proxy_excludes``), or None.
+
+    Unlike Temporal — which knows its single target host and resolves the bypass
+    itself via ``proxy_bypass_environment`` — obstore matches NO_PROXY per-host
+    at request time, so we just hand it the raw list.
+    """
+    return urllib.request.getproxies_environment().get("no") or None
 
 
 def obstore_client_options() -> ClientConfig:
@@ -140,6 +157,17 @@ def obstore_client_options() -> ClientConfig:
     proxy_url = _obstore_proxy_url()
     if proxy_url:
         opts["proxy_url"] = proxy_url
+        proxy_excludes = _obstore_proxy_excludes()
+        if proxy_excludes:
+            opts["proxy_excludes"] = proxy_excludes
+
+    from application_sdk.clients.ssl_utils import (  # noqa: PLC0415
+        get_custom_ca_cert_bytes,
+    )
+
+    root_certificate = get_custom_ca_cert_bytes()
+    if root_certificate:
+        opts["root_certificate"] = root_certificate
     return opts
 
 
@@ -360,18 +388,22 @@ def log_obstore_config(
 
 
 def _redact_proxy_userinfo(client_options: ClientConfig) -> dict:
-    """Return a copy of *client_options* with any proxy_url credentials masked.
+    """Return a log-safe copy of *client_options* (the real config is untouched).
 
-    The real config keeps the userinfo (obstore needs it); only the log copy is
-    redacted so a `user:pass@` proxy never lands in logs.
+    Masks ``proxy_url`` credentials and shrinks ``root_certificate`` to a byte
+    count, so logs never carry a proxy password or a full PEM bundle.
     """
     opts = dict(client_options)
     proxy = opts.get("proxy_url")
-    if not isinstance(proxy, str):
-        return opts
-    p = urlsplit(proxy)
-    if p.username or p.password:
-        host = p.hostname or ""
-        netloc = f"***@{host}:{p.port}" if p.port else f"***@{host}"
-        opts["proxy_url"] = urlunsplit((p.scheme, netloc, p.path, p.query, p.fragment))
+    if isinstance(proxy, str):
+        p = urlsplit(proxy)
+        if p.username or p.password:
+            host = p.hostname or ""
+            netloc = f"***@{host}:{p.port}" if p.port else f"***@{host}"
+            opts["proxy_url"] = urlunsplit(
+                (p.scheme, netloc, p.path, p.query, p.fragment)
+            )
+    root_cert = opts.get("root_certificate")
+    if isinstance(root_cert, (bytes, str)):
+        opts["root_certificate"] = f"<{len(root_cert)} bytes>"
     return opts

--- a/tests/unit/storage/test_obstore_config.py
+++ b/tests/unit/storage/test_obstore_config.py
@@ -75,9 +75,15 @@ class TestClientOptionsOverrides:
         monkeypatch.setenv("ATLAN_OBSTORE_USER_AGENT", "custom-agent/1.0")
         monkeypatch.setenv("ATLAN_OBSTORE_POOL_MAX_IDLE_PER_HOST", "32")
 
-        # Pin no proxy so the exact-dict assertion is deterministic regardless
-        # of the host's proxy env / system settings.
-        with patch("urllib.request.getproxies", return_value={}):
+        # Pin no proxy and no custom CA so the exact-dict assertion is
+        # deterministic regardless of the host's proxy env / SSL_CERT_DIR.
+        with (
+            patch("urllib.request.getproxies", return_value={}),
+            patch(
+                "application_sdk.clients.ssl_utils.get_custom_ca_cert_bytes",
+                return_value=None,
+            ),
+        ):
             opts = obstore_client_options()
         assert opts == {
             "timeout": "1h",
@@ -131,6 +137,80 @@ class TestClientOptionsProxy:
         ):
             opts = obstore_client_options()
         assert opts["proxy_url"] == "http://secure.corp:8080"
+
+
+class TestClientOptionsProxyExcludes:
+    """NO_PROXY is forwarded as ``proxy_excludes`` — but only when a proxy URL is
+    resolved (obstore ignores it otherwise)."""
+
+    def test_no_proxy_excludes_forwarded_when_proxy_set(self, monkeypatch) -> None:
+        monkeypatch.setenv("NO_PROXY", "localhost,.svc.cluster.local,10.0.0.0/8")
+        with patch(
+            "urllib.request.getproxies",
+            return_value={"https": "http://proxy.corp:8080"},
+        ):
+            opts = obstore_client_options()
+        assert opts["proxy_excludes"] == "localhost,.svc.cluster.local,10.0.0.0/8"
+
+    def test_lowercase_no_proxy_is_honored(self, monkeypatch) -> None:
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        monkeypatch.setenv("no_proxy", "internal.example.com")
+        with patch(
+            "urllib.request.getproxies",
+            return_value={"https": "http://proxy.corp:8080"},
+        ):
+            opts = obstore_client_options()
+        assert opts["proxy_excludes"] == "internal.example.com"
+
+    def test_excludes_omitted_without_proxy_url(self, monkeypatch) -> None:
+        # obstore only consults proxy_excludes when proxy_url is set, so don't
+        # emit a dangling exclude list when there's no proxy.
+        monkeypatch.setenv("NO_PROXY", "localhost")
+        with patch("urllib.request.getproxies", return_value={}):
+            opts = obstore_client_options()
+        assert "proxy_excludes" not in opts
+
+    def test_excludes_omitted_when_no_proxy_unset(self, monkeypatch) -> None:
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+        with patch(
+            "urllib.request.getproxies",
+            return_value={"https": "http://proxy.corp:8080"},
+        ):
+            opts = obstore_client_options()
+        assert "proxy_excludes" not in opts
+
+
+# ---------------------------------------------------------------------------
+# root_certificate plumbing (custom CA from SSL_CERT_DIR → obstore)
+# ---------------------------------------------------------------------------
+
+
+class TestClientOptionsRootCertificate:
+    """SSL_CERT_DIR custom CAs are forwarded as obstore's ``root_certificate``."""
+
+    def test_root_certificate_set_when_custom_ca_present(self) -> None:
+        pem = b"-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----"
+        with (
+            patch("urllib.request.getproxies", return_value={}),
+            patch(
+                "application_sdk.clients.ssl_utils.get_custom_ca_cert_bytes",
+                return_value=pem,
+            ),
+        ):
+            opts = obstore_client_options()
+        assert opts["root_certificate"] == pem
+
+    def test_root_certificate_omitted_without_custom_ca(self) -> None:
+        with (
+            patch("urllib.request.getproxies", return_value={}),
+            patch(
+                "application_sdk.clients.ssl_utils.get_custom_ca_cert_bytes",
+                return_value=None,
+            ),
+        ):
+            opts = obstore_client_options()
+        assert "root_certificate" not in opts
 
 
 # ---------------------------------------------------------------------------
@@ -212,6 +292,22 @@ class TestLogObstoreConfig:
         formatted = fmt % tuple(args)
         assert "secretpass" not in formatted
         assert "***@proxy.corp:8080" in formatted
+
+    def test_summarizes_root_certificate_bytes(self) -> None:
+        """The full PEM bundle is noise — the log shows only a byte-count."""
+        pem = (
+            b"-----BEGIN CERTIFICATE-----\nsecretlookingcert\n-----END CERTIFICATE-----"
+        )
+        with patch("application_sdk.storage._obstore_config.logger") as mock_logger:
+            log_obstore_config(
+                "s3",
+                client_options={"root_certificate": pem},
+                retry_config=None,
+            )
+        fmt, *args = mock_logger.info.call_args.args
+        formatted = fmt % tuple(args)
+        assert "secretlookingcert" not in formatted
+        assert f"<{len(pem)} bytes>" in formatted
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Object storage fronted by a private CA (self-hosted MinIO, an S3-compatible API behind a corp proxy) failed TLS verification, and `NO_PROXY` was ignored. Both should have worked all along — obstore simply didn't expose the client options until 0.11.0, which this repo already pins. This wires them in from config the SDK already reads:

- **`root_certificate`** — custom CAs from `SSL_CERT_DIR`, so private-CA stores verify without `allow_invalid_certificates`. Reuses `get_custom_ca_cert_bytes()`, the same helper the Temporal client already uses, so all TLS clients (httpx/aiohttp, Temporal, obstore) now honor `SSL_CERT_DIR` consistently.
- **`proxy_excludes`** — `NO_PROXY`, forwarded only when a proxy is set.

obstore *adds* `root_certificate` to the system trust store rather than replacing it (each PEM in the bundle goes through reqwest's `add_root_certificate`; built-in roots stay in effect), so public endpoints keep validating alongside the custom CA. Config logs show `root_certificate` as a byte count, not the raw PEM.

Tested with unit tests for both paths plus a real `S3Store` built with a trustme CA to confirm obstore accepts the keys.