### PR TITLE
fix(observability): resolve metric object stores lazily so a boot-time binding gap self-heals (BLDX-1567)

### DIFF
--- a/application_sdk/observability/_objectstore_metric_exporter.py
+++ b/application_sdk/observability/_objectstore_metric_exporter.py
@@ -296,6 +296,7 @@ class ObjectStoreMetricExporter(MetricExporter):
                 )
             else:
                 self._deferred.add(name)
+                # conformance: ignore[L004] transient boot-race deferral, not a failure — logged once without a stacktrace by design (see block comment above); a traceback for "not ready yet" reads as a failure.
                 logger.warning(
                     "Object store '%s' binding not resolvable yet; metric upload deferred, "
                     "retrying each flush until it appears",

--- a/application_sdk/observability/_objectstore_metric_exporter.py
+++ b/application_sdk/observability/_objectstore_metric_exporter.py
@@ -231,6 +231,11 @@ class ObjectStoreMetricExporter(MetricExporter):
         # retry below would re-log a full traceback every flush (~60s) for the
         # life of the process (BLDX-1567 regression guard).
         self._skip_stores: set[str] = set()
+        # Store names for which a *transient* deferral has already been warned
+        # about. The transient boot race is retried every flush, so we warn once
+        # (a persistent gap stays visible in prod) then stay quiet at DEBUG —
+        # same log-once-by-name discipline as ``_skip_stores`` above.
+        self._deferred: set[str] = set()
         self._writer_seq = 0
 
     def _ensure_stores(self) -> None:
@@ -270,18 +275,32 @@ class ObjectStoreMetricExporter(MetricExporter):
         )
 
         try:
-            return create_store_from_binding(name)
+            store = create_store_from_binding(name)
         except (StorageBindingNotFoundError, StorageBindingBrokenError):
             # Transient boot states: the component is not written yet, or it is
             # present but its placeholders / ``secretKeyRef`` env vars are not
             # substituted yet. Both heal once Dapr finishes writing and the
-            # secret env materialises, so retry quietly on the next export. Both
+            # secret env materialises, so retry on the next export. Both
             # subclass StorageConfigError, so this clause must precede it.
-            logger.debug(
-                "Object store '%s' binding not resolvable yet; metric upload deferred (will retry)",
-                name,
-                exc_info=True,
-            )
+            #
+            # Warn once (so a *persistent* gap stays visible in prod, where
+            # DEBUG is filtered out) then drop to DEBUG on subsequent flushes so
+            # the ~60s retry does not spam. No stacktrace: the condition is
+            # expected and self-describing, and a traceback for "not ready yet"
+            # reads as a failure. The heal is logged at INFO in the ``else``
+            # branch, so an unmatched warning is the signal it is truly stuck.
+            if name in self._deferred:
+                logger.debug(
+                    "Object store '%s' binding still not resolvable; metric upload still deferred",
+                    name,
+                )
+            else:
+                self._deferred.add(name)
+                logger.warning(
+                    "Object store '%s' binding not resolvable yet; metric upload deferred, "
+                    "retrying each flush until it appears",
+                    name,
+                )
             return None
         except StorageConfigError:
             # Non-transient misconfiguration (e.g. unsupported binding type). It
@@ -304,6 +323,17 @@ class ObjectStoreMetricExporter(MetricExporter):
                 exc_info=True,
             )
             return None
+        else:
+            # Resolved. If we had previously deferred this store, announce the
+            # heal at INFO so the earlier warning is closed out and a boot-time
+            # gap is observably self-healing.
+            if name in self._deferred:
+                self._deferred.discard(name)
+                logger.info(
+                    "Object store '%s' binding now resolved; metric upload active",
+                    name,
+                )
+            return store
 
     def export(
         self,

--- a/application_sdk/observability/_objectstore_metric_exporter.py
+++ b/application_sdk/observability/_objectstore_metric_exporter.py
@@ -215,31 +215,57 @@ class ObjectStoreMetricExporter(MetricExporter):
             },
         )
         self._data_dir = data_dir or get_observability_dir()
-        self._deployment_store: ObjectStore | None = (
-            self._resolve_store(DEPLOYMENT_OBJECT_STORE_NAME)
-            if ENABLE_OBSERVABILITY_STORE_SINK
-            else None
-        )
-        self._upstream_store: ObjectStore | None = (
-            self._resolve_store(UPSTREAM_OBJECT_STORE_NAME)
-            if ENABLE_OBSERVABILITY_STORE_SINK and ENABLE_ATLAN_UPLOAD
-            else None
-        )
+        # Stores are resolved lazily on the first export, not here (BLDX-1567).
+        # The metrics flush runs on a daemon thread that can construct this
+        # exporter during app-server boot — before the Dapr ``objectstore``
+        # component YAML has been written to ``./components``. Resolving eagerly
+        # turned that transient boot race into *permanent* metric-upload
+        # disablement for the whole process (and logged a full traceback at
+        # boot). Lazy resolution retries on each export until the binding
+        # appears, so a slow-to-materialise component self-heals.
+        self._deployment_store: ObjectStore | None = None
+        self._upstream_store: ObjectStore | None = None
         self._writer_seq = 0
+
+    def _ensure_stores(self) -> None:
+        """Resolve the deployment/upstream stores, retrying until they appear.
+
+        Idempotent and cheap once resolved (each store is resolved at most
+        once successfully, then cached). While a binding is still absent the
+        resolution is retried on the next export rather than being latched off,
+        which is what makes a boot-time binding gap self-healing.
+        """
+        if not ENABLE_OBSERVABILITY_STORE_SINK:
+            return
+        if self._deployment_store is None:
+            self._deployment_store = self._resolve_store(DEPLOYMENT_OBJECT_STORE_NAME)
+        if self._upstream_store is None and ENABLE_ATLAN_UPLOAD:
+            self._upstream_store = self._resolve_store(UPSTREAM_OBJECT_STORE_NAME)
 
     def _resolve_store(self, name: str) -> ObjectStore | None:
         from application_sdk.storage.binding import (  # noqa: PLC0415 — deferred to break the observability→storage circular import
             create_store_from_binding,
         )
         from application_sdk.storage.errors import (  # noqa: PLC0415 — deferred to break the observability→storage circular import
+            StorageBindingNotFoundError,
             StorageConfigError,
         )
 
         try:
             return create_store_from_binding(name)
+        except StorageBindingNotFoundError:
+            # Binding not present yet. Expected transiently during boot before
+            # Dapr writes its components; resolution is retried on the next
+            # export, so this is benign rather than a hard misconfiguration.
+            logger.debug(
+                "Object store '%s' binding not present yet; metric upload deferred (will retry)",
+                name,
+                exc_info=True,
+            )
+            return None
         except StorageConfigError:
             logger.warning(
-                "Object store '%s' not configured; metric upload disabled",
+                "Object store '%s' misconfigured; metric upload disabled",
                 name,
                 exc_info=True,
             )
@@ -265,6 +291,10 @@ class ObjectStoreMetricExporter(MetricExporter):
             records = _serialize_metrics_data(metrics_data)
             if not records:
                 return MetricExportResult.SUCCESS
+
+            # Resolve stores on first use (and retry until a boot-time binding
+            # gap heals). Only attempted when there is data to write.
+            self._ensure_stores()
 
             now = datetime.now()
             ts_ns = int(now.timestamp() * 1e9)

--- a/application_sdk/observability/_objectstore_metric_exporter.py
+++ b/application_sdk/observability/_objectstore_metric_exporter.py
@@ -225,21 +225,38 @@ class ObjectStoreMetricExporter(MetricExporter):
         # appears, so a slow-to-materialise component self-heals.
         self._deployment_store: ObjectStore | None = None
         self._upstream_store: ObjectStore | None = None
+        # Store names that hit a *non-transient* resolution error (e.g. an
+        # unsupported binding type). These will never heal on retry, so they are
+        # resolved once, logged once, and then skipped — otherwise the per-export
+        # retry below would re-log a full traceback every flush (~60s) for the
+        # life of the process (BLDX-1567 regression guard).
+        self._skip_stores: set[str] = set()
         self._writer_seq = 0
 
     def _ensure_stores(self) -> None:
         """Resolve the deployment/upstream stores, retrying until they appear.
 
         Idempotent and cheap once resolved (each store is resolved at most
-        once successfully, then cached). While a binding is still absent the
-        resolution is retried on the next export rather than being latched off,
-        which is what makes a boot-time binding gap self-healing.
+        once successfully, then cached). While a binding is still in a
+        *transient* boot state (component not yet written, or present but with
+        placeholders/secret env not yet substituted) resolution is retried on
+        the next export rather than being latched off — that retry is what makes
+        a boot-time binding gap self-healing. A store that hit a non-transient
+        error is recorded in ``_skip_stores`` and not retried, so a genuine
+        misconfiguration is logged once, not every flush.
         """
         if not ENABLE_OBSERVABILITY_STORE_SINK:
             return
-        if self._deployment_store is None:
+        if (
+            self._deployment_store is None
+            and DEPLOYMENT_OBJECT_STORE_NAME not in self._skip_stores
+        ):
             self._deployment_store = self._resolve_store(DEPLOYMENT_OBJECT_STORE_NAME)
-        if self._upstream_store is None and ENABLE_ATLAN_UPLOAD:
+        if (
+            self._upstream_store is None
+            and ENABLE_ATLAN_UPLOAD
+            and UPSTREAM_OBJECT_STORE_NAME not in self._skip_stores
+        ):
             self._upstream_store = self._resolve_store(UPSTREAM_OBJECT_STORE_NAME)
 
     def _resolve_store(self, name: str) -> ObjectStore | None:
@@ -247,23 +264,30 @@ class ObjectStoreMetricExporter(MetricExporter):
             create_store_from_binding,
         )
         from application_sdk.storage.errors import (  # noqa: PLC0415 — deferred to break the observability→storage circular import
+            StorageBindingBrokenError,
             StorageBindingNotFoundError,
             StorageConfigError,
         )
 
         try:
             return create_store_from_binding(name)
-        except StorageBindingNotFoundError:
-            # Binding not present yet. Expected transiently during boot before
-            # Dapr writes its components; resolution is retried on the next
-            # export, so this is benign rather than a hard misconfiguration.
+        except (StorageBindingNotFoundError, StorageBindingBrokenError):
+            # Transient boot states: the component is not written yet, or it is
+            # present but its placeholders / ``secretKeyRef`` env vars are not
+            # substituted yet. Both heal once Dapr finishes writing and the
+            # secret env materialises, so retry quietly on the next export. Both
+            # subclass StorageConfigError, so this clause must precede it.
             logger.debug(
-                "Object store '%s' binding not present yet; metric upload deferred (will retry)",
+                "Object store '%s' binding not resolvable yet; metric upload deferred (will retry)",
                 name,
                 exc_info=True,
             )
             return None
         except StorageConfigError:
+            # Non-transient misconfiguration (e.g. unsupported binding type). It
+            # will not heal on retry, so record the name to stop retrying and
+            # log exactly once instead of every flush.
+            self._skip_stores.add(name)
             logger.warning(
                 "Object store '%s' misconfigured; metric upload disabled",
                 name,
@@ -271,6 +295,9 @@ class ObjectStoreMetricExporter(MetricExporter):
             )
             return None
         except Exception:
+            # Unknown failure — also treated as non-transient: log once and stop
+            # retrying so an unexpected error cannot spam warnings every flush.
+            self._skip_stores.add(name)
             logger.warning(
                 "Object store '%s' setup failed; metric upload disabled",
                 name,

--- a/tests/unit/observability/test_objectstore_metric_exporter.py
+++ b/tests/unit/observability/test_objectstore_metric_exporter.py
@@ -311,10 +311,22 @@ class TestSdrUpstreamExport:
         assert deployment_store.put.call_count == 1
         assert upstream_store.put.call_count == 1
 
-    def test_upstream_store_built_only_when_atlan_upload_enabled(
-        self, tmp_path
-    ) -> None:
-        """``__init__`` resolves the upstream store only in SDR mode."""
+    def test_stores_resolved_lazily_not_at_init(self, tmp_path) -> None:
+        """Construction must not touch bindings (BLDX-1567 boot race).
+
+        Resolving eagerly in ``__init__`` meant a metrics-flush daemon thread
+        that constructed the exporter before the Dapr ``objectstore`` component
+        existed permanently disabled uploads. Stores must stay ``None`` until
+        the first ``_ensure_stores`` / ``export``.
+        """
+        with patch.object(ObjectStoreMetricExporter, "_resolve_store") as resolve_spy:
+            e = ObjectStoreMetricExporter(data_dir=str(tmp_path))
+        resolve_spy.assert_not_called()
+        assert e._deployment_store is None
+        assert e._upstream_store is None
+
+    def test_ensure_stores_resolves_upstream_only_in_sdr_mode(self, tmp_path) -> None:
+        """``_ensure_stores`` resolves the upstream store only in SDR mode."""
         from application_sdk.constants import (
             DEPLOYMENT_OBJECT_STORE_NAME,
             UPSTREAM_OBJECT_STORE_NAME,
@@ -328,13 +340,14 @@ class TestSdrUpstreamExport:
         def _fake_resolve(_self, name):
             return resolved[name]
 
-        # SDR mode: both stores resolved.
+        # SDR mode: both stores resolved on first ensure.
         with (
             patch(f"{_EXPORTER_MOD}.ENABLE_OBSERVABILITY_STORE_SINK", True),
             patch(f"{_EXPORTER_MOD}.ENABLE_ATLAN_UPLOAD", True),
             patch.object(ObjectStoreMetricExporter, "_resolve_store", _fake_resolve),
         ):
             e = ObjectStoreMetricExporter(data_dir=str(tmp_path))
+            e._ensure_stores()
         assert e._deployment_store is resolved[DEPLOYMENT_OBJECT_STORE_NAME]
         assert e._upstream_store is resolved[UPSTREAM_OBJECT_STORE_NAME]
 
@@ -345,5 +358,32 @@ class TestSdrUpstreamExport:
             patch.object(ObjectStoreMetricExporter, "_resolve_store", _fake_resolve),
         ):
             e2 = ObjectStoreMetricExporter(data_dir=str(tmp_path))
+            e2._ensure_stores()
         assert e2._deployment_store is resolved[DEPLOYMENT_OBJECT_STORE_NAME]
         assert e2._upstream_store is None
+
+    def test_ensure_stores_retries_until_binding_appears(self, tmp_path) -> None:
+        """A transient missing binding must not latch uploads off (BLDX-1567).
+
+        First resolution returns ``None`` (component not written yet); a later
+        one succeeds. The store must then be cached and not re-resolved.
+        """
+        store = MagicMock(name="deployment")
+        # None on the first attempt (boot race), then the real store.
+        attempts = iter([None, store, store])
+
+        def _fake_resolve(_self, _name):
+            return next(attempts)
+
+        with (
+            patch(f"{_EXPORTER_MOD}.ENABLE_OBSERVABILITY_STORE_SINK", True),
+            patch(f"{_EXPORTER_MOD}.ENABLE_ATLAN_UPLOAD", False),
+            patch.object(ObjectStoreMetricExporter, "_resolve_store", _fake_resolve),
+        ):
+            e = ObjectStoreMetricExporter(data_dir=str(tmp_path))
+            e._ensure_stores()
+            assert e._deployment_store is None  # still absent → retried later
+            e._ensure_stores()
+            assert e._deployment_store is store  # healed on retry
+            e._ensure_stores()
+            assert e._deployment_store is store  # cached, not re-resolved

--- a/tests/unit/observability/test_objectstore_metric_exporter.py
+++ b/tests/unit/observability/test_objectstore_metric_exporter.py
@@ -387,3 +387,78 @@ class TestSdrUpstreamExport:
             assert e._deployment_store is store  # healed on retry
             e._ensure_stores()
             assert e._deployment_store is store  # cached, not re-resolved
+
+    def test_non_transient_error_logs_once_and_stops_retrying(self, tmp_path) -> None:
+        """A non-transient error must be logged once, not every export (BLDX-1567).
+
+        ``StorageConfigError`` (e.g. an unsupported binding type) will never
+        heal on retry. The exporter must record the store name, stop retrying
+        it, and warn exactly once — not re-log a full traceback every flush.
+        """
+        from application_sdk.constants import DEPLOYMENT_OBJECT_STORE_NAME
+        from application_sdk.storage.errors import StorageConfigError
+
+        boom = StorageConfigError("Unsupported binding type: 'nope'")
+
+        with (
+            patch(f"{_EXPORTER_MOD}.ENABLE_OBSERVABILITY_STORE_SINK", True),
+            patch(f"{_EXPORTER_MOD}.ENABLE_ATLAN_UPLOAD", False),
+            patch(f"{_EXPORTER_MOD}.logger") as log,
+            patch(
+                "application_sdk.storage.binding.create_store_from_binding",
+                side_effect=boom,
+            ) as create,
+        ):
+            e = ObjectStoreMetricExporter(data_dir=str(tmp_path))
+            e._ensure_stores()
+            e._ensure_stores()
+            e._ensure_stores()
+
+        # Resolution attempted once, then skipped (name latched off).
+        assert create.call_count == 1
+        assert DEPLOYMENT_OBJECT_STORE_NAME in e._skip_stores
+        assert e._deployment_store is None
+        assert log.warning.call_count == 1
+        assert log.debug.call_count == 0
+
+    def test_binding_broken_is_transient_and_retried_quietly(self, tmp_path) -> None:
+        """A present-but-unresolved binding is a transient boot state (BLDX-1567).
+
+        ``StorageBindingBrokenError`` (placeholders / secret env not yet
+        substituted) heals once Dapr finishes boot, so it must be retried
+        quietly (debug, never warning) and not latched into ``_skip_stores``.
+        """
+        from application_sdk.constants import DEPLOYMENT_OBJECT_STORE_NAME
+        from application_sdk.storage.errors import StorageBindingBrokenError
+
+        store = MagicMock(name="deployment")
+        # Broken on the first attempt (secret env not substituted yet), then healed.
+        attempts = [
+            StorageBindingBrokenError("unresolved", binding_name="x"),
+            store,
+        ]
+
+        def _create(_name):
+            outcome = attempts.pop(0)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+        with (
+            patch(f"{_EXPORTER_MOD}.ENABLE_OBSERVABILITY_STORE_SINK", True),
+            patch(f"{_EXPORTER_MOD}.ENABLE_ATLAN_UPLOAD", False),
+            patch(f"{_EXPORTER_MOD}.logger") as log,
+            patch(
+                "application_sdk.storage.binding.create_store_from_binding",
+                side_effect=_create,
+            ),
+        ):
+            e = ObjectStoreMetricExporter(data_dir=str(tmp_path))
+            e._ensure_stores()
+            assert e._deployment_store is None  # broken → deferred, not skipped
+            assert DEPLOYMENT_OBJECT_STORE_NAME not in e._skip_stores
+            e._ensure_stores()
+            assert e._deployment_store is store  # healed on retry
+
+        assert log.warning.call_count == 0  # transient must never warn
+        assert log.debug.call_count == 1  # logged once, at debug

--- a/tests/unit/observability/test_objectstore_metric_exporter.py
+++ b/tests/unit/observability/test_objectstore_metric_exporter.py
@@ -421,19 +421,26 @@ class TestSdrUpstreamExport:
         assert log.warning.call_count == 1
         assert log.debug.call_count == 0
 
-    def test_binding_broken_is_transient_and_retried_quietly(self, tmp_path) -> None:
+    def test_binding_broken_is_transient_warned_once_then_healed(
+        self, tmp_path
+    ) -> None:
         """A present-but-unresolved binding is a transient boot state (BLDX-1567).
 
         ``StorageBindingBrokenError`` (placeholders / secret env not yet
-        substituted) heals once Dapr finishes boot, so it must be retried
-        quietly (debug, never warning) and not latched into ``_skip_stores``.
+        substituted) heals once Dapr finishes boot, so it must be retried and
+        never latched into ``_skip_stores``. The deferral is warned exactly once
+        (so a persistent gap stays visible where DEBUG is filtered out), stays
+        quiet at DEBUG on subsequent flushes, and the heal is announced at INFO.
+        The first-deferral warning must carry no stacktrace — the condition is
+        expected and self-describing.
         """
         from application_sdk.constants import DEPLOYMENT_OBJECT_STORE_NAME
         from application_sdk.storage.errors import StorageBindingBrokenError
 
         store = MagicMock(name="deployment")
-        # Broken on the first attempt (secret env not substituted yet), then healed.
+        # Broken on the first two attempts (secret env not substituted yet), then healed.
         attempts = [
+            StorageBindingBrokenError("unresolved", binding_name="x"),
             StorageBindingBrokenError("unresolved", binding_name="x"),
             store,
         ]
@@ -454,11 +461,17 @@ class TestSdrUpstreamExport:
             ),
         ):
             e = ObjectStoreMetricExporter(data_dir=str(tmp_path))
-            e._ensure_stores()
+            e._ensure_stores()  # first deferral → warn once
             assert e._deployment_store is None  # broken → deferred, not skipped
             assert DEPLOYMENT_OBJECT_STORE_NAME not in e._skip_stores
-            e._ensure_stores()
-            assert e._deployment_store is store  # healed on retry
+            assert DEPLOYMENT_OBJECT_STORE_NAME in e._deferred
+            e._ensure_stores()  # still broken → quiet at debug
+            assert e._deployment_store is None
+            e._ensure_stores()  # healed on retry
+            assert e._deployment_store is store
 
-        assert log.warning.call_count == 0  # transient must never warn
-        assert log.debug.call_count == 1  # logged once, at debug
+        assert log.warning.call_count == 1  # deferral warned exactly once
+        assert "exc_info" not in log.warning.call_args.kwargs  # no stacktrace
+        assert log.debug.call_count == 1  # subsequent retry stayed quiet
+        assert log.info.call_count == 1  # heal announced
+        assert DEPLOYMENT_OBJECT_STORE_NAME not in e._deferred  # cleared on heal


### PR DESCRIPTION
Fixes BLDX-1567.

## Problem
The observability metrics flush runs on a daemon thread that can construct `ObjectStoreMetricExporter` during app-server boot — before the Dapr `objectstore` component YAML has been written to `./components`. That surfaced as intermittent `App server failed to start within 60s` failures in the unified test framework (notably merge-queue runs) for connector apps.

## Findings (empirical, on current `main`)
The missing binding is already **caught** — the alarming traceback in logs is a `logger.warning(exc_info=True)`, not a fatal raise (the reported crash reflects the older SDK the connector pinned). But `__init__` resolved stores **once**, so a transient boot-time binding gap **permanently disabled** metric upload for the process lifetime and dumped a full traceback at boot.

## Fix
- Resolve stores **lazily on first export**, not in `__init__` (construction no longer touches bindings).
- **Retry** each export until the binding appears, so a slow-to-materialise component self-heals; cache the store once resolved.
- Split resolution errors into **transient** vs **non-transient**:
  - *Transient* (`StorageBindingNotFoundError` / `StorageBindingBrokenError` — component not written yet, or placeholders/`secretKeyRef` env not substituted yet) is retried on the next flush.
  - *Non-transient* (other `StorageConfigError`, or an unexpected error) is latched into a skip-list, logged **once** with a traceback, and never retried — no per-flush spam.

### Observability of the transient path
The transient deferral is a real signal — metric upload is not happening yet — so it must stay visible in production, where DEBUG is filtered out. Rather than log at DEBUG (invisible) or at WARNING every ~60s (spam), the exporter now:
- **Warns once** per store on the first deferral (no stacktrace — the condition is expected and self-describing).
- Stays **quiet at DEBUG** on subsequent flushes.
- Announces the **heal at INFO** once the binding resolves.

Net: a slow component produces one WARNING + one INFO; a genuinely stuck binding leaves a WARNING with no matching heal-INFO — the durable signal that metric upload is disabled. Reuses the same log-once-by-name `set` discipline as the non-transient skip-list.

## Validation
16 exporter unit tests (lazy-not-at-init guard, retry-until-appears, non-transient log-once, transient warn-once-then-heal) + the full unit suite (5854 passed) pass. `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)