### PR TITLE
fix(contract-toolkit): emit connector type on the ConnectionCreator widget

### DIFF
--- a/contract-toolkit/examples/agent-e2e/app/generated/agent-e2e.json
+++ b/contract-toolkit/examples/agent-e2e/app/generated/agent-e2e.json
@@ -69,7 +69,8 @@
           "label": "",
           "hidden": false,
           "help": "",
-          "grid": 8
+          "grid": 8,
+          "connector": "api"
         }
       }
     },

--- a/contract-toolkit/examples/bundle/app/generated/crawler/crawler.json
+++ b/contract-toolkit/examples/bundle/app/generated/crawler/crawler.json
@@ -26,7 +26,8 @@
           "hidden": false,
           "help": "",
           "placeholder": "Connection Name",
-          "grid": 8
+          "grid": 8,
+          "connector": "snowflake"
         }
       },
       "include-filter": {

--- a/contract-toolkit/examples/full/app/generated/full-featured.json
+++ b/contract-toolkit/examples/full/app/generated/full-featured.json
@@ -27,7 +27,8 @@
           "hidden": false,
           "help": "",
           "placeholder": "Connection Name",
-          "grid": 8
+          "grid": 8,
+          "connector": "postgres"
         }
       },
       "include_filter": {

--- a/contract-toolkit/examples/publish-controls/app/generated/publish-controls.json
+++ b/contract-toolkit/examples/publish-controls/app/generated/publish-controls.json
@@ -39,7 +39,8 @@
           "hidden": false,
           "help": "",
           "placeholder": "Connection Name",
-          "grid": 8
+          "grid": 8,
+          "connector": "trino"
         }
       },
       "load-to-atlan": {

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -28,9 +28,19 @@
 @ModuleInfo { minPklVersion = "0.25.1" }
 open module com.atlan.app.contract.App
 
-import "Connectors.pkl"
+import "Connectors.pkl" as ConnectorsPkg
 import "Deployment.pkl" as DeploymentPkg
 import "Widgets.pkl"
+
+// ── CONNECTOR RE-EXPORT ───────────────────────────────────────────────────────
+// Re-export the Connectors module so amending contracts can reference connector
+// constants as `Connectors.API`, `Connectors.SNOWFLAKE`, etc. WITHOUT a
+// supplemental `import "@app-contract-toolkit/Connectors.pkl"` — mirroring how
+// the widget types are re-exported below. `hidden` keeps it out of rendered
+// output. (Type-position references — e.g. `Connectors.Type` in an annotation —
+// still need the module import, which the toolkit uses internally as
+// `ConnectorsPkg`; amending apps set values like `connector = Connectors.API`.)
+hidden Connectors = ConnectorsPkg
 
 // ── WIDGET TYPE RE-EXPORTS ────────────────────────────────────────────────────
 // Typealiases so amending contracts write `new UIConfig { }`, `new TextInput { }`, etc.
@@ -116,7 +126,7 @@ displayName: String = name.capitalize()
 /// Connector type from the Connectors registry.
 /// Required only when a credential configmap is emitted (`hasCredentialConfig = true`).
 /// Apps without credentials (e.g. utility apps) can omit this.
-connector: Connectors.Type? = null
+connector: ConnectorsPkg.Type? = null
 
 /// Icon URL for the app.
 icon: String
@@ -2490,12 +2500,40 @@ local function generateExtractNode(): Mapping<String, Any> =
 
 // ── Output file emitters ──────────────────────────────────────────────────────
 
+// uiConfig with the app-level `connector` injected onto every ConnectionCreator
+// ("connection") widget, so the CREATE path emits `ui.connector` — the key the
+// frontend reads to mint a new connection's qualifiedName. Without this the
+// frontend has no connector type on the create widget and falls back to the
+// workflow's `orchestration.atlan.com/source` label (the app id) when building
+// `default/{connector}/{epoch}` — wrong whenever the app name and the connector
+// type differ (e.g. app "openapi" + connector "api"). Only the hidden
+// `connectorType` field is amended; `fixed ui` recomputes from it, so
+// non-ConnectionCreator widgets and apps without a `connector` are untouched.
+local connectorInjectedUiConfig: Widgets.UIConfig? =
+  if (uiConfig == null || connector == null) uiConfig
+  else (uiConfig!!) {
+    tasks {
+      for (stepKey, step in uiConfig!!.tasks) {
+        [stepKey] = (step) {
+          inputs {
+            for (inKey, inEl in step.inputs) {
+              [inKey] =
+                if (inEl is Widgets.ConnectionCreator)
+                  (inEl as Widgets.ConnectionCreator) { connectorType = connector!!.value }
+                else inEl
+            }
+          }
+        }
+      }
+    }
+  }
+
 local workflowConfigOutput: FileOutput = new FileOutput {
   value = new Mapping {
     ["id"] = workflowConfigName
     ["name"] = displayName
     ["logo"] = logo
-    ["config"] = uiConfig
+    ["config"] = connectorInjectedUiConfig
   }
   renderer = new JsonRenderer {}
 }
@@ -2926,7 +2964,14 @@ local function getSubsFieldLine(k: String, u: Widgets.UIElement): String? =
 local function generateE2EBasePy(): FileOutput = new FileOutput {
   local baseClass = e2eBaseClass()
   local cname = pascalCase(name)
-  local emitConnType = connector != null && connector!!.value != name
+  // Always emit connection_type when a connector is declared — never gate on
+  // `value != name`. The e2e base falls back to `connector_short_name` (= app
+  // name) when connection_type is unset, which is WRONG whenever the connector
+  // type differs from the app name (e.g. app name "openapi", connector "api").
+  // Emitting unconditionally makes this artifact agree with the frontend config
+  // and removes the entire latent app-name-fallback bug class. When value ==
+  // name the emitted line simply restates the fallback (harmless).
+  local emitConnType = connector != null
   local emitConnCat = connector != null && connector!!.category != "warehouse"
   text =
     "# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.\n" +

--- a/contract-toolkit/src/Config.pkl
+++ b/contract-toolkit/src/Config.pkl
@@ -603,6 +603,13 @@ class Widget {
   /// Whether to show connection options.
   connectionOptions: Boolean?
 
+  /// Connector type for the connection widget (ConnectionCreator). The frontend
+  /// reads this to build a newly-created connection's qualifiedName as
+  /// `default/{connector}/{epoch}`. Distinct from `connectorName` (the
+  /// connectionSelector's filter). Injected by the toolkit from the app-level
+  /// `connector`.
+  connector: String?
+
   /// Connection category filter for connectionSelector widget (e.g., "['warehouse', 'database', 'lake']").
   connectionCategories: String?
 
@@ -822,11 +829,23 @@ class ConnectionCreator extends UIElement {
   /// (Optional) Whether to show connection options.
   hidden showConnectionOptions: Boolean?
 
+  /// (Injected by the toolkit from the app-level `connector`.) The Atlan
+  /// connector type stamped on connections created via this widget, emitted as
+  /// `ui.connector` — the key the frontend's connection widget reads to build a
+  /// new connection's qualifiedName (`default/{connector}/{epoch}`). Without it
+  /// the frontend has no connector type on the CREATE path and falls back to the
+  /// workflow's `orchestration.atlan.com/source` label (the app id), which is
+  /// wrong whenever the app name differs from the connector type (e.g. app
+  /// "openapi", connector "api" → connections wrongly created as
+  /// `default/openapi/{epoch}`). Left null when no connector is injected.
+  hidden connectorType: String?
+
   /// (Generated) Internal configuration for the UI's rendering.
   fixed ui {
     widget = "connection"
     placeholder = placeholderText
     connectionOptions = showConnectionOptions
+    connector = connectorType
   }
 }
 

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -2737,6 +2737,32 @@ local function generateExtractNode(): Mapping<String, Any> =
   }
 
 /// Render workflow config directly as JSON.
+// uiConfig with the app-level `connector` injected onto every ConnectionCreator
+// ("connection") widget, so the CREATE path emits `ui.connector` — the key the
+// frontend reads to mint a new connection's qualifiedName. Without this the
+// frontend has no connector type on the create widget and falls back to the
+// workflow's `orchestration.atlan.com/source` label (the app id) when building
+// `default/{connector}/{epoch}` — wrong whenever the app name and the connector
+// type differ. Only the hidden `connectorType` field is amended; `fixed ui`
+// recomputes from it, so other widgets are untouched. Mirrors App.pkl.
+local connectorInjectedUiConfig: Config.UIConfig =
+  (uiConfig) {
+    tasks {
+      for (stepKey, step in uiConfig.tasks) {
+        [stepKey] = (step) {
+          inputs {
+            for (inKey, inEl in step.inputs) {
+              [inKey] =
+                if (inEl is Config.ConnectionCreator)
+                  (inEl as Config.ConnectionCreator) { connectorType = connector.value }
+                else inEl
+            }
+          }
+        }
+      }
+    }
+  }
+
 local workflowConfigOutput: FileOutput = new FileOutput {
   value = new Mapping {
     when (workflowConfigIncludeTopLevelMetadata) {
@@ -2744,7 +2770,7 @@ local workflowConfigOutput: FileOutput = new FileOutput {
       ["name"] = displayName
       ["logo"] = logo
     }
-    ["config"] = uiConfig
+    ["config"] = connectorInjectedUiConfig
   }
   renderer = new JsonRenderer {}
 }

--- a/contract-toolkit/src/Widgets.pkl
+++ b/contract-toolkit/src/Widgets.pkl
@@ -437,6 +437,13 @@ class Widget {
   /// Whether to show connection options.
   connectionOptions: Boolean?
 
+  /// Connector type for the connection widget (ConnectionCreator). The frontend
+  /// reads this to build a newly-created connection's qualifiedName as
+  /// `default/{connector}/{epoch}`. Distinct from `connectorName` (the
+  /// connectionSelector's filter). Injected by the toolkit from the app-level
+  /// `connector`.
+  connector: String?
+
   /// Connection category filter for connectionSelector widget.
   connectionCategories: String?
 
@@ -593,10 +600,23 @@ class ConnectionCreator extends UIElement {
 
   hidden showConnectionOptions: Boolean?
 
+  /// (Injected by the toolkit from the app-level `connector`.) The Atlan
+  /// connector type stamped on connections created via this widget, emitted as
+  /// `ui.connector` — the key the frontend's connection widget reads to build a
+  /// new connection's qualifiedName (`default/{connector}/{epoch}`). Without it
+  /// the frontend has no connector type on the CREATE path and falls back to the
+  /// workflow's `orchestration.atlan.com/source` label (the app id), which is
+  /// wrong whenever the app name differs from the connector type (e.g. app
+  /// "openapi", connector "api" → connections wrongly created as
+  /// `default/openapi/{epoch}`). Left null when the app declares no `connector`,
+  /// in which case the key is omitted and behaviour is unchanged.
+  hidden connectorType: String?
+
   fixed ui {
     widget = "connection"
     placeholder = placeholderText
     connectionOptions = showConnectionOptions
+    connector = connectorType
   }
 }
 

--- a/contract-toolkit/tests/connection_creator_connector_test.pkl
+++ b/contract-toolkit/tests/connection_creator_connector_test.pkl
@@ -4,11 +4,11 @@
 // When a user creates a NEW connection, the frontend mints its qualifiedName as
 // `default/{connectorType}/{epoch}`. The connector type must come from the app's
 // declared `connector` (e.g. Connectors.API → "api"), NOT from the app `name`.
-// The toolkit injects it as `ui.connectorName` on the ConnectionCreator, the same
-// key the ConnectionSelector already uses.
+// The toolkit injects it as `ui.connector` on the ConnectionCreator — NOT
+// `ui.connectorName`, which is the distinct key the ConnectionSelector reads.
 //
 // Regression guard: an app named "openapi" with `connector = Connectors.API` must
-// emit `connectorName = "api"` — never "openapi" — otherwise connections are
+// emit `connector = "api"` — never "openapi" — otherwise connections are
 // created under `default/openapi/{epoch}` and every child asset QN is poisoned.
 
 amends "pkl:test"
@@ -40,7 +40,7 @@ local openapiApp = (App) {
   }
 }
 
-// App whose name == connector value — connectorName should still be emitted.
+// App whose name == connector value — connector should still be emitted.
 local selfNamedApp = (App) {
   name = "snowflake"
   displayName = "Snowflake"
@@ -58,7 +58,7 @@ local selfNamedApp = (App) {
   }
 }
 
-// App with NO connector declared — connectorName must be omitted (unchanged
+// App with NO connector declared — connector must be omitted (unchanged
 // behaviour, no accidental key).
 local noConnectorApp = (App) {
   name = "no-connector"

--- a/contract-toolkit/tests/connection_creator_connector_test.pkl
+++ b/contract-toolkit/tests/connection_creator_connector_test.pkl
@@ -1,0 +1,138 @@
+// Tests for the connector type injected onto the ConnectionCreator ("connection")
+// widget in the generated workflow config JSON.
+//
+// When a user creates a NEW connection, the frontend mints its qualifiedName as
+// `default/{connectorType}/{epoch}`. The connector type must come from the app's
+// declared `connector` (e.g. Connectors.API → "api"), NOT from the app `name`.
+// The toolkit injects it as `ui.connectorName` on the ConnectionCreator, the same
+// key the ConnectionSelector already uses.
+//
+// Regression guard: an app named "openapi" with `connector = Connectors.API` must
+// emit `connectorName = "api"` — never "openapi" — otherwise connections are
+// created under `default/openapi/{epoch}` and every child asset QN is poisoned.
+
+amends "pkl:test"
+
+import "../src/App.pkl" as App
+import "../src/Config.pkl"
+import "../src/Connectors.pkl"
+import "../src/NativeApp.pkl"
+// Amends App.pkl and uses `Connectors.API` with NO Connectors import — proves
+// the re-export. Merely importing/evaluating it exercises the resolution.
+import "fixtures/connector_reexport_app.pkl" as reexportApp
+
+// App whose name ("openapi") differs from its connector type ("api") — the
+// exact scenario the bug was reported for.
+local openapiApp = (App) {
+  name = "openapi"
+  displayName = "OpenAPI Spec Loader"
+  icon = "https://example.com/icon.svg"
+  connector = Connectors.API
+  hasCredentialConfig = false
+  uiConfig = new App.UIConfig {
+    tasks {
+      ["Configuration"] {
+        inputs {
+          ["connection"] = new App.ConnectionCreator { placeholderText = "Connection" }
+        }
+      }
+    }
+  }
+}
+
+// App whose name == connector value — connectorName should still be emitted.
+local selfNamedApp = (App) {
+  name = "snowflake"
+  displayName = "Snowflake"
+  icon = "https://example.com/icon.svg"
+  connector = Connectors.SNOWFLAKE
+  hasCredentialConfig = false
+  uiConfig = new App.UIConfig {
+    tasks {
+      ["Configuration"] {
+        inputs {
+          ["connection"] = new App.ConnectionCreator { placeholderText = "Connection" }
+        }
+      }
+    }
+  }
+}
+
+// App with NO connector declared — connectorName must be omitted (unchanged
+// behaviour, no accidental key).
+local noConnectorApp = (App) {
+  name = "no-connector"
+  displayName = "No Connector"
+  icon = "https://example.com/icon.svg"
+  hasCredentialConfig = false
+  uiConfig = new App.UIConfig {
+    tasks {
+      ["Configuration"] {
+        inputs {
+          ["connection"] = new App.ConnectionCreator { placeholderText = "Connection" }
+        }
+      }
+    }
+  }
+}
+
+// NativeApp (legacy module) — same injection must apply on this path too.
+local nativeApp = (NativeApp) {
+  name = "native-openapi"
+  displayName = "Native OpenAPI"
+  connector = Connectors.API
+  icon = "https://example.com/icon.svg"
+  workflowType = "NativeOpenApiWorkflow"
+  hasCredentialConfig = false
+  uiConfig = new Config.UIConfig {
+    tasks {
+      ["Configuration"] {
+        inputs {
+          ["connection"] = new Config.ConnectionCreator {
+            title = "Connection"
+            placeholderText = "Connection"
+          }
+        }
+      }
+    }
+  }
+}
+
+local openapiConfig: String = openapiApp.output.files["app/generated/openapi.json"].text
+local selfNamedConfig: String = selfNamedApp.output.files["app/generated/snowflake.json"].text
+local noConnectorConfig: String = noConnectorApp.output.files["app/generated/no-connector.json"].text
+local nativeConfig: String = nativeApp.output.files["native-openapi.json"].text
+
+facts {
+  // ── App path ──────────────────────────────────────────────────────────────
+  // The frontend's connection (create) widget reads `ui.connector` — NOT
+  // `ui.connectorName` (that is the connectionSelector's filter) — to build the
+  // new connection's qualifiedName `default/{connector}/{epoch}`.
+  ["ConnectionCreator emits ui.connector from connector.value, not app name"] {
+    openapiConfig.contains("\"connector\": \"api\"")
+    !openapiConfig.contains("\"connector\": \"openapi\"")
+  }
+
+  ["ConnectionCreator emits ui.connector even when name == connector.value"] {
+    selfNamedConfig.contains("\"connector\": \"snowflake\"")
+  }
+
+  ["ConnectionCreator omits ui.connector when the app has no connector"] {
+    !noConnectorConfig.contains("\"connector\":")
+  }
+
+  // ── NativeApp path ──────────────────────────────────────────────────────────
+  ["NativeApp ConnectionCreator emits ui.connector from connector.value"] {
+    nativeConfig.contains("\"connector\": \"api\"")
+    !nativeConfig.contains("\"connector\": \"native-openapi\"")
+  }
+
+  // ── Connectors re-export ──────────────────────────────────────────────────
+  // The fixture amends App.pkl and sets `connector = Connectors.API` without
+  // importing Connectors.pkl; resolving it proves the re-export works.
+  ["App re-exports Connectors so apps need no separate import"] {
+    reexportApp.connector.value == "api"
+    reexportApp.output.files["app/generated/reexport-probe.json"].text
+      .contains("\"connector\": \"api\"")
+  }
+}

--- a/contract-toolkit/tests/e2e_codegen_test.pkl
+++ b/contract-toolkit/tests/e2e_codegen_test.pkl
@@ -396,8 +396,14 @@ facts {
     postgresBase.contains("connection_type = \"postgres\"")
   }
 
-  ["connection_type omitted when connector.value == name"] {
-    !selfNamedBase.contains("connection_type =")
+  // connection_type is now ALWAYS emitted when a connector is declared, even
+  // when it equals the app name. Gating on `value != name` left the e2e base
+  // relying on its `connection_type or connector_short_name` fallback, which is
+  // wrong whenever the two differ (e.g. app "openapi", connector "api").
+  // Emitting unconditionally keeps this artifact aligned with the frontend
+  // config; when value == name the line simply restates the fallback value.
+  ["connection_type emitted even when connector.value == name"] {
+    selfNamedBase.contains("connection_type = \"snowflake\"")
   }
 
   ["connection_category emitted when category is not warehouse"] {

--- a/contract-toolkit/tests/fixtures/connector_reexport_app.pkl
+++ b/contract-toolkit/tests/fixtures/connector_reexport_app.pkl
@@ -1,0 +1,24 @@
+/// Fixture: an app that amends App.pkl and references `Connectors.API`
+/// WITHOUT a supplemental `import "Connectors.pkl"`.
+///
+/// Proves the Connectors re-export: amending App.pkl alone gives access to the
+/// connector constants (just like the widget types), so apps no longer need a
+/// second import line. If the re-export regresses, evaluating this fixture fails
+/// with an "unresolved reference: Connectors" error.
+amends "../../src/App.pkl"
+
+name = "reexport-probe"
+displayName = "Re-export Probe"
+icon = "https://example.com/icon.svg"
+connector = Connectors.API
+hasCredentialConfig = false
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs {
+        ["connection"] = new ConnectionCreator { placeholderText = "Connection" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

When a user creates a **new** connection (`connection_usage=CREATE`), the frontend mints its qualifiedName as `default/{connector}/{epoch}`, reading the connector segment from the connection (`"connection"`) widget's **`ui.connector`**. The `ConnectionCreator` never emitted that key, so the frontend fell back to the workflow's `orchestration.atlan.com/source` label — i.e. the **app id**.

Whenever the app name differs from the connector type — e.g. app `"openapi"` with `connector = Connectors.API` (`"api"`) — connections were created as `default/openapi/{epoch}` instead of `default/api/{epoch}`, poisoning the prefix of **every** child asset. The REUSE path (`connectionSelector`) was already correct via `ui.connectorName`.

Verified against `atlan-frontend`: `src/workflowsv2/components/dynamicForm2/widget/connection.vue` reads `property.ui.connector` (line ~370) and builds `default/${connector.value}/${seconds}` (line ~470). The create widget reads `ui.connector`; the selector reads `ui.connectorName` — a real asymmetry.

## Fix

- **Inject the connector type onto every `ConnectionCreator`.** The toolkit now sets the app-level `connector` on the create widget, emitting **`ui.connector`** — the exact key the frontend reads. Applied on both the `App.pkl` and `NativeApp.pkl` (`Config.pkl`) paths. Only a hidden field is amended; `fixed ui` recomputes, so other widgets and apps without a `connector` are untouched (key omitted → no churn).
- **Always emit `connection_type` in `_e2e_base.py`** when a connector is declared (dropped the `value != name` guard) so the e2e artifact never depends on the app-name fallback and stays aligned with the frontend config unconditionally.
- **Re-export the Connectors module from `App.pkl`** (`hidden Connectors = …`) so apps that `amends "App.pkl"` can use `Connectors.API` without a separate `import "Connectors.pkl"` — mirroring the existing widget re-exports.

## Tests

- New `tests/connection_creator_connector_test.pkl` (+ fixture): App path, NativeApp path, `name != connector.value` (the openapi case), no-connector (key omitted), and the Connectors re-export.
- Updated `tests/e2e_codegen_test.pkl` for the always-emit `connection_type` behavior.
- Regenerated example configs now carry `ui.connector` (`api` / `snowflake` / `postgres` / `trino`).

Full suite: **269 passed / 645 asserts**, invariants pass.

## Downstream

`atlan-openapi-app` picks this up after a toolkit release + version bump + `make generate`; its create widget then emits `ui.connector: "api"` and the connection is created as `default/api/{epoch}`. It can then also drop its explicit `import "@app-contract-toolkit/Connectors.pkl"`.

## Note for reviewers

`connector` is added to the base `Widget` class (which already holds `connectorName`, `connectorConfigName`, `connectionCategories`, `connectionOptions`). Scoping it to only `ConnectionCreator` would require making the closed `Widget` class `open` plus re-deriving all base `ui` keys, so the one-field addition follows the existing pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)