### PR TITLE
fix(storage): de-flake rolling-writer time-rollover test (clock seam)

### DIFF
--- a/application_sdk/storage/rolling.py
+++ b/application_sdk/storage/rolling.py
@@ -87,6 +87,25 @@ logger = get_logger(__name__)
 
 T = TypeVar("T")
 
+
+def _monotonic() -> float:
+    """Monotonic clock seam for the writer.
+
+    The writer reads the clock through this indirection instead of calling
+    ``time.monotonic`` directly so tests can drive rollover deterministically
+    by patching ``application_sdk.storage.rolling._monotonic`` in isolation.
+
+    Patching the global ``time.monotonic`` instead would also intercept
+    asyncio's event-loop clock (``BaseEventLoop.time`` reads ``time.monotonic``),
+    whose read count during ``await`` scheduling is nondeterministic and
+    platform-dependent. A finite fake clock then gets exhausted mid-test —
+    ``next(iter)`` raises ``StopIteration`` which PEP 479 surfaces as
+    ``RuntimeError: generator raised StopIteration``. That is exactly what
+    flaked ``test_time_rollover_after_interval_elapsed`` on Python 3.13.
+    """
+    return time.monotonic()
+
+
 FlushFn = Callable[[list[T], str], Awaitable[None] | None]
 ChunkCompleteFn = Callable[[int, str], Awaitable[None] | None]
 SizeEstimatorFn = Callable[[Any], int]
@@ -164,7 +183,7 @@ class TimePolicy(RolloverPolicy):
         self.interval_seconds = interval_seconds
 
     def should_roll(self, state: BufferState) -> bool:
-        elapsed = time.monotonic() - state.chunk_start_monotonic
+        elapsed = _monotonic() - state.chunk_start_monotonic
         return elapsed >= self.interval_seconds
 
 
@@ -411,7 +430,7 @@ class RollingFileWriter(Generic[T]):
 
         async with self._lock:
             if self._chunk_start_monotonic is None:
-                self._chunk_start_monotonic = time.monotonic()
+                self._chunk_start_monotonic = _monotonic()
             self._buffer.append(batch)
 
             try:

--- a/tests/unit/storage/test_rolling.py
+++ b/tests/unit/storage/test_rolling.py
@@ -184,7 +184,7 @@ class TestRollingFileWriterRollover:
         # intercepts asyncio's event-loop scheduler, whose read count is
         # nondeterministic; that exhausted this iterator mid-test and raised
         # "generator raised StopIteration" on Python 3.13.
-        clock = iter([100.0, 100.5, 161.0, 161.5])
+        clock = iter([100.0, 100.5, 161.0])
         with patch("application_sdk.storage.rolling._monotonic", lambda: next(clock)):
             async with RollingFileWriter(
                 base,
@@ -193,13 +193,12 @@ class TestRollingFileWriterRollover:
                 chunk_interval_seconds=60.0,
                 scoped_subdir_name="run",
             ) as writer:
-                # First append at t=100 — starts chunk-0 timer.
-                # Read inside append: start=100.0, then elapsed-check at 100.5
-                # (elapsed=0.5, under 60).
+                # First append — two clock reads: start=100.0 sets chunk-0 timer,
+                # then elapsed-check at 100.5 (elapsed=0.5, under 60).
                 await writer.append({"id": 1})
-                # Second append at t=161 — start-check sees existing start,
-                # then elapsed-check at 161.5 (elapsed=61.5, over 60) → flush
-                # chunk-0 with [{1}, {2}].
+                # Second append — one clock read: chunk-0 start already set, so
+                # only the elapsed-check runs, at 161.0 (elapsed=61.0, over 60)
+                # → flush chunk-0 with [{1}, {2}].
                 await writer.append({"id": 2})
 
         # Exactly one rollover from the timer; __aexit__ found empty buffer

--- a/tests/unit/storage/test_rolling.py
+++ b/tests/unit/storage/test_rolling.py
@@ -178,11 +178,14 @@ class TestRollingFileWriterRollover:
     async def test_time_rollover_after_interval_elapsed(self, base: str) -> None:
         """append after interval elapses must flush the in-flight chunk."""
         flush_fn, calls = _make_flush_fn()
-        # Drive the monotonic clock deterministically.
+        # Drive the monotonic clock deterministically. Patch the writer's own
+        # ``_monotonic`` seam — NOT the global ``time.monotonic`` — so only the
+        # writer's reads consume the fake clock. Patching the global clock also
+        # intercepts asyncio's event-loop scheduler, whose read count is
+        # nondeterministic; that exhausted this iterator mid-test and raised
+        # "generator raised StopIteration" on Python 3.13.
         clock = iter([100.0, 100.5, 161.0, 161.5])
-        with patch(
-            "application_sdk.storage.rolling.time.monotonic", lambda: next(clock)
-        ):
+        with patch("application_sdk.storage.rolling._monotonic", lambda: next(clock)):
             async with RollingFileWriter(
                 base,
                 ".json",


### PR DESCRIPTION
## Problem
`tests/unit/storage/test_rolling.py::TestRollingFileWriterRollover::test_time_rollover_after_interval_elapsed` intermittently failed with `RuntimeError: generator raised StopIteration` on Python 3.13 / macOS, ejecting PRs from the merge queue.

## Root cause
The test drove rollover by patching **`application_sdk.storage.rolling.time.monotonic`**. Because `rolling.py` does `import time`, that name is the shared `time` module object — so the patch replaces `time.monotonic` **globally**. asyncio's event loop reads `time.monotonic()` via `BaseEventLoop.time()` on every `await`/schedule, and its read count is nondeterministic and platform-dependent. The finite 4-element fake-clock iterator got exhausted mid-test → `StopIteration` → (PEP 479) `RuntimeError: generator raised StopIteration`.

## Fix
- Add a module-level `_monotonic()` clock seam in `rolling.py`; `TimePolicy.should_roll` and `append` read the clock through it.
- The test now patches `application_sdk.storage.rolling._monotonic` — isolated from asyncio's own clock, so only the writer's reads consume the fake clock. Fully deterministic.

## Validation
Previously-flaky test run **15×** green; full `test_rolling.py` suite (43 passed). `pre-commit` (ruff + pyright) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)