### PR TITLE
ci(fleet-app): fix renovate-auto-approve.yml self-caller; migrate trivy-container.yaml

### DIFF
--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -52,5 +52,4 @@ jobs:
       event_name: ${{ github.event_name }}
       head_sha: ${{ github.event.workflow_run.head_sha }}
       pr_number: ${{ inputs.pr_number }}
-    secrets:
-      org_pat: ${{ secrets.ORG_PAT_GITHUB }}
+    secrets: inherit

--- a/.github/workflows/trivy-container.yaml
+++ b/.github/workflows/trivy-container.yaml
@@ -3,6 +3,19 @@
 # Runs Trivy, checks findings against the centralized base-allowlist in the SDK
 # repo (.security/base-allowlist.json), posts a summary comment on PRs, and
 # fails on new/expired entries.
+#
+# Usage:
+#
+#   jobs:
+#     build:
+#       uses: atlanhq/application-sdk/.github/workflows/trivy-container.yaml@main
+#       secrets: inherit
+#
+# This workflow mints a fleet App token (falling back to the caller's
+# ORG_PAT_GITHUB) for the cross-repo allowlist checkout and the
+# private-dependency BuildKit secret. Callers passing named secrets
+# explicitly instead of `inherit` keep working unchanged on their own
+# ORG_PAT_GITHUB.
 
 name: Atlan Application Trivy container scan
 
@@ -11,10 +24,17 @@ on:
     secrets:
       ORG_PAT_GITHUB:
         required: true
+        description: "Fallback PAT, used if the fleet App token can't be minted."
       CHAINGUARD_USERNAME:
         required: true
       CHAINGUARD_PASSWORD:
         required: true
+      FLEET_APP_ID:
+        required: false
+        description: "atlan-app-fleet App ID (org secret). Not passed explicitly by any current caller — auto-available via 'secrets: inherit'. Declared here so the contract is self-documenting."
+      FLEET_APP_PRIVATE_KEY:
+        required: false
+        description: "atlan-app-fleet App private key (org secret). Same availability as FLEET_APP_ID above."
 
     inputs:
       skip-files:
@@ -40,6 +60,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Mint fleet App token
+        # Not scoped to a specific repositories: list -- this token also
+        # feeds the composite's PRIVATE_REPO_ACCESS_TOKEN BuildKit secret,
+        # used by Dockerfiles that clone a private git dependency during the
+        # scan build. The target repo varies per caller and isn't known
+        # here, so this needs org-wide reach, same as build-and-scan.yaml's
+        # git_token mint.
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+
       - name: Checkout base allowlist from SDK
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -49,7 +84,7 @@ jobs:
             .security
             .github/scripts
           path: _sdk
-          token: ${{ secrets.ORG_PAT_GITHUB }}
+          token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
 
       # Composite handles build, Trivy JSON+SARIF scan, SARIF upload.
       # fail-on-vulns is disabled here — the allowlist gate below takes over.
@@ -58,7 +93,7 @@ jobs:
         with:
           chainguard-username: ${{ secrets.CHAINGUARD_USERNAME }}
           chainguard-password: ${{ secrets.CHAINGUARD_PASSWORD }}
-          github-token: ${{ secrets.ORG_PAT_GITHUB }}
+          github-token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
           skip-files: ${{ inputs.skip-files }}
           fail-on-vulns: 'false'
 

--- a/.github/workflows/trivy-container.yaml
+++ b/.github/workflows/trivy-container.yaml
@@ -46,6 +46,17 @@ on:
         required: false
         type: string
         default: 'true'
+      private_dep_repo:
+        description: >-
+          Optional bare repo name (under the atlanhq org) that the caller's
+          Dockerfile clones as a private git dependency during the scan build.
+          When set, the minted fleet App token is scoped to just that repo plus
+          application-sdk (needed for the allowlist checkout) for
+          least-privilege. When unset, the token stays org-wide (the default),
+          since a shared reusable can't know the caller's dependency repo.
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -61,11 +72,15 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Mint fleet App token
-        # Not scoped to a specific repositories: list -- this token also
-        # feeds the composite's PRIVATE_REPO_ACCESS_TOKEN BuildKit secret,
-        # used by Dockerfiles that clone a private git dependency during the
-        # scan build. The target repo varies per caller and isn't known
-        # here, so this needs org-wide reach, same as build-and-scan.yaml's
+        # This token feeds both the cross-repo application-sdk allowlist
+        # checkout below and the composite's PRIVATE_REPO_ACCESS_TOKEN BuildKit
+        # secret (used by Dockerfiles that clone a private git dependency
+        # during the scan build). A caller that knows its single dependency
+        # repo can advertise it via the private_dep_repo input; the token is
+        # then scoped to that repo plus application-sdk for least-privilege.
+        # When unset, repositories is empty and (with owner: atlanhq) the token
+        # stays org-wide -- the necessary default for a shared reusable whose
+        # dependency repo varies per caller, same as build-and-scan.yaml's
         # git_token mint.
         id: app-token
         continue-on-error: true
@@ -74,6 +89,7 @@ jobs:
           app-id: ${{ secrets.FLEET_APP_ID }}
           private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
           owner: atlanhq
+          repositories: ${{ inputs.private_dep_repo && format('application-sdk,{0}', inputs.private_dep_repo) || '' }}
 
       - name: Checkout base allowlist from SDK
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Two gaps found in a final comprehensive sweep of every `.github/workflows/*` file, beyond what Categories A-D covered:

**`renovate-auto-approve.yml`** (application-sdk's own caller, not the reusable) — still wired `secrets: { org_pat: ${{ secrets.ORG_PAT_GITHUB }} }` explicitly. Never got the same `secrets: inherit` fix already applied to the bootstrap template and rolled out to 13 consumer repos. Fixed.

**`trivy-container.yaml`** — a reusable workflow called by 30+ real app repos (confirmed via org-wide `gh search code`), missed by every prior category. No GHCR usage at all in this file — just a cross-repo checkout of application-sdk's security allowlist, plus a `github-token` pass-through that feeds the `trivy-container` composite action's `PRIVATE_REPO_ACCESS_TOKEN` BuildKit secret (same private-git-dependency mechanism as `build-and-scan.yaml`'s `git_token`, already verified working with the App token in Category C). Added a `continue-on-error` mint step (unscoped, since the private dependency's target repo varies per caller), migrated both sites with a fallback to `ORG_PAT_GITHUB`, and documented `secrets: inherit` as the recommended calling convention in the header.

Confirmed via a real caller (`atlan-state-enforcer-app`) that explicit named-secret callers (not yet on `inherit`) keep working unchanged — the mint gracefully no-ops without `FLEET_APP_ID`/`FLEET_APP_PRIVATE_KEY` and falls through to their PAT.

## Test plan
- [x] Both files validated (`python3 -c "import yaml; ..."`)
- [x] `pre-commit` clean
- [x] Confirmed real caller behavior (explicit-secrets callers unaffected) by reading an actual consumer's workflow file