### PR TITLE
feat(contract-toolkit): source Credential.pkl widgets from Widgets.pkl

### DIFF
--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -2902,14 +2902,38 @@ deploy = new DeployConfig {
 
 ## Credential.pkl — Legacy Module
 
-For Argo-era apps only. Uses `Config.pkl` widget classes instead of `FieldSpec`. Do not use for new native apps.
+For Argo-era apps only. Do not use for new native apps (use `FieldSpec` instead). Still used
+by CSA connector credential configs.
+
+Widget classes come from the modern `Widgets.pkl` module (not the older `Config.pkl`), and
+Credential.pkl re-exports them as unqualified typealiases — mirroring App.pkl — so a credential
+contract writes `new TextInput { }`, `new PasswordInput { }`, `new NestedInput { }`, etc.
+directly, with no supplemental `import`:
 
 ```pkl
-class NestedCredentialInput extends Config.NestedInput {
+amends "@app-contract-toolkit/Credential.pkl"
+
+name = "my-connector"
+source = "My Source"
+options {
+  ["basic"] = new NestedCredentialInput {
+    optionLabel = "Basic"
+    inputs {
+      ["username"] = new TextInput { title = "User" }
+      ["password"] = new PasswordInput { title = "Password" }
+    }
+  }
+}
+```
+
+Internally:
+
+```pkl
+class NestedCredentialInput extends Widgets.NestedInput {
   hidden optionLabel: String       // Auth radio label
   title = ""
   hide = true
-  hidden inputs: Mapping<CredentialAttribute, Config.UIElement>
+  hidden inputs: Mapping<CredentialAttribute, Widgets.UIElement>
 }
 
 typealias CredentialAttribute = "host"|"port"|"connection"|"username"|"password"|"extra"|"name"|"connector"|"connectorType"

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -2939,6 +2939,36 @@ class NestedCredentialInput extends Widgets.NestedInput {
 typealias CredentialAttribute = "host"|"port"|"connection"|"username"|"password"|"extra"|"name"|"connector"|"connectorType"
 ```
 
+### Migration (breaking): `Config.*` widgets → bare widget names
+
+Credential.pkl previously sourced its widget classes from the legacy `Config.pkl`, so
+credential contracts imported `Config.pkl` and wrote qualified `new Config.TextInput { }`.
+Widget classes now come from `Widgets.pkl`, and `Config.UIElement` / `Widgets.UIElement` are
+nominally distinct classes. A credential contract that still assigns `Config.*` widgets fails
+`pkl eval` on the next toolkit-version bump:
+
+```
+Expected value of type Widgets#UIElement, but got Config#TextInput
+```
+
+This is a **source-level breaking change** for credential contracts (generated JSON output is
+unchanged). To migrate a contract, drop the `Config.pkl` import and unqualify the widget names:
+
+```diff
+ amends "@app-contract-toolkit/Credential.pkl"
+-import "@app-contract-toolkit/Config.pkl"
+ ...
+-  ["username"] = new Config.TextInput { title = "User" }
+-  ["password"] = new Config.PasswordInput { title = "Password" }
++  ["username"] = new TextInput { title = "User" }
++  ["password"] = new PasswordInput { title = "Password" }
+```
+
+The same rename applies to every `Config.*` widget a contract uses (`Config.NestedInput` →
+`NestedInput`, `Config.Radio` → `Radio`, `Config.UIRule` → `UIRule`, and so on). The toolkit
+bump and the consumer migrations must land together — bumping the toolkit before a consumer is
+migrated breaks that consumer's `pkl eval`.
+
 ---
 
 ## Renderers.pkl — Legacy Renderers

--- a/contract-toolkit/src/Credential.pkl
+++ b/contract-toolkit/src/Credential.pkl
@@ -16,8 +16,65 @@
 @ModuleInfo { minPklVersion = "0.25.1" }
 open module com.atlan.app.contract.Credential
 
-import "Config.pkl"
+import "Widgets.pkl"
 import "Renderers.pkl"
+
+// ── WIDGET TYPE RE-EXPORTS ────────────────────────────────────────────────────
+// Typealiases so credential contracts write `new TextInput { }`, `new PasswordInput { }`,
+// etc. without needing a supplemental `import "@app-contract-toolkit/Config.pkl"` (or
+// Widgets.pkl).  Mirrors the same block in App.pkl so credential configs share the exact
+// widget vocabulary as app entrypoints.  Credential.pkl sources these from Widgets.pkl —
+// the modern widget module — and no longer depends on the legacy Config.pkl.
+
+typealias InfoBannerType = Widgets.InfoBannerType
+typealias WidgetLink = Widgets.WidgetLink
+typealias WidgetValidation = Widgets.WidgetValidation
+typealias UIConfig = Widgets.UIConfig
+typealias UIStep = Widgets.UIStep
+typealias UIRule = Widgets.UIRule
+typealias UIElement = Widgets.UIElement
+typealias UIElementWithEnum = Widgets.UIElementWithEnum
+typealias Widget = Widgets.Widget
+typealias TextInput = Widgets.TextInput
+typealias TextBoxInput = Widgets.TextBoxInput
+typealias Radio = Widgets.Radio
+typealias ConnectionCreator = Widgets.ConnectionCreator
+typealias ConnectionSelector = Widgets.ConnectionSelector
+typealias ConnectionRefInput = Widgets.ConnectionRefInput
+typealias FileUploader = Widgets.FileUploader
+typealias FileCopier = Widgets.FileCopier
+typealias NumericInput = Widgets.NumericInput
+typealias DateInput = Widgets.DateInput
+typealias BooleanInput = Widgets.BooleanInput
+typealias DropDown = Widgets.DropDown
+typealias TagsInput = Widgets.TagsInput
+typealias MultipleGroups = Widgets.MultipleGroups
+typealias SingleGroup = Widgets.SingleGroup
+typealias MultipleUsers = Widgets.MultipleUsers
+typealias SingleUser = Widgets.SingleUser
+typealias ConnectorTypeSelector = Widgets.ConnectorTypeSelector
+typealias APITokenSelector = Widgets.APITokenSelector
+typealias KeygenInput = Widgets.KeygenInput
+typealias PasswordInput = Widgets.PasswordInput
+typealias CredentialInput = Widgets.CredentialInput
+typealias NestedInput = Widgets.NestedInput
+typealias SQLExecutor = Widgets.SQLExecutor
+typealias APITree = Widgets.APITree
+typealias ApiTreeSelect = Widgets.ApiTreeSelect
+typealias InfoBanner = Widgets.InfoBanner
+typealias DsnTreeMap = Widgets.DsnTreeMap
+typealias GlossarySelector = Widgets.GlossarySelector
+typealias Switcher = Widgets.Switcher
+typealias Sage = Widgets.Sage
+typealias SageV2 = Widgets.SageV2
+typealias CloudProvider = Widgets.CloudProvider
+typealias AgentSelector = Widgets.AgentSelector
+typealias SqlTree = Widgets.SqlTree
+typealias ConditionalInput = Widgets.ConditionalInput
+typealias Condition = Widgets.Condition
+typealias InputRepeater = Widgets.InputRepeater
+typealias Schedule = Widgets.Schedule
+typealias CustomWidget = Widgets.CustomWidget
 
 /// Name of this connector-specific credential configuration.
 hidden name: String
@@ -53,7 +110,7 @@ hidden connectorType: String = "rest"
 ///   ...
 /// }
 /// ```
-hidden commonInputs: Mapping<CredentialAttribute, Config.UIElement>?
+hidden commonInputs: Mapping<CredentialAttribute, Widgets.UIElement>?
 
 /// Label to use above the radio button of options
 hidden optionsTitle: String = "Authentication"
@@ -65,9 +122,9 @@ hidden options: Mapping<String, NestedCredentialInput>
 /// Auth-type nested panes are spread with hidden=true and empty labels so the
 /// anyOf rules control their visibility. The radio button labels come from
 /// each option's `optionLabel` field.
-fixed properties: Map<String, Config.UIElement> = new Mapping<String, Config.UIElement> {
+fixed properties: Map<String, Widgets.UIElement> = new Mapping<String, Widgets.UIElement> {
   when (commonInputs != null) { ...commonInputs }
-  ["auth-type"] = new Config.Radio {
+  ["auth-type"] = new Widgets.Radio {
     title = optionsTitle
     possibleValues = new Mapping {
       for (k, v in options) {
@@ -95,13 +152,13 @@ fixed properties: Map<String, Config.UIElement> = new Mapping<String, Config.UIE
 ///   ...
 /// }
 /// ```
-hidden rules: Listing<Config.UIRule> = new Listing {}
+hidden rules: Listing<Widgets.UIRule> = new Listing {}
 
 /// (Generated) Details of all UI rules to use to control the UI.
-fixed anyOf: List<Config.UIRule>? =
+fixed anyOf: List<Widgets.UIRule>? =
   new Listing {
     for (k, _ in options) {
-      new Config.UIRule {
+      new Widgets.UIRule {
         whenInputs { ["auth-type"] = k }
         required { k }
       }
@@ -138,7 +195,7 @@ output = getModuleOutput(this)
 /// | **`inputs`** | | map of the sub-elements that should be nested within this input | |
 /// | `helpText` | | informational text to place in a hover-over to describe the use of the input | `""` |
 /// | `width` | | sizing of the input on the UI (8 is full-width, 4 is half-width) | `8` |
-class NestedCredentialInput extends Config.NestedInput {
+class NestedCredentialInput extends Widgets.NestedInput {
   /// Label shown in the auth-type radio button for this option.
   hidden optionLabel: String
 
@@ -147,5 +204,5 @@ class NestedCredentialInput extends Config.NestedInput {
   hide = true
 
   /// Map of the sub-elements that should be nested within this input, keyed by unique lower_snake_case variable name.
-  hidden inputs: Mapping<CredentialAttribute, Config.UIElement>
+  hidden inputs: Mapping<CredentialAttribute, Widgets.UIElement>
 }


### PR DESCRIPTION
## What

`Credential.pkl` imported the **legacy `Config.pkl`** for its widget classes and did not re-export them. So every credential contract (e.g. CSA connector credential configs) had to:

```pkl
amends "@app-contract-toolkit/Credential.pkl"
import "@app-contract-toolkit/Config.pkl"          // <- required
...
["username"] = new Config.TextInput { ... }        // <- qualified
```

App.pkl contracts, by contrast, get the widget vocabulary unqualified (App.pkl sources widgets from the modern `Widgets.pkl` and re-exports them as typealiases).

This PR brings `Credential.pkl` in line with `App.pkl`:

- Sources its widget classes from **`Widgets.pkl`** (the modern module) instead of `Config.pkl`.
- Re-exports the **same 49 widget typealiases** `App.pkl` exposes, so credential contracts write bare `new TextInput { }`, `new PasswordInput { }`, `new NestedInput { }`, … with **no supplemental import**.

```pkl
amends "@app-contract-toolkit/Credential.pkl"
...
["username"] = new TextInput { ... }               // bare, no Config import
```

## Verification

- **Byte-identical output**: rendered a representative credential contract (S3-style nested auth pane) through both the old (`Config.*`) and new (bare `Widgets`) forms via `pkl eval -m` — the generated JSON is identical.
- **All 263 toolkit pkl tests pass** (635 asserts), including the credential-rendering and JDBC auth-pane suites.
- `docs/reference.md` "Credential.pkl" section updated to the bare-name pattern, with a breaking-migration subsection.

## ⚠️ Breaking change — coordinated migration required

`Config.UIElement` and `Widgets.UIElement` are **nominally distinct** classes. Retyping
`commonInputs` / `NestedCredentialInput.inputs` / `properties` / `rules` / `anyOf` from
`Config.*` to `Widgets.*` is a **source-level breaking change**: a credential contract that
still assigns `Config.*` widgets fails `pkl eval` on its next toolkit bump with
`Expected value of type Widgets#UIElement, but got Config#TextInput`. Generated JSON output is
unchanged; only the authoring types change.

Migration per contract: drop `import "@app-contract-toolkit/Config.pkl"` and unqualify the
widget names (`Config.TextInput` → `TextInput`, `Config.NestedInput` → `NestedInput`,
`Config.Radio` → `Radio`, `Config.UIRule` → `UIRule`, `Config.PasswordInput` → `PasswordInput`, …).

Because the toolkit is pre-1.0 this ships under breaking-change commit syntax (`feat!`) rather
than a major bump, but it is still a break for the consumers below and must be sequenced with
their migrations.

### Affected credential contracts (full inventory)

An org-wide code search (`amends "@app-contract-toolkit/Credential.pkl"` + `Config.*` widget
assignments) found **5 credential contracts across 4 repositories**, all of which break on the
next toolkit bump. Treat this as a floor — the toolkit review's fleet scan indicated up to ~7;
any delta is likely code-search index lag, so re-scan before the bump.

| Repository | Contract | `Config.*` widgets used |
|---|---|---|
| `atlan-openapi-app` | `contract/csa-connectors-objectstore.pkl` | TextInput, PasswordInput, NestedInput (also drop the now-unneeded `// conformance: ignore[K002]`) |
| `atlan-dbt-app` | `contract/atlan-connectors-dbt.pkl` | TextInput, PasswordInput, UIRule |
| `atlan-dbt-app` | `contract/atlan-connectors-dbt-objectstore.pkl` | TextInput, PasswordInput, NestedInput, Radio |
| `atlan-generic-miner-app` | `contract/atlan-connectors-generic-miner-objectstore.pkl` | TextInput, PasswordInput, NestedInput, Radio |
| `atlan-coalesce-app` | `contract/atlan-connectors-coalesce.pkl` | TextInput, PasswordInput |

### Merge checklist (coordinated rollout)

Merging this source PR breaks no consumer in isolation — consumers pin a released
`@app-contract-toolkit` version and the generated JSON is byte-identical, so the break only
surfaces at a consumer's next toolkit-version bump. The gate is therefore the **release/version
bump**, not this merge:

- [ ] Open a migration PR against each of the 4 consumer repos above (drop the `Config.pkl` import, unqualify widget names).
- [ ] **Do not publish this breaking toolkit release to a channel consumers auto-pick-up until all 5 consumer migration PRs are open and ready to land in lockstep** — this is the actual break point, and it is a release-time gate rather than a gate on this source merge.
- [ ] Land those consumer PRs, or land this toolkit change and the consumer migrations together, so no consumer is left on an un-migrated contract when the toolkit version they pin bumps.
- [ ] Re-run the org-wide `amends Credential.pkl` + `Config.*` search immediately before the toolkit bump to catch any contract added after this inventory.

## Related

- Complements #2742 (`fix(conformance)`: K002 no longer false-positives on Credential.pkl contracts). #2742 fixes the lint non-breakingly; this PR removes the underlying need for the `Config.pkl` import at all.
