### PR TITLE
fix(storage): don't scope the S3 cross-account STS session to the bucket region

### DIFF
--- a/application_sdk/storage/binding.py
+++ b/application_sdk/storage/binding.py
@@ -337,7 +337,8 @@ def _build_s3_config(
         credential_provider = make_s3_assume_role_provider(
             role_arn=meta["assumeRoleArn"],
             session_name=_nonempty(meta, "sessionName") or "atlan-application-sdk",
-            region=resolved_region or None,
+            # No region: see cloud.py's identical fix — resolved_region is for
+            # the data-plane config above, not the STS session.
             base_access_key=base_access_key,
             base_secret_key=base_secret_key,
             base_session_token=base_session_token,

--- a/application_sdk/storage/cloud.py
+++ b/application_sdk/storage/cloud.py
@@ -529,7 +529,12 @@ def _create_s3_store(
             # two S3 auth paths are distinguishable in CloudTrail AssumeRole logs
             # (and preserves CloudStore's historical session name).
             session_name=extra.get("aws_role_session_name") or "cloud-store-session",
-            region=region or None,
+            # No region: the bucket's region belongs on the S3 store's own
+            # config (below) to avoid obstore's us-east-1 default/redirect —
+            # it has nothing to do with which STS endpoint assumes the role,
+            # and forcing it onto the STS session breaks AssumeRole for
+            # opt-in AWS regions (e.g. me-central-1), where ambient/IRSA
+            # credentials aren't valid against that region's STS endpoint.
             base_access_key=base_access_key,
             base_secret_key=base_secret_key,
             base_session_token=(creds.get("token") or None)

--- a/application_sdk/storage/cloud.py
+++ b/application_sdk/storage/cloud.py
@@ -529,12 +529,9 @@ def _create_s3_store(
             # two S3 auth paths are distinguishable in CloudTrail AssumeRole logs
             # (and preserves CloudStore's historical session name).
             session_name=extra.get("aws_role_session_name") or "cloud-store-session",
-            # No region: the bucket's region belongs on the S3 store's own
-            # config (below) to avoid obstore's us-east-1 default/redirect —
-            # it has nothing to do with which STS endpoint assumes the role,
-            # and forcing it onto the STS session breaks AssumeRole for
-            # opt-in AWS regions (e.g. me-central-1), where ambient/IRSA
-            # credentials aren't valid against that region's STS endpoint.
+            # No region: scoping the STS session to the bucket's region breaks
+            # AssumeRole for opt-in regions (e.g. me-central-1); region belongs
+            # on the S3 store's own config below, not the STS call.
             base_access_key=base_access_key,
             base_secret_key=base_secret_key,
             base_session_token=(creds.get("token") or None)

--- a/tests/unit/storage/test_binding.py
+++ b/tests/unit/storage/test_binding.py
@@ -644,16 +644,16 @@ class TestS3AssumeRole:
     @patch("application_sdk.storage._credential_providers.StsCredentialProvider")
     @patch("boto3.Session")
     @patch("obstore.store.S3Store")
-    def test_assume_role_region_falls_back_to_env(
+    def test_assume_role_region_not_scoped_to_sts_session(
         self,
         mock_s3_cls: MagicMock,
         mock_session_cls: MagicMock,
         mock_sts_cls: MagicMock,
         tmp_path: Path,
     ) -> None:
-        # resolved_region (binding.py L340) must flow into boto3.Session so
-        # the STS call targets the correct regional endpoint when metadata.region
-        # is absent but AWS_REGION is set (IRSA / EKS injection).
+        # resolved_region (env fallback here) still lands on the S3 store's own
+        # config, but must never reach the STS session — that breaks AssumeRole
+        # for opt-in AWS regions (e.g. me-central-1).
         mock_s3_cls.return_value = MagicMock()
         mock_sts_cls.return_value = MagicMock()
         mock_session_cls.return_value = MagicMock()
@@ -666,8 +666,9 @@ class TestS3AssumeRole:
         )
         create_store_from_binding("objectstore", components_dir=components_dir)
 
+        assert mock_s3_cls.call_args.kwargs["config"]["aws_region"] == "ap-south-1"
         session_kwargs = mock_session_cls.call_args.kwargs
-        assert session_kwargs.get("region_name") == "ap-south-1"
+        assert "region_name" not in session_kwargs
 
 
 class TestS3SecretKeyRef:

--- a/tests/unit/storage/test_cloud.py
+++ b/tests/unit/storage/test_cloud.py
@@ -191,12 +191,7 @@ class TestFromCredentials:
         config = call_kwargs.get("config") or {}
         assert "aws_role_arn" not in config
         assert "aws_role_session_name" not in config
-        # The bucket's region is for the S3 store's own config (avoids obstore's
-        # us-east-1 default/redirect) — it must NOT be forced onto the STS
-        # session used to assume the role. Opt-in AWS regions (e.g. me-central-1)
-        # reject ambient/IRSA credentials presented to their regional STS
-        # endpoint, so scoping the assume-role session to the bucket's region
-        # breaks cross-account access there (production incident: seon me-central-1).
+        # Region stays on the S3 store's config; must not reach the STS session.
         assert config.get("aws_region") == "us-east-1"
         session_kwargs = mock_session_cls.call_args.kwargs
         assert "region_name" not in session_kwargs

--- a/tests/unit/storage/test_cloud.py
+++ b/tests/unit/storage/test_cloud.py
@@ -191,6 +191,15 @@ class TestFromCredentials:
         config = call_kwargs.get("config") or {}
         assert "aws_role_arn" not in config
         assert "aws_role_session_name" not in config
+        # The bucket's region is for the S3 store's own config (avoids obstore's
+        # us-east-1 default/redirect) — it must NOT be forced onto the STS
+        # session used to assume the role. Opt-in AWS regions (e.g. me-central-1)
+        # reject ambient/IRSA credentials presented to their regional STS
+        # endpoint, so scoping the assume-role session to the bucket's region
+        # breaks cross-account access there (production incident: seon me-central-1).
+        assert config.get("aws_region") == "us-east-1"
+        session_kwargs = mock_session_cls.call_args.kwargs
+        assert "region_name" not in session_kwargs
 
     def test_adls_account_key_auth(self):
         # Azure requires base64-encoded account keys


### PR DESCRIPTION
## Problem
Cross-account S3 `AssumeRole` fails for opt-in AWS regions (e.g. `me-central-1`) with:
```
ClientError: An error occurred (InvalidClientTokenId) when calling the
AssumeRole operation: The security token included in the request is invalid
```
`_create_s3_store` scoped the boto3 STS session to the bucket's `region`. That region value exists to fix an unrelated obstore issue (defaults to `us-east-1`, 301-redirects otherwise) — it has nothing to do with STS. Scoping the session to an opt-in region breaks ambient/IRSA credential resolution for the `AssumeRole` call itself.

Confirmed by A/B: same AWS account, same connector, same code path — `eu-west-1` (standard region) succeeds, `me-central-1` (opt-in region) fails, region is the only variable that differs. The pre-CloudStore downloader (deleted in atlanhq/atlan-dbt-app#194) called `boto3.client("sts")` with no region at all and worked.

## Fix
Drop `region` from the `make_s3_assume_role_provider(...)` call. Region stays on the S3 store's own config, which still needs it.

## Verified
- **Live**: deployed to atlanhq/atlan-dbt-app#218 and re-tested auth against the failing tenant connection (seon, `me-central-1`) — **auth now succeeds**. Confirmed fixed, not just unit-tested.
- Unit: extended `test_s3_role_arn_wires_assume_role_provider` — fails pre-fix (`'region_name': 'us-east-1'` leaks into the STS session), passes post-fix. Full `test_cloud.py` / `test_binding.py` / `test_credential_providers.py` — 218 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)