### PR TITLE
chore(ci): verify App token authenticates for BuildKit git-clone secret

### DIFF
--- a/.github/workflows/_throwaway-buildkit-git-test.yaml
+++ b/.github/workflows/_throwaway-buildkit-git-test.yaml
@@ -1,0 +1,40 @@
+name: _throwaway BuildKit Git Clone Test
+on: workflow_dispatch
+permissions:
+  contents: read
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint fleet App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c2be908b74a4a3dccb0d4c2adaee49b6b2f4d556 # v3
+
+      - name: Write test Dockerfile
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/git-clone-test
+          cat > /tmp/git-clone-test/Dockerfile <<'DOCKERFILE'
+          FROM alpine:3.20
+          RUN apk add --no-cache git
+          RUN --mount=type=secret,id=git_token \
+              git config --global url."https://x-access-token:$(cat /run/secrets/git_token)@github.com/".insteadOf "https://github.com/" && \
+              git clone --depth=1 https://github.com/atlanhq/application-sdk.git /tmp/clone-test && \
+              echo "Clone succeeded with App token"
+          DOCKERFILE
+
+      - name: Build with BuildKit secret (App token)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: /tmp/git-clone-test
+          push: false
+          secrets: |
+            git_token=${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Throwaway, workflow_dispatch-only. Verifies the `--mount=type=secret,id=git_token` + `x-access-token` mechanism (used by `build-and-scan.yaml` and others for private git-dependency clones during Docker builds) works with a minted `atlan-app-fleet` App token, not just `ORG_PAT_GITHUB`.

Part of Category C verification for the fleet CI PAT migration. Will be removed via a standalone follow-up PR once the dispatched run confirms the clone succeeds.