### PR TITLE
fix(validation): default asset-validation-on-upload off pending isolation fix (CNCT-85)

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -446,9 +446,16 @@ if DEPLOYMENT_ARTIFACT_DUAL_WRITE_ENABLED:
 #: BLDX-1555 defense-in-depth: when True, ``App.upload()`` validates transformed
 #: asset NDJSON against the pyatlan_v9 ``.validate()`` backbone before handing it
 #: across the SDR→Atlan boundary. Warn-only — invalid/orphaned assets are logged,
-#: never block the upload. Set to "false" to disable the check entirely.
+#: never block the upload.
+#:
+#: TEMPORARILY DEFAULTED OFF (CNCT-85): the warn-only scan runs the pyatlan/msgspec
+#: decode inside the worker, where a native fault (msgspec 0.20.0 concurrent-decode
+#: segfault on py3.13) bypasses the try/except and kills the worker. The full fix
+#: (process isolation, PR #2769) depends on downstream pyatlan changes; until it
+#: lands the path is disabled by default. Set to "true" to re-enable. Revert this
+#: default (and drop this note) once #2769 merges.
 VALIDATE_ASSETS_ON_UPLOAD: bool = (
-    os.getenv("ATLAN_VALIDATE_ASSETS_ON_UPLOAD", "true").lower() == "true"
+    os.getenv("ATLAN_VALIDATE_ASSETS_ON_UPLOAD", "false").lower() == "true"
 )
 #: The single "rows per axis" cap for transformed-asset validation output —
 #: shared by both surfaces so they can never drift: the human-readable

--- a/docs/concepts/apps.md
+++ b/docs/concepts/apps.md
@@ -328,9 +328,13 @@ auto-stamped and each row joins to the workflow outcome by run id:
   logged as a WARNING body, but only for flagged runs.
 
 Uploads with nothing to validate emit nothing at all: when `ATLAN_VALIDATE_ASSETS_ON_UPLOAD=false`
-(the check is on by default) or when the path is not a `transformed/` subtree (e.g. a raw upload),
-no outcome event is produced. See [Monitoring](monitoring.md#asset-validation-outcome-event) for the
-attribute list as it reaches OTLP.
+or when the path is not a `transformed/` subtree (e.g. a raw upload), no outcome event is produced.
+See [Monitoring](monitoring.md#asset-validation-outcome-event) for the attribute list as it reaches
+OTLP.
+
+> **Temporarily disabled by default (CNCT-85).** The check is currently off by default while the
+> process-isolation fix ([#2769](https://github.com/atlanhq/application-sdk/pull/2769)) awaits
+> downstream changes. Set `ATLAN_VALIDATE_ASSETS_ON_UPLOAD=true` to opt back in.
 
 ## Passthrough Modules
 

--- a/tests/unit/app/test_upload_asset_validation.py
+++ b/tests/unit/app/test_upload_asset_validation.py
@@ -80,6 +80,14 @@ def _outcome_event(logger: MagicMock) -> dict:
 
 
 class TestWarnOnInvalidTransformedAssets:
+    @pytest.fixture(autouse=True)
+    def _enable_validation(self):
+        # The production default is OFF (CNCT-85, see constants). These tests
+        # exercise the enabled behavior, so force the flag on; the disabled-path
+        # test re-patches it False for its own body.
+        with patch("application_sdk.constants.VALIDATE_ASSETS_ON_UPLOAD", True):
+            yield
+
     async def test_disabled_flag_is_noop(self, tmp_path: Path) -> None:
         _valid_hierarchy(tmp_path)
         with patch.object(base_module, "_task_logger") as logger:


### PR DESCRIPTION
## TL;DR

The warn-only transformed-asset validation added in 3.23.0 runs the pyatlan/msgspec decode inside the Temporal worker. A native fault in that decode (the msgspec 0.20.0 concurrent-decode segfault on py3.13, CNCT-85) is not a Python exception — it bypasses the `try/except` and kills the whole worker.

The complete fix is process isolation (#2769), but that depends on downstream pyatlan changes that haven't released yet. To unblock a new SDK release now, this PR **turns the feature off by default** — the smallest, cleanest kill switch, trivially revertible once #2769 lands.

## What changed

- `application_sdk/constants.py`: `ATLAN_VALIDATE_ASSETS_ON_UPLOAD` now defaults to `false` (was `true`). This is the single load-bearing change — the flag is checked in `_warn_on_invalid_transformed_assets` **before** any thread dispatch, filesystem walk, or msgspec decode, so the entire code path (and the segfault trigger) is fully short-circuited. Nothing is commented out; the code stays intact behind the flag.
- `tests/unit/app/test_upload_asset_validation.py`: added an autouse fixture that forces the flag on for the behavior tests (they assert the *enabled* behavior). The disabled-path test re-patches it off for its own body.
- `docs/concepts/apps.md`: note that the check is temporarily off by default and how to opt back in.

## Reverting

Once #2769 (or the pyatlan msgspec-cap lift) ships, revert this PR: flip the default back to `true`, drop the temporary note in `constants.py`/`apps.md`, and remove the autouse test fixture.

## Opting in meanwhile

Operators who want the check before the full fix can set `ATLAN_VALIDATE_ASSETS_ON_UPLOAD=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)