### PR TITLE
ci: reconcile allowlist + tickets again 1h after release

### DIFF
--- a/.github/scripts/reconcile_allowlist.py
+++ b/.github/scripts/reconcile_allowlist.py
@@ -267,6 +267,22 @@ def _resolution_phrase(debounce: int) -> str:
     return f"{debounce} consecutive clean scans"
 
 
+def removal_branch(run_date: str) -> str:
+    """Branch name for the allowlist-removal PR — unique per run AND per pass.
+
+    GITHUB_RUN_ID keeps it unique across same-day reconcile runs. But the
+    on-release workflow runs two passes (t+0 and t+~1h, to catch a base-image
+    rebuild that lands just after the release) under the SAME GITHUB_RUN_ID, so
+    RECONCILE_PASS disambiguates them — otherwise both passes could push the
+    same branch and the second would fail. Falls back to run_date when neither
+    env var is set (e.g. local runs)."""
+    suffix = os.environ.get("GITHUB_RUN_ID", run_date) or run_date
+    pass_tag = os.environ.get("RECONCILE_PASS", "")
+    if pass_tag:
+        suffix = f"{suffix}-{pass_tag}"
+    return f"chore/allowlist-remove-{suffix}"
+
+
 def open_removal_pr(
     repo: str, removed: list[str], run_date: str, debounce: int, runner: Runner
 ) -> None:
@@ -276,9 +292,7 @@ def open_removal_pr(
         data.pop(cve, None)
     Path(ALLOWLIST_PATH).write_text(json.dumps(data, indent=2) + "\n")
 
-    # GITHUB_RUN_ID keeps the branch unique across same-day reconcile runs.
-    suffix = os.environ.get("GITHUB_RUN_ID", run_date) or run_date
-    branch = f"chore/allowlist-remove-{suffix}"
+    branch = removal_branch(run_date)
     joined = ", ".join(removed)
     runner(["git", "checkout", "-b", branch], check=True)
     runner(["git", "add", ALLOWLIST_PATH], check=True)

--- a/.github/scripts/tests/test_reconcile_allowlist.py
+++ b/.github/scripts/tests/test_reconcile_allowlist.py
@@ -186,6 +186,36 @@ def test_resolution_phrase():
 
 
 # ---------------------------------------------------------------------------
+# removal_branch — the on-release workflow runs two passes (t+0, t+60m) under
+# one GITHUB_RUN_ID, so RECONCILE_PASS must keep their removal branches distinct
+# (else the second pass pushes an existing branch and fails).
+# ---------------------------------------------------------------------------
+
+
+def test_removal_branch_disambiguates_passes(monkeypatch):
+    monkeypatch.setenv("GITHUB_RUN_ID", "999")
+    monkeypatch.setenv("RECONCILE_PASS", "0")
+    b0 = rec.removal_branch("2026-07-16")
+    monkeypatch.setenv("RECONCILE_PASS", "60")
+    b60 = rec.removal_branch("2026-07-16")
+    assert b0 == "chore/allowlist-remove-999-0"
+    assert b60 == "chore/allowlist-remove-999-60"
+    assert b0 != b60  # same run, different pass → distinct branches
+
+
+def test_removal_branch_without_pass_tag(monkeypatch):
+    monkeypatch.setenv("GITHUB_RUN_ID", "999")
+    monkeypatch.delenv("RECONCILE_PASS", raising=False)
+    assert rec.removal_branch("2026-07-16") == "chore/allowlist-remove-999"
+
+
+def test_removal_branch_falls_back_to_run_date(monkeypatch):
+    monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
+    monkeypatch.delenv("RECONCILE_PASS", raising=False)
+    assert rec.removal_branch("2026-07-16") == "chore/allowlist-remove-2026-07-16"
+
+
+# ---------------------------------------------------------------------------
 # scan_files_present + main() fail-safe — never reconcile against a phantom
 # empty scan. On `release: released` the release workflow scans fresh into the
 # CWD; if that scan produced nothing (failed/absent results), reconciling would

--- a/.github/workflows/vuln-reconcile-on-release.yml
+++ b/.github/workflows/vuln-reconcile-on-release.yml
@@ -91,7 +91,12 @@ jobs:
       # which keeps it from re-removing entries) and scans the current base image.
       - name: Wait ${{ matrix.delay-minutes }}m (widen the out-of-band rebuild window)
         shell: bash
-        run: sleep $(( ${{ matrix.delay-minutes }} * 60 ))
+        env:
+          # Via env (not inlined in run:) so the expression can't be treated as
+          # a shell-injection surface. matrix values are trusted, but this is the
+          # idiom actionlint/CI standards expect.
+          DELAY_MINUTES: ${{ matrix.delay-minutes }}
+        run: sleep $(( DELAY_MINUTES * 60 ))
       # ref: main (not the release tag) so the fresh scan reflects main and the
       # allowlist-removal PR bases cleanly on main. Releases are cut from main,
       # so main HEAD ≈ the released state. Checked out as atlan-ci so the removal

--- a/.github/workflows/vuln-reconcile-on-release.yml
+++ b/.github/workflows/vuln-reconcile-on-release.yml
@@ -30,6 +30,24 @@
 # and auto-merges via vuln-auto-merge.yml. workflow_dispatch is provided for
 # manual backfill / re-runs.
 #
+# Two passes per release (matrix `delay-minutes: [0, 60]`): the base-image
+# rebuild that clears a Case-4 CVE is a HUMAN step (platform republishes
+# app-runtime-base) and often lands SHORTLY AFTER the SDK release, not before
+# it. A release-time reconcile that only ran at t+0 would scan the still-old
+# base image, see the CVE, and conservatively leave the ticket + allowlist entry
+# in place — then nothing would retire them until the *next* release happened to
+# coincide with an already-rebuilt base (observed: a HIGH sat open for a full
+# release cycle this way). The t+60m pass re-scans an hour later and retires
+# anything the rebuild cleared in the interim.
+#
+# Why a delayed pass and not a plain cron: reconciliation must stay gated behind
+# a release event (see the allowlist-removal rationale above — connectors read
+# the allowlist from `main` while running the last *released* SDK). Both passes
+# fire only off a release, so removal stays release-gated; the delay just widens
+# the window to absorb an out-of-band base rebuild. The pass runs are
+# independent (`fail-fast: false`) and the reconcile script is idempotent — the
+# t+0 pass closing a ticket makes the t+60m pass a no-op for it, and vice versa.
+#
 # Trigger dependency (load-bearing): this fires only because tag-and-publish.yaml
 # creates the GitHub Release with a PAT (secrets.ORG_PAT_GITHUB). A release
 # created with the default GITHUB_TOKEN would NOT trigger this workflow (GitHub's
@@ -54,10 +72,26 @@ permissions:
 
 jobs:
   reconcile:
-    name: Reconcile allowlist + tickets
+    name: Reconcile allowlist + tickets (t+${{ matrix.delay-minutes }}m)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # t+60m pass idles for an hour before scanning, so the timeout must clear
+    # 60m delay + a full fresh scan (~a few min). Keep headroom above 60.
+    timeout-minutes: 90
+    strategy:
+      # t+0: retire CVEs already fixed in this release. t+60m: catch a base-image
+      # rebuild that lands just after the release (see header). Independent so a
+      # failure in one pass never cancels the other.
+      fail-fast: false
+      matrix:
+        delay-minutes: [0, 60]
     steps:
+      # Straight-line delay before checkout (per docs/standards/ci.md — no
+      # branching shell). Done before checkout so the delayed pass checks out
+      # main AS OF t+60m (picking up the t+0 pass's already-merged removal PR,
+      # which keeps it from re-removing entries) and scans the current base image.
+      - name: Wait ${{ matrix.delay-minutes }}m (widen the out-of-band rebuild window)
+        shell: bash
+        run: sleep $(( ${{ matrix.delay-minutes }} * 60 ))
       # ref: main (not the release tag) so the fresh scan reflects main and the
       # allowlist-removal PR bases cleanly on main. Releases are cut from main,
       # so main HEAD ≈ the released state. Checked out as atlan-ci so the removal
@@ -83,6 +117,9 @@ jobs:
           SCAN_WORKFLOW: daily-security-scan.yml
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LINEAR_TEAM_ID: ${{ vars.LINEAR_SECURITY_SCAN_TEAM_ID }}
+          # Both matrix passes share one GITHUB_RUN_ID; this keeps their
+          # allowlist-removal branches distinct (see removal_branch()).
+          RECONCILE_PASS: ${{ matrix.delay-minutes }}
         run: |
           export RUN_DATE=$(date -u +%Y-%m-%d)
           git config user.name "atlan-ci"

--- a/.github/workflows/vuln-reconcile-on-release.yml
+++ b/.github/workflows/vuln-reconcile-on-release.yml
@@ -87,8 +87,12 @@ jobs:
     steps:
       # Straight-line delay before checkout (per docs/standards/ci.md — no
       # branching shell). Done before checkout so the delayed pass checks out
-      # main AS OF t+60m (picking up the t+0 pass's already-merged removal PR,
-      # which keeps it from re-removing entries) and scans the current base image.
+      # main AS OF t+60m and scans the current base image. Best-effort, it also
+      # picks up the t+0 pass's removal PR *if that PR has merged by then*; if
+      # auto-merge is still pending (slow required checks / merge queue), the
+      # delayed pass opens a second removal PR on its own RECONCILE_PASS branch.
+      # Harmless: both passes are idempotent on the merged allowlist — whichever
+      # removal PR merges first wins, and a human closes the stale one.
       - name: Wait ${{ matrix.delay-minutes }}m (widen the out-of-band rebuild window)
         shell: bash
         env:


### PR DESCRIPTION
## Problem

Reconciliation (auto-close vuln tickets + open the allowlist-removal PR) runs **only** on a stable SDK release (`vuln-reconcile-on-release.yml`). For **base-image (Case-4) CVEs**, the fix is a manual platform rebuild + republish of `app-runtime-base` — and that rebuild often lands **shortly *after*** the SDK release, not before it.

When that happens, the release-time reconcile scans the *still-old* base image, still sees the CVE, and correctly (conservatively) leaves the ticket and allowlist entry in place. But nothing then retires them until some *later* release happens to coincide with an already-rebuilt base. Observed in practice: a HIGH stayed open for a full release cycle, its allowlist entry lingering, purely because the base rebuild landed ~1h after the release that would have closed it.

## Change

Run the reconcile job in **two passes per release** via `strategy.matrix.delay-minutes: [0, 60]`:

- **t+0** — retire CVEs already fixed in this release (unchanged behavior).
- **t+60m** — sleep an hour, then re-scan `main` fresh and retire anything an out-of-band base-image rebuild cleared in the interim.

### Why a delayed pass and not a plain cron
Reconciliation must stay **gated behind a release event** — connectors read the shared allowlist from SDK `main` while still running the *last released* SDK, so removing an entry off a blind clean scan (fix merged, not yet released) would drop their gate coverage. Both passes fire only off the release, so allowlist removal stays release-gated; the delay just widens the window to absorb a base rebuild that lands just after the release.

### Safety / idempotency
- Passes are independent (`fail-fast: false`) — one failing never cancels the other.
- The reconcile script is already idempotent: whichever pass acts first (closes a ticket / merges the removal PR) makes the other a no-op, because it re-checks out `main` and re-fetches open tickets at its own start.
- `removal_branch()` now folds `RECONCILE_PASS` into the branch name so the two passes (which share one `GITHUB_RUN_ID`) can't collide on the `chore/allowlist-remove-*` PR branch.
- `timeout-minutes` raised 30 → 90 to clear the 60m delay + fresh scan.

## Tests
`.github/scripts/tests/test_reconcile_allowlist.py` — 3 new cases for `removal_branch` (per-pass disambiguation, no-tag fallback, run-date fallback). Full suite: 29 passed.

## Trade-off
The t+60m pass idles a hosted runner for an hour and adds one extra scan per release (and per manual `workflow_dispatch`). Cost is a few cents/release for a workflow that runs a handful of times a week — deliberately accepted to close the out-of-band-rebuild gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)