### PR TITLE
ci(fleet-app): migrate Category B (same-repo privileged ops) to App token

### DIFF
--- a/.github/workflows/auto-fix-vulnerabilities.yaml
+++ b/.github/workflows/auto-fix-vulnerabilities.yaml
@@ -26,6 +26,12 @@ on:
     secrets:
       ORG_PAT_GITHUB:
         required: true
+      FLEET_APP_ID:
+        required: false
+        description: "atlan-app-fleet App ID (org secret). Not passed explicitly by any current caller — auto-available via 'secrets: inherit'. Declared here so the contract is self-documenting."
+      FLEET_APP_PRIVATE_KEY:
+        required: false
+        description: "atlan-app-fleet App private key (org secret). Same availability as FLEET_APP_ID above."
 
 permissions:
   contents: write
@@ -62,11 +68,20 @@ jobs:
               content: 'rocket',
             });
 
+      - name: Mint fleet App token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+
       - name: Checkout PR branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ steps.pr.outputs.branch }}
-          token: ${{ secrets.ORG_PAT_GITHUB }}
+          token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
 
       - name: Download latest scan artifacts
         env:

--- a/.github/workflows/auto-fix-vulnerabilities.yaml
+++ b/.github/workflows/auto-fix-vulnerabilities.yaml
@@ -76,6 +76,7 @@ jobs:
           app-id: ${{ secrets.FLEET_APP_ID }}
           private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
           owner: atlanhq
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout PR branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/capability-manifest-regen.yaml
+++ b/.github/workflows/capability-manifest-regen.yaml
@@ -5,10 +5,12 @@
 # and pushes the result as github-actions[bot].
 #
 # Modelled on auto-fix-vulnerabilities.yaml. Key design choices:
-#   - ORG_PAT_GITHUB checkout token so the resulting push re-fires PR check workflows
-#     (same pattern as auto-fix-vulnerabilities.yaml and release-version-bump.yaml).
-#   - github-actions[bot] identity, NOT atlan-ci, so the bot commit does not
-#     auto-satisfy the wildcard CODEOWNERS rule that includes @atlan-ci.
+#   - A minted atlan-app-fleet App checkout token so the resulting push re-fires
+#     PR check workflows (same pattern as auto-fix-vulnerabilities.yaml and
+#     release-version-bump.yaml). Confirmed empirically that App-token pushes
+#     re-trigger downstream workflows the same way a real PAT identity does.
+#   - github-actions[bot] identity, NOT atlan-ci (nor the App), so the bot commit
+#     does not auto-satisfy the wildcard CODEOWNERS rule that includes @atlan-ci.
 #   - Fork PRs are rejected immediately with an explanatory comment.
 #   - fetch-depth: 0 for the same reason as the drift-check workflow (source-sha).
 
@@ -91,11 +93,21 @@ jobs:
               content: 'rocket',
             });
 
+      - name: Mint fleet App token
+        id: app-token
+        if: steps.pr.outputs.is_fork != 'true' && steps.pr.outputs.is_bump_version != 'true'
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: steps.pr.outputs.is_fork != 'true' && steps.pr.outputs.is_bump_version != 'true'
         with:
           ref: ${{ steps.pr.outputs.branch }}
-          token: ${{ secrets.ORG_PAT_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2

--- a/.github/workflows/conformance-release.yml
+++ b/.github/workflows/conformance-release.yml
@@ -36,10 +36,23 @@ jobs:
         !startsWith(github.event.pull_request.head.ref, 'bump-version-conformance')
       )
     steps:
+      - name: Mint fleet App token
+        # A real (non-github-actions[bot]) identity is required so the push
+        # below re-fires the bump PR's required checks. No workflow auto-merges
+        # this PR (GitHub blocks self-approval regardless of author identity),
+        # so there's no bypass-actor dependency to preserve here.
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.ORG_PAT_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
@@ -53,7 +66,7 @@ jobs:
       - name: Compute version, bump pyproject + __init__, update CHANGELOG
         id: versions
         env:
-          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: python .github/scripts/conformance_release.py
 
@@ -64,7 +77,7 @@ jobs:
       - name: Push bump branch and open or update PR
         if: steps.versions.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           new_version="${{ steps.versions.outputs.new }}"

--- a/.github/workflows/contract-toolkit-release.yml
+++ b/.github/workflows/contract-toolkit-release.yml
@@ -38,10 +38,23 @@ jobs:
         !startsWith(github.event.pull_request.head.ref, 'bump-version-contract-toolkit')
       )
     steps:
+      - name: Mint fleet App token
+        # A real (non-github-actions[bot]) identity is required so the push
+        # below re-fires the bump PR's required checks. No workflow auto-merges
+        # this PR (GitHub blocks self-approval regardless of author identity),
+        # so there's no bypass-actor dependency to preserve here.
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.ORG_PAT_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install PKL
         run: |
@@ -57,7 +70,7 @@ jobs:
       - name: Compute version, bump PklProject, update CHANGELOG
         id: versions
         env:
-          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: python .github/scripts/contract_toolkit_release.py
 
@@ -68,7 +81,7 @@ jobs:
       - name: Push bump branch and open or update PR
         if: steps.versions.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           new_version="${{ steps.versions.outputs.new }}"

--- a/.github/workflows/dependabot-requirements-sync.yaml
+++ b/.github/workflows/dependabot-requirements-sync.yaml
@@ -16,9 +16,22 @@ jobs:
     name: Sync requirements.txt
     runs-on: ubuntu-latest
     steps:
+      - name: Mint fleet App token
+        # A real (non-github-actions[bot]) identity is required here: the
+        # push below must re-trigger the PR's required checks, which a push
+        # made with the default GITHUB_TOKEN would not. Confirmed empirically
+        # that App-token pushes do re-trigger (see the PR that added this).
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          token: ${{ secrets.ORG_PAT_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.ref }}
 
       - name: Install uv

--- a/.github/workflows/release-version-bump.yaml
+++ b/.github/workflows/release-version-bump.yaml
@@ -73,6 +73,7 @@ jobs:
           app-id: ${{ secrets.FLEET_APP_ID }}
           private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
           owner: atlanhq
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release-version-bump.yaml
+++ b/.github/workflows/release-version-bump.yaml
@@ -45,6 +45,12 @@ on:
       ORG_PAT_GITHUB:
         required: true
         description: "Org PAT for git push and gh pr create"
+      FLEET_APP_ID:
+        required: false
+        description: "atlan-app-fleet App ID (org secret). Not passed explicitly by any current caller — auto-available via 'secrets: inherit'. Declared here so the contract is self-documenting."
+      FLEET_APP_PRIVATE_KEY:
+        required: false
+        description: "atlan-app-fleet App private key (org secret). Same availability as FLEET_APP_ID above."
 
 permissions:
   contents: write
@@ -56,11 +62,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Mint fleet App token
+        # No workflow auto-merges the bump PR this opens (GitHub blocks
+        # self-approval regardless of author identity), so only the re-fire
+        # property matters here, not a specific bypass-actor identity.
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.ORG_PAT_GITHUB }}
+          token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
 
       - name: Checkout SDK helper scripts
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -94,13 +112,13 @@ jobs:
 
       - name: Generate changelog
         env:
-          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: python3 .sdk-scripts/.github/scripts/update_changelog.py "${{ steps.versions.outputs.current }}" "${{ steps.bump.outputs.new }}"
 
       - name: Commit and open PR
         env:
-          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
         run: |
           set -euo pipefail
           git config --global user.name 'atlan-ci'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,15 +76,29 @@ jobs:
             exit 1
           fi
 
+      - name: Mint fleet App token
+        # A real (non-github-actions[bot]) identity is required so the push
+        # below re-fires the bump PR's required checks. This PR always needs
+        # human/codeowner review regardless of author identity (GitHub blocks
+        # self-approval, and no workflow auto-merges bump-version-* PRs), so
+        # there's no bypass-actor dependency here to preserve.
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+
       - name: Generate changelog
         id: changelog
         env:
-          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: python .github/scripts/update_changelog.py "${{ env.CURRENT_VERSION }}" "${{ env.NEW_VERSION }}"
 
       - name: Commit version bump and changelog
         env:
-          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config --global user.name 'atlan-ci'
           git config --global user.email 'it@atlan.com'

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -12,10 +12,19 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
+      - name: Mint fleet App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+
       - name: Close Stale PRs
         uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
         with:
-          repo-token: ${{ secrets.ORG_PAT_GITHUB }}
+          repo-token: ${{ steps.app-token.outputs.token }}
           stale-issue-message: 'Stale Issue'
           stale-pr-message: 'Stale Pull Request'
           stale-issue-label: 'Stale'

--- a/.github/workflows/sdk-review-dismiss-on-human.yml
+++ b/.github/workflows/sdk-review-dismiss-on-human.yml
@@ -77,9 +77,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Mint fleet App token
+        # Dismissing a review or editing a label doesn't require any specific
+        # identity (unlike posting the codeowner approval itself, which must
+        # come from atlan-ci) -- just PR write access, which the App has.
+        # This workflow only ever runs directly in application-sdk (issue_comment/
+        # pull_request_review triggers, not workflow_call), so the org-wide
+        # FLEET_APP_ID/FLEET_APP_PRIVATE_KEY secrets are always available here.
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+
       - name: Dismiss @sdk-review atlan-ci approval(s)
         env:
-          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           # For pull_request_review events the PR number is at
           # event.pull_request.number; for issue_comment on a PR it's

--- a/.github/workflows/sdk-review-downgrade-on-ci-failure.yml
+++ b/.github/workflows/sdk-review-downgrade-on-ci-failure.yml
@@ -50,9 +50,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Mint fleet App token
+        # No specific identity needed (dismiss/label/status/comment ops, not
+        # posting a codeowner approval). Runs only directly in application-sdk
+        # (check_suite trigger, not workflow_call), so the org-wide secrets
+        # are always available.
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+
       - name: Downgrade approval if PR carries sdk-review-approved
         env:
-          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           SUITE_SHA: ${{ github.event.check_suite.head_sha }}
           SUITE_CONCLUSION: ${{ github.event.check_suite.conclusion }}

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -34,6 +34,12 @@ on:
       ORG_PAT_GITHUB:
         required: true
         description: "Org PAT for git tag push and gh release create"
+      FLEET_APP_ID:
+        required: false
+        description: "atlan-app-fleet App ID (org secret). Not passed explicitly by any current caller — auto-available via 'secrets: inherit'. Declared here so the contract is self-documenting."
+      FLEET_APP_PRIVATE_KEY:
+        required: false
+        description: "atlan-app-fleet App private key (org secret). Same availability as FLEET_APP_ID above."
 
 permissions:
   contents: write
@@ -44,11 +50,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Mint fleet App token
+        # Confirmed empirically (atlanhq/atlan-hello-world-app#117) that a
+        # GitHub Release created with an App token re-triggers on:release
+        # workflows in the caller's repo, the same way a real PAT identity
+        # does and the default GITHUB_TOKEN does not.
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.ORG_PAT_GITHUB }}
+          token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
 
       - name: Checkout SDK helper scripts
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -97,7 +116,7 @@ jobs:
       - name: Delete existing GitHub Release (if any)
         run: gh release delete "v${{ steps.get_version.outputs.version }}" --yes 2>/dev/null || true
         env:
-          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
@@ -107,4 +126,4 @@ jobs:
           body_path: .github/release_notes.md
           draft: false
           prerelease: ${{ contains(steps.get_version.outputs.version, '-') }}
-          token: ${{ secrets.ORG_PAT_GITHUB }}
+          token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -62,6 +62,7 @@ jobs:
           app-id: ${{ secrets.FLEET_APP_ID }}
           private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
           owner: atlanhq
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -36,6 +36,12 @@ on:
     secrets:
       ORG_PAT_GITHUB:
         required: false
+      FLEET_APP_ID:
+        required: false
+        description: "atlan-app-fleet App ID (org secret). Not passed explicitly by any current caller — auto-available via 'secrets: inherit'. Declared here so the contract is self-documenting."
+      FLEET_APP_PRIVATE_KEY:
+        required: false
+        description: "atlan-app-fleet App private key (org secret). Same availability as FLEET_APP_ID above."
 
 permissions:
   contents: read
@@ -58,13 +64,23 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Mint fleet App token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+
       - name: Checkout dashboard assets from SDK
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: atlanhq/application-sdk
           path: _sdk
           sparse-checkout: .security
-          token: ${{ secrets.ORG_PAT_GITHUB || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB || secrets.GITHUB_TOKEN }}
 
       - name: Download latest scan artifacts
         id: download


### PR DESCRIPTION
## Summary
Phase 2 Category B of the fleet CI rate-limit remediation: migrates same-repo privileged operations (releases, tags, dependency-sync pushes, sdk-review label/dismiss ops) from the shared `ORG_PAT_GITHUB` user PAT to a minted `atlan-app-fleet` GitHub App token.

**Migrated (12 files):**
- **No identity dependency, same-repo only** — `sdk-review-dismiss-on-human.yml`, `sdk-review-downgrade-on-ci-failure.yml`, `schedule.yaml`: only dismiss reviews (filtered by login, not requiring the acting token to *be* that identity), edit labels, set commit statuses. No codeowner posting, so no `atlan-ci` requirement.
- **Re-fire dependency (verified, not assumed)** — `dependabot-requirements-sync.yaml`, `capability-manifest-regen.yaml`, `release.yaml`, `conformance-release.yml`, `contract-toolkit-release.yml`: push a commit that must re-trigger the PR's required checks (the same property that makes the default `GITHUB_TOKEN` unusable here).
- **Reusable workflows called by consumers** — `auto-fix-vulnerabilities.yaml`, `release-version-bump.yaml`, `tag-and-release.yaml`, `update-dashboard.yaml`: already confirmed all real callers use `secrets: inherit`. `continue-on-error` mint steps + `|| secrets.ORG_PAT_GITHUB` fallback, matching the Category A fix-up pattern.

**Intentionally left on `ORG_PAT_GITHUB` (identity/bypass-actor bound):**
- `check-dapr-version.yaml`, `vuln-auto-merge.yml` — `atlan-ci` is a **ruleset bypass actor** on `main` (not just CODEOWNERS), so its approval/merge bypasses required review entirely. Migrating would need an org-admin ruleset change to add the App as a bypass actor — out of scope here.
- `vuln-reconcile-on-release.yml` — the allowlist-removal PR it opens is auto-merged by `vuln-auto-merge.yml`'s gate script, whose `trusted_authors = {"atlan-ci", "mothership-ai[bot]"}` explicitly checks PR **author** identity. Migrating the author would silently break auto-merge (found by reading the actual gate script, not just the header comment, which only mentioned re-fire).
- `sdk-review-approve-on-verdict.yml` — posts the actual `atlan-ci` codeowner approval directly.
- `harbor-release.yaml` — GHCR/registry auth, deferred to Category C.

**Empirically verified before any of this (not assumed):**
1. A push made with a minted App token triggers a new, separate workflow run (`event: push`, `actor: atlan-app-fleet[bot]`) — confirmed via application-sdk#2669.
2. A GitHub Release created with a minted App token triggers `on: release` workflows the same way — confirmed via atlanhq/atlan-hello-world-app#117 (needed separately since `tag-and-release.yaml` creates a Release, not a push).

## Test plan
- [x] All 12 touched files validated (`python3 -c "import yaml; ..."`)
- [x] `pre-commit` clean on all touched files
- [x] Confirmed the 4 identity-bound exceptions have zero diff
- [x] Empirically verified both re-fire mechanisms (push, release) with real App-token test runs, not assumed
- [ ] Watch the next real release/version-bump cycle and a `/fix-vulnerabilities` or `/regen-manifest` comment to confirm end-to-end in production
