### PR TITLE
fix(templates): SqlApp docstring teaches pyatlan_v9 .creator(), not a hand-built qualifiedName

### DIFF
--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -46,10 +46,23 @@ Usage::
         fetch_column_sql = "SELECT COLUMN_NAME as column_name FROM ..."
 
         def map_table(self, record, connection_qn):
-            from pyatlan_v9.model.assets import Table
-            return Table(
-                qualified_name=f"{connection_qn}/{record['database_name']}/{record['schema_name']}/{record['table_name']}",
+            from pyatlan_v9.model.assets import Database, Schema, Table
+
+            # Build assets with the pyatlan_v9 ``.creator()`` factories: each one
+            # computes its own qualifiedName from its parent's, so the grammar
+            # lives in pyatlan, not in a hand-rolled ``f"{connection_qn}/..."``
+            # string per connector (which conformance P028 flags).
+            database = Database.creator(
+                name=record["database_name"],
+                connection_qualified_name=connection_qn,
+            )
+            schema = Schema.creator(
+                name=record["schema_name"],
+                database_qualified_name=database.qualified_name,
+            )
+            return Table.creator(
                 name=record["table_name"],
+                schema_qualified_name=schema.qualified_name,
             )
 
         def map_column(self, record, connection_qn):


### PR DESCRIPTION
Resolves #2646.

## Problem

The `SqlApp` module docstring's `map_table` example taught app authors to hand-build:
```python
qualified_name=f"{connection_qn}/{record['database_name']}/{record['schema_name']}/{record['table_name']}"
```
That is the exact pattern conformance rule **P028** (`ManualQualifiedNameFString`) flags once an author writes it for real in their app. So the SDK's own template contradicted the rule it grades apps against. (The `map_*` methods themselves are unimplemented stubs — the only QN construction in the file was this teaching example.)

## Fix

Rewrite the example to build assets through the **pyatlan_v9 `.creator()` factories**, chaining `Database → Schema → Table` so each level computes its own qualifiedName from its parent's:
```python
database = Database.creator(name=..., connection_qualified_name=connection_qn)
schema   = Schema.creator(name=..., database_qualified_name=database.qualified_name)
return Table.creator(name=..., schema_qualified_name=schema.qualified_name)
```
No hand-rolled grammar. This agrees with **P028's own prescription** (`.creator()`) and with the SDK's forward direction (typed record → `map_<entity>()` → pyatlan_v9 Asset).

Verified the chain yields the same slash-delimited qualifiedName the f-string did:
`default/mysql/123` → `…/db` → `…/db/sch` → `…/db/sch/tbl`.

## Why not the `build_atlas_qualified_name` helper?

The investigation for #2646 suggested teaching the existing `build_atlas_qualified_name` helper. I did **not**, because it lives in `application_sdk.transformers`, which is **deprecated (removed in v4.0)** — its import emits a `DeprecationWarning` pointing to exactly this asset-mapper/`.creator()` pattern. Teaching a soon-to-be-removed import would be wrong; `.creator()` is the sanctioned, non-deprecated path.

## Scope / reviewer questions

- **Kept minimal**: docstring-only change. No detection-logic or rule-definition change — P028 already prescribes `.creator()`, so `gen-rule-docs` is a no-op.
- **Deferred (for the SDK team to decide)**: whether to also promote a *public* qualifiedName-string helper for the genuine cases where a raw string is needed (the only one today, `build_atlas_qualified_name`, is deprecated and named after the internal Atlas type system). That is a public-surface + naming + capability-manifest decision, out of scope here.

## Verification
- `Database/Schema/Table.creator()` chain produces correct qualifiedNames (no f-strings).
- `tests/unit/templates/test_sql_app.py`: 75 passed.
- `gen-rule-docs --check` clean; no capability-manifest drift (the manifest doesn't quote the docstring example); repo-root pinned pre-commit passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)