### PR TITLE
fix(contract-toolkit): generated JSON coercion uses orjson and logs its fallback

### DIFF
--- a/contract-toolkit/examples/full/app/generated/_input.py
+++ b/contract-toolkit/examples/full/app/generated/_input.py
@@ -2,14 +2,17 @@
 # To regenerate: pkl eval -m . contract/app.pkl
 from __future__ import annotations
 
-import json
 from typing import Annotated, Any, ClassVar
 
+import orjson
 from pydantic import Field, field_validator
 
 from application_sdk.contracts.types import MaxItems
 from application_sdk.credentials.ref import CredentialRef
+from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.templates.contracts import ExtractionInput
+
+logger = get_logger(__name__)
 
 
 class AppInputContract(ExtractionInput):
@@ -57,8 +60,12 @@ class AppInputContract(ExtractionInput):
             if not stripped:
                 return {}
             try:
-                parsed = json.loads(stripped)
-            except json.JSONDecodeError:
+                parsed = orjson.loads(stripped)
+            except orjson.JSONDecodeError:
+                logger.debug(
+                    "Coercion input was not valid JSON; passing the raw "
+                    "string through for downstream validation."
+                )
                 return value
             if isinstance(parsed, dict):
                 return parsed

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -2674,8 +2674,12 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
     "            if not stripped:\n" +
     "                return {}\n" +
     "            try:\n" +
-    "                parsed = json.loads(stripped)\n" +
-    "            except json.JSONDecodeError:\n" +
+    "                parsed = orjson.loads(stripped)\n" +
+    "            except orjson.JSONDecodeError:\n" +
+    "                logger.debug(\n" +
+    "                    \"Coercion input was not valid JSON; passing the raw \"\n" +
+    "                    \"string through for downstream validation.\"\n" +
+    "                )\n" +
     "                return value\n" +
     "            if isinstance(parsed, dict):\n" +
     "                return parsed\n" +
@@ -2745,8 +2749,12 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
     }
   }).toList()
   local stdlibImportLines: String =
-    (if (!objectStringCoercionFields.isEmpty) "import json\n" else "") +
     (if (!typingImports.isEmpty) "from typing import \(typingImports.join(", "))\n" else "")
+  // orjson is a core SDK dependency (~10x faster than stdlib json) and is the
+  // sanctioned JSON entrypoint (conformance O001). Emitted as a third-party
+  // import only when the JSON-object-string coercion validator is generated.
+  local thirdPartyImportLines: String =
+    (if (!objectStringCoercionFields.isEmpty) "import orjson\n" else "")
   local pydanticImports: List<String> = (new Listing {
     when (uiFieldLines.contains(" = Field(")) {
       "Field"
@@ -2773,17 +2781,30 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
       "from application_sdk.contracts.types import \(sdkTypeImports.join(", "))\n"
     else "") +
     (if (!credFieldLine.isEmpty) "from application_sdk.credentials.ref import CredentialRef\n" else "") +
+    (if (!objectStringCoercionFields.isEmpty)
+      "from application_sdk.observability.logger_adaptor import get_logger\n"
+    else "") +
     "from application_sdk.templates.contracts import ExtractionInput\n"
+  // Module-level logger, emitted only when the coercion validator needs it, so
+  // its benign "not valid JSON" fallback is observable (conformance E007) rather
+  // than silently swallowed. The message never logs the value itself.
+  local loggerModuleLine: String =
+    if (!objectStringCoercionFields.isEmpty) "logger = get_logger(__name__)\n\n\n" else ""
   local inputImportBlock: String =
     "from __future__ import annotations\n\n" +
     (if (!stdlibImportLines.isEmpty) stdlibImportLines + "\n" else "") +
-    (if (!pydanticImportLines.isEmpty) pydanticImportLines + "\n" else "") +
+    (if (!thirdPartyImportLines.isEmpty || !pydanticImportLines.isEmpty)
+      thirdPartyImportLines + pydanticImportLines + "\n"
+    else "") +
     firstPartyImportLines +
-    "\n\n"
+    // One blank line before the module-level logger assignment (if any),
+    // two before the class itself — matches ruff/isort canonical spacing.
+    (if (!loggerModuleLine.isEmpty) "\n" else "\n\n")
   text =
     "# AUTO-GENERATED from contract/app.pkl — DO NOT EDIT MANUALLY.\n" +
     "# To regenerate: pkl eval -m . contract/app.pkl\n" +
     inputImportBlock +
+    loggerModuleLine +
     "class AppInputContract(ExtractionInput):\n" +
     (if (classBody.isEmpty) "    pass\n" else classBody)
 }

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -2909,8 +2909,12 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
     "            if not stripped:\n" +
     "                return {}\n" +
     "            try:\n" +
-    "                parsed = json.loads(stripped)\n" +
-    "            except json.JSONDecodeError:\n" +
+    "                parsed = orjson.loads(stripped)\n" +
+    "            except orjson.JSONDecodeError:\n" +
+    "                logger.debug(\n" +
+    "                    \"Coercion input was not valid JSON; passing the raw \"\n" +
+    "                    \"string through for downstream validation.\"\n" +
+    "                )\n" +
     "                return value\n" +
     "            if isinstance(parsed, dict):\n" +
     "                return parsed\n" +
@@ -2955,8 +2959,12 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
     }
   }).toList()
   local stdlibImportLines: String =
-    (if (!objectStringCoercionFields.isEmpty) "import json\n" else "") +
     (if (!typingImports.isEmpty) "from typing import \(typingImports.join(", "))\n" else "")
+  // orjson is a core SDK dependency (~10x faster than stdlib json) and is the
+  // sanctioned JSON entrypoint (conformance O001). Emitted as a third-party
+  // import only when the JSON-object-string coercion validator is generated.
+  local thirdPartyImportLines: String =
+    (if (!objectStringCoercionFields.isEmpty) "import orjson\n" else "")
   local pydanticImports: List<String> = (new Listing {
     when (uiFieldLines.contains(" = Field(")) {
       "Field"
@@ -2983,17 +2991,30 @@ local function generateInputClassPy(): FileOutput = new FileOutput {
       "from application_sdk.contracts.types import \(sdkTypeImports.join(", "))\n"
     else "") +
     (if (!credFieldLine.isEmpty) "from application_sdk.credentials.ref import CredentialRef\n" else "") +
+    (if (!objectStringCoercionFields.isEmpty)
+      "from application_sdk.observability.logger_adaptor import get_logger\n"
+    else "") +
     "from application_sdk.templates.contracts import ExtractionInput\n"
+  // Module-level logger, emitted only when the coercion validator needs it, so
+  // its benign "not valid JSON" fallback is observable (conformance E007) rather
+  // than silently swallowed. The message never logs the value itself.
+  local loggerModuleLine: String =
+    if (!objectStringCoercionFields.isEmpty) "logger = get_logger(__name__)\n\n\n" else ""
   local inputImportBlock: String =
     "from __future__ import annotations\n\n" +
     (if (!stdlibImportLines.isEmpty) stdlibImportLines + "\n" else "") +
-    (if (!pydanticImportLines.isEmpty) pydanticImportLines + "\n" else "") +
+    (if (!thirdPartyImportLines.isEmpty || !pydanticImportLines.isEmpty)
+      thirdPartyImportLines + pydanticImportLines + "\n"
+    else "") +
     firstPartyImportLines +
-    "\n\n"
+    // One blank line before the module-level logger assignment (if any),
+    // two before the class itself — matches ruff/isort canonical spacing.
+    (if (!loggerModuleLine.isEmpty) "\n" else "\n\n")
   text =
     "# AUTO-GENERATED from app.pkl — DO NOT EDIT MANUALLY.\n" +
     "# To regenerate: make generate\n" +
     inputImportBlock +
+    loggerModuleLine +
     "class AppInputContract(ExtractionInput):\n" +
     publishHashExcludeBlock +
     uiFieldLines +

--- a/contract-toolkit/tests/open_source_examples_test.pkl
+++ b/contract-toolkit/tests/open_source_examples_test.pkl
@@ -175,18 +175,34 @@ facts {
   }
 
   ["Full example emits isort-compatible SDK input imports"] {
+    // orjson (third-party) is the sanctioned JSON entrypoint (O001); the
+    // module-level logger backs the coercion validator's observable fallback
+    // (E007). Both are emitted only because the full example has a
+    // JSON-object-string coercion field.
     fullInputPy.contains(
       "from __future__ import annotations\n\n" +
-      "import json\n" +
       "from typing import Annotated, Any, ClassVar\n\n" +
+      "import orjson\n" +
       "from pydantic import Field, field_validator\n\n" +
       "from application_sdk.contracts.types import MaxItems\n" +
       "from application_sdk.credentials.ref import CredentialRef\n" +
-      "from application_sdk.templates.contracts import ExtractionInput\n\n\n" +
+      "from application_sdk.observability.logger_adaptor import get_logger\n" +
+      "from application_sdk.templates.contracts import ExtractionInput\n\n" +
+      "logger = get_logger(__name__)\n\n\n" +
       "class AppInputContract(ExtractionInput):"
     )
+    !fullInputPy.contains("import json\n")
     !fullInputPy.contains("ConnectionRef")
     !fullInputPy.contains("FileReference")
+  }
+
+  ["JSON-object-string coercion uses orjson and logs its fallback"] {
+    // O001: orjson, not stdlib json. E007: the parse-failure fallback is
+    // logged (observable) rather than a silent return.
+    fullInputPy.contains("parsed = orjson.loads(stripped)")
+    fullInputPy.contains("except orjson.JSONDecodeError:")
+    fullInputPy.contains("logger.debug(")
+    !fullInputPy.contains("= json.loads(")
   }
 
   ["Full example UIRules wire conditional field requirements"] {


### PR DESCRIPTION
## Problem

The `_coerce_json_object_strings` validator emitted into `app/generated/_input.py` for every app with a JSON-object-string coercion field triggers two conformance warnings **in generated code the app can't fix**:

```python
try:
    parsed = json.loads(stripped)        # O001 — stdlib json, not orjson
except json.JSONDecodeError:
    return value                          # E007 — parse failure silently swallowed
```

## Fix (`contract-toolkit/src/App.pkl`)

```python
try:
    parsed = orjson.loads(stripped)
except orjson.JSONDecodeError:
    logger.debug(
        "Coercion input was not valid JSON; passing the raw "
        "string through for downstream validation."
    )
    return value
```

- **O001** — `orjson` is a core SDK dependency (~10× faster). `orjson.JSONDecodeError` subclasses `json.JSONDecodeError`/`ValueError`, so the fallback semantics are preserved.
- **E007** — a `logger.debug` makes the benign "not valid JSON → pass through" case observable instead of silently swallowed. Re-raising was rejected: the pass-through is the intended behaviour (non-JSON strings are validated downstream by pydantic). **The message never logs the value** (secret-safety).
- Imports: `import json` dropped; `import orjson` (third-party) and `from application_sdk.observability.logger_adaptor import get_logger` + module-level `logger` emitted **only** when the coercion validator is generated.

## Scope / blast radius

Confined to the SDK input model's internal JSON coercion. **No generated wire artifact changes** — `atlan.yaml`, `manifest.json`, credential JSON, and all field types/DAG fields are byte-identical. `_input.py` is the SDK runtime input model, not consumed by frontend/Heracles/AE, so downstream compat risk is nil.

## Verification

- `detect --series E,O` on the regenerated `full` example → **no violations** (the old pattern fires `E007`+`O001`).
- `./scripts/regenerate-all.sh` + `./scripts/check-invariants.sh` clean.
- `pkl test tests/*.pkl` → **263/263**. `test-sdk-import.py` → **38/38** files import.
- Updated the full-example import snapshot test; added a test asserting `orjson.loads` + the logged fallback.
- Only `examples/full` regenerated (the sole example with a coercion field).

## Update — extended to `NativeApp.pkl`

The same `_coerce_json_object_strings` validator was emitted byte-for-byte by `contract-toolkit/src/NativeApp.pkl`'s `generateInputClassPy()`, still on stdlib `json` with the silent-swallow `except`. `NativeApp.pkl` is the primary module for native app contracts (per `contract-toolkit/AGENTS.md`), so an app on that path with a JSON-object-string coercion field still generated the O001+E007 pattern. No toolkit example amends `NativeApp.pkl`, which is why regen + CI stayed green and the conformance suite never saw it. The identical fix (orjson + logged fallback + import swap + conditional `get_logger`/module `logger`) is now applied there too, so the class dies in one pass. Re-verified: `pkl test` 263/263, `regenerate-all` zero diff, invariants clean, 38/38 SDK imports.

## Behavioral note (orjson vs stdlib json)

`orjson` rejects the non-RFC literals `NaN`/`Infinity`/`-Infinity` that stdlib `json` accepts by default. A coercion field whose raw value is e.g. `{"v": NaN}` now passes through as a raw string to downstream pydantic validation instead of coercing to a dict with a float `NaN`. This is arguably more correct (strict RFC-8259 JSON) and is caught by the same fallback path — but it is an input-acceptance difference from the previous stdlib behavior, noted here for reviewers who relied on the coercion accepting non-standard literals.
