### PR TITLE
fix(conformance): P028 no longer flags object-store keys embedding a qualifiedName

### DIFF
--- a/packages/conformance/conformance/docs/rules/prescriptions.md
+++ b/packages/conformance/conformance/docs/rules/prescriptions.md
@@ -938,6 +938,15 @@ Fix: construct assets through the pyatlan asset `.creator()` factories, which co
 qualifiedName from typed parent references.  WARN tier — suppress with `# conformance:
 ignore[P028] <reason>` where a raw qualifiedName string is genuinely required.
 
+**Not flagged — object-store keys.** An asset qualifiedName is always *rooted* at its
+parent qn (the interpolated qn is the leading segment: `f"{connection_qn}/collections/{id}"`).
+An object-store **key** merely embeds a qn *after* a literal namespace prefix
+(`f"persistent-artifacts/apps/…/{connection_qn}/publish-state"`,
+`f"argo-artifacts/{connection_qn}/current-state"`) — that is a storage path, not an asset
+identity, and `.creator()` has nothing to say about it. When the qn reference is preceded
+by a `/`-bearing literal segment the f-string is treated as an object-store key and is not
+flagged.
+
 ---
 
 ## P029 — `SdrManifestMissingAgentJson` {#p029}

--- a/packages/conformance/conformance/suite/checks/prescriptions/_qualified_name.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_qualified_name.py
@@ -11,6 +11,16 @@ Per-file.  Heuristic, WARN-tier: flag an f-string that both (a) interpolates a
 ``*qualified_name`` / ``*_qn`` value and (b) contains a ``/`` path separator —
 i.e. is composing a slash-delimited qualifiedName.  This catches the whole chain
 (``db_qn = f"{connection_qn}/{db}"`` → ``schema_qn = f"{db_qn}/{schema}"`` …).
+
+An asset ``qualifiedName`` is always *rooted* at its parent qn: the interpolated
+qn value is the leading segment (``f"{connection_qn}/collections/{id}"``).  An
+object-store **key** merely *embeds* a qn after a literal namespace prefix
+(``f"persistent-artifacts/apps/…/{connection_qn}/publish-state"``,
+``f"argo-artifacts/{connection_qn}/current-state"``) — that is a storage path,
+not an asset identity, and pyatlan ``.creator()`` has nothing to say about it.
+So when the qn reference is preceded by a ``/``-bearing literal segment we treat
+the f-string as an object-store key and do **not** flag it — this removes the
+false positive without weakening detection of genuinely hand-rooted qualifiedNames.
 """
 
 from __future__ import annotations
@@ -25,19 +35,24 @@ from conformance.suite.schema.findings import Finding
 _QN_NAME = re.compile(r"(?i)(qualified_name|_qn$|^qn$)")
 
 
-def _references_qualified_name(joined: ast.JoinedStr) -> bool:
-    for part in joined.values:
-        if not isinstance(part, ast.FormattedValue):
-            continue
-        for sub in ast.walk(part.value):
-            ident: str | None = None
-            if isinstance(sub, ast.Name):
-                ident = sub.id
-            elif isinstance(sub, ast.Attribute):
-                ident = sub.attr
-            if ident and _QN_NAME.search(ident):
-                return True
+def _formatted_value_is_qn(part: ast.FormattedValue) -> bool:
+    """True when the interpolated expression references a qualifiedName value."""
+    for sub in ast.walk(part.value):
+        ident: str | None = None
+        if isinstance(sub, ast.Name):
+            ident = sub.id
+        elif isinstance(sub, ast.Attribute):
+            ident = sub.attr
+        if ident and _QN_NAME.search(ident):
+            return True
     return False
+
+
+def _references_qualified_name(joined: ast.JoinedStr) -> bool:
+    return any(
+        isinstance(part, ast.FormattedValue) and _formatted_value_is_qn(part)
+        for part in joined.values
+    )
 
 
 def _has_path_separator(joined: ast.JoinedStr) -> bool:
@@ -47,6 +62,28 @@ def _has_path_separator(joined: ast.JoinedStr) -> bool:
         and "/" in part.value
         for part in joined.values
     )
+
+
+def _is_object_store_key(joined: ast.JoinedStr) -> bool:
+    """True when the qn reference is *embedded* after a literal path segment.
+
+    An asset qualifiedName is rooted at its parent qn (``f"{parent_qn}/…"``);
+    an object-store key prefixes the qn with a literal namespace segment
+    (``f"persistent-artifacts/…/{connection_qn}/…"``).  We detect the latter by
+    finding a ``/``-bearing string literal that precedes the first qn reference.
+    """
+    seen_path_literal = False
+    for part in joined.values:
+        if (
+            isinstance(part, ast.Constant)
+            and isinstance(part.value, str)
+            and "/" in part.value
+        ):
+            seen_path_literal = True
+        elif isinstance(part, ast.FormattedValue) and _formatted_value_is_qn(part):
+            # First qn reference: it is a key iff a path literal came before it.
+            return seen_path_literal
+    return False
 
 
 def check_p028(
@@ -59,7 +96,11 @@ def check_p028(
     for node in ast.walk(tree):
         if not isinstance(node, ast.JoinedStr):
             continue
-        if _references_qualified_name(node) and _has_path_separator(node):
+        if (
+            _references_qualified_name(node)
+            and _has_path_separator(node)
+            and not _is_object_store_key(node)
+        ):
             findings.append(
                 make_finding(
                     filename=filename,

--- a/packages/conformance/conformance/suite/rules/prescriptions.py
+++ b/packages/conformance/conformance/suite/rules/prescriptions.py
@@ -386,6 +386,12 @@ RULES: tuple[RuleDefinition, ...] = (
             "grammar across the fleet, and a grammar change (tenant scoping, escaping)\n"
             "then breaks every connector independently with no single source of truth.\n"
             "\n"
+            "Not flagged — object-store keys: a qn reference preceded by a ``/``-bearing\n"
+            "literal segment (e.g.\n"
+            '``f"persistent-artifacts/.../{connection_qualified_name}/publish-state"``) is\n'
+            "a storage path that embeds a qn, not an asset qualifiedName rooted at its\n"
+            "parent qn, so it is not flagged.\n"
+            "\n"
             "Fix: construct assets through the pyatlan asset ``.creator()`` factories,\n"
             "which compute qualifiedName from typed parent references.  WARN tier —\n"
             "suppress with ``# conformance: ignore[P028] <reason>`` where a raw\n"

--- a/packages/conformance/tests/test_prescriptions.py
+++ b/packages/conformance/tests/test_prescriptions.py
@@ -2295,3 +2295,37 @@ def test_p028_suppressed_inline() -> None:
     )
     fs = [f for f in scan_text(src, "x.py") if f.rule_id == "P028"]
     assert fs and all(f.suppressed for f in fs)
+
+
+def test_p028_no_finding_on_object_store_key_prefix() -> None:
+    # qn embedded AFTER a literal storage-namespace prefix → object-store key,
+    # not an asset qualifiedName. Must not fire.
+    src = (
+        'k = f"persistent-artifacts/apps/publish/state/'
+        '{connection_qualified_name}/publish-state"\n'
+    )
+    assert "P028" not in _ids(src)
+
+
+def test_p028_no_finding_on_argo_artifacts_key() -> None:
+    src = 'k = f"argo-artifacts/{connection_qualified_name}/current-state"\n'
+    assert "P028" not in _ids(src)
+
+
+def test_p028_no_finding_on_multiline_object_store_key() -> None:
+    # Implicitly-concatenated f-string (parenthesised) is one JoinedStr node;
+    # the leading literal still precedes the qn ref.
+    src = (
+        "k = (\n"
+        '    f"persistent-artifacts/apps/publish/state/"\n'
+        '    f"{connection_qn}/lineage/publish-state"\n'
+        ")\n"
+    )
+    assert "P028" not in _ids(src)
+
+
+def test_p028_still_fires_when_qn_is_rooted() -> None:
+    # qn is the leading segment → genuine hand-built qualifiedName, still flagged
+    # even though later literal segments contain slashes.
+    src = 'qn = f"{connection_qn}/collections/{collection_id}"\n'
+    assert "P028" in _ids(src)

--- a/packages/conformance/tests/test_prescriptions.py
+++ b/packages/conformance/tests/test_prescriptions.py
@@ -2329,3 +2329,14 @@ def test_p028_still_fires_when_qn_is_rooted() -> None:
     # even though later literal segments contain slashes.
     src = 'qn = f"{connection_qn}/collections/{collection_id}"\n'
     assert "P028" in _ids(src)
+
+
+def test_p028_no_finding_on_dynamic_prefix_embedded_qn() -> None:
+    # Boundary case: a dynamic (non-literal) leading segment, then a bare "/"
+    # separator, then an embedded qn. The qn is NOT the leading segment, so this
+    # is object-store-key-shaped (a storage path with a runtime prefix), not a
+    # rooted asset qualifiedName — the discriminator exempts it. Pinned so a
+    # future refactor of the first-qn-ref early-return can't silently start
+    # flagging it (which would reintroduce a false positive on non-rooted keys).
+    src = 'k = f"{run_id}/{connection_qn}/current-state"\n'
+    assert "P028" not in _ids(src)


### PR DESCRIPTION
## Problem

P028 (`ManualQualifiedNameFString`) flags any f-string that interpolates a `*_qn`/`*qualified_name` value **and** contains a `/`. That misfires on **object-store keys** that merely embed a connection qn after a literal namespace prefix:

```python
f"persistent-artifacts/apps/atlan-publish-app/state/{connection_qn}/publish-state"
f"argo-artifacts/{connection_qn}/current-state"
```

These are storage paths, not asset identities — pyatlan `.creator()` has nothing to say about them, so there's no valid remediation and the warning is pure noise. Surfaced by a real connector emitting 6 such false positives.

## Fix

An asset `qualifiedName` is always **rooted** at its parent qn — the interpolated qn is the *leading* segment (`f"{connection_qn}/collections/{id}"`). An object-store key **embeds** the qn *after* a literal path prefix. So we skip the finding when the qn reference is preceded by a `/`-bearing literal segment.

This removes the false positive without weakening detection of genuinely hand-rooted qualifiedNames (including chained `db_qn`→`schema_qn` cases).

## Verification

Against a real connector's source:

| | P028 findings |
|---|---|
| before | 17 |
| after | **11** |

The 6 object-store-key hits clear; all 11 genuinely hand-rooted qualifiedName sites still fire.

- 4 new regression tests (single-line + multi-line/parenthesised keys, argo-artifacts, and a positive "still fires when rooted" test).
- Full `test_prescriptions.py` + `test_catalog.py`: 199 passed, 1 xfailed. Pre-commit clean.
- Rule doc (`docs/rules/prescriptions.md#p028`) updated with the exclusion.