### PR TITLE
chore(ci): throwaway workflow to verify atlan-app-fleet Checks API write access

### DIFF
--- a/.github/workflows/_throwaway-verify-fleet-checks-write.yml
+++ b/.github/workflows/_throwaway-verify-fleet-checks-write.yml
@@ -1,0 +1,53 @@
+# Throwaway verification workflow — delete after confirming the App works.
+#
+# #2630/#2634 confirmed the atlan-app-fleet App mints a token with an
+# isolated identity + rate limit. #2635 confirmed it can dispatch
+# cross-repo workflows. Neither tested the one thing that actually broke
+# the reverted e2e check-run callback (#2526): the Checks API's write
+# endpoints (create/update a check run) reject PATs outright ("You must
+# authenticate via a GitHub App") — only a real GitHub App installation
+# token works. This confirms that specific call before rebuilding the
+# callback design around it.
+name: _throwaway Verify Fleet App Checks Write
+on: workflow_dispatch
+
+permissions: {}
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint fleet App token (scoped to this repo)
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+
+      - name: Create a scratch check run
+        id: create
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          response=$(gh api --method POST repos/atlanhq/application-sdk/check-runs \
+            -f name="_throwaway-fleet-checks-write-test" \
+            -f "head_sha=${{ github.sha }}" \
+            -f status=in_progress)
+          echo "$response"
+          echo "id=$(echo "$response" | jq -r .id)" >> "$GITHUB_OUTPUT"
+
+      - name: Complete the scratch check run
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CHECK_RUN_ID: ${{ steps.create.outputs.id }}
+        run: |
+          set -euo pipefail
+          gh api --method PATCH "repos/atlanhq/application-sdk/check-runs/${CHECK_RUN_ID}" \
+            -f status=completed \
+            -f conclusion=success \
+            -f 'output[title]=Fleet App checks-write test' \
+            -f 'output[summary]=Confirmed: atlan-app-fleet can create + complete check runs.'
+          echo "Checks API write access confirmed via the Fleet App token."


### PR DESCRIPTION
## Summary
Throwaway verification, delete after confirming. Neither #2630/#2634 (identity + rate limit) nor #2635 (dispatch cross-repo) tested the specific call that broke the reverted e2e check-run callback (#2526): the Checks API's create/update endpoints reject PATs outright ("You must authenticate via a GitHub App"), only a real GitHub App installation token works.

This mints a Fleet App token scoped to `application-sdk` and does a real `POST` + `PATCH` against the Checks API (create then complete a scratch check-run on `HEAD`). Confirms the App can actually do the one thing that matters before the callback design gets rebuilt around it.

## Test plan
- [ ] Merge, dispatch via `workflow_dispatch`, confirm both API calls succeed
- [ ] Delete this workflow in a follow-up cleanup PR (mirrors #2630 → #2634)