### PR TITLE
chore(ci): use a valid GHCR image reference in the throwaway auth test

### DIFF
--- a/.github/workflows/_throwaway-ghcr-auth-test.yaml
+++ b/.github/workflows/_throwaway-ghcr-auth-test.yaml
@@ -38,6 +38,6 @@ jobs:
           COPY README.md /README.md
           DOCKERFILE
           cp README.md /tmp/ghcr-test/README.md 2>/dev/null || echo "test" > /tmp/ghcr-test/README.md
-          docker build -t ghcr.io/atlanhq/application-sdk/_throwaway-ghcr-auth-test:latest /tmp/ghcr-test
-          docker push ghcr.io/atlanhq/application-sdk/_throwaway-ghcr-auth-test:latest
+          docker build -t ghcr.io/atlanhq/application-sdk/throwaway-ghcr-auth-test:latest /tmp/ghcr-test
+          docker push ghcr.io/atlanhq/application-sdk/throwaway-ghcr-auth-test:latest
           echo "GHCR push succeeded with the App token."


### PR DESCRIPTION
The throwaway GHCR auth-test workflow (main) failed with `invalid reference format` — Docker image name components can't start with `_`. Drops the leading underscore from the test image name so the actual GHCR-auth verification can run. Still throwaway/workflow_dispatch-only.