### PR TITLE
fix(handler): pass log_config=None in SERVER mode to avoid startup deadlock

### DIFF
--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -2674,4 +2674,18 @@ def run_app_handler_service(
     import uvicorn  # noqa: PLC0415 — cold path: uvicorn only when starting standalone server
 
     app = create_app_handler_service(handler, **kwargs)
-    uvicorn.run(app, host=host, port=port, log_level=log_level)
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        log_level=log_level,
+        # Skip uvicorn's logging.config.dictConfig() call — it runs inside
+        # Config.load() before the socket is bound and grabs the global
+        # logging._lock. A background thread mid-emit while holding that lock
+        # (e.g. the OTel gRPC exporter, or the Temporal SDK) deadlocks startup,
+        # so the port never opens and k8s liveness probes kill the pod. This
+        # mirrors the combined-mode guard in main.py. Uvicorn logs still flow
+        # through Python's root logger to our structlog/loguru setup via the
+        # installed InterceptHandler.
+        log_config=None,
+    )

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -5092,6 +5092,26 @@ class TestRunAppHandlerService:
         assert kwargs.get("port") == 9000
         assert kwargs.get("log_level") == "warning"
 
+    def test_run_passes_log_config_none_to_avoid_startup_deadlock(self) -> None:
+        """Regression (CNCT-67): SERVER/handler mode must pass ``log_config=None``.
+
+        Uvicorn's ``Config.load()`` calls ``logging.config.dictConfig()`` before
+        the socket is bound; that grabs the global ``logging._lock``. A background
+        thread mid-emit while holding the lock (e.g. the OTel gRPC exporter)
+        deadlocks startup, the port never opens, and k8s liveness probes kill the
+        pod. Passing ``log_config=None`` skips the dictConfig call entirely.
+        """
+        from unittest.mock import patch
+
+        from application_sdk.handler.service import run_app_handler_service
+
+        with patch("uvicorn.run") as mock_run:
+            run_app_handler_service(
+                _TestHandler(), host="127.0.0.1", port=9000, log_level="warning"
+            )
+        _, kwargs = mock_run.call_args
+        assert kwargs.get("log_config") is None
+
 
 class TestWorkflowClientConfig:
     """Tests for WorkflowClientConfig.is_configured()."""


### PR DESCRIPTION
## What

SERVER/handler mode (`APPLICATION_MODE=SERVER`) can deadlock during startup and never bind its HTTP server on port 8000. Both k8s probes then get `connection refused`, the liveness probe SIGTERMs the container after ~90s, and the pod restart-loops.

`run_app_handler_service` called plain `uvicorn.run(...)` without `log_config=None`. Uvicorn's `Config.load()` runs `logging.config.dictConfig()` **before** the socket is bound (verified in uvicorn 0.51.0: `server.py` calls `config.load()` at line 85, `startup()`/bind at line 93). `dictConfig()` acquires the global `logging._lock`; a background thread mid-`emit` while holding that lock — e.g. the OTel gRPC exporter, active in the pod — deadlocks startup, so the port never opens.

Combined mode already guards against this via `uvicorn.Config(..., log_config=None)` in `main.py`, but the handler-service HTTP path was left unpatched — it has carried the bug since v3.0.0 (PR #1457), while the guard added in PR #1585 only touched `main.py`.

## Fix

Mirror the combined-mode guard: pass `log_config=None` so uvicorn skips its `dictConfig()` call. Uvicorn logs still flow through Python's root logger to our structlog/loguru setup via the installed `InterceptHandler`.

The guard comment is OS-agnostic here — the real trigger is any background thread holding `logging._lock` during startup (the pod repro was on Linux, driven by OTel gRPC threads), not Windows/Temporal specifically as the original `main.py` comment implies.

## Tests

- Added `test_run_passes_log_config_none_to_avoid_startup_deadlock` — regression test asserting `run_app_handler_service` passes `log_config=None` to `uvicorn.run`.
- `TestRunAppHandlerService` (2 tests) passing; ruff + ruff-format + pyright clean.

## Out of scope (noted for follow-up)

The ~60s Dapr sidecar readiness stall at startup (`infrastructure/_dapr/http.py`) is a **separate, secondary** aggravating factor — it eats most of the ~90s liveness budget and makes the deadlock fatal faster, but it is not the hang. Worth a separate look; tunable meanwhile via `ATLAN_DAPR_SIDECAR_WAIT_TIMEOUT`.

Fixes CNCT-67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
