### PR TITLE
feat(testing): DataForge rung-3 integration for cloud-only e2e sources (draft)

### DIFF
--- a/application_sdk/testing/e2e/dataforge.py
+++ b/application_sdk/testing/e2e/dataforge.py
@@ -239,9 +239,13 @@ class DataForgeClient:
         inputs: dict[str, Any],
         reason: str,
         lifecycle_days: int = 4,
+        category: str = "development",
     ) -> str:
         if len(reason.strip()) < 10:
             raise DataForgeError("DataForge `reason` must be ≥10 chars (shown to approvers).")
+        # category=development for ephemeral e2e test infra: the `ai` category is
+        # gated behind DataForge admin approval, whereas `development` clears
+        # without an admin (`skip_approval` alone is role-gated for non-admins).
         resp = self._call(
             "POST",
             "/api/v1/resources",
@@ -252,7 +256,7 @@ class DataForgeClient:
                 "lifecycle_enabled": True,
                 "lifecycle_days": lifecycle_days,
                 "skip_approval": True,
-                "category": "ai",
+                "category": category,
             },
         )
         rid = (resp or {}).get("id")

--- a/application_sdk/testing/e2e/dataforge.py
+++ b/application_sdk/testing/e2e/dataforge.py
@@ -5,9 +5,17 @@ the CI worker reaches by hostname (see :mod:`source_scaffold`). Cloud-only
 sources — Redshift, Snowflake, BigQuery, Databricks — have no container, so the
 full-DAG e2e instead provisions a **live instance** through DataForge, an
 internal Atlan provisioning service exposed as a REST API that stands up real
-source infrastructure via Terraform, hands back connection artifacts, and
-auto-expires the instance (``lifecycle_days``). Its base URL and credentials are
-supplied at runtime via env vars (below) — this module hardcodes no endpoint.
+source infrastructure via Terraform and hands back connection artifacts. Its
+base URL and credentials are supplied at runtime via env vars (below) — this
+module hardcodes no endpoint.
+
+Provisioning a new instance needs a one-time admin approval, so the harness
+treats these as **persistent shared fixtures**: one instance per engine, stood
+up (and approved) once, then reused across every run via ``find_reusable`` — no
+TTL, no per-run provision. ``create()`` therefore defaults to
+``lifecycle_enabled=False`` (never auto-expires); a throwaway instance with a
+hard TTL is available as an explicit opt-in (``lifecycle_enabled=True`` +
+``lifecycle_days``), but is not the default path.
 
 This module wraps that API for the harness, mirroring the internal
 provision-source flow:
@@ -227,7 +235,9 @@ class DataForgeClient:
     def find_reusable(self, datasource: str) -> str | None:
         """Return the id of an existing PROVISIONED instance, or None."""
         resources = self._call("GET", f"/api/v1/resources?q={datasource}")
-        items = resources if isinstance(resources, list) else resources.get("resources", [])
+        items = (
+            resources if isinstance(resources, list) else resources.get("resources", [])
+        )
         for r in items:
             if r.get("status") == _READY:
                 return r.get("id")
@@ -238,30 +248,35 @@ class DataForgeClient:
         module_id: str,
         inputs: dict[str, Any],
         reason: str,
-        lifecycle_days: int = 4,
+        *,
+        lifecycle_enabled: bool = False,
+        lifecycle_days: int | None = None,
         category: str = "development",
     ) -> str:
         if len(reason.strip()) < 10:
-            raise DataForgeError("DataForge `reason` must be ≥10 chars (shown to approvers).")
-        # category=development is the accurate bucket for e2e test infra (vs the
-        # default `ai`). NOTE: provisioning is admin-approval-gated regardless of
-        # category — a non-admin can't self-approve (skip_approval is role-gated),
-        # so a DataForge admin approves once. This is why the harness provisions a
-        # persistent instance and reuses it (find_reusable), rather than a fresh
-        # admin-gated provision per run.
-        resp = self._call(
-            "POST",
-            "/api/v1/resources",
-            {
-                "module_id": module_id,
-                "inputs": inputs,
-                "reason": reason,
-                "lifecycle_enabled": True,
-                "lifecycle_days": lifecycle_days,
-                "skip_approval": True,
-                "category": category,
-            },
-        )
+            raise DataForgeError(
+                "DataForge `reason` must be ≥10 chars (shown to approvers)."
+            )
+        # PERSISTENT posture (default): lifecycle_enabled=False → no TTL, the
+        # instance is NOT auto-deleted. Provisioning is admin-approval-gated
+        # regardless of category (a non-admin can't self-approve; skip_approval is
+        # role-gated), so a DataForge admin approves the shared fixture ONCE and
+        # every e2e run reuses it via find_reusable — never a per-run provision
+        # (that would re-hit the gate each PR). category=development is the
+        # accurate bucket for e2e infra (vs the default `ai`). Pass
+        # lifecycle_enabled=True + lifecycle_days only for a deliberately-ephemeral
+        # instance (not the shared-fixture path).
+        body: dict[str, Any] = {
+            "module_id": module_id,
+            "inputs": inputs,
+            "reason": reason,
+            "lifecycle_enabled": lifecycle_enabled,
+            "skip_approval": True,
+            "category": category,
+        }
+        if lifecycle_enabled and lifecycle_days is not None:
+            body["lifecycle_days"] = lifecycle_days
+        resp = self._call("POST", "/api/v1/resources", body)
         rid = (resp or {}).get("id")
         if not rid:
             raise DataForgeError(f"DataForge create returned no id: {resp}")
@@ -301,7 +316,9 @@ class DataForgeClient:
         try:
             self._call("DELETE", f"/api/v1/resources/{resource_id}")
         except DataForgeError as exc:
-            logger.warning("DataForge destroy of %s failed (non-fatal): %s", resource_id, exc)
+            logger.warning(
+                "DataForge destroy of %s failed (non-fatal): %s", resource_id, exc
+            )
 
     # ── interactive auth (OAuth device-code, RFC 8628) ──────────────────────────
 
@@ -370,10 +387,18 @@ class DataForgeClient:
         instance_name: str,
         reason: str,
         inputs: dict[str, Any] | None = None,
-        lifecycle_days: int = 4,
+        lifecycle_enabled: bool = False,
+        lifecycle_days: int | None = None,
         reuse: bool = True,
     ) -> tuple[str, dict[str, Any]]:
-        """Provision (or reuse) an instance and return ``(resource_id, creds)``.
+        """Reuse the persistent shared instance, or provision one if none exists.
+
+        The e2e model is a **persistent, shared-per-engine** fixture: one instance
+        per datasource is provisioned + admin-approved ONCE (``lifecycle_enabled``
+        defaults False → no TTL) and every run reuses it — so a PR never blocks on
+        the admin-approval gate. Hitting the provision path here means the shared
+        fixture is *missing* (never created, or deleted): it emits a WARNING and
+        needs a one-time approval, so it should be rare + alertable, not per-run.
 
         ``creds`` is the flat ``artifacts.data`` block (host / port / database /
         username / password) fetched on-demand — never cache it to disk.
@@ -381,12 +406,27 @@ class DataForgeClient:
         if reuse:
             existing = self.find_reusable(datasource)
             if existing:
-                logger.info("DataForge: reusing PROVISIONED %s %s", datasource, existing)
+                logger.info(
+                    "DataForge: reusing PROVISIONED %s %s", datasource, existing
+                )
                 resource = self._call("GET", f"/api/v1/resources/{existing}")
                 return existing, _artifacts(resource)
+        logger.warning(
+            "DataForge: no PROVISIONED %s fixture to reuse — provisioning a new "
+            "persistent instance %r. This needs a one-time admin approval and should "
+            "be rare; the shared fixture is meant to persist and be reused across runs.",
+            datasource,
+            instance_name,
+        )
         module_id = self.resolve_module_id(datasource, variant)
         merged = {"instance_name": instance_name, **(inputs or {})}
-        rid = self.create(module_id, merged, reason, lifecycle_days)
+        rid = self.create(
+            module_id,
+            merged,
+            reason,
+            lifecycle_enabled=lifecycle_enabled,
+            lifecycle_days=lifecycle_days,
+        )
         resource = self.poll(rid)
         return rid, _artifacts(resource)
 
@@ -482,15 +522,19 @@ def provision_source(
     *,
     instance_name: str,
     reason: str,
-    lifecycle_days: int = 4,
+    lifecycle_enabled: bool = False,
+    lifecycle_days: int | None = None,
     reuse: bool = True,
     client: DataForgeClient | None = None,
 ) -> tuple[str, DatabaseSpec]:
-    """Provision (or reuse) a cloud source for ``engine`` and return its DatabaseSpec.
+    """Reuse (or, if missing, provision) the shared cloud source for ``engine``.
 
-    The connector's full-DAG test calls this from ``database_spec()`` — the
-    cloud analog of pointing at a compose service. Apply :func:`load_seed`
-    (``engine``) to the instance before extraction.
+    The connector's full-DAG test calls this from ``database_spec()`` — the cloud
+    analog of pointing at a compose service. Defaults to the persistent shared
+    fixture (``lifecycle_enabled=False``, ``reuse=True``): one instance per engine,
+    admin-approved once, reused by every run. Apply :func:`load_seed` (``engine``)
+    to the instance idempotently before extraction so the shared fixture stays in
+    the canonical shape.
     """
     if engine not in _ENGINES:
         raise DataForgeError(
@@ -502,6 +546,7 @@ def provision_source(
         variant=variant,
         instance_name=instance_name,
         reason=reason,
+        lifecycle_enabled=lifecycle_enabled,
         lifecycle_days=lifecycle_days,
         reuse=reuse,
     )
@@ -522,7 +567,13 @@ def main(argv: list[str] | None = None, client: DataForgeClient | None = None) -
     p_prov.add_argument("engine", choices=sorted(_ENGINES))
     p_prov.add_argument("--instance-name", required=True)
     p_prov.add_argument("--reason", required=True)
-    p_prov.add_argument("--lifecycle-days", type=int, default=4)
+    p_prov.add_argument(
+        "--ephemeral-days",
+        type=int,
+        default=None,
+        help="opt-in TTL in days for a throwaway instance; omit for the default "
+        "persistent shared fixture (no TTL — approve once, reuse forever)",
+    )
     p_prov.add_argument("--no-reuse", action="store_true")
     p_del = sub.add_parser("destroy")
     p_del.add_argument("resource_id")
@@ -548,7 +599,8 @@ def main(argv: list[str] | None = None, client: DataForgeClient | None = None) -
         args.engine,
         instance_name=args.instance_name,
         reason=args.reason,
-        lifecycle_days=args.lifecycle_days,
+        lifecycle_enabled=args.ephemeral_days is not None,
+        lifecycle_days=args.ephemeral_days,
         reuse=not args.no_reuse,
         client=df,
     )

--- a/application_sdk/testing/e2e/dataforge.py
+++ b/application_sdk/testing/e2e/dataforge.py
@@ -1,0 +1,537 @@
+"""DataForge integration for the full-DAG e2e harness — rung 3 (cloud sources).
+
+Rungs 1-2 of the source ladder run the source as a local compose **container**
+the CI worker reaches by hostname (see :mod:`source_scaffold`). Cloud-only
+sources — Redshift, Snowflake, BigQuery, Databricks — have no container, so the
+full-DAG e2e instead provisions a **live instance** through DataForge, an
+internal Atlan provisioning service exposed as a REST API that stands up real
+source infrastructure via Terraform, hands back connection artifacts, and
+auto-expires the instance (``lifecycle_days``). Its base URL and credentials are
+supplied at runtime via env vars (below) — this module hardcodes no endpoint.
+
+This module wraps that API for the harness, mirroring the internal
+provision-source flow:
+
+    provision-or-reuse → poll to PROVISIONED → artifacts.data → DatabaseSpec
+
+so a cloud connector's full-DAG test resolves its source the same way a
+container connector does — via ``database_spec()`` — with the canonical seed
+(``seeds/<engine>.sql``) applied to the live instance first.
+
+Auth
+----
+DataForge authenticates with an OAuth **Bearer** session (SSO, device-code flow
+— RFC 8628). There is no long-lived static API key. A human runs the device-code
+flow **once** (the ``auth`` command prints a verification URL to approve in the
+browser); that writes ``~/.dataforge/session.json`` (a rotating refresh token).
+For CI, that ``session.json`` is stored as a repo secret and mounted to
+``~/.dataforge/session.json``. This client only *reads* the session token — it
+does not run the interactive flow unless asked. See the internal DataForge
+developer docs for the endpoint + setup.
+
+Config (env)
+------------
+* ``DATAFORGE_API_URL``   — base URL of the DataForge API (required; no default)
+* ``DATAFORGE_SESSION``   — session JSON *contents* (CI secret); falls back to
+  the file at ``DATAFORGE_SESSION_FILE`` (default ``~/.dataforge/session.json``)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing.e2e.payload import DatabaseSpec
+
+logger = get_logger(__name__)
+
+# No hardcoded endpoint: the DataForge base URL is internal and supplied at
+# runtime via DATAFORGE_API_URL (this SDK is a public repo — see the
+# public-repo hygiene rule; never bake internal hosts in).
+_DEFAULT_SESSION_FILE = "~/.dataforge/session.json"
+#: Terminal + in-flight resource states (per the DataForge resource lifecycle).
+_READY = "PROVISIONED"
+_FAILED = {"FAILED", "DELETED", "DELETING"}
+
+
+class DataForgeError(RuntimeError):
+    """A DataForge API / provisioning failure surfaced to the harness."""
+
+
+class DataForgeAuthError(DataForgeError):
+    """No usable DataForge session — the device-code flow must be run first."""
+
+
+# A pluggable transport: (method, url, headers, body) -> (status, json_or_none).
+# Real calls use urllib; tests inject a fake to exercise the flow offline.
+Transport = Callable[[str, str, dict[str, str], bytes | None], "tuple[int, Any]"]
+
+
+#: DataForge sits behind Cloudflare, which 403s (error 1010) the default
+#: ``Python-urllib`` User-Agent as a bad-bot signature. Send an honest,
+#: descriptive UA — verified accepted (a custom UA passes; no browser spoofing).
+_USER_AGENT = "atlan-application-sdk-e2e/1.0 (+dataforge)"
+
+
+def _urllib_transport(
+    method: str, url: str, headers: dict[str, str], body: bytes | None
+) -> tuple[int, Any]:
+    req = urllib.request.Request(
+        url, data=body, method=method, headers={"User-Agent": _USER_AGENT, **headers}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            raw = resp.read()
+            return resp.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        try:
+            parsed = json.loads(raw) if raw else None
+        except ValueError:
+            parsed = {"error": raw.decode(errors="replace")[:300]}
+        return exc.code, parsed
+
+
+def _load_session_token() -> str:
+    """Read the DataForge Bearer token from the CI secret or the session file."""
+    inline = os.environ.get("DATAFORGE_SESSION")
+    if inline:
+        raw: str | None = inline
+    else:
+        path = Path(
+            os.environ.get("DATAFORGE_SESSION_FILE", _DEFAULT_SESSION_FILE)
+        ).expanduser()
+        raw = path.read_text() if path.is_file() else None
+    if not raw:
+        raise DataForgeAuthError(
+            "No DataForge session found. Run the `auth` command once "
+            "(approve the printed verification URL in the browser) to write "
+            "~/.dataforge/session.json, then set DATAFORGE_SESSION (CI) or mount "
+            "the file. See the internal DataForge developer docs."
+        )
+    try:
+        token = json.loads(raw).get("session_token")
+    except ValueError as exc:
+        raise DataForgeAuthError(f"DataForge session is not valid JSON: {exc}") from exc
+    if not token:
+        raise DataForgeAuthError("DataForge session JSON has no 'session_token'.")
+    return token
+
+
+@dataclass
+class DataForgeClient:
+    """Thin client over the DataForge resource-provisioning REST API."""
+
+    api_url: str = field(
+        default_factory=lambda: os.environ.get("DATAFORGE_API_URL", "").rstrip("/")
+    )
+    transport: Transport = _urllib_transport
+    _token: str | None = None
+
+    def _require_api_url(self) -> str:
+        if not self.api_url:
+            raise DataForgeError(
+                "DATAFORGE_API_URL is not set — supply the DataForge API base URL "
+                "at runtime (no endpoint is baked into this public SDK)."
+            )
+        return self.api_url
+
+    def _headers(self) -> dict[str, str]:
+        if self._token is None:
+            self._token = _load_session_token()
+        return {
+            "Authorization": f"Bearer {self._token}",
+            "Content-Type": "application/json",
+        }
+
+    def _call(self, method: str, path: str, body: dict | None = None) -> Any:
+        url = f"{self._require_api_url()}{path}"
+        payload = json.dumps(body).encode() if body is not None else None
+        status, data = self.transport(method, url, self._headers(), payload)
+        if status == 401:
+            raise DataForgeAuthError(
+                "DataForge returned 401 — session expired. Re-run the device-code "
+                "flow and refresh the DATAFORGE_SESSION secret."
+            )
+        if status >= 400:
+            detail = (data or {}).get("error") or (data or {}).get("code") or data
+            raise DataForgeError(f"{method} {path} → HTTP {status}: {detail}")
+        return data
+
+    # ── module discovery ──────────────────────────────────────────────────────
+
+    def resolve_module_id(self, datasource: str, variant: str) -> str:
+        """Resolve the module UUID for a datasource + deployment variant."""
+        variants = self._call(
+            "GET", f"/api/v1/modules/datasources/{datasource}/variants"
+        )
+        items = variants if isinstance(variants, list) else variants.get("variants", [])
+        for v in items:
+            if v.get("variant") == variant or v.get("name") == variant:
+                mid = v.get("module_id") or v.get("id")
+                if mid:
+                    return mid
+        available = sorted(v.get("variant") or v.get("name") or "?" for v in items)
+        raise DataForgeError(
+            f"No DataForge variant {variant!r} for datasource {datasource!r}; "
+            f"available: {available}"
+        )
+
+    # ── resource lifecycle ─────────────────────────────────────────────────────
+
+    def find_reusable(self, datasource: str) -> str | None:
+        """Return the id of an existing PROVISIONED instance, or None."""
+        resources = self._call("GET", f"/api/v1/resources?q={datasource}")
+        items = resources if isinstance(resources, list) else resources.get("resources", [])
+        for r in items:
+            if r.get("status") == _READY:
+                return r.get("id")
+        return None
+
+    def create(
+        self,
+        module_id: str,
+        inputs: dict[str, Any],
+        reason: str,
+        lifecycle_days: int = 4,
+    ) -> str:
+        if len(reason.strip()) < 10:
+            raise DataForgeError("DataForge `reason` must be ≥10 chars (shown to approvers).")
+        resp = self._call(
+            "POST",
+            "/api/v1/resources",
+            {
+                "module_id": module_id,
+                "inputs": inputs,
+                "reason": reason,
+                "lifecycle_enabled": True,
+                "lifecycle_days": lifecycle_days,
+                "skip_approval": True,
+                "category": "ai",
+            },
+        )
+        rid = (resp or {}).get("id")
+        if not rid:
+            raise DataForgeError(f"DataForge create returned no id: {resp}")
+        return rid
+
+    def poll(
+        self,
+        resource_id: str,
+        *,
+        timeout_s: int = 1800,
+        interval_s: int = 30,
+        sleep: Callable[[float], None] = time.sleep,
+        now: Callable[[], float] = time.monotonic,
+    ) -> dict[str, Any]:
+        """Poll until the resource is PROVISIONED; raise on FAILED/timeout."""
+        deadline = now() + timeout_s
+        while True:
+            resource = self._call("GET", f"/api/v1/resources/{resource_id}")
+            status = (resource or {}).get("status")
+            if status == _READY:
+                return resource
+            if status in _FAILED:
+                raise DataForgeError(
+                    f"DataForge resource {resource_id} entered {status}: "
+                    f"{(resource or {}).get('error', '')}"
+                )
+            if now() >= deadline:
+                raise DataForgeError(
+                    f"DataForge resource {resource_id} not PROVISIONED within "
+                    f"{timeout_s}s (last status={status})."
+                )
+            logger.info("DataForge %s: %s — polling…", resource_id, status)
+            sleep(interval_s)
+
+    def destroy(self, resource_id: str) -> None:
+        """Trigger async Terraform teardown (idempotent; 202 expected)."""
+        try:
+            self._call("DELETE", f"/api/v1/resources/{resource_id}")
+        except DataForgeError as exc:
+            logger.warning("DataForge destroy of %s failed (non-fatal): %s", resource_id, exc)
+
+    # ── interactive auth (OAuth device-code, RFC 8628) ──────────────────────────
+
+    def device_login(
+        self,
+        *,
+        open_browser: bool = True,
+        write_path: str = _DEFAULT_SESSION_FILE,
+        sleep: Callable[[float], None] = time.sleep,
+        now: Callable[[], float] = time.monotonic,
+        echo: Callable[[str], None] = print,
+    ) -> str:
+        """Run the device-code flow and persist ``~/.dataforge/session.json``.
+
+        The device endpoints are unauthenticated (no Bearer). Requests a
+        user_code, prints the verification URL for the human to approve in the
+        browser (Okta SSO), then polls until approved and writes the
+        session/refresh tokens. Returns the path written.
+        """
+        hdr = {"Content-Type": "application/json"}
+        status, start = self.transport(
+            "POST", f"{self._require_api_url()}/auth/device/code", hdr, b"{}"
+        )
+        if status >= 400 or not start:
+            raise DataForgeError(f"device/code start failed: HTTP {status} {start}")
+        device_code = start["device_code"]
+        url = start.get("verification_url_complete") or start.get("verification_url")
+        echo(
+            "\n============================================================\n"
+            "  Authorize DataForge for this machine\n"
+            f"  Visit:  {url}\n"
+            f"  Code:   {start.get('user_code')}\n"
+            "  (Complete Okta SSO + click Approve; polling…)\n"
+            "============================================================\n"
+        )
+        if open_browser and url:
+            try:
+                import webbrowser  # noqa: PLC0415 — cold path, best-effort
+
+                webbrowser.open(url)
+            except Exception:  # noqa: BLE001,S110 — headless is fine; user has the URL
+                pass
+        interval = int(start.get("interval") or 5)
+        deadline = now() + int(start.get("expires_in") or 600)
+        body = json.dumps({"device_code": device_code}).encode()
+        while now() < deadline:
+            sleep(interval)
+            st, data = self.transport(
+                "POST", f"{self._require_api_url()}/auth/device/poll", hdr, body
+            )
+            if st == 200 and data and data.get("session_token"):
+                return _write_session(data, write_path)
+            err = (data or {}).get("error")
+            if err in (None, "authorization_pending"):
+                continue
+            raise DataForgeError(f"device authorization failed: {err}")
+        raise DataForgeError("device authorization timed out before approval")
+
+    # ── high-level convenience ──────────────────────────────────────────────────
+
+    def provision_or_reuse(
+        self,
+        *,
+        datasource: str,
+        variant: str,
+        instance_name: str,
+        reason: str,
+        inputs: dict[str, Any] | None = None,
+        lifecycle_days: int = 4,
+        reuse: bool = True,
+    ) -> tuple[str, dict[str, Any]]:
+        """Provision (or reuse) an instance and return ``(resource_id, creds)``.
+
+        ``creds`` is the flat ``artifacts.data`` block (host / port / database /
+        username / password) fetched on-demand — never cache it to disk.
+        """
+        if reuse:
+            existing = self.find_reusable(datasource)
+            if existing:
+                logger.info("DataForge: reusing PROVISIONED %s %s", datasource, existing)
+                resource = self._call("GET", f"/api/v1/resources/{existing}")
+                return existing, _artifacts(resource)
+        module_id = self.resolve_module_id(datasource, variant)
+        merged = {"instance_name": instance_name, **(inputs or {})}
+        rid = self.create(module_id, merged, reason, lifecycle_days)
+        resource = self.poll(rid)
+        return rid, _artifacts(resource)
+
+
+def _artifacts(resource: dict[str, Any]) -> dict[str, Any]:
+    data = ((resource or {}).get("artifacts") or {}).get("data")
+    if not isinstance(data, dict) or not data:
+        raise DataForgeError(
+            f"DataForge resource {resource.get('id')!r} has no artifacts.data "
+            f"connection block."
+        )
+    return data
+
+
+def load_seed(engine: str) -> str:
+    """Return the canonical DDL seed for a rung-3 engine (e.g. ``redshift``).
+
+    Loaded straight from the SDK ``seeds/`` dir — independent of the container
+    ``source_scaffold.ENGINES`` registry, since cloud sources have no compose
+    service. Apply this to the DataForge-provisioned instance before extraction
+    so asset counts match the container-source engines byte-for-byte.
+    """
+    try:
+        return (
+            resources.files("application_sdk.testing.e2e")
+            .joinpath("seeds", f"{engine}.sql")
+            .read_text()
+        )
+    except (FileNotFoundError, ModuleNotFoundError) as exc:
+        raise DataForgeError(
+            f"no canonical seed shipped for engine {engine!r} "
+            f"(expected seeds/{engine}.sql)"
+        ) from exc
+
+
+def _write_session(tokens: dict[str, Any], path: str) -> str:
+    """Persist the device-code token pair to ``path`` (mode 600). Returns path."""
+    p = Path(path).expanduser()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        json.dumps(
+            {
+                "session_token": tokens["session_token"],
+                "refresh_token": tokens.get("refresh_token", ""),
+            }
+        )
+    )
+    p.chmod(0o600)
+    return str(p)
+
+
+def creds_to_database_spec(
+    creds: dict[str, Any], *, connector_config_name: str = ""
+) -> DatabaseSpec:
+    """Map a DataForge ``artifacts.data`` block to a harness ``DatabaseSpec``.
+
+    ``database`` rides in ``extra`` (a SQL client whose DB_CONFIG.required lists
+    it reads it from ``credentials["extra"]["database"]`` — see build_agent_json).
+    Accepts the common artifact key spellings DataForge emits.
+    """
+
+    def pick(*keys: str, default: Any = None) -> Any:
+        for k in keys:
+            if creds.get(k) not in (None, ""):
+                return creds[k]
+        return default
+
+    database = pick("database", "dbname", "db")
+    return DatabaseSpec(
+        host=pick("host", "endpoint", "hostname", default=""),
+        port=int(pick("port", default=5439)),  # Redshift default
+        username=pick("username", "user", "master_username", default=""),
+        password=pick("password", "master_password", default=""),
+        extra={"database": database} if database else {},
+        connector_config_name=connector_config_name,
+    )
+
+
+# ── cloud-engine registry + CLI ─────────────────────────────────────────────--
+# engine → (DataForge datasource, module name/variant, connector-config).
+# Module names verified against the live catalog (GET /modules/datasources/
+# redshift/variants): "aws-redshift" (managed, ~$180/mo) and
+# "aws-redshift-serverless" (pay-per-RPU). Serverless preferred: cheaper for
+# short-lived e2e and can expose a public endpoint a GitHub-hosted CI worker
+# can reach (managed sits inside a private VPC).
+_ENGINES: dict[str, tuple[str, str, str]] = {
+    "redshift": ("redshift", "aws-redshift-serverless", "atlan-connectors-redshift"),
+}
+
+
+def provision_source(
+    engine: str,
+    *,
+    instance_name: str,
+    reason: str,
+    lifecycle_days: int = 4,
+    reuse: bool = True,
+    client: DataForgeClient | None = None,
+) -> tuple[str, DatabaseSpec]:
+    """Provision (or reuse) a cloud source for ``engine`` and return its DatabaseSpec.
+
+    The connector's full-DAG test calls this from ``database_spec()`` — the
+    cloud analog of pointing at a compose service. Apply :func:`load_seed`
+    (``engine``) to the instance before extraction.
+    """
+    if engine not in _ENGINES:
+        raise DataForgeError(
+            f"engine {engine!r} not registered for DataForge; known: {sorted(_ENGINES)}"
+        )
+    datasource, variant, config_name = _ENGINES[engine]
+    rid, creds = (client or DataForgeClient()).provision_or_reuse(
+        datasource=datasource,
+        variant=variant,
+        instance_name=instance_name,
+        reason=reason,
+        lifecycle_days=lifecycle_days,
+        reuse=reuse,
+    )
+    return rid, creds_to_database_spec(creds, connector_config_name=config_name)
+
+
+def main(argv: list[str] | None = None, client: DataForgeClient | None = None) -> int:
+    """CLI: ``provision <engine>`` / ``destroy <id>`` / ``verify``.
+
+    ``provision`` writes SOURCE_* (+ masks the password) to ``$GITHUB_ENV`` for a
+    CI step, and prints a non-secret summary. Password is never printed.
+    """
+    import argparse  # noqa: PLC0415 — cold path
+
+    parser = argparse.ArgumentParser(prog="dataforge")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    p_prov = sub.add_parser("provision")
+    p_prov.add_argument("engine", choices=sorted(_ENGINES))
+    p_prov.add_argument("--instance-name", required=True)
+    p_prov.add_argument("--reason", required=True)
+    p_prov.add_argument("--lifecycle-days", type=int, default=4)
+    p_prov.add_argument("--no-reuse", action="store_true")
+    p_del = sub.add_parser("destroy")
+    p_del.add_argument("resource_id")
+    sub.add_parser("verify")
+    sub.add_parser("auth")
+    args = parser.parse_args(argv)
+
+    df = client or DataForgeClient()
+    if args.cmd == "auth":
+        path = df.device_login()
+        print(f"DataForge session saved to {path}")  # noqa: T201 — CLI stdout
+        return 0
+    if args.cmd == "verify":
+        df._call("GET", "/api/v1/modules")  # raises on auth/HTTP failure
+        print("DataForge auth OK")  # noqa: T201 — CLI stdout
+        return 0
+    if args.cmd == "destroy":
+        df.destroy(args.resource_id)
+        print(f"destroy triggered for {args.resource_id}")  # noqa: T201 — CLI stdout
+        return 0
+    # provision
+    rid, spec = provision_source(
+        args.engine,
+        instance_name=args.instance_name,
+        reason=args.reason,
+        lifecycle_days=args.lifecycle_days,
+        reuse=not args.no_reuse,
+        client=df,
+    )
+    # Emit only NON-secret connection info + the resource id (for teardown). The
+    # password is deliberately never printed or written to disk/env here — the
+    # e2e resolves it *in process* via provision_source() → DatabaseSpec.password
+    # (held in memory by the pytest run), so a secret never crosses a log or an
+    # env file. This SDK is a public repo; keep it that way.
+    fields = {
+        "SOURCE_HOST": spec.host,
+        "SOURCE_PORT": str(spec.port),
+        "SOURCE_DATABASE": spec.extra.get("database", ""),
+        "SOURCE_USERNAME": spec.username,
+        "DATAFORGE_RESOURCE_ID": rid,
+    }
+    github_env = os.environ.get("GITHUB_ENV")
+    if github_env:
+        with open(github_env, "a") as fh:
+            fh.writelines(f"{k}={v}\n" for k, v in fields.items())
+    print(  # noqa: T201 — CLI stdout, non-secret summary only
+        f"provisioned {args.engine} resource={rid} "
+        f"host={spec.host} port={spec.port} database={spec.extra.get('database')} "
+        f"(password resolved in-process via provision_source(); not emitted)"
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/application_sdk/testing/e2e/dataforge.py
+++ b/application_sdk/testing/e2e/dataforge.py
@@ -101,9 +101,12 @@ def _urllib_transport(
         return exc.code, parsed
 
 
-def _load_session_token() -> str:
-    """Read the DataForge Bearer token from the CI secret or the session file."""
+def _load_session() -> tuple[str, str, Path | None]:
+    """Load ``(session_token, refresh_token, file_path)`` from the CI secret or
+    the session file. ``file_path`` is where a refreshed session is written back
+    (``None`` when the session came from the env, which can't be rewritten)."""
     inline = os.environ.get("DATAFORGE_SESSION")
+    path: Path | None = None
     if inline:
         raw: str | None = inline
     else:
@@ -111,6 +114,8 @@ def _load_session_token() -> str:
             os.environ.get("DATAFORGE_SESSION_FILE", _DEFAULT_SESSION_FILE)
         ).expanduser()
         raw = path.read_text() if path.is_file() else None
+        if raw is None:
+            path = None
     if not raw:
         raise DataForgeAuthError(
             "No DataForge session found. Run the `auth` command once "
@@ -119,23 +124,31 @@ def _load_session_token() -> str:
             "the file. See the internal DataForge developer docs."
         )
     try:
-        token = json.loads(raw).get("session_token")
+        d = json.loads(raw)
     except ValueError as exc:
         raise DataForgeAuthError(f"DataForge session is not valid JSON: {exc}") from exc
+    token = d.get("session_token")
     if not token:
         raise DataForgeAuthError("DataForge session JSON has no 'session_token'.")
-    return token
+    return token, d.get("refresh_token", ""), path
 
 
 @dataclass
 class DataForgeClient:
-    """Thin client over the DataForge resource-provisioning REST API."""
+    """Thin client over the DataForge resource-provisioning REST API.
+
+    The session token is short-lived (~15 min), while a provisioning poll can
+    run far longer — so a 401 mid-flight is expected and handled by exchanging
+    the refresh token for a fresh session and retrying once (see :meth:`_call`).
+    """
 
     api_url: str = field(
         default_factory=lambda: os.environ.get("DATAFORGE_API_URL", "").rstrip("/")
     )
     transport: Transport = _urllib_transport
     _token: str | None = None
+    _refresh_token: str = ""
+    _session_path: Path | None = None
 
     def _require_api_url(self) -> str:
         if not self.api_url:
@@ -147,20 +160,43 @@ class DataForgeClient:
 
     def _headers(self) -> dict[str, str]:
         if self._token is None:
-            self._token = _load_session_token()
+            self._token, self._refresh_token, self._session_path = _load_session()
         return {
             "Authorization": f"Bearer {self._token}",
             "Content-Type": "application/json",
         }
 
+    def _refresh(self) -> bool:
+        """Exchange the refresh token for a fresh session. Returns success."""
+        if not self._refresh_token:
+            return False
+        status, data = self.transport(
+            "POST",
+            f"{self._require_api_url()}/auth/refresh",
+            {"Content-Type": "application/json"},
+            json.dumps({"refresh_token": self._refresh_token}).encode(),
+        )
+        if status != 200 or not data or not data.get("session_token"):
+            return False
+        self._token = data["session_token"]
+        self._refresh_token = data.get("refresh_token", self._refresh_token)
+        if self._session_path is not None:
+            try:  # best-effort: keep the on-disk session current for reuse
+                _write_session(data, str(self._session_path))
+            except OSError:
+                pass
+        return True
+
     def _call(self, method: str, path: str, body: dict | None = None) -> Any:
         url = f"{self._require_api_url()}{path}"
         payload = json.dumps(body).encode() if body is not None else None
         status, data = self.transport(method, url, self._headers(), payload)
+        if status == 401 and self._refresh():
+            status, data = self.transport(method, url, self._headers(), payload)
         if status == 401:
             raise DataForgeAuthError(
-                "DataForge returned 401 — session expired. Re-run the device-code "
-                "flow and refresh the DATAFORGE_SESSION secret."
+                "DataForge returned 401 — session expired and refresh failed. "
+                "Re-run the `auth` command to mint a new session."
             )
         if status >= 400:
             detail = (data or {}).get("error") or (data or {}).get("code") or data

--- a/application_sdk/testing/e2e/dataforge.py
+++ b/application_sdk/testing/e2e/dataforge.py
@@ -243,9 +243,12 @@ class DataForgeClient:
     ) -> str:
         if len(reason.strip()) < 10:
             raise DataForgeError("DataForge `reason` must be ≥10 chars (shown to approvers).")
-        # category=development for ephemeral e2e test infra: the `ai` category is
-        # gated behind DataForge admin approval, whereas `development` clears
-        # without an admin (`skip_approval` alone is role-gated for non-admins).
+        # category=development is the accurate bucket for e2e test infra (vs the
+        # default `ai`). NOTE: provisioning is admin-approval-gated regardless of
+        # category — a non-admin can't self-approve (skip_approval is role-gated),
+        # so a DataForge admin approves once. This is why the harness provisions a
+        # persistent instance and reuses it (find_reusable), rather than a fresh
+        # admin-gated provision per run.
         resp = self._call(
             "POST",
             "/api/v1/resources",

--- a/application_sdk/testing/e2e/seeds/redshift.sql
+++ b/application_sdk/testing/e2e/seeds/redshift.sql
@@ -1,0 +1,77 @@
+-- Canonical hermetic seed for the full-DAG e2e harness (Amazon Redshift dialect).
+-- Rung 3 (DataForge): Redshift has no local container, so this DDL is applied to
+-- a live instance provisioned via the DataForge API (see dataforge.py). Byte-shape
+-- mirrors the postgres seed so asset counts stay uniform across engines.
+--
+-- Applied against the DataForge-provisioned database (e2e_main). Redshift nests
+-- schemas under one database, so the canonical shape uses three schemas:
+--   e2e_main      -> customers, orders (+ view v_customer_order_totals)
+--   e2e_other     -> products, inventory
+--   e2e_excluded  -> legacy_logs
+-- Under include_filter scoped to schema e2e_main: 1 database, 1 schema,
+-- 2 tables, 1 view, 10 columns.
+--
+-- Redshift dialect notes: SERIAL -> INTEGER IDENTITY(1,1); TEXT -> VARCHAR;
+-- FK/PK/UNIQUE are accepted but informational (not enforced) on Redshift; the
+-- view is created WITH NO SCHEMA BINDING to avoid late-binding drop coupling.
+
+CREATE SCHEMA IF NOT EXISTS e2e_main;
+CREATE SCHEMA IF NOT EXISTS e2e_other;
+CREATE SCHEMA IF NOT EXISTS e2e_excluded;
+
+CREATE TABLE e2e_main.customers (
+    id INTEGER IDENTITY(1,1) PRIMARY KEY,
+    name VARCHAR(120) NOT NULL,
+    email VARCHAR(200),
+    created_at TIMESTAMP DEFAULT SYSDATE
+);
+
+CREATE TABLE e2e_main.orders (
+    id INTEGER IDENTITY(1,1) PRIMARY KEY,
+    customer_id INTEGER NOT NULL REFERENCES e2e_main.customers (id),
+    amount DECIMAL(10, 2) NOT NULL,
+    placed_at TIMESTAMP DEFAULT SYSDATE
+);
+
+CREATE OR REPLACE VIEW e2e_main.v_customer_order_totals AS
+SELECT c.id AS customer_id, c.name, COALESCE(SUM(o.amount), 0) AS total_spend
+FROM e2e_main.customers c
+LEFT JOIN e2e_main.orders o ON o.customer_id = c.id
+GROUP BY c.id, c.name
+WITH NO SCHEMA BINDING;
+
+INSERT INTO e2e_main.customers (name, email) VALUES
+    ('Alice', 'alice@example.com'),
+    ('Bob',   'bob@example.com'),
+    ('Carol', 'carol@example.com');
+
+INSERT INTO e2e_main.orders (customer_id, amount) VALUES
+    (1, 19.95), (1, 42.00), (2, 7.50), (3, 199.00);
+
+CREATE TABLE e2e_other.products (
+    id INTEGER IDENTITY(1,1) PRIMARY KEY,
+    sku VARCHAR(64) UNIQUE NOT NULL,
+    description VARCHAR(500)
+);
+
+CREATE TABLE e2e_other.inventory (
+    product_id INTEGER NOT NULL REFERENCES e2e_other.products (id),
+    warehouse VARCHAR(32) NOT NULL,
+    on_hand INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (product_id, warehouse)
+);
+
+INSERT INTO e2e_other.products (sku, description) VALUES
+    ('SKU-001', 'Widget'),
+    ('SKU-002', 'Gadget');
+
+INSERT INTO e2e_other.inventory (product_id, warehouse, on_hand) VALUES
+    (1, 'east', 100), (1, 'west', 50), (2, 'east', 25);
+
+CREATE TABLE e2e_excluded.legacy_logs (
+    id INTEGER IDENTITY(1,1) PRIMARY KEY,
+    message VARCHAR(500),
+    logged_at TIMESTAMP DEFAULT SYSDATE
+);
+
+INSERT INTO e2e_excluded.legacy_logs (message) VALUES ('seed'), ('exclude-me');

--- a/application_sdk/testing/e2e/source_scaffold.py
+++ b/application_sdk/testing/e2e/source_scaffold.py
@@ -35,7 +35,11 @@ Implements rungs 1–2 of the source ladder (testcontainer / freely-available
 container) uniformly as a compose **service** — in this harness the *worker*
 container connects to the source by hostname, so the source must be a compose
 service, and "testcontainer available" reduces to "prefer the official image".
-Rung 3 (DataForge, for cloud-only sources with no container) is a follow-up.
+Rung 3 (DataForge, for cloud-only sources with no container — Redshift,
+Snowflake, BigQuery, …) is handled separately in
+:mod:`application_sdk.testing.e2e.dataforge`: it provisions a live instance via
+the DataForge API and applies the canonical ``seeds/<engine>.sql`` to it, rather
+than rendering a compose service here.
 
 Grounding: the ``sql``/``mysql`` path is validated against atlan-mysql-app's
 proven hand-written scaffold (parsed-YAML identical). ``object_store`` and

--- a/tests/unit/testing/e2e/test_dataforge.py
+++ b/tests/unit/testing/e2e/test_dataforge.py
@@ -1,0 +1,290 @@
+"""Unit tests for the DataForge rung-3 e2e integration (offline, fake transport)."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import urlsplit
+
+import pytest
+
+from application_sdk.testing.e2e.dataforge import (
+    DataForgeAuthError,
+    DataForgeClient,
+    DataForgeError,
+    creds_to_database_spec,
+    load_seed,
+)
+
+_ARTIFACTS = {
+    "host": "redshift.example.invalid",
+    "port": 5439,
+    "database": "e2e_main",
+    "username": "test_user",
+    "password": "test-not-a-real-pw",
+}
+
+
+_API = "https://dataforge.example.invalid"
+
+
+class FakeTransport:
+    """Scripted (method, path-suffix) → (status, json) transport recorder."""
+
+    def __init__(self, routes: dict[tuple[str, str], tuple[int, object]]) -> None:
+        self.routes = routes
+        self.calls: list[tuple[str, str, dict]] = []
+
+    def __call__(self, method, url, headers, body):
+        sp = urlsplit(url)
+        path = sp.path + (f"?{sp.query}" if sp.query else "")
+        self.calls.append((method, path, json.loads(body) if body else None))
+        for (m, suffix), resp in self.routes.items():
+            if m == method and path.startswith(suffix):
+                return resp
+        return 404, {"error": f"no route for {method} {path}"}
+
+
+def _client(transport: FakeTransport) -> DataForgeClient:
+    # _token preset → skips the session-file load entirely.
+    return DataForgeClient(transport=transport, _token="fake-session", api_url=_API)
+
+
+class TestSession:
+    def test_inline_session_env_wins(self, monkeypatch) -> None:
+        monkeypatch.setenv("DATAFORGE_SESSION", json.dumps({"session_token": "tok"}))
+        c = DataForgeClient(transport=FakeTransport({}), api_url=_API)
+        assert c._headers()["Authorization"] == "Bearer tok"
+
+    def test_missing_session_raises_auth_error(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.delenv("DATAFORGE_SESSION", raising=False)
+        monkeypatch.setenv("DATAFORGE_SESSION_FILE", str(tmp_path / "nope.json"))
+        c = DataForgeClient(transport=FakeTransport({}), api_url=_API)
+        with pytest.raises(DataForgeAuthError, match="No DataForge session"):
+            c._headers()
+
+    def test_401_surfaces_auth_error(self) -> None:
+        t = FakeTransport({("GET", "/api/v1/resources"): (401, {"code": "EXPIRED"})})
+        with pytest.raises(DataForgeAuthError, match="session expired"):
+            _client(t).find_reusable("redshift")
+
+
+class TestLifecycle:
+    def test_resolve_module_id_picks_variant(self) -> None:
+        t = FakeTransport({
+            ("GET", "/api/v1/modules/datasources/redshift/variants"): (
+                200,
+                [
+                    {"variant": "aws-managed", "module_id": "m-managed"},
+                    {"variant": "aws-serverless", "module_id": "m-serverless"},
+                ],
+            )
+        })
+        assert _client(t).resolve_module_id("redshift", "aws-serverless") == "m-serverless"
+
+    def test_resolve_module_id_unknown_variant_raises(self) -> None:
+        t = FakeTransport({
+            ("GET", "/api/v1/modules/datasources/redshift/variants"): (
+                200, [{"variant": "aws-managed", "module_id": "m"}]
+            )
+        })
+        with pytest.raises(DataForgeError, match="No DataForge variant"):
+            _client(t).resolve_module_id("redshift", "aws-serverless")
+
+    def test_find_reusable_returns_provisioned(self) -> None:
+        t = FakeTransport({
+            ("GET", "/api/v1/resources"): (
+                200,
+                [
+                    {"id": "r-old", "status": "DELETED"},
+                    {"id": "r-live", "status": "PROVISIONED"},
+                ],
+            )
+        })
+        assert _client(t).find_reusable("redshift") == "r-live"
+
+    def test_create_rejects_short_reason(self) -> None:
+        with pytest.raises(DataForgeError, match="reason"):
+            _client(FakeTransport({})).create("m", {"instance_name": "x"}, "short")
+
+    def test_create_posts_fixed_flags(self) -> None:
+        t = FakeTransport({("POST", "/api/v1/resources"): (201, {"id": "r-new"})})
+        rid = _client(t).create(
+            "m-1", {"instance_name": "e2e"}, "SDR full-DAG e2e for redshift", 3
+        )
+        assert rid == "r-new"
+        body = t.calls[0][2]
+        assert body["skip_approval"] is True
+        assert body["category"] == "ai"
+        assert body["lifecycle_days"] == 3
+        assert body["module_id"] == "m-1"
+
+    def test_poll_returns_on_provisioned(self) -> None:
+        seq = [
+            (200, {"id": "r", "status": "PROVISIONING"}),
+            (200, {"id": "r", "status": "PROVISIONED", "artifacts": {"data": _ARTIFACTS}}),
+        ]
+
+        def transport(method, url, headers, body):
+            return seq.pop(0)
+
+        client = DataForgeClient(transport=transport, _token="fake-session", api_url=_API)
+        got = client.poll("r", interval_s=0, sleep=lambda _s: None)
+        assert got["status"] == "PROVISIONED"
+
+    def test_poll_raises_on_failed(self) -> None:
+        t = FakeTransport({("GET", "/api/v1/resources/r"): (200, {"status": "FAILED"})})
+        with pytest.raises(DataForgeError, match="FAILED"):
+            _client(t).poll("r", interval_s=0, sleep=lambda _s: None)
+
+    def test_poll_times_out(self) -> None:
+        t = FakeTransport({("GET", "/api/v1/resources/r"): (200, {"status": "PROVISIONING"})})
+        clock = iter([0.0, 0.0, 999.0])
+        with pytest.raises(DataForgeError, match="not PROVISIONED within"):
+            _client(t).poll(
+                "r", timeout_s=10, interval_s=0, sleep=lambda _s: None,
+                now=lambda: next(clock),
+            )
+
+    def test_provision_or_reuse_reuses(self) -> None:
+        t = FakeTransport({
+            ("GET", "/api/v1/resources/r-live"): (
+                200, {"id": "r-live", "status": "PROVISIONED", "artifacts": {"data": _ARTIFACTS}}
+            ),
+            ("GET", "/api/v1/resources"): (200, [{"id": "r-live", "status": "PROVISIONED"}]),
+        })
+        rid, creds = _client(t).provision_or_reuse(
+            datasource="redshift", variant="aws-serverless",
+            instance_name="e2e", reason="SDR full-DAG e2e for redshift",
+        )
+        assert rid == "r-live"
+        assert creds["database"] == "e2e_main"
+        # reuse path must NOT create a new resource
+        assert not any(m == "POST" for m, _p, _b in t.calls)
+
+
+class TestMapping:
+    def test_creds_to_database_spec_puts_database_in_extra(self) -> None:
+        spec = creds_to_database_spec(_ARTIFACTS, connector_config_name="atlan-connectors-redshift")
+        assert spec.host == "redshift.example.invalid"
+        assert spec.port == 5439
+        assert spec.username == "test_user"
+        assert spec.extra == {"database": "e2e_main"}
+        assert spec.connector_config_name == "atlan-connectors-redshift"
+
+    def test_creds_alt_key_spellings(self) -> None:
+        spec = creds_to_database_spec(
+            {"endpoint": "h", "port": "5439", "dbname": "e2e_main", "user": "u", "password": "p"}
+        )
+        assert spec.host == "h" and spec.port == 5439
+        assert spec.username == "u" and spec.extra == {"database": "e2e_main"}
+
+    def test_missing_artifacts_raises(self) -> None:
+        from application_sdk.testing.e2e.dataforge import _artifacts
+
+        with pytest.raises(DataForgeError, match="artifacts.data"):
+            _artifacts({"id": "r", "artifacts": {}})
+
+
+class TestSeed:
+    def test_redshift_seed_shape(self) -> None:
+        sql = load_seed("redshift")
+        assert "CREATE SCHEMA IF NOT EXISTS e2e_main" in sql
+        assert "e2e_main.customers" in sql and "e2e_main.orders" in sql
+        assert "v_customer_order_totals" in sql
+        # Redshift dialect in the DDL (not the postgres SERIAL form)
+        assert "INTEGER IDENTITY(1,1) PRIMARY KEY" in sql
+        assert "SERIAL PRIMARY KEY" not in sql
+
+    def test_unknown_engine_seed_raises(self) -> None:
+        with pytest.raises(DataForgeError, match="no canonical seed"):
+            load_seed("snowflake")
+
+
+class TestCli:
+    from application_sdk.testing.e2e.dataforge import main, provision_source
+
+    def _reuse_transport(self) -> FakeTransport:
+        return FakeTransport({
+            ("GET", "/api/v1/resources/r-live"): (
+                200, {"id": "r-live", "status": "PROVISIONED", "artifacts": {"data": _ARTIFACTS}}
+            ),
+            ("GET", "/api/v1/resources"): (200, [{"id": "r-live", "status": "PROVISIONED"}]),
+        })
+
+    def test_provision_emits_source_env(self, monkeypatch, tmp_path) -> None:
+        from application_sdk.testing.e2e.dataforge import main
+
+        env_file = tmp_path / "gh.env"
+        monkeypatch.setenv("GITHUB_ENV", str(env_file))
+        rc = main(
+            ["provision", "redshift", "--instance-name", "e2e",
+             "--reason", "SDR full-DAG e2e for redshift"],
+            client=_client(self._reuse_transport()),
+        )
+        assert rc == 0
+        written = env_file.read_text()
+        assert "SOURCE_HOST=redshift.example.invalid" in written
+        assert "SOURCE_DATABASE=e2e_main" in written
+        assert "SOURCE_USERNAME=test_user" in written
+        assert "DATAFORGE_RESOURCE_ID=r-live" in written
+        # SECURITY: the password must NEVER be written to $GITHUB_ENV
+        assert "SOURCE_PASSWORD" not in written
+        assert "test-not-a-real-pw" not in written
+
+    def test_verify_ok(self) -> None:
+        from application_sdk.testing.e2e.dataforge import main
+
+        t = FakeTransport({("GET", "/api/v1/modules"): (200, {"modules": []})})
+        assert main(["verify"], client=_client(t)) == 0
+
+    def test_provision_source_unknown_engine(self) -> None:
+        from application_sdk.testing.e2e.dataforge import provision_source
+
+        with pytest.raises(DataForgeError, match="not registered for DataForge"):
+            provision_source("snowflake", instance_name="x", reason="x" * 12)
+
+
+class TestDeviceLogin:
+    def test_device_login_polls_then_writes_session(self, tmp_path) -> None:
+        session_path = tmp_path / ".dataforge" / "session.json"
+        responses = [
+            (200, {"device_code": "dc-1", "user_code": "ABCD-EFGH",
+                   "verification_url_complete": "https://dataforge.example.invalid/auth/device?user_code=ABCD-EFGH",
+                   "interval": 0, "expires_in": 600}),
+            (400, {"error": "authorization_pending"}),
+            (200, {"session_token": "test-session", "refresh_token": "test-refresh"}),
+        ]
+
+        def transport(method, url, headers, body):
+            return responses.pop(0)
+
+        client = DataForgeClient(transport=transport, api_url=_API)
+        clock = iter([0.0, 0.0, 0.0, 0.0])
+        prompts: list[str] = []
+        out = client.device_login(
+            open_browser=False, write_path=str(session_path),
+            sleep=lambda _s: None, now=lambda: next(clock), echo=prompts.append,
+        )
+        assert out == str(session_path)
+        saved = json.loads(session_path.read_text())
+        assert saved["session_token"] == "test-session"
+        assert saved["refresh_token"] == "test-refresh"
+        assert (session_path.stat().st_mode & 0o777) == 0o600
+        # the human-facing prompt carried the verification URL + code
+        assert any("ABCD-EFGH" in p for p in prompts)
+
+    def test_device_login_raises_on_access_denied(self, tmp_path) -> None:
+        responses = [
+            (200, {"device_code": "dc", "user_code": "X", "interval": 0, "expires_in": 9}),
+            (400, {"error": "access_denied"}),
+        ]
+
+        def transport(method, url, headers, body):
+            return responses.pop(0)
+
+        clock = iter([0.0, 0.0, 0.0])
+        with pytest.raises(DataForgeError, match="access_denied"):
+            DataForgeClient(transport=transport, api_url=_API).device_login(
+                open_browser=False, write_path=str(tmp_path / "s.json"),
+                sleep=lambda _s: None, now=lambda: next(clock), echo=lambda _m: None,
+            )

--- a/tests/unit/testing/e2e/test_dataforge.py
+++ b/tests/unit/testing/e2e/test_dataforge.py
@@ -114,7 +114,7 @@ class TestLifecycle:
         assert rid == "r-new"
         body = t.calls[0][2]
         assert body["skip_approval"] is True
-        assert body["category"] == "ai"
+        assert body["category"] == "development"
         assert body["lifecycle_days"] == 3
         assert body["module_id"] == "m-1"
 

--- a/tests/unit/testing/e2e/test_dataforge.py
+++ b/tests/unit/testing/e2e/test_dataforge.py
@@ -288,3 +288,33 @@ class TestDeviceLogin:
                 open_browser=False, write_path=str(tmp_path / "s.json"),
                 sleep=lambda _s: None, now=lambda: next(clock), echo=lambda _m: None,
             )
+
+
+class TestRefresh:
+    def test_401_then_refresh_then_retry_succeeds(self) -> None:
+        # GET 401 (expired) -> POST /auth/refresh 200 -> GET retry 200.
+        seq = [
+            (401, {"error": "unauthorized"}),
+            (200, {"session_token": "fresh-session", "refresh_token": "fresh-refresh"}),
+            (200, [{"id": "r-live", "status": "PROVISIONED"}]),
+        ]
+        seen = []
+
+        def transport(method, url, headers, body):
+            seen.append((method, url.rsplit("/", 2)[-2] + "/" + url.rsplit("/", 1)[-1]))
+            return seq.pop(0)
+
+        c = DataForgeClient(
+            transport=transport, api_url=_API,
+            _token="stale-session", _refresh_token="rt",
+        )
+        assert c.find_reusable("redshift") == "r-live"
+        assert c._token == "fresh-session"  # rotated
+        # the middle call hit the refresh endpoint
+        assert any("auth/refresh" in p for _m, p in seen)
+
+    def test_401_without_refresh_token_raises(self) -> None:
+        t = FakeTransport({("GET", "/api/v1/resources"): (401, {"error": "x"})})
+        # _client() sets no refresh token -> refresh() returns False -> raises
+        with pytest.raises(DataForgeAuthError, match="session expired"):
+            _client(t).find_reusable("redshift")

--- a/tests/unit/testing/e2e/test_dataforge.py
+++ b/tests/unit/testing/e2e/test_dataforge.py
@@ -70,64 +70,95 @@ class TestSession:
 
 class TestLifecycle:
     def test_resolve_module_id_picks_variant(self) -> None:
-        t = FakeTransport({
-            ("GET", "/api/v1/modules/datasources/redshift/variants"): (
-                200,
-                [
-                    {"variant": "aws-managed", "module_id": "m-managed"},
-                    {"variant": "aws-serverless", "module_id": "m-serverless"},
-                ],
-            )
-        })
-        assert _client(t).resolve_module_id("redshift", "aws-serverless") == "m-serverless"
+        t = FakeTransport(
+            {
+                ("GET", "/api/v1/modules/datasources/redshift/variants"): (
+                    200,
+                    [
+                        {"variant": "aws-managed", "module_id": "m-managed"},
+                        {"variant": "aws-serverless", "module_id": "m-serverless"},
+                    ],
+                )
+            }
+        )
+        assert (
+            _client(t).resolve_module_id("redshift", "aws-serverless") == "m-serverless"
+        )
 
     def test_resolve_module_id_unknown_variant_raises(self) -> None:
-        t = FakeTransport({
-            ("GET", "/api/v1/modules/datasources/redshift/variants"): (
-                200, [{"variant": "aws-managed", "module_id": "m"}]
-            )
-        })
+        t = FakeTransport(
+            {
+                ("GET", "/api/v1/modules/datasources/redshift/variants"): (
+                    200,
+                    [{"variant": "aws-managed", "module_id": "m"}],
+                )
+            }
+        )
         with pytest.raises(DataForgeError, match="No DataForge variant"):
             _client(t).resolve_module_id("redshift", "aws-serverless")
 
     def test_find_reusable_returns_provisioned(self) -> None:
-        t = FakeTransport({
-            ("GET", "/api/v1/resources"): (
-                200,
-                [
-                    {"id": "r-old", "status": "DELETED"},
-                    {"id": "r-live", "status": "PROVISIONED"},
-                ],
-            )
-        })
+        t = FakeTransport(
+            {
+                ("GET", "/api/v1/resources"): (
+                    200,
+                    [
+                        {"id": "r-old", "status": "DELETED"},
+                        {"id": "r-live", "status": "PROVISIONED"},
+                    ],
+                )
+            }
+        )
         assert _client(t).find_reusable("redshift") == "r-live"
 
     def test_create_rejects_short_reason(self) -> None:
         with pytest.raises(DataForgeError, match="reason"):
             _client(FakeTransport({})).create("m", {"instance_name": "x"}, "short")
 
-    def test_create_posts_fixed_flags(self) -> None:
+    def test_create_defaults_to_persistent_no_ttl(self) -> None:
+        # Default posture is the persistent shared fixture: lifecycle_enabled=False
+        # and NO lifecycle_days key (no hard TTL — approve once, reuse forever).
         t = FakeTransport({("POST", "/api/v1/resources"): (201, {"id": "r-new"})})
         rid = _client(t).create(
-            "m-1", {"instance_name": "e2e"}, "SDR full-DAG e2e for redshift", 3
+            "m-1", {"instance_name": "e2e"}, "SDR full-DAG e2e for redshift"
         )
         assert rid == "r-new"
         body = t.calls[0][2]
         assert body["skip_approval"] is True
         assert body["category"] == "development"
-        assert body["lifecycle_days"] == 3
+        assert body["lifecycle_enabled"] is False
+        assert "lifecycle_days" not in body
         assert body["module_id"] == "m-1"
+
+    def test_create_ephemeral_opt_in_sets_ttl(self) -> None:
+        # Explicit throwaway instance: lifecycle_enabled=True carries a hard TTL.
+        t = FakeTransport({("POST", "/api/v1/resources"): (201, {"id": "r-tmp"})})
+        _client(t).create(
+            "m-1",
+            {"instance_name": "e2e"},
+            "throwaway ephemeral e2e instance",
+            lifecycle_enabled=True,
+            lifecycle_days=3,
+        )
+        body = t.calls[0][2]
+        assert body["lifecycle_enabled"] is True
+        assert body["lifecycle_days"] == 3
 
     def test_poll_returns_on_provisioned(self) -> None:
         seq = [
             (200, {"id": "r", "status": "PROVISIONING"}),
-            (200, {"id": "r", "status": "PROVISIONED", "artifacts": {"data": _ARTIFACTS}}),
+            (
+                200,
+                {"id": "r", "status": "PROVISIONED", "artifacts": {"data": _ARTIFACTS}},
+            ),
         ]
 
         def transport(method, url, headers, body):
             return seq.pop(0)
 
-        client = DataForgeClient(transport=transport, _token="fake-session", api_url=_API)
+        client = DataForgeClient(
+            transport=transport, _token="fake-session", api_url=_API
+        )
         got = client.poll("r", interval_s=0, sleep=lambda _s: None)
         assert got["status"] == "PROVISIONED"
 
@@ -137,24 +168,41 @@ class TestLifecycle:
             _client(t).poll("r", interval_s=0, sleep=lambda _s: None)
 
     def test_poll_times_out(self) -> None:
-        t = FakeTransport({("GET", "/api/v1/resources/r"): (200, {"status": "PROVISIONING"})})
+        t = FakeTransport(
+            {("GET", "/api/v1/resources/r"): (200, {"status": "PROVISIONING"})}
+        )
         clock = iter([0.0, 0.0, 999.0])
         with pytest.raises(DataForgeError, match="not PROVISIONED within"):
             _client(t).poll(
-                "r", timeout_s=10, interval_s=0, sleep=lambda _s: None,
+                "r",
+                timeout_s=10,
+                interval_s=0,
+                sleep=lambda _s: None,
                 now=lambda: next(clock),
             )
 
     def test_provision_or_reuse_reuses(self) -> None:
-        t = FakeTransport({
-            ("GET", "/api/v1/resources/r-live"): (
-                200, {"id": "r-live", "status": "PROVISIONED", "artifacts": {"data": _ARTIFACTS}}
-            ),
-            ("GET", "/api/v1/resources"): (200, [{"id": "r-live", "status": "PROVISIONED"}]),
-        })
+        t = FakeTransport(
+            {
+                ("GET", "/api/v1/resources/r-live"): (
+                    200,
+                    {
+                        "id": "r-live",
+                        "status": "PROVISIONED",
+                        "artifacts": {"data": _ARTIFACTS},
+                    },
+                ),
+                ("GET", "/api/v1/resources"): (
+                    200,
+                    [{"id": "r-live", "status": "PROVISIONED"}],
+                ),
+            }
+        )
         rid, creds = _client(t).provision_or_reuse(
-            datasource="redshift", variant="aws-serverless",
-            instance_name="e2e", reason="SDR full-DAG e2e for redshift",
+            datasource="redshift",
+            variant="aws-serverless",
+            instance_name="e2e",
+            reason="SDR full-DAG e2e for redshift",
         )
         assert rid == "r-live"
         assert creds["database"] == "e2e_main"
@@ -164,7 +212,9 @@ class TestLifecycle:
 
 class TestMapping:
     def test_creds_to_database_spec_puts_database_in_extra(self) -> None:
-        spec = creds_to_database_spec(_ARTIFACTS, connector_config_name="atlan-connectors-redshift")
+        spec = creds_to_database_spec(
+            _ARTIFACTS, connector_config_name="atlan-connectors-redshift"
+        )
         assert spec.host == "redshift.example.invalid"
         assert spec.port == 5439
         assert spec.username == "test_user"
@@ -173,7 +223,13 @@ class TestMapping:
 
     def test_creds_alt_key_spellings(self) -> None:
         spec = creds_to_database_spec(
-            {"endpoint": "h", "port": "5439", "dbname": "e2e_main", "user": "u", "password": "p"}
+            {
+                "endpoint": "h",
+                "port": "5439",
+                "dbname": "e2e_main",
+                "user": "u",
+                "password": "p",
+            }
         )
         assert spec.host == "h" and spec.port == 5439
         assert spec.username == "u" and spec.extra == {"database": "e2e_main"}
@@ -204,12 +260,22 @@ class TestCli:
     from application_sdk.testing.e2e.dataforge import main, provision_source
 
     def _reuse_transport(self) -> FakeTransport:
-        return FakeTransport({
-            ("GET", "/api/v1/resources/r-live"): (
-                200, {"id": "r-live", "status": "PROVISIONED", "artifacts": {"data": _ARTIFACTS}}
-            ),
-            ("GET", "/api/v1/resources"): (200, [{"id": "r-live", "status": "PROVISIONED"}]),
-        })
+        return FakeTransport(
+            {
+                ("GET", "/api/v1/resources/r-live"): (
+                    200,
+                    {
+                        "id": "r-live",
+                        "status": "PROVISIONED",
+                        "artifacts": {"data": _ARTIFACTS},
+                    },
+                ),
+                ("GET", "/api/v1/resources"): (
+                    200,
+                    [{"id": "r-live", "status": "PROVISIONED"}],
+                ),
+            }
+        )
 
     def test_provision_emits_source_env(self, monkeypatch, tmp_path) -> None:
         from application_sdk.testing.e2e.dataforge import main
@@ -217,8 +283,14 @@ class TestCli:
         env_file = tmp_path / "gh.env"
         monkeypatch.setenv("GITHUB_ENV", str(env_file))
         rc = main(
-            ["provision", "redshift", "--instance-name", "e2e",
-             "--reason", "SDR full-DAG e2e for redshift"],
+            [
+                "provision",
+                "redshift",
+                "--instance-name",
+                "e2e",
+                "--reason",
+                "SDR full-DAG e2e for redshift",
+            ],
             client=_client(self._reuse_transport()),
         )
         assert rc == 0
@@ -248,9 +320,16 @@ class TestDeviceLogin:
     def test_device_login_polls_then_writes_session(self, tmp_path) -> None:
         session_path = tmp_path / ".dataforge" / "session.json"
         responses = [
-            (200, {"device_code": "dc-1", "user_code": "ABCD-EFGH",
-                   "verification_url_complete": "https://dataforge.example.invalid/auth/device?user_code=ABCD-EFGH",
-                   "interval": 0, "expires_in": 600}),
+            (
+                200,
+                {
+                    "device_code": "dc-1",
+                    "user_code": "ABCD-EFGH",
+                    "verification_url_complete": "https://dataforge.example.invalid/auth/device?user_code=ABCD-EFGH",
+                    "interval": 0,
+                    "expires_in": 600,
+                },
+            ),
             (400, {"error": "authorization_pending"}),
             (200, {"session_token": "test-session", "refresh_token": "test-refresh"}),
         ]
@@ -262,8 +341,11 @@ class TestDeviceLogin:
         clock = iter([0.0, 0.0, 0.0, 0.0])
         prompts: list[str] = []
         out = client.device_login(
-            open_browser=False, write_path=str(session_path),
-            sleep=lambda _s: None, now=lambda: next(clock), echo=prompts.append,
+            open_browser=False,
+            write_path=str(session_path),
+            sleep=lambda _s: None,
+            now=lambda: next(clock),
+            echo=prompts.append,
         )
         assert out == str(session_path)
         saved = json.loads(session_path.read_text())
@@ -275,7 +357,10 @@ class TestDeviceLogin:
 
     def test_device_login_raises_on_access_denied(self, tmp_path) -> None:
         responses = [
-            (200, {"device_code": "dc", "user_code": "X", "interval": 0, "expires_in": 9}),
+            (
+                200,
+                {"device_code": "dc", "user_code": "X", "interval": 0, "expires_in": 9},
+            ),
             (400, {"error": "access_denied"}),
         ]
 
@@ -285,8 +370,11 @@ class TestDeviceLogin:
         clock = iter([0.0, 0.0, 0.0])
         with pytest.raises(DataForgeError, match="access_denied"):
             DataForgeClient(transport=transport, api_url=_API).device_login(
-                open_browser=False, write_path=str(tmp_path / "s.json"),
-                sleep=lambda _s: None, now=lambda: next(clock), echo=lambda _m: None,
+                open_browser=False,
+                write_path=str(tmp_path / "s.json"),
+                sleep=lambda _s: None,
+                now=lambda: next(clock),
+                echo=lambda _m: None,
             )
 
 
@@ -305,8 +393,10 @@ class TestRefresh:
             return seq.pop(0)
 
         c = DataForgeClient(
-            transport=transport, api_url=_API,
-            _token="stale-session", _refresh_token="rt",
+            transport=transport,
+            api_url=_API,
+            _token="stale-session",
+            _refresh_token="rt",
         )
         assert c.find_reusable("redshift") == "r-live"
         assert c._token == "fresh-session"  # rotated


### PR DESCRIPTION
## DataForge rung-3 integration (cloud-only e2e sources) — DRAFT / follow-up

Split out of the hermetic-source scaffold PR so that lands with just the free
CI container/emulator rungs (1–2). This branch adds **rung 3**: sources that
have no free container (cloud warehouses/SaaS) and are provisioned as a live
instance via DataForge, an internal Atlan provisioning service (REST API; base
URL + credentials supplied at runtime via env — no endpoint baked into this
public SDK).

**Contents (4 commits):**
- `application_sdk/testing/e2e/dataforge.py` — `DataForgeClient` (resolve module
  → provision-or-reuse → poll → connection artifacts → `DatabaseSpec`), OAuth
  device-code auth with session auto-refresh, `provision_source()`, and a CLI
  (`auth` / `verify` / `provision` / `destroy`). Secrets are handled in-process;
  never logged or written to env/disk.
- `application_sdk/testing/e2e/seeds/redshift.sql` — canonical DDL mirroring the
  postgres seed shape (uniform asset counts across engines).
- 24 offline unit tests (fake transport).

**Status:** WIP. The client is live-validated up through provisioning; the first
end-to-end proof (a cloud connector's full DAG against a DataForge-provisioned
instance) is in progress. Kept as draft to iterate separately from the
container-rung PR.
