### PR TITLE
fix(workflows): fail fast on invalid workflow input instead of retrying forever

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -1643,6 +1643,13 @@ def _validate_workflow_input(raw_input: Any, input_type: type[Input]) -> Input:
     permissive annotation is confined to this generated wire boundary; there is no
     path by which a raw payload reaches app code, and app authors cannot opt into it.
 
+    Note that this validates in pydantic's python/lax mode (``model_validate`` on a
+    decoded dict) rather than the json mode the removed typed annotation gave Temporal's
+    data converter. The two are equivalent for every field type a permitted ``Input``
+    tree allows — ``bytes``/``bytearray``, the one genuinely mode-divergent type, is
+    forbidden by ``validate_payload_safety`` (contracts/base.py). A maintainer adding a
+    custom, mode-sensitive pydantic type to a contract should re-check that equivalence.
+
     Args:
         raw_input: The decoded payload — a dict from the wire, or (unit tests / the
             in-process ``/start`` path) an already-constructed ``input_type``.

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -1621,6 +1621,68 @@ async def _run_preflight_gate(
     # Success: the activity already emitted the proceeded outcome event.
 
 
+def _validate_workflow_input(raw_input: Any, input_type: type) -> Any:
+    """Validate a decoded workflow payload against the entry point's typed contract.
+
+    The generated workflow declares its argument to Temporal with a permissive
+    ``Any`` annotation (see ``generate_workflow_class``). That is deliberate: if the
+    argument were annotated as ``input_type``, Temporal's pydantic data converter
+    would validate the payload while *decoding the workflow task*, and a bad payload
+    would surface as a Workflow *Task* failure — which Temporal retries with backoff
+    **indefinitely** (there is no max-attempts for workflow tasks). A permanently
+    invalid input (e.g. a required object field sent as ``""``) would then retry
+    forever instead of failing.
+
+    Validating here, inside the workflow body, converts that into a clean,
+    non-retryable workflow *execution* failure that fails fast.
+
+    This does **not** loosen or bypass the typed contract. The payload is validated
+    against exactly ``input_type`` — the same model the entry point declares — before
+    any app code runs, and the fully typed, validated model is what every downstream
+    caller (preflight gate, ``_log_summary``, the entry point method) receives. The
+    permissive annotation is confined to this generated wire boundary; there is no
+    path by which a raw payload reaches app code, and app authors cannot opt into it.
+
+    Args:
+        raw_input: The decoded payload — a dict from the wire, or (unit tests / the
+            in-process ``/start`` path) an already-constructed ``input_type``.
+        input_type: The entry point's typed input contract.
+
+    Returns:
+        A validated ``input_type`` instance.
+
+    Raises:
+        ApplicationError: non-retryable, if the payload does not satisfy ``input_type``.
+    """
+    if isinstance(raw_input, input_type):
+        # Already the typed model (constructed by the SDK /start path or a test);
+        # it was validated at construction, so re-validation would be redundant.
+        return raw_input
+
+    # deferred import: circular — execution/__init__.py loads _temporal which imports app.base
+    from application_sdk.execution.errors import ApplicationError  # noqa: PLC0415
+
+    try:
+        return input_type.model_validate(raw_input)
+    # conformance: ignore[E004] deterministic input-validation failure; logged via _safe_log with exc_info=True and re-raised as a non-retryable ApplicationError
+    except Exception as e:
+        _safe_log(
+            "error",
+            "Workflow input failed validation against its typed contract",
+            input_type=input_type.__name__,
+            exc_info=True,
+        )
+        # Non-retryable: a payload that fails schema validation is deterministic —
+        # retrying the same input can never succeed. Failing the execution now
+        # avoids the indefinite Workflow Task retry loop that a decode-time failure
+        # would cause.
+        raise ApplicationError(
+            f"Invalid workflow input for {input_type.__name__}: {e}",
+            type="InputValidationError",
+            non_retryable=True,
+        ) from e
+
+
 def generate_workflow_class(app_cls: "type[App]", ep: "EntryPointMetadata") -> type:
     """Generate a Temporal workflow class for one entry point.
 
@@ -1665,10 +1727,20 @@ def generate_workflow_class(app_cls: "type[App]", ep: "EntryPointMetadata") -> t
             input_type.__name__,
         )
 
-    async def _run(self, input_data: Input) -> Output:
+    # input_data is annotated ``Any`` (not ``input_type``) so Temporal's data
+    # converter decodes the payload without validating it — validation happens
+    # below via _validate_workflow_input so a bad payload fails the workflow
+    # execution (fast, non-retryable) instead of failing the workflow *task*
+    # (retried by the server indefinitely). See _validate_workflow_input.
+    async def _run(self, input_data: Any) -> Output:
         # deferred imports: inside Temporal sandbox (workflow.unsafe.imports_passed_through context)
         # BLDX-878: inter-app calls deactivated pending review.
         # from application_sdk.app.client import WorkflowAppClient
+
+        # Fail fast on a malformed / wrong-typed payload, before any setup runs.
+        # Enforces the entry point's typed contract at the workflow boundary.
+        input_data = _validate_workflow_input(input_data, input_type)
+
         start_time = _safe_now()
         run_id = workflow.info().run_id
         workflow_id = workflow.info().workflow_id
@@ -1851,7 +1923,13 @@ def generate_workflow_class(app_cls: "type[App]", ep: "EntryPointMetadata") -> t
     _run.__name__ = "run"
     _run.__qualname__ = f"{cls_name}.run"
     _run.__module__ = app_cls.__module__
-    _run.__annotations__ = {"input_data": input_type, "return": output_type}
+    # input_data is decoded as ``Any`` on purpose: this is the annotation Temporal's
+    # pydantic data converter reads to decode the workflow task. Decoding as ``Any``
+    # keeps validation out of the converter (where a failure = an indefinitely
+    # retried Workflow Task failure) and defers it to _validate_workflow_input inside
+    # the run body, which enforces ``input_type`` and fails fast on a bad payload.
+    # The return type stays typed so results are still validated/serialized normally.
+    _run.__annotations__ = {"input_data": Any, "return": output_type}
 
     decorated_run = workflow.run(_run)
 

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -1740,12 +1740,18 @@ def generate_workflow_class(app_cls: "type[App]", ep: "EntryPointMetadata") -> t
         # Fail fast on a malformed / wrong-typed payload, before any setup runs.
         # Enforces the entry point's typed contract at the workflow boundary.
         #
-        # Placement is deliberate: this MUST stay above the outer try/except below
-        # (which re-wraps exceptions into ApplicationError). _validate_workflow_input
-        # already raises a non_retryable=True ApplicationError; moving this call
-        # inside that block would re-wrap it with non_retryable derived from
-        # RetryableError membership, flipping it back to retryable and
-        # reintroducing the indefinite Workflow Task retry loop this fix removes.
+        # Placement is deliberate — this MUST stay above the setup and the outer
+        # try/except below, for two reasons:
+        #   1. Downstream code (the preflight gate, _log_summary, the entry method)
+        #      requires a validated typed model; it must never see the raw dict the
+        #      Any-annotated argument decodes to.
+        #   2. It preserves pre-PR behavior: previously a bad payload failed during
+        #      Temporal's decode, so neither the _run body nor the on_complete()
+        #      finally ran. Moving this into the try/except would run on_complete()
+        #      for an input that never entered the workflow proper.
+        # (Retryability is not the reason: the raised ApplicationError is a
+        # FailureError subclass, so the outer handler's `isinstance(e, FailureError)`
+        # branch would bare re-raise it, preserving non_retryable=True either way.)
         input_data = _validate_workflow_input(input_data, input_type)
 
         start_time = _safe_now()

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -1621,7 +1621,7 @@ async def _run_preflight_gate(
     # Success: the activity already emitted the proceeded outcome event.
 
 
-def _validate_workflow_input(raw_input: Any, input_type: type) -> Any:
+def _validate_workflow_input(raw_input: Any, input_type: type[Input]) -> Input:
     """Validate a decoded workflow payload against the entry point's typed contract.
 
     The generated workflow declares its argument to Temporal with a permissive
@@ -1739,6 +1739,13 @@ def generate_workflow_class(app_cls: "type[App]", ep: "EntryPointMetadata") -> t
 
         # Fail fast on a malformed / wrong-typed payload, before any setup runs.
         # Enforces the entry point's typed contract at the workflow boundary.
+        #
+        # Placement is deliberate: this MUST stay above the outer try/except below
+        # (which re-wraps exceptions into ApplicationError). _validate_workflow_input
+        # already raises a non_retryable=True ApplicationError; moving this call
+        # inside that block would re-wrap it with non_retryable derived from
+        # RetryableError membership, flipping it back to retryable and
+        # reintroducing the indefinite Workflow Task retry loop this fix removes.
         input_data = _validate_workflow_input(input_data, input_type)
 
         start_time = _safe_now()

--- a/tests/unit/app/test_base.py
+++ b/tests/unit/app/test_base.py
@@ -1164,8 +1164,10 @@ class TestGenerateWorkflowClass:
             # "Input should be an object [input_value='', input_type=str]" failure.
             await wf_cls.run(mock.MagicMock(), "not-an-object")
 
-        assert getattr(exc.value, "non_retryable", None) is True
-        assert getattr(exc.value, "type", None) == "InputValidationError"
+        # Direct attribute access (not getattr-with-default): a contract-drift
+        # rename should surface as an AttributeError, not a silent None mismatch.
+        assert exc.value.non_retryable is True
+        assert exc.value.type == "InputValidationError"
         # The entry method never ran — we failed before any app code.
         assert ran == []
 

--- a/tests/unit/app/test_base.py
+++ b/tests/unit/app/test_base.py
@@ -32,6 +32,7 @@ from application_sdk.app.base import (
     _safe_now,
     _safe_uuid,
     _scan_entrypoints,
+    _validate_workflow_input,
     _workflow_class_cache,
     _wrap_instance_tasks,
     generate_workflow_class,
@@ -1167,6 +1168,14 @@ class TestGenerateWorkflowClass:
         assert getattr(exc.value, "type", None) == "InputValidationError"
         # The entry method never ran — we failed before any app code.
         assert ran == []
+
+    def test_validate_workflow_input_returns_typed_instance_unchanged(self) -> None:
+        """An already-typed instance is returned as the same object (fast-path),
+        not re-validated into a copy. Guards against a future refactor silently
+        dropping the ``isinstance`` early return."""
+        instance = _BLDXInput(value="hi")
+        result = _validate_workflow_input(instance, _BLDXInput)
+        assert result is instance
 
     def _patched_workflow_layer(self, info_mock: mock.MagicMock):
         """Returns a contextlib.ExitStack wired with the patches every _run test needs."""

--- a/tests/unit/app/test_base.py
+++ b/tests/unit/app/test_base.py
@@ -1081,6 +1081,93 @@ class TestGenerateWorkflowClass:
         assert results == ["ran:hi"]
         on_complete.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_run_raw_dict_payload_is_validated_into_typed_model(self) -> None:
+        """A raw wire payload (dict) is validated into the typed contract before the
+        entry method runs — the entry point still receives a typed model, so the
+        permissive Any annotation is not a bypass of the typed contract."""
+        seen: list[object] = []
+
+        class DictApp(App):
+            async def run(self, input: _BLDXInput) -> _BLDXOutput:
+                seen.append(input)
+                return _BLDXOutput(result="ok")
+
+        ep = self._make_ep(_BLDXInput, _BLDXOutput)
+        with (
+            mock.patch(
+                "application_sdk.app.base.workflow.run", side_effect=lambda f: f
+            ),
+            mock.patch(
+                "application_sdk.app.base.workflow.defn",
+                side_effect=lambda **_: lambda c: c,
+            ),
+        ):
+            wf_cls = generate_workflow_class(DictApp, ep)
+
+        info_mock = mock.MagicMock(run_id="r", workflow_id="w")
+        with (
+            self._patched_workflow_layer(info_mock),
+            mock.patch.object(DictApp, "on_complete", new_callable=mock.AsyncMock),
+            mock.patch(
+                "application_sdk.observability.correlation.get_correlation_context",
+                return_value=None,
+            ),
+        ):
+            # Pass a dict, as Temporal's data converter yields under the Any annotation.
+            out = await wf_cls.run(mock.MagicMock(), {"value": "hi"})
+
+        assert isinstance(out, _BLDXOutput)
+        assert len(seen) == 1
+        # Entry method received a fully typed, validated model — not the raw dict.
+        assert isinstance(seen[0], _BLDXInput)
+        assert seen[0].value == "hi"
+
+    @pytest.mark.asyncio
+    async def test_run_invalid_payload_fails_fast_non_retryable(self) -> None:
+        """An invalid payload fails as a non-retryable workflow *execution* error
+        (fast) rather than an unvalidated decode failure that Temporal would retry
+        as a Workflow Task indefinitely."""
+        ran: list[object] = []
+
+        class StrictApp(App):
+            async def run(self, input: _BLDXInput) -> _BLDXOutput:
+                ran.append(input)
+                return _BLDXOutput(result="ok")
+
+        ep = self._make_ep(_BLDXInput, _BLDXOutput)
+        with (
+            mock.patch(
+                "application_sdk.app.base.workflow.run", side_effect=lambda f: f
+            ),
+            mock.patch(
+                "application_sdk.app.base.workflow.defn",
+                side_effect=lambda **_: lambda c: c,
+            ),
+        ):
+            wf_cls = generate_workflow_class(StrictApp, ep)
+
+        from application_sdk.execution.errors import ApplicationError
+
+        info_mock = mock.MagicMock(run_id="r", workflow_id="w")
+        with (
+            self._patched_workflow_layer(info_mock),
+            mock.patch.object(StrictApp, "on_complete", new_callable=mock.AsyncMock),
+            mock.patch(
+                "application_sdk.observability.correlation.get_correlation_context",
+                return_value=None,
+            ),
+            pytest.raises(ApplicationError) as exc,
+        ):
+            # A bare string where an object is required — mirrors the observed
+            # "Input should be an object [input_value='', input_type=str]" failure.
+            await wf_cls.run(mock.MagicMock(), "not-an-object")
+
+        assert getattr(exc.value, "non_retryable", None) is True
+        assert getattr(exc.value, "type", None) == "InputValidationError"
+        # The entry method never ran — we failed before any app code.
+        assert ran == []
+
     def _patched_workflow_layer(self, info_mock: mock.MagicMock):
         """Returns a contextlib.ExitStack wired with the patches every _run test needs."""
         import contextlib


### PR DESCRIPTION
## Problem

When a workflow is dispatched with a schema-invalid payload (observed: a required object field sent as an empty string, `spec_file=''`), the run does **not** fail fast. It retries for 10+ minutes — in fact indefinitely — despite the input being permanently unusable.

### Root cause

The generated workflow's `run` argument was annotated with the entry point's typed contract (`input_type`). That annotation is what Temporal's pydantic data converter reads to decode the workflow task, so validation happened **during argument decoding**, before the run body executes.

A decode-time `ValidationError` surfaces as a **Workflow *Task* failure**, not a workflow *execution* failure. Temporal retries workflow tasks with backoff **indefinitely** (there is no max-attempts for workflow tasks) — by design, since a task failure normally means a transient bug or bad deploy. But a bad *input* is deterministic and permanent, so it inherits retry-forever treatment and never terminates.

The SDK already guards against this for exceptions raised *inside* the run body (`generate_workflow_class` wraps them in a non-retryable `ApplicationError`), but argument decoding happens one step earlier, so that guard never runs.

Only the direct-to-Temporal dispatch path hit this. The SDK `/start` HTTP path already validated up front via `model_validate` and failed fast.

## Fix

- Decode the workflow argument as `Any` (the `__annotations__` override), keeping validation out of the data converter.
- Validate against the entry point's `input_type` **inside** the run body via the new `_validate_workflow_input` helper, as the first statement — before any setup.
- On failure, raise a **non-retryable** `ApplicationError` (`type="InputValidationError"`), failing the workflow execution in seconds.

### This does not loosen or bypass the typed contract

- The payload is validated against exactly the declared `input_type` before any app code runs; the entry point still receives a fully typed, validated instance.
- The permissive annotation is confined to the SDK-generated `_run`; app authors can't reach it or opt into it.
- An `isinstance` fast-path passes an already-typed model through untouched (SDK `/start` path, tests), so no redundant re-validation.

### Equivalence check

Decoding as `Any` + `model_validate` (python mode) instead of the converter's `validate_json` is behaviorally equivalent for these contracts. The full `ExtractionInput` tree uses only `str`/`int`/`bool`/`list[str]`/bounded `dict`/nested `BaseModel` fields — all identical lax coercion in both modes. The one type that genuinely diverges (`bytes`/`bytearray`) is forbidden as an `Input` field by the existing `validate_payload_safety` guard, so it cannot appear.

## Behavior change

- **Invalid input**: workflow now fails in seconds, non-retryable, with `Invalid workflow input for <Contract>: ...` — instead of retrying forever.
- **`/start` HTTP path**: unchanged.
- **Automation Engine direct dispatch** (the path that had the bug): now fails fast.

## Tests

- `test_run_raw_dict_payload_is_validated_into_typed_model` — a raw dict payload is validated into the typed model before the entry method runs (proves no bypass).
- `test_run_invalid_payload_fails_fast_non_retryable` — an invalid payload raises a non-retryable `ApplicationError` and the entry method never runs.

Full `tests/unit` suite passes (5646 passed, 9 skipped); pre-commit clean.