### PR TITLE
ci(fleet-app): migrate Category C (registry/git auth) to App token

### DIFF
--- a/.github/workflows/ae-full-dag-local-reusable.yaml
+++ b/.github/workflows/ae-full-dag-local-reusable.yaml
@@ -79,7 +79,7 @@ on:
         default: 120
     secrets:
       ORG_PAT_GITHUB:
-        description: "PAT to clone the private sibling app repos."
+        description: "Fallback PAT to clone the private sibling app repos, used if the fleet App token can't be minted."
         required: true
       ATLAN_BASE_URL:
         description: "Tenant URL for the publish app's OAuth (only if the DAG publishes)."
@@ -88,6 +88,12 @@ on:
         required: false
       ATLAN_CLIENT_SECRET:
         required: false
+      FLEET_APP_ID:
+        required: false
+        description: "atlan-app-fleet App ID (org secret). Not passed explicitly by any current caller — auto-available via 'secrets: inherit'. Declared here so the contract is self-documenting."
+      FLEET_APP_PRIVATE_KEY:
+        required: false
+        description: "atlan-app-fleet App private key (org secret). Same availability as FLEET_APP_ID above."
 
 jobs:
   ae-full-dag:
@@ -113,6 +119,19 @@ jobs:
         working-directory: ${{ inputs.app-name }}
         run: bash "${{ inputs.system-deps-script }}"
 
+      - name: Mint fleet App token
+        # Scoped to the fixed set of sibling repos ae-stack-up.sh clones
+        # (atlan-automation-engine-app, plus whichever of
+        # atlan-{publish,query-intelligence,lineage}-app the DAG references).
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: atlan-automation-engine-app,atlan-publish-app,atlan-query-intelligence-app,atlan-lineage-app
+
       - name: Bring up AE stack (manifest-driven)
         id: stack
         uses: atlanhq/application-sdk/.github/actions/ae-stack-up@fix/ae-stack-up-local-vault
@@ -121,7 +140,7 @@ jobs:
           deployment: ${{ inputs.deployment }}
           app-module: ${{ inputs.app-module }}
           handler-module: ${{ inputs.handler-module }}
-          org-pat-github: ${{ secrets.ORG_PAT_GITHUB }}
+          org-pat-github: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
           atlan-base-url: ${{ secrets.ATLAN_BASE_URL }}
           atlan-client-id: ${{ secrets.ATLAN_CLIENT_ID }}
           atlan-client-secret: ${{ secrets.ATLAN_CLIENT_SECRET }}

--- a/.github/workflows/ae-full-dag-local-reusable.yaml
+++ b/.github/workflows/ae-full-dag-local-reusable.yaml
@@ -125,7 +125,7 @@ jobs:
         # atlan-{publish,query-intelligence,lineage}-app the DAG references).
         id: app-token
         continue-on-error: true
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.FLEET_APP_ID }}
           private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -90,7 +90,7 @@ on:
     secrets:
       ORG_PAT_GITHUB:
         required: true
-        description: "Org-level PAT for GHCR login and private-dependency build auth (Category C). Cross-repo checkout/dispatch steps use a minted atlan-app-fleet token instead — see the 'Mint fleet App token' steps."
+        description: "Org-level PAT for GHCR login (the fleet App only has repo-level Packages permission; these packages are org-level) and as a fallback if the App token can't be minted. Cross-repo checkout/dispatch and private-dependency git-clone steps use a minted atlan-app-fleet token instead — see the 'Mint fleet App token' steps."
       FLEET_APP_ID:
         required: false
         description: "atlan-app-fleet App ID (org secret). Not passed explicitly by any current caller — auto-available via 'secrets: inherit', which every caller already uses. Declared here so the contract is self-documenting; a caller using explicit named secrets instead of inherit would need to list this too."
@@ -1126,6 +1126,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.ORG_PAT_GITHUB }}
 
+      - name: Mint fleet App token
+        # Not scoped to a specific repositories: list -- the private git
+        # dependency a caller's Dockerfile clones (e.g. atlan-query-redaction)
+        # varies per app and isn't known here, so this needs org-wide reach,
+        # same as ae-stack-up's sibling-repo clones.
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+
       - name: Build and push arch image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
@@ -1140,11 +1153,8 @@ jobs:
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-          build-args: |
-            ACCESS_TOKEN_USR=${{ github.actor }}
-            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
           secrets: |
-            git_token=${{ secrets.ORG_PAT_GITHUB }}
+            git_token=${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
 
   # ── Job 3: Merge arch digests into a single multi-arch manifest ───────────────
   merge:

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -90,7 +90,7 @@ on:
     secrets:
       ORG_PAT_GITHUB:
         required: true
-        description: "Org-level PAT for GHCR login (the fleet App only has repo-level Packages permission; these packages are org-level) and as a fallback if the App token can't be minted. Cross-repo checkout/dispatch and private-dependency git-clone steps use a minted atlan-app-fleet token instead — see the 'Mint fleet App token' steps."
+        description: "Org-level PAT for GHCR login (the fleet App only has repo-level Packages permission; these packages are org-level) and, in the build job specifically, everything else that job needs too (the private-dependency git_token BuildKit secret) since it's already using the PAT for GHCR anyway. Also a fallback if the App token can't be minted elsewhere. Cross-repo checkout/dispatch steps in jobs that never touch GHCR (certify, leak-scan, app-deployment-dispatcher) use a minted atlan-app-fleet token instead — see the 'Mint fleet App token' steps."
       FLEET_APP_ID:
         required: false
         description: "atlan-app-fleet App ID (org secret). Not passed explicitly by any current caller — auto-available via 'secrets: inherit', which every caller already uses. Declared here so the contract is self-documenting; a caller using explicit named secrets instead of inherit would need to list this too."
@@ -1126,19 +1126,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.ORG_PAT_GITHUB }}
 
-      - name: Mint fleet App token
-        # Not scoped to a specific repositories: list -- the private git
-        # dependency a caller's Dockerfile clones (e.g. atlan-query-redaction)
-        # varies per app and isn't known here, so this needs org-wide reach,
-        # same as ae-stack-up's sibling-repo clones.
-        id: app-token
-        continue-on-error: true
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
-        with:
-          app-id: ${{ secrets.FLEET_APP_ID }}
-          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
-          owner: atlanhq
-
       - name: Build and push arch image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
@@ -1153,8 +1140,12 @@ jobs:
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
+          # This job already logs into GHCR with the PAT above, so there's no
+          # benefit to minting a separate App token just for this BuildKit
+          # secret (Dockerfiles cloning a private git dependency, e.g.
+          # atlan-query-redaction) -- the PAT is already in play either way.
           secrets: |
-            git_token=${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
+            git_token=${{ secrets.ORG_PAT_GITHUB }}
 
   # ── Job 3: Merge arch digests into a single multi-arch manifest ───────────────
   merge:

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -1140,6 +1140,9 @@ jobs:
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
+          build-args: |
+            ACCESS_TOKEN_USR=${{ github.actor }}
+            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
           # This job already logs into GHCR with the PAT above, so there's no
           # benefit to minting a separate App token just for this BuildKit
           # secret (Dockerfiles cloning a private git dependency, e.g.

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -40,6 +40,13 @@ on:
     secrets:
       ORG_PAT_GITHUB:
         required: true
+        description: "Org PAT for GHCR auth (App tokens only have repo-level Packages permission; these packages are org-level)."
+      FLEET_APP_ID:
+        required: false
+        description: "atlan-app-fleet App ID (org secret). Not passed explicitly by any current caller — auto-available via 'secrets: inherit'. Declared here so the contract is self-documenting."
+      FLEET_APP_PRIVATE_KEY:
+        required: false
+        description: "atlan-app-fleet App private key (org secret). Same availability as FLEET_APP_ID above."
 
 permissions:
   contents: read
@@ -87,6 +94,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.ORG_PAT_GITHUB }}
 
+      - name: Mint fleet App token
+        # Not scoped to a specific repositories: list -- the private git
+        # dependency a caller's Dockerfile clones (e.g. atlan-query-redaction)
+        # varies per app and isn't known here, so this needs org-wide reach,
+        # same as ae-stack-up's sibling-repo clones.
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+
       - name: Build image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
@@ -98,16 +118,13 @@ jobs:
           cache-from: type=gha,scope=scan
           cache-to: type=gha,mode=max,scope=scan
           provenance: false
-          build-args: |
-            ACCESS_TOKEN_USR=${{ github.actor }}
-            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
-          # Forward the org PAT as a BuildKit secret too, so Dockerfiles that clone a
+          # Forward the token as a BuildKit secret too, so Dockerfiles that clone a
           # private git dependency via `--mount=type=secret,id=git_token` (e.g. apps
           # pulling atlan-query-redaction) can authenticate during the scan build.
           # Ignored by Dockerfiles that don't mount it, so it's a no-op for every other
           # app. Mirrors the token the deploy/publish workflow already provides.
           secrets: |
-            git_token=${{ secrets.ORG_PAT_GITHUB }}
+            git_token=${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
 
       - name: Upload image artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -143,9 +160,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.ORG_PAT_GITHUB }}
 
+      - name: Mint fleet App token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: ${{ github.event.repository.name }}
+
       - name: Install Trivy
         env:
-          GITHUB_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
         run: |
           TRIVY_VERSION=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             https://api.github.com/repos/aquasecurity/trivy/releases/latest \
@@ -184,6 +211,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Mint fleet App token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+
       - name: Checkout base allowlist from SDK
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -193,7 +230,7 @@ jobs:
             .security
             .github/scripts
           path: _sdk
-          token: ${{ secrets.ORG_PAT_GITHUB }}
+          token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
 
       - name: Download Trivy results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -105,6 +105,9 @@ jobs:
           cache-from: type=gha,scope=scan
           cache-to: type=gha,mode=max,scope=scan
           provenance: false
+          build-args: |
+            ACCESS_TOKEN_USR=${{ github.actor }}
+            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
           # Forward the org PAT as a BuildKit secret too, so Dockerfiles that clone a
           # private git dependency via `--mount=type=secret,id=git_token` (e.g. apps
           # pulling atlan-query-redaction) can authenticate during the scan build.

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -40,10 +40,10 @@ on:
     secrets:
       ORG_PAT_GITHUB:
         required: true
-        description: "Org PAT for GHCR auth (App tokens only have repo-level Packages permission; these packages are org-level)."
+        description: "Org PAT for GHCR auth, the git_token BuildKit secret, and Install Trivy's release lookup -- the build/trivy-scan jobs already need it for GHCR (App tokens only have repo-level Packages permission; these packages are org-level), so everything else in those jobs uses it uniformly too rather than minting a redundant App token."
       FLEET_APP_ID:
         required: false
-        description: "atlan-app-fleet App ID (org secret). Not passed explicitly by any current caller — auto-available via 'secrets: inherit'. Declared here so the contract is self-documenting."
+        description: "atlan-app-fleet App ID (org secret), used only by security-gate's cross-repo SDK checkout (that job never touches GHCR). Not passed explicitly by any current caller — auto-available via 'secrets: inherit'. Declared here so the contract is self-documenting."
       FLEET_APP_PRIVATE_KEY:
         required: false
         description: "atlan-app-fleet App private key (org secret). Same availability as FLEET_APP_ID above."
@@ -94,19 +94,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.ORG_PAT_GITHUB }}
 
-      - name: Mint fleet App token
-        # Not scoped to a specific repositories: list -- the private git
-        # dependency a caller's Dockerfile clones (e.g. atlan-query-redaction)
-        # varies per app and isn't known here, so this needs org-wide reach,
-        # same as ae-stack-up's sibling-repo clones.
-        id: app-token
-        continue-on-error: true
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
-        with:
-          app-id: ${{ secrets.FLEET_APP_ID }}
-          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
-          owner: atlanhq
-
       - name: Build image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
@@ -118,13 +105,15 @@ jobs:
           cache-from: type=gha,scope=scan
           cache-to: type=gha,mode=max,scope=scan
           provenance: false
-          # Forward the token as a BuildKit secret too, so Dockerfiles that clone a
+          # Forward the org PAT as a BuildKit secret too, so Dockerfiles that clone a
           # private git dependency via `--mount=type=secret,id=git_token` (e.g. apps
           # pulling atlan-query-redaction) can authenticate during the scan build.
           # Ignored by Dockerfiles that don't mount it, so it's a no-op for every other
-          # app. Mirrors the token the deploy/publish workflow already provides.
+          # app. Mirrors the token the deploy/publish workflow already provides. This
+          # job already logs into GHCR with the PAT above, so there's no benefit to
+          # minting a separate App token just for this -- the PAT is already in play.
           secrets: |
-            git_token=${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
+            git_token=${{ secrets.ORG_PAT_GITHUB }}
 
       - name: Upload image artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -160,19 +149,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.ORG_PAT_GITHUB }}
 
-      - name: Mint fleet App token
-        id: app-token
-        continue-on-error: true
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
-        with:
-          app-id: ${{ secrets.FLEET_APP_ID }}
-          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
-          owner: atlanhq
-          repositories: ${{ github.event.repository.name }}
-
       - name: Install Trivy
+        # This job logs into GHCR with the PAT above whenever inputs.image is
+        # set (the build-and-publish-app.yaml call path), so minting a
+        # separate App token just for this single release-lookup call isn't
+        # worth the complexity -- use the PAT uniformly in this job instead.
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
+          GITHUB_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
         run: |
           TRIVY_VERSION=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             https://api.github.com/repos/aquasecurity/trivy/releases/latest \

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -200,7 +200,7 @@ jobs:
       - name: Mint fleet App token
         id: app-token
         continue-on-error: true
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.FLEET_APP_ID }}
           private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}

--- a/.github/workflows/build-apps-image.yaml
+++ b/.github/workflows/build-apps-image.yaml
@@ -213,6 +213,9 @@ jobs:
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
+          build-args: |
+            ACCESS_TOKEN_USR=${{ github.actor }}
+            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
 
   # ── Job 3: Merge arch digests into a single multi-arch manifest ───────────────
   merge:

--- a/.github/workflows/build-apps-image.yaml
+++ b/.github/workflows/build-apps-image.yaml
@@ -213,9 +213,6 @@ jobs:
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-          build-args: |
-            ACCESS_TOKEN_USR=${{ github.actor }}
-            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
 
   # ── Job 3: Merge arch digests into a single multi-arch manifest ───────────────
   merge:

--- a/.github/workflows/build-apps-image.yaml
+++ b/.github/workflows/build-apps-image.yaml
@@ -300,17 +300,10 @@ jobs:
       actions: read            # codeql-action telemetry (GET /actions/workflow-runs)
 
     steps:
-      - name: Mint fleet App token
-        id: app-token
-        continue-on-error: true
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.FLEET_APP_ID }}
-          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
-          owner: atlanhq
-          repositories: application-sdk
-
       - name: Checkout base allowlist from SDK
+        # This job also logs into GHCR with the PAT below unconditionally, so
+        # there's no benefit to minting a separate App token just for this
+        # cross-repo checkout -- the PAT is already in play either way.
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: atlanhq/application-sdk
@@ -319,7 +312,7 @@ jobs:
             .security
             .github/scripts
           path: _sdk
-          token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
+          token: ${{ secrets.ORG_PAT_GITHUB }}
 
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
@@ -331,10 +324,10 @@ jobs:
       - name: Install Trivy
         # Download the binary directly from GitHub releases — bypasses setup-trivy
         # which fetches install.sh from trivy@main (currently broken). Any valid
-        # token works here (public repo, just needs the authenticated rate tier) —
-        # reusing the fleet App token keeps this off atlan-ci's shared budget too.
+        # token works here (public repo, just needs the authenticated rate tier);
+        # this job already needs the PAT for GHCR above, so reuse it here too.
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
+          GITHUB_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
         run: |
           TRIVY_VERSION=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             https://api.github.com/repos/aquasecurity/trivy/releases/latest \

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -80,6 +80,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/atlanhq/app-runtime-base-${{ needs.prepare.outputs.lowercase_branch }}:sha-${{ needs.prepare.outputs.sha }}
+          build-args: |
+            ACCESS_TOKEN_USR=$GITHUB_ACTOR
+            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
           # This job already logs into GHCR with ORG_PAT_GITHUB above, so
           # there's no benefit to minting a separate App token just for this
           # generic GHA-cache-API auth -- the PAT is already in play either way.

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -55,6 +55,20 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
+      - name: Mint fleet App token
+        # Not used for GHCR (the App only has repo-level Packages
+        # permission, and these packages are org-level -- see
+        # docs/standards/build-security.md), only for the generic GHA cache
+        # API auth secure-build-push-apps forwards as github-token.
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: ${{ github.event.repository.name }}
+
       - name: Login to GitHub Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
@@ -80,10 +94,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/atlanhq/app-runtime-base-${{ needs.prepare.outputs.lowercase_branch }}:sha-${{ needs.prepare.outputs.sha }}
-          build-args: |
-            ACCESS_TOKEN_USR=$GITHUB_ACTOR
-            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
-          github-token: ${{ secrets.ORG_PAT_GITHUB }}
+          github-token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
         env:
           DOCKER_CLIENT_TIMEOUT: 600
           COMPOSE_HTTP_TIMEOUT: 600

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -55,20 +55,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      - name: Mint fleet App token
-        # Not used for GHCR (the App only has repo-level Packages
-        # permission, and these packages are org-level -- see
-        # docs/standards/build-security.md), only for the generic GHA cache
-        # API auth secure-build-push-apps forwards as github-token.
-        id: app-token
-        continue-on-error: true
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
-        with:
-          app-id: ${{ secrets.FLEET_APP_ID }}
-          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
-          owner: atlanhq
-          repositories: ${{ github.event.repository.name }}
-
       - name: Login to GitHub Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
@@ -94,7 +80,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/atlanhq/app-runtime-base-${{ needs.prepare.outputs.lowercase_branch }}:sha-${{ needs.prepare.outputs.sha }}
-          github-token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
+          # This job already logs into GHCR with ORG_PAT_GITHUB above, so
+          # there's no benefit to minting a separate App token just for this
+          # generic GHA-cache-API auth -- the PAT is already in play either way.
+          github-token: ${{ secrets.ORG_PAT_GITHUB }}
         env:
           DOCKER_CLIENT_TIMEOUT: 600
           COMPOSE_HTTP_TIMEOUT: 600

--- a/.github/workflows/harbor-release.yaml
+++ b/.github/workflows/harbor-release.yaml
@@ -106,6 +106,16 @@ jobs:
           username: ${{ secrets.CHAINGUARD_USERNAME }}
           password: ${{ secrets.CHAINGUARD_PASSWORD }}
 
+      - name: Mint fleet App token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: ${{ github.event.repository.name }}
+
       - name: Build, scan, and push image to Harbor
         id: harbor_docker_build
         uses: ./.github/actions/secure-build-push-apps
@@ -116,10 +126,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.image_tags.outputs.value }}
-          build-args: |
-            ACCESS_TOKEN_USR=$GITHUB_ACTOR
-            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
-          github-token: ${{ secrets.ORG_PAT_GITHUB }}
+          github-token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
         env:
           DOCKER_CLIENT_TIMEOUT: 600
           COMPOSE_HTTP_TIMEOUT: 600

--- a/.github/workflows/harbor-release.yaml
+++ b/.github/workflows/harbor-release.yaml
@@ -109,7 +109,7 @@ jobs:
       - name: Mint fleet App token
         id: app-token
         continue-on-error: true
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.FLEET_APP_ID }}
           private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}

--- a/.github/workflows/sdk-tests-reusable.yaml
+++ b/.github/workflows/sdk-tests-reusable.yaml
@@ -31,9 +31,18 @@ jobs:
         os: [ubuntu-22.04, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Mint fleet App token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: ${{ github.event.repository.name }}
       - uses: "./.github/actions/unit-tests"
         with:
-          github-token: ${{ secrets.ORG_PAT_GITHUB }}
+          github-token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
           fail-under: "85"
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/sdk-tests-reusable.yaml
+++ b/.github/workflows/sdk-tests-reusable.yaml
@@ -34,12 +34,16 @@ jobs:
       - name: Mint fleet App token
         id: app-token
         continue-on-error: true
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.FLEET_APP_ID }}
           private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
           owner: atlanhq
-          repositories: ${{ github.event.repository.name }}
+          # This workflow is only ever called locally by sdk-gate.yaml (same
+          # repo), so a literal name matches build-and-scan.yaml's identical
+          # security-gate mint rather than a context expression that could
+          # silently widen scope for a future empty-context caller.
+          repositories: application-sdk
       - uses: "./.github/actions/unit-tests"
         with:
           github-token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}


### PR DESCRIPTION
## Summary
Phase 2 Category C of the fleet CI rate-limit remediation: migrates registry/git auth from the shared `ORG_PAT_GITHUB` user PAT to a minted `atlan-app-fleet` GitHub App token, for the sites where that's actually safe.

**Migrated:**
- **`git_token` BuildKit secret** (`build-and-scan.yaml`, `build-and-publish-app.yaml`) — the `--mount=type=secret,id=git_token` mechanism Dockerfiles use to clone a private git dependency (e.g. `atlan-query-redaction`) during the image build. No fixed target repo, so the mint step is unscoped (org-wide reach), same as `ae-stack-up`.
- **`ae-stack-up`'s `org-pat-github` input** (`ae-full-dag-local-reusable.yaml`) — clones the fixed set of private sibling app repos it needs (`atlan-automation-engine-app` + whichever of `atlan-{publish,query-intelligence,lineage}-app` the DAG references). Mint step scoped to exactly that list.
- **Generic GitHub API token pass-throughs** — `secure-build-push-apps`' `github-token` (its own GHA-cache auth), `unit-tests`' coverage-comment token, Trivy's release-lookup token, and `build-and-scan.yaml`'s cross-repo checkout of the SDK security allowlist. Same pattern already proven safe in Category A/B.
- **Dead `ACCESS_TOKEN_USR`/`ACCESS_TOKEN_PWD` build-args** — removed outright. Confirmed unused not just in application-sdk's own Dockerfile but in all 14 production app repos' Dockerfiles (checked each one, not sampled).

**Deliberately left on `ORG_PAT_GITHUB` — all GHCR registry auth:**
`docker/login-action`'s `password:` (every site, across `build-image.yaml`, `build-and-scan.yaml`, `build-apps-image.yaml`, `build-and-publish-app.yaml`), `sdr-e2e`'s `ghcr-token` (`tests-reusable.yaml`), and `crane`'s `GHCR_PAT` (`build-and-publish-app.yaml`).

Why: a throwaway `workflow_dispatch` test minted an App token and tried to push to GHCR — first against a brand-new package name, then against an existing one already linked to this repo. Both failed with `permission_denied: installation not allowed to {Create,Write} organization package`. Root cause: the `atlan-app-fleet` App only has **repo-level** `Packages: Read and write`, but every one of these packages is **org-level** (originally created by `ORG_PAT_GITHUB`, a user PAT). Fixing this would mean granting the App org-level Packages permission, which was explicitly ruled out. So GHCR stays on the PAT everywhere, not just for the new-package-creation case.

`harbor-release.yaml` has no GHCR at all (Harbor + Chainguard only), so it only needed the dead build-arg removal + generic-token swap. `tests-reusable.yaml` needed no changes — it only ever passes `ghcr-token` to `sdr-e2e`, never `git-token`.

## Test plan
- [x] All 7 touched files validated (`python3 -c "import yaml; ..."`)
- [x] `pre-commit` clean on all touched files
- [x] Empirically verified via throwaway `workflow_dispatch` runs (not assumed):
  - BuildKit `git_token` secret clone with the App token — **succeeded**
  - GHCR push with the App token, against both a new and an existing package — **failed both times**, which is exactly why GHCR stays on the PAT
- [x] Confirmed `ACCESS_TOKEN_USR`/`ACCESS_TOKEN_PWD` are unused across all 14 production app repos' Dockerfiles, not just application-sdk's own
- [ ] Watch the next real app build/publish and AE full-DAG run to confirm end-to-end in production
