### PR TITLE
chore(ci): pin docker/setup-buildx-action to a real SHA in the throwaway test

### DIFF
--- a/.github/workflows/_throwaway-buildkit-git-test.yaml
+++ b/.github/workflows/_throwaway-buildkit-git-test.yaml
@@ -16,7 +16,7 @@ jobs:
           repositories: application-sdk
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c2be908b74a4a3dccb0d4c2adaee49b6b2f4d556 # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Write test Dockerfile
         run: |


### PR DESCRIPTION
The throwaway BuildKit git-clone test workflow (main) failed at job setup with `Unable to resolve action` — the SHA I pinned for `docker/setup-buildx-action` doesn't exist (fabricated). Swapped in the SHA already pinned for the same action+version elsewhere in this repo (`build-and-scan.yaml`, `build-apps-image.yaml`, etc). Still throwaway/workflow_dispatch-only.