### PR TITLE
ci: pin setup-uv version fleet-wide to avoid latest-version fetch flakes

### DIFF
--- a/.github/actions/sdk-trivy-scan/action.yaml
+++ b/.github/actions/sdk-trivy-scan/action.yaml
@@ -89,6 +89,7 @@ runs:
     - name: Install uv
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
+        version: "0.11.30"
         enable-cache: true
     - name: Sync SDK dependencies into .venv
       shell: bash

--- a/.github/workflows/auto-fix-vulnerabilities.yaml
+++ b/.github/workflows/auto-fix-vulnerabilities.yaml
@@ -178,6 +178,8 @@ jobs:
       - name: Install uv
         if: steps.identify.outputs.count > 0
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.30"
 
       - name: Fix vulnerable packages
         if: steps.identify.outputs.count > 0

--- a/.github/workflows/capability-manifest-check.yaml
+++ b/.github/workflows/capability-manifest-check.yaml
@@ -99,6 +99,8 @@ jobs:
 
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         if: steps.ctx.outputs.release == 'false'
+        with:
+          version: "0.11.30"
 
       - name: Regenerate capability manifest
         if: steps.ctx.outputs.release == 'false'

--- a/.github/workflows/capability-manifest-regen.yaml
+++ b/.github/workflows/capability-manifest-regen.yaml
@@ -112,6 +112,8 @@ jobs:
 
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         if: steps.pr.outputs.is_fork != 'true' && steps.pr.outputs.is_bump_version != 'true'
+        with:
+          version: "0.11.30"
 
       - name: Regenerate capability manifest
         if: steps.pr.outputs.is_fork != 'true' && steps.pr.outputs.is_bump_version != 'true'

--- a/.github/workflows/conformance-ci.yaml
+++ b/.github/workflows/conformance-ci.yaml
@@ -61,6 +61,8 @@ jobs:
       - name: "Set up uv"
         if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push'
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.30"
 
       - name: "Run C-series checks (published package)"
         if: (steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push') && inputs.conformance-ref == ''

--- a/.github/workflows/conformance-error-handling.yaml
+++ b/.github/workflows/conformance-error-handling.yaml
@@ -61,6 +61,8 @@ jobs:
       - name: "Set up uv"
         if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push'
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.30"
 
       - name: "Run E-series checks (published package)"
         if: (steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push') && inputs.conformance-ref == ''

--- a/.github/workflows/conformance-logging.yaml
+++ b/.github/workflows/conformance-logging.yaml
@@ -74,6 +74,8 @@ jobs:
       - name: "Set up uv"
         if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push'
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.30"
 
       - name: "Run L-series checks (published package)"
         if: (steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push') && inputs.conformance-ref == ''

--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -338,6 +338,8 @@ jobs:
       - name: "Set up uv"
         if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push' || inputs.force-all
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.30"
 
       - name: "Run ${{ matrix.series }}-series checks"
         if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push' || inputs.force-all
@@ -381,6 +383,8 @@ jobs:
 
       - name: "Set up uv"
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.30"
 
       - name: "Guard contract_schema.lock.json (published package)"
         if: inputs.conformance-ref == ''

--- a/.github/workflows/conformance-suite-tests-reusable.yaml
+++ b/.github/workflows/conformance-suite-tests-reusable.yaml
@@ -29,6 +29,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.30"
 
       - name: Run conformance package unit tests
         working-directory: packages/conformance

--- a/.github/workflows/contract-toolkit-release.yml
+++ b/.github/workflows/contract-toolkit-release.yml
@@ -68,6 +68,8 @@ jobs:
           python-version: "3.14"
 
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.30"
 
       - name: Compute version, bump PklProject, update CHANGELOG
         id: versions

--- a/.github/workflows/contract-toolkit-reusable.yaml
+++ b/.github/workflows/contract-toolkit-reusable.yaml
@@ -34,6 +34,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.30"
 
       - name: Install PKL
         run: |
@@ -103,6 +105,8 @@ jobs:
           python-version: "3.14"
 
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.30"
 
       - name: Check generated Python formatting
         run: |

--- a/.github/workflows/generated-freshness.yaml
+++ b/.github/workflows/generated-freshness.yaml
@@ -86,6 +86,8 @@ jobs:
       # diff compares against ruff-formatted output (matching how the artifacts
       # were committed).
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.30"
 
       - name: Install pkl
         run: |

--- a/.github/workflows/renovate-dashboard.yaml
+++ b/.github/workflows/renovate-dashboard.yaml
@@ -129,6 +129,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.30"
 
       - name: Run Renovate scanner
         run: |

--- a/.github/workflows/renovate-pkl-sync.yaml
+++ b/.github/workflows/renovate-pkl-sync.yaml
@@ -99,6 +99,8 @@ jobs:
 
       # Provides `uvx ruff`, used by the driver to format generated Python.
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.30"
 
       - name: Install pkl
         run: |

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -117,6 +117,8 @@ jobs:
       # Provides `uv`/`uvx` — used by Renovate's native uv manager to refresh
       # uv.lock AND by the driver's `uvx ruff` formatting of generated Python.
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.30"
 
       - name: Install pkl
         run: |

--- a/.github/workflows/scripts-tests.yaml
+++ b/.github/workflows/scripts-tests.yaml
@@ -39,6 +39,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.30"
 
       - name: Run script tests
         run: uv run --extra workflows --with pytest python -m pytest .github/scripts/tests -q

--- a/.github/workflows/v3-readiness-check.yaml
+++ b/.github/workflows/v3-readiness-check.yaml
@@ -127,6 +127,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.30"
 
       - name: Install application-sdk
         working-directory: sdk


### PR DESCRIPTION
## Problem
`Conformance / Security` (and the `Conformance Gate` that fails downstream of it) intermittently failed with `##[error]fetch failed` in the `astral-sh/setup-uv` step during merge-queue runs.

## Root cause
When no uv `version` is pinned, `setup-uv` queries the GitHub API for the latest uv release — an unauthenticated, rate-limited network call that flakes when many merge-queue jobs run concurrently from the same runner pool.

## Fix
Pin `version: "0.11.30"` (the version already used elsewhere in the repo) on **every** `astral-sh/setup-uv` step across all of `.github/` — both `.github/workflows/*.{yaml,yml}` and the composite actions under `.github/actions/`. No action SHAs changed.

## Verification
Complete audit across `.github/workflows/` **and** `.github/actions/`: **29 `setup-uv` steps total, 0 unpinned.** All changed files parse as valid YAML.

> Correction to the earlier revision of this description: the first sweep used a `*.yaml` glob scoped to `.github/workflows/` and reported "26, all pinned". That undercounted — it missed `.github/workflows/contract-toolkit-release.yml` (a `.yml` step added by #2808 after this branch forked) and two composite-action steps under `.github/actions/`. The audit now covers `.yml` + `.yaml` in both directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)