### PR TITLE
ci: provision release label + force-exclude generated freshness (CNCT-69, CNCT-70)

### DIFF
--- a/.github/scripts/renovate_pkl_sync.py
+++ b/.github/scripts/renovate_pkl_sync.py
@@ -177,13 +177,19 @@ def _format_generated() -> None:
     patterns (e.g. an app that exempts `app/generated/**` from a rule) only
     match a real relative path — they silently fail to match an absolute
     temp-dir path, which would make this over-apply rules relative to what
-    pre-commit actually enforces."""
+    pre-commit actually enforces.
+
+    `--force-exclude` makes ruff honor those `exclude`/`extend-exclude` patterns
+    even for the explicitly-passed paths (ruff otherwise ignores excludes for
+    paths named on the command line). An app that excludes `app/generated` then
+    keeps its raw pkl output here instead of this pass reformatting it into
+    freshness drift (CNCT-70)."""
     inputs = sorted(Path("app/generated").rglob("*.py"))
     if not inputs:
         return
     paths = [str(p) for p in inputs]
-    run(["uvx", "ruff", "check", "--fix", "--quiet", *paths])
-    run(["uvx", "ruff", "format", *paths])
+    run(["uvx", "ruff", "check", "--fix", "--quiet", "--force-exclude", *paths])
+    run(["uvx", "ruff", "format", "--force-exclude", *paths])
 
 
 def _swap_outputs(out_dir: Path) -> None:

--- a/.github/scripts/tests/test_renovate_pkl_sync.py
+++ b/.github/scripts/tests/test_renovate_pkl_sync.py
@@ -311,7 +311,7 @@ def test_format_generated_covers_all_py_not_just_input(tmp_path, monkeypatch):
 
     def spy_run(cmd, *, check=False):
         if cmd[:2] == ["uvx", "ruff"] and cmd[2] == "format":
-            formatted.extend(cmd[3:])
+            formatted.extend(a for a in cmd[3:] if not a.startswith("-"))
         return types.SimpleNamespace(returncode=0)
 
     monkeypatch.setattr(mod, "run", spy_run)
@@ -380,6 +380,34 @@ def test_format_generated_lints_real_path_not_temp_dir(tmp_path, monkeypatch):
     linted_path = check_calls[0][-1]
     assert not Path(linted_path).is_absolute()
     assert linted_path == str(Path("app/generated/_input.py"))
+
+
+def test_format_generated_passes_force_exclude(tmp_path, monkeypatch):
+    """Both ruff invocations must pass `--force-exclude` so a consumer's
+    `extend-exclude = ["app/generated"]` is honored even though paths are named
+    explicitly (ruff ignores excludes for explicit paths otherwise). Without it,
+    this pass reformats an app that deliberately keeps generated output raw,
+    which the freshness gate then flags as drift (CNCT-70)."""
+    monkeypatch.chdir(tmp_path)
+    gen = tmp_path / "app" / "generated"
+    gen.mkdir(parents=True)
+    (gen / "_input.py").write_text("import os\n")
+
+    calls: list[list[str]] = []
+
+    def spy_run(cmd, *, check=False):
+        if cmd[:2] == ["uvx", "ruff"]:
+            calls.append(cmd)
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(mod, "run", spy_run)
+    mod._format_generated()
+
+    subcommands = {cmd[2] for cmd in calls}
+    assert subcommands == {"check", "format"}
+    for cmd in calls:
+        assert "--force-exclude" in cmd, cmd
+        assert cmd[-1] == str(Path("app/generated/_input.py"))
 
 
 def test_resolve_failure_is_fatal(repo, monkeypatch):

--- a/.github/workflows/release-version-bump.yaml
+++ b/.github/workflows/release-version-bump.yaml
@@ -124,6 +124,9 @@ jobs:
           if [ -n "$EXISTING" ]; then
             echo "PR #${EXISTING} already exists for ${BRANCH}, skipping creation."
           else
+            gh label create "${{ inputs.release_label }}" \
+              --color 0e8a16 \
+              --description "Release version-bump PR" 2>/dev/null || true
             gh pr create \
               --base "${{ inputs.target_branch }}" \
               --title "Bump version to ${{ steps.bump.outputs.new }}" \


### PR DESCRIPTION
Two SDK-side fixes for CI breakage that surfaces after a repo adopts conformance. Both are central and self-healing — no per-app change needed.

## CNCT-69 — version-bump job hard-fails on a missing `release` label

The bootstrap installs `release.yaml` (Release Version Bump), whose reusable workflow opens the bump PR with `gh pr create --label "release"`. It never provisions the `release` label, so on the first post-merge run the label step dies (`could not add label: 'release' not found`), no bump PR is created, and a stray `bump-version-main` branch is left behind.

Fix: idempotently ensure the label exists right before applying it — `gh label create … 2>/dev/null || true`. Best-effort so it never regresses (label exists → no-op; missing + creatable → created; missing + no perms → same failure as today). The label isn't just dropped because it's what triggers `tag-and-publish.yaml` on merge.

## CNCT-70 — freshness gate reformats generated code the repo excludes from ruff

`_format_generated()` runs `ruff check --fix` + `ruff format` over `app/generated/*.py` before the freshness diff. Because it passes explicit paths, ruff ignores the repo's `[tool.ruff] extend-exclude = ["app/generated"]` (ruff only honors excludes for explicit paths under `--force-exclude`). So it reformats the generated output and flags drift against the committed (unformatted, pkl-eval) files.

Fix: add `--force-exclude` to both ruff calls so the driver defers to the repo's own ruff config — excluded apps keep their raw output (no drift); apps without the exclude are formatted exactly as before. Same code backs the renovate sync and the freshness check, so both stay consistent.
