### PR TITLE
fix(conformance): opt-in pytest-xdist parallelism for the e2e suite

### DIFF
--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -555,6 +555,23 @@ runs:
           sleep 1
         done
 
+    # Resolve opt-in pytest-xdist flags. Validation + the empty/sequential-vs-
+    # parallel decision live in a tested Python driver per docs/standards/ci.md
+    # (co-located with the action so it is checked out alongside sdr-e2e when
+    # consumed from another repo — never referenced from .github/scripts/, which
+    # is not present in consumer checkouts). Emits two outputs: uv_with and
+    # xdist_args (both empty ⇒ sequential, the default). This step is
+    # straight-line; the branching is inside the script.
+    - name: Resolve e2e parallelism flags
+      id: xdist
+      shell: bash
+      env:
+        SDR_E2E_ROOT: ${{ steps.action_root.outputs.path }}
+      run: |
+        OUT=$(python3 "$SDR_E2E_ROOT/build_pytest_parallel_args.py" \
+          --parallel-workers "${{ inputs.pytest-parallel-workers }}")
+        echo "$OUT" >> "$GITHUB_OUTPUT"
+
     - name: Run SDR integration tests
       id: tests
       shell: bash
@@ -565,21 +582,14 @@ runs:
         TWO_STORE: ${{ inputs.enable-two-store }}
       run: |
         mkdir -p results
-        # Opt-in pytest-xdist parallelism. Empty workers → sequential (default,
-        # unchanged). A worker count / "auto" pulls in xdist on the fly and
-        # distributes by loadscope (a module's tests stay on one worker).
-        UV_WITH=""
-        XDIST_ARGS=""
-        if [ -n "${{ inputs.pytest-parallel-workers }}" ]; then
-          UV_WITH="--with pytest-xdist"
-          XDIST_ARGS="-n ${{ inputs.pytest-parallel-workers }} --dist loadscope"
-          echo "Running e2e in parallel: ${XDIST_ARGS}"
-        fi
         set +e
-        uv run ${UV_WITH} pytest "${{ inputs.test-path }}" -v \
+        # uv_with / xdist_args are empty (sequential) unless the caller opted
+        # into parallelism via pytest-parallel-workers; the script validated
+        # the value so unquoted expansion here carries no shell metacharacters.
+        uv run ${{ steps.xdist.outputs.uv_with }} pytest "${{ inputs.test-path }}" -v \
           --tb=short \
           --junit-xml=results/sdr-test-results.xml \
-          ${XDIST_ARGS} \
+          ${{ steps.xdist.outputs.xdist_args }} \
           ${{ inputs.pytest-extra-args }} \
           2>&1 | tee results/sdr-test-output.txt
         TEST_EXIT_CODE=${PIPESTATUS[0]}

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -83,6 +83,19 @@ inputs:
     description: Extra arguments appended to the pytest invocation.
     required: false
     default: ""
+  pytest-parallel-workers:
+    description: |
+      Opt-in pytest-xdist parallelism. Empty (default) runs the suite
+      sequentially — the historical behaviour. Set to a worker count
+      (e.g. "2") or "auto" to run test cases concurrently: the action
+      pulls in pytest-xdist on the fly (`uv run --with pytest-xdist`) and
+      appends `-n <value> --dist loadscope`. loadscope keeps a module's /
+      class's tests on one worker, so only independent suites parallelise —
+      safe for connectors with class-scoped fixtures. Only opt in when the
+      test classes are mutually independent (distinct connections + AE
+      workflow slugs).
+    required: false
+    default: ""
   application-sdk-ref:
     description: |
       Optional application-sdk commit SHA / ref. When supplied, the
@@ -552,10 +565,21 @@ runs:
         TWO_STORE: ${{ inputs.enable-two-store }}
       run: |
         mkdir -p results
+        # Opt-in pytest-xdist parallelism. Empty workers → sequential (default,
+        # unchanged). A worker count / "auto" pulls in xdist on the fly and
+        # distributes by loadscope (a module's tests stay on one worker).
+        UV_WITH=""
+        XDIST_ARGS=""
+        if [ -n "${{ inputs.pytest-parallel-workers }}" ]; then
+          UV_WITH="--with pytest-xdist"
+          XDIST_ARGS="-n ${{ inputs.pytest-parallel-workers }} --dist loadscope"
+          echo "Running e2e in parallel: ${XDIST_ARGS}"
+        fi
         set +e
-        uv run pytest "${{ inputs.test-path }}" -v \
+        uv run ${UV_WITH} pytest "${{ inputs.test-path }}" -v \
           --tb=short \
           --junit-xml=results/sdr-test-results.xml \
+          ${XDIST_ARGS} \
           ${{ inputs.pytest-extra-args }} \
           2>&1 | tee results/sdr-test-output.txt
         TEST_EXIT_CODE=${PIPESTATUS[0]}

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -567,9 +567,14 @@ runs:
       shell: bash
       env:
         SDR_E2E_ROOT: ${{ steps.action_root.outputs.path }}
+        # Route the raw input through env (quoted below) rather than
+        # interpolating ${{ }} directly into the command string — the driver
+        # validates it, but the value must reach the driver intact, not be
+        # substituted into the run: line first. Mirrors "Build compose -f chain".
+        PARALLEL_WORKERS: ${{ inputs.pytest-parallel-workers }}
       run: |
         OUT=$(python3 "$SDR_E2E_ROOT/build_pytest_parallel_args.py" \
-          --parallel-workers "${{ inputs.pytest-parallel-workers }}")
+          --parallel-workers "${PARALLEL_WORKERS}")
         echo "$OUT" >> "$GITHUB_OUTPUT"
 
     - name: Run SDR integration tests

--- a/.github/actions/sdr-e2e/build_pytest_parallel_args.py
+++ b/.github/actions/sdr-e2e/build_pytest_parallel_args.py
@@ -1,0 +1,74 @@
+"""Emit pytest-xdist flags for the sdr-e2e composite action's test step.
+
+The e2e suite runs sequentially by default. A connector opts into parallelism
+by passing ``pytest-parallel-workers`` (a positive integer or ``"auto"``); this
+driver validates that value and prints the two GitHub Actions outputs the test
+step consumes:
+
+  uv_with     — "" (sequential) or "--with pytest-xdist"
+  xdist_args  — "" (sequential) or "-n <workers> --dist loadscope"
+
+Moved here (rather than left as inline ``if`` shell in ``action.yaml``) per
+``docs/standards/ci.md``, which reserves conditional logic in ``run:`` blocks
+for tested Python. Co-located with the action — NOT under ``.github/scripts/``
+— so it is checked out alongside the composite action when consumed from
+another repo (mirrors ``build_compose_chain.py`` / ``select_dapr_components.py``).
+
+Validating the value here also keeps the emitted args safe: only ``""`` / a
+positive integer / ``"auto"`` are ever produced, so the downstream unquoted
+shell expansion can never carry metacharacters or an invalid worker count
+(e.g. ``"0"``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+_AUTO = "auto"
+# A positive integer with no leading zeros (rejects "0", "01", "-1", "").
+_POSITIVE_INT_RE = re.compile(r"\A[1-9][0-9]*\Z")
+
+
+def build_xdist_flags(parallel_workers: str) -> tuple[str, str]:
+    """Return ``(uv_with, xdist_args)`` for a raw ``pytest-parallel-workers`` value.
+
+    Empty / whitespace-only → sequential (both ``""``). ``"auto"`` or a positive
+    integer → parallel. Any other value (``"0"``, ``"-1"``, ``"2 3"``,
+    ``"auto; rm -rf /"``, …) raises :class:`ValueError` so CI fails loudly
+    instead of silently mis-parallelising.
+    """
+    value = parallel_workers.strip()
+    if not value:
+        return "", ""
+    if value != _AUTO and not _POSITIVE_INT_RE.match(value):
+        raise ValueError(
+            "pytest-parallel-workers must be a positive integer or 'auto', "
+            f"got {parallel_workers!r}"
+        )
+    return "--with pytest-xdist", f"-n {value} --dist loadscope"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Resolve pytest-xdist flags.")
+    parser.add_argument("--parallel-workers", default="")
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    try:
+        uv_with, xdist_args = build_xdist_flags(args.parallel_workers)
+    except ValueError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    if xdist_args:
+        print(f"e2e parallelism enabled: {xdist_args}", file=sys.stderr)
+    else:
+        print("e2e parallelism disabled: running sequentially", file=sys.stderr)
+    print(f"uv_with={uv_with}")
+    print(f"xdist_args={xdist_args}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_build_pytest_parallel_args.py
+++ b/.github/scripts/tests/test_build_pytest_parallel_args.py
@@ -17,7 +17,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent / "actions" / "sdr-e2
 
 from build_pytest_parallel_args import build_xdist_flags, main  # noqa: E402
 
-
 # --- sequential (default) --------------------------------------------------
 
 

--- a/.github/scripts/tests/test_build_pytest_parallel_args.py
+++ b/.github/scripts/tests/test_build_pytest_parallel_args.py
@@ -1,0 +1,97 @@
+"""Tests for .github/actions/sdr-e2e/build_pytest_parallel_args.py.
+
+See test_build_compose_chain.py for why the module under test lives under
+.github/actions/sdr-e2e/ (co-located so it is checked out with the composite
+action in consumer repos) rather than .github/scripts/, and why the test
+itself still lives here.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "actions" / "sdr-e2e"))
+
+from build_pytest_parallel_args import build_xdist_flags, main  # noqa: E402
+
+
+# --- sequential (default) --------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["", "   ", "\n"])
+def test_empty_is_sequential(value: str) -> None:
+    assert build_xdist_flags(value) == ("", "")
+
+
+# --- parallel --------------------------------------------------------------
+
+
+def test_positive_int_enables_xdist() -> None:
+    assert build_xdist_flags("2") == (
+        "--with pytest-xdist",
+        "-n 2 --dist loadscope",
+    )
+
+
+def test_auto_enables_xdist() -> None:
+    assert build_xdist_flags("auto") == (
+        "--with pytest-xdist",
+        "-n auto --dist loadscope",
+    )
+
+
+def test_surrounding_whitespace_is_tolerated() -> None:
+    assert build_xdist_flags("  3 ") == (
+        "--with pytest-xdist",
+        "-n 3 --dist loadscope",
+    )
+
+
+# --- rejected values -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["0", "-1", "01", "2.5", "two", "2 3", "auto; rm -rf /", "$(whoami)", "-n 4"],
+)
+def test_invalid_values_raise(value: str) -> None:
+    with pytest.raises(ValueError):
+        build_xdist_flags(value)
+
+
+# --- CLI wrapper -----------------------------------------------------------
+
+
+def test_main_emits_outputs_for_parallel(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["--parallel-workers", "2"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "uv_with=--with pytest-xdist" in out
+    assert "xdist_args=-n 2 --dist loadscope" in out
+
+
+def test_main_emits_empty_outputs_for_sequential(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = main(["--parallel-workers", ""])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "uv_with=\n" in out
+    assert "xdist_args=\n" in out
+
+
+def test_main_defaults_to_sequential(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "uv_with=\n" in out
+
+
+def test_main_returns_error_on_invalid(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["--parallel-workers", "0"])
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "::error::" in err

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -151,6 +151,18 @@ on:
         required: false
         type: boolean
         default: false
+      e2e-parallel-workers:
+        description: |
+          Opt-in pytest-xdist parallelism for the e2e suite. Empty
+          (default) runs sequentially — unchanged behaviour. Set to a
+          worker count (e.g. "2") or "auto" to run independent test classes
+          concurrently against the shared CI worker; xdist is pulled in on
+          the fly and distribution is by loadscope. Only enable when the
+          suite's test classes are mutually independent (own connections and
+          AE workflow slugs).
+        required: false
+        type: string
+        default: ""
     secrets:
       SDR_TEST_TENANT:
         description: Tenant FQDN (e.g. devex.atlan.com — no https:// prefix). ATLAN_BASE_URL is derived from this.
@@ -227,6 +239,7 @@ jobs:
           # operators can watch the colour-emoji DAG progression
           # instead of waiting for a final dump.
           pytest-extra-args: "-s"
+          pytest-parallel-workers: ${{ inputs.e2e-parallel-workers }}
           application-sdk-ref: ${{ inputs.application-sdk-ref }}
           base-image-ref: ${{ inputs.base-image-ref }}
           enable-two-store: ${{ inputs.two-store }}

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -131,6 +131,18 @@ on:
           tenant blobstorage, so a connector that forgets to bridge an artifact
           shows up as zero downstream assets instead of being masked by a shared
           bucket. Default false: existing callers are unaffected.
+      e2e-parallel-workers:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Opt-in pytest-xdist parallelism for the e2e job. Empty (default)
+          runs the e2e suite sequentially — unchanged behaviour. Set to a
+          worker count (e.g. "2") or "auto" to run mutually-independent e2e
+          test classes concurrently against the shared CI worker (xdist is
+          pulled in on the fly, distributed by loadscope). Only enable when
+          the suite's classes are independent (own connections + AE workflow
+          slugs).
 
 jobs:
 
@@ -257,6 +269,8 @@ jobs:
           container-health-timeout-seconds: "120"
           # `-s` streams the harness poll-loop output in real time.
           pytest-extra-args: "-s"
+          # Opt-in e2e parallelism (empty = sequential, unchanged default).
+          pytest-parallel-workers: ${{ inputs.e2e-parallel-workers }}
           application-sdk-ref: ${{ inputs.application-sdk-ref }}
           base-image-ref: ${{ inputs.base-image-ref }}
           enable-two-store: ${{ inputs.two-store }}

--- a/packages/conformance/conformance/suite/checks/bootstrap_drift.py
+++ b/packages/conformance/conformance/suite/checks/bootstrap_drift.py
@@ -94,8 +94,10 @@ def _strip_regen_override(text: str) -> str:
 # (build_pytest_parallel_args.py): "auto" or a positive integer with no leading
 # zero, quoted or bare. An invalid value like "0"/"01" is deliberately NOT
 # stripped, so C002 flags it as drift before the driver rejects it at runtime.
+# A single comment line directly above, and a same-line trailing comment (like
+# _ACTION_PIN_RE consumes an inline "# v6.0.3"), are also normalised out.
 _E2E_PARALLEL_OVERRIDE_RE = re.compile(
-    r'\n(?:[ ]*#[^\n]*\n)?[ ]*e2e-parallel-workers:[ ]*"?(?:auto|[1-9][0-9]*)"?[ ]*'
+    r'\n(?:[ ]*#[^\n]*\n)?[ ]*e2e-parallel-workers:[ ]*"?(?:auto|[1-9][0-9]*)"?[ ]*(?:#[^\n]*)?'
 )
 
 

--- a/packages/conformance/conformance/suite/checks/bootstrap_drift.py
+++ b/packages/conformance/conformance/suite/checks/bootstrap_drift.py
@@ -24,7 +24,9 @@ package_name, etc.) are not flagged as drift — only structural changes are cau
 override that is normalised out of the on-disk file before comparison, so the
 choice is not flagged as drift (any *other* change still is).  Currently:
 ``renovate-pkl-sync.yaml`` tolerates a ``with: regenerate-contract: <bool>``
-opt-out on its reusable-workflow caller.
+opt-out on its reusable-workflow caller, and ``tests.yaml`` tolerates an
+``e2e-parallel-workers: <count|auto>`` input opting the e2e job into
+pytest-xdist parallelism (default is sequential).
 
 Remediation: run ``atlan-application-sdk-conformance bootstrap`` to re-sync.
 """
@@ -81,6 +83,21 @@ _REGEN_OVERRIDE_RE = re.compile(
 
 def _strip_regen_override(text: str) -> str:
     return _REGEN_OVERRIDE_RE.sub("", text)
+
+
+# tests.yaml runs the e2e suite sequentially by default; a connector whose e2e
+# test classes are mutually independent may opt into pytest-xdist parallelism by
+# adding an `e2e-parallel-workers` input to its tests-reusable caller. That is a
+# sanctioned per-repo choice, so strip it (and any single comment line directly
+# above it) before the drift comparison — only other structural changes should
+# flag C002. Matches a numeric worker count or "auto", quoted or bare.
+_E2E_PARALLEL_OVERRIDE_RE = re.compile(
+    r'\n(?:[ ]*#[^\n]*\n)?[ ]*e2e-parallel-workers:[ ]*"?(?:auto|[0-9]+)"?[ ]*'
+)
+
+
+def _strip_e2e_parallel_workers(text: str) -> str:
+    return _E2E_PARALLEL_OVERRIDE_RE.sub("", text)
 
 
 # ---------------------------------------------------------------------------
@@ -378,7 +395,10 @@ def _scan_tests_yaml(path: Path, root: Path) -> list[Finding]:
     params = _extract_tests_yaml_params(on_disk)
     canonical = render(_TESTS_WORKFLOW, **params)
 
-    if _strip_action_pins(on_disk) == _strip_action_pins(canonical):
+    # Opting into parallel e2e (e2e-parallel-workers) is a sanctioned per-repo
+    # choice — normalise it out so only other structural changes flag drift.
+    normalized = _strip_e2e_parallel_workers(on_disk)
+    if _strip_action_pins(normalized) == _strip_action_pins(canonical):
         return []
 
     return [

--- a/packages/conformance/conformance/suite/checks/bootstrap_drift.py
+++ b/packages/conformance/conformance/suite/checks/bootstrap_drift.py
@@ -90,9 +90,12 @@ def _strip_regen_override(text: str) -> str:
 # adding an `e2e-parallel-workers` input to its tests-reusable caller. That is a
 # sanctioned per-repo choice, so strip it (and any single comment line directly
 # above it) before the drift comparison — only other structural changes should
-# flag C002. Matches a numeric worker count or "auto", quoted or bare.
+# flag C002. The accepted values mirror the runtime driver
+# (build_pytest_parallel_args.py): "auto" or a positive integer with no leading
+# zero, quoted or bare. An invalid value like "0"/"01" is deliberately NOT
+# stripped, so C002 flags it as drift before the driver rejects it at runtime.
 _E2E_PARALLEL_OVERRIDE_RE = re.compile(
-    r'\n(?:[ ]*#[^\n]*\n)?[ ]*e2e-parallel-workers:[ ]*"?(?:auto|[0-9]+)"?[ ]*'
+    r'\n(?:[ ]*#[^\n]*\n)?[ ]*e2e-parallel-workers:[ ]*"?(?:auto|[1-9][0-9]*)"?[ ]*'
 )
 
 

--- a/packages/conformance/tests/test_bootstrap_drift.py
+++ b/packages/conformance/tests/test_bootstrap_drift.py
@@ -409,6 +409,67 @@ def test_tests_yaml_active_services_script_not_flagged(tmp_path: pathlib.Path) -
     assert findings == []
 
 
+def _opt_into_parallel(canonical: str, value: str, *, comment: bool = False) -> str:
+    """Insert an e2e-parallel-workers input into the canonical tests.yaml."""
+    block = f'      e2e-parallel-workers: "{value}"\n'
+    if comment:
+        block = "      # run independent e2e classes concurrently\n" + block
+    return canonical.replace(
+        "      two-store: true\n", "      two-store: true\n" + block
+    )
+
+
+def test_tests_yaml_e2e_parallel_workers_not_flagged(tmp_path: pathlib.Path) -> None:
+    """Opting the e2e job into pytest-xdist (e2e-parallel-workers) is a
+    sanctioned per-repo choice — not structural drift."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    wf = wf_dir / "tests.yaml"
+    wf.write_text(_opt_into_parallel(render("tests.yaml"), "2"))
+    findings = scan_path(wf, tmp_path)
+    assert findings == [], [f.message for f in findings]
+
+
+def test_tests_yaml_e2e_parallel_workers_auto_not_flagged(
+    tmp_path: pathlib.Path,
+) -> None:
+    """The 'auto' worker count is also sanctioned."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    wf = wf_dir / "tests.yaml"
+    wf.write_text(_opt_into_parallel(render("tests.yaml"), "auto"))
+    assert scan_path(wf, tmp_path) == []
+
+
+def test_tests_yaml_e2e_parallel_workers_with_comment_not_flagged(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A single explanatory comment directly above the input is stripped too."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    wf = wf_dir / "tests.yaml"
+    wf.write_text(_opt_into_parallel(render("tests.yaml"), "2", comment=True))
+    assert scan_path(wf, tmp_path) == []
+
+
+def test_tests_yaml_e2e_parallel_workers_does_not_mask_other_drift(
+    tmp_path: pathlib.Path,
+) -> None:
+    """The strip is targeted: real structural drift alongside the sanctioned
+    e2e-parallel-workers input is still flagged."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    wf = wf_dir / "tests.yaml"
+    opted_in = _opt_into_parallel(render("tests.yaml"), "2")
+    drifted = opted_in.replace(
+        "  tests:", "  tests:\n    timeout-minutes: 999  # structural drift"
+    )
+    wf.write_text(drifted)
+    findings = scan_path(wf, tmp_path)
+    assert len(findings) == 1
+    assert findings[0].rule_id == "C002"
+
+
 def test_tests_yaml_structural_drift_produces_finding(tmp_path: pathlib.Path) -> None:
     """Structural modification (not just param values) → one C002 finding."""
     wf_dir = tmp_path / ".github" / "workflows"

--- a/packages/conformance/tests/test_bootstrap_drift.py
+++ b/packages/conformance/tests/test_bootstrap_drift.py
@@ -452,6 +452,22 @@ def test_tests_yaml_e2e_parallel_workers_with_comment_not_flagged(
     assert scan_path(wf, tmp_path) == []
 
 
+@pytest.mark.parametrize("bad_value", ["0", "01", "-1", "two"])
+def test_tests_yaml_invalid_e2e_parallel_workers_still_flagged(
+    tmp_path: pathlib.Path, bad_value: str
+) -> None:
+    """Only values the runtime driver accepts (auto / positive int, no leading
+    zero) are sanctioned. An invalid value flags drift so conformance catches
+    the typo before the driver rejects it at e2e runtime."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    wf = wf_dir / "tests.yaml"
+    wf.write_text(_opt_into_parallel(render("tests.yaml"), bad_value))
+    findings = scan_path(wf, tmp_path)
+    assert len(findings) == 1
+    assert findings[0].rule_id == "C002"
+
+
 def test_tests_yaml_e2e_parallel_workers_does_not_mask_other_drift(
     tmp_path: pathlib.Path,
 ) -> None:

--- a/packages/conformance/tests/test_bootstrap_drift.py
+++ b/packages/conformance/tests/test_bootstrap_drift.py
@@ -409,9 +409,18 @@ def test_tests_yaml_active_services_script_not_flagged(tmp_path: pathlib.Path) -
     assert findings == []
 
 
-def _opt_into_parallel(canonical: str, value: str, *, comment: bool = False) -> str:
+def _opt_into_parallel(
+    canonical: str,
+    value: str,
+    *,
+    comment: bool = False,
+    trailing_comment: bool = False,
+) -> str:
     """Insert an e2e-parallel-workers input into the canonical tests.yaml."""
-    block = f'      e2e-parallel-workers: "{value}"\n'
+    line = f'      e2e-parallel-workers: "{value}"'
+    if trailing_comment:
+        line += "  # tune to the runner's core count"
+    block = line + "\n"
     if comment:
         block = "      # run independent e2e classes concurrently\n" + block
     return canonical.replace(
@@ -466,6 +475,18 @@ def test_tests_yaml_invalid_e2e_parallel_workers_still_flagged(
     findings = scan_path(wf, tmp_path)
     assert len(findings) == 1
     assert findings[0].rule_id == "C002"
+
+
+def test_tests_yaml_e2e_parallel_workers_trailing_comment_not_flagged(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A same-line trailing comment after the input is normalised out too, so it
+    doesn't orphan and flag spurious drift."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    wf = wf_dir / "tests.yaml"
+    wf.write_text(_opt_into_parallel(render("tests.yaml"), "2", trailing_comment=True))
+    assert scan_path(wf, tmp_path) == []
 
 
 def test_tests_yaml_e2e_parallel_workers_does_not_mask_other_drift(


### PR DESCRIPTION
## What

Adds an **opt-in** way to run a connector's full-DAG e2e suite in parallel with pytest-xdist. **Sequential remains the default** — no existing caller changes behaviour.

- `sdr-e2e` action: new `pytest-parallel-workers` input (default `""`). When set to a worker count (e.g. `"2"`) or `"auto"`, the pytest step runs `uv run --with pytest-xdist pytest ... -n <workers> --dist loadscope` — pulling in `pytest-xdist` on the fly. Empty → the exact command as today.
- `e2e-full-reusable.yaml` and `tests-reusable.yaml`: new `e2e-parallel-workers` input (default `""`), threaded down to the action.
- **Conformance C002 (bootstrap drift):** `tests.yaml` now tolerates an `e2e-parallel-workers` input as a sanctioned per-repo override — normalized out before the drift comparison (mirroring the `renovate-pkl-sync` `regenerate-contract` precedent), so a connector that opts in stays drift-clean while any *other* structural change is still flagged.

## Why

Once a connector's e2e test classes are mutually independent (own connections + own AE workflow slugs), running them sequentially just wastes wall-clock — each full DAG is several minutes. This lets a connector opt in via one input while keeping the shared single CI worker (a persistent Temporal worker serves concurrent workflows fine).

## Safety

- **Default off** — `""` yields the unchanged `uv run pytest ...` invocation, so every current caller is byte-for-byte the same.
- **`--dist loadscope`** keeps a module's/class's tests on one worker, so class-scoped fixtures aren't split across workers; only whole independent classes parallelise.
- xdist is only installed (`--with`) when parallelism is requested — no new dependency for sequential runs.
- No conformance template change (which would cause fleet-wide drift). The C002 allowance means opting in is a clean, sanctioned per-repo `tests.yaml` edit.
- Callers should only opt in when their e2e classes are truly independent (distinct connections + AE workflow slugs), else concurrent submissions race on shared state.

## Usage

A connector opts in by passing the input from its `tests.yaml` call, e.g.:

```yaml
uses: atlanhq/application-sdk/.github/workflows/tests-reusable.yaml@main
with:
  ...
  e2e-parallel-workers: "2"
```

## Testing
- `packages/conformance` C002 drift suite — 70 passed (incl. new cases: numeric/auto value, preceding comment, and "doesn't mask other drift").
- All three CI YAML files validated.

Follow-up to #2660 (the e2e stall-guard). Independent change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)