### PR TITLE
ci: validate atlan.yaml scalar types against chart schema

### DIFF
--- a/.github/scripts/config_validator.py
+++ b/.github/scripts/config_validator.py
@@ -17,6 +17,15 @@ Rules enforced:
   7. requests <= limits per resource.
   8. vpa.minAllowed         <= vpa.maxAllowed per resource.
   9. keda.minReplicaCount   <= keda.maxReplicaCount.
+ 10. Scalar fields the chart schema types strictly carry the declared type:
+     vpa.{min,max}Allowed.{cpu,memory}, resources.requests.{cpu,memory},
+     resources.limits.memory and applicationVersion must be strings;
+     keda.temporal.targetQueueSize must be an integer. A wrong scalar type
+     parses fine for rules 2-9 but fails the chart's values.schema.json at
+     Helm-apply time — blocking the release and freezing the TWD — so we catch
+     it in CI. resources.limits.cpu (schema allows integer|string) and the
+     serverResources/workerResources blocks (partly unconstrained) are
+     deliberately excluded to avoid false positives.
 
 Rules 4-7 hit `resources` always; `serverResources`/`workerResources` only when
 `splitDeploymentEnabled=true` (chart ignores them otherwise).
@@ -525,6 +534,88 @@ def _check_keda(cfg: dict) -> list[Violation]:
     return []
 
 
+# Scalar-type contract mirrored from the atlan-app chart's values.schema.json.
+# The chart's JSON schema rejects a wrong scalar type at Helm-apply time, which
+# blocks the release and (for TWC apps) freezes the worker deployment because
+# the TWD is never re-rendered. Catching it here fails the PR instead. Only
+# fields the chart types UNAMBIGUOUSLY are listed: resources.limits.cpu (schema
+# allows integer|string) and the server/workerResources blocks (partly
+# unconstrained) are omitted so we never flag a value the chart would accept.
+# Source of truth: atlan repo subcharts/atlan-app/values.schema.json.
+_STRING_TYPED_FIELDS: tuple[str, ...] = (
+    "applicationVersion",
+    "vpa.minAllowed.cpu",
+    "vpa.minAllowed.memory",
+    "vpa.maxAllowed.cpu",
+    "vpa.maxAllowed.memory",
+    "resources.requests.cpu",
+    "resources.requests.memory",
+    "resources.limits.memory",
+)
+_INT_TYPED_FIELDS: tuple[str, ...] = ("keda.temporal.targetQueueSize",)
+
+
+def _lookup(cfg: dict, path: str) -> tuple[Any, bool]:
+    """Resolve a dotted path. Returns (value, present); present is False when
+    any segment is missing or an intermediate node is not a mapping."""
+    node: Any = cfg
+    for part in path.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return None, False
+        node = node[part]
+    return node, True
+
+
+def _check_scalar_types(cfg: dict) -> list[Violation]:
+    """Type-check scalars the chart schema types strictly.
+
+    A bare `cpu: 4` (int) or a quoted `targetQueueSize: "25"` (str) satisfies
+    every magnitude rule but fails the chart's values.schema.json at deploy,
+    blocking the release. Emit invalid_type so it fails in CI instead. Kept
+    separate from the magnitude rules so those still run and report normally.
+    """
+    errs: list[Violation] = []
+    for path in _STRING_TYPED_FIELDS:
+        val, present = _lookup(cfg, path)
+        if not present or isinstance(val, str):
+            continue
+        leaf = path.rsplit(".", 1)[-1]
+        errs.append(
+            Violation(
+                field=path,
+                actual=val,
+                expected="string (quoted)",
+                rule="invalid_type",
+                fix=(
+                    f'Quote {path} as a string, e.g. {leaf}: "{val}". The chart '
+                    f"requires a string here; a bare {type(val).__name__} fails "
+                    "Helm schema validation at deploy time and blocks the release."
+                ),
+            )
+        )
+    for path in _INT_TYPED_FIELDS:
+        val, present = _lookup(cfg, path)
+        if not present:
+            continue
+        # bool is an int subclass — reject it explicitly (the chart schema does).
+        if isinstance(val, bool) or not isinstance(val, int):
+            errs.append(
+                Violation(
+                    field=path,
+                    actual=val,
+                    expected="integer (unquoted)",
+                    rule="invalid_type",
+                    fix=(
+                        f"Set {path} to an unquoted integer (got "
+                        f"{type(val).__name__}). The chart requires an integer "
+                        "here; the wrong type fails Helm schema validation at "
+                        "deploy time and blocks the release."
+                    ),
+                )
+            )
+    return errs
+
+
 def validate_config(config_yaml: Any, sdk_version: str | None = None) -> None:
     """Run all guardrail rules. Accepts YAML string or already-parsed dict.
 
@@ -568,6 +659,7 @@ def validate_config(config_yaml: Any, sdk_version: str | None = None) -> None:
     errs += bool_errs
     vpa_parsed, vpa_parse_errs = _parse_vpa(cfg)
     errs += vpa_parse_errs
+    errs += _check_scalar_types(cfg)
     errs += _check_split_requires_twc(cfg, bools, parsed_sdk)
     errs += _check_twc_sdk_floor(bools, parsed_sdk)
     errs += _check_vpa(cfg, vpa_parsed)

--- a/.github/scripts/tests/test_config_validator.py
+++ b/.github/scripts/tests/test_config_validator.py
@@ -749,7 +749,7 @@ class TestInvalidScalarType:
         # Chart schema types resources.limits.cpu as integer|string, so an int
         # here must NOT be flagged — mirroring the chart avoids false positives.
         validate_config(
-            'resources:\n'
+            "resources:\n"
             '  requests: {cpu: "1", memory: 1Gi}\n'
             "  limits:   {cpu: 2,   memory: 2Gi}\n"
         )

--- a/.github/scripts/tests/test_config_validator.py
+++ b/.github/scripts/tests/test_config_validator.py
@@ -130,7 +130,7 @@ workerResources:
 vpa:
   enabled: true
   maxAllowed:
-    cpu: 7
+    cpu: "7"
     memory: 27Gi
 """)
 
@@ -237,7 +237,7 @@ resources:
     def test_request_at_ceiling_passes(self):
         validate_config("""
 resources:
-  requests: {cpu: 7,    memory: 27Gi}
+  requests: {cpu: "7",  memory: 27Gi}
   limits:   {cpu: 7,    memory: 27Gi}
 """)
 
@@ -286,7 +286,7 @@ vpa:
   enabled: true
   updateMode: "Off"
 resources:
-  requests: {cpu: 3,    memory: 500Mi}
+  requests: {cpu: "3",  memory: 500Mi}
   limits:   {cpu: 3,    memory: 1Gi}
 """)
 
@@ -298,7 +298,7 @@ vpa:
   enabled: true
   updateMode: off
 resources:
-  requests: {cpu: 3,    memory: 500Mi}
+  requests: {cpu: "3",  memory: 500Mi}
   limits:   {cpu: 3,    memory: 1Gi}
 """)
 
@@ -365,9 +365,9 @@ resources:
         validate_config("""
 vpa:
   enabled: true
-  maxAllowed: {cpu: 5, memory: 20Gi}
+  maxAllowed: {cpu: "5", memory: 20Gi}
 resources:
-  requests: {cpu: 4,    memory: 16Gi}
+  requests: {cpu: "4",  memory: 16Gi}
   limits:   {cpu: 4,    memory: 20Gi}
 """)
 
@@ -392,7 +392,7 @@ resources:
 vpa:
   enabled: false
 resources:
-  requests: {cpu: 3,    memory: 500Mi}
+  requests: {cpu: "3",  memory: 500Mi}
   limits:   {cpu: 3,    memory: 1Gi}
 """)
 
@@ -701,3 +701,102 @@ class TestTwcSdkFloor:
             v for v in exc.value.violations if v.rule == "twc_requires_sdk_2_7_4"
         )
         assert "2.7.4" in floor.fix
+
+
+# ---------------------------------------------------------------------------
+# Rule: invalid_type on strictly-typed scalars (mirrors chart values.schema.json)
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidScalarType:
+    def test_int_vpa_max_cpu_fails(self):
+        # The exact class that froze snowflake-worker-twd: a bare int here
+        # passes magnitude rules but the chart schema wants a string.
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config("vpa:\n  maxAllowed:\n    cpu: 4\n")
+        assert ("invalid_type", "vpa.maxAllowed.cpu") in {
+            (v.rule, v.field) for v in exc.value.violations
+        }
+
+    def test_quoted_vpa_max_cpu_passes(self):
+        validate_config('vpa:\n  maxAllowed:\n    cpu: "4"\n')
+
+    def test_int_vpa_min_memory_fails(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config("vpa:\n  minAllowed:\n    memory: 2\n")
+        assert any(
+            v.rule == "invalid_type" and v.field == "vpa.minAllowed.memory"
+            for v in exc.value.violations
+        )
+
+    def test_int_requests_cpu_fails(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config("resources:\n  requests:\n    cpu: 2\n")
+        assert any(
+            v.rule == "invalid_type" and v.field == "resources.requests.cpu"
+            for v in exc.value.violations
+        )
+
+    def test_int_requests_memory_fails(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config("resources:\n  requests:\n    memory: 500\n")
+        assert any(
+            v.rule == "invalid_type" and v.field == "resources.requests.memory"
+            for v in exc.value.violations
+        )
+
+    def test_limits_cpu_int_allowed(self):
+        # Chart schema types resources.limits.cpu as integer|string, so an int
+        # here must NOT be flagged — mirroring the chart avoids false positives.
+        validate_config(
+            'resources:\n'
+            '  requests: {cpu: "1", memory: 1Gi}\n'
+            "  limits:   {cpu: 2,   memory: 2Gi}\n"
+        )
+
+    def test_string_target_queue_size_fails(self):
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config('keda:\n  temporal:\n    targetQueueSize: "25"\n')
+        assert any(
+            v.rule == "invalid_type" and v.field == "keda.temporal.targetQueueSize"
+            for v in exc.value.violations
+        )
+
+    def test_int_target_queue_size_passes(self):
+        validate_config("keda:\n  temporal:\n    targetQueueSize: 25\n")
+
+    def test_bool_target_queue_size_fails(self):
+        # bool is an int subclass; the chart schema still rejects it.
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config("keda:\n  temporal:\n    targetQueueSize: true\n")
+        assert any(
+            v.rule == "invalid_type" and v.field == "keda.temporal.targetQueueSize"
+            for v in exc.value.violations
+        )
+
+    def test_int_application_version_fails(self):
+        # An all-digit build id loads as int → chart (string) rejects it.
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config("applicationVersion: 12345\n")
+        assert any(
+            v.rule == "invalid_type" and v.field == "applicationVersion"
+            for v in exc.value.violations
+        )
+
+    def test_string_application_version_passes(self):
+        validate_config("applicationVersion: d776a49\n")
+
+    def test_snowflake_incident_repro(self):
+        # Shape that froze snowflake: keda enabled + vpa.maxAllowed.cpu as a
+        # bare int. Everything else valid; only the int cpu must be flagged.
+        with pytest.raises(ConfigValidationError) as exc:
+            validate_config("""
+keda: {enabled: true, minReplicaCount: 0, temporal: {targetQueueSize: 25}}
+vpa:
+  enabled: true
+  updateMode: "Off"
+  maxAllowed: {cpu: 4, memory: 27Gi}
+  minAllowed: {cpu: "50m", memory: 2Gi}
+""")
+        types = {(v.rule, v.field) for v in exc.value.violations}
+        assert ("invalid_type", "vpa.maxAllowed.cpu") in types


### PR DESCRIPTION
## What

Adds a scalar-type validation rule to `config_validator.py` (behind the `validate_atlan_yaml.py` CI driver) so `atlan.yaml` values whose type the `atlan-app` chart's `values.schema.json` enforces are checked in CI, not at Helm-apply time.

## Why

`vpa.maxAllowed.cpu: 4` (a bare int) passed SDK CI, but the chart schema requires a string. Helm rejected it (`Expected: string, given: integer`), the HelmRelease stayed in a failed upgrade, and the app's `TemporalWorkerDeployment` was never re-rendered - so no KEDA ScaledObject was created and the worker could not autoscale (stuck at 0 replicas). The same int/string class hit 8 connectors (snowflake, dbt, enrichment-studio, lineage, matillion, popularity, saphana, synapse). The SDK validator only checked magnitudes, not types, so it had drifted from the chart schema.

## What it checks

Mirrors the chart's `values.schema.json`:
- **string**: `vpa.{min,max}Allowed.{cpu,memory}`, `resources.requests.{cpu,memory}`, `resources.limits.memory`, `applicationVersion`
- **integer**: `keda.temporal.targetQueueSize`

Deliberately excludes fields the chart types loosely (`resources.limits.cpu` = int|string, `serverResources`/`workerResources` partly unconstrained) to avoid false positives.

## Blast radius

Runs in `build-and-publish-app.yaml`. Apps currently shipping int-typed quantities will start failing this step, but those configs already fail silently at deploy - this just surfaces them earlier. Hard-fail, consistent with the existing rules.

## Test

- `test_config_validator.py`: 97 passed (85 existing + 12 new, incl. `test_snowflake_incident_repro`). Updated 6 happy-path fixtures that used int quantities for string-typed fields.
- Ran the real driver against snowflake's failing config: it emits `::error file=atlan.yaml::[invalid_type] vpa.maxAllowed.cpu=4 ...` and exits 1; the quoted `"4"` variant passes.

Closes ARUN-954

🤖 Generated with [Claude Code](https://claude.com/claude-code)
