### PR TITLE
fix(docker): support OpenShift arbitrary-UID in the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,16 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 
 COPY --chown=appuser:appuser CHANGELOG.md /opt/atlan/application-sdk/CHANGELOG.md
 
+# OpenShift/MKS (and other restricted platforms) run containers as an arbitrary,
+# non-1000 UID with GID 0 rather than the image's own USER. Make the app and home
+# directories group-root and group-writable (`g=u` mirrors the owner's perms onto
+# the group) so the assigned UID — which is a member of GID 0 — can write, and pin
+# HOME so tools that resolve `$HOME` don't fall back to "/" for a UID absent from
+# /etc/passwd. Harmless on standard Kubernetes: the container still runs as uid
+# 1000 (appuser), the owner.
+USER root
+ENV HOME=/home/appuser
+RUN chgrp -R 0 /app /home/appuser && chmod -R g=u /app /home/appuser
+USER appuser
+
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
## Why
An SDR customer is deploying connector apps on OpenShift/MKS, whose `restricted-v2` SCC runs containers as an **arbitrary non-1000 UID with GID 0** (not the image's `USER`). The base image (`app-runtime-base`) sets up `/app` and `/home/appuser` as `1000:1000` (mode 755) and never pins `HOME`, so an assigned UID:
- can't write to `/app` (the WORKDIR) or `/home/appuser` (dapr home) → runtime `EACCES`, and
- gets `HOME=/` (no `/etc/passwd` entry) → tools resolving `$HOME/...` break.

The pod passes SCC *admission* once the chart drops the fixed `runAsUser` (see atlan-apps-deployment#25), but then fails at *runtime* without this image change.

## What
Standard Red Hat "support arbitrary user IDs" pattern:
```dockerfile
USER root
ENV HOME=/home/appuser
RUN chgrp -R 0 /app /home/appuser && chmod -R g=u /app /home/appuser
USER appuser
```
`chmod g=u` mirrors the owner's permissions onto the group, so GID 0 (hence any assigned UID) can write. **Standard Kubernetes is unaffected** — the container still runs as uid 1000 (the owner).

## Connector follow-up
Connector Dockerfiles that `COPY --chown=appuser:appuser` into `/app` reset the group back to 1000, so each must re-apply `chgrp 0 && chmod g=u /app` as a final layer. First one: atlan-hive-app (PR linked separately), which currently carries the full fix self-sufficiently so it can be tested before this base change ships.

## Draft — before marking ready
- [ ] Rebuild base image and run `trivy`/`grype` per `docs/standards/build-security.md`.
- [ ] Validate by running a built image as a non-1000 UID (`--user 1001120000:0`) and exercising a workflow (writes to `/app`, `$HOME/.dapr`).
- [ ] Confirm `chgrp`/`chmod` are available in the Wolfi/Chainguard build stage (they are used elsewhere in this Dockerfile).