### PR TITLE
fix(conformance): migrate renovate-pkl-sync.yaml to App token, fix bootstrap template

### DIFF
--- a/.github/workflows/renovate-pkl-sync.yaml
+++ b/.github/workflows/renovate-pkl-sync.yaml
@@ -34,9 +34,13 @@ name: Sync Pkl contract artifacts for Renovate (Reusable)
 #       # artifact regeneration is ON by default; opt OUT with:
 #       # with:
 #       #   regenerate-contract: false
+#       secrets: inherit
 #
-# The GITHUB_TOKEN in the called workflow inherits the caller's contents:write
-# permission, which is enough to commit and push to the renovate/** branch.
+# This workflow mints a minted atlan-app-fleet App token to push the commit
+# (a real, non-github-actions[bot] identity is needed so the push re-triggers
+# the PR's required checks against the new commit -- a GITHUB_TOKEN push
+# doesn't). Falls back to the caller's push_token, then plain GITHUB_TOKEN,
+# if the App token can't be minted.
 
 on:
   workflow_call:
@@ -58,11 +62,17 @@ on:
     secrets:
       push_token:
         description: >
-          PAT of an org member to use for the commit push. Required on public
-          repos — a GITHUB_TOKEN push from github-actions[bot] triggers
-          GitHub's outside-collaborator workflow re-approval gate. Falls back
-          to GITHUB_TOKEN when omitted (fine for private repos).
+          Fallback PAT of an org member to use for the commit push, if the
+          fleet App token can't be minted. Falls back further to GITHUB_TOKEN
+          if this is also omitted (fine for private repos, but won't re-fire
+          the PR's required checks against the sync commit).
         required: false
+      FLEET_APP_ID:
+        required: false
+        description: "atlan-app-fleet App ID (org secret). Not passed explicitly by any current caller — auto-available via 'secrets: inherit'. Declared here so the contract is self-documenting."
+      FLEET_APP_PRIVATE_KEY:
+        required: false
+        description: "atlan-app-fleet App private key (org secret). Same availability as FLEET_APP_ID above."
 
 permissions:
   contents: write
@@ -72,9 +82,19 @@ jobs:
     name: Re-resolve and regenerate Pkl contract artifacts
     runs-on: ubuntu-latest
     steps:
+      - name: Mint fleet App token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: ${{ github.event.repository.name }}
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          token: ${{ secrets.push_token || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token || secrets.push_token || secrets.GITHUB_TOKEN }}
           ref: ${{ github.ref }}
 
       # Provides `uvx ruff`, used by the driver to format generated Python.

--- a/packages/conformance/conformance/bootstrap/templates/renovate-pkl-sync.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/renovate-pkl-sync.yaml
@@ -17,5 +17,4 @@ permissions:
 jobs:
   sync:
     uses: atlanhq/application-sdk/.github/workflows/renovate-pkl-sync.yaml@main
-    secrets:
-      push_token: ${{ secrets.ORG_PAT_GITHUB }}
+    secrets: inherit

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -944,6 +944,12 @@ def test_tests_yaml_contains_secrets_inherit() -> None:
     assert "secrets: inherit" in content
 
 
+def test_renovate_pkl_sync_yaml_contains_secrets_inherit() -> None:
+    content = render("renovate-pkl-sync.yaml")
+    assert "secrets: inherit" in content
+    assert "push_token" not in content
+
+
 def test_tests_yaml_default_app_name() -> None:
     content = render("tests.yaml")
     assert 'app-name: "app"' in content


### PR DESCRIPTION
## Summary
Phase 2 Category D of the fleet CI PAT migration -- parts 1-2 only (bootstrap template + the SDK's own reusable workflow it wraps). Part 3 (rolling the 13 existing consumer repos over to `secrets: inherit`) is deferred to a follow-up.

**Discovered while sweeping `packages/conformance/conformance/bootstrap/templates/*` for stale `ORG_PAT_GITHUB` references:**
- Every template except one (`build-and-publish.yaml`, `tag-and-publish.yaml`, `release.yaml`, `tests.yaml`, `renovate-auto-approve.yml`) already correctly uses `secrets: inherit`.
- `renovate-pkl-sync.yaml`'s template was the one outlier -- it wires `push_token: ${{ secrets.ORG_PAT_GITHUB }}` explicitly.
- That traces back further: `.github/workflows/renovate-pkl-sync.yaml` (application-sdk's own reusable workflow) was itself missed in the original Category B survey. It's the same shape as `tag-and-release.yaml`/`release-version-bump.yaml` -- pushes a sync commit to the `renovate/**` branch, needs the PR's required checks to re-run against that commit -- but never got an internal App-token mint. It only ever accepted an optional caller-supplied `push_token`, falling back to plain `GITHUB_TOKEN`.
- 13 real app repos already call this workflow with the same stale explicit-`push_token` wiring (confirmed via an org-wide `gh search code`), and there was zero existing test coverage of the template's content, which is why this never got caught.

**Changed:**
- `.github/workflows/renovate-pkl-sync.yaml`: added a `continue-on-error` "Mint fleet App token" step; checkout token is now `steps.app-token.outputs.token || secrets.push_token || secrets.GITHUB_TOKEN`. Declared `FLEET_APP_ID`/`FLEET_APP_PRIVATE_KEY` as optional secrets for self-documentation, matching the established Category B pattern. Updated the header's documented usage example to `secrets: inherit`.
- `packages/conformance/conformance/bootstrap/templates/renovate-pkl-sync.yaml`: switched from explicit `push_token: secrets.ORG_PAT_GITHUB` to `secrets: inherit`.
- `packages/conformance/tests/test_bootstrap.py`: added `test_renovate_pkl_sync_yaml_contains_secrets_inherit`, mirroring the existing `test_tests_yaml_contains_secrets_inherit`, so this can't silently drift again.

**Deferred (part 3, tracked as a follow-up):** 13 individual app-repo PRs switching their own `.github/workflows/renovate-pkl-sync.yaml` from explicit `push_token: ORG_PAT_GITHUB` to `secrets: inherit` -- same shape as the renovate-auto-approve rollout. Not breaking to defer: `continue-on-error` + the fallback chain means these existing callers keep working unchanged on the PAT until each opts in individually.

## Test plan
- [x] Both touched workflow YAML files validated (`python3 -c "import yaml; ..."`)
- [x] Full `packages/conformance` bootstrap test suite green (138 passed), including the new regression test
- [x] `pre-commit` clean on all touched files
- [x] Confirmed via org-wide `gh search code` that every other bootstrap template already uses `secrets: inherit` -- this was the one outlier
