### PR TITLE
fix(e2e): per-leg task-queue isolation for the matrix e2e suites

### DIFF
--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -409,6 +409,26 @@ runs:
           echo "APP_YAML_PATH=$APP_YAML"
         } >> "$GITHUB_ENV"
 
+    # Give each matrix leg its own worker + Temporal queue. The queue is
+    # atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}; parallel legs
+    # share the run id, so without a per-leg suffix their workers co-serve one
+    # queue and Temporal splits a single workflow's activities across them —
+    # which, under the two-store posture (per-container localstorage), makes a
+    # FileReference written by one leg's worker invisible to the other. Derive a
+    # per-leg ATLAN_DEPLOYMENT_NAME (base + sanitised artifact-suffix) here, so
+    # both the worker (compose reads it below) and the harness (agent_spec reads
+    # the same env) land on the same isolated queue. Empty suffix (single-suite
+    # callers) keeps the original e2e-full-ci-<run_id> shape.
+    - name: Derive per-leg deployment name
+      shell: bash
+      env:
+        SDR_E2E_ROOT: ${{ steps.action_root.outputs.path }}
+        ARTIFACT_SUFFIX: ${{ inputs.artifact-suffix }}
+      run: |
+        python3 "$SDR_E2E_ROOT/derive_deployment_name.py" \
+          --run-id "${GITHUB_RUN_ID}" \
+          --suffix "${ARTIFACT_SUFFIX}" >> "$GITHUB_ENV"
+
     - name: Resolve app.yaml
       shell: bash
       env:

--- a/.github/actions/sdr-e2e/derive_deployment_name.py
+++ b/.github/actions/sdr-e2e/derive_deployment_name.py
@@ -1,0 +1,68 @@
+"""Derive the per-leg ``ATLAN_DEPLOYMENT_NAME`` for the sdr-e2e composite action.
+
+The worker container derives its Temporal task queue as
+``atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}`` (see
+``application_sdk.main._derive_task_queue``). When the e2e suite is fanned out
+across parallel matrix legs (one job per ``tests/e2e/test_*.py`` file) every leg
+shares the same GitHub run id — so without a per-leg discriminator all legs'
+workers register on the *same* queue. Temporal then load-balances a single
+workflow's activities across whichever leg-workers are co-serving that queue,
+and under the two-store CI posture (per-container localstorage) an artifact
+written by one leg's worker is invisible to the other → spurious
+``[AAF-STR-001] FileReference ... resolved to no objects`` failures.
+
+Appending the matrix leg name (the action's ``artifact-suffix``) to the
+deployment name gives each leg its own queue + worker, restoring isolation. The
+e2e harness derives its extract-node queue from the same two env vars
+(``BaseE2ETest.agent_spec``), so worker and harness stay in lock-step with no
+per-connector hard-coding.
+
+Prints one ``ATLAN_DEPLOYMENT_NAME=<value>`` line suitable for
+``>> "$GITHUB_ENV"``. Kept out of inline ``run:`` shell per
+``docs/standards/ci.md`` (conditional logic belongs in tested Python).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+
+# The full-DAG CI deployment convention; matches BaseE2ETest.connection_name_prefix.
+_BASE_PREFIX = "e2e-full-ci"
+# Collapse anything outside a conservative charset to a single hyphen so the
+# derived queue name stays log-friendly and stable across the worker + harness.
+_SANITIZE = re.compile(r"[^A-Za-z0-9]+")
+
+
+def derive(run_id: str, suffix: str) -> str:
+    """Return ``e2e-full-ci-<run_id>[-<suffix>]``.
+
+    *run_id* falls back to ``local`` when empty (developer / non-CI runs).
+    *suffix* (the matrix leg name) is sanitised and appended only when set; a
+    single-suite (non-matrix) run passes an empty suffix and keeps the original
+    ``e2e-full-ci-<run_id>`` shape, so existing callers are unaffected.
+    """
+    run_token = run_id.strip() or "local"
+    name = f"{_BASE_PREFIX}-{run_token}"
+    leg = _SANITIZE.sub("-", suffix.strip()).strip("-").lower()
+    if leg:
+        name = f"{name}-{leg}"
+    return name
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--run-id", default="", help="GitHub run id (GITHUB_RUN_ID)."
+    )
+    parser.add_argument(
+        "--suffix",
+        default="",
+        help="Matrix leg name (the action's artifact-suffix). Empty = single suite.",
+    )
+    args = parser.parse_args()
+    print(f"ATLAN_DEPLOYMENT_NAME={derive(args.run_id, args.suffix)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/sdr-e2e/derive_deployment_name.py
+++ b/.github/actions/sdr-e2e/derive_deployment_name.py
@@ -52,9 +52,7 @@ def derive(run_id: str, suffix: str) -> str:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--run-id", default="", help="GitHub run id (GITHUB_RUN_ID)."
-    )
+    parser.add_argument("--run-id", default="", help="GitHub run id (GITHUB_RUN_ID).")
     parser.add_argument(
         "--suffix",
         default="",

--- a/.github/scripts/tests/test_derive_deployment_name.py
+++ b/.github/scripts/tests/test_derive_deployment_name.py
@@ -1,0 +1,54 @@
+"""Tests for .github/actions/sdr-e2e/derive_deployment_name.py.
+
+Mirrors test_build_compose_chain.py: the module under test lives under
+.github/actions/sdr-e2e/ (invoked by the composite action), the test lives here.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "actions" / "sdr-e2e"))
+
+from derive_deployment_name import derive, main  # noqa: E402
+
+
+def test_no_suffix_keeps_single_suite_shape() -> None:
+    assert derive("12345", "") == "e2e-full-ci-12345"
+
+
+def test_suffix_is_appended() -> None:
+    assert derive("12345", "connection-create") == "e2e-full-ci-12345-connection-create"
+
+
+def test_distinct_suffixes_yield_distinct_names() -> None:
+    a = derive("12345", "connection-create")
+    b = derive("12345", "connection-reuse")
+    assert a != b
+
+
+def test_empty_run_id_falls_back_to_local() -> None:
+    assert derive("", "connection-reuse") == "e2e-full-ci-local-connection-reuse"
+
+
+def test_suffix_is_sanitised_and_lowercased() -> None:
+    # Whitespace / mixed case / stray punctuation collapse to hyphen-joined lower.
+    assert derive("7", " Connection Create! ") == "e2e-full-ci-7-connection-create"
+
+
+def test_suffix_of_only_punctuation_is_dropped() -> None:
+    assert derive("7", "///") == "e2e-full-ci-7"
+
+
+def test_run_id_is_stripped() -> None:
+    assert derive("  99  ", "") == "e2e-full-ci-99"
+
+
+def test_main_prints_github_env_line(capsys: pytest.CaptureFixture[str]) -> None:
+    sys.argv = ["derive_deployment_name.py", "--run-id", "42", "--suffix", "conn-x"]
+    main()
+    out = capsys.readouterr().out.strip()
+    assert out == "ATLAN_DEPLOYMENT_NAME=e2e-full-ci-42-conn-x"

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -222,9 +222,12 @@ jobs:
   # ── Full-DAG e2e (system apps — extract→qi→publish→lineage) ─────────────
   # One matrix leg per discovered suite. fail-fast:false so one suite's failure
   # doesn't cancel the others, and "Re-run failed jobs" re-runs only the failed
-  # leg. Each leg spins its own worker container polling the shared task queue;
-  # legs are independent (own connection + AE workflow slug), so co-serving is
-  # harmless. 120-min timeout (> ae_poll + atlas_poll + build/setup overhead).
+  # leg. Each leg spins its own worker container on its OWN Temporal queue: the
+  # sdr-e2e action derives a per-leg ATLAN_DEPLOYMENT_NAME (base + artifact-
+  # suffix) so legs don't co-serve one queue — under the two-store posture a
+  # shared queue lets Temporal split a workflow's activities across leg-workers
+  # with per-container localstorage, hiding artifacts cross-worker. 120-min
+  # timeout (> ae_poll + atlas_poll + build/setup overhead).
   e2e:
     name: End-to-end (${{ matrix.name }})
     needs: discover-e2e

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -7,7 +7,6 @@ A connector test:
     import os
     import pytest
     from application_sdk.testing.e2e import BaseE2ETest, RunMode
-    from application_sdk.testing.e2e.payload import AgentSpec
 
     @pytest.mark.e2e
     class TestOpenAPIE2E(BaseE2ETest):
@@ -15,8 +14,10 @@ A connector test:
         connection_name_prefix = "e2e-ci"
         expected_min_asset_counts = {"APISpec": 1, "APIPath": 10}
 
-        def agent_spec(self) -> AgentSpec:
-            return AgentSpec(agent_name=f"openapi-e2e-ci-{self.run_id}")
+    # agent_spec() is derived from ATLAN_APPLICATION_NAME + ATLAN_DEPLOYMENT_NAME
+    # by default (matching the worker's atlan-{app}-{deployment} queue, including
+    # any per-leg suffix the CI action sets). Override it only to pin an explicit
+    # queue — a run_id-keyed override would silently drop per-leg isolation.
 
 The base class handles submit + native-status poll + Atlas-side
 Connection assertion + per-node duration reporting. Subclasses provide
@@ -473,6 +474,12 @@ class BaseE2ETest:
         matrix leg its own worker + queue (avoiding cross-worker artifact
         invisibility under the two-store posture). Subclasses may still override
         to pin an explicit agent identity.
+
+        Only the two-var shape is derivable here. A worker deployed with
+        ATLAN_APPLICATION_NAME set but ATLAN_DEPLOYMENT_NAME absent polls the
+        bare ``{app}`` queue (see _derive_task_queue's middle branch); the
+        harness can't reconstruct that from env alone, so such deployments must
+        override agent_spec() explicitly.
         """
         if self.mode is RunMode.DIRECT:
             return None

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -458,11 +458,34 @@ class BaseE2ETest:
     # ------------------------------------------------------------------
 
     def agent_spec(self) -> AgentSpec | None:
-        """Agent identity (tier 4 only). Return None for direct mode."""
+        """Agent identity (tier 4 only). Return None for direct mode.
+
+        Default (AGENT mode): derive the agent identity from the worker's own
+        deployment env so the extract node is dispatched to exactly the queue
+        the deployed worker polls — no per-connector hard-coding. The worker
+        derives its Temporal queue as
+        ``atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}`` (see
+        :func:`application_sdk.main._derive_task_queue`); mirroring that here as
+        ``agent_name = {ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}`` makes
+        :meth:`_extract_task_queue` (``atlan-{agent_name}``) equal the worker
+        queue automatically. In particular this picks up any *per-leg*
+        ``ATLAN_DEPLOYMENT_NAME`` the CI action sets to give each parallel
+        matrix leg its own worker + queue (avoiding cross-worker artifact
+        invisibility under the two-store posture). Subclasses may still override
+        to pin an explicit agent identity.
+        """
         if self.mode is RunMode.DIRECT:
             return None
+        app_name = os.environ.get("ATLAN_APPLICATION_NAME", "")
+        deployment_name = os.environ.get("ATLAN_DEPLOYMENT_NAME", "")
+        if app_name and deployment_name:
+            return AgentSpec(agent_name=f"{app_name}-{deployment_name}")
         raise HarnessMethodNotImplementedError(
-            message="subclass must override agent_spec() for AGENT mode",
+            message=(
+                "AGENT mode needs an agent_spec() override, or both "
+                "ATLAN_APPLICATION_NAME and ATLAN_DEPLOYMENT_NAME set in the "
+                "environment to derive the worker's task queue"
+            ),
             operation="agent_spec",
         )
 

--- a/application_sdk/testing/e2e/sql_app.py
+++ b/application_sdk/testing/e2e/sql_app.py
@@ -111,9 +111,20 @@ class SQLAppE2ETest(BaseE2ETest):
         )
 
     def agent_spec(self) -> AgentSpec | None:
-        """Default AGENT-mode agent identity, or None in DIRECT mode."""
+        """Default AGENT-mode agent identity, or None in DIRECT mode.
+
+        Prefer the base env-derivation (``atlan-{app}-{deployment}``) when the
+        worker's ATLAN_APPLICATION_NAME + ATLAN_DEPLOYMENT_NAME are set, so SQL
+        apps inherit per-leg queue isolation with no per-connector hard-coding.
+        Fall back to the ``agent_name_template`` (run_id-keyed) only when the
+        deployment env is absent — e.g. an Argo template that pins its own queue.
+        """
         if self.mode is RunMode.DIRECT:
             return None
+        if os.environ.get("ATLAN_APPLICATION_NAME") and os.environ.get(
+            "ATLAN_DEPLOYMENT_NAME"
+        ):
+            return super().agent_spec()
         return AgentSpec(
             agent_name=self.agent_name_template.format(
                 connector=self.connector_short_name,

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -10,7 +10,7 @@ A connector test:
         BaseFullDAGE2ETest, RunMode,
     )
     from application_sdk.testing.full_dag.payload import (
-        ConnectionSpec, DatabaseSpec, AgentSpec,
+        ConnectionSpec, DatabaseSpec,
     )
 
     @pytest.mark.full_dag_e2e
@@ -31,8 +31,10 @@ A connector test:
                 password=os.environ["MYSQL_PASSWORD"],
             )
 
-        def agent_spec(self) -> AgentSpec | None:
-            return AgentSpec(agent_name=f"ci-{self.run_id}")
+    # agent_spec() is derived from ATLAN_APPLICATION_NAME + ATLAN_DEPLOYMENT_NAME
+    # by default (matching the worker's atlan-{app}-{deployment} queue, including
+    # any per-leg suffix the CI action sets). Override it only to pin an explicit
+    # queue — a run_id-keyed override would silently drop per-leg isolation.
 
 The base class handles submit + native-status poll + Atlas-side
 Connection assertion + per-node duration reporting. Subclasses just

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -342,9 +342,17 @@ class BaseFullDAGE2ETest:
         deployment env so the extract node lands on exactly the queue the
         deployed worker polls (``atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}``),
         including any per-leg ``ATLAN_DEPLOYMENT_NAME`` the CI action sets to
-        isolate parallel matrix legs. Mirrors
-        :meth:`application_sdk.testing.e2e.base.BaseE2ETest.agent_spec` (this
-        module is the deprecated alias). Subclasses may still override.
+        isolate parallel matrix legs. Subclasses may still override.
+
+        Only the two-var shape is derivable here: a worker with
+        ATLAN_APPLICATION_NAME set but ATLAN_DEPLOYMENT_NAME absent polls the
+        bare ``{app}`` queue, which the harness can't reconstruct from env — such
+        deployments must override agent_spec() explicitly.
+
+        NOTE: keep this env-derivation in sync with
+        :meth:`application_sdk.testing.e2e.base.BaseE2ETest.agent_spec` — this
+        module is the deprecated alias (removed in v4.0) and shares no
+        inheritance with it, so the block is intentionally duplicated.
         """
         if self.mode is RunMode.DIRECT:
             return None

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -336,11 +336,28 @@ class BaseFullDAGE2ETest:
         )
 
     def agent_spec(self) -> AgentSpec | None:
-        """Agent identity (tier 4 only). Return None for direct mode."""
+        """Agent identity (tier 4 only). Return None for direct mode.
+
+        Default (AGENT mode): derive the agent identity from the worker's own
+        deployment env so the extract node lands on exactly the queue the
+        deployed worker polls (``atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}``),
+        including any per-leg ``ATLAN_DEPLOYMENT_NAME`` the CI action sets to
+        isolate parallel matrix legs. Mirrors
+        :meth:`application_sdk.testing.e2e.base.BaseE2ETest.agent_spec` (this
+        module is the deprecated alias). Subclasses may still override.
+        """
         if self.mode is RunMode.DIRECT:
             return None
+        app_name = os.environ.get("ATLAN_APPLICATION_NAME", "")
+        deployment_name = os.environ.get("ATLAN_DEPLOYMENT_NAME", "")
+        if app_name and deployment_name:
+            return AgentSpec(agent_name=f"{app_name}-{deployment_name}")
         raise HarnessMethodNotImplementedError(
-            message="subclass must override agent_spec() for AGENT mode",
+            message=(
+                "AGENT mode needs an agent_spec() override, or both "
+                "ATLAN_APPLICATION_NAME and ATLAN_DEPLOYMENT_NAME set in the "
+                "environment to derive the worker's task queue"
+            ),
             operation="agent_spec",
         )
 

--- a/application_sdk/testing/full_dag/sql_app.py
+++ b/application_sdk/testing/full_dag/sql_app.py
@@ -84,9 +84,20 @@ class SQLAppE2EFullTest(BaseFullDAGE2ETest):
     agent_name_template: ClassVar[str] = "{connector}-{prefix}-{run_id}"
 
     def agent_spec(self) -> AgentSpec | None:
-        """Default AGENT-mode agent identity, or None in DIRECT mode."""
+        """Default AGENT-mode agent identity, or None in DIRECT mode.
+
+        Prefer the base env-derivation (``atlan-{app}-{deployment}``) when the
+        worker's ATLAN_APPLICATION_NAME + ATLAN_DEPLOYMENT_NAME are set, so SQL
+        apps inherit per-leg queue isolation with no per-connector hard-coding.
+        Fall back to the ``agent_name_template`` (run_id-keyed) only when the
+        deployment env is absent — e.g. an Argo template that pins its own queue.
+        """
         if self.mode is RunMode.DIRECT:
             return None
+        if os.environ.get("ATLAN_APPLICATION_NAME") and os.environ.get(
+            "ATLAN_DEPLOYMENT_NAME"
+        ):
+            return super().agent_spec()
         return AgentSpec(
             agent_name=self.agent_name_template.format(
                 connector=self.connector_short_name,

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -498,8 +498,22 @@ class TestAgentSpecDerivation:
     def test_agent_mode_without_deployment_env_raises(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        # APP set, DEPLOYMENT absent → the app-only queue shape isn't derivable.
         monkeypatch.setenv("ATLAN_APPLICATION_NAME", "openapi")
         monkeypatch.delenv("ATLAN_DEPLOYMENT_NAME", raising=False)
+
+        class _T(_ConcreteE2ETest):
+            mode = RunMode.AGENT
+
+        with pytest.raises(HarnessMethodNotImplementedError):
+            _T().agent_spec()
+
+    def test_agent_mode_without_application_env_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Symmetric branch: DEPLOYMENT set, APP absent → also not derivable.
+        monkeypatch.delenv("ATLAN_APPLICATION_NAME", raising=False)
+        monkeypatch.setenv("ATLAN_DEPLOYMENT_NAME", "e2e-full-ci-42-connection-create")
 
         class _T(_ConcreteE2ETest):
             mode = RunMode.AGENT

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -16,6 +16,7 @@ import pytest
 
 from application_sdk.contracts.types import ConnectionRef
 from application_sdk.testing.e2e._errors import (
+    HarnessMethodNotImplementedError,
     ManifestDagMissingError,
     ManifestFileNotFoundError,
 )
@@ -437,6 +438,74 @@ class TestExtractTaskQueue:
     def test_direct_mode_falls_back_to_connector_default(self) -> None:
         # _ConcreteE2ETest is RunMode.DIRECT → agent_spec() is None.
         assert _ConcreteE2ETest()._extract_task_queue() == "atlan-openapi-default"
+
+
+class TestAgentSpecDerivation:
+    """AGENT mode derives the agent identity — and therefore the extract queue —
+    from the worker's ATLAN_APPLICATION_NAME + ATLAN_DEPLOYMENT_NAME env, so a
+    per-leg ATLAN_DEPLOYMENT_NAME (set by the CI action) isolates each matrix
+    leg's queue with no per-connector hard-coding. Mirrors
+    application_sdk.main._derive_task_queue's atlan-{app}-{deployment} shape.
+    """
+
+    def test_derives_agent_name_and_queue_from_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATLAN_APPLICATION_NAME", "openapi")
+        monkeypatch.setenv("ATLAN_DEPLOYMENT_NAME", "e2e-full-ci-42-connection-create")
+
+        class _T(_ConcreteE2ETest):
+            mode = RunMode.AGENT
+
+        spec = _T().agent_spec()
+        assert spec is not None
+        assert spec.agent_name == "openapi-e2e-full-ci-42-connection-create"
+        # The extract node lands on exactly the worker's atlan-{app}-{deployment}
+        # queue (see _derive_task_queue), byte-for-byte.
+        assert (
+            _T()._extract_task_queue()
+            == "atlan-openapi-e2e-full-ci-42-connection-create"
+        )
+
+    def test_distinct_deployment_yields_distinct_queues(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATLAN_APPLICATION_NAME", "openapi")
+
+        class _T(_ConcreteE2ETest):
+            mode = RunMode.AGENT
+
+        monkeypatch.setenv("ATLAN_DEPLOYMENT_NAME", "e2e-full-ci-42-connection-create")
+        create_q = _T()._extract_task_queue()
+        monkeypatch.setenv("ATLAN_DEPLOYMENT_NAME", "e2e-full-ci-42-connection-reuse")
+        reuse_q = _T()._extract_task_queue()
+        assert create_q != reuse_q
+
+    def test_subclass_override_still_wins(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATLAN_APPLICATION_NAME", "openapi")
+        monkeypatch.setenv("ATLAN_DEPLOYMENT_NAME", "e2e-full-ci-42")
+
+        class _T(_ConcreteE2ETest):
+            mode = RunMode.AGENT
+
+            def agent_spec(self) -> AgentSpec:
+                return AgentSpec(agent_name="pinned-name")
+
+        assert _T().agent_spec().agent_name == "pinned-name"
+
+    def test_agent_mode_without_deployment_env_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATLAN_APPLICATION_NAME", "openapi")
+        monkeypatch.delenv("ATLAN_DEPLOYMENT_NAME", raising=False)
+
+        class _T(_ConcreteE2ETest):
+            mode = RunMode.AGENT
+
+        with pytest.raises(HarnessMethodNotImplementedError):
+            _T().agent_spec()
 
 
 class TestStallGuardDefault:

--- a/tests/unit/testing/e2e/test_sql_app_e2e.py
+++ b/tests/unit/testing/e2e/test_sql_app_e2e.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from application_sdk.testing.e2e.base import FullDAGOutcome
 from application_sdk.testing.e2e.client import (
     DAGNodeResult,
@@ -285,12 +287,31 @@ class TestSQLAppE2ETestHooks:
         t = self._make_test(RunMode.DIRECT)
         assert t.agent_spec() is None
 
-    def test_agent_spec_returns_agent_in_agent_mode(self) -> None:
+    def test_agent_spec_returns_agent_in_agent_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Deployment env absent → run_id template path.
+        monkeypatch.delenv("ATLAN_APPLICATION_NAME", raising=False)
+        monkeypatch.delenv("ATLAN_DEPLOYMENT_NAME", raising=False)
         t = self._make_test(RunMode.AGENT)
         spec = t.agent_spec()
         assert spec is not None
         assert "mysql" in spec.agent_name
         assert str(t.run_id) in spec.agent_name
+
+    def test_agent_spec_prefers_env_derivation_when_deployment_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Per-leg isolation: when the worker's ATLAN_APPLICATION_NAME +
+        # ATLAN_DEPLOYMENT_NAME are set, the agent name (and thus the extract
+        # queue) is derived from them — not the run_id template — so SQL matrix
+        # legs land on their own per-leg queue.
+        monkeypatch.setenv("ATLAN_APPLICATION_NAME", "mysql")
+        monkeypatch.setenv("ATLAN_DEPLOYMENT_NAME", "e2e-full-ci-1-connection-reuse")
+        t = self._make_test(RunMode.AGENT)
+        spec = t.agent_spec()
+        assert spec is not None
+        assert spec.agent_name == "mysql-e2e-full-ci-1-connection-reuse"
 
     def test_connection_spec_uses_admin_role_guid(self) -> None:
         t = self._make_test()

--- a/tests/unit/testing/full_dag/test_base.py
+++ b/tests/unit/testing/full_dag/test_base.py
@@ -15,6 +15,7 @@ import pytest
 
 from application_sdk.testing.full_dag import BaseFullDAGE2ETest, RunMode
 from application_sdk.testing.full_dag._errors import (
+    HarnessMethodNotImplementedError,
     ManifestDagMissingError,
     ManifestFileNotFoundError,
 )
@@ -112,6 +113,47 @@ def _bootstrap_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ATLAN_BASE_URL", "https://test.example.invalid")
     monkeypatch.setenv("ATLAN_API_KEY", "test-token")
     monkeypatch.setenv("GITHUB_RUN_ID", "9999999")
+
+
+class TestBaseAgentSpecDerivation:
+    """The (deprecated) full_dag base derives its agent identity from env —
+    kept in sync with the e2e module so SQL apps on the alias still get per-leg
+    isolation. Mirrors TestAgentSpecDerivation in the e2e test module.
+    """
+
+    @staticmethod
+    def _agent_mode_cls():
+        class _T(BaseFullDAGE2ETest):
+            connector_short_name = "mysql"
+            argo_package_name = "@atlan/mysql"
+            argo_template_name = "atlan-mysql"
+            mode = RunMode.AGENT
+            app_service_url = "http://mysql.svc"
+
+        return _T
+
+    def test_derives_agent_name_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATLAN_APPLICATION_NAME", "mysql")
+        monkeypatch.setenv("ATLAN_DEPLOYMENT_NAME", "e2e-full-ci-42-connection-reuse")
+        spec = self._agent_mode_cls()().agent_spec()
+        assert spec is not None
+        assert spec.agent_name == "mysql-e2e-full-ci-42-connection-reuse"
+
+    def test_without_deployment_env_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATLAN_APPLICATION_NAME", "mysql")
+        monkeypatch.delenv("ATLAN_DEPLOYMENT_NAME", raising=False)
+        with pytest.raises(HarnessMethodNotImplementedError):
+            self._agent_mode_cls()().agent_spec()
+
+    def test_without_application_env_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ATLAN_APPLICATION_NAME", raising=False)
+        monkeypatch.setenv("ATLAN_DEPLOYMENT_NAME", "e2e-full-ci-42-connection-reuse")
+        with pytest.raises(HarnessMethodNotImplementedError):
+            self._agent_mode_cls()().agent_spec()
 
 
 @pytest.fixture

--- a/tests/unit/testing/full_dag/test_sql_app.py
+++ b/tests/unit/testing/full_dag/test_sql_app.py
@@ -38,7 +38,9 @@ def _bootstrap_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GITHUB_RUN_ID", "9999999")
     # Keep the deployment env absent by default so the run_id template path is
     # deterministic regardless of the ambient CI environment; the env-derivation
-    # test sets it explicitly.
+    # test sets both explicitly. Clear both vars (not just DEPLOYMENT) so the
+    # gate is hermetic against an ambient ATLAN_APPLICATION_NAME.
+    monkeypatch.delenv("ATLAN_APPLICATION_NAME", raising=False)
     monkeypatch.delenv("ATLAN_DEPLOYMENT_NAME", raising=False)
 
 

--- a/tests/unit/testing/full_dag/test_sql_app.py
+++ b/tests/unit/testing/full_dag/test_sql_app.py
@@ -36,6 +36,10 @@ def _bootstrap_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ATLAN_BASE_URL", "https://test.example.invalid")
     monkeypatch.setenv("ATLAN_API_KEY", "test-token")
     monkeypatch.setenv("GITHUB_RUN_ID", "9999999")
+    # Keep the deployment env absent by default so the run_id template path is
+    # deterministic regardless of the ambient CI environment; the env-derivation
+    # test sets it explicitly.
+    monkeypatch.delenv("ATLAN_DEPLOYMENT_NAME", raising=False)
 
 
 def test_agent_spec_agent_mode_uses_run_id_template(
@@ -50,6 +54,25 @@ def test_agent_spec_agent_mode_uses_run_id_template(
     assert isinstance(agent, AgentSpec)
     # Default connection_name_prefix = "e2e-full-ci"; run_id = 9999999.
     assert agent.agent_name == "mysql-e2e-full-ci-9999999"
+
+
+def test_agent_spec_prefers_env_derivation_when_deployment_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-leg isolation: when ATLAN_APPLICATION_NAME + ATLAN_DEPLOYMENT_NAME are
+    set (the CI worker's env), the agent name — and thus the extract queue — is
+    derived from them (atlan-{app}-{deployment}), not the run_id template, so SQL
+    matrix legs stay on their own per-leg queue. Mirrors the e2e module.
+    """
+    _bootstrap_env(monkeypatch)
+    monkeypatch.setenv("ATLAN_APPLICATION_NAME", "mysql")
+    monkeypatch.setenv("ATLAN_DEPLOYMENT_NAME", "e2e-full-ci-9999999-connection-reuse")
+    cls = _make_test()
+    instance = cls()
+    instance.setup_method()
+    agent = instance.agent_spec()
+    assert agent is not None
+    assert agent.agent_name == "mysql-e2e-full-ci-9999999-connection-reuse"
 
 
 def test_agent_spec_direct_mode_returns_none(


### PR DESCRIPTION
## What

Give each matrix e2e leg its own worker **and its own Temporal task queue**, fixing the cross-worker artifact-invisibility failures seen on the openapi matrix run.

## Why

The matrix e2e job (#2683) fans out one job per `tests/e2e/test_*.py`. Each leg spins its own worker container, but they all polled the **same** queue `atlan-{app}-e2e-full-ci-{run_id}` — `ATLAN_DEPLOYMENT_NAME` was keyed only on the shared GitHub run id.

Temporal load-balances a single workflow's activities across every poller on a queue. With two co-serving leg-workers and the ADR-0014 two-store posture (per-container localstorage), a `FileReference` written by leg A's worker is invisible to leg B's worker → the extract node fails with:

```
[AAF-STR-001] FileReference path '.../file_refs/{hash}.jsonl' resolved to no objects
```

The old matrix comment asserted "co-serving is harmless" — that assumption was wrong under two-store.

## How

- **`sdr-e2e` action** derives a per-leg `ATLAN_DEPLOYMENT_NAME` = `e2e-full-ci-<run_id>[-<artifact-suffix>]` via a new tested driver `derive_deployment_name.py`, exported to `$GITHUB_ENV` **before** `docker compose up` so both the worker (compose interpolation) and the harness (pytest step) read the same value. Empty suffix (single-suite callers) keeps the original shape — backward compatible.
- **`BaseE2ETest.agent_spec()`** now derives the agent identity — and therefore the extract-node queue — from `ATLAN_APPLICATION_NAME` + `ATLAN_DEPLOYMENT_NAME` (mirroring `_derive_task_queue`'s `atlan-{app}-{deployment}`). Worker and harness stay in lock-step with **no per-connector hard-coding**; subclass overrides still win.
- Corrected the `tests-reusable` matrix comment.

Consumer (openapi) side switches its compose overlay to consume the injected value and drops its now-redundant hard-coded `agent_spec()` — see atlan-openapi-app#219.

## Tests

- New `.github/scripts/tests/test_derive_deployment_name.py` (8 cases: suffix append, sanitisation, empty-run-id fallback, `main()` output).
- New `TestAgentSpecDerivation` in `test_base_e2e.py` (derivation, distinct-queue-per-leg, override-wins, missing-env raises).
- `tests/unit/testing/` + `.github/scripts/tests/` — 925 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXvrj2UurwM8n2AHvKLe3w