### PR TITLE
fix(e2e): fail fast when no worker polls the extract task queue

### DIFF
--- a/application_sdk/testing/e2e/_errors.py
+++ b/application_sdk/testing/e2e/_errors.py
@@ -89,6 +89,24 @@ class AdminRoleNotResolvedError(PreconditionError):
 
 
 @dataclass(kw_only=True)
+class NoWorkerOnTaskQueueError(PreconditionError):
+    """No worker started any DAG node within the stall-grace window.
+
+    The AE run's parent workflow runs on the always-on automation-engine
+    queue, so the top-level run flips to ``Running`` even when the connector's
+    own ``extract`` node is stuck ``Pending`` because no worker is polling its
+    task queue. Rather than let the harness hang for the full
+    ``ae_poll_timeout_seconds`` (often 30 min), we fail fast here. The usual
+    cause is an agent-name / task-queue mismatch: the test's
+    ``agent_spec().agent_name`` must resolve to the same queue the deployed
+    worker polls (``atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}``).
+    """
+
+    code: ClassVar[str] = "PRECONDITION_NO_WORKER_ON_TASK_QUEUE"
+    expected_state: str | None = "a worker polling the extract task queue"
+
+
+@dataclass(kw_only=True)
 class AgentSpecRequiredError(InvalidInputError):
     """Agent mode requires an ``AgentSpec`` but none was provided."""
 

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -174,6 +174,11 @@ class BaseE2ETest:
     # suite that runs against shared / KEDA-autoscaled infra (e.g. some
     # RunMode.DIRECT setups hitting a prod pod that may be scaled to zero),
     # where legitimate pickup can take longer than any fixed grace.
+    #
+    # The guard fires at the first poll where elapsed >= grace, so real
+    # detection latency is grace + up to one ae_poll_interval_seconds
+    # (negligible at the 180/10 defaults; only noticeable if a subclass sets a
+    # grace close to the interval).
     ae_stall_grace_seconds: ClassVar[int] = 180
     atlas_poll_interval_seconds: ClassVar[int] = 30
     atlas_poll_timeout_seconds: ClassVar[int] = 1500
@@ -264,6 +269,22 @@ class BaseE2ETest:
                 "the CI worker the two-store env vars were applied to, so a "
                 "missing App.upload() hand-off will NOT be caught by this run.",
                 type(self).__name__,
+            )
+
+        # The stall guard assumes a dedicated worker that picks work up within
+        # seconds. Under RunMode.DIRECT extraction runs on the tenant's own
+        # deployed pod, which may be KEDA-idle and cold-start slower than the
+        # grace — tripping a spurious NoWorkerOnTaskQueueError on an otherwise
+        # healthy run. Nudge the operator toward the opt-out rather than fail.
+        if self.mode is RunMode.DIRECT and self.ae_stall_grace_seconds > 0:
+            logger.warning(
+                "%s runs in RunMode.DIRECT with ae_stall_grace_seconds=%ds — "
+                "extraction runs on the tenant's own (possibly KEDA-idle) pod, "
+                "whose cold-start can exceed the grace and raise a spurious "
+                "NoWorkerOnTaskQueueError. Set ae_stall_grace_seconds = 0 on the "
+                "test class to disable the stall guard if you see false failures.",
+                type(self).__name__,
+                self.ae_stall_grace_seconds,
             )
 
         tenant_url = os.environ.get("ATLAN_BASE_URL", "").rstrip("/")

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -160,20 +160,21 @@ class BaseE2ETest:
 
     ae_poll_interval_seconds: ClassVar[int] = 10
     ae_poll_timeout_seconds: ClassVar[int] = 600
-    # Fail-fast stall guard (OPT-IN, disabled by default): if set > 0 and no DAG
-    # node has started within this window, run_full_dag raises
-    # NoWorkerOnTaskQueueError instead of hanging for the full
-    # ae_poll_timeout_seconds — useful when a wedge means a real
-    # agent-name/task-queue mismatch (e.g. a second run_full_dag() in one test).
+    # Fail-fast stall guard (test-harness only — this module is never imported
+    # by the production execution path). If no DAG node has started within this
+    # window, run_full_dag raises NoWorkerOnTaskQueueError instead of hanging
+    # for the full ae_poll_timeout_seconds. Catches the common wedge where a
+    # test's agent_spec().agent_name doesn't match the deployed worker's queue
+    # (or a second run_full_dag() in one test targets a different agent_name).
     #
-    # Left OFF by default on purpose: against KEDA-autoscaled or saturated
-    # tenants a task can legitimately sit queued for a long time (cold-start
-    # scale-up, worker saturation — we've seen hours) before a worker picks it
-    # up, so a fixed grace would cause false failures. Only opt in on tests that
-    # run against a DEDICATED worker (e.g. the CI docker-compose container),
-    # where a stalled queue genuinely means "no worker on this queue", not
-    # "worker busy". The full ae_poll_timeout_seconds remains the real ceiling.
-    ae_stall_grace_seconds: ClassVar[int] = 0
+    # On by default at 180s: e2e runs against a dedicated worker (the CI
+    # docker-compose container) that long-polls and picks work up within
+    # seconds, so a healthy run never trips it, and the full
+    # ae_poll_timeout_seconds still bounds real work. Set to 0 to disable on a
+    # suite that runs against shared / KEDA-autoscaled infra (e.g. some
+    # RunMode.DIRECT setups hitting a prod pod that may be scaled to zero),
+    # where legitimate pickup can take longer than any fixed grace.
+    ae_stall_grace_seconds: ClassVar[int] = 180
     atlas_poll_interval_seconds: ClassVar[int] = 30
     atlas_poll_timeout_seconds: ClassVar[int] = 1500
     # Asset counts use a much shorter poll window: Elasticsearch is eventually

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -160,6 +160,14 @@ class BaseE2ETest:
 
     ae_poll_interval_seconds: ClassVar[int] = 10
     ae_poll_timeout_seconds: ClassVar[int] = 600
+    # Fail-fast stall guard: if no DAG node has started within this window, the
+    # run is almost certainly wedged on a task queue with no worker (e.g. the
+    # test's agent_spec().agent_name doesn't match the deployed worker's queue,
+    # or a second run in the same test used a different agent_name). Rather than
+    # hang for the full ae_poll_timeout_seconds, raise immediately. Generous
+    # enough that a healthy worker (which long-polls and picks up within
+    # seconds) never trips it. Set to 0/None on a subclass to disable.
+    ae_stall_grace_seconds: ClassVar[int] = 180
     atlas_poll_interval_seconds: ClassVar[int] = 30
     atlas_poll_timeout_seconds: ClassVar[int] = 1500
     # Asset counts use a much shorter poll window: Elasticsearch is eventually
@@ -589,6 +597,20 @@ class BaseE2ETest:
     # The actual flow
     # ------------------------------------------------------------------
 
+    def _extract_task_queue(self) -> str:
+        """Task queue the ``extract`` node is dispatched to.
+
+        Single source of truth for both the seed DAG (which pins the extract
+        node's ``task_queue`` to this value) and the stall-guard diagnostic. In
+        AGENT mode this must equal the queue the deployed worker polls
+        (``atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}``), so the
+        test's ``agent_spec().agent_name`` has to match that suffix.
+        """
+        agent = self.agent_spec()
+        if agent is not None:
+            return f"atlan-{agent.agent_name}"
+        return f"atlan-{self.connector_short_name}-default"
+
     def _bootstrap_workflow(self) -> str:
         """Ensure an AE workflow exists with a published version.
 
@@ -611,11 +633,7 @@ class BaseE2ETest:
         logger.info("Created (or reused) AE workflow: name=%s slug=%s", name, slug)
         time.sleep(3)
 
-        agent = self.agent_spec()
-        if agent is not None:
-            extract_queue = f"atlan-{agent.agent_name}"
-        else:
-            extract_queue = f"atlan-{self.connector_short_name}-default"
+        extract_queue = self._extract_task_queue()
 
         if self.manifest_path:
             seed_dag = self._seed_dag_from_manifest(extract_queue)
@@ -649,6 +667,8 @@ class BaseE2ETest:
             run_id,
             interval_seconds=self.ae_poll_interval_seconds,
             timeout_seconds=self.ae_poll_timeout_seconds,
+            stall_grace_seconds=self.ae_stall_grace_seconds or None,
+            stall_task_queue=self._extract_task_queue(),
         )
 
         asset_counts: dict[str, int] = {}

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -160,14 +160,20 @@ class BaseE2ETest:
 
     ae_poll_interval_seconds: ClassVar[int] = 10
     ae_poll_timeout_seconds: ClassVar[int] = 600
-    # Fail-fast stall guard: if no DAG node has started within this window, the
-    # run is almost certainly wedged on a task queue with no worker (e.g. the
-    # test's agent_spec().agent_name doesn't match the deployed worker's queue,
-    # or a second run in the same test used a different agent_name). Rather than
-    # hang for the full ae_poll_timeout_seconds, raise immediately. Generous
-    # enough that a healthy worker (which long-polls and picks up within
-    # seconds) never trips it. Set to 0/None on a subclass to disable.
-    ae_stall_grace_seconds: ClassVar[int] = 180
+    # Fail-fast stall guard (OPT-IN, disabled by default): if set > 0 and no DAG
+    # node has started within this window, run_full_dag raises
+    # NoWorkerOnTaskQueueError instead of hanging for the full
+    # ae_poll_timeout_seconds — useful when a wedge means a real
+    # agent-name/task-queue mismatch (e.g. a second run_full_dag() in one test).
+    #
+    # Left OFF by default on purpose: against KEDA-autoscaled or saturated
+    # tenants a task can legitimately sit queued for a long time (cold-start
+    # scale-up, worker saturation — we've seen hours) before a worker picks it
+    # up, so a fixed grace would cause false failures. Only opt in on tests that
+    # run against a DEDICATED worker (e.g. the CI docker-compose container),
+    # where a stalled queue genuinely means "no worker on this queue", not
+    # "worker busy". The full ae_poll_timeout_seconds remains the real ceiling.
+    ae_stall_grace_seconds: ClassVar[int] = 0
     atlas_poll_interval_seconds: ClassVar[int] = 30
     atlas_poll_timeout_seconds: ClassVar[int] = 1500
     # Asset counts use a much shorter poll window: Elasticsearch is eventually

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -674,7 +674,7 @@ class BaseE2ETest:
             run_id,
             interval_seconds=self.ae_poll_interval_seconds,
             timeout_seconds=self.ae_poll_timeout_seconds,
-            stall_grace_seconds=self.ae_stall_grace_seconds or None,
+            stall_grace_seconds=self.ae_stall_grace_seconds,
             stall_task_queue=self._extract_task_queue(),
         )
 

--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -616,8 +616,8 @@ class AEWorkflowClient:
         sustained outage, not a blip, and there's no point waiting.
 
         Fail-fast stall guard: when ``stall_grace_seconds`` is a positive int
-        (``0`` or ``None`` disables it) and NO DAG node has left the not-started
-        set (``Pending`` / ``Scheduled``) within that window, raise
+        (``None`` or any value ``<= 0`` disables it) and NO DAG node has left the
+        not-started set (``Pending`` / ``Scheduled``) within that window, raise
         :class:`NoWorkerOnTaskQueueError` instead of hanging
         for the full ``timeout_seconds``. The parent AE workflow runs on the
         always-on automation-engine queue, so the top-level run flips to
@@ -695,7 +695,10 @@ class AEWorkflowClient:
             # run is live (parent on the AE queue) but no node has begun, which
             # almost always means no worker is polling the extract task queue.
             if (
-                stall_grace_seconds  # truthy: > 0 (0 or None disables the guard)
+                # only a positive grace arms the guard; None or any value <= 0
+                # disables it (a negative would otherwise fire on the first poll)
+                stall_grace_seconds is not None
+                and stall_grace_seconds > 0
                 and not any_node_started
                 and elapsed >= stall_grace_seconds
             ):

--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -54,6 +54,7 @@ from application_sdk.testing.e2e._errors import (
     AtlanApiHttpError,
     AtlanApiResponseInvariantError,
     AtlanApiTimeoutError,
+    NoWorkerOnTaskQueueError,
 )
 
 logger = get_logger(__name__)
@@ -596,6 +597,8 @@ class AEWorkflowClient:
         interval_seconds: int = 10,
         timeout_seconds: int = 600,
         max_transient_failures: int = 5,
+        stall_grace_seconds: int | None = None,
+        stall_task_queue: str = "",
     ) -> DAGRunResult:
         """Poll until the run reaches a terminal top-level status.
 
@@ -611,12 +614,23 @@ class AEWorkflowClient:
         on a single bad response. After ``max_transient_failures``
         consecutive errors we give up and re-raise — that's a
         sustained outage, not a blip, and there's no point waiting.
+
+        Fail-fast stall guard: when ``stall_grace_seconds`` is set and NO DAG
+        node has left the not-started set (``Pending`` / ``Scheduled``) within
+        that window, raise :class:`NoWorkerOnTaskQueueError` instead of hanging
+        for the full ``timeout_seconds``. The parent AE workflow runs on the
+        always-on automation-engine queue, so the top-level run flips to
+        ``Running`` even when the connector's ``extract`` node is stuck because
+        no worker polls its task queue — hence the check is on node-level start,
+        not the run status. ``stall_task_queue`` is included in the error
+        message so the operator can see which queue had no worker.
         """
         elapsed = 0
         last_summary: str | None = None
         last_result: DAGRunResult | None = None
         transient_streak = 0
         last_log_elapsed = 0  # seconds since the last info log fired
+        any_node_started = False  # any node reached Running/terminal (stall guard)
         while elapsed < timeout_seconds:
             try:
                 result = self.get_native_status(run_id)
@@ -644,6 +658,14 @@ class AEWorkflowClient:
                 continue
             transient_streak = 0
             last_result = result
+            # Stall guard: a node has "started" once it leaves the not-started
+            # set. Tracked as a latch so a node that starts and finishes between
+            # polls still counts.
+            if any(
+                n.status not in (DAGNodeStatus.PENDING, DAGNodeStatus.SCHEDULED)
+                for n in result.nodes
+            ):
+                any_node_started = True
             summary = " ".join(_node_glyph(n) for n in result.nodes)
             run_glyph = _RUN_GLYPHS.get(result.status.value, "•")
             # Log on every status change. Also emit a heartbeat every
@@ -668,6 +690,31 @@ class AEWorkflowClient:
                 last_log_elapsed = elapsed
             if result.status.is_terminal:
                 return result
+            # Fail fast when nothing has started within the grace window: the
+            # run is live (parent on the AE queue) but no node has begun, which
+            # almost always means no worker is polling the extract task queue.
+            if (
+                stall_grace_seconds is not None
+                and not any_node_started
+                and elapsed >= stall_grace_seconds
+            ):
+                queue_hint = (
+                    f" task queue '{stall_task_queue}'"
+                    if stall_task_queue
+                    else " the extract task queue"
+                )
+                raise NoWorkerOnTaskQueueError(
+                    message=(
+                        f"No DAG node started within {stall_grace_seconds}s for run "
+                        f"{run_id} (top-level status={result.status.value}). This "
+                        f"almost always means no worker is polling{queue_hint}. "
+                        "Verify the test's agent_spec().agent_name resolves to the "
+                        "queue the deployed worker polls "
+                        "(atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}); a "
+                        "common cause is a second e2e test class using a different "
+                        "agent_name than the single worker the CI job started."
+                    ),
+                )
             time.sleep(interval_seconds)
             elapsed += interval_seconds
         # Timeout: return the last observation so callers can include

--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -615,9 +615,10 @@ class AEWorkflowClient:
         consecutive errors we give up and re-raise — that's a
         sustained outage, not a blip, and there's no point waiting.
 
-        Fail-fast stall guard: when ``stall_grace_seconds`` is set and NO DAG
-        node has left the not-started set (``Pending`` / ``Scheduled``) within
-        that window, raise :class:`NoWorkerOnTaskQueueError` instead of hanging
+        Fail-fast stall guard: when ``stall_grace_seconds`` is a positive int
+        (``0`` or ``None`` disables it) and NO DAG node has left the not-started
+        set (``Pending`` / ``Scheduled``) within that window, raise
+        :class:`NoWorkerOnTaskQueueError` instead of hanging
         for the full ``timeout_seconds``. The parent AE workflow runs on the
         always-on automation-engine queue, so the top-level run flips to
         ``Running`` even when the connector's ``extract`` node is stuck because
@@ -694,7 +695,7 @@ class AEWorkflowClient:
             # run is live (parent on the AE queue) but no node has begun, which
             # almost always means no worker is polling the extract task queue.
             if (
-                stall_grace_seconds is not None
+                stall_grace_seconds  # truthy: > 0 (0 or None disables the guard)
                 and not any_node_started
                 and elapsed >= stall_grace_seconds
             ):

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -371,3 +371,18 @@ class TestExtractTaskQueue:
     def test_direct_mode_falls_back_to_connector_default(self) -> None:
         # _ConcreteE2ETest is RunMode.DIRECT → agent_spec() is None.
         assert _ConcreteE2ETest()._extract_task_queue() == "atlan-openapi-default"
+
+
+class TestStallGuardDefault:
+    """The stall guard is opt-in: off by default so KEDA/saturated tenants
+    (where a task can legitimately wait a long time) don't get false failures.
+    """
+
+    def test_disabled_by_default(self) -> None:
+        assert _ConcreteE2ETest.ae_stall_grace_seconds == 0
+
+    def test_subclass_can_opt_in(self) -> None:
+        class _OptedIn(_ConcreteE2ETest):
+            ae_stall_grace_seconds = 180
+
+        assert _OptedIn.ae_stall_grace_seconds == 180

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -20,7 +20,7 @@ from application_sdk.testing.e2e._errors import (
     ManifestFileNotFoundError,
 )
 from application_sdk.testing.e2e.base import BaseE2ETest
-from application_sdk.testing.e2e.payload import RunMode
+from application_sdk.testing.e2e.payload import AgentSpec, RunMode
 from application_sdk.testing.e2e.substitutions import MustacheSubstitutions
 
 
@@ -347,3 +347,27 @@ class TestTwoStoreDirectModeWarning:
         _DirectModeTest().setup_method()
 
         mock_logger.warning.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _extract_task_queue
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTaskQueue:
+    """The extract task queue is the single source of truth shared by the seed
+    DAG and the stall-guard diagnostic (must match the deployed worker's queue).
+    """
+
+    def test_agent_mode_uses_agent_name(self) -> None:
+        class _AgentModeTest(_ConcreteE2ETest):
+            mode = RunMode.AGENT
+
+            def agent_spec(self) -> AgentSpec:
+                return AgentSpec(agent_name="openapi-e2e-full-ci-42")
+
+        assert _AgentModeTest()._extract_task_queue() == "atlan-openapi-e2e-full-ci-42"
+
+    def test_direct_mode_falls_back_to_connector_default(self) -> None:
+        # _ConcreteE2ETest is RunMode.DIRECT → agent_spec() is None.
+        assert _ConcreteE2ETest()._extract_task_queue() == "atlan-openapi-default"

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -374,15 +374,15 @@ class TestExtractTaskQueue:
 
 
 class TestStallGuardDefault:
-    """The stall guard is opt-in: off by default so KEDA/saturated tenants
-    (where a task can legitimately wait a long time) don't get false failures.
+    """The stall guard is on by default (test-harness only), and a suite that
+    runs against shared / autoscaled infra can disable it by setting 0.
     """
 
-    def test_disabled_by_default(self) -> None:
-        assert _ConcreteE2ETest.ae_stall_grace_seconds == 0
+    def test_enabled_by_default(self) -> None:
+        assert _ConcreteE2ETest.ae_stall_grace_seconds == 180
 
-    def test_subclass_can_opt_in(self) -> None:
-        class _OptedIn(_ConcreteE2ETest):
-            ae_stall_grace_seconds = 180
+    def test_subclass_can_opt_out(self) -> None:
+        class _OptedOut(_ConcreteE2ETest):
+            ae_stall_grace_seconds = 0
 
-        assert _OptedIn.ae_stall_grace_seconds == 180
+        assert _OptedOut.ae_stall_grace_seconds == 0

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -314,6 +314,9 @@ class TestTwoStoreDirectModeWarning:
 
         class _DirectModeTest(_ConcreteE2ETest):
             connection_admin_roles = ("test-admin-role-guid",)
+            # Isolate this test to the two-store warning (disable the stall-guard
+            # DIRECT warning, covered separately below).
+            ae_stall_grace_seconds = 0
 
         _DirectModeTest().setup_method()
 
@@ -343,10 +346,73 @@ class TestTwoStoreDirectModeWarning:
 
         class _DirectModeTest(_ConcreteE2ETest):
             connection_admin_roles = ("test-admin-role-guid",)
+            # Disable the stall-guard DIRECT warning so this test isolates the
+            # two-store path (covered separately below).
+            ae_stall_grace_seconds = 0
 
         _DirectModeTest().setup_method()
 
         mock_logger.warning.assert_not_called()
+
+
+class TestStallGuardDirectModeWarning:
+    """setup_method nudges toward the =0 opt-out when the stall guard is armed
+    under RunMode.DIRECT, where a KEDA-idle pod can cold-start past the grace.
+    """
+
+    def _bootstrap_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATLAN_BASE_URL", "https://test.example.invalid")
+        monkeypatch.setenv("ATLAN_API_KEY", "test-token")
+        monkeypatch.setenv("GITHUB_RUN_ID", "9999999")
+        monkeypatch.delenv("TWO_STORE", raising=False)
+
+    def _warn_messages(self, mock_logger: MagicMock) -> list[str]:
+        return [c.args[0] for c in mock_logger.warning.call_args_list]
+
+    def test_warns_when_direct_and_guard_armed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._bootstrap_env(monkeypatch)
+        mock_logger = MagicMock()
+        monkeypatch.setattr("application_sdk.testing.e2e.base.logger", mock_logger)
+
+        class _DirectGuarded(_ConcreteE2ETest):  # DIRECT + default grace 180
+            connection_admin_roles = ("test-admin-role-guid",)
+
+        _DirectGuarded().setup_method()
+
+        assert any(
+            "ae_stall_grace_seconds" in m for m in self._warn_messages(mock_logger)
+        )
+
+    def test_no_warning_when_guard_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._bootstrap_env(monkeypatch)
+        mock_logger = MagicMock()
+        monkeypatch.setattr("application_sdk.testing.e2e.base.logger", mock_logger)
+
+        class _DirectUnguarded(_ConcreteE2ETest):
+            connection_admin_roles = ("test-admin-role-guid",)
+            ae_stall_grace_seconds = 0
+
+        _DirectUnguarded().setup_method()
+
+        mock_logger.warning.assert_not_called()
+
+    def test_no_warning_when_mode_is_agent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._bootstrap_env(monkeypatch)
+        mock_logger = MagicMock()
+        monkeypatch.setattr("application_sdk.testing.e2e.base.logger", mock_logger)
+
+        # AGENT + default grace 180 → the stall guard is fine (dedicated worker).
+        _AgentModeE2ETest().setup_method()
+
+        assert not any(
+            "ae_stall_grace_seconds" in m for m in self._warn_messages(mock_logger)
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/testing/e2e/test_client.py
+++ b/tests/unit/testing/e2e/test_client.py
@@ -153,6 +153,22 @@ class TestPollNativeStatusStallGuard:
                 )
         assert result.status == DAGRunStatus.RUNNING
 
+    def test_negative_grace_does_not_fire_on_first_poll(self):
+        """A negative grace is non-positive → disabled, NOT 'fire immediately'
+        (elapsed 0 >= -1 would otherwise trip the guard on the first poll)."""
+        client = _make_client()
+        stuck = _result(DAGRunStatus.RUNNING, DAGNodeStatus.PENDING)
+
+        with patch.object(client, "get_native_status", return_value=stuck):
+            with patch("time.sleep"):
+                result = client.poll_native_status(
+                    _RUN_ID,
+                    interval_seconds=10,
+                    timeout_seconds=30,
+                    stall_grace_seconds=-1,
+                )
+        assert result.status == DAGRunStatus.RUNNING
+
 
 class TestPollNativeStatusTransientHandling:
     """poll_native_status must survive N < max_transient_failures blips."""

--- a/tests/unit/testing/e2e/test_client.py
+++ b/tests/unit/testing/e2e/test_client.py
@@ -101,6 +101,43 @@ class TestPollNativeStatusStallGuard:
         # Message names the queue so the operator can spot the mismatch.
         assert "atlan-openapi-e2e-full-ci-42" in str(exc.value)
 
+    def test_raises_when_node_stuck_in_scheduled(self):
+        """Symmetric to the Pending case: production treats both Pending AND
+        Scheduled as 'not started' (client.py), so a node stuck in Scheduled
+        must keep the guard armed and raise. Guards against a regression that
+        drops SCHEDULED from the not-started set."""
+        client = _make_client()
+        stuck = _result(DAGRunStatus.RUNNING, DAGNodeStatus.SCHEDULED)
+
+        with patch.object(client, "get_native_status", return_value=stuck):
+            with patch("time.sleep"):
+                with pytest.raises(NoWorkerOnTaskQueueError):
+                    client.poll_native_status(
+                        _RUN_ID,
+                        interval_seconds=10,
+                        timeout_seconds=600,
+                        stall_grace_seconds=30,
+                        stall_task_queue="atlan-openapi-e2e-full-ci-42",
+                    )
+
+    def test_generic_queue_hint_when_stall_task_queue_empty(self):
+        """With no stall_task_queue supplied, the error falls back to the
+        generic 'the extract task queue' phrasing."""
+        client = _make_client()
+        stuck = _result(DAGRunStatus.RUNNING, DAGNodeStatus.PENDING)
+
+        with patch.object(client, "get_native_status", return_value=stuck):
+            with patch("time.sleep"):
+                with pytest.raises(NoWorkerOnTaskQueueError) as exc:
+                    client.poll_native_status(
+                        _RUN_ID,
+                        interval_seconds=10,
+                        timeout_seconds=600,
+                        stall_grace_seconds=30,
+                        stall_task_queue="",
+                    )
+        assert "the extract task queue" in str(exc.value)
+
     def test_no_raise_when_node_starts_before_grace(self):
         """Once any node reaches Running the guard latches off — a long-running
         node past the grace window must NOT trip it."""

--- a/tests/unit/testing/e2e/test_client.py
+++ b/tests/unit/testing/e2e/test_client.py
@@ -137,6 +137,22 @@ class TestPollNativeStatusStallGuard:
                 )
         assert result.status == DAGRunStatus.RUNNING
 
+    def test_guard_disabled_when_grace_zero(self):
+        """stall_grace_seconds=0 also disables the guard (base passes the int
+        attr directly, so 0 must be treated as off, not 'grace of 0')."""
+        client = _make_client()
+        stuck = _result(DAGRunStatus.RUNNING, DAGNodeStatus.PENDING)
+
+        with patch.object(client, "get_native_status", return_value=stuck):
+            with patch("time.sleep"):
+                result = client.poll_native_status(
+                    _RUN_ID,
+                    interval_seconds=10,
+                    timeout_seconds=30,
+                    stall_grace_seconds=0,
+                )
+        assert result.status == DAGRunStatus.RUNNING
+
 
 class TestPollNativeStatusTransientHandling:
     """poll_native_status must survive N < max_transient_failures blips."""

--- a/tests/unit/testing/e2e/test_client.py
+++ b/tests/unit/testing/e2e/test_client.py
@@ -13,7 +13,11 @@ from unittest.mock import patch
 
 import pytest
 
-from application_sdk.testing.e2e._errors import AtlanApiHttpError, AtlanApiTimeoutError
+from application_sdk.testing.e2e._errors import (
+    AtlanApiHttpError,
+    AtlanApiTimeoutError,
+    NoWorkerOnTaskQueueError,
+)
 from application_sdk.testing.e2e.client import (
     _REQUEST_MAX_ATTEMPTS,
     AEWorkflowClient,
@@ -55,6 +59,83 @@ def _http_error() -> AtlanApiHttpError:
         message="AE-COMMON-500-01: An unexpected error occurred",
         target="GET /api/service/package-workflows/native-status HTTP 500",
     )
+
+
+def _result(run_status: DAGRunStatus, node_status: DAGNodeStatus) -> DAGRunResult:
+    return DAGRunResult(
+        run_id=_RUN_ID,
+        workflow_slug="slug",
+        status=run_status,
+        nodes=[
+            DAGNodeResult(
+                name="extract",
+                status=node_status,
+                started_at_ms=None,
+                completed_at_ms=None,
+                error_message=None,
+            )
+        ],
+    )
+
+
+class TestPollNativeStatusStallGuard:
+    """poll_native_status must fail fast when no node starts (no worker)."""
+
+    def test_raises_when_no_node_starts_within_grace(self):
+        """Run is Running but the extract node stays Pending → the parent is on
+        the AE queue while no worker polls the extract queue. Must raise
+        NoWorkerOnTaskQueueError once the grace window elapses, not hang."""
+        client = _make_client()
+        stuck = _result(DAGRunStatus.RUNNING, DAGNodeStatus.PENDING)
+
+        with patch.object(client, "get_native_status", return_value=stuck):
+            with patch("time.sleep"):
+                with pytest.raises(NoWorkerOnTaskQueueError) as exc:
+                    client.poll_native_status(
+                        _RUN_ID,
+                        interval_seconds=10,
+                        timeout_seconds=600,
+                        stall_grace_seconds=30,
+                        stall_task_queue="atlan-openapi-e2e-full-ci-42",
+                    )
+        # Message names the queue so the operator can spot the mismatch.
+        assert "atlan-openapi-e2e-full-ci-42" in str(exc.value)
+
+    def test_no_raise_when_node_starts_before_grace(self):
+        """Once any node reaches Running the guard latches off — a long-running
+        node past the grace window must NOT trip it."""
+        client = _make_client()
+        running = _result(DAGRunStatus.RUNNING, DAGNodeStatus.RUNNING)
+        done = _succeeded_result()
+        # Node running for many polls (well past grace), then succeeds.
+        side_effects = [running] * 6 + [done]
+
+        with patch.object(client, "get_native_status", side_effect=side_effects):
+            with patch("time.sleep"):
+                result = client.poll_native_status(
+                    _RUN_ID,
+                    interval_seconds=10,
+                    timeout_seconds=600,
+                    stall_grace_seconds=5,
+                    stall_task_queue="atlan-openapi-e2e-full-ci-42",
+                )
+        assert result.status == DAGRunStatus.SUCCEEDED
+
+    def test_guard_disabled_when_grace_none(self):
+        """stall_grace_seconds=None disables the guard: a stuck run polls to the
+        timeout and returns the last observation instead of raising."""
+        client = _make_client()
+        stuck = _result(DAGRunStatus.RUNNING, DAGNodeStatus.PENDING)
+
+        with patch.object(client, "get_native_status", return_value=stuck):
+            with patch("time.sleep"):
+                result = client.poll_native_status(
+                    _RUN_ID,
+                    interval_seconds=10,
+                    timeout_seconds=30,
+                    stall_grace_seconds=None,
+                )
+        assert result.status == DAGRunStatus.RUNNING
 
 
 class TestPollNativeStatusTransientHandling:


### PR DESCRIPTION
## Problem

The full-DAG e2e harness (`BaseE2ETest`) pins the `extract` node to `atlan-{agent_name}` and polls native-status. When **no worker polls that queue**, the run hangs for the full `ae_poll_timeout_seconds` (often 30 min) and then fails with an opaque timeout.

This bites as soon as you run **multiple** DAGs in one test (e.g. a CREATE-then-REUSE assertion-only scenario): if a test's `agent_spec().agent_name` doesn't resolve to the queue the single CI worker actually polls — `atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}` — the parent AE workflow flips to `Running` while the `extract` node sits `Pending` forever.

The SDK worker itself is persistent (long-polls its one fixed queue for the container's lifetime — no post-workflow teardown, idle scale-down, or per-run agent registration), so **multi-run already works when the queue matches**. The gap was the silent 30-minute hang on a mismatch.

## Change

Add a **fail-fast stall guard**. `poll_native_status` raises `NoWorkerOnTaskQueueError` when no DAG node leaves the not-started set (`Pending`/`Scheduled`) within `ae_stall_grace_seconds`, with a message naming the queue and the likely agent-name mismatch. The check is on node-level start (not run status) because the parent runs on the always-on automation-engine queue and flips to `Running` regardless.

Scope: `application_sdk/testing/e2e/` is the **test harness** — it is never imported by the production execution path, so this only affects e2e runs.

**On by default at 180s.** e2e runs against a dedicated worker (the CI docker-compose container) that long-polls and picks work up within seconds, so a healthy run never trips the guard, and the full `ae_poll_timeout_seconds` still bounds real work. A suite that runs against shared / KEDA-autoscaled infra (e.g. some `RunMode.DIRECT` setups hitting a prod pod that may be scaled to zero, where legitimate pickup can take longer than any fixed grace) can disable it with `ae_stall_grace_seconds = 0`.

- `client.poll_native_status`: new `stall_grace_seconds` + `stall_task_queue` params (default off at the client layer); latches "any node started" and raises on stall.
- `base.py`: `ae_stall_grace_seconds` class attr (**default 180**; set 0 to disable); new `_extract_task_queue()` helper as the single source of truth for both the seed DAG and the guard; wired into `run_full_dag`.
- `NoWorkerOnTaskQueueError` typed error leaf.
- Unit tests: guard raise-on-stall / latch-off-once-started / disabled-when-none; `_extract_task_queue` AGENT vs DIRECT; default-on + opt-out.

## Testing
- `pytest tests/unit/testing/e2e/` — passing
- ruff + ruff-format (repo pre-commit hooks) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)