### PR TITLE
ci(sdk-evolution): light delta+focus daily, one-theme weekly, stream-drop marker backstop [BLDX-1517]

### DIFF
--- a/.github/scripts/sdk_evolution_dispatch.py
+++ b/.github/scripts/sdk_evolution_dispatch.py
@@ -15,13 +15,14 @@ writes a **GITHUB_STEP_SUMMARY** (found / killed / PRs / cost + Linear parent
 link) — the missing observability that got the cron disabled. It parses the
 `=== SDK EVOLUTION SUMMARY ===` block the agent emits (ORCHESTRATION Stage 7).
 
-Stream-drop backstop: mothership's SSE stream can drop mid-run while the
-sandbox keeps working (a prior verification run completed all stages after the
-stream died). When the stream ends without a `complete` event — and no `error`
-event was seen — this script polls the pinned completion-marker issue
-(label `sdk-evolution-marker`) where ORCHESTRATION Stage 7 posts the summary
-block as a comment tagged `marker: <source_id>`. Marker found → the run really
-completed; recover the metrics from the comment and exit 0.
+Stream-drop backstop: mothership's SSE stream can end abnormally while the
+sandbox keeps working (observed twice: a silent drop, and a spurious empty
+`error` event — both after the run had completed all stages). On any abnormal
+ending this script polls the pinned Linear marker ticket (`MARKER_TICKET`)
+where ORCHESTRATION Stage 7 posts the summary block as a comment tagged
+`marker: <source_id>`. Marker found → the run really completed; recover the
+metrics from the comment and exit 0. Linear (not a GitHub issue) is the
+tracking surface by design — the pipeline must not create GitHub issues.
 
 Flow: resolve tier/focus/theme → health-check mothership (retries) → build
 prompt + payload → POST /api/sandbox/execute and stream SSE → (on stream drop)
@@ -39,8 +40,8 @@ Environment:
                         verify a PR branch's playbook before merge)
     GHA_RUN_URL         this workflow run's URL
     RUN_DATE            ISO date (computed if absent)
-    GH_TOKEN            GitHub token for the completion-marker poll
-    GITHUB_REPOSITORY   owner/repo for the marker poll (GHA sets this)
+    LINEAR_API_KEY      Linear API key for the completion-marker poll
+    MARKER_TICKET       pinned Linear ticket identifier holding run markers
     GITHUB_STEP_SUMMARY path GitHub Actions gives us to render the run summary
 """
 
@@ -79,9 +80,17 @@ DAILY_FOCUSES = frozenset(FOCUS_BY_WEEKDAY.values())
 WEEKLY_THEMES = ("ARCH", "TEMPORAL", "CONSUMERS", "TOOLKIT", "DX", "PERF")
 
 # Completion-marker backstop (see module docstring).
-MARKER_LABEL = "sdk-evolution-marker"
+LINEAR_API_URL = "https://api.linear.app/graphql"
 MARKER_POLL_ATTEMPTS = 45
 MARKER_POLL_INTERVAL_SECONDS = 60
+MARKER_QUERY = """\
+query($issue: String!, $needle: String!) {
+  issue(id: $issue) {
+    comments(filter: { body: { contains: $needle } }, first: 5) {
+      nodes { body }
+    }
+  }
+}"""
 
 SUMMARY_START = "=== SDK EVOLUTION SUMMARY ==="
 SUMMARY_END = "=== END SUMMARY ==="
@@ -149,6 +158,7 @@ def build_prompt(
     consumer_pr_cap: int,
     focus: str = "",
     theme: str = "",
+    marker_ticket: str = "",
 ) -> str:
     if tier == "weekly":
         cap_note = (
@@ -175,6 +185,8 @@ def build_prompt(
             f"open design debates; note weekly DESIGN candidates and move on.\n"
         )
         extra_lines = f"\n  FOCUS:            {focus}"
+    if marker_ticket:
+        extra_lines += f"\n  MARKER_TICKET:    {marker_ticket}"
     return f"""You are running the SDK Evolution pipeline in a Cloudflare sandbox.
 
 Repository cloned at: /workspace/application-sdk.
@@ -199,8 +211,10 @@ ruff / conformance CI / codeql / trivy already gates.
 
 Hand every surviving PR to a SINGLE @sdk-review pass (NOT auto-complete). At
 the very end (Stage 7), print the `=== SDK EVOLUTION SUMMARY ===` block
-verbatim AND post it as a completion-marker comment (see ORCHESTRATION
-Stage 7) so the workflow can surface the outcome even if this stream drops."""
+verbatim AND post it as a completion-marker comment on the MARKER_TICKET
+Linear issue (see ORCHESTRATION Stage 7) so the workflow can surface the
+outcome even if this stream drops. NEVER create GitHub issues — all tracking
+lives in Linear."""
 
 
 def build_payload(
@@ -211,6 +225,7 @@ def build_payload(
     focus: str = "",
     theme: str = "",
     base_branch: str = "main",
+    marker_ticket: str = "",
 ) -> dict[str, Any]:
     return {
         "mode": "direct",
@@ -221,7 +236,7 @@ def build_payload(
         "base_branch": base_branch,
         "snapshot": "_base",
         "prompt": build_prompt(
-            tier, run_date, gha_run_url, consumer_pr_cap, focus, theme
+            tier, run_date, gha_run_url, consumer_pr_cap, focus, theme, marker_ticket
         ),
         "max_timeout_seconds": STREAM_TIMEOUT_SECONDS,
         "idle_timeout_seconds": 1800,
@@ -383,78 +398,71 @@ def mine_summary(st: SSEState) -> dict[str, str]:
     return parse_summary(st.response_text) or parse_summary(st.raw_data)
 
 
-def _gh_api(
-    url: str, token: str, opener: Callable[..., Any] = urllib.request.urlopen
+def _linear_query(
+    query: str,
+    variables: dict[str, str],
+    api_key: str,
+    opener: Callable[..., Any] = urllib.request.urlopen,
 ) -> Any:
     req = urllib.request.Request(
-        url,
+        LINEAR_API_URL,
+        data=json.dumps({"query": query, "variables": variables}).encode(),
         headers={
-            "Authorization": f"Bearer {token}",
-            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "Authorization": api_key,
         },
+        method="POST",
     )
     with opener(req, timeout=30) as resp:
         return json.loads(resp.read().decode("utf-8", "replace"))
 
 
 def fetch_marker_summary(
-    repo: str,
+    marker_ticket: str,
     source_id: str,
-    run_date: str,
-    token: str,
+    api_key: str,
     opener: Callable[..., Any] = urllib.request.urlopen,
 ) -> dict[str, str] | None:
     """One poll attempt for the completion marker.
 
-    Looks for a comment containing `marker: <source_id>` on the pinned
-    tracking issue (label `sdk-evolution-marker`). Returns the parsed summary
-    block from that comment (may be empty when the block is malformed — the
-    marker alone still proves Stage 7 ran), or None when not found yet.
-    Network/API failures count as not-found so the poll loop keeps trying.
+    Looks for a comment containing `marker: <source_id>` on the pinned Linear
+    marker ticket. Returns the parsed summary block from that comment (may be
+    empty when the block is malformed — the marker alone still proves Stage 7
+    ran), or None when not found yet. Network/API failures count as not-found
+    so the poll loop keeps trying.
     """
-    base = f"https://api.github.com/repos/{repo}"
+    needle = f"marker: {source_id}"
     try:
-        issues = _gh_api(
-            f"{base}/issues?labels={MARKER_LABEL}&state=all&per_page=5",
-            token,
-            opener,
+        data = _linear_query(
+            MARKER_QUERY, {"issue": marker_ticket, "needle": needle}, api_key, opener
         )
-        for issue in issues if isinstance(issues, list) else []:
-            number = issue.get("number")
-            if number is None:
-                continue
-            comments = _gh_api(
-                f"{base}/issues/{number}/comments"
-                f"?since={run_date}T00:00:00Z&per_page=100",
-                token,
-                opener,
-            )
-            for comment in reversed(comments if isinstance(comments, list) else []):
-                body = comment.get("body") or ""
-                if f"marker: {source_id}" in body:
-                    return parse_summary(body)
+        issue = ((data or {}).get("data") or {}).get("issue") or {}
+        nodes = (issue.get("comments") or {}).get("nodes") or []
+        for node in nodes:
+            body = node.get("body") or ""
+            if needle in body:
+                return parse_summary(body)
     except (urllib.error.URLError, OSError, json.JSONDecodeError) as e:
         print(f"::warning::Completion-marker poll attempt failed: {e}")
     return None
 
 
 def poll_completion_marker(
-    repo: str,
+    marker_ticket: str,
     source_id: str,
-    run_date: str,
-    token: str,
+    api_key: str,
     opener: Callable[..., Any] = urllib.request.urlopen,
     sleeper: Callable[[float], None] = time.sleep,
     attempts: int = MARKER_POLL_ATTEMPTS,
 ) -> dict[str, str] | None:
-    """Poll for the Stage 7 completion marker after an SSE stream drop.
+    """Poll for the Stage 7 completion marker after an abnormal stream ending.
 
     The sandbox often outlives the stream; give it up to
     attempts × MARKER_POLL_INTERVAL_SECONDS to finish and post the marker.
     Returns the recovered summary dict (possibly empty), or None on timeout.
     """
     for attempt in range(1, attempts + 1):
-        found = fetch_marker_summary(repo, source_id, run_date, token, opener)
+        found = fetch_marker_summary(marker_ticket, source_id, api_key, opener)
         if found is not None:
             print(f"Completion marker found on poll attempt {attempt}")
             return found
@@ -615,6 +623,7 @@ def main() -> int:
     )
     consumer_pr_cap = _consumer_pr_cap()
     base_branch = os.environ.get("BASE_BRANCH") or "main"
+    marker_ticket = os.environ.get("MARKER_TICKET", "")
     print(
         f"Dispatching SDK Evolution: tier={tier} run_date={run_date}"
         + (f" focus={focus}" if focus else "")
@@ -627,7 +636,14 @@ def main() -> int:
         return 1
 
     payload = build_payload(
-        tier, run_date, gha_run_url, consumer_pr_cap, focus, theme, base_branch
+        tier,
+        run_date,
+        gha_run_url,
+        consumer_pr_cap,
+        focus,
+        theme,
+        base_branch,
+        marker_ticket,
     )
     req = urllib.request.Request(
         f"{base_url}/api/sandbox/execute",
@@ -653,18 +669,21 @@ def main() -> int:
     # (got_event); a failed POST can't have produced a marker.
     recovered: dict[str, str] | None = None
     if st.got_event and not clean_success(st):
-        gh_token = os.environ.get("GH_TOKEN", "")
-        repo = os.environ.get("GITHUB_REPOSITORY", "atlanhq/application-sdk")
-        if gh_token:
+        linear_key = os.environ.get("LINEAR_API_KEY", "")
+        marker_ticket = os.environ.get("MARKER_TICKET", "")
+        if linear_key and marker_ticket:
             print(
-                "::warning::Stream ended abnormally — polling for the run's "
-                "completion marker"
+                "::warning::Stream ended abnormally — polling the Linear "
+                "marker ticket for the run's completion marker"
             )
             recovered = poll_completion_marker(
-                repo, str(payload["source_id"]), run_date, gh_token
+                marker_ticket, str(payload["source_id"]), linear_key
             )
         else:
-            print("::warning::GH_TOKEN not set — cannot poll the completion marker")
+            print(
+                "::warning::LINEAR_API_KEY / MARKER_TICKET not set — cannot "
+                "poll the completion marker"
+            )
 
     write_step_summary(render_step_summary(st, tier, run_date, gha_run_url, recovered))
     code, message = decide_exit(st, recovered)

--- a/.github/scripts/sdk_evolution_dispatch.py
+++ b/.github/scripts/sdk_evolution_dispatch.py
@@ -4,8 +4,10 @@
 One dispatcher for both tiers of the pipeline (see
 `.mothership/sdk-evolution/ORCHESTRATION.md`):
 
-  * daily   — fast, high-confidence pass over the whole SDK (Mon–Sat)
-  * weekly  — the Sunday superset: design/ADR PRs, /audit-consumers, toolkit
+  * daily   — light pass (Mon–Sat): last-36h commit delta across all daily
+              check families + ONE rotating deep-focus family per weekday.
+  * weekly  — ONE rotating design theme (Sunday): a single deep design
+              investigation producing one DESIGN PR/ADR.
 
 The inline SSE-parsing shell that used to live in sdk-evolution-cron.yml is
 gone; this tested script owns it per docs/standards/ci.md. Beyond streaming, it
@@ -13,22 +15,38 @@ writes a **GITHUB_STEP_SUMMARY** (found / killed / PRs / cost + Linear parent
 link) — the missing observability that got the cron disabled. It parses the
 `=== SDK EVOLUTION SUMMARY ===` block the agent emits (ORCHESTRATION Stage 7).
 
-Flow: resolve tier → health-check mothership (retries) → build prompt + payload
-→ POST /api/sandbox/execute and stream SSE → render the step summary → exit
-non-zero on a sandbox error / incomplete stream / non-'completed' final status.
+Stream-drop backstop: mothership's SSE stream can drop mid-run while the
+sandbox keeps working (a prior verification run completed all stages after the
+stream died). When the stream ends without a `complete` event — and no `error`
+event was seen — this script polls the pinned completion-marker issue
+(label `sdk-evolution-marker`) where ORCHESTRATION Stage 7 posts the summary
+block as a comment tagged `marker: <source_id>`. Marker found → the run really
+completed; recover the metrics from the comment and exit 0.
+
+Flow: resolve tier/focus/theme → health-check mothership (retries) → build
+prompt + payload → POST /api/sandbox/execute and stream SSE → (on stream drop)
+poll the completion marker → render the step summary → exit non-zero on a
+sandbox error / unrecovered incomplete stream / non-'completed' final status.
 
 Environment:
     MOTHERSHIP_URL      base URL (e.g. https://mothership.atlan.dev)
     HARNESS_TOKEN       bearer for /api/sandbox/execute
     TIER                daily | weekly | auto (auto → weekly on Sunday UTC)
-    CONSUMER_PR_CAP     weekly only: max consumer migration PRs per run
+    FOCUS               daily only: check family override, or auto (by weekday)
+    THEME               weekly only: design theme override, or auto (by ISO week)
+    CONSUMER_PR_CAP     weekly CONSUMERS theme only: max consumer PRs per run
+    BASE_BRANCH         branch the sandbox clones (default main; override to
+                        verify a PR branch's playbook before merge)
     GHA_RUN_URL         this workflow run's URL
     RUN_DATE            ISO date (computed if absent)
+    GH_TOKEN            GitHub token for the completion-marker poll
+    GITHUB_REPOSITORY   owner/repo for the marker poll (GHA sets this)
     GITHUB_STEP_SUMMARY path GitHub Actions gives us to render the run summary
 """
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import os
 import re
@@ -43,6 +61,27 @@ HEALTH_RETRIES = 5
 HEALTH_BACKOFF_SECONDS = 5
 STREAM_TIMEOUT_SECONDS = 7200
 DEFAULT_CONSUMER_PR_CAP = 5
+
+# Daily rotating deep-focus family by weekday (Mon=0 … Sat=5). Sunday is the
+# weekly tier; a daily run forced on a Sunday gets the Monday focus.
+FOCUS_BY_WEEKDAY = {
+    0: "BUG",
+    1: "DOCS",
+    2: "TEST",
+    3: "TYPES+APICOMPAT",
+    4: "STALE+MANIFEST+LOG",
+    5: "CONF",
+    6: "BUG",
+}
+DAILY_FOCUSES = frozenset(FOCUS_BY_WEEKDAY.values())
+
+# Weekly design themes, rotated by ISO week number (~6-week full cycle).
+WEEKLY_THEMES = ("ARCH", "TEMPORAL", "CONSUMERS", "TOOLKIT", "DX", "PERF")
+
+# Completion-marker backstop (see module docstring).
+MARKER_LABEL = "sdk-evolution-marker"
+MARKER_POLL_ATTEMPTS = 45
+MARKER_POLL_INTERVAL_SECONDS = 60
 
 SUMMARY_START = "=== SDK EVOLUTION SUMMARY ==="
 SUMMARY_END = "=== END SUMMARY ==="
@@ -76,23 +115,69 @@ def resolve_tier(tier: str, run_date: str) -> str:
     return "weekly" if is_sunday else "daily"
 
 
+def resolve_focus(focus: str, run_date: str) -> str:
+    """Resolve the daily deep-focus family: explicit override, else by weekday."""
+    focus = (focus or "auto").strip().upper()
+    if focus in DAILY_FOCUSES:
+        return focus
+    try:
+        weekday = time.strptime(run_date, "%Y-%m-%d").tm_wday
+    except (ValueError, TypeError):
+        return FOCUS_BY_WEEKDAY[0]
+    return FOCUS_BY_WEEKDAY[weekday]
+
+
+def resolve_theme(theme: str, run_date: str) -> str:
+    """Resolve the weekly design theme: explicit override, else by ISO week."""
+    theme = (theme or "auto").strip().upper()
+    if theme in WEEKLY_THEMES:
+        return theme
+    try:
+        parsed = time.strptime(run_date, "%Y-%m-%d")
+        iso_week = dt.date(parsed.tm_year, parsed.tm_mon, parsed.tm_mday).isocalendar()[
+            1
+        ]
+    except (ValueError, TypeError):
+        return WEEKLY_THEMES[0]
+    return WEEKLY_THEMES[iso_week % len(WEEKLY_THEMES)]
+
+
 def build_prompt(
-    tier: str, run_date: str, gha_run_url: str, consumer_pr_cap: int
+    tier: str,
+    run_date: str,
+    gha_run_url: str,
+    consumer_pr_cap: int,
+    focus: str = "",
+    theme: str = "",
 ) -> str:
-    weekly_note = (
-        f"\nThis is a WEEKLY run — also do the deep + cross-repo stages "
-        f"(ARCH/TEMPORAL/CONSUMERS/TOOLKIT/DX). CONSUMER_PR_CAP={consumer_pr_cap} "
-        f"caps consumer migration PRs; rotate the remainder to next week.\n"
-        if tier == "weekly"
-        else "\nThis is a DAILY run — fast, high-confidence pass only. Do NOT open "
-        "design debates; note weekly DESIGN candidates and move on.\n"
-    )
-    # CONSUMER_PR_CAP only applies to the weekly consumer audit — daily ignores
-    # it, so keep it out of the daily prompt header.
-    cap_line = f"\n  CONSUMER_PR_CAP:  {consumer_pr_cap}" if tier == "weekly" else ""
+    if tier == "weekly":
+        cap_note = (
+            f" CONSUMER_PR_CAP={consumer_pr_cap} caps consumer migration PRs; "
+            f"rotate the remainder to the next CONSUMERS week."
+            if theme == "CONSUMERS"
+            else ""
+        )
+        tier_note = (
+            f"\nThis is a WEEKLY run — ONE design deep-dive on THEME={theme}. "
+            f"Produce exactly one well-argued DESIGN PR/ADR (+ child ticket, "
+            f"needs-design-review) for this theme; at most 3 incidental small "
+            f"FIX PRs found en route. Do NOT run the daily families.{cap_note}\n"
+        )
+        extra_lines = f"\n  THEME:            {theme}"
+        if theme == "CONSUMERS":
+            extra_lines += f"\n  CONSUMER_PR_CAP:  {consumer_pr_cap}"
+    else:
+        tier_note = (
+            f"\nThis is a DAILY run — the light pass. Scan ONLY (a) the commit "
+            f"delta of the last 36 hours across all daily check families, and "
+            f"(b) today's FOCUS={focus} family deep across all three surfaces. "
+            f"Quiet delta + clean focus scan → early-exit via Stage 7. Do NOT "
+            f"open design debates; note weekly DESIGN candidates and move on.\n"
+        )
+        extra_lines = f"\n  FOCUS:            {focus}"
     return f"""You are running the SDK Evolution pipeline in a Cloudflare sandbox.
 
-Repository cloned at: /workspace/application-sdk (on main).
+Repository cloned at: /workspace/application-sdk.
 Working directory: cd /workspace/application-sdk
 
 Read and follow the orchestration EXACTLY:
@@ -104,24 +189,28 @@ Read and follow the orchestration EXACTLY:
 Run metadata (use these verbatim):
   TIER:             {tier}
   RUN_DATE:         {run_date}
-  GHA_RUN_URL:      {gha_run_url}{cap_line}
-{weekly_note}
+  GHA_RUN_URL:      {gha_run_url}{extra_lines}
+{tier_note}
 GITHUB_TOKEN is pre-injected by the sandbox. Use `gh` for all GitHub operations.
 Linear proxy access: use the $PROXY_BASE and $PROXY_JWT env vars (see tools.md).
 
-Cover all three surfaces (application_sdk/, packages/conformance/,
-contract-toolkit/). Honour the check-registry DO-NOT-re-report list — never
-re-raise anything ruff / conformance CI / codeql / trivy already gates.
+Honour the check-registry DO-NOT-re-report list — never re-raise anything
+ruff / conformance CI / codeql / trivy already gates.
 
-Create a Linear parent ticket and put a link to GHA_RUN_URL at the top of its
-description and in the Stage 7 summary. Hand every surviving PR to a SINGLE
-@sdk-review pass (NOT auto-complete). At the very end, print the
-`=== SDK EVOLUTION SUMMARY ===` block from ORCHESTRATION Stage 7 verbatim so the
-workflow can surface it."""
+Hand every surviving PR to a SINGLE @sdk-review pass (NOT auto-complete). At
+the very end (Stage 7), print the `=== SDK EVOLUTION SUMMARY ===` block
+verbatim AND post it as a completion-marker comment (see ORCHESTRATION
+Stage 7) so the workflow can surface the outcome even if this stream drops."""
 
 
 def build_payload(
-    tier: str, run_date: str, gha_run_url: str, consumer_pr_cap: int
+    tier: str,
+    run_date: str,
+    gha_run_url: str,
+    consumer_pr_cap: int,
+    focus: str = "",
+    theme: str = "",
+    base_branch: str = "main",
 ) -> dict[str, Any]:
     return {
         "mode": "direct",
@@ -129,14 +218,18 @@ def build_payload(
         "source": "github-cron",
         "source_id": f"sdk-evolution-{tier}-{run_date}",
         "repositories": ["atlanhq/application-sdk"],
-        "base_branch": "main",
+        "base_branch": base_branch,
         "snapshot": "_base",
-        "prompt": build_prompt(tier, run_date, gha_run_url, consumer_pr_cap),
+        "prompt": build_prompt(
+            tier, run_date, gha_run_url, consumer_pr_cap, focus, theme
+        ),
         "max_timeout_seconds": STREAM_TIMEOUT_SECONDS,
         "idle_timeout_seconds": 1800,
         "metadata": {
             "tier": tier,
             "run_date": run_date,
+            "focus": focus,
+            "theme": theme,
             "consumer_pr_cap": consumer_pr_cap,
         },
     }
@@ -286,19 +379,109 @@ def mine_summary(st: SSEState) -> dict[str, str]:
     return parse_summary(st.response_text) or parse_summary(st.raw_data)
 
 
+def _gh_api(
+    url: str, token: str, opener: Callable[..., Any] = urllib.request.urlopen
+) -> Any:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+        },
+    )
+    with opener(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8", "replace"))
+
+
+def fetch_marker_summary(
+    repo: str,
+    source_id: str,
+    run_date: str,
+    token: str,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+) -> dict[str, str] | None:
+    """One poll attempt for the completion marker.
+
+    Looks for a comment containing `marker: <source_id>` on the pinned
+    tracking issue (label `sdk-evolution-marker`). Returns the parsed summary
+    block from that comment (may be empty when the block is malformed — the
+    marker alone still proves Stage 7 ran), or None when not found yet.
+    Network/API failures count as not-found so the poll loop keeps trying.
+    """
+    base = f"https://api.github.com/repos/{repo}"
+    try:
+        issues = _gh_api(
+            f"{base}/issues?labels={MARKER_LABEL}&state=all&per_page=5",
+            token,
+            opener,
+        )
+        for issue in issues if isinstance(issues, list) else []:
+            number = issue.get("number")
+            if number is None:
+                continue
+            comments = _gh_api(
+                f"{base}/issues/{number}/comments"
+                f"?since={run_date}T00:00:00Z&per_page=100",
+                token,
+                opener,
+            )
+            for comment in reversed(comments if isinstance(comments, list) else []):
+                body = comment.get("body") or ""
+                if f"marker: {source_id}" in body:
+                    return parse_summary(body)
+    except (urllib.error.URLError, OSError, json.JSONDecodeError) as e:
+        print(f"::warning::Completion-marker poll attempt failed: {e}")
+    return None
+
+
+def poll_completion_marker(
+    repo: str,
+    source_id: str,
+    run_date: str,
+    token: str,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+    sleeper: Callable[[float], None] = time.sleep,
+    attempts: int = MARKER_POLL_ATTEMPTS,
+) -> dict[str, str] | None:
+    """Poll for the Stage 7 completion marker after an SSE stream drop.
+
+    The sandbox often outlives the stream; give it up to
+    attempts × MARKER_POLL_INTERVAL_SECONDS to finish and post the marker.
+    Returns the recovered summary dict (possibly empty), or None on timeout.
+    """
+    for attempt in range(1, attempts + 1):
+        found = fetch_marker_summary(repo, source_id, run_date, token, opener)
+        if found is not None:
+            print(f"Completion marker found on poll attempt {attempt}")
+            return found
+        if attempt < attempts:
+            sleeper(MARKER_POLL_INTERVAL_SECONDS)
+    return None
+
+
 def render_step_summary(
-    st: SSEState, tier: str, run_date: str, gha_run_url: str
+    st: SSEState,
+    tier: str,
+    run_date: str,
+    gha_run_url: str,
+    recovered: dict[str, str] | None = None,
 ) -> str:
     """Build the Markdown written to GITHUB_STEP_SUMMARY — always renders."""
-    summary = mine_summary(st)
-    outcome = (
-        "✅ completed" if (st.completed and st.status == "completed") else "❌ failed"
-    )
+    summary = mine_summary(st) or (recovered or {})
+    if st.completed and st.status == "completed":
+        outcome = "✅ completed"
+        cost = st.cost or "n/a"
+    elif recovered is not None:
+        outcome = "⚠️ completed (recovered via completion marker — SSE stream dropped)"
+        cost = "n/a (stream dropped before the cost event)"
+    else:
+        outcome = "❌ failed"
+        cost = st.cost or "n/a"
     lines = [
         f"# SDK Evolution — {tier} — {run_date}",
         "",
         f"**Outcome:** {outcome}  ",
-        f"**Cost:** {st.cost or 'n/a'} USD  ",
+        f"**Cost:** {cost} USD  ",
     ]
     parent = summary.get("parent_ticket")
     if parent:
@@ -333,8 +516,10 @@ def write_step_summary(content: str) -> None:
         print(f"::warning::Could not write step summary: {e}")
 
 
-def decide_exit(st: SSEState) -> tuple[int, str]:
-    """Map the final stream state to (exit_code, message)."""
+def decide_exit(
+    st: SSEState, recovered: dict[str, str] | None = None
+) -> tuple[int, str]:
+    """Map the final stream state (+ marker recovery) to (exit_code, message)."""
     if st.errored:
         return 1, f"::error::Sandbox error: code={st.err_code} message={st.err_msg}"
     if not st.got_event:
@@ -343,7 +528,15 @@ def decide_exit(st: SSEState) -> tuple[int, str]:
             "::error::Stream ended without a single SSE event — likely VPN/network/proxy issue",
         )
     if not st.completed:
-        return 1, "::error::Stream ended without a 'complete' event"
+        if recovered is not None:
+            return 0, (
+                "SDK Evolution completed (outcome recovered via completion "
+                "marker after an SSE stream drop)."
+            )
+        return 1, (
+            "::error::Stream ended without a 'complete' event and no "
+            "completion marker appeared"
+        )
     if st.status != "completed":
         return 1, f"::error::Sandbox final status={st.status} (expected 'completed')"
     return 0, f"SDK Evolution completed successfully (cost={st.cost})."
@@ -392,14 +585,32 @@ def main() -> int:
     gha_run_url = os.environ.get("GHA_RUN_URL", "")
     run_date = os.environ.get("RUN_DATE") or time.strftime("%Y-%m-%d", time.gmtime())
     tier = resolve_tier(os.environ.get("TIER", "auto"), run_date)
+    focus = (
+        resolve_focus(os.environ.get("FOCUS", "auto"), run_date)
+        if tier == "daily"
+        else ""
+    )
+    theme = (
+        resolve_theme(os.environ.get("THEME", "auto"), run_date)
+        if tier == "weekly"
+        else ""
+    )
     consumer_pr_cap = _consumer_pr_cap()
-    print(f"Dispatching SDK Evolution: tier={tier} run_date={run_date}")
+    base_branch = os.environ.get("BASE_BRANCH") or "main"
+    print(
+        f"Dispatching SDK Evolution: tier={tier} run_date={run_date}"
+        + (f" focus={focus}" if focus else "")
+        + (f" theme={theme}" if theme else "")
+        + (f" base_branch={base_branch}" if base_branch != "main" else "")
+    )
 
     if not check_health(base_url):
         print("::error::Cannot reach mothership after retries")
         return 1
 
-    payload = build_payload(tier, run_date, gha_run_url, consumer_pr_cap)
+    payload = build_payload(
+        tier, run_date, gha_run_url, consumer_pr_cap, focus, theme, base_branch
+    )
     req = urllib.request.Request(
         f"{base_url}/api/sandbox/execute",
         data=json.dumps(payload).encode(),
@@ -419,8 +630,23 @@ def main() -> int:
         st.err_code = "http_error"
         st.err_msg = str(e)
 
-    write_step_summary(render_step_summary(st, tier, run_date, gha_run_url))
-    code, message = decide_exit(st)
+    recovered: dict[str, str] | None = None
+    if st.got_event and not st.errored and not st.completed:
+        gh_token = os.environ.get("GH_TOKEN", "")
+        repo = os.environ.get("GITHUB_REPOSITORY", "atlanhq/application-sdk")
+        if gh_token:
+            print(
+                "::warning::SSE stream ended without a 'complete' event — "
+                "polling for the run's completion marker"
+            )
+            recovered = poll_completion_marker(
+                repo, str(payload["source_id"]), run_date, gh_token
+            )
+        else:
+            print("::warning::GH_TOKEN not set — cannot poll the completion marker")
+
+    write_step_summary(render_step_summary(st, tier, run_date, gha_run_url, recovered))
+    code, message = decide_exit(st, recovered)
     print(message)
     return code
 

--- a/.github/scripts/sdk_evolution_dispatch.py
+++ b/.github/scripts/sdk_evolution_dispatch.py
@@ -333,7 +333,11 @@ def process_line(line: str, st: SSEState) -> str | None:
         st.errored = True
         st.err_code = _jget(data, "code", default="unknown")
         st.err_msg = _jget(data, "message")
-        return f"[error]     code={st.err_code} message={st.err_msg}"
+        # An empty/unrecognised payload leaves us blind on what actually broke
+        # (seen in production: an error event with no code/message after the
+        # sandbox had already completed) — keep the raw payload for triage.
+        raw_note = "" if st.err_msg else f" raw={data[:300]}"
+        return f"[error]     code={st.err_code} message={st.err_msg}{raw_note}"
     if st.event == "complete":
         st.completed = True
         st.status = _jget(data, "status", default="unknown")
@@ -468,12 +472,15 @@ def render_step_summary(
 ) -> str:
     """Build the Markdown written to GITHUB_STEP_SUMMARY — always renders."""
     summary = mine_summary(st) or (recovered or {})
-    if st.completed and st.status == "completed":
+    if clean_success(st):
         outcome = "✅ completed"
         cost = st.cost or "n/a"
     elif recovered is not None:
-        outcome = "⚠️ completed (recovered via completion marker — SSE stream dropped)"
-        cost = "n/a (stream dropped before the cost event)"
+        outcome = (
+            "⚠️ completed (recovered via completion marker — "
+            "the SSE stream ended abnormally)"
+        )
+        cost = st.cost or "n/a (stream ended before the cost event)"
     else:
         outcome = "❌ failed"
         cost = st.cost or "n/a"
@@ -516,10 +523,28 @@ def write_step_summary(content: str) -> None:
         print(f"::warning::Could not write step summary: {e}")
 
 
+def clean_success(st: SSEState) -> bool:
+    """True when the stream itself proved success (complete + status ok)."""
+    return st.completed and st.status == "completed" and not st.errored
+
+
 def decide_exit(
     st: SSEState, recovered: dict[str, str] | None = None
 ) -> tuple[int, str]:
-    """Map the final stream state (+ marker recovery) to (exit_code, message)."""
+    """Map the final stream state (+ marker recovery) to (exit_code, message).
+
+    The completion marker is ground truth: it can only exist if the run's
+    Stage 7 executed, so it overrides transport-level failures (silent stream
+    drops AND spurious error events — both observed in production after the
+    sandbox had already finished its work).
+    """
+    if clean_success(st):
+        return 0, f"SDK Evolution completed successfully (cost={st.cost})."
+    if recovered is not None:
+        return 0, (
+            "SDK Evolution completed (outcome recovered via completion "
+            "marker; the SSE stream ended abnormally)."
+        )
     if st.errored:
         return 1, f"::error::Sandbox error: code={st.err_code} message={st.err_msg}"
     if not st.got_event:
@@ -528,18 +553,11 @@ def decide_exit(
             "::error::Stream ended without a single SSE event — likely VPN/network/proxy issue",
         )
     if not st.completed:
-        if recovered is not None:
-            return 0, (
-                "SDK Evolution completed (outcome recovered via completion "
-                "marker after an SSE stream drop)."
-            )
         return 1, (
             "::error::Stream ended without a 'complete' event and no "
             "completion marker appeared"
         )
-    if st.status != "completed":
-        return 1, f"::error::Sandbox final status={st.status} (expected 'completed')"
-    return 0, f"SDK Evolution completed successfully (cost={st.cost})."
+    return 1, f"::error::Sandbox final status={st.status} (expected 'completed')"
 
 
 def check_health(
@@ -630,14 +648,17 @@ def main() -> int:
         st.err_code = "http_error"
         st.err_msg = str(e)
 
+    # Any abnormal ending (silent drop, spurious error event, error status)
+    # gets a marker poll — but only if the sandbox was actually started
+    # (got_event); a failed POST can't have produced a marker.
     recovered: dict[str, str] | None = None
-    if st.got_event and not st.errored and not st.completed:
+    if st.got_event and not clean_success(st):
         gh_token = os.environ.get("GH_TOKEN", "")
         repo = os.environ.get("GITHUB_REPOSITORY", "atlanhq/application-sdk")
         if gh_token:
             print(
-                "::warning::SSE stream ended without a 'complete' event — "
-                "polling for the run's completion marker"
+                "::warning::Stream ended abnormally — polling for the run's "
+                "completion marker"
             )
             recovered = poll_completion_marker(
                 repo, str(payload["source_id"]), run_date, gh_token

--- a/.github/scripts/tests/test_sdk_evolution_dispatch.py
+++ b/.github/scripts/tests/test_sdk_evolution_dispatch.py
@@ -357,76 +357,78 @@ class _ApiResp:
         return False
 
 
-def _api_opener(issues, comments):
-    """Fake urlopen routing the two GitHub API calls the poll makes."""
+def _linear_opener(comment_bodies, issue_present=True):
+    """Fake urlopen answering the Linear GraphQL marker query."""
 
     def opener(req, timeout=0):
-        url = req.full_url
-        if "/comments" in url:
-            return _ApiResp(comments)
-        assert "labels=sdk-evolution-marker" in url
-        return _ApiResp(issues)
+        assert req.full_url == sd.LINEAR_API_URL
+        sent = json.loads(req.data.decode())
+        assert sent["variables"]["issue"]
+        if not issue_present:
+            return _ApiResp({"data": {"issue": None}})
+        needle = sent["variables"]["needle"]
+        nodes = [{"body": b} for b in comment_bodies if needle in b]
+        return _ApiResp({"data": {"issue": {"comments": {"nodes": nodes}}}})
 
     return opener
 
 
 def test_fetch_marker_summary_found():
-    opener = _api_opener(issues=[{"number": 42}], comments=[{"body": _MARKER_BODY}])
     got = sd.fetch_marker_summary(
-        "o/r", "sdk-evolution-daily-2026-07-08", "2026-07-08", "tok", opener
+        "BLDX-1565",
+        "sdk-evolution-daily-2026-07-08",
+        "key",
+        _linear_opener([_MARKER_BODY]),
     )
     assert got is not None and got["discovered"] == "12"
 
 
 def test_fetch_marker_summary_wrong_source_id_is_not_found():
-    opener = _api_opener(issues=[{"number": 42}], comments=[{"body": _MARKER_BODY}])
     got = sd.fetch_marker_summary(
-        "o/r", "sdk-evolution-weekly-2026-07-05", "2026-07-05", "tok", opener
+        "BLDX-1565",
+        "sdk-evolution-weekly-2026-07-05",
+        "key",
+        _linear_opener([_MARKER_BODY]),
     )
     assert got is None
 
 
 def test_fetch_marker_found_but_malformed_block_still_counts():
     # The marker alone proves Stage 7 ran; metrics are best-effort.
-    opener = _api_opener(
-        issues=[{"number": 42}],
-        comments=[{"body": "marker: sdk-evolution-daily-2026-07-08"}],
-    )
     got = sd.fetch_marker_summary(
-        "o/r", "sdk-evolution-daily-2026-07-08", "2026-07-08", "tok", opener
+        "BLDX-1565",
+        "sdk-evolution-daily-2026-07-08",
+        "key",
+        _linear_opener(["marker: sdk-evolution-daily-2026-07-08"]),
     )
     assert got == {}
 
 
-def test_fetch_marker_no_tracking_issue():
-    opener = _api_opener(issues=[], comments=[])
-    assert sd.fetch_marker_summary("o/r", "sid", "2026-07-08", "tok", opener) is None
+def test_fetch_marker_no_tracking_ticket():
+    opener = _linear_opener([], issue_present=False)
+    assert sd.fetch_marker_summary("BLDX-0", "sid", "key", opener) is None
 
 
 def test_fetch_marker_api_error_counts_as_not_found():
     def opener(req, timeout=0):
         raise OSError("boom")
 
-    assert sd.fetch_marker_summary("o/r", "sid", "2026-07-08", "tok", opener) is None
+    assert sd.fetch_marker_summary("BLDX-1565", "sid", "key", opener) is None
 
 
 def test_poll_marker_found_on_later_attempt():
     calls = {"n": 0}
-    found_opener = _api_opener(
-        issues=[{"number": 42}], comments=[{"body": _MARKER_BODY}]
-    )
+    found = _linear_opener([_MARKER_BODY])
+    empty = _linear_opener([])
 
     def opener(req, timeout=0):
         calls["n"] += 1
-        if calls["n"] <= 2:  # first attempt: issue exists, no comment yet
-            return _api_opener(issues=[{"number": 42}], comments=[])(req, timeout)
-        return found_opener(req, timeout)
+        return (empty if calls["n"] <= 2 else found)(req, timeout)
 
     got = sd.poll_completion_marker(
-        "o/r",
+        "BLDX-1565",
         "sdk-evolution-daily-2026-07-08",
-        "2026-07-08",
-        "tok",
+        "key",
         opener=opener,
         sleeper=lambda _: None,
         attempts=5,
@@ -435,17 +437,33 @@ def test_poll_marker_found_on_later_attempt():
 
 
 def test_poll_marker_times_out():
-    opener = _api_opener(issues=[{"number": 42}], comments=[])
     slept = {"n": 0}
 
     def sleeper(_):
         slept["n"] += 1
 
     got = sd.poll_completion_marker(
-        "o/r", "sid", "2026-07-08", "tok", opener=opener, sleeper=sleeper, attempts=3
+        "BLDX-1565",
+        "sid",
+        "key",
+        opener=_linear_opener([]),
+        sleeper=sleeper,
+        attempts=3,
     )
     assert got is None
     assert slept["n"] == 2  # no sleep after the final attempt
+
+
+def test_prompt_carries_marker_ticket():
+    daily = sd.build_prompt(
+        "daily", "d", "u", 5, focus="BUG", marker_ticket="BLDX-1565"
+    )
+    weekly = sd.build_prompt(
+        "weekly", "d", "u", 5, theme="ARCH", marker_ticket="BLDX-1565"
+    )
+    assert "MARKER_TICKET:    BLDX-1565" in daily
+    assert "MARKER_TICKET:    BLDX-1565" in weekly
+    assert "NEVER create GitHub issues" in daily
 
 
 def test_decide_exit_incomplete_stream_recovered_by_marker():

--- a/.github/scripts/tests/test_sdk_evolution_dispatch.py
+++ b/.github/scripts/tests/test_sdk_evolution_dispatch.py
@@ -458,9 +458,33 @@ def test_decide_exit_incomplete_stream_recovered_by_marker():
     assert sd.decide_exit(st, recovered=None)[0] == 1
 
 
-def test_decide_exit_error_wins_over_recovery():
+def test_decide_exit_marker_overrides_spurious_error_event():
+    # Production case: the sandbox finished Stage 7 (marker posted), then the
+    # stream carried an empty `error` event. Marker is ground truth → success.
     st = _stream("event: error", 'data: {"code": "boom", "message": "kaboom"}')
-    assert sd.decide_exit(st, recovered={"fix_prs": "3"})[0] == 1
+    code, msg = sd.decide_exit(st, recovered={"fix_prs": "3"})
+    assert code == 0 and "completion marker" in msg
+    # Without a marker, the error stays an error.
+    assert sd.decide_exit(st, recovered=None)[0] == 1
+
+
+def test_decide_exit_marker_overrides_error_status():
+    st = _stream("event: complete", 'data: {"status": "error"}')
+    assert sd.decide_exit(st, recovered={})[0] == 0
+    assert sd.decide_exit(st, recovered=None)[0] == 1
+
+
+def test_error_event_with_empty_payload_logs_raw():
+    st = sd.SSEState()
+    st.event = "error"
+    st.got_event = True
+    msg = sd.process_line('data: {"detail": "sandbox evicted"}', st)
+    assert msg is not None and "raw=" in msg and "sandbox evicted" in msg
+    # A well-formed error payload stays concise (no raw dump).
+    st2 = sd.SSEState()
+    st2.event = "error"
+    msg2 = sd.process_line('data: {"code": "boom", "message": "kaboom"}', st2)
+    assert msg2 is not None and "raw=" not in msg2
 
 
 def test_render_step_summary_recovered_run():

--- a/.github/scripts/tests/test_sdk_evolution_dispatch.py
+++ b/.github/scripts/tests/test_sdk_evolution_dispatch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import sys
 from pathlib import Path
@@ -38,31 +39,88 @@ def test_auto_with_bad_date_falls_back_to_daily():
 
 
 # ---------------------------------------------------------------------------
+# focus / theme resolution
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_focus_is_respected():
+    assert sd.resolve_focus("DOCS", "2026-07-06") == "DOCS"
+    assert sd.resolve_focus("types+apicompat", "2026-07-06") == "TYPES+APICOMPAT"
+
+
+def test_auto_focus_rotates_by_weekday():
+    # 2026-07-06 Mon, 2026-07-07 Tue, 2026-07-08 Wed, 2026-07-11 Sat.
+    assert sd.resolve_focus("auto", "2026-07-06") == "BUG"
+    assert sd.resolve_focus("auto", "2026-07-07") == "DOCS"
+    assert sd.resolve_focus("auto", "2026-07-08") == "TEST"
+    assert sd.resolve_focus("auto", "2026-07-11") == "CONF"
+
+
+def test_focus_bad_date_or_unknown_falls_back_to_bug():
+    assert sd.resolve_focus("auto", "not-a-date") == "BUG"
+    assert sd.resolve_focus("NOT-A-FAMILY", "not-a-date") == "BUG"
+
+
+def test_explicit_theme_is_respected():
+    assert sd.resolve_theme("toolkit", "2026-07-05") == "TOOLKIT"
+
+
+def test_auto_theme_rotates_by_iso_week():
+    for date_str in ("2026-07-05", "2026-07-12"):
+        y, m, d = (int(x) for x in date_str.split("-"))
+        expected = sd.WEEKLY_THEMES[
+            dt.date(y, m, d).isocalendar()[1] % len(sd.WEEKLY_THEMES)
+        ]
+        assert sd.resolve_theme("auto", date_str) == expected
+    # Consecutive Sundays advance the rotation by exactly one slot.
+    a = sd.WEEKLY_THEMES.index(sd.resolve_theme("auto", "2026-07-05"))
+    b = sd.WEEKLY_THEMES.index(sd.resolve_theme("auto", "2026-07-12"))
+    assert b == (a + 1) % len(sd.WEEKLY_THEMES)
+
+
+def test_theme_bad_date_falls_back_to_first():
+    assert sd.resolve_theme("auto", "not-a-date") == sd.WEEKLY_THEMES[0]
+
+
+# ---------------------------------------------------------------------------
 # payload / prompt shape
 # ---------------------------------------------------------------------------
 
 
 def test_payload_shape_carries_tier():
-    p = sd.build_payload("weekly", "2026-07-05", "http://run", 7)
+    p = sd.build_payload("weekly", "2026-07-05", "http://run", 7, theme="ARCH")
     assert p["mode"] == "direct" and p["stream"] is True
     assert p["source_id"] == "sdk-evolution-weekly-2026-07-05"
     assert p["repositories"] == ["atlanhq/application-sdk"]
+    assert p["base_branch"] == "main"
     assert p["metadata"]["tier"] == "weekly"
+    assert p["metadata"]["theme"] == "ARCH"
     assert p["metadata"]["consumer_pr_cap"] == 7
 
 
+def test_payload_base_branch_override():
+    # Verification runs point the sandbox at a PR branch's playbook pre-merge.
+    p = sd.build_payload("daily", "d", "u", 5, focus="BUG", base_branch="my-branch")
+    assert p["base_branch"] == "my-branch"
+    assert p["metadata"]["focus"] == "BUG"
+
+
 def test_prompt_differs_by_tier():
-    weekly = sd.build_prompt("weekly", "d", "u", 5)
-    daily = sd.build_prompt("daily", "d", "u", 5)
-    assert "WEEKLY run" in weekly and "CONSUMER_PR_CAP=5" in weekly
-    assert "DAILY run" in daily
+    weekly = sd.build_prompt("weekly", "d", "u", 5, theme="TEMPORAL")
+    daily = sd.build_prompt("daily", "d", "u", 5, focus="DOCS")
+    assert "WEEKLY run" in weekly and "THEME=TEMPORAL" in weekly
+    assert "DAILY run" in daily and "FOCUS=DOCS" in daily
+    assert "THEME:" in weekly and "FOCUS:" in daily
+    assert "FOCUS:" not in weekly and "THEME:" not in daily
     assert "check-registry.md" in daily  # both tiers point at the registry
 
 
-def test_consumer_pr_cap_metadata_is_weekly_only():
-    # The CONSUMER_PR_CAP metadata row is clutter on daily (daily ignores it).
-    assert "CONSUMER_PR_CAP:" in sd.build_prompt("weekly", "d", "u", 5)
-    assert "CONSUMER_PR_CAP:" not in sd.build_prompt("daily", "d", "u", 5)
+def test_consumer_pr_cap_is_consumers_theme_only():
+    # The cap only governs the weekly CONSUMERS audit — clutter elsewhere.
+    consumers = sd.build_prompt("weekly", "d", "u", 5, theme="CONSUMERS")
+    assert "CONSUMER_PR_CAP:  5" in consumers and "CONSUMER_PR_CAP=5" in consumers
+    assert "CONSUMER_PR_CAP" not in sd.build_prompt("weekly", "d", "u", 5, theme="ARCH")
+    assert "CONSUMER_PR_CAP" not in sd.build_prompt("daily", "d", "u", 5, focus="BUG")
 
 
 def test_main_missing_required_env_returns_1(monkeypatch):
@@ -276,3 +334,146 @@ def test_health_retries_then_fails():
 
     assert sd.check_health("http://m", opener=opener, sleeper=lambda _: None) is False
     assert calls["n"] == sd.HEALTH_RETRIES
+
+
+# ---------------------------------------------------------------------------
+# completion-marker backstop (SSE stream drop)
+# ---------------------------------------------------------------------------
+
+_MARKER_BODY = f"marker: sdk-evolution-daily-2026-07-08\n\n{_SUMMARY_BLOCK}"
+
+
+class _ApiResp:
+    def __init__(self, obj):
+        self._obj = obj
+
+    def read(self):
+        return json.dumps(self._obj).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _api_opener(issues, comments):
+    """Fake urlopen routing the two GitHub API calls the poll makes."""
+
+    def opener(req, timeout=0):
+        url = req.full_url
+        if "/comments" in url:
+            return _ApiResp(comments)
+        assert "labels=sdk-evolution-marker" in url
+        return _ApiResp(issues)
+
+    return opener
+
+
+def test_fetch_marker_summary_found():
+    opener = _api_opener(issues=[{"number": 42}], comments=[{"body": _MARKER_BODY}])
+    got = sd.fetch_marker_summary(
+        "o/r", "sdk-evolution-daily-2026-07-08", "2026-07-08", "tok", opener
+    )
+    assert got is not None and got["discovered"] == "12"
+
+
+def test_fetch_marker_summary_wrong_source_id_is_not_found():
+    opener = _api_opener(issues=[{"number": 42}], comments=[{"body": _MARKER_BODY}])
+    got = sd.fetch_marker_summary(
+        "o/r", "sdk-evolution-weekly-2026-07-05", "2026-07-05", "tok", opener
+    )
+    assert got is None
+
+
+def test_fetch_marker_found_but_malformed_block_still_counts():
+    # The marker alone proves Stage 7 ran; metrics are best-effort.
+    opener = _api_opener(
+        issues=[{"number": 42}],
+        comments=[{"body": "marker: sdk-evolution-daily-2026-07-08"}],
+    )
+    got = sd.fetch_marker_summary(
+        "o/r", "sdk-evolution-daily-2026-07-08", "2026-07-08", "tok", opener
+    )
+    assert got == {}
+
+
+def test_fetch_marker_no_tracking_issue():
+    opener = _api_opener(issues=[], comments=[])
+    assert sd.fetch_marker_summary("o/r", "sid", "2026-07-08", "tok", opener) is None
+
+
+def test_fetch_marker_api_error_counts_as_not_found():
+    def opener(req, timeout=0):
+        raise OSError("boom")
+
+    assert sd.fetch_marker_summary("o/r", "sid", "2026-07-08", "tok", opener) is None
+
+
+def test_poll_marker_found_on_later_attempt():
+    calls = {"n": 0}
+    found_opener = _api_opener(
+        issues=[{"number": 42}], comments=[{"body": _MARKER_BODY}]
+    )
+
+    def opener(req, timeout=0):
+        calls["n"] += 1
+        if calls["n"] <= 2:  # first attempt: issue exists, no comment yet
+            return _api_opener(issues=[{"number": 42}], comments=[])(req, timeout)
+        return found_opener(req, timeout)
+
+    got = sd.poll_completion_marker(
+        "o/r",
+        "sdk-evolution-daily-2026-07-08",
+        "2026-07-08",
+        "tok",
+        opener=opener,
+        sleeper=lambda _: None,
+        attempts=5,
+    )
+    assert got is not None and got["fix_prs"] == "3"
+
+
+def test_poll_marker_times_out():
+    opener = _api_opener(issues=[{"number": 42}], comments=[])
+    slept = {"n": 0}
+
+    def sleeper(_):
+        slept["n"] += 1
+
+    got = sd.poll_completion_marker(
+        "o/r", "sid", "2026-07-08", "tok", opener=opener, sleeper=sleeper, attempts=3
+    )
+    assert got is None
+    assert slept["n"] == 2  # no sleep after the final attempt
+
+
+def test_decide_exit_incomplete_stream_recovered_by_marker():
+    st = _stream("event: action", 'data: {"action_name": "grep"}')
+    code, msg = sd.decide_exit(st, recovered={"fix_prs": "3"})
+    assert code == 0 and "completion marker" in msg
+    # An empty recovered dict (marker found, block malformed) still passes.
+    assert sd.decide_exit(st, recovered={})[0] == 0
+    # No recovery → the original failure.
+    assert sd.decide_exit(st, recovered=None)[0] == 1
+
+
+def test_decide_exit_error_wins_over_recovery():
+    st = _stream("event: error", 'data: {"code": "boom", "message": "kaboom"}')
+    assert sd.decide_exit(st, recovered={"fix_prs": "3"})[0] == 1
+
+
+def test_render_step_summary_recovered_run():
+    st = sd.SSEState()
+    st.got_event = True  # stream started, then dropped
+    out = sd.render_step_summary(
+        st,
+        "daily",
+        "2026-07-08",
+        "http://run",
+        recovered=sd.parse_summary(_SUMMARY_BLOCK),
+    )
+    assert "recovered via completion marker" in out
+    assert "| discovered | 12 |" in out
+    assert "BLDX-9" in out
+    assert "❌ failed" not in out

--- a/.github/workflows/sdk-evolution-cron.yml
+++ b/.github/workflows/sdk-evolution-cron.yml
@@ -135,6 +135,9 @@ jobs:
       # in one tested place, not the YAML.
       - name: Dispatch SDK Evolution to mothership Rover Direct API
         env:
+          # Unbuffered so SSE progress lines appear live in the GHA log
+          # instead of flushing in one block at process exit.
+          PYTHONUNBUFFERED: '1'
           MOTHERSHIP_URL: ${{ vars.MOTHERSHIP_URL }}
           HARNESS_TOKEN: ${{ secrets.HARNESS_TOKEN }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/sdk-evolution-cron.yml
+++ b/.github/workflows/sdk-evolution-cron.yml
@@ -7,13 +7,18 @@
 # logic lives there, not on mothership.
 #
 # ONE pipeline, two tiers (the orchestration branches on TIER):
-#   daily  (Mon–Sat) — fast, high-confidence pass over the whole SDK.
-#   weekly (Sunday)  — the daily superset: design/ADR PRs, /audit-consumers
-#                      across v3 apps (bounded consumer PRs), toolkit deep review.
-# Both tiers cover application_sdk/, packages/conformance/ and contract-toolkit/.
+#   daily  (Mon–Sat) — light pass: last-36h commit delta across all daily check
+#                      families + ONE rotating deep-focus family per weekday.
+#   weekly (Sunday)  — ONE rotating design theme (ARCH → TEMPORAL → CONSUMERS →
+#                      TOOLKIT → DX → PERF), producing one DESIGN PR/ADR.
 #
 # The dispatch + SSE-stream parsing + GITHUB_STEP_SUMMARY rendering live in the
 # tested sdk_evolution_dispatch.py (see docs/standards/ci.md) — NOT inlined here.
+# The script also owns the stream-drop backstop: if mothership's SSE stream
+# drops mid-run (the sandbox usually keeps working), it polls the pinned
+# completion-marker issue (label `sdk-evolution-marker`) where the run's
+# Stage 7 posts its summary — so a dropped stream no longer fails a run that
+# actually completed. That backstop needs `issues: read` + GH_TOKEN below.
 #
 # SCHEDULE IS DISABLED until a manual run proves the step summary + Linear
 # parent link render (that observability gap is exactly why the previous cron
@@ -30,7 +35,7 @@ name: SDK Evolution
 
 on:
   # Re-enable once a manual run proves the run is observable (job summary +
-  # Linear parent link). Weekly (Sunday) is the superset; Mon–Sat are daily.
+  # Linear parent link). Sunday is the weekly design theme; Mon–Sat are daily.
   # schedule:
   #   - cron: '0 2 * * 0'      # Sunday 2am UTC  → weekly
   #   - cron: '0 2 * * 1-6'    # Mon–Sat 2am UTC → daily
@@ -45,21 +50,54 @@ on:
           - auto
           - daily
           - weekly
+      focus:
+        description: 'Daily only: deep-focus family override (auto = by weekday)'
+        required: false
+        default: 'auto'
+        type: choice
+        options:
+          - auto
+          - BUG
+          - DOCS
+          - TEST
+          - TYPES+APICOMPAT
+          - STALE+MANIFEST+LOG
+          - CONF
+      theme:
+        description: 'Weekly only: design theme override (auto = by ISO week)'
+        required: false
+        default: 'auto'
+        type: choice
+        options:
+          - auto
+          - ARCH
+          - TEMPORAL
+          - CONSUMERS
+          - TOOLKIT
+          - DX
+          - PERF
       consumer_pr_cap:
-        description: 'Weekly only: max consumer migration PRs per run (rest rotate to next week)'
+        description: 'Weekly CONSUMERS theme only: max consumer migration PRs per run'
         required: false
         default: '5'
+        type: string
+      base_branch:
+        description: 'Branch the sandbox clones (override to verify a PR branch pre-merge)'
+        required: false
+        default: 'main'
         type: string
 
 permissions:
   contents: read
+  issues: read
 
 jobs:
   trigger:
     runs-on: ubuntu-latest
     # The sandbox runs up to 2h (max_timeout_seconds: 7200); the dispatch
-    # script's stream timeout matches.
-    timeout-minutes: 130
+    # script's stream timeout matches, and the marker-poll backstop adds up
+    # to 45 min after a stream drop.
+    timeout-minutes: 175
     steps:
       - name: Checkout repo (for local globalprotect-connect action)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -91,14 +129,19 @@ jobs:
           username: ${{ secrets.GLOBALPROTECT_USERNAME }}
           password: ${{ secrets.GLOBALPROTECT_PASSWORD }}
 
-      # Manual runs pass the chosen input; scheduled runs pass 'auto' and the
-      # tested dispatch script resolves it by weekday (weekly on Sunday, else
-      # daily) — keeping tier logic in one tested place, not the YAML.
+      # Manual runs pass the chosen inputs; scheduled runs pass 'auto' and the
+      # tested dispatch script resolves tier by weekday, the daily focus by
+      # weekday and the weekly theme by ISO week — keeping all of that logic
+      # in one tested place, not the YAML.
       - name: Dispatch SDK Evolution to mothership Rover Direct API
         env:
           MOTHERSHIP_URL: ${{ vars.MOTHERSHIP_URL }}
           HARNESS_TOKEN: ${{ secrets.HARNESS_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TIER: ${{ inputs.tier || 'auto' }}
+          FOCUS: ${{ inputs.focus || 'auto' }}
+          THEME: ${{ inputs.theme || 'auto' }}
           CONSUMER_PR_CAP: ${{ inputs.consumer_pr_cap || '5' }}
+          BASE_BRANCH: ${{ inputs.base_branch || 'main' }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: python3 .github/scripts/sdk_evolution_dispatch.py

--- a/.github/workflows/sdk-evolution-cron.yml
+++ b/.github/workflows/sdk-evolution-cron.yml
@@ -15,10 +15,10 @@
 # The dispatch + SSE-stream parsing + GITHUB_STEP_SUMMARY rendering live in the
 # tested sdk_evolution_dispatch.py (see docs/standards/ci.md) — NOT inlined here.
 # The script also owns the stream-drop backstop: if mothership's SSE stream
-# drops mid-run (the sandbox usually keeps working), it polls the pinned
-# completion-marker issue (label `sdk-evolution-marker`) where the run's
-# Stage 7 posts its summary — so a dropped stream no longer fails a run that
-# actually completed. That backstop needs `issues: read` + GH_TOKEN below.
+# ends abnormally (the sandbox usually keeps working), it polls the pinned
+# Linear marker ticket (MARKER_TICKET below) where the run's Stage 7 posts its
+# summary — so a bad stream no longer fails a run that actually completed.
+# All run tracking lives in Linear; the pipeline creates NO GitHub issues.
 #
 # SCHEDULE IS DISABLED until a manual run proves the step summary + Linear
 # parent link render (that observability gap is exactly why the previous cron
@@ -89,7 +89,6 @@ on:
 
 permissions:
   contents: read
-  issues: read
 
 jobs:
   trigger:
@@ -140,7 +139,11 @@ jobs:
           PYTHONUNBUFFERED: '1'
           MOTHERSHIP_URL: ${{ vars.MOTHERSHIP_URL }}
           HARNESS_TOKEN: ${{ secrets.HARNESS_TOKEN }}
-          GH_TOKEN: ${{ github.token }}
+          # Completion-marker backstop: the run posts its Stage 7 summary as a
+          # comment on this pinned Linear ticket; on an abnormal stream ending
+          # the dispatch script polls it via LINEAR_API_KEY.
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          MARKER_TICKET: BLDX-1565
           TIER: ${{ inputs.tier || 'auto' }}
           FOCUS: ${{ inputs.focus || 'auto' }}
           THEME: ${{ inputs.theme || 'auto' }}

--- a/.mothership/sdk-evolution/CLAUDE.md
+++ b/.mothership/sdk-evolution/CLAUDE.md
@@ -6,10 +6,10 @@ Your job: find what CI **cannot** catch — semantic bugs, docs staleness, weak
 tests, design drift, better Temporal usage, and SDK-improvement opportunities —
 then open Linear tickets + PRs for validated findings. One pipeline, two tiers.
 
-Mothership clones this repo on `main` into `/workspace/application-sdk` and
-runs you with a prompt carrying the run context (`RUN_DATE`, `TIER`,
-`GHA_RUN_URL`, and weekly `CONSUMER_PR_CAP`). Follow
-`.mothership/sdk-evolution/ORCHESTRATION.md` exactly. Print
+Mothership clones this repo into `/workspace/application-sdk` and runs you
+with a prompt carrying the run context (`RUN_DATE`, `TIER`, `GHA_RUN_URL`,
+plus daily `FOCUS` or weekly `THEME` — and `CONSUMER_PR_CAP` on the CONSUMERS
+theme). Follow `.mothership/sdk-evolution/ORCHESTRATION.md` exactly. Print
 `[Stage N complete] …` after each stage so the run is observable.
 
 ## Read first (source of truth)
@@ -26,14 +26,15 @@ reads the freshly-cloned source directly.
 
 ## Tiers
 
-- **daily** (Mon–Sat) — fast, high-confidence, whole SDK but shallow. Only
-  what a senior engineer would merge without a design debate.
-- **weekly** (Sunday) — the daily superset plus the deep and cross-repo work:
-  architecture/ADR drift, Temporal-concept ADR PRs, `/audit-consumers` across
-  v3 apps, toolkit deep review. No fixed PR cap — bounded by the time budget.
-
-Both tiers cover all three surfaces: `application_sdk/`, `packages/conformance/`,
-`contract-toolkit/`.
+- **daily** (Mon–Sat) — the light pass: the last-36h **commit delta** across
+  all daily check families + today's **`FOCUS`** family deep across all three
+  surfaces (`application_sdk/`, `packages/conformance/`, `contract-toolkit/`).
+  Only what a senior engineer would merge without a design debate. Quiet day →
+  cheap early exit; that is a success, not a shortfall.
+- **weekly** (Sunday) — ONE design deep-dive on **`THEME`** (rotation:
+  ARCH → TEMPORAL → CONSUMERS → TOOLKIT → DX → PERF). Output contract: one
+  well-argued DESIGN PR/ADR + at most 3 incidental small FIX PRs. Weekly does
+  NOT run the daily families.
 
 ## SDK v3 architecture context
 
@@ -60,8 +61,10 @@ Both tiers cover all three surfaces: `application_sdk/`, `packages/conformance/`
 8. **One `@sdk-review` pass, human merges** — no auto-complete/auto-merge loop
    while trust is being re-earned.
 9. **Conformance proposals ship rule + remediation in the SAME PR.**
-10. **Observability is the contract** — a run with no Linear parent + no step
-    summary is a failed run. This is why the cron was disabled before.
+10. **Observability is the contract** — a run that ends without the Stage 7
+    summary block AND the completion-marker comment is a failed run, even if
+    it opened PRs. This is why the cron was disabled before. (Zero-survivor
+    runs skip the Linear parent ticket — the summary + marker are the record.)
 
 ## Rules
 

--- a/.mothership/sdk-evolution/ORCHESTRATION.md
+++ b/.mothership/sdk-evolution/ORCHESTRATION.md
@@ -1,8 +1,15 @@
 # SDK Evolution — Orchestration Playbook
 
 One playbook, two tiers. The dispatch prompt sets **`TIER`** (`daily` |
-`weekly`). Daily is the fast, high-confidence pass (Mon–Sat). Weekly is the
-Sunday superset that also does the deep, design-level and cross-repo work.
+`weekly`) plus the tier's scope knob:
+
+- **daily** (Mon–Sat) — the light pass. Two scans only: the **commit delta**
+  of the last 36 hours across all daily check families, and today's
+  **`FOCUS`** family deep across all three surfaces. Quiet day → cheap early
+  exit.
+- **weekly** (Sunday) — ONE design deep-dive on **`THEME`**. The output is a
+  single well-argued DESIGN PR/ADR, not a breadth sweep. Weekly does NOT run
+  the daily families.
 
 Follow every stage in order. Every finding exits in exactly one state:
 **FIX** (PR), **DESIGN** (PR/ticket, `needs-design-review`), or **KILLED**
@@ -14,38 +21,41 @@ stage so the run is observable in the log.
 | Stage | daily | weekly |
 |---|---|---|
 | 0 Preflight | 2 min | 3 min |
-| 1 Discovery | 8 min | 20 min |
-| 2 Self-verify | 4 min | 8 min |
-| 3 Feasibility & worth | 4 min | 8 min |
-| 4 Tickets + PRs | 12 min | 30 min |
-| 5 Validation | 5 min | 10 min |
-| 6 Handoff | 2 min | 3 min |
-| 7 Summary | 2 min | 3 min |
-| **Hard stop** | **40 min** | **110 min** |
+| 1 Discovery | 6 min | 15 min |
+| 2 Self-verify | 3 min | 6 min |
+| 3 Feasibility & worth | 3 min | 6 min |
+| 4 Tickets + PRs | 6 min | 20 min |
+| 5 Validation | 3 min | 6 min |
+| 6 Handoff | 1 min | 2 min |
+| 7 Summary | 1 min | 2 min |
+| **Hard stop** | **25 min** | **60 min** (CONSUMERS theme: **90 min**) |
 
 At the hard stop: stop opening new work, close any un-validated PRs, cancel
 orphan tickets, jump to Stage 7 and emit the summary. A partial run with clean
 state beats a full run that dies mid-PR. (The sandbox itself caps at
-`max_timeout_seconds: 7200`; the weekly hard stop sits safely inside it.)
+`max_timeout_seconds: 7200`; both hard stops sit safely inside it.)
 
 ---
 
 ## Stage 0: Preflight
 
-Read `RUN_DATE`, `TIER`, `GHA_RUN_URL`, and (weekly only) `CONSUMER_PR_CAP` from
-the prompt header — do NOT re-derive them.
+Read `RUN_DATE`, `TIER`, `GHA_RUN_URL`, plus `FOCUS` (daily) or `THEME`
+(weekly, with `CONSUMER_PR_CAP` on the CONSUMERS theme) from the prompt
+header — do NOT re-derive them.
 
-1. **Working dir** — mothership cloned the repo on `main`:
+1. **Working dir** — mothership cloned the repo:
    ```bash
    cd /workspace/application-sdk
    uv sync --all-extras 2>/dev/null &      # warm deps in background
    echo "$GITHUB_TOKEN" | gh auth login --with-token 2>/dev/null
    ```
 2. **Read the playbook assets** (source of truth):
-   - `.mothership/sdk-evolution/references/check-registry.md` — which checks
-     run at this TIER, and the **DO-NOT-re-report** exclusion list.
+   - `.mothership/sdk-evolution/references/check-registry.md` — the check
+     families, their focus-day/theme mapping, and the **DO-NOT-re-report**
+     exclusion list.
    - `.mothership/sdk-evolution/agents/*.md` — the three discovery agents.
-   - `.mothership/sdk-evolution/tools.md` — Linear + GitHub + `@sdk-review`.
+   - `.mothership/sdk-evolution/tools.md` — Linear + GitHub + `@sdk-review`
+     + the completion-marker issue.
 3. **Build the suppression list** — query Linear for open tickets in the
    "App SDK v3.0" project (see tools.md). Extract file paths + rule IDs from
    each open ticket; skip re-raising them. On proxy failure → empty suppression
@@ -59,29 +69,39 @@ the prompt header — do NOT re-derive them.
    self-improve-to-Linear YAML with a signal you can trust: what humans actually
    merged vs closed.
 
-Print: `[Stage 0 complete] tier=<daily|weekly>, suppressed=<N>, noisy_categories=<list>`
+Print: `[Stage 0 complete] tier=<daily|weekly>, focus/theme=<value>, suppressed=<N>, noisy_categories=<list>`
 
 ---
 
-## Stage 1: Discovery (3 agents, parallel)
+## Stage 1: Discovery
 
-Dispatch all three via the Agent tool simultaneously. Each reads the same files
-and applies the checks the **check-registry** assigns to this TIER:
+### Daily — two scans, nothing else
 
-1. `agents/correctness-quality.md` →
-   `[BUG] [DOCS] [TEST] [STALE] [MANIFEST] [LOG] [TYPES] [APICOMPAT]`
-   and (weekly) `[ARCH] [FLAKY] [SMOKE]`.
-2. `agents/safety.md` → `[SEC]` (always) and (weekly)
-   `[PERF] [DEPDRIFT] [PERFTREND]`.
-3. `agents/evolution.md` → `[CONF]` (rule proposals), and (weekly)
-   `[DX] [CENTRAL] [TEMPORAL] [TOOLKIT] [EXAMPLE] [FLEET] [BOILERPLATE]
-   [APPHEALTH] [DOCSITE]`.
+1. **Delta scan.** Compute the change window:
+   ```bash
+   git log --since='36 hours ago' --name-only --pretty=format: origin/main | sort -u
+   ```
+   Every changed file on the three surfaces gets ALL daily check families
+   (see the registry). Dispatch only the discovery agents that own a family
+   with delta files to look at; give each agent the file list.
+2. **Focus scan.** Today's `FOCUS` family (or families, e.g.
+   `STALE+MANIFEST+LOG`) is scanned **deep across all three surfaces**
+   (`application_sdk/`, `packages/conformance/`, `contract-toolkit/`) by the
+   agent that owns it.
+3. **Early exit.** Empty delta AND clean focus scan → print
+   `[Stage 1 complete] 0 raw — early exit` and jump straight to Stage 7
+   (all-zero summary, marker comment, done). Do not pad the run.
 
-**Scope by surface, always all three:** `application_sdk/`,
-`packages/conformance/`, `contract-toolkit/`. Weekly additionally runs the
-`CONSUMERS` audit — see Stage 4.
+### Weekly — the theme, only the theme
 
-**Hard rule:** before flagging, every agent checks the registry's
+Dispatch ONLY the agent(s) that own this week's `THEME` (registry has the
+mapping). The goal is depth: read the whole subsystem, its callers, its ADRs,
+its consumers — enough to argue one design change convincingly. Do NOT run
+the daily families; incidental small defects you trip over may exit as at
+most 3 FIX PRs, everything else folds into the theme investigation or is
+KILLED.
+
+**Hard rule (both tiers):** before flagging, every agent checks the registry's
 DO-NOT-re-report list. Anything already gated by ruff / conformance CI / codeql
 / trivy is dropped at source, not surfaced.
 
@@ -89,8 +109,9 @@ DO-NOT-re-report list. Anything already gated by ruff / conformance CI / codeql
 - Matches suppression list → KILL.
 - Zero-caller code + severity < high → KILL.
 - Deprecated file + category ≠ security → KILL.
-- Daily tier + finding needs a design debate → convert to a weekly DESIGN
-  candidate note (don't PR it today), then KILL for this run.
+- Daily tier + finding needs a design debate → note it as a candidate for the
+  matching weekly THEME (mention it on the parent ticket if one is created),
+  then KILL for this run.
 
 Print: `[Stage 1 complete] <N> raw, <M> after pre-filter`
 
@@ -123,7 +144,8 @@ For each survivor, read the full file + its callers, then classify:
   it as-is → Stage 4 FIX path.
 - **DESIGN** — correct but larger / needs sign-off / a v3 replacement exists /
   the fix would worsen the code → Stage 4 DESIGN path (still gets a PR with the
-  proposed implementation so reviewers see real code).
+  proposed implementation so reviewers see real code). Daily never opens
+  DESIGN work — note it for the matching weekly theme and KILL.
 - **KILL** — not worth it, not feasible, or the fix is worse than the problem.
 
 Worth checks that force a KILL: tracked by an existing TODO+ticket; runs < 10×
@@ -139,12 +161,20 @@ Print: `[Stage 3 complete] <N> FIX, <M> DESIGN, <K> KILLED`
 ```bash
 git checkout main && git pull origin main
 ```
+(Verification runs may have cloned a non-main branch; PRs always branch off
+`origin/main`.)
 
 ### 4b. Linear parent ticket
-Create `SDK Evolution (<tier>) — <RUN_DATE>` in team **Builder Experience**,
-project **App SDK v3.0**, milestone **Autonomous SDK Evolution** (create if
-absent). Put the GHA run link at the top of the description:
-`**Run:** [logs + cost](<GHA_RUN_URL>)`. Every finding becomes a child.
+
+**Zero survivors → no parent ticket.** A run with nothing to hand over leaves
+only the Stage 7 summary + marker comment — daily Linear noise is a cost, not
+observability.
+
+Otherwise create `SDK Evolution (<tier>) — <RUN_DATE>` in team
+**Builder Experience**, project **App SDK v3.0**, milestone
+**Autonomous SDK Evolution** (create if absent). Put the GHA run link at the
+top of the description: `**Run:** [logs + cost](<GHA_RUN_URL>)`. Every finding
+becomes a child.
 
 **Tag the reviewers** (see tools.md → Reviewers): add both **Vaibhav Chopra**
 and **Chris** as subscribers on this parent and @-mention both in an opening
@@ -173,16 +203,15 @@ gh pr create --repo atlanhq/application-sdk --base main \
 ```
 Any step fails → cancel the ticket, no orphans. One test-fix retry, then KILL.
 
-**Grouping:** bug / security / perf / arch / centralization → individual PR.
+**Grouping:** bug / security / perf → individual PR.
 docs / test-quality / stale-cleanup → one PR per category.
-**No fixed PR cap** — open a PR for every finding that survives all gates. The
-bound is the stage time budget + the hard stop, not an arbitrary number; if the
-budget runs out, remaining survivors carry to the next run via the suppression
-list. Work in priority order so the most important work lands first when the
-budget is tight: security > bug > docs/test > stale > improvement > design.
+**Daily bound** is the time budget; work in priority order so the most
+important work lands first: security > bug > docs/test > stale > improvement.
+**Weekly bound** is the output contract: ONE DESIGN PR/ADR + ≤ 3 incidental
+FIX PRs.
 
-### 4d. DESIGN PRs
-Same mechanics, plus: title `[DESIGN] <category>: <title> [<TICKET_ID>]`,
+### 4d. DESIGN PR (weekly theme output)
+Same mechanics, plus: title `[DESIGN] <THEME>: <title> [<TICKET_ID>]`,
 labels `Autonomous SDK Evolution` + `needs-design-review`, and the body MUST
 include **Problem / Why it matters / Approaches considered (A/B/C) /
 Recommendation / How to review**. `[CONF]` proposals additionally carry the
@@ -190,27 +219,29 @@ rule **and its remediation counterpart in this same PR** + the catalog entry.
 
 **Tag the reviewers on every `needs-design-review` ticket** (see tools.md →
 Reviewers): add both **Vaibhav Chopra** and **Chris** as subscribers and
-@-mention both in a comment asking them to review the approach. This applies to
-DESIGN tickets here and the ADR tickets in 4e — anything needing human sign-off.
-Routine FIX tickets are NOT tagged (they go to `@sdk-review`).
+@-mention both in a comment asking them to review the approach. This applies
+to DESIGN and ADR tickets — anything needing human sign-off. Routine FIX
+tickets are NOT tagged (they go to `@sdk-review`).
 
-### 4e. Weekly-only work
-- **TEMPORAL** → open an **ADR PR** against `docs/adr/` (prototype diff where
-  feasible), `needs-design-review`.
-- **CONSUMERS** → run `/audit-consumers --sdk-major 3` (**v3 apps only**). Cover:
-  (a) **boilerplate removal** — app code reimplementing SDK-provided
+### 4e. Theme-specific playbooks (weekly)
+- **TEMPORAL** → the DESIGN output is an **ADR PR** against `docs/adr/`
+  (prototype diff where feasible), `needs-design-review`.
+- **CONSUMERS** → run `/audit-consumers --sdk-major 3` (**v3 apps only**).
+  Cover: (a) **boilerplate removal** — app code reimplementing SDK-provided
   functionality → migration PR that deletes it and calls the SDK; (b) **missing
   guardrails** → new app-scope conformance rule (rule + remediation same PR);
-  (c) **SDK gaps** → DESIGN ticket for a new SDK utility. Raise app-repo PRs with
-  `--raise-prs`, **capped at `CONSUMER_PR_CAP`**; list rotated-over repos on the
-  parent ticket so next week picks them up.
-- **APPHEALTH** → for each v3 app, check it still builds / boots / passes CI
-  against the current SDK; report the fleet's health on the parent ticket and
-  open a DESIGN ticket per app that's broken against current SDK.
+  (c) **SDK gaps** → the week's DESIGN ticket for a new SDK utility;
+  (d) **APPHEALTH/FLEET** — fleet health + version-drift section on the parent
+  ticket. App-repo PRs use `--raise-prs`, **capped at `CONSUMER_PR_CAP`**;
+  list rotated-over repos on the parent ticket so the next CONSUMERS week
+  picks them up.
 - **TOOLKIT** → changes to `contract-toolkit/` go through the
-  `toolkit-feature-workflow` downstream-compat validation before the PR opens.
+  `toolkit-feature-workflow` downstream-compat validation before the PR opens;
+  include the EXAMPLE freshness and `/scaffold-app` SMOKE checks.
+- **ARCH / DX / PERF** → standard DESIGN PR per 4d (PERF findings need a
+  benchmark note or a measured PERFTREND delta).
 
-Print: `[Stage 4 complete] parent=<ID>, <N> FIX PRs, <M> DESIGN PRs, <C> consumer PRs`
+Print: `[Stage 4 complete] parent=<ID|none>, <N> FIX PRs, <M> DESIGN PRs, <C> consumer PRs`
 
 ---
 
@@ -219,8 +250,8 @@ Print: `[Stage 4 complete] parent=<ID>, <N> FIX PRs, <M> DESIGN PRs, <C> consume
 For each PR: wait for CI (cap: daily 3 min, weekly 5 min), then deterministic
 checks — diff touches the flagged file; required test present for
 bug/security/perf; diff not bloated with unrelated files. On CI failure, one
-Sonnet-style fix attempt; if it persists → close PR + cancel ticket with a
-clear reason. Never leave a red PR open.
+fix attempt; if it persists → close PR + cancel ticket with a clear reason.
+Never leave a red PR open.
 
 Print: `[Stage 5 complete] <N> passed, <M> killed`
 
@@ -245,16 +276,17 @@ Print: `[Stage 6 complete] <N> PRs sent for one review pass`
 ## Stage 7: Summary (observable output — this is the re-enable gate)
 
 The dispatch script writes the machine summary to `GITHUB_STEP_SUMMARY`; your
-job is to make the numbers and the Linear link real:
+job is to make the numbers real AND durable:
 
-1. Update the Linear **parent** ticket with the metrics table and keep the
+1. If a parent ticket exists, update it with the metrics table and keep the
    `**Run:** [logs + cost](<GHA_RUN_URL>)` line at the top.
-2. Emit this block to stdout verbatim (the dispatch script parses it):
+2. Emit this block to stdout verbatim (the dispatch script parses it).
+   `parent_ticket` is `none` on a zero-survivor run:
    ```
    === SDK EVOLUTION SUMMARY ===
    tier: <daily|weekly>
    run_date: <RUN_DATE>
-   parent_ticket: <URL>
+   parent_ticket: <URL|none>
    discovered: <N>
    killed_prefilter: <N>
    killed_verify: <N>
@@ -265,11 +297,26 @@ job is to make the numbers and the Linear link real:
    handed_for_review: <N>
    === END SUMMARY ===
    ```
-3. Consistency audit: every child ticket has a PR link + "In Review" OR
-   "Canceled" + reason. No orphans. Parent reflects the aggregate.
-4. Security audit: no secrets/tokens/internal URLs in any PR or ticket body.
+3. **Post the completion marker** (the stream-drop backstop — see tools.md →
+   Completion marker). Find the pinned tracking issue by label and comment the
+   marker line + the SAME summary block:
+   ```bash
+   ISSUE=$(gh issue list --repo atlanhq/application-sdk \
+     --label sdk-evolution-marker --state all --limit 1 \
+     --json number --jq '.[0].number')
+   # First run ever: create it (label + issue) if $ISSUE is empty — see tools.md.
+   gh issue comment "$ISSUE" --repo atlanhq/application-sdk \
+     --body "marker: sdk-evolution-<TIER>-<RUN_DATE>
 
-Print: `[Stage 7 complete] parent updated, summary emitted`
+   <the summary block verbatim>"
+   ```
+   If mothership's SSE stream to GitHub Actions drops mid-run, this comment is
+   how the workflow still learns the run completed. **Never skip it.**
+4. Consistency audit: every child ticket has a PR link + "In Review" OR
+   "Canceled" + reason. No orphans. Parent reflects the aggregate.
+5. Security audit: no secrets/tokens/internal URLs in any PR or ticket body.
+
+Print: `[Stage 7 complete] parent updated, summary emitted, marker posted`
 
 ---
 
@@ -278,9 +325,11 @@ Print: `[Stage 7 complete] parent updated, summary emitted`
 - **Nothing deferred.** Every finding is FIX, DESIGN, or KILLED by end of run.
 - **Don't duplicate CI.** The registry's exclusion list is binding — re-raising
   a ruff/conformance/codeql finding is a bug in the run.
-- **Observability is the contract.** A run that produces no Linear parent + no
-  step summary is a failed run, even if it opened PRs. This is exactly why the
-  cron was disabled before.
+- **Observability is the contract.** A run that produces no step summary and
+  no completion marker is a failed run, even if it opened PRs. This is exactly
+  why the cron was disabled before.
 - **One review pass, human merges.** No auto-merge until trust is re-earned.
-- **Respect the tier.** Daily never opens a DESIGN debate; weekly owns the deep
-  and cross-repo work.
+- **Respect the tier.** Daily is delta + FOCUS only and never opens a DESIGN
+  debate; weekly is ONE theme, not a breadth sweep.
+- **Cheap when quiet.** An empty delta and a clean focus scan is a SUCCESS,
+  not a reason to dig for marginal findings.

--- a/.mothership/sdk-evolution/ORCHESTRATION.md
+++ b/.mothership/sdk-evolution/ORCHESTRATION.md
@@ -55,7 +55,7 @@ header — do NOT re-derive them.
      exclusion list.
    - `.mothership/sdk-evolution/agents/*.md` — the three discovery agents.
    - `.mothership/sdk-evolution/tools.md` — Linear + GitHub + `@sdk-review`
-     + the completion-marker issue.
+     + the completion-marker ticket (`MARKER_TICKET`).
 3. **Build the suppression list** — query Linear for open tickets in the
    "App SDK v3.0" project (see tools.md). Extract file paths + rule IDs from
    each open ticket; skip re-raising them. On proxy failure → empty suppression
@@ -301,20 +301,12 @@ job is to make the numbers real AND durable:
    === END SUMMARY ===
    ```
 3. **Post the completion marker** (the stream-drop backstop — see tools.md →
-   Completion marker). Find the pinned tracking issue by label and comment the
-   marker line + the SAME summary block:
-   ```bash
-   ISSUE=$(gh issue list --repo atlanhq/application-sdk \
-     --label sdk-evolution-marker --state all --limit 1 \
-     --json number --jq '.[0].number')
-   # First run ever: create it (label + issue) if $ISSUE is empty — see tools.md.
-   gh issue comment "$ISSUE" --repo atlanhq/application-sdk \
-     --body "marker: sdk-evolution-<TIER>-<RUN_DATE>
-
-   <the summary block verbatim>"
-   ```
-   If mothership's SSE stream to GitHub Actions drops mid-run, this comment is
-   how the workflow still learns the run completed. **Never skip it.**
+   Completion marker). Comment `marker: sdk-evolution-<TIER>-<RUN_DATE>` + the
+   SAME summary block on the pinned **Linear** ticket given as `MARKER_TICKET`
+   in the prompt header (via the Linear proxy). Do NOT use a GitHub issue —
+   the pipeline never creates GitHub issues. If mothership's SSE stream to
+   GitHub Actions ends abnormally mid-run, this comment is how the workflow
+   still learns the run completed. **Never skip it.**
 4. Consistency audit: every child ticket has a PR link + "In Review" OR
    "Canceled" + reason. No orphans. Parent reflects the aggregate.
 5. Security audit: no secrets/tokens/internal URLs in any PR or ticket body.

--- a/.mothership/sdk-evolution/ORCHESTRATION.md
+++ b/.mothership/sdk-evolution/ORCHESTRATION.md
@@ -211,10 +211,13 @@ important work lands first: security > bug > docs/test > stale > improvement.
 FIX PRs.
 
 ### 4d. DESIGN PR (weekly theme output)
-Same mechanics, plus: title `[DESIGN] <THEME>: <title> [<TICKET_ID>]`,
-labels `Autonomous SDK Evolution` + `needs-design-review`, and the body MUST
-include **Problem / Why it matters / Approaches considered (A/B/C) /
-Recommendation / How to review**. `[CONF]` proposals additionally carry the
+Same mechanics, plus: labels `Autonomous SDK Evolution` +
+`needs-design-review` (the label marks DESIGN status — NOT the title), and the
+body MUST include **Problem / Why it matters / Approaches considered (A/B/C) /
+Recommendation / How to review**. The title must satisfy the repo's
+`Validate PR title` gate (Conventional Commits + path scoping): docs/ADR-only
+proposals → `chore(adr): <title> [<TICKET_ID>]`; proposals carrying SDK source
+prototype code → `feat(<scope>): …` / `fix(<scope>): …`. `[CONF]` proposals additionally carry the
 rule **and its remediation counterpart in this same PR** + the catalog entry.
 
 **Tag the reviewers on every `needs-design-review` ticket** (see tools.md →

--- a/.mothership/sdk-evolution/agents/correctness-quality.md
+++ b/.mothership/sdk-evolution/agents/correctness-quality.md
@@ -2,8 +2,10 @@
 
 You review the Atlan application-sdk v3 for defects and drift that **static CI
 cannot catch**. Your authority is `references/check-registry.md` — apply only
-the checks it assigns to the current `TIER`, and honour its DO-NOT-re-report
-exclusion list (never surface anything ruff / conformance / codeql already gate).
+the checks the run scope assigns to you (daily: the delta file list you were
+given across all daily families + the `FOCUS` family deep; weekly: only your
+part of the `THEME`), and honour its DO-NOT-re-report exclusion list (never
+surface anything ruff / conformance / codeql already gate).
 
 ## Domain tags (tag every finding)
 
@@ -21,12 +23,10 @@ exclusion list (never surface anything ruff / conformance / codeql already gate)
   in contracts, missing return annotations on exported symbols).
 - `[APICOMPAT]` — an exported symbol removed/renamed/re-signatured with no
   deprecation path (diff the public surface vs the last release tag).
-- `[ARCH]` *(weekly only)* — ADR drift (`docs/adr/`), dependency-direction
+- `[ARCH]` *(weekly ARCH theme)* — ADR drift (`docs/adr/`), dependency-direction
   violations, dumping-ground files, cross-cutting refactor candidates.
-- `[FLAKY]` *(weekly only)* — tests that pass only on retry / intermittently
+- `[FLAKY]` *(weekly PERF theme)* — tests that pass only on retry / intermittently
   (mine recent CI history).
-- `[SMOKE]` *(weekly only)* — `/scaffold-app` no longer boots against the
-  current SDK.
 
 ## Inputs
 
@@ -40,18 +40,20 @@ callers yourself to establish caller counts and dumping-ground status.
 
 ## Holistic protocol (before flagging)
 
-1. Dumping-ground file → recommend decomposition (weekly `[ARCH]`), not a point fix.
+1. Dumping-ground file → recommend decomposition (weekly ARCH theme), not a point fix.
 2. A v3 replacement exists → recommend migrating callers, not patching.
 3. ≤ 5 callers → recommend migrating the callers.
 4. Deprecated file → only flag security issues.
 
 ## Instructions
 
-1. Scan all three surfaces at the depth the registry sets for this TIER.
+1. Daily: scan ONLY the delta file list (all your daily families) and, when
+   you own today's `FOCUS`, that family deep across all three surfaces.
+   Weekly: go deep on your slice of the `THEME`; nothing else.
 2. Read the full file (not just the flagged line) before reporting.
 3. Confidence ≥ 85. Skip suppressed items. Skip anything on the exclusion list.
 4. Daily: if a finding needs a design debate, do NOT report it as a fix —
-   mark it a weekly DESIGN candidate in your notes and drop it for today.
+   note it as a candidate for the matching weekly theme and drop it for today.
 
 ## Output
 

--- a/.mothership/sdk-evolution/agents/evolution.md
+++ b/.mothership/sdk-evolution/agents/evolution.md
@@ -2,34 +2,39 @@
 
 You don't find bugs — you find OPPORTUNITIES to make the SDK better and CRUFT
 to remove, plus patterns that should become **conformance rules**. Your
-authority is `references/check-registry.md`; apply only the checks it assigns to
-the current `TIER`.
+authority is `references/check-registry.md`; apply only the checks the run
+scope assigns to you (daily: `[CONF]` on the delta / the Saturday `CONF`
+focus deep-scan; weekly: only your `THEME`).
 
 ## Domain tags
 
-- `[CONF]` *(always)* — a recurring, detectable pattern (≥ 3 findings this run)
-  that CI does **not** yet gate → propose a conformance rule (scope `sdk`
-  daily, `app` weekly). Rule + remediation ship in the SAME PR. Check
+- `[CONF]` *(daily — focus: Sat)* — a recurring, detectable pattern (≥ 3
+  findings this run or noted by recent runs) that CI does **not** yet gate →
+  propose a conformance rule (scope `sdk`; scope `app` on the CONSUMERS
+  theme). Rule + remediation ship in the SAME PR. Check
   `packages/conformance` first — never duplicate an existing rule.
-- `[DX]` *(weekly)* — API ergonomics: confusing param names, > 5 required
-  params, inconsistent sibling APIs, missing convenience/batch methods.
-- `[CENTRAL]` *(weekly)* — boilerplate repeated in ≥ 3 places → one SDK
+- `[DX]` *(weekly DX theme)* — API ergonomics: confusing param names, > 5
+  required params, inconsistent sibling APIs, missing convenience/batch methods.
+- `[CENTRAL]` *(weekly DX theme)* — boilerplate repeated in ≥ 3 places → one SDK
   abstraction; logic in the wrong layer; scattered config parsing.
-- `[TEMPORAL]` *(weekly)* — more idiomatic Temporal usage (signals/queries/
-  child-workflows/continue-as-new/heartbeat + retry defaults, determinism
-  boundaries) → proposes an **ADR PR** against `docs/adr/`.
-- `[TOOLKIT]` *(weekly)* — `contract-toolkit/` improvements; must go through the
-  `toolkit-feature-workflow` downstream-compat validation.
-- `[EXAMPLE]` *(weekly)* — `contract-toolkit/examples/` drift from current APIs.
-- `[FLEET]` *(weekly)* — from `/audit-consumers` data, which v3 apps are N SDK
-  versions behind; surface adoption laggards.
-- `[BOILERPLATE]` *(weekly)* — v3 app code reimplementing SDK-provided
-  functionality → migration PR that deletes it and calls the SDK (and, when the
-  reinvention recurs, a new app-scope conformance rule).
-- `[APPHEALTH]` *(weekly)* — v3 apps that no longer build / boot / pass CI
-  against the current SDK.
-- `[DOCSITE]` *(weekly)* — docs.atlan.com SDK guides referencing removed/renamed
-  symbols (via the `write-docs` lens).
+- `[DOCSITE]` *(weekly DX theme)* — docs.atlan.com SDK guides referencing
+  removed/renamed symbols (via the `write-docs` lens).
+- `[TEMPORAL]` *(weekly TEMPORAL theme)* — more idiomatic Temporal usage
+  (signals/queries/child-workflows/continue-as-new/heartbeat + retry defaults,
+  determinism boundaries) → proposes an **ADR PR** against `docs/adr/`.
+- `[TOOLKIT]` *(weekly TOOLKIT theme)* — `contract-toolkit/` improvements; must
+  go through the `toolkit-feature-workflow` downstream-compat validation.
+- `[EXAMPLE]` *(weekly TOOLKIT theme)* — `contract-toolkit/examples/` drift
+  from current APIs.
+- `[SMOKE]` *(weekly TOOLKIT theme)* — `/scaffold-app` no longer boots against
+  the current SDK.
+- `[BOILERPLATE]` *(weekly CONSUMERS theme)* — v3 app code reimplementing
+  SDK-provided functionality → migration PR that deletes it and calls the SDK
+  (and, when the reinvention recurs, a new app-scope conformance rule).
+- `[FLEET]` *(weekly CONSUMERS theme)* — from `/audit-consumers` data, which v3
+  apps are N SDK versions behind; surface adoption laggards.
+- `[APPHEALTH]` *(weekly CONSUMERS theme)* — v3 apps that no longer build /
+  boot / pass CI against the current SDK.
 
 ## Inputs
 

--- a/.mothership/sdk-evolution/agents/safety.md
+++ b/.mothership/sdk-evolution/agents/safety.md
@@ -2,24 +2,25 @@
 
 You review the Atlan application-sdk v3 for production-safety issues that
 **static CI cannot catch**. Your authority is `references/check-registry.md` —
-apply only the checks it assigns to the current `TIER`, and honour its
-DO-NOT-re-report exclusion list. Static secret/SQL/CVE scanning is already done
-by conformance, codeql, trivy and grype — do NOT duplicate it.
+apply only the checks the run scope assigns to you (daily: `[SEC]` over the
+delta file list; weekly: the PERF theme), and honour its DO-NOT-re-report
+exclusion list. Static secret/SQL/CVE scanning is already done by conformance,
+codeql, trivy and grype — do NOT duplicate it.
 
 ## Domain tags
 
-- `[SEC]` *(always)* — security defects logic scanners miss: credential
-  handling flaws, multi-tenant isolation gaps, missing validation at system
-  boundaries, path traversal, error-info disclosure, unsafe deserialization
-  reachable at runtime. Always Critical or High — never Medium.
-- `[PERF]` *(weekly only)* — performance issues on **hot** paths:
+- `[SEC]` *(every daily delta scan)* — security defects logic scanners miss:
+  credential handling flaws, multi-tenant isolation gaps, missing validation
+  at system boundaries, path traversal, error-info disclosure, unsafe
+  deserialization reachable at runtime. Always Critical or High — never Medium.
+- `[PERF]` *(weekly PERF theme)* — performance issues on **hot** paths:
   blocking-in-async, missing timeouts, unbounded memory, N+1, missing pooling,
   sync large-file IO. Skip low-frequency and zero-caller code.
-- `[DEPDRIFT]` *(weekly only)* — direct deps, or the Dapr / Temporal SDK
+- `[DEPDRIFT]` *(weekly PERF theme)* — direct deps, or the Dapr / Temporal SDK
   versions, materially behind upstream stable, or a pin blocking a
   security-relevant upgrade (beyond CVE scanning, which trivy/grype own).
-- `[PERFTREND]` *(weekly only)* — a micro-benchmark regression vs the previous
-  weekly run, past a set threshold.
+- `[PERFTREND]` *(weekly PERF theme)* — a micro-benchmark regression vs the
+  previous PERF week, past a set threshold.
 
 ## Worth check before flagging `[PERF]`
 
@@ -29,16 +30,17 @@ by conformance, codeql, trivy and grype — do NOT duplicate it.
 
 ## Inputs
 
-- Full content of the three surfaces plus, for `[SEC]`, always inspect:
-  `Dockerfile`, `.github/workflows/`, `application_sdk/constants.py`, and any
+- Daily: the delta file list plus, for `[SEC]`, always inspect any changed
+  `Dockerfile`, `.github/workflows/`, `application_sdk/constants.py`, or
   credential-handling module — even if not in the primary scan set.
+  Weekly PERF theme: the hot paths across all three surfaces.
 - `references/check-registry.md`, `references/safety-examples.md` (BAD/GOOD +
   the perf worth-check), and the suppression list. No prebuilt index.
 
 ## Instructions
 
 1. `[SEC]`: severity is Critical or High only.
-2. `[PERF]`: apply the worth check first (weekly only).
+2. `[PERF]`: apply the worth check first (weekly PERF theme only).
 3. Confidence ≥ 85. Skip suppressed and excluded items.
 
 ## Output

--- a/.mothership/sdk-evolution/references/check-registry.md
+++ b/.mothership/sdk-evolution/references/check-registry.md
@@ -1,27 +1,53 @@
 # SDK Evolution — Check Registry
 
-One registry, tier-mapped. This replaces the old per-domain rule files. Every
-check declares its **tier** (`daily` / `weekly`), the **surface** it runs
-against, and its **exit** (FIX PR, DESIGN PR/ticket, or a conformance-rule
-proposal).
+One registry, tier-mapped. Every check declares its **tier** (`daily` /
+`weekly`), the **surface** it runs against, and its **exit** (FIX PR, DESIGN
+PR/ticket, or a conformance-rule proposal).
 
-> **daily** = the fast, high-confidence pass that runs Mon–Sat. Whole SDK, but
-> shallow: only report what a senior engineer would fix without a design debate.
-> **weekly** = the Sunday superset. Everything daily does, plus the deep,
-> design-level and cross-repo work. Weekly is the expensive run.
+> **daily** = the light Mon–Sat pass: the last-36h **commit delta** gets ALL
+> daily families; today's **`FOCUS`** family additionally goes deep across all
+> three surfaces. Only report what a senior engineer would fix without a
+> design debate.
+> **weekly** = ONE Sunday design deep-dive on **`THEME`**. Weekly does NOT run
+> the daily families.
 
 **Worked examples** (concrete BAD → GOOD + skip-when per check) live alongside
 this file — each discovery agent reads its own set:
 `correctness-examples.md`, `safety-examples.md`, `evolution-examples.md`. This
 file is the index (what/when/exit); those are the precision anchors.
 
-## Surfaces (all three, every run)
+## Daily focus rotation (set by the dispatch script, override via `FOCUS`)
 
-| Surface | Path | Daily depth | Weekly depth |
+| Weekday | FOCUS (deep scan, all three surfaces) |
+|---|---|
+| Mon | `BUG` |
+| Tue | `DOCS` |
+| Wed | `TEST` |
+| Thu | `TYPES+APICOMPAT` |
+| Fri | `STALE+MANIFEST+LOG` |
+| Sat | `CONF` |
+
+`SEC` is not a focus day — it applies to **every** daily delta scan (a
+security defect must never wait for its weekday).
+
+## Weekly theme rotation (set by the dispatch script via ISO week, override via `THEME`)
+
+| THEME | Covers (old check names) | Owning agent |
+|---|---|---|
+| `ARCH` | ARCH — ADR drift, dependency direction, dumping-ground files | correctness-quality |
+| `TEMPORAL` | TEMPORAL — idiomatic Temporal adoption → ADR PR | evolution |
+| `CONSUMERS` | CONSUMERS + BOILERPLATE + FLEET + APPHEALTH — v3 app audit | evolution |
+| `TOOLKIT` | TOOLKIT + EXAMPLE + SMOKE — toolkit deep review + scaffold check | evolution |
+| `DX` | DX + CENTRAL + DOCSITE — ergonomics, centralization, docs-site drift | evolution |
+| `PERF` | PERF + PERFTREND + DEPDRIFT + FLAKY — hot paths, trends, dep drift, flaky tests | safety (+ correctness-quality for FLAKY) |
+
+## Surfaces
+
+| Surface | Path | Daily | Weekly |
 |---|---|---|---|
-| SDK source | `application_sdk/` | full, shallow | full, deep |
-| Conformance | `packages/conformance/` | rule-proposal only | rule-proposal + `/remediate` |
-| Contract toolkit | `contract-toolkit/` | lint + docstring drift | full review via `toolkit-feature-workflow` (downstream-compat) |
+| SDK source | `application_sdk/` | delta + FOCUS deep | as the THEME requires |
+| Conformance | `packages/conformance/` | delta + FOCUS deep (CONF = rule proposals) | as the THEME requires |
+| Contract toolkit | `contract-toolkit/` | delta + FOCUS deep | TOOLKIT theme: full review via `toolkit-feature-workflow` |
 
 ---
 
@@ -45,12 +71,14 @@ not a PR — it is a **conformance-rule proposal** (check `CONF` below).
 
 ---
 
-## DAILY checks
+## DAILY check families
 
 Confidence bar is high (≥ 85). If it needs a design debate, it is not a daily
-FIX — downgrade it to a weekly DESIGN candidate and move on.
+FIX — note it for the matching weekly THEME and move on. Every family below
+runs on the **delta scan**; the FOCUS family additionally runs deep,
+everywhere.
 
-### BUG — semantic correctness `[daily]`
+### BUG — semantic correctness `[focus: Mon]`
 Runtime-correctness defects static analysis misses. Priority order:
 1. Temporal **determinism** violations — `random`/`time`/wall-clock/IO inside
    `run()` / `@entrypoint` (must be in a `@task`).
@@ -62,9 +90,18 @@ Runtime-correctness defects static analysis misses. Priority order:
 7. None/Optional mishandling; mutable default arguments.
 8. Off-by-one, inverted conditions, wrong comparison operators.
 
-**Exit:** small clean fix → FIX PR (write a failing test FIRST). Larger → weekly DESIGN.
+**Exit:** small clean fix → FIX PR (write a failing test FIRST). Larger → note
+for the ARCH theme.
 
-### DOCS — documentation quality & staleness `[daily]`
+### SEC — security `[every daily delta scan]`
+Security defects logic scanners miss: credential handling flaws, multi-tenant
+isolation gaps, missing validation at system boundaries, path traversal,
+error-info disclosure, unsafe deserialization reachable at runtime. Always
+Critical or High — never Medium.
+
+**Exit:** FIX PR (failing test first).
+
+### DOCS — documentation quality & staleness `[focus: Tue]`
 - Docstring drift: params/returns/raises out of sync with the signature.
 - Broken or non-running code examples in `docs/` and docstrings.
 - Stale version refs, dead internal links, references to removed v2 symbols.
@@ -72,7 +109,7 @@ Runtime-correctness defects static analysis misses. Priority order:
 
 **Exit:** FIX PR (docs are low-risk). Group per doc area.
 
-### TEST — test *quality* (not existence) `[daily]`
+### TEST — test *quality* (not existence) `[focus: Wed]`
 Existence of some test is not the check — CI coverage already tracks that.
 Flag tests that pass but don't protect:
 - Assertion-free or vague (`assert result`, `assert x is not None`).
@@ -83,23 +120,38 @@ Flag tests that pass but don't protect:
 
 **Exit:** FIX PR. Group per module.
 
-### STALE — deprecation / dead-code / TODO aging `[daily]`
+### TYPES — public-surface type safety `[focus: Thu]`
+Gradual-typing erosion pyright doesn't error on: a public/exported signature
+that newly widens to `Any`, bare `dict`/`list`, or `Dict[str, Any]` in a
+contract, or a missing return annotation on an exported symbol.
+
+**Exit:** FIX PR.
+
+### APICOMPAT — public API break detection `[focus: Thu]`
+An exported symbol (in an `__all__`) removed, renamed, or with a changed
+signature and **no deprecation path** — a silent break for connectors. Diff the
+public surface against the last release tag.
+
+**Exit:** FIX PR (restore + deprecate) — or note for the ARCH theme if the
+break is intended.
+
+### STALE — deprecation / dead-code / TODO aging `[focus: Fri]`
 - `warnings.warn(..., DeprecationWarning)` older than 3 months where all
   callers have migrated → remove the shim.
 - Zero-caller functions/classes (skip if exported, used in tests, or in
   `_temporal`/`_dapr`/`_redis` internals).
 - TODO/FIXME/HACK older than 6 months with no linked ticket → file or fix.
 
-**Exit:** small removal → FIX PR; broad cleanup → weekly DESIGN.
+**Exit:** small removal → FIX PR; broad cleanup → note for the ARCH theme.
 
-### MANIFEST — capability-manifest content freshness `[daily]`
+### MANIFEST — capability-manifest content freshness `[focus: Fri]`
 Presence is CI-gated; **content drift** is not. If a public symbol's signature
 or contract changed but `docs/agents/sdk-capabilities.md` still shows the old
 shape, regenerate via `/capability-manifest`.
 
 **Exit:** FIX PR (regeneration only).
 
-### LOG — observability signal quality `[daily]`
+### LOG — observability signal quality `[focus: Fri]`
 Not the L-series log-*level* lint (conformance owns that). Flag log **signal**
 defects: exceptions swallowed with no log, stack traces dropped on re-raise,
 ERROR used for non-failures, or INFO chatter that buries real lifecycle events.
@@ -107,23 +159,10 @@ Apply the `signal-over-noise` lens.
 
 **Exit:** FIX PR.
 
-### TYPES — public-surface type safety `[daily]`
-Gradual-typing erosion pyright doesn't error on: a public/exported signature
-that newly widens to `Any`, bare `dict`/`list`, or `Dict[str, Any]` in a
-contract, or a missing return annotation on an exported symbol.
-
-**Exit:** FIX PR.
-
-### APICOMPAT — public API break detection `[daily]`
-An exported symbol (in an `__all__`) removed, renamed, or with a changed
-signature and **no deprecation path** — a silent break for connectors. Diff the
-public surface against the last release tag.
-
-**Exit:** FIX PR (restore + deprecate) — or DESIGN if the break is intended.
-
-### CONF — SDK-level conformance rule proposal `[daily]`
-When ≥ 3 findings this run share one detectable pattern that CI does **not**
-yet gate, propose a conformance rule instead of N point fixes.
+### CONF — SDK-level conformance rule proposal `[focus: Sat]`
+When ≥ 3 findings (this run or noted by recent runs) share one detectable
+pattern that CI does **not** yet gate, propose a conformance rule instead of N
+point fixes.
 - Scope = `sdk` (runs against SDK source).
 - **Rule + remediation ship in the SAME PR** (per the `/conformance` discipline).
 - Do not duplicate an existing rule — check `packages/conformance` first.
@@ -132,11 +171,13 @@ yet gate, propose a conformance rule instead of N point fixes.
 
 ---
 
-## WEEKLY checks (superset — daily + the below)
+## WEEKLY themes — what "deep" means per theme
 
-Budget is larger; fan-out and cross-repo work live here.
+The weekly output contract: **one** DESIGN PR/ADR (+ child ticket,
+`needs-design-review`) + at most 3 incidental FIX PRs. Pick the single most
+valuable design change the theme surfaces; fold or KILL the rest.
 
-### ARCH — architecture / ADR drift `[weekly]`
+### ARCH — architecture / ADR drift
 Check against the ADR library in `docs/adr/`:
 - Dependency direction `app/ → execution/ → infrastructure/` (never reverse).
 - Direct `temporalio` / `DaprClient` imports outside the `_temporal`/`_dapr`/`_redis` seams.
@@ -145,110 +186,51 @@ Check against the ADR library in `docs/adr/`:
 - **Cross-cutting refactor detection:** a single file producing ≥ 5 findings →
   ONE holistic DESIGN ticket, not five point fixes.
 
-**Exit:** DESIGN PR/ticket, `needs-design-review`.
-
-### TEMPORAL — better Temporal-concept adoption → ADR PR `[weekly]`
+### TEMPORAL — better Temporal-concept adoption → ADR PR
 Where the SDK could model workflows more idiomatically:
 - Signals / queries / updates instead of polling or side-channel state.
 - Child workflows / `continue-as-new` for unbounded or long histories.
 - Correct heartbeat + activity retry-policy defaults.
 - Tightening determinism boundaries.
+The DESIGN output is an **ADR PR** against `docs/adr/` with a prototype diff
+where feasible.
 
-**Exit:** an **ADR PR** against `docs/adr/` proposing the change, with a
-prototype diff where feasible. `needs-design-review`.
-
-### CONSUMERS — v3 app audit → evolution + boilerplate removal + conformance `[weekly]`
+### CONSUMERS — v3 app audit (+ fleet health & version drift)
 Run `/audit-consumers --sdk-major 3` (grep-based, read-only discovery) across
-`atlanhq/` **v3 apps only** (v2 / other majors are skipped). Four angles:
+`atlanhq/` **v3 apps only**. Four angles:
 - **Boilerplate removal** — app code that reimplements something the SDK
-  ALREADY provides (retry/backoff, pagination, credential resolution,
-  state/object store, logging setup, heartbeating, typed errors, config
-  parsing, …). Raise a migration PR that **deletes the app code and calls the
-  SDK** instead — smaller app surface, one canonical path.
-- **Missing guardrail → new check** — when the same reinvention recurs and no
-  rule catches it, add an **app-scope conformance rule** (scope = `app`, rule +
-  remediation same PR) so future apps can't drift back into it.
+  ALREADY provides → migration PR that deletes it and calls the SDK.
+- **Missing guardrail → new check** — recurring reinvention no rule catches →
+  an **app-scope conformance rule** (rule + remediation same PR).
 - **SDK gap → evolution** — a pattern ≥ 3 apps reinvent that the SDK does NOT
-  yet provide → DESIGN proposal for a new SDK utility.
-- **Migration PRs** raised against app repos with `--raise-prs`, limited by
-  `CONSUMER_PR_CAP` per run (external-repo safety knob for the 2h budget);
-  rotate the remainder to following weeks.
+  provide → this week's DESIGN proposal.
+- **APPHEALTH / FLEET** — per-app build/boot/CI status against the current SDK
+  and version-drift laggards → a fleet-health section on the parent ticket.
+Migration PRs use `--raise-prs`, capped at `CONSUMER_PR_CAP`; rotate the
+remainder to the next CONSUMERS week.
 
-**Exit:** SDK DESIGN tickets + app conformance PR(s) + boilerplate-removal PRs
-(≤ cap) against v3 app repos.
-
-### APPHEALTH — v3 app fleet health `[weekly]`
-Are the v3 apps actually running? For each discovered **v3** app, check whether
-it still **builds / boots / passes its own CI against the CURRENT SDK** — so a
-broken or stalled fleet is visible instead of silent. Surface apps that are red,
-or pinned to an old SDK major/minor and drifting.
-
-**Exit:** a fleet-health section on the parent ticket + a DESIGN ticket per app
-that is broken against the current SDK.
-
-### TOOLKIT — contract-toolkit deep review `[weekly]`
+### TOOLKIT — contract-toolkit deep review
 Review `contract-toolkit/` through the `toolkit-feature-workflow` lens:
 classify affected generated surfaces and run the **mandatory downstream-compat
 validation** before proposing changes. Never review it like plain SDK source.
+Include: `contract-toolkit/examples/` freshness (EXAMPLE) and the
+`/scaffold-app` golden-path boot check (SMOKE).
 
-**Exit:** FIX PR for safe changes; DESIGN for anything touching generated contracts.
-
-### DX / CENTRAL — ergonomics & centralization `[weekly]`
-- Repeated boilerplate in ≥ 3 places → propose one SDK abstraction.
+### DX — ergonomics, centralization & docs-site drift
+- Repeated boilerplate in ≥ 3 places → propose one SDK abstraction (CENTRAL).
 - Confusing param names, > 5 required params, inconsistent sibling APIs.
 - Missing convenience/batch methods connectors keep reimplementing.
+- docs.atlan.com SDK guides referencing removed/renamed symbols (DOCSITE, via
+  the `write-docs` lens).
 
-**Exit:** DESIGN PR with proposed implementation.
-
-### PERF — performance review `[weekly]`
-Only worth-checked hot paths (skip low-frequency / zero-caller code):
-blocking-in-async on hot paths, missing timeouts, unbounded memory, N+1,
-missing pooling, sync large-file IO. Static perf lint is not the job here.
-
-**Exit:** FIX PR (with a benchmark note) or DESIGN.
-
-### EXAMPLE — example-app freshness `[weekly]`
-`contract-toolkit/examples/` still builds and reflects current SDK APIs; no
-references to removed symbols.
-
-**Exit:** FIX PR.
-
-### FLEET — v3 adoption & version drift `[weekly]`
-From the `/audit-consumers` discovery data, which `atlanhq/` v3 apps are N SDK
-versions behind. Surface the laggards so adoption is visible; complements the
-conformance fleet dashboard.
-
-**Exit:** a summary section on the parent ticket (+ a DESIGN ticket where a
-migration is actually needed).
-
-### DEPDRIFT — dependency / runtime version staleness `[weekly]`
-Beyond CVE scanning (trivy/grype own that): direct deps, and the **Dapr** and
-**Temporal** SDK versions, materially behind upstream stable — or a pin that is
-blocking a security-relevant upgrade.
-
-**Exit:** bump PR — or DESIGN if the upgrade needs source changes.
-
-### PERFTREND — performance regression trend `[weekly]`
-Run the micro-benchmark suite and compare against the previous weekly run; flag
-regressions over a threshold instead of one-shot guesses. Static perf lint is
-not the job (that's the `PERF` check).
-
-**Exit:** DESIGN ticket with the measured delta.
-
-### FLAKY — flaky-test detection `[weekly]`
-Mine recent CI history for tests that pass only on retry or intermittently —
-the unit suite hides these because a green re-run looks clean.
-
-**Exit:** FIX PR (stabilise) — or DESIGN if it exposes a real race.
-
-### SMOKE — golden-path scaffold check `[weekly]`
-Does `/scaffold-app` still produce an app that boots against the current SDK?
-Catches integration breakage the unit suite misses.
-
-**Exit:** FIX PR.
-
-### DOCSITE — published-docs drift `[weekly]`
-Cross-check the docs.atlan.com SDK guides against the real APIs (via the
-`write-docs` lens); flag guides that reference removed/renamed symbols.
-
-**Exit:** DESIGN ticket (published-docs changes are reviewed).
+### PERF — performance, trends, dependencies & flaky tests
+- Hot-path review: blocking-in-async, missing timeouts, unbounded memory, N+1,
+  missing pooling, sync large-file IO. Only worth-checked hot paths — skip
+  low-frequency / zero-caller code (that worth-check lives in
+  `safety-examples.md`).
+- PERFTREND: run the micro-benchmark suite vs the previous PERF week; flag
+  regressions over a threshold instead of one-shot guesses.
+- DEPDRIFT: direct deps and the **Dapr**/**Temporal** SDK versions materially
+  behind upstream stable, or a pin blocking a security-relevant upgrade
+  (beyond CVE scanning, which trivy/grype own).
+- FLAKY: mine recent CI history for tests that pass only on retry.

--- a/.mothership/sdk-evolution/references/correctness-examples.md
+++ b/.mothership/sdk-evolution/references/correctness-examples.md
@@ -128,8 +128,3 @@ type-only import under `TYPE_CHECKING`, or the seam is an accepted Protocol.
 From CI history, a test that failed then passed on re-run with no code change.
 Report the test + its flakiness rate. **skip-when:** the flake was an
 infra/runner outage, not the test.
-
-## SMOKE *(weekly)* — scaffold golden-path
-`/scaffold-app` output no longer boots against the current SDK (import error,
-missing contract, changed entrypoint signature). **skip-when:** the failure is
-environmental (missing local Dapr/Temporal), not an SDK break.

--- a/.mothership/sdk-evolution/references/evolution-examples.md
+++ b/.mothership/sdk-evolution/references/evolution-examples.md
@@ -83,3 +83,8 @@ then it's DESIGN, not FIX.
 EXAMPLE: `contract-toolkit/examples/` references a removed/renamed symbol.
 DOCSITE: a docs.atlan.com guide does the same. **skip-when:** the reference is
 still valid, or intentionally shows a deprecated-but-supported path.
+
+## SMOKE *(weekly TOOLKIT theme)* — scaffold golden-path
+`/scaffold-app` output no longer boots against the current SDK (import error,
+missing contract, changed entrypoint signature). **skip-when:** the failure is
+environmental (missing local Dapr/Temporal), not an SDK break.

--- a/.mothership/sdk-evolution/tools.md
+++ b/.mothership/sdk-evolution/tools.md
@@ -82,6 +82,32 @@ input) AND @-mention both in a comment so Linear pings them. Apply on:
 
 Do NOT tag them on routine FIX tickets — those go to `@sdk-review`.
 
+## Completion marker (Stage 7 — the stream-drop backstop)
+
+Mothership's SSE stream to GitHub Actions can drop while the sandbox keeps
+working. The dispatch script recovers the outcome by polling a pinned tracking
+issue — so Stage 7 MUST post the summary there, every run:
+
+```bash
+ISSUE=$(gh issue list --repo atlanhq/application-sdk \
+  --label sdk-evolution-marker --state all --limit 1 \
+  --json number --jq '.[0].number')
+if [ -z "$ISSUE" ]; then   # first run ever: create label + issue
+  gh label create sdk-evolution-marker --repo atlanhq/application-sdk \
+    --description "SDK Evolution run completion markers" || true
+  ISSUE=$(gh issue create --repo atlanhq/application-sdk \
+    --title "SDK Evolution — run markers" --label sdk-evolution-marker \
+    --body "Completion markers posted by SDK Evolution runs (Stage 7). One comment per run; the dispatch workflow polls these after an SSE stream drop. Do not close." \
+    | grep -oE '[0-9]+$')
+fi
+gh issue comment "$ISSUE" --repo atlanhq/application-sdk --body "marker: sdk-evolution-<TIER>-<RUN_DATE>
+
+<summary block verbatim>"
+```
+
+The `marker:` line must match the dispatch `source_id` exactly:
+`sdk-evolution-<TIER>-<RUN_DATE>` (e.g. `sdk-evolution-daily-2026-07-21`).
+
 ## Handoff — single review pass (Stage 6)
 
 ```bash

--- a/.mothership/sdk-evolution/tools.md
+++ b/.mothership/sdk-evolution/tools.md
@@ -84,25 +84,23 @@ Do NOT tag them on routine FIX tickets — those go to `@sdk-review`.
 
 ## Completion marker (Stage 7 — the stream-drop backstop)
 
-Mothership's SSE stream to GitHub Actions can drop while the sandbox keeps
-working. The dispatch script recovers the outcome by polling a pinned tracking
-issue — so Stage 7 MUST post the summary there, every run:
+Mothership's SSE stream to GitHub Actions can end abnormally while the sandbox
+keeps working. The dispatch script recovers the outcome by polling the pinned
+**Linear** marker ticket — its identifier arrives as `MARKER_TICKET` in the
+prompt header. Stage 7 MUST post the summary there, every run. **NEVER create
+a GitHub issue for this (or anything else) — all tracking lives in Linear.**
 
 ```bash
-ISSUE=$(gh issue list --repo atlanhq/application-sdk \
-  --label sdk-evolution-marker --state all --limit 1 \
-  --json number --jq '.[0].number')
-if [ -z "$ISSUE" ]; then   # first run ever: create label + issue
-  gh label create sdk-evolution-marker --repo atlanhq/application-sdk \
-    --description "SDK Evolution run completion markers" || true
-  ISSUE=$(gh issue create --repo atlanhq/application-sdk \
-    --title "SDK Evolution — run markers" --label sdk-evolution-marker \
-    --body "Completion markers posted by SDK Evolution runs (Stage 7). One comment per run; the dispatch workflow polls these after an SSE stream drop. Do not close." \
-    | grep -oE '[0-9]+$')
-fi
-gh issue comment "$ISSUE" --repo atlanhq/application-sdk --body "marker: sdk-evolution-<TIER>-<RUN_DATE>
+# 1. Resolve the marker ticket UUID (identifier → id):
+curl -s "$PROXY_BASE/proxy/linear" \
+  -H "Authorization: Bearer $PROXY_JWT" -H "Content-Type: application/json" \
+  -d '{"query": "{ issue(id: \"<MARKER_TICKET>\") { id } }"}'
 
-<summary block verbatim>"
+# 2. Comment the marker + the summary block on it:
+curl -s "$PROXY_BASE/proxy/linear" \
+  -H "Authorization: Bearer $PROXY_JWT" -H "Content-Type: application/json" \
+  -d '{"query": "mutation($input: CommentCreateInput!) { commentCreate(input: $input) { success }}",
+       "variables": {"input": {"issueId": "<uuid>", "body": "marker: sdk-evolution-<TIER>-<RUN_DATE>\n\n<summary block verbatim>"}}}'
 ```
 
 The `marker:` line must match the dispatch `source_id` exactly:


### PR DESCRIPTION
## Summary

Second iteration of the SDK Evolution pipeline rebuild (BLDX-1517). The July 9 verification run exposed two problems that this PR fixes before the cron is re-enabled:

1. **False failure on SSE stream drop.** The sandbox completed all 7 stages (Linear parent + metrics) *after* the SSE stream to GHA had already dropped at ~8 min — so the dispatch failed a run that actually succeeded and the step summary never rendered.
2. **Full daily rescans are wasteful.** The all-families daily scan of an unchanged codebase survived-zero findings at full sandbox cost.

## Changes

### Stream-drop backstop: completion marker
- ORCHESTRATION Stage 7 now also posts the summary block as a comment on a pinned tracking issue (`SDK Evolution — run markers`, label `sdk-evolution-marker`), tagged `marker: <source_id>`.
- On a stream that ends without a `complete` event (and no `error` event), the dispatch script polls that issue via the GitHub API (60s interval, up to 45 min). Marker found → outcome recovered, metrics parsed from the comment, exit 0 with a `⚠️ recovered` step summary. Not found → the original failure path.
- Workflow gets `issues: read` + `GH_TOKEN` for the poll.

### Daily tier → delta + rotating focus (the light pass)
- Daily scans ONLY (a) the last-36h commit delta across all daily families and (b) one rotating deep-focus family (Mon=BUG, Tue=DOCS, Wed=TEST, Thu=TYPES+APICOMPAT, Fri=STALE+MANIFEST+LOG, Sat=CONF; SEC runs on every delta). Quiet day → cheap early exit, no Linear parent for zero-survivor runs.
- Hard stop 40 → 25 min.

### Weekly tier → one rotating design theme
- Sunday is ONE design deep-dive on a theme rotated by ISO week: ARCH → TEMPORAL → CONSUMERS → TOOLKIT → DX → PERF (all previous weekly families folded into these six). Output contract: one well-argued DESIGN PR/ADR + ≤ 3 incidental FIX PRs. No longer the daily superset.
- Hard stop 110 → 60 min (CONSUMERS theme: 90).

### Verification support
- New `focus` / `theme` / `base_branch` workflow_dispatch inputs; `base_branch` lets a verification run point the sandbox at this PR branch so the updated playbook is exercised before merge.
- Dispatch pytest suite: 24 → 43 tests (focus/theme resolution, marker poll found/timeout/error paths, recovered-outcome rendering, prompt/payload shape).

## Rollout

The `schedule:` block stays commented. Re-enable gate: one manual daily + one manual weekly run must render the step summary (metrics + Linear link) — including via marker recovery if the stream drops. Schedule uncomment lands as a follow-up one-liner after that.

Linear: https://linear.app/atlan-epd/issue/BLDX-1517

🤖 Generated with [Claude Code](https://claude.com/claude-code)