### PR TITLE
ci(test): throwaway workflow to verify atlan-app-fleet GitHub App token

### DIFF
--- a/.github/workflows/_throwaway-verify-fleet-app.yml
+++ b/.github/workflows/_throwaway-verify-fleet-app.yml
@@ -1,0 +1,28 @@
+# Throwaway verification workflow — delete after confirming the App works.
+name: _throwaway Verify Fleet App Token
+on: workflow_dispatch
+
+permissions: {}
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint fleet App token
+        id: app-token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2
+        with:
+          app-id: ${{ vars.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+
+      - name: Confirm identity + isolated rate limit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # /installation/repositories only works for App installation tokens
+          # (not user/PAT tokens) — a 200 here confirms this really is the App.
+          echo "Repos this installation can access (confirms App identity):"
+          gh api installation/repositories --jq '.repositories[].full_name' | head -5
+          echo "Rate limit (should be isolated from atlan-ci's own budget):"
+          gh api rate_limit --jq '.rate'


### PR DESCRIPTION
## Summary
Temporary verification workflow only — confirms the newly-installed \`atlan-app-fleet\` GitHub App mints working installation tokens (isolated rate-limit budget, real installation identity via \`/installation/repositories\`) before Phase 2 token-swap work begins.

Mirrors the existing \`_throwaway Mothership Auth Probe\` pattern already on main. Will be deleted in a follow-up PR immediately after use.

## Test plan
- [ ] Dispatch manually, confirm it lists installation repos and an isolated rate_limit
- [ ] Delete this workflow file once confirmed