### PR TITLE
fix(dapr): return from startup sidecar wait once daprd HTTP API is reachable

### DIFF
--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -71,8 +71,14 @@ inputs:
       How long to wait for the SDR container's /server/health endpoint to
       respond before failing. Connectors with heavy native deps (e.g. SAP
       JCo) may need 180s+; default fits most.
+
+      INVARIANT: keep this strictly greater than the SDK's max startup
+      sidecar wait (ATLAN_DAPR_SIDECAR_WAIT_TIMEOUT, default 60 in
+      application_sdk/infrastructure/_dapr/http.py). The health bind happens
+      after that wait, so an equal value makes the gate a coin-flip. See
+      CNCT-66.
     required: false
-    default: "60"
+    default: "120"
   pytest-extra-args:
     description: Extra arguments appended to the pytest invocation.
     required: false

--- a/application_sdk/infrastructure/_dapr/http.py
+++ b/application_sdk/infrastructure/_dapr/http.py
@@ -156,27 +156,43 @@ async def wait_for_dapr_sidecar(
     url = f"{_dapr_base_url()}{_HEALTHZ_PATH}"
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout
+    last_exc: Exception | None = None
     async with httpx.AsyncClient(timeout=2.0) as client:
         while True:
             try:
                 r = await client.get(url)
             # conformance: ignore[E004] sidecar health probe; connection errors are expected while daprd is still cold-booting and are logged at debug
-            except Exception:
+            except Exception as exc:
+                last_exc = exc
                 logger.debug("Dapr sidecar poll failed", exc_info=True)
             else:
                 if r.status_code == 204:
                     _dapr_sidecar_confirmed_ready = True
                     return
-                logger.debug(
-                    "Dapr sidecar HTTP API reachable (healthz=%d); "
-                    "proceeding without full-component wait",
+                # Reachable but not fully initialized: this is the load-bearing
+                # "proceed early" decision (the only path that fires whenever
+                # healthz never reaches 204, e.g. SDR / optional non-init
+                # components). INFO, not DEBUG, so it survives the prod INFO
+                # floor and leaves a breadcrumb; not WARNING, since this is an
+                # expected steady state and per-call cold-start retries cover
+                # component readiness.
+                # conformance: ignore[L006] not a per-iteration log — this INFO fires at most once and immediately returns; it is the single "proceeded early" decision, not loop-body volume
+                logger.info(
+                    "Dapr sidecar HTTP API reachable (healthz=%d) but not fully "
+                    "initialized; proceeding without the full-component wait — "
+                    "per-call cold-start retries cover component readiness",
                     r.status_code,
                 )
                 return
             if loop.time() >= deadline:
+                # Only the connection-error path can reach here (any HTTP
+                # response returns above), so surface the last error — a
+                # genuinely unreachable/misconfigured sidecar (wrong port, DNS,
+                # perms) should be diagnosable, not just "timed out".
                 logger.warning(
                     "Dapr sidecar not reachable after %.0fs — proceeding anyway",
                     timeout,
+                    exc_info=last_exc,
                 )
                 return
             await asyncio.sleep(interval)

--- a/application_sdk/infrastructure/_dapr/http.py
+++ b/application_sdk/infrastructure/_dapr/http.py
@@ -60,13 +60,16 @@ METADATA_PATH = f"{_API_PREFIX}/metadata"
 
 
 _HEALTHZ_PATH = "/v1.0/healthz"
-# How long to wait at startup for the Dapr sidecar's HTTP server to accept
-# connections + finish component init. The old 10s was too short for cold
-# starts (image pull + daprd boot + component init on a fresh CI runner
-# routinely exceed it); when we proceeded before the sidecar was up, the first
-# Dapr call — e.g. an agent secret-bundle fetch during a workflow's preflight —
-# failed with "ConnectError: All connection attempts failed". Overridable via
-# env for pathologically slow (or fast) environments.
+# How long to wait at startup for the Dapr sidecar's HTTP server to start
+# accepting connections. The old 10s was too short for cold starts (image
+# pull + daprd boot on a fresh CI runner routinely exceed it); when we
+# proceeded before daprd was up, the first Dapr call — e.g. an agent
+# secret-bundle fetch during a workflow's preflight — failed with
+# "ConnectError: All connection attempts failed". We do NOT hold startup for
+# full component init (a healthz 204): once daprd answers the probe at all the
+# connection race is over, and per-component readiness is covered by each call
+# site's retry_past_dapr_cold_start budget. Overridable via env for
+# pathologically slow (or fast) environments.
 _DEFAULT_SIDECAR_WAIT_TIMEOUT = float(
     os.environ.get("ATLAN_DAPR_SIDECAR_WAIT_TIMEOUT", "60")
 )
@@ -119,15 +122,26 @@ async def wait_for_dapr_sidecar(
     timeout: float = _DEFAULT_SIDECAR_WAIT_TIMEOUT,
     interval: float = _DEFAULT_SIDECAR_POLL_INTERVAL,
 ) -> None:
-    """Poll /v1.0/healthz until the Dapr sidecar is ready or timeout elapses.
+    """Poll /v1.0/healthz until the Dapr sidecar's HTTP API is reachable or
+    timeout elapses.
 
-    Dapr returns 204 when all components have finished initializing. On
-    success, arms :data:`_dapr_sidecar_confirmed_ready` so the first real
-    Dapr call skips :func:`retry_past_dapr_cold_start`'s own wait — this
-    probe already paid it. On timeout the function logs a warning and
-    returns without arming the gate — startup proceeds, and the first real
-    call still gets a full retry budget in case the sidecar needed a little
-    longer.
+    Returns as soon as daprd answers the probe at all:
+
+    * 204 — every component has finished initializing. Arms
+      :data:`_dapr_sidecar_confirmed_ready` so the first real Dapr call skips
+      :func:`retry_past_dapr_cold_start`'s own wait; this probe already paid
+      it.
+    * any other status — daprd's HTTP API is up but a component is still
+      initializing. Returns *without* arming the gate: the connection race
+      this probe exists to close (daprd not yet accepting connections on a
+      cold start) is over, and per-component readiness is already covered by
+      each call site's :func:`retry_past_dapr_cold_start` budget. Holding
+      startup for it would only delay the HTTP health bind.
+
+    Only connection errors keep the loop polling to the deadline — those mean
+    daprd's HTTP server has not come up yet. On timeout the function logs a
+    warning and returns without arming the gate, so the first real call still
+    gets a full retry budget.
 
     Skipped entirely in local dev — /v1.0/healthz returns 500 because
     AWS-backed components can't initialize without real credentials.
@@ -146,15 +160,23 @@ async def wait_for_dapr_sidecar(
         while True:
             try:
                 r = await client.get(url)
+            # conformance: ignore[E004] sidecar health probe; connection errors are expected while daprd is still cold-booting and are logged at debug
+            except Exception:
+                logger.debug("Dapr sidecar poll failed", exc_info=True)
+            else:
                 if r.status_code == 204:
                     _dapr_sidecar_confirmed_ready = True
                     return
-            # conformance: ignore[E004] sidecar health probe; network errors are expected during startup and logged at debug
-            except Exception:
-                logger.debug("Dapr sidecar poll failed", exc_info=True)
+                logger.debug(
+                    "Dapr sidecar HTTP API reachable (healthz=%d); "
+                    "proceeding without full-component wait",
+                    r.status_code,
+                )
+                return
             if loop.time() >= deadline:
                 logger.warning(
-                    "Dapr sidecar not ready after %.0fs — proceeding anyway", timeout
+                    "Dapr sidecar not reachable after %.0fs — proceeding anyway",
+                    timeout,
                 )
                 return
             await asyncio.sleep(interval)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,7 +114,7 @@ Dapr component names are read at module-import time (not at runtime) because the
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ATLAN_DAPR_SIDECAR_WAIT_TIMEOUT` | `60` | Seconds to poll `/v1.0/healthz` at startup before proceeding anyway. Increase for pathologically slow cold starts (image pull + daprd boot + component init). |
+| `ATLAN_DAPR_SIDECAR_WAIT_TIMEOUT` | `60` | Max seconds to poll `/v1.0/healthz` at startup for daprd to start accepting connections. Startup proceeds as soon as daprd answers the probe at all (per-component readiness is covered by each call site's cold-start retry budget); only connection errors poll to this deadline. Increase for pathologically slow cold starts (image pull + daprd boot). |
 | `ATLAN_DAPR_COLD_START_MAX_WAIT_SECONDS` | `120.0` | Seconds a Dapr-backed call (secret fetch, credential-vault config fetch, ...) may retry a cold-sidecar race before giving up. Shared by every call site that opts into `retry_past_dapr_cold_start`. Env-overridable for pathologically slow runners. |
 
 ---

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -40,7 +40,7 @@ Both call the same composite action; difference is test target, Dapr components,
     secrets-script:     # OPTIONAL. Path to the script that writes
                         # <sdr-config-dir>/secrets/credentials.json from env vars.
                         # Default: .github/sdr-e2e/make-secrets.sh.
-    container-health-timeout-seconds:  # OPTIONAL. Default 60s. Bump for heavy native deps.
+    container-health-timeout-seconds:  # OPTIONAL. Default 120s. Bump for heavy native deps.
     pytest-extra-args:  # OPTIONAL. Appended to the pytest invocation.
     application-sdk-ref:               # OPTIONAL. Cross-repo dispatch: re-pin
                         # atlan-application-sdk in pyproject.toml to this ref

--- a/tests/unit/infrastructure/test_dapr_http.py
+++ b/tests/unit/infrastructure/test_dapr_http.py
@@ -440,13 +440,41 @@ class TestWaitForDaprSidecar:
             await wait_for_dapr_sidecar(timeout=5.0, interval=0.01)
         mock_get.assert_called_once()
 
-    async def test_ready_after_retries(self):
-        """Returns once sidecar eventually responds 204 after non-204 responses."""
-        not_ready = MagicMock()
-        not_ready.status_code = 503
+    async def test_ready_after_connection_errors(self):
+        """Polls through connection errors (daprd still cold-booting) and
+        returns once daprd finally answers 204."""
+        import httpx as _httpx
+
         ready = MagicMock()
         ready.status_code = 204
-        mock_get = AsyncMock(side_effect=[not_ready, not_ready, ready])
+        mock_get = AsyncMock(
+            side_effect=[
+                _httpx.ConnectError("refused"),
+                _httpx.ConnectError("refused"),
+                ready,
+            ]
+        )
+        with (
+            self._DEPLOYED,
+            patch(
+                "application_sdk.infrastructure._dapr.http.httpx.AsyncClient"
+            ) as mock_cls,
+            patch("application_sdk.infrastructure._dapr.http.logger"),
+        ):
+            mock_cls.return_value.__aenter__ = AsyncMock(
+                return_value=MagicMock(get=mock_get)
+            )
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            await wait_for_dapr_sidecar(timeout=5.0, interval=0.01)
+        assert mock_get.call_count == 3
+
+    async def test_returns_on_first_non_204(self):
+        """Returns on the first poll once daprd's HTTP API answers at all —
+        a non-204 (components still initializing) must NOT keep it waiting,
+        since per-component readiness is the per-call retry budget's job."""
+        not_ready = MagicMock()
+        not_ready.status_code = 503
+        mock_get = AsyncMock(return_value=not_ready)
         with (
             self._DEPLOYED,
             patch(
@@ -458,13 +486,14 @@ class TestWaitForDaprSidecar:
             )
             mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
             await wait_for_dapr_sidecar(timeout=5.0, interval=0.01)
-        assert mock_get.call_count == 3
+        mock_get.assert_called_once()
 
     async def test_timeout_logs_warning(self):
-        """Logs a warning and returns when sidecar never becomes ready."""
-        not_ready = MagicMock()
-        not_ready.status_code = 503
-        mock_get = AsyncMock(return_value=not_ready)
+        """Logs a warning and returns when daprd never accepts connections
+        (only the connection-error path can reach the deadline now)."""
+        import httpx as _httpx
+
+        mock_get = AsyncMock(side_effect=_httpx.ConnectError("refused"))
         with (
             self._DEPLOYED,
             patch(
@@ -478,7 +507,7 @@ class TestWaitForDaprSidecar:
             mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
             await wait_for_dapr_sidecar(timeout=0.05, interval=0.01)
         mock_logger.warning.assert_called_once()
-        assert "not ready" in mock_logger.warning.call_args[0][0]
+        assert "not reachable" in mock_logger.warning.call_args[0][0]
 
     async def test_connection_error_does_not_crash(self):
         """Poll loop survives connection errors and eventually times out cleanly."""
@@ -527,9 +556,38 @@ class TestWaitForDaprSidecar:
         assert http_mod._dapr_sidecar_confirmed_ready is True
 
     async def test_timeout_does_not_arm_shared_cold_start_gate(self, monkeypatch):
-        """Giving up on the health probe must NOT arm the shared gate — a
-        later real Dapr call still needs its own retry budget in case the
-        sidecar needed a little longer than the startup probe waited."""
+        """Giving up on the health probe (daprd never reachable) must NOT arm
+        the shared gate — a later real Dapr call still needs its own retry
+        budget in case the sidecar needed a little longer than the probe
+        waited."""
+        import httpx as _httpx
+
+        monkeypatch.setattr(
+            "application_sdk.infrastructure._dapr.http._dapr_sidecar_confirmed_ready",
+            False,
+        )
+        mock_get = AsyncMock(side_effect=_httpx.ConnectError("refused"))
+        with (
+            self._DEPLOYED,
+            patch(
+                "application_sdk.infrastructure._dapr.http.httpx.AsyncClient"
+            ) as mock_cls,
+            patch("application_sdk.infrastructure._dapr.http.logger"),
+        ):
+            mock_cls.return_value.__aenter__ = AsyncMock(
+                return_value=MagicMock(get=mock_get)
+            )
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            await wait_for_dapr_sidecar(timeout=0.05, interval=0.01)
+
+        import application_sdk.infrastructure._dapr.http as http_mod
+
+        assert http_mod._dapr_sidecar_confirmed_ready is False
+
+    async def test_non_204_does_not_arm_shared_cold_start_gate(self, monkeypatch):
+        """Returning early on a reachable-but-not-204 sidecar must NOT arm the
+        gate — components may still be initializing, so the first real Dapr
+        call still needs its own retry budget."""
         monkeypatch.setattr(
             "application_sdk.infrastructure._dapr.http._dapr_sidecar_confirmed_ready",
             False,
@@ -548,7 +606,7 @@ class TestWaitForDaprSidecar:
                 return_value=MagicMock(get=mock_get)
             )
             mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-            await wait_for_dapr_sidecar(timeout=0.05, interval=0.01)
+            await wait_for_dapr_sidecar(timeout=5.0, interval=0.01)
 
         import application_sdk.infrastructure._dapr.http as http_mod
 

--- a/tests/unit/infrastructure/test_dapr_http.py
+++ b/tests/unit/infrastructure/test_dapr_http.py
@@ -480,6 +480,7 @@ class TestWaitForDaprSidecar:
             patch(
                 "application_sdk.infrastructure._dapr.http.httpx.AsyncClient"
             ) as mock_cls,
+            patch("application_sdk.infrastructure._dapr.http.logger") as mock_logger,
         ):
             mock_cls.return_value.__aenter__ = AsyncMock(
                 return_value=MagicMock(get=mock_get)
@@ -487,6 +488,13 @@ class TestWaitForDaprSidecar:
             mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
             await wait_for_dapr_sidecar(timeout=5.0, interval=0.01)
         mock_get.assert_called_once()
+        # The "proceeding without full-component wait" decision is INFO (not
+        # DEBUG) so it survives the prod INFO floor, and it carries the status
+        # code — not WARNING, since a reachable-but-not-204 sidecar is an
+        # expected steady state, not an anomaly.
+        mock_logger.info.assert_called_once()
+        assert 503 in mock_logger.info.call_args[0]
+        mock_logger.warning.assert_not_called()
 
     async def test_timeout_logs_warning(self):
         """Logs a warning and returns when daprd never accepts connections
@@ -508,6 +516,11 @@ class TestWaitForDaprSidecar:
             await wait_for_dapr_sidecar(timeout=0.05, interval=0.01)
         mock_logger.warning.assert_called_once()
         assert "not reachable" in mock_logger.warning.call_args[0][0]
+        # The terminal give-up must carry the last connection error so a
+        # genuinely unreachable/misconfigured sidecar is diagnosable.
+        assert isinstance(
+            mock_logger.warning.call_args.kwargs.get("exc_info"), _httpx.ConnectError
+        )
 
     async def test_connection_error_does_not_crash(self):
         """Poll loop survives connection errors and eventually times out cleanly."""


### PR DESCRIPTION
TL;DR: On SDK >= 3.21.0, apps in combined/handler mode take ~60s to expose `/server/health` because the HTTP server binds only after `wait_for_dapr_sidecar()` returns, and that wait now runs its full 60s budget whenever dapr's `/v1.0/healthz` never reaches 204 (as in the SDR e2e stack). 60s equals the sdr-e2e container-start gate, so the container is killed before health binds and every connector's SDR check fails on the 3.21.x bump. This makes the wait return as soon as daprd's HTTP API is reachable instead of holding for full-component init. Fixes CNCT-66.

## Root cause

Two things combined:

1. Ordering (pre-existing): in both HTTP-serving modes, `/server/health` binds only after `_create_infrastructure()` completes, whose first awaited step is `await wait_for_dapr_sidecar()` (`main.py:610`).
2. Trigger (PR #2467, first in v3.21.0): raised `_DEFAULT_SIDECAR_WAIT_TIMEOUT` from 10s to 60s to close a cold-start secret-fetch race.

`wait_for_dapr_sidecar()` only returned early on healthz == 204. In the SDR stack (embedded/minimal dapr, local-file secretstore) healthz never reaches 204 in the window, so the poll ran the full 60s. 3.18.0's 10s budget gave up fast and bound the port well inside the gate; 3.21.x's 60s budget consumes the whole gate. The wait doesn't crash — on timeout it logs "proceeding anyway" and returns — the app just loses the photo-finish against the equal 60s gate.

## Why the fix is safe

PR #2467 added both the up-front wait and a per-call retry (`retry_past_dapr_cold_start`, 120s budget). The retry is the actual safety net for the secret race; the up-front 204 wait is an optimization (pay it once vs. per-call), not a correctness guarantee — on timeout it deliberately leaves `_dapr_sidecar_confirmed_ready = False` so the first real dapr call still gets its full retry budget.

The failure PR #2467 was fixing was `ConnectError: All connection attempts failed` — daprd not yet accepting connections on a cold runner. That's a connection error, not a non-204 response. So this change keeps the two apart:

- Connection errors keep polling to the full deadline — the original race is untouched.
- Any HTTP response ends the wait. On 204, arm the shared cold-start gate as before. On non-204 (daprd up, components still initializing), return without arming the gate — per-component readiness is already the per-call retry budget's job, and reaching that "unarmed" state early is byte-for-byte the existing timeout contract.

Behavior per environment:

| Environment | healthz | Before | After |
|---|---|---|---|
| Prod k8s | 204 quickly | fast return, gate armed | identical |
| SDR e2e stack | answers, never 204 | burns full 60s -> gate killed | returns in ~1s, health binds fast |
| Cold CI runner (PR #2467 case) | connection refused until daprd boots | polls up to 60s | identical |
| Local dev | skipped | no-op | no-op |

No startup reordering, no signature or config changes. The `ATLAN_DAPR_SIDECAR_WAIT_TIMEOUT` env var still works, and apps that shipped the per-app `docker-compose.ci.yml` overlay workaround can drop it.

## Harness invariant (defense in depth)

The SDK's sidecar-wait default and the sdr-e2e container-start gate were two independently-owned constants that were both 60s — equal by accident, which guaranteed the race for any app relying on the gate default. This bumps the sdr-e2e action's `container-health-timeout-seconds` default from 60 to 120 and documents the invariant (gate must stay strictly greater than the SDK's max sidecar wait). The SDK's own e2e workflows already pass 120 explicitly, which is why the SDK repo's own SDR gate never failed — only external apps on the default hit 60==60.

## Changes

- `application_sdk/infrastructure/_dapr/http.py` — `wait_for_dapr_sidecar()` returns on any HTTP response; arms the shared gate only on 204; only connection errors poll to the deadline.
- `.github/actions/sdr-e2e/action.yaml` — gate default 60 -> 120, invariant documented.
- `docs/configuration.md`, `docs/standards/connector-ci-e2e.md` — reflect the new behavior/default.
- `tests/unit/infrastructure/test_dapr_http.py` — rewrote the "polls through non-204s" test to the connection-error path; added coverage for early-return-on-non-204 and that non-204 / timeout leave the gate unarmed.

## Testing

- `tests/unit/infrastructure/test_dapr_http.py` (48) and `tests/unit/test_main.py` (133) pass.
- pre-commit clean on all changed files.
- e2e label added so the full SDR e2e suite runs on this PR as the live regression check.

## Deliberate tradeoff

Returning on the first non-204 removes the incidental "wait for full-component 204" barrier that used to hold startup until every dapr component was ready — which also shielded the state-store/pub-sub paths that aren't wrapped in `retry_past_dapr_cold_start`. The only dapr call in the startup window is the best-effort `WORKER_START` publish (`execution/_temporal/worker.py:270`), which is try/except + warn and has its own transport retry budget, so this is safe. Flagging it explicitly: unwrapped dapr paths now rely on transport-level retries during the narrow startup window rather than the holistic barrier.
