### PR TITLE
fix(conformance): recognise project-local _assert_* helpers in T005/T007

### DIFF
--- a/packages/conformance/conformance/suite/checks/test_quality.py
+++ b/packages/conformance/conformance/suite/checks/test_quality.py
@@ -224,7 +224,11 @@ def _call_is_assertion(call: ast.Call) -> bool:
     name = _call_attr_name(call)
     if name is None:
         return False
-    if name.lower().startswith("assert"):
+    # ``lstrip("_")`` so a project-local ``_assert_*`` helper is recognised — the
+    # documented vocabulary (see this module's docstring and the T005 rule's
+    # ``full_description``) lists it, but a leading underscore fails a bare
+    # ``startswith("assert")``.
+    if name.lower().lstrip("_").startswith("assert"):
         return True
     if name == "fail":
         return True

--- a/packages/conformance/tests/test_test_quality.py
+++ b/packages/conformance/tests/test_test_quality.py
@@ -119,6 +119,18 @@ def test_t005_silent_on_scenario_helper() -> None:
     assert findings == []
 
 
+def test_t005_silent_on_underscore_assert_helper() -> None:
+    """A test whose only check is a project-local ``_assert_*`` helper is
+    recognised — this vocabulary is documented in the module docstring and the
+    T005 rule's ``full_description``, but a leading underscore defeats a bare
+    ``startswith("assert")``."""
+    findings = scan_text(
+        "def test_foo():\n    result = compute()\n    _assert_structure(result)\n",
+        "tests/unit/test_foo.py",
+    )
+    assert findings == []
+
+
 def test_t005_silent_on_trailing_no_raise_marker() -> None:
     findings = scan_text(
         "def test_foo():\n    compute()  # should not raise\n",


### PR DESCRIPTION
## Problem

T005 (`AssertionFreeTest`) and T007 (`VacuousAssertion`) decide whether a call is an assertion in `_call_is_assertion` using `name.lower().startswith("assert")`. That fails to match a **project-local `_assert_*` helper** (leading underscore) — even though that form is part of the rule's **documented vocabulary**:

- `packages/conformance/conformance/suite/rules/tests.py:391` (the T005 rule's `full_description`, source of truth for the generated docs) — *"…`pandas.testing.assert_frame_equal`, a project-local `_assert_*` helper)"*
- the same wording in the `test_quality.py` module docstring, rendered into `docs/rules/tests.md:226`.

So the detector **contradicts its own published contract** and falsely flags any test whose only check is an `_assert_*` helper. There was a test for `mocker.assert_called_once()`, `self.assertEqual()`, and the `scenario.equals()` scenario helper — but none for a `_assert_*` helper, which is why the gap shipped.

## Fix

`packages/conformance/conformance/suite/checks/test_quality.py` — normalise leading underscores before the prefix test:

```python
if name.lower().lstrip("_").startswith("assert"):
```

This faithfully implements the documented `_assert_*` contract and stays consistent with the existing `startswith("assert")` breadth.

## Why it's safe

The change is **strictly more permissive** — it can only recognise an assertion where the code previously saw none, so it can only **reduce** T005/T007 findings, never introduce new ones. Verified on the SDK's own test tree with the before/after detector:

| | total T-findings | T005 | T007 |
|---|---|---|---|
| before | 131 | 127 | 2 |
| after | 103 | **99** | 2 |

−28 T005, zero increases. (The SDK itself had 28 tests using `_assert_*` helpers that were being falsely flagged.)

## Tests / docs / remediation

- Adds `test_t005_silent_on_underscore_assert_helper` (fails before the fix, passes after).
- Full conformance suite green: `1804 passed, 1 xfail` (pre-existing).
- `gen-rule-docs --check` clean — `rules/tests.py` is unchanged, so the generated docs need no update.
- **No remediation-program wiring needed**: this is a detector-correctness fix (removes false positives). `detect-violations` shells out to the runner and inherits the corrected behaviour; T-series stays judgment→residue.
- Repo-root pinned pre-commit passes on the changed files.

## Context

Surfaced while auditing `atlan-mysql-app` conformance (whose parity tests use `_assert_*` helpers). Follow-up SDK issues for other refinement candidates (E004 re-raise exemption, P028 vs `SqlApp.map_*` template, `application_sdk.dev` seam gap, D003 dynamic/entrypoint deps) are filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)