### PR TITLE
ci(fleet-app): migrate publish-app.yaml to App token

### DIFF
--- a/.github/workflows/publish-app.yaml
+++ b/.github/workflows/publish-app.yaml
@@ -71,7 +71,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
   actions: write
 
 jobs:

--- a/.github/workflows/publish-app.yaml
+++ b/.github/workflows/publish-app.yaml
@@ -53,10 +53,21 @@ on:
     secrets:
       ORG_PAT_GITHUB:
         required: true
-        description: "Org-level PAT for GHCR login and gh CLI auth"
+        description: >-
+          Fallback PAT for gh CLI auth (workflow-dispatch trigger/poll of the
+          caller's own build workflow, and the atlan-cli-releases download),
+          used if the fleet App token can't be minted. Not used for GHCR --
+          the actual image build+push happens in the caller's own separate
+          build workflow, authenticated there with its own secrets.
       APP_PUBLISH_TOKEN:
         required: true
         description: "API token for marketplace publish"
+      FLEET_APP_ID:
+        required: false
+        description: "atlan-app-fleet App ID (org secret). Not passed explicitly by any current caller — auto-available via 'secrets: inherit'. Declared here so the contract is self-documenting."
+      FLEET_APP_PRIVATE_KEY:
+        required: false
+        description: "atlan-app-fleet App private key (org secret). Same availability as FLEET_APP_ID above."
 
 permissions:
   contents: read
@@ -75,9 +86,22 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - name: Mint fleet App token
+        # Used for gh CLI auth only (release download + the workflow-dispatch
+        # trigger/poll the atlan CLI shells out to for the caller's own build
+        # workflow) -- no GHCR interaction happens in this file.
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: ${{ github.event.repository.name }}
+
       - name: Install Atlan CLI
         env:
-          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
         run: |
           set -euo pipefail
 
@@ -106,7 +130,7 @@ jobs:
 
       - name: Publish
         env:
-          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
           CHANNEL: ${{ inputs.channel }}
           TENANTS: ${{ inputs.tenants }}
           REF: ${{ inputs.ref || github.ref }}


### PR DESCRIPTION
Traced the closed-source `atlan` CLI's actual source (`atlanhq/atlan-cli`, private repo) to confirm this is safe rather than guessing: the 'internal flow' (no Harbor config, which is what CI always uses) never touches Docker/registry APIs directly. It shells out to the `gh` CLI (`gh workflow run` / `gh release download`), which reads `GH_TOKEN` from the environment automatically — that's the entire reason this env var exists in this workflow. The actual image build+push happens in a separate workflow in the caller's own repo, authenticated there with its own secrets (already covered by Category C — GHCR stays on `ORG_PAT_GITHUB` there).

Both `GH_TOKEN` sites now try a minted fleet App token first, falling back to `ORG_PAT_GITHUB`:
- **Install Atlan CLI** — `gh release download` from the *public* `atlan-cli-releases` repo. Doesn't strictly need auth at all, just the higher authenticated rate-limit tier (same rationale as the Trivy release-lookup sites already migrated — and empirically confirmed in this project that a token scoped to one repo still works fine for reading unrelated public repos, e.g. the `aquasecurity/trivy` release lookup in `build-apps-image.yaml`'s `trivy` job).
- **Publish** — triggers/polls the caller's own build workflow via `gh workflow run`.

Token is scoped to the calling repo (`repositories: ${{ github.event.repository.name }}`), matching `tag-and-release.yaml`'s established pattern for reusable workflows. Declared `FLEET_APP_ID`/`FLEET_APP_PRIVATE_KEY` as optional secrets; the header already documented `secrets: inherit` as the calling convention, confirmed via a real caller (`atlan-csa-csv-composite-app`).

## Test plan
- [x] YAML validated
- [x] `pre-commit` clean
- [x] Read the actual CLI source to confirm no GHCR interaction, rather than assuming from the `packages: write` permission declaration