### PR TITLE
fix(storage/json): preserve nested-object structure instead of str(obj) [cross-connector]

### DIFF
--- a/application_sdk/storage/formats/json.py
+++ b/application_sdk/storage/formats/json.py
@@ -1,3 +1,4 @@
+import dataclasses
 import os
 import warnings
 from collections.abc import AsyncIterator
@@ -22,6 +23,34 @@ if TYPE_CHECKING:
 from application_sdk.storage.formats import Reader, Writer
 
 logger = get_logger(__name__)
+
+
+def default_json_serializer(obj: object) -> Any:
+    """orjson ``default=`` hook that preserves nested-object structure.
+
+    Use this as the ``default=`` argument to ``orjson.dumps`` anywhere records
+    may contain non-native objects (connector output writers, local JSONL
+    writes behind ``RollingFileWriter``/``FileReference``). It exists so every
+    connector shares ONE correct serializer instead of copy-pasting a bare
+    ``return str(obj)`` fallback.
+
+    Why not ``str(obj)``: flattening a nested model — e.g. a Looker ``Dialect``
+    SDK object — to its string repr silently corrupts the record and later
+    crashes path access such as ``get_value_for_attr(rec, "dialect/name")`` with
+    ``'str' object has no attribute 'get'``. orjson re-serializes whatever we
+    return here, so a ``dict`` round-trips as a proper JSON object.
+
+    Scalars without ``__dict__`` (``pandas.Timestamp``, numpy scalars,
+    ``Decimal``, ``UUID``) fall through to ``str(obj)`` exactly as before.
+    """
+    if hasattr(obj, "model_dump"):  # pydantic v2 BaseModel
+        return obj.model_dump(mode="json")
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return dataclasses.asdict(obj)
+    # attrs / plain domain objects expose their fields via __dict__.
+    if hasattr(obj, "__dict__") and vars(obj):
+        return vars(obj)
+    return str(obj)
 
 
 class JsonFileReader(Reader):
@@ -384,18 +413,13 @@ class JsonFileWriter(Writer):
     async def _write_chunk(self, chunk: "pd.DataFrame", file_name: str):
         """Write a chunk to a JSON file using orjson."""
 
-        def _default_serializer(obj: object) -> str:
-            # pandas.Timestamp and similar datetime-like objects are not
-            # natively handled by orjson when they appear as dict values.
-            return str(obj)
-
         mode = "ab+" if SafeFileOps.exists(file_name) else "wb"
         with SafeFileOps.open(file_name, mode=mode) as f:
             for record in chunk.to_dict(orient="records"):
                 f.write(
                     orjson.dumps(
                         record,
-                        default=_default_serializer,
+                        default=default_json_serializer,
                         option=orjson.OPT_APPEND_NEWLINE,
                     )
                 )

--- a/tests/unit/storage/formats/writers/test_json_writer.py
+++ b/tests/unit/storage/formats/writers/test_json_writer.py
@@ -194,3 +194,48 @@ async def test_write_chunk_handles_pandas_timestamp(tmp_path: Path) -> None:
         record = orjson.loads(f.read().strip())
     assert record["name"] == "a"
     assert "2024-01-01" in record["ts"]
+
+
+@pytest.mark.asyncio
+async def test_write_chunk_preserves_nested_object_structure(tmp_path: Path) -> None:
+    """Nested model objects must round-trip as JSON objects, not str(obj).
+
+    Regression: the Looker ``Dialect`` SDK model (and any object with __dict__)
+    was flattened to its string repr by the ``str(obj)`` fallback, corrupting
+    the record and crashing downstream path access ("dialect/name").
+    """
+    import dataclasses as _dc
+
+    import orjson
+    import pandas as pd
+
+    @_dc.dataclass
+    class Dialect:
+        name: str
+        label: str
+
+    class Plain:
+        def __init__(self) -> None:
+            self.name = "postgres"
+
+    writer = JsonFileWriter(path=str(tmp_path / "out"))
+    df = pd.DataFrame(
+        {
+            "conn": ["c1", "c2"],
+            "dialect": [Dialect(name="postgres", label="PostgreSQL"), Plain()],
+            "ts": [pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02")],
+        }
+    )
+    out_file = str(tmp_path / "out" / "chunk.json")
+    await writer._write_chunk(df, out_file)
+
+    with open(out_file, "rb") as f:
+        records = [orjson.loads(line) for line in f.read().splitlines() if line.strip()]
+
+    # dataclass -> nested object; "dialect/name" is now traversable
+    assert records[0]["dialect"] == {"name": "postgres", "label": "PostgreSQL"}
+    assert records[0]["dialect"]["name"] == "postgres"
+    # plain object with __dict__ -> nested object
+    assert records[1]["dialect"] == {"name": "postgres"}
+    # scalar datetime-like still stringified (unchanged behaviour)
+    assert isinstance(records[0]["ts"], str) and "2024-01-01" in records[0]["ts"]


### PR DESCRIPTION
## What

Make the SDK's JSON serialization **structure-preserving** so nested model objects round-trip as JSON objects instead of being flattened to `str(obj)`. Prevents a class-of-bug that can hit **any** connector.

## Root cause (found via a real prod failure)

A Looker metadata extract on tenant `squarespace` failed with:

```
AttributeError: 'str' object has no attribute 'get'
  app/utils/__init__.py:133         obj = obj.get(attr_name)
  app/clients/looker_v2/store.py:507  get_value_for_attr(connection, "dialect/name")
```

The Looker SDK returns each connection's `dialect` as a **model object**. When the record was written to JSONL, the writer's `default=` hook did `return str(obj)`, so `dialect` was persisted as its **string repr** and read back as a plain `str`. Downstream path access `dialect/name` then called `.get()` on a string → crash, aborting the whole extract.

This `str(obj)` fallback lives in the shared SDK writer (`JsonFileWriter._write_chunk`) and was copy-pasted into connector-local writers — so it is a **cross-connector** latent defect, not a Looker-only one.

## Change

- Extract a reusable, public `default_json_serializer(obj)` in `application_sdk/storage/formats/json.py`:
  - pydantic v2 → `model_dump(mode="json")`
  - dataclass → `dataclasses.asdict`
  - object with `__dict__` (attrs / plain domain objects) → `vars(obj)`
  - everything else (scalars with no `__dict__`: `pandas.Timestamp`, numpy, `Decimal`, `UUID`) → `str(obj)` **(unchanged)**
- `JsonFileWriter._write_chunk` now uses it.
- Connectors doing local orjson writes behind `RollingFileWriter`/`FileReference` should import this instead of re-implementing `str(obj)`.

## Test

Added `test_write_chunk_preserves_nested_object_structure` — dataclass + plain-object cells round-trip as nested JSON objects; `pandas.Timestamp` stays a string. `pytest tests/unit/storage/formats` → 30 passed, 3 skipped. ruff clean; pyright 0 errors.

## ⚠️ Blast radius / reviewer note

This **changes the on-disk output format** for any record containing a nested object: a field previously written as `"SomeModel(name='x')"` now becomes `{"name": "x", ...}`. That is the intended fix, but any downstream transformer that currently reads such a field **as a string** would need to read it as an object. Please validate against connector parity/golden outputs before merge. Scalars (timestamps etc.) are unaffected. Opened as **draft** for SDK-owner review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
