### PR TITLE
fix(e2e): raise AE submit timeout to 300s for the concurrent fan-out

### DIFF
--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -71,12 +71,21 @@ _USER_AGENT = "atlan-sdk-full-dag-e2e/1.0 (+https://github.com/atlanhq/applicati
 # / ``poll_atlas_for_connection``; the per-request timeout just keeps
 # any one call from hanging the whole loop.
 _HTTP_TIMEOUT = 60
-# AE create and submit can take >60 s on the first call — the origin
-# server may be slow to respond, causing Cloudflare to return HTTP 504
-# at its own gateway timeout before urllib's 60 s window closes.  Using
-# 120 s lets Cloudflare's 504 arrive as an HTTP error (which the
-# existing 5xx retry loop handles) rather than a raw TimeoutError.
-_SUBMIT_TIMEOUT = 120
+# AE create and submit are slow, and — since submit is non-idempotent, we no
+# longer retry it on timeout (see submit_workflow) — the single POST must wait
+# long enough for AE to respond, or we lose the run entirely.
+#
+# Measured latency: a *solo* submit takes ~60 s end to end (mysql e2e, run
+# 29342337536: 14:48:43 submit → 14:49:44 run_id). Under the canonical-e2e
+# fan-out all three connectors submit within ~1 s of each other, and the
+# pile-up on the shared AE/Heracles instance pushes a submit past the old 120 s
+# cap — every fan-out failure was a raw TimeoutError at exactly 120 s with no
+# response (application-sdk#2657). 300 s gives that concurrent burst enough
+# headroom to return the real run_id. With no retry, a genuine hang still fails
+# cleanly at the cap — no duplicate-run risk. (The durable fix is an AE
+# idempotency key / lookup-by-slug so a lost submit response can be recovered;
+# tracked separately.)
+_SUBMIT_TIMEOUT = 300
 
 # Transient network-layer errors (DNS blips, read timeouts, connection resets)
 # are common during multi-minute polls over a VPN/loft tunnel to a tenant. Retry


### PR DESCRIPTION
## Why

Follow-up to #2707 / #2708. Those made the e2e harness *report* AE submit failures honestly instead of mistracking a phantom run. This addresses the failure they unmasked.

Every canonical-e2e failure (#2657) is the **3-connector fan-out**: mysql / openapi / metabase submit to the shared AE/Heracles instance **within ~1 s of each other**, and the pile-up pushes a submit past the 120 s cap. Each failure was a **raw `TimeoutError` at exactly 120 s with no response** — and since #2708 correctly no longer re-POSTs a non-idempotent submit, the run is simply lost.

### Evidence it's load-induced, not chronic

| Run | Shape | Submit latency | Result |
|---|---|---|---|
| mysql `29342337536` (14:46, solo) | 1 connector | **~60 s** (14:48:43 → 14:49:44) | ✅ passed |
| all `29369348*` / `29376205*` (21:23, 23:27) | **3 connectors, submit within 1 s** | **>120 s → timeout** | ❌ |

A solo submit is ~60 s end to end, so the endpoint works — it just needs headroom under the concurrent burst.

## Change

`_SUBMIT_TIMEOUT` 120 → **300 s**, so the single (no-retry) POST waits long enough for AE to return the real `run_id` under load.

- **No duplicate risk:** #2708 already disabled submit re-POST on timeout, so a genuine hang still fails cleanly at the cap — we just give AE more room to respond first.
- Applies to the AE write path (`_post_with_retry`): create / version / publish / submit.

## Not in this PR (durable fix, needs AE — filed separately)

The real fix is an **idempotency key or lookup-by-slug** on AE submit, so a *lost* submit response can be recovered and the submit safely retried (detect the `AE-WF-409-03` conflict → monitor the original run instead of failing). Today the submit is non-idempotent — the payload `run_id` is only a name tag; AE mints its own run UUID server-side and returns it only in the (lost) response; the 409 body omits it; and `native-status` is keyed by run UUID with no lookup-by-slug. Tracked as a follow-up against App Runtime.

Complementary infra option: stagger the #2657 fan-out so the three don't submit simultaneously.

## Tests

Unchanged behavior (constant bump); e2e client suite: **31 passed**. `ruff@0.6.4` check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)