### PR TITLE
ci: post SDK-PR comment with GITHUB_TOKEN, not the connector-scoped app token

### DIFF
--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -195,6 +195,15 @@ runs:
     # cross-repo dispatch outcome without clicking through to the
     # connector run. Uses updateComment in-place when a prior marker
     # exists so re-pushes don't spam the PR thread.
+    #
+    # This comments on THIS repo's PR (context.repo), so it uses the
+    # workflow's own GITHUB_TOKEN — NOT inputs.github-token, which is the
+    # fleet App token scoped to the *connector* repo (owner/repositories:
+    # <connector>) and therefore gets 403 "Resource not accessible by
+    # integration" when it tries to write an issue comment here. The calling
+    # workflow already grants `issues: write` + `pull-requests: write`
+    # (see pull_request.yaml permissions). All other steps below keep
+    # inputs.github-token — they legitimately act on the connector repo.
     - name: Post dispatched-run status to SDK PR
       if: always() && github.event_name == 'pull_request'
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -207,7 +216,7 @@ runs:
         DISPATCHED_STATUS: ${{ steps.status.outputs.status }}
         RENDERED_BODY_PATH: ${{ steps.dispatched_summary.outputs.body_path }}
       with:
-        github-token: ${{ inputs.github-token }}
+        github-token: ${{ github.token }}
         script: |
           const fs = require('fs');
           const repoName = process.env.REPO_NAME;


### PR DESCRIPTION
## Problem

The e2e-apps **"Post dispatched-run status to SDK PR"** step 403s with `Resource not accessible by integration` ([example](https://github.com/atlanhq/application-sdk/actions/runs/29342185503/job/87117008191)):

```
POST /repos/atlanhq/application-sdk/issues/2657/comments - 403
x-accepted-github-permissions: issues=write; pull_requests=write
```

It commented with `inputs.github-token` — the fleet App token minted per-connector (`create-github-app-token` with `owner: atlanhq, repositories: <connector>`). That token is scoped to the **connector** repo, so it can't write an issue comment on the **application-sdk** PR.

Because the step is `continue-on-error: true`, it never failed the job — so the sticky comment silently **never posted for any connector** (mysql/openapi/metabase alike). It was only *noticed* on metabase because that dispatched run also failed, turning the job red and surfacing the annotation.

## Fix

Comment on this repo's own PR (`context.repo`) with the workflow's **`GITHUB_TOKEN`** (`${{ github.token }}`). The calling workflow already grants `issues: write` + `pull-requests: write` at the top level (`pull_request.yaml` permissions), and `connector-tests` / `sdr-k8s-e2e` inherit it — so no permissions change is needed.

All other steps keep `inputs.github-token` — they dispatch to, poll, and fetch artifacts from the **connector** repo and legitimately need that token.

## Scope

One-line token swap on the single step that writes to the SDK PR. `git grep` confirms the other three `inputs.github-token` uses are connector-repo operations (return-dispatch, status poll, artifact fetch), left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)