### PR TITLE
chore(renovate): keep dual-author gate — application-sdk stays on Mend

### DIFF
--- a/.github/scripts/renovate_fleet_scan.py
+++ b/.github/scripts/renovate_fleet_scan.py
@@ -90,10 +90,10 @@ def resolve_scope(org: str, repo: Optional[str]) -> str:
     return f"repo:{repo}" if repo else f"org:{org}"
 
 
-# Renovate PR authors to scan. During the fleet cutover both engines coexist:
-# the Mend-hosted app (app/renovate) and the self-hosted runner
-# (app/atlan-app-fleet). GitHub PR search OR's multiple author: qualifiers.
-# Narrow to ("app/atlan-app-fleet",) once Mend is uninstalled (PR2 Stage 4).
+# Renovate PR authors to scan. The self-hosted runner (app/atlan-app-fleet)
+# covers the app fleet; application-sdk itself still uses the Mend-hosted app
+# (app/renovate) for its own workflow-action updates, so keep both. GitHub PR
+# search OR's multiple author: qualifiers.
 RENOVATE_PR_AUTHORS = ("app/renovate", "app/atlan-app-fleet")
 
 

--- a/.github/workflows/renovate-auto-approve-reusable.yml
+++ b/.github/workflows/renovate-auto-approve-reusable.yml
@@ -40,7 +40,8 @@
 #   freshness is guaranteed by the ruleset's dismiss_stale_reviews_on_push.
 #
 # Approval conditions (ALL must hold — see step comments in the bash below):
-#   1. PR author is a Renovate bot (renovate[bot] or atlan-app-fleet[bot] during cutover)
+#   1. PR author is a Renovate bot: atlan-app-fleet[bot] (self-hosted fleet
+#      runner) or renovate[bot] (Mend — still used by application-sdk itself)
 #   2. PR is open and not a draft
 #   3. Current HEAD SHA matches the evaluated SHA (race guard)
 #   4. Every changed file is under .github/, uv.lock, requirements.txt,
@@ -160,11 +161,12 @@ jobs:
             DRAFT=$(printf '%s'  "$PR_META"   | jq -r .draft)
             HEAD_SHA=$(printf '%s' "$PR_META" | jq -r .head_sha)
 
-            # a. Author must be a Renovate bot. Both engines are accepted during
-            #    the fleet cutover: renovate[bot] (Mend-hosted) and
-            #    atlan-app-fleet[bot] (self-hosted runner). Narrow to just
-            #    atlan-app-fleet[bot] once Mend is uninstalled (PR2 Stage 4).
-            if [ "$AUTHOR" != "renovate[bot]" ] && [ "$AUTHOR" != "atlan-app-fleet[bot]" ]; then
+            # a. Author must be a Renovate bot. Keep BOTH: atlan-app-fleet[bot]
+            #    is the self-hosted fleet runner; renovate[bot] is the Mend-hosted
+            #    app, which application-sdk itself still uses for its own
+            #    workflow-action updates. Do not drop renovate[bot] while
+            #    application-sdk remains on Mend.
+            if [ "$AUTHOR" != "atlan-app-fleet[bot]" ] && [ "$AUTHOR" != "renovate[bot]" ]; then
               echo "PR #${PR_NUM}: author is '${AUTHOR}', not a Renovate bot — skipping."
               continue
             fi


### PR DESCRIPTION
## Correction

Supersedes the original intent of this PR (which narrowed the auth gates to `atlan-app-fleet[bot]` only). That was **wrong**: `application-sdk` itself is a deliberate `renovate[bot]` holdout — it stays on the **Mend-hosted app** for its own workflow-action (`github-actions`) updates, because the self-hosted runner disables that manager and excludes application-sdk. It's still producing `renovate[bot]` PRs today (e.g. #2788).

Narrowing the auto-approve gate / dashboard scanner to fleet-bot-only would have **stopped auto-approving application-sdk's own Renovate PRs** and dropped them from the dashboard.

## What this PR now does

**No functional change** vs the dual-author state merged in #2765 — it only **corrects the comments** that said "narrow once Mend is uninstalled", so nobody later narrows the gate and silently breaks application-sdk's Renovate. Both authors remain accepted:
- `atlan-app-fleet[bot]` — the self-hosted fleet runner (17 app repos)
- `renovate[bot]` — Mend, still used by `application-sdk` itself

27 fleet-scan tests pass; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)