### PR TITLE
ci(renovate): invoke pkl-sync driver as a PATH command in postUpgradeTasks

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -113,10 +113,17 @@ jobs:
           private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
           owner: atlanhq
 
-      # application-sdk itself — provides the pkl-sync driver (SDK_SCRIPTS) and
-      # the self-hosted admin config. Renovate clones each target repo into its
-      # own base dir (a temp dir), so this checkout is never disturbed.
+      # application-sdk itself — provides the pkl-sync driver and the self-hosted
+      # admin config. Renovate clones each target repo into its own base dir (a
+      # temp dir), so this checkout is never disturbed.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Install the pkl-sync driver as a bare PATH command. postUpgradeTasks
+      # commands are NOT shell-expanded by Renovate, so the preset invokes
+      # `renovate-pkl-sync` directly (no ${VAR} path to expand). The script's
+      # `#!/usr/bin/env python3` shebang makes it directly executable.
+      - name: Install pkl-sync driver on PATH
+        run: sudo install -m 0755 .github/scripts/renovate_pkl_sync.py /usr/local/bin/renovate-pkl-sync
 
       # Provides `uv`/`uvx` — used by Renovate's native uv manager to refresh
       # uv.lock AND by the driver's `uvx ruff` formatting of generated Python.
@@ -144,11 +151,9 @@ jobs:
       - name: Run Renovate
         env:
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
-          # Admin config: platform, autodiscover=false, allowedPostUpgradeCommands,
-          # and customEnvVariables (which surfaces SDK_SCRIPTS to postUpgradeTasks).
+          # Admin config: platform, autodiscover=false, allowedCommands allowlist,
+          # and the github-actions manager disable.
           RENOVATE_CONFIG_FILE: ${{ github.workspace }}/renovate-config/self-hosted.js
-          # Resolves ${SDK_SCRIPTS} in the shared preset's postUpgradeTasks command.
-          SDK_SCRIPTS: ${{ github.workspace }}/.github/scripts
           LOG_LEVEL: debug
           # Pass the matrix repo through the environment rather than interpolating
           # it into the shell string, so the value can never be parsed as shell.

--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -48,7 +48,7 @@
       "enabled": false
     },
     {
-      "description": "app-contract-toolkit (Pkl): minor+patch in one PR; auto-merge on green. Matched by the regex customManager below. postUpgradeTasks re-resolves contract/PklProject.deps.json and regenerates app/generated/** (+ atlan.yaml/app.yaml) in-branch via the shared renovate_pkl_sync.py driver, so the bump lands as a self-contained PR with no follow-up glue workflow. Runs ONLY under self-hosted Renovate: postUpgradeTasks commands are gated by the allowedPostUpgradeCommands admin allowlist (set in application-sdk's central renovate workflow), so this block is an inert no-op under the Mend-hosted app. SDK_SCRIPTS is injected via the admin config's customEnvVariables and points at the checked-out .github/scripts; --no-commit leaves the fileFilters commit to Renovate.",
+      "description": "app-contract-toolkit (Pkl): minor+patch in one PR; auto-merge on green. Matched by the regex customManager below. postUpgradeTasks re-resolves contract/PklProject.deps.json and regenerates app/generated/** (+ atlan.yaml/app.yaml) in-branch via the shared renovate-pkl-sync driver, so the bump lands as a self-contained PR with no follow-up glue workflow. Runs ONLY under self-hosted Renovate: postUpgradeTasks commands are gated by the allowedCommands admin allowlist (set in application-sdk's central renovate workflow), so this block is an inert no-op under the Mend-hosted app. The driver is installed as a bare PATH command by that workflow (Renovate does NOT shell-expand the command, so it must not contain ${VARS}); --no-commit leaves the fileFilters commit to Renovate.",
       "matchManagers": [
         "custom.regex"
       ],
@@ -65,7 +65,7 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "python3 \"${SDK_SCRIPTS}/renovate_pkl_sync.py\" --contract-dir contract --regenerate true --no-commit"
+          "renovate-pkl-sync --contract-dir contract --regenerate true --no-commit"
         ],
         "fileFilters": [
           "contract/PklProject.deps.json",

--- a/renovate-config/self-hosted.js
+++ b/renovate-config/self-hosted.js
@@ -34,21 +34,14 @@ module.exports = {
   "github-actions": { enabled: false },
 
   // Authorize ONLY the pkl-sync driver as a post-upgrade command. (This option
-  // was renamed from `allowedPostUpgradeCommands` to `allowedCommands`.) The
-  // allowlist is matched against the raw command string in the shared preset's
-  // postUpgradeTasks (before ${SDK_SCRIPTS} expansion). Child processes the
-  // driver itself spawns (pkl, uvx ruff, git) need no entry here — the allowlist
-  // vets only the top-level commands Renovate is asked to run.
+  // was renamed from `allowedPostUpgradeCommands` to `allowedCommands`.) It is
+  // matched against the raw command string in the shared preset's
+  // postUpgradeTasks. The command is a bare PATH executable with NO ${VARS}:
+  // Renovate does not shell-expand post-upgrade commands, so any ${VAR} would be
+  // passed literally (the pilot caught exactly that). The workflow installs the
+  // driver as /usr/local/bin/renovate-pkl-sync. Child processes the driver
+  // spawns (pkl, uvx ruff, git) need no entry — only top-level commands are vetted.
   allowedCommands: [
-    '^python3 ".*/renovate_pkl_sync\\.py" --contract-dir contract --regenerate (true|false) --no-commit$',
+    "^renovate-pkl-sync --contract-dir contract --regenerate (true|false) --no-commit$",
   ],
-
-  // Resolves the ${SDK_SCRIPTS} reference in the preset's postUpgradeTasks
-  // command to the checked-out application-sdk/.github/scripts directory. The
-  // workflow exports SDK_SCRIPTS before invoking renovate; the `|| ""` keeps
-  // this a string (Renovate rejects a non-string customEnvVariables value) if
-  // the config is ever loaded without it set (e.g. renovate-config-validator).
-  customEnvVariables: {
-    SDK_SCRIPTS: process.env.SDK_SCRIPTS || "",
-  },
 };


### PR DESCRIPTION
## What the pilot found

Piloting the self-hosted runner (#2758) on `atlan-hello-world-app` surfaced a real bug: **Renovate does not shell-expand `postUpgradeTasks` commands.** The previous command

```
python3 "${SDK_SCRIPTS}/renovate_pkl_sync.py" --contract-dir contract --regenerate true --no-commit
```

was passed **literally** to `python3`, which failed:

```
python3: can't open file '.../atlan-hello-world-app/${SDK_SCRIPTS}/renovate_pkl_sync.py': No such file or directory
```

The `deps.json` sync still appeared in the branch — but **only because the old `renovate-pkl-sync.yaml` glue workflow is still active** in the consumer repo and fired on the push, masking the failure. The bot's own commit contained just the pin bump.

## Fix

Make the command self-contained with **no variable expansion**:
- The workflow installs the driver as a bare PATH executable: `sudo install -m 0755 .github/scripts/renovate_pkl_sync.py /usr/local/bin/renovate-pkl-sync` (the script's `#!/usr/bin/env python3` shebang makes it directly runnable).
- `postUpgradeTasks` now invokes `renovate-pkl-sync --contract-dir contract --regenerate true --no-commit`.
- `allowedCommands` updated to match the bare command; `SDK_SCRIPTS` `customEnvVariables` + workflow env removed (no longer needed).

## Validation

`renovate-config-validator` passes both configs with zero warnings; pre-commit clean. A follow-up live pilot re-run (Mend paused on the pilot repo) will confirm `postUpgradeTasks` now regenerates `deps.json` into the bot's own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)