### PR TITLE
feat(conformance): add T016+T017 e2e queue-isolation rules

### DIFF
--- a/packages/conformance/conformance/docs/rules/tests.md
+++ b/packages/conformance/conformance/docs/rules/tests.md
@@ -5,7 +5,7 @@
 
 # Test-Quality Rules (T-series)
 
-**16 rules** · Checker: `suite.checks.integration_marking` (T001), `suite.checks.sdr_test_checks` (T002-T003), `suite.checks.dev_entrypoint` (T004), `suite.checks.test_quality` (T005-T009), `suite.checks.test_structure` (T010-T013), and `suite.checks.coverage_config` (T014-T015) (AST/TOML-based)
+**17 rules** · Checker: `suite.checks.integration_marking` (T001), `suite.checks.sdr_test_checks` (T002-T003), `suite.checks.dev_entrypoint` (T004), `suite.checks.test_quality` (T005-T009), `suite.checks.test_structure` (T010-T013), and `suite.checks.coverage_config` (T014-T015) (AST/TOML-based)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -31,6 +31,7 @@ Suppress a finding on the violating line or the line directly above it:
 | [T014](#t014) | `CoverageGateDisabled` | `warn` | `app` | `coverage-config` | — | 0.12.0 |
 | [T015](#t015) | `CoverageOmitsProductCode` | `warn` | `app` | `coverage-config` | — | 0.12.0 |
 | [T016](#t016) | `E2EDeploymentNameNotInherited` | `warn` | `app` | `e2e-ci` | — | 0.13.0 |
+| [T017](#t017) | `E2EAgentSpecPinsQueue` | `warn` | `app` | `e2e-ci` | — | 0.13.0 |
 
 ---
 
@@ -683,5 +684,64 @@ A bare pass-through list entry (`- ATLAN_DEPLOYMENT_NAME` with no `=`) is also a
 Suppress with `# conformance: ignore[T016] <reason>` on the assignment line only when
 the overlay is intentionally single-queue (never fans out across matrix legs) and the
 hard-coded name is deliberate.
+
+---
+
+## T017 — `E2EAgentSpecPinsQueue` {#t017}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `e2e-ci` · **Autofixable:** — · **Since:** 0.13.0
+
+> e2e agent_spec() override hard-codes the queue instead of inheriting the per-leg ATLAN_DEPLOYMENT_NAME
+
+**Rationale:** The companion to T016. T016 polices the worker side (the compose overlay must inherit
+the sdr-e2e per-leg ATLAN_DEPLOYMENT_NAME); T017 polices the harness side. The worker
+derives its Temporal queue as atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME},
+and the harness derives the extract-node queue it dispatches to from the same two env
+vars via BaseE2ETest.agent_spec. An e2e test that overrides agent_spec with a hard-coded
+agent_name (e.g. AgentSpec(agent_name=f'metabase-e2e-full-ci-{self.run_id}')) that
+neither reads ATLAN_DEPLOYMENT_NAME nor calls super().agent_spec() pins the harness to
+the un-suffixed queue. Once the worker inherits the leg-suffixed value (T016), the two
+queues diverge, no worker polls the harness's queue, the extract node stays Running, and
+the run hangs — the exact atlan-metabase-app regression where the overlay was fixed but
+agent_spec was left hard-coded. Fixing the overlay (T016) and the agent_spec (T017) is a
+matched pair: applying one without the other breaks a previously-passing e2e.
+
+An `agent_spec` override under `tests/` returns a hard-coded `AgentSpec(agent_name=...)`
+(a plain string or an f-string such as `f"myconn-e2e-full-ci-{self.run_id}"`) without
+referencing `ATLAN_DEPLOYMENT_NAME` or calling `super().agent_spec()`.
+
+The harness builds its extract-node Temporal queue as `atlan-{agent_spec().agent_name}`.
+When the worker inherits the sdr-e2e per-leg `ATLAN_DEPLOYMENT_NAME`
+(`e2e-full-ci-<run_id>[-<leg>]`) but the harness pins a hard-coded
+`...-e2e-full-ci-<run_id>` name, the two land on different queues — no worker polls the
+harness's queue and the run hangs with `No Workers Running`.
+
+**Remediation (preferred): delete the override.** `BaseE2ETest.agent_spec` derives
+`atlan-{app}-{deployment}` from the worker's own env in CI and falls back to
+`{connector_short_name}-{connection_name_prefix}-{run_id}` locally, so no override is
+needed on either path — the harness picks up the per-leg suffix automatically and always
+matches the worker queue.
+
+If the override must stay (e.g. to pin a genuinely different agent identity), make it
+read the deployment env — defer to `super().agent_spec()` when `ATLAN_APPLICATION_NAME`
++ `ATLAN_DEPLOYMENT_NAME` are set, keeping the run-id name only as a local fallback
+(mirroring `SQLAppE2ETest.agent_spec`):
+
+```python
+def agent_spec(self) -> AgentSpec:
+    if os.environ.get('ATLAN_APPLICATION_NAME') and os.environ.get(
+        'ATLAN_DEPLOYMENT_NAME'
+    ):
+        return super().agent_spec()
+    return AgentSpec(agent_name=f'myconn-e2e-full-ci-{self.run_id}')
+```
+
+A connector that does not override `agent_spec` at all (inheriting the SDK's env-derived
+default) is never flagged. This rule and T016 are a matched pair — remediate both the
+overlay and the agent_spec together, never one alone.
+
+Suppress with `# conformance: ignore[T017] <reason>` on the `def agent_spec` line only
+when the hard-coded queue is deliberate (e.g. a single-leg suite that never fans out and
+whose overlay also hard-codes the same un-suffixed value).
 
 ---

--- a/packages/conformance/conformance/docs/rules/tests.md
+++ b/packages/conformance/conformance/docs/rules/tests.md
@@ -5,7 +5,7 @@
 
 # Test-Quality Rules (T-series)
 
-**15 rules** · Checker: `suite.checks.integration_marking` (T001), `suite.checks.sdr_test_checks` (T002-T003), `suite.checks.dev_entrypoint` (T004), `suite.checks.test_quality` (T005-T009), `suite.checks.test_structure` (T010-T013), and `suite.checks.coverage_config` (T014-T015) (AST/TOML-based)
+**16 rules** · Checker: `suite.checks.integration_marking` (T001), `suite.checks.sdr_test_checks` (T002-T003), `suite.checks.dev_entrypoint` (T004), `suite.checks.test_quality` (T005-T009), `suite.checks.test_structure` (T010-T013), and `suite.checks.coverage_config` (T014-T015) (AST/TOML-based)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -30,6 +30,7 @@ Suppress a finding on the violating line or the line directly above it:
 | [T013](#t013) | `TestFileOutsideTierDir` | `warn` | `both` | `test-tier-coverage` | — | 0.12.0 |
 | [T014](#t014) | `CoverageGateDisabled` | `warn` | `app` | `coverage-config` | — | 0.12.0 |
 | [T015](#t015) | `CoverageOmitsProductCode` | `warn` | `app` | `coverage-config` | — | 0.12.0 |
+| [T016](#t016) | `E2EDeploymentNameNotInherited` | `warn` | `app` | `e2e-ci` | — | 0.13.0 |
 
 ---
 
@@ -630,5 +631,57 @@ omit = ["app/generated/*"]
 Suppress with `# conformance: ignore[T015] <reason>` on the `omit`/ `source` line naming
 the specific module and why it's legitimately excluded (e.g. a vendored third-party shim
 with no branch logic worth covering).
+
+---
+
+## T016 — `E2EDeploymentNameNotInherited` {#t016}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `e2e-ci` · **Autofixable:** — · **Since:** 0.13.0
+
+> e2e CI compose overlay hard-codes ATLAN_DEPLOYMENT_NAME instead of inheriting the sdr-e2e per-leg value
+
+**Rationale:** The full-DAG e2e worker derives its Temporal task queue as
+atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}, and the harness
+(BaseE2ETest.agent_spec) derives the extract-node queue it dispatches to from the same
+two env vars. To keep worker and harness on one queue when the e2e suite fans out across
+parallel matrix legs, the SDK's sdr-e2e composite action derives a per-leg
+ATLAN_DEPLOYMENT_NAME (base + sanitised matrix-leg suffix) and exports it to
+$GITHUB_ENV; both sides then read that one value. A connector's e2e compose overlay that
+hard-codes ATLAN_DEPLOYMENT_NAME in a service's environment overrides that inherited
+value: the worker container drops the leg suffix and polls
+atlan-<app>-e2e-full-ci-<run_id> while the harness still dispatches to
+atlan-<app>-e2e-full-ci-<run_id>-<leg>. Two different queues means no worker polls the
+harness's queue, so the top-level AE run flips to Running (its parent lives on the
+always-on automation-engine queue) and then hangs until timeout — observed on
+atlan-mysql-app, ~20 min of dead CI per run, before this rule existed.
+
+An e2e CI docker-compose overlay under `.github/` (discovered as a `*.yml`/`*.yaml` with
+a top-level `services:` key that mentions `ATLAN_DEPLOYMENT_NAME`) assigns
+`ATLAN_DEPLOYMENT_NAME` in a service's `environment` to a literal that does not
+reference the inherited `${ATLAN_DEPLOYMENT_NAME...}` env var.
+
+The SDK's `sdr-e2e` composite action derives a per-leg `ATLAN_DEPLOYMENT_NAME`
+(`e2e-full-ci-<run_id>[-<leg>]`, see `derive_deployment_name.py`) and exports it to
+`$GITHUB_ENV` so the worker container and the pytest harness land on the same Temporal
+queue. A hard-coded overlay value overrides that inherited env, desynchronising the two
+— the worker polls one queue, the harness dispatches to another, and the run hangs with
+`No Workers Running`.
+
+**Remediation:** inherit the derived value, with a bare-shape fallback for local `docker
+compose` runs where the CI action hasn't exported it:
+
+```python
+services:
+  atlan-app:
+    environment:
+      - ATLAN_DEPLOYMENT_NAME=${ATLAN_DEPLOYMENT_NAME:-e2e-full-ci-${GITHUB_RUN_ID}}
+```
+
+A bare pass-through list entry (`- ATLAN_DEPLOYMENT_NAME` with no `=`) is also accepted
+— it inherits the runner env directly.
+
+Suppress with `# conformance: ignore[T016] <reason>` on the assignment line only when
+the overlay is intentionally single-queue (never fans out across matrix legs) and the
+hard-coded name is deliberate.
 
 ---

--- a/packages/conformance/conformance/docs/rules/tests.md
+++ b/packages/conformance/conformance/docs/rules/tests.md
@@ -5,7 +5,7 @@
 
 # Test-Quality Rules (T-series)
 
-**17 rules** · Checker: `suite.checks.integration_marking` (T001), `suite.checks.sdr_test_checks` (T002-T003), `suite.checks.dev_entrypoint` (T004), `suite.checks.test_quality` (T005-T009), `suite.checks.test_structure` (T010-T013), and `suite.checks.coverage_config` (T014-T015) (AST/TOML-based)
+**17 rules** · Checker: `suite.checks.integration_marking` (T001), `suite.checks.sdr_test_checks` (T002-T003), `suite.checks.dev_entrypoint` (T004), `suite.checks.test_quality` (T005-T009), `suite.checks.test_structure` (T010-T013), `suite.checks.coverage_config` (T014-T015), `suite.checks.e2e_deployment_name` (T016), and `suite.checks.e2e_agent_spec` (T017) (AST/TOML/YAML-based)
 
 Suppress a finding on the violating line or the line directly above it:
 

--- a/packages/conformance/conformance/programs/areas/tests.prose.md
+++ b/packages/conformance/conformance/programs/areas/tests.prose.md
@@ -6,13 +6,15 @@ description: >
   test-quality conformance findings: unmarked integration tests (T001), SDR
   test-coverage gaps (T002-T003), dev-entrypoint delegation (T004), assertion
   meaningfulness and silent non-execution (T005-T009), test-tier structure and
-  placement (T010-T013), and coverage-config integrity (T014-T015).  Every
-  rule in this series classifies as "judgment" — each fix requires reading the
-  test's I/O intent, the app's manifest/contract, or the app's App subclass
-  before a fix can be proposed with confidence.  T014/T015 are the most
-  mechanical of the set (usually a one-line pyproject.toml edit) but still
-  route to residue like the rest of the series — picking a real fail_under
-  value or confirming an omit pattern is legitimate still requires judgment.
+  placement (T010-T013), coverage-config integrity (T014-T015), and e2e CI
+  compose-overlay queue isolation (T016).  Every rule in this series classifies
+  as "judgment" — each fix requires reading the test's I/O intent, the app's
+  manifest/contract, or the app's App subclass before a fix can be proposed with
+  confidence.  T014/T015 are the most mechanical of the set (usually a one-line
+  pyproject.toml edit) but still route to residue like the rest of the series —
+  picking a real fail_under value or confirming an omit pattern is legitimate
+  still requires judgment.  T016's fix is deterministic but edits a file under
+  `.github/`, outside the remediator's write-scope, so it too routes to residue.
 ---
 
 ### Maintains
@@ -316,6 +318,50 @@ to residue):
   `classification` is `"judgment"` — confirming a given module is safe to
   keep omitted (vs. real product code that should count) requires reading
   what the module does, not just its path.
+
+- **T016 E2EDeploymentNameNotInherited** — an e2e CI docker-compose overlay
+  under `.github/` (a YAML file with a top-level `services:` key that mentions
+  `ATLAN_DEPLOYMENT_NAME`) assigns `ATLAN_DEPLOYMENT_NAME` in a service's
+  `environment` to a literal that does not reference the inherited
+  `${ATLAN_DEPLOYMENT_NAME...}` env var.  The SDK's `sdr-e2e` composite action
+  derives a per-leg `ATLAN_DEPLOYMENT_NAME` (`e2e-full-ci-<run_id>[-<leg>]`) and
+  exports it to `$GITHUB_ENV`; a hard-coded overlay value overrides that
+  inherited env, so the worker container polls a different Temporal queue than
+  the harness dispatches to — the extract activity stalls with "No Workers
+  Running" until the run times out (observed on atlan-mysql-app; atlan-metabase-app
+  had the same bug in map form).
+
+  The fix is deterministic: wrap the existing hard-coded value as the fallback
+  default so the value is inherited when set and preserved for local
+  `docker compose` runs when not.  For the list form
+  `- ATLAN_DEPLOYMENT_NAME=<value>`:
+
+  ```yaml
+  - ATLAN_DEPLOYMENT_NAME=${ATLAN_DEPLOYMENT_NAME:-<value>}
+  ```
+
+  For the mapping form `ATLAN_DEPLOYMENT_NAME: "<value>"`:
+
+  ```yaml
+  ATLAN_DEPLOYMENT_NAME: "${ATLAN_DEPLOYMENT_NAME:-<value>}"
+  ```
+
+  (A bare pass-through list entry `- ATLAN_DEPLOYMENT_NAME`, with no `=`, is
+  also acceptable — it inherits the runner env directly.)
+
+  **Route to residue** with the suggested edit — this function may not write
+  under `.github/` (see the write-scope constraint in
+  `remediate-finding.prose.md`; the remediator must never touch the CI gate it
+  is judged against), so T016 is not auto-applied even though the transform is
+  mechanical.
+
+  Suppress with `# conformance: ignore[T016] <reason>` on the assignment line
+  only when the overlay is intentionally single-queue (never fans out across
+  matrix legs) and the hard-coded name is deliberate — state that reason
+  explicitly.
+
+  `classification` is always `"judgment"` (edits a file outside write-scope;
+  routed to residue for a human to apply).
 
 **Suppress outcome (strict mode only, WARNING-tier findings)**:
 

--- a/packages/conformance/conformance/programs/areas/tests.prose.md
+++ b/packages/conformance/conformance/programs/areas/tests.prose.md
@@ -7,14 +7,16 @@ description: >
   test-coverage gaps (T002-T003), dev-entrypoint delegation (T004), assertion
   meaningfulness and silent non-execution (T005-T009), test-tier structure and
   placement (T010-T013), coverage-config integrity (T014-T015), and e2e CI
-  compose-overlay queue isolation (T016).  Every rule in this series classifies
-  as "judgment" — each fix requires reading the test's I/O intent, the app's
-  manifest/contract, or the app's App subclass before a fix can be proposed with
-  confidence.  T014/T015 are the most mechanical of the set (usually a one-line
-  pyproject.toml edit) but still route to residue like the rest of the series —
-  picking a real fail_under value or confirming an omit pattern is legitimate
-  still requires judgment.  T016's fix is deterministic but edits a file under
-  `.github/`, outside the remediator's write-scope, so it too routes to residue.
+  queue isolation (T016 worker-side overlay + T017 harness-side agent_spec).
+  Every rule in this series classifies as "judgment" — each fix requires reading
+  the test's I/O intent, the app's manifest/contract, or the app's App subclass
+  before a fix can be proposed with confidence.  T014/T015 are the most
+  mechanical of the set (usually a one-line pyproject.toml edit) but still route
+  to residue like the rest of the series — picking a real fail_under value or
+  confirming an omit pattern is legitimate still requires judgment.  T016/T017
+  are a matched pair (the worker queue and the harness queue must agree);
+  T016 edits a file under `.github/` (outside write-scope) and T017 edits a file
+  under `tests/` (also outside write-scope), so both route to residue.
 ---
 
 ### Maintains
@@ -355,10 +357,65 @@ to residue):
   is judged against), so T016 is not auto-applied even though the transform is
   mechanical.
 
+  **Pair with T017.** T016 fixes the *worker* queue; the *harness* must land on
+  the same queue via its `agent_spec` (T017). If the connector's e2e test
+  hard-codes `agent_spec` (see T017), applying this overlay fix *alone* makes
+  the worker inherit the leg suffix while the harness stays pinned to the
+  un-suffixed queue — breaking a previously-passing e2e (the atlan-metabase-app
+  regression). When routing a T016 finding to residue, check for a T017 finding
+  in the same repo and note that both must be applied together, never one alone.
+
   Suppress with `# conformance: ignore[T016] <reason>` on the assignment line
   only when the overlay is intentionally single-queue (never fans out across
   matrix legs) and the hard-coded name is deliberate — state that reason
   explicitly.
+
+  `classification` is always `"judgment"` (edits a file outside write-scope;
+  routed to residue for a human to apply).
+
+- **T017 E2EAgentSpecPinsQueue** — an `agent_spec` override under `tests/`
+  returns a hard-coded `AgentSpec(agent_name=...)` (a plain string or an
+  f-string like `f"myconn-e2e-full-ci-{self.run_id}"`) that neither reads
+  `ATLAN_DEPLOYMENT_NAME` nor calls `super().agent_spec()`. The harness builds
+  its extract-node queue as `atlan-{agent_name}`; a hard-coded name pins it to
+  `atlan-<app>-e2e-full-ci-<run_id>` (no matrix-leg suffix), so once the worker
+  inherits the sdr-e2e per-leg `ATLAN_DEPLOYMENT_NAME` (T016) the two diverge
+  and the run hangs with "No Workers Running".
+
+  Fix (preferred): **delete the override.** `BaseE2ETest.agent_spec` derives
+  `atlan-{app}-{deployment}` from the worker's env in CI and falls back to
+  `{connector_short_name}-{connection_name_prefix}-{run_id}` locally, so no
+  override is needed on either path — the harness picks up the per-leg suffix
+  automatically and always matches the worker queue. Also drop the now-unused
+  `AgentSpec` import if nothing else in the file uses it.
+
+  If the override must stay (pinning a genuinely different agent identity), make
+  it read the deployment env — defer to `super().agent_spec()` when
+  `ATLAN_APPLICATION_NAME` + `ATLAN_DEPLOYMENT_NAME` are set, keeping the run-id
+  name only as a local fallback (mirrors `SQLAppE2ETest.agent_spec`):
+
+  ```python
+  def agent_spec(self) -> AgentSpec:
+      if os.environ.get("ATLAN_APPLICATION_NAME") and os.environ.get(
+          "ATLAN_DEPLOYMENT_NAME"
+      ):
+          return super().agent_spec()
+      return AgentSpec(agent_name=f"myconn-e2e-full-ci-{self.run_id}")
+  ```
+
+  **Route to residue** with the suggested edit — this edits a file under
+  `tests/`, outside the remediator's write-scope (see
+  `remediate-finding.prose.md`).
+
+  **Pair with T016** (see above): the worker overlay and the harness agent_spec
+  must be fixed together. A repo showing only a T017 finding (overlay already
+  inherits, agent_spec still hard-coded) is actively broken and needs this fix;
+  a repo showing both must have both applied in the same change.
+
+  Suppress with `# conformance: ignore[T017] <reason>` on the `def agent_spec`
+  line only when the hard-coded queue is deliberate (a single-leg suite that
+  never fans out, whose overlay also hard-codes the same un-suffixed value) —
+  state that reason explicitly.
 
   `classification` is always `"judgment"` (edits a file outside write-scope;
   routed to residue for a human to apply).

--- a/packages/conformance/conformance/suite/checks/e2e_agent_spec.py
+++ b/packages/conformance/conformance/suite/checks/e2e_agent_spec.py
@@ -92,17 +92,26 @@ def _is_agentspec_call(node: ast.expr) -> bool:
 
 
 def _returns_hardcoded_agentspec(fn: ast.FunctionDef) -> bool:
-    """True when the function returns ``AgentSpec(agent_name=<literal>)``.
+    """True when the function returns ``AgentSpec`` with a hard-coded agent_name.
 
     A literal ``agent_name`` is a ``Constant`` (plain string) or ``JoinedStr``
     (f-string, e.g. ``f"...-{self.run_id}"``) — the hard-coded shape. A value
     built by a call or from the environment is not treated as hard-coded.
+
+    ``agent_name`` is ``AgentSpec``'s first (and only required) field, so both
+    the keyword form ``AgentSpec(agent_name="x")`` and the positional form
+    ``AgentSpec("x")`` / ``AgentSpec(f"...{self.run_id}")`` are inspected — the
+    positional form is valid Python and would otherwise escape detection.
     """
     for node in ast.walk(fn):
         if not isinstance(node, ast.Return) or not _is_agentspec_call(node.value):
             continue
         call = node.value
         assert isinstance(call, ast.Call)
+        # Positional: first arg is agent_name.
+        if call.args and isinstance(call.args[0], (ast.Constant, ast.JoinedStr)):
+            return True
+        # Keyword: agent_name=...
         for kw in call.keywords:
             if kw.arg == "agent_name" and isinstance(
                 kw.value, (ast.Constant, ast.JoinedStr)

--- a/packages/conformance/conformance/suite/checks/e2e_agent_spec.py
+++ b/packages/conformance/conformance/suite/checks/e2e_agent_spec.py
@@ -1,0 +1,205 @@
+"""T017 — e2e harness agent_spec() must inherit the per-leg deployment queue.
+
+The companion to T016 (:mod:`conformance.suite.checks.e2e_deployment_name`).
+T016 polices the *worker* side (the compose overlay must inherit the sdr-e2e
+per-leg ``ATLAN_DEPLOYMENT_NAME``); T017 polices the *harness* side.
+
+The full-DAG worker derives its Temporal queue as
+``atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}``, and the harness
+derives the extract-node queue it dispatches to from the SAME two env vars via
+``BaseE2ETest.agent_spec`` (``agent_name = {app}-{deployment}`` →
+``atlan-{agent_name}``). The sdr-e2e action exports a per-leg
+``ATLAN_DEPLOYMENT_NAME`` (``e2e-full-ci-<run_id>[-<matrix-leg>]``) to
+``$GITHUB_ENV`` so both sides land on one queue.
+
+A connector's e2e test that *overrides* ``agent_spec`` with a hard-coded
+``agent_name`` (e.g. ``AgentSpec(agent_name=f"metabase-e2e-full-ci-{self.run_id}")``)
+that neither reads ``ATLAN_DEPLOYMENT_NAME`` nor defers to ``super().agent_spec()``
+pins the harness to the un-suffixed queue ``atlan-<app>-e2e-full-ci-<run_id>``.
+Once the worker (correctly) inherits the leg-suffixed value, the two queues
+diverge, no worker polls the harness's queue, the extract node stays Running,
+and the run hangs ("No Workers Running"). This is exactly the atlan-metabase-app
+regression: overlay fixed (T016) but agent_spec left hard-coded.
+
+* ``T017`` — E2EAgentSpecPinsQueue: an ``agent_spec`` override under ``tests/``
+  returns a hard-coded ``AgentSpec(agent_name=...)`` without referencing
+  ``ATLAN_DEPLOYMENT_NAME`` or calling ``super().agent_spec()``.
+
+The compliant shape defers to the base env-derivation when the deployment env
+is present, keeping a run-id fallback for local runs (mirrors
+``SQLAppE2ETest.agent_spec``)::
+
+    def agent_spec(self) -> AgentSpec:
+        if os.environ.get("ATLAN_APPLICATION_NAME") and os.environ.get(
+            "ATLAN_DEPLOYMENT_NAME"
+        ):
+            return super().agent_spec()
+        return AgentSpec(agent_name=f"myconn-e2e-full-ci-{self.run_id}")
+
+Discovery
+---------
+Walks the whole ``tests/`` tree (an ``agent_spec`` override may live in an e2e
+test file or a shared harness base under ``tests/``). A connector that does not
+override ``agent_spec`` at all (inheriting the SDK's env-derived default, as the
+SQL apps do) is never flagged.
+
+Inline suppression
+------------------
+``# conformance: ignore[T017] <reason>`` on the ``def agent_spec`` line.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+from conformance.suite.checks._ast_common import (
+    _parse_directives,
+    make_cli_main,
+    make_finding,
+)
+from conformance.suite.schema.findings import Finding
+
+SERIES = "T"
+RULE_T017 = "T017"
+
+_DEPLOYMENT_ENV = "ATLAN_DEPLOYMENT_NAME"
+_AGENT_SPEC = "agent_spec"
+_AGENTSPEC_CTOR = "AgentSpec"
+
+__all__ = ["SERIES", "discover", "main", "scan_path", "scan_text"]
+
+
+def discover(root: Path) -> list[Path]:
+    """Walk ``tests/`` for all Python source files."""
+    base = root / "tests"
+    if not base.is_dir():
+        return []
+    return sorted(p for p in base.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def _is_agentspec_call(node: ast.expr) -> bool:
+    """True when *node* is a call to ``AgentSpec(...)`` (bare or attribute)."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id == _AGENTSPEC_CTOR
+    if isinstance(func, ast.Attribute):
+        return func.attr == _AGENTSPEC_CTOR
+    return False
+
+
+def _returns_hardcoded_agentspec(fn: ast.FunctionDef) -> bool:
+    """True when the function returns ``AgentSpec(agent_name=<literal>)``.
+
+    A literal ``agent_name`` is a ``Constant`` (plain string) or ``JoinedStr``
+    (f-string, e.g. ``f"...-{self.run_id}"``) — the hard-coded shape. A value
+    built by a call or from the environment is not treated as hard-coded.
+    """
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Return) or not _is_agentspec_call(node.value):
+            continue
+        call = node.value
+        assert isinstance(call, ast.Call)
+        for kw in call.keywords:
+            if kw.arg == "agent_name" and isinstance(
+                kw.value, (ast.Constant, ast.JoinedStr)
+            ):
+                return True
+    return False
+
+
+def _defers_to_env(fn: ast.FunctionDef) -> bool:
+    """True when the function reads ATLAN_DEPLOYMENT_NAME or calls super().agent_spec().
+
+    Either signal means the override consults the per-leg deployment env (or the
+    base env-derivation) rather than pinning a hard-coded queue.
+    """
+    for node in ast.walk(fn):
+        # `ATLAN_DEPLOYMENT_NAME` referenced as a string literal (os.environ.get(...)).
+        if isinstance(node, ast.Constant) and node.value == _DEPLOYMENT_ENV:
+            return True
+        # super().agent_spec() call.
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == _AGENT_SPEC
+            and isinstance(node.func.value, ast.Call)
+            and isinstance(node.func.value.func, ast.Name)
+            and node.func.value.func.id == "super"
+        ):
+            return True
+    return False
+
+
+def _message(fn_name: str) -> str:
+    return (
+        f"{_AGENT_SPEC}() override returns a hard-coded AgentSpec(agent_name=...) "
+        f"that neither reads {_DEPLOYMENT_ENV} nor calls super().{_AGENT_SPEC}(). "
+        "It pins the harness's extract queue to atlan-<app>-e2e-full-ci-<run_id> "
+        "(no matrix-leg suffix), so once the worker inherits the sdr-e2e per-leg "
+        f"{_DEPLOYMENT_ENV} the two land on different Temporal queues and the run "
+        'hangs ("No Workers Running"). Defer to the base env-derivation when '
+        f"ATLAN_APPLICATION_NAME + {_DEPLOYMENT_ENV} are set (return "
+        f"super().{_AGENT_SPEC}()), keeping the run-id name only as a local "
+        "fallback — see SQLAppE2ETest.agent_spec."
+    )
+
+
+def scan_text(text: str, file: str) -> list[Finding]:
+    """Scan one test-file *text* for T017 findings."""
+    try:
+        tree = ast.parse(text, filename=file)
+    except SyntaxError:
+        return []
+
+    directives = _parse_directives(text)
+    findings: list[Finding] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != _AGENT_SPEC:
+            continue
+        if not _returns_hardcoded_agentspec(node):
+            continue
+        if _defers_to_env(node):
+            continue
+        findings.append(
+            make_finding(
+                filename=file,
+                rule_id=RULE_T017,
+                node=node,
+                message=_message(node.name),
+                directives=directives,
+            )
+        )
+    return findings
+
+
+def scan_path(path: Path, root: Path) -> list[Finding]:
+    """Scan a single test file for T017 findings."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        rel = path
+    return scan_text(text, str(rel))
+
+
+main = make_cli_main(
+    scan_text,
+    description=(
+        "T017: e2e agent_spec() overrides must inherit the per-leg deployment "
+        "queue (read ATLAN_DEPLOYMENT_NAME / call super), not hard-code it."
+    ),
+    discover=discover,
+    default_scan_paths=("tests",),
+)
+"""CLI entry point for the T017 e2e-agent-spec check."""
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/conformance/conformance/suite/checks/e2e_deployment_name.py
+++ b/packages/conformance/conformance/suite/checks/e2e_deployment_name.py
@@ -1,0 +1,228 @@
+"""T016 — e2e-full CI compose overlay must inherit ATLAN_DEPLOYMENT_NAME.
+
+The full-DAG e2e worker derives its Temporal task queue as
+``atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}`` and the harness
+(``BaseE2ETest.agent_spec``) derives the extract-node queue it dispatches to
+from the *same* two env vars. To keep worker and harness on one queue when the
+e2e suite fans out across parallel matrix legs, the SDK's ``sdr-e2e`` composite
+action derives a **per-leg** ``ATLAN_DEPLOYMENT_NAME`` (base +
+sanitised matrix-leg suffix, e.g. ``e2e-full-ci-<run_id>-mysql-full-dag``) and
+exports it to ``$GITHUB_ENV`` — see ``sdr-e2e/derive_deployment_name.py``. Both
+sides then read that one value.
+
+A connector's e2e compose overlay under ``.github/`` breaks that contract when
+it **hard-codes** ``ATLAN_DEPLOYMENT_NAME`` in a service's ``environment``
+(e.g. ``ATLAN_DEPLOYMENT_NAME=e2e-full-ci-${GITHUB_RUN_ID}``): the explicit
+compose value overrides the runner env, so the worker container drops the leg
+suffix and registers on ``atlan-mysql-e2e-full-ci-<run_id>`` while the harness
+still dispatches to ``atlan-mysql-e2e-full-ci-<run_id>-<leg>``. Two different
+queues → "No Workers Running" and the top-level AE run hangs until timeout
+(observed on atlan-mysql-app before this rule existed).
+
+* ``T016`` — E2EDeploymentNameNotInherited: an e2e CI compose overlay assigns
+  ``ATLAN_DEPLOYMENT_NAME`` to a literal that does not reference the inherited
+  ``${ATLAN_DEPLOYMENT_NAME...}`` env var. The compliant forms are a
+  pass-through list entry (``- ATLAN_DEPLOYMENT_NAME``, no ``=``) or an
+  inherit-with-fallback interpolation
+  (``- ATLAN_DEPLOYMENT_NAME=${ATLAN_DEPLOYMENT_NAME:-e2e-full-ci-${GITHUB_RUN_ID}}``).
+
+Discovery
+---------
+Scans every ``*.yml``/``*.yaml`` under ``.github/`` that (a) looks like a
+docker-compose file (a top-level ``services:`` key) and (b) mentions
+``ATLAN_DEPLOYMENT_NAME`` at all. This deliberately targets CI compose overlays
+(``.github/e2e/…``) and skips GitHub *workflow* files (which have no
+``services:`` block) and local-dev compose files at the repo root (where
+hard-coding ``ATLAN_DEPLOYMENT_NAME=local`` is legitimate).
+
+Inline suppression
+------------------
+Add ``# conformance: ignore[T016] <reason>`` on the assignment's line (or the
+comment-only line directly above it) — the same directive grammar as every
+other series; YAML's ``#`` comments slot in naturally (see
+``_ast_common.parse_toml_suppressions``).
+
+Known limits (intentional — biased toward zero false positives):
+
+* Only string-literal assignments in the flat compose ``environment`` block are
+  inspected. A value built by a compose ``x-`` anchor / YAML alias, or one
+  injected via ``env_file``, is not statically visible and is not flagged.
+* The presence of *any* ``${ATLAN_DEPLOYMENT_NAME`` reference in the value is
+  treated as inheriting — the check does not attempt to prove the fallback
+  default is itself well-formed.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from conformance.suite.checks._ast_common import (
+    make_cli_main,
+    make_toml_finding,
+    parse_toml_suppressions,
+)
+from conformance.suite.schema.findings import Finding
+
+SERIES = "T"
+RULE_T016 = "T016"
+
+_ENV_VAR = "ATLAN_DEPLOYMENT_NAME"
+# The inherited-env reference that makes an assignment compliant. Matches both
+# ${ATLAN_DEPLOYMENT_NAME} and ${ATLAN_DEPLOYMENT_NAME:-<default>}.
+_INHERIT_MARKER = "${" + _ENV_VAR
+
+# A docker-compose file declares a top-level ``services:`` key (column 0). This
+# distinguishes a compose overlay from a GitHub workflow YAML, which never does.
+_SERVICES_RE = re.compile(r"^services:\s*(#.*)?$", re.MULTILINE)
+
+# List form:  - ATLAN_DEPLOYMENT_NAME[=<value>]   (optionally whole-quoted)
+_LIST_RE = re.compile(
+    rf"""^\s*-\s*['"]?{re.escape(_ENV_VAR)}
+        (?:=(?P<val>.*?))?          # optional =<value>; absent => pass-through
+        ['"]?\s*$""",
+    re.VERBOSE,
+)
+# Mapping form:  ATLAN_DEPLOYMENT_NAME: <value>
+_MAP_RE = re.compile(rf"^\s*{re.escape(_ENV_VAR)}\s*:\s*(?P<val>.*?)\s*$")
+
+__all__ = ["SERIES", "discover", "main", "scan_path", "scan_text"]
+
+
+def _is_compose_file(text: str) -> bool:
+    return _SERVICES_RE.search(text) is not None
+
+
+def _assignment_value(line: str) -> str | None:
+    """Return the assigned value for an ``ATLAN_DEPLOYMENT_NAME`` line.
+
+    Returns ``None`` when the line is not an ``ATLAN_DEPLOYMENT_NAME``
+    assignment, or is the bare pass-through list form (``- ATLAN_DEPLOYMENT_NAME``
+    with no ``=``) which inherits the value from the runner env and is always
+    compliant.
+    """
+    m = _LIST_RE.match(line)
+    if m is not None:
+        return m.group("val")  # None => pass-through (no '='); compliant
+    m = _MAP_RE.match(line)
+    if m is not None:
+        return m.group("val")
+    return None
+
+
+def _clean_value(value: str) -> str:
+    """Strip a trailing inline comment and surrounding quotes from *value*.
+
+    Deployment-name values never legitimately contain ``#``, so a ``#`` marks
+    the start of a YAML comment.
+    """
+    idx = value.find("#")
+    if idx != -1:
+        value = value[:idx]
+    return value.strip().strip("'\"").strip()
+
+
+def _is_inherited(value: str) -> bool:
+    return _INHERIT_MARKER in value
+
+
+def _message() -> str:
+    return (
+        f"e2e CI compose overlay hard-codes {_ENV_VAR} instead of inheriting the "
+        f"per-leg value the sdr-e2e action exports to $GITHUB_ENV. The explicit "
+        f"compose value overrides the runner env, so the worker registers on "
+        f"atlan-<app>-<deployment> without the matrix-leg suffix while the harness "
+        f"(BaseE2ETest.agent_spec) dispatches the extract activity to the "
+        f"leg-suffixed queue — two different Temporal queues, so no worker polls "
+        f"the harness's queue and the run hangs until timeout. Inherit the derived "
+        f"value with a local-dev fallback: "
+        f"{_ENV_VAR}=${{{_ENV_VAR}:-e2e-full-ci-${{GITHUB_RUN_ID}}}} "
+        f"(or a bare pass-through list entry, '- {_ENV_VAR}')."
+    )
+
+
+def scan_text(text: str, file: str) -> list[Finding]:
+    """Scan one compose-overlay *text* for T016 findings."""
+    if not _is_compose_file(text):
+        return []
+    if _ENV_VAR not in text:
+        return []
+
+    suppressions = parse_toml_suppressions(text)
+    findings: list[Finding] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        value = _assignment_value(line)
+        if value is None:
+            continue
+        cleaned = _clean_value(value)
+        if not cleaned:
+            # Empty value behaves like a pass-through: inherits the runner env.
+            continue
+        if _is_inherited(cleaned):
+            continue
+        findings.append(
+            make_toml_finding(
+                rule_id=RULE_T016,
+                file=file,
+                line=lineno,
+                column=1,
+                message=_message(),
+                suppressions=suppressions,
+            )
+        )
+    return findings
+
+
+def discover(root: Path) -> list[Path]:
+    """Discover e2e CI compose overlays under ``.github/``.
+
+    A candidate is a ``*.yml``/``*.yaml`` file that both looks like a
+    docker-compose file (top-level ``services:``) and mentions
+    ``ATLAN_DEPLOYMENT_NAME`` — overlays that never touch the var inherit it
+    automatically and have nothing to grade.
+    """
+    gh = root / ".github"
+    if not gh.is_dir():
+        return []
+    candidates = sorted(gh.rglob("*.yml")) + sorted(gh.rglob("*.yaml"))
+    paths: list[Path] = []
+    for path in candidates:
+        if "__pycache__" in path.parts:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if _ENV_VAR in text and _is_compose_file(text):
+            paths.append(path)
+    return sorted(paths)
+
+
+def scan_path(path: Path, root: Path) -> list[Finding]:
+    """Scan a single compose-overlay file for T016 findings."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        rel = path
+    return scan_text(text, str(rel))
+
+
+main = make_cli_main(
+    scan_text,
+    description=(
+        "T016: e2e CI compose overlays must inherit ATLAN_DEPLOYMENT_NAME from "
+        "the sdr-e2e per-leg derivation, not hard-code it."
+    ),
+    discover=discover,
+    default_scan_paths=(".github",),
+)
+"""CLI entry point for the T016 e2e-deployment-name check."""
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/conformance/conformance/suite/checks/e2e_deployment_name.py
+++ b/packages/conformance/conformance/suite/checks/e2e_deployment_name.py
@@ -94,20 +94,24 @@ def _is_compose_file(text: str) -> bool:
     return _SERVICES_RE.search(text) is not None
 
 
-def _assignment_value(line: str) -> str | None:
-    """Return the assigned value for an ``ATLAN_DEPLOYMENT_NAME`` line.
+def _assignment(line: str) -> tuple[str, str] | None:
+    """Return ``(form, value)`` for an ``ATLAN_DEPLOYMENT_NAME`` line, else None.
 
-    Returns ``None`` when the line is not an ``ATLAN_DEPLOYMENT_NAME``
-    assignment, or is the bare pass-through list form (``- ATLAN_DEPLOYMENT_NAME``
-    with no ``=``) which inherits the value from the runner env and is always
-    compliant.
+    ``form`` is ``"list"`` (``- ATLAN_DEPLOYMENT_NAME=<value>``) or ``"map"``
+    (``ATLAN_DEPLOYMENT_NAME: <value>``). Returns ``None`` when the line is not
+    an ``ATLAN_DEPLOYMENT_NAME`` assignment, or is the bare pass-through list
+    form (``- ATLAN_DEPLOYMENT_NAME`` with no ``=``) which inherits the value
+    from the runner env and is always compliant. The form matters because a
+    null-valued *map* entry (``ATLAN_DEPLOYMENT_NAME: null``) is a compose
+    pass-through, whereas a *list* ``=null`` is a literal string assignment.
     """
     m = _LIST_RE.match(line)
     if m is not None:
-        return m.group("val")  # None => pass-through (no '='); compliant
+        val = m.group("val")
+        return None if val is None else ("list", val)  # no '=' => pass-through
     m = _MAP_RE.match(line)
     if m is not None:
-        return m.group("val")
+        return ("map", m.group("val"))
     return None
 
 
@@ -121,6 +125,14 @@ def _clean_value(value: str) -> str:
     if idx != -1:
         value = value[:idx]
     return value.strip().strip("'\"").strip()
+
+
+# YAML null scalars. In a docker-compose ``environment`` MAP, a null value
+# (``ATLAN_DEPLOYMENT_NAME: null`` / ``: ~``) means "pass the variable through
+# from the host/runner env" — i.e. inherit, the same semantics as the bare
+# pass-through list form. (In LIST form, ``=null`` is a literal string "null"
+# and is correctly flagged.)
+_YAML_NULL_TOKENS: frozenset[str] = frozenset({"null", "~"})
 
 
 def _is_inherited(value: str) -> bool:
@@ -152,12 +164,17 @@ def scan_text(text: str, file: str) -> list[Finding]:
     suppressions = parse_toml_suppressions(text)
     findings: list[Finding] = []
     for lineno, line in enumerate(text.splitlines(), start=1):
-        value = _assignment_value(line)
-        if value is None:
+        assignment = _assignment(line)
+        if assignment is None:
             continue
+        form, value = assignment
         cleaned = _clean_value(value)
         if not cleaned:
             # Empty value behaves like a pass-through: inherits the runner env.
+            continue
+        if form == "map" and cleaned.lower() in _YAML_NULL_TOKENS:
+            # A null-valued compose env MAP entry passes the var through from the
+            # runner env (inherit) — same as the bare list pass-through form.
             continue
         if _is_inherited(cleaned):
             continue

--- a/packages/conformance/conformance/suite/rules/tests.py
+++ b/packages/conformance/conformance/suite/rules/tests.py
@@ -108,15 +108,24 @@ the code that ships:
   narrowed ``source``) excludes real product code under ``app/`` — inflating
   the reported percentage by hiding uncovered code from the denominator.
 
-e2e-CI queue-isolation rule:
+e2e-CI queue-isolation rules (a matched pair — the worker's queue and the
+harness's queue must agree; remediate both together, never one alone):
 
-* ``T016`` — E2EDeploymentNameNotInherited: an e2e CI docker-compose overlay
-  under ``.github/`` hard-codes ``ATLAN_DEPLOYMENT_NAME`` in a service's
-  ``environment`` instead of inheriting the per-leg value the SDK's ``sdr-e2e``
-  action exports to ``$GITHUB_ENV``. A hard-coded value overrides the inherited
-  env, so the worker container polls a different Temporal queue than the harness
-  dispatches to (dropping the matrix-leg suffix) → ``No Workers Running`` and a
-  ~20-min CI hang (observed on atlan-mysql-app).
+* ``T016`` — E2EDeploymentNameNotInherited (worker side): an e2e CI
+  docker-compose overlay under ``.github/`` hard-codes ``ATLAN_DEPLOYMENT_NAME``
+  in a service's ``environment`` instead of inheriting the per-leg value the
+  SDK's ``sdr-e2e`` action exports to ``$GITHUB_ENV``. A hard-coded value
+  overrides the inherited env, so the worker container polls a different Temporal
+  queue than the harness dispatches to (dropping the matrix-leg suffix) →
+  ``No Workers Running`` and a ~20-min CI hang (observed on atlan-mysql-app).
+
+* ``T017`` — E2EAgentSpecPinsQueue (harness side): an ``agent_spec`` override
+  under ``tests/`` returns a hard-coded ``AgentSpec(agent_name=...)`` that
+  neither reads ``ATLAN_DEPLOYMENT_NAME`` nor calls ``super().agent_spec()``,
+  pinning the harness's extract queue to the un-suffixed name. Once the worker
+  inherits the leg-suffixed value (T016), the two diverge and the run hangs —
+  the atlan-metabase-app regression where the overlay was fixed but the
+  agent_spec was left hard-coded.
 """
 
 from __future__ import annotations
@@ -1013,6 +1022,85 @@ RULES: tuple[RuleDefinition, ...] = (
         help_uri=(
             "https://github.com/atlanhq/application-sdk/blob/main/"
             "packages/conformance/conformance/docs/rules/tests.md#t016"
+        ),
+    ),
+    RuleDefinition(
+        id="T017",
+        scope=RuleScope.APP,
+        name="E2EAgentSpecPinsQueue",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="e2e-ci",
+        autofixable=False,
+        since="0.13.0",
+        rationale=(
+            "The companion to T016. T016 polices the worker side (the compose "
+            "overlay must inherit the sdr-e2e per-leg ATLAN_DEPLOYMENT_NAME); "
+            "T017 polices the harness side. The worker derives its Temporal queue "
+            "as atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}, and the "
+            "harness derives the extract-node queue it dispatches to from the same "
+            "two env vars via BaseE2ETest.agent_spec. An e2e test that overrides "
+            "agent_spec with a hard-coded agent_name (e.g. "
+            "AgentSpec(agent_name=f'metabase-e2e-full-ci-{self.run_id}')) that "
+            "neither reads ATLAN_DEPLOYMENT_NAME nor calls super().agent_spec() "
+            "pins the harness to the un-suffixed queue. Once the worker inherits "
+            "the leg-suffixed value (T016), the two queues diverge, no worker polls "
+            "the harness's queue, the extract node stays Running, and the run hangs "
+            "— the exact atlan-metabase-app regression where the overlay was fixed "
+            "but agent_spec was left hard-coded. Fixing the overlay (T016) and the "
+            "agent_spec (T017) is a matched pair: applying one without the other "
+            "breaks a previously-passing e2e."
+        ),
+        short_description=(
+            "e2e agent_spec() override hard-codes the queue instead of inheriting "
+            "the per-leg ATLAN_DEPLOYMENT_NAME"
+        ),
+        full_description=(
+            "An ``agent_spec`` override under ``tests/`` returns a hard-coded\n"
+            "``AgentSpec(agent_name=...)`` (a plain string or an f-string such as\n"
+            "``f\"myconn-e2e-full-ci-{self.run_id}\"``) without referencing\n"
+            "``ATLAN_DEPLOYMENT_NAME`` or calling ``super().agent_spec()``.\n"
+            "\n"
+            "The harness builds its extract-node Temporal queue as\n"
+            "``atlan-{agent_spec().agent_name}``. When the worker inherits the\n"
+            "sdr-e2e per-leg ``ATLAN_DEPLOYMENT_NAME`` (``e2e-full-ci-<run_id>[-<leg>]``)\n"
+            "but the harness pins a hard-coded ``...-e2e-full-ci-<run_id>`` name,\n"
+            "the two land on different queues — no worker polls the harness's\n"
+            "queue and the run hangs with ``No Workers Running``.\n"
+            "\n"
+            "**Remediation (preferred): delete the override.**\n"
+            "``BaseE2ETest.agent_spec`` derives ``atlan-{app}-{deployment}`` from\n"
+            "the worker's own env in CI and falls back to\n"
+            "``{connector_short_name}-{connection_name_prefix}-{run_id}`` locally,\n"
+            "so no override is needed on either path — the harness picks up the\n"
+            "per-leg suffix automatically and always matches the worker queue.\n"
+            "\n"
+            "If the override must stay (e.g. to pin a genuinely different agent\n"
+            "identity), make it read the deployment env — defer to\n"
+            "``super().agent_spec()`` when ``ATLAN_APPLICATION_NAME`` +\n"
+            "``ATLAN_DEPLOYMENT_NAME`` are set, keeping the run-id name only as a\n"
+            "local fallback (mirroring ``SQLAppE2ETest.agent_spec``)::\n"
+            "\n"
+            "    def agent_spec(self) -> AgentSpec:\n"
+            "        if os.environ.get('ATLAN_APPLICATION_NAME') and os.environ.get(\n"
+            "            'ATLAN_DEPLOYMENT_NAME'\n"
+            "        ):\n"
+            "            return super().agent_spec()\n"
+            "        return AgentSpec(agent_name=f'myconn-e2e-full-ci-{self.run_id}')\n"
+            "\n"
+            "A connector that does not override ``agent_spec`` at all (inheriting\n"
+            "the SDK's env-derived default) is never flagged. This rule and T016\n"
+            "are a matched pair — remediate both the overlay and the agent_spec\n"
+            "together, never one alone.\n"
+            "\n"
+            "Suppress with ``# conformance: ignore[T017] <reason>`` on the\n"
+            "``def agent_spec`` line only when the hard-coded queue is deliberate\n"
+            "(e.g. a single-leg suite that never fans out and whose overlay also\n"
+            "hard-codes the same un-suffixed value).\n"
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/tests.md#t017"
         ),
     ),
 )

--- a/packages/conformance/conformance/suite/rules/tests.py
+++ b/packages/conformance/conformance/suite/rules/tests.py
@@ -107,6 +107,16 @@ the code that ships:
 * ``T015`` — CoverageOmitsProductCode: ``[tool.coverage.run].omit`` (or a
   narrowed ``source``) excludes real product code under ``app/`` — inflating
   the reported percentage by hiding uncovered code from the denominator.
+
+e2e-CI queue-isolation rule:
+
+* ``T016`` — E2EDeploymentNameNotInherited: an e2e CI docker-compose overlay
+  under ``.github/`` hard-codes ``ATLAN_DEPLOYMENT_NAME`` in a service's
+  ``environment`` instead of inheriting the per-leg value the SDK's ``sdr-e2e``
+  action exports to ``$GITHUB_ENV``. A hard-coded value overrides the inherited
+  env, so the worker container polls a different Temporal queue than the harness
+  dispatches to (dropping the matrix-leg suffix) → ``No Workers Running`` and a
+  ~20-min CI hang (observed on atlan-mysql-app).
 """
 
 from __future__ import annotations
@@ -937,6 +947,72 @@ RULES: tuple[RuleDefinition, ...] = (
         help_uri=(
             "https://github.com/atlanhq/application-sdk/blob/main/"
             "packages/conformance/conformance/docs/rules/tests.md#t015"
+        ),
+    ),
+    RuleDefinition(
+        id="T016",
+        scope=RuleScope.APP,
+        name="E2EDeploymentNameNotInherited",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="e2e-ci",
+        autofixable=False,
+        since="0.13.0",
+        rationale=(
+            "The full-DAG e2e worker derives its Temporal task queue as "
+            "atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}, and the harness "
+            "(BaseE2ETest.agent_spec) derives the extract-node queue it dispatches to "
+            "from the same two env vars. To keep worker and harness on one queue when "
+            "the e2e suite fans out across parallel matrix legs, the SDK's sdr-e2e "
+            "composite action derives a per-leg ATLAN_DEPLOYMENT_NAME (base + "
+            "sanitised matrix-leg suffix) and exports it to $GITHUB_ENV; both sides "
+            "then read that one value. A connector's e2e compose overlay that "
+            "hard-codes ATLAN_DEPLOYMENT_NAME in a service's environment overrides "
+            "that inherited value: the worker container drops the leg suffix and polls "
+            "atlan-<app>-e2e-full-ci-<run_id> while the harness still dispatches to "
+            "atlan-<app>-e2e-full-ci-<run_id>-<leg>. Two different queues means no "
+            "worker polls the harness's queue, so the top-level AE run flips to "
+            "Running (its parent lives on the always-on automation-engine queue) and "
+            "then hangs until timeout — observed on atlan-mysql-app, ~20 min of dead "
+            "CI per run, before this rule existed."
+        ),
+        short_description=(
+            "e2e CI compose overlay hard-codes ATLAN_DEPLOYMENT_NAME instead of "
+            "inheriting the sdr-e2e per-leg value"
+        ),
+        full_description=(
+            "An e2e CI docker-compose overlay under ``.github/`` (discovered as a\n"
+            "``*.yml``/``*.yaml`` with a top-level ``services:`` key that mentions\n"
+            "``ATLAN_DEPLOYMENT_NAME``) assigns ``ATLAN_DEPLOYMENT_NAME`` in a\n"
+            "service's ``environment`` to a literal that does not reference the\n"
+            "inherited ``${ATLAN_DEPLOYMENT_NAME...}`` env var.\n"
+            "\n"
+            "The SDK's ``sdr-e2e`` composite action derives a per-leg\n"
+            "``ATLAN_DEPLOYMENT_NAME`` (``e2e-full-ci-<run_id>[-<leg>]``, see\n"
+            "``derive_deployment_name.py``) and exports it to ``$GITHUB_ENV`` so the\n"
+            "worker container and the pytest harness land on the same Temporal queue.\n"
+            "A hard-coded overlay value overrides that inherited env, desynchronising\n"
+            "the two — the worker polls one queue, the harness dispatches to another,\n"
+            "and the run hangs with ``No Workers Running``.\n"
+            "\n"
+            "**Remediation:** inherit the derived value, with a bare-shape fallback\n"
+            "for local ``docker compose`` runs where the CI action hasn't exported it::\n"
+            "\n"
+            "    services:\n"
+            "      atlan-app:\n"
+            "        environment:\n"
+            "          - ATLAN_DEPLOYMENT_NAME=${ATLAN_DEPLOYMENT_NAME:-e2e-full-ci-${GITHUB_RUN_ID}}\n"
+            "\n"
+            "A bare pass-through list entry (``- ATLAN_DEPLOYMENT_NAME`` with no\n"
+            "``=``) is also accepted — it inherits the runner env directly.\n"
+            "\n"
+            "Suppress with ``# conformance: ignore[T016] <reason>`` on the assignment\n"
+            "line only when the overlay is intentionally single-queue (never fans out\n"
+            "across matrix legs) and the hard-coded name is deliberate.\n"
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/tests.md#t016"
         ),
     ),
 )

--- a/packages/conformance/conformance/suite/rules/tests.py
+++ b/packages/conformance/conformance/suite/rules/tests.py
@@ -1058,7 +1058,7 @@ RULES: tuple[RuleDefinition, ...] = (
         full_description=(
             "An ``agent_spec`` override under ``tests/`` returns a hard-coded\n"
             "``AgentSpec(agent_name=...)`` (a plain string or an f-string such as\n"
-            "``f\"myconn-e2e-full-ci-{self.run_id}\"``) without referencing\n"
+            '``f"myconn-e2e-full-ci-{self.run_id}"``) without referencing\n'
             "``ATLAN_DEPLOYMENT_NAME`` or calling ``super().agent_spec()``.\n"
             "\n"
             "The harness builds its extract-node Temporal queue as\n"

--- a/packages/conformance/conformance/suite/runner.py
+++ b/packages/conformance/conformance/suite/runner.py
@@ -37,6 +37,7 @@ from conformance.suite.checks import (
     determinism,
     dev_entrypoint,
     dockerfile_conformance,
+    e2e_deployment_name,
     entrypoint_alignment,
     error_handling,
     generated_freshness,
@@ -159,6 +160,11 @@ _CHECKS: list[CheckRegistration] = [
         series=coverage_config.SERIES,
         discover=coverage_config.discover,
         scan_path=coverage_config.scan_path,
+    ),
+    CheckRegistration(
+        series=e2e_deployment_name.SERIES,
+        discover=e2e_deployment_name.discover,
+        scan_path=e2e_deployment_name.scan_path,
     ),
     CheckRegistration(
         series=dockerfile_conformance.SERIES,

--- a/packages/conformance/conformance/suite/runner.py
+++ b/packages/conformance/conformance/suite/runner.py
@@ -37,6 +37,7 @@ from conformance.suite.checks import (
     determinism,
     dev_entrypoint,
     dockerfile_conformance,
+    e2e_agent_spec,
     e2e_deployment_name,
     entrypoint_alignment,
     error_handling,
@@ -165,6 +166,11 @@ _CHECKS: list[CheckRegistration] = [
         series=e2e_deployment_name.SERIES,
         discover=e2e_deployment_name.discover,
         scan_path=e2e_deployment_name.scan_path,
+    ),
+    CheckRegistration(
+        series=e2e_agent_spec.SERIES,
+        discover=e2e_agent_spec.discover,
+        scan_path=e2e_agent_spec.scan_path,
     ),
     CheckRegistration(
         series=dockerfile_conformance.SERIES,

--- a/packages/conformance/conformance/tools/generate_rule_docs.py
+++ b/packages/conformance/conformance/tools/generate_rule_docs.py
@@ -159,8 +159,10 @@ _SERIES_META: list[SeriesMeta] = [
             "`suite.checks.sdr_test_checks` (T002-T003), "
             "`suite.checks.dev_entrypoint` (T004), "
             "`suite.checks.test_quality` (T005-T009), "
-            "`suite.checks.test_structure` (T010-T013), and "
-            "`suite.checks.coverage_config` (T014-T015) (AST/TOML-based)"
+            "`suite.checks.test_structure` (T010-T013), "
+            "`suite.checks.coverage_config` (T014-T015), "
+            "`suite.checks.e2e_deployment_name` (T016), and "
+            "`suite.checks.e2e_agent_spec` (T017) (AST/TOML/YAML-based)"
         ),
         suppression_example=(
             "# conformance: ignore[T001] intentional: marked dynamically via add_marker"

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -27,9 +27,9 @@ def test_catalog_no_duplicate_ids() -> None:
     """Every rule ID in the catalog is unique."""
     rules = load_catalog()
     ids = [r.id for r in rules]
-    assert len(ids) == len(set(ids)), (
-        f"Duplicate rule IDs: {[x for x in ids if ids.count(x) > 1]}"
-    )
+    assert len(ids) == len(
+        set(ids)
+    ), f"Duplicate rule IDs: {[x for x in ids if ids.count(x) > 1]}"
 
 
 def test_catalog_ids_match_pattern() -> None:
@@ -46,12 +46,12 @@ def test_catalog_all_have_required_fields() -> None:
     for rule in rules:
         assert rule.id, f"Rule missing id: {rule}"
         assert rule.name, f"Rule {rule.id} missing name"
-        assert isinstance(rule.tier, EnforcementTier), (
-            f"Rule {rule.id} has invalid tier"
-        )
-        assert isinstance(rule.mechanism, RuleMechanism), (
-            f"Rule {rule.id} has invalid mechanism"
-        )
+        assert isinstance(
+            rule.tier, EnforcementTier
+        ), f"Rule {rule.id} has invalid tier"
+        assert isinstance(
+            rule.mechanism, RuleMechanism
+        ), f"Rule {rule.id} has invalid mechanism"
         assert rule.category, f"Rule {rule.id} missing category"
 
 
@@ -59,9 +59,9 @@ def test_catalog_all_have_rationale() -> None:
     """Every rule in the catalog must have a non-empty rationale."""
     rules = load_catalog()
     missing = [rule.id for rule in rules if not rule.rationale.strip()]
-    assert not missing, (
-        f"Rules missing rationale (add a rationale= to each RuleDefinition): {missing}"
-    )
+    assert (
+        not missing
+    ), f"Rules missing rationale (add a rationale= to each RuleDefinition): {missing}"
 
 
 def test_catalog_all_have_scope() -> None:

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -191,6 +191,9 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
     # connector apps ship a .github/e2e/ docker-compose overlay for the full-DAG
     # worker; the SDK has no such overlay to grade (the sdr-e2e action that
     # derives the per-leg value lives here, but it is not a compose overlay).
+    # T017: e2e agent_spec() override must inherit the per-leg deployment queue —
+    # only connector apps subclass the e2e harness and (may) override agent_spec;
+    # the SDK ships the env-derived default, it doesn't hard-code a connector queue.
     assert app_scoped == {
         "B001",
         "C002",
@@ -241,6 +244,7 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
         "T014",
         "T015",
         "T016",
+        "T017",
         "O002",
         "O003",
         "O004",

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -27,9 +27,9 @@ def test_catalog_no_duplicate_ids() -> None:
     """Every rule ID in the catalog is unique."""
     rules = load_catalog()
     ids = [r.id for r in rules]
-    assert len(ids) == len(
-        set(ids)
-    ), f"Duplicate rule IDs: {[x for x in ids if ids.count(x) > 1]}"
+    assert len(ids) == len(set(ids)), (
+        f"Duplicate rule IDs: {[x for x in ids if ids.count(x) > 1]}"
+    )
 
 
 def test_catalog_ids_match_pattern() -> None:
@@ -46,12 +46,12 @@ def test_catalog_all_have_required_fields() -> None:
     for rule in rules:
         assert rule.id, f"Rule missing id: {rule}"
         assert rule.name, f"Rule {rule.id} missing name"
-        assert isinstance(
-            rule.tier, EnforcementTier
-        ), f"Rule {rule.id} has invalid tier"
-        assert isinstance(
-            rule.mechanism, RuleMechanism
-        ), f"Rule {rule.id} has invalid mechanism"
+        assert isinstance(rule.tier, EnforcementTier), (
+            f"Rule {rule.id} has invalid tier"
+        )
+        assert isinstance(rule.mechanism, RuleMechanism), (
+            f"Rule {rule.id} has invalid mechanism"
+        )
         assert rule.category, f"Rule {rule.id} missing category"
 
 
@@ -59,9 +59,9 @@ def test_catalog_all_have_rationale() -> None:
     """Every rule in the catalog must have a non-empty rationale."""
     rules = load_catalog()
     missing = [rule.id for rule in rules if not rule.rationale.strip()]
-    assert (
-        not missing
-    ), f"Rules missing rationale (add a rationale= to each RuleDefinition): {missing}"
+    assert not missing, (
+        f"Rules missing rationale (add a rationale= to each RuleDefinition): {missing}"
+    )
 
 
 def test_catalog_all_have_scope() -> None:

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -187,6 +187,10 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
     # hiding app/ product code) — only connector apps have an app/ product-code
     # tree with a ratcheting coverage floor; the SDK's own coverage config is a
     # different, already-enforced policy (BLDX-1400).
+    # T016: e2e CI compose overlay must inherit ATLAN_DEPLOYMENT_NAME — only
+    # connector apps ship a .github/e2e/ docker-compose overlay for the full-DAG
+    # worker; the SDK has no such overlay to grade (the sdr-e2e action that
+    # derives the per-leg value lives here, but it is not a compose overlay).
     assert app_scoped == {
         "B001",
         "C002",
@@ -236,6 +240,7 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
         "T012",
         "T014",
         "T015",
+        "T016",
         "O002",
         "O003",
         "O004",

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -440,12 +440,17 @@ def test_catalog_o_series_present() -> None:
 
 
 def test_catalog_t_series_present() -> None:
-    """The T-series test-quality rules are all present."""
+    """The T-series test-quality rules are all present: T001 (integration
+    marking), T002/T003 (SDR test-quality), T004 (dev-entrypoint), T005-T009
+    (assertion/collection quality), T010-T013 (tier structure), T014/T015
+    (coverage-config), and T016/T017 (e2e-CI queue isolation)."""
     rules = load_catalog()
     t_ids = {r.id for r in rules if r.id.startswith("T")}
-    expected = {f"T{n:03d}" for n in range(1, 16)}
+    expected = {f"T{n:03d}" for n in range(1, 18)}
     missing = expected - t_ids
     assert not missing, f"Missing T-series rules: {missing}"
+    extra = t_ids - expected
+    assert not extra, f"Unexpected T-series rules: {extra}"
 
 
 def test_catalog_b_series_present() -> None:

--- a/packages/conformance/tests/test_e2e_agent_spec.py
+++ b/packages/conformance/tests/test_e2e_agent_spec.py
@@ -64,6 +64,20 @@ def test_flags_hardcoded_plain_string_agent_spec() -> None:
     assert [f.rule_id for f in findings] == ["T017"]
 
 
+def test_flags_positional_hardcoded_agent_spec() -> None:
+    # agent_name is AgentSpec's first field, so the positional form
+    # AgentSpec("x") / AgentSpec(f"...{run_id}") is equally hard-coded and must
+    # be flagged too — not just the agent_name= keyword form.
+    for body in (
+        '        return AgentSpec("pinned-name")\n',
+        '        return AgentSpec(f"metabase-e2e-full-ci-{self.run_id}")\n',
+    ):
+        text = "class T(Base):\n    def agent_spec(self):\n" + body
+        assert [f.rule_id for f in scan_text(text, "tests/e2e/test_x.py")] == [
+            "T017"
+        ], body
+
+
 # ── Compliant forms (no finding) ─────────────────────────────────────────────
 
 

--- a/packages/conformance/tests/test_e2e_agent_spec.py
+++ b/packages/conformance/tests/test_e2e_agent_spec.py
@@ -1,0 +1,131 @@
+"""Meta-tests for the T017 e2e-agent-spec check.
+
+T017 catches an e2e harness ``agent_spec`` override that hard-codes the
+extract-node queue (a run-id-keyed ``AgentSpec`` that neither reads
+``ATLAN_DEPLOYMENT_NAME`` nor calls ``super().agent_spec()``) instead of
+inheriting the per-leg deployment queue. It is the harness-side complement to
+T016 — the pair that, split, produced the atlan-metabase-app "No Workers
+Running" regression.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from conformance.suite.checks.e2e_agent_spec import discover, scan_path, scan_text
+from conformance.suite.rules import get_rule
+from conformance.suite.schema.disposition import EnforcementTier, RuleScope
+
+# ── Rule metadata ────────────────────────────────────────────────────────────
+
+
+def test_t017_rule_metadata() -> None:
+    rule = get_rule("T017")
+    assert rule.name == "E2EAgentSpecPinsQueue"
+    assert rule.tier == EnforcementTier.WARN
+    assert rule.scope == RuleScope.APP
+    assert rule.category == "e2e-ci"
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+_HARDCODED_FSTRING = (
+    "class T(Base):\n"
+    "    def agent_spec(self) -> AgentSpec:\n"
+    '        return AgentSpec(agent_name=f"metabase-e2e-full-ci-{self.run_id}")\n'
+)
+_HARDCODED_PLAIN = (
+    "class T(Base):\n"
+    "    def agent_spec(self):\n"
+    '        return AgentSpec(agent_name="pinned-name")\n'
+)
+_GUARDED_SUPER = (
+    "class T(Base):\n"
+    "    def agent_spec(self):\n"
+    "        if os.environ.get('ATLAN_APPLICATION_NAME') and os.environ.get(\n"
+    "            'ATLAN_DEPLOYMENT_NAME'\n"
+    "        ):\n"
+    "            return super().agent_spec()\n"
+    '        return AgentSpec(agent_name=f"metabase-e2e-full-ci-{self.run_id}")\n'
+)
+
+
+# ── Positive detections ──────────────────────────────────────────────────────
+
+
+def test_flags_hardcoded_fstring_agent_spec() -> None:
+    findings = scan_text(_HARDCODED_FSTRING, "tests/e2e/test_x.py")
+    assert [f.rule_id for f in findings] == ["T017"]
+    assert findings[0].line == 2  # the def line
+
+
+def test_flags_hardcoded_plain_string_agent_spec() -> None:
+    findings = scan_text(_HARDCODED_PLAIN, "tests/e2e/test_x.py")
+    assert [f.rule_id for f in findings] == ["T017"]
+
+
+# ── Compliant forms (no finding) ─────────────────────────────────────────────
+
+
+def test_passes_no_agent_spec_override() -> None:
+    text = "class T(Base):\n    connector_short_name = 'metabase'\n"
+    assert scan_text(text, "tests/e2e/test_x.py") == []
+
+
+def test_passes_guarded_override_that_defers_to_super() -> None:
+    assert scan_text(_GUARDED_SUPER, "tests/e2e/test_x.py") == []
+
+
+def test_passes_override_reading_deployment_env() -> None:
+    text = (
+        "class T(Base):\n"
+        "    def agent_spec(self):\n"
+        "        dep = os.environ['ATLAN_DEPLOYMENT_NAME']\n"
+        '        return AgentSpec(agent_name=f"metabase-{dep}")\n'
+    )
+    assert scan_text(text, "tests/e2e/test_x.py") == []
+
+
+def test_passes_direct_mode_returning_none() -> None:
+    text = "class T(Base):\n    def agent_spec(self):\n        return None\n"
+    assert scan_text(text, "tests/e2e/test_x.py") == []
+
+
+def test_noop_on_syntax_error() -> None:
+    assert scan_text("class T(:\n  def", "tests/e2e/test_x.py") == []
+
+
+# ── Inline suppression ───────────────────────────────────────────────────────
+
+
+def test_suppression_directive_on_def_line() -> None:
+    text = (
+        "class T(Base):\n"
+        "    def agent_spec(self):  # conformance: ignore[T017] single-leg suite\n"
+        '        return AgentSpec(agent_name=f"metabase-e2e-full-ci-{self.run_id}")\n'
+    )
+    findings = scan_text(text, "tests/e2e/test_x.py")
+    assert len(findings) == 1
+    assert findings[0].suppressed is True
+    assert findings[0].suppression_justification == "single-leg suite"
+
+
+# ── Discovery + scan_path integration ────────────────────────────────────────
+
+
+def test_discover_walks_tests_tree_and_scan_path(tmp_path: Path) -> None:
+    e2e_dir = tmp_path / "tests" / "e2e"
+    e2e_dir.mkdir(parents=True)
+    test_file = e2e_dir / "test_conn_e2e.py"
+    test_file.write_text(_HARDCODED_FSTRING, encoding="utf-8")
+
+    discovered = discover(tmp_path)
+    assert test_file in discovered
+
+    findings = scan_path(test_file, tmp_path)
+    assert [f.rule_id for f in findings] == ["T017"]
+    assert findings[0].file == "tests/e2e/test_conn_e2e.py"
+
+
+def test_discover_empty_without_tests_dir(tmp_path: Path) -> None:
+    assert discover(tmp_path) == []

--- a/packages/conformance/tests/test_e2e_deployment_name.py
+++ b/packages/conformance/tests/test_e2e_deployment_name.py
@@ -1,0 +1,177 @@
+"""Meta-tests for the T016 e2e-deployment-name check.
+
+T016 catches an e2e CI docker-compose overlay that hard-codes
+``ATLAN_DEPLOYMENT_NAME`` instead of inheriting the per-leg value the SDK's
+``sdr-e2e`` action exports to ``$GITHUB_ENV``. A hard-coded value overrides the
+inherited env, so the worker container polls a different Temporal queue than the
+harness dispatches to — the failure mode that hung atlan-mysql-app's e2e for
+~20 min ("No Workers Running").
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from conformance.suite.checks.e2e_deployment_name import (
+    discover,
+    scan_path,
+    scan_text,
+)
+from conformance.suite.rules import get_rule
+from conformance.suite.schema.disposition import EnforcementTier, RuleScope
+
+# ── Rule metadata ────────────────────────────────────────────────────────────
+
+
+def test_t016_rule_metadata() -> None:
+    rule = get_rule("T016")
+    assert rule.name == "E2EDeploymentNameNotInherited"
+    assert rule.tier == EnforcementTier.WARN
+    assert rule.scope == RuleScope.APP
+    assert rule.category == "e2e-ci"
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+_HARDCODED_LIST = (
+    "services:\n"
+    "  atlan-app:\n"
+    "    environment:\n"
+    "      - ATLAN_DEPLOYMENT_NAME=e2e-full-ci-${GITHUB_RUN_ID}\n"
+)
+_INHERITED_LIST = (
+    "services:\n"
+    "  atlan-app:\n"
+    "    environment:\n"
+    "      - ATLAN_DEPLOYMENT_NAME=${ATLAN_DEPLOYMENT_NAME:-e2e-full-ci-${GITHUB_RUN_ID}}\n"
+)
+_PASSTHROUGH_LIST = (
+    "services:\n  atlan-app:\n    environment:\n      - ATLAN_DEPLOYMENT_NAME\n"
+)
+_HARDCODED_MAP = (
+    "services:\n"
+    "  atlan-app:\n"
+    "    environment:\n"
+    '      ATLAN_DEPLOYMENT_NAME: "e2e-full-ci-${GITHUB_RUN_ID}"\n'
+)
+_INHERITED_MAP = (
+    "services:\n"
+    "  atlan-app:\n"
+    "    environment:\n"
+    '      ATLAN_DEPLOYMENT_NAME: "${ATLAN_DEPLOYMENT_NAME:-e2e-full-ci-${GITHUB_RUN_ID}}"\n'
+)
+
+
+# ── Positive detections ──────────────────────────────────────────────────────
+
+
+def test_flags_hardcoded_list_form() -> None:
+    findings = scan_text(_HARDCODED_LIST, ".github/e2e/e2e-full-docker-compose.yaml")
+    assert [f.rule_id for f in findings] == ["T016"]
+    assert findings[0].line == 4
+
+
+def test_flags_hardcoded_map_form() -> None:
+    findings = scan_text(_HARDCODED_MAP, ".github/e2e/e2e-full-docker-compose.yaml")
+    assert [f.rule_id for f in findings] == ["T016"]
+    assert findings[0].line == 4
+
+
+def test_flags_bare_hardcoded_value_without_interpolation() -> None:
+    text = (
+        "services:\n"
+        "  atlan-app:\n"
+        "    environment:\n"
+        "      - ATLAN_DEPLOYMENT_NAME=production\n"
+    )
+    findings = scan_text(text, ".github/e2e/overlay.yaml")
+    assert [f.rule_id for f in findings] == ["T016"]
+
+
+# ── Compliant forms (no finding) ─────────────────────────────────────────────
+
+
+def test_passes_inherited_list_form() -> None:
+    assert scan_text(_INHERITED_LIST, ".github/e2e/overlay.yaml") == []
+
+
+def test_passes_inherited_map_form() -> None:
+    assert scan_text(_INHERITED_MAP, ".github/e2e/overlay.yaml") == []
+
+
+def test_passes_bare_passthrough_list_entry() -> None:
+    assert scan_text(_PASSTHROUGH_LIST, ".github/e2e/overlay.yaml") == []
+
+
+def test_passes_plain_interpolation_without_default() -> None:
+    text = (
+        "services:\n"
+        "  atlan-app:\n"
+        "    environment:\n"
+        "      - ATLAN_DEPLOYMENT_NAME=${ATLAN_DEPLOYMENT_NAME}\n"
+    )
+    assert scan_text(text, ".github/e2e/overlay.yaml") == []
+
+
+# ── No-ops / scoping ─────────────────────────────────────────────────────────
+
+
+def test_noop_on_non_compose_yaml() -> None:
+    # A GitHub workflow file mentions the var but has no top-level services: key.
+    text = (
+        "jobs:\n"
+        "  e2e:\n"
+        "    steps:\n"
+        "      - run: echo ATLAN_DEPLOYMENT_NAME=e2e-full-ci-${GITHUB_RUN_ID}\n"
+    )
+    assert scan_text(text, ".github/workflows/tests.yaml") == []
+
+
+def test_noop_when_var_absent() -> None:
+    text = "services:\n  atlan-app:\n    environment:\n      - FOO=bar\n"
+    assert scan_text(text, ".github/e2e/overlay.yaml") == []
+
+
+# ── Inline suppression ───────────────────────────────────────────────────────
+
+
+def test_suppression_directive_on_same_line() -> None:
+    text = (
+        "services:\n"
+        "  atlan-app:\n"
+        "    environment:\n"
+        "      - ATLAN_DEPLOYMENT_NAME=e2e-full-ci-${GITHUB_RUN_ID}  "
+        "# conformance: ignore[T016] single-queue by design\n"
+    )
+    findings = scan_text(text, ".github/e2e/overlay.yaml")
+    assert len(findings) == 1
+    assert findings[0].suppressed is True
+    assert findings[0].suppression_justification == "single-queue by design"
+
+
+# ── Discovery + scan_path integration ────────────────────────────────────────
+
+
+def test_discover_finds_e2e_overlay_and_skips_workflows(tmp_path: Path) -> None:
+    e2e_dir = tmp_path / ".github" / "e2e"
+    e2e_dir.mkdir(parents=True)
+    overlay = e2e_dir / "e2e-full-docker-compose.yaml"
+    overlay.write_text(_HARDCODED_MAP, encoding="utf-8")
+
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "tests.yaml").write_text(
+        "jobs:\n  e2e:\n    steps:\n      - run: echo ATLAN_DEPLOYMENT_NAME=x\n",
+        encoding="utf-8",
+    )
+
+    discovered = discover(tmp_path)
+    assert discovered == [overlay]
+
+    findings = scan_path(overlay, tmp_path)
+    assert [f.rule_id for f in findings] == ["T016"]
+    assert findings[0].file == ".github/e2e/e2e-full-docker-compose.yaml"
+
+
+def test_discover_empty_without_github_dir(tmp_path: Path) -> None:
+    assert discover(tmp_path) == []

--- a/packages/conformance/tests/test_e2e_deployment_name.py
+++ b/packages/conformance/tests/test_e2e_deployment_name.py
@@ -109,6 +109,32 @@ def test_passes_plain_interpolation_without_default() -> None:
     assert scan_text(text, ".github/e2e/overlay.yaml") == []
 
 
+def test_passes_yaml_null_map_value() -> None:
+    # A null-valued compose env MAP entry means "pass the var through from the
+    # host/runner env" (inherit) — same semantics as the bare list pass-through.
+    for null_token in ("null", "Null", "NULL", "~"):
+        text = (
+            "services:\n"
+            "  atlan-app:\n"
+            "    environment:\n"
+            f"      ATLAN_DEPLOYMENT_NAME: {null_token}\n"
+        )
+        assert scan_text(text, ".github/e2e/overlay.yaml") == [], null_token
+
+
+def test_flags_list_form_null_literal() -> None:
+    # Asymmetry: in LIST form ``=null`` is a literal string assignment (not a
+    # pass-through), so it is correctly flagged — the null pass-through is
+    # map-form-only.
+    text = (
+        "services:\n"
+        "  atlan-app:\n"
+        "    environment:\n"
+        "      - ATLAN_DEPLOYMENT_NAME=null\n"
+    )
+    assert [f.rule_id for f in scan_text(text, ".github/e2e/overlay.yaml")] == ["T016"]
+
+
 # ── No-ops / scoping ─────────────────────────────────────────────────────────
 
 

--- a/packages/conformance/tests/test_e2e_deployment_name.py
+++ b/packages/conformance/tests/test_e2e_deployment_name.py
@@ -12,11 +12,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from conformance.suite.checks.e2e_deployment_name import (
-    discover,
-    scan_path,
-    scan_text,
-)
+from conformance.suite.checks.e2e_deployment_name import discover, scan_path, scan_text
 from conformance.suite.rules import get_rule
 from conformance.suite.schema.disposition import EnforcementTier, RuleScope
 


### PR DESCRIPTION
## Why

atlan-mysql-app's full-DAG e2e stalled with **"No Workers Running"** for ~20 min: the compose worker and the test harness derived *different* Temporal task queues, so the extract activity was dispatched to a queue no worker polled.

The invariant: **the worker's queue and the harness's queue must agree.** Both are `atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}`, and the `sdr-e2e` action exports a per-leg `ATLAN_DEPLOYMENT_NAME` (`e2e-full-ci-<run_id>[-<matrix-leg>]`) so both sides can agree. Two independent hard-codings break it — and this PR adds a rule for **each side**, because fixing one alone is exactly what broke metabase.

## The two rules (a matched pair)

**T016 — `E2EDeploymentNameNotInherited`** (worker side). Flags an e2e CI compose overlay under `.github/` that hard-codes `ATLAN_DEPLOYMENT_NAME` in a service `environment` instead of inheriting `${ATLAN_DEPLOYMENT_NAME:-…}`. Handles list and map compose forms.

**T017 — `E2EAgentSpecPinsQueue`** (harness side). AST-flags an `agent_spec` override under `tests/` that returns a hard-coded `AgentSpec(agent_name=<literal>)` without reading `ATLAN_DEPLOYMENT_NAME` or calling `super().agent_spec()`. Preferred fix: **delete the override** (the base now provides the run-id fallback — #2700).

Both are WARN, app-scoped, `e2e-ci` category. The remediation prose documents them as a **matched pair** and cross-references each other, so a fix never lands one side alone (the metabase regression: overlay fixed by #203, `agent_spec` left hard-coded → 31-min hang).

## Deliverables (rule + check + remediation, per rule)

- Rule defs (`suite/rules/tests.py`), registered checks (`suite/checks/e2e_deployment_name.py`, `suite/checks/e2e_agent_spec.py`), catalog invariant updated, docs regenerated.
- Remediation prose in `programs/areas/tests.prose.md` (the `/remediate` skill's T-series program), both routing to residue (T016 edits `.github/`, T017 edits `tests/` — both outside the remediator's write-scope).
- Tests: `tests/test_e2e_deployment_name.py`, `tests/test_e2e_agent_spec.py`.

## Verification

- Full conformance suite: **1846 passed, 1 xfailed**; rule-doc freshness passes; ruff + isort clean.
- End-to-end: T016 flags the pre-fix mysql/metabase overlays and is clean on the fixed ones; T017 flags atlan-metabase-app (line 89) and atlan-openapi-app (line 54) hard-coded overrides and is clean on atlan-mysql-app (no override).

## Companion PRs (the fixes these rules now guard)

- atlan-mysql-app#407 (overlay), atlan-metabase-app#204 (delete agent_spec override), atlan-openapi-app#226 (overlay + delete override), application-sdk#2700 (base `agent_spec` fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)