### PR TITLE
ci: add diff-scoped mutation testing pilot (advisory)

### DIFF
--- a/.github/scripts/mutation_diff.py
+++ b/.github/scripts/mutation_diff.py
@@ -1,0 +1,272 @@
+"""Diff-scoped mutation testing driver (advisory).
+
+Runs mutmut against only the mutants that live in Python files changed
+vs. a base ref, then summarises which seeded faults the unit suite caught
+(killed) and which it missed (survived). Wraps `mutmut run` / `mutmut
+results` so the workflow `run:` block stays straight-line per
+docs/standards/ci.md.
+
+Usage (CI and local):
+    python .github/scripts/mutation_diff.py --base-ref origin/main
+
+Behaviour:
+- No changed product files  -> writes a "nothing to mutate" summary, exit 0.
+- Changed files but mutmut finds no mutants for them (e.g. only excluded
+  subtrees or non-function code changed) -> "no mutants" summary, exit 0.
+- Otherwise writes a scorecard (killed/survived/score + surviving mutant
+  names) to $GITHUB_STEP_SUMMARY (when set) and stdout.
+- Advisory by default: always exits 0 on a completed measurement. Pass
+  --min-score N to turn the score into a gate (future graduation path).
+- Infrastructure failures (mutmut crash for any other reason) exit non-zero.
+
+Mutant-name mapping: mutmut names mutants
+`<module.path>.<mangled_function>__mutmut_<n>`, so a changed file
+`application_sdk/services/objectstore.py` maps to the fnmatch pattern
+`application_sdk.services.objectstore.*` accepted by `mutmut run`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import os
+import subprocess
+import sys
+from collections import Counter
+
+SOURCE_ROOT = "application_sdk"
+
+# Keep in sync with [tool.mutmut] do_not_mutate in pyproject.toml. Changed
+# files under these subtrees are dropped before pattern derivation so an
+# exclusions-only diff is reported as "nothing to mutate" instead of
+# tripping mutmut's "nothing matches" assertion.
+EXCLUDED_PREFIXES = (
+    "application_sdk/test_utils/",
+    "application_sdk/testing/scale_data_generator/",
+    "application_sdk/testing/integration/",
+    "application_sdk/testing/e2e/",
+    "application_sdk/testing/hypothesis/",
+    "application_sdk/testing/parity/",
+)
+
+# `mutmut results --all` statuses that mean the fault was detected.
+DETECTED_STATUSES = frozenset({"killed", "timeout", "caught by type check", "segfault"})
+MISSED_STATUS = "survived"
+# Function has mutants but no test exercises it at all.
+UNTESTED_STATUS = "no tests"
+
+NOTHING_MATCHES_MARKER = "Filtered for specific mutants, but nothing matches"
+
+# mutmut runs pytest in-process, so it must share an environment with the
+# unit-test dependencies. Mirrors the setup-deps composite action's
+# `uv sync --all-extras --all-groups`.
+UV_RUN = ["uv", "run", "--all-extras", "--all-groups"]
+
+# Cap the per-mutant gap list in the summary; a low-scoring large diff can
+# have hundreds of survivors and GitHub truncates giant step summaries.
+MAX_LISTED_GAPS = 40
+
+
+def changed_python_files(base_ref: str) -> list[str]:
+    """Product .py files changed vs. the merge-base with ``base_ref``."""
+    out = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMR",
+            f"{base_ref}...HEAD",
+            "--",
+            f"{SOURCE_ROOT}/**/*.py",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    files = [line.strip() for line in out.splitlines() if line.strip()]
+    return [f for f in files if not f.startswith(EXCLUDED_PREFIXES)]
+
+
+def module_patterns(files: list[str]) -> list[str]:
+    """Map changed file paths to mutmut mutant-name fnmatch patterns."""
+    patterns = []
+    for f in files:
+        module = f.removesuffix(".py").replace("/", ".")
+        # Package changes mutate every module in the package.
+        module = module.removesuffix(".__init__")
+        patterns.append(f"{module}.*")
+    return sorted(set(patterns))
+
+
+def run_mutmut(patterns: list[str]) -> tuple[bool, str]:
+    """Run diff-scoped mutation testing.
+
+    Returns (measured, detail). ``measured`` is False when mutmut aborted
+    because no mutant matched the patterns — a valid "nothing to measure"
+    outcome, not an error. Any other non-zero exit is re-raised.
+    """
+    proc = subprocess.run(
+        [*UV_RUN, "mutmut", "run", *patterns],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode == 0:
+        return True, proc.stdout
+    combined = proc.stdout + proc.stderr
+    if NOTHING_MATCHES_MARKER in combined:
+        return False, combined
+    print(combined, file=sys.stderr)
+    raise SystemExit(
+        f"mutmut run failed with exit code {proc.returncode} "
+        "(not a 'nothing matches' outcome)"
+    )
+
+
+def collect_results() -> str:
+    # `--all` is a click option with a value (not a flag): include killed
+    # mutants too, so the score denominator is complete.
+    return subprocess.run(
+        [*UV_RUN, "mutmut", "results", "--all", "true"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def parse_results(results_output: str, patterns: list[str]) -> dict[str, str]:
+    """Parse `mutmut results --all` lines into {mutant_name: status}.
+
+    Only mutants matching one of ``patterns`` are kept (results lists the
+    whole cached run, not just this invocation's subset).
+    """
+    status_by_mutant: dict[str, str] = {}
+    for line in results_output.splitlines():
+        line = line.strip()
+        if not line or ": " not in line:
+            continue
+        name, status = line.rsplit(": ", 1)
+        if any(fnmatch.fnmatch(name, p) for p in patterns):
+            status_by_mutant[name] = status
+    return status_by_mutant
+
+
+def score(status_by_mutant: dict[str, str]) -> tuple[float | None, Counter]:
+    """Mutation score over decided mutants: detected / (detected + survived).
+
+    "no tests" mutants are excluded from the score (they indicate missing
+    coverage, reported separately) as are transient states like "not checked".
+    Returns (score or None when nothing was decided, per-status counts).
+    """
+    counts = Counter(status_by_mutant.values())
+    detected = sum(counts[s] for s in DETECTED_STATUSES)
+    missed = counts[MISSED_STATUS]
+    decided = detected + missed
+    return (detected / decided if decided else None), counts
+
+
+def render_summary(
+    files: list[str],
+    status_by_mutant: dict[str, str],
+    mutation_score: float | None,
+    counts: Counter,
+) -> str:
+    lines = ["## Mutation testing (diff-scoped, advisory)", ""]
+    if not files:
+        lines.append("No product code changed — nothing to mutate.")
+        return "\n".join(lines) + "\n"
+    lines.append(f"Changed product files: **{len(files)}**")
+    lines.append("")
+    if not status_by_mutant:
+        lines.append(
+            "mutmut generated no mutants for the changed lines "
+            "(non-function code, or excluded subtrees)."
+        )
+        return "\n".join(lines) + "\n"
+
+    detected = sum(counts[s] for s in DETECTED_STATUSES)
+    survived = counts[MISSED_STATUS]
+    untested = counts[UNTESTED_STATUS]
+    lines.append("| Metric | Value |")
+    lines.append("|---|---|")
+    if mutation_score is not None:
+        lines.append(f"| **Mutation score** | **{mutation_score:.0%}** |")
+    lines.append(f"| Mutants detected (killed/timeout/type-check) | {detected} |")
+    lines.append(f"| Mutants survived (bug would ship silently) | {survived} |")
+    if untested:
+        lines.append(f"| Mutants in functions no test exercises | {untested} |")
+    other = sum(counts.values()) - detected - survived - untested
+    if other:
+        lines.append(f"| Other (skipped/suspicious/not checked) | {other} |")
+    lines.append("")
+
+    interesting = {
+        name: status
+        for name, status in sorted(status_by_mutant.items())
+        if status in (MISSED_STATUS, UNTESTED_STATUS)
+    }
+    if interesting:
+        lines.append("### Gaps — seeded bugs the unit suite does not catch")
+        lines.append("")
+        for name, status in list(interesting.items())[:MAX_LISTED_GAPS]:
+            lines.append(f"- `{name}` — {status}")
+        if len(interesting) > MAX_LISTED_GAPS:
+            lines.append(f"- …and {len(interesting) - MAX_LISTED_GAPS} more")
+        lines.append("")
+        lines.append(
+            "Inspect locally with `uv run --group mutation mutmut show "
+            "<mutant-name>` (shows the exact code change that went undetected)."
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_summary(markdown: str) -> None:
+    print(markdown)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "")
+    if summary_path:
+        with open(summary_path, "a") as fh:
+            fh.write(markdown)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-ref",
+        default="origin/main",
+        help="Base ref to diff against (default: origin/main)",
+    )
+    parser.add_argument(
+        "--min-score",
+        type=float,
+        default=None,
+        help="Fail (exit 1) when the mutation score is below this fraction "
+        "(e.g. 0.6). Omitted = advisory, always exit 0.",
+    )
+    args = parser.parse_args(argv)
+
+    files = changed_python_files(args.base_ref)
+    if not files:
+        write_summary(render_summary([], {}, None, Counter()))
+        return 0
+
+    patterns = module_patterns(files)
+    measured, _ = run_mutmut(patterns)
+    status_by_mutant = parse_results(collect_results(), patterns) if measured else {}
+    mutation_score, counts = score(status_by_mutant)
+    write_summary(render_summary(files, status_by_mutant, mutation_score, counts))
+
+    if (
+        args.min_score is not None
+        and mutation_score is not None
+        and mutation_score < args.min_score
+    ):
+        print(
+            f"Mutation score {mutation_score:.0%} is below the required "
+            f"{args.min_score:.0%}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/test_mutation_diff.py
+++ b/.github/scripts/tests/test_mutation_diff.py
@@ -1,0 +1,257 @@
+"""Tests for mutation_diff.py — the diff-scoped mutation testing driver."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tomllib
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "mutation_diff.py"
+spec = importlib.util.spec_from_file_location("mutation_diff", SCRIPT)
+assert spec is not None and spec.loader is not None
+mutation_diff = importlib.util.module_from_spec(spec)
+sys.modules["mutation_diff"] = mutation_diff
+spec.loader.exec_module(mutation_diff)
+
+
+# ---------------------------------------------------------------- patterns
+
+
+def test_module_patterns_maps_paths_to_mutant_globs():
+    assert mutation_diff.module_patterns(
+        ["application_sdk/services/objectstore.py"]
+    ) == ["application_sdk.services.objectstore.*"]
+
+
+def test_module_patterns_package_init_covers_whole_package():
+    assert mutation_diff.module_patterns(["application_sdk/services/__init__.py"]) == [
+        "application_sdk.services.*"
+    ]
+
+
+def test_module_patterns_deduplicates_and_sorts():
+    patterns = mutation_diff.module_patterns(
+        [
+            "application_sdk/b.py",
+            "application_sdk/a.py",
+            "application_sdk/b.py",
+        ]
+    )
+    assert patterns == ["application_sdk.a.*", "application_sdk.b.*"]
+
+
+# ---------------------------------------------------- changed file filtering
+
+
+def test_changed_python_files_drops_excluded_subtrees(monkeypatch):
+    diff_output = "\n".join(
+        [
+            "application_sdk/services/objectstore.py",
+            "application_sdk/test_utils/helpers.py",
+            "application_sdk/testing/e2e/harness.py",
+        ]
+    )
+
+    class FakeProc:
+        stdout = diff_output
+
+    monkeypatch.setattr(mutation_diff.subprocess, "run", lambda *a, **k: FakeProc())
+    assert mutation_diff.changed_python_files("origin/main") == [
+        "application_sdk/services/objectstore.py"
+    ]
+
+
+def test_excluded_prefixes_match_pyproject_do_not_mutate():
+    """Guard against the script and [tool.mutmut] drifting apart."""
+    pyproject = Path(__file__).resolve().parents[3] / "pyproject.toml"
+    with open(pyproject, "rb") as fh:
+        config = tomllib.load(fh)["tool"]["mutmut"]
+    from_config = {p.removesuffix("*") for p in config["do_not_mutate"]}
+    assert from_config == set(mutation_diff.EXCLUDED_PREFIXES)
+
+
+# ------------------------------------------------------------ results parse
+
+
+RESULTS_OUTPUT = """\
+    application_sdk.services.objectstore.x_upload__mutmut_1: killed
+    application_sdk.services.objectstore.x_upload__mutmut_2: survived
+    application_sdk.services.objectstore.x_download__mutmut_1: no tests
+    application_sdk.clients.rest.x_get__mutmut_9: survived
+    application_sdk.services.objectstore.x_upload__mutmut_3: timeout
+"""
+
+
+def test_parse_results_keeps_only_matching_patterns():
+    parsed = mutation_diff.parse_results(
+        RESULTS_OUTPUT, ["application_sdk.services.objectstore.*"]
+    )
+    assert parsed == {
+        "application_sdk.services.objectstore.x_upload__mutmut_1": "killed",
+        "application_sdk.services.objectstore.x_upload__mutmut_2": "survived",
+        "application_sdk.services.objectstore.x_download__mutmut_1": "no tests",
+        "application_sdk.services.objectstore.x_upload__mutmut_3": "timeout",
+    }
+
+
+def test_parse_results_tolerates_blank_and_malformed_lines():
+    assert mutation_diff.parse_results("\n   \nnot-a-result\n", ["*"]) == {}
+
+
+# ------------------------------------------------------------------- score
+
+
+def test_score_counts_detected_and_survived():
+    status = {
+        "a__mutmut_1": "killed",
+        "a__mutmut_2": "survived",
+        "a__mutmut_3": "timeout",
+        "a__mutmut_4": "no tests",
+    }
+    mutation_score, counts = mutation_diff.score(status)
+    assert mutation_score == pytest.approx(2 / 3)
+    assert counts["no tests"] == 1
+
+
+def test_score_none_when_nothing_decided():
+    mutation_score, _ = mutation_diff.score({"a__mutmut_1": "no tests"})
+    assert mutation_score is None
+
+
+# ----------------------------------------------------------------- summary
+
+
+def test_render_summary_no_changed_files():
+    text = mutation_diff.render_summary([], {}, None, Counter())
+    assert "nothing to mutate" in text
+
+
+def test_render_summary_no_mutants_for_diff():
+    text = mutation_diff.render_summary(["application_sdk/a.py"], {}, None, Counter())
+    assert "no mutants" in text
+
+
+def test_render_summary_scorecard_lists_survivors():
+    status = {
+        "application_sdk.a.x_f__mutmut_1": "killed",
+        "application_sdk.a.x_f__mutmut_2": "survived",
+        "application_sdk.a.x_g__mutmut_1": "no tests",
+    }
+    mutation_score, counts = mutation_diff.score(status)
+    text = mutation_diff.render_summary(
+        ["application_sdk/a.py"], status, mutation_score, counts
+    )
+    assert "**50%**" in text
+    assert "application_sdk.a.x_f__mutmut_2" in text
+    assert "application_sdk.a.x_g__mutmut_1" in text
+    assert "mutmut show" in text
+
+
+def test_render_summary_caps_gap_list():
+    status = {
+        f"application_sdk.a.x_f__mutmut_{i}": "survived"
+        for i in range(mutation_diff.MAX_LISTED_GAPS + 10)
+    }
+    mutation_score, counts = mutation_diff.score(status)
+    text = mutation_diff.render_summary(
+        ["application_sdk/a.py"], status, mutation_score, counts
+    )
+    assert text.count("— survived") == mutation_diff.MAX_LISTED_GAPS
+    assert "…and 10 more" in text
+
+
+# ------------------------------------------------------------ run_mutmut
+
+
+class FakeRunProc:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_run_mutmut_success(monkeypatch):
+    monkeypatch.setattr(
+        mutation_diff.subprocess,
+        "run",
+        lambda *a, **k: FakeRunProc(0, stdout="ok"),
+    )
+    assert mutation_diff.run_mutmut(["application_sdk.a.*"]) == (True, "ok")
+
+
+def test_run_mutmut_nothing_matches_is_not_an_error(monkeypatch):
+    stderr = f"AssertionError: {mutation_diff.NOTHING_MATCHES_MARKER}\n"
+    monkeypatch.setattr(
+        mutation_diff.subprocess,
+        "run",
+        lambda *a, **k: FakeRunProc(1, stderr=stderr),
+    )
+    measured, _ = mutation_diff.run_mutmut(["application_sdk.a.*"])
+    assert measured is False
+
+
+def test_run_mutmut_other_failure_raises(monkeypatch):
+    monkeypatch.setattr(
+        mutation_diff.subprocess,
+        "run",
+        lambda *a, **k: FakeRunProc(2, stderr="boom"),
+    )
+    with pytest.raises(SystemExit):
+        mutation_diff.run_mutmut(["application_sdk.a.*"])
+
+
+# -------------------------------------------------------------------- main
+
+
+def test_main_no_changed_files_exits_zero(monkeypatch, capsys):
+    monkeypatch.setattr(mutation_diff, "changed_python_files", lambda base_ref: [])
+    assert mutation_diff.main([]) == 0
+    assert "nothing to mutate" in capsys.readouterr().out
+
+
+def test_main_advisory_never_fails_on_low_score(monkeypatch):
+    monkeypatch.setattr(
+        mutation_diff,
+        "changed_python_files",
+        lambda base_ref: ["application_sdk/a.py"],
+    )
+    monkeypatch.setattr(mutation_diff, "run_mutmut", lambda patterns: (True, ""))
+    monkeypatch.setattr(mutation_diff, "collect_results", lambda: "")
+    monkeypatch.setattr(
+        mutation_diff,
+        "parse_results",
+        lambda output, patterns: {"application_sdk.a.x_f__mutmut_1": "survived"},
+    )
+    assert mutation_diff.main([]) == 0
+
+
+def test_main_min_score_gates(monkeypatch):
+    monkeypatch.setattr(
+        mutation_diff,
+        "changed_python_files",
+        lambda base_ref: ["application_sdk/a.py"],
+    )
+    monkeypatch.setattr(mutation_diff, "run_mutmut", lambda patterns: (True, ""))
+    monkeypatch.setattr(mutation_diff, "collect_results", lambda: "")
+    monkeypatch.setattr(
+        mutation_diff,
+        "parse_results",
+        lambda output, patterns: {
+            "application_sdk.a.x_f__mutmut_1": "survived",
+            "application_sdk.a.x_f__mutmut_2": "killed",
+        },
+    )
+    assert mutation_diff.main(["--min-score", "0.6"]) == 1
+    assert mutation_diff.main(["--min-score", "0.4"]) == 0
+
+
+def test_main_writes_github_step_summary(monkeypatch, tmp_path):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    monkeypatch.setattr(mutation_diff, "changed_python_files", lambda base_ref: [])
+    mutation_diff.main([])
+    assert "nothing to mutate" in summary.read_text()

--- a/.github/workflows/mutation-tests.yaml
+++ b/.github/workflows/mutation-tests.yaml
@@ -1,0 +1,51 @@
+name: Mutation tests (advisory)
+
+# Diff-scoped mutation testing pilot: mutmut seeds small faults ("mutants")
+# into the Python files a PR changes and reports which of them the unit
+# suite fails to detect. A surviving mutant is a bug class that would ship
+# without any test failing — a direct measure of test meaningfulness that
+# line coverage cannot provide.
+#
+# ADVISORY ONLY for the pilot: the job posts a scorecard to the run summary
+# and never blocks the PR (continue-on-error + the driver exits 0 on any
+# completed measurement). Graduation to a gate is a later, data-driven
+# decision — see the --min-score flag in mutation_diff.py.
+#
+# All conditional logic lives in .github/scripts/mutation_diff.py (tested by
+# scripts-tests.yaml) per docs/standards/ci.md; the run block below is
+# straight-line.
+
+on:
+  pull_request:
+    paths:
+      - "application_sdk/**/*.py"
+      - ".github/scripts/mutation_diff.py"
+      - ".github/workflows/mutation-tests.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mutation-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mutation:
+    name: Diff-scoped mutation testing
+    runs-on: ubuntu-latest
+    # Pilot is observe-only: never block the PR, even on infra failure.
+    continue-on-error: true
+    timeout-minutes: 45
+    steps:
+      # fetch-depth: 0 — the driver diffs against the merge-base with the
+      # PR base branch, which a shallow clone does not contain.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - uses: "./.github/actions/setup-deps"
+
+      - name: Run diff-scoped mutation testing
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: uv run --all-extras --all-groups python .github/scripts/mutation_diff.py --base-ref "origin/${BASE_REF}"

--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,6 @@ remediation/runs/
 
 # Renovate setup
 renovate-config/README.md
+
+# mutmut mutation-testing working directory (poe mutation-diff)
+mutants/

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -3,6 +3,7 @@
 - Test command and conventions: `docs/standards/testing.md`.
 - New code should target 85% coverage per `docs/standards/review-checklist.md` (the tooling threshold in `pyproject.toml` is 85% — CI fails below it).
 - Current tests live in `tests/unit/`; follow existing structure when adding new tests.
+- Mutation testing (advisory pilot): the `mutation-tests.yaml` workflow runs mutmut on the Python files a PR changes and posts a scorecard of seeded faults the unit suite missed. It never blocks the PR. Run locally with `uv run poe mutation-diff`; inspect a surviving mutant with `uv run --group mutation mutmut show <mutant-name>`.
 - For consumer apps built on this SDK, the conformance suite's T-series (`packages/conformance/conformance/docs/rules/tests.md`) enforces the agreed per-connector testing-tier architecture (unit + integration required, e2e recommended, UI optional except for top connectors) plus test-quality checks — assertion-free tests, uncollectable test files, disabled coverage gates, and more. Run it with `/remediate` or `uv run atlan-application-sdk-conformance detect --series T`.
 
 ## What SDK Review Checks for Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,12 @@ examples = [
     "snowflake-sqlalchemy>=1.7.0,<2.0.0",
     "psycopg[binary]>=3.2.7,<4.0.0",
 ]
+# Mutation testing (advisory) — run via `poe mutation-diff` locally or the
+# mutation-tests CI workflow. Separate group: mutmut requires fork support
+# (Linux/macOS only) and is not part of the regular test matrix.
+mutation = [
+    "mutmut>=3.6.0,<4.0.0",
+]
 docs = [
     "mkdocs>=1.6.1,<2.0.0",
     "mkdocs-material>=9.6.4,<10.0.0",
@@ -189,6 +195,9 @@ test-integration = "pytest tests/integration/ -m integration -v --timeout=120"
 # Size via ATLAN_LOAD_TEST_SIZE_MIB (default 1024; 51200 = 50 GiB). See tests/load/README.md.
 load-test-storage = "pytest tests/load -m load -v -s --timeout=0"
 test-scripts = "bats .github/scripts/tests"  # requires: bats-core (apt-get install -y bats)
+# Diff-scoped mutation testing (advisory): mutates only files changed vs
+# origin/main and reports which seeded bugs the unit suite fails to catch.
+mutation-diff = "python .github/scripts/mutation_diff.py"
 
 # API docs — must be before any sub-table header ([tool.poe.tasks.*])
 # or TOML nests it inside the sub-table rather than the parent tasks namespace
@@ -266,6 +275,40 @@ markers = [
     "azure_integration: tests requiring keyless Azure Workload Identity Federation (AZURE_STORAGE_ACCOUNT, AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_FEDERATED_TOKEN_FILE)",
     "gcs_integration: tests requiring keyless GCS access (GCS_BUCKET, GCS_PROJECT_ID + ambient ADC, e.g. Workload Identity Federation)",
     "storage_emulator: hermetic object-store tests against local emulators (MinIO/Azurite/storage-testbench); run in CI with emulator sidecars",
+]
+
+# Mutation testing (mutmut 3.x). Advisory-only: measures whether the unit
+# suite actually detects seeded faults ("mutants") in changed code. Run
+# diff-scoped via `poe mutation-diff` / the mutation-tests workflow; a full
+# run is `uv run --group mutation mutmut run` (slow — whole-SDK).
+# The do_not_mutate list mirrors the unit-coverage omit list below: those
+# subtrees ship test infrastructure exercised under other markers, so
+# mutating them only produces "no tests" noise.
+[tool.mutmut]
+source_paths = ["application_sdk"]
+# Never mutate __file__-based path derivation: mutating it to None inside a
+# default argument evaluates at import time and crashes collection (and such
+# mutants are unproductive noise anyway).
+do_not_mutate_patterns = ['__file__']
+do_not_mutate = [
+    "application_sdk/test_utils/*",
+    "application_sdk/testing/scale_data_generator/*",
+    "application_sdk/testing/integration/*",
+    "application_sdk/testing/e2e/*",
+    "application_sdk/testing/hypothesis/*",
+    "application_sdk/testing/parity/*",
+]
+# Restrict mutmut's test runs to the hermetic unit tier; integration/e2e
+# markers are deselected by addopts anyway, this just skips collection.
+pytest_add_cli_args_test_selection = ["tests/unit"]
+# mutmut executes tests inside its mutants/ sandbox; every repo file the
+# unit suite reads (Dapr component YAMLs, CI scripts under test, the
+# capability-manifest extractor) must be copied in or collection fails.
+also_copy = [
+    "components/",
+    "tools/",
+    ".github/scripts/",
+    ".claude/skills/capability-manifest/",
 ]
 
 [tool.coverage.run]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,3 +7,24 @@ import os
 # (http://127.0.0.1:3500), which isn't running in unit test environments
 # and causes 60-second timeouts per test.
 os.environ.setdefault("ATLAN_ENABLE_OBSERVABILITY_DAPR_SINK", "false")
+
+# mutmut sandbox compat (mutation testing, `poe mutation-diff`): mutmut's
+# record_trampoline_hit() resolves the *relative* [tool.mutmut] source_paths
+# against the current working directory on every mutated-function call during
+# its stats phase, so any test that monkeypatch.chdir()s into a tmp_path
+# crashes with FileNotFoundError (mutmut 3.6.0; resolve happens even though
+# its result is only used by the max_stack_depth feature, which we leave at
+# the -1 default). Replace it with the equivalent minus the cwd-sensitive
+# resolve. Only active under `mutmut run` (MUTANT_UNDER_TEST is set there);
+# plain pytest runs never import mutmut.
+if os.environ.get("MUTANT_UNDER_TEST") is not None:
+    import mutmut
+    import mutmut.mutation.trampoline as _trampoline
+
+    def _record_trampoline_hit_without_cwd_resolve(name: str) -> None:
+        assert not name.startswith(
+            "src."
+        ), "Failed trampoline hit. Module name starts with `src.`, which is invalid"
+        mutmut._stats.add(name)
+
+    _trampoline.record_trampoline_hit = _record_trampoline_hit_without_cwd_resolve

--- a/uv.lock
+++ b/uv.lock
@@ -330,6 +330,9 @@ examples = [
     { name = "psycopg", extra = ["binary"] },
     { name = "snowflake-sqlalchemy" },
 ]
+mutation = [
+    { name = "mutmut" },
+]
 test = [
     { name = "coverage" },
     { name = "hypothesis" },
@@ -416,6 +419,7 @@ examples = [
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.7,<4.0.0" },
     { name = "snowflake-sqlalchemy", specifier = ">=1.7.0,<2.0.0" },
 ]
+mutation = [{ name = "mutmut", specifier = ">=3.6.0,<4.0.0" }]
 test = [
     { name = "coverage", specifier = ">=7.6.1,<8.0.0" },
     { name = "hypothesis", specifier = ">=6.114.0,<7.0.0" },
@@ -2264,6 +2268,18 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2304,6 +2320,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
 ]
 
 [[package]]
@@ -2403,6 +2424,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
 ]
 
 [[package]]
@@ -2779,6 +2812,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
     { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "mutmut"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "coverage" },
+    { name = "libcst" },
+    { name = "pytest" },
+    { name = "setproctitle" },
+    { name = "textual" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/b0/ebcae42b90b07756b7aa10c4176835f436332e6c1cb28bc35bae83462382/mutmut-3.6.0.tar.gz", hash = "sha256:bcbd3e4d0d2d4edf3dfb42955417279a8866a3dbbcb87d619f2f3fd0ac7fafda", size = 51538, upload-time = "2026-06-06T07:44:51.798Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/5a/a0caa3f9db407b5d12c311bd4c87aa67fdd6e3f329377149e303108a1c51/mutmut-3.6.0-py3-none-any.whl", hash = "sha256:a9f5b8dcf6cbf9496769d7cf8bdbba37a0ec709ad98f88d103238b62f10bdf37", size = 47770, upload-time = "2026-06-06T07:44:50.038Z" },
 ]
 
 [[package]]
@@ -4662,6 +4712,77 @@ wheels = [
 ]
 
 [[package]]
+name = "setproctitle"
+version = "1.3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/48/49393a96a2eef1ab418b17475fb92b8fcfad83d099e678751b05472e69de/setproctitle-1.3.7.tar.gz", hash = "sha256:bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e", size = 27002, upload-time = "2025-09-05T12:51:25.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/cd/1b7ba5cad635510720ce19d7122154df96a2387d2a74217be552887c93e5/setproctitle-1.3.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a600eeb4145fb0ee6c287cb82a2884bd4ec5bbb076921e287039dcc7b7cc6dd0", size = 18085, upload-time = "2025-09-05T12:49:22.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/1a/b2da0a620490aae355f9d72072ac13e901a9fec809a6a24fc6493a8f3c35/setproctitle-1.3.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:97a090fed480471bb175689859532709e28c085087e344bca45cf318034f70c4", size = 13097, upload-time = "2025-09-05T12:49:23.322Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2e/bd03ff02432a181c1787f6fc2a678f53b7dacdd5ded69c318fe1619556e8/setproctitle-1.3.7-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1607b963e7b53e24ec8a2cb4e0ab3ae591d7c6bf0a160feef0551da63452b37f", size = 32191, upload-time = "2025-09-05T12:49:24.567Z" },
+    { url = "https://files.pythonhosted.org/packages/28/78/1e62fc0937a8549f2220445ed2175daacee9b6764c7963b16148119b016d/setproctitle-1.3.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a20fb1a3974e2dab857870cf874b325b8705605cb7e7e8bcbb915bca896f52a9", size = 33203, upload-time = "2025-09-05T12:49:25.871Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3c/65edc65db3fa3df400cf13b05e9d41a3c77517b4839ce873aa6b4043184f/setproctitle-1.3.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f8d961bba676e07d77665204f36cffaa260f526e7b32d07ab3df6a2c1dfb44ba", size = 34963, upload-time = "2025-09-05T12:49:27.044Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/32/89157e3de997973e306e44152522385f428e16f92f3cf113461489e1e2ee/setproctitle-1.3.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:db0fd964fbd3a9f8999b502f65bd2e20883fdb5b1fae3a424e66db9a793ed307", size = 32398, upload-time = "2025-09-05T12:49:28.909Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/18/77a765a339ddf046844cb4513353d8e9dcd8183da9cdba6e078713e6b0b2/setproctitle-1.3.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:db116850fcf7cca19492030f8d3b4b6e231278e8fe097a043957d22ce1bdf3ee", size = 33657, upload-time = "2025-09-05T12:49:30.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/63/f0b6205c64d74d2a24a58644a38ec77bdbaa6afc13747e75973bf8904932/setproctitle-1.3.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:316664d8b24a5c91ee244460bdaf7a74a707adaa9e14fbe0dc0a53168bb9aba1", size = 31836, upload-time = "2025-09-05T12:49:32.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/51/e1277f9ba302f1a250bbd3eedbbee747a244b3cc682eb58fb9733968f6d8/setproctitle-1.3.7-cp311-cp311-win32.whl", hash = "sha256:b74774ca471c86c09b9d5037c8451fff06bb82cd320d26ae5a01c758088c0d5d", size = 12556, upload-time = "2025-09-05T12:49:33.529Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/7b/822a23f17e9003dfdee92cd72758441ca2a3680388da813a371b716fb07f/setproctitle-1.3.7-cp311-cp311-win_amd64.whl", hash = "sha256:acb9097213a8dd3410ed9f0dc147840e45ca9797785272928d4be3f0e69e3be4", size = 13243, upload-time = "2025-09-05T12:49:34.553Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f0/2dc88e842077719d7384d86cc47403e5102810492b33680e7dadcee64cd8/setproctitle-1.3.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2dc99aec591ab6126e636b11035a70991bc1ab7a261da428491a40b84376654e", size = 18049, upload-time = "2025-09-05T12:49:36.241Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b4/50940504466689cda65680c9e9a1e518e5750c10490639fa687489ac7013/setproctitle-1.3.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cdd8aa571b7aa39840fdbea620e308a19691ff595c3a10231e9ee830339dd798", size = 13079, upload-time = "2025-09-05T12:49:38.088Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/99/71630546b9395b095f4082be41165d1078204d1696c2d9baade3de3202d0/setproctitle-1.3.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2906b6c7959cdb75f46159bf0acd8cc9906cf1361c9e1ded0d065fe8f9039629", size = 32932, upload-time = "2025-09-05T12:49:39.271Z" },
+    { url = "https://files.pythonhosted.org/packages/50/22/cee06af4ffcfb0e8aba047bd44f5262e644199ae7527ae2c1f672b86495c/setproctitle-1.3.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6915964a6dda07920a1159321dcd6d94fc7fc526f815ca08a8063aeca3c204f1", size = 33736, upload-time = "2025-09-05T12:49:40.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/00/a5949a8bb06ef5e7df214fc393bb2fb6aedf0479b17214e57750dfdd0f24/setproctitle-1.3.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cff72899861c765bd4021d1ff1c68d60edc129711a2fdba77f9cb69ef726a8b6", size = 35605, upload-time = "2025-09-05T12:49:42.362Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3a/50caca532a9343828e3bf5778c7a84d6c737a249b1796d50dd680290594d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7cb05bd446687ff816a3aaaf831047fc4c364feff7ada94a66024f1367b448c", size = 33143, upload-time = "2025-09-05T12:49:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/14/b843a251296ce55e2e17c017d6b9f11ce0d3d070e9265de4ecad948b913d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3a57b9a00de8cae7e2a1f7b9f0c2ac7b69372159e16a7708aa2f38f9e5cc987a", size = 34434, upload-time = "2025-09-05T12:49:45.31Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b7/06145c238c0a6d2c4bc881f8be230bb9f36d2bf51aff7bddcb796d5eed67/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d8828b356114f6b308b04afe398ed93803d7fca4a955dd3abe84430e28d33739", size = 32795, upload-time = "2025-09-05T12:49:46.419Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/dc/ef76a81fac9bf27b84ed23df19c1f67391a753eed6e3c2254ebcb5133f56/setproctitle-1.3.7-cp312-cp312-win32.whl", hash = "sha256:b0304f905efc845829ac2bc791ddebb976db2885f6171f4a3de678d7ee3f7c9f", size = 12552, upload-time = "2025-09-05T12:49:47.635Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5b/a9fe517912cd6e28cf43a212b80cb679ff179a91b623138a99796d7d18a0/setproctitle-1.3.7-cp312-cp312-win_amd64.whl", hash = "sha256:9888ceb4faea3116cf02a920ff00bfbc8cc899743e4b4ac914b03625bdc3c300", size = 13247, upload-time = "2025-09-05T12:49:49.16Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/2f/fcedcade3b307a391b6e17c774c6261a7166aed641aee00ed2aad96c63ce/setproctitle-1.3.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c3736b2a423146b5e62230502e47e08e68282ff3b69bcfe08a322bee73407922", size = 18047, upload-time = "2025-09-05T12:49:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ae/afc141ca9631350d0a80b8f287aac79a76f26b6af28fd8bf92dae70dc2c5/setproctitle-1.3.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3384e682b158d569e85a51cfbde2afd1ab57ecf93ea6651fe198d0ba451196ee", size = 13073, upload-time = "2025-09-05T12:49:51.46Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ed/0a4f00315bc02510395b95eec3d4aa77c07192ee79f0baae77ea7b9603d8/setproctitle-1.3.7-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0564a936ea687cd24dffcea35903e2a20962aa6ac20e61dd3a207652401492dd", size = 33284, upload-time = "2025-09-05T12:49:52.741Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/e4/adf3c4c0a2173cb7920dc9df710bcc67e9bcdbf377e243b7a962dc31a51a/setproctitle-1.3.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5d1cb3f81531f0eb40e13246b679a1bdb58762b170303463cb06ecc296f26d0", size = 34104, upload-time = "2025-09-05T12:49:54.416Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4f/6daf66394152756664257180439d37047aa9a1cfaa5e4f5ed35e93d1dc06/setproctitle-1.3.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a7d159e7345f343b44330cbba9194169b8590cb13dae940da47aa36a72aa9929", size = 35982, upload-time = "2025-09-05T12:49:56.295Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/62/f2c0595403cf915db031f346b0e3b2c0096050e90e0be658a64f44f4278a/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0b5074649797fd07c72ca1f6bff0406f4a42e1194faac03ecaab765ce605866f", size = 33150, upload-time = "2025-09-05T12:49:58.025Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/29/10dd41cde849fb2f9b626c846b7ea30c99c81a18a5037a45cc4ba33c19a7/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:61e96febced3f61b766115381d97a21a6265a0f29188a791f6df7ed777aef698", size = 34463, upload-time = "2025-09-05T12:49:59.424Z" },
+    { url = "https://files.pythonhosted.org/packages/71/3c/cedd8eccfaf15fb73a2c20525b68c9477518917c9437737fa0fda91e378f/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:047138279f9463f06b858e579cc79580fbf7a04554d24e6bddf8fe5dddbe3d4c", size = 32848, upload-time = "2025-09-05T12:50:01.107Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3e/0a0e27d1c9926fecccfd1f91796c244416c70bf6bca448d988638faea81d/setproctitle-1.3.7-cp313-cp313-win32.whl", hash = "sha256:7f47accafac7fe6535ba8ba9efd59df9d84a6214565108d0ebb1199119c9cbbd", size = 12544, upload-time = "2025-09-05T12:50:15.81Z" },
+    { url = "https://files.pythonhosted.org/packages/36/1b/6bf4cb7acbbd5c846ede1c3f4d6b4ee52744d402e43546826da065ff2ab7/setproctitle-1.3.7-cp313-cp313-win_amd64.whl", hash = "sha256:fe5ca35aeec6dc50cabab9bf2d12fbc9067eede7ff4fe92b8f5b99d92e21263f", size = 13235, upload-time = "2025-09-05T12:50:16.89Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a4/d588d3497d4714750e3eaf269e9e8985449203d82b16b933c39bd3fc52a1/setproctitle-1.3.7-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:10e92915c4b3086b1586933a36faf4f92f903c5554f3c34102d18c7d3f5378e9", size = 18058, upload-time = "2025-09-05T12:50:02.501Z" },
+    { url = "https://files.pythonhosted.org/packages/05/77/7637f7682322a7244e07c373881c7e982567e2cb1dd2f31bd31481e45500/setproctitle-1.3.7-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:de879e9c2eab637f34b1a14c4da1e030c12658cdc69ee1b3e5be81b380163ce5", size = 13072, upload-time = "2025-09-05T12:50:03.601Z" },
+    { url = "https://files.pythonhosted.org/packages/52/09/f366eca0973cfbac1470068d1313fa3fe3de4a594683385204ec7f1c4101/setproctitle-1.3.7-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c18246d88e227a5b16248687514f95642505000442165f4b7db354d39d0e4c29", size = 34490, upload-time = "2025-09-05T12:50:04.948Z" },
+    { url = "https://files.pythonhosted.org/packages/71/36/611fc2ed149fdea17c3677e1d0df30d8186eef9562acc248682b91312706/setproctitle-1.3.7-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7081f193dab22df2c36f9fc6d113f3793f83c27891af8fe30c64d89d9a37e152", size = 35267, upload-time = "2025-09-05T12:50:06.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a4/64e77d0671446bd5a5554387b69e1efd915274686844bea733714c828813/setproctitle-1.3.7-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9cc9b901ce129350637426a89cfd650066a4adc6899e47822e2478a74023ff7c", size = 37376, upload-time = "2025-09-05T12:50:07.484Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/ad9c664fe524fb4a4b2d3663661a5c63453ce851736171e454fa2cdec35c/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:80e177eff2d1ec172188d0d7fd9694f8e43d3aab76a6f5f929bee7bf7894e98b", size = 33963, upload-time = "2025-09-05T12:50:09.056Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/01/a36de7caf2d90c4c28678da1466b47495cbbad43badb4e982d8db8167ed4/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:23e520776c445478a67ee71b2a3c1ffdafbe1f9f677239e03d7e2cc635954e18", size = 35550, upload-time = "2025-09-05T12:50:10.791Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/68/17e8aea0ed5ebc17fbf03ed2562bfab277c280e3625850c38d92a7b5fcd9/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5fa1953126a3b9bd47049d58c51b9dac72e78ed120459bd3aceb1bacee72357c", size = 33727, upload-time = "2025-09-05T12:50:12.032Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/33/90a3bf43fe3a2242b4618aa799c672270250b5780667898f30663fd94993/setproctitle-1.3.7-cp313-cp313t-win32.whl", hash = "sha256:4a5e212bf438a4dbeece763f4962ad472c6008ff6702e230b4f16a037e2f6f29", size = 12549, upload-time = "2025-09-05T12:50:13.074Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/0e/50d1f07f3032e1f23d814ad6462bc0a138f369967c72494286b8a5228e40/setproctitle-1.3.7-cp313-cp313t-win_amd64.whl", hash = "sha256:cf2727b733e90b4f874bac53e3092aa0413fe1ea6d4f153f01207e6ce65034d9", size = 13243, upload-time = "2025-09-05T12:50:14.146Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c7/43ac3a98414f91d1b86a276bc2f799ad0b4b010e08497a95750d5bc42803/setproctitle-1.3.7-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:80c36c6a87ff72eabf621d0c79b66f3bdd0ecc79e873c1e9f0651ee8bf215c63", size = 18052, upload-time = "2025-09-05T12:50:17.928Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2c/dc258600a25e1a1f04948073826bebc55e18dbd99dc65a576277a82146fa/setproctitle-1.3.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b53602371a52b91c80aaf578b5ada29d311d12b8a69c0c17fbc35b76a1fd4f2e", size = 13071, upload-time = "2025-09-05T12:50:19.061Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/26/8e3bb082992f19823d831f3d62a89409deb6092e72fc6940962983ffc94f/setproctitle-1.3.7-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fcb966a6c57cf07cc9448321a08f3be6b11b7635be502669bc1d8745115d7e7f", size = 33180, upload-time = "2025-09-05T12:50:20.395Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/ae692a20276d1159dd0cf77b0bcf92cbb954b965655eb4a69672099bb214/setproctitle-1.3.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46178672599b940368d769474fe13ecef1b587d58bb438ea72b9987f74c56ea5", size = 34043, upload-time = "2025-09-05T12:50:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b2/6a092076324dd4dac1a6d38482bedebbff5cf34ef29f58585ec76e47bc9d/setproctitle-1.3.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7f9e9e3ff135cbcc3edd2f4cf29b139f4aca040d931573102742db70ff428c17", size = 35892, upload-time = "2025-09-05T12:50:23.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/1a/8836b9f28cee32859ac36c3df85aa03e1ff4598d23ea17ca2e96b5845a8f/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:14c7eba8d90c93b0e79c01f0bd92a37b61983c27d6d7d5a3b5defd599113d60e", size = 32898, upload-time = "2025-09-05T12:50:25.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/22/8fabdc24baf42defb599714799d8445fe3ae987ec425a26ec8e80ea38f8e/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9e64e98077fb30b6cf98073d6c439cd91deb8ebbf8fc62d9dbf52bd38b0c6ac0", size = 34308, upload-time = "2025-09-05T12:50:26.827Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/b9bee9de6c8cdcb3b3a6cb0b3e773afdb86bbbc1665a3bfa424a4294fda2/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b91387cc0f02a00ac95dcd93f066242d3cca10ff9e6153de7ee07069c6f0f7c8", size = 32536, upload-time = "2025-09-05T12:50:28.5Z" },
+    { url = "https://files.pythonhosted.org/packages/37/0c/75e5f2685a5e3eda0b39a8b158d6d8895d6daf3ba86dec9e3ba021510272/setproctitle-1.3.7-cp314-cp314-win32.whl", hash = "sha256:52b054a61c99d1b72fba58b7f5486e04b20fefc6961cd76722b424c187f362ed", size = 12731, upload-time = "2025-09-05T12:50:43.955Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/acddbce90d1361e1786e1fb421bc25baeb0c22ef244ee5d0176511769ec8/setproctitle-1.3.7-cp314-cp314-win_amd64.whl", hash = "sha256:5818e4080ac04da1851b3ec71e8a0f64e3748bf9849045180566d8b736702416", size = 13464, upload-time = "2025-09-05T12:50:45.057Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6d/20886c8ff2e6d85e3cabadab6aab9bb90acaf1a5cfcb04d633f8d61b2626/setproctitle-1.3.7-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6fc87caf9e323ac426910306c3e5d3205cd9f8dcac06d233fcafe9337f0928a3", size = 18062, upload-time = "2025-09-05T12:50:29.78Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/60/26dfc5f198715f1343b95c2f7a1c16ae9ffa45bd89ffd45a60ed258d24ea/setproctitle-1.3.7-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6134c63853d87a4897ba7d5cc0e16abfa687f6c66fc09f262bb70d67718f2309", size = 13075, upload-time = "2025-09-05T12:50:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/21/9c/980b01f50d51345dd513047e3ba9e96468134b9181319093e61db1c47188/setproctitle-1.3.7-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1403d2abfd32790b6369916e2313dffbe87d6b11dca5bbd898981bcde48e7a2b", size = 34744, upload-time = "2025-09-05T12:50:32.777Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b4/82cd0c86e6d1c4538e1a7eb908c7517721513b801dff4ba3f98ef816a240/setproctitle-1.3.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7c5bfe4228ea22373e3025965d1a4116097e555ee3436044f5c954a5e63ac45", size = 35589, upload-time = "2025-09-05T12:50:34.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4f/9f6b2a7417fd45673037554021c888b31247f7594ff4bd2239918c5cd6d0/setproctitle-1.3.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:585edf25e54e21a94ccb0fe81ad32b9196b69ebc4fc25f81da81fb8a50cca9e4", size = 37698, upload-time = "2025-09-05T12:50:35.524Z" },
+    { url = "https://files.pythonhosted.org/packages/20/92/927b7d4744aac214d149c892cb5fa6dc6f49cfa040cb2b0a844acd63dcaf/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:96c38cdeef9036eb2724c2210e8d0b93224e709af68c435d46a4733a3675fee1", size = 34201, upload-time = "2025-09-05T12:50:36.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0c/fd4901db5ba4b9d9013e62f61d9c18d52290497f956745cd3e91b0d80f90/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:45e3ef48350abb49cf937d0a8ba15e42cee1e5ae13ca41a77c66d1abc27a5070", size = 35801, upload-time = "2025-09-05T12:50:38.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e3/54b496ac724e60e61cc3447f02690105901ca6d90da0377dffe49ff99fc7/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1fae595d032b30dab4d659bece20debd202229fce12b55abab978b7f30783d73", size = 33958, upload-time = "2025-09-05T12:50:39.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a8/c84bb045ebf8c6fdc7f7532319e86f8380d14bbd3084e6348df56bdfe6fd/setproctitle-1.3.7-cp314-cp314t-win32.whl", hash = "sha256:02432f26f5d1329ab22279ff863c83589894977063f59e6c4b4845804a08f8c2", size = 12745, upload-time = "2025-09-05T12:50:41.377Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b6/3a5a4f9952972791a9114ac01dfc123f0df79903577a3e0a7a404a695586/setproctitle-1.3.7-cp314-cp314t-win_amd64.whl", hash = "sha256:cbc388e3d86da1f766d8fc2e12682e446064c01cea9f88a88647cfe7c011de6a", size = 13469, upload-time = "2025-09-05T12:50:42.67Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/5b/5e1c117ac84e3cefcf8d7a7f6b2461795a87e20869da065a5c087149060b/setproctitle-1.3.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b1cac6a4b0252b8811d60b6d8d0f157c0fdfed379ac89c25a914e6346cf355a1", size = 12587, upload-time = "2025-09-05T12:51:21.195Z" },
+    { url = "https://files.pythonhosted.org/packages/73/02/b9eadc226195dcfa90eed37afe56b5dd6fa2f0e5220ab8b7867b8862b926/setproctitle-1.3.7-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f1704c9e041f2b1dc38f5be4552e141e1432fba3dd52c72eeffd5bc2db04dc65", size = 14286, upload-time = "2025-09-05T12:51:22.61Z" },
+    { url = "https://files.pythonhosted.org/packages/28/26/1be1d2a53c2a91ec48fa2ff4a409b395f836798adf194d99de9c059419ea/setproctitle-1.3.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:b08b61976ffa548bd5349ce54404bf6b2d51bd74d4f1b241ed1b0f25bce09c3a", size = 13282, upload-time = "2025-09-05T12:51:24.094Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -4856,6 +4977,23 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
+]
+
+[[package]]
 name = "tomlkit"
 version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4990,6 +5128,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds a **measure-only mutation-testing lane** to the SDK — the first step of the test-quality program (measure meaningfulness, not just coverage).

On every PR that touches `application_sdk/**/*.py`, a new non-blocking job seeds small faults ("mutants") into **only the changed files** via [mutmut 3.x](https://mutmut.readthedocs.io/) and reports which of them the unit suite fails to catch. A surviving mutant is a bug class that would ship without any test failing — a direct measure of test meaningfulness that line coverage cannot provide.

## How

- **`[tool.mutmut]` + `mutation` dependency group** (`pyproject.toml`): `do_not_mutate` mirrors the unit-coverage omit list; `do_not_mutate_patterns = ['__file__']` because mutating `__file__`-based path derivation inside a default argument evaluates at import time and kills collection.
- **`.github/scripts/mutation_diff.py`** (tested in `.github/scripts/tests/`, per `docs/standards/ci.md`): computes the changed product files vs the PR base, maps them to mutant-name patterns, runs `mutmut run`, parses `mutmut results`, and writes a scorecard (score, killed/survived counts, surviving mutant names capped at 40) to the step summary. **Advisory**: exits 0 on any completed measurement; `--min-score` exists for later, data-driven gate graduation.
- **`.github/workflows/mutation-tests.yaml`**: ubuntu-only (mutmut needs `fork`), `continue-on-error: true`, 45-min timeout.
- **`tests/conftest.py`**: under mutmut only (`MUTANT_UNDER_TEST` set), replaces `record_trampoline_hit` with an equivalent minus its cwd-sensitive `source_paths` resolve — mutmut 3.6.0 crashes on tests that `monkeypatch.chdir()`; the resolve only feeds the `max_stack_depth` feature, which stays at its disabled default. Inert under plain pytest.
- Local entry point: `uv run poe mutation-diff`; inspect a survivor with `uv run --group mutation mutmut show <mutant-name>`.

## Validation (local, end-to-end)

- Full unit suite — **1394 tests — passes inside the mutants sandbox** (after `also_copy` of `components/`, `tools/`, `.github/scripts/`, `.claude/skills/capability-manifest/`).
- Real single-file diff run (`application_sdk/testing/sdr/base.py`): **56% mutation score** — 284 detected, 226 survived, 9 in functions no test exercises — scorecard rendered, exit 0.
- Reference full-module run on `application_sdk/discovery.py`: 355 killed / 370 survived (~49%) — the kind of gap line coverage cannot see.
- Driver edge cases covered by 20 pytest cases: no changed files, no mutants for diff (constants-only modules), `--min-score` gating, summary cap, sandbox-exclusion parity with `[tool.mutmut]`.

## Non-goals (this PR)

Fleet/app rollout, score thresholds/gates, nightly full-repo runs, and dashboard aggregation — all deliberately deferred until this pilot produces real numbers on SDK PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)