### PR TITLE
fix(sql): encode credentials with quote() so passwords with spaces authenticate

### DIFF
--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -11,7 +11,7 @@ import hashlib
 from collections.abc import AsyncIterator, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, Union, cast
-from urllib.parse import quote_plus
+from urllib.parse import quote, quote_plus
 
 from application_sdk.clients._interface import ClientInterface
 from application_sdk.clients.models import DatabaseConfig
@@ -287,8 +287,17 @@ class BaseSQLClient(ClientInterface):
             case _:
                 raise SqlCredentialsParseError(field="authType", value_summary=authType)
 
-        # Handle None values and ensure token is a string before encoding
-        encoded_token = quote_plus(str(token or ""))
+        # Handle None values and ensure token is a string before encoding.
+        # This token is interpolated into the userinfo of a SQLAlchemy URL,
+        # which SQLAlchemy decodes with ``urllib.parse.unquote`` (percent-only).
+        # ``quote_plus`` encodes space as ``+``, and ``unquote`` never turns
+        # ``+`` back into a space, so a password containing a space would reach
+        # the driver corrupted (CONNECT-361). ``quote`` encodes space as ``%20``,
+        # which round-trips correctly. ``safe=""`` is required so that ``/`` in
+        # the credential is also encoded (an unencoded ``/`` in userinfo would
+        # otherwise break URL parsing). Query-string params below still use
+        # ``quote_plus`` — SQLAlchemy decodes query values with ``+`` -> space.
+        encoded_token = quote(str(token or ""), safe="")
         return encoded_token
 
     def add_connection_params(

--- a/tests/unit/clients/test_sql_client.py
+++ b/tests/unit/clients/test_sql_client.py
@@ -445,6 +445,45 @@ def test_get_sqlalchemy_connection_string_basic_auth(sql_client_with_db_config):
     assert conn_str == expected
 
 
+@pytest.mark.parametrize(
+    "password",
+    [
+        "my pass",  # space — the CONNECT-361 regression: quote_plus made this '+'
+        "sp ace+plus",  # space AND a literal '+'
+        "p@ss:w/rd",  # userinfo-significant chars @ : /
+        "100%sure",  # percent
+        "хм пароль",  # non-ASCII with a space
+    ],
+)
+def test_connection_string_password_survives_sqlalchemy_decode(
+    sql_client_with_db_config, password
+):
+    """Passwords with special characters must reach the driver unchanged.
+
+    ``get_auth_token`` encodes the password into the userinfo of a SQLAlchemy
+    URL. SQLAlchemy decodes that userinfo with ``urllib.parse.unquote``
+    (percent-only, NOT ``unquote_plus``), so encoding a space as ``+`` (what
+    ``quote_plus`` did) reached the driver as a literal ``+`` — the root cause of
+    CONNECT-361. ``sqlalchemy.engine.url.make_url`` is exactly the parser
+    ``create_engine`` uses internally, so asserting the round-trip through it
+    proves the driver receives the original password without needing a live DB.
+    """
+    from sqlalchemy.engine.url import make_url  # noqa: PLC0415 — optional dep
+
+    sql_client_with_db_config.credentials = {
+        "username": "test_user",
+        "password": password,
+        "host": "localhost",
+        "port": 5432,
+        "database": "test_db",
+        "authType": "basic",
+    }
+
+    conn_str = sql_client_with_db_config.get_sqlalchemy_connection_string()
+
+    assert make_url(conn_str).password == password
+
+
 def test_get_sqlalchemy_connection_string_iam_user(sql_client_with_db_config):
     """Test connection string generation with IAM user authentication"""
     credentials = {


### PR DESCRIPTION
## Summary

A DB password containing a **space** fails SQL authentication through app-sdk connectors, even though the same credential connects in a direct client (e.g. DBeaver). Symptom: `FATAL: password authentication failed`. Only spaces break — every other special character round-trips fine.

**Root cause:** `AsyncBaseSQLClient.get_auth_token()` encoded the credential with `quote_plus()` before interpolating it into the userinfo of the SQLAlchemy URL. SQLAlchemy decodes userinfo with `urllib.parse.unquote` (percent-only, **not** `unquote_plus`), so the `+` that `quote_plus` produces for a space is never converted back — the driver receives a literal `+` where the space should be.

## Fix

Switch that single encode point from `quote_plus` to `quote(token, safe="")`:

- `quote` encodes space as `%20`, which `unquote` reverses correctly.
- `safe=""` is load-bearing — it ensures `/` in the credential is also encoded (an unencoded `/` in userinfo would break URL parsing).
- **No-op for IAM auth:** `quote_plus` and `quote(safe="")` differ in exactly one byte class — space. IAM RDS tokens contain no literal spaces, so their encoded output is byte-for-byte identical; `iam_user`/`iam_role` behavior is unchanged.
- **Query-string params keep `quote_plus`** (`add_connection_params`) — verified that SQLAlchemy decodes query values with `+` → space, so `quote_plus` is correct there.

## Verification

- New parametrized regression test asserts the password round-trips through `sqlalchemy.engine.url.make_url` (the exact parser `create_engine` uses internally) for: space, space + literal `+`, `@:/`, `%`, and non-ASCII with a space.
- Existing basic / `iam_user` / `iam_role` / parameters tests pass unchanged.
- `pre-commit` (ruff, ruff-format, isort, pyright) green.

## Scope

Fix is in `application_sdk` (shared SQL client), not any single connector — the defect affects **every** connector using the base client's auth path. No changes to the `DB_CONFIG.template` contract.

Resolves CONNECT-361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)