### PR TITLE
feat(conformance): preflight-gate rules P032-P035 (BLDX-1545)

### DIFF
--- a/packages/conformance/conformance/docs/rules/prescriptions.md
+++ b/packages/conformance/conformance/docs/rules/prescriptions.md
@@ -1150,7 +1150,8 @@ Remediation: declare the key as a field on the extraction input contract (matchi
 UI form), or stop reading it in `preflight_check`. Keys are compared to contract field
 names with underscore/hyphen normalization; field aliases are not treated as allowed
 because `model_dump` emits field names, not aliases. The rule does not fire when no
-entrypoint Input contract is resolvable or when a contract opts into extra keys
-(`model_config = ConfigDict(extra="allow")`).
+entrypoint Input contract is resolvable or when a contract (or an in-repo ancestor) opts
+into extra keys via either `model_config` form: `ConfigDict(extra="allow")` or
+`{"extra": "allow"}`.
 
 ---

--- a/packages/conformance/conformance/docs/rules/prescriptions.md
+++ b/packages/conformance/conformance/docs/rules/prescriptions.md
@@ -1142,14 +1142,15 @@ The preflight gate does not forward the live UI form: it rebuilds
 (`_config_from_snapshot`), so only fields declared on an entrypoint `Input` contract
 survive. A key read inside `preflight_check` via `input.metadata.get("key", ...)` or
 `input.metadata["key"]` that is absent from the union of every entrypoint Input
-contract's fields (and their aliases) is silently missing on the gate path, so a
-defensive `.get(key, default)` read passes vacuously with the wrong configuration (e.g.
-database scoping silently dropped).
+contract's fields is silently missing on the gate path, so a defensive `.get(key,
+default)` read passes vacuously with the wrong configuration (e.g. database scoping
+silently dropped).
 
 Remediation: declare the key as a field on the extraction input contract (matching the
-UI form), or stop reading it in `preflight_check`. Keys and field aliases are compared
-with underscore/hyphen normalization. The rule does not fire when no entrypoint Input
-contract is resolvable or when a contract opts into extra fields (`extra="allow"` /
-`allow_unbounded_fields=True`).
+UI form), or stop reading it in `preflight_check`. Keys are compared to contract field
+names with underscore/hyphen normalization; field aliases are not treated as allowed
+because `model_dump` emits field names, not aliases. The rule does not fire when no
+entrypoint Input contract is resolvable or when a contract opts into extra keys
+(`model_config = ConfigDict(extra="allow")`).
 
 ---

--- a/packages/conformance/conformance/docs/rules/prescriptions.md
+++ b/packages/conformance/conformance/docs/rules/prescriptions.md
@@ -5,7 +5,7 @@
 
 # Prescription Rules (P-series)
 
-**31 rules** · Checker: `suite.checks.prescriptions` (P001–P003, P008–P015), `suite.checks.orchestration` (P004–P007, scans test files too), `suite.checks.entrypoint_alignment` (P016), `suite.checks.entrypoint` (P017–P018, scans test files too), `suite.checks.client_seam` (P019), `suite.checks.determinism` (P020–P024, P031), `suite.checks.app_name_alignment` (P025) (all AST-based / cross-artifact)
+**35 rules** · Checker: `suite.checks.prescriptions` (P001–P003, P008–P015), `suite.checks.orchestration` (P004–P007, scans test files too), `suite.checks.entrypoint_alignment` (P016), `suite.checks.entrypoint` (P017–P018, scans test files too), `suite.checks.client_seam` (P019), `suite.checks.determinism` (P020–P024, P031), `suite.checks.app_name_alignment` (P025) (all AST-based / cross-artifact)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -54,6 +54,10 @@ reassigned.
 | [P029](#p029) | `SdrManifestMissingAgentJson` | `block` | `app` | `sdr-readiness` | — | 0.9.0 |
 | [P030](#p030) | `SdrUploadNotCalled` | `warn` | `app` | `sdr-readiness` | — | 0.9.0 |
 | [P031](#p031) | `SharedDefaultExecutorOffload` | `warn` | `both` | `async-correctness` | — | 0.13.0 |
+| [P032](#p032) | `ReservedPreflightActivityName` | `warn` | `app` | `preflight-gate` | — | 0.15.0 |
+| [P033](#p033) | `DuplicateInWorkflowPreflight` | `warn` | `app` | `preflight-gate` | — | 0.15.0 |
+| [P034](#p034) | `UntypedPreflightCheckFailure` | `warn` | `app` | `preflight-gate` | — | 0.15.0 |
+| [P035](#p035) | `PreflightMetadataContractParity` | `warn` | `app` | `preflight-gate` | — | 0.15.0 |
 
 ---
 
@@ -1050,5 +1054,102 @@ rule targets. `application_sdk/execution/heartbeat.py` is exempt: that is where
 Remediation is a restructure (swap in `run_in_thread()`), so findings route to residue.
 Land as `WARN`; suppress a reviewed exception with `# conformance: ignore[P031]
 <reason>`.
+
+---
+
+## P032 — `ReservedPreflightActivityName` {#p032}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `preflight-gate` · **Autofixable:** — · **Since:** 0.15.0
+
+> An app @task registers the 'preflight' activity name reserved by the SDK gate
+
+**Rationale:** The SDK injects a mandatory pre-extraction gate as the activity '{app_name}:preflight'.
+An app @task that also registers the 'preflight' activity name collides with it: the
+worker raises WorkerActivityNameCollisionError at boot and never starts. Catching the
+collision statically surfaces it in the PR instead of on the first deploy.
+
+The SDK reserves the activity name `{app_name}:preflight` for the injected preflight
+gate and registers it unconditionally on the worker. An app `@task` whose effective
+activity name is `preflight` (an explicit `@task(name="preflight")` or a bare `@task` on
+a method named `preflight`) collides with the reserved name; worker boot fails with
+`WorkerActivityNameCollisionError`.
+
+Remediation: rename the task, or fold its logic into the app's `Handler.preflight_check`
+(which the gate already calls). A non-literal `@task(name=<expr>)` is not statically
+resolvable and is not flagged.
+
+---
+
+## P033 — `DuplicateInWorkflowPreflight` {#p033}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `preflight-gate` · **Autofixable:** — · **Since:** 0.15.0
+
+> App defines Handler.preflight_check and a separate preflight-named @task that will drift
+
+**Rationale:** An app that defines Handler.preflight_check AND its own preflight-named @task has two
+preflight implementations that inevitably drift. The gate runs preflight_check, so the
+app-owned activity is redundant — the exact anti-pattern the SDK-native gate eliminates.
+
+When an app declares a `Handler.preflight_check` and also registers its own
+preflight-named `@task` (any `@task` whose effective name contains `preflight` as a
+token but is not the reserved gate name — that exact case is P032), the two preflight
+paths diverge over time. The SDK gate invokes `Handler.preflight_check`; the app-owned
+activity is dead weight that silently rots.
+
+Remediation: delete the app-owned preflight activity and keep the single
+`Handler.preflight_check` implementation the gate calls.
+
+---
+
+## P034 — `UntypedPreflightCheckFailure` {#p034}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `preflight-gate` · **Autofixable:** — · **Since:** 0.15.0
+
+> PreflightCheck(passed=False) constructed without a typed error= — untyped failure
+
+**Rationale:** A failed PreflightCheck constructed without a typed error= falls back to the generic
+PREFLIGHT_CHECK_FAILED code, so the Automation Engine and the UI lose the
+category/code/audience/suggested_action the typed form carries on the wire. This points
+at the exact lines to migrate to typed failures.
+
+A `PreflightCheck` with an explicit `passed=False` and no typed `error=` (absent, or the
+literal `None`) is an untyped failure: the gate falls back to the generic
+`PREFLIGHT_CHECK_FAILED` code and only the deprecated free-text `message` reaches the
+caller. The typed form `error=AuthError(message=..., suggested_action=...,
+cause=exc).to_failure_details()` carries category / code / audience / retryable /
+suggested_action to the Automation Engine and the UI.
+
+Only an explicit `passed=False` literal is flagged; a failure expressed purely by the
+default `passed` and a non-literal `passed` are left alone to keep false positives near
+zero. A locally-defined, non-SDK class named `PreflightCheck` is not flagged.
+
+---
+
+## P035 — `PreflightMetadataContractParity` {#p035}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `preflight-gate` · **Autofixable:** — · **Since:** 0.15.0
+
+> A preflight_check metadata key is not declared on any entrypoint Input contract
+
+**Rationale:** On the gate path metadata is rebuilt from the extraction input's model_dump, so a
+metadata key that is not a field on any entrypoint Input contract is silently absent — a
+defensive input.metadata.get(key, default) read then passes vacuously with the wrong
+config. No runtime signal can catch this class of silent drift; the static check is the
+only guard.
+
+The preflight gate does not forward the live UI form: it rebuilds
+`PreflightInput.metadata` from the extraction input's `model_dump()`
+(`_config_from_snapshot`), so only fields declared on an entrypoint `Input` contract
+survive. A key read inside `preflight_check` via `input.metadata.get("key", ...)` or
+`input.metadata["key"]` that is absent from the union of every entrypoint Input
+contract's fields (and their aliases) is silently missing on the gate path, so a
+defensive `.get(key, default)` read passes vacuously with the wrong configuration (e.g.
+database scoping silently dropped).
+
+Remediation: declare the key as a field on the extraction input contract (matching the
+UI form), or stop reading it in `preflight_check`. Keys and field aliases are compared
+with underscore/hyphen normalization. The rule does not fire when no entrypoint Input
+contract is resolvable or when a contract opts into extra fields (`extra="allow"` /
+`allow_unbounded_fields=True`).
 
 ---

--- a/packages/conformance/conformance/suite/checks/preflight/__init__.py
+++ b/packages/conformance/conformance/suite/checks/preflight/__init__.py
@@ -1,0 +1,50 @@
+"""Preflight-gate checks (P032–P035, BLDX-1545).
+
+Cross-file only: ``scan_path`` is a no-op and ``scan_all`` builds one shared
+:class:`~._common.Registry` (single parse + import walk) then runs all four rule
+passes over it. Reuses the ``P`` series so it runs on the existing P leg of the
+fleet CI matrix with no workflow change.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from conformance.suite.checks._ast_common import discover, make_cli_main
+from conformance.suite.schema.findings import Finding
+
+from . import _metadata_parity, _reserved_gate, _untyped_failure
+from ._common import build_registry
+
+SERIES = "P"
+
+__all__ = ["SERIES", "discover", "main", "scan_all", "scan_path"]
+
+
+def scan_path(path: Path, root: Path) -> list[Finding]:  # noqa: ARG001
+    """No-op: the preflight checks need the whole repo; use :func:`scan_all`."""
+    return []
+
+
+def scan_all(paths: list[Path], root: Path) -> list[Finding]:
+    """Run the P032–P035 preflight-gate passes over *paths*."""
+    reg = build_registry(paths, root)
+    findings: list[Finding] = []
+    findings.extend(_reserved_gate.scan(reg))
+    findings.extend(_untyped_failure.scan(reg))
+    findings.extend(_metadata_parity.scan(reg))
+    return findings
+
+
+main = make_cli_main(
+    scan_all=scan_all,
+    description=(
+        "Preflight-gate conformance (P032-P035): reserved gate-name collision, "
+        "duplicate in-workflow preflight, untyped check failures, and "
+        "metadata/input-contract parity (BLDX-1545)."
+    ),
+)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/conformance/conformance/suite/checks/preflight/_common.py
+++ b/packages/conformance/conformance/suite/checks/preflight/_common.py
@@ -167,7 +167,6 @@ def _class_subclasses_handler(
     handler_base_locals: frozenset[str],
 ) -> bool:
     """True if *cls* directly or transitively derives from an SDK Handler base."""
-    cache: dict[str, bool | None] = {}
     for base in cls.bases:
         bname = base.id if isinstance(base, ast.Name) else getattr(base, "attr", None)
         if bname is None:
@@ -175,9 +174,12 @@ def _class_subclasses_handler(
         bname = aliases.get(bname, bname)
         if bname in handler_base_locals:
             return True
-        # Transitive: an in-repo intermediate that itself derives from a handler base.
+        # Transitive: an in-repo intermediate that itself derives from a handler
+        # base. resolve_ancestor memoizes by class name only, so each target needs
+        # its own cache — a fresh dict per hb avoids a False cached under one
+        # target leaking to another.
         for hb in handler_base_locals:
-            if resolve_ancestor(bname, hb, by_name, cache, set()) is True:
+            if resolve_ancestor(bname, hb, by_name, {}, set()) is True:
                 return True
     return False
 

--- a/packages/conformance/conformance/suite/checks/preflight/_common.py
+++ b/packages/conformance/conformance/suite/checks/preflight/_common.py
@@ -1,0 +1,298 @@
+"""Shared parsing and detection helpers for the preflight-gate checks (P032–P035).
+
+One :class:`Source` per scanned file carries the parsed tree, import aliases,
+suppression directives, and import provenance so the four rule passes share a
+single parse and a single import walk.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from conformance.suite.checks._ast_common import _IgnoreDirective, _parse_directives
+from conformance.suite.checks.prescriptions._decorator_provenance import (
+    _SDK_CONTRACT_MODULE_PREFIXES,
+    ImportProvenance,
+    collect_import_provenance,
+    is_entrypoint_decorator,
+    is_task_decorator,
+)
+from conformance.suite.checks.prescriptions._error_code_prefix import (
+    ClassRecord,
+    collect_classes,
+    collect_import_aliases,
+    resolve_ancestor,
+)
+from conformance.suite.checks.prescriptions._typed_boundaries import (
+    _annotation_terminal_name,
+    _get_non_self_params,
+    _iter_class_body_methods,
+)
+
+_HANDLER_MODULE_PREFIX = "application_sdk.handler"
+_PREFLIGHT_INPUT = "PreflightInput"
+_PREFLIGHT_CHECK = "PreflightCheck"
+
+
+@dataclass(frozen=True)
+class Source:
+    """A parsed source file plus the per-file context every rule pass needs."""
+
+    path: Path
+    rel: str
+    tree: ast.Module
+    aliases: dict[str, str]
+    directives: dict[int, _IgnoreDirective]
+    prov: ImportProvenance
+
+
+@dataclass(frozen=True)
+class Registry:
+    """Cross-file registry built once in ``scan_all`` and shared by all passes."""
+
+    sources: tuple[Source, ...]
+    by_name: dict[str, ClassRecord]
+    aliases_by_rel: dict[str, dict[str, str]]
+
+
+def build_registry(paths: list[Path], root: Path) -> Registry:
+    """Parse *paths* once, building the shared :class:`Registry`."""
+    sources: list[Source] = []
+    by_name: dict[str, ClassRecord] = {}
+    aliases_by_rel: dict[str, dict[str, str]] = {}
+
+    for path in paths:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            tree = ast.parse(text, filename=str(path))
+        except SyntaxError:
+            continue
+        if not isinstance(tree, ast.Module):
+            continue
+        try:
+            rel = str(path.relative_to(root))
+        except ValueError:
+            rel = str(path)
+        aliases = collect_import_aliases(tree)
+        sources.append(
+            Source(
+                path=path,
+                rel=rel,
+                tree=tree,
+                aliases=aliases,
+                directives=_parse_directives(text),
+                prov=collect_import_provenance(tree),
+            )
+        )
+        aliases_by_rel[rel] = aliases
+        for rec in collect_classes(tree, rel, aliases):
+            by_name.setdefault(rec.name, rec)
+
+    return Registry(
+        sources=tuple(sources), by_name=by_name, aliases_by_rel=aliases_by_rel
+    )
+
+
+def effective_task_name(
+    func: ast.FunctionDef | ast.AsyncFunctionDef, dec: ast.expr
+) -> str | None:
+    """Return the activity name a ``@task`` registers, or ``None`` if unverifiable.
+
+    An explicit literal ``@task(name="...")`` wins; a bare ``@task`` / ``@task()``
+    falls back to the method name (mirrors ``application_sdk/app/task.py``). A
+    non-literal ``name=<expr>`` cannot be resolved statically → ``None``.
+    """
+    if isinstance(dec, ast.Call):
+        for kw in dec.keywords:
+            if kw.arg == "name":
+                v = kw.value
+                if isinstance(v, ast.Constant) and isinstance(v.value, str):
+                    return v.value
+                return None
+    return func.name
+
+
+def task_decorator(
+    func: ast.FunctionDef | ast.AsyncFunctionDef, prov: ImportProvenance
+) -> ast.expr | None:
+    """Return the SDK ``@task`` decorator on *func*, if any."""
+    for dec in func.decorator_list:
+        if is_task_decorator(dec, prov):
+            return dec
+    return None
+
+
+_TOKEN_SPLIT = re.compile(r"[^a-z0-9]+")
+
+
+def has_preflight_token(name: str) -> bool:
+    """True if ``preflight`` appears as a whole token in *name* (snake or kebab)."""
+    return "preflight" in _TOKEN_SPLIT.split(name.lower())
+
+
+def _first_param_annotation_name(
+    func: ast.FunctionDef | ast.AsyncFunctionDef, aliases: dict[str, str]
+) -> str | None:
+    params = _get_non_self_params(func)
+    if not params or params[0].annotation is None:
+        return None
+    name = _annotation_terminal_name(params[0].annotation)
+    return aliases.get(name, name) if name else None
+
+
+def _sdk_handler_base_locals(tree: ast.Module) -> frozenset[str]:
+    """Local names imported from ``application_sdk.handler`` (Handler, DefaultHandler, …)."""
+    locals_: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == _HANDLER_MODULE_PREFIX or module.startswith(
+                _HANDLER_MODULE_PREFIX + "."
+            ):
+                for alias in node.names:
+                    locals_.add(alias.asname or alias.name)
+    return frozenset(locals_)
+
+
+def _class_subclasses_handler(
+    cls: ast.ClassDef,
+    aliases: dict[str, str],
+    by_name: dict[str, ClassRecord],
+    handler_base_locals: frozenset[str],
+) -> bool:
+    """True if *cls* directly or transitively derives from an SDK Handler base."""
+    cache: dict[str, bool | None] = {}
+    for base in cls.bases:
+        bname = base.id if isinstance(base, ast.Name) else getattr(base, "attr", None)
+        if bname is None:
+            continue
+        bname = aliases.get(bname, bname)
+        if bname in handler_base_locals:
+            return True
+        # Transitive: an in-repo intermediate that itself derives from a handler base.
+        for hb in handler_base_locals:
+            if resolve_ancestor(bname, hb, by_name, cache, set()) is True:
+                return True
+    return False
+
+
+def find_preflight_check_sites(
+    reg: Registry,
+) -> list[tuple[Source, ast.AsyncFunctionDef]]:
+    """Return ``(source, method_node)`` for every ``Handler.preflight_check`` override.
+
+    A method qualifies when it is an ``async def preflight_check`` whose enclosing
+    class derives from an SDK Handler base, or whose first non-self parameter is
+    annotated ``PreflightInput`` — either signal alone is a near-unambiguous marker.
+    """
+    sites: list[tuple[Source, ast.AsyncFunctionDef]] = []
+    for src in reg.sources:
+        handler_locals = _sdk_handler_base_locals(src.tree)
+        for cls in _class_defs(src.tree):
+            is_handler = _class_subclasses_handler(
+                cls, src.aliases, reg.by_name, handler_locals
+            )
+            for func in _iter_class_body_methods(cls):
+                if func.name != "preflight_check" or not isinstance(
+                    func, ast.AsyncFunctionDef
+                ):
+                    continue
+                if is_handler or _first_param_annotation_name(func, src.aliases) == (
+                    src.aliases.get(_PREFLIGHT_INPUT, _PREFLIGHT_INPUT)
+                ):
+                    sites.append((src, func))
+    return sites
+
+
+def sdk_preflightcheck_locals(tree: ast.Module) -> frozenset[str]:
+    """Local names bound to the SDK ``PreflightCheck`` via ``from … import PreflightCheck``."""
+    locals_: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if any(
+                module == p or module.startswith(p + ".")
+                for p in _SDK_CONTRACT_MODULE_PREFIXES
+            ):
+                for alias in node.names:
+                    if alias.name == _PREFLIGHT_CHECK:
+                        locals_.add(alias.asname or alias.name)
+    return frozenset(locals_)
+
+
+def is_preflightcheck_call(
+    func: ast.expr, local_names: frozenset[str], module_aliases: frozenset[str]
+) -> bool:
+    """True if a call's callee resolves to the SDK ``PreflightCheck`` constructor."""
+    if isinstance(func, ast.Name):
+        return func.id in local_names
+    if isinstance(func, ast.Attribute):
+        return (
+            func.attr == _PREFLIGHT_CHECK
+            and isinstance(func.value, ast.Name)
+            and func.value.id in module_aliases
+        )
+    return False
+
+
+def collect_entrypoint_input_contract_names(reg: Registry) -> frozenset[str]:
+    """Class names of every entrypoint *input* contract (outputs excluded).
+
+    Fork of ``_entrypoint_contract_fields.collect_entrypoint_contract_names`` with
+    the ``func.returns`` (output) branch dropped, so the gate-path metadata parity
+    check compares only against what the extraction input actually carries.
+    """
+    contracts: set[str] = set()
+    app_cache: dict[str, bool | None] = {}
+    for src in reg.sources:
+        for cls in _class_defs(src.tree):
+            for func in _iter_class_body_methods(cls):
+                is_ep = False
+                if any(
+                    is_entrypoint_decorator(d, src.prov) for d in func.decorator_list
+                ):
+                    is_ep = True
+                elif any(is_task_decorator(d, src.prov) for d in func.decorator_list):
+                    continue
+                elif func.name == "run" and isinstance(func, ast.AsyncFunctionDef):
+                    for base in cls.bases:
+                        bname = (
+                            base.id
+                            if isinstance(base, ast.Name)
+                            else getattr(base, "attr", None)
+                        )
+                        if bname is None:
+                            continue
+                        bname = src.aliases.get(bname, bname)
+                        if (
+                            bname == "App"
+                            or resolve_ancestor(
+                                bname, "App", reg.by_name, app_cache, set()
+                            )
+                            is True
+                        ):
+                            is_ep = True
+                            break
+                if not is_ep:
+                    continue
+                non_self = _get_non_self_params(func)
+                if non_self and non_self[0].annotation is not None:
+                    name = _annotation_terminal_name(non_self[0].annotation)
+                    if name:
+                        contracts.add(src.aliases.get(name, name))
+    return frozenset(contracts)
+
+
+def norm_key(key: str) -> str:
+    """Fold hyphen/underscore so ``include-database-regex`` == ``include_database_regex``."""
+    return key.replace("-", "_")
+
+
+def _class_defs(tree: ast.Module) -> list[ast.ClassDef]:
+    return [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]

--- a/packages/conformance/conformance/suite/checks/preflight/_metadata_parity.py
+++ b/packages/conformance/conformance/suite/checks/preflight/_metadata_parity.py
@@ -1,0 +1,198 @@
+"""P035 PreflightMetadataContractParity.
+
+On the gate path ``PreflightInput.metadata`` is rebuilt from the extraction
+input's ``model_dump()``, so only fields declared on an entrypoint ``Input``
+contract survive. A metadata key read inside ``preflight_check`` that is absent
+from the union of every entrypoint Input contract's field names and aliases is
+silently missing there, and a defensive ``.get(key, default)`` read passes
+vacuously with the wrong config.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from conformance.suite.checks._ast_common import make_finding
+from conformance.suite.checks._entrypoint_contract_fields import resolve_contract_fields
+from conformance.suite.checks.prescriptions._error_code_prefix import ClassRecord
+from conformance.suite.checks.prescriptions._typed_boundaries import (
+    _get_non_self_params,
+)
+from conformance.suite.schema.findings import Finding
+
+from ._common import (
+    Registry,
+    collect_entrypoint_input_contract_names,
+    find_preflight_check_sites,
+    norm_key,
+)
+
+_P035 = "P035"
+
+
+def scan(reg: Registry) -> list[Finding]:
+    input_contracts = collect_entrypoint_input_contract_names(reg)
+    if not input_contracts:
+        return []
+
+    allowed: set[str] = set()
+    for name in input_contracts:
+        rec = reg.by_name.get(name)
+        if rec is None:
+            # Entrypoint input is an external/generated type we cannot resolve —
+            # its field set is unknown, so we cannot make a parity claim.
+            return []
+        if _opts_into_extras(name, reg, set()):
+            return []
+        aliases = reg.aliases_by_rel.get(rec.file, {})
+        for fi in resolve_contract_fields(rec.node, aliases, reg.by_name):
+            allowed.add(norm_key(fi.name))
+        allowed.update(norm_key(a) for a in _collect_field_aliases(name, reg, set()))
+
+    findings: list[Finding] = []
+    for src, func in find_preflight_check_sites(reg):
+        params = _get_non_self_params(func)
+        if not params:
+            continue
+        param = params[0].arg
+        for key, node in _metadata_reads(func, param):
+            if norm_key(key) not in allowed:
+                findings.append(
+                    make_finding(
+                        filename=src.rel,
+                        rule_id=_P035,
+                        node=node,
+                        message=(
+                            f"preflight_check reads metadata key '{key}', which is not a "
+                            f"field on any entrypoint Input contract "
+                            f"({', '.join(sorted(input_contracts))}). On the gate path "
+                            "metadata is rebuilt from the extraction input's model_dump, "
+                            "so this key is silently absent and the read passes vacuously. "
+                            "Declare it on the extraction input contract or stop reading it."
+                        ),
+                        directives=src.directives,
+                    )
+                )
+    return findings
+
+
+def _metadata_reads(
+    func: ast.AsyncFunctionDef, param: str
+) -> list[tuple[str, ast.AST]]:
+    """Return ``(key, node)`` for literal ``<param>.metadata.get("k")`` / ``[...]`` reads."""
+    reads: list[tuple[str, ast.AST]] = []
+    for node in ast.walk(func):
+        if isinstance(node, ast.Call) and _is_metadata_get(node, param):
+            if node.args and _str_const(node.args[0]) is not None:
+                reads.append((_str_const(node.args[0]), node))  # type: ignore[arg-type]
+        elif isinstance(node, ast.Subscript) and _is_metadata_attr(node.value, param):
+            key = _str_const(node.slice)
+            if key is not None:
+                reads.append((key, node))
+    return reads
+
+
+def _is_metadata_get(call: ast.Call, param: str) -> bool:
+    func = call.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "get"
+        and _is_metadata_attr(func.value, param)
+    )
+
+
+def _is_metadata_attr(node: ast.expr, param: str) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "metadata"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == param
+    )
+
+
+def _str_const(node: ast.expr) -> str | None:
+    return (
+        node.value
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        else None
+    )
+
+
+def _collect_field_aliases(name: str, reg: Registry, seen: set[str]) -> set[str]:
+    """Field aliases declared on *name* and its in-repo ancestor contracts."""
+    if name in seen:
+        return set()
+    seen.add(name)
+    rec = reg.by_name.get(name)
+    if rec is None:
+        return set()
+    aliases: set[str] = set()
+    for stmt in rec.node.body:
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.value, ast.Call):
+            aliases.update(_field_call_aliases(stmt.value))
+    for base in rec.bases:
+        aliases.update(_collect_field_aliases(base, reg, seen))
+    return aliases
+
+
+def _field_call_aliases(call: ast.Call) -> set[str]:
+    if not _is_field_call(call):
+        return set()
+    out: set[str] = set()
+    for kw in call.keywords:
+        if kw.arg in ("alias", "serialization_alias"):
+            val = _str_const(kw.value)
+            if val is not None:
+                out.add(val)
+        elif kw.arg == "validation_alias":
+            if isinstance(kw.value, ast.Call):
+                out.update(a for a in map(_str_const, kw.value.args) if a is not None)
+            else:
+                val = _str_const(kw.value)
+                if val is not None:
+                    out.add(val)
+    return out
+
+
+def _is_field_call(call: ast.Call) -> bool:
+    func = call.func
+    return (isinstance(func, ast.Name) and func.id == "Field") or (
+        isinstance(func, ast.Attribute) and func.attr == "Field"
+    )
+
+
+def _opts_into_extras(name: str, reg: Registry, seen: set[str]) -> bool:
+    """True if *name* or an in-repo ancestor allows extra/unbounded fields."""
+    if name in seen:
+        return False
+    seen.add(name)
+    rec: ClassRecord | None = reg.by_name.get(name)
+    if rec is None:
+        return False
+    for kw in rec.node.keywords:
+        if (
+            kw.arg == "allow_unbounded_fields"
+            and isinstance(kw.value, ast.Constant)
+            and bool(kw.value.value)
+        ):
+            return True
+    for stmt in rec.node.body:
+        targets = (
+            stmt.targets
+            if isinstance(stmt, ast.Assign)
+            else [stmt.target]
+            if isinstance(stmt, ast.AnnAssign)
+            else []
+        )
+        is_model_config = any(
+            isinstance(t, ast.Name) and t.id == "model_config" for t in targets
+        )
+        if is_model_config and isinstance(stmt.value, ast.Call):
+            for kw in stmt.value.keywords:
+                if (
+                    kw.arg == "extra"
+                    and isinstance(kw.value, ast.Constant)
+                    and kw.value.value == "allow"
+                ):
+                    return True
+    return any(_opts_into_extras(base, reg, seen) for base in rec.bases)

--- a/packages/conformance/conformance/suite/checks/preflight/_metadata_parity.py
+++ b/packages/conformance/conformance/suite/checks/preflight/_metadata_parity.py
@@ -120,14 +120,39 @@ def _str_const(node: ast.expr) -> str | None:
     )
 
 
+def _config_allows_extra(value: ast.expr) -> bool:
+    """True if a ``model_config`` value opts into extra keys.
+
+    Both pydantic v2 forms count and mirror the SDK runtime check
+    (``base.py`` ``model_config.get("extra") == "allow"``): the
+    ``ConfigDict(extra="allow")`` call and the dict literal ``{"extra": "allow"}``.
+    """
+    if isinstance(value, ast.Call):
+        return any(
+            kw.arg == "extra"
+            and isinstance(kw.value, ast.Constant)
+            and kw.value.value == "allow"
+            for kw in value.keywords
+        )
+    if isinstance(value, ast.Dict):
+        return any(
+            isinstance(k, ast.Constant)
+            and k.value == "extra"
+            and isinstance(v, ast.Constant)
+            and v.value == "allow"
+            for k, v in zip(value.keys, value.values)
+        )
+    return False
+
+
 def _opts_into_extra_keys(name: str, reg: Registry, seen: set[str]) -> bool:
     """True if *name* or an in-repo ancestor keeps undeclared keys (``extra="allow"``).
 
-    Only a genuine ``model_config = ConfigDict(extra="allow")`` counts. Note that
-    ``allow_unbounded_fields=True`` does NOT: it only skips payload-safety type
-    validation (``application_sdk/contracts/base.py`` ``__init_subclass__``); the
-    extra policy stays pydantic-default ``"ignore"``, so undeclared metadata keys
-    are still dropped — exactly the drift P035 must keep catching.
+    Only a genuine ``model_config`` opting into extras counts (``ConfigDict(extra="allow")``
+    or the dict-literal form). Note that ``allow_unbounded_fields=True`` does NOT: it only
+    skips payload-safety type validation (``application_sdk/contracts/base.py``
+    ``__init_subclass__``); the extra policy stays pydantic-default ``"ignore"``, so
+    undeclared metadata keys are still dropped — exactly the drift P035 must keep catching.
     """
     if name in seen:
         return False
@@ -146,12 +171,10 @@ def _opts_into_extra_keys(name: str, reg: Registry, seen: set[str]) -> bool:
         is_model_config = any(
             isinstance(t, ast.Name) and t.id == "model_config" for t in targets
         )
-        if is_model_config and isinstance(stmt.value, ast.Call):
-            for kw in stmt.value.keywords:
-                if (
-                    kw.arg == "extra"
-                    and isinstance(kw.value, ast.Constant)
-                    and kw.value.value == "allow"
-                ):
-                    return True
+        if (
+            is_model_config
+            and stmt.value is not None
+            and _config_allows_extra(stmt.value)
+        ):
+            return True
     return any(_opts_into_extra_keys(base, reg, seen) for base in rec.bases)

--- a/packages/conformance/conformance/suite/checks/preflight/_metadata_parity.py
+++ b/packages/conformance/conformance/suite/checks/preflight/_metadata_parity.py
@@ -1,11 +1,14 @@
 """P035 PreflightMetadataContractParity.
 
 On the gate path ``PreflightInput.metadata`` is rebuilt from the extraction
-input's ``model_dump()``, so only fields declared on an entrypoint ``Input``
-contract survive. A metadata key read inside ``preflight_check`` that is absent
-from the union of every entrypoint Input contract's field names and aliases is
-silently missing there, and a defensive ``.get(key, default)`` read passes
-vacuously with the wrong config.
+input's ``model_dump()`` (``by_alias=False`` → field *names*, plus the
+underscore→hyphen variant added by ``_config_from_snapshot``). A metadata key
+read inside ``preflight_check`` that is absent from the union of every entrypoint
+Input contract's field names is silently missing there, and a defensive
+``.get(key, default)`` read passes vacuously with the wrong config. Field
+*aliases* are deliberately not treated as allowed: ``model_dump`` does not emit
+them, so a read via a differently-stemmed alias genuinely misses at runtime and
+should fire.
 """
 
 from __future__ import annotations
@@ -42,12 +45,11 @@ def scan(reg: Registry) -> list[Finding]:
             # Entrypoint input is an external/generated type we cannot resolve —
             # its field set is unknown, so we cannot make a parity claim.
             return []
-        if _opts_into_extras(name, reg, set()):
+        if _opts_into_extra_keys(name, reg, set()):
             return []
         aliases = reg.aliases_by_rel.get(rec.file, {})
         for fi in resolve_contract_fields(rec.node, aliases, reg.by_name):
             allowed.add(norm_key(fi.name))
-        allowed.update(norm_key(a) for a in _collect_field_aliases(name, reg, set()))
 
     findings: list[Finding] = []
     for src, func in find_preflight_check_sites(reg):
@@ -118,64 +120,21 @@ def _str_const(node: ast.expr) -> str | None:
     )
 
 
-def _collect_field_aliases(name: str, reg: Registry, seen: set[str]) -> set[str]:
-    """Field aliases declared on *name* and its in-repo ancestor contracts."""
-    if name in seen:
-        return set()
-    seen.add(name)
-    rec = reg.by_name.get(name)
-    if rec is None:
-        return set()
-    aliases: set[str] = set()
-    for stmt in rec.node.body:
-        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.value, ast.Call):
-            aliases.update(_field_call_aliases(stmt.value))
-    for base in rec.bases:
-        aliases.update(_collect_field_aliases(base, reg, seen))
-    return aliases
+def _opts_into_extra_keys(name: str, reg: Registry, seen: set[str]) -> bool:
+    """True if *name* or an in-repo ancestor keeps undeclared keys (``extra="allow"``).
 
-
-def _field_call_aliases(call: ast.Call) -> set[str]:
-    if not _is_field_call(call):
-        return set()
-    out: set[str] = set()
-    for kw in call.keywords:
-        if kw.arg in ("alias", "serialization_alias"):
-            val = _str_const(kw.value)
-            if val is not None:
-                out.add(val)
-        elif kw.arg == "validation_alias":
-            if isinstance(kw.value, ast.Call):
-                out.update(a for a in map(_str_const, kw.value.args) if a is not None)
-            else:
-                val = _str_const(kw.value)
-                if val is not None:
-                    out.add(val)
-    return out
-
-
-def _is_field_call(call: ast.Call) -> bool:
-    func = call.func
-    return (isinstance(func, ast.Name) and func.id == "Field") or (
-        isinstance(func, ast.Attribute) and func.attr == "Field"
-    )
-
-
-def _opts_into_extras(name: str, reg: Registry, seen: set[str]) -> bool:
-    """True if *name* or an in-repo ancestor allows extra/unbounded fields."""
+    Only a genuine ``model_config = ConfigDict(extra="allow")`` counts. Note that
+    ``allow_unbounded_fields=True`` does NOT: it only skips payload-safety type
+    validation (``application_sdk/contracts/base.py`` ``__init_subclass__``); the
+    extra policy stays pydantic-default ``"ignore"``, so undeclared metadata keys
+    are still dropped — exactly the drift P035 must keep catching.
+    """
     if name in seen:
         return False
     seen.add(name)
     rec: ClassRecord | None = reg.by_name.get(name)
     if rec is None:
         return False
-    for kw in rec.node.keywords:
-        if (
-            kw.arg == "allow_unbounded_fields"
-            and isinstance(kw.value, ast.Constant)
-            and bool(kw.value.value)
-        ):
-            return True
     for stmt in rec.node.body:
         targets = (
             stmt.targets
@@ -195,4 +154,4 @@ def _opts_into_extras(name: str, reg: Registry, seen: set[str]) -> bool:
                     and kw.value.value == "allow"
                 ):
                     return True
-    return any(_opts_into_extras(base, reg, seen) for base in rec.bases)
+    return any(_opts_into_extra_keys(base, reg, seen) for base in rec.bases)

--- a/packages/conformance/conformance/suite/checks/preflight/_metadata_parity.py
+++ b/packages/conformance/conformance/suite/checks/preflight/_metadata_parity.py
@@ -149,7 +149,7 @@ def _opts_into_extra_keys(name: str, reg: Registry, seen: set[str]) -> bool:
     """True if *name* or an in-repo ancestor keeps undeclared keys (``extra="allow"``).
 
     Only a genuine ``model_config`` opting into extras counts (``ConfigDict(extra="allow")``
-    or the dict-literal form). Note that ``allow_unbounded_fields=True`` does NOT: it only
+    or ``{"extra": "allow"}``). Note that ``allow_unbounded_fields=True`` does NOT: it only
     skips payload-safety type validation (``application_sdk/contracts/base.py``
     ``__init_subclass__``); the extra policy stays pydantic-default ``"ignore"``, so
     undeclared metadata keys are still dropped — exactly the drift P035 must keep catching.

--- a/packages/conformance/conformance/suite/checks/preflight/_reserved_gate.py
+++ b/packages/conformance/conformance/suite/checks/preflight/_reserved_gate.py
@@ -1,0 +1,75 @@
+"""P032 ReservedPreflightActivityName + P033 DuplicateInWorkflowPreflight.
+
+Both consume the same ``@task``-name pass. P032 fires on a task whose effective
+activity name is exactly ``preflight`` (collides with the SDK-reserved gate
+name). P033 fires on a task whose name carries a ``preflight`` token but is not
+that exact name, and only when the app also defines a ``Handler.preflight_check``
+(the two implementations drift). The two are mutually exclusive.
+"""
+
+from __future__ import annotations
+
+from conformance.suite.checks._ast_common import make_finding
+from conformance.suite.schema.findings import Finding
+
+from ._common import (
+    Registry,
+    _class_defs,
+    _iter_class_body_methods,
+    effective_task_name,
+    find_preflight_check_sites,
+    has_preflight_token,
+    task_decorator,
+)
+
+_P032 = "P032"
+_P033 = "P033"
+
+
+def scan(reg: Registry) -> list[Finding]:
+    preflight_sites = find_preflight_check_sites(reg)
+    handler_site = preflight_sites[0] if preflight_sites else None
+
+    findings: list[Finding] = []
+    for src in reg.sources:
+        for cls in _class_defs(src.tree):
+            for func in _iter_class_body_methods(cls):
+                dec = task_decorator(func, src.prov)
+                if dec is None:
+                    continue
+                name = effective_task_name(func, dec)
+                if name is None:
+                    continue
+                if name == "preflight":
+                    findings.append(
+                        make_finding(
+                            filename=src.rel,
+                            rule_id=_P032,
+                            node=func,
+                            message=(
+                                "@task registers the activity name 'preflight', which "
+                                "collides with the SDK-reserved preflight-gate activity "
+                                "'{app_name}:preflight'; the worker fails to boot with "
+                                "WorkerActivityNameCollisionError. Rename the task or "
+                                "fold it into Handler.preflight_check."
+                            ),
+                            directives=src.directives,
+                        )
+                    )
+                elif handler_site is not None and has_preflight_token(name):
+                    findings.append(
+                        make_finding(
+                            filename=src.rel,
+                            rule_id=_P033,
+                            node=func,
+                            message=(
+                                f"@task '{name}' is a second preflight implementation "
+                                f"alongside Handler.preflight_check ({handler_site[0].rel}:"
+                                f"{handler_site[1].lineno}); the two drift. "
+                                "The SDK gate calls preflight_check — remove the "
+                                "app-owned preflight activity."
+                            ),
+                            directives=src.directives,
+                        )
+                    )
+    return findings

--- a/packages/conformance/conformance/suite/checks/preflight/_reserved_gate.py
+++ b/packages/conformance/conformance/suite/checks/preflight/_reserved_gate.py
@@ -9,11 +9,14 @@ that exact name, and only when the app also defines a ``Handler.preflight_check`
 
 from __future__ import annotations
 
+import ast
+
 from conformance.suite.checks._ast_common import make_finding
 from conformance.suite.schema.findings import Finding
 
 from ._common import (
     Registry,
+    Source,
     _class_defs,
     _iter_class_body_methods,
     effective_task_name,
@@ -26,13 +29,34 @@ _P032 = "P032"
 _P033 = "P033"
 
 
+def _handler_site_for(
+    sites: list[tuple[Source, ast.AsyncFunctionDef]],
+    src: Source,
+    cls: ast.ClassDef,
+) -> tuple[Source, ast.AsyncFunctionDef] | None:
+    """Pick the preflight_check site to reference for a task in *cls*.
+
+    Prefer a handler co-located in the same class, then the same source, and
+    only then fall back to the first site — so the P033 message points at the
+    implementation the offending task actually drifts from.
+    """
+    if not sites:
+        return None
+    class_methods = set(_iter_class_body_methods(cls))
+    same_class = next((s for s in sites if s[0] is src and s[1] in class_methods), None)
+    if same_class is not None:
+        return same_class
+    same_src = next((s for s in sites if s[0] is src), None)
+    return same_src if same_src is not None else sites[0]
+
+
 def scan(reg: Registry) -> list[Finding]:
     preflight_sites = find_preflight_check_sites(reg)
-    handler_site = preflight_sites[0] if preflight_sites else None
 
     findings: list[Finding] = []
     for src in reg.sources:
         for cls in _class_defs(src.tree):
+            handler_site = _handler_site_for(preflight_sites, src, cls)
             for func in _iter_class_body_methods(cls):
                 dec = task_decorator(func, src.prov)
                 if dec is None:

--- a/packages/conformance/conformance/suite/checks/preflight/_untyped_failure.py
+++ b/packages/conformance/conformance/suite/checks/preflight/_untyped_failure.py
@@ -1,0 +1,61 @@
+"""P034 UntypedPreflightCheckFailure.
+
+Flags a ``PreflightCheck(...)`` constructed with an explicit ``passed=False`` and
+no typed ``error=`` (absent, or the literal ``None``). Only the SDK
+``PreflightCheck`` is matched — a locally-defined same-named class is ignored.
+Requiring the explicit ``passed=False`` literal keeps false positives near zero:
+bare ``PreflightCheck(name=...)`` templates and non-literal ``passed`` are left
+alone.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from conformance.suite.checks._ast_common import make_finding
+from conformance.suite.schema.findings import Finding
+
+from ._common import Registry, is_preflightcheck_call, sdk_preflightcheck_locals
+
+_P034 = "P034"
+_MISSING = object()
+
+
+def scan(reg: Registry) -> list[Finding]:
+    findings: list[Finding] = []
+    for src in reg.sources:
+        local_names = sdk_preflightcheck_locals(src.tree)
+        module_aliases = src.prov.sdk_contract_module_aliases
+        if not local_names and not module_aliases:
+            continue
+        for node in ast.walk(src.tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not is_preflightcheck_call(node.func, local_names, module_aliases):
+                continue
+            kwargs = {kw.arg: kw.value for kw in node.keywords if kw.arg is not None}
+            passed = kwargs.get("passed")
+            if not (isinstance(passed, ast.Constant) and passed.value is False):
+                continue
+            error = kwargs.get("error", _MISSING)
+            error_typed = not (
+                error is _MISSING
+                or (isinstance(error, ast.Constant) and error.value is None)
+            )
+            if error_typed:
+                continue
+            findings.append(
+                make_finding(
+                    filename=src.rel,
+                    rule_id=_P034,
+                    node=node,
+                    message=(
+                        "PreflightCheck(passed=False) has no typed error=; the gate "
+                        "falls back to the generic PREFLIGHT_CHECK_FAILED code and the "
+                        "Automation Engine loses category/code/audience/suggested_action. "
+                        "Pass error=<AppError>.to_failure_details()."
+                    ),
+                    directives=src.directives,
+                )
+            )
+    return findings

--- a/packages/conformance/conformance/suite/checks/preflight/_untyped_failure.py
+++ b/packages/conformance/conformance/suite/checks/preflight/_untyped_failure.py
@@ -33,7 +33,11 @@ def scan(reg: Registry) -> list[Finding]:
                 continue
             if not is_preflightcheck_call(node.func, local_names, module_aliases):
                 continue
-            kwargs = {kw.arg: kw.value for kw in node.keywords if kw.arg is not None}
+            if any(kw.arg is None for kw in node.keywords):
+                # ``**expansion`` may carry a typed error=; skip rather than
+                # false-fire, matching the rule's false-negative-over-false-positive stance.
+                continue
+            kwargs = {kw.arg: kw.value for kw in node.keywords}
             passed = kwargs.get("passed")
             if not (isinstance(passed, ast.Constant) and passed.value is False):
                 continue

--- a/packages/conformance/conformance/suite/rules/__init__.py
+++ b/packages/conformance/conformance/suite/rules/__init__.py
@@ -25,6 +25,7 @@ from conformance.suite.rules.error_handling import RULES as _E_RULES
 from conformance.suite.rules.logging import RULES as _L_RULES
 from conformance.suite.rules.optimizations import RULES as _O_RULES
 from conformance.suite.rules.orchestration import RULES as _ORCHESTRATION_RULES
+from conformance.suite.rules.preflight import RULES as _PREFLIGHT_RULES
 from conformance.suite.rules.prescriptions import RULES as _P_RULES
 from conformance.suite.rules.sdr import RULES as _SDR_RULES
 from conformance.suite.rules.security import RULES as _S_RULES
@@ -52,6 +53,7 @@ _ALL_SERIES: tuple[tuple[RuleDefinition, ...], ...] = (
     _I_RULES,
     _O_RULES,
     _P_RULES,
+    _PREFLIGHT_RULES,
     _ORCHESTRATION_RULES,
     _DETERMINISM_RULES,
     _ENTRYPOINT_RULES,

--- a/packages/conformance/conformance/suite/rules/preflight.py
+++ b/packages/conformance/conformance/suite/rules/preflight.py
@@ -157,17 +157,18 @@ RULES: tuple[RuleDefinition, ...] = (
             "(``_config_from_snapshot``), so only fields declared on an entrypoint "
             "``Input`` contract survive. A key read inside ``preflight_check`` via "
             '``input.metadata.get("key", ...)`` or ``input.metadata["key"]`` that is '
-            "absent from the union of every entrypoint Input contract's fields (and "
-            "their aliases) is silently missing on the gate path, so a defensive "
-            "``.get(key, default)`` read passes vacuously with the wrong configuration "
-            "(e.g. database scoping silently dropped).\n"
+            "absent from the union of every entrypoint Input contract's fields is "
+            "silently missing on the gate path, so a defensive ``.get(key, default)`` "
+            "read passes vacuously with the wrong configuration (e.g. database scoping "
+            "silently dropped).\n"
             "\n"
             "Remediation: declare the key as a field on the extraction input contract "
-            "(matching the UI form), or stop reading it in ``preflight_check``. Keys and "
-            "field aliases are compared with underscore/hyphen normalization. The rule "
-            "does not fire when no entrypoint Input contract is resolvable or when a "
-            'contract opts into extra fields (``extra="allow"`` / '
-            "``allow_unbounded_fields=True``)."
+            "(matching the UI form), or stop reading it in ``preflight_check``. Keys are "
+            "compared to contract field names with underscore/hyphen normalization; field "
+            "aliases are not treated as allowed because ``model_dump`` emits field names, "
+            "not aliases. The rule does not fire when no entrypoint Input contract is "
+            "resolvable or when a contract opts into extra keys ("
+            '``model_config = ConfigDict(extra="allow")``).'
         ),
         help_uri=f"{_HELP_BASE}#p035",
     ),

--- a/packages/conformance/conformance/suite/rules/preflight.py
+++ b/packages/conformance/conformance/suite/rules/preflight.py
@@ -1,0 +1,174 @@
+"""Preflight-gate rule definitions (P-series, BLDX-1545).
+
+The SDK injects a mandatory ``{app_name}:preflight`` activity as the first step
+of every extraction workflow; it runs the app's ``Handler.preflight_check`` and
+blocks the run on a ``NOT_READY`` verdict (application-sdk PRs #2361, #2626).
+These four rules make the gate pattern statically enforceable across the fleet:
+they surface a boot-time collision at review time (P032), the app-owned duplicate
+that drifts from the gate (P033), untyped failure results that lose their wire
+metadata (P034), and the silent metadata/contract drift that no runtime signal
+can catch (P035).
+
+The detector lives in ``suite.checks.preflight``; these rules reuse the ``P``
+series so they run on the existing P leg of the fleet CI matrix with no workflow
+change. Per the P-series stability policy (see ``prescriptions.py``) a P-id is a
+permanent public contract and is never renumbered or reused.
+"""
+
+from __future__ import annotations
+
+from conformance.suite.schema.catalog import RuleDefinition
+from conformance.suite.schema.disposition import (
+    EnforcementTier,
+    RuleMechanism,
+    RuleScope,
+)
+
+_HELP_BASE = (
+    "https://github.com/atlanhq/application-sdk/blob/main/"
+    "packages/conformance/conformance/docs/rules/prescriptions.md"
+)
+
+RULES: tuple[RuleDefinition, ...] = (
+    RuleDefinition(
+        id="P032",
+        scope=RuleScope.APP,
+        name="ReservedPreflightActivityName",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="preflight-gate",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.15.0",
+        rationale=(
+            "The SDK injects a mandatory pre-extraction gate as the activity "
+            "'{app_name}:preflight'. An app @task that also registers the 'preflight' "
+            "activity name collides with it: the worker raises "
+            "WorkerActivityNameCollisionError at boot and never starts. Catching the "
+            "collision statically surfaces it in the PR instead of on the first deploy."
+        ),
+        short_description=(
+            "An app @task registers the 'preflight' activity name reserved by the SDK gate"
+        ),
+        full_description=(
+            "The SDK reserves the activity name ``{app_name}:preflight`` for the "
+            "injected preflight gate and registers it unconditionally on the worker. "
+            "An app ``@task`` whose effective activity name is ``preflight`` (an explicit "
+            '``@task(name="preflight")`` or a bare ``@task`` on a method named '
+            "``preflight``) collides with the reserved name; worker boot fails with "
+            "``WorkerActivityNameCollisionError``.\n"
+            "\n"
+            "Remediation: rename the task, or fold its logic into the app's "
+            "``Handler.preflight_check`` (which the gate already calls). A non-literal "
+            "``@task(name=<expr>)`` is not statically resolvable and is not flagged."
+        ),
+        help_uri=f"{_HELP_BASE}#p032",
+    ),
+    RuleDefinition(
+        id="P033",
+        scope=RuleScope.APP,
+        name="DuplicateInWorkflowPreflight",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="preflight-gate",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.15.0",
+        rationale=(
+            "An app that defines Handler.preflight_check AND its own preflight-named "
+            "@task has two preflight implementations that inevitably drift. The gate "
+            "runs preflight_check, so the app-owned activity is redundant — the exact "
+            "anti-pattern the SDK-native gate eliminates."
+        ),
+        short_description=(
+            "App defines Handler.preflight_check and a separate preflight-named @task that will drift"
+        ),
+        full_description=(
+            "When an app declares a ``Handler.preflight_check`` and also registers its "
+            "own preflight-named ``@task`` (any ``@task`` whose effective name contains "
+            "``preflight`` as a token but is not the reserved gate name — that exact "
+            "case is P032), the two preflight paths diverge over time. The SDK gate "
+            "invokes ``Handler.preflight_check``; the app-owned activity is dead weight "
+            "that silently rots.\n"
+            "\n"
+            "Remediation: delete the app-owned preflight activity and keep the single "
+            "``Handler.preflight_check`` implementation the gate calls."
+        ),
+        help_uri=f"{_HELP_BASE}#p033",
+    ),
+    RuleDefinition(
+        id="P034",
+        scope=RuleScope.APP,
+        name="UntypedPreflightCheckFailure",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="preflight-gate",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.15.0",
+        rationale=(
+            "A failed PreflightCheck constructed without a typed error= falls back to "
+            "the generic PREFLIGHT_CHECK_FAILED code, so the Automation Engine and the "
+            "UI lose the category/code/audience/suggested_action the typed form carries "
+            "on the wire. This points at the exact lines to migrate to typed failures."
+        ),
+        short_description=(
+            "PreflightCheck(passed=False) constructed without a typed error= — untyped failure"
+        ),
+        full_description=(
+            "A ``PreflightCheck`` with an explicit ``passed=False`` and no typed "
+            "``error=`` (absent, or the literal ``None``) is an untyped failure: the "
+            "gate falls back to the generic ``PREFLIGHT_CHECK_FAILED`` code and only the "
+            "deprecated free-text ``message`` reaches the caller. The typed form "
+            "``error=AuthError(message=..., suggested_action=..., cause=exc)"
+            ".to_failure_details()`` carries category / code / audience / retryable / "
+            "suggested_action to the Automation Engine and the UI.\n"
+            "\n"
+            "Only an explicit ``passed=False`` literal is flagged; a failure expressed "
+            "purely by the default ``passed`` and a non-literal ``passed`` are left "
+            "alone to keep false positives near zero. A locally-defined, non-SDK class "
+            "named ``PreflightCheck`` is not flagged."
+        ),
+        help_uri=f"{_HELP_BASE}#p034",
+    ),
+    RuleDefinition(
+        id="P035",
+        scope=RuleScope.APP,
+        name="PreflightMetadataContractParity",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="preflight-gate",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.15.0",
+        rationale=(
+            "On the gate path metadata is rebuilt from the extraction input's "
+            "model_dump, so a metadata key that is not a field on any entrypoint Input "
+            "contract is silently absent — a defensive input.metadata.get(key, default) "
+            "read then passes vacuously with the wrong config. No runtime signal can "
+            "catch this class of silent drift; the static check is the only guard."
+        ),
+        short_description=(
+            "A preflight_check metadata key is not declared on any entrypoint Input contract"
+        ),
+        full_description=(
+            "The preflight gate does not forward the live UI form: it rebuilds "
+            "``PreflightInput.metadata`` from the extraction input's ``model_dump()`` "
+            "(``_config_from_snapshot``), so only fields declared on an entrypoint "
+            "``Input`` contract survive. A key read inside ``preflight_check`` via "
+            '``input.metadata.get("key", ...)`` or ``input.metadata["key"]`` that is '
+            "absent from the union of every entrypoint Input contract's fields (and "
+            "their aliases) is silently missing on the gate path, so a defensive "
+            "``.get(key, default)`` read passes vacuously with the wrong configuration "
+            "(e.g. database scoping silently dropped).\n"
+            "\n"
+            "Remediation: declare the key as a field on the extraction input contract "
+            "(matching the UI form), or stop reading it in ``preflight_check``. Keys and "
+            "field aliases are compared with underscore/hyphen normalization. The rule "
+            "does not fire when no entrypoint Input contract is resolvable or when a "
+            'contract opts into extra fields (``extra="allow"`` / '
+            "``allow_unbounded_fields=True``)."
+        ),
+        help_uri=f"{_HELP_BASE}#p035",
+    ),
+)

--- a/packages/conformance/conformance/suite/rules/preflight.py
+++ b/packages/conformance/conformance/suite/rules/preflight.py
@@ -167,8 +167,9 @@ RULES: tuple[RuleDefinition, ...] = (
             "compared to contract field names with underscore/hyphen normalization; field "
             "aliases are not treated as allowed because ``model_dump`` emits field names, "
             "not aliases. The rule does not fire when no entrypoint Input contract is "
-            "resolvable or when a contract opts into extra keys ("
-            '``model_config = ConfigDict(extra="allow")``).'
+            "resolvable or when a contract (or an in-repo ancestor) opts into extra keys "
+            "via either ``model_config`` form: "
+            '``ConfigDict(extra="allow")`` or ``{"extra": "allow"}``.'
         ),
         help_uri=f"{_HELP_BASE}#p035",
     ),

--- a/packages/conformance/conformance/suite/runner.py
+++ b/packages/conformance/conformance/suite/runner.py
@@ -46,6 +46,7 @@ from conformance.suite.checks import (
     manifest_contract,
     optimizations,
     orchestration,
+    preflight,
     prescriptions,
     security,
     test_quality,
@@ -182,6 +183,12 @@ _CHECKS: list[CheckRegistration] = [
         discover=app_name_alignment.discover,
         scan_path=app_name_alignment.scan_path,
         scan_all=app_name_alignment.scan_all,
+    ),
+    CheckRegistration(
+        series=preflight.SERIES,
+        discover=preflight.discover,
+        scan_path=preflight.scan_path,
+        scan_all=preflight.scan_all,
     ),
     CheckRegistration(
         series=legacy_contract.SERIES,

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -148,6 +148,10 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
     # the SDK has neither, so this check is meaningless there (BLDX-1491).
     # P029/P030: SDR-readiness — only apps declare self_deployed_runtime; the SDK
     # itself never does, so these are APP-scoped (DISTR-752).
+    # P032–P035: preflight-gate authoring — only apps register @task activities,
+    # define Handler.preflight_check, construct PreflightCheck results, and declare
+    # the entrypoint Input contracts the gate rebuilds metadata from; the SDK
+    # publishes the gate, it is not a subject of these rules (BLDX-1545).
     # T002/T003: SDR test-quality — apps that declare SDR must have an SDR test
     # class; the SDK itself is not an SDR app (DISTR-752).
     # T004: dev-entrypoint delegation — only consumer apps have a root main.py
@@ -228,6 +232,10 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
         "P028",
         "P029",
         "P030",
+        "P032",
+        "P033",
+        "P034",
+        "P035",
         "T002",
         "T003",
         "T004",
@@ -377,6 +385,9 @@ def test_catalog_p_series_present() -> None:
     P031 is SharedDefaultExecutorOffload — asyncio.to_thread(...) /
     run_in_executor(None, ...) bypass the SDK's dedicated run_in_thread() pool
     and land on asyncio's shared default executor instead (BLDX-1525).
+    P032–P035 are the preflight-gate rules — reserved gate-name collision,
+    duplicate in-workflow preflight, untyped check failures, and metadata /
+    input-contract parity (BLDX-1545).
     A stray or renumbered P-id would slip past a subset check while
     breaking fleet-wide ``# conformance: ignore[Pxxx]`` suppressions.
     """
@@ -414,6 +425,10 @@ def test_catalog_p_series_present() -> None:
         "P029",
         "P030",
         "P031",
+        "P032",
+        "P033",
+        "P034",
+        "P035",
     }
     missing = expected - p_ids
     assert not missing, f"Missing P-series rules: {missing}"

--- a/packages/conformance/tests/test_preflight.py
+++ b/packages/conformance/tests/test_preflight.py
@@ -429,6 +429,24 @@ def test_p035_silent_when_contract_allows_extra_keys(tmp_path: Path) -> None:
     assert [f.rule_id for f in _scan(tmp_path, files)] == []
 
 
+def test_p035_silent_on_dict_literal_extra_allow(tmp_path: Path) -> None:
+    # The pydantic v2 dict-literal form opts into extras just like ConfigDict → no parity claim.
+    app = (
+        _APP_IMPORTS
+        + "class ExtractInput(Input):\n"
+        + '    model_config = {"extra": "allow"}\n'
+        + "    include_filter: dict = {}\n"
+        + "class A(App):\n"
+        + "    @entrypoint()\n"
+        + "    async def extract(self, input: ExtractInput) -> None: ...\n"
+    )
+    files = {
+        "app.py": app,
+        "h.py": _handler_reading('x = input.metadata.get("anything")'),
+    }
+    assert [f.rule_id for f in _scan(tmp_path, files)] == []
+
+
 def test_p035_fires_despite_allow_unbounded_fields(tmp_path: Path) -> None:
     # allow_unbounded_fields only skips payload-safety type checks; the extra policy
     # stays "ignore", so undeclared keys are still dropped and P035 must still fire.

--- a/packages/conformance/tests/test_preflight.py
+++ b/packages/conformance/tests/test_preflight.py
@@ -1,0 +1,361 @@
+"""Meta-tests for the preflight-gate checks (P032–P035, BLDX-1545).
+
+These checks fan out across the fleet, so each rule is tested to fire *exactly*
+when it should and stay silent otherwise — both false positives and false
+negatives are guarded, plus the inline-suppression path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from conformance.suite.checks.preflight import scan_all
+from conformance.suite.rules import get_rule
+from conformance.suite.schema.disposition import (
+    EnforcementTier,
+    RuleMechanism,
+    RuleScope,
+)
+
+_HANDLER_IMPORTS = (
+    "from application_sdk.handler.base import Handler\n"
+    "from application_sdk.handler.contracts import "
+    "PreflightCheck, PreflightInput, PreflightOutput\n"
+)
+_APP_IMPORTS = (
+    "from application_sdk.app import App, task, entrypoint\n"
+    "from application_sdk.contracts import Input\n"
+    "from pydantic import Field\n"
+)
+
+
+def _scan(tmp_path: Path, files: dict[str, str]) -> list:
+    paths: list[Path] = []
+    for name, src in files.items():
+        p = tmp_path / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(src)
+        paths.append(p)
+    return scan_all(paths, tmp_path)
+
+
+def _ids(tmp_path: Path, src: str) -> list[str]:
+    return sorted(f.rule_id for f in _scan(tmp_path, {"m.py": src}))
+
+
+# ── metadata ────────────────────────────────────────────────────────────────
+
+
+def test_rule_metadata() -> None:
+    for rid in ("P032", "P033", "P034", "P035"):
+        rule = get_rule(rid)
+        assert rule.scope is RuleScope.APP
+        assert rule.tier is EnforcementTier.WARN
+        assert rule.mechanism is RuleMechanism.STATIC
+
+
+# ── P032 ReservedPreflightActivityName ────────────────────────────────────────
+
+
+def test_p032_fires_on_explicit_name(tmp_path: Path) -> None:
+    src = (
+        _APP_IMPORTS
+        + "class A(App):\n"
+        + '    @task(name="preflight")\n'
+        + "    async def anything(self): ...\n"
+    )
+    assert _ids(tmp_path, src) == ["P032"]
+
+
+def test_p032_fires_on_bare_task_named_preflight(tmp_path: Path) -> None:
+    src = (
+        _APP_IMPORTS
+        + "class A(App):\n"
+        + "    @task\n"
+        + "    async def preflight(self): ...\n"
+    )
+    assert _ids(tmp_path, src) == ["P032"]
+
+
+def test_p032_silent_on_non_preflight_task(tmp_path: Path) -> None:
+    src = _APP_IMPORTS + "class A(App):\n    @task\n    async def discover(self): ...\n"
+    assert _ids(tmp_path, src) == []
+
+
+def test_p032_silent_on_non_sdk_task(tmp_path: Path) -> None:
+    src = (
+        "from celery import task\n"
+        "class A:\n"
+        "    @task\n"
+        "    async def preflight(self): ...\n"
+    )
+    assert _ids(tmp_path, src) == []
+
+
+def test_p032_silent_on_non_literal_name(tmp_path: Path) -> None:
+    src = (
+        _APP_IMPORTS
+        + "NAME = 'preflight'\n"
+        + "class A(App):\n"
+        + "    @task(name=NAME)\n"
+        + "    async def anything(self): ...\n"
+    )
+    assert _ids(tmp_path, src) == []
+
+
+def test_p032_suppressed(tmp_path: Path) -> None:
+    src = (
+        _APP_IMPORTS
+        + "class A(App):\n"
+        + '    @task(name="preflight")\n'
+        + "    # conformance: ignore[P032] legacy task, migration tracked\n"
+        + "    async def anything(self): ...\n"
+    )
+    findings = _scan(tmp_path, {"m.py": src})
+    assert [f.rule_id for f in findings] == ["P032"]
+    assert findings[0].suppressed is True
+
+
+# ── P033 DuplicateInWorkflowPreflight ──────────────────────────────────────────
+
+
+def _handler_with_preflight(
+    body: str = "        return PreflightOutput(checks=[])\n",
+) -> str:
+    return (
+        _HANDLER_IMPORTS
+        + "class H(Handler):\n"
+        + "    async def preflight_check(self, input: PreflightInput) -> PreflightOutput:\n"
+        + body
+    )
+
+
+def test_p033_fires_when_handler_and_preflight_task_coexist(tmp_path: Path) -> None:
+    app = (
+        _APP_IMPORTS
+        + "class A(App):\n"
+        + "    @task\n"
+        + "    async def run_preflight(self): ...\n"
+    )
+    ids = sorted(
+        f.rule_id
+        for f in _scan(tmp_path, {"app.py": app, "h.py": _handler_with_preflight()})
+    )
+    assert ids == ["P033"]
+
+
+def test_p033_silent_without_handler_preflight(tmp_path: Path) -> None:
+    src = (
+        _APP_IMPORTS
+        + "class A(App):\n    @task\n    async def run_preflight(self): ...\n"
+    )
+    assert _ids(tmp_path, src) == []
+
+
+def test_p033_silent_on_exact_reserved_name_that_is_p032(tmp_path: Path) -> None:
+    app = (
+        _APP_IMPORTS + "class A(App):\n    @task\n    async def preflight(self): ...\n"
+    )
+    ids = sorted(
+        f.rule_id
+        for f in _scan(tmp_path, {"app.py": app, "h.py": _handler_with_preflight()})
+    )
+    assert ids == ["P032"]  # never double-fires P033
+
+
+def test_p033_silent_on_preflight_substring_non_token(tmp_path: Path) -> None:
+    app = (
+        _APP_IMPORTS
+        + "class A(App):\n    @task\n    async def preflightation(self): ...\n"
+    )
+    ids = sorted(
+        f.rule_id
+        for f in _scan(tmp_path, {"app.py": app, "h.py": _handler_with_preflight()})
+    )
+    assert ids == []
+
+
+def test_p033_suppressed(tmp_path: Path) -> None:
+    app = (
+        _APP_IMPORTS
+        + "class A(App):\n"
+        + "    @task\n"
+        + "    # conformance: ignore[P033] kept intentionally, see TICKET-1\n"
+        + "    async def run_preflight(self): ...\n"
+    )
+    findings = _scan(tmp_path, {"app.py": app, "h.py": _handler_with_preflight()})
+    assert [f.rule_id for f in findings] == ["P033"]
+    assert findings[0].suppressed is True
+
+
+# ── P034 UntypedPreflightCheckFailure ──────────────────────────────────────────
+
+
+def _pc(expr: str) -> str:
+    return (
+        "from application_sdk.handler.contracts import PreflightCheck\n"
+        "def make():\n"
+        f"    return {expr}\n"
+    )
+
+
+def test_p034_fires_on_explicit_passed_false(tmp_path: Path) -> None:
+    assert _ids(tmp_path, _pc('PreflightCheck(name="x", passed=False)')) == ["P034"]
+
+
+def test_p034_fires_with_only_deprecated_message(tmp_path: Path) -> None:
+    assert _ids(
+        tmp_path, _pc('PreflightCheck(name="x", passed=False, message="boom")')
+    ) == ["P034"]
+
+
+def test_p034_fires_on_explicit_error_none(tmp_path: Path) -> None:
+    assert _ids(
+        tmp_path, _pc('PreflightCheck(name="x", passed=False, error=None)')
+    ) == ["P034"]
+
+
+def test_p034_silent_with_typed_error(tmp_path: Path) -> None:
+    src = (
+        "from application_sdk.handler.contracts import PreflightCheck\n"
+        "def make(err):\n"
+        '    return PreflightCheck(name="x", passed=False, error=err)\n'
+    )
+    assert _ids(tmp_path, src) == []
+
+
+def test_p034_silent_on_passed_true(tmp_path: Path) -> None:
+    assert _ids(tmp_path, _pc('PreflightCheck(name="x", passed=True)')) == []
+
+
+def test_p034_silent_on_omitted_passed(tmp_path: Path) -> None:
+    # Deliberate false-negative: bare templates are the biggest FP source.
+    assert _ids(tmp_path, _pc('PreflightCheck(name="x")')) == []
+
+
+def test_p034_silent_on_non_literal_passed(tmp_path: Path) -> None:
+    src = (
+        "from application_sdk.handler.contracts import PreflightCheck\n"
+        "def make(ok):\n"
+        '    return PreflightCheck(name="x", passed=ok)\n'
+    )
+    assert _ids(tmp_path, src) == []
+
+
+def test_p034_silent_on_non_sdk_preflightcheck(tmp_path: Path) -> None:
+    src = (
+        "class PreflightCheck:\n    pass\n"
+        "def make():\n"
+        '    return PreflightCheck(name="x", passed=False)\n'
+    )
+    assert _ids(tmp_path, src) == []
+
+
+def test_p034_suppressed(tmp_path: Path) -> None:
+    src = (
+        "from application_sdk.handler.contracts import PreflightCheck\n"
+        "def make():\n"
+        "    # conformance: ignore[P034] migrating to typed errors\n"
+        '    return PreflightCheck(name="x", passed=False)\n'
+    )
+    findings = _scan(tmp_path, {"m.py": src})
+    assert [f.rule_id for f in findings] == ["P034"]
+    assert findings[0].suppressed is True
+
+
+# ── P035 PreflightMetadataContractParity ───────────────────────────────────────
+
+
+def _app_with_input(fields: str) -> str:
+    return (
+        _APP_IMPORTS
+        + "class ExtractInput(Input):\n"
+        + fields
+        + "class A(App):\n"
+        + "    @entrypoint()\n"
+        + "    async def extract(self, input: ExtractInput) -> None: ...\n"
+    )
+
+
+def _handler_reading(*reads: str) -> str:
+    body = "".join(f"        {r}\n" for r in reads)
+    return (
+        _HANDLER_IMPORTS
+        + "class H(Handler):\n"
+        + "    async def preflight_check(self, input: PreflightInput) -> PreflightOutput:\n"
+        + body
+        + "        return PreflightOutput(checks=[])\n"
+    )
+
+
+def test_p035_fires_on_key_absent_from_contract(tmp_path: Path) -> None:
+    files = {
+        "app.py": _app_with_input("    include_filter: dict = {}\n"),
+        "h.py": _handler_reading('x = input.metadata.get("unknown_key")'),
+    }
+    assert sorted(f.rule_id for f in _scan(tmp_path, files)) == ["P035"]
+
+
+def test_p035_silent_on_declared_field(tmp_path: Path) -> None:
+    files = {
+        "app.py": _app_with_input("    include_filter: dict = {}\n"),
+        "h.py": _handler_reading('x = input.metadata.get("include_filter")'),
+    }
+    assert [f.rule_id for f in _scan(tmp_path, files)] == []
+
+
+def test_p035_silent_on_hyphenated_alias_of_field(tmp_path: Path) -> None:
+    files = {
+        "app.py": _app_with_input("    include_filter: dict = {}\n"),
+        "h.py": _handler_reading('x = input.metadata.get("include-filter")'),
+    }
+    assert [f.rule_id for f in _scan(tmp_path, files)] == []
+
+
+def test_p035_silent_on_declared_field_alias(tmp_path: Path) -> None:
+    files = {
+        "app.py": _app_with_input(
+            '    object_filter: dict = Field(default_factory=dict, alias="type")\n'
+        ),
+        "h.py": _handler_reading('x = input.metadata.get("type")'),
+    }
+    assert [f.rule_id for f in _scan(tmp_path, files)] == []
+
+
+def test_p035_silent_on_subscript_read_of_field(tmp_path: Path) -> None:
+    files = {
+        "app.py": _app_with_input("    include_filter: dict = {}\n"),
+        "h.py": _handler_reading('x = input.metadata["include_filter"]'),
+    }
+    assert [f.rule_id for f in _scan(tmp_path, files)] == []
+
+
+def test_p035_silent_on_dynamic_key(tmp_path: Path) -> None:
+    files = {
+        "app.py": _app_with_input("    include_filter: dict = {}\n"),
+        "h.py": _handler_reading("k = 'x'", "y = input.metadata.get(k)"),
+    }
+    assert [f.rule_id for f in _scan(tmp_path, files)] == []
+
+
+def test_p035_silent_when_no_entrypoint_input(tmp_path: Path) -> None:
+    # No entrypoint Input contract to compare against → cannot make a parity claim.
+    assert [
+        f.rule_id
+        for f in _scan(
+            tmp_path, {"h.py": _handler_reading('x = input.metadata.get("anything")')}
+        )
+    ] == []
+
+
+def test_p035_suppressed(tmp_path: Path) -> None:
+    files = {
+        "app.py": _app_with_input("    include_filter: dict = {}\n"),
+        "h.py": _handler_reading(
+            "# conformance: ignore[P035] form-only key, tracked",
+            'x = input.metadata.get("unknown_key")',
+        ),
+    }
+    findings = _scan(tmp_path, files)
+    assert [f.rule_id for f in findings] == ["P035"]
+    assert findings[0].suppressed is True

--- a/packages/conformance/tests/test_preflight.py
+++ b/packages/conformance/tests/test_preflight.py
@@ -205,6 +205,27 @@ def test_p033_fires_via_transitive_handler_without_preflight_input_annotation(
     assert ids == ["P033"]
 
 
+def test_p033_message_points_at_colocated_handler(tmp_path: Path) -> None:
+    # With more than one preflight_check in scope, the message must reference the
+    # handler in the task's own source, not whichever site was scanned first.
+    other = _handler_with_preflight()  # a separate handler, another file
+    colocated = (
+        _APP_IMPORTS
+        + _HANDLER_IMPORTS
+        + "class A(App):\n"
+        + "    @task\n"
+        + "    async def run_preflight(self): ...\n"
+        + "class H(Handler):\n"
+        + "    async def preflight_check(self, input: PreflightInput) -> PreflightOutput:\n"
+        + "        return PreflightOutput(checks=[])\n"
+    )
+    findings = _scan(tmp_path, {"other.py": other, "app.py": colocated})
+    p033 = [f for f in findings if f.rule_id == "P033"]
+    assert len(p033) == 1
+    assert "app.py:" in p033[0].message
+    assert "other.py:" not in p033[0].message
+
+
 def test_p033_suppressed(tmp_path: Path) -> None:
     app = (
         _APP_IMPORTS
@@ -277,6 +298,16 @@ def test_p034_silent_on_non_sdk_preflightcheck(tmp_path: Path) -> None:
         "class PreflightCheck:\n    pass\n"
         "def make():\n"
         '    return PreflightCheck(name="x", passed=False)\n'
+    )
+    assert _ids(tmp_path, src) == []
+
+
+def test_p034_silent_on_kwargs_expansion(tmp_path: Path) -> None:
+    # A ``**`` expansion may carry a typed error=; suppress rather than false-fire.
+    src = (
+        "from application_sdk.handler.contracts import PreflightCheck\n"
+        "def make(err):\n"
+        '    return PreflightCheck(name="x", passed=False, **err)\n'
     )
     assert _ids(tmp_path, src) == []
 

--- a/packages/conformance/tests/test_preflight.py
+++ b/packages/conformance/tests/test_preflight.py
@@ -103,6 +103,16 @@ def test_p032_silent_on_non_literal_name(tmp_path: Path) -> None:
     assert _ids(tmp_path, src) == []
 
 
+def test_p032_fires_on_aliased_sdk_task_import(tmp_path: Path) -> None:
+    src = (
+        "from application_sdk.app import App, task as t\n"
+        "class A(App):\n"
+        '    @t(name="preflight")\n'
+        "    async def anything(self): ...\n"
+    )
+    assert _ids(tmp_path, src) == ["P032"]
+
+
 def test_p032_suppressed(tmp_path: Path) -> None:
     src = (
         _APP_IMPORTS
@@ -173,6 +183,26 @@ def test_p033_silent_on_preflight_substring_non_token(tmp_path: Path) -> None:
         for f in _scan(tmp_path, {"app.py": app, "h.py": _handler_with_preflight()})
     )
     assert ids == []
+
+
+def test_p033_fires_via_transitive_handler_without_preflight_input_annotation(
+    tmp_path: Path,
+) -> None:
+    # Handler detected only through the transitive base chain (in-repo intermediate),
+    # with an un-annotated preflight_check — exercises _class_subclasses_handler.
+    handler = (
+        "from application_sdk.handler.base import Handler, DefaultHandler\n"
+        "class Base(DefaultHandler): ...\n"
+        "class Concrete(Base):\n"
+        "    async def preflight_check(self, request):\n"
+        "        return None\n"
+    )
+    app = (
+        _APP_IMPORTS
+        + "class A(App):\n    @task\n    async def run_preflight(self): ...\n"
+    )
+    ids = sorted(f.rule_id for f in _scan(tmp_path, {"app.py": app, "h.py": handler}))
+    assert ids == ["P033"]
 
 
 def test_p033_suppressed(tmp_path: Path) -> None:
@@ -251,6 +281,15 @@ def test_p034_silent_on_non_sdk_preflightcheck(tmp_path: Path) -> None:
     assert _ids(tmp_path, src) == []
 
 
+def test_p034_fires_via_module_alias_call(tmp_path: Path) -> None:
+    src = (
+        "import application_sdk.handler.contracts as c\n"
+        "def make():\n"
+        '    return c.PreflightCheck(name="x", passed=False)\n'
+    )
+    assert _ids(tmp_path, src) == ["P034"]
+
+
 def test_p034_suppressed(tmp_path: Path) -> None:
     src = (
         "from application_sdk.handler.contracts import PreflightCheck\n"
@@ -312,14 +351,16 @@ def test_p035_silent_on_hyphenated_alias_of_field(tmp_path: Path) -> None:
     assert [f.rule_id for f in _scan(tmp_path, files)] == []
 
 
-def test_p035_silent_on_declared_field_alias(tmp_path: Path) -> None:
+def test_p035_fires_on_differently_stemmed_alias(tmp_path: Path) -> None:
+    # model_dump emits field NAMES, not aliases, so a read via a differently-stemmed
+    # alias genuinely misses on the gate path and must fire.
     files = {
         "app.py": _app_with_input(
             '    object_filter: dict = Field(default_factory=dict, alias="type")\n'
         ),
         "h.py": _handler_reading('x = input.metadata.get("type")'),
     }
-    assert [f.rule_id for f in _scan(tmp_path, files)] == []
+    assert sorted(f.rule_id for f in _scan(tmp_path, files)) == ["P035"]
 
 
 def test_p035_silent_on_subscript_read_of_field(tmp_path: Path) -> None:
@@ -336,6 +377,43 @@ def test_p035_silent_on_dynamic_key(tmp_path: Path) -> None:
         "h.py": _handler_reading("k = 'x'", "y = input.metadata.get(k)"),
     }
     assert [f.rule_id for f in _scan(tmp_path, files)] == []
+
+
+def test_p035_silent_when_contract_allows_extra_keys(tmp_path: Path) -> None:
+    # model_config extra="allow" genuinely keeps undeclared keys → no parity claim.
+    app = (
+        _APP_IMPORTS
+        + "from pydantic import ConfigDict\n"
+        + "class ExtractInput(Input):\n"
+        + '    model_config = ConfigDict(extra="allow")\n'
+        + "    include_filter: dict = {}\n"
+        + "class A(App):\n"
+        + "    @entrypoint()\n"
+        + "    async def extract(self, input: ExtractInput) -> None: ...\n"
+    )
+    files = {
+        "app.py": app,
+        "h.py": _handler_reading('x = input.metadata.get("anything")'),
+    }
+    assert [f.rule_id for f in _scan(tmp_path, files)] == []
+
+
+def test_p035_fires_despite_allow_unbounded_fields(tmp_path: Path) -> None:
+    # allow_unbounded_fields only skips payload-safety type checks; the extra policy
+    # stays "ignore", so undeclared keys are still dropped and P035 must still fire.
+    app = (
+        _APP_IMPORTS
+        + "class ExtractInput(Input, allow_unbounded_fields=True):\n"
+        + "    include_filter: dict = {}\n"
+        + "class A(App):\n"
+        + "    @entrypoint()\n"
+        + "    async def extract(self, input: ExtractInput) -> None: ...\n"
+    )
+    files = {
+        "app.py": app,
+        "h.py": _handler_reading('x = input.metadata.get("unknown_key")'),
+    }
+    assert sorted(f.rule_id for f in _scan(tmp_path, files)) == ["P035"]
 
 
 def test_p035_silent_when_no_entrypoint_input(tmp_path: Path) -> None:


### PR DESCRIPTION
TL;DR: adds four static conformance checks (P032-P035) that enforce the SDK-native preflight-gate pattern across the fleet. Closes BLDX-1545.

The preflight gate shipped in #2361/#2626 — every extraction workflow now dispatches `{app}:preflight` as its first activity and runs the app's `Handler.preflight_check`. These rules make the pattern statically enforceable so it can be remediated across app repos.

They reuse the existing `P` series on purpose: the fleet CI reusable workflow hard-codes its series matrix, so a new series letter would not run in any consumer repo without editing that workflow everywhere. Reusing `P` means they run on the existing P leg with zero CI change. All four are APP-scope, STATIC, and land at WARN (per the BLDX-1393 convention — new rules do not turn the fleet red overnight).

Rules:
- P032 ReservedPreflightActivityName — an app `@task` registering the `preflight` activity name collides with the injected gate; worker boot fails with `WorkerActivityNameCollisionError`. Static analog that surfaces it in the PR instead of on deploy.
- P033 DuplicateInWorkflowPreflight — app defines `Handler.preflight_check` and its own preflight-named `@task`; the two implementations drift. The gate calls `preflight_check`, so the app-owned activity is redundant.
- P034 UntypedPreflightCheckFailure — `PreflightCheck(passed=False)` with no typed `error=` falls back to the generic `PREFLIGHT_CHECK_FAILED` code, losing category/code/audience/suggested_action on the wire. Points at the exact lines for typed-error migration.
- P035 PreflightMetadataContractParity — the only check with no runtime counterpart. On the gate path metadata is rebuilt from the extraction input's `model_dump` (by_alias=False → field names), so a `preflight_check` metadata key that is not a field on any entrypoint `Input` contract is silently absent and a `.get(key, default)` read passes vacuously with wrong config.

Design notes on false positives (a noisy fleet-wide rule is the failure mode):
- P033 matches `preflight` as a whole token, not a substring, and only fires when a real `Handler.preflight_check` exists; never double-fires with P032.
- P034 requires an explicit `passed=False` literal and treats `error=<var>` as typed-present — deliberately accepting the omitted-`passed` false negative to keep noise near zero.
- P035 self-suppresses only when there is no resolvable entrypoint Input contract or when a contract genuinely keeps extra keys (`model_config = ConfigDict(extra="allow")`). `allow_unbounded_fields=True` does NOT suppress it — that flag only skips payload-safety type checks; undeclared keys are still dropped, so the drift must still fire. Keys are compared to field names with underscore/hyphen normalization; aliases are not treated as allowed because `model_dump` emits field names, not aliases.

Detection reuses the existing AST machinery (`collect_classes`, `resolve_ancestor`, decorator provenance, `resolve_contract_fields`); the P035 pass mirrors the B005/B006 two-pass contract-compat template. Rule 4 forks `collect_entrypoint_contract_names` into an input-only variant so it compares against the extraction input, not outputs.

Testing:
- New `tests/test_preflight.py` (fires / silent-variant / suppressed per rule, plus provenance/transitive-handler/extras edges); catalog meta-tests updated for the new IDs and APP scope.
- Full conformance suite passes; pre-commit clean.
- End-to-end `detect --series P` on a synthetic app repo fires all four at the right lines into SARIF (including the `include-database-regex` drift case); scan over the real SDK tree (299 files) yields zero findings.

Reviewed with an internal audit before opening; three correctness fixes applied (P035 extras semantics, per-target handler-detection cache, alias handling). Rollout: WARN only. Dry-run `detect` across a sample of consumer repos before considering any graduation to BLOCK.
