### PR TITLE
ci: create the missing reusable .github/workflows/stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,60 @@
+name: Stale issues and PRs (Reusable)
+
+# Reusable workflow: marks stale issues and PRs. Called by every app repo's
+# own .github/workflows/stale.yml (scaffolded by
+# `atlan-application-sdk-conformance bootstrap`):
+#
+#   on:
+#     schedule:
+#       - cron: 0 0 * * 0
+#   jobs:
+#     call-stale-workflow:
+#       uses: atlanhq/application-sdk/.github/workflows/stale.yml@main
+#
+# This file did not exist until now -- every caller above has been failing
+# with a "workflow not found" startup error since the bootstrap template
+# was introduced. Mirrors this repo's own stale job (schedule.yaml),
+# including debug-only: true: that's a deliberate choice here (observe,
+# don't auto-close) so activating this for the first time across the whole
+# fleet doesn't immediately close a large accumulated backlog. Flip
+# debug-only off per-repo (via a fork of this file, or once this input is
+# added) if a caller wants real closure.
+
+on:
+  workflow_call:
+    secrets:
+      FLEET_APP_ID:
+        required: false
+        description: "atlan-app-fleet App ID (org secret). Not passed explicitly by any current caller (none use 'secrets: inherit' yet) -- falls back to the default GITHUB_TOKEN, which is sufficient here."
+      FLEET_APP_PRIVATE_KEY:
+        required: false
+        description: "atlan-app-fleet App private key (org secret). Same availability as FLEET_APP_ID above."
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint fleet App token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Mark stale issues and PRs
+        uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
+        with:
+          repo-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'Stale Issue'
+          stale-pr-message: 'Stale Pull Request'
+          stale-issue-label: 'Stale'
+          stale-pr-label: 'Stale'
+          days-before-stale: 60
+          debug-only: 'true'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,6 +19,16 @@ name: Stale issues and PRs (Reusable)
 # fleet doesn't immediately close a large accumulated backlog. Flip
 # debug-only off per-repo (via a fork of this file, or once this input is
 # added) if a caller wants real closure.
+#
+# When flipping debug-only off, mind write permissions: the permissions block
+# below declares the maximum this reusable workflow can use, but for a caller
+# invoked via `uses:` those are capped by the caller's token, not escalated. On
+# the fallback path (secrets.GITHUB_TOKEN, which every current caller uses), a
+# caller whose default token is read-only would have these writes capped and
+# actions/stale would 403 on the first label/comment. Before real closure, the
+# caller must either grant `issues: write` / `pull-requests: write` at its job
+# level or pass the fleet App token (via `secrets: inherit`), which carries its
+# own permissions. Harmless while debug-only: true, since no writes happen.
 
 on:
   workflow_call:
@@ -37,6 +47,9 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    # actions/stale finishes in seconds; cap the job so a hung GitHub API call or
+    # rate-limit wait can't hold a runner up to the 6-hour default.
+    timeout-minutes: 10
     steps:
       - name: Mint fleet App token
         id: app-token
@@ -45,8 +58,12 @@ jobs:
         with:
           app-id: ${{ secrets.FLEET_APP_ID }}
           private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
-          owner: atlanhq
-          repositories: ${{ github.event.repository.name }}
+          # No owner/repositories: with both omitted, create-github-app-token
+          # scopes the token to the current repository. Callers trigger this
+          # on: schedule, whose event payload does not populate
+          # github.event.repository, so deriving the repo name from the event
+          # would resolve empty -- the current-repo default is reliable on any
+          # event and is exactly the scope this job needs.
 
       - name: Mark stale issues and PRs
         uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10


### PR DESCRIPTION
The conformance bootstrap's `stale.yml` template (and 30+ real app repos scaffolded from it — confirmed via org-wide `gh search code`) calls `uses: atlanhq/application-sdk/.github/workflows/stale.yml@main` — but this file has **never existed** in application-sdk (empty git history). Confirmed via a real production repo (`atlan-mysql-app`): this workflow has been failing with a startup error, silently, every week, for months.

**Fix**: create the missing reusable workflow. Mirrors this repo's own stale job (`schedule.yaml`), including `debug-only: true` — a deliberate choice, not an oversight: activating this for the first time across the whole fleet with real closure enabled could immediately close a large accumulated backlog of issues/PRs across 30+ repos that have never had this actually run. Once this settles in as observe-only for a bit, flipping to real closure fleet-wide is a separate, easy follow-up.

Mints a fleet App token for consistency with the rest of this migration, falling back to the default `GITHUB_TOKEN`. In practice the fallback is what runs today for every existing caller (none currently pass `secrets: inherit`), which is fine — this job needs no special identity, cross-repo access, or re-fire property, so `GITHUB_TOKEN` is sufficient on its own.

## Test plan
- [x] YAML validated
- [x] `pre-commit` clean
- [x] Confirmed the file has never existed (`git log --all`) and confirmed real failures in production (`atlan-mysql-app`'s actual run history) before writing the fix