### PR TITLE
ci: regenerate/freshness-check every contract module, not just app.pkl

### DIFF
--- a/.github/scripts/regenerate_contract.py
+++ b/.github/scripts/regenerate_contract.py
@@ -99,14 +99,25 @@ def resolve(contract_dir: str) -> None:
 def evaluate(contract_dir: str) -> bool:
     """Regenerate artifacts in place via ``pkl eval``. Returns True on success.
 
+    Evals every top-level contract module (``contract/*.pkl``), not just
+    ``app.pkl``: a contract dir may also hold credential contracts (e.g.
+    ``csa-connectors-objectstore.pkl``) that emit their own generated config.
+    Regenerating only ``app.pkl`` left those unregenerated and unchecked, so a
+    toolkit change that breaks a credential contract (e.g. 0.19.0 retyping
+    Credential inputs to ``Widgets.*``) slipped through. Mirrors the app
+    Makefile's ``pkl eval -m . contract/*.pkl``; ``PklProject`` has no ``.pkl``
+    extension so the glob excludes it. Sorted for deterministic eval order.
+
     ``--project-dir``: the contract is a Pkl project declaring
     app-contract-toolkit as a dependency, so eval must load that project to
     resolve the ``@app-contract-toolkit`` import. ``-m .`` writes each output
     key (app/generated/**, atlan.yaml, app.yaml) at its natural path relative
     to the repo root — exactly where the Docker build COPYs from and the tests
     read."""
-    app_pkl = str(Path(contract_dir) / "app.pkl")
-    proc = run(["pkl", "eval", "--project-dir", contract_dir, "-m", ".", app_pkl])
+    contract_modules = sorted(str(p) for p in Path(contract_dir).glob("*.pkl"))
+    proc = run(
+        ["pkl", "eval", "--project-dir", contract_dir, "-m", ".", *contract_modules]
+    )
     return proc.returncode == 0
 
 

--- a/.github/scripts/renovate_pkl_sync.py
+++ b/.github/scripts/renovate_pkl_sync.py
@@ -119,11 +119,22 @@ def regenerate(contract_dir: str) -> bool:
 
     tmp = Path(tempfile.mkdtemp())
     try:
+        # Eval every top-level contract module, not just app.pkl: a contract
+        # dir may also hold credential contracts (e.g.
+        # csa-connectors-objectstore.pkl) that emit their own generated config.
+        # Regenerating only app.pkl left those invisible to both this sync and
+        # the freshness gate, so a toolkit change that breaks a credential
+        # contract (e.g. 0.19.0 retyping Credential inputs to Widgets.*) slipped
+        # through undetected. Mirrors the app Makefile's
+        # `pkl eval -m . contract/*.pkl`; PklProject has no `.pkl` extension so
+        # the glob excludes it. Sorted for deterministic eval order.
+        #
         # --project-dir: the contract is a Pkl project declaring
         # app-contract-toolkit as a *remote package*, so eval must load that
         # project to resolve the `@app-contract-toolkit` import. The bare
-        # `pkl eval contract/app.pkl` from the repo root finds no project and
+        # `pkl eval contract/*.pkl` from the repo root finds no project and
         # fails. -m writes each output key relative to the output base.
+        contract_modules = sorted(str(p) for p in Path(contract_dir).glob("*.pkl"))
         eval_cmd = [
             "pkl",
             "eval",
@@ -131,7 +142,7 @@ def regenerate(contract_dir: str) -> bool:
             contract_dir,
             "-m",
             str(tmp),
-            str(app_pkl),
+            *contract_modules,
         ]
         result = run(eval_cmd)
         attempt = 1

--- a/.github/scripts/tests/test_regenerate_contract.py
+++ b/.github/scripts/tests/test_regenerate_contract.py
@@ -129,6 +129,30 @@ def test_app_level_regenerates_in_place_without_resolve(repo, monkeypatch):
     assert any(c[1] == "eval" for c in calls)
 
 
+def test_evals_all_contract_modules_including_credentials(repo, monkeypatch):
+    """Every contract/*.pkl is passed to `pkl eval`, not just app.pkl — a
+    credential contract (e.g. csa-connectors-objectstore.pkl) must be
+    regenerated too, or a toolkit change that breaks it slips past both this
+    regen and the freshness gate (the 0.19.0 Credential.pkl retyping regression).
+    PklProject (no .pkl extension) must NOT be passed."""
+    (repo / "contract" / "csa-connectors-objectstore.pkl").write_text(
+        'amends "@app-contract-toolkit/Credential.pkl"\n'
+    )
+    calls: list = []
+    monkeypatch.setattr(mod, "run", _make_fake_run(repo, calls=calls))
+
+    assert mod.main([]) == 0
+
+    eval_cmds = [c for c in calls if c[1] == "eval"]
+    assert eval_cmds, "pkl eval was not invoked"
+    modules = [a for c in eval_cmds for a in c if a.endswith(".pkl")]
+    assert any(m.endswith("app.pkl") for m in modules), modules
+    assert any(
+        m.endswith("csa-connectors-objectstore.pkl") for m in modules
+    ), f"credential contract was not eval'd; modules passed: {modules}"
+    assert not any(m.endswith("PklProject") for c in eval_cmds for m in c)
+
+
 def test_app_level_eval_failure_warns_not_fatal(repo, monkeypatch, capsys):
     monkeypatch.setattr(mod, "run", _make_fake_run(repo, eval_rc=1))
 

--- a/.github/scripts/tests/test_renovate_pkl_sync.py
+++ b/.github/scripts/tests/test_renovate_pkl_sync.py
@@ -181,6 +181,45 @@ def test_default_regenerates(repo, monkeypatch):
     )
 
 
+def test_evals_all_contract_modules_including_credentials(repo, monkeypatch):
+    """regenerate() passes every contract/*.pkl to `pkl eval`, not just app.pkl,
+    so credential contracts (e.g. csa-connectors-objectstore.pkl) are
+    regenerated and freshness-checked too — otherwise a toolkit change that
+    breaks a credential contract (0.19.0 Credential.pkl retyping) slips through.
+    PklProject (no .pkl extension) must not be passed."""
+    (repo / "contract" / "csa-connectors-objectstore.pkl").write_text(
+        'amends "@app-contract-toolkit/Credential.pkl"\n'
+    )
+    eval_cmds: list = []
+    real_run = subprocess.run
+
+    def fake_run(cmd, *, check=False):
+        if cmd[0] == "pkl" and cmd[1] == "eval":
+            eval_cmds.append(cmd)
+            out_dir = Path(cmd[cmd.index("-m") + 1])
+            gen = out_dir / "app" / "generated"
+            gen.mkdir(parents=True, exist_ok=True)
+            (gen / "manifest.json").write_text(FRESH_MANIFEST)
+            return types.SimpleNamespace(returncode=0)
+        if cmd[0] == "pkl" and cmd[1:3] == ["project", "resolve"]:
+            return types.SimpleNamespace(returncode=0)
+        if cmd[0] == "uvx":
+            return types.SimpleNamespace(returncode=0)
+        return real_run(cmd, check=check, text=True, capture_output=True)
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    assert mod.main([]) == 0
+
+    assert eval_cmds, "pkl eval was not invoked"
+    modules = [a for c in eval_cmds for a in c if a.endswith(".pkl")]
+    assert any(m.endswith("app.pkl") for m in modules), modules
+    assert any(
+        m.endswith("csa-connectors-objectstore.pkl") for m in modules
+    ), f"credential contract was not eval'd; modules passed: {modules}"
+    assert not any(m.endswith("PklProject") for c in eval_cmds for m in c)
+
+
 def test_regenerate_eval_failure_falls_back_to_lock_only(repo, monkeypatch):
     monkeypatch.setattr(mod, "run", _make_fake_run(repo, eval_rc=1))
     before = _commit_count(repo)


### PR DESCRIPTION
## Problem

`renovate_pkl_sync.regenerate()` and `regenerate_contract.evaluate()` both ran `pkl eval … contract/app.pkl` — **only the app contract**. A contract dir may also hold **credential contracts** (e.g. `csa-connectors-objectstore.pkl`) that emit their own generated config, and those were never regenerated or freshness-checked.

**Consequence:** a toolkit change that breaks a credential contract slips through undetected. Concretely — app-contract-toolkit **0.19.0** retyped `Credential.NestedCredentialInput.inputs` to `Widgets.UIElement`, so a contract still using the legacy `Config.*` widgets no longer evaluates. Yet:
- the Renovate bump PR regenerated **green** (only `app.pkl` was eval'd), and
- the freshness gate (which reuses this regeneration) stayed **green**,

leaving `make generate` **broken on the consumer's `main`** — discovered on `atlan-openapi-app` after its 0.19.0 bump.

## Fix

Both eval sites now eval **every top-level `contract/*.pkl`** (sorted; `PklProject` has no `.pkl` extension so it's excluded) — mirroring the app Makefile's `pkl eval -m . contract/*.pkl`. `_swap_outputs` already swaps the whole `app/generated` dir, so credential configs come along.

- `renovate_pkl_sync.py` → `regenerate()` (used by renovate-pkl-sync **and** the freshness gate)
- `regenerate_contract.py` → `evaluate()` (used by the regenerate-contract composite action)

## Tests

Regression tests in both suites assert all contract modules — including a credential contract — are passed to `pkl eval`, and that `PklProject` is not. Full script suite: **44 passed**. Lint/format clean (ruff v0.6.4, the repo's pinned version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtUH8uDLYErR4LK8kbBr9h