### PR TITLE
fix(handler): resolve flat single-entrypoint configmap for app-id requests (fleet-wide blank setup wizard)

### DIFF
--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -1742,19 +1742,39 @@ def _register_workflow_routes(
                 )
                 ep = None
             if ep is not None:
-                # Form configmaps for an entrypoint live under
-                # CONTRACT_GENERATED_DIR/<ep.name>/ (see EntryPointMetadata
-                # docstring: kebab name on the wire and on disk). Pick the
-                # form file by excluding the two well-known non-form siblings:
-                # `manifest.json` (DAG manifest) and `atlan-connectors-*.json`
-                # (credential template). Sorted for determinism.
-                entrypoint_dir = CONTRACT_GENERATED_DIR / ep.name
-                if entrypoint_dir.is_dir():
-                    for json_file in sorted(entrypoint_dir.glob("*.json")):
+                # Locate the entrypoint's form configmap across BOTH generated
+                # layouts:
+                #   * multi-entrypoint (bundle) apps nest each entrypoint's form
+                #     under CONTRACT_GENERATED_DIR/<ep.name>/ (see
+                #     EntryPointMetadata: kebab name on the wire and on disk);
+                #   * single-entrypoint apps emit it FLAT in CONTRACT_GENERATED_DIR
+                #     itself (e.g. `openapi.json` alongside `manifest.json`).
+                # Search the nested dir first, then fall back to the flat dir, so
+                # an app-id request (e.g. "atlan-openapi", which the marketplace
+                # UI builds instead of the form stem) resolves for either shape.
+                # Previously only the nested layout was searched, so a flat
+                # single-entrypoint app 404'd on an app-id request even though its
+                # form file was present — a blank setup wizard in the UI.
+                #
+                # Pick the form file by excluding the well-known non-form
+                # siblings: `manifest.json` (DAG manifest) and the
+                # `{atlan,csa}-connectors-*.json` credential templates. Sorted
+                # for determinism.
+                for search_dir in (
+                    CONTRACT_GENERATED_DIR / ep.name,
+                    CONTRACT_GENERATED_DIR,
+                ):
+                    if not search_dir.is_dir():
+                        continue
+                    for json_file in sorted(search_dir.glob("*.json")):
                         stem = json_file.stem
-                        if stem == "manifest" or stem.startswith("atlan-connectors-"):
+                        if stem == "manifest" or stem.startswith(
+                            ("atlan-connectors-", "csa-connectors-")
+                        ):
                             continue
                         target = json_file
+                        break
+                    if target is not None:
                         break
 
         if target is not None:

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -405,6 +405,21 @@ _storage: ObjectStore | None = None
 # Directory where generated contract JSON files are stored
 CONTRACT_GENERATED_DIR = Path(_CONTRACT_GENERATED_DIR)
 
+# Non-form JSON siblings that live in CONTRACT_GENERATED_DIR next to the
+# generated setup-form configmaps. Credential templates are emitted per
+# object-store family (`atlan-connectors-*.json`, `csa-connectors-*.json`).
+# Centralised so the form-discovery exclusion vocabulary is named in one place
+# instead of re-spelled inline (adding the next connector family prefix here
+# then covers every form-discovery site).
+_CREDENTIAL_TEMPLATE_PREFIXES = ("atlan-connectors-", "csa-connectors-")
+
+
+def _is_form_configmap(stem: str) -> bool:
+    """True when a generated JSON stem is a setup-form configmap, i.e. neither
+    the DAG ``manifest`` nor a credential template."""
+    return stem != "manifest" and not stem.startswith(_CREDENTIAL_TEMPLATE_PREFIXES)
+
+
 # Allowlist regex for entrypoint names: letter-start, then letters/digits/hyphens/underscores.
 # Identical to the @entrypoint decorator constraint. Used as a path-traversal guard
 # in get_manifest() before any filesystem path is constructed.
@@ -1757,9 +1772,9 @@ def _register_workflow_routes(
                 # form file was present — a blank setup wizard in the UI.
                 #
                 # Pick the form file by excluding the well-known non-form
-                # siblings: `manifest.json` (DAG manifest) and the
-                # `{atlan,csa}-connectors-*.json` credential templates. Sorted
-                # for determinism.
+                # siblings (`manifest.json` and the `{atlan,csa}-connectors-*`
+                # credential templates) via `_is_form_configmap`. Sorted for
+                # determinism.
                 for search_dir in (
                     CONTRACT_GENERATED_DIR / ep.name,
                     CONTRACT_GENERATED_DIR,
@@ -1767,10 +1782,7 @@ def _register_workflow_routes(
                     if not search_dir.is_dir():
                         continue
                     for json_file in sorted(search_dir.glob("*.json")):
-                        stem = json_file.stem
-                        if stem == "manifest" or stem.startswith(
-                            ("atlan-connectors-", "csa-connectors-")
-                        ):
+                        if not _is_form_configmap(json_file.stem):
                             continue
                         target = json_file
                         break

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -409,8 +409,10 @@ CONTRACT_GENERATED_DIR = Path(_CONTRACT_GENERATED_DIR)
 # generated setup-form configmaps. Credential templates are emitted per
 # object-store family (`atlan-connectors-*.json`, `csa-connectors-*.json`).
 # Centralised so the form-discovery exclusion vocabulary is named in one place
-# instead of re-spelled inline (adding the next connector family prefix here
-# then covers every form-discovery site).
+# instead of re-spelled inline; `_is_form_configmap` applies it in the
+# get_configmap default-entrypoint fallback, so adding the next connector-family
+# prefix here updates that site without re-spelling the list. `list_configmaps`
+# still uses its own `manifest`-only exclusion (a separate, deliberate decision).
 _CREDENTIAL_TEMPLATE_PREFIXES = ("atlan-connectors-", "csa-connectors-")
 
 

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -1972,6 +1972,60 @@ class TestConfigMapEndpoints:
         finally:
             svc_module.CONTRACT_GENERATED_DIR = original
 
+    def test_configmap_default_fallback_serves_flat_single_entrypoint_form(
+        self, tmp_path: Path
+    ) -> None:
+        """App-id request resolves a FLAT single-entrypoint form configmap.
+
+        Single-entrypoint apps emit their form flat in CONTRACT_GENERATED_DIR
+        (e.g. ``openapi.json`` beside ``manifest.json``), not nested under an
+        ``<ep.name>/`` dir like multi-entrypoint bundles. The marketplace UI
+        requests the configmap by app-id (``atlan-openapi``), which never
+        matches the flat form stem (``openapi``), so the handler must fall
+        through the default-entrypoint search into the FLAT dir.
+
+        Regression: previously only the nested ``<ep.name>/`` dir was searched,
+        so a flat single-entrypoint app returned 404 and its setup wizard
+        rendered blank even though the form was present (observed in prod:
+        ``ConfigMap not found: requested=atlan-openapi
+        available=['manifest', 'openapi']``).
+        """
+        from application_sdk.app.base import App
+        from application_sdk.app.entrypoint import entrypoint
+        from application_sdk.handler import service as svc_module
+
+        class _OneEpApp(App):
+            @entrypoint
+            async def crawler(self, input: _RoutingInput) -> _RoutingOutput:
+                return _RoutingOutput()
+
+        # Flat layout: form + manifest + a credential template at the ROOT, with
+        # NO per-entrypoint subdir. The credential file sorts before the form
+        # (c < o) and must be skipped — exercising the csa-connectors- exclusion.
+        (tmp_path / "manifest.json").write_text(json.dumps({"dag": {}}))
+        (tmp_path / "csa-connectors-objectstore.json").write_text(
+            json.dumps({"config": {"key": "credential-schema"}})
+        )
+        (tmp_path / "openapi.json").write_text(
+            json.dumps({"config": {"key": "flat-form"}})
+        )
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            svc = create_app_handler_service(
+                _TestHandler(), app_name="openapi", app_class=_OneEpApp
+            )
+            client = TestClient(svc, raise_server_exceptions=False)
+            response = client.get("/workflows/v1/configmap/atlan-openapi")
+            assert response.status_code == 200
+            data = response.json()["data"]
+            assert data["metadata"]["name"] == "atlan-openapi"
+            parsed_config = json.loads(data["data"]["config"])
+            assert parsed_config["key"] == "flat-form"
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
     def test_configmap_default_fallback_returns_404_when_only_excluded_files(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -2026,6 +2026,54 @@ class TestConfigMapEndpoints:
         finally:
             svc_module.CONTRACT_GENERATED_DIR = original
 
+    def test_configmap_default_fallback_prefers_nested_over_flat_form(
+        self, tmp_path: Path
+    ) -> None:
+        """Nested ``<ep.name>/`` form wins over a flat sibling for the same app.
+
+        Pins the documented search order in :func:`get_configmap`: the
+        default-entrypoint fallback searches the nested per-entrypoint dir
+        BEFORE the flat ``CONTRACT_GENERATED_DIR``. Without both layouts present
+        in one test, swapping the two ``search_dir`` candidates (flat before
+        nested) would pass the whole suite, since the flat and nested regression
+        tests each supply only one layout.
+        """
+        from application_sdk.app.base import App
+        from application_sdk.app.entrypoint import entrypoint
+        from application_sdk.handler import service as svc_module
+
+        class _OneEpApp(App):
+            @entrypoint
+            async def crawler(self, input: _RoutingInput) -> _RoutingOutput:
+                return _RoutingOutput()
+
+        # Both layouts present for the same app-id request: a nested
+        # per-entrypoint form (ep.name == "crawler") and a flat form at the
+        # root. The nested one must win.
+        nested_dir = tmp_path / "crawler"
+        nested_dir.mkdir()
+        (nested_dir / "openapi.json").write_text(
+            json.dumps({"config": {"key": "nested-form"}})
+        )
+        (tmp_path / "manifest.json").write_text(json.dumps({"dag": {}}))
+        (tmp_path / "openapi.json").write_text(
+            json.dumps({"config": {"key": "flat-form"}})
+        )
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            svc = create_app_handler_service(
+                _TestHandler(), app_name="openapi", app_class=_OneEpApp
+            )
+            client = TestClient(svc, raise_server_exceptions=False)
+            response = client.get("/workflows/v1/configmap/atlan-openapi")
+            assert response.status_code == 200
+            parsed_config = json.loads(response.json()["data"]["data"]["config"])
+            assert parsed_config["key"] == "nested-form"
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
     def test_configmap_default_fallback_returns_404_when_only_excluded_files(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary

Single-entrypoint connectors that use the plain `App` base with a `run()` override render a **blank setup wizard** — the deployed app 404s the form request. Confirmed on the `developer-experience` tenant across **two** apps and spreading:

| App | Base class | Toolkit | SDK | `GET /configmap/atlan-<name>` |
|---|---|---|---|---|
| mysql v2.0.2 | `MySQLApp(SqlApp)` | 0.18.1 | 3.22.0 | **200** ✅ |
| metabase v2.2.1 | `MetabaseApp(App)` | 0.18.2 | 3.22.1 | **404** ❌ |
| openapi v0.5.1 | `OpenAPIConnector(App)` | 0.18.2 | 3.22.1 | **404** ❌ |

## Root cause (not a version regression)
The tenant UI requests the form by app-id (`GET /workflows/v1/configmap/atlan-<name>`). `get_configmap`'s app-id fallback resolves the default entrypoint and looks for the form **only** under a nested `CONTRACT_GENERATED_DIR/<ep.name>/` dir.

For a single-entrypoint app that overrides `run()`, the implicit entrypoint's name is **hardcoded to `"run"`** (`application_sdk/app/_ep_registration.py`). So the fallback looks in `app/generated/run/` — which **does not exist**, because single-entrypoint apps emit the form flat (`app/generated/<name>.json` beside `manifest.json`). → 404, though the form file is present:

```
ConfigMap not found: requested=atlan-openapi  available=['manifest', 'openapi']
ConfigMap not found: requested=atlan-metabase available=['atlan-connectors-metabase', 'manifest', 'metabase']
```

This is **not** an SDK-version or toolkit-version regression — verified:
- `handler/service.py`, `_ep_registration.py`, `entrypoint.py` are byte-identical across SDK 3.22.0↔3.22.1 (the only `app/` change between them is unrelated workflow-input validation).
- contract-toolkit 0.18.1↔0.18.2 differs only by an orjson import in generated `_input.py` — no layout change.

The nested-only fallback was written for **multi-entrypoint bundles** (snowflake `crawler/`,`miner/`). The **flat single-entrypoint layout was never handled** by the app-id path, and no test covered it — a latent gap now being hit as apps migrate to the single-entrypoint `App`+`run()` shape (metabase's v2.2.1 docstring documents exactly that migration from a former two-`@entrypoint` shape). `SqlApp`-based apps (mysql) currently escape it via an app-class-specific runtime path; this fix makes flat resolution explicit and deterministic for all.

## Fix
After the nested `<ep.name>/` lookup misses, also search the flat `CONTRACT_GENERATED_DIR`, with the same exclusions (`manifest.json`, `{atlan,csa}-connectors-*.json`):

```python
for search_dir in (CONTRACT_GENERATED_DIR / ep.name, CONTRACT_GENERATED_DIR):
    if not search_dir.is_dir():
        continue
    for json_file in sorted(search_dir.glob("*.json")):
        stem = json_file.stem
        if stem == "manifest" or stem.startswith(("atlan-connectors-", "csa-connectors-")):
            continue
        target = json_file
        break
    if target is not None:
        break
```

**Strictly additive:** exact-stem match and the nested lookup run first and win where they apply; the flat branch only runs when both missed. Multi-entrypoint apps and stem requests are unaffected.

## Verification
- New regression test `test_configmap_default_fallback_serves_flat_single_entrypoint_form` — **fails (404) against the current handler, passes with this fix**; also asserts `csa-connectors-*` is skipped.
- 14 configmap tests + 277 handler tests pass; ruff/format clean; existing 404-guard tests unaffected.

## Urgency
This breaks **every** single-entrypoint `App`-based connector as it releases onto the current runtime (openapi + metabase already down; more will follow as they adopt the single-entrypoint shape). Recommend prioritizing the merge + an SDK release; affected apps pick it up on their next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)