### PR TITLE
ci(e2e): own connector-e2e check runs with the fleet App (callback works) + clarify dispatch vs run names

### DIFF
--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -46,7 +46,8 @@ inputs:
       'poll' (default, legacy): dispatch, then busy-poll the dispatched
       run's status via the REST API every 60s for up to 2h, all against
       the shared org PAT. 'callback': create an in_progress GitHub check
-      run on this repo's own SHA (github-token's own rate-limit bucket),
+      run on this repo's own SHA (owned by the fleet App via
+      checks-app-token, so the connector's callback can complete it),
       dispatch + do a short bounded locate of the resulting run (so the
       check has a real link to click, not just the connector's generic
       Actions tab), then exit — the connector's own workflow completes
@@ -54,10 +55,21 @@ inputs:
       report-to-sdk job), so there is no waiting for the actual test
       result on this side, only for the dispatch to become visible.
       Requires check-run-name + check-sha.
+  checks-app-token:
+    required: false
+    default: ""
+    description: |
+      Required when wait-mode is 'callback'. A GitHub App installation token
+      scoped to THIS repo with checks:write, used to create + update the check
+      run. Must be the same App the connector's callback (tests-reusable.yaml
+      report-to-sdk) uses to complete it — a check run can only be updated by
+      the App that created it. Do NOT pass github.token here: github-actions
+      would own the check, the fleet-App callback could not complete it, and it
+      would be filed under an arbitrary github-actions check suite.
   check-run-name:
     required: false
     default: ""
-    description: Required when wait-mode is 'callback'. Name of the check run to create, e.g. "Connector E2E / atlan-mysql-app".
+    description: Required when wait-mode is 'callback'. Name of the check run to create, e.g. "Connector E2E run / atlan-mysql-app".
   check-sha:
     required: false
     default: ""
@@ -99,9 +111,10 @@ runs:
       env:
         CHECK_RUN_NAME: ${{ inputs.check-run-name }}
         CHECK_SHA: ${{ inputs.check-sha }}
+        CHECKS_APP_TOKEN: ${{ inputs.checks-app-token }}
       run: |
-        if [ -z "$CHECK_RUN_NAME" ] || [ -z "$CHECK_SHA" ]; then
-          echo "::error::wait-mode=callback requires both check-run-name and check-sha"
+        if [ -z "$CHECK_RUN_NAME" ] || [ -z "$CHECK_SHA" ] || [ -z "$CHECKS_APP_TOKEN" ]; then
+          echo "::error::wait-mode=callback requires check-run-name, check-sha, and checks-app-token"
           exit 1
         fi
 
@@ -110,7 +123,10 @@ runs:
       if: inputs.wait-mode == 'callback'
       shell: bash
       env:
-        GH_TOKEN: ${{ github.token }}
+        # Fleet App token (this repo), NOT github.token — the connector's
+        # callback completes this check with the same App, and a check run can
+        # only be updated by its creating App.
+        GH_TOKEN: ${{ inputs.checks-app-token }}
         REPO: ${{ github.repository }}
         SHA: ${{ inputs.check-sha }}
         NAME: ${{ inputs.check-run-name }}
@@ -159,7 +175,8 @@ runs:
       continue-on-error: true
       shell: bash
       env:
-        GH_TOKEN: ${{ github.token }}
+        # Same fleet App token that created the check (see Create step).
+        GH_TOKEN: ${{ inputs.checks-app-token }}
         REPO: ${{ github.repository }}
         CHECK_RUN_ID: ${{ steps.create_check.outputs.check_run_id }}
         RUN_URL: ${{ steps.return_dispatch_callback.outputs.run_url }}

--- a/.github/scripts/complete_check_run.py
+++ b/.github/scripts/complete_check_run.py
@@ -146,7 +146,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--name",
         required=True,
-        help="Check run name, e.g. 'Connector E2E / atlan-mysql-app'.",
+        help="Check run name, e.g. 'Connector E2E run / atlan-mysql-app'.",
     )
     parser.add_argument(
         "--conclusion",

--- a/.github/scripts/create_check_run.py
+++ b/.github/scripts/create_check_run.py
@@ -84,7 +84,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--name",
         required=True,
-        help="Check run name, e.g. 'Connector E2E / atlan-mysql-app'.",
+        help="Check run name, e.g. 'Connector E2E run / atlan-mysql-app'.",
     )
     parser.add_argument("--title", default=None)
     parser.add_argument("--summary", required=True)

--- a/.github/scripts/poll_check_runs_gate.py
+++ b/.github/scripts/poll_check_runs_gate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Roll up the async ``Connector E2E / *`` check runs into a single pass/fail
+"""Roll up the async ``Connector E2E run / *`` check runs into a single pass/fail
 for the required "Test Gate" (Connector Tests Gate).
 
 The dispatch side (create_check_run.py, invoked from e2e-apps) exits right

--- a/.github/scripts/tests/test_complete_check_run.py
+++ b/.github/scripts/tests/test_complete_check_run.py
@@ -13,7 +13,7 @@ import complete_check_run as mod
 
 REPO = "atlanhq/application-sdk"
 SHA = "abc123"
-NAME = "Connector E2E / atlan-mysql-app"
+NAME = "Connector E2E run / atlan-mysql-app"
 
 
 def _completed(stdout: str) -> subprocess.CompletedProcess:
@@ -37,7 +37,7 @@ def test_find_check_run_picks_highest_id_on_duplicates():
     runs = [
         {"id": 1, "name": NAME},
         {"id": 5, "name": NAME},
-        {"id": 3, "name": "Connector E2E / atlan-openapi-app"},
+        {"id": 3, "name": "Connector E2E run / atlan-openapi-app"},
     ]
     found = mod.find_check_run(runs, NAME)
     assert found["id"] == 5

--- a/.github/scripts/tests/test_create_check_run.py
+++ b/.github/scripts/tests/test_create_check_run.py
@@ -13,7 +13,7 @@ import create_check_run as mod
 
 REPO = "atlanhq/application-sdk"
 SHA = "abc123"
-NAME = "Connector E2E / atlan-mysql-app"
+NAME = "Connector E2E run / atlan-mysql-app"
 
 
 def _completed(stdout: str) -> subprocess.CompletedProcess:

--- a/.github/scripts/tests/test_poll_check_runs_gate.py
+++ b/.github/scripts/tests/test_poll_check_runs_gate.py
@@ -15,7 +15,7 @@ import poll_check_runs_gate as mod
 
 REPO = "atlanhq/application-sdk"
 SHA = "abc123"
-NAMES = ["Connector E2E / atlan-openapi-app", "Connector E2E / atlan-mysql-app"]
+NAMES = ["Connector E2E run / atlan-openapi-app", "Connector E2E run / atlan-mysql-app"]
 
 
 @pytest.fixture(autouse=True)

--- a/.github/scripts/tests/test_timeout_stale_check_runs.py
+++ b/.github/scripts/tests/test_timeout_stale_check_runs.py
@@ -14,7 +14,7 @@ import timeout_stale_check_runs as mod
 
 REPO = "atlanhq/application-sdk"
 NOW = datetime(2026, 7, 5, 12, 0, 0, tzinfo=timezone.utc)
-PREFIX = "Connector E2E / "
+PREFIX = "Connector E2E run / "
 
 
 def _completed(stdout: str) -> subprocess.CompletedProcess:

--- a/.github/scripts/timeout_stale_check_runs.py
+++ b/.github/scripts/timeout_stale_check_runs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Watchdog for the cross-repo e2e callback pattern: time out any
-``Connector E2E / *`` check run that's been stuck ``in_progress`` past the
+``Connector E2E run / *`` check run that's been stuck ``in_progress`` past the
 window a connector run could legitimately still be running.
 
 This only matters when a connector runner dies before its ``report-to-sdk``
@@ -157,7 +157,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--repo", required=True, help="owner/repo, e.g. atlanhq/application-sdk"
     )
-    parser.add_argument("--name-prefix", default="Connector E2E / ")
+    parser.add_argument("--name-prefix", default="Connector E2E run / ")
     parser.add_argument(
         "--max-age-minutes",
         type=int,

--- a/.github/workflows/e2e-callback-watchdog.yml
+++ b/.github/workflows/e2e-callback-watchdog.yml
@@ -3,7 +3,7 @@ name: E2E Callback Watchdog
 # Safety net for the cross-repo e2e callback pattern (see e2e-apps'
 # wait-mode: callback and tests-reusable.yaml's report-to-sdk job).
 #
-# Each connector reports back by PATCHing its own 'Connector E2E / <repo>'
+# Each connector reports back by PATCHing its own 'Connector E2E run / <repo>'
 # check run to completed the instant its run finishes — there's no polling
 # on the happy path. But if a connector runner dies before that callback
 # step runs (crash, force-cancel, runner reclaim), the check run is left

--- a/.github/workflows/e2e-callback-watchdog.yml
+++ b/.github/workflows/e2e-callback-watchdog.yml
@@ -13,18 +13,25 @@ name: E2E Callback Watchdog
 # pending check is confusing, so this sweeps them out periodically.
 #
 # 15-minute cadence, one call per open PR plus one per stale check found —
-# negligible against github.token's own rate-limit bucket regardless of how
+# negligible against the fleet App token's rate-limit bucket regardless of how
 # many connectors or PRs are open.
+#
+# The sweep runs as the atlan-app-fleet App (scoped to this repo), NOT
+# github.token: the 'Connector E2E run / <repo>' checks are created + completed
+# by that App, and a check run can only be updated by its creating App — so the
+# watchdog's PATCH (timeout_stale_check_runs.py) must use the same App or it is
+# rejected and the stuck checks can never be swept. Same ownership rule the
+# create/callback path relies on (see e2e-apps + tests-reusable report-to-sdk).
 
 on:
   schedule:
     - cron: "*/15 * * * *"
   workflow_dispatch:
 
+# github.token only needs contents:read for the checkout; the sweep's list +
+# PATCH calls all run under the fleet App token minted below.
 permissions:
   contents: read
-  pull-requests: read
-  checks: write
 
 concurrency:
   group: e2e-callback-watchdog
@@ -45,9 +52,21 @@ jobs:
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
 
+      # Same App that owns the check runs (see pull_request.yaml's "Mint fleet
+      # App token (SDK checks)" step) so the sweep's PATCH is accepted. Scoped
+      # to this repo; needs pull-requests:read + checks:write on the App.
+      - name: Mint fleet App token (SDK checks)
+        id: checks-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+
       - name: Sweep for stale check runs
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.checks-app-token.outputs.token }}
         run: |
           python3 .github/scripts/timeout_stale_check_runs.py \
             --repo "${{ github.repository }}"

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -306,13 +306,14 @@ jobs:
     # — so it MUST be the creator too, or the callback's PATCH is rejected and
     # the check hangs until the watchdog. Creating it under the fleet App also
     # attributes it to the fleet App's check suite instead of an arbitrary
-    # github-actions suite. github.token keeps checks:write only for the
-    # dispatch-status housekeeping; a job-level permissions block replaces
-    # rather than merges with the workflow defaults, so contents:read is
-    # repeated here for the checkout step.
+    # github-actions suite. In callback mode every check write goes through the
+    # fleet token, so github.token needs only contents:read (the checkout) — the
+    # sole github.token check/PR-writing step (Post dispatched-run status) is
+    # wait-mode != 'callback' and never runs here. A job-level permissions block
+    # replaces rather than merges with the workflow defaults, so contents:read
+    # is spelled out explicitly.
     permissions:
       contents: read
-      checks: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrix-builder.outputs.matrix) }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -276,7 +276,7 @@ jobs:
   #     On this path base_image_ref is the freshly-built PR base image, so
   #     the connector is rebuilt on top of the SDK PR's runtime image.
   connector-tests:
-    name: Connector Tests (${{ matrix.repo_name }})
+    name: Connector E2E dispatch (${{ matrix.repo_name }})
     needs: [changes, matrix-builder, build-sdk-base-image]
     # always() so a *skipped* build-sdk-base-image (merge_group path) does
     # not auto-skip this job. The explicit result clause still BLOCKS this
@@ -299,11 +299,17 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
-    # Least-privilege override: this is the only job that creates check runs
-    # (e2e-apps wait-mode: callback, via github.token — see docs/standards/ci.md),
-    # so checks:write is scoped here instead of at workflow level. A job-level
-    # permissions block replaces rather than merges with the workflow
-    # defaults, so contents:read is repeated here for the checkout step.
+    # The check run is created + updated with the atlan-app-fleet App token
+    # (scoped to application-sdk below), NOT github.token. A check run can only
+    # be updated by the App that created it, and the connector's own callback
+    # (tests-reusable.yaml report-to-sdk) completes it with that same fleet App
+    # — so it MUST be the creator too, or the callback's PATCH is rejected and
+    # the check hangs until the watchdog. Creating it under the fleet App also
+    # attributes it to the fleet App's check suite instead of an arbitrary
+    # github-actions suite. github.token keeps checks:write only for the
+    # dispatch-status housekeeping; a job-level permissions block replaces
+    # rather than merges with the workflow defaults, so contents:read is
+    # repeated here for the checkout step.
     permissions:
       contents: read
       checks: write
@@ -312,7 +318,9 @@ jobs:
       matrix: ${{ fromJson(needs.matrix-builder.outputs.matrix) }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Mint fleet App token
+      # Dispatch token: fleet App scoped to the CONNECTOR repo (return-dispatch
+      # triggers that repo's workflow).
+      - name: Mint fleet App token (connector dispatch)
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
@@ -320,15 +328,29 @@ jobs:
           private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
           owner: atlanhq
           repositories: ${{ matrix.repo_name }}
+      # Checks token: same fleet App, scoped to THIS repo (application-sdk), so
+      # the check run it creates is owned by the fleet App and the connector's
+      # callback (same App) can complete it. Kept separate from the dispatch
+      # token for least privilege — dispatch can't write SDK checks and vice
+      # versa.
+      - name: Mint fleet App token (SDK checks)
+        id: checks-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
       - uses: "./.github/actions/e2e-apps"
         with:
           github-token: ${{ steps.app-token.outputs.token }}
+          checks-app-token: ${{ steps.checks-app-token.outputs.token }}
           repo-name: ${{ matrix.repo_name }}
           target-branch: "refs/heads/${{ matrix.target_branch }}"
           workflow: tests.yaml
           workflow-inputs: ${{ github.event_name == 'merge_group' && format('{{"application_sdk_ref":"{0}"}}', github.sha) || format('{{"application_sdk_ref":"{0}","run_e2e":"true","base_image_ref":"{1}"}}', github.event.pull_request.head.sha, needs.build-sdk-base-image.outputs.image) }}
           wait-mode: callback
-          check-run-name: "Connector E2E / ${{ matrix.repo_name }}"
+          check-run-name: "Connector E2E run / ${{ matrix.repo_name }}"
           check-sha: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
 
   # SDR-on-Kubernetes e2e — dispatched cross-repo to atlan-local-marketplace-app,
@@ -394,7 +416,7 @@ jobs:
   # ── The single required check for the connector e2e area ────────────────────
   # Always runs and always concludes, so branch protection / the merge queue can
   # require exactly this one stable context instead of the matrix legs
-  # (whose names are label-driven: "Connector Tests (<repo>)"). Without this,
+  # (whose names are label-driven: "Connector E2E dispatch (<repo>)"). Without this,
   # the matrix legs are not required, so the merge queue (ALLGREEN) merges as
   # soon as the OTHER required contexts (SDK Gate, Trivy, …) conclude — even
   # while the connector legs are still running. This gate closes that window.
@@ -419,7 +441,7 @@ jobs:
 
       # connector-tests now only dispatches (e2e-apps wait-mode: callback) —
       # its own success means "dispatch succeeded", not "tests passed". The
-      # actual pass/fail lands later via the Connector E2E / <repo> check
+      # actual pass/fail lands later via the Connector E2E run / <repo> check
       # runs that each connector completes directly (tests-reusable.yaml's
       # report-to-sdk job); this step still validates the upstream chain
       # that had to succeed for those checks to exist at all.
@@ -437,7 +459,7 @@ jobs:
             --base-image-result "$BASE_IMAGE_RESULT" \
             --connector-result "$CONNECTOR_RESULT"
 
-      # Rolls up every 'Connector E2E / <repo>' check run in ONE endpoint
+      # Rolls up every 'Connector E2E run / <repo>' check run in ONE endpoint
       # call per poll (not one busy-poll per matrix leg), using conditional
       # requests so an unchanged poll doesn't count against the rate limit.
       # Each check flips the instant its connector's own run reports back
@@ -452,7 +474,7 @@ jobs:
           SHA: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          NAMES_JSON=$(jq -c '[.include[] | "Connector E2E / " + .repo_name]' <<< "$MATRIX_JSON")
+          NAMES_JSON=$(jq -c '[.include[] | "Connector E2E run / " + .repo_name]' <<< "$MATRIX_JSON")
           python3 .github/scripts/poll_check_runs_gate.py \
             --repo "${{ github.repository }}" \
             --sha "$SHA" \

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -389,7 +389,7 @@ jobs:
           python3 application-sdk-scripts/.github/scripts/complete_check_run.py \
             --repo atlanhq/application-sdk \
             --sha "$SHA" \
-            --name "Connector E2E / ${REPO_SHORT}" \
+            --name "Connector E2E run / ${REPO_SHORT}" \
             --conclusion "${{ steps.report.outputs.conclusion }}" \
             --summary-file "${{ steps.report.outputs.summary_file }}" \
             --details-url "$RUN_URL"

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -113,9 +113,12 @@ Threaded secrets the reusable workflow expects on the caller side:
 
 A single always-on job (`connector-tests`) on apps-sdk PRs fans out to the connector matrix:
 
-| Job on apps-sdk PR | Connector workflow dispatched | Gating |
+| Check on apps-sdk PR | What it is | Gating |
 |---|---|---|
-| `Connector Tests (<repo>)` (matrix over all registered connectors) | `tests.yaml` | _none — auto on every code-changing PR_ |
+| `Connector E2E dispatch (<repo>)` (matrix over all registered connectors) | SDK-side job that fires `tests.yaml` in each connector and exits — success means "dispatch succeeded", not "tests passed" | _none — auto on every code-changing PR_ |
+| `Connector E2E run / <repo>` | Check run tracking the actual connector run. Created (pending) by the dispatch job under the **atlan-app-fleet App** token; the connector's own run **completes it via callback** (`tests-reusable.yaml` `report-to-sdk`, same App — a check run can only be updated by its creating App). No busy-wait poll. | rolled up by `Connector Tests Gate` |
+
+> The two are deliberately split: the dispatch job can't stay pending for the whole (8+ min) connector run without polling, so a separate `run` check holds the "is it done?" state and is closed by a push callback. Both are owned by the fleet App so the cross-repo callback can complete them and they're attributed to the fleet App's check suite (not an arbitrary `github-actions` one). The `E2E Callback Watchdog` sweeps any `run` check left pending if a connector runner dies before its callback fires.
 
 The `tests.yaml` job in each connector runs unit + integration tests unconditionally. The full-DAG `e2e` job inside `tests.yaml` runs only when the SDK PR carries the `e2e` label — controlled via the `run_e2e` workflow input (`"true"` / `"false"`) passed by the dispatcher.
 


### PR DESCRIPTION
## Why

The cross-repo e2e **callback** (dispatch → connector runs → connector pushes result back, no busy-wait) was **half-broken**, and the same root cause produced the confusing "Allowlist Expiry Check / Connector E2E / …" attribution.

**The bug:** the `Connector E2E / <repo>` check run was **created with `github.token`** (owned by the `github-actions` App), but the connector's callback (`tests-reusable.yaml` `report-to-sdk`) **completes it with the `atlan-app-fleet` App**. GitHub only lets the *creating* App update a check run — so the callback's PATCH is rejected. Consequences:

1. The check hangs `in_progress` until the 15-min `E2E Callback Watchdog`, and `Connector Tests Gate` falls back to its bounded poll → **the "no busy-wait" callback silently never fired.**
2. Because it's an API check created by `github-actions`, GitHub files it into an arbitrary `github-actions` check suite on the commit — which is why the merge box prefixed it with the unrelated **"Allowlist Expiry Check"** workflow.

(Confirmed on the live #2657 run: the `Connector E2E / <repo>` checks sat pending for ~67 min and never completed.)

## Fix

Create **and** update the check with a **fleet-App token scoped to `application-sdk`**, so the same App (`atlan-app-fleet`) owns it for its whole lifecycle:

- New `checks-app-token` input on the `e2e-apps` action; the two check steps use it instead of `github.token`.
- `pull_request.yaml` mints it alongside the existing connector-scoped dispatch token (kept separate for least privilege — dispatch can't write SDK checks and vice-versa).

Result: the connector's fleet-App callback can now complete the check (**real push callback, no poll**), and it's attributed to the fleet App's own check suite (no more "Allowlist Expiry Check" prefix).

## Clarify names (dispatch vs run/callback)

- dispatch job: `Connector Tests (<repo>)` → **`Connector E2E dispatch (<repo>)`** (success = "dispatch succeeded")
- callback check: `Connector E2E / <repo>` → **`Connector E2E run / <repo>`** (the actual run, completed by callback)

The check name is a **cross-file contract** — renamed consistently across the create side, gate rollup, connector callback, watchdog, scripts, tests, and docs.

## Notes / follow-ups

- **App display name:** the merge-box prefix is now the `atlan-app-fleet` App's display name. Renaming that App (org GitHub App setting — not code) to e.g. "Atlan Connector E2E" would make the prefix read even cleaner. Recommended separately.
- Bootstrapping: for *this* PR's own e2e, the connector callback runs from `main`'s `tests-reusable.yaml` (old name) until merge, so this PR's callback may not line up — expected, resolves on merge (all sites move together).

## Tests

Check-run script suites pass (**46**), `ruff@0.6.4` clean, all three changed workflows/action YAML-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)