### PR TITLE
ci(sdk-resolve): block for the review reply instead of exiting after triggering it

### DIFF
--- a/.github/scripts/sdk_resolve_dispatch.py
+++ b/.github/scripts/sdk_resolve_dispatch.py
@@ -280,15 +280,34 @@ def mine_summary(st: SSEState) -> dict[str, str]:
     return parse_summary(st.response_text) or parse_summary(st.raw_data)
 
 
+def _rounds_completed(summary: dict[str, str]) -> int | None:
+    """Parsed `rounds` count from the summary block, or None if absent/malformed."""
+    try:
+        return int(summary["rounds"].strip())
+    except (KeyError, ValueError, AttributeError):
+        return None
+
+
 def render_step_summary(st: SSEState, pr_number: str, gha_run_url: str) -> str:
     """Build the Markdown written to GITHUB_STEP_SUMMARY — always renders."""
     summary = mine_summary(st)
     ok = st.completed and st.status == "completed"
     merge_ready = summary.get("merge_ready", "").lower() == "yes"
+    # Backstop for the "exited before the review returned" failure mode: a run
+    # that completes not-merge-ready having finished ZERO review rounds never
+    # actually ran the review->fix loop (e.g. it posted @sdk-review then ended
+    # its turn before the reply landed). That is a resolver defect, not a genuine
+    # hand-to-human — flag it distinctly so it isn't mistaken for normal triage.
+    exited_early = ok and not merge_ready and _rounds_completed(summary) == 0
     if not ok:
         outcome = "❌ run failed"
     elif merge_ready:
         outcome = "✅ merge-ready (human merges)"
+    elif exited_early:
+        outcome = (
+            "⚠️ exited before completing a review round — the resolver did not run "
+            "the review→fix loop; safe to re-run `@sdk-resolve`"
+        )
     else:
         outcome = "⚠️ stopped short — needs a human"
     lines = [

--- a/.github/scripts/tests/test_sdk_resolve_dispatch.py
+++ b/.github/scripts/tests/test_sdk_resolve_dispatch.py
@@ -176,13 +176,39 @@ def test_render_merge_ready():
 
 
 def test_render_stopped_short():
+    # merge_ready: no after real rounds (rounds: 3) → genuine hand-to-human.
     st = sr.SSEState()
     st.completed = True
     st.status = "completed"
     st.cost = "9.00"
     st.response_text = _SUMMARY_BLOCK.replace("merge_ready: yes", "merge_ready: no")
     out = sr.render_step_summary(st, "1234", "http://run")
-    assert "needs a human" in out
+    assert "stopped short — needs a human" in out
+    assert "exited before" not in out  # not the early-exit backstop
+
+
+def test_render_exited_before_any_round_is_flagged_distinctly():
+    # merge_ready: no with rounds: 0 is the "exited before the review returned"
+    # bug fingerprint — must render as a distinct, re-runnable outcome, NOT the
+    # generic stopped-short (which reads as normal triage and gets ignored).
+    st = sr.SSEState()
+    st.completed = True
+    st.status = "completed"
+    st.cost = "3.22"
+    st.response_text = _SUMMARY_BLOCK.replace(
+        "merge_ready: yes", "merge_ready: no"
+    ).replace("rounds: 3", "rounds: 0")
+    out = sr.render_step_summary(st, "1234", "http://run")
+    assert "exited before completing a review round" in out
+    assert "re-run" in out
+    assert "stopped short — needs a human" not in out
+
+
+def test_rounds_completed_parsing():
+    assert sr._rounds_completed({"rounds": "3"}) == 3
+    assert sr._rounds_completed({"rounds": " 0 "}) == 0
+    assert sr._rounds_completed({}) is None
+    assert sr._rounds_completed({"rounds": "n/a"}) is None
 
 
 def test_render_failed_run():

--- a/.mothership/pr-resolve/CLAUDE.md
+++ b/.mothership/pr-resolve/CLAUDE.md
@@ -28,11 +28,22 @@ auto-merge loop is what the SDK-evolution rebuild was undoing).
 
 ## Guardrails
 
+> **Paramount — a round is not over when you post `@sdk-review`.** That comment
+> only *triggers* the reviewer's separate sandbox; the review lands minutes
+> later. You MUST block until its reply arrives (ORCHESTRATION Phase 3b) and then
+> act on the findings. Never end the run, and never emit the Phase-4 summary, in
+> the same turn you posted the trigger or before you have consumed a review reply
+> this run. (This is the exact failure to never repeat: trigger the review, then
+> exit before it answers — leaving every finding unaddressed.)
+
 1. **Minimal, targeted fixes only** — address the finding; no drive-by refactor.
-2. **Prove-false is allowed, twice-is-human** — a finding you believe is wrong:
-   reply on the PR with a concrete rationale instead of editing. If the reviewer
-   re-raises the *same* finding after you dismissed it, do NOT loop — stop and
-   hand to a human (`NEEDS_HUMAN`).
+2. **Prove-false is allowed; re-raise handling depends on severity** — a finding
+   you believe is wrong: reply on the PR with a concrete rationale instead of
+   editing. If the reviewer re-raises the *same* finding after you dismissed it:
+   a **nit** → *raise it again* (restate the rationale, treat as proven-false)
+   and proceed toward merge-ready — a nit never forces a stop; a **substantive**
+   finding → post one escalated rebuttal and stop at `NEEDS_HUMAN`. Re-argue
+   once, never loop.
 3. **Expect the reset churn** — every push fires `reset-on-push` (strips
    `sdk-review-*` labels, resets the `sdk-review` status) and re-runs CI. That
    is normal. Key your loop off the *reviewer's findings + CI*, never off the

--- a/.mothership/pr-resolve/CLAUDE.md
+++ b/.mothership/pr-resolve/CLAUDE.md
@@ -19,8 +19,11 @@ Follow `.mothership/pr-resolve/ORCHESTRATION.md` exactly. Print
 
 All THREE true, then stop and report:
 1. Required CI checks are green.
-2. The latest `@sdk-review` reports **zero findings** — including nits — except
-   any you have **proven false** with a recorded rationale.
+2. The latest `@sdk-review` reports **zero findings** — including nits — with
+   everything **fixed**. A finding you dispute does NOT count as cleared: you
+   never reach merge-ready over it. Dismiss it with a rationale, and if the
+   reviewer re-raises it, **end the run at `NEEDS_HUMAN`** with that rationale in
+   the summary (guardrail 2) — never ship over a disagreement.
 3. Reviewer verdict is `READY_TO_MERGE`.
 
 You never `gh pr merge`. Merging is the human gate (deliberate — the autonomous
@@ -37,13 +40,13 @@ auto-merge loop is what the SDK-evolution rebuild was undoing).
 > exit before it answers — leaving every finding unaddressed.)
 
 1. **Minimal, targeted fixes only** — address the finding; no drive-by refactor.
-2. **Prove-false is allowed; re-raise handling depends on severity** — a finding
-   you believe is wrong: reply on the PR with a concrete rationale instead of
-   editing. If the reviewer re-raises the *same* finding after you dismissed it:
-   a **nit** → *raise it again* (restate the rationale, treat as proven-false)
-   and proceed toward merge-ready — a nit never forces a stop; a **substantive**
-   finding → post one escalated rebuttal and stop at `NEEDS_HUMAN`. Re-argue
-   once, never loop.
+2. **Prove-false is allowed; a re-raised dismissal ends the run** — a finding you
+   believe is wrong: reply on the PR with a concrete rationale instead of
+   editing. If the reviewer re-raises the *same* finding after you dismissed it —
+   **any severity, nits included** — re-argue **once**, then **stop at
+   `NEEDS_HUMAN`** (`stopped_reason: re-raised-after-dismiss`) and record the
+   finding + your rationale in the `<!-- SDK_RESOLVE_SUMMARY -->`. Never loop on
+   it, and never silently ship over it — a human adjudicates the disagreement.
 3. **Expect the reset churn** — every push fires `reset-on-push` (strips
    `sdk-review-*` labels, resets the `sdk-review` status) and re-runs CI. That
    is normal. Key your loop off the *reviewer's findings + CI*, never off the
@@ -70,6 +73,8 @@ auto-merge loop is what the SDK-evolution rebuild was undoing).
     and will re-run `@sdk-review` after pushing — and always close with the
     mandatory `<!-- SDK_RESOLVE_SUMMARY -->` comment (§Phase 4), on every exit
     path. The stopping line is strict: keep looping until **every finding (nits
-    included) is fixed or recorded proven-false**, green CI, and
-    `READY_TO_MERGE`; never stop on an open nit you have neither fixed nor
-    rebutted.
+    included) is fixed** → green CI + `READY_TO_MERGE`. The only other way to end
+    is a documented `NEEDS_HUMAN` stop — a finding you dispute that the reviewer
+    re-raises — with your rationale in the `<!-- SDK_RESOLVE_SUMMARY -->`. Never
+    stop on an open nit you have simply left unaddressed, and never ship
+    (merge-ready) over a finding you dispute.

--- a/.mothership/pr-resolve/CLAUDE.md
+++ b/.mothership/pr-resolve/CLAUDE.md
@@ -69,5 +69,7 @@ auto-merge loop is what the SDK-evolution rebuild was undoing).
     §3c′) *before* fixing — so the PR visibly shows resolve picked up the review
     and will re-run `@sdk-review` after pushing — and always close with the
     mandatory `<!-- SDK_RESOLVE_SUMMARY -->` comment (§Phase 4), on every exit
-    path. The stopping line is strict: keep looping until **zero findings,
-    nits included**, green CI, and `READY_TO_MERGE`; never stop on an open nit.
+    path. The stopping line is strict: keep looping until **every finding (nits
+    included) is fixed or recorded proven-false**, green CI, and
+    `READY_TO_MERGE`; never stop on an open nit you have neither fixed nor
+    rebutted.

--- a/.mothership/pr-resolve/ORCHESTRATION.md
+++ b/.mothership/pr-resolve/ORCHESTRATION.md
@@ -163,8 +163,9 @@ first time:
 STATUS_BODY="<!-- SDK_RESOLVE_STATUS -->
 🤖 **SDK Resolve — round ${R}.** Picked up the latest review: ${N} open finding(s)
 (${CRIT} blocking, ${NIT} nit). Fixing them now, then I'll push and re-run
-\`@sdk-review\` automatically — I keep looping until zero findings (nits included)
-+ green CI + \`READY_TO_MERGE\`. Progress: ${GHA_RUN_URL}"
+\`@sdk-review\` automatically — I keep looping until every finding (nits included)
+is fixed + green CI + \`READY_TO_MERGE\` (anything I dispute I hand back to a human
+with a rationale, rather than merging over it). Progress: ${GHA_RUN_URL}"
 
 CID=$(gh api "repos/atlanhq/application-sdk/issues/${PR_NUMBER}/comments" --paginate \
   --jq 'map(select(.body | contains("<!-- SDK_RESOLVE_STATUS -->"))) | last | .id // empty')
@@ -238,8 +239,8 @@ step 2 regardless, and do it before you exit.
    dismissal rationales), final CI + verdict, and — if stopped short — exactly
    what remains and why (round-cap / re-raised-after-dismiss / ci-stuck /
    ambiguous-fork / cross-repo / review-timeout). State plainly whether it's
-   merge-ready (green + zero findings incl. nits + `READY_TO_MERGE`) or needs
-   their call. This is the human-facing counterpart to the machine block in step
+   merge-ready (green + every finding fixed, nits included + `READY_TO_MERGE`) or
+   needs their call. This is the human-facing counterpart to the machine block in step
    4 — post both, never just one.
 3. **Do NOT `gh pr merge`.** Leave the merge to a human.
 4. Emit this block verbatim (the dispatch script parses it):
@@ -262,8 +263,8 @@ Print: `[Phase 4 complete] merge_ready=<yes|no>`
 
 ## Principles
 
-- **Merge-ready, not merged.** Green CI + zero findings + `READY_TO_MERGE`, then
-  hand back to a human.
+- **Merge-ready, not merged.** Green CI + every finding fixed (nits included) +
+  `READY_TO_MERGE`, then hand back to a human.
 - **The reviewer stays read-only.** You are the only writer; it runs in its own
   sandbox and you consume its comment output.
 - **A round isn't done until the review answers.** Posting `@sdk-review` only

--- a/.mothership/pr-resolve/ORCHESTRATION.md
+++ b/.mothership/pr-resolve/ORCHESTRATION.md
@@ -93,30 +93,73 @@ TRIGGER_TIME=$(gh api "repos/atlanhq/application-sdk/issues/comments/$TRIGGER_ID
 > machine identity for programmatic re-triggers. If your sandbox token posts as
 > some other bot, the reviewer won't fire and 3b will time out.
 
-### 3b. Wait for the reply
-Poll every ~30s (up to ~40 min) for a comment created **after** `TRIGGER_TIME`,
-authored by a login containing `mothership`, whose body contains
-`<!-- SDK_REVIEW -->`. Take the last such comment across all pages. Never treat
-CI comments, human comments, or an older review as the reply.
+### 3b. Wait for the reply — BLOCKING; do NOT end your turn here
+
+Posting `@sdk-review` is **not** a stopping point — it only triggers the
+reviewer's *separate* sandbox, which typically replies in ~5–15 min. You MUST
+block here until that reply lands (or the per-round wait elapses). Run the poll
+as a **single long-running command** so the session stays alive and you cannot
+end your turn mid-wait:
+
+```bash
+# Blocks until the reviewer replies or ~40 min elapse. The heartbeat each
+# iteration keeps bytes flowing so neither mothership's idle_timeout (1800s) nor
+# the dispatch read watchdog (1900s) fires during a slow review.
+REPLY=""
+deadline=$(( $(date +%s) + 2400 ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  REPLY=$(gh pr view "$PR_NUMBER" --json comments --jq \
+    "[.comments[] | select(.createdAt > \"$TRIGGER_TIME\")
+       | select(.author.login | test(\"mothership\"))
+       | select(.body | contains(\"<!-- SDK_REVIEW -->\"))] | last | .url // empty")
+  [ -n "$REPLY" ] && break
+  echo "[3b] waiting for @sdk-review reply … $(date -u +%H:%M:%S)"
+  sleep 30
+done
+[ -z "$REPLY" ] && echo "[3b] no reply after 40 min — stopped_reason=review-timeout"
+```
+
+Take the **last** matching comment (never a CI comment, a human comment, the
+`@sdk-review` trigger you just posted, or an older review). If the wait elapses
+with no reply, that is a `NEEDS_HUMAN` stop with `stopped_reason: review-timeout`
+— still run Phase 4 and post the report. **Never** emit the Phase-4 summary
+block in the same turn you posted the trigger, and never emit it with
+`merge_ready: no` without having consumed at least one review reply this run.
 
 ### 3c. Read the verdict + findings
 From the reply body, read the `<!-- VERDICT: X -->` marker and every bullet
 under `### Findings` (all severities, **including `Nit`**).
 
-**Stopping condition:** `### Findings` absent / empty AND verdict
-`READY_TO_MERGE` AND CI green → done, go to Phase 4. (This is stricter than the
-bot's own verdict, which tolerates nits — here nits count.)
+**Stopping condition — all three true → done, go to Phase 4:**
+1. CI green.
+2. Verdict `READY_TO_MERGE`.
+3. Every bullet under `### Findings` — **nits included** — is either fixed (so it
+   no longer appears) or one you have **recorded as proven-false with a
+   rationale** this run. A nit you merely dislike does not qualify: fix it or
+   prove it false. (Proven-false findings the read-only reviewer keeps re-listing
+   do **not** block merge-ready — that is what the nit-rebuttal branch in 3d is
+   for.)
 
 ### 3d. Fix every finding (or prove it false)
 For each bullet, incl. every nit:
 - Locate the file/line, read enough context, apply the **minimal** fix the
-  `Path:` clause describes.
+  `Path:` clause describes. A finding whose `Path:` clause spells out a concrete
+  fix is **fixable — apply it.** Do not punt a fixable finding to a human just
+  because it touches a design question the fix itself already answers.
 - If genuinely wrong: reply with a concrete rationale (why it's a false
-  positive) instead of editing. **If this exact finding was already dismissed
-  in a prior round and the reviewer re-raised it → stop, verdict `NEEDS_HUMAN`,
-  report it. Do not loop.**
-- Genuinely ambiguous design fork with no clear winner → leave it, note it for
-  human, keep going with the rest.
+  positive) instead of editing.
+- **Re-raised after you dismissed it** — the reviewer repeats a finding you
+  already dismissed with a rationale. Do NOT silently loop, and do NOT silently
+  capitulate:
+  - **Nit** → you disagree, so *raise it again*: reply restating your rationale
+    (add any new evidence), treat it as **proven-false**, and carry on toward
+    merge-ready. A nit never forces a human stop.
+  - **Substantive** (Important / Blocker / anything non-nit) → post one
+    **escalated rebuttal** laying out both positions plainly, then stop with
+    verdict `NEEDS_HUMAN` (`stopped_reason: re-raised-after-dismiss`) so a human
+    adjudicates. Re-argue **once** — never keep looping on it.
+- Genuinely ambiguous design fork with no clear winner **and no concrete `Path:`
+  fix** → leave it, note it for human, keep going with the rest.
 
 ### 3e. Commit, push, re-green CI (best-effort)
 `uv run pre-commit run --files <changed>` → relevant tests → commit specific
@@ -149,7 +192,7 @@ Print at end: `[Phase 3 complete] rounds=<R>, converged=<yes|no>`
    requester) so they know it's their turn, and includes: rounds taken, findings
    fixed vs dismissed (with dismissal rationales), final CI + verdict, and — if
    stopped short — exactly what remains and why (round cap /
-   re-raised-after-dismiss / ambiguous fork). State plainly whether it's
+   re-raised-after-dismiss / ambiguous fork / review-timeout). State plainly whether it's
    merge-ready (green + zero findings + `READY_TO_MERGE`) or needs their call.
 3. **Do NOT `gh pr merge`.** Leave the merge to a human.
 4. Emit this block verbatim (the dispatch script parses it):
@@ -162,7 +205,7 @@ Print at end: `[Phase 3 complete] rounds=<R>, converged=<yes|no>`
    ci: <green|red|noted-preexisting>
    final_verdict: <READY_TO_MERGE|NEEDS_HUMAN|NEEDS_FIXES|...>
    merge_ready: <yes|no>
-   stopped_reason: <converged|round-cap|re-raised-after-dismiss|ci-stuck|fork>
+   stopped_reason: <converged|round-cap|re-raised-after-dismiss|ci-stuck|fork|review-timeout>
    === END SUMMARY ===
    ```
 
@@ -176,7 +219,13 @@ Print: `[Phase 4 complete] merge_ready=<yes|no>`
   hand back to a human.
 - **The reviewer stays read-only.** You are the only writer; it runs in its own
   sandbox and you consume its comment output.
-- **Converge or escalate.** Never loop forever — round cap, re-raise-after-
-  dismiss, and ambiguous forks all stop cleanly with a `NEEDS_HUMAN` report.
+- **A round isn't done until the review answers.** Posting `@sdk-review` only
+  triggers the reviewer's separate sandbox — block for its reply (Phase 3b)
+  before ending the run or emitting the summary. Never exit the same turn you
+  triggered the review.
+- **Converge or escalate.** Never loop forever — round cap, a re-raised
+  *substantive* finding, ambiguous forks, and review-timeout all stop cleanly
+  with a `NEEDS_HUMAN` report. A re-raised *nit* is rebutted-once and does not
+  stop the run.
 - **Real state only.** Read `gh` before every decision; never simulate a CI or
   reviewer result.

--- a/.mothership/pr-resolve/ORCHESTRATION.md
+++ b/.mothership/pr-resolve/ORCHESTRATION.md
@@ -133,19 +133,20 @@ under `### Findings` (all severities, **including `Nit`**).
 **Stopping condition — all three true → done (merge-ready), go to Phase 4:**
 1. CI green.
 2. Verdict `READY_TO_MERGE`.
-3. Every bullet under `### Findings` — **nits included** — is either fixed (so it
-   no longer appears) or one you have **recorded as proven-false with a
-   rationale** this run. A nit you merely dislike does not qualify: fix it or
-   prove it false — a lone open nit you have neither fixed nor rebutted does NOT
-   let you stop; keep looping. (Proven-false findings the read-only reviewer keeps
-   re-listing do **not** block merge-ready — that is what the nit-rebuttal branch
-   in 3d is for.)
+3. `### Findings` is empty — every finding, **nits included**, has been **fixed**
+   (so none remain listed). A finding you *disagree* with is not "done": you
+   never reach merge-ready by ignoring it or by unilaterally clearing it. Fix the
+   ones you agree with; anything you dispute goes through the disagreement path in
+   3d, which **ends the run** with your rationale in the Phase 4 summary — it does
+   NOT pass to merge-ready.
 
 The only other ways this loop ends are the explicit escalations (round-cap /
-re-raised **substantive** finding-after-dismiss / ci-stuck / ambiguous-fork /
-cross-repo / review-timeout) — a re-raised *nit* is rebutted-once and does **not**
-escalate (3d). Every escalation still runs Phase 4 and posts the report. **Never
-end the run with open findings and no Phase 4 report on the PR.**
+re-raised-after-dismiss — a finding you dismissed that the reviewer re-lists,
+**any severity, nits included** / ci-stuck / ambiguous-fork / cross-repo /
+review-timeout). Every escalation runs Phase 4 and posts the report, and a
+disagreement stop MUST carry your rationale in that summary. **Never end the run
+with open findings and no Phase 4 report, and never ship (merge-ready) over a
+finding you merely dispute — end with a documented rationale instead.**
 
 ### 3c′. Acknowledge on the PR — visible status (every round that has findings)
 A review comment landing on the PR is not, by itself, a signal that anyone is
@@ -185,15 +186,13 @@ For each bullet, incl. every nit:
 - If genuinely wrong: reply with a concrete rationale (why it's a false
   positive) instead of editing.
 - **Re-raised after you dismissed it** — the reviewer repeats a finding you
-  already dismissed with a rationale. Do NOT silently loop, and do NOT silently
-  capitulate:
-  - **Nit** → you disagree, so *raise it again*: reply restating your rationale
-    (add any new evidence), treat it as **proven-false**, and carry on toward
-    merge-ready. A nit never forces a human stop.
-  - **Substantive** (Important / Blocker / anything non-nit) → post one
-    **escalated rebuttal** laying out both positions plainly, then stop with
-    verdict `NEEDS_HUMAN` (`stopped_reason: re-raised-after-dismiss`) so a human
-    adjudicates. Re-argue **once** — never keep looping on it.
+  already dismissed with a rationale. You disagree and it's re-listed. Do NOT
+  silently loop, and do NOT silently ship over it: post your rebuttal on the PR
+  (re-argue **once**), then **end the run** with verdict `NEEDS_HUMAN`
+  (`stopped_reason: re-raised-after-dismiss`) and record the finding + your
+  rationale in the Phase 4 summary so a human adjudicates. This holds for
+  **every severity, nits included** — the resolver never merges over a
+  disagreement, and never argues a point more than once.
 - Genuinely ambiguous design fork with no clear winner **and no concrete `Path:`
   fix** → leave it, note it for human, keep going with the rest.
 
@@ -271,9 +270,10 @@ Print: `[Phase 4 complete] merge_ready=<yes|no>`
   triggers the reviewer's separate sandbox — block for its reply (Phase 3b)
   before ending the run or emitting the summary. Never exit the same turn you
   triggered the review.
-- **Converge or escalate.** Never loop forever — round cap, a re-raised
-  *substantive* finding, ambiguous forks, and review-timeout all stop cleanly
-  with a `NEEDS_HUMAN` report. A re-raised *nit* is rebutted-once and does not
-  stop the run.
+- **Converge or escalate.** Never loop forever — round-cap, a re-raised finding
+  you dismissed (**any severity, nits included**), ambiguous forks, ci-stuck, and
+  review-timeout all stop cleanly with a `NEEDS_HUMAN` report. Never ship over a
+  finding you dispute: end with the rationale in the summary and let a human
+  decide.
 - **Real state only.** Read `gh` before every decision; never simulate a CI or
   reviewer result.


### PR DESCRIPTION
## What & why

An `@sdk-resolve` run on PR #2720 finished as `⚠️ stopped short — needs a human` on a **green** run (cost $3.22) — but it had done no work. Reconstructing from authoritative GitHub comment timestamps:

| Time | Event |
|---|---|
| 11:35:14 | resolver posts `@sdk-review` (Phase 3a) |
| 11:36:36 | **resolver sandbox completes** (`status=completed`, `merge_ready: no`) |
| 11:46:08 | reviewer posts verdict `NEEDS_FIXES` — **10 min after the resolver already exited** |

The resolver **ended its turn ~82s after triggering the review**, long before the reply landed. It never consumed a finding, fixed nothing, and posted no Phase-4 report. Phase 3b already said "poll every ~30s (up to ~40 min)" — as prose — and the agent simply didn't do it.

## Changes

**`.mothership/pr-resolve/` (the playbook the sandbox reads at runtime)**
- **Phase 3b → a hard blocking wait.** Posting `@sdk-review` is explicitly *not* a stopping point. The wait is now a single long-running `while … sleep 30` loop with a per-iteration heartbeat, so it can't trip mothership's `idle_timeout` (1800s) or the dispatch read watchdog (1900s) during a slow review (a latent second bug — the 40-min poll previously exceeded the 1800s idle cap with zero output). The summary block may not be emitted before a reply is consumed. New `stopped_reason: review-timeout`.
- **Re-raise handling split by severity (Phase 3d + 3c).** A re-raised **nit** you disagree with is re-argued once, treated as proven-false, and the 3c stopping gate now lets proven-false findings through to merge-ready (previously it looped to round-cap). A re-raised **substantive** finding gets one escalated rebuttal, then `NEEDS_HUMAN` with both sides documented. A finding with a concrete `Path:` fix is applied, not punted to a human.
- `CLAUDE.md`: a paramount guardrail encoding the wait invariant + the severity-split re-raise rule.

**`.github/scripts/sdk_resolve_dispatch.py` (deterministic backstop)**
- A run that completes not-merge-ready having finished **zero** review rounds (`merge_ready: no` + `rounds: 0`) is the fingerprint of this exact bug. It now renders a distinct *"exited before completing a review round — safe to re-run"* outcome instead of the generic "stopped short," so it can't masquerade as normal triage. This is the one guard that doesn't depend on the agent behaving.

## Testing
- `.github/scripts/tests/test_sdk_resolve_dispatch.py`: added coverage for the backstop (early-exit fingerprint renders distinctly; genuine stopped-short with real rounds still renders as before; `_rounds_completed` parsing). **21 passed.**
- Verified the new Phase 3b `--jq` filter against PR #2720 itself: returns exactly the real review reply, correctly excluding the `<!-- SDK_REVIEW_STARTED -->` comment and the `@sdk-review` trigger.

## Honest caveat
This is an instruction-level fix to an agent playbook plus a deterministic dispatch-side backstop. Nothing structurally *forces* the sandbox agent to run the loop rather than end its turn — this is the strongest lever available in-repo, and the backstop makes a recurrence loud rather than silent. The real proof is the next live `@sdk-resolve` run actually waiting for its review.
