### PR TITLE
ci(renovate): flip the fleet runner live (PR2 Stage 3)

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -10,20 +10,19 @@ name: Renovate (self-hosted fleet runner)
 # us provide the toolchain (uv, pkl, python, ruff) with the same steps the old
 # renovate-pkl-sync.yaml glue used, instead of baking a custom Renovate image.
 #
-# SAFE BY DEFAULT: dry_run defaults to 'full', so scheduled runs and an
-# un-parameterised dispatch make NO changes (no PRs, no commits). Going live:
-#   * pilot   — dispatch with dry_run='null' and repos scoped to a repo or two;
-#   * fleet   — flip the schedule default to 'null' (a one-line change) once the
-#               Mend app is uninstalled. See the Model A rollout plan, steps 4-9.
+# LIVE: dry_run defaults to 'null', so scheduled runs and the release fan-out
+# open/update real PRs across the discovered fleet. Mend has been uninstalled
+# fleet-wide, so there is no second engine to collide with. For a manual dry
+# run, dispatch with dry_run='full' (and optionally scope with the repos input).
 
 on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Renovate dry-run mode. 'full' = no changes (default, safe); 'null' = live (open/update PRs)."
+        description: "Renovate dry-run mode. 'null' = live (default, open/update PRs); 'full' = no changes (manual dry run)."
         type: choice
         options: ["full", "lookup", "null"]
-        default: "full"
+        default: "null"
       repos:
         description: 'Optional JSON array of "owner/repo" to scope the run (pilot). Empty = full discovered fleet.'
         type: string
@@ -49,16 +48,6 @@ jobs:
     outputs:
       repos: ${{ steps.discover.outputs.repos }}
     steps:
-      # Fail-fast on an accidental unscoped live dispatch: a live run
-      # (dry_run != 'full') with no `repos` scope would fan out real PRs across
-      # the entire discovered fleet. Scheduled runs are unaffected — they carry
-      # the safe 'full' default. Remove this guard when the fleet goes live.
-      - name: Guard against unscoped live dispatch
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run != 'full' && inputs.repos == '' }}
-        run: |
-          echo "::error::Refusing an unscoped live run (dry_run='${{ inputs.dry_run }}', empty 'repos'): this would open live PRs across the entire discovered fleet. Scope the 'repos' input to a pilot set, or use dry_run='full'."
-          exit 1
-
       - name: Mint fleet App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
@@ -98,9 +87,10 @@ jobs:
         # `&&`/`||` short-circuit, so fromJson is never called on an empty string.
         repo: ${{ (inputs.repos != '' && fromJson(inputs.repos)) || fromJson(needs.discover.outputs.repos) }}
     env:
-      # 'full' (default) makes no changes. Overridden per-dispatch via the input;
-      # scheduled runs inherit the safe default until the fleet goes live.
-      RENOVATE_DRY_RUN: ${{ inputs.dry_run || 'full' }}
+      # Live by default. workflow_dispatch supplies the input ('null' default);
+      # scheduled runs have no inputs context, so the `|| 'null'` fallback applies.
+      # A manual dry run = dispatch with dry_run='full'.
+      RENOVATE_DRY_RUN: ${{ inputs.dry_run || 'null' }}
     steps:
       - name: Mint fleet App token
         id: app-token


### PR DESCRIPTION
## Context

Mend is now **uninstalled fleet-wide** (IT completed it). The self-hosted runner is the sole Renovate engine, so there's no second engine to collide with. This flips it from safe-by-default to live.

## Changes (`.github/workflows/renovate.yaml`)

- `dry_run` dispatch-input default **`full → null`**, and the scheduled-run env fallback **`|| 'full'` → `|| 'null'`**. Scheduled runs *and* the release fan-out now open/update real PRs across the discovered fleet. Manual dry run still available via `dry_run=full`.
- **Removed the pilot-era "unscoped live dispatch" guard** — unscoped-live is now the intended default, and the guard would otherwise block the release fan-out (which dispatches with no `repos` scope).

## Not changed

- **Per-repo merge policy** — soft-rollout repos (`automerge:false`, e.g. mssql) still raise-but-don't-merge; opted-in repos auto-merge on green. The runner only reads each repo's own `renovate.json`.
- Discovery, `onboarding:false` guard, `github-actions` disable — all as merged.

## Rollout note

Before the first fleet-wide live run, stale `renovate/*` branches left by Mend are swept (operator, `scratchpad/sweep-renovate-branches.sh --apply`) so the runner doesn't skip repos on handover. Decommission of the `renovate-pkl-sync.yaml` glue + narrowing the auto-approve author gate to `atlan-app-fleet[bot]` only follows as PR2 Stage 4, after this is verified live fleet-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)