### PR TITLE
fix(handler): default-entrypoint /manifest fallback for multi-entrypoint apps

### DIFF
--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -1971,29 +1971,63 @@ def _register_workflow_routes(
         # caller (e.g. Heracles/AE pre-validation) omits ?entrypoint=, fall
         # back to the app's default entrypoint instead of 404-ing.
         try:
-            _, ep = _resolve_app_entrypoint(
+            app_meta, default_ep = _resolve_app_entrypoint(
                 _workflow_config.app_name, None, unknown_ep_status=404
             )
         except HTTPException:
-            # No default entrypoint resolvable (the only HTTPException
-            # _resolve_app_entrypoint raises), so the handler falls through
-            # to a 404. Warning, not debug: this is exc_info-worthy
-            # telemetry an operator should see in production, not just
-            # local control flow.
+            # No *default* entrypoint resolvable. Don't give up on the fallback:
+            # resolve the app's metadata INDEPENDENTLY of default resolution so
+            # the explicit-entrypoint alphabetical fallback below still applies.
+            # A servable multi-entrypoint app must not 404 just because the
+            # builder didn't mark a default — that invariant is off-screen and
+            # load-bearing, and this keeps the fallback robust to it changing.
+            # Warning, not debug: exc_info-worthy telemetry for operators.
             logger.warning(
-                "No default entrypoint for app %s; serving manifest 404",
+                "No default entrypoint for app %s; trying explicit-entrypoint "
+                "fallback before serving 404",
                 _workflow_config.app_name,
                 exc_info=True,
             )
-            ep = None
-        if ep is not None:
+            default_ep = None
             try:
-                return await _serve_entrypoint_manifest(ep.name, fe_inputs, deployment)
+                from application_sdk.app.registry import (  # noqa: PLC0415
+                    AppNotFoundError,
+                    AppRegistry,
+                )
+
+                app_meta = AppRegistry.get_instance().get(_workflow_config.app_name)
+            except AppNotFoundError:
+                # App genuinely not registered — no fallback possible, 404.
+                app_meta = None
+
+        # Candidate order: the resolved default first, then every *explicit*
+        # (non-implicit) entrypoint alphabetically. The second group matters
+        # for a connector that both implements run() (via the
+        # SqlMetadataExtractor template) AND declares explicit @entrypoints:
+        # the framework forces the implicit run() as the default (see
+        # app/entrypoint.py — "run() + @entrypoint(s) → run() always"), but
+        # run() has no generated manifest dir, so serving it 404s. Rather than
+        # 404 the whole route, fall back to the explicit entrypoints, ordered
+        # alphabetically — the same tie-break the framework uses when multiple
+        # @entrypoints carry no marked default. For a SQL bundle app this
+        # resolves to `crawler` (c < m < …), the connector's primary path.
+        candidates: list[str] = []
+        if default_ep is not None:
+            candidates.append(default_ep.name)
+        if app_meta is not None:
+            candidates.extend(
+                ep.name
+                for ep in sorted(app_meta.entry_points.values(), key=lambda e: e.name)
+                if not ep.implicit and ep.name not in candidates
+            )
+
+        for cand in candidates:
+            try:
+                return await _serve_entrypoint_manifest(cand, fe_inputs, deployment)
             except HTTPException as exc:
                 if exc.status_code != 404:
                     raise
-                # Default entrypoint exists but has no manifest file on disk —
-                # fall through to the canonical 404 below.
+                # This candidate has no manifest file on disk — try the next.
 
         raise HTTPException(status_code=404, detail="No manifest available")
 

--- a/docs/concepts/entry-points.md
+++ b/docs/concepts/entry-points.md
@@ -244,12 +244,12 @@ Retrieve a specific manifest with:
 GET /workflows/v1/manifest?entrypoint=<entry-point-name>
 ```
 
-Behaviour:
+Behaviour (with `?entrypoint=<entry-point-name>`):
 - Returns 400 if `<entry-point-name>` fails validation (`^[a-zA-Z][a-zA-Z0-9_-]*$`).
-- Returns 404 if the subfolder or `manifest.json` is missing.
+- Returns 404 if that entry point's subfolder or `manifest.json` is missing.
 - The `?entrypoint=` token is the same kebab-case identifier used on `POST /workflows/v1/start` — one naming convention, two endpoints.
 
-For single-entry-point apps, `GET /workflows/v1/manifest` (no query param) is unchanged.
+Without a query param, `GET /workflows/v1/manifest` serves the app's **default** entry point's manifest. If no default is marked, it falls back to the explicit (non-implicit) entry points in alphabetical order — so a `run()` + `@entrypoint(s)` app (whose implicit `run` has no manifest dir) resolves to its first explicit entry point (e.g. `crawler`) with a **200** rather than 404. It 404s only when no candidate has a servable `manifest.json`. For single-entry-point apps this is just that app's manifest, as before.
 
 > **Configmap discovery** also benefits from the subfolder layout: the handler uses `rglob("*.json")` so configmap files can live inside per-entry subfolders alongside the manifests.
 

--- a/docs/concepts/entry-points.md
+++ b/docs/concepts/entry-points.md
@@ -249,7 +249,7 @@ Behaviour (with `?entrypoint=<entry-point-name>`):
 - Returns 404 if that entry point's subfolder or `manifest.json` is missing.
 - The `?entrypoint=` token is the same kebab-case identifier used on `POST /workflows/v1/start` — one naming convention, two endpoints.
 
-Without a query param, `GET /workflows/v1/manifest` serves the app's **default** entry point's manifest. If no default is marked, it falls back to the explicit (non-implicit) entry points in alphabetical order — so a `run()` + `@entrypoint(s)` app (whose implicit `run` has no manifest dir) resolves to its first explicit entry point (e.g. `crawler`) with a **200** rather than 404. It 404s only when no candidate has a servable `manifest.json`. For single-entry-point apps this is just that app's manifest, as before.
+Without a query param, `GET /workflows/v1/manifest` serves the first candidate with a manifest on disk: the default entry point (if any), then the explicit (non-implicit) entry points in alphabetical order. So a `run()` + `@entrypoint(s)` app — whose implicit `run` default has no manifest dir — resolves to its first explicit entry point (e.g. `crawler`) with a **200** rather than 404. It 404s only when no candidate has a servable `manifest.json`. For single-entry-point apps this is just that app's manifest, as before.
 
 > **Configmap discovery** also benefits from the subfolder layout: the handler uses `rglob("*.json")` so configmap files can live inside per-entry subfolders alongside the manifests.
 

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -2835,6 +2835,125 @@ class TestManifestEndpoint:
         finally:
             svc_module.CONTRACT_GENERATED_DIR = original
 
+    def test_manifest_404_when_mixed_run_app_has_no_servable_manifest(
+        self, tmp_path: Path
+    ) -> None:
+        """Mixed run()+@entrypoint app with no manifest dirs at all → 404.
+
+        Negative mirror of
+        ``test_manifest_falls_back_to_explicit_ep_when_implicit_run_is_default``
+        (and of the sibling ``test_manifest_returns_404_when_fallback_ep_dir_missing``)
+        for the mixed ``run()`` shape: the implicit ``run()`` default has no
+        manifest dir AND neither explicit entrypoint dir exists, so every
+        candidate misses on disk and the route terminates in the canonical
+        ``"No manifest available"`` 404 rather than serving stale data or 500-ing.
+        """
+        from application_sdk.app.base import App
+        from application_sdk.app.entrypoint import entrypoint
+        from application_sdk.handler import service as svc_module
+
+        class _MixedRunNoManifestApp(App):
+            async def run(self, input: _RoutingInput) -> _RoutingOutput:
+                return _RoutingOutput()
+
+            @entrypoint
+            async def crawler(self, input: _RoutingInput) -> _RoutingOutput:
+                return _RoutingOutput()
+
+            @entrypoint
+            async def miner(self, input: _AlphaInput) -> _AlphaOutput:
+                return _AlphaOutput()
+
+        # tmp_path has no crawler/ or miner/ subdir and no root manifest.json —
+        # every candidate (implicit run default + both explicit eps) misses.
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            svc = create_app_handler_service(
+                _TestHandler(), app_name="postgres", app_class=_MixedRunNoManifestApp
+            )
+            client = TestClient(svc, raise_server_exceptions=False)
+            response = client.get("/workflows/v1/manifest")
+            assert response.status_code == 404
+            assert response.json()["detail"] == "No manifest available"
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
+    def test_manifest_recovery_block_serves_explicit_ep_when_no_default_marked(
+        self, tmp_path: Path
+    ) -> None:
+        """No-default multi-ep app: the ``except`` recovery branch still serves.
+
+        The builder auto-marks a default for every multi-``@entrypoint`` app
+        (``_ep_registration._build_entry_points``), so ``_resolve_app_entrypoint``
+        never raises the 400 "entrypoint required" for a builder-produced app —
+        the handler's ``except HTTPException`` recovery block (re-fetch
+        ``app_meta`` from the registry, then fall back to the explicit
+        entrypoints) is defensive future-proofing against that invariant
+        changing. This test locks that branch: it clears the auto-marked default
+        on the registry entry so default resolution raises 400, then asserts the
+        recovery path re-fetches the app and serves the alphabetically-first
+        explicit entrypoint (``crawler``) rather than 404-ing.
+        """
+        from dataclasses import replace
+
+        from application_sdk.app.base import App
+        from application_sdk.app.entrypoint import entrypoint
+        from application_sdk.app.registry import AppRegistry
+        from application_sdk.handler import service as svc_module
+
+        class _NoDefaultMultiEpApp(App):
+            @entrypoint
+            async def crawler(self, input: _RoutingInput) -> _RoutingOutput:
+                return _RoutingOutput()
+
+            @entrypoint
+            async def miner(self, input: _AlphaInput) -> _AlphaOutput:
+                return _AlphaOutput()
+
+        # Re-register the app with every default flag cleared, so
+        # _resolve_default_entrypoint returns None (multi-ep, no marked default)
+        # and _resolve_app_entrypoint raises 400 — the only way to drive the
+        # handler's except-block recovery for a registered app.
+        registry = AppRegistry.get_instance()
+        meta = registry.get(_NoDefaultMultiEpApp._app_name)
+        no_default_eps = {
+            name: replace(ep, default=False) for name, ep in meta.entry_points.items()
+        }
+        registry.register(
+            name=meta.name,
+            version=meta.version,
+            app_cls=meta.app_cls,
+            input_type=meta.input_type,
+            output_type=meta.output_type,
+            entry_points=no_default_eps,
+            allow_override=True,
+        )
+
+        # Both explicit entrypoints have manifests on disk; the recovery block
+        # must pick crawler (c < m) after default resolution fails.
+        for ep_name in ("crawler", "miner"):
+            ep_dir = tmp_path / ep_name
+            ep_dir.mkdir()
+            (ep_dir / "manifest.json").write_text(
+                json.dumps({"execution_mode": "automation-engine", "ep": ep_name})
+            )
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            svc = create_app_handler_service(
+                _TestHandler(), app_name="postgres", app_class=_NoDefaultMultiEpApp
+            )
+            client = TestClient(svc, raise_server_exceptions=False)
+            response = client.get("/workflows/v1/manifest")
+            assert response.status_code == 200
+            # No default resolvable → recovery block re-fetches app_meta and
+            # falls back to the alphabetically-first explicit ep, crawler.
+            assert response.json()["ep"] == "crawler"
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
     def test_simple_app_manifest_lives_at_root_not_in_subdir(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -2778,6 +2778,63 @@ class TestManifestEndpoint:
         finally:
             svc_module.CONTRACT_GENERATED_DIR = original
 
+    def test_manifest_falls_back_to_explicit_ep_when_implicit_run_is_default(
+        self, tmp_path: Path
+    ) -> None:
+        """Mixed run()+@entrypoint app: implicit run() default has no manifest.
+
+        A SQL-template connector (e.g. ``PostgresApp(SqlMetadataExtractor)``)
+        both implements ``run()`` AND declares explicit ``@entrypoint``s
+        (crawler, miner). The framework forces the implicit ``run()`` as the
+        default entrypoint and prohibits ``@entrypoint(default=True)`` elsewhere
+        (see ``_ep_registration._build_entry_points``) — but ``run()`` has no
+        generated manifest dir, so the no-``?entrypoint=`` route AE/Heracles use
+        for pre-flight validation would 404. The handler must instead fall back
+        to the explicit entrypoints alphabetically and serve ``crawler``
+        (c < m), the connector's primary path, rather than 404-ing.
+        """
+        from application_sdk.app.base import App
+        from application_sdk.app.entrypoint import entrypoint
+        from application_sdk.handler import service as svc_module
+
+        class _MixedRunApp(App):
+            async def run(self, input: _RoutingInput) -> _RoutingOutput:
+                return _RoutingOutput()
+
+            @entrypoint
+            async def crawler(self, input: _RoutingInput) -> _RoutingOutput:
+                return _RoutingOutput()
+
+            @entrypoint
+            async def miner(self, input: _AlphaInput) -> _AlphaOutput:
+                return _AlphaOutput()
+
+        # Only the explicit entrypoints have generated manifests; the implicit
+        # run() has no dir — exactly the postgres/bundle on-disk layout.
+        for ep_name in ("crawler", "miner"):
+            ep_dir = tmp_path / ep_name
+            ep_dir.mkdir()
+            (ep_dir / "manifest.json").write_text(
+                json.dumps({"execution_mode": "automation-engine", "ep": ep_name})
+            )
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            # app_name= sets the task-queue name only; _resolve_app_entrypoint
+            # keys on _MixedRunApp._app_name (kebab of the class name).
+            svc = create_app_handler_service(
+                _TestHandler(), app_name="postgres", app_class=_MixedRunApp
+            )
+            client = TestClient(svc, raise_server_exceptions=False)
+            response = client.get("/workflows/v1/manifest")
+            assert response.status_code == 200
+            # Default (implicit run) has no manifest → alphabetically-first
+            # explicit entrypoint, i.e. crawler, NOT miner.
+            assert response.json()["ep"] == "crawler"
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
     def test_simple_app_manifest_lives_at_root_not_in_subdir(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Runtime fix split out of #2639 (which is now test-harness + CI only). Multi-entrypoint apps 404'd on a bare `GET /workflows/v1/manifest` (no `?entrypoint=`), breaking AE submit-time pre-validation. Falls back to the default entrypoint, then explicit entrypoints alphabetically; 404 only when none is servable. `app_meta` is resolved independently of default resolution so the fallback survives the marked-default invariant changing. Docs + unit test included.

Apps get this via a normal SDK release — it is intentionally NOT in the runtime-agnostic harness PR.