### PR TITLE
ci(renovate): add self-hosted OSS Renovate fleet runner (Model A, dormant)

### DIFF
--- a/.github/scripts/discover_org_consumers.py
+++ b/.github/scripts/discover_org_consumers.py
@@ -67,9 +67,23 @@ def main(argv: Optional[list] = None, run: RunFn = _run_gh) -> int:
         required=True,
         help="gh search code query, e.g. 'atlan-application-sdk filename:pyproject.toml'",
     )
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=None,
+        metavar="OWNER/REPO",
+        help="Repo (owner/repo) to drop from the discovered list; repeatable. "
+        "Used to keep a repo on a different Renovate engine — e.g. the "
+        "self-hosted fleet runner excludes atlanhq/application-sdk, which stays "
+        "on the Mend-hosted app.",
+    )
     args = parser.parse_args(argv)
 
     repos = discover_repos(args.owner, args.query, run=run)
+
+    excluded = set(args.exclude or [])
+    if excluded:
+        repos = [r for r in repos if r not in excluded]
 
     if not repos:
         print(

--- a/.github/scripts/renovate_pkl_sync.py
+++ b/.github/scripts/renovate_pkl_sync.py
@@ -12,8 +12,11 @@ Two responsibilities:
      (``app/generated/**`` + ``atlan.yaml`` / ``app.yaml``) via ``pkl eval`` so
      a toolkit bump that changes generated output lands as a self-contained PR.
 
-Then it stages and commits whatever changed; the caller workflow runs
-``git push``.
+Then, unless ``--no-commit`` is passed, it stages and commits whatever changed;
+the caller workflow runs ``git push``. With ``--no-commit`` it generates only and
+leaves staging/commit to the caller — used by Renovate's ``postUpgradeTasks``,
+which commits the ``fileFilters`` matches into the upgrade branch itself. A repo
+with no ``contract/PklProject`` is a safe no-op (nothing to resolve).
 
 Why this is a script and not inlined YAML: it carries all the conditional
 logic (opt-in gate, missing-contract skip, eval-failure fallback,
@@ -251,11 +254,37 @@ def main(argv: list[str] | None = None) -> int:
         help="'true' (default) to also regenerate app/generated/** via pkl "
         "eval; 'false' to re-resolve the lock only.",
     )
+    parser.add_argument(
+        "--no-commit",
+        action="store_true",
+        help="Generate/re-resolve artifacts but do NOT git-add or commit them. "
+        "Use when the caller commits the changed files itself — e.g. Renovate's "
+        "postUpgradeTasks, which stages whatever the `fileFilters` match into the "
+        "upgrade branch. Without this flag the driver stages and commits (the "
+        "GitHub Actions glue-workflow behaviour).",
+    )
     args = parser.parse_args(argv)
     regenerate_enabled = args.regenerate == "true"
 
+    # Safe no-op on any repo/branch without a Pkl contract. Under Renovate the
+    # postUpgradeTask is scoped to the app-contract-toolkit manager, but
+    # executionMode=branch still invokes this once per matched branch, and a
+    # contract-less repo (application-sdk itself, or an app with no contract/)
+    # has no PklProject to resolve. Bail before `pkl project resolve`, which is
+    # fatal on a missing project — a contract-less repo must never fail the task.
+    pkl_project = Path(args.contract_dir) / "PklProject"
+    if not pkl_project.exists():
+        print(f"::notice::No {pkl_project} — nothing to sync (skipped).")
+        return 0
+
     resolve(args.contract_dir)
     regenerated = regenerate(args.contract_dir) if regenerate_enabled else False
+    if args.no_commit:
+        # Renovate commits the fileFilters matches itself; the driver only
+        # generates. Leaving git untouched here also keeps the git identity /
+        # commit-message concern entirely on the caller side.
+        print("--no-commit: staging and commit left to the caller.")
+        return 0
     message = COMMIT_MESSAGE_REGEN if regenerated else COMMIT_MESSAGE_LOCK_ONLY
     stage_and_commit(message)
     return 0

--- a/.github/scripts/tests/test_discover_org_consumers.py
+++ b/.github/scripts/tests/test_discover_org_consumers.py
@@ -103,6 +103,23 @@ def test_main_writes_github_output(tmp_path, monkeypatch, capsys):
     assert "Discovered 1 consumer repos" in err
 
 
+def test_main_excludes_named_repos(tmp_path, monkeypatch):
+    output_file = tmp_path / "github_output"
+    output_file.write_text("")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+    def fake_run(args):
+        return '["atlanhq/application-sdk", "atlanhq/atlan-mysql-app"]'
+
+    rc = doc.main(
+        ["--owner", "atlanhq", "--query", "q", "--exclude", "atlanhq/application-sdk"],
+        run=fake_run,
+    )
+    assert rc == 0
+    # application-sdk (stays on Mend) is dropped; the app repo remains.
+    assert output_file.read_text() == 'repos=["atlanhq/atlan-mysql-app"]\n'
+
+
 def test_main_warns_when_no_repos_discovered(tmp_path, monkeypatch, capsys):
     output_file = tmp_path / "github_output"
     output_file.write_text("")

--- a/.github/scripts/tests/test_renovate_pkl_sync.py
+++ b/.github/scripts/tests/test_renovate_pkl_sync.py
@@ -7,6 +7,8 @@ in renovate-pkl-sync.yaml:
   * --regenerate true, eval OK   -> artifacts regenerated + committed
   * --regenerate true, eval fails -> degrade to lock-only, artifacts untouched
   * no contract/app.pkl -> skip regeneration (re-resolve only)
+  * no contract/PklProject -> whole run is a safe no-op (no pkl, no commit)
+  * --no-commit         -> regenerate in-tree but leave staging/commit to caller
   * nothing changed     -> no commit
 
 `pkl` and `uvx` are stubbed; `git` runs for real against a throwaway repo in
@@ -50,6 +52,14 @@ def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """A throwaway repo with a contract, a committed (stale) lock, and stale
     generated artifacts — the state of a Renovate branch before sync."""
     (tmp_path / "contract").mkdir()
+    (tmp_path / "contract" / "PklProject").write_text(
+        'amends "pkl:Project"\n'
+        "dependencies {\n"
+        '  ["app-contract-toolkit"] {\n'
+        '    uri = "package://atlanhq.github.io/application-sdk/contracts/app-contract-toolkit@0.14.1"\n'
+        "  }\n"
+        "}\n"
+    )
     (tmp_path / "contract" / "app.pkl").write_text(
         'amends "@app-contract-toolkit/App.pkl"\n'
     )
@@ -288,6 +298,41 @@ def test_no_changes_makes_no_commit(repo, monkeypatch):
     assert mod.main(["--regenerate", "false"]) == 0
 
     assert _commit_count(repo) == before  # no new commit
+
+
+def test_no_commit_regenerates_but_does_not_commit(repo, monkeypatch):
+    """--no-commit: artifacts are re-resolved/regenerated in the working tree
+    but the driver makes NO git commit — Renovate's postUpgradeTasks stages the
+    fileFilters matches into the branch itself."""
+    monkeypatch.setattr(mod, "run", _make_fake_run(repo, eval_rc=0))
+    before = _commit_count(repo)
+
+    assert mod.main(["--regenerate", "true", "--no-commit"]) == 0
+
+    # Working tree WAS updated ...
+    assert (repo / "app" / "generated" / "manifest.json").read_text() == FRESH_MANIFEST
+    assert (repo / "atlan.yaml").exists()
+    assert "0.14.2" in (repo / "contract" / "PklProject.deps.json").read_text()
+    # ... but nothing was committed (the changes sit unstaged for the caller).
+    assert _commit_count(repo) == before
+
+
+def test_missing_pkl_project_is_noop(repo, monkeypatch):
+    """A repo/branch with no contract/PklProject is a safe no-op: the driver
+    returns 0 without invoking `pkl project resolve` (which would be fatal) and
+    without committing."""
+    (repo / "contract" / "PklProject").unlink()
+    before = _commit_count(repo)
+
+    def fail_if_called(cmd, *, check=False):
+        if cmd[0] == "pkl":
+            pytest.fail(f"pkl must not run when PklProject is absent: {cmd}")
+        return subprocess.run(cmd, check=check, text=True, capture_output=True)
+
+    monkeypatch.setattr(mod, "run", fail_if_called)
+
+    assert mod.main(["--regenerate", "true"]) == 0
+    assert _commit_count(repo) == before
 
 
 def test_format_generated_covers_all_py_not_just_input(tmp_path, monkeypatch):

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -45,9 +45,20 @@ jobs:
   discover:
     name: Discover consumer repos
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       repos: ${{ steps.discover.outputs.repos }}
     steps:
+      # Fail-fast on an accidental unscoped live dispatch: a live run
+      # (dry_run != 'full') with no `repos` scope would fan out real PRs across
+      # the entire discovered fleet. Scheduled runs are unaffected — they carry
+      # the safe 'full' default. Remove this guard when the fleet goes live.
+      - name: Guard against unscoped live dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run != 'full' && inputs.repos == '' }}
+        run: |
+          echo "::error::Refusing an unscoped live run (dry_run='${{ inputs.dry_run }}', empty 'repos'): this would open live PRs across the entire discovered fleet. Scope the 'repos' input to a pilot set, or use dry_run='full'."
+          exit 1
+
       - name: Mint fleet App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
@@ -75,6 +86,9 @@ jobs:
     # discovered fleet. Ternary lives in a GitHub expression; no shell branching.
     if: ${{ (inputs.repos != '' && inputs.repos != '[]') || needs.discover.outputs.repos != '[]' }}
     runs-on: ubuntu-latest
+    # Cap a hung renovate/gh call so a stuck matrix job frees the runner well
+    # before GitHub's 6h default rather than occupying it for hours.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       # Cap concurrency to keep the shared fleet-App GitHub API budget under the
@@ -136,6 +150,9 @@ jobs:
           # Resolves ${SDK_SCRIPTS} in the shared preset's postUpgradeTasks command.
           SDK_SCRIPTS: ${{ github.workspace }}/.github/scripts
           LOG_LEVEL: debug
+          # Pass the matrix repo through the environment rather than interpolating
+          # it into the shell string, so the value can never be parsed as shell.
+          TARGET_REPO: ${{ matrix.repo }}
         # Positional arg = the single repository this job handles. The consumer's
         # own renovate.json (extending renovate-config/default.json) is read as usual.
-        run: renovate "${{ matrix.repo }}"
+        run: renovate "$TARGET_REPO"

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,141 @@
+name: Renovate (self-hosted fleet runner)
+
+# Central OSS Renovate runner for the atlan-*-app fleet — the replacement for
+# the free Mend-hosted app. Discovers consumers, then runs the OSS Renovate CLI
+# once per repo (matrix) authenticated as the atlan-app-fleet App.
+#
+# Why runner-native (npm i -g renovate) rather than the containerised
+# renovatebot/github-action: postUpgradeTasks and Renovate's NATIVE uv.lock
+# updates both execute in Renovate's own environment. Running on the runner lets
+# us provide the toolchain (uv, pkl, python, ruff) with the same steps the old
+# renovate-pkl-sync.yaml glue used, instead of baking a custom Renovate image.
+#
+# SAFE BY DEFAULT: dry_run defaults to 'full', so scheduled runs and an
+# un-parameterised dispatch make NO changes (no PRs, no commits). Going live:
+#   * pilot   — dispatch with dry_run='null' and repos scoped to a repo or two;
+#   * fleet   — flip the schedule default to 'null' (a one-line change) once the
+#               Mend app is uninstalled. See the Model A rollout plan, steps 4-9.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Renovate dry-run mode. 'full' = no changes (default, safe); 'null' = live (open/update PRs)."
+        type: choice
+        options: ["full", "lookup", "null"]
+        default: "full"
+      repos:
+        description: 'Optional JSON array of "owner/repo" to scope the run (pilot). Empty = full discovered fleet.'
+        type: string
+        default: ""
+  schedule:
+    # Baseline cadence. Best-effort (GitHub may delay scheduled runs under load);
+    # on-demand immediacy comes from the release fan-out that dispatches this
+    # workflow from tag-and-publish.yaml / contract-toolkit-publish.yml.
+    - cron: "0 */4 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: renovate-fleet
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    name: Discover consumer repos
+    runs-on: ubuntu-latest
+    outputs:
+      repos: ${{ steps.discover.outputs.repos }}
+    steps:
+      - name: Mint fleet App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Discover atlan-application-sdk consumers
+        id: discover
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          python3 .github/scripts/discover_org_consumers.py \
+            --owner atlanhq \
+            --query "atlan-application-sdk filename:pyproject.toml" \
+            --exclude atlanhq/application-sdk
+
+  renovate:
+    name: Renovate ${{ matrix.repo }}
+    needs: [discover]
+    # Run when there is at least one repo — either the pilot `repos` input or the
+    # discovered fleet. Ternary lives in a GitHub expression; no shell branching.
+    if: ${{ (inputs.repos != '' && inputs.repos != '[]') || needs.discover.outputs.repos != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # Cap concurrency to keep the shared fleet-App GitHub API budget under the
+      # 15k/hr ceiling during a full-fleet sweep (see Model A scaling notes).
+      max-parallel: 10
+      matrix:
+        # Pilot scope (`repos` input) when provided, else the discovered fleet.
+        # `&&`/`||` short-circuit, so fromJson is never called on an empty string.
+        repo: ${{ (inputs.repos != '' && fromJson(inputs.repos)) || fromJson(needs.discover.outputs.repos) }}
+    env:
+      # 'full' (default) makes no changes. Overridden per-dispatch via the input;
+      # scheduled runs inherit the safe default until the fleet goes live.
+      RENOVATE_DRY_RUN: ${{ inputs.dry_run || 'full' }}
+    steps:
+      - name: Mint fleet App token
+        id: app-token
+        # Owner-scoped (not per-repo): mirrors reusable-renovate-dispatch.yaml.
+        # Each matrix job mints its own token, so API budgets stay isolated.
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+
+      # application-sdk itself — provides the pkl-sync driver (SDK_SCRIPTS) and
+      # the self-hosted admin config. Renovate clones each target repo into its
+      # own base dir (a temp dir), so this checkout is never disturbed.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Provides `uv`/`uvx` — used by Renovate's native uv manager to refresh
+      # uv.lock AND by the driver's `uvx ruff` formatting of generated Python.
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+
+      - name: Install pkl
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/pkl \
+            "https://github.com/apple/pkl/releases/download/0.27.2/pkl-linux-amd64"
+          chmod +x /tmp/pkl
+          sudo mv /tmp/pkl /usr/local/bin/pkl
+
+      # Renovate 43 requires Node >=24.11 — newer than the ubuntu-latest default,
+      # so pin the runtime explicitly rather than relying on the preinstalled one.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      - name: Install Renovate CLI
+        # Exact pin for reproducibility; bump deliberately (Renovate releases
+        # multiple times a week). Keep in step with the setup-node version above.
+        run: npm install -g renovate@43.265.3
+
+      - name: Run Renovate
+        env:
+          RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Admin config: platform, autodiscover=false, allowedPostUpgradeCommands,
+          # and customEnvVariables (which surfaces SDK_SCRIPTS to postUpgradeTasks).
+          RENOVATE_CONFIG_FILE: ${{ github.workspace }}/renovate-config/self-hosted.js
+          # Resolves ${SDK_SCRIPTS} in the shared preset's postUpgradeTasks command.
+          SDK_SCRIPTS: ${{ github.workspace }}/.github/scripts
+          LOG_LEVEL: debug
+        # Positional arg = the single repository this job handles. The consumer's
+        # own renovate.json (extending renovate-config/default.json) is read as usual.
+        run: renovate "${{ matrix.repo }}"

--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -48,7 +48,7 @@
       "enabled": false
     },
     {
-      "description": "app-contract-toolkit (Pkl): minor+patch in one PR; auto-merge on green. Matched by the regex customManager below.",
+      "description": "app-contract-toolkit (Pkl): minor+patch in one PR; auto-merge on green. Matched by the regex customManager below. postUpgradeTasks re-resolves contract/PklProject.deps.json and regenerates app/generated/** (+ atlan.yaml/app.yaml) in-branch via the shared renovate_pkl_sync.py driver, so the bump lands as a self-contained PR with no follow-up glue workflow. Runs ONLY under self-hosted Renovate: postUpgradeTasks commands are gated by the allowedPostUpgradeCommands admin allowlist (set in application-sdk's central renovate workflow), so this block is an inert no-op under the Mend-hosted app. SDK_SCRIPTS is injected via the admin config's customEnvVariables and points at the checked-out .github/scripts; --no-commit leaves the fileFilters commit to Renovate.",
       "matchManagers": [
         "custom.regex"
       ],
@@ -62,7 +62,19 @@
       "platformAutomerge": true,
       "addLabels": [
         "contract-toolkit-update"
-      ]
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "python3 \"${SDK_SCRIPTS}/renovate_pkl_sync.py\" --contract-dir contract --regenerate true --no-commit"
+        ],
+        "fileFilters": [
+          "contract/PklProject.deps.json",
+          "app/generated/**",
+          "atlan.yaml",
+          "app.yaml"
+        ],
+        "executionMode": "branch"
+      }
     },
     {
       "description": "app-contract-toolkit: disable major bumps.",

--- a/renovate-config/self-hosted.js
+++ b/renovate-config/self-hosted.js
@@ -13,9 +13,10 @@
 module.exports = {
   platform: "github",
 
-  // The matrix passes exactly one "owner/repo" per job via RENOVATE_REPOSITORIES.
-  // Never autodiscover: it is unreliable with GitHub App installation tokens, and
-  // an explicit per-job repo keeps each run's GitHub API budget isolated.
+  // The matrix passes exactly one "owner/repo" per job as a positional CLI
+  // argument (`renovate "$TARGET_REPO"`). Never autodiscover: it is unreliable
+  // with GitHub App installation tokens, and an explicit per-job repo keeps each
+  // run's GitHub API budget isolated.
   autodiscover: false,
 
   // Disable the github-actions manager for the fleet run. GitHub requires an App

--- a/renovate-config/self-hosted.js
+++ b/renovate-config/self-hosted.js
@@ -1,0 +1,53 @@
+// Self-hosted (admin) Renovate config for the central fleet runner defined in
+// .github/workflows/renovate.yaml.
+//
+// Everything here is an ADMIN-ONLY option — it can never be set from a
+// repository's renovate.json, by design. That restriction is exactly why the
+// fleet has to leave the Mend-hosted app to run postUpgradeTasks: the
+// allowedPostUpgradeCommands allowlist below only exists for a runner we own.
+//
+// Consumed via RENOVATE_CONFIG_FILE. Per-repo upgrade policy still lives in each
+// consumer's renovate.json (which extends renovate-config/default.json); this
+// file carries only the trust/execution settings the runner itself must own.
+
+module.exports = {
+  platform: "github",
+
+  // The matrix passes exactly one "owner/repo" per job via RENOVATE_REPOSITORIES.
+  // Never autodiscover: it is unreliable with GitHub App installation tokens, and
+  // an explicit per-job repo keeps each run's GitHub API budget isolated.
+  autodiscover: false,
+
+  // Disable the github-actions manager for the fleet run. GitHub requires an App
+  // token to hold `workflows: write` to modify any file under .github/workflows/,
+  // and the atlan-app-fleet App deliberately does NOT hold it (fleet-wide
+  // workflow-write is a supply-chain surface we don't want). Instead, app repos'
+  // workflow/action pins are owned by the bootstrap pipeline and propagated from
+  // the application-sdk templates — a push, not a per-repo Renovate PR. So the
+  // fleet runner needs only contents + pull-requests write.
+  //
+  // Manager-level disable (not an enabledManagers allowlist, which would risk
+  // silently dropping a manager we forgot to list; and not a packageRule
+  // enabled:false, which the shared preset's github-actions rule would override
+  // on merge). A disabled manager never extracts, so no workflow file is touched.
+  "github-actions": { enabled: false },
+
+  // Authorize ONLY the pkl-sync driver as a post-upgrade command. (This option
+  // was renamed from `allowedPostUpgradeCommands` to `allowedCommands`.) The
+  // allowlist is matched against the raw command string in the shared preset's
+  // postUpgradeTasks (before ${SDK_SCRIPTS} expansion). Child processes the
+  // driver itself spawns (pkl, uvx ruff, git) need no entry here — the allowlist
+  // vets only the top-level commands Renovate is asked to run.
+  allowedCommands: [
+    '^python3 ".*/renovate_pkl_sync\\.py" --contract-dir contract --regenerate (true|false) --no-commit$',
+  ],
+
+  // Resolves the ${SDK_SCRIPTS} reference in the preset's postUpgradeTasks
+  // command to the checked-out application-sdk/.github/scripts directory. The
+  // workflow exports SDK_SCRIPTS before invoking renovate; the `|| ""` keeps
+  // this a string (Renovate rejects a non-string customEnvVariables value) if
+  // the config is ever loaded without it set (e.g. renovate-config-validator).
+  customEnvVariables: {
+    SDK_SCRIPTS: process.env.SDK_SCRIPTS || "",
+  },
+};


### PR DESCRIPTION
## What

Adds a central, self-hosted **OSS Renovate CLI** runner as the eventual replacement for the free Mend-hosted app across the `atlan-*-app` fleet (Model A). This is the **safe, additive first tranche** — everything here stays **inert** until deliberately activated, so merging changes nothing about the live dependency-update flow.

- **`.github/workflows/renovate.yaml`** — central runner: discover consumers → per-repo matrix run, authenticated as **atlan-app-fleet**. Runner-native (`npm i -g renovate@43.265.3` on Node 24 via pinned `setup-node`) so `postUpgradeTasks` and Renovate's native `uv.lock` updates share one toolchain (uv, pkl, python, ruff). **Safe by default:** `dry_run` defaults to `full` (no changes); scheduled runs inherit that until go-live.
- **`renovate-config/self-hosted.js`** — admin config (options that can't live in a repo): `allowedCommands` allowlist for the pkl-sync driver, `autodiscover: false`, and the **`github-actions` manager disabled** (see permissions note below).
- **`renovate-config/default.json`** — re-adds `postUpgradeTasks` (scoped to the `app-contract-toolkit` packageRule) to re-resolve the Pkl lock + regenerate `app/generated/**` in-branch. Authorised **only** under self-hosted Renovate — a no-op under the hosted app (which has no `allowedCommands`), exactly as before commit `1e8b0b8`.
- **`renovate_pkl_sync.py`** — new `--no-commit` (Renovate commits the `fileFilters` matches itself) + a no-op guard when `contract/PklProject` is absent. Existing retry/degrade/format logic reused unchanged.
- **`discover_org_consumers.py`** — new `--exclude` to drop repos kept on another engine.

## Why

The Mend-hosted app **cannot** run our pkl post-processing (`postUpgradeTasks` needs the self-hosted-only `allowedCommands`), which is why the `renovate-pkl-sync.yaml` glue CI exists. Self-hosting lets that post-processing run in-process and eventually retire the glue, and replaces the free hosted tier (1 concurrent job, 4h cadence) that won't scale to ~70-100 repos.

## Permissions — no new grant needed

`atlan-app-fleet` needs only **`contents:write` + `pull-requests:write`** (already held), **not `workflows:write`**. GitHub gates any App-token write under `.github/workflows/`, so instead of granting fleet-wide workflow-write, the **`github-actions` manager is disabled in the runner** — app repos' action pins stay owned by the **bootstrap pipeline** (propagated from application-sdk templates). `application-sdk` itself stays on Mend for now and is excluded from discovery.

## Safety

- Dormant under the current hosted app; merging is behaviourally inert.
- `dry_run=full` default means even an accidental dispatch/scheduled run makes no changes.
- Validated: `renovate-config-validator` passes both configs with zero warnings; 27 unit tests pass; pre-commit clean.

## Not in this PR (staged for after pilot)

Auto-approve author-gate flip (`renovate[bot]` → `atlan-app-fleet[bot]`), glue removal (`renovate-pkl-sync.yaml`, `reusable-renovate-dispatch.yaml`), release fan-out wiring, and Mend uninstall.

## Pilot (after merge)

```bash
# Smoke (no changes):
gh workflow run renovate.yaml --repo atlanhq/application-sdk \
  --field dry_run=full --field repos='["atlanhq/atlan-hello-world-app"]'
# Live (pause Mend on that repo first to avoid duplicate PRs):
gh workflow run renovate.yaml --repo atlanhq/application-sdk \
  --field dry_run=null --field repos='["atlanhq/atlan-hello-world-app"]'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)