### PR TITLE
fix(handler): serve flat single-entrypoint manifest for ?entrypoint= requests

### DIFF
--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -1869,10 +1869,23 @@ def _register_workflow_routes(
         }
         ep_manifest = registry.get(entrypoint_name)
         if ep_manifest is None:
-            raise HTTPException(
-                status_code=404,
-                detail=f"No manifest found for entrypoint {entrypoint_name!r}",
-            )
+            # Multi-entrypoint (bundle) apps nest each entrypoint's manifest
+            # under <ep.name>/manifest.json (matched above). Single-entrypoint
+            # apps emit it FLAT at CONTRACT_GENERATED_DIR/manifest.json, with no
+            # per-entrypoint subdir. Heracles/AE always sends ?entrypoint=<name>
+            # on package-workflow submit, so without this fallback a flat
+            # single-entrypoint app 404s ("No manifest found for entrypoint")
+            # and the platform surfaces it as a 500 on submit — blocking every
+            # run. Mirrors the flat-layout fallback in get_configmap and the
+            # no-?entrypoint branch of get_manifest.
+            flat_manifest = CONTRACT_GENERATED_DIR / "manifest.json"
+            if flat_manifest.is_file():
+                ep_manifest = flat_manifest
+            else:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"No manifest found for entrypoint {entrypoint_name!r}",
+                )
         raw = ep_manifest.read_bytes()
         # app_name is baked into the generated manifest by the contract toolkit
         # (from the contract `name`); only the per-deployment token is substituted here.

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -2626,6 +2626,46 @@ class TestManifestEndpoint:
         finally:
             svc_module.CONTRACT_GENERATED_DIR = original
 
+    def test_manifest_entrypoint_param_falls_back_to_flat_single_entrypoint(
+        self, tmp_path: Path
+    ) -> None:
+        """``?entrypoint=<name>`` on a FLAT single-entrypoint app serves the root manifest.
+
+        Single-entrypoint apps emit a flat manifest at
+        ``CONTRACT_GENERATED_DIR/manifest.json`` (no ``<ep>/`` subdir). Heracles/AE
+        always sends ``?entrypoint=<name>`` on package-workflow submit, which routes
+        straight to ``_serve_entrypoint_manifest`` — a nested-only lookup. Without
+        the flat fallback the app 404s ("No manifest found for entrypoint 'openapi'")
+        and the platform surfaces a 500, blocking every run (observed on the openapi
+        connector's first submit). Regression guard for that path.
+        """
+        from application_sdk.app.base import App
+        from application_sdk.app.entrypoint import entrypoint
+        from application_sdk.handler import service as svc_module
+
+        class _OneEpApp(App):
+            @entrypoint
+            async def crawler(self, input: _RoutingInput) -> _RoutingOutput:
+                return _RoutingOutput()
+
+        # Flat layout: manifest at the ROOT, no per-entrypoint subdir.
+        (tmp_path / "manifest.json").write_text(
+            json.dumps({"execution_mode": "linear", "source": "flat-root"})
+        )
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            svc = create_app_handler_service(
+                _TestHandler(), app_name="openapi", app_class=_OneEpApp
+            )
+            client = TestClient(svc, raise_server_exceptions=False)
+            response = client.get("/workflows/v1/manifest?entrypoint=openapi")
+            assert response.status_code == 200
+            assert response.json()["source"] == "flat-root"
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
     def test_manifest_root_file_wins_over_default_entrypoint_fallback(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary

Companion to #2759 — the **same flat-single-entrypoint bug, in the `/manifest` endpoint**. With #2759 the setup wizard renders, but **submitting a run 500s** because the platform can't fetch the app's manifest.

`_serve_entrypoint_manifest` resolves the manifest only from a nested `CONTRACT_GENERATED_DIR/<ep.name>/manifest.json` (the multi-entrypoint bundle layout). Single-entrypoint apps emit the manifest **flat** at `CONTRACT_GENERATED_DIR/manifest.json`. `get_manifest` checks the flat root only on the *no*-`?entrypoint=` branch — but **Heracles/AE always sends `?entrypoint=<name>`** on package-workflow submit, which routes straight to `_serve_entrypoint_manifest` → nested-only lookup → **404**.

## Confirmed in production (openapi, developer-experience tenant)
App handler log:
```
GET /manifest?entrypoint=openapi → 404
```
Heracles log (same instant):
```
api-fatal POST /package-workflows?submit=true 500
action:        atlan:packageworkflow:create
error_message: app validation error: 404 - map[detail:No manifest found for entrypoint 'openapi']
```
The app's 404 becomes the platform's 500 on submit — so the "run" flow is dead for every flat single-entrypoint app, even though the manifest file is present.

## Fix
When the nested `<ep.name>/manifest.json` lookup misses, fall back to the flat `CONTRACT_GENERATED_DIR/manifest.json` — the same layout `get_manifest`'s no-`?entrypoint=` branch and `get_configmap` (#2759) already serve:

```python
ep_manifest = registry.get(entrypoint_name)
if ep_manifest is None:
    flat_manifest = CONTRACT_GENERATED_DIR / "manifest.json"
    if flat_manifest.is_file():
        ep_manifest = flat_manifest
    else:
        raise HTTPException(404, detail=f"No manifest found for entrypoint {entrypoint_name!r}")
```

**Safe:** multi-entrypoint apps have no root manifest, so a bogus/unknown entrypoint still 404s. The flat branch only triggers for a genuine single-entrypoint app.

## Verification
- New regression test `test_manifest_entrypoint_param_falls_back_to_flat_single_entrypoint` — **fails (404) against the current handler, passes with the fix** (reproduces the exact openapi/Heracles failure).
- 279 handler tests pass; ruff + ruff-format clean.

## Context: this is the last of a cluster
Flat single-entrypoint apps (single `App` + `run()`, flat generated layout) were never handled by the entrypoint-qualified config-serving handlers:
- **#2759** — `get_configmap` (blank setup wizard) ✅ merged, shipped in SDK 3.23.0
- **this PR** — `/manifest` via `_serve_entrypoint_manifest` (500 on submit)

With both, openapi/metabase/etc. resolve the wizard **and** submit runs. Recommend an SDK release with this so the affected connectors can bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)