### PR TITLE
fix(storage): preserve full key path for empty-prefix CloudStore downloads

### DIFF
--- a/application_sdk/storage/cloud.py
+++ b/application_sdk/storage/cloud.py
@@ -273,9 +273,14 @@ class CloudStore:
 
         async def _dl(obj_key: str, size: int, etag: str | None) -> Path:
             async with sem:
+                # No `list_prefix and` guard here: when list_prefix == "" (a
+                # whole-bucket download), startswith("") is always True, so the
+                # full key is kept instead of falling through to the basename-only
+                # branch below, which would clobber same-named files from
+                # different subdirectories onto one path.
                 rel = (
                     obj_key[len(list_prefix) :]
-                    if list_prefix and obj_key.startswith(list_prefix)
+                    if obj_key.startswith(list_prefix)
                     else Path(obj_key).name
                 )
                 # Reject keys whose resolved path escapes output (e.g. via ".." segments).

--- a/tests/unit/storage/test_cloud.py
+++ b/tests/unit/storage/test_cloud.py
@@ -250,6 +250,27 @@ class TestCloudStoreOps:
         with pytest.raises(StorageError, match="No files found"):
             await store.download(prefix="empty", output_dir=tmp_path / "out")
 
+    async def test_download_empty_prefix_preserves_subdirectories(self, tmp_path):
+        """A whole-bucket download (prefix="") must not flatten same-named files
+        from different subdirectories onto one path.
+
+        Regression test: list_prefix is "" for prefix="", and obj_key.startswith("")
+        is always True, so each key's full path — not just its basename — must be
+        kept. Before the fix, an `and list_prefix` guard forced every object here
+        onto the basename-only branch, so both manifest.json files below clobbered
+        onto a single downloaded file.
+        """
+        store = self._make_store(tmp_path)
+        await store.upload_bytes("client-a/manifest.json", b"client-a-manifest")
+        await store.upload_bytes("client-b/manifest.json", b"client-b-manifest")
+
+        out = tmp_path / "out"
+        downloaded = await store.download(prefix="", output_dir=out)
+
+        assert len(downloaded) == 2
+        contents = {p.read_bytes() for p in downloaded}
+        assert contents == {b"client-a-manifest", b"client-b-manifest"}
+
     async def test_path_traversal_guard_exists(self, tmp_path):
         """Verify the path traversal guard is in the download code path.
 


### PR DESCRIPTION
### Changelog
- Fix `CloudStore._download_prefix` (`application_sdk/storage/cloud.py`) silently flattening every downloaded object to its basename when `prefix=""` (a whole-bucket download), which clobbers same-named files from different subdirectories onto one path.
- Add a regression test (`test_download_empty_prefix_preserves_subdirectories`) that seeds two same-named files under different subdirectories and asserts both survive a `prefix=""` download.

### What was broken

`_download_prefix`'s per-file relative-path computation:

```python
rel = (
    obj_key[len(list_prefix) :]
    if list_prefix and obj_key.startswith(list_prefix)
    else Path(obj_key).name
)
```

When `prefix=""` (list the whole bucket), `list_prefix` is also `""`. `"" and ...` short-circuits `False`, so **every** object falls into the `else Path(obj_key).name` branch — the full key path is discarded and only the basename is kept. Concurrent downloads (`max_concurrency=4`) then race to write same-named files (e.g. every project's `manifest.json`) onto the same local path, with the last writer winning. Everything else silently disappears.

### How this was found

Root-caused from a real production incident: a dbt connection's objectStore credential was auto-created with `extra.prefix=""` by a migration. The customer's bucket has one folder per client dbt project (thousands of files). The empty-prefix download listed the whole bucket (confirmed — the download activity took 141s to produce only ~30MB / 4 files, which is otherwise inexplicable) and collapsed it down to one client's ~4-file artifact set. That fed the rest of the dbt pipeline a ~450x under-extraction (590 models found vs. ~287K expected). The downstream publish diff correctly computed a huge delete from that bad input and the circuit breaker blocked it before anything was actually deleted — but the extraction itself silently returned wrong data with no error, for any caller using `prefix=""`.

### The fix

```python
rel = (
    obj_key[len(list_prefix) :]
    if obj_key.startswith(list_prefix)
    else Path(obj_key).name
)
```

`obj_key.startswith("")` is always `True`, and `obj_key[0:] == obj_key`, so dropping the `list_prefix and` conjunct preserves the full key when the prefix is empty, while leaving non-empty-prefix behavior byte-identical (that branch was already effectively unreachable for non-empty prefixes, since `_list_keys_with_meta` only returns keys that themselves start with `list_prefix`).

Verified the fix is necessary and sufficient by reverting it locally and confirming the new test fails exactly as in production (one of two same-named files silently disappears), then restoring it and confirming all 600 `tests/unit/storage/` tests pass (parquet/pandas-dependent tests excluded — pre-existing, unrelated to this change, missing optional dep in this sandbox).

### Blast radius

Any caller of `CloudStore.download(prefix="")` / `.download()` with no prefix, on a store whose keys aren't already flat, is affected — not just this one dbt connection. Worth an audit of which connections/credentials have been configured with an empty objectStore prefix.

### Additional context (e.g. screenshots, logs, links)
- Traced via Temporal history (extract workflow `download_from_cloud_storage` activity, 141s for 4 files) + the actual downloaded `manifest.json`/`catalog.json`/`run_results.json` from S3 (all one coherent dbt invocation, one client project) + the objectStore credential config (`prefix: ""`, `description: "Auto-created by native-migration for dbt Core → External Object Storage"`).

### Checklist
- [x] Additional tests added
- [x] All CI checks passed (ran `pre-commit run` — ruff, ruff-format, isort, pyright all pass; `pytest tests/unit/storage/` — 600 passed, 1 skipped, excluding pre-existing pandas-dependent format tests unrelated to this change)
- [ ] Relevant documentation updated (no doc references this code path's prefix-empty behavior; none needed)

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?