### PR TITLE
fix(observability): make AtlanLoggerAdapter.__del__ teardown-safe

### DIFF
--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -1320,9 +1320,23 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
             logging.error("Error processing log record", exc_info=True)
 
     def __del__(self):
-        """Cleanup when the logger is destroyed."""
-        if AtlanLoggerAdapter._flush_task and not AtlanLoggerAdapter._flush_task.done():
-            AtlanLoggerAdapter._flush_task.cancel()
+        """Cancel the periodic flush task when the logger is destroyed.
+
+        Guarded against interpreter teardown: during shutdown Python rebinds
+        module globals — including the ``AtlanLoggerAdapter`` class name this
+        references — to ``None``, so the attribute access raises
+        ``AttributeError`` ("'NoneType' object has no attribute '_flush_task'").
+        The event loop may likewise already be closed, making ``cancel()``
+        raise. Both are benign during GC/shutdown (there is nothing left to
+        flush) and cannot be logged (the logging stack may be gone), so they
+        are swallowed.
+        """
+        try:
+            task = AtlanLoggerAdapter._flush_task
+            if task is not None and not task.done():
+                task.cancel()
+        except Exception:  # noqa: S110, BLE001 — teardown-only; see docstring
+            pass
 
 
 # Create a singleton instance of the logger


### PR DESCRIPTION
## Problem
An `Exception ignored in: <function AtlanLoggerAdapter.__del__>` with `AttributeError: 'NoneType' object has no attribute '_flush_task'` printed during interpreter teardown (seen in test runs). Benign, but it's log noise and another latent source of confusing CI output.

## Root cause
During interpreter shutdown Python rebinds module globals — including the `AtlanLoggerAdapter` class name that `__del__` references — to `None`, so `AtlanLoggerAdapter._flush_task` raises `AttributeError`. The event loop may also already be closed, making `.cancel()` raise.

## Fix
Guard the flush-task cancellation in `__del__` with `try/except`. Both failure modes are benign during GC/shutdown (nothing left to flush) and cannot be logged (the logging stack may be gone), so they're swallowed with an explanatory docstring.

## Validation
`pre-commit` (ruff + pyright) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)