### PR TITLE
fix(sql): execute pre-rendered queries without SQLAlchemy bind-param parsing (colon-safe)

### DIFF
--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -39,6 +39,18 @@ from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
 
+
+def _escape_bind_colons(query: str) -> str:
+    """Backslash-escape literal colons so SQLAlchemy ``text()`` does not treat them as bind params.
+
+    Callers pass fully-rendered SQL (all values inlined; no bind params to supply). ``text()``
+    reads any ``:name`` as a required bind parameter and raises at compile time on colon-bearing
+    SQL — a regex ``(?:...)``, a ``::text`` cast, a ``'12:30:00'`` literal. SQLAlchemy strips the
+    backslash before the driver, so the DB receives the original literal colon.
+    """
+    return query.replace(":", "\\:")
+
+
 if TYPE_CHECKING:
     import pandas as pd
     from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
@@ -392,7 +404,7 @@ class BaseSQLClient(ClientInterface):
                 from sqlalchemy import text  # noqa: PLC0415 — optional dep: sqlalchemy
 
                 cursor = await loop.run_in_executor(
-                    pool, connection.execute, text(query)
+                    pool, connection.execute, text(_escape_bind_colons(query))
                 )
                 if not cursor or not cursor.cursor:
                     raise UnsupportedSqlCursorError()
@@ -437,7 +449,9 @@ class BaseSQLClient(ClientInterface):
         from sqlalchemy import text  # noqa: PLC0415 — optional dep: sqlalchemy
 
         if import_optional_dependency("sqlalchemy", errors="ignore"):
-            return pd.read_sql_query(text(query), conn, chunksize=chunksize)
+            return pd.read_sql_query(
+                text(_escape_bind_colons(query)), conn, chunksize=chunksize
+            )
         else:
             dbapi_conn = getattr(conn, "connection", None)
             return pd.read_sql_query(query, dbapi_conn, chunksize=chunksize)
@@ -674,10 +688,11 @@ class AsyncBaseSQLClient(BaseSQLClient):
                         yield_per=batch_size
                     )
 
+                escaped_query = _escape_bind_colons(query)
                 result = (
-                    await connection.stream(text(query))
+                    await connection.stream(text(escaped_query))
                     if use_server_side_cursor
-                    else await connection.execute(text(query))
+                    else await connection.execute(text(escaped_query))
                 )
 
                 column_names = list(result.keys())

--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -40,13 +40,16 @@ from application_sdk.observability.logger_adaptor import get_logger
 logger = get_logger(__name__)
 
 
-def _escape_bind_colons(query: str) -> str:
-    """Backslash-escape literal colons so SQLAlchemy ``text()`` does not treat them as bind params.
+def _escape_colons_for_text(query: str) -> str:
+    """Backslash-escape *every* literal colon so SQLAlchemy ``text()`` does not treat them as bind params.
 
     Callers pass fully-rendered SQL (all values inlined; no bind params to supply). ``text()``
     reads any ``:name`` as a required bind parameter and raises at compile time on colon-bearing
     SQL — a regex ``(?:...)``, a ``::text`` cast, a ``'12:30:00'`` literal. SQLAlchemy strips the
     backslash before the driver, so the DB receives the original literal colon.
+
+    Note: this escapes *all* colons. Any future call site that genuinely needs ``:name`` bind
+    parameters must not route through this helper.
     """
     return query.replace(":", "\\:")
 
@@ -404,7 +407,7 @@ class BaseSQLClient(ClientInterface):
                 from sqlalchemy import text  # noqa: PLC0415 — optional dep: sqlalchemy
 
                 cursor = await loop.run_in_executor(
-                    pool, connection.execute, text(_escape_bind_colons(query))
+                    pool, connection.execute, text(_escape_colons_for_text(query))
                 )
                 if not cursor or not cursor.cursor:
                     raise UnsupportedSqlCursorError()
@@ -450,7 +453,7 @@ class BaseSQLClient(ClientInterface):
 
         if import_optional_dependency("sqlalchemy", errors="ignore"):
             return pd.read_sql_query(
-                text(_escape_bind_colons(query)), conn, chunksize=chunksize
+                text(_escape_colons_for_text(query)), conn, chunksize=chunksize
             )
         else:
             dbapi_conn = getattr(conn, "connection", None)
@@ -688,7 +691,7 @@ class AsyncBaseSQLClient(BaseSQLClient):
                         yield_per=batch_size
                     )
 
-                escaped_query = _escape_bind_colons(query)
+                escaped_query = _escape_colons_for_text(query)
                 result = (
                     await connection.stream(text(escaped_query))
                     if use_server_side_cursor

--- a/tests/unit/clients/test_async_sql_client.py
+++ b/tests/unit/clients/test_async_sql_client.py
@@ -285,6 +285,7 @@ async def test_run_query_escapes_colons_client_side(
     async for _ in async_sql_client.run_query("RLIKE '^(?:cdl)'"):
         pass
 
+    mock_text.assert_called_once_with("RLIKE '^(?\\:cdl)'")
     mock_connection.execute.assert_called_once_with("RLIKE '^(?\\:cdl)'")
 
 
@@ -310,4 +311,5 @@ async def test_run_query_escapes_colons_server_side(
     async for _ in async_sql_client.run_query("RLIKE '^(?:cdl)'"):
         pass
 
+    mock_text.assert_called_once_with("RLIKE '^(?\\:cdl)'")
     mock_connection_with_options.stream.assert_called_once_with("RLIKE '^(?\\:cdl)'")

--- a/tests/unit/clients/test_async_sql_client.py
+++ b/tests/unit/clients/test_async_sql_client.py
@@ -259,3 +259,55 @@ async def test_run_query_with_error(
             results.extend(batch)
     assert exc_info.value.message == "Error executing SQL query"
     assert isinstance(exc_info.value.cause, Exception)
+
+
+# ---------- colon-safe query execution (CONNECT-260) ----------
+
+
+@pytest.mark.asyncio
+@patch("sqlalchemy.text", side_effect=lambda q: q)  # type: ignore
+async def test_run_query_escapes_colons_client_side(
+    mock_text: MagicMock,
+    async_sql_client: AsyncBaseSQLClient,
+    mock_async_engine_with_connection,
+):
+    """The client-side execute path escapes literal colons before text()."""
+    mock_engine, mock_connection, _ = mock_async_engine_with_connection
+    async_sql_client.engine = mock_engine
+
+    mock_result = MagicMock()
+    mock_result.keys.side_effect = lambda: ["a"]
+    mock_result.cursor = MagicMock()
+    mock_result.cursor.fetchmany = MagicMock(side_effect=[[("v",)], []])
+    mock_connection.execute = AsyncMock(return_value=mock_result)
+    async_sql_client.use_server_side_cursor = False
+
+    async for _ in async_sql_client.run_query("RLIKE '^(?:cdl)'"):
+        pass
+
+    mock_connection.execute.assert_called_once_with("RLIKE '^(?\\:cdl)'")
+
+
+@pytest.mark.asyncio
+@patch("sqlalchemy.text", side_effect=lambda q: q)  # type: ignore
+async def test_run_query_escapes_colons_server_side(
+    mock_text: MagicMock,
+    async_sql_client: AsyncBaseSQLClient,
+    mock_async_engine_with_connection,
+):
+    """The server-side stream path escapes literal colons before text()."""
+    mock_engine, mock_connection, mock_connection_with_options = (
+        mock_async_engine_with_connection
+    )
+    async_sql_client.engine = mock_engine
+
+    mock_result = MagicMock()
+    mock_result.keys.side_effect = lambda: ["a"]
+    mock_result.fetchmany = AsyncMock(side_effect=[[("v",)], []])
+    mock_connection_with_options.stream = AsyncMock(return_value=mock_result)
+    async_sql_client.use_server_side_cursor = True
+
+    async for _ in async_sql_client.run_query("RLIKE '^(?:cdl)'"):
+        pass
+
+    mock_connection_with_options.stream.assert_called_once_with("RLIKE '^(?\\:cdl)'")

--- a/tests/unit/clients/test_sql_client.py
+++ b/tests/unit/clients/test_sql_client.py
@@ -6,7 +6,11 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 
 from application_sdk.clients.models import DatabaseConfig
-from application_sdk.clients.sql import AsyncBaseSQLClient, BaseSQLClient
+from application_sdk.clients.sql import (
+    AsyncBaseSQLClient,
+    BaseSQLClient,
+    _escape_bind_colons,
+)
 from application_sdk.clients.sql_errors import (
     EngineNotInitializedError,
     InvalidSqlEngineTypeError,
@@ -908,6 +912,124 @@ def test_read_sql_query_uses_session_connection(sql_client: BaseSQLClient):
         out = sql_client._read_sql_query(fake_session, "SELECT 1", chunksize=5)
     assert out == "df"
     mock_exec.assert_called_once_with("conn-from-session", "SELECT 1", chunksize=5)
+
+
+# ---------- colon-safe query execution (CONNECT-260) ----------
+
+
+@pytest.mark.parametrize(
+    "query, expected",
+    [
+        ("RLIKE '^(?:cdl|das).*$'", "RLIKE '^(?\\:cdl|das).*$'"),
+        ("col::text", "col\\:\\:text"),
+        ("'12:30:00'", "'12\\:30\\:00'"),
+        ("SELECT 1", "SELECT 1"),  # no colon: unchanged
+        ("regex '\\:'", "regex '\\\\:'"),  # pre-existing backslash-colon round-trips
+    ],
+)
+def test_escape_bind_colons(query: str, expected: str):
+    assert _escape_bind_colons(query) == expected
+
+
+def test_execute_pandas_query_colon_in_text_returns_rows(sql_client: BaseSQLClient):
+    """A pre-rendered query with literal colons must run and return the correct
+    rows on the SQLAlchemy read path — not merely avoid InvalidRequestError."""
+    from sqlalchemy import create_engine
+
+    engine = create_engine("sqlite://")
+    with engine.connect() as conn:
+        df = sql_client._execute_pandas_query(
+            conn, "SELECT '(?:cdl)' AS a, '12:30:00' AS b", chunksize=None
+        )
+        assert df.to_dict("records") == [{"a": "(?:cdl)", "b": "12:30:00"}]
+
+
+def test_execute_pandas_query_colon_chunked_returns_iterator(
+    sql_client: BaseSQLClient,
+):
+    """chunksize on a colon-bearing query yields the correct iterator of frames."""
+    from sqlalchemy import create_engine
+
+    engine = create_engine("sqlite://")
+    with engine.connect() as conn:
+        frames = list(
+            sql_client._execute_pandas_query(
+                conn,
+                "SELECT '(?:x)' AS a UNION ALL SELECT '(?:y)'",
+                chunksize=1,
+            )
+        )
+    assert [f.to_dict("records") for f in frames] == [
+        [{"a": "(?:x)"}],
+        [{"a": "(?:y)"}],
+    ]
+
+
+def test_execute_pandas_query_no_colon_unchanged(sql_client: BaseSQLClient):
+    """An ordinary query returns identical results (no regression)."""
+    from sqlalchemy import create_engine
+
+    engine = create_engine("sqlite://")
+    with engine.connect() as conn:
+        df = sql_client._execute_pandas_query(conn, "SELECT 1 AS x", chunksize=None)
+    assert df.to_dict("records") == [{"x": 1}]
+
+
+def test_execute_pandas_query_escapes_colons_before_text(sql_client: BaseSQLClient):
+    """The read path hands text() the colon-escaped string, never the raw one."""
+    fake_pandas = MagicMock()
+    fake_pandas.read_sql_query.return_value = "df"
+    fake_compat = MagicMock()
+    fake_compat.import_optional_dependency.return_value = MagicMock()  # truthy
+    fake_pandas.compat = MagicMock()
+    fake_pandas.compat._optional = fake_compat
+
+    fake_sqlalchemy = MagicMock()
+    fake_sqlalchemy.text = MagicMock(side_effect=lambda q: f"text({q})")
+
+    conn = MagicMock()
+    with patch.dict(
+        "sys.modules",
+        {
+            "pandas": fake_pandas,
+            "pandas.compat": fake_pandas.compat,
+            "pandas.compat._optional": fake_compat,
+            "sqlalchemy": fake_sqlalchemy,
+        },
+    ):
+        sql_client._execute_pandas_query(conn, "RLIKE '^(?:cdl)'", chunksize=None)
+    fake_sqlalchemy.text.assert_called_once_with("RLIKE '^(?\\:cdl)'")
+
+
+@pytest.mark.asyncio
+@patch("sqlalchemy.text", side_effect=lambda q: q)  # type: ignore
+@patch(
+    "application_sdk.clients.sql.asyncio.get_running_loop",
+    new_callable=MagicMock,
+)
+async def test_run_query_escapes_colons(
+    mock_loop: MagicMock, mock_text: Any, sql_client: BaseSQLClient
+):
+    """The threadpool execute path escapes literal colons before text()."""
+    sql_client.engine = MagicMock()
+    sql_client.engine.connect.return_value = MagicMock()
+
+    cursor = MagicMock()
+    col = MagicMock()
+    col.name = "a"
+    cursor.cursor.description = [col]
+
+    # run_in_executor is called once for execute (returns the cursor) then once
+    # per fetchmany batch — an empty batch ends the loop.
+    mock_loop.return_value.run_in_executor = AsyncMock(
+        side_effect=[cursor, [("v",)], []]
+    )
+
+    async for _ in sql_client.run_query("RLIKE '^(?:cdl)'"):
+        pass
+
+    # sqlalchemy.text (identity-mocked) receives the colon-escaped string.
+    mock_text.assert_called_once_with("RLIKE '^(?\\:cdl)'")
 
 
 # ---------- _execute_async_read_operation / get_results / get_batched_results ----------

--- a/tests/unit/clients/test_sql_client.py
+++ b/tests/unit/clients/test_sql_client.py
@@ -931,6 +931,35 @@ def test_escape_bind_colons(query: str, expected: str):
     assert _escape_bind_colons(query) == expected
 
 
+@pytest.mark.parametrize(
+    "literal",
+    [
+        "^(?:(?:cdl|das|dap|aif|app).*_prod|cdl_mads_dev)$",  # the CONNECT-260 regex
+        "(?:cdl)",  # colon before '('
+        "(?i)abc",  # inline flag
+        "[[:alpha:]]+",  # POSIX class
+        "12:30:00",  # time literal (colon before a digit)
+        "x::y",  # cast-style double colon
+        "a:9b",  # colon before a digit mid-string
+        "abc:",  # trailing colon
+        "name:cdl",  # colon before an identifier (the would-be bind param)
+    ],
+)
+def test_escaped_colon_round_trips_to_driver(literal: str):
+    """The load-bearing fact: escaping colons and wrapping in text() must deliver
+    the *original literal colon* to the database — not a backslash-corrupted
+    string — for every colon shape (regex, POSIX class, cast, time literal). All
+    four execution sites share this escape+text() path, so proving it once on a
+    real engine proves the semantics for every site."""
+    from sqlalchemy import create_engine, text
+
+    engine = create_engine("sqlite://")
+    with engine.connect() as conn:
+        query = f"SELECT '{literal}' AS v"
+        returned = conn.execute(text(_escape_bind_colons(query))).fetchall()[0][0]
+    assert returned == literal
+
+
 def test_execute_pandas_query_colon_in_text_returns_rows(sql_client: BaseSQLClient):
     """A pre-rendered query with literal colons must run and return the correct
     rows on the SQLAlchemy read path — not merely avoid InvalidRequestError."""

--- a/tests/unit/clients/test_sql_client.py
+++ b/tests/unit/clients/test_sql_client.py
@@ -9,7 +9,7 @@ from application_sdk.clients.models import DatabaseConfig
 from application_sdk.clients.sql import (
     AsyncBaseSQLClient,
     BaseSQLClient,
-    _escape_bind_colons,
+    _escape_colons_for_text,
 )
 from application_sdk.clients.sql_errors import (
     EngineNotInitializedError,
@@ -925,10 +925,11 @@ def test_read_sql_query_uses_session_connection(sql_client: BaseSQLClient):
         ("'12:30:00'", "'12\\:30\\:00'"),
         ("SELECT 1", "SELECT 1"),  # no colon: unchanged
         ("regex '\\:'", "regex '\\\\:'"),  # pre-existing backslash-colon round-trips
+        ("", ""),  # empty string: identity
     ],
 )
-def test_escape_bind_colons(query: str, expected: str):
-    assert _escape_bind_colons(query) == expected
+def test_escape_colons_for_text(query: str, expected: str):
+    assert _escape_colons_for_text(query) == expected
 
 
 @pytest.mark.parametrize(
@@ -949,14 +950,16 @@ def test_escaped_colon_round_trips_to_driver(literal: str):
     """The load-bearing fact: escaping colons and wrapping in text() must deliver
     the *original literal colon* to the database — not a backslash-corrupted
     string — for every colon shape (regex, POSIX class, cast, time literal). All
-    four execution sites share this escape+text() path, so proving it once on a
-    real engine proves the semantics for every site."""
+    four execution sites share this one escape+text() path, so this real-engine
+    check exercises that shared path end to end. It runs on SQLite; the escape is
+    dialect-agnostic (SQLAlchemy strips the backslash before the driver on every
+    dialect), so a passing SQLite round-trip is representative, not exhaustive."""
     from sqlalchemy import create_engine, text
 
     engine = create_engine("sqlite://")
     with engine.connect() as conn:
         query = f"SELECT '{literal}' AS v"
-        returned = conn.execute(text(_escape_bind_colons(query))).fetchall()[0][0]
+        returned = conn.execute(text(_escape_colons_for_text(query))).fetchall()[0][0]
     assert returned == literal
 
 
@@ -1006,28 +1009,21 @@ def test_execute_pandas_query_no_colon_unchanged(sql_client: BaseSQLClient):
 
 def test_execute_pandas_query_escapes_colons_before_text(sql_client: BaseSQLClient):
     """The read path hands text() the colon-escaped string, never the raw one."""
-    fake_pandas = MagicMock()
-    fake_pandas.read_sql_query.return_value = "df"
-    fake_compat = MagicMock()
-    fake_compat.import_optional_dependency.return_value = MagicMock()  # truthy
-    fake_pandas.compat = MagicMock()
-    fake_pandas.compat._optional = fake_compat
-
-    fake_sqlalchemy = MagicMock()
-    fake_sqlalchemy.text = MagicMock(side_effect=lambda q: f"text({q})")
+    import pandas
+    from pandas.compat import _optional
 
     conn = MagicMock()
-    with patch.dict(
-        "sys.modules",
-        {
-            "pandas": fake_pandas,
-            "pandas.compat": fake_pandas.compat,
-            "pandas.compat._optional": fake_compat,
-            "sqlalchemy": fake_sqlalchemy,
-        },
+    # Patch sqlalchemy.text and the two pandas call sites the method uses, rather
+    # than swapping whole modules in sys.modules (which is fragile across pandas
+    # versions). The method imports these locally, so the patched attributes are
+    # what it resolves at call time.
+    with (
+        patch("sqlalchemy.text", side_effect=lambda q: f"text({q})") as mock_text,
+        patch.object(_optional, "import_optional_dependency", return_value=object()),
+        patch.object(pandas, "read_sql_query", return_value="df"),
     ):
         sql_client._execute_pandas_query(conn, "RLIKE '^(?:cdl)'", chunksize=None)
-    fake_sqlalchemy.text.assert_called_once_with("RLIKE '^(?\\:cdl)'")
+    mock_text.assert_called_once_with("RLIKE '^(?\\:cdl)'")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Execute pre-rendered SQL queries without SQLAlchemy interpreting literal colons as bind parameters.

## Why

`sqlalchemy.text(query)` scans the string for `:name` patterns and treats each as a **required bind parameter**, failing at compile time (before the query reaches the database):

```
sqlalchemy.exc.InvalidRequestError: A value is required for bind parameter 'cdl'
```

Every SQL execution site in `BaseSQLClient` passes a **fully-rendered** query string to `text()` — callers inline all values via `prepare_query` (`.format()`); there are no bind params to supply. So any query whose text legitimately contains a colon crashes:

- a regex `RLIKE '^(?:cdl|das).*$'` (non-capturing group → `:cdl`)
- a `col::text` cast
- a `'12:30:00'` time literal
- a JSON path

**Real-world chain:** a connector inlines a user's catalog-filter regex into `RLIKE '<regex>'`. A `(?:...)` group makes `text()` raise → tag extraction returns zero → downstream publish deletes tag definitions.

Reproduces on any SQLAlchemy engine (even SQLite) — the crash is at `text()` compile time, dialect-independent.

## What changed

Backslash-escape literal colons (`:` → `\:`) at all four `text()` execution sites in `application_sdk/clients/sql.py`:

- `_execute_pandas_query` — pandas read path
- `run_query` (sync) — pooled `connection.execute`
- `run_query` (async) — `connection.stream` / `connection.execute`

SQLAlchemy strips the backslash before handing SQL to the driver, so **the database receives the original literal colon** and returns the correct rows. This keeps every existing execution mechanism intact — the SQLAlchemy connectable, dtypes, `chunksize` chunking, and server-side streaming are all unchanged. Only the colon parsing is neutralized.

No caller supplies bind params (query-string-only signatures; zero `bindparams`/`params` usages), so removing the bind parsing regresses nothing. A `params` path was deliberately **not** added.

## Tests

New coverage in `tests/unit/clients/test_sql_client.py` and `test_async_sql_client.py`:

- `_escape_bind_colons` unit cases: regex, `::` cast, time literal, no-colon unchanged, pre-existing `\:` round-trips
- **Real-engine row proof** (SQLite): a colon-bearing query returns the correct rows on the read path (asserts rows, not just absence of exception); chunked path returns the correct iterator of frames; no-colon query unchanged
- Escape is applied on the read, sync-execute, async-execute, and async-stream sites (the escaped string is what reaches `text()`)

Full `test_sql_client.py` + `test_async_sql_client.py`: 64 passed, 3 skipped. Ruff + pyright + pre-commit clean.

## Scope

Fixes all four pre-rendered-query `text()` sites in the file (read, execute, stream) so no execution path is left crashing on a colon. Defense-in-depth for all connectors; not Databricks-specific. The connector-side colon-safety + fail-loud fix ships separately.

Refs CONNECT-260
