### PR TITLE
ci(renovate): fleet cutover prep — dual-author gate + release fan-out (PR2 Stage 1)

### DIFF
--- a/.github/scripts/renovate_fleet_scan.py
+++ b/.github/scripts/renovate_fleet_scan.py
@@ -90,9 +90,18 @@ def resolve_scope(org: str, repo: Optional[str]) -> str:
     return f"repo:{repo}" if repo else f"org:{org}"
 
 
+# Renovate PR authors to scan. During the fleet cutover both engines coexist:
+# the Mend-hosted app (app/renovate) and the self-hosted runner
+# (app/atlan-app-fleet). GitHub PR search OR's multiple author: qualifiers.
+# Narrow to ("app/atlan-app-fleet",) once Mend is uninstalled (PR2 Stage 4).
+RENOVATE_PR_AUTHORS = ("app/renovate", "app/atlan-app-fleet")
+
+
 def build_search_query(scope: str, extra: str) -> str:
-    """Build a GitHub search-syntax query, e.g. 'org:atlanhq is:pr author:app/renovate is:open'."""
-    return f"{scope} is:pr author:app/renovate {extra}".strip()
+    """Build a GitHub search-syntax query, e.g.
+    'org:atlanhq is:pr author:app/renovate author:app/atlan-app-fleet is:open'."""
+    authors = " ".join(f"author:{a}" for a in RENOVATE_PR_AUTHORS)
+    return f"{scope} is:pr {authors} {extra}".strip()
 
 
 def build_graphql_payload(search_query: str, fields: str, after: Optional[str]) -> dict:

--- a/.github/scripts/tests/test_renovate_fleet_scan.py
+++ b/.github/scripts/tests/test_renovate_fleet_scan.py
@@ -28,16 +28,19 @@ def test_resolve_scope_single_repo_when_repo_set():
 
 def test_build_search_query_full_fleet():
     q = rfs.build_search_query("org:atlanhq", "is:open")
-    assert q == "org:atlanhq is:pr author:app/renovate is:open"
+    assert (
+        q == "org:atlanhq is:pr author:app/renovate author:app/atlan-app-fleet is:open"
+    )
 
 
 def test_build_search_query_single_repo():
     q = rfs.build_search_query(
         "repo:atlanhq/atlan-mysql-app", "is:merged merged:>=2026-06-01"
     )
-    assert (
-        q
-        == "repo:atlanhq/atlan-mysql-app is:pr author:app/renovate is:merged merged:>=2026-06-01"
+    assert q == (
+        "repo:atlanhq/atlan-mysql-app is:pr "
+        "author:app/renovate author:app/atlan-app-fleet "
+        "is:merged merged:>=2026-06-01"
     )
 
 

--- a/.github/workflows/contract-toolkit-publish.yml
+++ b/.github/workflows/contract-toolkit-publish.yml
@@ -138,3 +138,31 @@ jobs:
       # interleave with SDK v* releases on the repo's releases page, which
       # is confusing. The annotated tag, gh-pages publish, and
       # contract-toolkit/CHANGELOG.md are the authoritative record.
+
+  fan-out:
+    # After a contract-toolkit release, trigger the self-hosted Renovate runner
+    # so consumers pick up the new app-contract-toolkit version within minutes.
+    # Skipped automatically when `publish` is skipped or fails.
+    name: Fan out Renovate to consumers
+    needs: [publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Mint fleet App token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+      - name: Trigger the self-hosted Renovate runner
+        # Inherits renovate.yaml defaults (full discovery; dry_run=full until PR2
+        # Stage 3 flips it live). Soft-fail so a fan-out hiccup never fails publish.
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
+        run: |
+          gh workflow run renovate.yaml --repo atlanhq/application-sdk \
+          || echo "::warning::Could not trigger renovate.yaml — consumers will update on the next scheduled run."

--- a/.github/workflows/renovate-auto-approve-reusable.yml
+++ b/.github/workflows/renovate-auto-approve-reusable.yml
@@ -40,7 +40,7 @@
 #   freshness is guaranteed by the ruleset's dismiss_stale_reviews_on_push.
 #
 # Approval conditions (ALL must hold — see step comments in the bash below):
-#   1. PR author is renovate[bot]
+#   1. PR author is a Renovate bot (renovate[bot] or atlan-app-fleet[bot] during cutover)
 #   2. PR is open and not a draft
 #   3. Current HEAD SHA matches the evaluated SHA (race guard)
 #   4. Every changed file is under .github/, uv.lock, requirements.txt,
@@ -160,9 +160,12 @@ jobs:
             DRAFT=$(printf '%s'  "$PR_META"   | jq -r .draft)
             HEAD_SHA=$(printf '%s' "$PR_META" | jq -r .head_sha)
 
-            # a. Author must be renovate[bot].
-            if [ "$AUTHOR" != "renovate[bot]" ]; then
-              echo "PR #${PR_NUM}: author is '${AUTHOR}', not renovate[bot] — skipping."
+            # a. Author must be a Renovate bot. Both engines are accepted during
+            #    the fleet cutover: renovate[bot] (Mend-hosted) and
+            #    atlan-app-fleet[bot] (self-hosted runner). Narrow to just
+            #    atlan-app-fleet[bot] once Mend is uninstalled (PR2 Stage 4).
+            if [ "$AUTHOR" != "renovate[bot]" ] && [ "$AUTHOR" != "atlan-app-fleet[bot]" ]; then
+              echo "PR #${PR_NUM}: author is '${AUTHOR}', not a Renovate bot — skipping."
               continue
             fi
 

--- a/.github/workflows/tag-and-publish.yaml
+++ b/.github/workflows/tag-and-publish.yaml
@@ -104,3 +104,34 @@ jobs:
         run: |
           uv build
           uv publish
+
+  fan-out:
+    # After an SDK release, trigger the self-hosted Renovate runner so consumers
+    # pick up the new atlan-application-sdk version within minutes rather than
+    # waiting for the next scheduled run. Skipped automatically when `release` is
+    # skipped (non-release PR) or fails.
+    name: Fan out Renovate to consumers
+    needs: [release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Mint fleet App token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+      - name: Trigger the self-hosted Renovate runner
+        # No dry_run/repos overrides: inherits renovate.yaml's defaults (full
+        # discovery; dry_run=full until PR2 Stage 3 flips it live). So this is an
+        # inert rehearsal today and becomes the real post-release fan-out at
+        # go-live. Soft-fail so a fan-out hiccup never fails the release.
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
+        run: |
+          gh workflow run renovate.yaml --repo atlanhq/application-sdk \
+          || echo "::warning::Could not trigger renovate.yaml — consumers will update on the next scheduled run."


### PR DESCRIPTION
## Context

PR2 **Stage 1** of migrating the ~15 `atlan-*-app` repos from the Mend-hosted app (`renovate[bot]`) to the self-hosted runner (`atlan-app-fleet[bot]`). The runner (#2758) and the pilot are done; this readies the shared SDK-side pieces so both engines can **coexist** during a short switch window.

**Non-breaking by design:** Mend-served repos keep working exactly as today, and the self-hosted runner still defaults to `dry_run=full` (inert). Nothing changes engine behavior until Stage 3.

## Changes

- **Dual-author auto-approve gate** — `renovate-auto-approve-reusable.yml` accepts **both** `renovate[bot]` and `atlan-app-fleet[bot]` as PR authors (was `renovate[bot]`-only). Ensures in-flight PRs from either engine get the `atlan-ci` CODEOWNER approval during the transition.
- **Dashboard scanner dual-author** — `renovate_fleet_scan.py` searches both authors via a new `RENOVATE_PR_AUTHORS` constant (GitHub PR search OR's `author:` qualifiers). Tests updated. No other scanner change needed — `scan.py`/`classify.py` key on branch/labels/approver, all engine-neutral.
- **Release fan-out** — `tag-and-publish.yaml` and `contract-toolkit-publish.yml` gain a `fan-out` job that dispatches the central `renovate.yaml` after publish. It inherits the runner's defaults (full discovery, `dry_run=full`), so it's an **inert rehearsal today** and becomes the real post-release fan-out once Stage 3 flips the runner live. Soft-fails so a fan-out hiccup never fails a release.

## What this does NOT do (later stages)

- **Stage 2** — full-fleet `dry_run=full` rehearsal (operational, no code).
- **Stage 3** — uninstall Mend fleet-wide, sweep stale `renovate/*` branches, flip the runner's `dry_run` default to live, relax the pilot unscoped-live guard (operational + a one-line flip).
- **Stage 4** — narrow both author lists back to `atlan-app-fleet[bot]` only; delete the glue (`renovate-pkl-sync.yaml`, `reusable-renovate-dispatch.yaml`) + bootstrap glue template.

**Guardrail preserved:** the runner keeps the default `branchPrefix` (`renovate/`) — both engines share it, and `renovate/**` triggers + the dashboard classifier depend on it.

## Validation

`renovate_fleet_scan.py` tests (27) pass; pre-commit clean; all three workflows parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)