### PR TITLE
fix(e2e): recognize AE 'Skipped' as a terminal DAG status

### DIFF
--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -104,6 +104,7 @@ _NODE_GLYPHS = {
     "Pending": "🟡",
     "Cancelled": "🚫",
     "TimedOut": "⏰",
+    "Skipped": "⏭️",
 }
 _RUN_GLYPHS = {
     "Succeeded": "✅",
@@ -112,6 +113,7 @@ _RUN_GLYPHS = {
     "Pending": "🟡",
     "Cancelled": "🚫",
     "TimedOut": "⏰",
+    "Skipped": "⏭️",
 }
 
 
@@ -138,6 +140,10 @@ class DAGNodeStatus(str, Enum):
     FAILED = "Failed"
     ERROR = "Error"
     CANCELLED = "Cancelled"
+    # AE emits this when a node is bypassed (e.g. an opted-out DAG leg, or
+    # every downstream node once an upstream one fails). Terminal but not a
+    # success — a skipped node will not run without re-submission.
+    SKIPPED = "Skipped"
 
     @property
     def is_terminal(self) -> bool:
@@ -147,6 +153,7 @@ class DAGNodeStatus(str, Enum):
             DAGNodeStatus.FAILED,
             DAGNodeStatus.ERROR,
             DAGNodeStatus.CANCELLED,
+            DAGNodeStatus.SKIPPED,
         }
 
     @property
@@ -164,6 +171,12 @@ class DAGRunStatus(str, Enum):
     FAILED = "Failed"
     ERROR = "Error"
     CANCELLED = "Cancelled"
+    # A run AE never executed — e.g. deduplicated against an in-flight run, or
+    # every node opted out. Terminal: recognising it lets poll_native_status
+    # return the true outcome immediately instead of mapping the unknown value
+    # to PENDING and waiting out the full stall grace, which surfaces as a
+    # misleading NoWorkerOnTaskQueueError.
+    SKIPPED = "Skipped"
 
     @property
     def is_terminal(self) -> bool:
@@ -172,6 +185,7 @@ class DAGRunStatus(str, Enum):
             DAGRunStatus.FAILED,
             DAGRunStatus.ERROR,
             DAGRunStatus.CANCELLED,
+            DAGRunStatus.SKIPPED,
         }
 
 

--- a/tests/unit/testing/e2e/test_client.py
+++ b/tests/unit/testing/e2e/test_client.py
@@ -25,6 +25,8 @@ from application_sdk.testing.e2e.client import (
     DAGNodeStatus,
     DAGRunResult,
     DAGRunStatus,
+    _safe_node_status,
+    _safe_run_status,
 )
 
 _RUN_ID = "test-run-123"
@@ -205,6 +207,40 @@ class TestPollNativeStatusStallGuard:
                     stall_grace_seconds=-1,
                 )
         assert result.status == DAGRunStatus.RUNNING
+
+
+class TestSkippedStatus:
+    """AE emits 'Skipped' as a real status; it must parse as a terminal enum
+    value rather than being swallowed to PENDING (which masked a skipped run as
+    a stalled one and surfaced as a spurious NoWorkerOnTaskQueueError)."""
+
+    def test_run_skipped_parses_and_is_terminal(self):
+        assert _safe_run_status("Skipped") is DAGRunStatus.SKIPPED
+        assert DAGRunStatus.SKIPPED.is_terminal is True
+
+    def test_node_skipped_parses_terminal_but_not_success(self):
+        assert _safe_node_status("Skipped") is DAGNodeStatus.SKIPPED
+        assert DAGNodeStatus.SKIPPED.is_terminal is True
+        assert DAGNodeStatus.SKIPPED.is_success is False
+
+    def test_skipped_run_returns_fast_without_tripping_stall_guard(self):
+        """A Skipped run is terminal, so poll_native_status returns it
+        immediately — even though no node started, the stall guard (which would
+        otherwise raise NoWorkerOnTaskQueueError) must not fire on a terminal
+        status."""
+        client = _make_client()
+        skipped = _result(DAGRunStatus.SKIPPED, DAGNodeStatus.PENDING)
+
+        with patch.object(client, "get_native_status", return_value=skipped):
+            with patch("time.sleep"):
+                result = client.poll_native_status(
+                    _RUN_ID,
+                    interval_seconds=10,
+                    timeout_seconds=600,
+                    stall_grace_seconds=5,
+                    stall_task_queue="atlan-openapi-e2e-full-ci-42",
+                )
+        assert result.status == DAGRunStatus.SKIPPED
 
 
 class TestPollNativeStatusTransientHandling:


### PR DESCRIPTION
## Why

AE returns **`Skipped`** as a real DAG status — both top-level (a run deduplicated against an in-flight one, or every node opted out) and per-node (downstream nodes bypassed after an upstream failure). Neither `DAGRunStatus` nor `DAGNodeStatus` had a `Skipped` member, so the defensive parsers (`_safe_run_status` / `_safe_node_status`) fell into their `except ValueError` branch, logged a traceback via `exc_info=True`, and mapped the value to **`PENDING`**.

Mapping a skipped run to PENDING mislabels it as *"never started"*: `poll_native_status` never observes a terminal status, runs out the full `stall_grace_seconds`, and raises a misleading **`NoWorkerOnTaskQueueError`** — even when the worker ran fine.

### Observed
On the openapi canonical-e2e leg in #2657, the connector **completed successfully** (`publish_completed=True … App completed`), yet the test failed with:
```
ValueError: 'Skipped' is not a valid DAGRunStatus      # the swallowed exc_info traceback
...
NoWorkerOnTaskQueueError: No DAG node started within 180s for run ... (top-level status=Pending)
```
The `status=Pending` in that message is the tell — it was really `Skipped`, remapped.

## Fix

- Add `SKIPPED = "Skipped"` to `DAGRunStatus` **and** `DAGNodeStatus`.
- Include it in `is_terminal` (a skipped run/node will not progress without re-submission); it is **not** a success, so `all_nodes_succeeded` / `failed_nodes` still fail the test — but now with the *true* outcome instead of a spurious no-worker timeout.
- Add a `⏭️` glyph for the poll-loop summary.

Because the status is now terminal, `poll_native_status` returns immediately (line ~692) instead of waiting out the stall grace.

## Tests

New `TestSkippedStatus`: parsing (`_safe_*` → `SKIPPED`, no longer `PENDING`), terminal/non-success semantics, and that a `Skipped` run returns fast without tripping the stall guard. Full testing-package suite: **331 passed**. `ruff@0.6.4` check + format clean.

## Note

This makes the harness *report* `Skipped` accurately; it does not address **why** openapi's run came back Skipped (likely AE dedup / idempotency collision on the shared tenant — a separate follow-up, same family as the mysql/metabase `credentials_name_key` duplicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)