### PR TITLE
ci(e2e): fall back to main callback scripts when dispatching SDK ref is stale

### DIFF
--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -345,10 +345,10 @@ jobs:
           repositories: application-sdk
 
       # Pinned to the exact SHA that dispatched this run (not `main`): that
-      # SHA is what created the check run we're about to complete, so the
-      # callback script version can never drift from it. Also required for
-      # this PR itself to be testable pre-merge — the callback scripts don't
-      # exist on `main` until this PR lands.
+      # SHA is what created the check run we're about to complete, so a PR
+      # that *modifies* the callback scripts self-tests its own version (the
+      # scripts don't exist on `main` until such a PR lands — the fallback
+      # below is skipped whenever the pinned ref already carries them).
       - name: Checkout application-sdk callback script
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -358,6 +358,38 @@ jobs:
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
           path: application-sdk-scripts
+
+      # A dispatching SDK PR branch that forked *before* the callback scripts
+      # merged (and never picked up main since) checks out a ref that lacks
+      # build_callback_summary.py — the callback then hard-fails on a missing
+      # file even though the connector tests passed, leaving the check stuck
+      # in_progress until the 130-min watchdog flips it to timed_out (a red
+      # result for a green run). Fall back to main's scripts for those stale
+      # refs. Only the *script source* falls back — the check run still
+      # completes on the dispatching SHA via `--sha`, so nothing about which
+      # commit gets the result changes. `hashFiles() == ''` is a step-level
+      # expression, not inlined conditional shell, so it stays within the CI
+      # authoring rule (no branching logic in `run:` blocks).
+      - name: Fall back to main callback scripts if pinned SHA predates them
+        id: scripts-fallback
+        if: hashFiles('application-sdk-scripts/.github/scripts/build_callback_summary.py') == ''
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: atlanhq/application-sdk
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+          path: application-sdk-scripts
+
+      # `outcome == 'success'` is true only when the fallback step actually
+      # ran (skipped when the pinned ref already had the scripts), so the
+      # warning fires exactly on the stale-ref path.
+      - name: Warn that the dispatching SDK ref was stale
+        if: steps.scripts-fallback.outcome == 'success'
+        env:
+          SDK_REF: ${{ inputs.application-sdk-ref }}
+        run: echo "::warning::Dispatching application-sdk ref ${SDK_REF} predates the callback scripts; used main's copy instead. Merge main into that SDK branch to silence this."
 
       - name: Download connector e2e results
         if: needs.e2e.result != 'skipped'

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -370,6 +370,19 @@ jobs:
       # commit gets the result changes. `hashFiles() == ''` is a step-level
       # expression, not inlined conditional shell, so it stays within the CI
       # authoring rule (no branching logic in `run:` blocks).
+      # Clear the incomplete pinned-ref checkout before re-checking out from
+      # main into the same path. `actions/checkout` already defaults to
+      # `clean: true`, so this is belt-and-suspenders — it makes the "one
+      # path, two checkouts" pattern self-evidently clean for future readers.
+      # Gated on the SAME condition as the fallback: on the happy path (pinned
+      # ref carries the scripts) it is skipped, so the good checkout is never
+      # deleted and the fallback stays skipped — the PR-self-test property is
+      # preserved. Straight-line `rm`, no branching in the shell, per the CI
+      # authoring rule.
+      - name: Clear the stale sparse checkout before falling back
+        if: hashFiles('application-sdk-scripts/.github/scripts/build_callback_summary.py') == ''
+        run: rm -rf application-sdk-scripts
+
       - name: Fall back to main callback scripts if pinned SHA predates them
         id: scripts-fallback
         if: hashFiles('application-sdk-scripts/.github/scripts/build_callback_summary.py') == ''


### PR DESCRIPTION
## Problem

The cross-repo e2e **reporting callback** (`report-to-sdk` in `tests-reusable.yaml`) sparse-checks-out the callback scripts **at the dispatching SDK SHA** (`application-sdk-ref`), by design, so a PR that *modifies* those scripts self-tests its own version.

That breaks for any SDK PR branch that **forked before the callback scripts merged** (PR #2716, `29abf316`, 2026-07-15 16:12) and hasn't picked up `main` since. Such a ref has no `build_callback_summary.py`, so the callback dies:

```
python3: can't open file '.../application-sdk-scripts/.github/scripts/build_callback_summary.py': [Errno 2] No such file or directory
##[error]Process completed with exit code 2.
```

Because `complete_check_run.py` never runs after that, the `Connector E2E run / <repo>` check is left stuck `in_progress` until the 130-min watchdog (`e2e-callback-watchdog.yml`) flips it to `timed_out` — **a red result for a green run**, and the SDK PR's gate (`poll_check_runs_gate.py`, 130-min budget) fails.

Observed on a real dispatch from SDK PR #2712 (`fix/worker-restart-on-fatal-poll`), whose branch predates #2716.

## Fix

Add a **main-scripts fallback** to `report-to-sdk`:

- Keyed on `hashFiles(...) == ''` — a step-level GitHub expression, **not** inlined conditional shell, so it complies with the CI authoring rule (no branching logic in `run:`).
- Triggers **only** when the pinned ref lacks the script. A callback-modifying PR still self-tests its own version (fallback is skipped when the pinned ref carries the scripts).
- Only the *script source* falls back to `main`; the check run still completes on the dispatching SHA via `--sha`, so which commit receives the result is unchanged.
- A `::warning::` annotation surfaces the stale-ref case with remediation guidance.

## Scope / non-goals

- The watchdog is unchanged — it correctly remains the last-resort cleaner for genuine runner deaths (checks stuck with no callback at all). This PR fixes the case where the callback *ran but couldn't find its script*.
- Immediate remediation for an already-affected branch (e.g. #2712) is still to merge `main` into it; this PR prevents recurrence on any other stale branch.

## Testing

- `yaml.safe_load` parses clean; `pre-commit` passes on the changed file.
- Fallback path: pinned ref without the script → fallback checkout runs → warning fires → callback proceeds against main's scripts.
- Happy path: pinned ref with the script → fallback + warning both skip → behavior identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)